### PR TITLE
Always insert methods into the search index, even if we're currently in a private module

### DIFF
--- a/src/test/run-make/rustdoc-search-index/Makefile
+++ b/src/test/run-make/rustdoc-search-index/Makefile
@@ -1,0 +1,17 @@
+-include ../tools.mk
+
+# FIXME ignore windows
+ifndef IS_WINDOWS
+
+source=index.rs
+
+all:
+	$(HOST_RPATH_ENV) $(RUSTDOC) -w html -o $(TMPDIR)/doc $(source)
+	cp $(source) $(TMPDIR)
+	cp verify.sh $(TMPDIR)
+	$(call RUN,verify.sh) $(TMPDIR)
+
+else
+all:
+
+endif

--- a/src/test/run-make/rustdoc-search-index/index.rs
+++ b/src/test/run-make/rustdoc-search-index/index.rs
@@ -1,0 +1,29 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "rustdoc_test"]
+
+// In: Foo
+pub use private::Foo;
+
+mod private {
+    pub struct Foo;
+    impl Foo {
+        // In: test_method
+        pub fn test_method() {}
+        // Out: priv_method
+        fn priv_method() {}
+    }
+
+    pub trait PrivateTrait {
+        // Out: priv_method
+        fn trait_method() {}
+    }
+}

--- a/src/test/run-make/rustdoc-search-index/verify.sh
+++ b/src/test/run-make/rustdoc-search-index/verify.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+source="$1/index.rs"
+index="$1/doc/search-index.js"
+
+if ! [ -e $index ]
+then
+    echo "Could not find the search index (looked for $index)"
+    exit 1
+fi
+
+ins=$(grep -o 'In: .*' $source | sed 's/In: \(.*\)/\1/g')
+outs=$(grep -o 'Out: .*' $source | sed 's/Out: \(.*\)/\1/g')
+
+for p in $ins
+do
+    if ! grep -q $p $index
+    then
+        echo "'$p' was erroneously excluded from search index."
+        exit 1
+    fi
+done
+
+for p in $outs
+do
+    if grep -q $p $index
+    then
+        echo "'$p' was erroneously included in search index."
+        exit 1
+    fi
+done
+
+exit 0


### PR DESCRIPTION
Previously, this caused methods of re-exported types to not be inserted into
the search index. This fix may introduce some false positives, but in my
testing they appear as orphaned methods and end up not being inserted into the
final search index at a later stage.

Fixes issue #11943
