### PR TITLE
libcollections: In tests, remove some uses of deprecated methods and

### DIFF
--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -786,21 +786,21 @@ mod tests {
     fn test_basic() {
         let mut m: DList<Box<int>> = DList::new();
         assert_eq!(m.pop_front(), None);
-        assert_eq!(m.pop_back(), None);
+        assert_eq!(m.pop(), None);
         assert_eq!(m.pop_front(), None);
         m.push_front(box 1);
         assert_eq!(m.pop_front(), Some(box 1));
-        m.push_back(box 2);
-        m.push_back(box 3);
+        m.push(box 2);
+        m.push(box 3);
         assert_eq!(m.len(), 2);
         assert_eq!(m.pop_front(), Some(box 2));
         assert_eq!(m.pop_front(), Some(box 3));
         assert_eq!(m.len(), 0);
         assert_eq!(m.pop_front(), None);
-        m.push_back(box 1);
-        m.push_back(box 3);
-        m.push_back(box 5);
-        m.push_back(box 7);
+        m.push(box 1);
+        m.push(box 3);
+        m.push(box 5);
+        m.push(box 7);
         assert_eq!(m.pop_front(), Some(box 1));
 
         let mut n = DList::new();
@@ -837,19 +837,19 @@ mod tests {
         {
             let mut m = DList::new();
             let mut n = DList::new();
-            n.push_back(2i);
+            n.push(2i);
             m.append(n);
             assert_eq!(m.len(), 1);
-            assert_eq!(m.pop_back(), Some(2));
+            assert_eq!(m.pop(), Some(2));
             check_links(&m);
         }
         {
             let mut m = DList::new();
             let n = DList::new();
-            m.push_back(2i);
+            m.push(2i);
             m.append(n);
             assert_eq!(m.len(), 1);
-            assert_eq!(m.pop_back(), Some(2));
+            assert_eq!(m.pop(), Some(2));
             check_links(&m);
         }
 
@@ -870,10 +870,10 @@ mod tests {
         {
             let mut m = DList::new();
             let mut n = DList::new();
-            n.push_back(2i);
+            n.push(2i);
             m.prepend(n);
             assert_eq!(m.len(), 1);
-            assert_eq!(m.pop_back(), Some(2));
+            assert_eq!(m.pop(), Some(2));
             check_links(&m);
         }
 
@@ -931,9 +931,9 @@ mod tests {
     #[test]
     fn test_iterator_clone() {
         let mut n = DList::new();
-        n.push_back(2i);
-        n.push_back(3);
-        n.push_back(4);
+        n.push(2i);
+        n.push(3);
+        n.push(4);
         let mut it = n.iter();
         it.next();
         let mut jt = it.clone();
@@ -988,7 +988,7 @@ mod tests {
         let mut n = DList::new();
         assert!(n.mut_iter().next().is_none());
         n.push_front(4i);
-        n.push_back(5);
+        n.push(5);
         let mut it = n.mut_iter();
         assert_eq!(it.size_hint(), (2, Some(2)));
         assert!(it.next().is_some());
@@ -1062,8 +1062,8 @@ mod tests {
         assert_eq!(n.pop_front(), Some(1));
 
         let mut m = DList::new();
-        m.push_back(2i);
-        m.push_back(4);
+        m.push(2i);
+        m.push(4);
         m.insert_ordered(3);
         check_links(&m);
         assert_eq!(vec![2,3,4], m.move_iter().collect::<Vec<int>>());
@@ -1100,7 +1100,7 @@ mod tests {
         assert!(n == m);
         n.push_front(1);
         assert!(n != m);
-        m.push_back(1);
+        m.push(1);
         assert!(n == m);
 
         let n = list_from([2i,3,4]);
@@ -1115,9 +1115,9 @@ mod tests {
 
       assert!(hash::hash(&x) == hash::hash(&y));
 
-      x.push_back(1i);
-      x.push_back(2);
-      x.push_back(3);
+      x.push(1i);
+      x.push(2);
+      x.push(3);
 
       y.push_front(3i);
       y.push_front(2);
@@ -1197,19 +1197,19 @@ mod tests {
             let r: u8 = rand::random();
             match r % 6 {
                 0 => {
-                    m.pop_back();
+                    m.pop();
                     v.pop();
                 }
                 1 => {
                     m.pop_front();
-                    v.shift();
+                    v.remove(0);
                 }
                 2 | 4 =>  {
                     m.push_front(-i);
-                    v.unshift(-i);
+                    v.insert(0, -i);
                 }
                 3 | 5 | _ => {
-                    m.push_back(i);
+                    m.push(i);
                     v.push(i);
                 }
             }
@@ -1245,7 +1245,7 @@ mod tests {
     fn bench_push_back(b: &mut test::Bencher) {
         let mut m: DList<int> = DList::new();
         b.iter(|| {
-            m.push_back(0);
+            m.push(0);
         })
     }
 
@@ -1253,8 +1253,8 @@ mod tests {
     fn bench_push_back_pop_back(b: &mut test::Bencher) {
         let mut m: DList<int> = DList::new();
         b.iter(|| {
-            m.push_back(0);
-            m.pop_back();
+            m.push(0);
+            m.pop();
         })
     }
 

--- a/src/libcollections/hash/mod.rs
+++ b/src/libcollections/hash/mod.rs
@@ -293,7 +293,6 @@ impl<S: Writer, T: Hash<S>, U: Hash<S>> Hash<S> for Result<T, U> {
 
 #[cfg(test)]
 mod tests {
-    use std::prelude::*;
     use std::mem;
 
     use slice::ImmutableSlice;

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -541,9 +541,9 @@ mod tests {
         assert_eq!(d.len(), 0u);
         d.push_front(17i);
         d.push_front(42i);
-        d.push_back(137);
+        d.push(137);
         assert_eq!(d.len(), 3u);
-        d.push_back(137);
+        d.push(137);
         assert_eq!(d.len(), 4u);
         debug!("{:?}", d.front());
         assert_eq!(*d.front().unwrap(), 42);
@@ -552,21 +552,21 @@ mod tests {
         let mut i = d.pop_front();
         debug!("{:?}", i);
         assert_eq!(i, Some(42));
-        i = d.pop_back();
+        i = d.pop();
         debug!("{:?}", i);
         assert_eq!(i, Some(137));
-        i = d.pop_back();
+        i = d.pop();
         debug!("{:?}", i);
         assert_eq!(i, Some(137));
-        i = d.pop_back();
+        i = d.pop();
         debug!("{:?}", i);
         assert_eq!(i, Some(17));
         assert_eq!(d.len(), 0u);
-        d.push_back(3);
+        d.push(3);
         assert_eq!(d.len(), 1u);
         d.push_front(2);
         assert_eq!(d.len(), 2u);
-        d.push_back(4);
+        d.push(4);
         assert_eq!(d.len(), 3u);
         d.push_front(1);
         assert_eq!(d.len(), 4u);
@@ -591,22 +591,22 @@ mod tests {
         assert_eq!(deq.len(), 0);
         deq.push_front(a);
         deq.push_front(b);
-        deq.push_back(c);
+        deq.push(c);
         assert_eq!(deq.len(), 3);
-        deq.push_back(d);
+        deq.push(d);
         assert_eq!(deq.len(), 4);
         assert_eq!(deq.front(), Some(&b));
         assert_eq!(deq.back(), Some(&d));
         assert_eq!(deq.pop_front(), Some(b));
-        assert_eq!(deq.pop_back(), Some(d));
-        assert_eq!(deq.pop_back(), Some(c));
-        assert_eq!(deq.pop_back(), Some(a));
+        assert_eq!(deq.pop(), Some(d));
+        assert_eq!(deq.pop(), Some(c));
+        assert_eq!(deq.pop(), Some(a));
         assert_eq!(deq.len(), 0);
-        deq.push_back(c);
+        deq.push(c);
         assert_eq!(deq.len(), 1);
         deq.push_front(b);
         assert_eq!(deq.len(), 2);
-        deq.push_back(d);
+        deq.push(d);
         assert_eq!(deq.len(), 3);
         deq.push_front(a);
         assert_eq!(deq.len(), 4);
@@ -622,22 +622,22 @@ mod tests {
         assert_eq!(deq.len(), 0);
         deq.push_front(a.clone());
         deq.push_front(b.clone());
-        deq.push_back(c.clone());
+        deq.push(c.clone());
         assert_eq!(deq.len(), 3);
-        deq.push_back(d.clone());
+        deq.push(d.clone());
         assert_eq!(deq.len(), 4);
         assert_eq!((*deq.front().unwrap()).clone(), b.clone());
         assert_eq!((*deq.back().unwrap()).clone(), d.clone());
         assert_eq!(deq.pop_front().unwrap(), b.clone());
-        assert_eq!(deq.pop_back().unwrap(), d.clone());
-        assert_eq!(deq.pop_back().unwrap(), c.clone());
-        assert_eq!(deq.pop_back().unwrap(), a.clone());
+        assert_eq!(deq.pop().unwrap(), d.clone());
+        assert_eq!(deq.pop().unwrap(), c.clone());
+        assert_eq!(deq.pop().unwrap(), a.clone());
         assert_eq!(deq.len(), 0);
-        deq.push_back(c.clone());
+        deq.push(c.clone());
         assert_eq!(deq.len(), 1);
         deq.push_front(b.clone());
         assert_eq!(deq.len(), 2);
-        deq.push_back(d.clone());
+        deq.push(d.clone());
         assert_eq!(deq.len(), 3);
         deq.push_front(a.clone());
         assert_eq!(deq.len(), 4);
@@ -661,7 +661,7 @@ mod tests {
 
         let mut deq = RingBuf::new();
         for i in range(0u, 66) {
-            deq.push_back(i);
+            deq.push(i);
         }
 
         for i in range(0u, 66) {
@@ -699,7 +699,7 @@ mod tests {
     fn bench_push_back(b: &mut test::Bencher) {
         let mut deq = RingBuf::new();
         b.iter(|| {
-            deq.push_back(0i);
+            deq.push(0i);
         })
     }
 
@@ -778,10 +778,10 @@ mod tests {
     #[test]
     fn test_with_capacity() {
         let mut d = RingBuf::with_capacity(0);
-        d.push_back(1i);
+        d.push(1i);
         assert_eq!(d.len(), 1);
         let mut d = RingBuf::with_capacity(50);
-        d.push_back(1i);
+        d.push(1i);
         assert_eq!(d.len(), 1);
     }
 
@@ -829,11 +829,11 @@ mod tests {
     #[test]
     fn test_reserve_exact() {
         let mut d = RingBuf::new();
-        d.push_back(0u64);
+        d.push(0u64);
         d.reserve_exact(50);
         assert_eq!(d.elts.capacity(), 50);
         let mut d = RingBuf::new();
-        d.push_back(0u32);
+        d.push(0u32);
         d.reserve_exact(50);
         assert_eq!(d.elts.capacity(), 50);
     }
@@ -841,11 +841,11 @@ mod tests {
     #[test]
     fn test_reserve() {
         let mut d = RingBuf::new();
-        d.push_back(0u64);
+        d.push(0u64);
         d.reserve(50);
         assert_eq!(d.elts.capacity(), 64);
         let mut d = RingBuf::new();
-        d.push_back(0u32);
+        d.push(0u32);
         d.reserve(50);
         assert_eq!(d.elts.capacity(), 64);
     }
@@ -865,7 +865,7 @@ mod tests {
         assert_eq!(d.iter().size_hint(), (0, Some(0)));
 
         for i in range(0i, 5) {
-            d.push_back(i);
+            d.push(i);
         }
         {
             let b: &[_] = &[&0,&1,&2,&3,&4];
@@ -896,7 +896,7 @@ mod tests {
         assert_eq!(d.iter().rev().next(), None);
 
         for i in range(0i, 5) {
-            d.push_back(i);
+            d.push(i);
         }
         {
             let b: &[_] = &[&4,&3,&2,&1,&0];
@@ -915,11 +915,11 @@ mod tests {
         let mut d = RingBuf::with_capacity(3);
         assert!(d.mut_iter().rev().next().is_none());
 
-        d.push_back(1i);
-        d.push_back(2);
-        d.push_back(3);
+        d.push(1i);
+        d.push(2);
+        d.push(3);
         assert_eq!(d.pop_front(), Some(1));
-        d.push_back(4);
+        d.push(4);
 
         assert_eq!(d.mut_iter().rev().map(|x| *x).collect::<Vec<int>>(),
                    vec!(4, 3, 2));
@@ -992,13 +992,13 @@ mod tests {
         let mut d = RingBuf::new();
         d.push_front(17i);
         d.push_front(42);
-        d.push_back(137);
-        d.push_back(137);
+        d.push(137);
+        d.push(137);
         assert_eq!(d.len(), 4u);
         let mut e = d.clone();
         assert_eq!(e.len(), 4u);
         while !d.is_empty() {
-            assert_eq!(d.pop_back(), e.pop_back());
+            assert_eq!(d.pop(), e.pop());
         }
         assert_eq!(d.len(), 0u);
         assert_eq!(e.len(), 0u);
@@ -1011,15 +1011,15 @@ mod tests {
         d.push_front(137i);
         d.push_front(17);
         d.push_front(42);
-        d.push_back(137);
+        d.push(137);
         let mut e = RingBuf::with_capacity(0);
-        e.push_back(42);
-        e.push_back(17);
-        e.push_back(137);
-        e.push_back(137);
+        e.push(42);
+        e.push(17);
+        e.push(137);
+        e.push(137);
         assert!(&e == &d);
-        e.pop_back();
-        e.push_back(0);
+        e.pop();
+        e.push(0);
         assert!(e != d);
         e.clear();
         assert!(e == RingBuf::new());

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -2374,7 +2374,6 @@ mod bench {
     use test::Bencher;
     use test::black_box;
     use super::*;
-    use std::option::{None, Some};
     use std::iter::{Iterator, DoubleEndedIterator};
     use std::collections::Collection;
 


### PR DESCRIPTION
unused imports.

This is mostly converting uses of `push_back`, `pop_back`, `shift` and `unshift` to `push`, `pop`, `remove` and `insert`.
