### PR TITLE
Manual: Change `Language items` `sync` to `share`. Fix minor sorting mistake

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -2218,14 +2218,14 @@ These types help drive the compiler's analysis
 
 * `begin_unwind`
   : ___Needs filling in___
+* `managed_bound`
+  : This type implements "managed"
 * `no_copy_bound`
   : This type does not implement "copy", even if eligible
 * `no_send_bound`
   : This type does not implement "send", even if eligible
-* `no_sync_bound`
-  : This type does not implement "sync", even if eligible
-* `managed_bound`
-  : This type implements "managed"
+* `no_share_bound`
+  : This type does not implement "share", even if eligible
 * `eh_personality`
   : ___Needs filling in___
 * `exchange_free`


### PR DESCRIPTION
The _Language item_ `no_sync_bound` in [Marker types](http://doc.rust-lang.org/rust.html#marker-types) has been replaced with `no_share_bound`. This updates the manual and does a minor sorting fix.

Fixes https://github.com/rust-lang/rust/issues/16414

cc @cmr 

r?
