### PR TITLE
Forbid ~str and ~[]

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1427,14 +1427,10 @@ impl<'a> Parser<'a> {
         } else if self.token == token::TILDE {
             // OWNED POINTER
             self.bump();
-            let span = self.last_span;
+            let last_span = self.last_span;
             match self.token {
-                token::IDENT(ref ident, _)
-                        if "str" == token::get_ident(*ident).get() => {
-                    // This is OK (for now).
-                }
-                token::LBRACKET => {}   // Also OK.
-                _ => self.obsolete(span, ObsoleteOwnedType)
+                token::LBRACKET => self.obsolete(last_span, ObsoleteOwnedVector),
+                _ => self.obsolete(last_span, ObsoleteOwnedType)
             }
             TyUniq(self.parse_ty(false))
         } else if self.token == token::BINOP(token::STAR) {
@@ -2563,13 +2559,10 @@ impl<'a> Parser<'a> {
           }
           token::TILDE => {
             self.bump();
-            let span = self.last_span;
+            let last_span = self.last_span;
             match self.token {
-                token::LIT_STR(_) => {
-                    // This is OK (for now).
-                }
-                token::LBRACKET => {}   // Also OK.
-                _ => self.obsolete(span, ObsoleteOwnedExpr)
+                token::LBRACKET => self.obsolete(last_span, ObsoleteOwnedVector),
+                _ => self.obsolete(last_span, ObsoleteOwnedExpr)
             }
 
             let e = self.parse_prefix_expr();

--- a/src/test/compile-fail/obsolete-tilde.rs
+++ b/src/test/compile-fail/obsolete-tilde.rs
@@ -1,0 +1,21 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that ~ pointers give an obsolescence message.
+
+fn foo(x: ~int) {} //~ ERROR obsolete syntax: `~` notation for owned pointers
+fn bar(x: ~str) {} //~ ERROR obsolete syntax: `~` notation for owned pointers
+fn baz(x: ~[int]) {} //~ ERROR obsolete syntax: `~[T]` is no longer a type
+
+fn main() {
+    let x = ~4i; //~ ERROR obsolete syntax: `~` notation for owned pointer allocation
+    let y = ~"hello"; //~ ERROR obsolete syntax: `~` notation for owned pointer allocation
+    let z = ~[1i, 2, 3]; //~ ERROR obsolete syntax: `~[T]` is no longer a type
+}


### PR DESCRIPTION
This corrects a rebasing error. Also adds a test so it won't happen again.

r?
