### PR TITLE
Forbid the Sized bound on unsized types

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -167,6 +167,5 @@ register_diagnostics!(
     E0155,
     E0156,
     E0157,
-    E0158,
-    E0159
+    E0158
 )

--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -167,5 +167,6 @@ register_diagnostics!(
     E0155,
     E0156,
     E0157,
-    E0158
+    E0158,
+    E0159
 )

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -596,8 +596,8 @@ fn check_ty(cx: &mut Context, aty: &Ty) {
                 Some(ref item_substs) => {
                     let def_map = cx.tcx.def_map.borrow();
                     let did = def_map.get_copy(&id).def_id();
-                    let ty = ty::lookup_item_type(cx.tcx, did);
-                    for def in ty.generics.types.iter() {
+                    let generics = ty::lookup_item_type(cx.tcx, did).generics;
+                    for def in generics.types.iter() {
                         let ty = *item_substs.substs.types.get(def.space,
                                                                def.index);
                         check_typaram_bounds(cx, aty.span, ty, def);
@@ -644,20 +644,6 @@ pub fn check_typaram_bounds(cx: &Context,
     });
 }
 
-// Check that the programmer has not added the `Sized` bound to a trait type
-// which would fool the compiler into thinking that trait types are sized, when
-// they are really unsized.
-fn check_false_sized(cx: &Context, sp: Span, ty: ty::t) {
-    match ty::get(ty).sty {
-        ty::ty_trait(..) if ty::type_is_sized(cx.tcx, ty) => {
-            span_err!(cx.tcx.sess, sp, E0159,
-                      "explicitly adding `Sized` bound to an unsized type `{}`",
-                       ty_to_string(cx.tcx, ty));
-        }
-        _ => {}
-    }
-}
-
 fn check_bounds_on_structs_or_enums_in_type_if_possible(cx: &mut Context,
                                                         span: Span,
                                                         ty: ty::t) {
@@ -688,7 +674,6 @@ fn check_bounds_on_structs_or_enums_in_type_if_possible(cx: &mut Context,
                                                                .types
                                                                .iter()) {
                     check_typaram_bounds(cx, span, *ty, type_param_def);
-                    check_false_sized(cx, span, *ty);
                 }
 
                 // Check trait bounds.
@@ -716,7 +701,6 @@ fn check_bounds_on_structs_or_enums_in_type_if_possible(cx: &mut Context,
                                             cx.tcx)).as_slice());
                 })
             }
-            ty::ty_uniq(ty) => check_false_sized(cx, span, ty),
             _ => {}
         }
     });

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2362,7 +2362,7 @@ pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
             }
 
             ty_trait(box ty::TyTrait { bounds, .. }) => {
-                object_contents(cx, bounds) | TC::ReachesFfiUnsafe
+                object_contents(cx, bounds) | TC::ReachesFfiUnsafe | TC::Nonsized
             }
 
             ty_ptr(ref mt) => {

--- a/src/test/compile-fail/bad-sized.rs
+++ b/src/test/compile-fail/bad-sized.rs
@@ -1,0 +1,25 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::cell::RefCell;
+
+trait Trait {}
+
+pub fn main() {
+    let x: Vec<Trait + Sized> = Vec::new();
+    //~^ ERROR explicitly adding `Sized` bound to an unsized type `Trait+Sized`
+    //~^^ ERROR explicitly adding `Sized` bound to an unsized type `Trait+Sized`
+    let x: Vec<Box<Trait + Sized>> = Vec::new();
+    //~^ ERROR explicitly adding `Sized` bound to an unsized type `Trait+Sized`
+    //~^^ ERROR explicitly adding `Sized` bound to an unsized type `Trait+Sized`
+    let x: Vec<Box<RefCell<Trait + Sized>>> = Vec::new();
+    //~^ ERROR explicitly adding `Sized` bound to an unsized type `Trait+Sized`
+    //~^^ ERROR explicitly adding `Sized` bound to an unsized type `Trait+Sized`
+}

--- a/src/test/compile-fail/bad-sized.rs
+++ b/src/test/compile-fail/bad-sized.rs
@@ -8,18 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-tidy-linelength
+
 use std::cell::RefCell;
 
 trait Trait {}
 
 pub fn main() {
     let x: Vec<Trait + Sized> = Vec::new();
-    //~^ ERROR explicitly adding `Sized` bound to an unsized type `Trait+Sized`
-    //~^^ ERROR explicitly adding `Sized` bound to an unsized type `Trait+Sized`
-    let x: Vec<Box<Trait + Sized>> = Vec::new();
-    //~^ ERROR explicitly adding `Sized` bound to an unsized type `Trait+Sized`
-    //~^^ ERROR explicitly adding `Sized` bound to an unsized type `Trait+Sized`
+    //~^ ERROR instantiating a type parameter with an incompatible type `Trait+Sized`, which does not fulfill `Sized`
+    //~^^ ERROR instantiating a type parameter with an incompatible type `Trait+Sized`, which does not fulfill `Sized`
+    //~^^^ ERROR instantiating a type parameter with an incompatible type `Trait+Sized`, which does not fulfill `Sized`
     let x: Vec<Box<RefCell<Trait + Sized>>> = Vec::new();
-    //~^ ERROR explicitly adding `Sized` bound to an unsized type `Trait+Sized`
-    //~^^ ERROR explicitly adding `Sized` bound to an unsized type `Trait+Sized`
+    //~^ ERROR instantiating a type parameter with an incompatible type `Trait+Sized`, which does not fulfill `Sized`
+    //~^^ ERROR instantiating a type parameter with an incompatible type `Trait+Sized`, which does not fulfill `Sized`
 }


### PR DESCRIPTION
closes #16800 
r? @nikomatsakis - I'm not 100% sure this is the right approach, it is kind of ad-hoc. The trouble is we don't have any intrinsic notion of which types are sized and which are not, we only have the Sized bound, so I have nothing to validate the Sized bound against.
