### PR TITLE
Fixed misleading docs in liballoc

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! This is the lowest level library through which allocation in Rust can be
 //! performed where the allocation is assumed to succeed. This library will
-//! trigger a task failure when allocation fails.
+//! abort the process when allocation fails.
 //!
 //! This library, like libcore, is not intended for general usage, but rather as
 //! a building block of other libraries. The types and interfaces in this


### PR DESCRIPTION
liballoc will call `abort` on OOM, not fail the task.
