### PR TITLE
Allow `!` as the return type of proc/closure literals

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4092,20 +4092,20 @@ impl<'a> Parser<'a> {
                 (optional_unboxed_closure_kind, args)
             }
         };
-        let output = if self.eat(&token::RARROW) {
-            self.parse_ty(true)
+        let (style, output) = if self.token == token::RARROW {
+            self.parse_ret_ty()
         } else {
-            P(Ty {
+            (Return, P(Ty {
                 id: ast::DUMMY_NODE_ID,
                 node: TyInfer,
                 span: self.span,
-            })
+            }))
         };
 
         (P(FnDecl {
             inputs: inputs_captures,
             output: output,
-            cf: Return,
+            cf: style,
             variadic: false
         }), optional_unboxed_closure_kind)
     }
@@ -4118,20 +4118,20 @@ impl<'a> Parser<'a> {
                                      seq_sep_trailing_allowed(token::COMMA),
                                      |p| p.parse_fn_block_arg());
 
-        let output = if self.eat(&token::RARROW) {
-            self.parse_ty(true)
+        let (style, output) = if self.token == token::RARROW {
+            self.parse_ret_ty()
         } else {
-            P(Ty {
+            (Return, P(Ty {
                 id: ast::DUMMY_NODE_ID,
                 node: TyInfer,
                 span: self.span,
-            })
+            }))
         };
 
         P(FnDecl {
             inputs: inputs,
             output: output,
-            cf: Return,
+            cf: style,
             variadic: false
         })
     }

--- a/src/test/compile-fail/dead-code-closure-bang.rs
+++ b/src/test/compile-fail/dead-code-closure-bang.rs
@@ -8,13 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn foo(f: || -> !) {}
+#![deny(unreachable_code)]
 
 fn main() {
-    // Type inference didn't use to be able to handle this:
-    foo(|| fail!());
-    foo(|| -> ! fail!());
-    foo(|| 22); //~ ERROR mismatched types
-    foo(|| -> ! 22); //~ ERROR mismatched types
-    let x = || -> ! 1; //~ ERROR mismatched types
+    let x: || -> ! = || fail!();
+    x();
+    println!("Foo bar"); //~ ERROR: unreachable statement
 }

--- a/src/test/run-pass/closure-return-bang.rs
+++ b/src/test/run-pass/closure-return-bang.rs
@@ -8,13 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn foo(f: || -> !) {}
+#![allow(dead_code)]
+
+fn f(x: || -> !) -> ! {
+    x();
+}
 
 fn main() {
-    // Type inference didn't use to be able to handle this:
-    foo(|| fail!());
-    foo(|| -> ! fail!());
-    foo(|| 22); //~ ERROR mismatched types
-    foo(|| -> ! 22); //~ ERROR mismatched types
-    let x = || -> ! 1; //~ ERROR mismatched types
+    let x: || -> ! = || fail!();
+    let _y: || -> ! = || x();
 }

--- a/src/test/run-pass/closure-syntax.rs
+++ b/src/test/run-pass/closure-syntax.rs
@@ -78,6 +78,10 @@ fn bar<'b>() {
 
     let a = A;
     a.foo::<<'a>||>();
+
+    // issue #13490
+    let _ = || -> ! loop {};
+    let _ = proc() -> ! loop {};
 }
 
 struct B<T>;


### PR DESCRIPTION
Fixes #13490.
