### PR TITLE
Tweak error message for use of a keyword in ident position.

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -630,7 +630,7 @@ In Rust, however, using `let` to introduce a binding is _not_ an expression. The
 following will produce a compile-time error:
 
 ```{ignore}
-let x = (let y = 5i); // found `let` in ident position
+let x = (let y = 5i); // expected identifier, found keyword `let`
 ```
 
 The compiler is telling us here that it was expecting to see the beginning of

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -599,7 +599,7 @@ impl<'a> Parser<'a> {
             let token_str = self.this_token_to_string();
             let span = self.span;
             self.span_err(span,
-                          format!("found `{}` in ident position",
+                          format!("expected identifier, found keyword `{}`",
                                   token_str).as_slice());
         }
     }

--- a/src/test/compile-fail/bad-value-ident-false.rs
+++ b/src/test/compile-fail/bad-value-ident-false.rs
@@ -8,5 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn false() { } //~ ERROR found `false` in ident position
+fn false() { } //~ ERROR expected identifier, found keyword `false`
 fn main() { }

--- a/src/test/compile-fail/bad-value-ident-true.rs
+++ b/src/test/compile-fail/bad-value-ident-true.rs
@@ -8,5 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn true() { } //~ ERROR found `true` in ident position
+fn true() { } //~ ERROR expected identifier, found keyword `true`
 fn main() { }

--- a/src/test/compile-fail/keyword-super.rs
+++ b/src/test/compile-fail/keyword-super.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 fn main() {
-    let super: int; //~ ERROR found `super` in ident position
+    let super: int; //~ ERROR expected identifier, found keyword `super`
 }

--- a/src/test/compile-fail/keyword.rs
+++ b/src/test/compile-fail/keyword.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 pub mod break {
-    //~^ ERROR found `break` in ident position
+    //~^ ERROR expected identifier, found keyword `break`
 }

--- a/src/test/compile-fail/removed-syntax-field-let.rs
+++ b/src/test/compile-fail/removed-syntax-field-let.rs
@@ -10,6 +10,6 @@
 
 struct s {
     let foo: (),
-    //~^  ERROR found `let` in ident position
+    //~^  ERROR expected identifier, found keyword `let`
     //~^^ ERROR expected `:`, found `foo`
 }

--- a/src/test/compile-fail/removed-syntax-mut-vec-expr.rs
+++ b/src/test/compile-fail/removed-syntax-mut-vec-expr.rs
@@ -10,6 +10,6 @@
 
 fn f() {
     let v = [mut 1, 2, 3, 4];
-    //~^  ERROR found `mut` in ident position
+    //~^  ERROR expected identifier, found keyword `mut`
     //~^^ ERROR expected `]`, found `1`
 }

--- a/src/test/compile-fail/removed-syntax-mut-vec-ty.rs
+++ b/src/test/compile-fail/removed-syntax-mut-vec-ty.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 type v = [mut int];
-    //~^  ERROR found `mut` in ident position
+    //~^  ERROR expected identifier, found keyword `mut`
     //~^^ ERROR expected `]`, found `int`

--- a/src/test/compile-fail/removed-syntax-uniq-mut-expr.rs
+++ b/src/test/compile-fail/removed-syntax-uniq-mut-expr.rs
@@ -10,6 +10,6 @@
 
 fn f() {
     let a_box = box mut 42;
-    //~^  ERROR found `mut` in ident position
+    //~^  ERROR expected identifier, found keyword `mut`
     //~^^ ERROR expected `;`, found `42`
 }

--- a/src/test/compile-fail/removed-syntax-uniq-mut-ty.rs
+++ b/src/test/compile-fail/removed-syntax-uniq-mut-ty.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 type mut_box = Box<mut int>;
-    //~^  ERROR found `mut` in ident position
+    //~^  ERROR expected identifier, found keyword `mut`
     //~^^ ERROR expected `,`, found `int`

--- a/src/test/compile-fail/unsized2.rs
+++ b/src/test/compile-fail/unsized2.rs
@@ -13,5 +13,5 @@
 fn f<X>() {}
 
 pub fn main() {
-    f<type>(); //~ ERROR found `type` in ident position
+    f<type>(); //~ ERROR expected identifier, found keyword `type`
 }


### PR DESCRIPTION
Closes #15358
