### PR TITLE
Relax lifetime bounds on Reader/Writer impls for trait boxes

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -945,7 +945,13 @@ pub trait Reader {
     }
 }
 
+#[cfg(stage0)]
 impl Reader for Box<Reader+'static> {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> { self.read(buf) }
+}
+
+#[cfg(not(stage0))]
+impl<'a> Reader for Box<Reader+'a> {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> { self.read(buf) }
 }
 
@@ -1295,7 +1301,17 @@ pub trait Writer {
     }
 }
 
+#[cfg(stage0)]
 impl Writer for Box<Writer+'static> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> IoResult<()> { self.write(buf) }
+
+    #[inline]
+    fn flush(&mut self) -> IoResult<()> { self.flush() }
+}
+
+#[cfg(not(stage0))]
+impl<'a> Writer for Box<Writer+'a> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> IoResult<()> { self.write(buf) }
 


### PR DESCRIPTION
Cargo needs this to be able to instantiate `TerminfoTerminal<Box<Writer+'a>>` for 'a other than 'static.
