### PR TITLE
Parse bracketed `box` expressions

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2584,10 +2584,17 @@ impl<'a> Parser<'a> {
                 if !self.eat(&token::RPAREN) {
                     let place = self.parse_expr();
                     self.expect(&token::RPAREN);
-                    let subexpression = self.parse_prefix_expr();
-                    hi = subexpression.span.hi;
-                    ex = ExprBox(place, subexpression);
-                    return self.mk_expr(lo, hi, ex);
+                    if can_begin_expr(&self.token) {
+                        let subexpression = self.parse_prefix_expr();
+                        hi = subexpression.span.hi;
+                        ex = ExprBox(place, subexpression);
+                        return self.mk_expr(lo, hi, ex);
+                    } else { // Support `box(EXPR)` == `box EXPR`.
+                        let subexpression = place;
+                        hi = subexpression.span.hi;
+                        ex = self.mk_unary(UnUniq, subexpression);
+                        return self.mk_expr(lo, hi, ex);
+                    }
                 }
             }
 

--- a/src/test/run-pass/parenthesized-box.rs
+++ b/src/test/run-pass/parenthesized-box.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x: Box<int> = box (1 + 2);
+    assert_eq!(x, box 3);
+}


### PR DESCRIPTION
This lets the parser parse expressions like `box (1i + 2)` as `box() (1i + 2)`. Expressions are parsed greedily in `if`, `while`, and `for` expressions, so that `if box(foo) {} {}` is parsed as `if (box(foo) {}) {}`. This is the same behaviour as before this change.

Closes #15386.
