### PR TITLE
Implement tuple and tuple struct indexing (RFC 53)

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -2555,6 +2555,8 @@ The currently implemented features of the reference compiler are:
                         which is considered wildly unsafe and will be
                         obsoleted by language improvements.
 
+* `tuple_indexing` - Allows use of tuple indexing (expressions like `expr.0`)
+
 If a feature is promoted to a language feature, then all existing programs will
 start to receive compilation warnings about #[feature] directives which enabled
 the new feature (because the directive is no longer necessary). However, if

--- a/src/librustc/front/feature_gate.rs
+++ b/src/librustc/front/feature_gate.rs
@@ -70,6 +70,7 @@ static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[
     ("unboxed_closures", Active),
     ("import_shadowing", Active),
     ("advanced_slice_patterns", Active),
+    ("tuple_indexing", Active),
 
     // if you change this list without updating src/doc/rust.md, cmr will be sad
 
@@ -337,6 +338,11 @@ impl<'a> Visitor<()> for Context<'a> {
                                   e.span,
                                   "unboxed closures are a work-in-progress \
                                    feature with known bugs");
+            }
+            ast::ExprTupField(..) => {
+                self.gate_feature("tuple_indexing",
+                                  e.span,
+                                  "tuple indexing is experimental");
             }
             _ => {}
         }

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -1056,6 +1056,7 @@ impl UnnecessaryParens {
                 ast::ExprUnary(_, ref x) |
                 ast::ExprCast(ref x, _) |
                 ast::ExprField(ref x, _, _) |
+                ast::ExprTupField(ref x, _, _) |
                 ast::ExprIndex(ref x, _) => {
                     // &X { y: 1 }, X { y: 1 }.y
                     contains_exterior_struct_lit(&**x)

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -807,7 +807,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                         out.push_str(token::get_name(fname).get());
                     }
                     mc::PositionalField(idx) => {
-                        out.push_char('#'); // invent a notation here
+                        out.push_char('.');
                         out.push_str(idx.to_string().as_slice());
                     }
                 }

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -467,7 +467,8 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
             ast::ExprCast(e, _) |
             ast::ExprUnary(_, e) |
             ast::ExprParen(e) |
-            ast::ExprField(e, _, _) => {
+            ast::ExprField(e, _, _) |
+            ast::ExprTupField(e, _, _) => {
                 self.straightline(expr, pred, [e])
             }
 

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -173,6 +173,7 @@ fn check_expr(v: &mut CheckCrateVisitor, e: &Expr, is_const: bool) {
           ExprAddrOf(MutImmutable, _) |
           ExprParen(..) |
           ExprField(..) |
+          ExprTupField(..) |
           ExprIndex(..) |
           ExprTup(..) |
           ExprRepeat(..) |

--- a/src/librustc/middle/check_static.rs
+++ b/src/librustc/middle/check_static.rs
@@ -106,7 +106,7 @@ impl<'a, 'tcx> Visitor<bool> for CheckStaticVisitor<'a, 'tcx> {
         }
 
         match e.node {
-            ast::ExprField(..) | ast::ExprVec(..) |
+            ast::ExprField(..) | ast::ExprTupField(..) | ast::ExprVec(..) |
             ast::ExprBlock(..) | ast::ExprTup(..)  => {
                 visit::walk_expr(self, e, is_const);
             }

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -225,6 +225,8 @@ impl<'a, 'tcx> ConstEvalVisitor<'a, 'tcx> {
 
             ast::ExprField(ref base, _, _) => self.classify(&**base),
 
+            ast::ExprTupField(ref base, _, _) => self.classify(&**base),
+
             ast::ExprIndex(ref base, ref idx) =>
                 join(self.classify(&**base), self.classify(&**idx)),
 

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -324,6 +324,10 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,TYPER> {
                 self.select_from_expr(&**base);
             }
 
+            ast::ExprTupField(ref base, _, _) => {         // base.<n>
+                self.select_from_expr(&**base);
+            }
+
             ast::ExprIndex(ref lhs, ref rhs) => {           // lhs[rhs]
                 if !self.walk_overloaded_operator(expr, &**lhs, [rhs.clone()]) {
                     self.select_from_expr(&**lhs);

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -511,7 +511,7 @@ fn visit_expr(ir: &mut IrMaps, expr: &Expr) {
       }
 
       // otherwise, live nodes are not required:
-      ExprIndex(..) | ExprField(..) | ExprVec(..) |
+      ExprIndex(..) | ExprField(..) | ExprTupField(..) | ExprVec(..) |
       ExprCall(..) | ExprMethodCall(..) | ExprTup(..) |
       ExprBinary(..) | ExprAddrOf(..) |
       ExprCast(..) | ExprUnary(..) | ExprBreak(_) |
@@ -965,6 +965,10 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
               self.propagate_through_expr(&**e, succ)
           }
 
+          ExprTupField(ref e, _, _) => {
+              self.propagate_through_expr(&**e, succ)
+          }
+
           ExprFnBlock(_, _, ref blk) |
           ExprProc(_, ref blk) |
           ExprUnboxedFn(_, _, _, ref blk) => {
@@ -1271,6 +1275,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
         match expr.node {
             ExprPath(_) => succ,
             ExprField(ref e, _, _) => self.propagate_through_expr(&**e, succ),
+            ExprTupField(ref e, _, _) => self.propagate_through_expr(&**e, succ),
             _ => self.propagate_through_expr(expr, succ)
         }
     }
@@ -1445,7 +1450,7 @@ fn check_expr(this: &mut Liveness, expr: &Expr) {
       // no correctness conditions related to liveness
       ExprCall(..) | ExprMethodCall(..) | ExprIf(..) | ExprMatch(..) |
       ExprWhile(..) | ExprLoop(..) | ExprIndex(..) | ExprField(..) |
-      ExprVec(..) | ExprTup(..) | ExprBinary(..) |
+      ExprTupField(..) | ExprVec(..) | ExprTup(..) | ExprBinary(..) |
       ExprCast(..) | ExprUnary(..) | ExprRet(..) | ExprBreak(..) |
       ExprAgain(..) | ExprLit(_) | ExprBlock(..) |
       ExprMac(..) | ExprAddrOf(..) | ExprStruct(..) | ExprRepeat(..) |

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -465,6 +465,11 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
             Ok(self.cat_field(expr, base_cmt, f_name.node, expr_ty))
           }
 
+          ast::ExprTupField(ref base, idx, _) => {
+            let base_cmt = if_ok!(self.cat_expr(&**base));
+            Ok(self.cat_tup_field(expr, base_cmt, idx.node, expr_ty))
+          }
+
           ast::ExprIndex(ref base, _) => {
             let method_call = typeck::MethodCall::expr(expr.id());
             match self.typer.node_method_ty(method_call) {
@@ -733,6 +738,21 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
             span: node.span(),
             mutbl: base_cmt.mutbl.inherit(),
             cat: cat_interior(base_cmt, InteriorField(NamedField(f_name.name))),
+            ty: f_ty
+        })
+    }
+
+    pub fn cat_tup_field<N:ast_node>(&self,
+                                     node: &N,
+                                     base_cmt: cmt,
+                                     f_idx: uint,
+                                     f_ty: ty::t)
+                                     -> cmt {
+        Rc::new(cmt_ {
+            id: node.id(),
+            span: node.span(),
+            mutbl: base_cmt.mutbl.inherit(),
+            cat: cat_interior(base_cmt, InteriorField(PositionalField(f_idx))),
             ty: f_ty
         })
     }

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -819,6 +819,14 @@ impl<'a, 'tcx> Visitor<()> for PrivacyVisitor<'a, 'tcx> {
                     _ => {}
                 }
             }
+            ast::ExprTupField(ref base, idx, _) => {
+                match ty::get(ty::expr_ty_adjusted(self.tcx, &**base)).sty {
+                    ty::ty_struct(id, _) => {
+                        self.check_field(expr.span, id, UnnamedField(idx.node));
+                    }
+                    _ => {}
+                }
+            }
             ast::ExprMethodCall(ident, _, _) => {
                 let method_call = MethodCall::expr(expr.id);
                 match self.tcx.method_map.borrow().find(&method_call) {

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -779,6 +779,7 @@ fn resolve_local(visitor: &mut RegionResolutionVisitor,
                 ast::ExprAddrOf(_, ref subexpr) |
                 ast::ExprUnary(ast::UnDeref, ref subexpr) |
                 ast::ExprField(ref subexpr, _, _) |
+                ast::ExprTupField(ref subexpr, _, _) |
                 ast::ExprIndex(ref subexpr, _) |
                 ast::ExprParen(ref subexpr) => {
                     let subexpr: &'a Gc<Expr> = subexpr; // FIXME(#11586)

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -440,6 +440,13 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
                   (adt::const_get_field(cx, &*brepr, bv, discr, ix), inlineable)
               })
           }
+          ast::ExprTupField(ref base, idx, _) => {
+              let (bv, inlineable, bt) = const_expr(cx, &**base, is_local);
+              let brepr = adt::represent_type(cx, bt);
+              expr::with_field_tys(cx.tcx(), bt, None, |discr, _| {
+                  (adt::const_get_field(cx, &*brepr, bv, discr, idx.node), inlineable)
+              })
+          }
 
           ast::ExprIndex(ref base, ref index) => {
               let (bv, inlineable, bt) = const_expr(cx, &**base, is_local);

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -3457,6 +3457,7 @@ fn populate_scope_map(cx: &CrateContext,
             ast::ExprCast(ref sub_exp, _)     |
             ast::ExprAddrOf(_, ref sub_exp)  |
             ast::ExprField(ref sub_exp, _, _) |
+            ast::ExprTupField(ref sub_exp, _, _) |
             ast::ExprParen(ref sub_exp) =>
                 walk_expr(cx, &**sub_exp, scope_stack, scope_map),
 

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -222,6 +222,7 @@ mod svh_visitor {
 
         SawExprLoop(Option<token::InternedString>),
         SawExprField(token::InternedString),
+        SawExprTupField(uint),
         SawExprBreak(Option<token::InternedString>),
         SawExprAgain(Option<token::InternedString>),
 
@@ -276,6 +277,7 @@ mod svh_visitor {
             ExprAssign(..)           => SawExprAssign,
             ExprAssignOp(op, _, _)   => SawExprAssignOp(op),
             ExprField(_, id, _)      => SawExprField(content(id.node)),
+            ExprTupField(_, id, _)   => SawExprTupField(id.node),
             ExprIndex(..)            => SawExprIndex,
             ExprPath(..)             => SawExprPath,
             ExprAddrOf(m, _)         => SawExprAddrOf(m),

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -540,6 +540,7 @@ pub enum Expr_ {
     ExprAssign(Gc<Expr>, Gc<Expr>),
     ExprAssignOp(BinOp, Gc<Expr>, Gc<Expr>),
     ExprField(Gc<Expr>, SpannedIdent, Vec<P<Ty>>),
+    ExprTupField(Gc<Expr>, Spanned<uint>, Vec<P<Ty>>),
     ExprIndex(Gc<Expr>, Gc<Expr>),
 
     /// Variable reference, possibly containing `::` and/or

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -120,6 +120,8 @@ pub trait AstBuilder {
     fn expr_mut_addr_of(&self, sp: Span, e: Gc<ast::Expr>) -> Gc<ast::Expr>;
     fn expr_field_access(&self, span: Span, expr: Gc<ast::Expr>,
                          ident: ast::Ident) -> Gc<ast::Expr>;
+    fn expr_tup_field_access(&self, sp: Span, expr: Gc<ast::Expr>,
+                             idx: uint) -> Gc<ast::Expr>;
     fn expr_call(&self, span: Span, expr: Gc<ast::Expr>,
                  args: Vec<Gc<ast::Expr>>) -> Gc<ast::Expr>;
     fn expr_call_ident(&self, span: Span, id: ast::Ident,
@@ -604,6 +606,16 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
 
         let id = Spanned { node: ident, span: field_span };
         self.expr(sp, ast::ExprField(expr, id, Vec::new()))
+    }
+    fn expr_tup_field_access(&self, sp: Span, expr: Gc<ast::Expr>, idx: uint) -> Gc<ast::Expr> {
+        let field_span = Span {
+            lo: sp.lo - Pos::from_uint(idx.to_string().len()),
+            hi: sp.hi,
+            expn_info: sp.expn_info,
+        };
+
+        let id = Spanned { node: idx, span: field_span };
+        self.expr(sp, ast::ExprTupField(expr, id, Vec::new()))
     }
     fn expr_addr_of(&self, sp: Span, e: Gc<ast::Expr>) -> Gc<ast::Expr> {
         self.expr(sp, ast::ExprAddrOf(ast::MutImmutable, e))

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -134,6 +134,10 @@ pub trait Folder {
         noop_fold_ident(i, self)
     }
 
+    fn fold_uint(&mut self, i: uint) -> uint {
+        noop_fold_uint(i, self)
+    }
+
     fn fold_path(&mut self, p: &Path) -> Path {
         noop_fold_path(p, self)
     }
@@ -463,6 +467,10 @@ pub fn noop_fold_variant<T: Folder>(v: &Variant, fld: &mut T) -> P<Variant> {
 }
 
 pub fn noop_fold_ident<T: Folder>(i: Ident, _: &mut T) -> Ident {
+    i
+}
+
+pub fn noop_fold_uint<T: Folder>(i: uint, _: &mut T) -> uint {
     i
 }
 
@@ -1178,6 +1186,11 @@ pub fn noop_fold_expr<T: Folder>(e: Gc<Expr>, folder: &mut T) -> Gc<Expr> {
         ExprField(el, id, ref tys) => {
             ExprField(folder.fold_expr(el),
                       respan(id.span, folder.fold_ident(id.node)),
+                      tys.iter().map(|&x| folder.fold_ty(x)).collect())
+        }
+        ExprTupField(el, id, ref tys) => {
+            ExprTupField(folder.fold_expr(el),
+                      respan(id.span, folder.fold_uint(id.node)),
                       tys.iter().map(|&x| folder.fold_ty(x)).collect())
         }
         ExprIndex(el, er) => {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1607,6 +1607,18 @@ impl<'a> State<'a> {
                     try!(word(&mut self.s, ">"));
                 }
             }
+            ast::ExprTupField(ref expr, id, ref tys) => {
+                try!(self.print_expr(&**expr));
+                try!(word(&mut self.s, "."));
+                try!(self.print_uint(id.node));
+                if tys.len() > 0u {
+                    try!(word(&mut self.s, "::<"));
+                    try!(self.commasep(
+                        Inconsistent, tys.as_slice(),
+                        |s, ty| s.print_type_ref(ty)));
+                    try!(word(&mut self.s, ">"));
+                }
+            }
             ast::ExprIndex(ref expr, ref index) => {
                 try!(self.print_expr(&**expr));
                 try!(word(&mut self.s, "["));
@@ -1736,6 +1748,10 @@ impl<'a> State<'a> {
             try!(word(&mut self.s, token::get_ident(ident).get()))
         }
         self.ann.post(self, NodeIdent(&ident))
+    }
+
+    pub fn print_uint(&mut self, i: uint) -> IoResult<()> {
+        word(&mut self.s, i.to_string().as_slice())
     }
 
     pub fn print_name(&mut self, name: ast::Name) -> IoResult<()> {

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -830,6 +830,12 @@ pub fn walk_expr<E: Clone, V: Visitor<E>>(visitor: &mut V, expression: &Expr, en
                 visitor.visit_ty(&**typ, env.clone())
             }
         }
+        ExprTupField(ref subexpression, _, ref types) => {
+            visitor.visit_expr(&**subexpression, env.clone());
+            for typ in types.iter() {
+                visitor.visit_ty(&**typ, env.clone())
+            }
+        }
         ExprIndex(ref main_expression, ref index_expression) => {
             visitor.visit_expr(&**main_expression, env.clone());
             visitor.visit_expr(&**index_expression, env.clone())

--- a/src/test/compile-fail/borrow-tuple-fields.rs
+++ b/src/test/compile-fail/borrow-tuple-fields.rs
@@ -1,0 +1,42 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(tuple_indexing)]
+
+struct Foo(Box<int>, int);
+
+struct Bar(int, int);
+
+fn main() {
+    let x = (box 1i, 2i);
+    let r = &x.0;
+    let y = x; //~ ERROR cannot move out of `x` because it is borrowed
+
+    let mut x = (1i, 2i);
+    let a = &x.0;
+    let b = &mut x.0; //~ ERROR cannot borrow `x.0` as mutable because it is also borrowed as
+
+    let mut x = (1i, 2i);
+    let a = &mut x.0;
+    let b = &mut x.0; //~ ERROR cannot borrow `x.0` as mutable more than once at a time
+
+
+    let x = Foo(box 1i, 2i);
+    let r = &x.0;
+    let y = x; //~ ERROR cannot move out of `x` because it is borrowed
+
+    let mut x = Bar(1i, 2i);
+    let a = &x.0;
+    let b = &mut x.0; //~ ERROR cannot borrow `x.0` as mutable because it is also borrowed as
+
+    let mut x = Bar(1i, 2i);
+    let a = &mut x.0;
+    let b = &mut x.0; //~ ERROR cannot borrow `x.0` as mutable more than once at a time
+}

--- a/src/test/compile-fail/move-out-of-tuple-field.rs
+++ b/src/test/compile-fail/move-out-of-tuple-field.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(tuple_indexing)]
+
+struct Foo(Box<int>);
+
+fn main() {
+    let x = (box 1i,);
+    let y = x.0;
+    let z = x.0; //~ ERROR use of moved value: `x.0`
+
+    let x = Foo(box 1i);
+    let y = x.0;
+    let z = x.0; //~ ERROR use of moved value: `x.0`
+}

--- a/src/test/compile-fail/tuple-index-not-tuple.rs
+++ b/src/test/compile-fail/tuple-index-not-tuple.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(tuple_indexing)]
+
+struct Point { x: int, y: int }
+struct Empty;
+
+fn main() {
+    let origin = Point { x: 0, y: 0 };
+    origin.0;
+    //~^ ERROR attempted tuple index `0` on type `Point`, but the type was not
+    Empty.0;
+    //~^ ERROR attempted tuple index `0` on type `Empty`, but the type was not
+}

--- a/src/test/compile-fail/tuple-index-out-of-bounds.rs
+++ b/src/test/compile-fail/tuple-index-out-of-bounds.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(tuple_indexing)]
+
+struct Point(int, int);
+
+fn main() {
+    let origin = Point(0, 0);
+    origin.0;
+    origin.1;
+    origin.2;
+    //~^ ERROR attempted out-of-bounds tuple index `2` on type `Point`
+    let tuple = (0i, 0i);
+    tuple.0;
+    tuple.1;
+    tuple.2;
+    //~^ ERROR attempted out-of-bounds tuple index `2` on type `(int,int)`
+}

--- a/src/test/run-pass/borrow-tuple-fields.rs
+++ b/src/test/run-pass/borrow-tuple-fields.rs
@@ -1,0 +1,48 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(tuple_indexing)]
+
+struct Foo(int, int);
+
+fn main() {
+    let x = (1i, 2i);
+    let a = &x.0;
+    let b = &x.0;
+    assert_eq!(*a, 1);
+    assert_eq!(*b, 1);
+
+    let mut x = (1i, 2i);
+    {
+        let a = &x.0;
+        let b = &mut x.1;
+        *b = 5;
+        assert_eq!(*a, 1);
+    }
+    assert_eq!(x.0, 1);
+    assert_eq!(x.1, 5);
+
+
+    let x = Foo(1i, 2i);
+    let a = &x.0;
+    let b = &x.0;
+    assert_eq!(*a, 1);
+    assert_eq!(*b, 1);
+
+    let mut x = Foo(1i, 2i);
+    {
+        let a = &x.0;
+        let b = &mut x.1;
+        *b = 5;
+        assert_eq!(*a, 1);
+    }
+    assert_eq!(x.0, 1);
+    assert_eq!(x.1, 5);
+}

--- a/src/test/run-pass/tuple-index-fat-types.rs
+++ b/src/test/run-pass/tuple-index-fat-types.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(tuple_indexing)]
+
+struct Foo<'a>(&'a [int]);
+
+fn main() {
+    let x: &[int] = &[1i, 2, 3];
+    let y = (x,);
+    assert_eq!(y.0, x);
+
+    let x: &[int] = &[1i, 2, 3];
+    let y = Foo(x);
+    assert_eq!(y.0, x);
+}

--- a/src/test/run-pass/tuple-index.rs
+++ b/src/test/run-pass/tuple-index.rs
@@ -1,0 +1,42 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(tuple_indexing)]
+
+struct Point(int, int);
+
+fn main() {
+    let mut x = Point(3, 2);
+    assert_eq!(x.0, 3);
+    assert_eq!(x.1, 2);
+    x.0 += 5;
+    assert_eq!(x.0, 8);
+    {
+        let ry = &mut x.1;
+        *ry -= 2;
+        x.0 += 3;
+        assert_eq!(x.0, 11);
+    }
+    assert_eq!(x.1, 0);
+
+    let mut x = (3i, 2i);
+    assert_eq!(x.0, 3);
+    assert_eq!(x.1, 2);
+    x.0 += 5;
+    assert_eq!(x.0, 8);
+    {
+        let ry = &mut x.1;
+        *ry -= 2;
+        x.0 += 3;
+        assert_eq!(x.0, 11);
+    }
+    assert_eq!(x.1, 0);
+
+}


### PR DESCRIPTION
This allows code to access the fields of tuples and tuple structs behind the feature gate `tuple_indexing`:

``` rust
#![feature(tuple_indexing)]

let x = (1i, 2i);
assert_eq!(x.1, 2);

struct Point(int, int);
let origin = Point(0, 0);
assert_eq!(origin.0, 0);
assert_eq!(origin.1, 0);
```

Implements [RFC 53](https://github.com/rust-lang/rfcs/blob/master/active/0053-tuple-accessors.md). Closes #16950.
