### PR TITLE
Detect traits being used as structs in check_expr_with_unifier

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -169,5 +169,6 @@ register_diagnostics!(
     E0155,
     E0156,
     E0157,
-    E0158
+    E0158,
+    E0159
 )

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3463,6 +3463,22 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         fcx.write_ty(id, enum_type);
     }
 
+    fn check_struct_fields_on_error(fcx: &FnCtxt,
+                                    id: ast::NodeId,
+                                    fields: &[ast::Field],
+                                    base_expr: Option<Gc<ast::Expr>>) {
+        // Make sure to still write the types
+        // otherwise we might ICE
+        fcx.write_error(id);
+        for field in fields.iter() {
+            check_expr(fcx, &*field.expr);
+        }
+        match base_expr {
+            Some(ref base) => check_expr(fcx, &**base),
+            None => {}
+        }
+    }
+
     type ExprCheckerWithTy = fn(&FnCtxt, &ast::Expr, ty::t);
 
     let tcx = fcx.ccx.tcx;
@@ -3982,6 +3998,16 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                                           variant_id, fields.as_slice());
                 enum_id
             }
+            Some(def::DefTrait(def_id)) => {
+                span_err!(tcx.sess, path.span, E0159,
+                    "`{}` is a trait not a structure",
+                    pprust::path_to_string(path));
+                check_struct_fields_on_error(fcx,
+                                             id,
+                                             fields.as_slice(),
+                                             base_expr);
+                def_id
+            },
             Some(def) => {
                 // Verify that this was actually a struct.
                 let typ = ty::lookup_item_type(fcx.ccx.tcx, def.def_id());
@@ -3998,17 +4024,10 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                         span_err!(tcx.sess, path.span, E0071,
                             "`{}` does not name a structure",
                             pprust::path_to_string(path));
-
-                        // Make sure to still write the types
-                        // otherwise we might ICE
-                        fcx.write_error(id);
-                        for field in fields.iter() {
-                            check_expr(fcx, &*field.expr);
-                        }
-                        match base_expr {
-                            Some(ref base) => check_expr(fcx, &**base),
-                            None => {}
-                        }
+                        check_struct_fields_on_error(fcx,
+                                                     id,
+                                                     fields.as_slice(),
+                                                     base_expr);
                     }
                 }
 

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -4000,7 +4000,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             }
             Some(def::DefTrait(def_id)) => {
                 span_err!(tcx.sess, path.span, E0159,
-                    "`{}` is a trait not a structure",
+                    "use of trait `{}` as a struct constructor",
                     pprust::path_to_string(path));
                 check_struct_fields_on_error(fcx,
                                              id,

--- a/src/test/compile-fail/trait-as-struct-constructor.rs
+++ b/src/test/compile-fail/trait-as-struct-constructor.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait TraitNotAStruct { }
+
+fn main() {
+    TraitNotAStruct{ value: 0 };
+    //~^ ERROR: use of trait `TraitNotAStruct` as a struct constructor [E0159]
+}
+


### PR DESCRIPTION
Not sure if this is addressing the root cause or just patching up a symptom. Also not sure if I should be adding a diagnostic code for this.

Fixes #16750
Fixes #15812
