### PR TITLE
test: Ignore a deadlocking test on OSX

### DIFF
--- a/src/test/run-pass/tcp-accept-stress.rs
+++ b/src/test/run-pass/tcp-accept-stress.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-macos #16872 spurious deadlock
+
 #![feature(phase)]
 
 #[phase(plugin)]


### PR DESCRIPTION
This test apparently keeps making no progress and timing out builds on the OSX
builder, so this commit is switching the test to be ignored.

cc #16872
