### PR TITLE
Defailbloat fail!(string) in libcore

### DIFF
--- a/src/libcore/failure.rs
+++ b/src/libcore/failure.rs
@@ -56,6 +56,11 @@ fn fail_bounds_check(file_line: &(&'static str, uint),
 }
 
 #[cold] #[inline(never)]
+pub fn begin_unwind_string(msg: &str, file: &(&'static str, uint)) -> ! {
+    format_args!(|fmt| begin_unwind(fmt, file), "{}", msg)
+}
+
+#[cold] #[inline(never)]
 pub fn begin_unwind(fmt: &fmt::Arguments, file_line: &(&'static str, uint)) -> ! {
     #[allow(ctypes)]
     extern {

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -16,9 +16,10 @@ macro_rules! fail(
     () => (
         fail!("{}", "explicit failure")
     );
-    ($msg:expr) => (
-        fail!("{}", $msg)
-    );
+    ($msg:expr) => ({
+        static _FILE_LINE: (&'static str, uint) = (file!(), line!());
+        ::core::failure::begin_unwind_string($msg, &_FILE_LINE)
+    });
     ($fmt:expr, $($arg:tt)*) => ({
         // a closure can't have return type !, so we need a full
         // function to pass to format_args!, *and* we need the


### PR DESCRIPTION
by not performing formatting at the failure site

This cuts about 673382 bytes from libcore.rlib
