### PR TITLE
Allow ExprLit expression macros to be used in patterns.

### DIFF
--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -154,6 +154,16 @@ impl MacResult for MacExpr {
     fn make_expr(&self) -> Option<Gc<ast::Expr>> {
         Some(self.e)
     }
+    fn make_pat(&self) -> Option<Gc<ast::Pat>> {
+        match self.e.node {
+            ast::ExprLit(_) => Some(box(GC) ast::Pat {
+                id: ast::DUMMY_NODE_ID,
+                node: ast::PatLit(self.e),
+                span: self.e.span
+            }),
+            _ => None
+        }
+    }
 }
 /// A convenience type for macros that return a single pattern.
 pub struct MacPat {

--- a/src/test/run-pass/concat.rs
+++ b/src/test/run-pass/concat.rs
@@ -18,4 +18,9 @@ pub fn main() {
         concat!(1, 2i, 3u, 4f32, 4.0, 'a', true, ()),
         "12344.0atrue"
     );
+
+    assert!(match "12344.0atrue" {
+        concat!(1, 2i, 3u, 4f32, 4.0, 'a', true, ()) => true,
+        _ => false
+    })
 }

--- a/src/test/run-pass/syntax-extension-source-utils.rs
+++ b/src/test/run-pass/syntax-extension-source-utils.rs
@@ -43,4 +43,9 @@ pub fn main() {
         [1] == (42 as u8)); // '*'
     // The Windows tests are wrapped in an extra module for some reason
     assert!((m1::m2::where_am_i().as_slice().ends_with("m1::m2")));
+
+    assert!(match (47, "( 2 * 3 ) + 5") {
+        (line!(), stringify!((2*3) + 5)) => true,
+        _ => false
+    })
 }


### PR DESCRIPTION
Enables any macros using `MacExpr` to be treated as patterns when
they produce a literal in the form `ExprLit` (e.g. `stringify!` or `line!`).

Fixes #16876.
