### PR TITLE
Make -L arguments given to linker always have the same order as the rustc -L arguments

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -28,7 +28,6 @@ use util::ppaux;
 use util::sha2::{Digest, Sha256};
 
 use std::char;
-use std::collections::HashSet;
 use std::io::{fs, TempDir, Command};
 use std::io;
 use std::mem;
@@ -570,10 +569,7 @@ fn link_binary_output(sess: &Session,
 fn archive_search_paths(sess: &Session) -> Vec<Path> {
     let mut rustpath = filesearch::rust_path();
     rustpath.push(sess.target_filesearch().get_lib_path());
-    // FIXME: Addl lib search paths are an unordered HashSet?
-    // Shouldn't this search be done in some order?
-    let addl_lib_paths: HashSet<Path> = sess.opts.addl_lib_search_paths.borrow().clone();
-    let mut search: Vec<Path> = addl_lib_paths.move_iter().collect();
+    let mut search: Vec<Path> = sess.opts.addl_lib_search_paths.borrow().clone();
     search.push_all(rustpath.as_slice());
     return search;
 }

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -30,7 +30,7 @@ use syntax::diagnostic::{ColorConfig, Auto, Always, Never};
 use syntax::parse;
 use syntax::parse::token::InternedString;
 
-use std::collections::{HashSet, HashMap};
+use std::collections::HashMap;
 use getopts::{optopt, optmulti, optflag, optflagopt};
 use getopts;
 use std::cell::{RefCell};
@@ -76,7 +76,7 @@ pub struct Options {
     // This was mutable for rustpkg, which updates search paths based on the
     // parsed code. It remains mutable in case its replacements wants to use
     // this.
-    pub addl_lib_search_paths: RefCell<HashSet<Path>>,
+    pub addl_lib_search_paths: RefCell<Vec<Path>>,
     pub maybe_sysroot: Option<Path>,
     pub target_triple: String,
     // User-specified cfg meta items. The compiler itself will add additional
@@ -113,7 +113,7 @@ pub fn basic_options() -> Options {
         lint_opts: Vec::new(),
         describe_lints: false,
         output_types: Vec::new(),
-        addl_lib_search_paths: RefCell::new(HashSet::new()),
+        addl_lib_search_paths: RefCell::new(Vec::new()),
         maybe_sysroot: None,
         target_triple: driver::host_triple().to_string(),
         cfg: Vec::new(),

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -30,7 +30,7 @@ pub type pick<'a> = |path: &Path|: 'a -> FileMatch;
 
 pub struct FileSearch<'a> {
     pub sysroot: &'a Path,
-    pub addl_lib_search_paths: &'a RefCell<HashSet<Path>>,
+    pub addl_lib_search_paths: &'a RefCell<Vec<Path>>,
     pub triple: &'a str,
 }
 
@@ -125,7 +125,7 @@ impl<'a> FileSearch<'a> {
 
     pub fn new(sysroot: &'a Path,
                triple: &'a str,
-               addl_lib_search_paths: &'a RefCell<HashSet<Path>>) -> FileSearch<'a> {
+               addl_lib_search_paths: &'a RefCell<Vec<Path>>) -> FileSearch<'a> {
         debug!("using sysroot = {}, triple = {}", sysroot.display(), triple);
         FileSearch {
             sysroot: sysroot,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -80,7 +80,7 @@ pub struct CrateAnalysis {
 pub type Externs = HashMap<String, Vec<String>>;
 
 /// Parses, resolves, and typechecks the given crate
-fn get_ast_and_resolve(cpath: &Path, libs: HashSet<Path>, cfgs: Vec<String>,
+fn get_ast_and_resolve(cpath: &Path, libs: Vec<Path>, cfgs: Vec<String>,
                        externs: Externs, triple: Option<String>)
                        -> (DocContext, CrateAnalysis) {
     use syntax::codemap::dummy_spanned;
@@ -153,7 +153,7 @@ fn get_ast_and_resolve(cpath: &Path, libs: HashSet<Path>, cfgs: Vec<String>,
     })
 }
 
-pub fn run_core(libs: HashSet<Path>, cfgs: Vec<String>, externs: Externs,
+pub fn run_core(libs: Vec<Path>, cfgs: Vec<String>, externs: Externs,
                 path: &Path, triple: Option<String>)
                 -> (clean::Crate, CrateAnalysis) {
     let (ctxt, analysis) = get_ast_and_resolve(path, libs, cfgs, externs, triple);

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -369,11 +369,7 @@ fn rust_input(cratefile: &str, externs: core::Externs, matches: &getopts::Matche
     info!("starting to run rustc");
     let (mut krate, analysis) = std::task::try(proc() {
         let cr = cr;
-        core::run_core(libs.move_iter().collect(),
-                       cfgs,
-                       externs,
-                       &cr,
-                       triple)
+        core::run_core(libs, cfgs, externs, &cr, triple)
     }).map_err(|boxed_any|format!("{:?}", boxed_any)).unwrap();
     info!("finished with rustc");
     analysiskey.replace(Some(analysis));

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::collections::HashSet;
 use std::io;
 use std::string::String;
 
@@ -136,7 +135,7 @@ pub fn render(input: &str, mut output: Path, matches: &getopts::Matches,
 }
 
 /// Run any tests/code examples in the markdown file `input`.
-pub fn test(input: &str, libs: HashSet<Path>, externs: core::Externs,
+pub fn test(input: &str, libs: Vec<Path>, externs: core::Externs,
             mut test_args: Vec<String>) -> int {
     let input_str = load_or_return!(input, 1, 2);
 

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -39,7 +39,7 @@ use visit_ast::RustdocVisitor;
 
 pub fn run(input: &str,
            cfgs: Vec<String>,
-           libs: HashSet<Path>,
+           libs: Vec<Path>,
            externs: core::Externs,
            mut test_args: Vec<String>,
            crate_name: Option<String>)
@@ -109,7 +109,7 @@ pub fn run(input: &str,
     0
 }
 
-fn runtest(test: &str, cratename: &str, libs: HashSet<Path>, externs: core::Externs,
+fn runtest(test: &str, cratename: &str, libs: Vec<Path>, externs: core::Externs,
            should_fail: bool, no_run: bool, as_test_harness: bool) {
     // the test harness wants its own `main` & top level functions, so
     // never wrap the test in `fn main() { ... }`
@@ -244,7 +244,7 @@ pub fn maketest(s: &str, cratename: Option<&str>, lints: bool, dont_insert_main:
 pub struct Collector {
     pub tests: Vec<testing::TestDescAndFn>,
     names: Vec<String>,
-    libs: HashSet<Path>,
+    libs: Vec<Path>,
     externs: core::Externs,
     cnt: uint,
     use_headers: bool,
@@ -253,7 +253,7 @@ pub struct Collector {
 }
 
 impl Collector {
-    pub fn new(cratename: String, libs: HashSet<Path>, externs: core::Externs,
+    pub fn new(cratename: String, libs: Vec<Path>, externs: core::Externs,
                use_headers: bool) -> Collector {
         Collector {
             tests: Vec::new(),

--- a/src/test/run-make/link-path-order/Makefile
+++ b/src/test/run-make/link-path-order/Makefile
@@ -1,0 +1,17 @@
+-include ../tools.mk
+
+# Verifies that the -L arguments given to the linker is in the same order
+# as the -L arguments on the rustc command line.
+
+CORRECT_DIR=$(TMPDIR)/correct
+WRONG_DIR=$(TMPDIR)/wrong
+
+all: $(TMPDIR)/libcorrect.a $(TMPDIR)/libwrong.a
+	mkdir -p $(CORRECT_DIR) $(WRONG_DIR)
+	mv $(TMPDIR)/libcorrect.a $(CORRECT_DIR)/libfoo.a
+	mv $(TMPDIR)/libwrong.a $(WRONG_DIR)/libfoo.a
+	$(RUSTC) main.rs -o $(TMPDIR)/should_succeed -L $(CORRECT_DIR) -L $(WRONG_DIR)
+	$(call RUN,should_succeed)
+	$(RUSTC) main.rs -o $(TMPDIR)/should_fail -L $(WRONG_DIR) -L $(CORRECT_DIR)
+	$(call FAIL,should_fail)
+

--- a/src/test/run-make/link-path-order/correct.c
+++ b/src/test/run-make/link-path-order/correct.c
@@ -1,0 +1,1 @@
+int should_return_one() { return 1; }

--- a/src/test/run-make/link-path-order/main.rs
+++ b/src/test/run-make/link-path-order/main.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate libc;
+
+#[link(name="foo")]
+extern {
+    fn should_return_one() -> libc::c_int;
+}
+
+fn main() {
+    let result = unsafe {
+        should_return_one()
+    };
+
+    if result != 1 {
+        std::os::set_exit_status(255);
+    }
+}

--- a/src/test/run-make/link-path-order/wrong.c
+++ b/src/test/run-make/link-path-order/wrong.c
@@ -1,0 +1,1 @@
+int should_return_one() { return 0; }


### PR DESCRIPTION
Issue can be reproduced by the following:

```
$ cat main.rs
fn main() {}
$ rustc -Z print-link-args -Lfoo -Lbar main.rs
```

Run the rustc command a few times and observe that the order of the '-L' 'foo' '-L' 'bar' options randomly changes.

Actually hit this issue in practice on Windows when specifying two -L directories to rustc, one with rust-sdl2 in it and one with the C SDL2.dll. Since Windows file systems aren't case-sensitive, gcc randomly attempted to link against the rust sdl2.dll instead of SDL2.dll if that -L directory happened to come first.

The randomness was due to addl_lib_search_paths being a HashSet. Changed it to a Vec instead which maintains the ordering.
Unsure how to test this though since it is random by nature; suggestions very welcome.
