### PR TITLE
Have std::io::TempDir::new and new_in return IoResult

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -1120,7 +1120,7 @@ fn link_rlib<'a>(sess: &'a Session,
             // contain the metadata in a separate file. We use a temp directory
             // here so concurrent builds in the same directory don't try to use
             // the same filename for metadata (stomping over one another)
-            let tmpdir = TempDir::new("rustc").expect("needs a temp dir");
+            let tmpdir = TempDir::new("rustc").ok().expect("needs a temp dir");
             let metadata = tmpdir.path().join(METADATA_FILENAME);
             match fs::File::create(&metadata).write(trans.metadata
                                                          .as_slice()) {
@@ -1280,7 +1280,7 @@ fn link_staticlib(sess: &Session, obj_filename: &Path, out_filename: &Path) {
 // links to all upstream files as well.
 fn link_natively(sess: &Session, trans: &CrateTranslation, dylib: bool,
                  obj_filename: &Path, out_filename: &Path) {
-    let tmpdir = TempDir::new("rustc").expect("needs a temp dir");
+    let tmpdir = TempDir::new("rustc").ok().expect("needs a temp dir");
 
     // The invocations of cc share some flags across platforms
     let pname = get_cc_prog(sess);

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -170,7 +170,7 @@ fn runtest(test: &str, cratename: &str, libs: HashSet<Path>, externs: core::Exte
                                       None,
                                       span_diagnostic_handler);
 
-    let outdir = TempDir::new("rustdoctest").expect("rustdoc needs a tempdir");
+    let outdir = TempDir::new("rustdoctest").ok().expect("rustdoc needs a tempdir");
     let out = Some(outdir.path().clone());
     let cfg = config::build_configuration(&sess);
     let libdir = sess.target_filesearch().get_lib_path();

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1660,7 +1660,7 @@ mod tests {
     #[test]
     pub fn ratchet_test() {
 
-        let dpth = TempDir::new("test-ratchet").expect("missing test for ratchet");
+        let dpth = TempDir::new("test-ratchet").ok().expect("missing test for ratchet");
         let pth = dpth.path().join("ratchet.json");
 
         let mut m1 = MetricMap::new();

--- a/src/test/run-pass/rename-directory.rs
+++ b/src/test/run-pass/rename-directory.rs
@@ -22,7 +22,7 @@ fn rename_directory() {
     unsafe {
         static U_RWX: i32 = (libc::S_IRUSR | libc::S_IWUSR | libc::S_IXUSR) as i32;
 
-        let tmpdir = TempDir::new("rename_directory").expect("rename_directory failed");
+        let tmpdir = TempDir::new("rename_directory").ok().expect("rename_directory failed");
         let tmpdir = tmpdir.path();
         let old_path = tmpdir.join_many(["foo", "bar", "baz"]);
         fs::mkdir_recursive(&old_path, io::UserRWX);

--- a/src/test/run-pass/tempfile.rs
+++ b/src/test/run-pass/tempfile.rs
@@ -160,8 +160,8 @@ fn recursive_mkdir_rel_2() {
 pub fn test_rmdir_recursive_ok() {
     let rwx = io::UserRWX;
 
-    let tmpdir = TempDir::new("test").expect("test_rmdir_recursive_ok: \
-                                              couldn't create temp dir");
+    let tmpdir = TempDir::new("test").ok().expect("test_rmdir_recursive_ok: \
+                                                   couldn't create temp dir");
     let tmpdir = tmpdir.path();
     let root = tmpdir.join("foo");
 
@@ -190,7 +190,7 @@ pub fn dont_double_fail() {
 }
 
 fn in_tmpdir(f: ||) {
-    let tmpdir = TempDir::new("test").expect("can't make tmpdir");
+    let tmpdir = TempDir::new("test").ok().expect("can't make tmpdir");
     assert!(os::change_dir(tmpdir.path()));
 
     f();


### PR DESCRIPTION
This allows using `try!()`

[breaking-change]

Fixes #16875
