### PR TITLE
Make doc search results use <a> tags instead of js for navigating

### DIFF
--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -218,11 +218,10 @@ nav.sub {
 }
 
 .content .highlighted {
-    cursor: pointer;
     color: #000 !important;
     background-color: #ccc;
 }
-.content .highlighted a { color: #000 !important; }
+.content .highlighted a, .content .highlighted span { color: #000 !important; }
 .content .highlighted.trait { background-color: #fece7e; }
 .content .highlighted.mod { background-color: #afc6e4; }
 .content .highlighted.enum { background-color: #b4d1b9; }
@@ -335,11 +334,11 @@ a {
 p a { color: #4e8bca; }
 p a:hover { text-decoration: underline; }
 
-.content a.trait, .block a.current.trait { color: #ed9603; }
-.content a.mod, .block a.current.mod { color: #4d76ae; }
-.content a.enum, .block a.current.enum { color: #5e9766; }
-.content a.struct, .block a.current.struct { color: #e53700; }
-.content a.fn, .block a.current.fn { color: #8c6067; }
+.content span.trait, .block a.current.trait { color: #ed9603; }
+.content span.mod, .block a.current.mod { color: #4d76ae; }
+.content span.enum, .block a.current.enum { color: #5e9766; }
+.content span.struct, .block a.current.struct { color: #e53700; }
+.content span.fn, .block a.current.fn { color: #8c6067; }
 .content .fnname { color: #8c6067; }
 
 .search-input {
@@ -376,6 +375,13 @@ p a:hover { text-decoration: underline; }
     overflow: hidden;
     display: block;
 }
+
+.search-results a {
+    display: block;
+}
+
+.content .search-results td:first-child { padding-right: 0; }
+.content .search-results td:first-child a { padding-right: 10px; }
 
 #help {
     background: #e9e9e9;

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -395,8 +395,8 @@
                 if (window.location.pathname == dst.pathname) {
                     $('#search').addClass('hidden');
                     $('#main').removeClass('hidden');
+                    document.location.href = dst.href;
                 }
-                document.location.href = dst.href;
             }).on('mouseover', function() {
                 var $el = $(this);
                 clearTimeout(hoverTimeout);
@@ -451,7 +451,7 @@
                 shown = [];
 
                 results.forEach(function(item) {
-                    var name, type;
+                    var name, type, href, displayPath;
 
                     if (shown.indexOf(item) !== -1) {
                         return;
@@ -461,43 +461,35 @@
                     name = item.name;
                     type = itemTypes[item.ty];
 
-                    output += '<tr class="' + type + ' result"><td>';
-
                     if (type === 'mod') {
-                        output += item.path +
-                            '::<a href="' + rootPath +
-                            item.path.replace(/::/g, '/') + '/' +
-                            name + '/index.html" class="' +
-                            type + '">' + name + '</a>';
+                        displayPath = item.path + '::';
+                        href = rootPath + item.path.replace(/::/g, '/') + '/' +
+                               name + '/index.html';
                     } else if (type === 'static' || type === 'reexport') {
-                        output += item.path +
-                            '::<a href="' + rootPath +
-                            item.path.replace(/::/g, '/') +
-                            '/index.html" class="' + type +
-                            '">' + name + '</a>';
+                        displayPath = item.path + '::';
+                        href = rootPath + item.path.replace(/::/g, '/') +
+                               '/index.html';
                     } else if (item.parent !== undefined) {
                         var myparent = item.parent;
                         var anchor = '#' + type + '.' + name;
-                        output += item.path + '::' + myparent.name +
-                            '::<a href="' + rootPath +
-                            item.path.replace(/::/g, '/') +
-                            '/' + itemTypes[myparent.ty] +
-                            '.' + myparent.name +
-                            '.html' + anchor +
-                            '" class="' + type +
-                            '">' + name + '</a>';
+                        displayPath = item.path + '::' + myparent.name + '::';
+                        href = rootPath + item.path.replace(/::/g, '/') +
+                               '/' + itemTypes[myparent.ty] +
+                               '.' + myparent.name +
+                               '.html' + anchor;
                     } else {
-                        output += item.path +
-                            '::<a href="' + rootPath +
-                            item.path.replace(/::/g, '/') +
-                            '/' + type +
-                            '.' + name +
-                            '.html" class="' + type +
-                            '">' + name + '</a>';
+                        displayPath = item.path + '::';
+                        href = rootPath + item.path.replace(/::/g, '/') +
+                               '/' + type + '.' + name + '.html';
                     }
 
-                    output += '</td><td><span class="desc">' + item.desc +
-                        '</span></td></tr>';
+                    output += '<tr class="' + type + ' result"><td>' +
+                              '<a href="' + href + '">' +
+                              displayPath + '<span class="' + type + '">' +
+                              name + '</span></a></td><td>' +
+                              '<a href="' + href + '">' +
+                              '<span class="desc">' + item.desc +
+                              '&nbsp;</span></a></td></tr>';
                 });
             } else {
                 output += 'No results :( <a href="https://duckduckgo.com/?q=' +


### PR DESCRIPTION
This has the primary advantage of not interfering with browser default behavior for links like being able to cmd/ctrl+click on a result to open the result in a new tab but leave the current page as-is (previous behavior both opened a new tab and changed the current tab's location to the result's).

I've done my best to keep the rest of the behavior and the appearance the same-- the whole row still highlights, still has a hand cursor, still moves to the result page with a normal click, arrows+enter still work. If the result is on the current page, the search is simply hidden.

The biggest difference in behavior is that people using tab to navigate through the links will have to hit tab twice for each row, since each cell has its own `a` tag.. I could fix this by switching to `div`s and `span`s instead of a table, but that's potentially more CSS finicky?

The biggest difference in appearance is probably that all the text in the search results is Fira Sans now, instead of just the method name with the rest of the text in Source Serif Pro. I can put this appearance back, but it looks like all links anywhere on the page are Fira Sans. Only the name was in an `a` tag before, but the whole row was ACTING like a link, so I think this is actually more consistent.

[I've pushed these changes to a gh-pages repo](https://carols10cents.github.io/rustdoc-playground/std/index.html?search=t) if you'd like to take a look at the effects; note that I also have my changes for PR #16735 there too so the search results will be sorted differently than on master.
