### PR TITLE
ICE Fix #16562

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -24,10 +24,13 @@ use std::rc::Rc;
 use std::str;
 use std::string::String;
 use std::uint;
+use std::cmp;
 use syntax::abi;
 use syntax::ast;
 use syntax::ast::*;
 use syntax::parse::token;
+
+static DATA_TRUNCATE : uint = 32;
 
 // Compact string representation for ty::t values. API ty_str &
 // parse_from_str. Extra parameters are for converting to/from def_ids in the
@@ -115,16 +118,25 @@ pub fn parse_state_from_data<'a>(data: &'a [u8], crate_num: ast::CrateNum,
     }
 }
 
-fn data_log_string(data: &[u8], pos: uint) -> String {
+fn data_log_string(data: &[u8], pos: uint, max: uint) -> String {
     let mut buf = String::new();
+    let end = match max {
+        0u => data.len(),
+        x => cmp::min( pos + x, data.len() )
+    };
     buf.push_str("<<");
-    for i in range(pos, data.len()) {
+    for i in range(pos, end) {
         let c = data[i];
         if c > 0x20 && c <= 0x7F {
             buf.push_char(c as char);
         } else {
             buf.push_char('.');
         }
+    }
+    if end < data.len() {
+        buf.push_str(
+            format!( " ({} more bytes)", data.len() - end ).as_slice() 
+        );
     }
     buf.push_str(">>");
     buf
@@ -142,35 +154,35 @@ pub fn parse_ty_closure_data(data: &[u8],
 
 pub fn parse_ty_data(data: &[u8], crate_num: ast::CrateNum, pos: uint, tcx: &ty::ctxt,
                      conv: conv_did) -> ty::t {
-    debug!("parse_ty_data {}", data_log_string(data, pos));
+    debug!("parse_ty_data {}", data_log_string(data, pos, DATA_TRUNCATE));
     let mut st = parse_state_from_data(data, crate_num, pos, tcx);
     parse_ty(&mut st, conv)
 }
 
 pub fn parse_region_data(data: &[u8], crate_num: ast::CrateNum, pos: uint, tcx: &ty::ctxt,
                          conv: conv_did) -> ty::Region {
-    debug!("parse_region_data {}", data_log_string(data, pos));
+    debug!("parse_region_data {}", data_log_string(data, pos, DATA_TRUNCATE));
     let mut st = parse_state_from_data(data, crate_num, pos, tcx);
     parse_region(&mut st, conv)
 }
 
 pub fn parse_bare_fn_ty_data(data: &[u8], crate_num: ast::CrateNum, pos: uint, tcx: &ty::ctxt,
                              conv: conv_did) -> ty::BareFnTy {
-    debug!("parse_bare_fn_ty_data {}", data_log_string(data, pos));
+    debug!("parse_bare_fn_ty_data {}", data_log_string(data, pos, DATA_TRUNCATE));
     let mut st = parse_state_from_data(data, crate_num, pos, tcx);
     parse_bare_fn_ty(&mut st, conv)
 }
 
 pub fn parse_trait_ref_data(data: &[u8], crate_num: ast::CrateNum, pos: uint, tcx: &ty::ctxt,
                             conv: conv_did) -> ty::TraitRef {
-    debug!("parse_trait_ref_data {}", data_log_string(data, pos));
+    debug!("parse_trait_ref_data {}", data_log_string(data, pos, DATA_TRUNCATE));
     let mut st = parse_state_from_data(data, crate_num, pos, tcx);
     parse_trait_ref(&mut st, conv)
 }
 
 pub fn parse_substs_data(data: &[u8], crate_num: ast::CrateNum, pos: uint, tcx: &ty::ctxt,
                          conv: conv_did) -> subst::Substs {
-    debug!("parse_substs_data {}", data_log_string(data, pos));
+    debug!("parse_substs_data {}", data_log_string(data, pos, DATA_TRUNCATE));
     let mut st = parse_state_from_data(data, crate_num, pos, tcx);
     parse_substs(&mut st, conv)
 }

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -513,10 +513,9 @@ fn search_for_vtable(vcx: &VtableContext,
                                           is_early) {
             Some(ref substs) => (*substs).clone(),
             None => {
-                assert!(is_early);
                 // Bail out with a bogus answer
                 return Some(vtable_error);
-            }
+            },
         };
 
         debug!("The fixed-up substs are {} - \
@@ -565,12 +564,16 @@ fn fixup_substs(vcx: &VtableContext,
     let t = ty::mk_trait(tcx,
                          id, substs,
                          ty::region_existential_bound(ty::ReStatic));
-    fixup_ty(vcx, span, t, is_early).map(|t_f| {
-        match ty::get(t_f).sty {
-          ty::ty_trait(ref inner) => inner.substs.clone(),
-          _ => fail!("t_f should be a trait")
-        }
-    })
+    match fixup_ty(vcx, span, t, is_early) {
+        Some( t_f ) => {
+            match ty::get(t_f).sty {
+                ty::ty_trait(ref inner) => Some(inner.substs.clone()),
+                ty::ty_err => None,
+                _ => fail!("t_f should be a trait")
+            }
+        },
+        None => None
+    }
 }
 
 fn fixup_ty(vcx: &VtableContext,

--- a/src/test/compile-fail/issue-16562.rs
+++ b/src/test/compile-fail/issue-16562.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait MatrixShape {}
+
+struct Col<D, C> {
+    data: D,
+    col: C,
+}
+
+// NB The `T` parameter is not necessary (it shouldn't be in the list), but it triggers the ICE
+impl<T, M: MatrixShape> Collection for Col<M, uint> {
+//~^ ERROR: cannot determine a type for this bounded type parameter: unconstrained type
+	fn len(&self) -> uint {
+        unimplemented!()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #16562

Detect ty_err in fixup_substs and return None instead of failing.
In search_for_vtable return vtable_error in both early and non-early
if fixup_substs returns None. This was asserting previously. I don't
know anything about the early vs. non-early stages and whether this
is significant or not.

Reduced the amount of data being printed to the debug log in
tydecode.rs. It was printing several megabytes of metadata.
