### PR TITLE
Prevent failure when using fail! with invalid utf8.

### DIFF
--- a/src/librustrt/unwind.rs
+++ b/src/librustrt/unwind.rs
@@ -61,6 +61,7 @@ use core::prelude::*;
 
 use alloc::boxed::Box;
 use collections::string::String;
+use collections::str::StrAllocating;
 use collections::vec::Vec;
 use core::any::Any;
 use core::atomic;
@@ -525,7 +526,8 @@ pub fn begin_unwind_fmt(msg: &fmt::Arguments, file_line: &(&'static str, uint)) 
     let mut v = Vec::new();
     let _ = write!(&mut VecWriter { v: &mut v }, "{}", msg);
 
-    begin_unwind_inner(box String::from_utf8(v).unwrap(), file_line)
+    let msg = box String::from_utf8_lossy(v.as_slice()).into_string();
+    begin_unwind_inner(msg, file_line)
 }
 
 /// This is the entry point of unwinding for fail!() and assert!().

--- a/src/test/run-fail/fail-non-utf8.rs
+++ b/src/test/run-fail/fail-non-utf8.rs
@@ -1,0 +1,26 @@
+
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Previously failed formating invalid utf8.
+// cc #16877
+
+// error-pattern:failed at 'hello�'
+
+struct Foo;
+impl std::fmt::Show for Foo {
+    fn fmt(&self, fmtr:&mut std::fmt::Formatter) -> std::fmt::Result {
+        // Purge invalid utf8: 0xff
+        fmtr.write(&[104, 101, 108, 108, 111, 0xff])
+    }
+}
+fn main() {
+    fail!("{}", Foo)
+}


### PR DESCRIPTION
Closes #16877.
