### PR TITLE
native: Remove a bogus assert in net::read

### DIFF
--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -959,7 +959,7 @@ pub fn read<T>(fd: sock_t,
             // wait for the socket to become readable again.
             let _guard = lock();
             match retry(|| read(deadline.is_some())) {
-                -1 if util::wouldblock() => { assert!(deadline.is_some()); }
+                -1 if util::wouldblock() => {}
                 -1 => return Err(os::last_error()),
                n => { ret = n; break }
             }


### PR DESCRIPTION
This assert was likely inherited from some point, but it's not quite valid as a
no-timeout read may enter this loop, but data could be stolen by any other read
after the socket is deemed readable.

I saw this fail in a recent bors run where the assertion was tripped.
