### PR TITLE
test: Ignore failing gdb pretty tests

### DIFF
--- a/src/test/debuginfo/gdb-pretty-struct-and-enums-pre-gdb-7-7.rs
+++ b/src/test/debuginfo/gdb-pretty-struct-and-enums-pre-gdb-7-7.rs
@@ -12,6 +12,7 @@
 // older versions of GDB too. A more extensive test can be found in
 // gdb-pretty-struct-and-enums.rs
 
+// ignore-test FIXME(#16919)
 // ignore-tidy-linelength
 // ignore-lldb
 // ignore-android: FIXME(#10381)

--- a/src/test/debuginfo/gdb-pretty-struct-and-enums.rs
+++ b/src/test/debuginfo/gdb-pretty-struct-and-enums.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test FIXME(#16919)
 // ignore-tidy-linelength
 // ignore-lldb
 // ignore-android: FIXME(#10381)


### PR DESCRIPTION
These tests are blocking a linux nightly and a new snapshot, so ignore them for
now. Their tracking issue is #16919.
