### PR TITLE
std: Turn down the stdout chunk size

### DIFF
--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -362,7 +362,14 @@ impl Writer for StdWriter {
         // sizes. For an example, see #14940. For this reason, chunk the output
         // buffer on windows, but on unix we can just write the whole buffer all
         // at once.
-        let max_size = if cfg!(windows) {64 * 1024} else {uint::MAX};
+        //
+        // For some other references, it appears that this problem has been
+        // encountered by others [1] [2]. We choose the number 8KB just because
+        // libuv does the same.
+        //
+        // [1]: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/1232
+        // [2]: http://www.mail-archive.com/log4net-dev@logging.apache.org/msg00661.html
+        let max_size = if cfg!(windows) {8192} else {uint::MAX};
         for chunk in buf.chunks(max_size) {
             try!(match self.inner {
                 TTY(ref mut tty) => tty.write(chunk),


### PR DESCRIPTION
I've found that 64k is still too much and continue to see the errors as reported
in #14940. I've locally found that 32k fails, and 24k succeeds, so I've trimmed
the size down to 10000 which the included links in the added comment end up
recommending.

It sounds like the limit can still be hit with many threads in play, but I have
yet to reproduce this, so I figure we can wait until that's hit (if it's
possible) and then take action.
