### PR TITLE
libtime: Fix adding negative duration to Timespec.

### DIFF
--- a/src/libtime/lib.rs
+++ b/src/libtime/lib.rs
@@ -103,6 +103,9 @@ impl Add<Duration, Timespec> for Timespec {
         if nsec >= NSEC_PER_SEC {
             nsec -= NSEC_PER_SEC;
             sec += 1;
+        } else if nsec < 0 {
+            nsec += NSEC_PER_SEC;
+            sec -= 1;
         }
         Timespec::new(sec, nsec)
     }
@@ -1533,6 +1536,12 @@ mod tests {
         let w = u + v;
         assert_eq!(w.sec, 4);
         assert_eq!(w.nsec, 1);
+
+        let k = Timespec::new(1, 0);
+        let l = Duration::nanoseconds(-1);
+        let m = k + l;
+        assert_eq!(m.sec, 0);
+        assert_eq!(m.nsec, 999_999_999);
     }
 
     fn test_timespec_sub() {


### PR DESCRIPTION
Changing from `Timespec` to `Duration` introduced a bug for negative durations. This fixes that.
