### PR TITLE
Add Mathjax Support to Rustdoc

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -20,6 +20,7 @@ pub struct Layout {
     pub external_html: ExternalHtml,
     pub krate: String,
     pub playground_url: String,
+    pub use_mathjax: bool,
 }
 
 pub struct Page<'a> {
@@ -124,6 +125,7 @@ r##"<!DOCTYPE html>
     <script src="{root_path}main.js"></script>
     {play_js}
     <script async src="{root_path}search-index.js"></script>
+    {mathjax_js}
 </body>
 </html>"##,
     content   = *t,
@@ -155,6 +157,12 @@ r##"<!DOCTYPE html>
         "".to_string()
     } else {
         format!(r#"<script src="{}playpen.js"></script>"#, page.root_path)
+    },
+    mathjax_js = if layout.use_mathjax {
+        r#"<script async src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+        </script>"#.to_string()
+    } else {
+        "".to_string()
     },
     )
 }

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -12,6 +12,7 @@ use std::fmt;
 use std::io;
 
 use externalfiles::ExternalHtml;
+use html::markdown;
 
 #[deriving(Clone)]
 pub struct Layout {
@@ -35,6 +36,10 @@ pub fn render<T: fmt::Show, S: fmt::Show>(
     dst: &mut io::Writer, layout: &Layout, page: &Page, sidebar: &S, t: &T)
     -> io::IoResult<()>
 {
+    // Reset state on whether we've seen math, so as to avoid loading mathjax
+    // on pages that don't actually *have* math.
+    markdown::math_seen.replace(Some(false));
+
     write!(dst,
 r##"<!DOCTYPE html>
 <html lang="en">
@@ -158,7 +163,8 @@ r##"<!DOCTYPE html>
     } else {
         format!(r#"<script src="{}playpen.js"></script>"#, page.root_path)
     },
-    mathjax_js = if layout.use_mathjax {
+    // this must be last so that `math_seen` captures all possible $$'s on this page.
+    mathjax_js = if layout.use_mathjax && markdown::math_seen.get().map_or(false, |x| *x) {
         r#"<script async src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
         </script>"#.to_string()
     } else {

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -110,7 +110,9 @@ struct hoedown_buffer {
     size: libc::size_t,
     asize: libc::size_t,
     unit: libc::size_t,
-    other: [libc::size_t, ..3],
+    data_realloc: *mut Option<extern "C" fn(*mut libc::c_void, libc::size_t)>,
+    data_free: Option<extern "C" fn(*mut libc::c_void)>,
+    buffer_free: Option<extern "C" fn(*mut libc::c_void)>,
 }
 
 // hoedown FFI

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -77,7 +77,7 @@ struct hoedown_renderer {
                                     *mut libc::c_void)>,
     header: Option<extern "C" fn(*mut hoedown_buffer, *const hoedown_buffer,
                                  libc::c_int, *mut libc::c_void)>,
-    other: [libc::size_t, ..28],
+    other: [libc::size_t, ..29],
 }
 
 #[repr(C)]
@@ -110,6 +110,7 @@ struct hoedown_buffer {
     size: libc::size_t,
     asize: libc::size_t,
     unit: libc::size_t,
+    other: [libc::size_t, ..3],
 }
 
 // hoedown FFI

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -65,6 +65,9 @@ static HOEDOWN_EXTENSIONS: libc::c_uint =
     HOEDOWN_EXT_FOOTNOTES;
 
 type hoedown_document = libc::c_void;  // this is opaque to us
+type hoedown_realloc_callback = extern "C" fn(*mut libc::c_void, libc::size_t)
+    -> *mut libc::size_t;
+type hoedown_free_callback = extern "C" fn(*mut libc::c_void);
 
 #[repr(C)]
 struct hoedown_renderer {
@@ -110,9 +113,9 @@ struct hoedown_buffer {
     size: libc::size_t,
     asize: libc::size_t,
     unit: libc::size_t,
-    data_realloc: *mut Option<extern "C" fn(*mut libc::c_void, libc::size_t)>,
-    data_free: Option<extern "C" fn(*mut libc::c_void)>,
-    buffer_free: Option<extern "C" fn(*mut libc::c_void)>,
+    data_realloc: Option<hoedown_realloc_callback>,
+    data_free: Option<hoedown_free_callback>,
+    buffer_free: Option<hoedown_free_callback>,
 }
 
 // hoedown FFI

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -245,10 +245,13 @@ pub fn run(mut krate: clean::Crate, external_html: &ExternalHtml, dst: Path) -> 
             external_html: external_html.clone(),
             krate: krate.name.clone(),
             playground_url: "".to_string(),
+            use_mathjax: false,
         },
         include_sources: true,
         render_redirect_pages: false,
     };
+
+    markdown::use_mathjax.replace(None);
 
     try!(mkdir(&cx.dst));
 
@@ -283,6 +286,11 @@ pub fn run(mut krate: clean::Crate, external_html: &ExternalHtml, dst: Path) -> 
                     clean::Word(ref x)
                             if "html_no_source" == x.as_slice() => {
                         cx.include_sources = false;
+                    }
+                    clean::Word(ref x)
+                            if "enable_mathjax" == x.as_slice() => {
+                        cx.layout.use_mathjax = true;
+                        markdown::use_mathjax.replace(Some(true));
                     }
                     _ => {}
                 }


### PR DESCRIPTION
I'm not _super_ clear on the best way to use TLDs and `#![doc]` configs, but this seems to work, and isn't _obviously_ wrong:

http://cg.scs.carleton.ca/~abeinges/doc/collections/vec/struct.Vec.html

However, the current design interacts weirdly with re-exports:

http://cg.scs.carleton.ca/~abeinges/doc/std/vec/struct.Vec.html

Detailed design:

Mathjax support will only be enabled on crates that declare `#!doc[(enable_mathjax)]`. When enabled mathjax can be used by wrapping math in double-dollars like so: `$$ \sqrt{x} + \log^2n $$`. If the dollars are part of a larger block element, the content will be rendered inline. If they surround an _entire_ block, the math will be rendered in "display mode" as seen in my example pages. Note: the opening  `$$`'s must be lead by whitespace, and the closing `$$`'s must be followed by whitespace. Therefore `blah blah $$x^2$$.` will not render as math, because there is no whitespace between the last `$` and the `.`. 

Closes #16300
Trivializes #15285
