### PR TITLE
Add lifetime bounds on Items and MutItems.

### DIFF
--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -46,12 +46,12 @@ struct AbsEntries<T> {
 }
 
 /// An iterator over a BTreeMap's entries.
-pub struct Entries<'a, K, V> {
+pub struct Entries<'a, K: 'a, V: 'a> {
     inner: AbsEntries<Traversal<'a, K, V>>
 }
 
 /// A mutable iterator over a BTreeMap's entries.
-pub struct MutEntries<'a, K, V> {
+pub struct MutEntries<'a, K: 'a, V: 'a> {
     inner: AbsEntries<MutTraversal<'a, K, V>>
 }
 

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -849,9 +849,9 @@ impl<T> Vec<T> {
             let cap = self.cap;
             let begin = self.ptr as *const T;
             let end = if mem::size_of::<T>() == 0 {
-                (ptr as uint + self.len()) as *const T;
+                (ptr as uint + self.len()) as *const T
             } else {
-                ptr.offset(self.len() as int)
+                ptr.offset(self.len() as int) as *const T
             };
             mem::forget(self);
             MoveItems { allocation: ptr, cap: cap, ptr: begin, end: end }
@@ -1788,7 +1788,7 @@ impl<T> MoveItems<T> {
     pub fn unwrap(mut self) -> Vec<T> {
         unsafe {
             for _x in self { }
-            let MoveItems { allocation, cap, iter: _iter } = self;
+            let MoveItems { allocation, cap, ptr: _ptr, end: _end } = self;
             mem::forget(self);
             Vec { ptr: allocation, cap: cap, len: 0 }
         }
@@ -2569,33 +2569,30 @@ mod tests {
     fn test_move_items() {
         let mut vec = vec!(1i, 2, 3);
         let mut vec2 : Vec<int> = vec!();
-        for i in vec.move_iter() {
+        for i in vec.into_iter() {
             vec2.push(i);
         }
         assert!(vec2 == vec!(1i, 2, 3));
-        assert!(vec.empty());
     }
 
     #[test]
     fn test_move_items_reverse() {
         let mut vec = vec!(1i, 2, 3);
         let mut vec2 : Vec<int> = vec!();
-        for i in vec.move_iter().rev() {
+        for i in vec.into_iter().rev() {
             vec2.push(i);
         }
         assert!(vec2 == vec!(3i, 2, 1));
-        assert!(vec.empty());
     }
 
     #[test]
     fn test_move_items_zero_sized() {
         let mut vec = vec!((), (), ());
         let mut vec2 : Vec<()> = vec!();
-        for i in vec.move_iter() {
+        for i in vec.into_iter() {
             vec2.push(i);
         }
         assert!(vec2 == vec!((), (), ()));
-        assert!(vec.empty());
     }
 
     #[bench]

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -2565,6 +2565,39 @@ mod tests {
         assert_eq!(v.map_in_place(|_| ZeroSized).as_slice(), [ZeroSized, ZeroSized].as_slice());
     }
 
+    #[test]
+    fn test_move_items() {
+        let mut vec = vec!(1i, 2, 3);
+        let mut vec2 : Vec<int> = vec!();
+        for i in vec.move_iter() {
+            vec2.push(i);
+        }
+        assert!(vec2 == vec!(1i, 2, 3));
+        assert!(vec.empty());
+    }
+
+    #[test]
+    fn test_move_items_reverse() {
+        let mut vec = vec!(1i, 2, 3);
+        let mut vec2 : Vec<int> = vec!();
+        for i in vec.move_iter().rev() {
+            vec2.push(i);
+        }
+        assert!(vec2 == vec!(3i, 2, 1));
+        assert!(vec.empty());
+    }
+
+    #[test]
+    fn test_move_items_zero_sized() {
+        let mut vec = vec!((), (), ());
+        let mut vec2 : Vec<()> = vec!();
+        for i in vec.move_iter() {
+            vec2.push(i);
+        }
+        assert!(vec2 == vec!((), (), ()));
+        assert!(vec.empty());
+    }
+
     #[bench]
     fn bench_new(b: &mut Bencher) {
         b.iter(|| {

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -848,7 +848,11 @@ impl<T> Vec<T> {
             let ptr = self.ptr;
             let cap = self.cap;
             let begin = self.ptr as *const T;
-            let end = (self.ptr as uint + self.len()) as *const T;
+            let end = if mem::size_of::<T>() == 0 {
+                (ptr as uint + self.len()) as *const T;
+            } else {
+                ptr.offset(self.len() as int)
+            };
             mem::forget(self);
             MoveItems { allocation: ptr, cap: cap, ptr: begin, end: end }
         }

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1163,7 +1163,7 @@ macro_rules! iterator {
 
 /// Immutable slice iterator
 #[experimental = "needs review"]
-pub struct Items<'a, T> {
+pub struct Items<'a, T: 'a> {
     ptr: *const T,
     end: *const T,
     marker: marker::ContravariantLifetime<'a>
@@ -1206,7 +1206,7 @@ impl<'a, T> RandomAccessIterator<&'a T> for Items<'a, T> {
 
 /// Mutable slice iterator.
 #[experimental = "needs review"]
-pub struct MutItems<'a, T> {
+pub struct MutItems<'a, T: 'a> {
     ptr: *mut T,
     end: *mut T,
     marker: marker::ContravariantLifetime<'a>,


### PR DESCRIPTION
This also required a fix for Vec's MoveItems. This resolves issue #16941
