### PR TITLE
collections/slice: Reexport mut_ref_slice in addition to ref_slice.

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -96,7 +96,7 @@ use vec::Vec;
 pub use core::slice::{Chunks, Slice, ImmutableSlice, ImmutablePartialEqSlice};
 pub use core::slice::{ImmutableOrdSlice, MutableSlice, Items, MutItems};
 pub use core::slice::{MutSplits, MutChunks, Splits};
-pub use core::slice::{bytes, ref_slice, MutableCloneableSlice};
+pub use core::slice::{bytes, mut_ref_slice, ref_slice, MutableCloneableSlice};
 pub use core::slice::{Found, NotFound};
 
 // Functional utilities


### PR DESCRIPTION
`std::slice` exported `ref_slice` but not `mut_ref_slice`. This change makes it export both.
