### PR TITLE
rustdoc/html: emphasize the crate part of the full path.

### DIFF
--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -177,6 +177,8 @@ nav.sub {
     color: #333;
 }
 
+.location a:first-child { font-weight: bold; }
+
 .block {
     padding: 0 10px;
     margin-bottom: 14px;


### PR DESCRIPTION
If you browse to, say, http://doc.rust-lang.org/libc/types/os/common/posix01/struct.timeval.html , you will see the "location" window showing `libc::types::os::common::posix01`.  The first element points to a crate and others point modules.  This patch adds the bold attribute to the first (ie. crate) element so that it stands out more.
