### PR TITLE
Fixes type range issue during linting (#16684)

### DIFF
--- a/src/test/compile-fail/lint-type-overflow.rs
+++ b/src/test/compile-fail/lint-type-overflow.rs
@@ -49,6 +49,7 @@ fn main() {
     let x = -2147483649_i32; //~ error: literal out of range for its type
 
     let x = 9223372036854775808_i64; //~ error: literal out of range for its type
+    let x = -9223372036854775808_i64; // should be OK
     let x = 18446744073709551615_i64; //~ error: literal out of range for its type
 
     let x = -3.40282348e+38_f32; //~ error: literal out of range for its type


### PR DESCRIPTION
- Ensures the propagated negation sign is properly utilized during type checking.
- Combines #16962, Closes #16684.
