### PR TITLE
Fix deprecate warning "extern crate ... as ..."

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4780,7 +4780,7 @@ impl<'a> Parser<'a> {
                     self.span_warn(span,
                             format!("this extern crate syntax is deprecated. \
                             Use: extern crate \"{}\" as {};",
-                            the_ident.as_str(), path.ref0().get() ).as_slice()
+                            path.ref0().get(), the_ident.as_str() ).as_slice()
                     );
                     Some(path)
                 } else {None};


### PR DESCRIPTION
Its arguments were inverted.

For instance it displayed this message:

```
warning: this extern crate syntax is deprecated. Use: extern create "foobar" as foo;
```

Instead of:

```
warning: this extern crate syntax is deprecated. Use: extern create "foo" as foobar;
```
