### PR TITLE
libnative: generic retry() for 64 bit read/write().

### DIFF
--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -11,12 +11,10 @@
 //! Blocking posix-based file I/O
 
 use alloc::arc::Arc;
-use libc::{c_int, c_void};
-use libc;
+use libc::{mod, c_int, c_void};
 use std::c_str::CString;
 use std::mem;
-use std::rt::rtio;
-use std::rt::rtio::IoResult;
+use std::rt::rtio::{mod, IoResult};
 
 use io::{retry, keep_going};
 use io::util;
@@ -55,7 +53,7 @@ impl FileDesc {
         let ret = retry(|| unsafe {
             libc::read(self.fd(),
                        buf.as_mut_ptr() as *mut libc::c_void,
-                       buf.len() as libc::size_t) as libc::c_int
+                       buf.len() as libc::size_t)
         });
         if ret == 0 {
             Err(util::eof())
@@ -93,7 +91,7 @@ impl rtio::RtioFileStream for FileDesc {
         match retry(|| unsafe {
             libc::pread(self.fd(), buf.as_ptr() as *mut _,
                         buf.len() as libc::size_t,
-                        offset as libc::off_t) as libc::c_int
+                        offset as libc::off_t)
         }) {
             -1 => Err(super::last_error()),
             n => Ok(n as int)
@@ -103,7 +101,7 @@ impl rtio::RtioFileStream for FileDesc {
         super::mkerr_libc(retry(|| unsafe {
             libc::pwrite(self.fd(), buf.as_ptr() as *const _,
                          buf.len() as libc::size_t, offset as libc::off_t)
-        } as c_int))
+        }))
     }
     fn seek(&mut self, pos: i64, whence: rtio::SeekStyle) -> IoResult<u64> {
         let whence = match whence {

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -13,8 +13,7 @@ use libc;
 use std::mem;
 use std::ptr;
 use std::rt::mutex;
-use std::rt::rtio;
-use std::rt::rtio::{IoResult, IoError};
+use std::rt::rtio::{mod, IoResult, IoError};
 use std::sync::atomic;
 
 use super::{retry, keep_going};
@@ -988,9 +987,7 @@ pub fn write<T>(fd: sock_t,
                 write(false, inner, len)
             });
         } else {
-            ret = retry(|| {
-                write(false, buf.as_ptr(), buf.len()) as libc::c_int
-            }) as i64;
+            ret = retry(|| { write(false, buf.as_ptr(), buf.len()) });
             if ret > 0 { written = ret as uint; }
         }
     }
@@ -1017,7 +1014,7 @@ pub fn write<T>(fd: sock_t,
             let _guard = lock();
             let ptr = buf.slice_from(written).as_ptr();
             let len = buf.len() - written;
-            match retry(|| write(deadline.is_some(), ptr, len) as libc::c_int) {
+            match retry(|| write(deadline.is_some(), ptr, len)) {
                 -1 if util::wouldblock() => {}
                 -1 => return Err(os::last_error()),
                 n => { written += n as uint; }


### PR DESCRIPTION
The current implementation of `retry()` cannot handle, say, `write()` of >2 GB data because it truncates the return value of the closure parameter into `c_int` which is (almost always) only 32 bit.

This is my first code to use traits... I hope `#[inline]` works as intended.

I think `mkerr_libc()` is still causing bugs here and there;  I'll fix them later.
