### PR TITLE
librustc: Parse and resolve higher-rank lifetimes in traits.

### DIFF
--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -1110,6 +1110,7 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
                     ast::TraitTyParamBound(ast::TraitRef {
                         path: new_path,
                         ref_id: tr.ref_id,
+                        lifetimes: tr.lifetimes.clone(),
                     })
                 }
             }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -223,6 +223,7 @@ pub type TyParamBounds = OwnedSlice<TyParamBound>;
 pub struct UnboxedFnBound {
     pub path: Path,
     pub decl: P<FnDecl>,
+    pub lifetimes: Vec<LifetimeDef>,
     pub ref_id: NodeId,
 }
 
@@ -1219,6 +1220,7 @@ pub struct Attribute_ {
 pub struct TraitRef {
     pub path: Path,
     pub ref_id: NodeId,
+    pub lifetimes: Vec<LifetimeDef>,
 }
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -435,7 +435,8 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     fn trait_ref(&self, path: ast::Path) -> ast::TraitRef {
         ast::TraitRef {
             path: path,
-            ref_id: ast::DUMMY_NODE_ID
+            ref_id: ast::DUMMY_NODE_ID,
+            lifetimes: Vec::new(),
         }
     }
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -668,11 +668,13 @@ pub fn noop_fold_ty_param_bound<T>(tpb: TyParamBound, fld: &mut T)
                 UnboxedFnBound {
                     ref path,
                     ref decl,
+                    ref lifetimes,
                     ref_id
                 } => {
                     UnboxedFnTyParamBound(P(UnboxedFnBound {
                         path: fld.fold_path(path.clone()),
                         decl: fld.fold_fn_decl(decl.clone()),
+                        lifetimes: fld.fold_lifetime_defs(lifetimes.clone()),
                         ref_id: fld.new_id(ref_id),
                     }))
                 }
@@ -808,10 +810,17 @@ pub fn noop_fold_struct_def<T: Folder>(struct_def: P<StructDef>, fld: &mut T) ->
     })
 }
 
-pub fn noop_fold_trait_ref<T: Folder>(TraitRef {ref_id, path}: TraitRef, fld: &mut T) -> TraitRef {
-    TraitRef {
-        ref_id: fld.new_id(ref_id),
+pub fn noop_fold_trait_ref<T: Folder>(p: TraitRef, fld: &mut T) -> TraitRef {
+    let id = fld.new_id(p.ref_id);
+    let TraitRef {
+        path,
+        lifetimes,
+        ..
+    } = p;
+    ast::TraitRef {
         path: fld.fold_path(path),
+        ref_id: id,
+        lifetimes: fld.fold_lifetime_defs(lifetimes),
     }
 }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -900,6 +900,16 @@ impl<'a> State<'a> {
     }
 
     fn print_trait_ref(&mut self, t: &ast::TraitRef) -> IoResult<()> {
+        if t.lifetimes.len() > 0 {
+            try!(self.print_generics(&ast::Generics {
+                lifetimes: t.lifetimes.clone(),
+                ty_params: OwnedSlice::empty(),
+                where_clause: ast::WhereClause {
+                    id: ast::DUMMY_NODE_ID,
+                    predicates: Vec::new(),
+                },
+            }));
+        }
         self.print_path(&t.path, false)
     }
 

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -202,7 +202,9 @@ pub fn walk_explicit_self<'v, V: Visitor<'v>>(visitor: &mut V,
 
 /// Like with walk_method_helper this doesn't correspond to a method
 /// in Visitor, and so it gets a _helper suffix.
-pub fn walk_trait_ref_helper<'v, V: Visitor<'v>>(visitor: &mut V, trait_ref: &'v TraitRef) {
+pub fn walk_trait_ref_helper<'v,V>(visitor: &mut V, trait_ref: &'v TraitRef)
+                                   where V: Visitor<'v> {
+    walk_lifetime_decls(visitor, &trait_ref.lifetimes);
     visitor.visit_path(&trait_ref.path, trait_ref.ref_id)
 }
 
@@ -495,6 +497,7 @@ pub fn walk_ty_param_bounds<'v, V: Visitor<'v>>(visitor: &mut V,
                     visitor.visit_ty(&*argument.ty)
                 }
                 visitor.visit_ty(&*function_declaration.decl.output);
+                walk_lifetime_decls(visitor, &function_declaration.lifetimes);
             }
             RegionTyParamBound(ref lifetime) => {
                 visitor.visit_lifetime_ref(lifetime);

--- a/src/test/compile-fail/regions-name-duplicated.rs
+++ b/src/test/compile-fail/regions-name-duplicated.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 struct Foo<'a, 'a> { //~ ERROR lifetime name `'a` declared twice
+//~^ ERROR lifetime name `'a` declared twice
     x: &'a int
 }
 

--- a/src/test/compile-fail/regions-name-static.rs
+++ b/src/test/compile-fail/regions-name-static.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 struct Foo<'static> { //~ ERROR illegal lifetime parameter name: `'static`
+//~^ ERROR illegal lifetime parameter name: `'static`
     x: &'static int
 }
 


### PR DESCRIPTION
They will ICE during typechecking if used, because they depend on trait
reform.

This is part of unboxed closures.

r? @nikomatsakis 
