### PR TITLE
collections: Stabilize Vec

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -3833,8 +3833,9 @@ fn map<A: Clone, B: Clone>(f: |A| -> B, xs: &[A]) -> Vec<B> {
        return vec![];
     }
     let first: B = f(xs[0].clone());
-    let rest: Vec<B> = map(f, xs.slice(1, xs.len()));
-    return vec![first].append(rest.as_slice());
+    let mut rest: Vec<B> = map(f, xs.slice(1, xs.len()));
+    rest.insert(0, first);
+    return rest;
 }
 ~~~~
 

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -631,7 +631,7 @@ impl Bitv {
         let old_size = self.storage.len();
         let size = (size + uint::BITS - 1) / uint::BITS;
         if old_size < size {
-            self.storage.grow(size - old_size, &0);
+            self.storage.grow(size - old_size, 0);
         }
     }
 
@@ -687,7 +687,7 @@ impl Bitv {
         // Allocate new words, if needed
         if new_nwords > self.storage.len() {
           let to_add = new_nwords - self.storage.len();
-          self.storage.grow(to_add, &full_value);
+          self.storage.grow(to_add, full_value);
         }
         // Adjust internal bit count
         self.nbits = new_nbits;

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -283,7 +283,11 @@ pub trait CloneableVector<T> {
 impl<'a, T: Clone> CloneableVector<T> for &'a [T] {
     /// Returns a copy of `v`.
     #[inline]
-    fn to_vec(&self) -> Vec<T> { Vec::from_slice(*self) }
+    fn to_vec(&self) -> Vec<T> {
+        let mut vector = Vec::with_capacity(self.len());
+        vector.push_all(*self);
+        vector
+    }
 
     #[inline(always)]
     fn into_vec(self) -> Vec<T> { self.to_vec() }
@@ -1039,7 +1043,7 @@ mod tests {
     fn test_grow() {
         // Test on-stack grow().
         let mut v = vec![];
-        v.grow(2u, &1i);
+        v.grow(2u, 1i);
         {
             let v = v.as_slice();
             assert_eq!(v.len(), 2u);
@@ -1048,7 +1052,7 @@ mod tests {
         }
 
         // Test on-heap grow().
-        v.grow(3u, &2i);
+        v.grow(3u, 2i);
         {
             let v = v.as_slice();
             assert_eq!(v.len(), 5u);

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -67,6 +67,7 @@ use core::prelude::{range};
 use {Deque, MutableSeq};
 use hash;
 use ringbuf::RingBuf;
+use slice::CloneableVector;
 use string::String;
 use unicode;
 use vec::Vec;
@@ -754,7 +755,7 @@ pub trait StrAllocating: Str {
     #[inline]
     fn to_owned(&self) -> String {
         unsafe {
-            mem::transmute(Vec::from_slice(self.as_slice().as_bytes()))
+            mem::transmute(self.as_slice().as_bytes().to_vec())
         }
     }
 

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -23,6 +23,7 @@ use core::raw::Slice as RawSlice;
 
 use {Mutable, MutableSeq};
 use hash;
+use slice::CloneableVector;
 use str;
 use str::{CharRange, StrAllocating, MaybeOwned, Owned};
 use str::Slice as MaybeOwnedSlice; // So many `Slice`s...
@@ -75,9 +76,7 @@ impl String {
     /// ```
     #[inline]
     pub fn from_str(string: &str) -> String {
-        String {
-            vec: Vec::from_slice(string.as_bytes())
-        }
+        String { vec: string.as_bytes().to_vec() }
     }
 
     /// Deprecated. Replaced by `string::raw::from_parts`

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -273,16 +273,7 @@ impl<T> Vec<T> {
 }
 
 impl<T: Clone> Vec<T> {
-    /// Iterates over the `second` vector, copying each element and appending it to
-    /// the `first`. Afterwards, the `first` is then returned for use again.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// let vec = vec![1i, 2i];
-    /// let vec = vec.append([3i, 4i]);
-    /// assert_eq!(vec, vec![1, 2, 3, 4]);
-    /// ```
+    /// Deprecated, call `extend` instead.
     #[inline]
     #[deprecated = "this function has been deprecated in favor of extend()"]
     pub fn append(mut self, second: &[T]) -> Vec<T> {
@@ -290,21 +281,10 @@ impl<T: Clone> Vec<T> {
         self
     }
 
-    /// Constructs a `Vec` by cloning elements of a slice.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// let slice = [1i, 2, 3];
-    /// let vec = Vec::from_slice(slice);
-    /// ```
+    /// Deprecated, call `to_vec()` instead
     #[inline]
     #[deprecated = "this function has been deprecated in favor of to_vec()"]
-    pub fn from_slice(values: &[T]) -> Vec<T> {
-        let mut vector = Vec::new();
-        vector.push_all(values);
-        vector
-    }
+    pub fn from_slice(values: &[T]) -> Vec<T> { values.to_vec() }
 
     /// Constructs a `Vec` with copies of a value.
     ///
@@ -442,9 +422,7 @@ impl<T: Clone> Vec<T> {
 
 #[unstable]
 impl<T:Clone> Clone for Vec<T> {
-    fn clone(&self) -> Vec<T> {
-        Vec::from_slice(self.as_slice())
-    }
+    fn clone(&self) -> Vec<T> { self.as_slice().to_vec() }
 
     fn clone_from(&mut self, other: &Vec<T>) {
         // drop anything in self that will not be overwritten
@@ -736,16 +714,7 @@ impl<T> Vec<T> {
         }
     }
 
-    /// Appends one element to the vector provided. The vector itself is then
-    /// returned for use again.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// let vec = vec![1i, 2];
-    /// let vec = vec.append_one(3);
-    /// assert_eq!(vec, vec![1, 2, 3]);
-    /// ```
+    /// Deprecated, call `push` instead
     #[inline]
     #[deprecated = "call .push() instead"]
     pub fn append_one(mut self, x: T) -> Vec<T> {
@@ -765,7 +734,7 @@ impl<T> Vec<T> {
     /// vec.truncate(2);
     /// assert_eq!(vec, vec![1, 2]);
     /// ```
-    #[stable]
+    #[unstable = "waiting on failure semantics"]
     pub fn truncate(&mut self, len: uint) {
         unsafe {
             // drop any extra elements
@@ -1123,7 +1092,7 @@ impl<T> Vec<T> {
     /// vec.insert(4, 5);
     /// assert_eq!(vec, vec![1, 4, 2, 3, 5]);
     /// ```
-    #[stable]
+    #[unstable = "failure semantics need settling"]
     pub fn insert(&mut self, index: uint, element: T) {
         let len = self.len();
         assert!(index <= len);
@@ -1160,7 +1129,7 @@ impl<T> Vec<T> {
     /// // v is unchanged:
     /// assert_eq!(v, vec![1, 3]);
     /// ```
-    #[stable]
+    #[unstable = "failure semantics need settling"]
     pub fn remove(&mut self, index: uint) -> Option<T> {
         let len = self.len();
         if index < len {
@@ -1192,11 +1161,13 @@ impl<T> Vec<T> {
     /// # Example
     ///
     /// ```
+    /// # #![allow(deprecated)]
     /// let mut vec = vec![box 1i];
     /// vec.push_all_move(vec![box 2, box 3, box 4]);
     /// assert_eq!(vec, vec![box 1, box 2, box 3, box 4]);
     /// ```
     #[inline]
+    #[deprecated = "use .extend(other.into_iter())"]
     pub fn push_all_move(&mut self, other: Vec<T>) {
         self.extend(other.into_iter());
     }

--- a/src/libgraphviz/maybe_owned_vec.rs
+++ b/src/libgraphviz/maybe_owned_vec.rs
@@ -170,7 +170,7 @@ impl<'a,T:Clone> MaybeOwnedVector<'a,T> {
     pub fn into_vec(self) -> Vec<T> {
         match self {
             Growable(v) => v,
-            Borrowed(v) => Vec::from_slice(v),
+            Borrowed(v) => v.to_vec(),
         }
     }
 }

--- a/src/librbml/io.rs
+++ b/src/librbml/io.rs
@@ -87,7 +87,7 @@ impl Writer for SeekableMemWriter {
             // currently are
             let difference = self.pos as i64 - self.buf.len() as i64;
             if difference > 0 {
-                self.buf.grow(difference as uint, &0);
+                self.buf.grow(difference as uint, 0);
             }
 
             // Figure out what bytes will be used to overwrite what's currently

--- a/src/libregex/compile.rs
+++ b/src/libregex/compile.rs
@@ -156,7 +156,7 @@ impl<'r> Compiler<'r> {
             Capture(cap, name, x) => {
                 let len = self.names.len();
                 if cap >= len {
-                    self.names.grow(10 + cap - len, &None)
+                    self.names.grow(10 + cap - len, None)
                 }
                 *self.names.get_mut(cap) = name;
 

--- a/src/libregex/parse.rs
+++ b/src/libregex/parse.rs
@@ -986,9 +986,9 @@ fn combine_ranges(unordered: Vec<(char, char)>) -> Vec<(char, char)> {
 // (or any of their negated forms). Note that this does not handle negation.
 fn perl_unicode_class(which: char) -> Vec<(char, char)> {
     match which.to_lowercase() {
-        'd' => Vec::from_slice(PERLD),
-        's' => Vec::from_slice(PERLS),
-        'w' => Vec::from_slice(PERLW),
+        'd' => PERLD.to_vec(),
+        's' => PERLS.to_vec(),
+        'w' => PERLW.to_vec(),
         _ => unreachable!(),
     }
 }
@@ -997,7 +997,7 @@ fn perl_unicode_class(which: char) -> Vec<(char, char)> {
 // `Cat` expression will never be a direct child of another `Cat` expression.
 fn concat_flatten(x: Ast, y: Ast) -> Ast {
     match (x, y) {
-        (Cat(mut xs), Cat(ys)) => { xs.push_all_move(ys); Cat(xs) }
+        (Cat(mut xs), Cat(ys)) => { xs.extend(ys.into_iter()); Cat(xs) }
         (Cat(mut xs), ast) => { xs.push(ast); Cat(xs) }
         (ast, Cat(mut xs)) => { xs.insert(0, ast); Cat(xs) }
         (ast1, ast2) => Cat(vec!(ast1, ast2)),
@@ -1019,7 +1019,7 @@ fn is_valid_cap(c: char) -> bool {
 
 fn find_class(classes: NamedClasses, name: &str) -> Option<Vec<(char, char)>> {
     match classes.binary_search(|&(s, _)| s.cmp(&name)) {
-        slice::Found(i) => Some(Vec::from_slice(classes[i].val1())),
+        slice::Found(i) => Some(classes[i].val1().to_vec()),
         slice::NotFound(_) => None,
     }
 }

--- a/src/libregex_macros/lib.rs
+++ b/src/libregex_macros/lib.rs
@@ -133,7 +133,7 @@ impl<'a> NfaGen<'a> {
         let init_groups = self.vec_expr(range(0, num_cap_locs),
                                         |cx, _| cx.expr_none(self.sp));
 
-        let prefix_lit = Rc::new(Vec::from_slice(self.prog.prefix.as_slice().as_bytes()));
+        let prefix_lit = Rc::new(self.prog.prefix.as_slice().as_bytes().to_vec());
         let prefix_bytes = self.cx.expr_lit(self.sp, ast::LitBinary(prefix_lit));
 
         let check_prefix = self.check_prefix();

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -505,7 +505,7 @@ fn external_path(cx: &DocContext, name: &str, substs: &subst::Substs) -> Path {
                     .iter()
                     .filter_map(|v| v.clean(cx))
                     .collect();
-    let types = Vec::from_slice(substs.types.get_slice(subst::TypeSpace));
+    let types = substs.types.get_slice(subst::TypeSpace).to_vec();
     let types = types.clean(cx);
     Path {
         global: false,
@@ -661,8 +661,8 @@ impl<'a> Clean<Generics> for (&'a ty::Generics, subst::ParamSpace) {
     fn clean(&self, cx: &DocContext) -> Generics {
         let (me, space) = *self;
         Generics {
-            type_params: Vec::from_slice(me.types.get_slice(space)).clean(cx),
-            lifetimes: Vec::from_slice(me.regions.get_slice(space)).clean(cx),
+            type_params: me.types.get_slice(space).to_vec().clean(cx),
+            lifetimes: me.regions.get_slice(space).to_vec().clean(cx),
         }
     }
 }
@@ -991,7 +991,7 @@ impl Clean<Item> for ty::Method {
                                                self.fty.sig.clone()),
             s => {
                 let sig = ty::FnSig {
-                    inputs: Vec::from_slice(self.fty.sig.inputs.slice_from(1)),
+                    inputs: self.fty.sig.inputs.slice_from(1).to_vec(),
                     ..self.fty.sig.clone()
                 };
                 let s = match s {

--- a/src/librustdoc/flock.rs
+++ b/src/librustdoc/flock.rs
@@ -183,8 +183,8 @@ mod imp {
 
     impl Lock {
         pub fn new(p: &Path) -> Lock {
-            let p_16: Vec<u16> = p.as_str().unwrap().utf16_units().collect();
-            let p_16 = p_16.append_one(0);
+            let mut p_16: Vec<u16> = p.as_str().unwrap().utf16_units().collect();
+            p_16.push(0);
             let handle = unsafe {
                 libc::CreateFileW(p_16.as_ptr(),
                                   libc::FILE_GENERIC_READ |

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -740,8 +740,9 @@ impl<'a> SourceCollector<'a> {
             root_path.push_str("../");
         });
 
-        cur.push(Vec::from_slice(p.filename().expect("source has no filename"))
-                 .append(b".html"));
+        let mut fname = p.filename().expect("source has no filename").to_vec();
+        fname.extend(".html".bytes());
+        cur.push(fname);
         let mut w = BufferedWriter::new(try!(File::create(&cur)));
 
         let title = format!("{} -- source", cur.filename_display());

--- a/src/librustrt/args.rs
+++ b/src/librustrt/args.rs
@@ -47,6 +47,7 @@ mod imp {
     use core::prelude::*;
 
     use alloc::boxed::Box;
+    use collections::slice::CloneableVector;
     use collections::vec::Vec;
     use core::mem;
     use core::slice;
@@ -106,7 +107,7 @@ mod imp {
             let mut len = 0;
             while *base.offset(len) != 0 { len += 1; }
             slice::raw::buf_as_slice(base, len as uint, |slice| {
-                Vec::from_slice(slice)
+                slice.to_vec()
             })
         })
     }

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -655,7 +655,7 @@ impl rtio::RtioUdpSocket for UdpWatcher {
 
         // see comments in StreamWatcher::write for why we may allocate a buffer
         // here.
-        let data = if guard.can_timeout {Some(Vec::from_slice(buf))} else {None};
+        let data = if guard.can_timeout {Some(buf.to_vec())} else {None};
         let uv_buf = if guard.can_timeout {
             slice_to_uv_buf(data.as_ref().unwrap().as_slice())
         } else {

--- a/src/librustuv/stream.rs
+++ b/src/librustuv/stream.rs
@@ -159,7 +159,7 @@ impl StreamWatcher {
         //
         // To do this, the write context has an optionally owned vector of
         // bytes.
-        let data = if may_timeout {Some(Vec::from_slice(buf))} else {None};
+        let data = if may_timeout {Some(buf.to_vec())} else {None};
         let uv_buf = if may_timeout {
             slice_to_uv_buf(data.as_ref().unwrap().as_slice())
         } else {

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -21,8 +21,7 @@ use mem;
 use option::{Option, Some, None};
 use slice::{ImmutableSlice, MutableSlice, Slice};
 use str::{Str, StrSlice};
-use str;
-use string::String;
+use string::{mod, String};
 use to_string::IntoStr;
 use vec::Vec;
 
@@ -113,7 +112,7 @@ impl Ascii {
     /// Check if the character is a letter or number
     #[inline]
     pub fn is_alphanumeric(&self) -> bool {
-        self.is_alpha() || self.is_digit()
+        self.is_alphabetic() || self.is_digit()
     }
 
     /// Check if the character is a space or horizontal tab
@@ -169,7 +168,7 @@ impl Ascii {
     /// Checks if the character is punctuation
     #[inline]
     pub fn is_punctuation(&self) -> bool {
-        self.is_graph() && !self.is_alnum()
+        self.is_graph() && !self.is_alphanumeric()
     }
 
     /// Checks if the character is a valid hex digit
@@ -338,12 +337,12 @@ impl<'a> AsciiStr for &'a [Ascii] {
 
     #[inline]
     fn to_lower(&self) -> Vec<Ascii> {
-        self.iter().map(|a| a.to_lower()).collect()
+        self.iter().map(|a| a.to_lowercase()).collect()
     }
 
     #[inline]
     fn to_upper(&self) -> Vec<Ascii> {
-        self.iter().map(|a| a.to_upper()).collect()
+        self.iter().map(|a| a.to_uppercase()).collect()
     }
 
     #[inline]
@@ -410,13 +409,13 @@ impl<'a> AsciiExt<String> for &'a str {
     #[inline]
     fn to_ascii_upper(&self) -> String {
         // Vec<u8>::to_ascii_upper() preserves the UTF-8 invariant.
-        unsafe { str::raw::from_utf8_owned(self.as_bytes().to_ascii_upper()) }
+        unsafe { string::raw::from_utf8(self.as_bytes().to_ascii_upper()) }
     }
 
     #[inline]
     fn to_ascii_lower(&self) -> String {
         // Vec<u8>::to_ascii_lower() preserves the UTF-8 invariant.
-        unsafe { str::raw::from_utf8_owned(self.as_bytes().to_ascii_lower()) }
+        unsafe { string::raw::from_utf8(self.as_bytes().to_ascii_lower()) }
     }
 
     #[inline]
@@ -429,13 +428,13 @@ impl OwnedAsciiExt for String {
     #[inline]
     fn into_ascii_upper(self) -> String {
         // Vec<u8>::into_ascii_upper() preserves the UTF-8 invariant.
-        unsafe { str::raw::from_utf8_owned(self.into_bytes().into_ascii_upper()) }
+        unsafe { string::raw::from_utf8(self.into_bytes().into_ascii_upper()) }
     }
 
     #[inline]
     fn into_ascii_lower(self) -> String {
         // Vec<u8>::into_ascii_lower() preserves the UTF-8 invariant.
-        unsafe { str::raw::from_utf8_owned(self.into_bytes().into_ascii_lower()) }
+        unsafe { string::raw::from_utf8(self.into_bytes().into_ascii_lower()) }
     }
 }
 

--- a/src/libstd/collections/hashmap/map.rs
+++ b/src/libstd/collections/hashmap/map.rs
@@ -1288,7 +1288,7 @@ impl<K: Eq + Hash<S>, V: Clone, S, H: Hasher<S>> HashMap<K, V, H> {
     /// let s: String = map.get_copy(&1);
     /// ```
     pub fn get_copy(&self, k: &K) -> V {
-        (*self.get(k)).clone()
+        self[*k].clone()
     }
 }
 
@@ -1325,6 +1325,7 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S> + Default> Default for HashMap<K, V, H>
 
 impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> Index<K, V> for HashMap<K, V, H> {
     #[inline]
+    #[allow(deprecated)]
     fn index<'a>(&'a self, index: &K) -> &'a V {
         self.get(index)
     }

--- a/src/libstd/collections/hashmap/table.rs
+++ b/src/libstd/collections/hashmap/table.rs
@@ -846,8 +846,8 @@ impl<K: Clone, V: Clone> Clone for RawTable<K, V> {
                                 (full.hash(), k.clone(), v.clone())
                             };
                             *new_buckets.raw.hash = h.inspect();
-                            mem::overwrite(new_buckets.raw.key, k);
-                            mem::overwrite(new_buckets.raw.val, v);
+                            ptr::write(new_buckets.raw.key, k);
+                            ptr::write(new_buckets.raw.val, v);
                         }
                         Empty(..) => {
                             *new_buckets.raw.hash = EMPTY_BUCKET;

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -281,6 +281,7 @@ pub mod dl {
 #[cfg(target_os = "windows")]
 pub mod dl {
     use c_str::ToCStr;
+    use collections::MutableSeq;
     use iter::Iterator;
     use libc;
     use os;
@@ -295,8 +296,8 @@ pub mod dl {
         // Windows expects Unicode data
         let filename_cstr = filename.to_c_str();
         let filename_str = str::from_utf8(filename_cstr.as_bytes_no_nul()).unwrap();
-        let filename_str: Vec<u16> = filename_str.utf16_units().collect();
-        let filename_str = filename_str.append_one(0);
+        let mut filename_str: Vec<u16> = filename_str.utf16_units().collect();
+        filename_str.push(0);
         LoadLibraryW(filename_str.as_ptr() as *const libc::c_void) as *mut u8
     }
 

--- a/src/libstd/failure.rs
+++ b/src/libstd/failure.rs
@@ -38,9 +38,9 @@ impl Writer for Stdio {
 }
 
 pub fn on_fail(obj: &Any + Send, file: &'static str, line: uint) {
-    let msg = match obj.as_ref::<&'static str>() {
+    let msg = match obj.downcast_ref::<&'static str>() {
         Some(s) => *s,
-        None => match obj.as_ref::<String>() {
+        None => match obj.downcast_ref::<String>() {
             Some(s) => s.as_slice(),
             None => "Box<Any>",
         }

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -162,7 +162,7 @@ impl<W: Writer> BufferedWriter<W> {
 
     fn flush_buf(&mut self) -> IoResult<()> {
         if self.pos != 0 {
-            let ret = self.inner.get_mut_ref().write(self.buf.slice_to(self.pos));
+            let ret = self.inner.as_mut().unwrap().write(self.buf.slice_to(self.pos));
             self.pos = 0;
             ret
         } else {
@@ -174,7 +174,7 @@ impl<W: Writer> BufferedWriter<W> {
     ///
     /// This type does not expose the ability to get a mutable reference to the
     /// underlying reader because that could possibly corrupt the buffer.
-    pub fn get_ref<'a>(&'a self) -> &'a W { self.inner.get_ref() }
+    pub fn get_ref<'a>(&'a self) -> &'a W { self.inner.as_ref().unwrap() }
 
     /// Unwraps this `BufferedWriter`, returning the underlying writer.
     ///
@@ -193,7 +193,7 @@ impl<W: Writer> Writer for BufferedWriter<W> {
         }
 
         if buf.len() > self.buf.len() {
-            self.inner.get_mut_ref().write(buf)
+            self.inner.as_mut().unwrap().write(buf)
         } else {
             let dst = self.buf.slice_from_mut(self.pos);
             slice::bytes::copy_memory(dst, buf);
@@ -203,7 +203,7 @@ impl<W: Writer> Writer for BufferedWriter<W> {
     }
 
     fn flush(&mut self) -> IoResult<()> {
-        self.flush_buf().and_then(|()| self.inner.get_mut_ref().flush())
+        self.flush_buf().and_then(|()| self.inner.as_mut().unwrap().flush())
     }
 }
 
@@ -273,7 +273,7 @@ impl<W> InternalBufferedWriter<W> {
 
 impl<W: Reader> Reader for InternalBufferedWriter<W> {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
-        self.get_mut().inner.get_mut_ref().read(buf)
+        self.get_mut().inner.as_mut().unwrap().read(buf)
     }
 }
 

--- a/src/libstd/io/comm_adapters.rs
+++ b/src/libstd/io/comm_adapters.rs
@@ -15,7 +15,7 @@ use comm::{Sender, Receiver};
 use io;
 use option::{None, Option, Some};
 use result::{Ok, Err};
-use slice::{bytes, MutableSlice, ImmutableSlice};
+use slice::{bytes, MutableSlice, ImmutableSlice, CloneableVector};
 use str::StrSlice;
 use super::{Reader, Writer, IoResult};
 use vec::Vec;
@@ -118,7 +118,7 @@ impl Clone for ChanWriter {
 
 impl Writer for ChanWriter {
     fn write(&mut self, buf: &[u8]) -> IoResult<()> {
-        self.tx.send_opt(Vec::from_slice(buf)).map_err(|_| {
+        self.tx.send_opt(buf.to_vec()).map_err(|_| {
             io::IoError {
                 kind: io::BrokenPipe,
                 desc: "Pipe closed",

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -61,7 +61,7 @@ use io::{IoResult, IoError, FileStat, SeekStyle, Seek, Writer, Reader};
 use io::{Read, Truncate, SeekCur, SeekSet, ReadWrite, SeekEnd, Append};
 use io::UpdateIoError;
 use io;
-use iter::Iterator;
+use iter::{Iterator, Extendable};
 use kinds::Send;
 use libc;
 use option::{Some, None, Option};
@@ -688,7 +688,7 @@ impl Iterator<Path> for Directories {
                                                 e, path.display()));
 
                     match result {
-                        Ok(dirs) => { self.stack.push_all_move(dirs); }
+                        Ok(dirs) => { self.stack.extend(dirs.into_iter()); }
                         Err(..) => {}
                     }
                 }

--- a/src/libstd/io/tempfile.rs
+++ b/src/libstd/io/tempfile.rs
@@ -79,7 +79,7 @@ impl TempDir {
 
     /// Access the wrapped `std::path::Path` to the temporary directory.
     pub fn path<'a>(&'a self) -> &'a Path {
-        self.path.get_ref()
+        self.path.as_ref().unwrap()
     }
 
     /// Close and remove the temporary directory

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -112,7 +112,6 @@
 // Don't link to std. We are std.
 #![no_std]
 
-#![allow(deprecated)]
 #![deny(missing_doc)]
 
 #![reexport_test_harness_main = "test_main"]

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -276,17 +276,18 @@ pub fn env_as_bytes() -> Vec<(Vec<u8>,Vec<u8>)> {
             extern {
                 fn rust_env_pairs() -> *const *const c_char;
             }
-            let environ = rust_env_pairs();
+            let mut environ = rust_env_pairs();
             if environ as uint == 0 {
                 fail!("os::env() failure getting env string from OS: {}",
                        os::last_os_error());
             }
             let mut result = Vec::new();
-            ptr::array_each(environ, |e| {
+            while *environ != 0 as *const _ {
                 let env_pair =
-                    Vec::from_slice(CString::new(e, false).as_bytes_no_nul());
+                    Vec::from_slice(CString::new(*environ, false).as_bytes_no_nul());
                 result.push(env_pair);
-            });
+                environ = environ.offset(1);
+            }
             result
         }
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -46,15 +46,14 @@ use ptr::RawPtr;
 use ptr;
 use result::{Err, Ok, Result};
 use slice::{Slice, ImmutableSlice, MutableSlice, ImmutablePartialEqSlice};
+use slice::CloneableVector;
 use str::{Str, StrSlice, StrAllocating};
 use string::String;
 use sync::atomic::{AtomicInt, INIT_ATOMIC_INT, SeqCst};
 use vec::Vec;
 
-#[cfg(unix)]
-use c_str::ToCStr;
-#[cfg(unix)]
-use libc::c_char;
+#[cfg(unix)] use c_str::ToCStr;
+#[cfg(unix)] use libc::c_char;
 
 /// Get the number of cores available
 pub fn num_cpus() -> uint {
@@ -260,8 +259,11 @@ pub fn env_as_bytes() -> Vec<(Vec<u8>,Vec<u8>)> {
             let mut i = 0;
             while *ch.offset(i) != 0 {
                 let p = &*ch.offset(i);
-                let len = ptr::position(p, |c| *c == 0);
-                raw::buf_as_slice(p, len, |s| {
+                let mut len = 0;
+                while *(p as *const _).offset(len) != 0 {
+                    len += 1;
+                }
+                raw::buf_as_slice(p, len as uint, |s| {
                     result.push(String::from_utf16_lossy(s).into_bytes());
                 });
                 i += len as int + 1;
@@ -284,7 +286,7 @@ pub fn env_as_bytes() -> Vec<(Vec<u8>,Vec<u8>)> {
             let mut result = Vec::new();
             while *environ != 0 as *const _ {
                 let env_pair =
-                    Vec::from_slice(CString::new(*environ, false).as_bytes_no_nul());
+                    CString::new(*environ, false).as_bytes_no_nul().to_vec();
                 result.push(env_pair);
                 environ = environ.offset(1);
             }
@@ -295,9 +297,9 @@ pub fn env_as_bytes() -> Vec<(Vec<u8>,Vec<u8>)> {
             let mut pairs = Vec::new();
             for p in input.iter() {
                 let mut it = p.as_slice().splitn(1, |b| *b == b'=');
-                let key = Vec::from_slice(it.next().unwrap());
+                let key = it.next().unwrap().to_vec();
                 let default: &[u8] = &[];
-                let val = Vec::from_slice(it.next().unwrap_or(default));
+                let val = it.next().unwrap_or(default).to_vec();
                 pairs.push((key, val));
             }
             pairs
@@ -351,8 +353,7 @@ pub fn getenv_as_bytes(n: &str) -> Option<Vec<u8>> {
             if s.is_null() {
                 None
             } else {
-                Some(Vec::from_slice(CString::new(s as *const i8,
-                                                  false).as_bytes_no_nul()))
+                Some(CString::new(s as *const i8, false).as_bytes_no_nul().to_vec())
             }
         })
     }
@@ -365,8 +366,8 @@ pub fn getenv(n: &str) -> Option<String> {
     unsafe {
         with_env_lock(|| {
             use os::windows::{fill_utf16_buf_and_decode};
-            let n: Vec<u16> = n.utf16_units().collect();
-            let n = n.append_one(0);
+            let mut n: Vec<u16> = n.utf16_units().collect();
+            n.push(0);
             fill_utf16_buf_and_decode(|buf, sz| {
                 libc::GetEnvironmentVariableW(n.as_ptr(), buf, sz)
             })
@@ -412,10 +413,10 @@ pub fn setenv<T: BytesContainer>(n: &str, v: T) {
 
     #[cfg(windows)]
     fn _setenv(n: &str, v: &[u8]) {
-        let n: Vec<u16> = n.utf16_units().collect();
-        let n = n.append_one(0);
-        let v: Vec<u16> = ::str::from_utf8(v).unwrap().utf16_units().collect();
-        let v = v.append_one(0);
+        let mut n: Vec<u16> = n.utf16_units().collect();
+        n.push(0);
+        let mut v: Vec<u16> = ::str::from_utf8(v).unwrap().utf16_units().collect();
+        v.push(0);
 
         unsafe {
             with_env_lock(|| {
@@ -442,8 +443,8 @@ pub fn unsetenv(n: &str) {
 
     #[cfg(windows)]
     fn _unsetenv(n: &str) {
-        let n: Vec<u16> = n.utf16_units().collect();
-        let n = n.append_one(0);
+        let mut n: Vec<u16> = n.utf16_units().collect();
+        n.push(0);
         unsafe {
             with_env_lock(|| {
                 libc::SetEnvironmentVariableW(n.as_ptr(), ptr::null());
@@ -883,7 +884,11 @@ pub fn change_dir(p: &Path) -> bool {
     #[cfg(windows)]
     fn chdir(p: &Path) -> bool {
         let p = match p.as_str() {
-            Some(s) => s.utf16_units().collect::<Vec<u16>>().append_one(0),
+            Some(s) => {
+                let mut p = s.utf16_units().collect::<Vec<u16>>();
+                p.push(0);
+                p
+            }
             None => return false,
         };
         unsafe {
@@ -1100,8 +1105,7 @@ unsafe fn load_argc_and_argv(argc: int,
     use c_str::CString;
 
     Vec::from_fn(argc as uint, |i| {
-        Vec::from_slice(CString::new(*argv.offset(i as int),
-                                     false).as_bytes_no_nul())
+        CString::new(*argv.offset(i as int), false).as_bytes_no_nul().to_vec()
     })
 }
 
@@ -1170,7 +1174,7 @@ fn real_args_as_bytes() -> Vec<Vec<u8>> {
                 mem::transmute(objc_msgSend(tmp, utf8Sel));
             let s = CString::new(utf_c_str, false);
             if s.is_not_null() {
-                res.push(Vec::from_slice(s.as_bytes_no_nul()))
+                res.push(s.as_bytes_no_nul().to_vec())
             }
         }
     }

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -76,7 +76,7 @@ use option::{Option, None, Some};
 use str;
 use str::{MaybeOwned, Str, StrSlice};
 use string::String;
-use slice::Slice;
+use slice::{Slice, CloneableVector};
 use slice::{ImmutablePartialEqSlice, ImmutableSlice};
 use vec::Vec;
 
@@ -480,7 +480,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
             let extlen = extension.container_as_bytes().len();
             match (name.rposition_elem(&dot), extlen) {
                 (None, 0) | (Some(0), 0) => None,
-                (Some(idx), 0) => Some(Vec::from_slice(name.slice_to(idx))),
+                (Some(idx), 0) => Some(name.slice_to(idx).to_vec()),
                 (idx, extlen) => {
                     let idx = match idx {
                         None | Some(0) => name.len(),
@@ -798,7 +798,7 @@ pub trait BytesContainer {
     /// Consumes the receiver and converts it into Vec<u8>
     #[inline]
     fn container_into_owned_bytes(self) -> Vec<u8> {
-        Vec::from_slice(self.container_as_bytes())
+        self.container_as_bytes().to_vec()
     }
     /// Returns the receiver interpreted as a utf-8 string, if possible
     #[inline]

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -399,7 +399,7 @@ impl Path {
             }
         };
         match val {
-            None => Vec::from_slice(v.as_slice()),
+            None => v.as_slice().to_vec(),
             Some(val) => val
         }
     }

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -264,7 +264,7 @@ impl GenericPath for Path {
 
     #[inline]
     fn is_absolute(&self) -> bool {
-        *self.repr.get(0) == SEP_BYTE
+        self.repr[0] == SEP_BYTE
     }
 
     fn is_ancestor_of(&self, other: &Path) -> bool {
@@ -409,7 +409,7 @@ impl Path {
     /// /a/b/c and a/b/c yield the same set of components.
     /// A path of "/" yields no components. A path of "." yields one component.
     pub fn components<'a>(&'a self) -> Components<'a> {
-        let v = if *self.repr.get(0) == SEP_BYTE {
+        let v = if self.repr[0] == SEP_BYTE {
             self.repr.slice_from(1)
         } else { self.repr.as_slice() };
         let mut ret = v.split(is_sep_byte);

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -264,10 +264,10 @@ impl GenericPathUnsafe for Path {
             let repr = me.repr.as_slice();
             match me.prefix {
                 Some(DiskPrefix) => {
-                    repr.as_bytes()[0] == path.as_bytes()[0].to_ascii().to_upper().to_byte()
+                    repr.as_bytes()[0] == path.as_bytes()[0].to_ascii().to_uppercase().to_byte()
                 }
                 Some(VerbatimDiskPrefix) => {
-                    repr.as_bytes()[4] == path.as_bytes()[0].to_ascii().to_upper().to_byte()
+                    repr.as_bytes()[4] == path.as_bytes()[0].to_ascii().to_uppercase().to_byte()
                 }
                 _ => false
             }
@@ -776,9 +776,9 @@ impl Path {
                                 let mut s = String::from_str(s.slice_to(len));
                                 unsafe {
                                     let v = s.as_mut_vec();
-                                    *v.get_mut(0) = v.get(0)
+                                    *v.get_mut(0) = (*v)[0]
                                                      .to_ascii()
-                                                     .to_upper()
+                                                     .to_uppercase()
                                                      .to_byte();
                                 }
                                 if is_abs {
@@ -794,7 +794,7 @@ impl Path {
                                 let mut s = String::from_str(s.slice_to(len));
                                 unsafe {
                                     let v = s.as_mut_vec();
-                                    *v.get_mut(4) = v.get(4).to_ascii().to_upper().to_byte();
+                                    *v.get_mut(4) = (*v)[4].to_ascii().to_uppercase().to_byte();
                                 }
                                 Some(s)
                             }
@@ -815,12 +815,12 @@ impl Path {
                         let mut s = String::with_capacity(n);
                         match prefix {
                             Some(DiskPrefix) => {
-                                s.push_char(prefix_.as_bytes()[0].to_ascii().to_upper().to_char());
+                                s.push_char(prefix_.as_bytes()[0].to_ascii().to_uppercase().to_char());
                                 s.push_char(':');
                             }
                             Some(VerbatimDiskPrefix) => {
                                 s.push_str(prefix_.slice_to(4));
-                                s.push_char(prefix_.as_bytes()[4].to_ascii().to_upper().to_char());
+                                s.push_char(prefix_.as_bytes()[4].to_ascii().to_uppercase().to_char());
                                 s.push_str(prefix_.slice_from(5));
                             }
                             Some(UNCPrefix(a,b)) => {

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -371,7 +371,7 @@ impl GenericPath for Path {
 
     #[inline]
     fn into_vec(self) -> Vec<u8> {
-        Vec::from_slice(self.repr.as_bytes())
+        self.repr.into_bytes()
     }
 
     #[inline]
@@ -815,12 +815,14 @@ impl Path {
                         let mut s = String::with_capacity(n);
                         match prefix {
                             Some(DiskPrefix) => {
-                                s.push_char(prefix_.as_bytes()[0].to_ascii().to_uppercase().to_char());
+                                s.push_char(prefix_.as_bytes()[0].to_ascii()
+                                                   .to_uppercase().to_char());
                                 s.push_char(':');
                             }
                             Some(VerbatimDiskPrefix) => {
                                 s.push_str(prefix_.slice_to(4));
-                                s.push_char(prefix_.as_bytes()[4].to_ascii().to_uppercase().to_char());
+                                s.push_char(prefix_.as_bytes()[4].to_ascii()
+                                                   .to_uppercase().to_char());
                                 s.push_str(prefix_.slice_from(5));
                             }
                             Some(UNCPrefix(a,b)) => {
@@ -1619,7 +1621,7 @@ mod tests {
         t!(s: "a\\b\\c", ["d".to_string(), "e".to_string()], "a\\b\\c\\d\\e");
         t!(v: b"a\\b\\c", [b"d", b"e"], b"a\\b\\c\\d\\e");
         t!(v: b"a\\b\\c", [b"d", b"\\e", b"f"], b"\\e\\f");
-        t!(v: b"a\\b\\c", [Vec::from_slice(b"d"), Vec::from_slice(b"e")],
+        t!(v: b"a\\b\\c", [b"d".to_vec(), b"e".to_vec()],
            b"a\\b\\c\\d\\e");
     }
 
@@ -1759,7 +1761,7 @@ mod tests {
         t!(s: "a\\b\\c", ["d", "\\e", "f"], "\\e\\f");
         t!(s: "a\\b\\c", ["d".to_string(), "e".to_string()], "a\\b\\c\\d\\e");
         t!(v: b"a\\b\\c", [b"d", b"e"], b"a\\b\\c\\d\\e");
-        t!(v: b"a\\b\\c", [Vec::from_slice(b"d"), Vec::from_slice(b"e")],
+        t!(v: b"a\\b\\c", [b"d".to_vec(), b"e".to_vec()],
            b"a\\b\\c\\d\\e");
     }
 

--- a/src/libstd/sync/task_pool.rs
+++ b/src/libstd/sync/task_pool.rs
@@ -79,7 +79,7 @@ impl<T> TaskPool<T> {
     /// Executes the function `f` on a task in the pool. The function
     /// receives a reference to the local data returned by the `init_fn`.
     pub fn execute(&mut self, f: proc(&T):Send) {
-        self.channels.get(self.next_index).send(Execute(f));
+        self.channels[self.next_index].send(Execute(f));
         self.next_index += 1;
         if self.next_index == self.channels.len() { self.next_index = 0; }
     }

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -505,8 +505,8 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
             if flags.precision > s.len() {
                 let mut s_ = Vec::with_capacity(flags.precision);
                 let n = flags.precision - s.len();
-                s_.grow(n, &b'0');
-                s_.push_all_move(s);
+                s_.grow(n, b'0');
+                s_.extend(s.into_iter());
                 s = s_;
             }
             assert!(!s.is_empty(), "string conversion produced empty result");
@@ -524,7 +524,7 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
                 FormatHex => {
                     if flags.alternate {
                         let s_ = replace(&mut s, vec!(b'0', b'x'));
-                        s.push_all_move(s_);
+                        s.extend(s_.into_iter());
                     }
                 }
                 FormatHEX => {
@@ -536,7 +536,7 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
                          .collect();
                     if flags.alternate {
                         let s_ = replace(&mut s, vec!(b'0', b'X'));
-                        s.push_all_move(s_);
+                        s.extend(s_.into_iter());
                     }
                 }
                 FormatString => unreachable!()
@@ -546,7 +546,7 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
         Words(s) => {
             match op {
                 FormatString => {
-                    let mut s = Vec::from_slice(s.as_bytes());
+                    let mut s = s.as_bytes().to_vec();
                     if flags.precision > 0 && flags.precision < s.len() {
                         s.truncate(flags.precision);
                     }
@@ -562,11 +562,11 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
     if flags.width > s.len() {
         let n = flags.width - s.len();
         if flags.left {
-            s.grow(n, &b' ');
+            s.grow(n, b' ');
         } else {
             let mut s_ = Vec::with_capacity(flags.width);
-            s_.grow(n, &b' ');
-            s_.push_all_move(s);
+            s_.grow(n, b' ');
+            s_.extend(s.into_iter());
             s = s_;
         }
     }

--- a/src/libterm/terminfo/parser/compiled.rs
+++ b/src/libterm/terminfo/parser/compiled.rs
@@ -290,9 +290,8 @@ pub fn parse(file: &mut io::Reader, longnames: bool)
             match nulpos {
                 Some(len) => {
                     string_map.insert(name.to_string(),
-                                      Vec::from_slice(
-                                          string_table.slice(offset as uint,
-                                          offset as uint + len)))
+                                      string_table.slice(offset as uint,
+                                          offset as uint + len).to_vec())
                 },
                 None => {
                     return Err("invalid file: missing NUL in \
@@ -314,10 +313,10 @@ pub fn parse(file: &mut io::Reader, longnames: bool)
 /// Create a dummy TermInfo struct for msys terminals
 pub fn msys_terminfo() -> Box<TermInfo> {
     let mut strings = HashMap::new();
-    strings.insert("sgr0".to_string(), Vec::from_slice(b"\x1B[0m"));
-    strings.insert("bold".to_string(), Vec::from_slice(b"\x1B[1m"));
-    strings.insert("setaf".to_string(), Vec::from_slice(b"\x1B[3%p1%dm"));
-    strings.insert("setab".to_string(), Vec::from_slice(b"\x1B[4%p1%dm"));
+    strings.insert("sgr0".to_string(), b"\x1B[0m".to_vec());
+    strings.insert("bold".to_string(), b"\x1B[1m".to_vec());
+    strings.insert("setaf".to_string(), b"\x1B[3%p1%dm".to_vec());
+    strings.insert("setab".to_string(), b"\x1B[4%p1%dm".to_vec());
     box TermInfo {
         names: vec!("cygwin".to_string()), // msys is a fork of an older cygwin version
         bools: HashMap::new(),

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -261,13 +261,13 @@ impl<'a, T: FloatMath + FromPrimitive> Stats<T> for &'a [T] {
     }
 
     fn percentile(self, pct: T) -> T {
-        let mut tmp = Vec::from_slice(self);
+        let mut tmp = self.to_vec();
         local_sort(tmp.as_mut_slice());
         percentile_of_sorted(tmp.as_slice(), pct)
     }
 
     fn quartiles(self) -> (T,T,T) {
-        let mut tmp = Vec::from_slice(self);
+        let mut tmp = self.to_vec();
         local_sort(tmp.as_mut_slice());
         let first = FromPrimitive::from_uint(25).unwrap();
         let a = percentile_of_sorted(tmp.as_slice(), first);
@@ -318,7 +318,7 @@ fn percentile_of_sorted<T: Float + FromPrimitive>(sorted_samples: &[T],
 ///
 /// See: http://en.wikipedia.org/wiki/Winsorising
 pub fn winsorize<T: Float + FromPrimitive>(samples: &mut [T], pct: T) {
-    let mut tmp = Vec::from_slice(samples);
+    let mut tmp = samples.to_vec();
     local_sort(tmp.as_mut_slice());
     let lo = percentile_of_sorted(tmp.as_slice(), pct);
     let hundred: T = FromPrimitive::from_uint(100).unwrap();

--- a/src/test/compile-fail/borrowck-for-loop-head-linkage.rs
+++ b/src/test/compile-fail/borrowck-for-loop-head-linkage.rs
@@ -12,7 +12,7 @@ fn main() {
     let mut vector = vec![1u, 2];
     for &x in vector.iter() {
         let cap = vector.capacity();
-        vector.grow(cap, &0u);      //~ ERROR cannot borrow
+        vector.grow(cap, 0u);      //~ ERROR cannot borrow
         *vector.get_mut(1u) = 5u;   //~ ERROR cannot borrow
     }
 }


### PR DESCRIPTION
The following methods, types, and names have become stable:
- Vec
- Vec::as_mut_slice
- Vec::as_slice
- Vec::capacity
- Vec::clear
- Vec::default
- Vec::grow
- Vec::insert
- Vec::len
- Vec::new
- Vec::pop
- Vec::push
- Vec::remove
- Vec::set_len
- Vec::shrink_to_fit
- Vec::truncate
- Vec::with_capacity
- vec::raw
- vec::raw::from_buf
- vec::raw::from_raw_parts

The following have become unstable:
- Vec::dedup        // naming
- Vec::from_fn      // naming and unboxed closures
- Vec::get_mut      // will be removed for IndexMut
- Vec::grow_fn      // unboxed closures and naming
- Vec::retain       // unboxed closures
- Vec::swap_remove  // uncertain naming
- Vec::from_elem    // uncertain semantics
- vec::unzip        // should be generic for all collections

The following have been deprecated
- Vec::append - call .extend()
- Vec::append_one - call .push()
- Vec::from_slice - call .to_vec()
- Vec::grow_set - call .grow() and then .push()
- Vec::into_vec - move the vector instead
- Vec::move_iter - renamed to iter_move()
- Vec::push_all - call .extend()
- Vec::to_vec - call .clone()
- Vec:from_raw_parts - moved to raw::from_raw_parts

This is a breaking change in terms of the signature of the `Vec::grow` function.
The argument used to be taken by reference, but it is now taken by value. Code
must update by removing a leading `&` sigil or by calling `.clone()` to create a
value.

[breaking-change]
