### PR TITLE
Fix an ICE with trans of calls to foreign fns. Refactoring

### DIFF
--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -508,11 +508,7 @@ pub fn get_res_dtor(ccx: &CrateContext,
                     substs: &subst::Substs)
                  -> ValueRef {
     let _icx = push_ctxt("trans_res_dtor");
-    let did = if did.krate != ast::LOCAL_CRATE {
-        inline::maybe_instantiate_inline(ccx, did)
-    } else {
-        did
-    };
+    let did = inline::maybe_instantiate_inline(ccx, did);
 
     if !substs.types.is_empty() {
         assert_eq!(did.krate, ast::LOCAL_CRATE);

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -141,8 +141,10 @@ fn trans<'a>(bcx: &'a Block<'a>, expr: &ast::Expr) -> Callee<'a> {
         let expr_ty = node_id_type(bcx, ref_expr.id);
         match def {
             def::DefFn(did, _) if {
-                let def_id = inline::maybe_instantiate_inline(bcx.ccx(), did);
-                match bcx.tcx().map.find(def_id.node) {
+                let maybe_def_id = inline::get_local_instance(bcx.ccx(), did);
+                let maybe_ast_node = maybe_def_id.and_then(|def_id| bcx.tcx().map
+                                                                             .find(def_id.node));
+                match maybe_ast_node {
                     Some(ast_map::NodeStructCtor(_)) => true,
                     _ => false
                 }

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -141,11 +141,7 @@ fn trans<'a>(bcx: &'a Block<'a>, expr: &ast::Expr) -> Callee<'a> {
         let expr_ty = node_id_type(bcx, ref_expr.id);
         match def {
             def::DefFn(did, _) if {
-                let def_id = if did.krate != ast::LOCAL_CRATE {
-                    inline::maybe_instantiate_inline(bcx.ccx(), did)
-                } else {
-                    did
-                };
+                let def_id = inline::maybe_instantiate_inline(bcx.ccx(), did);
                 match bcx.tcx().map.find(def_id.node) {
                     Some(ast_map::NodeStructCtor(_)) => true,
                     _ => false
@@ -162,11 +158,7 @@ fn trans<'a>(bcx: &'a Block<'a>, expr: &ast::Expr) -> Callee<'a> {
                 _ => false
             } => {
                 let substs = node_id_substs(bcx, ExprId(ref_expr.id));
-                let def_id = if did.krate != ast::LOCAL_CRATE {
-                    inline::maybe_instantiate_inline(bcx.ccx(), did)
-                } else {
-                    did
-                };
+                let def_id = inline::maybe_instantiate_inline(bcx.ccx(), did);
                 Callee { bcx: bcx, data: Intrinsic(def_id.node, substs) }
             }
             def::DefFn(did, _) |
@@ -524,13 +516,7 @@ pub fn trans_fn_ref_with_vtables(
 
     // Check whether this fn has an inlined copy and, if so, redirect
     // def_id to the local id of the inlined copy.
-    let def_id = {
-        if def_id.krate != ast::LOCAL_CRATE {
-            inline::maybe_instantiate_inline(ccx, def_id)
-        } else {
-            def_id
-        }
-    };
+    let def_id = inline::maybe_instantiate_inline(ccx, def_id);
 
     // We must monomorphise if the fn has type parameters, is a default method,
     // or is a named tuple constructor.

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -830,19 +830,6 @@ fn trans_def<'a>(bcx: &'a Block<'a>,
             //     an external global, and return a pointer to that.
             let const_ty = expr_ty(bcx, ref_expr);
 
-            fn get_did(ccx: &CrateContext, did: ast::DefId)
-                       -> ast::DefId {
-                if did.krate != ast::LOCAL_CRATE {
-                    // Case 2 or 3.  Which one we're in is determined by
-                    // whether the DefId produced by `maybe_instantiate_inline`
-                    // is in the LOCAL_CRATE or not.
-                    inline::maybe_instantiate_inline(ccx, did)
-                } else {
-                    // Case 1.
-                    did
-                }
-            }
-
             fn get_val<'a>(bcx: &'a Block<'a>, did: ast::DefId, const_ty: ty::t)
                        -> ValueRef {
                 // For external constants, we don't inline.
@@ -881,8 +868,9 @@ fn trans_def<'a>(bcx: &'a Block<'a>,
                     }
                 }
             }
-
-            let did = get_did(bcx.ccx(), did);
+            // The DefId produced by `maybe_instantiate_inline`
+            // may be in the LOCAL_CRATE or not.
+            let did = inline::maybe_instantiate_inline(bcx.ccx(), did);
             let val = get_val(bcx, did, const_ty);
             DatumBlock::new(bcx, Datum::new(val, const_ty, LvalueExpr))
         }


### PR DESCRIPTION
A match in callee.rs was recognizing some foreign fns as named tuple constructors. A reproducible test case for this is nearly impossible since it depends on the way NodeIds happen to be assigned in different crates.

Fixes #15913 
