### PR TITLE
librustc: Implement the syntax in the RFC for unboxed closure sugar.

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -213,11 +213,18 @@ pub static DUMMY_NODE_ID: NodeId = -1;
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub enum TyParamBound {
     TraitTyParamBound(TraitRef),
-    UnboxedFnTyParamBound(UnboxedFnTy),
+    UnboxedFnTyParamBound(P<UnboxedFnBound>),
     RegionTyParamBound(Lifetime)
 }
 
 pub type TyParamBounds = OwnedSlice<TyParamBound>;
+
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+pub struct UnboxedFnBound {
+    pub path: Path,
+    pub decl: P<FnDecl>,
+    pub ref_id: NodeId,
+}
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub struct TyParam {

--- a/src/test/compile-fail/unboxed-closure-sugar-nonexistent-trait.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-nonexistent-trait.rs
@@ -8,22 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(overloaded_calls)]
+fn f<F:Nonexist(int) -> int>(x: F) {} //~ ERROR unresolved trait
 
-fn a<F:Fn(int, int) -> int>(mut f: F) {
-    let g = &mut f;
-    f(1, 2);    //~ ERROR cannot borrow `f` as immutable
-    //~^ ERROR cannot borrow `f` as immutable
-}
+type Typedef = int;
 
-fn b<F:FnMut(int, int) -> int>(f: F) {
-    f(1, 2);    //~ ERROR cannot borrow immutable argument
-}
-
-fn c<F:FnOnce(int, int) -> int>(f: F) {
-    f(1, 2);
-    f(1, 2);    //~ ERROR use of moved value
-}
+fn g<F:Typedef(int) -> int>(x: F) {} //~ ERROR `Typedef` is not a trait
 
 fn main() {}
 

--- a/src/test/compile-fail/unboxed-closure-sugar-wrong-trait.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-wrong-trait.rs
@@ -8,22 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(overloaded_calls)]
+trait Trait {}
 
-fn a<F:Fn(int, int) -> int>(mut f: F) {
-    let g = &mut f;
-    f(1, 2);    //~ ERROR cannot borrow `f` as immutable
-    //~^ ERROR cannot borrow `f` as immutable
-}
-
-fn b<F:FnMut(int, int) -> int>(f: F) {
-    f(1, 2);    //~ ERROR cannot borrow immutable argument
-}
-
-fn c<F:FnOnce(int, int) -> int>(f: F) {
-    f(1, 2);
-    f(1, 2);    //~ ERROR use of moved value
-}
+fn f<F:Trait(int) -> int>(x: F) {}
+//~^ ERROR unboxed function trait must be one of `Fn`, `FnMut`, or `FnOnce`
 
 fn main() {}
 

--- a/src/test/compile-fail/unboxed-closures-wrong-trait.rs
+++ b/src/test/compile-fail/unboxed-closures-wrong-trait.rs
@@ -10,7 +10,7 @@
 
 #![feature(lang_items, overloaded_calls, unboxed_closures)]
 
-fn c<F:|: int, int| -> int>(f: F) -> int {
+fn c<F:FnOnce(int, int) -> int>(f: F) -> int {
     f(5, 6)
 }
 

--- a/src/test/run-pass/fn-trait-sugar.rs
+++ b/src/test/run-pass/fn-trait-sugar.rs
@@ -21,7 +21,7 @@ impl FnMut<(int,),int> for S {
     }
 }
 
-fn call_it<F:|int|->int>(mut f: F, x: int) -> int {
+fn call_it<F:FnMut(int)->int>(mut f: F, x: int) -> int {
     f.call_mut((x,)) + 3
 }
 

--- a/src/test/run-pass/unboxed-closures-all-traits.rs
+++ b/src/test/run-pass/unboxed-closures-all-traits.rs
@@ -10,15 +10,15 @@
 
 #![feature(lang_items, overloaded_calls, unboxed_closures)]
 
-fn a<F:|&: int, int| -> int>(f: F) -> int {
+fn a<F:Fn(int, int) -> int>(f: F) -> int {
     f(1, 2)
 }
 
-fn b<F:|&mut: int, int| -> int>(mut f: F) -> int {
+fn b<F:FnMut(int, int) -> int>(mut f: F) -> int {
     f(3, 4)
 }
 
-fn c<F:|: int, int| -> int>(f: F) -> int {
+fn c<F:FnOnce(int, int) -> int>(f: F) -> int {
     f(5, 6)
 }
 

--- a/src/test/run-pass/unboxed-closures-drop.rs
+++ b/src/test/run-pass/unboxed-closures-drop.rs
@@ -41,15 +41,15 @@ impl Drop for Droppable {
     }
 }
 
-fn a<F:|&: int, int| -> int>(f: F) -> int {
+fn a<F:Fn(int, int) -> int>(f: F) -> int {
     f(1, 2)
 }
 
-fn b<F:|&mut: int, int| -> int>(mut f: F) -> int {
+fn b<F:FnMut(int, int) -> int>(mut f: F) -> int {
     f(3, 4)
 }
 
-fn c<F:|: int, int| -> int>(f: F) -> int {
+fn c<F:FnOnce(int, int) -> int>(f: F) -> int {
     f(5, 6)
 }
 

--- a/src/test/run-pass/unboxed-closures-single-word-env.rs
+++ b/src/test/run-pass/unboxed-closures-single-word-env.rs
@@ -13,15 +13,15 @@
 
 #![feature(overloaded_calls, unboxed_closures)]
 
-fn a<F:|&: int, int| -> int>(f: F) -> int {
+fn a<F:Fn(int, int) -> int>(f: F) -> int {
     f(1, 2)
 }
 
-fn b<F:|&mut: int, int| -> int>(mut f: F) -> int {
+fn b<F:FnMut(int, int) -> int>(mut f: F) -> int {
     f(3, 4)
 }
 
-fn c<F:|: int, int| -> int>(f: F) -> int {
+fn c<F:FnOnce(int, int) -> int>(f: F) -> int {
     f(5, 6)
 }
 

--- a/src/test/run-pass/unboxed-closures-unique-type-id.rs
+++ b/src/test/run-pass/unboxed-closures-unique-type-id.rs
@@ -21,8 +21,7 @@
 
 use std::ptr;
 
-pub fn replace_map<'a, T, F>(src: &mut T, prod: F)
-where F: |: T| -> T {
+pub fn replace_map<'a, T, F>(src: &mut T, prod: F) where F: FnOnce(T) -> T {
     unsafe { *src = prod(ptr::read(src as *mut T as *const T)); }
 }
 

--- a/src/test/run-pass/where-clauses-unboxed-closures.rs
+++ b/src/test/run-pass/where-clauses-unboxed-closures.rs
@@ -13,7 +13,7 @@
 struct Bencher;
 
 // ICE
-fn warm_up<'a, F>(f: F) where F: |&: &'a mut Bencher| {
+fn warm_up<'a, F>(f: F) where F: Fn(&'a mut Bencher) {
 }
 
 fn main() {


### PR DESCRIPTION
Part of issue #16640. I am leaving this issue open to handle parsing of
higher-rank lifetimes in traits.

This change breaks code that used unboxed closures:
- Instead of `F:|&: int| -> int`, write `F:Fn(int) -> int`.
- Instead of `F:|&mut: int| -> int`, write `F:FnMut(int) -> int`.
- Instead of `F:|: int| -> int`, write `F:FnOnce(int) -> int`.

[breaking-change]

r? @alexcrichton
