### PR TITLE
librustc: Obsolete the old external crate renaming syntax.

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -42,8 +42,8 @@ extern crate flate;
 extern crate getopts;
 extern crate graphviz;
 extern crate libc;
-extern crate "rustc_llvm" as llvm;
-extern crate "rustc_back" as rustc_back;
+extern crate rustc_llvm;
+extern crate rustc_back;
 extern crate serialize;
 extern crate rbml;
 extern crate time;
@@ -52,6 +52,8 @@ extern crate time;
 
 #[cfg(test)]
 extern crate test;
+
+pub use rustc_llvm as llvm;
 
 mod diagnostics;
 

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -36,6 +36,7 @@ pub enum ObsoleteSyntax {
     ObsoleteManagedExpr,
     ObsoleteImportRenaming,
     ObsoleteSubsliceMatch,
+    ObsoleteExternCrateRenaming,
 }
 
 pub trait ParserObsoleteMethods {
@@ -92,6 +93,10 @@ impl<'a> ParserObsoleteMethods for parser::Parser<'a> {
             ObsoleteSubsliceMatch => (
                 "subslice match syntax",
                 "instead of `..xs`, write `xs..` in a pattern"
+            ),
+            ObsoleteExternCrateRenaming => (
+                "`extern crate foo = bar` syntax",
+                "write `extern crate bar as foo` instead"
             )
         };
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4783,11 +4783,7 @@ impl<'a> Parser<'a> {
                     self.bump();
                     let path = self.parse_str();
                     let span = self.span;
-                    self.span_warn(span,
-                            format!("this extern crate syntax is deprecated. \
-                            Use: extern crate \"{}\" as {};",
-                            path.ref0().get(), the_ident.as_str() ).as_slice()
-                    );
+                    self.obsolete(span, ObsoleteExternCrateRenaming);
                     Some(path)
                 } else {None};
 


### PR DESCRIPTION
Instead of `extern crate foo = bar`, write `extern crate bar as foo`.
Instead of `extern crate baz = "quux"`, write `extern crate "quux" as
baz`.

Closes #16461.

[breaking-change]

r? @brson
