### PR TITLE
(WIP) rustc: Implement nested C-like enums

### DIFF
--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -52,7 +52,6 @@ use libc::c_ulonglong;
 use std::collections::Map;
 use std::num::Int;
 use std::rc::Rc;
-// use std::vec::Vec;
 
 use llvm::{ValueRef, True, IntEQ, IntNE};
 use middle::subst;
@@ -140,19 +139,6 @@ pub struct Struct {
     pub sized: bool,
     pub packed: bool,
     pub fields: Vec<ty::t>
-}
-
-#[deriving(Show)]
-enum BitRepr {
-    UsesBits(u64),
-    FreeBits(u64),
-    // EnumSet(HashSet<Disr>),
-    // AnyDiscr(Disr),
-    UsesVariants(Disr, Option<CEnumRepr>),
-    FreeVariants {
-        pub bits: u64,
-        pub nvariants: Disr
-    },
 }
 
 #[deriving(Show)]
@@ -878,9 +864,6 @@ pub fn trans_field_ptr(bcx: &Block, r: &Repr, val: ValueRef, discr: Disr,
     // decide to do some kind of cdr-coding-like non-unique repr
     // someday), it will need to return a possibly-new bcx as well.
     match *r {
-        // CEnum(_, _, _, 1) => {
-        //     // ptr?
-        // }
         CEnum(..) => {
             // C_integral(ll_inttype(ccx, ity), discr as u64, true)
             debug!("trans_field_ptr ix {}", ix);

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -2383,7 +2383,7 @@ fn prepare_enum_metadata(cx: &CrateContext,
     let type_rep = adt::represent_type(cx, enum_type);
 
     let discriminant_type_metadata = match *type_rep {
-        adt::CEnum(inttype, _, _) => {
+        adt::CEnum(inttype, _, _, _) => {
             return FinalMetadata(discriminant_type_metadata(inttype))
         },
         adt::RawNullablePointer { .. }           |

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3013,6 +3013,11 @@ pub fn type_is_c_like_enum(cx: &ctxt, ty: t) -> bool {
                 false
             } else {
                 variants.iter().all(|v| v.args.len() == 0)
+                    || lookup_repr_hints(cx, did).iter().any(|a|
+                        match a {
+                            &attr::ReprInt(..) => true,
+                            _ => false
+                        })
             }
         }
         _ => false


### PR DESCRIPTION
Allows `#[repr(XX)]` on more complex enums. Checks for inner variant collisions.
### Example

``` rust
// exception.rs
#[repr(u8)]
pub enum Fault {
    DivideError = 0,
    NMI = 2,
    Breakpoint = 3,
    // ...
}

// interrupt.rs
#[repr(u8)]    // < this is allowed
pub enum Interrupt {
    Fault(Fault),
    IRQ0 = 32,
    IRQ1 = 33,
    Syscall = 0x80
}
```
