### PR TITLE
librustc: Change the syntax of subslice matching to use postfix `..`

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -3300,7 +3300,7 @@ it will bind the corresponding slice to the variable. Example:
 fn is_symmetric(list: &[uint]) -> bool {
     match list {
         [] | [_]                   => true,
-        [x, ..inside, y] if x == y => is_symmetric(inside),
+        [x, inside.., y] if x == y => is_symmetric(inside),
         _                          => false
     }
 }

--- a/src/doc/tutorial.md
+++ b/src/doc/tutorial.md
@@ -1707,7 +1707,7 @@ let score = match numbers {
     [] => 0,
     [a] => a * 10,
     [a, b] => a * 6 + b * 4,
-    [a, b, c, ..rest] => a * 5 + b * 3 + c * 2 + rest.len() as int
+    [a, b, c, rest..] => a * 5 + b * 3 + c * 2 + rest.len() as int
 };
 ~~~~
 

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1549,18 +1549,13 @@ impl<'a> Resolver<'a> {
                             PathListMod { .. } => Some(item.span),
                             _ => None
                         }).collect::<Vec<Span>>();
-                        match mod_spans.as_slice() {
-                            [first, second, ..other] => {
-                                self.resolve_error(first,
-                                    "`mod` import can only appear once in the list");
-                                self.session.span_note(second,
-                                        "another `mod` import appears here");
-                                for &other_span in other.iter() {
-                                    self.session.span_note(other_span,
-                                        "another `mod` import appears here");
-                                }
-                            },
-                            [_] | [] => ()
+                        if mod_spans.len() > 1 {
+                            self.resolve_error(mod_spans[0],
+                                "`mod` import can only appear once in the list");
+                            for other_span in mod_spans.iter().skip(1) {
+                                self.session.span_note(*other_span,
+                                    "another `mod` import appears here");
+                            }
                         }
 
                         for source_item in source_items.iter() {

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -35,6 +35,7 @@ pub enum ObsoleteSyntax {
     ObsoleteManagedType,
     ObsoleteManagedExpr,
     ObsoleteImportRenaming,
+    ObsoleteSubsliceMatch,
 }
 
 pub trait ParserObsoleteMethods {
@@ -87,6 +88,10 @@ impl<'a> ParserObsoleteMethods for parser::Parser<'a> {
             ObsoleteImportRenaming => (
                 "`use foo = bar` syntax",
                 "write `use bar as foo` instead"
+            ),
+            ObsoleteSubsliceMatch => (
+                "subslice match syntax",
+                "instead of `..xs`, write `xs..` in a pattern"
             )
         };
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1912,13 +1912,13 @@ impl<'a> State<'a> {
                                    |s, p| s.print_pat(&**p)));
                 for p in slice.iter() {
                     if !before.is_empty() { try!(self.word_space(",")); }
+                    try!(self.print_pat(&**p));
                     match **p {
                         ast::Pat { node: ast::PatWild(ast::PatWildMulti), .. } => {
                             // this case is handled by print_pat
                         }
                         _ => try!(word(&mut self.s, "..")),
                     }
-                    try!(self.print_pat(&**p));
                     if !after.is_empty() { try!(self.word_space(",")); }
                 }
                 try!(self.commasep(Inconsistent,

--- a/src/test/compile-fail/borrowck-move-out-of-vec-tail.rs
+++ b/src/test/compile-fail/borrowck-move-out-of-vec-tail.rs
@@ -25,7 +25,7 @@ pub fn main() {
     );
     let x: &[Foo] = x.as_slice();
     match x {
-        [_, ..tail] => {
+        [_, tail..] => {
             match tail {
                 [Foo { string: a }, //~ ERROR cannot move out of dereference of `&`-pointer
                  Foo { string: b }] => {

--- a/src/test/compile-fail/borrowck-vec-pattern-element-loan.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-element-loan.rs
@@ -12,7 +12,7 @@ fn a<'a>() -> &'a [int] {
     let vec = vec!(1, 2, 3, 4);
     let vec: &[int] = vec.as_slice(); //~ ERROR does not live long enough
     let tail = match vec {
-        [_, ..tail] => tail,
+        [_, tail..] => tail,
         _ => fail!("a")
     };
     tail
@@ -22,7 +22,7 @@ fn b<'a>() -> &'a [int] {
     let vec = vec!(1, 2, 3, 4);
     let vec: &[int] = vec.as_slice(); //~ ERROR does not live long enough
     let init = match vec {
-        [..init, _] => init,
+        [init.., _] => init,
         _ => fail!("b")
     };
     init
@@ -32,7 +32,7 @@ fn c<'a>() -> &'a [int] {
     let vec = vec!(1, 2, 3, 4);
     let vec: &[int] = vec.as_slice(); //~ ERROR does not live long enough
     let slice = match vec {
-        [_, ..slice, _] => slice,
+        [_, slice.., _] => slice,
         _ => fail!("c")
     };
     slice

--- a/src/test/compile-fail/borrowck-vec-pattern-loan-from-mut.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-loan-from-mut.rs
@@ -12,7 +12,7 @@ fn a() {
     let mut v = vec!(1, 2, 3);
     let vb: &mut [int] = v.as_mut_slice();
     match vb {
-        [_a, ..tail] => {
+        [_a, tail..] => {
             v.push(tail[0] + tail[1]); //~ ERROR cannot borrow
         }
         _ => {}

--- a/src/test/compile-fail/borrowck-vec-pattern-move-tail.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-move-tail.rs
@@ -11,7 +11,7 @@
 fn main() {
     let mut a = [1i, 2, 3, 4];
     let t = match a {
-        [1, 2, ..tail] => tail,
+        [1, 2, tail..] => tail,
         _ => unreachable!()
     };
     a[0] = 0; //~ ERROR cannot assign to `a[..]` because it is borrowed

--- a/src/test/compile-fail/borrowck-vec-pattern-nesting.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-nesting.rs
@@ -22,7 +22,7 @@ fn b() {
     let mut vec = vec!(box 1i, box 2, box 3);
     let vec: &mut [Box<int>] = vec.as_mut_slice();
     match vec {
-        [.._b] => {
+        [_b..] => {
             vec[0] = box 4; //~ ERROR cannot assign
         }
     }
@@ -33,7 +33,7 @@ fn c() {
     let vec: &mut [Box<int>] = vec.as_mut_slice();
     match vec {
         [_a,         //~ ERROR cannot move out
-         .._b] => {  //~^ NOTE attempting to move value to here
+         _b..] => {  //~^ NOTE attempting to move value to here
 
             // Note: `_a` is *moved* here, but `b` is borrowing,
             // hence illegal.
@@ -50,7 +50,7 @@ fn d() {
     let mut vec = vec!(box 1i, box 2, box 3);
     let vec: &mut [Box<int>] = vec.as_mut_slice();
     match vec {
-        [.._a,     //~ ERROR cannot move out
+        [_a..,     //~ ERROR cannot move out
          _b] => {} //~ NOTE attempting to move value to here
         _ => {}
     }

--- a/src/test/compile-fail/borrowck-vec-pattern-tail-element-loan.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-tail-element-loan.rs
@@ -12,7 +12,7 @@ fn a<'a>() -> &'a int {
     let vec = vec!(1, 2, 3, 4);
     let vec: &[int] = vec.as_slice(); //~ ERROR `vec` does not live long enough
     let tail = match vec {
-        [_a, ..tail] => &tail[0],
+        [_a, tail..] => &tail[0],
         _ => fail!("foo")
     };
     tail

--- a/src/test/compile-fail/issue-12369.rs
+++ b/src/test/compile-fail/issue-12369.rs
@@ -13,7 +13,7 @@ fn main() {
     let v: int = match sl.as_slice() {
         [] => 0,
         [a,b,c] => 3,
-        [a, ..rest] => a,
-        [10,a, ..rest] => 10 //~ ERROR: unreachable pattern
+        [a, rest..] => a,
+        [10,a, rest..] => 10 //~ ERROR: unreachable pattern
     };
 }

--- a/src/test/compile-fail/issue-12567.rs
+++ b/src/test/compile-fail/issue-12567.rs
@@ -11,10 +11,10 @@
 fn match_vecs<'a, T>(l1: &'a [T], l2: &'a [T]) {
     match (l1, l2) {
         ([], []) => println!("both empty"),
-        ([], [hd, ..tl]) | ([hd, ..tl], []) => println!("one empty"),
+        ([], [hd, tl..]) | ([hd, tl..], []) => println!("one empty"),
         //~^ ERROR: cannot move out of dereference
         //~^^ ERROR: cannot move out of dereference
-        ([hd1, ..tl1], [hd2, ..tl2]) => println!("both nonempty"),
+        ([hd1, tl1..], [hd2, tl2..]) => println!("both nonempty"),
         //~^ ERROR: cannot move out of dereference
         //~^^ ERROR: cannot move out of dereference
     }

--- a/src/test/compile-fail/match-vec-invalid.rs
+++ b/src/test/compile-fail/match-vec-invalid.rs
@@ -11,7 +11,7 @@
 fn main() {
     let a = Vec::new();
     match a {
-        [1, ..tail, ..tail] => {}, //~ ERROR: unexpected token: `..`
+        [1, tail.., tail..] => {}, //~ ERROR: expected `,`, found `..`
         _ => ()
     }
 }

--- a/src/test/compile-fail/match-vec-unreachable.rs
+++ b/src/test/compile-fail/match-vec-unreachable.rs
@@ -31,7 +31,7 @@ fn main() {
     let x: Vec<char> = vec!('a', 'b', 'c');
     let x: &[char] = x.as_slice();
     match x {
-        ['a', 'b', 'c', .._tail] => {}
+        ['a', 'b', 'c', _tail..] => {}
         ['a', 'b', 'c'] => {} //~ ERROR unreachable pattern
         _ => {}
     }

--- a/src/test/compile-fail/non-exhaustive-match.rs
+++ b/src/test/compile-fail/non-exhaustive-match.rs
@@ -38,14 +38,14 @@ fn main() {
     let vec = vec!(Some(42i), None, Some(21i));
     let vec: &[Option<int>] = vec.as_slice();
     match vec { //~ ERROR non-exhaustive patterns: `[]` not covered
-        [Some(..), None, ..tail] => {}
-        [Some(..), Some(..), ..tail] => {}
+        [Some(..), None, tail..] => {}
+        [Some(..), Some(..), tail..] => {}
         [None] => {}
     }
     let vec = vec!(1i);
     let vec: &[int] = vec.as_slice();
     match vec {
-        [_, ..tail] => (),
+        [_, tail..] => (),
         [] => ()
     }
     let vec = vec!(0.5f32);
@@ -59,10 +59,10 @@ fn main() {
     let vec = vec!(Some(42i), None, Some(21i));
     let vec: &[Option<int>] = vec.as_slice();
     match vec {
-        [Some(..), None, ..tail] => {}
-        [Some(..), Some(..), ..tail] => {}
-        [None, None, ..tail] => {}
-        [None, Some(..), ..tail] => {}
+        [Some(..), None, tail..] => {}
+        [Some(..), Some(..), tail..] => {}
+        [None, None, tail..] => {}
+        [None, Some(..), tail..] => {}
         [Some(_)] => {}
         [None] => {}
         [] => {}

--- a/src/test/compile-fail/non-exhaustive-pattern-witness.rs
+++ b/src/test/compile-fail/non-exhaustive-pattern-witness.rs
@@ -63,7 +63,7 @@ fn vectors_with_nested_enums() {
         [Second(true), First] => (),
         [Second(true), Second(true)] => (),
         [Second(false), _] => (),
-        [_, _, ..tail, _] => ()
+        [_, _, tail.., _] => ()
     }
 }
 

--- a/src/test/compile-fail/vec-matching-obsolete-syntax.rs
+++ b/src/test/compile-fail/vec-matching-obsolete-syntax.rs
@@ -9,22 +9,14 @@
 // except according to those terms.
 
 fn main() {
-    let mut x: &[_] = &[1i, 2, 3, 4];
-
-    let mut result = vec!();
-    loop {
-        x = match x {
-            [1, n, 3, rest..] => {
-                result.push(n);
-                rest
-            }
-            [n, rest..] => {
-                result.push(n);
-                rest
-            }
-            [] =>
-                break
+    let x = [1i, 2, 3];
+    match x {
+        [a, b, ..c] => {    //~ ERROR obsolete syntax
+            assert_eq!(a, 1);
+            assert_eq!(b, 2);
+            let expected: &[_] = &[3];
+            assert_eq!(c, expected);
         }
     }
-    assert!(result.as_slice() == [2, 4]);
 }
+

--- a/src/test/run-pass/issue-15104.rs
+++ b/src/test/run-pass/issue-15104.rs
@@ -16,6 +16,6 @@ fn count_members(v: &[uint]) -> uint {
     match v {
         []         => 0,
         [_]        => 1,
-        [_x, ..xs] => 1 + count_members(xs)
+        [_x, xs..] => 1 + count_members(xs)
     }
 }

--- a/src/test/run-pass/issue-7784.rs
+++ b/src/test/run-pass/issue-7784.rs
@@ -29,7 +29,7 @@ fn main() {
     assert_eq!(d, "baz");
 
     let out = bar("baz", "foo");
-    let [a, ..xs, d] = out;
+    let [a, xs.., d] = out;
     assert_eq!(a, "baz");
     assert!(xs == ["foo", "foo"]);
     assert_eq!(d, "baz");

--- a/src/test/run-pass/vec-matching-fold.rs
+++ b/src/test/run-pass/vec-matching-fold.rs
@@ -13,7 +13,7 @@ fn foldl<T,U:Clone>(values: &[T],
                     function: |partial: U, element: &T| -> U)
                     -> U {
     match values {
-        [ref head, ..tail] =>
+        [ref head, tail..] =>
             foldl(tail, function(initial, head), function),
         [] => initial.clone()
     }
@@ -24,7 +24,7 @@ fn foldr<T,U:Clone>(values: &[T],
                     function: |element: &T, partial: U| -> U)
                     -> U {
     match values {
-        [..head, ref tail] =>
+        [head.., ref tail] =>
             foldr(head, function(tail, initial), function),
         [] => initial.clone()
     }

--- a/src/test/run-pass/vec-matching-legal-tail-element-borrow.rs
+++ b/src/test/run-pass/vec-matching-legal-tail-element-borrow.rs
@@ -13,7 +13,7 @@ pub fn main() {
     let x: &[int] = &[1, 2, 3, 4, 5];
     if !x.is_empty() {
         let el = match x {
-            [1, ..ref tail] => &tail[0],
+            [1, ref tail..] => &tail[0],
             _ => unreachable!()
         };
         println!("{}", *el);

--- a/src/test/run-pass/vec-matching.rs
+++ b/src/test/run-pass/vec-matching.rs
@@ -20,7 +20,7 @@ fn a() {
 fn b() {
     let x = [1i, 2, 3];
     match x {
-        [a, b, ..c] => {
+        [a, b, c..] => {
             assert_eq!(a, 1);
             assert_eq!(b, 2);
             let expected: &[_] = &[3];
@@ -28,7 +28,7 @@ fn b() {
         }
     }
     match x {
-        [..a, b, c] => {
+        [a.., b, c] => {
             let expected: &[_] = &[1];
             assert_eq!(a, expected);
             assert_eq!(b, 2);
@@ -36,7 +36,7 @@ fn b() {
         }
     }
     match x {
-        [a, ..b, c] => {
+        [a, b.., c] => {
             assert_eq!(a, 1);
             let expected: &[_] = &[2];
             assert_eq!(b, expected);

--- a/src/test/run-pass/vec-tail-matching.rs
+++ b/src/test/run-pass/vec-tail-matching.rs
@@ -20,14 +20,14 @@ pub fn main() {
         Foo { string: "baz".to_string() }
     ];
     match x {
-        [ref first, ..tail] => {
+        [ref first, tail..] => {
             assert!(first.string == "foo".to_string());
             assert_eq!(tail.len(), 2);
             assert!(tail[0].string == "bar".to_string());
             assert!(tail[1].string == "baz".to_string());
 
             match tail {
-                [Foo { .. }, _, Foo { .. }, .. _tail] => {
+                [Foo { .. }, _, Foo { .. }, _tail..] => {
                     unreachable!();
                 }
                 [Foo { string: ref a }, Foo { string: ref b }] => {


### PR DESCRIPTION
instead of prefix `..`.

This breaks code that looked like:

```
match foo {
    [ first, ..middle, last ] => { ... }
}
```

Change this code to:

```
match foo {
    [ first, middle.., last ] => { ... }
}
```

RFC #55.

Closes #16967.

[breaking-change]

r? @brson
