### PR TITLE
Flip arguments to `std::iter::iterate`.

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -2185,7 +2185,7 @@ pub type Iterate<'a, T> = Unfold<'a, T, IterateState<'a, T>>;
 /// Creates a new iterator that produces an infinite sequence of
 /// repeated applications of the given function `f`.
 #[allow(visible_private_types)]
-pub fn iterate<'a, T: Clone>(f: |T|: 'a -> T, seed: T) -> Iterate<'a, T> {
+pub fn iterate<'a, T: Clone>(seed: T, f: |T|: 'a -> T) -> Iterate<'a, T> {
     Unfold::new((f, Some(seed), true), |st| {
         let &(ref mut f, ref mut val, ref mut first) = st;
         if *first {

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -839,7 +839,7 @@ fn test_min_max_result() {
 
 #[test]
 fn test_iterate() {
-    let mut it = iterate(|x| x * 2, 1u);
+    let mut it = iterate(1u, |x| x * 2);
     assert_eq!(it.next(), Some(1u));
     assert_eq!(it.next(), Some(2u));
     assert_eq!(it.next(), Some(4u));


### PR DESCRIPTION
Breaks `iterate(f, seed)`, use `iterate(seed, f)` instead.
The convention is to have the closure last.

Closes #17066.

[breaking-change]
