### PR TITLE
Allow Rust to be built with LLVM trunk (3.6).

### DIFF
--- a/configure
+++ b/configure
@@ -707,7 +707,7 @@ then
             | cut -d ' ' -f 2)
 
         case $CFG_CLANG_VERSION in
-            (3.0svn | 3.0 | 3.1* | 3.2* | 3.3* | 3.4* | 3.5* )
+            (3.0svn | 3.0 | 3.1* | 3.2* | 3.3* | 3.4* | 3.5* | 3.6*)
             step_msg "found ok version of CLANG: $CFG_CLANG_VERSION"
             if [ -z "$CC" ]
             then


### PR DESCRIPTION
The development branch of LLVM now identifies as 3.6. Add the condition to ./configure.
