### PR TITLE
replace LaTeX \bot with actual ⊥ symbol

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -1197,11 +1197,11 @@ fn my_err(s: &str) -> ! {
 ~~~~
 
 We call such functions "diverging" because they never return a value to the
-caller. Every control path in a diverging function must end with a
-`fail!()` or a call to another diverging function on every
-control path. The `!` annotation does *not* denote a type. Rather, the result
-type of a diverging function is a special type called $\bot$ ("bottom") that
-unifies with any type. Rust has no syntax for $\bot$.
+caller. Every control path in a diverging function must end with a `fail!()` or
+a call to another diverging function on every control path. The `!` annotation
+does *not* denote a type. Rather, the result type of a diverging function is a
+special type, ⊥ ("bottom"), that unifies with any type. Rust has no syntax for
+⊥.
 
 It might be necessary to declare a diverging function because as mentioned
 previously, the typechecker checks that every control path in a function ends


### PR DESCRIPTION
Right now, the LaTeXism `$\bot$` [shows up literally](http://doc.rust-lang.org/rust.html#diverging-functions) in the manual. This PR replaces the LaTeX with the unicode bottom symbol.
