### PR TITLE
fixes for Box<[T]>

### DIFF
--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -12,7 +12,6 @@
 // FIXME: #13996: mark the `allocate` and `reallocate` return value as `noalias`
 //                and `nonnull`
 
-use core::ptr::RawPtr;
 #[cfg(not(test))] use core::raw;
 #[cfg(stage0, not(test))] use util;
 
@@ -70,11 +69,6 @@ pub unsafe fn reallocate_inplace(ptr: *mut u8, size: uint, align: uint,
 /// the value returned by `usable_size` for the requested size.
 #[inline]
 pub unsafe fn deallocate(ptr: *mut u8, size: uint, align: uint) {
-    // FIXME(14395) This is only required for DST ~[T], it should be removed once
-    // we fix that representation to not use null pointers.
-    if ptr.is_null() {
-        return;
-    }
     imp::deallocate(ptr, size, align)
 }
 

--- a/src/test/run-pass/empty-allocation-non-null.rs
+++ b/src/test/run-pass/empty-allocation-non-null.rs
@@ -11,6 +11,12 @@
 pub fn main() {
     assert!(Some(box() ()).is_some());
 
+    let xs: Box<[()]> = box [];
+    assert!(Some(xs).is_some());
+
     struct Foo;
     assert!(Some(box Foo).is_some());
+
+    let ys: Box<[Foo]> = box [];
+    assert!(Some(ys).is_some());
 }


### PR DESCRIPTION
The pointer in the slice must not be null, because enum representations
make that assumption. The `exchange_malloc` function returns a non-null
sentinel for the zero size case, and it must not be passed to the
`exchange_free` lang item.

Since the length is always equal to the true capacity, a branch on the
length is enough for most types. Slices of zero size types are
statically special cased to never attempt deallocation. This is the same
implementation as `Vec<T>`.

Closes #14395
