### PR TITLE
Change collect behaviour for maps

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -212,14 +212,13 @@ impl LintStore {
             match self.by_name.find_equiv(&lint_name.as_slice()) {
                 Some(&lint_id) => self.set_level(lint_id, (level, CommandLine)),
                 None => {
-                    match self.lint_groups.iter().map(|(&x, pair)| (x, pair.ref0().clone()))
-                                                 .collect::<HashMap<&'static str, Vec<LintId>>>()
-                                                 .find_equiv(&lint_name.as_slice()) {
+                    match self.lint_groups.iter()
+                                          .find(|&(&x, _)| x == lint_name.as_slice())
+                                          .map(|(_, pair)| pair.ref0().clone()) {
                         Some(v) => {
-                            v.iter()
-                             .map(|lint_id: &LintId|
-                                     self.set_level(*lint_id, (level, CommandLine)))
-                             .collect::<Vec<()>>();
+                            for &lint_id in v.iter() {
+                                self.set_level(lint_id, (level, CommandLine))
+                            }
                         }
                         None => sess.err(format!("unknown {} flag: {}",
                                                  level.as_str(), lint_name).as_slice()),

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -404,15 +404,17 @@ fn resolve_crate_deps(e: &mut Env,
     debug!("resolving deps of external crate");
     // The map from crate numbers in the crate we're resolving to local crate
     // numbers
-    decoder::get_crate_deps(cdata).iter().map(|dep| {
+    let mut map = HashMap::new();
+    for dep in decoder::get_crate_deps(cdata).iter() {
         debug!("resolving dep crate {} hash: `{}`", dep.name, dep.hash);
         let (local_cnum, _, _) = resolve_crate(e, root,
                                                dep.name.as_slice(),
                                                dep.name.as_slice(),
                                                Some(&dep.hash),
                                                span);
-        (dep.cnum, local_cnum)
-    }).collect()
+        map.insert(dep.cnum, local_cnum);
+    }
+    map
 }
 
 pub struct PluginMetadataReader<'a> {

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -30,7 +30,7 @@ extern crate time;
 
 use std::io;
 use std::io::{File, MemWriter};
-use std::collections::HashMap;
+use std::collections::{HashMap, TreeMap};
 use serialize::{json, Decodable, Encodable};
 use externalfiles::ExternalHtml;
 
@@ -494,15 +494,17 @@ fn json_output(krate: clean::Crate, res: Vec<plugins::PluginJson> ,
     // }
     let mut json = std::collections::TreeMap::new();
     json.insert("schema".to_string(), json::String(SCHEMA_VERSION.to_string()));
-    let plugins_json = res.move_iter()
-                          .filter_map(|opt| {
-                              match opt {
-                                  None => None,
-                                  Some((string, json)) => {
-                                      Some((string.to_string(), json))
-                                  }
-                              }
-                          }).collect();
+
+    let mut plugins_json = TreeMap::new();
+
+    for opt in res.move_iter() {
+        match opt {
+            Some((string, json)) => {
+                plugins_json.insert(string.to_string(), json);
+            },
+            None => {}
+        }
+    }
 
     // FIXME #8335: yuck, Rust -> str -> JSON round trip! No way to .encode
     // straight to the Rust JSON representation.

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -167,10 +167,13 @@ impl Command {
             None => {
                 // if the env is currently just inheriting from the parent's,
                 // materialize the parent's env into a hashtable.
-                self.env = Some(os::env_as_bytes().move_iter()
-                                   .map(|(k, v)| (k.as_slice().to_c_str(),
-                                                  v.as_slice().to_c_str()))
-                                   .collect());
+                let mut map = HashMap::new();
+                for (k, v) in os::env_as_bytes().move_iter() {
+                    map.insert(k.as_slice().to_c_str(),
+                               v.as_slice().to_c_str());
+                }
+
+                self.env = Some(map);
                 self.env.as_mut().unwrap()
             }
         }
@@ -195,8 +198,12 @@ impl Command {
     /// variable, the *rightmost* instance will determine the value.
     pub fn env_set_all<'a, T: ToCStr, U: ToCStr>(&'a mut self, env: &[(T,U)])
                                                  -> &'a mut Command {
-        self.env = Some(env.iter().map(|&(ref k, ref v)| (k.to_c_str(), v.to_c_str()))
-                                  .collect());
+        let mut map = HashMap::new();
+        for &(ref k, ref v) in env.iter() {
+            map.insert(k.to_c_str(), v.to_c_str());
+        }
+
+        self.env = Some(map);
         self
     }
 

--- a/src/libsyntax/diagnostics/registry.rs
+++ b/src/libsyntax/diagnostics/registry.rs
@@ -16,7 +16,12 @@ pub struct Registry {
 
 impl Registry {
     pub fn new(descriptions: &[(&'static str, &'static str)]) -> Registry {
-        Registry { descriptions: descriptions.iter().map(|&tuple| tuple).collect() }
+        let mut map = HashMap::new();
+        for &(k, v) in descriptions.iter() {
+            map.insert(k, v);
+        }
+
+        Registry { descriptions: map }
     }
 
     pub fn find_description(&self, code: &str) -> Option<&'static str> {


### PR DESCRIPTION
Current `collect` behavior for the Map types is lossy, where additional values per key are thrown away and only the last value is kept. I think the user should make an explicit decision regarding this behavior.  

Perhaps this warrants a different trait, or another static method to initialize maps from an iterator of pairs (with the lossy behaviour), i.e. `Hashmap::from_iter_lossy(..)`?

I think it's worth looking closely at the changes in the 2nd commit as some of them may benefit from assertions that duplicates don't exist.

Also from an implementation standpoint, I'm sure I'm overlooking a better way to get an iterator from a single value, rather than `Some(v).move_iter()`.
