### PR TITLE
Handle `Sized?` in `type` items.

### DIFF
--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -3936,6 +3936,7 @@ impl<'a> Resolver<'a> {
                                                                item.id,
                                                                ItemRibKind),
                                              |this| {
+                    this.resolve_type_parameters(&generics.ty_params);
                     visit::walk_item(this, item, ());
                 });
             }

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -488,7 +488,9 @@ pub fn ensure_no_ty_param_bounds(ccx: &CrateCtxt,
                                  generics: &ast::Generics,
                                  thing: &'static str) {
     for ty_param in generics.ty_params.iter() {
-        for bound in ty_param.bounds.iter() {
+        let bounds = ty_param.bounds.iter();
+        let mut bounds = bounds.chain(ty_param.unbound.iter());
+        for bound in bounds {
             match *bound {
                 ast::TraitTyParamBound(..) | ast::UnboxedFnTyParamBound(..) => {
                     // According to accepted RFC #XXX, we should
@@ -1076,9 +1078,10 @@ fn add_unsized_bound(ccx: &CrateCtxt,
                      desc: &str,
                      span: Span) {
     let kind_id = ccx.tcx.lang_items.require(SizedTraitLangItem);
+
     match unbound {
         &Some(ast::TraitTyParamBound(ref tpb)) => {
-            // #FIXME(8559) currently requires the unbound to be built-in.
+            // FIXME(#8559) currently requires the unbound to be built-in.
             let trait_def_id = ty::trait_ref_to_def_id(ccx.tcx, tpb);
             match kind_id {
                 Ok(kind_id) if trait_def_id != kind_id => {

--- a/src/test/run-pass/unsized.rs
+++ b/src/test/run-pass/unsized.rs
@@ -24,6 +24,7 @@ struct S1<Sized? X>;
 enum E<Sized? X> {}
 impl <Sized? X> T1 for S1<X> {}
 fn f<Sized? X>() {}
+type TT<Sized? T> = T;
 
 pub fn main() {
 }


### PR DESCRIPTION
Resolves bounds for `type` and adds the warning for 'unbounds' (? bounds) that we have for bounds.

Closes #16888 

r?
