### PR TITLE
Fix naming of windows installer

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -123,7 +123,7 @@ PKG_EXE = dist/$(PKG_NAME)-install.exe
 $(PKG_EXE): rust.iss modpath.iss upgrade.iss LICENSE.txt rust-logo.ico \
             $(CSREQ3_T_$(CFG_BUILD)_H_$(CFG_BUILD)) \
             dist-prepare-win
-	$(CFG_PYTHON) $(S)src/etc/copy-runtime-deps.py tmp/dist/win/bin
+	$(CFG_PYTHON) $(S)src/etc/copy-runtime-deps.py tmp/dist/win/bin $(CFG_BUILD)
 	@$(call E, ISCC: $@)
 	$(Q)"$(CFG_ISCC)" $<
 

--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -112,7 +112,7 @@ distcheck-tar-src: dist-tar-src
 
 ifdef CFG_ISCC
 
-PKG_EXE = dist/$(PKG_NAME)-install.exe
+PKG_EXE = dist/$(PKG_NAME)-$(CFG_BUILD).exe
 
 %.iss: $(S)src/etc/pkg/%.iss
 	cp $< $@

--- a/src/etc/copy-runtime-deps.py
+++ b/src/etc/copy-runtime-deps.py
@@ -12,8 +12,8 @@
 
 import snapshot, sys, os, shutil
 
-def copy_runtime_deps(dest_dir):
-    for path in snapshot.get_winnt_runtime_deps():
+def copy_runtime_deps(dest_dir, triple):
+    for path in snapshot.get_winnt_runtime_deps(snapshot.get_platform(triple)):
         shutil.copy(path, dest_dir)
 
     lic_dest = os.path.join(dest_dir, "third-party")
@@ -21,4 +21,4 @@ def copy_runtime_deps(dest_dir):
         shutil.rmtree(lic_dest) # copytree() won't overwrite existing files
     shutil.copytree(os.path.join(os.path.dirname(__file__), "third-party"), lic_dest)
 
-copy_runtime_deps(sys.argv[1])
+copy_runtime_deps(sys.argv[1], sys.argv[2])

--- a/src/etc/pkg/rust.iss
+++ b/src/etc/pkg/rust.iss
@@ -1,6 +1,7 @@
 #define CFG_VERSION_WIN GetEnv("CFG_VERSION_WIN")
 #define CFG_RELEASE GetEnv("CFG_RELEASE")
 #define CFG_PACKAGE_NAME GetEnv("CFG_PACKAGE_NAME")
+#define CFG_BUILD GetEnv("CFG_BUILD")
 
 [Setup]
 
@@ -20,7 +21,7 @@ DisableStartupPrompt=true
 
 OutputDir=.\dist\
 SourceDir=.\
-OutputBaseFilename={#CFG_PACKAGE_NAME}-install
+OutputBaseFilename={#CFG_PACKAGE_NAME}-{#CFG_BUILD}
 DefaultDirName={pf32}\Rust
 
 Compression=lzma2/ultra


### PR DESCRIPTION
This builds on https://github.com/rust-lang/rust/pull/17109, putting the target triple into the installer name so that we can have both 32-bit and 64-bit.

The resulting installers will be called `rust-0.12.0-pre-x86_64-w64-mingw32.exe`, etc.
