### PR TITLE
reintroduce manual link in doc index

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -43,6 +43,10 @@ discussion about Rust.
 There is also a [developer forum](http://discuss.rust-lang.org/), where the
 development of Rust itself is discussed.
 
+# Specification
+
+Rust does not have an exact specification, but an effort to describe as much of
+the language in as much detail as possible is in [the manual](rust.html).
 
 # Guides
 


### PR DESCRIPTION
whoops

Fixes https://github.com/rust-lang/rust/pull/16827#issuecomment-55160273
