### PR TITLE
librustc: Forbid inherent implementations that aren't adjacent to the

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -20,6 +20,7 @@ use util::logv;
 use util;
 
 use std::io::File;
+use std::io::fs::PathExtensions;
 use std::io::fs;
 use std::io::net::tcp;
 use std::io::process::ProcessExit;

--- a/src/libglob/lib.rs
+++ b/src/libglob/lib.rs
@@ -37,6 +37,7 @@
 
 use std::cell::Cell;
 use std::{cmp, os, path};
+use std::io::fs::PathExtensions;
 use std::io::fs;
 use std::path::is_sep;
 use std::string::String;

--- a/src/libnative/io/process.rs
+++ b/src/libnative/io/process.rs
@@ -21,6 +21,7 @@ use std::rt::rtio;
 use super::file;
 use super::util;
 
+#[cfg(windows)] use std::io::fs::PathExtensions;
 #[cfg(windows)] use std::string::String;
 #[cfg(unix)] use super::c;
 #[cfg(unix)] use super::retry;

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -28,6 +28,7 @@ use util::ppaux;
 use util::sha2::{Digest, Sha256};
 
 use std::char;
+use std::io::fs::PathExtensions;
 use std::io::{fs, TempDir, Command};
 use std::io;
 use std::mem;

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -11,9 +11,10 @@
 #![allow(non_camel_case_types)]
 
 use std::cell::RefCell;
-use std::os;
-use std::io::fs;
 use std::collections::HashSet;
+use std::io::fs::PathExtensions;
+use std::io::fs;
+use std::os;
 
 use util::fs as myfs;
 

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -229,6 +229,7 @@ use util::fs;
 
 use std::c_str::ToCStr;
 use std::cmp;
+use std::io::fs::PathExtensions;
 use std::io;
 use std::mem;
 use std::ptr;

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1313,10 +1313,6 @@ impl<'a> Resolver<'a> {
                 // If this implements an anonymous trait, then add all the
                 // methods within to a new module, if the type was defined
                 // within this module.
-                //
-                // FIXME (#3785): This is quite unsatisfactory. Perhaps we
-                // should modify anonymous traits to only be implementable in
-                // the same module that declared the type.
 
                 // Create the module and add all methods.
                 match ty.node {
@@ -1400,7 +1396,13 @@ impl<'a> Resolver<'a> {
                             }
                         }
                     }
-                    _ => {}
+                    _ => {
+                        self.resolve_error(ty.span,
+                                           "inherent implementations may \
+                                            only be implemented in the same \
+                                            module as the type they are \
+                                            implemented for")
+                    }
                 }
 
                 parent

--- a/src/librustc_back/archive.rs
+++ b/src/librustc_back/archive.rs
@@ -10,6 +10,7 @@
 
 //! A helper class for dealing with static archives
 
+use std::io::fs::PathExtensions;
 use std::io::process::{Command, ProcessOutput};
 use std::io::{fs, TempDir};
 use std::io;

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -35,6 +35,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::io::fs::PathExtensions;
 use std::io::{fs, File, BufferedWriter, MemWriter, BufferedReader};
 use std::io;
 use std::str;

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1721,6 +1721,7 @@ pub enum FileType {
 /// # Example
 ///
 /// ```
+/// # use std::io::fs::PathExtensions;
 /// # fn main() {}
 /// # fn foo() {
 /// let info = match Path::new("foo.txt").stat() {

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -53,6 +53,8 @@ actually operates on the path; it is only intended for display.
 ## Example
 
 ```rust
+use std::io::fs::PathExtensions;
+
 let mut path = Path::new("/tmp/path");
 println!("path: {}", path.display());
 path.set_filename("foo");

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -82,6 +82,7 @@ use parse::{new_sub_parser_from_file, ParseSess};
 use owned_slice::OwnedSlice;
 
 use std::collections::HashSet;
+use std::io::fs::PathExtensions;
 use std::mem::replace;
 use std::rc::Rc;
 use std::gc::{Gc, GC};

--- a/src/libterm/terminfo/searcher.rs
+++ b/src/libterm/terminfo/searcher.rs
@@ -13,6 +13,7 @@
 //! Does not support hashed database, only filesystem!
 
 use std::io::File;
+use std::io::fs::PathExtensions;
 use std::os::getenv;
 use std::os;
 

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -56,6 +56,7 @@ use std::f64;
 use std::fmt;
 use std::fmt::Show;
 use std::from_str::FromStr;
+use std::io::fs::PathExtensions;
 use std::io::stdio::StdWriter;
 use std::io::{File, ChanReader, ChanWriter};
 use std::io;

--- a/src/test/auxiliary/inner_static.rs
+++ b/src/test/auxiliary/inner_static.rs
@@ -13,6 +13,18 @@ pub struct B<T>;
 
 pub mod test {
     pub struct A<T>;
+
+    impl<T> A<T> {
+        pub fn foo(&self) -> int {
+            static a: int = 5;
+            return a
+        }
+
+        pub fn bar(&self) -> int {
+            static a: int = 6;
+            return a;
+        }
+    }
 }
 
 impl<T> A<T> {
@@ -35,18 +47,6 @@ impl<T> B<T> {
 
     pub fn bar(&self) -> int {
         static a: int = 4;
-        return a;
-    }
-}
-
-impl<T> test::A<T> {
-    pub fn foo(&self) -> int {
-        static a: int = 5;
-        return a
-    }
-
-    pub fn bar(&self) -> int {
-        static a: int = 6;
         return a;
     }
 }

--- a/src/test/compile-fail/impl-not-adjacent-to-type.rs
+++ b/src/test/compile-fail/impl-not-adjacent-to-type.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+mod foo {
+    pub struct Foo {
+        x: int,
+        y: int,
+    }
+}
+
+impl foo::Foo {
+//~^ ERROR implementations may only be implemented in the same module
+    fn bar() {}
+}
+
+fn main() {}
+

--- a/src/test/run-pass/rename-directory.rs
+++ b/src/test/run-pass/rename-directory.rs
@@ -14,9 +14,10 @@
 extern crate libc;
 
 use std::io::TempDir;
-use std::os;
-use std::io;
+use std::io::fs::PathExtensions;
 use std::io::fs;
+use std::io;
+use std::os;
 
 fn rename_directory() {
     unsafe {

--- a/src/test/run-pass/stat.rs
+++ b/src/test/run-pass/stat.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
+use std::io::fs::PathExtensions;
 use std::io::{File, TempDir};
 
 pub fn main() {

--- a/src/test/run-pass/tempfile.rs
+++ b/src/test/run-pass/tempfile.rs
@@ -20,6 +20,7 @@
 
 extern crate debug;
 
+use std::io::fs::PathExtensions;
 use std::io::{fs, TempDir};
 use std::io;
 use std::os;


### PR DESCRIPTION
type they provide an implementation for.

This breaks code like:

```
mod foo {
    struct Foo { ... }
}

impl foo::Foo {
    ...
}
```

Change this code to:

```
mod foo {
    struct Foo { ... }

    impl Foo {
        ...
    }
}
```

Closes #17059.

RFC #155.

[breaking-change]

r? @brson
