### PR TITLE
Add 'no_struct_literal_expr' non-terminal to macro_rules.

### DIFF
--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -84,7 +84,7 @@ use codemap;
 use parse::lexer::*; //resolve bug?
 use parse::ParseSess;
 use parse::attr::ParserAttr;
-use parse::parser::{LifetimeAndTypesWithoutColons, Parser};
+use parse::parser::{LifetimeAndTypesWithoutColons, Parser, RESTRICT_NO_STRUCT_LITERAL};
 use parse::token::{Token, EOF, Nonterminal};
 use parse::token;
 
@@ -435,6 +435,9 @@ pub fn parse_nt(p: &mut Parser, name: &str) -> Nonterminal {
       "stmt" => token::NtStmt(p.parse_stmt(Vec::new())),
       "pat" => token::NtPat(p.parse_pat()),
       "expr" => token::NtExpr(p.parse_expr()),
+      "no_struct_literal_expr" => {
+        token::NtExpr(p.parse_expr_res(RESTRICT_NO_STRUCT_LITERAL))
+      }
       "ty" => token::NtTy(p.parse_ty(false /* no need to disambiguate*/)),
       // this could be handled like a token, since it is one
       "ident" => match p.token {

--- a/src/test/run-pass/macro-non-struct-literal-expr.rs
+++ b/src/test/run-pass/macro-non-struct-literal-expr.rs
@@ -1,0 +1,35 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(macro_rules)]
+
+macro_rules! for_emulator {
+    (for $pat:pat in $expr:no_struct_literal_expr $block:block) => {
+        loop {
+            match $expr.next() {
+                Some($pat) => {
+                    $block
+                },
+                None => break
+            }
+        }
+    }
+}
+
+fn main() {
+    let mut a = false;
+    let mut iter = Some(true).move_iter();
+    for_emulator!{
+        for v in iter {
+            a = v;
+        }
+    }
+    assert!(a);
+}


### PR DESCRIPTION
This is necessary due to [RFC 25](https://github.com/rust-lang/rfcs/blob/master/complete/0025-struct-grammar.md). Without it, the eager parsing of the `expr` nonterminal precludes writing constructs similar to the built in ones like `if`, `while` and `for`-loop (see the added test for an example). The name for this non-terminal was lifted from the grammar in the manual.
