### PR TITLE
librustc: Enum nullable pointer opt should not apply to raw pointers.

### DIFF
--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -298,9 +298,8 @@ impl Case {
 
         for (i, &ty) in self.tys.iter().enumerate() {
             match ty::get(ty).sty {
-                // &T/&mut T/*T could either be a thin or fat pointer depending on T
-                ty::ty_rptr(_, ty::mt { ty, .. })
-                | ty::ty_ptr(ty::mt { ty, .. }) => match ty::get(ty).sty {
+                // &T/&mut T could either be a thin or fat pointer depending on T
+                ty::ty_rptr(_, ty::mt { ty, .. }) => match ty::get(ty).sty {
                     // &[T] and &str are a pointer and length pair
                     ty::ty_vec(_, None) | ty::ty_str => return Some(FatPointer(i, slice_elt_base)),
 

--- a/src/test/run-pass/enum-null-pointer-opt.rs
+++ b/src/test/run-pass/enum-null-pointer-opt.rs
@@ -37,4 +37,9 @@ fn main() {
     assert_eq!(size_of::<Box<int>>(), size_of::<Option<Box<int>>>());
     assert_eq!(size_of::<Gc<int>>(), size_of::<Option<Gc<int>>>());
 
+
+    // The optimization can't apply to raw pointers
+    assert!(size_of::<Option<*const int>>() != size_of::<*const int>());
+    assert!(Some(0 as *const int).is_some()); // Can't collapse None to null
+
 }


### PR DESCRIPTION
Fixes #17120.
