### PR TITLE
add debuginfo for unboxed closures

### DIFF
--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -511,6 +511,9 @@ impl TypeMap {
                     unique_type_id.push_char('+');
                 }
             },
+            ty::ty_unboxed_closure(..) => {
+                unique_type_id.push_str("closure");
+            }
             _ => {
                 cx.sess().bug(format!("get_unique_type_id_of_type() - unexpected type: {}, {:?}",
                                       ppaux::ty_to_string(cx.tcx(), type_).as_slice(),
@@ -2979,6 +2982,13 @@ fn type_metadata(cx: &CrateContext,
                                    elements.as_slice(),
                                    unique_type_id,
                                    usage_site_span).finalize(cx)
+        }
+        ty::ty_unboxed_closure(def_id, _) => {
+            let unboxed_closures = cx.tcx().unboxed_closures.borrow();
+            let ref function_type = unboxed_closures.get(&def_id)
+                                                    .closure_type;
+
+            subroutine_type_metadata(cx, unique_type_id, &function_type.sig, usage_site_span)
         }
         _ => {
             cx.sess().bug(format!("debuginfo: unexpected type in type_metadata: {:?}",

--- a/src/test/run-pass/unboxed-closures-unique-type-id.rs
+++ b/src/test/run-pass/unboxed-closures-unique-type-id.rs
@@ -7,6 +7,9 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+// compile-flags:-g
+
 //
 // This code used to produce the following ICE:
 //


### PR DESCRIPTION
This catches two unhandled patterns in middle/trans/debuginfo.rs where a
ty::ty_unboxed_closure could show up, preventing various potential ICEs
when #[feature(unboxed_closures)] is used with `-g`.

It also updates the test case from #17093 in response to new information
from #17021 showing that the test still caused an ICE when compiling
with debuginfo.

Closes #17021.
