### PR TITLE
remove dead and broken tvec ~[T] code path

### DIFF
--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -587,25 +587,7 @@ fn trans_datum_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             let contents_ty = expr_ty(bcx, &**contents);
             match ty::get(box_ty).sty {
                 ty::ty_uniq(..) => {
-                    let is_vec = match contents.node {
-                        ast::ExprRepeat(..) | ast::ExprVec(..) => true,
-                        ast::ExprLit(lit) => match lit.node {
-                            ast::LitStr(..) => true,
-                            _ => false
-                        },
-                        _ => false
-                    };
-
-                    if is_vec {
-                        // Special case for owned vectors.
-                        fcx.push_ast_cleanup_scope(contents.id);
-                        let datum = unpack_datum!(
-                            bcx, tvec::trans_uniq_vec(bcx, expr, &**contents));
-                        bcx = fcx.pop_and_trans_ast_cleanup_scope(bcx, contents.id);
-                        DatumBlock::new(bcx, datum)
-                    } else {
-                        trans_uniq_expr(bcx, box_ty, &**contents, contents_ty)
-                    }
+                    trans_uniq_expr(bcx, box_ty, &**contents, contents_ty)
                 }
                 ty::ty_box(..) => {
                     trans_managed_expr(bcx, box_ty, &**contents, contents_ty)


### PR DESCRIPTION
`Box<[T]>` is created by allocating `Box<[T, ..n]>` and coercing it so
this code path is never used. It's also broken because it clamps the
capacity of the memory allocations to 4 elements and that's incompatible
with sized deallocation. This dates back to when `~[T]` was a growable
vector type implemented as:

*{ { tydesc, ref_count, prev, next }, { length, capacity, data[] } }

Since even empty vectors had to allocate, it started off the capacity of
all vectors at 4 as a heuristic. It's not possible to grow `Box<[T]>`
and there is no need for a memory allocation when it's empty, so it
would be a terrible heuristic today even if it worked.
