### PR TITLE
 Fix check for existing crate when using --extern

### DIFF
--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -281,7 +281,7 @@ fn existing_match(e: &Env, name: &str,
                   hash: Option<&Svh>) -> Option<ast::CrateNum> {
     let mut ret = None;
     e.sess.cstore.iter_crate_data(|cnum, data| {
-        if data.name().as_slice() != name { return }
+        if data.name.as_slice() != name { return }
 
         match hash {
             Some(hash) if *hash == data.hash() => { ret = Some(cnum); return }

--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -145,7 +145,7 @@ fn extract_crate_info(e: &Env, i: &ast::ViewItem) -> Option<CrateInfo> {
     match i.node {
         ast::ViewItemExternCrate(ident, ref path_opt, id) => {
             let ident = token::get_ident(ident);
-            debug!("resolving extern crate stmt. ident: {:?} path_opt: {:?}",
+            debug!("resolving extern crate stmt. ident: {} path_opt: {}",
                    ident, path_opt);
             let name = match *path_opt {
                 Some((ref path_str, _)) => {

--- a/src/test/run-make/extern-diff-internal-name/Makefile
+++ b/src/test/run-make/extern-diff-internal-name/Makefile
@@ -1,0 +1,6 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) lib.rs
+	$(RUSTC) test.rs --extern foo=$(TMPDIR)/libbar.rlib 2>&1 | \
+		{ ! grep "using multiple versions of crate"; }

--- a/src/test/run-make/extern-diff-internal-name/lib.rs
+++ b/src/test/run-make/extern-diff-internal-name/lib.rs
@@ -1,0 +1,12 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "bar"]
+#![crate_type = "rlib"]

--- a/src/test/run-make/extern-diff-internal-name/test.rs
+++ b/src/test/run-make/extern-diff-internal-name/test.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(phase)]
+
+#[phase(plugin, link)]
+extern crate foo;
+
+fn main() {
+}


### PR DESCRIPTION
When checking for an existing crate, compare against the `crate_metadata::name` field, which is the crate name which was requested during resolution, rather than the result of the `crate_metadata::name()` method, which is the crate name within the crate metadata, as these may not match when using the --extern option to `rustc`.

This fixes spurious "multiple crate version" warnings under the following scenario:
- The crate `foo`, is referenced multiple times
- `--extern foo=./path/to/libbar.rlib` is specified to rustc
- The internal crate name of `libbar.rlib` is not `foo`

The behavior surrounding `Context::should_match_name` and the comments in `loader.rs` both lead me to believe that this scenario is intended to work.

Fixes #17186
