### PR TITLE
Don't pass -fno-use-linker-plugin on OS X

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -931,7 +931,12 @@ fn link_args(cmd: &mut Command,
     }
 
     // Rust does its' own LTO
-    cmd.arg("-fno-lto").arg("-fno-use-linker-plugin");
+    cmd.arg("-fno-lto");
+
+    // clang fails hard if -fno-use-linker-plugin is passed
+    if sess.targ_cfg.os == abi::OsWindows {
+        cmd.arg("-fno-use-linker-plugin");
+    }
 
     // If we're building a dylib, we don't use --gc-sections because LLVM has
     // already done the best it can do, and we also don't want to eliminate the


### PR DESCRIPTION
Don't pass -fno-use-linker-plugin on OS X as clang does not accept it.

clang fails linking with:

```
error: linking with `cc` failed: exit code: 1
... arg list omitted...
note: clang: error: unknown argument: '-fno-use-linker-plugin' [-Wunused-command-line-argument-hard-error-in-future]
clang: note: this will be a hard error (cannot be downgraded to a warning) in the future
```

clang version:

```
$ clang -v
Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)
Target: x86_64-apple-darwin13.2.0
Thread model: posix
```
