### PR TITLE
Ignore most debuginfo tests on windows. #17202

### DIFF
--- a/src/test/debuginfo/basic-types-globals-metadata.rs
+++ b/src/test/debuginfo/basic-types-globals-metadata.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-windows: FIXME #13256
+// ignore-windows (#17202): FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/basic-types-globals.rs
+++ b/src/test/debuginfo/basic-types-globals.rs
@@ -14,7 +14,7 @@
 // about UTF-32 character encoding and will print a rust char as only
 // its numerical value.
 
-// ignore-windows: FIXME #13256
+// ignore-windows (#17202): FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/basic-types-metadata.rs
+++ b/src/test/debuginfo/basic-types-metadata.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/basic-types-mut-globals.rs
+++ b/src/test/debuginfo/basic-types-mut-globals.rs
@@ -14,7 +14,7 @@
 // about UTF-32 character encoding and will print a rust char as only
 // its numerical value.
 
-// ignore-windows: FIXME #13256
+// ignore-windows (#17202): FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/basic-types.rs
+++ b/src/test/debuginfo/basic-types.rs
@@ -14,6 +14,7 @@
 // about UTF-32 character encoding and will print a rust char as only
 // its numerical value.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/borrowed-basic.rs
+++ b/src/test/debuginfo/borrowed-basic.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // Gdb doesn't know about UTF-32 character encoding and will print a rust char as only

--- a/src/test/debuginfo/borrowed-c-style-enum.rs
+++ b/src/test/debuginfo/borrowed-c-style-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/borrowed-enum.rs
+++ b/src/test/debuginfo/borrowed-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/borrowed-managed-basic.rs
+++ b/src/test/debuginfo/borrowed-managed-basic.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 

--- a/src/test/debuginfo/borrowed-struct.rs
+++ b/src/test/debuginfo/borrowed-struct.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 // compile-flags:-g
 

--- a/src/test/debuginfo/borrowed-tuple.rs
+++ b/src/test/debuginfo/borrowed-tuple.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 

--- a/src/test/debuginfo/borrowed-unique-basic.rs
+++ b/src/test/debuginfo/borrowed-unique-basic.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // Gdb doesn't know about UTF-32 character encoding and will print a rust char as only

--- a/src/test/debuginfo/box.rs
+++ b/src/test/debuginfo/box.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/boxed-struct.rs
+++ b/src/test/debuginfo/boxed-struct.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/by-value-non-immediate-argument.rs
+++ b/src/test/debuginfo/by-value-non-immediate-argument.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/by-value-self-argument-in-trait-impl.rs
+++ b/src/test/debuginfo/by-value-self-argument-in-trait-impl.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 

--- a/src/test/debuginfo/c-style-enum-in-composite.rs
+++ b/src/test/debuginfo/c-style-enum-in-composite.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 

--- a/src/test/debuginfo/c-style-enum.rs
+++ b/src/test/debuginfo/c-style-enum.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-windows: FIXME #13256
+// ignore-windows (#17202): FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/closure-in-generic-function.rs
+++ b/src/test/debuginfo/closure-in-generic-function.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/destructured-fn-argument.rs
+++ b/src/test/debuginfo/destructured-fn-argument.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/destructured-local.rs
+++ b/src/test/debuginfo/destructured-local.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/evec-in-struct.rs
+++ b/src/test/debuginfo/evec-in-struct.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/function-arg-initialization.rs
+++ b/src/test/debuginfo/function-arg-initialization.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // This test case checks if function arguments already have the correct value when breaking at the

--- a/src/test/debuginfo/function-arguments.rs
+++ b/src/test/debuginfo/function-arguments.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/function-prologue-stepping-no-split-stack.rs
+++ b/src/test/debuginfo/function-prologue-stepping-no-split-stack.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // This test case checks if function arguments already have the correct value when breaking at the

--- a/src/test/debuginfo/generic-function.rs
+++ b/src/test/debuginfo/generic-function.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/generic-functions-nested.rs
+++ b/src/test/debuginfo/generic-functions-nested.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/generic-method-on-generic-struct.rs
+++ b/src/test/debuginfo/generic-method-on-generic-struct.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/generic-static-method-on-struct-and-enum.rs
+++ b/src/test/debuginfo/generic-static-method-on-struct-and-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/generic-struct-style-enum.rs
+++ b/src/test/debuginfo/generic-struct-style-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 

--- a/src/test/debuginfo/generic-struct.rs
+++ b/src/test/debuginfo/generic-struct.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 

--- a/src/test/debuginfo/generic-tuple-style-enum.rs
+++ b/src/test/debuginfo/generic-tuple-style-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 

--- a/src/test/debuginfo/include_string.rs
+++ b/src/test/debuginfo/include_string.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/issue12886.rs
+++ b/src/test/debuginfo/issue12886.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/lexical-scope-in-if.rs
+++ b/src/test/debuginfo/lexical-scope-in-if.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/lexical-scope-in-match.rs
+++ b/src/test/debuginfo/lexical-scope-in-match.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/lexical-scope-in-stack-closure.rs
+++ b/src/test/debuginfo/lexical-scope-in-stack-closure.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/lexical-scope-in-unconditional-loop.rs
+++ b/src/test/debuginfo/lexical-scope-in-unconditional-loop.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/lexical-scope-in-unique-closure.rs
+++ b/src/test/debuginfo/lexical-scope-in-unique-closure.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/lexical-scope-in-while.rs
+++ b/src/test/debuginfo/lexical-scope-in-while.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/lexical-scope-with-macro.rs
+++ b/src/test/debuginfo/lexical-scope-with-macro.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/lexical-scopes-in-block-expression.rs
+++ b/src/test/debuginfo/lexical-scopes-in-block-expression.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-windows: FIXME #13256
+// ignore-windows (#17202): FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/limited-debuginfo.rs
+++ b/src/test/debuginfo/limited-debuginfo.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // ignore-lldb

--- a/src/test/debuginfo/managed-enum.rs
+++ b/src/test/debuginfo/managed-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/managed-pointer-within-unique-vec.rs
+++ b/src/test/debuginfo/managed-pointer-within-unique-vec.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 

--- a/src/test/debuginfo/managed-pointer-within-unique.rs
+++ b/src/test/debuginfo/managed-pointer-within-unique.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 

--- a/src/test/debuginfo/method-on-enum.rs
+++ b/src/test/debuginfo/method-on-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/method-on-generic-struct.rs
+++ b/src/test/debuginfo/method-on-generic-struct.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/method-on-struct.rs
+++ b/src/test/debuginfo/method-on-struct.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/method-on-trait.rs
+++ b/src/test/debuginfo/method-on-trait.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/method-on-tuple-struct.rs
+++ b/src/test/debuginfo/method-on-tuple-struct.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/multiple-functions-equal-var-names.rs
+++ b/src/test/debuginfo/multiple-functions-equal-var-names.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/multiple-functions.rs
+++ b/src/test/debuginfo/multiple-functions.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/name-shadowing-and-scope-nesting.rs
+++ b/src/test/debuginfo/name-shadowing-and-scope-nesting.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/nil-enum.rs
+++ b/src/test/debuginfo/nil-enum.rs
@@ -11,6 +11,7 @@
 // LLDB can't handle zero-sized values
 // ignore-lldb
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/no-debug-attribute.rs
+++ b/src/test/debuginfo/no-debug-attribute.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 // ignore-lldb
 

--- a/src/test/debuginfo/option-like-enum.rs
+++ b/src/test/debuginfo/option-like-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 

--- a/src/test/debuginfo/packed-struct-with-destructor.rs
+++ b/src/test/debuginfo/packed-struct-with-destructor.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 

--- a/src/test/debuginfo/packed-struct.rs
+++ b/src/test/debuginfo/packed-struct.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 

--- a/src/test/debuginfo/recursive-struct.rs
+++ b/src/test/debuginfo/recursive-struct.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 // ignore-lldb

--- a/src/test/debuginfo/self-in-default-method.rs
+++ b/src/test/debuginfo/self-in-default-method.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/self-in-generic-default-method.rs
+++ b/src/test/debuginfo/self-in-generic-default-method.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/shadowed-argument.rs
+++ b/src/test/debuginfo/shadowed-argument.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/shadowed-variable.rs
+++ b/src/test/debuginfo/shadowed-variable.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/simd.rs
+++ b/src/test/debuginfo/simd.rs
@@ -11,6 +11,7 @@
 // Need a fix for LLDB first...
 // ignore-lldb
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/simple-lexical-scope.rs
+++ b/src/test/debuginfo/simple-lexical-scope.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/simple-struct.rs
+++ b/src/test/debuginfo/simple-struct.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-windows: FIXME #13256
+// ignore-windows (#17202): FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/simple-tuple.rs
+++ b/src/test/debuginfo/simple-tuple.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-windows: FIXME #13256
+// ignore-windows (#17202): FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/static-method-on-struct-and-enum.rs
+++ b/src/test/debuginfo/static-method-on-struct-and-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/struct-in-enum.rs
+++ b/src/test/debuginfo/struct-in-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 

--- a/src/test/debuginfo/struct-in-struct.rs
+++ b/src/test/debuginfo/struct-in-struct.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 

--- a/src/test/debuginfo/struct-style-enum.rs
+++ b/src/test/debuginfo/struct-style-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 

--- a/src/test/debuginfo/struct-with-destructor.rs
+++ b/src/test/debuginfo/struct-with-destructor.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/tuple-in-struct.rs
+++ b/src/test/debuginfo/tuple-in-struct.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/tuple-in-tuple.rs
+++ b/src/test/debuginfo/tuple-in-tuple.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/tuple-struct.rs
+++ b/src/test/debuginfo/tuple-struct.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/tuple-style-enum.rs
+++ b/src/test/debuginfo/tuple-style-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 

--- a/src/test/debuginfo/type-names.rs
+++ b/src/test/debuginfo/type-names.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-tidy-linelength
 // ignore-lldb
 // ignore-android: FIXME(#10381)

--- a/src/test/debuginfo/unique-enum.rs
+++ b/src/test/debuginfo/unique-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/var-captured-in-nested-closure.rs
+++ b/src/test/debuginfo/var-captured-in-nested-closure.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/var-captured-in-sendable-closure.rs
+++ b/src/test/debuginfo/var-captured-in-sendable-closure.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/var-captured-in-stack-closure.rs
+++ b/src/test/debuginfo/var-captured-in-stack-closure.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-windows (#17202)
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/vec-slices.rs
+++ b/src/test/debuginfo/vec-slices.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-windows: FIXME #13256
+// ignore-windows (#17202): FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g

--- a/src/test/debuginfo/vec.rs
+++ b/src/test/debuginfo/vec.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-windows: FIXME #13256
+// ignore-windows (#17202): FIXME #13256
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g


### PR DESCRIPTION
In preparation for running the full test suite on the bots.
