### PR TITLE
stop adding a jemalloc prefix on Linux

### DIFF
--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -294,6 +294,9 @@ ifeq ($$(CFG_WINDOWSY_$(1)),1)
 else
   JEMALLOC_REAL_NAME_$(1) := $$(call CFG_STATIC_LIB_NAME_$(1),jemalloc_pic)
 endif
+ifneq ($(OSTYPE_$(1)), unknown-linux-gnu)
+	JEMALLOC_ARGS_$(1) := --with-jemalloc-prefix=je_
+endif
 JEMALLOC_LIB_$(1) := $$(RT_OUTPUT_DIR_$(1))/$$(JEMALLOC_NAME_$(1))
 JEMALLOC_BUILD_DIR_$(1) := $$(RT_OUTPUT_DIR_$(1))/jemalloc
 JEMALLOC_LOCAL_$(1) := $$(JEMALLOC_BUILD_DIR_$(1))/lib/$$(JEMALLOC_REAL_NAME_$(1))
@@ -301,7 +304,7 @@ JEMALLOC_LOCAL_$(1) := $$(JEMALLOC_BUILD_DIR_$(1))/lib/$$(JEMALLOC_REAL_NAME_$(1
 $$(JEMALLOC_LOCAL_$(1)): $$(JEMALLOC_DEPS) $$(MKFILE_DEPS)
 	@$$(call E, make: jemalloc)
 	cd "$$(JEMALLOC_BUILD_DIR_$(1))"; "$(S)src/jemalloc/configure" \
-		$$(JEMALLOC_ARGS_$(1)) --with-jemalloc-prefix=je_ $(CFG_JEMALLOC_FLAGS) \
+		$$(JEMALLOC_ARGS_$(1)) $(CFG_JEMALLOC_FLAGS) \
 		--build=$(CFG_BUILD) --host=$(1) \
 		CC="$$(CC_$(1))" \
 		AR="$$(AR_$(1))" \

--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -166,6 +166,32 @@ mod imp {
     #[cfg(not(test))]
     extern {}
 
+    #[cfg(target_os = "linux")]
+    extern {
+        #[link_name = "mallocx"]
+        fn je_mallocx(size: size_t, flags: c_int) -> *mut c_void;
+        #[link_name = "rallocx"]
+        fn je_rallocx(ptr: *mut c_void, size: size_t,
+                      flags: c_int) -> *mut c_void;
+        #[link_name = "xallocx"]
+        fn je_xallocx(ptr: *mut c_void, size: size_t, extra: size_t,
+                      flags: c_int) -> size_t;
+        #[cfg(stage0)]
+        #[link_name = "dallocx"]
+        fn je_dallocx(ptr: *mut c_void, flags: c_int);
+        #[cfg(not(stage0))]
+        #[link_name = "sdallocx"]
+        fn je_sdallocx(ptr: *mut c_void, size: size_t, flags: c_int);
+        #[link_name = "nallocx"]
+        fn je_nallocx(size: size_t, flags: c_int) -> size_t;
+        #[link_name = "malloc_stats_print"]
+        fn je_malloc_stats_print(write_cb: Option<extern "C" fn(cbopaque: *mut c_void,
+                                                                *const c_char)>,
+                                 cbopaque: *mut c_void,
+                                 opts: *const c_char);
+    }
+
+    #[cfg(not(target_os = "linux"))]
     extern {
         fn je_mallocx(size: size_t, flags: c_int) -> *mut c_void;
         fn je_rallocx(ptr: *mut c_void, size: size_t,


### PR DESCRIPTION
The prefix was added for all operating systems to avoid issues on OS X
and Windows. However, it does work properly on Linux with the defaults.

This will make it possible to use the jemalloc provided by distributions
after the next release with `sdallocx`. 8c057984 can then be reverted
once Travis has a recent enough jemalloc available.

Avoiding the prefix allows jemalloc to override the weak symbols from
libc and the malloc hooks. This eliminates the external fragmentation
caused by having two general purpose allocators in the same process.

The time spent on LLVM passes in the Rust compiler is cut by 10-15%, and
peak memory usage is reduced by 8-20%.

In the future, this can be extended to other operating systems but it
will require lots of testing, and may involve carefully ordering the
libraries the linker is asked to include so that jemalloc is included
before the C standard library.

Closes #14117
