### PR TITLE
Add support for LLVM optimization remarks

### DIFF
--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -716,8 +716,8 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
             None      |
             Some("2") => FullDebugInfo,
             Some(arg) => {
-                early_error(format!("optimization level needs to be between \
-                                     0-3 (instead was `{}`)",
+                early_error(format!("debug info level needs to be between \
+                                     0-2 (instead was `{}`)",
                                     arg).as_slice());
             }
         }

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -235,6 +235,21 @@ pub fn debugging_opts_map() -> Vec<(&'static str, &'static str, u64)> {
                        --pretty flowgraph output", FLOWGRAPH_PRINT_ALL))
 }
 
+#[deriving(Clone)]
+pub enum Passes {
+    Passes(Vec<String>),
+    AllPasses,
+}
+
+impl Passes {
+    pub fn is_empty(&self) -> bool {
+        match *self {
+            Passes(ref v) => v.is_empty(),
+            AllPasses => false,
+        }
+    }
+}
+
 /// Declare a macro that will define all CodegenOptions fields and parsers all
 /// at once. The goal of this macro is to define an interface that can be
 /// programmatically used by the option parser in order to initialize the struct
@@ -261,7 +276,7 @@ macro_rules! cgoptions(
         &[ $( (stringify!($opt), cgsetters::$opt, $desc) ),* ];
 
     mod cgsetters {
-        use super::CodegenOptions;
+        use super::{CodegenOptions, Passes, AllPasses};
 
         $(
             pub fn $opt(cg: &mut CodegenOptions, v: Option<&str>) -> bool {
@@ -310,6 +325,24 @@ macro_rules! cgoptions(
                 None => false
             }
         }
+
+        fn parse_passes(slot: &mut Passes, v: Option<&str>) -> bool {
+            match v {
+                Some("all") => {
+                    *slot = AllPasses;
+                    true
+                }
+                v => {
+                    let mut passes = vec!();
+                    if parse_list(&mut passes, v) {
+                        *slot = Passes(passes);
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+        }
     }
 ) )
 
@@ -356,6 +389,8 @@ cgoptions!(
          "extra data to put in each output filename"),
     codegen_units: uint = (1, parse_uint,
         "divide crate into N units to optimize in parallel"),
+    remark: Passes = (Passes(Vec::new()), parse_passes,
+        "print remarks for these optimization passes (space separated, or \"all\")"),
 )
 
 pub fn build_codegen_options(matches: &getopts::Matches) -> CodegenOptions
@@ -743,6 +778,10 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
                     --print-file-name");
     }
     let cg = build_codegen_options(matches);
+
+    if !cg.remark.is_empty() && debuginfo == NoDebugInfo {
+        early_warn("-C remark will not show source locations without --debuginfo");
+    }
 
     let color = match matches.opt_str("color").as_ref().map(|s| s.as_slice()) {
         Some("auto")   => Auto,

--- a/src/librustc/middle/trans/type_.rs
+++ b/src/librustc/middle/trans/type_.rs
@@ -21,11 +21,10 @@ use syntax::abi::{X86, X86_64, Arm, Mips, Mipsel};
 
 use std::c_str::ToCStr;
 use std::mem;
-use std::string;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use libc::{c_uint, c_void, free};
+use libc::c_uint;
 
 #[deriving(Clone, PartialEq, Show)]
 pub struct Type {
@@ -339,12 +338,9 @@ impl TypeNames {
     }
 
     pub fn type_to_string(&self, ty: Type) -> String {
-        unsafe {
-            let s = llvm::LLVMTypeToString(ty.to_ref());
-            let ret = string::raw::from_buf(s as *const u8);
-            free(s as *mut c_void);
-            ret
-        }
+        llvm::build_string(|s| unsafe {
+                llvm::LLVMWriteTypeToString(ty.to_ref(), s);
+            }).expect("non-UTF8 type description from LLVM")
     }
 
     pub fn types_to_str(&self, tys: &[Type]) -> String {
@@ -353,11 +349,8 @@ impl TypeNames {
     }
 
     pub fn val_to_string(&self, val: ValueRef) -> String {
-        unsafe {
-            let s = llvm::LLVMValueToString(val);
-            let ret = string::raw::from_buf(s as *const u8);
-            free(s as *mut c_void);
-            ret
-        }
+        llvm::build_string(|s| unsafe {
+                llvm::LLVMWriteValueToString(val, s);
+            }).expect("nun-UTF8 value description from LLVM")
     }
 }

--- a/src/librustc_llvm/diagnostic.rs
+++ b/src/librustc_llvm/diagnostic.rs
@@ -1,0 +1,92 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! LLVM diagnostic reports.
+
+use libc::c_char;
+
+use {ValueRef, TwineRef, DebugLocRef, DiagnosticInfoRef};
+
+pub enum OptimizationDiagnosticKind {
+    OptimizationRemark,
+    OptimizationMissed,
+    OptimizationAnalysis,
+    OptimizationFailure,
+}
+
+impl OptimizationDiagnosticKind {
+    pub fn describe(self) -> &'static str {
+        match self {
+            OptimizationRemark => "remark",
+            OptimizationMissed => "missed",
+            OptimizationAnalysis => "analysis",
+            OptimizationFailure => "failure",
+        }
+    }
+}
+
+pub struct OptimizationDiagnostic {
+    pub kind: OptimizationDiagnosticKind,
+    pub pass_name: *const c_char,
+    pub function: ValueRef,
+    pub debug_loc: DebugLocRef,
+    pub message: TwineRef,
+}
+
+impl OptimizationDiagnostic {
+    unsafe fn unpack(kind: OptimizationDiagnosticKind, di: DiagnosticInfoRef)
+            -> OptimizationDiagnostic {
+
+        let mut opt = OptimizationDiagnostic {
+            kind: kind,
+            pass_name: 0 as *const c_char,
+            function: 0 as ValueRef,
+            debug_loc: 0 as DebugLocRef,
+            message: 0 as TwineRef,
+        };
+
+        super::LLVMUnpackOptimizationDiagnostic(di,
+            &mut opt.pass_name,
+            &mut opt.function,
+            &mut opt.debug_loc,
+            &mut opt.message);
+
+        opt
+    }
+}
+
+pub enum Diagnostic {
+    Optimization(OptimizationDiagnostic),
+
+    /// LLVM has other types that we do not wrap here.
+    UnknownDiagnostic(DiagnosticInfoRef),
+}
+
+impl Diagnostic {
+    pub unsafe fn unpack(di: DiagnosticInfoRef) -> Diagnostic {
+        let kind = super::LLVMGetDiagInfoKind(di);
+
+        match kind {
+            super::DK_OptimizationRemark
+                => Optimization(OptimizationDiagnostic::unpack(OptimizationRemark, di)),
+
+            super::DK_OptimizationRemarkMissed
+                => Optimization(OptimizationDiagnostic::unpack(OptimizationMissed, di)),
+
+            super::DK_OptimizationRemarkAnalysis
+                => Optimization(OptimizationDiagnostic::unpack(OptimizationAnalysis, di)),
+
+            super::DK_OptimizationFailure
+                => Optimization(OptimizationDiagnostic::unpack(OptimizationFailure, di)),
+
+            _ => UnknownDiagnostic(di)
+        }
+    }
+}

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -11,6 +11,8 @@
 #include "rustllvm.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/IR/DiagnosticInfo.h"
+#include "llvm/IR/DiagnosticPrinter.h"
 
 #if LLVM_VERSION_MINOR >= 5
 #include "llvm/IR/CallSite.h"
@@ -822,4 +824,50 @@ LLVMRustGetSectionName(LLVMSectionIteratorRef SI, const char **ptr) {
 extern "C" LLVMTypeRef
 LLVMRustArrayType(LLVMTypeRef ElementType, uint64_t ElementCount) {
     return wrap(ArrayType::get(unwrap(ElementType), ElementCount));
+}
+
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(Twine, LLVMTwineRef)
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(DebugLoc, LLVMDebugLocRef)
+
+extern "C" void
+LLVMWriteTwineToString(LLVMTwineRef T, RustStringRef str) {
+    raw_rust_string_ostream os(str);
+    unwrap(T)->print(os);
+}
+
+extern "C" void
+LLVMUnpackOptimizationDiagnostic(
+    LLVMDiagnosticInfoRef di,
+    const char **pass_name_out,
+    LLVMValueRef *function_out,
+    LLVMDebugLocRef *debugloc_out,
+    LLVMTwineRef *message_out)
+{
+    // Undefined to call this not on an optimization diagnostic!
+    llvm::DiagnosticInfoOptimizationBase *opt
+        = static_cast<llvm::DiagnosticInfoOptimizationBase*>(unwrap(di));
+
+    *pass_name_out = opt->getPassName();
+    *function_out = wrap(&opt->getFunction());
+    *debugloc_out = wrap(&opt->getDebugLoc());
+    *message_out = wrap(&opt->getMsg());
+}
+
+extern "C" void LLVMWriteDiagnosticInfoToString(LLVMDiagnosticInfoRef di, RustStringRef str) {
+    raw_rust_string_ostream os(str);
+    DiagnosticPrinterRawOStream dp(os);
+    unwrap(di)->print(dp);
+}
+
+extern "C" int LLVMGetDiagInfoKind(LLVMDiagnosticInfoRef di) {
+    return unwrap(di)->getKind();
+}
+
+extern "C" void LLVMWriteDebugLocToString(
+    LLVMContextRef C,
+    LLVMDebugLocRef dl,
+    RustStringRef str)
+{
+    raw_rust_string_ostream os(str);
+    unwrap(dl)->print(*unwrap(C), os);
 }

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -645,22 +645,18 @@ extern "C" void LLVMDICompositeTypeSetTypeArray(
 #endif
 }
 
-extern "C" char *LLVMTypeToString(LLVMTypeRef Type) {
-    std::string s;
-    llvm::raw_string_ostream os(s);
+extern "C" void LLVMWriteTypeToString(LLVMTypeRef Type, RustStringRef str) {
+    raw_rust_string_ostream os(str);
     unwrap<llvm::Type>(Type)->print(os);
-    return strdup(os.str().data());
 }
 
-extern "C" char *LLVMValueToString(LLVMValueRef Value) {
-    std::string s;
-    llvm::raw_string_ostream os(s);
+extern "C" void LLVMWriteValueToString(LLVMValueRef Value, RustStringRef str) {
+    raw_rust_string_ostream os(str);
     os << "(";
     unwrap<llvm::Value>(Value)->getType()->print(os);
     os << ":";
     unwrap<llvm::Value>(Value)->print(os);
     os << ")";
-    return strdup(os.str().data());
 }
 
 #if LLVM_VERSION_MINOR >= 5

--- a/src/rustllvm/rustllvm.h
+++ b/src/rustllvm/rustllvm.h
@@ -71,6 +71,8 @@
 void LLVMRustSetLastError(const char*);
 
 typedef struct OpaqueRustString *RustStringRef;
+typedef struct LLVMOpaqueTwine *LLVMTwineRef;
+typedef struct LLVMOpaqueDebugLoc *LLVMDebugLocRef;
 
 extern "C" void
 rust_llvm_string_write_impl(RustStringRef str, const char *ptr, size_t size);

--- a/src/rustllvm/rustllvm.h
+++ b/src/rustllvm/rustllvm.h
@@ -69,3 +69,31 @@
 #endif
 
 void LLVMRustSetLastError(const char*);
+
+typedef struct OpaqueRustString *RustStringRef;
+
+extern "C" void
+rust_llvm_string_write_impl(RustStringRef str, const char *ptr, size_t size);
+
+class raw_rust_string_ostream : public llvm::raw_ostream  {
+    RustStringRef str;
+    uint64_t pos;
+
+    void write_impl(const char *ptr, size_t size) override {
+        rust_llvm_string_write_impl(str, ptr, size);
+        pos += size;
+    }
+
+    uint64_t current_pos() const override {
+        return pos;
+    }
+
+public:
+    explicit raw_rust_string_ostream(RustStringRef str)
+        : str(str), pos(0) { }
+
+    ~raw_rust_string_ostream() {
+        // LLVM requires this.
+        flush();
+    }
+};


### PR DESCRIPTION
I would like to map this information back to AST nodes, so that we can print remarks with spans, and so that remarks can be enabled on a per-function basis.  Unfortunately, doing this would require a lot more code restructuring — for example, we currently throw away the AST map and lots of other information before LLVM optimizations run.  So for the time being, we print the remarks with debug location strings from LLVM.  There's a warning if you use `-C remark` without `--debuginfo`.

Fixes #17116.
