### PR TITLE
update vim indent file

### DIFF
--- a/src/etc/vim/indent/rust.vim
+++ b/src/etc/vim/indent/rust.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:         Rust
 " Author:           Chris Morgan <me@chrismorgan.info>
-" Last Change:      2013 Oct 29
+" Last Change:      2014 Sep 13
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -10,7 +10,7 @@ endif
 let b:did_indent = 1
 
 setlocal cindent
-setlocal cinoptions=L0,(0,Ws,JN,j1
+setlocal cinoptions=L0,(0,Ws,J1,j1
 setlocal cinkeys=0{,0},!^F,o,O,0[,0]
 " Don't think cinwords will actually do anything at all... never mind
 setlocal cinwords=for,if,else,while,loop,impl,mod,unsafe,trait,struct,enum,fn,extern
@@ -151,42 +151,7 @@ function GetRustIndent(lnum)
 		"
 		" There are probably other cases where we don't want to do this as
 		" well. Add them as needed.
-		return GetRustIndent(a:lnum - 1)
-	endif
-
-	" cindent doesn't do the module scope well at all; e.g.::
-	"
-	" static FOO : &'static [bool] = [
-	" true,
-	"     false,
-	"     false,
-	"     true,
-	"     ];
-	"
-	"     uh oh, next statement is indented further!
-
-	" Note that this does *not* apply the line continuation pattern properly;
-	" that's too hard to do correctly for my liking at present, so I'll just
-	" start with these two main cases (square brackets and not returning to
-	" column zero)
-
-	call cursor(a:lnum, 1)
-	if searchpair('{\|(', '', '}\|)', 'nbW',
-				\ 's:is_string_comment(line("."), col("."))') == 0
-		if searchpair('\[', '', '\]', 'nbW',
-					\ 's:is_string_comment(line("."), col("."))') == 0
-			" Global scope, should be zero
-			return 0
-		else
-			" At the module scope, inside square brackets only
-			"if getline(a:lnum)[0] == ']' || search('\[', '', '\]', 'nW') == a:lnum
-			if line =~ "^\\s*]"
-				" It's the closing line, dedent it
-				return 0
-			else
-				return &shiftwidth
-			endif
-		endif
+		return indent(prevlinenum)
 	endif
 
 	" Fall back on cindent, which does it mostly right


### PR DESCRIPTION
There are currently two huge problems with the indent file:
1. Long list-like things cannot be indented. See #14446 for one example. Another one is long enums with over 100 lines, including comments. The indentation process stops after 100 lines and the rest is in column 0.
2. In certain files, opening a new line at mod level is extremely slow. See [this](https://github.com/mahkoh/posix.rs/blob/master/src/unistd/mod.rs) for an example. Opening a line at the very end and holing <cr> down will freeze vim temporarily.

The reason for 1. is that cindent doesn't properly indent things that end with a `,` and the indent file tries to work around this by using the indentation of the previous line. It does this by recursively calling a function on the previous lines until it reaches the start of the block. Naturally O(n^2) function calls don't scale very well. Instead of recalculating the indentation of the previous line, we will now simply use the given indentation of the previous line and let the user deal with the rest. This is sufficient unless the user manually mis-indents a line.

The reason for 2. seems to be function calls of the form

```
searchpair('{\|(', '', '}\|)', 'nbW', 's:is_string_comment(line("."), col("."))')
```

I've no idea what this even does or why it is there since I cannot reproduce the mistake cindent is supposed to make without this fix. Therefore I've simply removed that part.
