### PR TITLE
Fix unsafety in StrInterner

### DIFF
--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -19,7 +19,6 @@ use std::cell::RefCell;
 use std::cmp::Equiv;
 use std::fmt;
 use std::hash::Hash;
-use std::mem;
 use std::rc::Rc;
 
 pub struct Interner<T> {
@@ -190,16 +189,6 @@ impl StrInterner {
 
     pub fn get(&self, idx: Name) -> RcStr {
         (*self.vect.borrow().get(idx.uint())).clone()
-    }
-
-    /// Returns this string with lifetime tied to the interner. Since
-    /// strings may never be removed from the interner, this is safe.
-    pub fn get_ref<'a>(&'a self, idx: Name) -> &'a str {
-        let vect = self.vect.borrow();
-        let s: &str = vect.get(idx.uint()).as_slice();
-        unsafe {
-            mem::transmute(s)
-        }
     }
 
     pub fn len(&self) -> uint {


### PR DESCRIPTION
The `StrInterner::clear()` method takes self immutably but can invalidate references returned by `StrInterner::get_ref`. Since `get_ref` is unused, just remove it.

Closes #17181 
