### PR TITLE
Detect whether cc (the linker) is gcc or clang.

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -16,6 +16,7 @@ use super::svh::Svh;
 use super::write::{OutputTypeBitcode, OutputTypeExe, OutputTypeObject};
 use driver::driver::{CrateTranslation, OutputFilenames, Input, FileInput};
 use driver::config::NoDebugInfo;
+use driver::session::{CcArgumentsFormat, GccArguments};
 use driver::session::Session;
 use driver::config;
 use metadata::common::LinkMeta;
@@ -71,7 +72,6 @@ pub static RLIB_BYTECODE_OBJECT_V1_DATASIZE_OFFSET: uint =
 // version 1
 pub static RLIB_BYTECODE_OBJECT_V1_DATA_OFFSET: uint =
     RLIB_BYTECODE_OBJECT_V1_DATASIZE_OFFSET + 8;
-
 
 /*
  * Name mangling and its relationship to metadata. This is complex. Read
@@ -378,29 +378,6 @@ pub fn mangle_internal_name_by_type_and_seq(ccx: &CrateContext,
 
 pub fn mangle_internal_name_by_path_and_seq(path: PathElems, flav: &str) -> String {
     mangle(path.chain(Some(gensym_name(flav)).move_iter()), None)
-}
-
-pub fn get_cc_prog(sess: &Session) -> String {
-    match sess.opts.cg.linker {
-        Some(ref linker) => return linker.to_string(),
-        None => {}
-    }
-
-    // In the future, FreeBSD will use clang as default compiler.
-    // It would be flexible to use cc (system's default C compiler)
-    // instead of hard-coded gcc.
-    // For Windows, there is no cc command, so we add a condition to make it use gcc.
-    match sess.targ_cfg.os {
-        abi::OsWindows => "gcc",
-        _ => "cc",
-    }.to_string()
-}
-
-pub fn get_ar_prog(sess: &Session) -> String {
-    match sess.opts.cg.ar {
-        Some(ref ar) => (*ar).clone(),
-        None => "ar".to_string()
-    }
 }
 
 pub fn remove(sess: &Session, path: &Path) {
@@ -811,11 +788,11 @@ fn link_natively(sess: &Session, trans: &CrateTranslation, dylib: bool,
     let tmpdir = TempDir::new("rustc").ok().expect("needs a temp dir");
 
     // The invocations of cc share some flags across platforms
-    let pname = get_cc_prog(sess);
-    let mut cmd = Command::new(pname.as_slice());
+    let (pname, args_fmt) = sess.get_cc_prog();
+    let mut cmd = Command::new(pname);
 
     cmd.args(sess.targ_cfg.target_strs.cc_args.as_slice());
-    link_args(&mut cmd, sess, dylib, tmpdir.path(),
+    link_args(&mut cmd, args_fmt, sess, dylib, tmpdir.path(),
               trans, obj_filename, out_filename);
 
     if (sess.opts.debugging_opts & config::PRINT_LINK_ARGS) != 0 {
@@ -867,6 +844,7 @@ fn link_natively(sess: &Session, trans: &CrateTranslation, dylib: bool,
 }
 
 fn link_args(cmd: &mut Command,
+             args_fmt: CcArgumentsFormat,
              sess: &Session,
              dylib: bool,
              tmpdir: &Path,
@@ -929,8 +907,13 @@ fn link_args(cmd: &mut Command,
         cmd.arg("-nodefaultlibs");
     }
 
-    // Rust does its' own LTO
-    cmd.arg("-fno-lto").arg("-fno-use-linker-plugin");
+    // Rust does its own LTO
+    cmd.arg("-fno-lto");
+
+    // clang fails hard if -fno-use-linker-plugin is passed
+    if args_fmt == GccArguments {
+        cmd.arg("-fno-use-linker-plugin");
+    }
 
     // If we're building a dylib, we don't use --gc-sections because LLVM has
     // already done the best it can do, and we also don't want to eliminate the

--- a/src/librustc/back/write.rs
+++ b/src/librustc/back/write.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use back::lto;
-use back::link::{get_cc_prog, remove};
+use back::link::{remove};
 use driver::driver::{CrateTranslation, ModuleTranslation, OutputFilenames};
 use driver::config::NoDebugInfo;
 use driver::session::Session;
@@ -632,8 +632,8 @@ pub fn run_passes(sess: &Session,
                 None
             };
 
-        let pname = get_cc_prog(sess);
-        let mut cmd = Command::new(pname.as_slice());
+        let pname = sess.get_cc_prog_str();
+        let mut cmd = Command::new(pname);
 
         cmd.args(sess.targ_cfg.target_strs.cc_args.as_slice());
         cmd.arg("-nostdlib");
@@ -828,8 +828,8 @@ fn run_work_multithreaded(sess: &Session,
 }
 
 pub fn run_assembler(sess: &Session, outputs: &OutputFilenames) {
-    let pname = get_cc_prog(sess);
-    let mut cmd = Command::new(pname.as_slice());
+    let pname = sess.get_cc_prog_str();
+    let mut cmd = Command::new(pname);
 
     cmd.arg("-c").arg("-o").arg(outputs.path(OutputTypeObject))
                            .arg(outputs.temp_path(OutputTypeAssembly));


### PR DESCRIPTION
Detect whether cc (the linker) is gcc or clang.

Use this information to drive which options are added to the `cc`
command line arguments.

As a drive-by, fix an english grammar mistake in a comment.

This is meant to be, in part, a more robust version of PR #17192.

Fix #17214.
