### PR TITLE
Allow syntax extensions to return multiple items, closes #16723

### DIFF
--- a/src/libsyntax/diagnostics/plugin.rs
+++ b/src/libsyntax/diagnostics/plugin.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use ast;
 use ast::{Ident, Name, TokenTree};
 use codemap::Span;
-use ext::base::{ExtCtxt, MacExpr, MacItem, MacResult};
+use ext::base::{ExtCtxt, MacExpr, MacResult, MacItems};
 use ext::build::AstBuilder;
 use parse::token;
 use ptr::P;
@@ -102,7 +102,7 @@ pub fn expand_register_diagnostic<'cx>(ecx: &'cx mut ExtCtxt,
     let sym = Ident::new(token::gensym((
         "__register_diagnostic_".to_string() + token::get_ident(*code).get()
     ).as_slice()));
-    MacItem::new(quote_item!(ecx, mod $sym {}).unwrap())
+    MacItems::new(vec![quote_item!(ecx, mod $sym {}).unwrap()].into_iter())
 }
 
 pub fn expand_build_diagnostic_array<'cx>(ecx: &'cx mut ExtCtxt,
@@ -133,7 +133,7 @@ pub fn expand_build_diagnostic_array<'cx>(ecx: &'cx mut ExtCtxt,
             (descriptions.len(), ecx.expr_vec(span, descriptions))
         })
     });
-    MacItem::new(quote_item!(ecx,
+    MacItems::new(vec![quote_item!(ecx,
         pub static $name: [(&'static str, &'static str), ..$count] = $expr;
-    ).unwrap())
+    ).unwrap()].into_iter())
 }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -203,25 +203,20 @@ impl MacResult for MacPat {
         Some(self.p)
     }
 }
-/// A convenience type for macros that return a single item.
-pub struct MacItem {
-    i: P<ast::Item>
+/// A type for macros that return multiple items.
+pub struct MacItems {
+    items: SmallVector<P<ast::Item>>
 }
-impl MacItem {
-    pub fn new(i: P<ast::Item>) -> Box<MacResult+'static> {
-        box MacItem { i: i } as Box<MacResult+'static>
+
+impl MacItems {
+    pub fn new<I: Iterator<P<ast::Item>>>(mut it: I) -> Box<MacResult+'static> {
+        box MacItems { items: it.collect() } as Box<MacResult+'static>
     }
 }
-impl MacResult for MacItem {
-    fn make_items(self: Box<MacItem>) -> Option<SmallVector<P<ast::Item>>> {
-        Some(SmallVector::one(self.i))
-    }
-    fn make_stmt(self: Box<MacItem>) -> Option<P<ast::Stmt>> {
-        Some(P(codemap::respan(
-            self.i.span,
-            ast::StmtDecl(
-                P(codemap::respan(self.i.span, ast::DeclItem(self.i))),
-                ast::DUMMY_NODE_ID))))
+
+impl MacResult for MacItems {
+    fn make_items(self: Box<MacItems>) -> Option<SmallVector<P<ast::Item>>> {
+        Some(self.items)
     }
 }
 

--- a/src/test/auxiliary/issue_16723_multiple_items_syntax_ext.rs
+++ b/src/test/auxiliary/issue_16723_multiple_items_syntax_ext.rs
@@ -1,0 +1,33 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// ignore-stage1
+#![feature(plugin_registrar, managed_boxes, quote)]
+#![crate_type = "dylib"]
+
+extern crate syntax;
+extern crate rustc;
+
+use syntax::ast;
+use syntax::codemap;
+use syntax::ext::base::{ExtCtxt, MacResult, MacItems};
+use rustc::plugin::Registry;
+
+#[plugin_registrar]
+pub fn plugin_registrar(reg: &mut Registry) {
+    reg.register_macro("multiple_items", expand)
+}
+
+fn expand(cx: &mut ExtCtxt, _: codemap::Span, _: &[ast::TokenTree]) -> Box<MacResult+'static> {
+    MacItems::new(vec![
+        quote_item!(cx, struct Struct1;).unwrap(),
+        quote_item!(cx, struct Struct2;).unwrap()
+    ].into_iter())
+}

--- a/src/test/run-pass-fulldeps/issue_16723_multiple_items_syntax_ext.rs
+++ b/src/test/run-pass-fulldeps/issue_16723_multiple_items_syntax_ext.rs
@@ -1,0 +1,30 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-stage1
+// aux-build:issue_16723_multiple_items_syntax_ext.rs
+#![feature(phase)]
+
+#[phase(plugin)] extern crate issue_16723_multiple_items_syntax_ext;
+
+multiple_items!()
+
+impl Struct1 {
+    fn foo() {}
+}
+impl Struct2 {
+    fn foo() {}
+}
+
+fn main() {
+    Struct1::foo();
+    Struct2::foo();
+    println!("hallo");
+}


### PR DESCRIPTION
This is PR is basically the change proposed by @SimonSapin for #16723. I can also extend MacItem, as @huonw  suggested, but I'm not sure how that was meant exactly. A comment for MacItem states that it's a convenience type for macros that return a single item. Should I adapt MacItem to contain a SmallVector of items instead of a single item and update the comment?

And I've two questions concerning the patch.

First, I am not sure what's the best way to duplicate the SmallVector holding the items. The way I'm doing it at the moment strikes me as suboptimal (https://github.com/fhahn/rust/compare/issue-16723-multiple-items?expand=1#diff-5100da09ad52c81568562e36ee359343R241). An additional map() call is required, because `iter()` returns an iterator to pointers to the elements. Is there a better way? Should I open a ticket and implement `clone()` for `SmallVector`?

And second, I had problems running the test in the test suite because it complains that there is no name `MacItems` in `syntax::base::ext` although there is. When I compile the file with 

```
 LD_LIBRARY_PATH=x86_64-unknown-linux-gnu/stage2/lib/ 
 x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/bin/rustc 
 -L x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib/ 
 src/test/auxiliary/issue_16723_multiple_items_syntax_ext.rs 
```

it works. But I'm not sure which `rustc` binary should be used, e.g. there is on stage1 build in `x86_64-unknown-linux-gnu/stage1/bin/rustc` and one in `x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/bin/rustc`.
