### PR TITLE
Fix resource leak in for loops

### DIFF
--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -357,7 +357,10 @@ pub fn trans_for<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
 
     // Codegen the body.
     body_bcx_out = trans_block(body_bcx_out, body, expr::Ignore);
-    body_bcx_out.fcx.pop_custom_cleanup_scope(binding_cleanup_scope);
+    body_bcx_out =
+        body_bcx_out.fcx
+                    .pop_and_trans_custom_cleanup_scope(body_bcx_out,
+                                                        binding_cleanup_scope);
     body_bcx_out =
         body_bcx_out.fcx
                     .pop_and_trans_custom_cleanup_scope(body_bcx_out,

--- a/src/test/run-pass/issue-17216.rs
+++ b/src/test/run-pass/issue-17216.rs
@@ -1,0 +1,32 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unsafe_destructor)]
+
+struct Leak<'a> {
+    dropped: &'a mut bool
+}
+
+#[unsafe_destructor]
+impl<'a> Drop for Leak<'a> {
+    fn drop(&mut self) {
+        *self.dropped = true;
+    }
+}
+
+fn main() {
+    let mut dropped = false;
+    {
+        let leak = Leak { dropped: &mut dropped };
+        for ((), leaked) in Some(((),leak)).move_iter() {}
+    }
+
+    assert!(dropped);
+}


### PR DESCRIPTION
Trans the cleanup scope of for loop bindings so we don't leak resources.  Regression test included.

Closes #17216
