### PR TITLE
Display the doc-block toggle on everything again.

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -762,7 +762,7 @@
 
         $(".method").each(function() {
            if ($(this).next().is(".docblock")) {
-               $(this).children().first().after(toggle[0]);
+               $(this).children().first().after(toggle.clone());
            }
         });
 


### PR DESCRIPTION
This needs a clone otherwise each successive insertion detaches `toggle`
from the previous position.

Fixes #17125.
