### PR TITLE
impl ExactSize for vec::MoveItems

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1662,6 +1662,8 @@ impl<T> DoubleEndedIterator<T> for MoveItems<T> {
     }
 }
 
+impl<T> ExactSize<T> for MoveItems<T> {}
+
 #[unsafe_destructor]
 impl<T> Drop for MoveItems<T> {
     fn drop(&mut self) {


### PR DESCRIPTION
Seems to correctly report exact size, so it should claim to do so formally.
