### PR TITLE
fix for platform inconsistency in creation time

### DIFF
--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -455,11 +455,22 @@ fn mkstat(stat: &libc::stat) -> rtio::FileStat {
     #[cfg(target_os = "linux")] #[cfg(target_os = "android")]
     fn gen(_stat: &libc::stat) -> u64 { 0 }
 
+    #[cfg(not(target_os = "linux"), not(target_os = "android"))]
+    fn created(stat: &libc::stat) -> u64 { mktime(stat.st_ctime as u64, stat.st_ctime_nsec as u64) }
+    #[cfg(target_os = "linux")] #[cfg(target_os = "android")]
+    fn created(_stat: &libc::stat) -> u64 { 0 }
+
+    #[cfg(not(target_os = "linux"), not(target_os = "android"))]
+    fn changed(_stat: &libc::stat) -> u64 { 0 }
+    #[cfg(target_os = "linux")] #[cfg(target_os = "android")]
+    fn changed(stat: &libc::stat) -> u64 { mktime(stat.st_ctime as u64, stat.st_ctime_nsec as u64) }
+
     rtio::FileStat {
         size: stat.st_size as u64,
         kind: stat.st_mode as u64,
         perm: stat.st_mode as u64,
-        created: mktime(stat.st_ctime as u64, stat.st_ctime_nsec as u64),
+        created: created(stat),
+        changed: changed(stat),
         modified: mktime(stat.st_mtime as u64, stat.st_mtime_nsec as u64),
         accessed: mktime(stat.st_atime as u64, stat.st_atime_nsec as u64),
         device: stat.st_dev as u64,

--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -460,11 +460,11 @@ fn mkstat(stat: &libc::stat) -> rtio::FileStat {
     #[cfg(target_os = "windows")]
     fn created(stat: &libc::stat) -> u64 { mktime(stat.st_ctime as u64, stat.st_ctime_nsec as u64) }
     #[cfg(target_os = "macos", target_arch = "x86_64")]
-    fn created(stat: &libc::stat) -> u64 { 
+    fn created(stat: &libc::stat) -> u64 {
         mktime(stat.st_birthtime as u64, stat.st_birthtime_nsec as u64)
     }
     #[cfg(target_os = "freebsd")]
-    fn created(stat: &libc::stat) -> u64 { 
+    fn created(stat: &libc::stat) -> u64 {
         mktime(stat.st_birthtime as u64, stat.st_birthtime_nsec as u64)
     }
     #[cfg(target_family = "unix")]

--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -465,7 +465,7 @@ fn mkstat(stat: &libc::stat) -> rtio::FileStat {
     fn created(stat: &libc::stat) -> u64 { mktime(stat.st_birthtime as u64, stat.st_birthtime_nsec as u64) }
 
     #[cfg(target_family = "unix")]
-    fn created(stat: &libc::stat) -> u64 { mktime(stat.st_ctime as u64, stat.st_ctime_nsec as u64) }
+    fn changed(stat: &libc::stat) -> u64 { mktime(stat.st_ctime as u64, stat.st_ctime_nsec as u64) }
     #[cfg(target_os = "windows")]
     fn changed(_stat: &libc::stat) -> u64 { 0 }
 

--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -455,15 +455,19 @@ fn mkstat(stat: &libc::stat) -> rtio::FileStat {
     #[cfg(target_os = "linux")] #[cfg(target_os = "android")]
     fn gen(_stat: &libc::stat) -> u64 { 0 }
 
-    #[cfg(not(target_os = "linux"), not(target_os = "android"))]
-    fn created(stat: &libc::stat) -> u64 { mktime(stat.st_ctime as u64, stat.st_ctime_nsec as u64) }
-    #[cfg(target_os = "linux")] #[cfg(target_os = "android")]
+    #[cfg(target_os = "linux")]
     fn created(_stat: &libc::stat) -> u64 { 0 }
+    #[cfg(target_os = "windows")]
+    fn created(stat: &libc::stat) -> u64 { mktime(stat.st_ctime as u64, stat.st_ctime_nsec as u64) }
+    #[cfg(target_os = "macos", target_arch = "x86_64")]
+    fn created(stat: &libc::stat) -> u64 { mktime(stat.st_birthtime as u64, stat.st_birthtime_nsec as u64) }
+    #[cfg(target_os = "freebsd")]
+    fn created(stat: &libc::stat) -> u64 { mktime(stat.st_birthtime as u64, stat.st_birthtime_nsec as u64) }
 
-    #[cfg(not(target_os = "linux"), not(target_os = "android"))]
+    #[cfg(target_family = "unix")]
+    fn created(stat: &libc::stat) -> u64 { mktime(stat.st_ctime as u64, stat.st_ctime_nsec as u64) }
+    #[cfg(target_os = "windows")]
     fn changed(_stat: &libc::stat) -> u64 { 0 }
-    #[cfg(target_os = "linux")] #[cfg(target_os = "android")]
-    fn changed(stat: &libc::stat) -> u64 { mktime(stat.st_ctime as u64, stat.st_ctime_nsec as u64) }
 
     rtio::FileStat {
         size: stat.st_size as u64,

--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -460,10 +460,13 @@ fn mkstat(stat: &libc::stat) -> rtio::FileStat {
     #[cfg(target_os = "windows")]
     fn created(stat: &libc::stat) -> u64 { mktime(stat.st_ctime as u64, stat.st_ctime_nsec as u64) }
     #[cfg(target_os = "macos", target_arch = "x86_64")]
-    fn created(stat: &libc::stat) -> u64 { mktime(stat.st_birthtime as u64, stat.st_birthtime_nsec as u64) }
+    fn created(stat: &libc::stat) -> u64 { 
+        mktime(stat.st_birthtime as u64, stat.st_birthtime_nsec as u64)
+    }
     #[cfg(target_os = "freebsd")]
-    fn created(stat: &libc::stat) -> u64 { mktime(stat.st_birthtime as u64, stat.st_birthtime_nsec as u64) }
-
+    fn created(stat: &libc::stat) -> u64 { 
+        mktime(stat.st_birthtime as u64, stat.st_birthtime_nsec as u64)
+    }
     #[cfg(target_family = "unix")]
     fn changed(stat: &libc::stat) -> u64 { mktime(stat.st_ctime as u64, stat.st_ctime_nsec as u64) }
     #[cfg(target_os = "windows")]

--- a/src/librustrt/rtio.rs
+++ b/src/librustrt/rtio.rs
@@ -417,6 +417,7 @@ pub struct FileStat {
     pub kind: u64,
     pub perm: u64,
     pub created: u64,
+    pub changed: u64,
     pub modified: u64,
     pub accessed: u64,
     pub device: u64,

--- a/src/librustuv/file.rs
+++ b/src/librustuv/file.rs
@@ -283,6 +283,7 @@ impl FsRequest {
             kind: stat.st_mode as u64,
             perm: stat.st_mode as u64,
             created: to_msec(stat.st_birthtim),
+            changed: to_msec(stat.st_ctim),
             modified: to_msec(stat.st_mtim),
             accessed: to_msec(stat.st_atim),
             device: stat.st_dev as u64,

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -374,7 +374,7 @@ fn from_rtio(s: rtio::FileStat) -> FileStat {
     type Mode = libc::mode_t;
 
     let rtio::FileStat {
-        size, kind, perm, created, modified,
+        size, kind, perm, created, changed, modified,
         accessed, device, inode, rdev,
         nlink, uid, gid, blksize, blocks, flags, gen
     } = s;
@@ -391,6 +391,7 @@ fn from_rtio(s: rtio::FileStat) -> FileStat {
         },
         perm: FilePermission::from_bits_truncate(perm as u32),
         created: created,
+        changed: changed,
         modified: modified,
         accessed: accessed,
         unstable: UnstableFileStat {

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1748,6 +1748,9 @@ pub struct FileStat {
     /// The time that the file was created at, in platform-dependent
     /// milliseconds
     pub created: u64,
+    /// The time that the file was changed (in metadata or content)
+    /// in platform-dependent milliseconds
+    pub changed: u64,
     /// The time that this file was last modified, in platform-dependent
     /// milliseconds
     pub modified: u64,


### PR DESCRIPTION
this introduces a new field to the filestat struct which accounts for platform differences in time fields.
