### PR TITLE
add missing semicolon to fix configure on darwin

### DIFF
--- a/configure
+++ b/configure
@@ -636,7 +636,7 @@ then
             # check that gcc, cc and g++ all point to the same compiler.
             # note that for xcode 5, g++ points to clang, not clang++
             if !((chk_cc gcc clang  && chk_cc g++ clang) ||
-                (chk_cc gcc gcc  &&( chk_cc g++ g++ || chk g++ gcc))) then
+                (chk_cc gcc gcc  &&( chk_cc g++ g++ || chk g++ gcc))); then
                 err "the gcc and g++ in your path point to different compilers.
     Check which versions are in your path with gcc --version and g++ --version.
     To resolve this problem, either fix your PATH  or run configure with --enable-clang"


### PR DESCRIPTION
A missing semicolon prevents configure from running on OS X when real POSIX shells are used as /bin/sh (pdksh, for example). This change simply adds a semicolon to the statement.
