### PR TITLE
mk: Update how the build deals with version labels. #16677

### DIFF
--- a/configure
+++ b/configure
@@ -453,6 +453,8 @@ valopt datadir "${CFG_PREFIX}/share" "install data"
 valopt infodir "${CFG_PREFIX}/share/info" "install additional info"
 valopt mandir "${CFG_PREFIX}/share/man" "install man pages in PATH"
 
+valopt release-channel "source" "the name of the release channel to build"
+
 # On windows we just store the libraries in the bin directory because
 # there's no rpath. This is where the build system itself puts libraries;
 # --libdir is used to configure the installation directory.
@@ -480,6 +482,23 @@ validate_opt
 CFG_BUILD=`echo "${CFG_BUILD}" | sed 's/-pc-mingw32/-w64-mingw32/g'`
 CFG_HOST=`echo "${CFG_HOST}" | sed 's/-pc-mingw32/-w64-mingw32/g'`
 CFG_TARGET=`echo "${CFG_TARGET}" | sed 's/-pc-mingw32/-w64-mingw32/g'`
+
+# Validate the release channel
+case "$CFG_RELEASE_CHANNEL" in
+    (source | nightly | beta | stable)
+	;;
+    (*)
+        err "release channel must be 'source', 'nightly', 'beta' or 'stable'"
+        ;;
+esac
+
+# Continue supporting the old --enable-nightly flag to transition the bots
+# XXX Remove me
+if [ $CFG_ENABLE_NIGHTLY -eq 1 ]
+then
+    CFG_RELEASE_CHANNEL=nightly
+    putvar CFG_RELEASE_CHANNEL
+fi
 
 step_msg "looking for build programs"
 

--- a/man/rustc.1
+++ b/man/rustc.1
@@ -1,4 +1,4 @@
-.TH RUSTC "1" "March 2014" "rustc 0.12.0-pre" "User Commands"
+.TH RUSTC "1" "March 2014" "rustc 0.12.0" "User Commands"
 .SH NAME
 rustc \- The Rust compiler
 .SH SYNOPSIS

--- a/man/rustdoc.1
+++ b/man/rustdoc.1
@@ -1,4 +1,4 @@
-.TH RUSTDOC "1" "March 2014" "rustdoc 0.12.0-pre" "User Commands"
+.TH RUSTDOC "1" "March 2014" "rustdoc 0.12.0" "User Commands"
 .SH NAME
 rustdoc \- generate documentation from Rust source code
 .SH SYNOPSIS

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -14,22 +14,32 @@
 
 # The version number
 CFG_RELEASE_NUM=0.12.0
-CFG_RELEASE_LABEL=-pre
 
 CFG_FILENAME_EXTRA=4e7c5e5c
 
-ifndef CFG_ENABLE_NIGHTLY
-# This is the normal version string
-CFG_RELEASE=$(CFG_RELEASE_NUM)$(CFG_RELEASE_LABEL)
-CFG_PACKAGE_VERS=$(CFG_RELEASE)
-else
-# Modify the version label for nightly builds
-CFG_RELEASE=$(CFG_RELEASE_NUM)$(CFG_RELEASE_LABEL)-nightly
-# When building nightly distributables just reuse the same "rust-nightly" name
-# so when we upload we'll always override the previous nighly. This doesn't actually
-# impact the version reported by rustc - it's just for file naming.
+ifeq ($(CFG_RELEASE_CHANNEL),stable)
+# This is the normal semver version string, e.g. "0.12.0", "0.12.0-nightly"
+CFG_RELEASE=$(CFG_RELEASE_NUM)
+# This is the string used in dist artifact file names, e.g. "0.12.0", "nightly"
+CFG_PACKAGE_VERS=$(CFG_RELEASE_NUM)
+endif
+ifeq ($(CFG_RELEASE_CHANNEL),beta)
+CFG_RELEASE=$(CFG_RELEASE_NUM)-beta
+# When building beta/nightly distributables just reuse the same "beta"
+# name so when we upload we'll always override the previous
+# nighly. This doesn't actually impact the version reported by rustc -
+# it's just for file naming.
+CFG_PACKAGE_VERS=beta
+endif
+ifeq ($(CFG_RELEASE_CHANNEL),nightly)
+CFG_RELEASE=$(CFG_RELEASE_NUM)-nightly
 CFG_PACKAGE_VERS=nightly
 endif
+ifeq ($(CFG_RELEASE_CHANNEL),source)
+CFG_RELEASE=$(CFG_RELEASE_NUM)-pre
+CFG_PACKAGE_VERS=$(CFG_RELEASE_NUM)-pre
+endif
+
 # The name of the package to use for creating tarballs, installers etc.
 CFG_PACKAGE_NAME=rust-$(CFG_PACKAGE_VERS)
 

--- a/src/etc/kate/rust.xml
+++ b/src/etc/kate/rust.xml
@@ -7,7 +7,7 @@
 	<!ENTITY rustIdent "[a-zA-Z_][a-zA-Z_0-9]*">
 	<!ENTITY rustIntSuf "([iu](8|16|32|64)?)?">
 ]>
-<language name="Rust" version="0.12.0-pre" kateversion="2.4" section="Sources" extensions="*.rs" mimetype="text/x-rust" priority="15">
+<language name="Rust" version="0.12.0" kateversion="2.4" section="Sources" extensions="*.rs" mimetype="text/x-rust" priority="15">
 <highlighting>
 	<list name="fn">
 		<item> fn </item>


### PR DESCRIPTION
Adds a new configure flag, --release-channel, which determines how the version
number should be augmented with a release label, as well as how the distribution
artifacts will be named. This is entirely for use by the build automation.

--release-channel can be either 'source', 'nightly', 'beta', or 'stable'.

Here's a summary of the affect of these values on version number and
artifact naming, respectively:
- source - '0.12.0-pre', 'rust-0.12.0-pre-...'
- nightly - '0.12.0-nightly', 'rust-nightly-...'
- beta - '0.12.0-beta', 'rust-beta-...'
- stable - '0.12.0', 'rust-0.12.0-...'

Per http://discuss.rust-lang.org/t/rfc-impending-changes-to-the-release-process/508/1

The only immediate practical impact of this is that nightlies will now be versioned `0.12.0-nightly` instead of `0.12.0-pre-nightly`.

r? @alexcrichton 
