### PR TITLE
stop spawning so many tasks in guide-tasks

### DIFF
--- a/src/doc/guide-tasks.md
+++ b/src/doc/guide-tasks.md
@@ -235,7 +235,7 @@ fn partial_sum(start: uint) -> f64 {
 }
 
 fn main() {
-    let mut futures = Vec::from_fn(1000, |ind| Future::spawn( proc() { partial_sum(ind) }));
+    let mut futures = Vec::from_fn(200, |ind| Future::spawn( proc() { partial_sum(ind) }));
 
     let mut final_res = 0f64;
     for ft in futures.mut_iter()  {


### PR DESCRIPTION
1000 tasks \* 2MiB stack size -> 2GiB of virtual memory

On a 64-bit OS, a 32-bit executable has 4GiB available, but the kernel
gets half of the available address space so the limit is 2GiB on 32-bit.

Closes #17044
