### PR TITLE
Correct windows install link in guide

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -29,8 +29,11 @@ $ curl -s https://static.rust-lang.org/rustup.sh | sudo sh
 (If you're concerned about `curl | sudo sh`, please keep reading. Disclaimer
 below.)
 
-If you're on Windows, please [download this .exe and run
-it](https://static.rust-lang.org/dist/rust-nightly-install.exe).
+If you're on Windows, please download either the [32-bit
+installer](https://static.rust-lang.org/dist/rust-nightly-i686-pc-mingw32.exe)
+or the [64-bit
+installer](https://static.rust-lang.org/dist/rust-nightly-x86_64-w64-mingw32.exe)
+and run it.
 
 If you decide you don't want Rust anymore, we'll be a bit sad, but that's okay.
 Not every programming language is great for everyone. Just pass an argument to

--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -30,7 +30,7 @@ $ curl -s https://static.rust-lang.org/rustup.sh | sudo sh
 below.)
 
 If you're on Windows, please download either the [32-bit
-installer](https://static.rust-lang.org/dist/rust-nightly-i686-pc-mingw32.exe)
+installer](https://static.rust-lang.org/dist/rust-nightly-i686-w64-mingw32.exe)
 or the [64-bit
 installer](https://static.rust-lang.org/dist/rust-nightly-x86_64-w64-mingw32.exe)
 and run it.


### PR DESCRIPTION
This closes #17260. The guide references the old install location for
the windows rust install before it was split into 64bit and 32bit
installers. This adds a link to each binary.
