### PR TITLE
Rename std::io::net::unix to std::io::net::pipe.

### DIFF
--- a/src/libstd/io/net/mod.rs
+++ b/src/libstd/io/net/mod.rs
@@ -19,8 +19,7 @@ pub mod addrinfo;
 pub mod tcp;
 pub mod udp;
 pub mod ip;
-// FIXME(#12093) - this should not be called unix
-pub mod unix;
+pub mod pipe;
 
 fn to_rtio(ip: IpAddr) -> rtio::IpAddr {
     match ip {

--- a/src/libstd/io/net/pipe.rs
+++ b/src/libstd/io/net/pipe.rs
@@ -46,7 +46,7 @@ impl UnixStream {
     ///
     /// ```rust
     /// # #![allow(unused_must_use)]
-    /// use std::io::net::unix::UnixStream;
+    /// use std::io::net::pipe::UnixStream;
     ///
     /// let server = Path::new("path/to/my/socket");
     /// let mut stream = UnixStream::connect(&server);
@@ -164,7 +164,7 @@ impl UnixListener {
     /// # fn main() {}
     /// # fn foo() {
     /// # #![allow(unused_must_use)]
-    /// use std::io::net::unix::UnixListener;
+    /// use std::io::net::pipe::UnixListener;
     /// use std::io::{Listener, Acceptor};
     ///
     /// let server = Path::new("/path/to/my/socket");

--- a/src/libstd/io/test.rs
+++ b/src/libstd/io/test.rs
@@ -34,7 +34,7 @@ macro_rules! iotest (
             use io::net::ip::*;
             use io::net::udp::*;
             #[cfg(unix)]
-            use io::net::unix::*;
+            use io::net::pipe::*;
             use io::timer::*;
             use io::process::*;
             use rt::running_on_valgrind;


### PR DESCRIPTION
Closes #12093
