### PR TITLE
net: Fix some valgrind annoyances

### DIFF
--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -86,6 +86,7 @@ fn addr_to_sockaddr(addr: rtio::SocketAddr,
                 (*storage).sin6_family = libc::AF_INET6 as libc::sa_family_t;
                 (*storage).sin6_port = htons(addr.port);
                 (*storage).sin6_addr = inaddr;
+                (*storage).sin6_flowinfo = 0;
                 mem::size_of::<libc::sockaddr_in6>()
             }
         };

--- a/src/librustuv/net.rs
+++ b/src/librustuv/net.rs
@@ -98,6 +98,7 @@ fn addr_to_sockaddr(addr: rtio::SocketAddr,
                 let storage = storage as *mut _ as *mut libc::sockaddr_in6;
                 (*storage).sin6_family = libc::AF_INET6 as libc::sa_family_t;
                 (*storage).sin6_port = htons(addr.port);
+                (*storage).sin6_flowinfo = 0;
                 (*storage).sin6_addr = libc::in6_addr {
                     s6_addr: [
                         htons(a),


### PR DESCRIPTION
According to valgrind these bytes are always uninitialized, which I don't
understand because the memory is always allocated with mem::zeroed(), but just
to be safe set sin6_flowinfo to 0 unconditionally.
