### PR TITLE
Pop the expansion context after expanding a method macro

### DIFF
--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -42,6 +42,8 @@ pub struct TestProps {
     pub pretty_mode: String,
     // Only compare pretty output and don't try compiling
     pub pretty_compare_only: bool,
+    // Patterns which must not appear in the output of a cfail test.
+    pub forbid_output: Vec<String>,
 }
 
 // Load any test directives embedded in the file
@@ -59,6 +61,7 @@ pub fn load_props(testfile: &Path) -> TestProps {
     let mut no_pretty_expanded = false;
     let mut pretty_mode = None;
     let mut pretty_compare_only = false;
+    let mut forbid_output = Vec::new();
     iter_header(testfile, |ln| {
         match parse_error_pattern(ln) {
           Some(ep) => error_patterns.push(ep),
@@ -116,6 +119,11 @@ pub fn load_props(testfile: &Path) -> TestProps {
             None => ()
         };
 
+        match parse_forbid_output(ln) {
+            Some(of) => forbid_output.push(of),
+            None => (),
+        }
+
         true
     });
 
@@ -132,7 +140,8 @@ pub fn load_props(testfile: &Path) -> TestProps {
         no_prefer_dynamic: no_prefer_dynamic,
         no_pretty_expanded: no_pretty_expanded,
         pretty_mode: pretty_mode.unwrap_or("normal".to_string()),
-        pretty_compare_only: pretty_compare_only
+        pretty_compare_only: pretty_compare_only,
+        forbid_output: forbid_output,
     }
 }
 
@@ -208,6 +217,10 @@ fn iter_header(testfile: &Path, it: |&str| -> bool) -> bool {
 
 fn parse_error_pattern(line: &str) -> Option<String> {
     parse_name_value_directive(line, "error-pattern")
+}
+
+fn parse_forbid_output(line: &str) -> Option<String> {
+    parse_name_value_directive(line, "forbid-output")
 }
 
 fn parse_aux_build(line: &str) -> Option<String> {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -897,7 +897,10 @@ fn expand_method(m: P<ast::Method>, fld: &mut MacroExpander) -> SmallVector<P<as
             };
 
             // expand again if necessary
-            new_methods.into_iter().flat_map(|m| fld.fold_method(m).into_iter()).collect()
+            let new_methods = new_methods.move_iter()
+                                  .flat_map(|m| fld.fold_method(m).into_iter()).collect();
+            fld.cx.bt_pop();
+            new_methods
         }
     })
 }

--- a/src/test/compile-fail/method-macro-backtrace.rs
+++ b/src/test/compile-fail/method-macro-backtrace.rs
@@ -1,0 +1,37 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// forbid-output: in expansion of
+
+#![feature(macro_rules)]
+
+macro_rules! make_method ( ($name:ident) => (
+    fn $name(&self) { }
+))
+
+struct S;
+
+impl S {
+    // We had a bug where these wouldn't clean up macro backtrace frames.
+    make_method!(foo1)
+    make_method!(foo2)
+    make_method!(foo3)
+    make_method!(foo4)
+    make_method!(foo5)
+    make_method!(foo6)
+    make_method!(foo7)
+    make_method!(foo8)
+
+    // Cause an error. It shouldn't have any macro backtrace frames.
+    fn bar(&self) { }
+    fn bar(&self) { } //~ ERROR duplicate definition
+}
+
+fn main() { }


### PR DESCRIPTION
We were leaving these on the stack, causing spurious backtraces.
