### PR TITLE
Fix the inverted RUST_LOG filter

### DIFF
--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -283,7 +283,7 @@ pub fn log(level: u32, loc: &'static LogLocation, args: &fmt::Arguments) {
     // Test the literal string from args against the current filter, if there
     // is one.
     match unsafe { FILTER.as_ref() } {
-        Some(filter) if filter.is_match(args.to_string().as_slice()) => return,
+        Some(filter) if !filter.is_match(args.to_string().as_slice()) => return,
         _ => {}
     }
 
@@ -383,7 +383,7 @@ fn enabled(level: u32,
 
 /// Initialize logging for the current process.
 ///
-/// This is not threadsafe at all, so initialization os performed through a
+/// This is not threadsafe at all, so initialization is performed through a
 /// `Once` primitive (and this function is called from that primitive).
 fn init() {
     let (mut directives, filter) = match os::getenv("RUST_LOG") {

--- a/src/test/run-pass/rust-log-filter.rs
+++ b/src/test/run-pass/rust-log-filter.rs
@@ -1,0 +1,54 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// exec-env:RUST_LOG=rust-log-filter/f.o
+
+#![feature(phase)]
+#[phase(plugin,link)]
+extern crate log;
+
+pub struct ChannelLogger {
+    tx: Sender<String>
+}
+
+impl ChannelLogger {
+    pub fn new() -> (Box<ChannelLogger>, Receiver<String>) {
+        let (tx, rx) = channel();
+        (box ChannelLogger { tx: tx }, rx)
+    }
+}
+
+impl log::Logger for ChannelLogger {
+    fn log(&mut self, record: &log::LogRecord) {
+        self.tx.send(format!("{}", record.args));
+    }
+}
+
+pub fn main() {
+    let (logger, rx) = ChannelLogger::new();
+
+    spawn(proc() {
+        log::set_logger(logger);
+
+        // our regex is "f.o"
+        // ensure it is a regex, and isn't anchored
+        info!("foo");
+        info!("bar");
+        info!("foo bar");
+        info!("bar foo");
+        info!("f1o");
+    });
+
+    assert_eq!(rx.recv().as_slice(), "foo");
+    assert_eq!(rx.recv().as_slice(), "foo bar");
+    assert_eq!(rx.recv().as_slice(), "bar foo");
+    assert_eq!(rx.recv().as_slice(), "f1o");
+    assert!(rx.recv_opt().is_err());
+}


### PR DESCRIPTION
RUST_LOG supports regex filtering of log messages with a syntax like
`RUST_LOG=main/foo` to use the regex filter 'foo'. Unfortunately, the
filter was inverted, so `RUST_LOG=main/foo` would actually show all
messages except the ones containing 'foo'.
