### PR TITLE
Drop a few unused diagnostic codes

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -109,11 +109,6 @@ register_diagnostics!(
     E0092,
     E0093,
     E0094,
-    E0095,
-    E0096,
-    E0097,
-    E0098,
-    E0099,
     E0100,
     E0101,
     E0102,
@@ -153,7 +148,6 @@ register_diagnostics!(
     E0139,
     E0140,
     E0141,
-    E0142,
     E0143,
     E0144,
     E0145,
@@ -169,6 +163,5 @@ register_diagnostics!(
     E0157,
     E0158,
     E0159,
-    E0160,
     E0161
 )


### PR DESCRIPTION
Avoids warnings during bootstrap, similar to:

  src/librustc/lib.rs:149:1: 149:39 warning: diagnostic code E0099 never used
  src/librustc/lib.rs:149 __build_diagnostic_array!(DIAGNOSTICS)

All of these codes stopped being used in this commit:
688ddf7 ("typeck/kind -- stop using old trait framework.")

See also similar fix: https://github.com/rust-lang/rust/issues/16449
