### PR TITLE
Add enum variants to the type namespace

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -872,7 +872,7 @@ mod tests {
 
     use {Mutable, MutableSeq};
     use str;
-    use str::{Str, StrSlice, Owned, Slice};
+    use str::{Str, StrSlice, Owned};
     use super::String;
     use vec::Vec;
 
@@ -898,10 +898,10 @@ mod tests {
     #[test]
     fn test_from_utf8_lossy() {
         let xs = b"hello";
-        assert_eq!(String::from_utf8_lossy(xs), Slice("hello"));
+        assert_eq!(String::from_utf8_lossy(xs), str::Slice("hello"));
 
         let xs = "ศไทย中华Việt Nam".as_bytes();
-        assert_eq!(String::from_utf8_lossy(xs), Slice("ศไทย中华Việt Nam"));
+        assert_eq!(String::from_utf8_lossy(xs), str::Slice("ศไทย中华Việt Nam"));
 
         let xs = b"Hello\xC2 There\xFF Goodbye";
         assert_eq!(String::from_utf8_lossy(xs),

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -23,6 +23,7 @@
 
 use std::char;
 use std::str;
+use std::string;
 
 /// A piece is a portion of the format string which represents the next part
 /// to emit. These are emitted as a stream by the `Parser` class.
@@ -32,7 +33,7 @@ pub enum Piece<'a> {
     String(&'a str),
     /// This describes that formatting should process the next argument (as
     /// specified inside) for emission.
-    Argument(Argument<'a>),
+    NextArgument(Argument<'a>),
 }
 
 /// Representation of an argument specification.
@@ -129,7 +130,7 @@ pub struct Parser<'a> {
     input: &'a str,
     cur: str::CharOffsets<'a>,
     /// Error messages accumulated during parsing
-    pub errors: Vec<String>,
+    pub errors: Vec<string::String>,
 }
 
 impl<'a> Iterator<Piece<'a>> for Parser<'a> {
@@ -140,7 +141,7 @@ impl<'a> Iterator<Piece<'a>> for Parser<'a> {
                 if self.consume('{') {
                     Some(String(self.string(pos + 1)))
                 } else {
-                    let ret = Some(Argument(self.argument()));
+                    let ret = Some(NextArgument(self.argument()));
                     self.must_consume('}');
                     ret
                 }
@@ -469,28 +470,28 @@ mod tests {
 
     #[test]
     fn format_nothing() {
-        same("{}", [Argument(Argument {
+        same("{}", [NextArgument(Argument {
             position: ArgumentNext,
             format: fmtdflt(),
         })]);
     }
     #[test]
     fn format_position() {
-        same("{3}", [Argument(Argument {
+        same("{3}", [NextArgument(Argument {
             position: ArgumentIs(3),
             format: fmtdflt(),
         })]);
     }
     #[test]
     fn format_position_nothing_else() {
-        same("{3:}", [Argument(Argument {
+        same("{3:}", [NextArgument(Argument {
             position: ArgumentIs(3),
             format: fmtdflt(),
         })]);
     }
     #[test]
     fn format_type() {
-        same("{3:a}", [Argument(Argument {
+        same("{3:a}", [NextArgument(Argument {
             position: ArgumentIs(3),
             format: FormatSpec {
                 fill: None,
@@ -504,7 +505,7 @@ mod tests {
     }
     #[test]
     fn format_align_fill() {
-        same("{3:>}", [Argument(Argument {
+        same("{3:>}", [NextArgument(Argument {
             position: ArgumentIs(3),
             format: FormatSpec {
                 fill: None,
@@ -515,7 +516,7 @@ mod tests {
                 ty: "",
             },
         })]);
-        same("{3:0<}", [Argument(Argument {
+        same("{3:0<}", [NextArgument(Argument {
             position: ArgumentIs(3),
             format: FormatSpec {
                 fill: Some('0'),
@@ -526,7 +527,7 @@ mod tests {
                 ty: "",
             },
         })]);
-        same("{3:*<abcd}", [Argument(Argument {
+        same("{3:*<abcd}", [NextArgument(Argument {
             position: ArgumentIs(3),
             format: FormatSpec {
                 fill: Some('*'),
@@ -540,7 +541,7 @@ mod tests {
     }
     #[test]
     fn format_counts() {
-        same("{:10s}", [Argument(Argument {
+        same("{:10s}", [NextArgument(Argument {
             position: ArgumentNext,
             format: FormatSpec {
                 fill: None,
@@ -551,7 +552,7 @@ mod tests {
                 ty: "s",
             },
         })]);
-        same("{:10$.10s}", [Argument(Argument {
+        same("{:10$.10s}", [NextArgument(Argument {
             position: ArgumentNext,
             format: FormatSpec {
                 fill: None,
@@ -562,7 +563,7 @@ mod tests {
                 ty: "s",
             },
         })]);
-        same("{:.*s}", [Argument(Argument {
+        same("{:.*s}", [NextArgument(Argument {
             position: ArgumentNext,
             format: FormatSpec {
                 fill: None,
@@ -573,7 +574,7 @@ mod tests {
                 ty: "s",
             },
         })]);
-        same("{:.10$s}", [Argument(Argument {
+        same("{:.10$s}", [NextArgument(Argument {
             position: ArgumentNext,
             format: FormatSpec {
                 fill: None,
@@ -584,7 +585,7 @@ mod tests {
                 ty: "s",
             },
         })]);
-        same("{:a$.b$s}", [Argument(Argument {
+        same("{:a$.b$s}", [NextArgument(Argument {
             position: ArgumentNext,
             format: FormatSpec {
                 fill: None,
@@ -598,7 +599,7 @@ mod tests {
     }
     #[test]
     fn format_flags() {
-        same("{:-}", [Argument(Argument {
+        same("{:-}", [NextArgument(Argument {
             position: ArgumentNext,
             format: FormatSpec {
                 fill: None,
@@ -609,7 +610,7 @@ mod tests {
                 ty: "",
             },
         })]);
-        same("{:+#}", [Argument(Argument {
+        same("{:+#}", [NextArgument(Argument {
             position: ArgumentNext,
             format: FormatSpec {
                 fill: None,
@@ -623,7 +624,7 @@ mod tests {
     }
     #[test]
     fn format_mixture() {
-        same("abcd {3:a} efg", [String("abcd "), Argument(Argument {
+        same("abcd {3:a} efg", [String("abcd "), NextArgument(Argument {
             position: ArgumentIs(3),
             format: FormatSpec {
                 fill: None,

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -37,7 +37,7 @@ pub fn ntohs(u: u16) -> u16 {
 }
 
 enum InAddr {
-    InAddr(libc::in_addr),
+    In4Addr(libc::in_addr),
     In6Addr(libc::in6_addr),
 }
 
@@ -48,7 +48,7 @@ fn ip_to_inaddr(ip: rtio::IpAddr) -> InAddr {
                      (b as u32 << 16) |
                      (c as u32 <<  8) |
                      (d as u32 <<  0);
-            InAddr(libc::in_addr {
+            In4Addr(libc::in_addr {
                 s_addr: Int::from_be(ip)
             })
         }
@@ -74,7 +74,7 @@ fn addr_to_sockaddr(addr: rtio::SocketAddr,
                     -> libc::socklen_t {
     unsafe {
         let len = match ip_to_inaddr(addr.ip) {
-            InAddr(inaddr) => {
+            In4Addr(inaddr) => {
                 let storage = storage as *mut _ as *mut libc::sockaddr_in;
                 (*storage).sin_family = libc::AF_INET as libc::sa_family_t;
                 (*storage).sin_port = htons(addr.port);
@@ -723,7 +723,7 @@ impl UdpSocket {
     pub fn set_membership(&mut self, addr: rtio::IpAddr,
                           opt: libc::c_int) -> IoResult<()> {
         match ip_to_inaddr(addr) {
-            InAddr(addr) => {
+            In4Addr(addr) => {
                 let mreq = libc::ip_mreq {
                     imr_multiaddr: addr,
                     // interface == INADDR_ANY

--- a/src/libregex/compile.rs
+++ b/src/libregex/compile.rs
@@ -16,7 +16,7 @@ use std::cmp;
 use parse;
 use parse::{
     Flags, FLAG_EMPTY,
-    Nothing, Literal, Dot, Class, Begin, End, WordBoundary, Capture, Cat, Alt,
+    Nothing, Literal, Dot, AstClass, Begin, End, WordBoundary, Capture, Cat, Alt,
     Rep,
     ZeroOne, ZeroMore, OneMore,
 };
@@ -148,7 +148,7 @@ impl<'r> Compiler<'r> {
             Nothing => {},
             Literal(c, flags) => self.push(OneChar(c, flags)),
             Dot(nl) => self.push(Any(nl)),
-            Class(ranges, flags) =>
+            AstClass(ranges, flags) =>
                 self.push(CharClass(ranges, flags)),
             Begin(flags) => self.push(EmptyBegin(flags)),
             End(flags) => self.push(EmptyEnd(flags)),

--- a/src/libregex/lib.rs
+++ b/src/libregex/lib.rs
@@ -425,7 +425,7 @@ pub mod native {
         FLAG_EMPTY, FLAG_NOCASE, FLAG_MULTI, FLAG_DOTNL,
         FLAG_SWAP_GREED, FLAG_NEGATED,
     };
-    pub use re::{Dynamic, Native};
+    pub use re::{Dynamic, ExDynamic, Native, ExNative};
     pub use vm::{
         MatchKind, Exists, Location, Submatches,
         StepState, StepMatchEarlyReturn, StepMatch, StepContinue,

--- a/src/libregex/re.rs
+++ b/src/libregex/re.rs
@@ -110,14 +110,14 @@ pub enum Regex {
     // See the comments for the `program` module in `lib.rs` for a more
     // detailed explanation for what `regex!` requires.
     #[doc(hidden)]
-    Dynamic(Dynamic),
+    Dynamic(ExDynamic),
     #[doc(hidden)]
-    Native(Native),
+    Native(ExNative),
 }
 
 #[deriving(Clone)]
 #[doc(hidden)]
-pub struct Dynamic {
+pub struct ExDynamic {
     original: String,
     names: Vec<Option<String>>,
     #[doc(hidden)]
@@ -125,7 +125,7 @@ pub struct Dynamic {
 }
 
 #[doc(hidden)]
-pub struct Native {
+pub struct ExNative {
     #[doc(hidden)]
     pub original: &'static str,
     #[doc(hidden)]
@@ -134,8 +134,8 @@ pub struct Native {
     pub prog: fn(MatchKind, &str, uint, uint) -> Vec<Option<uint>>
 }
 
-impl Clone for Native {
-    fn clone(&self) -> Native { *self }
+impl Clone for ExNative {
+    fn clone(&self) -> ExNative { *self }
 }
 
 impl fmt::Show for Regex {
@@ -156,7 +156,7 @@ impl Regex {
     pub fn new(re: &str) -> Result<Regex, parse::Error> {
         let ast = try!(parse::parse(re));
         let (prog, names) = Program::new(ast);
-        Ok(Dynamic(Dynamic {
+        Ok(Dynamic(ExDynamic {
             original: re.to_string(),
             names: names,
             prog: prog,
@@ -510,8 +510,8 @@ impl Regex {
     /// Returns the original string of this regex.
     pub fn as_str<'a>(&'a self) -> &'a str {
         match *self {
-            Dynamic(Dynamic { ref original, .. }) => original.as_slice(),
-            Native(Native { ref original, .. }) => original.as_slice(),
+            Dynamic(ExDynamic { ref original, .. }) => original.as_slice(),
+            Native(ExNative { ref original, .. }) => original.as_slice(),
         }
     }
 
@@ -915,8 +915,8 @@ fn exec(re: &Regex, which: MatchKind, input: &str) -> CaptureLocs {
 fn exec_slice(re: &Regex, which: MatchKind,
               input: &str, s: uint, e: uint) -> CaptureLocs {
     match *re {
-        Dynamic(Dynamic { ref prog, .. }) => vm::run(which, prog, input, s, e),
-        Native(Native { prog, .. }) => prog(which, input, s, e),
+        Dynamic(ExDynamic { ref prog, .. }) => vm::run(which, prog, input, s, e),
+        Native(ExNative { prog, .. }) => prog(which, input, s, e),
     }
 }
 

--- a/src/libregex_macros/lib.rs
+++ b/src/libregex_macros/lib.rs
@@ -42,7 +42,7 @@ use regex::Regex;
 use regex::native::{
     OneChar, CharClass, Any, Save, Jump, Split,
     Match, EmptyBegin, EmptyEnd, EmptyWordBoundary,
-    Program, Dynamic, Native,
+    Program, Dynamic, ExDynamic, Native,
     FLAG_NOCASE, FLAG_MULTI, FLAG_DOTNL, FLAG_NEGATED,
 };
 
@@ -91,7 +91,7 @@ fn native(cx: &mut ExtCtxt, sp: codemap::Span, tts: &[ast::TokenTree])
         }
     };
     let prog = match re {
-        Dynamic(Dynamic { ref prog, .. }) => prog.clone(),
+        Dynamic(ExDynamic { ref prog, .. }) => prog.clone(),
         Native(_) => unreachable!(),
     };
 
@@ -322,7 +322,7 @@ fn exec<'t>(which: ::regex::native::MatchKind, input: &'t str,
     }
 }
 
-::regex::native::Native(::regex::native::Native {
+::regex::native::Native(::regex::native::ExNative {
     original: $regex,
     names: CAP_NAMES,
     prog: exec,

--- a/src/librustc/back/write.rs
+++ b/src/librustc/back/write.rs
@@ -11,7 +11,7 @@
 use back::lto;
 use back::link::{get_cc_prog, remove};
 use driver::driver::{CrateTranslation, ModuleTranslation, OutputFilenames};
-use driver::config::{NoDebugInfo, Passes, AllPasses};
+use driver::config::{NoDebugInfo, Passes, SomePasses, AllPasses};
 use driver::session::Session;
 use driver::config;
 use llvm;
@@ -341,7 +341,7 @@ unsafe extern "C" fn diagnostic_handler(info: DiagnosticInfoRef, user: *mut c_vo
             let pass_name = pass_name.as_str().expect("got a non-UTF8 pass name from LLVM");
             let enabled = match cgcx.remark {
                 AllPasses => true,
-                Passes(ref v) => v.iter().any(|s| s.as_slice() == pass_name),
+                SomePasses(ref v) => v.iter().any(|s| s.as_slice() == pass_name),
             };
 
             if enabled {
@@ -482,14 +482,14 @@ unsafe fn optimize_and_codegen(cgcx: &CodegenContext,
         if config.emit_asm {
             let path = output_names.with_extension(format!("{}.s", name_extra).as_slice());
             with_codegen(tm, llmod, config.no_builtins, |cpm| {
-                write_output_file(cgcx.handler, tm, cpm, llmod, &path, llvm::AssemblyFile);
+                write_output_file(cgcx.handler, tm, cpm, llmod, &path, llvm::AssemblyFileType);
             });
         }
 
         if config.emit_obj {
             let path = output_names.with_extension(format!("{}.o", name_extra).as_slice());
             with_codegen(tm, llmod, config.no_builtins, |cpm| {
-                write_output_file(cgcx.handler, tm, cpm, llmod, &path, llvm::ObjectFile);
+                write_output_file(cgcx.handler, tm, cpm, llmod, &path, llvm::ObjectFileType);
             });
         }
     });

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -237,14 +237,14 @@ pub fn debugging_opts_map() -> Vec<(&'static str, &'static str, u64)> {
 
 #[deriving(Clone)]
 pub enum Passes {
-    Passes(Vec<String>),
+    SomePasses(Vec<String>),
     AllPasses,
 }
 
 impl Passes {
     pub fn is_empty(&self) -> bool {
         match *self {
-            Passes(ref v) => v.is_empty(),
+            SomePasses(ref v) => v.is_empty(),
             AllPasses => false,
         }
     }
@@ -276,7 +276,7 @@ macro_rules! cgoptions(
         &[ $( (stringify!($opt), cgsetters::$opt, $desc) ),* ];
 
     mod cgsetters {
-        use super::{CodegenOptions, Passes, AllPasses};
+        use super::{CodegenOptions, Passes, SomePasses, AllPasses};
 
         $(
             pub fn $opt(cg: &mut CodegenOptions, v: Option<&str>) -> bool {
@@ -335,7 +335,7 @@ macro_rules! cgoptions(
                 v => {
                     let mut passes = vec!();
                     if parse_list(&mut passes, v) {
-                        *slot = Passes(passes);
+                        *slot = SomePasses(passes);
                         true
                     } else {
                         false
@@ -389,7 +389,7 @@ cgoptions!(
          "extra data to put in each output filename"),
     codegen_units: uint = (1, parse_uint,
         "divide crate into N units to optimize in parallel"),
-    remark: Passes = (Passes(Vec::new()), parse_passes,
+    remark: Passes = (SomePasses(Vec::new()), parse_passes,
         "print remarks for these optimization passes (space separated, or \"all\")"),
 )
 

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -1297,7 +1297,7 @@ impl LintPass for UnnecessaryAllocation {
         match cx.tcx.adjustments.borrow().find(&e.id) {
             Some(adjustment) => {
                 match *adjustment {
-                    ty::AutoDerefRef(ty::AutoDerefRef { ref autoref, .. }) => {
+                    ty::AdjustDerefRef(ty::AutoDerefRef { ref autoref, .. }) => {
                         match (allocation, autoref) {
                             (VectorAllocation, &Some(ty::AutoPtr(_, _, None))) => {
                                 cx.span_lint(UNNECESSARY_ALLOCATION, e.span,
@@ -1512,12 +1512,12 @@ impl LintPass for Stability {
                             typeck::MethodStaticUnboxedClosure(def_id) => {
                                 def_id
                             }
-                            typeck::MethodParam(typeck::MethodParam {
+                            typeck::MethodTypeParam(typeck::MethodParam {
                                 trait_ref: ref trait_ref,
                                 method_num: index,
                                 ..
                             }) |
-                            typeck::MethodObject(typeck::MethodObject {
+                            typeck::MethodTraitObject(typeck::MethodObject {
                                 trait_ref: ref trait_ref,
                                 method_num: index,
                                 ..

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -425,12 +425,12 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                                adj: &ty::AutoAdjustment)
                                -> mc::cmt {
         let r = match *adj {
-            ty::AutoDerefRef(
+            ty::AdjustDerefRef(
                 ty::AutoDerefRef {
                     autoderefs: autoderefs, ..}) => {
                 self.mc().cat_expr_autoderefd(expr, autoderefs)
             }
-            ty::AutoAddEnv(..) => {
+            ty::AdjustAddEnv(..) => {
                 // no autoderefs
                 self.mc().cat_expr_unadjusted(expr)
             }

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -101,12 +101,12 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
                         }
                     }
                     typeck::MethodStaticUnboxedClosure(_) => {}
-                    typeck::MethodParam(typeck::MethodParam {
+                    typeck::MethodTypeParam(typeck::MethodParam {
                         trait_ref: ref trait_ref,
                         method_num: index,
                         ..
                     }) |
-                    typeck::MethodObject(typeck::MethodObject {
+                    typeck::MethodTraitObject(typeck::MethodObject {
                         trait_ref: ref trait_ref,
                         method_num: index,
                         ..

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -19,7 +19,8 @@ use middle::def;
 use middle::freevars;
 use middle::pat_util;
 use middle::ty;
-use middle::typeck::{MethodCall, MethodObject, MethodOrigin, MethodParam};
+use middle::typeck::{MethodCall, MethodObject, MethodTraitObject};
+use middle::typeck::{MethodOrigin, MethodParam, MethodTypeParam};
 use middle::typeck::{MethodStatic, MethodStaticUnboxedClosure};
 use middle::typeck;
 use util::ppaux::Repr;
@@ -177,8 +178,8 @@ impl OverloadedCallType {
             MethodStaticUnboxedClosure(def_id) => {
                 OverloadedCallType::from_unboxed_closure(tcx, def_id)
             }
-            MethodParam(MethodParam { trait_ref: ref trait_ref, .. }) |
-            MethodObject(MethodObject { trait_ref: ref trait_ref, .. }) => {
+            MethodTypeParam(MethodParam { trait_ref: ref trait_ref, .. }) |
+            MethodTraitObject(MethodObject { trait_ref: ref trait_ref, .. }) => {
                 OverloadedCallType::from_trait_id(tcx, trait_ref.def_id)
             }
         }
@@ -673,7 +674,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,TYPER> {
             None => { }
             Some(adjustment) => {
                 match *adjustment {
-                    ty::AutoAddEnv(..) => {
+                    ty::AdjustAddEnv(..) => {
                         // Creating a closure consumes the input and stores it
                         // into the resulting rvalue.
                         debug!("walk_adjustment(AutoAddEnv)");
@@ -681,7 +682,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,TYPER> {
                             return_if_err!(self.mc.cat_expr_unadjusted(expr));
                         self.delegate_consume(expr.id, expr.span, cmt_unadjusted);
                     }
-                    ty::AutoDerefRef(ty::AutoDerefRef {
+                    ty::AdjustDerefRef(ty::AutoDerefRef {
                         autoref: ref opt_autoref,
                         autoderefs: n
                     }) => {

--- a/src/librustc/middle/kind.rs
+++ b/src/librustc/middle/kind.rs
@@ -274,6 +274,7 @@ pub fn check_expr(cx: &mut Context, e: &Expr) {
 
     visit::walk_expr(cx, e);
 }
+
 fn check_ty(cx: &mut Context, aty: &Ty) {
     match aty.node {
         TyPath(_, _, id) => {

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -414,14 +414,14 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
 
             Some(adjustment) => {
                 match *adjustment {
-                    ty::AutoAddEnv(..) => {
+                    ty::AdjustAddEnv(..) => {
                         // Convert a bare fn to a closure by adding NULL env.
                         // Result is an rvalue.
                         let expr_ty = if_ok!(self.expr_ty_adjusted(expr));
                         Ok(self.cat_rvalue_node(expr.id(), expr.span(), expr_ty))
                     }
 
-                    ty::AutoDerefRef(
+                    ty::AdjustDerefRef(
                         ty::AutoDerefRef {
                             autoref: Some(_), ..}) => {
                         // Equivalent to &*expr or something similar.
@@ -430,7 +430,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                         Ok(self.cat_rvalue_node(expr.id(), expr.span(), expr_ty))
                     }
 
-                    ty::AutoDerefRef(
+                    ty::AdjustDerefRef(
                         ty::AutoDerefRef {
                             autoref: None, autoderefs: autoderefs}) => {
                         // Equivalent to *expr or something similar.

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -19,8 +19,8 @@ use middle::def;
 use lint;
 use middle::resolve;
 use middle::ty;
-use middle::typeck::{MethodCall, MethodMap, MethodOrigin, MethodParam};
-use middle::typeck::{MethodStatic, MethodStaticUnboxedClosure, MethodObject};
+use middle::typeck::{MethodCall, MethodMap, MethodOrigin, MethodParam, MethodTypeParam};
+use middle::typeck::{MethodStatic, MethodStaticUnboxedClosure, MethodObject, MethodTraitObject};
 use util::nodemap::{NodeMap, NodeSet};
 
 use syntax::ast;
@@ -829,8 +829,8 @@ impl<'a, 'tcx> PrivacyVisitor<'a, 'tcx> {
             MethodStaticUnboxedClosure(_) => {}
             // Trait methods are always all public. The only controlling factor
             // is whether the trait itself is accessible or not.
-            MethodParam(MethodParam { trait_ref: ref trait_ref, .. }) |
-            MethodObject(MethodObject { trait_ref: ref trait_ref, .. }) => {
+            MethodTypeParam(MethodParam { trait_ref: ref trait_ref, .. }) |
+            MethodTraitObject(MethodObject { trait_ref: ref trait_ref, .. }) => {
                 self.report_error(self.ensure_public(span, trait_ref.def_id,
                                                      None, "source trait"));
             }

--- a/src/librustc/middle/save/mod.rs
+++ b/src/librustc/middle/save/mod.rs
@@ -904,14 +904,14 @@ impl <'l, 'tcx> DxrVisitor<'l, 'tcx> {
                 };
                 (Some(def_id), decl_id)
             }
-            typeck::MethodParam(ref mp) => {
+            typeck::MethodTypeParam(ref mp) => {
                 // method invoked on a type parameter
                 let trait_item = ty::trait_item(&self.analysis.ty_cx,
                                                 mp.trait_ref.def_id,
                                                 mp.method_num);
                 (None, Some(trait_item.def_id()))
             }
-            typeck::MethodObject(ref mo) => {
+            typeck::MethodTraitObject(ref mo) => {
                 // method invoked on a trait instance
                 let trait_item = ty::trait_item(&self.analysis.ty_cx,
                                                 mo.trait_ref.def_id,

--- a/src/librustc/middle/traits/fulfill.rs
+++ b/src/librustc/middle/traits/fulfill.rs
@@ -13,10 +13,10 @@ use middle::typeck::infer::{InferCtxt, skolemize};
 use util::nodemap::DefIdMap;
 use util::ppaux::Repr;
 
-use super::Ambiguity;
+use super::CodeAmbiguity;
 use super::Obligation;
 use super::FulfillmentError;
-use super::SelectionError;
+use super::CodeSelectionError;
 use super::select::SelectionContext;
 use super::Unimplemented;
 
@@ -78,7 +78,7 @@ impl FulfillmentContext {
         let errors: Vec<FulfillmentError> =
             self.trait_obligations
             .iter()
-            .map(|o| FulfillmentError::new((*o).clone(), Ambiguity))
+            .map(|o| FulfillmentError::new((*o).clone(), CodeAmbiguity))
             .collect();
 
         if errors.is_empty() {
@@ -129,7 +129,7 @@ impl FulfillmentContext {
 
                         errors.push(FulfillmentError::new(
                             (*obligation).clone(),
-                            SelectionError(selection_err)));
+                            CodeSelectionError(selection_err)));
                         false
                     }
                 }
@@ -237,7 +237,7 @@ impl FulfillmentContext {
             errors.push(
                 FulfillmentError::new(
                     (*obligation).clone(),
-                    SelectionError(Unimplemented)));
+                    CodeSelectionError(Unimplemented)));
         }
 
         if errors.is_empty() {

--- a/src/librustc/middle/traits/mod.rs
+++ b/src/librustc/middle/traits/mod.rs
@@ -97,8 +97,8 @@ pub struct FulfillmentError {
 
 #[deriving(Clone)]
 pub enum FulfillmentErrorCode {
-    SelectionError(SelectionError),
-    Ambiguity,
+    CodeSelectionError(SelectionError),
+    CodeAmbiguity,
 }
 
 /**
@@ -110,7 +110,7 @@ pub enum FulfillmentErrorCode {
  *   to inconclusive type inference.
  * - `Err(e)`: error `e` occurred
  */
-pub type SelectionResult<T> = Result<Option<T>,SelectionError>;
+pub type SelectionResult<T> = Result<Option<T>, SelectionError>;
 
 #[deriving(PartialEq,Eq,Show)]
 pub enum EvaluationResult {
@@ -157,12 +157,12 @@ pub enum EvaluationResult {
  *
  * ### The type parameter `N`
  *
- * See explanation on `VtableImpl`.
+ * See explanation on `VtableImplData`.
  */
 #[deriving(Show,Clone)]
 pub enum Vtable<N> {
     /// Vtable identifying a particular impl.
-    VtableImpl(VtableImpl<N>),
+    VtableImpl(VtableImplData<N>),
 
     /// Vtable automatically generated for an unboxed closure. The def
     /// ID is the ID of the closure expression. This is a `VtableImpl`
@@ -172,7 +172,7 @@ pub enum Vtable<N> {
 
     /// Successful resolution to an obligation provided by the caller
     /// for some type parameter.
-    VtableParam(VtableParam),
+    VtableParam(VtableParamData),
 
     /// Successful resolution for a builtin trait.
     VtableBuiltin,
@@ -191,7 +191,7 @@ pub enum Vtable<N> {
  * impl, and nested obligations are satisfied later.
  */
 #[deriving(Clone)]
-pub struct VtableImpl<N> {
+pub struct VtableImplData<N> {
     pub impl_def_id: ast::DefId,
     pub substs: subst::Substs,
     pub nested: subst::VecPerParamSpace<N>
@@ -203,7 +203,7 @@ pub struct VtableImpl<N> {
  * on an instance of `T`, the vtable would be of type `VtableParam`.
  */
 #[deriving(Clone)]
-pub struct VtableParam {
+pub struct VtableParamData {
     // In the above example, this would `Eq`
     pub bound: Rc<ty::TraitRef>,
 }
@@ -274,7 +274,7 @@ pub fn select_inherent_impl(infcx: &InferCtxt,
                             cause: ObligationCause,
                             impl_def_id: ast::DefId,
                             self_ty: ty::t)
-                            -> SelectionResult<VtableImpl<Obligation>>
+                            -> SelectionResult<VtableImplData<Obligation>>
 {
     /*!
      * Matches the self type of the inherent impl `impl_def_id`
@@ -398,21 +398,21 @@ impl<N> Vtable<N> {
     }
 }
 
-impl<N> VtableImpl<N> {
+impl<N> VtableImplData<N> {
     pub fn map_nested<M>(&self,
                          op: |&N| -> M)
-                         -> VtableImpl<M>
+                         -> VtableImplData<M>
     {
-        VtableImpl {
+        VtableImplData {
             impl_def_id: self.impl_def_id,
             substs: self.substs.clone(),
             nested: self.nested.map(op)
         }
     }
 
-    pub fn map_move_nested<M>(self, op: |N| -> M) -> VtableImpl<M> {
-        let VtableImpl { impl_def_id, substs, nested } = self;
-        VtableImpl {
+    pub fn map_move_nested<M>(self, op: |N| -> M) -> VtableImplData<M> {
+        let VtableImplData { impl_def_id, substs, nested } = self;
+        VtableImplData {
             impl_def_id: impl_def_id,
             substs: substs,
             nested: nested.map_move(op)

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -18,6 +18,7 @@ use super::{SelectionError, Unimplemented, Overflow,
 use super::{Selection};
 use super::{SelectionResult};
 use super::{VtableBuiltin, VtableImpl, VtableParam, VtableUnboxedClosure};
+use super::{VtableImplData, VtableParamData};
 use super::{util};
 
 use middle::subst::{Subst, Substs, VecPerParamSpace};
@@ -82,7 +83,7 @@ enum MatchResult<T> {
 enum Candidate {
     MatchedBuiltinCandidate,
     AmbiguousBuiltinCandidate,
-    MatchedParamCandidate(VtableParam),
+    MatchedParamCandidate(VtableParamData),
     AmbiguousParamCandidate,
     Impl(ImplCandidate),
     MatchedUnboxedClosureCandidate(/* closure */ ast::DefId)
@@ -142,7 +143,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                 impl_def_id: ast::DefId,
                                 obligation_cause: ObligationCause,
                                 obligation_self_ty: ty::t)
-                                -> SelectionResult<VtableImpl<Obligation>>
+                                -> SelectionResult<VtableImplData<Obligation>>
     {
         debug!("select_inherent_impl(impl_def_id={}, obligation_self_ty={})",
                impl_def_id.repr(self.tcx()),
@@ -597,8 +598,8 @@ v         */
 
     fn confirm_param_candidate(&self,
                                obligation: &Obligation,
-                               param: VtableParam)
-                               -> Result<VtableParam,SelectionError>
+                               param: VtableParamData)
+                               -> Result<VtableParamData,SelectionError>
     {
         debug!("confirm_param_candidate({},{})",
                obligation.repr(self.tcx()),
@@ -613,7 +614,7 @@ v         */
     fn confirm_impl_candidate(&self,
                               obligation: &Obligation,
                               impl_def_id: ast::DefId)
-                              -> Result<VtableImpl<Obligation>,SelectionError>
+                              -> Result<VtableImplData<Obligation>,SelectionError>
     {
         debug!("confirm_impl_candidate({},{})",
                obligation.repr(self.tcx()),
@@ -642,7 +643,7 @@ v         */
                                        obligation_cause: ObligationCause,
                                        obligation_self_ty: ty::t,
                                        obligation_recursion_depth: uint)
-                                       -> Result<VtableImpl<Obligation>,
+                                       -> Result<VtableImplData<Obligation>,
                                                  SelectionError>
     {
         let substs = match self.match_impl_self_types(impl_def_id,
@@ -663,7 +664,7 @@ v         */
                                   obligation_recursion_depth,
                                   impl_def_id,
                                   &substs);
-        let vtable_impl = VtableImpl { impl_def_id: impl_def_id,
+        let vtable_impl = VtableImplData { impl_def_id: impl_def_id,
                                        substs: substs,
                                        nested: impl_obligations };
 

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -19,7 +19,7 @@ use syntax::ast;
 use syntax::codemap::Span;
 use util::ppaux::Repr;
 
-use super::{Obligation, ObligationCause, VtableImpl, VtableParam};
+use super::{Obligation, ObligationCause, VtableImpl, VtableParam, VtableParamData, VtableImplData};
 
 ///////////////////////////////////////////////////////////////////////////
 // Supertrait iterator
@@ -137,13 +137,13 @@ pub fn fresh_substs_for_impl(infcx: &InferCtxt,
     infcx.fresh_substs_for_generics(span, &impl_generics)
 }
 
-impl<N> fmt::Show for VtableImpl<N> {
+impl<N> fmt::Show for VtableImplData<N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "VtableImpl({})", self.impl_def_id)
     }
 }
 
-impl fmt::Show for VtableParam {
+impl fmt::Show for VtableParamData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "VtableParam(...)")
     }
@@ -239,7 +239,7 @@ pub fn obligation_for_builtin_bound(
 pub fn search_trait_and_supertraits_from_bound(tcx: &ty::ctxt,
                                                caller_bound: Rc<ty::TraitRef>,
                                                test: |ast::DefId| -> bool)
-                                               -> Option<VtableParam>
+                                               -> Option<VtableParamData>
 {
     /*!
      * Starting from a caller obligation `caller_bound` (which has
@@ -252,7 +252,7 @@ pub fn search_trait_and_supertraits_from_bound(tcx: &ty::ctxt,
 
     for bound in transitive_bounds(tcx, &[caller_bound]) {
         if test(bound.def_id) {
-            let vtable_param = VtableParam { bound: bound };
+            let vtable_param = VtableParamData { bound: bound };
             return Some(vtable_param);
         }
     }
@@ -287,7 +287,7 @@ impl<N:Repr> Repr for super::Vtable<N> {
     }
 }
 
-impl<N:Repr> Repr for super::VtableImpl<N> {
+impl<N:Repr> Repr for super::VtableImplData<N> {
     fn repr(&self, tcx: &ty::ctxt) -> String {
         format!("VtableImpl(impl_def_id={}, substs={}, nested={})",
                 self.impl_def_id.repr(tcx),
@@ -296,7 +296,7 @@ impl<N:Repr> Repr for super::VtableImpl<N> {
     }
 }
 
-impl Repr for super::VtableParam {
+impl Repr for super::VtableParamData {
     fn repr(&self, tcx: &ty::ctxt) -> String {
         format!("VtableParam(bound={})",
                 self.bound.repr(tcx))
@@ -331,8 +331,8 @@ impl Repr for super::FulfillmentError {
 impl Repr for super::FulfillmentErrorCode {
     fn repr(&self, tcx: &ty::ctxt) -> String {
         match *self {
-            super::SelectionError(ref o) => o.repr(tcx),
-            super::Ambiguity => format!("Ambiguity")
+            super::CodeSelectionError(ref o) => o.repr(tcx),
+            super::CodeAmbiguity => format!("Ambiguity")
         }
     }
 }
@@ -340,8 +340,8 @@ impl Repr for super::FulfillmentErrorCode {
 impl fmt::Show for super::FulfillmentErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            super::SelectionError(ref e) => write!(f, "{}", e),
-            super::Ambiguity => write!(f, "Ambiguity")
+            super::CodeSelectionError(ref e) => write!(f, "{}", e),
+            super::CodeAmbiguity => write!(f, "Ambiguity")
         }
     }
 }

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -207,7 +207,7 @@ pub fn const_expr(cx: &CrateContext, e: &ast::Expr, is_local: bool) -> (ValueRef
         None => { }
         Some(adj) => {
             match adj {
-                ty::AutoAddEnv(ty::RegionTraitStore(ty::ReStatic, _)) => {
+                ty::AdjustAddEnv(ty::RegionTraitStore(ty::ReStatic, _)) => {
                     let def = ty::resolve_expr(cx.tcx(), e);
                     let wrapper = closure::get_wrapper_for_bare_fn(cx,
                                                                    ety_adjusted,
@@ -216,13 +216,13 @@ pub fn const_expr(cx: &CrateContext, e: &ast::Expr, is_local: bool) -> (ValueRef
                                                                    is_local);
                     llconst = C_struct(cx, [wrapper, C_null(Type::i8p(cx))], false)
                 }
-                ty::AutoAddEnv(store) => {
+                ty::AdjustAddEnv(store) => {
                     cx.sess()
                       .span_bug(e.span,
                                 format!("unexpected static function: {:?}",
                                         store).as_slice())
                 }
-                ty::AutoDerefRef(ref adj) => {
+                ty::AdjustDerefRef(ref adj) => {
                     let mut ty = ety;
                     // Save the last autoderef in case we can avoid it.
                     if adj.autoderefs > 0 {

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -664,7 +664,7 @@ pub struct FunctionDebugContext {
 }
 
 enum FunctionDebugContextRepr {
-    FunctionDebugContext(Box<FunctionDebugContextData>),
+    DebugInfo(Box<FunctionDebugContextData>),
     DebugInfoDisabled,
     FunctionWithoutDebugInfo,
 }
@@ -675,7 +675,7 @@ impl FunctionDebugContext {
                    span: Span)
                    -> &'a FunctionDebugContextData {
         match self.repr {
-            FunctionDebugContext(box ref data) => data,
+            DebugInfo(box ref data) => data,
             DebugInfoDisabled => {
                 cx.sess().span_bug(span,
                                    FunctionDebugContext::debuginfo_disabled_message());
@@ -1044,7 +1044,7 @@ pub fn set_source_location(fcx: &FunctionContext,
             set_debug_location(fcx.ccx, UnknownLocation);
             return;
         }
-        FunctionDebugContext(box ref function_debug_context) => {
+        DebugInfo(box ref function_debug_context) => {
             let cx = fcx.ccx;
 
             debug!("set_source_location: {}", cx.sess().codemap().span_to_string(span));
@@ -1082,7 +1082,7 @@ pub fn clear_source_location(fcx: &FunctionContext) {
 /// first real statement/expression of the function is translated.
 pub fn start_emitting_source_locations(fcx: &FunctionContext) {
     match fcx.debug_context.repr {
-        FunctionDebugContext(box ref data) => {
+        DebugInfo(box ref data) => {
             data.source_locations_enabled.set(true)
         },
         _ => { /* safe to ignore */ }
@@ -1291,7 +1291,7 @@ pub fn create_function_debug_context(cx: &CrateContext,
                        fn_metadata,
                        &mut *fn_debug_context.scope_map.borrow_mut());
 
-    return FunctionDebugContext { repr: FunctionDebugContext(fn_debug_context) };
+    return FunctionDebugContext { repr: DebugInfo(fn_debug_context) };
 
     fn get_function_signature(cx: &CrateContext,
                               fn_ast_id: ast::NodeId,
@@ -3134,7 +3134,7 @@ fn DIB(cx: &CrateContext) -> DIBuilderRef {
 
 fn fn_should_be_ignored(fcx: &FunctionContext) -> bool {
     match fcx.debug_context.repr {
-        FunctionDebugContext(_) => false,
+        DebugInfo(_) => false,
         _ => true
     }
 }

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -64,7 +64,7 @@ use middle::trans::inline;
 use middle::trans::tvec;
 use middle::trans::type_of;
 use middle::ty::{struct_fields, tup_fields};
-use middle::ty::{AutoDerefRef, AutoAddEnv, AutoUnsafe};
+use middle::ty::{AdjustDerefRef, AdjustAddEnv, AutoUnsafe};
 use middle::ty::{AutoPtr};
 use middle::ty;
 use middle::typeck;
@@ -190,10 +190,10 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     debug!("unadjusted datum for expr {}: {}",
            expr.id, datum.to_string(bcx.ccx()));
     match adjustment {
-        AutoAddEnv(..) => {
+        AdjustAddEnv(..) => {
             datum = unpack_datum!(bcx, add_env(bcx, expr, datum));
         }
-        AutoDerefRef(ref adj) => {
+        AdjustDerefRef(ref adj) => {
             let (autoderefs, use_autoref) = match adj.autoref {
                 // Extracting a value from a box counts as a deref, but if we are
                 // just converting Box<[T, ..n]> to Box<[T]> we aren't really doing

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -131,7 +131,7 @@ pub fn trans_method_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             }
         }
 
-        typeck::MethodParam(typeck::MethodParam {
+        typeck::MethodTypeParam(typeck::MethodParam {
             trait_ref: ref trait_ref,
             method_num: method_num
         }) => {
@@ -147,7 +147,7 @@ pub fn trans_method_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                        method_num, origin)
         }
 
-        typeck::MethodObject(ref mt) => {
+        typeck::MethodTraitObject(ref mt) => {
             let self_expr = match self_expr {
                 Some(self_expr) => self_expr,
                 None => {
@@ -243,7 +243,7 @@ pub fn trans_static_method_callee(bcx: Block,
     // Now that we know which impl is being used, we can dispatch to
     // the actual function:
     match vtbl {
-        traits::VtableImpl(traits::VtableImpl {
+        traits::VtableImpl(traits::VtableImplData {
             impl_def_id: impl_did,
             substs: impl_substs,
             nested: _ }) =>
@@ -562,7 +562,7 @@ pub fn get_vtable(bcx: Block,
                                         trait_ref.clone());
         match vtable {
             traits::VtableImpl(
-                traits::VtableImpl {
+                traits::VtableImplData {
                     impl_def_id: id,
                     substs: substs,
                     nested: _ }) => {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -279,8 +279,8 @@ pub enum Variance {
 
 #[deriving(Clone)]
 pub enum AutoAdjustment {
-    AutoAddEnv(ty::TraitStore),
-    AutoDerefRef(AutoDerefRef)
+    AdjustAddEnv(ty::TraitStore),
+    AdjustDerefRef(AutoDerefRef)
 }
 
 #[deriving(Clone, PartialEq)]
@@ -352,7 +352,7 @@ fn autoref_object_region(autoref: &AutoRef) -> (bool, bool, Option<Region>) {
 // returns the region of the borrowed reference.
 pub fn adjusted_object_region(adj: &AutoAdjustment) -> Option<Region> {
     match adj {
-        &AutoDerefRef(AutoDerefRef{autoref: Some(ref autoref), ..}) => {
+        &AdjustDerefRef(AutoDerefRef{autoref: Some(ref autoref), ..}) => {
             let (b, _, r) = autoref_object_region(autoref);
             if b {
                 r
@@ -367,7 +367,7 @@ pub fn adjusted_object_region(adj: &AutoAdjustment) -> Option<Region> {
 // Returns true if there is a trait cast at the bottom of the adjustment.
 pub fn adjust_is_object(adj: &AutoAdjustment) -> bool {
     match adj {
-        &AutoDerefRef(AutoDerefRef{autoref: Some(ref autoref), ..}) => {
+        &AdjustDerefRef(AutoDerefRef{autoref: Some(ref autoref), ..}) => {
             let (b, _, _) = autoref_object_region(autoref);
             b
         }
@@ -409,7 +409,7 @@ pub fn type_of_adjust(cx: &ctxt, adj: &AutoAdjustment) -> Option<t> {
     }
 
     match adj {
-        &AutoDerefRef(AutoDerefRef{autoref: Some(ref autoref), ..}) => {
+        &AdjustDerefRef(AutoDerefRef{autoref: Some(ref autoref), ..}) => {
             type_of_autoref(cx, autoref)
         }
         _ => None
@@ -3425,7 +3425,7 @@ pub fn adjust_ty(cx: &ctxt,
     return match adjustment {
         Some(adjustment) => {
             match *adjustment {
-                AutoAddEnv(store) => {
+                AdjustAddEnv(store) => {
                     match ty::get(unadjusted_ty).sty {
                         ty::ty_bare_fn(ref b) => {
                             let bounds = ty::ExistentialBounds {
@@ -3451,7 +3451,7 @@ pub fn adjust_ty(cx: &ctxt,
                     }
                 }
 
-                AutoDerefRef(ref adj) => {
+                AdjustDerefRef(ref adj) => {
                     let mut adjusted_ty = unadjusted_ty;
 
                     if !ty::type_is_error(adjusted_ty) {
@@ -3584,12 +3584,12 @@ pub fn method_call_type_param_defs<'tcx, T>(typer: &T,
                               .trait_did(typer.tcx());
             lookup_trait_def(typer.tcx(), def_id).generics.types.clone()
         }
-        typeck::MethodParam(typeck::MethodParam{
+        typeck::MethodTypeParam(typeck::MethodParam{
             trait_ref: ref trait_ref,
             method_num: n_mth,
             ..
         }) |
-        typeck::MethodObject(typeck::MethodObject{
+        typeck::MethodTraitObject(typeck::MethodObject{
                 trait_ref: ref trait_ref,
                 method_num: n_mth,
                 ..

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -353,9 +353,9 @@ impl TypeFoldable for traits::Obligation {
     }
 }
 
-impl<N:TypeFoldable> TypeFoldable for traits::VtableImpl<N> {
-    fn fold_with<'tcx, F:TypeFolder<'tcx>>(&self, folder: &mut F) -> traits::VtableImpl<N> {
-        traits::VtableImpl {
+impl<N:TypeFoldable> TypeFoldable for traits::VtableImplData<N> {
+    fn fold_with<'tcx, F:TypeFolder<'tcx>>(&self, folder: &mut F) -> traits::VtableImplData<N> {
+        traits::VtableImplData {
             impl_def_id: self.impl_def_id,
             substs: self.substs.fold_with(folder),
             nested: self.nested.fold_with(folder),
@@ -374,9 +374,9 @@ impl<N:TypeFoldable> TypeFoldable for traits::Vtable<N> {
     }
 }
 
-impl TypeFoldable for traits::VtableParam {
-    fn fold_with<'tcx, F:TypeFolder<'tcx>>(&self, folder: &mut F) -> traits::VtableParam {
-        traits::VtableParam {
+impl TypeFoldable for traits::VtableParamData {
+    fn fold_with<'tcx, F:TypeFolder<'tcx>>(&self, folder: &mut F) -> traits::VtableParamData {
+        traits::VtableParamData {
             bound: self.bound.fold_with(folder),
         }
     }

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1704,7 +1704,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.write_adjustment(
             node_id,
             span,
-            ty::AutoDerefRef(ty::AutoDerefRef {
+            ty::AdjustDerefRef(ty::AutoDerefRef {
                 autoderefs: derefs,
                 autoref: None })
         );
@@ -1730,8 +1730,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                        span: Span,
                                        adj: &ty::AutoAdjustment) {
         match *adj {
-            ty::AutoAddEnv(..) => { }
-            ty::AutoDerefRef(ref d_r) => {
+            ty::AdjustAddEnv(..) => { }
+            ty::AdjustDerefRef(ref d_r) => {
                 match d_r.autoref {
                     Some(ref a_r) => {
                         self.register_autoref_obligations(span, a_r);

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -592,7 +592,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
     for &adjustment in rcx.fcx.inh.adjustments.borrow().find(&expr.id).iter() {
         debug!("adjustment={:?}", adjustment);
         match *adjustment {
-            ty::AutoDerefRef(ty::AutoDerefRef {autoderefs, autoref: ref opt_autoref}) => {
+            ty::AdjustDerefRef(ty::AutoDerefRef {autoderefs, autoref: ref opt_autoref}) => {
                 let expr_ty = rcx.resolve_node_type(expr.id);
                 constrain_autoderefs(rcx, expr, autoderefs, expr_ty);
                 for autoref in opt_autoref.iter() {

--- a/src/librustc/middle/typeck/check/vtable2.rs
+++ b/src/librustc/middle/typeck/check/vtable2.rs
@@ -13,7 +13,7 @@ use middle::traits;
 use middle::traits::{SelectionError, Overflow,
                      OutputTypeParameterMismatch, Unimplemented};
 use middle::traits::{Obligation, obligation_for_builtin_bound};
-use middle::traits::{FulfillmentError, Ambiguity};
+use middle::traits::{FulfillmentError, CodeSelectionError, CodeAmbiguity};
 use middle::traits::{ObligationCause};
 use middle::ty;
 use middle::typeck::check::{FnCtxt,
@@ -244,10 +244,10 @@ pub fn report_fulfillment_errors(fcx: &FnCtxt,
 pub fn report_fulfillment_error(fcx: &FnCtxt,
                                 error: &FulfillmentError) {
     match error.code {
-        SelectionError(ref e) => {
+        CodeSelectionError(ref e) => {
             report_selection_error(fcx, &error.obligation, e);
         }
-        Ambiguity => {
+        CodeAmbiguity => {
             maybe_report_ambiguity(fcx, &error.obligation);
         }
     }

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -282,7 +282,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
             Some(adjustment) => {
                 let adj_object = ty::adjust_is_object(&adjustment);
                 let resolved_adjustment = match adjustment {
-                    ty::AutoAddEnv(store) => {
+                    ty::AdjustAddEnv(store) => {
                         // FIXME(eddyb) #2190 Allow only statically resolved
                         // bare functions to coerce to a closure to avoid
                         // constructing (slower) indirect call wrappers.
@@ -298,10 +298,10 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                             }
                         }
 
-                        ty::AutoAddEnv(self.resolve(&store, reason))
+                        ty::AdjustAddEnv(self.resolve(&store, reason))
                     }
 
-                    ty::AutoDerefRef(adj) => {
+                    ty::AdjustDerefRef(adj) => {
                         for autoderef in range(0, adj.autoderefs) {
                             let method_call = MethodCall::autoderef(id, autoderef);
                             self.visit_method_map_entry(reason, method_call);
@@ -312,7 +312,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                             self.visit_method_map_entry(reason, method_call);
                         }
 
-                        ty::AutoDerefRef(ty::AutoDerefRef {
+                        ty::AdjustDerefRef(ty::AutoDerefRef {
                             autoderefs: adj.autoderefs,
                             autoref: self.resolve(&adj.autoref, reason),
                         })

--- a/src/librustc/middle/typeck/infer/coercion.rs
+++ b/src/librustc/middle/typeck/infer/coercion.rs
@@ -65,7 +65,7 @@ we may want to adjust precisely when coercions occur.
 */
 
 use middle::subst;
-use middle::ty::{AutoPtr, AutoDerefRef, AutoUnsize, AutoUnsafe};
+use middle::ty::{AutoPtr, AutoDerefRef, AdjustDerefRef, AutoUnsize, AutoUnsafe};
 use middle::ty::{mt};
 use middle::ty;
 use middle::typeck::infer::{CoerceResult, resolve_type, Coercion};
@@ -270,7 +270,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                                      mt {ty: inner_ty, mutbl: mutbl_b});
         try!(sub.tys(a_borrowed, b));
 
-        Ok(Some(AutoDerefRef(AutoDerefRef {
+        Ok(Some(AdjustDerefRef(AutoDerefRef {
             autoderefs: 1,
             autoref: Some(AutoPtr(r_borrow, mutbl_b, None))
         })))
@@ -295,7 +295,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                 let unsized_ty = ty::mk_slice(self.get_ref().infcx.tcx, r_borrow,
                                               mt {ty: t_a, mutbl: mutbl_b});
                 try!(self.get_ref().infcx.try(|| sub.tys(unsized_ty, b)));
-                Ok(Some(AutoDerefRef(AutoDerefRef {
+                Ok(Some(AdjustDerefRef(AutoDerefRef {
                     autoderefs: 0,
                     autoref: Some(ty::AutoPtr(r_borrow,
                                               mutbl_b,
@@ -343,7 +343,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                             try!(self.get_ref().infcx.try(|| sub.tys(ty, b)));
                             debug!("Success, coerced with AutoDerefRef(1, \
                                     AutoPtr(AutoUnsize({:?})))", kind);
-                            Ok(Some(AutoDerefRef(AutoDerefRef {
+                            Ok(Some(AdjustDerefRef(AutoDerefRef {
                                 autoderefs: 1,
                                 autoref: Some(ty::AutoPtr(r_borrow, mt_b.mutbl,
                                                           Some(box AutoUnsize(kind))))
@@ -366,7 +366,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                             try!(self.get_ref().infcx.try(|| sub.tys(ty, b)));
                             debug!("Success, coerced with AutoDerefRef(1, \
                                     AutoPtr(AutoUnsize({:?})))", kind);
-                            Ok(Some(AutoDerefRef(AutoDerefRef {
+                            Ok(Some(AdjustDerefRef(AutoDerefRef {
                                 autoderefs: 1,
                                 autoref: Some(ty::AutoUnsafe(mt_b.mutbl,
                                                              Some(box AutoUnsize(kind))))
@@ -384,7 +384,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                             try!(self.get_ref().infcx.try(|| sub.tys(ty, b)));
                             debug!("Success, coerced with AutoDerefRef(1, \
                                     AutoUnsizeUniq({:?}))", kind);
-                            Ok(Some(AutoDerefRef(AutoDerefRef {
+                            Ok(Some(AdjustDerefRef(AutoDerefRef {
                                 autoderefs: 1,
                                 autoref: Some(ty::AutoUnsizeUniq(kind))
                             })))
@@ -537,7 +537,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
 
                     let tr = ty::mk_trait(tcx, def_id, substs.clone(), bounds);
                     try!(self.subtype(mk_ty(tr), b));
-                    Ok(Some(AutoDerefRef(AutoDerefRef {
+                    Ok(Some(AdjustDerefRef(AutoDerefRef {
                         autoderefs: 1,
                         autoref: Some(mk_adjust())
                     })))
@@ -593,7 +593,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                 _ => return self.subtype(a, b)
             };
 
-            let adj = ty::AutoAddEnv(fn_ty_b.store);
+            let adj = ty::AdjustAddEnv(fn_ty_b.store);
             let a_closure = ty::mk_closure(self.get_ref().infcx.tcx,
                                            ty::ClosureTy {
                                                 sig: fn_ty_a.sig.clone(),
@@ -630,7 +630,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
         // Although references and unsafe ptrs have the same
         // representation, we still register an AutoDerefRef so that
         // regionck knows that the region for `a` must be valid here.
-        Ok(Some(AutoDerefRef(AutoDerefRef {
+        Ok(Some(AdjustDerefRef(AutoDerefRef {
             autoderefs: 1,
             autoref: Some(ty::AutoUnsafe(mutbl_b, None))
         })))

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -102,10 +102,10 @@ pub enum MethodOrigin {
     MethodStaticUnboxedClosure(ast::DefId),
 
     // method invoked on a type parameter with a bounded trait
-    MethodParam(MethodParam),
+    MethodTypeParam(MethodParam),
 
     // method invoked on a trait instance
-    MethodObject(MethodObject),
+    MethodTraitObject(MethodObject),
 
 }
 

--- a/src/librustc/plugin/registry.rs
+++ b/src/librustc/plugin/registry.rs
@@ -13,7 +13,7 @@
 use lint::{LintPassObject, LintId, Lint};
 
 use syntax::ext::base::{SyntaxExtension, NamedSyntaxExtension, NormalTT};
-use syntax::ext::base::{IdentTT, LetSyntaxTT, ItemDecorator, ItemModifier};
+use syntax::ext::base::{IdentTT, LetSyntaxTT, Decorator, Modifier};
 use syntax::ext::base::{MacroExpanderFn};
 use syntax::codemap::Span;
 use syntax::parse::token;
@@ -61,8 +61,8 @@ impl Registry {
         self.syntax_exts.push((name, match extension {
             NormalTT(ext, _) => NormalTT(ext, Some(self.krate_span)),
             IdentTT(ext, _) => IdentTT(ext, Some(self.krate_span)),
-            ItemDecorator(ext) => ItemDecorator(ext),
-            ItemModifier(ext) => ItemModifier(ext),
+            Decorator(ext) => Decorator(ext),
+            Modifier(ext) => Modifier(ext),
             // there's probably a nicer way to signal this:
             LetSyntaxTT(_, _) => fail!("can't register a new LetSyntax!"),
         }));

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -962,10 +962,10 @@ impl Repr for typeck::MethodOrigin {
             &typeck::MethodStaticUnboxedClosure(def_id) => {
                 format!("MethodStaticUnboxedClosure({})", def_id.repr(tcx))
             }
-            &typeck::MethodParam(ref p) => {
+            &typeck::MethodTypeParam(ref p) => {
                 p.repr(tcx)
             }
-            &typeck::MethodObject(ref p) => {
+            &typeck::MethodTraitObject(ref p) => {
                 p.repr(tcx)
             }
         }

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -324,11 +324,11 @@ pub enum AtomicOrdering {
 // Consts for the LLVMCodeGenFileType type (in include/llvm/c/TargetMachine.h)
 #[repr(C)]
 pub enum FileType {
-    AssemblyFile = 0,
-    ObjectFile = 1
+    AssemblyFileType = 0,
+    ObjectFileType = 1
 }
 
-pub enum Metadata {
+pub enum MetadataType {
     MD_dbg = 0,
     MD_tbaa = 1,
     MD_prof = 2,

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -40,8 +40,8 @@ pub trait DocFolder {
                 EnumItem(i)
             },
             TraitItem(mut i) => {
-                fn vtrm<T: DocFolder>(this: &mut T, trm: TraitItem)
-                        -> Option<TraitItem> {
+                fn vtrm<T: DocFolder>(this: &mut T, trm: TraitMethod)
+                        -> Option<TraitMethod> {
                     match trm {
                         RequiredMethod(it) => {
                             match this.fold_item(it) {

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -277,7 +277,7 @@ fn path(w: &mut fmt::Formatter, path: &clean::Path, print_all: bool,
 }
 
 fn primitive_link(f: &mut fmt::Formatter,
-                  prim: clean::Primitive,
+                  prim: clean::PrimitiveType,
                   name: &str) -> fmt::Result {
     let m = cache_key.get().unwrap();
     let mut needs_termination = false;

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -177,7 +177,7 @@ pub struct Cache {
     pub extern_locations: HashMap<ast::CrateNum, ExternalLocation>,
 
     /// Cache of where documentation for primitives can be found.
-    pub primitive_locations: HashMap<clean::Primitive, ast::CrateNum>,
+    pub primitive_locations: HashMap<clean::PrimitiveType, ast::CrateNum>,
 
     /// Set of definitions which have been inlined from external crates.
     pub inlined: HashSet<ast::DefId>,
@@ -1637,7 +1637,7 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                                   _ => false,
                               }
                           })
-                          .collect::<Vec<&clean::TraitItem>>();
+                          .collect::<Vec<&clean::TraitMethod>>();
     let provided = t.items.iter()
                           .filter(|m| {
                               match **m {
@@ -1645,7 +1645,7 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                                   _ => false,
                               }
                           })
-                          .collect::<Vec<&clean::TraitItem>>();
+                          .collect::<Vec<&clean::TraitMethod>>();
 
     if t.items.len() == 0 {
         try!(write!(w, "{{ }}"));
@@ -1671,7 +1671,7 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
     // Trait documentation
     try!(document(w, it));
 
-    fn trait_item(w: &mut fmt::Formatter, m: &clean::TraitItem)
+    fn trait_item(w: &mut fmt::Formatter, m: &clean::TraitMethod)
                   -> fmt::Result {
         try!(write!(w, "<h3 id='{}.{}' class='method'>{}<code>",
                     shortty(m.item()),
@@ -2180,7 +2180,7 @@ fn item_macro(w: &mut fmt::Formatter, it: &clean::Item,
 
 fn item_primitive(w: &mut fmt::Formatter,
                   it: &clean::Item,
-                  _p: &clean::Primitive) -> fmt::Result {
+                  _p: &clean::PrimitiveType) -> fmt::Result {
     try!(document(w, it));
     render_methods(w, it)
 }

--- a/src/librustdoc/stability_summary.rs
+++ b/src/librustdoc/stability_summary.rs
@@ -21,7 +21,7 @@ use syntax::attr::{Deprecated, Experimental, Unstable, Stable, Frozen, Locked};
 use syntax::ast::Public;
 
 use clean::{Crate, Item, ModuleItem, Module, StructItem, Struct, EnumItem, Enum};
-use clean::{ImplItem, Impl, Trait, TraitItem, ProvidedMethod, RequiredMethod};
+use clean::{ImplItem, Impl, Trait, TraitItem, TraitMethod, ProvidedMethod, RequiredMethod};
 use clean::{TypeTraitItem, ViewItemItem, PrimitiveItem};
 
 #[deriving(Zero, Encodable, Decodable, PartialEq, Eq)]
@@ -128,7 +128,7 @@ fn summarize_item(item: &Item) -> (Counts, Option<ModuleSummary>) {
             items: ref trait_items,
             ..
         }) => {
-            fn extract_item<'a>(trait_item: &'a TraitItem) -> &'a Item {
+            fn extract_item<'a>(trait_item: &'a TraitMethod) -> &'a Item {
                 match *trait_item {
                     ProvidedMethod(ref item) |
                     RequiredMethod(ref item) |

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -28,7 +28,7 @@ Data types that can be encoded are JavaScript types (see the `Json` enum for mor
 * `Boolean`: equivalent to rust's `bool`
 * `Number`: equivalent to rust's `f64`
 * `String`: equivalent to rust's `String`
-* `Array`: equivalent to rust's `Vec<T>`, but also allowing objects of different types in the same
+* `List`: equivalent to rust's `Vec<T>`, but also allowing objects of different types in the same
 array
 * `Object`: equivalent to rust's `Treemap<String, json::Json>`
 * `Null`
@@ -201,7 +201,7 @@ use std::io::MemWriter;
 use std::mem::{swap, transmute};
 use std::num::{FPNaN, FPInfinite};
 use std::str::ScalarValue;
-use std::string::String;
+use std::string;
 use std::vec::Vec;
 
 use Encodable;
@@ -212,15 +212,15 @@ pub enum Json {
     I64(i64),
     U64(u64),
     F64(f64),
-    String(String),
+    String(string::String),
     Boolean(bool),
-    List(List),
-    Object(Object),
+    List(JsonList),
+    Object(JsonObject),
     Null,
 }
 
-pub type List = Vec<Json>;
-pub type Object = TreeMap<String, Json>;
+pub type JsonList = Vec<Json>;
+pub type JsonObject = TreeMap<string::String, Json>;
 
 /// The errors that can arise while parsing a JSON stream.
 #[deriving(Clone, PartialEq)]
@@ -257,10 +257,10 @@ pub type BuilderError = ParserError;
 #[deriving(Clone, PartialEq, Show)]
 pub enum DecoderError {
     ParseError(ParserError),
-    ExpectedError(String, String),
-    MissingFieldError(String),
-    UnknownVariantError(String),
-    ApplicationError(String)
+    ExpectedError(string::String, string::String),
+    MissingFieldError(string::String),
+    UnknownVariantError(string::String),
+    ApplicationError(string::String)
 }
 
 /// Returns a readable error string for a given error code.
@@ -298,9 +298,9 @@ pub fn decode<T: ::Decodable<Decoder, DecoderError>>(s: &str) -> DecodeResult<T>
 }
 
 /// Shortcut function to encode a `T` into a JSON `String`
-pub fn encode<'a, T: Encodable<Encoder<'a>, io::IoError>>(object: &T) -> String {
+pub fn encode<'a, T: Encodable<Encoder<'a>, io::IoError>>(object: &T) -> string::String {
     let buff = Encoder::buffer_encode(object);
-    String::from_utf8(buff).unwrap()
+    string::String::from_utf8(buff).unwrap()
 }
 
 impl fmt::Show for ErrorCode {
@@ -375,9 +375,9 @@ fn spaces(wr: &mut io::Writer, mut n: uint) -> Result<(), io::IoError> {
     }
 }
 
-fn fmt_number_or_null(v: f64) -> String {
+fn fmt_number_or_null(v: f64) -> string::String {
     match v.classify() {
-        FPNaN | FPInfinite => String::from_str("null"),
+        FPNaN | FPInfinite => string::String::from_str("null"),
         _ => f64::to_str_digits(v, 6u)
     }
 }
@@ -411,7 +411,7 @@ impl<'a> Encoder<'a> {
     ///
     /// Note: this function is deprecated. Consider using `json::encode` instead.
     #[deprecated = "Replaced by `json::encode`"]
-    pub fn str_encode<T: Encodable<Encoder<'a>, io::IoError>>(object: &T) -> String {
+    pub fn str_encode<T: Encodable<Encoder<'a>, io::IoError>>(object: &T) -> string::String {
         encode(object)
     }
 }
@@ -877,15 +877,15 @@ impl Json {
     }
 
     /// Encodes a json value into a string
-    pub fn to_pretty_str(&self) -> String {
+    pub fn to_pretty_str(&self) -> string::String {
         let mut s = MemWriter::new();
         self.to_pretty_writer(&mut s as &mut io::Writer).unwrap();
-        String::from_utf8(s.unwrap()).unwrap()
+        string::String::from_utf8(s.unwrap()).unwrap()
     }
 
      /// If the Json value is an Object, returns the value associated with the provided key.
     /// Otherwise, returns None.
-    pub fn find<'a>(&'a self, key: &String) -> Option<&'a Json>{
+    pub fn find<'a>(&'a self, key: &string::String) -> Option<&'a Json>{
         match self {
             &Object(ref map) => map.find(key),
             _ => None
@@ -895,7 +895,7 @@ impl Json {
     /// Attempts to get a nested Json Object for each key in `keys`.
     /// If any key is found not to exist, find_path will return None.
     /// Otherwise, it will return the Json value associated with the final key.
-    pub fn find_path<'a>(&'a self, keys: &[&String]) -> Option<&'a Json>{
+    pub fn find_path<'a>(&'a self, keys: &[&string::String]) -> Option<&'a Json>{
         let mut target = self;
         for key in keys.iter() {
             match target.find(*key) {
@@ -909,7 +909,7 @@ impl Json {
     /// If the Json value is an Object, performs a depth-first search until
     /// a value associated with the provided key is found. If no value is found
     /// or the Json value is not an Object, returns None.
-    pub fn search<'a>(&'a self, key: &String) -> Option<&'a Json> {
+    pub fn search<'a>(&'a self, key: &string::String) -> Option<&'a Json> {
         match self {
             &Object(ref map) => {
                 match map.find(key) {
@@ -937,7 +937,7 @@ impl Json {
 
     /// If the Json value is an Object, returns the associated TreeMap.
     /// Returns None otherwise.
-    pub fn as_object<'a>(&'a self) -> Option<&'a Object> {
+    pub fn as_object<'a>(&'a self) -> Option<&'a JsonObject> {
         match self {
             &Object(ref map) => Some(map),
             _ => None
@@ -951,7 +951,7 @@ impl Json {
 
     /// If the Json value is a List, returns the associated vector.
     /// Returns None otherwise.
-    pub fn as_list<'a>(&'a self) -> Option<&'a List> {
+    pub fn as_list<'a>(&'a self) -> Option<&'a JsonList> {
         match self {
             &List(ref list) => Some(&*list),
             _ => None
@@ -1075,7 +1075,7 @@ pub enum JsonEvent {
     I64Value(i64),
     U64Value(u64),
     F64Value(f64),
-    StringValue(String),
+    StringValue(string::String),
     NullValue,
     Error(ParserError),
 }
@@ -1083,7 +1083,7 @@ pub enum JsonEvent {
 #[deriving(PartialEq, Show)]
 enum ParserState {
     // Parse a value in a list, true means first element.
-    ParseList(bool),
+    ParseArray(bool),
     // Parse ',' or ']' after an element in a list.
     ParseListComma,
     // Parse a key:value in an object, true means first element.
@@ -1191,7 +1191,7 @@ impl Stack {
     }
 
     // Used by Parser to insert Key elements at the top of the stack.
-    fn push_key(&mut self, key: String) {
+    fn push_key(&mut self, key: string::String) {
         self.stack.push(InternalKey(self.str_buffer.len() as u16, key.len() as u16));
         for c in key.as_bytes().iter() {
             self.str_buffer.push(*c);
@@ -1502,9 +1502,9 @@ impl<T: Iterator<char>> Parser<T> {
         Ok(n)
     }
 
-    fn parse_str(&mut self) -> Result<String, ParserError> {
+    fn parse_str(&mut self) -> Result<string::String, ParserError> {
         let mut escape = false;
-        let mut res = String::new();
+        let mut res = string::String::new();
 
         loop {
             self.bump();
@@ -1574,7 +1574,7 @@ impl<T: Iterator<char>> Parser<T> {
             // The only paths where the loop can spin a new iteration
             // are in the cases ParseListComma and ParseObjectComma if ','
             // is parsed. In these cases the state is set to (respectively)
-            // ParseList(false) and ParseObject(false), which always return,
+            // ParseArray(false) and ParseObject(false), which always return,
             // so there is no risk of getting stuck in an infinite loop.
             // All other paths return before the end of the loop's iteration.
             self.parse_whitespace();
@@ -1583,7 +1583,7 @@ impl<T: Iterator<char>> Parser<T> {
                 ParseStart => {
                     return self.parse_start();
                 }
-                ParseList(first) => {
+                ParseArray(first) => {
                     return self.parse_list(first);
                 }
                 ParseListComma => {
@@ -1615,7 +1615,7 @@ impl<T: Iterator<char>> Parser<T> {
         let val = self.parse_value();
         self.state = match val {
             Error(_) => { ParseFinished }
-            ListStart => { ParseList(true) }
+            ListStart => { ParseArray(true) }
             ObjectStart => { ParseObject(true) }
             _ => { ParseBeforeFinish }
         };
@@ -1647,7 +1647,7 @@ impl<T: Iterator<char>> Parser<T> {
 
         self.state = match val {
             Error(_) => { ParseFinished }
-            ListStart => { ParseList(true) }
+            ListStart => { ParseArray(true) }
             ObjectStart => { ParseObject(true) }
             _ => { ParseListComma }
         };
@@ -1657,7 +1657,7 @@ impl<T: Iterator<char>> Parser<T> {
     fn parse_list_comma_or_end(&mut self) -> Option<JsonEvent> {
         if self.ch_is(',') {
             self.stack.bump_index();
-            self.state = ParseList(false);
+            self.state = ParseArray(false);
             self.bump();
             return None;
         } else if self.ch_is(']') {
@@ -1728,7 +1728,7 @@ impl<T: Iterator<char>> Parser<T> {
 
         self.state = match val {
             Error(_) => { ParseFinished }
-            ListStart => { ParseList(true) }
+            ListStart => { ParseArray(true) }
             ObjectStart => { ParseObject(true) }
             _ => { ParseObjectComma }
         };
@@ -1830,7 +1830,7 @@ impl<T: Iterator<char>> Builder<T> {
             Some(F64Value(n)) => { Ok(F64(n)) }
             Some(BooleanValue(b)) => { Ok(Boolean(b)) }
             Some(StringValue(ref mut s)) => {
-                let mut temp = String::new();
+                let mut temp = string::String::new();
                 swap(s, &mut temp);
                 Ok(String(temp))
             }
@@ -2034,7 +2034,7 @@ impl ::Decoder<DecoderError> for Decoder {
         Err(ExpectedError("single character string".to_string(), format!("{}", s)))
     }
 
-    fn read_str(&mut self) -> DecodeResult<String> {
+    fn read_str(&mut self) -> DecodeResult<string::String> {
         debug!("read_str");
         expect!(self.pop(), String)
     }
@@ -2284,7 +2284,7 @@ impl ToJson for bool {
     fn to_json(&self) -> Json { Boolean(*self) }
 }
 
-impl ToJson for String {
+impl ToJson for string::String {
     fn to_json(&self) -> Json { String((*self).clone()) }
 }
 
@@ -2328,7 +2328,7 @@ impl<A: ToJson> ToJson for Vec<A> {
     fn to_json(&self) -> Json { List(self.iter().map(|elt| elt.to_json()).collect()) }
 }
 
-impl<A: ToJson> ToJson for TreeMap<String, A> {
+impl<A: ToJson> ToJson for TreeMap<string::String, A> {
     fn to_json(&self) -> Json {
         let mut d = TreeMap::new();
         for (key, value) in self.iter() {
@@ -2338,7 +2338,7 @@ impl<A: ToJson> ToJson for TreeMap<String, A> {
     }
 }
 
-impl<A: ToJson> ToJson for HashMap<String, A> {
+impl<A: ToJson> ToJson for HashMap<string::String, A> {
     fn to_json(&self) -> Json {
         let mut d = TreeMap::new();
         for (key, value) in self.iter() {
@@ -2375,7 +2375,7 @@ mod tests {
     extern crate test;
     use self::test::Bencher;
     use {Encodable, Decodable};
-    use super::{Encoder, Decoder, Error, Boolean, I64, U64, F64, List, String, Null,
+    use super::{List, Encoder, Decoder, Error, Boolean, I64, U64, F64, String, Null,
                 PrettyEncoder, Object, Json, from_str, ParseError, ExpectedError,
                 MissingFieldError, UnknownVariantError, DecodeResult, DecoderError,
                 JsonEvent, Parser, StackElement,
@@ -2386,6 +2386,7 @@ mod tests {
                 TrailingCharacters, TrailingComma};
     use std::{i64, u64, f32, f64, io};
     use std::collections::TreeMap;
+    use std::string;
 
     #[deriving(Decodable, Eq, PartialEq, Show)]
     struct OptionData {
@@ -2417,14 +2418,14 @@ mod tests {
     #[deriving(PartialEq, Encodable, Decodable, Show)]
     enum Animal {
         Dog,
-        Frog(String, int)
+        Frog(string::String, int)
     }
 
     #[deriving(PartialEq, Encodable, Decodable, Show)]
     struct Inner {
         a: (),
         b: uint,
-        c: Vec<String>,
+        c: Vec<string::String>,
     }
 
     #[deriving(PartialEq, Encodable, Decodable, Show)]
@@ -2432,7 +2433,7 @@ mod tests {
         inner: Vec<Inner>,
     }
 
-    fn mk_object(items: &[(String, Json)]) -> Json {
+    fn mk_object(items: &[(string::String, Json)]) -> Json {
         let mut d = TreeMap::new();
 
         for item in items.iter() {
@@ -2610,7 +2611,7 @@ mod tests {
                    from_str(a.to_pretty_str().as_slice()).unwrap());
     }
 
-    fn with_str_writer(f: |&mut io::Writer|) -> String {
+    fn with_str_writer(f: |&mut io::Writer|) -> string::String {
         use std::io::MemWriter;
         use std::str;
 
@@ -2678,7 +2679,7 @@ mod tests {
 
     #[test]
     fn test_write_none() {
-        let value: Option<String> = None;
+        let value: Option<string::String> = None;
         let s = with_str_writer(|writer| {
             let mut encoder = Encoder::new(writer);
             value.encode(&mut encoder).unwrap();
@@ -2825,7 +2826,7 @@ mod tests {
                  ("\"\\uAB12\"", "\uAB12")];
 
         for &(i, o) in s.iter() {
-            let v: String = super::decode(i).unwrap();
+            let v: string::String = super::decode(i).unwrap();
             assert_eq!(v.as_slice(), o);
         }
     }
@@ -2959,10 +2960,10 @@ mod tests {
 
     #[test]
     fn test_decode_option() {
-        let value: Option<String> = super::decode("null").unwrap();
+        let value: Option<string::String> = super::decode("null").unwrap();
         assert_eq!(value, None);
 
-        let value: Option<String> = super::decode("\"jodhpurs\"").unwrap();
+        let value: Option<string::String> = super::decode("\"jodhpurs\"").unwrap();
         assert_eq!(value, Some("jodhpurs".to_string()));
     }
 
@@ -2980,7 +2981,7 @@ mod tests {
     fn test_decode_map() {
         let s = "{\"a\": \"Dog\", \"b\": {\"variant\":\"Frog\",\
                   \"fields\":[\"Henry\", 349]}}";
-        let mut map: TreeMap<String, Animal> = super::decode(s).unwrap();
+        let mut map: TreeMap<string::String, Animal> = super::decode(s).unwrap();
 
         assert_eq!(map.pop(&"a".to_string()), Some(Dog));
         assert_eq!(map.pop(&"b".to_string()), Some(Frog("Henry".to_string(), 349)));
@@ -2997,13 +2998,13 @@ mod tests {
     struct DecodeStruct {
         x: f64,
         y: bool,
-        z: String,
+        z: string::String,
         w: Vec<DecodeStruct>
     }
     #[deriving(Decodable)]
     enum DecodeEnum {
         A(f64),
-        B(String)
+        B(string::String)
     }
     fn check_err<T: Decodable<Decoder, DecoderError>>(to_parse: &'static str,
                                                       expected: DecoderError) {
@@ -3709,7 +3710,7 @@ mod tests {
         });
     }
 
-    fn big_json() -> String {
+    fn big_json() -> string::String {
         let mut src = "[\n".to_string();
         for _ in range(0i, 500) {
             src.push_str(r#"{ "a": true, "b": null, "c":3.1415, "d": "Hello world", "e": \

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -304,10 +304,10 @@ macro_rules! println(
 #[macro_export]
 macro_rules! local_data_key(
     ($name:ident: $ty:ty) => (
-        static $name: ::std::local_data::Key<$ty> = &::std::local_data::Key;
+        static $name: ::std::local_data::Key<$ty> = &::std::local_data::KeyValueKey;
     );
     (pub $name:ident: $ty:ty) => (
-        pub static $name: ::std::local_data::Key<$ty> = &::std::local_data::Key;
+        pub static $name: ::std::local_data::Key<$ty> = &::std::local_data::KeyValueKey;
     );
 )
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -305,11 +305,11 @@ pub enum SyntaxExtension {
     /// based upon it.
     ///
     /// `#[deriving(...)]` is an `ItemDecorator`.
-    ItemDecorator(Box<ItemDecorator + 'static>),
+    Decorator(Box<ItemDecorator + 'static>),
 
     /// A syntax extension that is attached to an item and modifies it
     /// in-place.
-    ItemModifier(Box<ItemModifier + 'static>),
+    Modifier(Box<ItemModifier + 'static>),
 
     /// A normal, function-like syntax extension.
     ///
@@ -387,7 +387,7 @@ fn initial_syntax_expander_table() -> SyntaxEnv {
                             builtin_normal_expander(
                                     ext::log_syntax::expand_syntax_ext));
     syntax_expanders.insert(intern("deriving"),
-                            ItemDecorator(box ext::deriving::expand_meta_deriving));
+                            Decorator(box ext::deriving::expand_meta_deriving));
 
     // Quasi-quoting expanders
     syntax_expanders.insert(intern("quote_tokens"),

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -254,7 +254,7 @@ pub fn expand_item(it: P<ast::Item>, fld: &mut MacroExpander)
 
         match fld.cx.syntax_env.find(&intern(mname.get())) {
             Some(rc) => match *rc {
-                ItemDecorator(ref dec) => {
+                Decorator(ref dec) => {
                     attr::mark_used(attr);
 
                     fld.cx.bt_push(ExpnInfo {
@@ -311,7 +311,7 @@ fn expand_item_modifiers(mut it: P<ast::Item>, fld: &mut MacroExpander)
     // partition the attributes into ItemModifiers and others
     let (modifiers, other_attrs) = it.attrs.partitioned(|attr| {
         match fld.cx.syntax_env.find(&intern(attr.name().get())) {
-            Some(rc) => match *rc { ItemModifier(_) => true, _ => false },
+            Some(rc) => match *rc { Modifier(_) => true, _ => false },
             _ => false
         }
     });
@@ -330,7 +330,7 @@ fn expand_item_modifiers(mut it: P<ast::Item>, fld: &mut MacroExpander)
 
         match fld.cx.syntax_env.find(&intern(mname.get())) {
             Some(rc) => match *rc {
-                ItemModifier(ref mac) => {
+                Modifier(ref mac) => {
                     attr::mark_used(attr);
                     fld.cx.bt_push(ExpnInfo {
                         call_site: attr.span,

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -60,7 +60,7 @@
 //! avoid combining it with other lines and making matters even worse.
 
 use std::io;
-use std::string::String;
+use std::string;
 
 #[deriving(Clone, PartialEq)]
 pub enum Breaks {
@@ -82,7 +82,7 @@ pub struct BeginToken {
 
 #[deriving(Clone)]
 pub enum Token {
-    String(String, int),
+    String(string::String, int),
     Break(BreakToken),
     Begin(BeginToken),
     End,
@@ -107,7 +107,7 @@ impl Token {
     }
 }
 
-pub fn tok_str(t: Token) -> String {
+pub fn tok_str(t: Token) -> string::String {
     match t {
         String(s, len) => return format!("STR({},{})", s, len),
         Break(_) => return "BREAK".to_string(),
@@ -122,12 +122,12 @@ pub fn buf_str(toks: Vec<Token>,
                left: uint,
                right: uint,
                lim: uint)
-               -> String {
+               -> string::String {
     let n = toks.len();
     assert_eq!(n, szs.len());
     let mut i = left;
     let mut l = lim;
-    let mut s = String::from_str("[");
+    let mut s = string::String::from_str("[");
     while i != right && l != 0u {
         l -= 1u;
         if i != left {

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -41,7 +41,7 @@ enum FormatState {
 #[allow(missing_doc)]
 #[deriving(Clone)]
 pub enum Param {
-    String(String),
+    Words(String),
     Number(int)
 }
 
@@ -140,8 +140,8 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     '{' => state = IntConstant(0),
                     'l' => if stack.len() > 0 {
                         match stack.pop().unwrap() {
-                            String(s) => stack.push(Number(s.len() as int)),
-                            _         => return Err("a non-str was used with %l".to_string())
+                            Words(s) => stack.push(Number(s.len() as int)),
+                            _        => return Err("a non-str was used with %l".to_string())
                         }
                     } else { return Err("stack is empty".to_string()) },
                     '+' => if stack.len() > 1 {
@@ -543,7 +543,7 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
             }
             s
         }
-        String(s) => {
+        Words(s) => {
             match op {
                 FormatString => {
                     let mut s = Vec::from_slice(s.as_bytes());
@@ -575,7 +575,7 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
 
 #[cfg(test)]
 mod test {
-    use super::{expand,String,Variables,Number};
+    use super::{expand,Words,Variables,Number};
     use std::result::Ok;
 
     #[test]
@@ -611,7 +611,7 @@ mod test {
             assert!(res.is_err(),
                     "Op {} succeeded incorrectly with 0 stack entries", *cap);
             let p = if *cap == "%s" || *cap == "%l" {
-                String("foo".to_string())
+                Words("foo".to_string())
             } else {
                 Number(97)
             };
@@ -689,12 +689,12 @@ mod test {
         let mut varstruct = Variables::new();
         let vars = &mut varstruct;
         assert_eq!(expand(b"%p1%s%p2%2s%p3%2s%p4%.2s",
-                          [String("foo".to_string()),
-                           String("foo".to_string()),
-                           String("f".to_string()),
-                           String("foo".to_string())], vars),
+                          [Words("foo".to_string()),
+                           Words("foo".to_string()),
+                           Words("f".to_string()),
+                           Words("foo".to_string())], vars),
                    Ok("foofoo ffo".bytes().collect()));
-        assert_eq!(expand(b"%p1%:-4.2s", [String("foo".to_string())], vars),
+        assert_eq!(expand(b"%p1%:-4.2s", [Words("foo".to_string())], vars),
                    Ok("fo  ".bytes().collect()));
 
         assert_eq!(expand(b"%p1%d%p1%.3d%p1%5d%p1%:+d", [Number(1)], vars),

--- a/src/test/auxiliary/macro_crate_test.rs
+++ b/src/test/auxiliary/macro_crate_test.rs
@@ -35,7 +35,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_macro("identity", expand_identity);
     reg.register_syntax_extension(
         token::intern("into_foo"),
-        ItemModifier(box expand_into_foo));
+        Modifier(box expand_into_foo));
 }
 
 fn expand_make_a_1(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree])

--- a/src/test/auxiliary/xcrate_unit_struct.rs
+++ b/src/test/auxiliary/xcrate_unit_struct.rs
@@ -15,7 +15,7 @@
 pub struct Struct;
 
 pub enum Unit {
-    Unit,
+    UnitVariant,
     Argument(Struct)
 }
 

--- a/src/test/compile-fail/enum-variant-type-2.rs
+++ b/src/test/compile-fail/enum-variant-type-2.rs
@@ -8,11 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum foo { foo_(bar) }
-struct bar { x: bar }
-//~^ ERROR illegal recursive struct type; wrap the inner value in a box to make it representable
-//~^^ ERROR this type cannot be instantiated without an instance of itself
+// Test that enum variants are not actually types.
 
-fn main() {
+enum Foo {
+    Bar
 }
 
+fn foo(x: Bar) {} //~ERROR found value name used as a type
+
+fn main() {}

--- a/src/test/compile-fail/enum-variant-type.rs
+++ b/src/test/compile-fail/enum-variant-type.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum y { x }
+// Test that enum variants are in the type namespace.
 
-enum x {}
+enum Foo {
+    Foo //~ERROR duplicate definition of type or module `Foo`
+}
+
+enum Bar {
+    Baz
+}
+
+trait Baz {} //~ERROR duplicate definition of type or module `Baz`
 
 pub fn main() {}

--- a/src/test/compile-fail/issue-3008-1.rs
+++ b/src/test/compile-fail/issue-3008-1.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum foo { foo(bar) }
+enum foo { foo_(bar) }
 enum bar { bar_none, bar_some(bar) }
 //~^ ERROR illegal recursive enum type; wrap the inner value in a box to make it representable
 

--- a/src/test/compile-fail/recursion.rs
+++ b/src/test/compile-fail/recursion.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum Nil {Nil}
+enum Nil {NilValue}
 struct Cons<T> {head:int, tail:T}
 trait Dot {fn dot(&self, other:Self) -> int;}
 impl Dot for Nil {
@@ -29,6 +29,6 @@ fn test<T:Dot> (n:int, i:int, first:T, second:T) ->int {
   }
 }
 pub fn main() {
-  let n = test(1, 0, Nil, Nil);
+  let n = test(1, 0, NilValue, NilValue);
   println!("{}", n);
 }

--- a/src/test/pretty/tag-blank-lines.rs
+++ b/src/test/pretty/tag-blank-lines.rs
@@ -11,8 +11,8 @@
 // pp-exact
 
 enum foo {
-    foo, // a foo.
-    bar,
+    bar, // a bar.
+    baz,
 }
 
 fn main() { }

--- a/src/test/run-fail/issue-2444.rs
+++ b/src/test/run-fail/issue-2444.rs
@@ -12,7 +12,7 @@
 
 use std::sync::Arc;
 
-enum e<T> { e(Arc<T>) }
+enum e<T> { ee(Arc<T>) }
 
 fn foo() -> e<int> {fail!();}
 

--- a/src/test/run-pass/borrowck-univariant-enum.rs
+++ b/src/test/run-pass/borrowck-univariant-enum.rs
@@ -13,7 +13,7 @@ use std::cell::Cell;
 use std::gc::GC;
 
 enum newtype {
-    newtype(int)
+    newvar(int)
 }
 
 pub fn main() {
@@ -22,9 +22,9 @@ pub fn main() {
     // specially.
 
     let x = box(GC) Cell::new(5);
-    let y = box(GC) Cell::new(newtype(3));
+    let y = box(GC) Cell::new(newvar(3));
     let z = match y.get() {
-      newtype(b) => {
+      newvar(b) => {
         x.set(x.get() + 1);
         x.get() * b
       }

--- a/src/test/run-pass/coerce-to-closure-and-proc.rs
+++ b/src/test/run-pass/coerce-to-closure-and-proc.rs
@@ -17,7 +17,7 @@ struct Foo<T>(T);
 
 #[deriving(PartialEq, Show)]
 enum Bar<T> {
-    Bar(T)
+    Baz(T)
 }
 
 pub fn main() {
@@ -33,11 +33,11 @@ pub fn main() {
     let f: proc(int) -> Foo<int> = Foo;
     assert_eq!(f(5), Foo(5));
 
-    let f: |int| -> Bar<int> = Bar;
-    assert_eq!(f(5), Bar(5));
+    let f: |int| -> Bar<int> = Baz;
+    assert_eq!(f(5), Baz(5));
 
-    let f: proc(int) -> Bar<int> = Bar;
-    assert_eq!(f(5), Bar(5));
+    let f: proc(int) -> Bar<int> = Baz;
+    assert_eq!(f(5), Baz(5));
 
     let f: |int| -> Option<int> = Some;
     assert_eq!(f(5), Some(5));

--- a/src/test/run-pass/issue-2804.rs
+++ b/src/test/run-pass/issue-2804.rs
@@ -22,7 +22,7 @@ enum object {
     int_value(i64),
 }
 
-fn lookup(table: json::Object, key: String, default: String) -> String
+fn lookup(table: json::JsonObject, key: String, default: String) -> String
 {
     match table.find(&key.to_string()) {
         option::Some(&json::String(ref s)) => {

--- a/src/test/run-pass/issue-3874.rs
+++ b/src/test/run-pass/issue-3874.rs
@@ -8,10 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum PureCounter { PureCounter(uint) }
+enum PureCounter { PureCounterVariant(uint) }
 
 fn each(thing: PureCounter, blk: |v: &uint|) {
-    let PureCounter(ref x) = thing;
+    let PureCounterVariant(ref x) = thing;
     blk(x);
 }
 

--- a/src/test/run-pass/match-arm-statics.rs
+++ b/src/test/run-pass/match-arm-statics.rs
@@ -88,10 +88,10 @@ fn issue_14576() {
 }
 
 fn issue_13731() {
-    enum A { A(()) }
-    static B: A = A(());
+    enum A { AA(()) }
+    static B: A = AA(());
 
-    match A(()) {
+    match AA(()) {
         B => ()
     }
 }

--- a/src/test/run-pass/tag-align-shape.rs
+++ b/src/test/run-pass/tag-align-shape.rs
@@ -11,7 +11,7 @@
 extern crate debug;
 
 enum a_tag {
-    a_tag(u64)
+    a_tag_var(u64)
 }
 
 struct t_rec {
@@ -20,8 +20,8 @@ struct t_rec {
 }
 
 pub fn main() {
-    let x = t_rec {c8: 22u8, t: a_tag(44u64)};
+    let x = t_rec {c8: 22u8, t: a_tag_var(44u64)};
     let y = format!("{:?}", x);
     println!("y = {}", y);
-    assert_eq!(y, "t_rec{c8: 22u8, t: a_tag(44u64)}".to_string());
+    assert_eq!(y, "t_rec{c8: 22u8, t: a_tag_var(44u64)}".to_string());
 }

--- a/src/test/run-pass/tag-align-u64.rs
+++ b/src/test/run-pass/tag-align-u64.rs
@@ -14,7 +14,7 @@
 use std::mem;
 
 enum Tag {
-    Tag(u64)
+    TagInner(u64)
 }
 
 struct Rec {
@@ -23,7 +23,7 @@ struct Rec {
 }
 
 fn mk_rec() -> Rec {
-    return Rec { c8:0u8, t:Tag(0u64) };
+    return Rec { c8:0u8, t:TagInner(0u64) };
 }
 
 fn is_8_byte_aligned(u: &Tag) -> bool {

--- a/src/test/run-pass/xcrate-unit-struct.rs
+++ b/src/test/run-pass/xcrate-unit-struct.rs
@@ -12,7 +12,7 @@
 extern crate xcrate_unit_struct;
 
 static s1: xcrate_unit_struct::Struct = xcrate_unit_struct::Struct;
-static s2: xcrate_unit_struct::Unit = xcrate_unit_struct::Unit;
+static s2: xcrate_unit_struct::Unit = xcrate_unit_struct::UnitVariant;
 static s3: xcrate_unit_struct::Unit =
                 xcrate_unit_struct::Argument(xcrate_unit_struct::Struct);
 static s4: xcrate_unit_struct::Unit = xcrate_unit_struct::Argument(s1);
@@ -22,7 +22,7 @@ fn f2(_: xcrate_unit_struct::Unit) {}
 
 pub fn main() {
     f1(xcrate_unit_struct::Struct);
-    f2(xcrate_unit_struct::Unit);
+    f2(xcrate_unit_struct::UnitVariant);
     f2(xcrate_unit_struct::Argument(xcrate_unit_struct::Struct));
 
     f1(s1);


### PR DESCRIPTION
Change to resolve and update compiler and libs for uses.

[breaking-change]

Enum variants are now in both the value and type namespaces. This means that
if you have a variant with the same name as a type in scope in a module, you
will get a name clash and thus an error. The solution is to either rename the
type or the variant.

closes #17323

r? anyone? (I realise this still needs a cfail test (and the commit message, I just noticed), but otherwise does it look OK? I expect some of the new names could be better).
