### PR TITLE
test: Un-ignore some GDB pretty printing tests

### DIFF
--- a/src/test/debuginfo/gdb-pretty-struct-and-enums-pre-gdb-7-7.rs
+++ b/src/test/debuginfo/gdb-pretty-struct-and-enums-pre-gdb-7-7.rs
@@ -12,7 +12,6 @@
 // older versions of GDB too. A more extensive test can be found in
 // gdb-pretty-struct-and-enums.rs
 
-// ignore-test FIXME(#16919)
 // ignore-tidy-linelength
 // ignore-lldb
 // ignore-android: FIXME(#10381)

--- a/src/test/debuginfo/gdb-pretty-struct-and-enums.rs
+++ b/src/test/debuginfo/gdb-pretty-struct-and-enums.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-test FIXME(#16919)
 // ignore-tidy-linelength
 // ignore-lldb
 // ignore-android: FIXME(#10381)


### PR DESCRIPTION
I've confirmed that these are working on the snapshot builders

Closes #16919
