### PR TITLE
libgetopts: align for non-existing short options

### DIFF
--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -683,7 +683,9 @@ pub fn usage(brief: &str, opts: &[OptGroup]) -> String {
 
         // short option
         match short_name.len() {
-            0 => {}
+            0 => {
+                row.push_str("   ");
+            }
             1 => {
                 row.push_char('-');
                 row.push_str(short_name.as_slice());


### PR DESCRIPTION
I'm not sure if I need to make changes to tests, existing test of libgetopts doesn't check `usage` output.
