### PR TITLE
Remove unstable marker from std::rt

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -263,7 +263,6 @@ pub mod fmt;
 
 // FIXME #7809: This shouldn't be pub, and it should be reexported under 'unstable'
 // but name resolution doesn't work without it being pub.
-#[unstable]
 pub mod rt;
 mod failure;
 


### PR DESCRIPTION
The `std::rt` module was marked `unstable` [a while back](https://github.com/rust-lang/rust/commit/b6d4d117f4c2770649c7ddc2ad9ad4ce4c3b13b1), and this change was not reverted when we moved to an `experimental` baseline for `std`.
