### PR TITLE
Fix warning and make code follow the text better

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -1577,8 +1577,6 @@ we haven't seen before. Here's a simple program that reads some input,
 and then prints it back out:
 
 ```{rust,ignore}
-use std::io;
-
 fn main() {
     println!("Type something!");
 


### PR DESCRIPTION
Without this change, this piece of code throws a warning because `std::io` is imported, and then `std::io::stdin` is used explicitly.

From reading the paragraphs that follow that code, I assume that the original intent of the author was to show that code without the first line, the `use` line. That way, the text seems to make better sense to me.
