### PR TITLE
Document that CStrings live in the libc heap

### DIFF
--- a/src/librustrt/c_str.rs
+++ b/src/librustrt/c_str.rs
@@ -38,8 +38,9 @@ unnecessary amounts of allocations.
 
 Be carefull to remember that the memory is managed by C allocator API and not
 by Rust allocator API.
-That means that the CString pointers should only be freed with C allocator API
-if you intend to do that on your own.
+That means that the CString pointers should be freed with C allocator API
+if you intend to do that on your own, as the behaviour if you free them with
+Rust's allocator API is not well defined
 
 An example of creating and using a C string would be:
 
@@ -137,8 +138,8 @@ impl<S: hash::Writer> hash::Hash<S> for CString {
 
 impl CString {
     /// Create a C String from a pointer, with memory managed by C's allocator
-    /// API, so do not call it with a pointer to memory managed by Rust's
-    /// allocator API.
+    /// API, so avoid calling it with a pointer to memory managed by Rust's
+    /// allocator API, as the behaviour would not be well defined.
     ///
     ///# Failure
     ///
@@ -272,7 +273,7 @@ impl CString {
     /// forgotten, meaning that the backing allocation of this
     /// `CString` is not automatically freed if it owns the
     /// allocation. In this case, a user of `.unwrap()` should ensure
-    /// the allocation is freed, to avoid leaking memory. You have to
+    /// the allocation is freed, to avoid leaking memory. You should
     /// use libc's memory allocator in this case.
     ///
     /// Prefer `.as_ptr()` when just retrieving a pointer to the

--- a/src/librustrt/c_str.rs
+++ b/src/librustrt/c_str.rs
@@ -36,10 +36,10 @@ not tied to the lifetime of the original string/data buffer). If C strings are
 heavily used in applications, then caching may be advisable to prevent
 unnecessary amounts of allocations.
 
-Be carefull to remember that the memory is managed by libc's malloc and not
-by jemalloc which is the 'normal' rust memory allocator.
-That means that the CString pointers should only be freed with 
-alloc::libc_heap::malloc_raw if you intend to do that on your own.
+Be carefull to remember that the memory is managed by C allocator API and not
+by Rust allocator API.
+That means that the CString pointers should only be freed with C allocator API
+if you intend to do that on your own.
 
 An example of creating and using a C string would be:
 
@@ -97,7 +97,7 @@ pub struct CString {
 impl Clone for CString {
     /// Clone this CString into a new, uniquely owned CString. For safety
     /// reasons, this is always a deep clone with the memory allocated
-    /// with libc's malloc, rather than the usual shallow clone.
+    /// with C's allocator API, rather than the usual shallow clone.
     fn clone(&self) -> CString {
         let len = self.len() + 1;
         let buf = unsafe { malloc_raw(len) } as *mut libc::c_char;
@@ -136,8 +136,9 @@ impl<S: hash::Writer> hash::Hash<S> for CString {
 }
 
 impl CString {
-    /// Create a C String from a pointer, with memory managed by libc's malloc,
-    /// so do not call it with a pointer allocated by jemalloc.
+    /// Create a C String from a pointer, with memory managed by C's allocator
+    /// API, so do not call it with a pointer to memory managed by Rust's
+    /// allocator API.
     ///
     ///# Failure
     ///


### PR DESCRIPTION
Insists on the fact that the memory is managed by malloc
and not jemalloc
Closes #17067
