### PR TITLE
stop clamping the DWARF version to 3 on Linux

### DIFF
--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -738,12 +738,6 @@ pub fn finalize(cx: &CrateContext) {
             cx.sess().targ_cfg.os == abi::OsiOS {
             "Dwarf Version".with_c_str(
                 |s| llvm::LLVMRustAddModuleFlag(cx.llmod(), s, 2));
-        } else if cx.sess().targ_cfg.os == abi::OsLinux {
-            // FIXME(#13611) this is a kludge fix because the Linux bots have
-            //               gdb 7.4 which doesn't understand dwarf4, we should
-            //               do something more graceful here.
-            "Dwarf Version".with_c_str(
-                |s| llvm::LLVMRustAddModuleFlag(cx.llmod(), s, 3));
         }
 
         // Prevent bitcode readers from deleting the debug info.


### PR DESCRIPTION
Closes #13611
