### PR TITLE
resolve: allow limited inherent impl's outside of the implementee's module.

### DIFF
--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1417,12 +1417,27 @@ impl<'a> Resolver<'a> {
                             }
                         }
                     }
-                    _ => {
-                        self.resolve_error(ty.span,
-                                           "inherent implementations may \
-                                            only be implemented in the same \
-                                            module as the type they are \
-                                            implemented for")
+                    _ => for impl_item in impl_items.iter() {
+                        // Forbid static methods and associated items.
+                        match *impl_item {
+                            MethodImplItem(ref method) => {
+                                match method.pe_explicit_self().node {
+                                    SelfStatic => {
+                                        self.resolve_error(method.span,
+                                            "inherent implementations in a different \
+                                             module than the type they are implemented \
+                                             for may not contain static methods")
+                                    }
+                                    _ => {}
+                                }
+                            }
+                            TypeImplItem(ref typedef) => {
+                                self.resolve_error(typedef.span,
+                                    "inherent implementations in a different \
+                                     module than the type they are implemented \
+                                     for may not contain associated items")
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
Allow inherent impl's in different modules than the one the type they are implemented for is in.
Unlike regular inherent impl's, these cannot contain static methods or associated items and are not subject to UFCS.
**NOTE**: this requires an RFC amending [RFC 57](https://github.com/rust-lang/rfcs/blob/master/active/0057-anonymous-impl-only-in-same-module.md).
