### PR TITLE
std: Don't require bitflags! be u32

### DIFF
--- a/src/libstd/bitflags.rs
+++ b/src/libstd/bitflags.rs
@@ -223,7 +223,7 @@ macro_rules! bitflags {
     }) => {
         bitflags! {
             $(#[$attr])*
-            flags $BitFlags: u32 {
+            flags $BitFlags: $T {
                 $($(#[$Flag_attr])* static $Flag = $value),+
             }
         }
@@ -252,6 +252,12 @@ mod tests {
             static FlagABC     = FlagA.bits
                                | FlagB.bits
                                | FlagC.bits,
+        }
+    }
+
+    bitflags! {
+        flags AnotherSetOfFlags: uint {
+            static AnotherFlag = 1u,
         }
     }
 


### PR DESCRIPTION
If you didn't have a trailing comma at the end of the variants, you could use
any type you wanted, but if you used a trailing comma the macro would
erroneously require the bits be a u32.
