### PR TITLE
Fix some ICEs and annoyances surrounding `!` type

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -4394,21 +4394,21 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
           check_expr(fcx, &**idx);
           let raw_base_t = fcx.expr_ty(&**base);
           let idx_t = fcx.expr_ty(&**idx);
-          if ty::type_is_error(raw_base_t) || ty::type_is_bot(raw_base_t) {
+          if ty::type_is_error(raw_base_t) {
               fcx.write_ty(id, raw_base_t);
-          } else if ty::type_is_error(idx_t) || ty::type_is_bot(idx_t) {
+          } else if ty::type_is_error(idx_t) {
               fcx.write_ty(id, idx_t);
           } else {
               let (_, autoderefs, field_ty) =
                 autoderef(fcx, expr.span, raw_base_t, Some(base.id),
                           lvalue_pref, |base_t, _| ty::index(base_t));
               match field_ty {
-                  Some(ty) => {
+                  Some(ty) if !ty::type_is_bot(ty) => {
                       check_expr_has_type(fcx, &**idx, ty::mk_uint());
                       fcx.write_ty(id, ty);
                       fcx.write_autoderef_adjustment(base.id, base.span, autoderefs);
                   }
-                  None => {
+                  _ => {
                       // This is an overloaded method.
                       let base_t = structurally_resolved_type(fcx,
                                                               expr.span,

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2156,6 +2156,10 @@ pub fn autoderef<T>(fcx: &FnCtxt, sp: Span, base_ty: ty::t,
     for autoderefs in range(0, fcx.tcx().sess.recursion_limit.get()) {
         let resolved_t = structurally_resolved_type(fcx, sp, t);
 
+        if ty::type_is_bot(resolved_t) {
+            return (resolved_t, autoderefs, None);
+        }
+
         match should_stop(resolved_t, autoderefs) {
             Some(x) => return (resolved_t, autoderefs, Some(x)),
             None => {}

--- a/src/test/compile-fail/index-bot.rs
+++ b/src/test/compile-fail/index-bot.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    (return)[0u]; //~ ERROR cannot index a value of type `!`
+}

--- a/src/test/compile-fail/issue-17373.rs
+++ b/src/test/compile-fail/issue-17373.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    *return; //~ ERROR type `!` cannot be dereferenced
+}


### PR DESCRIPTION
- Don't attempt to autoderef `!`.  The `Deref`/`DerefMut` trait lookup would generate a bunch of unhelpful error spew.
- Don't allow explicit deref of `!`, since later passes just ICE.  This closes issue #17373 
- Don't allow explicit index of `!`, since later passes just ICE.  There does not seem to be an issue associated with this
