### PR TITLE
Fixed quote_method!() implementation

### DIFF
--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -464,9 +464,13 @@ pub fn expand_quote_method(cx: &mut ExtCtxt,
                            sp: Span,
                            tts: &[ast::TokenTree])
                            -> Box<base::MacResult+'static> {
-    let e_param_colons = cx.expr_none(sp);
+    let e_attrs = cx.expr_vec_ng(sp);
+    let e_visibility = cx.expr_path(cx.path_global(sp, vec!(
+        id_ext("syntax"),
+        id_ext("ast"),
+        id_ext("Inherited"))));
     let expanded = expand_parse_call(cx, sp, "parse_method",
-                                     vec!(e_param_colons), tts);
+                                     vec!(e_attrs, e_visibility), tts);
     base::MacExpr::new(expanded)
 }
 

--- a/src/test/run-pass-fulldeps/quote-tokens.rs
+++ b/src/test/run-pass-fulldeps/quote-tokens.rs
@@ -35,6 +35,8 @@ fn syntax_extension(cx: &ExtCtxt) {
 
     let i: Option<P<syntax::ast::Item>> = quote_item!(cx, #[deriving(Eq)] struct Foo; );
     assert!(i.is_some());
+
+    let _j: P<syntax::ast::Method> = quote_method!(cx, fn foo(&self) {});
 }
 
 fn main() {


### PR DESCRIPTION
Parser.parse_method now has a second argument, I assume ast::Inherited is the correct visibility in this case.
