### PR TITLE
Minor grammar fixes.

### DIFF
--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -2928,7 +2928,7 @@ impl<'a> Resolver<'a> {
                             Some(span) => {
                                 self.session
                                     .span_note(span,
-                                               "note conflicting value here");
+                                               "conflicting value here");
                             }
                         }
                     }
@@ -2951,7 +2951,7 @@ impl<'a> Resolver<'a> {
                             Some(span) => {
                                 self.session
                                     .span_note(span,
-                                               "note conflicting type here")
+                                               "conflicting type here")
                             }
                         }
                     }


### PR DESCRIPTION
Fix grammar (double "note") in situations like:

src/reader/events.rs:120:5: 120:25 **note: note** conflicting type here
src/reader/events.rs:120     Error(common::Error)
