### PR TITLE
Indent style no longer prescribed by Rust (vim)

### DIFF
--- a/src/etc/vim/ftplugin/rust.vim
+++ b/src/etc/vim/ftplugin/rust.vim
@@ -35,8 +35,6 @@ silent! setlocal formatoptions+=j
 " otherwise it's better than nothing.
 setlocal smartindent nocindent
 
-setlocal tabstop=4 shiftwidth=4 softtabstop=4 expandtab
-
 setlocal textwidth=99
 
 " This includeexpr isn't perfect, but it's a good start


### PR DESCRIPTION
The language should not say whether you are using tabs or spaces, how long your indents are, &c. That should all be set in the .vimrc.
