### PR TITLE
Add to_c_str_opt/with_c_str_opt functions and fix an ICE

### DIFF
--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -101,6 +101,12 @@ impl ToCStr for Path {
     }
 
     #[inline]
+    fn to_c_str_opt(&self) -> Option<CString> {
+        // The Path impl guarantees no internal NUL
+        Some( unsafe { self.to_c_str_unchecked() } )
+    }
+
+    #[inline]
     unsafe fn to_c_str_unchecked(&self) -> CString {
         self.as_vec().to_c_str_unchecked()
     }
@@ -110,6 +116,11 @@ impl<'a> ToCStr for &'a Path {
     #[inline]
     fn to_c_str(&self) -> CString {
         (*self).to_c_str()
+    }
+
+    #[inline]
+    fn to_c_str_opt(&self) -> Option<CString> {
+        (*self).to_c_str_opt()
     }
 
     #[inline]

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -125,6 +125,12 @@ impl ToCStr for Path {
     }
 
     #[inline]
+    fn to_c_str_opt(&self) -> Option<CString> {
+        // The Path impl guarantees no internal NUL
+        Some(unsafe { self.to_c_str_unchecked() })
+    }
+
+    #[inline]
     unsafe fn to_c_str_unchecked(&self) -> CString {
         self.as_vec().to_c_str_unchecked()
     }
@@ -134,6 +140,11 @@ impl<'a> ToCStr for &'a Path {
     #[inline]
     fn to_c_str(&self) -> CString {
         (*self).to_c_str()
+    }
+
+    #[inline]
+    fn to_c_str_opt(&self) -> Option<CString> {
+        (*self).to_c_str_opt()
     }
 
     #[inline]


### PR DESCRIPTION
Add to_c_str_opt and with_c_str_opt functions to the ToCStr trait. These functions return an Option if the string they are passed contains a null byte, rather than failing the task like to_c_str/with_c_str.

Updated get_item_val in middle/trans/base to use these functions to fix the ICE in issue #16478.

Fixes #16478
