### PR TITLE
collections: Stabilize String

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -444,7 +444,8 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                      "-nx".to_string(),
                      format!("-command={}", debugger_script.as_str().unwrap()));
 
-            let gdb_path = tool_path.append("/bin/arm-linux-androideabi-gdb");
+            let mut gdb_path = tool_path;
+            gdb_path.push_str("/bin/arm-linux-androideabi-gdb");
             let procsrv::Result {
                 out,
                 err,

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -698,7 +698,7 @@ pub trait StrAllocating: Str {
         let me = self.as_slice();
         let mut out = String::with_capacity(me.len());
         for c in me.chars() {
-            c.escape_default(|c| out.push_char(c));
+            c.escape_default(|c| out.push(c));
         }
         out
     }
@@ -708,7 +708,7 @@ pub trait StrAllocating: Str {
         let me = self.as_slice();
         let mut out = String::with_capacity(me.len());
         for c in me.chars() {
-            c.escape_unicode(|c| out.push_char(c));
+            c.escape_unicode(|c| out.push(c));
         }
         out
     }

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -159,7 +159,7 @@ impl String {
 
         if i > 0 {
             unsafe {
-                res.push_bytes(v.slice_to(i))
+                res.as_mut_vec().push_all(v.slice_to(i))
             };
         }
 
@@ -176,10 +176,10 @@ impl String {
             macro_rules! error(() => ({
                 unsafe {
                     if subseqidx != i_ {
-                        res.push_bytes(v.slice(subseqidx, i_));
+                        res.as_mut_vec().push_all(v.slice(subseqidx, i_));
                     }
                     subseqidx = i;
-                    res.push_bytes(REPLACEMENT);
+                    res.as_mut_vec().push_all(REPLACEMENT);
                 }
             }))
 
@@ -245,7 +245,7 @@ impl String {
         }
         if subseqidx < total {
             unsafe {
-                res.push_bytes(v.slice(subseqidx, total))
+                res.as_mut_vec().push_all(v.slice(subseqidx, total))
             };
         }
         Owned(res.into_string())
@@ -271,7 +271,7 @@ impl String {
         let mut s = String::with_capacity(v.len() / 2);
         for c in str::utf16_items(v) {
             match c {
-                str::ScalarValue(c) => s.push_char(c),
+                str::ScalarValue(c) => s.push(c),
                 str::LoneSurrogate(_) => return None
             }
         }
@@ -332,6 +332,7 @@ impl String {
     /// # Example
     ///
     /// ```
+    /// # #![allow(deprecated)]
     /// let s = String::from_str("hello");
     /// let big = s.append(" ").append("world").append("!");
     /// // s has now been moved and cannot be used
@@ -362,11 +363,11 @@ impl String {
         }
 
         let mut buf = String::new();
-        buf.push_char(ch);
+        buf.push(ch);
         let size = buf.len() * length;
         buf.reserve(size);
         for _ in range(1, length) {
-            buf.push_char(ch)
+            buf.push(ch)
         }
         buf
     }
@@ -380,6 +381,7 @@ impl String {
     /// # Example
     ///
     /// ```rust
+    /// # #![allow(deprecated)]
     /// let s = String::from_byte(104);
     /// assert_eq!(s.as_slice(), "h");
     /// ```
@@ -417,7 +419,7 @@ impl String {
     #[unstable = "duplicate of iterator-based functionality"]
     pub fn grow(&mut self, count: uint, ch: char) {
         for _ in range(0, count) {
-            self.push_char(ch)
+            self.push(ch)
         }
     }
 
@@ -426,6 +428,7 @@ impl String {
     /// # Example
     ///
     /// ```
+    /// # #![allow(deprecated)]
     /// let s = String::with_capacity(10);
     /// assert!(s.byte_capacity() >= 10);
     /// ```
@@ -441,7 +444,7 @@ impl String {
     ///
     /// ```
     /// let s = String::with_capacity(10);
-    /// assert!(s.byte_capacity() >= 10);
+    /// assert!(s.capacity() >= 10);
     /// ```
     #[inline]
     #[unstable = "just implemented, needs to prove itself"]
@@ -455,9 +458,9 @@ impl String {
     ///
     /// ```
     /// let mut s = String::with_capacity(10);
-    /// let before = s.byte_capacity();
+    /// let before = s.capacity();
     /// s.reserve_additional(100);
-    /// assert!(s.byte_capacity() - before >= 100);
+    /// assert!(s.capacity() - before >= 100);
     /// ```
     #[inline]
     pub fn reserve_additional(&mut self, extra: uint) {
@@ -471,7 +474,7 @@ impl String {
     /// ```
     /// let mut s = String::new();
     /// s.reserve(10);
-    /// assert!(s.byte_capacity() >= 10);
+    /// assert!(s.capacity() >= 10);
     /// ```
     #[inline]
     pub fn reserve(&mut self, capacity: uint) {
@@ -485,7 +488,7 @@ impl String {
     /// ```
     /// let mut s = String::new();
     /// s.reserve_exact(10);
-    /// assert_eq!(s.byte_capacity(), 10);
+    /// assert_eq!(s.capacity(), 10);
     /// ```
     #[inline]
     pub fn reserve_exact(&mut self, capacity: uint) {
@@ -499,9 +502,9 @@ impl String {
     /// ```
     /// let mut s = String::from_str("foo");
     /// s.reserve(100);
-    /// assert!(s.byte_capacity() >= 100);
+    /// assert!(s.capacity() >= 100);
     /// s.shrink_to_fit();
-    /// assert_eq!(s.byte_capacity(), 3);
+    /// assert_eq!(s.capacity(), 3);
     /// ```
     #[inline]
     pub fn shrink_to_fit(&mut self) {
@@ -527,7 +530,7 @@ impl String {
     /// assert_eq!(s.as_slice(), "abc123");
     /// ```
     #[inline]
-    #[stable = "function just renamed from push_char"]
+    #[stable = "function just renamed from push"]
     pub fn push(&mut self, ch: char) {
         let cur_len = self.len();
         // This may use up to 4 bytes.
@@ -552,6 +555,7 @@ impl String {
     /// # Example
     ///
     /// ```
+    /// # #![allow(deprecated)]
     /// let mut s = String::new();
     /// unsafe {
     ///     s.push_bytes([104, 101, 108, 108, 111]);
@@ -587,6 +591,7 @@ impl String {
     /// # Example
     ///
     /// ```
+    /// # #![allow(deprecated)]
     /// let mut s = String::from_str("hello");
     /// unsafe {
     ///     let bytes = s.as_mut_bytes();
@@ -598,7 +603,7 @@ impl String {
     /// assert_eq!(s.as_slice(), "h3ll0")
     /// ```
     #[inline]
-    #[deprecated = "call .as_mut_vec().as_slice() instead"]
+    #[deprecated = "call .as_mut_vec().as_mut_slice() instead"]
     pub unsafe fn as_mut_bytes<'a>(&'a mut self) -> &'a mut [u8] {
         self.vec.as_mut_slice()
     }
@@ -631,6 +636,7 @@ impl String {
     /// # Example
     ///
     /// ```
+    /// # #![allow(deprecated)]
     /// let mut s = String::from_str("hell");
     /// unsafe {
     ///     s.push_byte(111);
@@ -652,6 +658,7 @@ impl String {
     /// # Example
     ///
     /// ```
+    /// # #![allow(deprecated)]
     /// let mut s = String::from_str("foo");
     /// unsafe {
     ///     assert_eq!(s.pop_byte(), Some(111));
@@ -714,6 +721,7 @@ impl String {
     /// # Example
     ///
     /// ```
+    /// # #![allow(deprecated)]
     /// let mut s = String::from_str("foo");
     /// unsafe {
     ///     assert_eq!(s.shift_byte(), Some(102));
@@ -722,7 +730,7 @@ impl String {
     ///     assert_eq!(s.shift_byte(), None);
     /// }
     /// ```
-    #[deprecated = "call .as_mut_rev().remove(0)"]
+    #[deprecated = "call .as_mut_vec().remove(0)"]
     pub unsafe fn shift_byte(&mut self) -> Option<u8> {
         self.vec.remove(0)
     }
@@ -782,6 +790,7 @@ impl String {
     ///
     /// If `idx` does not lie on a character boundary or is out of bounds, then
     /// this function will fail.
+    #[unstable = "the failure semantics of this function are uncertain"]
     pub fn insert(&mut self, idx: uint, ch: char) {
         let len = self.len();
         assert!(idx <= len);
@@ -854,7 +863,7 @@ impl FromIterator<char> for String {
 impl Extendable<char> for String {
     fn extend<I:Iterator<char>>(&mut self, mut iterator: I) {
         for ch in iterator {
-            self.push_char(ch)
+            self.push(ch)
         }
     }
 }
@@ -1171,13 +1180,13 @@ mod tests {
     }
 
     #[test]
-    fn test_push_char() {
+    fn test_push() {
         let mut data = String::from_str("ประเทศไทย中");
-        data.push_char('华');
-        data.push_char('b'); // 1 byte
-        data.push_char('¢'); // 2 byte
-        data.push_char('€'); // 3 byte
-        data.push_char('𤭢'); // 4 byte
+        data.push('华');
+        data.push('b'); // 1 byte
+        data.push('¢'); // 2 byte
+        data.push('€'); // 3 byte
+        data.push('𤭢'); // 4 byte
         assert_eq!(data.as_slice(), "ประเทศไทย中华b¢€𤭢");
     }
 

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -685,9 +685,9 @@ pub fn usage(brief: &str, opts: &[OptGroup]) -> String {
         match short_name.len() {
             0 => {}
             1 => {
-                row.push_char('-');
+                row.push('-');
                 row.push_str(short_name.as_slice());
-                row.push_char(' ');
+                row.push(' ');
             }
             _ => fail!("the short name should only be 1 ascii char long"),
         }
@@ -698,7 +698,7 @@ pub fn usage(brief: &str, opts: &[OptGroup]) -> String {
             _ => {
                 row.push_str("--");
                 row.push_str(long_name.as_slice());
-                row.push_char(' ');
+                row.push(' ');
             }
         }
 
@@ -707,9 +707,9 @@ pub fn usage(brief: &str, opts: &[OptGroup]) -> String {
             No => {}
             Yes => row.push_str(hint.as_slice()),
             Maybe => {
-                row.push_char('[');
+                row.push('[');
                 row.push_str(hint.as_slice());
-                row.push_char(']');
+                row.push(']');
             }
         }
 
@@ -718,7 +718,7 @@ pub fn usage(brief: &str, opts: &[OptGroup]) -> String {
         let rowlen = row.as_slice().char_len();
         if rowlen < 24 {
             for _ in range(0, 24 - rowlen) {
-                row.push_char(' ');
+                row.push(' ');
             }
         } else {
             row.push_str(desc_sep.as_slice())
@@ -728,7 +728,7 @@ pub fn usage(brief: &str, opts: &[OptGroup]) -> String {
         let mut desc_normalized_whitespace = String::new();
         for word in desc.as_slice().words() {
             desc_normalized_whitespace.push_str(word);
-            desc_normalized_whitespace.push_char(' ');
+            desc_normalized_whitespace.push(' ');
         }
 
         // FIXME: #5516 should be graphemes not codepoints
@@ -755,12 +755,12 @@ fn format_option(opt: &OptGroup) -> String {
     let mut line = String::new();
 
     if opt.occur != Req {
-        line.push_char('[');
+        line.push('[');
     }
 
     // Use short_name is possible, but fallback to long_name.
     if opt.short_name.len() > 0 {
-        line.push_char('-');
+        line.push('-');
         line.push_str(opt.short_name.as_slice());
     } else {
         line.push_str("--");
@@ -768,18 +768,18 @@ fn format_option(opt: &OptGroup) -> String {
     }
 
     if opt.hasarg != No {
-        line.push_char(' ');
+        line.push(' ');
         if opt.hasarg == Maybe {
-            line.push_char('[');
+            line.push('[');
         }
         line.push_str(opt.hint.as_slice());
         if opt.hasarg == Maybe {
-            line.push_char(']');
+            line.push(']');
         }
     }
 
     if opt.occur != Req {
-        line.push_char(']');
+        line.push(']');
     }
     if opt.occur == Multi {
         line.push_str("..");

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -426,7 +426,7 @@ impl<'a> LabelText<'a> {
     fn escape_str(s: &str) -> String {
         let mut out = String::with_capacity(s.len());
         for c in s.chars() {
-            LabelText::escape_char(c, |c| out.push_char(c));
+            LabelText::escape_char(c, |c| out.push(c));
         }
         out
     }
@@ -461,9 +461,11 @@ impl<'a> LabelText<'a> {
 
     /// Puts `suffix` on a line below this label, with a blank line separator.
     pub fn suffix_line(self, suffix: LabelText) -> LabelText<'static> {
-        let prefix = self.pre_escaped_content().into_string();
+        let mut prefix = self.pre_escaped_content().into_string();
         let suffix = suffix.pre_escaped_content();
-        EscStr(str::Owned(prefix.append(r"\n\n").append(suffix.as_slice())))
+        prefix.push_str(r"\n\n");
+        prefix.push_str(suffix.as_slice());
+        EscStr(str::Owned(prefix))
     }
 }
 

--- a/src/libregex/compile.rs
+++ b/src/libregex/compile.rs
@@ -105,7 +105,7 @@ impl Program {
         let mut pre = String::with_capacity(5);
         for inst in c.insts.slice_from(1).iter() {
             match *inst {
-                OneChar(c, FLAG_EMPTY) => pre.push_char(c),
+                OneChar(c, FLAG_EMPTY) => pre.push(c),
                 _ => break
             }
         }

--- a/src/libregex/re.rs
+++ b/src/libregex/re.rs
@@ -26,9 +26,9 @@ pub fn quote(text: &str) -> String {
     let mut quoted = String::with_capacity(text.len());
     for c in text.chars() {
         if parse::is_punct(c) {
-            quoted.push_char('\\')
+            quoted.push('\\')
         }
-        quoted.push_char(c);
+        quoted.push(c);
     }
     quoted
 }
@@ -504,7 +504,8 @@ impl Regex {
             new.push_str(rep.reg_replace(&cap).as_slice());
             last_match = e;
         }
-        new.append(text.slice(last_match, text.len()))
+        new.push_str(text.slice(last_match, text.len()));
+        return new;
     }
 
     /// Returns the original string of this regex.

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1961,9 +1961,9 @@ fn lit_to_string(lit: &ast::Lit) -> String {
         ast::LitByte(b) => {
             let mut res = String::from_str("b'");
             (b as char).escape_default(|c| {
-                res.push_char(c);
+                res.push(c);
             });
-            res.push_char('\'');
+            res.push('\'');
             res
         },
         ast::LitChar(c) => format!("'{}'", c),

--- a/src/librustdoc/externalfiles.rs
+++ b/src/librustdoc/externalfiles.rs
@@ -64,7 +64,7 @@ pub fn load_external_files(names: &[String]) -> Option<String> {
     let mut out = String::new();
     for name in names.iter() {
         out.push_str(load_or_return!(name.as_slice(), None, None).as_slice());
-        out.push_char('\n');
+        out.push('\n');
     }
     Some(out)
 }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1080,7 +1080,8 @@ impl Context {
             let mut json_out = BufferedWriter::new(try!(File::create(json_dst)));
             try!(stability.encode(&mut json::Encoder::new(&mut json_out)));
 
-            let title = stability.name.clone().append(" - Stability dashboard");
+            let mut title = stability.name.clone();
+            title.push_str(" - Stability dashboard");
             let desc = format!("API stability overview for the Rust `{}` crate.",
                                this.layout.krate);
             let page = layout::Page {

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -276,7 +276,7 @@ pub fn collapse_docs(krate: clean::Crate) -> plugins::PluginResult {
                     clean::NameValue(ref x, ref s)
                             if "doc" == x.as_slice() => {
                         docstr.push_str(s.as_slice());
-                        docstr.push_char('\n');
+                        docstr.push('\n');
                     },
                     _ => ()
                 }

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1514,14 +1514,14 @@ impl<T: Iterator<char>> Parser<T> {
 
             if escape {
                 match self.ch_or_null() {
-                    '"' => res.push_char('"'),
-                    '\\' => res.push_char('\\'),
-                    '/' => res.push_char('/'),
-                    'b' => res.push_char('\x08'),
-                    'f' => res.push_char('\x0c'),
-                    'n' => res.push_char('\n'),
-                    'r' => res.push_char('\r'),
-                    't' => res.push_char('\t'),
+                    '"' => res.push('"'),
+                    '\\' => res.push('\\'),
+                    '/' => res.push('/'),
+                    'b' => res.push('\x08'),
+                    'f' => res.push('\x0c'),
+                    'n' => res.push('\n'),
+                    'r' => res.push('\r'),
+                    't' => res.push('\t'),
                     'u' => match try!(self.decode_hex_escape()) {
                         0xDC00 .. 0xDFFF => return self.error(LoneLeadingSurrogateInHexEscape),
 
@@ -1535,13 +1535,13 @@ impl<T: Iterator<char>> Parser<T> {
 
                             let buf = [n1, try!(self.decode_hex_escape())];
                             match str::utf16_items(buf.as_slice()).next() {
-                                Some(ScalarValue(c)) => res.push_char(c),
+                                Some(ScalarValue(c)) => res.push(c),
                                 _ => return self.error(LoneLeadingSurrogateInHexEscape),
                             }
                         }
 
                         n => match char::from_u32(n as u32) {
-                            Some(c) => res.push_char(c),
+                            Some(c) => res.push(c),
                             None => return self.error(InvalidUnicodeCodePoint),
                         },
                     },
@@ -1556,7 +1556,7 @@ impl<T: Iterator<char>> Parser<T> {
                         self.bump();
                         return Ok(res);
                     },
-                    Some(c) => res.push_char(c),
+                    Some(c) => res.push(c),
                     None => unreachable!()
                 }
             }

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -212,7 +212,7 @@ impl GenericPathUnsafe for Path {
             None if ".." == self.repr.as_slice() => {
                 let mut s = String::with_capacity(3 + filename.len());
                 s.push_str("..");
-                s.push_char(SEP);
+                s.push(SEP);
                 s.push_str(filename);
                 self.update_normalized(s);
             }
@@ -222,7 +222,7 @@ impl GenericPathUnsafe for Path {
             Some((_,idxa,end)) if self.repr.as_slice().slice(idxa,end) == ".." => {
                 let mut s = String::with_capacity(end + 1 + filename.len());
                 s.push_str(self.repr.as_slice().slice_to(end));
-                s.push_char(SEP);
+                s.push(SEP);
                 s.push_str(filename);
                 self.update_normalized(s);
             }
@@ -235,7 +235,7 @@ impl GenericPathUnsafe for Path {
             Some((idxb,_,_)) => {
                 let mut s = String::with_capacity(idxb + 1 + filename.len());
                 s.push_str(self.repr.as_slice().slice_to(idxb));
-                s.push_char(SEP);
+                s.push(SEP);
                 s.push_str(filename);
                 self.update_normalized(s);
             }
@@ -299,7 +299,7 @@ impl GenericPathUnsafe for Path {
             match me.prefix {
                 Some(DiskPrefix) if me.repr.len() == plen => (),
                 _ if !(me.repr.len() > plen && me.repr.as_bytes()[me.repr.len()-1] == SEP_BYTE) => {
-                    s.push_char(SEP);
+                    s.push(SEP);
                 }
                 _ => ()
             }
@@ -745,7 +745,7 @@ impl Path {
                 Some(VerbatimUNCPrefix(x, 0)) if s.len() == 8 + x => {
                     // the server component has no trailing '\'
                     let mut s = String::from_str(s);
-                    s.push_char(SEP);
+                    s.push(SEP);
                     Some(s)
                 }
                 _ => None
@@ -815,20 +815,20 @@ impl Path {
                         let mut s = String::with_capacity(n);
                         match prefix {
                             Some(DiskPrefix) => {
-                                s.push_char(prefix_.as_bytes()[0].to_ascii()
+                                s.push(prefix_.as_bytes()[0].to_ascii()
                                                    .to_uppercase().to_char());
-                                s.push_char(':');
+                                s.push(':');
                             }
                             Some(VerbatimDiskPrefix) => {
                                 s.push_str(prefix_.slice_to(4));
-                                s.push_char(prefix_.as_bytes()[4].to_ascii()
+                                s.push(prefix_.as_bytes()[4].to_ascii()
                                                    .to_uppercase().to_char());
                                 s.push_str(prefix_.slice_from(5));
                             }
                             Some(UNCPrefix(a,b)) => {
                                 s.push_str("\\\\");
                                 s.push_str(prefix_.slice(2, a+2));
-                                s.push_char(SEP);
+                                s.push(SEP);
                                 s.push_str(prefix_.slice(3+a, 3+a+b));
                             }
                             Some(_) => s.push_str(prefix_),
@@ -842,7 +842,7 @@ impl Path {
                             }
                         }
                         for comp in it {
-                            s.push_char(SEP);
+                            s.push(SEP);
                             s.push_str(comp);
                         }
                         Some(s)


### PR DESCRIPTION
# Rationale

When dealing with strings, many functions deal with either a `char` (unicode
codepoint) or a byte (utf-8 encoding related). There is often an inconsistent
way in which methods are referred to as to whether they contain "byte", "char",
or nothing in their name.  There are also issues open to rename _all_ methods to
reflect that they operate on utf8 encodings or bytes (e.g. utf8_len() or
byte_len()).

The current state of String seems to largely be what is desired, so this PR
proposes the following rationale for methods dealing with bytes or characters:

> When constructing a string, the input encoding _must_ be mentioned (e.g.
> from_utf8). This makes it clear what exactly the input type is expected to be
> in terms of encoding.
> 
> When a method operates on anything related to an _index_ within the string
> such as length, capacity, position, etc, the method _implicitly_ operates on
> bytes. It is an understood fact that String is a utf-8 encoded string, and
> burdening all methods with "bytes" would be redundant.
> 
> When a method operates on the _contents_ of a string, such as push() or pop(),
> then "char" is the default type. A String can loosely be thought of as being a
> collection of unicode codepoints, but not all collection-related operations
> make sense because some can be woefully inefficient.
# Method stabilization

The following methods have been marked #[stable]
- The String type itself
- String::new
- String::with_capacity
- String::from_utf16_lossy
- String::into_bytes
- String::as_bytes
- String::len
- String::clear
- String::as_slice

The following methods have been marked #[unstable]
- String::from_utf8 - The error type in the returned `Result` may change to
                    provide a nicer message when it's `unwrap()`'d
- String::from_utf8_lossy - The returned `MaybeOwned` type still needs
                          stabilization
- String::from_utf16 - The return type may change to become a `Result` which
                     includes more contextual information like where the error
                     occurred.
- String::from_chars - This is equivalent to iter().collect(), but currently not
                     as ergonomic.
- String::from_char - This method is the equivalent of Vec::from_elem, and has
                    been marked #[unstable] becuase it can be seen as a
                    duplicate of iterator-based functionality as well as
                    possibly being renamed.
- String::push_str - This _can_ be emulated with .extend(foo.chars()), but is
                   less efficient because of decoding/encoding. Due to the
                   desire to minimize API surface this may be able to be
                   removed in the future for something possibly generic with
                   no loss in performance.
- String::grow - This is a duplicate of iterator-based functionality, which may
               become more ergonomic in the future.
- String::capacity - This function was just added.
- String::push - This function was just added.
- String::pop - This function was just added.
- String::truncate - The failure conventions around String methods and byte
                   indices isn't totally clear at this time, so the failure
                   semantics and return value of this method are subject to
                   change.
- String::as_mut_vec - the naming of this method may change.
- string::raw::\* - these functions are all waiting on [an RFC](rust-lang/rfcs#240)

The following method have been marked #[experimental]
- String::from_str - This function only exists as it's more efficient than
                   to_string(), but having a less ergonomic function for
                   performance reasons isn't the greatest reason to keep it
                   around. Like Vec::push_all, this has been marked
                   experimental for now.

The following methods have been #[deprecated]
- String::append - This method has been deprecated to remain consistent with the
                 deprecation of Vec::append. While convenient, it is one of
                 the only functional-style apis on String, and requires more
                 though as to whether it belongs as a first-class method or
                 now (and how it relates to other collections).
- String::from_byte - This is fairly rare functionality and can be emulated with
                    str::from_utf8 plus an assert plus a call to to_string().
                    Additionally, String::from_char could possibly be used.
- String::byte_capacity - Renamed to String::capacity due to the rationale
                        above.
- String::push_char - Renamed to String::push due to the rationale above.
- String::pop_char - Renamed to String::pop due to the rationale above.
- String::push_bytes - There are a number of `unsafe` functions on the `String`
                     type which allow bypassing utf-8 checks. These have all
                     been deprecated in favor of calling `.as_mut_vec()` and
                     then operating directly on the vector returned. These
                     methods were deprecated because naming them with relation
                     to other methods was difficult to rationalize and it's
                     arguably more composable to call .as_mut_vec().
- String::as_mut_bytes - See push_bytes
- String::push_byte - See push_bytes
- String::pop_byte - See push_bytes
- String::shift_byte - See push_bytes
# Reservation methods

This commit does not yet touch the methods for reserving bytes. The methods on
Vec have also not yet been modified. These methods are discussed in the upcoming
[Collections reform RFC](https://github.com/aturon/rfcs/blob/collections-conventions/active/0000-collections-conventions.md#implicit-growth)
