### PR TITLE
Fix snapshot builders

### DIFF
--- a/src/test/auxiliary/issue_16723_multiple_items_syntax_ext.rs
+++ b/src/test/auxiliary/issue_16723_multiple_items_syntax_ext.rs
@@ -7,8 +7,10 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-//
+
 // ignore-stage1
+// force-host
+
 #![feature(plugin_registrar, managed_boxes, quote)]
 #![crate_type = "dylib"]
 


### PR DESCRIPTION
The test in question does not pass when cross compiling because the syntax
extension must always be compiled for the host, not the target.
