### PR TITLE
Revert "Prefer bundled gcc.  External gcc can still be used if one provi...

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -560,8 +560,8 @@ pub fn phase_6_link_output(sess: &Session,
                            trans: &CrateTranslation,
                            outputs: &OutputFilenames) {
     let old_path = os::getenv("PATH").unwrap_or_else(||String::new());
-    let mut new_path = sess.host_filesearch().get_tools_search_paths();
-    new_path.push_all_move(os::split_paths(old_path.as_slice()));
+    let mut new_path = os::split_paths(old_path.as_slice());
+    new_path.push_all_move(sess.host_filesearch().get_tools_search_paths());
     os::setenv("PATH", os::join_paths(new_path.as_slice()).unwrap());
 
     time(sess.time_passes(), "linking", (), |_|


### PR DESCRIPTION
...des a full path via -Clinker=..."

This reverts commit 94f05324fee6cd4637adc01f441fafd09e678668.
