### PR TITLE
add #[experimental] as_string/as_vec functions

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -28,7 +28,7 @@ use slice::CloneableVector;
 use str;
 use str::{CharRange, StrAllocating, MaybeOwned, Owned};
 use str::Slice as MaybeOwnedSlice; // So many `Slice`s...
-use vec::Vec;
+use vec::{DerefVec, Vec, as_vec};
 
 /// A growable string stored as a UTF-8 encoded buffer.
 #[deriving(Clone, PartialEq, PartialOrd, Eq, Ord)]
@@ -973,6 +973,24 @@ impl ops::Slice<uint, str> for String {
     }
 }
 
+/// Wrapper type providing a `&String` reference via `Deref`.
+#[experimental]
+pub struct DerefString<'a> {
+    x: DerefVec<'a, u8>
+}
+
+impl<'a> Deref<String> for DerefString<'a> {
+    fn deref<'b>(&'b self) -> &'b String {
+        unsafe { mem::transmute(&*self.x) }
+    }
+}
+
+/// Convert a string slice to a wrapper type providing a `&String` reference.
+#[experimental]
+pub fn as_string<'a>(x: &'a str) -> DerefString<'a> {
+    DerefString { x: as_vec(x.as_bytes()) }
+}
+
 /// Unsafe operations
 #[unstable = "waiting on raw module conventions"]
 pub mod raw {
@@ -1039,8 +1057,14 @@ mod tests {
     use {Mutable, MutableSeq};
     use str;
     use str::{Str, StrSlice, Owned};
-    use super::String;
+    use super::{as_string, String};
     use vec::Vec;
+
+    #[test]
+    fn test_as_string() {
+        let x = "foo";
+        assert_eq!(x, as_string(x).as_slice());
+    }
 
     #[test]
     fn test_from_str() {


### PR DESCRIPTION
This provides a way to pass `&[T]` to functions taking `&U` where `U` is
a `Vec<T>`. This is useful in many cases not covered by the Equiv trait
or methods like `find_with` on TreeMap.
