### PR TITLE
use PIE (full ASLR) by default on Android too

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -949,7 +949,7 @@ fn link_args(cmd: &mut Command,
     // relocation model of position independent code is not changed. This is a requirement to take
     // advantage of ASLR, as otherwise the functions in the executable are not randomized and can
     // be used during an exploit of a vulnerability in any code.
-    if sess.targ_cfg.os == abi::OsLinux {
+    if sess.targ_cfg.os == abi::OsLinux || sess.targ_cfg.os == abi::OsAndroid {
         let mut args = sess.opts.cg.link_args.iter().chain(used_link_args.iter());
         if !dylib && sess.opts.cg.relocation_model.as_slice() == "pic" &&
             !args.any(|x| x.as_slice() == "-static") {

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -10,6 +10,7 @@
 
 // no-pretty-expanded FIXME #15189
 // ignore-windows FIXME #13259
+// ignore-android FIXME #17520
 extern crate native;
 
 use std::os;


### PR DESCRIPTION
Android no longer permits non-PIE executables.

Closes #17437
