### PR TITLE
Ensure that cross compiler info is passed to GYP correctly

### DIFF
--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -203,6 +203,9 @@ LIBUV_CFLAGS_$(1) := $(subst -Werror,,$(CFG_GCCISH_CFLAGS_$(1)))
 
 $$(LIBUV_MAKEFILE_$(1)): $$(LIBUV_DEPS) $$(MKFILE_DEPS) $$(LIBUV_STAMP_$(1))
 	(cd $(S)src/libuv/ && \
+	CC="$$(CC_$(1))" \
+	CXX="$$(CXX_$(1))" \
+	AR="$$(AR_$(1))" \
 	 $$(CFG_PYTHON) ./gyp_uv.py -f make -Dtarget_arch=$$(LIBUV_ARCH_$(1)) \
 	   -D ninja \
 	   -DOS=$$(LIBUV_OSTYPE_$(1)) \

--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -228,6 +228,9 @@ else ifeq ($(OSTYPE_$(1)), apple-ios) # iOS
 $$(LIBUV_XCODEPROJ_$(1)): $$(LIBUV_DEPS) $$(MKFILE_DEPS) $$(LIBUV_STAMP_$(1))
 	cp -rf $(S)src/libuv/ $$(LIBUV_BUILD_DIR_$(1))
 	(cd $$(LIBUV_BUILD_DIR_$(1)) && \
+	CC="$$(CC_$(1))" \
+	CXX="$$(CXX_$(1))" \
+	AR="$$(AR_$(1))" \
 	 $$(CFG_PYTHON) ./gyp_uv.py -f xcode \
 	   -D ninja \
 	   -R libuv)


### PR DESCRIPTION
Right now, libuv will **always** be built for the host system (at least when building on OSX) because the information about the cross compiler is never actually passed to GYP. I don't know how anybody has been managing to build cross compilers with this.

Note that, at least on OSX, there is a bug in GYP that will send clang flags to non-clang compilers and it will still attempt to use Xcode's libtool, so this doesn't completely fix the problem of cross-compiling on an OSX host, but it's a start.
