### PR TITLE
Add cargo.vim compiler file.

### DIFF
--- a/src/etc/vim/compiler/cargo.vim
+++ b/src/etc/vim/compiler/cargo.vim
@@ -1,0 +1,49 @@
+" Vim compiler file
+" Compiler:         Cargo Compiler
+" Maintainer:       Damien Radtke <damienradtke@gmail.com>
+" Latest Revision:  2014 Sep 18
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "cargo"
+
+if exists(":CompilerSet") != 2
+    command -nargs=* CompilerSet setlocal <args>
+endif
+
+CompilerSet errorformat&
+CompilerSet makeprg=cargo\ $*
+
+" Allow a configurable global Cargo.toml name. This makes it easy to
+" support variations like 'cargo.toml'.
+if !exists('g:cargo_toml_name')
+    let g:cargo_toml_name = 'Cargo.toml'
+endif
+
+let s:toml_dir = fnamemodify(findfile(g:cargo_toml_name, '.;'), ':p:h').'/'
+
+if s:toml_dir != ''
+    augroup cargo
+        au!
+        au QuickfixCmdPost make call s:FixPaths()
+    augroup END
+
+    " FixPaths() is run after Cargo, and is used to change the file paths
+    " to be relative to the current directory instead of Cargo.toml.
+    function! s:FixPaths()
+        let qflist = getqflist()
+        for qf in qflist
+            if !qf['valid']
+                continue
+            endif
+            let filename = bufname(qf['bufnr'])
+            if stridx(filename, s:toml_dir) == -1
+                let filename = s:toml_dir.filename
+            endif
+            let qf['filename'] = simplify(s:toml_dir.bufname(qf['bufnr']))
+            call remove(qf, 'bufnr')
+        endfor
+        call setqflist(qflist, 'r')
+    endfunction
+endif


### PR DESCRIPTION
This PR adds a new Vim compiler file specifically for use with Cargo. It passes all arguments through, so commands like `:make build`, `:make clean`, and `:make run` all work as expected.

It also adds a quickfix autocommand for fixing the paths before populating the error list. `cargo build` reports errors with file paths that are relative to Cargo.toml, so if you're further down in the project tree, then trying to open the error will result in a blank buffer because Vim treats that path as relative to the working directory instead. With this fix, the paths work properly no matter where you are in the project.
