### PR TITLE
Use locale 'C' for running tests. This fixes #17423

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -67,8 +67,7 @@ export LC_ALL=C
 # If we're running perf then set this environment variable
 # to put the benchmarks into 'hard mode'
 ifeq ($(MAKECMDGOALS),perf)
-  RUST_BENCH=1
-  export RUST_BENCH
+  export RUST_BENCH=1
 endif
 
 TEST_LOG_FILE=tmp/check-stage$(1)-T-$(2)-H-$(3)-$(4).log

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -60,6 +60,10 @@ ifdef VERBOSE
   CTEST_TESTARGS += --verbose
 endif
 
+# Setting locale ensures that gdb's output remains consistent.
+# This prevents tests from failing with some locales (fixes #17423).
+export LC_ALL=C
+
 # If we're running perf then set this environment variable
 # to put the benchmarks into 'hard mode'
 ifeq ($(MAKECMDGOALS),perf)


### PR DESCRIPTION
Setting LC_ALL to C helps keep gdb's output consistent ('print' gives us expected output). This fixes #17423. I do not have access to a windows/mac machines to test this. I've only tested it on an x86_64 linux box.
