### PR TITLE
librustc: Give trait methods accessible via fewer autoderefs priority

### DIFF
--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -158,13 +158,7 @@ pub fn lookup<'a, 'tcx>(
 
     debug!("searching inherent candidates");
     lcx.push_inherent_candidates(self_ty);
-    let mme = lcx.search(self_ty);
-    if mme.is_some() {
-        return mme;
-    }
-
     debug!("searching extension candidates");
-    lcx.reset_candidates();
     lcx.push_bound_candidates(self_ty, None);
     lcx.push_extension_candidates(expr.id);
     lcx.search(self_ty)
@@ -424,11 +418,6 @@ impl<'a, 'tcx> LookupContext<'a, 'tcx> {
 
     // ______________________________________________________________________
     // Candidate collection (see comment at start of file)
-
-    fn reset_candidates(&mut self) {
-        self.inherent_candidates = Vec::new();
-        self.extension_candidates = Vec::new();
-    }
 
     fn push_inherent_candidates(&mut self, self_ty: ty::t) {
         /*!

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -881,7 +881,8 @@ impl Repr for ty::Variance {
         // The first `.to_string()` returns a &'static str (it is not an implementation
         // of the ToString trait). Because of that, we need to call `.to_string()` again
         // if we want to have a `String`.
-        self.to_string().to_string()
+        let result: &'static str = (*self).to_string();
+        result.to_string()
     }
 }
 

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -946,11 +946,14 @@ pub trait Reader {
 }
 
 impl<'a> Reader for Box<Reader+'a> {
-    fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> { self.read(buf) }
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
+        let reader: &mut Reader = &mut **self;
+        reader.read(buf)
+    }
 }
 
 impl<'a> Reader for &'a mut Reader+'a {
-    fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> { self.read(buf) }
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> { (*self).read(buf) }
 }
 
 /// Returns a slice of `v` between `start` and `end`.
@@ -1281,10 +1284,14 @@ pub trait Writer {
 
 impl<'a> Writer for Box<Writer+'a> {
     #[inline]
-    fn write(&mut self, buf: &[u8]) -> IoResult<()> { self.write(buf) }
+    fn write(&mut self, buf: &[u8]) -> IoResult<()> {
+        (&mut **self).write(buf)
+    }
 
     #[inline]
-    fn flush(&mut self) -> IoResult<()> { self.flush() }
+    fn flush(&mut self) -> IoResult<()> {
+        (&mut **self).flush()
+    }
 }
 
 impl<'a> Writer for &'a mut Writer+'a {

--- a/src/test/run-pass/class-cast-to-trait-cross-crate-2.rs
+++ b/src/test/run-pass/class-cast-to-trait-cross-crate-2.rs
@@ -15,7 +15,7 @@ use std::to_string::ToString;
 use cci_class_cast::kitty::cat;
 
 fn print_out(thing: Box<ToString>, expected: String) {
-  let actual = thing.to_string();
+  let actual = (*thing).to_string();
   println!("{}", actual);
   assert_eq!(actual.to_string(), expected);
 }

--- a/src/test/run-pass/class-separate-impl.rs
+++ b/src/test/run-pass/class-separate-impl.rs
@@ -58,7 +58,7 @@ impl fmt::Show for cat {
 }
 
 fn print_out(thing: Box<ToString>, expected: String) {
-  let actual = thing.to_string();
+  let actual = (*thing).to_string();
   println!("{}", actual);
   assert_eq!(actual.to_string(), expected);
 }

--- a/src/test/run-pass/inherent-trait-method-order.rs
+++ b/src/test/run-pass/inherent-trait-method-order.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,14 +8,27 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+struct Foo;
 
-pub fn main() {
-  trait Text {
-    fn to_string(&self) -> String;
-  }
-
-  fn to_string(t: Box<Text>) {
-    println!("{}", (*t).to_string());
-  }
-
+impl Foo {
+    #[allow(dead_code)]
+    fn foo(self) {
+        fail!("wrong method!")
+    }
 }
+
+trait Trait {
+    fn foo(self);
+}
+
+impl<'a,'b,'c> Trait for &'a &'b &'c Foo {
+    fn foo(self) {
+        // ok
+    }
+}
+
+fn main() {
+    let x = &(&(&Foo));
+    x.foo();
+}
+


### PR DESCRIPTION
over inherent methods accessible via more autoderefs.

This simplifies the trait matching algorithm. It breaks code like:

```
impl Foo {
    fn foo(self) {
        // before this change, this will be called
    }
}

impl<'a,'b,'c> Trait for &'a &'b &'c Foo {
    fn foo(self) {
        // after this change, this will be called
    }
}

fn main() {
    let x = &(&(&Foo));
    x.foo();
}
```

To explicitly indicate that you wish to call the inherent method, perform
explicit dereferences. For example:

```
fn main() {
    let x = &(&(&Foo));
    (***x).foo();
}
```

Part of #17282.

[breaking-change]

r? @nikomatsakis
