### PR TITLE
Emit an error rather than ICEing for a missing built-in bound lang item.

### DIFF
--- a/src/librustc/middle/traits/mod.rs
+++ b/src/librustc/middle/traits/mod.rs
@@ -86,6 +86,10 @@ pub enum ObligationCauseCode {
     FieldSized,
 }
 
+// An error has already been reported to the user, so no need to continue checking.
+#[deriving(Clone,Show)]
+pub struct ErrorReported;
+
 pub type Obligations = subst::VecPerParamSpace<Obligation>;
 
 pub type Selection = Vtable<Obligation>;
@@ -332,7 +336,7 @@ pub fn obligation_for_builtin_bound(tcx: &ty::ctxt,
                                     cause: ObligationCause,
                                     source_ty: ty::t,
                                     builtin_bound: ty::BuiltinBound)
-                                    -> Obligation
+                                    -> Result<Obligation, ErrorReported>
 {
     util::obligation_for_builtin_bound(tcx, cause, builtin_bound, 0, source_ty)
 }

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -228,6 +228,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 bound,
                 previous_stack.obligation.recursion_depth + 1,
                 ty);
+        let obligation = match obligation {
+            Ok(ob) => ob,
+            _ => return EvaluatedToMatch
+        };
+
         self.evaluate_obligation_recursively(previous_stack, &obligation)
     }
 

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1795,12 +1795,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                               code: traits::ObligationCauseCode,
                               bound: ty::BuiltinBound)
     {
-        self.register_obligation(
-            traits::obligation_for_builtin_bound(
-                self.tcx(),
-                traits::ObligationCause::new(span, code),
-                ty,
-                bound));
+        let obligation = traits::obligation_for_builtin_bound(
+            self.tcx(),
+            traits::ObligationCause::new(span, code),
+            ty,
+            bound);
+        match obligation {
+            Ok(ob) => self.register_obligation(ob),
+            _ => {}
+        }
     }
 
     pub fn require_type_is_sized(&self,

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -945,7 +945,13 @@ fn check_expr_fn_block(rcx: &mut Rcx,
                 let cause = traits::ObligationCause::new(freevar.span, code);
                 let obligation = traits::obligation_for_builtin_bound(rcx.tcx(), cause,
                                                                       var_ty, builtin_bound);
-                rcx.fcx.inh.fulfillment_cx.borrow_mut().register_obligation(rcx.tcx(), obligation);
+                match obligation {
+                    Ok(obligation) => {
+                        rcx.fcx.inh.fulfillment_cx.borrow_mut().register_obligation(rcx.tcx(),
+                                                                                    obligation)
+                    }
+                    _ => {}
+                }
             }
             type_must_outlive(
                 rcx, infer::RelateProcBound(expr.span, var_node_id, var_ty),

--- a/src/librustc/middle/typeck/check/vtable2.rs
+++ b/src/librustc/middle/typeck/check/vtable2.rs
@@ -170,13 +170,16 @@ pub fn register_object_cast_obligations(fcx: &FnCtxt,
     // object type is Foo+Send, this would create an obligation
     // for the Send check.)
     for builtin_bound in object_trait.bounds.builtin_bounds.iter() {
-        fcx.register_obligation(
-            obligation_for_builtin_bound(
+            let obligation = obligation_for_builtin_bound(
                 fcx.tcx(),
                 ObligationCause::new(span,
                                      traits::ObjectCastObligation(object_trait_ty)),
                 referent_ty,
-                builtin_bound));
+                builtin_bound);
+            match obligation {
+                Ok(obligation) => fcx.register_obligation(obligation),
+                _ => {}
+            }
     }
 
     object_trait_ref

--- a/src/librustc/middle/typeck/check/wf.rs
+++ b/src/librustc/middle/typeck/check/wf.rs
@@ -124,11 +124,14 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
                 if variant.fields.len() > 0 {
                     for field in variant.fields.init().iter() {
                         let cause = traits::ObligationCause::new(field.span, traits::FieldSized);
-                        fcx.register_obligation(
-                            traits::obligation_for_builtin_bound(fcx.tcx(),
-                                                                 cause,
-                                                                 field.ty,
-                                                                 ty::BoundSized));
+                        let obligation = traits::obligation_for_builtin_bound(fcx.tcx(),
+                                                                              cause,
+                                                                              field.ty,
+                                                                              ty::BoundSized);
+                        match obligation {
+                            Ok(obligation) => fcx.register_obligation(obligation),
+                            _ => {}
+                        }
                     }
                 }
             }
@@ -213,11 +216,14 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
                                                           &trait_def.bounds,
                                                           trait_ref.self_ty());
             for builtin_bound in trait_def.bounds.builtin_bounds.iter() {
-                fcx.register_obligation(
-                    traits::obligation_for_builtin_bound(fcx.tcx(),
-                                                         cause,
-                                                         trait_ref.self_ty(),
-                                                         builtin_bound));
+                let obligation = traits::obligation_for_builtin_bound(fcx.tcx(),
+                                                                      cause,
+                                                                      trait_ref.self_ty(),
+                                                                      builtin_bound);
+                match obligation {
+                    Ok (obligation) => fcx.register_obligation(obligation),
+                    _ => {}
+                }
             }
             for trait_bound in trait_def.bounds.trait_bounds.iter() {
                 let trait_bound = trait_bound.subst(fcx.tcx(), &trait_ref.substs);
@@ -453,12 +459,14 @@ fn check_struct_safe_for_destructor(fcx: &FnCtxt,
         && !struct_tpt.generics.has_region_params(subst::TypeSpace)
     {
         let cause = traits::ObligationCause::new(span, traits::DropTrait);
-        fcx.register_obligation(
-            traits::obligation_for_builtin_bound(
-                fcx.tcx(),
-                cause,
-                self_ty,
-                ty::BoundSend));
+        let obligation = traits::obligation_for_builtin_bound(fcx.tcx(),
+                                                              cause,
+                                                              self_ty,
+                                                              ty::BoundSend);
+        match obligation {
+            Ok(obligation) => fcx.register_obligation(obligation),
+            _ => {}
+        }
     } else {
         span_err!(fcx.tcx().sess, span, E0141,
                   "cannot implement a destructor on a structure \

--- a/src/test/compile-fail/lang-item-missing.rs
+++ b/src/test/compile-fail/lang-item-missing.rs
@@ -1,0 +1,21 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that a missing lang item (in this case `sized`) does not cause an ICE,
+// see #17392.
+
+// error-pattern: requires `sized` lang_item
+
+#![no_std]
+
+#[start]
+fn start(argc: int, argv: *const *const u8) -> int {
+    0
+}


### PR DESCRIPTION
closes #17392 

r? @nikomatsakis 

Kind of a first draft because I'm not sure if this is the right approach. I believe the general idea of giving an error rather than an ICE in obligation_for_builtin_bound is right, but not sure about returning an Option, etc.

Also, could probably have a better error message.
