### PR TITLE
Link libgcc statically on Win64.

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -991,10 +991,15 @@ fn link_args(cmd: &mut Command,
     }
 
     if sess.targ_cfg.os == abi::OsWindows {
-        // Make sure that we link to the dynamic libgcc, otherwise cross-module
-        // DWARF stack unwinding will not work.
-        // This behavior may be overridden by --link-args "-static-libgcc"
-        cmd.arg("-shared-libgcc");
+        if sess.targ_cfg.arch == abi::X86 {
+            // Make sure that we link to the dynamic libgcc, otherwise cross-module
+            // DWARF stack unwinding will not work.
+            // This behavior may be overridden by -Clink-args="-static-libgcc"
+            cmd.arg("-shared-libgcc");
+        } else {
+            // On Win64 unwinding is handled by the OS, so we can link libgcc statically.
+            cmd.arg("-static-libgcc");
+        }
 
         // And here, we see obscure linker flags #45. On windows, it has been
         // found to be necessary to have this flag to compile liblibc.

--- a/src/librustrt/libunwind.rs
+++ b/src/librustrt/libunwind.rs
@@ -87,7 +87,6 @@ pub type _Unwind_Exception_Cleanup_Fn =
 
 #[cfg(target_os = "linux")]
 #[cfg(target_os = "freebsd")]
-#[cfg(target_os = "windows")]
 #[link(name = "gcc_s")]
 extern {}
 


### PR DESCRIPTION
Closes #17271
Closes #15420
