### PR TITLE
Add partial_min/max to libcore/cmp

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -39,7 +39,7 @@
 
 #![stable]
 
-use option::{Option, Some};
+use option::{Option, Some, None};
 
 /// Trait for values that can be compared for equality and inequality.
 ///
@@ -266,6 +266,32 @@ pub fn min<T: Ord>(v1: T, v2: T) -> T {
 #[stable]
 pub fn max<T: Ord>(v1: T, v2: T) -> T {
     if v1 > v2 { v1 } else { v2 }
+}
+
+/// Compare and return the minimum of two values if there is one.
+///
+/// Returns the first argument if the comparison determines them to be equal.
+#[inline]
+#[experimental]
+pub fn partial_min<T: PartialOrd>(v1: T, v2: T) -> Option<T> {
+    match v1.partial_cmp(&v2) {
+        Some(Less) | Some(Equal) => Some(v1),
+        Some(Greater) => Some(v2),
+        None => None
+    }
+}
+
+/// Compare and return the maximum of two values if there is one.
+///
+/// Returns the first argument if the comparison determines them to be equal.
+#[inline]
+#[experimental]
+pub fn partial_max<T: PartialOrd>(v1: T, v2: T) -> Option<T> {
+    match v1.partial_cmp(&v2) {
+        Some(Less) => Some(v2),
+        Some(Equal) | Some(Greater) => Some(v1),
+        None => None
+    }
 }
 
 // Implementation of PartialEq, Eq, PartialOrd and Ord for primitive types

--- a/src/libcoretest/cmp.rs
+++ b/src/libcoretest/cmp.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use core::cmp::lexical_ordering;
+use core::cmp::{ partial_min, partial_max };
 
 #[test]
 fn test_int_totalord() {
@@ -54,6 +55,72 @@ fn test_lexical_ordering() {
         t(Equal, o, o);
         t(Greater, o, Greater);
      }
+}
+
+#[test]
+fn test_partial_min() {
+    use core::f64::NAN;
+    let data_integer = [
+        // a, b, result
+        (0i, 0i, Some(0i)),
+        (1i, 0i, Some(0i)),
+        (0i, 1i, Some(0i)),
+        (-1i, 0i, Some(-1i)),
+        (0i, -1i, Some(-1i))
+    ];
+
+    let data_float = [
+        // a, b, result
+        (0.0f64, 0.0f64, Some(0.0f64)),
+        (1.0f64, 0.0f64, Some(0.0f64)),
+        (0.0f64, 1.0f64, Some(0.0f64)),
+        (-1.0f64, 0.0f64, Some(-1.0f64)),
+        (0.0f64, -1.0f64, Some(-1.0f64)),
+        (NAN, NAN, None),
+        (NAN, 1.0f64, None),
+        (1.0f64, NAN, None)
+    ];
+
+    for &(a, b, result) in data_integer.iter() {
+        assert!(partial_min(a, b) == result);
+    }
+
+    for &(a, b, result) in data_float.iter() {
+        assert!(partial_min(a, b) == result);
+    }
+}
+
+#[test]
+fn test_partial_max() {
+    use core::f64::NAN;
+    let data_integer = [
+        // a, b, result
+        (0i, 0i, Some(0i)),
+        (1i, 0i, Some(1i)),
+        (0i, 1i, Some(1i)),
+        (-1i, 0i, Some(0i)),
+        (0i, -1i, Some(0i))
+    ];
+
+    let data_float = [
+        // a, b, result
+        (0.0f64, 0.0f64, Some(0.0f64)),
+        (1.0f64, 0.0f64, Some(1.0f64)),
+        (0.0f64, 1.0f64, Some(1.0f64)),
+        (-1.0f64, 0.0f64, Some(0.0f64)),
+        (0.0f64, -1.0f64, Some(0.0f64)),
+        (NAN, NAN, None),
+        (NAN, 1.0f64, None),
+        (1.0f64, NAN, None)
+    ];
+
+    for &(a, b, result) in data_integer.iter() {
+        assert!(partial_max(a, b) == result);
+    }
+
+    for &(a, b, result) in data_float.iter() {
+        assert!(partial_max(a, b) == result);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Intended to prevent each user to write his own partial_min/max, possibly differing in slight details. @sfackler encouraged to PR this on IRC.

(Let's hope this works... First PR.)
