### PR TITLE
liblibc and libnative: misc fixes

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -4633,7 +4633,7 @@ pub mod funcs {
                               option_len: socklen_t) -> c_int;
             pub fn recv(socket: c_int, buf: *mut c_void, len: size_t,
                         flags: c_int) -> ssize_t;
-            pub fn send(socket: c_int, buf: *mut c_void, len: size_t,
+            pub fn send(socket: c_int, buf: *const c_void, len: size_t,
                         flags: c_int) -> ssize_t;
             pub fn recvfrom(socket: c_int, buf: *mut c_void, len: size_t,
                             flags: c_int, addr: *mut sockaddr,
@@ -4673,7 +4673,7 @@ pub mod funcs {
             pub fn closesocket(socket: SOCKET) -> c_int;
             pub fn recv(socket: SOCKET, buf: *mut c_void, len: c_int,
                         flags: c_int) -> c_int;
-            pub fn send(socket: SOCKET, buf: *mut c_void, len: c_int,
+            pub fn send(socket: SOCKET, buf: *const c_void, len: c_int,
                         flags: c_int) -> c_int;
             pub fn recvfrom(socket: SOCKET, buf: *mut c_void, len: c_int,
                             flags: c_int, addr: *mut sockaddr,

--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -303,7 +303,7 @@ impl rtio::RtioFileStream for CFile {
         self.flush().and_then(|()| self.fd.fsync())
     }
     fn datasync(&mut self) -> IoResult<()> {
-        self.flush().and_then(|()| self.fd.fsync())
+        self.flush().and_then(|()| self.fd.datasync())
     }
     fn truncate(&mut self, offset: i64) -> IoResult<()> {
         self.flush().and_then(|()| self.fd.truncate(offset))

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -337,7 +337,7 @@ impl rtio::RtioTcpStream for TcpStream {
         let dowrite = |nb: bool, buf: *const u8, len: uint| unsafe {
             let flags = if nb {c::MSG_DONTWAIT} else {0};
             libc::send(fd,
-                       buf as *mut libc::c_void,
+                       buf as *const _,
                        len as wrlen,
                        flags) as i64
         };

--- a/src/libnative/io/pipe_unix.rs
+++ b/src/libnative/io/pipe_unix.rs
@@ -173,7 +173,7 @@ impl rtio::RtioPipe for UnixStream {
         let dowrite = |nb: bool, buf: *const u8, len: uint| unsafe {
             let flags = if nb {c::MSG_DONTWAIT} else {0};
             libc::send(fd,
-                       buf as *mut libc::c_void,
+                       buf as *const _,
                        len as libc::size_t,
                        flags) as i64
         };


### PR DESCRIPTION
libnative/io: datasync() wrongly called fsync().
liblibc and libnative: send() should use const buffers.
