### PR TITLE
use emit_tuple_arg while serializing tuples

### DIFF
--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -503,7 +503,7 @@ macro_rules! tuple (
                 $(let $name = $name; n += 1;)*
                 s.emit_tuple(n, |s| {
                     let mut i = 0;
-                    $(try!(s.emit_seq_elt({ i+=1; i-1 }, |s| $name.encode(s)));)*
+                    $(try!(s.emit_tuple_arg({ i+=1; i-1 }, |s| $name.encode(s)));)*
                     Ok(())
                 })
             }


### PR DESCRIPTION
The tuple serialization logic should be using the tuple-specific emit function.  This fixes part of #17158.  The JSON encoder already proxies to `emit_seq_elt` when `emit_tuple_arg` is called, so this should have an effect.
