### PR TITLE
Remove unnecessary code from an example

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -4324,8 +4324,6 @@ and so we tell it that we want a vector of integers.
 is one:
 
 ```{rust}
-let one_to_one_hundred = range(0i, 100i);
-
 let greater_than_forty_two = range(0i, 100i)
                              .find(|x| *x >= 42);
 


### PR DESCRIPTION
The `let one_to_one_hundred = range(0i, 100i);` is not needed here as it relates to the previous example and produces a warning here.
r @steveklabnik ?
