### PR TITLE
Correct typo in the Iterator adapters section

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -4490,7 +4490,7 @@ This will print
 
 `filter()` is an adapter that takes a closure as an argument. This closure
 returns `true` or `false`. The new iterator `filter()` produces
-only the elements that that closure returned `true` for:
+only the elements that that closure returns `true` for:
 
 ```{rust}
 for i in range(1i, 100i).filter(|x| x % 2 == 0) {

--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -4489,7 +4489,7 @@ This will print
 ```
 
 `filter()` is an adapter that takes a closure as an argument. This closure
-returns `true` or `false`. The new iterator `filter()` produces returns
+returns `true` or `false`. The new iterator `filter()` produces
 only the elements that that closure returned `true` for:
 
 ```{rust}


### PR DESCRIPTION
The sentence "The new iterator `filter()` produces returns only the elements that that closure returned `true` for:"  can be structured as:

"The new iterator `filter()` produces only the elements that that closure returned `true` for:"

or as:

"The new iterator `filter()` returns only the elements that that closure returned `true` for:"

however, not both. 

I went with "produces", since it then talks about returning true and having "return" so close together doesn't sound nice. 
r @steveklabnik ?
