### PR TITLE
guide-pointers.md: C sample code should match the Rust version.

### DIFF
--- a/src/doc/guide-pointers.md
+++ b/src/doc/guide-pointers.md
@@ -505,6 +505,7 @@ As being similar to this C code:
 {
     int *x;
     x = (int *)malloc(sizeof(int));
+    *x = 5;
 
     // stuff happens
 


### PR DESCRIPTION
Fix rust-lang/rust#17255

This is such a trivial change.  Devs: perhaps you might want to omit to run `make check` on Travis.
