### PR TITLE
Some improvements to the Vim Cargo compiler file.

### DIFF
--- a/src/etc/vim/compiler/cargo.vim
+++ b/src/etc/vim/compiler/cargo.vim
@@ -23,9 +23,13 @@ endif
 " support variations like 'cargo.toml'.
 let s:cargo_manifest_name = get(g:, 'cargo_manifest_name', 'Cargo.toml')
 
+function! s:is_absolute(path)
+    return a:path[0] == '/' || a:path =~ '[A-Z]\+:'
+endfunction
+
 let s:local_manifest = findfile(s:cargo_manifest_name, '.;')
 if s:local_manifest != ''
-	let s:local_manifest = fnamemodify(s:local_manifest, ':p:h').'/'
+    let s:local_manifest = fnamemodify(s:local_manifest, ':p:h').'/'
     augroup cargo
         au!
         au QuickfixCmdPost make call s:FixPaths()
@@ -43,14 +47,14 @@ if s:local_manifest != ''
                     let manifest = m[1].'/'
                     " Manually strip another slash if needed; usually just an
                     " issue on Windows.
-                    if manifest =~ '^/[A-Z]:/'
+                    if manifest =~ '^/[A-Z]\+:/'
                         let manifest = manifest[1:]
                     endif
                 endif
                 continue
             endif
             let filename = bufname(qf.bufnr)
-            if filereadable(filename)
+            if s:is_absolute(filename)
                 continue
             endif
             let qf.filename = simplify(manifest.filename)

--- a/src/etc/vim/compiler/cargo.vim
+++ b/src/etc/vim/compiler/cargo.vim
@@ -3,17 +3,28 @@
 " Maintainer:       Damien Radtke <damienradtke@gmail.com>
 " Latest Revision:  2014 Sep 24
 
-if exists("current_compiler")
+if exists('current_compiler')
   finish
 endif
 let current_compiler = "cargo"
 
-if exists(":CompilerSet") != 2
+if exists(':CompilerSet') != 2
     command -nargs=* CompilerSet setlocal <args>
 endif
 
-CompilerSet errorformat=%A%f:%l:%c:\ %m,%-Z%p^,%-C%.%#
-CompilerSet makeprg=cargo\ $*
+if exists('g:cargo_makeprg_params')
+    execute 'CompilerSet makeprg=cargo\ '.g:cargo_makeprg_params.'\ $*'
+else
+    CompilerSet makeprg=cargo\ $*
+endif
+
+CompilerSet errorformat=
+			\%f:%l:%c:\ %t%*[^:]:\ %m,
+			\%f:%l:%c:\ %*\\d:%*\\d\ %t%*[^:]:\ %m,
+			\%-G%f:%l\ %s,
+			\%-G%*[\ ]^,
+			\%-G%*[\ ]^%*[~],
+			\%-G%*[\ ]...
 
 " Allow a configurable global Cargo.toml name. This makes it easy to
 " support variations like 'cargo.toml'.

--- a/src/etc/vim/doc/rust.txt
+++ b/src/etc/vim/doc/rust.txt
@@ -79,6 +79,13 @@ g:ftplugin_rust_source_path~
 	    let g:ftplugin_rust_source_path = $HOME.'/dev/rust'
 <
 
+                                                       *g:cargo_manifest_name*
+g:cargo_manifest_name~
+	Set this option to the name of the manifest file for your projects. If
+	not specified it defaults to 'Cargo.toml' : >
+	    let g:cargo_manifest_name = 'Cargo.toml'
+<
+
 ==============================================================================
 COMMANDS                                                       *rust-commands*
 


### PR DESCRIPTION
Looks like I made my previous PR a little too hastily. =)

This PR fixes a couple issues that I discovered with my previous revision:
1. Updated the errorformat to ignore "pointer lines" so that they don't show up in the output (with quickfix jumping, they're redundant and unnecessary).
2. Renamed a couple variables to be more in line with Cargo's terminology (`g:cargo_toml_name` should now be `g:cargo_manifest_name`).
3. Added support for errors reported with absolute paths (looks to be the case when compiling an executable instead of a library).
4. Most importantly, added support for errors reported while compiling a dependency. When building a Cargo package with local dependencies, if one of those dependencies failed to compile, the quickfix would be completely broken as it assumed that all errors were relative to the local manifest, or the closest Cargo.toml. With this update, it now pays attention to lines that end with `(file://<path>)`, and from then on adjusts all errors to be relative to `<path>`.

As a side note, that `<path>` output is somewhat broken on Windows. While `file:///home/damien/...` on *Nix is a valid URI, `file:///C:/Users/damien/...` on Windows is not, because `C:/` (or whatever the drive is) should take the place of the third slash which is *Nix's root, not be appended to it. I added a workaround for this in my script, but I figured I'd mention it to see if this is a bug in how Rust formats paths.
