### PR TITLE
Adding Show to rustrt::rtio::IoError

### DIFF
--- a/src/librustrt/rtio.rs
+++ b/src/librustrt/rtio.rs
@@ -362,6 +362,12 @@ pub struct IoError {
     pub detail: Option<String>,
 }
 
+impl fmt::Show for IoError{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt,"Code:{}, Extra:{}, detail:{}", self.code, self.extra, self.detail)
+    }
+}
+
 pub type IoResult<T> = Result<T, IoError>;
 
 #[deriving(PartialEq, Eq)]


### PR DESCRIPTION
I added implemented show trait to rustrt::rtio::IoError, I'm working on a library that was trying to print one in a test.

This is my first commit, so please tell me if I have done anything incorrectly.

The merge thing below was just because I didn't realize you fork then edit. 
