### PR TITLE
Fix free lifetime vars in HashMap's iterators

### DIFF
--- a/src/libstd/collections/hashmap/table.rs
+++ b/src/libstd/collections/hashmap/table.rs
@@ -663,7 +663,8 @@ impl<K, V> RawTable<K, V> {
             raw: self.first_bucket_raw(),
             hashes_end: unsafe {
                 self.hashes.offset(self.capacity as int)
-            }
+            },
+            marker: marker::ContravariantLifetime,
         }
     }
 
@@ -682,8 +683,14 @@ impl<K, V> RawTable<K, V> {
     }
 
     pub fn into_iter(self) -> MoveEntries<K, V> {
+        let RawBuckets { raw, hashes_end, .. } = self.raw_buckets();
+        // Replace the marker regardless of lifetime bounds on parameters.
         MoveEntries {
-            iter: self.raw_buckets(),
+            iter: RawBuckets {
+                raw: raw,
+                hashes_end: hashes_end,
+                marker: marker::ContravariantLifetime,
+            },
             table: self,
         }
     }
@@ -695,7 +702,8 @@ impl<K, V> RawTable<K, V> {
         RevMoveBuckets {
             raw: raw_bucket.offset(self.capacity as int),
             hashes_end: raw_bucket.hash,
-            elems_left: self.size
+            elems_left: self.size,
+            marker:     marker::ContravariantLifetime,
         }
     }
 }
@@ -704,7 +712,8 @@ impl<K, V> RawTable<K, V> {
 /// this interface is safe, it's not used outside this module.
 struct RawBuckets<'a, K, V> {
     raw: RawBucket<K, V>,
-    hashes_end: *mut u64
+    hashes_end: *mut u64,
+    marker: marker::ContravariantLifetime<'a>,
 }
 
 impl<'a, K, V> Iterator<RawBucket<K, V>> for RawBuckets<'a, K, V> {
@@ -730,7 +739,8 @@ impl<'a, K, V> Iterator<RawBucket<K, V>> for RawBuckets<'a, K, V> {
 struct RevMoveBuckets<'a, K, V> {
     raw: RawBucket<K, V>,
     hashes_end: *mut u64,
-    elems_left: uint
+    elems_left: uint,
+    marker: marker::ContravariantLifetime<'a>,
 }
 
 impl<'a, K, V> Iterator<(K, V)> for RevMoveBuckets<'a, K, V> {

--- a/src/test/compile-fail/hashmap-iter-value-lifetime.rs
+++ b/src/test/compile-fail/hashmap-iter-value-lifetime.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let mut my_stuff = std::collections::HashMap::new();
+    my_stuff.insert(0i, 42i);
+
+    let (_, thing) = my_stuff.iter().next().unwrap();
+
+    my_stuff.clear(); //~ ERROR cannot borrow
+
+    println!("{}", *thing);
+}

--- a/src/test/compile-fail/hashmap-lifetimes.rs
+++ b/src/test/compile-fail/hashmap-lifetimes.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let mut my_stuff = std::collections::HashMap::new();
+    my_stuff.insert(0i, 42i);
+
+    let mut it = my_stuff.iter();
+    my_stuff.swap(1, 43); //~ ERROR cannot borrow
+}


### PR DESCRIPTION
Fixes #17500 
