### PR TITLE
librustc: Eliminate the `ref` syntax for unboxed closure capture clauses

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -96,12 +96,6 @@ pub trait BoxAny {
     /// `Err(Self)` if it isn't.
     #[unstable = "naming conventions around accessing innards may change"]
     fn downcast<T: 'static>(self) -> Result<Box<T>, Self>;
-
-    /// Deprecated; this method has been renamed to `downcast`.
-    #[deprecated = "use downcast instead"]
-    fn move<T: 'static>(self) -> Result<Box<T>, Self> {
-        self.downcast::<T>()
-    }
 }
 
 #[stable]

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -652,12 +652,12 @@ impl<'a, 'tcx> CheckLoanCtxt<'a, 'tcx> {
         debug!("check_if_path_is_moved(id={:?}, use_kind={:?}, lp={})",
                id, use_kind, lp.repr(self.bccx.tcx));
         let base_lp = owned_ptr_base_path_rc(lp);
-        self.move_data.each_move_of(id, &base_lp, |move, moved_lp| {
+        self.move_data.each_move_of(id, &base_lp, |the_move, moved_lp| {
             self.bccx.report_use_of_moved_value(
                 span,
                 use_kind,
                 &**lp,
-                move,
+                the_move,
                 moved_lp);
             false
         });

--- a/src/librustc/middle/borrowck/graphviz.rs
+++ b/src/librustc/middle/borrowck/graphviz.rs
@@ -108,8 +108,8 @@ impl<'a, 'tcx> DataflowLabeller<'a, 'tcx> {
         let move_index_to_path = |move_index| {
             let move_data = &self.analysis_data.move_data.move_data;
             let moves = move_data.moves.borrow();
-            let move = moves.get(move_index);
-            move_data.path_loan_path(move.path)
+            let the_move = moves.get(move_index);
+            move_data.path_loan_path(the_move.path)
         };
         self.build_set(e, cfgidx, dfcx, move_index_to_path)
     }

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -409,14 +409,14 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                                      use_span: Span,
                                      use_kind: MovedValueUseKind,
                                      lp: &LoanPath,
-                                     move: &move_data::Move,
+                                     the_move: &move_data::Move,
                                      moved_lp: &LoanPath) {
         let verb = match use_kind {
             MovedInUse => "use",
             MovedInCapture => "capture",
         };
 
-        match move.kind {
+        match the_move.kind {
             move_data::Declared => {
                 self.tcx.sess.span_err(
                     use_span,
@@ -435,18 +435,20 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
             }
         }
 
-        match move.kind {
+        match the_move.kind {
             move_data::Declared => {}
 
             move_data::MoveExpr => {
-                let (expr_ty, expr_span) = match self.tcx.map.find(move.id) {
+                let (expr_ty, expr_span) = match self.tcx
+                                                     .map
+                                                     .find(the_move.id) {
                     Some(ast_map::NodeExpr(expr)) => {
                         (ty::expr_ty_adjusted(self.tcx, &*expr), expr.span)
                     }
                     r => {
                         self.tcx.sess.bug(format!("MoveExpr({:?}) maps to \
                                                    {:?}, not Expr",
-                                                  move.id,
+                                                  the_move.id,
                                                   r).as_slice())
                     }
                 };
@@ -461,8 +463,8 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
             }
 
             move_data::MovePat => {
-                let pat_ty = ty::node_id_to_type(self.tcx, move.id);
-                self.tcx.sess.span_note(self.tcx.map.span(move.id),
+                let pat_ty = ty::node_id_to_type(self.tcx, the_move.id);
+                self.tcx.sess.span_note(self.tcx.map.span(the_move.id),
                     format!("`{}` moved here because it has type `{}`, \
                              which is moved by default (use `ref` to \
                              override)",
@@ -471,14 +473,16 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
             }
 
             move_data::Captured => {
-                let (expr_ty, expr_span) = match self.tcx.map.find(move.id) {
+                let (expr_ty, expr_span) = match self.tcx
+                                                     .map
+                                                     .find(the_move.id) {
                     Some(ast_map::NodeExpr(expr)) => {
                         (ty::expr_ty_adjusted(self.tcx, &*expr), expr.span)
                     }
                     r => {
                         self.tcx.sess.bug(format!("Captured({:?}) maps to \
                                                    {:?}, not Expr",
-                                                  move.id,
+                                                  the_move.id,
                                                   r).as_slice())
                     }
                 };

--- a/src/librustc/middle/borrowck/move_data.rs
+++ b/src/librustc/middle/borrowck/move_data.rs
@@ -413,8 +413,8 @@ impl MoveData {
          * killed by scoping. See `doc.rs` for more details.
          */
 
-        for (i, move) in self.moves.borrow().iter().enumerate() {
-            dfcx_moves.add_gen(move.id, i);
+        for (i, the_move) in self.moves.borrow().iter().enumerate() {
+            dfcx_moves.add_gen(the_move.id, i);
         }
 
         for (i, assignment) in self.var_assignments.borrow().iter().enumerate() {
@@ -577,10 +577,10 @@ impl<'a, 'tcx> FlowedMoveData<'a, 'tcx> {
         let mut ret = None;
         for loan_path_index in self.move_data.path_map.borrow().find(&*loan_path).iter() {
             self.dfcx_moves.each_gen_bit(id, |move_index| {
-                let move = self.move_data.moves.borrow();
-                let move = move.get(move_index);
-                if move.path == **loan_path_index {
-                    ret = Some(move.kind);
+                let the_move = self.move_data.moves.borrow();
+                let the_move = the_move.get(move_index);
+                if the_move.path == **loan_path_index {
+                    ret = Some(the_move.kind);
                     false
                 } else {
                     true
@@ -622,13 +622,13 @@ impl<'a, 'tcx> FlowedMoveData<'a, 'tcx> {
         let mut ret = true;
 
         self.dfcx_moves.each_bit_on_entry(id, |index| {
-            let move = self.move_data.moves.borrow();
-            let move = move.get(index);
-            let moved_path = move.path;
+            let the_move = self.move_data.moves.borrow();
+            let the_move = the_move.get(index);
+            let moved_path = the_move.path;
             if base_indices.iter().any(|x| x == &moved_path) {
                 // Scenario 1 or 2: `loan_path` or some base path of
                 // `loan_path` was moved.
-                if !f(move, &*self.move_data.path_loan_path(moved_path)) {
+                if !f(the_move, &*self.move_data.path_loan_path(moved_path)) {
                     ret = false;
                 }
             } else {
@@ -637,7 +637,8 @@ impl<'a, 'tcx> FlowedMoveData<'a, 'tcx> {
                         if p == loan_path_index {
                             // Scenario 3: some extension of `loan_path`
                             // was moved
-                            f(move, &*self.move_data.path_loan_path(moved_path))
+                            f(the_move,
+                              &*self.move_data.path_loan_path(moved_path))
                         } else {
                             true
                         }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2084,7 +2084,7 @@ impl<'a> Parser<'a> {
                                     ExprBlock(blk));
             },
             token::BINOP(token::OR) |  token::OROR => {
-                return self.parse_lambda_expr(CaptureByValue);
+                return self.parse_lambda_expr(CaptureByRef);
             },
             // FIXME #13626: Should be able to stick in
             // token::SELF_KEYWORD_NAME
@@ -2135,8 +2135,8 @@ impl<'a> Parser<'a> {
                 hi = self.last_span.hi;
             }
             _ => {
-                if self.eat_keyword(keywords::Ref) {
-                    return self.parse_lambda_expr(CaptureByRef);
+                if self.eat_keyword(keywords::Move) {
+                    return self.parse_lambda_expr(CaptureByValue);
                 }
                 if self.eat_keyword(keywords::Proc) {
                     let decl = self.parse_proc_decl();

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -482,40 +482,41 @@ declare_special_idents_and_keywords! {
         (25,                         Loop,       "loop");
         (26,                         Match,      "match");
         (27,                         Mod,        "mod");
-        (28,                         Mut,        "mut");
-        (29,                         Once,       "once");
-        (30,                         Pub,        "pub");
-        (31,                         Ref,        "ref");
-        (32,                         Return,     "return");
+        (28,                         Move,       "move");
+        (29,                         Mut,        "mut");
+        (30,                         Once,       "once");
+        (31,                         Pub,        "pub");
+        (32,                         Ref,        "ref");
+        (33,                         Return,     "return");
         // Static and Self are also special idents (prefill de-dupes)
         (super::STATIC_KEYWORD_NAME_NUM, Static, "static");
         (super::SELF_KEYWORD_NAME_NUM,   Self,   "self");
-        (33,                         Struct,     "struct");
+        (34,                         Struct,     "struct");
         (super::SUPER_KEYWORD_NAME_NUM, Super,   "super");
-        (34,                         True,       "true");
-        (35,                         Trait,      "trait");
-        (36,                         Type,       "type");
-        (37,                         Unsafe,     "unsafe");
-        (38,                         Use,        "use");
-        (39,                         Virtual,    "virtual");
-        (40,                         While,      "while");
-        (41,                         Continue,   "continue");
-        (42,                         Proc,       "proc");
-        (43,                         Box,        "box");
-        (44,                         Const,      "const");
-        (45,                         Where,      "where");
+        (35,                         True,       "true");
+        (36,                         Trait,      "trait");
+        (37,                         Type,       "type");
+        (38,                         Unsafe,     "unsafe");
+        (39,                         Use,        "use");
+        (40,                         Virtual,    "virtual");
+        (41,                         While,      "while");
+        (42,                         Continue,   "continue");
+        (43,                         Proc,       "proc");
+        (44,                         Box,        "box");
+        (45,                         Const,      "const");
+        (46,                         Where,      "where");
 
         'reserved:
-        (46,                         Alignof,    "alignof");
-        (47,                         Be,         "be");
-        (48,                         Offsetof,   "offsetof");
-        (49,                         Priv,       "priv");
-        (50,                         Pure,       "pure");
-        (51,                         Sizeof,     "sizeof");
-        (52,                         Typeof,     "typeof");
-        (53,                         Unsized,    "unsized");
-        (54,                         Yield,      "yield");
-        (55,                         Do,         "do");
+        (47,                         Alignof,    "alignof");
+        (48,                         Be,         "be");
+        (49,                         Offsetof,   "offsetof");
+        (50,                         Priv,       "priv");
+        (51,                         Pure,       "pure");
+        (52,                         Sizeof,     "sizeof");
+        (53,                         Typeof,     "typeof");
+        (54,                         Unsized,    "unsized");
+        (55,                         Yield,      "yield");
+        (56,                         Do,         "do");
     }
 }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2176,8 +2176,8 @@ impl<'a> State<'a> {
     pub fn print_capture_clause(&mut self, capture_clause: ast::CaptureClause)
                                 -> IoResult<()> {
         match capture_clause {
-            ast::CaptureByValue => Ok(()),
-            ast::CaptureByRef => self.word_space("ref"),
+            ast::CaptureByValue => self.word_space("move"),
+            ast::CaptureByRef => Ok(()),
         }
     }
 

--- a/src/test/compile-fail/regionck-unboxed-closure-lifetimes.rs
+++ b/src/test/compile-fail/regionck-unboxed-closure-lifetimes.rs
@@ -17,7 +17,7 @@ fn main() {
     {
         let c = 1;
         let c_ref = &c; //~ ERROR `c` does not live long enough
-        f = |&mut: a: int, b: int| { a + b + *c_ref };
+        f = move |&mut: a: int, b: int| { a + b + *c_ref };
     }
 }
 

--- a/src/test/run-pass/capture-clauses-boxed-closures.rs
+++ b/src/test/run-pass/capture-clauses-boxed-closures.rs
@@ -17,7 +17,7 @@ fn each<T>(x: &[T], f: |&T|) {
 fn main() {
     let mut sum = 0u;
     let elems = [ 1u, 2, 3, 4, 5 ];
-    each(elems, ref |val| sum += *val);
+    each(elems, |val| sum += *val);
     assert_eq!(sum, 15);
 }
 

--- a/src/test/run-pass/unboxed-closures-all-traits.rs
+++ b/src/test/run-pass/unboxed-closures-all-traits.rs
@@ -24,8 +24,8 @@ fn c<F:FnOnce(int, int) -> int>(f: F) -> int {
 
 fn main() {
     let z: int = 7;
-    assert_eq!(a(|&: x: int, y| x + y + z), 10);
-    assert_eq!(b(|&mut: x: int, y| x + y + z), 14);
-    assert_eq!(c(|: x: int, y| x + y + z), 18);
+    assert_eq!(a(move |&: x: int, y| x + y + z), 10);
+    assert_eq!(b(move |&mut: x: int, y| x + y + z), 14);
+    assert_eq!(c(move |: x: int, y| x + y + z), 18);
 }
 

--- a/src/test/run-pass/unboxed-closures-boxed.rs
+++ b/src/test/run-pass/unboxed-closures-boxed.rs
@@ -13,7 +13,8 @@
 use std::ops::FnMut;
 
  fn make_adder(x: int) -> Box<FnMut<(int,),int>+'static> {
-    (box |&mut: y: int| -> int { x + y }) as Box<FnMut<(int,),int>+'static>
+    (box move |&mut: y: int| -> int { x + y }) as
+        Box<FnMut<(int,),int>+'static>
 }
 
 pub fn main() {

--- a/src/test/run-pass/unboxed-closures-drop.rs
+++ b/src/test/run-pass/unboxed-closures-drop.rs
@@ -55,13 +55,13 @@ fn c<F:FnOnce(int, int) -> int>(f: F) -> int {
 
 fn test_fn() {
     {
-        a(|&: a: int, b| { a + b });
+        a(move |&: a: int, b| { a + b });
     }
     assert_eq!(drop_count(), 0);
 
     {
         let z = &Droppable::new();
-        a(|&: a: int, b| { z; a + b });
+        a(move |&: a: int, b| { z; a + b });
         assert_eq!(drop_count(), 0);
     }
     assert_eq!(drop_count(), 1);
@@ -69,7 +69,7 @@ fn test_fn() {
     {
         let z = &Droppable::new();
         let zz = &Droppable::new();
-        a(|&: a: int, b| { z; zz; a + b });
+        a(move |&: a: int, b| { z; zz; a + b });
         assert_eq!(drop_count(), 1);
     }
     assert_eq!(drop_count(), 3);
@@ -77,13 +77,13 @@ fn test_fn() {
 
 fn test_fn_mut() {
     {
-        b(|&mut: a: int, b| { a + b });
+        b(move |&mut: a: int, b| { a + b });
     }
     assert_eq!(drop_count(), 3);
 
     {
         let z = &Droppable::new();
-        b(|&mut: a: int, b| { z; a + b });
+        b(move |&mut: a: int, b| { z; a + b });
         assert_eq!(drop_count(), 3);
     }
     assert_eq!(drop_count(), 4);
@@ -91,7 +91,7 @@ fn test_fn_mut() {
     {
         let z = &Droppable::new();
         let zz = &Droppable::new();
-        b(|&mut: a: int, b| { z; zz; a + b });
+        b(move |&mut: a: int, b| { z; zz; a + b });
         assert_eq!(drop_count(), 4);
     }
     assert_eq!(drop_count(), 6);
@@ -99,13 +99,13 @@ fn test_fn_mut() {
 
 fn test_fn_once() {
     {
-        c(|: a: int, b| { a + b });
+        c(move |: a: int, b| { a + b });
     }
     assert_eq!(drop_count(), 6);
 
     {
         let z = Droppable::new();
-        c(|: a: int, b| { z; a + b });
+        c(move |: a: int, b| { z; a + b });
         assert_eq!(drop_count(), 7);
     }
     assert_eq!(drop_count(), 7);
@@ -113,7 +113,7 @@ fn test_fn_once() {
     {
         let z = Droppable::new();
         let zz = Droppable::new();
-        c(|: a: int, b| { z; zz; a + b });
+        c(move |: a: int, b| { z; zz; a + b });
         assert_eq!(drop_count(), 9);
     }
     assert_eq!(drop_count(), 9);

--- a/src/test/run-pass/unboxed-closures-single-word-env.rs
+++ b/src/test/run-pass/unboxed-closures-single-word-env.rs
@@ -27,8 +27,8 @@ fn c<F:FnOnce(int, int) -> int>(f: F) -> int {
 
 fn main() {
     let z = 10;
-    assert_eq!(a(|&: x: int, y| x + y + z), 13);
-    assert_eq!(b(|&mut: x: int, y| x + y + z), 17);
-    assert_eq!(c(|: x: int, y| x + y + z), 21);
+    assert_eq!(a(move |&: x: int, y| x + y + z), 13);
+    assert_eq!(b(move |&mut: x: int, y| x + y + z), 17);
+    assert_eq!(c(move |: x: int, y| x + y + z), 21);
 }
 


### PR DESCRIPTION
in favor of `move`.

This breaks code that used `move` as an identifier, because it is now a
keyword. Change such identifiers to not use the keyword `move`.
Additionally, this breaks code that was counting on by-value or
by-reference capture semantics for unboxed closures (behind the feature
gate). Change `ref |:|` to `|:|` and `|:|` to `move |:|`.

Part of RFC #63; part of issue #12831.

[breaking-change]

r? @nikomatsakis 
