### PR TITLE
Implement cfg syntax changes

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -226,7 +226,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
     // baz! should not use this definition unless foo is enabled.
 
     krate = time(time_passes, "configuration 1", krate, |krate|
-                 syntax::config::strip_unconfigured_items(krate));
+                 syntax::config::strip_unconfigured_items(sess.diagnostic(), krate));
 
     let mut addl_plugins = Some(addl_plugins);
     let Plugins { macros, registrars }
@@ -307,7 +307,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
 
     // strip again, in case expansion added anything with a #[cfg].
     krate = time(time_passes, "configuration 2", krate, |krate|
-                 syntax::config::strip_unconfigured_items(krate));
+                 syntax::config::strip_unconfigured_items(sess.diagnostic(), krate));
 
     krate = time(time_passes, "maybe building test harness", krate, |krate|
                  syntax::test::modify_for_testing(&sess.parse_sess,

--- a/src/test/compile-fail/asm-in-bad-modifier.rs
+++ b/src/test/compile-fail/asm-in-bad-modifier.rs
@@ -12,10 +12,9 @@
 
 fn foo(x: int) { println!("{}", x); }
 
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "x86_64")]
-#[cfg(target_arch = "arm")]
-
+#[cfg(any(target_arch = "x86",
+          target_arch = "x86_64",
+          target_arch = "arm"))]
 pub fn main() {
     let x: int;
     let y: int;
@@ -27,5 +26,5 @@ pub fn main() {
     foo(y);
 }
 
-#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"), not(target_arch = "arm"))]
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm")))]
 pub fn main() {}

--- a/src/test/compile-fail/asm-misplaced-option.rs
+++ b/src/test/compile-fail/asm-misplaced-option.rs
@@ -14,8 +14,8 @@
 
 #![allow(dead_code)]
 
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86",
+          target_arch = "x86_64"))]
 pub fn main() {
     // assignment not dead
     let mut x: int = 0;

--- a/src/test/compile-fail/asm-out-assign-imm.rs
+++ b/src/test/compile-fail/asm-out-assign-imm.rs
@@ -12,9 +12,9 @@
 
 fn foo(x: int) { println!("{}", x); }
 
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "x86_64")]
-#[cfg(target_arch = "arm")]
+#[cfg(any(target_arch = "x86",
+          target_arch = "x86_64",
+          target_arch = "arm"))]
 pub fn main() {
     let x: int;
     x = 1; //~ NOTE prior assignment occurs here
@@ -25,5 +25,5 @@ pub fn main() {
     foo(x);
 }
 
-#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"), not(target_arch = "arm"))]
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm")))]
 pub fn main() {}

--- a/src/test/compile-fail/asm-out-no-modifier.rs
+++ b/src/test/compile-fail/asm-out-no-modifier.rs
@@ -12,9 +12,9 @@
 
 fn foo(x: int) { println!("{}", x); }
 
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "x86_64")]
-#[cfg(target_arch = "arm")]
+#[cfg(any(target_arch = "x86",
+          target_arch = "x86_64",
+          target_arch = "arm"))]
 pub fn main() {
     let x: int;
     unsafe {
@@ -23,5 +23,5 @@ pub fn main() {
     foo(x);
 }
 
-#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"), not(target_arch = "arm"))]
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm")))]
 pub fn main() {}

--- a/src/test/compile-fail/asm-out-read-uninit.rs
+++ b/src/test/compile-fail/asm-out-read-uninit.rs
@@ -12,9 +12,9 @@
 
 fn foo(x: int) { println!("{}", x); }
 
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "x86_64")]
-#[cfg(target_arch = "arm")]
+#[cfg(any(target_arch = "x86",
+          target_arch = "x86_64",
+          target_arch = "arm"))]
 pub fn main() {
     let x: int;
     unsafe {
@@ -23,5 +23,5 @@ pub fn main() {
     foo(x);
 }
 
-#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"), not(target_arch = "arm"))]
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm")))]
 pub fn main() {}

--- a/src/test/compile-fail/test-cfg.rs
+++ b/src/test/compile-fail/test-cfg.rs
@@ -10,7 +10,7 @@
 
 // compile-flags: --cfg foo
 
-#[cfg(foo, bar)] // foo AND bar
+#[cfg(all(foo, bar))] // foo AND bar
 fn foo() {}
 
 fn main() {

--- a/src/test/pretty/raw-str-nonexpr.rs
+++ b/src/test/pretty/raw-str-nonexpr.rs
@@ -12,7 +12,7 @@
 
 #![feature(asm)]
 
-#[cfg = r#"just parse this"#]
+#[cfg(foo = r#"just parse this"#)]
 extern crate r##"blah"## as blah;
 
 fn main() { unsafe { asm!(r###"blah"###); } }

--- a/src/test/run-pass/syntax-extension-cfg.rs
+++ b/src/test/run-pass/syntax-extension-cfg.rs
@@ -8,27 +8,27 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: --cfg foo --cfg bar(baz) --cfg qux="foo"
+// compile-flags: --cfg foo --cfg qux="foo"
 
 pub fn main() {
     // check
     if ! cfg!(foo) { fail!() }
     if   cfg!(not(foo)) { fail!() }
 
-    if ! cfg!(bar(baz)) { fail!() }
-    if   cfg!(not(bar(baz))) { fail!() }
-
     if ! cfg!(qux="foo") { fail!() }
     if   cfg!(not(qux="foo")) { fail!() }
 
-    if ! cfg!(foo, bar(baz), qux="foo") { fail!() }
-    if   cfg!(not(foo, bar(baz), qux="foo")) { fail!() }
+    if ! cfg!(foo, qux="foo") { fail!() }
+    if   cfg!(not(foo, qux="foo")) { fail!() }
+    if   cfg!(all(not(foo, qux="foo"))) { fail!() }
 
     if cfg!(not_a_cfg) { fail!() }
-    if cfg!(not_a_cfg, foo, bar(baz), qux="foo") { fail!() }
+    if cfg!(not_a_cfg, foo, qux="foo") { fail!() }
+    if cfg!(all(not_a_cfg, foo, qux="foo")) { fail!() }
+    if ! cfg!(any(not_a_cfg, foo)) { fail!() }
 
     if ! cfg!(not(not_a_cfg)) { fail!() }
-    if ! cfg!(not(not_a_cfg), foo, bar(baz), qux="foo") { fail!() }
+    if ! cfg!(not(not_a_cfg), foo, qux="foo") { fail!() }
 
     if cfg!(trailing_comma, ) { fail!() }
 }


### PR DESCRIPTION
We'll need a snapshot before we can convert the codebase over and turn on the deprecation warnings.

cc #17490

This is sitting on top of #17506
