### PR TITLE
debuginfo: Make sure that all calls to drop glue are associated with debug locations.

### DIFF
--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -714,8 +714,12 @@ pub fn trans_call_inner<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             fcx.pop_custom_cleanup_scope(arg_cleanup_scope);
 
             let ctor_ty = callee_ty.subst(bcx.tcx(), &substs);
-            return base::trans_named_tuple_constructor(bcx, ctor_ty, disr,
-                                                       args, dest.unwrap());
+            return base::trans_named_tuple_constructor(bcx,
+                                                       ctor_ty,
+                                                       disr,
+                                                       args,
+                                                       dest.unwrap(),
+                                                       call_info);
         }
     };
 
@@ -835,7 +839,7 @@ pub fn trans_call_inner<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     match (dest, opt_llretslot) {
         (Some(expr::Ignore), Some(llretslot)) => {
             // drop the value if it is not being saved.
-            bcx = glue::drop_ty(bcx, llretslot, ret_ty);
+            bcx = glue::drop_ty(bcx, llretslot, ret_ty, call_info);
             call_lifetime_end(bcx, llretslot);
         }
         _ => {}

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -541,7 +541,7 @@ pub fn trans_intrinsic_call<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>, node: ast::N
     // If we made a temporary stack slot, let's clean it up
     match dest {
         expr::Ignore => {
-            bcx = glue::drop_ty(bcx, llresult, ret_ty);
+            bcx = glue::drop_ty(bcx, llresult, ret_ty, Some(call_info));
         }
         expr::SaveIn(_) => {}
     }

--- a/src/librustc/middle/trans/tvec.rs
+++ b/src/librustc/middle/trans/tvec.rs
@@ -64,7 +64,7 @@ pub fn make_drop_glue_unboxed<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         let dataptr = get_dataptr(bcx, vptr);
         let bcx = if ty::type_needs_drop(tcx, unit_ty) {
             let len = get_len(bcx, vptr);
-            iter_vec_raw(bcx, dataptr, unit_ty, len, glue::drop_ty)
+            iter_vec_raw(bcx, dataptr, unit_ty, len, |bb, vv, tt| glue::drop_ty(bb, vv, tt, None))
         } else {
             bcx
         };

--- a/src/test/debuginfo/borrowed-basic.rs
+++ b/src/test/debuginfo/borrowed-basic.rs
@@ -130,8 +130,8 @@ fn main() {
     let i32_val: i32 = -32;
     let i32_ref: &i32 = &i32_val;
 
-    let uint_val: i64 = -64;
-    let i64_ref: &i64 = &uint_val;
+    let i64_val: i64 = -64;
+    let i64_ref: &i64 = &i64_val;
 
     let uint_val: uint = 1;
     let uint_ref: &uint = &uint_val;


### PR DESCRIPTION
This PR makes rustc emit debug locations for _all_ call and invoke statements in LLVM IR, if they are contained within a function that debuginfo is enabled for. This is important because LLVM does not handle the case where a function body containing debuginfo is inlined into another function with debuginfo, but the inlined call statement does not have a debug location. In this case, LLVM will not know where (in terms of source code coordinates) the function was inlined to and we end up with some statements still linked to the source locations in there original, non-inlined function without any indication that they are indeed an inline-copy. Later, when generating DWARF from the IR, LLVM will interpret this as corrupt IR and abort.

Unfortunately, the undesirable case described above can still occur when using LTO. If there is a crate compiled without debuginfo calling into a crate compiled with debuginfo, we again end up with the conditions triggering the error. This is why some LTO tests still fail with the dreaded assertion, if the standard library was built with debuginfo enabled. That is, `RUSTFLAGS_STAGE2=-g make rustc-stage2` will succeed but `RUSTFLAGS_STAGE2=-g make check` will still fail after this PR has been merged. I will open a separate issue for this problem.
