### PR TITLE
Use 'dev' for the release channel and version suffix when building from ...

### DIFF
--- a/configure
+++ b/configure
@@ -453,7 +453,7 @@ valopt datadir "${CFG_PREFIX}/share" "install data"
 valopt infodir "${CFG_PREFIX}/share/info" "install additional info"
 valopt mandir "${CFG_PREFIX}/share/man" "install man pages in PATH"
 
-valopt release-channel "source" "the name of the release channel to build"
+valopt release-channel "dev" "the name of the release channel to build"
 
 # On windows we just store the libraries in the bin directory because
 # there's no rpath. This is where the build system itself puts libraries;
@@ -479,10 +479,10 @@ validate_opt
 
 # Validate the release channel
 case "$CFG_RELEASE_CHANNEL" in
-    (source | nightly | beta | stable)
+    (dev | nightly | beta | stable)
 	;;
     (*)
-        err "release channel must be 'source', 'nightly', 'beta' or 'stable'"
+        err "release channel must be 'dev', 'nightly', 'beta' or 'stable'"
         ;;
 esac
 

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -35,9 +35,9 @@ ifeq ($(CFG_RELEASE_CHANNEL),nightly)
 CFG_RELEASE=$(CFG_RELEASE_NUM)-nightly
 CFG_PACKAGE_VERS=nightly
 endif
-ifeq ($(CFG_RELEASE_CHANNEL),source)
-CFG_RELEASE=$(CFG_RELEASE_NUM)-pre
-CFG_PACKAGE_VERS=$(CFG_RELEASE_NUM)-pre
+ifeq ($(CFG_RELEASE_CHANNEL),dev)
+CFG_RELEASE=$(CFG_RELEASE_NUM)-dev
+CFG_PACKAGE_VERS=$(CFG_RELEASE_NUM)-dev
 endif
 
 # The name of the package to use for creating tarballs, installers etc.


### PR DESCRIPTION
...source

This is more consistent with how the other channels work.

r? @alexcrichton 
