### PR TITLE
librustc: Implement the unboxed closure trait hierarchy.

### DIFF
--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -1332,6 +1332,7 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
             rbml_w.id(id);
             rbml_w.tag(c::tag_table_val, |rbml_w| {
                 rbml_w.emit_closure_type(ecx, &unboxed_closure.closure_type);
+                rbml_w.emit_def_id(unboxed_closure.expr_id);
                 encode_unboxed_closure_kind(rbml_w, unboxed_closure.kind)
             })
         })
@@ -1750,6 +1751,7 @@ impl<'a> rbml_decoder_decoder_helpers for reader::Decoder<'a> {
                 dcx.tcx,
                 |s, a| this.convert_def_id(dcx, s, a)))
         }).unwrap();
+        let expr_id = self.read_def_id(dcx);
         let variants = [
             "FnUnboxedClosureKind",
             "FnMutUnboxedClosureKind",
@@ -1765,6 +1767,7 @@ impl<'a> rbml_decoder_decoder_helpers for reader::Decoder<'a> {
         }).unwrap();
         ty::UnboxedClosure {
             closure_type: closure_type,
+            expr_id: expr_id,
             kind: kind,
         }
     }

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -282,7 +282,7 @@ pub fn closure_to_block(closure_id: ast::NodeId,
         ast_map::NodeExpr(expr) => match expr.node {
             ast::ExprProc(_, ref block) |
             ast::ExprFnBlock(_, _, ref block) |
-            ast::ExprUnboxedFn(_, _, _, ref block) => { block.id }
+            ast::ExprUnboxedFn(_, _, _, _, ref block) => { block.id }
             _ => fail!("encountered non-closure id: {}", closure_id)
         },
         _ => fail!("encountered non-expr id: {}", closure_id)

--- a/src/librustc/middle/check_loop.rs
+++ b/src/librustc/middle/check_loop.rs
@@ -49,7 +49,7 @@ impl<'a, 'v> Visitor<'v> for CheckLoopVisitor<'a> {
             }
             ast::ExprFnBlock(_, _, ref b) |
             ast::ExprProc(_, ref b) |
-            ast::ExprUnboxedFn(_, _, _, ref b) => {
+            ast::ExprUnboxedFn(_, _, _, _, ref b) => {
                 self.with_context(Closure, |v| v.visit_block(&**b));
             }
             ast::ExprBreak(_) => self.require_loop("break", e.span),

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -961,7 +961,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
 
           ExprFnBlock(_, _, ref blk) |
           ExprProc(_, ref blk) |
-          ExprUnboxedFn(_, _, _, ref blk) => {
+          ExprUnboxedFn(_, _, _, _, ref blk) => {
               debug!("{} is an ExprFnBlock, ExprProc, or ExprUnboxedFn",
                      expr_to_string(expr));
 

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -580,10 +580,21 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                       }
                   }
                   ty::ty_unboxed_closure(closure_id, _) => {
-                      let unboxed_closures = self.typer
-                                                 .unboxed_closures()
-                                                 .borrow();
-                      let kind = unboxed_closures.get(&closure_id).kind;
+                      assert!(closure_id.krate == ast::LOCAL_CRATE);
+                      let kind = match self.typer
+                                           .tcx()
+                                           .map
+                                           .expect_expr(closure_id.node)
+                                           .node {
+                        ast::ExprUnboxedFn(_, kind, _, _, _) => {
+                            ty::UnboxedClosureKind::from_ast_kind(kind)
+                        }
+                        _ => {
+                            self.typer.tcx().sess.bug("didn't find unboxed \
+                                                       fn with appropriate \
+                                                       type in AST map")
+                        }
+                      };
                       let onceness = match kind {
                           ty::FnUnboxedClosureKind |
                           ty::FnMutUnboxedClosureKind => ast::Many,

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -5815,7 +5815,7 @@ impl<'a> Resolver<'a> {
                                       Some(&**fn_decl), NoTypeParameters,
                                       &**block);
             }
-            ExprUnboxedFn(capture_clause, _, ref fn_decl, ref block) => {
+            ExprUnboxedFn(capture_clause, _, _, ref fn_decl, ref block) => {
                 self.capture_mode_map.borrow_mut().insert(expr.id, capture_clause);
                 self.resolve_function(ClosureRibKind(expr.id, block.id),
                                       Some(&**fn_decl), NoTypeParameters,

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -32,6 +32,7 @@ use std::cell::RefCell;
 use std::collections::hashmap::HashMap;
 use std::rc::Rc;
 use syntax::ast;
+use syntax::ast_util;
 use util::ppaux::Repr;
 
 pub struct SelectionContext<'cx, 'tcx:'cx> {
@@ -543,6 +544,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
          * unboxed closure type.
          */
 
+        debug!("assemble_unboxed_candidates()");
+
         let closure_def_id = match ty::get(skol_obligation_self_ty).sty {
             ty::ty_unboxed_closure(id, _) => id,
             _ => { return Ok(()); }
@@ -564,22 +567,34 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 _ => continue,
             };
 
-            // Check to see whether the argument and return types match.
-            let closure_kind = match self.typer.unboxed_closures().borrow().find(&closure_def_id) {
-                Some(closure) => closure.kind,
-                None => {
-                    self.tcx().sess.span_bug(
-                        obligation.cause.span,
-                        format!("No entry for unboxed closure: {}",
-                                closure_def_id.repr(self.tcx())).as_slice());
-                }
-            };
+            // Check to see whether the closure could implement this trait.
+            assert!(closure_def_id.krate == ast::LOCAL_CRATE);
+            let auxiliary_closure_id =
+                match self.tcx().map.expect_expr(closure_def_id.node).node {
+                    ast::ExprUnboxedFn(_, _, ref ids, _, _) => {
+                        ast_util::local_def(
+                            kind.select_auxiliary_unboxed_closure_id(&**ids))
+                    }
+                    _ => {
+                        self.tcx().sess.span_bug(
+                            obligation.cause.span,
+                            "unboxed fn didn't map to an expr")
+                    }
+                };
 
-            if closure_kind != kind {
-                continue;
+            debug!("assemble_unboxed_candidates(kind={})", kind);
+
+            // Check to see whether the argument and return types match.
+            if !self.typer
+                    .unboxed_closures()
+                    .borrow()
+                    .contains_key(&auxiliary_closure_id) {
+                // Not compatible with this trait.
+                continue
             }
 
-            candidates.push(MatchedUnboxedClosureCandidate(closure_def_id));
+            candidates.push(MatchedUnboxedClosureCandidate(
+                    auxiliary_closure_id));
         }
 
         Ok(())
@@ -1067,7 +1082,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             }
 
             MatchedUnboxedClosureCandidate(closure_def_id) => {
-                try!(self.confirm_unboxed_closure_candidate(obligation, closure_def_id));
+                try!(self.confirm_unboxed_closure_candidate(
+                        obligation,
+                        closure_def_id));
                 Ok(Some(VtableUnboxedClosure(closure_def_id)))
             }
         }
@@ -1148,11 +1165,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         Ok(vtable_impl)
     }
 
-    fn confirm_unboxed_closure_candidate(&mut self,
-                                         obligation: &Obligation,
-                                         closure_def_id: ast::DefId)
-                                         -> Result<(),SelectionError>
-    {
+    fn confirm_unboxed_closure_candidate(
+            &mut self,
+            obligation: &Obligation,
+            closure_def_id: ast::DefId)
+            -> Result<(),SelectionError> {
         debug!("confirm_unboxed_closure_candidate({},{})",
                obligation.repr(self.tcx()),
                closure_def_id.repr(self.tcx()));

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -286,7 +286,7 @@ pub fn trans_unboxing_shim(bcx: Block,
         link::mangle_internal_name_by_path_and_seq(path, "unboxing_shim")
     });
     let llfn = decl_internal_rust_fn(ccx,
-                                     boxed_function_type,
+                                     NormalFunctionType(boxed_function_type),
                                      function_name.as_slice());
 
     let block_arena = TypedArena::new();

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -1158,7 +1158,11 @@ pub fn create_function_debug_context(cx: &CrateContext,
             match expr.node {
                 ast::ExprFnBlock(_, ref fn_decl, ref top_level_block) |
                 ast::ExprProc(ref fn_decl, ref top_level_block) |
-                ast::ExprUnboxedFn(_, _, ref fn_decl, ref top_level_block) => {
+                ast::ExprUnboxedFn(_,
+                                   _,
+                                   _,
+                                   ref fn_decl,
+                                   ref top_level_block) => {
                     let name = format!("fn{}", token::gensym("fn"));
                     let name = token::str_to_ident(name.as_slice());
                     (name, &**fn_decl,
@@ -3566,7 +3570,7 @@ fn populate_scope_map(cx: &CrateContext,
 
             ast::ExprFnBlock(_, ref decl, ref block) |
             ast::ExprProc(ref decl, ref block) |
-            ast::ExprUnboxedFn(_, _, ref decl, ref block) => {
+            ast::ExprUnboxedFn(_, _, _, ref decl, ref block) => {
                 with_new_scope(cx,
                                block.span,
                                scope_stack,

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -1041,8 +1041,13 @@ fn trans_rvalue_dps_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                    expr_to_string(expr), expr_ty.repr(tcx));
             closure::trans_expr_fn(bcx, store, &**decl, &**body, expr.id, dest)
         }
-        ast::ExprUnboxedFn(_, _, ref decl, ref body) => {
-            closure::trans_unboxed_closure(bcx, &**decl, &**body, expr.id, dest)
+        ast::ExprUnboxedFn(_, _, ref ids, ref decl, ref body) => {
+            closure::trans_unboxed_closure(bcx,
+                                           &**decl,
+                                           &**body,
+                                           expr.id,
+                                           &**ids,
+                                           dest)
         }
         ast::ExprCall(ref f, ref args) => {
             if bcx.tcx().is_method_call(expr.id) {

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -13,7 +13,7 @@ use back::{link};
 use llvm::{ValueRef, CallConv, Linkage, get_param};
 use llvm;
 use middle::weak_lang_items;
-use middle::trans::base::push_ctxt;
+use middle::trans::base::{NormalFunctionType, push_ctxt};
 use middle::trans::base;
 use middle::trans::build::*;
 use middle::trans::cabi;
@@ -639,7 +639,9 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: &CrateContext,
                ccx.tcx().map.path_to_string(id),
                id, t.repr(tcx));
 
-        let llfn = base::decl_internal_rust_fn(ccx, t, ps.as_slice());
+        let llfn = base::decl_internal_rust_fn(ccx,
+                                               NormalFunctionType(t),
+                                               ps.as_slice());
         base::set_llvm_fn_attrs(attrs, llfn);
         base::trans_fn(ccx, decl, body, llfn, param_substs, id, []);
         llfn
@@ -809,7 +811,8 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: &CrateContext,
         // Perform the call itself
         debug!("calling llrustfn = {}, t = {}",
                ccx.tn().val_to_string(llrustfn), t.repr(ccx.tcx()));
-        let attributes = base::get_fn_llvm_attributes(ccx, t);
+        let attributes = base::get_fn_llvm_attributes(ccx,
+                                                      NormalFunctionType(t));
         let llrust_ret_val = builder.call(llrustfn, llrust_args.as_slice(), Some(attributes));
 
         // Get the return value where the foreign fn expects it.

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -571,15 +571,15 @@ pub fn get_vtable(bcx: Block,
                     nested: _ }) => {
                 emit_vtable_methods(bcx, id, substs).into_iter()
             }
-            traits::VtableUnboxedClosure(closure_def_id) => {
+            traits::VtableUnboxedClosure(auxiliary_def_id) => {
                 let callee_substs =
                     get_callee_substitutions_for_unboxed_closure(
                         bcx,
-                        closure_def_id);
+                        auxiliary_def_id);
 
                 let mut llfn = trans_fn_ref_with_substs(
                     bcx,
-                    closure_def_id,
+                    auxiliary_def_id,
                     ExprId(0),
                     callee_substs.clone());
 
@@ -588,14 +588,14 @@ pub fn get_vtable(bcx: Block,
                                               .unboxed_closures
                                               .borrow();
                     let closure_info =
-                        unboxed_closures.find(&closure_def_id)
+                        unboxed_closures.find(&auxiliary_def_id)
                                         .expect("get_vtable(): didn't find \
                                                  unboxed closure");
                     if closure_info.kind == ty::FnOnceUnboxedClosureKind {
                         // Untuple the arguments and create an unboxing shim.
                         let mut new_inputs = vec![
                             ty::mk_unboxed_closure(bcx.tcx(),
-                                                   closure_def_id,
+                                                   closure_info.expr_id,
                                                    ty::ReStatic)
                         ];
                         match ty::get(closure_info.closure_type
@@ -630,7 +630,7 @@ pub fn get_vtable(bcx: Block,
                         llfn = trans_unboxing_shim(bcx,
                                                    llfn,
                                                    &closure_type,
-                                                   closure_def_id,
+                                                   auxiliary_def_id,
                                                    callee_substs);
                     }
                 }

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -14,9 +14,9 @@ use llvm::ValueRef;
 use llvm;
 use middle::subst;
 use middle::subst::Subst;
-use middle::trans::base::{set_llvm_fn_attrs, set_inline_hint};
-use middle::trans::base::{trans_enum_variant, push_ctxt, get_item_val};
-use middle::trans::base::{trans_fn, decl_internal_rust_fn};
+use middle::trans::base::{NormalFunctionType, decl_internal_rust_fn};
+use middle::trans::base::{get_item_val, push_ctxt, set_inline_hint};
+use middle::trans::base::{set_llvm_fn_attrs, trans_enum_variant, trans_fn};
 use middle::trans::base;
 use middle::trans::common::*;
 use middle::trans::foreign;
@@ -141,7 +141,9 @@ pub fn monomorphic_fn(ccx: &CrateContext,
         let lldecl = if abi != abi::Rust {
             foreign::decl_rust_fn_with_foreign_abi(ccx, mono_ty, s.as_slice())
         } else {
-            decl_internal_rust_fn(ccx, mono_ty, s.as_slice())
+            decl_internal_rust_fn(ccx,
+                                  NormalFunctionType(mono_ty),
+                                  s.as_slice())
         };
 
         ccx.monomorphized().borrow_mut().insert(hash_id.take().unwrap(), lldecl);

--- a/src/librustc/middle/trans/reflect.rs
+++ b/src/librustc/middle/trans/reflect.rs
@@ -339,7 +339,7 @@ impl<'a, 'blk, 'tcx> Reflector<'a, 'blk, 'tcx> {
                 let fn_ty = ty::mk_ctor_fn(ccx.tcx(), ast::DUMMY_NODE_ID,
                                            [opaqueptrty], ty::mk_u64());
                 let llfdecl = decl_internal_rust_fn(ccx,
-                                                    fn_ty,
+                                                    NormalFunctionType(fn_ty),
                                                     sym.as_slice());
                 let arena = TypedArena::new();
                 let empty_param_substs = param_substs::empty();

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1438,9 +1438,11 @@ pub struct UnboxedClosure {
     pub closure_type: ClosureTy,
     /// The kind of unboxed closure this is.
     pub kind: UnboxedClosureKind,
+    /// The ID of the expression.
+    pub expr_id: ast::DefId,
 }
 
-#[deriving(Clone, PartialEq, Eq)]
+#[deriving(Clone, PartialEq, Eq, Show)]
 pub enum UnboxedClosureKind {
     FnUnboxedClosureKind,
     FnMutUnboxedClosureKind,
@@ -1448,6 +1450,29 @@ pub enum UnboxedClosureKind {
 }
 
 impl UnboxedClosureKind {
+    pub fn from_ast_kind(ast_kind: ast::UnboxedClosureKind)
+                         -> UnboxedClosureKind {
+        match ast_kind {
+            ast::FnUnboxedClosureKind => FnUnboxedClosureKind,
+            ast::FnMutUnboxedClosureKind => FnMutUnboxedClosureKind,
+            ast::FnOnceUnboxedClosureKind => FnOnceUnboxedClosureKind,
+        }
+    }
+
+    pub fn from_trait_did(cx: &ctxt, trait_did: ast::DefId)
+                          -> UnboxedClosureKind {
+        if Some(trait_did) == cx.lang_items.fn_trait() {
+            FnUnboxedClosureKind
+        } else if Some(trait_did) == cx.lang_items.fn_mut_trait() {
+            FnMutUnboxedClosureKind
+        } else if Some(trait_did) == cx.lang_items.fn_once_trait() {
+            FnOnceUnboxedClosureKind
+        } else {
+            cx.sess.bug("UnboxedClosureKind::from_trait_did(): not an \
+                         unboxed closure trait")
+        }
+    }
+
     pub fn trait_did(&self, cx: &ctxt) -> ast::DefId {
         let result = match *self {
             FnUnboxedClosureKind => cx.lang_items.require(FnTraitLangItem),
@@ -1461,6 +1486,44 @@ impl UnboxedClosureKind {
         match result {
             Ok(trait_did) => trait_did,
             Err(err) => cx.sess.fatal(err.as_slice()),
+        }
+    }
+
+    pub fn is_compatible_with(self, bound: UnboxedClosureKind) -> bool {
+        match (self, bound) {
+            (FnOnceUnboxedClosureKind, _) |
+            (FnMutUnboxedClosureKind, FnUnboxedClosureKind) |
+            (FnMutUnboxedClosureKind, FnMutUnboxedClosureKind) |
+            (FnUnboxedClosureKind, FnUnboxedClosureKind) => true,
+            _ => false,
+        }
+    }
+
+    pub fn select_auxiliary_unboxed_closure_id(
+            self,
+            ids: &ast::AuxiliaryUnboxedClosureIds)
+            -> ast::NodeId {
+        match self {
+            FnUnboxedClosureKind => ids.fn_id,
+            FnMutUnboxedClosureKind => ids.fn_mut_id,
+            FnOnceUnboxedClosureKind => ids.fn_once_id,
+        }
+    }
+}
+
+pub fn auxiliary_def_id_for_unboxed_closure(tcx: &ctxt, expr_id: ast::NodeId)
+                                            -> ast::DefId {
+    let expr = tcx.map.expect_expr(expr_id);
+    match expr.node {
+        ast::ExprUnboxedFn(_, kind, ref ids, _, _) => {
+            let kind = UnboxedClosureKind::from_ast_kind(kind);
+            ast_util::local_def(kind.select_auxiliary_unboxed_closure_id(
+                    &**ids))
+        }
+        _ => {
+            tcx.sess.span_bug(expr.span,
+                              "auxiliary_def_id_for_unboxed_closure(): ID \
+                               passed in wasn't that of an unboxed fn")
         }
     }
 }

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2117,11 +2117,11 @@ fn try_overloaded_call<'a>(fcx: &FnCtxt,
         _ => {}
     }
 
-    // Try `FnOnce`, then `FnMut`, then `Fn`.
+    // Try `Fn`, then `FnMut`, then `FnOnce`.
     for &(maybe_function_trait, method_name) in [
-        (fcx.tcx().lang_items.fn_once_trait(), token::intern("call_once")),
+        (fcx.tcx().lang_items.fn_trait(), token::intern("call")),
         (fcx.tcx().lang_items.fn_mut_trait(), token::intern("call_mut")),
-        (fcx.tcx().lang_items.fn_trait(), token::intern("call"))
+        (fcx.tcx().lang_items.fn_once_trait(), token::intern("call_once"))
     ].iter() {
         let function_trait = match maybe_function_trait {
             None => continue,
@@ -3290,6 +3290,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
     fn check_unboxed_closure(fcx: &FnCtxt,
                              expr: &ast::Expr,
                              kind: ast::UnboxedClosureKind,
+                             ids: &ast::AuxiliaryUnboxedClosureIds,
                              decl: &ast::FnDecl,
                              body: &ast::Block) {
         let mut fn_ty = astconv::ty_of_closure(
@@ -3320,6 +3321,9 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                                                   local_def(expr.id),
                                                   region);
         fcx.write_ty(expr.id, closure_type);
+        fcx.write_ty(ids.fn_id, closure_type);
+        fcx.write_ty(ids.fn_mut_id, closure_type);
+        fcx.write_ty(ids.fn_once_id, closure_type);
 
         check_fn(fcx.ccx,
                  ast::NormalFn,
@@ -3344,15 +3348,38 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             ast::FnOnceUnboxedClosureKind => ty::FnOnceUnboxedClosureKind,
         };
 
-        let unboxed_closure = ty::UnboxedClosure {
-            closure_type: fn_ty,
-            kind: kind,
-        };
-
         fcx.inh
            .unboxed_closures
            .borrow_mut()
-           .insert(local_def(expr.id), unboxed_closure);
+           .insert(local_def(ids.fn_once_id),
+                   ty::UnboxedClosure {
+                closure_type: fn_ty.clone(),
+                expr_id: ast_util::local_def(expr.id),
+                kind: ty::FnOnceUnboxedClosureKind,
+           });
+        if kind == ty::FnUnboxedClosureKind ||
+                kind == ty::FnMutUnboxedClosureKind {
+            fcx.inh
+               .unboxed_closures
+               .borrow_mut()
+               .insert(local_def(ids.fn_mut_id),
+                       ty::UnboxedClosure {
+                    closure_type: fn_ty.clone(),
+                    expr_id: ast_util::local_def(expr.id),
+                    kind: ty::FnMutUnboxedClosureKind,
+               });
+        }
+        if kind == ty::FnUnboxedClosureKind {
+            fcx.inh
+               .unboxed_closures
+               .borrow_mut()
+               .insert(local_def(ids.fn_id),
+                       ty::UnboxedClosure {
+                    closure_type: fn_ty,
+                    expr_id: ast_util::local_def(expr.id),
+                    kind: ty::FnUnboxedClosureKind,
+               });
+        }
     }
 
     fn check_expr_fn(fcx: &FnCtxt,
@@ -4124,10 +4151,11 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                       &**body,
                       expected);
       }
-      ast::ExprUnboxedFn(_, kind, ref decl, ref body) => {
+      ast::ExprUnboxedFn(_, kind, ref ids, ref decl, ref body) => {
         check_unboxed_closure(fcx,
                               expr,
                               kind,
+                              &**ids,
                               &**decl,
                               &**body);
       }

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -733,7 +733,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
 
         ast::ExprFnBlock(_, _, ref body) |
         ast::ExprProc(_, ref body) |
-        ast::ExprUnboxedFn(_, _, _, ref body) => {
+        ast::ExprUnboxedFn(_, _, _, _, ref body) => {
             check_expr_fn_block(rcx, expr, &**body);
         }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -502,6 +502,13 @@ pub enum UnsafeSource {
 }
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+pub struct AuxiliaryUnboxedClosureIds {
+    pub fn_id: NodeId,
+    pub fn_mut_id: NodeId,
+    pub fn_once_id: NodeId,
+}
+
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub struct Expr {
     pub id: NodeId,
     pub node: Expr_,
@@ -531,7 +538,11 @@ pub enum Expr_ {
     ExprMatch(P<Expr>, Vec<Arm>),
     ExprFnBlock(CaptureClause, P<FnDecl>, P<Block>),
     ExprProc(P<FnDecl>, P<Block>),
-    ExprUnboxedFn(CaptureClause, UnboxedClosureKind, P<FnDecl>, P<Block>),
+    ExprUnboxedFn(CaptureClause,
+                  UnboxedClosureKind,
+                  P<AuxiliaryUnboxedClosureIds>,
+                  P<FnDecl>,
+                  P<Block>),
     ExprBlock(P<Block>),
 
     ExprAssign(P<Expr>, P<Expr>),

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -1233,11 +1233,16 @@ pub fn noop_fold_expr<T: Folder>(Expr {id, node, span}: Expr, folder: &mut T) ->
                 ExprProc(folder.fold_fn_decl(decl),
                          folder.fold_block(body))
             }
-            ExprUnboxedFn(capture_clause, kind, decl, body) => {
+            ExprUnboxedFn(capture_clause, kind, ids, decl, body) => {
                 ExprUnboxedFn(capture_clause,
-                            kind,
-                            folder.fold_fn_decl(decl),
-                            folder.fold_block(body))
+                              kind,
+                              P(AuxiliaryUnboxedClosureIds {
+                                  fn_id: folder.new_id(ids.fn_id),
+                                  fn_mut_id: folder.new_id(ids.fn_mut_id),
+                                  fn_once_id: folder.new_id(ids.fn_once_id),
+                              }),
+                              folder.fold_fn_decl(decl),
+                              folder.fold_block(body))
             }
             ExprBlock(blk) => ExprBlock(folder.fold_block(blk)),
             ExprAssign(el, er) => {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -11,7 +11,7 @@
 #![macro_escape]
 
 use abi;
-use ast::{AssociatedType, BareFnTy, ClosureTy};
+use ast::{AssociatedType, AuxiliaryUnboxedClosureIds, BareFnTy, ClosureTy};
 use ast::{RegionTyParamBound, TraitTyParamBound};
 use ast::{ProvidedMethod, Public, FnStyle};
 use ast::{Mod, BiAdd, Arg, Arm, Attribute, BindByRef, BindByValue};
@@ -2893,10 +2893,16 @@ impl<'a> Parser<'a> {
 
         match optional_unboxed_closure_kind {
             Some(unboxed_closure_kind) => {
+                let ids = P(AuxiliaryUnboxedClosureIds {
+                    fn_id: ast::DUMMY_NODE_ID,
+                    fn_mut_id: ast::DUMMY_NODE_ID,
+                    fn_once_id: ast::DUMMY_NODE_ID,
+                });
                 self.mk_expr(lo,
                              fakeblock.span.hi,
                              ExprUnboxedFn(capture_clause,
                                            unboxed_closure_kind,
+                                           ids,
                                            decl,
                                            fakeblock))
             }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1552,7 +1552,11 @@ impl<'a> State<'a> {
                 // empty box to satisfy the close.
                 try!(self.ibox(0));
             }
-            ast::ExprUnboxedFn(capture_clause, kind, ref decl, ref body) => {
+            ast::ExprUnboxedFn(capture_clause,
+                               kind,
+                               _,
+                               ref decl,
+                               ref body) => {
                 try!(self.print_capture_clause(capture_clause));
 
                 // in do/for blocks we don't want to show an empty

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -749,7 +749,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
                              expression.span,
                              expression.id)
         }
-        ExprUnboxedFn(_, _, ref function_declaration, ref body) => {
+        ExprUnboxedFn(_, _, _, ref function_declaration, ref body) => {
             visitor.visit_fn(FkFnBlock,
                              &**function_declaration,
                              &**body,

--- a/src/test/compile-fail/borrowck-overloaded-call.rs
+++ b/src/test/compile-fail/borrowck-overloaded-call.rs
@@ -23,6 +23,18 @@ impl Fn<(int,),int> for SFn {
     }
 }
 
+impl FnMut<(int,),int> for SFn {
+    extern "rust-call" fn call_mut(&mut self, (z,): (int,)) -> int {
+        self.call((z,))
+    }
+}
+
+impl FnOnce<(int,),int> for SFn {
+    extern "rust-call" fn call_once(self, (z,): (int,)) -> int {
+        self.call((z,))
+    }
+}
+
 struct SFnMut {
     x: int,
     y: int,
@@ -31,6 +43,12 @@ struct SFnMut {
 impl FnMut<(int,),int> for SFnMut {
     extern "rust-call" fn call_mut(&mut self, (z,): (int,)) -> int {
         self.x * self.y * z
+    }
+}
+
+impl FnOnce<(int,),int> for SFnMut {
+    extern "rust-call" fn call_once(mut self, (z,): (int,)) -> int {
+        self.call_mut((z,))
     }
 }
 

--- a/src/test/compile-fail/issue-15094.rs
+++ b/src/test/compile-fail/issue-15094.rs
@@ -16,6 +16,16 @@ struct Shower<T> {
     x: T
 }
 
+impl<T: fmt::Show> ops::FnOnce<(), ()> for Shower<T> {
+    extern "rust-call" fn call_once(self, _args: ()) {
+    }
+}
+
+impl<T: fmt::Show> ops::FnMut<(), ()> for Shower<T> {
+    extern "rust-call" fn call_mut(&mut self, _args: ()) {
+    }
+}
+
 impl<T: fmt::Show> ops::Fn<(), ()> for Shower<T> {
     fn call(&self, _args: ()) {
 //~^ ERROR `call` has an incompatible type for trait: expected "rust-call" fn, found "Rust" fn

--- a/src/test/compile-fail/overloaded-calls-bad.rs
+++ b/src/test/compile-fail/overloaded-calls-bad.rs
@@ -23,6 +23,12 @@ impl FnMut<(int,),int> for S {
     }
 }
 
+impl FnOnce<(int,),int> for S {
+    extern "rust-call" fn call_once(mut self, (z,): (int,)) -> int {
+        self.call_mut((z,))
+    }
+}
+
 fn main() {
     let mut s = S {
         x: 3,

--- a/src/test/compile-fail/overloaded-calls-nontuple.rs
+++ b/src/test/compile-fail/overloaded-calls-nontuple.rs
@@ -23,6 +23,12 @@ impl FnMut<int,int> for S {
     }
 }
 
+impl FnOnce<int,int> for S {
+    extern "rust-call" fn call_once(mut self, z: int) -> int {
+        self.call_mut(z)
+    }
+}
+
 fn main() {
     let mut s = S {
         x: 1,

--- a/src/test/run-pass/fn-trait-sugar.rs
+++ b/src/test/run-pass/fn-trait-sugar.rs
@@ -15,6 +15,12 @@ use std::ops::FnMut;
 
 struct S;
 
+impl FnOnce<(int,),int> for S {
+    extern "rust-call" fn call_once(mut self, (x,): (int,)) -> int {
+        self.call_mut((x,))
+    }
+}
+
 impl FnMut<(int,),int> for S {
     extern "rust-call" fn call_mut(&mut self, (x,): (int,)) -> int {
         x * x

--- a/src/test/run-pass/issue-14958.rs
+++ b/src/test/run-pass/issue-14958.rs
@@ -14,6 +14,14 @@ trait Foo {}
 
 struct Bar;
 
+impl<'a> std::ops::FnOnce<(&'a Foo+'a,), ()> for Bar {
+    extern "rust-call" fn call_once(self, _: (&'a Foo,)) {}
+}
+
+impl<'a> std::ops::FnMut<(&'a Foo+'a,), ()> for Bar {
+    extern "rust-call" fn call_mut(&mut self, _: (&'a Foo,)) {}
+}
+
 impl<'a> std::ops::Fn<(&'a Foo+'a,), ()> for Bar {
     extern "rust-call" fn call(&self, _: (&'a Foo,)) {}
 }

--- a/src/test/run-pass/issue-14959.rs
+++ b/src/test/run-pass/issue-14959.rs
@@ -33,6 +33,14 @@ impl Alloy {
     }
 }
 
+impl<'a, 'b> FnOnce<(&'b mut Response+'b,),()> for SendFile<'a> {
+    extern "rust-call" fn call_once(self, (_res,): (&'b mut Response+'b,)) {}
+}
+
+impl<'a, 'b> FnMut<(&'b mut Response+'b,),()> for SendFile<'a> {
+    extern "rust-call" fn call_mut(&mut self, (_res,): (&'b mut Response+'b,)) {}
+}
+
 impl<'a, 'b> Fn<(&'b mut Response+'b,),()> for SendFile<'a> {
     extern "rust-call" fn call(&self, (_res,): (&'b mut Response+'b,)) {}
 }

--- a/src/test/run-pass/overloaded-calls-param-vtables.rs
+++ b/src/test/run-pass/overloaded-calls-param-vtables.rs
@@ -16,6 +16,18 @@ use std::ops::Fn;
 
 struct G;
 
+impl<'a, A: Add<int, int>> FnOnce<(A,), int> for G {
+    extern "rust-call" fn call_once(self, (arg,): (A,)) -> int {
+        self.call((arg,))
+    }
+}
+
+impl<'a, A: Add<int, int>> FnMut<(A,), int> for G {
+    extern "rust-call" fn call_mut(&mut self, (arg,): (A,)) -> int {
+        self.call((arg,))
+    }
+}
+
 impl<'a, A: Add<int, int>> Fn<(A,), int> for G {
     extern "rust-call" fn call(&self, (arg,): (A,)) -> int {
         arg.add(&1)

--- a/src/test/run-pass/overloaded-calls-simple.rs
+++ b/src/test/run-pass/overloaded-calls-simple.rs
@@ -17,6 +17,12 @@ struct S1 {
     y: int,
 }
 
+impl FnOnce<(int,),int> for S1 {
+    extern "rust-call" fn call_once(mut self, (z,): (int,)) -> int {
+        self.call_mut((z,))
+    }
+}
+
 impl FnMut<(int,),int> for S1 {
     extern "rust-call" fn call_mut(&mut self, (z,): (int,)) -> int {
         self.x * self.y * z
@@ -26,6 +32,18 @@ impl FnMut<(int,),int> for S1 {
 struct S2 {
     x: int,
     y: int,
+}
+
+impl FnOnce<(int,),int> for S2 {
+    extern "rust-call" fn call_once(self, (z,): (int,)) -> int {
+        self.call((z,))
+    }
+}
+
+impl FnMut<(int,),int> for S2 {
+    extern "rust-call" fn call_mut(&mut self, (z,): (int,)) -> int {
+        self.call((z,))
+    }
 }
 
 impl Fn<(int,),int> for S2 {

--- a/src/test/run-pass/overloaded-calls-zero-args.rs
+++ b/src/test/run-pass/overloaded-calls-zero-args.rs
@@ -17,6 +17,12 @@ struct S {
     y: int,
 }
 
+impl FnOnce<(),int> for S {
+    extern "rust-call" fn call_once(mut self, (): ()) -> int {
+        self.call_mut(())
+    }
+}
+
 impl FnMut<(),int> for S {
     extern "rust-call" fn call_mut(&mut self, (): ()) -> int {
         self.x * self.y

--- a/src/test/run-pass/unboxed-closure-trait-hierarchy.rs
+++ b/src/test/run-pass/unboxed-closure-trait-hierarchy.rs
@@ -8,15 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(lang_items, overloaded_calls, unboxed_closures)]
+#![feature(overloaded_calls, unboxed_closures)]
 
-fn c<F:Fn(int, int) -> int>(f: F) -> int {
-    f(5, 6)
+fn foo<F>(f: F) -> int where F: FnOnce(int) -> int {
+    f(1i)
+}
+
+fn bar<F>(mut f: F) -> int where F: FnMut(int) -> int {
+    f(1i)
 }
 
 fn main() {
-    let z: int = 7;
-    assert_eq!(c(|&mut : x: int, y| x + y + z), 10);
-    //~^ ERROR not implemented
+    assert_eq!(foo(|&mut: x: int| x + 3), 4i);
+    assert_eq!(bar(|&: x: int| x + 7), 8i);
 }
 


### PR DESCRIPTION
This makes `FnMut` require `FnOnce` and `Fn` require `FnMut`. Therefore,
this change breaks code that implements the `FnMut` and/or `Fn` traits
directly, without also implementing their dependencies. A simple
forwarding implementation that defines `FnOnce` in terms of `FnMut`
and/or `Fn` in terms of `FnMut` will suffice.

This does not affect code that simply uses the `|&:|`/`|&mut:|`/`|:|`
unboxed closure construction notation.

Part of RFC #44; needed to implement RFC #63.

Part of issue #12831.

[breaking-change]

r? @nikomatsakis 
