### PR TITLE
fix a misspelling in the configure script

### DIFF
--- a/configure
+++ b/configure
@@ -458,7 +458,7 @@ valopt release-channel "source" "the name of the release channel to build"
 # On windows we just store the libraries in the bin directory because
 # there's no rpath. This is where the build system itself puts libraries;
 # --libdir is used to configure the installation directory.
-# FIXME: Thise needs to parameterized over target triples. Do it in platform.mk
+# FIXME: This needs to parameterized over target triples. Do it in platform.mk
 CFG_LIBDIR_RELATIVE=lib
 if [ "$CFG_OSTYPE" = "pc-mingw32" ] || [ "$CFG_OSTYPE" = "w64-mingw32" ]
 then


### PR DESCRIPTION
Hi, this fixes a simple misspelling in the configure script.
