### PR TITLE
tiny linguistic correction in docs: s/its'/its/

### DIFF
--- a/src/librustrt/unwind.rs
+++ b/src/librustrt/unwind.rs
@@ -37,11 +37,11 @@
 //! In the cleanup phase, personality routines invoke cleanup code associated
 //! with their stack frames (i.e. destructors).  Once stack has been unwound down
 //! to the handler frame level, unwinding stops and the last personality routine
-//! transfers control to its' catch block.
+//! transfers control to its catch block.
 //!
 //! ## Frame unwind info registration
 //!
-//! Each module has its' own frame unwind info section (usually ".eh_frame"), and
+//! Each module has its own frame unwind info section (usually ".eh_frame"), and
 //! unwinder needs to know about all of them in order for unwinding to be able to
 //! cross module boundaries.
 //!


### PR DESCRIPTION
See e.g.: http://dictionary.reference.com/browse/its
