### PR TITLE
dist: Make Windows installer modify system %PATH%

### DIFF
--- a/src/etc/pkg/rust.iss
+++ b/src/etc/pkg/rust.iss
@@ -8,7 +8,7 @@
 SetupIconFile=rust-logo.ico
 AppName=Rust
 AppVersion={#CFG_RELEASE}
-AppCopyright=Copyright (C) 2006-2013 Mozilla Foundation, MIT license
+AppCopyright=Copyright (C) 2006-2014 Mozilla Foundation, MIT license
 AppPublisher=Mozilla Foundation
 AppPublisherURL=http://www.rust-lang.org
 VersionInfoVersion={#CFG_VERSION_WIN}
@@ -43,7 +43,7 @@ Source: "tmp/dist/win/*.*" ; DestDir: "{app}"; Flags: ignoreversion recursesubdi
 [Code]
 const
 	ModPathName = 'modifypath';
-	ModPathType = 'user';
+	ModPathType = 'system';
 
 function ModPathDir(): TArrayOfString;
 begin


### PR DESCRIPTION
Modify the system %PATH% environment variable instead of the current
user's %PATH% environment. The current user will be an admin user
that may not be the same user who originally started the installer.
Closes #17570.
