### PR TITLE
Remove unnecessary allocation, update API name for starting the rustc dr...

### DIFF
--- a/src/librustc/driver/mod.rs
+++ b/src/librustc/driver/mod.rs
@@ -29,16 +29,13 @@ use syntax::diagnostics;
 
 use getopts;
 
-
 pub mod driver;
 pub mod session;
 pub mod config;
 pub mod pretty;
 
-
-pub fn main_args(args: &[String]) -> int {
-    let owned_args = args.to_vec();
-    monitor(proc() run_compiler(owned_args.as_slice()));
+pub fn run(args: Vec<String>) -> int {
+    monitor(proc() run_compiler(args.as_slice()));
     0
 }
 

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -149,5 +149,6 @@ mod rustc {
 
 pub fn main() {
     let args = std::os::args();
-    std::os::set_exit_status(driver::main_args(args.as_slice()));
+    let result = driver::run(args);
+    std::os::set_exit_status(result);
 }


### PR DESCRIPTION
Removes an unnecessary allocation when passing the command line arguments to the librustc driver.
