### PR TITLE
make EnumSet derive Ord and PartialOrd

### DIFF
--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -16,7 +16,7 @@
 use core::prelude::*;
 use core::fmt;
 
-#[deriving(Clone, PartialEq, Eq, Hash)]
+#[deriving(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// A specialized `Set` implementation to use enum types.
 pub struct EnumSet<E> {
     // We must maintain the invariant that no bits are set


### PR DESCRIPTION
Seems legit? Maybe there's some semantic of EnumSet that makes this inappropriate, but otherwise, seems fine to do.
