### PR TITLE
Defailbloat fail!(&'static str)

### DIFF
--- a/src/libcore/failure.rs
+++ b/src/libcore/failure.rs
@@ -35,6 +35,10 @@ use intrinsics;
 
 // NOTE: remove after next snapshot
 #[cfg(stage0)]
+pub use self::fail_ as fail;
+
+// NOTE: remove after next snapshot
+#[cfg(stage0)]
 #[cold] #[inline(never)] // this is the slow path, always
 #[lang="fail_"]
 fn fail_(expr_file_line: &(&'static str, &'static str, uint)) -> ! {
@@ -50,7 +54,7 @@ fn fail_(expr_file_line: &(&'static str, &'static str, uint)) -> ! {
 #[cfg(not(stage0))]
 #[cold] #[inline(never)] // this is the slow path, always
 #[lang="fail"]
-fn fail(expr_file_line: &(&'static str, &'static str, uint)) -> ! {
+pub fn fail(expr_file_line: &(&'static str, &'static str, uint)) -> ! {
     let (expr, file, line) = *expr_file_line;
     let ref file_line = (file, line);
     format_args!(|args| -> () {
@@ -68,11 +72,6 @@ fn fail_bounds_check(file_line: &(&'static str, uint),
         fail_fmt(args, file_line);
     }, "index out of bounds: the len is {} but the index is {}", len, index);
     unsafe { intrinsics::abort() }
-}
-
-#[cold] #[inline(never)]
-pub fn fail_str(msg: &str, file: &(&'static str, uint)) -> ! {
-    format_args!(|fmt| fail_fmt(fmt, file), "{}", msg)
 }
 
 #[cold] #[inline(never)]

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -17,8 +17,8 @@ macro_rules! fail(
         fail!("{}", "explicit failure")
     );
     ($msg:expr) => ({
-        static _FILE_LINE: (&'static str, uint) = (file!(), line!());
-        ::core::failure::fail_str($msg, &_FILE_LINE)
+        static _MSG_FILE_LINE: (&'static str, &'static str, uint) = ($msg, file!(), line!());
+        ::core::failure::fail(&_MSG_FILE_LINE)
     });
     ($fmt:expr, $($arg:tt)*) => ({
         // a closure can't have return type !, so we need a full

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -312,7 +312,7 @@ impl<T> Option<T> {
     pub fn expect(self, msg: &str) -> T {
         match self {
             Some(val) => val,
-            None => fail!(msg),
+            None => fail!("{}", msg),
         }
     }
 


### PR DESCRIPTION
rustc.rlib before: 77429264
rustc.rlib after: 76977406

This bloats Option::expects a bit, but it doesn't seem to be a problem.

This makes fail!(msg) assume that msg is a &'static str, change instances where this is not the case to fail!("{}", msg)

Closes #15792

[breaking-change]
