### PR TITLE
Correctly populate trait impl map when checking for impl overlaps

### DIFF
--- a/src/librustc/middle/typeck/coherence/overlap.rs
+++ b/src/librustc/middle/typeck/coherence/overlap.rs
@@ -49,8 +49,8 @@ impl<'cx, 'tcx> OverlapChecker<'cx, 'tcx> {
 
         // FIXME -- it seems like this method actually pushes
         // duplicate impls onto the list
-        ty::populate_implementations_for_type_if_necessary(self.tcx,
-                                                           trait_def_id);
+        ty::populate_implementations_for_trait_if_necessary(self.tcx,
+                                                            trait_def_id);
 
         let mut impls = Vec::new();
         self.push_impls_of_trait(trait_def_id, &mut impls);

--- a/src/test/compile-fail/conflicting-implementations-aux.rs
+++ b/src/test/compile-fail/conflicting-implementations-aux.rs
@@ -15,7 +15,9 @@
 extern crate trait_impl_conflict;
 use trait_impl_conflict::Foo;
 
-impl<A> Foo for A { //~ ERROR E0117
+impl<A> Foo for A {
+    //~^ ERROR E0117
+    //~^^ ERROR E0119
 }
 
 fn main() {


### PR DESCRIPTION
Also fix an existing compile-fail test which was intended to cover
this case.

This closes issue #17593
