### PR TITLE
rustc: Fix permission denied error in 'ar' when lto is enabled

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -1319,6 +1319,18 @@ fn add_upstream_rust_crates(cmd: &mut Command, sess: &Session,
                         sess.abort_if_errors();
                     }
                 }
+                // Fix up permissions of the copy, as fs::copy() preserves
+                // permissions, but the original file may have been installed
+                // by a package manager and may be read-only.
+                match fs::chmod(&dst, io::UserRead | io::UserWrite) {
+                    Ok(..) => {}
+                    Err(e) => {
+                        sess.err(format!("failed to chmod {} when preparing \
+                                          for LTO: {}", dst.display(),
+                                         e).as_slice());
+                        sess.abort_if_errors();
+                    }
+                }
                 let handler = &sess.diagnostic().handler;
                 let config = ArchiveConfig {
                     handler: handler,

--- a/src/test/run-make/lto-readonly-lib/Makefile
+++ b/src/test/run-make/lto-readonly-lib/Makefile
@@ -1,0 +1,12 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) lib.rs
+
+	# the compiler needs to copy and modify the rlib file when performing
+	# LTO, so we should ensure that it can cope with the original rlib
+	# being read-only.
+	chmod 444 $(TMPDIR)/*.rlib
+
+	$(RUSTC) main.rs -C lto
+	$(call RUN,main)

--- a/src/test/run-make/lto-readonly-lib/lib.rs
+++ b/src/test/run-make/lto-readonly-lib/lib.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]

--- a/src/test/run-make/lto-readonly-lib/main.rs
+++ b/src/test/run-make/lto-readonly-lib/main.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate lib;
+
+fn main() {}


### PR DESCRIPTION
The reason that 'ar' can fail with permission denied is that when
link-time optimizations are enabled, rustc copies libraries into a
temporary directory, preserving file permissions, and subsequently
modifies them using 'ar'.

The modification can fail because some package managers may install
libraries in system directories as read-only files, which means the
temporary file also becomes read-only when it is copied.

I have fixed this by giving the temporary file's owner read+write
permissions after the copy.

I have also added a regression test for this issue.
