### PR TITLE
Update ANTLR float suffix grammar

### DIFF
--- a/src/grammar/RustLexer.g4
+++ b/src/grammar/RustLexer.g4
@@ -120,10 +120,9 @@ LIT_INTEGER
   | '0x' [0-9a-fA-F][0-9a-fA-F_]* INT_SUFFIX?
   ;
 
-FLOAT_SUFFIX
+fragment FLOAT_SUFFIX
   : 'f32'
   | 'f64'
-  | 'f128'
   ;
 
 LIT_FLOAT


### PR DESCRIPTION
- Removes `f128` from the grammar, which is no longer supported in rustc
- The `fragment` modifier is added so it won't parse a float suffix as a separate token (this fixes an issue in [VisualRust](https://github.com/PistonDevelopers/VisualRust), where the ANTLR lexer is used for syntax highlighting)
