### PR TITLE
Ignore yet another windows debuginfo test

### DIFF
--- a/src/test/debuginfo/issue12886.rs
+++ b/src/test/debuginfo/issue12886.rs
@@ -9,12 +9,13 @@
 // except according to those terms.
 
 // ignore-android: FIXME(#10381)
+// ignore-windows failing on 64-bit bots FIXME #17638
 
 // compile-flags:-g
-// gdb-command:break issue12886.rs:29
+// gdb-command:break issue12886.rs:30
 // gdb-command:run
 // gdb-command:next
-// gdb-check:[...]30[...]s
+// gdb-check:[...]31[...]s
 // gdb-command:continue
 
 // IF YOU MODIFY THIS FILE, BE CAREFUL TO ADAPT THE LINE NUMBERS IN THE DEBUGGER COMMANDS


### PR DESCRIPTION
I swear this is the last step. p=1 please so i can get the bots changed over before the test suite regresses again.
