### PR TITLE
Minor installation fixes on windows

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -283,7 +283,7 @@ distcheck-docs: dist-docs
 
 ifdef CFG_WINDOWSY_$(CFG_BUILD)
 
-dist: dist-win
+dist: dist-win dist-tar-bins
 
 distcheck: distcheck-win
 	$(Q)rm -Rf tmp/distcheck

--- a/src/etc/install.sh
+++ b/src/etc/install.sh
@@ -325,7 +325,7 @@ then
     if [ -z "${CFG_UNINSTALL}" ]
     then
         msg "verifying platform can run binaries"
-        export $CFG_LD_PATH_VAR="${CFG_SRC_DIR}/lib":$CFG_OLD_LD_PATH_VAR
+        export $CFG_LD_PATH_VAR="${CFG_SRC_DIR}/lib:$CFG_OLD_LD_PATH_VAR"
         "${CFG_SRC_DIR}/bin/rustc" --version > /dev/null
         if [ $? -ne 0 ]
         then
@@ -489,7 +489,7 @@ then
     "${CFG_PREFIX}/bin/rustc" --version 2> /dev/null 1> /dev/null
     if [ $? -ne 0 ]
     then
-        export $CFG_LD_PATH_VAR="${CFG_PREFIX}/lib":$CFG_OLD_LD_PATH_VAR
+        export $CFG_LD_PATH_VAR="${CFG_PREFIX}/lib:$CFG_OLD_LD_PATH_VAR"
         "${CFG_PREFIX}/bin/rustc" --version > /dev/null
         if [ $? -ne 0 ]
         then


### PR DESCRIPTION
This makes the windows `make dist` target start producing binary tarballs, and tweaks install.sh so they work, in preparation for working on a combined Rust+Cargo installer.
