### PR TITLE
Fix a handful of ICEs around casting

### DIFF
--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -547,6 +547,9 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr,
               (expr::cast_integral, expr::cast_pointer) => {
                 llvm::LLVMConstIntToPtr(v, llty.to_ref())
               }
+              (expr::cast_pointer, expr::cast_integral) => {
+                llvm::LLVMConstPtrToInt(v, llty.to_ref())
+              }
               _ => {
                 cx.sess().impossible_case(e.span,
                                           "bad combination of types for cast")

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1468,7 +1468,7 @@ fn check_cast(fcx: &FnCtxt,
     // casts to scalars other than `char` and `bare fn` are trivial
     let t_1_is_trivial = t_1_is_scalar && !t_1_is_char && !t_1_is_bare_fn;
     if ty::type_is_c_like_enum(fcx.tcx(), t_e) && t_1_is_trivial {
-        if t_1_is_float {
+        if t_1_is_float || ty::type_is_unsafe_ptr(t_1) {
             fcx.type_error_message(span, |actual| {
                 format!("illegal cast; cast through an \
                          integer first: `{}` as `{}`",

--- a/src/test/compile-fail/issue-17444.rs
+++ b/src/test/compile-fail/issue-17444.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum Test {
+    Foo = 0
+}
+
+fn main() {
+    let _x = Foo as *const int;
+    //~^ ERROR illegal cast; cast through an integer first: `Test` as `*const int`
+}

--- a/src/test/run-pass/issue-17458.rs
+++ b/src/test/run-pass/issue-17458.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+static X: uint = 0 as *const uint as uint;
+
+fn main() {
+    assert_eq!(X, 0);
+}


### PR DESCRIPTION
This fixes missing cases in trans for various casts that are permitted by typeck.  I wasn't sure whether some of these were actually intended to be allowed (e.g. enum -> pointer), so each commit is a self-contained change that can easily be dropped if necessary.

Closes issue #17458 
Closes issue #17444
