### PR TITLE
Fold `MethodOrigin`s to resolve inference variables they may contain.

### DIFF
--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -251,6 +251,33 @@ impl TypeFoldable for ty::AutoRef {
     }
 }
 
+impl TypeFoldable for typeck::MethodOrigin {
+    fn fold_with<'tcx, F: TypeFolder<'tcx>>(&self, folder: &mut F) -> typeck::MethodOrigin {
+        match *self {
+            typeck::MethodStatic(def_id) => {
+                typeck::MethodStatic(def_id)
+            }
+            typeck::MethodStaticUnboxedClosure(def_id) => {
+                typeck::MethodStaticUnboxedClosure(def_id)
+            }
+            typeck::MethodTypeParam(ref param) => {
+                typeck::MethodTypeParam(typeck::MethodParam {
+                    trait_ref: param.trait_ref.fold_with(folder),
+                    method_num: param.method_num
+                })
+            }
+            typeck::MethodTraitObject(ref object) => {
+                typeck::MethodTraitObject(typeck::MethodObject {
+                    trait_ref: object.trait_ref.fold_with(folder),
+                    object_trait_id: object.object_trait_id,
+                    method_num: object.method_num,
+                    real_index: object.real_index
+                })
+            }
+        }
+    }
+}
+
 impl TypeFoldable for typeck::vtable_origin {
     fn fold_with<'tcx, F: TypeFolder<'tcx>>(&self, folder: &mut F) -> typeck::vtable_origin {
         match *self {

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -323,7 +323,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                        method_call,
                        method.repr(self.tcx()));
                 let new_method = MethodCallee {
-                    origin: method.origin,
+                    origin: self.resolve(&method.origin, reason),
                     ty: self.resolve(&method.ty, reason),
                     substs: self.resolve(&method.substs, reason),
                 };

--- a/src/test/auxiliary/issue-17662.rs
+++ b/src/test/auxiliary/issue-17662.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "lib"]
+
+pub trait Foo<'a, T> {
+    fn foo(&self) -> T;
+}
+
+pub fn foo<'a, T>(x: &'a Foo<'a, T>) -> T {
+    let x: &'a Foo<T> = x;
+    //            ^ the lifetime parameter of Foo is left to be infered.
+    x.foo()
+    // ^ encoding this method call in metadata triggers an ICE.
+}

--- a/src/test/run-pass/issue-17662.rs
+++ b/src/test/run-pass/issue-17662.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-17662.rs
+
+extern crate "issue-17662" as i;
+
+struct Bar<'a>;
+
+impl<'a> i::Foo<'a, uint> for Bar<'a> {
+    fn foo(&self) -> uint { 5u }
+}
+
+pub fn main() {
+    assert_eq!(i::foo(&Bar), 5);
+}


### PR DESCRIPTION
Fixes #17662.
