### PR TITLE
Limit recursion depth for macro expansions, closes #17628

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -291,6 +291,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
                 crate_name: crate_name.to_string(),
                 deriving_hash_type_parameter: sess.features.borrow().default_type_params,
                 enable_quotes: sess.features.borrow().quote,
+                recursion_limit: sess.recursion_limit.get(),
             };
             let ret = syntax::ext::expand::expand_crate(&sess.parse_sess,
                                               cfg,

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1069,6 +1069,7 @@ pub struct ExpansionConfig {
     pub crate_name: String,
     pub deriving_hash_type_parameter: bool,
     pub enable_quotes: bool,
+    pub recursion_limit: uint,
 }
 
 impl ExpansionConfig {
@@ -1077,6 +1078,7 @@ impl ExpansionConfig {
             crate_name: crate_name,
             deriving_hash_type_parameter: false,
             enable_quotes: false,
+            recursion_limit: 64,
         }
     }
 }

--- a/src/test/compile-fail/infinite-macro-expansion.rs
+++ b/src/test/compile-fail/infinite-macro-expansion.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(macro_rules)]
+
+macro_rules! recursive(
+      () => (
+                recursive!() //~ ERROR Recursion limit reached while expanding the macro `recursive`
+              )
+      )
+
+fn main() {
+    recursive!()
+}
+


### PR DESCRIPTION
This is a patch for #17628, thanks to @kmcallister for your helpful hints!
