### PR TITLE
Macro docs put the implementation after the description

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2174,9 +2174,9 @@ impl<'a> fmt::Show for Source<'a> {
 
 fn item_macro(w: &mut fmt::Formatter, it: &clean::Item,
               t: &clean::Macro) -> fmt::Result {
-    try!(w.write(highlight::highlight(t.source.as_slice(), Some("macro"),
-                                      None).as_bytes()));
-    document(w, it)
+    try!(document(w, it))
+    w.write(highlight::highlight(t.source.as_slice(), Some("macro"),
+                                      None).as_bytes())
 }
 
 fn item_primitive(w: &mut fmt::Formatter,


### PR DESCRIPTION
This puts the description of marcos before their implementation.
It doesn't put the implementation at the bottom, but doing so while keeping the description on top would require a bigger rewrite of the file (as the description is currectly linked to the macro code, and separationg them would require creating another Item).
I'll look into it later
Closes #17616
