### PR TITLE
Teach --dep-info how to escape filenames containing spaces

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -261,12 +261,13 @@ ALL_HS := $(filter-out $(S)src/rt/valgrind/valgrind.h \
 tidy:
 		@$(call E, check: formatting)
 		$(Q)find $(S)src -name '*.r[sc]' \
-		| grep '^$(S)src/jemalloc' -v \
-		| grep '^$(S)src/libuv' -v \
-		| grep '^$(S)src/llvm' -v \
-		| grep '^$(S)src/gyp' -v \
-		| grep '^$(S)src/libbacktrace' -v \
-		| xargs -n 10 $(CFG_PYTHON) $(S)src/etc/tidy.py
+		    -and -not -regex '^$(S)src/jemalloc.*' \
+		    -and -not -regex '^$(S)src/libuv.*' \
+		    -and -not -regex '^$(S)src/llvm.*' \
+		    -and -not -regex '^$(S)src/gyp.*' \
+		    -and -not -regex '^$(S)src/libbacktrace.*' \
+		    -print0 \
+		| xargs -0 -n 10 $(CFG_PYTHON) $(S)src/etc/tidy.py
 		$(Q)find $(S)src/etc -name '*.py' \
 		| xargs -n 10 $(CFG_PYTHON) $(S)src/etc/tidy.py
 		$(Q)find $(S)src/doc -name '*.js' \

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -615,6 +615,12 @@ pub fn stop_after_phase_5(sess: &Session) -> bool {
     return false;
 }
 
+fn escape_dep_filename(filename: &str) -> String {
+    // Apparently clang and gcc *only* escape spaces:
+    // http://llvm.org/klaus/clang/commit/9d50634cfc268ecc9a7250226dd5ca0e945240d4
+    filename.replace(" ", "\\ ")
+}
+
 fn write_out_deps(sess: &Session,
                   input: &Input,
                   outputs: &OutputFilenames,
@@ -658,7 +664,7 @@ fn write_out_deps(sess: &Session,
         // write Makefile-compatible dependency rules
         let files: Vec<String> = sess.codemap().files.borrow()
                                    .iter().filter(|fmap| fmap.is_real_file())
-                                   .map(|fmap| fmap.name.to_string())
+                                   .map(|fmap| escape_dep_filename(fmap.name.as_slice()))
                                    .collect();
         let mut file = try!(io::File::create(&deps_filename));
         for path in out_filenames.iter() {

--- a/src/test/run-make/dep-info-spaces/Makefile
+++ b/src/test/run-make/dep-info-spaces/Makefile
@@ -1,0 +1,25 @@
+-include ../tools.mk
+
+# FIXME: ignore freebsd/windows
+# (windows: see `../dep-info/Makefile`)
+ifneq ($(shell uname),FreeBSD)
+ifndef IS_WINDOWS
+all:
+	$(RUSTC) --dep-info $(TMPDIR)/custom-deps-file.d --crate-type=lib lib.rs
+	sleep 1
+	touch 'foo foo.rs'
+	-rm -f $(TMPDIR)/done
+	$(MAKE) -drf Makefile.foo
+	rm $(TMPDIR)/done
+	pwd
+	$(MAKE) -drf Makefile.foo
+	rm $(TMPDIR)/done && exit 1 || exit 0
+else
+all:
+
+endif
+
+else
+all:
+
+endif

--- a/src/test/run-make/dep-info-spaces/Makefile.foo
+++ b/src/test/run-make/dep-info-spaces/Makefile.foo
@@ -1,0 +1,7 @@
+LIB := $(shell $(RUSTC) --print-file-name --crate-type=lib lib.rs)
+
+$(TMPDIR)/$(LIB):
+	$(RUSTC) --dep-info $(TMPDIR)/custom-deps-file.d --crate-type=lib lib.rs
+	touch $(TMPDIR)/done
+
+-include $(TMPDIR)/custom-deps-file.d

--- a/src/test/run-make/dep-info-spaces/bar.rs
+++ b/src/test/run-make/dep-info-spaces/bar.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn bar() {}

--- a/src/test/run-make/dep-info-spaces/foo foo.rs
+++ b/src/test/run-make/dep-info-spaces/foo foo.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn foo() {}

--- a/src/test/run-make/dep-info-spaces/lib.rs
+++ b/src/test/run-make/dep-info-spaces/lib.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[path="foo foo.rs"]
+pub mod foo;
+
+pub mod bar;


### PR DESCRIPTION
cc #17627 
