### PR TITLE
Fix async assertion in test_sendable_future

### DIFF
--- a/src/libstd/sync/future.rs
+++ b/src/libstd/sync/future.rs
@@ -201,12 +201,13 @@ mod test {
     #[test]
     fn test_sendable_future() {
         let expected = "schlorf";
+        let (tx, rx) = channel();
         let f = Future::spawn(proc() { expected });
         task::spawn(proc() {
             let mut f = f;
-            let actual = f.get();
-            assert_eq!(actual, expected);
+            tx.send(f.get());
         });
+        assert_eq!(rx.recv(), expected);
     }
 
     #[test]


### PR DESCRIPTION
This fixes the problem that ff the assertion in the seperate task fails the test case would still pass. 
