### PR TITLE
Fix `make TAGS.vi` target

### DIFF
--- a/mk/ctags.mk
+++ b/mk/ctags.mk
@@ -28,7 +28,7 @@ CTAGS_LOCATIONS=$(patsubst ${CFG_SRC_DIR}src/llvm,, \
 				$(patsubst ${CFG_SRC_DIR}src/rt/sundown,, \
 				$(patsubst ${CFG_SRC_DIR}src/rt/vg,, \
 				$(wildcard ${CFG_SRC_DIR}src/*) $(wildcard ${CFG_SRC_DIR}src/rt/*) \
-				)))))))))))
+				)))))))))
 CTAGS_OPTS=--options="${CFG_SRC_DIR}src/etc/ctags.rust" --languages=-javascript --recurse ${CTAGS_LOCATIONS}
 # We could use `--languages=Rust`, but there is value in producing tags for the
 # C++ parts of the code base too (at the time of writing, those are .h and .cpp


### PR DESCRIPTION
Remove superfluous parentheses from the CTAGS_LOCATIONS expression.
Fixes the following error when executing `make TAGS.vi`:

```
/bin/sh: -c: line 0: syntax error near unexpected token `)'
```
