### PR TITLE
Add overloaded slice operations to the prelude

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -98,7 +98,7 @@ use core::iter::{range_step, MultiplicativeIterator};
 use MutableSeq;
 use vec::Vec;
 
-pub use core::slice::{Chunks, Slice, ImmutableSlice, ImmutablePartialEqSlice};
+pub use core::slice::{Chunks, AsSlice, ImmutableSlice, ImmutablePartialEqSlice};
 pub use core::slice::{ImmutableOrdSlice, MutableSlice, Items, MutItems};
 pub use core::slice::{MutSplits, MutChunks, Splits};
 pub use core::slice::{bytes, mut_ref_slice, ref_slice, MutableCloneableSlice};
@@ -117,7 +117,7 @@ pub trait VectorVector<T> {
     fn connect_vec(&self, sep: &T) -> Vec<T>;
 }
 
-impl<'a, T: Clone, V: Slice<T>> VectorVector<T> for &'a [V] {
+impl<'a, T: Clone, V: AsSlice<T>> VectorVector<T> for &'a [V] {
     fn concat_vec(&self) -> Vec<T> {
         let size = self.iter().fold(0u, |acc, v| acc + v.as_slice().len());
         let mut result = Vec::with_capacity(size);

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -61,7 +61,7 @@ use core::iter::AdditiveIterator;
 use core::mem;
 use core::prelude::{Char, Clone, Collection, Eq, Equiv, ImmutableSlice};
 use core::prelude::{Iterator, MutableSlice, None, Option, Ord, Ordering};
-use core::prelude::{PartialEq, PartialOrd, Result, Slice, Some, Tuple2};
+use core::prelude::{PartialEq, PartialOrd, Result, AsSlice, Some, Tuple2};
 use core::prelude::{range};
 
 use {Deque, MutableSeq};

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -24,7 +24,7 @@ use core::num;
 use core::ops;
 use core::ptr;
 use core::raw::Slice as RawSlice;
-use core::slice::Slice as SliceSlice;
+use core::slice::AsSlice;
 use core::uint;
 
 use {Mutable, MutableSeq};
@@ -461,34 +461,25 @@ impl<T> Index<uint,T> for Vec<T> {
     }
 }*/
 
-// Annoying helper function because there are two Slice::as_slice functions in
-// scope.
-#[cfg(not(stage0))]
-#[inline]
-fn slice_to_slice<'a, T, U: Slice<T>>(this: &'a U) -> &'a [T] {
-    this.as_slice()
-}
-
-
 #[cfg(not(stage0))]
 impl<T> ops::Slice<uint, [T]> for Vec<T> {
     #[inline]
-    fn as_slice<'a>(&'a self) -> &'a [T] {
-        slice_to_slice(self)
+    fn as_slice_<'a>(&'a self) -> &'a [T] {
+        self.as_slice()
     }
 
     #[inline]
     fn slice_from<'a>(&'a self, start: &uint) -> &'a [T] {
-        slice_to_slice(self).slice_from(start)
+        self.as_slice().slice_from(start)
     }
 
     #[inline]
     fn slice_to<'a>(&'a self, end: &uint) -> &'a [T] {
-        slice_to_slice(self).slice_to(end)
+        self.as_slice().slice_to(end)
     }
     #[inline]
     fn slice<'a>(&'a self, start: &uint, end: &uint) -> &'a [T] {
-        slice_to_slice(self).slice(start, end)
+        self.as_slice().slice(start, end)
     }
 }
 #[cfg(stage0)]
@@ -601,7 +592,7 @@ impl<T: PartialOrd> PartialOrd for Vec<T> {
 impl<T: Eq> Eq for Vec<T> {}
 
 #[experimental]
-impl<T: PartialEq, V: Slice<T>> Equiv<V> for Vec<T> {
+impl<T: PartialEq, V: AsSlice<T>> Equiv<V> for Vec<T> {
     #[inline]
     fn equiv(&self, other: &V) -> bool { self.as_slice() == other.as_slice() }
 }
@@ -1654,7 +1645,7 @@ impl<T: PartialEq> Vec<T> {
     }
 }
 
-impl<T> Slice<T> for Vec<T> {
+impl<T> AsSlice<T> for Vec<T> {
     /// Returns a slice into `self`.
     ///
     /// # Example
@@ -1672,7 +1663,7 @@ impl<T> Slice<T> for Vec<T> {
     }
 }
 
-impl<T: Clone, V: Slice<T>> Add<V, Vec<T>> for Vec<T> {
+impl<T: Clone, V: AsSlice<T>> Add<V, Vec<T>> for Vec<T> {
     #[inline]
     fn add(&self, rhs: &V) -> Vec<T> {
         let mut res = Vec::with_capacity(self.len() + rhs.as_slice().len());

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -22,7 +22,7 @@ use option::{Option, Some, None};
 use ops::Deref;
 use result::{Ok, Err};
 use result;
-use slice::{Slice, ImmutableSlice};
+use slice::{AsSlice, ImmutableSlice};
 use slice;
 use str::StrSlice;
 use str;

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -715,7 +715,7 @@ pub trait IndexMut<Index, Result> {
 #[lang="slice"]
 pub trait Slice<Idx, Sized? Result> for Sized? {
     /// The method for the slicing operation foo[]
-    fn as_slice<'a>(&'a self) -> &'a Result;
+    fn as_slice_<'a>(&'a self) -> &'a Result;
     /// The method for the slicing operation foo[from..]
     fn slice_from<'a>(&'a self, from: &Idx) -> &'a Result;
     /// The method for the slicing operation foo[..to]
@@ -933,4 +933,3 @@ def_fn_mut!(A0 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12)
 def_fn_mut!(A0 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13)
 def_fn_mut!(A0 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13 A14)
 def_fn_mut!(A0 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13 A14 A15)
-

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -149,7 +149,7 @@ use iter::{Iterator, DoubleEndedIterator, FromIterator, ExactSize};
 use mem;
 use result::{Result, Ok, Err};
 use slice;
-use slice::Slice;
+use slice::AsSlice;
 
 // Note that this is not a lang item per se, but it has a hidden dependency on
 // `Iterator`, which is one. The compiler assumes that the `next` method of
@@ -846,7 +846,7 @@ impl<T: Default> Option<T> {
 // Trait implementations
 /////////////////////////////////////////////////////////////////////////////
 
-impl<T> Slice<T> for Option<T> {
+impl<T> AsSlice<T> for Option<T> {
     /// Convert from `Option<T>` to `&[T]` (without copying)
     #[inline]
     #[stable]

--- a/src/libcore/prelude.rs
+++ b/src/libcore/prelude.rs
@@ -36,6 +36,7 @@ pub use ops::{Drop, Deref, DerefMut};
 pub use ops::{Shl, Shr};
 pub use ops::{Index, IndexMut};
 pub use ops::{Fn, FnMut, FnOnce};
+pub use ops::{Slice, SliceMut};
 pub use option::{Option, Some, None};
 pub use result::{Result, Ok, Err};
 
@@ -63,4 +64,4 @@ pub use tuple::{Tuple5, Tuple6, Tuple7, Tuple8};
 pub use tuple::{Tuple9, Tuple10, Tuple11, Tuple12};
 pub use slice::{ImmutablePartialEqSlice, ImmutableOrdSlice};
 pub use slice::{MutableSlice};
-pub use slice::{Slice, ImmutableSlice};
+pub use slice::{AsSlice, ImmutableSlice};

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -280,7 +280,7 @@ use clone::Clone;
 use cmp::PartialEq;
 use std::fmt::Show;
 use slice;
-use slice::Slice;
+use slice::AsSlice;
 use iter::{Iterator, DoubleEndedIterator, FromIterator, ExactSize};
 use option::{None, Option, Some};
 
@@ -844,7 +844,7 @@ impl<T: Show, E> Result<T, E> {
 // Trait implementations
 /////////////////////////////////////////////////////////////////////////////
 
-impl<T, E> Slice<T> for Result<T, E> {
+impl<T, E> AsSlice<T> for Result<T, E> {
     /// Convert from `Result<T, E>` to `&[T]` (without copying)
     #[inline]
     #[stable]

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1057,13 +1057,13 @@ impl<'a, T:Clone> MutableCloneableSlice<T> for &'a mut [T] {
 
 /// Data that is viewable as a slice.
 #[unstable = "may merge with other traits"]
-pub trait Slice<T> {
+pub trait AsSlice<T> {
     /// Work with `self` as a slice.
     fn as_slice<'a>(&'a self) -> &'a [T];
 }
 
 #[unstable = "trait is unstable"]
-impl<'a,T> Slice<T> for &'a [T] {
+impl<'a,T> AsSlice<T> for &'a [T] {
     #[inline(always)]
     fn as_slice<'a>(&'a self) -> &'a [T] { *self }
 }
@@ -1742,7 +1742,7 @@ impl<'a,T:PartialEq> PartialEq for &'a [T] {
 impl<'a,T:Eq> Eq for &'a [T] {}
 
 #[unstable = "waiting for DST"]
-impl<'a,T:PartialEq, V: Slice<T>> Equiv<V> for &'a [T] {
+impl<'a,T:PartialEq, V: AsSlice<T>> Equiv<V> for &'a [T] {
     #[inline]
     fn equiv(&self, other: &V) -> bool { self.as_slice() == other.as_slice() }
 }
@@ -1763,7 +1763,7 @@ impl<'a,T:PartialEq> PartialEq for &'a mut [T] {
 impl<'a,T:Eq> Eq for &'a mut [T] {}
 
 #[unstable = "waiting for DST"]
-impl<'a,T:PartialEq, V: Slice<T>> Equiv<V> for &'a mut [T] {
+impl<'a,T:PartialEq, V: AsSlice<T>> Equiv<V> for &'a mut [T] {
     #[inline]
     fn equiv(&self, other: &V) -> bool { self.as_slice() == other.as_slice() }
 }

--- a/src/libgraphviz/maybe_owned_vec.rs
+++ b/src/libgraphviz/maybe_owned_vec.rs
@@ -84,7 +84,7 @@ impl<'a, T: Ord> Ord for MaybeOwnedVector<'a, T> {
     }
 }
 
-impl<'a, T: PartialEq, V: Slice<T>> Equiv<V> for MaybeOwnedVector<'a, T> {
+impl<'a, T: PartialEq, V: AsSlice<T>> Equiv<V> for MaybeOwnedVector<'a, T> {
     fn equiv(&self, other: &V) -> bool {
         self.as_slice() == other.as_slice()
     }
@@ -99,7 +99,7 @@ impl<'a, T: PartialEq, V: Slice<T>> Equiv<V> for MaybeOwnedVector<'a, T> {
 // In any case, with `Vector` in place, the client can just use
 // `as_slice` if they prefer that over `match`.
 
-impl<'b,T> Slice<T> for MaybeOwnedVector<'b,T> {
+impl<'b,T> AsSlice<T> for MaybeOwnedVector<'b,T> {
     fn as_slice<'a>(&'a self) -> &'a [T] {
         match self {
             &Growable(ref v) => v.as_slice(),

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -19,7 +19,7 @@ use fmt;
 use iter::Iterator;
 use mem;
 use option::{Option, Some, None};
-use slice::{ImmutableSlice, MutableSlice, Slice};
+use slice::{ImmutableSlice, MutableSlice, AsSlice};
 use str::{Str, StrSlice};
 use string::{mod, String};
 use to_string::IntoStr;

--- a/src/libstd/c_vec.rs
+++ b/src/libstd/c_vec.rs
@@ -43,7 +43,7 @@ use option::{Option, Some, None};
 use ptr::RawPtr;
 use ptr;
 use raw;
-use slice::Slice;
+use slice::AsSlice;
 
 /// The type representing a foreign chunk of memory
 pub struct CVec<T> {
@@ -145,7 +145,7 @@ impl<T> CVec<T> {
     }
 }
 
-impl<T> Slice<T> for CVec<T> {
+impl<T> AsSlice<T> for CVec<T> {
     /// View the stored data as a slice.
     fn as_slice<'a>(&'a self) -> &'a [T] {
         unsafe {

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -29,7 +29,7 @@ use option::*;
 use os;
 use path::{Path,GenericPath};
 use result::*;
-use slice::{Slice,ImmutableSlice};
+use slice::{AsSlice,ImmutableSlice};
 use str;
 use string::String;
 use vec::Vec;

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -23,7 +23,7 @@ use num::Int;
 use option::{Option, Some, None};
 use ptr::RawPtr;
 use result::{Ok, Err};
-use slice::{ImmutableSlice, Slice};
+use slice::{ImmutableSlice, AsSlice};
 
 /// An iterator that reads a single byte on each iteration,
 /// until `.read_byte()` returns `EndOfFile`.

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -19,7 +19,7 @@ use result::{Err, Ok};
 use io;
 use io::{Reader, Writer, Seek, Buffer, IoError, SeekStyle, IoResult};
 use slice;
-use slice::Slice;
+use slice::AsSlice;
 use vec::Vec;
 
 static BUF_CAPACITY: uint = 128;

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -235,7 +235,7 @@ use os;
 use boxed::Box;
 use result::{Ok, Err, Result};
 use rt::rtio;
-use slice::{Slice, ImmutableSlice};
+use slice::{AsSlice, ImmutableSlice};
 use str::{Str, StrSlice};
 use str;
 use string::String;

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -45,7 +45,7 @@ use path::{Path, GenericPath, BytesContainer};
 use ptr::RawPtr;
 use ptr;
 use result::{Err, Ok, Result};
-use slice::{Slice, ImmutableSlice, MutableSlice, ImmutablePartialEqSlice};
+use slice::{AsSlice, ImmutableSlice, MutableSlice, ImmutablePartialEqSlice};
 use slice::CloneableVector;
 use str::{Str, StrSlice, StrAllocating};
 use string::String;

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -76,7 +76,7 @@ use option::{Option, None, Some};
 use str;
 use str::{MaybeOwned, Str, StrSlice};
 use string::String;
-use slice::{Slice, CloneableVector};
+use slice::{AsSlice, CloneableVector};
 use slice::{ImmutablePartialEqSlice, ImmutableSlice};
 use vec::Vec;
 

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -21,7 +21,7 @@ use iter::{DoubleEndedIterator, AdditiveIterator, Extendable, Iterator, Map};
 use option::{Option, None, Some};
 use str::Str;
 use str;
-use slice::{CloneableVector, Splits, Slice, VectorVector,
+use slice::{CloneableVector, Splits, AsSlice, VectorVector,
             ImmutablePartialEqSlice, ImmutableSlice};
 use vec::Vec;
 
@@ -367,7 +367,7 @@ impl Path {
 
     /// Returns a normalized byte vector representation of a path, by removing all empty
     /// components, and unnecessary . and .. components.
-    fn normalize<V: Slice<u8>+CloneableVector<u8>>(v: V) -> Vec<u8> {
+    fn normalize<V: AsSlice<u8>+CloneableVector<u8>>(v: V) -> Vec<u8> {
         // borrowck is being very picky
         let val = {
             let is_abs = !v.as_slice().is_empty() && v.as_slice()[0] == SEP_BYTE;

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -23,7 +23,7 @@ use io::Writer;
 use iter::{AdditiveIterator, DoubleEndedIterator, Extendable, Iterator, Map};
 use mem;
 use option::{Option, Some, None};
-use slice::{Slice, ImmutableSlice};
+use slice::{AsSlice, ImmutableSlice};
 use str::{CharSplits, Str, StrAllocating, StrVector, StrSlice};
 use string::String;
 use unicode::char::UnicodeChar;

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -47,6 +47,7 @@
 #[doc(no_inline)] pub use ops::{Shl, Shr};
 #[doc(no_inline)] pub use ops::{Index, IndexMut};
 #[doc(no_inline)] pub use ops::{Fn, FnMut, FnOnce};
+#[doc(no_inline)] pub use ops::{Slice, SliceMut};
 #[doc(no_inline)] pub use option::{Option, Some, None};
 #[doc(no_inline)] pub use result::{Result, Ok, Err};
 
@@ -87,7 +88,7 @@
 #[doc(no_inline)] pub use slice::{MutableCloneableSlice, MutableOrdSlice};
 #[doc(no_inline)] pub use slice::{ImmutableSlice, MutableSlice};
 #[doc(no_inline)] pub use slice::{ImmutablePartialEqSlice, ImmutableOrdSlice};
-#[doc(no_inline)] pub use slice::{Slice, VectorVector};
+#[doc(no_inline)] pub use slice::{AsSlice, VectorVector};
 #[doc(no_inline)] pub use slice::MutableSliceAllocating;
 #[doc(no_inline)] pub use string::String;
 #[doc(no_inline)] pub use vec::Vec;


### PR DESCRIPTION
methods on slice types. However, the relevant traits were not included
in the prelude, meaning that you would have to manually import
`std::ops::Slice` to get these operations -- an unintended regression.

This commit adds the traits to the prelude, as is done with most other
operator traits.

Unfortunately, the trait `std::slice::Slice` (which defines an
`as_slice` method) was already included in the prelude. This trait is
renamed to `AsSlice`, which is a better name in any case.

In addition, because of both `AsSlice` and `Str` traits being included
in the prelude, both of which define `as_slice`, and both of which are
used for generic programming, this commit renames `ops::Slice::as_slice`
to `ops::Slice::as_slice_`. This is a stopgap solution; we'll need to
figure out a long-term story here later on.

Closes rust-lang#17710

Due to the renamings, this is a:

[breaking-change]
