### PR TITLE
Revert overloaded slice notation being merged with library slicing

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![crate_type = "bin"]
-#![feature(phase, slicing_syntax)]
+#![feature(phase)]
 
 #![deny(warnings)]
 

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -874,7 +874,7 @@ fn check_error_patterns(props: &TestProps,
     if done { return; }
 
     let missing_patterns =
-        props.error_patterns[next_err_idx..];
+        props.error_patterns.slice(next_err_idx, props.error_patterns.len());
     if missing_patterns.len() == 1u {
         fatal_proc_rec(format!("error pattern '{}' not found!",
                               missing_patterns[0]).as_slice(),

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -3828,7 +3828,7 @@ type signature of `print`, and the cast expression in `main`.
 Within the body of an item that has type parameter declarations, the names of
 its type parameters are types:
 
-```ignore
+```
 fn map<A: Clone, B: Clone>(f: |A| -> B, xs: &[A]) -> Vec<B> {
     if xs.len() == 0 {
        return vec![];

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -194,7 +194,7 @@ impl Bitv {
         if start > self.storage.len() {
             start = self.storage.len();
         }
-        let mut iter = self.storage[start..].iter();
+        let mut iter = self.storage.slice_from(start).iter();
         MaskWords {
           next_word: iter.next(),
           iter: iter,

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -19,9 +19,8 @@
        html_root_url = "http://doc.rust-lang.org/master/",
        html_playground_url = "http://play.rust-lang.org/")]
 
-#![allow(unknown_features)]
 #![feature(macro_rules, managed_boxes, default_type_params, phase, globs)]
-#![feature(unsafe_destructor, import_shadowing, slicing_syntax)]
+#![feature(unsafe_destructor, import_shadowing)]
 #![no_std]
 
 #[phase(plugin, link)] extern crate core;

--- a/src/libcollections/ringbuf.rs
+++ b/src/libcollections/ringbuf.rs
@@ -271,7 +271,7 @@ impl<T> RingBuf<T> {
     ///     *num = *num - 2;
     /// }
     /// let b: &[_] = &[&mut 3, &mut 1, &mut 2];
-    /// assert_eq!(buf.iter_mut().collect::<Vec<&mut int>>()[], b);
+    /// assert_eq!(buf.iter_mut().collect::<Vec<&mut int>>().as_slice(), b);
     /// ```
     pub fn iter_mut<'a>(&'a mut self) -> MutItems<'a, T> {
         let start_index = raw_index(self.lo, self.elts.len(), 0);
@@ -291,7 +291,7 @@ impl<T> RingBuf<T> {
         } else {
             // Items to iterate goes from start_index to end_index:
             let (empty, elts) = self.elts.split_at_mut(0);
-            let remaining1 = elts[mut start_index..end_index];
+            let remaining1 = elts.slice_mut(start_index, end_index);
             MutItems { remaining1: remaining1,
                                  remaining2: empty,
                                  nelts: self.nelts }

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -51,12 +51,9 @@
 //! interval `[a, b)`:
 //!
 //! ```rust
-//! #![feature(slicing_syntax)]
-//! fn main() {
-//!     let numbers = [0i, 1i, 2i];
-//!     let last_numbers = numbers[1..3];
-//!     // last_numbers is now &[1i, 2i]
-//! }
+//! let numbers = [0i, 1i, 2i];
+//! let last_numbers = numbers[1..3];
+//! // last_numbers is now &[1i, 2i]
 //! ```
 //!
 //! ## Implementations of other traits

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -46,13 +46,12 @@
 //! These traits include `ImmutableSlice`, which is defined for `&[T]` types,
 //! and `MutableSlice`, defined for `&mut [T]` types.
 //!
-//! An example is the `slice` method which enables slicing syntax `[a..b]` that
-//! returns an immutable "view" into a `Vec` or another slice from the index
-//! interval `[a, b)`:
+//! An example is the method `.slice(a, b)` that returns an immutable "view" into
+//! a `Vec` or another slice from the index interval `[a, b)`:
 //!
 //! ```rust
 //! let numbers = [0i, 1i, 2i];
-//! let last_numbers = numbers[1..3];
+//! let last_numbers = numbers.slice(1, 3);
 //! // last_numbers is now &[1i, 2i]
 //! ```
 //!
@@ -611,7 +610,7 @@ impl<'a,T> MutableSliceAllocating<'a, T> for &'a mut [T] {
 
     #[inline]
     fn move_from(self, mut src: Vec<T>, start: uint, end: uint) -> uint {
-        for (a, b) in self.iter_mut().zip(src[mut start..end].iter_mut()) {
+        for (a, b) in self.iter_mut().zip(src.slice_mut(start, end).iter_mut()) {
             mem::swap(a, b);
         }
         cmp::min(self.len(), end-start)
@@ -703,7 +702,7 @@ impl<'a, T: Ord> MutableOrdSlice<T> for &'a mut [T] {
         self.swap(j, i-1);
 
         // Step 4: Reverse the (previously) weakly decreasing part
-        self[mut i..].reverse();
+        self.slice_from_mut(i).reverse();
 
         true
     }
@@ -724,7 +723,7 @@ impl<'a, T: Ord> MutableOrdSlice<T> for &'a mut [T] {
         }
 
         // Step 2: Reverse the weakly increasing part
-        self[mut i..].reverse();
+        self.slice_from_mut(i).reverse();
 
         // Step 3: Find the rightmost element equal to or bigger than the pivot (i-1)
         let mut j = self.len() - 1;
@@ -991,7 +990,7 @@ mod tests {
     fn test_slice() {
         // Test fixed length vector.
         let vec_fixed = [1i, 2, 3, 4];
-        let v_a = vec_fixed[1u..vec_fixed.len()].to_vec();
+        let v_a = vec_fixed.slice(1u, vec_fixed.len()).to_vec();
         assert_eq!(v_a.len(), 3u);
         let v_a = v_a.as_slice();
         assert_eq!(v_a[0], 2);
@@ -999,8 +998,8 @@ mod tests {
         assert_eq!(v_a[2], 4);
 
         // Test on stack.
-        let vec_stack: &[_] = &[1i, 2, 3];
-        let v_b = vec_stack[1u..3u].to_vec();
+        let vec_stack = &[1i, 2, 3];
+        let v_b = vec_stack.slice(1u, 3u).to_vec();
         assert_eq!(v_b.len(), 2u);
         let v_b = v_b.as_slice();
         assert_eq!(v_b[0], 2);
@@ -1008,7 +1007,7 @@ mod tests {
 
         // Test `Box<[T]>`
         let vec_unique = vec![1i, 2, 3, 4, 5, 6];
-        let v_d = vec_unique[1u..6u].to_vec();
+        let v_d = vec_unique.slice(1u, 6u).to_vec();
         assert_eq!(v_d.len(), 5u);
         let v_d = v_d.as_slice();
         assert_eq!(v_d[0], 2);
@@ -1021,21 +1020,21 @@ mod tests {
     #[test]
     fn test_slice_from() {
         let vec: &[int] = &[1, 2, 3, 4];
-        assert_eq!(vec[0..], vec);
+        assert_eq!(vec.slice_from(0), vec);
         let b: &[int] = &[3, 4];
-        assert_eq!(vec[2..], b);
+        assert_eq!(vec.slice_from(2), b);
         let b: &[int] = &[];
-        assert_eq!(vec[4..], b);
+        assert_eq!(vec.slice_from(4), b);
     }
 
     #[test]
     fn test_slice_to() {
         let vec: &[int] = &[1, 2, 3, 4];
-        assert_eq!(vec[..4], vec);
+        assert_eq!(vec.slice_to(4), vec);
         let b: &[int] = &[1, 2];
-        assert_eq!(vec[..2], b);
+        assert_eq!(vec.slice_to(2), b);
         let b: &[int] = &[];
-        assert_eq!(vec[..0], b);
+        assert_eq!(vec.slice_to(0), b);
     }
 
 
@@ -1976,7 +1975,7 @@ mod tests {
         assert!(a == [7i,2,3,4]);
         let mut a = [1i,2,3,4,5];
         let b = vec![5i,6,7,8,9,0];
-        assert_eq!(a[mut 2..4].move_from(b,1,6), 2);
+        assert_eq!(a.slice_mut(2,4).move_from(b,1,6), 2);
         assert!(a == [1i,2,6,7,5]);
     }
 
@@ -1996,7 +1995,7 @@ mod tests {
     #[test]
     fn test_reverse_part() {
         let mut values = [1i,2,3,4,5];
-        values[mut 1..4].reverse();
+        values.slice_mut(1, 4).reverse();
         assert!(values == [1,4,3,2,5]);
     }
 
@@ -2043,9 +2042,9 @@ mod tests {
     fn test_bytes_set_memory() {
         use slice::bytes::MutableByteVector;
         let mut values = [1u8,2,3,4,5];
-        values[mut 0..5].set_memory(0xAB);
+        values.slice_mut(0,5).set_memory(0xAB);
         assert!(values == [0xAB, 0xAB, 0xAB, 0xAB, 0xAB]);
-        values[mut 2..4].set_memory(0xFF);
+        values.slice_mut(2,4).set_memory(0xFF);
         assert!(values == [0xAB, 0xAB, 0xFF, 0xFF, 0xAB]);
     }
 
@@ -2071,18 +2070,12 @@ mod tests {
         let mut values = [1u8,2,3,4,5];
         {
             let (left, right) = values.split_at_mut(2);
-            {
-                let left: &[_] = left;
-                assert!(left[0..left.len()] == [1, 2]);
-            }
+            assert!(left.slice(0, left.len()) == [1, 2]);
             for p in left.iter_mut() {
                 *p += 1;
             }
 
-            {
-                let right: &[_] = right;
-                assert!(right[0..right.len()] == [3, 4, 5]);
-            }
+            assert!(right.slice(0, right.len()) == [3, 4, 5]);
             for p in right.iter_mut() {
                 *p += 2;
             }
@@ -2106,7 +2099,7 @@ mod tests {
         }
         assert_eq!(cnt, 3);
 
-        for f in v[1..3].iter() {
+        for f in v.slice(1, 3).iter() {
             assert!(*f == Foo);
             cnt += 1;
         }

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -44,8 +44,7 @@
 //!
 //! A number of traits add methods that allow you to accomplish tasks with slices.
 //! These traits include `ImmutableSlice`, which is defined for `&[T]` types,
-//! `MutableSlice`, defined for `&mut [T]` types, and `Slice` and `SliceMut`
-//! which are defined for `[T]`.
+//! and `MutableSlice`, defined for `&mut [T]` types.
 //!
 //! An example is the `slice` method which enables slicing syntax `[a..b]` that
 //! returns an immutable "view" into a `Vec` or another slice from the index

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1680,7 +1680,7 @@ mod tests {
         let mut bytes = [0u8, ..4];
         for c in range(0u32, 0x110000).filter_map(|c| ::core::char::from_u32(c)) {
             let len = c.encode_utf8(bytes).unwrap_or(0);
-            let s = ::core::str::from_utf8(bytes[..len]).unwrap();
+            let s = ::core::str::from_utf8(bytes.slice_to(len)).unwrap();
             if Some(c) != s.chars().next() {
                 fail!("character {:x}={} does not decode correctly", c as u32, c);
             }
@@ -1692,7 +1692,7 @@ mod tests {
         let mut bytes = [0u8, ..4];
         for c in range(0u32, 0x110000).filter_map(|c| ::core::char::from_u32(c)) {
             let len = c.encode_utf8(bytes).unwrap_or(0);
-            let s = ::core::str::from_utf8(bytes[..len]).unwrap();
+            let s = ::core::str::from_utf8(bytes.slice_to(len)).unwrap();
             if Some(c) != s.chars().rev().next() {
                 fail!("character {:x}={} does not decode correctly", c as u32, c);
             }

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -160,7 +160,7 @@ impl String {
 
         if i > 0 {
             unsafe {
-                res.as_mut_vec().push_all(v[..i])
+                res.as_mut_vec().push_all(v.[..i])
             };
         }
 
@@ -177,7 +177,7 @@ impl String {
             macro_rules! error(() => ({
                 unsafe {
                     if subseqidx != i_ {
-                        res.as_mut_vec().push_all(v[subseqidx..i_]);
+                        res.as_mut_vec().push_all(vv[subseqidx..i_]);
                     }
                     subseqidx = i;
                     res.as_mut_vec().push_all(REPLACEMENT);

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -160,7 +160,7 @@ impl String {
 
         if i > 0 {
             unsafe {
-                res.as_mut_vec().push_all(v.[..i])
+                res.as_mut_vec().push_all(v.slice_to(i))
             };
         }
 
@@ -177,7 +177,7 @@ impl String {
             macro_rules! error(() => ({
                 unsafe {
                     if subseqidx != i_ {
-                        res.as_mut_vec().push_all(vv[subseqidx..i_]);
+                        res.as_mut_vec().push_all(v.slice(subseqidx, i_));
                     }
                     subseqidx = i;
                     res.as_mut_vec().push_all(REPLACEMENT);
@@ -246,7 +246,7 @@ impl String {
         }
         if subseqidx < total {
             unsafe {
-                res.as_mut_vec().push_all(v[subseqidx..total])
+                res.as_mut_vec().push_all(v.slice(subseqidx, total))
             };
         }
         Owned(res.into_string())

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -927,7 +927,6 @@ impl<S: Str> Add<S, String> for String {
     }
 }
 
-#[cfg(stage0)]
 impl ops::Slice<uint, str> for String {
     #[inline]
     fn as_slice_<'a>(&'a self) -> &'a str {
@@ -946,34 +945,6 @@ impl ops::Slice<uint, str> for String {
 
     #[inline]
     fn slice_<'a>(&'a self, from: &uint, to: &uint) -> &'a str {
-        self[][*from..*to]
-    }
-}
-
-#[cfg(not(stage0))]
-#[inline]
-fn str_to_slice<'a, U: Str>(this: &'a U) -> &'a str {
-    this.as_slice()
-}
-#[cfg(not(stage0))]
-impl ops::Slice<uint, str> for String {
-    #[inline]
-    fn as_slice<'a>(&'a self) -> &'a str {
-        str_to_slice(self)
-    }
-
-    #[inline]
-    fn slice_from<'a>(&'a self, from: &uint) -> &'a str {
-        self[][*from..]
-    }
-
-    #[inline]
-    fn slice_to<'a>(&'a self, to: &uint) -> &'a str {
-        self[][..*to]
-    }
-
-    #[inline]
-    fn slice<'a>(&'a self, from: &uint, to: &uint) -> &'a str {
         self[][*from..*to]
     }
 }

--- a/src/libcollections/trie.rs
+++ b/src/libcollections/trie.rs
@@ -24,7 +24,6 @@ use core::fmt;
 use core::fmt::Show;
 use core::mem::zeroed;
 use core::mem;
-use core::ops::{Slice,SliceMut};
 use core::uint;
 use core::iter;
 use std::hash::{Writer, Hash};
@@ -379,7 +378,7 @@ macro_rules! bound {
                         }
                     };
                     // push to the stack.
-                    it.stack[it.length] = children.$slice_from(&slice_idx).$iter();
+                    it.stack[it.length] = children.$slice_from(slice_idx).$iter();
                     it.length += 1;
                     if ret { return it }
                 })
@@ -393,7 +392,7 @@ impl<T> TrieMap<T> {
     fn bound<'a>(&'a self, key: uint, upper: bool) -> Entries<'a, T> {
         bound!(Entries, self = self,
                key = key, is_upper = upper,
-               slice_from = slice_from_, iter = iter,
+               slice_from = slice_from, iter = iter,
                mutability = )
     }
 
@@ -435,7 +434,7 @@ impl<T> TrieMap<T> {
     fn bound_mut<'a>(&'a mut self, key: uint, upper: bool) -> MutEntries<'a, T> {
         bound!(MutEntries, self = self,
                key = key, is_upper = upper,
-               slice_from = slice_from_mut_, iter = iter_mut,
+               slice_from = slice_from_mut, iter = iter_mut,
                mutability = mut)
     }
 

--- a/src/libcollections/trie.rs
+++ b/src/libcollections/trie.rs
@@ -389,20 +389,11 @@ macro_rules! bound {
 
 impl<T> TrieMap<T> {
     // If `upper` is true then returns upper_bound else returns lower_bound.
-    #[cfg(stage0)]
     #[inline]
     fn bound<'a>(&'a self, key: uint, upper: bool) -> Entries<'a, T> {
         bound!(Entries, self = self,
                key = key, is_upper = upper,
                slice_from = slice_from_, iter = iter,
-               mutability = )
-    }
-    #[cfg(not(stage0))]
-    #[inline]
-    fn bound<'a>(&'a self, key: uint, upper: bool) -> Entries<'a, T> {
-        bound!(Entries, self = self,
-               key = key, is_upper = upper,
-               slice_from = slice_from, iter = iter,
                mutability = )
     }
 
@@ -440,20 +431,11 @@ impl<T> TrieMap<T> {
         self.bound(key, true)
     }
     // If `upper` is true then returns upper_bound else returns lower_bound.
-    #[cfg(stage0)]
     #[inline]
     fn bound_mut<'a>(&'a mut self, key: uint, upper: bool) -> MutEntries<'a, T> {
         bound!(MutEntries, self = self,
                key = key, is_upper = upper,
                slice_from = slice_from_mut_, iter = iter_mut,
-               mutability = mut)
-    }
-    #[cfg(not(stage0))]
-    #[inline]
-    fn bound_mut<'a>(&'a mut self, key: uint, upper: bool) -> MutEntries<'a, T> {
-        bound!(MutEntries, self = self,
-               key = key, is_upper = upper,
-               slice_from = slice_from_mut, iter = iter_mut,
                mutability = mut)
     }
 

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -438,7 +438,7 @@ impl<T:Clone> Clone for Vec<T> {
 
         // self.len <= other.len due to the truncate above, so the
         // slice here is always in-bounds.
-        let slice = other[self.len()..];
+        let slice = other.slice_from(self.len());
         self.push_all(slice);
     }
 }
@@ -928,12 +928,11 @@ impl<T> Vec<T> {
     ///
     /// ```
     /// let vec = vec![1i, 2, 3, 4];
-    /// assert!(vec[0..2] == [1, 2]);
+    /// assert!(vec.slice(0, 2) == [1, 2]);
     /// ```
     #[inline]
-    #[deprecated = "use slicing syntax"]
     pub fn slice<'a>(&'a self, start: uint, end: uint) -> &'a [T] {
-        self[start..end]
+        self.as_slice().slice(start, end)
     }
 
     /// Returns a slice containing all but the first element of the vector.
@@ -950,7 +949,7 @@ impl<T> Vec<T> {
     /// ```
     #[inline]
     pub fn tail<'a>(&'a self) -> &'a [T] {
-        self[].tail()
+        self.as_slice().tail()
     }
 
     /// Returns all but the first `n' elements of a vector.
@@ -967,9 +966,9 @@ impl<T> Vec<T> {
     /// assert!(vec.tailn(2) == [3, 4]);
     /// ```
     #[inline]
-    #[deprecated = "use slicing syntax"]
+    #[deprecated = "use slice_from"]
     pub fn tailn<'a>(&'a self, n: uint) -> &'a [T] {
-        self[n..]
+        self.as_slice().slice_from(n)
     }
 
     /// Returns a reference to the last element of a vector, or `None` if it is
@@ -983,7 +982,7 @@ impl<T> Vec<T> {
     /// ```
     #[inline]
     pub fn last<'a>(&'a self) -> Option<&'a T> {
-        self[].last()
+        self.as_slice().last()
     }
 
     /// Deprecated: use `last_mut`.
@@ -1177,10 +1176,10 @@ impl<T> Vec<T> {
     }
 
     /// Deprecated: use `slice_mut`.
-    #[deprecated = "use slicing syntax"]
+    #[deprecated = "use slice_mut"]
     pub fn mut_slice<'a>(&'a mut self, start: uint, end: uint)
                          -> &'a mut [T] {
-        self[mut start..end]
+        self.slice_mut(start, end)
     }
 
     /// Returns a mutable slice of `self` between `start` and `end`.
@@ -1194,19 +1193,18 @@ impl<T> Vec<T> {
     ///
     /// ```
     /// let mut vec = vec![1i, 2, 3, 4];
-    /// assert!(vec[mut 0..2] == [1, 2]);
+    /// assert!(vec.slice_mut(0, 2) == [1, 2]);
     /// ```
     #[inline]
-    #[deprecated = "use slicing syntax"]
     pub fn slice_mut<'a>(&'a mut self, start: uint, end: uint)
                          -> &'a mut [T] {
-        self[mut start..end]
+        self.as_mut_slice().slice_mut(start, end)
     }
 
     /// Deprecated: use "slice_from_mut".
-    #[deprecated = "use slicing syntax"]
+    #[deprecated = "use slice_from_mut"]
     pub fn mut_slice_from<'a>(&'a mut self, start: uint) -> &'a mut [T] {
-        self[mut start..]
+        self.slice_from_mut(start)
     }
 
     /// Returns a mutable slice of `self` from `start` to the end of the `Vec`.
@@ -1219,18 +1217,17 @@ impl<T> Vec<T> {
     ///
     /// ```
     /// let mut vec = vec![1i, 2, 3, 4];
-    /// assert!(vec[mut 2..] == [3, 4]);
+    /// assert!(vec.slice_from_mut(2) == [3, 4]);
     /// ```
     #[inline]
-    #[deprecated = "use slicing syntax"]
     pub fn slice_from_mut<'a>(&'a mut self, start: uint) -> &'a mut [T] {
-        self[mut start..]
+        self.as_mut_slice().slice_from_mut(start)
     }
 
     /// Deprecated: use `slice_to_mut`.
-    #[deprecated = "use slicing syntax"]
+    #[deprecated = "use slice_to_mut"]
     pub fn mut_slice_to<'a>(&'a mut self, end: uint) -> &'a mut [T] {
-        self[mut ..end]
+        self.slice_to_mut(end)
     }
 
     /// Returns a mutable slice of `self` from the start of the `Vec` to `end`.
@@ -1243,12 +1240,11 @@ impl<T> Vec<T> {
     ///
     /// ```
     /// let mut vec = vec![1i, 2, 3, 4];
-    /// assert!(vec[mut ..2] == [1, 2]);
+    /// assert!(vec.slice_to_mut(2) == [1, 2]);
     /// ```
     #[inline]
-    #[deprecated = "use slicing syntax"]
     pub fn slice_to_mut<'a>(&'a mut self, end: uint) -> &'a mut [T] {
-        self[mut ..end]
+        self.as_mut_slice().slice_to_mut(end)
     }
 
     /// Deprecated: use `split_at_mut`.
@@ -1293,7 +1289,7 @@ impl<T> Vec<T> {
     /// ```
     #[inline]
     pub fn split_at_mut<'a>(&'a mut self, mid: uint) -> (&'a mut [T], &'a mut [T]) {
-        self[mut].split_at_mut(mid)
+        self.as_mut_slice().split_at_mut(mid)
     }
 
     /// Reverses the order of elements in a vector, in place.
@@ -1307,7 +1303,7 @@ impl<T> Vec<T> {
     /// ```
     #[inline]
     pub fn reverse(&mut self) {
-        self[mut].reverse()
+        self.as_mut_slice().reverse()
     }
 
     /// Returns a slice of `self` from `start` to the end of the vec.
@@ -1320,12 +1316,11 @@ impl<T> Vec<T> {
     ///
     /// ```
     /// let vec = vec![1i, 2, 3];
-    /// assert!(vec[1..] == [2, 3]);
+    /// assert!(vec.slice_from(1) == [2, 3]);
     /// ```
     #[inline]
-    #[deprecated = "use slicing syntax"]
     pub fn slice_from<'a>(&'a self, start: uint) -> &'a [T] {
-        self[start..]
+        self.as_slice().slice_from(start)
     }
 
     /// Returns a slice of self from the start of the vec to `end`.
@@ -1338,12 +1333,11 @@ impl<T> Vec<T> {
     ///
     /// ```
     /// let vec = vec![1i, 2, 3, 4];
-    /// assert!(vec[..2] == [1, 2]);
+    /// assert!(vec.slice_to(2) == [1, 2]);
     /// ```
     #[inline]
-    #[deprecated = "use slicing syntax"]
     pub fn slice_to<'a>(&'a self, end: uint) -> &'a [T] {
-        self[..end]
+        self.as_slice().slice_to(end)
     }
 
     /// Returns a slice containing all but the last element of the vector.
@@ -1360,7 +1354,7 @@ impl<T> Vec<T> {
     /// ```
     #[inline]
     pub fn init<'a>(&'a self) -> &'a [T] {
-        self[0..self.len() - 1]
+        self.slice(0, self.len() - 1)
     }
 
 
@@ -2218,18 +2212,12 @@ mod tests {
         let mut values = Vec::from_slice([1u8,2,3,4,5]);
         {
             let (left, right) = values.split_at_mut(2);
-            {
-                let left: &[_] = left;
-                assert!(left[0..left.len()] == [1, 2]);
-            }
+            assert!(left.slice(0, left.len()) == [1, 2]);
             for p in left.iter_mut() {
                 *p += 1;
             }
 
-            {
-                let right: &[_] = right;
-                assert!(right[0..right.len()] == [3, 4, 5]);
-            }
+            assert!(right.slice(0, right.len()) == [3, 4, 5]);
             for p in right.iter_mut() {
                 *p += 2;
             }

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -463,7 +463,6 @@ impl<T> Index<uint,T> for Vec<T> {
 
 // Annoying helper function because there are two Slice::as_slice functions in
 // scope.
-#[cfg(not(stage0))]
 #[inline]
 fn slice_to_slice<'a, T, U: Slice<T>>(this: &'a U) -> &'a [T] {
     this.as_slice()
@@ -985,6 +984,7 @@ impl<T> Vec<T> {
     /// assert!(vec[0..2] == [1, 2]);
     /// ```
     #[inline]
+    #[deprecated = "use slicing syntax"]
     pub fn slice<'a>(&'a self, start: uint, end: uint) -> &'a [T] {
         self[start..end]
     }
@@ -1020,7 +1020,7 @@ impl<T> Vec<T> {
     /// assert!(vec.tailn(2) == [3, 4]);
     /// ```
     #[inline]
-    #[deprecated = "use slice_from"]
+    #[deprecated = "use slicing syntax"]
     pub fn tailn<'a>(&'a self, n: uint) -> &'a [T] {
         self[n..]
     }
@@ -1230,7 +1230,7 @@ impl<T> Vec<T> {
     }
 
     /// Deprecated: use `slice_mut`.
-    #[deprecated = "use slice_from"]
+    #[deprecated = "use slicing syntax"]
     pub fn mut_slice<'a>(&'a mut self, start: uint, end: uint)
                          -> &'a mut [T] {
         self[mut start..end]
@@ -1250,13 +1250,14 @@ impl<T> Vec<T> {
     /// assert!(vec[mut 0..2] == [1, 2]);
     /// ```
     #[inline]
+    #[deprecated = "use slicing syntax"]
     pub fn slice_mut<'a>(&'a mut self, start: uint, end: uint)
                          -> &'a mut [T] {
         self[mut start..end]
     }
 
     /// Deprecated: use "slice_from_mut".
-    #[deprecated = "use slice_from_mut"]
+    #[deprecated = "use slicing syntax"]
     pub fn mut_slice_from<'a>(&'a mut self, start: uint) -> &'a mut [T] {
         self[mut start..]
     }
@@ -1274,12 +1275,13 @@ impl<T> Vec<T> {
     /// assert!(vec[mut 2..] == [3, 4]);
     /// ```
     #[inline]
+    #[deprecated = "use slicing syntax"]
     pub fn slice_from_mut<'a>(&'a mut self, start: uint) -> &'a mut [T] {
         self[mut start..]
     }
 
     /// Deprecated: use `slice_to_mut`.
-    #[deprecated = "use slice_to_mut"]
+    #[deprecated = "use slicing syntax"]
     pub fn mut_slice_to<'a>(&'a mut self, end: uint) -> &'a mut [T] {
         self[mut ..end]
     }
@@ -1297,6 +1299,7 @@ impl<T> Vec<T> {
     /// assert!(vec[mut ..2] == [1, 2]);
     /// ```
     #[inline]
+    #[deprecated = "use slicing syntax"]
     pub fn slice_to_mut<'a>(&'a mut self, end: uint) -> &'a mut [T] {
         self[mut ..end]
     }
@@ -1373,6 +1376,7 @@ impl<T> Vec<T> {
     /// assert!(vec[1..] == [2, 3]);
     /// ```
     #[inline]
+    #[deprecated = "use slicing syntax"]
     pub fn slice_from<'a>(&'a self, start: uint) -> &'a [T] {
         self[start..]
     }
@@ -1390,6 +1394,7 @@ impl<T> Vec<T> {
     /// assert!(vec[..2] == [1, 2]);
     /// ```
     #[inline]
+    #[deprecated = "use slicing syntax"]
     pub fn slice_to<'a>(&'a self, end: uint) -> &'a [T] {
         self[..end]
     }

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -24,7 +24,6 @@ use core::num;
 use core::ops;
 use core::ptr;
 use core::raw::Slice as RawSlice;
-use core::slice::Slice as SliceSlice;
 use core::uint;
 
 use {Mutable, MutableSeq};
@@ -461,36 +460,6 @@ impl<T> Index<uint,T> for Vec<T> {
     }
 }*/
 
-// Annoying helper function because there are two Slice::as_slice functions in
-// scope.
-#[inline]
-fn slice_to_slice<'a, T, U: Slice<T>>(this: &'a U) -> &'a [T] {
-    this.as_slice()
-}
-
-
-#[cfg(not(stage0))]
-impl<T> ops::Slice<uint, [T]> for Vec<T> {
-    #[inline]
-    fn as_slice<'a>(&'a self) -> &'a [T] {
-        slice_to_slice(self)
-    }
-
-    #[inline]
-    fn slice_from<'a>(&'a self, start: &uint) -> &'a [T] {
-        slice_to_slice(self).slice_from(start)
-    }
-
-    #[inline]
-    fn slice_to<'a>(&'a self, end: &uint) -> &'a [T] {
-        slice_to_slice(self).slice_to(end)
-    }
-    #[inline]
-    fn slice<'a>(&'a self, start: &uint, end: &uint) -> &'a [T] {
-        slice_to_slice(self).slice(start, end)
-    }
-}
-#[cfg(stage0)]
 impl<T> ops::Slice<uint, [T]> for Vec<T> {
     #[inline]
     fn as_slice_<'a>(&'a self) -> &'a [T] {
@@ -512,28 +481,6 @@ impl<T> ops::Slice<uint, [T]> for Vec<T> {
     }
 }
 
-#[cfg(not(stage0))]
-impl<T> ops::SliceMut<uint, [T]> for Vec<T> {
-    #[inline]
-    fn as_mut_slice<'a>(&'a mut self) -> &'a mut [T] {
-        self.as_mut_slice()
-    }
-
-    #[inline]
-    fn slice_from_mut<'a>(&'a mut self, start: &uint) -> &'a mut [T] {
-        self.as_mut_slice().slice_from_mut(start)
-    }
-
-    #[inline]
-    fn slice_to_mut<'a>(&'a mut self, end: &uint) -> &'a mut [T] {
-        self.as_mut_slice().slice_to_mut(end)
-    }
-    #[inline]
-    fn slice_mut<'a>(&'a mut self, start: &uint, end: &uint) -> &'a mut [T] {
-        self.as_mut_slice().slice_mut(start, end)
-    }
-}
-#[cfg(stage0)]
 impl<T> ops::SliceMut<uint, [T]> for Vec<T> {
     #[inline]
     fn as_mut_slice_<'a>(&'a mut self) -> &'a mut [T] {

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -17,7 +17,7 @@ use iter::{range, DoubleEndedIterator};
 use num::{Float, FPNaN, FPInfinite, ToPrimitive, Primitive};
 use num::{Zero, One, cast};
 use result::Ok;
-use slice::MutableSlice;
+use slice::{ImmutableSlice, MutableSlice};
 use slice;
 use str::StrSlice;
 
@@ -173,7 +173,7 @@ pub fn float_to_str_bytes_common<T: Primitive + Float, U>(
         _ => ()
     }
 
-    buf[mut ..end].reverse();
+    buf.slice_to_mut(end).reverse();
 
     // Remember start of the fractional digits.
     // Points one beyond end of buf if none get generated,
@@ -310,7 +310,7 @@ pub fn float_to_str_bytes_common<T: Primitive + Float, U>(
 
             impl<'a> fmt::FormatWriter for Filler<'a> {
                 fn write(&mut self, bytes: &[u8]) -> fmt::Result {
-                    slice::bytes::copy_memory(self.buf[mut *self.end..],
+                    slice::bytes::copy_memory(self.buf.slice_from_mut(*self.end),
                                               bytes);
                     *self.end += bytes.len();
                     Ok(())
@@ -328,5 +328,5 @@ pub fn float_to_str_bytes_common<T: Primitive + Float, U>(
         }
     }
 
-    f(buf[..end])
+    f(buf.slice_to(end))
 }

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -423,7 +423,7 @@ impl<'a> Formatter<'a> {
             for c in sign.into_iter() {
                 let mut b = [0, ..4];
                 let n = c.encode_utf8(b).unwrap_or(0);
-                try!(f.buf.write(b[..n]));
+                try!(f.buf.write(b.slice_to(n)));
             }
             if prefixed { f.buf.write(prefix.as_bytes()) }
             else { Ok(()) }
@@ -530,13 +530,13 @@ impl<'a> Formatter<'a> {
         let len = self.fill.encode_utf8(fill).unwrap_or(0);
 
         for _ in range(0, pre_pad) {
-            try!(self.buf.write(fill[..len]));
+            try!(self.buf.write(fill.slice_to(len)));
         }
 
         try!(f(self));
 
         for _ in range(0, post_pad) {
-            try!(self.buf.write(fill[..len]));
+            try!(self.buf.write(fill.slice_to(len)));
         }
 
         Ok(())
@@ -611,7 +611,7 @@ impl Char for char {
 
         let mut utf8 = [0u8, ..4];
         let amt = self.encode_utf8(utf8).unwrap_or(0);
-        let s: &str = unsafe { mem::transmute(utf8[..amt]) };
+        let s: &str = unsafe { mem::transmute(utf8.slice_to(amt)) };
         secret_string(&s, f)
     }
 }

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -18,7 +18,7 @@ use collections::Collection;
 use fmt;
 use iter::DoubleEndedIterator;
 use num::{Int, cast, zero};
-use slice::{MutableSlice};
+use slice::{ImmutableSlice, MutableSlice};
 
 /// A type that represents a specific radix
 #[doc(hidden)]
@@ -60,7 +60,7 @@ trait GenericRadix {
                 if x == zero() { break; }                 // No more digits left to accumulate.
             }
         }
-        f.pad_integral(is_positive, self.prefix(), buf[curr..])
+        f.pad_integral(is_positive, self.prefix(), buf.slice_from(curr))
     }
 }
 

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -57,9 +57,8 @@
        html_playground_url = "http://play.rust-lang.org/")]
 
 #![no_std]
-#![allow(unknown_features)]
 #![feature(globs, intrinsics, lang_items, macro_rules, managed_boxes, phase)]
-#![feature(simd, unsafe_destructor, slicing_syntax)]
+#![feature(simd, unsafe_destructor)]
 #![deny(missing_doc)]
 
 mod macros;

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -688,19 +688,19 @@ pub trait IndexMut<Index, Result> {
  * struct Foo;
  *
  * impl ::core::ops::Slice<Foo, Foo> for Foo {
- *     fn as_slice<'a>(&'a self) -> &'a Foo {
+ *     fn as_slice_<'a>(&'a self) -> &'a Foo {
  *         println!("Slicing!");
  *         self
  *     }
- *     fn slice_from<'a>(&'a self, from: &Foo) -> &'a Foo {
+ *     fn slice_from_<'a>(&'a self, from: &Foo) -> &'a Foo {
  *         println!("Slicing!");
  *         self
  *     }
- *     fn slice_to<'a>(&'a self, to: &Foo) -> &'a Foo {
+ *     fn slice_to_<'a>(&'a self, to: &Foo) -> &'a Foo {
  *         println!("Slicing!");
  *         self
  *     }
- *     fn slice<'a>(&'a self, from: &Foo, to: &Foo) -> &'a Foo {
+ *     fn slice_<'a>(&'a self, from: &Foo, to: &Foo) -> &'a Foo {
  *         println!("Slicing!");
  *         self
  *     }
@@ -711,22 +711,7 @@ pub trait IndexMut<Index, Result> {
  * }
  * ```
  */
-#[cfg(not(stage0))]
-#[lang="slice"]
-pub trait Slice<Idx, Sized? Result> for Sized? {
-    /// The method for the slicing operation foo[]
-    fn as_slice<'a>(&'a self) -> &'a Result;
-    /// The method for the slicing operation foo[from..]
-    fn slice_from<'a>(&'a self, from: &Idx) -> &'a Result;
-    /// The method for the slicing operation foo[..to]
-    fn slice_to<'a>(&'a self, to: &Idx) -> &'a Result;
-    /// The method for the slicing operation foo[from..to]
-    fn slice<'a>(&'a self, from: &Idx, to: &Idx) -> &'a Result;
-}
-/**
- *
- */
-#[cfg(stage0)]
+// FIXME(#17273) remove the postscript _s
 #[lang="slice"]
 pub trait Slice<Idx, Sized? Result> for Sized? {
     /// The method for the slicing operation foo[]
@@ -753,19 +738,19 @@ pub trait Slice<Idx, Sized? Result> for Sized? {
  * struct Foo;
  *
  * impl ::core::ops::SliceMut<Foo, Foo> for Foo {
- *     fn as_mut_slice<'a>(&'a mut self) -> &'a mut Foo {
+ *     fn as_mut_slice_<'a>(&'a mut self) -> &'a mut Foo {
  *         println!("Slicing!");
  *         self
  *     }
- *     fn slice_from_mut<'a>(&'a mut self, from: &Foo) -> &'a mut Foo {
+ *     fn slice_from_mut_<'a>(&'a mut self, from: &Foo) -> &'a mut Foo {
  *         println!("Slicing!");
  *         self
  *     }
- *     fn slice_to_mut<'a>(&'a mut self, to: &Foo) -> &'a mut Foo {
+ *     fn slice_to_mut_<'a>(&'a mut self, to: &Foo) -> &'a mut Foo {
  *         println!("Slicing!");
  *         self
  *     }
- *     fn slice_mut<'a>(&'a mut self, from: &Foo, to: &Foo) -> &'a mut Foo {
+ *     fn slice_mut_<'a>(&'a mut self, from: &Foo, to: &Foo) -> &'a mut Foo {
  *         println!("Slicing!");
  *         self
  *     }
@@ -776,22 +761,7 @@ pub trait Slice<Idx, Sized? Result> for Sized? {
  * }
  * ```
  */
-#[cfg(not(stage0))]
-#[lang="slice_mut"]
-pub trait SliceMut<Idx, Sized? Result> for Sized? {
-    /// The method for the slicing operation foo[]
-    fn as_mut_slice<'a>(&'a mut self) -> &'a mut Result;
-    /// The method for the slicing operation foo[from..]
-    fn slice_from_mut<'a>(&'a mut self, from: &Idx) -> &'a mut Result;
-    /// The method for the slicing operation foo[..to]
-    fn slice_to_mut<'a>(&'a mut self, to: &Idx) -> &'a mut Result;
-    /// The method for the slicing operation foo[from..to]
-    fn slice_mut<'a>(&'a mut self, from: &Idx, to: &Idx) -> &'a mut Result;
-}
-/**
- *
- */
-#[cfg(stage0)]
+// FIXME(#17273) remove the postscript _s
 #[lang="slice_mut"]
 pub trait SliceMut<Idx, Sized? Result> for Sized? {
     /// The method for the slicing operation foo[mut]
@@ -803,7 +773,6 @@ pub trait SliceMut<Idx, Sized? Result> for Sized? {
     /// The method for the slicing operation foo[mut from..to]
     fn slice_mut_<'a>(&'a mut self, from: &Idx, to: &Idx) -> &'a mut Result;
 }
-
 /**
  *
  * The `Deref` trait is used to specify the functionality of dereferencing

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -684,7 +684,7 @@ pub trait IndexMut<Index, Result> {
  * A trivial implementation of `Slice`. When `Foo[..Foo]` happens, it ends up
  * calling `slice_to`, and therefore, `main` prints `Slicing!`.
  *
- * ```ignore
+ * ```
  * struct Foo;
  *
  * impl ::core::ops::Slice<Foo, Foo> for Foo {
@@ -749,7 +749,7 @@ pub trait Slice<Idx, Sized? Result> for Sized? {
  * A trivial implementation of `SliceMut`. When `Foo[Foo..]` happens, it ends up
  * calling `slice_from_mut`, and therefore, `main` prints `Slicing!`.
  *
- * ```ignore
+ * ```
  * struct Foo;
  *
  * impl ::core::ops::SliceMut<Foo, Foo> for Foo {
@@ -771,7 +771,7 @@ pub trait Slice<Idx, Sized? Result> for Sized? {
  *     }
  * }
  *
- * pub fn main() {
+ * fn main() {
  *     Foo[mut Foo..];
  * }
  * ```

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -61,6 +61,32 @@ use raw::Slice as RawSlice;
 /// Extension methods for immutable slices.
 #[unstable = "may merge with other traits; region parameter may disappear"]
 pub trait ImmutableSlice<'a, T> {
+    /// Returns a subslice spanning the interval [`start`, `end`).
+    ///
+    /// Fails when the end of the new slice lies beyond the end of the
+    /// original slice (i.e. when `end > self.len()`) or when `start > end`.
+    ///
+    /// Slicing with `start` equal to `end` yields an empty slice.
+    #[unstable = "waiting on final error conventions"]
+    //fn slice(&self, start: uint, end: uint) -> &'a [T];
+
+    /// Returns a subslice from `start` to the end of the slice.
+    ///
+    /// Fails when `start` is strictly greater than the length of the original slice.
+    ///
+    /// Slicing from `self.len()` yields an empty slice.
+    #[unstable = "waiting on final error conventions"]
+    // TODO
+    //fn slice_from(&self, start: uint) -> &'a [T];
+
+    /// Returns a subslice from the start of the slice to `end`.
+    ///
+    /// Fails when `end` is strictly greater than the length of the original slice.
+    ///
+    /// Slicing to `0` yields an empty slice.
+    #[unstable = "waiting on final error conventions"]
+    //fn slice_to(&self, end: uint) -> &'a [T];
+
     /// Divides one slice into two at an index.
     ///
     /// The first will contain all indices from `[0, mid)` (excluding
@@ -418,35 +444,6 @@ impl<'a,T> ImmutableSlice<'a, T> for &'a [T] {
     }
 }
 
-#[cfg(not(stage0))]
-impl<T> ops::Slice<uint, [T]> for [T] {
-    #[inline]
-    fn as_slice<'a>(&'a self) -> &'a [T] {
-        self
-    }
-
-    #[inline]
-    fn slice_from<'a>(&'a self, start: &uint) -> &'a [T] {
-        self.slice(start, &self.len())
-    }
-
-    #[inline]
-    fn slice_to<'a>(&'a self, end: &uint) -> &'a [T] {
-        self.slice(&0, end)
-    }
-    #[inline]
-    fn slice<'a>(&'a self, start: &uint, end: &uint) -> &'a [T] {
-        assert!(*start <= *end);
-        assert!(*end <= self.len());
-        unsafe {
-            transmute(RawSlice {
-                    data: self.as_ptr().offset(*start as int),
-                    len: (*end - *start)
-                })
-        }
-    }
-}
-#[cfg(stage0)]
 impl<T> ops::Slice<uint, [T]> for [T] {
     #[inline]
     fn as_slice_<'a>(&'a self) -> &'a [T] {
@@ -474,36 +471,7 @@ impl<T> ops::Slice<uint, [T]> for [T] {
         }
     }
 }
-#[cfg(not(stage0))]
-impl<T> ops::SliceMut<uint, [T]> for [T] {
-    #[inline]
-    fn as_mut_slice<'a>(&'a mut self) -> &'a mut [T] {
-        self
-    }
 
-    #[inline]
-    fn slice_from_mut<'a>(&'a mut self, start: &uint) -> &'a mut [T] {
-        let len = &self.len();
-        self.slice_mut(start, len)
-    }
-
-    #[inline]
-    fn slice_to_mut<'a>(&'a mut self, end: &uint) -> &'a mut [T] {
-        self.slice_mut(&0, end)
-    }
-    #[inline]
-    fn slice_mut<'a>(&'a mut self, start: &uint, end: &uint) -> &'a mut [T] {
-        assert!(*start <= *end);
-        assert!(*end <= self.len());
-        unsafe {
-            transmute(RawSlice {
-                    data: self.as_ptr().offset(*start as int),
-                    len: (*end - *start)
-                })
-        }
-    }
-}
-#[cfg(stage0)]
 impl<T> ops::SliceMut<uint, [T]> for [T] {
     #[inline]
     fn as_mut_slice_<'a>(&'a mut self) -> &'a mut [T] {
@@ -545,6 +513,49 @@ pub trait MutableSlice<'a, T> {
     /// Primarily intended for getting a &mut [T] from a [T, ..N].
     #[deprecated = "use slicing syntax"]
     fn as_mut_slice(self) -> &'a mut [T];
+
+    /// Deprecated: use `slice_mut`.
+    #[deprecated = "use slicing syntax"]
+    //fn mut_slice(self, start: uint, end: uint) -> &'a mut [T] {
+    //    self[mut start..end]
+    //}
+
+    /// Returns a mutable subslice spanning the interval [`start`, `end`).
+    ///
+    /// Fails when the end of the new slice lies beyond the end of the
+    /// original slice (i.e. when `end > self.len()`) or when `start > end`.
+    ///
+    /// Slicing with `start` equal to `end` yields an empty slice.
+    #[unstable = "waiting on final error conventions"]
+    //fn slice_mut(self, start: uint, end: uint) -> &'a mut [T];
+
+    /// Deprecated: use `slicing syntax`.
+    #[deprecated = "use slicing syntax"]
+    //fn mut_slice_from(self, start: uint) -> &'a mut [T] {
+    //    self[mut start..]
+    //}
+
+    /// Returns a mutable subslice from `start` to the end of the slice.
+    ///
+    /// Fails when `start` is strictly greater than the length of the original slice.
+    ///
+    /// Slicing from `self.len()` yields an empty slice.
+    #[unstable = "waiting on final error conventions"]
+    //fn slice_from_mut(self, start: uint) -> &'a mut [T];
+
+    /// Deprecated: use `slicing syntax`.
+    #[deprecated = "use slicing syntax"]
+    //fn mut_slice_to(self, end: uint) -> &'a mut [T] {
+    //    self[mut ..end]
+    //}
+
+    /// Returns a mutable subslice from the start of the slice to `end`.
+    ///
+    /// Fails when `end` is strictly greater than the length of the original slice.
+    ///
+    /// Slicing to `0` yields an empty slice.
+    #[unstable = "waiting on final error conventions"]
+    //fn slice_to_mut(self, end: uint) -> &'a mut [T];
 
     /// Deprecated: use `iter_mut`.
     #[deprecated = "use iter_mut"]

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -814,13 +814,13 @@ impl<'a,T> MutableSlice<'a, T> for &'a mut [T] {
     #[inline]
     fn tail_mut(self) -> &'a mut [T] {
         let len = self.len();
-        self[mut 1..len]
+        self.slice_mut(1, len)
     }
 
     #[inline]
     fn init_mut(self) -> &'a mut [T] {
         let len = self.len();
-        self[mut 0..len - 1]
+        self.slice_mut(0, len - 1)
     }
 
     #[inline]

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -152,7 +152,7 @@ pub trait ImmutableSlice<'a, T> {
     fn tail(&self) -> &'a [T];
 
     /// Returns all but the first `n' elements of a slice.
-    #[deprecated = "use slice_from"]
+    #[deprecated = "use slicing syntax"]
     fn tailn(&self, n: uint) -> &'a [T];
 
     /// Returns all but the last element of a slice.
@@ -161,6 +161,7 @@ pub trait ImmutableSlice<'a, T> {
 
     /// Returns all but the last `n' elements of a slice.
     #[deprecated = "use slice_to but note the arguments are different"]
+    #[deprecated = "use slicing syntax, but note the arguments are different"]
     fn initn(&self, n: uint) -> &'a [T];
 
     /// Returns the last element of a slice, or `None` if it is empty.
@@ -320,7 +321,7 @@ impl<'a,T> ImmutableSlice<'a, T> for &'a [T] {
     fn tail(&self) -> &'a [T] { (*self)[1..] }
 
     #[inline]
-    #[deprecated = "use slice_from"]
+    #[deprecated = "use slicing syntax"]
     fn tailn(&self, n: uint) -> &'a [T] { (*self)[n..] }
 
     #[inline]
@@ -329,7 +330,7 @@ impl<'a,T> ImmutableSlice<'a, T> for &'a [T] {
     }
 
     #[inline]
-    #[deprecated = "use slice_to but note the arguments are different"]
+    #[deprecated = "use slicing syntax but note the arguments are different"]
     fn initn(&self, n: uint) -> &'a [T] {
         (*self)[..self.len() - n]
     }
@@ -542,6 +543,7 @@ pub trait MutableSlice<'a, T> {
     fn get_mut(self, index: uint) -> Option<&'a mut T>;
     /// Work with `self` as a mut slice.
     /// Primarily intended for getting a &mut [T] from a [T, ..N].
+    #[deprecated = "use slicing syntax"]
     fn as_mut_slice(self) -> &'a mut [T];
 
     /// Deprecated: use `iter_mut`.

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -30,7 +30,7 @@ use iter::range;
 use num::{CheckedMul, Saturating};
 use option::{Option, None, Some};
 use raw::Repr;
-use slice::ImmutableSlice;
+use slice::{ImmutableSlice, MutableSlice};
 use slice;
 use uint;
 
@@ -393,7 +393,7 @@ impl NaiveSearcher {
 
     fn next(&mut self, haystack: &[u8], needle: &[u8]) -> Option<(uint, uint)> {
         while self.position + needle.len() <= haystack.len() {
-            if haystack[self.position .. self.position + needle.len()] == needle {
+            if haystack.slice(self.position, self.position + needle.len()) == needle {
                 let match_pos = self.position;
                 self.position += needle.len(); // add 1 for all matches
                 return Some((match_pos, match_pos + needle.len()));
@@ -514,10 +514,10 @@ impl TwoWaySearcher {
         //
         // What's going on is we have some critical factorization (u, v) of the
         // needle, and we want to determine whether u is a suffix of
-        // v[..period]. If it is, we use "Algorithm CP1". Otherwise we use
+        // v.slice_to(period). If it is, we use "Algorithm CP1". Otherwise we use
         // "Algorithm CP2", which is optimized for when the period of the needle
         // is large.
-        if needle[..crit_pos] == needle[period.. period + crit_pos] {
+        if needle.slice_to(crit_pos) == needle.slice(period, period + crit_pos) {
             TwoWaySearcher {
                 crit_pos: crit_pos,
                 period: period,
@@ -741,7 +741,7 @@ impl<'a> Iterator<u16> for Utf16CodeUnits<'a> {
 
         let mut buf = [0u16, ..2];
         self.chars.next().map(|ch| {
-            let n = ch.encode_utf16(buf[mut]).unwrap_or(0);
+            let n = ch.encode_utf16(buf.as_mut_slice()).unwrap_or(0);
             if n == 2 { self.extra = buf[1]; }
             buf[0]
         })
@@ -1007,7 +1007,7 @@ pub fn utf16_items<'a>(v: &'a [u16]) -> Utf16Items<'a> {
 pub fn truncate_utf16_at_nul<'a>(v: &'a [u16]) -> &'a [u16] {
     match v.iter().position(|c| *c == 0) {
         // don't include the 0
-        Some(i) => v[..i],
+        Some(i) => v.slice_to(i),
         None => v
     }
 }
@@ -1994,13 +1994,13 @@ impl<'a> StrSlice<'a> for &'a str {
     #[inline]
     fn starts_with<'a>(&self, needle: &'a str) -> bool {
         let n = needle.len();
-        self.len() >= n && needle.as_bytes() == self.as_bytes()[..n]
+        self.len() >= n && needle.as_bytes() == self.as_bytes().slice_to(n)
     }
 
     #[inline]
     fn ends_with(&self, needle: &str) -> bool {
         let (m, n) = (self.len(), needle.len());
-        m >= n && needle.as_bytes() == self.as_bytes()[m-n..]
+        m >= n && needle.as_bytes() == self.as_bytes().slice_from(m - n)
     }
 
     #[inline]

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1164,7 +1164,6 @@ pub mod traits {
         fn equiv(&self, other: &S) -> bool { eq_slice(*self, other.as_slice()) }
     }
 
-    #[cfg(stage0)]
     impl ops::Slice<uint, str> for str {
         #[inline]
         fn as_slice_<'a>(&'a self) -> &'a str {
@@ -1173,39 +1172,17 @@ pub mod traits {
 
         #[inline]
         fn slice_from_<'a>(&'a self, from: &uint) -> &'a str {
-            super::slice_from_impl(&self, *from)
+            self.slice_from(*from)
         }
 
         #[inline]
         fn slice_to_<'a>(&'a self, to: &uint) -> &'a str {
-            super::slice_to_impl(&self, *to)
+            self.slice_to(*to)
         }
 
         #[inline]
         fn slice_<'a>(&'a self, from: &uint, to: &uint) -> &'a str {
-            super::slice_impl(&self, *from, *to)
-        }
-    }
-    #[cfg(not(stage0))]
-    impl ops::Slice<uint, str> for str {
-        #[inline]
-        fn as_slice<'a>(&'a self) -> &'a str {
-            self
-        }
-
-        #[inline]
-        fn slice_from<'a>(&'a self, from: &uint) -> &'a str {
-            super::slice_from_impl(&self, *from)
-        }
-
-        #[inline]
-        fn slice_to<'a>(&'a self, to: &uint) -> &'a str {
-            super::slice_to_impl(&self, *to)
-        }
-
-        #[inline]
-        fn slice<'a>(&'a self, from: &uint, to: &uint) -> &'a str {
-            super::slice_impl(&self, *from, *to)
+            self.slice(*from, *to)
         }
     }
 }
@@ -1858,38 +1835,6 @@ fn slice_error_fail(s: &str, begin: uint, end: uint) -> ! {
           begin, end, s);
 }
 
-#[inline]
-fn slice_impl<'a>(this: &&'a str, begin: uint, end: uint) -> &'a str {
-    // is_char_boundary checks that the index is in [0, .len()]
-    if begin <= end &&
-       this.is_char_boundary(begin) &&
-       this.is_char_boundary(end) {
-        unsafe { raw::slice_unchecked(*this, begin, end) }
-    } else {
-        slice_error_fail(*this, begin, end)
-    }
-}
-
-#[inline]
-fn slice_from_impl<'a>(this: &&'a str, begin: uint) -> &'a str {
-    // is_char_boundary checks that the index is in [0, .len()]
-    if this.is_char_boundary(begin) {
-        unsafe { raw::slice_unchecked(*this, begin, this.len()) }
-    } else {
-        slice_error_fail(*this, begin, this.len())
-    }
-}
-
-#[inline]
-fn slice_to_impl<'a>(this: &&'a str, end: uint) -> &'a str {
-    // is_char_boundary checks that the index is in [0, .len()]
-    if this.is_char_boundary(end) {
-        unsafe { raw::slice_unchecked(*this, 0, end) }
-    } else {
-        slice_error_fail(*this, 0, end)
-    }
-}
-
 impl<'a> StrSlice<'a> for &'a str {
     #[inline]
     fn contains<'a>(&self, needle: &'a str) -> bool {
@@ -1993,17 +1938,34 @@ impl<'a> StrSlice<'a> for &'a str {
 
     #[inline]
     fn slice(&self, begin: uint, end: uint) -> &'a str {
-        slice_impl(self, begin, end)
+        // is_char_boundary checks that the index is in [0, .len()]
+        if begin <= end &&
+           self.is_char_boundary(begin) &&
+           self.is_char_boundary(end) {
+            unsafe { raw::slice_unchecked(*self, begin, end) }
+        } else {
+            slice_error_fail(*self, begin, end)
+        }
     }
 
     #[inline]
     fn slice_from(&self, begin: uint) -> &'a str {
-        slice_from_impl(self, begin)
+        // is_char_boundary checks that the index is in [0, .len()]
+        if self.is_char_boundary(begin) {
+            unsafe { raw::slice_unchecked(*self, begin, self.len()) }
+        } else {
+            slice_error_fail(*self, begin, self.len())
+        }
     }
 
     #[inline]
     fn slice_to(&self, end: uint) -> &'a str {
-        slice_to_impl(self, end)
+        // is_char_boundary checks that the index is in [0, .len()]
+        if self.is_char_boundary(end) {
+            unsafe { raw::slice_unchecked(*self, 0, end) }
+        } else {
+            slice_error_fail(*self, 0, end)
+        }
     }
 
     fn slice_chars(&self, begin: uint, end: uint) -> &'a str {

--- a/src/libcoretest/char.rs
+++ b/src/libcoretest/char.rs
@@ -174,7 +174,7 @@ fn test_encode_utf8() {
     fn check(input: char, expect: &[u8]) {
         let mut buf = [0u8, ..4];
         let n = input.encode_utf8(buf.as_mut_slice()).unwrap_or(0);
-        assert_eq!(buf[..n], expect);
+        assert_eq!(buf.slice_to(n), expect);
     }
 
     check('x', [0x78]);
@@ -188,7 +188,7 @@ fn test_encode_utf16() {
     fn check(input: char, expect: &[u16]) {
         let mut buf = [0u16, ..2];
         let n = input.encode_utf16(buf.as_mut_slice()).unwrap_or(0);
-        assert_eq!(buf[..n], expect);
+        assert_eq!(buf.slice_to(n), expect);
     }
 
     check('x', [0x0078]);

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -13,7 +13,6 @@ use core::iter::order::*;
 use core::uint;
 use core::cmp;
 use core::num;
-use core::ops::Slice;
 
 use test::Bencher;
 
@@ -229,7 +228,7 @@ fn test_inspect() {
                .collect::<Vec<uint>>();
 
     assert_eq!(n, xs.len());
-    assert_eq!(xs[], ys[]);
+    assert_eq!(xs.as_slice(), ys.as_slice());
 }
 
 #[test]
@@ -269,7 +268,7 @@ fn test_cycle() {
 
 #[test]
 fn test_iterator_nth() {
-    let v: &[_] = &[0i, 1, 2, 3, 4];
+    let v = &[0i, 1, 2, 3, 4];
     for i in range(0u, v.len()) {
         assert_eq!(v.iter().nth(i).unwrap(), &v[i]);
     }
@@ -278,55 +277,55 @@ fn test_iterator_nth() {
 
 #[test]
 fn test_iterator_last() {
-    let v: &[_] = &[0i, 1, 2, 3, 4];
+    let v = &[0i, 1, 2, 3, 4];
     assert_eq!(v.iter().last().unwrap(), &4);
-    assert_eq!(v[0..1].iter().last().unwrap(), &0);
+    assert_eq!(v.slice(0, 1).iter().last().unwrap(), &0);
 }
 
 #[test]
 fn test_iterator_len() {
-    let v: &[_] = &[0i, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    assert_eq!(v[0..4].iter().count(), 4);
-    assert_eq!(v[0..10].iter().count(), 10);
-    assert_eq!(v[0..0].iter().count(), 0);
+    let v = &[0i, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    assert_eq!(v.slice(0, 4).iter().count(), 4);
+    assert_eq!(v.slice(0, 10).iter().count(), 10);
+    assert_eq!(v.slice(0, 0).iter().count(), 0);
 }
 
 #[test]
 fn test_iterator_sum() {
-    let v: &[_] = &[0i, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    assert_eq!(v[0..4].iter().map(|&x| x).sum(), 6);
+    let v = &[0i, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    assert_eq!(v.slice(0, 4).iter().map(|&x| x).sum(), 6);
     assert_eq!(v.iter().map(|&x| x).sum(), 55);
-    assert_eq!(v[0..0].iter().map(|&x| x).sum(), 0);
+    assert_eq!(v.slice(0, 0).iter().map(|&x| x).sum(), 0);
 }
 
 #[test]
 fn test_iterator_product() {
-    let v: &[_] = &[0i, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    assert_eq!(v[0..4].iter().map(|&x| x).product(), 0);
-    assert_eq!(v[1..5].iter().map(|&x| x).product(), 24);
-    assert_eq!(v[0..0].iter().map(|&x| x).product(), 1);
+    let v = &[0i, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    assert_eq!(v.slice(0, 4).iter().map(|&x| x).product(), 0);
+    assert_eq!(v.slice(1, 5).iter().map(|&x| x).product(), 24);
+    assert_eq!(v.slice(0, 0).iter().map(|&x| x).product(), 1);
 }
 
 #[test]
 fn test_iterator_max() {
-    let v: &[_] = &[0i, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    assert_eq!(v[0..4].iter().map(|&x| x).max(), Some(3));
+    let v = &[0i, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    assert_eq!(v.slice(0, 4).iter().map(|&x| x).max(), Some(3));
     assert_eq!(v.iter().map(|&x| x).max(), Some(10));
-    assert_eq!(v[0..0].iter().map(|&x| x).max(), None);
+    assert_eq!(v.slice(0, 0).iter().map(|&x| x).max(), None);
 }
 
 #[test]
 fn test_iterator_min() {
-    let v: &[_] = &[0i, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    assert_eq!(v[0..4].iter().map(|&x| x).min(), Some(0));
+    let v = &[0i, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    assert_eq!(v.slice(0, 4).iter().map(|&x| x).min(), Some(0));
     assert_eq!(v.iter().map(|&x| x).min(), Some(0));
-    assert_eq!(v[0..0].iter().map(|&x| x).min(), None);
+    assert_eq!(v.slice(0, 0).iter().map(|&x| x).min(), None);
 }
 
 #[test]
 fn test_iterator_size_hint() {
     let c = count(0i, 1);
-    let v: &[_] = &[0i, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    let v = &[0i, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     let v2 = &[10i, 11, 12];
     let vi = v.iter();
 
@@ -373,7 +372,7 @@ fn test_all() {
     assert!(v.iter().all(|&x| x < 10));
     assert!(!v.iter().all(|&x| x % 2 == 0));
     assert!(!v.iter().all(|&x| x > 100));
-    assert!(v.slice_(&0, &0).iter().all(|_| fail!()));
+    assert!(v.slice(0, 0).iter().all(|_| fail!()));
 }
 
 #[test]
@@ -382,7 +381,7 @@ fn test_any() {
     assert!(v.iter().any(|&x| x < 10));
     assert!(v.iter().any(|&x| x % 2 == 0));
     assert!(!v.iter().any(|&x| x > 100));
-    assert!(!v.slice_(&0, &0).iter().any(|_| fail!()));
+    assert!(!v.slice(0, 0).iter().any(|_| fail!()));
 }
 
 #[test]
@@ -567,7 +566,7 @@ fn check_randacc_iter<A: PartialEq, T: Clone + RandomAccessIterator<A>>(a: T, le
 fn test_double_ended_flat_map() {
     let u = [0u,1];
     let v = [5u,6,7,8];
-    let mut it = u.iter().flat_map(|x| v[*x..v.len()].iter());
+    let mut it = u.iter().flat_map(|x| v.slice(*x, v.len()).iter());
     assert_eq!(it.next_back().unwrap(), &8);
     assert_eq!(it.next().unwrap(),      &5);
     assert_eq!(it.next_back().unwrap(), &7);

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -373,7 +373,7 @@ fn test_all() {
     assert!(v.iter().all(|&x| x < 10));
     assert!(!v.iter().all(|&x| x % 2 == 0));
     assert!(!v.iter().all(|&x| x > 100));
-    assert!(v.slice(&0, &0).iter().all(|_| fail!()));
+    assert!(v.slice_(&0, &0).iter().all(|_| fail!()));
 }
 
 #[test]
@@ -382,7 +382,7 @@ fn test_any() {
     assert!(v.iter().any(|&x| x < 10));
     assert!(v.iter().any(|&x| x % 2 == 0));
     assert!(!v.iter().any(|&x| x > 100));
-    assert!(!v.slice(&0, &0).iter().any(|_| fail!()));
+    assert!(!v.slice_(&0, &0).iter().any(|_| fail!()));
 }
 
 #[test]

--- a/src/libcoretest/lib.rs
+++ b/src/libcoretest/lib.rs
@@ -7,7 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(globs, unsafe_destructor, macro_rules, slicing_syntax)]
+#![feature(globs, unsafe_destructor, macro_rules)]
 
 extern crate core;
 extern crate test;

--- a/src/libnative/io/net.rs
+++ b/src/libnative/io/net.rs
@@ -1012,7 +1012,7 @@ pub fn write<T>(fd: sock_t,
             // Also as with read(), we use MSG_DONTWAIT to guard ourselves
             // against unforeseen circumstances.
             let _guard = lock();
-            let ptr = buf[written..].as_ptr();
+            let ptr = buf.slice_from(written).as_ptr();
             let len = buf.len() - written;
             match retry(|| write(deadline.is_some(), ptr, len)) {
                 -1 if util::wouldblock() => {}

--- a/src/libnative/io/pipe_windows.rs
+++ b/src/libnative/io/pipe_windows.rs
@@ -448,7 +448,7 @@ impl rtio::RtioPipe for UnixStream {
             }
             let ret = unsafe {
                 libc::WriteFile(self.handle(),
-                                buf[offset..].as_ptr() as libc::LPVOID,
+                                buf.slice_from(offset).as_ptr() as libc::LPVOID,
                                 (buf.len() - offset) as libc::DWORD,
                                 &mut bytes_written,
                                 &mut overlapped)

--- a/src/libnative/lib.rs
+++ b/src/libnative/lib.rs
@@ -57,8 +57,7 @@
 
 #![deny(unused_result, unused_must_use)]
 #![allow(non_camel_case_types, deprecated)]
-#![allow(unknown_features)]
-#![feature(default_type_params, lang_items, slicing_syntax)]
+#![feature(default_type_params, lang_items)]
 
 // NB this crate explicitly does *not* allow glob imports, please seriously
 //    consider whether they're needed before adding that feature here (the

--- a/src/libnum/bigint.rs
+++ b/src/libnum/bigint.rs
@@ -735,7 +735,7 @@ impl BigUint {
         let mut power: BigUint  = One::one();
         loop {
             let start = cmp::max(end, unit_len) - unit_len;
-            match uint::parse_bytes(buf[start..end], radix) {
+            match uint::parse_bytes(buf.slice(start, end), radix) {
                 Some(d) => {
                     let d: Option<BigUint> = FromPrimitive::from_uint(d);
                     match d {
@@ -1406,7 +1406,7 @@ impl BigInt {
             sign  = Minus;
             start = 1;
         }
-        return BigUint::parse_bytes(buf[start..], radix)
+        return BigUint::parse_bytes(buf.slice(start, buf.len()), radix)
             .map(|bu| BigInt::from_biguint(sign, bu));
     }
 

--- a/src/libnum/lib.rs
+++ b/src/libnum/lib.rs
@@ -43,8 +43,7 @@
 //!
 //! [newt]: https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method
 
-#![allow(unknown_features)]
-#![feature(macro_rules, slicing_syntax)]
+#![feature(macro_rules)]
 #![feature(default_type_params)]
 
 #![crate_name = "num"]

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -228,7 +228,7 @@ pub trait Rng {
     /// let choices = [1i, 2, 4, 8, 16, 32];
     /// let mut rng = task_rng();
     /// println!("{}", rng.choose(choices));
-    /// assert_eq!(rng.choose(choices[..0]), None);
+    /// assert_eq!(rng.choose(choices.slice_to(0)), None);
     /// ```
     fn choose<'a, T>(&mut self, values: &'a [T]) -> Option<&'a T> {
         if values.is_empty() {

--- a/src/librbml/io.rs
+++ b/src/librbml/io.rs
@@ -94,7 +94,7 @@ impl Writer for SeekableMemWriter {
             // there (left), and what will be appended on the end (right)
             let cap = self.buf.len() - self.pos;
             let (left, right) = if cap <= buf.len() {
-                (buf[..cap], buf[cap..])
+                (buf.slice_to(cap), buf.slice_from(cap))
             } else {
                 let result: (_, &[_]) = (buf, &[]);
                 result
@@ -102,7 +102,7 @@ impl Writer for SeekableMemWriter {
 
             // Do the necessary writes
             if left.len() > 0 {
-                slice::bytes::copy_memory(self.buf[mut self.pos..], left);
+                slice::bytes::copy_memory(self.buf.slice_from_mut(self.pos), left);
             }
             if right.len() > 0 {
                 self.buf.push_all(right);

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -54,7 +54,7 @@ impl<'doc> Doc<'doc> {
     }
 
     pub fn as_str_slice<'a>(&'a self) -> &'a str {
-        str::from_utf8(self.data[self.start..self.end]).unwrap()
+        str::from_utf8(self.data.slice(self.start, self.end)).unwrap()
     }
 
     pub fn as_str(&self) -> String {
@@ -280,7 +280,7 @@ pub mod reader {
     }
 
     pub fn with_doc_data<'a, T>(d: Doc<'a>, f: |x: &'a [u8]| -> T) -> T {
-        f(d.data[d.start..d.end])
+        f(d.data.slice(d.start, d.end))
     }
 
 

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -24,8 +24,7 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/master/",
        html_playground_url = "http://play.rust-lang.org/")]
-#![allow(unknown_features)]
-#![feature(macro_rules, phase, slicing_syntax)]
+#![feature(macro_rules, phase)]
 #![allow(missing_doc)]
 
 extern crate serialize;

--- a/src/libregex/compile.rs
+++ b/src/libregex/compile.rs
@@ -102,7 +102,7 @@ impl Program {
         // This is a bit hacky since we have to skip over the initial
         // 'Save' instruction.
         let mut pre = String::with_capacity(5);
-        for inst in c.insts[1..].iter() {
+        for inst in c.insts.slice_from(1).iter() {
             match *inst {
                 OneChar(c, FLAG_EMPTY) => pre.push(c),
                 _ => break

--- a/src/libregex/lib.rs
+++ b/src/libregex/lib.rs
@@ -368,8 +368,7 @@
        html_root_url = "http://doc.rust-lang.org/master/",
        html_playground_url = "http://play.rust-lang.org/")]
 
-#![allow(unknown_features)]
-#![feature(macro_rules, phase, slicing_syntax)]
+#![feature(macro_rules, phase)]
 #![deny(missing_doc)]
 
 #[cfg(test)]

--- a/src/libregex/parse.rs
+++ b/src/libregex/parse.rs
@@ -511,7 +511,7 @@ impl<'a> Parser<'a> {
         self.chari = closer;
         let greed = try!(self.get_next_greedy());
         let inner = String::from_chars(
-            self.chars[start+1..closer]);
+            self.chars.as_slice().slice(start + 1, closer));
 
         // Parse the min and max values from the regex.
         let (mut min, mut max): (uint, Option<uint>);
@@ -944,7 +944,7 @@ impl<'a> Parser<'a> {
     }
 
     fn slice(&self, start: uint, end: uint) -> String {
-        String::from_chars(self.chars[start..end])
+        String::from_chars(self.chars.as_slice().slice(start, end))
     }
 }
 

--- a/src/libregex/test/tests.rs
+++ b/src/libregex/test/tests.rs
@@ -130,7 +130,7 @@ macro_rules! mat(
             // actual capture groups to match test set.
             let (sexpect, mut sgot) = (expected.as_slice(), got.as_slice());
             if sgot.len() > sexpect.len() {
-                sgot = sgot[0..sexpect.len()]
+                sgot = sgot.slice(0, sexpect.len())
             }
             if sexpect != sgot {
                 fail!("For RE '{}' against '{}', expected '{}' but got '{}'",

--- a/src/libregex/vm.rs
+++ b/src/libregex/vm.rs
@@ -145,7 +145,7 @@ impl<'r, 't> Nfa<'r, 't> {
                 // out early.
                 if self.prog.prefix.len() > 0 && clist.size == 0 {
                     let needle = self.prog.prefix.as_slice().as_bytes();
-                    let haystack = self.input.as_bytes()[self.ic..];
+                    let haystack = self.input.as_bytes().slice_from(self.ic);
                     match find_prefix(needle, haystack) {
                         None => break,
                         Some(i) => {

--- a/src/libregex_macros/lib.rs
+++ b/src/libregex_macros/lib.rs
@@ -550,7 +550,7 @@ fn exec<'t>(which: ::regex::native::MatchKind, input: &'t str,
         } else {
             quote_expr!(self.cx,
                 if clist.size == 0 {
-                    let haystack = self.input.as_bytes()[self.ic..];
+                    let haystack = self.input.as_bytes().slice_from(self.ic);
                     match find_prefix(prefix_bytes, haystack) {
                         None => break,
                         Some(i) => {

--- a/src/librustc/back/lto.rs
+++ b/src/librustc/back/lto.rs
@@ -89,9 +89,9 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
                     if version == 1 {
                         // The only version existing so far
                         let data_size = extract_compressed_bytecode_size_v1(bc_encoded);
-                        let compressed_data = bc_encoded[
-                            link::RLIB_BYTECODE_OBJECT_V1_DATA_OFFSET..
-                            link::RLIB_BYTECODE_OBJECT_V1_DATA_OFFSET + data_size as uint];
+                        let compressed_data = bc_encoded.slice(
+                            link::RLIB_BYTECODE_OBJECT_V1_DATA_OFFSET,
+                            link::RLIB_BYTECODE_OBJECT_V1_DATA_OFFSET + data_size as uint);
 
                         match flate::inflate_bytes(compressed_data) {
                             Some(inflated) => inflated,
@@ -188,7 +188,7 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
 fn is_versioned_bytecode_format(bc: &[u8]) -> bool {
     let magic_id_byte_count = link::RLIB_BYTECODE_OBJECT_MAGIC.len();
     return bc.len() > magic_id_byte_count &&
-           bc[..magic_id_byte_count] == link::RLIB_BYTECODE_OBJECT_MAGIC;
+           bc.slice(0, magic_id_byte_count) == link::RLIB_BYTECODE_OBJECT_MAGIC;
 }
 
 fn extract_bytecode_format_version(bc: &[u8]) -> u32 {
@@ -200,8 +200,8 @@ fn extract_compressed_bytecode_size_v1(bc: &[u8]) -> u64 {
 }
 
 fn read_from_le_bytes<T: Int>(bytes: &[u8], position_in_bytes: uint) -> T {
-    let byte_data = bytes[position_in_bytes..
-                          position_in_bytes + mem::size_of::<T>()];
+    let byte_data = bytes.slice(position_in_bytes,
+                                position_in_bytes + mem::size_of::<T>());
     let data = unsafe {
         *(byte_data.as_ptr() as *const T)
     };

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -29,9 +29,8 @@ This API is completely unstable and subject to change.
       html_root_url = "http://doc.rust-lang.org/master/")]
 
 #![allow(deprecated)]
-#![allow(unknown_features)]
 #![feature(macro_rules, globs, struct_variant, quote)]
-#![feature(default_type_params, phase, unsafe_destructor, slicing_syntax)]
+#![feature(default_type_params, phase, unsafe_destructor)]
 
 #![feature(rustc_diagnostic_macros)]
 #![feature(import_shadowing)]

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -70,7 +70,7 @@ fn lookup_hash<'a>(d: rbml::Doc<'a>, eq_fn: |&[u8]| -> bool,
     let mut ret = None;
     reader::tagged_docs(tagged_doc.doc, belt, |elt| {
         let pos = u64_from_be_bytes(elt.data, elt.start, 4) as uint;
-        if eq_fn(elt.data[elt.start + 4 .. elt.end]) {
+        if eq_fn(elt.data.slice(elt.start + 4, elt.end)) {
             ret = Some(reader::doc_at(d.data, pos).unwrap().doc);
             false
         } else {
@@ -84,7 +84,7 @@ pub fn maybe_find_item<'a>(item_id: ast::NodeId,
                            items: rbml::Doc<'a>) -> Option<rbml::Doc<'a>> {
     fn eq_item(bytes: &[u8], item_id: ast::NodeId) -> bool {
         return u64_from_be_bytes(
-            bytes[0u..4u], 0u, 4u) as ast::NodeId
+            bytes.slice(0u, 4u), 0u, 4u) as ast::NodeId
             == item_id;
     }
     lookup_hash(items,

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -91,7 +91,7 @@ fn scan<R>(st: &mut PState, is_last: |char| -> bool, op: |&[u8]| -> R) -> R {
     }
     let end_pos = st.pos;
     st.pos += 1;
-    return op(st.data[start_pos..end_pos]);
+    return op(st.data.slice(start_pos, end_pos));
 }
 
 pub fn parse_ident(st: &mut PState, last: char) -> ast::Ident {
@@ -599,8 +599,8 @@ pub fn parse_def_id(buf: &[u8]) -> ast::DefId {
         fail!();
     }
 
-    let crate_part = buf[0u..colon_idx];
-    let def_part = buf[colon_idx + 1u..len];
+    let crate_part = buf.slice(0u, colon_idx);
+    let def_part = buf.slice(colon_idx + 1u, len);
 
     let crate_num = match uint::parse_bytes(crate_part, 10u) {
        Some(cn) => cn as ast::CrateNum,

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -870,7 +870,7 @@ pub fn specialize<'a>(cx: &MatchCheckCtxt, r: &[&'a Pat],
             None
         }
     };
-    head.map(|head| head.append(r[..col]).append(r[col + 1..]))
+    head.map(|head| head.append(r.slice_to(col)).append(r.slice_from(col + 1)))
 }
 
 fn check_local(cx: &mut MatchCheckCtxt, loc: &Local) {

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -4014,7 +4014,7 @@ impl<'a> Resolver<'a> {
         for (i, rib) in ribs.iter().enumerate().rev() {
             match rib.bindings.find_copy(&name) {
                 Some(def_like) => {
-                    return self.upvarify(ribs[i + 1..], def_like, span);
+                    return self.upvarify(ribs.slice_from(i + 1), def_like, span);
                 }
                 None => {
                     // Continue.

--- a/src/librustc/middle/save/mod.rs
+++ b/src/librustc/middle/save/mod.rs
@@ -193,7 +193,7 @@ impl <'l, 'tcx> DxrVisitor<'l, 'tcx> {
         if len <= 2 {
             return;
         }
-        let sub_paths = sub_paths[..len-2];
+        let sub_paths = sub_paths.slice(0, len-2);
         for &(ref span, ref qualname) in sub_paths.iter() {
             self.fmt.sub_mod_ref_str(path.span,
                                      *span,

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -473,7 +473,7 @@ fn enter_default<'a, 'p, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     // Collect all of the matches that can match against anything.
     enter_match(bcx, dm, m, col, val, |pats| {
         if pat_is_binding_or_wild(dm, &*pats[col]) {
-            Some(Vec::from_slice(pats[..col]).append(pats[col + 1..]))
+            Some(Vec::from_slice(pats.slice_to(col)).append(pats.slice_from(col + 1)))
         } else {
             None
         }
@@ -949,7 +949,7 @@ fn compile_submatch<'a, 'p, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                 bcx = compile_guard(bcx,
                                     &**guard_expr,
                                     m[0].data,
-                                    m[1..m.len()],
+                                    m.slice(1, m.len()),
                                     vals,
                                     chk,
                                     has_genuine_default);
@@ -988,7 +988,7 @@ fn compile_submatch_continue<'a, 'p, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
     let tcx = bcx.tcx();
     let dm = &tcx.def_map;
 
-    let vals_left = Vec::from_slice(vals[0u..col]).append(vals[col + 1u..vals.len()]);
+    let vals_left = Vec::from_slice(vals.slice(0u, col)).append(vals.slice(col + 1u, vals.len()));
     let ccx = bcx.fcx.ccx;
 
     // Find a real id (we're adding placeholder wildcard patterns, but

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -550,7 +550,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             for (small_vec_e, &ix) in small_vec.iter_mut().zip(ixs.iter()) {
                 *small_vec_e = C_i32(self.ccx, ix as i32);
             }
-            self.inbounds_gep(base, small_vec[..ixs.len()])
+            self.inbounds_gep(base, small_vec.slice(0, ixs.len()))
         } else {
             let v = ixs.iter().map(|i| C_i32(self.ccx, *i as i32)).collect::<Vec<ValueRef>>();
             self.count_insn("gepi");

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -931,7 +931,7 @@ pub fn create_captured_var_metadata(bcx: Block,
 
     let variable_access = IndirectVariable {
         alloca: env_pointer,
-        address_operations: address_operations[..address_op_count]
+        address_operations: address_operations.slice_to(address_op_count)
     };
 
     declare_local(bcx,

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -330,7 +330,7 @@ fn ast_path_substs<'tcx,AC,RS>(
         }
     }
 
-    for param in ty_param_defs[supplied_ty_param_count..].iter() {
+    for param in ty_param_defs.slice_from(supplied_ty_param_count).iter() {
         match param.default {
             Some(default) => {
                 // This is a default type parameter.

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3032,7 +3032,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         };
 
         // Call the generic checker.
-        let args: Vec<_> = args[1..].iter().map(|x| x).collect();
+        let args: Vec<_> = args.slice_from(1).iter().map(|x| x).collect();
         let ret_ty = check_method_argument_types(fcx,
                                                  method_name.span,
                                                  fn_ty,

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2271,10 +2271,10 @@ fn try_overloaded_slice(fcx: &FnCtxt,
         match fcx.tcx().lang_items.slice_mut_trait() {
             Some(trait_did) => {
                 let method_name = match (start_expr, end_expr) {
-                    (&Some(_), &Some(_)) => "slice_mut",
-                    (&Some(_), &None) => "slice_from_mut",
-                    (&None, &Some(_)) => "slice_to_mut",
-                    (&None, &None) => "as_mut_slice",
+                    (&Some(_), &Some(_)) => "slice_mut_",
+                    (&Some(_), &None) => "slice_from_mut_",
+                    (&None, &Some(_)) => "slice_to_mut_",
+                    (&None, &None) => "as_mut_slice_",
                 };
 
                 method::lookup_in_trait(fcx,
@@ -2296,10 +2296,10 @@ fn try_overloaded_slice(fcx: &FnCtxt,
         match fcx.tcx().lang_items.slice_trait() {
             Some(trait_did) => {
                 let method_name = match (start_expr, end_expr) {
-                    (&Some(_), &Some(_)) => "slice",
-                    (&Some(_), &None) => "slice_from",
-                    (&None, &Some(_)) => "slice_to",
-                    (&None, &None) => "as_slice",
+                    (&Some(_), &Some(_)) => "slice_",
+                    (&Some(_), &None) => "slice_from_",
+                    (&None, &Some(_)) => "slice_to_",
+                    (&None, &None) => "as_slice_",
                 };
 
                 method::lookup_in_trait(fcx,

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -490,7 +490,7 @@ pub fn parameterized(cx: &ctxt,
         0
     };
 
-    for t in tps[..tps.len() - num_defaults].iter() {
+    for t in tps.slice_to(tps.len() - num_defaults).iter() {
         strs.push(ty_to_string(cx, *t))
     }
 

--- a/src/librustc_back/lib.rs
+++ b/src/librustc_back/lib.rs
@@ -31,8 +31,7 @@
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://doc.rust-lang.org/")]
 
-#![allow(unknown_features)]
-#![feature(globs, phase, macro_rules, slicing_syntax)]
+#![feature(globs, phase, macro_rules)]
 
 #[phase(plugin, link)]
 extern crate log;

--- a/src/librustc_back/sha2.rs
+++ b/src/librustc_back/sha2.rs
@@ -136,14 +136,14 @@ impl FixedBuffer for FixedBuffer64 {
             let buffer_remaining = size - self.buffer_idx;
             if input.len() >= buffer_remaining {
                     copy_memory(
-                        self.buffer[mut self.buffer_idx..size],
-                        input[..buffer_remaining]);
+                        self.buffer.slice_mut(self.buffer_idx, size),
+                        input.slice_to(buffer_remaining));
                 self.buffer_idx = 0;
                 func(self.buffer);
                 i += buffer_remaining;
             } else {
                 copy_memory(
-                    self.buffer[mut self.buffer_idx..self.buffer_idx + input.len()],
+                    self.buffer.slice_mut(self.buffer_idx, self.buffer_idx + input.len()),
                     input);
                 self.buffer_idx += input.len();
                 return;
@@ -153,7 +153,7 @@ impl FixedBuffer for FixedBuffer64 {
         // While we have at least a full buffer size chunk's worth of data, process that data
         // without copying it into the buffer
         while input.len() - i >= size {
-            func(input[i..i + size]);
+            func(input.slice(i, i + size));
             i += size;
         }
 
@@ -162,8 +162,8 @@ impl FixedBuffer for FixedBuffer64 {
         // be empty.
         let input_remaining = input.len() - i;
         copy_memory(
-            self.buffer[mut ..input_remaining],
-            input[i..]);
+            self.buffer.slice_mut(0, input_remaining),
+            input.slice_from(i));
         self.buffer_idx += input_remaining;
     }
 
@@ -173,19 +173,19 @@ impl FixedBuffer for FixedBuffer64 {
 
     fn zero_until(&mut self, idx: uint) {
         assert!(idx >= self.buffer_idx);
-        self.buffer[mut self.buffer_idx..idx].set_memory(0);
+        self.buffer.slice_mut(self.buffer_idx, idx).set_memory(0);
         self.buffer_idx = idx;
     }
 
     fn next<'s>(&'s mut self, len: uint) -> &'s mut [u8] {
         self.buffer_idx += len;
-        return self.buffer[mut self.buffer_idx - len..self.buffer_idx];
+        return self.buffer.slice_mut(self.buffer_idx - len, self.buffer_idx);
     }
 
     fn full_buffer<'s>(&'s mut self) -> &'s [u8] {
         assert!(self.buffer_idx == 64);
         self.buffer_idx = 0;
-        return self.buffer[..64];
+        return self.buffer.slice_to(64);
     }
 
     fn position(&self) -> uint { self.buffer_idx }
@@ -359,7 +359,7 @@ impl Engine256State {
              )
         )
 
-        read_u32v_be(w[mut 0..16], data);
+        read_u32v_be(w.slice_mut(0, 16), data);
 
         // Putting the message schedule inside the same loop as the round calculations allows for
         // the compiler to generate better code.
@@ -495,14 +495,14 @@ impl Digest for Sha256 {
     fn result(&mut self, out: &mut [u8]) {
         self.engine.finish();
 
-        write_u32_be(out[mut 0..4], self.engine.state.h0);
-        write_u32_be(out[mut 4..8], self.engine.state.h1);
-        write_u32_be(out[mut 8..12], self.engine.state.h2);
-        write_u32_be(out[mut 12..16], self.engine.state.h3);
-        write_u32_be(out[mut 16..20], self.engine.state.h4);
-        write_u32_be(out[mut 20..24], self.engine.state.h5);
-        write_u32_be(out[mut 24..28], self.engine.state.h6);
-        write_u32_be(out[mut 28..32], self.engine.state.h7);
+        write_u32_be(out.slice_mut(0, 4), self.engine.state.h0);
+        write_u32_be(out.slice_mut(4, 8), self.engine.state.h1);
+        write_u32_be(out.slice_mut(8, 12), self.engine.state.h2);
+        write_u32_be(out.slice_mut(12, 16), self.engine.state.h3);
+        write_u32_be(out.slice_mut(16, 20), self.engine.state.h4);
+        write_u32_be(out.slice_mut(20, 24), self.engine.state.h5);
+        write_u32_be(out.slice_mut(24, 28), self.engine.state.h6);
+        write_u32_be(out.slice_mut(28, 32), self.engine.state.h7);
     }
 
     fn reset(&mut self) {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -698,7 +698,7 @@ impl Clean<Item> for ast::Method {
         let all_inputs = &self.pe_fn_decl().inputs;
         let inputs = match self.pe_explicit_self().node {
             ast::SelfStatic => all_inputs.as_slice(),
-            _ => all_inputs[1..]
+            _ => all_inputs.slice_from(1)
         };
         let decl = FnDecl {
             inputs: Arguments {
@@ -737,7 +737,7 @@ impl Clean<Item> for ast::TypeMethod {
     fn clean(&self, cx: &DocContext) -> Item {
         let inputs = match self.explicit_self.node {
             ast::SelfStatic => self.decl.inputs.as_slice(),
-            _ => self.decl.inputs[1..]
+            _ => self.decl.inputs.slice_from(1)
         };
         let decl = FnDecl {
             inputs: Arguments {
@@ -1009,7 +1009,7 @@ impl Clean<Item> for ty::Method {
                                                self.fty.sig.clone()),
             s => {
                 let sig = ty::FnSig {
-                    inputs: self.fty.sig.inputs[1..].to_vec(),
+                    inputs: self.fty.sig.inputs.slice_from(1).to_vec(),
                     ..self.fty.sig.clone()
                 };
                 let s = match s {

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -249,7 +249,7 @@ fn path(w: &mut fmt::Formatter, path: &clean::Path, print_all: bool,
         match rel_root {
             Some(root) => {
                 let mut root = String::from_str(root.as_slice());
-                for seg in path.segments[..amt].iter() {
+                for seg in path.segments.slice_to(amt).iter() {
                     if "super" == seg.name.as_slice() ||
                             "self" == seg.name.as_slice() {
                         try!(write!(w, "{}::", seg.name));
@@ -264,7 +264,7 @@ fn path(w: &mut fmt::Formatter, path: &clean::Path, print_all: bool,
                 }
             }
             None => {
-                for seg in path.segments[..amt].iter() {
+                for seg in path.segments.slice_to(amt).iter() {
                     try!(write!(w, "{}::", seg.name));
                 }
             }
@@ -275,7 +275,7 @@ fn path(w: &mut fmt::Formatter, path: &clean::Path, print_all: bool,
         // This is a documented path, link to it!
         Some((ref fqp, shortty)) if abs_root.is_some() => {
             let mut url = String::from_str(abs_root.unwrap().as_slice());
-            let to_link = fqp[..fqp.len() - 1];
+            let to_link = fqp.slice_to(fqp.len() - 1);
             for component in to_link.iter() {
                 url.push_str(component.as_slice());
                 url.push_str("/");

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -394,7 +394,7 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> io::IoResult<String> 
                     search_index.push(IndexItem {
                         ty: shortty(item),
                         name: item.name.clone().unwrap(),
-                        path: fqp[..fqp.len() - 1].connect("::"),
+                        path: fqp.slice_to(fqp.len() - 1).connect("::"),
                         desc: shorter(item.doc_value()).to_string(),
                         parent: Some(did),
                     });
@@ -549,7 +549,7 @@ fn write_shared(cx: &Context,
         };
 
         let mut mydst = dst.clone();
-        for part in remote_path[..remote_path.len() - 1].iter() {
+        for part in remote_path.slice_to(remote_path.len() - 1).iter() {
             mydst.push(part.as_slice());
             try!(mkdir(&mydst));
         }
@@ -829,7 +829,7 @@ impl DocFolder for Cache {
                     clean::StructFieldItem(..) |
                     clean::VariantItem(..) => {
                         ((Some(*self.parent_stack.last().unwrap()),
-                          Some(self.stack[..self.stack.len() - 1])),
+                          Some(self.stack.slice_to(self.stack.len() - 1))),
                           false)
                     }
                     clean::MethodItem(..) => {
@@ -840,13 +840,13 @@ impl DocFolder for Cache {
                             let did = *last;
                             let path = match self.paths.find(&did) {
                                 Some(&(_, item_type::Trait)) =>
-                                    Some(self.stack[..self.stack.len() - 1]),
+                                    Some(self.stack.slice_to(self.stack.len() - 1)),
                                 // The current stack not necessarily has correlation for
                                 // where the type was defined. On the other hand,
                                 // `paths` always has the right information if present.
                                 Some(&(ref fqp, item_type::Struct)) |
                                 Some(&(ref fqp, item_type::Enum)) =>
-                                    Some(fqp[..fqp.len() - 1]),
+                                    Some(fqp.slice_to(fqp.len() - 1)),
                                 Some(..) => Some(self.stack.as_slice()),
                                 None => None
                             };
@@ -1172,7 +1172,7 @@ impl Context {
                 let mut url = "../".repeat(cx.current.len());
                 match cache_key.get().unwrap().paths.find(&it.def_id) {
                     Some(&(ref names, _)) => {
-                        for name in names[..names.len() - 1].iter() {
+                        for name in names.slice_to(names.len() - 1).iter() {
                             url.push_str(name.as_slice());
                             url.push_str("/");
                         }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -15,8 +15,7 @@
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 
-#![allow(unknown_features)]
-#![feature(globs, struct_variant, managed_boxes, macro_rules, phase, slicing_syntax)]
+#![feature(globs, struct_variant, managed_boxes, macro_rules, phase)]
 
 extern crate arena;
 extern crate debug;

--- a/src/librustrt/lib.rs
+++ b/src/librustrt/lib.rs
@@ -16,10 +16,9 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/master/")]
 
-#![allow(unknown_features)]
 #![feature(macro_rules, phase, globs, thread_local, managed_boxes, asm)]
 #![feature(linkage, lang_items, unsafe_destructor, default_type_params)]
-#![feature(import_shadowing, slicing_syntax)]
+#![feature(import_shadowing)]
 #![no_std]
 #![experimental]
 

--- a/src/librustrt/unwind.rs
+++ b/src/librustrt/unwind.rs
@@ -562,7 +562,7 @@ fn begin_unwind_inner(msg: Box<Any + Send>, file_line: &(&'static str, uint)) ->
     // MAX_CALLBACKS, so we're sure to clamp it as necessary.
     let callbacks = unsafe {
         let amt = CALLBACK_CNT.load(atomic::SeqCst);
-        CALLBACKS[..cmp::min(amt, MAX_CALLBACKS)]
+        CALLBACKS.slice_to(cmp::min(amt, MAX_CALLBACKS))
     };
     for cb in callbacks.iter() {
         match cb.load(atomic::SeqCst) {

--- a/src/librustrt/util.rs
+++ b/src/librustrt/util.rs
@@ -62,8 +62,8 @@ pub fn abort(args: &fmt::Arguments) -> ! {
     }
     impl<'a> FormatWriter for BufWriter<'a> {
         fn write(&mut self, bytes: &[u8]) -> fmt::Result {
-            let left = self.buf[mut self.pos..];
-            let to_write = bytes[..cmp::min(bytes.len(), left.len())];
+            let left = self.buf.slice_from_mut(self.pos);
+            let to_write = bytes.slice_to(cmp::min(bytes.len(), left.len()));
             slice::bytes::copy_memory(left, to_write);
             self.pos += to_write.len();
             Ok(())
@@ -74,7 +74,7 @@ pub fn abort(args: &fmt::Arguments) -> ! {
     let mut msg = [0u8, ..512];
     let mut w = BufWriter { buf: msg, pos: 0 };
     let _ = write!(&mut w, "{}", args);
-    let msg = str::from_utf8(w.buf[mut ..w.pos]).unwrap_or("aborted");
+    let msg = str::from_utf8(w.buf.slice_to(w.pos)).unwrap_or("aborted");
     let msg = if msg.is_empty() {"aborted"} else {msg};
 
     // Give some context to the message

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -334,7 +334,7 @@ pub fn escape_bytes(wr: &mut io::Writer, bytes: &[u8]) -> Result<(), io::IoError
         };
 
         if start < i {
-            try!(wr.write(bytes[start..i]));
+            try!(wr.write(bytes.slice(start, i)));
         }
 
         try!(wr.write_str(escaped));
@@ -343,7 +343,7 @@ pub fn escape_bytes(wr: &mut io::Writer, bytes: &[u8]) -> Result<(), io::IoError
     }
 
     if start != bytes.len() {
-        try!(wr.write(bytes[start..]));
+        try!(wr.write(bytes.slice_from(start)));
     }
 
     wr.write_str("\"")
@@ -369,7 +369,7 @@ fn spaces(wr: &mut io::Writer, mut n: uint) -> Result<(), io::IoError> {
     }
 
     if n > 0 {
-        wr.write(buf[..n])
+        wr.write(buf.slice_to(n))
     } else {
         Ok(())
     }
@@ -1149,7 +1149,7 @@ impl Stack {
             InternalIndex(i) => { Index(i) }
             InternalKey(start, size) => {
                 Key(str::from_utf8(
-                    self.str_buffer[start as uint .. start as uint + size as uint]).unwrap())
+                    self.str_buffer.slice(start as uint, start as uint + size as uint)).unwrap())
             }
         }
     }
@@ -1191,7 +1191,7 @@ impl Stack {
             Some(&InternalIndex(i)) => Some(Index(i)),
             Some(&InternalKey(start, size)) => {
                 Some(Key(str::from_utf8(
-                    self.str_buffer[start as uint .. (start+size) as uint]
+                    self.str_buffer.slice(start as uint, (start+size) as uint)
                 ).unwrap()))
             }
         }

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -23,8 +23,7 @@ Core encoding and decoding interfaces.
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/master/",
        html_playground_url = "http://play.rust-lang.org/")]
-#![allow(unknown_features)]
-#![feature(macro_rules, managed_boxes, default_type_params, phase, slicing_syntax)]
+#![feature(macro_rules, managed_boxes, default_type_params, phase)]
 
 // test harness access
 #[cfg(test)]

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -90,10 +90,10 @@ impl<R: Reader> BufferedReader<R> {
 impl<R: Reader> Buffer for BufferedReader<R> {
     fn fill_buf<'a>(&'a mut self) -> IoResult<&'a [u8]> {
         if self.pos == self.cap {
-            self.cap = try!(self.inner.read(self.buf[mut]));
+            self.cap = try!(self.inner.read(self.buf.as_mut_slice()));
             self.pos = 0;
         }
-        Ok(self.buf[self.pos..self.cap])
+        Ok(self.buf.slice(self.pos, self.cap))
     }
 
     fn consume(&mut self, amt: uint) {
@@ -107,7 +107,7 @@ impl<R: Reader> Reader for BufferedReader<R> {
         let nread = {
             let available = try!(self.fill_buf());
             let nread = cmp::min(available.len(), buf.len());
-            slice::bytes::copy_memory(buf, available[..nread]);
+            slice::bytes::copy_memory(buf, available.slice_to(nread));
             nread
         };
         self.pos += nread;
@@ -162,7 +162,7 @@ impl<W: Writer> BufferedWriter<W> {
 
     fn flush_buf(&mut self) -> IoResult<()> {
         if self.pos != 0 {
-            let ret = self.inner.as_mut().unwrap().write(self.buf[..self.pos]);
+            let ret = self.inner.as_mut().unwrap().write(self.buf.slice_to(self.pos));
             self.pos = 0;
             ret
         } else {
@@ -195,7 +195,7 @@ impl<W: Writer> Writer for BufferedWriter<W> {
         if buf.len() > self.buf.len() {
             self.inner.as_mut().unwrap().write(buf)
         } else {
-            let dst = self.buf[mut self.pos..];
+            let dst = self.buf.slice_from_mut(self.pos);
             slice::bytes::copy_memory(dst, buf);
             self.pos += buf.len();
             Ok(())
@@ -250,9 +250,9 @@ impl<W: Writer> Writer for LineBufferedWriter<W> {
     fn write(&mut self, buf: &[u8]) -> IoResult<()> {
         match buf.iter().rposition(|&b| b == b'\n') {
             Some(i) => {
-                try!(self.inner.write(buf[..i + 1]));
+                try!(self.inner.write(buf.slice_to(i + 1)));
                 try!(self.inner.flush());
-                try!(self.inner.write(buf[i + 1..]));
+                try!(self.inner.write(buf.slice_from(i + 1)));
                 Ok(())
             }
             None => self.inner.write(buf),

--- a/src/libstd/io/comm_adapters.rs
+++ b/src/libstd/io/comm_adapters.rs
@@ -15,7 +15,8 @@ use comm::{Sender, Receiver};
 use io;
 use option::{None, Option, Some};
 use result::{Ok, Err};
-use slice::{bytes, CloneableVector};
+use slice::{bytes, MutableSlice, ImmutableSlice, CloneableVector};
+use str::StrSlice;
 use super::{Reader, Writer, IoResult};
 use vec::Vec;
 
@@ -61,10 +62,10 @@ impl Reader for ChanReader {
         loop {
             match self.buf {
                 Some(ref prev) => {
-                    let dst = buf[mut num_read..];
-                    let src = prev[self.pos..];
+                    let dst = buf.slice_from_mut(num_read);
+                    let src = prev.slice_from(self.pos);
                     let count = cmp::min(dst.len(), src.len());
-                    bytes::copy_memory(dst, src[..count]);
+                    bytes::copy_memory(dst, src.slice_to(count));
                     num_read += count;
                     self.pos += count;
                 },

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -485,7 +485,7 @@ pub fn copy(from: &Path, to: &Path) -> IoResult<()> {
             Err(ref e) if e.kind == io::EndOfFile => { break }
             Err(e) => return update_err(Err(e), from, to)
         };
-        try!(writer.write(buf[..amt]));
+        try!(writer.write(buf.slice_to(amt)));
     }
 
     chmod(to, try!(update_err(from.stat(), from, to)).perm)
@@ -1014,7 +1014,7 @@ mod test {
             let mut read_buf = [0, .. 1028];
             let read_str = match check!(read_stream.read(read_buf)) {
                 -1|0 => fail!("shouldn't happen"),
-                n => str::from_utf8(read_buf[..n]).unwrap().to_string()
+                n => str::from_utf8(read_buf.slice_to(n)).unwrap().to_string()
             };
             assert_eq!(read_str.as_slice(), message);
         }
@@ -1061,11 +1061,11 @@ mod test {
         {
             let mut read_stream = File::open_mode(filename, Open, Read);
             {
-                let read_buf = read_mem[mut 0..4];
+                let read_buf = read_mem.slice_mut(0, 4);
                 check!(read_stream.read(read_buf));
             }
             {
-                let read_buf = read_mem[mut 4..8];
+                let read_buf = read_mem.slice_mut(4, 8);
                 check!(read_stream.read(read_buf));
             }
         }

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -19,7 +19,7 @@ use result::{Err, Ok};
 use io;
 use io::{Reader, Writer, Seek, Buffer, IoError, SeekStyle, IoResult};
 use slice;
-use slice::Slice;
+use slice::{Slice, ImmutableSlice, MutableSlice};
 use vec::Vec;
 
 static BUF_CAPACITY: uint = 128;
@@ -146,8 +146,8 @@ impl Reader for MemReader {
 
         let write_len = min(buf.len(), self.buf.len() - self.pos);
         {
-            let input = self.buf[self.pos.. self.pos + write_len];
-            let output = buf[mut ..write_len];
+            let input = self.buf.slice(self.pos, self.pos + write_len);
+            let output = buf.slice_mut(0, write_len);
             assert_eq!(input.len(), output.len());
             slice::bytes::copy_memory(output, input);
         }
@@ -174,7 +174,7 @@ impl Buffer for MemReader {
     #[inline]
     fn fill_buf<'a>(&'a mut self) -> IoResult<&'a [u8]> {
         if self.pos < self.buf.len() {
-            Ok(self.buf[self.pos..])
+            Ok(self.buf.slice_from(self.pos))
         } else {
             Err(io::standard_error(io::EndOfFile))
         }
@@ -232,7 +232,7 @@ impl<'a> Writer for BufWriter<'a> {
             })
         }
 
-        slice::bytes::copy_memory(self.buf[mut self.pos..], buf);
+        slice::bytes::copy_memory(self.buf.slice_from_mut(self.pos), buf);
         self.pos += buf.len();
         Ok(())
     }
@@ -292,8 +292,8 @@ impl<'a> Reader for BufReader<'a> {
 
         let write_len = min(buf.len(), self.buf.len() - self.pos);
         {
-            let input = self.buf[self.pos.. self.pos + write_len];
-            let output = buf[mut ..write_len];
+            let input = self.buf.slice(self.pos, self.pos + write_len);
+            let output = buf.slice_mut(0, write_len);
             assert_eq!(input.len(), output.len());
             slice::bytes::copy_memory(output, input);
         }
@@ -320,7 +320,7 @@ impl<'a> Buffer for BufReader<'a> {
     #[inline]
     fn fill_buf<'a>(&'a mut self) -> IoResult<&'a [u8]> {
         if self.pos < self.buf.len() {
-            Ok(self.buf[self.pos..])
+            Ok(self.buf.slice_from(self.pos))
         } else {
             Err(io::standard_error(io::EndOfFile))
         }
@@ -427,7 +427,7 @@ mod test {
         assert_eq!(buf.as_slice(), b);
         assert_eq!(reader.read(buf), Ok(3));
         let b: &[_] = &[5, 6, 7];
-        assert_eq!(buf[0..3], b);
+        assert_eq!(buf.slice(0, 3), b);
         assert!(reader.read(buf).is_err());
         let mut reader = MemReader::new(vec!(0, 1, 2, 3, 4, 5, 6, 7));
         assert_eq!(reader.read_until(3).unwrap(), vec!(0, 1, 2, 3));
@@ -454,7 +454,7 @@ mod test {
         assert_eq!(buf.as_slice(), b);
         assert_eq!(reader.read(buf), Ok(3));
         let b: &[_] = &[5, 6, 7];
-        assert_eq!(buf[0..3], b);
+        assert_eq!(buf.slice(0, 3), b);
         assert!(reader.read(buf).is_err());
         let mut reader = BufReader::new(in_buf.as_slice());
         assert_eq!(reader.read_until(3).unwrap(), vec!(0, 1, 2, 3));
@@ -548,7 +548,7 @@ mod test {
         assert!(r.read_at_least(buf.len(), buf).is_ok());
         let b: &[_] = &[1, 2, 3];
         assert_eq!(buf.as_slice(), b);
-        assert!(r.read_at_least(0, buf[mut ..0]).is_ok());
+        assert!(r.read_at_least(0, buf.slice_to_mut(0)).is_ok());
         assert_eq!(buf.as_slice(), b);
         assert!(r.read_at_least(buf.len(), buf).is_ok());
         let b: &[_] = &[4, 5, 6];

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -235,7 +235,7 @@ use os;
 use boxed::Box;
 use result::{Ok, Err, Result};
 use rt::rtio;
-use slice::{Slice, ImmutableSlice};
+use slice::{Slice, MutableSlice, ImmutableSlice};
 use str::{Str, StrSlice};
 use str;
 use string::String;
@@ -575,7 +575,7 @@ pub trait Reader {
         while read < min {
             let mut zeroes = 0;
             loop {
-                match self.read(buf[mut read..]) {
+                match self.read(buf.slice_from_mut(read)) {
                     Ok(0) => {
                         zeroes += 1;
                         if zeroes >= NO_PROGRESS_LIMIT {
@@ -1111,8 +1111,8 @@ pub trait Writer {
     #[inline]
     fn write_char(&mut self, c: char) -> IoResult<()> {
         let mut buf = [0u8, ..4];
-        let n = c.encode_utf8(buf[mut]).unwrap_or(0);
-        self.write(buf[..n])
+        let n = c.encode_utf8(buf.as_mut_slice()).unwrap_or(0);
+        self.write(buf.slice_to(n))
     }
 
     /// Write the result of passing n through `int::to_str_bytes`.
@@ -1496,7 +1496,7 @@ pub trait Buffer: Reader {
                 };
                 match available.iter().position(|&b| b == byte) {
                     Some(i) => {
-                        res.push_all(available[..i + 1]);
+                        res.push_all(available.slice_to(i + 1));
                         used = i + 1;
                         break
                     }
@@ -1528,14 +1528,14 @@ pub trait Buffer: Reader {
         {
             let mut start = 1;
             while start < width {
-                match try!(self.read(buf[mut start..width])) {
+                match try!(self.read(buf.slice_mut(start, width))) {
                     n if n == width - start => break,
                     n if n < width - start => { start += n; }
                     _ => return Err(standard_error(InvalidInput)),
                 }
             }
         }
-        match str::from_utf8(buf[..width]) {
+        match str::from_utf8(buf.slice_to(width)) {
             Some(s) => Ok(s.char_at(0)),
             None => Err(standard_error(InvalidInput))
         }

--- a/src/libstd/io/net/ip.rs
+++ b/src/libstd/io/net/ip.rs
@@ -21,7 +21,7 @@ use from_str::FromStr;
 use iter::Iterator;
 use option::{Option, None, Some};
 use str::StrSlice;
-use slice::{MutableCloneableSlice, MutableSlice};
+use slice::{MutableCloneableSlice, ImmutableSlice, MutableSlice};
 
 pub type Port = u16;
 
@@ -241,7 +241,7 @@ impl<'a> Parser<'a> {
             assert!(head.len() + tail.len() <= 8);
             let mut gs = [0u16, ..8];
             gs.clone_from_slice(head);
-            gs[mut 8 - tail.len() .. 8].clone_from_slice(tail);
+            gs.slice_mut(8 - tail.len(), 8).clone_from_slice(tail);
             Ipv6Addr(gs[0], gs[1], gs[2], gs[3], gs[4], gs[5], gs[6], gs[7])
         }
 
@@ -303,7 +303,7 @@ impl<'a> Parser<'a> {
 
         let mut tail = [0u16, ..8];
         let (tail_size, _) = read_groups(self, &mut tail, 8 - head_size);
-        Some(ipv6_addr_from_head_tail(head[..head_size], tail[..tail_size]))
+        Some(ipv6_addr_from_head_tail(head.slice(0, head_size), tail.slice(0, tail_size)))
     }
 
     fn read_ipv6_addr(&mut self) -> Option<IpAddr> {

--- a/src/libstd/io/net/udp.rs
+++ b/src/libstd/io/net/udp.rs
@@ -48,7 +48,7 @@ use rt::rtio;
 /// match socket.recv_from(buf) {
 ///     Ok((amt, src)) => {
 ///         // Send a reply to the socket we received data from
-///         let buf = buf[mut ..amt];
+///         let buf = buf.slice_to_mut(amt);
 ///         buf.reverse();
 ///         socket.send_to(buf, src);
 ///     }

--- a/src/libstd/io/net/udp.rs
+++ b/src/libstd/io/net/udp.rs
@@ -35,29 +35,26 @@ use rt::rtio;
 ///
 /// ```rust,no_run
 /// # #![allow(unused_must_use)]
-/// #![feature(slicing_syntax)]
-///
 /// use std::io::net::udp::UdpSocket;
 /// use std::io::net::ip::{Ipv4Addr, SocketAddr};
-/// fn main() {
-///     let addr = SocketAddr { ip: Ipv4Addr(127, 0, 0, 1), port: 34254 };
-///     let mut socket = match UdpSocket::bind(addr) {
-///         Ok(s) => s,
-///         Err(e) => fail!("couldn't bind socket: {}", e),
-///     };
 ///
-///     let mut buf = [0, ..10];
-///     match socket.recv_from(buf) {
-///         Ok((amt, src)) => {
-///             // Send a reply to the socket we received data from
-///             let buf = buf[mut ..amt];
-///             buf.reverse();
-///             socket.send_to(buf, src);
-///         }
-///         Err(e) => println!("couldn't receive a datagram: {}", e)
+/// let addr = SocketAddr { ip: Ipv4Addr(127, 0, 0, 1), port: 34254 };
+/// let mut socket = match UdpSocket::bind(addr) {
+///     Ok(s) => s,
+///     Err(e) => fail!("couldn't bind socket: {}", e),
+/// };
+///
+/// let mut buf = [0, ..10];
+/// match socket.recv_from(buf) {
+///     Ok((amt, src)) => {
+///         // Send a reply to the socket we received data from
+///         let buf = buf[mut ..amt];
+///         buf.reverse();
+///         socket.send_to(buf, src);
 ///     }
-///     drop(socket); // close the socket
+///     Err(e) => println!("couldn't receive a datagram: {}", e)
 /// }
+/// drop(socket); // close the socket
 /// ```
 pub struct UdpSocket {
     obj: Box<RtioUdpSocket + Send>,

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -47,7 +47,7 @@ impl<R: Reader> Reader for LimitReader<R> {
         }
 
         let len = cmp::min(self.limit, buf.len());
-        let res = self.inner.read(buf[mut ..len]);
+        let res = self.inner.read(buf.slice_to_mut(len));
         match res {
             Ok(len) => self.limit -= len,
             _ => {}
@@ -59,7 +59,7 @@ impl<R: Reader> Reader for LimitReader<R> {
 impl<R: Buffer> Buffer for LimitReader<R> {
     fn fill_buf<'a>(&'a mut self) -> io::IoResult<&'a [u8]> {
         let amt = try!(self.inner.fill_buf());
-        let buf = amt[..cmp::min(amt.len(), self.limit)];
+        let buf = amt.slice_to(cmp::min(amt.len(), self.limit));
         if buf.len() == 0 {
             Err(io::standard_error(io::EndOfFile))
         } else {
@@ -216,7 +216,7 @@ impl<R: Reader, W: Writer> TeeReader<R, W> {
 impl<R: Reader, W: Writer> Reader for TeeReader<R, W> {
     fn read(&mut self, buf: &mut [u8]) -> io::IoResult<uint> {
         self.reader.read(buf).and_then(|len| {
-            self.writer.write(buf[mut ..len]).map(|()| len)
+            self.writer.write(buf.slice_to(len)).map(|()| len)
         })
     }
 }
@@ -230,7 +230,7 @@ pub fn copy<R: Reader, W: Writer>(r: &mut R, w: &mut W) -> io::IoResult<()> {
             Err(ref e) if e.kind == io::EndOfFile => return Ok(()),
             Err(e) => return Err(e),
         };
-        try!(w.write(buf[..len]));
+        try!(w.write(buf.slice_to(len)));
     }
 }
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -105,10 +105,9 @@
        html_root_url = "http://doc.rust-lang.org/master/",
        html_playground_url = "http://play.rust-lang.org/")]
 
-#![allow(unknown_features)]
 #![feature(macro_rules, globs, managed_boxes, linkage)]
 #![feature(default_type_params, phase, lang_items, unsafe_destructor)]
-#![feature(import_shadowing, slicing_syntax)]
+#![feature(import_shadowing)]
 
 // Don't link to std. We are std.
 #![no_std]

--- a/src/libstd/num/i16.rs
+++ b/src/libstd/num/i16.rs
@@ -17,6 +17,7 @@ use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
+use slice::ImmutableSlice;
 use string::String;
 
 pub use core::i16::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/i32.rs
+++ b/src/libstd/num/i32.rs
@@ -17,6 +17,7 @@ use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
+use slice::ImmutableSlice;
 use string::String;
 
 pub use core::i32::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/i64.rs
+++ b/src/libstd/num/i64.rs
@@ -17,6 +17,7 @@ use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
+use slice::ImmutableSlice;
 use string::String;
 
 pub use core::i64::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/i8.rs
+++ b/src/libstd/num/i8.rs
@@ -17,6 +17,7 @@ use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
+use slice::ImmutableSlice;
 use string::String;
 
 pub use core::i8::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/int.rs
+++ b/src/libstd/num/int.rs
@@ -17,6 +17,7 @@ use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
+use slice::ImmutableSlice;
 use string::String;
 
 pub use core::int::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -78,7 +78,7 @@ pub fn to_str_bytes<U>(n: $T, radix: uint, f: |v: &[u8]| -> U) -> U {
         (write!(&mut wr, "{}", ::fmt::radix(n, radix as u8))).unwrap();
         wr.tell().unwrap() as uint
     };
-    f(buf[..amt])
+    f(buf.slice(0, amt))
 }
 
 #[deprecated = "use fmt::radix"]

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -730,7 +730,7 @@ pub fn from_str_bytes_common<T:NumCast+Zero+One+PartialEq+PartialOrd+Div<T,T>+
         // parse remaining bytes as decimal integer,
         // skipping the exponent char
         let exp: Option<int> = from_str_bytes_common(
-            buf[i+1..len], 10, true, false, false, ExpNone, false,
+            buf.slice(i+1, len), 10, true, false, false, ExpNone, false,
             ignore_underscores);
 
         match exp {

--- a/src/libstd/num/u16.rs
+++ b/src/libstd/num/u16.rs
@@ -17,6 +17,7 @@ use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
+use slice::ImmutableSlice;
 use string::String;
 
 pub use core::u16::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/u32.rs
+++ b/src/libstd/num/u32.rs
@@ -17,6 +17,7 @@ use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
+use slice::ImmutableSlice;
 use string::String;
 
 pub use core::u32::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/u64.rs
+++ b/src/libstd/num/u64.rs
@@ -17,6 +17,7 @@ use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
+use slice::ImmutableSlice;
 use string::String;
 
 pub use core::u64::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/u8.rs
+++ b/src/libstd/num/u8.rs
@@ -17,6 +17,7 @@ use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
+use slice::ImmutableSlice;
 use string::String;
 
 pub use core::u8::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/uint.rs
+++ b/src/libstd/num/uint.rs
@@ -17,6 +17,7 @@ use from_str::FromStr;
 use num::{ToStrRadix, FromStrRadix};
 use num::strconv;
 use option::Option;
+use slice::ImmutableSlice;
 use string::String;
 
 pub use core::uint::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -79,7 +79,7 @@ pub fn to_str_bytes<U>(n: $T, radix: uint, f: |v: &[u8]| -> U) -> U {
         (write!(&mut wr, "{}", ::fmt::radix(n, radix as u8))).unwrap();
         wr.tell().unwrap() as uint
     };
-    f(buf[..amt])
+    f(buf.slice(0, amt))
 }
 
 #[deprecated = "use fmt::radix"]

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -144,7 +144,7 @@ pub mod windows {
     use option::{None, Option};
     use option;
     use os::TMPBUF_SZ;
-    use slice::MutableSlice;
+    use slice::{MutableSlice, ImmutableSlice};
     use string::String;
     use str::StrSlice;
     use vec::Vec;

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -357,7 +357,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
                 match name.rposition_elem(&dot) {
                     None | Some(0) => name,
                     Some(1) if name == b".." => name,
-                    Some(pos) => name[..pos]
+                    Some(pos) => name.slice_to(pos)
                 }
             })
         }
@@ -404,7 +404,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
                 match name.rposition_elem(&dot) {
                     None | Some(0) => None,
                     Some(1) if name == b".." => None,
-                    Some(pos) => Some(name[pos+1..])
+                    Some(pos) => Some(name.slice_from(pos+1))
                 }
             }
         }
@@ -480,7 +480,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
             let extlen = extension.container_as_bytes().len();
             match (name.rposition_elem(&dot), extlen) {
                 (None, 0) | (Some(0), 0) => None,
-                (Some(idx), 0) => Some(name[..idx].to_vec()),
+                (Some(idx), 0) => Some(name.slice_to(idx).to_vec()),
                 (idx, extlen) => {
                     let idx = match idx {
                         None | Some(0) => name.len(),
@@ -489,7 +489,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
 
                     let mut v;
                     v = Vec::with_capacity(idx + extlen + 1);
-                    v.push_all(name[..idx]);
+                    v.push_all(name.slice_to(idx));
                     v.push(dot);
                     v.push_all(extension.container_as_bytes());
                     Some(v)

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -999,7 +999,7 @@ mod imp {
                 let bytes = cstr.as_bytes();
                 match cstr.as_str() {
                     Some(s) => try!(super::demangle(w, s)),
-                    None => try!(w.write(bytes[..bytes.len()-1])),
+                    None => try!(w.write(bytes.slice_to(bytes.len() - 1))),
                 }
             }
             try!(w.write(['\n' as u8]));

--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -496,7 +496,7 @@ impl<'ast> Map<'ast> {
         NodesMatchingSuffix {
             map: self,
             item_name: parts.last().unwrap(),
-            in_which: parts[..parts.len() - 1],
+            in_which: parts.slice_to(parts.len() - 1),
             idx: 0,
         }
     }

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -414,7 +414,7 @@ fn highlight_lines(err: &mut EmitterWriter,
     let mut elided = false;
     let mut display_lines = lines.lines.as_slice();
     if display_lines.len() > MAX_LINES {
-        display_lines = display_lines[0u..MAX_LINES];
+        display_lines = display_lines.slice(0u, MAX_LINES);
         elided = true;
     }
     // Print the offending lines

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -70,7 +70,6 @@ static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[
     ("tuple_indexing", Active),
     ("associated_types", Active),
     ("visible_private_types", Active),
-    ("slicing_syntax", Active),
 
     ("if_let", Active),
 
@@ -362,11 +361,6 @@ impl<'a, 'v> Visitor<'v> for Context<'a> {
             ast::ExprIfLet(..) => {
                 self.gate_feature("if_let", e.span,
                                   "`if let` syntax is experimental");
-            }
-            ast::ExprSlice(..) => {
-                self.gate_feature("slicing_syntax",
-                                  e.span,
-                                  "slicing syntax is experimental");
             }
             _ => {}
         }

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -23,8 +23,7 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/master/")]
 
-#![allow(unknown_features)]
-#![feature(macro_rules, globs, default_type_params, phase, slicing_syntax)]
+#![feature(macro_rules, globs, default_type_params, phase)]
 #![feature(quote, struct_variant, unsafe_destructor, import_shadowing)]
 #![allow(deprecated)]
 

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -49,8 +49,7 @@
        html_root_url = "http://doc.rust-lang.org/master/",
        html_playground_url = "http://play.rust-lang.org/")]
 
-#![allow(unknown_features)]
-#![feature(macro_rules, phase, slicing_syntax)]
+#![feature(macro_rules, phase)]
 
 #![deny(missing_doc)]
 

--- a/src/libterm/terminfo/parser/compiled.rs
+++ b/src/libterm/terminfo/parser/compiled.rs
@@ -285,13 +285,13 @@ pub fn parse(file: &mut io::Reader, longnames: bool)
 
 
             // Find the offset of the NUL we want to go to
-            let nulpos = string_table[offset as uint .. string_table_bytes as uint]
+            let nulpos = string_table.slice(offset as uint, string_table_bytes as uint)
                 .iter().position(|&b| b == 0);
             match nulpos {
                 Some(len) => {
                     string_map.insert(name.to_string(),
-                                      string_table[offset as uint ..
-                                          offset as uint + len].to_vec())
+                                      string_table.slice(offset as uint,
+                                          offset as uint + len).to_vec())
                 },
                 None => {
                     return Err("invalid file: missing NUL in \

--- a/src/test/bench/shootout-fannkuch-redux.rs
+++ b/src/test/bench/shootout-fannkuch-redux.rs
@@ -50,7 +50,7 @@ fn rotate(x: &mut [i32]) {
 
 fn next_permutation(perm: &mut [i32], count: &mut [i32]) {
     for i in range(1, perm.len()) {
-        rotate(perm[mut ..i + 1]);
+        rotate(perm.slice_to_mut(i + 1));
         let count_i = &mut count[i];
         if *count_i >= i as i32 {
             *count_i = 0;
@@ -99,7 +99,7 @@ impl Perm {
             let d = idx / self.fact[i] as i32;
             self.cnt[i] = d;
             idx %= self.fact[i] as i32;
-            for (place, val) in pp.iter_mut().zip(self.perm.p[..i+1].iter()) {
+            for (place, val) in pp.iter_mut().zip(self.perm.p.slice_to(i + 1).iter()) {
                 *place = (*val) as u8
             }
 
@@ -125,7 +125,7 @@ impl Perm {
 
 
 fn reverse(tperm: &mut [i32], mut k: uint) {
-    tperm[mut ..k].reverse()
+    tperm.slice_to_mut(k).reverse()
 }
 
 fn work(mut perm: Perm, n: uint, max: uint) -> (i32, i32) {

--- a/src/test/bench/shootout-fannkuch-redux.rs
+++ b/src/test/bench/shootout-fannkuch-redux.rs
@@ -38,8 +38,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#![feature(slicing_syntax)]
-
 use std::{cmp, iter, mem};
 use std::sync::Future;
 

--- a/src/test/bench/shootout-fasta-redux.rs
+++ b/src/test/bench/shootout-fasta-redux.rs
@@ -124,8 +124,8 @@ impl<'a, W: Writer> RepeatFasta<'a, W> {
 
         copy_memory(buf.as_mut_slice(), alu);
         let buf_len = buf.len();
-        copy_memory(buf[mut alu_len..buf_len],
-                    alu[..LINE_LEN]);
+        copy_memory(buf.slice_mut(alu_len, buf_len),
+                    alu.slice_to(LINE_LEN));
 
         let mut pos = 0;
         let mut bytes;
@@ -201,7 +201,7 @@ impl<'a, W: Writer> RandomFasta<'a, W> {
         for i in range(0u, chars_left) {
             buf[i] = self.nextc();
         }
-        self.out.write(buf[..chars_left])
+        self.out.write(buf.slice_to(chars_left))
     }
 }
 

--- a/src/test/bench/shootout-fasta-redux.rs
+++ b/src/test/bench/shootout-fasta-redux.rs
@@ -38,8 +38,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#![feature(slicing_syntax)]
-
 use std::cmp::min;
 use std::io::{stdout, IoResult};
 use std::os;

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -38,8 +38,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#![feature(slicing_syntax)]
-
 use std::io;
 use std::io::{BufferedWriter, File};
 use std::cmp::min;

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -93,7 +93,7 @@ fn make_fasta<W: Writer, I: Iterator<u8>>(
         }
         n -= nb;
         line[nb] = '\n' as u8;
-        wr.write(line[..nb+1]);
+        wr.write(line.slice_to(nb + 1));
     }
 }
 

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -13,8 +13,6 @@
 
 // multi tasking k-nucleotide
 
-#![feature(slicing_syntax)]
-
 extern crate collections;
 
 use std::collections::HashMap;

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -97,11 +97,11 @@ fn windows_with_carry(bb: &[u8], nn: uint, it: |window: &[u8]|) -> Vec<u8> {
 
    let len = bb.len();
    while ii < len - (nn - 1u) {
-      it(bb[ii..ii+nn]);
+      it(bb.slice(ii, ii+nn));
       ii += 1u;
    }
 
-   return Vec::from_slice(bb[len - (nn - 1u)..len]);
+   return Vec::from_slice(bb.slice(len - (nn - 1u), len));
 }
 
 fn make_sequence_processor(sz: uint,

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -40,8 +40,6 @@
 
 // ignore-android see #10393 #13206
 
-#![feature(slicing_syntax)]
-
 use std::string::String;
 use std::slice;
 use std::sync::{Arc, Future};

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -240,14 +240,14 @@ fn generate_frequencies(mut input: &[u8], frame: uint) -> Table {
     // Pull first frame.
     for _ in range(0, frame) {
         code = code.push_char(input[0]);
-        input = input[1..];
+        input = input.slice_from(1);
     }
     frequencies.lookup(code, BumpCallback);
 
     while input.len() != 0 && input[0] != ('>' as u8) {
         code = code.rotate(input[0], frame);
         frequencies.lookup(code, BumpCallback);
-        input = input[1..];
+        input = input.slice_from(1);
     }
     frequencies
 }

--- a/src/test/bench/shootout-regex-dna.rs
+++ b/src/test/bench/shootout-regex-dna.rs
@@ -41,7 +41,7 @@
 // ignore-stage1
 // ignore-cross-compile #12102
 
-#![feature(macro_rules, phase, slicing_syntax)]
+#![feature(macro_rules, phase)]
 
 extern crate regex;
 #[phase(plugin)]extern crate regex_macros;

--- a/src/test/bench/shootout-reverse-complement.rs
+++ b/src/test/bench/shootout-reverse-complement.rs
@@ -81,7 +81,7 @@ fn main() {
             Some(c) => c
         };
         let len = seq.len();
-        let seq = seq[mut begin+1..len-1];
+        let seq = seq.slice_mut(begin + 1, len - 1);
 
         // arrange line breaks
         let len = seq.len();

--- a/src/test/bench/shootout-reverse-complement.rs
+++ b/src/test/bench/shootout-reverse-complement.rs
@@ -41,8 +41,6 @@
 // ignore-pretty very bad with line comments
 // ignore-android doesn't terminate?
 
-#![feature(slicing_syntax)]
-
 use std::iter::range_step;
 use std::io::{stdin, stdout, File};
 

--- a/src/test/compile-fail/issue-15730.rs
+++ b/src/test/compile-fail/issue-15730.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(slicing_syntax)]
-
 fn main() {
     let mut array = [1, 2, 3];
 //~^ ERROR cannot determine a type for this local variable: cannot determine the type of this integ

--- a/src/test/compile-fail/issue-15730.rs
+++ b/src/test/compile-fail/issue-15730.rs
@@ -11,5 +11,5 @@
 fn main() {
     let mut array = [1, 2, 3];
 //~^ ERROR cannot determine a type for this local variable: cannot determine the type of this integ
-    let pie_slice = array[1..2];
+    let pie_slice = array.slice(1, 2);
 }

--- a/src/test/compile-fail/slice-2.rs
+++ b/src/test/compile-fail/slice-2.rs
@@ -10,8 +10,6 @@
 
 // Test that slicing syntax gives errors if we have not implemented the trait.
 
-#![feature(slicing_syntax)]
-
 struct Foo;
 
 fn main() {

--- a/src/test/compile-fail/slice-borrow.rs
+++ b/src/test/compile-fail/slice-borrow.rs
@@ -10,8 +10,6 @@
 
 // Test slicing expressions doesn't defeat the borrow checker.
 
-#![feature(slicing_syntax)]
-
 fn main() {
     let y;
     {

--- a/src/test/compile-fail/slice-mut-2.rs
+++ b/src/test/compile-fail/slice-mut-2.rs
@@ -10,8 +10,6 @@
 
 // Test mutability and slicing syntax.
 
-#![feature(slicing_syntax)]
-
 fn main() {
     let x: &[int] = &[1, 2, 3, 4, 5];
     // Can't mutably slice an immutable slice

--- a/src/test/compile-fail/slice-mut.rs
+++ b/src/test/compile-fail/slice-mut.rs
@@ -10,8 +10,6 @@
 
 // Test mutability and slicing syntax.
 
-#![feature(slicing_syntax)]
-
 fn main() {
     let x: &[int] = &[1, 2, 3, 4, 5];
     // Immutable slices are not mutable.

--- a/src/test/debuginfo/vec-slices.rs
+++ b/src/test/debuginfo/vec-slices.rs
@@ -80,7 +80,6 @@
 // lldb-check:[...]$5 = &[AStruct { x: 10, y: 11, z: 12 }, AStruct { x: 13, y: 14, z: 15 }]
 
 #![allow(unused_variable)]
-#![feature(slicing_syntax)]
 
 struct AStruct {
     x: i16,

--- a/src/test/debuginfo/vec-slices.rs
+++ b/src/test/debuginfo/vec-slices.rs
@@ -94,7 +94,7 @@ fn main() {
     let empty: &[i64] = &[];
     let singleton: &[i64] = &[1];
     let multiple: &[i64] = &[2, 3, 4, 5];
-    let slice_of_slice = multiple[1..3];
+    let slice_of_slice = multiple.slice(1,3);
 
     let padded_tuple: &[(i32, i16)] = &[(6, 7), (8, 9)];
 

--- a/src/test/run-pass/issue-3888-2.rs
+++ b/src/test/run-pass/issue-3888-2.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(slicing_syntax)]
-
 fn vec_peek<'r, T>(v: &'r [T]) -> &'r [T] {
     v[1..5]
 }

--- a/src/test/run-pass/issue-3888-2.rs
+++ b/src/test/run-pass/issue-3888-2.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 fn vec_peek<'r, T>(v: &'r [T]) -> &'r [T] {
-    v[1..5]
+    v.slice(1, 5)
 }
 
 pub fn main() {}

--- a/src/test/run-pass/issue-4464.rs
+++ b/src/test/run-pass/issue-4464.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(slicing_syntax)]
-
 fn broken(v: &[u8], i: uint, j: uint) -> &[u8] { v[i..j] }
 
 pub fn main() {}

--- a/src/test/run-pass/issue-4464.rs
+++ b/src/test/run-pass/issue-4464.rs
@@ -8,6 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn broken(v: &[u8], i: uint, j: uint) -> &[u8] { v[i..j] }
+fn broken(v: &[u8], i: uint, j: uint) -> &[u8] { v.slice(i, j) }
 
 pub fn main() {}

--- a/src/test/run-pass/issue-8898.rs
+++ b/src/test/run-pass/issue-8898.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(slicing_syntax)]
 
 extern crate debug;
 

--- a/src/test/run-pass/issue-8898.rs
+++ b/src/test/run-pass/issue-8898.rs
@@ -21,7 +21,7 @@ pub fn main() {
     let abc = [1i, 2, 3];
     let tf = [true, false];
     let x  = [(), ()];
-    let slice = x[0..1];
+    let slice = x.slice(0,1);
     let z = box(GC) x;
 
     assert_repr_eq(abc, "[1, 2, 3]".to_string());

--- a/src/test/run-pass/slice-2.rs
+++ b/src/test/run-pass/slice-2.rs
@@ -10,8 +10,6 @@
 
 // Test slicing expressions on slices and Vecs.
 
-#![feature(slicing_syntax)]
-
 fn main() {
     let x: &[int] = &[1, 2, 3, 4, 5];
     let cmp: &[int] = &[1, 2, 3, 4, 5];

--- a/src/test/run-pass/slice-fail-1.rs
+++ b/src/test/run-pass/slice-fail-1.rs
@@ -10,8 +10,6 @@
 
 // Test that is a slicing expr[..] fails, the correct cleanups happen.
 
-#![feature(slicing_syntax)]
-
 use std::task;
 
 struct Foo;

--- a/src/test/run-pass/slice-fail-2.rs
+++ b/src/test/run-pass/slice-fail-2.rs
@@ -10,8 +10,6 @@
 
 // Test that is a slicing expr[..] fails, the correct cleanups happen.
 
-#![feature(slicing_syntax)]
-
 use std::task;
 
 struct Foo;

--- a/src/test/run-pass/slice.rs
+++ b/src/test/run-pass/slice.rs
@@ -10,8 +10,6 @@
 
 // Test slicing sugar.
 
-#![feature(slicing_syntax)]
-
 extern crate core;
 use core::ops::{Slice,SliceMut};
 

--- a/src/test/run-pass/slice.rs
+++ b/src/test/run-pass/slice.rs
@@ -18,38 +18,38 @@ static mut COUNT: uint = 0;
 struct Foo;
 
 impl Slice<Foo, Foo> for Foo {
-    fn as_slice<'a>(&'a self) -> &'a Foo {
+    fn as_slice_<'a>(&'a self) -> &'a Foo {
         unsafe { COUNT += 1; }
         self
     }
-    fn slice_from<'a>(&'a self, _from: &Foo) -> &'a Foo {
+    fn slice_from_<'a>(&'a self, _from: &Foo) -> &'a Foo {
         unsafe { COUNT += 1; }
         self
     }
-    fn slice_to<'a>(&'a self, _to: &Foo) -> &'a Foo {
+    fn slice_to_<'a>(&'a self, _to: &Foo) -> &'a Foo {
         unsafe { COUNT += 1; }
         self
     }
-    fn slice<'a>(&'a self, _from: &Foo, _to: &Foo) -> &'a Foo {
+    fn slice_<'a>(&'a self, _from: &Foo, _to: &Foo) -> &'a Foo {
         unsafe { COUNT += 1; }
         self
     }
 }
 
 impl SliceMut<Foo, Foo> for Foo {
-    fn as_mut_slice<'a>(&'a mut self) -> &'a mut Foo {
+    fn as_mut_slice_<'a>(&'a mut self) -> &'a mut Foo {
         unsafe { COUNT += 1; }
         self
     }
-    fn slice_from_mut<'a>(&'a mut self, _from: &Foo) -> &'a mut Foo {
+    fn slice_from_mut_<'a>(&'a mut self, _from: &Foo) -> &'a mut Foo {
         unsafe { COUNT += 1; }
         self
     }
-    fn slice_to_mut<'a>(&'a mut self, _to: &Foo) -> &'a mut Foo {
+    fn slice_to_mut_<'a>(&'a mut self, _to: &Foo) -> &'a mut Foo {
         unsafe { COUNT += 1; }
         self
     }
-    fn slice_mut<'a>(&'a mut self, _from: &Foo, _to: &Foo) -> &'a mut Foo {
+    fn slice_mut_<'a>(&'a mut self, _from: &Foo, _to: &Foo) -> &'a mut Foo {
         unsafe { COUNT += 1; }
         self
     }


### PR DESCRIPTION
This PR reverts https://github.com/rust-lang/rust/pull/17620, which caused a significant regression for slices.

As discussed with @alexcrichton, all of the public-facing changes of the earlier PR need to be rolled back, and it's not clear that we should move the libraries over to this new notation yet anyway (especially given its feature-gated status).

Closes #17710
