### PR TITLE
travis: Stop building and testing rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,63 +1,33 @@
 # Use something that's not 'ruby' so we don't set up things like
-# RVM/bundler/ruby and whatnot. Right now 'rust' isn't a language on travis and
-# it treats unknown languages as ruby-like I believe.
+# RVM/bundler/ruby and whatnot. Right now 'rust' as a language actually
+# downloads a rust/cargo snapshot, which we don't really want for building rust.
 language: c
 
-# Before we start doing anything, install a stock LLVM
+# Make sure we've got an up-to-date g++ compiler to get past the LLVM configure
+# script.
 install:
-  - sudo sh -c "echo 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.4 main' >> /etc/apt/sources.list"
-  - sudo sh -c "echo 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main' >> /etc/apt/sources.list"
-  - sudo sh -c "echo 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu precise main' >> /etc/apt/sources.list"
-  - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
-  - sudo apt-get install -qq --force-yes -y llvm-$LLVM_VERSION
-    llvm-${LLVM_VERSION}-dev clang-$LLVM_VERSION lldb-$LLVM_VERSION
+  - sudo apt-get install g++-4.7
 
-
-# All of the llvm tools are suffixed with "-$VERS" which we don't want, so
-# symlink them all into a local directory and just use that
+# The test suite is in general way too stressful for travis, especially in
+# terms of time limit and reliability. In the past we've tried to scale things
+# back to only build the stage1 compiler and run a subset of tests, but this
+# didn't end up panning out very well.
 #
-# FIXME: this shouldn't update the src/llvm sub-repo, that takes about a minute
-#        it's gotta download so much stuff.
+# As a result, we're just using travis to run `make tidy` now. It'll help
+# everyone find out about their trailing spaces early on!
 before_script:
-  - mkdir -p local-llvm/bin
-  - ln -nsf /usr/bin/llvm-config-$LLVM_VERSION local-llvm/bin/llvm-config
-  - ln -nsf /usr/bin/llvm-mc-$LLVM_VERSION local-llvm/bin/llvm-mc
-  - ln -nsf /usr/bin/llvm-as-$LLVM_VERSION local-llvm/bin/llvm-as
-  - ln -nsf /usr/bin/llvm-dis-$LLVM_VERSION local-llvm/bin/llvm-dis
-  - ln -nsf /usr/bin/llc-$LLVM_VERSION local-llvm/bin/llc
-  - ln -nsf /usr/include/llvm-$LLVM_VERSION local-llvm/include
-  - ./configure --disable-optimize-tests --llvm-root=`pwd`/local-llvm
-    --enable-fast-make --enable-clang
-
-# Tidy everything up first, then build a few things, and then run a few tests.
-# Note that this is meant to run in a "fairly small" amount of time, so this
-# isn't exhaustive at all.
-#
-# As a result of https://github.com/travis-ci/travis-ci/issues/1066, we run
-# everything in one large command instead of multiple commands.
-script: |
-  if [[ $TRAVIS_PULL_REQUEST != 'false' ]]; then
-    if [[ $LLVM_VERSION != '3.4' ]]; then exit 0; fi
-  fi &&
-  make tidy &&
-  make -j4 rustc-stage1 RUSTFLAGS='-Z time-passes' &&
-  make check-stage1-std check-stage1-rpass check-stage1-cfail check-stage1-rfail check-stage1-doc
-
-env:
-  global:
-    - NO_BENCH=1
-  matrix:
-    - LLVM_VERSION=3.3
-    - LLVM_VERSION=3.4
-
-# We track this ourselves, and in theory we don't have to update the LLVM repo
-# (but sadly we do right now anyway).
-git:
-  submodules: false
+  - ./configure --llvm-root=`pwd`/local-llvm
+script:
+  - make tidy
 
 notifications:
   email: false
+
+env:
+  global:
+    - LLVM_VERSION=3.4
 
 branches:
   only:


### PR DESCRIPTION
Instead, only run `make tidy`. The tidy script can run quite quickly, and it's
super annoying to run tests for 50 minutes only to have bors fail with a
"trailing whitespace" error.
