### PR TITLE
Update release notes and authors file for 0.12.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,8 +8,8 @@ Version 0.12.0 (October 2014)
     * The introductory documentation (now called The Rust Guide) has
       been completely rewritten, as have a number of supplementary
       guides.
-    * Rust's package manager, Cargo, continues to improve and is,
-      reportedly, 'awesome'.
+    * Rust's package manager, Cargo, continues to improve and is
+      sometimes considered to be quite awesome.
     * Many API's in `std` have been reviewed and updated for
       consistency with the in-development Rust coding
       guidelines. The standard library documentation tracks


### PR DESCRIPTION
The 0.12.0 release is nigh. I've dug through the commit log looking for the most interesting stuff to add to the release notes, but I'm positive I've missed things that should be mentioned.

The [detailed notes](https://github.com/rust-lang/rust/wiki/Doc-detailed-release-notes) on the wiki also need love.
