### PR TITLE
test: Don't depend on /bin/bash

### DIFF
--- a/src/test/run-make/rustdoc-where/verify.sh
+++ b/src/test/run-make/rustdoc-where/verify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 # $1 is the TMPDIR


### PR DESCRIPTION
Our FreeBSD bots apparently don't have bash installed, and it's ok to run with
sh anyway!

Unblocks a snapshot
