### PR TITLE
travis: Fix for real this time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,6 @@
 # downloads a rust/cargo snapshot, which we don't really want for building rust.
 language: c
 
-# Make sure we've got an up-to-date g++ compiler to get past the LLVM configure
-# script.
-install:
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update -qq
-  - sudo apt-get install g++-4.7
-
 # The test suite is in general way too stressful for travis, especially in
 # terms of time limit and reliability. In the past we've tried to scale things
 # back to only build the stage1 compiler and run a subset of tests, but this
@@ -18,7 +11,7 @@ install:
 # As a result, we're just using travis to run `make tidy` now. It'll help
 # everyone find out about their trailing spaces early on!
 before_script:
-  - ./configure
+  - ./configure --llvm-root=path/to/nowhere
 script:
   - make tidy
 


### PR DESCRIPTION
I ended up botching the merge when making the rollup, and the fix was to just
not configure LLVM all via --llvm-root with a nonexistent path.
