### PR TITLE
Remove core::any::AnyPrivate

### DIFF
--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -91,19 +91,14 @@ pub enum Void { }
 /// Every type with no non-`'static` references implements `Any`, so `Any` can
 /// be used as a trait object to emulate the effects dynamic typing.
 #[stable]
-pub trait Any: AnyPrivate + 'static {}
-
-/// An inner trait to ensure that only this module can call `get_type_id()`.
-pub trait AnyPrivate {
+pub trait Any: 'static {
     /// Get the `TypeId` of `self`
     fn get_type_id(&self) -> TypeId;
 }
 
-impl<T: 'static> AnyPrivate for T {
+impl<T: 'static> Any for T {
     fn get_type_id(&self) -> TypeId { TypeId::of::<T>() }
 }
-
-impl<T: 'static + AnyPrivate> Any for T {}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Extension methods for Any trait objects.

--- a/src/test/compile-fail/issue-14366.rs
+++ b/src/test/compile-fail/issue-14366.rs
@@ -12,6 +12,4 @@ fn main() {
     let _x = "test" as &::std::any::Any;
 //~^ ERROR the trait `core::kinds::Sized` is not implemented for the type `str`
 //~^^ NOTE the trait `core::kinds::Sized` must be implemented for the cast to the object type
-//~^^^ ERROR the trait `core::kinds::Sized` is not implemented for the type `str`
-//~^^^^ NOTE the trait `core::kinds::Sized` must be implemented for the cast to the object type
 }


### PR DESCRIPTION
[Previously](https://github.com/rust-lang/rust/commit/e5da6a71a6a0b46dd3630fc8326e6d5906a1fde6), the `Any` trait was split into a private portion and an (empty) public portion, in order to hide the implementation strategy used for downcasting. However, the [new rules](https://github.com/rust-lang/rust/commit/e9ad12c0cae5c43ada6641c7dc840a0fbe5010a2) for privacy forbid `AnyPrivate` from actually being private.

This patch thus reverts the introduction of `AnyPrivate`.

Although this is unlikely to break any real code, it removes a public trait and is therefore a:

[breaking-change]
