### PR TITLE
Fix preallocation amount in String::from_utf16

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -269,7 +269,7 @@ impl String {
     /// ```
     #[unstable = "error value in return may change"]
     pub fn from_utf16(v: &[u16]) -> Option<String> {
-        let mut s = String::with_capacity(v.len() / 2);
+        let mut s = String::with_capacity(v.len());
         for c in str::utf16_items(v) {
             match c {
                 str::ScalarValue(c) => s.push(c),


### PR DESCRIPTION
`v.len()` counts code units, not UTF-16 bytes. The lower bound is one UTF-8 byte per code unit, not per two code units.

I believe this is correct, but it’s late. Someone please double check.
