### PR TITLE
Changed `extern crate foo as bar;` error message

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4981,18 +4981,27 @@ impl<'a> Parser<'a> {
                                 attrs: Vec<Attribute> )
                                 -> ItemOrViewItem {
 
+        let span = self.span;
         let (maybe_path, ident) = match self.token {
             token::IDENT(..) => {
                 let the_ident = self.parse_ident();
-                self.expect_one_of(&[], &[token::EQ, token::SEMI]);
-                let path = if self.token == token::EQ {
-                    self.bump();
+                let path = if self.eat(&token::EQ) {
                     let path = self.parse_str();
                     let span = self.span;
                     self.obsolete(span, ObsoleteExternCrateRenaming);
                     Some(path)
-                } else {None};
+                } else if self.eat_keyword(keywords::As) {
+                    // skip the ident if there is one
+                    if is_ident(&self.token) { self.bump(); }
 
+                    self.span_err(span,
+                                  format!("expected `;`, found `as`; perhaps you meant \
+                                          to enclose the crate name `{}` in a string?",
+                                          the_ident.as_str()).as_slice());
+                    None
+                } else {
+                    None
+                };
                 self.expect(&token::SEMI);
                 (path, the_ident)
             },

--- a/src/test/compile-fail/extern-crate-as-no-string-help.rs
+++ b/src/test/compile-fail/extern-crate-as-no-string-help.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that the proper help is displayed in the error message
+
+extern crate foo as bar;
+//~^ ERROR expected `;`, found `as`; perhaps you meant to enclose the crate name `foo` in a string?

--- a/src/test/compile-fail/extern-foreign-crate.rs
+++ b/src/test/compile-fail/extern-foreign-crate.rs
@@ -11,4 +11,4 @@
 // Verifies that the expected token errors for `extern crate` are
 // raised
 
-extern crate foo {} //~ERROR expected one of `=`, `;`, found `{`
+extern crate foo {} //~ERROR expected `;`, found `{`


### PR DESCRIPTION
I did not put the crate name in the error note, if that's necessary I'll look into it.

Closes #17709
