### PR TITLE
Fix ICE generating unboxed closure type visitor glue

### DIFF
--- a/src/test/run-pass/issue-17737.rs
+++ b/src/test/run-pass/issue-17737.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unboxed_closures)]
+
+// Test generating type visitor glue for unboxed closures
+
+extern crate debug;
+
+fn main() {
+    let expected = "fn(); fn(uint, uint) -> uint; fn() -> !";
+    let result = format!("{:?}; {:?}; {:?}",
+                         |:| {},
+                         |&: x: uint, y: uint| { x + y },
+                         |&mut:| -> ! { fail!() });
+    assert_eq!(expected, result.as_slice());
+}


### PR DESCRIPTION
This is a quick fix.  In the long term, the `TyVisitor` interface should be expanded to better represent closure types.

Closes issue #17737
