### PR TITLE
Fix quote_method!

### DIFF
--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -464,13 +464,8 @@ pub fn expand_quote_method(cx: &mut ExtCtxt,
                            sp: Span,
                            tts: &[ast::TokenTree])
                            -> Box<base::MacResult+'static> {
-    let e_attrs = cx.expr_vec_ng(sp);
-    let e_visibility = cx.expr_path(cx.path_global(sp, vec!(
-        id_ext("syntax"),
-        id_ext("ast"),
-        id_ext("Inherited"))));
-    let expanded = expand_parse_call(cx, sp, "parse_method",
-                                     vec!(e_attrs, e_visibility), tts);
+    let expanded = expand_parse_call(cx, sp, "parse_method_with_outer_attributes",
+                                     vec!(), tts);
     base::MacExpr::new(expanded)
 }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4371,6 +4371,13 @@ impl<'a> Parser<'a> {
         (ident, ItemFn(decl, fn_style, abi, generics, body), Some(inner_attrs))
     }
 
+    /// Parse a method in a trait impl
+    pub fn parse_method_with_outer_attributes(&mut self) -> P<Method> {
+        let attrs = self.parse_outer_attributes();
+        let visa = self.parse_visibility();
+        self.parse_method(attrs, visa)
+    }
+
     /// Parse a method in a trait impl, starting with `attrs` attributes.
     pub fn parse_method(&mut self,
                         attrs: Vec<Attribute>,

--- a/src/test/run-pass-fulldeps/quote-tokens.rs
+++ b/src/test/run-pass-fulldeps/quote-tokens.rs
@@ -37,6 +37,7 @@ fn syntax_extension(cx: &ExtCtxt) {
     assert!(i.is_some());
 
     let _j: P<syntax::ast::Method> = quote_method!(cx, fn foo(&self) {});
+    let _k: P<syntax::ast::Method> = quote_method!(cx, #[doc = "hello"] fn foo(&self) {});
 }
 
 fn main() {


### PR DESCRIPTION
The previous fix introduced in 75d49c8203405ab0af7a2b8b8698af02868fdbc2 neglected to parse outer attributes as described in #17782.
