### PR TITLE
Fix target-feature codegen option syntax in rustc man page.

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -125,8 +125,8 @@ is invoked.
 Selects a target processor. If the value is 'help', then a list of available
 CPUs is printed.
 .TP
-\fBtarget-feature\fR='+feature1 -feature2'
-A space-separated list of features to enable or disable for the target. A
+\fBtarget-feature\fR='+feature1,-feature2'
+A comma-separated list of features to enable or disable for the target. A
 preceding '+' enables a feature while a preceding '-' disables it. Available
 features can be discovered through target-cpu=help.
 .TP


### PR DESCRIPTION
The man page stated that the list of features was space-separated when
it's actually comma-separated.
