### PR TITLE
rustdoc: Fix up some bugs with bounds

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -324,7 +324,7 @@ fn build_impl(cx: &DocContext, tcx: &ty::ctxt,
             trait_: associated_trait.clean(cx).map(|bound| {
                 match bound {
                     clean::TraitBound(ty) => ty,
-                    clean::UnboxedFnBound => unimplemented!(),
+                    clean::UnboxedFnBound(..) |
                     clean::RegionBound(..) |
                     clean::UnknownBound => unreachable!(),
                 }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -324,7 +324,9 @@ fn build_impl(cx: &DocContext, tcx: &ty::ctxt,
             trait_: associated_trait.clean(cx).map(|bound| {
                 match bound {
                     clean::TraitBound(ty) => ty,
-                    clean::RegionBound => unreachable!(),
+                    clean::UnboxedFnBound => unimplemented!(),
+                    clean::RegionBound(..) |
+                    clean::UnknownBound => unreachable!(),
                 }
             }),
             for_: ty.ty.clean(cx),

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -325,8 +325,7 @@ fn build_impl(cx: &DocContext, tcx: &ty::ctxt,
                 match bound {
                     clean::TraitBound(ty) => ty,
                     clean::UnboxedFnBound(..) |
-                    clean::RegionBound(..) |
-                    clean::UnknownBound => unreachable!(),
+                    clean::RegionBound(..) => unreachable!(),
                 }
             }),
             for_: ty.ty.clean(cx),

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -475,7 +475,6 @@ impl Clean<TyParam> for ty::TypeParameterDef {
 pub enum TyParamBound {
     RegionBound(Lifetime),
     UnboxedFnBound(UnboxedFnType),
-    UnknownBound,
     TraitBound(Type)
 }
 
@@ -521,7 +520,7 @@ impl Clean<TyParamBound> for ty::BuiltinBound {
     fn clean(&self, cx: &DocContext) -> TyParamBound {
         let tcx = match cx.tcx_opt() {
             Some(tcx) => tcx,
-            None => return UnknownBound
+            None => return RegionBound(Lifetime::statik())
         };
         let empty = subst::Substs::empty();
         let (did, path) = match *self {
@@ -554,7 +553,7 @@ impl Clean<TyParamBound> for ty::TraitRef {
     fn clean(&self, cx: &DocContext) -> TyParamBound {
         let tcx = match cx.tcx_opt() {
             Some(tcx) => tcx,
-            None => return UnknownBound
+            None => return RegionBound(Lifetime::statik())
         };
         let fqn = csearch::get_item_path(tcx, self.def_id);
         let fqn = fqn.into_iter().map(|i| i.to_string())

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -462,6 +462,7 @@ impl Clean<TyParam> for ty::TypeParameterDef {
     fn clean(&self, cx: &DocContext) -> TyParam {
         cx.external_typarams.borrow_mut().as_mut().unwrap()
           .insert(self.def_id, self.ident.clean(cx));
+
         TyParam {
             name: self.ident.clean(cx),
             did: self.def_id,
@@ -580,6 +581,9 @@ impl Clean<Vec<TyParamBound>> for ty::ParamBounds {
         }
         for t in self.trait_bounds.iter() {
             v.push(t.clean(cx));
+        }
+        for r in self.region_bounds.iter().filter_map(|r| r.clean(cx)) {
+            v.push(RegionBound(r));
         }
         return v;
     }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -143,8 +143,8 @@ impl fmt::Show for clean::TyParamBound {
             clean::RegionBound(ref lt) => {
                 write!(f, "{}", *lt)
             }
-            clean::UnboxedFnBound(..) => {
-                write!(f, "Fn(???)") // FIXME
+            clean::UnboxedFnBound(ref ty) => {
+                write!(f, "{}{}", ty.path, ty.decl)
             }
             clean::UnknownBound => {
                 write!(f, "'static")
@@ -408,7 +408,7 @@ impl fmt::Show for clean::Type {
                            for bound in decl.bounds.iter() {
                                 match *bound {
                                     clean::RegionBound(..) |
-                                    clean::UnboxedFnBound |
+                                    clean::UnboxedFnBound(..) |
                                     clean::UnknownBound => {}
                                     clean::TraitBound(ref t) => {
                                         if ret.len() == 0 {

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -146,9 +146,6 @@ impl fmt::Show for clean::TyParamBound {
             clean::UnboxedFnBound(ref ty) => {
                 write!(f, "{}{}", ty.path, ty.decl)
             }
-            clean::UnknownBound => {
-                write!(f, "'static")
-            }
             clean::TraitBound(ref ty) => {
                 write!(f, "{}", *ty)
             }
@@ -408,8 +405,7 @@ impl fmt::Show for clean::Type {
                            for bound in decl.bounds.iter() {
                                 match *bound {
                                     clean::RegionBound(..) |
-                                    clean::UnboxedFnBound(..) |
-                                    clean::UnknownBound => {}
+                                    clean::UnboxedFnBound(..) => {}
                                     clean::TraitBound(ref t) => {
                                         if ret.len() == 0 {
                                             ret.push_str(": ");

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -140,8 +140,14 @@ impl fmt::Show for clean::Lifetime {
 impl fmt::Show for clean::TyParamBound {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            clean::RegionBound => {
-                f.write("'static".as_bytes())
+            clean::RegionBound(ref lt) => {
+                write!(f, "{}", *lt)
+            }
+            clean::UnboxedFnBound(..) => {
+                write!(f, "Fn(???)") // FIXME
+            }
+            clean::UnknownBound => {
+                write!(f, "'static")
             }
             clean::TraitBound(ref ty) => {
                 write!(f, "{}", *ty)
@@ -401,7 +407,9 @@ impl fmt::Show for clean::Type {
                            let mut ret = String::new();
                            for bound in decl.bounds.iter() {
                                 match *bound {
-                                    clean::RegionBound => {}
+                                    clean::RegionBound(..) |
+                                    clean::UnboxedFnBound |
+                                    clean::UnknownBound => {}
                                     clean::TraitBound(ref t) => {
                                         if ret.len() == 0 {
                                             ret.push_str(": ");


### PR DESCRIPTION
This PR adds support in rustdoc for properly naming lifetimes in bounds, instead of just showing `'static` for everything. It also adds support for unboxed function sugar bounds, which were also previously rendered as `'static`.
