### PR TITLE
Fix ICE generating debug info for unboxed closures

### DIFF
--- a/src/test/run-pass/unboxed-closures-unique-type-id.rs
+++ b/src/test/run-pass/unboxed-closures-unique-type-id.rs
@@ -16,6 +16,8 @@
 //    ReScope(63u32))
 //
 // This is a regression test for issue #17021.
+//
+// compile-flags: -g
 
 #![feature(unboxed_closures, overloaded_calls)]
 


### PR DESCRIPTION
This closes issue #17021.
