### PR TITLE
Improve interpolation of macro lhs and doc comments. Remove `Matcher`s

### DIFF
--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -163,7 +163,8 @@ fn doit(sess: &parse::ParseSess, mut lexer: lexer::StringReader,
 
             token::Lifetime(..) => "lifetime",
             token::DocComment(..) => "doccomment",
-            token::Underscore | token::Eof | token::Interpolated(..) => "",
+            token::Underscore | token::Eof | token::Interpolated(..) |
+                token::MatchNt(..) | token::SubstNt(..) => "",
         };
 
         // as mentioned above, use the original source code instead of

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -78,7 +78,7 @@
 
 
 use ast;
-use ast::{Matcher, TokenTree, Ident};
+use ast::{TokenTree, Ident};
 use ast::{TtDelimited, TtSequence, TtToken};
 use codemap::{BytePos, mk_sp};
 use codemap;
@@ -97,9 +97,8 @@ use std::rc::Rc;
 use std::collections::HashMap;
 use std::collections::hash_map::{Vacant, Occupied};
 
-/* to avoid costly uniqueness checks, we require that `MatchSeq` always has a
-nonempty body. */
-
+// To avoid costly uniqueness checks, we require that `MatchSeq` always has
+// a nonempty body.
 
 /// an unzipping of `TokenTree`s
 #[deriving(Clone)]
@@ -157,22 +156,22 @@ pub fn initial_matcher_pos(ms: Rc<Vec<TokenTree>>, sep: Option<Token>, lo: ByteP
     }
 }
 
-/// NamedMatch is a pattern-match result for a single ast::MatchNonterminal:
+/// NamedMatch is a pattern-match result for a single token::MATCH_NONTERMINAL:
 /// so it is associated with a single ident in a parse, and all
-/// MatchedNonterminal's in the NamedMatch have the same nonterminal type
-/// (expr, item, etc). All the leaves in a single NamedMatch correspond to a
-/// single matcher_nonterminal in the ast::Matcher that produced it.
+/// `MatchedNonterminal`s in the NamedMatch have the same nonterminal type
+/// (expr, item, etc). Each leaf in a single NamedMatch corresponds to a
+/// single token::MATCH_NONTERMINAL in the TokenTree that produced it.
 ///
 /// The in-memory structure of a particular NamedMatch represents the match
 /// that occurred when a particular subset of a matcher was applied to a
 /// particular token tree.
 ///
 /// The width of each MatchedSeq in the NamedMatch, and the identity of the
-/// MatchedNonterminal's, will depend on the token tree it was applied to: each
-/// MatchedSeq corresponds to a single MatchSeq in the originating
-/// ast::Matcher. The depth of the NamedMatch structure will therefore depend
-/// only on the nesting depth of ast::MatchSeq's in the originating
-/// ast::Matcher it was derived from.
+/// `MatchedNonterminal`s, will depend on the token tree it was applied to:
+/// each MatchedSeq corresponds to a single TTSeq in the originating
+/// token tree. The depth of the NamedMatch structure will therefore depend
+/// only on the nesting depth of `ast::TTSeq`s in the originating
+/// token tree it was derived from.
 
 pub enum NamedMatch {
     MatchedSeq(Vec<Rc<NamedMatch>>, codemap::Span),
@@ -512,7 +511,6 @@ pub fn parse_nt(p: &mut Parser, name: &str) -> Nonterminal {
         p.quote_depth -= 1u;
         res
       }
-      "matchers" => token::NtMatchers(p.parse_matchers()),
       _ => {
           p.fatal(format!("unsupported builtin nonterminal parser: {}",
                           name).as_slice())

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -78,69 +78,80 @@
 
 
 use ast;
-use ast::{Matcher, MatchTok, MatchSeq, MatchNonterminal, Ident};
+use ast::{Matcher, TokenTree, Ident};
+use ast::{TtDelimited, TtSequence, TtToken};
 use codemap::{BytePos, mk_sp};
 use codemap;
 use parse::lexer::*; //resolve bug?
 use parse::ParseSess;
 use parse::attr::ParserAttr;
 use parse::parser::{LifetimeAndTypesWithoutColons, Parser};
+use parse::token::{Eof, DocComment, MatchNt, SubstNt};
 use parse::token::{Token, Nonterminal};
 use parse::token;
 use print::pprust;
 use ptr::P;
 
+use std::mem;
 use std::rc::Rc;
 use std::collections::HashMap;
+use std::collections::hash_map::{Vacant, Occupied};
 
 /* to avoid costly uniqueness checks, we require that `MatchSeq` always has a
 nonempty body. */
 
 
+/// an unzipping of `TokenTree`s
+#[deriving(Clone)]
+struct MatcherTtFrame {
+    elts: Rc<Vec<ast::TokenTree>>,
+    idx: uint,
+}
+
 #[deriving(Clone)]
 pub struct MatcherPos {
-    elts: Vec<ast::Matcher> , // maybe should be <'>? Need to understand regions.
+    stack: Vec<MatcherTtFrame>,
+    elts: Rc<Vec<ast::TokenTree>>,
     sep: Option<Token>,
     idx: uint,
     up: Option<Box<MatcherPos>>,
     matches: Vec<Vec<Rc<NamedMatch>>>,
-    match_lo: uint, match_hi: uint,
+    match_lo: uint,
+    match_cur: uint,
+    match_hi: uint,
     sp_lo: BytePos,
 }
 
-pub fn count_names(ms: &[Matcher]) -> uint {
-    ms.iter().fold(0, |ct, m| {
-        ct + match m.node {
-            MatchTok(_) => 0u,
-            MatchSeq(ref more_ms, _, _, _, _) => {
-                count_names(more_ms.as_slice())
+pub fn count_names(ms: &[TokenTree]) -> uint {
+    ms.iter().fold(0, |count, elt| {
+        count + match elt {
+            &TtSequence(_, _, _, _, advance_by) => {
+                advance_by
             }
-            MatchNonterminal(_, _, _) => 1u
-        }})
+            &TtDelimited(_, ref delim) => {
+                count_names(delim.tts.as_slice())
+            }
+            &TtToken(_, MatchNt(..)) => {
+                1
+            }
+            &TtToken(_, _) => 0,
+        }
+    })
 }
 
-pub fn initial_matcher_pos(ms: Vec<Matcher> , sep: Option<Token>, lo: BytePos)
+pub fn initial_matcher_pos(ms: Rc<Vec<TokenTree>>, sep: Option<Token>, lo: BytePos)
                            -> Box<MatcherPos> {
-    let mut match_idx_hi = 0u;
-    for elt in ms.iter() {
-        match elt.node {
-            MatchTok(_) => (),
-            MatchSeq(_,_,_,_,hi) => {
-                match_idx_hi = hi;       // it is monotonic...
-            }
-            MatchNonterminal(_,_,pos) => {
-                match_idx_hi = pos+1u;  // ...so latest is highest
-            }
-        }
-    }
-    let matches = Vec::from_fn(count_names(ms.as_slice()), |_i| Vec::new());
+    let match_idx_hi = count_names(ms.as_slice());
+    let matches = Vec::from_fn(match_idx_hi, |_i| Vec::new());
     box MatcherPos {
+        stack: vec![],
         elts: ms,
         sep: sep,
         idx: 0u,
         up: None,
         matches: matches,
         match_lo: 0u,
+        match_cur: 0u,
         match_hi: match_idx_hi,
         sp_lo: lo
     }
@@ -152,11 +163,9 @@ pub fn initial_matcher_pos(ms: Vec<Matcher> , sep: Option<Token>, lo: BytePos)
 /// (expr, item, etc). All the leaves in a single NamedMatch correspond to a
 /// single matcher_nonterminal in the ast::Matcher that produced it.
 ///
-/// It should probably be renamed, it has more or less exact correspondence to
-/// ast::match nodes, and the in-memory structure of a particular NamedMatch
-/// represents the match that occurred when a particular subset of an
-/// ast::match -- those ast::Matcher nodes leading to a single
-/// MatchNonterminal -- was applied to a particular token tree.
+/// The in-memory structure of a particular NamedMatch represents the match
+/// that occurred when a particular subset of a matcher was applied to a
+/// particular token tree.
 ///
 /// The width of each MatchedSeq in the NamedMatch, and the identity of the
 /// MatchedNonterminal's, will depend on the token tree it was applied to: each
@@ -170,34 +179,43 @@ pub enum NamedMatch {
     MatchedNonterminal(Nonterminal)
 }
 
-pub fn nameize(p_s: &ParseSess, ms: &[Matcher], res: &[Rc<NamedMatch>])
+pub fn nameize(p_s: &ParseSess, ms: &[TokenTree], res: &[Rc<NamedMatch>])
             -> HashMap<Ident, Rc<NamedMatch>> {
-    fn n_rec(p_s: &ParseSess, m: &Matcher, res: &[Rc<NamedMatch>],
-             ret_val: &mut HashMap<Ident, Rc<NamedMatch>>) {
-        match *m {
-          codemap::Spanned {node: MatchTok(_), .. } => (),
-          codemap::Spanned {node: MatchSeq(ref more_ms, _, _, _, _), .. } => {
-            for next_m in more_ms.iter() {
-                n_rec(p_s, next_m, res, ret_val)
-            };
-          }
-          codemap::Spanned {
-                node: MatchNonterminal(bind_name, _, idx),
-                span
-          } => {
-            if ret_val.contains_key(&bind_name) {
-                let string = token::get_ident(bind_name);
-                p_s.span_diagnostic
-                   .span_fatal(span,
-                               format!("duplicated bind name: {}",
-                                       string.get()).as_slice())
+    fn n_rec(p_s: &ParseSess, m: &TokenTree, res: &[Rc<NamedMatch>],
+             ret_val: &mut HashMap<Ident, Rc<NamedMatch>>, idx: &mut uint) {
+        match m {
+            &TtSequence(_, ref more_ms, _, _, _) => {
+                for next_m in more_ms.iter() {
+                    n_rec(p_s, next_m, res, ret_val, idx)
+                }
             }
-            ret_val.insert(bind_name, res[idx].clone());
-          }
+            &TtDelimited(_, ref delim) => {
+                for next_m in delim.tts.iter() {
+                    n_rec(p_s, next_m, res, ret_val, idx)
+                }
+            }
+            &TtToken(sp, MatchNt(bind_name, _, _, _)) => {
+                match ret_val.entry(bind_name) {
+                    Vacant(spot) => {
+                        spot.set(res[*idx].clone());
+                        *idx += 1;
+                    }
+                    Occupied(..) => {
+                        let string = token::get_ident(bind_name);
+                        p_s.span_diagnostic
+                           .span_fatal(sp,
+                                       format!("duplicated bind name: {}",
+                                               string.get()).as_slice())
+                    }
+                }
+            }
+            &TtToken(_, SubstNt(..)) => panic!("Cannot fill in a NT"),
+            &TtToken(_, _) => (),
         }
     }
     let mut ret_val = HashMap::new();
-    for m in ms.iter() { n_rec(p_s, m, res, &mut ret_val) }
+    let mut idx = 0u;
+    for m in ms.iter() { n_rec(p_s, m, res, &mut ret_val, &mut idx) }
     ret_val
 }
 
@@ -210,7 +228,7 @@ pub enum ParseResult {
 pub fn parse_or_else(sess: &ParseSess,
                      cfg: ast::CrateConfig,
                      rdr: TtReader,
-                     ms: Vec<Matcher> )
+                     ms: Vec<TokenTree> )
                      -> HashMap<Ident, Rc<NamedMatch>> {
     match parse(sess, cfg, rdr, ms.as_slice()) {
         Success(m) => m,
@@ -237,12 +255,12 @@ pub fn token_name_eq(t1 : &Token, t2 : &Token) -> bool {
 pub fn parse(sess: &ParseSess,
              cfg: ast::CrateConfig,
              mut rdr: TtReader,
-             ms: &[Matcher])
+             ms: &[TokenTree])
              -> ParseResult {
     let mut cur_eis = Vec::new();
-    cur_eis.push(initial_matcher_pos(ms.iter()
-                                       .map(|x| (*x).clone())
-                                       .collect(),
+    cur_eis.push(initial_matcher_pos(Rc::new(ms.iter()
+                                                .map(|x| (*x).clone())
+                                                .collect()),
                                      None,
                                      rdr.peek().sp.lo));
 
@@ -255,10 +273,21 @@ pub fn parse(sess: &ParseSess,
 
         /* we append new items to this while we go */
         loop {
-            let ei = match cur_eis.pop() {
+            let mut ei = match cur_eis.pop() {
                 None => break, /* for each Earley Item */
                 Some(ei) => ei,
             };
+
+            // When unzipped trees end, remove them
+            while ei.idx >= ei.elts.len() {
+                match ei.stack.pop() {
+                    Some(MatcherTtFrame { elts, idx }) => {
+                        ei.elts = elts;
+                        ei.idx = idx + 1;
+                    }
+                    None => break
+                }
+            }
 
             let idx = ei.idx;
             let len = ei.elts.len();
@@ -293,6 +322,7 @@ pub fn parse(sess: &ParseSess,
                                                                        sp.hi))));
                         }
 
+                        new_pos.match_cur = ei.match_hi;
                         new_pos.idx += 1;
                         cur_eis.push(new_pos);
                     }
@@ -301,69 +331,88 @@ pub fn parse(sess: &ParseSess,
 
                     // the *_t vars are workarounds for the lack of unary move
                     match ei.sep {
-                      Some(ref t) if idx == len => { // we need a separator
-                        // i'm conflicted about whether this should be hygienic....
-                        // though in this case, if the separators are never legal
-                        // idents, it shouldn't matter.
-                        if token_name_eq(&tok, t) { //pass the separator
-                            let mut ei_t = ei.clone();
-                            ei_t.idx += 1;
-                            next_eis.push(ei_t);
+                        Some(ref t) if idx == len => { // we need a separator
+                            // i'm conflicted about whether this should be hygienic....
+                            // though in this case, if the separators are never legal
+                            // idents, it shouldn't matter.
+                            if token_name_eq(&tok, t) { //pass the separator
+                                let mut ei_t = ei.clone();
+                                // ei_t.match_cur = ei_t.match_lo;
+                                ei_t.idx += 1;
+                                next_eis.push(ei_t);
+                            }
                         }
-                      }
-                      _ => { // we don't need a separator
-                        let mut ei_t = ei;
-                        ei_t.idx = 0;
-                        cur_eis.push(ei_t);
-                      }
+                        _ => { // we don't need a separator
+                            let mut ei_t = ei;
+                            ei_t.match_cur = ei_t.match_lo;
+                            ei_t.idx = 0;
+                            cur_eis.push(ei_t);
+                        }
                     }
                 } else {
                     eof_eis.push(ei);
                 }
             } else {
-                match ei.elts[idx].node.clone() {
-                  /* need to descend into sequence */
-                  MatchSeq(ref matchers, ref sep, kleene_op,
-                           match_idx_lo, match_idx_hi) => {
-                    if kleene_op == ast::ZeroOrMore {
-                        let mut new_ei = ei.clone();
-                        new_ei.idx += 1u;
-                        //we specifically matched zero repeats.
-                        for idx in range(match_idx_lo, match_idx_hi) {
-                            new_ei.matches[idx]
-                                  .push(Rc::new(MatchedSeq(Vec::new(), sp)));
+                match (*ei.elts)[idx].clone() {
+                    /* need to descend into sequence */
+                    TtSequence(_, ref matchers, ref sep, kleene_op, match_num) => {
+                        if kleene_op == ast::ZeroOrMore {
+                            let mut new_ei = ei.clone();
+                            new_ei.match_cur += match_num;
+                            new_ei.idx += 1u;
+                            //we specifically matched zero repeats.
+                            for idx in range(ei.match_cur, ei.match_cur + match_num) {
+                                new_ei.matches[idx]
+                                      .push(Rc::new(MatchedSeq(Vec::new(), sp)));
+                            }
+
+                            cur_eis.push(new_ei);
                         }
 
-                        cur_eis.push(new_ei);
+                        let matches = Vec::from_elem(ei.matches.len(), Vec::new());
+                        let ei_t = ei;
+                        cur_eis.push(box MatcherPos {
+                            stack: vec![],
+                            elts: matchers.clone(),
+                            sep: (*sep).clone(),
+                            idx: 0u,
+                            matches: matches,
+                            match_lo: ei_t.match_cur,
+                            match_cur: ei_t.match_cur,
+                            match_hi: ei_t.match_cur + match_num,
+                            up: Some(ei_t),
+                            sp_lo: sp.lo
+                        });
                     }
-
-                    let matches = Vec::from_elem(ei.matches.len(), Vec::new());
-                    let ei_t = ei;
-                    cur_eis.push(box MatcherPos {
-                        elts: (*matchers).clone(),
-                        sep: (*sep).clone(),
-                        idx: 0u,
-                        up: Some(ei_t),
-                        matches: matches,
-                        match_lo: match_idx_lo, match_hi: match_idx_hi,
-                        sp_lo: sp.lo
-                    });
-                  }
-                  MatchNonterminal(_,_,_) => {
-                    // Built-in nonterminals never start with these tokens,
-                    // so we can eliminate them from consideration.
-                    match tok {
-                        token::CloseDelim(_) => {},
-                        _ => bb_eis.push(ei),
+                    TtToken(_, MatchNt(..)) => {
+                        // Built-in nonterminals never start with these tokens,
+                        // so we can eliminate them from consideration.
+                        match tok {
+                            token::CloseDelim(_) => {},
+                            _ => bb_eis.push(ei),
+                        }
                     }
-                  }
-                  MatchTok(ref t) => {
-                    let mut ei_t = ei.clone();
-                    if token_name_eq(t,&tok) {
-                        ei_t.idx += 1;
-                        next_eis.push(ei_t);
+                    TtToken(sp, SubstNt(..)) => {
+                        return Error(sp, "Cannot transcribe in macro LHS".into_string())
                     }
-                  }
+                    seq @ TtDelimited(..) | seq @ TtToken(_, DocComment(..)) => {
+                        let tts = seq.expand_into_tts();
+                        let elts = mem::replace(&mut ei.elts, tts);
+                        let idx = ei.idx;
+                        ei.stack.push(MatcherTtFrame {
+                            elts: elts,
+                            idx: idx,
+                        });
+                        ei.idx = 0;
+                        cur_eis.push(ei);
+                    }
+                    TtToken(_, ref t) => {
+                        let mut ei_t = ei.clone();
+                        if token_name_eq(t,&tok) {
+                            ei_t.idx += 1;
+                            next_eis.push(ei_t);
+                        }
+                    }
                 }
             }
         }
@@ -385,8 +434,8 @@ pub fn parse(sess: &ParseSess,
             if (bb_eis.len() > 0u && next_eis.len() > 0u)
                 || bb_eis.len() > 1u {
                 let nts = bb_eis.iter().map(|ei| {
-                    match ei.elts[ei.idx].node {
-                      MatchNonterminal(bind, name, _) => {
+                    match (*ei.elts)[ei.idx] {
+                      TtToken(_, MatchNt(bind, name, _, _)) => {
                         (format!("{} ('{}')",
                                 token::get_ident(name),
                                 token::get_ident(bind))).to_string()
@@ -410,12 +459,14 @@ pub fn parse(sess: &ParseSess,
                 let mut rust_parser = Parser::new(sess, cfg.clone(), box rdr.clone());
 
                 let mut ei = bb_eis.pop().unwrap();
-                match ei.elts[ei.idx].node {
-                  MatchNonterminal(_, name, idx) => {
+                match (*ei.elts)[ei.idx] {
+                  TtToken(_, MatchNt(_, name, _, _)) => {
                     let name_string = token::get_ident(name);
-                    ei.matches[idx].push(Rc::new(MatchedNonterminal(
+                    let match_cur = ei.match_cur;
+                    ei.matches[match_cur].push(Rc::new(MatchedNonterminal(
                         parse_nt(&mut rust_parser, name_string.get()))));
                     ei.idx += 1u;
+                    ei.match_cur += 1;
                   }
                   _ => panic!()
                 }

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -164,11 +164,12 @@ fn generic_extension<'cx>(cx: &'cx ExtCtxt,
                 _ => cx.span_fatal(sp, "malformed macro lhs")
             };
             // `None` is because we're not interpolating
-            let arg_rdr = new_tt_reader(&cx.parse_sess().span_diagnostic,
-                                        None,
-                                        arg.iter()
-                                           .map(|x| (*x).clone())
-                                           .collect());
+            let mut arg_rdr = new_tt_reader(&cx.parse_sess().span_diagnostic,
+                                            None,
+                                            arg.iter()
+                                               .map(|x| (*x).clone())
+                                               .collect());
+            arg_rdr.desugar_doc_comments = true;
             match parse(cx.parse_sess(), cx.cfg(), arg_rdr, lhs_tt) {
               Success(named_matches) => {
                 let rhs = match *rhses[i] {

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast::{Ident, Matcher_, Matcher, MatchTok, MatchNonterminal, MatchSeq, TtDelimited};
-use ast::{TtSequence, TtToken};
+use ast::{Ident, TtDelimited, TtSequence, TtToken};
 use ast;
 use codemap::{Span, DUMMY_SP};
 use ext::base::{ExtCtxt, MacResult, MacroDef};
@@ -21,7 +20,7 @@ use parse::lexer::new_tt_reader;
 use parse::parser::Parser;
 use parse::attr::ParserAttr;
 use parse::token::{special_idents, gensym_ident};
-use parse::token::{MatchNt, NtMatchers, NtTT};
+use parse::token::{MatchNt, NtTT};
 use parse::token;
 use print;
 use ptr::P;
@@ -206,6 +205,11 @@ fn generic_extension<'cx>(cx: &'cx ExtCtxt,
     }
     cx.span_fatal(best_fail_spot, best_fail_msg.as_slice());
 }
+
+// Note that macro-by-example's input is also matched against a token tree:
+//                   $( $lhs:tt => $rhs:tt );+
+//
+// Holy self-referential!
 
 /// This procedure performs the expansion of the
 /// macro_rules! macro. It parses the RHS and adds

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -233,20 +233,24 @@ pub fn add_new_extension<'cx>(cx: &'cx mut ExtCtxt,
     let match_rhs_tok = MatchNt(rhs_nm, special_idents::tt, token::Plain, token::Plain);
     let argument_gram = vec!(
         TtSequence(DUMMY_SP,
-                   Rc::new(vec![
-                       TtToken(DUMMY_SP, match_lhs),
-                       TtToken(DUMMY_SP, token::FatArrow),
-                       TtToken(DUMMY_SP, match_rhs)]),
-                   Some(token::Semi),
-                   ast::OneOrMore,
-                   2),
+                   Rc::new(ast::SequenceRepetition {
+                       tts: vec![
+                           TtToken(DUMMY_SP, match_lhs_tok),
+                           TtToken(DUMMY_SP, token::FatArrow),
+                           TtToken(DUMMY_SP, match_rhs_tok)],
+                       separator: Some(token::Semi),
+                       op: ast::OneOrMore,
+                       num_captures: 2
+                   })),
         //to phase into semicolon-termination instead of
         //semicolon-separation
         TtSequence(DUMMY_SP,
-                   Rc::new(vec![TtToken(DUMMY_SP, token::Semi)]),
-                   None,
-                   ast::ZeroOrMore,
-                   0));
+                   Rc::new(ast::SequenceRepetition {
+                       tts: vec![TtToken(DUMMY_SP, token::Semi)],
+                       separator: None,
+                       op: ast::ZeroOrMore,
+                       num_captures: 0
+                   })));
 
 
     // Parse the macro_rules! invocation (`none` is for no interpolations):

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -581,13 +581,12 @@ pub fn noop_fold_tt<T: Folder>(tt: &TokenTree, fld: &mut T) -> TokenTree {
                             }
                         ))
         },
-        TtSequence(span, ref pattern, ref sep, is_optional) =>
+        TtSequence(span, ref pattern, ref sep, is_optional, advance_by) =>
             TtSequence(span,
                        Rc::new(fld.fold_tts(pattern.as_slice())),
                        sep.clone().map(|tok| fld.fold_token(tok)),
-                       is_optional),
-        TtNonterminal(sp,ref ident) =>
-            TtNonterminal(sp,fld.fold_ident(*ident))
+                       is_optional,
+                       advance_by),
     }
 }
 
@@ -603,6 +602,12 @@ pub fn noop_fold_token<T: Folder>(t: token::Token, fld: &mut T) -> token::Token 
         }
         token::Lifetime(id) => token::Lifetime(fld.fold_ident(id)),
         token::Interpolated(nt) => token::Interpolated(fld.fold_interpolated(nt)),
+        token::SubstNt(ident, namep) => {
+            token::SubstNt(fld.fold_ident(ident), namep)
+        }
+        token::MatchNt(name, kind, namep, kindp) => {
+            token::MatchNt(fld.fold_ident(name), fld.fold_ident(kind), namep, kindp)
+        }
         _ => t
     }
 }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -581,12 +581,13 @@ pub fn noop_fold_tt<T: Folder>(tt: &TokenTree, fld: &mut T) -> TokenTree {
                             }
                         ))
         },
-        TtSequence(span, ref pattern, ref sep, is_optional, advance_by) =>
+        TtSequence(span, ref seq) =>
             TtSequence(span,
-                       Rc::new(fld.fold_tts(pattern.as_slice())),
-                       sep.clone().map(|tok| fld.fold_token(tok)),
-                       is_optional,
-                       advance_by),
+                       Rc::new(SequenceRepetition {
+                           tts: fld.fold_tts(seq.tts.as_slice()),
+                           separator: seq.separator.clone().map(|tok| fld.fold_token(tok)),
+                           ..**seq
+                       })),
     }
 }
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -656,8 +656,6 @@ pub fn noop_fold_interpolated<T: Folder>(nt: token::Nonterminal, fld: &mut T)
         token::NtMeta(meta_item) => token::NtMeta(fld.fold_meta_item(meta_item)),
         token::NtPath(box path) => token::NtPath(box fld.fold_path(path)),
         token::NtTT(tt) => token::NtTT(P(fld.fold_tt(&*tt))),
-        // it looks to me like we can leave out the matchers: token::NtMatchers(matchers)
-        _ => nt
     }
 }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -48,7 +48,8 @@ use ast::{StmtExpr, StmtSemi, StmtMac, StructDef, StructField};
 use ast::{StructVariantKind, BiSub};
 use ast::StrStyle;
 use ast::{SelfExplicit, SelfRegion, SelfStatic, SelfValue};
-use ast::{Delimited, TokenTree, TraitItem, TraitRef, TtDelimited, TtSequence, TtToken};
+use ast::{Delimited, SequenceRepetition, TokenTree, TraitItem, TraitRef};
+use ast::{TtDelimited, TtSequence, TtToken};
 use ast::{TupleVariantKind, Ty, Ty_, TyBot};
 use ast::{TypeField, TyFixedLengthVec, TyClosure, TyProc, TyBareFn};
 use ast::{TyTypeof, TyInfer, TypeMethod};
@@ -2551,7 +2552,13 @@ impl<'a> Parser<'a> {
                         Spanned { node, .. } => node,
                     };
                     let name_num = macro_parser::count_names(seq.as_slice());
-                    TtSequence(mk_sp(sp.lo, p.span.hi), Rc::new(seq), sep, repeat, name_num)
+                    TtSequence(mk_sp(sp.lo, p.span.hi),
+                               Rc::new(SequenceRepetition {
+                                   tts: seq,
+                                   separator: sep,
+                                   op: repeat,
+                                   num_captures: name_num
+                               }))
                 } else {
                     // A nonterminal that matches or not
                     let namep = match p.token { token::Ident(_, p) => p, _ => token::Plain };

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -337,7 +337,6 @@ pub enum Nonterminal {
     NtMeta(P<ast::MetaItem>),
     NtPath(Box<ast::Path>),
     NtTT(P<ast::TokenTree>), // needs P'ed to break a circularity
-    NtMatchers(Vec<ast::Matcher>)
 }
 
 impl fmt::Show for Nonterminal {
@@ -353,7 +352,6 @@ impl fmt::Show for Nonterminal {
             NtMeta(..) => f.pad("NtMeta(..)"),
             NtPath(..) => f.pad("NtPath(..)"),
             NtTT(..) => f.pad("NtTT(..)"),
-            NtMatchers(..) => f.pad("NtMatchers(..)"),
         }
     }
 }

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -108,7 +108,15 @@ pub enum Token {
 
     /* For interpolation */
     Interpolated(Nonterminal),
+    // Can be expanded into several tokens.
+    /// Doc comment
     DocComment(ast::Name),
+    // In left-hand-sides of MBE macros:
+    /// Parse a nonterminal (name to bind, name of NT, styles of their idents)
+    MatchNt(ast::Ident, ast::Ident, IdentStyle, IdentStyle),
+    // In right-hand-sides of MBE macros:
+    /// A syntactic variable that will be filled in by macro expansion.
+    SubstNt(ast::Ident, IdentStyle),
 
     // Junk. These carry no data because we don't really care about the data
     // they *would* carry, and don't really want to allocate a new ident for

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -254,6 +254,8 @@ pub fn token_to_string(tok: &Token) -> String {
 
         /* Other */
         token::DocComment(s)        => s.as_str().into_string(),
+        token::SubstNt(s, _)        => format!("${}", s),
+        token::MatchNt(s, t, _, _)  => format!("${}:{}", s, t),
         token::Eof                  => "<eof>".into_string(),
         token::Whitespace           => " ".into_string(),
         token::Comment              => "/* */".into_string(),
@@ -1120,13 +1122,6 @@ impl<'a> State<'a> {
     /// expression arguments as expressions). It can be done! I think.
     pub fn print_tt(&mut self, tt: &ast::TokenTree) -> IoResult<()> {
         match *tt {
-            ast::TtDelimited(_, ref delimed) => {
-                try!(word(&mut self.s, token_to_string(&delimed.open_token()).as_slice()));
-                try!(space(&mut self.s));
-                try!(self.print_tts(delimed.tts.as_slice()));
-                try!(space(&mut self.s));
-                word(&mut self.s, token_to_string(&delimed.close_token()).as_slice())
-            },
             ast::TtToken(_, ref tk) => {
                 try!(word(&mut self.s, token_to_string(tk).as_slice()));
                 match *tk {
@@ -1136,7 +1131,14 @@ impl<'a> State<'a> {
                     _ => Ok(())
                 }
             }
-            ast::TtSequence(_, ref tts, ref separator, kleene_op) => {
+            ast::TtDelimited(_, ref delimed) => {
+                try!(word(&mut self.s, token_to_string(&delimed.open_token()).as_slice()));
+                try!(space(&mut self.s));
+                try!(self.print_tts(delimed.tts.as_slice()));
+                try!(space(&mut self.s));
+                word(&mut self.s, token_to_string(&delimed.close_token()).as_slice())
+            },
+            ast::TtSequence(_, ref tts, ref separator, kleene_op, _) => {
                 try!(word(&mut self.s, "$("));
                 for tt_elt in (*tts).iter() {
                     try!(self.print_tt(tt_elt));
@@ -1152,10 +1154,6 @@ impl<'a> State<'a> {
                     ast::ZeroOrMore => word(&mut self.s, "*"),
                     ast::OneOrMore => word(&mut self.s, "+"),
                 }
-            }
-            ast::TtNonterminal(_, name) => {
-                try!(word(&mut self.s, "$"));
-                self.print_ident(name)
             }
         }
     }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -272,7 +272,6 @@ pub fn token_to_string(tok: &Token) -> String {
             token::NtPat(..)      => "an interpolated pattern".into_string(),
             token::NtIdent(..)    => "an interpolated identifier".into_string(),
             token::NtTT(..)       => "an interpolated tt".into_string(),
-            token::NtMatchers(..) => "an interpolated matcher sequence".into_string(),
         }
     }
 }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1137,19 +1137,19 @@ impl<'a> State<'a> {
                 try!(space(&mut self.s));
                 word(&mut self.s, token_to_string(&delimed.close_token()).as_slice())
             },
-            ast::TtSequence(_, ref tts, ref separator, kleene_op, _) => {
+            ast::TtSequence(_, ref seq) => {
                 try!(word(&mut self.s, "$("));
-                for tt_elt in (*tts).iter() {
+                for tt_elt in seq.tts.iter() {
                     try!(self.print_tt(tt_elt));
                 }
                 try!(word(&mut self.s, ")"));
-                match *separator {
+                match seq.separator {
                     Some(ref tk) => {
                         try!(word(&mut self.s, token_to_string(tk).as_slice()));
                     }
                     None => {},
                 }
-                match kleene_op {
+                match seq.op {
                     ast::ZeroOrMore => word(&mut self.s, "*"),
                     ast::OneOrMore => word(&mut self.s, "+"),
                 }

--- a/src/test/compile-fail/macro-match-nonterminal.rs
+++ b/src/test/compile-fail/macro-match-nonterminal.rs
@@ -10,14 +10,8 @@
 
 #![feature(macro_rules)]
 
-// error-pattern: unexpected token
-
-macro_rules! e(
-    ($inp:ident) => (
-        $nonexistent
-    );
-)
+macro_rules! test ( ($a, $b) => (()); ) //~ ERROR Cannot transcribe
 
 fn main() {
-    e!(foo);
+    test!()
 }

--- a/src/test/run-pass/macro-of-higher-order.rs
+++ b/src/test/run-pass/macro-of-higher-order.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,20 +10,14 @@
 
 #![feature(macro_rules)]
 
-macro_rules! print_hd_tl (
-    ($field_hd:ident, $($field_tl:ident),+) => ({
-        print!("{}", stringify!($field)); //~ ERROR unknown macro variable
-        print!("::[");
-        $(
-            print!("{}", stringify!($field_tl));
-            print!(", ");
-        )+
-        // FIXME: #9970
-        print!("{}", "]\n");
-    })
+macro_rules! higher_order (
+    (subst $lhs:tt => $rhs:tt) => ({
+            macro_rules! anon ( $lhs => $rhs )
+            anon!(1u, 2u, "foo")
+    });
 )
 
 fn main() {
-    print_hd_tl!(x, y, z, w)
+    let val = higher_order!(subst ($x:expr, $y:expr, $foo:expr) => (($x + $y, $foo)));
+    assert_eq!(val, (3, "foo"));
 }
-


### PR DESCRIPTION
Closes #14197

Removes the `matchers` nonterminal.

If you're using `$foo:matchers` in a macro, write `$foo:tt` instead.

[breaking-change]
