### PR TITLE
rustc: add --asm-syntax flag

### DIFF
--- a/src/librustc/back/write.rs
+++ b/src/librustc/back/write.rs
@@ -12,6 +12,7 @@ use back::lto;
 use back::link::{get_cc_prog, remove};
 use driver::driver::{CrateTranslation, ModuleTranslation, OutputFilenames};
 use driver::config::{NoDebugInfo, Passes, SomePasses, AllPasses};
+use driver::config::{AsmDefault, AsmIntel, AsmAtt};
 use driver::session::Session;
 use driver::config;
 use llvm;
@@ -33,7 +34,6 @@ use std::mem;
 use std::sync::{Arc, Mutex};
 use std::task::TaskBuilder;
 use libc::{c_uint, c_int, c_void};
-
 
 #[deriving(Clone, PartialEq, PartialOrd, Ord, Eq)]
 pub enum OutputType {
@@ -957,6 +957,13 @@ unsafe fn configure_llvm(sess: &Session) {
         add("rustc"); // fake program name
         if vectorize_loop { add("-vectorize-loops"); }
         if vectorize_slp  { add("-vectorize-slp");   }
+
+        match sess.opts.syntax {
+            AsmIntel => add("-x86-asm-syntax=intel"),
+            AsmAtt => add("-x86-asm-syntax=att"),
+            AsmDefault => {}
+        }
+
         if sess.time_llvm_passes() { add("-time-passes"); }
         if sess.print_llvm_passes() { add("-debug-pass=Structure"); }
 


### PR DESCRIPTION
This allows the user to specify which asm syntax is desired for
`--emit=asm`

I also considered an environment variable to let it lurk under the covers a bit more but this seemed most optimal for a generic interface.

I asked on irc and didn't hear anything back so I figured I'd just go ahead and do it and amend if necessary. I was torn between a toplevel option and lurking it in behind `-Z` or similar.

I have some concerns that would hold this back from being merged:
- ~~What does this do on arches that can't intel? (my intuition is that `llc` will barf horribly but I have no idea how rustc will deal with that)~~ Haven't tested on arm (rustc builds are /very/ expensive), but unless anyone objects I don't think this should block.
- Is the toplevel option ok?
- Do I need to add tests for this? It seems like it should have them, but I couldn't find any preexisting. If not I will fumble through them.
