### PR TITLE
Fix keyword table

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -187,6 +187,8 @@ grammar as double-quoted strings. Other tokens have exact rules given.
 
 The keywords are the following strings, organized by first letter:
 
+<div id="keywords">
+|          |        |        |       |
 |----------|--------|--------|-------|
 | as       |        |        |       |
 |----------|--------|--------|-------|
@@ -216,6 +218,7 @@ The keywords are the following strings, organized by first letter:
 |----------|--------|--------|-------|
 | while    |        |        |       |
 |----------|--------|--------|-------|
+</div>
 
 Each of these keywords has special meaning in its grammar, and all of them are
 excluded from the `ident` rule.

--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -392,3 +392,5 @@ pre.rust { position: relative; }
         background-color: #fff !important;
     }
 }
+
+#keywords table td { border: none; }


### PR DESCRIPTION
Markdown tables require a header, and we don't want one.

Fixes #17528
