### PR TITLE
Generate better code for "large" vec![] macro invocations

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -321,12 +321,39 @@ macro_rules! try(
     ($e:expr) => (match $e { Ok(e) => e, Err(e) => return Err(e) })
 )
 
+/// A macro to count the number of expressions passed to it
+#[macro_export]
+macro_rules! count(
+    ($x:expr, $($xs:expr),+) => {
+        1 + count!($($xs),+)
+    };
+    ($x:expr) => {
+        1u
+    };
+    ($($x:expr),*) => {
+        0u
+    };
+)
+
 /// Create a `std::vec::Vec` containing the arguments.
+#[cfg(stage0)]
 #[macro_export]
 macro_rules! vec(
     ($($e:expr),*) => ({
         // leading _ to allow empty construction without a warning.
         let mut _temp = ::std::vec::Vec::new();
+        $(_temp.push($e);)*
+        _temp
+    });
+    ($($e:expr),+,) => (vec!($($e),+))
+)
+
+#[not(cfg(stage0))]
+#[macro_export]
+macro_rules! vec(
+    ($($e:expr),*) => ({
+        // leading _ to allow empty construction without a warning.
+        let mut _temp = ::std::vec::Vec::with_capacity(count!($($e),*));
         $(_temp.push($e);)*
         _temp
     });


### PR DESCRIPTION
Even when optimized, something like vec![1i,2,3,4,5,6,7,8,9,10] will
allocate three times, because LLVM can only drop the call based on the
observed size of the previous allocation. Using a simple macro to count
the number of elements, we can initialize the vector with the correct
size and avoid reallocations.

Since LLVM already does constant folding for us, the new count!() macro
results in a single integer constant even if building without
optimizations, so we don't end up with an awful lot of additions in the
generated code.
