### PR TITLE
debuginfo: Add LLDB version detection to compiletest and fix some LLDB issues

### DIFF
--- a/configure
+++ b/configure
@@ -535,13 +535,17 @@ probe CFG_LLDB             lldb
 
 if [ ! -z "$CFG_GDB" ]
 then
-    # Extract the version
+    # Store GDB's version
     CFG_GDB_VERSION=$($CFG_GDB --version 2>/dev/null | head -1)
     putvar CFG_GDB_VERSION
 fi
 
 if [ ! -z "$CFG_LLDB" ]
 then
+    # Store LLDB's version
+    CFG_LLDB_VERSION=$($CFG_LLDB --version 2>/dev/null | head -1)
+    putvar CFG_LLDB_VERSION
+
     # If CFG_LLDB_PYTHON_DIR is not already set from the outside and valid, try to read it from
     # LLDB via the -P commandline options.
     if [ -z "$CFG_LLDB_PYTHON_DIR" ] || [ ! -d "$CFG_LLDB_PYTHON_DIR" ]

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -625,6 +625,7 @@ CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) := \
         --target $(2) \
         --host $(3) \
         --gdb-version="$(CFG_GDB_VERSION)" \
+        --lldb-version="$(CFG_LLDB_VERSION)" \
         --android-cross-path=$(CFG_ANDROID_CROSS_PATH) \
         --adb-path=$(CFG_ADB) \
         --adb-test-dir=$(CFG_ADB_TEST_DIR) \

--- a/src/compiletest/common.rs
+++ b/src/compiletest/common.rs
@@ -133,6 +133,9 @@ pub struct Config {
     // Version of GDB
     pub gdb_version: Option<String>,
 
+    // Version of LLDB
+    pub lldb_version: Option<String>,
+
     // Path to the android tools
     pub android_cross_path: Path,
 

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -626,6 +626,17 @@ fn run_debuginfo_lldb_test(config: &Config, props: &TestProps, testfile: &Path) 
 
     let exe_file = make_exe_name(config, testfile);
 
+    match config.lldb_version {
+        Some(ref version) => {
+            println!("NOTE: compiletest thinks it is using LLDB version {}",
+                     version.as_slice());
+        }
+        _ => {
+            println!("NOTE: compiletest does not know which version of \
+                      LLDB it is using");
+        }
+    }
+
     // Parse debugger commands etc from test files
     let DebuggerCommands {
         commands,

--- a/src/etc/gdb_rust_pretty_printing.py
+++ b/src/etc/gdb_rust_pretty_printing.py
@@ -196,7 +196,7 @@ def classify_struct(type):
   if field_count == 0:
     return STRUCT_KIND_REGULAR_STRUCT
 
-  if fields[0].artificial:
+  if fields[0].name == "RUST$ENUM$DISR":
     if field_count == 1:
       return STRUCT_KIND_CSTYLE_VARIANT
     elif fields[1].name == None:

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -242,7 +242,6 @@ static UNKNOWN_FILE_METADATA: DIFile = (0 as DIFile);
 static UNKNOWN_SCOPE_METADATA: DIScope = (0 as DIScope);
 
 static FLAGS_NONE: c_uint = 0;
-static FLAGS_ARTIFICAL: c_uint = llvm::debuginfo::FlagArtificial as c_uint;
 
 //=-----------------------------------------------------------------------------
 //  Public Interface of debuginfo module
@@ -2276,11 +2275,7 @@ impl VariantMemberDescriptionFactory {
                     _ => type_metadata(cx, ty, self.span)
                 },
                 offset: ComputedMemberOffset,
-                flags: if self.discriminant_type_metadata.is_some() &&  i == 0 {
-                    FLAGS_ARTIFICAL
-                } else {
-                    FLAGS_NONE
-                }
+                flags: FLAGS_NONE
             }
         }).collect()
     }
@@ -2339,9 +2334,9 @@ fn describe_enum_variant(cx: &CrateContext,
         None => variant_info.args.iter().map(|_| "".to_string()).collect()
     };
 
-    // If this is not a univariant enum, there is also the (unnamed) discriminant field.
+    // If this is not a univariant enum, there is also the discriminant field.
     match discriminant_info {
-        RegularDiscriminant(_) => arg_names.insert(0, "".to_string()),
+        RegularDiscriminant(_) => arg_names.insert(0, "RUST$ENUM$DISR".to_string()),
         _ => { /* do nothing */ }
     };
 
@@ -2713,14 +2708,14 @@ fn vec_slice_metadata(cx: &CrateContext,
             llvm_type: *member_llvm_types.get(0),
             type_metadata: element_type_metadata,
             offset: ComputedMemberOffset,
-            flags: FLAGS_ARTIFICAL
+            flags: FLAGS_NONE
         },
         MemberDescription {
             name: "length".to_string(),
             llvm_type: *member_llvm_types.get(1),
             type_metadata: type_metadata(cx, ty::mk_uint(), span),
             offset: ComputedMemberOffset,
-            flags: FLAGS_ARTIFICAL
+            flags: FLAGS_NONE
         },
     ];
 

--- a/src/test/debuginfo/borrowed-enum.rs
+++ b/src/test/debuginfo/borrowed-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g
@@ -19,10 +20,10 @@
 // gdb-command:finish
 
 // gdb-command:print *the_a_ref
-// gdb-check:$1 = {{TheA, x = 0, y = 8970181431921507452}, {TheA, 0, 2088533116, 2088533116}}
+// gdb-check:$1 = {{RUST$ENUM$DISR = TheA, x = 0, y = 8970181431921507452}, {RUST$ENUM$DISR = TheA, 0, 2088533116, 2088533116}}
 
 // gdb-command:print *the_b_ref
-// gdb-check:$2 = {{TheB, x = 0, y = 1229782938247303441}, {TheB, 0, 286331153, 286331153}}
+// gdb-check:$2 = {{RUST$ENUM$DISR = TheB, x = 0, y = 1229782938247303441}, {RUST$ENUM$DISR = TheB, 0, 286331153, 286331153}}
 
 // gdb-command:print *univariant_ref
 // gdb-check:$3 = {{4820353753753434}}

--- a/src/test/debuginfo/by-value-non-immediate-argument.rs
+++ b/src/test/debuginfo/by-value-non-immediate-argument.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g
@@ -43,7 +44,7 @@
 
 // gdb-command:finish
 // gdb-command:print x
-// gdb-check:$7 = {{Case1, x = 0, y = 8970181431921507452}, {Case1, 0, 2088533116, 2088533116}}
+// gdb-check:$7 = {{RUST$ENUM$DISR = Case1, x = 0, y = 8970181431921507452}, {RUST$ENUM$DISR = Case1, 0, 2088533116, 2088533116}}
 // gdb-command:continue
 
 

--- a/src/test/debuginfo/generic-struct-style-enum.rs
+++ b/src/test/debuginfo/generic-struct-style-enum.rs
@@ -18,13 +18,13 @@
 // gdb-command:finish
 
 // gdb-command:print case1
-// gdb-check:$1 = {{Case1, a = 0, b = 31868, c = 31868, d = 31868, e = 31868}, {Case1, a = 0, b = 2088533116, c = 2088533116}, {Case1, a = 0, b = 8970181431921507452}}
+// gdb-check:$1 = {{RUST$ENUM$DISR = Case1, a = 0, b = 31868, c = 31868, d = 31868, e = 31868}, {RUST$ENUM$DISR = Case1, a = 0, b = 2088533116, c = 2088533116}, {RUST$ENUM$DISR = Case1, a = 0, b = 8970181431921507452}}
 
 // gdb-command:print case2
-// gdb-check:$2 = {{Case2, a = 0, b = 4369, c = 4369, d = 4369, e = 4369}, {Case2, a = 0, b = 286331153, c = 286331153}, {Case2, a = 0, b = 1229782938247303441}}
+// gdb-check:$2 = {{RUST$ENUM$DISR = Case2, a = 0, b = 4369, c = 4369, d = 4369, e = 4369}, {RUST$ENUM$DISR = Case2, a = 0, b = 286331153, c = 286331153}, {RUST$ENUM$DISR = Case2, a = 0, b = 1229782938247303441}}
 
 // gdb-command:print case3
-// gdb-check:$3 = {{Case3, a = 0, b = 22873, c = 22873, d = 22873, e = 22873}, {Case3, a = 0, b = 1499027801, c = 1499027801}, {Case3, a = 0, b = 6438275382588823897}}
+// gdb-check:$3 = {{RUST$ENUM$DISR = Case3, a = 0, b = 22873, c = 22873, d = 22873, e = 22873}, {RUST$ENUM$DISR = Case3, a = 0, b = 1499027801, c = 1499027801}, {RUST$ENUM$DISR = Case3, a = 0, b = 6438275382588823897}}
 
 // gdb-command:print univariant
 // gdb-check:$4 = {{a = -1}}

--- a/src/test/debuginfo/generic-tuple-style-enum.rs
+++ b/src/test/debuginfo/generic-tuple-style-enum.rs
@@ -21,13 +21,13 @@
 // gdb-command:finish
 
 // gdb-command:print case1
-// gdb-check:$1 = {{Case1, 0, 31868, 31868, 31868, 31868}, {Case1, 0, 2088533116, 2088533116}, {Case1, 0, 8970181431921507452}}
+// gdb-check:$1 = {{RUST$ENUM$DISR = Case1, 0, 31868, 31868, 31868, 31868}, {RUST$ENUM$DISR = Case1, 0, 2088533116, 2088533116}, {RUST$ENUM$DISR = Case1, 0, 8970181431921507452}}
 
 // gdb-command:print case2
-// gdb-check:$2 = {{Case2, 0, 4369, 4369, 4369, 4369}, {Case2, 0, 286331153, 286331153}, {Case2, 0, 1229782938247303441}}
+// gdb-check:$2 = {{RUST$ENUM$DISR = Case2, 0, 4369, 4369, 4369, 4369}, {RUST$ENUM$DISR = Case2, 0, 286331153, 286331153}, {RUST$ENUM$DISR = Case2, 0, 1229782938247303441}}
 
 // gdb-command:print case3
-// gdb-check:$3 = {{Case3, 0, 22873, 22873, 22873, 22873}, {Case3, 0, 1499027801, 1499027801}, {Case3, 0, 6438275382588823897}}
+// gdb-check:$3 = {{RUST$ENUM$DISR = Case3, 0, 22873, 22873, 22873, 22873}, {RUST$ENUM$DISR = Case3, 0, 1499027801, 1499027801}, {RUST$ENUM$DISR = Case3, 0, 6438275382588823897}}
 
 // gdb-command:print univariant
 // gdb-check:$4 = {{-1}}

--- a/src/test/debuginfo/method-on-enum.rs
+++ b/src/test/debuginfo/method-on-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g
@@ -20,7 +21,7 @@
 // STACK BY REF
 // gdb-command:finish
 // gdb-command:print *self
-// gdb-check:$1 = {{Variant2, [...]}, {Variant2, 117901063}}
+// gdb-check:$1 = {{RUST$ENUM$DISR = Variant2, [...]}, {RUST$ENUM$DISR = Variant2, 117901063}}
 // gdb-command:print arg1
 // gdb-check:$2 = -1
 // gdb-command:print arg2
@@ -30,7 +31,7 @@
 // STACK BY VAL
 // gdb-command:finish
 // gdb-command:print self
-// gdb-check:$4 = {{Variant2, [...]}, {Variant2, 117901063}}
+// gdb-check:$4 = {{RUST$ENUM$DISR = Variant2, [...]}, {RUST$ENUM$DISR = Variant2, 117901063}}
 // gdb-command:print arg1
 // gdb-check:$5 = -3
 // gdb-command:print arg2
@@ -40,7 +41,7 @@
 // OWNED BY REF
 // gdb-command:finish
 // gdb-command:print *self
-// gdb-check:$7 = {{Variant1, x = 1799, y = 1799}, {Variant1, [...]}}
+// gdb-check:$7 = {{RUST$ENUM$DISR = Variant1, x = 1799, y = 1799}, {RUST$ENUM$DISR = Variant1, [...]}}
 // gdb-command:print arg1
 // gdb-check:$8 = -5
 // gdb-command:print arg2
@@ -50,7 +51,7 @@
 // OWNED BY VAL
 // gdb-command:finish
 // gdb-command:print self
-// gdb-check:$10 = {{Variant1, x = 1799, y = 1799}, {Variant1, [...]}}
+// gdb-check:$10 = {{RUST$ENUM$DISR = Variant1, x = 1799, y = 1799}, {RUST$ENUM$DISR = Variant1, [...]}}
 // gdb-command:print arg1
 // gdb-check:$11 = -7
 // gdb-command:print arg2
@@ -60,7 +61,7 @@
 // OWNED MOVED
 // gdb-command:finish
 // gdb-command:print *self
-// gdb-check:$13 = {{Variant1, x = 1799, y = 1799}, {Variant1, [...]}}
+// gdb-check:$13 = {{RUST$ENUM$DISR = Variant1, x = 1799, y = 1799}, {RUST$ENUM$DISR = Variant1, [...]}}
 // gdb-command:print arg1
 // gdb-check:$14 = -9
 // gdb-command:print arg2

--- a/src/test/debuginfo/struct-in-enum.rs
+++ b/src/test/debuginfo/struct-in-enum.rs
@@ -21,10 +21,10 @@
 // gdb-command:finish
 
 // gdb-command:print case1
-// gdb-check:$1 = {{Case1, 0, {x = 2088533116, y = 2088533116, z = 31868}}, {Case1, 0, 8970181431921507452, 31868}}
+// gdb-check:$1 = {{RUST$ENUM$DISR = Case1, 0, {x = 2088533116, y = 2088533116, z = 31868}}, {RUST$ENUM$DISR = Case1, 0, 8970181431921507452, 31868}}
 
 // gdb-command:print case2
-// gdb-check:$2 = {{Case2, 0, {x = 286331153, y = 286331153, z = 4369}}, {Case2, 0, 1229782938247303441, 4369}}
+// gdb-check:$2 = {{RUST$ENUM$DISR = Case2, 0, {x = 286331153, y = 286331153, z = 4369}}, {RUST$ENUM$DISR = Case2, 0, 1229782938247303441, 4369}}
 
 // gdb-command:print univariant
 // gdb-check:$3 = {{{x = 123, y = 456, z = 789}}}

--- a/src/test/debuginfo/struct-style-enum.rs
+++ b/src/test/debuginfo/struct-style-enum.rs
@@ -21,13 +21,13 @@
 // gdb-command:finish
 
 // gdb-command:print case1
-// gdb-check:$1 = {{Case1, a = 0, b = 31868, c = 31868, d = 31868, e = 31868}, {Case1, a = 0, b = 2088533116, c = 2088533116}, {Case1, a = 0, b = 8970181431921507452}}
+// gdb-check:$1 = {{RUST$ENUM$DISR = Case1, a = 0, b = 31868, c = 31868, d = 31868, e = 31868}, {RUST$ENUM$DISR = Case1, a = 0, b = 2088533116, c = 2088533116}, {RUST$ENUM$DISR = Case1, a = 0, b = 8970181431921507452}}
 
 // gdb-command:print case2
-// gdb-check:$2 = {{Case2, a = 0, b = 4369, c = 4369, d = 4369, e = 4369}, {Case2, a = 0, b = 286331153, c = 286331153}, {Case2, a = 0, b = 1229782938247303441}}
+// gdb-check:$2 = {{RUST$ENUM$DISR = Case2, a = 0, b = 4369, c = 4369, d = 4369, e = 4369}, {RUST$ENUM$DISR = Case2, a = 0, b = 286331153, c = 286331153}, {RUST$ENUM$DISR = Case2, a = 0, b = 1229782938247303441}}
 
 // gdb-command:print case3
-// gdb-check:$3 = {{Case3, a = 0, b = 22873, c = 22873, d = 22873, e = 22873}, {Case3, a = 0, b = 1499027801, c = 1499027801}, {Case3, a = 0, b = 6438275382588823897}}
+// gdb-check:$3 = {{RUST$ENUM$DISR = Case3, a = 0, b = 22873, c = 22873, d = 22873, e = 22873}, {RUST$ENUM$DISR = Case3, a = 0, b = 1499027801, c = 1499027801}, {RUST$ENUM$DISR = Case3, a = 0, b = 6438275382588823897}}
 
 // gdb-command:print univariant
 // gdb-check:$4 = {{a = -1}}

--- a/src/test/debuginfo/tuple-style-enum.rs
+++ b/src/test/debuginfo/tuple-style-enum.rs
@@ -21,13 +21,13 @@
 // gdb-command:finish
 
 // gdb-command:print case1
-// gdb-check:$1 = {{Case1, 0, 31868, 31868, 31868, 31868}, {Case1, 0, 2088533116, 2088533116}, {Case1, 0, 8970181431921507452}}
+// gdb-check:$1 = {{RUST$ENUM$DISR = Case1, 0, 31868, 31868, 31868, 31868}, {RUST$ENUM$DISR = Case1, 0, 2088533116, 2088533116}, {RUST$ENUM$DISR = Case1, 0, 8970181431921507452}}
 
 // gdb-command:print case2
-// gdb-check:$2 = {{Case2, 0, 4369, 4369, 4369, 4369}, {Case2, 0, 286331153, 286331153}, {Case2, 0, 1229782938247303441}}
+// gdb-check:$2 = {{RUST$ENUM$DISR = Case2, 0, 4369, 4369, 4369, 4369}, {RUST$ENUM$DISR = Case2, 0, 286331153, 286331153}, {RUST$ENUM$DISR = Case2, 0, 1229782938247303441}}
 
 // gdb-command:print case3
-// gdb-check:$3 = {{Case3, 0, 22873, 22873, 22873, 22873}, {Case3, 0, 1499027801, 1499027801}, {Case3, 0, 6438275382588823897}}
+// gdb-check:$3 = {{RUST$ENUM$DISR = Case3, 0, 22873, 22873, 22873, 22873}, {RUST$ENUM$DISR = Case3, 0, 1499027801, 1499027801}, {RUST$ENUM$DISR = Case3, 0, 6438275382588823897}}
 
 // gdb-command:print univariant
 // gdb-check:$4 = {{-1}}

--- a/src/test/debuginfo/unique-enum.rs
+++ b/src/test/debuginfo/unique-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-tidy-linelength
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g
@@ -19,10 +20,10 @@
 // gdb-command:finish
 
 // gdb-command:print *the_a
-// gdb-check:$1 = {{TheA, x = 0, y = 8970181431921507452}, {TheA, 0, 2088533116, 2088533116}}
+// gdb-check:$1 = {{RUST$ENUM$DISR = TheA, x = 0, y = 8970181431921507452}, {RUST$ENUM$DISR = TheA, 0, 2088533116, 2088533116}}
 
 // gdb-command:print *the_b
-// gdb-check:$2 = {{TheB, x = 0, y = 1229782938247303441}, {TheB, 0, 286331153, 286331153}}
+// gdb-check:$2 = {{RUST$ENUM$DISR = TheB, x = 0, y = 1229782938247303441}, {RUST$ENUM$DISR = TheB, 0, 286331153, 286331153}}
 
 // gdb-command:print *univariant
 // gdb-check:$3 = {{123234}}

--- a/src/test/debuginfo/var-captured-in-nested-closure.rs
+++ b/src/test/debuginfo/var-captured-in-nested-closure.rs
@@ -63,21 +63,21 @@
 // lldb-command:print *owned
 // lldb-check:[...]$4 = 6
 // lldb-command:print closure_local
-// lldb-check:[...]$6 = 8
+// lldb-check:[...]$5 = 8
 // lldb-command:continue
 
 // lldb-command:print variable
-// lldb-check:[...]$7 = 1
+// lldb-check:[...]$6 = 1
 // lldb-command:print constant
-// lldb-check:[...]$8 = 2
+// lldb-check:[...]$7 = 2
 // lldb-command:print a_struct
-// lldb-check:[...]$9 = Struct { a: -3, b: 4.5, c: 5 }
+// lldb-check:[...]$8 = Struct { a: -3, b: 4.5, c: 5 }
 // lldb-command:print *struct_ref
-// lldb-check:[...]$10 = Struct { a: -3, b: 4.5, c: 5 }
+// lldb-check:[...]$9 = Struct { a: -3, b: 4.5, c: 5 }
 // lldb-command:print *owned
-// lldb-check:[...]$11 = 6
+// lldb-check:[...]$10 = 6
 // lldb-command:print closure_local
-// lldb-check:[...]$13 = 8
+// lldb-check:[...]$11 = 8
 // lldb-command:continue
 
 #![allow(unused_variable)]


### PR DESCRIPTION
Apart from making the build system determine the LLDB version, this PR also fixes an issue with enums in LLDB pretty printers. In order for GDB's pretty printers to know for sure if a field of some value is an enum discriminant, I had rustc mark discriminant fields with the `artificial` DWARF tag. This worked out nicely for GDB but it turns out that one can't access artificial fields from LLDB. So I changed the debuginfo representation so that enum discriminants are marked by the special field name `RUST$ENUM$DISR` instead, which works in both cases.

The PR does not activate the LLDB test suite yet.
