### PR TITLE
readme: Link 'Using' wiki page instead of 'Getting started'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ documentation.
 3. Enjoy!
 
 > ***Note:*** Windows users can read the detailed
-> [getting started][wiki-start] notes on the wiki.
+> [using Rust on Windows][win-wiki] notes on the wiki.
 
 [installer]: http://www.rust-lang.org/install.html
 [guide]: http://doc.rust-lang.org/guide.html
-[wiki-start]: https://github.com/rust-lang/rust/wiki/Note-getting-started-developing-Rust
 [win-wiki]: https://github.com/rust-lang/rust/wiki/Using-Rust-on-Windows
 
 ## Building from Source


### PR DESCRIPTION
The Windows-specific instruction under 'Quick Start' linked the wiki article on getting started developing Rust itself, but the quick start is just about obtaining a working Rust installation. The actual wiki page with Windows-specific instructions was difficult to find.

The most important thing to note on Windows is that you need mingw-builds, and it is totally not obvious. The only place where I have seen it mentioned is the wiki page, which was difficult to find before.
