### PR TITLE
In sieve example, end iteration sooner

### DIFF
--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -33,7 +33,7 @@
 //!     bv.set(0, false);
 //!     bv.set(1, false);
 //!
-//!     for i in range(2, max_prime) {
+//!     for i in iter::range_inclusive(2, (max_prime as f64).sqrt() as uint) {
 //!         // if i is a prime
 //!         if bv[i] {
 //!             // Mark all multiples of i as non-prime (any multiples below i * i


### PR DESCRIPTION
The Sieve algorithm only requires checking all elements up to and including the square root of the maximum prime you're looking for. After that, the remaining elements are guaranteed to be prime.
