### PR TITLE
Update README.md to add 64-bit Windows support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ fetch snapshots, and an OS that can execute the available snapshot binaries.
 
 Snapshot binaries are currently built and tested on several platforms:
 
-* Windows (7, 8, Server 2008 R2), x86 only
+* Windows (7, 8, Server 2008 R2), x86 and x86-64 (64-bit support added in Rust 0.12.0)
 * Linux (2.6.18 or later, various distributions), x86 and x86-64
 * OSX 10.7 (Lion) or greater, x86 and x86-64
 


### PR DESCRIPTION
Added 64-bit Windows support to the list of platforms. Support for 64-bit Windows was added in Rust 0.12.0. See  https://mail.mozilla.org/pipermail/rust-dev/2014-October/011267.html for the release notes.
