### PR TITLE
librustc: Improve method autoderef/deref/index behavior more, and enable IndexMut on mutable vectors.

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -452,13 +452,13 @@ impl<T> Index<uint,T> for Vec<T> {
     }
 }
 
-// FIXME(#12825) Indexing will always try IndexMut first and that causes issues.
-/*impl<T> IndexMut<uint,T> for Vec<T> {
+#[cfg(not(stage0))]
+impl<T> IndexMut<uint,T> for Vec<T> {
     #[inline]
     fn index_mut<'a>(&'a mut self, index: &uint) -> &'a mut T {
         self.get_mut(*index)
     }
-}*/
+}
 
 #[cfg(stage0)]
 impl<T> ops::Slice<uint, [T]> for Vec<T> {
@@ -2190,7 +2190,6 @@ impl<T> Vec<T> {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2975,12 +2975,10 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                          expr: &ast::Expr,
                          method_name: ast::SpannedIdent,
                          args: &[P<ast::Expr>],
-                         tps: &[P<ast::Ty>]) {
+                         tps: &[P<ast::Ty>],
+                         lvalue_pref: LvaluePreference) {
         let rcvr = &*args[0];
-        // We can't know if we need &mut self before we look up the method,
-        // so treat the receiver as mutable just in case - only explicit
-        // overloaded dereferences care about the distinction.
-        check_expr_with_lvalue_pref(fcx, &*rcvr, PreferMutLvalue);
+        check_expr_with_lvalue_pref(fcx, &*rcvr, lvalue_pref);
 
         // no need to check for bot/err -- callee does that
         let expr_t = structurally_resolved_type(fcx,
@@ -4195,7 +4193,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
           }
       }
       ast::ExprMethodCall(ident, ref tps, ref args) => {
-        check_method_call(fcx, expr, ident, args.as_slice(), tps.as_slice());
+        check_method_call(fcx, expr, ident, args.as_slice(), tps.as_slice(), lvalue_pref);
         let mut arg_tys = args.iter().map(|a| fcx.expr_ty(&**a));
         let (args_bot, args_err) = arg_tys.fold((false, false),
              |(rest_bot, rest_err), a| {

--- a/src/test/run-pass/overloaded-deref-count.rs
+++ b/src/test/run-pass/overloaded-deref-count.rs
@@ -68,12 +68,10 @@ pub fn main() {
     *n -= 3; // Mutable deref + assignment with binary operation.
     assert_eq!(n.counts(), (2, 3));
 
-    // Mutable deref used for calling a method taking &self.
-    // N.B. This is required because method lookup hasn't been performed so
-    // we don't know whether the called method takes mutable self, before
-    // the dereference itself is type-checked (a chicken-and-egg problem).
+    // Immutable deref used for calling a method taking &self. (The
+    // typechecker is smarter now about doing this.)
     (*n).to_string();
-    assert_eq!(n.counts(), (2, 4));
+    assert_eq!(n.counts(), (3, 3));
 
     // Mutable deref used for calling a method taking &mut self.
     (*v).push(2);


### PR DESCRIPTION
librustc: Improve method autoderef/deref/index behavior more, and enable IndexMut on mutable vectors.

This fixes a bug whereby the mutability fixups for method behavior were
not kicking in after autoderef failed to happen at any level. It also
adds support for `Index` to the fixer-upper.

Closes #12825.

r? @pnkfelix 
