### PR TITLE
remove shootout warnings

### DIFF
--- a/src/test/bench/shootout-chameneos-redux.rs
+++ b/src/test/bench/shootout-chameneos-redux.rs
@@ -72,7 +72,7 @@ struct CreatureInfo {
 fn show_color_list(set: Vec<Color>) -> String {
     let mut out = String::new();
     for col in set.iter() {
-        out.push_char(' ');
+        out.push(' ');
         out.push_str(col.to_string().as_slice());
     }
     out

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -123,8 +123,8 @@ struct Entry {
 }
 
 struct Table {
-    count: uint,
-    items: Vec<Option<Box<Entry>>> }
+    items: Vec<Option<Box<Entry>>>
+}
 
 struct Items<'a> {
     cur: Option<&'a Entry>,
@@ -134,7 +134,6 @@ struct Items<'a> {
 impl Table {
     fn new() -> Table {
         Table {
-            count: 0,
             items: Vec::from_fn(TABLE_SIZE, |_| None),
         }
     }
@@ -165,7 +164,7 @@ impl Table {
         let index = key.hash() % (TABLE_SIZE as u64);
 
         {
-            if self.items.get(index as uint).is_none() {
+            if self.items[index as uint].is_none() {
                 let mut entry = box Entry {
                     code: key,
                     count: 0,
@@ -178,7 +177,7 @@ impl Table {
         }
 
         {
-            let entry = &mut *self.items.get_mut(index as uint).get_mut_ref();
+            let entry = self.items.get_mut(index as uint).as_mut().unwrap();
             if entry.code == key {
                 c.f(&mut **entry);
                 return;
@@ -286,7 +285,7 @@ fn get_sequence<R: Buffer>(r: &mut R, key: &str) -> Vec<u8> {
         res.push_all(l.as_slice().trim().as_bytes());
     }
     for b in res.iter_mut() {
-        *b = b.to_ascii().to_upper().to_byte();
+        *b = b.to_ascii().to_uppercase().to_byte();
     }
     res
 }

--- a/src/test/bench/shootout-mandelbrot.rs
+++ b/src/test/bench/shootout-mandelbrot.rs
@@ -109,8 +109,8 @@ fn mandelbrot<W: io::Writer>(w: uint, mut out: W) -> io::IoResult<()> {
 
     for res in precalc_futures.into_iter() {
         let (rs, is) = res.unwrap();
-        precalc_r.push_all_move(rs);
-        precalc_i.push_all_move(is);
+        precalc_r.extend(rs.into_iter());
+        precalc_i.extend(is.into_iter());
     }
 
     assert_eq!(precalc_r.len(), w);

--- a/src/test/bench/shootout-meteor.rs
+++ b/src/test/bench/shootout-meteor.rs
@@ -193,9 +193,9 @@ fn is_board_unfeasible(board: u64, masks: &Vec<Vec<Vec<u64>>>) -> bool {
 // Filter the masks that we can prove to result to unfeasible board.
 fn filter_masks(masks: &mut Vec<Vec<Vec<u64>>>) {
     for i in range(0, masks.len()) {
-        for j in range(0, masks.get(i).len()) {
+        for j in range(0, (*masks)[i].len()) {
             *masks.get_mut(i).get_mut(j) =
-                masks.get(i).get(j).iter().map(|&m| m)
+                (*masks)[i][j].iter().map(|&m| m)
                 .filter(|&m| !is_board_unfeasible(m, masks))
                 .collect();
         }
@@ -287,12 +287,12 @@ fn search(
     while board & (1 << i)  != 0 && i < 50 {i += 1;}
     // the board is full: a solution is found.
     if i >= 50 {return handle_sol(&cur, data);}
-    let masks_at = masks.get(i);
+    let masks_at = &masks[i];
 
     // for every unused piece
     for id in range(0u, 10).filter(|id| board & (1 << (id + 50)) == 0) {
         // for each mask that fits on the board
-        for m in masks_at.get(id).iter().filter(|&m| board & *m == 0) {
+        for m in masks_at[id].iter().filter(|&m| board & *m == 0) {
             // This check is too costly.
             //if is_board_unfeasible(board | m, masks) {continue;}
             search(masks, board | *m, i + 1, Cons(*m, &cur), data);
@@ -306,7 +306,7 @@ fn par_search(masks: Vec<Vec<Vec<u64>>>) -> Data {
 
     // launching the search in parallel on every masks at minimum
     // coordinate (0,0)
-    for m in masks.get(0).iter().flat_map(|masks_pos| masks_pos.iter()) {
+    for m in (*masks)[0].iter().flat_map(|masks_pos| masks_pos.iter()) {
         let masks = masks.clone();
         let tx = tx.clone();
         let m = *m;

--- a/src/test/bench/shootout-nbody.rs
+++ b/src/test/bench/shootout-nbody.rs
@@ -133,14 +133,14 @@ fn advance(bodies: &mut [Planet, ..N_BODIES], dt: f64, steps: int) {
 
 fn energy(bodies: &[Planet, ..N_BODIES]) -> f64 {
     let mut e = 0.0;
-    let mut bodies = bodies.as_slice();
+    let mut bodies = bodies.iter();
     loop {
-        let bi = match bodies.shift_ref() {
+        let bi = match bodies.next() {
             Some(bi) => bi,
             None => break
         };
         e += (bi.vx * bi.vx + bi.vy * bi.vy + bi.vz * bi.vz) * bi.mass / 2.0;
-        for bj in bodies.iter() {
+        for bj in bodies.clone() {
             let dx = bi.x - bj.x;
             let dy = bi.y - bj.y;
             let dz = bi.z - bj.z;


### PR DESCRIPTION
Only one warning remain, and I can't find a way to remove it without doing more bound checks:

```
shootout-nbody.rs:105:36: 105:51 warning: use of deprecated item: use iter_mut, #[warn(deprecated)] on by default
shootout-nbody.rs:105             let bi = match b_slice.mut_shift_ref() {
```

using `split_at_mut` may be an option, but it will do more bound checking.

If anyone have an idea, I'll update this PR.
