### PR TITLE
compiletest needs to link to native crate, or at least the `rt` library.

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -101,7 +101,7 @@ DEPS_regex := std
 DEPS_regex_macros = rustc syntax std regex
 DEPS_fmt_macros = std
 
-TOOL_DEPS_compiletest := test getopts
+TOOL_DEPS_compiletest := test getopts native
 TOOL_DEPS_rustdoc := rustdoc native
 TOOL_DEPS_rustc := rustc native
 TOOL_SOURCE_compiletest := $(S)src/compiletest/compiletest.rs


### PR DESCRIPTION
compiletest needs to link to native crate, or at least the `rt` library.

(I tried using a dependency on `rustrt` instead, and that did not resolve the problem.  But this does.)

Partially addresses #17883
