### PR TITLE
Remove deprecated into_vec method from &[T]

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -277,12 +277,14 @@ pub trait CloneableVector<T> {
     }
 
     /// Converts `self` into an owned vector, not making a copy if possible.
+    /// Deprecated. Use 'to_vec'
+    #[deprecated = "Replaced by `to_vec`"]
     fn into_vec(self) -> Vec<T>;
 
-    /// Deprecated. Use `into_vec`
-    #[deprecated = "Replaced by `into_vec`"]
+    /// Deprecated. Use `to_vec`
+    #[deprecated = "Replaced by `to_vec`"]
     fn into_owned(self) -> Vec<T> {
-        self.into_vec()
+        self.to_vec()
     }
 }
 
@@ -2328,9 +2330,9 @@ mod tests {
     }
 
     #[test]
-    fn test_into_vec() {
+    fn test_to_vec() {
         let xs = box [1u, 2, 3];
-        let ys = xs.into_vec();
+        let ys = xs.to_vec();
         assert_eq!(ys.as_slice(), [1u, 2, 3].as_slice());
     }
 }

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -614,13 +614,6 @@ impl<T> Collection for Vec<T> {
     }
 }
 
-impl<T: Clone> CloneableVector<T> for Vec<T> {
-    #[deprecated = "call .clone() instead"]
-    fn to_vec(&self) -> Vec<T> { self.clone() }
-    #[deprecated = "move the vector instead"]
-    fn into_vec(self) -> Vec<T> { self }
-}
-
 // FIXME: #13996: need a way to mark the return value as `noalias`
 #[inline(never)]
 unsafe fn alloc_or_realloc<T>(ptr: *mut T, old_size: uint, size: uint) -> *mut T {

--- a/src/libgraphviz/maybe_owned_vec.rs
+++ b/src/libgraphviz/maybe_owned_vec.rs
@@ -140,7 +140,7 @@ impl<'a,T:Clone> CloneableVector<T> for MaybeOwnedVector<'a,T> {
 impl<'a, T: Clone> Clone for MaybeOwnedVector<'a, T> {
     fn clone(&self) -> MaybeOwnedVector<'a, T> {
         match *self {
-            Growable(ref v) => Growable(v.to_vec()),
+            Growable(ref v) => Growable(v.clone()),
             Borrowed(v) => Borrowed(v)
         }
     }

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1014,7 +1014,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
             ty::ty_tup(ref tys) => {
                 // (T1, ..., Tn) -- meets any bound that all of T1...Tn meet
-                Ok(If(tys.to_owned()))
+                Ok(If(tys.clone()))
             }
 
             ty::ty_unboxed_closure(def_id, _) => {


### PR DESCRIPTION
[breaking-change]
Closes #17916
