### PR TITLE
loader: suggest to set crate type explicitly

### DIFF
--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -426,6 +426,14 @@ impl<'a> Context<'a> {
                 (file.slice(dylib_prefix.len(), file.len() - suffix.len()),
                  false)
             } else {
+                let static_lib = format!("lib{}.a", self.crate_name);
+                if file == static_lib.as_slice() {
+                    let msg = format!("found staticlib `{}` instead of \
+                                       rlib `{}`, please compile using \
+                                       --crate-type rlib instead.",
+                                       self.crate_name, self.crate_name);
+                    self.sess.span_warn(self.span, msg.as_slice());
+                }
                 return FileDoesntMatch
             };
             info!("lib candidate: {}", path.display());


### PR DESCRIPTION
Now loader suggests to set crate type explicitly if it founds file with
name similar to crate name, but different extension.

This commit adds warning if loader found static library instead of rlib
or dylib.
Closes #14416.
