### PR TITLE
Renamed AsciiStr::to_lower and AsciiStr::to_upper

### DIFF
--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -31,7 +31,7 @@ pub fn load_errors(re: &Regex, testfile: &Path) -> Vec<ExpectedError> {
 fn parse_expected(line_num: uint, line: &str, re: &Regex) -> Option<ExpectedError> {
     re.captures(line).and_then(|caps| {
         let adjusts = caps.name("adjusts").len();
-        let kind = caps.name("kind").to_ascii().to_lower().into_string();
+        let kind = caps.name("kind").to_ascii().to_lowercase().into_string();
         let msg = caps.name("msg").trim().to_string();
 
         debug!("line={} kind={} msg={}", line_num, kind, msg);

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -228,7 +228,7 @@ pub fn render(w: &mut fmt::Formatter, s: &str, print_toc: bool) -> fmt::Result {
         // Transform the contents of the header into a hyphenated string
         let id = s.as_slice().words().map(|s| {
             match s.to_ascii_opt() {
-                Some(s) => s.to_lower().into_string(),
+                Some(s) => s.to_lowercase().into_string(),
                 None => s.to_string()
             }
         }).collect::<Vec<String>>().connect("-");

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -62,8 +62,8 @@ impl Ascii {
         Ascii{chr: ASCII_LOWER_MAP[self.chr as uint]}
     }
 
+    /// Deprecated: use `to_uppercase`
     #[inline]
-    #[allow(missing_doc)]
     #[deprecated="renamed to `to_uppercase`"]
     pub fn to_upper(self) -> Ascii {
         self.to_uppercase()
@@ -139,8 +139,8 @@ impl Ascii {
         (self.chr - 0x20) < 0x5F
     }
 
+    /// Deprecated: use `to_lowercase`
     #[inline]
-    #[allow(missing_doc)]
     #[deprecated="renamed to `is_lowercase`"]
     pub fn is_lower(&self) -> bool {
         self.is_lowercase()
@@ -319,11 +319,19 @@ pub trait AsciiStr {
     /// Convert to a string.
     fn as_str_ascii<'a>(&'a self) -> &'a str;
 
-    /// Convert to vector representing a lower cased ascii string.
+    /// Deprecated: use `to_lowercase`
+    #[deprecated="renamed `to_lowercase`"]
     fn to_lower(&self) -> Vec<Ascii>;
 
-    /// Convert to vector representing a upper cased ascii string.
+    /// Convert to vector representing a lower cased ascii string.
+    fn to_lowercase(&self) -> Vec<Ascii>;
+
+    /// Deprecated: use `to_uppercase`
+    #[deprecated="renamed `to_uppercase`"]
     fn to_upper(&self) -> Vec<Ascii>;
+
+    /// Convert to vector representing a upper cased ascii string.
+    fn to_uppercase(&self) -> Vec<Ascii>;
 
     /// Compares two Ascii strings ignoring case.
     fn eq_ignore_case(self, other: &[Ascii]) -> bool;
@@ -337,11 +345,21 @@ impl<'a> AsciiStr for &'a [Ascii] {
 
     #[inline]
     fn to_lower(&self) -> Vec<Ascii> {
+      self.to_lowercase()
+    }
+
+    #[inline]
+    fn to_lowercase(&self) -> Vec<Ascii> {
         self.iter().map(|a| a.to_lowercase()).collect()
     }
 
     #[inline]
     fn to_upper(&self) -> Vec<Ascii> {
+      self.to_uppercase()
+    }
+
+    #[inline]
+    fn to_uppercase(&self) -> Vec<Ascii> {
         self.iter().map(|a| a.to_uppercase()).collect()
     }
 
@@ -582,15 +600,15 @@ mod tests {
         assert_eq!('A'.to_ascii().to_char(), 'A');
         assert_eq!('A'.to_ascii().to_byte(), 65u8);
 
-        assert_eq!('A'.to_ascii().to_lower().to_char(), 'a');
-        assert_eq!('Z'.to_ascii().to_lower().to_char(), 'z');
-        assert_eq!('a'.to_ascii().to_upper().to_char(), 'A');
-        assert_eq!('z'.to_ascii().to_upper().to_char(), 'Z');
+        assert_eq!('A'.to_ascii().to_lowercase().to_char(), 'a');
+        assert_eq!('Z'.to_ascii().to_lowercase().to_char(), 'z');
+        assert_eq!('a'.to_ascii().to_uppercase().to_char(), 'A');
+        assert_eq!('z'.to_ascii().to_uppercase().to_char(), 'Z');
 
-        assert_eq!('@'.to_ascii().to_lower().to_char(), '@');
-        assert_eq!('['.to_ascii().to_lower().to_char(), '[');
-        assert_eq!('`'.to_ascii().to_upper().to_char(), '`');
-        assert_eq!('{'.to_ascii().to_upper().to_char(), '{');
+        assert_eq!('@'.to_ascii().to_lowercase().to_char(), '@');
+        assert_eq!('['.to_ascii().to_lowercase().to_char(), '[');
+        assert_eq!('`'.to_ascii().to_uppercase().to_char(), '`');
+        assert_eq!('{'.to_ascii().to_uppercase().to_char(), '{');
 
         assert!('0'.to_ascii().is_digit());
         assert!('9'.to_ascii().is_digit());
@@ -615,12 +633,13 @@ mod tests {
         assert_eq!(v.as_slice().to_ascii(), b);
         assert_eq!("( ;".to_string().as_slice().to_ascii(), b);
 
-        assert_eq!("abCDef&?#".to_ascii().to_lower().into_string(), "abcdef&?#".to_string());
-        assert_eq!("abCDef&?#".to_ascii().to_upper().into_string(), "ABCDEF&?#".to_string());
+        assert_eq!("abCDef&?#".to_ascii().to_lowercase().into_string(), "abcdef&?#".to_string());
+        assert_eq!("abCDef&?#".to_ascii().to_uppercase().into_string(), "ABCDEF&?#".to_string());
 
-        assert_eq!("".to_ascii().to_lower().into_string(), "".to_string());
-        assert_eq!("YMCA".to_ascii().to_lower().into_string(), "ymca".to_string());
-        assert_eq!("abcDEFxyz:.;".to_ascii().to_upper().into_string(), "ABCDEFXYZ:.;".to_string());
+        assert_eq!("".to_ascii().to_lowercase().into_string(), "".to_string());
+        assert_eq!("YMCA".to_ascii().to_lowercase().into_string(), "ymca".to_string());
+        let mixed = "abcDEFxyz:.;".to_ascii();
+        assert_eq!(mixed.to_uppercase().into_string(), "ABCDEFXYZ:.;".to_string());
 
         assert!("aBcDeF&?#".to_ascii().eq_ignore_case("AbCdEf&?#".to_ascii()));
 
@@ -632,11 +651,12 @@ mod tests {
 
     #[test]
     fn test_ascii_vec_ng() {
-        assert_eq!("abCDef&?#".to_ascii().to_lower().into_string(), "abcdef&?#".to_string());
-        assert_eq!("abCDef&?#".to_ascii().to_upper().into_string(), "ABCDEF&?#".to_string());
-        assert_eq!("".to_ascii().to_lower().into_string(), "".to_string());
-        assert_eq!("YMCA".to_ascii().to_lower().into_string(), "ymca".to_string());
-        assert_eq!("abcDEFxyz:.;".to_ascii().to_upper().into_string(), "ABCDEFXYZ:.;".to_string());
+        assert_eq!("abCDef&?#".to_ascii().to_lowercase().into_string(), "abcdef&?#".to_string());
+        assert_eq!("abCDef&?#".to_ascii().to_uppercase().into_string(), "ABCDEF&?#".to_string());
+        assert_eq!("".to_ascii().to_lowercase().into_string(), "".to_string());
+        assert_eq!("YMCA".to_ascii().to_lowercase().into_string(), "ymca".to_string());
+        let mixed = "abcDEFxyz:.;".to_ascii();
+        assert_eq!(mixed.to_uppercase().into_string(), "ABCDEFXYZ:.;".to_string());
     }
 
     #[test]

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -530,7 +530,7 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
                 FormatHEX => {
                     s = s.as_slice()
                          .to_ascii()
-                         .to_upper()
+                         .to_uppercase()
                          .into_bytes()
                          .into_iter()
                          .collect();

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -65,7 +65,7 @@ fn sort_and_fmt(mm: &HashMap<Vec<u8> , uint>, total: uint) -> String {
        buffer.push_str(format!("{} {:0.3f}\n",
                                k.as_slice()
                                .to_ascii()
-                               .to_upper()
+                               .to_uppercase()
                                .into_string(), v).as_slice());
    }
 
@@ -74,7 +74,7 @@ fn sort_and_fmt(mm: &HashMap<Vec<u8> , uint>, total: uint) -> String {
 
 // given a map, search for the frequency of a pattern
 fn find(mm: &HashMap<Vec<u8> , uint>, key: String) -> uint {
-   let key = key.into_ascii().as_slice().to_lower().into_string();
+   let key = key.into_ascii().as_slice().to_lowercase().into_string();
    match mm.find_equiv(&key.as_bytes()) {
       option::None      => { return 0u; }
       option::Some(&num) => { return num; }


### PR DESCRIPTION
AsciiStr::to_lower is now AsciiStr::to_lowercase and AsciiStr::to_upper is AsciiStr::to_uppercase to match Ascii trait.

Part of issue #17790.

This is my first pull request so let me know if anything is incorrect.

Thanks!

[breaking-changes]
