### PR TITLE
Continue cfg syntax transition

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -952,10 +952,10 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
         to_lower(line).as_slice().starts_with(to_lower(prefix).as_slice())
     }
 
-    #[cfg(target_os = "linux")]
-    #[cfg(target_os = "macos")]
-    #[cfg(target_os = "freebsd")]
-    #[cfg(target_os = "dragonfly")]
+    #[cfg(any(target_os = "linux",
+              target_os = "macos",
+              target_os = "freebsd",
+              target_os = "dragonfly"))]
     fn prefix_matches( line : &str, prefix : &str ) -> bool {
         line.starts_with( prefix )
     }
@@ -1356,10 +1356,10 @@ fn program_output(config: &Config, testfile: &Path, lib_path: &str, prog: String
 }
 
 // Linux and mac don't require adjusting the library search path
-#[cfg(target_os = "linux")]
-#[cfg(target_os = "macos")]
-#[cfg(target_os = "freebsd")]
-#[cfg(target_os = "dragonfly")]
+#[cfg(any(target_os = "linux",
+          target_os = "macos",
+          target_os = "freebsd",
+          target_os = "dragonfly"))]
 fn make_cmdline(_libpath: &str, prog: &str, args: &[String]) -> String {
     format!("{} {}", prog, args.connect(" "))
 }

--- a/src/doc/guide-ffi.md
+++ b/src/doc/guide-ffi.md
@@ -475,7 +475,7 @@ conventions. Rust provides a way to tell the compiler which convention to use:
 ~~~~
 extern crate libc;
 
-#[cfg(target_os = "win32", target_arch = "x86")]
+#[cfg(all(target_os = "win32", target_arch = "x86"))]
 #[link(name = "kernel32")]
 #[allow(non_snake_case)]
 extern "stdcall" {

--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -313,8 +313,7 @@ literal string (i.e `""`)
 ```
 #![feature(asm)]
 
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn foo() {
     unsafe {
         asm!("NOP");
@@ -322,8 +321,7 @@ fn foo() {
 }
 
 // other platforms
-#[cfg(not(target_arch = "x86"),
-      not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 fn foo() { /* ... */ }
 
 fn main() {
@@ -340,7 +338,7 @@ but you must add the right number of `:` if you skip them:
 
 ```
 # #![feature(asm)]
-# #[cfg(target_arch = "x86")] #[cfg(target_arch = "x86_64")]
+# #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 # fn main() { unsafe {
 asm!("xor %eax, %eax"
     :
@@ -354,7 +352,7 @@ Whitespace also doesn't matter:
 
 ```
 # #![feature(asm)]
-# #[cfg(target_arch = "x86")] #[cfg(target_arch = "x86_64")]
+# #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 # fn main() { unsafe {
 asm!("xor %eax, %eax" ::: "eax");
 # } }
@@ -368,7 +366,7 @@ expressions must be mutable lvalues:
 
 ```
 # #![feature(asm)]
-# #[cfg(target_arch = "x86")] #[cfg(target_arch = "x86_64")]
+# #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn add(a: int, b: int) -> int {
     let mut c = 0;
     unsafe {
@@ -379,7 +377,7 @@ fn add(a: int, b: int) -> int {
     }
     c
 }
-# #[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"))]
+# #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 # fn add(a: int, b: int) -> int { a + b }
 
 fn main() {
@@ -396,7 +394,7 @@ stay valid.
 
 ```
 # #![feature(asm)]
-# #[cfg(target_arch = "x86")] #[cfg(target_arch = "x86_64")]
+# #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 # fn main() { unsafe {
 // Put the value 0x200 in eax
 asm!("mov $$0x200, %eax" : /* no outputs */ : /* no inputs */ : "eax");

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2066,26 +2066,28 @@ fn macos_only() {
 }
 
 // This function is only included when either foo or bar is defined
-#[cfg(foo)]
-#[cfg(bar)]
+#[cfg(any(foo, bar))]
 fn needs_foo_or_bar() {
   // ...
 }
 
 // This function is only included when compiling for a unixish OS with a 32-bit
 // architecture
-#[cfg(unix, target_word_size = "32")]
+#[cfg(all(unix, target_word_size = "32"))]
 fn on_32bit_unix() {
+  // ...
+}
+
+// This function is only included when foo is not defined
+#[cfg(not(foo))]
+fn needs_not_foo() {
   // ...
 }
 ```
 
 This illustrates some conditional compilation can be achieved using the
-`#[cfg(...)]` attribute. Note that `#[cfg(foo, bar)]` is a condition that needs
-both `foo` and `bar` to be defined while `#[cfg(foo)] #[cfg(bar)]` only needs
-one of `foo` and `bar` to be defined (this resembles in the disjunctive normal
-form). Additionally, one can reverse a condition by enclosing it in a
-`not(...)`, like e. g. `#[cfg(not(target_os = "win32"))]`.
+`#[cfg(...)]` attribute. `any`, `all` and `not` can be used to assemble
+arbitrarily complex configurations through nesting.
 
 The following configurations must be defined by the implementation:
 

--- a/src/libcoretest/mem.rs
+++ b/src/libcoretest/mem.rs
@@ -19,10 +19,10 @@ fn size_of_basic() {
 }
 
 #[test]
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "arm")]
-#[cfg(target_arch = "mips")]
-#[cfg(target_arch = "mipsel")]
+#[cfg(any(target_arch = "x86",
+          target_arch = "arm",
+          target_arch = "mips",
+          target_arch = "mipsel"))]
 fn size_of_32() {
     assert_eq!(size_of::<uint>(), 4u);
     assert_eq!(size_of::<*const uint>(), 4u);
@@ -51,10 +51,10 @@ fn align_of_basic() {
 }
 
 #[test]
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "arm")]
-#[cfg(target_arch = "mips")]
-#[cfg(target_arch = "mipsel")]
+#[cfg(any(target_arch = "x86",
+          target_arch = "arm",
+          target_arch = "mips",
+          target_arch = "mipsel"))]
 fn align_of_32() {
     assert_eq!(align_of::<uint>(), 4u);
     assert_eq!(align_of::<*const uint>(), 4u);

--- a/src/librustc_back/rpath.rs
+++ b/src/librustc_back/rpath.rs
@@ -200,8 +200,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
-    #[cfg(target_os = "android")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     fn test_rpath_relative() {
         let config = &mut RPathConfig {
             os: abi::OsLinux,

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -261,20 +261,20 @@ fn in_cfg(diagnostic: &SpanHandler, cfg: &[P<ast::MetaItem>], attrs: &[ast::Attr
         };
 
         if mis.len() != 1 {
-            diagnostic.span_warn(attr.span, "The use of multiple cfgs in the top level of \
-                                             `#[cfg(..)]` is deprecated. Change `#[cfg(a, b)]` to \
-                                             `#[cfg(all(a, b))]`.");
+            diagnostic.span_err(attr.span, "expected 1 cfg-pattern");
+            return false;
         }
 
         if seen_cfg {
-            diagnostic.span_warn(attr.span, "The semantics of multiple `#[cfg(..)]` attributes on \
-                                             same item are changing from the union of the cfgs to \
-                                             the intersection of the cfgs. Change `#[cfg(a)] \
-                                             #[cfg(b)]` to `#[cfg(any(a, b))]`.");
+            diagnostic.span_err(attr.span, "The semantics of multiple `#[cfg(..)]` attributes on \
+                                            same item are changing from the union of the cfgs to \
+                                            the intersection of the cfgs. Change `#[cfg(a)] \
+                                            #[cfg(b)]` to `#[cfg(any(a, b))]`.");
+            return false;
         }
 
         seen_cfg = true;
-        in_cfg |= mis.iter().all(|mi| attr::cfg_matches(diagnostic, cfg, &**mi));
+        in_cfg |= attr::cfg_matches(diagnostic, cfg, &*mis[0]);
     }
     in_cfg | !seen_cfg
 }

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -126,7 +126,7 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
                         span: i.span,
                         path: self.cx.path.clone(),
                         bench: is_bench_fn(&self.cx, &*i),
-                        ignore: is_ignored(&self.cx, &*i),
+                        ignore: is_ignored(&*i),
                         should_fail: should_fail(&*i)
                     };
                     self.cx.testfns.push(test);
@@ -343,22 +343,8 @@ fn is_bench_fn(cx: &TestCtxt, i: &ast::Item) -> bool {
     return has_bench_attr && has_test_signature(i);
 }
 
-fn is_ignored(cx: &TestCtxt, i: &ast::Item) -> bool {
-    i.attrs.iter().any(|attr| {
-        // check ignore(cfg(foo, bar))
-        attr.check_name("ignore") && match attr.meta_item_list() {
-            Some(ref cfgs) => {
-                if cfgs.iter().any(|cfg| cfg.check_name("cfg")) {
-                    cx.span_diagnostic.span_warn(attr.span,
-                            "The use of cfg filters in #[ignore] is \
-                             deprecated. Use #[cfg_attr(<cfg pattern>, \
-                             ignore)] instead.");
-                }
-                attr::test_cfg(cx.config.as_slice(), cfgs.iter())
-            }
-            None => true
-        }
-    })
+fn is_ignored(i: &ast::Item) -> bool {
+    i.attrs.iter().any(|attr| attr.check_name("ignore"))
 }
 
 fn should_fail(i: &ast::Item) -> bool {

--- a/src/test/auxiliary/extern_calling_convention.rs
+++ b/src/test/auxiliary/extern_calling_convention.rs
@@ -26,8 +26,7 @@ pub extern "win64" fn foo(a: int, b: int, c: int, d: int) {
 }
 
 #[inline(never)]
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "arm")]
+#[cfg(any(target_arch = "x86", target_arch = "arm"))]
 pub extern fn foo(a: int, b: int, c: int, d: int) {
     assert!(a == 1);
     assert!(b == 2);

--- a/src/test/run-make/test-harness/test-ignore-cfg.rs
+++ b/src/test/run-make/test-harness/test-ignore-cfg.rs
@@ -9,11 +9,11 @@
 // except according to those terms.
 
 #[test]
-#[ignore(cfg(ignorecfg))]
+#[cfg_attr(ignorecfg, ignore)]
 fn shouldignore() {
 }
 
 #[test]
-#[ignore(cfg(noignorecfg))]
+#[cfg_attr(noignorecfg, ignore)]
 fn shouldnotignore() {
 }

--- a/src/test/run-pass/asm-in-out-operand.rs
+++ b/src/test/run-pass/asm-in-out-operand.rs
@@ -10,8 +10,7 @@
 
 #![feature(asm)]
 
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 unsafe fn next_power_of_2(n: u32) -> u32 {
     let mut tmp = n;
     asm!("dec $0" : "+rm"(tmp) :: "cc");
@@ -28,8 +27,7 @@ unsafe fn next_power_of_2(n: u32) -> u32 {
     return tmp;
 }
 
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn main() {
     unsafe {
         assert_eq!(64, next_power_of_2(37));
@@ -62,5 +60,5 @@ pub fn main() {
     assert_eq!(x, 60);
 }
 
-#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 pub fn main() {}

--- a/src/test/run-pass/asm-out-assign.rs
+++ b/src/test/run-pass/asm-out-assign.rs
@@ -10,8 +10,7 @@
 
 #![feature(asm)]
 
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn main() {
     let x: int;
     unsafe {
@@ -30,5 +29,5 @@ pub fn main() {
     assert_eq!(x, 13);
 }
 
-#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 pub fn main() {}

--- a/src/test/run-pass/bitwise.rs
+++ b/src/test/run-pass/bitwise.rs
@@ -9,8 +9,7 @@
 // except according to those terms.
 
 
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "arm")]
+#[cfg(any(target_arch = "x86", target_arch = "arm"))]
 fn target() {
     assert_eq!(-1000 as uint >> 3u, 536870787u);
 }

--- a/src/test/run-pass/cfgs-on-items.rs
+++ b/src/test/run-pass/cfgs-on-items.rs
@@ -11,24 +11,23 @@
 // compile-flags: --cfg fooA --cfg fooB
 
 // fooA AND !bar
-#[cfg(fooA, not(bar))]
+#[cfg(all(fooA, not(bar)))]
 fn foo1() -> int { 1 }
 
 // !fooA AND !bar
-#[cfg(not(fooA), not(bar))]
+#[cfg(all(not(fooA), not(bar)))]
 fn foo2() -> int { 2 }
 
 // fooC OR (fooB AND !bar)
-#[cfg(fooC)]
-#[cfg(fooB, not(bar))]
+#[cfg(any(fooC, all(fooB, not(bar))))]
 fn foo2() -> int { 3 }
 
 // fooA AND bar
-#[cfg(fooA, bar)]
+#[cfg(all(fooA, bar))]
 fn foo3() -> int { 2 }
 
 // !(fooA AND bar)
-#[cfg(not(fooA, bar))]
+#[cfg(not(all(fooA, bar)))]
 fn foo3() -> int { 3 }
 
 pub fn main() {

--- a/src/test/run-pass/core-run-destroy.rs
+++ b/src/test/run-pass/core-run-destroy.rs
@@ -60,10 +60,10 @@ pub fn test_destroy_actually_kills(force: bool) {
     use libc;
     use std::str;
 
-    #[cfg(unix,not(target_os="android"))]
+    #[cfg(all(unix,not(target_os="android")))]
     static BLOCK_COMMAND: &'static str = "cat";
 
-    #[cfg(unix,target_os="android")]
+    #[cfg(all(unix,target_os="android"))]
     static BLOCK_COMMAND: &'static str = "/system/bin/cat";
 
     #[cfg(windows)]

--- a/src/test/run-pass/intrinsic-alignment.rs
+++ b/src/test/run-pass/intrinsic-alignment.rs
@@ -17,10 +17,10 @@ mod rusti {
     }
 }
 
-#[cfg(target_os = "linux")]
-#[cfg(target_os = "macos")]
-#[cfg(target_os = "freebsd")]
-#[cfg(target_os = "dragonfly")]
+#[cfg(any(target_os = "linux",
+          target_os = "macos",
+          target_os = "freebsd",
+          target_os = "dragonfly"))]
 mod m {
     #[main]
     #[cfg(target_arch = "x86")]
@@ -32,8 +32,7 @@ mod m {
     }
 
     #[main]
-    #[cfg(target_arch = "x86_64")]
-    #[cfg(target_arch = "arm")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "arm"))]
     pub fn main() {
         unsafe {
             assert_eq!(::rusti::pref_align_of::<u64>(), 8u);

--- a/src/test/run-pass/issue-14936.rs
+++ b/src/test/run-pass/issue-14936.rs
@@ -36,8 +36,7 @@ macro_rules! demo {
     }
 }
 
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {
     fn out_write_only_expr_then_in_expr() {
         demo!("=r")
@@ -51,5 +50,5 @@ fn main() {
     out_read_write_expr_then_in_expr();
 }
 
-#[cfg(not(target_arch = "x86"), not(target_arch = "x86_64"))]
+#[cfg(all(not(target_arch = "x86"), not(target_arch = "x86_64")))]
 pub fn main() {}

--- a/src/test/run-pass/issue-2895.rs
+++ b/src/test/run-pass/issue-2895.rs
@@ -28,8 +28,7 @@ pub fn main() {
     assert_eq!(mem::size_of::<Kitty>(), 16 as uint);
 }
 
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "arm")]
+#[cfg(any(target_arch = "x86", target_arch = "arm"))]
 pub fn main() {
     assert_eq!(mem::size_of::<Cat>(), 4 as uint);
     assert_eq!(mem::size_of::<Kitty>(), 8 as uint);

--- a/src/test/run-pass/rec-align-u32.rs
+++ b/src/test/run-pass/rec-align-u32.rs
@@ -36,8 +36,7 @@ struct Outer {
 }
 
 
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "arm")]
+#[cfg(any(target_arch = "x86", target_arch = "arm"))]
 mod m {
     pub fn align() -> uint { 4u }
     pub fn size() -> uint { 8u }

--- a/src/test/run-pass/rec-align-u64.rs
+++ b/src/test/run-pass/rec-align-u64.rs
@@ -36,10 +36,10 @@ struct Outer {
 }
 
 
-#[cfg(target_os = "linux")]
-#[cfg(target_os = "macos")]
-#[cfg(target_os = "freebsd")]
-#[cfg(target_os = "dragonfly")]
+#[cfg(any(target_os = "linux",
+          target_os = "macos",
+          target_os = "freebsd",
+          target_os = "dragonfly"))]
 mod m {
     #[cfg(target_arch = "x86")]
     pub mod m {
@@ -47,8 +47,7 @@ mod m {
         pub fn size() -> uint { 12u }
     }
 
-    #[cfg(target_arch = "x86_64")]
-    #[cfg(target_arch = "arm")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "arm"))]
     pub mod m {
         pub fn align() -> uint { 8u }
         pub fn size() -> uint { 16u }

--- a/src/test/run-pass/struct-return.rs
+++ b/src/test/run-pass/struct-return.rs
@@ -57,8 +57,7 @@ fn test2() {
     }
 }
 
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "arm")]
+#[cfg(any(target_arch = "x86", target_arch = "arm"))]
 fn test2() {
 }
 

--- a/src/test/run-pass/syntax-extension-cfg.rs
+++ b/src/test/run-pass/syntax-extension-cfg.rs
@@ -18,17 +18,15 @@ pub fn main() {
     if ! cfg!(qux="foo") { fail!() }
     if   cfg!(not(qux="foo")) { fail!() }
 
-    if ! cfg!(foo, qux="foo") { fail!() }
-    if   cfg!(not(foo, qux="foo")) { fail!() }
-    if   cfg!(all(not(foo, qux="foo"))) { fail!() }
+    if ! cfg!(all(foo, qux="foo")) { fail!() }
+    if   cfg!(not(all(foo, qux="foo"))) { fail!() }
+    if   cfg!(all(not(all(foo, qux="foo")))) { fail!() }
 
     if cfg!(not_a_cfg) { fail!() }
-    if cfg!(not_a_cfg, foo, qux="foo") { fail!() }
+    if cfg!(all(not_a_cfg, foo, qux="foo")) { fail!() }
     if cfg!(all(not_a_cfg, foo, qux="foo")) { fail!() }
     if ! cfg!(any(not_a_cfg, foo)) { fail!() }
 
     if ! cfg!(not(not_a_cfg)) { fail!() }
-    if ! cfg!(not(not_a_cfg), foo, qux="foo") { fail!() }
-
-    if cfg!(trailing_comma, ) { fail!() }
+    if ! cfg!(all(not(not_a_cfg), foo, qux="foo")) { fail!() }
 }

--- a/src/test/run-pass/x86stdcall.rs
+++ b/src/test/run-pass/x86stdcall.rs
@@ -30,9 +30,9 @@ pub fn main() {
     }
 }
 
-#[cfg(target_os = "macos")]
-#[cfg(target_os = "linux")]
-#[cfg(target_os = "freebsd")]
-#[cfg(target_os = "dragonfly")]
-#[cfg(target_os = "android")]
+#[cfg(any(target_os = "macos",
+          target_os = "linux",
+          target_os = "freebsd",
+          target_os = "dragonfly",
+          target_os = "android"))]
 pub fn main() { }


### PR DESCRIPTION
All deprecation warnings have been converted to errors. This includes
the warning for multiple cfgs on one item. We'll leave that as an error
for some period of time to ensure that all uses are updated before the
behavior changes from "or" to "and".
