### PR TITLE
Add subsecond resolution to 'std::io::fs::change_file_times'

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -202,6 +202,7 @@ pub use funcs::bsd43::{shutdown};
 #[cfg(unix)] pub use funcs::posix01::stat_::{lstat};
 #[cfg(unix)] pub use funcs::posix01::unistd::{fsync, ftruncate};
 #[cfg(unix)] pub use funcs::posix01::unistd::{readlink, symlink};
+#[cfg(unix)] pub use funcs::posix01::unistd::utimes;
 #[cfg(unix)] pub use funcs::bsd43::{getifaddrs, freeifaddrs};
 
 #[cfg(windows)] pub use consts::os::c95::{WSAECONNREFUSED, WSAECONNRESET, WSAEACCES};
@@ -4499,6 +4500,7 @@ pub mod funcs {
         pub mod unistd {
             use types::os::arch::c95::{c_char, c_int, size_t};
             use types::os::arch::posix88::{ssize_t, off_t};
+            use types::os::common::posix01::timeval;
 
             extern {
                 pub fn readlink(path: *const c_char,
@@ -4520,6 +4522,7 @@ pub mod funcs {
                                path2: *const c_char) -> c_int;
 
                 pub fn ftruncate(fd: c_int, length: off_t) -> c_int;
+                pub fn utimes(file: *const c_char, buf: *const timeval) -> c_int;
             }
         }
 

--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -491,11 +491,11 @@ pub fn lstat(p: &CString) -> IoResult<rtio::FileStat> {
 }
 
 pub fn utime(p: &CString, atime: u64, mtime: u64) -> IoResult<()> {
-    let buf = libc::utimbuf {
-        actime: (atime / 1000) as libc::time_t,
-        modtime: (mtime / 1000) as libc::time_t,
-    };
-    super::mkerr_libc(unsafe { libc::utime(p.as_ptr(), &buf) })
+    let buf = [
+        util::ms_to_timeval(atime),
+        util::ms_to_timeval(mtime),
+    ];
+    super::mkerr_libc(unsafe { libc::utimes(p.as_ptr(), buf.as_ptr()) })
 }
 
 #[cfg(test)]

--- a/src/test/run-pass/issue-17946.rs
+++ b/src/test/run-pass/issue-17946.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+// 
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io;
+use std::io::fs::PathExtensions;
+
+fn main() {
+    let tmp_dir = io::TempDir::new("").unwrap();
+    let tmp_file = tmp_dir.path().join("file"); 
+    io::fs::File::create(&tmp_file).unwrap();
+    io::fs::change_file_times(&tmp_file, 10000999, 20000999).unwrap();
+    let stat = tmp_file.stat().unwrap();
+    assert!(stat.accessed == 10000999, "Expected 10000999, got {}", stat.accessed);
+    assert!(stat.modified == 20000999, "Expected 20000999, got {}", stat.modified);
+}

--- a/src/test/run-pass/issue-17946.rs
+++ b/src/test/run-pass/issue-17946.rs
@@ -1,7 +1,7 @@
 // Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
-// 
+//
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
@@ -13,7 +13,7 @@ use std::io::fs::PathExtensions;
 
 fn main() {
     let tmp_dir = io::TempDir::new("").unwrap();
-    let tmp_file = tmp_dir.path().join("file"); 
+    let tmp_file = tmp_dir.path().join("file");
     io::fs::File::create(&tmp_file).unwrap();
     io::fs::change_file_times(&tmp_file, 10000999, 20000999).unwrap();
     let stat = tmp_file.stat().unwrap();


### PR DESCRIPTION
As described on issue #17946, the function 'change_file_times' does not update the milliseconds portion of the file timestamp when running under Unix.

As per the suggestion of @mahkoh, I have modified the function 'native::io::file::utime' so that it uses the native 'utimes' function, which does allow for millisecond granularity.
