### PR TITLE
optimize position independent code in executables

### DIFF
--- a/src/librustc/back/write.rs
+++ b/src/librustc/back/write.rs
@@ -34,7 +34,6 @@ use std::sync::{Arc, Mutex};
 use std::task::TaskBuilder;
 use libc::{c_uint, c_int, c_void};
 
-
 #[deriving(Clone, PartialEq, PartialOrd, Ord, Eq)]
 pub enum OutputType {
     OutputTypeBitcode,
@@ -43,7 +42,6 @@ pub enum OutputType {
     OutputTypeObject,
     OutputTypeExe,
 }
-
 
 pub fn llvm_err(handler: &diagnostic::Handler, msg: String) -> ! {
     unsafe {
@@ -202,6 +200,10 @@ fn create_target_machine(sess: &Session) -> TargetMachineRef {
                      (sess.targ_cfg.os == abi::OsMacos &&
                       sess.targ_cfg.arch == abi::X86_64);
 
+    let any_library = sess.crate_types.borrow().iter().any(|ty| {
+        *ty != config::CrateTypeExecutable
+    });
+
     // OSX has -dead_strip, which doesn't rely on ffunction_sections
     // FIXME(#13846) this should be enabled for windows
     let ffunction_sections = sess.targ_cfg.os != abi::OsMacos &&
@@ -240,6 +242,7 @@ fn create_target_machine(sess: &Session) -> TargetMachineRef {
                         true /* EnableSegstk */,
                         use_softfp,
                         no_fp_elim,
+                        !any_library && reloc_model == llvm::RelocPIC,
                         ffunction_sections,
                         fdata_sections,
                     )

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -353,6 +353,7 @@ pub enum CodeGenOptLevel {
     CodeGenLevelAggressive = 3,
 }
 
+#[deriving(PartialEq)]
 #[repr(C)]
 pub enum RelocMode {
     RelocDefault = 0,
@@ -1907,6 +1908,7 @@ extern {
                                        EnableSegstk: bool,
                                        UseSoftFP: bool,
                                        NoFramePointerElim: bool,
+                                       PositionIndependentExecutable: bool,
                                        FunctionSections: bool,
                                        DataSections: bool) -> TargetMachineRef;
     pub fn LLVMRustDisposeTargetMachine(T: TargetMachineRef);

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -71,6 +71,7 @@ LLVMRustCreateTargetMachine(const char *triple,
                             bool EnableSegmentedStacks,
                             bool UseSoftFloat,
                             bool NoFramePointerElim,
+                            bool PositionIndependentExecutable,
                             bool FunctionSections,
                             bool DataSections) {
     std::string Error;
@@ -83,6 +84,7 @@ LLVMRustCreateTargetMachine(const char *triple,
     }
 
     TargetOptions Options;
+    Options.PositionIndependentExecutable = PositionIndependentExecutable;
     Options.NoFramePointerElim = NoFramePointerElim;
 #if LLVM_VERSION_MINOR < 5
     Options.EnableSegmentedStacks = EnableSegmentedStacks;


### PR DESCRIPTION
Position independent code has fewer requirements in executables, so pass
the appropriate flag to LLVM in order to allow more optimization. At the
moment this means faster thread-local storage.
