### PR TITLE
Fix `find` check for executables

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -284,7 +284,7 @@ tidy:
 		| xargs -n 10 $(CFG_PYTHON) $(S)src/etc/tidy.py
 		$(Q)echo $(ALL_HS) \
 		| xargs -n 10 $(CFG_PYTHON) $(S)src/etc/tidy.py
-		$(Q)find $(S)src -type f -perm a+x \
+		$(Q)find $(S)src -type f -perm +a+x \
 		    -not -name '*.rs' -and -not -name '*.py' \
 		    -and -not -name '*.sh' \
 		| grep '^$(S)src/jemalloc' -v \


### PR DESCRIPTION
Apparently the fix in d08441b9 didn't catch a recent executable (#17965), but
I've verified that this does indeed catch the executable
