### PR TITLE
Properly visit nested functions and closures in check_rvalues

### DIFF
--- a/src/librustc/middle/check_rvalues.rs
+++ b/src/librustc/middle/check_rvalues.rs
@@ -32,13 +32,16 @@ struct RvalueContext<'a, 'tcx: 'a> {
 
 impl<'a, 'tcx, 'v> visit::Visitor<'v> for RvalueContext<'a, 'tcx> {
     fn visit_fn(&mut self,
-                _: visit::FnKind<'v>,
+                fk: visit::FnKind<'v>,
                 fd: &'v ast::FnDecl,
                 b: &'v ast::Block,
-                _: Span,
+                s: Span,
                 _: ast::NodeId) {
-        let mut euv = euv::ExprUseVisitor::new(self, self.tcx);
-        euv.walk_fn(fd, b);
+        {
+            let mut euv = euv::ExprUseVisitor::new(self, self.tcx);
+            euv.walk_fn(fd, b);
+        }
+        visit::walk_fn(self, fk, fd, b, s)
     }
 }
 

--- a/src/test/compile-fail/issue-17651.rs
+++ b/src/test/compile-fail/issue-17651.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that moves of unsized values within closures are caught
+// and rejected.
+
+fn main() {
+    (|| box *[0u].as_slice())();
+    //~^ ERROR cannot move a value of type [uint]
+}


### PR DESCRIPTION
This correctly catches moves of unsized values in nested
functions and closures.

Closes issue #17651
