### PR TITLE
Include the Unicode version used to generate `src/libunicode/tables.rs`.

### DIFF
--- a/src/etc/unicode.py
+++ b/src/etc/unicode.py
@@ -604,6 +604,15 @@ if __name__ == "__main__":
         rf.write(preamble)
 
         # download and parse all the data
+        fetch("ReadMe.txt")
+        with open("ReadMe.txt") as readme:
+            pattern = "for Version (\d+)\.(\d+)\.(\d+) of the Unicode"
+            unicode_version = re.search(pattern, readme.read()).groups()
+        rf.write("""
+/// The version of [Unicode](http://www.unicode.org/)
+/// that the `UnicodeChar` and `UnicodeStrSlice` traits are based on.
+pub const UNICODE_VERSION: (uint, uint, uint) = (%s, %s, %s);
+""" % unicode_version)
         (canon_decomp, compat_decomp, gencats, combines,
                 lowerupper, upperlower) = load_unicode_data("UnicodeData.txt")
         want_derived = ["XID_Start", "XID_Continue", "Alphabetic", "Lowercase", "Uppercase"]

--- a/src/libunicode/lib.rs
+++ b/src/libunicode/lib.rs
@@ -64,6 +64,7 @@ pub mod char {
     pub use normalize::{decompose_canonical, decompose_compatible, compose};
 
     pub use tables::normalization::canonical_combining_class;
+    pub use tables::UNICODE_VERSION;
 
     pub use u_char::{is_alphabetic, is_XID_start, is_XID_continue};
     pub use u_char::{is_lowercase, is_uppercase, is_whitespace};

--- a/src/libunicode/tables.rs
+++ b/src/libunicode/tables.rs
@@ -12,6 +12,10 @@
 
 #![allow(missing_doc, non_uppercase_statics, non_snake_case)]
 
+/// The version of [Unicode](http://www.unicode.org/)
+/// that the `UnicodeChar` and `UnicodeStrSlice` traits are based on.
+pub const UNICODE_VERSION: (uint, uint, uint) = (7, 0, 0);
+
 fn bsearch_range_table(c: char, r: &'static [(char,char)]) -> bool {
     use core::cmp::{Equal, Less, Greater};
     use core::slice::ImmutableSlice;


### PR DESCRIPTION
And re-export it as `std::char::UNICODE_VERSION`.
