### PR TITLE
Doc: Clarify the meaning of "copy" in std::mem::swap/replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ documentation.
 3. Enjoy!
 
 > ***Note:*** Windows users can read the detailed
-> [getting started][wiki-start] notes on the wiki.
+> [using Rust on Windows][win-wiki] notes on the wiki.
 
 [installer]: http://www.rust-lang.org/install.html
 [guide]: http://doc.rust-lang.org/guide.html
-[wiki-start]: https://github.com/rust-lang/rust/wiki/Note-getting-started-developing-Rust
 [win-wiki]: https://github.com/rust-lang/rust/wiki/Using-Rust-on-Windows
 
 ## Building from Source

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ fetch snapshots, and an OS that can execute the available snapshot binaries.
 
 Snapshot binaries are currently built and tested on several platforms:
 
-* Windows (7, 8, Server 2008 R2), x86 only
+* Windows (7, 8, Server 2008 R2), x86 and x86-64 (64-bit support added in Rust 0.12.0)
 * Linux (2.6.18 or later, various distributions), x86 and x86-64
 * OSX 10.7 (Lion) or greater, x86 and x86-64
 

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2503,6 +2503,8 @@ The currently implemented features of the reference compiler are:
 
 * `if_let` - Allows use of the `if let` syntax.
 
+* `while_let` - Allows use of the `while let` syntax.
+
 * `intrinsics` - Allows use of the "rust-intrinsics" ABI. Compiler intrinsics
                  are inherently unstable and no promise about them is made.
 

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -3511,6 +3511,18 @@ of a condition expression it expects a refutable let statement. If the value of 
 expression on the right hand side of the let statement matches the pattern, the corresponding
 block will execute, otherwise flow proceeds to the first `else` block that follows.
 
+### While let loops
+
+```{.ebnf .gram}
+while_let_expr : "while" "let" pat '=' expr '{' block '}' ;
+```
+
+A `while let` loop is semantically identical to a `while` loop but in place of a
+condition expression it expects a refutable let statement. If the value of the
+expression on the right hand side of the let statement matches the pattern, the
+loop body block executes and control returns to the pattern matching statement.
+Otherwise, the while expression completes.
+
 ### Return expressions
 
 ```{.ebnf .gram}

--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -33,7 +33,7 @@
 //!     bv.set(0, false);
 //!     bv.set(1, false);
 //!
-//!     for i in range(2, max_prime) {
+//!     for i in iter::range_inclusive(2, (max_prime as f64).sqrt() as uint) {
 //!         // if i is a prime
 //!         if bv[i] {
 //!             // Mark all multiples of i as non-prime (any multiples below i * i

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -263,9 +263,8 @@ pub fn from_be32(x: u32) -> u32 { Int::from_be(x) }
 #[deprecated = "use `Int::from_be` instead"]
 pub fn from_be64(x: u64) -> u64 { Int::from_be(x) }
 
-/// Swap the values at two mutable locations of the same type, without
-/// deinitialising or semantically copying either one. Note that shallow byte
-/// copies are performed.
+/// Swap the values at two mutable locations of the same type using shallow byte
+/// copies, without deinitialising or recursively copying (via `Clone`) either one.
 #[inline]
 #[stable]
 pub fn swap<T>(x: &mut T, y: &mut T) {
@@ -285,8 +284,8 @@ pub fn swap<T>(x: &mut T, y: &mut T) {
 }
 
 /// Replace the value at a mutable location with a new one, returning the old
-/// value, without deinitialising or semantically copying either one. Note that
-/// shallow byte copies are performed.
+/// value. Only shallow byte copies are used; neither value is deinitialized or
+/// recursively copied (via `Clone`).
 ///
 /// This is primarily used for transferring and swapping ownership of a value
 /// in a mutable location. For example, this function allows consumption of

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -264,7 +264,8 @@ pub fn from_be32(x: u32) -> u32 { Int::from_be(x) }
 pub fn from_be64(x: u64) -> u64 { Int::from_be(x) }
 
 /// Swap the values at two mutable locations of the same type, without
-/// deinitialising or copying either one.
+/// deinitialising or semantically copying either one. Note that shallow byte
+/// copies are performed.
 #[inline]
 #[stable]
 pub fn swap<T>(x: &mut T, y: &mut T) {
@@ -284,7 +285,8 @@ pub fn swap<T>(x: &mut T, y: &mut T) {
 }
 
 /// Replace the value at a mutable location with a new one, returning the old
-/// value, without deinitialising or copying either one.
+/// value, without deinitialising or semantically copying either one. Note that
+/// shallow byte copies are performed.
 ///
 /// This is primarily used for transferring and swapping ownership of a value
 /// in a mutable location. For example, this function allows consumption of

--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -150,5 +150,6 @@ register_diagnostics!(
     E0161,
     E0162,
     E0163,
-    E0164
+    E0164,
+    E0165
 )

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -1082,7 +1082,8 @@ impl LintPass for UnnecessaryParens {
             ast::ExprWhile(ref cond, _, _) => (cond, "`while` condition", true),
             ast::ExprMatch(ref head, _, source) => match source {
                 ast::MatchNormal => (head, "`match` head expression", true),
-                ast::MatchIfLetDesugar => (head, "`if let` head expression", true)
+                ast::MatchIfLetDesugar => (head, "`if let` head expression", true),
+                ast::MatchWhileLetDesugar => (head, "`while let` head expression", true),
             },
             ast::ExprRet(Some(ref value)) => (value, "`return` value", false),
             ast::ExprAssign(_, ref value) => (value, "assigned value", false),

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -259,6 +259,10 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
                 expr_exit
             }
 
+            ast::ExprWhileLet(..) => {
+                self.tcx.sess.span_bug(expr.span, "non-desugared ExprWhileLet");
+            }
+
             ast::ExprForLoop(ref pat, ref head, ref body, _) => {
                 //
                 //          [pred]

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -261,20 +261,30 @@ fn check_arms(cx: &MatchCheckCtxt, arms: &[(Vec<P<Pat>>, Option<&Expr>)], source
 
             match is_useful(cx, &seen, v.as_slice(), LeaveOutWitness) {
                 NotUseful => {
-                    if source == MatchIfLetDesugar {
-                        if printed_if_let_err {
-                            // we already printed an irrefutable if-let pattern error.
-                            // We don't want two, that's just confusing.
-                        } else {
+                    match source {
+                        MatchIfLetDesugar => {
+                            if printed_if_let_err {
+                                // we already printed an irrefutable if-let pattern error.
+                                // We don't want two, that's just confusing.
+                            } else {
+                                // find the first arm pattern so we can use its span
+                                let &(ref first_arm_pats, _) = &arms[0];
+                                let first_pat = first_arm_pats.get(0);
+                                let span = first_pat.span;
+                                span_err!(cx.tcx.sess, span, E0162, "irrefutable if-let pattern");
+                                printed_if_let_err = true;
+                            }
+                        },
+
+                        MatchWhileLetDesugar => {
                             // find the first arm pattern so we can use its span
                             let &(ref first_arm_pats, _) = &arms[0];
                             let first_pat = first_arm_pats.get(0);
                             let span = first_pat.span;
-                            span_err!(cx.tcx.sess, span, E0162, "irrefutable if-let pattern");
-                            printed_if_let_err = true;
-                        }
-                    } else {
-                        span_err!(cx.tcx.sess, pat.span, E0001, "unreachable pattern");
+                            span_err!(cx.tcx.sess, span, E0165, "irrefutable while-let pattern");
+                        },
+
+                        _ => span_err!(cx.tcx.sess, pat.span, E0001, "unreachable pattern")
                     }
                 }
                 Useful => (),

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -284,7 +284,9 @@ fn check_arms(cx: &MatchCheckCtxt, arms: &[(Vec<P<Pat>>, Option<&Expr>)], source
                             span_err!(cx.tcx.sess, span, E0165, "irrefutable while-let pattern");
                         },
 
-                        _ => span_err!(cx.tcx.sess, pat.span, E0001, "unreachable pattern")
+                        MatchNormal => {
+                            span_err!(cx.tcx.sess, pat.span, E0001, "unreachable pattern")
+                        },
                     }
                 }
                 Useful => (),

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -429,6 +429,10 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,TYPER> {
                 self.walk_block(&**blk);
             }
 
+            ast::ExprWhileLet(..) => {
+                self.tcx().sess.span_bug(expr.span, "non-desugared ExprWhileLet");
+            }
+
             ast::ExprForLoop(ref pat, ref head, ref blk, _) => {
                 // The pattern lives as long as the block.
                 debug!("walk_expr for loop case: blk id={}", blk.id);

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -484,6 +484,9 @@ fn visit_expr(ir: &mut IrMaps, expr: &Expr) {
       ExprIfLet(..) => {
           ir.tcx.sess.span_bug(expr.span, "non-desugared ExprIfLet");
       }
+      ExprWhileLet(..) => {
+          ir.tcx.sess.span_bug(expr.span, "non-desugared ExprWhileLet");
+      }
       ExprForLoop(ref pat, _, _, _) => {
         pat_util::pat_bindings(&ir.tcx.def_map, &**pat, |bm, p_id, sp, path1| {
             debug!("adding local variable {} from for loop with bm {:?}",
@@ -1022,6 +1025,10 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
             self.propagate_through_loop(expr, WhileLoop(&**cond), &**blk, succ)
           }
 
+          ExprWhileLet(..) => {
+              self.ir.tcx.sess.span_bug(expr.span, "non-desugared ExprWhileLet");
+          }
+
           ExprForLoop(ref pat, ref head, ref blk, _) => {
             let ln = self.propagate_through_loop(expr, ForLoop(&**pat), &**blk, succ);
             self.propagate_through_expr(&**head, ln)
@@ -1479,6 +1486,9 @@ fn check_expr(this: &mut Liveness, expr: &Expr) {
       }
       ExprIfLet(..) => {
         this.ir.tcx.sess.span_bug(expr.span, "non-desugared ExprIfLet");
+      }
+      ExprWhileLet(..) => {
+        this.ir.tcx.sess.span_bug(expr.span, "non-desugared ExprWhileLet");
       }
     }
 }

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -530,6 +530,9 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
           ast::ExprIfLet(..) => {
             self.tcx().sess.span_bug(expr.span, "non-desugared ExprIfLet");
           }
+          ast::ExprWhileLet(..) => {
+            self.tcx().sess.span_bug(expr.span, "non-desugared ExprWhileLet");
+          }
         }
     }
 

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -3496,6 +3496,11 @@ fn populate_scope_map(cx: &CrateContext,
                 })
             }
 
+            ast::ExprWhileLet(..) => {
+                cx.sess().span_bug(exp.span, "debuginfo::populate_scope_map() - \
+                                              Found unexpanded while-let.");
+            }
+
             ast::ExprForLoop(ref pattern, ref head, ref body, _) => {
                 walk_expr(cx, &**head, scope_stack, scope_map);
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3615,6 +3615,9 @@ pub fn expr_kind(tcx: &ctxt, expr: &ast::Expr) -> ExprKind {
         ast::ExprIfLet(..) => {
             tcx.sess.span_bug(expr.span, "non-desugared ExprIfLet");
         }
+        ast::ExprWhileLet(..) => {
+            tcx.sess.span_bug(expr.span, "non-desugared ExprWhileLet");
+        }
 
         ast::ExprLit(ref lit) if lit_is_str(&**lit) => {
             RvalueDpsExpr

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -4116,6 +4116,9 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
             fcx.write_nil(id);
         }
       }
+      ast::ExprWhileLet(..) => {
+        tcx.sess.span_bug(expr.span, "non-desugared ExprWhileLet");
+      }
       ast::ExprForLoop(ref pat, ref head, ref block, _) => {
         check_expr(fcx, &**head);
         let typ = lookup_method_for_for_loop(fcx, &**head, expr.id);

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -93,6 +93,9 @@ pub fn explain_region_and_span(cx: &ctxt, region: ty::Region)
                 explain_span(cx, "method call", expr.span)
               },
               ast::ExprMatch(_, _, ast::MatchIfLetDesugar) => explain_span(cx, "if let", expr.span),
+              ast::ExprMatch(_, _, ast::MatchWhileLetDesugar) => {
+                  explain_span(cx, "while let", expr.span)
+              },
               ast::ExprMatch(..) => explain_span(cx, "match", expr.span),
               _ => explain_span(cx, "expression", expr.span)
             }

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -294,6 +294,7 @@ mod svh_visitor {
 
             // just syntactic artifacts, expanded away by time of SVH.
             ExprIfLet(..)            => unreachable!(),
+            ExprWhileLet(..)         => unreachable!(),
             ExprMac(..)              => unreachable!(),
         }
     }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -524,6 +524,8 @@ pub enum Expr_ {
     // FIXME #6993: change to Option<Name> ... or not, if these are hygienic.
     ExprWhile(P<Expr>, P<Block>, Option<Ident>),
     // FIXME #6993: change to Option<Name> ... or not, if these are hygienic.
+    ExprWhileLet(P<Pat>, P<Expr>, P<Block>, Option<Ident>),
+    // FIXME #6993: change to Option<Name> ... or not, if these are hygienic.
     ExprForLoop(P<Pat>, P<Expr>, P<Block>, Option<Ident>),
     // Conditionless loop (can be exited with break, cont, or ret)
     // FIXME #6993: change to Option<Name> ... or not, if these are hygienic.

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -581,7 +581,8 @@ pub struct QPath {
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub enum MatchSource {
     MatchNormal,
-    MatchIfLetDesugar
+    MatchIfLetDesugar,
+    MatchWhileLetDesugar,
 }
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -147,6 +147,8 @@ pub trait AstBuilder {
     fn expr_some(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr>;
     fn expr_none(&self, sp: Span) -> P<ast::Expr>;
 
+    fn expr_break(&self, sp: Span) -> P<ast::Expr>;
+
     fn expr_tuple(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr>;
 
     fn expr_fail(&self, span: Span, msg: InternedString) -> P<ast::Expr>;
@@ -687,6 +689,12 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             self.ident_of("None")));
         self.expr_path(none)
     }
+
+
+    fn expr_break(&self, sp: Span) -> P<ast::Expr> {
+        self.expr(sp, ast::ExprBreak(None))
+    }
+
 
     fn expr_tuple(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprTup(exprs))

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -73,6 +73,7 @@ static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[
     ("slicing_syntax", Active),
 
     ("if_let", Active),
+    ("while_let", Active),
 
     // if you change this list without updating src/doc/reference.md, cmr will be sad
 
@@ -355,6 +356,10 @@ impl<'a, 'v> Visitor<'v> for Context<'a> {
                 self.gate_feature("slicing_syntax",
                                   e.span,
                                   "slicing syntax is experimental");
+            }
+            ast::ExprWhileLet(..) => {
+                self.gate_feature("while_let", e.span,
+                                  "`while let` syntax is experimental");
             }
             _ => {}
         }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -1218,6 +1218,12 @@ pub fn noop_fold_expr<T: Folder>(Expr {id, node, span}: Expr, folder: &mut T) ->
                           folder.fold_block(body),
                           opt_ident.map(|i| folder.fold_ident(i)))
             }
+            ExprWhileLet(pat, expr, body, opt_ident) => {
+                ExprWhileLet(folder.fold_pat(pat),
+                             folder.fold_expr(expr),
+                             folder.fold_block(body),
+                             opt_ident.map(|i| folder.fold_ident(i)))
+            }
             ExprForLoop(pat, iter, body, opt_ident) => {
                 ExprForLoop(folder.fold_pat(pat),
                             folder.fold_expr(iter),

--- a/src/libsyntax/parse/classify.rs
+++ b/src/libsyntax/parse/classify.rs
@@ -28,6 +28,7 @@ pub fn expr_requires_semi_to_be_stmt(e: &ast::Expr) -> bool {
         | ast::ExprMatch(..)
         | ast::ExprBlock(_)
         | ast::ExprWhile(..)
+        | ast::ExprWhileLet(..)
         | ast::ExprLoop(..)
         | ast::ExprForLoop(..) => false,
         _ => true

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1525,6 +1525,19 @@ impl<'a> State<'a> {
                 try!(space(&mut self.s));
                 try!(self.print_block(&**blk));
             }
+            ast::ExprWhileLet(ref pat, ref expr, ref blk, opt_ident) => {
+                for ident in opt_ident.iter() {
+                    try!(self.print_ident(*ident));
+                    try!(self.word_space(":"));
+                }
+                try!(self.head("while let"));
+                try!(self.print_pat(&**pat));
+                try!(space(&mut self.s));
+                try!(self.word_space("="));
+                try!(self.print_expr(&**expr));
+                try!(space(&mut self.s));
+                try!(self.print_block(&**blk));
+            }
             ast::ExprForLoop(ref pat, ref iter, ref blk, opt_ident) => {
                 for ident in opt_ident.iter() {
                     try!(self.print_ident(*ident));

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -737,6 +737,11 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             visitor.visit_block(&**if_block);
             walk_expr_opt(visitor, optional_else);
         }
+        ExprWhileLet(ref pattern, ref subexpression, ref block, _) => {
+            visitor.visit_pat(&**pattern);
+            visitor.visit_expr(&**subexpression);
+            visitor.visit_block(&**block);
+        }
         ExprForLoop(ref pattern, ref subexpression, ref block, _) => {
             visitor.visit_pat(&**pattern);
             visitor.visit_expr(&**subexpression);

--- a/src/test/compile-fail/lint-unnecessary-parens.rs
+++ b/src/test/compile-fail/lint-unnecessary-parens.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![deny(unnecessary_parens)]
-#![feature(if_let)]
+#![feature(if_let,while_let)]
 
 #[deriving(Eq, PartialEq)]
 struct X { y: bool }
@@ -34,6 +34,7 @@ fn main() {
         _ => {}
     }
     if let 1i = (1i) {} //~ ERROR unnecessary parentheses around `if let` head expression
+    while let 1i = (2i) {} //~ ERROR unnecessary parentheses around `while let` head expression
     let v = X { y: false };
     // struct lits needs parens, so these shouldn't warn.
     if (v == X { y: true }) {}

--- a/src/test/compile-fail/while-let.rs
+++ b/src/test/compile-fail/while-let.rs
@@ -1,0 +1,37 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(macro_rules,while_let)]
+
+fn macros() {
+    macro_rules! foo{
+        ($p:pat, $e:expr, $b:block) => {{
+            while let $p = $e $b
+        }}
+    }
+    macro_rules! bar{
+        ($p:pat, $e:expr, $b:block) => {{
+            foo!($p, $e, $b)
+        }}
+    }
+
+    foo!(a, 1i, { //~ ERROR irrefutable while-let
+        println!("irrefutable pattern");
+    });
+    bar!(a, 1i, { //~ ERROR irrefutable while-let
+        println!("irrefutable pattern");
+    });
+}
+
+pub fn main() {
+    while let a = 1i { //~ ERROR irrefutable while-let
+        println!("irrefutable pattern");
+    }
+}

--- a/src/test/run-pass/while-let.rs
+++ b/src/test/run-pass/while-let.rs
@@ -1,0 +1,56 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(while_let)]
+
+use std::collections::PriorityQueue;
+
+fn make_pq() -> PriorityQueue<int> {
+    PriorityQueue::from_vec(vec![1i,2,3])
+}
+
+pub fn main() {
+    let mut pq = make_pq();
+    let mut sum = 0i;
+    while let Some(x) = pq.pop() {
+        sum += x;
+    }
+    assert_eq!(sum, 6i);
+
+    pq = make_pq();
+    sum = 0;
+    'a: while let Some(x) = pq.pop() {
+        sum += x;
+        if x == 2 {
+            break 'a;
+        }
+    }
+    assert_eq!(sum, 5i);
+
+    pq = make_pq();
+    sum = 0;
+    'a: while let Some(x) = pq.pop() {
+        if x == 3 {
+            continue 'a;
+        }
+        sum += x;
+    }
+    assert_eq!(sum, 3i);
+
+    let mut pq1 = make_pq();
+    sum = 0;
+    while let Some(x) = pq1.pop() {
+        let mut pq2 = make_pq();
+        while let Some(y) = pq2.pop() {
+            sum += x * y;
+        }
+    }
+    assert_eq!(sum, 6i + 12 + 18);
+}


### PR DESCRIPTION
The use of "without copying" in the std::mem docs was a source of confusion to those less familiar with Rust, as it could refer to either semantic copying or byte copying. This clarifies which meaning was intended.
