### PR TITLE
Make bors check `compiletest` builds from both stage0 and stage1 rustc

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -199,13 +199,28 @@ check-docs: cleantestlibs cleantmptestlogs check-stage2-docs
 
 # Some less critical tests that are not prone to breakage.
 # Not run as part of the normal test suite, but tested by bors on checkin.
-check-secondary: check-lexer check-pretty
+check-secondary: check-build-compiletest check-lexer check-pretty
 
 # check + check-secondary.
-check-all: check check-secondary
+#
+# Issue #17883: build check-secondary first so hidden dependencies in
+# e.g. building compiletest are exercised (resolve those by adding
+# deps to rules that need them; not by putting `check` first here).
+check-all: check-secondary check
 
 # Pretty-printing tests.
 check-pretty: check-stage2-T-$(CFG_BUILD)-H-$(CFG_BUILD)-pretty-exec
+
+define DEF_CHECK_BUILD_COMPILETEST_FOR_STAGE
+check-stage$(1)-build-compiletest: 	$$(HBIN$(1)_H_$(CFG_BUILD))/compiletest$$(X_$(CFG_BUILD))
+endef
+
+$(foreach stage,$(STAGES), \
+ $(eval $(call DEF_CHECK_BUILD_COMPILETEST_FOR_STAGE,$(stage))))
+
+check-build-compiletest: \
+	check-stage1-build-compiletest \
+	check-stage2-build-compiletest
 
 .PHONY: cleantmptestlogs cleantestlibs
 
@@ -720,6 +735,13 @@ PRETTY_DEPS_pretty-rpass-full = $(RPASS_FULL_TESTS)
 PRETTY_DEPS_pretty-rfail = $(RFAIL_TESTS)
 PRETTY_DEPS_pretty-bench = $(BENCH_TESTS)
 PRETTY_DEPS_pretty-pretty = $(PRETTY_TESTS)
+# The stage- and host-specific dependencies are for e.g. macro_crate_test which pulls in
+# external crates.
+PRETTY_DEPS$(1)_H_$(3)_pretty-rpass =
+PRETTY_DEPS$(1)_H_$(3)_pretty-rpass-full = $$(HLIB$(1)_H_$(3))/stamp.syntax $$(HLIB$(1)_H_$(3))/stamp.rustc
+PRETTY_DEPS$(1)_H_$(3)_pretty-rfail =
+PRETTY_DEPS$(1)_H_$(3)_pretty-bench =
+PRETTY_DEPS$(1)_H_$(3)_pretty-pretty =
 PRETTY_DIRNAME_pretty-rpass = run-pass
 PRETTY_DIRNAME_pretty-rpass-full = run-pass-fulldeps
 PRETTY_DIRNAME_pretty-rfail = run-fail
@@ -738,7 +760,8 @@ check-stage$(1)-T-$(2)-H-$(3)-$(4)-exec: $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4
 
 $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4)): \
 	        $$(TEST_SREQ$(1)_T_$(2)_H_$(3)) \
-	        $$(PRETTY_DEPS_$(4))
+	        $$(PRETTY_DEPS_$(4)) \
+	        $$(PRETTY_DEPS$(1)_H_$(3)_$(4))
 	@$$(call E, run pretty-rpass [$(2)]: $$<)
 	$$(Q)$$(call CFG_RUN_CTEST_$(2),$(1),$$<,$(3)) \
 		$$(PRETTY_ARGS$(1)-T-$(2)-H-$(3)-$(4)) \


### PR DESCRIPTION
Make bors check `compiletest` builds from both stage0 and stage1 rustc

---

To reproduce issue on commit ba246100ca3b0c3bd0d68548677d75e6790c4f60
it does not suffice to add just `check-build-compiletest` to
`check-secondary`; one must also ensure that `check-build-compiletest`
precedes the satisification of the `check` rule.

Otherwise hidden dependencies of `compiletest` would end up getting
satisfied when make builds `rustc` at each stage in order to
eventually run `check-stage2`.

So to handle that I moved `check-secondary` before `check` in the
`check-all` rule that bors uses, and for good measure, I also put
`check-build-compiltest` at the front of the `check-secondary` rule's
dependencies.

My understanding is that running `check-secondary` should be
relatively cheap, and thus such a reordering will not hurt bors.

---

Fix #17883.
