### PR TITLE
Fix issue #17999 (Unused variables inside `for` are not detected)

### DIFF
--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1464,6 +1464,8 @@ fn check_expr(this: &mut Liveness, expr: &Expr) {
         this.pat_bindings(&**pat, |this, ln, var, sp, id| {
             this.warn_about_unused(sp, id, ln, var);
         });
+
+        visit::walk_expr(this, expr);
       }
 
       // no correctness conditions related to liveness

--- a/src/test/compile-fail/issue-17999.rs
+++ b/src/test/compile-fail/issue-17999.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(unused_variable)]
+
+fn main() {
+    for _ in range(1i, 101) {
+        let x = (); //~ ERROR: unused variable: `x`
+        match () {
+            a => {} //~ ERROR: unused variable: `a`
+        }
+    }
+}


### PR DESCRIPTION
Fix issue #17999 (Unused variables inside `for` are not detected)
