### PR TITLE
Avoid false ambiguity in multidispatch trait resolution

### DIFF
--- a/src/test/compile-fail/type-params-in-different-spaces-2.rs
+++ b/src/test/compile-fail/type-params-in-different-spaces-2.rs
@@ -8,28 +8,25 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Test static calls to make sure that we align the Self and input
+// type parameters on a trait correctly.
+
 trait Tr<T> {
     fn op(T) -> Self;
 }
 
-// these compile as if Self: Tr<U>, even tho only Self: Tr<Self or T>
 trait A:    Tr<Self> {
     fn test<U>(u: U) -> Self {
         Tr::op(u)   //~ ERROR not implemented
     }
 }
+
 trait B<T>: Tr<T> {
     fn test<U>(u: U) -> Self {
         Tr::op(u)   //~ ERROR not implemented
     }
 }
 
-impl<T> Tr<T> for T {
-    fn op(t: T) -> T { t }
-}
-impl<T> A for T {}
-
 fn main() {
-    std::io::println(A::test((&7306634593706211700, 8)));
 }
 

--- a/src/test/run-pass/multidispatch-infer-from-single-impl.rs
+++ b/src/test/run-pass/multidispatch-infer-from-single-impl.rs
@@ -1,0 +1,32 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that we correctly infer that `E` must be `()` here.  This is
+// known because there is just one impl that could apply where
+// `Self=()`.
+
+pub trait FromError<E> {
+    fn from_error(err: E) -> Self;
+}
+
+impl<E> FromError<E> for E {
+    fn from_error(err: E) -> E {
+        err
+    }
+}
+
+fn test() -> Result<(), ()> {
+    Err(FromError::from_error(()))
+}
+
+fn main() {
+    let result = (|| Err(FromError::from_error(())))();
+    let foo: () = result.unwrap_or(());
+}


### PR DESCRIPTION
Only consider impliciy unboxed closure impl if the obligation is actually for `Fn`, `FnMut`, or `FnOnce`.

Fixes #18019

r? @pcwalton 
