### PR TITLE
Fix var name in doc for ops.rs

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -687,7 +687,7 @@ pub trait IndexMut<Index, Result> {
  * ```ignore
  * struct Foo;
  *
- * impl ::core::ops::Slice<Foo, Foo> for Foo {
+ * impl Slice<Foo, Foo> for Foo {
  *     fn as_slice_<'a>(&'a self) -> &'a Foo {
  *         println!("Slicing!");
  *         self
@@ -736,7 +736,7 @@ pub trait Slice<Idx, Sized? Result> for Sized? {
  * ```ignore
  * struct Foo;
  *
- * impl ::core::ops::SliceMut<Foo, Foo> for Foo {
+ * impl SliceMut<Foo, Foo> for Foo {
  *     fn as_mut_slice_<'a>(&'a mut self) -> &'a mut Foo {
  *         println!("Slicing!");
  *         self

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -626,7 +626,7 @@ shr_impl!(uint u8 u16 u32 u64 int i8 i16 i32 i64)
  * struct Foo;
  *
  * impl Index<Foo, Foo> for Foo {
- *     fn index<'a>(&'a self, _rhs: &Foo) -> &'a Foo {
+ *     fn index<'a>(&'a self, _index: &Foo) -> &'a Foo {
  *         println!("Indexing!");
  *         self
  *     }
@@ -657,7 +657,7 @@ pub trait Index<Index, Result> {
  * struct Foo;
  *
  * impl IndexMut<Foo, Foo> for Foo {
- *     fn index_mut<'a>(&'a mut self, _rhs: &Foo) -> &'a mut Foo {
+ *     fn index_mut<'a>(&'a mut self, _index: &Foo) -> &'a mut Foo {
  *         println!("Indexing!");
  *         self
  *     }
@@ -901,4 +901,3 @@ def_fn_mut!(A0 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12)
 def_fn_mut!(A0 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13)
 def_fn_mut!(A0 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13 A14)
 def_fn_mut!(A0 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13 A14 A15)
-

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -692,15 +692,15 @@ pub trait IndexMut<Index, Result> {
  *         println!("Slicing!");
  *         self
  *     }
- *     fn slice_from_or_fail<'a>(&'a self, from: &Foo) -> &'a Foo {
+ *     fn slice_from_or_fail<'a>(&'a self, _from: &Foo) -> &'a Foo {
  *         println!("Slicing!");
  *         self
  *     }
- *     fn slice_to_or_fail<'a>(&'a self, to: &Foo) -> &'a Foo {
+ *     fn slice_to_or_fail<'a>(&'a self, _to: &Foo) -> &'a Foo {
  *         println!("Slicing!");
  *         self
  *     }
- *     fn slice_or_fail<'a>(&'a self, from: &Foo, to: &Foo) -> &'a Foo {
+ *     fn slice_or_fail<'a>(&'a self, _from: &Foo, _to: &Foo) -> &'a Foo {
  *         println!("Slicing!");
  *         self
  *     }
@@ -741,15 +741,15 @@ pub trait Slice<Idx, Sized? Result> for Sized? {
  *         println!("Slicing!");
  *         self
  *     }
- *     fn slice_from_or_fail_mut<'a>(&'a mut self, from: &Foo) -> &'a mut Foo {
+ *     fn slice_from_or_fail_mut<'a>(&'a mut self, _from: &Foo) -> &'a mut Foo {
  *         println!("Slicing!");
  *         self
  *     }
- *     fn slice_to_or_fail_mut<'a>(&'a mut self, to: &Foo) -> &'a mut Foo {
+ *     fn slice_to_or_fail_mut<'a>(&'a mut self, _to: &Foo) -> &'a mut Foo {
  *         println!("Slicing!");
  *         self
  *     }
- *     fn slice_or_fail_mut<'a>(&'a mut self, from: &Foo, to: &Foo) -> &'a mut Foo {
+ *     fn slice_or_fail_mut<'a>(&'a mut self, _from: &Foo, _to: &Foo) -> &'a mut Foo {
  *         println!("Slicing!");
  *         self
  *     }


### PR DESCRIPTION
Make the doc more consistent & runnable.
- Use `_index` instead of `_rhs` when appropriate.
- Use `_from` and `_to` to avoid warning.
- Remove unnecessary `::core::ops`
