### PR TITLE
rustc: implement lint conventions (RFC 344)

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -704,7 +704,7 @@ pub fn collect_crate_types(session: &Session,
                 }
                 Some(ref n) if n.equiv(&("bin")) => Some(config::CrateTypeExecutable),
                 Some(_) => {
-                    session.add_lint(lint::builtin::UNKNOWN_CRATE_TYPE,
+                    session.add_lint(lint::builtin::UNKNOWN_CRATE_TYPES,
                                      ast::CRATE_NODE_ID,
                                      a.span,
                                      "invalid `crate_type` \
@@ -712,7 +712,7 @@ pub fn collect_crate_types(session: &Session,
                     None
                 }
                 _ => {
-                    session.add_lint(lint::builtin::UNKNOWN_CRATE_TYPE,
+                    session.add_lint(lint::builtin::UNKNOWN_CRATE_TYPES,
                                      ast::CRATE_NODE_ID,
                                      a.span,
                                      "`crate_type` requires a \

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -1623,7 +1623,8 @@ impl LintPass for HardwiredLints {
             WARNINGS,
             UNKNOWN_FEATURES,
             UNKNOWN_CRATE_TYPES,
-            VARIANT_SIZE_DIFFERENCES
+            VARIANT_SIZE_DIFFERENCES,
+            FAT_PTR_TRANSMUTES
         )
     }
 }

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -81,14 +81,14 @@ impl LintPass for WhileTrue {
     }
 }
 
-declare_lint!(UNNECESSARY_TYPECAST, Allow,
+declare_lint!(UNUSED_TYPECASTS, Allow,
               "detects unnecessary type casts, that can be removed")
 
 pub struct UnusedCasts;
 
 impl LintPass for UnusedCasts {
     fn get_lints(&self) -> LintArray {
-        lint_array!(UNNECESSARY_TYPECAST)
+        lint_array!(UNUSED_TYPECASTS)
     }
 
     fn check_expr(&mut self, cx: &Context, e: &ast::Expr) {
@@ -96,7 +96,7 @@ impl LintPass for UnusedCasts {
             ast::ExprCast(ref expr, ref ty) => {
                 let t_t = ast_ty_to_ty(cx, &infer::new_infer_ctxt(cx.tcx), &**ty);
                 if ty::get(ty::expr_ty(cx.tcx, &**expr)).sty == ty::get(t_t).sty {
-                    cx.span_lint(UNNECESSARY_TYPECAST, ty.span, "unnecessary type cast");
+                    cx.span_lint(UNUSED_TYPECASTS, ty.span, "unnecessary type cast");
                 }
             }
             _ => ()
@@ -104,13 +104,13 @@ impl LintPass for UnusedCasts {
     }
 }
 
-declare_lint!(UNSIGNED_NEGATE, Warn,
+declare_lint!(UNSIGNED_NEGATION, Warn,
               "using an unary minus operator on unsigned type")
 
-declare_lint!(TYPE_LIMITS, Warn,
+declare_lint!(UNUSED_COMPARISONS, Warn,
               "comparisons made useless by limits of the types involved")
 
-declare_lint!(TYPE_OVERFLOW, Warn,
+declare_lint!(OVERFLOWING_LITERALS, Warn,
               "literal out of range for its type")
 
 pub struct TypeLimits {
@@ -128,7 +128,7 @@ impl TypeLimits {
 
 impl LintPass for TypeLimits {
     fn get_lints(&self) -> LintArray {
-        lint_array!(UNSIGNED_NEGATE, TYPE_LIMITS, TYPE_OVERFLOW)
+        lint_array!(UNSIGNED_NEGATION, UNUSED_COMPARISONS, OVERFLOWING_LITERALS)
     }
 
     fn check_expr(&mut self, cx: &Context, e: &ast::Expr) {
@@ -138,7 +138,7 @@ impl LintPass for TypeLimits {
                     ast::ExprLit(ref lit) => {
                         match lit.node {
                             ast::LitInt(_, ast::UnsignedIntLit(_)) => {
-                                cx.span_lint(UNSIGNED_NEGATE, e.span,
+                                cx.span_lint(UNSIGNED_NEGATION, e.span,
                                              "negation of unsigned int literal may \
                                              be unintentional");
                             },
@@ -149,7 +149,7 @@ impl LintPass for TypeLimits {
                         let t = ty::expr_ty(cx.tcx, &**expr);
                         match ty::get(t).sty {
                             ty::ty_uint(_) => {
-                                cx.span_lint(UNSIGNED_NEGATE, e.span,
+                                cx.span_lint(UNSIGNED_NEGATION, e.span,
                                              "negation of unsigned int variable may \
                                              be unintentional");
                             },
@@ -167,7 +167,7 @@ impl LintPass for TypeLimits {
             },
             ast::ExprBinary(binop, ref l, ref r) => {
                 if is_comparison(binop) && !check_limits(cx.tcx, binop, &**l, &**r) {
-                    cx.span_lint(TYPE_LIMITS, e.span,
+                    cx.span_lint(UNUSED_COMPARISONS, e.span,
                                  "comparison is useless due to type limits");
                 }
             },
@@ -185,7 +185,7 @@ impl LintPass for TypeLimits {
 
                                 if (negative && v > (min.abs() as u64)) ||
                                    (!negative && v > (max.abs() as u64)) {
-                                    cx.span_lint(TYPE_OVERFLOW, e.span,
+                                    cx.span_lint(OVERFLOWING_LITERALS, e.span,
                                                  "literal out of range for its type");
                                     return;
                                 }
@@ -204,7 +204,7 @@ impl LintPass for TypeLimits {
                             _ => fail!()
                         };
                         if  lit_val < min || lit_val > max {
-                            cx.span_lint(TYPE_OVERFLOW, e.span,
+                            cx.span_lint(OVERFLOWING_LITERALS, e.span,
                                          "literal out of range for its type");
                         }
                     },
@@ -219,7 +219,7 @@ impl LintPass for TypeLimits {
                             _ => fail!()
                         };
                         if lit_val < min || lit_val > max {
-                            cx.span_lint(TYPE_OVERFLOW, e.span,
+                            cx.span_lint(OVERFLOWING_LITERALS, e.span,
                                          "literal out of range for its type");
                         }
                     },
@@ -330,23 +330,23 @@ impl LintPass for TypeLimits {
     }
 }
 
-declare_lint!(CTYPES, Warn,
+declare_lint!(IMPROPER_CTYPES, Warn,
               "proper use of libc types in foreign modules")
 
-struct CTypesVisitor<'a, 'tcx: 'a> {
+struct ImproperCTypesVisitor<'a, 'tcx: 'a> {
     cx: &'a Context<'a, 'tcx>
 }
 
-impl<'a, 'tcx> CTypesVisitor<'a, 'tcx> {
+impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
     fn check_def(&mut self, sp: Span, ty_id: ast::NodeId, path_id: ast::NodeId) {
         match self.cx.tcx.def_map.borrow().get_copy(&path_id) {
             def::DefPrimTy(ast::TyInt(ast::TyI)) => {
-                self.cx.span_lint(CTYPES, sp,
+                self.cx.span_lint(IMPROPER_CTYPES, sp,
                                   "found rust type `int` in foreign module, while \
                                    libc::c_int or libc::c_long should be used");
             }
             def::DefPrimTy(ast::TyUint(ast::TyU)) => {
-                self.cx.span_lint(CTYPES, sp,
+                self.cx.span_lint(IMPROPER_CTYPES, sp,
                                   "found rust type `uint` in foreign module, while \
                                    libc::c_uint or libc::c_ulong should be used");
             }
@@ -357,7 +357,7 @@ impl<'a, 'tcx> CTypesVisitor<'a, 'tcx> {
                 };
 
                 if !ty::is_ffi_safe(self.cx.tcx, tty) {
-                    self.cx.span_lint(CTYPES, sp,
+                    self.cx.span_lint(IMPROPER_CTYPES, sp,
                                       "found type without foreign-function-safe
                                       representation annotation in foreign module, consider \
                                       adding a #[repr(...)] attribute to the type");
@@ -368,7 +368,7 @@ impl<'a, 'tcx> CTypesVisitor<'a, 'tcx> {
     }
 }
 
-impl<'a, 'tcx, 'v> Visitor<'v> for CTypesVisitor<'a, 'tcx> {
+impl<'a, 'tcx, 'v> Visitor<'v> for ImproperCTypesVisitor<'a, 'tcx> {
     fn visit_ty(&mut self, ty: &ast::Ty) {
         match ty.node {
             ast::TyPath(_, _, id) => self.check_def(ty.span, ty.id, id),
@@ -378,16 +378,16 @@ impl<'a, 'tcx, 'v> Visitor<'v> for CTypesVisitor<'a, 'tcx> {
     }
 }
 
-pub struct CTypes;
+pub struct ImproperCTypes;
 
-impl LintPass for CTypes {
+impl LintPass for ImproperCTypes {
     fn get_lints(&self) -> LintArray {
-        lint_array!(CTYPES)
+        lint_array!(IMPROPER_CTYPES)
     }
 
     fn check_item(&mut self, cx: &Context, it: &ast::Item) {
         fn check_ty(cx: &Context, ty: &ast::Ty) {
-            let mut vis = CTypesVisitor { cx: cx };
+            let mut vis = ImproperCTypesVisitor { cx: cx };
             vis.visit_ty(ty);
         }
 
@@ -412,12 +412,12 @@ impl LintPass for CTypes {
     }
 }
 
-declare_lint!(OWNED_HEAP_MEMORY, Allow,
+declare_lint!(BOX_POINTERS, Allow,
               "use of owned (Box type) heap memory")
 
-pub struct HeapMemory;
+pub struct BoxPointers;
 
-impl HeapMemory {
+impl BoxPointers {
     fn check_heap_type(&self, cx: &Context, span: Span, ty: ty::t) {
         let mut n_uniq = 0i;
         ty::fold_ty(cx.tcx, ty, |t| {
@@ -438,14 +438,14 @@ impl HeapMemory {
         if n_uniq > 0 {
             let s = ty_to_string(cx.tcx, ty);
             let m = format!("type uses owned (Box type) pointers: {}", s);
-            cx.span_lint(OWNED_HEAP_MEMORY, span, m.as_slice());
+            cx.span_lint(BOX_POINTERS, span, m.as_slice());
         }
     }
 }
 
-impl LintPass for HeapMemory {
+impl LintPass for BoxPointers {
     fn get_lints(&self) -> LintArray {
-        lint_array!(OWNED_HEAP_MEMORY)
+        lint_array!(BOX_POINTERS)
     }
 
     fn check_item(&mut self, cx: &Context, it: &ast::Item) {
@@ -545,14 +545,14 @@ impl LintPass for RawPointerDeriving {
     }
 }
 
-declare_lint!(UNUSED_ATTRIBUTE, Warn,
+declare_lint!(UNUSED_ATTRIBUTES, Warn,
               "detects attributes that were not used by the compiler")
 
-pub struct UnusedAttribute;
+pub struct UnusedAttributes;
 
-impl LintPass for UnusedAttribute {
+impl LintPass for UnusedAttributes {
     fn get_lints(&self) -> LintArray {
-        lint_array!(UNUSED_ATTRIBUTE)
+        lint_array!(UNUSED_ATTRIBUTES)
     }
 
     fn check_attribute(&mut self, cx: &Context, attr: &ast::Attribute) {
@@ -618,7 +618,7 @@ impl LintPass for UnusedAttribute {
         }
 
         if !attr::is_used(attr) {
-            cx.span_lint(UNUSED_ATTRIBUTE, attr.span, "unused attribute");
+            cx.span_lint(UNUSED_ATTRIBUTES, attr.span, "unused attribute");
             if CRATE_ATTRS.contains(&attr.name().get()) {
                 let msg = match attr.node.style {
                     ast::AttrOuter => "crate-level attribute should be an inner \
@@ -626,27 +626,27 @@ impl LintPass for UnusedAttribute {
                     ast::AttrInner => "crate-level attribute should be in the \
                                        root module",
                 };
-                cx.span_lint(UNUSED_ATTRIBUTE, attr.span, msg);
+                cx.span_lint(UNUSED_ATTRIBUTES, attr.span, msg);
             }
         }
     }
 }
 
-declare_lint!(pub PATH_STATEMENT, Warn,
+declare_lint!(pub PATH_STATEMENTS, Warn,
               "path statements with no effect")
 
-pub struct PathStatement;
+pub struct PathStatements;
 
-impl LintPass for PathStatement {
+impl LintPass for PathStatements {
     fn get_lints(&self) -> LintArray {
-        lint_array!(PATH_STATEMENT)
+        lint_array!(PATH_STATEMENTS)
     }
 
     fn check_stmt(&mut self, cx: &Context, s: &ast::Stmt) {
         match s.node {
             ast::StmtSemi(ref expr, _) => {
                 match expr.node {
-                    ast::ExprPath(_) => cx.span_lint(PATH_STATEMENT, s.span,
+                    ast::ExprPath(_) => cx.span_lint(PATH_STATEMENTS, s.span,
                                                      "path statement with no effect"),
                     _ => ()
                 }
@@ -659,14 +659,14 @@ impl LintPass for PathStatement {
 declare_lint!(pub UNUSED_MUST_USE, Warn,
               "unused result of a type flagged as #[must_use]")
 
-declare_lint!(pub UNUSED_RESULT, Allow,
+declare_lint!(pub UNUSED_RESULTS, Allow,
               "unused result of an expression in a statement")
 
-pub struct UnusedResult;
+pub struct UnusedResults;
 
-impl LintPass for UnusedResult {
+impl LintPass for UnusedResults {
     fn get_lints(&self) -> LintArray {
-        lint_array!(UNUSED_MUST_USE, UNUSED_RESULT)
+        lint_array!(UNUSED_MUST_USE, UNUSED_RESULTS)
     }
 
     fn check_stmt(&mut self, cx: &Context, s: &ast::Stmt) {
@@ -702,7 +702,7 @@ impl LintPass for UnusedResult {
             _ => {}
         }
         if !warned {
-            cx.span_lint(UNUSED_RESULT, s.span, "unused result");
+            cx.span_lint(UNUSED_RESULTS, s.span, "unused result");
         }
 
         fn check_must_use(cx: &Context, attrs: &[ast::Attribute], sp: Span) -> bool {
@@ -966,14 +966,14 @@ impl LintPass for NonSnakeCase {
     }
 }
 
-declare_lint!(pub NON_UPPERCASE_STATICS, Warn,
+declare_lint!(pub NON_UPPER_CASE_GLOBALS, Warn,
               "static constants should have uppercase identifiers")
 
-pub struct NonUppercaseStatics;
+pub struct NonUpperCaseGlobals;
 
-impl LintPass for NonUppercaseStatics {
+impl LintPass for NonUpperCaseGlobals {
     fn get_lints(&self) -> LintArray {
-        lint_array!(NON_UPPERCASE_STATICS)
+        lint_array!(NON_UPPER_CASE_GLOBALS)
     }
 
     fn check_item(&mut self, cx: &Context, it: &ast::Item) {
@@ -986,7 +986,7 @@ impl LintPass for NonUppercaseStatics {
                 // ones (some scripts don't have a concept of
                 // upper/lowercase)
                 if s.get().chars().any(|c| c.is_lowercase()) {
-                    cx.span_lint(NON_UPPERCASE_STATICS, it.span,
+                    cx.span_lint(NON_UPPER_CASE_GLOBALS, it.span,
                         format!("static constant `{}` should have an uppercase name \
                                  such as `{}`",
                                 s.get(), s.get().chars().map(|c| c.to_uppercase())
@@ -1003,7 +1003,7 @@ impl LintPass for NonUppercaseStatics {
             (&ast::PatIdent(_, ref path1, _), Some(&def::DefConst(..))) => {
                 let s = token::get_ident(path1.node);
                 if s.get().chars().any(|c| c.is_lowercase()) {
-                    cx.span_lint(NON_UPPERCASE_STATICS, path1.span,
+                    cx.span_lint(NON_UPPER_CASE_GLOBALS, path1.span,
                         format!("static constant in pattern `{}` should have an uppercase \
                                  name such as `{}`",
                                 s.get(), s.get().chars().map(|c| c.to_uppercase())
@@ -1015,19 +1015,19 @@ impl LintPass for NonUppercaseStatics {
     }
 }
 
-declare_lint!(UNNECESSARY_PARENS, Warn,
+declare_lint!(UNUSED_PARENS, Warn,
               "`if`, `match`, `while` and `return` do not need parentheses")
 
-pub struct UnnecessaryParens;
+pub struct UnusedParens;
 
-impl UnnecessaryParens {
+impl UnusedParens {
     fn check_unnecessary_parens_core(&self, cx: &Context, value: &ast::Expr, msg: &str,
                                      struct_lit_needs_parens: bool) {
         match value.node {
             ast::ExprParen(ref inner) => {
                 let necessary = struct_lit_needs_parens && contains_exterior_struct_lit(&**inner);
                 if !necessary {
-                    cx.span_lint(UNNECESSARY_PARENS, value.span,
+                    cx.span_lint(UNUSED_PARENS, value.span,
                                  format!("unnecessary parentheses around {}",
                                          msg).as_slice())
                 }
@@ -1071,9 +1071,9 @@ impl UnnecessaryParens {
     }
 }
 
-impl LintPass for UnnecessaryParens {
+impl LintPass for UnusedParens {
     fn get_lints(&self) -> LintArray {
-        lint_array!(UNNECESSARY_PARENS)
+        lint_array!(UNUSED_PARENS)
     }
 
     fn check_expr(&mut self, cx: &Context, e: &ast::Expr) {
@@ -1108,14 +1108,14 @@ impl LintPass for UnnecessaryParens {
     }
 }
 
-declare_lint!(UNNECESSARY_IMPORT_BRACES, Allow,
+declare_lint!(UNUSED_IMPORT_BRACES, Allow,
               "unnecessary braces around an imported item")
 
-pub struct UnnecessaryImportBraces;
+pub struct UnusedImportBraces;
 
-impl LintPass for UnnecessaryImportBraces {
+impl LintPass for UnusedImportBraces {
     fn get_lints(&self) -> LintArray {
-        lint_array!(UNNECESSARY_IMPORT_BRACES)
+        lint_array!(UNUSED_IMPORT_BRACES)
     }
 
     fn check_view_item(&mut self, cx: &Context, view_item: &ast::ViewItem) {
@@ -1128,7 +1128,7 @@ impl LintPass for UnnecessaryImportBraces {
                                 ast::PathListIdent {ref name, ..} => {
                                     let m = format!("braces around {} is unnecessary",
                                                     token::get_ident(*name).get());
-                                    cx.span_lint(UNNECESSARY_IMPORT_BRACES, view_item.span,
+                                    cx.span_lint(UNUSED_IMPORT_BRACES, view_item.span,
                                                  m.as_slice());
                                 },
                                 _ => ()
@@ -1167,21 +1167,21 @@ impl LintPass for UnusedUnsafe {
     }
 }
 
-declare_lint!(UNSAFE_BLOCK, Allow,
+declare_lint!(UNSAFE_BLOCKS, Allow,
               "usage of an `unsafe` block")
 
-pub struct UnsafeBlock;
+pub struct UnsafeBlocks;
 
-impl LintPass for UnsafeBlock {
+impl LintPass for UnsafeBlocks {
     fn get_lints(&self) -> LintArray {
-        lint_array!(UNSAFE_BLOCK)
+        lint_array!(UNSAFE_BLOCKS)
     }
 
     fn check_expr(&mut self, cx: &Context, e: &ast::Expr) {
         match e.node {
             // Don't warn about generated blocks, that'll just pollute the output.
             ast::ExprBlock(ref blk) if blk.rules == ast::UnsafeBlock(ast::UserProvided) => {
-                cx.span_lint(UNSAFE_BLOCK, blk.span, "usage of an `unsafe` block");
+                cx.span_lint(UNSAFE_BLOCKS, blk.span, "usage of an `unsafe` block");
             }
             _ => ()
         }
@@ -1266,14 +1266,14 @@ impl LintPass for UnusedMut {
     }
 }
 
-declare_lint!(UNNECESSARY_ALLOCATION, Warn,
+declare_lint!(UNUSED_ALLOCATION, Warn,
               "detects unnecessary allocations that can be eliminated")
 
-pub struct UnnecessaryAllocation;
+pub struct UnusedAllocation;
 
-impl LintPass for UnnecessaryAllocation {
+impl LintPass for UnusedAllocation {
     fn get_lints(&self) -> LintArray {
-        lint_array!(UNNECESSARY_ALLOCATION)
+        lint_array!(UNUSED_ALLOCATION)
     }
 
     fn check_expr(&mut self, cx: &Context, e: &ast::Expr) {
@@ -1288,11 +1288,11 @@ impl LintPass for UnnecessaryAllocation {
                     ty::AdjustDerefRef(ty::AutoDerefRef { ref autoref, .. }) => {
                         match autoref {
                             &Some(ty::AutoPtr(_, ast::MutImmutable, None)) => {
-                                cx.span_lint(UNNECESSARY_ALLOCATION, e.span,
+                                cx.span_lint(UNUSED_ALLOCATION, e.span,
                                              "unnecessary allocation, use & instead");
                             }
                             &Some(ty::AutoPtr(_, ast::MutMutable, None)) => {
-                                cx.span_lint(UNNECESSARY_ALLOCATION, e.span,
+                                cx.span_lint(UNUSED_ALLOCATION, e.span,
                                              "unnecessary allocation, use &mut instead");
                             }
                             _ => ()
@@ -1306,7 +1306,7 @@ impl LintPass for UnnecessaryAllocation {
     }
 }
 
-declare_lint!(MISSING_DOC, Allow,
+declare_lint!(MISSING_DOCS, Allow,
               "detects missing documentation for public members")
 
 pub struct MissingDoc {
@@ -1358,7 +1358,7 @@ impl MissingDoc {
             }
         });
         if !has_doc {
-            cx.span_lint(MISSING_DOC, sp,
+            cx.span_lint(MISSING_DOCS, sp,
                 format!("missing documentation for {}", desc).as_slice());
         }
     }
@@ -1366,7 +1366,7 @@ impl MissingDoc {
 
 impl LintPass for MissingDoc {
     fn get_lints(&self) -> LintArray {
-        lint_array!(MISSING_DOC)
+        lint_array!(MISSING_DOCS)
     }
 
     fn enter_lint_attrs(&mut self, _: &Context, attrs: &[ast::Attribute]) {
@@ -1569,19 +1569,19 @@ impl LintPass for Stability {
 declare_lint!(pub UNUSED_IMPORTS, Warn,
               "imports that are never used")
 
-declare_lint!(pub UNUSED_EXTERN_CRATE, Allow,
+declare_lint!(pub UNUSED_EXTERN_CRATES, Allow,
               "extern crates that are never used")
 
-declare_lint!(pub UNNECESSARY_QUALIFICATION, Allow,
+declare_lint!(pub UNUSED_QUALIFICATIONS, Allow,
               "detects unnecessarily qualified names")
 
-declare_lint!(pub UNRECOGNIZED_LINT, Warn,
+declare_lint!(pub UNKNOWN_LINTS, Warn,
               "unrecognized lint attribute")
 
-declare_lint!(pub UNUSED_VARIABLE, Warn,
+declare_lint!(pub UNUSED_VARIABLES, Warn,
               "detect variables which are not used in any way")
 
-declare_lint!(pub DEAD_ASSIGNMENT, Warn,
+declare_lint!(pub UNUSED_ASSIGNMENTS, Warn,
               "detect assignments that will never be read")
 
 declare_lint!(pub DEAD_CODE, Warn,
@@ -1596,13 +1596,13 @@ declare_lint!(pub WARNINGS, Warn,
 declare_lint!(pub UNKNOWN_FEATURES, Deny,
               "unknown features found in crate-level #[feature] directives")
 
-declare_lint!(pub UNKNOWN_CRATE_TYPE, Deny,
+declare_lint!(pub UNKNOWN_CRATE_TYPES, Deny,
               "unknown crate type found in #[crate_type] directive")
 
-declare_lint!(pub VARIANT_SIZE_DIFFERENCE, Allow,
+declare_lint!(pub VARIANT_SIZE_DIFFERENCES, Allow,
               "detects enums with widely varying variant sizes")
 
-declare_lint!(pub TRANSMUTE_FAT_PTR, Allow,
+declare_lint!(pub FAT_PTR_TRANSMUTES, Allow,
               "detects transmutes of fat pointers")
 
 /// Does nothing as a lint pass, but registers some `Lint`s
@@ -1613,17 +1613,17 @@ impl LintPass for HardwiredLints {
     fn get_lints(&self) -> LintArray {
         lint_array!(
             UNUSED_IMPORTS,
-            UNUSED_EXTERN_CRATE,
-            UNNECESSARY_QUALIFICATION,
-            UNRECOGNIZED_LINT,
-            UNUSED_VARIABLE,
-            DEAD_ASSIGNMENT,
+            UNUSED_EXTERN_CRATES,
+            UNUSED_QUALIFICATIONS,
+            UNKNOWN_LINTS,
+            UNUSED_VARIABLES,
+            UNUSED_ASSIGNMENTS,
             DEAD_CODE,
             UNREACHABLE_CODE,
             WARNINGS,
             UNKNOWN_FEATURES,
-            UNKNOWN_CRATE_TYPE,
-            VARIANT_SIZE_DIFFERENCE
+            UNKNOWN_CRATE_TYPES,
+            VARIANT_SIZE_DIFFERENCES
         )
     }
 }

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -1585,10 +1585,10 @@ declare_lint!(pub UNUSED_ASSIGNMENTS, Warn,
               "detect assignments that will never be read")
 
 declare_lint!(pub DEAD_CODE, Warn,
-              "detect piece of code that will never be used")
+              "detect unused, unexported items")
 
 declare_lint!(pub UNREACHABLE_CODE, Warn,
-              "detects unreachable code")
+              "detects unreachable code paths")
 
 declare_lint!(pub WARNINGS, Warn,
               "mass-change the level for lints which produce warnings")

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -175,20 +175,20 @@ impl LintStore {
                      HardwiredLints,
                      WhileTrue,
                      UnusedCasts,
-                     CTypes,
-                     HeapMemory,
-                     UnusedAttribute,
-                     PathStatement,
-                     UnusedResult,
+                     ImproperCTypes,
+                     BoxPointers,
+                     UnusedAttributes,
+                     PathStatements,
+                     UnusedResults,
                      NonCamelCaseTypes,
                      NonSnakeCase,
-                     NonUppercaseStatics,
-                     UnnecessaryParens,
-                     UnnecessaryImportBraces,
+                     NonUpperCaseGlobals,
+                     UnusedParens,
+                     UnusedImportBraces,
                      UnusedUnsafe,
-                     UnsafeBlock,
+                     UnsafeBlocks,
                      UnusedMut,
-                     UnnecessaryAllocation,
+                     UnusedAllocation,
                      Stability,
         )
 
@@ -199,12 +199,12 @@ impl LintStore {
         )
 
         add_lint_group!(sess, "bad_style",
-                        NON_CAMEL_CASE_TYPES, NON_SNAKE_CASE, NON_UPPERCASE_STATICS)
+                        NON_CAMEL_CASE_TYPES, NON_SNAKE_CASE, NON_UPPER_CASE_GLOBALS)
 
         add_lint_group!(sess, "unused",
-                        UNUSED_IMPORTS, UNUSED_VARIABLE, DEAD_ASSIGNMENT, DEAD_CODE,
-                        UNUSED_MUT, UNREACHABLE_CODE, UNUSED_EXTERN_CRATE, UNUSED_MUST_USE,
-                        UNUSED_UNSAFE, UNUSED_RESULT, PATH_STATEMENT)
+                        UNUSED_IMPORTS, UNUSED_VARIABLES, UNUSED_ASSIGNMENTS, DEAD_CODE,
+                        UNUSED_MUT, UNREACHABLE_CODE, UNUSED_EXTERN_CRATES, UNUSED_MUST_USE,
+                        UNUSED_UNSAFE, UNUSED_RESULTS, PATH_STATEMENTS)
 
         // We have one lint pass defined in this module.
         self.register_pass(sess, false, box GatherNodeLevels as LintPassObject);
@@ -430,7 +430,7 @@ impl<'a, 'tcx> Context<'a, 'tcx> {
                                                            (*lint_id, level, span))
                                                       .collect(),
                                 None => {
-                                    self.span_lint(builtin::UNRECOGNIZED_LINT, span,
+                                    self.span_lint(builtin::UNKNOWN_LINTS, span,
                                                format!("unknown `{}` attribute: `{}`",
                                                        level.as_str(), lint_name).as_slice());
                                     continue;
@@ -713,7 +713,7 @@ impl LintPass for GatherNodeLevels {
     fn check_item(&mut self, cx: &Context, it: &ast::Item) {
         match it.node {
             ast::ItemEnum(..) => {
-                let lint_id = LintId::of(builtin::VARIANT_SIZE_DIFFERENCE);
+                let lint_id = LintId::of(builtin::VARIANT_SIZE_DIFFERENCES);
                 let lvlsrc = cx.lints.get_level_source(lint_id);
                 match lvlsrc {
                     (lvl, _) if lvl != Allow => {

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1629,11 +1629,11 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                 };
 
                 if is_assigned {
-                    self.ir.tcx.sess.add_lint(lint::builtin::UNUSED_VARIABLE, id, sp,
+                    self.ir.tcx.sess.add_lint(lint::builtin::UNUSED_VARIABLES, id, sp,
                         format!("variable `{}` is assigned to, but never used",
                                 *name));
                 } else {
-                    self.ir.tcx.sess.add_lint(lint::builtin::UNUSED_VARIABLE, id, sp,
+                    self.ir.tcx.sess.add_lint(lint::builtin::UNUSED_VARIABLES, id, sp,
                         format!("unused variable: `{}`", *name));
                 }
             }
@@ -1651,7 +1651,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
         if self.live_on_exit(ln, var).is_none() {
             let r = self.should_warn(var);
             for name in r.iter() {
-                self.ir.tcx.sess.add_lint(lint::builtin::DEAD_ASSIGNMENT, id, sp,
+                self.ir.tcx.sess.add_lint(lint::builtin::UNUSED_ASSIGNMENTS, id, sp,
                     format!("value assigned to `{}` is never read", *name));
             }
         }

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -5232,7 +5232,7 @@ impl<'a> Resolver<'a> {
             match (def, unqualified_def) {
                 (Some((ref d, _)), Some((ref ud, _))) if *d == *ud => {
                     self.session
-                        .add_lint(lint::builtin::UNNECESSARY_QUALIFICATION,
+                        .add_lint(lint::builtin::UNUSED_QUALIFICATIONS,
                                   id,
                                   path.span,
                                   "unnecessary qualification".to_string());
@@ -6125,7 +6125,7 @@ impl<'a> Resolver<'a> {
                 match self.session.cstore.find_extern_mod_stmt_cnum(id)
                 {
                     Some(crate_num) => if !self.used_crates.contains(&crate_num) {
-                    self.session.add_lint(lint::builtin::UNUSED_EXTERN_CRATE,
+                    self.session.add_lint(lint::builtin::UNUSED_EXTERN_CRATES,
                                           id,
                                           vi.span,
                                           "unused extern crate".to_string());

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2078,7 +2078,7 @@ fn enum_variant_size_lint(ccx: &CrateContext, enum_def: &ast::EnumDef, sp: Span,
     let mut sizes = Vec::new(); // does no allocation if no pushes, thankfully
 
     let levels = ccx.tcx().node_lint_levels.borrow();
-    let lint_id = lint::LintId::of(lint::builtin::VARIANT_SIZE_DIFFERENCE);
+    let lint_id = lint::LintId::of(lint::builtin::VARIANT_SIZE_DIFFERENCES);
     let lvlsrc = match levels.find(&(id, lint_id)) {
         None | Some(&(lint::Allow, _)) => return,
         Some(&lvlsrc) => lvlsrc,
@@ -2115,7 +2115,7 @@ fn enum_variant_size_lint(ccx: &CrateContext, enum_def: &ast::EnumDef, sp: Span,
     if largest > slargest * 3 && slargest > 0 {
         // Use lint::raw_emit_lint rather than sess.add_lint because the lint-printing
         // pass for the latter already ran.
-        lint::raw_emit_lint(&ccx.tcx().sess, lint::builtin::VARIANT_SIZE_DIFFERENCE,
+        lint::raw_emit_lint(&ccx.tcx().sess, lint::builtin::VARIANT_SIZE_DIFFERENCES,
                             lvlsrc, Some(sp),
                             format!("enum variant is more than three times larger \
                                      ({} bytes) than the next largest (ignoring padding)",

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -122,7 +122,7 @@ pub fn check_intrinsics(ccx: &CrateContext) {
         if ty::type_is_fat_ptr(ccx.tcx(), transmute_restriction.to) ||
            ty::type_is_fat_ptr(ccx.tcx(), transmute_restriction.from) {
             ccx.sess()
-               .add_lint(::lint::builtin::TRANSMUTE_FAT_PTR,
+               .add_lint(::lint::builtin::FAT_PTR_TRANSMUTES,
                          transmute_restriction.id,
                          transmute_restriction.span,
                          format!("Transmuting fat pointer types; {} to {}.\


### PR DESCRIPTION
[RFC 344](https://github.com/rust-lang/rfcs/pull/344) proposes a set of naming conventions for lints. This PR
renames existing lints to follow the conventions.

Use the following sed script to bring your code up to date:

```
s/unnecessary_typecast/unused_typecasts/g
s/unsigned_negate/unsigned_negation/g
s/type_limits/unused_comparisons/g
s/type_overflow/overflowing_literals/g
s/ctypes/improper_ctypes/g
s/owned_heap_memory/box_pointers/g
s/unused_attribute/unused_attributes/g
s/path_statement/path_statements/g
s/unused_must_use/unused_must_use/g
s/unused_result/unused_results/g
s/non_uppercase_statics/non_upper_case_globals/g
s/unnecessary_parens/unused_parens/g
s/unnecessary_import_braces/unused_import_braces/g
s/unused_unsafe/unused_unsafe/g
s/unsafe_block/unsafe_blocks/g
s/unused_mut/unused_mut/g
s/unnecessary_allocation/unused_allocation/g
s/missing_doc/missing_docs/g
s/unused_imports/unused_imports/g
s/unused_extern_crate/unused_extern_crates/g
s/unnecessary_qualification/unused_qualifications/g
s/unrecognized_lint/unknown_lints/g
s/unused_variable/unused_variables/g
s/dead_assignment/unused_assignments/g
s/unknown_crate_type/unknown_crate_types/g
s/variant_size_difference/variant_size_differences/g
s/transmute_fat_ptr/fat_ptr_transmutes/g
```

Since a large number of lints are being renamed for RFC 344, this PR
adds some basic deprecation/renaming functionality to the pluggable lint
system. It allows a simple mapping of old to new names, and can warn
when old names are being used.

This change needs to be rolled out in stages. In this PR, the
deprecation warning is commented out, but the old name is forwarded to
the new one.

Once the PR lands and we have generated a new snapshot of the
compiler, we can add the deprecation warning and rename all uses of the
lints in the rust codebase. I will file a PR to do so.

Closes #16545
Closes #17932

r? @pcwalton 
