### PR TITLE
Removes useless confs from bitv.rs

### DIFF
--- a/src/libcollections/bitv.rs
+++ b/src/libcollections/bitv.rs
@@ -59,8 +59,6 @@
 //! println!("There are {} primes below {}", num_primes, max_prime);
 //! ```
 
-#![allow(missing_doc)]
-
 use core::prelude::*;
 
 use core::cmp;
@@ -1640,7 +1638,6 @@ mod tests {
     use std::prelude::*;
     use std::iter::range_step;
     use std::u32;
-    use std::uint;
     use std::rand;
     use std::rand::Rng;
     use test::Bencher;


### PR DESCRIPTION
I was going to write some doc in order to remove the #[allow(missing_doc)] but there was actually none missing.
I also removed a warning i didn't see in my last commit  #18018
Linked to #18009
