### PR TITLE
 Fix translation of unboxing shim for rust-call ABI methods

### DIFF
--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -44,10 +44,10 @@ pub fn type_of_explicit_arg(ccx: &CrateContext, arg_ty: ty::t) -> Type {
 /// Yields the types of the "real" arguments for this function. For most
 /// functions, these are simply the types of the arguments. For functions with
 /// the `RustCall` ABI, however, this untuples the arguments of the function.
-fn untuple_arguments_if_necessary(ccx: &CrateContext,
-                                  inputs: &[ty::t],
-                                  abi: abi::Abi)
-                                  -> Vec<ty::t> {
+pub fn untuple_arguments_if_necessary(ccx: &CrateContext,
+                                      inputs: &[ty::t],
+                                      abi: abi::Abi)
+                                      -> Vec<ty::t> {
     if abi != abi::RustCall {
         return inputs.iter().map(|x| (*x).clone()).collect()
     }

--- a/src/test/run-pass/issue-16739.rs
+++ b/src/test/run-pass/issue-16739.rs
@@ -1,0 +1,42 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unboxed_closures)]
+
+// Test that unboxing shim for calling rust-call ABI methods through a
+// trait box works and does not cause an ICE
+
+struct Foo { foo: uint }
+
+impl FnOnce<(), uint> for Foo {
+    #[rust_call_abi_hack]
+    fn call_once(self, _: ()) -> uint { self.foo }
+}
+
+impl FnOnce<(uint,), uint> for Foo {
+    #[rust_call_abi_hack]
+    fn call_once(self, (x,): (uint,)) -> uint { self.foo + x }
+}
+
+impl FnOnce<(uint, uint), uint> for Foo {
+    #[rust_call_abi_hack]
+    fn call_once(self, (x, y): (uint, uint)) -> uint { self.foo + x + y }
+}
+
+fn main() {
+    let f = box Foo { foo: 42 } as Box<FnOnce<(), uint>>;
+    assert_eq!(f.call_once(()), 42);
+
+    let f = box Foo { foo: 40 } as Box<FnOnce<(uint,), uint>>;
+    assert_eq!(f.call_once((2,)), 42);
+
+    let f = box Foo { foo: 40 } as Box<FnOnce<(uint, uint), uint>>;
+    assert_eq!(f.call_once((1, 1)), 42);
+}


### PR DESCRIPTION
When translating the unboxing shim, account for the fact that the shim translation has already performed the necessary unboxing of input types and values when forwarding to the shimmed function.  This prevents ICEing or generating incorrect code.

Closes #16739
