### PR TITLE
Split CString::new into CString::new and CString::new_owned

### DIFF
--- a/src/libnative/io/addrinfo.rs
+++ b/src/libnative/io/addrinfo.rs
@@ -106,7 +106,7 @@ fn get_error(s: c_int) -> IoError {
     use std::c_str::CString;
 
     let err_str = unsafe {
-        CString::new(gai_strerror(s), false).as_str().unwrap().to_string()
+        CString::new(gai_strerror(s)).as_str().unwrap().to_string()
     };
     IoError {
         code: s as uint,

--- a/src/libnative/io/file_unix.rs
+++ b/src/libnative/io/file_unix.rs
@@ -351,7 +351,7 @@ pub fn readdir(p: &CString) -> IoResult<Vec<CString>> {
     use libc::{opendir, readdir_r, closedir};
 
     fn prune(root: &CString, dirs: Vec<Path>) -> Vec<CString> {
-        let root = unsafe { CString::new(root.as_ptr(), false) };
+        let root = unsafe { CString::new(root.as_ptr()) };
         let root = Path::new(root);
 
         dirs.into_iter().filter(|path| {
@@ -376,7 +376,7 @@ pub fn readdir(p: &CString) -> IoResult<Vec<CString>> {
         while unsafe { readdir_r(dir_ptr, ptr, &mut entry_ptr) == 0 } {
             if entry_ptr.is_null() { break }
             let cstr = unsafe {
-                CString::new(rust_list_dir_val(entry_ptr), false)
+                CString::new(rust_list_dir_val(entry_ptr))
             };
             paths.push(Path::new(cstr));
         }

--- a/src/libnative/io/file_windows.rs
+++ b/src/libnative/io/file_windows.rs
@@ -347,7 +347,7 @@ pub fn mkdir(p: &CString, _mode: uint) -> IoResult<()> {
 
 pub fn readdir(p: &CString) -> IoResult<Vec<CString>> {
     fn prune(root: &CString, dirs: Vec<Path>) -> Vec<CString> {
-        let root = unsafe { CString::new(root.as_ptr(), false) };
+        let root = unsafe { CString::new(root.as_ptr()) };
         let root = Path::new(root);
 
         dirs.into_iter().filter(|path| {
@@ -356,7 +356,7 @@ pub fn readdir(p: &CString) -> IoResult<Vec<CString>> {
     }
 
     let star = Path::new(unsafe {
-        CString::new(p.as_ptr(), false)
+        CString::new(p.as_ptr())
     }).join("*");
     let path = try!(to_utf16(&star.to_c_str()));
 

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -2988,7 +2988,7 @@ fn internalize_symbols(cx: &SharedCrateContext, reachable: &HashSet<String>) {
                     continue
                 }
 
-                let name = CString::new(llvm::LLVMGetValueName(val), false);
+                let name = CString::new(llvm::LLVMGetValueName(val));
                 declared.insert(name);
             }
         }
@@ -3004,7 +3004,7 @@ fn internalize_symbols(cx: &SharedCrateContext, reachable: &HashSet<String>) {
                     continue
                 }
 
-                let name = CString::new(llvm::LLVMGetValueName(val), false);
+                let name = CString::new(llvm::LLVMGetValueName(val));
                 if !declared.contains(&name) &&
                    !reachable.contains_equiv(name.as_str().unwrap()) {
                     llvm::SetLinkage(val, llvm::InternalLinkage);

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -1625,7 +1625,7 @@ extern {
 
     /** Returns a string describing the last error caused by an LLVMRust*
     call. */
-    pub fn LLVMRustGetLastError() -> *const c_char;
+    pub fn LLVMRustGetLastError() -> *mut c_char;
 
     /// Print the pass timings since static dtors aren't picking them up.
     pub fn LLVMRustPrintPassTimings();

--- a/src/librustrt/c_str.rs
+++ b/src/librustrt/c_str.rs
@@ -22,20 +22,6 @@ strings can validly contain a null-byte in the middle of the string (0 is a
 valid Unicode codepoint). This means that not all Rust strings can actually be
 translated to C strings.
 
-# Creation of a C string
-
-A C string is managed through the `CString` type defined in this module. It
-"owns" the internal buffer of characters and will automatically deallocate the
-buffer when the string is dropped. The `ToCStr` trait is implemented for `&str`
-and `&[u8]`, but the conversions can fail due to some of the limitations
-explained above.
-
-This also means that currently whenever a C string is created, an allocation
-must be performed to place the data elsewhere (the lifetime of the C string is
-not tied to the lifetime of the original string/data buffer). If C strings are
-heavily used in applications, then caching may be advisable to prevent
-unnecessary amounts of allocations.
-
 Be carefull to remember that the memory is managed by C allocator API and not
 by Rust allocator API.
 That means that the CString pointers should be freed with C allocator API
@@ -432,7 +418,7 @@ impl ToCStr for [u8] {
         ptr::copy_memory(buf, self.as_ptr(), self_len);
         *buf.offset(self_len as int) = 0;
 
-        CString::new_owned(buf as *mut i8)
+        CString::new_owned(buf as *mut libc::c_char)
     }
 
     fn with_c_str<T>(&self, f: |*const libc::c_char| -> T) -> T {

--- a/src/librustrt/c_str.rs
+++ b/src/librustrt/c_str.rs
@@ -276,7 +276,7 @@ impl CString {
     /// terminator).
     #[inline]
     pub fn len(&self) -> uint {
-        unsafe { libc::strlen(self.buf) as uint }
+        unsafe { libc::strlen(self.as_ptr()) as uint }
     }
 
     /// Returns if there are no bytes in this string
@@ -295,17 +295,6 @@ impl Drop for CString {
     }
 }
 
-<<<<<<< HEAD
-=======
-impl Collection for CString {
-    /// Return the number of bytes in the CString (not including the NUL terminator).
-    #[inline]
-    fn len(&self) -> uint {
-        unsafe { libc::strlen(self.as_ptr()) as uint }
-    }
-}
-
->>>>>>> Split CString::new into CString::new and CString::new_owned
 impl fmt::Show for CString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         String::from_utf8_lossy(self.as_bytes_no_nul()).fmt(f)

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -242,7 +242,7 @@ pub mod dl {
             let ret = if ptr::null() == last_error {
                 Ok(result)
             } else {
-                Err(String::from_str(CString::new(last_error, false).as_str()
+                Err(String::from_str(CString::new(last_error).as_str()
                     .unwrap()))
             };
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -100,7 +100,7 @@ pub fn getcwd() -> Path {
         if libc::getcwd(buf.as_mut_ptr(), buf.len() as libc::size_t).is_null() {
             panic!()
         }
-        Path::new(CString::new(buf.as_ptr(), false))
+        Path::new(CString::new(buf.as_ptr()))
     }
 }
 
@@ -288,7 +288,7 @@ pub fn env_as_bytes() -> Vec<(Vec<u8>,Vec<u8>)> {
             let mut result = Vec::new();
             while *environ != 0 as *const _ {
                 let env_pair =
-                    CString::new(*environ, false).as_bytes_no_nul().to_vec();
+                    CString::new(*environ).as_bytes_no_nul().to_vec();
                 result.push(env_pair);
                 environ = environ.offset(1);
             }
@@ -355,7 +355,7 @@ pub fn getenv_as_bytes(n: &str) -> Option<Vec<u8>> {
             if s.is_null() {
                 None
             } else {
-                Some(CString::new(s as *const i8, false).as_bytes_no_nul().to_vec())
+                Some(CString::new(s as *const i8).as_bytes_no_nul().to_vec())
             }
         })
     }
@@ -1103,7 +1103,7 @@ unsafe fn load_argc_and_argv(argc: int,
     use c_str::CString;
 
     Vec::from_fn(argc as uint, |i| {
-        CString::new(*argv.offset(i as int), false).as_bytes_no_nul().to_vec()
+        CString::new(*argv.offset(i as int)).as_bytes_no_nul().to_vec()
     })
 }
 
@@ -1170,7 +1170,7 @@ fn real_args_as_bytes() -> Vec<Vec<u8>> {
             let tmp = objc_msgSend(args, objectAtSel, i);
             let utf_c_str: *const libc::c_char =
                 mem::transmute(objc_msgSend(tmp, utf8Sel));
-            let s = CString::new(utf_c_str, false);
+            let s = CString::new(utf_c_str);
             res.push(s.as_bytes_no_nul().to_vec())
         }
     }

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -382,7 +382,7 @@ mod imp {
             output(w, idx,addr, None)
         } else {
             output(w, idx, addr, Some(unsafe {
-                CString::new(info.dli_sname, false)
+                CString::new(info.dli_sname)
             }))
         }
     }
@@ -516,7 +516,7 @@ mod imp {
         if ret == 0 || data.is_null() {
             output(w, idx, addr, None)
         } else {
-            output(w, idx, addr, Some(unsafe { CString::new(data, false) }))
+            output(w, idx, addr, Some(unsafe { CString::new(data) }))
         }
     }
 
@@ -990,7 +990,7 @@ mod imp {
 
             if ret == libc::TRUE {
                 try!(write!(w, " - "));
-                let cstr = unsafe { CString::new(info.Name.as_ptr(), false) };
+                let cstr = unsafe { CString::new(info.Name.as_ptr()) };
                 let bytes = cstr.as_bytes();
                 match cstr.as_str() {
                     Some(s) => try!(super::demangle(w, s)),

--- a/src/test/run-pass/unix-process-spawn-errno.rs
+++ b/src/test/run-pass/unix-process-spawn-errno.rs
@@ -24,7 +24,7 @@ use rustrt::c_str;
 macro_rules! c_string {
     ($s:expr) => { {
         let ptr = concat!($s, "\0").as_ptr() as *const i8;
-        unsafe { &c_str::CString::new(ptr, false) }
+        unsafe { &c_str::CString::new(ptr) }
     } }
 }
 

--- a/src/test/run-pass/variadic-ffi.rs
+++ b/src/test/run-pass/variadic-ffi.rs
@@ -21,7 +21,7 @@ extern {
 unsafe fn check<T>(expected: &str, f: |*mut c_char| -> T) {
     let mut x = [0i8, ..50];
     f(&mut x[0] as *mut c_char);
-    let res = CString::new(&x[0], false);
+    let res = CString::new(&x[0]);
     assert_eq!(expected, res.as_str().unwrap());
 }
 


### PR DESCRIPTION
This is a fix for #18117
