### PR TITLE
Fix warning in Struct sync::Mutex example

### DIFF
--- a/src/libsync/lock.rs
+++ b/src/libsync/lock.rs
@@ -167,7 +167,7 @@ impl<'a> Condvar<'a> {
 ///     val.cond.signal();
 /// });
 ///
-/// let mut value = mutex.lock();
+/// let value = mutex.lock();
 /// while *value != 2 {
 ///     value.cond.wait();
 /// }


### PR DESCRIPTION
let mut value = mutex.lock();
warning: variable does not need to be mutable
