### PR TITLE
Add skip(n: uint) to Read, Seek, File, MemReader and BufferedReader

### DIFF
--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -113,6 +113,17 @@ impl<R: Reader> Reader for BufferedReader<R> {
         self.pos += nread;
         Ok(nread)
     }
+
+    fn skip(&mut self, num_bytes: uint) -> IoResult<uint> {
+        let bytes_in_buf = self.cap - self.pos;
+        Ok( if num_bytes <= bytes_in_buf {
+            self.pos += num_bytes;
+            num_bytes
+        } else {
+            self.pos += bytes_in_buf;
+            bytes_in_buf + try!( self.inner.skip(num_bytes - bytes_in_buf) )
+        } )
+    }
 }
 
 /// Wraps a Writer and buffers output to it

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -259,6 +259,12 @@ impl File {
         err.update_err("couldn't fstat file",
                        |e| format!("{}; path={}", e, self.path.display()))
     }
+
+    /// Call Seek::skip(), not Reader::skip().
+    #[inline]
+    pub fn skip(&mut self, num_bytes: uint) -> IoResult<uint> {
+        Seek::skip(self, num_bytes)
+    }
 }
 
 /// Unlink a file from the underlying filesystem.

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -137,6 +137,12 @@ impl MemReader {
     /// Unwraps this `MemReader`, returning the underlying buffer
     #[inline]
     pub fn unwrap(self) -> Vec<u8> { self.buf }
+
+    /// Call Seek::skip(), not Reader::skip().
+    #[inline]
+    pub fn skip(&mut self, num_bytes: uint) -> IoResult<uint> {
+        Seek::skip(self, num_bytes)
+    }
 }
 
 impl Reader for MemReader {


### PR DESCRIPTION
Resolve #13989

Note: the second patch is based on UFCS and doesn't compile with snapshot 2014-10-10.

I could write unit tests only for Read::skip().  How should I add more?
