### PR TITLE
[Docs] Fix fold explanation in the guide

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -4365,7 +4365,7 @@ element, `find` returns an `Option` rather than the element itself.
 Another important consumer is `fold`. Here's what it looks like:
 
 ```{rust}
-let sum = range(1i, 100i)
+let sum = range(1i, 4i)
               .fold(0i, |sum, x| sum + x);
 ```
 
@@ -4389,7 +4389,7 @@ in this iterator:
 We called `fold()` with these arguments:
 
 ```{rust}
-# range(1i, 5i)
+# range(1i, 4i)
 .fold(0i, |sum, x| sum + x);
 ```
 


### PR DESCRIPTION
The explanation of fold talks about three elements that should be summed, but it uses different values in the provided code.
