### PR TITLE
Fix the reason for calling a file lib.rs

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -3125,8 +3125,8 @@ pub fn add_three_times_four(x: int) -> int {
 }
 ```
 
-We're calling this file `lib.rs` because it has the same name as our project,
-and so it's named this, by convention.
+We're calling this file `lib.rs`, because Cargo uses that filename as the crate
+root by convention.
 
 We'll then need to use this crate in our `src/main.rs`:
 


### PR DESCRIPTION
The reason given didn't make any sense when I read it when reading through the docs. I think this is more clear. Please let me know it is also more correct.
