### PR TITLE
Fix monomorphization of unboxed closures

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -465,9 +465,12 @@ fn parse_ty(st: &mut PState, conv: conv_did) -> ty::t {
           return ty::mk_struct(st.tcx, did, substs);
       }
       'k' => {
+          assert_eq!(next(st), '[');
           let did = parse_def(st, NominalType, |x,y| conv(x,y));
-          let region = parse_region(st, conv);
-          return ty::mk_unboxed_closure(st.tcx, did, region);
+          let region = parse_region(st, |x,y| conv(x,y));
+          let substs = parse_substs(st, |x,y| conv(x,y));
+          assert_eq!(next(st), ']');
+          return ty::mk_unboxed_closure(st.tcx, did, region, substs);
       }
       'e' => {
           return ty::mk_err();

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -285,9 +285,11 @@ fn enc_sty(w: &mut SeekableMemWriter, cx: &ctxt, st: &ty::sty) {
             enc_substs(w, cx, substs);
             mywrite!(w, "]");
         }
-        ty::ty_unboxed_closure(def, region) => {
-            mywrite!(w, "k{}", (cx.ds)(def));
+        ty::ty_unboxed_closure(def, region, ref substs) => {
+            mywrite!(w, "k[{}|", (cx.ds)(def));
             enc_region(w, cx, region);
+            enc_substs(w, cx, substs);
+            mywrite!(w, "]");
         }
         ty::ty_err => {
             mywrite!(w, "e");

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -594,7 +594,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                       };
                       self.cat_upvar(id, span, var_id, fn_node_id, kind, mode, false)
                   }
-                  ty::ty_unboxed_closure(closure_id, _) => {
+                  ty::ty_unboxed_closure(closure_id, _, _) => {
                       let unboxed_closures = self.typer.unboxed_closures().borrow();
                       let kind = (*unboxed_closures)[closure_id].kind;
                       let mode = self.typer.capture_mode(fn_node_id);

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -176,8 +176,8 @@ fn represent_type_uncached(cx: &CrateContext, t: ty::t) -> Repr {
 
             return Univariant(mk_struct(cx, ftys.as_slice(), packed, t), dtor)
         }
-        ty::ty_unboxed_closure(def_id, _) => {
-            let upvars = ty::unboxed_closure_upvars(cx.tcx(), def_id);
+        ty::ty_unboxed_closure(def_id, _, ref substs) => {
+            let upvars = ty::unboxed_closure_upvars(cx.tcx(), def_id, substs);
             let upvar_types = upvars.iter().map(|u| u.ty).collect::<Vec<_>>();
             return Univariant(mk_struct(cx, upvar_types.as_slice(), false, t),
                               false)

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -491,7 +491,7 @@ pub fn trans_fn_ref_with_substs(
     };
 
     // If this is an unboxed closure, redirect to it.
-    match closure::get_or_create_declaration_if_unboxed_closure(ccx, def_id) {
+    match closure::get_or_create_declaration_if_unboxed_closure(bcx, def_id) {
         None => {}
         Some(llfn) => return llfn,
     }

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -138,7 +138,7 @@ pub struct LocalCrateContext {
     builder: BuilderRef_res,
 
     /// Holds the LLVM values for closure IDs.
-    unboxed_closure_vals: RefCell<DefIdMap<ValueRef>>,
+    unboxed_closure_vals: RefCell<HashMap<MonoId, ValueRef>>,
 
     dbg_cx: Option<debuginfo::CrateDebugContext>,
 
@@ -419,7 +419,7 @@ impl LocalCrateContext {
                 int_type: Type::from_ref(ptr::null_mut()),
                 opaque_vec_type: Type::from_ref(ptr::null_mut()),
                 builder: BuilderRef_res(llvm::LLVMCreateBuilderInContext(llcx)),
-                unboxed_closure_vals: RefCell::new(DefIdMap::new()),
+                unboxed_closure_vals: RefCell::new(HashMap::new()),
                 dbg_cx: dbg_cx,
                 eh_personality: RefCell::new(None),
                 intrinsics: RefCell::new(HashMap::new()),
@@ -689,7 +689,7 @@ impl<'b, 'tcx> CrateContext<'b, 'tcx> {
         self.local.opaque_vec_type
     }
 
-    pub fn unboxed_closure_vals<'a>(&'a self) -> &'a RefCell<DefIdMap<ValueRef>> {
+    pub fn unboxed_closure_vals<'a>(&'a self) -> &'a RefCell<HashMap<MonoId,ValueRef>> {
         &self.local.unboxed_closure_vals
     }
 

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -190,7 +190,7 @@ use llvm;
 use llvm::{ModuleRef, ContextRef, ValueRef};
 use llvm::debuginfo::*;
 use metadata::csearch;
-use middle::subst;
+use middle::subst::{mod, Subst};
 use middle::trans::adt;
 use middle::trans::common::*;
 use middle::trans::machine;
@@ -460,9 +460,9 @@ impl TypeMap {
                                                         closure_ty.clone(),
                                                         &mut unique_type_id);
             },
-            ty::ty_unboxed_closure(ref def_id, _) => {
+            ty::ty_unboxed_closure(ref def_id, _, ref substs) => {
                 let closure_ty = cx.tcx().unboxed_closures.borrow()
-                                   .find(def_id).unwrap().closure_type.clone();
+                                   .find(def_id).unwrap().closure_type.subst(cx.tcx(), substs);
                 self.get_unique_type_id_of_closure_type(cx,
                                                         closure_ty,
                                                         &mut unique_type_id);
@@ -2911,9 +2911,9 @@ fn type_metadata(cx: &CrateContext,
         ty::ty_closure(ref closurety) => {
             subroutine_type_metadata(cx, unique_type_id, &closurety.sig, usage_site_span)
         }
-        ty::ty_unboxed_closure(ref def_id, _) => {
+        ty::ty_unboxed_closure(ref def_id, _, ref substs) => {
             let sig = cx.tcx().unboxed_closures.borrow()
-                        .find(def_id).unwrap().closure_type.sig.clone();
+                        .find(def_id).unwrap().closure_type.sig.subst(cx.tcx(), substs);
             subroutine_type_metadata(cx, unique_type_id, &sig, usage_site_span)
         }
         ty::ty_struct(def_id, ref substs) => {

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -309,11 +309,15 @@ pub fn type_of(cx: &CrateContext, t: ty::t) -> Type {
           let name = llvm_type_name(cx, an_enum, did, tps);
           adt::incomplete_type_of(cx, &*repr, name.as_slice())
       }
-      ty::ty_unboxed_closure(did, _) => {
+      ty::ty_unboxed_closure(did, _, ref substs) => {
           // Only create the named struct, but don't fill it in. We
           // fill it in *after* placing it into the type cache.
           let repr = adt::represent_type(cx, t);
-          let name = llvm_type_name(cx, an_unboxed_closure, did, []);
+          // Unboxed closures can have substitutions in all spaces
+          // inherited from their environment, so we use entire
+          // contents of the VecPerParamSpace to to construct the llvm
+          // name
+          let name = llvm_type_name(cx, an_unboxed_closure, did, substs.types.as_slice());
           adt::incomplete_type_of(cx, &*repr, name.as_slice())
       }
 

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -534,8 +534,8 @@ pub fn super_fold_sty<'tcx, T: TypeFolder<'tcx>>(this: &mut T,
         ty::ty_struct(did, ref substs) => {
             ty::ty_struct(did, substs.fold_with(this))
         }
-        ty::ty_unboxed_closure(did, ref region) => {
-            ty::ty_unboxed_closure(did, region.fold_with(this))
+        ty::ty_unboxed_closure(did, ref region, ref substs) => {
+            ty::ty_unboxed_closure(did, region.fold_with(this), substs.fold_with(this))
         }
         ty::ty_nil | ty::ty_bot | ty::ty_bool | ty::ty_char | ty::ty_str |
         ty::ty_int(_) | ty::ty_uint(_) | ty::ty_float(_) |

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -505,7 +505,7 @@ impl<'a, 'tcx> LookupContext<'a, 'tcx> {
                 }
                 ty_enum(did, _) |
                 ty_struct(did, _) |
-                ty_unboxed_closure(did, _) => {
+                ty_unboxed_closure(did, _, _) => {
                     if self.check_traits == CheckTraitsAndInherentMethods {
                         self.push_inherent_impl_candidates_for_type(did);
                     }

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -3270,7 +3270,8 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         };
         let closure_type = ty::mk_unboxed_closure(fcx.ccx.tcx,
                                                   local_def(expr.id),
-                                                  region);
+                                                  region,
+                                                  fcx.inh.param_env.free_substs.clone());
         fcx.write_ty(expr.id, closure_type);
 
         check_fn(fcx.ccx,

--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -867,7 +867,7 @@ fn check_expr_fn_block(rcx: &mut Rcx,
                 }
             });
         }
-        ty::ty_unboxed_closure(_, region) => {
+        ty::ty_unboxed_closure(_, region, _) => {
             if tcx.capture_modes.borrow().get_copy(&expr.id) == ast::CaptureByRef {
                 ty::with_freevars(tcx, expr.id, |freevars| {
                     if !freevars.is_empty() {
@@ -908,7 +908,7 @@ fn check_expr_fn_block(rcx: &mut Rcx,
                 ensure_free_variable_types_outlive_closure_bound(rcx, bounds, expr, freevars);
             })
         }
-        ty::ty_unboxed_closure(_, region) => {
+        ty::ty_unboxed_closure(_, region, _) => {
             ty::with_freevars(tcx, expr.id, |freevars| {
                 let bounds = ty::region_existential_bound(region);
                 ensure_free_variable_types_outlive_closure_bound(rcx, bounds, expr, freevars);

--- a/src/librustc/middle/typeck/check/regionmanip.rs
+++ b/src/librustc/middle/typeck/check/regionmanip.rs
@@ -108,7 +108,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
                 self.accumulate_from_closure_ty(ty, c);
             }
 
-            ty::ty_unboxed_closure(_, region) => {
+            ty::ty_unboxed_closure(_, region, _) => {
                 // An "unboxed closure type" is basically
                 // modeled here as equivalent to a struct like
                 //
@@ -118,6 +118,18 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
                 //
                 // where the `'b` is the lifetime bound of the
                 // contents (i.e., all contents must outlive 'b).
+                //
+                // Even though unboxed closures are glorified structs
+                // of upvars, we do not need to consider them as they
+                // can't generate any new constraints.  The
+                // substitutions on the closure are equal to the free
+                // substitutions of the enclosing parameter
+                // environment.  An upvar captured by value has the
+                // same type as the original local variable which is
+                // already checked for consistency.  If the upvar is
+                // captured by reference it must also outlive the
+                // region bound on the closure, but this is explicitly
+                // handled by logic in regionck.
                 self.push_region_constraint_from_top(region);
             }
 

--- a/src/librustc/middle/typeck/coherence/mod.rs
+++ b/src/librustc/middle/typeck/coherence/mod.rs
@@ -105,7 +105,7 @@ fn get_base_type_def_id(inference_context: &InferCtxt,
             match get(base_type).sty {
                 ty_enum(def_id, _) |
                 ty_struct(def_id, _) |
-                ty_unboxed_closure(def_id, _) => {
+                ty_unboxed_closure(def_id, _, _) => {
                     Some(def_id)
                 }
                 ty_ptr(ty::mt {ty, ..}) |
@@ -445,7 +445,7 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
             match ty::get(self_type.ty).sty {
                 ty::ty_enum(type_def_id, _) |
                 ty::ty_struct(type_def_id, _) |
-                ty::ty_unboxed_closure(type_def_id, _) => {
+                ty::ty_unboxed_closure(type_def_id, _, _) => {
                     tcx.destructor_for_type
                        .borrow_mut()
                        .insert(type_def_id, method_def_id.def_id());

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -734,9 +734,8 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                 /* leaf type -- noop */
             }
 
-            ty::ty_unboxed_closure(_, region) => {
-                let contra = self.contravariant(variance);
-                self.add_constraints_from_region(region, contra);
+            ty::ty_unboxed_closure(..) => {
+                self.tcx().sess.bug("Unexpected unboxed closure type in variance computation");
             }
 
             ty::ty_rptr(region, ref mt) => {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -425,7 +425,12 @@ pub fn ty_to_string(cx: &ctxt, typ: t) -> String {
                   bound_str)
       }
       ty_str => "str".to_string(),
-      ty_unboxed_closure(..) => "closure".to_string(),
+      ty_unboxed_closure(ref did, _, ref substs) => {
+          let unboxed_closures = cx.unboxed_closures.borrow();
+          unboxed_closures.find(did).map(|cl| {
+              closure_to_string(cx, &cl.closure_type.subst(cx, substs))
+          }).unwrap_or_else(|| "closure".to_string())
+      }
       ty_vec(t, sz) => {
           match sz {
               Some(n) => {

--- a/src/test/run-pass/unboxed-closures-monomorphization.rs
+++ b/src/test/run-pass/unboxed-closures-monomorphization.rs
@@ -1,0 +1,36 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that unboxed closures in contexts with free type parameters
+// monomorphize correctly (issue #16791)
+
+#![feature(unboxed_closures)]
+
+fn main(){
+    fn bar<'a, T:'a> (t: T) -> Box<FnOnce<(),T> + 'a> {
+        box move |:| t
+    }
+
+    let f = bar(42u);
+    assert_eq!(f.call_once(()), 42);
+
+    let f = bar("forty-two");
+    assert_eq!(f.call_once(()), "forty-two");
+
+    let x = 42u;
+    let f = bar(&x);
+    assert_eq!(f.call_once(()), &x);
+
+    #[deriving(Show, PartialEq)]
+    struct Foo(uint, &'static str);
+    let x = Foo(42, "forty-two");
+    let f = bar(x);
+    assert_eq!(f.call_once(()), x);
+}


### PR DESCRIPTION
This allows unboxed closures that reference free type/region parameters to be monomorphized correctly in trans.

It was necessary to make `ty_unboxed_closure` carry around a `Substs` to accomplish this.  Plumbing this through typeck revealed several areas where type/region parameters in unboxed closure types are possibly not being handled correctly.  Since my goal was just to fix trans, I decided to leave FIXME comments on areas that still need attention and seek feedback on the best way to clean them up, possibly as a follow-up PR.

Closes #16791
