### PR TITLE
Optimize MemWriter::write_char

### DIFF
--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -13,14 +13,16 @@
 //! Readers and Writers for in-memory buffers
 
 use cmp::min;
-use collections::Collection;
+use collections::{MutableSeq, Collection};
 use option::None;
 use result::{Err, Ok};
 use io;
 use io::{Reader, Writer, Seek, Buffer, IoError, SeekStyle, IoResult};
 use slice;
-use slice::AsSlice;
+use slice::{ImmutableSlice, AsSlice};
 use vec::Vec;
+use char::Char;
+use iter::Iterator;
 
 static BUF_CAPACITY: uint = 128;
 
@@ -88,6 +90,16 @@ impl Writer for MemWriter {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> IoResult<()> {
         self.buf.push_all(buf);
+        Ok(())
+    }
+
+    #[inline]
+    fn write_char(&mut self, c: char) -> IoResult<()> {
+        let mut buf: [u8,..4] = unsafe { ::core::mem::uninitialized() };
+        let n = c.encode_utf8(buf[mut]).unwrap_or(0);
+        for &b in buf[].iter().take(n) {
+            self.buf.push(b)
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Previously, the `write_char` function typically made a call to `memcpy` (as seen in `ltrace`) to copy the UTF-8 encoded bytes. For the common ASCII case that meant a lot of 1-byte `memcpy`s. It sometimes got rid of the call in microbenchmarks, but rarely in real code. This commit gets rid of the call to `memcpy`.

For this benchmark (compiled with -O), performance improves a lot:

```
#![feature(slicing_syntax)]
extern crate test;
use std::io::MemWriter;
use test::Bencher;

#[inline(never)]
fn f<W: Writer>(w: &mut W, c: char) {
    w.write_char(c);
    w.write_char(c);
    w.write_char(c);
}

#[bench]
fn bench_write_char(b: &mut Bencher) {
    let n = 10000;
    let s = String::from_char(n, 'x');
    b.iter(|| {
        let mut w = MemWriter::with_capacity(3*n + 1);
        for c in s[].chars() {
            f(&mut w, c);
        }
        test::black_box(w);
    });
    b.bytes = 3 * n as u64;
}
```

Before

```
test bench_write_char ... bench:    252621 ns/iter (+/- 11388) = 118 MB/s
```

After

```
test bench_write_char ... bench:    163071 ns/iter (+/- 5512) = 183 MB/s
```
