### PR TITLE
Add lint for checking exceeding bitshifts #17713

### DIFF
--- a/src/test/compile-fail/huge-array-simple.rs
+++ b/src/test/compile-fail/huge-array-simple.rs
@@ -11,5 +11,5 @@
 // error-pattern: too big for the current
 
 fn main() {
-   let fat : [u8, ..(1<<61)+(1<<31)] = [0, ..(1<<61)+(1<<31)];
+   let fat : [u8, ..(1<<61)+(1<<31)] = [0, ..(1u64<<61) as uint +(1u64<<31) as uint];
 }

--- a/src/test/compile-fail/lint-exceeding-bitshifts.rs
+++ b/src/test/compile-fail/lint-exceeding-bitshifts.rs
@@ -1,0 +1,58 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(exceeding_bitshifts)]
+#![allow(unused_variables)]
+
+fn main() {
+      let n = 1u8 << 8;
+      let n = 1u8 << 9;   //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u16 << 16;
+      let n = 1u16 << 17; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u32 << 32;
+      let n = 1u32 << 33; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u64 << 64;
+      let n = 1u64 << 65; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i8 << 8;
+      let n = 1i8 << 9;   //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i16 << 16;
+      let n = 1i16 << 17; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i32 << 32;
+      let n = 1i32 << 33; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i64 << 64;
+      let n = 1i64 << 65; //~ ERROR: bitshift exceeds the type's number of bits
+
+      let n = 1u8 >> 8;
+      let n = 1u8 >> 9;   //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u16 >> 16;
+      let n = 1u16 >> 17; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u32 >> 32;
+      let n = 1u32 >> 33; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u64 >> 64;
+      let n = 1u64 >> 65; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i8 >> 8;
+      let n = 1i8 >> 9;   //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i16 >> 16;
+      let n = 1i16 >> 17; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i32 >> 32;
+      let n = 1i32 >> 33; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i64 >> 64;
+      let n = 1i64 >> 65; //~ ERROR: bitshift exceeds the type's number of bits
+
+      let n = 1u8;
+      let n = n << 8;
+      let n = n << 9; //~ ERROR: bitshift exceeds the type's number of bits
+
+      let n = 1u8 << -9; //~ ERROR: bitshift exceeds the type's number of bits
+
+      let n = 1u8 << (4+4);
+      let n = 1u8 << (4+5); //~ ERROR: bitshift exceeds the type's number of bits
+}
+


### PR DESCRIPTION
Add lint for checking exceeding bitshifts #17713

It also const-evaluates the shift width (RHS) to check more complex shifts like `1u8 << (4+5)`.
The lint-level is set to `Warn` but perhaps it must be `Deny` as in llvm exceeding bitshifts are undefined as @ben0x539 stated in #17713
