### PR TITLE
enable parallel codegen by default

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -157,6 +157,13 @@ RUSTFLAGS_STAGE1 += -C prefer-dynamic
 # by not emitting them.
 RUSTFLAGS_STAGE0 += -Z no-landing-pads
 
+# Go fast for stage0, and also for stage1/stage2 if optimization is off.
+RUSTFLAGS_STAGE0 += -C codegen-units=4
+ifdef CFG_DISABLE_OPTIMIZE
+	RUSTFLAGS_STAGE1 += -C codegen-units=4
+	RUSTFLAGS_STAGE2 += -C codegen-units=4
+endif
+
 # platform-specific auto-configuration
 include $(CFG_SRC_DIR)mk/platform.mk
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -628,6 +628,10 @@ CTEST_RUSTC_FLAGS := $$(subst -O,,$$(CTEST_RUSTC_FLAGS))
 ifndef CFG_DISABLE_OPTIMIZE_TESTS
 CTEST_RUSTC_FLAGS += -O
 endif
+# Force codegen-units=1 for compiletest tests.  compiletest does its own
+# parallelization internally, so rustc's default codegen-units=2 will actually
+# slow things down.
+CTEST_RUSTC_FLAGS += -C codegen-units=1
 
 CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) := \
 		--compile-lib-path $$(HLIB$(1)_H_$(3)) \

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -780,7 +780,20 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         early_warn("the --crate-file-name argument has been renamed to \
                     --print-file-name");
     }
-    let cg = build_codegen_options(matches);
+
+    let mut cg = build_codegen_options(matches);
+
+    if cg.codegen_units == 0 {
+        match opt_level {
+            // `-C lto` doesn't work with multiple codegen units.
+            _ if cg.lto => cg.codegen_units = 1,
+
+            No | Less => cg.codegen_units = 2,
+            Default | Aggressive => cg.codegen_units = 1,
+        }
+    }
+    let cg = cg;
+
 
     if !cg.remark.is_empty() && debuginfo == NoDebugInfo {
         early_warn("-C remark will not show source locations without --debuginfo");


### PR DESCRIPTION
Enable parallel codegen (2 units) by default when --opt-level is 0 or 1.  This
gives a minor speedup on large crates (~10%), with only a tiny slowdown (~2%)
for small ones (which usually build in under a second regardless).  The current
default (no parallelization) is used when the user requests optimization
(--opt-level 2 or 3), and when the user has enabled LTO (which is incompatible
with parallel codegen).

This commit also changes the rust build system to use parallel codegen
when appropriate.  This means codegen-units=4 for stage0 always, and
also for stage1 and stage2 when configured with --disable-optimize.
(Other settings use codegen-units=1 for stage1 and stage2, to get
maximum performance for release binaries.)  The build system also sets
codegen-units=1 for compiletest tests (compiletest does its own
parallelization) and uses the same setting as stage2 for crate tests.

r? @aturon
