### PR TITLE
Adjust orphan rules to consider all input types, not just self type.

### DIFF
--- a/src/librustc/middle/traits/coherence.rs
+++ b/src/librustc/middle/traits/coherence.rs
@@ -67,9 +67,9 @@ pub fn impl_is_local(tcx: &ty::ctxt,
         return true;
     }
 
-    // Otherwise, self type must be local to the crate.
-    let self_ty = ty::lookup_item_type(tcx, impl_def_id).ty;
-    return ty_is_local(tcx, self_ty);
+    // Otherwise, at least one of the input types must be local to the
+    // crate.
+    trait_ref.input_types().iter().any(|&t| ty_is_local(tcx, t))
 }
 
 pub fn ty_is_local(tcx: &ty::ctxt,

--- a/src/test/auxiliary/coherence-orphan-lib.rs
+++ b/src/test/auxiliary/coherence-orphan-lib.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait TheTrait<T> {
+    fn the_fn(&self);
+}
+

--- a/src/test/compile-fail/coherence-orphan.rs
+++ b/src/test/compile-fail/coherence-orphan.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:coherence-orphan-lib.rs
+
+extern crate "coherence-orphan-lib" as lib;
+
+use lib::TheTrait;
+
+struct TheType;
+
+impl TheTrait<uint> for int { } //~ ERROR E0117
+
+impl TheTrait<TheType> for int { }
+
+impl TheTrait<int> for TheType { }
+
+fn main() { }


### PR DESCRIPTION
Adjust orphan rules to consider all input types, not just self type.

Fixes #18222.

r? @pcwalton 
