### PR TITLE
Improve TokenTree variants

### DIFF
--- a/src/doc/guide-plugin.md
+++ b/src/doc/guide-plugin.md
@@ -56,7 +56,7 @@ extern crate rustc;
 
 use syntax::codemap::Span;
 use syntax::parse::token::{IDENT, get_ident};
-use syntax::ast::{TokenTree, TTTok};
+use syntax::ast::{TokenTree, TTToken};
 use syntax::ext::base::{ExtCtxt, MacResult, DummyResult, MacExpr};
 use syntax::ext::build::AstBuilder;  // trait for expr_uint
 use rustc::plugin::Registry;
@@ -71,7 +71,7 @@ fn expand_rn(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
         ("I",    1)];
 
     let text = match args {
-        [TTTok(_, IDENT(s, _))] => get_ident(s).to_string(),
+        [TTToken(_, IDENT(s, _))] => get_ident(s).to_string(),
         _ => {
             cx.span_err(sp, "argument should be a single identifier");
             return DummyResult::any(sp);

--- a/src/doc/guide-plugin.md
+++ b/src/doc/guide-plugin.md
@@ -56,7 +56,7 @@ extern crate rustc;
 
 use syntax::codemap::Span;
 use syntax::parse::token::{IDENT, get_ident};
-use syntax::ast::{TokenTree, TTToken};
+use syntax::ast::{TokenTree, TtToken};
 use syntax::ext::base::{ExtCtxt, MacResult, DummyResult, MacExpr};
 use syntax::ext::build::AstBuilder;  // trait for expr_uint
 use rustc::plugin::Registry;
@@ -71,7 +71,7 @@ fn expand_rn(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
         ("I",    1)];
 
     let text = match args {
-        [TTToken(_, IDENT(s, _))] => get_ident(s).to_string(),
+        [TtToken(_, IDENT(s, _))] => get_ident(s).to_string(),
         _ => {
             cx.span_err(sp, "argument should be a single identifier");
             return DummyResult::any(sp);

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -25,7 +25,7 @@ use std::rc::Rc;
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 
 #[cfg(stage0)]
-pub use self::TTToken as TTTok;
+pub use self::TtToken as TTTok;
 
 // FIXME #6993: in librustc, uses of "ident" should be replaced
 // by just "Name".
@@ -603,9 +603,9 @@ pub struct Delimiter {
 }
 
 impl Delimiter {
-    /// Convert the delimiter to a `TTToken`
+    /// Convert the delimiter to a `TtToken`
     pub fn to_tt(&self) -> TokenTree {
-        TTToken(self.span, self.token.clone())
+        TtToken(self.span, self.token.clone())
     }
 }
 
@@ -617,9 +617,9 @@ impl Delimiter {
 /// If the syntax extension is an MBE macro, it will attempt to match its
 /// LHS "matchers" against the provided token tree, and if it finds a
 /// match, will transcribe the RHS token tree, splicing in any captured
-/// `macro_parser::matched_nonterminals` into the `TTNonterminal`s it finds.
+/// `macro_parser::matched_nonterminals` into the `TtNonterminal`s it finds.
 ///
-/// The RHS of an MBE macro is the only place a `TTNonterminal` or `TTSequence`
+/// The RHS of an MBE macro is the only place a `TtNonterminal` or `TtSequence`
 /// makes any real sense. You could write them elsewhere but nothing
 /// else knows what to do with them, so you'll probably get a syntax
 /// error.
@@ -627,10 +627,10 @@ impl Delimiter {
 #[doc="For macro invocations; parsing is delegated to the macro"]
 pub enum TokenTree {
     /// A single token
-    TTToken(Span, ::parse::token::Token),
+    TtToken(Span, ::parse::token::Token),
     /// A delimited sequence of token trees
     // FIXME(eddyb) #6308 Use Rc<[TokenTree]> after DST.
-    TTDelimited(Span, Delimiter, Rc<Vec<TokenTree>>, Delimiter),
+    TtDelimited(Span, Delimiter, Rc<Vec<TokenTree>>, Delimiter),
 
     // These only make sense for right-hand-sides of MBE macros:
 
@@ -638,20 +638,20 @@ pub enum TokenTree {
     /// an optional separator, and a boolean where true indicates
     /// zero or more (..), and false indicates one or more (+).
     // FIXME(eddyb) #6308 Use Rc<[TokenTree]> after DST.
-    TTSequence(Span, Rc<Vec<TokenTree>>, Option<::parse::token::Token>, bool),
+    TtSequence(Span, Rc<Vec<TokenTree>>, Option<::parse::token::Token>, bool),
 
     /// A syntactic variable that will be filled in by macro expansion.
-    TTNonterminal(Span, Ident)
+    TtNonterminal(Span, Ident)
 }
 
 impl TokenTree {
     /// Returns the `Span` corresponding to this token tree.
     pub fn get_span(&self) -> Span {
         match *self {
-            TTToken(span, _)           => span,
-            TTDelimited(span, _, _, _) => span,
-            TTSequence(span, _, _, _)  => span,
-            TTNonterminal(span, _)     => span,
+            TtToken(span, _)           => span,
+            TtDelimited(span, _, _, _) => span,
+            TtSequence(span, _, _, _)  => span,
+            TtNonterminal(span, _)     => span,
         }
     }
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -24,6 +24,9 @@ use std::fmt::Show;
 use std::rc::Rc;
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 
+#[cfg(stage0)]
+pub use self::TTToken as TTTok;
+
 // FIXME #6993: in librustc, uses of "ident" should be replaced
 // by just "Name".
 
@@ -600,9 +603,9 @@ pub struct Delimiter {
 }
 
 impl Delimiter {
-    /// Convert the delimiter to a `TTTok`
+    /// Convert the delimiter to a `TTToken`
     pub fn to_tt(&self) -> TokenTree {
-        TTTok(self.span, self.token.clone())
+        TTToken(self.span, self.token.clone())
     }
 }
 
@@ -614,9 +617,9 @@ impl Delimiter {
 /// If the syntax extension is an MBE macro, it will attempt to match its
 /// LHS "matchers" against the provided token tree, and if it finds a
 /// match, will transcribe the RHS token tree, splicing in any captured
-/// macro_parser::matched_nonterminals into the TTNonterminals it finds.
+/// `macro_parser::matched_nonterminals` into the `TTNonterminal`s it finds.
 ///
-/// The RHS of an MBE macro is the only place a TTNonterminal or TTSeq
+/// The RHS of an MBE macro is the only place a `TTNonterminal` or `TTSequence`
 /// makes any real sense. You could write them elsewhere but nothing
 /// else knows what to do with them, so you'll probably get a syntax
 /// error.
@@ -624,18 +627,18 @@ impl Delimiter {
 #[doc="For macro invocations; parsing is delegated to the macro"]
 pub enum TokenTree {
     /// A single token
-    TTTok(Span, ::parse::token::Token),
+    TTToken(Span, ::parse::token::Token),
     /// A delimited sequence of token trees
     // FIXME(eddyb) #6308 Use Rc<[TokenTree]> after DST.
-    TTDelim(Span, Delimiter, Rc<Vec<TokenTree>>, Delimiter),
+    TTDelimited(Span, Delimiter, Rc<Vec<TokenTree>>, Delimiter),
 
     // These only make sense for right-hand-sides of MBE macros:
 
-    /// A kleene-style repetition sequence with a span, a TTForest,
+    /// A kleene-style repetition sequence with a span, a `TTForest`,
     /// an optional separator, and a boolean where true indicates
     /// zero or more (..), and false indicates one or more (+).
     // FIXME(eddyb) #6308 Use Rc<[TokenTree]> after DST.
-    TTSeq(Span, Rc<Vec<TokenTree>>, Option<::parse::token::Token>, bool),
+    TTSequence(Span, Rc<Vec<TokenTree>>, Option<::parse::token::Token>, bool),
 
     /// A syntactic variable that will be filled in by macro expansion.
     TTNonterminal(Span, Ident)
@@ -645,10 +648,10 @@ impl TokenTree {
     /// Returns the `Span` corresponding to this token tree.
     pub fn get_span(&self) -> Span {
         match *self {
-            TTTok(span, _)         => span,
-            TTDelim(span, _, _, _) => span,
-            TTSeq(span, _, _, _)   => span,
-            TTNonterminal(span, _) => span,
+            TTToken(span, _)           => span,
+            TTDelimited(span, _, _, _) => span,
+            TTSequence(span, _, _, _)  => span,
+            TTNonterminal(span, _)     => span,
         }
     }
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -609,6 +609,14 @@ impl Delimiter {
     }
 }
 
+/// A Kleene-style [repetition operator](http://en.wikipedia.org/wiki/Kleene_star)
+/// for token sequences.
+#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
+pub enum KleeneOp {
+    ZeroOrMore,
+    OneOrMore,
+}
+
 /// When the main rust parser encounters a syntax-extension invocation, it
 /// parses the arguments to the invocation as a token-tree. This is a very
 /// loose structure, such that all sorts of different AST-fragments can
@@ -633,12 +641,9 @@ pub enum TokenTree {
 
     // These only make sense for right-hand-sides of MBE macros:
 
-    /// A kleene-style repetition sequence with a span, a `TTForest`,
-    /// an optional separator, and a boolean where true indicates
-    /// zero or more (..), and false indicates one or more (+).
+    /// A Kleene-style repetition sequence with an optional separator.
     // FIXME(eddyb) #6308 Use Rc<[TokenTree]> after DST.
-    TtSequence(Span, Rc<Vec<TokenTree>>, Option<::parse::token::Token>, bool),
-
+    TtSequence(Span, Rc<Vec<TokenTree>>, Option<::parse::token::Token>, KleeneOp),
     /// A syntactic variable that will be filled in by macro expansion.
     TtNonterminal(Span, Ident)
 }
@@ -711,9 +716,9 @@ pub type Matcher = Spanned<Matcher_>;
 pub enum Matcher_ {
     /// Match one token
     MatchTok(::parse::token::Token),
-    /// Match repetitions of a sequence: body, separator, zero ok?,
+    /// Match repetitions of a sequence: body, separator, Kleene operator,
     /// lo, hi position-in-match-array used:
-    MatchSeq(Vec<Matcher> , Option<::parse::token::Token>, bool, uint, uint),
+    MatchSeq(Vec<Matcher> , Option<::parse::token::Token>, KleeneOp, uint, uint),
     /// Parse a Rust NT: name to bind, name of NT, position in match array:
     MatchNonterminal(Ident, Ident, uint)
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -629,8 +629,7 @@ pub enum TokenTree {
     /// A single token
     TtToken(Span, ::parse::token::Token),
     /// A delimited sequence of token trees
-    // FIXME(eddyb) #6308 Use Rc<[TokenTree]> after DST.
-    TtDelimited(Span, Delimiter, Rc<Vec<TokenTree>>, Delimiter),
+    TtDelimited(Span, Rc<(Delimiter, Vec<TokenTree>, Delimiter)>),
 
     // These only make sense for right-hand-sides of MBE macros:
 
@@ -649,7 +648,7 @@ impl TokenTree {
     pub fn get_span(&self) -> Span {
         match *self {
             TtToken(span, _)           => span,
-            TtDelimited(span, _, _, _) => span,
+            TtDelimited(span, _)       => span,
             TtSequence(span, _, _, _)  => span,
             TtNonterminal(span, _)     => span,
         }

--- a/src/libsyntax/diagnostics/plugin.rs
+++ b/src/libsyntax/diagnostics/plugin.rs
@@ -50,7 +50,7 @@ pub fn expand_diagnostic_used<'cx>(ecx: &'cx mut ExtCtxt,
                                    token_tree: &[TokenTree])
                                    -> Box<MacResult+'cx> {
     let code = match token_tree {
-        [ast::TTTok(_, token::IDENT(code, _))] => code,
+        [ast::TTToken(_, token::IDENT(code, _))] => code,
         _ => unreachable!()
     };
     with_registered_diagnostics(|diagnostics| {
@@ -82,12 +82,12 @@ pub fn expand_register_diagnostic<'cx>(ecx: &'cx mut ExtCtxt,
                                        token_tree: &[TokenTree])
                                        -> Box<MacResult+'cx> {
     let (code, description) = match token_tree {
-        [ast::TTTok(_, token::IDENT(ref code, _))] => {
+        [ast::TTToken(_, token::IDENT(ref code, _))] => {
             (code, None)
         },
-        [ast::TTTok(_, token::IDENT(ref code, _)),
-         ast::TTTok(_, token::COMMA),
-         ast::TTTok(_, token::LIT_STR_RAW(description, _))] => {
+        [ast::TTToken(_, token::IDENT(ref code, _)),
+         ast::TTToken(_, token::COMMA),
+         ast::TTToken(_, token::LIT_STR_RAW(description, _))] => {
             (code, Some(description))
         }
         _ => unreachable!()
@@ -110,7 +110,7 @@ pub fn expand_build_diagnostic_array<'cx>(ecx: &'cx mut ExtCtxt,
                                           token_tree: &[TokenTree])
                                           -> Box<MacResult+'cx> {
     let name = match token_tree {
-        [ast::TTTok(_, token::IDENT(ref name, _))] => name,
+        [ast::TTToken(_, token::IDENT(ref name, _))] => name,
         _ => unreachable!()
     };
 

--- a/src/libsyntax/diagnostics/plugin.rs
+++ b/src/libsyntax/diagnostics/plugin.rs
@@ -50,7 +50,7 @@ pub fn expand_diagnostic_used<'cx>(ecx: &'cx mut ExtCtxt,
                                    token_tree: &[TokenTree])
                                    -> Box<MacResult+'cx> {
     let code = match token_tree {
-        [ast::TTToken(_, token::IDENT(code, _))] => code,
+        [ast::TtToken(_, token::IDENT(code, _))] => code,
         _ => unreachable!()
     };
     with_registered_diagnostics(|diagnostics| {
@@ -82,12 +82,12 @@ pub fn expand_register_diagnostic<'cx>(ecx: &'cx mut ExtCtxt,
                                        token_tree: &[TokenTree])
                                        -> Box<MacResult+'cx> {
     let (code, description) = match token_tree {
-        [ast::TTToken(_, token::IDENT(ref code, _))] => {
+        [ast::TtToken(_, token::IDENT(ref code, _))] => {
             (code, None)
         },
-        [ast::TTToken(_, token::IDENT(ref code, _)),
-         ast::TTToken(_, token::COMMA),
-         ast::TTToken(_, token::LIT_STR_RAW(description, _))] => {
+        [ast::TtToken(_, token::IDENT(ref code, _)),
+         ast::TtToken(_, token::COMMA),
+         ast::TtToken(_, token::LIT_STR_RAW(description, _))] => {
             (code, Some(description))
         }
         _ => unreachable!()
@@ -110,7 +110,7 @@ pub fn expand_build_diagnostic_array<'cx>(ecx: &'cx mut ExtCtxt,
                                           token_tree: &[TokenTree])
                                           -> Box<MacResult+'cx> {
     let name = match token_tree {
-        [ast::TTToken(_, token::IDENT(ref name, _))] => name,
+        [ast::TtToken(_, token::IDENT(ref name, _))] => name,
         _ => unreachable!()
     };
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -684,8 +684,8 @@ pub fn get_single_str_from_tts(cx: &ExtCtxt,
         cx.span_err(sp, format!("{} takes 1 argument.", name).as_slice());
     } else {
         match tts[0] {
-            ast::TTTok(_, token::LIT_STR(ident)) => return Some(parse::str_lit(ident.as_str())),
-            ast::TTTok(_, token::LIT_STR_RAW(ident, _)) => {
+            ast::TTToken(_, token::LIT_STR(ident)) => return Some(parse::str_lit(ident.as_str())),
+            ast::TTToken(_, token::LIT_STR_RAW(ident, _)) => {
                 return Some(parse::raw_str_lit(ident.as_str()))
             }
             _ => {

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -684,8 +684,8 @@ pub fn get_single_str_from_tts(cx: &ExtCtxt,
         cx.span_err(sp, format!("{} takes 1 argument.", name).as_slice());
     } else {
         match tts[0] {
-            ast::TTToken(_, token::LIT_STR(ident)) => return Some(parse::str_lit(ident.as_str())),
-            ast::TTToken(_, token::LIT_STR_RAW(ident, _)) => {
+            ast::TtToken(_, token::LIT_STR(ident)) => return Some(parse::str_lit(ident.as_str())),
+            ast::TtToken(_, token::LIT_STR_RAW(ident, _)) => {
                 return Some(parse::raw_str_lit(ident.as_str()))
             }
             _ => {

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -23,7 +23,7 @@ pub fn expand_syntax_ext<'cx>(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]
     for (i, e) in tts.iter().enumerate() {
         if i & 1 == 1 {
             match *e {
-                ast::TTTok(_, token::COMMA) => (),
+                ast::TTToken(_, token::COMMA) => (),
                 _ => {
                     cx.span_err(sp, "concat_idents! expecting comma.");
                     return DummyResult::expr(sp);
@@ -31,7 +31,7 @@ pub fn expand_syntax_ext<'cx>(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]
             }
         } else {
             match *e {
-                ast::TTTok(_, token::IDENT(ident,_)) => {
+                ast::TTToken(_, token::IDENT(ident,_)) => {
                     res_str.push_str(token::get_ident(ident).get())
                 }
                 _ => {

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -23,7 +23,7 @@ pub fn expand_syntax_ext<'cx>(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]
     for (i, e) in tts.iter().enumerate() {
         if i & 1 == 1 {
             match *e {
-                ast::TTToken(_, token::COMMA) => (),
+                ast::TtToken(_, token::COMMA) => (),
                 _ => {
                     cx.span_err(sp, "concat_idents! expecting comma.");
                     return DummyResult::expr(sp);
@@ -31,7 +31,7 @@ pub fn expand_syntax_ext<'cx>(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]
             }
         } else {
             match *e {
-                ast::TTToken(_, token::IDENT(ident,_)) => {
+                ast::TtToken(_, token::IDENT(ident,_)) => {
                     res_str.push_str(token::get_ident(ident).get())
                 }
                 _ => {

--- a/src/libsyntax/ext/log_syntax.rs
+++ b/src/libsyntax/ext/log_syntax.rs
@@ -13,16 +13,14 @@ use codemap;
 use ext::base;
 use print;
 
-use std::rc::Rc;
-
 pub fn expand_syntax_ext<'cx>(cx: &'cx mut base::ExtCtxt,
                               sp: codemap::Span,
-                              tt: &[ast::TokenTree])
+                              tts: &[ast::TokenTree])
                               -> Box<base::MacResult+'cx> {
 
     cx.print_backtrace();
-    println!("{}", print::pprust::tt_to_string(&ast::TTDelim(
-                Rc::new(tt.iter().map(|x| (*x).clone()).collect()))));
+
+    println!("{}", print::pprust::tts_to_string(tts));
 
     // any so that `log_syntax` can be invoked as an expression and item.
     base::DummyResult::any(sp)

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -651,7 +651,8 @@ fn mk_tt(cx: &ExtCtxt, _: Span, tt: &ast::TokenTree) -> Vec<P<ast::Stmt>> {
                                     vec!(e_tok));
             vec!(cx.stmt_expr(e_push))
         },
-        ast::TtDelimited(sp, ref open, ref tts, ref close) => {
+        ast::TtDelimited(sp, ref delimed) => {
+            let (ref open, ref tts, ref close) = **delimed;
             mk_tt(cx, sp, &open.to_tt()).into_iter()
                 .chain(tts.iter().flat_map(|tt| mk_tt(cx, sp, tt).into_iter()))
                 .chain(mk_tt(cx, sp, &close.to_tt()).into_iter())

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -652,11 +652,10 @@ fn mk_tt(cx: &ExtCtxt, _: Span, tt: &ast::TokenTree) -> Vec<P<ast::Stmt>> {
             vec!(cx.stmt_expr(e_push))
         },
         ast::TTDelimited(sp, ref open, ref tts, ref close) => {
-            let mut stmts = vec![];
-            stmts.extend(mk_tt(cx, sp, &open.to_tt()).into_iter());
-            stmts.extend(tts.iter().flat_map(|tt| mk_tt(cx, sp, tt).into_iter()));
-            stmts.extend(mk_tt(cx, sp, &close.to_tt()).into_iter());
-            stmts
+            mk_tt(cx, sp, &open.to_tt()).into_iter()
+                .chain(tts.iter().flat_map(|tt| mk_tt(cx, sp, tt).into_iter()))
+                .chain(mk_tt(cx, sp, &close.to_tt()).into_iter())
+                .collect()
         },
         ast::TTSequence(..) => fail!("TTSequence in quote!"),
         ast::TTNonterminal(sp, ident) => {

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -23,7 +23,7 @@ use ptr::P;
 *
 * This is registered as a set of expression syntax extension called quote!
 * that lifts its argument token-tree to an AST representing the
-* construction of the same token tree, with ast::TTNonterminal nodes
+* construction of the same token tree, with ast::TtNonterminal nodes
 * interpreted as antiquotes (splices).
 *
 */
@@ -639,10 +639,10 @@ fn mk_token(cx: &ExtCtxt, sp: Span, tok: &token::Token) -> P<ast::Expr> {
 
 fn mk_tt(cx: &ExtCtxt, _: Span, tt: &ast::TokenTree) -> Vec<P<ast::Stmt>> {
     match *tt {
-        ast::TTToken(sp, ref tok) => {
+        ast::TtToken(sp, ref tok) => {
             let e_sp = cx.expr_ident(sp, id_ext("_sp"));
             let e_tok = cx.expr_call(sp,
-                                     mk_ast_path(cx, sp, "TTToken"),
+                                     mk_ast_path(cx, sp, "TtToken"),
                                      vec!(e_sp, mk_token(cx, sp, tok)));
             let e_push =
                 cx.expr_method_call(sp,
@@ -651,14 +651,14 @@ fn mk_tt(cx: &ExtCtxt, _: Span, tt: &ast::TokenTree) -> Vec<P<ast::Stmt>> {
                                     vec!(e_tok));
             vec!(cx.stmt_expr(e_push))
         },
-        ast::TTDelimited(sp, ref open, ref tts, ref close) => {
+        ast::TtDelimited(sp, ref open, ref tts, ref close) => {
             mk_tt(cx, sp, &open.to_tt()).into_iter()
                 .chain(tts.iter().flat_map(|tt| mk_tt(cx, sp, tt).into_iter()))
                 .chain(mk_tt(cx, sp, &close.to_tt()).into_iter())
                 .collect()
         },
-        ast::TTSequence(..) => fail!("TTSequence in quote!"),
-        ast::TTNonterminal(sp, ident) => {
+        ast::TtSequence(..) => fail!("TtSequence in quote!"),
+        ast::TtNonterminal(sp, ident) => {
             // tt.extend($ident.to_tokens(ext_cx).into_iter())
 
             let e_to_toks =
@@ -692,7 +692,7 @@ fn mk_tts(cx: &ExtCtxt, sp: Span, tts: &[ast::TokenTree])
 fn expand_tts(cx: &ExtCtxt, sp: Span, tts: &[ast::TokenTree])
               -> (P<ast::Expr>, P<ast::Expr>) {
     // NB: It appears that the main parser loses its mind if we consider
-    // $foo as a TTNonterminal during the main parse, so we have to re-parse
+    // $foo as a TtNonterminal during the main parse, so we have to re-parse
     // under quote_depth > 0. This is silly and should go away; the _guess_ is
     // it has to do with transition away from supporting old-style macros, so
     // try removing it when enough of them are gone.

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -639,10 +639,10 @@ fn mk_token(cx: &ExtCtxt, sp: Span, tok: &token::Token) -> P<ast::Expr> {
 
 fn mk_tt(cx: &ExtCtxt, _: Span, tt: &ast::TokenTree) -> Vec<P<ast::Stmt>> {
     match *tt {
-        ast::TTTok(sp, ref tok) => {
+        ast::TTToken(sp, ref tok) => {
             let e_sp = cx.expr_ident(sp, id_ext("_sp"));
             let e_tok = cx.expr_call(sp,
-                                     mk_ast_path(cx, sp, "TTTok"),
+                                     mk_ast_path(cx, sp, "TTToken"),
                                      vec!(e_sp, mk_token(cx, sp, tok)));
             let e_push =
                 cx.expr_method_call(sp,
@@ -651,14 +651,14 @@ fn mk_tt(cx: &ExtCtxt, _: Span, tt: &ast::TokenTree) -> Vec<P<ast::Stmt>> {
                                     vec!(e_tok));
             vec!(cx.stmt_expr(e_push))
         },
-        ast::TTDelim(sp, ref open, ref tts, ref close) => {
+        ast::TTDelimited(sp, ref open, ref tts, ref close) => {
             let mut stmts = vec![];
             stmts.extend(mk_tt(cx, sp, &open.to_tt()).into_iter());
             stmts.extend(tts.iter().flat_map(|tt| mk_tt(cx, sp, tt).into_iter()));
             stmts.extend(mk_tt(cx, sp, &close.to_tt()).into_iter());
             stmts
         },
-        ast::TTSeq(..) => fail!("TTSeq in quote!"),
+        ast::TTSequence(..) => fail!("TTSequence in quote!"),
         ast::TTNonterminal(sp, ident) => {
             // tt.extend($ident.to_tokens(ext_cx).into_iter())
 

--- a/src/libsyntax/ext/trace_macros.rs
+++ b/src/libsyntax/ext/trace_macros.rs
@@ -20,10 +20,10 @@ pub fn expand_trace_macros(cx: &mut ExtCtxt,
                            tt: &[ast::TokenTree])
                            -> Box<base::MacResult+'static> {
     match tt {
-        [ast::TTToken(_, ref tok)] if is_keyword(keywords::True, tok) => {
+        [ast::TtToken(_, ref tok)] if is_keyword(keywords::True, tok) => {
             cx.set_trace_macros(true);
         }
-        [ast::TTToken(_, ref tok)] if is_keyword(keywords::False, tok) => {
+        [ast::TtToken(_, ref tok)] if is_keyword(keywords::False, tok) => {
             cx.set_trace_macros(false);
         }
         _ => cx.span_err(sp, "trace_macros! accepts only `true` or `false`"),

--- a/src/libsyntax/ext/trace_macros.rs
+++ b/src/libsyntax/ext/trace_macros.rs
@@ -20,10 +20,10 @@ pub fn expand_trace_macros(cx: &mut ExtCtxt,
                            tt: &[ast::TokenTree])
                            -> Box<base::MacResult+'static> {
     match tt {
-        [ast::TTTok(_, ref tok)] if is_keyword(keywords::True, tok) => {
+        [ast::TTToken(_, ref tok)] if is_keyword(keywords::True, tok) => {
             cx.set_trace_macros(true);
         }
-        [ast::TTTok(_, ref tok)] if is_keyword(keywords::False, tok) => {
+        [ast::TTToken(_, ref tok)] if is_keyword(keywords::False, tok) => {
             cx.set_trace_macros(false);
         }
         _ => cx.span_err(sp, "trace_macros! accepts only `true` or `false`"),

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -323,9 +323,9 @@ pub fn parse(sess: &ParseSess,
             } else {
                 match ei.elts[idx].node.clone() {
                   /* need to descend into sequence */
-                  MatchSeq(ref matchers, ref sep, zero_ok,
+                  MatchSeq(ref matchers, ref sep, kleene_op,
                            match_idx_lo, match_idx_hi) => {
-                    if zero_ok {
+                    if kleene_op == ast::ZeroOrMore {
                         let mut new_ei = ei.clone();
                         new_ei.idx += 1u;
                         //we specifically matched zero repeats.

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -172,7 +172,10 @@ fn generic_extension<'cx>(cx: &'cx ExtCtxt,
                     MatchedNonterminal(NtTT(ref tt)) => {
                         match **tt {
                             // ignore delimiters
-                            TtDelimited(_, _, ref tts, _) => (**tts).clone(),
+                            TtDelimited(_, ref delimed) => {
+                                let (_, ref tts, _) = **delimed;
+                                tts.clone()
+                            },
                             _ => cx.span_fatal(sp, "macro rhs must be delimited"),
                         }
                     },

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast::{Ident, Matcher_, Matcher, MatchTok, MatchNonterminal, MatchSeq, TTDelim};
+use ast::{Ident, Matcher_, Matcher, MatchTok, MatchNonterminal, MatchSeq, TTDelimited};
 use ast;
 use codemap::{Span, Spanned, DUMMY_SP};
 use ext::base::{ExtCtxt, MacResult, MacroDef};
@@ -172,7 +172,7 @@ fn generic_extension<'cx>(cx: &'cx ExtCtxt,
                     MatchedNonterminal(NtTT(ref tt)) => {
                         match **tt {
                             // ignore delimiters
-                            TTDelim(_, _, ref tts, _) => (**tts).clone(),
+                            TTDelimited(_, _, ref tts, _) => (**tts).clone(),
                             _ => cx.span_fatal(sp, "macro rhs must be delimited"),
                         }
                     },

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -147,13 +147,9 @@ fn generic_extension<'cx>(cx: &'cx ExtCtxt,
                           rhses: &[Rc<NamedMatch>])
                           -> Box<MacResult+'cx> {
     if cx.trace_macros() {
-        println!("{}! {} {} {}",
+        println!("{}! {{ {} }}",
                  token::get_ident(name),
-                 "{",
-                 print::pprust::tt_to_string(&TTDelim(Rc::new(arg.iter()
-                                                              .map(|x| (*x).clone())
-                                                              .collect()))),
-                 "}");
+                 print::pprust::tts_to_string(arg));
     }
 
     // Which arm's failure should we report? (the one furthest along)
@@ -175,15 +171,9 @@ fn generic_extension<'cx>(cx: &'cx ExtCtxt,
                     // okay, what's your transcriber?
                     MatchedNonterminal(NtTT(ref tt)) => {
                         match **tt {
-                            // cut off delimiters; don't parse 'em
-                            TTDelim(ref tts) => {
-                                (*tts).slice(1u,(*tts).len()-1u)
-                                      .iter()
-                                      .map(|x| (*x).clone())
-                                      .collect()
-                            }
-                            _ => cx.span_fatal(
-                                sp, "macro rhs must be delimited")
+                            // ignore delimiters
+                            TTDelim(_, _, ref tts, _) => (**tts).clone(),
+                            _ => cx.span_fatal(sp, "macro rhs must be delimited"),
                         }
                     },
                     _ => cx.span_bug(sp, "bad thing in rhs")

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast::{Ident, Matcher_, Matcher, MatchTok, MatchNonterminal, MatchSeq, TTDelimited};
+use ast::{Ident, Matcher_, Matcher, MatchTok, MatchNonterminal, MatchSeq, TtDelimited};
 use ast;
 use codemap::{Span, Spanned, DUMMY_SP};
 use ext::base::{ExtCtxt, MacResult, MacroDef};
@@ -172,7 +172,7 @@ fn generic_extension<'cx>(cx: &'cx ExtCtxt,
                     MatchedNonterminal(NtTT(ref tt)) => {
                         match **tt {
                             // ignore delimiters
-                            TTDelimited(_, _, ref tts, _) => (**tts).clone(),
+                            TtDelimited(_, _, ref tts, _) => (**tts).clone(),
                             _ => cx.span_fatal(sp, "macro rhs must be delimited"),
                         }
                     },

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -232,10 +232,11 @@ pub fn add_new_extension<'cx>(cx: &'cx mut ExtCtxt,
         ms(MatchSeq(vec!(
             ms(MatchNonterminal(lhs_nm, special_idents::matchers, 0u)),
             ms(MatchTok(FAT_ARROW)),
-            ms(MatchNonterminal(rhs_nm, special_idents::tt, 1u))), Some(SEMI), false, 0u, 2u)),
+            ms(MatchNonterminal(rhs_nm, special_idents::tt, 1u))), Some(SEMI),
+                                ast::OneOrMore, 0u, 2u)),
         //to phase into semicolon-termination instead of
         //semicolon-separation
-        ms(MatchSeq(vec!(ms(MatchTok(SEMI))), None, true, 2u, 2u)));
+        ms(MatchSeq(vec!(ms(MatchTok(SEMI))), None, ast::ZeroOrMore, 2u, 2u)));
 
 
     // Parse the macro_rules! invocation (`none` is for no interpolations):

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -202,14 +202,14 @@ pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
             (*frame.forest)[frame.idx].clone()
         };
         match t {
-            TTDelimited(_, open, delimed_tts, close) => {
-                let mut tts = vec![];
-                tts.push(open.to_tt());
-                tts.extend(delimed_tts.iter().map(|x| (*x).clone()));
-                tts.push(close.to_tt());
+            TTDelimited(_, open, tts, close) => {
+                let mut forest = Vec::with_capacity(1 + tts.len() + 1);
+                forest.push(open.to_tt());
+                forest.extend(tts.iter().map(|x| (*x).clone()));
+                forest.push(close.to_tt());
 
                 r.stack.push(TtFrame {
-                    forest: Rc::new(tts),
+                    forest: Rc::new(forest),
                     idx: 0,
                     dotdotdoted: false,
                     sep: None

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -227,9 +227,9 @@ pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
                 r.stack.last_mut().unwrap().idx += 1;
                 return ret_val;
             }
-            TtSequence(sp, tts, sep, zerok) => {
+            TtSequence(sp, tts, sep, kleene_op) => {
                 // FIXME(pcwalton): Bad copy.
-                match lockstep_iter_size(&TtSequence(sp, tts.clone(), sep.clone(), zerok), r) {
+                match lockstep_iter_size(&TtSequence(sp, tts.clone(), sep.clone(), kleene_op), r) {
                     LisUnconstrained => {
                         r.sp_diag.span_fatal(
                             sp.clone(), /* blame macro writer */
@@ -243,7 +243,7 @@ pub fn tt_next_token(r: &mut TtReader) -> TokenAndSpan {
                         }
                     LisConstraint(len, _) => {
                         if len == 0 {
-                            if !zerok {
+                            if kleene_op == ast::OneOrMore {
                                 // FIXME #2887 blame invoker
                                 r.sp_diag.span_fatal(sp.clone(),
                                                      "this must repeat at least once");

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -571,7 +571,17 @@ pub fn noop_fold_tt<T: Folder>(tt: &TokenTree, fld: &mut T) -> TokenTree {
     match *tt {
         TTTok(span, ref tok) =>
             TTTok(span, fld.fold_token(tok.clone())),
-        TTDelim(ref tts) => TTDelim(Rc::new(fld.fold_tts(tts.as_slice()))),
+        TTDelim(span, ref open, ref tts, ref close) =>
+            TTDelim(span,
+                    Delimiter {
+                        span: open.span,
+                        token: fld.fold_token(open.token.clone())
+                    },
+                    Rc::new(fld.fold_tts(tts.as_slice())),
+                    Delimiter {
+                        span: close.span,
+                        token: fld.fold_token(close.token.clone())
+                    }),
         TTSeq(span, ref pattern, ref sep, is_optional) =>
             TTSeq(span,
                   Rc::new(fld.fold_tts(pattern.as_slice())),

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -569,24 +569,24 @@ pub fn noop_fold_arg<T: Folder>(Arg {id, pat, ty}: Arg, fld: &mut T) -> Arg {
 
 pub fn noop_fold_tt<T: Folder>(tt: &TokenTree, fld: &mut T) -> TokenTree {
     match *tt {
-        TTTok(span, ref tok) =>
-            TTTok(span, fld.fold_token(tok.clone())),
-        TTDelim(span, ref open, ref tts, ref close) =>
-            TTDelim(span,
-                    Delimiter {
-                        span: open.span,
-                        token: fld.fold_token(open.token.clone())
-                    },
-                    Rc::new(fld.fold_tts(tts.as_slice())),
-                    Delimiter {
-                        span: close.span,
-                        token: fld.fold_token(close.token.clone())
-                    }),
-        TTSeq(span, ref pattern, ref sep, is_optional) =>
-            TTSeq(span,
-                  Rc::new(fld.fold_tts(pattern.as_slice())),
-                  sep.clone().map(|tok| fld.fold_token(tok)),
-                  is_optional),
+        TTToken(span, ref tok) =>
+            TTToken(span, fld.fold_token(tok.clone())),
+        TTDelimited(span, ref open, ref tts, ref close) =>
+            TTDelimited(span,
+                        Delimiter {
+                            span: open.span,
+                            token: fld.fold_token(open.token.clone())
+                        },
+                        Rc::new(fld.fold_tts(tts.as_slice())),
+                        Delimiter {
+                            span: close.span,
+                            token: fld.fold_token(close.token.clone())
+                        }),
+        TTSequence(span, ref pattern, ref sep, is_optional) =>
+            TTSequence(span,
+                       Rc::new(fld.fold_tts(pattern.as_slice())),
+                       sep.clone().map(|tok| fld.fold_token(tok)),
+                       is_optional),
         TTNonterminal(sp,ref ident) =>
             TTNonterminal(sp,fld.fold_ident(*ident))
     }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -571,17 +571,20 @@ pub fn noop_fold_tt<T: Folder>(tt: &TokenTree, fld: &mut T) -> TokenTree {
     match *tt {
         TtToken(span, ref tok) =>
             TtToken(span, fld.fold_token(tok.clone())),
-        TtDelimited(span, ref open, ref tts, ref close) =>
-            TtDelimited(span,
-                        Delimiter {
-                            span: open.span,
-                            token: fld.fold_token(open.token.clone())
-                        },
-                        Rc::new(fld.fold_tts(tts.as_slice())),
-                        Delimiter {
-                            span: close.span,
-                            token: fld.fold_token(close.token.clone())
-                        }),
+        TtDelimited(span, ref delimed) => {
+            let (ref open, ref tts, ref close) = **delimed;
+            TtDelimited(span, Rc::new((
+                            Delimiter {
+                                span: open.span,
+                                token: fld.fold_token(open.token.clone())
+                            },
+                            fld.fold_tts(tts.as_slice()),
+                            Delimiter {
+                                span: close.span,
+                                token: fld.fold_token(close.token.clone())
+                            },
+                        )))
+        },
         TtSequence(span, ref pattern, ref sep, is_optional) =>
             TtSequence(span,
                        Rc::new(fld.fold_tts(pattern.as_slice())),

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -569,10 +569,10 @@ pub fn noop_fold_arg<T: Folder>(Arg {id, pat, ty}: Arg, fld: &mut T) -> Arg {
 
 pub fn noop_fold_tt<T: Folder>(tt: &TokenTree, fld: &mut T) -> TokenTree {
     match *tt {
-        TTToken(span, ref tok) =>
-            TTToken(span, fld.fold_token(tok.clone())),
-        TTDelimited(span, ref open, ref tts, ref close) =>
-            TTDelimited(span,
+        TtToken(span, ref tok) =>
+            TtToken(span, fld.fold_token(tok.clone())),
+        TtDelimited(span, ref open, ref tts, ref close) =>
+            TtDelimited(span,
                         Delimiter {
                             span: open.span,
                             token: fld.fold_token(open.token.clone())
@@ -582,13 +582,13 @@ pub fn noop_fold_tt<T: Folder>(tt: &TokenTree, fld: &mut T) -> TokenTree {
                             span: close.span,
                             token: fld.fold_token(close.token.clone())
                         }),
-        TTSequence(span, ref pattern, ref sep, is_optional) =>
-            TTSequence(span,
+        TtSequence(span, ref pattern, ref sep, is_optional) =>
+            TtSequence(span,
                        Rc::new(fld.fold_tts(pattern.as_slice())),
                        sep.clone().map(|tok| fld.fold_token(tok)),
                        is_optional),
-        TTNonterminal(sp,ref ident) =>
-            TTNonterminal(sp,fld.fold_ident(*ident))
+        TtNonterminal(sp,ref ident) =>
+            TtNonterminal(sp,fld.fold_ident(*ident))
     }
 }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -788,35 +788,34 @@ mod test {
     }
 
     // check the token-tree-ization of macros
-    #[test] fn string_to_tts_macro () {
+    #[test]
+    fn string_to_tts_macro () {
         let tts = string_to_tts("macro_rules! zip (($a)=>($a))".to_string());
         let tts: &[ast::TokenTree] = tts.as_slice();
         match tts {
-            [ast::TTTok(_,_),
-             ast::TTTok(_,token::NOT),
-             ast::TTTok(_,_),
-             ast::TTDelim(ref delim_elts)] => {
+            [ast::TTTok(_, _),
+             ast::TTTok(_, token::NOT),
+             ast::TTTok(_, _),
+             ast::TTDelim(_, ast::TTTok(_, token::LPAREN),
+                          ref delim_elts,
+                          ast::TTTok(_, token::RPAREN))] => {
                 let delim_elts: &[ast::TokenTree] = delim_elts.as_slice();
                 match delim_elts {
-                    [ast::TTTok(_,token::LPAREN),
-                     ast::TTDelim(ref first_set),
-                     ast::TTTok(_,token::FAT_ARROW),
-                     ast::TTDelim(ref second_set),
-                     ast::TTTok(_,token::RPAREN)] => {
+                    [ast::TTDelim(_, ast::TTTok(_, token::LPAREN),
+                                  ref first_set,
+                                  ast::TTTok(_, token::RPAREN)),
+                     ast::TTTok(_, token::FAT_ARROW),
+                     ast::TTDelim(_, ast::TTTok(_, token::LPAREN),
+                                  ref second_set,
+                                  ast::TTTok(_, token::RPAREN))] => {
                         let first_set: &[ast::TokenTree] =
                             first_set.as_slice();
                         match first_set {
-                            [ast::TTTok(_,token::LPAREN),
-                             ast::TTTok(_,token::DOLLAR),
-                             ast::TTTok(_,_),
-                             ast::TTTok(_,token::RPAREN)] => {
+                            [ast::TTTok(_, token::DOLLAR), ast::TTTok(_, _)] => {
                                 let second_set: &[ast::TokenTree] =
                                     second_set.as_slice();
                                 match second_set {
-                                    [ast::TTTok(_,token::LPAREN),
-                                     ast::TTTok(_,token::DOLLAR),
-                                     ast::TTTok(_,_),
-                                     ast::TTTok(_,token::RPAREN)] => {
+                                    [ast::TTTok(_, token::DOLLAR), ast::TTTok(_, _)] => {
                                         assert_eq!("correct","correct")
                                     }
                                     _ => assert_eq!("wrong 4","correct")
@@ -837,7 +836,7 @@ mod test {
             _ => {
                 error!("failing value: {}",tts);
                 assert_eq!("wrong 1","correct");
-            }
+            },
         }
     }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -793,29 +793,29 @@ mod test {
         let tts = string_to_tts("macro_rules! zip (($a)=>($a))".to_string());
         let tts: &[ast::TokenTree] = tts.as_slice();
         match tts {
-            [ast::TTToken(_, _),
-             ast::TTToken(_, token::NOT),
-             ast::TTToken(_, _),
-             ast::TTDelimited(_, ast::TTToken(_, token::LPAREN),
+            [ast::TtToken(_, _),
+             ast::TtToken(_, token::NOT),
+             ast::TtToken(_, _),
+             ast::TtDelimited(_, ast::TtToken(_, token::LPAREN),
                           ref delim_elts,
-                          ast::TTToken(_, token::RPAREN))] => {
+                          ast::TtToken(_, token::RPAREN))] => {
                 let delim_elts: &[ast::TokenTree] = delim_elts.as_slice();
                 match delim_elts {
-                    [ast::TTDelimited(_, ast::TTToken(_, token::LPAREN),
+                    [ast::TtDelimited(_, ast::TtToken(_, token::LPAREN),
                                   ref first_set,
-                                  ast::TTToken(_, token::RPAREN)),
-                     ast::TTToken(_, token::FAT_ARROW),
-                     ast::TTDelimited(_, ast::TTToken(_, token::LPAREN),
+                                  ast::TtToken(_, token::RPAREN)),
+                     ast::TtToken(_, token::FAT_ARROW),
+                     ast::TtDelimited(_, ast::TtToken(_, token::LPAREN),
                                   ref second_set,
-                                  ast::TTToken(_, token::RPAREN))] => {
+                                  ast::TtToken(_, token::RPAREN))] => {
                         let first_set: &[ast::TokenTree] =
                             first_set.as_slice();
                         match first_set {
-                            [ast::TTToken(_, token::DOLLAR), ast::TTToken(_, _)] => {
+                            [ast::TtToken(_, token::DOLLAR), ast::TtToken(_, _)] => {
                                 let second_set: &[ast::TokenTree] =
                                     second_set.as_slice();
                                 match second_set {
-                                    [ast::TTToken(_, token::DOLLAR), ast::TTToken(_, _)] => {
+                                    [ast::TtToken(_, token::DOLLAR), ast::TtToken(_, _)] => {
                                         assert_eq!("correct","correct")
                                     }
                                     _ => assert_eq!("wrong 4","correct")
@@ -845,7 +845,7 @@ mod test {
         assert_eq!(json::encode(&tts),
         "[\
     {\
-        \"variant\":\"TTToken\",\
+        \"variant\":\"TtToken\",\
         \"fields\":[\
             null,\
             {\
@@ -858,7 +858,7 @@ mod test {
         ]\
     },\
     {\
-        \"variant\":\"TTToken\",\
+        \"variant\":\"TtToken\",\
         \"fields\":[\
             null,\
             {\
@@ -871,18 +871,18 @@ mod test {
         ]\
     },\
     {\
-        \"variant\":\"TTDelimited\",\
+        \"variant\":\"TtDelimited\",\
         \"fields\":[\
             [\
                 {\
-                    \"variant\":\"TTToken\",\
+                    \"variant\":\"TtToken\",\
                     \"fields\":[\
                         null,\
                         \"LPAREN\"\
                     ]\
                 },\
                 {\
-                    \"variant\":\"TTToken\",\
+                    \"variant\":\"TtToken\",\
                     \"fields\":[\
                         null,\
                         {\
@@ -895,14 +895,14 @@ mod test {
                     ]\
                 },\
                 {\
-                    \"variant\":\"TTToken\",\
+                    \"variant\":\"TtToken\",\
                     \"fields\":[\
                         null,\
                         \"COLON\"\
                     ]\
                 },\
                 {\
-                    \"variant\":\"TTToken\",\
+                    \"variant\":\"TtToken\",\
                     \"fields\":[\
                         null,\
                         {\
@@ -915,7 +915,7 @@ mod test {
                     ]\
                 },\
                 {\
-                    \"variant\":\"TTToken\",\
+                    \"variant\":\"TtToken\",\
                     \"fields\":[\
                         null,\
                         \"RPAREN\"\
@@ -925,18 +925,18 @@ mod test {
         ]\
     },\
     {\
-        \"variant\":\"TTDelimited\",\
+        \"variant\":\"TtDelimited\",\
         \"fields\":[\
             [\
                 {\
-                    \"variant\":\"TTToken\",\
+                    \"variant\":\"TtToken\",\
                     \"fields\":[\
                         null,\
                         \"LBRACE\"\
                     ]\
                 },\
                 {\
-                    \"variant\":\"TTToken\",\
+                    \"variant\":\"TtToken\",\
                     \"fields\":[\
                         null,\
                         {\
@@ -949,14 +949,14 @@ mod test {
                     ]\
                 },\
                 {\
-                    \"variant\":\"TTToken\",\
+                    \"variant\":\"TtToken\",\
                     \"fields\":[\
                         null,\
                         \"SEMI\"\
                     ]\
                 },\
                 {\
-                    \"variant\":\"TTToken\",\
+                    \"variant\":\"TtToken\",\
                     \"fields\":[\
                         null,\
                         \"RBRACE\"\

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -793,29 +793,29 @@ mod test {
         let tts = string_to_tts("macro_rules! zip (($a)=>($a))".to_string());
         let tts: &[ast::TokenTree] = tts.as_slice();
         match tts {
-            [ast::TTTok(_, _),
-             ast::TTTok(_, token::NOT),
-             ast::TTTok(_, _),
-             ast::TTDelim(_, ast::TTTok(_, token::LPAREN),
+            [ast::TTToken(_, _),
+             ast::TTToken(_, token::NOT),
+             ast::TTToken(_, _),
+             ast::TTDelimited(_, ast::TTToken(_, token::LPAREN),
                           ref delim_elts,
-                          ast::TTTok(_, token::RPAREN))] => {
+                          ast::TTToken(_, token::RPAREN))] => {
                 let delim_elts: &[ast::TokenTree] = delim_elts.as_slice();
                 match delim_elts {
-                    [ast::TTDelim(_, ast::TTTok(_, token::LPAREN),
+                    [ast::TTDelimited(_, ast::TTToken(_, token::LPAREN),
                                   ref first_set,
-                                  ast::TTTok(_, token::RPAREN)),
-                     ast::TTTok(_, token::FAT_ARROW),
-                     ast::TTDelim(_, ast::TTTok(_, token::LPAREN),
+                                  ast::TTToken(_, token::RPAREN)),
+                     ast::TTToken(_, token::FAT_ARROW),
+                     ast::TTDelimited(_, ast::TTToken(_, token::LPAREN),
                                   ref second_set,
-                                  ast::TTTok(_, token::RPAREN))] => {
+                                  ast::TTToken(_, token::RPAREN))] => {
                         let first_set: &[ast::TokenTree] =
                             first_set.as_slice();
                         match first_set {
-                            [ast::TTTok(_, token::DOLLAR), ast::TTTok(_, _)] => {
+                            [ast::TTToken(_, token::DOLLAR), ast::TTToken(_, _)] => {
                                 let second_set: &[ast::TokenTree] =
                                     second_set.as_slice();
                                 match second_set {
-                                    [ast::TTTok(_, token::DOLLAR), ast::TTTok(_, _)] => {
+                                    [ast::TTToken(_, token::DOLLAR), ast::TTToken(_, _)] => {
                                         assert_eq!("correct","correct")
                                     }
                                     _ => assert_eq!("wrong 4","correct")
@@ -845,7 +845,7 @@ mod test {
         assert_eq!(json::encode(&tts),
         "[\
     {\
-        \"variant\":\"TTTok\",\
+        \"variant\":\"TTToken\",\
         \"fields\":[\
             null,\
             {\
@@ -858,7 +858,7 @@ mod test {
         ]\
     },\
     {\
-        \"variant\":\"TTTok\",\
+        \"variant\":\"TTToken\",\
         \"fields\":[\
             null,\
             {\
@@ -871,18 +871,18 @@ mod test {
         ]\
     },\
     {\
-        \"variant\":\"TTDelim\",\
+        \"variant\":\"TTDelimited\",\
         \"fields\":[\
             [\
                 {\
-                    \"variant\":\"TTTok\",\
+                    \"variant\":\"TTToken\",\
                     \"fields\":[\
                         null,\
                         \"LPAREN\"\
                     ]\
                 },\
                 {\
-                    \"variant\":\"TTTok\",\
+                    \"variant\":\"TTToken\",\
                     \"fields\":[\
                         null,\
                         {\
@@ -895,14 +895,14 @@ mod test {
                     ]\
                 },\
                 {\
-                    \"variant\":\"TTTok\",\
+                    \"variant\":\"TTToken\",\
                     \"fields\":[\
                         null,\
                         \"COLON\"\
                     ]\
                 },\
                 {\
-                    \"variant\":\"TTTok\",\
+                    \"variant\":\"TTToken\",\
                     \"fields\":[\
                         null,\
                         {\
@@ -915,7 +915,7 @@ mod test {
                     ]\
                 },\
                 {\
-                    \"variant\":\"TTTok\",\
+                    \"variant\":\"TTToken\",\
                     \"fields\":[\
                         null,\
                         \"RPAREN\"\
@@ -925,18 +925,18 @@ mod test {
         ]\
     },\
     {\
-        \"variant\":\"TTDelim\",\
+        \"variant\":\"TTDelimited\",\
         \"fields\":[\
             [\
                 {\
-                    \"variant\":\"TTTok\",\
+                    \"variant\":\"TTToken\",\
                     \"fields\":[\
                         null,\
                         \"LBRACE\"\
                     ]\
                 },\
                 {\
-                    \"variant\":\"TTTok\",\
+                    \"variant\":\"TTToken\",\
                     \"fields\":[\
                         null,\
                         {\
@@ -949,14 +949,14 @@ mod test {
                     ]\
                 },\
                 {\
-                    \"variant\":\"TTTok\",\
+                    \"variant\":\"TTToken\",\
                     \"fields\":[\
                         null,\
                         \"SEMI\"\
                     ]\
                 },\
                 {\
-                    \"variant\":\"TTTok\",\
+                    \"variant\":\"TTToken\",\
                     \"fields\":[\
                         null,\
                         \"RBRACE\"\

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -48,8 +48,8 @@ use ast::{StmtExpr, StmtSemi, StmtMac, StructDef, StructField};
 use ast::{StructVariantKind, BiSub};
 use ast::StrStyle;
 use ast::{SelfExplicit, SelfRegion, SelfStatic, SelfValue};
-use ast::{Delimiter, TokenTree, TraitItem, TraitRef, TTDelimited, TTSequence, TTToken};
-use ast::{TTNonterminal, TupleVariantKind, Ty, Ty_, TyBot};
+use ast::{Delimiter, TokenTree, TraitItem, TraitRef, TtDelimited, TtSequence, TtToken};
+use ast::{TtNonterminal, TupleVariantKind, Ty, Ty_, TyBot};
 use ast::{TypeField, TyFixedLengthVec, TyClosure, TyProc, TyBareFn};
 use ast::{TyTypeof, TyInfer, TypeMethod};
 use ast::{TyNil, TyParam, TyParamBound, TyParen, TyPath, TyPtr, TyQPath};
@@ -2526,8 +2526,8 @@ impl<'a> Parser<'a> {
     /// parse a single token tree from the input.
     pub fn parse_token_tree(&mut self) -> TokenTree {
         // FIXME #6994: currently, this is too eager. It
-        // parses token trees but also identifies TTSequence's
-        // and TTNonterminal's; it's too early to know yet
+        // parses token trees but also identifies TtSequence's
+        // and TtNonterminal's; it's too early to know yet
         // whether something will be a nonterminal or a seq
         // yet.
         maybe_whole!(deref self, NtTT);
@@ -2568,13 +2568,13 @@ impl<'a> Parser<'a> {
                     let seq = match seq {
                         Spanned { node, .. } => node,
                     };
-                    TTSequence(mk_sp(sp.lo, p.span.hi), Rc::new(seq), s, z)
+                    TtSequence(mk_sp(sp.lo, p.span.hi), Rc::new(seq), s, z)
                 } else {
-                    TTNonterminal(sp, p.parse_ident())
+                    TtNonterminal(sp, p.parse_ident())
                 }
               }
               _ => {
-                  TTToken(p.span, p.bump_and_get())
+                  TtToken(p.span, p.bump_and_get())
               }
             }
         }
@@ -2615,7 +2615,7 @@ impl<'a> Parser<'a> {
                 // Expand to cover the entire delimited token tree
                 let span = Span { hi: self.span.hi, ..pre_span };
 
-                TTDelimited(span, open, Rc::new(tts), close)
+                TtDelimited(span, open, Rc::new(tts), close)
             }
             _ => parse_non_delim_tt_tok(self)
         }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2615,7 +2615,7 @@ impl<'a> Parser<'a> {
                 // Expand to cover the entire delimited token tree
                 let span = Span { hi: self.span.hi, ..pre_span };
 
-                TtDelimited(span, open, Rc::new(tts), close)
+                TtDelimited(span, Rc::new((open, tts, close)))
             }
             _ => parse_non_delim_tt_tok(self)
         }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -48,7 +48,7 @@ use ast::{StmtExpr, StmtSemi, StmtMac, StructDef, StructField};
 use ast::{StructVariantKind, BiSub};
 use ast::StrStyle;
 use ast::{SelfExplicit, SelfRegion, SelfStatic, SelfValue};
-use ast::{Delimiter, TokenTree, TraitItem, TraitRef, TTDelim, TTSeq, TTTok};
+use ast::{Delimiter, TokenTree, TraitItem, TraitRef, TTDelimited, TTSequence, TTToken};
 use ast::{TTNonterminal, TupleVariantKind, Ty, Ty_, TyBot};
 use ast::{TypeField, TyFixedLengthVec, TyClosure, TyProc, TyBareFn};
 use ast::{TyTypeof, TyInfer, TypeMethod};
@@ -2526,7 +2526,7 @@ impl<'a> Parser<'a> {
     /// parse a single token tree from the input.
     pub fn parse_token_tree(&mut self) -> TokenTree {
         // FIXME #6994: currently, this is too eager. It
-        // parses token trees but also identifies TTSeq's
+        // parses token trees but also identifies TTSequence's
         // and TTNonterminal's; it's too early to know yet
         // whether something will be a nonterminal or a seq
         // yet.
@@ -2568,13 +2568,13 @@ impl<'a> Parser<'a> {
                     let seq = match seq {
                         Spanned { node, .. } => node,
                     };
-                    TTSeq(mk_sp(sp.lo, p.span.hi), Rc::new(seq), s, z)
+                    TTSequence(mk_sp(sp.lo, p.span.hi), Rc::new(seq), s, z)
                 } else {
                     TTNonterminal(sp, p.parse_ident())
                 }
               }
               _ => {
-                  TTTok(p.span, p.bump_and_get())
+                  TTToken(p.span, p.bump_and_get())
               }
             }
         }
@@ -2615,7 +2615,7 @@ impl<'a> Parser<'a> {
                 // Expand to cover the entire delimited token tree
                 let span = Span { hi: self.span.hi, ..pre_span };
 
-                TTDelim(span, open, Rc::new(tts), close)
+                TTDelimited(span, open, Rc::new(tts), close)
             }
             _ => parse_non_delim_tt_tok(self)
         }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1037,20 +1037,23 @@ impl<'a> State<'a> {
                     _ => Ok(())
                 }
             }
-            ast::TtSequence(_, ref tts, ref sep, zerok) => {
+            ast::TtSequence(_, ref tts, ref separator, kleene_op) => {
                 try!(word(&mut self.s, "$("));
                 for tt_elt in (*tts).iter() {
                     try!(self.print_tt(tt_elt));
                 }
                 try!(word(&mut self.s, ")"));
-                match *sep {
+                match *separator {
                     Some(ref tk) => {
                         try!(word(&mut self.s,
                                   parse::token::to_string(tk).as_slice()));
                     }
                     None => ()
                 }
-                word(&mut self.s, if zerok { "*" } else { "+" })
+                match kleene_op {
+                    ast::ZeroOrMore => word(&mut self.s, "*"),
+                    ast::OneOrMore => word(&mut self.s, "+"),
+                }
             }
             ast::TtNonterminal(_, name) => {
                 try!(word(&mut self.s, "$"));

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1020,7 +1020,13 @@ impl<'a> State<'a> {
     /// expression arguments as expressions). It can be done! I think.
     pub fn print_tt(&mut self, tt: &ast::TokenTree) -> IoResult<()> {
         match *tt {
-            ast::TTDelim(ref tts) => self.print_tts(tts.as_slice()),
+            ast::TTDelim(_, ref open, ref tts, ref close) => {
+                try!(word(&mut self.s, parse::token::to_string(&open.token).as_slice()));
+                try!(space(&mut self.s));
+                try!(self.print_tts(tts.as_slice()));
+                try!(space(&mut self.s));
+                word(&mut self.s, parse::token::to_string(&close.token).as_slice())
+            },
             ast::TTTok(_, ref tk) => {
                 try!(word(&mut self.s, parse::token::to_string(tk).as_slice()));
                 match *tk {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1020,7 +1020,8 @@ impl<'a> State<'a> {
     /// expression arguments as expressions). It can be done! I think.
     pub fn print_tt(&mut self, tt: &ast::TokenTree) -> IoResult<()> {
         match *tt {
-            ast::TtDelimited(_, ref open, ref tts, ref close) => {
+            ast::TtDelimited(_, ref delimed) => {
+                let (ref open, ref tts, ref close) = **delimed;
                 try!(word(&mut self.s, parse::token::to_string(&open.token).as_slice()));
                 try!(space(&mut self.s));
                 try!(self.print_tts(tts.as_slice()));

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1020,14 +1020,14 @@ impl<'a> State<'a> {
     /// expression arguments as expressions). It can be done! I think.
     pub fn print_tt(&mut self, tt: &ast::TokenTree) -> IoResult<()> {
         match *tt {
-            ast::TTDelimited(_, ref open, ref tts, ref close) => {
+            ast::TtDelimited(_, ref open, ref tts, ref close) => {
                 try!(word(&mut self.s, parse::token::to_string(&open.token).as_slice()));
                 try!(space(&mut self.s));
                 try!(self.print_tts(tts.as_slice()));
                 try!(space(&mut self.s));
                 word(&mut self.s, parse::token::to_string(&close.token).as_slice())
             },
-            ast::TTToken(_, ref tk) => {
+            ast::TtToken(_, ref tk) => {
                 try!(word(&mut self.s, parse::token::to_string(tk).as_slice()));
                 match *tk {
                     parse::token::DOC_COMMENT(..) => {
@@ -1036,7 +1036,7 @@ impl<'a> State<'a> {
                     _ => Ok(())
                 }
             }
-            ast::TTSequence(_, ref tts, ref sep, zerok) => {
+            ast::TtSequence(_, ref tts, ref sep, zerok) => {
                 try!(word(&mut self.s, "$("));
                 for tt_elt in (*tts).iter() {
                     try!(self.print_tt(tt_elt));
@@ -1051,7 +1051,7 @@ impl<'a> State<'a> {
                 }
                 word(&mut self.s, if zerok { "*" } else { "+" })
             }
-            ast::TTNonterminal(_, name) => {
+            ast::TtNonterminal(_, name) => {
                 try!(word(&mut self.s, "$"));
                 self.print_ident(name)
             }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1020,14 +1020,14 @@ impl<'a> State<'a> {
     /// expression arguments as expressions). It can be done! I think.
     pub fn print_tt(&mut self, tt: &ast::TokenTree) -> IoResult<()> {
         match *tt {
-            ast::TTDelim(_, ref open, ref tts, ref close) => {
+            ast::TTDelimited(_, ref open, ref tts, ref close) => {
                 try!(word(&mut self.s, parse::token::to_string(&open.token).as_slice()));
                 try!(space(&mut self.s));
                 try!(self.print_tts(tts.as_slice()));
                 try!(space(&mut self.s));
                 word(&mut self.s, parse::token::to_string(&close.token).as_slice())
             },
-            ast::TTTok(_, ref tk) => {
+            ast::TTToken(_, ref tk) => {
                 try!(word(&mut self.s, parse::token::to_string(tk).as_slice()));
                 match *tk {
                     parse::token::DOC_COMMENT(..) => {
@@ -1036,7 +1036,7 @@ impl<'a> State<'a> {
                     _ => Ok(())
                 }
             }
-            ast::TTSeq(_, ref tts, ref sep, zerok) => {
+            ast::TTSequence(_, ref tts, ref sep, zerok) => {
                 try!(word(&mut self.s, "$("));
                 for tt_elt in (*tts).iter() {
                     try!(self.print_tt(tt_elt));

--- a/src/test/auxiliary/roman_numerals.rs
+++ b/src/test/auxiliary/roman_numerals.rs
@@ -18,7 +18,7 @@ extern crate rustc;
 
 use syntax::codemap::Span;
 use syntax::parse::token::{IDENT, get_ident};
-use syntax::ast::{TokenTree, TTTok};
+use syntax::ast::{TokenTree, TTToken};
 use syntax::ext::base::{ExtCtxt, MacResult, DummyResult, MacExpr};
 use syntax::ext::build::AstBuilder;  // trait for expr_uint
 use rustc::plugin::Registry;
@@ -39,7 +39,7 @@ fn expand_rn(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
         ("I",    1)];
 
     let text = match args {
-        [TTTok(_, IDENT(s, _))] => get_ident(s).to_string(),
+        [TTToken(_, IDENT(s, _))] => get_ident(s).to_string(),
         _ => {
             cx.span_err(sp, "argument should be a single identifier");
             return DummyResult::any(sp);

--- a/src/test/auxiliary/roman_numerals.rs
+++ b/src/test/auxiliary/roman_numerals.rs
@@ -18,7 +18,7 @@ extern crate rustc;
 
 use syntax::codemap::Span;
 use syntax::parse::token::{IDENT, get_ident};
-use syntax::ast::{TokenTree, TTToken};
+use syntax::ast::{TokenTree, TtToken};
 use syntax::ext::base::{ExtCtxt, MacResult, DummyResult, MacExpr};
 use syntax::ext::build::AstBuilder;  // trait for expr_uint
 use rustc::plugin::Registry;
@@ -39,7 +39,7 @@ fn expand_rn(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
         ("I",    1)];
 
     let text = match args {
-        [TTToken(_, IDENT(s, _))] => get_ident(s).to_string(),
+        [TtToken(_, IDENT(s, _))] => get_ident(s).to_string(),
         _ => {
             cx.span_err(sp, "argument should be a single identifier");
             return DummyResult::any(sp);


### PR DESCRIPTION
I have renamed the `TokenTree` variants to be longer and clearer, and to use standard capitalisation. They should also fit in better with the existing `TTNonterminal` variant.

The new definition of  `TtDelimited` adds an associated `Span` that covers the whole token tree, and moves the opening and closing delimiters out of the vector of delimited token trees. This came up when working [on the gl-rs generator plugin](https://github.com/bjz/gl-rs/blob/990383de801bd2e233159d5be07c9b5622827620/src/gl_generator/lib.rs#L135-L146).

The `bool` in `TtSequence` has been replaced with a `KleeneOp` enum. This should make the intent of the code clearer (I had trouble understanding it).

A `get_span` method has also been added to `TokenTree` type to make it easier to implement better error messages for syntax extensions.

[breaking-change]

Renamed:
- `TTTok` -> `TtToken`
- `TTDelim` -> `TtDelimited`
- `TTSeq` -> `TtSequence`
- `TTNonterminal` -> `TtNonterminal`

New definition of `TtDelimited`:

``` rust
TtDelimited(Span, Rc<(Delimiter, Vec<TokenTree>, Delimiter)>)
```

New definition of `TtSequence`:

``` rust
TtSequence(Span, Rc<Vec<TokenTree>>, Option<::parse::token::Token>, KleeneOp)
```
