### PR TITLE
Guide: Change >= to > in closure

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -4347,7 +4347,7 @@ is one:
 
 ```{rust}
 let greater_than_forty_two = range(0i, 100i)
-                             .find(|x| *x >= 42);
+                             .find(|x| *x > 42);
 
 match greater_than_forty_two {
     Some(_) => println!("We got some numbers!"),


### PR DESCRIPTION
The variable is called <code>greater_than_forty_two</code>, but the find will return <code>Some(42)</code>. I fixed it by removing the "=" in the closure.
