### PR TITLE
rustc: Fail immediately if linking returns status code != 0

### DIFF
--- a/src/librustc/back/write.rs
+++ b/src/librustc/back/write.rs
@@ -714,7 +714,13 @@ pub fn run_passes(sess: &Session,
            .stdout(::std::io::process::InheritFd(1))
            .stderr(::std::io::process::InheritFd(2));
         match cmd.status() {
-            Ok(_) => {},
+            Ok(status) => {
+                if !status.success() {
+                    sess.err(format!("linking of {} with `{}` failed",
+                                     output_path.display(), cmd).as_slice());
+                    sess.abort_if_errors();
+                }
+            },
             Err(e) => {
                 sess.err(format!("could not exec the linker `{}`: {}",
                                  pname,


### PR DESCRIPTION
If rustc fails to link a library (as described in #17951), it still tries to rename the non-existent file on Windows. I'm not sure how to test this as we'd have to reproduce a linking failure...

Closes #17951
