### PR TITLE
Improved examples on Vec documentation

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -641,8 +641,11 @@ impl<T> Vec<T> {
     /// # Example
     ///
     /// ```
-    /// let mut vec = vec![1i, 2, 3];
+    /// let mut vec: Vec<int> = Vec::with_capacity(10);
+    /// vec.push_all([1, 2, 3]);
+    /// assert_eq!(vec.capacity(), 10);
     /// vec.shrink_to_fit();
+    /// assert_eq!(vec.capacity(), 3);
     /// ```
     #[stable]
     pub fn shrink_to_fit(&mut self) {
@@ -830,6 +833,7 @@ impl<T> Vec<T> {
     /// for num in vec.iter_mut() {
     ///     *num = 0;
     /// }
+    /// assert_eq!(vec, vec![0i, 0, 0]);
     /// ```
     #[inline]
     pub fn iter_mut<'a>(&'a mut self) -> MutItems<'a,T> {

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -636,7 +636,9 @@ impl<T> Vec<T> {
         }
     }
 
-    /// Shrinks the capacity of the vector as much as possible.
+    /// Shrinks the capacity of the vector as much as possible. It will drop
+    /// down as close as possible to the length but the allocator may still
+    /// inform the vector that there is space for a few more elements.
     ///
     /// # Example
     ///
@@ -645,7 +647,7 @@ impl<T> Vec<T> {
     /// vec.push_all([1, 2, 3]);
     /// assert_eq!(vec.capacity(), 10);
     /// vec.shrink_to_fit();
-    /// assert_eq!(vec.capacity(), 3);
+    /// assert!(vec.capacity() >= 3);
     /// ```
     #[stable]
     pub fn shrink_to_fit(&mut self) {


### PR DESCRIPTION
- shrink_to_fit example is now more clear by asserting the capacity value
- annotation [0, mid) changed for [0, mid]
