### PR TITLE
Don't use range as variable name

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -4225,10 +4225,10 @@ call the `.next()` method on repeatedly, and it gives us a sequence of things.
 Like this:
 
 ```{rust}
-let mut range = range(0i, 10i);
+let mut iterator = range(0i, 10i);
 
 loop {
-    match range.next() {
+    match iterator.next() {
         Some(x) => {
             println!("{}", x);
         },


### PR DESCRIPTION
If you're trying out more code snippets from http://doc.rust-lang.org/guide.html#iterators `let mut range = ...` is shadowing the `range()` function and therefore on further usage errors are thrown.
