### PR TITLE
Make MIN_ALIGN a const to allow better optimization

### DIFF
--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -112,10 +112,10 @@ unsafe fn exchange_free(ptr: *mut u8, size: uint, align: uint) {
 #[cfg(any(target_arch = "arm",
           target_arch = "mips",
           target_arch = "mipsel"))]
-static MIN_ALIGN: uint = 8;
+const MIN_ALIGN: uint = 8;
 #[cfg(any(target_arch = "x86",
           target_arch = "x86_64"))]
-static MIN_ALIGN: uint = 16;
+const MIN_ALIGN: uint = 16;
 
 #[cfg(jemalloc)]
 mod imp {


### PR DESCRIPTION
With MIN_ALIGN as a static, other crates don't have access to its value
at compile time, because it is an extern global. That means that the
checks against it can't be optimized out, which is rather unfortunate.
So let's make it a constant instead.
