### PR TITLE
libcore: Make fail handlers optional

### DIFF
--- a/src/libcore/failure.rs
+++ b/src/libcore/failure.rs
@@ -27,72 +27,74 @@
 //! necessary lang items for the compiler. All failure is funneled through this
 //! one function. Currently, the actual symbol is declared in the standard
 //! library, but the location of this may change over time.
+//!
+//! Users that have no use for formatted failure messages can define
+//! `cfg(no_fail_fmt)` to reduce their binary size by 1.5 kilobytes
+//! or so.
 
 #![allow(dead_code, missing_doc)]
 
-pub use failure::internal::{fail, fail_fmt};
+use fmt;
+use intrinsics;
 
 #[cfg(not(no_fail_fmt))]
-mod internal {
-    use fmt;
-    use intrinsics;
+#[cold] #[inline(never)] // this is the slow path, always
+#[lang="fail"]
+pub fn fail(expr_file_line: &(&'static str, &'static str, uint)) -> ! {
+    let (expr, file, line) = *expr_file_line;
+    let ref file_line = (file, line);
+    format_args!(|args| -> () {
+        fail_fmt(args, file_line);
+    }, "{}", expr);
 
-    #[cold] #[inline(never)] // this is the slow path, always
-    #[lang="fail"]
-    pub fn fail(expr_file_line: &(&'static str, &'static str, uint)) -> ! {
-        let (expr, file, line) = *expr_file_line;
-        let ref file_line = (file, line);
-        format_args!(|args| -> () {
-            fail_fmt(args, file_line);
-        }, "{}", expr);
-
-        unsafe { intrinsics::abort() }
-    }
-
-    #[cold] #[inline(never)]
-    #[lang="fail_bounds_check"]
-    fn fail_bounds_check(file_line: &(&'static str, uint),
-                         index: uint, len: uint) -> ! {
-        format_args!(|args| -> () {
-            fail_fmt(args, file_line);
-        }, "index out of bounds: the len is {} but the index is {}", len, index);
-        unsafe { intrinsics::abort() }
-    }
-
-    #[cold] #[inline(never)]
-    pub fn fail_fmt(fmt: &fmt::Arguments, file_line: &(&'static str, uint)) -> ! {
-        #[allow(ctypes)]
-        extern {
-            #[lang = "fail_fmt"]
-            fn fail_impl(fmt: &fmt::Arguments, file: &'static str,
-                            line: uint) -> !;
-        }
-
-        let (file, line) = *file_line;
-        unsafe { fail_impl(fmt, file, line) }
-    }
+    unsafe { intrinsics::abort() }
 }
 
 #[cfg(no_fail_fmt)]
-mod internal {
-    use fmt;
-    use intrinsics;
+#[cold] #[inline(never)] // this is the slow path, always
+#[lang="fail"]
+pub fn fail(expr_file_line: &(&'static str, &'static str, uint)) -> ! {
+    let (_, file, line) = *expr_file_line;
+    let ref file_line = (file, line);
+    format_args!(|args| -> () {
+        fail_fmt(args, file_line);
+    }, "");
 
-    #[cold] #[inline(never)] // this is the slow path, always
-    #[lang="fail"]
-    pub fn fail(_expr_file_line: &(&'static str, &'static str, uint)) -> ! {
-        unsafe { intrinsics::abort() }
-    }
+    unsafe { intrinsics::abort() }
+}
 
-    #[cold] #[inline(never)]
-    #[lang="fail_bounds_check"]
-    fn fail_bounds_check(_file_line: &(&'static str, uint),
-                         _index: uint, _len: uint) -> ! {
-        unsafe { intrinsics::abort() }
-    }
+#[cfg(not(no_fail_fmt))]
+#[cold] #[inline(never)]
+#[lang="fail_bounds_check"]
+fn fail_bounds_check(file_line: &(&'static str, uint),
+                     index: uint, len: uint) -> ! {
+    format_args!(|args| -> () {
+        fail_fmt(args, file_line);
+    }, "index out of bounds: the len is {} but the index is {}", len, index);
 
-    #[cold] #[inline(never)]
-    pub fn fail_fmt(_fmt: &fmt::Arguments, _file_line: &(&'static str, uint)) -> ! {
-        unsafe { intrinsics::abort() }
+    unsafe { intrinsics::abort() }
+}
+
+#[cfg(no_fail_fmt)]
+#[cold] #[inline(never)]
+#[lang="fail_bounds_check"]
+fn fail_bounds_check(file_line: &(&'static str, uint),
+                     _index: uint, _len: uint) -> ! {
+    format_args!(|args| -> () {
+        fail_fmt(args, file_line);
+    }, "");
+
+    unsafe { intrinsics::abort() }
+}
+
+#[cold] #[inline(never)]
+pub fn fail_fmt(fmt: &fmt::Arguments, file_line: &(&'static str, uint)) -> ! {
+    #[allow(ctypes)]
+    extern {
+        #[lang = "fail_fmt"]
+        fn fail_impl(fmt: &fmt::Arguments, file: &'static str,
+                        line: uint) -> !;
     }
+    let (file, line) = *file_line;
+    unsafe { fail_impl(fmt, file, line) }
 }


### PR DESCRIPTION
Some users, particularly those targeting embedded systems, would rather avoid depending on `fmt` due to its effect on code size. See #17886.
