### PR TITLE
check_static_recursion: Handle foreign items

### DIFF
--- a/src/librustc/middle/check_static_recursion.rs
+++ b/src/librustc/middle/check_static_recursion.rs
@@ -99,7 +99,17 @@ impl<'a, 'ast, 'v> Visitor<'v> for CheckItemRecursionVisitor<'a, 'ast> {
                     Some(&DefStatic(def_id, _)) |
                     Some(&DefConst(def_id)) if
                             ast_util::is_local(def_id) => {
-                        self.visit_item(&*self.ast_map.expect_item(def_id.node));
+                        match self.ast_map.get(def_id.node) {
+                          ast_map::NodeItem(item) =>
+                            self.visit_item(item),
+                          ast_map::NodeForeignItem(_) => {},
+                          _ => {
+                            self.sess.span_err(e.span,
+                              format!("expected item, found {}",
+                                      self.ast_map.node_to_string(def_id.node)).as_slice());
+                            return;
+                          },
+                        }
                     }
                     _ => ()
                 }

--- a/src/test/auxiliary/check_static_recursion_foreign_helper.rs
+++ b/src/test/auxiliary/check_static_recursion_foreign_helper.rs
@@ -1,0 +1,19 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Helper definition for test/run-pass/check-static-recursion-foreign.rs.
+
+#[crate_id = "check_static_recursion_foreign_helper"]
+#[crate_type = "lib"]
+
+extern crate libc;
+
+#[no_mangle]
+pub static test_static: libc::c_int = 0;

--- a/src/test/run-pass/check-static-recursion-foreign.rs
+++ b/src/test/run-pass/check-static-recursion-foreign.rs
@@ -1,0 +1,27 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Static recursion check shouldn't fail when given a foreign item (#18279)
+
+// aux-build:check_static_recursion_foreign_helper.rs
+extern crate check_static_recursion_foreign_helper;
+extern crate libc;
+
+use libc::c_int;
+
+#[link_name = "check_static_recursion_foreign_helper"]
+extern "C" {
+    #[allow(dead_code)]
+    static test_static: c_int;
+}
+
+static B: &'static c_int = &test_static;
+
+pub fn main() {}


### PR DESCRIPTION
I just found this patch which at some point solved a problem I encountered. Unfortunately I apparently dropped it before I managed to write a test case. I'll try to dig up the code that triggered the issue.
