### PR TITLE
Specify that Reader::read doesn't return 0.

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -535,20 +535,22 @@ pub trait Reader {
     // Only method which need to get implemented for this trait
 
     /// Read bytes, up to the length of `buf` and place them in `buf`.
-    /// Returns the number of bytes read. The number of bytes read may
-    /// be less than the number requested, even 0. Returns `Err` on EOF.
     ///
-    /// # Error
+    /// # Return value
     ///
-    /// If an error occurs during this I/O operation, then it is returned as
-    /// `Err(IoError)`. Note that end-of-file is considered an error, and can be
-    /// inspected for in the error's `kind` field. Also note that reading 0
-    /// bytes is not considered an error in all circumstances
+    /// If the length of `buf` is 0, the return value is unspecified.
+    ///
+    /// Otherwise, on success, the number of bytes read is returned. The number of bytes
+    /// read may be less than the number requested, but not 0.
+    ///
+    /// If an error occurs during the I/O operation, then it is returned as
+    /// `Err(IoError)`. Note that end-of-file is considered an error, and can be inspected
+    /// for in the error's `kind` field.
     ///
     /// # Implementation Note
     ///
-    /// When implementing this method on a new Reader, you are strongly encouraged
-    /// not to return 0 if you can avoid it.
+    /// If you've reached EOF, return `Err(EndOfFile)`. If no data is available and you
+    /// don't want to block, return `Err(ResourceUnavailable)`.
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint>;
 
     // Convenient helper methods based on the above methods


### PR DESCRIPTION
Reader is a trait for byte-oriented streams. Unlike with packet oriented
protocols such as UDP or lower level network traffic, there is no reason
for a read on a stream to ever return a zero bytes buffer.

If data is available, read shall return a suitable amount of it in the
buffer. If no data is available, read shall either block or signal a
condition via an Error.

Note that it is already impossible to use many Reader methods on packet
oriented protocols. E.g., consider reading an u64.
1) If a new packet is available, what should be done with the remainder
of the packet?
2) If we've stored a previous packet and there are still four bytes
available, should we a) attempt to read another packet and possibly
block and then combine the bytes into an 8 byte sequence, or b) return
an error?

Objects that implement packet oriented protocols or for which it makes
sense to return 0-sized reads should implement read methods that are
independent of the Reader trait.

This is a breaking change because there might be Reader implementations
that return 0, however, no such implementations are in the standard
library.

[breaking-change]

---

Note that the last paragraph is AFAIK true after https://github.com/rust-lang/rust/pull/18130

Closes https://github.com/rust-lang/rust/issues/18079
