### PR TITLE
Enable Android stack overflow messages

### DIFF
--- a/src/librustrt/stack_overflow.rs
+++ b/src/librustrt/stack_overflow.rs
@@ -62,7 +62,7 @@ pub unsafe fn report() {
 // It returns the guard page of the current task or 0 if that
 // guard page doesn't exist. None is returned if there's currently
 // no local task.
-#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
+#[cfg(any(windows, target_os = "linux", target_os = "android", target_os = "macos"))]
 unsafe fn get_task_guard_page() -> Option<uint> {
     let task: Option<*mut Task> = Local::try_unsafe_borrow();
 
@@ -167,7 +167,7 @@ mod imp {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
 mod imp {
     use core::prelude::*;
     use stack;
@@ -386,6 +386,7 @@ mod imp {
 }
 
 #[cfg(not(any(target_os = "linux",
+              target_os = "android",
               target_os = "macos",
               windows)))]
 mod imp {

--- a/src/librustrt/thread.rs
+++ b/src/librustrt/thread.rs
@@ -285,7 +285,7 @@ mod imp {
     pub type rust_thread = libc::pthread_t;
     pub type rust_thread_return = *mut u8;
 
-    #[cfg(all(not(target_os = "linux"), not(target_os = "macos")))]
+    #[cfg(all(not(target_os = "linux"), not(target_os = "macos"), not(target_os = "android")))]
     pub mod guard {
         pub unsafe fn current() -> uint {
             0
@@ -299,7 +299,7 @@ mod imp {
         }
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
     pub mod guard {
         use super::*;
         #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -489,7 +489,7 @@ mod imp {
         PTHREAD_STACK_MIN
     }
 
-    #[cfg(any(target_os = "linux"))]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     extern {
         pub fn pthread_self() -> libc::pthread_t;
         pub fn pthread_getattr_np(native: libc::pthread_t,

--- a/src/test/run-pass/out-of-stack-new-thread-no-split.rs
+++ b/src/test/run-pass/out-of-stack-new-thread-no-split.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//ignore-android
 //ignore-freebsd
 //ignore-ios
 //ignore-dragonfly

--- a/src/test/run-pass/out-of-stack-no-split.rs
+++ b/src/test/run-pass/out-of-stack-no-split.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//ignore-android
 //ignore-linux
 //ignore-freebsd
 //ignore-ios


### PR DESCRIPTION
I removed the usage of `signal` so this should work better for Android.
