### PR TITLE
Prevent pointer -> int casts in constexprs

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -36,6 +36,7 @@ register_diagnostics!(
     E0015,
     E0016,
     E0017,
+    E0018,
     E0019,
     E0020,
     E0022,

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -119,12 +119,18 @@ fn check_expr(v: &mut CheckCrateVisitor, e: &Expr) -> bool {
             }
         }
         ExprLit(_) => (),
-        ExprCast(_, _) => {
-            let ety = ty::expr_ty(v.tcx, e);
-            if !ty::type_is_numeric(ety) && !ty::type_is_unsafe_ptr(ety) {
+        ExprCast(ref from, _) => {
+            let toty = ty::expr_ty(v.tcx, e);
+            let fromty = ty::expr_ty(v.tcx, &**from);
+            if !ty::type_is_numeric(toty) && !ty::type_is_unsafe_ptr(toty) {
                 span_err!(v.tcx.sess, e.span, E0012,
                           "can not cast to `{}` in a constant expression",
-                          ppaux::ty_to_string(v.tcx, ety));
+                          ppaux::ty_to_string(v.tcx, toty));
+            }
+            if ty::type_is_unsafe_ptr(fromty) && ty::type_is_numeric(toty) {
+                span_err!(v.tcx.sess, e.span, E0018,
+                          "can not cast a pointer to an integer in a constant \
+                           expression");
             }
         }
         ExprPath(ref pth) => {

--- a/src/test/compile-fail/issue-18294.rs
+++ b/src/test/compile-fail/issue-18294.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    const X: u32 = 1;
+    const Y: uint = &X as *const u32 as uint; //~ ERROR E0018
+    println!("{}", Y);
+}


### PR DESCRIPTION
These cause issues, as addresses aren't fixed at compile-time.

Fixes #18294
