### PR TITLE
Add MemWriter::from_vec

### DIFF
--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -22,7 +22,7 @@ use slice;
 use slice::AsSlice;
 use vec::Vec;
 
-static BUF_CAPACITY: uint = 128;
+const BUF_CAPACITY: uint = 128;
 
 fn combine(seek: SeekStyle, cur: uint, end: uint, offset: i64) -> IoResult<u64> {
     // compute offset as signed and clamp to prevent overflow
@@ -71,7 +71,12 @@ impl MemWriter {
     /// the internal buffer.
     #[inline]
     pub fn with_capacity(n: uint) -> MemWriter {
-        MemWriter { buf: Vec::with_capacity(n) }
+        MemWriter::from_vec(Vec::with_capacity(n))
+    }
+    /// Create a new `MemWriter` that will append to an existing `Vec`.
+    #[inline]
+    pub fn from_vec(buf: Vec<u8>) -> MemWriter {
+        MemWriter { buf: buf }
     }
 
     /// Acquires an immutable reference to the underlying buffer of this


### PR DESCRIPTION
This is useful in cases where you're buffering and sending data in a loop, like this: https://github.com/sfackler/rust-postgres/blob/a480ec1cfb94a155dad64cfad821e4c7d1b8dccb/src/lib.rs#L1628-L1674
