### PR TITLE
Guide: Pointers: cruft removal + minor clarifications

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -3463,7 +3463,7 @@ note: previous borrow ends here
 
 This is a big error message. Let's dig into it for a moment. There are three
 parts: the error and two notes. The error says what we expected, we cannot have
-two pointers that point to the same memory.
+two mutable pointers that point to the same memory.
 
 The two notes give some extra context. Rust's error messages often contain this
 kind of extra information when the error is complex. Rust is telling us two
@@ -3762,7 +3762,7 @@ value that must persist as long as any of several referrers, read on.
 
 ## Rc and Arc
 
-Sometimes, you need a variable that is referenced from multiple places
+Sometimes you need a variable that is referenced from multiple places
 (immutably!), lasting as long as any of those places, and disappearing when it
 is no longer referenced. For instance, in a graph-like data structure, a node
 might be referenced from all of its neighbors. In this case, it is not possible
@@ -3858,7 +3858,7 @@ match x {
 ```
 
 If you're matching on an enum which has variants, you can use `..` to
-ignore the value in the variant:
+ignore the value and type in the variant:
 
 ```{rust}
 enum OptionalInt {

--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -3419,7 +3419,7 @@ let y = &mut x;
 Rust will complain:
 
 ```{ignore,notrust}
-6:19 error: cannot borrow immutable local variable `x` as mutable
+error: cannot borrow immutable local variable `x` as mutable
  let y = &mut x;
               ^
 ```
@@ -3734,10 +3734,10 @@ let y = &mut x;
 This gives us this error:
 
 ```{notrust,ignore}
-8:7 error: cannot use `*x` because it was mutably borrowed
+error: cannot use `*x` because it was mutably borrowed
  *x;
  ^~
- 6:19 note: borrow of `x` occurs here
+note: borrow of `x` occurs here
  let y = &mut x;
               ^
 ```
@@ -4530,8 +4530,8 @@ So this would give us the numbers from `2-100`. Well, almost! If you
 compile the example, you'll get a warning:
 
 ```{notrust,ignore}
-2:37 warning: unused result which must be used: iterator adaptors are lazy and
-              do nothing unless consumed, #[warn(unused_must_use)] on by default
+warning: unused result which must be used: iterator adaptors are lazy and
+         do nothing unless consumed, #[warn(unused_must_use)] on by default
  range(1i, 100i).map(|x| x + 1i);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```


### PR DESCRIPTION
This removes some leftover line-numbering cruft from elided error examples and brings some minor clarifications.

I’m not super happy about the ‘we cannot have two mutable pointers that point to the same memory’ wording (to the best of my understanding we can’t even have one mutable and one immutable), but other attempts to word this were derailing the flow a bit too much.
