### PR TITLE
debuginfo: Set RUST_TEST_TASKS to 1 again for LLDB tests

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -25,7 +25,7 @@ use std::io::fs;
 use std::from_str::FromStr;
 use getopts::{optopt, optflag, reqopt};
 use common::Config;
-use common::{Pretty, DebugInfoGdb, Codegen};
+use common::{Pretty, DebugInfoGdb, DebugInfoLldb, Codegen};
 use util::logv;
 use regex::Regex;
 
@@ -242,6 +242,16 @@ pub fn run_tests(config: &Config) {
         //so, we test 1 task at once.
         // also trying to isolate problems with adb_run_wrapper.sh ilooping
         os::setenv("RUST_TEST_TASKS","1");
+    }
+
+    match config.mode {
+        DebugInfoLldb => {
+            // Some older versions of LLDB seem to have problems with multiple
+            // instances running in parallel, so only run one test task at a
+            // time.
+            os::setenv("RUST_TEST_TASKS", "1");
+        }
+        _ => { /* proceed */ }
     }
 
     let opts = test_opts(config);


### PR DESCRIPTION
Let's try if not running LLDB tests in parallel solves the sporadic deadlocks we've seen since enabling the LLDB test suite. Running the tests in parallel has lead to unstable behaviour in the past (with LLDB versions below 310.x.x). Maybe our new minimum LLDB version isn't quite up to it either.

cc @alexcrichton 
