### PR TITLE
Preserve struct field pattern shorthand in the prettyprinter.

### DIFF
--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -421,7 +421,7 @@ fn construct_witness(cx: &MatchCheckCtxt, ctor: &Constructor,
                         node: FieldPat {
                             ident: Ident::new(field.name),
                             pat: pat,
-                            is_shorthand: true,
+                            is_shorthand: false,
                         }
                     }).collect();
                 let has_more_fields = field_pats.len() < pats_len;

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -341,7 +341,7 @@ pub fn const_expr_to_pat(tcx: &ty::ctxt, expr: &Expr) -> P<Pat> {
                 node: FieldPat {
                     ident: field.ident.node,
                     pat: const_expr_to_pat(tcx, &*field.expr),
-                    is_shorthand: true,
+                    is_shorthand: false,
                 },
             }).collect();
             PatStruct(path.clone(), field_pats, false)

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -1250,7 +1250,7 @@ impl<'a> TraitDef<'a> {
                 // id is guaranteed to be Some
                 codemap::Spanned {
                     span: pat.span,
-                    node: ast::FieldPat { ident: id.unwrap(), pat: pat, is_shorthand: true },
+                    node: ast::FieldPat { ident: id.unwrap(), pat: pat, is_shorthand: false },
                 }
             }).collect();
             cx.pat_struct(self.span, matching_path, field_pats)

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1983,8 +1983,10 @@ impl<'a> State<'a> {
                     Consistent, fields.as_slice(),
                     |s, f| {
                         try!(s.cbox(indent_unit));
-                        try!(s.print_ident(f.node.ident));
-                        try!(s.word_nbsp(":"));
+                        if !f.node.is_shorthand {
+                            try!(s.print_ident(f.node.ident));
+                            try!(s.word_nbsp(":"));
+                        }
                         try!(s.print_pat(&*f.node.pat));
                         s.end()
                     },

--- a/src/test/pretty/struct-pattern.rs
+++ b/src/test/pretty/struct-pattern.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// pp-exact
+// pretty-compare-only
+// Testing that shorthand struct patterns are preserved
+
+fn main() { let Foo { a, ref b, mut c, x: y, z: z } = foo; }


### PR DESCRIPTION
Use the `is_shorthand` field introduced by #17813 (ead6c4b) to make the prettyprinter output the shorthand form. Fixes a few places that set `is_shorthand: true` when the pattern is not a `PatIdent` with the same name as the field.

This fixes incorrect `non_shorthand_field_patterns` warnings when the shorthand is used in a quasiquote, e.g. in [rust-peg](https://github.com/kevinmehall/rust-peg/blob/69227a61f866590d4e849cfcd8f169fdc5ce59cb/src/translate.rs#L214).
