### PR TITLE
Don't throw away mutability of `&mut str` in astconv

### DIFF
--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -674,7 +674,7 @@ fn mk_pointer<'tcx, AC: AstConv<'tcx>, RS: RegionScope>(
                             return constr(ty::mk_str(tcx));
                         }
                         RPtr(r) => {
-                            return ty::mk_str_slice(tcx, r, ast::MutImmutable);
+                            return ty::mk_str_slice(tcx, r, a_seq_mutbl);
                         }
                     }
                 }

--- a/src/test/run-pass/issue-17361.rs
+++ b/src/test/run-pass/issue-17361.rs
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that astconv doesn't forget about mutability of &mut str
+
+fn main() {
+    fn foo<Sized? T>(_: &mut T) {}
+    let _f: fn(&mut str) = foo;
+}


### PR DESCRIPTION
Closes #17361
