### PR TITLE
Doc: Updates a little the make tips message

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,4 @@
-# Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+# Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.
 #
@@ -99,7 +99,7 @@
 # This is hardly all there is to know of The Rust Build System's
 # mysteries. The tale continues on the wiki[1][2].
 #
-# [1]: https://github.com/rust-lang/rust/wiki/Note-build-system
+# [1]: http://tomlee.co/2014/04/03/a-more-detailed-tour-of-the-rust-compiler/
 # [2]: https://github.com/rust-lang/rust/wiki/Note-testsuite
 #
 # If you really feel like getting your hands dirty, then:


### PR DESCRIPTION
The link to the more detailed tour of rustc, is not a link to the repo
so I don't know if it's ok, but it's the closest to the idea of a build
suite I could find.

Another solution might be to complete the link in the wiki, but I'm not familiar enough with the build suite to do that :/

Closes #17950
