### PR TITLE
bubble up out-of-memory errors from liballoc

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -11,8 +11,7 @@
 //! # The Rust core allocation library
 //!
 //! This is the lowest level library through which allocation in Rust can be
-//! performed where the allocation is assumed to succeed. This library will
-//! abort the process when allocation fails.
+//! performed.
 //!
 //! This library, like libcore, is not intended for general usage, but rather as
 //! a building block of other libraries. The types and interfaces in this
@@ -95,8 +94,10 @@ pub mod boxed;
 pub mod arc;
 pub mod rc;
 
-/// Common OOM routine used by liballoc
-fn oom() -> ! {
+/// Common out-of-memory routine
+#[cold]
+#[inline(never)]
+pub fn oom() -> ! {
     // FIXME(#14674): This really needs to do something other than just abort
     //                here, but any printing done must be *guaranteed* to not
     //                allocate.

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -31,6 +31,8 @@
 #![feature(unsafe_destructor)]
 #![allow(missing_docs)]
 
+extern crate alloc;
+
 use std::cell::{Cell, RefCell};
 use std::cmp;
 use std::intrinsics::{TyDesc, get_tydesc};
@@ -386,6 +388,7 @@ impl<T> TypedArenaChunk<T> {
         let size = calculate_size::<T>(capacity);
         let chunk = allocate(size, mem::min_align_of::<TypedArenaChunk<T>>())
                     as *mut TypedArenaChunk<T>;
+        if chunk.is_null() { alloc::oom() }
         (*chunk).next = next;
         (*chunk).capacity = capacity;
         chunk

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -629,6 +629,7 @@ impl<T> Vec<T> {
                                .expect("capacity overflow");
             unsafe {
                 self.ptr = alloc_or_realloc(self.ptr, self.cap * mem::size_of::<T>(), size);
+                if self.ptr.is_null() { ::alloc::oom() }
             }
             self.cap = capacity;
         }
@@ -666,6 +667,7 @@ impl<T> Vec<T> {
                                       self.cap * mem::size_of::<T>(),
                                       self.len * mem::size_of::<T>(),
                                       mem::min_align_of::<T>()) as *mut T;
+                if self.ptr.is_null() { ::alloc::oom() }
             }
             self.cap = self.len;
         }
@@ -988,6 +990,7 @@ impl<T> Vec<T> {
             if old_size > size { panic!("capacity overflow") }
             unsafe {
                 self.ptr = alloc_or_realloc(self.ptr, old_size, size);
+                if self.ptr.is_null() { ::alloc::oom() }
             }
             self.cap = max(self.cap, 2) * 2;
         }

--- a/src/librustrt/c_str.rs
+++ b/src/librustrt/c_str.rs
@@ -101,7 +101,7 @@ impl Clone for CString {
     fn clone(&self) -> CString {
         let len = self.len() + 1;
         let buf = unsafe { libc::malloc(len as libc::size_t) } as *mut libc::c_char;
-        if buf.is_null() { panic!("out of memory") }
+        if buf.is_null() { ::alloc::oom() }
         unsafe { ptr::copy_nonoverlapping_memory(buf, self.buf, len); }
         CString { buf: buf as *const libc::c_char, owns_buffer_: true }
     }
@@ -388,7 +388,7 @@ impl ToCStr for [u8] {
     unsafe fn to_c_str_unchecked(&self) -> CString {
         let self_len = self.len();
         let buf = libc::malloc(self_len as libc::size_t + 1) as *mut u8;
-        if buf.is_null() { panic!("out of memory") }
+        if buf.is_null() { ::alloc::oom() }
 
         ptr::copy_memory(buf, self.as_ptr(), self_len);
         *buf.offset(self_len as int) = 0;

--- a/src/librustrt/local_data.rs
+++ b/src/librustrt/local_data.rs
@@ -354,6 +354,7 @@ impl TLDValue {
         let box_ptr = unsafe {
             let allocation = heap::allocate(mem::size_of::<TLDValueBox<T>>(),
                                             mem::min_align_of::<TLDValueBox<T>>());
+            if allocation.is_null() { ::alloc::oom() }
             let value_box = allocation as *mut TLDValueBox<T>;
             ptr::write(value_box, TLDValueBox {
                 value: value,

--- a/src/librustrt/mutex.rs
+++ b/src/librustrt/mutex.rs
@@ -519,6 +519,7 @@ mod imp {
     use alloc::heap;
     use core::atomic;
     use core::ptr;
+    use core::ptr::RawPtr;
     use libc::{HANDLE, BOOL, LPSECURITY_ATTRIBUTES, c_void, DWORD, LPCSTR};
     use libc;
 
@@ -608,6 +609,7 @@ mod imp {
 
     pub unsafe fn init_lock() -> uint {
         let block = heap::allocate(CRIT_SECTION_SIZE, 8) as *mut c_void;
+        if block.is_null() { ::alloc::oom() }
         InitializeCriticalSectionAndSpinCount(block, SPIN_COUNT);
         return block as uint;
     }

--- a/src/libstd/c_vec.rs
+++ b/src/libstd/c_vec.rs
@@ -170,7 +170,7 @@ mod tests {
     fn malloc(n: uint) -> CVec<u8> {
         unsafe {
             let mem = libc::malloc(n as libc::size_t);
-            if mem.is_null() { panic!("out of memory") }
+            if mem.is_null() { ::alloc::oom() }
 
             CVec::new_with_dtor(mem as *mut u8, n,
                 proc() { libc::free(mem as *mut libc::c_void); })

--- a/src/libstd/collections/hashmap/table.rs
+++ b/src/libstd/collections/hashmap/table.rs
@@ -607,6 +607,7 @@ impl<K, V> RawTable<K, V> {
                 "capacity overflow");
 
         let buffer = allocate(size, malloc_alignment);
+        if buffer.is_null() { ::alloc::oom() }
 
         let hashes = buffer.offset(hash_offset as int) as *mut u64;
 

--- a/src/libsync/deque.rs
+++ b/src/libsync/deque.rs
@@ -353,6 +353,7 @@ impl<T: Send> Buffer<T> {
     unsafe fn new(log_size: uint) -> Buffer<T> {
         let size = buffer_alloc_size::<T>(log_size);
         let buffer = allocate(size, min_align_of::<T>());
+        if buffer.is_null() { ::alloc::oom() }
         Buffer {
             storage: buffer as *const T,
             log_size: log_size,

--- a/src/test/run-pass/realloc-16687.rs
+++ b/src/test/run-pass/realloc-16687.rs
@@ -49,6 +49,7 @@ unsafe fn test_triangle() -> bool {
         if PRINT { println!("allocate(size={:u} align={:u})", size, align); }
 
         let ret = heap::allocate(size, align);
+        if ret.is_null() { alloc::oom() }
 
         if PRINT { println!("allocate(size={:u} align={:u}) ret: 0x{:010x}",
                             size, align, ret as uint);
@@ -70,6 +71,7 @@ unsafe fn test_triangle() -> bool {
         }
 
         let ret = heap::reallocate(ptr, old_size, size, align);
+        if ret.is_null() { alloc::oom() }
 
         if PRINT {
             println!("reallocate(ptr=0x{:010x} old_size={:u} size={:u} align={:u}) \


### PR DESCRIPTION
This makes the low-level allocation API suitable for use cases where
out-of-memory conditions need to be handled.

Closes #18292

[breaking-change]
