### PR TITLE
Diagnostic: resolve bare fn in expected closure

### DIFF
--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -282,7 +282,9 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                             }
                             _ => {
                                 span_err!(self.tcx().sess, reason.span(self.tcx()), E0100,
-                                    "cannot coerce non-statically resolved bare fn");
+                                    "cannot coerce non-statically resolved bare fn to closure");
+                                span_help!(self.tcx().sess, reason.span(self.tcx()),
+                                    "consider embedding the function in a closure");
                             }
                         }
 

--- a/src/libsyntax/diagnostics/macros.rs
+++ b/src/libsyntax/diagnostics/macros.rs
@@ -40,6 +40,13 @@ macro_rules! span_note(
 )
 
 #[macro_export]
+macro_rules! span_help(
+    ($session:expr, $span:expr, $($message:tt)*) => ({
+        ($session).span_help($span, format!($($message)*).as_slice())
+    })
+)
+
+#[macro_export]
 macro_rules! register_diagnostics(
     ($($code:tt),*) => (
         $(register_diagnostic!($code))*

--- a/src/test/compile-fail/coerce-bare-fn-to-closure-and-proc.rs
+++ b/src/test/compile-fail/coerce-bare-fn-to-closure-and-proc.rs
@@ -13,7 +13,9 @@ fn foo() {}
 fn main() {
     let f = foo;
     let f_closure: || = f;
-    //~^ ERROR: cannot coerce non-statically resolved bare fn
+    //~^ ERROR: cannot coerce non-statically resolved bare fn to closure
+    //~^ HELP: consider embedding the function in a closure
     let f_proc: proc() = f;
-    //~^ ERROR: cannot coerce non-statically resolved bare fn
+    //~^ ERROR: cannot coerce non-statically resolved bare fn to closure
+    //~^ HELP: consider embedding the function in a closure
 }


### PR DESCRIPTION
Closes #15273 (I did not find how to get the identifier in the message :/ ... if someone knows how to do that I would be happy to rebase)

Also creates the span_help! macro associated with #18126
