### PR TITLE
Revert "enable parallel codegen by default"

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -157,13 +157,6 @@ RUSTFLAGS_STAGE1 += -C prefer-dynamic
 # by not emitting them.
 RUSTFLAGS_STAGE0 += -Z no-landing-pads
 
-# Go fast for stage0, and also for stage1/stage2 if optimization is off.
-RUSTFLAGS_STAGE0 += -C codegen-units=4
-ifdef CFG_DISABLE_OPTIMIZE
-	RUSTFLAGS_STAGE1 += -C codegen-units=4
-	RUSTFLAGS_STAGE2 += -C codegen-units=4
-endif
-
 # platform-specific auto-configuration
 include $(CFG_SRC_DIR)mk/platform.mk
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -633,10 +633,6 @@ CTEST_RUSTC_FLAGS := $$(subst -O,,$$(CTEST_RUSTC_FLAGS))
 ifndef CFG_DISABLE_OPTIMIZE_TESTS
 CTEST_RUSTC_FLAGS += -O
 endif
-# Force codegen-units=1 for compiletest tests.  compiletest does its own
-# parallelization internally, so rustc's default codegen-units=2 will actually
-# slow things down.
-CTEST_RUSTC_FLAGS += -C codegen-units=1
 
 
 CTEST_COMMON_ARGS$(1)-T-$(2)-H-$(3) := \

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -780,20 +780,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         early_warn("the --crate-file-name argument has been renamed to \
                     --print-file-name");
     }
-
-    let mut cg = build_codegen_options(matches);
-
-    if cg.codegen_units == 0 {
-        match opt_level {
-            // `-C lto` doesn't work with multiple codegen units.
-            _ if cg.lto => cg.codegen_units = 1,
-
-            No | Less => cg.codegen_units = 2,
-            Default | Aggressive => cg.codegen_units = 1,
-        }
-    }
-    let cg = cg;
-
+    let cg = build_codegen_options(matches);
 
     if !cg.remark.is_empty() && debuginfo == NoDebugInfo {
         early_warn("-C remark will not show source locations without --debuginfo");


### PR DESCRIPTION
This reverts commit c245c5bbad10923b47c9f66d5f0da2913ef11a38.

Parallel code generation generates invalid code for librand, which is
caught by recent versions of binutils.
