### PR TITLE
debuginfo: Make GDB tests use line breakpoints like done in LLDB tests.

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -364,7 +364,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
         commands,
         check_lines,
         use_gdb_pretty_printer,
-        ..
+        breakpoint_lines
     } = parse_debugger_commands(testfile, "gdb");
     let mut cmds = commands.connect("\n");
 
@@ -535,10 +535,21 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                 }
             }
 
+            // The following line actually doesn't have to do anything with
+            // pretty printing, it just tells GDB to print values on one line:
+            script_str.push_str("set print pretty off\n");
+
             // Load the target executable
             script_str.push_str(format!("file {}\n",
                                         exe_file.as_str().unwrap().replace("\\", "\\\\"))
                                     .as_slice());
+
+            // Add line breakpoints
+            for line in breakpoint_lines.iter() {
+                script_str.push_str(format!("break '{}':{}\n",
+                                            testfile.filename_display(),
+                                            *line)[]);
+            }
 
             script_str.push_str(cmds.as_slice());
             script_str.push_str("quit\n");

--- a/src/test/debuginfo/basic-types-globals-metadata.rs
+++ b/src/test/debuginfo/basic-types-globals-metadata.rs
@@ -13,9 +13,7 @@
 // min-lldb-version: 310
 
 // compile-flags:-g
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 // gdb-command:whatis 'basic-types-globals-metadata::B'
 // gdb-check:type = bool
 // gdb-command:whatis 'basic-types-globals-metadata::I'
@@ -66,7 +64,7 @@ static F32: f32 = 2.5;
 static F64: f64 = 3.5;
 
 fn main() {
-    _zzz();
+    _zzz(); // #break
 
     let a = (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F32, F64);
 }

--- a/src/test/debuginfo/basic-types-globals-metadata.rs
+++ b/src/test/debuginfo/basic-types-globals-metadata.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 // min-lldb-version: 310
 

--- a/src/test/debuginfo/basic-types-globals.rs
+++ b/src/test/debuginfo/basic-types-globals.rs
@@ -14,7 +14,6 @@
 // about UTF-32 character encoding and will print a rust char as only
 // its numerical value.
 
-// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 // min-lldb-version: 310
 

--- a/src/test/debuginfo/basic-types-globals.rs
+++ b/src/test/debuginfo/basic-types-globals.rs
@@ -19,9 +19,7 @@
 // min-lldb-version: 310
 
 // compile-flags:-g
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 // gdb-command:print 'basic-types-globals::B'
 // gdb-check:$1 = false
 // gdb-command:print 'basic-types-globals::I'
@@ -70,7 +68,7 @@ static F32: f32 = 2.5;
 static F64: f64 = 3.5;
 
 fn main() {
-    _zzz();
+    _zzz(); // #break
 
     let a = (B, I, C, I8, I16, I32, I64, U, U8, U16, U32, U64, F32, F64);
 }

--- a/src/test/debuginfo/basic-types-metadata.rs
+++ b/src/test/debuginfo/basic-types-metadata.rs
@@ -12,9 +12,7 @@
 // min-lldb-version: 310
 
 // compile-flags:-g
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 // gdb-command:whatis unit
 // gdb-check:type = ()
 // gdb-command:whatis b
@@ -67,7 +65,7 @@ fn main() {
     let u64: u64 = 64;
     let f32: f32 = 2.5;
     let f64: f64 = 3.5;
-    _zzz();
+    _zzz(); // #break
     if 1i == 1 { _yyy(); }
 }
 

--- a/src/test/debuginfo/basic-types-mut-globals.rs
+++ b/src/test/debuginfo/basic-types-mut-globals.rs
@@ -14,7 +14,6 @@
 // about UTF-32 character encoding and will print a rust char as only
 // its numerical value.
 
-// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 // min-lldb-version: 310
 

--- a/src/test/debuginfo/basic-types-mut-globals.rs
+++ b/src/test/debuginfo/basic-types-mut-globals.rs
@@ -19,9 +19,8 @@
 // min-lldb-version: 310
 
 // compile-flags:-g
-// gdb-command:rbreak zzz
+
 // gdb-command:run
-// gdb-command:finish
 
 // Check initializers
 // gdb-command:print 'basic-types-mut-globals::B'
@@ -84,9 +83,6 @@
 // gdb-command:print 'basic-types-mut-globals'::F64
 // gdb-check:$28 = 9.25
 
-// gdb-command:detach
-// gdb-command:quit
-
 #![allow(unused_variables)]
 
 static mut B: bool = false;
@@ -105,7 +101,7 @@ static mut F32: f32 = 2.5;
 static mut F64: f64 = 3.5;
 
 fn main() {
-    _zzz();
+    _zzz(); // #break
 
     unsafe {
         B = true;
@@ -124,7 +120,7 @@ fn main() {
         F64 = 9.25;
     }
 
-    _zzz();
+    _zzz(); // #break
 }
 
 fn _zzz() {()}

--- a/src/test/debuginfo/basic-types.rs
+++ b/src/test/debuginfo/basic-types.rs
@@ -21,9 +21,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 // gdb-command:print b
 // gdb-check:$1 = false
 // gdb-command:print i

--- a/src/test/debuginfo/borrowed-basic.rs
+++ b/src/test/debuginfo/borrowed-basic.rs
@@ -18,9 +18,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 // gdb-command:print *bool_ref
 // gdb-check:$1 = true
 

--- a/src/test/debuginfo/borrowed-c-style-enum.rs
+++ b/src/test/debuginfo/borrowed-c-style-enum.rs
@@ -15,9 +15,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print *the_a_ref
 // gdb-check:$1 = TheA

--- a/src/test/debuginfo/borrowed-enum.rs
+++ b/src/test/debuginfo/borrowed-enum.rs
@@ -16,9 +16,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print *the_a_ref
 // gdb-check:$1 = {{RUST$ENUM$DISR = TheA, x = 0, y = 8970181431921507452}, {RUST$ENUM$DISR = TheA, 0, 2088533116, 2088533116}}

--- a/src/test/debuginfo/borrowed-struct.rs
+++ b/src/test/debuginfo/borrowed-struct.rs
@@ -14,9 +14,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print *stack_val_ref
 // gdb-check:$1 = {x = 10, y = 23.5}

--- a/src/test/debuginfo/borrowed-tuple.rs
+++ b/src/test/debuginfo/borrowed-tuple.rs
@@ -15,9 +15,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print *stack_val_ref
 // gdb-check:$1 = {-14, -19}

--- a/src/test/debuginfo/borrowed-unique-basic.rs
+++ b/src/test/debuginfo/borrowed-unique-basic.rs
@@ -18,9 +18,8 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
+
 // gdb-command:print *bool_ref
 // gdb-check:$1 = true
 

--- a/src/test/debuginfo/box.rs
+++ b/src/test/debuginfo/box.rs
@@ -15,10 +15,8 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:set print pretty off
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
+
 // gdb-command:print *a
 // gdb-check:$1 = 1
 // gdb-command:print *b

--- a/src/test/debuginfo/boxed-struct.rs
+++ b/src/test/debuginfo/boxed-struct.rs
@@ -15,9 +15,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print *unique
 // gdb-check:$1 = {x = 99, y = 999, z = 9999, w = 99999}

--- a/src/test/debuginfo/by-value-non-immediate-argument.rs
+++ b/src/test/debuginfo/by-value-non-immediate-argument.rs
@@ -16,15 +16,12 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print s
 // gdb-check:$1 = {a = 1, b = 2.5}
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$2 = {a = 3, b = 4.5}
 // gdb-command:print y
@@ -33,17 +30,14 @@
 // gdb-check:$4 = 6.5
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print a
 // gdb-check:$5 = {7, 8, 9.5, 10.5}
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print a
 // gdb-check:$6 = {11.5, 12.5, 13, 14}
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$7 = {{RUST$ENUM$DISR = Case1, x = 0, y = 8970181431921507452}, {RUST$ENUM$DISR = Case1, 0, 2088533116, 2088533116}}
 // gdb-command:continue

--- a/src/test/debuginfo/by-value-self-argument-in-trait-impl.rs
+++ b/src/test/debuginfo/by-value-self-argument-in-trait-impl.rs
@@ -15,20 +15,16 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$1 = 1111
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$2 = {x = 2222, y = 3333}
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$3 = {4444.5, 5555, 6666, 7777.5}
 // gdb-command:continue

--- a/src/test/debuginfo/c-style-enum-in-composite.rs
+++ b/src/test/debuginfo/c-style-enum-in-composite.rs
@@ -16,9 +16,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print tuple_interior_padding
 // gdb-check:$1 = {0, OneHundred}

--- a/src/test/debuginfo/c-style-enum.rs
+++ b/src/test/debuginfo/c-style-enum.rs
@@ -16,8 +16,6 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
-
 // gdb-command:print 'c-style-enum::SINGLE_VARIANT'
 // gdb-check:$1 = TheOnlyVariant
 
@@ -40,7 +38,6 @@
 // gdb-check:$7 = OneHundred
 
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print auto_one
 // gdb-check:$8 = One

--- a/src/test/debuginfo/c-style-enum.rs
+++ b/src/test/debuginfo/c-style-enum.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 // min-lldb-version: 310
 

--- a/src/test/debuginfo/closure-in-generic-function.rs
+++ b/src/test/debuginfo/closure-in-generic-function.rs
@@ -15,17 +15,14 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$1 = 0.5
 // gdb-command:print y
 // gdb-check:$2 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print *x
 // gdb-check:$3 = 29
 // gdb-command:print *y

--- a/src/test/debuginfo/destructured-fn-argument.rs
+++ b/src/test/debuginfo/destructured-fn-argument.rs
@@ -15,17 +15,14 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print a
 // gdb-check:$1 = 1
 // gdb-command:print b
 // gdb-check:$2 = false
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print a
 // gdb-check:$3 = 2
 // gdb-command:print b
@@ -34,14 +31,12 @@
 // gdb-check:$5 = 4
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print a
 // gdb-check:$6 = 5
 // gdb-command:print b
 // gdb-check:$7 = {6, 7}
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print h
 // gdb-check:$8 = 8
 // gdb-command:print i
@@ -50,26 +45,22 @@
 // gdb-check:$10 = 11
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print k
 // gdb-check:$11 = 12
 // gdb-command:print l
 // gdb-check:$12 = 13
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print m
 // gdb-check:$13 = 14
 // gdb-command:print n
 // gdb-check:$14 = 16
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print o
 // gdb-check:$15 = 18
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print p
 // gdb-check:$16 = 19
 // gdb-command:print q
@@ -78,14 +69,12 @@
 // gdb-check:$18 = {a = 21, b = 22}
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print s
 // gdb-check:$19 = 24
 // gdb-command:print t
 // gdb-check:$20 = 23
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print u
 // gdb-check:$21 = 25
 // gdb-command:print v
@@ -106,68 +95,56 @@
 // gdb-check:$29 = 33
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print aa
 // gdb-check:$30 = {34, 35}
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print bb
 // gdb-check:$31 = {36, 37}
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print cc
 // gdb-check:$32 = 38
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print dd
 // gdb-check:$33 = {40, 41, 42}
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print *ee
 // gdb-check:$34 = {43, 44, 45}
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print *ff
 // gdb-check:$35 = 46
 // gdb-command:print gg
 // gdb-check:$36 = {47, 48}
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print *hh
 // gdb-check:$37 = 50
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print ii
 // gdb-check:$38 = 51
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print *jj
 // gdb-check:$39 = 52
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print kk
 // gdb-check:$40 = 53
 // gdb-command:print ll
 // gdb-check:$41 = 54
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print mm
 // gdb-check:$42 = 55
 // gdb-command:print *nn
 // gdb-check:$43 = 56
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print oo
 // gdb-check:$44 = 57
 // gdb-command:print pp
@@ -176,7 +153,6 @@
 // gdb-check:$46 = 59
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print rr
 // gdb-check:$47 = 60
 // gdb-command:print ss
@@ -187,6 +163,7 @@
 
 
 // === LLDB TESTS ==================================================================================
+
 // lldb-command:run
 
 // lldb-command:print a

--- a/src/test/debuginfo/destructured-local.rs
+++ b/src/test/debuginfo/destructured-local.rs
@@ -15,9 +15,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print a
 // gdb-check:$1 = 1

--- a/src/test/debuginfo/evec-in-struct.rs
+++ b/src/test/debuginfo/evec-in-struct.rs
@@ -15,10 +15,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:set print pretty off
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print no_padding1
 // gdb-check:$1 = {x = {0, 1, 2}, y = -3, z = {4.5, 5.5}}

--- a/src/test/debuginfo/function-arg-initialization.rs
+++ b/src/test/debuginfo/function-arg-initialization.rs
@@ -15,21 +15,8 @@
 // first line of the function, that is if the function prologue has already been executed at the
 // first line. Note that because of the __morestack part of the prologue GDB incorrectly breaks at
 // before the arguments have been properly loaded when setting the breakpoint via the function name.
-// Therefore the setup here sets them using line numbers (so be careful when changing this file).
 
 // compile-flags:-g
-// gdb-command:set print pretty off
-// gdb-command:break function-arg-initialization.rs:244
-// gdb-command:break function-arg-initialization.rs:259
-// gdb-command:break function-arg-initialization.rs:263
-// gdb-command:break function-arg-initialization.rs:267
-// gdb-command:break function-arg-initialization.rs:271
-// gdb-command:break function-arg-initialization.rs:275
-// gdb-command:break function-arg-initialization.rs:279
-// gdb-command:break function-arg-initialization.rs:283
-// gdb-command:break function-arg-initialization.rs:287
-// gdb-command:break function-arg-initialization.rs:295
-// gdb-command:break function-arg-initialization.rs:302
 
 // === GDB TESTS ===================================================================================
 
@@ -241,7 +228,7 @@
 
 
 fn immediate_args(a: int, b: bool, c: f64) {
-    () // #break
+    ::std::io::print("") // #break
 }
 
 struct BigStruct {
@@ -256,15 +243,17 @@ struct BigStruct {
 }
 
 fn non_immediate_args(a: BigStruct, b: BigStruct) {
-    () // #break
+    ::std::io::print("") // #break
 }
 
 fn binding(a: i64, b: u64, c: f64) {
     let x = 0i; // #break
+    ::std::io::print("")
 }
 
 fn assignment(mut a: u64, b: u64, c: f64) {
     a = b; // #break
+    ::std::io::print("")
 }
 
 fn function_call(x: u64, y: u64, z: f64) {

--- a/src/test/debuginfo/function-arguments.rs
+++ b/src/test/debuginfo/function-arguments.rs
@@ -15,23 +15,19 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print x
 // gdb-check:$1 = 111102
 // gdb-command:print y
 // gdb-check:$2 = true
-
 // gdb-command:continue
-// gdb-command:finish
 
 // gdb-command:print a
 // gdb-check:$3 = 2000
 // gdb-command:print b
 // gdb-check:$4 = 3000
-
+// gdb-command:continue
 
 // === LLDB TESTS ==================================================================================
 

--- a/src/test/debuginfo/function-prologue-stepping-no-stack-check.rs
+++ b/src/test/debuginfo/function-prologue-stepping-no-stack-check.rs
@@ -22,7 +22,6 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:set print pretty off
 // gdb-command:rbreak immediate_args
 // gdb-command:rbreak binding
 // gdb-command:rbreak assignment
@@ -249,7 +248,7 @@
 
 #[no_stack_check]
 fn immediate_args(a: int, b: bool, c: f64) {
-    ()
+    ::std::io::print("");
 }
 
 struct BigStruct {
@@ -265,17 +264,19 @@ struct BigStruct {
 
 #[no_stack_check]
 fn non_immediate_args(a: BigStruct, b: BigStruct) {
-    ()
+    ::std::io::print("");
 }
 
 #[no_stack_check]
 fn binding(a: i64, b: u64, c: f64) {
     let x = 0i;
+    ::std::io::print("");
 }
 
 #[no_stack_check]
 fn assignment(mut a: u64, b: u64, c: f64) {
     a = b;
+    ::std::io::print("");
 }
 
 #[no_stack_check]

--- a/src/test/debuginfo/gdb-pretty-struct-and-enums-pre-gdb-7-7.rs
+++ b/src/test/debuginfo/gdb-pretty-struct-and-enums-pre-gdb-7-7.rs
@@ -19,13 +19,7 @@
 // compile-flags:-g
 // gdb-use-pretty-printer
 
-// The following line actually doesn't have to do anything with pretty printing,
-// it just tells GDB to print values on one line:
-// gdb-command: set print pretty off
-
-// gdb-command: rbreak zzz
 // gdb-command: run
-// gdb-command: finish
 
 // gdb-command: print regular_struct
 // gdb-check:$1 = RegularStruct = {the_first_field = 101, the_second_field = 102.5, the_third_field = false}
@@ -70,7 +64,7 @@ fn main() {
     let c_style_enum2 = CStyleEnumVar2;
     let c_style_enum3 = CStyleEnumVar3;
 
-    zzz();
+    zzz(); // #break
 }
 
 fn zzz() { () }

--- a/src/test/debuginfo/gdb-pretty-struct-and-enums.rs
+++ b/src/test/debuginfo/gdb-pretty-struct-and-enums.rs
@@ -20,13 +20,7 @@
 // case the test runner to ignore this test if an older GDB version is used:
 // min-gdb-version 7.7
 
-// The following line actually doesn't have to do anything with pretty printing,
-// it just tells GDB to print values on one line:
-// gdb-command: set print pretty off
-
-// gdb-command: rbreak zzz
 // gdb-command: run
-// gdb-command: finish
 
 // gdb-command: print regular_struct
 // gdb-check:$1 = RegularStruct = {the_first_field = 101, the_second_field = 102.5, the_third_field = false, the_fourth_field = "I'm so pretty, oh so pretty..."}
@@ -167,7 +161,7 @@ fn main() {
         }
     };
 
-    zzz();
+    zzz(); // #break
 }
 
 fn zzz() { () }

--- a/src/test/debuginfo/generic-function.rs
+++ b/src/test/debuginfo/generic-function.rs
@@ -15,10 +15,8 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print *t0
 // gdb-check:$1 = 1
 // gdb-command:print *t1
@@ -27,7 +25,6 @@
 // gdb-check:$3 = {{1, 2.5}, {2.5, 1}}
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print *t0
 // gdb-check:$4 = 3.5
 // gdb-command:print *t1
@@ -36,7 +33,6 @@
 // gdb-check:$6 = {{3.5, 4}, {4, 3.5}}
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print *t0
 // gdb-check:$7 = 5
 // gdb-command:print *t1

--- a/src/test/debuginfo/generic-functions-nested.rs
+++ b/src/test/debuginfo/generic-functions-nested.rs
@@ -15,31 +15,26 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$1 = -1
 // gdb-command:print y
 // gdb-check:$2 = 1
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$3 = -1
 // gdb-command:print y
 // gdb-check:$4 = 2.5
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$5 = -2.5
 // gdb-command:print y
 // gdb-check:$6 = 1
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$7 = -2.5
 // gdb-command:print y

--- a/src/test/debuginfo/generic-method-on-generic-struct.rs
+++ b/src/test/debuginfo/generic-method-on-generic-struct.rs
@@ -15,11 +15,9 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // STACK BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$1 = {x = {8888, -8888}}
 // gdb-command:print arg1
@@ -29,7 +27,6 @@
 // gdb-command:continue
 
 // STACK BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$4 = {x = {8888, -8888}}
 // gdb-command:print arg1
@@ -39,7 +36,6 @@
 // gdb-command:continue
 
 // OWNED BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$7 = {x = 1234.5}
 // gdb-command:print arg1
@@ -49,7 +45,6 @@
 // gdb-command:continue
 
 // OWNED BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$10 = {x = 1234.5}
 // gdb-command:print arg1
@@ -59,7 +54,6 @@
 // gdb-command:continue
 
 // OWNED MOVED
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$13 = {x = 1234.5}
 // gdb-command:print arg1

--- a/src/test/debuginfo/generic-static-method-on-struct-and-enum.rs
+++ b/src/test/debuginfo/generic-static-method-on-struct-and-enum.rs
@@ -13,11 +13,9 @@
 
 // compile-flags:-g
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // STRUCT
-// gdb-command:finish
 // gdb-command:print arg1
 // gdb-check:$1 = 1
 // gdb-command:print arg2
@@ -25,7 +23,6 @@
 // gdb-command:continue
 
 // ENUM
-// gdb-command:finish
 // gdb-command:print arg1
 // gdb-check:$3 = -3
 // gdb-command:print arg2
@@ -43,7 +40,7 @@ struct Struct {
 impl Struct {
 
     fn static_method<T1, T2>(arg1: T1, arg2: T2) -> int {
-        zzz();
+        zzz(); // #break
         return 0;
     }
 }
@@ -57,7 +54,7 @@ enum Enum {
 impl Enum {
 
     fn static_method<T1, T2, T3>(arg1: T1, arg2: T2, arg3: T3) -> int {
-        zzz();
+        zzz(); // #break
         return 1;
     }
 }

--- a/src/test/debuginfo/generic-struct-style-enum.rs
+++ b/src/test/debuginfo/generic-struct-style-enum.rs
@@ -15,9 +15,7 @@
 // compile-flags:-g
 
 // gdb-command:set print union on
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print case1
 // gdb-check:$1 = {{RUST$ENUM$DISR = Case1, a = 0, b = 31868, c = 31868, d = 31868, e = 31868}, {RUST$ENUM$DISR = Case1, a = 0, b = 2088533116, c = 2088533116}, {RUST$ENUM$DISR = Case1, a = 0, b = 8970181431921507452}}
@@ -76,7 +74,7 @@ fn main() {
 
     let univariant = TheOnlyCase { a: -1i };
 
-    zzz();
+    zzz(); // #break
 }
 
 fn zzz() {()}

--- a/src/test/debuginfo/generic-struct.rs
+++ b/src/test/debuginfo/generic-struct.rs
@@ -16,10 +16,8 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print int_int
 // gdb-check:$1 = {key = 0, value = 1}
 // gdb-command:print int_float

--- a/src/test/debuginfo/generic-trait-generic-static-default-method.rs
+++ b/src/test/debuginfo/generic-trait-generic-static-default-method.rs
@@ -11,17 +11,14 @@
 // except according to those terms.
 
 // compile-flags:-g
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print arg1
 // gdb-check:$1 = 1000
 // gdb-command:print *arg2
 // gdb-check:$2 = {1, 2.5}
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print arg1
 // gdb-check:$3 = 2000
 // gdb-command:print *arg2
@@ -35,7 +32,7 @@ struct Struct {
 
 trait Trait<T1> {
     fn generic_static_default_method<T2>(arg1: int, arg2: &(T1, T2)) -> int {
-        zzz();
+        zzz(); // #break
         arg1
     }
 }

--- a/src/test/debuginfo/generic-tuple-style-enum.rs
+++ b/src/test/debuginfo/generic-tuple-style-enum.rs
@@ -17,9 +17,7 @@
 // === GDB TESTS ===================================================================================
 
 // gdb-command:set print union on
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print case1
 // gdb-check:$1 = {{RUST$ENUM$DISR = Case1, 0, 31868, 31868, 31868, 31868}, {RUST$ENUM$DISR = Case1, 0, 2088533116, 2088533116}, {RUST$ENUM$DISR = Case1, 0, 8970181431921507452}}

--- a/src/test/debuginfo/include_string.rs
+++ b/src/test/debuginfo/include_string.rs
@@ -12,9 +12,7 @@
 // min-lldb-version: 310
 
 // compile-flags:-g
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 // gdb-command:print string1.length
 // gdb-check:$1 = 48
 // gdb-command:print string2.length

--- a/src/test/debuginfo/issue12886.rs
+++ b/src/test/debuginfo/issue12886.rs
@@ -13,7 +13,7 @@
 // ignore-lldb
 
 // compile-flags:-g
-// gdb-command:break issue12886.rs:31
+
 // gdb-command:run
 // gdb-command:next
 // gdb-check:[...]32[...]s
@@ -22,13 +22,13 @@
 // IF YOU MODIFY THIS FILE, BE CAREFUL TO ADAPT THE LINE NUMBERS IN THE DEBUGGER COMMANDS
 
 // This test makes sure that gdb does not set unwanted breakpoints in inlined functions. If a
-// breakpoint existed in unwrap(), then calling `next` would (when stopped at line 31) stop
+// breakpoint existed in unwrap(), then calling `next` would (when stopped at `let s = ...`) stop
 // in unwrap() instead of stepping over the function invocation. By making sure that `s` is
 // contained in the output, after calling `next` just once, we can be sure that we did not stop in
 // unwrap(). (The testing framework doesn't allow for checking that some text is *not* contained in
 // the output, which is why we have to make the test in this kind of roundabout way)
 fn bar() -> int {
-    let s = Some(5).unwrap();
+    let s = Some(5).unwrap(); // #break
     s
 }
 

--- a/src/test/debuginfo/issue13213.rs
+++ b/src/test/debuginfo/issue13213.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-android: FIXME(#10381)
-// ignore-lldb
+// min-lldb-version: 310
 
 // aux-build:issue13213aux.rs
 extern crate issue13213aux;
@@ -21,7 +21,5 @@ extern crate issue13213aux;
 // be available because they have been optimized out from the exporting crate.
 fn main() {
     let b: issue13213aux::S = issue13213aux::A;
-    zzz();
+    ::std::io::println("Nothing to do here...");
 }
-
-fn zzz() {()}

--- a/src/test/debuginfo/issue14411.rs
+++ b/src/test/debuginfo/issue14411.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-android: FIXME(#10381)
-// ignore-lldb
+// min-lldb-version: 310
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/issue7712.rs
+++ b/src/test/debuginfo/issue7712.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:--debuginfo=1
-// ignore-lldb
+// min-lldb-version: 310
 
 pub trait TraitWithDefaultMethod {
     fn method(self) {

--- a/src/test/debuginfo/lexical-scope-in-for-loop.rs
+++ b/src/test/debuginfo/lexical-scope-in-for-loop.rs
@@ -16,44 +16,36 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // FIRST ITERATION
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$1 = 1
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$2 = -1
 // gdb-command:continue
 
 // SECOND ITERATION
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$3 = 2
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$4 = -2
 // gdb-command:continue
 
 // THIRD ITERATION
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$5 = 3
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$6 = -3
 // gdb-command:continue
 
 // AFTER LOOP
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$7 = 1000000
 // gdb-command:continue

--- a/src/test/debuginfo/lexical-scope-in-if.rs
+++ b/src/test/debuginfo/lexical-scope-in-if.rs
@@ -15,11 +15,9 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // BEFORE if
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$1 = 999
 // gdb-command:print y
@@ -27,7 +25,6 @@
 // gdb-command:continue
 
 // AT BEGINNING of 'then' block
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$3 = 999
 // gdb-command:print y
@@ -35,7 +32,6 @@
 // gdb-command:continue
 
 // AFTER 1st redeclaration of 'x'
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$5 = 1001
 // gdb-command:print y
@@ -43,7 +39,6 @@
 // gdb-command:continue
 
 // AFTER 2st redeclaration of 'x'
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$7 = 1002
 // gdb-command:print y
@@ -51,7 +46,6 @@
 // gdb-command:continue
 
 // AFTER 1st if expression
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$9 = 999
 // gdb-command:print y
@@ -59,7 +53,6 @@
 // gdb-command:continue
 
 // BEGINNING of else branch
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$11 = 999
 // gdb-command:print y
@@ -67,7 +60,6 @@
 // gdb-command:continue
 
 // BEGINNING of else branch
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$13 = 1004
 // gdb-command:print y
@@ -75,7 +67,6 @@
 // gdb-command:continue
 
 // BEGINNING of else branch
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$15 = 999
 // gdb-command:print y

--- a/src/test/debuginfo/lexical-scope-in-match.rs
+++ b/src/test/debuginfo/lexical-scope-in-match.rs
@@ -15,17 +15,14 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print shadowed
 // gdb-check:$1 = 231
 // gdb-command:print not_shadowed
 // gdb-check:$2 = 232
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print shadowed
 // gdb-check:$3 = 233
 // gdb-command:print not_shadowed
@@ -34,14 +31,12 @@
 // gdb-check:$5 = 234
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print shadowed
 // gdb-check:$6 = 236
 // gdb-command:print not_shadowed
 // gdb-check:$7 = 232
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print shadowed
 // gdb-check:$8 = 237
 // gdb-command:print not_shadowed
@@ -50,28 +45,24 @@
 // gdb-check:$10 = 238
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print shadowed
 // gdb-check:$11 = 239
 // gdb-command:print not_shadowed
 // gdb-check:$12 = 232
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print shadowed
 // gdb-check:$13 = 241
 // gdb-command:print not_shadowed
 // gdb-check:$14 = 232
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print shadowed
 // gdb-check:$15 = 243
 // gdb-command:print *local_to_arm
 // gdb-check:$16 = 244
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print shadowed
 // gdb-check:$17 = 231
 // gdb-command:print not_shadowed

--- a/src/test/debuginfo/lexical-scope-in-stack-closure.rs
+++ b/src/test/debuginfo/lexical-scope-in-stack-closure.rs
@@ -15,35 +15,28 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$1 = false
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$2 = false
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$3 = 1000
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$4 = 2.5
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$5 = true
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$6 = false
 // gdb-command:continue

--- a/src/test/debuginfo/lexical-scope-in-unconditional-loop.rs
+++ b/src/test/debuginfo/lexical-scope-in-unconditional-loop.rs
@@ -15,73 +15,59 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // FIRST ITERATION
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$1 = 0
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$2 = 1
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$3 = 101
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$4 = 101
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$5 = -987
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$6 = 101
 // gdb-command:continue
 
 
 // SECOND ITERATION
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$7 = 1
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$8 = 2
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$9 = 102
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$10 = 102
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$11 = -987
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$12 = 102
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$13 = 2
 // gdb-command:continue

--- a/src/test/debuginfo/lexical-scope-in-unique-closure.rs
+++ b/src/test/debuginfo/lexical-scope-in-unique-closure.rs
@@ -15,35 +15,28 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$1 = false
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$2 = false
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$3 = 1000
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$4 = 2.5
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$5 = true
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$6 = false
 // gdb-command:continue

--- a/src/test/debuginfo/lexical-scope-in-while.rs
+++ b/src/test/debuginfo/lexical-scope-in-while.rs
@@ -15,73 +15,59 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // FIRST ITERATION
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$1 = 0
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$2 = 1
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$3 = 101
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$4 = 101
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$5 = -987
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$6 = 101
 // gdb-command:continue
 
 
 // SECOND ITERATION
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$7 = 1
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$8 = 2
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$9 = 102
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$10 = 102
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$11 = -987
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$12 = 102
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$13 = 2
 // gdb-command:continue

--- a/src/test/debuginfo/lexical-scope-with-macro.rs
+++ b/src/test/debuginfo/lexical-scope-with-macro.rs
@@ -15,52 +15,44 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print a
 // gdb-check:$1 = 10
 // gdb-command:print b
 // gdb-check:$2 = 34
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print a
 // gdb-check:$3 = 890242
 // gdb-command:print b
 // gdb-check:$4 = 34
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print a
 // gdb-check:$5 = 10
 // gdb-command:print b
 // gdb-check:$6 = 34
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print a
 // gdb-check:$7 = 102
 // gdb-command:print b
 // gdb-check:$8 = 34
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print a
 // gdb-check:$9 = 110
 // gdb-command:print b
 // gdb-check:$10 = 34
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print a
 // gdb-check:$11 = 10
 // gdb-command:print b
 // gdb-check:$12 = 34
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print a
 // gdb-check:$13 = 10
 // gdb-command:print b

--- a/src/test/debuginfo/lexical-scopes-in-block-expression.rs
+++ b/src/test/debuginfo/lexical-scopes-in-block-expression.rs
@@ -16,21 +16,18 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // gdb-command:print 'lexical-scopes-in-block-expression::MUT_INT'
 // gdb-check:$1 = 0
 
 // STRUCT EXPRESSION
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$2 = -1
 // gdb-command:print ten
 // gdb-check:$3 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$4 = 11
 // gdb-command:print 'lexical-scopes-in-block-expression::MUT_INT'
@@ -39,7 +36,6 @@
 // gdb-check:$6 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$7 = -1
 // gdb-command:print ten
@@ -47,14 +43,12 @@
 // gdb-command:continue
 
 // FUNCTION CALL
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$9 = -1
 // gdb-command:print ten
 // gdb-check:$10 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$11 = 12
 // gdb-command:print 'lexical-scopes-in-block-expression::MUT_INT'
@@ -63,7 +57,6 @@
 // gdb-check:$13 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$14 = -1
 // gdb-command:print ten
@@ -71,14 +64,12 @@
 // gdb-command:continue
 
 // TUPLE EXPRESSION
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$16 = -1
 // gdb-command:print ten
 // gdb-check:$17 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$18 = 13
 // gdb-command:print 'lexical-scopes-in-block-expression::MUT_INT'
@@ -87,7 +78,6 @@
 // gdb-check:$20 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$21 = -1
 // gdb-command:print ten
@@ -95,14 +85,12 @@
 // gdb-command:continue
 
 // VEC EXPRESSION
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$23 = -1
 // gdb-command:print ten
 // gdb-check:$24 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$25 = 14
 // gdb-command:print 'lexical-scopes-in-block-expression::MUT_INT'
@@ -111,7 +99,6 @@
 // gdb-check:$27 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$28 = -1
 // gdb-command:print ten
@@ -119,14 +106,12 @@
 // gdb-command:continue
 
 // REPEAT VEC EXPRESSION
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$30 = -1
 // gdb-command:print ten
 // gdb-check:$31 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$32 = 15
 // gdb-command:print 'lexical-scopes-in-block-expression::MUT_INT'
@@ -135,7 +120,6 @@
 // gdb-check:$34 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$35 = -1
 // gdb-command:print ten
@@ -143,14 +127,12 @@
 // gdb-command:continue
 
 // ASSIGNMENT EXPRESSION
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$37 = -1
 // gdb-command:print ten
 // gdb-check:$38 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$39 = 16
 // gdb-command:print 'lexical-scopes-in-block-expression::MUT_INT'
@@ -159,7 +141,6 @@
 // gdb-check:$41 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$42 = -1
 // gdb-command:print ten
@@ -168,14 +149,12 @@
 
 
 // ARITHMETIC EXPRESSION
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$44 = -1
 // gdb-command:print ten
 // gdb-check:$45 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$46 = 17
 // gdb-command:print 'lexical-scopes-in-block-expression::MUT_INT'
@@ -184,7 +163,6 @@
 // gdb-check:$48 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$49 = -1
 // gdb-command:print ten
@@ -192,14 +170,12 @@
 // gdb-command:continue
 
 // INDEX EXPRESSION
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$51 = -1
 // gdb-command:print ten
 // gdb-check:$52 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$53 = 18
 // gdb-command:print 'lexical-scopes-in-block-expression::MUT_INT'
@@ -208,7 +184,6 @@
 // gdb-check:$55 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print val
 // gdb-check:$56 = -1
 // gdb-command:print ten

--- a/src/test/debuginfo/lexical-scopes-in-block-expression.rs
+++ b/src/test/debuginfo/lexical-scopes-in-block-expression.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 // min-lldb-version: 310
 

--- a/src/test/debuginfo/limited-debuginfo.rs
+++ b/src/test/debuginfo/limited-debuginfo.rs
@@ -21,11 +21,9 @@
 // gdb-check:[...]void[...]some_other_function([...]);
 // gdb-check:[...]void[...]zzz([...]);
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // Make sure there is no information about locals
-// gdb-command:finish
 // gdb-command:info locals
 // gdb-check:No locals.
 // gdb-command:continue
@@ -49,7 +47,7 @@ fn zzz() {()}
 fn some_function(a: int, b: int) {
     let some_variable = Struct { a: 11, b: 22 };
     let some_other_variable = 23i;
-    zzz();
+    zzz(); // #break
 }
 
 fn some_other_function(a: int, b: int) -> bool { true }

--- a/src/test/debuginfo/method-on-enum.rs
+++ b/src/test/debuginfo/method-on-enum.rs
@@ -16,11 +16,9 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // STACK BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$1 = {{RUST$ENUM$DISR = Variant2, [...]}, {RUST$ENUM$DISR = Variant2, 117901063}}
 // gdb-command:print arg1
@@ -30,7 +28,6 @@
 // gdb-command:continue
 
 // STACK BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$4 = {{RUST$ENUM$DISR = Variant2, [...]}, {RUST$ENUM$DISR = Variant2, 117901063}}
 // gdb-command:print arg1
@@ -40,7 +37,6 @@
 // gdb-command:continue
 
 // OWNED BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$7 = {{RUST$ENUM$DISR = Variant1, x = 1799, y = 1799}, {RUST$ENUM$DISR = Variant1, [...]}}
 // gdb-command:print arg1
@@ -50,7 +46,6 @@
 // gdb-command:continue
 
 // OWNED BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$10 = {{RUST$ENUM$DISR = Variant1, x = 1799, y = 1799}, {RUST$ENUM$DISR = Variant1, [...]}}
 // gdb-command:print arg1
@@ -60,7 +55,6 @@
 // gdb-command:continue
 
 // OWNED MOVED
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$13 = {{RUST$ENUM$DISR = Variant1, x = 1799, y = 1799}, {RUST$ENUM$DISR = Variant1, [...]}}
 // gdb-command:print arg1

--- a/src/test/debuginfo/method-on-generic-struct.rs
+++ b/src/test/debuginfo/method-on-generic-struct.rs
@@ -15,11 +15,9 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // STACK BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$1 = {x = {8888, -8888}}
 // gdb-command:print arg1
@@ -29,7 +27,6 @@
 // gdb-command:continue
 
 // STACK BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$4 = {x = {8888, -8888}}
 // gdb-command:print arg1
@@ -39,7 +36,6 @@
 // gdb-command:continue
 
 // OWNED BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$7 = {x = 1234.5}
 // gdb-command:print arg1
@@ -49,7 +45,6 @@
 // gdb-command:continue
 
 // OWNED BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$10 = {x = 1234.5}
 // gdb-command:print arg1
@@ -59,7 +54,6 @@
 // gdb-command:continue
 
 // OWNED MOVED
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$13 = {x = 1234.5}
 // gdb-command:print arg1

--- a/src/test/debuginfo/method-on-struct.rs
+++ b/src/test/debuginfo/method-on-struct.rs
@@ -15,11 +15,9 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // STACK BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$1 = {x = 100}
 // gdb-command:print arg1
@@ -29,7 +27,6 @@
 // gdb-command:continue
 
 // STACK BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$4 = {x = 100}
 // gdb-command:print arg1
@@ -39,7 +36,6 @@
 // gdb-command:continue
 
 // OWNED BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$7 = {x = 200}
 // gdb-command:print arg1
@@ -49,7 +45,6 @@
 // gdb-command:continue
 
 // OWNED BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$10 = {x = 200}
 // gdb-command:print arg1
@@ -59,7 +54,6 @@
 // gdb-command:continue
 
 // OWNED MOVED
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$13 = {x = 200}
 // gdb-command:print arg1

--- a/src/test/debuginfo/method-on-trait.rs
+++ b/src/test/debuginfo/method-on-trait.rs
@@ -15,11 +15,9 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // STACK BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$1 = {x = 100}
 // gdb-command:print arg1
@@ -29,7 +27,6 @@
 // gdb-command:continue
 
 // STACK BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$4 = {x = 100}
 // gdb-command:print arg1
@@ -39,7 +36,6 @@
 // gdb-command:continue
 
 // OWNED BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$7 = {x = 200}
 // gdb-command:print arg1
@@ -49,7 +45,6 @@
 // gdb-command:continue
 
 // OWNED BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$10 = {x = 200}
 // gdb-command:print arg1
@@ -59,7 +54,6 @@
 // gdb-command:continue
 
 // OWNED MOVED
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$13 = {x = 200}
 // gdb-command:print arg1

--- a/src/test/debuginfo/method-on-tuple-struct.rs
+++ b/src/test/debuginfo/method-on-tuple-struct.rs
@@ -15,11 +15,9 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // STACK BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$1 = {100, -100.5}
 // gdb-command:print arg1
@@ -29,7 +27,6 @@
 // gdb-command:continue
 
 // STACK BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$4 = {100, -100.5}
 // gdb-command:print arg1
@@ -39,7 +36,6 @@
 // gdb-command:continue
 
 // OWNED BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$7 = {200, -200.5}
 // gdb-command:print arg1
@@ -49,7 +45,6 @@
 // gdb-command:continue
 
 // OWNED BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$10 = {200, -200.5}
 // gdb-command:print arg1
@@ -59,7 +54,6 @@
 // gdb-command:continue
 
 // OWNED MOVED
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$13 = {200, -200.5}
 // gdb-command:print arg1

--- a/src/test/debuginfo/multiple-functions-equal-var-names.rs
+++ b/src/test/debuginfo/multiple-functions-equal-var-names.rs
@@ -15,20 +15,16 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print abc
 // gdb-check:$1 = 10101
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print abc
 // gdb-check:$2 = 20202
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print abc
 // gdb-check:$3 = 30303
 

--- a/src/test/debuginfo/multiple-functions.rs
+++ b/src/test/debuginfo/multiple-functions.rs
@@ -15,20 +15,16 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print a
 // gdb-check:$1 = 10101
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print b
 // gdb-check:$2 = 20202
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print c
 // gdb-check:$3 = 30303
 

--- a/src/test/debuginfo/name-shadowing-and-scope-nesting.rs
+++ b/src/test/debuginfo/name-shadowing-and-scope-nesting.rs
@@ -15,45 +15,38 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$1 = false
 // gdb-command:print y
 // gdb-check:$2 = true
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$3 = 10
 // gdb-command:print y
 // gdb-check:$4 = true
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$5 = 10.5
 // gdb-command:print y
 // gdb-check:$6 = 20
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$7 = true
 // gdb-command:print y
 // gdb-check:$8 = 2220
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$9 = 203203.5
 // gdb-command:print y
 // gdb-check:$10 = 2220
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$11 = 10.5
 // gdb-command:print y

--- a/src/test/debuginfo/nil-enum.rs
+++ b/src/test/debuginfo/nil-enum.rs
@@ -14,9 +14,7 @@
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print first
 // gdb-check:$1 = {<No data fields>}
@@ -29,16 +27,14 @@
 enum ANilEnum {}
 enum AnotherNilEnum {}
 
-// I (mw) am not sure this test case makes much sense...
-// Also, it relies on some implementation details:
-// 1. That empty enums as well as '()' are represented as empty structs
-// 2. That gdb prints the string "{<No data fields>}" for empty structs (which may change some time)
+// This test relies on gdb printing the string "{<No data fields>}" for empty
+// structs (which may change some time)
 fn main() {
     unsafe {
-        let first: ANilEnum = std::mem::transmute(());
-        let second: AnotherNilEnum = std::mem::transmute(());
+        let first: ANilEnum = ::std::mem::zeroed();
+        let second: AnotherNilEnum = ::std::mem::zeroed();
 
-        zzz();
+        zzz(); // #break
     }
 }
 

--- a/src/test/debuginfo/no-debug-attribute.rs
+++ b/src/test/debuginfo/no-debug-attribute.rs
@@ -13,8 +13,6 @@
 
 // compile-flags:-g
 
-// gdb-command:break 'no-debug-attribute.rs':32
-// gdb-command:break 'no-debug-attribute.rs':38
 // gdb-command:run
 
 // gdb-command:info locals

--- a/src/test/debuginfo/option-like-enum.rs
+++ b/src/test/debuginfo/option-like-enum.rs
@@ -16,9 +16,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print some
 // gdb-check:$1 = {RUST$ENCODED$ENUM$0$None = {0x12345678}}

--- a/src/test/debuginfo/packed-struct-with-destructor.rs
+++ b/src/test/debuginfo/packed-struct-with-destructor.rs
@@ -16,10 +16,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:set print pretty off
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print packed
 // gdb-check:$1 = {x = 123, y = 234, z = 345}

--- a/src/test/debuginfo/packed-struct.rs
+++ b/src/test/debuginfo/packed-struct.rs
@@ -16,10 +16,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:set print pretty off
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print packed
 // gdb-check:$1 = {x = 123, y = 234, z = 345}

--- a/src/test/debuginfo/recursive-enum.rs
+++ b/src/test/debuginfo/recursive-enum.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // ignore-android: FIXME(#10381)
-
 // ignore-lldb
 
 // compile-flags:-g

--- a/src/test/debuginfo/recursive-struct.rs
+++ b/src/test/debuginfo/recursive-struct.rs
@@ -12,12 +12,8 @@
 // ignore-android: FIXME(#10381)
 // ignore-lldb
 
-
 // compile-flags:-g
-// gdb-command:set print pretty off
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print stack_unique.value
 // gdb-check:$1 = 0
@@ -217,7 +213,7 @@ fn main() {
         value: 30
     };
 
-    zzz();
+    zzz(); // #break
 }
 
 fn zzz() {()}

--- a/src/test/debuginfo/self-in-default-method.rs
+++ b/src/test/debuginfo/self-in-default-method.rs
@@ -15,11 +15,9 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // STACK BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$1 = {x = 100}
 // gdb-command:print arg1
@@ -29,7 +27,6 @@
 // gdb-command:continue
 
 // STACK BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$4 = {x = 100}
 // gdb-command:print arg1
@@ -39,7 +36,6 @@
 // gdb-command:continue
 
 // OWNED BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$7 = {x = 200}
 // gdb-command:print arg1
@@ -49,7 +45,6 @@
 // gdb-command:continue
 
 // OWNED BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$10 = {x = 200}
 // gdb-command:print arg1
@@ -59,7 +54,6 @@
 // gdb-command:continue
 
 // OWNED MOVED
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$13 = {x = 200}
 // gdb-command:print arg1

--- a/src/test/debuginfo/self-in-generic-default-method.rs
+++ b/src/test/debuginfo/self-in-generic-default-method.rs
@@ -15,11 +15,9 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // STACK BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$1 = {x = 987}
 // gdb-command:print arg1
@@ -29,7 +27,6 @@
 // gdb-command:continue
 
 // STACK BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$4 = {x = 987}
 // gdb-command:print arg1
@@ -39,7 +36,6 @@
 // gdb-command:continue
 
 // OWNED BY REF
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$7 = {x = 879}
 // gdb-command:print arg1
@@ -49,7 +45,6 @@
 // gdb-command:continue
 
 // OWNED BY VAL
-// gdb-command:finish
 // gdb-command:print self
 // gdb-check:$10 = {x = 879}
 // gdb-command:print arg1
@@ -59,7 +54,6 @@
 // gdb-command:continue
 
 // OWNED MOVED
-// gdb-command:finish
 // gdb-command:print *self
 // gdb-check:$13 = {x = 879}
 // gdb-command:print arg1

--- a/src/test/debuginfo/shadowed-argument.rs
+++ b/src/test/debuginfo/shadowed-argument.rs
@@ -15,24 +15,20 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$1 = false
 // gdb-command:print y
 // gdb-check:$2 = true
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$3 = 10
 // gdb-command:print y
 // gdb-check:$4 = true
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$5 = 10.5
 // gdb-command:print y

--- a/src/test/debuginfo/shadowed-variable.rs
+++ b/src/test/debuginfo/shadowed-variable.rs
@@ -15,24 +15,20 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$1 = false
 // gdb-command:print y
 // gdb-check:$2 = true
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$3 = 10
 // gdb-command:print y
 // gdb-check:$4 = true
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$5 = 10.5
 // gdb-command:print y

--- a/src/test/debuginfo/simd.rs
+++ b/src/test/debuginfo/simd.rs
@@ -14,10 +14,8 @@
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print/d vi8x16
 // gdb-check:$1 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 // gdb-command:print/d vi16x8
@@ -66,7 +64,7 @@ fn main() {
     let vf32x4 = f32x4(60.5f32, 61.5f32, 62.5f32, 63.5f32);
     let vf64x2 = f64x2(64.5f64, 65.5f64);
 
-    zzz();
+    zzz(); // #break
 }
 
 #[inline(never)]

--- a/src/test/debuginfo/simple-lexical-scope.rs
+++ b/src/test/debuginfo/simple-lexical-scope.rs
@@ -15,40 +15,32 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$1 = false
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$2 = false
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$3 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$4 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$5 = 10.5
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$6 = 10
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print x
 // gdb-check:$7 = false
 // gdb-command:continue

--- a/src/test/debuginfo/simple-struct.rs
+++ b/src/test/debuginfo/simple-struct.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 // min-lldb-version: 310
 

--- a/src/test/debuginfo/simple-struct.rs
+++ b/src/test/debuginfo/simple-struct.rs
@@ -16,9 +16,6 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:set print pretty off
-// gdb-command:rbreak zzz
-
 // gdb-command:print 'simple-struct::NO_PADDING_16'
 // gdb-check:$1 = {x = 1000, y = -1001}
 
@@ -38,7 +35,6 @@
 // gdb-check:$6 = {x = 13, y = 14}
 
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print no_padding16
 // gdb-check:$7 = {x = 10000, y = -10001}
@@ -76,6 +72,7 @@
 // gdb-command:print 'simple-struct::PADDING_AT_END'
 // gdb-check:$18 = {x = -27, y = 28}
 
+// gdb-command:continue
 
 // === LLDB TESTS ==================================================================================
 

--- a/src/test/debuginfo/simple-tuple.rs
+++ b/src/test/debuginfo/simple-tuple.rs
@@ -16,9 +16,6 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:set print pretty off
-// gdb-command:rbreak zzz
-
 // gdb-command:print/d 'simple-tuple::NO_PADDING_8'
 // gdb-check:$1 = {-50, 50}
 // gdb-command:print 'simple-tuple::NO_PADDING_16'
@@ -37,7 +34,6 @@
 // gdb-check:$7 = {16, 17}
 
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print/d noPadding8
 // gdb-check:$8 = {-100, 100}

--- a/src/test/debuginfo/simple-tuple.rs
+++ b/src/test/debuginfo/simple-tuple.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 // min-lldb-version: 310
 

--- a/src/test/debuginfo/static-method-on-struct-and-enum.rs
+++ b/src/test/debuginfo/static-method-on-struct-and-enum.rs
@@ -15,11 +15,9 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
 // STRUCT
-// gdb-command:finish
 // gdb-command:print arg1
 // gdb-check:$1 = 1
 // gdb-command:print arg2
@@ -27,7 +25,6 @@
 // gdb-command:continue
 
 // ENUM
-// gdb-command:finish
 // gdb-command:print arg1
 // gdb-check:$3 = -3
 // gdb-command:print arg2

--- a/src/test/debuginfo/struct-in-enum.rs
+++ b/src/test/debuginfo/struct-in-enum.rs
@@ -17,9 +17,7 @@
 // === GDB TESTS ===================================================================================
 
 // gdb-command:set print union on
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print case1
 // gdb-check:$1 = {{RUST$ENUM$DISR = Case1, 0, {x = 2088533116, y = 2088533116, z = 31868}}, {RUST$ENUM$DISR = Case1, 0, 8970181431921507452, 31868}}

--- a/src/test/debuginfo/struct-in-struct.rs
+++ b/src/test/debuginfo/struct-in-struct.rs
@@ -16,10 +16,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:set print pretty off
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print three_simple_structs
 // gdb-check:$1 = {x = {x = 1}, y = {x = 2}, z = {x = 3}}

--- a/src/test/debuginfo/struct-style-enum.rs
+++ b/src/test/debuginfo/struct-style-enum.rs
@@ -17,9 +17,7 @@
 // === GDB TESTS ===================================================================================
 
 // gdb-command:set print union on
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print case1
 // gdb-check:$1 = {{RUST$ENUM$DISR = Case1, a = 0, b = 31868, c = 31868, d = 31868, e = 31868}, {RUST$ENUM$DISR = Case1, a = 0, b = 2088533116, c = 2088533116}, {RUST$ENUM$DISR = Case1, a = 0, b = 8970181431921507452}}

--- a/src/test/debuginfo/struct-with-destructor.rs
+++ b/src/test/debuginfo/struct-with-destructor.rs
@@ -15,9 +15,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 // gdb-command:print simple
 // gdb-check:$1 = {x = 10, y = 20}
 

--- a/src/test/debuginfo/trait-generic-static-default-method.rs
+++ b/src/test/debuginfo/trait-generic-static-default-method.rs
@@ -14,17 +14,14 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
 
-// gdb-command:finish
 // gdb-command:print arg1
 // gdb-check:$1 = 1000
 // gdb-command:print arg2
 // gdb-check:$2 = 0.5
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print arg1
 // gdb-check:$3 = 2000
 // gdb-command:print *arg2
@@ -36,30 +33,17 @@
 
 // lldb-command:run
 
-// lldb-command:print no_padding1
-// lldb-check:[...]$0 = { x = (0, 1) y = 2 z = (3, 4, 5) }
-// lldb-command:print no_padding2
-// lldb-check:[...]$1 = { x = (6, 7) y = { = (8, 9) = 10 } }
+// lldb-command:print arg1
+// lldb-check:[...]$0 = 1000
+// lldb-command:print arg2
+// lldb-check:[...]$1 = 0.5
+// lldb-command:continue
 
-// lldb-command:print tuple_internal_padding
-// lldb-check:[...]$2 = { x = (11, 12) y = (13, 14) }
-// lldb-command:print struct_internal_padding
-// lldb-check:[...]$3 = { x = (15, 16) y = (17, 18) }
-// lldb-command:print both_internally_padded
-// lldb-check:[...]$4 = { x = (19, 20, 21) y = (22, 23) }
-
-// lldb-command:print single_tuple
-// lldb-check:[...]$5 = { x = (24, 25, 26) }
-
-// lldb-command:print tuple_padded_at_end
-// lldb-check:[...]$6 = { x = (27, 28) y = (29, 30) }
-// lldb-command:print struct_padded_at_end
-// lldb-check:[...]$7 = { x = (31, 32) y = (33, 34) }
-// lldb-command:print both_padded_at_end
-// lldb-check:[...]$8 = { x = (35, 36, 37) y = (38, 39) }
-
-// lldb-command:print mixed_padding
-// lldb-check:[...]$9 = { x = { = (40, 41, 42) = (43, 44) } y = (45, 46, 47, 48) }
+// lldb-command:print arg1
+// lldb-check:[...]$2 = 2000
+// lldb-command:print *arg2
+// lldb-check:[...]$3 = (1, 2, 3)
+// lldb-command:continue
 
 struct Struct {
     x: int

--- a/src/test/debuginfo/trait-pointers.rs
+++ b/src/test/debuginfo/trait-pointers.rs
@@ -9,14 +9,13 @@
 // except according to those terms.
 
 // ignore-android: FIXME(#10381)
-
-// ignore-lldb
+// min-lldb-version: 310
 
 // compile-flags:-g
 // gdb-command:run
+// lldb-command:run
 
 #![allow(unused_variables)]
-
 
 trait Trait {
     fn method(&self) -> int { 0 }

--- a/src/test/debuginfo/tuple-in-struct.rs
+++ b/src/test/debuginfo/tuple-in-struct.rs
@@ -12,10 +12,8 @@
 // min-lldb-version: 310
 
 // compile-flags:-g
-// gdb-command:set print pretty off
-// gdb-command:rbreak zzz
+
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print no_padding1
 // gdb-check:$1 = {x = {0, 1}, y = 2, z = {3, 4, 5}}
@@ -148,7 +146,7 @@ fn main() {
         y: (45, 46, 47, 48)
     };
 
-    zzz();
+    zzz(); // #break
 }
 
 fn zzz() {()}

--- a/src/test/debuginfo/tuple-in-tuple.rs
+++ b/src/test/debuginfo/tuple-in-tuple.rs
@@ -15,10 +15,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:set print pretty off
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print no_padding1
 // gdb-check:$1 = {{0, 1}, 2, 3}

--- a/src/test/debuginfo/tuple-struct.rs
+++ b/src/test/debuginfo/tuple-struct.rs
@@ -15,10 +15,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:set print pretty off
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print no_padding16
 // gdb-check:$1 = {10000, -10001}

--- a/src/test/debuginfo/tuple-style-enum.rs
+++ b/src/test/debuginfo/tuple-style-enum.rs
@@ -17,9 +17,7 @@
 // === GDB TESTS ===================================================================================
 
 // gdb-command:set print union on
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print case1
 // gdb-check:$1 = {{RUST$ENUM$DISR = Case1, 0, 31868, 31868, 31868, 31868}, {RUST$ENUM$DISR = Case1, 0, 2088533116, 2088533116}, {RUST$ENUM$DISR = Case1, 0, 8970181431921507452}}

--- a/src/test/debuginfo/type-names.rs
+++ b/src/test/debuginfo/type-names.rs
@@ -13,10 +13,8 @@
 // ignore-android: FIXME(#10381)
 
 // compile-flags:-g
-// gdb-command:rbreak zzz
-// gdb-command:run
-// gdb-command:finish
 
+// gdb-command:run
 
 // STRUCTS
 // gdb-command:whatis simple_struct
@@ -326,7 +324,7 @@ fn main() {
     let stack_closure1 = (|x:int| {}, 0u);
     let stack_closure2 = (|x:i8, y: f32| { (x as f32) + y }, 0u);
 
-    zzz();
+    zzz(); // #break
 }
 
 #[inline(never)]

--- a/src/test/debuginfo/unique-enum.rs
+++ b/src/test/debuginfo/unique-enum.rs
@@ -16,9 +16,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print *the_a
 // gdb-check:$1 = {{RUST$ENUM$DISR = TheA, x = 0, y = 8970181431921507452}, {RUST$ENUM$DISR = TheA, 0, 2088533116, 2088533116}}

--- a/src/test/debuginfo/var-captured-in-nested-closure.rs
+++ b/src/test/debuginfo/var-captured-in-nested-closure.rs
@@ -15,9 +15,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print variable
 // gdb-check:$1 = 1
@@ -33,7 +31,6 @@
 // gdb-check:$6 = 8
 // gdb-command:continue
 
-// gdb-command:finish
 // gdb-command:print variable
 // gdb-check:$7 = 1
 // gdb-command:print constant

--- a/src/test/debuginfo/var-captured-in-sendable-closure.rs
+++ b/src/test/debuginfo/var-captured-in-sendable-closure.rs
@@ -15,9 +15,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print constant
 // gdb-check:$1 = 1

--- a/src/test/debuginfo/var-captured-in-stack-closure.rs
+++ b/src/test/debuginfo/var-captured-in-stack-closure.rs
@@ -15,9 +15,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 
 // gdb-command:print variable
 // gdb-check:$1 = 1

--- a/src/test/debuginfo/vec-slices.rs
+++ b/src/test/debuginfo/vec-slices.rs
@@ -16,10 +16,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:set print pretty off
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 // gdb-command:print empty.length
 // gdb-check:$1 = 0
 

--- a/src/test/debuginfo/vec-slices.rs
+++ b/src/test/debuginfo/vec-slices.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 // min-lldb-version: 310
 

--- a/src/test/debuginfo/vec.rs
+++ b/src/test/debuginfo/vec.rs
@@ -16,10 +16,7 @@
 
 // === GDB TESTS ===================================================================================
 
-// gdb-command:set print pretty off
-// gdb-command:rbreak zzz
 // gdb-command:run
-// gdb-command:finish
 // gdb-command:print a
 // gdb-check:$1 = {1, 2, 3}
 // gdb-command:print vec::VECT

--- a/src/test/debuginfo/vec.rs
+++ b/src/test/debuginfo/vec.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-windows: FIXME #13256
 // ignore-android: FIXME(#10381)
 // min-lldb-version: 310
 


### PR DESCRIPTION
On some Windows versions of GDB this is more stable than setting breakpoints via function names. This is also something I wanted to do for some time now because it makes the tests more consistent.

@brson:
These changes are in response to issue #17540. It works on my machine with the toolchain mentioned in the issue. In order to find out if the problem is really worked around, we also need to make the build bots use the newer GDB version again.
