### PR TITLE
mk: Clean just one llvm build at a time. Closes #17852

### DIFF
--- a/mk/llvm.mk
+++ b/mk/llvm.mk
@@ -38,7 +38,7 @@ endif
 # the stamp in the source dir.
 $$(LLVM_STAMP_$(1)): $(S)src/rustllvm/llvm-auto-clean-trigger
 	@$$(call E, make: cleaning llvm)
-	$(Q)$(MAKE) clean-llvm
+	$(Q)$(MAKE) clean-llvm$(1)
 	@$$(call E, make: done cleaning llvm)
 	touch $$@
 


### PR DESCRIPTION
When building for multiple targets, the initial 'make' invocation
always fails. The missing build stamp causes clean-llvm to be
invoked, but clean-llvm cleans _all_ llvm builds. So what happens
is that 1) all llvm's are cleaned (a no-op), 2) llvm-${target1}
builds, 3) all llvm's are cleaned (deleting llvm-${target1}),
4) llvm-${target2} is built, 5) the remaining build for ${target1}
fails because llvm does not exist.

This makes the clean operation only clean the correct llvm build.
Should greatly reduce bot failures.
