### PR TITLE
Add command line flag for notifying when error free

### DIFF
--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -89,6 +89,7 @@ pub struct Options {
     pub parse_only: bool,
     pub no_trans: bool,
     pub no_analysis: bool,
+    pub notify_error_free: bool,
     pub debugging_opts: u64,
     /// Whether to write dependency files. It's (enabled, optional filename).
     pub write_dependency_info: (bool, Option<Path>),
@@ -122,6 +123,7 @@ pub fn basic_options() -> Options {
         parse_only: false,
         no_trans: false,
         no_analysis: false,
+        notify_error_free: false,
         debugging_opts: 0,
         write_dependency_info: (false, None),
         print_metas: (false, false),
@@ -594,6 +596,8 @@ pub fn optgroups() -> Vec<getopts::OptGroup> {
         optflag("", "no-trans", "Run all passes except translation; no output"),
         optflag("", "no-analysis",
               "Parse and expand the source, but run no analysis and produce no output"),
+        optflag("", "notify-error-free",
+               "Notify when the crate is known to be error free"),
         optflag("O", "", "Equivalent to --opt-level=2"),
         optopt("o", "", "Write output to <filename>", "FILENAME"),
         optopt("", "opt-level", "Optimize with possible levels 0-3", "LEVEL"),
@@ -652,6 +656,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
     let parse_only = matches.opt_present("parse-only");
     let no_trans = matches.opt_present("no-trans");
     let no_analysis = matches.opt_present("no-analysis");
+    let notify_error_free = matches.opt_present("notify-error-free");
 
     let mut lint_opts = vec!();
     let mut describe_lints = false;
@@ -836,6 +841,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         parse_only: parse_only,
         no_trans: no_trans,
         no_analysis: no_analysis,
+        notify_error_free: notify_error_free,
         debugging_opts: debugging_opts,
         write_dependency_info: write_dependency_info,
         print_metas: print_metas,

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -95,6 +95,9 @@ pub fn compile_input(sess: Session,
         let type_arena = TypedArena::new();
         let analysis = phase_3_run_analysis_passes(sess, ast_map, &type_arena, id);
         phase_save_analysis(&analysis.ty_cx.sess, analysis.ty_cx.map.krate(), &analysis, outdir);
+        if analysis.ty_cx.sess.opts.notify_error_free {
+            analysis.ty_cx.sess.note("crate is error free");
+        }
         if stop_after_phase_3(&analysis.ty_cx.sess) { return; }
         let (tcx, trans) = phase_4_translate_to_llvm(analysis);
 


### PR DESCRIPTION
Inspired by [@cmr's `rest_easy`](http://www.reddit.com/r/rust/comments/2krdbu/rest_easy_a_lint_to_tell_you_when_compilation/)

The name and text of the flag could use some improvement, and perhaps it should be behind `-Z`. Suggestions?
