### PR TITLE
DSTify BytesContainer

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -627,7 +627,7 @@ fn find_rust_src_root(config: &Config) -> Option<Path> {
     let path_postfix = Path::new("src/etc/lldb_batchmode.py");
 
     while path.pop() {
-        if path.join(path_postfix.clone()).is_file() {
+        if path.join(&path_postfix).is_file() {
             return Some(path);
         }
     }

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -231,7 +231,7 @@ pub fn build_session_(sopts: config::Options,
         if path.is_absolute() {
             path.clone()
         } else {
-            os::getcwd().join(path.clone())
+            os::getcwd().join(&path)
         }
     );
 

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -918,7 +918,7 @@ mod tests {
         let prog = pwd_cmd().cwd(&parent_dir).spawn().unwrap();
 
         let output = String::from_utf8(prog.wait_with_output().unwrap().output).unwrap();
-        let child_dir = Path::new(output.as_slice().trim().into_string());
+        let child_dir = Path::new(output.as_slice().trim());
 
         let parent_stat = parent_dir.stat().unwrap();
         let child_stat = child_dir.stat().unwrap();

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -117,17 +117,6 @@ impl BytesContainer for Path {
     fn container_as_bytes<'a>(&'a self) -> &'a [u8] {
         self.as_vec()
     }
-    #[inline]
-    fn container_into_owned_bytes(self) -> Vec<u8> {
-        self.into_vec()
-    }
-}
-
-impl<'a> BytesContainer for &'a Path {
-    #[inline]
-    fn container_as_bytes<'a>(&'a self) -> &'a [u8] {
-        self.as_vec()
-    }
 }
 
 impl GenericPathUnsafe for Path {

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -149,28 +149,11 @@ impl BytesContainer for Path {
         self.as_vec()
     }
     #[inline]
-    fn container_into_owned_bytes(self) -> Vec<u8> {
-        self.into_vec()
-    }
-    #[inline]
     fn container_as_str<'a>(&'a self) -> Option<&'a str> {
         self.as_str()
     }
     #[inline]
-    fn is_str(_: Option<Path>) -> bool { true }
-}
-
-impl<'a> BytesContainer for &'a Path {
-    #[inline]
-    fn container_as_bytes<'a>(&'a self) -> &'a [u8] {
-        self.as_vec()
-    }
-    #[inline]
-    fn container_as_str<'a>(&'a self) -> Option<&'a str> {
-        self.as_str()
-    }
-    #[inline]
-    fn is_str(_: Option<&'a Path>) -> bool { true }
+    fn is_str(_: Option<&Path>) -> bool { true }
 }
 
 impl GenericPathUnsafe for Path {

--- a/src/libterm/terminfo/searcher.rs
+++ b/src/libterm/terminfo/searcher.rs
@@ -41,7 +41,7 @@ pub fn get_dbpath_for_term(term: &str) -> Option<Box<Path>> {
                     if i == "" {
                         dirs_to_search.push(Path::new("/usr/share/terminfo"));
                     } else {
-                        dirs_to_search.push(Path::new(i.to_string()));
+                        dirs_to_search.push(Path::new(i));
                     }
                 },
                 // Found nothing in TERMINFO_DIRS, use the default paths:

--- a/src/test/run-pass/process-spawn-with-unicode-params.rs
+++ b/src/test/run-pass/process-spawn-with-unicode-params.rs
@@ -48,7 +48,7 @@ fn main() {
 
         let child_filestem = Path::new(child_name);
         let child_filename = child_filestem.with_extension(my_ext);
-        let child_path     = cwd.join(child_filename.clone());
+        let child_path     = cwd.join(child_filename);
 
         // make a separate directory for the child
         drop(fs::mkdir(&cwd, io::USER_RWX).is_ok());


### PR DESCRIPTION
- The `BytesContainer::container_into_owned_bytes` method has been removed
- Methods that used to take `BytesContainer` implementors by value, now take them by reference. In particular, this breaks some uses of Path:

``` rust
Path::new("foo")  // Still works
path.join(another_path) -> path.join(&another_path)
```

[breaking-change]

---

Re: `container_into_owned_bytes`, I've removed it because
- Nothing in the whole repository uses it
- Takes `self` by value, which is incompatible with unsized types (`str`)

The alternative to removing this method is to split `BytesContainer` into `BytesContainer for Sized?` and `SizedBytesContainer: BytesContainer + Sized`, where the second trait only contains the `container_into_owned_bytes` method. I tried this alternative [in another branch](https://github.com/japaric/rust/commits/bytes) and it works, but it seemed better not to create a new trait for an unused method.

Re: Breakage of `Path` methods

We could use the idea that @alexcrichton proposed in #18457 (add blanket `impl BytesContainer for &T where T: BytesContainer` + keep taking `T: BytesContainer` by value in `Path` methods) to avoid breaking any code.

r? @aturon 
cc #16918
