### PR TITLE
DSTify PartialEq, PartialOrd, Eq, Ord

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -61,12 +61,16 @@ impl<T: Clone> Clone for Box<T> {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<T:PartialEq> PartialEq for Box<T> {
     #[inline]
     fn eq(&self, other: &Box<T>) -> bool { *(*self) == *(*other) }
     #[inline]
     fn ne(&self, other: &Box<T>) -> bool { *(*self) != *(*other) }
 }
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<T:PartialOrd> PartialOrd for Box<T> {
     #[inline]
     fn partial_cmp(&self, other: &Box<T>) -> Option<Ordering> {
@@ -81,13 +85,49 @@ impl<T:PartialOrd> PartialOrd for Box<T> {
     #[inline]
     fn gt(&self, other: &Box<T>) -> bool { *(*self) > *(*other) }
 }
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<T: Ord> Ord for Box<T> {
     #[inline]
     fn cmp(&self, other: &Box<T>) -> Ordering {
         (**self).cmp(&**other)
     }
 }
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<T: Eq> Eq for Box<T> {}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<Sized? T: PartialEq> PartialEq for Box<T> {
+    #[inline]
+    fn eq(&self, other: &Box<T>) -> bool { PartialEq::eq(&**self, &**other) }
+    #[inline]
+    fn ne(&self, other: &Box<T>) -> bool { PartialEq::ne(&**self, &**other) }
+}
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<Sized? T: PartialOrd> PartialOrd for Box<T> {
+    #[inline]
+    fn partial_cmp(&self, other: &Box<T>) -> Option<Ordering> {
+        PartialOrd::partial_cmp(&**self, &**other)
+    }
+    #[inline]
+    fn lt(&self, other: &Box<T>) -> bool { PartialOrd::lt(&**self, &**other) }
+    #[inline]
+    fn le(&self, other: &Box<T>) -> bool { PartialOrd::le(&**self, &**other) }
+    #[inline]
+    fn ge(&self, other: &Box<T>) -> bool { PartialOrd::ge(&**self, &**other) }
+    #[inline]
+    fn gt(&self, other: &Box<T>) -> bool { PartialOrd::gt(&**self, &**other) }
+}
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<Sized? T: Ord> Ord for Box<T> {
+    #[inline]
+    fn cmp(&self, other: &Box<T>) -> Ordering {
+        Ord::cmp(&**self, &**other)
+    }
+}
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<Sized? T: Eq> Eq for Box<T> {}
 
 /// Extension methods for an owning `Any` trait object.
 #[unstable = "post-DST and coherence changes, this will not be a trait but \

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1598,15 +1598,15 @@ mod tests {
     #[test]
     fn test_total_ord() {
         let c: &[int] = &[1, 2, 3];
-        [1, 2, 3, 4][].cmp(& c) == Greater;
+        [1, 2, 3, 4][].cmp(c) == Greater;
         let c: &[int] = &[1, 2, 3, 4];
-        [1, 2, 3][].cmp(& c) == Less;
+        [1, 2, 3][].cmp(c) == Less;
         let c: &[int] = &[1, 2, 3, 6];
-        [1, 2, 3, 4][].cmp(& c) == Equal;
+        [1, 2, 3, 4][].cmp(c) == Equal;
         let c: &[int] = &[1, 2, 3, 4, 5, 6];
-        [1, 2, 3, 4, 5, 5, 5, 5][].cmp(& c) == Less;
+        [1, 2, 3, 4, 5, 5, 5, 5][].cmp(c) == Less;
         let c: &[int] = &[1, 2, 3, 4];
-        [2, 2][].cmp(& c) == Greater;
+        [2, 2][].cmp(c) == Greater;
     }
 
     #[test]

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -532,9 +532,16 @@ impl<'a> PartialOrd for MaybeOwned<'a> {
 }
 
 impl<'a> Ord for MaybeOwned<'a> {
+    // NOTE(stage0): remove method after a snapshot
+    #[cfg(stage0)]
     #[inline]
     fn cmp(&self, other: &MaybeOwned) -> Ordering {
         self.as_slice().cmp(&other.as_slice())
+    }
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    #[inline]
+    fn cmp(&self, other: &MaybeOwned) -> Ordering {
+        self.as_slice().cmp(other.as_slice())
     }
 }
 

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1530,11 +1530,11 @@ mod tests {
 
     #[test]
     fn test_total_ord() {
-        "1234".cmp(&("123")) == Greater;
-        "123".cmp(&("1234")) == Less;
-        "1234".cmp(&("1234")) == Equal;
-        "12345555".cmp(&("123456")) == Less;
-        "22".cmp(&("1234")) == Greater;
+        "1234".cmp("123") == Greater;
+        "123".cmp("1234") == Less;
+        "1234".cmp("1234") == Equal;
+        "12345555".cmp("123456") == Less;
+        "22".cmp("1234") == Greater;
     }
 
     #[test]

--- a/src/libcollections/tree/map.rs
+++ b/src/libcollections/tree/map.rs
@@ -579,7 +579,7 @@ impl<K, V> TreeMap<K, V> {
     /// let headers = get_headers();
     /// let ua_key = "User-Agent";
     /// let ua = headers.find_with(|k| {
-    ///    ua_key.cmp(&k.as_slice())
+    ///    ua_key.cmp(k.as_slice())
     /// });
     ///
     /// assert_eq!((*ua.unwrap()).as_slice(), "Curl-Rust/0.1");
@@ -603,7 +603,7 @@ impl<K, V> TreeMap<K, V> {
     /// t.insert("User-Agent", "Curl-Rust/0.1");
     ///
     /// let new_ua = "Safari/156.0";
-    /// match t.find_with_mut(|k| "User-Agent".cmp(k)) {
+    /// match t.find_with_mut(|&k| "User-Agent".cmp(k)) {
     ///    Some(x) => *x = new_ua,
     ///    None => panic!(),
     /// }
@@ -1302,7 +1302,7 @@ mod test_treemap {
     #[test]
     fn find_with_empty() {
         let m: TreeMap<&'static str,int> = TreeMap::new();
-        assert!(m.find_with(|k| "test".cmp(k)) == None);
+        assert!(m.find_with(|&k| "test".cmp(k)) == None);
     }
 
     #[test]
@@ -1311,7 +1311,7 @@ mod test_treemap {
         assert!(m.insert("test1", 2i));
         assert!(m.insert("test2", 3i));
         assert!(m.insert("test3", 3i));
-        assert_eq!(m.find_with(|k| "test4".cmp(k)), None);
+        assert_eq!(m.find_with(|&k| "test4".cmp(k)), None);
     }
 
     #[test]
@@ -1320,7 +1320,7 @@ mod test_treemap {
         assert!(m.insert("test1", 2i));
         assert!(m.insert("test2", 3i));
         assert!(m.insert("test3", 4i));
-        assert_eq!(m.find_with(|k| "test2".cmp(k)), Some(&3i));
+        assert_eq!(m.find_with(|&k| "test2".cmp(k)), Some(&3i));
     }
 
     #[test]
@@ -1343,10 +1343,10 @@ mod test_treemap {
         assert!(m.insert("t2", 8));
         assert!(m.insert("t5", 14));
         let new = 100;
-        match m.find_with_mut(|k| "t5".cmp(k)) {
+        match m.find_with_mut(|&k| "t5".cmp(k)) {
           None => panic!(), Some(x) => *x = new
         }
-        assert_eq!(m.find_with(|k| "t5".cmp(k)), Some(&new));
+        assert_eq!(m.find_with(|&k| "t5".cmp(k)), Some(&new));
     }
 
     #[test]

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -506,9 +506,16 @@ impl<T: PartialEq> PartialEq for Vec<T> {
 
 #[unstable = "waiting on PartialOrd stability"]
 impl<T: PartialOrd> PartialOrd for Vec<T> {
+    // NOTE(stage0): remove method after a snapshot
+    #[cfg(stage0)]
     #[inline]
     fn partial_cmp(&self, other: &Vec<T>) -> Option<Ordering> {
         self.as_slice().partial_cmp(&other.as_slice())
+    }
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    #[inline]
+    fn partial_cmp(&self, other: &Vec<T>) -> Option<Ordering> {
+        self.as_slice().partial_cmp(other.as_slice())
     }
 }
 
@@ -523,9 +530,16 @@ impl<T: PartialEq, V: AsSlice<T>> Equiv<V> for Vec<T> {
 
 #[unstable = "waiting on Ord stability"]
 impl<T: Ord> Ord for Vec<T> {
+    // NOTE(stage0): remove method after a snapshot
+    #[cfg(stage0)]
     #[inline]
     fn cmp(&self, other: &Vec<T>) -> Ordering {
         self.as_slice().cmp(&other.as_slice())
+    }
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    #[inline]
+    fn cmp(&self, other: &Vec<T>) -> Ordering {
+        self.as_slice().cmp(other.as_slice())
     }
 }
 

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -55,9 +55,36 @@ use option::{Option, Some, None};
 ///
 /// Eventually, this will be implemented by default for types that implement
 /// `Eq`.
+// NOTE(stage0): remove trait after a snapshot
+#[cfg(stage0)]
 #[lang="eq"]
 #[unstable = "Definition may change slightly after trait reform"]
 pub trait PartialEq {
+    /// This method tests for `self` and `other` values to be equal, and is used by `==`.
+    fn eq(&self, other: &Self) -> bool;
+
+    /// This method tests for `!=`.
+    #[inline]
+    fn ne(&self, other: &Self) -> bool { !self.eq(other) }
+}
+
+/// Trait for values that can be compared for equality and inequality.
+///
+/// This trait allows for partial equality, for types that do not have an
+/// equivalence relation. For example, in floating point numbers `NaN != NaN`,
+/// so floating point types implement `PartialEq` but not `Eq`.
+///
+/// PartialEq only requires the `eq` method to be implemented; `ne` is defined
+/// in terms of it by default. Any manual implementation of `ne` *must* respect
+/// the rule that `eq` is a strict inverse of `ne`; that is, `!(a == b)` if and
+/// only if `a != b`.
+///
+/// Eventually, this will be implemented by default for types that implement
+/// `Eq`.
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[lang="eq"]
+#[unstable = "Definition may change slightly after trait reform"]
+pub trait PartialEq for Sized? {
     /// This method tests for `self` and `other` values to be equal, and is used by `==`.
     fn eq(&self, other: &Self) -> bool;
 
@@ -75,8 +102,34 @@ pub trait PartialEq {
 /// - reflexive: `a == a`;
 /// - symmetric: `a == b` implies `b == a`; and
 /// - transitive: `a == b` and `b == c` implies `a == c`.
+// NOTE(stage0): remove trait after a snapshot
+#[cfg(stage0)]
 #[unstable = "Definition may change slightly after trait reform"]
 pub trait Eq: PartialEq {
+    // FIXME #13101: this method is used solely by #[deriving] to
+    // assert that every component of a type implements #[deriving]
+    // itself, the current deriving infrastructure means doing this
+    // assertion without using a method on this trait is nearly
+    // impossible.
+    //
+    // This should never be implemented by hand.
+    #[doc(hidden)]
+    #[inline(always)]
+    fn assert_receiver_is_total_eq(&self) {}
+}
+
+/// Trait for equality comparisons which are [equivalence relations](
+/// https://en.wikipedia.org/wiki/Equivalence_relation).
+///
+/// This means, that in addition to `a == b` and `a != b` being strict
+/// inverses, the equality must be (for all `a`, `b` and `c`):
+///
+/// - reflexive: `a == a`;
+/// - symmetric: `a == b` implies `b == a`; and
+/// - transitive: `a == b` and `b == c` implies `a == c`.
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[unstable = "Definition may change slightly after trait reform"]
+pub trait Eq for Sized?: PartialEq {
     // FIXME #13101: this method is used solely by #[deriving] to
     // assert that every component of a type implements #[deriving]
     // itself, the current deriving infrastructure means doing this
@@ -145,8 +198,35 @@ impl Ordering {
 ///   true; and
 /// - transitive, `a < b` and `b < c` implies `a < c`. The same must hold for
 ///   both `==` and `>`.
+// NOTE(stage0): remove trait after a snapshot
+#[cfg(stage0)]
 #[unstable = "Definition may change slightly after trait reform"]
 pub trait Ord: Eq + PartialOrd {
+    /// This method returns an ordering between `self` and `other` values.
+    ///
+    /// By convention, `self.cmp(&other)` returns the ordering matching
+    /// the expression `self <operator> other` if true.  For example:
+    ///
+    /// ```
+    /// assert_eq!( 5u.cmp(&10), Less);     // because 5 < 10
+    /// assert_eq!(10u.cmp(&5),  Greater);  // because 10 > 5
+    /// assert_eq!( 5u.cmp(&5),  Equal);    // because 5 == 5
+    /// ```
+    fn cmp(&self, other: &Self) -> Ordering;
+}
+
+/// Trait for types that form a [total order](
+/// https://en.wikipedia.org/wiki/Total_order).
+///
+/// An order is a total order if it is (for all `a`, `b` and `c`):
+///
+/// - total and antisymmetric: exactly one of `a < b`, `a == b` or `a > b` is
+///   true; and
+/// - transitive, `a < b` and `b < c` implies `a < c`. The same must hold for
+///   both `==` and `>`.
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[unstable = "Definition may change slightly after trait reform"]
+pub trait Ord for Sized?: Eq + PartialOrd {
     /// This method returns an ordering between `self` and `other` values.
     ///
     /// By convention, `self.cmp(&other)` returns the ordering matching
@@ -188,9 +268,65 @@ impl PartialOrd for Ordering {
 /// which do not have a total order. For example, for floating point numbers,
 /// `NaN < 0 == false` and `NaN >= 0 == false` (cf. IEEE 754-2008 section
 /// 5.11).
+// NOTE(stage0): remove trait after a snapshot
+#[cfg(stage0)]
 #[lang="ord"]
 #[unstable = "Definition may change slightly after trait reform"]
 pub trait PartialOrd: PartialEq {
+    /// This method returns an ordering between `self` and `other` values
+    /// if one exists.
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering>;
+
+    /// This method tests less than (for `self` and `other`) and is used by the `<` operator.
+    #[inline]
+    fn lt(&self, other: &Self) -> bool {
+        match self.partial_cmp(other) {
+            Some(Less) => true,
+            _ => false,
+        }
+    }
+
+    /// This method tests less than or equal to (`<=`).
+    #[inline]
+    fn le(&self, other: &Self) -> bool {
+        match self.partial_cmp(other) {
+            Some(Less) | Some(Equal) => true,
+            _ => false,
+        }
+    }
+
+    /// This method tests greater than (`>`).
+    #[inline]
+    fn gt(&self, other: &Self) -> bool {
+        match self.partial_cmp(other) {
+            Some(Greater) => true,
+            _ => false,
+        }
+    }
+
+    /// This method tests greater than or equal to (`>=`).
+    #[inline]
+    fn ge(&self, other: &Self) -> bool {
+        match self.partial_cmp(other) {
+            Some(Greater) | Some(Equal) => true,
+            _ => false,
+        }
+    }
+}
+
+/// Trait for values that can be compared for a sort-order.
+///
+/// PartialOrd only requires implementation of the `partial_cmp` method,
+/// with the others generated from default implementations.
+///
+/// However it remains possible to implement the others separately for types
+/// which do not have a total order. For example, for floating point numbers,
+/// `NaN < 0 == false` and `NaN >= 0 == false` (cf. IEEE 754-2008 section
+/// 5.11).
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[lang="ord"]
+#[unstable = "Definition may change slightly after trait reform"]
+pub trait PartialOrd for Sized?: PartialEq {
     /// This method returns an ordering between `self` and `other` values
     /// if one exists.
     fn partial_cmp(&self, other: &Self) -> Option<Ordering>;
@@ -286,6 +422,8 @@ pub fn partial_max<T: PartialOrd>(v1: T, v2: T) -> Option<T> {
 mod impls {
     use cmp::{PartialOrd, Ord, PartialEq, Eq, Ordering,
               Less, Greater, Equal};
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    use kinds::Sized;
     use option::{Option, Some, None};
 
     macro_rules! partial_eq_impl(
@@ -393,6 +531,8 @@ mod impls {
     ord_impl!(char uint u8 u16 u32 u64 int i8 i16 i32 i64)
 
     // & pointers
+    // NOTE(stage0): remove impl after a snapshot
+    #[cfg(stage0)]
     #[unstable = "Trait is unstable."]
     impl<'a, T: PartialEq> PartialEq for &'a T {
         #[inline]
@@ -400,6 +540,8 @@ mod impls {
         #[inline]
         fn ne(&self, other: & &'a T) -> bool { *(*self) != *(*other) }
     }
+    // NOTE(stage0): remove impl after a snapshot
+    #[cfg(stage0)]
     #[unstable = "Trait is unstable."]
     impl<'a, T: PartialOrd> PartialOrd for &'a T {
         #[inline]
@@ -415,15 +557,55 @@ mod impls {
         #[inline]
         fn gt(&self, other: & &'a T) -> bool { *(*self) > *(*other) }
     }
+    // NOTE(stage0): remove impl after a snapshot
+    #[cfg(stage0)]
     #[unstable = "Trait is unstable."]
     impl<'a, T: Ord> Ord for &'a T {
         #[inline]
         fn cmp(&self, other: & &'a T) -> Ordering { (**self).cmp(*other) }
     }
+    // NOTE(stage0): remove impl after a snapshot
+    #[cfg(stage0)]
     #[unstable = "Trait is unstable."]
     impl<'a, T: Eq> Eq for &'a T {}
 
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    #[unstable = "Trait is unstable."]
+    impl<'a, Sized? T: PartialEq> PartialEq for &'a T {
+        #[inline]
+        fn eq(&self, other: & &'a T) -> bool { PartialEq::eq(*self, *other) }
+        #[inline]
+        fn ne(&self, other: & &'a T) -> bool { PartialEq::ne(*self, *other) }
+    }
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    #[unstable = "Trait is unstable."]
+    impl<'a, Sized? T: PartialOrd> PartialOrd for &'a T {
+        #[inline]
+        fn partial_cmp(&self, other: &&'a T) -> Option<Ordering> {
+            PartialOrd::partial_cmp(*self, *other)
+        }
+        #[inline]
+        fn lt(&self, other: & &'a T) -> bool { PartialOrd::lt(*self, *other) }
+        #[inline]
+        fn le(&self, other: & &'a T) -> bool { PartialOrd::le(*self, *other) }
+        #[inline]
+        fn ge(&self, other: & &'a T) -> bool { PartialOrd::ge(*self, *other) }
+        #[inline]
+        fn gt(&self, other: & &'a T) -> bool { PartialOrd::gt(*self, *other) }
+    }
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    #[unstable = "Trait is unstable."]
+    impl<'a, Sized? T: Ord> Ord for &'a T {
+        #[inline]
+        fn cmp(&self, other: & &'a T) -> Ordering { Ord::cmp(*self, *other) }
+    }
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    #[unstable = "Trait is unstable."]
+    impl<'a, Sized? T: Eq> Eq for &'a T {}
+
     // &mut pointers
+    // NOTE(stage0): remove impl after a snapshot
+    #[cfg(stage0)]
     #[unstable = "Trait is unstable."]
     impl<'a, T: PartialEq> PartialEq for &'a mut T {
         #[inline]
@@ -431,6 +613,8 @@ mod impls {
         #[inline]
         fn ne(&self, other: &&'a mut T) -> bool { **self != *(*other) }
     }
+    // NOTE(stage0): remove impl after a snapshot
+    #[cfg(stage0)]
     #[unstable = "Trait is unstable."]
     impl<'a, T: PartialOrd> PartialOrd for &'a mut T {
         #[inline]
@@ -446,11 +630,49 @@ mod impls {
         #[inline]
         fn gt(&self, other: &&'a mut T) -> bool { **self > **other }
     }
+    // NOTE(stage0): remove impl after a snapshot
+    #[cfg(stage0)]
     #[unstable = "Trait is unstable."]
     impl<'a, T: Ord> Ord for &'a mut T {
         #[inline]
         fn cmp(&self, other: &&'a mut T) -> Ordering { (**self).cmp(*other) }
     }
+    // NOTE(stage0): remove impl after a snapshot
+    #[cfg(stage0)]
     #[unstable = "Trait is unstable."]
     impl<'a, T: Eq> Eq for &'a mut T {}
+
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    #[unstable = "Trait is unstable."]
+    impl<'a, Sized? T: PartialEq> PartialEq for &'a mut T {
+        #[inline]
+        fn eq(&self, other: &&'a mut T) -> bool { PartialEq::eq(*self, *other) }
+        #[inline]
+        fn ne(&self, other: &&'a mut T) -> bool { PartialEq::ne(*self, *other) }
+    }
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    #[unstable = "Trait is unstable."]
+    impl<'a, Sized? T: PartialOrd> PartialOrd for &'a mut T {
+        #[inline]
+        fn partial_cmp(&self, other: &&'a mut T) -> Option<Ordering> {
+            PartialOrd::partial_cmp(*self, *other)
+        }
+        #[inline]
+        fn lt(&self, other: &&'a mut T) -> bool { PartialOrd::lt(*self, *other) }
+        #[inline]
+        fn le(&self, other: &&'a mut T) -> bool { PartialOrd::le(*self, *other) }
+        #[inline]
+        fn ge(&self, other: &&'a mut T) -> bool { PartialOrd::ge(*self, *other) }
+        #[inline]
+        fn gt(&self, other: &&'a mut T) -> bool { PartialOrd::gt(*self, *other) }
+    }
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    #[unstable = "Trait is unstable."]
+    impl<'a, Sized? T: Ord> Ord for &'a mut T {
+        #[inline]
+        fn cmp(&self, other: &&'a mut T) -> Ordering { Ord::cmp(*self, *other) }
+    }
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    #[unstable = "Trait is unstable."]
+    impl<'a, Sized? T: Eq> Eq for &'a mut T {}
 }

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -143,7 +143,7 @@
 
 #![stable]
 
-use cmp::{PartialEq, Eq, Ord};
+use cmp::{Eq, Ord};
 use default::Default;
 use iter::{Iterator, DoubleEndedIterator, FromIterator, ExactSize};
 use mem;

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -276,7 +276,6 @@
 
 #![stable]
 
-use cmp::PartialEq;
 use std::fmt::Show;
 use slice;
 use slice::AsSlice;

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1555,6 +1555,8 @@ pub mod bytes {
 // Boilerplate traits
 //
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 #[unstable = "waiting for DST"]
 impl<'a,T:PartialEq> PartialEq for &'a [T] {
     fn eq(&self, other: & &'a [T]) -> bool {
@@ -1567,8 +1569,27 @@ impl<'a,T:PartialEq> PartialEq for &'a [T] {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[unstable = "waiting for DST"]
+impl<T: PartialEq> PartialEq for [T] {
+    fn eq(&self, other: &[T]) -> bool {
+        self.len() == other.len() &&
+            order::eq(self.iter(), other.iter())
+    }
+    fn ne(&self, other: &[T]) -> bool {
+        self.len() != other.len() ||
+            order::ne(self.iter(), other.iter())
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 #[unstable = "waiting for DST"]
 impl<'a,T:Eq> Eq for &'a [T] {}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[unstable = "waiting for DST"]
+impl<T: Eq> Eq for [T] {}
 
 #[unstable = "waiting for DST"]
 impl<T: PartialEq, V: AsSlice<T>> Equiv<V> for [T] {
@@ -1576,6 +1597,8 @@ impl<T: PartialEq, V: AsSlice<T>> Equiv<V> for [T] {
     fn equiv(&self, other: &V) -> bool { self.as_slice() == other.as_slice() }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 #[unstable = "waiting for DST"]
 impl<'a,T:PartialEq> PartialEq for &'a mut [T] {
     fn eq(&self, other: & &'a mut [T]) -> bool {
@@ -1588,6 +1611,8 @@ impl<'a,T:PartialEq> PartialEq for &'a mut [T] {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 #[unstable = "waiting for DST"]
 impl<'a,T:Eq> Eq for &'a mut [T] {}
 
@@ -1597,6 +1622,8 @@ impl<'a,T:PartialEq, V: AsSlice<T>> Equiv<V> for &'a mut [T] {
     fn equiv(&self, other: &V) -> bool { self.as_slice() == other.as_slice() }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 #[unstable = "waiting for DST"]
 impl<'a,T:Ord> Ord for &'a [T] {
     fn cmp(&self, other: & &'a [T]) -> Ordering {
@@ -1604,6 +1631,16 @@ impl<'a,T:Ord> Ord for &'a [T] {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[unstable = "waiting for DST"]
+impl<T: Ord> Ord for [T] {
+    fn cmp(&self, other: &[T]) -> Ordering {
+        order::cmp(self.iter(), other.iter())
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 #[unstable = "waiting for DST"]
 impl<'a, T: PartialOrd> PartialOrd for &'a [T] {
     #[inline]
@@ -1624,6 +1661,31 @@ impl<'a, T: PartialOrd> PartialOrd for &'a [T] {
     }
     #[inline]
     fn gt(&self, other: & &'a [T]) -> bool {
+        order::gt(self.iter(), other.iter())
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[unstable = "waiting for DST"]
+impl<T: PartialOrd> PartialOrd for [T] {
+    #[inline]
+    fn partial_cmp(&self, other: &[T]) -> Option<Ordering> {
+        order::partial_cmp(self.iter(), other.iter())
+    }
+    #[inline]
+    fn lt(&self, other: &[T]) -> bool {
+        order::lt(self.iter(), other.iter())
+    }
+    #[inline]
+    fn le(&self, other: &[T]) -> bool {
+        order::le(self.iter(), other.iter())
+    }
+    #[inline]
+    fn ge(&self, other: &[T]) -> bool {
+        order::ge(self.iter(), other.iter())
+    }
+    #[inline]
+    fn gt(&self, other: &[T]) -> bool {
         order::gt(self.iter(), other.iter())
     }
 }

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1122,6 +1122,8 @@ pub mod traits {
     use ops;
     use str::{Str, StrSlice, eq_slice};
 
+    // NOTE(stage0): remove impl after a snapshot
+    #[cfg(stage0)]
     impl<'a> Ord for &'a str {
         #[inline]
         fn cmp(&self, other: & &'a str) -> Ordering {
@@ -1137,6 +1139,24 @@ pub mod traits {
         }
     }
 
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    impl Ord for str {
+        #[inline]
+        fn cmp(&self, other: &str) -> Ordering {
+            for (s_b, o_b) in self.bytes().zip(other.bytes()) {
+                match s_b.cmp(&o_b) {
+                    Greater => return Greater,
+                    Less => return Less,
+                    Equal => ()
+                }
+            }
+
+            self.len().cmp(&other.len())
+        }
+    }
+
+    // NOTE(stage0): remove impl after a snapshot
+    #[cfg(stage0)]
     impl<'a> PartialEq for &'a str {
         #[inline]
         fn eq(&self, other: & &'a str) -> bool {
@@ -1146,11 +1166,36 @@ pub mod traits {
         fn ne(&self, other: & &'a str) -> bool { !(*self).eq(other) }
     }
 
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    impl PartialEq for str {
+        #[inline]
+        fn eq(&self, other: &str) -> bool {
+            eq_slice(self, other)
+        }
+        #[inline]
+        fn ne(&self, other: &str) -> bool { !(*self).eq(other) }
+    }
+
+    // NOTE(stage0): remove impl after a snapshot
+    #[cfg(stage0)]
     impl<'a> Eq for &'a str {}
 
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    impl Eq for str {}
+
+    // NOTE(stage0): remove impl after a snapshot
+    #[cfg(stage0)]
     impl<'a> PartialOrd for &'a str {
         #[inline]
         fn partial_cmp(&self, other: &&'a str) -> Option<Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    impl PartialOrd for str {
+        #[inline]
+        fn partial_cmp(&self, other: &str) -> Option<Ordering> {
             Some(self.cmp(other))
         }
     }

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -19,8 +19,7 @@
 use mem;
 use char;
 use char::Char;
-use cmp;
-use cmp::{PartialEq, Eq};
+use cmp::{Eq, mod};
 use default::Default;
 use iter::{Map, Iterator};
 use iter::{DoubleEndedIterator, ExactSize};

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -93,7 +93,6 @@
 
 #[cfg(test)] #[phase(plugin, link)] extern crate log;
 
-use std::cmp::PartialEq;
 use std::fmt;
 use std::result::{Err, Ok};
 use std::result;

--- a/src/libgraphviz/maybe_owned_vec.rs
+++ b/src/libgraphviz/maybe_owned_vec.rs
@@ -76,14 +76,26 @@ impl<'a, T: PartialEq> PartialEq for MaybeOwnedVector<'a, T> {
 impl<'a, T: Eq> Eq for MaybeOwnedVector<'a, T> {}
 
 impl<'a, T: PartialOrd> PartialOrd for MaybeOwnedVector<'a, T> {
+    // NOTE(stage0): remove method after a snapshot
+    #[cfg(stage0)]
     fn partial_cmp(&self, other: &MaybeOwnedVector<T>) -> Option<Ordering> {
         self.as_slice().partial_cmp(&other.as_slice())
+    }
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    fn partial_cmp(&self, other: &MaybeOwnedVector<T>) -> Option<Ordering> {
+        self.as_slice().partial_cmp(other.as_slice())
     }
 }
 
 impl<'a, T: Ord> Ord for MaybeOwnedVector<'a, T> {
+    // NOTE(stage0): remove method after a snapshot
+    #[cfg(stage0)]
     fn cmp(&self, other: &MaybeOwnedVector<T>) -> Ordering {
         self.as_slice().cmp(&other.as_slice())
+    }
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    fn cmp(&self, other: &MaybeOwnedVector<T>) -> Ordering {
+        self.as_slice().cmp(other.as_slice())
     }
 }
 

--- a/src/libregex/parse.rs
+++ b/src/libregex/parse.rs
@@ -1020,8 +1020,18 @@ fn is_valid_cap(c: char) -> bool {
     || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 }
 
+// NOTE(stage0): remove function after a snapshot
+#[cfg(stage0)]
 fn find_class(classes: NamedClasses, name: &str) -> Option<Vec<(char, char)>> {
     match classes.binary_search(|&(s, _)| s.cmp(&name)) {
+        slice::Found(i) => Some(classes[i].val1().to_vec()),
+        slice::NotFound(_) => None,
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+fn find_class(classes: NamedClasses, name: &str) -> Option<Vec<(char, char)>> {
+    match classes.binary_search(|&(s, _)| s.cmp(name)) {
         slice::Found(i) => Some(classes[i].val1().to_vec()),
         slice::NotFound(_) => None,
     }

--- a/src/librustc/driver/mod.rs
+++ b/src/librustc/driver/mod.rs
@@ -182,6 +182,8 @@ Available lint options:
 
 ");
 
+    // NOTE(stage0): remove function after a snapshot
+    #[cfg(stage0)]
     fn sort_lints(lints: Vec<(&'static Lint, bool)>) -> Vec<&'static Lint> {
         let mut lints: Vec<_> = lints.into_iter().map(|(x, _)| x).collect();
         lints.sort_by(|x: &&Lint, y: &&Lint| {
@@ -194,12 +196,38 @@ Available lint options:
         lints
     }
 
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    fn sort_lints(lints: Vec<(&'static Lint, bool)>) -> Vec<&'static Lint> {
+        let mut lints: Vec<_> = lints.into_iter().map(|(x, _)| x).collect();
+        lints.sort_by(|x: &&Lint, y: &&Lint| {
+            match x.default_level.cmp(&y.default_level) {
+                // The sort doesn't case-fold but it's doubtful we care.
+                Equal => x.name.cmp(y.name),
+                r => r,
+            }
+        });
+        lints
+    }
+
+    // NOTE(stage0): remove function after a snapshot
+    #[cfg(stage0)]
     fn sort_lint_groups(lints: Vec<(&'static str, Vec<lint::LintId>, bool)>)
                      -> Vec<(&'static str, Vec<lint::LintId>)> {
         let mut lints: Vec<_> = lints.into_iter().map(|(x, y, _)| (x, y)).collect();
         lints.sort_by(|&(x, _): &(&'static str, Vec<lint::LintId>),
                        &(y, _): &(&'static str, Vec<lint::LintId>)| {
             x.cmp(&y)
+        });
+        lints
+    }
+
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    fn sort_lint_groups(lints: Vec<(&'static str, Vec<lint::LintId>, bool)>)
+                     -> Vec<(&'static str, Vec<lint::LintId>)> {
+        let mut lints: Vec<_> = lints.into_iter().map(|(x, y, _)| (x, y)).collect();
+        lints.sort_by(|&(x, _): &(&'static str, Vec<lint::LintId>),
+                       &(y, _): &(&'static str, Vec<lint::LintId>)| {
+            x.cmp(y)
         });
         lints
     }

--- a/src/librustrt/c_str.rs
+++ b/src/librustrt/c_str.rs
@@ -121,9 +121,16 @@ impl PartialEq for CString {
 }
 
 impl PartialOrd for CString {
+    // NOTE(stage0): remove method after a snapshot
+    #[cfg(stage0)]
     #[inline]
     fn partial_cmp(&self, other: &CString) -> Option<Ordering> {
         self.as_bytes().partial_cmp(&other.as_bytes())
+    }
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    #[inline]
+    fn partial_cmp(&self, other: &CString) -> Option<Ordering> {
+        self.as_bytes().partial_cmp(other.as_bytes())
     }
 }
 

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -890,9 +890,21 @@ impl Json {
 
      /// If the Json value is an Object, returns the value associated with the provided key.
     /// Otherwise, returns None.
+    // NOTE(stage0): remove function after a snapshot
+    #[cfg(stage0)]
     pub fn find<'a>(&'a self, key: &str) -> Option<&'a Json>{
         match self {
             &Object(ref map) => map.find_with(|s| key.cmp(&s.as_slice())),
+            _ => None
+        }
+    }
+
+     /// If the Json value is an Object, returns the value associated with the provided key.
+    /// Otherwise, returns None.
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    pub fn find<'a>(&'a self, key: &str) -> Option<&'a Json>{
+        match self {
+            &Object(ref map) => map.find_with(|s| key.cmp(s.as_slice())),
             _ => None
         }
     }
@@ -914,10 +926,36 @@ impl Json {
     /// If the Json value is an Object, performs a depth-first search until
     /// a value associated with the provided key is found. If no value is found
     /// or the Json value is not an Object, returns None.
+    // NOTE(stage0): remove function after a snapshot
+    #[cfg(stage0)]
     pub fn search<'a>(&'a self, key: &str) -> Option<&'a Json> {
         match self {
             &Object(ref map) => {
                 match map.find_with(|s| key.cmp(&s.as_slice())) {
+                    Some(json_value) => Some(json_value),
+                    None => {
+                        for (_, v) in map.iter() {
+                            match v.search(key) {
+                                x if x.is_some() => return x,
+                                _ => ()
+                            }
+                        }
+                        None
+                    }
+                }
+            },
+            _ => None
+        }
+    }
+
+    /// If the Json value is an Object, performs a depth-first search until
+    /// a value associated with the provided key is found. If no value is found
+    /// or the Json value is not an Object, returns None.
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    pub fn search<'a>(&'a self, key: &str) -> Option<&'a Json> {
+        match self {
+            &Object(ref map) => {
+                match map.find_with(|s| key.cmp(s.as_slice())) {
                     Some(json_value) => Some(json_value),
                     None => {
                         for (_, v) in map.iter() {

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -97,8 +97,14 @@ pub struct RcStr {
 impl Eq for RcStr {}
 
 impl Ord for RcStr {
+    // NOTE(stage0): remove method after a snapshot
+    #[cfg(stage0)]
     fn cmp(&self, other: &RcStr) -> Ordering {
         self.as_slice().cmp(&other.as_slice())
+    }
+    #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+    fn cmp(&self, other: &RcStr) -> Ordering {
+        self.as_slice().cmp(other.as_slice())
     }
 }
 

--- a/src/test/compile-fail/deriving-no-inner-impl-error-message.rs
+++ b/src/test/compile-fail/deriving-no-inner-impl-error-message.rs
@@ -12,8 +12,8 @@ struct NoCloneOrEq;
 
 #[deriving(PartialEq)]
 struct E {
-    x: NoCloneOrEq //~ ERROR does not implement any method in scope named `eq`
-         //~^ ERROR does not implement any method in scope named `ne`
+    x: NoCloneOrEq //~ ERROR binary operation `==` cannot be applied to type `NoCloneOrEq`
+         //~^ ERROR binary operation `!=` cannot be applied to type `NoCloneOrEq`
 }
 #[deriving(Clone)]
 struct C {

--- a/src/test/run-pass/deriving-eq-ord-boxed-slice.rs
+++ b/src/test/run-pass/deriving-eq-ord-boxed-slice.rs
@@ -1,0 +1,24 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[deriving(PartialEq, PartialOrd, Eq, Ord)]
+struct Foo(Box<[u8]>);
+
+pub fn main() {
+    let a = Foo(box [0, 1, 2]);
+    let b = Foo(box [0, 1, 2]);
+    assert!(a == b);
+    println!("{}", a != b);
+    println!("{}", a < b);
+    println!("{}", a <= b);
+    println!("{}", a == b);
+    println!("{}", a > b);
+    println!("{}", a >= b);
+}

--- a/src/test/run-pass/issue-15689-1.rs
+++ b/src/test/run-pass/issue-15689-1.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[deriving(PartialEq)]
+enum Test<'a> {
+    Slice(&'a int)
+}
+
+fn main() {
+    assert!(Slice(&1) == Slice(&1))
+}


### PR DESCRIPTION
`eq`, `ne`, `cmp`, etc methods now require one less level of indirection when dealing with `&str`/`&[T]`

``` rust
"foo".ne(&"bar") -> "foo".ne("bar")
slice.cmp(&another_slice) -> slice.cmp(another_slice)
// slice and another_slice have type `&[T]`
```

[breaking-change]
