### PR TITLE
Ensure Extend is implemented and renamed Extendable to Extend

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -93,7 +93,7 @@ syn keyword rustEnum Ordering
 syn keyword rustEnumVariant Less Equal Greater
 syn keyword rustTrait Collection Mutable Map MutableMap MutableSeq
 syn keyword rustTrait Set MutableSet
-syn keyword rustTrait FromIterator Extendable ExactSize
+syn keyword rustTrait FromIterator IntoIterator Extend ExactSize
 syn keyword rustTrait Iterator DoubleEndedIterator
 syn keyword rustTrait RandomAccessIterator CloneableIterator
 syn keyword rustTrait OrdIterator MutableDoubleEndedIterator

--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -555,7 +555,7 @@ impl<T: Ord> FromIterator<T> for BinaryHeap<T> {
     }
 }
 
-impl<T: Ord> Extendable<T> for BinaryHeap<T> {
+impl<T: Ord> Extend<T> for BinaryHeap<T> {
     fn extend<Iter: Iterator<T>>(&mut self, mut iter: Iter) {
         let (lower, _) = iter.size_hint();
 

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -835,7 +835,7 @@ impl FromIterator<bool> for Bitv {
     }
 }
 
-impl Extendable<bool> for Bitv {
+impl Extend<bool> for Bitv {
     #[inline]
     fn extend<I: Iterator<bool>>(&mut self, mut iterator: I) {
         let (min, _) = iterator.size_hint();
@@ -1014,7 +1014,7 @@ impl FromIterator<bool> for BitvSet {
     }
 }
 
-impl Extendable<bool> for BitvSet {
+impl Extend<bool> for BitvSet {
     #[inline]
     fn extend<I: Iterator<bool>>(&mut self, iterator: I) {
         let &BitvSet(ref mut self_bitv) = self;

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -727,7 +727,7 @@ impl<K: Ord, V> FromIterator<(K, V)> for BTreeMap<K, V> {
     }
 }
 
-impl<K: Ord, V> Extendable<(K, V)> for BTreeMap<K, V> {
+impl<K: Ord, V> Extend<(K, V)> for BTreeMap<K, V> {
     #[inline]
     fn extend<T: Iterator<(K, V)>>(&mut self, mut iter: T) {
         for (k, v) in iter {

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -316,7 +316,7 @@ impl<T: Ord> FromIterator<T> for BTreeSet<T> {
     }
 }
 
-impl<T: Ord> Extendable<T> for BTreeSet<T> {
+impl<T: Ord> Extend<T> for BTreeSet<T> {
     #[inline]
     fn extend<Iter: Iterator<T>>(&mut self, mut iter: Iter) {
         for elem in iter {

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -720,7 +720,7 @@ impl<A> FromIterator<A> for DList<A> {
     }
 }
 
-impl<A> Extendable<A> for DList<A> {
+impl<A> Extend<A> for DList<A> {
     fn extend<T: Iterator<A>>(&mut self, mut iterator: T) {
         for elt in iterator { self.push_back(elt); }
     }

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -230,6 +230,22 @@ impl<E:CLike> Iterator<E> for Items<E> {
     }
 }
 
+impl<E:CLike> FromIterator<E> for EnumSet<E> {
+    fn from_iter<I:Iterator<E>>(iterator: I) -> EnumSet<E> {
+        let mut ret = EnumSet::new();
+        ret.extend(iterator);
+        ret
+    }
+}
+
+impl<E:CLike> Extend<E> for EnumSet<E> {
+    fn extend<I: Iterator<E>>(&mut self, mut iterator: I) {
+        for element in iterator {
+            self.insert(element);
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::prelude::*;

--- a/src/libcollections/ring_buf.rs
+++ b/src/libcollections/ring_buf.rs
@@ -735,7 +735,7 @@ impl<A> FromIterator<A> for RingBuf<A> {
     }
 }
 
-impl<A> Extendable<A> for RingBuf<A> {
+impl<A> Extend<A> for RingBuf<A> {
     fn extend<T: Iterator<A>>(&mut self, mut iterator: T) {
         for elt in iterator {
             self.push_back(elt);

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -683,8 +683,8 @@ impl FromIterator<char> for String {
     }
 }
 
-#[experimental = "waiting on Extendable stabilization"]
-impl Extendable<char> for String {
+#[experimental = "waiting on Extend stabilization"]
+impl Extend<char> for String {
     fn extend<I:Iterator<char>>(&mut self, mut iterator: I) {
         for ch in iterator {
             self.push(ch)

--- a/src/libcollections/tree/map.rs
+++ b/src/libcollections/tree/map.rs
@@ -1260,7 +1260,7 @@ impl<K: Ord, V> FromIterator<(K, V)> for TreeMap<K, V> {
     }
 }
 
-impl<K: Ord, V> Extendable<(K, V)> for TreeMap<K, V> {
+impl<K: Ord, V> Extend<(K, V)> for TreeMap<K, V> {
     #[inline]
     fn extend<T: Iterator<(K, V)>>(&mut self, mut iter: T) {
         for (k, v) in iter {

--- a/src/libcollections/tree/set.rs
+++ b/src/libcollections/tree/set.rs
@@ -659,7 +659,7 @@ impl<T: Ord> FromIterator<T> for TreeSet<T> {
     }
 }
 
-impl<T: Ord> Extendable<T> for TreeSet<T> {
+impl<T: Ord> Extend<T> for TreeSet<T> {
     #[inline]
     fn extend<Iter: Iterator<T>>(&mut self, mut iter: Iter) {
         for elem in iter {

--- a/src/libcollections/trie/map.rs
+++ b/src/libcollections/trie/map.rs
@@ -628,7 +628,7 @@ impl<T> FromIterator<(uint, T)> for TrieMap<T> {
     }
 }
 
-impl<T> Extendable<(uint, T)> for TrieMap<T> {
+impl<T> Extend<(uint, T)> for TrieMap<T> {
     fn extend<Iter: Iterator<(uint, T)>>(&mut self, mut iter: Iter) {
         for (k, v) in iter {
             self.insert(k, v);

--- a/src/libcollections/trie/set.rs
+++ b/src/libcollections/trie/set.rs
@@ -355,7 +355,7 @@ impl FromIterator<uint> for TrieSet {
     }
 }
 
-impl Extendable<uint> for TrieSet {
+impl Extend<uint> for TrieSet {
     fn extend<Iter: Iterator<uint>>(&mut self, mut iter: Iter) {
         for elem in iter {
             self.insert(elem);

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -484,8 +484,8 @@ impl<T> FromIterator<T> for Vec<T> {
     }
 }
 
-#[experimental = "waiting on Extendable stability"]
-impl<T> Extendable<T> for Vec<T> {
+#[experimental = "waiting on Extend stability"]
+impl<T> Extend<T> for Vec<T> {
     #[inline]
     fn extend<I: Iterator<T>>(&mut self, mut iterator: I) {
         let (lower, _) = iterator.size_hint();

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -499,7 +499,7 @@ impl<V> FromIterator<(uint, V)> for VecMap<V> {
     }
 }
 
-impl<V> Extendable<(uint, V)> for VecMap<V> {
+impl<V> Extend<(uint, V)> for VecMap<V> {
     fn extend<Iter: Iterator<(uint, V)>>(&mut self, mut iter: Iter) {
         for (k, v) in iter {
             self.insert(k, v);

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -66,6 +66,7 @@ use num::{Zero, One, CheckedAdd, CheckedSub, Saturating, ToPrimitive, Int};
 use ops::{Add, Mul, Sub};
 use option::{Option, Some, None};
 use uint;
+#[deprecated = "renamed to Extend"] pub use self::Extend as Extendable;
 
 /// Conversion from an `Iterator`
 pub trait FromIterator<A> {
@@ -74,8 +75,8 @@ pub trait FromIterator<A> {
 }
 
 /// A type growable from an `Iterator` implementation
-pub trait Extendable<A>: FromIterator<A> {
-    /// Extend a container with the elements yielded by an iterator
+pub trait Extend<A> {
+    /// Extend a container with the elements yielded by an arbitrary iterator
     fn extend<T: Iterator<A>>(&mut self, iterator: T);
 }
 

--- a/src/libcore/prelude.rs
+++ b/src/libcore/prelude.rs
@@ -48,7 +48,7 @@ pub use char::Char;
 pub use clone::Clone;
 pub use cmp::{PartialEq, PartialOrd, Eq, Ord};
 pub use cmp::{Ordering, Less, Equal, Greater, Equiv};
-pub use iter::{FromIterator, Extendable};
+pub use iter::{FromIterator, Extend};
 pub use iter::{Iterator, DoubleEndedIterator, RandomAccessIterator, CloneableIterator};
 pub use iter::{OrdIterator, MutableDoubleEndedIterator, ExactSize};
 pub use num::{Num, NumCast, CheckedAdd, CheckedSub, CheckedMul};

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use clean::*;
-use std::iter::Extendable;
+use std::iter::Extend;
 use std::mem::{replace, swap};
 
 pub trait DocFolder {

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -15,7 +15,7 @@ use cmp::{max, Eq, Equiv, PartialEq};
 use default::Default;
 use fmt::{mod, Show};
 use hash::{Hash, Hasher, RandomSipHasher};
-use iter::{mod, Iterator, FromIterator, Extendable};
+use iter::{mod, Iterator, FromIterator, Extend};
 use kinds::Sized;
 use mem::{mod, replace};
 use num;
@@ -1449,7 +1449,7 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S> + Default> FromIterator<(K, V)> for Has
     }
 }
 
-impl<K: Eq + Hash<S>, V, S, H: Hasher<S> + Default> Extendable<(K, V)> for HashMap<K, V, H> {
+impl<K: Eq + Hash<S>, V, S, H: Hasher<S> + Default> Extend<(K, V)> for HashMap<K, V, H> {
     fn extend<T: Iterator<(K, V)>>(&mut self, mut iter: T) {
         for (k, v) in iter {
             self.insert(k, v);

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -16,7 +16,7 @@ use default::Default;
 use fmt::Show;
 use fmt;
 use hash::{Hash, Hasher, RandomSipHasher};
-use iter::{Iterator, FromIterator, FilterMap, Chain, Repeat, Zip, Extendable};
+use iter::{Iterator, FromIterator, FilterMap, Chain, Repeat, Zip, Extend};
 use iter;
 use option::{Some, None};
 use result::{Ok, Err};
@@ -574,7 +574,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S> + Default> FromIterator<T> for HashSet<T, 
     }
 }
 
-impl<T: Eq + Hash<S>, S, H: Hasher<S> + Default> Extendable<T> for HashSet<T, H> {
+impl<T: Eq + Hash<S>, S, H: Hasher<S> + Default> Extend<T> for HashSet<T, H> {
     fn extend<I: Iterator<T>>(&mut self, mut iter: I) {
         for k in iter {
             self.insert(k);

--- a/src/libstd/collections/lru_cache.rs
+++ b/src/libstd/collections/lru_cache.rs
@@ -41,7 +41,7 @@ use cmp::{PartialEq, Eq};
 use collections::HashMap;
 use fmt;
 use hash::Hash;
-use iter::{range, Iterator};
+use iter::{range, Iterator, Extend};
 use mem;
 use ops::Drop;
 use option::{Some, None, Option};
@@ -329,6 +329,15 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
     /// Clear the cache of all key-value pairs.
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn clear(&mut self) { self.map.clear(); }
+
+}
+
+impl<K: Hash + Eq, V> Extend<(K, V)> for LruCache<K, V> {
+    fn extend<T: Iterator<(K, V)>>(&mut self, mut iter: T) {
+        for (k, v) in iter{
+            self.insert(k, v);
+        }
+    }
 }
 
 impl<A: fmt::Show + Hash + Eq, B: fmt::Show> fmt::Show for LruCache<A, B> {

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -60,7 +60,7 @@ use io::{IoResult, IoError, FileStat, SeekStyle, Seek, Writer, Reader};
 use io::{Read, Truncate, SeekCur, SeekSet, ReadWrite, SeekEnd, Append};
 use io::UpdateIoError;
 use io;
-use iter::{Iterator, Extendable};
+use iter::{Iterator, Extend};
 use kinds::Send;
 use libc;
 use option::{Some, None, Option};

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -16,7 +16,7 @@ use cmp::{PartialEq, Eq, PartialOrd, Ord, Ordering};
 use from_str::FromStr;
 use hash;
 use io::Writer;
-use iter::{DoubleEndedIterator, AdditiveIterator, Extendable, Iterator, Map};
+use iter::{DoubleEndedIterator, AdditiveIterator, Extend, Iterator, Map};
 use option::{Option, None, Some};
 use str::Str;
 use str;

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -19,7 +19,7 @@ use cmp::{PartialEq, Eq, PartialOrd, Ord, Ordering};
 use from_str::FromStr;
 use hash;
 use io::Writer;
-use iter::{AdditiveIterator, DoubleEndedIterator, Extendable, Iterator, Map};
+use iter::{AdditiveIterator, DoubleEndedIterator, Extend, Iterator, Map};
 use mem;
 use option::{Option, Some, None};
 use slice::{AsSlice, SlicePrelude};

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -63,7 +63,7 @@
 #[doc(no_inline)] pub use clone::Clone;
 #[doc(no_inline)] pub use cmp::{PartialEq, PartialOrd, Eq, Ord};
 #[doc(no_inline)] pub use cmp::{Ordering, Less, Equal, Greater, Equiv};
-#[doc(no_inline)] pub use iter::{FromIterator, Extendable, ExactSize};
+#[doc(no_inline)] pub use iter::{FromIterator, Extend, ExactSize};
 #[doc(no_inline)] pub use iter::{Iterator, DoubleEndedIterator};
 #[doc(no_inline)] pub use iter::{RandomAccessIterator, CloneableIterator};
 #[doc(no_inline)] pub use iter::{OrdIterator, MutableDoubleEndedIterator};

--- a/src/libsyntax/util/small_vector.rs
+++ b/src/libsyntax/util/small_vector.rs
@@ -33,7 +33,7 @@ impl<T> FromIterator<T> for SmallVector<T> {
     }
 }
 
-impl<T> Extendable<T> for SmallVector<T> {
+impl<T> Extend<T> for SmallVector<T> {
     fn extend<I: Iterator<T>>(&mut self, mut iter: I) {
         for val in iter {
             self.push(val);


### PR DESCRIPTION
Ensured that Extend & FromIterator are implemented for the libcollection.

Removed the fact that FromIterator had to be implemented in order to implement Extend, as it did not make sense for LruCache (it needs to be given a size and there are no Default for LruCache).

Changed the name from Extend to Extendable.

Part of #18424 
