### PR TITLE
rustc: Change byte literals to fixed-size arrays

### DIFF
--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -677,9 +677,8 @@ pub fn C_str_slice(cx: &CrateContext, s: InternedString) -> ValueRef {
     }
 }
 
-pub fn C_binary_slice(cx: &CrateContext, data: &[u8]) -> ValueRef {
+pub fn C_binary_array(cx: &CrateContext, data: &[u8]) -> ValueRef {
     unsafe {
-        let len = data.len();
         let lldata = C_bytes(cx, data);
 
         let gsym = token::gensym("binary");
@@ -689,9 +688,7 @@ pub fn C_binary_slice(cx: &CrateContext, data: &[u8]) -> ValueRef {
         llvm::LLVMSetInitializer(g, lldata);
         llvm::LLVMSetGlobalConstant(g, True);
         llvm::SetLinkage(g, llvm::InternalLinkage);
-
-        let cs = llvm::LLVMConstPointerCast(g, Type::i8p(cx).to_ref());
-        C_struct(cx, [cs, C_uint(cx, len)], false)
+        g
     }
 }
 

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -83,7 +83,7 @@ pub fn const_lit(cx: &CrateContext, e: &ast::Expr, lit: &ast::Lit)
         ast::LitBool(b) => C_bool(cx, b),
         ast::LitNil => C_nil(cx),
         ast::LitStr(ref s, _) => C_str_slice(cx, (*s).clone()),
-        ast::LitBinary(ref data) => C_binary_slice(cx, data.as_slice()),
+        ast::LitBinary(ref data) => C_binary_array(cx, data.as_slice()),
     }
 }
 

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2690,8 +2690,11 @@ fn check_lit(fcx: &FnCtxt,
 
     match lit.node {
         ast::LitStr(..) => ty::mk_str_slice(tcx, ty::ReStatic, ast::MutImmutable),
-        ast::LitBinary(..) => {
-            ty::mk_slice(tcx, ty::ReStatic, ty::mt{ ty: ty::mk_u8(), mutbl: ast::MutImmutable })
+        ast::LitBinary(ref v) => {
+            ty::mk_rptr(tcx, ty::ReStatic, ty::mt {
+                ty: ty::mk_vec(tcx, ty::mk_u8(), Some(v.len())),
+                mutbl: ast::MutImmutable,
+            })
         }
         ast::LitByte(_) => ty::mk_u8(),
         ast::LitChar(_) => ty::mk_char(),

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -154,7 +154,7 @@ impl GenericPathUnsafe for Path {
     unsafe fn set_filename_unchecked<T: BytesContainer>(&mut self, filename: T) {
         let filename = filename.container_as_bytes();
         match self.sepidx {
-            None if b".." == self.repr.as_slice() => {
+            None if self.repr.as_slice() == b".." => {
                 let mut v = Vec::with_capacity(3 + filename.len());
                 v.push_all(dot_dot_static);
                 v.push(SEP_BYTE);
@@ -214,7 +214,7 @@ impl GenericPath for Path {
 
     fn dirname<'a>(&'a self) -> &'a [u8] {
         match self.sepidx {
-            None if b".." == self.repr.as_slice() => self.repr.as_slice(),
+            None if self.repr.as_slice() == b".." => self.repr.as_slice(),
             None => dot_static,
             Some(0) => self.repr[..1],
             Some(idx) if self.repr[idx+1..] == b".." => self.repr.as_slice(),
@@ -224,8 +224,8 @@ impl GenericPath for Path {
 
     fn filename<'a>(&'a self) -> Option<&'a [u8]> {
         match self.sepidx {
-            None if b"." == self.repr.as_slice() ||
-                b".." == self.repr.as_slice() => None,
+            None if self.repr.as_slice() == b"." ||
+                self.repr.as_slice() == b".." => None,
             None => Some(self.repr.as_slice()),
             Some(idx) if self.repr[idx+1..] == b".." => None,
             Some(0) if self.repr[1..].is_empty() => None,
@@ -235,13 +235,13 @@ impl GenericPath for Path {
 
     fn pop(&mut self) -> bool {
         match self.sepidx {
-            None if b"." == self.repr.as_slice() => false,
+            None if self.repr.as_slice() == b"." => false,
             None => {
                 self.repr = vec![b'.'];
                 self.sepidx = None;
                 true
             }
-            Some(0) if b"/" == self.repr.as_slice() => false,
+            Some(0) if self.repr.as_slice() == b"/" => false,
             Some(idx) => {
                 if idx == 0 {
                     self.repr.truncate(idx+1);
@@ -273,7 +273,7 @@ impl GenericPath for Path {
         } else {
             let mut ita = self.components();
             let mut itb = other.components();
-            if b"." == self.repr.as_slice() {
+            if self.repr.as_slice() == b"." {
                 return match itb.next() {
                     None => true,
                     Some(b) => b != b".."

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -801,7 +801,7 @@ impl LitIntType {
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub enum Lit_ {
     LitStr(InternedString, StrStyle),
-    LitBinary(Rc<Vec<u8> >),
+    LitBinary(Rc<Vec<u8>>),
     LitByte(u8),
     LitChar(char),
     LitInt(u64, LitIntType),

--- a/src/test/run-pass/issue-18465.rs
+++ b/src/test/run-pass/issue-18465.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const FOO: &'static [u8, ..3] = b"foo";
+const BAR: &'static [u8] = b"foo";
+
+fn main() {
+    let foo: &'static [u8, ..3] = b"foo";
+    let bar: &'static [u8] = b"foo";
+}


### PR DESCRIPTION
This commit alters the type of `b"foo"` from `&'static [u8]` to
`&'static [u8, ..3]` and is an implementation of RFC 339.

This is a breaking change because not all operations are always compatible with
fixed-size arrays currently when compared with slices. As seen in the diff, if a
fixed-size array is the left hand size of an equality then the operator may not
resolve. Breakage may require some shuffling or explicitly converting to a slice
via `.as_slice()` or `[]`.

[breaking-change]
Closes #18465
