### PR TITLE
First stage of implementation of namespaced enums

### DIFF
--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -15,6 +15,7 @@
 use metadata::common::*;
 use metadata::cstore;
 use metadata::decoder;
+use middle::def;
 use middle::lang_items;
 use middle::resolve;
 use middle::ty;
@@ -112,6 +113,12 @@ pub fn maybe_get_item_ast<'tcx>(tcx: &ty::ctxt<'tcx>, def: ast::DefId,
     let cstore = &tcx.sess.cstore;
     let cdata = cstore.get_crate_data(def.krate);
     decoder::maybe_get_item_ast(&*cdata, tcx, def.node, decode_inlined_item)
+}
+
+pub fn get_enum_variant_defs(cstore: &cstore::CStore, enum_id: ast::DefId)
+                             -> Vec<(def::Def, ast::Name, ast::Visibility)> {
+    let cdata = cstore.get_crate_data(enum_id.krate);
+    decoder::get_enum_variant_defs(&*cstore.intr, &*cdata, enum_id.node)
 }
 
 pub fn get_enum_variants(tcx: &ty::ctxt, def: ast::DefId)

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -659,6 +659,24 @@ pub fn maybe_get_item_ast<'tcx>(cdata: Cmd, tcx: &ty::ctxt<'tcx>, id: ast::NodeI
     }
 }
 
+pub fn get_enum_variant_defs(intr: &IdentInterner,
+                             cdata: Cmd,
+                             id: ast::NodeId)
+                             -> Vec<(def::Def, ast::Name, ast::Visibility)> {
+    let data = cdata.data();
+    let items = reader::get_doc(rbml::Doc::new(data), tag_items);
+    let item = find_item(id, items);
+    enum_variant_ids(item, cdata).iter().map(|did| {
+        let item = find_item(did.node, items);
+        let name = item_name(intr, item);
+        let visibility = item_visibility(item);
+        match item_to_def_like(item, *did, cdata.cnum) {
+            DlDef(def @ def::DefVariant(..)) => (def, name, visibility),
+            _ => unreachable!()
+        }
+    }).collect()
+}
+
 pub fn get_enum_variants(intr: Rc<IdentInterner>, cdata: Cmd, id: ast::NodeId,
                      tcx: &ty::ctxt) -> Vec<Rc<ty::VariantInfo>> {
     let data = cdata.data();

--- a/src/test/auxiliary/namespaced_enum_emulate_flat.rs
+++ b/src/test/auxiliary/namespaced_enum_emulate_flat.rs
@@ -7,29 +7,32 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![feature(globs, struct_variant)]
 
-pub use self::sub::{Bar, Baz};
+pub use Foo::*;
 
-pub trait Trait {
-    fn foo();
+pub enum Foo {
+    A,
+    B(int),
+    C { a: int },
 }
-
-struct Foo;
 
 impl Foo {
-    pub fn new() {}
+    pub fn foo() {}
 }
 
-mod sub {
-    pub struct Bar;
+pub mod nest {
+    pub use self::Bar::*;
+
+    pub enum Bar {
+        D,
+        E(int),
+        F { a: int },
+    }
 
     impl Bar {
-        pub fn new() {}
-    }
-
-    pub enum Baz {}
-
-    impl Baz {
-        pub fn new() {}
+        pub fn foo() {}
     }
 }
+
+

--- a/src/test/auxiliary/namespaced_enums.rs
+++ b/src/test/auxiliary/namespaced_enums.rs
@@ -7,29 +7,16 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![feature(struct_variant)]
 
-pub use self::sub::{Bar, Baz};
-
-pub trait Trait {
-    fn foo();
+pub enum Foo {
+    A,
+    B(int),
+    C { a: int },
 }
-
-struct Foo;
 
 impl Foo {
-    pub fn new() {}
+    pub fn foo() {}
+    pub fn bar(&self) {}
 }
 
-mod sub {
-    pub struct Bar;
-
-    impl Bar {
-        pub fn new() {}
-    }
-
-    pub enum Baz {}
-
-    impl Baz {
-        pub fn new() {}
-    }
-}

--- a/src/test/compile-fail/enum-and-module-in-same-scope.rs
+++ b/src/test/compile-fail/enum-and-module-in-same-scope.rs
@@ -13,7 +13,7 @@ mod Foo {
 }
 
 enum Foo {  //~ ERROR duplicate definition of type or module `Foo`
-    X
+    X //~ ERROR duplicate definition of value `X`
 }
 
 fn main() {}

--- a/src/test/compile-fail/namespaced-enum-glob-import-no-impls-xcrate.rs
+++ b/src/test/compile-fail/namespaced-enum-glob-import-no-impls-xcrate.rs
@@ -8,28 +8,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub use self::sub::{Bar, Baz};
+// aux-build:namespaced_enums.rs
+#![feature(struct_variant, globs)]
 
-pub trait Trait {
-    fn foo();
+extern crate namespaced_enums;
+
+mod m {
+    pub use namespaced_enums::Foo::*;
 }
 
-struct Foo;
+pub fn main() {
+    use namespaced_enums::Foo::*;
 
-impl Foo {
-    pub fn new() {}
+    foo(); //~ ERROR unresolved name `foo`
+    m::foo(); //~ ERROR unresolved name `m::foo`
+    bar(); //~ ERROR unresolved name `bar`
+    m::bar(); //~ ERROR unresolved name `m::bar`
 }
 
-mod sub {
-    pub struct Bar;
-
-    impl Bar {
-        pub fn new() {}
-    }
-
-    pub enum Baz {}
-
-    impl Baz {
-        pub fn new() {}
-    }
-}

--- a/src/test/compile-fail/namespaced-enum-glob-import-no-impls.rs
+++ b/src/test/compile-fail/namespaced-enum-glob-import-no-impls.rs
@@ -7,29 +7,30 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![feature(struct_variant, globs)]
 
-pub use self::sub::{Bar, Baz};
-
-pub trait Trait {
-    fn foo();
-}
-
-struct Foo;
-
-impl Foo {
-    pub fn new() {}
-}
-
-mod sub {
-    pub struct Bar;
-
-    impl Bar {
-        pub fn new() {}
+mod m2 {
+    pub enum Foo {
+        A,
+        B(int),
+        C { a: int },
     }
 
-    pub enum Baz {}
-
-    impl Baz {
-        pub fn new() {}
+    impl Foo {
+        pub fn foo() {}
+        pub fn bar(&self) {}
     }
+}
+
+mod m {
+    pub use m2::Foo::*;
+}
+
+pub fn main() {
+    use m2::Foo::*;
+
+    foo(); //~ ERROR unresolved name `foo`
+    m::foo(); //~ ERROR unresolved name `m::foo`
+    bar(); //~ ERROR unresolved name `bar`
+    m::bar(); //~ ERROR unresolved name `m::bar`
 }

--- a/src/test/compile-fail/use-from-trait-xc.rs
+++ b/src/test/compile-fail/use-from-trait-xc.rs
@@ -13,12 +13,15 @@
 extern crate use_from_trait_xc;
 
 use use_from_trait_xc::Trait::foo;
-//~^ ERROR unresolved import `use_from_trait_xc::Trait::foo`. Cannot import from a trait or type imp
+//~^ ERROR `foo` is not directly importable
 
 use use_from_trait_xc::Foo::new;
-//~^ ERROR unresolved import `use_from_trait_xc::Foo::new`. Cannot import from a trait or type imple
+//~^ ERROR `new` is not directly importable
 
-use use_from_trait_xc::Bar::new;
-//~^ ERROR unresolved import `use_from_trait_xc::Bar::new`. Cannot import from a trait or type
+use use_from_trait_xc::Bar::new as bnew;
+//~^ ERROR `bnew` is not directly importable
+
+use use_from_trait_xc::Baz::new as baznew;
+//~^ ERROR `baznew` is not directly importable
 
 fn main() {}

--- a/src/test/compile-fail/use-from-trait.rs
+++ b/src/test/compile-fail/use-from-trait.rs
@@ -9,9 +9,9 @@
 // except according to those terms.
 
 use Trait::foo;
-//~^ ERROR unresolved import `Trait::foo`. Cannot import from a trait or type implementation
+//~^ ERROR `foo` is not directly importable
 use Foo::new;
-//~^ ERROR unresolved import `Foo::new`. Cannot import from a trait or type implementation
+//~^ ERROR `new` is not directly importable
 
 pub trait Trait {
     fn foo();

--- a/src/test/run-pass/namespaced-enum-emulate-flat-xc.rs
+++ b/src/test/run-pass/namespaced-enum-emulate-flat-xc.rs
@@ -8,28 +8,25 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub use self::sub::{Bar, Baz};
+// aux-build:namespaced_enum_emulate_flat.rs
+#![feature(struct_variant)]
 
-pub trait Trait {
-    fn foo();
-}
+extern crate namespaced_enum_emulate_flat;
 
-struct Foo;
+use namespaced_enum_emulate_flat::{Foo, A, B, C};
+use namespaced_enum_emulate_flat::nest::{Bar, D, E, F};
 
-impl Foo {
-    pub fn new() {}
-}
-
-mod sub {
-    pub struct Bar;
-
-    impl Bar {
-        pub fn new() {}
-    }
-
-    pub enum Baz {}
-
-    impl Baz {
-        pub fn new() {}
+fn _f(f: Foo) {
+    match f {
+        A | B(_) | C { .. } => {}
     }
 }
+
+fn _f2(f: Bar) {
+    match f {
+        D | E(_) | F { .. } => {}
+    }
+}
+
+pub fn main() {}
+

--- a/src/test/run-pass/namespaced-enum-emulate-flat.rs
+++ b/src/test/run-pass/namespaced-enum-emulate-flat.rs
@@ -7,29 +7,45 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![feature(globs, struct_variant)]
 
-pub use self::sub::{Bar, Baz};
+pub use Foo::*;
+use nest::{Bar, D, E, F};
 
-pub trait Trait {
-    fn foo();
+pub enum Foo {
+    A,
+    B(int),
+    C { a: int },
 }
-
-struct Foo;
 
 impl Foo {
-    pub fn new() {}
+    pub fn foo() {}
 }
 
-mod sub {
-    pub struct Bar;
+fn _f(f: Foo) {
+    match f {
+        A | B(_) | C { .. } => {}
+    }
+}
+
+mod nest {
+    pub use self::Bar::*;
+
+    pub enum Bar {
+        D,
+        E(int),
+        F { a: int },
+    }
 
     impl Bar {
-        pub fn new() {}
-    }
-
-    pub enum Baz {}
-
-    impl Baz {
-        pub fn new() {}
+        pub fn foo() {}
     }
 }
+
+fn _f2(f: Bar) {
+    match f {
+        D | E(_) | F { .. } => {}
+    }
+}
+
+fn main() {}

--- a/src/test/run-pass/namespaced-enum-glob-import-xcrate.rs
+++ b/src/test/run-pass/namespaced-enum-glob-import-xcrate.rs
@@ -8,28 +8,27 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub use self::sub::{Bar, Baz};
+// aux-build:namespaced_enums.rs
+#![feature(globs, struct_variant)]
 
-pub trait Trait {
-    fn foo();
-}
+extern crate namespaced_enums;
 
-struct Foo;
+fn _f(f: namespaced_enums::Foo) {
+    use namespaced_enums::Foo::*;
 
-impl Foo {
-    pub fn new() {}
-}
-
-mod sub {
-    pub struct Bar;
-
-    impl Bar {
-        pub fn new() {}
-    }
-
-    pub enum Baz {}
-
-    impl Baz {
-        pub fn new() {}
+    match f {
+        A | B(_) | C { .. } => {}
     }
 }
+
+mod m {
+    pub use namespaced_enums::Foo::*;
+}
+
+fn _f2(f: namespaced_enums::Foo) {
+    match f {
+        m::A | m::B(_) | m::C { .. } => {}
+    }
+}
+
+pub fn main() {}

--- a/src/test/run-pass/namespaced-enum-glob-import.rs
+++ b/src/test/run-pass/namespaced-enum-glob-import.rs
@@ -7,29 +7,36 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![feature(globs, struct_variant)]
 
-pub use self::sub::{Bar, Baz};
-
-pub trait Trait {
-    fn foo();
-}
-
-struct Foo;
-
-impl Foo {
-    pub fn new() {}
-}
-
-mod sub {
-    pub struct Bar;
-
-    impl Bar {
-        pub fn new() {}
+mod m2 {
+    pub enum Foo {
+        A,
+        B(int),
+        C { a: int },
     }
 
-    pub enum Baz {}
-
-    impl Baz {
-        pub fn new() {}
+    impl Foo {
+        pub fn foo() {}
     }
 }
+
+mod m {
+    pub use m2::Foo::*;
+}
+
+fn _f(f: m2::Foo) {
+    use m2::Foo::*;
+
+    match f {
+        A | B(_) | C { .. } => {}
+    }
+}
+
+fn _f2(f: m2::Foo) {
+    match f {
+        m::A | m::B(_) | m::C { .. } => {}
+    }
+}
+
+pub fn main() {}

--- a/src/test/run-pass/namespaced-enums-xcrate.rs
+++ b/src/test/run-pass/namespaced-enums-xcrate.rs
@@ -8,28 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub use self::sub::{Bar, Baz};
+// aux-build:namespaced_enums.rs
+#![feature(struct_variant)]
 
-pub trait Trait {
-    fn foo();
-}
+extern crate namespaced_enums;
 
-struct Foo;
+use namespaced_enums::Foo;
 
-impl Foo {
-    pub fn new() {}
-}
-
-mod sub {
-    pub struct Bar;
-
-    impl Bar {
-        pub fn new() {}
-    }
-
-    pub enum Baz {}
-
-    impl Baz {
-        pub fn new() {}
+fn _foo (f: Foo) {
+    match f {
+        Foo::A | Foo::B(_) | Foo::C { .. } => {}
     }
 }
+
+pub fn main() {}
+

--- a/src/test/run-pass/namespaced-enums.rs
+++ b/src/test/run-pass/namespaced-enums.rs
@@ -7,29 +7,18 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![feature(struct_variant)]
 
-pub use self::sub::{Bar, Baz};
-
-pub trait Trait {
-    fn foo();
+enum Foo {
+    A,
+    B(int),
+    C { a: int },
 }
 
-struct Foo;
-
-impl Foo {
-    pub fn new() {}
-}
-
-mod sub {
-    pub struct Bar;
-
-    impl Bar {
-        pub fn new() {}
-    }
-
-    pub enum Baz {}
-
-    impl Baz {
-        pub fn new() {}
+fn _foo (f: Foo) {
+    match f {
+        Foo::A | Foo::B(_) | Foo::C { .. } => {}
     }
 }
+
+pub fn main() {}


### PR DESCRIPTION
After a snapshot, everything can be switched over and the small bit of hackery in resolve dealing with `ENUM_STAGING_HACK` can be removed.

cc #18478
