### PR TITLE
Support Sized bounds for associated types

### DIFF
--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -717,8 +717,9 @@ impl<'a> vtable_decoder_helpers for reader::Decoder<'a> {
     {
         let types = self.read_to_vec(|this| Ok(f(this))).unwrap();
         let selfs = self.read_to_vec(|this| Ok(f(this))).unwrap();
+        let assocs = self.read_to_vec(|this| Ok(f(this))).unwrap();
         let fns = self.read_to_vec(|this| Ok(f(this))).unwrap();
-        VecPerParamSpace::new(types, selfs, fns)
+        VecPerParamSpace::new(types, selfs, assocs, fns)
     }
 
     fn read_vtable_res_with_key(&mut self,

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -81,7 +81,7 @@ pub fn encode_inlined_item(ecx: &e::EncodeContext,
         e::IIForeignRef(i) => i.id,
         e::IITraitItemRef(_, &ast::ProvidedMethod(ref m)) => m.id,
         e::IITraitItemRef(_, &ast::RequiredMethod(ref m)) => m.id,
-        e::IITraitItemRef(_, &ast::TypeTraitItem(ref ti)) => ti.id,
+        e::IITraitItemRef(_, &ast::TypeTraitItem(ref ti)) => ti.ty_param.id,
         e::IIImplItemRef(_, &ast::MethodImplItem(ref m)) => m.id,
         e::IIImplItemRef(_, &ast::TypeImplItem(ref ti)) => ti.id,
     };
@@ -156,7 +156,7 @@ pub fn decode_inlined_item<'tcx>(cdata: &cstore::crate_metadata,
                 match *ti {
                     ast::ProvidedMethod(ref m) => m.pe_ident(),
                     ast::RequiredMethod(ref ty_m) => ty_m.ident,
-                    ast::TypeTraitItem(ref ti) => ti.ident,
+                    ast::TypeTraitItem(ref ti) => ti.ty_param.ident,
                 }
             },
             ast::IIImplItem(_, ref m) => {

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -296,8 +296,8 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EmbargoVisitor<'a, 'tcx> {
                             self.exported_items.insert(m.id);
                         }
                         ast::TypeTraitItem(ref t) => {
-                            debug!("typedef {}", t.id);
-                            self.exported_items.insert(t.id);
+                            debug!("typedef {}", t.ty_param.id);
+                            self.exported_items.insert(t.ty_param.id);
                         }
                     }
                 }

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -1559,19 +1559,19 @@ impl<'a> Resolver<'a> {
                         }
                         ast::TypeTraitItem(ref associated_type) => {
                             let def = DefAssociatedTy(local_def(
-                                    associated_type.id));
+                                    associated_type.ty_param.id));
 
                             let name_bindings =
-                                self.add_child(associated_type.ident.name,
+                                self.add_child(associated_type.ty_param.ident.name,
                                                module_parent.clone(),
                                                ForbidDuplicateTypesAndValues,
-                                               associated_type.span);
+                                               associated_type.ty_param.span);
                             // NB: not IMPORTABLE
                             name_bindings.define_type(def,
-                                                      associated_type.span,
+                                                      associated_type.ty_param.span,
                                                       PUBLIC);
 
-                            (associated_type.ident.name, TypeTraitItemKind)
+                            (associated_type.ty_param.ident.name, TypeTraitItemKind)
                         }
                     };
 
@@ -4218,7 +4218,7 @@ impl<'a> Resolver<'a> {
                                             impl_items.as_slice());
             }
 
-            ItemTrait(ref generics, ref unbound, ref bounds, ref methods) => {
+            ItemTrait(ref generics, ref unbound, ref bounds, ref trait_items) => {
                 // Create a new rib for the self type.
                 let mut self_type_rib = Rib::new(ItemRibKind);
 
@@ -4246,13 +4246,13 @@ impl<'a> Resolver<'a> {
                         _ => {}
                     }
 
-                    for method in (*methods).iter() {
-                        // Create a new rib for the method-specific type
+                    for trait_item in (*trait_items).iter() {
+                        // Create a new rib for the trait_item-specific type
                         // parameters.
                         //
                         // FIXME #4951: Do we need a node ID here?
 
-                        match *method {
+                        match *trait_item {
                           ast::RequiredMethod(ref ty_m) => {
                             this.with_type_parameter_rib
                                 (HasTypeParameters(&ty_m.generics,
@@ -4287,8 +4287,9 @@ impl<'a> Resolver<'a> {
                                                                 ProvidedMethod(m.id)),
                                                   &**m)
                           }
-                          ast::TypeTraitItem(_) => {
-                              visit::walk_trait_item(this, method);
+                          ast::TypeTraitItem(ref data) => {
+                              this.resolve_type_parameter(&data.ty_param);
+                              visit::walk_trait_item(this, trait_item);
                           }
                         }
                     }
@@ -4477,20 +4478,25 @@ impl<'a> Resolver<'a> {
     fn resolve_type_parameters(&mut self,
                                type_parameters: &OwnedSlice<TyParam>) {
         for type_parameter in type_parameters.iter() {
-            for bound in type_parameter.bounds.iter() {
-                self.resolve_type_parameter_bound(type_parameter.id, bound,
-                                                  TraitBoundingTypeParameter);
-            }
-            match &type_parameter.unbound {
-                &Some(ref unbound) =>
-                    self.resolve_type_parameter_bound(
-                        type_parameter.id, unbound, TraitBoundingTypeParameter),
-                &None => {}
-            }
-            match type_parameter.default {
-                Some(ref ty) => self.resolve_type(&**ty),
-                None => {}
-            }
+            self.resolve_type_parameter(type_parameter);
+        }
+    }
+
+    fn resolve_type_parameter(&mut self,
+                              type_parameter: &TyParam) {
+        for bound in type_parameter.bounds.iter() {
+            self.resolve_type_parameter_bound(type_parameter.id, bound,
+                                              TraitBoundingTypeParameter);
+        }
+        match &type_parameter.unbound {
+            &Some(ref unbound) =>
+                self.resolve_type_parameter_bound(
+                    type_parameter.id, unbound, TraitBoundingTypeParameter),
+            &None => {}
+        }
+        match type_parameter.default {
+            Some(ref ty) => self.resolve_type(&**ty),
+            None => {}
         }
     }
 
@@ -4577,14 +4583,14 @@ impl<'a> Resolver<'a> {
                         self.resolve_error(trait_reference.path.span,
                                            format!("`{}` is not a trait",
                                                    self.path_names_to_string(
-                                                        &trait_reference.path)));
+                                                       &trait_reference.path)));
 
                         // If it's a typedef, give a note
                         match def {
                             DefTy(..) => {
                                 self.session.span_note(
-                                                trait_reference.path.span,
-                                                format!("`type` aliases cannot \
+                                    trait_reference.path.span,
+                                    format!("`type` aliases cannot \
                                                         be used for traits")
                                                         .as_slice());
                             }

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -86,7 +86,7 @@ impl<'v> Visitor<'v> for Annotator {
                 }
             }
 
-            TypeTraitItem(ref typedef) => (typedef.id, &typedef.attrs),
+            TypeTraitItem(ref typedef) => (typedef.ty_param.id, &typedef.attrs),
         };
         self.annotate(id, attrs, |v| visit::walk_trait_item(v, t));
     }

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -118,10 +118,11 @@ impl Substs {
 
     pub fn new_trait(t: Vec<ty::t>,
                      r: Vec<ty::Region>,
+                     a: Vec<ty::t>,
                      s: ty::t)
                     -> Substs
     {
-        Substs::new(VecPerParamSpace::new(t, vec!(s), Vec::new(), Vec::new()),
+        Substs::new(VecPerParamSpace::new(t, vec!(s), a, Vec::new()),
                     VecPerParamSpace::new(r, Vec::new(), Vec::new(), Vec::new()))
     }
 

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1683,6 +1683,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 vec![arguments_tuple.subst(self.tcx(), substs),
                      new_signature.output.unwrap().subst(self.tcx(), substs)],
                 vec![],
+                vec![],
                 obligation.self_ty())
         });
 

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1607,7 +1607,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             Ok(o) => o,
             Err(ErrorReported) => Vec::new()
         };
-        let obligations = VecPerParamSpace::new(obligations, Vec::new(), Vec::new());
+        let obligations = VecPerParamSpace::new(obligations, Vec::new(),
+                                                Vec::new(), Vec::new());
         VtableBuiltinData { nested: obligations }
     }
 

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -205,7 +205,7 @@ pub fn trans_static_method_callee(bcx: Block,
     // type parameters that belong to the trait but also some that
     // belong to the method:
     let rcvr_substs = node_id_substs(bcx, ExprId(expr_id));
-    let (rcvr_type, rcvr_self, rcvr_method) = rcvr_substs.types.split();
+    let (rcvr_type, rcvr_self, rcvr_assoc, rcvr_method) = rcvr_substs.types.split();
 
     // Lookup the precise impl being called. To do that, we need to
     // create a trait reference identifying the self type and other
@@ -232,6 +232,7 @@ pub fn trans_static_method_callee(bcx: Block,
     let trait_substs =
         Substs::erased(VecPerParamSpace::new(rcvr_type,
                                              rcvr_self,
+                                             rcvr_assoc,
                                              Vec::new()));
     debug!("trait_substs={}", trait_substs.repr(bcx.tcx()));
     let trait_ref = Rc::new(ty::TraitRef { def_id: trait_id,
@@ -265,10 +266,11 @@ pub fn trans_static_method_callee(bcx: Block,
             // that with the `rcvr_method` from before, which tells us
             // the type parameters from the *method*, to yield
             // `callee_substs=[[T=int],[],[U=String]]`.
-            let (impl_type, impl_self, _) = impl_substs.types.split();
+            let (impl_type, impl_self, impl_assoc, _) = impl_substs.types.split();
             let callee_substs =
                 Substs::erased(VecPerParamSpace::new(impl_type,
                                                      impl_self,
+                                                     impl_assoc,
                                                      rcvr_method));
 
             let mth_id = method_with_name(ccx, impl_did, mname);
@@ -397,12 +399,12 @@ fn combine_impl_and_methods_tps(bcx: Block,
 
     // Break apart the type parameters from the node and type
     // parameters from the receiver.
-    let (_, _, node_method) = node_substs.types.split();
-    let (rcvr_type, rcvr_self, rcvr_method) = rcvr_substs.types.clone().split();
+    let (_, _, _, node_method) = node_substs.types.split();
+    let (rcvr_type, rcvr_self, rcvr_assoc, rcvr_method) = rcvr_substs.types.clone().split();
     assert!(rcvr_method.is_empty());
     subst::Substs {
         regions: subst::ErasedRegions,
-        types: subst::VecPerParamSpace::new(rcvr_type, rcvr_self, node_method)
+        types: subst::VecPerParamSpace::new(rcvr_type, rcvr_self, rcvr_assoc, node_method)
     }
 }
 

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -205,7 +205,12 @@ pub fn trans_static_method_callee(bcx: Block,
     // type parameters that belong to the trait but also some that
     // belong to the method:
     let rcvr_substs = node_id_substs(bcx, ExprId(expr_id));
-    let (rcvr_type, rcvr_self, rcvr_assoc, rcvr_method) = rcvr_substs.types.split();
+    let subst::SeparateVecsPerParamSpace {
+        types: rcvr_type,
+        selfs: rcvr_self,
+        assocs: rcvr_assoc,
+        fns: rcvr_method
+    } = rcvr_substs.types.split();
 
     // Lookup the precise impl being called. To do that, we need to
     // create a trait reference identifying the self type and other
@@ -266,7 +271,12 @@ pub fn trans_static_method_callee(bcx: Block,
             // that with the `rcvr_method` from before, which tells us
             // the type parameters from the *method*, to yield
             // `callee_substs=[[T=int],[],[U=String]]`.
-            let (impl_type, impl_self, impl_assoc, _) = impl_substs.types.split();
+            let subst::SeparateVecsPerParamSpace {
+                types: impl_type,
+                selfs: impl_self,
+                assocs: impl_assoc,
+                fns: _
+            } = impl_substs.types.split();
             let callee_substs =
                 Substs::erased(VecPerParamSpace::new(impl_type,
                                                      impl_self,
@@ -399,8 +409,13 @@ fn combine_impl_and_methods_tps(bcx: Block,
 
     // Break apart the type parameters from the node and type
     // parameters from the receiver.
-    let (_, _, _, node_method) = node_substs.types.split();
-    let (rcvr_type, rcvr_self, rcvr_assoc, rcvr_method) = rcvr_substs.types.clone().split();
+    let node_method = node_substs.types.split().fns;
+    let subst::SeparateVecsPerParamSpace {
+        types: rcvr_type,
+        selfs: rcvr_self,
+        assocs: rcvr_assoc,
+        fns: rcvr_method
+    } = rcvr_substs.types.clone().split();
     assert!(rcvr_method.is_empty());
     subst::Substs {
         regions: subst::ErasedRegions,

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -573,10 +573,6 @@ pub struct ctxt<'tcx> {
     /// Maps def IDs to true if and only if they're associated types.
     pub associated_types: RefCell<DefIdMap<bool>>,
 
-    /// Maps def IDs of traits to information about their associated types.
-    pub trait_associated_types:
-        RefCell<DefIdMap<Rc<Vec<AssociatedTypeInfo>>>>,
-
     /// Caches the results of trait selection. This cache is used
     /// for things that do not have to do with the parameters in scope.
     pub selection_cache: traits::SelectionCache,
@@ -1564,7 +1560,6 @@ pub fn mk_ctxt<'tcx>(s: Session,
         stability: RefCell::new(stability),
         capture_modes: capture_modes,
         associated_types: RefCell::new(DefIdMap::new()),
-        trait_associated_types: RefCell::new(DefIdMap::new()),
         selection_cache: traits::SelectionCache::new(),
         repr_hint_cache: RefCell::new(DefIdMap::new()),
    }
@@ -1991,6 +1986,16 @@ impl ItemSubsts {
 
     pub fn is_noop(&self) -> bool {
         self.substs.is_noop()
+    }
+}
+
+impl ParamBounds {
+    pub fn empty() -> ParamBounds {
+        ParamBounds {
+            builtin_bounds: empty_builtin_bounds(),
+            trait_bounds: Vec::new(),
+            region_bounds: Vec::new(),
+        }
     }
 }
 
@@ -4153,18 +4158,6 @@ impl Ord for AssociatedTypeInfo {
     fn cmp(&self, other: &AssociatedTypeInfo) -> Ordering {
         self.index.cmp(&other.index)
     }
-}
-
-/// Returns the associated types belonging to the given trait, in parameter
-/// order.
-pub fn associated_types_for_trait(cx: &ctxt, trait_id: ast::DefId)
-                                  -> Rc<Vec<AssociatedTypeInfo>> {
-    cx.trait_associated_types
-      .borrow()
-      .find(&trait_id)
-      .expect("associated_types_for_trait(): trait not found, try calling \
-               ensure_associated_types()")
-      .clone()
 }
 
 pub fn trait_item_def_ids(cx: &ctxt, id: ast::DefId)

--- a/src/librustc/middle/typeck/infer/mod.rs
+++ b/src/librustc/middle/typeck/infer/mod.rs
@@ -774,10 +774,15 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         assert!(generics.regions.len(subst::FnSpace) == 0);
 
         let type_parameter_count = generics.types.len(subst::TypeSpace);
+        let type_parameters = self.next_ty_vars(type_parameter_count);
+
         let region_param_defs = generics.regions.get_slice(subst::TypeSpace);
         let regions = self.region_vars_for_defs(span, region_param_defs);
-        let type_parameters = self.next_ty_vars(type_parameter_count);
-        subst::Substs::new_trait(type_parameters, regions, self_ty)
+
+        let assoc_type_parameter_count = generics.types.len(subst::AssocSpace);
+        let assoc_type_parameters = self.next_ty_vars(assoc_type_parameter_count);
+
+        subst::Substs::new_trait(type_parameters, regions, assoc_type_parameters, self_ty)
     }
 
     pub fn fresh_bound_region(&self, binder_id: ast::NodeId) -> ty::Region {
@@ -791,7 +796,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
     pub fn ty_to_string(&self, t: ty::t) -> String {
         ty_to_string(self.tcx,
-                  self.resolve_type_vars_if_possible(t))
+                     self.resolve_type_vars_if_possible(t))
     }
 
     pub fn tys_to_string(&self, ts: &[ty::t]) -> String {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -666,10 +666,11 @@ impl Repr for subst::Substs {
 
 impl<T:Repr> Repr for subst::VecPerParamSpace<T> {
     fn repr(&self, tcx: &ctxt) -> String {
-        format!("[{};{};{}]",
-                       self.get_slice(subst::TypeSpace).repr(tcx),
-                       self.get_slice(subst::SelfSpace).repr(tcx),
-                       self.get_slice(subst::FnSpace).repr(tcx))
+        format!("[{};{};{};{}]",
+                self.get_slice(subst::TypeSpace).repr(tcx),
+                self.get_slice(subst::SelfSpace).repr(tcx),
+                self.get_slice(subst::AssocSpace).repr(tcx),
+                self.get_slice(subst::FnSpace).repr(tcx))
     }
 }
 

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -423,7 +423,13 @@ pub fn ty_to_string(cx: &ctxt, typ: t) -> String {
         }
         ty_infer(infer_ty) => infer_ty_to_string(cx, infer_ty),
         ty_err => "[type error]".to_string(),
-        ty_param(ref param_ty) => param_ty.repr(cx),
+        ty_param(ref param_ty) => {
+            if cx.sess.verbose() {
+                param_ty.repr(cx)
+            } else {
+                param_ty.user_string(cx)
+            }
+        }
         ty_enum(did, ref substs) | ty_struct(did, ref substs) => {
             let base = ty::item_path_str(cx, did);
             let generics = ty::lookup_item_type(cx, did).generics;
@@ -479,6 +485,17 @@ pub fn parameterized(cx: &ctxt,
                      generics: &ty::Generics)
                      -> String
 {
+    if cx.sess.verbose() {
+        if substs.is_noop() {
+            return format!("{}", base);
+        } else {
+            return format!("{}<{},{}>",
+                           base,
+                           substs.regions.repr(cx),
+                           substs.types.repr(cx));
+        }
+    }
+
     let mut strs = Vec::new();
 
     match substs.regions {
@@ -503,7 +520,7 @@ pub fn parameterized(cx: &ctxt,
     let tps = substs.types.get_slice(subst::TypeSpace);
     let ty_params = generics.types.get_slice(subst::TypeSpace);
     let has_defaults = ty_params.last().map_or(false, |def| def.default.is_some());
-    let num_defaults = if has_defaults && !cx.sess.verbose() {
+    let num_defaults = if has_defaults {
         ty_params.iter().zip(tps.iter()).rev().take_while(|&(def, &actual)| {
             match def.default {
                 Some(default) => default.subst(cx, substs) == actual,
@@ -516,18 +533,6 @@ pub fn parameterized(cx: &ctxt,
 
     for t in tps[..tps.len() - num_defaults].iter() {
         strs.push(ty_to_string(cx, *t))
-    }
-
-    if cx.sess.verbose() {
-        for t in substs.types.get_slice(subst::SelfSpace).iter() {
-            strs.push(format!("self {}", t.repr(cx)));
-        }
-
-        // generally there shouldn't be any substs in the fn param
-        // space, but in verbose mode, print them out.
-        for t in substs.types.get_slice(subst::FnSpace).iter() {
-            strs.push(format!("fn {}", t.repr(cx)));
-        }
     }
 
     if strs.len() > 0u {
@@ -725,7 +730,7 @@ impl Repr for ty::TraitRef {
     fn repr(&self, tcx: &ctxt) -> String {
         let base = ty::item_path_str(tcx, self.def_id);
         let trait_def = ty::lookup_trait_def(tcx, self.def_id);
-        format!("<{} as {}>",
+        format!("<{} : {}>",
                 self.substs.self_ty().repr(tcx),
                 parameterized(tcx, base.as_slice(), &self.substs, &trait_def.generics))
     }
@@ -737,6 +742,19 @@ impl Repr for ty::TraitDef {
                 self.generics.repr(tcx),
                 self.bounds.repr(tcx),
                 self.trait_ref.repr(tcx))
+    }
+}
+
+impl Repr for ast::TraitItem {
+    fn repr(&self, _tcx: &ctxt) -> String {
+        match *self {
+            ast::RequiredMethod(ref data) => format!("RequiredMethod({}, id={})",
+                                                     data.ident, data.id),
+            ast::ProvidedMethod(ref data) => format!("ProvidedMethod(id={})",
+                                                     data.id),
+            ast::TypeTraitItem(ref data) => format!("TypeTraitItem({}, id={})",
+                                                     data.ty_param.ident, data.ty_param.id),
+        }
     }
 }
 
@@ -755,6 +773,12 @@ impl Repr for ast::Path {
 impl UserString for ast::Path {
     fn user_string(&self, _tcx: &ctxt) -> String {
         pprust::path_to_string(self)
+    }
+}
+
+impl Repr for ast::Ty {
+    fn repr(&self, _tcx: &ctxt) -> String {
+        format!("type({})", pprust::ty_to_string(self))
     }
 }
 
@@ -1261,7 +1285,8 @@ impl UserString for ParamTy {
 
 impl Repr for ParamTy {
     fn repr(&self, tcx: &ctxt) -> String {
-        self.user_string(tcx)
+        let ident = self.user_string(tcx);
+        format!("{}/{}.{}", ident, self.space, self.idx)
     }
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2203,12 +2203,12 @@ impl Clean<Stability> for attr::Stability {
 impl Clean<Item> for ast::AssociatedType {
     fn clean(&self, cx: &DocContext) -> Item {
         Item {
-            source: self.span.clean(cx),
-            name: Some(self.ident.clean(cx)),
+            source: self.ty_param.span.clean(cx),
+            name: Some(self.ty_param.ident.clean(cx)),
             attrs: self.attrs.clean(cx),
             inner: AssociatedTypeItem,
             visibility: None,
-            def_id: ast_util::local_def(self.id),
+            def_id: ast_util::local_def(self.ty_param.id),
             stability: None,
         }
     }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -861,10 +861,8 @@ pub enum ImplItem {
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub struct AssociatedType {
-    pub id: NodeId,
-    pub span: Span,
-    pub ident: Ident,
     pub attrs: Vec<Attribute>,
+    pub ty_param: TyParam,
 }
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]

--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -405,7 +405,9 @@ impl<'ast> Map<'ast> {
                         MethMac(_) => panic!("no path elem for {}", node),
                     }
                 }
-                TypeTraitItem(ref m) => PathName(m.ident.name),
+                TypeTraitItem(ref m) => {
+                    PathName(m.ty_param.ident.name)
+                }
             },
             NodeVariant(v) => PathName(v.node.name.name),
             _ => panic!("no path elem for {}", node)
@@ -510,7 +512,7 @@ impl<'ast> Map<'ast> {
                 match *trait_method {
                     RequiredMethod(ref type_method) => type_method.span,
                     ProvidedMethod(ref method) => method.span,
-                    TypeTraitItem(ref typedef) => typedef.span,
+                    TypeTraitItem(ref typedef) => typedef.ty_param.span,
                 }
             }
             Some(NodeImplItem(ref impl_item)) => {
@@ -650,7 +652,7 @@ impl Named for TraitItem {
         match *self {
             RequiredMethod(ref tm) => tm.ident.name,
             ProvidedMethod(ref m) => m.name(),
-            TypeTraitItem(ref at) => at.ident.name,
+            TypeTraitItem(ref at) => at.ty_param.ident.name,
         }
     }
 }
@@ -783,7 +785,7 @@ impl<'ast> Visitor<'ast> for NodeCollector<'ast> {
                             self.insert(m.id, NodeTraitItem(tm));
                         }
                         TypeTraitItem(ref typ) => {
-                            self.insert(typ.id, NodeTraitItem(tm));
+                            self.insert(typ.ty_param.id, NodeTraitItem(tm));
                         }
                     }
                 }
@@ -976,7 +978,7 @@ pub fn map_decoded_item<'ast, F: FoldOps>(map: &Map<'ast>,
             let trait_item_id = match *trait_item {
                 ProvidedMethod(ref m) => m.id,
                 RequiredMethod(ref m) => m.id,
-                TypeTraitItem(ref ty) => ty.id,
+                TypeTraitItem(ref ty) => ty.ty_param.id,
             };
 
             collector.insert(trait_item_id, NodeTraitItem(trait_item));
@@ -1080,7 +1082,7 @@ fn node_id_to_string(map: &Map, id: NodeId) -> String {
                 }
                 TypeTraitItem(ref t) => {
                     format!("type item {} in {} (id={})",
-                            token::get_ident(t.ident),
+                            token::get_ident(t.ty_param.ident),
                             map.path_to_string(id),
                             id)
                 }

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -525,7 +525,7 @@ impl<'a, 'v, O: IdVisitingOperation> Visitor<'v> for IdVisitor<'a, O> {
         match *tm {
             ast::RequiredMethod(ref m) => self.operation.visit_id(m.id),
             ast::ProvidedMethod(ref m) => self.operation.visit_id(m.id),
-            ast::TypeTraitItem(ref typ) => self.operation.visit_id(typ.id),
+            ast::TypeTraitItem(ref typ) => self.operation.visit_id(typ.ty_param.id),
         }
         visit::walk_trait_item(self, tm);
     }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -260,7 +260,7 @@ impl<'a, 'v> Visitor<'v> for Context<'a> {
             ast::RequiredMethod(_) | ast::ProvidedMethod(_) => {}
             ast::TypeTraitItem(ref ti) => {
                 self.gate_feature("associated_types",
-                                  ti.span,
+                                  ti.ty_param.span,
                                   "associated types are experimental")
             }
         }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -793,19 +793,16 @@ pub fn noop_fold_typedef<T>(t: Typedef, folder: &mut T)
 
 pub fn noop_fold_associated_type<T>(at: AssociatedType, folder: &mut T)
                                     -> AssociatedType
-                                    where T: Folder {
-    let new_id = folder.new_id(at.id);
-    let new_span = folder.new_span(at.span);
-    let new_ident = folder.fold_ident(at.ident);
+                                    where T: Folder
+{
     let new_attrs = at.attrs
                       .iter()
                       .map(|attr| folder.fold_attribute((*attr).clone()))
                       .collect();
+    let new_param = folder.fold_ty_param(at.ty_param);
     ast::AssociatedType {
-        ident: new_ident,
         attrs: new_attrs,
-        id: new_id,
-        span: new_span,
+        ty_param: new_param,
     }
 }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1229,16 +1229,13 @@ impl<'a> Parser<'a> {
     /// Parses `type Foo;` in a trait declaration only. The `type` keyword has
     /// already been parsed.
     fn parse_associated_type(&mut self, attrs: Vec<Attribute>)
-                             -> AssociatedType {
-        let lo = self.span.lo;
-        let ident = self.parse_ident();
-        let hi = self.span.hi;
+                             -> AssociatedType
+    {
+        let ty_param = self.parse_ty_param();
         self.expect(&token::Semi);
         AssociatedType {
-            id: ast::DUMMY_NODE_ID,
-            span: mk_sp(lo, hi),
-            ident: ident,
             attrs: attrs,
+            ty_param: ty_param,
         }
     }
 

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -596,7 +596,8 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_method: &'v Tr
         RequiredMethod(ref method_type) => visitor.visit_ty_method(method_type),
         ProvidedMethod(ref method) => walk_method_helper(visitor, &**method),
         TypeTraitItem(ref associated_type) => {
-            visitor.visit_ident(associated_type.span, associated_type.ident)
+            visitor.visit_ident(associated_type.ty_param.span,
+                                associated_type.ty_param.ident)
         }
     }
 }

--- a/src/test/compile-fail/associated-types-unsized.rs
+++ b/src/test/compile-fail/associated-types-unsized.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(associated_types)]
+
+trait Get {
+    type Sized? Value;
+    fn get(&self) -> <Self as Get>::Value;
+}
+
+fn foo<T:Get>(t: T) {
+    let x = t.get(); //~ ERROR the trait `core::kinds::Sized` is not implemented
+}
+
+fn main() {
+}
+

--- a/src/test/compile-fail/variance-regions-direct.rs
+++ b/src/test/compile-fail/variance-regions-direct.rs
@@ -14,7 +14,7 @@
 // Regions that just appear in normal spots are contravariant:
 
 #[rustc_variance]
-struct Test2<'a, 'b, 'c> { //~ ERROR regions=[[-, -, -];[];[]]
+struct Test2<'a, 'b, 'c> { //~ ERROR regions=[[-, -, -];[];[];[]]
     x: &'a int,
     y: &'b [int],
     c: &'c str
@@ -23,7 +23,7 @@ struct Test2<'a, 'b, 'c> { //~ ERROR regions=[[-, -, -];[];[]]
 // Those same annotations in function arguments become covariant:
 
 #[rustc_variance]
-struct Test3<'a, 'b, 'c> { //~ ERROR regions=[[+, +, +];[];[]]
+struct Test3<'a, 'b, 'c> { //~ ERROR regions=[[+, +, +];[];[];[]]
     x: extern "Rust" fn(&'a int),
     y: extern "Rust" fn(&'b [int]),
     c: extern "Rust" fn(&'c str),
@@ -32,7 +32,7 @@ struct Test3<'a, 'b, 'c> { //~ ERROR regions=[[+, +, +];[];[]]
 // Mutability induces invariance:
 
 #[rustc_variance]
-struct Test4<'a, 'b:'a> { //~ ERROR regions=[[-, o];[];[]]
+struct Test4<'a, 'b:'a> { //~ ERROR regions=[[-, o];[];[];[]]
     x: &'a mut &'b int,
 }
 
@@ -40,7 +40,7 @@ struct Test4<'a, 'b:'a> { //~ ERROR regions=[[-, o];[];[]]
 // contravariant context:
 
 #[rustc_variance]
-struct Test5<'a, 'b> { //~ ERROR regions=[[+, o];[];[]]
+struct Test5<'a, 'b> { //~ ERROR regions=[[+, o];[];[];[]]
     x: extern "Rust" fn(&'a mut &'b int),
 }
 
@@ -50,21 +50,21 @@ struct Test5<'a, 'b> { //~ ERROR regions=[[+, o];[];[]]
 // argument list occurs in an invariant context.
 
 #[rustc_variance]
-struct Test6<'a, 'b> { //~ ERROR regions=[[-, o];[];[]]
+struct Test6<'a, 'b> { //~ ERROR regions=[[-, o];[];[];[]]
     x: &'a mut extern "Rust" fn(&'b int),
 }
 
 // No uses at all is bivariant:
 
 #[rustc_variance]
-struct Test7<'a> { //~ ERROR regions=[[*];[];[]]
+struct Test7<'a> { //~ ERROR regions=[[*];[];[];[]]
     x: int
 }
 
 // Try enums too.
 
 #[rustc_variance]
-enum Test8<'a, 'b, 'c:'b> { //~ ERROR regions=[[+, -, o];[];[]]
+enum Test8<'a, 'b, 'c:'b> { //~ ERROR regions=[[+, -, o];[];[];[]]
     Test8A(extern "Rust" fn(&'a int)),
     Test8B(&'b [int]),
     Test8C(&'b mut &'c str),

--- a/src/test/compile-fail/variance-regions-indirect.rs
+++ b/src/test/compile-fail/variance-regions-indirect.rs
@@ -13,29 +13,29 @@
 // Try enums too.
 
 #[rustc_variance]
-enum Base<'a, 'b, 'c:'b, 'd> { //~ ERROR regions=[[+, -, o, *];[];[]]
+enum Base<'a, 'b, 'c:'b, 'd> { //~ ERROR regions=[[+, -, o, *];[];[];[]]
     Test8A(extern "Rust" fn(&'a int)),
     Test8B(&'b [int]),
     Test8C(&'b mut &'c str),
 }
 
 #[rustc_variance]
-struct Derived1<'w, 'x:'y, 'y, 'z> { //~ ERROR regions=[[*, o, -, +];[];[]]
+struct Derived1<'w, 'x:'y, 'y, 'z> { //~ ERROR regions=[[*, o, -, +];[];[];[]]
     f: Base<'z, 'y, 'x, 'w>
 }
 
 #[rustc_variance] // Combine - and + to yield o
-struct Derived2<'a, 'b:'a, 'c> { //~ ERROR regions=[[o, o, *];[];[]]
+struct Derived2<'a, 'b:'a, 'c> { //~ ERROR regions=[[o, o, *];[];[];[]]
     f: Base<'a, 'a, 'b, 'c>
 }
 
 #[rustc_variance] // Combine + and o to yield o (just pay attention to 'a here)
-struct Derived3<'a:'b, 'b, 'c> { //~ ERROR regions=[[o, -, *];[];[]]
+struct Derived3<'a:'b, 'b, 'c> { //~ ERROR regions=[[o, -, *];[];[];[]]
     f: Base<'a, 'b, 'a, 'c>
 }
 
 #[rustc_variance] // Combine + and * to yield + (just pay attention to 'a here)
-struct Derived4<'a, 'b, 'c:'b> { //~ ERROR regions=[[+, -, o];[];[]]
+struct Derived4<'a, 'b, 'c:'b> { //~ ERROR regions=[[+, -, o];[];[];[]]
     f: Base<'a, 'b, 'c, 'a>
 }
 

--- a/src/test/compile-fail/variance-trait-object-bound.rs
+++ b/src/test/compile-fail/variance-trait-object-bound.rs
@@ -19,7 +19,7 @@ use std::mem;
 trait T { fn foo(); }
 
 #[rustc_variance]
-struct TOption<'a> { //~ ERROR regions=[[-];[];[]]
+struct TOption<'a> { //~ ERROR regions=[[-];[];[];[]]
     v: Option<Box<T + 'a>>,
 }
 


### PR DESCRIPTION
This also refactors associated types in various ways, most notably by moving the associated types defined in a trait into their own param space which replaces the associated-types hashmap (which is just removed). We should probably move the synthetic type parameters into yet another namespace, but that can wait.

Fixes #17921 
