### PR TITLE
Fix obscure ICE in trans (#18514)

### DIFF
--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -502,7 +502,11 @@ impl<'blk, 'tcx> mc::Typer<'tcx> for BlockS<'blk, 'tcx> {
     }
 
     fn node_method_ty(&self, method_call: typeck::MethodCall) -> Option<ty::t> {
-        self.tcx().method_map.borrow().find(&method_call).map(|method| method.ty)
+        self.tcx()
+            .method_map
+            .borrow()
+            .find(&method_call)
+            .map(|method| monomorphize_type(self, method.ty))
     }
 
     fn adjustments<'a>(&'a self) -> &'a RefCell<NodeMap<ty::AutoAdjustment>> {

--- a/src/test/auxiliary/issue-18514.rs
+++ b/src/test/auxiliary/issue-18514.rs
@@ -1,0 +1,27 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]
+
+pub trait Tr {
+    fn tr(&self);
+}
+
+pub struct St<V>(pub Vec<V>);
+
+impl<V> Tr for St<V> {
+    fn tr(&self) {
+        match self {
+            &St(ref v) => {
+                v.iter();
+            }
+        }
+    }
+}

--- a/src/test/run-pass/issue-18514.rs
+++ b/src/test/run-pass/issue-18514.rs
@@ -1,0 +1,24 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that we don't ICE when translating a generic impl method from
+// an extern crate that contains a match expression on a local
+// variable lvalue where one of the match case bodies contains an
+// expression that autoderefs through an overloaded generic deref
+// impl.
+
+// aux-build:issue-18514.rs
+extern crate "issue-18514" as ice;
+use ice::{Tr, St};
+
+fn main() {
+    let st: St<()> = St(vec![]);
+    st.tr();
+}


### PR DESCRIPTION
Don't ICE when translating a generic impl method from an extern crate that contains a match expression on a local variable lvalue where one of the match case bodies contains an expression that autoderefs through an overloaded generic deref impl and we neglect to monomorphize the result type of the deref method.

Closes #17810
Closes #18514
