### PR TITLE
Object safety check fixes

### DIFF
--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -187,7 +187,11 @@ pub fn check_object_safety(tcx: &ty::ctxt, object_trait: &ty::TyTrait, span: Spa
                                    receiver through a trait object", method_name))
             }
 
-            ty::StaticExplicitSelfCategory |
+            ty::StaticExplicitSelfCategory => {
+                // Static methods are always object-safe since they
+                // can't be called through a trait object
+                return msgs
+            }
             ty::ByReferenceExplicitSelfCategory(..) |
             ty::ByBoxExplicitSelfCategory => {}
         }

--- a/src/test/run-pass/trait-object-safety.rs
+++ b/src/test/run-pass/trait-object-safety.rs
@@ -1,0 +1,27 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that object-safe methods are identified as such.  Also
+// acts as a regression test for #18490
+
+trait Tr {
+    // Static methods are always safe regardless of other rules
+    fn new() -> Self;
+}
+
+struct St;
+
+impl Tr for St {
+    fn new() -> St { St }
+}
+
+fn main() {
+    &St as &Tr;
+}


### PR DESCRIPTION
- Always consider static methods object-safe since they can never be called through a trait object anyway.  The RFC doesn't mention static methods at all, so I'm assuming this is reasonable behavior.
- Fix issue #18490 as a side-effect since we avoid trying to take an out-of-bounds slice later in the code

Closes #18490

r? @nick29581 
