### PR TITLE
rustc: Respect CC variable at runtime

### DIFF
--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -33,6 +33,7 @@ use std::io::{fs, TempDir, Command};
 use std::io;
 use std::mem;
 use std::str;
+use std::os;
 use std::string::String;
 use flate;
 use serialize::hex::ToHex;
@@ -370,10 +371,13 @@ pub fn get_cc_prog(sess: &Session) -> String {
     // It would be flexible to use cc (system's default C compiler)
     // instead of hard-coded gcc.
     // For Windows, there is no cc command, so we add a condition to make it use gcc.
-    match sess.targ_cfg.os {
-        abi::OsWindows => "gcc",
-        _ => "cc",
-    }.to_string()
+    match os::getenv("CC") {
+        Some(cc) => cc,
+        None => match sess.targ_cfg.os {
+            abi::OsWindows => "gcc",
+            _ => "cc",
+        }.to_string()
+    }
 }
 
 pub fn remove(sess: &Session, path: &Path) {


### PR DESCRIPTION
This really should be passed in either from sniffing CFG_CC during
configure, or with a --cc-program flag to the configure script, but an
escape hatch is required for platforms with nothing called `cc' on PATH.
