### PR TITLE
rand: Add next_f64/f32 to Rng.

### DIFF
--- a/src/librand/distributions/mod.rs
+++ b/src/librand/distributions/mod.rs
@@ -227,6 +227,13 @@ fn ziggurat<R:Rng>(
         // creating a f64), so we might as well reuse some to save
         // generating a whole extra random number. (Seems to be 15%
         // faster.)
+        //
+        // This unfortunately misses out on the benefits of direct
+        // floating point generation if an RNG like dSMFT is
+        // used. (That is, such RNGs create floats directly, highly
+        // efficiently and overload next_f32/f64, so by not calling it
+        // this may be slower than it would be otherwise.)
+        // FIXME: investigate/optimise for the above.
         let bits: u64 = rng.gen();
         let i = (bits & 0xff) as uint;
         let f = (bits >> 11) as f64 / SCALE;

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -78,6 +78,46 @@ pub trait Rng {
         (self.next_u32() as u64 << 32) | (self.next_u32() as u64)
     }
 
+    /// Return the next random f32 selected from the half-open
+    /// interval `[0, 1)`.
+    ///
+    /// By default this is implemented in terms of `next_u32`, but a
+    /// random number generator which can generate numbers satisfying
+    /// the requirements directly can overload this for performance.
+    /// It is required that the return value lies in `[0, 1)`.
+    ///
+    /// See `Closed01` for the closed interval `[0,1]`, and
+    /// `Open01` for the open interval `(0,1)`.
+    fn next_f32(&mut self) -> f32 {
+        const MANTISSA_BITS: uint = 24;
+        const IGNORED_BITS: uint = 8;
+        const SCALE: f32 = (1u64 << MANTISSA_BITS) as f32;
+
+        // using any more than `MANTISSA_BITS` bits will
+        // cause (e.g.) 0xffff_ffff to correspond to 1
+        // exactly, so we need to drop some (8 for f32, 11
+        // for f64) to guarantee the open end.
+        (self.next_u32() >> IGNORED_BITS) as f32 / SCALE
+    }
+
+    /// Return the next random f64 selected from the half-open
+    /// interval `[0, 1)`.
+    ///
+    /// By default this is implemented in terms of `next_u64`, but a
+    /// random number generator which can generate numbers satisfying
+    /// the requirements directly can overload this for performance.
+    /// It is required that the return value lies in `[0, 1)`.
+    ///
+    /// See `Closed01` for the closed interval `[0,1]`, and
+    /// `Open01` for the open interval `(0,1)`.
+    fn next_f64(&mut self) -> f64 {
+        const MANTISSA_BITS: uint = 53;
+        const IGNORED_BITS: uint = 11;
+        const SCALE: f64 = (1u64 << MANTISSA_BITS) as f64;
+
+        (self.next_u64() >> IGNORED_BITS) as f64 / SCALE
+    }
+
     /// Fill `dest` with random data.
     ///
     /// This has a default implementation in terms of `next_u64` and


### PR DESCRIPTION
Some random number generates output floating point numbers directly, so
by providing these methods all the functionality in librand is available
with high-performance for these things.

An example of such an is [dSFMT (Double precision SIMD-oriented Fast
Mersenne Twister)](http://www.math.sci.hiroshima-u.ac.jp/~%20m-mat/MT/SFMT/index.html#dSFMT).

The choice to use the open interval [0, 1) has backing elsewhere,
e.g. GSL (GNU Scientific Library) [uses this range](https://www.gnu.org/software/gsl/manual/html_node/Sampling-from-a-random-number-generator.html), and dSFMT supports
generating this natively (I believe the most natural range for that
library is [1, 2), but that is not totally sensible from a user
perspective, and would trip people up).

Fixes https://github.com/rust-lang/rfcs/issues/425.
