### PR TITLE
Clean up string->{float, int} implementation

### DIFF
--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -36,7 +36,7 @@ use std::io::extensions::u64_from_be_bytes;
 use std::io;
 use std::collections::hashmap::HashMap;
 use std::rc::Rc;
-use std::u64;
+use std::str;
 use rbml::reader;
 use rbml;
 use serialize::Decodable;
@@ -215,7 +215,9 @@ fn each_reexport(d: rbml::Doc, f: |rbml::Doc| -> bool) -> bool {
 
 fn variant_disr_val(d: rbml::Doc) -> Option<ty::Disr> {
     reader::maybe_get_doc(d, tag_disr_val).and_then(|val_doc| {
-        reader::with_doc_data(val_doc, |data| u64::parse_bytes(data, 10u))
+        reader::with_doc_data(val_doc, |data| {
+            str::from_utf8(data).and_then(from_str)
+        })
     })
 }
 

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -23,7 +23,6 @@ use middle::ty;
 use std::rc::Rc;
 use std::str;
 use std::string::String;
-use std::uint;
 use syntax::abi;
 use syntax::ast;
 use syntax::ast::*;
@@ -615,12 +614,12 @@ pub fn parse_def_id(buf: &[u8]) -> ast::DefId {
     let crate_part = buf[0u..colon_idx];
     let def_part = buf[colon_idx + 1u..len];
 
-    let crate_num = match uint::parse_bytes(crate_part, 10u) {
+    let crate_num = match str::from_utf8(crate_part).and_then(from_str::<uint>) {
        Some(cn) => cn as ast::CrateNum,
        None => panic!("internal error: parse_def_id: crate number expected, found {}",
                      crate_part)
     };
-    let def_num = match uint::parse_bytes(def_part, 10u) {
+    let def_num = match str::from_utf8(def_part).and_then(from_str::<uint>) {
        Some(dn) => dn as ast::NodeId,
        None => panic!("internal error: parse_def_id: id expected, found {}",
                      def_part)

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -359,8 +359,8 @@ pub fn to_str_exp_digits(num: f32, dig: uint, upper: bool) -> String {
 /// `None` if the string did not represent a valid number.  Otherwise,
 /// `Some(n)` where `n` is the floating-point number represented by `[num]`.
 #[inline]
-pub fn from_str_hex(num: &str) -> Option<f32> {
-    strconv::from_str_float(num, 16u, true, strconv::ExpBin)
+pub fn from_str_hex(src: &str) -> Option<f32> {
+    strconv::from_str_radix_float(src, 16u)
 }
 
 impl FromStr for f32 {
@@ -390,8 +390,8 @@ impl FromStr for f32 {
     /// `None` if the string did not represent a valid number.  Otherwise,
     /// `Some(n)` where `n` is the floating-point number represented by `num`.
     #[inline]
-    fn from_str(val: &str) -> Option<f32> {
-        strconv::from_str_float(val, 10u, true, strconv::ExpDec)
+    fn from_str(src: &str) -> Option<f32> {
+        strconv::from_str_radix_float(src, 10u)
     }
 }
 
@@ -414,8 +414,8 @@ impl num::FromStrRadix for f32 {
     /// `None` if the string did not represent a valid number. Otherwise,
     /// `Some(n)` where `n` is the floating-point number represented by `num`.
     #[inline]
-    fn from_str_radix(val: &str, rdx: uint) -> Option<f32> {
-        strconv::from_str_float(val, rdx, false, strconv::ExpNone)
+    fn from_str_radix(src: &str, radix: uint) -> Option<f32> {
+        strconv::from_str_radix_float(src, radix)
     }
 }
 

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -361,7 +361,7 @@ pub fn to_str_exp_digits(num: f32, dig: uint, upper: bool) -> String {
 #[inline]
 pub fn from_str_hex(num: &str) -> Option<f32> {
     strconv::from_str_common(num, 16u, true, true, true,
-                             strconv::ExpBin, false, false)
+                             strconv::ExpBin, false)
 }
 
 impl FromStr for f32 {
@@ -393,7 +393,7 @@ impl FromStr for f32 {
     #[inline]
     fn from_str(val: &str) -> Option<f32> {
         strconv::from_str_common(val, 10u, true, true, true,
-                                 strconv::ExpDec, false, false)
+                                 strconv::ExpDec, false)
     }
 }
 
@@ -418,7 +418,7 @@ impl num::FromStrRadix for f32 {
     #[inline]
     fn from_str_radix(val: &str, rdx: uint) -> Option<f32> {
         strconv::from_str_common(val, rdx, true, true, false,
-                                 strconv::ExpNone, false, false)
+                                 strconv::ExpNone, false)
     }
 }
 

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -360,8 +360,7 @@ pub fn to_str_exp_digits(num: f32, dig: uint, upper: bool) -> String {
 /// `Some(n)` where `n` is the floating-point number represented by `[num]`.
 #[inline]
 pub fn from_str_hex(num: &str) -> Option<f32> {
-    strconv::from_str_common(num, 16u, true, true, true,
-                             strconv::ExpBin, false)
+    strconv::from_str_float(num, 16u, true, strconv::ExpBin)
 }
 
 impl FromStr for f32 {
@@ -392,8 +391,7 @@ impl FromStr for f32 {
     /// `Some(n)` where `n` is the floating-point number represented by `num`.
     #[inline]
     fn from_str(val: &str) -> Option<f32> {
-        strconv::from_str_common(val, 10u, true, true, true,
-                                 strconv::ExpDec, false)
+        strconv::from_str_float(val, 10u, true, strconv::ExpDec)
     }
 }
 
@@ -417,8 +415,7 @@ impl num::FromStrRadix for f32 {
     /// `Some(n)` where `n` is the floating-point number represented by `num`.
     #[inline]
     fn from_str_radix(val: &str, rdx: uint) -> Option<f32> {
-        strconv::from_str_common(val, rdx, true, true, false,
-                                 strconv::ExpNone, false)
+        strconv::from_str_float(val, rdx, false, strconv::ExpNone)
     }
 }
 

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -333,34 +333,10 @@ pub fn to_str_exp_digits(num: f32, dig: uint, upper: bool) -> String {
     r
 }
 
-/// Convert a string in base 16 to a float.
-/// Accepts an optional binary exponent.
-///
-/// This function accepts strings such as
-///
-/// * 'a4.fe'
-/// * '+a4.fe', equivalent to 'a4.fe'
-/// * '-a4.fe'
-/// * '2b.aP128', or equivalently, '2b.ap128'
-/// * '2b.aP-128'
-/// * '.' (understood as 0)
-/// * 'c.'
-/// * '.c', or, equivalently,  '0.c'
-/// * '+inf', 'inf', '-inf', 'NaN'
-///
-/// Leading and trailing whitespace represent an error.
-///
-/// # Arguments
-///
-/// * num - A string
-///
-/// # Return value
-///
-/// `None` if the string did not represent a valid number.  Otherwise,
-/// `Some(n)` where `n` is the floating-point number represented by `[num]`.
 #[inline]
+#[deprecated="Use `FromStrRadix::from_str_radix(src, 16)`"]
 pub fn from_str_hex(src: &str) -> Option<f32> {
-    strconv::from_str_radix_float(src, 16u)
+    strconv::from_str_radix_float(src, 16)
 }
 
 impl FromStr for f32 {
@@ -383,12 +359,12 @@ impl FromStr for f32 {
     ///
     /// # Arguments
     ///
-    /// * num - A string
+    /// * src - A string
     ///
     /// # Return value
     ///
     /// `None` if the string did not represent a valid number.  Otherwise,
-    /// `Some(n)` where `n` is the floating-point number represented by `num`.
+    /// `Some(n)` where `n` is the floating-point number represented by `src`.
     #[inline]
     fn from_str(src: &str) -> Option<f32> {
         strconv::from_str_radix_float(src, 10u)
@@ -406,13 +382,13 @@ impl num::FromStrRadix for f32 {
     ///
     /// # Arguments
     ///
-    /// * num - A string
+    /// * src - A string
     /// * radix - The base to use. Must lie in the range [2 .. 36]
     ///
     /// # Return value
     ///
     /// `None` if the string did not represent a valid number. Otherwise,
-    /// `Some(n)` where `n` is the floating-point number represented by `num`.
+    /// `Some(n)` where `n` is the floating-point number represented by `src`.
     #[inline]
     fn from_str_radix(src: &str, radix: uint) -> Option<f32> {
         strconv::from_str_radix_float(src, radix)
@@ -707,8 +683,8 @@ mod tests {
     fn test_ldexp() {
         // We have to use from_str until base-2 exponents
         // are supported in floating-point literals
-        let f1: f32 = from_str_hex("1p-123").unwrap();
-        let f2: f32 = from_str_hex("1p-111").unwrap();
+        let f1: f32 = FromStrRadix::from_str_radix("1p-123", 16).unwrap();
+        let f2: f32 = FromStrRadix::from_str_radix("1p-111", 16).unwrap();
         assert_eq!(FloatMath::ldexp(1f32, -123), f1);
         assert_eq!(FloatMath::ldexp(1f32, -111), f2);
 
@@ -727,8 +703,8 @@ mod tests {
     fn test_frexp() {
         // We have to use from_str until base-2 exponents
         // are supported in floating-point literals
-        let f1: f32 = from_str_hex("1p-123").unwrap();
-        let f2: f32 = from_str_hex("1p-111").unwrap();
+        let f1: f32 = FromStrRadix::from_str_radix("1p-123", 16).unwrap();
+        let f2: f32 = FromStrRadix::from_str_radix("1p-111", 16).unwrap();
         let (x1, exp1) = f1.frexp();
         let (x2, exp2) = f2.frexp();
         assert_eq!((x1, exp1), (0.5f32, -122));

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -368,7 +368,7 @@ pub fn to_str_exp_digits(num: f64, dig: uint, upper: bool) -> String {
 /// `Some(n)` where `n` is the floating-point number represented by `[num]`.
 #[inline]
 pub fn from_str_hex(num: &str) -> Option<f64> {
-    strconv::from_str_float(num, 16u, true, strconv::ExpBin)
+    strconv::from_str_radix_float(num, 16u)
 }
 
 impl FromStr for f64 {
@@ -399,7 +399,7 @@ impl FromStr for f64 {
     /// `Some(n)` where `n` is the floating-point number represented by `num`.
     #[inline]
     fn from_str(val: &str) -> Option<f64> {
-        strconv::from_str_float(val, 10u, true, strconv::ExpDec)
+        strconv::from_str_radix_float(val, 10u)
     }
 }
 
@@ -422,8 +422,8 @@ impl num::FromStrRadix for f64 {
     /// `None` if the string did not represent a valid number. Otherwise,
     /// `Some(n)` where `n` is the floating-point number represented by `num`.
     #[inline]
-    fn from_str_radix(val: &str, rdx: uint) -> Option<f64> {
-        strconv::from_str_float(val, rdx, false, strconv::ExpNone)
+    fn from_str_radix(val: &str, radix: uint) -> Option<f64> {
+        strconv::from_str_radix_float(val, radix)
     }
 }
 

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -369,7 +369,7 @@ pub fn to_str_exp_digits(num: f64, dig: uint, upper: bool) -> String {
 #[inline]
 pub fn from_str_hex(num: &str) -> Option<f64> {
     strconv::from_str_common(num, 16u, true, true, true,
-                             strconv::ExpBin, false, false)
+                             strconv::ExpBin, false)
 }
 
 impl FromStr for f64 {
@@ -401,7 +401,7 @@ impl FromStr for f64 {
     #[inline]
     fn from_str(val: &str) -> Option<f64> {
         strconv::from_str_common(val, 10u, true, true, true,
-                                 strconv::ExpDec, false, false)
+                                 strconv::ExpDec, false)
     }
 }
 
@@ -426,7 +426,7 @@ impl num::FromStrRadix for f64 {
     #[inline]
     fn from_str_radix(val: &str, rdx: uint) -> Option<f64> {
         strconv::from_str_common(val, rdx, true, true, false,
-                                 strconv::ExpNone, false, false)
+                                 strconv::ExpNone, false)
     }
 }
 

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -341,89 +341,60 @@ pub fn to_str_exp_digits(num: f64, dig: uint, upper: bool) -> String {
     r
 }
 
-/// Convert a string in base 16 to a float.
-/// Accepts an optional binary exponent.
-///
-/// This function accepts strings such as
-///
-/// * 'a4.fe'
-/// * '+a4.fe', equivalent to 'a4.fe'
-/// * '-a4.fe'
-/// * '2b.aP128', or equivalently, '2b.ap128'
-/// * '2b.aP-128'
-/// * '.' (understood as 0)
-/// * 'c.'
-/// * '.c', or, equivalently,  '0.c'
-/// * '+inf', 'inf', '-inf', 'NaN'
-///
-/// Leading and trailing whitespace represent an error.
-///
-/// # Arguments
-///
-/// * num - A string
-///
-/// # Return value
-///
-/// `None` if the string did not represent a valid number.  Otherwise,
-/// `Some(n)` where `n` is the floating-point number represented by `[num]`.
 #[inline]
-pub fn from_str_hex(num: &str) -> Option<f64> {
-    strconv::from_str_radix_float(num, 16u)
+#[deprecated="Use `FromStrRadix::from_str_radix(src, 16)`"]
+pub fn from_str_hex(src: &str) -> Option<f64> {
+    strconv::from_str_radix_float(src, 16)
 }
 
 impl FromStr for f64 {
     /// Convert a string in base 10 to a float.
     /// Accepts an optional decimal exponent.
     ///
-    /// This function accepts strings such as
+    /// This function accepts strings such as:
     ///
     /// * '3.14'
-    /// * '+3.14', equivalent to '3.14'
     /// * '-3.14'
     /// * '2.5E10', or equivalently, '2.5e10'
     /// * '2.5E-10'
     /// * '.' (understood as 0)
     /// * '5.'
     /// * '.5', or, equivalently,  '0.5'
-    /// * '+inf', 'inf', '-inf', 'NaN'
+    /// * inf', '-inf', 'NaN'
     ///
     /// Leading and trailing whitespace represent an error.
     ///
     /// # Arguments
     ///
-    /// * num - A string
+    /// * src - A string
     ///
     /// # Return value
     ///
     /// `none` if the string did not represent a valid number.  Otherwise,
-    /// `Some(n)` where `n` is the floating-point number represented by `num`.
+    /// `Some(n)` where `n` is the floating-point number represented by `src`.
     #[inline]
-    fn from_str(val: &str) -> Option<f64> {
-        strconv::from_str_radix_float(val, 10u)
+    fn from_str(src: &str) -> Option<f64> {
+        strconv::from_str_radix_float(src, 10u)
     }
 }
 
 impl num::FromStrRadix for f64 {
     /// Convert a string in a given base to a float.
     ///
-    /// Due to possible conflicts, this function does **not** accept
-    /// the special values `inf`, `-inf`, `+inf` and `NaN`, **nor**
-    /// does it recognize exponents of any kind.
-    ///
     /// Leading and trailing whitespace represent an error.
     ///
     /// # Arguments
     ///
-    /// * num - A string
+    /// * src - A string
     /// * radix - The base to use. Must lie in the range [2 .. 36]
     ///
     /// # Return value
     ///
     /// `None` if the string did not represent a valid number. Otherwise,
-    /// `Some(n)` where `n` is the floating-point number represented by `num`.
+    /// `Some(n)` where `n` is the floating-point number represented by `src`.
     #[inline]
-    fn from_str_radix(val: &str, radix: uint) -> Option<f64> {
-        strconv::from_str_radix_float(val, radix)
+    fn from_str_radix(src: &str, radix: uint) -> Option<f64> {
+        strconv::from_str_radix_float(src, radix)
     }
 }
 
@@ -709,8 +680,8 @@ mod tests {
     fn test_ldexp() {
         // We have to use from_str until base-2 exponents
         // are supported in floating-point literals
-        let f1: f64 = from_str_hex("1p-123").unwrap();
-        let f2: f64 = from_str_hex("1p-111").unwrap();
+        let f1: f64 = FromStrRadix::from_str_radix("1p-123", 16).unwrap();
+        let f2: f64 = FromStrRadix::from_str_radix("1p-111", 16).unwrap();
         assert_eq!(FloatMath::ldexp(1f64, -123), f1);
         assert_eq!(FloatMath::ldexp(1f64, -111), f2);
 
@@ -729,8 +700,8 @@ mod tests {
     fn test_frexp() {
         // We have to use from_str until base-2 exponents
         // are supported in floating-point literals
-        let f1: f64 = from_str_hex("1p-123").unwrap();
-        let f2: f64 = from_str_hex("1p-111").unwrap();
+        let f1: f64 = FromStrRadix::from_str_radix("1p-123", 16).unwrap();
+        let f2: f64 = FromStrRadix::from_str_radix("1p-111", 16).unwrap();
         let (x1, exp1) = f1.frexp();
         let (x2, exp2) = f2.frexp();
         assert_eq!((x1, exp1), (0.5f64, -122));

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -368,8 +368,7 @@ pub fn to_str_exp_digits(num: f64, dig: uint, upper: bool) -> String {
 /// `Some(n)` where `n` is the floating-point number represented by `[num]`.
 #[inline]
 pub fn from_str_hex(num: &str) -> Option<f64> {
-    strconv::from_str_common(num, 16u, true, true, true,
-                             strconv::ExpBin, false)
+    strconv::from_str_float(num, 16u, true, strconv::ExpBin)
 }
 
 impl FromStr for f64 {
@@ -400,8 +399,7 @@ impl FromStr for f64 {
     /// `Some(n)` where `n` is the floating-point number represented by `num`.
     #[inline]
     fn from_str(val: &str) -> Option<f64> {
-        strconv::from_str_common(val, 10u, true, true, true,
-                                 strconv::ExpDec, false)
+        strconv::from_str_float(val, 10u, true, strconv::ExpDec)
     }
 }
 
@@ -425,8 +423,7 @@ impl num::FromStrRadix for f64 {
     /// `Some(n)` where `n` is the floating-point number represented by `num`.
     #[inline]
     fn from_str_radix(val: &str, rdx: uint) -> Option<f64> {
-        strconv::from_str_common(val, rdx, true, true, false,
-                                 strconv::ExpNone, false)
+        strconv::from_str_float(val, rdx, false, strconv::ExpNone)
     }
 }
 

--- a/src/libstd/num/int_macros.rs
+++ b/src/libstd/num/int_macros.rs
@@ -14,31 +14,11 @@
 
 macro_rules! int_module (($T:ty) => (
 
-// String conversion functions and impl str -> num
-
-/// Parse a byte slice as a number in the given base
-///
-/// Yields an `Option` because `buf` may or may not actually be parseable.
-///
-/// # Examples
-///
-/// ```
-/// let num = std::i64::parse_bytes([49,50,51,52,53,54,55,56,57], 10);
-/// assert!(num == Some(123456789));
-/// ```
-#[inline]
-#[experimental = "might need to return Result"]
-pub fn parse_bytes(buf: &[u8], radix: uint) -> Option<$T> {
-    strconv::from_str_bytes_common(buf, radix, true, false, false,
-                               strconv::ExpNone, false, false)
-}
-
 #[experimental = "might need to return Result"]
 impl FromStr for $T {
     #[inline]
     fn from_str(s: &str) -> Option<$T> {
-        strconv::from_str_common(s, 10u, true, false, false,
-                             strconv::ExpNone, false, false)
+        strconv::from_str_radix_int(s, 10)
     }
 }
 
@@ -46,18 +26,14 @@ impl FromStr for $T {
 impl FromStrRadix for $T {
     #[inline]
     fn from_str_radix(s: &str, radix: uint) -> Option<$T> {
-        strconv::from_str_common(s, radix, true, false, false,
-                             strconv::ExpNone, false, false)
+        strconv::from_str_radix_int(s, radix)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use prelude::*;
-    use super::*;
-
-    use i32;
-    use str::StrSlice;
+    use num::FromStrRadix;
 
     #[test]
     fn test_from_str() {
@@ -73,33 +49,33 @@ mod tests {
         assert_eq!(from_str::<i32>("-123456789"), Some(-123456789 as i32));
         assert_eq!(from_str::<$T>("-00100"), Some(-100 as $T));
 
-        assert!(from_str::<$T>(" ").is_none());
-        assert!(from_str::<$T>("x").is_none());
+        assert_eq!(from_str::<$T>(""), None);
+        assert_eq!(from_str::<$T>(" "), None);
+        assert_eq!(from_str::<$T>("x"), None);
     }
 
     #[test]
-    fn test_parse_bytes() {
-        use str::StrSlice;
-        assert_eq!(parse_bytes("123".as_bytes(), 10u), Some(123 as $T));
-        assert_eq!(parse_bytes("1001".as_bytes(), 2u), Some(9 as $T));
-        assert_eq!(parse_bytes("123".as_bytes(), 8u), Some(83 as $T));
-        assert_eq!(i32::parse_bytes("123".as_bytes(), 16u), Some(291 as i32));
-        assert_eq!(i32::parse_bytes("ffff".as_bytes(), 16u), Some(65535 as i32));
-        assert_eq!(i32::parse_bytes("FFFF".as_bytes(), 16u), Some(65535 as i32));
-        assert_eq!(parse_bytes("z".as_bytes(), 36u), Some(35 as $T));
-        assert_eq!(parse_bytes("Z".as_bytes(), 36u), Some(35 as $T));
+    fn test_from_str_radix() {
+        assert_eq!(FromStrRadix::from_str_radix("123", 10), Some(123 as $T));
+        assert_eq!(FromStrRadix::from_str_radix("1001", 2), Some(9 as $T));
+        assert_eq!(FromStrRadix::from_str_radix("123", 8), Some(83 as $T));
+        assert_eq!(FromStrRadix::from_str_radix("123", 16), Some(291 as i32));
+        assert_eq!(FromStrRadix::from_str_radix("ffff", 16), Some(65535 as i32));
+        assert_eq!(FromStrRadix::from_str_radix("FFFF", 16), Some(65535 as i32));
+        assert_eq!(FromStrRadix::from_str_radix("z", 36), Some(35 as $T));
+        assert_eq!(FromStrRadix::from_str_radix("Z", 36), Some(35 as $T));
 
-        assert_eq!(parse_bytes("-123".as_bytes(), 10u), Some(-123 as $T));
-        assert_eq!(parse_bytes("-1001".as_bytes(), 2u), Some(-9 as $T));
-        assert_eq!(parse_bytes("-123".as_bytes(), 8u), Some(-83 as $T));
-        assert_eq!(i32::parse_bytes("-123".as_bytes(), 16u), Some(-291 as i32));
-        assert_eq!(i32::parse_bytes("-ffff".as_bytes(), 16u), Some(-65535 as i32));
-        assert_eq!(i32::parse_bytes("-FFFF".as_bytes(), 16u), Some(-65535 as i32));
-        assert_eq!(parse_bytes("-z".as_bytes(), 36u), Some(-35 as $T));
-        assert_eq!(parse_bytes("-Z".as_bytes(), 36u), Some(-35 as $T));
+        assert_eq!(FromStrRadix::from_str_radix("-123", 10), Some(-123 as $T));
+        assert_eq!(FromStrRadix::from_str_radix("-1001", 2), Some(-9 as $T));
+        assert_eq!(FromStrRadix::from_str_radix("-123", 8), Some(-83 as $T));
+        assert_eq!(FromStrRadix::from_str_radix("-123", 16), Some(-291 as i32));
+        assert_eq!(FromStrRadix::from_str_radix("-ffff", 16), Some(-65535 as i32));
+        assert_eq!(FromStrRadix::from_str_radix("-FFFF", 16), Some(-65535 as i32));
+        assert_eq!(FromStrRadix::from_str_radix("-z", 36), Some(-35 as $T));
+        assert_eq!(FromStrRadix::from_str_radix("-Z", 36), Some(-35 as $T));
 
-        assert!(parse_bytes("Z".as_bytes(), 35u).is_none());
-        assert!(parse_bytes("-9".as_bytes(), 2u).is_none());
+        assert_eq!(FromStrRadix::from_str_radix("Z", 35), None::<$T>);
+        assert_eq!(FromStrRadix::from_str_radix("-9", 2), None::<$T>);
     }
 
     #[test]
@@ -133,35 +109,35 @@ mod tests {
     fn test_int_from_str_overflow() {
         let mut i8_val: i8 = 127_i8;
         assert_eq!(from_str::<i8>("127"), Some(i8_val));
-        assert!(from_str::<i8>("128").is_none());
+        assert_eq!(from_str::<i8>("128"), None);
 
         i8_val += 1 as i8;
         assert_eq!(from_str::<i8>("-128"), Some(i8_val));
-        assert!(from_str::<i8>("-129").is_none());
+        assert_eq!(from_str::<i8>("-129"), None);
 
         let mut i16_val: i16 = 32_767_i16;
         assert_eq!(from_str::<i16>("32767"), Some(i16_val));
-        assert!(from_str::<i16>("32768").is_none());
+        assert_eq!(from_str::<i16>("32768"), None);
 
         i16_val += 1 as i16;
         assert_eq!(from_str::<i16>("-32768"), Some(i16_val));
-        assert!(from_str::<i16>("-32769").is_none());
+        assert_eq!(from_str::<i16>("-32769"), None);
 
         let mut i32_val: i32 = 2_147_483_647_i32;
         assert_eq!(from_str::<i32>("2147483647"), Some(i32_val));
-        assert!(from_str::<i32>("2147483648").is_none());
+        assert_eq!(from_str::<i32>("2147483648"), None);
 
         i32_val += 1 as i32;
         assert_eq!(from_str::<i32>("-2147483648"), Some(i32_val));
-        assert!(from_str::<i32>("-2147483649").is_none());
+        assert_eq!(from_str::<i32>("-2147483649"), None);
 
         let mut i64_val: i64 = 9_223_372_036_854_775_807_i64;
         assert_eq!(from_str::<i64>("9223372036854775807"), Some(i64_val));
-        assert!(from_str::<i64>("9223372036854775808").is_none());
+        assert_eq!(from_str::<i64>("9223372036854775808"), None);
 
         i64_val += 1 as i64;
         assert_eq!(from_str::<i64>("-9223372036854775808"), Some(i64_val));
-        assert!(from_str::<i64>("-9223372036854775809").is_none());
+        assert_eq!(from_str::<i64>("-9223372036854775809"), None);
     }
 }
 

--- a/src/test/bench/shootout-pfib.rs
+++ b/src/test/bench/shootout-pfib.rs
@@ -24,7 +24,6 @@ extern crate time;
 use std::os;
 use std::result::{Ok, Err};
 use std::task;
-use std::uint;
 
 fn fib(n: int) -> int {
     fn pfib(tx: &Sender<int>, n: int) {
@@ -102,8 +101,7 @@ fn main() {
     if opts.stress {
         stress(2);
     } else {
-        let max = uint::parse_bytes(args[1].as_bytes(), 10u).unwrap() as
-            int;
+        let max = from_str::<uint>(args[1].as_slice()).unwrap() as int;
 
         let num_trials = 10;
 


### PR DESCRIPTION
I have been meaning to clean up `std::num::strconv` for a long time. This module is too generic and hard to understand, both for maintainers and users.

I have specialized the underlying string->{float, int} implementations into two separate underlying functions. This will allow it to be more easily optimized in the future, and untangles the logic to make it more easier to understand.

The function signatures were also simplified to take only a source string and a radix. `{f32, f64}::from_str_hex` was deprecated in favor of `FromStrRadix::from_str_radix`.

r? @aturon @alexcrichton 
