### PR TITLE
Replace secret formatting functions with UFCS versions

### DIFF
--- a/src/libstd/fmt.rs
+++ b/src/libstd/fmt.rs
@@ -424,14 +424,20 @@ pub use core::fmt::{Argument, Arguments, write, radix, Radix, RadixFmt};
 
 #[doc(hidden)]
 pub use core::fmt::{argument, argumentstr, argumentuint};
+// NOTE(stage0): remove these imports after a snapshot
+#[cfg(stage0)]
 #[doc(hidden)]
 pub use core::fmt::{secret_show, secret_string, secret_unsigned};
+#[cfg(stage0)]
 #[doc(hidden)]
 pub use core::fmt::{secret_signed, secret_lower_hex, secret_upper_hex};
+#[cfg(stage0)]
 #[doc(hidden)]
 pub use core::fmt::{secret_bool, secret_char, secret_octal, secret_binary};
+#[cfg(stage0)]
 #[doc(hidden)]
 pub use core::fmt::{secret_float, secret_upper_exp, secret_lower_exp};
+#[cfg(stage0)]
 #[doc(hidden)]
 pub use core::fmt::{secret_pointer};
 

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -663,28 +663,28 @@ impl<'a, 'b> Context<'a, 'b> {
     fn format_arg(ecx: &ExtCtxt, sp: Span,
                   ty: &ArgumentType, arg: P<ast::Expr>)
                   -> P<ast::Expr> {
-        let (krate, fmt_fn) = match *ty {
+        let trait_ = match *ty {
             Known(ref tyname) => {
                 match tyname.as_slice() {
-                    ""  => ("std", "secret_show"),
-                    "b" => ("std", "secret_bool"),
-                    "c" => ("std", "secret_char"),
-                    "d" | "i" => ("std", "secret_signed"),
-                    "e" => ("std", "secret_lower_exp"),
-                    "E" => ("std", "secret_upper_exp"),
-                    "f" => ("std", "secret_float"),
-                    "o" => ("std", "secret_octal"),
-                    "p" => ("std", "secret_pointer"),
-                    "s" => ("std", "secret_string"),
-                    "t" => ("std", "secret_binary"),
-                    "u" => ("std", "secret_unsigned"),
-                    "x" => ("std", "secret_lower_hex"),
-                    "X" => ("std", "secret_upper_hex"),
+                    ""  => "Show",
+                    "b" => "Bool",
+                    "c" => "Char",
+                    "d" | "i" => "Signed",
+                    "e" => "LowerExp",
+                    "E" => "UpperExp",
+                    "f" => "Float",
+                    "o" => "Octal",
+                    "p" => "Pointer",
+                    "s" => "String",
+                    "t" => "Binary",
+                    "u" => "Unsigned",
+                    "x" => "LowerHex",
+                    "X" => "UpperHex",
                     _ => {
                         ecx.span_err(sp,
                                      format!("unknown format trait `{}`",
                                              *tyname).as_slice());
-                        ("std", "dummy")
+                        "Dummy"
                     }
                 }
             }
@@ -697,9 +697,10 @@ impl<'a, 'b> Context<'a, 'b> {
         };
 
         let format_fn = ecx.path_global(sp, vec![
-                ecx.ident_of(krate),
+                ecx.ident_of("std"),
                 ecx.ident_of("fmt"),
-                ecx.ident_of(fmt_fn)]);
+                ecx.ident_of(trait_),
+                ecx.ident_of("fmt")]);
         ecx.expr_call_global(sp, vec![
                 ecx.ident_of("std"),
                 ecx.ident_of("fmt"),


### PR DESCRIPTION
This PR replaces the uses of e.g. the `secret_show` function with `Show::fmt`.

**Note** #18523 has to be merged first or this will ICE during `make`

r? @alexcrichton 
