### PR TITLE
librustc: Check if return type is void not zero-sized for fn->closure wrapper.

### DIFF
--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -623,7 +623,7 @@ pub fn get_wrapper_for_bare_fn(ccx: &CrateContext,
     let retval = Call(bcx, fn_ptr, llargs.as_slice(), None);
     match f.sig.output {
         ty::FnConverging(output_type) => {
-            if type_is_zero_size(ccx, output_type) || fcx.llretslotptr.get().is_some() {
+            if return_type_is_void(ccx, output_type) || fcx.llretslotptr.get().is_some() {
                 RetVoid(bcx);
             } else {
                 Ret(bcx, retval);

--- a/src/test/run-pass/issue-18539.rs
+++ b/src/test/run-pass/issue-18539.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that coercing bare fn's that return a zero sized type to
+// a closure doesn't cause an LLVM ERROR
+
+struct Foo;
+
+fn uint_to_foo(_: uint) -> Foo {
+    Foo
+}
+
+#[allow(unused_must_use)]
+fn main() {
+    range(0u, 10).map(uint_to_foo);
+}


### PR DESCRIPTION
Fixes #18539.
