### PR TITLE
First pass at replacing `loop` with `while true`.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2165,11 +2165,13 @@ impl<'a> Parser<'a> {
                         return self.parse_for_expr(Some(lifetime))
                     }
                     if self.eat_keyword(keywords::Loop) {
+                        self.warn("`loop` keyword has been deprecated in favor of `while true`");
                         return self.parse_loop_expr(Some(lifetime))
                     }
-                    self.fatal("expected `while`, `for`, or `loop` after a label")
+                    self.fatal("expected `while` or `for` after a label")
                 }
                 if self.eat_keyword(keywords::Loop) {
+                    self.warn("`loop` keyword has been deprecated in favor of `while true`");
                     return self.parse_loop_expr(None);
                 }
                 if self.eat_keyword(keywords::Continue) {
@@ -2960,6 +2962,8 @@ impl<'a> Parser<'a> {
     pub fn parse_while_expr(&mut self, opt_ident: Option<ast::Ident>) -> P<Expr> {
         if self.token.is_keyword(keywords::Let) {
             return self.parse_while_let_expr(opt_ident);
+        } else if self.eat_keyword(keywords::True) {
+            return self.parse_loop_expr(opt_ident);
         }
         let lo = self.last_span.lo;
         let cond = self.parse_expr_res(RESTRICTION_NO_STRUCT_LITERAL);


### PR DESCRIPTION
Proto-RFC here: https://github.com/jkleint/rfcs/blob/remove-loop-keyword/text/0000-remove-loop-keyword.md

This is my first foray into modifying the Rust compiler, so please let me know if I'm way off the mark.  I'm not sure this is the right way to do things, it's just to get the conversation started and show it may be simple.

This piggybacks on while-expression parsing the same way as `while let` to recognize `while true` and call the existing `loop` parsing code.

I haven't been able to thoroughly test it, but it does seem to compile code like this:

```
fn main() {
    let x;
    while true { x = 1i; break; }
    println!("{}", x)
}
```

which previously did not compile (`x` possibly uninitialized).

I'm unsure of how to use the existing deprecation machinery for a keyword, so I have just put in placeholder warnings, but please advise on how do do that properly.  I'm also not sure if the source span properly encompasses the whole while loop.

Fixes #12975.
