### PR TITLE
Fix ICE when checking call overload

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -2536,7 +2536,7 @@ fn check_argument_types<'a>(fcx: &FnCtxt,
                 span_err!(tcx.sess, sp, E0059,
                     "cannot use call notation; the first type parameter \
                      for the function trait is neither a tuple nor unit");
-                err_args(supplied_arg_count)
+                err_args(args.len())
             }
         }
     } else if expected_arg_count == supplied_arg_count {

--- a/src/test/compile-fail/issue-18532.rs
+++ b/src/test/compile-fail/issue-18532.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that overloaded call parameter checking does not ICE
+// when a type error or unconstrained type variable propagates
+// into it.
+
+#![feature(overloaded_calls)]
+
+fn main() {
+    (return)((),());
+    //~^ ERROR the type of this value must be known
+    //~^^ ERROR the type of this value must be known
+    //~^^^ ERROR cannot use call notation
+}


### PR DESCRIPTION
If the overloaded method does not have a tuple or unit type as its first non-self parameter, produce a list of error types with the correct length to prevent a later index bound panic.  This typically occurs due to propagation of an earlier type error or unconstrained type variable.  Closes #18532
