### PR TITLE
Use UFCS in the expansion of `#[deriving(Clone)]`

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -276,7 +276,6 @@
 
 #![stable]
 
-use clone::Clone;
 use cmp::PartialEq;
 use std::fmt::Show;
 use slice;

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -19,7 +19,6 @@
 use mem;
 use char;
 use char::Char;
-use clone::Clone;
 use cmp;
 use cmp::{PartialEq, Eq};
 use default::Default;

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -10,7 +10,6 @@
 //
 // ignore-lexer-test FIXME #15883
 
-use clone::Clone;
 use cmp::{Eq, Equiv, PartialEq};
 use core::kinds::Sized;
 use default::Default;

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -26,7 +26,6 @@ use rt::rtio;
 use c_str::CString;
 use collections::HashMap;
 use hash::Hash;
-use clone::Clone;
 #[cfg(windows)]
 use std::hash::sip::SipState;
 

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -52,11 +52,19 @@ fn cs_clone(
     name: &str,
     cx: &mut ExtCtxt, trait_span: Span,
     substr: &Substructure) -> P<Expr> {
-    let clone_ident = substr.method_ident;
     let ctor_ident;
     let all_fields;
-    let subcall = |field: &FieldInfo|
-        cx.expr_method_call(field.span, field.self_.clone(), clone_ident, Vec::new());
+    let fn_path = vec![
+        cx.ident_of("std"),
+        cx.ident_of("clone"),
+        cx.ident_of("Clone"),
+        cx.ident_of("clone"),
+    ];
+    let subcall = |field: &FieldInfo| {
+        let args = vec![cx.expr_addr_of(field.span, field.self_.clone())];
+
+        cx.expr_call_global(field.span, fn_path.clone(), args)
+    };
 
     match *substr.fields {
         Struct(ref af) => {

--- a/src/libunicode/u_str.rs
+++ b/src/libunicode/u_str.rs
@@ -17,7 +17,6 @@
  * methods provided by the UnicodeChar trait.
  */
 
-use core::clone::Clone;
 use core::cmp;
 use core::slice::ImmutableSlice;
 use core::iter::{Filter, AdditiveIterator, Iterator, DoubleEndedIterator};

--- a/src/test/compile-fail/deriving-no-inner-impl-error-message.rs
+++ b/src/test/compile-fail/deriving-no-inner-impl-error-message.rs
@@ -17,7 +17,8 @@ struct E {
 }
 #[deriving(Clone)]
 struct C {
-    x: NoCloneOrEq //~ ERROR does not implement any method in scope named `clone`
+    x: NoCloneOrEq
+    //~^ ERROR the trait `core::clone::Clone` is not implemented for the type `NoCloneOrEq`
 }
 
 

--- a/src/test/run-pass/issue-15689-2.rs
+++ b/src/test/run-pass/issue-15689-2.rs
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[deriving(Clone)]
+enum Test<'a> {
+    Slice(&'a int)
+}
+
+fn main() {}


### PR DESCRIPTION
Changes the return expression of expanded `clone` method from e.g. `Slice((*__self_0).clone())` to `Slice(::std::clone::Clone::clone(&(*__self_0)))`

Fixes the [second half](https://github.com/rust-lang/rust/issues/15689#issuecomment-49086188) of #15689

(The [first half](https://github.com/rust-lang/rust/issues/15689#issue-37918558) will be fixed by #18467)

**Note** #18523 must be merged first or this will ICE during `make`

r? @alexcrichton 
(I can squash the commits after the review)
