### PR TITLE
Also fix undefined behaviour when shift equals the number of bits

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -187,12 +187,12 @@ impl LintPass for TypeLimits {
 
                     if let Some(bits) = opt_ty_bits {
                         let exceeding = if let ast::ExprLit(ref lit) = r.node {
-                            if let ast::LitInt(shift, _) = lit.node { shift > bits }
+                            if let ast::LitInt(shift, _) = lit.node { shift >= bits }
                             else { false }
                         } else {
                             match eval_const_expr_partial(cx.tcx, &**r) {
-                                Ok(const_int(shift)) => { shift as u64 > bits },
-                                Ok(const_uint(shift)) => { shift > bits },
+                                Ok(const_int(shift)) => { shift as u64 >= bits },
+                                Ok(const_uint(shift)) => { shift >= bits },
                                 _ => { false }
                             }
                         };

--- a/src/test/compile-fail/lint-exceeding-bitshifts.rs
+++ b/src/test/compile-fail/lint-exceeding-bitshifts.rs
@@ -12,47 +12,47 @@
 #![allow(unused_variables)]
 
 fn main() {
-      let n = 1u8 << 8;
-      let n = 1u8 << 9;   //~ ERROR: bitshift exceeds the type's number of bits
-      let n = 1u16 << 16;
-      let n = 1u16 << 17; //~ ERROR: bitshift exceeds the type's number of bits
-      let n = 1u32 << 32;
-      let n = 1u32 << 33; //~ ERROR: bitshift exceeds the type's number of bits
-      let n = 1u64 << 64;
-      let n = 1u64 << 65; //~ ERROR: bitshift exceeds the type's number of bits
-      let n = 1i8 << 8;
-      let n = 1i8 << 9;   //~ ERROR: bitshift exceeds the type's number of bits
-      let n = 1i16 << 16;
-      let n = 1i16 << 17; //~ ERROR: bitshift exceeds the type's number of bits
-      let n = 1i32 << 32;
-      let n = 1i32 << 33; //~ ERROR: bitshift exceeds the type's number of bits
-      let n = 1i64 << 64;
-      let n = 1i64 << 65; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u8 << 7;
+      let n = 1u8 << 8;   //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u16 << 15;
+      let n = 1u16 << 16; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u32 << 31;
+      let n = 1u32 << 32; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u64 << 63;
+      let n = 1u64 << 64; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i8 << 7;
+      let n = 1i8 << 8;   //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i16 << 15;
+      let n = 1i16 << 16; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i32 << 31;
+      let n = 1i32 << 32; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i64 << 63;
+      let n = 1i64 << 64; //~ ERROR: bitshift exceeds the type's number of bits
 
-      let n = 1u8 >> 8;
-      let n = 1u8 >> 9;   //~ ERROR: bitshift exceeds the type's number of bits
-      let n = 1u16 >> 16;
-      let n = 1u16 >> 17; //~ ERROR: bitshift exceeds the type's number of bits
-      let n = 1u32 >> 32;
-      let n = 1u32 >> 33; //~ ERROR: bitshift exceeds the type's number of bits
-      let n = 1u64 >> 64;
-      let n = 1u64 >> 65; //~ ERROR: bitshift exceeds the type's number of bits
-      let n = 1i8 >> 8;
-      let n = 1i8 >> 9;   //~ ERROR: bitshift exceeds the type's number of bits
-      let n = 1i16 >> 16;
-      let n = 1i16 >> 17; //~ ERROR: bitshift exceeds the type's number of bits
-      let n = 1i32 >> 32;
-      let n = 1i32 >> 33; //~ ERROR: bitshift exceeds the type's number of bits
-      let n = 1i64 >> 64;
-      let n = 1i64 >> 65; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u8 >> 7;
+      let n = 1u8 >> 8;   //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u16 >> 15;
+      let n = 1u16 >> 16; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u32 >> 31;
+      let n = 1u32 >> 32; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u64 >> 63;
+      let n = 1u64 >> 64; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i8 >> 7;
+      let n = 1i8 >> 8;   //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i16 >> 15;
+      let n = 1i16 >> 16; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i32 >> 31;
+      let n = 1i32 >> 32; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1i64 >> 63;
+      let n = 1i64 >> 64; //~ ERROR: bitshift exceeds the type's number of bits
 
       let n = 1u8;
-      let n = n << 8;
-      let n = n << 9; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = n << 7;
+      let n = n << 8; //~ ERROR: bitshift exceeds the type's number of bits
 
-      let n = 1u8 << -9; //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u8 << -8; //~ ERROR: bitshift exceeds the type's number of bits
 
-      let n = 1u8 << (4+4);
-      let n = 1u8 << (4+5); //~ ERROR: bitshift exceeds the type's number of bits
+      let n = 1u8 << (4+3);
+      let n = 1u8 << (4+4); //~ ERROR: bitshift exceeds the type's number of bits
 }
 


### PR DESCRIPTION
As @ben0x539 commented in #18206 for issue #17713

LLVM states:  "If op2 is (statically or dynamically) negative or equal
to or larger than the number of bits in op1, the result is undefined."
