### PR TITLE
rustc: Set the exceeding_bitshifts lint to Allow

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -116,7 +116,7 @@ declare_lint!(UNUSED_COMPARISONS, Warn,
 declare_lint!(OVERFLOWING_LITERALS, Warn,
               "literal out of range for its type")
 
-declare_lint!(EXCEEDING_BITSHIFTS, Deny,
+declare_lint!(EXCEEDING_BITSHIFTS, Allow,
               "shift exceeds the type's number of bits")
 
 pub struct TypeLimits {


### PR DESCRIPTION
There's currently a bug in it which fires erroneously on cross compiles,
preventing new nightlies from being generated. This can be reset back to Deny
once it's been fixed.

cc #18587
