### PR TITLE
rustc: Default to static linking dylibs

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -148,12 +148,13 @@ endif
 # libraries, so in the interest of space, prefer dynamic linking throughout the
 # compilation process.
 #
-# Note though that these flags are omitted for stage2+. This means that the
-# snapshot will be generated with a statically linked rustc so we only have to
-# worry about the distribution of one file (with its native dynamic
+# Note though that these flags are omitted for the *bins* in stage2+. This means
+# that the snapshot will be generated with a statically linked rustc so we only
+# have to worry about the distribution of one file (with its native dynamic
 # dependencies)
 RUSTFLAGS_STAGE0 += -C prefer-dynamic
 RUSTFLAGS_STAGE1 += -C prefer-dynamic
+RUST_LIB_FLAGS_ST2 += -C prefer-dynamic
 
 # Landing pads require a lot of codegen. We can get through bootstrapping faster
 # by not emitting them.

--- a/mk/target.mk
+++ b/mk/target.mk
@@ -17,9 +17,9 @@ export CFG_COMPILER_HOST_TRIPLE
 # code, make sure that these common warnings are denied by default. These can
 # be overridden during development temporarily. For stage0, we allow warnings
 # which may be bugs in stage0 (should be fixed in stage1+)
-WFLAGS_ST0 = -W warnings
-WFLAGS_ST1 = -D warnings
-WFLAGS_ST2 = -D warnings
+RUST_LIB_FLAGS_ST0 += -W warnings
+RUST_LIB_FLAGS_ST1 += -D warnings
+RUST_LIB_FLAGS_ST2 += -D warnings
 
 # Macro that generates the full list of dependencies for a crate at a particular
 # stage/target/host tuple.
@@ -80,7 +80,7 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4): \
 	$$(call REMOVE_ALL_OLD_GLOB_MATCHES, \
 	    $$(dir $$@)$$(call CFG_RLIB_GLOB,$(4)))
 	$$(STAGE$(1)_T_$(2)_H_$(3)) \
-		$$(WFLAGS_ST$(1)) \
+		$$(RUST_LIB_FLAGS_ST$(1)) \
 		-L "$$(RT_OUTPUT_DIR_$(2))" \
 		-L "$$(LLVM_LIBDIR_$(2))" \
 		-L "$$(dir $$(LLVM_STDCPP_LOCATION_$(2)))" \

--- a/src/librustc/middle/dependency_format.rs
+++ b/src/librustc/middle/dependency_format.rs
@@ -123,6 +123,16 @@ fn calculate_type(sess: &session::Session,
             return Vec::new();
         }
 
+        // Generating a dylib without `-C prefer-dynamic` means that we're going
+        // to try to eagerly statically link all dependencies. This is normally
+        // done for end-product dylibs, not intermediate products.
+        config::CrateTypeDylib if !sess.opts.cg.prefer_dynamic => {
+            match attempt_static(sess) {
+                Some(v) => return v,
+                None => {}
+            }
+        }
+
         // Everything else falls through below
         config::CrateTypeExecutable | config::CrateTypeDylib => {},
     }

--- a/src/test/auxiliary/issue-12133-dylib.rs
+++ b/src/test/auxiliary/issue-12133-dylib.rs
@@ -8,6 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// no-prefer-dynamic
-
 #![crate_type = "dylib"]

--- a/src/test/auxiliary/syntax-extension-with-dll-deps-2.rs
+++ b/src/test/auxiliary/syntax-extension-with-dll-deps-2.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // force-host
-// no-prefer-dynamic
 
 #![crate_type = "dylib"]
 #![feature(plugin_registrar, quote, globs)]

--- a/src/test/run-make/c-dynamic-dylib/Makefile
+++ b/src/test/run-make/c-dynamic-dylib/Makefile
@@ -6,7 +6,7 @@ all:
 	echo ignored
 else
 all: $(call DYLIB,cfoo)
-	$(RUSTC) foo.rs
+	$(RUSTC) foo.rs -C prefer-dynamic
 	$(RUSTC) bar.rs
 	$(call RUN,bar)
 	$(call REMOVE_DYLIBS,cfoo)

--- a/src/test/run-make/c-static-dylib/Makefile
+++ b/src/test/run-make/c-static-dylib/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
 all: $(call STATICLIB,cfoo)
-	$(RUSTC) foo.rs
+	$(RUSTC) foo.rs -C prefer-dynamic
 	$(RUSTC) bar.rs
 	rm $(TMPDIR)/$(call STATICLIB_GLOB,cfoo)
 	$(call RUN,bar)

--- a/src/test/run-make/dylib-chain/Makefile
+++ b/src/test/run-make/dylib-chain/Makefile
@@ -1,9 +1,9 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) m1.rs
-	$(RUSTC) m2.rs
-	$(RUSTC) m3.rs
+	$(RUSTC) m1.rs -C prefer-dynamic
+	$(RUSTC) m2.rs -C prefer-dynamic
+	$(RUSTC) m3.rs -C prefer-dynamic
 	$(RUSTC) m4.rs
 	$(call RUN,m4)
 	$(call REMOVE_DYLIBS,m1)

--- a/src/test/run-make/issue-15460/Makefile
+++ b/src/test/run-make/issue-15460/Makefile
@@ -1,6 +1,6 @@
 -include ../tools.mk
 
 all: $(TMPDIR)/libfoo.a
-	$(RUSTC) foo.rs -C extra-filename=-383hf8
+	$(RUSTC) foo.rs -C extra-filename=-383hf8 -C prefer-dynamic
 	$(RUSTC) bar.rs
 	$(call RUN,bar)

--- a/src/test/run-make/mixing-deps/Makefile
+++ b/src/test/run-make/mixing-deps/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) both.rs
+	$(RUSTC) both.rs -C prefer-dynamic
 	$(RUSTC) dylib.rs -C prefer-dynamic
 	$(RUSTC) prog.rs
 	$(call RUN,prog)

--- a/src/test/run-make/mixing-formats/Makefile
+++ b/src/test/run-make/mixing-formats/Makefile
@@ -15,60 +15,60 @@
 all:
 	# Building just baz
 	$(RUSTC) --crate-type=rlib  foo.rs
-	$(RUSTC) --crate-type=dylib bar1.rs
-	$(RUSTC) --crate-type=dylib,rlib baz.rs
+	$(RUSTC) --crate-type=dylib bar1.rs -C prefer-dynamic
+	$(RUSTC) --crate-type=dylib,rlib baz.rs -C prefer-dynamic
 	$(RUSTC) --crate-type=bin baz.rs
 	rm $(TMPDIR)/*
-	$(RUSTC) --crate-type=dylib foo.rs
+	$(RUSTC) --crate-type=dylib foo.rs -C prefer-dynamic
 	$(RUSTC) --crate-type=rlib  bar1.rs
-	$(RUSTC) --crate-type=dylib,rlib baz.rs
+	$(RUSTC) --crate-type=dylib,rlib baz.rs -C prefer-dynamic
 	$(RUSTC) --crate-type=bin baz.rs
 	rm $(TMPDIR)/*
 	# Building baz2
 	$(RUSTC) --crate-type=rlib  foo.rs
-	$(RUSTC) --crate-type=dylib bar1.rs
-	$(RUSTC) --crate-type=dylib bar2.rs
+	$(RUSTC) --crate-type=dylib bar1.rs -C prefer-dynamic
+	$(RUSTC) --crate-type=dylib bar2.rs -C prefer-dynamic
 	$(RUSTC) --crate-type=dylib baz2.rs && exit 1 || exit 0
 	$(RUSTC) --crate-type=bin baz2.rs && exit 1 || exit 0
 	rm $(TMPDIR)/*
 	$(RUSTC) --crate-type=rlib  foo.rs
 	$(RUSTC) --crate-type=rlib  bar1.rs
-	$(RUSTC) --crate-type=dylib bar2.rs
+	$(RUSTC) --crate-type=dylib bar2.rs -C prefer-dynamic
 	$(RUSTC) --crate-type=dylib,rlib baz2.rs
 	$(RUSTC) --crate-type=bin baz2.rs
 	rm $(TMPDIR)/*
 	$(RUSTC) --crate-type=rlib  foo.rs
-	$(RUSTC) --crate-type=dylib bar1.rs
+	$(RUSTC) --crate-type=dylib bar1.rs -C prefer-dynamic
 	$(RUSTC) --crate-type=rlib  bar2.rs
-	$(RUSTC) --crate-type=dylib,rlib baz2.rs
+	$(RUSTC) --crate-type=dylib,rlib baz2.rs -C prefer-dynamic
 	$(RUSTC) --crate-type=bin baz2.rs
 	rm $(TMPDIR)/*
 	$(RUSTC) --crate-type=rlib  foo.rs
 	$(RUSTC) --crate-type=rlib  bar1.rs
 	$(RUSTC) --crate-type=rlib  bar2.rs
-	$(RUSTC) --crate-type=dylib,rlib baz2.rs
+	$(RUSTC) --crate-type=dylib,rlib baz2.rs -C prefer-dynamic
 	$(RUSTC) --crate-type=bin baz2.rs
 	rm $(TMPDIR)/*
-	$(RUSTC) --crate-type=dylib foo.rs
+	$(RUSTC) --crate-type=dylib foo.rs -C prefer-dynamic
 	$(RUSTC) --crate-type=rlib  bar1.rs
+	$(RUSTC) --crate-type=rlib  bar2.rs
+	$(RUSTC) --crate-type=dylib,rlib baz2.rs -C prefer-dynamic
+	$(RUSTC) --crate-type=bin baz2.rs
+	rm $(TMPDIR)/*
+	$(RUSTC) --crate-type=dylib foo.rs -C prefer-dynamic
+	$(RUSTC) --crate-type=dylib bar1.rs -C prefer-dynamic
 	$(RUSTC) --crate-type=rlib  bar2.rs
 	$(RUSTC) --crate-type=dylib,rlib baz2.rs
 	$(RUSTC) --crate-type=bin baz2.rs
 	rm $(TMPDIR)/*
-	$(RUSTC) --crate-type=dylib foo.rs
-	$(RUSTC) --crate-type=dylib bar1.rs
-	$(RUSTC) --crate-type=rlib  bar2.rs
-	$(RUSTC) --crate-type=dylib,rlib baz2.rs
-	$(RUSTC) --crate-type=bin baz2.rs
-	rm $(TMPDIR)/*
-	$(RUSTC) --crate-type=dylib foo.rs
+	$(RUSTC) --crate-type=dylib foo.rs -C prefer-dynamic
 	$(RUSTC) --crate-type=rlib  bar1.rs
-	$(RUSTC) --crate-type=dylib bar2.rs
+	$(RUSTC) --crate-type=dylib bar2.rs -C prefer-dynamic
 	$(RUSTC) --crate-type=dylib,rlib baz2.rs
 	$(RUSTC) --crate-type=bin baz2.rs
 	rm $(TMPDIR)/*
-	$(RUSTC) --crate-type=dylib foo.rs
-	$(RUSTC) --crate-type=dylib bar1.rs
-	$(RUSTC) --crate-type=dylib bar2.rs
+	$(RUSTC) --crate-type=dylib foo.rs -C prefer-dynamic
+	$(RUSTC) --crate-type=dylib bar1.rs -C prefer-dynamic
+	$(RUSTC) --crate-type=dylib bar2.rs -C prefer-dynamic
 	$(RUSTC) --crate-type=dylib,rlib baz2.rs
 	$(RUSTC) --crate-type=bin baz2.rs

--- a/src/test/run-make/prefer-dylib/Makefile
+++ b/src/test/run-make/prefer-dylib/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) bar.rs --crate-type=dylib --crate-type=rlib
+	$(RUSTC) bar.rs --crate-type=dylib --crate-type=rlib -C prefer-dynamic
 	$(RUSTC) foo.rs -C prefer-dynamic
 	$(call RUN,foo)
 	rm $(TMPDIR)/*bar*

--- a/src/test/run-make/simple-dylib/Makefile
+++ b/src/test/run-make/simple-dylib/Makefile
@@ -1,5 +1,5 @@
 -include ../tools.mk
 all:
-	$(RUSTC) bar.rs --crate-type=dylib
+	$(RUSTC) bar.rs --crate-type=dylib -C prefer-dynamic
 	$(RUSTC) foo.rs
 	$(call RUN,foo)

--- a/src/test/run-make/static-dylib-by-default/Makefile
+++ b/src/test/run-make/static-dylib-by-default/Makefile
@@ -1,0 +1,9 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) foo.rs
+	$(RUSTC) bar.rs
+	$(CC) main.c -o $(call RUN_BINFILE,main) -lbar
+	rm $(TMPDIR)/*.rlib
+	rm $(call DYLIB,foo)
+	$(call RUN,main)

--- a/src/test/run-make/static-dylib-by-default/bar.rs
+++ b/src/test/run-make/static-dylib-by-default/bar.rs
@@ -8,10 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// force-host
-
 #![crate_type = "dylib"]
 
-pub fn the_answer() -> int {
-    2
+extern crate foo;
+
+#[no_mangle]
+pub extern fn bar() {
+    foo::foo();
 }

--- a/src/test/run-make/static-dylib-by-default/foo.rs
+++ b/src/test/run-make/static-dylib-by-default/foo.rs
@@ -8,10 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// force-host
-
+#![crate_type = "rlib"]
 #![crate_type = "dylib"]
 
-pub fn the_answer() -> int {
-    2
-}
+pub fn foo() {}

--- a/src/test/run-make/static-dylib-by-default/main.c
+++ b/src/test/run-make/static-dylib-by-default/main.c
@@ -8,10 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// force-host
+extern void bar();
 
-#![crate_type = "dylib"]
-
-pub fn the_answer() -> int {
-    2
+int main() {
+    bar();
+    return 0;
 }

--- a/src/test/run-make/suspicious-library/Makefile
+++ b/src/test/run-make/suspicious-library/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) foo.rs
+	$(RUSTC) foo.rs -C prefer-dynamic
 	touch $(call DYLIB,foo-something-special)
 	touch $(call DYLIB,foo-something-special2)
 	$(RUSTC) bar.rs

--- a/src/test/run-make/symlinked-libraries/Makefile
+++ b/src/test/run-make/symlinked-libraries/Makefile
@@ -4,7 +4,7 @@
 ifndef IS_WINDOWS
 
 all:
-	$(RUSTC) foo.rs
+	$(RUSTC) foo.rs -C prefer-dynamic
 	mkdir -p $(TMPDIR)/other
 	ln -nsf $(TMPDIR)/$(call DYLIB_GLOB,foo) $(TMPDIR)/other
 	$(RUSTC) bar.rs -L $(TMPDIR)/other


### PR DESCRIPTION
If a dylib is being produced, the compiler will now first check to see if it can
be created entirely statically before falling back to dynamic dependencies. This
behavior can be overridden with `-C prefer-dynamic`.

Due to the alteration in behavior, this is a breaking change. Any previous users
relying on dylibs implicitly maximizing dynamic dependencies should start
passing `-C prefer-dynamic` to compilations.

Closes #18499
[breaking-change]
