### PR TITLE
Some stabilization and conventions changes to std::char

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -1566,7 +1566,7 @@ fn _arm_exec_compiled_test(config: &Config,
 
     let mut exitcode: int = 0;
     for c in exitcode_out.as_slice().chars() {
-        if !c.is_digit() { break; }
+        if !c.is_numeric() { break; }
         exitcode = exitcode * 10 + match c {
             '0' ... '9' => c as int - ('0' as int),
             _ => 101,

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1189,7 +1189,7 @@ mod tests {
         assert_eq!("11foo1bar11".trim_left_chars('1'), "foo1bar11");
         let chars: &[char] = &['1', '2'];
         assert_eq!("12foo1bar12".trim_left_chars(chars), "foo1bar12");
-        assert_eq!("123foo1bar123".trim_left_chars(|c: char| c.is_digit()), "foo1bar123");
+        assert_eq!("123foo1bar123".trim_left_chars(|c: char| c.is_numeric()), "foo1bar123");
     }
 
     #[test]
@@ -1204,7 +1204,7 @@ mod tests {
         assert_eq!("11foo1bar11".trim_right_chars('1'), "11foo1bar");
         let chars: &[char] = &['1', '2'];
         assert_eq!("12foo1bar12".trim_right_chars(chars), "12foo1bar");
-        assert_eq!("123foo1bar123".trim_right_chars(|c: char| c.is_digit()), "123foo1bar");
+        assert_eq!("123foo1bar123".trim_right_chars(|c: char| c.is_numeric()), "123foo1bar");
     }
 
     #[test]
@@ -1219,7 +1219,7 @@ mod tests {
         assert_eq!("11foo1bar11".trim_chars('1'), "foo1bar");
         let chars: &[char] = &['1', '2'];
         assert_eq!("12foo1bar12".trim_chars(chars), "foo1bar");
-        assert_eq!("123foo1bar123".trim_chars(|c: char| c.is_digit()), "foo1bar");
+        assert_eq!("123foo1bar123".trim_chars(|c: char| c.is_numeric()), "foo1bar");
     }
 
     #[test]

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -630,7 +630,9 @@ pub trait StrAllocating: Str {
         let me = self.as_slice();
         let mut out = String::with_capacity(me.len());
         for c in me.chars() {
-            c.escape_default(|c| out.push(c));
+            for c in c.escape_default() {
+                out.push(c);
+            }
         }
         out
     }
@@ -640,7 +642,9 @@ pub trait StrAllocating: Str {
         let me = self.as_slice();
         let mut out = String::with_capacity(me.len());
         for c in me.chars() {
-            c.escape_unicode(|c| out.push(c));
+            for c in c.escape_unicode() {
+                out.push(c);
+            }
         }
         out
     }

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -229,6 +229,7 @@ pub fn len_utf8_bytes(c: char) -> uint {
 }
 
 /// Basic `char` manipulations.
+#[experimental = "trait organization may change"]
 pub trait Char {
     /// Checks if a `char` parses as a numeric digit in the given radix.
     ///
@@ -315,6 +316,7 @@ pub trait Char {
     fn encode_utf16(&self, dst: &mut [u16]) -> Option<uint>;
 }
 
+#[experimental = "trait is experimental"]
 impl Char for char {
     fn is_digit_radix(&self, radix: uint) -> bool { is_digit_radix(*self, radix) }
 

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -63,6 +63,7 @@ static MAX_THREE_B: u32 =  0x10000u32;
 */
 
 /// The highest valid code point
+#[stable]
 pub const MAX: char = '\U0010ffff';
 
 /// Converts from `u32` to a `char`

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -323,6 +323,10 @@ pub trait Char {
     /// UTF-8.
     fn len_utf8(&self) -> uint;
 
+    /// Returns the amount of bytes this character would need if encoded in
+    /// UTF-16.
+    fn len_utf16(&self) -> uint;
+
     /// Encodes this character as UTF-8 into the provided byte buffer,
     /// and then returns the number of bytes written.
     ///
@@ -362,6 +366,12 @@ impl Char for char {
 
     #[inline]
     fn len_utf8(&self) -> uint { len_utf8_bytes(*self) }
+
+    #[inline]
+    fn len_utf16(&self) -> uint {
+        let ch = *self as u32;
+        if (ch & 0xFFFF_u32) == ch { 1 } else { 2 }
+    }
 
     #[inline]
     fn encode_utf8<'a>(&self, dst: &'a mut [u8]) -> Option<uint> {

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -316,7 +316,12 @@ pub trait Char {
 
     /// Returns the amount of bytes this character would need if encoded in
     /// UTF-8.
+    #[deprecated = "use len_utf8"]
     fn len_utf8_bytes(&self) -> uint;
+
+    /// Returns the amount of bytes this character would need if encoded in
+    /// UTF-8.
+    fn len_utf8(&self) -> uint;
 
     /// Encodes this character as UTF-8 into the provided byte buffer,
     /// and then returns the number of bytes written.
@@ -352,7 +357,11 @@ impl Char for char {
     fn escape_default(&self, f: |char|) { escape_default(*self, f) }
 
     #[inline]
+    #[deprecated = "use len_utf8"]
     fn len_utf8_bytes(&self) -> uint { len_utf8_bytes(*self) }
+
+    #[inline]
+    fn len_utf8(&self) -> uint { len_utf8_bytes(*self) }
 
     #[inline]
     fn encode_utf8<'a>(&self, dst: &'a mut [u8]) -> Option<uint> {

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -270,6 +270,9 @@ pub trait Char {
     /// Panics if given a radix > 36.
     fn from_digit(num: uint, radix: uint) -> Option<Self>;
 
+    /// Converts from `u32` to a `char`
+    fn from_u32(i: u32) -> Option<char>;
+
     /// Returns the hexadecimal Unicode escape of a character.
     ///
     /// The rules are as follows:
@@ -318,6 +321,9 @@ impl Char for char {
     fn to_digit(&self, radix: uint) -> Option<uint> { to_digit(*self, radix) }
 
     fn from_digit(num: uint, radix: uint) -> Option<char> { from_digit(num, radix) }
+
+    #[inline]
+    fn from_u32(i: u32) -> Option<char> { from_u32(i) }
 
     fn escape_unicode(&self, f: |char|) { escape_unicode(*self, f) }
 

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -68,6 +68,7 @@ pub const MAX: char = '\U0010ffff';
 
 /// Converts from `u32` to a `char`
 #[inline]
+#[unstable = "pending decisions about costructors for primitives"]
 pub fn from_u32(i: u32) -> Option<char> {
     // catch out-of-bounds and surrogates
     if (i > MAX as u32) || (i >= 0xD800 && i <= 0xDFFF) {
@@ -146,6 +147,7 @@ pub fn to_digit(c: char, radix: uint) -> Option<uint> {
 /// Panics if given an `radix` > 36.
 ///
 #[inline]
+#[unstable = "pending decisions about costructors for primitives"]
 pub fn from_digit(num: uint, radix: uint) -> Option<char> {
     if radix > 36 {
         panic!("from_digit: radix is to high (maximum 36)");
@@ -286,9 +288,11 @@ pub trait Char {
     /// # Panics
     ///
     /// Panics if given a radix > 36.
+    #[deprecated = "use the char::from_digit free function"]
     fn from_digit(num: uint, radix: uint) -> Option<Self>;
 
     /// Converts from `u32` to a `char`
+    #[deprecated = "use the char::from_u32 free function"]
     fn from_u32(i: u32) -> Option<char>;
 
     /// Returns the hexadecimal Unicode escape of a character.
@@ -351,9 +355,11 @@ impl Char for char {
 
     fn to_digit(&self, radix: uint) -> Option<uint> { to_digit(*self, radix) }
 
+    #[deprecated = "use the char::from_digit free function"]
     fn from_digit(num: uint, radix: uint) -> Option<char> { from_digit(num, radix) }
 
     #[inline]
+    #[deprecated = "use the char::from_u32 free function"]
     fn from_u32(i: u32) -> Option<char> { from_u32(i) }
 
     fn escape_unicode(&self, f: |char|) { escape_unicode(*self, f) }

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -268,6 +268,7 @@ pub trait Char {
     /// # Failure
     ///
     /// Fails if given a radix > 36.
+    #[unstable = "pending error conventions"]
     fn is_digit(&self, radix: uint) -> bool;
 
     /// Converts a character to the corresponding digit.
@@ -281,6 +282,7 @@ pub trait Char {
     /// # Panics
     ///
     /// Panics if given a radix outside the range [0..36].
+    #[unstable = "pending error conventions, trait organization"]
     fn to_digit(&self, radix: uint) -> Option<uint>;
 
     /// Converts a number to the character representing it.
@@ -307,6 +309,7 @@ pub trait Char {
     /// * Characters in [0,0xff] get 2-digit escapes: `\\xNN`
     /// * Characters in [0x100,0xffff] get 4-digit escapes: `\\uNNNN`.
     /// * Characters above 0x10000 get 8-digit escapes: `\\UNNNNNNNN`.
+    #[unstable = "pending error conventions, trait organization"]
     fn escape_unicode(&self, f: |char|);
 
     /// Returns a 'default' ASCII and C++11-like literal escape of a
@@ -321,6 +324,7 @@ pub trait Char {
     ///   escaped.
     /// * Any other chars in the range [0x20,0x7e] are not escaped.
     /// * Any other chars are given hex Unicode escapes; see `escape_unicode`.
+    #[unstable = "pending error conventions, trait organization"]
     fn escape_default(&self, f: |char|);
 
     /// Returns the amount of bytes this character would need if encoded in
@@ -330,10 +334,12 @@ pub trait Char {
 
     /// Returns the amount of bytes this character would need if encoded in
     /// UTF-8.
+    #[unstable = "pending trait organization"]
     fn len_utf8(&self) -> uint;
 
     /// Returns the amount of bytes this character would need if encoded in
     /// UTF-16.
+    #[unstable = "pending trait organization"]
     fn len_utf16(&self) -> uint;
 
     /// Encodes this character as UTF-8 into the provided byte buffer,
@@ -341,6 +347,7 @@ pub trait Char {
     ///
     /// If the buffer is not large enough, nothing will be written into it
     /// and a `None` will be returned.
+    #[unstable = "pending trait organization"]
     fn encode_utf8(&self, dst: &mut [u8]) -> Option<uint>;
 
     /// Encodes this character as UTF-16 into the provided `u16` buffer,
@@ -348,6 +355,7 @@ pub trait Char {
     ///
     /// If the buffer is not large enough, nothing will be written into it
     /// and a `None` will be returned.
+    #[unstable = "pending trait organization"]
     fn encode_utf16(&self, dst: &mut [u16]) -> Option<uint>;
 }
 
@@ -356,8 +364,10 @@ impl Char for char {
     #[deprecated = "use is_digit"]
     fn is_digit_radix(&self, radix: uint) -> bool { is_digit_radix(*self, radix) }
 
+    #[unstable = "pending trait organization"]
     fn is_digit(&self, radix: uint) -> bool { is_digit_radix(*self, radix) }
 
+    #[unstable = "pending trait organization"]
     fn to_digit(&self, radix: uint) -> Option<uint> { to_digit(*self, radix) }
 
     #[deprecated = "use the char::from_digit free function"]
@@ -367,8 +377,10 @@ impl Char for char {
     #[deprecated = "use the char::from_u32 free function"]
     fn from_u32(i: u32) -> Option<char> { from_u32(i) }
 
+    #[unstable = "pending error conventions, trait organization"]
     fn escape_unicode(&self, f: |char|) { escape_unicode(*self, f) }
 
+    #[unstable = "pending error conventions, trait organization"]
     fn escape_default(&self, f: |char|) { escape_default(*self, f) }
 
     #[inline]
@@ -376,15 +388,18 @@ impl Char for char {
     fn len_utf8_bytes(&self) -> uint { len_utf8_bytes(*self) }
 
     #[inline]
+    #[unstable = "pending trait organization"]
     fn len_utf8(&self) -> uint { len_utf8_bytes(*self) }
 
     #[inline]
+    #[unstable = "pending trait organization"]
     fn len_utf16(&self) -> uint {
         let ch = *self as u32;
         if (ch & 0xFFFF_u32) == ch { 1 } else { 2 }
     }
 
     #[inline]
+    #[unstable = "pending error conventions, trait organization"]
     fn encode_utf8<'a>(&self, dst: &'a mut [u8]) -> Option<uint> {
         // Marked #[inline] to allow llvm optimizing it away
         let code = *self as u32;
@@ -412,6 +427,7 @@ impl Char for char {
     }
 
     #[inline]
+    #[unstable = "pending error conventions, trait organization"]
     fn encode_utf16(&self, dst: &mut [u16]) -> Option<uint> {
         // Marked #[inline] to allow llvm optimizing it away
         let mut ch = *self as u32;

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -245,7 +245,23 @@ pub trait Char {
     /// # Panics
     ///
     /// Panics if given a radix > 36.
+    #[deprecated = "use is_digit"]
     fn is_digit_radix(&self, radix: uint) -> bool;
+
+    /// Checks if a `char` parses as a numeric digit in the given radix.
+    ///
+    /// Compared to `is_digit()`, this function only recognizes the characters
+    /// `0-9`, `a-z` and `A-Z`.
+    ///
+    /// # Return value
+    ///
+    /// Returns `true` if `c` is a valid digit under `radix`, and `false`
+    /// otherwise.
+    ///
+    /// # Failure
+    ///
+    /// Fails if given a radix > 36.
+    fn is_digit(&self, radix: uint) -> bool;
 
     /// Converts a character to the corresponding digit.
     ///
@@ -319,7 +335,10 @@ pub trait Char {
 
 #[experimental = "trait is experimental"]
 impl Char for char {
+    #[deprecated = "use is_digit"]
     fn is_digit_radix(&self, radix: uint) -> bool { is_digit_radix(*self, radix) }
+
+    fn is_digit(&self, radix: uint) -> bool { is_digit_radix(*self, radix) }
 
     fn to_digit(&self, radix: uint) -> Option<uint> { to_digit(*self, radix) }
 

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -225,9 +225,9 @@ pub trait Char {
     /// Returns `true` if `c` is a valid digit under `radix`, and `false`
     /// otherwise.
     ///
-    /// # Failure
+    /// # Panics
     ///
-    /// Fails if given a radix > 36.
+    /// Panics if given a radix > 36.
     #[unstable = "pending error conventions"]
     fn is_digit(self, radix: uint) -> bool;
 

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -209,7 +209,7 @@ pub trait Char {
     ///
     /// Panics if given a radix > 36.
     #[deprecated = "use is_digit"]
-    fn is_digit_radix(&self, radix: uint) -> bool;
+    fn is_digit_radix(self, radix: uint) -> bool;
 
     /// Checks if a `char` parses as a numeric digit in the given radix.
     ///
@@ -225,7 +225,7 @@ pub trait Char {
     ///
     /// Fails if given a radix > 36.
     #[unstable = "pending error conventions"]
-    fn is_digit(&self, radix: uint) -> bool;
+    fn is_digit(self, radix: uint) -> bool;
 
     /// Converts a character to the corresponding digit.
     ///
@@ -239,7 +239,7 @@ pub trait Char {
     ///
     /// Panics if given a radix outside the range [0..36].
     #[unstable = "pending error conventions, trait organization"]
-    fn to_digit(&self, radix: uint) -> Option<uint>;
+    fn to_digit(self, radix: uint) -> Option<uint>;
 
     /// Converts a number to the character representing it.
     ///
@@ -266,7 +266,7 @@ pub trait Char {
     /// * Characters in [0x100,0xffff] get 4-digit escapes: `\\uNNNN`.
     /// * Characters above 0x10000 get 8-digit escapes: `\\UNNNNNNNN`.
     #[unstable = "pending error conventions, trait organization"]
-    fn escape_unicode(&self, f: |char|);
+    fn escape_unicode(self, f: |char|);
 
     /// Returns a 'default' ASCII and C++11-like literal escape of a
     /// character.
@@ -281,22 +281,22 @@ pub trait Char {
     /// * Any other chars in the range [0x20,0x7e] are not escaped.
     /// * Any other chars are given hex Unicode escapes; see `escape_unicode`.
     #[unstable = "pending error conventions, trait organization"]
-    fn escape_default(&self, f: |char|);
+    fn escape_default(self, f: |char|);
 
     /// Returns the amount of bytes this character would need if encoded in
     /// UTF-8.
     #[deprecated = "use len_utf8"]
-    fn len_utf8_bytes(&self) -> uint;
+    fn len_utf8_bytes(self) -> uint;
 
     /// Returns the amount of bytes this character would need if encoded in
     /// UTF-8.
     #[unstable = "pending trait organization"]
-    fn len_utf8(&self) -> uint;
+    fn len_utf8(self) -> uint;
 
     /// Returns the amount of bytes this character would need if encoded in
     /// UTF-16.
     #[unstable = "pending trait organization"]
-    fn len_utf16(&self) -> uint;
+    fn len_utf16(self) -> uint;
 
     /// Encodes this character as UTF-8 into the provided byte buffer,
     /// and then returns the number of bytes written.
@@ -318,10 +318,10 @@ pub trait Char {
 #[experimental = "trait is experimental"]
 impl Char for char {
     #[deprecated = "use is_digit"]
-    fn is_digit_radix(&self, radix: uint) -> bool { self.is_digit(radix) }
+    fn is_digit_radix(self, radix: uint) -> bool { self.is_digit(radix) }
 
     #[unstable = "pending trait organization"]
-    fn is_digit(&self, radix: uint) -> bool {
+    fn is_digit(self, radix: uint) -> bool {
         match self.to_digit(radix) {
             Some(_) => true,
             None    => false,
@@ -329,14 +329,14 @@ impl Char for char {
     }
 
     #[unstable = "pending trait organization"]
-    fn to_digit(&self, radix: uint) -> Option<uint> {
+    fn to_digit(self, radix: uint) -> Option<uint> {
         if radix > 36 {
             panic!("to_digit: radix is too high (maximum 36)");
         }
-        let val = match *self {
-          '0' ... '9' => *self as uint - ('0' as uint),
-          'a' ... 'z' => *self as uint + 10u - ('a' as uint),
-          'A' ... 'Z' => *self as uint + 10u - ('A' as uint),
+        let val = match self {
+          '0' ... '9' => self as uint - ('0' as uint),
+          'a' ... 'z' => self as uint + 10u - ('a' as uint),
+          'A' ... 'Z' => self as uint + 10u - ('A' as uint),
           _ => return None,
         };
         if val < radix { Some(val) }
@@ -351,19 +351,19 @@ impl Char for char {
     fn from_u32(i: u32) -> Option<char> { from_u32(i) }
 
     #[unstable = "pending error conventions, trait organization"]
-    fn escape_unicode(&self, f: |char|) {
+    fn escape_unicode(self, f: |char|) {
         // avoid calling str::to_str_radix because we don't really need to allocate
         // here.
         f('\\');
         let pad = match () {
-            _ if *self <= '\xff'    => { f('x'); 2 }
-            _ if *self <= '\uffff'  => { f('u'); 4 }
+            _ if self <= '\xff'    => { f('x'); 2 }
+            _ if self <= '\uffff'  => { f('u'); 4 }
             _                   => { f('U'); 8 }
         };
         for offset in range_step::<i32>(4 * (pad - 1), -1, -4) {
             let offset = offset as uint;
             unsafe {
-                match ((*self as i32) >> offset) & 0xf {
+                match ((self as i32) >> offset) & 0xf {
                     i @ 0 ... 9 => { f(transmute('0' as i32 + i)); }
                     i => { f(transmute('a' as i32 + (i - 10))); }
                 }
@@ -372,27 +372,27 @@ impl Char for char {
     }
 
     #[unstable = "pending error conventions, trait organization"]
-    fn escape_default(&self, f: |char|) {
-        match *self {
+    fn escape_default(self, f: |char|) {
+        match self {
             '\t' => { f('\\'); f('t'); }
             '\r' => { f('\\'); f('r'); }
             '\n' => { f('\\'); f('n'); }
             '\\' => { f('\\'); f('\\'); }
             '\'' => { f('\\'); f('\''); }
             '"'  => { f('\\'); f('"'); }
-            '\x20' ... '\x7e' => { f(*self); }
+            '\x20' ... '\x7e' => { f(self); }
             _ => self.escape_unicode(f),
         }
     }
 
     #[inline]
     #[deprecated = "use len_utf8"]
-    fn len_utf8_bytes(&self) -> uint { self.len_utf8() }
+    fn len_utf8_bytes(self) -> uint { self.len_utf8() }
 
     #[inline]
     #[unstable = "pending trait organization"]
-    fn len_utf8(&self) -> uint {
-        let code = *self as u32;
+    fn len_utf8(self) -> uint {
+        let code = self as u32;
         match () {
             _ if code < MAX_ONE_B   => 1u,
             _ if code < MAX_TWO_B   => 2u,
@@ -403,8 +403,8 @@ impl Char for char {
 
     #[inline]
     #[unstable = "pending trait organization"]
-    fn len_utf16(&self) -> uint {
-        let ch = *self as u32;
+    fn len_utf16(self) -> uint {
+        let ch = self as u32;
         if (ch & 0xFFFF_u32) == ch { 1 } else { 2 }
     }
 

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -262,7 +262,8 @@ pub trait Char {
     #[deprecated = "use the char::from_u32 free function"]
     fn from_u32(i: u32) -> Option<char>;
 
-    /// Returns the hexadecimal Unicode escape of a character.
+    /// Returns an iterator that yields the hexadecimal Unicode escape
+    /// of a character, as `char`s.
     ///
     /// The rules are as follows:
     ///
@@ -272,8 +273,8 @@ pub trait Char {
     #[unstable = "pending error conventions, trait organization"]
     fn escape_unicode(self) -> UnicodeEscapedChars;
 
-    /// Returns a 'default' ASCII and C++11-like literal escape of a
-    /// character.
+    /// Returns an iterator that yields the 'default' ASCII and
+    /// C++11-like literal escape of a character, as `char`s.
     ///
     /// The default is chosen with a bias toward producing literals that are
     /// legal in a variety of languages, including C++11 and similar C-family

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -98,6 +98,7 @@ pub fn from_u32(i: u32) -> Option<char> {
 /// This just wraps `to_digit()`.
 ///
 #[inline]
+#[deprecated = "use the Char::is_digit method"]
 pub fn is_digit_radix(c: char, radix: uint) -> bool {
     match to_digit(c, radix) {
         Some(_) => true,
@@ -120,6 +121,7 @@ pub fn is_digit_radix(c: char, radix: uint) -> bool {
 /// Panics if given a `radix` outside the range `[0..36]`.
 ///
 #[inline]
+#[deprecated = "use the Char::to_digit method"]
 pub fn to_digit(c: char, radix: uint) -> Option<uint> {
     if radix > 36 {
         panic!("to_digit: radix is too high (maximum 36)");
@@ -174,6 +176,7 @@ pub fn from_digit(num: uint, radix: uint) -> Option<char> {
 /// - chars in [0x100,0xffff] get 4-digit escapes: `\\uNNNN`
 /// - chars above 0x10000 get 8-digit escapes: `\\UNNNNNNNN`
 ///
+#[deprecated = "use the Char::escape_unicode method"]
 pub fn escape_unicode(c: char, f: |char|) {
     // avoid calling str::to_str_radix because we don't really need to allocate
     // here.
@@ -206,6 +209,7 @@ pub fn escape_unicode(c: char, f: |char|) {
 /// - Any other chars in the range [0x20,0x7e] are not escaped.
 /// - Any other chars are given hex Unicode escapes; see `escape_unicode`.
 ///
+#[deprecated = "use the Char::escape_default method"]
 pub fn escape_default(c: char, f: |char|) {
     match c {
         '\t' => { f('\\'); f('t'); }
@@ -221,6 +225,7 @@ pub fn escape_default(c: char, f: |char|) {
 
 /// Returns the amount of bytes this `char` would need if encoded in UTF-8
 #[inline]
+#[deprecated = "use the Char::len_utf8 method"]
 pub fn len_utf8_bytes(c: char) -> uint {
     let code = c as u32;
     match () {

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -15,6 +15,7 @@ pub use self::SignificantDigits::*;
 pub use self::SignFormat::*;
 
 use char;
+use char::Char;
 use fmt;
 use iter::{range, DoubleEndedIterator};
 use num::{Float, FPNaN, FPInfinite, ToPrimitive};
@@ -222,7 +223,7 @@ pub fn float_to_str_bytes_common<T: Float, U>(
         // round the remaining ones.
         if limit_digits && dig == digit_count {
             let ascii2value = |chr: u8| {
-                char::to_digit(chr as char, radix).unwrap()
+                (chr as char).to_digit(radix).unwrap()
             };
             let value2ascii = |val: uint| {
                 char::from_digit(val, radix).unwrap() as u8

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1315,7 +1315,7 @@ pub trait StrPrelude for Sized? {
     /// let v: Vec<&str> = "Mary had a little lamb".split(' ').collect();
     /// assert_eq!(v, vec!["Mary", "had", "a", "little", "lamb"]);
     ///
-    /// let v: Vec<&str> = "abc1def2ghi".split(|c: char| c.is_digit()).collect();
+    /// let v: Vec<&str> = "abc1def2ghi".split(|c: char| c.is_numeric()).collect();
     /// assert_eq!(v, vec!["abc", "def", "ghi"]);
     ///
     /// let v: Vec<&str> = "lionXXtigerXleopard".split('X').collect();
@@ -1336,7 +1336,7 @@ pub trait StrPrelude for Sized? {
     /// let v: Vec<&str> = "Mary had a little lambda".splitn(2, ' ').collect();
     /// assert_eq!(v, vec!["Mary", "had", "a little lambda"]);
     ///
-    /// let v: Vec<&str> = "abc1def2ghi".splitn(1, |c: char| c.is_digit()).collect();
+    /// let v: Vec<&str> = "abc1def2ghi".splitn(1, |c: char| c.is_numeric()).collect();
     /// assert_eq!(v, vec!["abc", "def2ghi"]);
     ///
     /// let v: Vec<&str> = "lionXXtigerXleopard".splitn(2, 'X').collect();
@@ -1368,7 +1368,7 @@ pub trait StrPrelude for Sized? {
     /// let v: Vec<&str> = "Mary had a little lamb".split(' ').rev().collect();
     /// assert_eq!(v, vec!["lamb", "little", "a", "had", "Mary"]);
     ///
-    /// let v: Vec<&str> = "abc1def2ghi".split(|c: char| c.is_digit()).rev().collect();
+    /// let v: Vec<&str> = "abc1def2ghi".split(|c: char| c.is_numeric()).rev().collect();
     /// assert_eq!(v, vec!["ghi", "def", "abc"]);
     ///
     /// let v: Vec<&str> = "lionXXtigerXleopard".split('X').rev().collect();
@@ -1386,7 +1386,7 @@ pub trait StrPrelude for Sized? {
     /// let v: Vec<&str> = "Mary had a little lamb".rsplitn(2, ' ').collect();
     /// assert_eq!(v, vec!["lamb", "little", "Mary had a"]);
     ///
-    /// let v: Vec<&str> = "abc1def2ghi".rsplitn(1, |c: char| c.is_digit()).collect();
+    /// let v: Vec<&str> = "abc1def2ghi".rsplitn(1, |c: char| c.is_numeric()).collect();
     /// assert_eq!(v, vec!["ghi", "abc1def"]);
     ///
     /// let v: Vec<&str> = "lionXXtigerXleopard".rsplitn(2, 'X').collect();
@@ -1596,7 +1596,7 @@ pub trait StrPrelude for Sized? {
     /// assert_eq!("11foo1bar11".trim_chars('1'), "foo1bar")
     /// let x: &[_] = &['1', '2'];
     /// assert_eq!("12foo1bar12".trim_chars(x), "foo1bar")
-    /// assert_eq!("123foo1bar123".trim_chars(|c: char| c.is_digit()), "foo1bar")
+    /// assert_eq!("123foo1bar123".trim_chars(|c: char| c.is_numeric()), "foo1bar")
     /// ```
     fn trim_chars<'a, C: CharEq>(&'a self, to_trim: C) -> &'a str;
 
@@ -1612,7 +1612,7 @@ pub trait StrPrelude for Sized? {
     /// assert_eq!("11foo1bar11".trim_left_chars('1'), "foo1bar11")
     /// let x: &[_] = &['1', '2'];
     /// assert_eq!("12foo1bar12".trim_left_chars(x), "foo1bar12")
-    /// assert_eq!("123foo1bar123".trim_left_chars(|c: char| c.is_digit()), "foo1bar123")
+    /// assert_eq!("123foo1bar123".trim_left_chars(|c: char| c.is_numeric()), "foo1bar123")
     /// ```
     fn trim_left_chars<'a, C: CharEq>(&'a self, to_trim: C) -> &'a str;
 
@@ -1628,7 +1628,7 @@ pub trait StrPrelude for Sized? {
     /// assert_eq!("11foo1bar11".trim_right_chars('1'), "11foo1bar")
     /// let x: &[_] = &['1', '2'];
     /// assert_eq!("12foo1bar12".trim_right_chars(x), "12foo1bar")
-    /// assert_eq!("123foo1bar123".trim_right_chars(|c: char| c.is_digit()), "123foo1bar")
+    /// assert_eq!("123foo1bar123".trim_right_chars(|c: char| c.is_numeric()), "123foo1bar")
     /// ```
     fn trim_right_chars<'a, C: CharEq>(&'a self, to_trim: C) -> &'a str;
 

--- a/src/libcoretest/char.rs
+++ b/src/libcoretest/char.rs
@@ -105,12 +105,12 @@ fn test_is_control() {
 
 #[test]
 fn test_is_digit() {
-   assert!('2'.is_digit());
-   assert!('7'.is_digit());
-   assert!(!'c'.is_digit());
-   assert!(!'i'.is_digit());
-   assert!(!'z'.is_digit());
-   assert!(!'Q'.is_digit());
+   assert!('2'.is_numeric());
+   assert!('7'.is_numeric());
+   assert!(!'c'.is_numeric());
+   assert!(!'i'.is_numeric());
+   assert!(!'z'.is_numeric());
+   assert!(!'Q'.is_numeric());
 }
 
 #[test]

--- a/src/libcoretest/char.rs
+++ b/src/libcoretest/char.rs
@@ -198,6 +198,14 @@ fn test_encode_utf16() {
 }
 
 #[test]
+fn test_len_utf16() {
+    assert!('x'.len_utf16() == 1);
+    assert!('\u00e9'.len_utf16() == 1);
+    assert!('\ua66e'.len_utf16() == 1);
+    assert!('\U0001f4a9'.len_utf16() == 2);
+}
+
+#[test]
 fn test_width() {
     assert_eq!('\x00'.width(false),Some(0));
     assert_eq!('\x00'.width(true),Some(0));

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -411,7 +411,7 @@ impl<'a> Parser<'a> {
         loop {
             match self.cur.clone().next() {
                 Some((_, c)) => {
-                    match char::to_digit(c, 10) {
+                    match c.to_digit(10) {
                         Some(i) => {
                             cur = cur * 10 + i;
                             found = true;

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -383,7 +383,7 @@ impl<'a> Parser<'a> {
     /// characters.
     fn word(&mut self) -> &'a str {
         let start = match self.cur.clone().next() {
-            Some((pos, c)) if c.is_XID_start() => {
+            Some((pos, c)) if c.is_xid_start() => {
                 self.cur.next();
                 pos
             }
@@ -392,7 +392,7 @@ impl<'a> Parser<'a> {
         let mut end;
         loop {
             match self.cur.clone().next() {
-                Some((_, c)) if c.is_XID_continue() => {
+                Some((_, c)) if c.is_xid_continue() => {
                     self.cur.next();
                 }
                 Some((pos, _)) => { end = pos; break }

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -26,7 +26,6 @@ pub use self::Alignment::*;
 pub use self::Flag::*;
 pub use self::Count::*;
 
-use std::char;
 use std::str;
 use std::string;
 
@@ -221,7 +220,7 @@ impl<'a> Parser<'a> {
     fn ws(&mut self) {
         loop {
             match self.cur.clone().next() {
-                Some((_, c)) if char::is_whitespace(c) => { self.cur.next(); }
+                Some((_, c)) if c.is_whitespace() => { self.cur.next(); }
                 Some(..) | None => { return }
             }
         }
@@ -261,7 +260,7 @@ impl<'a> Parser<'a> {
             Some(i) => { ArgumentIs(i) }
             None => {
                 match self.cur.clone().next() {
-                    Some((_, c)) if char::is_alphabetic(c) => {
+                    Some((_, c)) if c.is_alphabetic() => {
                         ArgumentNamed(self.word())
                     }
                     _ => ArgumentNext
@@ -384,7 +383,7 @@ impl<'a> Parser<'a> {
     /// characters.
     fn word(&mut self) -> &'a str {
         let start = match self.cur.clone().next() {
-            Some((pos, c)) if char::is_XID_start(c) => {
+            Some((pos, c)) if c.is_XID_start() => {
                 self.cur.next();
                 pos
             }
@@ -393,7 +392,7 @@ impl<'a> Parser<'a> {
         let mut end;
         loop {
             match self.cur.clone().next() {
-                Some((_, c)) if char::is_XID_continue(c) => {
+                Some((_, c)) if c.is_XID_continue() => {
                     self.cur.next();
                 }
                 Some((pos, _)) => { end = pos; break }

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -886,7 +886,7 @@ fn each_split_within<'a>(ss: &'a str, lim: uint, it: |&'a str| -> bool)
     }
 
     let machine: |&mut bool, (uint, char)| -> bool = |cont, (i, c)| {
-        let whitespace = if ::std::char::is_whitespace(c) { Ws }       else { Cr };
+        let whitespace = if c.is_whitespace() { Ws }       else { Cr };
         let limit      = if (i - slice_start + 1) <= lim  { UnderLim } else { OverLim };
 
         state = match (state, whitespace, limit) {

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -431,7 +431,7 @@ impl<'a> LabelText<'a> {
             // not escaping \\, since Graphviz escString needs to
             // interpret backslashes; see EscStr above.
             '\\' => f(c),
-            _ => c.escape_default(f)
+            _ => for c in c.escape_default() { f(c) }
         }
     }
     fn escape_str(s: &str) -> String {

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -920,7 +920,7 @@ impl NonSnakeCase {
             let mut allow_underscore = true;
             ident.chars().all(|c| {
                 allow_underscore = match c {
-                    c if c.is_lowercase() || c.is_digit() => true,
+                    c if c.is_lowercase() || c.is_numeric() => true,
                     '_' if allow_underscore => false,
                     _ => return false,
                 };

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -27,7 +27,6 @@ use util::common::time;
 use util::ppaux;
 use util::sha2::{Digest, Sha256};
 
-use std::char;
 use std::io::fs::PathExtensions;
 use std::io::{fs, TempDir, Command};
 use std::io;
@@ -272,7 +271,7 @@ pub fn sanitize(s: &str) -> String {
     // Underscore-qualify anything that didn't start as an ident.
     if result.len() > 0u &&
         result.as_bytes()[0] != '_' as u8 &&
-        ! char::is_XID_start(result.as_bytes()[0] as char) {
+        ! (result.as_bytes()[0] as char).is_XID_start() {
         return format!("_{}", result.as_slice());
     }
 

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -271,7 +271,7 @@ pub fn sanitize(s: &str) -> String {
     // Underscore-qualify anything that didn't start as an ident.
     if result.len() > 0u &&
         result.as_bytes()[0] != '_' as u8 &&
-        ! (result.as_bytes()[0] as char).is_XID_start() {
+        ! (result.as_bytes()[0] as char).is_xid_start() {
         return format!("_{}", result.as_slice());
     }
 

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -262,7 +262,7 @@ pub fn sanitize(s: &str) -> String {
 
             _ => {
                 let mut tstr = String::new();
-                char::escape_unicode(c, |c| tstr.push(c));
+                for c in c.escape_unicode() { tstr.push(c) }
                 result.push('$');
                 result.push_str(tstr.as_slice().slice_from(1));
             }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2033,9 +2033,9 @@ fn lit_to_string(lit: &ast::Lit) -> String {
         ast::LitBinary(ref data) => format!("{}", data),
         ast::LitByte(b) => {
             let mut res = String::from_str("b'");
-            (b as char).escape_default(|c| {
+            for c in (b as char).escape_default() {
                 res.push(c);
-            });
+            }
             res.push('\'');
             res
         },

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use std::cell::RefCell;
-use std::char;
 use std::dynamic_lib::DynamicLibrary;
 use std::io::{Command, TempDir};
 use std::io;
@@ -300,8 +299,8 @@ impl Collector {
             // we use these headings as test names, so it's good if
             // they're valid identifiers.
             let name = name.chars().enumerate().map(|(i, c)| {
-                    if (i == 0 && char::is_XID_start(c)) ||
-                        (i != 0 && char::is_XID_continue(c)) {
+                    if (i == 0 && c.is_XID_start()) ||
+                        (i != 0 && c.is_XID_continue()) {
                         c
                     } else {
                         '_'

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -299,8 +299,8 @@ impl Collector {
             // we use these headings as test names, so it's good if
             // they're valid identifiers.
             let name = name.chars().enumerate().map(|(i, c)| {
-                    if (i == 0 && c.is_XID_start()) ||
-                        (i != 0 && c.is_XID_continue()) {
+                    if (i == 0 && c.is_xid_start()) ||
+                        (i != 0 && c.is_xid_continue()) {
                         c
                     } else {
                         '_'

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -17,6 +17,7 @@ pub use self::SignificantDigits::*;
 pub use self::SignFormat::*;
 
 use char;
+use char::Char;
 use num;
 use num::{Int, Float, FPNaN, FPInfinite, ToPrimitive};
 use slice::{SlicePrelude, CloneSliceAllocPrelude};
@@ -320,7 +321,7 @@ pub fn float_to_str_bytes_common<T: Float>(
         // round the remaining ones.
         if limit_digits && dig == digit_count {
             let ascii2value = |chr: u8| {
-                char::to_digit(chr as char, radix).unwrap()
+                (chr as char).to_digit(radix).unwrap()
             };
             let value2ascii = |val: uint| {
                 char::from_digit(val, radix).unwrap() as u8

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -71,7 +71,7 @@ fn demangle(writer: &mut Writer, s: &str) -> IoResult<()> {
         while valid {
             let mut i = 0;
             for c in chars {
-                if c.is_digit() {
+                if c.is_numeric() {
                     i = i * 10 + c as uint - '0' as uint;
                 } else {
                     break
@@ -101,7 +101,7 @@ fn demangle(writer: &mut Writer, s: &str) -> IoResult<()> {
                 first = false;
             }
             let mut rest = s;
-            while rest.char_at(0).is_digit() {
+            while rest.char_at(0).is_numeric() {
                 rest = rest.slice_from(1);
             }
             let i: uint = from_str(s.slice_to(s.len() - rest.len())).unwrap();

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -193,7 +193,7 @@ impl<'a> StringReader<'a> {
     fn fatal_span_char(&self, from_pos: BytePos, to_pos: BytePos, m: &str, c: char) -> ! {
         let mut m = m.to_string();
         m.push_str(": ");
-        char::escape_default(c, |c| m.push(c));
+        for c in c.escape_default() { m.push(c) }
         self.fatal_span_(from_pos, to_pos, m.as_slice());
     }
 
@@ -202,7 +202,7 @@ impl<'a> StringReader<'a> {
     fn err_span_char(&self, from_pos: BytePos, to_pos: BytePos, m: &str, c: char) {
         let mut m = m.to_string();
         m.push_str(": ");
-        char::escape_default(c, |c| m.push(c));
+        for c in c.escape_default() { m.push(c) }
         self.err_span_(from_pos, to_pos, m.as_slice());
     }
 

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -692,7 +692,7 @@ impl<'a> StringReader<'a> {
         // integer literal followed by field/method access or a range pattern
         // (`0..2` and `12.foo()`)
         if self.curr_is('.') && !self.nextch_is('.') && !self.nextch().unwrap_or('\0')
-                                                             .is_XID_start() {
+                                                             .is_xid_start() {
             // might have stuff after the ., and if it does, it needs to start
             // with a number
             self.bump();
@@ -1385,7 +1385,7 @@ fn ident_start(c: Option<char>) -> bool {
     (c >= 'a' && c <= 'z')
         || (c >= 'A' && c <= 'Z')
         || c == '_'
-        || (c > '\x7f' && c.is_XID_start())
+        || (c > '\x7f' && c.is_xid_start())
 }
 
 fn ident_continue(c: Option<char>) -> bool {
@@ -1395,7 +1395,7 @@ fn ident_continue(c: Option<char>) -> bool {
         || (c >= 'A' && c <= 'Z')
         || (c >= '0' && c <= '9')
         || c == '_'
-        || (c > '\x7f' && c.is_XID_continue())
+        || (c > '\x7f' && c.is_xid_continue())
 }
 
 #[cfg(test)]

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1385,7 +1385,7 @@ fn ident_start(c: Option<char>) -> bool {
     (c >= 'a' && c <= 'z')
         || (c >= 'A' && c <= 'Z')
         || c == '_'
-        || (c > '\x7f' && char::is_XID_start(c))
+        || (c > '\x7f' && c.is_XID_start())
 }
 
 fn ident_continue(c: Option<char>) -> bool {
@@ -1395,7 +1395,7 @@ fn ident_continue(c: Option<char>) -> bool {
         || (c >= 'A' && c <= 'Z')
         || (c >= '0' && c <= '9')
         || c == '_'
-        || (c > '\x7f' && char::is_XID_continue(c))
+        || (c > '\x7f' && c.is_XID_continue())
 }
 
 #[cfg(test)]

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -645,7 +645,7 @@ impl<'a> StringReader<'a> {
         loop {
             let c = self.curr;
             if c == Some('_') { debug!("skipping a _"); self.bump(); continue; }
-            match c.and_then(|cc| char::to_digit(cc, radix)) {
+            match c.and_then(|cc| cc.to_digit(radix)) {
                 Some(_) => {
                     debug!("{} in scan_digits", c);
                     len += 1;
@@ -677,7 +677,7 @@ impl<'a> StringReader<'a> {
                     return token::Integer(self.name_from(start_bpos));
                 }
             }
-        } else if c.is_digit_radix(10) {
+        } else if c.is_digit(10) {
             num_digits = self.scan_digits(10) + 1;
         } else {
             num_digits = 0;
@@ -696,7 +696,7 @@ impl<'a> StringReader<'a> {
             // might have stuff after the ., and if it does, it needs to start
             // with a number
             self.bump();
-            if self.curr.unwrap_or('\0').is_digit_radix(10) {
+            if self.curr.unwrap_or('\0').is_digit(10) {
                 self.scan_digits(10);
                 self.scan_float_exponent();
             }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2756,7 +2756,9 @@ impl<'a> State<'a> {
             }
             ast::LitChar(ch) => {
                 let mut res = String::from_str("'");
-                ch.escape_default(|c| res.push(c));
+                for c in ch.escape_default() {
+                    res.push(c);
+                }
                 res.push('\'');
                 word(&mut self.s, res.as_slice())
             }

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -14,8 +14,6 @@ pub use self::Param::*;
 use self::States::*;
 use self::FormatState::*;
 use self::FormatOp::*;
-
-use std::char;
 use std::mem::replace;
 
 #[deriving(PartialEq)]
@@ -298,7 +296,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
             },
             PushParam => {
                 // params are 1-indexed
-                stack.push(mparams[match char::to_digit(cur, 10) {
+                stack.push(mparams[match cur.to_digit(10) {
                     Some(d) => d - 1,
                     None => return Err("bad param number".to_string())
                 }].clone());

--- a/src/libunicode/u_char.rs
+++ b/src/libunicode/u_char.rs
@@ -217,7 +217,7 @@ pub trait UnicodeChar {
     fn is_control(&self) -> bool;
 
     /// Indicates whether the character is numeric (Nd, Nl, or No).
-    fn is_digit(&self) -> bool;
+    fn is_numeric(&self) -> bool;
 
     /// Converts a character to its lowercase equivalent.
     ///
@@ -281,7 +281,7 @@ impl UnicodeChar for char {
 
     fn is_control(&self) -> bool { is_control(*self) }
 
-    fn is_digit(&self) -> bool { is_digit(*self) }
+    fn is_numeric(&self) -> bool { is_digit(*self) }
 
     fn to_lowercase(&self) -> char { to_lowercase(*self) }
 

--- a/src/libunicode/u_char.rs
+++ b/src/libunicode/u_char.rs
@@ -166,7 +166,7 @@ pub fn width(c: char, is_cjk: bool) -> Option<uint> {
 pub trait UnicodeChar {
     /// Returns whether the specified character is considered a Unicode
     /// alphabetic code point.
-    fn is_alphabetic(&self) -> bool;
+    fn is_alphabetic(self) -> bool;
 
     /// Returns whether the specified character satisfies the 'XID_Start'
     /// Unicode property.
@@ -175,7 +175,7 @@ pub trait UnicodeChar {
     /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
     /// mostly similar to ID_Start but modified for closure under NFKx.
     #[allow(non_snake_case)]
-    fn is_XID_start(&self) -> bool;
+    fn is_XID_start(self) -> bool;
 
     /// Returns whether the specified `char` satisfies the 'XID_Continue'
     /// Unicode property.
@@ -184,40 +184,40 @@ pub trait UnicodeChar {
     /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
     /// mostly similar to 'ID_Continue' but modified for closure under NFKx.
     #[allow(non_snake_case)]
-    fn is_XID_continue(&self) -> bool;
+    fn is_XID_continue(self) -> bool;
 
 
     /// Indicates whether a character is in lowercase.
     ///
     /// This is defined according to the terms of the Unicode Derived Core
     /// Property `Lowercase`.
-    fn is_lowercase(&self) -> bool;
+    fn is_lowercase(self) -> bool;
 
     /// Indicates whether a character is in uppercase.
     ///
     /// This is defined according to the terms of the Unicode Derived Core
     /// Property `Uppercase`.
-    fn is_uppercase(&self) -> bool;
+    fn is_uppercase(self) -> bool;
 
     /// Indicates whether a character is whitespace.
     ///
     /// Whitespace is defined in terms of the Unicode Property `White_Space`.
-    fn is_whitespace(&self) -> bool;
+    fn is_whitespace(self) -> bool;
 
     /// Indicates whether a character is alphanumeric.
     ///
     /// Alphanumericness is defined in terms of the Unicode General Categories
     /// 'Nd', 'Nl', 'No' and the Derived Core Property 'Alphabetic'.
-    fn is_alphanumeric(&self) -> bool;
+    fn is_alphanumeric(self) -> bool;
 
     /// Indicates whether a character is a control code point.
     ///
     /// Control code points are defined in terms of the Unicode General
     /// Category `Cc`.
-    fn is_control(&self) -> bool;
+    fn is_control(self) -> bool;
 
     /// Indicates whether the character is numeric (Nd, Nl, or No).
-    fn is_numeric(&self) -> bool;
+    fn is_numeric(self) -> bool;
 
     /// Converts a character to its lowercase equivalent.
     ///
@@ -228,7 +228,7 @@ pub trait UnicodeChar {
     ///
     /// Returns the lowercase equivalent of the character, or the character
     /// itself if no conversion is possible.
-    fn to_lowercase(&self) -> char;
+    fn to_lowercase(self) -> char;
 
     /// Converts a character to its uppercase equivalent.
     ///
@@ -250,7 +250,7 @@ pub trait UnicodeChar {
     /// [`SpecialCasing`.txt`]: ftp://ftp.unicode.org/Public/UNIDATA/SpecialCasing.txt
     ///
     /// [2]: http://www.unicode.org/versions/Unicode4.0.0/ch03.pdf#G33992
-    fn to_uppercase(&self) -> char;
+    fn to_uppercase(self) -> char;
 
     /// Returns this character's displayed width in columns, or `None` if it is a
     /// control character other than `'\x00'`.
@@ -261,31 +261,33 @@ pub trait UnicodeChar {
     /// [Unicode Standard Annex #11](http://www.unicode.org/reports/tr11/)
     /// recommends that these characters be treated as 1 column (i.e.,
     /// `is_cjk` = `false`) if the context cannot be reliably determined.
-    fn width(&self, is_cjk: bool) -> Option<uint>;
+    #[experimental = "needs expert opinion. is_cjk flag stands out as ugly"]
+    fn width(self, is_cjk: bool) -> Option<uint>;
 }
 
 impl UnicodeChar for char {
-    fn is_alphabetic(&self) -> bool { is_alphabetic(*self) }
+    fn is_alphabetic(self) -> bool { is_alphabetic(self) }
 
-    fn is_XID_start(&self) -> bool { is_XID_start(*self) }
+    fn is_XID_start(self) -> bool { is_XID_start(self) }
 
-    fn is_XID_continue(&self) -> bool { is_XID_continue(*self) }
+    fn is_XID_continue(self) -> bool { is_XID_continue(self) }
 
-    fn is_lowercase(&self) -> bool { is_lowercase(*self) }
+    fn is_lowercase(self) -> bool { is_lowercase(self) }
 
-    fn is_uppercase(&self) -> bool { is_uppercase(*self) }
+    fn is_uppercase(self) -> bool { is_uppercase(self) }
 
-    fn is_whitespace(&self) -> bool { is_whitespace(*self) }
+    fn is_whitespace(self) -> bool { is_whitespace(self) }
 
-    fn is_alphanumeric(&self) -> bool { is_alphanumeric(*self) }
+    fn is_alphanumeric(self) -> bool { is_alphanumeric(self) }
 
-    fn is_control(&self) -> bool { is_control(*self) }
+    fn is_control(self) -> bool { is_control(self) }
 
-    fn is_numeric(&self) -> bool { is_digit(*self) }
+    fn is_numeric(self) -> bool { is_digit(self) }
 
-    fn to_lowercase(&self) -> char { to_lowercase(*self) }
+    fn to_lowercase(self) -> char { to_lowercase(self) }
 
-    fn to_uppercase(&self) -> char { to_uppercase(*self) }
+    fn to_uppercase(self) -> char { to_uppercase(self) }
 
-    fn width(&self, is_cjk: bool) -> Option<uint> { width(*self, is_cjk) }
+    #[experimental = "needs expert opinion. is_cjk flag stands out as ugly"]
+    fn width(self, is_cjk: bool) -> Option<uint> { width(self, is_cjk) }
 }

--- a/src/libunicode/u_char.rs
+++ b/src/libunicode/u_char.rs
@@ -176,7 +176,6 @@ pub trait UnicodeChar {
     /// 'XID_Start' is a Unicode Derived Property specified in
     /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
     /// mostly similar to ID_Start but modified for closure under NFKx.
-    #[allow(non_snake_case)]
     fn is_xid_start(self) -> bool;
 
     /// Returns whether the specified `char` satisfies the 'XID_Continue'
@@ -195,7 +194,6 @@ pub trait UnicodeChar {
     /// 'XID_Continue' is a Unicode Derived Property specified in
     /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
     /// mostly similar to 'ID_Continue' but modified for closure under NFKx.
-    #[allow(non_snake_case)]
     fn is_xid_continue(self) -> bool;
 
     /// Indicates whether a character is in lowercase.

--- a/src/libunicode/u_char.rs
+++ b/src/libunicode/u_char.rs
@@ -167,7 +167,17 @@ pub trait UnicodeChar {
     /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
     /// mostly similar to ID_Start but modified for closure under NFKx.
     #[allow(non_snake_case)]
+    #[deprecated = "use is_xid_start"]
     fn is_XID_start(self) -> bool;
+
+    /// Returns whether the specified character satisfies the 'XID_Start'
+    /// Unicode property.
+    ///
+    /// 'XID_Start' is a Unicode Derived Property specified in
+    /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
+    /// mostly similar to ID_Start but modified for closure under NFKx.
+    #[allow(non_snake_case)]
+    fn is_xid_start(self) -> bool;
 
     /// Returns whether the specified `char` satisfies the 'XID_Continue'
     /// Unicode property.
@@ -176,8 +186,17 @@ pub trait UnicodeChar {
     /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
     /// mostly similar to 'ID_Continue' but modified for closure under NFKx.
     #[allow(non_snake_case)]
+    #[deprecated = "use is_xid_continue"]
     fn is_XID_continue(self) -> bool;
 
+    /// Returns whether the specified `char` satisfies the 'XID_Continue'
+    /// Unicode property.
+    ///
+    /// 'XID_Continue' is a Unicode Derived Property specified in
+    /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
+    /// mostly similar to 'ID_Continue' but modified for closure under NFKx.
+    #[allow(non_snake_case)]
+    fn is_xid_continue(self) -> bool;
 
     /// Indicates whether a character is in lowercase.
     ///
@@ -267,9 +286,15 @@ impl UnicodeChar for char {
         }
     }
 
+    #[deprecated = "use is_xid_start"]
     fn is_XID_start(self) -> bool { derived_property::XID_Start(self) }
 
+    #[deprecated = "use is_xid_continue"]
     fn is_XID_continue(self) -> bool { derived_property::XID_Continue(self) }
+
+    fn is_xid_start(self) -> bool { derived_property::XID_Start(self) }
+
+    fn is_xid_continue(self) -> bool { derived_property::XID_Continue(self) }
 
     fn is_lowercase(self) -> bool {
         match self {

--- a/src/libunicode/u_char.rs
+++ b/src/libunicode/u_char.rs
@@ -20,12 +20,9 @@ use tables::{derived_property, property, general_category, conversions, charwidt
 
 /// Returns whether the specified `char` is considered a Unicode alphabetic
 /// code point
+#[deprecated = "use UnicodeChar::is_alphabetic"]
 pub fn is_alphabetic(c: char) -> bool {
-    match c {
-        'a' ... 'z' | 'A' ... 'Z' => true,
-        c if c > '\x7f' => derived_property::Alphabetic(c),
-        _ => false
-    }
+    c.is_alphabetic()
 }
 
 /// Returns whether the specified `char` satisfies the 'XID_Start' Unicode property
@@ -34,6 +31,7 @@ pub fn is_alphabetic(c: char) -> bool {
 /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
 /// mostly similar to ID_Start but modified for closure under NFKx.
 #[allow(non_snake_case)]
+#[deprecated = "use UnicodeChar::is_XID_start"]
 pub fn is_XID_start(c: char) -> bool    { derived_property::XID_Start(c) }
 
 /// Returns whether the specified `char` satisfies the 'XID_Continue' Unicode property
@@ -42,6 +40,7 @@ pub fn is_XID_start(c: char) -> bool    { derived_property::XID_Start(c) }
 /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
 /// mostly similar to 'ID_Continue' but modified for closure under NFKx.
 #[allow(non_snake_case)]
+#[deprecated = "use UnicodeChar::is_XID_continue"]
 pub fn is_XID_continue(c: char) -> bool { derived_property::XID_Continue(c) }
 
 ///
@@ -50,12 +49,9 @@ pub fn is_XID_continue(c: char) -> bool { derived_property::XID_Continue(c) }
 /// This is defined according to the terms of the Unicode Derived Core Property 'Lowercase'.
 ///
 #[inline]
+#[deprecated = "use UnicodeChar::is_lowercase"]
 pub fn is_lowercase(c: char) -> bool {
-    match c {
-        'a' ... 'z' => true,
-        c if c > '\x7f' => derived_property::Lowercase(c),
-        _ => false
-    }
+    c.is_lowercase()
 }
 
 ///
@@ -64,12 +60,9 @@ pub fn is_lowercase(c: char) -> bool {
 /// This is defined according to the terms of the Unicode Derived Core Property 'Uppercase'.
 ///
 #[inline]
+#[deprecated = "use UnicodeChar::is_uppercase"]
 pub fn is_uppercase(c: char) -> bool {
-    match c {
-        'A' ... 'Z' => true,
-        c if c > '\x7f' => derived_property::Uppercase(c),
-        _ => false
-    }
+    c.is_uppercase()
 }
 
 ///
@@ -78,12 +71,9 @@ pub fn is_uppercase(c: char) -> bool {
 /// Whitespace is defined in terms of the Unicode Property 'White_Space'.
 ///
 #[inline]
+#[deprecated = "use UnicodeChar::is_whitespace"]
 pub fn is_whitespace(c: char) -> bool {
-    match c {
-        ' ' | '\x09' ... '\x0d' => true,
-        c if c > '\x7f' => property::White_Space(c),
-        _ => false
-    }
+    c.is_whitespace()
 }
 
 ///
@@ -93,9 +83,9 @@ pub fn is_whitespace(c: char) -> bool {
 /// 'Nd', 'Nl', 'No' and the Derived Core Property 'Alphabetic'.
 ///
 #[inline]
+#[deprecated = "use UnicodeChar::is_alphanumeric"]
 pub fn is_alphanumeric(c: char) -> bool {
-    is_alphabetic(c)
-        || is_digit(c)
+    c.is_alphanumeric()
 }
 
 ///
@@ -105,16 +95,14 @@ pub fn is_alphanumeric(c: char) -> bool {
 /// 'Cc'.
 ///
 #[inline]
+#[deprecated = "use UnicodeChar::is_control"]
 pub fn is_control(c: char) -> bool { general_category::Cc(c) }
 
 /// Indicates whether the `char` is numeric (Nd, Nl, or No)
 #[inline]
+#[deprecated = "use UnicodeChar::is_numeric"]
 pub fn is_digit(c: char) -> bool {
-    match c {
-        '0' ... '9' => true,
-        c if c > '\x7f' => general_category::N(c),
-        _ => false
-    }
+    c.is_numeric()
 }
 
 /// Convert a char to its uppercase equivalent
@@ -132,6 +120,7 @@ pub fn is_digit(c: char) -> bool {
 ///
 /// Returns the char itself if no conversion was made
 #[inline]
+#[deprecated = "use UnicodeChar::to_uppercase"]
 pub fn to_uppercase(c: char) -> char {
     conversions::to_upper(c)
 }
@@ -145,6 +134,7 @@ pub fn to_uppercase(c: char) -> char {
 ///
 /// Returns the char itself if no conversion if possible
 #[inline]
+#[deprecated = "use UnicodeChar::to_lowercase"]
 pub fn to_lowercase(c: char) -> char {
     conversions::to_lower(c)
 }
@@ -158,11 +148,13 @@ pub fn to_lowercase(c: char) -> char {
 /// [Unicode Standard Annex #11](http://www.unicode.org/reports/tr11/)
 /// recommends that these characters be treated as 1 column (i.e.,
 /// `is_cjk` = `false`) if the context cannot be reliably determined.
+#[deprecated = "use UnicodeChar::width"]
 pub fn width(c: char, is_cjk: bool) -> Option<uint> {
     charwidth::width(c, is_cjk)
 }
 
 /// Useful functions for Unicode characters.
+#[experimental = "pending prelude organization"]
 pub trait UnicodeChar {
     /// Returns whether the specified character is considered a Unicode
     /// alphabetic code point.
@@ -265,29 +257,62 @@ pub trait UnicodeChar {
     fn width(self, is_cjk: bool) -> Option<uint>;
 }
 
+#[experimental = "pending prelude organization"]
 impl UnicodeChar for char {
-    fn is_alphabetic(self) -> bool { is_alphabetic(self) }
+    fn is_alphabetic(self) -> bool {
+        match self {
+            'a' ... 'z' | 'A' ... 'Z' => true,
+            c if c > '\x7f' => derived_property::Alphabetic(c),
+            _ => false
+        }
+    }
 
-    fn is_XID_start(self) -> bool { is_XID_start(self) }
+    fn is_XID_start(self) -> bool { derived_property::XID_Start(self) }
 
-    fn is_XID_continue(self) -> bool { is_XID_continue(self) }
+    fn is_XID_continue(self) -> bool { derived_property::XID_Continue(self) }
 
-    fn is_lowercase(self) -> bool { is_lowercase(self) }
+    fn is_lowercase(self) -> bool {
+        match self {
+            'a' ... 'z' => true,
+            c if c > '\x7f' => derived_property::Lowercase(c),
+            _ => false
+        }
+    }
 
-    fn is_uppercase(self) -> bool { is_uppercase(self) }
+    fn is_uppercase(self) -> bool {
+        match self {
+            'A' ... 'Z' => true,
+            c if c > '\x7f' => derived_property::Uppercase(c),
+            _ => false
+        }
+    }
 
-    fn is_whitespace(self) -> bool { is_whitespace(self) }
+    fn is_whitespace(self) -> bool {
+        match self {
+            ' ' | '\x09' ... '\x0d' => true,
+            c if c > '\x7f' => property::White_Space(c),
+            _ => false
+        }
+    }
 
-    fn is_alphanumeric(self) -> bool { is_alphanumeric(self) }
+    fn is_alphanumeric(self) -> bool {
+        self.is_alphabetic() || self.is_numeric()
+    }
 
-    fn is_control(self) -> bool { is_control(self) }
+    fn is_control(self) -> bool { general_category::Cc(self) }
 
-    fn is_numeric(self) -> bool { is_digit(self) }
+    fn is_numeric(self) -> bool {
+        match self {
+            '0' ... '9' => true,
+            c if c > '\x7f' => general_category::N(c),
+            _ => false
+        }
+    }
 
-    fn to_lowercase(self) -> char { to_lowercase(self) }
+    fn to_lowercase(self) -> char { conversions::to_lower(self) }
 
-    fn to_uppercase(self) -> char { to_uppercase(self) }
+    fn to_uppercase(self) -> char { conversions::to_upper(self) }
 
     #[experimental = "needs expert opinion. is_cjk flag stands out as ugly"]
-    fn width(self, is_cjk: bool) -> Option<uint> { width(self, is_cjk) }
+    fn width(self, is_cjk: bool) -> Option<uint> { charwidth::width(self, is_cjk) }
 }

--- a/src/libunicode/u_str.rs
+++ b/src/libunicode/u_str.rs
@@ -24,13 +24,13 @@ use core::iter::{Filter, AdditiveIterator, Iterator, DoubleEndedIterator};
 use core::kinds::Sized;
 use core::option::{Option, None, Some};
 use core::str::{CharSplits, StrPrelude};
-use u_char;
 use u_char::UnicodeChar;
 use tables::grapheme::GraphemeCat;
 
 /// An iterator over the words of a string, separated by a sequence of whitespace
+/// FIXME: This should be opaque
 pub type Words<'a> =
-    Filter<'a, &'a str, CharSplits<'a, extern "Rust" fn(char) -> bool>>;
+    Filter<'a, &'a str, CharSplits<'a, |char|:'a -> bool>>;
 
 /// Methods for Unicode string slices
 pub trait UnicodeStrPrelude for Sized? {
@@ -143,14 +143,15 @@ impl UnicodeStrPrelude for str {
 
     #[inline]
     fn words(&self) -> Words {
-        self.split(u_char::is_whitespace).filter(|s| !s.is_empty())
+        let f = |c: char| c.is_whitespace();
+        self.split(f).filter(|s| !s.is_empty())
     }
 
     #[inline]
-    fn is_whitespace(&self) -> bool { self.chars().all(u_char::is_whitespace) }
+    fn is_whitespace(&self) -> bool { self.chars().all(|c| c.is_whitespace()) }
 
     #[inline]
-    fn is_alphanumeric(&self) -> bool { self.chars().all(u_char::is_alphanumeric) }
+    fn is_alphanumeric(&self) -> bool { self.chars().all(|c| c.is_alphanumeric()) }
 
     #[inline]
     fn width(&self, is_cjk: bool) -> uint {
@@ -164,12 +165,12 @@ impl UnicodeStrPrelude for str {
 
     #[inline]
     fn trim_left(&self) -> &str {
-        self.trim_left_chars(u_char::is_whitespace)
+        self.trim_left_chars(|c: char| c.is_whitespace())
     }
 
     #[inline]
     fn trim_right(&self) -> &str {
-        self.trim_right_chars(u_char::is_whitespace)
+        self.trim_right_chars(|c: char| c.is_whitespace())
     }
 }
 


### PR DESCRIPTION
- Deprecate the free functions in favor of methods, except the two ctors `from_u32` and `from_digit`, whose methods are deprecated.
- Mark the `Char` and `UnicodeChar` traits experimental until we decide for sure that we won't have some sort of inherent methods for primitives.
- The `UnicodeChar` methods related to numerics are now called e.g. `is_numeric` to match the 'numeric' unicode character class, and the `*_digit_radix` methods on `Char` now just called `*_digit`.
- `len_utf8_bytes` -> `len_utf8`
- Converted methods to take self by-value
- Converted `escape_default` and `escape_unicode` to iterators over chars.
- Renamed `is_XID_start`, `is_XID_continue` to `is_xid_start`, `is_xid_continue` to match conventions

This also converts `encode_utf8` and `encode_utf16` to return iterators. I suspect this is not the final form of these methods. Perf is worse (numbers in the commit). Many of the uses ended up being awkward, copying into a buffer then writing that buffer to a `Writer`. It might be more appropriate for these to return `Reader`s instead, but that type is defined in `std`.

Note: although I _did_ add the `from_u32` ctor to the `Char` trait, I deprecated it again later, preferring the free ctors.

I've been sitting on this for a while.

cc @aturon
