### PR TITLE
Implement low-hanging fruit of collection conventions

### DIFF
--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -162,6 +162,8 @@ use core::ptr;
 use slice;
 use vec::Vec;
 
+// FIXME(conventions): implement into_iter
+
 /// A priority queue implemented with a binary heap.
 ///
 /// This will be a max-heap.
@@ -184,6 +186,7 @@ impl<T: Ord> BinaryHeap<T> {
     /// use std::collections::BinaryHeap;
     /// let pq: BinaryHeap<uint> = BinaryHeap::new();
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn new() -> BinaryHeap<T> { BinaryHeap{data: vec!(),} }
 
     /// Creates an empty `BinaryHeap` with a specific capacity.
@@ -197,6 +200,7 @@ impl<T: Ord> BinaryHeap<T> {
     /// use std::collections::BinaryHeap;
     /// let pq: BinaryHeap<uint> = BinaryHeap::with_capacity(10u);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn with_capacity(capacity: uint) -> BinaryHeap<T> {
         BinaryHeap { data: Vec::with_capacity(capacity) }
     }
@@ -234,6 +238,7 @@ impl<T: Ord> BinaryHeap<T> {
     ///     println!("{}", x);
     /// }
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter<'a>(&'a self) -> Items<'a, T> {
         Items { iter: self.data.iter() }
     }
@@ -268,10 +273,19 @@ impl<T: Ord> BinaryHeap<T> {
     /// let pq: BinaryHeap<uint> = BinaryHeap::with_capacity(100u);
     /// assert!(pq.capacity() >= 100u);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn capacity(&self) -> uint { self.data.capacity() }
 
-    /// Reserves capacity for exactly `n` elements in the `BinaryHeap`.
-    /// Do nothing if the capacity is already sufficient.
+    /// Reserves the minimum capacity for exactly `additional` more elements to be inserted in the
+    /// given `BinaryHeap`. Does nothing if the capacity is already sufficient.
+    ///
+    /// Note that the allocator may give the collection more space than it requests. Therefore
+    /// capacity can not be relied upon to be precisely minimal. Prefer `reserve` if future
+    /// insertions are expected.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `uint`.
     ///
     /// # Example
     ///
@@ -280,12 +294,17 @@ impl<T: Ord> BinaryHeap<T> {
     ///
     /// let mut pq: BinaryHeap<uint> = BinaryHeap::new();
     /// pq.reserve_exact(100u);
-    /// assert!(pq.capacity() == 100u);
+    /// assert!(pq.capacity() >= 100u);
     /// ```
-    pub fn reserve_exact(&mut self, n: uint) { self.data.reserve_exact(n) }
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn reserve_exact(&mut self, additional: uint) { self.data.reserve_exact(additional) }
 
-    /// Reserves capacity for at least `n` elements in the `BinaryHeap`.
-    /// Do nothing if the capacity is already sufficient.
+    /// Reserves capacity for at least `additional` more elements to be inserted in the
+    /// `BinaryHeap`. The collection may reserve more space to avoid frequent reallocations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `uint`.
     ///
     /// # Example
     ///
@@ -296,8 +315,15 @@ impl<T: Ord> BinaryHeap<T> {
     /// pq.reserve(100u);
     /// assert!(pq.capacity() >= 100u);
     /// ```
-    pub fn reserve(&mut self, n: uint) {
-        self.data.reserve(n)
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn reserve(&mut self, additional: uint) {
+        self.data.reserve(additional)
+    }
+
+    /// Discards as much additional capacity as possible.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn shrink_to_fit(&mut self) {
+        self.data.shrink_to_fit()
     }
 
     /// Removes the greatest item from a queue and returns it, or `None` if it
@@ -314,6 +340,7 @@ impl<T: Ord> BinaryHeap<T> {
     /// assert_eq!(pq.pop(), Some(1i));
     /// assert_eq!(pq.pop(), None);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn pop(&mut self) -> Option<T> {
         match self.data.pop() {
             None           => { None }
@@ -342,6 +369,7 @@ impl<T: Ord> BinaryHeap<T> {
     /// assert_eq!(pq.len(), 3);
     /// assert_eq!(pq.top(), Some(&5i));
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn push(&mut self, item: T) {
         self.data.push(item);
         let new_len = self.len() - 1;
@@ -495,12 +523,15 @@ impl<T: Ord> BinaryHeap<T> {
     }
 
     /// Returns the length of the queue.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn len(&self) -> uint { self.data.len() }
 
     /// Returns true if the queue contains no elements
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_empty(&self) -> bool { self.len() == 0 }
 
     /// Drops all items from the queue.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn clear(&mut self) { self.data.truncate(0) }
 }
 
@@ -528,8 +559,7 @@ impl<T: Ord> Extendable<T> for BinaryHeap<T> {
     fn extend<Iter: Iterator<T>>(&mut self, mut iter: Iter) {
         let (lower, _) = iter.size_hint();
 
-        let len = self.capacity();
-        self.reserve(len + lower);
+        self.reserve(lower);
 
         for elem in iter {
             self.push(elem);

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -75,6 +75,8 @@ use std::hash;
 
 use vec::Vec;
 
+// FIXME(conventions): look, we just need to refactor this whole thing. Inside and out.
+
 type MatchWords<'a> = Chain<MaskWords<'a>, Skip<Take<Enumerate<Repeat<u32>>>>>;
 // Take two BitV's, and return iterators of their words, where the shorter one
 // has been padded with 0's
@@ -216,6 +218,7 @@ impl Bitv {
     /// use std::collections::Bitv;
     /// let mut bv = Bitv::new();
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn new() -> Bitv {
         Bitv { storage: Vec::new(), nbits: 0 }
     }
@@ -613,6 +616,7 @@ impl Bitv {
     /// bv.truncate(2);
     /// assert!(bv.eq_vec([false, true]));
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn truncate(&mut self, len: uint) {
         if len < self.len() {
             self.nbits = len;
@@ -760,14 +764,17 @@ impl Bitv {
 
     /// Return the total number of bits in this vector
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn len(&self) -> uint { self.nbits }
 
     /// Returns true if there are no bits in this vector
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_empty(&self) -> bool { self.len() == 0 }
 
     /// Clears all bits in this vector.
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn clear(&mut self) {
         for w in self.storage.iter_mut() { *w = 0u32; }
     }
@@ -849,8 +856,7 @@ impl Clone for Bitv {
     #[inline]
     fn clone_from(&mut self, source: &Bitv) {
         self.nbits = source.nbits;
-        self.storage.reserve(source.storage.len());
-        for (i, w) in self.storage.iter_mut().enumerate() { *w = source.storage[i]; }
+        self.storage.clone_from(&source.storage);
     }
 }
 
@@ -1052,6 +1058,7 @@ impl BitvSet {
     /// let mut s = BitvSet::new();
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn new() -> BitvSet {
         BitvSet(Bitv::new())
     }
@@ -1067,6 +1074,7 @@ impl BitvSet {
     /// assert!(s.capacity() >= 100);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn with_capacity(nbits: uint) -> BitvSet {
         let bitv = Bitv::with_capacity(nbits, false);
         BitvSet::from_bitv(bitv)
@@ -1106,6 +1114,7 @@ impl BitvSet {
     /// assert!(s.capacity() >= 100);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn capacity(&self) -> uint {
         let &BitvSet(ref bitv) = self;
         bitv.capacity()
@@ -1212,6 +1221,7 @@ impl BitvSet {
     /// println!("new capacity: {}", s.capacity());
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn shrink_to_fit(&mut self) {
         let &BitvSet(ref mut bitv) = self;
         // Obtain original length
@@ -1240,6 +1250,7 @@ impl BitvSet {
     /// }
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter<'a>(&'a self) -> BitPositions<'a> {
         BitPositions {set: self, next_idx: 0u}
     }
@@ -1262,6 +1273,7 @@ impl BitvSet {
     /// }
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn union<'a>(&'a self, other: &'a BitvSet) -> TwoBitPositions<'a> {
         TwoBitPositions {
             set: self,
@@ -1290,6 +1302,7 @@ impl BitvSet {
     /// }
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn intersection<'a>(&'a self, other: &'a BitvSet) -> Take<TwoBitPositions<'a>> {
         let min = cmp::min(self.capacity(), other.capacity());
         TwoBitPositions {
@@ -1326,6 +1339,7 @@ impl BitvSet {
     /// }
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn difference<'a>(&'a self, other: &'a BitvSet) -> TwoBitPositions<'a> {
         TwoBitPositions {
             set: self,
@@ -1355,6 +1369,7 @@ impl BitvSet {
     /// }
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn symmetric_difference<'a>(&'a self, other: &'a BitvSet) -> TwoBitPositions<'a> {
         TwoBitPositions {
             set: self,
@@ -1473,6 +1488,7 @@ impl BitvSet {
 
     /// Return the number of set bits in this set.
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn len(&self) -> uint  {
         let &BitvSet(ref bitv) = self;
         bitv.storage.iter().fold(0, |acc, &n| acc + n.count_ones())
@@ -1480,6 +1496,7 @@ impl BitvSet {
 
     /// Returns whether there are no bits set in this set
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_empty(&self) -> bool {
         let &BitvSet(ref bitv) = self;
         bitv.storage.iter().all(|&n| n == 0)
@@ -1487,6 +1504,7 @@ impl BitvSet {
 
     /// Clears all bits in this set
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn clear(&mut self) {
         let &BitvSet(ref mut bitv) = self;
         bitv.clear();
@@ -1494,6 +1512,7 @@ impl BitvSet {
 
     /// Returns `true` if this set contains the specified integer.
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn contains(&self, value: &uint) -> bool {
         let &BitvSet(ref bitv) = self;
         *value < bitv.nbits && bitv.get(*value)
@@ -1502,12 +1521,14 @@ impl BitvSet {
     /// Returns `true` if the set has no elements in common with `other`.
     /// This is equivalent to checking for an empty intersection.
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_disjoint(&self, other: &BitvSet) -> bool {
         self.intersection(other).next().is_none()
     }
 
     /// Returns `true` if the set is a subset of another.
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_subset(&self, other: &BitvSet) -> bool {
         let &BitvSet(ref self_bitv) = self;
         let &BitvSet(ref other_bitv) = other;
@@ -1521,12 +1542,14 @@ impl BitvSet {
 
     /// Returns `true` if the set is a superset of another.
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_superset(&self, other: &BitvSet) -> bool {
         other.is_subset(self)
     }
 
     /// Adds a value to the set. Returns `true` if the value was not already
     /// present in the set.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn insert(&mut self, value: uint) -> bool {
         if self.contains(&value) {
             return false;
@@ -1545,6 +1568,7 @@ impl BitvSet {
 
     /// Removes a value from the set. Returns `true` if the value was
     /// present in the set.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn remove(&mut self, value: &uint) -> bool {
         if !self.contains(value) {
             return false;

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -20,6 +20,9 @@ use core::{iter, fmt};
 use core::iter::Peekable;
 use core::fmt::Show;
 
+// FIXME(conventions): implement bounded iterators
+// FIXME(conventions): implement BitOr, BitAnd, BitXor, and Sub
+
 /// A set based on a B-Tree.
 ///
 /// See BTreeMap's documentation for a detailed discussion of this collection's performance
@@ -61,6 +64,7 @@ pub struct UnionItems<'a, T:'a> {
 
 impl<T: Ord> BTreeSet<T> {
     /// Makes a new BTreeSet with a reasonable choice of B.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn new() -> BTreeSet<T> {
         BTreeSet { map: BTreeMap::new() }
     }
@@ -75,11 +79,13 @@ impl<T: Ord> BTreeSet<T> {
 
 impl<T> BTreeSet<T> {
     /// Gets an iterator over the BTreeSet's contents.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter<'a>(&'a self) -> Items<'a, T> {
         self.map.keys()
     }
 
     /// Gets an iterator for moving out the BtreeSet's contents.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn into_iter(self) -> MoveItems<T> {
         self.map.into_iter().map(|(k, _)| k)
     }
@@ -87,23 +93,27 @@ impl<T> BTreeSet<T> {
 
 impl<T: Ord> BTreeSet<T> {
     /// Visits the values representing the difference, in ascending order.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn difference<'a>(&'a self, other: &'a BTreeSet<T>) -> DifferenceItems<'a, T> {
         DifferenceItems{a: self.iter().peekable(), b: other.iter().peekable()}
     }
 
     /// Visits the values representing the symmetric difference, in ascending order.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn symmetric_difference<'a>(&'a self, other: &'a BTreeSet<T>)
         -> SymDifferenceItems<'a, T> {
         SymDifferenceItems{a: self.iter().peekable(), b: other.iter().peekable()}
     }
 
     /// Visits the values representing the intersection, in ascending order.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn intersection<'a>(&'a self, other: &'a BTreeSet<T>)
         -> IntersectionItems<'a, T> {
         IntersectionItems{a: self.iter().peekable(), b: other.iter().peekable()}
     }
 
     /// Visits the values representing the union, in ascending order.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn union<'a>(&'a self, other: &'a BTreeSet<T>) -> UnionItems<'a, T> {
         UnionItems{a: self.iter().peekable(), b: other.iter().peekable()}
     }
@@ -120,6 +130,7 @@ impl<T: Ord> BTreeSet<T> {
     /// v.insert(1i);
     /// assert_eq!(v.len(), 1);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn len(&self) -> uint { self.map.len() }
 
     /// Returns true if the set contains no elements
@@ -134,6 +145,7 @@ impl<T: Ord> BTreeSet<T> {
     /// v.insert(1i);
     /// assert!(!v.is_empty());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_empty(&self) -> bool { self.len() == 0 }
 
     /// Clears the set, removing all values.
@@ -148,6 +160,7 @@ impl<T: Ord> BTreeSet<T> {
     /// v.clear();
     /// assert!(v.is_empty());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn clear(&mut self) {
         self.map.clear()
     }
@@ -163,8 +176,9 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(set.contains(&1), true);
     /// assert_eq!(set.contains(&4), false);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn contains(&self, value: &T) -> bool {
-        self.map.find(value).is_some()
+        self.map.contains_key(value)
     }
 
     /// Returns `true` if the set has no elements in common with `other`.
@@ -184,6 +198,7 @@ impl<T: Ord> BTreeSet<T> {
     /// b.insert(1);
     /// assert_eq!(a.is_disjoint(&b), false);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_disjoint(&self, other: &BTreeSet<T>) -> bool {
         self.intersection(other).next().is_none()
     }
@@ -204,6 +219,7 @@ impl<T: Ord> BTreeSet<T> {
     /// set.insert(4);
     /// assert_eq!(set.is_subset(&sup), false);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_subset(&self, other: &BTreeSet<T>) -> bool {
         // Stolen from TreeMap
         let mut x = self.iter();
@@ -248,6 +264,7 @@ impl<T: Ord> BTreeSet<T> {
     /// set.insert(2);
     /// assert_eq!(set.is_superset(&sub), true);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_superset(&self, other: &BTreeSet<T>) -> bool {
         other.is_subset(self)
     }
@@ -266,8 +283,9 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(set.insert(2i), false);
     /// assert_eq!(set.len(), 1);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn insert(&mut self, value: T) -> bool {
-        self.map.insert(value, ())
+        self.map.insert(value, ()).is_none()
     }
 
     /// Removes a value from the set. Returns `true` if the value was
@@ -284,8 +302,9 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(set.remove(&2), true);
     /// assert_eq!(set.remove(&2), false);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn remove(&mut self, value: &T) -> bool {
-        self.map.remove(value)
+        self.map.remove(value).is_some()
     }
 }
 

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -195,6 +195,7 @@ impl<T> Default for DList<T> {
 impl<T> DList<T> {
     /// Creates an empty `DList`.
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn new() -> DList<T> {
         DList{list_head: None, list_tail: Rawlink::none(), length: 0}
     }
@@ -209,9 +210,9 @@ impl<T> DList<T> {
     /// use std::collections::DList;
     ///
     /// let mut dl = DList::new();
-    /// dl.push(1i);
-    /// dl.push(2);
-    /// dl.push(3);
+    /// dl.push_back(1i);
+    /// dl.push_back(2);
+    /// dl.push_back(3);
     ///
     /// dl.rotate_forward();
     ///
@@ -236,9 +237,9 @@ impl<T> DList<T> {
     /// use std::collections::DList;
     ///
     /// let mut dl = DList::new();
-    /// dl.push(1i);
-    /// dl.push(2);
-    /// dl.push(3);
+    /// dl.push_back(1i);
+    /// dl.push_back(2);
+    /// dl.push_back(3);
     ///
     /// dl.rotate_backward();
     ///
@@ -264,10 +265,10 @@ impl<T> DList<T> {
     ///
     /// let mut a = DList::new();
     /// let mut b = DList::new();
-    /// a.push(1i);
-    /// a.push(2);
-    /// b.push(3i);
-    /// b.push(4);
+    /// a.push_back(1i);
+    /// a.push_back(2);
+    /// b.push_back(3i);
+    /// b.push_back(4);
     ///
     /// a.append(b);
     ///
@@ -305,10 +306,10 @@ impl<T> DList<T> {
     ///
     /// let mut a = DList::new();
     /// let mut b = DList::new();
-    /// a.push(1i);
-    /// a.push(2);
-    /// b.push(3i);
-    /// b.push(4);
+    /// a.push_back(1i);
+    /// a.push_back(2);
+    /// b.push_back(3i);
+    /// b.push_back(4);
     ///
     /// a.prepend(b);
     ///
@@ -333,10 +334,10 @@ impl<T> DList<T> {
     /// use std::collections::DList;
     ///
     /// let mut a: DList<int> = DList::new();
-    /// a.push(2i);
-    /// a.push(4);
-    /// a.push(7);
-    /// a.push(8);
+    /// a.push_back(2i);
+    /// a.push_back(4);
+    /// a.push_back(7);
+    /// a.push_back(8);
     ///
     /// // insert 11 before the first odd number in the list
     /// a.insert_when(11, |&e, _| e % 2 == 1);
@@ -387,12 +388,14 @@ impl<T> DList<T> {
 
     /// Provides a forward iterator.
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter<'a>(&'a self) -> Items<'a, T> {
         Items{nelem: self.len(), head: &self.list_head, tail: self.list_tail}
     }
 
     /// Provides a forward iterator with mutable references.
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter_mut<'a>(&'a mut self) -> MutItems<'a, T> {
         let head_raw = match self.list_head {
             Some(ref mut h) => Rawlink::some(&mut **h),
@@ -408,6 +411,7 @@ impl<T> DList<T> {
 
     /// Consumes the list into an iterator yielding elements by value.
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn into_iter(self) -> MoveItems<T> {
         MoveItems{list: self}
     }
@@ -416,6 +420,7 @@ impl<T> DList<T> {
     ///
     /// This operation should compute in O(1) time.
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_empty(&self) -> bool {
         self.list_head.is_none()
     }
@@ -424,6 +429,7 @@ impl<T> DList<T> {
     ///
     /// This operation should compute in O(1) time.
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn len(&self) -> uint {
         self.length
     }
@@ -432,6 +438,7 @@ impl<T> DList<T> {
     ///
     /// This operation should compute in O(n) time.
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn clear(&mut self) {
         *self = DList::new()
     }
@@ -439,34 +446,39 @@ impl<T> DList<T> {
     /// Provides a reference to the front element, or `None` if the list is
     /// empty.
     #[inline]
-    pub fn front<'a>(&'a self) -> Option<&'a T> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn front(&self) -> Option<&T> {
         self.list_head.as_ref().map(|head| &head.value)
     }
 
     /// Provides a mutable reference to the front element, or `None` if the list
     /// is empty.
     #[inline]
-    pub fn front_mut<'a>(&'a mut self) -> Option<&'a mut T> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn front_mut(&mut self) -> Option<&mut T> {
         self.list_head.as_mut().map(|head| &mut head.value)
     }
 
     /// Provides a reference to the back element, or `None` if the list is
     /// empty.
     #[inline]
-    pub fn back<'a>(&'a self) -> Option<&'a T> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn back(&self) -> Option<&T> {
         self.list_tail.resolve_immut().as_ref().map(|tail| &tail.value)
     }
 
     /// Provides a mutable reference to the back element, or `None` if the list
     /// is empty.
     #[inline]
-    pub fn back_mut<'a>(&'a mut self) -> Option<&'a mut T> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn back_mut(&mut self) -> Option<&mut T> {
         self.list_tail.resolve().map(|tail| &mut tail.value)
     }
 
     /// Adds an element first in the list.
     ///
     /// This operation should compute in O(1) time.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn push_front(&mut self, elt: T) {
         self.push_front_node(box Node::new(elt))
     }
@@ -475,8 +487,15 @@ impl<T> DList<T> {
     /// empty.
     ///
     /// This operation should compute in O(1) time.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn pop_front(&mut self) -> Option<T> {
         self.pop_front_node().map(|box Node{value, ..}| value)
+    }
+
+    /// Deprecated: Renamed to `push_back`.
+    #[deprecated = "Renamed to `push_back`"]
+    pub fn push(&mut self, elt: T) {
+        self.push_back(elt)
     }
 
     /// Appends an element to the back of a list
@@ -487,12 +506,19 @@ impl<T> DList<T> {
     /// use std::collections::DList;
     ///
     /// let mut d = DList::new();
-    /// d.push(1i);
-    /// d.push(3);
+    /// d.push_back(1i);
+    /// d.push_back(3);
     /// assert_eq!(3, *d.back().unwrap());
     /// ```
-    pub fn push(&mut self, elt: T) {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn push_back(&mut self, elt: T) {
         self.push_back_node(box Node::new(elt))
+    }
+
+    /// Deprecated: Renamed to `pop_back`.
+    #[deprecated = "Renamed to `pop_back`"]
+    pub fn pop(&mut self) -> Option<T> {
+        self.pop_back()
     }
 
     /// Removes the last element from a list and returns it, or `None` if
@@ -504,12 +530,13 @@ impl<T> DList<T> {
     /// use std::collections::DList;
     ///
     /// let mut d = DList::new();
-    /// assert_eq!(d.pop(), None);
-    /// d.push(1i);
-    /// d.push(3);
-    /// assert_eq!(d.pop(), Some(3));
+    /// assert_eq!(d.pop_back(), None);
+    /// d.push_back(1i);
+    /// d.push_back(3);
+    /// assert_eq!(d.pop_back(), Some(3));
     /// ```
-    pub fn pop(&mut self) -> Option<T> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn pop_back(&mut self) -> Option<T> {
         self.pop_back_node().map(|box Node{value, ..}| value)
     }
 }
@@ -682,7 +709,7 @@ impl<A> Iterator<A> for MoveItems<A> {
 
 impl<A> DoubleEndedIterator<A> for MoveItems<A> {
     #[inline]
-    fn next_back(&mut self) -> Option<A> { self.list.pop() }
+    fn next_back(&mut self) -> Option<A> { self.list.pop_back() }
 }
 
 impl<A> FromIterator<A> for DList<A> {
@@ -695,7 +722,7 @@ impl<A> FromIterator<A> for DList<A> {
 
 impl<A> Extendable<A> for DList<A> {
     fn extend<T: Iterator<A>>(&mut self, mut iterator: T) {
-        for elt in iterator { self.push(elt); }
+        for elt in iterator { self.push_back(elt); }
     }
 }
 
@@ -801,21 +828,21 @@ mod tests {
     fn test_basic() {
         let mut m: DList<Box<int>> = DList::new();
         assert_eq!(m.pop_front(), None);
-        assert_eq!(m.pop(), None);
+        assert_eq!(m.pop_back(), None);
         assert_eq!(m.pop_front(), None);
         m.push_front(box 1);
         assert_eq!(m.pop_front(), Some(box 1));
-        m.push(box 2);
-        m.push(box 3);
+        m.push_back(box 2);
+        m.push_back(box 3);
         assert_eq!(m.len(), 2);
         assert_eq!(m.pop_front(), Some(box 2));
         assert_eq!(m.pop_front(), Some(box 3));
         assert_eq!(m.len(), 0);
         assert_eq!(m.pop_front(), None);
-        m.push(box 1);
-        m.push(box 3);
-        m.push(box 5);
-        m.push(box 7);
+        m.push_back(box 1);
+        m.push_back(box 3);
+        m.push_back(box 5);
+        m.push_back(box 7);
         assert_eq!(m.pop_front(), Some(box 1));
 
         let mut n = DList::new();
@@ -853,19 +880,19 @@ mod tests {
         {
             let mut m = DList::new();
             let mut n = DList::new();
-            n.push(2i);
+            n.push_back(2i);
             m.append(n);
             assert_eq!(m.len(), 1);
-            assert_eq!(m.pop(), Some(2));
+            assert_eq!(m.pop_back(), Some(2));
             check_links(&m);
         }
         {
             let mut m = DList::new();
             let n = DList::new();
-            m.push(2i);
+            m.push_back(2i);
             m.append(n);
             assert_eq!(m.len(), 1);
-            assert_eq!(m.pop(), Some(2));
+            assert_eq!(m.pop_back(), Some(2));
             check_links(&m);
         }
 
@@ -887,10 +914,10 @@ mod tests {
         {
             let mut m = DList::new();
             let mut n = DList::new();
-            n.push(2i);
+            n.push_back(2i);
             m.prepend(n);
             assert_eq!(m.len(), 1);
-            assert_eq!(m.pop(), Some(2));
+            assert_eq!(m.pop_back(), Some(2));
             check_links(&m);
         }
 
@@ -948,9 +975,9 @@ mod tests {
     #[test]
     fn test_iterator_clone() {
         let mut n = DList::new();
-        n.push(2i);
-        n.push(3);
-        n.push(4);
+        n.push_back(2i);
+        n.push_back(3);
+        n.push_back(4);
         let mut it = n.iter();
         it.next();
         let mut jt = it.clone();
@@ -1005,7 +1032,7 @@ mod tests {
         let mut n = DList::new();
         assert!(n.iter_mut().next().is_none());
         n.push_front(4i);
-        n.push(5);
+        n.push_back(5);
         let mut it = n.iter_mut();
         assert_eq!(it.size_hint(), (2, Some(2)));
         assert!(it.next().is_some());
@@ -1079,8 +1106,8 @@ mod tests {
         assert_eq!(n.pop_front(), Some(1));
 
         let mut m = DList::new();
-        m.push(2i);
-        m.push(4);
+        m.push_back(2i);
+        m.push_back(4);
         m.insert_ordered(3);
         check_links(&m);
         assert_eq!(vec![2,3,4], m.into_iter().collect::<Vec<int>>());
@@ -1117,7 +1144,7 @@ mod tests {
         assert!(n == m);
         n.push_front(1);
         assert!(n != m);
-        m.push(1);
+        m.push_back(1);
         assert!(n == m);
 
         let n = list_from([2i,3,4]);
@@ -1132,9 +1159,9 @@ mod tests {
 
       assert!(hash::hash(&x) == hash::hash(&y));
 
-      x.push(1i);
-      x.push(2);
-      x.push(3);
+      x.push_back(1i);
+      x.push_back(2);
+      x.push_back(3);
 
       y.push_front(3i);
       y.push_front(2);
@@ -1214,7 +1241,7 @@ mod tests {
             let r: u8 = rand::random();
             match r % 6 {
                 0 => {
-                    m.pop();
+                    m.pop_back();
                     v.pop();
                 }
                 1 => {
@@ -1226,7 +1253,7 @@ mod tests {
                     v.insert(0, -i);
                 }
                 3 | 5 | _ => {
-                    m.push(i);
+                    m.push_back(i);
                     v.push(i);
                 }
             }
@@ -1262,7 +1289,7 @@ mod tests {
     fn bench_push_back(b: &mut test::Bencher) {
         let mut m: DList<int> = DList::new();
         b.iter(|| {
-            m.push(0);
+            m.push_back(0);
         })
     }
 
@@ -1270,8 +1297,8 @@ mod tests {
     fn bench_push_back_pop_back(b: &mut test::Bencher) {
         let mut m: DList<int> = DList::new();
         b.iter(|| {
-            m.push(0);
-            m.pop();
+            m.push_back(0);
+            m.pop_back();
         })
     }
 

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -16,6 +16,10 @@
 use core::prelude::*;
 use core::fmt;
 
+// FIXME(conventions): implement BitXor
+// FIXME(contentions): implement union family of methods? (general design may be wrong here)
+// FIXME(conventions): implement len
+
 #[deriving(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// A specialized `Set` implementation to use enum types.
 pub struct EnumSet<E> {
@@ -47,34 +51,56 @@ pub trait CLike {
     fn from_uint(uint) -> Self;
 }
 
-fn bit<E:CLike>(e: E) -> uint {
+fn bit<E:CLike>(e: &E) -> uint {
     1 << e.to_uint()
 }
 
 impl<E:CLike> EnumSet<E> {
-    /// Returns an empty `EnumSet`.
+    /// Deprecated: Renamed to `new`.
+    #[deprecated = "Renamed to `new`"]
     pub fn empty() -> EnumSet<E> {
+        EnumSet::new()
+    }
+
+    /// Returns an empty `EnumSet`.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn new() -> EnumSet<E> {
         EnumSet {bits: 0}
     }
 
     /// Returns true if the `EnumSet` is empty.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_empty(&self) -> bool {
         self.bits == 0
     }
 
+    pub fn clear(&mut self) {
+        self.bits = 0;
+    }
+
     /// Returns `true` if the `EnumSet` contains any enum of the given `EnumSet`.
+    /// Deprecated: Use `is_disjoint`.
+    #[deprecated = "Use `is_disjoint`"]
     pub fn intersects(&self, e: EnumSet<E>) -> bool {
-        (self.bits & e.bits) != 0
+        !self.is_disjoint(&e)
     }
 
-    /// Returns the intersection of both `EnumSets`.
-    pub fn intersection(&self, e: EnumSet<E>) -> EnumSet<E> {
-        EnumSet {bits: self.bits & e.bits}
+    /// Returns `false` if the `EnumSet` contains any enum of the given `EnumSet`.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn is_disjoint(&self, other: &EnumSet<E>) -> bool {
+        (self.bits & other.bits) == 0
     }
 
-    /// Returns `true` if a given `EnumSet` is included in an `EnumSet`.
-    pub fn contains(&self, e: EnumSet<E>) -> bool {
-        (self.bits & e.bits) == e.bits
+    /// Returns `true` if a given `EnumSet` is included in this `EnumSet`.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn is_superset(&self, other: &EnumSet<E>) -> bool {
+        (self.bits & other.bits) == other.bits
+    }
+
+    /// Returns `true` if this `EnumSet` is included in the given `EnumSet`.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn is_subset(&self, other: &EnumSet<E>) -> bool {
+        other.is_subset(self)
     }
 
     /// Returns the union of both `EnumSets`.
@@ -82,17 +108,47 @@ impl<E:CLike> EnumSet<E> {
         EnumSet {bits: self.bits | e.bits}
     }
 
-    /// Adds an enum to an `EnumSet`.
+    /// Returns the intersection of both `EnumSets`.
+    pub fn intersection(&self, e: EnumSet<E>) -> EnumSet<E> {
+        EnumSet {bits: self.bits & e.bits}
+    }
+
+    /// Deprecated: Use `insert`.
+    #[deprecated = "Use `insert`"]
     pub fn add(&mut self, e: E) {
-        self.bits |= bit(e);
+        self.insert(e);
+    }
+
+    /// Adds an enum to the `EnumSet`, and returns `true` if it wasn't there before
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn insert(&mut self, e: E) -> bool {
+        let result = !self.contains(&e);
+        self.bits |= bit(&e);
+        result
+    }
+
+    /// Removes an enum from the EnumSet
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn remove(&mut self, e: &E) -> bool {
+        let result = self.contains(e);
+        self.bits &= !bit(e);
+        result
+    }
+
+    /// Deprecated: use `contains`.
+    #[deprecated = "use `contains"]
+    pub fn contains_elem(&self, e: E) -> bool {
+        self.contains(&e)
     }
 
     /// Returns `true` if an `EnumSet` contains a given enum.
-    pub fn contains_elem(&self, e: E) -> bool {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn contains(&self, e: &E) -> bool {
         (self.bits & bit(e)) != 0
     }
 
     /// Returns an iterator over an `EnumSet`.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter(&self) -> Items<E> {
         Items::new(self.bits)
     }
@@ -174,18 +230,18 @@ mod test {
     }
 
     #[test]
-    fn test_empty() {
-        let e: EnumSet<Foo> = EnumSet::empty();
+    fn test_new() {
+        let e: EnumSet<Foo> = EnumSet::new();
         assert!(e.is_empty());
     }
 
     #[test]
     fn test_show() {
-        let mut e = EnumSet::empty();
+        let mut e = EnumSet::new();
         assert_eq!("{}", e.to_string().as_slice());
-        e.add(A);
+        e.insert(A);
         assert_eq!("{A}", e.to_string().as_slice());
-        e.add(C);
+        e.insert(C);
         assert_eq!("{A, C}", e.to_string().as_slice());
     }
 
@@ -194,75 +250,75 @@ mod test {
 
     #[test]
     fn test_two_empties_do_not_intersect() {
-        let e1: EnumSet<Foo> = EnumSet::empty();
-        let e2: EnumSet<Foo> = EnumSet::empty();
-        assert!(!e1.intersects(e2));
+        let e1: EnumSet<Foo> = EnumSet::new();
+        let e2: EnumSet<Foo> = EnumSet::new();
+        assert!(e1.is_disjoint(&e2));
     }
 
     #[test]
     fn test_empty_does_not_intersect_with_full() {
-        let e1: EnumSet<Foo> = EnumSet::empty();
+        let e1: EnumSet<Foo> = EnumSet::new();
 
-        let mut e2: EnumSet<Foo> = EnumSet::empty();
-        e2.add(A);
-        e2.add(B);
-        e2.add(C);
+        let mut e2: EnumSet<Foo> = EnumSet::new();
+        e2.insert(A);
+        e2.insert(B);
+        e2.insert(C);
 
-        assert!(!e1.intersects(e2));
+        assert!(e1.is_disjoint(&e2));
     }
 
     #[test]
     fn test_disjoint_intersects() {
-        let mut e1: EnumSet<Foo> = EnumSet::empty();
-        e1.add(A);
+        let mut e1: EnumSet<Foo> = EnumSet::new();
+        e1.insert(A);
 
-        let mut e2: EnumSet<Foo> = EnumSet::empty();
-        e2.add(B);
+        let mut e2: EnumSet<Foo> = EnumSet::new();
+        e2.insert(B);
 
-        assert!(!e1.intersects(e2));
+        assert!(e1.is_disjoint(&e2));
     }
 
     #[test]
     fn test_overlapping_intersects() {
-        let mut e1: EnumSet<Foo> = EnumSet::empty();
-        e1.add(A);
+        let mut e1: EnumSet<Foo> = EnumSet::new();
+        e1.insert(A);
 
-        let mut e2: EnumSet<Foo> = EnumSet::empty();
-        e2.add(A);
-        e2.add(B);
+        let mut e2: EnumSet<Foo> = EnumSet::new();
+        e2.insert(A);
+        e2.insert(B);
 
-        assert!(e1.intersects(e2));
+        assert!(!e1.is_disjoint(&e2));
     }
 
     ///////////////////////////////////////////////////////////////////////////
     // contains and contains_elem
 
     #[test]
-    fn test_contains() {
-        let mut e1: EnumSet<Foo> = EnumSet::empty();
-        e1.add(A);
+    fn test_superset() {
+        let mut e1: EnumSet<Foo> = EnumSet::new();
+        e1.insert(A);
 
-        let mut e2: EnumSet<Foo> = EnumSet::empty();
-        e2.add(A);
-        e2.add(B);
+        let mut e2: EnumSet<Foo> = EnumSet::new();
+        e2.insert(A);
+        e2.insert(B);
 
-        assert!(!e1.contains(e2));
-        assert!(e2.contains(e1));
+        assert!(!e1.is_superset(&e2));
+        assert!(e2.is_superset(&e1));
     }
 
     #[test]
-    fn test_contains_elem() {
-        let mut e1: EnumSet<Foo> = EnumSet::empty();
-        e1.add(A);
-        assert!(e1.contains_elem(A));
-        assert!(!e1.contains_elem(B));
-        assert!(!e1.contains_elem(C));
+    fn test_contains() {
+        let mut e1: EnumSet<Foo> = EnumSet::new();
+        e1.insert(A);
+        assert!(e1.contains(&A));
+        assert!(!e1.contains(&B));
+        assert!(!e1.contains(&C));
 
-        e1.add(A);
-        e1.add(B);
-        assert!(e1.contains_elem(A));
-        assert!(e1.contains_elem(B));
-        assert!(!e1.contains_elem(C));
+        e1.insert(A);
+        e1.insert(B);
+        assert!(e1.contains(&A));
+        assert!(e1.contains(&B));
+        assert!(!e1.contains(&C));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -270,24 +326,24 @@ mod test {
 
     #[test]
     fn test_iterator() {
-        let mut e1: EnumSet<Foo> = EnumSet::empty();
+        let mut e1: EnumSet<Foo> = EnumSet::new();
 
         let elems: Vec<Foo> = e1.iter().collect();
         assert!(elems.is_empty())
 
-        e1.add(A);
+        e1.insert(A);
         let elems = e1.iter().collect();
         assert_eq!(vec![A], elems)
 
-        e1.add(C);
+        e1.insert(C);
         let elems = e1.iter().collect();
         assert_eq!(vec![A,C], elems)
 
-        e1.add(C);
+        e1.insert(C);
         let elems = e1.iter().collect();
         assert_eq!(vec![A,C], elems)
 
-        e1.add(B);
+        e1.insert(B);
         let elems = e1.iter().collect();
         assert_eq!(vec![A,B,C], elems)
     }
@@ -297,13 +353,13 @@ mod test {
 
     #[test]
     fn test_operators() {
-        let mut e1: EnumSet<Foo> = EnumSet::empty();
-        e1.add(A);
-        e1.add(C);
+        let mut e1: EnumSet<Foo> = EnumSet::new();
+        e1.insert(A);
+        e1.insert(C);
 
-        let mut e2: EnumSet<Foo> = EnumSet::empty();
-        e2.add(B);
-        e2.add(C);
+        let mut e2: EnumSet<Foo> = EnumSet::new();
+        e2.insert(B);
+        e2.insert(C);
 
         let e_union = e1 | e2;
         let elems = e_union.iter().collect();

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1523,10 +1523,10 @@ mod tests {
     fn test_capacity() {
         let mut v = vec![0u64];
         v.reserve_exact(10u);
-        assert_eq!(v.capacity(), 10u);
+        assert!(v.capacity() >= 11u);
         let mut v = vec![0u32];
         v.reserve_exact(10u);
-        assert_eq!(v.capacity(), 10u);
+        assert!(v.capacity() >= 11u);
     }
 
     #[test]
@@ -2318,7 +2318,7 @@ mod bench {
                 v.set_len(1024);
             }
             for i in range(0u, 1024) {
-                *v.get_mut(i) = 0;
+                v[i] = 0;
             }
         });
     }

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -76,6 +76,8 @@ pub use core::str::{truncate_utf16_at_nul, utf8_char_width, CharRange};
 pub use core::str::{Str, StrSlice};
 pub use unicode::str::{UnicodeStrSlice, Words, Graphemes, GraphemeIndices};
 
+// FIXME(conventions): ensure bit/char conventions are followed by str's API
+
 /*
 Section: Creating a string
 */
@@ -308,7 +310,7 @@ impl<'a> Iterator<char> for Recompositions<'a> {
                                             self.composee = Some(ch);
                                             return Some(k);
                                         }
-                                        self.buffer.push(ch);
+                                        self.buffer.push_back(ch);
                                         self.last_ccc = Some(ch_class);
                                     }
                                 }
@@ -322,7 +324,7 @@ impl<'a> Iterator<char> for Recompositions<'a> {
                                         self.state = Purging;
                                         return Some(k);
                                     }
-                                    self.buffer.push(ch);
+                                    self.buffer.push_back(ch);
                                     self.last_ccc = Some(ch_class);
                                     continue;
                                 }
@@ -332,7 +334,7 @@ impl<'a> Iterator<char> for Recompositions<'a> {
                                         continue;
                                     }
                                     None => {
-                                        self.buffer.push(ch);
+                                        self.buffer.push_back(ch);
                                         self.last_ccc = Some(ch_class);
                                     }
                                 }

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -330,8 +330,8 @@ impl String {
 
         let mut buf = String::new();
         buf.push(ch);
-        let size = buf.len() * length;
-        buf.reserve(size);
+        let size = buf.len() * (length - 1);
+        buf.reserve_exact(size);
         for _ in range(1, length) {
             buf.push(ch)
         }
@@ -379,27 +379,23 @@ impl String {
     /// assert!(s.capacity() >= 10);
     /// ```
     #[inline]
-    #[unstable = "just implemented, needs to prove itself"]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn capacity(&self) -> uint {
         self.vec.capacity()
     }
 
-    /// Reserves capacity for at least `extra` additional bytes in this string buffer.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// let mut s = String::with_capacity(10);
-    /// let before = s.capacity();
-    /// s.reserve_additional(100);
-    /// assert!(s.capacity() - before >= 100);
-    /// ```
-    #[inline]
+    /// Deprecated: Renamed to `reserve`.
+    #[deprecated = "Renamed to `reserve`"]
     pub fn reserve_additional(&mut self, extra: uint) {
-        self.vec.reserve_additional(extra)
+        self.vec.reserve(extra)
     }
 
-    /// Reserves capacity for at least `capacity` bytes in this string buffer.
+    /// Reserves capacity for at least `additional` more bytes to be inserted in the given
+    /// `String`. The collection may reserve more space to avoid frequent reallocations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `uint`.
     ///
     /// # Example
     ///
@@ -409,22 +405,33 @@ impl String {
     /// assert!(s.capacity() >= 10);
     /// ```
     #[inline]
-    pub fn reserve(&mut self, capacity: uint) {
-        self.vec.reserve(capacity)
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn reserve(&mut self, additional: uint) {
+        self.vec.reserve(additional)
     }
 
-    /// Reserves capacity for exactly `capacity` bytes in this string buffer.
+    /// Reserves the minimum capacity for exactly `additional` more bytes to be inserted in the
+    /// given `String`. Does nothing if the capacity is already sufficient.
+    ///
+    /// Note that the allocator may give the collection more space than it requests. Therefore
+    /// capacity can not be relied upon to be precisely minimal. Prefer `reserve` if future
+    /// insertions are expected.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `uint`.
     ///
     /// # Example
     ///
     /// ```
     /// let mut s = String::new();
-    /// s.reserve_exact(10);
-    /// assert_eq!(s.capacity(), 10);
+    /// s.reserve(10);
+    /// assert!(s.capacity() >= 10);
     /// ```
     #[inline]
-    pub fn reserve_exact(&mut self, capacity: uint) {
-        self.vec.reserve_exact(capacity)
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn reserve_exact(&mut self, additional: uint) {
+        self.vec.reserve_exact(additional)
     }
 
     /// Shrinks the capacity of this string buffer to match its length.
@@ -439,6 +446,7 @@ impl String {
     /// assert_eq!(s.capacity(), 3);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn shrink_to_fit(&mut self) {
         self.vec.shrink_to_fit()
     }
@@ -459,7 +467,7 @@ impl String {
     pub fn push(&mut self, ch: char) {
         let cur_len = self.len();
         // This may use up to 4 bytes.
-        self.vec.reserve_additional(4);
+        self.vec.reserve(4);
 
         unsafe {
             // Attempt to not use an intermediate buffer by just pushing bytes
@@ -590,7 +598,7 @@ impl String {
         let len = self.len();
         assert!(idx <= len);
         assert!(self.as_slice().is_char_boundary(idx));
-        self.vec.reserve_additional(4);
+        self.vec.reserve(4);
         let mut bits = [0, ..4];
         let amt = ch.encode_utf8(bits).unwrap();
 

--- a/src/libcollections/tree/map.rs
+++ b/src/libcollections/tree/map.rs
@@ -21,6 +21,9 @@ use std::hash::{Writer, Hash};
 
 use vec::Vec;
 
+// FIXME(conventions): implement bounded iterators
+// FIXME(conventions): replace rev_iter(_mut) by making iter(_mut) DoubleEnded
+
 /// This is implemented as an AA tree, which is a simplified variation of
 /// a red-black tree where red (horizontal) nodes can only be added
 /// as a right child. The time complexity is the same, and re-balancing
@@ -60,7 +63,7 @@ use vec::Vec;
 /// }
 ///
 /// for key in range(0, 4) {
-///     match map.find(&key) {
+///     match map.get(&key) {
 ///         Some(val) => println!("{} has a value: {}", key, val),
 ///         None => println!("{} not in map", key),
 ///     }
@@ -188,14 +191,14 @@ impl<K: Ord, V> Default for TreeMap<K,V> {
 impl<K: Ord, V> Index<K, V> for TreeMap<K, V> {
     #[inline]
     fn index<'a>(&'a self, i: &K) -> &'a V {
-        self.find(i).expect("no entry found for key")
+        self.get(i).expect("no entry found for key")
     }
 }
 
 impl<K: Ord, V> IndexMut<K, V> for TreeMap<K, V> {
     #[inline]
     fn index_mut<'a>(&'a mut self, i: &K) -> &'a mut V {
-        self.find_mut(i).expect("no entry found for key")
+        self.get_mut(i).expect("no entry found for key")
     }
 }
 
@@ -208,6 +211,7 @@ impl<K: Ord, V> TreeMap<K, V> {
     /// use std::collections::TreeMap;
     /// let mut map: TreeMap<&str, int> = TreeMap::new();
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn new() -> TreeMap<K, V> { TreeMap{root: None, length: 0} }
 
     /// Gets a lazy iterator over the keys in the map, in ascending order.
@@ -226,6 +230,7 @@ impl<K: Ord, V> TreeMap<K, V> {
     ///     println!("{}", x);
     /// }
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn keys<'a>(&'a self) -> Keys<'a, K, V> {
         self.iter().map(|(k, _v)| k)
     }
@@ -247,6 +252,7 @@ impl<K: Ord, V> TreeMap<K, V> {
     ///     println!("{}", x);
     /// }
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn values<'a>(&'a self) -> Values<'a, K, V> {
         self.iter().map(|(_k, v)| v)
     }
@@ -267,6 +273,7 @@ impl<K: Ord, V> TreeMap<K, V> {
     ///     println!("{}: {}", key, value);
     /// }
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter<'a>(&'a self) -> Entries<'a, K, V> {
         Entries {
             stack: vec!(),
@@ -314,10 +321,11 @@ impl<K: Ord, V> TreeMap<K, V> {
     ///     if key == &"b" { break }
     /// }
     ///
-    /// assert_eq!(map.find(&"a"), Some(&11));
-    /// assert_eq!(map.find(&"b"), Some(&12));
-    /// assert_eq!(map.find(&"c"), Some(&3));
+    /// assert_eq!(map.get(&"a"), Some(&11));
+    /// assert_eq!(map.get(&"b"), Some(&12));
+    /// assert_eq!(map.get(&"c"), Some(&3));
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter_mut<'a>(&'a mut self) -> MutEntries<'a, K, V> {
         MutEntries {
             stack: vec!(),
@@ -345,15 +353,15 @@ impl<K: Ord, V> TreeMap<K, V> {
     ///     if key == &"b" { break }
     /// }
     ///
-    /// assert_eq!(map.find(&"a"), Some(&1));
-    /// assert_eq!(map.find(&"b"), Some(&12));
-    /// assert_eq!(map.find(&"c"), Some(&13));
+    /// assert_eq!(map.get(&"a"), Some(&1));
+    /// assert_eq!(map.get(&"b"), Some(&12));
+    /// assert_eq!(map.get(&"c"), Some(&13));
     /// ```
     pub fn rev_iter_mut<'a>(&'a mut self) -> RevMutEntries<'a, K, V> {
         RevMutEntries{iter: self.iter_mut()}
     }
 
-    /// Gets a lazy iterator that consumes the TreeMap.
+    /// Gets a lazy iterator that consumes the treemap.
     ///
     /// # Example
     ///
@@ -368,6 +376,7 @@ impl<K: Ord, V> TreeMap<K, V> {
     /// let vec: Vec<(&str, int)> = map.into_iter().collect();
     /// assert_eq!(vec, vec![("a", 1), ("b", 2), ("c", 3)]);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn into_iter(self) -> MoveEntries<K, V> {
         let TreeMap { root, length } = self;
         let stk = match root {
@@ -392,6 +401,7 @@ impl<K: Ord, V> TreeMap<K, V> {
     /// a.insert(1u, "a");
     /// assert_eq!(a.len(), 1);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn len(&self) -> uint { self.length }
 
     /// Return true if the map contains no elements.
@@ -406,6 +416,7 @@ impl<K: Ord, V> TreeMap<K, V> {
     /// a.insert(1u, "a");
     /// assert!(!a.is_empty());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     #[inline]
     pub fn is_empty(&self) -> bool { self.len() == 0 }
 
@@ -421,9 +432,16 @@ impl<K: Ord, V> TreeMap<K, V> {
     /// a.clear();
     /// assert!(a.is_empty());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn clear(&mut self) {
         self.root = None;
         self.length = 0
+    }
+
+    /// Deprecated: Renamed to `get`.
+    #[deprecated = "Renamed to `get`"]
+    pub fn find(&self, key: &K) -> Option<&V> {
+        self.get(key)
     }
 
     /// Returns a reference to the value corresponding to the key.
@@ -435,11 +453,12 @@ impl<K: Ord, V> TreeMap<K, V> {
     ///
     /// let mut map = TreeMap::new();
     /// map.insert(1u, "a");
-    /// assert_eq!(map.find(&1), Some(&"a"));
-    /// assert_eq!(map.find(&2), None);
+    /// assert_eq!(map.get(&1), Some(&"a"));
+    /// assert_eq!(map.get(&2), None);
     /// ```
     #[inline]
-    pub fn find<'a>(&'a self, key: &K) -> Option<&'a V> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn get(&self, key: &K) -> Option<&V> {
         tree_find_with(&self.root, |k2| key.cmp(k2))
     }
 
@@ -456,8 +475,15 @@ impl<K: Ord, V> TreeMap<K, V> {
     /// assert_eq!(map.contains_key(&2), false);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn contains_key(&self, key: &K) -> bool {
-        self.find(key).is_some()
+        self.get(key).is_some()
+    }
+
+    /// Deprecated: Renamed to `get_mut`.
+    #[deprecated = "Renamed to `get_mut`"]
+    pub fn find_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.get_mut(key)
     }
 
     /// Returns a mutable reference to the value corresponding to the key.
@@ -469,52 +495,22 @@ impl<K: Ord, V> TreeMap<K, V> {
     ///
     /// let mut map = TreeMap::new();
     /// map.insert(1u, "a");
-    /// match map.find_mut(&1) {
+    /// match map.get_mut(&1) {
     ///     Some(x) => *x = "b",
     ///     None => (),
     /// }
     /// assert_eq!(map[1], "b");
     /// ```
     #[inline]
-    pub fn find_mut<'a>(&'a mut self, key: &K) -> Option<&'a mut V> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
         tree_find_with_mut(&mut self.root, |x| key.cmp(x))
     }
 
-    /// Inserts a key-value pair into the map. An existing value for a
-    /// key is replaced by the new value. Returns `true` if the key did
-    /// not already exist in the map.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use std::collections::TreeMap;
-    ///
-    /// let mut map = TreeMap::new();
-    /// assert_eq!(map.insert(2u, "value"), true);
-    /// assert_eq!(map.insert(2, "value2"), false);
-    /// assert_eq!(map[2], "value2");
-    /// ```
-    #[inline]
-    pub fn insert(&mut self, key: K, value: V) -> bool {
-        self.swap(key, value).is_none()
-    }
-
-    /// Removes a key-value pair from the map. Returns `true` if the key
-    /// was present in the map.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use std::collections::TreeMap;
-    ///
-    /// let mut map = TreeMap::new();
-    /// assert_eq!(map.remove(&1u), false);
-    /// map.insert(1, "a");
-    /// assert_eq!(map.remove(&1), true);
-    /// ```
-    #[inline]
-    pub fn remove(&mut self, key: &K) -> bool {
-        self.pop(key).is_some()
+    /// Deprecated: Renamed to `insert`.
+    #[deprecated = "Renamed to `insert`"]
+    pub fn swap(&mut self, key: K, value: V) -> Option<V> {
+        self.insert(key, value)
     }
 
     /// Inserts a key-value pair from the map. If the key already had a value
@@ -526,17 +522,24 @@ impl<K: Ord, V> TreeMap<K, V> {
     /// use std::collections::TreeMap;
     ///
     /// let mut map = TreeMap::new();
-    /// assert_eq!(map.swap(37u, "a"), None);
+    /// assert_eq!(map.insert(37u, "a"), None);
     /// assert_eq!(map.is_empty(), false);
     ///
     /// map.insert(37, "b");
-    /// assert_eq!(map.swap(37, "c"), Some("b"));
+    /// assert_eq!(map.insert(37, "c"), Some("b"));
     /// assert_eq!(map[37], "c");
     /// ```
-    pub fn swap(&mut self, key: K, value: V) -> Option<V> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         let ret = insert(&mut self.root, key, value);
         if ret.is_none() { self.length += 1 }
         ret
+    }
+
+    /// Deprecated: Renamed to `remove`.
+    #[deprecated = "Renamed to `remove`"]
+    pub fn pop(&mut self, key: &K) -> Option<V> {
+        self.remove(key)
     }
 
     /// Removes a key from the map, returning the value at the key if the key
@@ -549,10 +552,11 @@ impl<K: Ord, V> TreeMap<K, V> {
     ///
     /// let mut map = TreeMap::new();
     /// map.insert(1u, "a");
-    /// assert_eq!(map.pop(&1), Some("a"));
-    /// assert_eq!(map.pop(&1), None);
+    /// assert_eq!(map.remove(&1), Some("a"));
+    /// assert_eq!(map.remove(&1), None);
     /// ```
-    pub fn pop(&mut self, key: &K) -> Option<V> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn remove(&mut self, key: &K) -> Option<V> {
         let ret = remove(&mut self.root, key);
         if ret.is_some() { self.length -= 1 }
         ret
@@ -567,7 +571,7 @@ impl<K, V> TreeMap<K, V> {
     /// # Example
     ///
     /// ```
-    /// use std::collections::TreeMap;
+    /// use collections::tree_map::TreeMap;
     ///
     /// fn get_headers() -> TreeMap<String, String> {
     ///     let mut result = TreeMap::new();
@@ -585,7 +589,7 @@ impl<K, V> TreeMap<K, V> {
     /// assert_eq!((*ua.unwrap()).as_slice(), "Curl-Rust/0.1");
     /// ```
     #[inline]
-    pub fn find_with<'a>(&'a self, f:|&K| -> Ordering) -> Option<&'a V> {
+    pub fn find_with(&self, f:|&K| -> Ordering) -> Option<&V> {
         tree_find_with(&self.root, f)
     }
 
@@ -596,9 +600,7 @@ impl<K, V> TreeMap<K, V> {
     /// # Example
     ///
     /// ```
-    /// use std::collections::TreeMap;
-    ///
-    /// let mut t = TreeMap::new();
+    /// let mut t = collections::tree_map::TreeMap::new();
     /// t.insert("Content-Type", "application/xml");
     /// t.insert("User-Agent", "Curl-Rust/0.1");
     ///
@@ -608,7 +610,7 @@ impl<K, V> TreeMap<K, V> {
     ///    None => panic!(),
     /// }
     ///
-    /// assert_eq!(t.find(&"User-Agent"), Some(&new_ua));
+    /// assert_eq!(t.get(&"User-Agent"), Some(&new_ua));
     /// ```
     #[inline]
     pub fn find_with_mut<'a>(&'a mut self, f:|&K| -> Ordering) -> Option<&'a mut V> {
@@ -742,10 +744,10 @@ impl<K: Ord, V> TreeMap<K, V> {
     ///     *value = "changed";
     /// }
     ///
-    /// assert_eq!(map.find(&2), Some(&"a"));
-    /// assert_eq!(map.find(&4), Some(&"changed"));
-    /// assert_eq!(map.find(&6), Some(&"changed"));
-    /// assert_eq!(map.find(&8), Some(&"changed"));
+    /// assert_eq!(map.get(&2), Some(&"a"));
+    /// assert_eq!(map.get(&4), Some(&"changed"));
+    /// assert_eq!(map.get(&6), Some(&"changed"));
+    /// assert_eq!(map.get(&8), Some(&"changed"));
     /// ```
     pub fn lower_bound_mut<'a>(&'a mut self, k: &K) -> MutEntries<'a, K, V> {
         bound_setup!(self.iter_mut_for_traversal(), k, true)
@@ -776,10 +778,10 @@ impl<K: Ord, V> TreeMap<K, V> {
     ///     *value = "changed";
     /// }
     ///
-    /// assert_eq!(map.find(&2), Some(&"a"));
-    /// assert_eq!(map.find(&4), Some(&"b"));
-    /// assert_eq!(map.find(&6), Some(&"changed"));
-    /// assert_eq!(map.find(&8), Some(&"changed"));
+    /// assert_eq!(map.get(&2), Some(&"a"));
+    /// assert_eq!(map.get(&4), Some(&"b"));
+    /// assert_eq!(map.get(&6), Some(&"changed"));
+    /// assert_eq!(map.get(&8), Some(&"changed"));
     /// ```
     pub fn upper_bound_mut<'a>(&'a mut self, k: &K) -> MutEntries<'a, K, V> {
         bound_setup!(self.iter_mut_for_traversal(), k, false)
@@ -1287,16 +1289,16 @@ mod test_treemap {
     #[test]
     fn find_empty() {
         let m: TreeMap<int,int> = TreeMap::new();
-        assert!(m.find(&5) == None);
+        assert!(m.get(&5) == None);
     }
 
     #[test]
     fn find_not_found() {
         let mut m = TreeMap::new();
-        assert!(m.insert(1i, 2i));
-        assert!(m.insert(5i, 3i));
-        assert!(m.insert(9i, 3i));
-        assert_eq!(m.find(&2), None);
+        assert!(m.insert(1i, 2i).is_none());
+        assert!(m.insert(5i, 3i).is_none());
+        assert!(m.insert(9i, 3i).is_none());
+        assert_eq!(m.get(&2), None);
     }
 
     #[test]
@@ -1308,41 +1310,42 @@ mod test_treemap {
     #[test]
     fn find_with_not_found() {
         let mut m = TreeMap::new();
-        assert!(m.insert("test1", 2i));
-        assert!(m.insert("test2", 3i));
-        assert!(m.insert("test3", 3i));
+        assert!(m.insert("test1", 2i).is_none());
+        assert!(m.insert("test2", 3i).is_none());
+        assert!(m.insert("test3", 3i).is_none());
         assert_eq!(m.find_with(|&k| "test4".cmp(k)), None);
     }
 
     #[test]
     fn find_with_found() {
         let mut m = TreeMap::new();
-        assert!(m.insert("test1", 2i));
-        assert!(m.insert("test2", 3i));
-        assert!(m.insert("test3", 4i));
+        assert!(m.insert("test1", 2i).is_none());
+        assert!(m.insert("test2", 3i).is_none());
+        assert!(m.insert("test3", 4i).is_none());
         assert_eq!(m.find_with(|&k| "test2".cmp(k)), Some(&3i));
     }
 
     #[test]
     fn test_find_mut() {
         let mut m = TreeMap::new();
-        assert!(m.insert(1i, 12i));
-        assert!(m.insert(2, 8));
-        assert!(m.insert(5, 14));
+        assert!(m.insert(1i, 12i).is_none());
+        assert!(m.insert(2, 8).is_none());
+        assert!(m.insert(5, 14).is_none());
         let new = 100;
-        match m.find_mut(&5) {
+        match m.get_mut(&5) {
           None => panic!(), Some(x) => *x = new
         }
-        assert_eq!(m.find(&5), Some(&new));
+        assert_eq!(m.get(&5), Some(&new));
     }
 
     #[test]
     fn test_find_with_mut() {
         let mut m = TreeMap::new();
-        assert!(m.insert("t1", 12i));
-        assert!(m.insert("t2", 8));
-        assert!(m.insert("t5", 14));
+        assert!(m.insert("t1", 12i).is_none());
+        assert!(m.insert("t2", 8).is_none());
+        assert!(m.insert("t5", 14).is_none());
         let new = 100;
+
         match m.find_with_mut(|&k| "t5".cmp(k)) {
           None => panic!(), Some(x) => *x = new
         }
@@ -1352,23 +1355,23 @@ mod test_treemap {
     #[test]
     fn insert_replace() {
         let mut m = TreeMap::new();
-        assert!(m.insert(5i, 2i));
-        assert!(m.insert(2, 9));
-        assert!(!m.insert(2, 11));
-        assert_eq!(m.find(&2).unwrap(), &11);
+        assert!(m.insert(5i, 2i).is_none());
+        assert!(m.insert(2, 9).is_none());
+        assert!(!m.insert(2, 11).is_none());
+        assert_eq!(m.get(&2).unwrap(), &11);
     }
 
     #[test]
     fn test_clear() {
         let mut m = TreeMap::new();
         m.clear();
-        assert!(m.insert(5i, 11i));
-        assert!(m.insert(12, -3));
-        assert!(m.insert(19, 2));
+        assert!(m.insert(5i, 11i).is_none());
+        assert!(m.insert(12, -3).is_none());
+        assert!(m.insert(19, 2).is_none());
         m.clear();
-        assert!(m.find(&5).is_none());
-        assert!(m.find(&12).is_none());
-        assert!(m.find(&19).is_none());
+        assert!(m.get(&5).is_none());
+        assert!(m.get(&12).is_none());
+        assert!(m.get(&19).is_none());
         assert!(m.is_empty());
     }
 
@@ -1384,8 +1387,8 @@ mod test_treemap {
         m.insert(k1.clone(), v1.clone());
         m.insert(k2.clone(), v2.clone());
 
-        assert_eq!(m.find(&k2), Some(&v2));
-        assert_eq!(m.find(&k1), Some(&v1));
+        assert_eq!(m.get(&k2), Some(&v2));
+        assert_eq!(m.get(&k1), Some(&v1));
     }
 
     fn check_equal<K: PartialEq + Ord, V: PartialEq>(ctrl: &[(K, V)],
@@ -1393,7 +1396,7 @@ mod test_treemap {
         assert_eq!(ctrl.is_empty(), map.is_empty());
         for x in ctrl.iter() {
             let &(ref k, ref v) = x;
-            assert!(map.find(k).unwrap() == v)
+            assert!(map.get(k).unwrap() == v)
         }
         for (map_k, map_v) in map.iter() {
             let mut found = false;
@@ -1455,7 +1458,7 @@ mod test_treemap {
         let mut ctrl = vec![];
 
         check_equal(ctrl.as_slice(), &map);
-        assert!(map.find(&5).is_none());
+        assert!(map.get(&5).is_none());
 
         let seed: &[_] = &[42];
         let mut rng: rand::IsaacRng = rand::SeedableRng::from_seed(seed);
@@ -1465,7 +1468,7 @@ mod test_treemap {
                 let k = rng.gen();
                 let v = rng.gen();
                 if !ctrl.iter().any(|x| x == &(k, v)) {
-                    assert!(map.insert(k, v));
+                    assert!(map.insert(k, v).is_none());
                     ctrl.push((k, v));
                     check_structure(&map);
                     check_equal(ctrl.as_slice(), &map);
@@ -1475,7 +1478,7 @@ mod test_treemap {
             for _ in range(0u, 30) {
                 let r = rng.gen_range(0, ctrl.len());
                 let (key, _) = ctrl.remove(r).unwrap();
-                assert!(map.remove(&key));
+                assert!(map.remove(&key).is_some());
                 check_structure(&map);
                 check_equal(ctrl.as_slice(), &map);
             }
@@ -1485,19 +1488,19 @@ mod test_treemap {
     #[test]
     fn test_len() {
         let mut m = TreeMap::new();
-        assert!(m.insert(3i, 6i));
+        assert!(m.insert(3i, 6i).is_none());
         assert_eq!(m.len(), 1);
-        assert!(m.insert(0, 0));
+        assert!(m.insert(0, 0).is_none());
         assert_eq!(m.len(), 2);
-        assert!(m.insert(4, 8));
+        assert!(m.insert(4, 8).is_none());
         assert_eq!(m.len(), 3);
-        assert!(m.remove(&3));
+        assert!(m.remove(&3).is_some());
         assert_eq!(m.len(), 2);
-        assert!(!m.remove(&5));
+        assert!(!m.remove(&5).is_some());
         assert_eq!(m.len(), 2);
-        assert!(m.insert(2, 4));
+        assert!(m.insert(2, 4).is_none());
         assert_eq!(m.len(), 3);
-        assert!(m.insert(1, 2));
+        assert!(m.insert(1, 2).is_none());
         assert_eq!(m.len(), 4);
     }
 
@@ -1505,11 +1508,11 @@ mod test_treemap {
     fn test_iterator() {
         let mut m = TreeMap::new();
 
-        assert!(m.insert(3i, 6i));
-        assert!(m.insert(0, 0));
-        assert!(m.insert(4, 8));
-        assert!(m.insert(2, 4));
-        assert!(m.insert(1, 2));
+        assert!(m.insert(3i, 6i).is_none());
+        assert!(m.insert(0, 0).is_none());
+        assert!(m.insert(4, 8).is_none());
+        assert!(m.insert(2, 4).is_none());
+        assert!(m.insert(1, 2).is_none());
 
         let mut n = 0;
         for (k, v) in m.iter() {
@@ -1524,7 +1527,7 @@ mod test_treemap {
     fn test_interval_iteration() {
         let mut m = TreeMap::new();
         for i in range(1i, 100i) {
-            assert!(m.insert(i * 2, i * 4));
+            assert!(m.insert(i * 2, i * 4).is_none());
         }
 
         for i in range(1i, 198i) {
@@ -1548,11 +1551,11 @@ mod test_treemap {
     fn test_rev_iter() {
         let mut m = TreeMap::new();
 
-        assert!(m.insert(3i, 6i));
-        assert!(m.insert(0, 0));
-        assert!(m.insert(4, 8));
-        assert!(m.insert(2, 4));
-        assert!(m.insert(1, 2));
+        assert!(m.insert(3i, 6i).is_none());
+        assert!(m.insert(0, 0).is_none());
+        assert!(m.insert(4, 8).is_none());
+        assert!(m.insert(2, 4).is_none());
+        assert!(m.insert(1, 2).is_none());
 
         let mut n = 4;
         for (k, v) in m.rev_iter() {
@@ -1566,7 +1569,7 @@ mod test_treemap {
     fn test_mut_iter() {
         let mut m = TreeMap::new();
         for i in range(0u, 10) {
-            assert!(m.insert(i, 100 * i));
+            assert!(m.insert(i, 100 * i).is_none());
         }
 
         for (i, (&k, v)) in m.iter_mut().enumerate() {
@@ -1581,7 +1584,7 @@ mod test_treemap {
     fn test_mut_rev_iter() {
         let mut m = TreeMap::new();
         for i in range(0u, 10) {
-            assert!(m.insert(i, 100 * i));
+            assert!(m.insert(i, 100 * i).is_none());
         }
 
         for (i, (&k, v)) in m.rev_iter_mut().enumerate() {
@@ -1598,8 +1601,8 @@ mod test_treemap {
         let mut m_lower = TreeMap::new();
         let mut m_upper = TreeMap::new();
         for i in range(1i, 100i) {
-            assert!(m_lower.insert(i * 2, i * 4));
-            assert!(m_upper.insert(i * 2, i * 4));
+            assert!(m_lower.insert(i * 2, i * 4).is_none());
+            assert!(m_upper.insert(i * 2, i * 4).is_none());
         }
 
         for i in range(1i, 199) {
@@ -1653,15 +1656,15 @@ mod test_treemap {
         let mut b = TreeMap::new();
 
         assert!(a == b);
-        assert!(a.insert(0i, 5i));
+        assert!(a.insert(0i, 5i).is_none());
         assert!(a != b);
-        assert!(b.insert(0, 4));
+        assert!(b.insert(0, 4).is_none());
         assert!(a != b);
-        assert!(a.insert(5, 19));
+        assert!(a.insert(5, 19).is_none());
         assert!(a != b);
-        assert!(!b.insert(0, 5));
+        assert!(!b.insert(0, 5).is_none());
         assert!(a != b);
-        assert!(b.insert(5, 19));
+        assert!(b.insert(5, 19).is_none());
         assert!(a == b);
     }
 
@@ -1671,15 +1674,15 @@ mod test_treemap {
         let mut b = TreeMap::new();
 
         assert!(!(a < b) && !(b < a));
-        assert!(b.insert(0i, 5i));
+        assert!(b.insert(0i, 5i).is_none());
         assert!(a < b);
-        assert!(a.insert(0, 7));
+        assert!(a.insert(0, 7).is_none());
         assert!(!(a < b) && b < a);
-        assert!(b.insert(-2, 0));
+        assert!(b.insert(-2, 0).is_none());
         assert!(b < a);
-        assert!(a.insert(-5, 2));
+        assert!(a.insert(-5, 2).is_none());
         assert!(a < b);
-        assert!(a.insert(6, 2));
+        assert!(a.insert(6, 2).is_none());
         assert!(a < b && !(b < a));
     }
 
@@ -1689,10 +1692,10 @@ mod test_treemap {
         let mut b = TreeMap::new();
 
         assert!(a <= b && a >= b);
-        assert!(a.insert(1i, 1i));
+        assert!(a.insert(1i, 1i).is_none());
         assert!(a > b && a >= b);
         assert!(b < a && b <= a);
-        assert!(b.insert(2, 2));
+        assert!(b.insert(2, 2).is_none());
         assert!(b > a && b >= a);
         assert!(a < b && a <= b);
     }
@@ -1720,11 +1723,11 @@ mod test_treemap {
         let (x4, y4) = (29, 5);
         let (x5, y5) = (103, 3);
 
-        assert!(m.insert(x1, y1));
-        assert!(m.insert(x2, y2));
-        assert!(m.insert(x3, y3));
-        assert!(m.insert(x4, y4));
-        assert!(m.insert(x5, y5));
+        assert!(m.insert(x1, y1).is_none());
+        assert!(m.insert(x2, y2).is_none());
+        assert!(m.insert(x3, y3).is_none());
+        assert!(m.insert(x4, y4).is_none());
+        assert!(m.insert(x5, y5).is_none());
 
         let m = m;
         let mut a = m.iter();
@@ -1765,7 +1768,7 @@ mod test_treemap {
         let map: TreeMap<int, int> = xs.iter().map(|&x| x).collect();
 
         for &(k, v) in xs.iter() {
-            assert_eq!(map.find(&k), Some(&v));
+            assert_eq!(map.get(&k), Some(&v));
         }
     }
 
@@ -1795,17 +1798,17 @@ mod test_treemap {
     #[test]
     fn test_swap() {
         let mut m = TreeMap::new();
-        assert_eq!(m.swap(1u, 2i), None);
-        assert_eq!(m.swap(1u, 3i), Some(2));
-        assert_eq!(m.swap(1u, 4i), Some(3));
+        assert_eq!(m.insert(1u, 2i), None);
+        assert_eq!(m.insert(1u, 3i), Some(2));
+        assert_eq!(m.insert(1u, 4i), Some(3));
     }
 
     #[test]
     fn test_pop() {
         let mut m = TreeMap::new();
         m.insert(1u, 2i);
-        assert_eq!(m.pop(&1), Some(2));
-        assert_eq!(m.pop(&1), None);
+        assert_eq!(m.remove(&1), Some(2));
+        assert_eq!(m.remove(&1), None);
     }
 }
 
@@ -1857,7 +1860,7 @@ mod bench {
         let mut m : TreeMap<uint,uint> = TreeMap::new();
         find_rand_n(100, &mut m, b,
                     |m, i| { m.insert(i, 1); },
-                    |m, i| { m.find(&i); });
+                    |m, i| { m.get(&i); });
     }
 
     #[bench]
@@ -1865,7 +1868,7 @@ mod bench {
         let mut m : TreeMap<uint,uint> = TreeMap::new();
         find_rand_n(10_000, &mut m, b,
                     |m, i| { m.insert(i, 1); },
-                    |m, i| { m.find(&i); });
+                    |m, i| { m.get(&i); });
     }
 
     // Find seq
@@ -1874,7 +1877,7 @@ mod bench {
         let mut m : TreeMap<uint,uint> = TreeMap::new();
         find_seq_n(100, &mut m, b,
                    |m, i| { m.insert(i, 1); },
-                   |m, i| { m.find(&i); });
+                   |m, i| { m.get(&i); });
     }
 
     #[bench]
@@ -1882,7 +1885,7 @@ mod bench {
         let mut m : TreeMap<uint,uint> = TreeMap::new();
         find_seq_n(10_000, &mut m, b,
                    |m, i| { m.insert(i, 1); },
-                   |m, i| { m.find(&i); });
+                   |m, i| { m.get(&i); });
     }
 
     fn bench_iter(b: &mut Bencher, size: uint) {
@@ -1890,7 +1893,7 @@ mod bench {
         let mut rng = weak_rng();
 
         for _ in range(0, size) {
-            map.swap(rng.gen(), rng.gen());
+            map.insert(rng.gen(), rng.gen());
         }
 
         b.iter(|| {

--- a/src/libcollections/tree/set.rs
+++ b/src/libcollections/tree/set.rs
@@ -19,6 +19,10 @@ use std::hash::{Writer, Hash};
 
 use tree_map::{TreeMap, Entries, RevEntries, MoveEntries};
 
+// FIXME(conventions): implement bounded iterators
+// FIXME(conventions): implement BitOr, BitAnd, BitXor, and Sub
+// FIXME(conventions): replace rev_iter(_mut) by making iter(_mut) DoubleEnded
+
 /// An implementation of the `Set` trait on top of the `TreeMap` container. The
 /// only requirement is that the type of the elements contained ascribes to the
 /// `Ord` trait.
@@ -145,6 +149,7 @@ impl<T: Ord> TreeSet<T> {
     /// let mut set: TreeSet<int> = TreeSet::new();
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn new() -> TreeSet<T> { TreeSet{map: TreeMap::new()} }
 
     /// Gets a lazy iterator over the values in the set, in ascending order.
@@ -161,6 +166,7 @@ impl<T: Ord> TreeSet<T> {
     /// }
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter<'a>(&'a self) -> SetItems<'a, T> {
         SetItems{iter: self.map.iter()}
     }
@@ -197,6 +203,7 @@ impl<T: Ord> TreeSet<T> {
     /// assert_eq!(v, vec![1, 2, 3, 4, 5]);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn into_iter(self) -> MoveSetItems<T> {
         self.map.into_iter().map(|(value, _)| value)
     }
@@ -261,6 +268,7 @@ impl<T: Ord> TreeSet<T> {
     /// let diff: TreeSet<int> = b.difference(&a).map(|&x| x).collect();
     /// assert_eq!(diff, [4, 5].iter().map(|&x| x).collect());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn difference<'a>(&'a self, other: &'a TreeSet<T>) -> DifferenceItems<'a, T> {
         DifferenceItems{a: self.iter().peekable(), b: other.iter().peekable()}
     }
@@ -286,6 +294,7 @@ impl<T: Ord> TreeSet<T> {
     /// assert_eq!(diff1, diff2);
     /// assert_eq!(diff1, [1, 2, 4, 5].iter().map(|&x| x).collect());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn symmetric_difference<'a>(&'a self, other: &'a TreeSet<T>)
         -> SymDifferenceItems<'a, T> {
         SymDifferenceItems{a: self.iter().peekable(), b: other.iter().peekable()}
@@ -309,6 +318,7 @@ impl<T: Ord> TreeSet<T> {
     /// let diff: TreeSet<int> = a.intersection(&b).map(|&x| x).collect();
     /// assert_eq!(diff, [2, 3].iter().map(|&x| x).collect());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn intersection<'a>(&'a self, other: &'a TreeSet<T>)
         -> IntersectionItems<'a, T> {
         IntersectionItems{a: self.iter().peekable(), b: other.iter().peekable()}
@@ -332,6 +342,7 @@ impl<T: Ord> TreeSet<T> {
     /// let diff: TreeSet<int> = a.union(&b).map(|&x| x).collect();
     /// assert_eq!(diff, [1, 2, 3, 4, 5].iter().map(|&x| x).collect());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn union<'a>(&'a self, other: &'a TreeSet<T>) -> UnionItems<'a, T> {
         UnionItems{a: self.iter().peekable(), b: other.iter().peekable()}
     }
@@ -349,6 +360,7 @@ impl<T: Ord> TreeSet<T> {
     /// assert_eq!(v.len(), 1);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn len(&self) -> uint { self.map.len() }
 
     /// Returns true if the set contains no elements
@@ -363,6 +375,7 @@ impl<T: Ord> TreeSet<T> {
     /// v.insert(1i);
     /// assert!(!v.is_empty());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_empty(&self) -> bool { self.len() == 0 }
 
     /// Clears the set, removing all values.
@@ -378,6 +391,7 @@ impl<T: Ord> TreeSet<T> {
     /// assert!(v.is_empty());
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn clear(&mut self) { self.map.clear() }
 
     /// Returns `true` if the set contains a value.
@@ -392,6 +406,7 @@ impl<T: Ord> TreeSet<T> {
     /// assert_eq!(set.contains(&4), false);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn contains(&self, value: &T) -> bool {
         self.map.contains_key(value)
     }
@@ -413,6 +428,7 @@ impl<T: Ord> TreeSet<T> {
     /// b.insert(1);
     /// assert_eq!(a.is_disjoint(&b), false);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_disjoint(&self, other: &TreeSet<T>) -> bool {
         self.intersection(other).next().is_none()
     }
@@ -433,6 +449,7 @@ impl<T: Ord> TreeSet<T> {
     /// set.insert(4);
     /// assert_eq!(set.is_subset(&sup), false);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_subset(&self, other: &TreeSet<T>) -> bool {
         let mut x = self.iter();
         let mut y = other.iter();
@@ -476,6 +493,7 @@ impl<T: Ord> TreeSet<T> {
     /// set.insert(2);
     /// assert_eq!(set.is_superset(&sub), true);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_superset(&self, other: &TreeSet<T>) -> bool {
         other.is_subset(self)
     }
@@ -495,7 +513,8 @@ impl<T: Ord> TreeSet<T> {
     /// assert_eq!(set.len(), 1);
     /// ```
     #[inline]
-    pub fn insert(&mut self, value: T) -> bool { self.map.insert(value, ()) }
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn insert(&mut self, value: T) -> bool { self.map.insert(value, ()).is_none() }
 
     /// Removes a value from the set. Returns `true` if the value was
     /// present in the set.
@@ -512,7 +531,8 @@ impl<T: Ord> TreeSet<T> {
     /// assert_eq!(set.remove(&2), false);
     /// ```
     #[inline]
-    pub fn remove(&mut self, value: &T) -> bool { self.map.remove(value) }
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn remove(&mut self, value: &T) -> bool { self.map.remove(value).is_some() }
 }
 
 /// A lazy forward iterator over a set.

--- a/src/libcollections/trie/set.rs
+++ b/src/libcollections/trie/set.rs
@@ -8,6 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// FIXME(conventions): implement bounded iterators
+// FIXME(conventions): implement union family of fns
+// FIXME(conventions): implement BitOr, BitAnd, BitXor, and Sub
+// FIXME(conventions): replace each_reverse by making iter DoubleEnded
+// FIXME(conventions): implement iter_mut and into_iter
+
 use core::prelude::*;
 
 use core::default::Default;
@@ -79,6 +85,7 @@ impl TrieSet {
     /// let mut set = TrieSet::new();
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn new() -> TrieSet {
         TrieSet{map: TrieMap::new()}
     }
@@ -126,6 +133,7 @@ impl TrieSet {
     /// }
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter<'a>(&'a self) -> SetItems<'a> {
         SetItems{iter: self.map.iter()}
     }
@@ -177,6 +185,7 @@ impl TrieSet {
     /// assert_eq!(v.len(), 1);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn len(&self) -> uint { self.map.len() }
 
     /// Returns true if the set contains no elements
@@ -191,6 +200,7 @@ impl TrieSet {
     /// v.insert(1);
     /// assert!(!v.is_empty());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_empty(&self) -> bool { self.len() == 0 }
 
     /// Clears the set, removing all values.
@@ -206,6 +216,7 @@ impl TrieSet {
     /// assert!(v.is_empty());
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn clear(&mut self) { self.map.clear() }
 
     /// Returns `true` if the set contains a value.
@@ -220,6 +231,7 @@ impl TrieSet {
     /// assert_eq!(set.contains(&4), false);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn contains(&self, value: &uint) -> bool {
         self.map.contains_key(value)
     }
@@ -242,6 +254,7 @@ impl TrieSet {
     /// assert_eq!(a.is_disjoint(&b), false);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_disjoint(&self, other: &TrieSet) -> bool {
         self.iter().all(|v| !other.contains(&v))
     }
@@ -263,6 +276,7 @@ impl TrieSet {
     /// assert_eq!(set.is_subset(&sup), false);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_subset(&self, other: &TrieSet) -> bool {
         self.iter().all(|v| other.contains(&v))
     }
@@ -287,6 +301,7 @@ impl TrieSet {
     /// assert_eq!(set.is_superset(&sub), true);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_superset(&self, other: &TrieSet) -> bool {
         other.is_subset(self)
     }
@@ -306,8 +321,9 @@ impl TrieSet {
     /// assert_eq!(set.len(), 1);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn insert(&mut self, value: uint) -> bool {
-        self.map.insert(value, ())
+        self.map.insert(value, ()).is_none()
     }
 
     /// Removes a value from the set. Returns `true` if the value was
@@ -325,8 +341,9 @@ impl TrieSet {
     /// assert_eq!(set.remove(&2), false);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn remove(&mut self, value: &uint) -> bool {
-        self.map.remove(value)
+        self.map.remove(value).is_some()
     }
 }
 

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -26,6 +26,8 @@ use vec::Vec;
 use hash;
 use hash::Hash;
 
+// FIXME(conventions): capacity management???
+
 /// A map optimized for small integer keys.
 ///
 /// # Example
@@ -42,14 +44,14 @@ use hash::Hash;
 ///     println!("The end is near!");
 /// }
 ///
-/// assert_eq!(months.find(&1), Some(&"Jan"));
+/// assert_eq!(months.get(&1), Some(&"Jan"));
 ///
-/// match months.find_mut(&3) {
+/// match months.get_mut(&3) {
 ///     Some(value) => *value = "Venus",
 ///     None => (),
 /// }
 ///
-/// assert_eq!(months.find(&3), Some(&"Venus"));
+/// assert_eq!(months.get(&3), Some(&"Venus"));
 ///
 /// // Print out all months
 /// for (key, value) in months.iter() {
@@ -77,10 +79,7 @@ impl<V:Clone> Clone for VecMap<V> {
 
     #[inline]
     fn clone_from(&mut self, source: &VecMap<V>) {
-        self.v.reserve(source.v.len());
-        for (i, w) in self.v.iter_mut().enumerate() {
-            *w = source.v[i].clone();
-        }
+        self.v.clone_from(&source.v);
     }
 }
 
@@ -99,6 +98,7 @@ impl<V> VecMap<V> {
     /// use std::collections::VecMap;
     /// let mut map: VecMap<&str> = VecMap::new();
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn new() -> VecMap<V> { VecMap{v: vec!()} }
 
     /// Creates an empty `VecMap` with space for at least `capacity`
@@ -110,18 +110,21 @@ impl<V> VecMap<V> {
     /// use std::collections::VecMap;
     /// let mut map: VecMap<&str> = VecMap::with_capacity(10);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn with_capacity(capacity: uint) -> VecMap<V> {
         VecMap { v: Vec::with_capacity(capacity) }
     }
 
     /// Returns an iterator visiting all keys in ascending order by the keys.
     /// The iterator's element type is `uint`.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn keys<'r>(&'r self) -> Keys<'r, V> {
         self.iter().map(|(k, _v)| k)
     }
 
     /// Returns an iterator visiting all values in ascending order by the keys.
     /// The iterator's element type is `&'r V`.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn values<'r>(&'r self) -> Values<'r, V> {
         self.iter().map(|(_k, v)| v)
     }
@@ -144,6 +147,7 @@ impl<V> VecMap<V> {
     ///     println!("{}: {}", key, value);
     /// }
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter<'r>(&'r self) -> Entries<'r, V> {
         Entries {
             front: 0,
@@ -174,6 +178,7 @@ impl<V> VecMap<V> {
     ///     assert_eq!(value, &"x");
     /// }
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter_mut<'r>(&'r mut self) -> MutEntries<'r, V> {
         MutEntries {
             front: 0,
@@ -201,6 +206,7 @@ impl<V> VecMap<V> {
     ///
     /// assert_eq!(vec, vec![(1, "a"), (2, "b"), (3, "c")]);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn into_iter(&mut self)
         -> FilterMap<(uint, Option<V>), (uint, V),
                 Enumerate<vec::MoveItems<Option<V>>>>
@@ -223,6 +229,7 @@ impl<V> VecMap<V> {
     /// a.insert(1, "a");
     /// assert_eq!(a.len(), 1);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn len(&self) -> uint {
         self.v.iter().filter(|elt| elt.is_some()).count()
     }
@@ -239,6 +246,7 @@ impl<V> VecMap<V> {
     /// a.insert(1, "a");
     /// assert!(!a.is_empty());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_empty(&self) -> bool {
         self.v.iter().all(|elt| elt.is_none())
     }
@@ -255,7 +263,14 @@ impl<V> VecMap<V> {
     /// a.clear();
     /// assert!(a.is_empty());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn clear(&mut self) { self.v.clear() }
+
+    /// Deprecated: Renamed to `get`.
+    #[deprecated = "Renamed to `get`"]
+    pub fn find(&self, key: &uint) -> Option<&V> {
+        self.get(key)
+    }
 
     /// Returns a reference to the value corresponding to the key.
     ///
@@ -266,10 +281,11 @@ impl<V> VecMap<V> {
     ///
     /// let mut map = VecMap::new();
     /// map.insert(1, "a");
-    /// assert_eq!(map.find(&1), Some(&"a"));
-    /// assert_eq!(map.find(&2), None);
+    /// assert_eq!(map.get(&1), Some(&"a"));
+    /// assert_eq!(map.get(&2), None);
     /// ```
-    pub fn find<'a>(&'a self, key: &uint) -> Option<&'a V> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn get(&self, key: &uint) -> Option<&V> {
         if *key < self.v.len() {
             match self.v[*key] {
               Some(ref value) => Some(value),
@@ -293,8 +309,15 @@ impl<V> VecMap<V> {
     /// assert_eq!(map.contains_key(&2), false);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn contains_key(&self, key: &uint) -> bool {
-        self.find(key).is_some()
+        self.get(key).is_some()
+    }
+
+    /// Deprecated: Renamed to `get_mut`.
+    #[deprecated = "Renamed to `get_mut`"]
+    pub fn find_mut(&mut self, key: &uint) -> Option<&mut V> {
+        self.get_mut(key)
     }
 
     /// Returns a mutable reference to the value corresponding to the key.
@@ -306,13 +329,14 @@ impl<V> VecMap<V> {
     ///
     /// let mut map = VecMap::new();
     /// map.insert(1, "a");
-    /// match map.find_mut(&1) {
+    /// match map.get_mut(&1) {
     ///     Some(x) => *x = "b",
     ///     None => (),
     /// }
     /// assert_eq!(map[1], "b");
     /// ```
-    pub fn find_mut<'a>(&'a mut self, key: &uint) -> Option<&'a mut V> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn get_mut(&mut self, key: &uint) -> Option<&mut V> {
         if *key < self.v.len() {
             match *(&mut self.v[*key]) {
               Some(ref mut value) => Some(value),
@@ -323,45 +347,10 @@ impl<V> VecMap<V> {
         }
     }
 
-    /// Inserts a key-value pair into the map. An existing value for a
-    /// key is replaced by the new value. Returns `true` if the key did
-    /// not already exist in the map.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use std::collections::VecMap;
-    ///
-    /// let mut map = VecMap::new();
-    /// assert_eq!(map.insert(2, "value"), true);
-    /// assert_eq!(map.insert(2, "value2"), false);
-    /// assert_eq!(map[2], "value2");
-    /// ```
-    pub fn insert(&mut self, key: uint, value: V) -> bool {
-        let exists = self.contains_key(&key);
-        let len = self.v.len();
-        if len <= key {
-            self.v.grow_fn(key - len + 1, |_| None);
-        }
-        self.v[key] = Some(value);
-        !exists
-    }
-
-    /// Removes a key-value pair from the map. Returns `true` if the key
-    /// was present in the map.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use std::collections::VecMap;
-    ///
-    /// let mut map = VecMap::new();
-    /// assert_eq!(map.remove(&1), false);
-    /// map.insert(1, "a");
-    /// assert_eq!(map.remove(&1), true);
-    /// ```
-    pub fn remove(&mut self, key: &uint) -> bool {
-        self.pop(key).is_some()
+    /// Deprecated: Renamed to `insert`.
+    #[deprecated = "Renamed to `insert`"]
+    pub fn swap(&mut self, key: uint, value: V) -> Option<V> {
+        self.insert(key, value)
     }
 
     /// Inserts a key-value pair from the map. If the key already had a value
@@ -373,20 +362,26 @@ impl<V> VecMap<V> {
     /// use std::collections::VecMap;
     ///
     /// let mut map = VecMap::new();
-    /// assert_eq!(map.swap(37, "a"), None);
+    /// assert_eq!(map.insert(37, "a"), None);
     /// assert_eq!(map.is_empty(), false);
     ///
     /// map.insert(37, "b");
-    /// assert_eq!(map.swap(37, "c"), Some("b"));
+    /// assert_eq!(map.insert(37, "c"), Some("b"));
     /// assert_eq!(map[37], "c");
     /// ```
-    pub fn swap(&mut self, key: uint, value: V) -> Option<V> {
-        match self.find_mut(&key) {
-            Some(loc) => { return Some(replace(loc, value)); }
-            None => ()
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn insert(&mut self, key: uint, value: V) -> Option<V> {
+        let len = self.v.len();
+        if len <= key {
+            self.v.grow_fn(key - len + 1, |_| None);
         }
-        self.insert(key, value);
-        return None;
+        replace(&mut self.v[key], Some(value))
+    }
+
+    /// Deprecated: Renamed to `remove`.
+    #[deprecated = "Renamed to `remove`"]
+    pub fn pop(&mut self, key: &uint) -> Option<V> {
+        self.remove(key)
     }
 
     /// Removes a key from the map, returning the value at the key if the key
@@ -399,10 +394,11 @@ impl<V> VecMap<V> {
     ///
     /// let mut map = VecMap::new();
     /// map.insert(1, "a");
-    /// assert_eq!(map.pop(&1), Some("a"));
-    /// assert_eq!(map.pop(&1), None);
+    /// assert_eq!(map.remove(&1), Some("a"));
+    /// assert_eq!(map.remove(&1), None);
     /// ```
-    pub fn pop(&mut self, key: &uint) -> Option<V> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn remove(&mut self, key: &uint) -> Option<V> {
         if *key >= self.v.len() {
             return None;
         }
@@ -460,11 +456,11 @@ impl<V:Clone> VecMap<V> {
                            val: V,
                            ff: |uint, V, V| -> V)
                            -> bool {
-        let new_val = match self.find(&key) {
+        let new_val = match self.get(&key) {
             None => val,
             Some(orig) => ff(key, (*orig).clone(), val)
         };
-        self.insert(key, new_val)
+        self.insert(key, new_val).is_none()
     }
 }
 
@@ -514,14 +510,14 @@ impl<V> Extendable<(uint, V)> for VecMap<V> {
 impl<V> Index<uint, V> for VecMap<V> {
     #[inline]
     fn index<'a>(&'a self, i: &uint) -> &'a V {
-        self.find(i).expect("key not present")
+        self.get(i).expect("key not present")
     }
 }
 
 impl<V> IndexMut<uint, V> for VecMap<V> {
     #[inline]
     fn index_mut<'a>(&'a mut self, i: &uint) -> &'a mut V {
-        self.find_mut(i).expect("key not present")
+        self.get_mut(i).expect("key not present")
     }
 }
 
@@ -615,16 +611,16 @@ mod test_map {
     use super::VecMap;
 
     #[test]
-    fn test_find_mut() {
+    fn test_get_mut() {
         let mut m = VecMap::new();
-        assert!(m.insert(1, 12i));
-        assert!(m.insert(2, 8));
-        assert!(m.insert(5, 14));
+        assert!(m.insert(1, 12i).is_none());
+        assert!(m.insert(2, 8).is_none());
+        assert!(m.insert(5, 14).is_none());
         let new = 100;
-        match m.find_mut(&5) {
+        match m.get_mut(&5) {
             None => panic!(), Some(x) => *x = new
         }
-        assert_eq!(m.find(&5), Some(&new));
+        assert_eq!(m.get(&5), Some(&new));
     }
 
     #[test]
@@ -632,13 +628,13 @@ mod test_map {
         let mut map = VecMap::new();
         assert_eq!(map.len(), 0);
         assert!(map.is_empty());
-        assert!(map.insert(5, 20i));
+        assert!(map.insert(5, 20i).is_none());
         assert_eq!(map.len(), 1);
         assert!(!map.is_empty());
-        assert!(map.insert(11, 12));
+        assert!(map.insert(11, 12).is_none());
         assert_eq!(map.len(), 2);
         assert!(!map.is_empty());
-        assert!(map.insert(14, 22));
+        assert!(map.insert(14, 22).is_none());
         assert_eq!(map.len(), 3);
         assert!(!map.is_empty());
     }
@@ -646,14 +642,14 @@ mod test_map {
     #[test]
     fn test_clear() {
         let mut map = VecMap::new();
-        assert!(map.insert(5, 20i));
-        assert!(map.insert(11, 12));
-        assert!(map.insert(14, 22));
+        assert!(map.insert(5, 20i).is_none());
+        assert!(map.insert(11, 12).is_none());
+        assert!(map.insert(14, 22).is_none());
         map.clear();
         assert!(map.is_empty());
-        assert!(map.find(&5).is_none());
-        assert!(map.find(&11).is_none());
-        assert!(map.find(&14).is_none());
+        assert!(map.get(&5).is_none());
+        assert!(map.get(&11).is_none());
+        assert!(map.get(&14).is_none());
     }
 
     #[test]
@@ -678,28 +674,28 @@ mod test_map {
         map.update_with_key(3, 2, add_more_to_count);
 
         // check the total counts
-        assert_eq!(map.find(&3).unwrap(), &10);
-        assert_eq!(map.find(&5).unwrap(), &3);
-        assert_eq!(map.find(&9).unwrap(), &1);
+        assert_eq!(map.get(&3).unwrap(), &10);
+        assert_eq!(map.get(&5).unwrap(), &3);
+        assert_eq!(map.get(&9).unwrap(), &1);
 
         // sadly, no sevens were counted
-        assert!(map.find(&7).is_none());
+        assert!(map.get(&7).is_none());
     }
 
     #[test]
-    fn test_swap() {
+    fn test_insert() {
         let mut m = VecMap::new();
-        assert_eq!(m.swap(1, 2i), None);
-        assert_eq!(m.swap(1, 3i), Some(2));
-        assert_eq!(m.swap(1, 4i), Some(3));
+        assert_eq!(m.insert(1, 2i), None);
+        assert_eq!(m.insert(1, 3i), Some(2));
+        assert_eq!(m.insert(1, 4i), Some(3));
     }
 
     #[test]
-    fn test_pop() {
+    fn test_remove() {
         let mut m = VecMap::new();
         m.insert(1, 2i);
-        assert_eq!(m.pop(&1), Some(2));
-        assert_eq!(m.pop(&1), None);
+        assert_eq!(m.remove(&1), Some(2));
+        assert_eq!(m.remove(&1), None);
     }
 
     #[test]
@@ -732,11 +728,11 @@ mod test_map {
     fn test_iterator() {
         let mut m = VecMap::new();
 
-        assert!(m.insert(0, 1i));
-        assert!(m.insert(1, 2));
-        assert!(m.insert(3, 5));
-        assert!(m.insert(6, 10));
-        assert!(m.insert(10, 11));
+        assert!(m.insert(0, 1i).is_none());
+        assert!(m.insert(1, 2).is_none());
+        assert!(m.insert(3, 5).is_none());
+        assert!(m.insert(6, 10).is_none());
+        assert!(m.insert(10, 11).is_none());
 
         let mut it = m.iter();
         assert_eq!(it.size_hint(), (0, Some(11)));
@@ -757,11 +753,11 @@ mod test_map {
     fn test_iterator_size_hints() {
         let mut m = VecMap::new();
 
-        assert!(m.insert(0, 1i));
-        assert!(m.insert(1, 2));
-        assert!(m.insert(3, 5));
-        assert!(m.insert(6, 10));
-        assert!(m.insert(10, 11));
+        assert!(m.insert(0, 1i).is_none());
+        assert!(m.insert(1, 2).is_none());
+        assert!(m.insert(3, 5).is_none());
+        assert!(m.insert(6, 10).is_none());
+        assert!(m.insert(10, 11).is_none());
 
         assert_eq!(m.iter().size_hint(), (0, Some(11)));
         assert_eq!(m.iter().rev().size_hint(), (0, Some(11)));
@@ -773,11 +769,11 @@ mod test_map {
     fn test_mut_iterator() {
         let mut m = VecMap::new();
 
-        assert!(m.insert(0, 1i));
-        assert!(m.insert(1, 2));
-        assert!(m.insert(3, 5));
-        assert!(m.insert(6, 10));
-        assert!(m.insert(10, 11));
+        assert!(m.insert(0, 1i).is_none());
+        assert!(m.insert(1, 2).is_none());
+        assert!(m.insert(3, 5).is_none());
+        assert!(m.insert(6, 10).is_none());
+        assert!(m.insert(10, 11).is_none());
 
         for (k, v) in m.iter_mut() {
             *v += k as int;
@@ -796,11 +792,11 @@ mod test_map {
     fn test_rev_iterator() {
         let mut m = VecMap::new();
 
-        assert!(m.insert(0, 1i));
-        assert!(m.insert(1, 2));
-        assert!(m.insert(3, 5));
-        assert!(m.insert(6, 10));
-        assert!(m.insert(10, 11));
+        assert!(m.insert(0, 1i).is_none());
+        assert!(m.insert(1, 2).is_none());
+        assert!(m.insert(3, 5).is_none());
+        assert!(m.insert(6, 10).is_none());
+        assert!(m.insert(10, 11).is_none());
 
         let mut it = m.iter().rev();
         assert_eq!(it.next().unwrap(), (10, &11));
@@ -815,11 +811,11 @@ mod test_map {
     fn test_mut_rev_iterator() {
         let mut m = VecMap::new();
 
-        assert!(m.insert(0, 1i));
-        assert!(m.insert(1, 2));
-        assert!(m.insert(3, 5));
-        assert!(m.insert(6, 10));
-        assert!(m.insert(10, 11));
+        assert!(m.insert(0, 1i).is_none());
+        assert!(m.insert(1, 2).is_none());
+        assert!(m.insert(3, 5).is_none());
+        assert!(m.insert(6, 10).is_none());
+        assert!(m.insert(10, 11).is_none());
 
         for (k, v) in m.iter_mut().rev() {
             *v += k as int;
@@ -880,15 +876,15 @@ mod test_map {
         let mut b = VecMap::new();
 
         assert!(a == b);
-        assert!(a.insert(0, 5i));
+        assert!(a.insert(0, 5i).is_none());
         assert!(a != b);
-        assert!(b.insert(0, 4i));
+        assert!(b.insert(0, 4i).is_none());
         assert!(a != b);
-        assert!(a.insert(5, 19));
+        assert!(a.insert(5, 19).is_none());
         assert!(a != b);
-        assert!(!b.insert(0, 5));
+        assert!(!b.insert(0, 5).is_none());
         assert!(a != b);
-        assert!(b.insert(5, 19));
+        assert!(b.insert(5, 19).is_none());
         assert!(a == b);
     }
 
@@ -898,15 +894,15 @@ mod test_map {
         let mut b = VecMap::new();
 
         assert!(!(a < b) && !(b < a));
-        assert!(b.insert(2u, 5i));
+        assert!(b.insert(2u, 5i).is_none());
         assert!(a < b);
-        assert!(a.insert(2, 7));
+        assert!(a.insert(2, 7).is_none());
         assert!(!(a < b) && b < a);
-        assert!(b.insert(1, 0));
+        assert!(b.insert(1, 0).is_none());
         assert!(b < a);
-        assert!(a.insert(0, 6));
+        assert!(a.insert(0, 6).is_none());
         assert!(a < b);
-        assert!(a.insert(6, 2));
+        assert!(a.insert(6, 2).is_none());
         assert!(a < b && !(b < a));
     }
 
@@ -916,10 +912,10 @@ mod test_map {
         let mut b = VecMap::new();
 
         assert!(a <= b && a >= b);
-        assert!(a.insert(1u, 1i));
+        assert!(a.insert(1u, 1i).is_none());
         assert!(a > b && a >= b);
         assert!(b < a && b <= a);
-        assert!(b.insert(2, 2));
+        assert!(b.insert(2, 2).is_none());
         assert!(b > a && b >= a);
         assert!(a < b && a <= b);
     }
@@ -948,7 +944,7 @@ mod test_map {
         let map: VecMap<char> = xs.iter().map(|&x| x).collect();
 
         for &(k, v) in xs.iter() {
-            assert_eq!(map.find(&k), Some(&v));
+            assert_eq!(map.get(&k), Some(&v));
         }
     }
 
@@ -1022,7 +1018,7 @@ mod bench {
         let mut m : VecMap<uint> = VecMap::new();
         find_rand_n(100, &mut m, b,
                     |m, i| { m.insert(i, 1); },
-                    |m, i| { m.find(&i); });
+                    |m, i| { m.get(&i); });
     }
 
     #[bench]
@@ -1030,7 +1026,7 @@ mod bench {
         let mut m : VecMap<uint> = VecMap::new();
         find_rand_n(10_000, &mut m, b,
                     |m, i| { m.insert(i, 1); },
-                    |m, i| { m.find(&i); });
+                    |m, i| { m.get(&i); });
     }
 
     // Find seq
@@ -1039,7 +1035,7 @@ mod bench {
         let mut m : VecMap<uint> = VecMap::new();
         find_seq_n(100, &mut m, b,
                    |m, i| { m.insert(i, 1); },
-                   |m, i| { m.find(&i); });
+                   |m, i| { m.get(&i); });
     }
 
     #[bench]
@@ -1047,6 +1043,6 @@ mod bench {
         let mut m : VecMap<uint> = VecMap::new();
         find_seq_n(10_000, &mut m, b,
                    |m, i| { m.insert(i, 1); },
-                   |m, i| { m.find(&i); });
+                   |m, i| { m.get(&i); });
     }
 }

--- a/src/libgreen/lib.rs
+++ b/src/libgreen/lib.rs
@@ -417,7 +417,7 @@ impl SchedPool {
         }
 
         // Jettison the task away!
-        self.handles.get_mut(idx).send(TaskFromFriend(task));
+        self.handles[idx].send(TaskFromFriend(task));
     }
 
     /// Spawns a new scheduler into this M:N pool. A handle is returned to the

--- a/src/libgreen/sched.rs
+++ b/src/libgreen/sched.rs
@@ -502,7 +502,7 @@ impl Scheduler {
         let len = work_queues.len();
         let start_index = self.rng.gen_range(0, len);
         for index in range(0, len).map(|i| (i + start_index) % len) {
-            match work_queues.get_mut(index).steal() {
+            match work_queues[index].steal() {
                 deque::Data(task) => {
                     rtdebug!("found task by stealing");
                     return Some(task)

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -220,7 +220,7 @@ fn symbol_hash(tcx: &ty::ctxt,
 }
 
 fn get_symbol_hash(ccx: &CrateContext, t: ty::t) -> String {
-    match ccx.type_hashcodes().borrow().find(&t) {
+    match ccx.type_hashcodes().borrow().get(&t) {
         Some(h) => return h.to_string(),
         None => {}
     }

--- a/src/librustc/driver/session.rs
+++ b/src/librustc/driver/session.rs
@@ -127,7 +127,7 @@ impl Session {
                     msg: String) {
         let lint_id = lint::LintId::of(lint);
         let mut lints = self.lints.borrow_mut();
-        match lints.find_mut(&id) {
+        match lints.get_mut(&id) {
             Some(arr) => { arr.push((lint_id, sp, msg)); return; }
             None => {}
         }

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -403,7 +403,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                                    libc::c_uint or libc::c_ulong should be used");
             }
             def::DefTy(..) => {
-                let tty = match self.cx.tcx.ast_ty_to_ty_cache.borrow().find(&ty_id) {
+                let tty = match self.cx.tcx.ast_ty_to_ty_cache.borrow().get(&ty_id) {
                     Some(&ty::atttce_resolved(t)) => t,
                     _ => panic!("ast_ty_to_ty_cache was incomplete after typeck!")
                 };
@@ -994,7 +994,7 @@ impl LintPass for NonSnakeCase {
     fn check_pat(&mut self, cx: &Context, p: &ast::Pat) {
         match &p.node {
             &ast::PatIdent(_, ref path1, _) => {
-                match cx.tcx.def_map.borrow().find(&p.id) {
+                match cx.tcx.def_map.borrow().get(&p.id) {
                     Some(&def::DefLocal(_)) => {
                         self.check_snake_case(cx, "variable", path1.node, p.span);
                     }
@@ -1051,7 +1051,7 @@ impl LintPass for NonUpperCaseGlobals {
 
     fn check_pat(&mut self, cx: &Context, p: &ast::Pat) {
         // Lint for constants that look like binding identifiers (#7526)
-        match (&p.node, cx.tcx.def_map.borrow().find(&p.id)) {
+        match (&p.node, cx.tcx.def_map.borrow().get(&p.id)) {
             (&ast::PatIdent(_, ref path1, _), Some(&def::DefConst(..))) => {
                 let s = token::get_ident(path1.node);
                 if s.get().chars().any(|c| c.is_lowercase()) {
@@ -1211,7 +1211,7 @@ impl LintPass for NonShorthandFieldPatterns {
             ast::PatStruct(_, ref v, _) => {
                 for fieldpat in v.iter()
                                  .filter(|fieldpat| !fieldpat.node.is_shorthand)
-                                 .filter(|fieldpat| def_map.find(&fieldpat.node.pat.id)
+                                 .filter(|fieldpat| def_map.get(&fieldpat.node.pat.id)
                                     == Some(&def::DefLocal(fieldpat.node.pat.id))) {
                     match fieldpat.node.pat.node {
                         ast::PatIdent(_, ident, None) if ident.node.as_str()
@@ -1368,7 +1368,7 @@ impl LintPass for UnusedAllocation {
             _ => return
         }
 
-        match cx.tcx.adjustments.borrow().find(&e.id) {
+        match cx.tcx.adjustments.borrow().get(&e.id) {
             Some(adjustment) => {
                 match *adjustment {
                     ty::AdjustDerefRef(ty::AutoDerefRef { ref autoref, .. }) => {
@@ -1637,7 +1637,7 @@ impl LintPass for Stability {
 
         let id = match e.node {
             ast::ExprPath(..) | ast::ExprStruct(..) => {
-                match cx.tcx.def_map.borrow().find(&e.id) {
+                match cx.tcx.def_map.borrow().get(&e.id) {
                     Some(&def) => def.def_id(),
                     None => return
                 }
@@ -1645,7 +1645,7 @@ impl LintPass for Stability {
             ast::ExprMethodCall(i, _, _) => {
                 span = i.span;
                 let method_call = typeck::MethodCall::expr(e.id);
-                match cx.tcx.method_map.borrow().find(&method_call) {
+                match cx.tcx.method_map.borrow().get(&method_call) {
                     Some(method) => {
                         match method.origin {
                             typeck::MethodStatic(def_id) => {

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -213,7 +213,7 @@ impl CStore {
 
     pub fn find_extern_mod_stmt_cnum(&self, emod_id: ast::NodeId)
                                      -> Option<ast::CrateNum> {
-        self.extern_mod_crate_map.borrow().find(&emod_id).map(|x| *x)
+        self.extern_mod_crate_map.borrow().get(&emod_id).map(|x| *x)
     }
 }
 

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1209,7 +1209,7 @@ pub fn translate_def_id(cdata: Cmd, did: ast::DefId) -> ast::DefId {
         return ast::DefId { krate: cdata.cnum, node: did.node };
     }
 
-    match cdata.cnum_map.find(&did.krate) {
+    match cdata.cnum_map.get(&did.krate) {
         Some(&n) => {
             ast::DefId {
                 krate: n,
@@ -1321,7 +1321,7 @@ pub fn get_dylib_dependency_formats(cdata: Cmd)
         let cnum = spec.split(':').nth(0).unwrap();
         let link = spec.split(':').nth(1).unwrap();
         let cnum = from_str(cnum).unwrap();
-        let cnum = match cdata.cnum_map.find(&cnum) {
+        let cnum = match cdata.cnum_map.get(&cnum) {
             Some(&n) => n,
             None => panic!("didn't find a crate in the cnum_map")
         };

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -253,7 +253,7 @@ fn encode_symbol(ecx: &EncodeContext,
                  rbml_w: &mut Encoder,
                  id: NodeId) {
     rbml_w.start_tag(tag_items_data_item_symbol);
-    match ecx.item_symbols.borrow().find(&id) {
+    match ecx.item_symbols.borrow().get(&id) {
         Some(x) => {
             debug!("encode_symbol(id={}, str={})", id, *x);
             rbml_w.writer.write(x.as_bytes());
@@ -397,7 +397,7 @@ fn encode_reexported_static_base_methods(ecx: &EncodeContext,
                                          exp: &middle::resolve::Export2)
                                          -> bool {
     let impl_items = ecx.tcx.impl_items.borrow();
-    match ecx.tcx.inherent_impls.borrow().find(&exp.def_id) {
+    match ecx.tcx.inherent_impls.borrow().get(&exp.def_id) {
         Some(implementations) => {
             for base_impl_did in implementations.iter() {
                 for &method_did in (*impl_items)[*base_impl_did].iter() {
@@ -426,7 +426,7 @@ fn encode_reexported_static_trait_methods(ecx: &EncodeContext,
                                           rbml_w: &mut Encoder,
                                           exp: &middle::resolve::Export2)
                                           -> bool {
-    match ecx.tcx.trait_items_cache.borrow().find(&exp.def_id) {
+    match ecx.tcx.trait_items_cache.borrow().get(&exp.def_id) {
         Some(trait_items) => {
             for trait_item in trait_items.iter() {
                 match *trait_item {
@@ -531,7 +531,7 @@ fn encode_reexports(ecx: &EncodeContext,
                     id: NodeId,
                     path: PathElems) {
     debug!("(encoding info for module) encoding reexports for {}", id);
-    match ecx.reexports2.find(&id) {
+    match ecx.reexports2.get(&id) {
         Some(ref exports) => {
             debug!("(encoding info for module) found reexports for {}", id);
             for exp in exports.iter() {
@@ -978,7 +978,7 @@ fn should_inline(attrs: &[Attribute]) -> bool {
 fn encode_inherent_implementations(ecx: &EncodeContext,
                                    rbml_w: &mut Encoder,
                                    def_id: DefId) {
-    match ecx.tcx.inherent_impls.borrow().find(&def_id) {
+    match ecx.tcx.inherent_impls.borrow().get(&def_id) {
         None => {}
         Some(implementations) => {
             for &impl_def_id in implementations.iter() {
@@ -994,7 +994,7 @@ fn encode_inherent_implementations(ecx: &EncodeContext,
 fn encode_extension_implementations(ecx: &EncodeContext,
                                     rbml_w: &mut Encoder,
                                     trait_def_id: DefId) {
-    match ecx.tcx.trait_impls.borrow().find(&trait_def_id) {
+    match ecx.tcx.trait_impls.borrow().get(&trait_def_id) {
         None => {}
         Some(implementations) => {
             for &impl_def_id in implementations.borrow().iter() {
@@ -1987,7 +1987,7 @@ fn encode_crate_triple(rbml_w: &mut Encoder, triple: &str) {
 
 fn encode_dylib_dependency_formats(rbml_w: &mut Encoder, ecx: &EncodeContext) {
     rbml_w.start_tag(tag_dylib_dependency_formats);
-    match ecx.tcx.dependency_formats.borrow().find(&config::CrateTypeDylib) {
+    match ecx.tcx.dependency_formats.borrow().get(&config::CrateTypeDylib) {
         Some(arr) => {
             let s = arr.iter().enumerate().filter_map(|(i, slot)| {
                 slot.map(|kind| (format!("{}:{}", i + 1, match kind {

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -675,16 +675,16 @@ fn parse_builtin_bounds(st: &mut PState, _conv: conv_did) -> ty::BuiltinBounds {
     loop {
         match next(st) {
             'S' => {
-                builtin_bounds.add(ty::BoundSend);
+                builtin_bounds.insert(ty::BoundSend);
             }
             'Z' => {
-                builtin_bounds.add(ty::BoundSized);
+                builtin_bounds.insert(ty::BoundSized);
             }
             'P' => {
-                builtin_bounds.add(ty::BoundCopy);
+                builtin_bounds.insert(ty::BoundCopy);
             }
             'T' => {
-                builtin_bounds.add(ty::BoundSync);
+                builtin_bounds.insert(ty::BoundSync);
             }
             '.' => {
                 return builtin_bounds;

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -50,7 +50,7 @@ pub struct ty_abbrev {
 pub type abbrev_map = RefCell<HashMap<ty::t, ty_abbrev>>;
 
 pub fn enc_ty(w: &mut SeekableMemWriter, cx: &ctxt, t: ty::t) {
-    match cx.abbrevs.borrow_mut().find(&t) {
+    match cx.abbrevs.borrow_mut().get(&t) {
         Some(a) => { w.write(a.s.as_bytes()); return; }
         None => {}
     }

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -1151,14 +1151,14 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
 
     debug!("Encoding side tables for id {}", id);
 
-    for def in tcx.def_map.borrow().find(&id).iter() {
+    for def in tcx.def_map.borrow().get(&id).iter() {
         rbml_w.tag(c::tag_table_def, |rbml_w| {
             rbml_w.id(id);
             rbml_w.tag(c::tag_table_val, |rbml_w| (*def).encode(rbml_w).unwrap());
         })
     }
 
-    for &ty in tcx.node_types.borrow().find(&(id as uint)).iter() {
+    for &ty in tcx.node_types.borrow().get(&(id as uint)).iter() {
         rbml_w.tag(c::tag_table_node_type, |rbml_w| {
             rbml_w.id(id);
             rbml_w.tag(c::tag_table_val, |rbml_w| {
@@ -1167,7 +1167,7 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
         })
     }
 
-    for &item_substs in tcx.item_substs.borrow().find(&id).iter() {
+    for &item_substs in tcx.item_substs.borrow().get(&id).iter() {
         rbml_w.tag(c::tag_table_item_subst, |rbml_w| {
             rbml_w.id(id);
             rbml_w.tag(c::tag_table_val, |rbml_w| {
@@ -1176,7 +1176,7 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
         })
     }
 
-    for &fv in tcx.freevars.borrow().find(&id).iter() {
+    for &fv in tcx.freevars.borrow().get(&id).iter() {
         rbml_w.tag(c::tag_table_freevars, |rbml_w| {
             rbml_w.id(id);
             rbml_w.tag(c::tag_table_val, |rbml_w| {
@@ -1209,7 +1209,7 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
         }
     }
 
-    for &cm in tcx.capture_modes.borrow().find(&id).iter() {
+    for &cm in tcx.capture_modes.borrow().get(&id).iter() {
         rbml_w.tag(c::tag_table_capture_modes, |rbml_w| {
             rbml_w.id(id);
             rbml_w.tag(c::tag_table_val, |rbml_w| {
@@ -1219,7 +1219,7 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
     }
 
     let lid = ast::DefId { krate: ast::LOCAL_CRATE, node: id };
-    for &pty in tcx.tcache.borrow().find(&lid).iter() {
+    for &pty in tcx.tcache.borrow().get(&lid).iter() {
         rbml_w.tag(c::tag_table_tcache, |rbml_w| {
             rbml_w.id(id);
             rbml_w.tag(c::tag_table_val, |rbml_w| {
@@ -1228,7 +1228,7 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
         })
     }
 
-    for &type_param_def in tcx.ty_param_defs.borrow().find(&id).iter() {
+    for &type_param_def in tcx.ty_param_defs.borrow().get(&id).iter() {
         rbml_w.tag(c::tag_table_param_defs, |rbml_w| {
             rbml_w.id(id);
             rbml_w.tag(c::tag_table_val, |rbml_w| {
@@ -1238,7 +1238,7 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
     }
 
     let method_call = MethodCall::expr(id);
-    for &method in tcx.method_map.borrow().find(&method_call).iter() {
+    for &method in tcx.method_map.borrow().get(&method_call).iter() {
         rbml_w.tag(c::tag_table_method_map, |rbml_w| {
             rbml_w.id(id);
             rbml_w.tag(c::tag_table_val, |rbml_w| {
@@ -1247,7 +1247,7 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
         })
     }
 
-    for &trait_ref in tcx.object_cast_map.borrow().find(&id).iter() {
+    for &trait_ref in tcx.object_cast_map.borrow().get(&id).iter() {
         rbml_w.tag(c::tag_table_object_cast_map, |rbml_w| {
             rbml_w.id(id);
             rbml_w.tag(c::tag_table_val, |rbml_w| {
@@ -1256,11 +1256,11 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
         })
     }
 
-    for &adjustment in tcx.adjustments.borrow().find(&id).iter() {
+    for &adjustment in tcx.adjustments.borrow().get(&id).iter() {
         match *adjustment {
             _ if ty::adjust_is_object(adjustment) => {
                 let method_call = MethodCall::autoobject(id);
-                for &method in tcx.method_map.borrow().find(&method_call).iter() {
+                for &method in tcx.method_map.borrow().get(&method_call).iter() {
                     rbml_w.tag(c::tag_table_method_map, |rbml_w| {
                         rbml_w.id(id);
                         rbml_w.tag(c::tag_table_val, |rbml_w| {
@@ -1273,7 +1273,7 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
                 assert!(!ty::adjust_is_object(adjustment));
                 for autoderef in range(0, adj.autoderefs) {
                     let method_call = MethodCall::autoderef(id, autoderef);
-                    for &method in tcx.method_map.borrow().find(&method_call).iter() {
+                    for &method in tcx.method_map.borrow().get(&method_call).iter() {
                         rbml_w.tag(c::tag_table_method_map, |rbml_w| {
                             rbml_w.id(id);
                             rbml_w.tag(c::tag_table_val, |rbml_w| {
@@ -1299,7 +1299,7 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
 
     for unboxed_closure in tcx.unboxed_closures
                               .borrow()
-                              .find(&ast_util::local_def(id))
+                              .get(&ast_util::local_def(id))
                               .iter() {
         rbml_w.tag(c::tag_table_unboxed_closures, |rbml_w| {
             rbml_w.id(id);

--- a/src/librustc/middle/borrowck/move_data.rs
+++ b/src/librustc/middle/borrowck/move_data.rs
@@ -242,7 +242,7 @@ impl MoveData {
          * base paths that do not yet have an index.
          */
 
-        match self.path_map.borrow().find(&lp) {
+        match self.path_map.borrow().get(&lp) {
             Some(&index) => {
                 return index;
             }
@@ -577,7 +577,7 @@ impl<'a, 'tcx> FlowedMoveData<'a, 'tcx> {
         //! Returns the kind of a move of `loan_path` by `id`, if one exists.
 
         let mut ret = None;
-        for loan_path_index in self.move_data.path_map.borrow().find(&*loan_path).iter() {
+        for loan_path_index in self.move_data.path_map.borrow().get(&*loan_path).iter() {
             self.dfcx_moves.each_gen_bit(id, |move_index| {
                 let the_move = self.move_data.moves.borrow();
                 let the_move = (*the_move)[move_index];

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -512,7 +512,7 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
             func_or_rcvr: &ast::Expr,
             args: I) -> CFGIndex {
         let method_call = typeck::MethodCall::expr(call_expr.id);
-        let return_ty = ty::ty_fn_ret(match self.tcx.method_map.borrow().find(&method_call) {
+        let return_ty = ty::ty_fn_ret(match self.tcx.method_map.borrow().get(&method_call) {
             Some(method) => method.ty,
             None => ty::expr_ty(self.tcx, func_or_rcvr)
         });
@@ -610,7 +610,7 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
             }
 
             Some(_) => {
-                match self.tcx.def_map.borrow().find(&expr.id) {
+                match self.tcx.def_map.borrow().get(&expr.id) {
                     Some(&def::DefLabel(loop_id)) => {
                         for l in self.loop_scopes.iter() {
                             if l.loop_id == loop_id {

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -143,7 +143,7 @@ fn check_expr(v: &mut CheckCrateVisitor, e: &Expr) -> bool {
                           "paths in constants may only refer to items without \
                            type parameters");
             }
-            match v.tcx.def_map.borrow().find(&e.id) {
+            match v.tcx.def_map.borrow().get(&e.id) {
                 Some(&DefStatic(..)) |
                 Some(&DefConst(..)) |
                 Some(&DefFn(..)) |
@@ -162,7 +162,7 @@ fn check_expr(v: &mut CheckCrateVisitor, e: &Expr) -> bool {
             }
         }
         ExprCall(ref callee, _) => {
-            match v.tcx.def_map.borrow().find(&callee.id) {
+            match v.tcx.def_map.borrow().get(&callee.id) {
                 Some(&DefStruct(..)) |
                 Some(&DefVariant(..)) => {}    // OK.
 

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -639,7 +639,7 @@ fn pat_constructors(cx: &MatchCheckCtxt, p: &Pat,
     let pat = raw_pat(p);
     match pat.node {
         PatIdent(..) =>
-            match cx.tcx.def_map.borrow().find(&pat.id) {
+            match cx.tcx.def_map.borrow().get(&pat.id) {
                 Some(&DefConst(..)) =>
                     cx.tcx.sess.span_bug(pat.span, "const pattern should've \
                                                     been rewritten"),
@@ -648,7 +648,7 @@ fn pat_constructors(cx: &MatchCheckCtxt, p: &Pat,
                 _ => vec!()
             },
         PatEnum(..) =>
-            match cx.tcx.def_map.borrow().find(&pat.id) {
+            match cx.tcx.def_map.borrow().get(&pat.id) {
                 Some(&DefConst(..)) =>
                     cx.tcx.sess.span_bug(pat.span, "const pattern should've \
                                                     been rewritten"),
@@ -656,7 +656,7 @@ fn pat_constructors(cx: &MatchCheckCtxt, p: &Pat,
                 _ => vec!(Single)
             },
         PatStruct(..) =>
-            match cx.tcx.def_map.borrow().find(&pat.id) {
+            match cx.tcx.def_map.borrow().get(&pat.id) {
                 Some(&DefConst(..)) =>
                     cx.tcx.sess.span_bug(pat.span, "const pattern should've \
                                                     been rewritten"),

--- a/src/librustc/middle/check_static_recursion.rs
+++ b/src/librustc/middle/check_static_recursion.rs
@@ -95,7 +95,7 @@ impl<'a, 'ast, 'v> Visitor<'v> for CheckItemRecursionVisitor<'a, 'ast> {
     fn visit_expr(&mut self, e: &ast::Expr) {
         match e.node {
             ast::ExprPath(..) => {
-                match self.def_map.borrow().find(&e.id) {
+                match self.def_map.borrow().get(&e.id) {
                     Some(&DefStatic(def_id, _)) |
                     Some(&DefConst(def_id)) if
                             ast_util::is_local(def_id) => {

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -123,7 +123,7 @@ fn lookup_variant_by_id<'a>(tcx: &'a ty::ctxt,
             Some(_) => None
         }
     } else {
-        match tcx.extern_const_variants.borrow().find(&variant_def) {
+        match tcx.extern_const_variants.borrow().get(&variant_def) {
             Some(&ast::DUMMY_NODE_ID) => return None,
             Some(&expr_id) => {
                 return Some(tcx.map.expect_expr(expr_id));
@@ -163,7 +163,7 @@ pub fn lookup_const_by_id<'a>(tcx: &'a ty::ctxt, def_id: ast::DefId)
             Some(_) => None
         }
     } else {
-        match tcx.extern_const_statics.borrow().find(&def_id) {
+        match tcx.extern_const_statics.borrow().get(&def_id) {
             Some(&ast::DUMMY_NODE_ID) => return None,
             Some(&expr_id) => {
                 return Some(tcx.map.expect_expr(expr_id));
@@ -192,7 +192,7 @@ struct ConstEvalVisitor<'a, 'tcx: 'a> {
 impl<'a, 'tcx> ConstEvalVisitor<'a, 'tcx> {
     fn classify(&mut self, e: &Expr) -> constness {
         let did = ast_util::local_def(e.id);
-        match self.ccache.find(&did) {
+        match self.ccache.get(&did) {
             Some(&x) => return x,
             None => {}
         }

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -86,7 +86,7 @@ struct PropagationContext<'a, 'b: 'a, 'tcx: 'b, O: 'a> {
 }
 
 fn to_cfgidx_or_die(id: ast::NodeId, index: &NodeMap<CFGIndex>) -> CFGIndex {
-    let opt_cfgindex = index.find(&id).map(|&i|i);
+    let opt_cfgindex = index.get(&id).map(|&i|i);
     opt_cfgindex.unwrap_or_else(|| {
         panic!("nodeid_to_index does not have entry for NodeId {}", id);
     })
@@ -397,7 +397,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
 
             let mut changed = false;
             for &node_id in edge.data.exiting_scopes.iter() {
-                let opt_cfg_idx = self.nodeid_to_index.find(&node_id).map(|&i|i);
+                let opt_cfg_idx = self.nodeid_to_index.get(&node_id).map(|&i|i);
                 match opt_cfg_idx {
                     Some(cfg_idx) => {
                         let (start, end) = self.compute_id_range(cfg_idx);

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -74,7 +74,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
     }
 
     fn lookup_and_handle_definition(&mut self, id: &ast::NodeId) {
-        self.tcx.def_map.borrow().find(id).map(|def| {
+        self.tcx.def_map.borrow().get(id).map(|def| {
             match def {
                 &def::DefConst(_) => {
                     self.check_def_id(def.def_id())
@@ -95,7 +95,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
     fn lookup_and_handle_method(&mut self, id: ast::NodeId,
                                 span: codemap::Span) {
         let method_call = typeck::MethodCall::expr(id);
-        match self.tcx.method_map.borrow().find(&method_call) {
+        match self.tcx.method_map.borrow().get(&method_call) {
             Some(method) => {
                 match method.origin {
                     typeck::MethodStatic(def_id) => {
@@ -493,7 +493,7 @@ impl<'a, 'tcx> DeadVisitor<'a, 'tcx> {
         // method of a private type is used, but the type itself is never
         // called directly.
         let impl_items = self.tcx.impl_items.borrow();
-        match self.tcx.inherent_impls.borrow().find(&local_def(id)) {
+        match self.tcx.inherent_impls.borrow().get(&local_def(id)) {
             None => (),
             Some(impl_list) => {
                 for impl_did in impl_list.iter() {

--- a/src/librustc/middle/dependency_format.rs
+++ b/src/librustc/middle/dependency_format.rs
@@ -158,7 +158,7 @@ fn calculate_type(sess: &session::Session,
 
     // Collect what we've got so far in the return vector.
     let mut ret = range(1, sess.cstore.next_crate_num()).map(|i| {
-        match formats.find(&i).map(|v| *v) {
+        match formats.get(&i).map(|v| *v) {
             v @ Some(cstore::RequireDynamic) => v,
             _ => None,
         }
@@ -209,7 +209,7 @@ fn add_library(sess: &session::Session,
                cnum: ast::CrateNum,
                link: cstore::LinkagePreference,
                m: &mut HashMap<ast::CrateNum, cstore::LinkagePreference>) {
-    match m.find(&cnum) {
+    match m.get(&cnum) {
         Some(&link2) => {
             // If the linkages differ, then we'd have two copies of the library
             // if we continued linking. If the linkages are both static, then we

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -162,7 +162,7 @@ impl OverloadedCallType {
         let trait_did =
             tcx.unboxed_closures
                .borrow()
-               .find(&closure_did)
+               .get(&closure_did)
                .expect("OverloadedCallType::from_unboxed_closure: didn't \
                         find closure id")
                .kind
@@ -535,7 +535,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,TYPER> {
                     match self.tcx()
                               .method_map
                               .borrow()
-                              .find(&MethodCall::expr(call.id)) {
+                              .get(&MethodCall::expr(call.id)) {
                     Some(ref method_callee) => {
                         OverloadedCallType::from_method_origin(
                             self.tcx(),
@@ -686,7 +686,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,TYPER> {
     // process.
     fn walk_adjustment(&mut self, expr: &ast::Expr) {
         let typer = self.typer;
-        match typer.adjustments().borrow().find(&expr.id) {
+        match typer.adjustments().borrow().get(&expr.id) {
             None => { }
             Some(adjustment) => {
                 match *adjustment {

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -173,7 +173,7 @@ impl<'a> LanguageItemCollector<'a> {
         }
 
         // Matched.
-        *self.items.items.get_mut(item_index) = Some(item_def_id);
+        self.items.items[item_index] = Some(item_def_id);
     }
 
     pub fn collect_local_language_items(&mut self, krate: &ast::Crate) {

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -322,7 +322,7 @@ impl<'a, 'tcx> IrMaps<'a, 'tcx> {
     }
 
     fn variable(&self, node_id: NodeId, span: Span) -> Variable {
-        match self.variable_map.find(&node_id) {
+        match self.variable_map.get(&node_id) {
           Some(&var) => var,
           None => {
             self.tcx
@@ -591,7 +591,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
     }
 
     fn live_node(&self, node_id: NodeId, span: Span) -> LiveNode {
-        match self.ir.live_node_map.find(&node_id) {
+        match self.ir.live_node_map.get(&node_id) {
           Some(&ln) => ln,
           None => {
             // This must be a mismatch between the ir_map construction
@@ -719,7 +719,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
             Some(_) => {
                 // Refers to a labeled loop. Use the results of resolve
                 // to find with one
-                match self.ir.tcx.def_map.borrow().find(&id) {
+                match self.ir.tcx.def_map.borrow().get(&id) {
                     Some(&DefLabel(loop_id)) => loop_id,
                     _ => self.ir.tcx.sess.span_bug(sp, "label on break/loop \
                                                         doesn't refer to a loop")
@@ -988,7 +988,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
 
                  // the construction of a closure itself is not important,
                  // but we have to consider the closed over variables.
-                 let caps = match this.ir.capture_info_map.find(&expr.id) {
+                 let caps = match this.ir.capture_info_map.get(&expr.id) {
                     Some(caps) => caps.clone(),
                     None => {
                         this.ir.tcx.sess.span_bug(expr.span, "no registered caps");
@@ -1096,7 +1096,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
               // Now that we know the label we're going to,
               // look it up in the break loop nodes table
 
-              match self.break_ln.find(&sc) {
+              match self.break_ln.get(&sc) {
                   Some(&b) => b,
                   None => self.ir.tcx.sess.span_bug(expr.span,
                                                     "break to unknown label")
@@ -1110,7 +1110,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
               // Now that we know the label we're going to,
               // look it up in the continue loop nodes table
 
-              match self.cont_ln.find(&sc) {
+              match self.cont_ln.get(&sc) {
                   Some(&b) => b,
                   None => self.ir.tcx.sess.span_bug(expr.span,
                                                     "loop to unknown label")
@@ -1167,7 +1167,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
 
           ExprMethodCall(_, _, ref args) => {
             let method_call = typeck::MethodCall::expr(expr.id);
-            let method_ty = self.ir.tcx.method_map.borrow().find(&method_call).unwrap().ty;
+            let method_ty = self.ir.tcx.method_map.borrow().get(&method_call).unwrap().ty;
             let diverges = ty::ty_fn_ret(method_ty) == ty::FnDiverging;
             let succ = if diverges {
                 self.s.exit_ln
@@ -1520,7 +1520,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
             ty::ty_unboxed_closure(closure_def_id, _, _) =>
                 self.ir.tcx.unboxed_closures()
                     .borrow()
-                    .find(&closure_def_id)
+                    .get(&closure_def_id)
                     .unwrap()
                     .closure_type
                     .sig

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -389,7 +389,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
     fn expr_ty_adjusted(&self, expr: &ast::Expr) -> McResult<ty::t> {
         let unadjusted_ty = if_ok!(self.expr_ty(expr));
         Ok(ty::adjust_ty(self.tcx(), expr.span, expr.id, unadjusted_ty,
-                         self.typer.adjustments().borrow().find(&expr.id),
+                         self.typer.adjustments().borrow().get(&expr.id),
                          |method_call| self.typer.node_method_ty(method_call)))
     }
 
@@ -402,7 +402,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
     }
 
     pub fn cat_expr(&self, expr: &ast::Expr) -> McResult<cmt> {
-        match self.typer.adjustments().borrow().find(&expr.id) {
+        match self.typer.adjustments().borrow().get(&expr.id) {
             None => {
                 // No adjustments.
                 self.cat_expr_unadjusted(expr)
@@ -861,7 +861,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                              deref_cnt: uint,
                              implicit: bool)
                              -> cmt {
-        let adjustment = match self.typer.adjustments().borrow().find(&node.id()) {
+        let adjustment = match self.typer.adjustments().borrow().get(&node.id()) {
             Some(adj) if ty::adjust_is_object(adj) => typeck::AutoObject,
             _ if deref_cnt != 0 => typeck::AutoDeref(deref_cnt),
             _ => typeck::NoAdjustment
@@ -1170,7 +1170,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
             // variant(..)
           }
           ast::PatEnum(_, Some(ref subpats)) => {
-            match self.tcx().def_map.borrow().find(&pat.id) {
+            match self.tcx().def_map.borrow().get(&pat.id) {
                 Some(&def::DefVariant(enum_did, _, _)) => {
                     // variant(x, y, z)
 

--- a/src/librustc/middle/pat_util.rs
+++ b/src/librustc/middle/pat_util.rs
@@ -34,7 +34,7 @@ pub fn pat_is_refutable(dm: &resolve::DefMap, pat: &Pat) -> bool {
     match pat.node {
         PatLit(_) | PatRange(_, _) => true,
         PatEnum(_, _) | PatIdent(_, _, None) | PatStruct(..) => {
-            match dm.borrow().find(&pat.id) {
+            match dm.borrow().get(&pat.id) {
                 Some(&DefVariant(..)) => true,
                 _ => false
             }
@@ -47,7 +47,7 @@ pub fn pat_is_refutable(dm: &resolve::DefMap, pat: &Pat) -> bool {
 pub fn pat_is_variant_or_struct(dm: &resolve::DefMap, pat: &Pat) -> bool {
     match pat.node {
         PatEnum(_, _) | PatIdent(_, _, None) | PatStruct(..) => {
-            match dm.borrow().find(&pat.id) {
+            match dm.borrow().get(&pat.id) {
                 Some(&DefVariant(..)) | Some(&DefStruct(..)) => true,
                 _ => false
             }
@@ -59,7 +59,7 @@ pub fn pat_is_variant_or_struct(dm: &resolve::DefMap, pat: &Pat) -> bool {
 pub fn pat_is_const(dm: &resolve::DefMap, pat: &Pat) -> bool {
     match pat.node {
         PatIdent(_, _, None) | PatEnum(..) => {
-            match dm.borrow().find(&pat.id) {
+            match dm.borrow().get(&pat.id) {
                 Some(&DefConst(..)) => true,
                 _ => false
             }

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -399,7 +399,7 @@ impl<'a, 'tcx> PrivacyVisitor<'a, 'tcx> {
             }
             debug!("privacy - is {} a public method", did);
 
-            return match self.tcx.impl_or_trait_items.borrow().find(&did) {
+            return match self.tcx.impl_or_trait_items.borrow().get(&did) {
                 Some(&ty::MethodTraitItem(ref meth)) => {
                     debug!("privacy - well at least it's a method: {}",
                            *meth);
@@ -462,7 +462,7 @@ impl<'a, 'tcx> PrivacyVisitor<'a, 'tcx> {
         debug!("privacy - local {} not public all the way down",
                self.tcx.map.node_to_string(did.node));
         // return quickly for things in the same module
-        if self.parents.find(&did.node) == self.parents.find(&self.curitem) {
+        if self.parents.get(&did.node) == self.parents.get(&self.curitem) {
             debug!("privacy - same parent, we're done here");
             return Allowable;
         }
@@ -855,7 +855,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for PrivacyVisitor<'a, 'tcx> {
             }
             ast::ExprMethodCall(ident, _, _) => {
                 let method_call = MethodCall::expr(expr.id);
-                match self.tcx.method_map.borrow().find(&method_call) {
+                match self.tcx.method_map.borrow().get(&method_call) {
                     None => {
                         self.tcx.sess.span_bug(expr.span,
                                                 "method call not in \
@@ -909,7 +909,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for PrivacyVisitor<'a, 'tcx> {
                              with private fields");
                     }
                 };
-                match self.tcx.def_map.borrow().find(&expr.id) {
+                match self.tcx.def_map.borrow().get(&expr.id) {
                     Some(&def::DefStruct(did)) => {
                         guard(if is_local(did) {
                             local_def(self.tcx.map.get_parent(did.node))
@@ -986,7 +986,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for PrivacyVisitor<'a, 'tcx> {
                         }
                     }
                     ty::ty_enum(_, _) => {
-                        match self.tcx.def_map.borrow().find(&pattern.id) {
+                        match self.tcx.def_map.borrow().get(&pattern.id) {
                             Some(&def::DefVariant(_, variant_id, _)) => {
                                 for field in fields.iter() {
                                     self.check_field(pattern.span, variant_id,

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -106,7 +106,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for ReachableContext<'a, 'tcx> {
 
         match expr.node {
             ast::ExprPath(_) => {
-                let def = match self.tcx.def_map.borrow().find(&expr.id) {
+                let def = match self.tcx.def_map.borrow().get(&expr.id) {
                     Some(&def) => def,
                     None => {
                         self.tcx.sess.span_bug(expr.span,

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -103,7 +103,7 @@ struct RegionResolutionVisitor<'a> {
 
 impl RegionMaps {
     pub fn relate_free_regions(&self, sub: FreeRegion, sup: FreeRegion) {
-        match self.free_region_map.borrow_mut().find_mut(&sub) {
+        match self.free_region_map.borrow_mut().get_mut(&sub) {
             Some(sups) => {
                 if !sups.iter().any(|x| x == &sup) {
                     sups.push(sup);
@@ -149,13 +149,13 @@ impl RegionMaps {
 
     pub fn opt_encl_scope(&self, id: ast::NodeId) -> Option<ast::NodeId> {
         //! Returns the narrowest scope that encloses `id`, if any.
-        self.scope_map.borrow().find(&id).map(|x| *x)
+        self.scope_map.borrow().get(&id).map(|x| *x)
     }
 
     #[allow(dead_code)] // used in middle::cfg
     pub fn encl_scope(&self, id: ast::NodeId) -> ast::NodeId {
         //! Returns the narrowest scope that encloses `id`, if any.
-        match self.scope_map.borrow().find(&id) {
+        match self.scope_map.borrow().get(&id) {
             Some(&r) => r,
             None => { panic!("no enclosing scope for id {}", id); }
         }
@@ -165,7 +165,7 @@ impl RegionMaps {
         /*!
          * Returns the lifetime of the local variable `var_id`
          */
-        match self.var_map.borrow().find(&var_id) {
+        match self.var_map.borrow().get(&var_id) {
             Some(&r) => r,
             None => { panic!("no enclosing scope for id {}", var_id); }
         }
@@ -175,7 +175,7 @@ impl RegionMaps {
         //! Returns the scope when temp created by expr_id will be cleaned up
 
         // check for a designated rvalue scope
-        match self.rvalue_scopes.borrow().find(&expr_id) {
+        match self.rvalue_scopes.borrow().get(&expr_id) {
             Some(&s) => {
                 debug!("temporary_scope({}) = {} [custom]", expr_id, s);
                 return Some(s);
@@ -232,7 +232,7 @@ impl RegionMaps {
 
         let mut s = subscope;
         while superscope != s {
-            match self.scope_map.borrow().find(&s) {
+            match self.scope_map.borrow().get(&s) {
                 None => {
                     debug!("is_subscope_of({}, {}, s={})=false",
                            subscope, superscope, s);
@@ -356,7 +356,7 @@ impl RegionMaps {
             let mut result = vec!(scope);
             let mut scope = scope;
             loop {
-                match this.scope_map.borrow().find(&scope) {
+                match this.scope_map.borrow().get(&scope) {
                     None => return result,
                     Some(&superscope) => {
                         result.push(superscope);

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -2234,7 +2234,7 @@ impl<'a> Resolver<'a> {
 
                 let mut import_resolutions = module_.import_resolutions
                                                     .borrow_mut();
-                match import_resolutions.find_mut(&target) {
+                match import_resolutions.get_mut(&target) {
                     Some(resolution) => {
                         debug!("(building import directive) bumping \
                                 reference");
@@ -2552,7 +2552,7 @@ impl<'a> Resolver<'a> {
         // Search for direct children of the containing module.
         self.populate_module_if_necessary(&containing_module);
 
-        match containing_module.children.borrow().find(&source) {
+        match containing_module.children.borrow().get(&source) {
             None => {
                 // Continue.
             }
@@ -2588,7 +2588,7 @@ impl<'a> Resolver<'a> {
                 }
 
                 // Now search the exported imports within the containing module.
-                match containing_module.import_resolutions.borrow().find(&source) {
+                match containing_module.import_resolutions.borrow().get(&source) {
                     None => {
                         debug!("(resolving single import) no import");
                         // The containing module definitely doesn't have an
@@ -2853,7 +2853,7 @@ impl<'a> Resolver<'a> {
 
             // Here we merge two import resolutions.
             let mut import_resolutions = module_.import_resolutions.borrow_mut();
-            match import_resolutions.find_mut(ident) {
+            match import_resolutions.get_mut(ident) {
                 Some(dest_import_resolution) => {
                     // Merge the two import resolutions at a finer-grained
                     // level.
@@ -3046,7 +3046,7 @@ impl<'a> Resolver<'a> {
 
         // Check for item conflicts.
         let children = module.children.borrow();
-        let name_bindings = match children.find(&name) {
+        let name_bindings = match children.get(&name) {
             None => {
                 // There can't be any conflicts.
                 return
@@ -3432,7 +3432,7 @@ impl<'a> Resolver<'a> {
         // its immediate children.
         self.populate_module_if_necessary(&module_);
 
-        match module_.children.borrow().find(&name) {
+        match module_.children.borrow().get(&name) {
             Some(name_bindings)
                     if name_bindings.defined_in_namespace(namespace) => {
                 debug!("top name bindings succeeded");
@@ -3448,7 +3448,7 @@ impl<'a> Resolver<'a> {
         // all its imports in the usual way; this is because chains of
         // adjacent import statements are processed as though they mutated the
         // current scope.
-        match module_.import_resolutions.borrow().find(&name) {
+        match module_.import_resolutions.borrow().get(&name) {
             None => {
                 // Not found; continue.
             }
@@ -3705,7 +3705,7 @@ impl<'a> Resolver<'a> {
         // First, check the direct children of the module.
         self.populate_module_if_necessary(&module_);
 
-        match module_.children.borrow().find(&name) {
+        match module_.children.borrow().get(&name) {
             Some(name_bindings)
                     if name_bindings.defined_in_namespace(namespace) => {
                 debug!("(resolving name in module) found node as child");
@@ -3728,7 +3728,7 @@ impl<'a> Resolver<'a> {
         }
 
         // Check the list of resolved imports.
-        match module_.import_resolutions.borrow().find(&name) {
+        match module_.import_resolutions.borrow().get(&name) {
             Some(import_resolution) if allow_private_imports ||
                                        import_resolution.is_public => {
 
@@ -3967,7 +3967,7 @@ impl<'a> Resolver<'a> {
             Some(name) => {
                 self.populate_module_if_necessary(&orig_module);
 
-                match orig_module.children.borrow().find(&name) {
+                match orig_module.children.borrow().get(&name) {
                     None => {
                         debug!("!!! (with scope) didn't find `{}` in `{}`",
                                token::get_name(name),
@@ -4691,7 +4691,7 @@ impl<'a> Resolver<'a> {
             Some(ref trait_ref) => {
                 self.resolve_trait_reference(id, trait_ref, TraitImplementation);
 
-                match self.def_map.borrow().find(&trait_ref.ref_id) {
+                match self.def_map.borrow().get(&trait_ref.ref_id) {
                     Some(def) => {
                         let did = def.def_id();
                         Some((did, trait_ref.clone()))
@@ -4767,7 +4767,7 @@ impl<'a> Resolver<'a> {
                 // a type (shadowing any imported modules or types with this name), leading
                 // to weird user-visible bugs. So we ward this off here. See #15060.
                 TyPath(ref path, _, path_id) => {
-                    match self.def_map.borrow().find(&path_id) {
+                    match self.def_map.borrow().get(&path_id) {
                         // FIXME: should we catch other options and give more precise errors?
                         Some(&DefMod(_)) => {
                             self.resolve_error(path.span, "inherent implementations are not \
@@ -4785,7 +4785,7 @@ impl<'a> Resolver<'a> {
     fn check_trait_item(&self, name: Name, span: Span) {
         // If there is a TraitRef in scope for an impl, then the method must be in the trait.
         for &(did, ref trait_ref) in self.current_trait_ref.iter() {
-            if self.trait_item_map.find(&(name, did)).is_none() {
+            if self.trait_item_map.get(&(name, did)).is_none() {
                 let path_str = self.path_names_to_string(&trait_ref.path);
                 self.resolve_error(span,
                                     format!("method `{}` is not a member of trait `{}`",
@@ -4849,7 +4849,7 @@ impl<'a> Resolver<'a> {
             let map_i = self.binding_mode_map(&**p);
 
             for (&key, &binding_0) in map_0.iter() {
-                match map_i.find(&key) {
+                match map_i.get(&key) {
                   None => {
                     self.resolve_error(
                         p.span,
@@ -4908,7 +4908,7 @@ impl<'a> Resolver<'a> {
 
         // Move down in the graph, if there's an anonymous module rooted here.
         let orig_module = self.current_module.clone();
-        match orig_module.anonymous_children.borrow().find(&block.id) {
+        match orig_module.anonymous_children.borrow().get(&block.id) {
             None => { /* Nothing to do. */ }
             Some(anonymous_module) => {
                 debug!("(resolving block) found anonymous module, moving \
@@ -4943,7 +4943,7 @@ impl<'a> Resolver<'a> {
 
                     match self.primitive_type_table
                             .primitive_types
-                            .find(&id.name) {
+                            .get(&id.name) {
 
                         Some(&primitive_type) => {
                             result_def =
@@ -5181,7 +5181,7 @@ impl<'a> Resolver<'a> {
                                                            token::get_ident(
                                                                ident))
                                                    .as_slice())
-                            } else if bindings_list.find(&renamed) ==
+                            } else if bindings_list.get(&renamed) ==
                                     Some(&pat_id) {
                                 // Then this is a duplicate variable in the
                                 // same disjunction, which is an error.
@@ -5407,7 +5407,7 @@ impl<'a> Resolver<'a> {
         // First, search children.
         self.populate_module_if_necessary(&containing_module);
 
-        match containing_module.children.borrow().find(&name) {
+        match containing_module.children.borrow().get(&name) {
             Some(child_name_bindings) => {
                 match child_name_bindings.def_for_namespace(namespace) {
                     Some(def) => {
@@ -5426,7 +5426,7 @@ impl<'a> Resolver<'a> {
         }
 
         // Next, search import resolutions.
-        match containing_module.import_resolutions.borrow().find(&name) {
+        match containing_module.import_resolutions.borrow().get(&name) {
             Some(import_resolution) if import_resolution.is_public => {
                 match (*import_resolution).target_for_namespace(namespace) {
                     Some(target) => {
@@ -5715,10 +5715,10 @@ impl<'a> Resolver<'a> {
             let last_name = name_path.last().unwrap();
 
             if name_path.len() == 1 {
-                match this.primitive_type_table.primitive_types.find(last_name) {
+                match this.primitive_type_table.primitive_types.get(last_name) {
                     Some(_) => None,
                     None => {
-                        match this.current_module.children.borrow().find(last_name) {
+                        match this.current_module.children.borrow().get(last_name) {
                             Some(child) => child.get_module_if_available(),
                             None => None
                         }
@@ -5746,10 +5746,10 @@ impl<'a> Resolver<'a> {
 
         if allowed == Everything {
             // Look for a field with the same name in the current self_type.
-            match self.def_map.borrow().find(&node_id) {
+            match self.def_map.borrow().get(&node_id) {
                  Some(&DefTy(did, _))
                 | Some(&DefStruct(did))
-                | Some(&DefVariant(_, did, _)) => match self.structs.find(&did) {
+                | Some(&DefVariant(_, did, _)) => match self.structs.get(&did) {
                     None => {}
                     Some(fields) => {
                         if fields.iter().any(|&field_name| name == field_name) {
@@ -5765,7 +5765,7 @@ impl<'a> Resolver<'a> {
 
         // Look for a method in the current self type's impl module.
         match get_module(self, path.span, name_path.as_slice()) {
-            Some(module) => match module.children.borrow().find(&name) {
+            Some(module) => match module.children.borrow().get(&name) {
                 Some(binding) => {
                     let p_str = self.path_names_to_string(&path);
                     match binding.def_for_namespace(ValueNS) {
@@ -5790,7 +5790,7 @@ impl<'a> Resolver<'a> {
             Some((did, ref trait_ref)) => {
                 let path_str = self.path_names_to_string(&trait_ref.path);
 
-                match self.trait_item_map.find(&(name, did)) {
+                match self.trait_item_map.get(&(name, did)) {
                     Some(&StaticMethodTraitItemKind) => {
                         return TraitMethod(path_str)
                     }
@@ -6270,7 +6270,7 @@ impl<'a> Resolver<'a> {
                                   "unused import".to_string());
         }
 
-        let (v_priv, t_priv) = match self.last_private.find(&id) {
+        let (v_priv, t_priv) = match self.last_private.get(&id) {
             Some(&LastImport {
                 value_priv: v,
                 value_used: _,

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -906,7 +906,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     {
         let cache = self.pick_candidate_cache(&cache_skol_trait_ref);
         let hashmap = cache.hashmap.borrow();
-        hashmap.find(&cache_skol_trait_ref).map(|c| (*c).clone())
+        hashmap.get(&cache_skol_trait_ref).map(|c| (*c).clone())
     }
 
     fn insert_candidate_cache(&mut self,
@@ -1032,7 +1032,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                self_ty.repr(self.tcx()),
                obligation.repr(self.tcx()));
 
-        let closure_kind = match self.typer.unboxed_closures().borrow().find(&closure_def_id) {
+        let closure_kind = match self.typer.unboxed_closures().borrow().get(&closure_def_id) {
             Some(closure) => closure.kind,
             None => {
                 self.tcx().sess.span_bug(
@@ -1282,7 +1282,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
                             ty::BoundSync |
                             ty::BoundSend => {
-                                if c.bounds.builtin_bounds.contains_elem(bound) {
+                                if c.bounds.builtin_bounds.contains(&bound) {
                                     Ok(If(Vec::new()))
                                 } else {
                                     Err(Unimplemented)
@@ -1306,7 +1306,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
                             ty::BoundSync |
                             ty::BoundSend => {
-                                if c.bounds.builtin_bounds.contains_elem(bound) {
+                                if c.bounds.builtin_bounds.contains(&bound) {
                                     Ok(If(Vec::new()))
                                 } else {
                                     Err(Unimplemented)
@@ -1323,7 +1323,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                         Err(Unimplemented)
                     }
                     ty::BoundCopy | ty::BoundSync | ty::BoundSend => {
-                        if bounds.builtin_bounds.contains_elem(bound) {
+                        if bounds.builtin_bounds.contains(&bound) {
                             Ok(If(Vec::new()))
                         } else {
                             Err(Unimplemented)
@@ -1428,7 +1428,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 // is reserve judgement and then intertwine this
                 // analysis with closure inference.
                 assert_eq!(def_id.krate, ast::LOCAL_CRATE);
-                match self.tcx().freevars.borrow().find(&def_id.node) {
+                match self.tcx().freevars.borrow().get(&def_id.node) {
                     None => {
                         // No upvars.
                         Ok(If(Vec::new()))
@@ -1690,7 +1690,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                closure_def_id.repr(self.tcx()),
                substs.repr(self.tcx()));
 
-        let closure_type = match self.typer.unboxed_closures().borrow().find(&closure_def_id) {
+        let closure_type = match self.typer.unboxed_closures().borrow().get(&closure_def_id) {
             Some(closure) => closure.closure_type.clone(),
             None => {
                 self.tcx().sess.span_bug(
@@ -1973,7 +1973,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         ty::populate_implementations_for_trait_if_necessary(self.tcx(),
                                                             trait_def_id);
-        match self.tcx().trait_impls.borrow().find(&trait_def_id) {
+        match self.tcx().trait_impls.borrow().get(&trait_def_id) {
             None => Vec::new(),
             Some(impls) => impls.borrow().clone()
         }

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -696,13 +696,13 @@ fn any_irrefutable_adt_pat(tcx: &ty::ctxt, m: &[Match], col: uint) -> bool {
         match pat.node {
             ast::PatTup(_) => true,
             ast::PatStruct(..) => {
-                match tcx.def_map.borrow().find(&pat.id) {
+                match tcx.def_map.borrow().get(&pat.id) {
                     Some(&def::DefVariant(..)) => false,
                     _ => true,
                 }
             }
             ast::PatEnum(..) | ast::PatIdent(_, _, None) => {
-                match tcx.def_map.borrow().find(&pat.id) {
+                match tcx.def_map.borrow().get(&pat.id) {
                     Some(&def::DefStruct(..)) => true,
                     _ => false
                 }

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -147,7 +147,7 @@ pub fn represent_node(bcx: Block, node: ast::NodeId) -> Rc<Repr> {
 /// Decides how to represent a given type.
 pub fn represent_type(cx: &CrateContext, t: ty::t) -> Rc<Repr> {
     debug!("Representing: {}", ty_to_string(cx.tcx(), t));
-    match cx.adt_reprs().borrow().find(&t) {
+    match cx.adt_reprs().borrow().get(&t) {
         Some(repr) => return repr.clone(),
         None => {}
     }

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -316,7 +316,7 @@ pub fn get_extern_const(ccx: &CrateContext, did: ast::DefId,
                         t: ty::t) -> ValueRef {
     let name = csearch::get_symbol(&ccx.sess().cstore, did);
     let ty = type_of(ccx, t);
-    match ccx.externs().borrow_mut().find(&name) {
+    match ccx.externs().borrow_mut().get(&name) {
         Some(n) => return *n,
         None => ()
     }
@@ -409,7 +409,7 @@ pub fn malloc_raw_dyn_proc<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: ty::t) -> Resu
 // Type descriptor and type glue stuff
 
 pub fn get_tydesc(ccx: &CrateContext, t: ty::t) -> Rc<tydesc_info> {
-    match ccx.tydescs().borrow().find(&t) {
+    match ccx.tydescs().borrow().get(&t) {
         Some(inf) => return inf.clone(),
         _ => { }
     }
@@ -2100,7 +2100,7 @@ fn enum_variant_size_lint(ccx: &CrateContext, enum_def: &ast::EnumDef, sp: Span,
 
     let levels = ccx.tcx().node_lint_levels.borrow();
     let lint_id = lint::LintId::of(lint::builtin::VARIANT_SIZE_DIFFERENCES);
-    let lvlsrc = match levels.find(&(id, lint_id)) {
+    let lvlsrc = match levels.get(&(id, lint_id)) {
         None | Some(&(lint::Allow, _)) => return,
         Some(&lvlsrc) => lvlsrc,
     };
@@ -2645,7 +2645,7 @@ pub fn create_entry_wrapper(ccx: &CrateContext,
 
 fn exported_name(ccx: &CrateContext, id: ast::NodeId,
                  ty: ty::t, attrs: &[ast::Attribute]) -> String {
-    match ccx.external_srcs().borrow().find(&id) {
+    match ccx.external_srcs().borrow().get(&id) {
         Some(&did) => {
             let sym = csearch::get_symbol(&ccx.sess().cstore, did);
             debug!("found item {} in other crate...", sym);
@@ -3123,7 +3123,7 @@ pub fn trans_crate<'tcx>(analysis: CrateAnalysis<'tcx>)
         .collect();
 
     let mut reachable: Vec<String> = shared_ccx.reachable().iter().filter_map(|id| {
-        shared_ccx.item_symbols().borrow().find(id).map(|s| s.to_string())
+        shared_ccx.item_symbols().borrow().get(id).map(|s| s.to_string())
     }).collect();
 
     // For the purposes of LTO, we add to the reachable set all of the upstream

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -81,7 +81,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 s.push('/');
                 s.push_str(category);
 
-                let n = match h.find(&s) {
+                let n = match h.get(&s) {
                     Some(&n) => n,
                     _ => 0u
                 };

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -438,7 +438,7 @@ pub fn get_or_create_declaration_if_unboxed_closure<'blk, 'tcx>(bcx: Block<'blk,
         params: params
     };
 
-    match ccx.unboxed_closure_vals().borrow().find(&mono_id) {
+    match ccx.unboxed_closure_vals().borrow().get(&mono_id) {
         Some(llfn) => {
             debug!("get_or_create_declaration_if_unboxed_closure(): found \
                     closure");
@@ -564,7 +564,7 @@ pub fn get_wrapper_for_bare_fn(ccx: &CrateContext,
         }
     };
 
-    match ccx.closure_bare_wrapper_cache().borrow().find(&fn_ptr) {
+    match ccx.closure_bare_wrapper_cache().borrow().get(&fn_ptr) {
         Some(&llval) => return llval,
         None => {}
     }

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -466,7 +466,7 @@ impl<'blk, 'tcx> BlockS<'blk, 'tcx> {
     }
 
     pub fn def(&self, nid: ast::NodeId) -> def::Def {
-        match self.tcx().def_map.borrow().find(&nid) {
+        match self.tcx().def_map.borrow().get(&nid) {
             Some(v) => v.clone(),
             None => {
                 self.tcx().sess.bug(format!(
@@ -505,7 +505,7 @@ impl<'blk, 'tcx> mc::Typer<'tcx> for BlockS<'blk, 'tcx> {
         self.tcx()
             .method_map
             .borrow()
-            .find(&method_call)
+            .get(&method_call)
             .map(|method| monomorphize_type(self, method.ty))
     }
 
@@ -647,7 +647,7 @@ pub fn C_u8(ccx: &CrateContext, i: uint) -> ValueRef {
 // our boxed-and-length-annotated strings.
 pub fn C_cstr(cx: &CrateContext, s: InternedString, null_terminated: bool) -> ValueRef {
     unsafe {
-        match cx.const_cstr_cache().borrow().find(&s) {
+        match cx.const_cstr_cache().borrow().get(&s) {
             Some(&llval) => return llval,
             None => ()
         }
@@ -813,7 +813,7 @@ pub fn fulfill_obligation(ccx: &CrateContext,
     let trait_ref = ty_fold::erase_regions(tcx, trait_ref);
 
     // First check the cache.
-    match ccx.trait_cache().borrow().find(&trait_ref) {
+    match ccx.trait_cache().borrow().get(&trait_ref) {
         Some(vtable) => {
             info!("Cache hit: {}", trait_ref.repr(ccx.tcx()));
             return (*vtable).clone();

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -90,7 +90,7 @@ pub fn const_lit(cx: &CrateContext, e: &ast::Expr, lit: &ast::Lit)
 pub fn const_ptrcast(cx: &CrateContext, a: ValueRef, t: Type) -> ValueRef {
     unsafe {
         let b = llvm::LLVMConstPointerCast(a, t.ptr_to().to_ref());
-        assert!(cx.const_globals().borrow_mut().insert(b as int, a));
+        assert!(cx.const_globals().borrow_mut().insert(b as int, a).is_none());
         b
     }
 }
@@ -125,7 +125,7 @@ pub fn const_addr_of(cx: &CrateContext, cv: ValueRef, mutbl: ast::Mutability) ->
 }
 
 fn const_deref_ptr(cx: &CrateContext, v: ValueRef) -> ValueRef {
-    let v = match cx.const_globals().borrow().find(&(v as int)) {
+    let v = match cx.const_globals().borrow().get(&(v as int)) {
         Some(&v) => v,
         None => v
     };

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -421,7 +421,7 @@ pub fn trans_break_cont<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let loop_id = match opt_label {
         None => fcx.top_loop_scope(),
         Some(_) => {
-            match bcx.tcx().def_map.borrow().find(&expr_id) {
+            match bcx.tcx().def_map.borrow().get(&expr_id) {
                 Some(&def::DefLabel(loop_id)) => loop_id,
                 ref r => {
                     bcx.tcx().sess.bug(format!("{} in def-map for label",

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -282,7 +282,7 @@ impl TypeMap {
                                    cx: &CrateContext,
                                    type_: ty::t,
                                    metadata: DIType) {
-        if !self.type_to_metadata.insert(ty::type_id(type_), metadata) {
+        if self.type_to_metadata.insert(ty::type_id(type_), metadata).is_some() {
             cx.sess().bug(format!("Type metadata for ty::t '{}' is already in the TypeMap!",
                                    ppaux::ty_to_string(cx.tcx(), type_)).as_slice());
         }
@@ -294,7 +294,7 @@ impl TypeMap {
                                         cx: &CrateContext,
                                         unique_type_id: UniqueTypeId,
                                         metadata: DIType) {
-        if !self.unique_id_to_metadata.insert(unique_type_id, metadata) {
+        if self.unique_id_to_metadata.insert(unique_type_id, metadata).is_some() {
             let unique_type_id_str = self.get_unique_type_id_as_string(unique_type_id);
             cx.sess().bug(format!("Type metadata for unique id '{}' is already in the TypeMap!",
                                   unique_type_id_str.as_slice()).as_slice());
@@ -468,7 +468,7 @@ impl TypeMap {
             },
             ty::ty_unboxed_closure(ref def_id, _, ref substs) => {
                 let closure_ty = cx.tcx().unboxed_closures.borrow()
-                                   .find(def_id).unwrap().closure_type.subst(cx.tcx(), substs);
+                                   .get(def_id).unwrap().closure_type.subst(cx.tcx(), substs);
                 self.get_unique_type_id_of_closure_type(cx,
                                                         closure_ty,
                                                         &mut unique_type_id);
@@ -2939,7 +2939,7 @@ fn type_metadata(cx: &CrateContext,
         }
         ty::ty_unboxed_closure(ref def_id, _, ref substs) => {
             let sig = cx.tcx().unboxed_closures.borrow()
-                        .find(def_id).unwrap().closure_type.sig.subst(cx.tcx(), substs);
+                        .get(def_id).unwrap().closure_type.sig.subst(cx.tcx(), substs);
             subroutine_type_metadata(cx, unique_type_id, &sig, usage_site_span)
         }
         ty::ty_struct(def_id, ref substs) => {

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -212,7 +212,7 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                         // Don't skip a conversion from Box<T> to &T, etc.
                         ty::ty_rptr(..) => {
                             let method_call = MethodCall::autoderef(expr.id, adj.autoderefs-1);
-                            let method = bcx.tcx().method_map.borrow().find(&method_call).is_some();
+                            let method = bcx.tcx().method_map.borrow().get(&method_call).is_some();
                             if method {
                                 // Don't skip an overloaded deref.
                                 (adj.autoderefs, true)
@@ -601,7 +601,7 @@ fn trans_datum_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             let method_ty = ccx.tcx()
                                .method_map
                                .borrow()
-                               .find(&method_call)
+                               .get(&method_call)
                                .map(|method| method.ty);
             let base_datum = unpack_datum!(bcx, trans(bcx, &**base));
 
@@ -736,7 +736,7 @@ fn trans_index<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let method_ty = ccx.tcx()
                        .method_map
                        .borrow()
-                       .find(&method_call)
+                       .get(&method_call)
                        .map(|method| method.ty);
     let elt_datum = match method_ty {
         Some(method_ty) => {
@@ -1114,7 +1114,7 @@ fn trans_rvalue_dps_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             if ty::type_is_trait(node_id_type(bcx, expr.id)) {
                 let trait_ref =
                     bcx.tcx().object_cast_map.borrow()
-                                             .find(&expr.id)
+                                             .get(&expr.id)
                                              .map(|t| (*t).clone())
                                              .unwrap();
                 let trait_ref =
@@ -1232,7 +1232,7 @@ pub fn trans_local_var<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         def::DefUpvar(nid, _, _) => {
             // Can't move upvars, so this is never a ZeroMemLastUse.
             let local_ty = node_id_type(bcx, nid);
-            match bcx.fcx.llupvars.borrow().find(&nid) {
+            match bcx.fcx.llupvars.borrow().get(&nid) {
                 Some(&val) => Datum::new(val, local_ty, Lvalue),
                 None => {
                     bcx.sess().bug(format!(
@@ -1242,7 +1242,7 @@ pub fn trans_local_var<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             }
         }
         def::DefLocal(nid) => {
-            let datum = match bcx.fcx.lllocals.borrow().find(&nid) {
+            let datum = match bcx.fcx.lllocals.borrow().get(&nid) {
                 Some(&v) => v,
                 None => {
                     bcx.sess().bug(format!(
@@ -2089,7 +2089,7 @@ fn deref_once<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
     // Check for overloaded deref.
     let method_ty = ccx.tcx().method_map.borrow()
-                       .find(&method_call).map(|method| method.ty);
+                       .get(&method_call).map(|method| method.ty);
     let datum = match method_ty {
         Some(method_ty) => {
             // Overloaded. Evaluate `trans_overloaded_op`, which will

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -144,7 +144,7 @@ pub fn get_drop_glue(ccx: &CrateContext, t: ty::t) -> ValueRef {
     debug!("make drop glue for {}", ppaux::ty_to_string(ccx.tcx(), t));
     let t = get_drop_glue_type(ccx, t);
     debug!("drop glue type {}", ppaux::ty_to_string(ccx.tcx(), t));
-    match ccx.drop_glues().borrow().find(&t) {
+    match ccx.drop_glues().borrow().get(&t) {
         Some(&glue) => return glue,
         _ => { }
     }
@@ -157,7 +157,7 @@ pub fn get_drop_glue(ccx: &CrateContext, t: ty::t) -> ValueRef {
 
     let llfnty = Type::glue_fn(ccx, llty);
 
-    let (glue, new_sym) = match ccx.available_drop_glues().borrow().find(&t) {
+    let (glue, new_sym) = match ccx.available_drop_glues().borrow().get(&t) {
         Some(old_sym) => {
             let glue = decl_cdecl_fn(ccx, old_sym.as_slice(), llfnty, ty::mk_nil());
             (glue, None)

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -21,7 +21,7 @@ use syntax::ast_util::{local_def, PostExpansionMethod};
 fn instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
     -> Option<ast::DefId> {
     let _icx = push_ctxt("maybe_instantiate_inline");
-    match ccx.external().borrow().find(&fn_id) {
+    match ccx.external().borrow().get(&fn_id) {
         Some(&Some(node_id)) => {
             // Already inline
             debug!("maybe_instantiate_inline({}): already inline as node id {}",

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -116,7 +116,7 @@ pub fn trans_method_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let (origin, method_ty) =
         bcx.tcx().method_map
                  .borrow()
-                 .find(&method_call)
+                 .get(&method_call)
                  .map(|method| (method.origin.clone(), method.ty))
                  .unwrap();
 
@@ -308,7 +308,7 @@ fn method_with_name(ccx: &CrateContext, impl_id: ast::DefId, name: ast::Name)
 
     let impl_items = ccx.tcx().impl_items.borrow();
     let impl_items =
-        impl_items.find(&impl_id)
+        impl_items.get(&impl_id)
                   .expect("could not find impl while translating");
     let meth_did = impl_items.iter()
                              .find(|&did| {
@@ -559,7 +559,7 @@ pub fn get_vtable(bcx: Block,
 
     // Check the cache.
     let cache_key = (box_ty, trait_ref.clone());
-    match ccx.vtables().borrow().find(&cache_key) {
+    match ccx.vtables().borrow().get(&cache_key) {
         Some(&val) => { return val }
         None => { }
     }
@@ -599,7 +599,7 @@ pub fn get_vtable(bcx: Block,
                                               .unboxed_closures
                                               .borrow();
                     let closure_info =
-                        unboxed_closures.find(&closure_def_id)
+                        unboxed_closures.get(&closure_def_id)
                                         .expect("get_vtable(): didn't find \
                                                  unboxed closure");
                     if closure_info.kind == ty::FnOnceUnboxedClosureKind {

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -54,7 +54,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
         params: real_substs.types.clone()
     };
 
-    match ccx.monomorphized().borrow().find(&hash_id) {
+    match ccx.monomorphized().borrow().get(&hash_id) {
         Some(&val) => {
             debug!("leaving monomorphic fn {}",
             ty::item_path_str(ccx.tcx(), fn_id));
@@ -106,7 +106,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
     let depth;
     {
         let mut monomorphizing = ccx.monomorphizing().borrow_mut();
-        depth = match monomorphizing.find(&fn_id) {
+        depth = match monomorphizing.get(&fn_id) {
             Some(&d) => d, None => 0
         };
 

--- a/src/librustc/middle/trans/type_.rs
+++ b/src/librustc/middle/trans/type_.rs
@@ -332,7 +332,7 @@ impl TypeNames {
 
     pub fn associate_type(&self, s: &str, t: &Type) {
         assert!(self.named_types.borrow_mut().insert(s.to_string(),
-                                                     t.to_ref()));
+                                                     t.to_ref()).is_none());
     }
 
     pub fn find_type(&self, s: &str) -> Option<Type> {

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -272,7 +272,7 @@ pub fn type_of(cx: &CrateContext, t: ty::t) -> Type {
     }
 
     // Check the cache.
-    match cx.lltypes().borrow().find(&t) {
+    match cx.lltypes().borrow().get(&t) {
         Some(&llty) => return llty,
         None => ()
     }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1080,14 +1080,14 @@ pub enum BuiltinBound {
 }
 
 pub fn empty_builtin_bounds() -> BuiltinBounds {
-    EnumSet::empty()
+    EnumSet::new()
 }
 
 pub fn all_builtin_bounds() -> BuiltinBounds {
-    let mut set = EnumSet::empty();
-    set.add(BoundSend);
-    set.add(BoundSized);
-    set.add(BoundSync);
+    let mut set = EnumSet::new();
+    set.insert(BoundSend);
+    set.insert(BoundSized);
+    set.insert(BoundSync);
     set
 }
 
@@ -1584,7 +1584,7 @@ pub fn mk_t(cx: &ctxt, st: sty) -> t {
 
     let key = intern_key { sty: &st };
 
-    match cx.interner.borrow().find(&key) {
+    match cx.interner.borrow().get(&key) {
         Some(t) => unsafe { return mem::transmute(&t.sty); },
         _ => ()
     }
@@ -2418,11 +2418,11 @@ pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
         // value for the type contents of list.  The correct value is
         // TC::OwnsOwned.  This manifested as issue #4821.
         let ty_id = type_id(ty);
-        match cache.find(&ty_id) {
+        match cache.get(&ty_id) {
             Some(tc) => { return *tc; }
             None => {}
         }
-        match cx.tc_cache.borrow().find(&ty_id) {    // Must check both caches!
+        match cx.tc_cache.borrow().get(&ty_id) {    // Must check both caches!
             Some(tc) => { return *tc; }
             None => {}
         }
@@ -3192,7 +3192,7 @@ pub fn array_element_ty(t: t) -> Option<t> {
 }
 
 pub fn node_id_to_trait_ref(cx: &ctxt, id: ast::NodeId) -> Rc<ty::TraitRef> {
-    match cx.trait_refs.borrow().find(&id) {
+    match cx.trait_refs.borrow().get(&id) {
         Some(t) => t.clone(),
         None => cx.sess.bug(
             format!("node_id_to_trait_ref: no trait ref for node `{}`",
@@ -3214,14 +3214,14 @@ pub fn node_id_to_type(cx: &ctxt, id: ast::NodeId) -> t {
 }
 
 pub fn node_id_to_type_opt(cx: &ctxt, id: ast::NodeId) -> Option<t> {
-    match cx.node_types.borrow().find(&(id as uint)) {
+    match cx.node_types.borrow().get(&(id as uint)) {
        Some(&t) => Some(t),
        None => None
     }
 }
 
 pub fn node_id_item_substs(cx: &ctxt, id: ast::NodeId) -> ItemSubsts {
-    match cx.item_substs.borrow().find(&id) {
+    match cx.item_substs.borrow().get(&id) {
       None => ItemSubsts::empty(),
       Some(ts) => ts.clone(),
     }
@@ -3361,8 +3361,8 @@ pub fn expr_ty_adjusted(cx: &ctxt, expr: &ast::Expr) -> t {
      */
 
     adjust_ty(cx, expr.span, expr.id, expr_ty(cx, expr),
-              cx.adjustments.borrow().find(&expr.id),
-              |method_call| cx.method_map.borrow().find(&method_call).map(|method| method.ty))
+              cx.adjustments.borrow().get(&expr.id),
+              |method_call| cx.method_map.borrow().get(&method_call).map(|method| method.ty))
 }
 
 pub fn expr_span(cx: &ctxt, id: NodeId) -> Span {
@@ -3553,7 +3553,7 @@ pub fn unsize_ty(cx: &ctxt,
 }
 
 pub fn resolve_expr(tcx: &ctxt, expr: &ast::Expr) -> def::Def {
-    match tcx.def_map.borrow().find(&expr.id) {
+    match tcx.def_map.borrow().get(&expr.id) {
         Some(&def) => def,
         None => {
             tcx.sess.span_bug(expr.span, format!(
@@ -3690,7 +3690,7 @@ pub fn expr_kind(tcx: &ctxt, expr: &ast::Expr) -> ExprKind {
         }
 
         ast::ExprCast(..) => {
-            match tcx.node_types.borrow().find(&(expr.id as uint)) {
+            match tcx.node_types.borrow().get(&(expr.id as uint)) {
                 Some(&t) => {
                     if type_is_trait(t) {
                         RvalueDpsExpr
@@ -3736,7 +3736,7 @@ pub fn expr_kind(tcx: &ctxt, expr: &ast::Expr) -> ExprKind {
 
         ast::ExprBox(ref place, _) => {
             // Special case `Box<T>` for now:
-            let definition = match tcx.def_map.borrow().find(&place.id) {
+            let definition = match tcx.def_map.borrow().get(&place.id) {
                 Some(&def) => def,
                 None => panic!("no def for place"),
             };
@@ -4003,7 +4003,7 @@ pub fn note_and_explain_type_err(cx: &ctxt, err: &type_err) {
 }
 
 pub fn provided_source(cx: &ctxt, id: ast::DefId) -> Option<ast::DefId> {
-    cx.provided_method_sources.borrow().find(&id).map(|x| *x)
+    cx.provided_method_sources.borrow().get(&id).map(|x| *x)
 }
 
 pub fn provided_trait_methods(cx: &ctxt, id: ast::DefId) -> Vec<Rc<Method>> {
@@ -4113,7 +4113,7 @@ pub fn impl_or_trait_item(cx: &ctxt, id: ast::DefId) -> ImplOrTraitItem {
 pub fn is_associated_type(cx: &ctxt, id: ast::DefId) -> bool {
     memoized(&cx.associated_types, id, |id: ast::DefId| {
         if id.krate == ast::LOCAL_CRATE {
-            match cx.impl_or_trait_items.borrow().find(&id) {
+            match cx.impl_or_trait_items.borrow().get(&id) {
                 Some(ref item) => {
                     match **item {
                         TypeTraitItem(_) => true,
@@ -4198,7 +4198,7 @@ pub fn impl_trait_ref(cx: &ctxt, id: ast::DefId) -> Option<Rc<TraitRef>> {
 
 pub fn trait_ref_to_def_id(tcx: &ctxt, tr: &ast::TraitRef) -> ast::DefId {
     let def = *tcx.def_map.borrow()
-                     .find(&tr.ref_id)
+                     .get(&tr.ref_id)
                      .expect("no def-map entry for trait");
     def.def_id()
 }
@@ -4215,7 +4215,7 @@ pub fn try_add_builtin_trait(
     //! is a builtin trait.
 
     match tcx.lang_items.to_builtin_kind(trait_def_id) {
-        Some(bound) => { builtin_bounds.add(bound); true }
+        Some(bound) => { builtin_bounds.insert(bound); true }
         None => false
     }
 }
@@ -4346,7 +4346,7 @@ impl DtorKind {
 /* If struct_id names a struct with a dtor, return Some(the dtor's id).
    Otherwise return none. */
 pub fn ty_dtor(cx: &ctxt, struct_id: DefId) -> DtorKind {
-    match cx.destructor_for_type.borrow().find(&struct_id) {
+    match cx.destructor_for_type.borrow().get(&struct_id) {
         Some(&method_def_id) => {
             let flag = !has_attr(cx, struct_id, "unsafe_no_drop_flag");
 
@@ -4569,7 +4569,7 @@ pub fn lookup_field_type(tcx: &ctxt,
 pub fn lookup_struct_fields(cx: &ctxt, did: ast::DefId) -> Vec<field_ty> {
     if did.krate == ast::LOCAL_CRATE {
         let struct_fields = cx.struct_fields.borrow();
-        match struct_fields.find(&did) {
+        match struct_fields.get(&did) {
             Some(fields) => (**fields).clone(),
             _ => {
                 cx.sess.bug(
@@ -4632,7 +4632,7 @@ pub fn unboxed_closure_upvars(tcx: &ctxt, closure_id: ast::DefId, substs: &Subst
     // implemented.
     assert!(closure_id.krate == ast::LOCAL_CRATE);
     let capture_mode = tcx.capture_modes.borrow().get_copy(&closure_id.node);
-    match tcx.freevars.borrow().find(&closure_id.node) {
+    match tcx.freevars.borrow().get(&closure_id.node) {
         None => vec![],
         Some(ref freevars) => {
             freevars.iter().map(|freevar| {
@@ -4898,7 +4898,7 @@ pub fn required_region_bounds(tcx: &ctxt,
                           all_bounds: &mut Vec<ty::Region>) {
         all_bounds.push_all(region_bounds.as_slice());
 
-        if builtin_bounds.contains_elem(ty::BoundSend) {
+        if builtin_bounds.contains(&ty::BoundSend) {
             all_bounds.push(ty::ReStatic);
         }
     }
@@ -4921,7 +4921,7 @@ pub fn item_variances(tcx: &ctxt, item_id: ast::DefId) -> Rc<ItemVariances> {
 pub fn record_trait_implementation(tcx: &ctxt,
                                    trait_def_id: DefId,
                                    impl_def_id: DefId) {
-    match tcx.trait_impls.borrow().find(&trait_def_id) {
+    match tcx.trait_impls.borrow().get(&trait_def_id) {
         Some(impls_for_trait) => {
             impls_for_trait.borrow_mut().push(impl_def_id);
             return;
@@ -5094,7 +5094,7 @@ pub fn trait_of_item(tcx: &ctxt, def_id: ast::DefId) -> Option<ast::DefId> {
 /// Otherwise, return `None`.
 pub fn trait_item_of_item(tcx: &ctxt, def_id: ast::DefId)
                           -> Option<ImplOrTraitItemId> {
-    let impl_item = match tcx.impl_or_trait_items.borrow().find(&def_id) {
+    let impl_item = match tcx.impl_or_trait_items.borrow().get(&def_id) {
         Some(m) => m.clone(),
         None => return None,
     };
@@ -5449,7 +5449,7 @@ impl<'tcx> mc::Typer<'tcx> for ty::ctxt<'tcx> {
     }
 
     fn node_method_ty(&self, method_call: typeck::MethodCall) -> Option<ty::t> {
-        self.method_map.borrow().find(&method_call).map(|method| method.ty)
+        self.method_map.borrow().get(&method_call).map(|method| method.ty)
     }
 
     fn adjustments<'a>(&'a self) -> &'a RefCell<NodeMap<ty::AutoAdjustment>> {
@@ -5561,7 +5561,7 @@ pub type FreevarMap = NodeMap<Vec<Freevar>>;
 pub type CaptureModeMap = NodeMap<ast::CaptureClause>;
 
 pub fn with_freevars<T>(tcx: &ty::ctxt, fid: ast::NodeId, f: |&[Freevar]| -> T) -> T {
-    match tcx.freevars.borrow().find(&fid) {
+    match tcx.freevars.borrow().get(&fid) {
         None => f(&[]),
         Some(d) => f(d.as_slice())
     }

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -99,7 +99,7 @@ pub trait AstConv<'tcx> {
 
 pub fn ast_region_to_region(tcx: &ty::ctxt, lifetime: &ast::Lifetime)
                             -> ty::Region {
-    let r = match tcx.named_region_map.find(&lifetime.id) {
+    let r = match tcx.named_region_map.get(&lifetime.id) {
         None => {
             // should have been recorded by the `resolve_lifetime` pass
             tcx.sess.span_bug(lifetime.span, "unresolved lifetime");
@@ -467,7 +467,7 @@ fn check_path_args(tcx: &ty::ctxt,
 pub fn ast_ty_to_prim_ty(tcx: &ty::ctxt, ast_ty: &ast::Ty) -> Option<ty::t> {
     match ast_ty.node {
         ast::TyPath(ref path, _, id) => {
-            let a_def = match tcx.def_map.borrow().find(&id) {
+            let a_def = match tcx.def_map.borrow().get(&id) {
                 None => {
                     tcx.sess.span_bug(ast_ty.span,
                                       format!("unbound path {}",
@@ -524,7 +524,7 @@ pub fn ast_ty_to_builtin_ty<'tcx, AC: AstConv<'tcx>, RS: RegionScope>(
 
     match ast_ty.node {
         ast::TyPath(ref path, _, id) => {
-            let a_def = match this.tcx().def_map.borrow().find(&id) {
+            let a_def = match this.tcx().def_map.borrow().get(&id) {
                 None => {
                     this.tcx()
                         .sess
@@ -675,7 +675,7 @@ fn mk_pointer<'tcx, AC: AstConv<'tcx>, RS: RegionScope>(
             // Note that the "bounds must be empty if path is not a trait"
             // restriction is enforced in the below case for ty_path, which
             // will run after this as long as the path isn't a trait.
-            match tcx.def_map.borrow().find(&id) {
+            match tcx.def_map.borrow().get(&id) {
                 Some(&def::DefPrimTy(ast::TyStr)) => {
                     check_path_args(tcx, path, NO_TPS | NO_REGIONS);
                     match ptr_ty {
@@ -802,7 +802,7 @@ pub fn ast_ty_to_ty<'tcx, AC: AstConv<'tcx>, RS: RegionScope>(
     let tcx = this.tcx();
 
     let mut ast_ty_to_ty_cache = tcx.ast_ty_to_ty_cache.borrow_mut();
-    match ast_ty_to_ty_cache.find(&ast_ty.id) {
+    match ast_ty_to_ty_cache.get(&ast_ty.id) {
         Some(&ty::atttce_resolved(ty)) => return ty,
         Some(&ty::atttce_unresolved) => {
             tcx.sess.span_fatal(ast_ty.span,
@@ -900,7 +900,7 @@ pub fn ast_ty_to_ty<'tcx, AC: AstConv<'tcx>, RS: RegionScope>(
                 ty::mk_err()
             }
             ast::TyPath(ref path, ref bounds, id) => {
-                let a_def = match tcx.def_map.borrow().find(&id) {
+                let a_def = match tcx.def_map.borrow().get(&id) {
                     None => {
                         tcx.sess
                            .span_bug(ast_ty.span,
@@ -990,7 +990,7 @@ pub fn ast_ty_to_ty<'tcx, AC: AstConv<'tcx>, RS: RegionScope>(
                 }
             }
             ast::TyQPath(ref qpath) => {
-                match tcx.def_map.borrow().find(&ast_ty.id) {
+                match tcx.def_map.borrow().get(&ast_ty.id) {
                     None => {
                         tcx.sess.span_bug(ast_ty.span,
                                           "unbound qualified path")
@@ -1549,7 +1549,7 @@ pub fn partition_bounds<'a>(tcx: &ty::ctxt,
             ast::TraitTyParamBound(ref b) => {
                 match lookup_def_tcx(tcx, b.path.span, b.ref_id) {
                     def::DefTrait(trait_did) => {
-                        match trait_def_ids.find(&trait_did) {
+                        match trait_def_ids.get(&trait_did) {
                             // Already seen this trait. We forbid
                             // duplicates in the list (for some
                             // reason).

--- a/src/librustc/middle/typeck/check/_match.rs
+++ b/src/librustc/middle/typeck/check/_match.rs
@@ -324,7 +324,7 @@ pub fn check_pat_struct(pcx: &pat_ctxt, pat: &ast::Pat,
 
     let item_substs = fcx
         .item_substs()
-        .find(&pat.id)
+        .get(&pat.id)
         .map(|substs| substs.substs.clone())
         .unwrap_or_else(|| Substs::empty());
 

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -678,7 +678,7 @@ impl<'a, 'tcx> LookupContext<'a, 'tcx> {
         debug!("push_extension_candidates(expr_id={})", expr_id);
 
         let mut duplicates = HashSet::new();
-        let opt_applicable_traits = self.fcx.ccx.trait_map.find(&expr_id);
+        let opt_applicable_traits = self.fcx.ccx.trait_map.get(&expr_id);
         for applicable_traits in opt_applicable_traits.into_iter() {
             for &trait_did in applicable_traits.iter() {
                 if duplicates.insert(trait_did) {
@@ -912,7 +912,7 @@ impl<'a, 'tcx> LookupContext<'a, 'tcx> {
         // metadata if necessary.
         ty::populate_implementations_for_type_if_necessary(self.tcx(), did);
 
-        for impl_infos in self.tcx().inherent_impls.borrow().find(&did).iter() {
+        for impl_infos in self.tcx().inherent_impls.borrow().get(&did).iter() {
             for impl_did in impl_infos.iter() {
                 self.push_candidates_from_inherent_impl(*impl_did);
             }
@@ -1627,7 +1627,7 @@ impl<'a, 'tcx> LookupContext<'a, 'tcx> {
                                             .inh
                                             .adjustments
                                             .borrow()
-                                            .find(&expr.id) {
+                                            .get(&expr.id) {
                 Some(&ty::AdjustDerefRef(ty::AutoDerefRef {
                     autoderefs: autoderef_count,
                     autoref: _
@@ -1658,7 +1658,7 @@ impl<'a, 'tcx> LookupContext<'a, 'tcx> {
                 match expr.node {
                     ast::ExprIndex(ref base_expr, _) => {
                         let mut base_adjustment =
-                            match self.fcx.inh.adjustments.borrow().find(&base_expr.id) {
+                            match self.fcx.inh.adjustments.borrow().get(&base_expr.id) {
                                 Some(&ty::AdjustDerefRef(ref adr)) => (*adr).clone(),
                                 None => ty::AutoDerefRef { autoderefs: 0, autoref: None },
                                 Some(_) => {
@@ -1839,7 +1839,7 @@ fn impl_method(tcx: &ty::ctxt,
                -> Option<Rc<ty::Method>>
 {
     let impl_items = tcx.impl_items.borrow();
-    let impl_items = impl_items.find(&impl_def_id).unwrap();
+    let impl_items = impl_items.get(&impl_def_id).unwrap();
     impl_items
         .iter()
         .map(|&did| ty::impl_or_trait_item(tcx, did.def_id()))

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -298,7 +298,7 @@ impl<'a, 'tcx> mem_categorization::Typer<'tcx> for FnCtxt<'a, 'tcx> {
     }
     fn node_method_ty(&self, method_call: typeck::MethodCall)
                       -> Option<ty::t> {
-        self.inh.method_map.borrow().find(&method_call).map(|m| m.ty)
+        self.inh.method_map.borrow().get(&method_call).map(|m| m.ty)
     }
     fn adjustments<'a>(&'a self) -> &'a RefCell<NodeMap<ty::AutoAdjustment>> {
         &self.inh.adjustments
@@ -1556,7 +1556,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     pub fn local_ty(&self, span: Span, nid: ast::NodeId) -> ty::t {
-        match self.inh.locals.borrow().find(&nid) {
+        match self.inh.locals.borrow().get(&nid) {
             Some(&t) => t,
             None => {
                 self.tcx().sess.span_bug(
@@ -1808,7 +1808,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     pub fn expr_ty(&self, ex: &ast::Expr) -> ty::t {
-        match self.inh.node_types.borrow().find(&ex.id) {
+        match self.inh.node_types.borrow().get(&ex.id) {
             Some(&t) => t,
             None => {
                 self.tcx().sess.bug(format!("no type for expr in fcx {}",
@@ -1824,7 +1824,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
          */
 
         let adjustments = self.inh.adjustments.borrow();
-        let adjustment = adjustments.find(&expr.id);
+        let adjustment = adjustments.get(&expr.id);
         self.adjust_expr_ty(expr, adjustment)
     }
 
@@ -1845,12 +1845,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                       raw_ty,
                       adjustment,
                       |method_call| self.inh.method_map.borrow()
-                                                       .find(&method_call)
+                                                       .get(&method_call)
                                                        .map(|method| method.ty))
     }
 
     pub fn node_ty(&self, id: ast::NodeId) -> ty::t {
-        match self.inh.node_types.borrow().find(&id) {
+        match self.inh.node_types.borrow().get(&id) {
             Some(&t) => t,
             None => {
                 self.tcx().sess.bug(
@@ -1868,7 +1868,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn opt_node_ty_substs(&self,
                               id: ast::NodeId,
                               f: |&ty::ItemSubsts|) {
-        match self.inh.item_substs.borrow().find(&id) {
+        match self.inh.item_substs.borrow().get(&id) {
             Some(s) => { f(s) }
             None => { }
         }
@@ -3554,7 +3554,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
                     let (bounds, onceness) = match expr.node {
                         ast::ExprProc(..) => {
                             let mut bounds = ty::region_existential_bound(ty::ReStatic);
-                            bounds.builtin_bounds.add(ty::BoundSend); // FIXME
+                            bounds.builtin_bounds.insert(ty::BoundSend); // FIXME
                             (bounds, ast::Once)
                         }
                         _ => {
@@ -3763,7 +3763,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
         for field in ast_fields.iter() {
             let mut expected_field_type = ty::mk_err();
 
-            let pair = class_field_map.find(&field.ident.node.name).map(|x| *x);
+            let pair = class_field_map.get(&field.ident.node.name).map(|x| *x);
             match pair {
                 None => {
                     fcx.type_error_message(
@@ -4422,7 +4422,7 @@ fn check_expr_with_unifier(fcx: &FnCtxt,
       }
       ast::ExprStruct(ref path, ref fields, ref base_expr) => {
         // Resolve the path.
-        let def = tcx.def_map.borrow().find(&id).map(|i| *i);
+        let def = tcx.def_map.borrow().get(&id).map(|i| *i);
         let struct_id = match def {
             Some(def::DefVariant(enum_id, variant_id, true)) => {
                 check_struct_enum_variant(fcx, id, expr.span, enum_id,
@@ -5603,7 +5603,7 @@ pub fn may_break(cx: &ty::ctxt, id: ast::NodeId, b: &ast::Block) -> bool {
     (block_query(b, |e| {
         match e.node {
             ast::ExprBreak(Some(_)) => {
-                match cx.def_map.borrow().find(&e.id) {
+                match cx.def_map.borrow().get(&e.id) {
                     Some(&def::DefLabel(loop_id)) if id == loop_id => true,
                     _ => false,
                 }

--- a/src/librustc/middle/typeck/check/writeback.rs
+++ b/src/librustc/middle/typeck/check/writeback.rs
@@ -263,7 +263,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
     }
 
     fn visit_adjustments(&self, reason: ResolveReason, id: ast::NodeId) {
-        match self.fcx.inh.adjustments.borrow_mut().pop(&id) {
+        match self.fcx.inh.adjustments.borrow_mut().remove(&id) {
             None => {
                 debug!("No adjustments for node {}", id);
             }
@@ -275,7 +275,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                         // FIXME(eddyb) #2190 Allow only statically resolved
                         // bare functions to coerce to a closure to avoid
                         // constructing (slower) indirect call wrappers.
-                        match self.tcx().def_map.borrow().find(&id) {
+                        match self.tcx().def_map.borrow().get(&id) {
                             Some(&def::DefFn(..)) |
                             Some(&def::DefStaticMethod(..)) |
                             Some(&def::DefVariant(..)) |
@@ -320,7 +320,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                               reason: ResolveReason,
                               method_call: MethodCall) {
         // Resolve any method map entry
-        match self.fcx.inh.method_map.borrow_mut().pop(&method_call) {
+        match self.fcx.inh.method_map.borrow_mut().remove(&method_call) {
             Some(method) => {
                 debug!("writeback::resolve_method_map_entry(call={}, entry={})",
                        method_call,

--- a/src/librustc/middle/typeck/coherence/mod.rs
+++ b/src/librustc/middle/typeck/coherence/mod.rs
@@ -294,7 +294,7 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
     }
 
     fn add_inherent_impl(&self, base_def_id: DefId, impl_def_id: DefId) {
-        match self.inherent_impls.borrow().find(&base_def_id) {
+        match self.inherent_impls.borrow().get(&base_def_id) {
             Some(implementation_list) => {
                 implementation_list.borrow_mut().push(impl_def_id);
                 return;

--- a/src/librustc/middle/typeck/coherence/overlap.rs
+++ b/src/librustc/middle/typeck/coherence/overlap.rs
@@ -114,7 +114,7 @@ impl<'cx, 'tcx> OverlapChecker<'cx, 'tcx> {
     fn push_impls_of_trait(&self,
                            trait_def_id: ast::DefId,
                            out: &mut Vec<ast::DefId>) {
-        match self.tcx.trait_impls.borrow().find(&trait_def_id) {
+        match self.tcx.trait_impls.borrow().get(&trait_def_id) {
             Some(impls) => { out.push_all(impls.borrow().as_slice()); }
             None => { /* no impls */ }
         }

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -1243,7 +1243,7 @@ pub fn convert_struct(ccx: &CrateCtxt,
         let result = convert_field(ccx, &pty.generics, f, local_def(id));
 
         if result.name != special_idents::unnamed_field.name {
-            let dup = match seen_fields.find(&result.name) {
+            let dup = match seen_fields.get(&result.name) {
                 Some(prev_span) => {
                     span_err!(tcx.sess, f.span, E0124,
                               "field `{}` is already declared",
@@ -1386,7 +1386,7 @@ fn get_trait_def(ccx: &CrateCtxt, trait_id: ast::DefId) -> Rc<ty::TraitDef> {
 pub fn trait_def_of_item(ccx: &CrateCtxt, it: &ast::Item) -> Rc<ty::TraitDef> {
     let def_id = local_def(it.id);
     let tcx = ccx.tcx;
-    match tcx.trait_defs.borrow().find(&def_id) {
+    match tcx.trait_defs.borrow().get(&def_id) {
         Some(def) => return def.clone(),
         _ => {}
     }
@@ -1486,7 +1486,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: &ast::Item)
                   -> ty::Polytype {
     let def_id = local_def(it.id);
     let tcx = ccx.tcx;
-    match tcx.tcache.borrow().find(&def_id) {
+    match tcx.tcache.borrow().get(&def_id) {
         Some(pty) => return pty.clone(),
         _ => {}
     }
@@ -1528,7 +1528,7 @@ pub fn ty_of_item(ccx: &CrateCtxt, it: &ast::Item)
             return pty;
         }
         ast::ItemTy(ref t, ref generics) => {
-            match tcx.tcache.borrow_mut().find(&local_def(it.id)) {
+            match tcx.tcache.borrow_mut().get(&local_def(it.id)) {
                 Some(pty) => return pty.clone(),
                 None => { }
             }
@@ -1933,7 +1933,7 @@ fn get_or_create_type_parameter_def<'tcx,AC>(this: &AC,
                                              -> ty::TypeParameterDef
     where AC: AstConv<'tcx>
 {
-    match this.tcx().ty_param_defs.borrow().find(&param.id) {
+    match this.tcx().ty_param_defs.borrow().get(&param.id) {
         Some(d) => { return (*d).clone(); }
         None => { }
     }
@@ -2027,13 +2027,13 @@ fn check_bounds_compatible(tcx: &ty::ctxt,
                            span: Span) {
     // Currently the only bound which is incompatible with other bounds is
     // Sized/Unsized.
-    if !param_bounds.builtin_bounds.contains_elem(ty::BoundSized) {
+    if !param_bounds.builtin_bounds.contains(&ty::BoundSized) {
         ty::each_bound_trait_and_supertraits(
             tcx,
             param_bounds.trait_bounds.as_slice(),
             |trait_ref| {
                 let trait_def = ty::lookup_trait_def(tcx, trait_ref.def_id);
-                if trait_def.bounds.builtin_bounds.contains_elem(ty::BoundSized) {
+                if trait_def.bounds.builtin_bounds.contains(&ty::BoundSized) {
                     span_err!(tcx.sess, span, E0129,
                               "incompatible bounds on type parameter `{}`, \
                                bound `{}` does not allow unsized type",
@@ -2136,7 +2136,7 @@ fn merge_param_bounds<'a>(tcx: &ty::ctxt,
         let predicate_param_id =
             tcx.def_map
                .borrow()
-               .find(&predicate.id)
+               .get(&predicate.id)
                .expect("compute_bounds(): resolve didn't resolve the type \
                         parameter identifier in a `where` clause")
                .def_id();

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -1240,7 +1240,7 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
                     ty_queue.push(&*mut_ty.ty);
                 }
                 ast::TyPath(ref path, ref bounds, id) => {
-                    let a_def = match self.tcx.def_map.borrow().find(&id) {
+                    let a_def = match self.tcx.def_map.borrow().get(&id) {
                         None => {
                             self.tcx
                                 .sess

--- a/src/librustc/middle/typeck/infer/region_inference/mod.rs
+++ b/src/librustc/middle/typeck/infer/region_inference/mod.rs
@@ -367,7 +367,7 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
         debug!("RegionVarBindings: add_constraint({})",
                constraint.repr(self.tcx));
 
-        if self.constraints.borrow_mut().insert(constraint, origin) {
+        if self.constraints.borrow_mut().insert(constraint, origin).is_none() {
             if self.in_snapshot() {
                 self.undo_log.borrow_mut().push(AddConstraint(constraint));
             }
@@ -559,7 +559,7 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
                                  new_r: Region|)
                         -> Region {
         let vars = TwoRegions { a: a, b: b };
-        match self.combine_map(t).borrow().find(&vars) {
+        match self.combine_map(t).borrow().get(&vars) {
             Some(&c) => {
                 return ReInfer(ReVar(c));
             }
@@ -991,7 +991,7 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
             debug!("expansion: constraint={} origin={}",
                    constraint.repr(self.tcx),
                    self.constraints.borrow()
-                                   .find(constraint)
+                                   .get(constraint)
                                    .unwrap()
                                    .repr(self.tcx));
             match *constraint {
@@ -1075,7 +1075,7 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
             debug!("contraction: constraint={} origin={}",
                    constraint.repr(self.tcx),
                    self.constraints.borrow()
-                                   .find(constraint)
+                                   .get(constraint)
                                    .unwrap()
                                    .repr(self.tcx));
             match *constraint {

--- a/src/librustc/middle/typeck/infer/sub.rs
+++ b/src/librustc/middle/typeck/infer/sub.rs
@@ -113,7 +113,7 @@ impl<'f, 'tcx> Combine<'tcx> for Sub<'f, 'tcx> {
         // e.g., fn:Copy() <: fn(), because the former is a function
         // that only closes over copyable things, but the latter is
         // any function at all.
-        if a.contains(b) {
+        if a.is_superset(&b) {
             Ok(a)
         } else {
             Err(ty::terr_builtin_bounds(expected_found(self, a, b)))

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -301,7 +301,7 @@ pub fn write_substs_to_tcx(tcx: &ty::ctxt,
     }
 }
 pub fn lookup_def_tcx(tcx:&ty::ctxt, sp: Span, id: ast::NodeId) -> def::Def {
-    match tcx.def_map.borrow().find(&id) {
+    match tcx.def_map.borrow().get(&id) {
         Some(x) => x.clone(),
         _ => {
             tcx.sess.span_fatal(sp, "internal error looking up a definition")

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -322,7 +322,7 @@ impl<'a, 'tcx> TermsContext<'a, 'tcx> {
                                                 index: index,
                                                 param_id: param_id,
                                                 term: term });
-        let newly_added = self.inferred_map.insert(param_id, inf_index);
+        let newly_added = self.inferred_map.insert(param_id, inf_index).is_none();
         assert!(newly_added);
 
         debug!("add_inferred(item_id={}, \
@@ -376,7 +376,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for TermsContext<'a, 'tcx> {
                 if self.num_inferred() == inferreds_on_entry {
                     let newly_added = self.tcx.item_variance_map.borrow_mut().insert(
                         ast_util::local_def(item.id),
-                        self.empty_variances.clone());
+                        self.empty_variances.clone()).is_none();
                     assert!(newly_added);
                 }
 
@@ -556,7 +556,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
     }
 
     fn inferred_index(&self, param_id: ast::NodeId) -> InferredIndex {
-        match self.terms_cx.inferred_map.find(&param_id) {
+        match self.terms_cx.inferred_map.get(&param_id) {
             Some(&index) => index,
             None => {
                 self.tcx().sess.bug(format!(
@@ -569,7 +569,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
     fn find_binding_for_lifetime(&self, param_id: ast::NodeId) -> ast::NodeId {
         let tcx = self.terms_cx.tcx;
         assert!(is_lifetime(&tcx.map, param_id));
-        match tcx.named_region_map.find(&param_id) {
+        match tcx.named_region_map.get(&param_id) {
             Some(&rl::DefEarlyBoundRegion(_, _, lifetime_decl_id))
                 => lifetime_decl_id,
             Some(_) => panic!("should not encounter non early-bound cases"),
@@ -810,7 +810,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
 
             ty::ty_param(ty::ParamTy { ref def_id, .. }) => {
                 assert_eq!(def_id.krate, ast::LOCAL_CRATE);
-                match self.terms_cx.inferred_map.find(&def_id.node) {
+                match self.terms_cx.inferred_map.get(&def_id.node) {
                     Some(&index) => {
                         self.add_constraint(index, variance);
                     }
@@ -1060,7 +1060,7 @@ impl<'a, 'tcx> SolveContext<'a, 'tcx> {
             }
 
             let newly_added = tcx.item_variance_map.borrow_mut()
-                                 .insert(item_def_id, Rc::new(item_variances));
+                                 .insert(item_def_id, Rc::new(item_variances)).is_none();
             assert!(newly_added);
         }
     }

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -139,7 +139,7 @@ pub fn can_reach<S,H:Hasher<S>,T:Eq+Clone+Hash<S>>(
     let mut queue = vec!(source);
     let mut i = 0;
     while i < queue.len() {
-        match edges_map.find(&queue[i]) {
+        match edges_map.get(&queue[i]) {
             Some(edges) => {
                 for target in edges.iter() {
                     if *target == destination {
@@ -200,7 +200,7 @@ pub fn memoized_with_key<T, K: Hash<S> + Eq, U: Clone, S, H: Hasher<S>>(
     k: |&T| -> K
 ) -> U {
     let key = k(&arg);
-    let result = cache.borrow().find(&key).map(|result| result.clone());
+    let result = cache.borrow().get(&key).map(|result| result.clone());
     match result {
         Some(result) => result,
         None => {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -451,7 +451,7 @@ pub fn ty_to_string(cx: &ctxt, typ: t) -> String {
         ty_str => "str".to_string(),
         ty_unboxed_closure(ref did, _, ref substs) => {
             let unboxed_closures = cx.unboxed_closures.borrow();
-            unboxed_closures.find(did).map(|cl| {
+            unboxed_closures.get(did).map(|cl| {
                 closure_to_string(cx, &cl.closure_type.subst(cx, substs))
             }).unwrap_or_else(|| "closure".to_string())
         }
@@ -1108,7 +1108,7 @@ impl UserString for ty::ParamBounds {
 
 impl UserString for ty::ExistentialBounds {
     fn user_string(&self, tcx: &ctxt) -> String {
-        if self.builtin_bounds.contains_elem(ty::BoundSend) &&
+        if self.builtin_bounds.contains(&ty::BoundSend) &&
             self.region_bound == ty::ReStatic
         { // Region bound is implied by builtin bounds:
             return self.builtin_bounds.repr(tcx);
@@ -1277,7 +1277,7 @@ impl UserString for ParamTy {
     fn user_string(&self, tcx: &ctxt) -> String {
         let id = self.idx;
         let did = self.def_id;
-        let ident = match tcx.ty_param_defs.borrow().find(&did.node) {
+        let ident = match tcx.ty_param_defs.borrow().get(&did.node) {
             Some(def) => token::get_name(def.name).get().to_string(),
 
             // This can only happen when a type mismatch error happens and

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -45,7 +45,7 @@ pub fn try_inline(cx: &DocContext, id: ast::NodeId, into: Option<ast::Ident>)
         Some(tcx) => tcx,
         None => return None,
     };
-    let def = match tcx.def_map.borrow().find(&id) {
+    let def = match tcx.def_map.borrow().get(&id) {
         Some(def) => *def,
         None => return None,
     };
@@ -223,7 +223,7 @@ fn build_impls(cx: &DocContext, tcx: &ty::ctxt,
     ty::populate_implementations_for_type_if_necessary(tcx, did);
     let mut impls = Vec::new();
 
-    match tcx.inherent_impls.borrow().find(&did) {
+    match tcx.inherent_impls.borrow().get(&did) {
         None => {}
         Some(i) => {
             impls.extend(i.iter().map(|&did| { build_impl(cx, tcx, did) }));

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1395,7 +1395,7 @@ impl Clean<Item> for ty::field_ty {
         let (name, attrs) = if self.name == unnamed_field.name {
             (None, None)
         } else {
-            (Some(self.name), Some(attr_map.find(&self.id.node).unwrap()))
+            (Some(self.name), Some(attr_map.get(&self.id.node).unwrap()))
         };
 
         let ty = ty::lookup_item_type(cx.tcx(), self.id);
@@ -2090,7 +2090,7 @@ fn resolve_type(cx: &DocContext, path: Path,
         None => return Primitive(Bool),
     };
     debug!("searching for {} in defmap", id);
-    let def = match tcx.def_map.borrow().find(&id) {
+    let def = match tcx.def_map.borrow().get(&id) {
         Some(&k) => k,
         None => panic!("unresolved id not in defmap")
     };
@@ -2159,7 +2159,7 @@ fn resolve_use_source(cx: &DocContext, path: Path, id: ast::NodeId) -> ImportSou
 
 fn resolve_def(cx: &DocContext, id: ast::NodeId) -> Option<ast::DefId> {
     cx.tcx_opt().and_then(|tcx| {
-        tcx.def_map.borrow().find(&id).map(|&def| register_def(cx, def))
+        tcx.def_map.borrow().get(&id).map(|&def| register_def(cx, def))
     })
 }
 

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -208,7 +208,7 @@ fn resolved_path(w: &mut fmt::Formatter, did: ast::DefId, p: &clean::Path,
             }
         },
         |cache| {
-            match cache.paths.find(&did) {
+            match cache.paths.get(&did) {
                 None => None,
                 Some(&(ref fqp, shortty)) => Some((fqp.clone(), shortty))
             }
@@ -313,7 +313,7 @@ fn primitive_link(f: &mut fmt::Formatter,
                   name: &str) -> fmt::Result {
     let m = cache_key.get().unwrap();
     let mut needs_termination = false;
-    match m.primitive_locations.find(&prim) {
+    match m.primitive_locations.get(&prim) {
         Some(&ast::LOCAL_CRATE) => {
             let loc = current_location_key.get().unwrap();
             let len = if loc.len() == 0 {0} else {loc.len() - 1};

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -242,7 +242,7 @@ pub fn render(w: &mut fmt::Formatter, s: &str, print_toc: bool) -> fmt::Result {
 
         // Make sure our hyphenated ID is unique for this page
         let map = used_header_map.get().unwrap();
-        let id = match map.borrow_mut().find_mut(&id) {
+        let id = match map.borrow_mut().get_mut(&id) {
             None => id,
             Some(a) => { *a += 1; format!("{}-{}", id, *a - 1) }
         };

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -389,7 +389,7 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> io::IoResult<String> 
         // has since been learned.
         for &(pid, ref item) in orphan_methods.iter() {
             let did = ast_util::local_def(pid);
-            match paths.find(&did) {
+            match paths.get(&did) {
                 Some(&(ref fqp, _)) => {
                     search_index.push(IndexItem {
                         ty: shortty(item),
@@ -443,7 +443,7 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> io::IoResult<String> 
                     item.desc.to_json().to_string()));
         match item.parent {
             Some(nodeid) => {
-                let pathid = *nodeid_to_pathid.find(&nodeid).unwrap();
+                let pathid = *nodeid_to_pathid.get(&nodeid).unwrap();
                 try!(write!(&mut w, ",{}", pathid));
             }
             None => {}
@@ -454,7 +454,7 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> io::IoResult<String> 
     try!(write!(&mut w, r#"],"paths":["#));
 
     for (i, &did) in pathid_to_nodeid.iter().enumerate() {
-        let &(ref fqp, short) = cache.paths.find(&did).unwrap();
+        let &(ref fqp, short) = cache.paths.get(&did).unwrap();
         if i > 0 {
             try!(write!(&mut w, ","));
         }
@@ -543,7 +543,7 @@ fn write_shared(cx: &Context,
         //
         // FIXME: this is a vague explanation for why this can't be a `get`, in
         //        theory it should be...
-        let &(ref remote_path, remote_item_type) = match cache.paths.find(&did) {
+        let &(ref remote_path, remote_item_type) = match cache.paths.get(&did) {
             Some(p) => p,
             None => continue,
         };
@@ -838,7 +838,7 @@ impl DocFolder for Cache {
                         } else {
                             let last = self.parent_stack.last().unwrap();
                             let did = *last;
-                            let path = match self.paths.find(&did) {
+                            let path = match self.paths.get(&did) {
                                 Some(&(_, item_type::Trait)) =>
                                     Some(self.stack[..self.stack.len() - 1]),
                                 // The current stack not necessarily has correlation for
@@ -1170,7 +1170,7 @@ impl Context {
                                     &Item{ cx: cx, item: it }));
             } else {
                 let mut url = "../".repeat(cx.current.len());
-                match cache_key.get().unwrap().paths.find(&it.def_id) {
+                match cache_key.get().unwrap().paths.get(&it.def_id) {
                     Some(&(ref names, _)) => {
                         for name in names[..names.len() - 1].iter() {
                             url.push_str(name.as_slice());
@@ -1735,7 +1735,7 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
         <h2 id='implementors'>Implementors</h2>
         <ul class='item-list' id='implementors-list'>
     "));
-    match cache.implementors.find(&it.def_id) {
+    match cache.implementors.get(&it.def_id) {
         Some(implementors) => {
             for i in implementors.iter() {
                 try!(writeln!(w, "<li>{}<code>impl{} {} for {}{}</code></li>",
@@ -1992,7 +1992,7 @@ fn render_struct(w: &mut fmt::Formatter, it: &clean::Item,
 }
 
 fn render_methods(w: &mut fmt::Formatter, it: &clean::Item) -> fmt::Result {
-    match cache_key.get().unwrap().impls.find(&it.def_id) {
+    match cache_key.get().unwrap().impls.get(&it.def_id) {
         Some(v) => {
             let (non_trait, traits) = v.partitioned(|i| i.impl_.trait_.is_none());
             if non_trait.len() > 0 {
@@ -2080,7 +2080,7 @@ fn render_impl(w: &mut fmt::Formatter, i: &Impl) -> fmt::Result {
     match i.impl_.trait_ {
         Some(clean::ResolvedPath { did, .. }) => {
             try!({
-                match cache_key.get().unwrap().traits.find(&did) {
+                match cache_key.get().unwrap().traits.get(&did) {
                     Some(t) => try!(render_default_methods(w, t, &i.impl_)),
                     None => {}
                 }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -417,7 +417,7 @@ fn json_input(input: &str) -> Result<Output, String> {
         Ok(json::Object(obj)) => {
             let mut obj = obj;
             // Make sure the schema is what we expect
-            match obj.pop(&"schema".to_string()) {
+            match obj.remove(&"schema".to_string()) {
                 Some(json::String(version)) => {
                     if version.as_slice() != SCHEMA_VERSION {
                         return Err(format!(
@@ -428,7 +428,7 @@ fn json_input(input: &str) -> Result<Output, String> {
                 Some(..) => return Err("malformed json".to_string()),
                 None => return Err("expected a schema version".to_string()),
             }
-            let krate = match obj.pop(&"crate".to_string()) {
+            let krate = match obj.remove(&"crate".to_string()) {
                 Some(json) => {
                     let mut d = json::Decoder::new(json);
                     Decodable::decode(&mut d).unwrap()

--- a/src/librustrt/local_data.rs
+++ b/src/librustrt/local_data.rs
@@ -186,7 +186,7 @@ impl<T: 'static> KeyValue<T> {
 
         // The following match takes a mutable borrow on the map. In order to insert
         // our data if the key isn't present, we need to let the match end first.
-        let data = match (map.find_mut(&keyval), data) {
+        let data = match (map.get_mut(&keyval), data) {
             (None, Some(data)) => {
                 // The key doesn't exist and we need to insert it. To make borrowck
                 // happy, return it up a scope and insert it there.
@@ -266,7 +266,7 @@ impl<T: 'static> KeyValue<T> {
         };
         let keyval = key_to_key_value(self);
 
-        match map.find(&keyval) {
+        match map.get(&keyval) {
             Some(slot) => {
                 let value_box = slot.box_ptr as *mut TLDValueBox<T>;
                 if unsafe { *(*value_box).refcount.get() } >= 1 {

--- a/src/libserialize/collection_impls.rs
+++ b/src/libserialize/collection_impls.rs
@@ -39,7 +39,7 @@ impl<E, D:Decoder<E>,T:Decodable<D, E>> Decodable<D, E> for DList<T> {
         d.read_seq(|d, len| {
             let mut list = DList::new();
             for i in range(0u, len) {
-                list.push(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
+                list.push_back(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
             }
             Ok(list)
         })
@@ -66,7 +66,7 @@ impl<E, D:Decoder<E>,T:Decodable<D, E>> Decodable<D, E> for RingBuf<T> {
         d.read_seq(|d, len| {
             let mut deque: RingBuf<T> = RingBuf::new();
             for i in range(0u, len) {
-                deque.push(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
+                deque.push_back(try!(d.read_seq_elt(i, |d| Decodable::decode(d))));
             }
             Ok(deque)
         })
@@ -165,10 +165,10 @@ impl<
 > Decodable<D, E> for EnumSet<T> {
     fn decode(d: &mut D) -> Result<EnumSet<T>, E> {
         let bits = try!(d.read_uint());
-        let mut set = EnumSet::empty();
+        let mut set = EnumSet::new();
         for bit in range(0, uint::BITS) {
             if bits & (1 << bit) != 0 {
-                set.add(CLike::from_uint(1 << bit));
+                set.insert(CLike::from_uint(1 << bit));
             }
         }
         Ok(set)

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -2113,7 +2113,7 @@ impl ::Decoder<DecoderError> for Decoder {
         let name = match self.pop() {
             String(s) => s,
             Object(mut o) => {
-                let n = match o.pop(&"variant".to_string()) {
+                let n = match o.remove(&"variant".to_string()) {
                     Some(String(s)) => s,
                     Some(val) => {
                         return Err(ExpectedError("String".to_string(), format!("{}", val)))
@@ -2122,7 +2122,7 @@ impl ::Decoder<DecoderError> for Decoder {
                         return Err(MissingFieldError("variant".to_string()))
                     }
                 };
-                match o.pop(&"fields".to_string()) {
+                match o.remove(&"fields".to_string()) {
                     Some(List(l)) => {
                         for field in l.into_iter().rev() {
                             self.stack.push(field);
@@ -2192,7 +2192,7 @@ impl ::Decoder<DecoderError> for Decoder {
         debug!("read_struct_field(name={}, idx={})", name, idx);
         let mut obj = try!(expect!(self.pop(), Object));
 
-        let value = match obj.pop(&name.to_string()) {
+        let value = match obj.remove(&name.to_string()) {
             None => {
                 // Add a Null and try to parse it as an Option<_>
                 // to get None as a default value.
@@ -3072,8 +3072,8 @@ mod tests {
                   \"fields\":[\"Henry\", 349]}}";
         let mut map: TreeMap<string::String, Animal> = super::decode(s).unwrap();
 
-        assert_eq!(map.pop(&"a".to_string()), Some(Dog));
-        assert_eq!(map.pop(&"b".to_string()), Some(Frog("Henry".to_string(), 349)));
+        assert_eq!(map.remove(&"a".to_string()), Some(Dog));
+        assert_eq!(map.remove(&"b".to_string()), Some(Frog("Henry".to_string(), 349)));
     }
 
     #[test]

--- a/src/libstd/collections/hash/bench.rs
+++ b/src/libstd/collections/hash/bench.rs
@@ -102,14 +102,14 @@ fn hashmap_as_queue(b: &mut Bencher) {
     let mut k = 1i;
 
     b.iter(|| {
-        m.pop(&k);
+        m.remove(&k);
         m.insert(k + 1000, k + 1000);
         k += 1;
     });
 }
 
 #[bench]
-fn find_pop_insert(b: &mut Bencher) {
+fn get_remove_insert(b: &mut Bencher) {
     use super::map::HashMap;
 
     let mut m = HashMap::new();
@@ -121,9 +121,9 @@ fn find_pop_insert(b: &mut Bencher) {
     let mut k = 1i;
 
     b.iter(|| {
-        m.find(&(k + 400));
-        m.find(&(k + 2000));
-        m.pop(&k);
+        m.get(&(k + 400));
+        m.get(&(k + 2000));
+        m.remove(&k);
         m.insert(k + 1000, k + 1000);
         k += 1;
     })

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -36,6 +36,9 @@ use super::table::{
     SafeHash
 };
 
+// FIXME(conventions): update capacity management to match other collections (no auto-shrink)
+// FIXME(conventions): axe find_copy/get_copy in favour of Option.cloned (also implement that)
+
 const INITIAL_LOG2_CAP: uint = 5;
 pub const INITIAL_CAPACITY: uint = 1 << INITIAL_LOG2_CAP; // 2^5
 
@@ -233,7 +236,7 @@ impl DefaultResizePolicy {
 /// // look up the values associated with some keys.
 /// let to_find = ["Pride and Prejudice", "Alice's Adventure in Wonderland"];
 /// for book in to_find.iter() {
-///     match book_reviews.find(book) {
+///     match book_reviews.get(book) {
 ///         Some(review) => println!("{}: {}", *book, *review),
 ///         None => println!("{} is unreviewed.", *book)
 ///     }
@@ -480,6 +483,7 @@ impl<K: Hash + Eq, V> HashMap<K, V, RandomSipHasher> {
     /// let mut map: HashMap<&str, int> = HashMap::with_capacity(10);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn new() -> HashMap<K, V, RandomSipHasher> {
         let hasher = RandomSipHasher::new();
         HashMap::with_hasher(hasher)
@@ -494,6 +498,7 @@ impl<K: Hash + Eq, V> HashMap<K, V, RandomSipHasher> {
     /// let mut map: HashMap<&str, int> = HashMap::with_capacity(10);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn with_capacity(capacity: uint) -> HashMap<K, V, RandomSipHasher> {
         let hasher = RandomSipHasher::new();
         HashMap::with_capacity_and_hasher(capacity, hasher)
@@ -741,38 +746,6 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
         }
     }
 
-    /// Retrieves a mutable value for the given key.
-    /// See [`find_mut`](../trait.MutableMap.html#tymethod.find_mut) for a non-panicking
-    /// alternative.
-    ///
-    /// # Failure
-    ///
-    /// Fails if the key is not present.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use std::collections::HashMap;
-    ///
-    /// let mut map = HashMap::new();
-    /// map.insert("a", 1i);
-    /// {
-    ///     // val will freeze map to prevent usage during its lifetime
-    ///     let val = map.get_mut(&"a");
-    ///     *val = 40;
-    /// }
-    /// assert_eq!(map["a"], 40);
-    ///
-    /// // A more direct way could be:
-    /// *map.get_mut(&"a") = -2;
-    /// assert_eq!(map["a"], -2);
-    /// ```
-    #[deprecated = "use indexing instead: `&mut map[key]`"]
-    pub fn get_mut<'a>(&'a mut self, k: &K) -> &'a mut V {
-        &mut self[*k]
-    }
-
     /// Return true if the map contains a value for the specified key,
     /// using equivalence.
     ///
@@ -875,6 +848,7 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     ///     println!("{}", key);
     /// }
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn keys(&self) -> Keys<K, V> {
         self.iter().map(|(k, _v)| k)
     }
@@ -896,6 +870,7 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     ///     println!("{}", key);
     /// }
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn values(&self) -> Values<K, V> {
         self.iter().map(|(_k, v)| v)
     }
@@ -917,6 +892,7 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     ///     println!("key: {} val: {}", key, val);
     /// }
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter(&self) -> Entries<K, V> {
         Entries { inner: self.table.iter() }
     }
@@ -944,6 +920,7 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     ///     println!("key: {} val: {}", key, val);
     /// }
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter_mut(&mut self) -> MutEntries<K, V> {
         MutEntries { inner: self.table.iter_mut() }
     }
@@ -965,6 +942,7 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     /// // Not possible with .iter()
     /// let vec: Vec<(&str, int)> = map.into_iter().collect();
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn into_iter(self) -> MoveEntries<K, V> {
         MoveEntries {
             inner: self.table.into_iter().map(|(_, k, v)| (k, v))
@@ -996,6 +974,7 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     /// a.insert(1u, "a");
     /// assert_eq!(a.len(), 1);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn len(&self) -> uint { self.table.size() }
 
     /// Return true if the map contains no elements.
@@ -1011,6 +990,7 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     /// assert!(!a.is_empty());
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_empty(&self) -> bool { self.len() == 0 }
 
     /// Clears the map, removing all key-value pairs. Keeps the allocated memory
@@ -1026,6 +1006,7 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     /// a.clear();
     /// assert!(a.is_empty());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn clear(&mut self) {
         // Prevent reallocations from happening from now on. Makes it possible
         // for the map to be reused but has a downside: reserves permanently.
@@ -1045,6 +1026,12 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
         }
     }
 
+    /// Deprecated: Renamed to `get`.
+    #[deprecated = "Renamed to `get`"]
+    pub fn find(&self, k: &K) -> Option<&V> {
+        self.get(k)
+    }
+
     /// Returns a reference to the value corresponding to the key.
     ///
     /// # Example
@@ -1054,10 +1041,11 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     ///
     /// let mut map = HashMap::new();
     /// map.insert(1u, "a");
-    /// assert_eq!(map.find(&1), Some(&"a"));
-    /// assert_eq!(map.find(&2), None);
+    /// assert_eq!(map.get(&1), Some(&"a"));
+    /// assert_eq!(map.get(&2), None);
     /// ```
-    pub fn find<'a>(&'a self, k: &K) -> Option<&'a V> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn get(&self, k: &K) -> Option<&V> {
         self.search(k).map(|bucket| {
             let (_, v) = bucket.into_refs();
             v
@@ -1076,8 +1064,15 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     /// assert_eq!(map.contains_key(&1), true);
     /// assert_eq!(map.contains_key(&2), false);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn contains_key(&self, k: &K) -> bool {
         self.search(k).is_some()
+    }
+
+    /// Deprecated: Renamed to `get_mut`.
+    #[deprecated = "Renamed to `get_mut`"]
+    pub fn find_mut(&mut self, k: &K) -> Option<&mut V> {
+        self.get_mut(k)
     }
 
     /// Returns a mutable reference to the value corresponding to the key.
@@ -1089,13 +1084,14 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     ///
     /// let mut map = HashMap::new();
     /// map.insert(1u, "a");
-    /// match map.find_mut(&1) {
+    /// match map.get_mut(&1) {
     ///     Some(x) => *x = "b",
     ///     None => (),
     /// }
     /// assert_eq!(map[1], "b");
     /// ```
-    pub fn find_mut<'a>(&'a mut self, k: &K) -> Option<&'a mut V> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn get_mut(&mut self, k: &K) -> Option<&mut V> {
         match self.search_mut(k) {
             Some(bucket) => {
                 let (_, v) = bucket.into_mut_refs();
@@ -1105,41 +1101,10 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
         }
     }
 
-    /// Inserts a key-value pair into the map. An existing value for a
-    /// key is replaced by the new value. Returns `true` if the key did
-    /// not already exist in the map.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use std::collections::HashMap;
-    ///
-    /// let mut map = HashMap::new();
-    /// assert_eq!(map.insert(2u, "value"), true);
-    /// assert_eq!(map.insert(2, "value2"), false);
-    /// assert_eq!(map[2], "value2");
-    /// ```
-    #[inline]
-    pub fn insert(&mut self, key: K, value: V) -> bool {
-        self.swap(key, value).is_none()
-    }
-
-    /// Removes a key-value pair from the map. Returns `true` if the key
-    /// was present in the map.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use std::collections::HashMap;
-    ///
-    /// let mut map = HashMap::new();
-    /// assert_eq!(map.remove(&1u), false);
-    /// map.insert(1, "a");
-    /// assert_eq!(map.remove(&1), true);
-    /// ```
-    #[inline]
-    pub fn remove(&mut self, key: &K) -> bool {
-        self.pop(key).is_some()
+    /// Deprecated: Renamed to `insert`.
+    #[deprecated = "Renamed to `insert`"]
+    pub fn swap(&mut self, k: K, v: V) -> Option<V> {
+        self.insert(k, v)
     }
 
     /// Inserts a key-value pair from the map. If the key already had a value
@@ -1151,14 +1116,15 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     /// use std::collections::HashMap;
     ///
     /// let mut map = HashMap::new();
-    /// assert_eq!(map.swap(37u, "a"), None);
+    /// assert_eq!(map.insert(37u, "a"), None);
     /// assert_eq!(map.is_empty(), false);
     ///
     /// map.insert(37, "b");
-    /// assert_eq!(map.swap(37, "c"), Some("b"));
+    /// assert_eq!(map.insert(37, "c"), Some("b"));
     /// assert_eq!(map[37], "c");
     /// ```
-    pub fn swap(&mut self, k: K, v: V) -> Option<V> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn insert(&mut self, k: K, v: V) -> Option<V> {
         let hash = self.make_hash(&k);
         let potential_new_size = self.table.size() + 1;
         self.make_some_room(potential_new_size);
@@ -1168,6 +1134,12 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
             retval = Some(replace(val_ref, val));
         });
         retval
+    }
+
+    /// Deprecated: Renamed to `remove`.
+    #[deprecated = "Renamed to `remove`"]
+    pub fn pop(&mut self, k: &K) -> Option<V> {
+        self.remove(k)
     }
 
     /// Removes a key from the map, returning the value at the key if the key
@@ -1180,10 +1152,11 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     ///
     /// let mut map = HashMap::new();
     /// map.insert(1u, "a");
-    /// assert_eq!(map.pop(&1), Some("a"));
-    /// assert_eq!(map.pop(&1), None);
+    /// assert_eq!(map.remove(&1), Some("a"));
+    /// assert_eq!(map.remove(&1), None);
     /// ```
-    pub fn pop(&mut self, k: &K) -> Option<V> {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn remove(&mut self, k: &K) -> Option<V> {
         if self.table.size() == 0 {
             return None
         }
@@ -1260,7 +1233,7 @@ impl<K: Eq + Hash<S>, V: Clone, S, H: Hasher<S>> HashMap<K, V, H> {
     /// let s: String = map.find_copy(&1).unwrap();
     /// ```
     pub fn find_copy(&self, k: &K) -> Option<V> {
-        self.find(k).map(|v| (*v).clone())
+        self.get(k).map(|v| (*v).clone())
     }
 
     /// Return a copy of the value corresponding to the key.
@@ -1288,7 +1261,7 @@ impl<K: Eq + Hash<S>, V: PartialEq, S, H: Hasher<S>> PartialEq for HashMap<K, V,
         if self.len() != other.len() { return false; }
 
         self.iter().all(|(key, value)|
-            other.find(key).map_or(false, |v| *value == *v)
+            other.get(key).map_or(false, |v| *value == *v)
         )
     }
 }
@@ -1317,14 +1290,14 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S> + Default> Default for HashMap<K, V, H>
 impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> Index<K, V> for HashMap<K, V, H> {
     #[inline]
     fn index<'a>(&'a self, index: &K) -> &'a V {
-        self.find(index).expect("no entry found for key")
+        self.get(index).expect("no entry found for key")
     }
 }
 
 impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> IndexMut<K, V> for HashMap<K, V, H> {
     #[inline]
     fn index_mut<'a>(&'a mut self, index: &K) -> &'a mut V {
-        match self.find_mut(index) {
+        match self.get_mut(index) {
             Some(v) => v,
             None => panic!("no entry found for key")
         }
@@ -1514,7 +1487,7 @@ mod test_map {
     fn test_create_capacity_zero() {
         let mut m = HashMap::with_capacity(0);
 
-        assert!(m.insert(1i, 1i));
+        assert!(m.insert(1i, 1i).is_none());
 
         assert!(m.contains_key(&1));
         assert!(!m.contains_key(&0));
@@ -1524,12 +1497,12 @@ mod test_map {
     fn test_insert() {
         let mut m = HashMap::new();
         assert_eq!(m.len(), 0);
-        assert!(m.insert(1i, 2i));
+        assert!(m.insert(1i, 2i).is_none());
         assert_eq!(m.len(), 1);
-        assert!(m.insert(2i, 4i));
+        assert!(m.insert(2i, 4i).is_none());
         assert_eq!(m.len(), 2);
-        assert_eq!(*m.find(&1).unwrap(), 2);
-        assert_eq!(*m.find(&2).unwrap(), 4);
+        assert_eq!(*m.get(&1).unwrap(), 2);
+        assert_eq!(*m.get(&2).unwrap(), 4);
     }
 
     local_data_key!(drop_vector: RefCell<Vec<int>>)
@@ -1588,7 +1561,7 @@ mod test_map {
 
             for i in range(0u, 50) {
                 let k = Dropable::new(i);
-                let v = m.pop(&k);
+                let v = m.remove(&k);
 
                 assert!(v.is_some());
 
@@ -1679,7 +1652,7 @@ mod test_map {
     #[test]
     fn test_empty_pop() {
         let mut m: HashMap<int, bool> = HashMap::new();
-        assert_eq!(m.pop(&0), None);
+        assert_eq!(m.remove(&0), None);
     }
 
     #[test]
@@ -1692,15 +1665,15 @@ mod test_map {
             assert!(m.is_empty());
 
             for i in range_inclusive(1i, 1000) {
-                assert!(m.insert(i, i));
+                assert!(m.insert(i, i).is_none());
 
                 for j in range_inclusive(1, i) {
-                    let r = m.find(&j);
+                    let r = m.get(&j);
                     assert_eq!(r, Some(&j));
                 }
 
                 for j in range_inclusive(i+1, 1000) {
-                    let r = m.find(&j);
+                    let r = m.get(&j);
                     assert_eq!(r, None);
                 }
             }
@@ -1711,7 +1684,7 @@ mod test_map {
 
             // remove forwards
             for i in range_inclusive(1i, 1000) {
-                assert!(m.remove(&i));
+                assert!(m.remove(&i).is_some());
 
                 for j in range_inclusive(1, i) {
                     assert!(!m.contains_key(&j));
@@ -1727,12 +1700,12 @@ mod test_map {
             }
 
             for i in range_inclusive(1i, 1000) {
-                assert!(m.insert(i, i));
+                assert!(m.insert(i, i).is_none());
             }
 
             // remove backwards
             for i in range_step_inclusive(1000i, 1, -1) {
-                assert!(m.remove(&i));
+                assert!(m.remove(&i).is_some());
 
                 for j in range_inclusive(i, 1000) {
                     assert!(!m.contains_key(&j));
@@ -1748,59 +1721,59 @@ mod test_map {
     #[test]
     fn test_find_mut() {
         let mut m = HashMap::new();
-        assert!(m.insert(1i, 12i));
-        assert!(m.insert(2i, 8i));
-        assert!(m.insert(5i, 14i));
+        assert!(m.insert(1i, 12i).is_none());
+        assert!(m.insert(2i, 8i).is_none());
+        assert!(m.insert(5i, 14i).is_none());
         let new = 100;
-        match m.find_mut(&5) {
+        match m.get_mut(&5) {
             None => panic!(), Some(x) => *x = new
         }
-        assert_eq!(m.find(&5), Some(&new));
+        assert_eq!(m.get(&5), Some(&new));
     }
 
     #[test]
     fn test_insert_overwrite() {
         let mut m = HashMap::new();
-        assert!(m.insert(1i, 2i));
-        assert_eq!(*m.find(&1).unwrap(), 2);
-        assert!(!m.insert(1i, 3i));
-        assert_eq!(*m.find(&1).unwrap(), 3);
+        assert!(m.insert(1i, 2i).is_none());
+        assert_eq!(*m.get(&1).unwrap(), 2);
+        assert!(!m.insert(1i, 3i).is_none());
+        assert_eq!(*m.get(&1).unwrap(), 3);
     }
 
     #[test]
     fn test_insert_conflicts() {
         let mut m = HashMap::with_capacity(4);
-        assert!(m.insert(1i, 2i));
-        assert!(m.insert(5i, 3i));
-        assert!(m.insert(9i, 4i));
-        assert_eq!(*m.find(&9).unwrap(), 4);
-        assert_eq!(*m.find(&5).unwrap(), 3);
-        assert_eq!(*m.find(&1).unwrap(), 2);
+        assert!(m.insert(1i, 2i).is_none());
+        assert!(m.insert(5i, 3i).is_none());
+        assert!(m.insert(9i, 4i).is_none());
+        assert_eq!(*m.get(&9).unwrap(), 4);
+        assert_eq!(*m.get(&5).unwrap(), 3);
+        assert_eq!(*m.get(&1).unwrap(), 2);
     }
 
     #[test]
     fn test_conflict_remove() {
         let mut m = HashMap::with_capacity(4);
-        assert!(m.insert(1i, 2i));
-        assert_eq!(*m.find(&1).unwrap(), 2);
-        assert!(m.insert(5, 3));
-        assert_eq!(*m.find(&1).unwrap(), 2);
-        assert_eq!(*m.find(&5).unwrap(), 3);
-        assert!(m.insert(9, 4));
-        assert_eq!(*m.find(&1).unwrap(), 2);
-        assert_eq!(*m.find(&5).unwrap(), 3);
-        assert_eq!(*m.find(&9).unwrap(), 4);
-        assert!(m.remove(&1));
-        assert_eq!(*m.find(&9).unwrap(), 4);
-        assert_eq!(*m.find(&5).unwrap(), 3);
+        assert!(m.insert(1i, 2i).is_none());
+        assert_eq!(*m.get(&1).unwrap(), 2);
+        assert!(m.insert(5, 3).is_none());
+        assert_eq!(*m.get(&1).unwrap(), 2);
+        assert_eq!(*m.get(&5).unwrap(), 3);
+        assert!(m.insert(9, 4).is_none());
+        assert_eq!(*m.get(&1).unwrap(), 2);
+        assert_eq!(*m.get(&5).unwrap(), 3);
+        assert_eq!(*m.get(&9).unwrap(), 4);
+        assert!(m.remove(&1).is_some());
+        assert_eq!(*m.get(&9).unwrap(), 4);
+        assert_eq!(*m.get(&5).unwrap(), 3);
     }
 
     #[test]
     fn test_is_empty() {
         let mut m = HashMap::with_capacity(4);
-        assert!(m.insert(1i, 2i));
+        assert!(m.insert(1i, 2i).is_none());
         assert!(!m.is_empty());
-        assert!(m.remove(&1));
+        assert!(m.remove(&1).is_some());
         assert!(m.is_empty());
     }
 
@@ -1808,8 +1781,8 @@ mod test_map {
     fn test_pop() {
         let mut m = HashMap::new();
         m.insert(1i, 2i);
-        assert_eq!(m.pop(&1), Some(2));
-        assert_eq!(m.pop(&1), None);
+        assert_eq!(m.remove(&1), Some(2));
+        assert_eq!(m.remove(&1), None);
     }
 
     #[test]
@@ -1822,18 +1795,10 @@ mod test_map {
     }
 
     #[test]
-    fn test_swap() {
-        let mut m = HashMap::new();
-        assert_eq!(m.swap(1i, 2i), None);
-        assert_eq!(m.swap(1i, 3i), Some(2));
-        assert_eq!(m.swap(1i, 4i), Some(3));
-    }
-
-    #[test]
     fn test_iterate() {
         let mut m = HashMap::with_capacity(4);
         for i in range(0u, 32) {
-            assert!(m.insert(i, i*2));
+            assert!(m.insert(i, i*2).is_none());
         }
         assert_eq!(m.len(), 32);
 
@@ -1871,9 +1836,9 @@ mod test_map {
     #[test]
     fn test_find() {
         let mut m = HashMap::new();
-        assert!(m.find(&1i).is_none());
+        assert!(m.get(&1i).is_none());
         m.insert(1i, 2i);
-        match m.find(&1) {
+        match m.get(&1) {
             None => panic!(),
             Some(v) => assert_eq!(*v, 2)
         }
@@ -1882,7 +1847,7 @@ mod test_map {
     #[test]
     fn test_find_copy() {
         let mut m = HashMap::new();
-        assert!(m.find(&1i).is_none());
+        assert!(m.get(&1i).is_none());
 
         for i in range(1i, 10000) {
             m.insert(i, i + 7);
@@ -2026,7 +1991,7 @@ mod test_map {
         let map: HashMap<int, int> = xs.iter().map(|&x| x).collect();
 
         for &(k, v) in xs.iter() {
-            assert_eq!(map.find(&k), Some(&v));
+            assert_eq!(map.get(&k), Some(&v));
         }
     }
 
@@ -2093,7 +2058,7 @@ mod test_map {
                 assert_eq!(view.set(100), 10);
             }
         }
-        assert_eq!(map.find(&1).unwrap(), &100);
+        assert_eq!(map.get(&1).unwrap(), &100);
         assert_eq!(map.len(), 6);
 
 
@@ -2106,7 +2071,7 @@ mod test_map {
                 *v = new_v;
             }
         }
-        assert_eq!(map.find(&2).unwrap(), &200);
+        assert_eq!(map.get(&2).unwrap(), &200);
         assert_eq!(map.len(), 6);
 
         // Existing key (take)
@@ -2116,7 +2081,7 @@ mod test_map {
                 assert_eq!(view.take(), 30);
             }
         }
-        assert_eq!(map.find(&3), None);
+        assert_eq!(map.get(&3), None);
         assert_eq!(map.len(), 5);
 
 
@@ -2127,7 +2092,7 @@ mod test_map {
                 assert_eq!(*view.set(1000), 1000);
             }
         }
-        assert_eq!(map.find(&10).unwrap(), &1000);
+        assert_eq!(map.get(&10).unwrap(), &1000);
         assert_eq!(map.len(), 6);
     }
 }

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -23,6 +23,9 @@ use result::{Ok, Err};
 
 use super::map::{HashMap, Entries, MoveEntries, INITIAL_CAPACITY};
 
+// FIXME(conventions): implement BitOr, BitAnd, BitXor, and Sub
+// FIXME(conventions): update capacity management to match other collections (no auto-shrink)
+
 
 // Future Optimization (FIXME!)
 // =============================
@@ -103,6 +106,7 @@ impl<T: Hash + Eq> HashSet<T, RandomSipHasher> {
     /// let mut set: HashSet<int> = HashSet::new();
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn new() -> HashSet<T, RandomSipHasher> {
         HashSet::with_capacity(INITIAL_CAPACITY)
     }
@@ -117,6 +121,7 @@ impl<T: Hash + Eq> HashSet<T, RandomSipHasher> {
     /// let mut set: HashSet<int> = HashSet::with_capacity(10);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn with_capacity(capacity: uint) -> HashSet<T, RandomSipHasher> {
         HashSet { map: HashMap::with_capacity(capacity) }
     }
@@ -240,14 +245,9 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     ///     println!("{}", x);
     /// }
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter<'a>(&'a self) -> SetItems<'a, T> {
         self.map.keys()
-    }
-
-    /// Deprecated: use `into_iter`.
-    #[deprecated = "use into_iter"]
-    pub fn move_iter(self) -> SetMoveItems<T> {
-        self.into_iter()
     }
 
     /// Creates a consuming iterator, that is, one that moves each value out
@@ -270,6 +270,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     ///     println!("{}", x);
     /// }
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn into_iter(self) -> SetMoveItems<T> {
         self.map.into_iter().map(|(k, _)| k)
     }
@@ -296,6 +297,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     /// let diff: HashSet<int> = b.difference(&a).map(|&x| x).collect();
     /// assert_eq!(diff, [4i].iter().map(|&x| x).collect());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn difference<'a>(&'a self, other: &'a HashSet<T, H>) -> SetAlgebraItems<'a, T, H> {
         Repeat::new(other).zip(self.iter())
             .filter_map(|(other, elt)| {
@@ -323,6 +325,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     /// assert_eq!(diff1, diff2);
     /// assert_eq!(diff1, [1i, 4].iter().map(|&x| x).collect());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn symmetric_difference<'a>(&'a self, other: &'a HashSet<T, H>)
         -> Chain<SetAlgebraItems<'a, T, H>, SetAlgebraItems<'a, T, H>> {
         self.difference(other).chain(other.difference(self))
@@ -345,6 +348,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     /// let diff: HashSet<int> = a.intersection(&b).map(|&x| x).collect();
     /// assert_eq!(diff, [2i, 3].iter().map(|&x| x).collect());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn intersection<'a>(&'a self, other: &'a HashSet<T, H>)
         -> SetAlgebraItems<'a, T, H> {
         Repeat::new(other).zip(self.iter())
@@ -370,6 +374,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     /// let diff: HashSet<int> = a.union(&b).map(|&x| x).collect();
     /// assert_eq!(diff, [1i, 2, 3, 4].iter().map(|&x| x).collect());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn union<'a>(&'a self, other: &'a HashSet<T, H>)
         -> Chain<SetItems<'a, T>, SetAlgebraItems<'a, T, H>> {
         self.iter().chain(other.difference(self))
@@ -387,6 +392,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     /// v.insert(1u);
     /// assert_eq!(v.len(), 1);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn len(&self) -> uint { self.map.len() }
 
     /// Returns true if the set contains no elements
@@ -401,6 +407,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     /// v.insert(1u);
     /// assert!(!v.is_empty());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_empty(&self) -> bool { self.map.len() == 0 }
 
     /// Clears the set, removing all values.
@@ -415,6 +422,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     /// v.clear();
     /// assert!(v.is_empty());
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn clear(&mut self) { self.map.clear() }
 
     /// Returns `true` if the set contains a value.
@@ -428,6 +436,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     /// assert_eq!(set.contains(&1), true);
     /// assert_eq!(set.contains(&4), false);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn contains(&self, value: &T) -> bool { self.map.contains_key(value) }
 
     /// Returns `true` if the set has no elements in common with `other`.
@@ -447,6 +456,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     /// b.insert(1);
     /// assert_eq!(a.is_disjoint(&b), false);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_disjoint(&self, other: &HashSet<T, H>) -> bool {
         self.iter().all(|v| !other.contains(v))
     }
@@ -467,6 +477,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     /// set.insert(4);
     /// assert_eq!(set.is_subset(&sup), false);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_subset(&self, other: &HashSet<T, H>) -> bool {
         self.iter().all(|v| other.contains(v))
     }
@@ -491,6 +502,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     /// assert_eq!(set.is_superset(&sub), true);
     /// ```
     #[inline]
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_superset(&self, other: &HashSet<T, H>) -> bool {
         other.is_subset(self)
     }
@@ -509,7 +521,8 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     /// assert_eq!(set.insert(2), false);
     /// assert_eq!(set.len(), 1);
     /// ```
-    pub fn insert(&mut self, value: T) -> bool { self.map.insert(value, ()) }
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn insert(&mut self, value: T) -> bool { self.map.insert(value, ()).is_none() }
 
     /// Removes a value from the set. Returns `true` if the value was
     /// present in the set.
@@ -525,7 +538,8 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     /// assert_eq!(set.remove(&2), true);
     /// assert_eq!(set.remove(&2), false);
     /// ```
-    pub fn remove(&mut self, value: &T) -> bool { self.map.remove(value) }
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn remove(&mut self, value: &T) -> bool { self.map.remove(value).is_some() }
 }
 
 impl<T: Eq + Hash<S>, S, H: Hasher<S>> PartialEq for HashSet<T, H> {

--- a/src/libstd/collections/lru_cache.rs
+++ b/src/libstd/collections/lru_cache.rs
@@ -20,20 +20,20 @@
 //! use std::collections::LruCache;
 //!
 //! let mut cache: LruCache<int, int> = LruCache::new(2);
-//! cache.put(1, 10);
-//! cache.put(2, 20);
-//! cache.put(3, 30);
+//! cache.insert(1, 10);
+//! cache.insert(2, 20);
+//! cache.insert(3, 30);
 //! assert!(cache.get(&1).is_none());
 //! assert_eq!(*cache.get(&2).unwrap(), 20);
 //! assert_eq!(*cache.get(&3).unwrap(), 30);
 //!
-//! cache.put(2, 22);
+//! cache.insert(2, 22);
 //! assert_eq!(*cache.get(&2).unwrap(), 22);
 //!
-//! cache.put(6, 60);
+//! cache.insert(6, 60);
 //! assert!(cache.get(&3).is_none());
 //!
-//! cache.change_capacity(1);
+//! cache.set_capacity(1);
 //! assert!(cache.get(&2).is_none());
 //! ```
 
@@ -48,6 +48,9 @@ use option::{Some, None, Option};
 use boxed::Box;
 use ptr;
 use result::{Ok, Err};
+
+// FIXME(conventions): implement iterators?
+// FIXME(conventions): implement indexing?
 
 struct KeyRef<K> { k: *const K }
 
@@ -99,6 +102,7 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
     /// use std::collections::LruCache;
     /// let mut cache: LruCache<int, &str> = LruCache::new(10);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn new(capacity: uint) -> LruCache<K, V> {
         let cache = LruCache {
             map: HashMap::new(),
@@ -112,7 +116,14 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
         return cache;
     }
 
-    /// Put a key-value pair into cache.
+    /// Deprecated: Replaced with `insert`.
+    #[deprecated = "Replaced with `insert`"]
+    pub fn put(&mut self, k: K, v: V) {
+        self.insert(k, v);
+    }
+
+    /// Inserts a key-value pair into the cache. If the key already existed, the old value is
+    /// returned.
     ///
     /// # Example
     ///
@@ -120,22 +131,23 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
     /// use std::collections::LruCache;
     /// let mut cache = LruCache::new(2);
     ///
-    /// cache.put(1i, "a");
-    /// cache.put(2, "b");
+    /// cache.insert(1i, "a");
+    /// cache.insert(2, "b");
     /// assert_eq!(cache.get(&1), Some(&"a"));
     /// assert_eq!(cache.get(&2), Some(&"b"));
     /// ```
-    pub fn put(&mut self, k: K, v: V) {
-        let (node_ptr, node_opt) = match self.map.find_mut(&KeyRef{k: &k}) {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn insert(&mut self, k: K, v: V) -> Option<V> {
+        let (node_ptr, node_opt, old_val) = match self.map.get_mut(&KeyRef{k: &k}) {
             Some(node) => {
-                node.value = v;
+                let old_val = mem::replace(&mut node.value, v);
                 let node_ptr: *mut LruEntry<K, V> = &mut **node;
-                (node_ptr, None)
+                (node_ptr, None, Some(old_val))
             }
             None => {
                 let mut node = box LruEntry::new(k, v);
                 let node_ptr: *mut LruEntry<K, V> = &mut *node;
-                (node_ptr, Some(node))
+                (node_ptr, Some(node), None)
             }
         };
         match node_opt {
@@ -146,13 +158,14 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
             }
             Some(node) => {
                 let keyref = unsafe { &(*node_ptr).key };
-                self.map.swap(KeyRef{k: keyref}, node);
+                self.map.insert(KeyRef{k: keyref}, node);
                 self.attach(node_ptr);
                 if self.len() > self.capacity() {
                     self.remove_lru();
                 }
             }
         }
+        old_val
     }
 
     /// Return a value corresponding to the key in the cache.
@@ -163,16 +176,17 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
     /// use std::collections::LruCache;
     /// let mut cache = LruCache::new(2);
     ///
-    /// cache.put(1i, "a");
-    /// cache.put(2, "b");
-    /// cache.put(2, "c");
-    /// cache.put(3, "d");
+    /// cache.insert(1i, "a");
+    /// cache.insert(2, "b");
+    /// cache.insert(2, "c");
+    /// cache.insert(3, "d");
     ///
     /// assert_eq!(cache.get(&1), None);
     /// assert_eq!(cache.get(&2), Some(&"c"));
     /// ```
-    pub fn get<'a>(&'a mut self, k: &K) -> Option<&'a V> {
-        let (value, node_ptr_opt) = match self.map.find_mut(&KeyRef{k: k}) {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn get(&mut self, k: &K) -> Option<&V> {
+        let (value, node_ptr_opt) = match self.map.get_mut(&KeyRef{k: k}) {
             None => (None, None),
             Some(node) => {
                 let node_ptr: *mut LruEntry<K, V> = &mut **node;
@@ -189,6 +203,12 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
         return value;
     }
 
+    /// Deprecated: Renamed to `remove`.
+    #[deprecated = "Renamed to `remove`"]
+    pub fn pop(&mut self, k: &K) -> Option<V> {
+        self.remove(k)
+    }
+
     /// Remove and return a value corresponding to the key from the cache.
     ///
     /// # Example
@@ -197,15 +217,16 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
     /// use std::collections::LruCache;
     /// let mut cache = LruCache::new(2);
     ///
-    /// cache.put(2i, "a");
+    /// cache.insert(2i, "a");
     ///
-    /// assert_eq!(cache.pop(&1), None);
-    /// assert_eq!(cache.pop(&2), Some("a"));
-    /// assert_eq!(cache.pop(&2), None);
+    /// assert_eq!(cache.remove(&1), None);
+    /// assert_eq!(cache.remove(&2), Some("a"));
+    /// assert_eq!(cache.remove(&2), None);
     /// assert_eq!(cache.len(), 0);
     /// ```
-    pub fn pop(&mut self, k: &K) -> Option<V> {
-        match self.map.pop(&KeyRef{k: k}) {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn remove(&mut self, k: &K) -> Option<V> {
+        match self.map.remove(&KeyRef{k: k}) {
             None => None,
             Some(lru_entry) => Some(lru_entry.value)
         }
@@ -220,8 +241,15 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
     /// let mut cache: LruCache<int, &str> = LruCache::new(2);
     /// assert_eq!(cache.capacity(), 2);
     /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn capacity(&self) -> uint {
         self.max_size
+    }
+
+    /// Deprecated: Renamed to `set_capacity`.
+    #[deprecated = "Renamed to `set_capacity`"]
+    pub fn change_capacity(&mut self, capacity: uint) {
+        self.set_capacity(capacity)
     }
 
     /// Change the number of key-value pairs the cache can hold. Remove
@@ -233,29 +261,30 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
     /// use std::collections::LruCache;
     /// let mut cache = LruCache::new(2);
     ///
-    /// cache.put(1i, "a");
-    /// cache.put(2, "b");
-    /// cache.put(3, "c");
+    /// cache.insert(1i, "a");
+    /// cache.insert(2, "b");
+    /// cache.insert(3, "c");
     ///
     /// assert_eq!(cache.get(&1), None);
     /// assert_eq!(cache.get(&2), Some(&"b"));
     /// assert_eq!(cache.get(&3), Some(&"c"));
     ///
-    /// cache.change_capacity(3);
-    /// cache.put(1i, "a");
-    /// cache.put(2, "b");
+    /// cache.set_capacity(3);
+    /// cache.insert(1i, "a");
+    /// cache.insert(2, "b");
     ///
     /// assert_eq!(cache.get(&1), Some(&"a"));
     /// assert_eq!(cache.get(&2), Some(&"b"));
     /// assert_eq!(cache.get(&3), Some(&"c"));
     ///
-    /// cache.change_capacity(1);
+    /// cache.set_capacity(1);
     ///
     /// assert_eq!(cache.get(&1), None);
     /// assert_eq!(cache.get(&2), None);
     /// assert_eq!(cache.get(&3), Some(&"c"));
     /// ```
-    pub fn change_capacity(&mut self, capacity: uint) {
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn set_capacity(&mut self, capacity: uint) {
         for _ in range(capacity, self.len()) {
             self.remove_lru();
         }
@@ -267,7 +296,7 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
         if self.len() > 0 {
             let lru = unsafe { (*self.head).prev };
             self.detach(lru);
-            self.map.pop(&KeyRef{k: unsafe { &(*lru).key }});
+            self.map.remove(&KeyRef{k: unsafe { &(*lru).key }});
         }
     }
 
@@ -290,12 +319,15 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
     }
 
     /// Return the number of key-value pairs in the cache.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn len(&self) -> uint { self.map.len() }
 
     /// Returns whether the cache is currently empty.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn is_empty(&self) -> bool { self.len() == 0 }
 
     /// Clear the cache of all key-value pairs.
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn clear(&mut self) { self.map.clear(); }
 }
 
@@ -347,8 +379,8 @@ mod tests {
     #[test]
     fn test_put_and_get() {
         let mut cache: LruCache<int, int> = LruCache::new(2);
-        cache.put(1, 10);
-        cache.put(2, 20);
+        cache.insert(1, 10);
+        cache.insert(2, 20);
         assert_opt_eq(cache.get(&1), 10);
         assert_opt_eq(cache.get(&2), 20);
         assert_eq!(cache.len(), 2);
@@ -357,8 +389,8 @@ mod tests {
     #[test]
     fn test_put_update() {
         let mut cache: LruCache<String, Vec<u8>> = LruCache::new(1);
-        cache.put("1".to_string(), vec![10, 10]);
-        cache.put("1".to_string(), vec![10, 19]);
+        cache.insert("1".to_string(), vec![10, 10]);
+        cache.insert("1".to_string(), vec![10, 19]);
         assert_opt_eq(cache.get(&"1".to_string()), vec![10, 19]);
         assert_eq!(cache.len(), 1);
     }
@@ -366,22 +398,22 @@ mod tests {
     #[test]
     fn test_expire_lru() {
         let mut cache: LruCache<String, String> = LruCache::new(2);
-        cache.put("foo1".to_string(), "bar1".to_string());
-        cache.put("foo2".to_string(), "bar2".to_string());
-        cache.put("foo3".to_string(), "bar3".to_string());
+        cache.insert("foo1".to_string(), "bar1".to_string());
+        cache.insert("foo2".to_string(), "bar2".to_string());
+        cache.insert("foo3".to_string(), "bar3".to_string());
         assert!(cache.get(&"foo1".to_string()).is_none());
-        cache.put("foo2".to_string(), "bar2update".to_string());
-        cache.put("foo4".to_string(), "bar4".to_string());
+        cache.insert("foo2".to_string(), "bar2update".to_string());
+        cache.insert("foo4".to_string(), "bar4".to_string());
         assert!(cache.get(&"foo3".to_string()).is_none());
     }
 
     #[test]
     fn test_pop() {
         let mut cache: LruCache<int, int> = LruCache::new(2);
-        cache.put(1, 10);
-        cache.put(2, 20);
+        cache.insert(1, 10);
+        cache.insert(2, 20);
         assert_eq!(cache.len(), 2);
-        let opt1 = cache.pop(&1);
+        let opt1 = cache.remove(&1);
         assert!(opt1.is_some());
         assert_eq!(opt1.unwrap(), 10);
         assert!(cache.get(&1).is_none());
@@ -392,9 +424,9 @@ mod tests {
     fn test_change_capacity() {
         let mut cache: LruCache<int, int> = LruCache::new(2);
         assert_eq!(cache.capacity(), 2);
-        cache.put(1, 10);
-        cache.put(2, 20);
-        cache.change_capacity(1);
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        cache.set_capacity(1);
         assert!(cache.get(&1).is_none());
         assert_eq!(cache.capacity(), 1);
     }
@@ -402,25 +434,25 @@ mod tests {
     #[test]
     fn test_to_string() {
         let mut cache: LruCache<int, int> = LruCache::new(3);
-        cache.put(1, 10);
-        cache.put(2, 20);
-        cache.put(3, 30);
+        cache.insert(1, 10);
+        cache.insert(2, 20);
+        cache.insert(3, 30);
         assert_eq!(cache.to_string(), "{3: 30, 2: 20, 1: 10}".to_string());
-        cache.put(2, 22);
+        cache.insert(2, 22);
         assert_eq!(cache.to_string(), "{2: 22, 3: 30, 1: 10}".to_string());
-        cache.put(6, 60);
+        cache.insert(6, 60);
         assert_eq!(cache.to_string(), "{6: 60, 2: 22, 3: 30}".to_string());
         cache.get(&3);
         assert_eq!(cache.to_string(), "{3: 30, 6: 60, 2: 22}".to_string());
-        cache.change_capacity(2);
+        cache.set_capacity(2);
         assert_eq!(cache.to_string(), "{3: 30, 6: 60}".to_string());
     }
 
     #[test]
     fn test_clear() {
         let mut cache: LruCache<int, int> = LruCache::new(2);
-        cache.put(1, 10);
-        cache.put(2, 20);
+        cache.insert(1, 10);
+        cache.insert(2, 20);
         cache.clear();
         assert!(cache.get(&1).is_none());
         assert!(cache.get(&2).is_none());

--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -278,7 +278,7 @@
 //!     }
 //! }
 //!
-//! assert_eq!(count.find(&'s'), Some(&8));
+//! assert_eq!(count.get(&'s'), Some(&8));
 //!
 //! println!("Number of occurences of each character");
 //! for (char, count) in count.iter() {

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -627,7 +627,7 @@ pub trait Reader {
     /// as `Err(IoError)`. See `read()` for more details.
     fn push(&mut self, len: uint, buf: &mut Vec<u8>) -> IoResult<uint> {
         let start_len = buf.len();
-        buf.reserve_additional(len);
+        buf.reserve(len);
 
         let n = {
             let s = unsafe { slice_vec_capacity(buf, start_len, start_len + len) };
@@ -658,7 +658,7 @@ pub trait Reader {
         }
 
         let start_len = buf.len();
-        buf.reserve_additional(len);
+        buf.reserve(len);
 
         // we can't just use self.read_at_least(min, slice) because we need to push
         // successful reads onto the vector before any returned errors.

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -1137,7 +1137,7 @@ mod tests {
         cmd.env("path", "foo");
         cmd.env("Path", "bar");
         let env = &cmd.env.unwrap();
-        let val = env.find(&EnvKey("PATH".to_c_str()));
+        let val = env.get(&EnvKey("PATH".to_c_str()));
         assert!(val.unwrap() == &"bar".to_c_str());
     }
 }

--- a/src/libsyntax/diagnostics/plugin.rs
+++ b/src/libsyntax/diagnostics/plugin.rs
@@ -63,7 +63,7 @@ pub fn expand_diagnostic_used<'cx>(ecx: &'cx mut ExtCtxt,
         ()
     });
     with_used_diagnostics(|diagnostics| {
-        match diagnostics.swap(code.name, span) {
+        match diagnostics.insert(code.name, span) {
             Some(previous_span) => {
                 ecx.span_warn(span, format!(
                     "diagnostic code {} already used", token::get_ident(code).get()
@@ -93,7 +93,7 @@ pub fn expand_register_diagnostic<'cx>(ecx: &'cx mut ExtCtxt,
         _ => unreachable!()
     };
     with_registered_diagnostics(|diagnostics| {
-        if !diagnostics.insert(code.name, description) {
+        if diagnostics.insert(code.name, description).is_some() {
             ecx.span_err(span, format!(
                 "diagnostic code {} already registered", token::get_ident(*code).get()
             ).as_slice());

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -768,7 +768,7 @@ impl SyntaxEnv {
 
     pub fn find(&self, k: &Name) -> Option<Rc<SyntaxExtension>> {
         for frame in self.chain.iter().rev() {
-            match frame.map.find(k) {
+            match frame.map.get(k) {
                 Some(v) => return Some(v.clone()),
                 None => {}
             }

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -252,7 +252,7 @@ impl<'a, 'b> Context<'a, 'b> {
             }
 
             Named(name) => {
-                let span = match self.names.find(&name) {
+                let span = match self.names.get(&name) {
                     Some(e) => e.span,
                     None => {
                         let msg = format!("there is no argument named `{}`", name);
@@ -260,7 +260,7 @@ impl<'a, 'b> Context<'a, 'b> {
                         return;
                     }
                 };
-                self.verify_same(span, &ty, self.name_types.find(&name));
+                self.verify_same(span, &ty, self.name_types.get(&name));
                 if !self.name_types.contains_key(&name) {
                     self.name_types.insert(name.clone(), ty);
                 }
@@ -555,11 +555,11 @@ impl<'a, 'b> Context<'a, 'b> {
             heads.push(self.ecx.expr_addr_of(e.span, e));
         }
         for name in self.name_ordering.iter() {
-            let e = match self.names.pop(name) {
+            let e = match self.names.remove(name) {
                 Some(e) => e,
                 None => continue
             };
-            let arg_ty = match self.name_types.find(name) {
+            let arg_ty = match self.name_types.get(name) {
                 Some(ty) => ty,
                 None => continue
             };

--- a/src/libsyntax/ext/mtwt.rs
+++ b/src/libsyntax/ext/mtwt.rs
@@ -182,7 +182,7 @@ fn resolve_internal(id: Ident,
                     resolve_table: &mut ResolveTable) -> Name {
     let key = (id.name, id.ctxt);
 
-    match resolve_table.find(&key) {
+    match resolve_table.get(&key) {
         Some(&name) => return name,
         None => {}
     }

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -45,7 +45,7 @@ impl<T: Eq + Hash + Clone + 'static> Interner<T> {
 
     pub fn intern(&self, val: T) -> Name {
         let mut map = self.map.borrow_mut();
-        match (*map).find(&val) {
+        match (*map).get(&val) {
             Some(&idx) => return idx,
             None => (),
         }

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1209,7 +1209,7 @@ impl MetricMap {
         let MetricMap(ref selfmap) = *self;
         let MetricMap(ref old) = *old;
         for (k, vold) in old.iter() {
-            let r = match selfmap.find(k) {
+            let r = match selfmap.get(k) {
                 None => MetricRemoved,
                 Some(v) => {
                     let delta = v.value - vold.value;
@@ -1678,31 +1678,31 @@ mod tests {
 
         let diff1 = m2.compare_to_old(&m1, None);
 
-        assert_eq!(*(diff1.find(&"in-both-noise".to_string()).unwrap()), LikelyNoise);
-        assert_eq!(*(diff1.find(&"in-first-noise".to_string()).unwrap()), MetricRemoved);
-        assert_eq!(*(diff1.find(&"in-second-noise".to_string()).unwrap()), MetricAdded);
-        assert_eq!(*(diff1.find(&"in-both-want-downwards-but-regressed".to_string()).unwrap()),
+        assert_eq!(*(diff1.get(&"in-both-noise".to_string()).unwrap()), LikelyNoise);
+        assert_eq!(*(diff1.get(&"in-first-noise".to_string()).unwrap()), MetricRemoved);
+        assert_eq!(*(diff1.get(&"in-second-noise".to_string()).unwrap()), MetricAdded);
+        assert_eq!(*(diff1.get(&"in-both-want-downwards-but-regressed".to_string()).unwrap()),
                    Regression(100.0));
-        assert_eq!(*(diff1.find(&"in-both-want-downwards-and-improved".to_string()).unwrap()),
+        assert_eq!(*(diff1.get(&"in-both-want-downwards-and-improved".to_string()).unwrap()),
                    Improvement(50.0));
-        assert_eq!(*(diff1.find(&"in-both-want-upwards-but-regressed".to_string()).unwrap()),
+        assert_eq!(*(diff1.get(&"in-both-want-upwards-but-regressed".to_string()).unwrap()),
                    Regression(50.0));
-        assert_eq!(*(diff1.find(&"in-both-want-upwards-and-improved".to_string()).unwrap()),
+        assert_eq!(*(diff1.get(&"in-both-want-upwards-and-improved".to_string()).unwrap()),
                    Improvement(100.0));
         assert_eq!(diff1.len(), 7);
 
         let diff2 = m2.compare_to_old(&m1, Some(200.0));
 
-        assert_eq!(*(diff2.find(&"in-both-noise".to_string()).unwrap()), LikelyNoise);
-        assert_eq!(*(diff2.find(&"in-first-noise".to_string()).unwrap()), MetricRemoved);
-        assert_eq!(*(diff2.find(&"in-second-noise".to_string()).unwrap()), MetricAdded);
-        assert_eq!(*(diff2.find(&"in-both-want-downwards-but-regressed".to_string()).unwrap()),
+        assert_eq!(*(diff2.get(&"in-both-noise".to_string()).unwrap()), LikelyNoise);
+        assert_eq!(*(diff2.get(&"in-first-noise".to_string()).unwrap()), MetricRemoved);
+        assert_eq!(*(diff2.get(&"in-second-noise".to_string()).unwrap()), MetricAdded);
+        assert_eq!(*(diff2.get(&"in-both-want-downwards-but-regressed".to_string()).unwrap()),
                    LikelyNoise);
-        assert_eq!(*(diff2.find(&"in-both-want-downwards-and-improved".to_string()).unwrap()),
+        assert_eq!(*(diff2.get(&"in-both-want-downwards-and-improved".to_string()).unwrap()),
                    LikelyNoise);
-        assert_eq!(*(diff2.find(&"in-both-want-upwards-but-regressed".to_string()).unwrap()),
+        assert_eq!(*(diff2.get(&"in-both-want-upwards-but-regressed".to_string()).unwrap()),
                    LikelyNoise);
-        assert_eq!(*(diff2.find(&"in-both-want-upwards-and-improved".to_string()).unwrap()),
+        assert_eq!(*(diff2.get(&"in-both-want-upwards-and-improved".to_string()).unwrap()),
                    LikelyNoise);
         assert_eq!(diff2.len(), 7);
     }
@@ -1727,29 +1727,29 @@ mod tests {
         let (diff1, ok1) = m2.ratchet(&pth, None);
         assert_eq!(ok1, false);
         assert_eq!(diff1.len(), 2);
-        assert_eq!(*(diff1.find(&"runtime".to_string()).unwrap()), Regression(10.0));
-        assert_eq!(*(diff1.find(&"throughput".to_string()).unwrap()), LikelyNoise);
+        assert_eq!(*(diff1.get(&"runtime".to_string()).unwrap()), Regression(10.0));
+        assert_eq!(*(diff1.get(&"throughput".to_string()).unwrap()), LikelyNoise);
 
         // Check that it was not rewritten.
         let m3 = MetricMap::load(&pth);
         let MetricMap(m3) = m3;
         assert_eq!(m3.len(), 2);
-        assert_eq!(*(m3.find(&"runtime".to_string()).unwrap()), Metric::new(1000.0, 2.0));
-        assert_eq!(*(m3.find(&"throughput".to_string()).unwrap()), Metric::new(50.0, 2.0));
+        assert_eq!(*(m3.get(&"runtime".to_string()).unwrap()), Metric::new(1000.0, 2.0));
+        assert_eq!(*(m3.get(&"throughput".to_string()).unwrap()), Metric::new(50.0, 2.0));
 
         // Ask for a ratchet with an explicit noise-percentage override,
         // that should advance.
         let (diff2, ok2) = m2.ratchet(&pth, Some(10.0));
         assert_eq!(ok2, true);
         assert_eq!(diff2.len(), 2);
-        assert_eq!(*(diff2.find(&"runtime".to_string()).unwrap()), LikelyNoise);
-        assert_eq!(*(diff2.find(&"throughput".to_string()).unwrap()), LikelyNoise);
+        assert_eq!(*(diff2.get(&"runtime".to_string()).unwrap()), LikelyNoise);
+        assert_eq!(*(diff2.get(&"throughput".to_string()).unwrap()), LikelyNoise);
 
         // Check that it was rewritten.
         let m4 = MetricMap::load(&pth);
         let MetricMap(m4) = m4;
         assert_eq!(m4.len(), 2);
-        assert_eq!(*(m4.find(&"runtime".to_string()).unwrap()), Metric::new(1100.0, 2.0));
-        assert_eq!(*(m4.find(&"throughput".to_string()).unwrap()), Metric::new(50.0, 2.0));
+        assert_eq!(*(m4.get(&"runtime".to_string()).unwrap()), Metric::new(1100.0, 2.0));
+        assert_eq!(*(m4.get(&"throughput".to_string()).unwrap()), Metric::new(50.0, 2.0));
     }
 }

--- a/src/test/bench/core-map.rs
+++ b/src/test/bench/core-map.rs
@@ -30,18 +30,18 @@ trait MutableMap {
 
 impl MutableMap for TreeMap<uint, uint> {
     fn insert(&mut self, k: uint, v: uint) { self.insert(k, v); }
-    fn remove(&mut self, k: &uint) -> bool { self.remove(k) }
-    fn find(&self, k: &uint) -> Option<&uint> { self.find(k) }
+    fn remove(&mut self, k: &uint) -> bool { self.remove(k).is_some() }
+    fn find(&self, k: &uint) -> Option<&uint> { self.get(k) }
 }
 impl MutableMap for HashMap<uint, uint> {
     fn insert(&mut self, k: uint, v: uint) { self.insert(k, v); }
-    fn remove(&mut self, k: &uint) -> bool { self.remove(k) }
-    fn find(&self, k: &uint) -> Option<&uint> { self.find(k) }
+    fn remove(&mut self, k: &uint) -> bool { self.remove(k).is_some() }
+    fn find(&self, k: &uint) -> Option<&uint> { self.get(k) }
 }
 impl MutableMap for TrieMap<uint> {
     fn insert(&mut self, k: uint, v: uint) { self.insert(k, v); }
-    fn remove(&mut self, k: &uint) -> bool { self.remove(k) }
-    fn find(&self, k: &uint) -> Option<&uint> { self.find(k) }
+    fn remove(&mut self, k: &uint) -> bool { self.remove(k).is_some() }
+    fn find(&self, k: &uint) -> Option<&uint> { self.get(k) }
 }
 
 fn ascending<M: MutableMap>(map: &mut M, n_keys: uint) {

--- a/src/test/bench/shootout-chameneos-redux.rs
+++ b/src/test/bench/shootout-chameneos-redux.rs
@@ -197,8 +197,8 @@ fn rendezvous(nn: uint, set: Vec<Color>) {
 
         creatures_met += 2;
 
-        to_creature.get_mut(fst_creature.name).send(snd_creature);
-        to_creature.get_mut(snd_creature.name).send(fst_creature);
+        to_creature[fst_creature.name].send(snd_creature);
+        to_creature[snd_creature.name].send(fst_creature);
     }
 
     // tell each creature to stop

--- a/src/test/bench/shootout-fasta-redux.rs
+++ b/src/test/bench/shootout-fasta-redux.rs
@@ -100,7 +100,7 @@ fn sum_and_scale(a: &'static [AminoAcid]) -> Vec<AminoAcid> {
         result.push(a_i);
     }
     let result_len = result.len();
-    result.get_mut(result_len - 1).p = LOOKUP_SCALE;
+    result[result_len - 1].p = LOOKUP_SCALE;
     result
 }
 

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -171,13 +171,13 @@ impl Table {
                     next: None,
                 };
                 c.f(&mut *entry);
-                *self.items.get_mut(index as uint) = Some(entry);
+                self.items[index as uint] = Some(entry);
                 return;
             }
         }
 
         {
-            let entry = self.items.get_mut(index as uint).as_mut().unwrap();
+            let entry = self.items[index as uint].as_mut().unwrap();
             if entry.code == key {
                 c.f(&mut **entry);
                 return;

--- a/src/test/bench/shootout-meteor.rs
+++ b/src/test/bench/shootout-meteor.rs
@@ -194,7 +194,7 @@ fn is_board_unfeasible(board: u64, masks: &Vec<Vec<Vec<u64>>>) -> bool {
 fn filter_masks(masks: &mut Vec<Vec<Vec<u64>>>) {
     for i in range(0, masks.len()) {
         for j in range(0, (*masks)[i].len()) {
-            *masks.get_mut(i).get_mut(j) =
+            masks[i][j] =
                 (*masks)[i][j].iter().map(|&m| m)
                 .filter(|&m| !is_board_unfeasible(m, masks))
                 .collect();
@@ -217,7 +217,7 @@ fn to_vec(raw_sol: &List<u64>) -> Vec<u8> {
         let id = '0' as u8 + get_id(m);
         for i in range(0u, 50) {
             if m & 1 << i != 0 {
-                *sol.get_mut(i) = id;
+                sol[i] = id;
             }
         }
     }

--- a/src/test/bench/shootout-regex-dna.rs
+++ b/src/test/bench/shootout-regex-dna.rs
@@ -114,7 +114,7 @@ fn main() {
     }
 
     for (i, variant) in variant_strs.iter().enumerate() {
-        println!("{} {}", variant, counts.get_mut(i).get());
+        println!("{} {}", variant, counts[i].get());
     }
     println!("");
     println!("{}", ilen);

--- a/src/test/bench/shootout-reverse-complement.rs
+++ b/src/test/bench/shootout-reverse-complement.rs
@@ -112,14 +112,15 @@ fn read_to_end<R: Reader>(r: &mut R) -> IoResult<Vec<u8>> {
     let mut vec = Vec::with_capacity(CHUNK);
     loop {
         // workaround: very fast growing
-        if vec.capacity() - vec.len() < CHUNK {
+        let len = vec.len();
+        if vec.capacity() - len < CHUNK {
             let cap = vec.capacity();
             let mult = if cap < 256 * 1024 * 1024 {
                 16
             } else {
                 2
             };
-            vec.reserve_exact(mult * cap);
+            vec.reserve_exact(mult * cap - len);
         }
         match r.push_at_least(1, CHUNK, &mut vec) {
             Ok(_) => {}

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -79,7 +79,7 @@ impl Sudoku {
             if comps.len() == 3u {
                 let row     = from_str::<uint>(comps[0]).unwrap() as u8;
                 let col     = from_str::<uint>(comps[1]).unwrap() as u8;
-                *g.get_mut(row as uint).get_mut(col as uint) =
+                g[row as uint][col as uint] =
                     from_str::<uint>(comps[2]).unwrap() as u8;
             }
             else {
@@ -139,10 +139,10 @@ impl Sudoku {
 
             // find first remaining color that is available
             let next = avail.next();
-            *self.grid.get_mut(row as uint).get_mut(col as uint) = next;
+            self.grid[row as uint][col as uint] = next;
             return 0u8 != next;
         }
-        *self.grid.get_mut(row as uint).get_mut(col as uint) = 0u8;
+        self.grid[row as uint][col as uint] = 0u8;
         return false;
     }
 

--- a/src/test/compile-fail/borrowck-assign-comp-idx.rs
+++ b/src/test/compile-fail/borrowck-assign-comp-idx.rs
@@ -19,7 +19,7 @@ fn a() {
     // Create an immutable pointer into p's contents:
     let q: &int = &p[0];
 
-    *p.get_mut(0) = 5; //~ ERROR cannot borrow
+    p[0] = 5; //~ ERROR cannot borrow
 
     println!("{}", *q);
 }
@@ -34,7 +34,7 @@ fn b() {
 
     borrow(
         p.as_slice(),
-        || *p.get_mut(0) = 5); //~ ERROR cannot borrow `p` as mutable
+        || p[0] = 5); //~ ERROR cannot borrow `p` as mutable
 }
 
 fn c() {
@@ -42,7 +42,7 @@ fn c() {
     // modification:
     let mut p = vec!(1);
     borrow(p.as_slice(), ||{});
-    *p.get_mut(0) = 5;
+    p[0] = 5;
 }
 
 fn main() {

--- a/src/test/compile-fail/borrowck-for-loop-head-linkage.rs
+++ b/src/test/compile-fail/borrowck-for-loop-head-linkage.rs
@@ -13,7 +13,7 @@ fn main() {
     for &x in vector.iter() {
         let cap = vector.capacity();
         vector.grow(cap, 0u);      //~ ERROR cannot borrow
-        *vector.get_mut(1u) = 5u;   //~ ERROR cannot borrow
+        vector[1u] = 5u;   //~ ERROR cannot borrow
     }
 }
 

--- a/src/test/compile-fail/borrowck-loan-vec-content.rs
+++ b/src/test/compile-fail/borrowck-loan-vec-content.rs
@@ -26,7 +26,7 @@ fn has_mut_vec_but_tries_to_change_it() {
     takes_imm_elt(
         &v[0],
         || { //~ ERROR cannot borrow `v` as mutable
-            *v.get_mut(1) = 4;
+            v[1] = 4;
         })
 }
 

--- a/src/test/run-pass/foreach-nested.rs
+++ b/src/test/run-pass/foreach-nested.rs
@@ -15,7 +15,7 @@ pub fn main() {
     let mut a: Vec<int> = vec!(-1, -1, -1, -1);
     let mut p: int = 0;
     two(|i| {
-        two(|j| { *a.get_mut(p as uint) = 10 * i + j; p += 1; })
+        two(|j| { a[p as uint] = 10 * i + j; p += 1; })
     });
     assert_eq!(a[0], 0);
     assert_eq!(a[1], 1);

--- a/src/test/run-pass/hashmap-memory.rs
+++ b/src/test/run-pass/hashmap-memory.rs
@@ -83,7 +83,7 @@ mod map_reduce {
               mapper_done => { num_mappers -= 1; }
               find_reducer(k, cc) => {
                 let mut c;
-                match reducers.find(&str::from_utf8(
+                match reducers.get(&str::from_utf8(
                         k.as_slice()).unwrap().to_string()) {
                   Some(&_c) => { c = _c; }
                   None => { c = 0; }

--- a/src/test/run-pass/issue-3563-3.rs
+++ b/src/test/run-pass/issue-3563-3.rs
@@ -86,8 +86,8 @@ impl AsciiArt {
                 // element is:
                 // 1) potentially large
                 // 2) needs to be modified
-                let row = self.lines.get_mut(v);
-                *row.get_mut(h) = self.fill;
+                let row = &mut self.lines[v];
+                row[h] = self.fill;
             }
         }
     }

--- a/src/test/run-pass/issue-3991.rs
+++ b/src/test/run-pass/issue-3991.rs
@@ -15,7 +15,7 @@ struct HasNested {
 
 impl HasNested {
     fn method_push_local(&mut self) {
-        self.nest.get_mut(0).push(0);
+        self.nest[0].push(0);
     }
 }
 

--- a/src/test/run-pass/overloaded-deref.rs
+++ b/src/test/run-pass/overloaded-deref.rs
@@ -44,8 +44,8 @@ pub fn main() {
     assert_eq!(*(*p).borrow(), Point {x: 3, y: 5});
 
     let v = Rc::new(RefCell::new(vec!(1i, 2, 3)));
-    *(*(*v).borrow_mut()).get_mut(0) = 3;
-    *(*(*v).borrow_mut()).get_mut(1) += 3;
+    (*(*v).borrow_mut())[0] = 3;
+    (*(*v).borrow_mut())[1] += 3;
     assert_eq!(((*(*v).borrow())[0],
                 (*(*v).borrow())[1],
                 (*(*v).borrow())[2]), (3, 5, 3));

--- a/src/test/run-pass/send_str_hashmap.rs
+++ b/src/test/run-pass/send_str_hashmap.rs
@@ -16,37 +16,37 @@ use std::option::Some;
 
 pub fn main() {
     let mut map: HashMap<SendStr, uint> = HashMap::new();
-    assert!(map.insert(Slice("foo"), 42));
-    assert!(!map.insert(Owned("foo".to_string()), 42));
-    assert!(!map.insert(Slice("foo"), 42));
-    assert!(!map.insert(Owned("foo".to_string()), 42));
+    assert!(map.insert(Slice("foo"), 42).is_none());
+    assert!(map.insert(Owned("foo".to_string()), 42).is_some());
+    assert!(map.insert(Slice("foo"), 42).is_some());
+    assert!(map.insert(Owned("foo".to_string()), 42).is_some());
 
-    assert!(!map.insert(Slice("foo"), 43));
-    assert!(!map.insert(Owned("foo".to_string()), 44));
-    assert!(!map.insert(Slice("foo"), 45));
-    assert!(!map.insert(Owned("foo".to_string()), 46));
+    assert!(map.insert(Slice("foo"), 43).is_some());
+    assert!(map.insert(Owned("foo".to_string()), 44).is_some());
+    assert!(map.insert(Slice("foo"), 45).is_some());
+    assert!(map.insert(Owned("foo".to_string()), 46).is_some());
 
     let v = 46;
 
-    assert_eq!(map.find(&Owned("foo".to_string())), Some(&v));
-    assert_eq!(map.find(&Slice("foo")), Some(&v));
+    assert_eq!(map.get(&Owned("foo".to_string())), Some(&v));
+    assert_eq!(map.get(&Slice("foo")), Some(&v));
 
     let (a, b, c, d) = (50, 51, 52, 53);
 
-    assert!(map.insert(Slice("abc"), a));
-    assert!(map.insert(Owned("bcd".to_string()), b));
-    assert!(map.insert(Slice("cde"), c));
-    assert!(map.insert(Owned("def".to_string()), d));
+    assert!(map.insert(Slice("abc"), a).is_none());
+    assert!(map.insert(Owned("bcd".to_string()), b).is_none());
+    assert!(map.insert(Slice("cde"), c).is_none());
+    assert!(map.insert(Owned("def".to_string()), d).is_none());
 
-    assert!(!map.insert(Slice("abc"), a));
-    assert!(!map.insert(Owned("bcd".to_string()), b));
-    assert!(!map.insert(Slice("cde"), c));
-    assert!(!map.insert(Owned("def".to_string()), d));
+    assert!(map.insert(Slice("abc"), a).is_some());
+    assert!(map.insert(Owned("bcd".to_string()), b).is_some());
+    assert!(map.insert(Slice("cde"), c).is_some());
+    assert!(map.insert(Owned("def".to_string()), d).is_some());
 
-    assert!(!map.insert(Owned("abc".to_string()), a));
-    assert!(!map.insert(Slice("bcd"), b));
-    assert!(!map.insert(Owned("cde".to_string()), c));
-    assert!(!map.insert(Slice("def"), d));
+    assert!(map.insert(Owned("abc".to_string()), a).is_some());
+    assert!(map.insert(Slice("bcd"), b).is_some());
+    assert!(map.insert(Owned("cde".to_string()), c).is_some());
+    assert!(map.insert(Slice("def"), d).is_some());
 
     assert_eq!(map.find_equiv("abc"), Some(&a));
     assert_eq!(map.find_equiv("bcd"), Some(&b));

--- a/src/test/run-pass/send_str_treemap.rs
+++ b/src/test/run-pass/send_str_treemap.rs
@@ -17,49 +17,49 @@ use std::option::Some;
 
 pub fn main() {
     let mut map: TreeMap<SendStr, uint> = TreeMap::new();
-    assert!(map.insert(Slice("foo"), 42));
-    assert!(!map.insert(Owned("foo".to_string()), 42));
-    assert!(!map.insert(Slice("foo"), 42));
-    assert!(!map.insert(Owned("foo".to_string()), 42));
+    assert!(map.insert(Slice("foo"), 42).is_none());
+    assert!(map.insert(Owned("foo".to_string()), 42).is_some());
+    assert!(map.insert(Slice("foo"), 42).is_some());
+    assert!(map.insert(Owned("foo".to_string()), 42).is_some());
 
-    assert!(!map.insert(Slice("foo"), 43));
-    assert!(!map.insert(Owned("foo".to_string()), 44));
-    assert!(!map.insert(Slice("foo"), 45));
-    assert!(!map.insert(Owned("foo".to_string()), 46));
+    assert!(map.insert(Slice("foo"), 43).is_some());
+    assert!(map.insert(Owned("foo".to_string()), 44).is_some());
+    assert!(map.insert(Slice("foo"), 45).is_some());
+    assert!(map.insert(Owned("foo".to_string()), 46).is_some());
 
     let v = 46;
 
-    assert_eq!(map.find(&Owned("foo".to_string())), Some(&v));
-    assert_eq!(map.find(&Slice("foo")), Some(&v));
+    assert_eq!(map.get(&Owned("foo".to_string())), Some(&v));
+    assert_eq!(map.get(&Slice("foo")), Some(&v));
 
     let (a, b, c, d) = (50, 51, 52, 53);
 
-    assert!(map.insert(Slice("abc"), a));
-    assert!(map.insert(Owned("bcd".to_string()), b));
-    assert!(map.insert(Slice("cde"), c));
-    assert!(map.insert(Owned("def".to_string()), d));
+    assert!(map.insert(Slice("abc"), a).is_none());
+    assert!(map.insert(Owned("bcd".to_string()), b).is_none());
+    assert!(map.insert(Slice("cde"), c).is_none());
+    assert!(map.insert(Owned("def".to_string()), d).is_none());
 
-    assert!(!map.insert(Slice("abc"), a));
-    assert!(!map.insert(Owned("bcd".to_string()), b));
-    assert!(!map.insert(Slice("cde"), c));
-    assert!(!map.insert(Owned("def".to_string()), d));
+    assert!(map.insert(Slice("abc"), a).is_some());
+    assert!(map.insert(Owned("bcd".to_string()), b).is_some());
+    assert!(map.insert(Slice("cde"), c).is_some());
+    assert!(map.insert(Owned("def".to_string()), d).is_some());
 
-    assert!(!map.insert(Owned("abc".to_string()), a));
-    assert!(!map.insert(Slice("bcd"), b));
-    assert!(!map.insert(Owned("cde".to_string()), c));
-    assert!(!map.insert(Slice("def"), d));
+    assert!(map.insert(Owned("abc".to_string()), a).is_some());
+    assert!(map.insert(Slice("bcd"), b).is_some());
+    assert!(map.insert(Owned("cde".to_string()), c).is_some());
+    assert!(map.insert(Slice("def"), d).is_some());
 
-    assert_eq!(map.find(&Slice("abc")), Some(&a));
-    assert_eq!(map.find(&Slice("bcd")), Some(&b));
-    assert_eq!(map.find(&Slice("cde")), Some(&c));
-    assert_eq!(map.find(&Slice("def")), Some(&d));
+    assert_eq!(map.get(&Slice("abc")), Some(&a));
+    assert_eq!(map.get(&Slice("bcd")), Some(&b));
+    assert_eq!(map.get(&Slice("cde")), Some(&c));
+    assert_eq!(map.get(&Slice("def")), Some(&d));
 
-    assert_eq!(map.find(&Owned("abc".to_string())), Some(&a));
-    assert_eq!(map.find(&Owned("bcd".to_string())), Some(&b));
-    assert_eq!(map.find(&Owned("cde".to_string())), Some(&c));
-    assert_eq!(map.find(&Owned("def".to_string())), Some(&d));
+    assert_eq!(map.get(&Owned("abc".to_string())), Some(&a));
+    assert_eq!(map.get(&Owned("bcd".to_string())), Some(&b));
+    assert_eq!(map.get(&Owned("cde".to_string())), Some(&c));
+    assert_eq!(map.get(&Owned("def".to_string())), Some(&d));
 
-    assert!(map.pop(&Slice("foo")).is_some());
+    assert!(map.remove(&Slice("foo")).is_some());
     assert_eq!(map.into_iter().map(|(k, v)| format!("{}{}", k, v))
                               .collect::<Vec<String>>()
                               .concat(),

--- a/src/test/run-pass/swap-2.rs
+++ b/src/test/run-pass/swap-2.rs
@@ -16,7 +16,7 @@ pub fn main() {
     assert_eq!(a[2], 4);
     assert_eq!(a[4], 2);
     let mut n = 42;
-    swap(&mut n, a.get_mut(0));
+    swap(&mut n, &mut a[0]);
     assert_eq!(a[0], 42);
     assert_eq!(n, 0);
 }

--- a/src/test/run-pass/unique-in-vec-copy.rs
+++ b/src/test/run-pass/unique-in-vec-copy.rs
@@ -17,7 +17,7 @@ pub fn main() {
     assert_eq!(*b[0], 10);
 
     // This should only modify the value in a, not b
-    **a.get_mut(0) = 20;
+    *a[0] = 20;
 
     assert_eq!(*a[0], 20);
     assert_eq!(*b[0], 10);


### PR DESCRIPTION
 Implement low-hanging fruit of collection conventions
- Renames/deprecates the simplest and most obvious methods
- Adds FIXME(conventions)s for outstanding work
- Marks "handled" methods as unstable
  
  NOTE: the semantics of reserve and reserve_exact have changed!
  Other methods have had their semantics changed as well, but in a
  way that should obviously not typecheck if used incorrectly.
  
  Lots of work and breakage to come, but this handles most of the core
  APIs and most eggregious breakage. Future changes should _mostly_ focus on
  niche collections, APIs, or simply back-compat additions.
  
  [breaking-change]

r? @aturon
