### PR TITLE
rustc: Support stability attributes on crates

### DIFF
--- a/src/test/compile-fail/lint-output-format.rs
+++ b/src/test/compile-fail/lint-output-format.rs
@@ -11,7 +11,7 @@
 // compile-flags:-F experimental -D unstable
 // aux-build:lint_output_format.rs
 
-extern crate lint_output_format;
+extern crate lint_output_format; //~ ERROR: use of unmarked item
 use lint_output_format::{foo, bar, baz};
 
 fn main() {

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -19,7 +19,7 @@
 
 mod cross_crate {
     #[phase(plugin, link)]
-    extern crate lint_stability;
+    extern crate lint_stability; //~ ERROR: use of unmarked item
     use self::lint_stability::*;
 
     fn test() {
@@ -144,7 +144,7 @@ mod cross_crate {
 }
 
 mod inheritance {
-    extern crate inherited_stability;
+    extern crate inherited_stability; //~ ERROR: use of experimental item
     use self::inherited_stability::*;
 
     fn test_inheritance() {


### PR DESCRIPTION
This commit adds support for linting `extern crate` statements for stability
attributes attached to the crate itself. This is likely to be the mechanism used
to deny access to experimental crates that are part of the standard
distribution.

cc #18585 

r? @aturon
