### PR TITLE
Clarify Error description and detail should be single line

### DIFF
--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -88,9 +88,11 @@ use string::String;
 /// Base functionality for all errors in Rust.
 pub trait Error: Send {
     /// A short description of the error; usually a static string.
+    /// Description should be single-line, i. e. it should not contain \n characters.
     fn description(&self) -> &str;
 
     /// A detailed description of the error, usually including dynamic information.
+    /// Detail should be single-line, i. e. it should not contain \n characters.
     fn detail(&self) -> Option<String> { None }
 
     /// The lower-level cause of this error, if any.


### PR DESCRIPTION
When description and detail are known to be single line, they can
be used like this, and programmer can be sure that message is
formatted nicely.

```
println!("could not download file: {}, trying again in 5s", e.description());
```
