### PR TITLE
Purge `|:|` notation from types and trait references, in favor of `Foo()`

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -57,7 +57,6 @@ register_diagnostics!(
     E0044,
     E0045,
     E0046,
-    E0047,
     E0049,
     E0050,
     E0051,
@@ -111,7 +110,6 @@ register_diagnostics!(
     E0108,
     E0109,
     E0110,
-    E0113,
     E0116,
     E0117,
     E0118,
@@ -145,5 +143,6 @@ register_diagnostics!(
     E0163,
     E0164,
     E0165,
-    E0166
+    E0166,
+    E0167
 )

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -138,7 +138,7 @@ fn check_expr(v: &mut CheckCrateVisitor, e: &Expr) -> bool {
             // to handle on-demand instantiation of functions via
             // foo::<bar> in a const. Currently that is only done on
             // a path in trans::callee that only works in block contexts.
-            if !pth.segments.iter().all(|segment| segment.types.is_empty()) {
+            if !pth.segments.iter().all(|segment| segment.parameters.is_empty()) {
                 span_err!(v.tcx.sess, e.span, E0013,
                           "paths in constants may only refer to items without \
                            type parameters");

--- a/src/librustc/middle/pat_util.rs
+++ b/src/librustc/middle/pat_util.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 use syntax::ast::*;
 use syntax::ast_util::{walk_pat};
 use syntax::codemap::{Span, DUMMY_SP};
-use syntax::owned_slice::OwnedSlice;
 
 pub type PatIdMap = HashMap<Ident, NodeId>;
 
@@ -133,8 +132,7 @@ pub fn def_to_path(tcx: &ty::ctxt, id: DefId) -> Path {
         global: false,
         segments: path.last().map(|elem| PathSegment {
             identifier: Ident::new(elem.name()),
-            lifetimes: vec!(),
-            types: OwnedSlice::empty()
+            parameters: PathParameters::none(),
         }).into_iter().collect(),
         span: DUMMY_SP,
     })

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -27,7 +27,6 @@ use syntax::ast_map;
 use syntax::ast_util::{is_local, local_def, PostExpansionMethod};
 use syntax::codemap::Span;
 use syntax::parse::token;
-use syntax::owned_slice::OwnedSlice;
 use syntax::visit;
 use syntax::visit::Visitor;
 
@@ -945,8 +944,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for PrivacyVisitor<'a, 'tcx> {
                                     debug!("privacy - ident item {}", id);
                                     let seg = ast::PathSegment {
                                         identifier: name,
-                                        lifetimes: Vec::new(),
-                                        types: OwnedSlice::empty(),
+                                        parameters: ast::PathParameters::none(),
                                     };
                                     let segs = vec![seg];
                                     let path = ast::Path {

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -4951,12 +4951,12 @@ impl<'a> Resolver<'a> {
 
                             if path.segments
                                    .iter()
-                                   .any(|s| !s.lifetimes.is_empty()) {
+                                   .any(|s| s.parameters.has_lifetimes()) {
                                 span_err!(self.session, path.span, E0157,
                                     "lifetime parameters are not allowed on this type");
                             } else if path.segments
                                           .iter()
-                                          .any(|s| s.types.len() > 0) {
+                                          .any(|s| !s.parameters.is_empty()) {
                                 span_err!(self.session, path.span, E0153,
                                     "type parameters are not allowed on this type");
                             }
@@ -5234,7 +5234,7 @@ impl<'a> Resolver<'a> {
                     // Check the types in the path pattern.
                     for ty in path.segments
                                   .iter()
-                                  .flat_map(|s| s.types.iter()) {
+                                  .flat_map(|s| s.parameters.types().into_iter()) {
                         self.resolve_type(&**ty);
                     }
                 }
@@ -5340,7 +5340,7 @@ impl<'a> Resolver<'a> {
                     namespace: Namespace,
                     check_ribs: bool) -> Option<(Def, LastPrivate)> {
         // First, resolve the types.
-        for ty in path.segments.iter().flat_map(|s| s.types.iter()) {
+        for ty in path.segments.iter().flat_map(|s| s.parameters.types().into_iter()) {
             self.resolve_type(&**ty);
         }
 

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -40,7 +40,7 @@ use syntax::ast::{TupleVariantKind, Ty, TyBool, TyChar, TyClosure, TyF32};
 use syntax::ast::{TyF64, TyFloat, TyI, TyI8, TyI16, TyI32, TyI64, TyInt};
 use syntax::ast::{TyParam, TyParamBound, TyPath, TyPtr, TyProc, TyQPath};
 use syntax::ast::{TyRptr, TyStr, TyU, TyU8, TyU16, TyU32, TyU64, TyUint};
-use syntax::ast::{TypeImplItem, UnboxedFnTyParamBound, UnnamedField};
+use syntax::ast::{TypeImplItem, UnnamedField};
 use syntax::ast::{Variant, ViewItem, ViewItemExternCrate};
 use syntax::ast::{ViewItemUse, ViewPathGlob, ViewPathList, ViewPathSimple};
 use syntax::ast::{Visibility};
@@ -4522,41 +4522,6 @@ impl<'a> Resolver<'a> {
         match *type_parameter_bound {
             TraitTyParamBound(ref tref) => {
                 self.resolve_trait_reference(id, tref, reference_type)
-            }
-            UnboxedFnTyParamBound(ref unboxed_function) => {
-                match self.resolve_path(unboxed_function.ref_id,
-                                        &unboxed_function.path,
-                                        TypeNS,
-                                        true) {
-                    None => {
-                        let path_str = self.path_names_to_string(
-                            &unboxed_function.path);
-                        self.resolve_error(unboxed_function.path.span,
-                                           format!("unresolved trait `{}`",
-                                                   path_str).as_slice())
-                    }
-                    Some(def) => {
-                        match def {
-                            (DefTrait(_), _) => {
-                                self.record_def(unboxed_function.ref_id, def);
-                            }
-                            _ => {
-                                let msg =
-                                    format!("`{}` is not a trait",
-                                            self.path_names_to_string(
-                                                &unboxed_function.path));
-                                self.resolve_error(unboxed_function.path.span,
-                                                   msg.as_slice());
-                            }
-                        }
-                    }
-                }
-
-                for argument in unboxed_function.decl.inputs.iter() {
-                    self.resolve_type(&*argument.ty);
-                }
-
-                self.resolve_type(&*unboxed_function.decl.output);
             }
             RegionTyParamBound(..) => {}
         }

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -204,9 +204,6 @@ impl<'a> LifetimeContext<'a> {
                 ast::TraitTyParamBound(ref trait_ref) => {
                     self.visit_trait_ref(trait_ref);
                 }
-                ast::UnboxedFnTyParamBound(ref fn_decl) => {
-                    self.visit_unboxed_fn_ty_param_bound(&**fn_decl);
-                }
                 ast::RegionTyParamBound(ref lifetime) => {
                     self.visit_lifetime_ref(lifetime);
                 }
@@ -223,18 +220,6 @@ impl<'a> LifetimeContext<'a> {
                 v.visit_lifetime_decl(lifetime);
             }
             v.visit_path(&trait_ref.path, trait_ref.ref_id);
-        })
-    }
-
-    fn visit_unboxed_fn_ty_param_bound(&mut self,
-                                       bound: &ast::UnboxedFnBound) {
-        self.with(|scope, f| {
-            f(LateScope(bound.ref_id, &bound.lifetimes, scope))
-        }, |v| {
-            for argument in bound.decl.inputs.iter() {
-                v.visit_ty(&*argument.ty);
-            }
-            v.visit_ty(&*bound.decl.output);
         })
     }
 

--- a/src/librustc/middle/save/mod.rs
+++ b/src/librustc/middle/save/mod.rs
@@ -705,7 +705,7 @@ impl <'l, 'tcx> DxrVisitor<'l, 'tcx> {
                 ast::TraitTyParamBound(ref trait_ref) => {
                     trait_ref
                 }
-                ast::UnboxedFnTyParamBound(..) | ast::RegionTyParamBound(..) => {
+                ast::RegionTyParamBound(..) => {
                     continue;
                 }
             };

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1836,11 +1836,7 @@ pub fn trans_closure(ccx: &CrateContext,
         NotUnboxedClosure => monomorphized_arg_types,
 
         // Tuple up closure argument types for the "rust-call" ABI.
-        IsUnboxedClosure => vec![if monomorphized_arg_types.is_empty() {
-            ty::mk_nil()
-        } else {
-            ty::mk_tup(ccx.tcx(), monomorphized_arg_types)
-        }]
+        IsUnboxedClosure => vec![ty::mk_tup_or_nil(ccx.tcx(), monomorphized_arg_types)]
     };
     for monomorphized_arg_type in monomorphized_arg_types.iter() {
         debug!("trans_closure: monomorphized_arg_type: {}",

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -625,7 +625,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr) -> ValueRef {
           }
           ast::ExprPath(ref pth) => {
             // Assert that there are no type parameters in this path.
-            assert!(pth.segments.iter().all(|seg| seg.types.is_empty()));
+            assert!(pth.segments.iter().all(|seg| !seg.parameters.has_types()));
 
             let opt_def = cx.tcx().def_map.borrow().find_copy(&e.id);
             match opt_def {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1838,6 +1838,14 @@ pub fn mk_slice(cx: &ctxt, r: Region, tm: mt) -> t {
 
 pub fn mk_tup(cx: &ctxt, ts: Vec<t>) -> t { mk_t(cx, ty_tup(ts)) }
 
+pub fn mk_tup_or_nil(cx: &ctxt, ts: Vec<t>) -> t {
+    if ts.len() == 0 {
+        ty::mk_nil()
+    } else {
+        mk_t(cx, ty_tup(ts))
+    }
+}
+
 pub fn mk_closure(cx: &ctxt, fty: ClosureTy) -> t {
     mk_t(cx, ty_closure(box fty))
 }

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -638,7 +638,7 @@ pub fn ensure_no_ty_param_bounds(ccx: &CrateCtxt,
         let mut bounds = bounds.chain(ty_param.unbound.iter());
         for bound in bounds {
             match *bound {
-                ast::TraitTyParamBound(..) | ast::UnboxedFnTyParamBound(..) => {
+                ast::TraitTyParamBound(..) => {
                     // According to accepted RFC #XXX, we should
                     // eventually accept these, but it will not be
                     // part of this PR. Still, convert to warning to
@@ -1356,20 +1356,6 @@ pub fn instantiate_trait_ref<'tcx,AC>(this: &AC,
     }
 }
 
-pub fn instantiate_unboxed_fn_ty<'tcx,AC>(this: &AC,
-                                          unboxed_function: &ast::UnboxedFnTy,
-                                          param_ty: ty::ParamTy)
-                                          -> Rc<ty::TraitRef>
-                                          where AC: AstConv<'tcx> {
-    let rscope = ExplicitRscope;
-    let param_ty = param_ty.to_ty(this.tcx());
-    Rc::new(astconv::trait_ref_for_unboxed_function(this,
-                                                    &rscope,
-                                                    unboxed_function.kind,
-                                                    &*unboxed_function.decl,
-                                                    Some(param_ty)))
-}
-
 fn get_trait_def(ccx: &CrateCtxt, trait_id: ast::DefId) -> Rc<ty::TraitDef> {
     if trait_id.krate != ast::LOCAL_CRATE {
         return ty::lookup_trait_def(ccx.tcx, trait_id)
@@ -1879,7 +1865,6 @@ fn ty_generics<'tcx,AC>(this: &AC,
                 // In the above example, `ast_trait_ref` is `Iterator`.
                 let ast_trait_ref = match *bound {
                     ast::TraitTyParamBound(ref r) => r,
-                    ast::UnboxedFnTyParamBound(..) => { continue; }
                     ast::RegionTyParamBound(..) => { continue; }
                 };
 
@@ -2057,45 +2042,8 @@ fn conv_param_bounds<'tcx,AC>(this: &AC,
         merge_param_bounds(this.tcx(), param_ty, ast_bounds, where_clause);
     let astconv::PartitionedBounds { builtin_bounds,
                                      trait_bounds,
-                                     region_bounds,
-                                     unboxed_fn_ty_bounds } =
+                                     region_bounds } =
         astconv::partition_bounds(this.tcx(), span, all_bounds.as_slice());
-
-    let unboxed_fn_ty_bounds = unboxed_fn_ty_bounds.into_iter().map(|b| {
-        let trait_id = (*this.tcx().def_map.borrow())[b.ref_id].def_id();
-        let mut kind = None;
-        for &(lang_item, this_kind) in [
-            (this.tcx().lang_items.fn_trait(), ast::FnUnboxedClosureKind),
-            (this.tcx().lang_items.fn_mut_trait(),
-             ast::FnMutUnboxedClosureKind),
-            (this.tcx().lang_items.fn_once_trait(),
-             ast::FnOnceUnboxedClosureKind)
-        ].iter() {
-            if Some(trait_id) == lang_item {
-                kind = Some(this_kind);
-                break
-            }
-        }
-
-        let kind = match kind {
-            Some(kind) => kind,
-            None => {
-                this.tcx().sess.span_err(b.path.span,
-                                         "unboxed function trait must be one \
-                                          of `Fn`, `FnMut`, or `FnOnce`");
-                ast::FnMutUnboxedClosureKind
-            }
-        };
-
-        let rscope = ExplicitRscope;
-        let param_ty = param_ty.to_ty(this.tcx());
-        Rc::new(astconv::trait_ref_for_unboxed_function(this,
-                                                        &rscope,
-                                                        kind,
-                                                        &*b.decl,
-                                                        Some(param_ty)))
-    });
-
     let trait_bounds: Vec<Rc<ty::TraitRef>> =
         trait_bounds.into_iter()
         .map(|b| {
@@ -2104,7 +2052,6 @@ fn conv_param_bounds<'tcx,AC>(this: &AC,
                                   param_ty.to_ty(this.tcx()),
                                   Some(param_ty.to_ty(this.tcx())))
         })
-        .chain(unboxed_fn_ty_bounds)
         .collect();
     let region_bounds: Vec<ty::Region> =
         region_bounds.into_iter()

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -1340,7 +1340,8 @@ pub fn instantiate_trait_ref<'tcx,AC>(this: &AC,
                                                trait_did,
                                                Some(self_ty),
                                                associated_type,
-                                               &ast_trait_ref.path);
+                                               &ast_trait_ref.path,
+                                               ast_trait_ref.ref_id);
 
             this.tcx().trait_refs.borrow_mut().insert(ast_trait_ref.ref_id,
                                                       trait_ref.clone());

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -1108,7 +1108,8 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
                 &ast::TraitTyParamBound(ref tr) => {
                     let last_seg = tr.path.segments.last().unwrap();
                     let mut insert = Vec::new();
-                    for (i, lt) in last_seg.lifetimes.iter().enumerate() {
+                    let lifetimes = last_seg.parameters.lifetimes();
+                    for (i, lt) in lifetimes.iter().enumerate() {
                         if region_names.contains(&lt.name) {
                             insert.push(i);
                         }
@@ -1116,7 +1117,7 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
                     let rebuild_info = RebuildPathInfo {
                         path: &tr.path,
                         indexes: insert,
-                        expected: last_seg.lifetimes.len(),
+                        expected: lifetimes.len(),
                         anon_nums: &HashSet::new(),
                         region_names: region_names
                     };
@@ -1257,7 +1258,7 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
                             let expected =
                                 generics.regions.len(subst::TypeSpace);
                             let lifetimes =
-                                &path.segments.last().unwrap().lifetimes;
+                                path.segments.last().unwrap().parameters.lifetimes();
                             let mut insert = Vec::new();
                             if lifetimes.len() == 0 {
                                 let anon = self.cur_anon.get();
@@ -1357,7 +1358,8 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
     fn rebuild_path(&self,
                     rebuild_info: RebuildPathInfo,
                     lifetime: ast::Lifetime)
-                    -> ast::Path {
+                    -> ast::Path
+    {
         let RebuildPathInfo {
             path,
             indexes,
@@ -1367,37 +1369,48 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
         } = rebuild_info;
 
         let last_seg = path.segments.last().unwrap();
-        let mut new_lts = Vec::new();
-        if last_seg.lifetimes.len() == 0 {
-            // traverse once to see if there's a need to insert lifetime
-            let need_insert = range(0, expected).any(|i| {
-                indexes.contains(&i)
-            });
-            if need_insert {
-                for i in range(0, expected) {
-                    if indexes.contains(&i) {
-                        new_lts.push(lifetime);
-                    } else {
-                        new_lts.push(self.life_giver.give_lifetime());
+        let new_parameters = match last_seg.parameters {
+            ast::ParenthesizedParameters(..) => {
+                last_seg.parameters.clone()
+            }
+
+            ast::AngleBracketedParameters(ref data) => {
+                let mut new_lts = Vec::new();
+                if data.lifetimes.len() == 0 {
+                    // traverse once to see if there's a need to insert lifetime
+                    let need_insert = range(0, expected).any(|i| {
+                        indexes.contains(&i)
+                    });
+                    if need_insert {
+                        for i in range(0, expected) {
+                            if indexes.contains(&i) {
+                                new_lts.push(lifetime);
+                            } else {
+                                new_lts.push(self.life_giver.give_lifetime());
+                            }
+                        }
+                    }
+                } else {
+                    for (i, lt) in data.lifetimes.iter().enumerate() {
+                        if indexes.contains(&i) {
+                            new_lts.push(lifetime);
+                        } else {
+                            new_lts.push(*lt);
+                        }
                     }
                 }
+                let new_types = data.types.map(|t| {
+                    self.rebuild_arg_ty_or_output(&**t, lifetime, anon_nums, region_names)
+                });
+                ast::AngleBracketedParameters(ast::AngleBracketedParameterData {
+                    lifetimes: new_lts,
+                    types: new_types
+                })
             }
-        } else {
-            for (i, lt) in last_seg.lifetimes.iter().enumerate() {
-                if indexes.contains(&i) {
-                    new_lts.push(lifetime);
-                } else {
-                    new_lts.push(*lt);
-                }
-            }
-        }
-        let new_types = last_seg.types.map(|t| {
-            self.rebuild_arg_ty_or_output(&**t, lifetime, anon_nums, region_names)
-        });
+        };
         let new_seg = ast::PathSegment {
             identifier: last_seg.identifier,
-            lifetimes: new_lts,
-            types: new_types,
+            parameters: new_parameters
         };
         let mut new_segs = Vec::new();
         new_segs.push_all(path.segments.init());

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -1102,9 +1102,6 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
                     // be passing down a map.
                     ast::RegionTyParamBound(lt)
                 }
-                &ast::UnboxedFnTyParamBound(ref unboxed_function_type) => {
-                    ast::UnboxedFnTyParamBound((*unboxed_function_type).clone())
-                }
                 &ast::TraitTyParamBound(ref tr) => {
                     let last_seg = tr.path.segments.last().unwrap();
                     let mut insert = Vec::new();

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -323,7 +323,6 @@ fn build_impl(cx: &DocContext, tcx: &ty::ctxt,
             trait_: associated_trait.clean(cx).map(|bound| {
                 match bound {
                     clean::TraitBound(ty) => ty,
-                    clean::UnboxedFnBound(..) |
                     clean::RegionBound(..) => unreachable!(),
                 }
             }),

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -476,7 +476,6 @@ impl Clean<TyParam> for ty::TypeParameterDef {
 #[deriving(Clone, Encodable, Decodable, PartialEq)]
 pub enum TyParamBound {
     RegionBound(Lifetime),
-    UnboxedFnBound(UnboxedFnType),
     TraitBound(Type)
 }
 
@@ -484,7 +483,6 @@ impl Clean<TyParamBound> for ast::TyParamBound {
     fn clean(&self, cx: &DocContext) -> TyParamBound {
         match *self {
             ast::RegionTyParamBound(lt) => RegionBound(lt.clean(cx)),
-            ast::UnboxedFnTyParamBound(ref ty) => { UnboxedFnBound(ty.clean(cx)) },
             ast::TraitTyParamBound(ref t) => TraitBound(t.clean(cx)),
         }
     }
@@ -596,21 +594,6 @@ impl Clean<Option<Vec<TyParamBound>>> for subst::Substs {
         v.extend(self.regions().iter().filter_map(|r| r.clean(cx)).map(RegionBound));
         v.extend(self.types.iter().map(|t| TraitBound(t.clean(cx))));
         if v.len() > 0 {Some(v)} else {None}
-    }
-}
-
-#[deriving(Clone, Encodable, Decodable, PartialEq)]
-pub struct UnboxedFnType {
-    pub path: Path,
-    pub decl: FnDecl
-}
-
-impl Clean<UnboxedFnType> for ast::UnboxedFnBound {
-    fn clean(&self, cx: &DocContext) -> UnboxedFnType {
-        UnboxedFnType {
-            path: self.path.clean(cx),
-            decl: self.decl.clean(cx)
-        }
     }
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1641,10 +1641,23 @@ pub struct PathSegment {
 
 impl Clean<PathSegment> for ast::PathSegment {
     fn clean(&self, cx: &DocContext) -> PathSegment {
+        let (lifetimes, types) = match self.parameters {
+            ast::AngleBracketedParameters(ref data) => {
+                (data.lifetimes.clean(cx), data.types.clean(cx))
+            }
+
+            ast::ParenthesizedParameters(ref data) => {
+                // FIXME -- rustdoc should be taught about Foo() notation
+                let inputs = Tuple(data.inputs.clean(cx));
+                let output = data.output.as_ref().map(|t| t.clean(cx)).unwrap_or(Tuple(Vec::new()));
+                (Vec::new(), vec![inputs, output])
+            }
+        };
+
         PathSegment {
             name: self.identifier.clean(cx),
-            lifetimes: self.lifetimes.clean(cx),
-            types: self.types.clean(cx),
+            lifetimes: lifetimes,
+            types: types,
         }
     }
 }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -143,9 +143,6 @@ impl fmt::Show for clean::TyParamBound {
             clean::RegionBound(ref lt) => {
                 write!(f, "{}", *lt)
             }
-            clean::UnboxedFnBound(ref ty) => {
-                write!(f, "{}{}", ty.path, ty.decl)
-            }
             clean::TraitBound(ref ty) => {
                 write!(f, "{}", *ty)
             }
@@ -404,8 +401,7 @@ impl fmt::Show for clean::Type {
                            let mut ret = String::new();
                            for bound in decl.bounds.iter() {
                                 match *bound {
-                                    clean::RegionBound(..) |
-                                    clean::UnboxedFnBound(..) => {}
+                                    clean::RegionBound(..) => {}
                                     clean::TraitBound(ref t) => {
                                         if ret.len() == 0 {
                                             ret.push_str(": ");

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -308,19 +308,10 @@ pub const DUMMY_NODE_ID: NodeId = -1;
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub enum TyParamBound {
     TraitTyParamBound(TraitRef),
-    UnboxedFnTyParamBound(P<UnboxedFnBound>),
     RegionTyParamBound(Lifetime)
 }
 
 pub type TyParamBounds = OwnedSlice<TyParamBound>;
-
-#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
-pub struct UnboxedFnBound {
-    pub path: Path,
-    pub decl: P<FnDecl>,
-    pub lifetimes: Vec<LifetimeDef>,
-    pub ref_id: NodeId,
-}
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub struct TyParam {
@@ -1090,12 +1081,6 @@ pub struct BareFnTy {
 }
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
-pub struct UnboxedFnTy {
-    pub kind: UnboxedClosureKind,
-    pub decl: P<FnDecl>,
-}
-
-#[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub enum Ty_ {
     TyNil,
     TyBot, /* bottom type */
@@ -1107,7 +1092,6 @@ pub enum Ty_ {
     TyClosure(P<ClosureTy>),
     TyProc(P<ClosureTy>),
     TyBareFn(P<BareFnTy>),
-    TyUnboxedFn(P<UnboxedFnTy>),
     TyTup(Vec<P<Ty>> ),
     TyPath(Path, Option<TyParamBounds>, NodeId), // for #7264; see above
     /// A "qualified path", e.g. `<Vec<T> as SomeTrait>::SomeType`

--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -848,9 +848,6 @@ impl<'ast> Visitor<'ast> for NodeCollector<'ast> {
             TyBareFn(ref fd) => {
                 self.visit_fn_decl(&*fd.decl);
             }
-            TyUnboxedFn(ref fd) => {
-                self.visit_fn_decl(&*fd.decl);
-            }
             _ => {}
         }
         visit::walk_ty(self, ty);

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -171,8 +171,10 @@ pub fn ident_to_path(s: Span, identifier: Ident) -> Path {
         segments: vec!(
             ast::PathSegment {
                 identifier: identifier,
-                lifetimes: Vec::new(),
-                types: OwnedSlice::empty(),
+                parameters: ast::AngleBracketedParameters(ast::AngleBracketedParameterData {
+                    lifetimes: Vec::new(),
+                    types: OwnedSlice::empty(),
+                })
             }
         ),
     }
@@ -681,11 +683,11 @@ pub fn segments_name_eq(a : &[ast::PathSegment], b : &[ast::PathSegment]) -> boo
         false
     } else {
         for (idx,seg) in a.iter().enumerate() {
-            if (seg.identifier.name != b[idx].identifier.name)
+            if seg.identifier.name != b[idx].identifier.name
                 // FIXME #7743: ident -> name problems in lifetime comparison?
-                || (seg.lifetimes != b[idx].lifetimes)
                 // can types contain idents?
-                || (seg.types != b[idx].types) {
+                || seg.parameters != b[idx].parameters
+            {
                 return false;
             }
         }
@@ -747,12 +749,10 @@ impl PostExpansionMethod for Method {
 mod test {
     use ast::*;
     use super::*;
-    use owned_slice::OwnedSlice;
 
     fn ident_to_segment(id : &Ident) -> PathSegment {
-        PathSegment {identifier:id.clone(),
-                     lifetimes: Vec::new(),
-                     types: OwnedSlice::empty()}
+        PathSegment {identifier: id.clone(),
+                     parameters: PathParameters::none()}
     }
 
     #[test] fn idents_name_eq_test() {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -313,14 +313,15 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                                                       .map(|ident| {
             ast::PathSegment {
                 identifier: ident,
-                lifetimes: Vec::new(),
-                types: OwnedSlice::empty(),
+                parameters: ast::PathParameters::none(),
             }
         }).collect();
         segments.push(ast::PathSegment {
             identifier: last_identifier,
-            lifetimes: lifetimes,
-            types: OwnedSlice::from_vec(types),
+            parameters: ast::AngleBracketedParameters(ast::AngleBracketedParameterData {
+                lifetimes: lifetimes,
+                types: OwnedSlice::from_vec(types),
+            })
         });
         ast::Path {
             span: sp,

--- a/src/libsyntax/ext/concat_idents.rs
+++ b/src/libsyntax/ext/concat_idents.rs
@@ -12,7 +12,6 @@ use ast;
 use codemap::Span;
 use ext::base::*;
 use ext::base;
-use owned_slice::OwnedSlice;
 use parse::token;
 use parse::token::{str_to_ident};
 use ptr::P;
@@ -52,8 +51,7 @@ pub fn expand_syntax_ext<'cx>(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree]
                  segments: vec!(
                     ast::PathSegment {
                         identifier: res,
-                        lifetimes: Vec::new(),
-                        types: OwnedSlice::empty(),
+                        parameters: ast::PathParameters::none(),
                     }
                 )
             }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -313,11 +313,6 @@ impl<'a, 'v> Visitor<'v> for Context<'a> {
                                    experimental and likely to be removed");
 
             },
-            ast::TyUnboxedFn(..) => {
-                self.gate_feature("unboxed_closure_sugar",
-                                  t.span,
-                                  "unboxed closure trait sugar is experimental");
-            }
             _ => {}
         }
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -166,6 +166,22 @@ pub trait Folder {
         noop_fold_path(p, self)
     }
 
+    fn fold_path_parameters(&mut self, p: PathParameters) -> PathParameters {
+        noop_fold_path_parameters(p, self)
+    }
+
+    fn fold_angle_bracketed_parameter_data(&mut self, p: AngleBracketedParameterData)
+                                           -> AngleBracketedParameterData
+    {
+        noop_fold_angle_bracketed_parameter_data(p, self)
+    }
+
+    fn fold_parenthesized_parameter_data(&mut self, p: ParenthesizedParameterData)
+                                         -> ParenthesizedParameterData
+    {
+        noop_fold_parenthesized_parameter_data(p, self)
+    }
+
     fn fold_local(&mut self, l: P<Local>) -> P<Local> {
         noop_fold_local(l, self)
     }
@@ -480,13 +496,41 @@ pub fn noop_fold_uint<T: Folder>(i: uint, _: &mut T) -> uint {
 pub fn noop_fold_path<T: Folder>(Path {global, segments, span}: Path, fld: &mut T) -> Path {
     Path {
         global: global,
-        segments: segments.move_map(|PathSegment {identifier, lifetimes, types}| PathSegment {
+        segments: segments.move_map(|PathSegment {identifier, parameters}| PathSegment {
             identifier: fld.fold_ident(identifier),
-            lifetimes: fld.fold_lifetimes(lifetimes),
-            types: types.move_map(|typ| fld.fold_ty(typ)),
+            parameters: fld.fold_path_parameters(parameters),
         }),
         span: fld.new_span(span)
     }
+}
+
+pub fn noop_fold_path_parameters<T: Folder>(path_parameters: PathParameters, fld: &mut T)
+                                            -> PathParameters
+{
+    match path_parameters {
+        AngleBracketedParameters(data) =>
+            AngleBracketedParameters(fld.fold_angle_bracketed_parameter_data(data)),
+        ParenthesizedParameters(data) =>
+            ParenthesizedParameters(fld.fold_parenthesized_parameter_data(data)),
+    }
+}
+
+pub fn noop_fold_angle_bracketed_parameter_data<T: Folder>(data: AngleBracketedParameterData,
+                                                           fld: &mut T)
+                                                           -> AngleBracketedParameterData
+{
+    let AngleBracketedParameterData { lifetimes, types } = data;
+    AngleBracketedParameterData { lifetimes: fld.fold_lifetimes(lifetimes),
+                                  types: types.move_map(|ty| fld.fold_ty(ty)) }
+}
+
+pub fn noop_fold_parenthesized_parameter_data<T: Folder>(data: ParenthesizedParameterData,
+                                                         fld: &mut T)
+                                                         -> ParenthesizedParameterData
+{
+    let ParenthesizedParameterData { inputs, output } = data;
+    ParenthesizedParameterData { inputs: inputs.move_map(|ty| fld.fold_ty(ty)),
+                                 output: output.map(|ty| fld.fold_ty(ty)) }
 }
 
 pub fn noop_fold_local<T: Folder>(l: P<Local>, fld: &mut T) -> P<Local> {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -424,12 +424,6 @@ pub fn noop_fold_ty<T: Folder>(t: P<Ty>, fld: &mut T) -> P<Ty> {
                     decl: fld.fold_fn_decl(decl)
                 }))
             }
-            TyUnboxedFn(f) => {
-                TyUnboxedFn(f.map(|UnboxedFnTy {decl, kind}| UnboxedFnTy {
-                    decl: fld.fold_fn_decl(decl),
-                    kind: kind,
-                }))
-            }
             TyTup(tys) => TyTup(tys.move_map(|ty| fld.fold_ty(ty))),
             TyParen(ty) => TyParen(fld.fold_ty(ty)),
             TyPath(path, bounds, id) => {
@@ -715,23 +709,6 @@ pub fn noop_fold_ty_param_bound<T>(tpb: TyParamBound, fld: &mut T)
     match tpb {
         TraitTyParamBound(ty) => TraitTyParamBound(fld.fold_trait_ref(ty)),
         RegionTyParamBound(lifetime) => RegionTyParamBound(fld.fold_lifetime(lifetime)),
-        UnboxedFnTyParamBound(bound) => {
-            match *bound {
-                UnboxedFnBound {
-                    ref path,
-                    ref decl,
-                    ref lifetimes,
-                    ref_id
-                } => {
-                    UnboxedFnTyParamBound(P(UnboxedFnBound {
-                        path: fld.fold_path(path.clone()),
-                        decl: fld.fold_fn_decl(decl.clone()),
-                        lifetimes: fld.fold_lifetime_defs(lifetimes.clone()),
-                        ref_id: fld.new_id(ref_id),
-                    }))
-                }
-            }
-        }
     }
 }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -749,8 +749,7 @@ mod test {
                         segments: vec!(
                             ast::PathSegment {
                                 identifier: str_to_ident("a"),
-                                lifetimes: Vec::new(),
-                                types: OwnedSlice::empty(),
+                                parameters: ast::PathParameters::none(),
                             }
                         ),
                     }),
@@ -768,13 +767,11 @@ mod test {
                             segments: vec!(
                                 ast::PathSegment {
                                     identifier: str_to_ident("a"),
-                                    lifetimes: Vec::new(),
-                                    types: OwnedSlice::empty(),
+                                    parameters: ast::PathParameters::none(),
                                 },
                                 ast::PathSegment {
                                     identifier: str_to_ident("b"),
-                                    lifetimes: Vec::new(),
-                                    types: OwnedSlice::empty(),
+                                    parameters: ast::PathParameters::none(),
                                 }
                             )
                         }),
@@ -952,8 +949,7 @@ mod test {
                             segments: vec!(
                                 ast::PathSegment {
                                     identifier: str_to_ident("d"),
-                                    lifetimes: Vec::new(),
-                                    types: OwnedSlice::empty(),
+                                    parameters: ast::PathParameters::none(),
                                 }
                             ),
                         }),
@@ -974,8 +970,7 @@ mod test {
                                segments: vec!(
                                 ast::PathSegment {
                                     identifier: str_to_ident("b"),
-                                    lifetimes: Vec::new(),
-                                    types: OwnedSlice::empty(),
+                                    parameters: ast::PathParameters::none(),
                                 }
                                ),
                             }),
@@ -1022,8 +1017,7 @@ mod test {
                                             ast::PathSegment {
                                                 identifier:
                                                     str_to_ident("int"),
-                                                lifetimes: Vec::new(),
-                                                types: OwnedSlice::empty(),
+                                                parameters: ast::PathParameters::none(),
                                             }
                                         ),
                                         }, None, ast::DUMMY_NODE_ID),
@@ -1072,10 +1066,8 @@ mod test {
                                                                 identifier:
                                                                 str_to_ident(
                                                                     "b"),
-                                                                lifetimes:
-                                                                Vec::new(),
-                                                                types:
-                                                                OwnedSlice::empty()
+                                                                parameters:
+                                                                ast::PathParameters::none(),
                                                             }
                                                         ),
                                                       }),

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1487,9 +1487,9 @@ impl<'a> Parser<'a> {
                 trait_name: trait_name.path,
                 item_name: item_name,
             }))
-        } else if self.token == token::ModSep
-            || self.token.is_ident()
-            || self.token.is_path() {
+        } else if self.token == token::ModSep ||
+                  self.token.is_ident() ||
+                  self.token.is_path() {
             // NAMED TYPE
             let mode = if plus_allowed {
                 LifetimeAndTypesAndBounds
@@ -1771,27 +1771,36 @@ impl<'a> Parser<'a> {
             let identifier = self.parse_ident();
 
             // Parse types, optionally.
-            let (lifetimes, types) = if self.eat_lt(false) {
-                self.parse_generic_values_after_lt()
-            } else if false && self.eat(&token::LParen) {
-                let mut types = self.parse_seq_to_end(
-                    &token::RParen,
+            let parameters = if self.eat_lt(false) {
+                let (lifetimes, types) = self.parse_generic_values_after_lt();
+
+                ast::AngleBracketedParameters(ast::AngleBracketedParameterData {
+                    lifetimes: lifetimes,
+                    types: OwnedSlice::from_vec(types),
+                })
+            } else if self.eat(&token::OpenDelim(token::Paren)) {
+                let inputs = self.parse_seq_to_end(
+                    &token::CloseDelim(token::Paren),
                     seq_sep_trailing_allowed(token::Comma),
                     |p| p.parse_ty(true));
 
-                if self.eat(&token::RArrow) {
-                    types.push(self.parse_ty(true))
-                }
+                let output_ty = if self.eat(&token::RArrow) {
+                    Some(self.parse_ty(true))
+                } else {
+                    None
+                };
 
-                (Vec::new(), types)
+                ast::ParenthesizedParameters(ast::ParenthesizedParameterData {
+                    inputs: inputs,
+                    output: output_ty
+                })
             } else {
-                (Vec::new(), Vec::new())
+                ast::PathParameters::none()
             };
 
             // Assemble and push the result.
             segments.push(ast::PathSegment { identifier: identifier,
-                                             lifetimes: lifetimes,
-                                             types: OwnedSlice::from_vec(types), });
+                                             parameters: parameters });
 
             // Continue only if we see a `::`
             if !self.eat(&token::ModSep) {
@@ -1810,9 +1819,13 @@ impl<'a> Parser<'a> {
 
             // If we do not see a `::`, stop.
             if !self.eat(&token::ModSep) {
-                segments.push(ast::PathSegment { identifier: identifier,
-                                                 lifetimes: Vec::new(),
-                                                 types: OwnedSlice::empty() });
+                segments.push(ast::PathSegment {
+                    identifier: identifier,
+                    parameters: ast::AngleBracketedParameters(ast::AngleBracketedParameterData {
+                        lifetimes: Vec::new(),
+                        types: OwnedSlice::empty(),
+                    })
+                });
                 return segments;
             }
 
@@ -1820,9 +1833,13 @@ impl<'a> Parser<'a> {
             if self.eat_lt(false) {
                 // Consumed `a::b::<`, go look for types
                 let (lifetimes, types) = self.parse_generic_values_after_lt();
-                segments.push(ast::PathSegment { identifier: identifier,
-                                                 lifetimes: lifetimes,
-                                                 types: OwnedSlice::from_vec(types) });
+                segments.push(ast::PathSegment {
+                    identifier: identifier,
+                    parameters: ast::AngleBracketedParameters(ast::AngleBracketedParameterData {
+                        lifetimes: lifetimes,
+                        types: OwnedSlice::from_vec(types),
+                    }),
+                });
 
                 // Consumed `a::b::<T,U>`, check for `::` before proceeding
                 if !self.eat(&token::ModSep) {
@@ -1830,9 +1847,10 @@ impl<'a> Parser<'a> {
                 }
             } else {
                 // Consumed `a::`, go look for `b`
-                segments.push(ast::PathSegment { identifier: identifier,
-                                                 lifetimes: Vec::new(),
-                                                 types: OwnedSlice::empty() });
+                segments.push(ast::PathSegment {
+                    identifier: identifier,
+                    parameters: ast::PathParameters::none(),
+                });
             }
         }
     }
@@ -1847,9 +1865,10 @@ impl<'a> Parser<'a> {
             let identifier = self.parse_ident();
 
             // Assemble and push the result.
-            segments.push(ast::PathSegment { identifier: identifier,
-                                             lifetimes: Vec::new(),
-                                             types: OwnedSlice::empty(), });
+            segments.push(ast::PathSegment {
+                identifier: identifier,
+                parameters: ast::PathParameters::none()
+            });
 
             // If we do not see a `::`, stop.
             if !self.eat(&token::ModSep) {
@@ -3455,13 +3474,9 @@ impl<'a> Parser<'a> {
                           },
                           _ => {
                               if !enum_path.global &&
-                                    enum_path.segments.len() == 1 &&
-                                    enum_path.segments[0]
-                                             .lifetimes
-                                             .len() == 0 &&
-                                    enum_path.segments[0]
-                                             .types
-                                             .len() == 0 {
+                                  enum_path.segments.len() == 1 &&
+                                  enum_path.segments[0].parameters.is_empty()
+                              {
                                   // it could still be either an enum
                                   // or an identifier pattern, resolve
                                   // will sort it out:
@@ -3960,8 +3975,7 @@ impl<'a> Parser<'a> {
     fn trait_ref_from_ident(ident: Ident, span: Span) -> ast::TraitRef {
         let segment = ast::PathSegment {
             identifier: ident,
-            lifetimes: Vec::new(),
-            types: OwnedSlice::empty(),
+            parameters: ast::PathParameters::none()
         };
         let path = ast::Path {
             span: span,
@@ -5677,8 +5691,7 @@ impl<'a> Parser<'a> {
                 segments: path.into_iter().map(|identifier| {
                     ast::PathSegment {
                         identifier: identifier,
-                        lifetimes: Vec::new(),
-                        types: OwnedSlice::empty(),
+                        parameters: ast::PathParameters::none(),
                     }
                 }).collect()
             };
@@ -5712,8 +5725,7 @@ impl<'a> Parser<'a> {
                         segments: path.into_iter().map(|identifier| {
                             ast::PathSegment {
                                 identifier: identifier,
-                                lifetimes: Vec::new(),
-                                types: OwnedSlice::empty(),
+                                parameters: ast::PathParameters::none(),
                             }
                         }).collect()
                     };
@@ -5730,8 +5742,7 @@ impl<'a> Parser<'a> {
                         segments: path.into_iter().map(|identifier| {
                             ast::PathSegment {
                                 identifier: identifier,
-                                lifetimes: Vec::new(),
-                                types: OwnedSlice::empty(),
+                                parameters: ast::PathParameters::none(),
                             }
                         }).collect()
                     };
@@ -5752,8 +5763,7 @@ impl<'a> Parser<'a> {
             segments: path.into_iter().map(|identifier| {
                 ast::PathSegment {
                     identifier: identifier,
-                    lifetimes: Vec::new(),
-                    types: OwnedSlice::empty(),
+                    parameters: ast::PathParameters::none(),
                 }
             }).collect()
         };

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -13,7 +13,7 @@ use ast::{FnUnboxedClosureKind, FnMutUnboxedClosureKind};
 use ast::{FnOnceUnboxedClosureKind};
 use ast::{MethodImplItem, RegionTyParamBound, TraitTyParamBound};
 use ast::{RequiredMethod, ProvidedMethod, TypeImplItem, TypeTraitItem};
-use ast::{UnboxedClosureKind, UnboxedFnTyParamBound};
+use ast::{UnboxedClosureKind};
 use ast;
 use ast_util;
 use owned_slice::OwnedSlice;
@@ -699,7 +699,6 @@ impl<'a> State<'a> {
                                       None,
                                       &OwnedSlice::empty(),
                                       Some(&generics),
-                                      None,
                                       None));
             }
             ast::TyClosure(ref f) => {
@@ -719,7 +718,6 @@ impl<'a> State<'a> {
                                       None,
                                       &f.bounds,
                                       Some(&generics),
-                                      None,
                                       None));
             }
             ast::TyProc(ref f) => {
@@ -739,20 +737,7 @@ impl<'a> State<'a> {
                                       None,
                                       &f.bounds,
                                       Some(&generics),
-                                      None,
                                       None));
-            }
-            ast::TyUnboxedFn(ref f) => {
-                try!(self.print_ty_fn(None,
-                                      None,
-                                      ast::NormalFn,
-                                      ast::Many,
-                                      &*f.decl,
-                                      None,
-                                      &OwnedSlice::empty(),
-                                      None,
-                                      None,
-                                      Some(f.kind)));
             }
             ast::TyPath(ref path, ref bounds, _) => {
                 try!(self.print_bounded_path(path, bounds));
@@ -1212,8 +1197,7 @@ impl<'a> State<'a> {
                               Some(m.ident),
                               &OwnedSlice::empty(),
                               Some(&m.generics),
-                              Some(&m.explicit_self.node),
-                              None));
+                              Some(&m.explicit_self.node)));
         word(&mut self.s, ";")
     }
 
@@ -2407,15 +2391,6 @@ impl<'a> State<'a> {
                     RegionTyParamBound(ref lt) => {
                         self.print_lifetime(lt)
                     }
-                    UnboxedFnTyParamBound(ref unboxed_function_type) => {
-                        try!(self.print_path(&unboxed_function_type.path,
-                                             false));
-                        try!(self.popen());
-                        try!(self.print_fn_args(&*unboxed_function_type.decl,
-                                                None));
-                        try!(self.pclose());
-                        self.print_fn_output(&*unboxed_function_type.decl)
-                    }
                 })
             }
             Ok(())
@@ -2675,9 +2650,7 @@ impl<'a> State<'a> {
                        id: Option<ast::Ident>,
                        bounds: &OwnedSlice<ast::TyParamBound>,
                        generics: Option<&ast::Generics>,
-                       opt_explicit_self: Option<&ast::ExplicitSelf_>,
-                       opt_unboxed_closure_kind:
-                        Option<ast::UnboxedClosureKind>)
+                       opt_explicit_self: Option<&ast::ExplicitSelf_>)
                        -> IoResult<()> {
         try!(self.ibox(indent_unit));
 
@@ -2694,9 +2667,7 @@ impl<'a> State<'a> {
             try!(self.print_fn_style(fn_style));
             try!(self.print_opt_abi_and_extern_if_nondefault(opt_abi));
             try!(self.print_onceness(onceness));
-            if opt_unboxed_closure_kind.is_none() {
-                try!(word(&mut self.s, "fn"));
-            }
+            try!(word(&mut self.s, "fn"));
         }
 
         match id {
@@ -2710,30 +2681,15 @@ impl<'a> State<'a> {
         match generics { Some(g) => try!(self.print_generics(g)), _ => () }
         try!(zerobreak(&mut self.s));
 
-        if opt_unboxed_closure_kind.is_some() || opt_sigil == Some('&') {
+        if opt_sigil == Some('&') {
             try!(word(&mut self.s, "|"));
         } else {
             try!(self.popen());
         }
 
-        match opt_unboxed_closure_kind {
-            Some(ast::FnUnboxedClosureKind) => {
-                try!(word(&mut self.s, "&"));
-                try!(self.word_space(":"));
-            }
-            Some(ast::FnMutUnboxedClosureKind) => {
-                try!(word(&mut self.s, "&mut"));
-                try!(self.word_space(":"));
-            }
-            Some(ast::FnOnceUnboxedClosureKind) => {
-                try!(self.word_space(":"));
-            }
-            None => {}
-        }
-
         try!(self.print_fn_args(decl, opt_explicit_self));
 
-        if opt_unboxed_closure_kind.is_some() || opt_sigil == Some('&') {
+        if opt_sigil == Some('&') {
             try!(word(&mut self.s, "|"));
         } else {
             if decl.variadic {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1995,14 +1995,34 @@ impl<'a> State<'a> {
 
             try!(self.print_ident(segment.identifier));
 
-            if !segment.lifetimes.is_empty() || !segment.types.is_empty() {
-                if colons_before_params {
-                    try!(word(&mut self.s, "::"))
-                }
+            try!(self.print_path_parameters(&segment.parameters, colons_before_params));
+        }
+
+        match *opt_bounds {
+            None => Ok(()),
+            Some(ref bounds) => self.print_bounds("+", bounds)
+        }
+    }
+
+    fn print_path_parameters(&mut self,
+                             parameters: &ast::PathParameters,
+                             colons_before_params: bool)
+                             -> IoResult<()>
+    {
+        if parameters.is_empty() {
+            return Ok(());
+        }
+
+        if colons_before_params {
+            try!(word(&mut self.s, "::"))
+        }
+
+        match *parameters {
+            ast::AngleBracketedParameters(ref data) => {
                 try!(word(&mut self.s, "<"));
 
                 let mut comma = false;
-                for lifetime in segment.lifetimes.iter() {
+                for lifetime in data.lifetimes.iter() {
                     if comma {
                         try!(self.word_space(","))
                     }
@@ -2010,24 +2030,38 @@ impl<'a> State<'a> {
                     comma = true;
                 }
 
-                if !segment.types.is_empty() {
+                if !data.types.is_empty() {
                     if comma {
                         try!(self.word_space(","))
                     }
                     try!(self.commasep(
                         Inconsistent,
-                        segment.types.as_slice(),
+                        data.types.as_slice(),
                         |s, ty| s.print_type(&**ty)));
                 }
 
                 try!(word(&mut self.s, ">"))
             }
+
+            ast::ParenthesizedParameters(ref data) => {
+                try!(word(&mut self.s, "("));
+                try!(self.commasep(
+                    Inconsistent,
+                    data.inputs.as_slice(),
+                    |s, ty| s.print_type(&**ty)));
+                try!(word(&mut self.s, ")"));
+
+                match data.output {
+                    None => { }
+                    Some(ref ty) => {
+                        try!(self.word_space("->"));
+                        try!(self.print_type(&**ty));
+                    }
+                }
+            }
         }
 
-        match *opt_bounds {
-            None => Ok(()),
-            Some(ref bounds) => self.print_bounds("+", bounds)
-        }
+        Ok(())
     }
 
     fn print_path(&mut self, path: &ast::Path,

--- a/src/libsyntax/std_inject.rs
+++ b/src/libsyntax/std_inject.rs
@@ -14,7 +14,6 @@ use codemap::DUMMY_SP;
 use codemap;
 use fold::Folder;
 use fold;
-use owned_slice::OwnedSlice;
 use parse::token::InternedString;
 use parse::token::special_idents;
 use parse::token;
@@ -181,13 +180,11 @@ impl<'a> fold::Folder for PreludeInjector<'a> {
             segments: vec!(
                 ast::PathSegment {
                     identifier: token::str_to_ident("std"),
-                    lifetimes: Vec::new(),
-                    types: OwnedSlice::empty(),
+                    parameters: ast::PathParameters::none(),
                 },
                 ast::PathSegment {
                     identifier: token::str_to_ident("prelude"),
-                    lifetimes: Vec::new(),
-                    types: OwnedSlice::empty(),
+                    parameters: ast::PathParameters::none(),
                 }),
         };
 

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -453,8 +453,7 @@ fn path_node(ids: Vec<ast::Ident> ) -> ast::Path {
         global: false,
         segments: ids.into_iter().map(|identifier| ast::PathSegment {
             identifier: identifier,
-            lifetimes: Vec::new(),
-            types: OwnedSlice::empty(),
+            parameters: ast::PathParameters::none(),
         }).collect()
     }
 }

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -407,11 +407,23 @@ pub fn walk_path<'v, V: Visitor<'v>>(visitor: &mut V, path: &'v Path) {
     for segment in path.segments.iter() {
         visitor.visit_ident(path.span, segment.identifier);
 
-        for typ in segment.types.iter() {
-            visitor.visit_ty(&**typ);
-        }
-        for lifetime in segment.lifetimes.iter() {
-            visitor.visit_lifetime_ref(lifetime);
+        match segment.parameters {
+            ast::AngleBracketedParameters(ref data) => {
+                for typ in data.types.iter() {
+                    visitor.visit_ty(&**typ);
+                }
+                for lifetime in data.lifetimes.iter() {
+                    visitor.visit_lifetime_ref(lifetime);
+                }
+            }
+            ast::ParenthesizedParameters(ref data) => {
+                for typ in data.inputs.iter() {
+                    visitor.visit_ty(&**typ);
+                }
+                for typ in data.output.iter() {
+                    visitor.visit_ty(&**typ);
+                }
+            }
         }
     }
 }

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -365,12 +365,6 @@ pub fn walk_ty<'v, V: Visitor<'v>>(visitor: &mut V, typ: &'v Ty) {
             visitor.visit_ty(&*function_declaration.decl.output);
             walk_lifetime_decls(visitor, &function_declaration.lifetimes);
         }
-        TyUnboxedFn(ref function_declaration) => {
-            for argument in function_declaration.decl.inputs.iter() {
-                visitor.visit_ty(&*argument.ty)
-            }
-            visitor.visit_ty(&*function_declaration.decl.output);
-        }
         TyPath(ref path, ref opt_bounds, id) => {
             visitor.visit_path(path, id);
             match *opt_bounds {
@@ -504,13 +498,6 @@ pub fn walk_ty_param_bounds<'v, V: Visitor<'v>>(visitor: &mut V,
         match *bound {
             TraitTyParamBound(ref typ) => {
                 walk_trait_ref_helper(visitor, typ)
-            }
-            UnboxedFnTyParamBound(ref function_declaration) => {
-                for argument in function_declaration.decl.inputs.iter() {
-                    visitor.visit_ty(&*argument.ty)
-                }
-                visitor.visit_ty(&*function_declaration.decl.output);
-                walk_lifetime_decls(visitor, &function_declaration.lifetimes);
             }
             RegionTyParamBound(ref lifetime) => {
                 visitor.visit_lifetime_ref(lifetime);

--- a/src/test/compile-fail/issue-18423.rs
+++ b/src/test/compile-fail/issue-18423.rs
@@ -8,7 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn fn1(0: Box) {} //~ ERROR: wrong number of type arguments: expected 1, found 0
+// Test that `Box` cannot be used with a lifetime parameter.
 
-fn main() {}
+struct Foo<'a> {
+    x: Box<'a, int> //~ ERROR wrong number of lifetime parameters
+}
 
+pub fn main() {
+}

--- a/src/test/compile-fail/unboxed-closure-sugar-default.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-default.rs
@@ -1,0 +1,37 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test interaction between unboxed closure sugar and default type
+// parameters (should be exactly as if angle brackets were used).
+
+#![feature(default_type_params)]
+#![allow(dead_code)]
+
+struct Foo<T,U,V=T> {
+    t: T, u: U
+}
+
+trait Eq<X> { }
+impl<X> Eq<X> for X { }
+fn eq<A,B:Eq<A>>() { }
+
+fn test<'a,'b>() {
+    // Parens are equivalent to omitting default in angle.
+    eq::< Foo<(int,),()>,               Foo(int)                      >();
+
+    // In angle version, we supply something other than the default
+    eq::< Foo<(int,),(),int>,           Foo(int)                      >();
+    //~^ ERROR not implemented
+
+    // Supply default explicitly.
+    eq::< Foo<(int,),(),(int,)>,        Foo(int)                      >();
+}
+
+fn main() { }

--- a/src/test/compile-fail/unboxed-closure-sugar-equiv.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-equiv.rs
@@ -1,0 +1,39 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that the unboxed closure sugar can be used with an arbitrary
+// struct type and that it is equivalent to the same syntax using
+// angle brackets. This test covers only simple types and in
+// particular doesn't test bound regions.
+
+#![allow(dead_code)]
+
+struct Foo<T,U> {
+    t: T, u: U
+}
+
+trait Eq<X> { }
+impl<X> Eq<X> for X { }
+fn eq<A,B:Eq<A>>() { }
+
+fn test<'a,'b>() {
+    // No errors expected:
+    eq::< Foo<(),()>,                   Foo()                         >();
+    eq::< Foo<(int,),()>,               Foo(int)                      >();
+    eq::< Foo<(int,uint),()>,           Foo(int,uint)                 >();
+    eq::< Foo<(int,uint),uint>,         Foo(int,uint) -> uint         >();
+    eq::< Foo<(&'a int,&'b uint),uint>, Foo(&'a int,&'b uint) -> uint >();
+
+    // Errors expected:
+    eq::< Foo<(),()>,                   Foo(char)                     >();
+    //~^ ERROR not implemented
+}
+
+fn main() { }

--- a/src/test/compile-fail/unboxed-closure-sugar-nonexistent-trait.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-nonexistent-trait.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn f<F:Nonexist(int) -> int>(x: F) {} //~ ERROR unresolved trait
+fn f<F:Nonexist(int) -> int>(x: F) {} //~ ERROR nonexistent trait `Nonexist`
 
 type Typedef = int;
 

--- a/src/test/compile-fail/unboxed-closure-sugar-region.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-region.rs
@@ -1,0 +1,45 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test interaction between unboxed closure sugar and region
+// parameters (should be exactly as if angle brackets were used
+// and regions omitted).
+
+#![feature(default_type_params)]
+#![allow(dead_code)]
+
+use std::kinds::marker;
+
+struct Foo<'a,T,U> {
+    t: T,
+    u: U,
+    m: marker::InvariantLifetime<'a>
+}
+
+trait Eq<X> { }
+impl<X> Eq<X> for X { }
+fn eq<A,B:Eq<A>>() { }
+fn same_type<A,B:Eq<A>>(a: A, b: B) { }
+
+fn test<'a,'b>() {
+    // Parens are equivalent to omitting default in angle.
+    eq::< Foo<(int,),()>,               Foo(int)                      >();
+
+    // Here we specify 'static explicitly in angle-bracket version.
+    // Parenthesized winds up getting inferred.
+    eq::< Foo<'static, (int,),()>,               Foo(int)                      >();
+}
+
+fn test2(x: Foo<(int,),()>, y: Foo(int)) {
+    // Here, the omitted lifetimes are expanded to distinct things.
+    same_type(x, y) //~ ERROR cannot infer
+}
+
+fn main() { }

--- a/src/test/compile-fail/unboxed-closure-sugar-wrong-number-number-type-parameters-1.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-wrong-number-number-type-parameters-1.rs
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn fn1(0: Box) {} //~ ERROR: wrong number of type arguments: expected 1, found 0
+struct One<A>;
 
-fn main() {}
+fn foo(_: One()) //~ ERROR wrong number of type arguments
+{}
 
+fn main() { }

--- a/src/test/compile-fail/unboxed-closure-sugar-wrong-number-number-type-parameters-3.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-wrong-number-number-type-parameters-3.rs
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn fn1(0: Box) {} //~ ERROR: wrong number of type arguments: expected 1, found 0
+struct Three<A,B,C>;
 
-fn main() {}
+fn foo(_: Three()) //~ ERROR wrong number of type arguments
+{}
 
+fn main() { }

--- a/src/test/compile-fail/unboxed-closure-sugar-wrong-number-number-type-parameters.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-wrong-number-number-type-parameters.rs
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn fn1(0: Box) {} //~ ERROR: wrong number of type arguments: expected 1, found 0
+struct Zero;
 
-fn main() {}
+fn foo(_: Zero()) //~ ERROR wrong number of type arguments
+{}
 
+fn main() { }

--- a/src/test/compile-fail/unboxed-closure-sugar-wrong-trait.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-wrong-trait.rs
@@ -11,7 +11,7 @@
 trait Trait {}
 
 fn f<F:Trait(int) -> int>(x: F) {}
-//~^ ERROR unboxed function trait must be one of `Fn`, `FnMut`, or `FnOnce`
+//~^ ERROR wrong number of type arguments: expected 0, found 2
 
 fn main() {}
 

--- a/src/test/run-pass/unboxed-closures-manual-impl.rs
+++ b/src/test/run-pass/unboxed-closures-manual-impl.rs
@@ -25,7 +25,7 @@ fn call_it<F:FnMut(int)->int>(mut f: F, x: int) -> int {
     f.call_mut((x,)) + 3
 }
 
-fn call_box(f: &mut |&mut: int|->int, x: int) -> int {
+fn call_box(f: &mut FnMut(int) -> int, x: int) -> int {
     f.call_mut((x,)) + 3
 }
 

--- a/src/test/run-pass/unboxed-closures-prelude.rs
+++ b/src/test/run-pass/unboxed-closures-prelude.rs
@@ -13,7 +13,7 @@
 #![feature(unboxed_closures, unboxed_closure_sugar)]
 
 fn main() {
-    let task: Box<|: int| -> int> = box |: x| x;
+    let task: Box<FnOnce(int) -> int> = box |: x| x;
     task.call_once((0i, ));
 }
 

--- a/src/test/run-pass/unboxed-closures-sugar-1.rs
+++ b/src/test/run-pass/unboxed-closures-sugar-1.rs
@@ -1,0 +1,34 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that the unboxed closure sugar can be used with an arbitrary
+// struct type and that it is equivalent to the same syntax using
+// angle brackets. This test covers only simple types and in
+// particular doesn't test bound regions.
+
+#![allow(dead_code)]
+
+struct Foo<T,U> {
+    t: T, u: U
+}
+
+trait Eq<X> { }
+impl<X> Eq<X> for X { }
+fn eq<A,B:Eq<A>>() { }
+
+fn test<'a,'b>() {
+    eq::< Foo<(),()>,                   Foo()                         >();
+    eq::< Foo<(int,),()>,               Foo(int)                      >();
+    eq::< Foo<(int,uint),()>,           Foo(int,uint)                 >();
+    eq::< Foo<(int,uint),uint>,         Foo(int,uint) -> uint         >();
+    eq::< Foo<(&'a int,&'b uint),uint>, Foo(&'a int,&'b uint) -> uint >();
+}
+
+fn main() { }

--- a/src/test/run-pass/unboxed-closures-sugar-object.rs
+++ b/src/test/run-pass/unboxed-closures-sugar-object.rs
@@ -8,7 +8,27 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn fn1(0: Box) {} //~ ERROR: wrong number of type arguments: expected 1, found 0
+// Test unboxed closure sugar used in object types.
 
-fn main() {}
+#![allow(dead_code)]
 
+struct Foo<T,U> {
+    t: T, u: U
+}
+
+trait Getter<A,R> {
+    fn get(&self, arg: A) -> R;
+}
+
+struct Identity;
+impl<X> Getter<X,X> for Identity {
+    fn get(&self, arg: X) -> X {
+        arg
+    }
+}
+
+fn main() {
+    let x: &Getter(int) -> (int,) = &Identity;
+    let (y,) = x.get((22,));
+    assert_eq!(y, 22);
+}

--- a/src/test/run-pass/unboxed-closures-unboxing-shim.rs
+++ b/src/test/run-pass/unboxed-closures-unboxing-shim.rs
@@ -13,7 +13,7 @@
 use std::ops::FnOnce;
 
 fn main() {
-    let task: Box<|: int| -> int> = box |: x| x;
+    let task: Box<FnOnce(int) -> int> = box |: x| x;
     assert!(task.call_once((1234i,)) == 1234i);
 }
 


### PR DESCRIPTION
Follow up to the paren branch.

r? @pcwalton 

Fixes #17703 (among other things).
