### PR TITLE
test: correct spelling error & inverted match.

### DIFF
--- a/src/test/run-make/target-specs/Makefile
+++ b/src/test/run-make/target-specs/Makefile
@@ -2,7 +2,7 @@
 all:
 	$(RUSTC) foo.rs --target=my-awesome-platform.json --crate-type=lib --emit=asm
 	grep --quiet --invert-match morestack < $(TMPDIR)/foo.s
-	$(RUSTC) foo.rs --target=my-invalid-platform.json 2>&1 | grep --quiet --invert-match "Error loading taget specification"
+	$(RUSTC) foo.rs --target=my-invalid-platform.json 2>&1 | grep --quiet "Error loading target specification"
 	$(RUSTC) foo.rs --target=my-incomplete-platform.json 2>&1 | grep 'Field llvm-target'
 	RUST_TARGET_PATH=. $(RUSTC) foo.rs --target=my-awesome-platform --crate-type=lib --emit=asm
 	RUST_TARGET_PATH=. $(RUSTC) foo.rs --target=x86_64-unknown-linux-gnu --crate-type=lib --emit=asm


### PR DESCRIPTION
r? @cmr

(I don't know if this is correct, but the old code was certainly wrong.)
