### PR TITLE
rustc: Process #[cfg]/#[cfg_attr] on crates

### DIFF
--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -212,11 +212,6 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         *ty == config::CrateTypeExecutable
     });
 
-    krate = time(time_passes, "crate injection", krate, |krate|
-                 syntax::std_inject::maybe_inject_crates_ref(krate,
-                                                             sess.opts.alt_std_name.clone(),
-                                                             any_exe));
-
     // strip before expansion to allow macros to depend on
     // configuration variables e.g/ in
     //
@@ -227,6 +222,11 @@ pub fn phase_2_configure_and_expand(sess: &Session,
 
     krate = time(time_passes, "configuration 1", krate, |krate|
                  syntax::config::strip_unconfigured_items(sess.diagnostic(), krate));
+
+    krate = time(time_passes, "crate injection", krate, |krate|
+                 syntax::std_inject::maybe_inject_crates_ref(krate,
+                                                             sess.opts.alt_std_name.clone(),
+                                                             any_exe));
 
     let mut addl_plugins = Some(addl_plugins);
     let Plugins { macros, registrars }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -1057,12 +1057,41 @@ pub fn noop_fold_mod<T: Folder>(Mod {inner, view_items, items}: Mod, folder: &mu
 
 pub fn noop_fold_crate<T: Folder>(Crate {module, attrs, config, exported_macros, span}: Crate,
                                   folder: &mut T) -> Crate {
+    let config = folder.fold_meta_items(config);
+
+    let mut items = folder.fold_item(P(ast::Item {
+        ident: token::special_idents::invalid,
+        attrs: attrs,
+        id: ast::DUMMY_NODE_ID,
+        vis: ast::Public,
+        span: span,
+        node: ast::ItemMod(module),
+    })).into_iter();
+
+    let (module, attrs, span) = match items.next() {
+        Some(item) => {
+            assert!(items.next().is_none(),
+                    "a crate cannot expand to more than one item");
+            item.and_then(|ast::Item { attrs, span, node, .. }| {
+                match node {
+                    ast::ItemMod(m) => (m, attrs, span),
+                    _ => panic!("fold converted a module to not a module"),
+                }
+            })
+        }
+        None => (ast::Mod {
+            inner: span,
+            view_items: Vec::new(),
+            items: Vec::new(),
+        }, Vec::new(), span)
+    };
+
     Crate {
-        module: folder.fold_mod(module),
-        attrs: attrs.move_map(|x| folder.fold_attribute(x)),
-        config: folder.fold_meta_items(config),
+        module: module,
+        attrs: attrs,
+        config: config,
         exported_macros: exported_macros,
-        span: folder.new_span(span)
+        span: span,
     }
 }
 

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -108,7 +108,10 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
     }
 
     fn fold_item(&mut self, i: P<ast::Item>) -> SmallVector<P<ast::Item>> {
-        self.cx.path.push(i.ident);
+        let ident = i.ident;
+        if ident.name != token::special_idents::invalid.name {
+            self.cx.path.push(ident);
+        }
         debug!("current path: {}",
                ast_util::path_name_i(self.cx.path.as_slice()));
 
@@ -143,7 +146,9 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
             ast::ItemMod(..) => fold::noop_fold_item(i, self),
             _ => SmallVector::one(i),
         };
-        self.cx.path.pop();
+        if ident.name != token::special_idents::invalid.name {
+            self.cx.path.pop();
+        }
         res
     }
 

--- a/src/test/auxiliary/stability_cfg1.rs
+++ b/src/test/auxiliary/stability_cfg1.rs
@@ -8,6 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub fn expr_add_3() {
-    3i + 4;
-}
+#![cfg_attr(foo, experimental)]
+#![cfg_attr(not(foo), stable)]

--- a/src/test/auxiliary/stability_cfg2.rs
+++ b/src/test/auxiliary/stability_cfg2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub fn expr_add_3() {
-    3i + 4;
-}
+// compile-flags:--cfg foo
+
+#![cfg_attr(foo, experimental)]
+#![cfg_attr(not(foo), stable)]
+

--- a/src/test/compile-fail/cfg-in-crate-1.rs
+++ b/src/test/compile-fail/cfg-in-crate-1.rs
@@ -8,6 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub fn expr_add_3() {
-    3i + 4;
-}
+// error-pattern:main function not found
+
+#![cfg(bar)]

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -10,6 +10,8 @@
 
 // aux-build:lint_stability.rs
 // aux-build:inherited_stability.rs
+// aux-build:stability_cfg1.rs
+// aux-build:stability_cfg2.rs
 
 #![feature(globs, phase)]
 #![deny(unstable)]
@@ -18,6 +20,9 @@
 #![allow(dead_code)]
 
 mod cross_crate {
+    extern crate stability_cfg1;
+    extern crate stability_cfg2; //~ ERROR: use of experimental item
+
     #[phase(plugin, link)]
     extern crate lint_stability; //~ ERROR: use of unmarked item
     use self::lint_stability::*;

--- a/src/test/run-make/graphviz-flowgraph/f03.dot-expected.dot
+++ b/src/test/run-make/graphviz-flowgraph/f03.dot-expected.dot
@@ -2,10 +2,10 @@ digraph block {
     N0[label="entry"];
     N1[label="exit"];
     N2[label="expr 3i"];
-    N3[label="expr 33i"];
-    N4[label="expr 3i + 33i"];
-    N5[label="stmt 3i + 33i;"];
-    N6[label="block { 3i + 33i; }"];
+    N3[label="expr 4"];
+    N4[label="expr 3i + 4"];
+    N5[label="stmt 3i + 4;"];
+    N6[label="block { 3i + 4; }"];
     N0 -> N2;
     N2 -> N3;
     N3 -> N4;

--- a/src/test/run-pass/cfg-in-crate-1.rs
+++ b/src/test/run-pass/cfg-in-crate-1.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub fn expr_add_3() {
-    3i + 4;
-}
+// compile-flags: --cfg bar -D warnings
+// ignore-pretty
+
+#![cfg(bar)]
+
+fn main() {}


### PR DESCRIPTION
This commit implements processing these two attributes at the crate level as
well as at the item level. When #[cfg] is applied at the crate level, then the
entire crate will be omitted if the cfg doesn't match. The #[cfg_attr] attribute
is processed as usual in that the attribute is included or not depending on
whether the cfg matches.

This was spurred on by motivations of #18585 where #[cfg_attr] annotations will
be applied at the crate-level.

cc #18585
