### PR TITLE
librustc_back: Fix triple for linux armhf.

### DIFF
--- a/src/librustc_back/target/arm_unknown_linux_gnueabihf.rs
+++ b/src/librustc_back/target/arm_unknown_linux_gnueabihf.rs
@@ -18,7 +18,7 @@ pub fn target() -> Target {
                       -f32:32:32-f64:64:64\
                       -v64:64:64-v128:64:128\
                       -a0:0:64-n32".to_string(),
-        llvm_target: "arm-unknown-linux-gnueabi".to_string(),
+        llvm_target: "arm-unknown-linux-gnueabihf".to_string(),
         target_endian: "little".to_string(),
         target_word_size: "32".to_string(),
         arch: "arm".to_string(),


### PR DESCRIPTION
Fix a small typo.
