### PR TITLE
librustc: Call return_type only for functions.

### DIFF
--- a/src/librustc/middle/trans/build.rs
+++ b/src/librustc/middle/trans/build.rs
@@ -655,7 +655,7 @@ pub fn _UndefReturn(cx: Block, fn_: ValueRef) -> ValueRef {
     unsafe {
         let ccx = cx.fcx.ccx;
         let ty = val_ty(fn_);
-        let retty = if ty.kind() == llvm::Integer {
+        let retty = if ty.kind() == llvm::Function {
             ty.return_type()
         } else {
             ccx.int_type()

--- a/src/test/run-fail/issue-18576.rs
+++ b/src/test/run-fail/issue-18576.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:stop
+
+// #18576
+// Make sure that an calling extern function pointer in an unreachable
+// context doesn't cause an LLVM assertion
+
+#[allow(unreachable_code)]
+fn main() {
+    panic!("stop");
+    let pointer = other;
+    pointer();
+}
+extern fn other() {}


### PR DESCRIPTION
Fixes #18576.
