### PR TITLE
Rename misspelled module reference.

### DIFF
--- a/src/librustc_back/target/i686_unknown_dragonfly.rs
+++ b/src/librustc_back/target/i686_unknown_dragonfly.rs
@@ -11,7 +11,7 @@
 use target::Target;
 
 pub fn target() -> Target {
-    let mut base = super::draginfly_base::opts();
+    let mut base = super::dragonfly_base::opts();
     base.pre_link_args.push("-m32".to_string());
 
     Target {

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -63,6 +63,7 @@ mod arm_unknown_linux_gnueabihf;
 mod i686_apple_darwin;
 mod i386_apple_ios;
 mod i686_pc_windows_gnu;
+mod i686_unknown_dragonfly;
 mod i686_unknown_linux_gnu;
 mod mips_unknown_linux_gnu;
 mod mipsel_unknown_linux_gnu;
@@ -338,6 +339,7 @@ impl Target {
 
             x86_64_unknown_freebsd,
 
+            i686_unknown_dragonfly,
             x86_64_unknown_dragonfly,
 
             x86_64_apple_darwin,


### PR DESCRIPTION
I renamed the module reference from "draginfly_base" to "dragonfly_base".
