### PR TITLE
debuginfo: Add timeout for LLDB tests.

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -677,7 +677,9 @@ CTEST_DEPS_cfail_$(1)-T-$(2)-H-$(3) = $$(CFAIL_TESTS)
 CTEST_DEPS_bench_$(1)-T-$(2)-H-$(3) = $$(BENCH_TESTS)
 CTEST_DEPS_perf_$(1)-T-$(2)-H-$(3) = $$(PERF_TESTS)
 CTEST_DEPS_debuginfo-gdb_$(1)-T-$(2)-H-$(3) = $$(DEBUGINFO_GDB_TESTS)
-CTEST_DEPS_debuginfo-lldb_$(1)-T-$(2)-H-$(3) = $$(DEBUGINFO_LLDB_TESTS)
+CTEST_DEPS_debuginfo-lldb_$(1)-T-$(2)-H-$(3) = $$(DEBUGINFO_LLDB_TESTS) \
+                                               $(S)src/etc/lldb_batchmode.py \
+                                               $(S)src/etc/lldb_rust_formatters.py
 CTEST_DEPS_codegen_$(1)-T-$(2)-H-$(3) = $$(CODEGEN_TESTS)
 
 endef

--- a/src/etc/lldb_batchmode.py
+++ b/src/etc/lldb_batchmode.py
@@ -30,6 +30,7 @@ import sys
 import threading
 import re
 import atexit
+import time
 
 # Set this to True for additional output
 DEBUG_OUTPUT = False
@@ -175,6 +176,10 @@ try:
 
   for line in script_file:
     command = line.strip()
+    if command == "run" or command == "r" or re.match("^process\s+launch.*", command):
+      # Before starting to run the program, let the thread sleep a bit, so all
+      # breakpoint added events can be processed
+      time.sleep(0.5)
     if command != '':
       execute_command(command_interpreter, command)
 


### PR DESCRIPTION
If a test takes longer than 10 seconds it will be aborted now, which should prevent the build infrastructure from being blocked for a full hour if an LLDB freeze happens.

Since, as far as I've seen, the freezing happens very rarely and at random tests, we could also get fancy and automatically retry running the tests a few times if it was aborted due to a timeout. That would be quite nice actually.

cc @alexcrichton 
