### PR TITLE
Properly escape paths to executables. Fixes #18632.

### DIFF
--- a/configure
+++ b/configure
@@ -86,7 +86,7 @@ putpathvar() {
     else
         printf "configure: %-20s := %s %s\n" $1 "$T" "$2"
     fi
-    printf "%-20s := %q\n" $1 "$T" >>config.tmp
+    printf "%-20s := \"%s\"\n" $1 "$T" >>config.tmp
 }
 
 probe() {
@@ -651,9 +651,9 @@ probe CFG_ADB        adb
 
 if [ ! -z "$CFG_PANDOC" ]
 then
-    PV_MAJOR_MINOR=$(pandoc --version | grep '^pandoc ' |
+    PV_MAJOR_MINOR=$(pandoc --version | grep '^pandoc\(.exe\)\? ' |
         # extract the first 2 version fields, ignore everything else
-        sed 's/pandoc \([0-9]*\)\.\([0-9]*\).*/\1 \2/')
+        sed 's/pandoc\(.exe\)\? \([0-9]*\)\.\([0-9]*\).*/\2 \3/')
 
     MIN_PV_MAJOR="1"
     MIN_PV_MINOR="9"

--- a/configure
+++ b/configure
@@ -76,6 +76,19 @@ putvar() {
     printf "%-20s := %s\n" $1 "$T" >>config.tmp
 }
 
+putpathvar() {
+    local T
+    eval T=\$$1
+    eval TLEN=\${#$1}
+    if [ $TLEN -gt 35 ]
+    then
+        printf "configure: %-20s := %.35s ...\n" $1 "$T"
+    else
+        printf "configure: %-20s := %s %s\n" $1 "$T" "$2"
+    fi
+    printf "%-20s := %q\n" $1 "$T" >>config.tmp
+}
+
 probe() {
     local V=$1
     shift
@@ -101,7 +114,7 @@ probe() {
         fi
     done
     eval $V=\$T
-    putvar $V "$VER"
+    putpathvar $V "$VER"
 }
 
 probe_need() {
@@ -1330,8 +1343,7 @@ do
 done
 
 # Munge any paths that appear in config.mk back to posix-y
-perl -i.bak -p -e 's@ ([a-zA-Z]):[/\\]@ /\1/@go;' \
-               -e 's@\\@/@go;' config.tmp
+perl -i.bak -p -e 's@ ([a-zA-Z]):[/\\]@ /\1/@go;' config.tmp
 rm -f config.tmp.bak
 
 msg

--- a/configure
+++ b/configure
@@ -86,7 +86,12 @@ putpathvar() {
     else
         printf "configure: %-20s := %s %s\n" $1 "$T" "$2"
     fi
-    printf "%-20s := \"%s\"\n" $1 "$T" >>config.tmp
+    if [ -z "$T" ]
+    then
+        printf "%-20s := \n" $1 >>config.tmp
+    else
+        printf "%-20s := \"%s\"\n" $1 "$T" >>config.tmp
+    fi
 }
 
 probe() {

--- a/mk/reconfig.mk
+++ b/mk/reconfig.mk
@@ -19,7 +19,7 @@ ifndef CFG_DISABLE_MANAGE_SUBMODULES
 # (nothing checked out at all).  `./configure --{llvm,jemalloc}-root`
 # will explicitly deinitialize the corresponding submodules, and we don't
 # want to force constant rebuilds in that case.
-NEED_GIT_RECONFIG=$(shell cd "$(CFG_SRC_DIR)" && "$(CFG_GIT)" submodule status | grep -c '^+')
+NEED_GIT_RECONFIG=$(shell cd "$(CFG_SRC_DIR)" && $(CFG_GIT) submodule status | grep -c '^+')
 else
 NEED_GIT_RECONFIG=0
 endif


### PR DESCRIPTION
1. Introduce `putpathvar` function that prints variable shell-quoted by using `%q` format specifier. This function is used within `probe` to save the result into `config.tmp`.
2. Removes search-and-replace pattern that transforms `\` into `/` as it messes up shell-quoted strings.
