### PR TITLE
use jemalloc's default prefix

### DIFF
--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -175,7 +175,7 @@ JEMALLOC_LOCAL_$(1) := $$(JEMALLOC_BUILD_DIR_$(1))/lib/$$(JEMALLOC_REAL_NAME_$(1
 $$(JEMALLOC_LOCAL_$(1)): $$(JEMALLOC_DEPS) $$(MKFILE_DEPS)
 	@$$(call E, make: jemalloc)
 	cd "$$(JEMALLOC_BUILD_DIR_$(1))"; "$(S)src/jemalloc/configure" \
-		$$(JEMALLOC_ARGS_$(1)) --with-jemalloc-prefix=je_ $(CFG_JEMALLOC_FLAGS) \
+		$$(JEMALLOC_ARGS_$(1)) $(CFG_JEMALLOC_FLAGS) \
 		--build=$$(CFG_GNU_TRIPLE_$(CFG_BUILD)) --host=$$(CFG_GNU_TRIPLE_$(1)) \
 		CC="$$(CC_$(1))" \
 		AR="$$(AR_$(1))" \


### PR DESCRIPTION
By default, jemalloc only uses a prefix on OS X, iOS and Windows where
attempting to replace the platform allocator is broken. The lack of a
prefix allows jemalloc to override the weak symbols from the C standard
library to replace the system allocator.

This results in a performance improvement for memory allocation in C
along with reduced fragmentation. For example, the time spent on LLVM
passes in the Rust compiler on Linux is cut by 10% and peak memory usage
is reduced by 15%. Even on platforms like FreeBSD where jemalloc is the
system allocator, this eliminates the inevitable external fragmentation
and performance hit caused by using two general purpose allocators.

Closes #18676
