### PR TITLE
libstd’s Duration refactor

### DIFF
--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -382,7 +382,7 @@ impl FromStr for Duration {
             (Some(c), rem) if c == 'P' || c == 'p' => rem,
             _ => return None
         };
- 
+
         // D - days
         let (days, _, next) = atoi(s);
 
@@ -411,14 +411,14 @@ impl FromStr for Duration {
             }
 
             s = match next.slice_shift_char() {
-                (Some(c), rem) if (c == 'H' || c == 'h') 
+                (Some(c), rem) if (c == 'H' || c == 'h')
                                             && hours.is_none() && minutes.is_none()
                                             && seconds.is_none() && nanos.is_none() => {
                     hours = value;
                     rem
                 },
-                (Some(c), rem) if (c == 'M' || c == 'm') 
-                                            && minutes.is_none() && seconds.is_none() 
+                (Some(c), rem) if (c == 'M' || c == 'm')
+                                            && minutes.is_none() && seconds.is_none()
                                             && nanos.is_none() => {
                     minutes = value;
                     rem
@@ -427,7 +427,7 @@ impl FromStr for Duration {
                     seconds = value;
                     rem
                 },
-                (Some(c), rem) if (c == 'S' || c == 's') 
+                (Some(c), rem) if (c == 'S' || c == 's')
                                             && (seconds.is_none() || nanos.is_none()) => {
                     if seconds.is_none() {
                         seconds = value;
@@ -457,17 +457,17 @@ impl FromStr for Duration {
 
         millis = try_opt!(millis.checked_add(&minutes_millis));
         millis = try_opt!(millis.checked_add(&seconds_millis));
-        
+
         let mut nanos = nanos.unwrap_or(0);
 
-        if sign == '-' { 
+        if sign == '-' {
             millis = -millis;
             nanos = -nanos;
         }
 
         Some(
             duration!(
-                try_opt!(millis.checked_add(&(nanos / NANOS_PER_MILLI))), 
+                try_opt!(millis.checked_add(&(nanos / NANOS_PER_MILLI))),
                 (nanos % NANOS_PER_MILLI) as i32
             )
         )

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -168,6 +168,7 @@ impl Duration {
     }
 
     /// Returns the total number of microseconds in the duration.
+    /// or `None` on overflow (exceeding 2^63 microseconds in either direction).
     #[inline]
     pub fn num_microseconds(&self) -> Option<i64> {
         let micros = try_opt!(self.millis.checked_mul(&MICROS_PER_MILLI));
@@ -175,6 +176,7 @@ impl Duration {
     }
 
     /// Returns the total number of nanoseconds in the duration.
+    /// or `None` on overflow (exceeding 2^63 nanoseconds in either direction).
     #[inline]
     pub fn num_nanoseconds(&self) -> Option<i64> {
         let nanos = try_opt!(self.millis.checked_mul(&NANOS_PER_MILLI));

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -43,7 +43,7 @@ const OUT_OF_BOUNDS: &'static str = "Duration out of bounds";
 /// An absolute amount of time, independent of time zones and calendars with nanosecond precision.
 /// A duration can express the positive or negative difference between two instants in time
 /// according to a particular clock.
-#[deriving(Clone, PartialEq, Eq, PartialOrd, Ord, Zero, Default, Hash, Rand)]
+#[deriving(Clone, PartialEq, Eq, PartialOrd, Ord, Zero, Default, Hash)]
 pub struct Duration {
     millis: i64, // Milliseconds
     nanos:  i32, // Nanoseconds, |nanos| < NANOS_PER_MILLI

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -346,7 +346,7 @@ impl FromStr for Duration {
 
             while !s.is_empty() {
                 s = match s.slice_shift_char() {
-                    (Some(c), rem) if c.is_digit() => {
+                    (Some(c), rem) if '0' <= c && c <= '9' => {
                         let digit = (c as u8 - b'0') as i64;
 
                         value = value.unwrap_or(0).checked_mul(&10);


### PR DESCRIPTION
This commit changes the internal representation of Duration from

```
pub struct Duraion {
    secs: i64,
    nanos: i32
}
```

to

```
pub struct Duration {
    millis: i64, // Milliseconds
    nanos:  i32, // Nanoseconds, |nanos| < NANOS_PER_MILLI
}
```
