### PR TITLE
Remove struct_variant feature gate.

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1339,7 +1339,6 @@ a = Cat;
 Enumeration constructors can have either named or unnamed fields:
 
 ```
-# #![feature(struct_variant)]
 # fn main() {
 enum Animal {
     Dog (String, f64),
@@ -2539,13 +2538,6 @@ The currently implemented features of the reference compiler are:
 
 * `struct_inherit` - Allows using struct inheritance, which is barely
                      implemented and will probably be removed. Don't use this.
-
-* `struct_variant` - Structural enum variants (those with named fields). It is
-                     currently unknown whether this style of enum variant is as
-                     fully supported as the tuple-forms, and it's not certain
-                     that this style of variant should remain in the language.
-                     For now this style of variant is hidden behind a feature
-                     flag.
 
 * `thread_local` - The usage of the `#[thread_local]` attribute is experimental
                    and should be seen as unstable. This attribute is used to

--- a/src/etc/generate-deriving-span-tests.py
+++ b/src/etc/generate-deriving-span-tests.py
@@ -37,7 +37,6 @@ TEMPLATE = """// Copyright {year} The Rust Project Developers. See the COPYRIGHT
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 {error_deriving}

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -29,7 +29,7 @@ This API is completely unstable and subject to change.
       html_root_url = "http://doc.rust-lang.org/nightly/")]
 
 #![feature(default_type_params, globs, if_let, import_shadowing, macro_rules, phase, quote)]
-#![feature(slicing_syntax, struct_variant, unsafe_destructor)]
+#![feature(slicing_syntax, unsafe_destructor)]
 #![feature(rustc_diagnostic_macros)]
 
 extern crate arena;

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -16,7 +16,7 @@
 #![crate_type = "rlib"]
 
 #![allow(unknown_features)]
-#![feature(globs, struct_variant, macro_rules, phase, slicing_syntax)]
+#![feature(globs, macro_rules, phase, slicing_syntax)]
 
 extern crate arena;
 extern crate getopts;

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -37,7 +37,7 @@ use std::slice;
 static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[
     ("globs", Active),
     ("macro_rules", Active),
-    ("struct_variant", Active),
+    ("struct_variant", Removed),
     ("once_fns", Active),
     ("asm", Active),
     ("managed_boxes", Removed),

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -25,7 +25,7 @@
 
 #![allow(unknown_features)]
 #![feature(macro_rules, globs, default_type_params, phase, slicing_syntax)]
-#![feature(quote, struct_variant, unsafe_destructor, import_shadowing)]
+#![feature(quote, unsafe_destructor, import_shadowing)]
 
 extern crate arena;
 extern crate fmt_macros;

--- a/src/test/auxiliary/issue-8044.rs
+++ b/src/test/auxiliary/issue-8044.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 pub struct BTree<V> {
     pub node: TreeItem<V>,
 }

--- a/src/test/auxiliary/namespaced_enum_emulate_flat.rs
+++ b/src/test/auxiliary/namespaced_enum_emulate_flat.rs
@@ -7,7 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(globs, struct_variant)]
+#![feature(globs)]
 
 pub use Foo::*;
 

--- a/src/test/auxiliary/namespaced_enums.rs
+++ b/src/test/auxiliary/namespaced_enums.rs
@@ -7,7 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(struct_variant)]
 
 pub enum Foo {
     A,

--- a/src/test/auxiliary/privacy-struct-variant.rs
+++ b/src/test/auxiliary/privacy-struct-variant.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 pub enum Foo {
     Bar {
         baz: int

--- a/src/test/auxiliary/struct_variant_xc_aux.rs
+++ b/src/test/auxiliary/struct_variant_xc_aux.rs
@@ -11,8 +11,6 @@
 #![crate_name="struct_variant_xc_aux"]
 #![crate_type = "lib"]
 
-#![feature(struct_variant)]
-
 pub enum Enum {
     Variant(u8),
     StructVariant { pub arg: u8 }

--- a/src/test/compile-fail/deriving-primitive.rs
+++ b/src/test/compile-fail/deriving-primitive.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 use std::num::FromPrimitive;
 use std::int;
 

--- a/src/test/compile-fail/deriving-span-Clone-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-Clone-enum-struct-variant.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Clone-enum.rs
+++ b/src/test/compile-fail/deriving-span-Clone-enum.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Clone-struct.rs
+++ b/src/test/compile-fail/deriving-span-Clone-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Clone-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Clone-tuple-struct.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Default-struct.rs
+++ b/src/test/compile-fail/deriving-span-Default-struct.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Default-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Default-tuple-struct.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Hash-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-Hash-enum-struct-variant.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Hash-enum.rs
+++ b/src/test/compile-fail/deriving-span-Hash-enum.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Hash-struct.rs
+++ b/src/test/compile-fail/deriving-span-Hash-struct.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Hash-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Hash-tuple-struct.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-PartialEq-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-PartialEq-enum-struct-variant.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-PartialEq-enum.rs
+++ b/src/test/compile-fail/deriving-span-PartialEq-enum.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-PartialEq-struct.rs
+++ b/src/test/compile-fail/deriving-span-PartialEq-struct.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-PartialEq-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-PartialEq-tuple-struct.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-PartialOrd-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-PartialOrd-enum-struct-variant.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-PartialOrd-enum.rs
+++ b/src/test/compile-fail/deriving-span-PartialOrd-enum.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-PartialOrd-struct.rs
+++ b/src/test/compile-fail/deriving-span-PartialOrd-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-PartialOrd-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-PartialOrd-tuple-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-Rand-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-Rand-enum-struct-variant.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Rand-enum.rs
+++ b/src/test/compile-fail/deriving-span-Rand-enum.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Rand-struct.rs
+++ b/src/test/compile-fail/deriving-span-Rand-struct.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Rand-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Rand-tuple-struct.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Show-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-Show-enum-struct-variant.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Show-enum.rs
+++ b/src/test/compile-fail/deriving-span-Show-enum.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Show-struct.rs
+++ b/src/test/compile-fail/deriving-span-Show-struct.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Show-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Show-tuple-struct.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-TotalEq-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-TotalEq-enum-struct-variant.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-TotalEq-enum.rs
+++ b/src/test/compile-fail/deriving-span-TotalEq-enum.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-TotalEq-struct.rs
+++ b/src/test/compile-fail/deriving-span-TotalEq-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-TotalEq-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-TotalEq-tuple-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-TotalOrd-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-TotalOrd-enum-struct-variant.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(Eq,PartialOrd,PartialEq)]

--- a/src/test/compile-fail/deriving-span-TotalOrd-enum.rs
+++ b/src/test/compile-fail/deriving-span-TotalOrd-enum.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(Eq,PartialOrd,PartialEq)]

--- a/src/test/compile-fail/deriving-span-TotalOrd-struct.rs
+++ b/src/test/compile-fail/deriving-span-TotalOrd-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(Eq,PartialOrd,PartialEq)]

--- a/src/test/compile-fail/deriving-span-TotalOrd-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-TotalOrd-tuple-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(Eq,PartialOrd,PartialEq)]

--- a/src/test/compile-fail/deriving-span-Zero-struct.rs
+++ b/src/test/compile-fail/deriving-span-Zero-struct.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/deriving-span-Zero-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Zero-tuple-struct.rs
@@ -10,9 +10,7 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
-
 
 struct Error;
 

--- a/src/test/compile-fail/dup-struct-enum-struct-variant.rs
+++ b/src/test/compile-fail/dup-struct-enum-struct-variant.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 enum Foo { C { a: int, b: int } }
 struct C { a: int, b: int }         //~ ERROR error: duplicate definition of type or module `C`
 

--- a/src/test/compile-fail/gated-non-ascii-idents.rs
+++ b/src/test/compile-fail/gated-non-ascii-idents.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 
-#![feature(struct_variant)]
-
 extern crate bäz; //~ ERROR non-ascii idents
 
 use föö::bar; //~ ERROR non-ascii idents

--- a/src/test/compile-fail/issue-13624.rs
+++ b/src/test/compile-fail/issue-13624.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 mod a {
   pub enum Enum {
     EnumStructVariant { x: u8, y: u8, z: u8 }

--- a/src/test/compile-fail/issue-18252.rs
+++ b/src/test/compile-fail/issue-18252.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 enum Foo {
     Variant { x: uint }
 }

--- a/src/test/compile-fail/lint-dead-code-4.rs
+++ b/src/test/compile-fail/lint-dead-code-4.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
 #![allow(unused_variables)]
 #![allow(non_camel_case_types)]
 #![deny(dead_code)]

--- a/src/test/compile-fail/lint-dead-code-5.rs
+++ b/src/test/compile-fail/lint-dead-code-5.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
 #![allow(unused_variables)]
 #![deny(dead_code)]
 

--- a/src/test/compile-fail/lint-missing-doc.rs
+++ b/src/test/compile-fail/lint-missing-doc.rs
@@ -10,7 +10,6 @@
 
 // When denying at the crate level, be sure to not get random warnings from the
 // injected intrinsics by the compiler.
-#![feature(struct_variant)]
 #![feature(globs)]
 #![deny(missing_docs)]
 #![allow(dead_code)]

--- a/src/test/compile-fail/lint-raw-ptr-deriving.rs
+++ b/src/test/compile-fail/lint-raw-ptr-deriving.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
 #![allow(dead_code)]
 #![deny(raw_pointer_deriving)]
 

--- a/src/test/compile-fail/lint-visible-private-types.rs
+++ b/src/test/compile-fail/lint-visible-private-types.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
 #![deny(visible_private_types)]
 #![allow(dead_code)]
 #![crate_type="lib"]

--- a/src/test/compile-fail/namespaced-enum-glob-import-no-impls-xcrate.rs
+++ b/src/test/compile-fail/namespaced-enum-glob-import-no-impls-xcrate.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:namespaced_enums.rs
-#![feature(struct_variant, globs)]
+#![feature(globs)]
 
 extern crate namespaced_enums;
 

--- a/src/test/compile-fail/namespaced-enum-glob-import-no-impls.rs
+++ b/src/test/compile-fail/namespaced-enum-glob-import-no-impls.rs
@@ -7,7 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(struct_variant, globs)]
+#![feature(globs)]
 
 mod m2 {
     pub enum Foo {

--- a/src/test/compile-fail/non-exhaustive-pattern-witness.rs
+++ b/src/test/compile-fail/non-exhaustive-pattern-witness.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(advanced_slice_patterns, struct_variant)]
+#![feature(advanced_slice_patterns)]
 
 struct Foo {
     first: bool,

--- a/src/test/compile-fail/privacy-struct-variant.rs
+++ b/src/test/compile-fail/privacy-struct-variant.rs
@@ -10,8 +10,6 @@
 
 // aux-build:privacy-struct-variant.rs
 
-#![feature(struct_variant)]
-
 extern crate "privacy-struct-variant" as other;
 
 mod a {

--- a/src/test/compile-fail/struct-like-enum-nonexhaustive.rs
+++ b/src/test/compile-fail/struct-like-enum-nonexhaustive.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 enum A {
     B { x: Option<int> },
     C

--- a/src/test/compile-fail/unsized5.rs
+++ b/src/test/compile-fail/unsized5.rs
@@ -7,7 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(struct_variant)]
 
 // Test `Sized?` types not allowed in fields (except the last one).
 

--- a/src/test/debuginfo/borrowed-enum.rs
+++ b/src/test/debuginfo/borrowed-enum.rs
@@ -40,7 +40,6 @@
 // lldb-check:[...]$2 = TheOnlyCase(4820353753753434)
 
 #![allow(unused_variables)]
-#![feature(struct_variant)]
 
 // The first element is to ensure proper alignment, irrespective of the machines word size. Since
 // the size of the discriminant value is machine dependent, this has be taken into account when

--- a/src/test/debuginfo/by-value-non-immediate-argument.rs
+++ b/src/test/debuginfo/by-value-non-immediate-argument.rs
@@ -71,8 +71,6 @@
 // lldb-check:[...]$6 = Case1 { x: 0, y: 8970181431921507452 }
 // lldb-command:continue
 
-#![feature(struct_variant)]
-
 #[deriving(Clone)]
 struct Struct {
     a: int,

--- a/src/test/debuginfo/gdb-pretty-struct-and-enums.rs
+++ b/src/test/debuginfo/gdb-pretty-struct-and-enums.rs
@@ -64,8 +64,6 @@
 // gdb-command: print nested_variant2
 // gdb-check:$14 = NestedVariant2 = {abc = NestedStruct = {regular_struct = RegularStruct = {the_first_field = 117, the_second_field = 118.5, the_third_field = false, the_fourth_field = "NestedStructString10"}, tuple_struct = TupleStruct = {119.5, 120}, empty_struct = EmptyStruct, c_style_enum = CStyleEnumVar3, mixed_enum = MixedEnumStructVar = {field1 = 121.5, field2 = -122}}}
 
-#![feature(struct_variant)]
-
 struct RegularStruct {
     the_first_field: int,
     the_second_field: f64,

--- a/src/test/debuginfo/generic-static-method-on-struct-and-enum.rs
+++ b/src/test/debuginfo/generic-static-method-on-struct-and-enum.rs
@@ -31,8 +31,6 @@
 // gdb-check:$5 = 5
 // gdb-command:continue
 
-#![feature(struct_variant)]
-
 struct Struct {
     x: int
 }

--- a/src/test/debuginfo/generic-struct-style-enum.rs
+++ b/src/test/debuginfo/generic-struct-style-enum.rs
@@ -29,8 +29,6 @@
 // gdb-command:print univariant
 // gdb-check:$4 = {{a = -1}}
 
-#![feature(struct_variant)]
-
 // NOTE: This is a copy of the non-generic test case. The `Txx` type parameters have to be
 // substituted with something of size `xx` bits and the same alignment as an integer type of the
 // same size.

--- a/src/test/debuginfo/method-on-enum.rs
+++ b/src/test/debuginfo/method-on-enum.rs
@@ -113,8 +113,6 @@
 // lldb-check:[...]$14 = -10
 // lldb-command:continue
 
-#![feature(struct_variant)]
-
 enum Enum {
     Variant1 { x: u16, y: u16 },
     Variant2 (u32)

--- a/src/test/debuginfo/option-like-enum.rs
+++ b/src/test/debuginfo/option-like-enum.rs
@@ -62,8 +62,6 @@
 // lldb-check:[...]$5 = Void
 
 
-#![feature(struct_variant)]
-
 // If a struct has exactly two variants, one of them is empty, and the other one
 // contains a non-nullable pointer, then this value is used as the discriminator.
 // The test cases in this file make sure that something readable is generated for

--- a/src/test/debuginfo/recursive-struct.rs
+++ b/src/test/debuginfo/recursive-struct.rs
@@ -69,7 +69,6 @@
 // gdb-command:continue
 
 #![allow(unused_variables)]
-#![feature(struct_variant)]
 
 enum Opt<T> {
     Empty,

--- a/src/test/debuginfo/static-method-on-struct-and-enum.rs
+++ b/src/test/debuginfo/static-method-on-struct-and-enum.rs
@@ -54,8 +54,6 @@
 // lldb-check:[...]$4 = 5
 // lldb-command:continue
 
-#![feature(struct_variant)]
-
 struct Struct {
     x: int
 }

--- a/src/test/debuginfo/struct-style-enum.rs
+++ b/src/test/debuginfo/struct-style-enum.rs
@@ -49,8 +49,6 @@
 // lldb-check:[...]$3 = TheOnlyCase { a: -1 }
 
 #![allow(unused_variables)]
-#![feature(struct_variant)]
-
 // The first element is to ensure proper alignment, irrespective of the machines word size. Since
 // the size of the discriminant value is machine dependent, this has be taken into account when
 // datatype layout should be predictable as in this case.

--- a/src/test/debuginfo/unique-enum.rs
+++ b/src/test/debuginfo/unique-enum.rs
@@ -42,7 +42,6 @@
 // lldb-check:[...]$2 = TheOnlyCase(123234)
 
 #![allow(unused_variables)]
-#![feature(struct_variant)]
 
 // The first element is to ensure proper alignment, irrespective of the machines word size. Since
 // the size of the discriminant value is machine dependent, this has be taken into account when

--- a/src/test/run-pass/const-enum-structlike.rs
+++ b/src/test/run-pass/const-enum-structlike.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 enum E {
     S0 { s: String },
     S1 { u: uint }

--- a/src/test/run-pass/deriving-cmp-generic-struct-enum.rs
+++ b/src/test/run-pass/deriving-cmp-generic-struct-enum.rs
@@ -10,8 +10,6 @@
 
 // no-pretty-expanded FIXME #15189
 
-#![feature(struct_variant)]
-
 #[deriving(PartialEq, Eq, PartialOrd, Ord)]
 enum ES<T> {
     ES1 { x: T },

--- a/src/test/run-pass/deriving-encodable-decodable.rs
+++ b/src/test/run-pass/deriving-encodable-decodable.rs
@@ -13,8 +13,6 @@
 
 // ignore-test FIXME(#5121)
 
-#![feature(struct_variant)]
-
 extern crate rand;
 extern crate rbml;
 extern crate serialize;

--- a/src/test/run-pass/deriving-rand.rs
+++ b/src/test/run-pass/deriving-rand.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 use std::rand;
 
 #[deriving(Rand)]

--- a/src/test/run-pass/deriving-show-2.rs
+++ b/src/test/run-pass/deriving-show-2.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 use std::fmt;
 
 #[deriving(Show)]

--- a/src/test/run-pass/deriving-show.rs
+++ b/src/test/run-pass/deriving-show.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant, macro_rules)]
+#![feature(macro_rules)]
 
 #[deriving(Show)]
 struct Unit;

--- a/src/test/run-pass/deriving-via-extension-struct-like-enum-variant.rs
+++ b/src/test/run-pass/deriving-via-extension-struct-like-enum-variant.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 #[deriving(PartialEq, Show)]
 enum S {
     X { x: int, y: int },

--- a/src/test/run-pass/drop-trait-enum.rs
+++ b/src/test/run-pass/drop-trait-enum.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 use std::task;
 
 #[deriving(PartialEq, Show)]

--- a/src/test/run-pass/enum-variants.rs
+++ b/src/test/run-pass/enum-variants.rs
@@ -10,7 +10,6 @@
 
 #![allow(dead_assignment)]
 #![allow(unused_variable)]
-#![feature(struct_variant)]
 
 enum Animal {
     Dog (String, f64),

--- a/src/test/run-pass/issue-11085.rs
+++ b/src/test/run-pass/issue-11085.rs
@@ -10,8 +10,6 @@
 
 // compile-flags: --cfg foo
 
-#![feature(struct_variant)]
-
 struct Foo {
     #[cfg(fail)]
     bar: baz,

--- a/src/test/run-pass/issue-11577.rs
+++ b/src/test/run-pass/issue-11577.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 // Destructuring struct variants would ICE where regular structs wouldn't
 
 enum Foo {

--- a/src/test/run-pass/issue-14837.rs
+++ b/src/test/run-pass/issue-14837.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 #[deny(dead_code)]
 pub enum Foo {
     Bar {

--- a/src/test/run-pass/issue-5530.rs
+++ b/src/test/run-pass/issue-5530.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 enum Enum {
     Foo { foo: uint },
     Bar { bar: uint }

--- a/src/test/run-pass/issue-8351-1.rs
+++ b/src/test/run-pass/issue-8351-1.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 enum E {
     Foo{f: int},
     Bar,

--- a/src/test/run-pass/issue-8351-2.rs
+++ b/src/test/run-pass/issue-8351-2.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 enum E {
     Foo{f: int, b: bool},
     Bar,

--- a/src/test/run-pass/match-arm-statics.rs
+++ b/src/test/run-pass/match-arm-statics.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 struct NewBool(bool);
 
 enum Direction {

--- a/src/test/run-pass/match-enum-struct-0.rs
+++ b/src/test/run-pass/match-enum-struct-0.rs
@@ -10,8 +10,6 @@
 
 // regression test for issue #5625
 
-#![feature(struct_variant)]
-
 enum E {
     Foo{f : int},
     Bar

--- a/src/test/run-pass/match-enum-struct-1.rs
+++ b/src/test/run-pass/match-enum-struct-1.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 enum E {
     Foo{f : int},
     Bar

--- a/src/test/run-pass/match-in-macro.rs
+++ b/src/test/run-pass/match-in-macro.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(macro_rules, struct_variant)]
+#![feature(macro_rules)]
 
 enum Foo {
     B { b1: int, bb1: int},

--- a/src/test/run-pass/namespaced-enum-emulate-flat-xc.rs
+++ b/src/test/run-pass/namespaced-enum-emulate-flat-xc.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // aux-build:namespaced_enum_emulate_flat.rs
-#![feature(struct_variant)]
 
 extern crate namespaced_enum_emulate_flat;
 

--- a/src/test/run-pass/namespaced-enum-emulate-flat.rs
+++ b/src/test/run-pass/namespaced-enum-emulate-flat.rs
@@ -7,7 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(globs, struct_variant)]
+#![feature(globs)]
 
 pub use Foo::*;
 use nest::{Bar, D, E, F};

--- a/src/test/run-pass/namespaced-enum-glob-import-xcrate.rs
+++ b/src/test/run-pass/namespaced-enum-glob-import-xcrate.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:namespaced_enums.rs
-#![feature(globs, struct_variant)]
+#![feature(globs)]
 
 extern crate namespaced_enums;
 

--- a/src/test/run-pass/namespaced-enum-glob-import.rs
+++ b/src/test/run-pass/namespaced-enum-glob-import.rs
@@ -7,7 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(globs, struct_variant)]
+#![feature(globs)]
 
 mod m2 {
     pub enum Foo {

--- a/src/test/run-pass/namespaced-enums-xcrate.rs
+++ b/src/test/run-pass/namespaced-enums-xcrate.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // aux-build:namespaced_enums.rs
-#![feature(struct_variant)]
 
 extern crate namespaced_enums;
 

--- a/src/test/run-pass/namespaced-enums.rs
+++ b/src/test/run-pass/namespaced-enums.rs
@@ -7,7 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(struct_variant)]
 
 enum Foo {
     A,

--- a/src/test/run-pass/struct-like-variant-construct.rs
+++ b/src/test/run-pass/struct-like-variant-construct.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 enum Foo {
     Bar {
         a: int,

--- a/src/test/run-pass/struct-like-variant-match.rs
+++ b/src/test/run-pass/struct-like-variant-match.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 enum Foo {
     Bar {
         x: int,

--- a/src/test/run-pass/unsized2.rs
+++ b/src/test/run-pass/unsized2.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 //
 // ignore-lexer-test FIXME #15879
-#![feature(struct_variant)]
-
 
 // Test sized-ness checking in substitution.
 

--- a/src/test/run-pass/variant-structs-trivial.rs
+++ b/src/test/run-pass/variant-structs-trivial.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 enum Foo {
     Bar { x: int },
     Baz { y: int }


### PR DESCRIPTION
Not ready for merge yet!

While I continue to ponder the ownership guide, I figured I'd do little `rustc` hacking. I currently have this, which I believe removes the feature gate, but, given that the snapshot has the gate turned off, what's the right strategy to fix this? Maybe turn https://github.com/steveklabnik/rust/commit/7903830ffb716ed30adeaa3e39f1c197569b554c#diff-8fe611e80215042c8d89714f4dd6f8baL40 to 'inactive', wait for a snapshot, and then apply this PR afterwards?
