### PR TITLE
DSTify more traits

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -48,6 +48,10 @@ impl<T: Default> Default for Box<T> {
     fn default() -> Box<T> { box Default::default() }
 }
 
+impl<T> Default for Box<[T]> {
+    fn default() -> Box<[T]> { box [] }
+}
+
 #[unstable]
 impl<T: Clone> Clone for Box<T> {
     /// Returns a copy of the owned box.

--- a/src/libserialize/base64.rs
+++ b/src/libserialize/base64.rs
@@ -54,13 +54,13 @@ static URLSAFE_CHARS: &'static[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                                        0123456789-_";
 
 /// A trait for converting a value to base64 encoding.
-pub trait ToBase64 {
+pub trait ToBase64 for Sized? {
     /// Converts the value of `self` to a base64 value following the specified
     /// format configuration, returning the owned string.
     fn to_base64(&self, config: Config) -> String;
 }
 
-impl<'a> ToBase64 for &'a [u8] {
+impl ToBase64 for [u8] {
     /**
      * Turn a vector of `u8` bytes into a base64 string.
      *
@@ -155,7 +155,7 @@ impl<'a> ToBase64 for &'a [u8] {
 }
 
 /// A trait for converting from base64 encoded values.
-pub trait FromBase64 {
+pub trait FromBase64 for Sized? {
     /// Converts the value of `self`, interpreted as base64 encoded data, into
     /// an owned vector of bytes, returning the vector.
     fn from_base64(&self) -> Result<Vec<u8>, FromBase64Error>;
@@ -192,7 +192,7 @@ impl error::Error for FromBase64Error {
     }
 }
 
-impl<'a> FromBase64 for &'a str {
+impl FromBase64 for str {
     /**
      * Convert any base64 encoded string (literal, `@`, `&`, or `~`)
      * to the byte values it encodes.
@@ -227,7 +227,7 @@ impl<'a> FromBase64 for &'a str {
     }
 }
 
-impl<'a> FromBase64 for &'a [u8] {
+impl FromBase64 for [u8] {
     fn from_base64(&self) -> Result<Vec<u8>, FromBase64Error> {
         let mut r = Vec::new();
         let mut buf: u32 = 0;

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -16,7 +16,7 @@ use std::string;
 use std::error;
 
 /// A trait for converting a value to hexadecimal encoding
-pub trait ToHex {
+pub trait ToHex for Sized? {
     /// Converts the value of `self` to a hex value, returning the owned
     /// string.
     fn to_hex(&self) -> String;
@@ -24,7 +24,7 @@ pub trait ToHex {
 
 static CHARS: &'static[u8] = b"0123456789abcdef";
 
-impl<'a> ToHex for &'a [u8] {
+impl ToHex for [u8] {
     /**
      * Turn a vector of `u8` bytes into a hexadecimal string.
      *
@@ -54,7 +54,7 @@ impl<'a> ToHex for &'a [u8] {
 }
 
 /// A trait for converting hexadecimal encoded values
-pub trait FromHex {
+pub trait FromHex for Sized? {
     /// Converts the value of `self`, interpreted as hexadecimal encoded data,
     /// into an owned vector of bytes, returning the vector.
     fn from_hex(&self) -> Result<Vec<u8>, FromHexError>;
@@ -92,7 +92,7 @@ impl error::Error for FromHexError {
 }
 
 
-impl<'a> FromHex for &'a str {
+impl FromHex for str {
     /**
      * Convert any hexadecimal encoded string (literal, `@`, `&`, or `~`)
      * to the byte values it encodes.

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -2303,7 +2303,7 @@ impl ::Decoder<DecoderError> for Decoder {
 }
 
 /// A trait for converting values to JSON
-pub trait ToJson {
+pub trait ToJson for Sized? {
     /// Converts the value of `self` to an instance of JSON
     fn to_json(&self) -> Json;
 }
@@ -2389,7 +2389,7 @@ tuple_impl!{A, B, C, D, E, F, G, H, I, J}
 tuple_impl!{A, B, C, D, E, F, G, H, I, J, K}
 tuple_impl!{A, B, C, D, E, F, G, H, I, J, K, L}
 
-impl<'a, A: ToJson> ToJson for &'a [A] {
+impl<A: ToJson> ToJson for [A] {
     fn to_json(&self) -> Json { List(self.iter().map(|elt| elt.to_json()).collect()) }
 }
 

--- a/src/test/run-pass/deriving-default-box.rs
+++ b/src/test/run-pass/deriving-default-box.rs
@@ -1,0 +1,22 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::default::Default;
+
+#[deriving(Default)]
+struct A {
+    foo: Box<[bool]>,
+}
+
+pub fn main() {
+    let a: A = Default::default();
+    let b: Box<[_]> = box [];
+    assert_eq!(a.foo, b);
+}

--- a/src/test/run-pass/deriving-encodable-decodable-box.rs
+++ b/src/test/run-pass/deriving-encodable-decodable-box.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate serialize;
+
+use serialize::{Encodable, Decodable};
+use serialize::json;
+
+#[deriving(Encodable, Decodable)]
+struct A {
+    foo: Box<[bool]>,
+}
+
+fn main() {
+    let obj = A { foo: box [true, false] };
+    let s = json::encode(&obj);
+    let obj2: A = json::decode(s.as_slice()).unwrap();
+    assert!(obj.foo == obj2.foo);
+}


### PR DESCRIPTION
We now can do `#[deriving(Default, Encodable, Decodable)]` on structs that contain `Box[T]`.

r? @aturon / @alexcrichton 
