### PR TITLE
mk: Add -C prefer-dynamic to stage3 libs

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -155,6 +155,7 @@ endif
 RUSTFLAGS_STAGE0 += -C prefer-dynamic
 RUSTFLAGS_STAGE1 += -C prefer-dynamic
 RUST_LIB_FLAGS_ST2 += -C prefer-dynamic
+RUST_LIB_FLAGS_ST3 += -C prefer-dynamic
 
 # Landing pads require a lot of codegen. We can get through bootstrapping faster
 # by not emitting them.


### PR DESCRIPTION
Right now the windows nightlies are failing because they're encountering a
linker error when producing stage3 libs. The stage3 libs aren't actually used in
general, and we primarily just want to generate a static stage3 binary, not
static stage3 dylibs.
