### PR TITLE
Fix incorrect unboxed closure-related assert in trans

### DIFF
--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -322,7 +322,6 @@ fn load_unboxed_closure_environment<'blk, 'tcx>(
                                          self_type,
                                          "unboxed_closure_env");
         store_ty(bcx, bcx.fcx.llenv.unwrap(), datum.val, self_type);
-        assert!(freevars.len() <= 1);
         datum.val
     } else {
         bcx.fcx.llenv.unwrap()

--- a/src/test/run-pass/issue-18652.rs
+++ b/src/test/run-pass/issue-18652.rs
@@ -1,0 +1,21 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests multiple free variables being passed by value into an unboxed
+// once closure as an optimization by trans.  This used to hit an
+// incorrect assert.
+
+#![feature(unboxed_closures, overloaded_calls)]
+
+fn main() {
+    let x = 2u8;
+    let y = 3u8;
+    assert_eq!((move |:| x + y)(), 5);
+}


### PR DESCRIPTION
`FnOnce` environments that fit within an `int` are passed to the closure by value.  For some reason there was an assert that this would only happen if there were 1 or 0 free variables, but it can also happen if there are multiple variables that happen to fit.

Closes #18652 
