### PR TITLE
Prepend should be append in the 30 minute intro

### DIFF
--- a/src/doc/intro.md
+++ b/src/doc/intro.md
@@ -217,7 +217,7 @@ including the right thing!) Even though we compiled with flags to give us as
 many warnings as possible, and to treat those warnings as errors, we got no
 errors. When we ran the program, it crashed.
 
-Why does this happen? When we prepend to an array, its length changes. Since
+Why does this happen? When we append to an array, its length changes. Since
 its length changes, we may need to allocate more memory. In Ruby, this happens
 as well, we just don't think about it very often. So why does the C++ version
 segfault when we allocate more memory?


### PR DESCRIPTION
A most trivial documentation correction. The examples in the intro are all about adding to the end of the array, not the beginning, but this one line says "prepend".

This isn't a very serious problem, it just made me a bit confused when I got to it.
