### PR TITLE
Treat builtin bounds like all other kinds of trait matches.

### DIFF
--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -965,7 +965,7 @@ pub fn trans_external_path<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 
 pub fn invoke<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                           llfn: ValueRef,
-                          llargs: Vec<ValueRef> ,
+                          llargs: &[ValueRef],
                           fn_ty: Ty<'tcx>,
                           call_info: Option<NodeInfo>,
                           // FIXME(15064) is_lang_item is a horrible hack, please remove it

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -808,7 +808,7 @@ pub fn trans_call_inner<'a, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         // Invoke the actual rust fn and update bcx/llresult.
         let (llret, b) = base::invoke(bcx,
                                       llfn,
-                                      llargs,
+                                      llargs[],
                                       callee_ty,
                                       call_info,
                                       dest.is_none());

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -291,7 +291,7 @@ fn trans_struct_drop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         let dtor_ty = ty::mk_ctor_fn(bcx.tcx(),
                                      &[get_drop_glue_type(bcx.ccx(), t)],
                                      ty::mk_nil(bcx.tcx()));
-        let (_, variant_cx) = invoke(variant_cx, dtor_addr, args, dtor_ty, None, false);
+        let (_, variant_cx) = invoke(variant_cx, dtor_addr, args[], dtor_ty, None, false);
 
         variant_cx.fcx.pop_and_trans_custom_cleanup_scope(variant_cx, field_scope);
         variant_cx

--- a/src/test/compile-fail/comm-not-freeze-receiver.rs
+++ b/src/test/compile-fail/comm-not-freeze-receiver.rs
@@ -11,5 +11,5 @@
 fn test<T: Sync>() {}
 
 fn main() {
-    test::<Sender<int>>();     //~ ERROR: `core::kinds::Sync` is not implemented
+    test::<Receiver<int>>();   //~ ERROR: `core::kinds::Sync` is not implemented
 }

--- a/src/test/compile-fail/dst-object-from-unsized-type.rs
+++ b/src/test/compile-fail/dst-object-from-unsized-type.rs
@@ -13,18 +13,24 @@
 trait Foo for Sized? {}
 impl Foo for str {}
 
-fn test<Sized? T: Foo>(t: &T) {
+fn test1<Sized? T: Foo>(t: &T) {
     let u: &Foo = t;
     //~^ ERROR `core::kinds::Sized` is not implemented for the type `T`
+}
 
+fn test2<Sized? T: Foo>(t: &T) {
     let v: &Foo = t as &Foo;
     //~^ ERROR `core::kinds::Sized` is not implemented for the type `T`
 }
 
-fn main() {
+fn test3() {
     let _: &[&Foo] = &["hi"];
     //~^ ERROR `core::kinds::Sized` is not implemented for the type `str`
+}
 
+fn test4() {
     let _: &Foo = "hi" as &Foo;
     //~^ ERROR `core::kinds::Sized` is not implemented for the type `str`
 }
+
+fn main() { }

--- a/src/test/compile-fail/issue-5883.rs
+++ b/src/test/compile-fail/issue-5883.rs
@@ -18,7 +18,6 @@ fn new_struct(r: A+'static)
     -> Struct { //~^  ERROR the trait `core::kinds::Sized` is not implemented
     //~^ ERROR the trait `core::kinds::Sized` is not implemented
     Struct { r: r }
-    //~^ ERROR the trait `core::kinds::Sized` is not implemented
 }
 
 trait Curve {}

--- a/src/test/compile-fail/issue-7013.rs
+++ b/src/test/compile-fail/issue-7013.rs
@@ -32,5 +32,5 @@ struct A {
 
 fn main() {
     let a = A {v: box B{v: None} as Box<Foo+Send>};
-    //~^ ERROR the trait `core::kinds::Send` is not implemented for the type `B`
+    //~^ ERROR the trait `core::kinds::Send` is not implemented
 }

--- a/src/test/compile-fail/issue-8727.rs
+++ b/src/test/compile-fail/issue-8727.rs
@@ -8,14 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// error-pattern:reached the recursion limit during monomorphization
+
 // Verify the compiler fails with an error on infinite function
 // recursions.
-
 
 struct Data(Box<Option<Data>>);
 
 fn generic<T>( _ : Vec<(Data,T)> ) {
-    //~^ ERROR reached the recursion limit during monomorphization
     let rec : Vec<(Data,(bool,T))> = Vec::new();
     generic( rec );
 }

--- a/src/test/compile-fail/kindck-copy.rs
+++ b/src/test/compile-fail/kindck-copy.rs
@@ -22,7 +22,7 @@ struct MyStruct {
 }
 
 struct MyNoncopyStruct {
-    x: Box<int>,
+    x: Box<char>,
 }
 
 fn test<'a,T,U:Copy>(_: &'a int) {

--- a/src/test/compile-fail/kindck-destructor-owned.rs
+++ b/src/test/compile-fail/kindck-destructor-owned.rs
@@ -16,7 +16,7 @@ struct Foo {
 }
 
 impl Drop for Foo {
-//~^ ERROR the trait `core::kinds::Send` is not implemented for the type `Foo`
+//~^ ERROR the trait `core::kinds::Send` is not implemented
 //~^^ NOTE cannot implement a destructor on a structure or enumeration that does not satisfy Send
     fn drop(&mut self) {
     }

--- a/src/test/compile-fail/kindck-impl-type-params.rs
+++ b/src/test/compile-fail/kindck-impl-type-params.rs
@@ -22,6 +22,10 @@ fn f<T>(val: T) {
     let a = &t as &Gettable<T>;
     //~^ ERROR the trait `core::kinds::Send` is not implemented
     //~^^ ERROR the trait `core::kinds::Copy` is not implemented
+}
+
+fn g<T>(val: T) {
+    let t: S<T> = S;
     let a: &Gettable<T> = &t;
     //~^ ERROR the trait `core::kinds::Send` is not implemented
     //~^^ ERROR the trait `core::kinds::Copy` is not implemented
@@ -30,9 +34,15 @@ fn f<T>(val: T) {
 fn foo<'a>() {
     let t: S<&'a int> = S;
     let a = &t as &Gettable<&'a int>;
+}
+
+fn foo2<'a>() {
     let t: Box<S<String>> = box S;
     let a = t as Box<Gettable<String>>;
     //~^ ERROR the trait `core::kinds::Copy` is not implemented
+}
+
+fn foo3<'a>() {
     let t: Box<S<String>> = box S;
     let a: Box<Gettable<String>> = t;
     //~^ ERROR the trait `core::kinds::Copy` is not implemented

--- a/src/test/compile-fail/kindck-nonsendable-1.rs
+++ b/src/test/compile-fail/kindck-nonsendable-1.rs
@@ -13,10 +13,14 @@ use std::rc::Rc;
 
 fn foo(_x: Rc<uint>) {}
 
-fn main() {
+fn bar() {
     let x = Rc::new(3u);
     let _: proc():Send = proc() foo(x); //~ ERROR `core::kinds::Send` is not implemented
-    let _: proc():Send = proc() foo(x); //~ ERROR `core::kinds::Send` is not implemented
-    let _: proc():Send = proc() foo(x); //~ ERROR `core::kinds::Send` is not implemented
+}
+
+fn bar2() {
+    let x = Rc::new(3u);
     let _: proc() = proc() foo(x);
 }
+
+fn main() { }

--- a/src/test/compile-fail/unsendable-class.rs
+++ b/src/test/compile-fail/unsendable-class.rs
@@ -29,5 +29,5 @@ fn foo(i:int, j: Rc<String>) -> foo {
 fn main() {
   let cat = "kitty".to_string();
   let (tx, _) = channel(); //~ ERROR `core::kinds::Send` is not implemented
-  tx.send(foo(42, Rc::new(cat))); //~ ERROR `core::kinds::Send` is not implemented
+  tx.send(foo(42, Rc::new(cat)));
 }

--- a/src/test/compile-fail/unsized-enum.rs
+++ b/src/test/compile-fail/unsized-enum.rs
@@ -8,14 +8,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum Foo<T> { FooSome(T), FooNone }
 
-fn bar<T: Sized>() { }
-fn foo<Sized? T>() { bar::<Foo<T>>() }
+fn is_sized<T:Sized>() { }
+fn not_sized<Sized? T>() { }
+
+enum Foo<U> { FooSome(U), FooNone }
+fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
+fn foo2<Sized? T>() { not_sized::<Foo<T>>() }
 //~^ ERROR the trait `core::kinds::Sized` is not implemented
-//~^^ ERROR the trait `core::kinds::Sized` is not implemented
 //
-// One error is for T being provided to Foo<T>, the other is
-// for Foo<T> being provided to bar.
+// Not OK: `T` is not sized.
+
+enum Bar<Sized? U> { BarSome(U), BarNone }
+fn bar1<Sized? T>() { not_sized::<Bar<T>>() }
+fn bar2<Sized? T>() { is_sized::<Bar<T>>() }
+//~^ ERROR the trait `core::kinds::Sized` is not implemented
+//
+// Not OK: `Bar<T>` is not sized, but it should be.
 
 fn main() { }

--- a/src/test/compile-fail/unsized-struct.rs
+++ b/src/test/compile-fail/unsized-struct.rs
@@ -8,13 +8,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct Foo<T> { data: T }
 
-fn bar<T: Sized>() { }
-fn foo<Sized? T>() { bar::<Foo<T>>() }
+fn is_sized<T:Sized>() { }
+fn not_sized<Sized? T>() { }
+
+struct Foo<T> { data: T }
+fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
+fn foo2<Sized? T>() { not_sized::<Foo<T>>() }
 //~^ ERROR the trait `core::kinds::Sized` is not implemented
-//~^^ ERROR the trait `core::kinds::Sized` is not implemented
-// One error is for the T in Foo<T>, the other is for Foo<T> as a value
-// for bar's type parameter.
+//
+// Not OK: `T` is not sized.
+
+struct Bar<Sized? T> { data: T }
+fn bar1<Sized? T>() { not_sized::<Bar<T>>() }
+fn bar2<Sized? T>() { is_sized::<Bar<T>>() }
+//~^ ERROR the trait `core::kinds::Sized` is not implemented
+//
+// Not OK: `Bar<T>` is not sized, but it should be.
 
 fn main() { }

--- a/src/test/compile-fail/unsized3.rs
+++ b/src/test/compile-fail/unsized3.rs
@@ -57,6 +57,9 @@ fn f8<Sized? X>(x1: &S<X>, x2: &S<X>) {
 fn f9<Sized? X>(x1: Box<S<X>>, x2: Box<E<X>>) {
     f5(&(*x1, 34i));
     //~^ ERROR the trait `core::kinds::Sized` is not implemented
+}
+
+fn f10<Sized? X>(x1: Box<S<X>>, x2: Box<E<X>>) {
     f5(&(32i, *x2));
     //~^ ERROR the trait `core::kinds::Sized` is not implemented
 }

--- a/src/test/compile-fail/unsized5.rs
+++ b/src/test/compile-fail/unsized5.rs
@@ -29,6 +29,8 @@ struct S4 {
 }
 enum E<Sized? X> {
     V1(X, int), //~ERROR `core::kinds::Sized` is not implemented
+}
+enum F<Sized? X> {
     V2{f1: X, f: int}, //~ERROR `core::kinds::Sized` is not implemented
 }
 


### PR DESCRIPTION
Treat builtin bounds like all other kinds of trait matches. Introduce a simple hashset in the fulfillment context to catch cases where we register the exact same obligation twice. This helps prevent duplicate error reports but also handles the recursive obligations created by builtin bounds.

r? @pcwalton 
cc @FlaPer87 
