### PR TITLE
Require that objects can only be made from Sized types. Fixes #18333.

### DIFF
--- a/src/librustc/middle/traits/mod.rs
+++ b/src/librustc/middle/traits/mod.rs
@@ -94,6 +94,9 @@ pub enum ObligationCauseCode<'tcx> {
 
     // Types of fields (other than the last) in a struct must be sized.
     FieldSized,
+
+    // Only Sized types can be made into objects
+    ObjectSized,
 }
 
 pub type Obligations<'tcx> = subst::VecPerParamSpace<Obligation<'tcx>>;

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1771,12 +1771,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             ty::UnsizeVtable(ref ty_trait, self_ty) => {
                 vtable::check_object_safety(self.tcx(), ty_trait, span);
+
                 // If the type is `Foo+'a`, ensures that the type
                 // being cast to `Foo+'a` implements `Foo`:
                 vtable::register_object_cast_obligations(self,
-                                                          span,
-                                                          ty_trait,
-                                                          self_ty);
+                                                         span,
+                                                         ty_trait,
+                                                         self_ty);
 
                 // If the type is `Foo+'a`, ensures that the type
                 // being cast to `Foo+'a` outlives `'a`:

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -20,7 +20,8 @@ use syntax::ast;
 use syntax::visit;
 use syntax::visit::Visitor;
 
-// An error has already been reported to the user, so no need to continue checking.
+// Useful type to use with `Result<>` indicate that an error has already
+// been reported to the user, so no need to continue checking.
 #[deriving(Clone,Show)]
 pub struct ErrorReported;
 

--- a/src/test/compile-fail/dst-object-from-unsized-type.rs
+++ b/src/test/compile-fail/dst-object-from-unsized-type.rs
@@ -1,0 +1,30 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that we cannot create objects from unsized types.
+
+trait Foo for Sized? {}
+impl Foo for str {}
+
+fn test<Sized? T: Foo>(t: &T) {
+    let u: &Foo = t;
+    //~^ ERROR `core::kinds::Sized` is not implemented for the type `T`
+
+    let v: &Foo = t as &Foo;
+    //~^ ERROR `core::kinds::Sized` is not implemented for the type `T`
+}
+
+fn main() {
+    let _: &[&Foo] = &["hi"];
+    //~^ ERROR `core::kinds::Sized` is not implemented for the type `str`
+
+    let _: &Foo = "hi" as &Foo;
+    //~^ ERROR `core::kinds::Sized` is not implemented for the type `str`
+}

--- a/src/test/compile-fail/issue-14366.rs
+++ b/src/test/compile-fail/issue-14366.rs
@@ -11,5 +11,5 @@
 fn main() {
     let _x = "test" as &::std::any::Any;
 //~^ ERROR the trait `core::kinds::Sized` is not implemented for the type `str`
-//~^^ NOTE the trait `core::kinds::Sized` must be implemented for the cast to the object type
+//~^^ ERROR the trait `core::kinds::Sized` is not implemented for the type `str`
 }


### PR DESCRIPTION
In the general case, at least, it is not possible to make an object out of an unsized type. This is because the object type would have to store the fat pointer information for the `self` value _and_ the vtable -- meaning it'd have to be a fat pointer with three words -- but for the compiler to know that the object requires three words, it would have to know the self-type of the object (is `self` a thin or fat pointer?), which of course it doesn't.

Fixes #18333.

r? @nick29581 
