### PR TITLE
Rename deprecated EnumSet methods in unit tests.

### DIFF
--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -426,7 +426,7 @@ mod test {
                 unsafe { mem::transmute(v) }
             }
         }
-        let mut set = EnumSet::empty();
-        set.add(V64);
+        let mut set = EnumSet::new();
+        set.insert(V64);
     }
 }


### PR DESCRIPTION
I renamed the deprecated methods, resulting from the collection reform.
