### PR TITLE
syntax: Use UFCS in the expansion of `#[deriving(PartialOrd)]`

### DIFF
--- a/src/libsyntax/ext/deriving/cmp/eq.rs
+++ b/src/libsyntax/ext/deriving/cmp/eq.rs
@@ -30,7 +30,7 @@ pub fn expand_deriving_eq(cx: &mut ExtCtxt,
             |cx, span, subexpr, self_f, other_fs| {
                 let other_f = match other_fs {
                     [ref o_f] => o_f,
-                    _ => cx.span_bug(span, "not exactly 2 arguments in `deriving(Eq)`")
+                    _ => cx.span_bug(span, "not exactly 2 arguments in `deriving(PartialEq)`")
                 };
 
                 let eq = cx.expr_binary(span, ast::BiEq, self_f, other_f.clone());
@@ -47,7 +47,7 @@ pub fn expand_deriving_eq(cx: &mut ExtCtxt,
             |cx, span, subexpr, self_f, other_fs| {
                 let other_f = match other_fs {
                     [ref o_f] => o_f,
-                    _ => cx.span_bug(span, "not exactly 2 arguments in `deriving(Eq)`")
+                    _ => cx.span_bug(span, "not exactly 2 arguments in `deriving(PartialEq)`")
                 };
 
                 let eq = cx.expr_binary(span, ast::BiNe, self_f, other_f.clone());

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -107,12 +107,19 @@ pub fn cs_partial_cmp(cx: &mut ExtCtxt, span: Span,
     let ordering = cx.expr_path(ordering);
     let equals_expr = cx.expr_some(span, ordering);
 
+    let partial_cmp_path = vec![
+        cx.ident_of("std"),
+        cx.ident_of("cmp"),
+        cx.ident_of("PartialOrd"),
+        cx.ident_of("partial_cmp"),
+    ];
+
     /*
     Builds:
 
-    let __test = self_field1.partial_cmp(&other_field2);
+    let __test = ::std::cmp::PartialOrd::partial_cmp(&self_field1, &other_field1);
     if __test == ::std::option::Some(::std::cmp::Equal) {
-        let __test = self_field2.partial_cmp(&other_field2);
+        let __test = ::std::cmp::PartialOrd::partial_cmp(&self_field2, &other_field2);
         if __test == ::std::option::Some(::std::cmp::Equal) {
             ...
         } else {
@@ -124,17 +131,31 @@ pub fn cs_partial_cmp(cx: &mut ExtCtxt, span: Span,
 
     FIXME #6449: These `if`s could/should be `match`es.
     */
-    cs_same_method_fold(
+    cs_fold(
         // foldr nests the if-elses correctly, leaving the first field
         // as the outermost one, and the last as the innermost.
         false,
-        |cx, span, old, new| {
+        |cx, span, old, self_f, other_fs| {
             // let __test = new;
             // if __test == Some(::std::cmp::Equal) {
             //    old
             // } else {
             //    __test
             // }
+
+            let new = {
+                let other_f = match other_fs {
+                    [ref o_f] => o_f,
+                    _ => cx.span_bug(span, "not exactly 2 arguments in `deriving(Ord)`"),
+                };
+
+                let args = vec![
+                    cx.expr_addr_of(span, self_f),
+                    cx.expr_addr_of(span, other_f.clone()),
+                ];
+
+                cx.expr_call_global(span, partial_cmp_path.clone(), args)
+            };
 
             let assign = cx.stmt_let(span, false, test_id, new);
 

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -146,7 +146,7 @@ pub fn cs_partial_cmp(cx: &mut ExtCtxt, span: Span,
             let new = {
                 let other_f = match other_fs {
                     [ref o_f] => o_f,
-                    _ => cx.span_bug(span, "not exactly 2 arguments in `deriving(Ord)`"),
+                    _ => cx.span_bug(span, "not exactly 2 arguments in `deriving(PartialOrd)`"),
                 };
 
                 let args = vec![
@@ -170,7 +170,7 @@ pub fn cs_partial_cmp(cx: &mut ExtCtxt, span: Span,
         equals_expr.clone(),
         |cx, span, (self_args, tag_tuple), _non_self_args| {
             if self_args.len() != 2 {
-                cx.span_bug(span, "not exactly 2 arguments in `deriving(Ord)`")
+                cx.span_bug(span, "not exactly 2 arguments in `deriving(PartialOrd)`")
             } else {
                 some_ordering_collapsed(cx, span, PartialCmpOp, tag_tuple)
             }
@@ -204,7 +204,7 @@ fn cs_op(less: bool, equal: bool, cx: &mut ExtCtxt,
             */
             let other_f = match other_fs {
                 [ref o_f] => o_f,
-                _ => cx.span_bug(span, "not exactly 2 arguments in `deriving(Ord)`")
+                _ => cx.span_bug(span, "not exactly 2 arguments in `deriving(PartialOrd)`")
             };
 
             let cmp = cx.expr_binary(span, op, self_f.clone(), other_f.clone());
@@ -218,7 +218,7 @@ fn cs_op(less: bool, equal: bool, cx: &mut ExtCtxt,
         cx.expr_bool(span, equal),
         |cx, span, (self_args, tag_tuple), _non_self_args| {
             if self_args.len() != 2 {
-                cx.span_bug(span, "not exactly 2 arguments in `deriving(Ord)`")
+                cx.span_bug(span, "not exactly 2 arguments in `deriving(PartialOrd)`")
             } else {
                 let op = match (less, equal) {
                     (true,  true) => LeOp, (true,  false) => LtOp,

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -108,7 +108,7 @@ pub fn cs_cmp(cx: &mut ExtCtxt, span: Span,
         cx.expr_path(equals_path.clone()),
         |cx, span, (self_args, tag_tuple), _non_self_args| {
             if self_args.len() != 2 {
-                cx.span_bug(span, "not exactly 2 arguments in `deriving(TotalOrd)`")
+                cx.span_bug(span, "not exactly 2 arguments in `deriving(Ord)`")
             } else {
                 ordering_collapsed(cx, span, tag_tuple)
             }

--- a/src/test/run-pass/issue-18738.rs
+++ b/src/test/run-pass/issue-18738.rs
@@ -1,0 +1,25 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[deriving(PartialEq, PartialOrd)]
+enum Test<'a> {
+    Int(&'a int),
+    Slice(&'a [u8]),
+}
+
+#[deriving(PartialEq, PartialOrd)]
+struct Version {
+    vendor_info: &'static str
+}
+
+#[deriving(PartialEq, PartialOrd)]
+struct Foo(&'static str);
+
+fn main() {}


### PR DESCRIPTION
Closes #18738
cc #15689

r? @alexcrichton 
cc @cmr 
