### PR TITLE
syntax: improve message for misused inner attributes

### DIFF
--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -75,6 +75,8 @@ impl<'a> ParserAttr for Parser<'a> {
                         self.span_err(span,
                                       "an inner attribute is not permitted in \
                                        this context");
+                        self.span_help(span,
+                                       "place inner attribute at the top of the module or block");
                     }
                     ast::AttrInner
                 } else {


### PR DESCRIPTION
for the code:

```
use std::io;

#![crate_type="rlib"] // ERROR: an inner attribute is not permitted in this context

fn say_hello() {
    println!("hello");
}
```

this PR provides another note to help programmer fixing this error more easily:

```
hello.rs:6:3: 6:4 error: an inner attribute is not permitted in this context
hello.rs:6 #![crate_type="rlib"]
             ^
hello.rs:6:3: 6:4 note: put inner attribute in top of file or block
hello.rs:6 #![crate_type="rlib"]
             ^
```
