### PR TITLE
Fix handling of for loops in regionck

### DIFF
--- a/src/librustc/middle/typeck/check/regionck.rs
+++ b/src/librustc/middle/typeck/check/regionck.rs
@@ -770,8 +770,12 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
 
             {
                 let mc = mc::MemCategorizationContext::new(rcx);
-                let head_cmt = ignore_err!(mc.cat_expr(&**head));
-                link_pattern(rcx, mc, head_cmt, &**pat);
+                let pat_ty = rcx.resolve_node_type(pat.id);
+                let pat_cmt = mc.cat_rvalue(pat.id,
+                                            pat.span,
+                                            ty::ReScope(body.id),
+                                            pat_ty);
+                link_pattern(rcx, mc, pat_cmt, &**pat);
             }
 
             rcx.visit_expr(&**head);

--- a/src/test/run-pass/issue-17068.rs
+++ b/src/test/run-pass/issue-17068.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that regionck creates the right region links in the pattern
+// binding of a for loop
+fn foo<'a>(v: &'a [uint]) -> &'a uint {
+    for &ref x in v.iter() { return x; }
+    unreachable!()
+}
+
+fn main() {
+    assert_eq!(foo(&[0]), &0);
+}

--- a/src/test/run-pass/issue-18767.rs
+++ b/src/test/run-pass/issue-18767.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that regionck uses the right memcat for patterns in for loops
+// and doesn't ICE.
+
+fn main() {
+    for &&x in Some(&0u).iter() {
+        assert_eq!(x, 0)
+    }
+}


### PR DESCRIPTION
Use the mem-cat of the iterator element type rather than the iterator itself when processing the for loop pattern.

Closes #17068
Closes #18767
