### PR TITLE
Added `as` and `move` keywords to Vim syntax file

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -17,13 +17,13 @@ syn keyword   rustConditional match if else
 syn keyword   rustOperator    as
 
 syn match     rustAssert      "\<assert\(\w\)*!" contained
-syn match     rustFail        "\<fail\(\w\)*!" contained
+syn match     rustPanic       "\<panic\(\w\)*!" contained
 syn keyword   rustKeyword     break
 syn keyword   rustKeyword     box nextgroup=rustBoxPlacement skipwhite skipempty
 syn keyword   rustKeyword     continue
 syn keyword   rustKeyword     extern nextgroup=rustExternCrate,rustObsoleteExternMod skipwhite skipempty
 syn keyword   rustKeyword     fn nextgroup=rustFuncName skipwhite skipempty
-syn keyword   rustKeyword     for in if impl let
+syn keyword   rustKeyword     for in if impl let move
 syn keyword   rustKeyword     loop once proc pub
 syn keyword   rustKeyword     return super
 syn keyword   rustKeyword     unsafe virtual where while
@@ -151,8 +151,8 @@ syn match     rustSigil        display /[&~@*][^)= \t\r\n]/he=e-1,me=e-1
 " Last, because the & in && isn't a sigil
 syn match     rustOperator     display "&&\|||"
 
-syn match     rustMacro       '\w\(\w\)*!' contains=rustAssert,rustFail
-syn match     rustMacro       '#\w\(\w\)*' contains=rustAssert,rustFail
+syn match     rustMacro       '\w\(\w\)*!' contains=rustAssert,rustPanic
+syn match     rustMacro       '#\w\(\w\)*' contains=rustAssert,rustPanic
 
 syn match     rustEscapeError   display contained /\\./
 syn match     rustEscape        display contained /\\\([nrt0\\'"]\|x\x\{2}\)/
@@ -263,7 +263,7 @@ hi def link rustCommentLineDoc SpecialComment
 hi def link rustCommentBlock  rustCommentLine
 hi def link rustCommentBlockDoc rustCommentLineDoc
 hi def link rustAssert        PreCondit
-hi def link rustFail          PreCondit
+hi def link rustPanic         PreCondit
 hi def link rustMacro         Macro
 hi def link rustType          Type
 hi def link rustTodo          Todo
@@ -282,7 +282,7 @@ hi def link rustBoxPlacementExpr rustKeyword
 " hi rustAttribute ctermfg=cyan
 " hi rustDeriving ctermfg=cyan
 " hi rustAssert ctermfg=yellow
-" hi rustFail ctermfg=red
+" hi rustPanic ctermfg=red
 " hi rustMacro ctermfg=magenta
 
 syn sync minlines=200


### PR DESCRIPTION
`as` (already for a long time) and `move` (which was only added recently, AFAIK) are not marked as keywords in Vim syntax file, so they are not highlighted as keywords in Rust sources. This PR fixes this.
