### PR TITLE
Make std::io::Buffer object-safe.

### DIFF
--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -75,7 +75,7 @@
 #[doc(no_inline)] pub use path::{GenericPath, Path, PosixPath, WindowsPath};
 #[doc(no_inline)] pub use ptr::{RawPtr, RawMutPtr};
 #[doc(no_inline)] pub use result::{Result, Ok, Err};
-#[doc(no_inline)] pub use io::{Buffer, Writer, Reader, Seek};
+#[doc(no_inline)] pub use io::{Buffer, Writer, Reader, Seek, BufferPrelude};
 #[doc(no_inline)] pub use str::{Str, StrVector, StrPrelude};
 #[doc(no_inline)] pub use str::{IntoMaybeOwned, StrAllocating, UnicodeStrPrelude};
 #[doc(no_inline)] pub use to_string::{ToString, IntoStr};


### PR DESCRIPTION
This moves chars() and lines() out of Buffer and into separate traits (CharsBuffer and LinesBuffer respectively) - this matches the pattern used for bytes() on Reader (with BytesReader).

(I came across this when I wanted a trait object of a Buffer, so that I could use read_line(); rustc errors about std::io::Buffer not being object-safe.)

[breaking-change]
Any uses of Buffer::lines() will need to use the new trait std::io::LinesBuffer.
The same is true for Buffer::chars() with std::io::CharsBuffer.
