### PR TITLE
Add 'move' keyword to emacs, kate, and vim editor modes.

### DIFF
--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -176,7 +176,7 @@
     "false" "fn" "for"
     "if" "impl" "in"
     "let" "loop"
-    "match" "mod" "mut"
+    "match" "mod" "move" "mut"
     "priv" "proc" "pub"
     "ref" "return"
     "self" "static" "struct" "super"

--- a/src/etc/kate/rust.xml
+++ b/src/etc/kate/rust.xml
@@ -34,6 +34,7 @@
 		<item> loop </item>
 		<item> match </item>
 		<item> mod </item>
+		<item> move </item>
 		<item> mut </item>
 		<item> priv </item>
 		<item> pub </item>


### PR DESCRIPTION
I noticed today that `move` wasn't getting highlighted in my editor of choice (emacs), so I went ahead and added it as a keyword in the emacs, vim, and kate editor files. Apparently it has already been done for gedit.
