### PR TITLE
Prefer bundled linker redux

### DIFF
--- a/src/etc/make-win-dist.py
+++ b/src/etc/make-win-dist.py
@@ -23,7 +23,7 @@ def find_files(files, path):
     return found
 
 def make_win_dist(dist_root, target_triple):
-    # Ask gcc where it keeps its' stuff
+    # Ask gcc where it keeps its stuff
     gcc_out = subprocess.check_output(["gcc.exe", "-print-search-dirs"])
     bin_path = os.environ["PATH"].split(os.pathsep)
     lib_path = []
@@ -59,14 +59,14 @@ def make_win_dist(dist_root, target_triple):
         shutil.copy(src, dist_bin_dir)
 
     # Copy platform tools to platform-specific bin directory
-    target_bin_dir = os.path.join(dist_root, "bin", "rustlib", target_triple, "gcc", "bin")
+    target_bin_dir = os.path.join(dist_root, "bin", "rustlib", target_triple, "bin")
     if not os.path.exists(target_bin_dir):
         os.makedirs(target_bin_dir)
     for src in target_tools:
         shutil.copy(src, target_bin_dir)
 
     # Copy platform libs to platform-spcific lib directory
-    target_lib_dir = os.path.join(dist_root, "bin", "rustlib", target_triple, "gcc", "lib")
+    target_lib_dir = os.path.join(dist_root, "bin", "rustlib", target_triple, "lib")
     if not os.path.exists(target_lib_dir):
         os.makedirs(target_lib_dir)
     for src in target_libs:

--- a/src/etc/make-win-dist.py
+++ b/src/etc/make-win-dist.py
@@ -42,11 +42,48 @@ def make_win_dist(dist_root, target_triple):
     else:
         rustc_dlls.append("libgcc_s_seh-1.dll")
 
-    target_libs = ["crtbegin.o", "crtend.o", "crt2.o", "dllcrt2.o",
-                   "libadvapi32.a", "libcrypt32.a", "libgcc.a", "libgcc_eh.a", "libgcc_s.a",
-                   "libimagehlp.a", "libiphlpapi.a", "libkernel32.a", "libm.a", "libmingw32.a",
-                   "libmingwex.a", "libmsvcrt.a", "libpsapi.a", "libshell32.a", "libstdc++.a",
-                   "libuser32.a", "libws2_32.a", "libiconv.a", "libmoldname.a"]
+    target_libs = [ # MinGW libs
+                    "crtbegin.o",
+                    "crtend.o",
+                    "crt2.o",
+                    "dllcrt2.o",
+                    "libgcc.a",
+                    "libgcc_eh.a",
+                    "libgcc_s.a",
+                    "libm.a",
+                    "libmingw32.a",
+                    "libmingwex.a",
+                    "libstdc++.a",
+                    "libiconv.a",
+                    "libmoldname.a",
+                    # Windows import libs
+                    "libadvapi32.a",
+                    "libbcrypt.a",
+                    "libcomctl32.a",
+                    "libcomdlg32.a",
+                    "libcrypt32.a",
+                    "libctl3d32.a",
+                    "libgdi32.a",
+                    "libimagehlp.a",
+                    "libiphlpapi.a",
+                    "libkernel32.a",
+                    "libmsvcrt.a",
+                    "libodbc32.a",
+                    "libole32.a",
+                    "liboleaut32.a",
+                    "libopengl32.a",
+                    "libpsapi.a",
+                    "librpcrt4.a",
+                    "libsetupapi.a",
+                    "libshell32.a",
+                    "libuser32.a",
+                    "libuuid.a",
+                    "libwinhttp.a",
+                    "libwinmm.a",
+                    "libwinspool.a",
+                    "libws2_32.a",
+                    "libwsock32.a",
+                    ]
 
     # Find mingw artifacts we want to bundle
     target_tools = find_files(target_tools, bin_path)

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -890,9 +890,6 @@ fn link_args(cmd: &mut Command,
         cmd.arg(obj_filename.with_extension("metadata.o"));
     }
 
-    // Rust does its' own LTO
-    cmd.arg("-fno-lto");
-
     if t.options.is_like_osx {
         // The dead_strip option to the linker specifies that functions and data
         // unreachable by the entry point will be removed. This is quite useful

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -568,8 +568,8 @@ pub fn phase_6_link_output(sess: &Session,
                            trans: &CrateTranslation,
                            outputs: &OutputFilenames) {
     let old_path = os::getenv("PATH").unwrap_or_else(||String::new());
-    let mut new_path = os::split_paths(old_path.as_slice());
-    new_path.extend(sess.host_filesearch().get_tools_search_paths().into_iter());
+    let mut new_path = sess.host_filesearch().get_tools_search_paths();
+    new_path.extend(os::split_paths(old_path.as_slice()).into_iter());
     os::setenv("PATH", os::join_paths(new_path.as_slice()).unwrap());
 
     time(sess.time_passes(), "linking", (), |_|

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -150,12 +150,8 @@ impl<'a> FileSearch<'a> {
         p.push(find_libdir(self.sysroot));
         p.push(rustlibdir());
         p.push(self.triple);
-        let mut p1 = p.clone();
-        p1.push("bin");
-        let mut p2 = p.clone();
-        p2.push("gcc");
-        p2.push("bin");
-        vec![p1, p2]
+        p.push("bin");
+        vec![p]
     }
 }
 


### PR DESCRIPTION
Based on Windows bundle feedback we got to date, 
- We _do_ want to prefer the bundled linker: The external one might be for the wrong architecture (e.g. 32 bit vs 64 bit).  On the other hand, binutils don't add many new features these days, so using an older bundled linker is not likely to be a problem.
- We _do_ want to prefer bundled libraries: The external ones might not have the symbols we expect (e.g. what's needed for DWARF exceptions vs SjLj).  Since `-L rustlib/<triple>/lib` appears first on the linker command line, it's a good place to keep our platform libs that we want to be found first.

Closes #18325, closes #17726.
