### PR TITLE
Fix upvars sometimes not being marked as used mutably

### DIFF
--- a/src/librustc/middle/borrowck/gather_loans/mod.rs
+++ b/src/librustc/middle/borrowck/gather_loans/mod.rs
@@ -395,10 +395,10 @@ impl<'a, 'tcx> GatherLoanCtxt<'a, 'tcx> {
             LpUpvar(ty::UpvarId{ var_id: local_id, closure_expr_id: _ }) => {
                 self.tcx().used_mut_nodes.borrow_mut().insert(local_id);
             }
-            LpExtend(ref base, mc::McInherited, _) => {
+            LpExtend(ref base, mc::McInherited, _) |
+            LpExtend(ref base, mc::McDeclared, _) => {
                 self.mark_loan_path_as_mutated(&**base);
             }
-            LpExtend(_, mc::McDeclared, _) |
             LpExtend(_, mc::McImmutable, _) => {
                 // Nothing to do.
             }

--- a/src/test/run-pass/unboxed-closures-move-mutable.rs
+++ b/src/test/run-pass/unboxed-closures-move-mutable.rs
@@ -14,7 +14,9 @@
 // Test that mutating a mutable upvar in a capture-by-value unboxed
 // closure does not ice (issue #18238) and marks the upvar as used
 // mutably so we do not get a spurious warning about it not needing to
-// be declared mutable (issue #18336).
+// be declared mutable (issue #18336 and #18769)
+
+fn set(x: &mut uint) { *x = 42; }
 
 fn main() {
     {
@@ -24,5 +26,13 @@ fn main() {
     {
         let mut x = 0u;
         move |:| x += 1;
+    }
+    {
+        let mut x = 0u;
+        move |&mut:| set(&mut x);
+    }
+    {
+        let mut x = 0u;
+        move |:| set(&mut x);
     }
 }


### PR DESCRIPTION
Drill down the loan path for `McDeclared` references as well since it might lead to an upvar.  Closes #18769
