### PR TITLE
Fix ICEs introduced in #17830 that involved quasi-quotation

### DIFF
--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -10,7 +10,7 @@
 
 // The Rust abstract syntax tree.
 
-use codemap::{Span, Spanned, DUMMY_SP, ExpnId, respan};
+use codemap::{Span, Spanned, DUMMY_SP, ExpnId};
 use abi::Abi;
 use ast_util;
 use owned_slice::OwnedSlice;
@@ -783,13 +783,13 @@ impl TokenTree {
                 TtToken(sp, token::Pound)
             }
             (&TtToken(sp, token::DocComment(name)), 1) => {
-                let doc = MetaNameValue(token::intern_and_get_ident("doc"),
-                                        respan(sp, LitStr(token::get_name(name), CookedStr)));
-                let doc = token::NtMeta(P(respan(sp, doc)));
                 TtDelimited(sp, Rc::new(Delimited {
                     delim: token::Bracket,
                     open_span: sp,
-                    tts: vec![TtToken(sp, token::Interpolated(doc))],
+                    tts: vec![TtToken(sp, token::Ident(token::str_to_ident("doc"),
+                                                       token::Plain)),
+                              TtToken(sp, token::Eq),
+                              TtToken(sp, token::LitStr(name))],
                     close_span: sp,
                 }))
             }

--- a/src/test/run-pass-fulldeps/issue-18763-quote-token-tree.rs
+++ b/src/test/run-pass-fulldeps/issue-18763-quote-token-tree.rs
@@ -1,0 +1,31 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-android
+// ignore-pretty: does not work well with `--test`
+
+#![feature(quote)]
+
+extern crate syntax;
+
+use syntax::ext::base::ExtCtxt;
+
+fn syntax_extension(cx: &ExtCtxt) {
+    let _toks_1 = vec![quote_tokens!(cx, /** comment */ fn foo() {})];
+    let name = quote_tokens!(cx, bar);
+    let _toks_2 = vec![quote_item!(cx, static $name:int = 2;)];
+    let _toks_3 = vec![quote_item!(cx,
+        /// comment
+        fn foo() { let $name:int = 3; }
+    )];
+}
+
+fn main() {
+}


### PR DESCRIPTION
Fix ICEs introduced in #17830
- fixed get_tt for doc comments
- properly handle MatchNt in `quote`

Fixes #18763
Fixes #18775
