### PR TITLE
tidy: Make errors be printed in red and underlined

### DIFF
--- a/src/etc/tidy.py
+++ b/src/etc/tidy.py
@@ -28,7 +28,7 @@ autocrlf=result.strip() == true if result is not None else False
 
 def report_error_name_no(name, no, s):
     global err
-    print("%s:%d: %s" % (name, no, s))
+    print("\033[4;31m%s:%d: %s\033[0m" % (name, no, s))
     err=1
 
 def report_err(s):


### PR DESCRIPTION
This is what it looks like with this patch
![Image of an error](https://i.imgur.com/OUEyfUd.png)
