### PR TITLE
Rogue 'panic' -> 'fail' in guide.

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -5274,7 +5274,7 @@ let result = task::try(proc() {
 
 This task will randomly panic or succeed. `task::try` returns a `Result`
 type, so we can handle the response like any other computation that may
-panic.
+fail.
 
 # Macros
 


### PR DESCRIPTION
Should refer to handling panicking tasks like any other computation
that may _fail_, not any other computation that may _panic_.
