### PR TITLE
Diagnostic tweaks

### DIFF
--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -307,7 +307,8 @@ impl<'a> Context<'a> {
             format!("found possibly newer version of crate `{}`",
                     self.ident)
         } else if self.rejected_via_triple.len() > 0 {
-            format!("found incorrect triple for crate `{}`", self.ident)
+            format!("couldn't find crate `{}` with expected target triple {}",
+                    self.ident, self.triple)
         } else {
             format!("can't find crate for `{}`", self.ident)
         };
@@ -318,15 +319,12 @@ impl<'a> Context<'a> {
         };
         self.sess.span_err(self.span, message.as_slice());
 
-        let mismatches = self.rejected_via_triple.iter();
         if self.rejected_via_triple.len() > 0 {
-            self.sess.span_note(self.span,
-                                format!("expected triple of {}",
-                                        self.triple).as_slice());
+            let mismatches = self.rejected_via_triple.iter();
             for (i, &CrateMismatch{ ref path, ref got }) in mismatches.enumerate() {
                 self.sess.fileline_note(self.span,
-                    format!("crate `{}` path {}{}, triple {}: {}",
-                            self.ident, "#", i+1, got, path.display()).as_slice());
+                    format!("crate `{}`, path #{}, triple {}: {}",
+                            self.ident, i+1, got, path.display()).as_slice());
             }
         }
         if self.rejected_via_hash.len() > 0 {

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -806,6 +806,13 @@ impl<'a> StringReader<'a> {
                                     if ascii_only { "unknown byte escape" }
                                     else { "unknown character escape" },
                                     c);
+                                if e == '\r' {
+                                    let sp = codemap::mk_sp(escaped_pos, last_pos);
+                                    self.span_diagnostic.span_help(
+                                        sp,
+                                        "this is an isolated carriage return; consider checking \
+                                         your editor and version control settings.")
+                                }
                                 false
                             }
                         }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1646,7 +1646,8 @@ impl<'a> Parser<'a> {
             token::LitByte(i) => LitByte(parse::byte_lit(i.as_str()).val0()),
             token::LitChar(i) => LitChar(parse::char_lit(i.as_str()).val0()),
             token::LitInteger(s) => parse::integer_lit(s.as_str(),
-                                                        &self.sess.span_diagnostic, self.span),
+                                                        &self.sess.span_diagnostic,
+                                                       self.last_span),
             token::LitFloat(s) => parse::float_lit(s.as_str()),
             token::LitStr(s) => {
                 LitStr(token::intern_and_get_ident(parse::str_lit(s.as_str()).as_slice()),

--- a/src/test/compile-fail/.gitattributes
+++ b/src/test/compile-fail/.gitattributes
@@ -1,0 +1,1 @@
+trailing-carriage-return-in-string.rs -text

--- a/src/test/compile-fail/extern-crate-as-no-string-help.rs
+++ b/src/test/compile-fail/extern-crate-as-no-string-help.rs
@@ -11,4 +11,5 @@
 // Tests that the proper help is displayed in the error message
 
 extern crate foo as bar;
-//~^ ERROR expected `;`, found `as`; perhaps you meant to enclose the crate name `foo` in a string?
+//~^ ERROR expected `;`, found `as`
+//~^^ HELP perhaps you meant to enclose the crate name `foo` in a string?

--- a/src/test/compile-fail/int-literal-too-large-span.rs
+++ b/src/test/compile-fail/int-literal-too-large-span.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// issue #17123
+
+fn main() {
+    100000000000000000000000000000000 //~ ERROR int literal is too large
+
+        ; // the span shouldn't point to this.
+}

--- a/src/test/compile-fail/mod_file_not_exist.rs
+++ b/src/test/compile-fail/mod_file_not_exist.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
+//~^ HELP name the file either not_a_real_file.rs or not_a_real_file/mod.rs inside the directory
 
 fn main() {
     assert_eq!(mod_file_aux::bar(), 10);

--- a/src/test/compile-fail/trailing-carriage-return-in-string.rs
+++ b/src/test/compile-fail/trailing-carriage-return-in-string.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-tidy-cr
+// Issue #11669
+
+fn main() {
+    // \r\n
+    let ok = "This is \
+ a test";
+    // \r only
+    let bad = "This is \ a test";
+    //~^ ERROR unknown character escape: \r
+    //~^^ HELP this is an isolated carriage return
+
+}

--- a/src/test/run-make/mismatching-target-triples/Makefile
+++ b/src/test/run-make/mismatching-target-triples/Makefile
@@ -1,0 +1,11 @@
+-include ../tools.mk
+
+# Issue #10814
+#
+# these are no_std to avoid having to have the standard library or any
+# linkers/assemblers for the relevant platform
+
+all:
+	$(RUSTC) foo.rs --target=i686-unknown-linux-gnu
+	$(RUSTC) bar.rs --target=x86_64-unknown-linux-gnu 2>&1 \
+		| grep "couldn't find crate .foo. with expected target triple x86_64-unknown-linux-gnu"

--- a/src/test/run-make/mismatching-target-triples/bar.rs
+++ b/src/test/run-make/mismatching-target-triples/bar.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![no_std]
+extern crate foo;

--- a/src/test/run-make/mismatching-target-triples/foo.rs
+++ b/src/test/run-make/mismatching-target-triples/foo.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![no_std]
+#![crate_type = "lib"]


### PR DESCRIPTION
Fix some old papercuts with diagnostics, e.g. tweaking spans, rewording messages. See individual commits.
