### PR TITLE
mk: Fix configuration of version commit information

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -52,7 +52,7 @@ CFG_GIT_DIR := $(CFG_SRC_DIR).git
 # so we use a hack: define $(SPACE) which contains space character.
 SPACE :=
 SPACE +=
-ifneq ($(wildcard $(subst $(SPACE),\$(SPACE),$(CFG_GIT))),)
+ifneq ($(CFG_GIT),)
 ifneq ($(wildcard $(subst $(SPACE),\$(SPACE),$(CFG_GIT_DIR))),)
     CFG_VER_DATE = $(shell git --git-dir='$(CFG_GIT_DIR)' log -1 --pretty=format:'%ci')
     CFG_VER_HASH = $(shell git --git-dir='$(CFG_GIT_DIR)' rev-parse HEAD)


### PR DESCRIPTION
Commit bec2ee77f78b4bb8a503101091272a634a273a1c started quoting paths
discovered as part of the `probe` function, which includes git.  The
`make` `wildcard` function appears to be incompatible with quoted
paths so this check in the makefile now fails. Employing `wildcard`
here appears to only re-verify that git actually exists, which the
configure script already did, so I've just removed it.

Additionally, with the quoted paths the `subst` function should no
longer be needed, so I've removed it as well.

Closes #18771
