### PR TITLE
Revert "Properly escape paths to executables. Fixes #18632."

### DIFF
--- a/configure
+++ b/configure
@@ -76,24 +76,6 @@ putvar() {
     printf "%-20s := %s\n" $1 "$T" >>config.tmp
 }
 
-putpathvar() {
-    local T
-    eval T=\$$1
-    eval TLEN=\${#$1}
-    if [ $TLEN -gt 35 ]
-    then
-        printf "configure: %-20s := %.35s ...\n" $1 "$T"
-    else
-        printf "configure: %-20s := %s %s\n" $1 "$T" "$2"
-    fi
-    if [ -z "$T" ]
-    then
-        printf "%-20s := \n" $1 >>config.tmp
-    else
-        printf "%-20s := \"%s\"\n" $1 "$T" >>config.tmp
-    fi
-}
-
 probe() {
     local V=$1
     shift
@@ -119,7 +101,7 @@ probe() {
         fi
     done
     eval $V=\$T
-    putpathvar $V "$VER"
+    putvar $V "$VER"
 }
 
 probe_need() {
@@ -1348,7 +1330,8 @@ do
 done
 
 # Munge any paths that appear in config.mk back to posix-y
-perl -i.bak -p -e 's@ ([a-zA-Z]):[/\\]@ /\1/@go;' config.tmp
+perl -i.bak -p -e 's@ ([a-zA-Z]):[/\\]@ /\1/@go;' \
+               -e 's@\\@/@go;' config.tmp
 rm -f config.tmp.bak
 
 msg


### PR DESCRIPTION
This reverts commit bec2ee77f78b4bb8a503101091272a634a273a1c.

Conflicts:
    configure

Caused distcheck failures and #18771
