### PR TITLE
rustdoc: revise method counts in stability summary

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -114,19 +114,19 @@ pub enum ExternalLocation {
 
 /// Metadata about an implementor of a trait.
 pub struct Implementor {
-    def_id: ast::DefId,
-    generics: clean::Generics,
-    trait_: clean::Type,
-    for_: clean::Type,
-    stability: Option<clean::Stability>,
+    pub def_id: ast::DefId,
+    pub generics: clean::Generics,
+    pub trait_: clean::Type,
+    pub for_: clean::Type,
+    pub stability: Option<clean::Stability>,
 }
 
 /// Metadata about implementations for a type.
 #[deriving(Clone)]
 pub struct Impl {
-    impl_: clean::Impl,
-    dox: Option<String>,
-    stability: Option<clean::Stability>,
+    pub impl_: clean::Impl,
+    pub dox: Option<String>,
+    pub stability: Option<clean::Stability>,
 }
 
 /// This cache is used to store information about the `clean::Crate` being
@@ -254,11 +254,6 @@ pub fn run(mut krate: clean::Crate, external_html: &ExternalHtml, dst: Path) -> 
 
     try!(mkdir(&cx.dst));
 
-    // Crawl the crate, building a summary of the stability levels.  NOTE: this
-    // summary *must* be computed with the original `krate`; the folding below
-    // removes the impls from their modules.
-    let summary = stability_summary::build(&krate);
-
     // Crawl the crate attributes looking for attributes which control how we're
     // going to emit HTML
     let default: &[_] = &[];
@@ -371,6 +366,9 @@ pub fn run(mut krate: clean::Crate, external_html: &ExternalHtml, dst: Path) -> 
 
     try!(write_shared(&cx, &krate, &*cache, index));
     let krate = try!(render_sources(&mut cx, krate));
+
+    // Crawl the crate, building a summary of the stability levels.
+    let summary = stability_summary::build(&krate);
 
     // And finally render the whole crate's documentation
     cx.krate(krate, summary)

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -16,7 +16,7 @@
 #![crate_type = "rlib"]
 
 #![allow(unknown_features)]
-#![feature(globs, struct_variant, macro_rules, phase, slicing_syntax)]
+#![feature(globs, struct_variant, macro_rules, phase, slicing_syntax, tuple_indexing)]
 
 extern crate arena;
 extern crate getopts;


### PR DESCRIPTION
Previously, the stability summary page attempted to associate impl
blocks with the module in which they were defined, rather than the
module defining the type they apply to (which is usually, but not
always, the same). Unfortunately, due to the basic architecture of
rustdoc, this meant that impls from re-exports were not being counted.

This commit makes the stability summary work the same way that rustdoc's
rendered output does: all methods are counted alongside the type they
apply to, no matter where the methods are defined.

In addition, for trait impl blocks only the stability of the overall
block is counted; the stability of the methods within is not
counted (since that stability level is part of the trait definition).

Fixes #18812
