### PR TITLE
Refactor QPath to take an ast::TraitRef

### DIFF
--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -100,6 +100,10 @@ impl<'tcx> Substs<'tcx> {
         regions_is_noop && self.types.is_empty()
     }
 
+    pub fn type_for_def(&self, ty_param_def: &ty::TypeParameterDef) -> Ty<'tcx> {
+        *self.types.get(ty_param_def.space, ty_param_def.index)
+    }
+
     pub fn has_regions_escaping_depth(&self, depth: uint) -> bool {
         self.types.iter().any(|&t| ty::type_escapes_depth(t, depth)) || {
             match self.regions {

--- a/src/librustc/middle/traits/mod.rs
+++ b/src/librustc/middle/traits/mod.rs
@@ -25,6 +25,7 @@ use std::rc::Rc;
 use std::slice::Items;
 use syntax::ast;
 use syntax::codemap::{Span, DUMMY_SP};
+use util::common::ErrorReported;
 
 pub use self::fulfill::FulfillmentContext;
 pub use self::select::SelectionContext;
@@ -94,10 +95,6 @@ pub enum ObligationCauseCode<'tcx> {
     // Types of fields (other than the last) in a struct must be sized.
     FieldSized,
 }
-
-// An error has already been reported to the user, so no need to continue checking.
-#[deriving(Clone,Show)]
-pub struct ErrorReported;
 
 pub type Obligations<'tcx> = subst::VecPerParamSpace<Obligation<'tcx>>;
 

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -17,7 +17,6 @@ use self::Candidate::*;
 use self::BuiltinBoundConditions::*;
 use self::EvaluationResult::*;
 
-use super::{ErrorReported};
 use super::{Obligation, ObligationCause};
 use super::{SelectionError, Unimplemented, Overflow,
             OutputTypeParameterMismatch};
@@ -38,6 +37,7 @@ use std::cell::RefCell;
 use std::collections::hash_map::HashMap;
 use std::rc::Rc;
 use syntax::ast;
+use util::common::ErrorReported;
 use util::ppaux::Repr;
 
 pub struct SelectionContext<'cx, 'tcx:'cx> {

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -18,9 +18,10 @@ use std::fmt;
 use std::rc::Rc;
 use syntax::ast;
 use syntax::codemap::Span;
+use util::common::ErrorReported;
 use util::ppaux::Repr;
 
-use super::{ErrorReported, Obligation, ObligationCause, VtableImpl,
+use super::{Obligation, ObligationCause, VtableImpl,
             VtableParam, VtableParamData, VtableImplData};
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -684,7 +684,11 @@ fn find_associated_type_in_generics<'tcx>(tcx: &ty::ctxt<'tcx>,
                                           ty: Option<Ty<'tcx>>,
                                           associated_type_id: ast::DefId,
                                           generics: &ty::Generics<'tcx>)
-                                          -> Ty<'tcx> {
+                                          -> Ty<'tcx>
+{
+    debug!("find_associated_type_in_generics(ty={}, associated_type_id={}, generics={}",
+           ty.repr(tcx), associated_type_id.repr(tcx), generics.repr(tcx));
+
     let ty = match ty {
         None => {
             tcx.sess.span_bug(span,
@@ -703,20 +707,22 @@ fn find_associated_type_in_generics<'tcx>(tcx: &ty::ctxt<'tcx>,
             for type_parameter in generics.types.iter() {
                 if type_parameter.def_id == associated_type_id
                     && type_parameter.associated_with == Some(param_id) {
-                    return ty::mk_param_from_def(tcx, type_parameter)
+                    return ty::mk_param_from_def(tcx, type_parameter);
                 }
             }
 
-            tcx.sess.span_bug(span,
-                              "find_associated_type_in_generics(): didn't \
-                               find associated type anywhere in the generics \
-                               list")
+            tcx.sess.span_err(
+                span,
+                format!("no suitable bound on `{}`",
+                        ty.user_string(tcx))[]);
+            ty::mk_err()
         }
         _ => {
-            tcx.sess.span_bug(span,
-                              "find_associated_type_in_generics(): self type \
-                               is not a parameter")
-
+            tcx.sess.span_err(
+                span,
+                "it is currently unsupported to access associated types except \
+                 through a type parameter; this restriction will be lifted in time");
+            ty::mk_err()
         }
     }
 }
@@ -1155,7 +1161,7 @@ pub fn convert(ccx: &CrateCtxt, it: &ast::Item) {
 
             for trait_ref in opt_trait_ref.iter() {
                 astconv::instantiate_trait_ref(&icx, &ExplicitRscope, trait_ref,
-                                               Some(selfty), None);
+                                               Some(selfty));
             }
         },
         ast::ItemTrait(_, _, _, ref trait_methods) => {
@@ -1627,7 +1633,7 @@ fn ty_generics_for_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                         ccx,
                         subst::AssocSpace,
                         &associated_type.ty_param,
-                        generics.types.len(subst::TypeSpace),
+                        generics.types.len(subst::AssocSpace),
                         &ast_generics.where_clause,
                         Some(local_def(trait_id)));
                 ccx.tcx.ty_param_defs.borrow_mut().insert(associated_type.ty_param.id,
@@ -2019,7 +2025,6 @@ fn conv_param_bounds<'tcx,AC>(this: &AC,
             astconv::instantiate_poly_trait_ref(this,
                                                 &ExplicitRscope,
                                                 bound,
-                                                Some(param_ty.to_ty(this.tcx())),
                                                 Some(param_ty.to_ty(this.tcx())))
         })
         .collect();

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -20,6 +20,10 @@ use syntax::ast;
 use syntax::visit;
 use syntax::visit::Visitor;
 
+// An error has already been reported to the user, so no need to continue checking.
+#[deriving(Clone,Show)]
+pub struct ErrorReported;
+
 pub fn time<T, U>(do_it: bool, what: &str, u: U, f: |U| -> T) -> T {
     local_data_key!(depth: uint);
     if !do_it { return f(u); }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -706,11 +706,11 @@ pub enum Expr_ {
 ///
 ///     <Vec<T> as SomeTrait>::SomeAssociatedItem
 ///      ^~~~~     ^~~~~~~~~   ^~~~~~~~~~~~~~~~~~
-///      for_type  trait_name  item_name
+///      self_type  trait_name  item_name
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub struct QPath {
-    pub for_type: P<Ty>,
-    pub trait_name: Path,
+    pub self_type: P<Ty>,
+    pub trait_ref: P<TraitRef>,
     pub item_name: Ident,
 }
 

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -142,6 +142,10 @@ pub trait Folder {
         noop_fold_ty(t, self)
     }
 
+    fn fold_qpath(&mut self, t: P<QPath>) -> P<QPath> {
+        noop_fold_qpath(t, self)
+    }
+
     fn fold_mod(&mut self, m: Mod) -> Mod {
         noop_fold_mod(m, self)
     }
@@ -435,12 +439,8 @@ pub fn noop_fold_ty<T: Folder>(t: P<Ty>, fld: &mut T) -> P<Ty> {
                         fld.fold_opt_bounds(bounds),
                         id)
             }
-            TyQPath(ref qpath) => {
-                TyQPath(P(QPath {
-                    for_type: fld.fold_ty(qpath.for_type.clone()),
-                    trait_name: fld.fold_path(qpath.trait_name.clone()),
-                    item_name: fld.fold_ident(qpath.item_name.clone()),
-                }))
+            TyQPath(qpath) => {
+                TyQPath(fld.fold_qpath(qpath))
             }
             TyFixedLengthVec(ty, e) => {
                 TyFixedLengthVec(fld.fold_ty(ty), fld.fold_expr(e))
@@ -453,6 +453,16 @@ pub fn noop_fold_ty<T: Folder>(t: P<Ty>, fld: &mut T) -> P<Ty> {
             }
         },
         span: fld.new_span(span)
+    })
+}
+
+pub fn noop_fold_qpath<T: Folder>(qpath: P<QPath>, fld: &mut T) -> P<QPath> {
+    qpath.map(|qpath| {
+        QPath {
+            self_type: fld.fold_ty(qpath.self_type),
+            trait_ref: qpath.trait_ref.map(|tr| fld.fold_trait_ref(tr)),
+            item_name: fld.fold_ident(qpath.item_name),
+        }
     })
 }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1502,17 +1502,17 @@ impl<'a> Parser<'a> {
         } else if self.eat_keyword(keywords::Proc) {
             self.parse_proc_type(Vec::new())
         } else if self.token == token::Lt {
-            // QUALIFIED PATH
+            // QUALIFIED PATH `<TYPE as TRAIT_REF>::item`
             self.bump();
-            let for_type = self.parse_ty(true);
+            let self_type = self.parse_ty(true);
             self.expect_keyword(keywords::As);
-            let trait_name = self.parse_path(LifetimeAndTypesWithoutColons);
+            let trait_ref = self.parse_trait_ref();
             self.expect(&token::Gt);
             self.expect(&token::ModSep);
             let item_name = self.parse_ident();
             TyQPath(P(QPath {
-                for_type: for_type,
-                trait_name: trait_name.path,
+                self_type: self_type,
+                trait_ref: P(trait_ref),
                 item_name: item_name,
             }))
         } else if self.token == token::ModSep ||

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -744,10 +744,10 @@ impl<'a> State<'a> {
             }
             ast::TyQPath(ref qpath) => {
                 try!(word(&mut self.s, "<"));
-                try!(self.print_type(&*qpath.for_type));
+                try!(self.print_type(&*qpath.self_type));
                 try!(space(&mut self.s));
                 try!(self.word_space("as"));
-                try!(self.print_path(&qpath.trait_name, false));
+                try!(self.print_trait_ref(&*qpath.trait_ref));
                 try!(word(&mut self.s, ">"));
                 try!(word(&mut self.s, "::"));
                 try!(self.print_ident(qpath.item_name));

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -403,8 +403,8 @@ pub fn walk_ty<'v, V: Visitor<'v>>(visitor: &mut V, typ: &'v Ty) {
             }
         }
         TyQPath(ref qpath) => {
-            visitor.visit_ty(&*qpath.for_type);
-            visitor.visit_path(&qpath.trait_name, typ.id);
+            visitor.visit_ty(&*qpath.self_type);
+            visitor.visit_trait_ref(&*qpath.trait_ref);
             visitor.visit_ident(typ.span, qpath.item_name);
         }
         TyFixedLengthVec(ref ty, ref expression) => {

--- a/src/test/compile-fail/associated-types-in-ambiguous-context.rs
+++ b/src/test/compile-fail/associated-types-in-ambiguous-context.rs
@@ -20,12 +20,12 @@ fn get<T:Get,U:Get>(x: T, y: U) -> Get::Value {}
 
 trait Other {
     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) {}
-    //~^ ERROR this associated type is not allowed in this context
+    //~^ ERROR no suitable bound on `Self`
 }
 
 impl<T:Get> Other for T {
     fn uhoh<U:Get>(&self, foo: U, bar: <(T, U) as Get>::Value) {}
-    //~^ ERROR this associated type is not allowed in this context
+    //~^ ERROR currently unsupported
 }
 
 trait Grab {

--- a/src/test/run-pass/associated-types-qualified-path-with-trait-with-type-parameters.rs
+++ b/src/test/run-pass/associated-types-qualified-path-with-trait-with-type-parameters.rs
@@ -10,23 +10,9 @@
 
 #![feature(associated_types)]
 
-trait Get {
-    type Value;
-    fn get(&self) -> <Self as Get>::Value;
+trait Foo<T> {
+    type Bar;
+    fn get_bar() -> <Self as Foo<T>>::Bar;
 }
 
-fn get(x: int) -> <int as Get>::Value {}
-//~^ ERROR unsupported
-
-struct Struct {
-    x: int,
-}
-
-impl Struct {
-    fn uhoh<T>(foo: <T as Get>::Value) {}
-    //~^ ERROR no suitable bound on `T`
-}
-
-fn main() {
-}
-
+fn main() { }


### PR DESCRIPTION
This fixes #17388. 

Note that we don't check type parameters in trait-references and so on, so we accept some nonsense (I opened https://github.com/rust-lang/rust/issues/18865). (It may be easier to just add support for `T::Foo` and deprecate the qpath code until we can implement it more robustly using the trait lookup infrastructure, not sure.)
