### PR TITLE
libsyntax: Forbid type parameters in field expressions.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2415,9 +2415,16 @@ impl<'a> Parser<'a> {
                             e = self.mk_expr(lo, hi, nd);
                         }
                         _ => {
+                            if !tys.is_empty() {
+                                let last_span = self.last_span;
+                                self.span_err(last_span,
+                                              "field expressions may not \
+                                               have type parameters");
+                            }
+
                             let id = spanned(dot, hi, i);
                             let field = self.mk_field(e, id, tys);
-                            e = self.mk_expr(lo, hi, field)
+                            e = self.mk_expr(lo, hi, field);
                         }
                     }
                   }

--- a/src/test/compile-fail/type-parameters-in-field-exprs.rs
+++ b/src/test/compile-fail/type-parameters-in-field-exprs.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo {
+    x: int,
+    y: int,
+}
+
+fn main() {
+    let f = Foo {
+        x: 1,
+        y: 2,
+    };
+    f.x::<int>;
+    //~^ ERROR field expressions may not have type parameters
+}
+


### PR DESCRIPTION
This breaks code like:

```
struct Foo {
    x: int,
}

let f: Foo = ...;
... f.x::<int> ...
```

Change this code to not contain an unused type parameter. For example:

```
struct Foo {
    x: int,
}

let f: Foo = ...;
... f.x ...
```

Closes #18680.

[breaking-change]

r? @aturon
