### PR TITLE
implement Writer for Vec<u8>

### DIFF
--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -90,7 +90,7 @@ impl<'a> dot::GraphWalk<'a, Nd, Ed> for Edges {
     fn target(&self, e: &Ed) -> Nd { let &(_,t) = e; t }
 }
 
-# pub fn main() { use std::io::MemWriter; render_to(&mut MemWriter::new()) }
+# pub fn main() { render_to(&mut Vec::new()) }
 ```
 
 ```no_run
@@ -182,7 +182,7 @@ impl<'a> dot::GraphWalk<'a, Nd, Ed<'a>> for Graph {
     fn target(&self, e: &Ed) -> Nd { let & &(_,t) = e; t }
 }
 
-# pub fn main() { use std::io::MemWriter; render_to(&mut MemWriter::new()) }
+# pub fn main() { render_to(&mut Vec::new()) }
 ```
 
 ```no_run
@@ -246,7 +246,7 @@ impl<'a> dot::GraphWalk<'a, Nd<'a>, Ed<'a>> for Graph {
     fn target(&self, e: &Ed<'a>) -> Nd<'a> { let &(_,t) = e; t }
 }
 
-# pub fn main() { use std::io::MemWriter; render_to(&mut MemWriter::new()) }
+# pub fn main() { render_to(&mut Vec::new()) }
 ```
 
 ```no_run
@@ -274,7 +274,7 @@ pub fn main() {
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/")]
-#![feature(globs)]
+#![feature(globs, slicing_syntax)]
 
 pub use self::LabelText::*;
 
@@ -553,7 +553,7 @@ mod tests {
     use self::NodeLabels::*;
     use super::{Id, LabelText, LabelStr, EscStr, Labeller};
     use super::{Nodes, Edges, GraphWalk, render};
-    use std::io::{MemWriter, BufReader, IoResult};
+    use std::io::{BufReader, IoResult};
     use std::str;
 
     /// each node is an index in a vector in the graph.
@@ -702,9 +702,9 @@ mod tests {
     }
 
     fn test_input(g: LabelledGraph) -> IoResult<String> {
-        let mut writer = MemWriter::new();
+        let mut writer = Vec::new();
         render(&g, &mut writer).unwrap();
-        let mut r = BufReader::new(writer.get_ref());
+        let mut r = BufReader::new(writer[]);
         r.read_to_string()
     }
 
@@ -809,7 +809,7 @@ r#"digraph hasse_diagram {
             "branch2",
             "afterward"));
 
-        let mut writer = MemWriter::new();
+        let mut writer = Vec::new();
 
         let g = LabelledGraphWithEscStrs::new(
             "syntax_tree", labels,
@@ -817,7 +817,7 @@ r#"digraph hasse_diagram {
                  edge(1, 3, ";"),    edge(2, 3, ";"   )));
 
         render(&g, &mut writer).unwrap();
-        let mut r = BufReader::new(writer.get_ref());
+        let mut r = BufReader::new(writer[]);
         let r = r.read_to_string();
 
         assert_eq!(r.unwrap().as_slice(),

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -122,7 +122,6 @@ use util::nodemap::NodeMap;
 use std::fmt;
 use std::io;
 use std::rc::Rc;
-use std::str;
 use std::uint;
 use syntax::ast;
 use syntax::ast::*;
@@ -742,7 +741,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
 
     #[allow(unused_must_use)]
     fn ln_str(&self, ln: LiveNode) -> String {
-        let mut wr = io::MemWriter::new();
+        let mut wr = Vec::new();
         {
             let wr = &mut wr as &mut io::Writer;
             write!(wr, "[ln({}) of kind {} reads", ln.get(), self.ir.lnk(ln));
@@ -751,7 +750,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
             self.write_vars(wr, ln, |idx| self.users[idx].writer);
             write!(wr, "  precedes {}]", self.successors[ln.get()].to_string());
         }
-        str::from_utf8(wr.unwrap().as_slice()).unwrap().to_string()
+        String::from_utf8(wr).unwrap()
     }
 
     fn init_empty(&mut self, ln: LiveNode, succ_ln: LiveNode) {

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -28,13 +28,13 @@ pub fn highlight(src: &str, class: Option<&str>, id: Option<&str>) -> String {
                                       src.to_string(),
                                       "<stdin>".to_string());
 
-    let mut out = io::MemWriter::new();
+    let mut out = Vec::new();
     doit(&sess,
          lexer::StringReader::new(&sess.span_diagnostic, fm),
          class,
          id,
          &mut out).unwrap();
-    String::from_utf8_lossy(out.unwrap().as_slice()).into_string()
+    String::from_utf8_lossy(out[]).into_string()
 }
 
 /// Exhausts the `lexer` writing the output into `out`.

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -38,7 +38,7 @@ use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::{Occupied, Vacant};
 use std::fmt;
 use std::io::fs::PathExtensions;
-use std::io::{fs, File, BufferedWriter, MemWriter, BufferedReader};
+use std::io::{fs, File, BufferedWriter, BufferedReader};
 use std::io;
 use std::str;
 use std::string::String;
@@ -420,7 +420,7 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> io::IoResult<String> 
     }
 
     // Collect the index into a string
-    let mut w = MemWriter::new();
+    let mut w = Vec::new();
     try!(write!(&mut w, r#"searchIndex['{}'] = {{"items":["#, krate.name));
 
     let mut lastpath = "".to_string();
@@ -463,7 +463,7 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> io::IoResult<String> 
 
     try!(write!(&mut w, "]}};"));
 
-    Ok(String::from_utf8(w.unwrap()).unwrap())
+    Ok(String::from_utf8(w).unwrap())
 }
 
 fn write_shared(cx: &Context,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -28,7 +28,7 @@ extern crate "test" as testing;
 #[phase(plugin, link)] extern crate log;
 
 use std::io;
-use std::io::{File, MemWriter};
+use std::io::File;
 use std::collections::HashMap;
 use std::collections::hash_map::{Occupied, Vacant};
 use serialize::{json, Decodable, Encodable};
@@ -467,12 +467,12 @@ fn json_output(krate: clean::Crate, res: Vec<plugins::PluginJson> ,
     // FIXME #8335: yuck, Rust -> str -> JSON round trip! No way to .encode
     // straight to the Rust JSON representation.
     let crate_json_str = {
-        let mut w = MemWriter::new();
+        let mut w = Vec::new();
         {
             let mut encoder = json::Encoder::new(&mut w as &mut io::Writer);
             krate.encode(&mut encoder).unwrap();
         }
-        String::from_utf8(w.unwrap()).unwrap()
+        String::from_utf8(w).unwrap()
     };
     let crate_json = match json::from_str(crate_json_str.as_slice()) {
         Ok(j) => j,

--- a/src/libstd/fmt.rs
+++ b/src/libstd/fmt.rs
@@ -256,7 +256,7 @@ actually invoking the `write` function defined in this module. Example usage is:
 # #![allow(unused_must_use)]
 use std::io;
 
-let mut w = io::MemWriter::new();
+let mut w = Vec::new();
 write!(&mut w as &mut io::Writer, "Hello {}!", "world");
 ```
 
@@ -415,6 +415,7 @@ use io::Writer;
 use io;
 use result::{Ok, Err};
 use string;
+use vec::Vec;
 
 pub use core::fmt::{Formatter, Result, FormatWriter, rt};
 pub use core::fmt::{Show, Bool, Char, Signed, Unsigned, Octal, Binary};
@@ -443,10 +444,10 @@ pub use core::fmt::{argument, argumentstr, argumentuint};
 /// let s = format_args!(fmt::format, "Hello, {}!", "world");
 /// assert_eq!(s, "Hello, world!".to_string());
 /// ```
-pub fn format(args: &Arguments) -> string::String{
-    let mut output = io::MemWriter::new();
-    let _ = write!(&mut output, "{}", args);
-    string::String::from_utf8(output.unwrap()).unwrap()
+pub fn format(args: &Arguments) -> string::String {
+    let mut output = Vec::new();
+    let _ = write!(&mut output as &mut Writer, "{}", args);
+    string::String::from_utf8(output).unwrap()
 }
 
 impl<'a> Writer for Formatter<'a> {

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -374,7 +374,7 @@ mod test {
     use prelude::*;
     use super::*;
     use super::super::{IoResult, EndOfFile};
-    use super::super::mem::{MemReader, MemWriter, BufReader};
+    use super::super::mem::{MemReader, BufReader};
     use self::test::Bencher;
     use str::StrPrelude;
 
@@ -447,57 +447,57 @@ mod test {
 
     #[test]
     fn test_buffered_writer() {
-        let inner = MemWriter::new();
+        let inner = Vec::new();
         let mut writer = BufferedWriter::with_capacity(2, inner);
 
         writer.write(&[0, 1]).unwrap();
         let b: &[_] = &[];
-        assert_eq!(writer.get_ref().get_ref(), b);
+        assert_eq!(writer.get_ref()[], b);
 
         writer.write(&[2]).unwrap();
         let b: &[_] = &[0, 1];
-        assert_eq!(writer.get_ref().get_ref(), b);
+        assert_eq!(writer.get_ref()[], b);
 
         writer.write(&[3]).unwrap();
-        assert_eq!(writer.get_ref().get_ref(), b);
+        assert_eq!(writer.get_ref()[], b);
 
         writer.flush().unwrap();
         let a: &[_] = &[0, 1, 2, 3];
-        assert_eq!(a, writer.get_ref().get_ref());
+        assert_eq!(a, writer.get_ref()[]);
 
         writer.write(&[4]).unwrap();
         writer.write(&[5]).unwrap();
-        assert_eq!(a, writer.get_ref().get_ref());
+        assert_eq!(a, writer.get_ref()[]);
 
         writer.write(&[6]).unwrap();
         let a: &[_] = &[0, 1, 2, 3, 4, 5];
         assert_eq!(a,
-                   writer.get_ref().get_ref());
+                   writer.get_ref()[]);
 
         writer.write(&[7, 8]).unwrap();
         let a: &[_] = &[0, 1, 2, 3, 4, 5, 6];
         assert_eq!(a,
-                   writer.get_ref().get_ref());
+                   writer.get_ref()[]);
 
         writer.write(&[9, 10, 11]).unwrap();
         let a: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
         assert_eq!(a,
-                   writer.get_ref().get_ref());
+                   writer.get_ref()[]);
 
         writer.flush().unwrap();
         assert_eq!(a,
-                   writer.get_ref().get_ref());
+                   writer.get_ref()[]);
     }
 
     #[test]
     fn test_buffered_writer_inner_flushes() {
-        let mut w = BufferedWriter::with_capacity(3, MemWriter::new());
+        let mut w = BufferedWriter::with_capacity(3, Vec::new());
         w.write(&[0, 1]).unwrap();
         let a: &[_] = &[];
-        assert_eq!(a, w.get_ref().get_ref());
+        assert_eq!(a, w.get_ref()[]);
         let w = w.unwrap();
         let a: &[_] = &[0, 1];
-        assert_eq!(a, w.get_ref());
+        assert_eq!(a, w[]);
     }
 
     // This is just here to make sure that we don't infinite loop in the
@@ -536,24 +536,24 @@ mod test {
 
     #[test]
     fn test_line_buffer() {
-        let mut writer = LineBufferedWriter::new(MemWriter::new());
+        let mut writer = LineBufferedWriter::new(Vec::new());
         writer.write(&[0]).unwrap();
         let b: &[_] = &[];
-        assert_eq!(writer.get_ref().get_ref(), b);
+        assert_eq!(writer.get_ref()[], b);
         writer.write(&[1]).unwrap();
-        assert_eq!(writer.get_ref().get_ref(), b);
+        assert_eq!(writer.get_ref()[], b);
         writer.flush().unwrap();
         let b: &[_] = &[0, 1];
-        assert_eq!(writer.get_ref().get_ref(), b);
+        assert_eq!(writer.get_ref()[], b);
         writer.write(&[0, b'\n', 1, b'\n', 2]).unwrap();
         let b: &[_] = &[0, 1, 0, b'\n', 1, b'\n'];
-        assert_eq!(writer.get_ref().get_ref(), b);
+        assert_eq!(writer.get_ref()[], b);
         writer.flush().unwrap();
         let b: &[_] = &[0, 1, 0, b'\n', 1, b'\n', 2];
-        assert_eq!(writer.get_ref().get_ref(), b);
+        assert_eq!(writer.get_ref()[], b);
         writer.write(&[3, b'\n']).unwrap();
         let b: &[_] = &[0, 1, 0, b'\n', 1, b'\n', 2, 3, b'\n'];
-        assert_eq!(writer.get_ref().get_ref(), b);
+        assert_eq!(writer.get_ref()[], b);
     }
 
     #[test]

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -171,7 +171,7 @@ pub fn u64_from_be_bytes(data: &[u8], start: uint, size: uint) -> u64 {
 mod test {
     use prelude::*;
     use io;
-    use io::{MemReader, MemWriter, BytesReader};
+    use io::{MemReader, BytesReader};
 
     struct InitialZeroByteReader {
         count: int,
@@ -397,12 +397,12 @@ mod test {
     fn test_read_write_le_mem() {
         let uints = [0, 1, 2, 42, 10_123, 100_123_456, ::u64::MAX];
 
-        let mut writer = MemWriter::new();
+        let mut writer = Vec::new();
         for i in uints.iter() {
             writer.write_le_u64(*i).unwrap();
         }
 
-        let mut reader = MemReader::new(writer.unwrap());
+        let mut reader = MemReader::new(writer);
         for i in uints.iter() {
             assert!(reader.read_le_u64().unwrap() == *i);
         }
@@ -413,12 +413,12 @@ mod test {
     fn test_read_write_be() {
         let uints = [0, 1, 2, 42, 10_123, 100_123_456, ::u64::MAX];
 
-        let mut writer = MemWriter::new();
+        let mut writer = Vec::new();
         for i in uints.iter() {
             writer.write_be_u64(*i).unwrap();
         }
 
-        let mut reader = MemReader::new(writer.unwrap());
+        let mut reader = MemReader::new(writer);
         for i in uints.iter() {
             assert!(reader.read_be_u64().unwrap() == *i);
         }
@@ -428,12 +428,12 @@ mod test {
     fn test_read_be_int_n() {
         let ints = [::i32::MIN, -123456, -42, -5, 0, 1, ::i32::MAX];
 
-        let mut writer = MemWriter::new();
+        let mut writer = Vec::new();
         for i in ints.iter() {
             writer.write_be_i32(*i).unwrap();
         }
 
-        let mut reader = MemReader::new(writer.unwrap());
+        let mut reader = MemReader::new(writer);
         for i in ints.iter() {
             // this tests that the sign extension is working
             // (comparing the values as i32 would not test this)
@@ -446,10 +446,10 @@ mod test {
         //big-endian floating-point 8.1250
         let buf = vec![0x41, 0x02, 0x00, 0x00];
 
-        let mut writer = MemWriter::new();
+        let mut writer = Vec::new();
         writer.write(buf.as_slice()).unwrap();
 
-        let mut reader = MemReader::new(writer.unwrap());
+        let mut reader = MemReader::new(writer);
         let f = reader.read_be_f32().unwrap();
         assert!(f == 8.1250);
     }
@@ -458,11 +458,11 @@ mod test {
     fn test_read_write_f32() {
         let f:f32 = 8.1250;
 
-        let mut writer = MemWriter::new();
+        let mut writer = Vec::new();
         writer.write_be_f32(f).unwrap();
         writer.write_le_f32(f).unwrap();
 
-        let mut reader = MemReader::new(writer.unwrap());
+        let mut reader = MemReader::new(writer);
         assert!(reader.read_be_f32().unwrap() == 8.1250);
         assert!(reader.read_le_f32().unwrap() == 8.1250);
     }

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -12,6 +12,8 @@
 
 //! Readers and Writers for in-memory buffers
 
+#![allow(deprecated)]
+
 use cmp::min;
 use option::None;
 use result::{Err, Ok};
@@ -41,6 +43,14 @@ fn combine(seek: SeekStyle, cur: uint, end: uint, offset: i64) -> IoResult<u64> 
     }
 }
 
+impl Writer for Vec<u8> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> IoResult<()> {
+        self.push_all(buf);
+        Ok(())
+    }
+}
+
 /// Writes to an owned, growable byte vector
 ///
 /// # Example
@@ -54,6 +64,7 @@ fn combine(seek: SeekStyle, cur: uint, end: uint, offset: i64) -> IoResult<u64> 
 ///
 /// assert_eq!(w.unwrap(), vec!(0, 1, 2));
 /// ```
+#[deprecated = "use the Vec<u8> Writer implementation directly"]
 #[deriving(Clone)]
 pub struct MemWriter {
     buf: Vec<u8>,

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1297,9 +1297,9 @@ impl<'a> Writer for &'a mut Writer+'a {
 /// # fn process_input<R: Reader>(r: R) {}
 /// # fn foo () {
 /// use std::io::util::TeeReader;
-/// use std::io::{stdin, MemWriter, ByRefWriter};
+/// use std::io::{stdin, ByRefWriter};
 ///
-/// let mut output = MemWriter::new();
+/// let mut output = Vec::new();
 ///
 /// {
 ///     // Don't give ownership of 'output' to the 'tee'. Instead we keep a
@@ -1308,7 +1308,7 @@ impl<'a> Writer for &'a mut Writer+'a {
 ///     process_input(tee);
 /// }
 ///
-/// println!("input processed: {}", output.unwrap());
+/// println!("input processed: {}", output);
 /// # }
 /// ```
 pub struct RefWriter<'a, W:'a> {

--- a/src/libstd/io/result.rs
+++ b/src/libstd/io/result.rs
@@ -84,15 +84,15 @@ mod test {
 
     #[test]
     fn test_option_writer() {
-        let mut writer: io::IoResult<MemWriter> = Ok(MemWriter::new());
+        let mut writer: io::IoResult<Vec<u8>> = Ok(Vec::new());
         writer.write(&[0, 1, 2]).unwrap();
         writer.flush().unwrap();
-        assert_eq!(writer.unwrap().unwrap(), vec!(0, 1, 2));
+        assert_eq!(writer.unwrap(), vec!(0, 1, 2));
     }
 
     #[test]
     fn test_option_writer_error() {
-        let mut writer: io::IoResult<MemWriter> =
+        let mut writer: io::IoResult<Vec<u8>> =
             Err(io::standard_error(io::EndOfFile));
 
         match writer.write(&[0, 0, 0]) {

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -265,7 +265,7 @@ impl<T: Iterator<u8>> Reader for IterReader<T> {
 
 #[cfg(test)]
 mod test {
-    use io::{MemReader, MemWriter, BufReader, ByRefReader};
+    use io::{MemReader, BufReader, ByRefReader};
     use io;
     use boxed::Box;
     use super::*;
@@ -371,18 +371,18 @@ mod test {
     #[test]
     fn test_tee_reader() {
         let mut r = TeeReader::new(MemReader::new(vec!(0, 1, 2)),
-                                   MemWriter::new());
+                                   Vec::new());
         assert_eq!(vec!(0, 1, 2), r.read_to_end().unwrap());
         let (_, w) = r.unwrap();
-        assert_eq!(vec!(0, 1, 2), w.unwrap());
+        assert_eq!(vec!(0, 1, 2), w);
     }
 
     #[test]
     fn test_copy() {
         let mut r = MemReader::new(vec!(0, 1, 2, 3, 4));
-        let mut w = MemWriter::new();
+        let mut w = Vec::new();
         copy(&mut r, &mut w).unwrap();
-        assert_eq!(vec!(0, 1, 2, 3, 4), w.unwrap());
+        assert_eq!(vec!(0, 1, 2, 3, 4), w);
     }
 
     #[test]

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -253,9 +253,8 @@ macro_rules! format(
 ///
 /// ```
 /// # #![allow(unused_must_use)]
-/// use std::io::MemWriter;
 ///
-/// let mut w = MemWriter::new();
+/// let mut w = Vec::new();
 /// write!(&mut w, "test");
 /// write!(&mut w, "formatted {}", "arguments");
 /// ```

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -1009,12 +1009,10 @@ mod imp {
 #[cfg(test)]
 mod test {
     use prelude::*;
-    use io::MemWriter;
-
     macro_rules! t( ($a:expr, $b:expr) => ({
-        let mut m = MemWriter::new();
+        let mut m = Vec::new();
         super::demangle(&mut m, $a).unwrap();
-        assert_eq!(String::from_utf8(m.unwrap()).unwrap(), $b.to_string());
+        assert_eq!(String::from_utf8(m).unwrap(), $b.to_string());
     }) )
 
     #[test]

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -33,7 +33,7 @@ use print::pp;
 use ptr::P;
 
 use std::ascii;
-use std::io::{IoResult, MemWriter};
+use std::io::IoResult;
 use std::io;
 use std::mem;
 
@@ -169,17 +169,17 @@ impl<'a> State<'a> {
 
 pub fn to_string(f: |&mut State| -> IoResult<()>) -> String {
     use std::raw::TraitObject;
-    let mut s = rust_printer(box MemWriter::new());
+    let mut s = rust_printer(box Vec::new());
     f(&mut s).unwrap();
     eof(&mut s.s).unwrap();
     let wr = unsafe {
         // FIXME(pcwalton): A nasty function to extract the string from an `io::Writer`
-        // that we "know" to be a `MemWriter` that works around the lack of checked
+        // that we "know" to be a `Vec<u8>` that works around the lack of checked
         // downcasts.
         let obj: &TraitObject = mem::transmute(&s.s.out);
-        mem::transmute::<*mut (), &MemWriter>(obj.data)
+        mem::transmute::<*mut (), &Vec<u8>>(obj.data)
     };
-    String::from_utf8(wr.get_ref().to_vec()).unwrap()
+    String::from_utf8(wr.clone()).unwrap()
 }
 
 pub fn binop_to_string(op: BinOpToken) -> &'static str {

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -33,7 +33,7 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/")]
 
-#![feature(asm, macro_rules, phase, globs)]
+#![feature(asm, macro_rules, phase, globs, slicing_syntax)]
 
 extern crate getopts;
 extern crate regex;
@@ -848,8 +848,6 @@ pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn> ) -> io::IoR
 
 #[test]
 fn should_sort_failures_before_printing_them() {
-    use std::io::MemWriter;
-
     let test_a = TestDesc {
         name: StaticTestName("a"),
         ignore: false,
@@ -864,7 +862,7 @@ fn should_sort_failures_before_printing_them() {
 
     let mut st = ConsoleTestState {
         log_out: None,
-        out: Raw(MemWriter::new()),
+        out: Raw(Vec::new()),
         use_color: false,
         total: 0u,
         passed: 0u,
@@ -878,7 +876,7 @@ fn should_sort_failures_before_printing_them() {
 
     st.write_failures().unwrap();
     let s = match st.out {
-        Raw(ref m) => String::from_utf8_lossy(m.get_ref()),
+        Raw(ref m) => String::from_utf8_lossy(m[]),
         Pretty(_) => unreachable!()
     };
 

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -1027,10 +1027,9 @@ mod tests {
     #[test]
     fn test_boxplot_nonpositive() {
         fn t(s: &Summary<f64>, expected: String) {
-            use std::io::MemWriter;
-            let mut m = MemWriter::new();
+            let mut m = Vec::new();
             write_boxplot(&mut m as &mut io::Writer, s, 30).unwrap();
-            let out = String::from_utf8(m.unwrap()).unwrap();
+            let out = String::from_utf8(m).unwrap();
             assert_eq!(out, expected);
         }
 

--- a/src/test/compile-fail/variance-trait-matching-2.rs
+++ b/src/test/compile-fail/variance-trait-matching-2.rs
@@ -10,7 +10,6 @@
 
 extern crate serialize;
 
-use std::io::MemWriter;
 use std::io;
 use serialize::{Encodable, Encoder};
 
@@ -18,14 +17,14 @@ pub fn buffer_encode<'a,
                      T:Encodable<serialize::json::Encoder<'a>,io::IoError>>(
                      to_encode_object: &T)
                      -> Vec<u8> {
-    let mut m = MemWriter::new();
+    let mut m = Vec::new();
     {
         let mut encoder =
             serialize::json::Encoder::new(&mut m as &mut io::Writer);
         //~^ ERROR `m` does not live long enough
         to_encode_object.encode(&mut encoder);
     }
-    m.unwrap()
+    m
 }
 
 fn main() {}

--- a/src/test/run-pass/auto-encode.rs
+++ b/src/test/run-pass/auto-encode.rs
@@ -31,12 +31,11 @@ fn test_rbml<'a, 'b, A:
     Encodable<EBWriter::Encoder<'a>> +
     Decodable<EBReader::Decoder<'b>>
 >(a1: &A) {
-    let mut wr = std::io::MemWriter::new();
+    let mut wr = Vec::new();
     let mut rbml_w = EBwriter::Encoder::new(&mut wr);
     a1.encode(&mut rbml_w);
-    let bytes = wr.get_ref();
 
-    let d: serialize::rbml::Doc<'a> = EBDoc::new(bytes);
+    let d: serialize::rbml::Doc<'a> = EBDoc::new(wr[]);
     let mut decoder: EBReader::Decoder<'a> = EBreader::Decoder::new(d);
     let a2: A = Decodable::decode(&mut decoder);
     assert!(*a1 == a2);

--- a/src/test/run-pass/colorful-write-macros.rs
+++ b/src/test/run-pass/colorful-write-macros.rs
@@ -10,7 +10,7 @@
 
 // no-pretty-expanded
 
-#![allow(unused_must_use, dead_code)]
+#![allow(unused_must_use, dead_code, deprecated)]
 #![feature(macro_rules)]
 
 use std::io::MemWriter;

--- a/src/test/run-pass/deriving-encodable-decodable-cell-refcell.rs
+++ b/src/test/run-pass/deriving-encodable-decodable-cell-refcell.rs
@@ -14,7 +14,6 @@
 extern crate serialize;
 
 use std::cell::{Cell, RefCell};
-use std::io::MemWriter;
 use serialize::{Encodable, Decodable};
 use serialize::json;
 

--- a/src/test/run-pass/deriving-encodable-decodable.rs
+++ b/src/test/run-pass/deriving-encodable-decodable.rs
@@ -19,7 +19,6 @@ extern crate rand;
 extern crate rbml;
 extern crate serialize;
 
-use std::io::MemWriter;
 use rand::{random, Rand};
 use rbml;
 use rbml::Doc;
@@ -59,10 +58,10 @@ struct G<T> {
 fn roundtrip<'a, T: Rand + Eq + Encodable<Encoder<'a>> +
                     Decodable<Decoder<'a>>>() {
     let obj: T = random();
-    let mut w = MemWriter::new();
+    let mut w = Vec::new();
     let mut e = Encoder::new(&mut w);
     obj.encode(&mut e);
-    let doc = rbml::Doc::new(@w.get_ref());
+    let doc = rbml::Doc::new(@w[]);
     let mut dec = Decoder::new(doc);
     let obj2 = Decodable::decode(&mut dec);
     assert!(obj == obj2);

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -16,9 +16,7 @@
 #![allow(unused_must_use)]
 
 use std::fmt;
-use std::io::MemWriter;
 use std::io;
-use std::str;
 
 struct A;
 struct B;
@@ -161,7 +159,7 @@ pub fn main() {
 // Basic test to make sure that we can invoke the `write!` macro with an
 // io::Writer instance.
 fn test_write() {
-    let mut buf = MemWriter::new();
+    let mut buf = Vec::new();
     write!(&mut buf as &mut io::Writer, "{}", 3i);
     {
         let w = &mut buf as &mut io::Writer;
@@ -171,7 +169,7 @@ fn test_write() {
         writeln!(w, "{foo}", foo="bar");
     }
 
-    let s = str::from_utf8(buf.unwrap().as_slice()).unwrap().to_string();
+    let s = String::from_utf8(buf).unwrap();
     t!(s, "34helloline\nbar\n");
 }
 
@@ -188,14 +186,14 @@ fn test_print() {
 // Just make sure that the macros are defined, there's not really a lot that we
 // can do with them just yet (to test the output)
 fn test_format_args() {
-    let mut buf = MemWriter::new();
+    let mut buf = Vec::new();
     {
         let w = &mut buf as &mut io::Writer;
         format_args!(|args| { write!(w, "{}", args); }, "{}", 1i);
         format_args!(|args| { write!(w, "{}", args); }, "test");
         format_args!(|args| { write!(w, "{}", args); }, "{test}", test=3i);
     }
-    let s = str::from_utf8(buf.unwrap().as_slice()).unwrap().to_string();
+    let s = String::from_utf8(buf).unwrap();
     t!(s, "1test3");
 
     let s = format_args!(fmt::format, "hello {}", "world");


### PR DESCRIPTION
The trait has an obvious, sensible implementation directly on vectors so
the MemWriter wrapper is unnecessary. This will halt the trend towards
providing all of the vector methods on MemWriter along with eliminating
the noise caused by conversions between the two types. It also provides
the useful default Writer methods on Vec<u8>.

After the type is removed and code has been migrated, it would make
sense to add a new implementation of MemWriter with seeking support. The
simple use cases can be covered with vectors alone, and ones with the
need for seeks can use a new MemWriter implementation.
