### PR TITLE
rustc: do not inherit #[stable]

### DIFF
--- a/src/test/auxiliary/inherited_stability.rs
+++ b/src/test/auxiliary/inherited_stability.rs
@@ -18,10 +18,18 @@ pub fn stable() {}
 
 #[stable]
 pub mod stable_mod {
+    pub fn experimental() {}
+
+    #[stable]
+    pub fn stable() {}
+}
+
+#[unstable]
+pub mod unstable_mod {
     #[experimental]
     pub fn experimental() {}
 
-    pub fn stable() {}
+    pub fn unstable() {}
 }
 
 pub mod experimental_mod {
@@ -33,9 +41,9 @@ pub mod experimental_mod {
 
 #[stable]
 pub trait Stable {
-    #[experimental]
     fn experimental(&self);
 
+    #[stable]
     fn stable(&self);
 }
 

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -165,6 +165,9 @@ mod inheritance {
         stable_mod::experimental(); //~ ERROR use of experimental item
         stable_mod::stable();
 
+        unstable_mod::experimental(); //~ ERROR use of experimental item
+        unstable_mod::unstable(); //~ ERROR use of unstable item
+
         experimental_mod::experimental(); //~ ERROR use of experimental item
         experimental_mod::stable();
 


### PR DESCRIPTION
This patch tweaks the stability inheritance infrastructure so that
`#{stable]` attributes are not inherited. Doing so solves two problems:
1. It allows us to mark module _names_ as stable without accidentally
   marking the items they contain as stable.
2. It means that a `#[stable]` attribution must always appear directly
   on the item it applies to, which makes it easier for reviewers to catch
   changes to stable APIs.

Fixes #17484
