### PR TITLE
Fix unboxed closure ICE in trans

### DIFF
--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -253,11 +253,13 @@ pub fn trans_unboxing_shim(bcx: Block,
                            llshimmedfn: ValueRef,
                            fty: &ty::BareFnTy,
                            method_id: ast::DefId,
-                           substs: subst::Substs)
+                           substs: &subst::Substs)
                            -> ValueRef {
     let _icx = push_ctxt("trans_unboxing_shim");
     let ccx = bcx.ccx();
     let tcx = bcx.tcx();
+
+    let fty = fty.subst(tcx, substs);
 
     // Transform the self type to `Box<self_type>`.
     let self_type = fty.sig.inputs[0];
@@ -279,8 +281,7 @@ pub fn trans_unboxing_shim(bcx: Block,
         abi: fty.abi,
         sig: boxed_function_type,
     };
-    let boxed_function_type =
-        ty::mk_bare_fn(tcx, boxed_function_type).subst(tcx, &substs);
+    let boxed_function_type = ty::mk_bare_fn(tcx, boxed_function_type);
     let function_type = match fty.abi {
         synabi::RustCall => {
             // We're passing through to a RustCall ABI function, but
@@ -301,10 +302,10 @@ pub fn trans_unboxing_shim(bcx: Block,
                 abi: synabi::Rust,
                 sig: fake_ty,
             };
-            ty::mk_bare_fn(tcx, fake_ty).subst(tcx, &substs)
+            ty::mk_bare_fn(tcx, fake_ty)
         }
         _ => {
-            ty::mk_bare_fn(tcx, (*fty).clone()).subst(tcx, &substs)
+            ty::mk_bare_fn(tcx, fty)
         }
     };
 

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -624,7 +624,7 @@ pub fn get_vtable(bcx: Block,
                                                    llfn,
                                                    &closure_type,
                                                    closure_def_id,
-                                                   substs);
+                                                   &substs);
                     }
                 }
 
@@ -723,7 +723,7 @@ fn emit_vtable_methods(bcx: Block,
                                                      fn_ref,
                                                      &m.fty,
                                                      m_id,
-                                                     substs.clone());
+                                                     &substs);
                     }
                     Some(fn_ref).into_iter()
                 }

--- a/src/test/run-pass/issue-18883.rs
+++ b/src/test/run-pass/issue-18883.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that we don't ICE due to encountering unsubstituted type
+// parameters when untupling FnOnce parameters during translation of
+// an unboxing shim.
+
+#![feature(unboxed_closures)]
+
+fn main() {
+    let _: Box<FnOnce<(),()>> = box move |&mut:| {};
+}


### PR DESCRIPTION
This was a simple case of substitutions being applied inconsistently.  I haven't investigated why type parameters are actually showing up in the closure type here, but trans needs to handle them correctly in any case.
