### PR TITLE
Results aren't panics

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -267,7 +267,7 @@
 //! a bug.
 //!
 //! A module that instead returns `Results` is alerting the caller
-//! that panics are possible, and providing precise control over how
+//! that failure is possible, and providing precise control over how
 //! it is handled.
 //!
 //! Furthermore, panics may not be recoverable at all, depending on


### PR DESCRIPTION
A typo about Results being panics crawled in. Fixing it.
