### PR TITLE
test: failure in infer

### DIFF
--- a/src/test/run-pass/option-closure.rs
+++ b/src/test/run-pass/option-closure.rs
@@ -1,0 +1,23 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn calls(cb: Option<|&str, &i32|>) {
+    let s = "foo";
+    let i = 32;
+
+    match cb {
+        Some(cb) => cb(s, &i),
+        _ => {},
+    }
+
+}
+fn main() {
+    calls(Some(|s, u| {}));
+}


### PR DESCRIPTION
Regression test for an ICE. This is the smallest test case I could repro with.

(It still panics without the match, but the run-pass test wouldn't pass when it's fixed)

```
task 'rustc' panicked at 'assertion failed: !ty::type_needs_infer(ty)', /Users/richo/code/ext/rust/src/librustc/middle/typeck/mod.rs:287

stack backtrace:
   1:        0x112381a2f - rt::backtrace::imp::write::h3cada5b84f89fbe66mt
   2:        0x112384bb7 - failure::on_fail::hefa905209ce455fcVDt
   3:        0x112602cb5 - unwind::begin_unwind_inner::hd39f16915ccee7d1j1c
   4:        0x10f07ad7c - unwind::begin_unwind::h8713304023686688726
   5:        0x10f534b12 - middle::typeck::write_ty_to_tcx::hee84591aa553710dV8o
   6:        0x10f532003 - middle::typeck::check::writeback::WritebackCx<'cx, 'tcx>::visit_node_id::hdc27417171fe85120LO
   7:        0x10f52f6bd - middle::typeck::check::writeback::WritebackCx<'cx, 'tcx>.Visitor<'v>::visit_expr::h4ede99bcea8c72220AO
   8:        0x10f52f90b - middle::typeck::check::writeback::WritebackCx<'cx, 'tcx>.Visitor<'v>::visit_expr::h4ede99bcea8c72220AO
   9:        0x10f534057 - visit::walk_block::h15487588812085133261
  10:        0x10f530eb9 - middle::typeck::check::writeback::resolve_type_vars_in_fn::he9911200a7aceb616vO
  11:        0x10f584e3a - middle::typeck::check::check_bare_fn::h8f531b6690a1add9p5V
  12:        0x10f580f7d - middle::typeck::check::check_item::h7a25d3594f0d3906ypW
  13:        0x10f584c50 - middle::typeck::check::check_item_types::h7ccfbf35ece3b808z4V
  14:        0x10f096566 - util::common::time::h6828651919031589828
  15:        0x10f88f97e - middle::typeck::check_crate::hb629f897f68c14d7rrp
  16:        0x10f8f66e1 - driver::driver::phase_3_run_analysis_passes::h6ad8a93237fb4f5ctaC
  17:        0x10f8f1538 - driver::driver::compile_input::h8bb423d5b9daff3aeRB
  18:        0x10f96ea1d - driver::run_compiler::hc37ae4f2706fc942vHF
  19:        0x10f96cf5e - driver::run::closure.146204
  20:        0x10f0ae81b - task::TaskBuilder<S>::try_future::closure.104764
  21:        0x10f0ae713 - task::TaskBuilder<S>::spawn_internal::closure.104735
  22:        0x10f06f7dd - task::NativeSpawner.Spawner::spawn::closure.2551
  23:        0x112663bac - rust_try_inner
  24:        0x112663b96 - rust_try
  25:        0x112600487 - unwind::try::h7139a84d1900eb6d1Pc
  26:        0x11260031c - task::Task::run::h9971b53b16560a2b61b
  27:        0x10f06f603 - task::NativeSpawner.Spawner::spawn::closure.2475
  28:        0x112601b47 - thread::thread_start::h8caac61a203a88313mc
  29:     0x7fff90f5c2fc - _pthread_body
  30:     0x7fff90f5c279 - _pthread_body
```
