### PR TITLE
guide.md removed confusing semicolons

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -798,7 +798,7 @@ But what about early returns? Rust does have a keyword for that, `return`:
 
 ```{rust}
 fn foo(x: int) -> int {
-    if x < 5 { return x; }
+    if x < 5 { return x }
 
     x + 1
 }
@@ -809,7 +809,7 @@ style:
 
 ```{rust}
 fn foo(x: int) -> int {
-    if x < 5 { return x; }
+    if x < 5 { return x }
 
     return x + 1;
 }


### PR DESCRIPTION
Hi everybody,

I'm completely new to Rust. In fact I'm just in the middle reading the Rust Guide. I really like this introduction, it has a great flow. However I stumbled upon a "semicolon". It was the first time I had to switch from the guide and search for an answer and as I found out, I wasn't the only one http://stackoverflow.com/questions/26446587/what-difference-semicolons-make-in-early-returns.

_My Problem_
It looks like these three examples all compile and work in the same way:

``` rust
fn foo(x: int) -> int {
    if x < 5 { return x; }

    x + 1
}
```

``` rust
fn foo(x: int) -> int {
    if x < 5 { return x }

    x + 1
}
```

``` rust
fn foo(x: int) -> int {
    if x < 5 { return x };

    x + 1
}
```

Because the semicolon was just introduced before the example I expected the first example which is used currently in the guide to throw an error. (I'd think `()` would be returned.) As it turns out in the StackOverflow answer `return` is a special case which isn't explained in the guide before this example.

_My Proposal_
Remove the semicolon and/or make a statement about the best practices of semicolons after `return` (e.g. like the "poor style" example, but as a "good style" example").
