### PR TITLE
Add --print-sysroot commandline option to rustc

### DIFF
--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -566,6 +566,7 @@ pub fn optgroups() -> Vec<getopts::OptGroup> {
                  "Output dependency info to <filename> after compiling, \
                   in a format suitable for use by Makefiles", "FILENAME"),
         optopt("", "sysroot", "Override the system root", "PATH"),
+        optflag("", "print-sysroot", "Print the system root"),
         optflag("", "test", "Build a test harness"),
         optopt("", "target", "Target triple cpu-manufacturer-kernel[-os]
                             to compile for (see chapter 3.4 of http://www.sourceware.org/autobook/

--- a/src/librustc/driver/mod.rs
+++ b/src/librustc/driver/mod.rs
@@ -73,6 +73,13 @@ fn run_compiler(args: &[String]) {
                 describe_lints(&ls, false);
                 return;
             }
+
+            if matches.opt_present("print-sysroot") {
+                let sess = build_session(sopts, None, descriptions);
+                println!("{}", sess.sysroot().display());
+                return;
+            }
+
             early_error("no input filename given");
         }
         1u => {


### PR DESCRIPTION
This is in support of the coming "rust-mode" debugger startup scripts.
The implementation given here will print the sysroot if no input filename is given to rustc. Otherwise the option is silently ignored. Let me know if you'd like to have a different behavior.

cc @brson @alexcrichton 
