### PR TITLE
fix "warning: deprecated syntax, use `for` keyword now"

### DIFF
--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -630,12 +630,12 @@ pub fn get_item_path(cdata: Cmd, id: ast::NodeId) -> Vec<ast_map::PathElem> {
     item_path(lookup_item(id, cdata.data()))
 }
 
-pub type DecodeInlinedItem<'a> = <'tcx> |cdata: Cmd,
-                                         tcx: &ty::ctxt<'tcx>,
-                                         path: Vec<ast_map::PathElem>,
-                                         par_doc: rbml::Doc|: 'a
-                                         -> Result<&'tcx ast::InlinedItem,
-                                                   Vec<ast_map::PathElem>>;
+pub type DecodeInlinedItem<'a> = for<'tcx> |cdata: Cmd,
+                                            tcx: &ty::ctxt<'tcx>,
+                                            path: Vec<ast_map::PathElem>,
+                                            par_doc: rbml::Doc|: 'a
+                                            -> Result<&'tcx ast::InlinedItem,
+                                                      Vec<ast_map::PathElem>>;
 
 pub fn maybe_get_item_ast<'tcx>(cdata: Cmd, tcx: &ty::ctxt<'tcx>, id: ast::NodeId,
                                 decode_inlined_item: DecodeInlinedItem)

--- a/src/librustc/middle/trans/base.rs
+++ b/src/librustc/middle/trans/base.rs
@@ -1787,8 +1787,8 @@ pub fn trans_closure(ccx: &CrateContext,
                      abi: Abi,
                      has_env: bool,
                      is_unboxed_closure: IsUnboxedClosureFlag,
-                     maybe_load_env: <'blk, 'tcx> |Block<'blk, 'tcx>, ScopeId|
-                                                  -> Block<'blk, 'tcx>) {
+                     maybe_load_env: for<'blk, 'tcx> |Block<'blk, 'tcx>, ScopeId|
+                                                     -> Block<'blk, 'tcx>) {
     ccx.stats().n_closures.set(ccx.stats().n_closures.get() + 1);
 
     let _icx = push_ctxt("trans_closure");

--- a/src/librustc/middle/trans/glue.rs
+++ b/src/librustc/middle/trans/glue.rs
@@ -528,8 +528,8 @@ fn declare_generic_glue(ccx: &CrateContext, t: ty::t, llfnty: Type,
 fn make_generic_glue(ccx: &CrateContext,
                      t: ty::t,
                      llfn: ValueRef,
-                     helper: <'blk, 'tcx> |Block<'blk, 'tcx>, ValueRef, ty::t|
-                                           -> Block<'blk, 'tcx>,
+                     helper: for<'blk, 'tcx> |Block<'blk, 'tcx>, ValueRef, ty::t|
+                                              -> Block<'blk, 'tcx>,
                      name: &str)
                      -> ValueRef {
     let _icx = push_ctxt("make_generic_glue");

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -89,7 +89,7 @@ pub trait TTMacroExpander {
 }
 
 pub type MacroExpanderFn =
-    fn<'cx>(&'cx mut ExtCtxt, Span, &[ast::TokenTree]) -> Box<MacResult+'cx>;
+    for<'cx> fn(&'cx mut ExtCtxt, Span, &[ast::TokenTree]) -> Box<MacResult+'cx>;
 
 impl TTMacroExpander for MacroExpanderFn {
     fn expand<'cx>(&self,
@@ -111,7 +111,7 @@ pub trait IdentMacroExpander {
 }
 
 pub type IdentMacroExpanderFn =
-    fn<'cx>(&'cx mut ExtCtxt, Span, ast::Ident, Vec<ast::TokenTree>) -> Box<MacResult+'cx>;
+    for<'cx> fn(&'cx mut ExtCtxt, Span, ast::Ident, Vec<ast::TokenTree>) -> Box<MacResult+'cx>;
 
 impl IdentMacroExpander for IdentMacroExpanderFn {
     fn expand<'cx>(&self,


### PR DESCRIPTION
r? @alexcrichton 
