### PR TITLE
std: Fix the return value of Duration::span

### DIFF
--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -35,7 +35,7 @@ pub fn time<T, U>(do_it: bool, what: &str, u: U, f: |U| -> T) -> T {
     let rv = rv.unwrap();
 
     println!("{}time: {}.{:03} \t{}", "  ".repeat(old),
-             dur.num_seconds(), dur.num_milliseconds(), what);
+             dur.num_seconds(), dur.num_milliseconds() % 1000, what);
     depth.replace(Some(old));
 
     rv

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -140,7 +140,7 @@ impl Duration {
     pub fn span(f: ||) -> Duration {
         let before = super::precise_time_ns();
         f();
-        Duration::nanoseconds((before - super::precise_time_ns()) as i64)
+        Duration::nanoseconds((super::precise_time_ns() - before) as i64)
     }
 
     /// Returns the total number of whole weeks in the duration.
@@ -564,5 +564,12 @@ mod tests {
         // the format specifier should have no effect on `Duration`
         assert_eq!(format!("{:30}", Duration::days(1) + Duration::milliseconds(2345)),
                    "P1DT2.345S".to_string());
+    }
+
+    #[test]
+    fn span() {
+        use io::timer::sleep;
+        let dur = Duration::span(|| sleep(Duration::milliseconds(5)));
+        assert!(dur > Duration::milliseconds(1));
     }
 }


### PR DESCRIPTION
The subtraction was erroneously backwards, returning negative durations!

Closes #18925
