### PR TITLE
etc: Don't bundle libctl3d32 on windows

### DIFF
--- a/src/etc/make-win-dist.py
+++ b/src/etc/make-win-dist.py
@@ -62,7 +62,6 @@ def make_win_dist(dist_root, target_triple):
                     "libcomctl32.a",
                     "libcomdlg32.a",
                     "libcrypt32.a",
-                    "libctl3d32.a",
                     "libgdi32.a",
                     "libimagehlp.a",
                     "libiphlpapi.a",


### PR DESCRIPTION
Apparently it's not found on win64!

Closes #18928
