### PR TITLE
impl Default for Cell and RefCell

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -157,6 +157,7 @@
 
 use clone::Clone;
 use cmp::PartialEq;
+use default::Default;
 use kinds::{marker, Copy};
 use ops::{Deref, DerefMut, Drop};
 use option::{None, Option, Some};
@@ -208,6 +209,13 @@ impl<T:Copy> Cell<T> {
 impl<T:Copy> Clone for Cell<T> {
     fn clone(&self) -> Cell<T> {
         Cell::new(self.get())
+    }
+}
+
+#[unstable]
+impl<T:Default + Copy> Default for Cell<T> {
+    fn default() -> Cell<T> {
+        Cell::new(Default::default())
     }
 }
 
@@ -334,6 +342,13 @@ impl<T> RefCell<T> {
 impl<T: Clone> Clone for RefCell<T> {
     fn clone(&self) -> RefCell<T> {
         RefCell::new(self.borrow().clone())
+    }
+}
+
+#[unstable]
+impl<T:Default> Default for RefCell<T> {
+    fn default() -> RefCell<T> {
+        RefCell::new(Default::default())
     }
 }
 

--- a/src/libcoretest/cell.rs
+++ b/src/libcoretest/cell.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use core::cell::*;
+use core::default::Default;
 use std::mem::drop;
 
 #[test]
@@ -145,4 +146,16 @@ fn as_unsafe_cell() {
     let r2: RefCell<uint> = RefCell::new(0u);
     unsafe { *r2.as_unsafe_cell().get() = 1u; }
     assert_eq!(1u, *r2.borrow());
+}
+
+#[test]
+fn cell_default() {
+    let cell: Cell<u32> = Default::default();
+    assert_eq!(0, cell.get());
+}
+
+#[test]
+fn refcell_default() {
+    let cell: RefCell<u64> = Default::default();
+    assert_eq!(0, *cell.borrow());
 }


### PR DESCRIPTION
It is necessary to have `#[deriving(Default)]` for struct containing
cells like `Cell<u32>`.
