### PR TITLE
librustc: Forbid partial reinitialization of uninitialized structures or enumerations that implement the Drop trait.

### DIFF
--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -597,6 +597,18 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
         }
     }
 
+    pub fn report_partial_reinitialization_of_uninitialized_structure(
+            &self,
+            span: Span,
+            lp: &LoanPath) {
+        self.tcx
+            .sess
+            .span_err(span,
+                      (format!("partial reinitialization of uninitialized \
+                               structure `{}`",
+                               self.loan_path_to_string(lp))).as_slice());
+    }
+
     pub fn report_reassigned_immutable_variable(&self,
                                                 span: Span,
                                                 lp: &LoanPath,

--- a/src/test/compile-fail/borrowck-partial-reinit-1.rs
+++ b/src/test/compile-fail/borrowck-partial-reinit-1.rs
@@ -1,0 +1,37 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Test;
+
+struct Test2 {
+    b: Option<Test>,
+}
+
+impl Drop for Test {
+    fn drop(&mut self) {
+        println!("dropping!");
+    }
+}
+
+impl Drop for Test2 {
+    fn drop(&mut self) {}
+}
+
+fn stuff() {
+    let mut t = Test2 { b: None };
+    let u = Test;
+    drop(t);
+    t.b = Some(u);
+    //~^ ERROR partial reinitialization of uninitialized structure
+}
+
+fn main() {
+    stuff()
+}

--- a/src/test/compile-fail/borrowck-partial-reinit-2.rs
+++ b/src/test/compile-fail/borrowck-partial-reinit-2.rs
@@ -1,0 +1,34 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Test {
+    a: int,
+    b: Option<Box<Test>>,
+}
+
+impl Drop for Test {
+    fn drop(&mut self) {
+        println!("Dropping {}", self.a);
+    }
+}
+
+fn stuff() {
+    let mut t = Test { a: 1, b: None};
+    let mut u = Test { a: 2, b: Some(box t)};    
+    t.b = Some(box u);
+    //~^ ERROR partial reinitialization of uninitialized structure
+    println!("done");
+}
+
+fn main() {
+    stuff();
+    println!("Hello, world!")
+}
+


### PR DESCRIPTION
This breaks code like:

```
struct Struct {
    f: String,
    g: String,
}

impl Drop for Struct { ... }

fn main() {
    let x = Struct { ... };
    drop(x);
    x.f = ...;
}
```

Change this code to not create partially-initialized structures. For
example:

```
struct Struct {
    f: String,
    g: String,
}

impl Drop for Struct { ... }

fn main() {
    let x = Struct { ... };
    drop(x);
    x = Struct {
        f: ...,
        g: ...,
    }
}
```

Closes #18571.

[breaking-change]

I suspect I may have missed some cases that I should have checked.

r? @nikomatsakis
