### PR TITLE
Hide interactive elements when printing rustdoc

### DIFF
--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -584,3 +584,9 @@ pre.rust { position: relative; }
         height: 1.5em;
     }
 }
+
+@media print {
+    nav.sub, .content .out-of-band, .collapse-toggle {
+        display: none;
+    }
+}


### PR DESCRIPTION
Hide the search form and expand/collapse buttons, since they aren't useful when printed.

Preview at http://misc.coreyford.name/rust/doc/std/index.html
