### PR TITLE
Guide: add a pointer to play.rust-lang.org

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -159,6 +159,8 @@ $ ./main # or main.exe on Windows
 Hello, world!
 ```
 
+You can also run these examples on [play.rust-lang.org](http://play.rust-lang.org/) by clicking on the arrow that appears in the upper right of the example when you mouse over the code.
+
 Success! Let's go over what just happened in detail.
 
 ```{rust}


### PR DESCRIPTION
As-is, there's no indication that the code examples pop out into a window that runs on `play.rust-lang.org` until you mouse over them. I managed to get to section 4 of the guide before realizing you could do this since it didn't occur to me to mouse over the example text.

cc @rose since we went through the tutorial together and I think it wasn't obvious to her either.
