### PR TITLE
Un-feature gate struct variants

### DIFF
--- a/src/etc/generate-deriving-span-tests.py
+++ b/src/etc/generate-deriving-span-tests.py
@@ -37,7 +37,6 @@ TEMPLATE = """// Copyright {year} The Rust Project Developers. See the COPYRIGHT
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 {error_deriving}

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -665,6 +665,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for Context<'a, 'tcx> {
         self.with_lint_attrs(v.node.attrs.as_slice(), |cx| {
             run_lints!(cx, check_variant, v, g);
             visit::walk_variant(cx, v, g);
+            run_lints!(cx, check_variant_post, v, g);
         })
     }
 

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -149,6 +149,7 @@ pub trait LintPass {
         _: &ast::StructDef, _: ast::Ident, _: &ast::Generics, _: ast::NodeId) { }
     fn check_struct_field(&mut self, _: &Context, _: &ast::StructField) { }
     fn check_variant(&mut self, _: &Context, _: &ast::Variant, _: &ast::Generics) { }
+    fn check_variant_post(&mut self, _: &Context, _: &ast::Variant, _: &ast::Generics) { }
     fn check_opt_lifetime_ref(&mut self, _: &Context, _: Span, _: &Option<ast::Lifetime>) { }
     fn check_lifetime_ref(&mut self, _: &Context, _: &ast::Lifetime) { }
     fn check_lifetime_decl(&mut self, _: &Context, _: &ast::LifetimeDef) { }

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -102,10 +102,10 @@ pub enum LastPrivate {
     // and whether the import is in fact used for each.
     // If the Option<PrivateDep> fields are None, it means there is no definition
     // in that namespace.
-    LastImport{pub value_priv: Option<PrivateDep>,
-               pub value_used: ImportUse,
-               pub type_priv: Option<PrivateDep>,
-               pub type_used: ImportUse},
+    LastImport{value_priv: Option<PrivateDep>,
+               value_used: ImportUse,
+               type_priv: Option<PrivateDep>,
+               type_used: ImportUse},
 }
 
 #[deriving(Show)]

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -101,9 +101,9 @@ pub enum Repr {
      * otherwise it indicates the other case.
      */
     RawNullablePointer {
-        pub nndiscr: Disr,
-        pub nnty: ty::t,
-        pub nullfields: Vec<ty::t>
+        nndiscr: Disr,
+        nnty: ty::t,
+        nullfields: Vec<ty::t>
     },
     /**
      * Two cases distinguished by a nullable pointer: the case with discriminant
@@ -117,10 +117,10 @@ pub enum Repr {
      * identity function.
      */
     StructWrappedNullablePointer {
-        pub nonnull: Struct,
-        pub nndiscr: Disr,
-        pub ptrfield: PointerField,
-        pub nullfields: Vec<ty::t>,
+        nonnull: Struct,
+        nndiscr: Disr,
+        ptrfield: PointerField,
+        nullfields: Vec<ty::t>,
     }
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1085,9 +1085,9 @@ impl Clean<Item> for ty::ImplOrTraitItem {
 pub enum Type {
     /// structs/enums/traits (anything that'd be an ast::TyPath)
     ResolvedPath {
-        pub path: Path,
-        pub typarams: Option<Vec<TyParamBound>>,
-        pub did: ast::DefId,
+        path: Path,
+        typarams: Option<Vec<TyParamBound>>,
+        did: ast::DefId,
     },
     // I have no idea how to usefully use this.
     TyParamBinder(ast::NodeId),
@@ -1110,9 +1110,9 @@ pub enum Type {
     Unique(Box<Type>),
     RawPointer(Mutability, Box<Type>),
     BorrowedRef {
-        pub lifetime: Option<Lifetime>,
-        pub mutability: Mutability,
-        pub type_: Box<Type>,
+        lifetime: Option<Lifetime>,
+        mutability: Mutability,
+        type_: Box<Type>,
     },
     // region, raw, other boxes, mutable
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1292,8 +1292,8 @@ pub type Variant = Spanned<Variant_>;
 
 #[deriving(Clone, PartialEq, Eq, Encodable, Decodable, Hash, Show)]
 pub enum PathListItem_ {
-    PathListIdent { pub name: Ident, pub id: NodeId },
-    PathListMod { pub id: NodeId }
+    PathListIdent { name: Ident, id: NodeId },
+    PathListMod { id: NodeId }
 }
 
 impl PathListItem_ {

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -37,7 +37,7 @@ use std::slice;
 static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[
     ("globs", Active),
     ("macro_rules", Active),
-    ("struct_variant", Active),
+    ("struct_variant", Accepted),
     ("asm", Active),
     ("managed_boxes", Removed),
     ("non_ascii_idents", Active),
@@ -184,19 +184,6 @@ impl<'a, 'v> Visitor<'v> for Context<'a> {
             }
         }
         match i.node {
-            ast::ItemEnum(ref def, _) => {
-                for variant in def.variants.iter() {
-                    match variant.node.kind {
-                        ast::StructVariantKind(..) => {
-                            self.gate_feature("struct_variant", variant.span,
-                                              "enum struct variants are \
-                                               experimental and possibly buggy");
-                        }
-                        _ => {}
-                    }
-                }
-            }
-
             ast::ItemForeignMod(ref foreign_module) => {
                 if attr::contains_name(i.attrs.as_slice(), "link_args") {
                     self.gate_feature("link_args", i.span,

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4648,7 +4648,7 @@ impl<'a> Parser<'a> {
             is_tuple_like = false;
             fields = Vec::new();
             while self.token != token::CloseDelim(token::Brace) {
-                fields.push(self.parse_struct_decl_field());
+                fields.push(self.parse_struct_decl_field(true));
             }
             if fields.len() == 0 {
                 self.fatal(format!("unit-like struct definition should be \
@@ -4725,12 +4725,16 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse an element of a struct definition
-    fn parse_struct_decl_field(&mut self) -> StructField {
+    fn parse_struct_decl_field(&mut self, allow_pub: bool) -> StructField {
 
         let attrs = self.parse_outer_attributes();
 
         if self.eat_keyword(keywords::Pub) {
-           return self.parse_single_struct_field(Public, attrs);
+            if !allow_pub {
+                let span = self.last_span;
+                self.span_err(span, "`pub` is not allowed here");
+            }
+            return self.parse_single_struct_field(Public, attrs);
         }
 
         return self.parse_single_struct_field(Inherited, attrs);
@@ -5178,7 +5182,7 @@ impl<'a> Parser<'a> {
     fn parse_struct_def(&mut self) -> P<StructDef> {
         let mut fields: Vec<StructField> = Vec::new();
         while self.token != token::CloseDelim(token::Brace) {
-            fields.push(self.parse_struct_decl_field());
+            fields.push(self.parse_struct_decl_field(false));
         }
         self.bump();
 

--- a/src/test/compile-fail/deriving-primitive.rs
+++ b/src/test/compile-fail/deriving-primitive.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 use std::num::FromPrimitive;
 use std::int;
 

--- a/src/test/compile-fail/deriving-span-Clone-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-Clone-enum-struct-variant.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Clone-enum.rs
+++ b/src/test/compile-fail/deriving-span-Clone-enum.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Clone-struct.rs
+++ b/src/test/compile-fail/deriving-span-Clone-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Clone-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Clone-tuple-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Default-struct.rs
+++ b/src/test/compile-fail/deriving-span-Default-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Default-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Default-tuple-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Hash-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-Hash-enum-struct-variant.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Hash-enum.rs
+++ b/src/test/compile-fail/deriving-span-Hash-enum.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Hash-struct.rs
+++ b/src/test/compile-fail/deriving-span-Hash-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Hash-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Hash-tuple-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-PartialEq-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-PartialEq-enum-struct-variant.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-PartialEq-enum.rs
+++ b/src/test/compile-fail/deriving-span-PartialEq-enum.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-PartialEq-struct.rs
+++ b/src/test/compile-fail/deriving-span-PartialEq-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-PartialEq-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-PartialEq-tuple-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-PartialOrd-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-PartialOrd-enum-struct-variant.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-PartialOrd-enum.rs
+++ b/src/test/compile-fail/deriving-span-PartialOrd-enum.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-PartialOrd-struct.rs
+++ b/src/test/compile-fail/deriving-span-PartialOrd-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-PartialOrd-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-PartialOrd-tuple-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-Rand-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-Rand-enum-struct-variant.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Rand-enum.rs
+++ b/src/test/compile-fail/deriving-span-Rand-enum.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Rand-struct.rs
+++ b/src/test/compile-fail/deriving-span-Rand-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Rand-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Rand-tuple-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Show-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-Show-enum-struct-variant.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Show-enum.rs
+++ b/src/test/compile-fail/deriving-span-Show-enum.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Show-struct.rs
+++ b/src/test/compile-fail/deriving-span-Show-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Show-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Show-tuple-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-TotalEq-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-TotalEq-enum-struct-variant.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-TotalEq-enum.rs
+++ b/src/test/compile-fail/deriving-span-TotalEq-enum.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-TotalEq-struct.rs
+++ b/src/test/compile-fail/deriving-span-TotalEq-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-TotalEq-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-TotalEq-tuple-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(PartialEq)]

--- a/src/test/compile-fail/deriving-span-TotalOrd-enum-struct-variant.rs
+++ b/src/test/compile-fail/deriving-span-TotalOrd-enum-struct-variant.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(Eq,PartialOrd,PartialEq)]

--- a/src/test/compile-fail/deriving-span-TotalOrd-enum.rs
+++ b/src/test/compile-fail/deriving-span-TotalOrd-enum.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(Eq,PartialOrd,PartialEq)]

--- a/src/test/compile-fail/deriving-span-TotalOrd-struct.rs
+++ b/src/test/compile-fail/deriving-span-TotalOrd-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(Eq,PartialOrd,PartialEq)]

--- a/src/test/compile-fail/deriving-span-TotalOrd-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-TotalOrd-tuple-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 #[deriving(Eq,PartialOrd,PartialEq)]

--- a/src/test/compile-fail/deriving-span-Zero-struct.rs
+++ b/src/test/compile-fail/deriving-span-Zero-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/deriving-span-Zero-tuple-struct.rs
+++ b/src/test/compile-fail/deriving-span-Zero-tuple-struct.rs
@@ -10,7 +10,6 @@
 
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
-#![feature(struct_variant)]
 extern crate rand;
 
 

--- a/src/test/compile-fail/dup-struct-enum-struct-variant.rs
+++ b/src/test/compile-fail/dup-struct-enum-struct-variant.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 enum Foo { C { a: int, b: int } }
 struct C { a: int, b: int }         //~ ERROR error: duplicate definition of type or module `C`
 

--- a/src/test/compile-fail/gated-non-ascii-idents.rs
+++ b/src/test/compile-fail/gated-non-ascii-idents.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-#![feature(struct_variant)]
-
 extern crate bäz; //~ ERROR non-ascii idents
 
 use föö::bar; //~ ERROR non-ascii idents

--- a/src/test/compile-fail/issue-13624.rs
+++ b/src/test/compile-fail/issue-13624.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 mod a {
   pub enum Enum {
     EnumStructVariant { x: u8, y: u8, z: u8 }

--- a/src/test/compile-fail/issue-18252.rs
+++ b/src/test/compile-fail/issue-18252.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 enum Foo {
     Variant { x: uint }
 }

--- a/src/test/compile-fail/lint-dead-code-4.rs
+++ b/src/test/compile-fail/lint-dead-code-4.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
 #![allow(unused_variables)]
 #![allow(non_camel_case_types)]
 #![deny(dead_code)]

--- a/src/test/compile-fail/lint-dead-code-5.rs
+++ b/src/test/compile-fail/lint-dead-code-5.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
 #![allow(unused_variables)]
 #![deny(dead_code)]
 

--- a/src/test/compile-fail/lint-missing-doc.rs
+++ b/src/test/compile-fail/lint-missing-doc.rs
@@ -10,7 +10,6 @@
 
 // When denying at the crate level, be sure to not get random warnings from the
 // injected intrinsics by the compiler.
-#![feature(struct_variant)]
 #![feature(globs)]
 #![deny(missing_docs)]
 #![allow(dead_code)]
@@ -106,8 +105,7 @@ enum Baz {
 
 pub enum PubBaz { //~ ERROR: missing documentation
     PubBazA { //~ ERROR: missing documentation
-        pub a: int, //~ ERROR: missing documentation
-        b: int
+        a: int, //~ ERROR: missing documentation
     },
 }
 
@@ -116,15 +114,13 @@ pub enum PubBaz2 {
     /// dox
     PubBaz2A {
         /// dox
-        pub a: int,
-        b: int
+        a: int,
     },
 }
 
 #[allow(missing_docs)]
 pub enum PubBaz3 {
     PubBaz3A {
-        pub a: int,
         b: int
     },
 }

--- a/src/test/compile-fail/lint-raw-ptr-deriving.rs
+++ b/src/test/compile-fail/lint-raw-ptr-deriving.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
 #![allow(dead_code)]
 #![deny(raw_pointer_deriving)]
 

--- a/src/test/compile-fail/lint-visible-private-types.rs
+++ b/src/test/compile-fail/lint-visible-private-types.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
 #![deny(visible_private_types)]
 #![allow(dead_code)]
 #![crate_type="lib"]
@@ -57,8 +56,7 @@ struct Bar {
 pub enum Baz {
     Baz1(Private<int>), //~ ERROR private type in exported type signature
     Baz2 {
-        pub x: Private<int>, //~ ERROR private type in exported type signature
-        y: Private<int>
+        y: Private<int> //~ ERROR private type in exported type signature
     },
 }
 

--- a/src/test/compile-fail/namespaced-enum-glob-import-no-impls-xcrate.rs
+++ b/src/test/compile-fail/namespaced-enum-glob-import-no-impls-xcrate.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:namespaced_enums.rs
-#![feature(struct_variant, globs)]
+#![feature(globs)]
 
 extern crate namespaced_enums;
 

--- a/src/test/compile-fail/namespaced-enum-glob-import-no-impls.rs
+++ b/src/test/compile-fail/namespaced-enum-glob-import-no-impls.rs
@@ -7,7 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(struct_variant, globs)]
+#![feature(globs)]
 
 mod m2 {
     pub enum Foo {

--- a/src/test/compile-fail/non-exhaustive-pattern-witness.rs
+++ b/src/test/compile-fail/non-exhaustive-pattern-witness.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(advanced_slice_patterns, struct_variant)]
+#![feature(advanced_slice_patterns)]
 
 struct Foo {
     first: bool,

--- a/src/test/compile-fail/struct-like-enum-nonexhaustive.rs
+++ b/src/test/compile-fail/struct-like-enum-nonexhaustive.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(struct_variant)]
-
 enum A {
     B { x: Option<int> },
     C

--- a/src/test/compile-fail/struct-variant-no-pub.rs
+++ b/src/test/compile-fail/struct-variant-no-pub.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum A { B { foo: int } }
-//~^ ERROR: enum struct variants are experimental
+enum Foo {
+    Bar {
+        pub a: int //~ ERROR: `pub` is not allowed here
+    }
+}
 
 fn main() {}
-

--- a/src/test/compile-fail/struct-variant-privacy-xc.rs
+++ b/src/test/compile-fail/struct-variant-privacy-xc.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 // aux-build:struct_variant_privacy.rs
-#![feature(struct_variant)]
-
 extern crate struct_variant_privacy;
 
 fn f(b: struct_variant_privacy::Bar) { //~ ERROR enum `Bar` is private

--- a/src/test/compile-fail/struct-variant-privacy.rs
+++ b/src/test/compile-fail/struct-variant-privacy.rs
@@ -7,8 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(struct_variant)]
-
 mod foo {
     enum Bar {
         Baz { a: int }

--- a/src/test/compile-fail/unsized5.rs
+++ b/src/test/compile-fail/unsized5.rs
@@ -7,7 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(struct_variant)]
 
 // Test `Sized?` types not allowed in fields (except the last one).
 


### PR DESCRIPTION
Struct variant field visibility is now inherited. Remove `pub` keywords
from declarations.

Closes #18641

[breaking-change]

r? @alexcrichton 
