### PR TITLE
doc: make end comment consistent with start comment

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -133,7 +133,7 @@ Some productions are defined by exclusion of particular Unicode characters:
 
 ```{.ebnf .gram}
 comment : block_comment | line_comment ;
-block_comment : "/*" block_comment_body * '*' + '/' ;
+block_comment : "/*" block_comment_body * "*/" ;
 block_comment_body : [block_comment | character] * ;
 line_comment : "//" non_eol * ;
 ```


### PR DESCRIPTION
Start comment is a string literal while end comment is made up of two character literals. This change is to make them consistent.
