### PR TITLE
libs: stabilize most numerics after RFC changes

### DIFF
--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -429,12 +429,12 @@ impl Float for f32 {
 
     /// Converts to degrees, assuming the number is in radians.
     #[inline]
-    fn to_degrees(self) -> f32 { self * (180.0f32 / Float::pi()) }
+    fn to_degrees(self) -> f32 { self * (180.0f32 / consts::PI) }
 
     /// Converts to radians, assuming the number is in degrees.
     #[inline]
     fn to_radians(self) -> f32 {
-        let value: f32 = Float::pi();
+        let value: f32 = consts::PI;
         self * (value / 180.0f32)
     }
 }

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -14,43 +14,56 @@
 // FIXME: MIN_VALUE and MAX_VALUE literals are parsed as -inf and inf #14353
 #![allow(overflowing_literals)]
 
+#![stable]
+
 use intrinsics;
 use mem;
 use num::{Float, FPNormal, FPCategory, FPZero, FPSubnormal, FPInfinite, FPNaN};
 use num::from_str_radix;
 use option::Option;
 
+#[stable]
 pub const RADIX: uint = 2u;
 
+#[stable]
 pub const MANTISSA_DIGITS: uint = 24u;
+#[stable]
 pub const DIGITS: uint = 6u;
 
+#[stable]
 pub const EPSILON: f32 = 1.19209290e-07_f32;
 
 /// Smallest finite f32 value
+#[stable]
 pub const MIN_VALUE: f32 = -3.40282347e+38_f32;
 /// Smallest positive, normalized f32 value
+#[stable]
 pub const MIN_POS_VALUE: f32 = 1.17549435e-38_f32;
 /// Largest finite f32 value
+#[stable]
 pub const MAX_VALUE: f32 = 3.40282347e+38_f32;
 
+#[stable]
 pub const MIN_EXP: int = -125;
+#[stable]
 pub const MAX_EXP: int = 128;
 
+#[stable]
 pub const MIN_10_EXP: int = -37;
+#[stable]
 pub const MAX_10_EXP: int = 38;
 
+#[stable]
 pub const NAN: f32 = 0.0_f32/0.0_f32;
+#[stable]
 pub const INFINITY: f32 = 1.0_f32/0.0_f32;
+#[stable]
 pub const NEG_INFINITY: f32 = -1.0_f32/0.0_f32;
 
 /// Various useful constants.
+#[unstable = "naming scheme needs to be revisited"]
 pub mod consts {
     // FIXME: replace with mathematical constants from cmath.
-
-    // FIXME(#5527): These constants should be deprecated once associated
-    // constants are implemented in favour of referencing the respective members
-    // of `Float`.
 
     /// Archimedes' constant
     pub const PI: f32 = 3.14159265358979323846264338327950288_f32;
@@ -104,6 +117,7 @@ pub mod consts {
     pub const LN_10: f32 = 2.30258509299404568401799145468436421_f32;
 }
 
+#[unstable = "trait is unstable"]
 impl Float for f32 {
     #[inline]
     fn nan() -> f32 { NAN }

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -437,12 +437,12 @@ impl Float for f64 {
 
     /// Converts to degrees, assuming the number is in radians.
     #[inline]
-    fn to_degrees(self) -> f64 { self * (180.0f64 / Float::pi()) }
+    fn to_degrees(self) -> f64 { self * (180.0f64 / consts::PI) }
 
     /// Converts to radians, assuming the number is in degrees.
     #[inline]
     fn to_radians(self) -> f64 {
-        let value: f64 = Float::pi();
+        let value: f64 = consts::PI;
         self * (value / 180.0)
     }
 }

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -14,6 +14,8 @@
 // FIXME: MIN_VALUE and MAX_VALUE literals are parsed as -inf and inf #14353
 #![allow(overflowing_literals)]
 
+#![stable]
+
 use intrinsics;
 use mem;
 use num::{Float, FPNormal, FPCategory, FPZero, FPSubnormal, FPInfinite, FPNaN};
@@ -24,33 +26,46 @@ use option::Option;
 // constants are implemented in favour of referencing the respective
 // members of `Bounded` and `Float`.
 
+#[stable]
 pub const RADIX: uint = 2u;
 
+#[stable]
 pub const MANTISSA_DIGITS: uint = 53u;
+#[stable]
 pub const DIGITS: uint = 15u;
 
+#[stable]
 pub const EPSILON: f64 = 2.2204460492503131e-16_f64;
 
 /// Smallest finite f64 value
+#[stable]
 pub const MIN_VALUE: f64 = -1.7976931348623157e+308_f64;
 /// Smallest positive, normalized f64 value
+#[stable]
 pub const MIN_POS_VALUE: f64 = 2.2250738585072014e-308_f64;
 /// Largest finite f64 value
+#[stable]
 pub const MAX_VALUE: f64 = 1.7976931348623157e+308_f64;
 
+#[stable]
 pub const MIN_EXP: int = -1021;
+#[stable]
 pub const MAX_EXP: int = 1024;
 
+#[stable]
 pub const MIN_10_EXP: int = -307;
+#[stable]
 pub const MAX_10_EXP: int = 308;
 
+#[stable]
 pub const NAN: f64 = 0.0_f64/0.0_f64;
-
+#[stable]
 pub const INFINITY: f64 = 1.0_f64/0.0_f64;
-
+#[stable]
 pub const NEG_INFINITY: f64 = -1.0_f64/0.0_f64;
 
 /// Various useful constants.
+#[unstable = "naming scheme needs to be revisited"]
 pub mod consts {
     // FIXME: replace with mathematical constants from cmath.
 
@@ -110,6 +125,7 @@ pub mod consts {
     pub const LN_10: f64 = 2.30258509299404568401799145468436421_f64;
 }
 
+#[unstable = "trait is unstable"]
 impl Float for f64 {
     #[inline]
     fn nan() -> f64 { NAN }

--- a/src/libcore/num/i16.rs
+++ b/src/libcore/num/i16.rs
@@ -10,8 +10,7 @@
 
 //! Operations and constants for signed 16-bits integers (`i16` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "i16")]
 
 int_module!(i16, 16)
-

--- a/src/libcore/num/i32.rs
+++ b/src/libcore/num/i32.rs
@@ -10,8 +10,7 @@
 
 //! Operations and constants for signed 32-bits integers (`i32` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "i32")]
 
 int_module!(i32, 32)
-

--- a/src/libcore/num/i64.rs
+++ b/src/libcore/num/i64.rs
@@ -10,8 +10,7 @@
 
 //! Operations and constants for signed 64-bits integers (`i64` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "i64")]
 
 int_module!(i64, 64)
-

--- a/src/libcore/num/i8.rs
+++ b/src/libcore/num/i8.rs
@@ -10,8 +10,7 @@
 
 //! Operations and constants for signed 8-bits integers (`i8` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "i8")]
 
 int_module!(i8, 8)
-

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -12,6 +12,7 @@
 
 //! Numeric traits and functions for the built-in numeric types.
 
+#![stable]
 #![allow(missing_docs)]
 
 pub use self::FPCategory::*;
@@ -34,6 +35,7 @@ use str::{FromStr, from_str, StrPrelude};
 
 /// Simultaneous division and remainder
 #[inline]
+#[deprecated = "use division and remainder directly"]
 pub fn div_rem<T: Div<T, T> + Rem<T, T>>(x: T, y: T) -> (T, T) {
     (x / y, x % y)
 }
@@ -46,6 +48,7 @@ pub fn pow<T: Int>(base: T, exp: uint) -> T {
 }
 
 /// A built-in signed or unsigned integer.
+#[unstable = "recently settled as part of numerics reform"]
 pub trait Int
     : Copy + Clone
     + NumCast
@@ -384,6 +387,7 @@ macro_rules! uint_impl {
      $add_with_overflow:path,
      $sub_with_overflow:path,
      $mul_with_overflow:path) => {
+        #[unstable = "trait is unstable"]
         impl Int for $T {
             #[inline]
             fn zero() -> $T { 0 }
@@ -514,6 +518,7 @@ macro_rules! int_impl {
      $add_with_overflow:path,
      $sub_with_overflow:path,
      $mul_with_overflow:path) => {
+        #[unstable = "trait is unstable"]
         impl Int for $T {
             #[inline]
             fn zero() -> $T { 0 }
@@ -606,6 +611,7 @@ int_impl!(int = i64, u64, 64,
     intrinsics::i64_mul_with_overflow)
 
 /// A built-in two's complement integer.
+#[unstable = "recently settled as part of numerics reform"]
 pub trait SignedInt
     : Int
     + Neg<Self>
@@ -663,6 +669,7 @@ signed_int_impl!(i64)
 signed_int_impl!(int)
 
 /// A built-in unsigned integer.
+#[unstable = "recently settled as part of numerics reform"]
 pub trait UnsignedInt: Int {
     /// Returns `true` iff `self == 2^k` for some `k`.
     fn is_power_of_two(self) -> bool {
@@ -697,13 +704,23 @@ pub trait UnsignedInt: Int {
     }
 }
 
+#[unstable = "trait is unstable"]
 impl UnsignedInt for uint {}
+
+#[unstable = "trait is unstable"]
 impl UnsignedInt for u8 {}
+
+#[unstable = "trait is unstable"]
 impl UnsignedInt for u16 {}
+
+#[unstable = "trait is unstable"]
 impl UnsignedInt for u32 {}
+
+#[unstable = "trait is unstable"]
 impl UnsignedInt for u64 {}
 
 /// A generic trait for converting a value to a number.
+#[experimental = "trait is likely to be removed"]
 pub trait ToPrimitive {
     /// Converts the value of `self` to an `int`.
     #[inline]
@@ -968,6 +985,7 @@ impl_to_primitive_float!(f32)
 impl_to_primitive_float!(f64)
 
 /// A generic trait for converting a number to a value.
+#[experimental = "trait is likely to be removed"]
 pub trait FromPrimitive {
     /// Convert an `int` to return an optional value of this type. If the
     /// value cannot be represented by this value, the `None` is returned.
@@ -1049,61 +1067,73 @@ pub trait FromPrimitive {
 }
 
 /// A utility function that just calls `FromPrimitive::from_int`.
+#[experimental = "likely to be removed"]
 pub fn from_int<A: FromPrimitive>(n: int) -> Option<A> {
     FromPrimitive::from_int(n)
 }
 
 /// A utility function that just calls `FromPrimitive::from_i8`.
+#[experimental = "likely to be removed"]
 pub fn from_i8<A: FromPrimitive>(n: i8) -> Option<A> {
     FromPrimitive::from_i8(n)
 }
 
 /// A utility function that just calls `FromPrimitive::from_i16`.
+#[experimental = "likely to be removed"]
 pub fn from_i16<A: FromPrimitive>(n: i16) -> Option<A> {
     FromPrimitive::from_i16(n)
 }
 
 /// A utility function that just calls `FromPrimitive::from_i32`.
+#[experimental = "likely to be removed"]
 pub fn from_i32<A: FromPrimitive>(n: i32) -> Option<A> {
     FromPrimitive::from_i32(n)
 }
 
 /// A utility function that just calls `FromPrimitive::from_i64`.
+#[experimental = "likely to be removed"]
 pub fn from_i64<A: FromPrimitive>(n: i64) -> Option<A> {
     FromPrimitive::from_i64(n)
 }
 
 /// A utility function that just calls `FromPrimitive::from_uint`.
+#[experimental = "likely to be removed"]
 pub fn from_uint<A: FromPrimitive>(n: uint) -> Option<A> {
     FromPrimitive::from_uint(n)
 }
 
 /// A utility function that just calls `FromPrimitive::from_u8`.
+#[experimental = "likely to be removed"]
 pub fn from_u8<A: FromPrimitive>(n: u8) -> Option<A> {
     FromPrimitive::from_u8(n)
 }
 
 /// A utility function that just calls `FromPrimitive::from_u16`.
+#[experimental = "likely to be removed"]
 pub fn from_u16<A: FromPrimitive>(n: u16) -> Option<A> {
     FromPrimitive::from_u16(n)
 }
 
 /// A utility function that just calls `FromPrimitive::from_u32`.
+#[experimental = "likely to be removed"]
 pub fn from_u32<A: FromPrimitive>(n: u32) -> Option<A> {
     FromPrimitive::from_u32(n)
 }
 
 /// A utility function that just calls `FromPrimitive::from_u64`.
+#[experimental = "likely to be removed"]
 pub fn from_u64<A: FromPrimitive>(n: u64) -> Option<A> {
     FromPrimitive::from_u64(n)
 }
 
 /// A utility function that just calls `FromPrimitive::from_f32`.
+#[experimental = "likely to be removed"]
 pub fn from_f32<A: FromPrimitive>(n: f32) -> Option<A> {
     FromPrimitive::from_f32(n)
 }
 
 /// A utility function that just calls `FromPrimitive::from_f64`.
+#[experimental = "likely to be removed"]
 pub fn from_f64<A: FromPrimitive>(n: f64) -> Option<A> {
     FromPrimitive::from_f64(n)
 }
@@ -1154,11 +1184,13 @@ impl_from_primitive!(f64, to_f64)
 /// ```
 ///
 #[inline]
+#[experimental = "likely to be removed"]
 pub fn cast<T: NumCast,U: NumCast>(n: T) -> Option<U> {
     NumCast::from(n)
 }
 
 /// An interface for casting between machine scalars.
+#[experimental = "trait is likely to be removed"]
 pub trait NumCast: ToPrimitive {
     /// Creates a number from another value that can be converted into a primitive via the
     /// `ToPrimitive` trait.
@@ -1193,6 +1225,7 @@ impl_num_cast!(f64,   to_f64)
 
 /// Used for representing the classification of floating point numbers
 #[deriving(PartialEq, Show)]
+#[unstable = "may be renamed"]
 pub enum FPCategory {
     /// "Not a Number", often obtained by dividing by zero
     FPNaN,
@@ -1212,6 +1245,7 @@ pub enum FPCategory {
 //
 // FIXME(#8888): Several of these functions have a parameter named
 //               `unused_self`. Removing it requires #8888 to be fixed.
+#[unstable = "recently settled as part of numerics reform"]
 pub trait Float
     : Copy + Clone
     + NumCast
@@ -1329,38 +1363,51 @@ pub trait Float
     /// Take the reciprocal (inverse) square root of a number, `1/sqrt(x)`.
     fn rsqrt(self) -> Self;
 
-    // FIXME (#5527): These should be associated constants
-
     /// Archimedes' constant.
+    #[deprecated = "use f32::consts or f64::consts instead"]
     fn pi() -> Self;
     /// 2.0 * pi.
+    #[deprecated = "use f32::consts or f64::consts instead"]
     fn two_pi() -> Self;
     /// pi / 2.0.
+    #[deprecated = "use f32::consts or f64::consts instead"]
     fn frac_pi_2() -> Self;
     /// pi / 3.0.
+    #[deprecated = "use f32::consts or f64::consts instead"]
     fn frac_pi_3() -> Self;
     /// pi / 4.0.
+    #[deprecated = "use f32::consts or f64::consts instead"]
     fn frac_pi_4() -> Self;
     /// pi / 6.0.
+    #[deprecated = "use f32::consts or f64::consts instead"]
     fn frac_pi_6() -> Self;
     /// pi / 8.0.
+    #[deprecated = "use f32::consts or f64::consts instead"]
     fn frac_pi_8() -> Self;
     /// 1.0 / pi.
+    #[deprecated = "use f32::consts or f64::consts instead"]
     fn frac_1_pi() -> Self;
     /// 2.0 / pi.
+    #[deprecated = "use f32::consts or f64::consts instead"]
     fn frac_2_pi() -> Self;
     /// 2.0 / sqrt(pi).
+    #[deprecated = "use f32::consts or f64::consts instead"]
     fn frac_2_sqrtpi() -> Self;
 
     /// Euler's number.
+    #[deprecated = "use f32::consts or f64::consts instead"]
     fn e() -> Self;
     /// log2(e).
+    #[deprecated = "use f32::consts or f64::consts instead"]
     fn log2_e() -> Self;
     /// log10(e).
+    #[deprecated = "use f32::consts or f64::consts instead"]
     fn log10_e() -> Self;
     /// ln(2.0).
+    #[deprecated = "use f32::consts or f64::consts instead"]
     fn ln_2() -> Self;
     /// ln(10.0).
+    #[deprecated = "use f32::consts or f64::consts instead"]
     fn ln_10() -> Self;
 
     /// Returns `e^(self)`, (the exponential function).

--- a/src/libcore/num/u16.rs
+++ b/src/libcore/num/u16.rs
@@ -10,7 +10,7 @@
 
 //! Operations and constants for unsigned 16-bits integers (`u16` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "u16")]
 
 uint_module!(u16, i16, 16)

--- a/src/libcore/num/u32.rs
+++ b/src/libcore/num/u32.rs
@@ -10,8 +10,7 @@
 
 //! Operations and constants for unsigned 32-bits integers (`u32` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "u32")]
 
 uint_module!(u32, i32, 32)
-

--- a/src/libcore/num/u64.rs
+++ b/src/libcore/num/u64.rs
@@ -10,8 +10,7 @@
 
 //! Operations and constants for unsigned 64-bits integer (`u64` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "u64")]
 
 uint_module!(u64, i64, 64)
-

--- a/src/libcore/num/u8.rs
+++ b/src/libcore/num/u8.rs
@@ -10,8 +10,7 @@
 
 //! Operations and constants for unsigned 8-bits integers (`u8` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "u8")]
 
 uint_module!(u8, i8, 8)
-

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -42,7 +42,7 @@ use cmp::{PartialEq, PartialOrd, Eq, Ord, Ordering, Less, Equal, Greater, Equiv}
 use cmp;
 use default::Default;
 use iter::*;
-use num::{Int, div_rem};
+use num::Int;
 use ops;
 use option::{None, Option, Some};
 use ptr;
@@ -1384,7 +1384,8 @@ impl<'a, T> Iterator<&'a [T]> for Chunks<'a, T> {
         if self.v.len() == 0 {
             (0, Some(0))
         } else {
-            let (n, rem) = div_rem(self.v.len(), self.size);
+            let n = self.v.len() / self.size;
+            let rem = self.v.len() % self.size;
             let n = if rem > 0 { n+1 } else { n };
             (n, Some(n))
         }
@@ -1457,7 +1458,8 @@ impl<'a, T> Iterator<&'a mut [T]> for MutChunks<'a, T> {
         if self.v.len() == 0 {
             (0, Some(0))
         } else {
-            let (n, rem) = div_rem(self.v.len(), self.chunk_size);
+            let n = self.v.len() / self.chunk_size;
+            let rem = self.v.len() % self.chunk_size;
             let n = if rem > 0 { n + 1 } else { n };
             (n, Some(n))
         }

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -10,7 +10,7 @@
 
 //! Operations and constants for 32-bits floats (`f32` type)
 
-#![experimental]
+#![stable]
 #![allow(missing_docs)]
 #![allow(unsigned_negation)]
 #![doc(primitive = "f32")]
@@ -68,6 +68,7 @@ mod cmath {
     }
 }
 
+#[unstable = "trait is unstable"]
 impl FloatMath for f32 {
     /// Constructs a floating point number by multiplying `x` by 2 raised to the
     /// power of `exp`
@@ -248,6 +249,7 @@ impl FloatMath for f32 {
 ///
 /// * num - The float value
 #[inline]
+#[experimental = "may be removed or relocated"]
 pub fn to_string(num: f32) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigAll, strconv::ExpNone, false);
@@ -260,6 +262,7 @@ pub fn to_string(num: f32) -> String {
 ///
 /// * num - The float value
 #[inline]
+#[experimental = "may be removed or relocated"]
 pub fn to_str_hex(num: f32) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 16u, true, strconv::SignNeg, strconv::DigAll, strconv::ExpNone, false);
@@ -274,6 +277,7 @@ pub fn to_str_hex(num: f32) -> String {
 /// * num - The float value
 /// * radix - The base to use
 #[inline]
+#[experimental = "may be removed or relocated"]
 pub fn to_str_radix_special(num: f32, rdx: uint) -> (String, bool) {
     strconv::float_to_str_common(num, rdx, true,
                            strconv::SignNeg, strconv::DigAll, strconv::ExpNone, false)
@@ -287,6 +291,7 @@ pub fn to_str_radix_special(num: f32, rdx: uint) -> (String, bool) {
 /// * num - The float value
 /// * digits - The number of significant digits
 #[inline]
+#[experimental = "may be removed or relocated"]
 pub fn to_str_exact(num: f32, dig: uint) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigExact(dig), strconv::ExpNone, false);
@@ -301,6 +306,7 @@ pub fn to_str_exact(num: f32, dig: uint) -> String {
 /// * num - The float value
 /// * digits - The number of significant digits
 #[inline]
+#[experimental = "may be removed or relocated"]
 pub fn to_str_digits(num: f32, dig: uint) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigMax(dig), strconv::ExpNone, false);
@@ -316,6 +322,7 @@ pub fn to_str_digits(num: f32, dig: uint) -> String {
 /// * digits - The number of digits after the decimal point
 /// * upper - Use `E` instead of `e` for the exponent sign
 #[inline]
+#[experimental = "may be removed or relocated"]
 pub fn to_str_exp_exact(num: f32, dig: uint, upper: bool) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigExact(dig), strconv::ExpDec, upper);
@@ -331,6 +338,7 @@ pub fn to_str_exp_exact(num: f32, dig: uint, upper: bool) -> String {
 /// * digits - The number of digits after the decimal point
 /// * upper - Use `E` instead of `e` for the exponent sign
 #[inline]
+#[experimental = "may be removed or relocated"]
 pub fn to_str_exp_digits(num: f32, dig: uint, upper: bool) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigMax(dig), strconv::ExpDec, upper);

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -10,7 +10,7 @@
 
 //! Operations and constants for 64-bits floats (`f64` type)
 
-#![experimental]
+#![stable]
 #![allow(missing_docs)]
 #![doc(primitive = "f64")]
 
@@ -76,6 +76,7 @@ mod cmath {
     }
 }
 
+#[unstable = "trait is unstable"]
 impl FloatMath for f64 {
     /// Constructs a floating point number by multiplying `x` by 2 raised to the
     /// power of `exp`
@@ -256,6 +257,7 @@ impl FloatMath for f64 {
 ///
 /// * num - The float value
 #[inline]
+#[experimental = "may be removed or relocated"]
 pub fn to_string(num: f64) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigAll, strconv::ExpNone, false);
@@ -268,6 +270,7 @@ pub fn to_string(num: f64) -> String {
 ///
 /// * num - The float value
 #[inline]
+#[experimental = "may be removed or relocated"]
 pub fn to_str_hex(num: f64) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 16u, true, strconv::SignNeg, strconv::DigAll, strconv::ExpNone, false);
@@ -282,6 +285,7 @@ pub fn to_str_hex(num: f64) -> String {
 /// * num - The float value
 /// * radix - The base to use
 #[inline]
+#[experimental = "may be removed or relocated"]
 pub fn to_str_radix_special(num: f64, rdx: uint) -> (String, bool) {
     strconv::float_to_str_common(num, rdx, true,
                            strconv::SignNeg, strconv::DigAll, strconv::ExpNone, false)
@@ -295,6 +299,7 @@ pub fn to_str_radix_special(num: f64, rdx: uint) -> (String, bool) {
 /// * num - The float value
 /// * digits - The number of significant digits
 #[inline]
+#[experimental = "may be removed or relocated"]
 pub fn to_str_exact(num: f64, dig: uint) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigExact(dig), strconv::ExpNone, false);
@@ -309,6 +314,7 @@ pub fn to_str_exact(num: f64, dig: uint) -> String {
 /// * num - The float value
 /// * digits - The number of significant digits
 #[inline]
+#[experimental = "may be removed or relocated"]
 pub fn to_str_digits(num: f64, dig: uint) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigMax(dig), strconv::ExpNone, false);
@@ -324,6 +330,7 @@ pub fn to_str_digits(num: f64, dig: uint) -> String {
 /// * digits - The number of digits after the decimal point
 /// * upper - Use `E` instead of `e` for the exponent sign
 #[inline]
+#[experimental = "may be removed or relocated"]
 pub fn to_str_exp_exact(num: f64, dig: uint, upper: bool) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigExact(dig), strconv::ExpDec, upper);
@@ -339,6 +346,7 @@ pub fn to_str_exp_exact(num: f64, dig: uint, upper: bool) -> String {
 /// * digits - The number of digits after the decimal point
 /// * upper - Use `E` instead of `e` for the exponent sign
 #[inline]
+#[experimental = "may be removed or relocated"]
 pub fn to_str_exp_digits(num: f64, dig: uint, upper: bool) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 10u, true, strconv::SignNeg, strconv::DigMax(dig), strconv::ExpDec, upper);

--- a/src/libstd/num/i16.rs
+++ b/src/libstd/num/i16.rs
@@ -10,7 +10,7 @@
 
 //! Operations and constants for signed 16-bits integers (`i16` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "i16")]
 
 pub use core::i16::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/i32.rs
+++ b/src/libstd/num/i32.rs
@@ -10,7 +10,7 @@
 
 //! Operations and constants for signed 32-bits integers (`i32` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "i32")]
 
 pub use core::i32::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/i64.rs
+++ b/src/libstd/num/i64.rs
@@ -10,7 +10,7 @@
 
 //! Operations and constants for signed 64-bits integers (`i64` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "i64")]
 
 pub use core::i64::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/i8.rs
+++ b/src/libstd/num/i8.rs
@@ -10,7 +10,7 @@
 
 //! Operations and constants for signed 8-bits integers (`i8` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "i8")]
 
 pub use core::i8::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -13,7 +13,7 @@
 //! These are implemented for the primitive numeric types in `std::{u8, u16,
 //! u32, u64, uint, i8, i16, i32, i64, int, f32, f64}`.
 
-#![experimental]
+#![stable]
 #![allow(missing_docs)]
 
 #[cfg(test)] use cmp::PartialEq;
@@ -33,9 +33,11 @@ pub use core::num::{FromStrRadix, from_str_radix};
 pub use core::num::{FPCategory, FPNaN, FPInfinite, FPZero, FPSubnormal};
 pub use core::num::{FPNormal, Float};
 
+#[experimental = "may be removed or relocated"]
 pub mod strconv;
 
 /// Mathematical operations on primitive floating point numbers.
+#[unstable = "may be altered to inline the Float trait"]
 pub trait FloatMath: Float {
     /// Constructs a floating point number created by multiplying `x` by 2
     /// raised to the power of `exp`.

--- a/src/libstd/num/u16.rs
+++ b/src/libstd/num/u16.rs
@@ -10,7 +10,7 @@
 
 //! Operations and constants for unsigned 16-bits integers (`u16` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "u16")]
 
 pub use core::u16::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/u32.rs
+++ b/src/libstd/num/u32.rs
@@ -10,7 +10,7 @@
 
 //! Operations and constants for unsigned 32-bits integers (`u32` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "u32")]
 
 pub use core::u32::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/u64.rs
+++ b/src/libstd/num/u64.rs
@@ -10,7 +10,7 @@
 
 //! Operations and constants for unsigned 64-bits integer (`u64` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "u64")]
 
 pub use core::u64::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/u8.rs
+++ b/src/libstd/num/u8.rs
@@ -10,7 +10,7 @@
 
 //! Operations and constants for unsigned 8-bits integers (`u8` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "u8")]
 
 pub use core::u8::{BITS, BYTES, MIN, MAX};


### PR DESCRIPTION
This commit adds stability markers for the APIs that have recently been aligned with [numerics reform](https://github.com/rust-lang/rfcs/pull/369). For APIs that were changed as part of that reform, `#[unstable]` is used to reflect the recency, but the APIs will become `#[stable]` in a follow-up pass.

In addition, a few aspects of the APIs not explicitly covered by the RFC are marked here -- in particular, constants for floats.

This commit does not mark the `uint` or `int` modules as `#[stable]`, given the ongoing debate out the names and roles of these types.

Due to some deprecation (see the RFC for details), this is a:

[breaking-change]

r? @alexcrichton 
cc @bjz 
