### PR TITLE
Bring back the dylib kind of the link attribute

### DIFF
--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -242,6 +242,8 @@ fn visit_item(e: &Env, i: &ast::Item) {
                                     cstore::NativeFramework
                                 } else if k.equiv(&("framework")) {
                                     cstore::NativeFramework
+                                } else if k.equiv(&("dylib")) {
+                                    cstore::NativeUnknown
                                 } else {
                                     e.sess.span_err(m.span,
                                         format!("unknown kind: `{}`",


### PR DESCRIPTION
Hello,

`dylib` [seems](https://github.com/rust-lang/rust/blob/8f8753878644b0bfb38d24781edb9ef2028730f2/src/librustc/metadata/creader.rs#L237) to be no longer an option for the `kind` key of the `link` attribute.

UPDATE: It should be the other way around: It [seems](https://github.com/rust-lang/rust/blob/8f8753878644b0bfb38d24781edb9ef2028730f2/src/librustc/metadata/creader.rs#L237) `dylib` has been lost as a possible variant of the `kind` key of the `link` attribute. See the comment below.

Regards,
Ivan
