### PR TITLE
Search for implemented kinds recursively on Trait types. Fixes #15155 and #13155.

### DIFF
--- a/src/test/run-pass/issue-15155.rs
+++ b/src/test/run-pass/issue-15155.rs
@@ -1,0 +1,32 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait TraitWithSend: Send {}
+trait IndirectTraitWithSend: TraitWithSend {}
+
+// Check struct instantiation (Box<TraitWithSend> will only have Send if TraitWithSend has Send)
+#[allow(dead_code)]
+struct Blah { x: Box<TraitWithSend> }
+impl TraitWithSend for Blah {}
+
+// Struct instantiation 2-levels deep
+#[allow(dead_code)]
+struct IndirectBlah { x: Box<IndirectTraitWithSend> }
+impl TraitWithSend for IndirectBlah {}
+impl IndirectTraitWithSend for IndirectBlah {}
+
+fn test_trait<Sized? T: Send>() { println!("got here!") }
+
+fn main() {
+    test_trait::<TraitWithSend>();
+    test_trait::<IndirectTraitWithSend>();
+}
+
+


### PR DESCRIPTION
It looks like currently kinds required by traits are not propagated when they are wrapped in a TyTrait. Additionally, in SelectionContext::builtin_bound, no attempt is made to check whether the target trait or its supertraits require the kind specified.

This PR alters SelectionContext::builtin_bound to examine all supertraits in the target trait's bounds recursively for required kinds.

Alternatively, the kinds could be added to the TyTrait upon creation (by just setting its builtin_bounds to the union of the bounds requested in this instance and the bounds required by the trait), this option may have less overhead during compilation but information is lost about which kinds were explicitly requested for this instance (vs those specified by traits/supertraits) would be lost.
