### PR TITLE
Add a function to copy from a Reader to a Writer

### DIFF
--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -381,16 +381,8 @@ pub fn copy(from: &Path, to: &Path) -> IoResult<()> {
 
     let mut reader = try!(File::open(from));
     let mut writer = try!(File::create(to));
-    let mut buf = [0, ..io::DEFAULT_BUF_SIZE];
 
-    loop {
-        let amt = match reader.read(buf) {
-            Ok(n) => n,
-            Err(ref e) if e.kind == io::EndOfFile => { break }
-            Err(e) => return update_err(Err(e), from, to)
-        };
-        try!(writer.write(buf[..amt]));
-    }
+    try!(io::copy(&mut reader, &mut writer));
 
     chmod(to, try!(update_err(from.stat(), from, to)).perm)
 }


### PR DESCRIPTION
Move copying between streams from io::fs::copy() into a separate fn, adding a NoProgress check from read_at_least.
Initially I wanted to add a write_from_reader() to Writer but it seemed to run afoul of object safety rules.
