### PR TITLE
Remove duplicate code by using util::copy()

### DIFF
--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -381,16 +381,8 @@ pub fn copy(from: &Path, to: &Path) -> IoResult<()> {
 
     let mut reader = try!(File::open(from));
     let mut writer = try!(File::create(to));
-    let mut buf = [0, ..io::DEFAULT_BUF_SIZE];
 
-    loop {
-        let amt = match reader.read(&mut buf) {
-            Ok(n) => n,
-            Err(ref e) if e.kind == io::EndOfFile => { break }
-            Err(e) => return update_err(Err(e), from, to)
-        };
-        try!(writer.write(buf[..amt]));
-    }
+    try!(super::util::copy(&mut reader, &mut writer));
 
     chmod(to, try!(update_err(from.stat(), from, to)).perm)
 }

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -382,7 +382,7 @@ pub fn copy(from: &Path, to: &Path) -> IoResult<()> {
     let mut reader = try!(File::open(from));
     let mut writer = try!(File::create(to));
 
-    try!(super::util::copy(&mut reader, &mut writer));
+    try!(update_err(super::util::copy(&mut reader, &mut writer), from, to));
 
     chmod(to, try!(update_err(from.stat(), from, to)).perm)
 }


### PR DESCRIPTION
This code is identical to io::util::copy()
