### PR TITLE
Disallow parsing of struct variants with 0 fields

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5175,7 +5175,15 @@ impl<'a> Parser<'a> {
             if self.eat(&token::OpenDelim(token::Brace)) {
                 // Parse a struct variant.
                 all_nullary = false;
-                kind = StructVariantKind(self.parse_struct_def());
+                let start_span = self.span;
+                let struct_def = self.parse_struct_def();
+                if struct_def.fields.len() == 0 {
+                    self.span_err(start_span,
+                        format!("unit-like struct variant should be written \
+                                 without braces, as `{},`",
+                                token::get_ident(ident)).as_slice());
+                }
+                kind = StructVariantKind(struct_def);
             } else if self.token == token::OpenDelim(token::Paren) {
                 all_nullary = false;
                 let arg_tys = self.parse_enum_variant_seq(

--- a/src/test/compile-fail/struct-variant-no-fields.rs
+++ b/src/test/compile-fail/struct-variant-no-fields.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum Foo {
+    Bar {} //~ ERROR unit-like struct variant should be written without braces, as `Bar,`
+}


### PR DESCRIPTION
Make struct variant syntax more consistent with struct syntax and fix an
assert in middle::typeck.

Fix #19003
