### PR TITLE
creating convenience types for make_def, make_stmt, make_methods in MacResult

### DIFF
--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -202,7 +202,7 @@ impl MacResult for MacPat {
         Some(self.p)
     }
 }
-/// A type for macros that return multiple items.
+/// A convenience type for macros that return multiple items.
 pub struct MacItems {
     items: SmallVector<P<ast::Item>>
 }
@@ -218,6 +218,59 @@ impl MacResult for MacItems {
         Some(self.items)
     }
 }
+
+/// A convenience type for macros that return a single statement
+pub struct MacStmt {
+    stmt: P<ast::Stmt>,
+}
+
+impl MacStmt {
+    pub fn new(stmt: P<ast::Stmt>) -> MacStmt {
+        MacStmt{ stmt: stmt }
+    }
+}
+
+impl MacResult for MacStmt {
+    fn make_stmt(self: Box<MacStmt>) -> Option<P<ast::Stmt>> {
+        Some(self.stmt)
+    }
+}
+
+
+/// A convenience type for macros that return a macro def
+pub struct MacDef {
+    def: Option<MacroDef>
+}
+
+impl MacDef {
+    pub fn new(def: MacroDef) -> MacDef {
+        MacDef{ def: Some(def) }
+    }
+}
+
+impl MacResult for MacDef {
+    fn make_def(&mut self) -> Option<MacroDef> {
+        Some(self.def.take().expect("empty MacDef"))
+    }
+}
+
+/// A convenience type for macros that return methods
+pub struct MacMethods {
+    methods: SmallVector<P<ast::Method>>
+}
+
+impl MacMethods {
+    pub fn new(methods: SmallVector<P<ast::Method>>) -> MacMethods {
+        MacMethods{ methods: methods }
+    }
+}
+
+impl MacResult for MacMethods {
+    fn make_methods(self: Box<MacMethods>) -> Option<SmallVector<P<ast::Method>>> {
+        Some(self.methods)
+    }
+}
+
 
 /// Fill-in macro expansion result, to allow compilation to continue
 /// after hitting errors.

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -11,7 +11,7 @@
 use ast::{Ident, TtDelimited, TtSequence, TtToken};
 use ast;
 use codemap::{Span, DUMMY_SP};
-use ext::base::{ExtCtxt, MacResult, MacroDef};
+use ext::base::{ExtCtxt, MacDef, MacResult, MacroDef};
 use ext::base::{NormalTT, TTMacroExpander};
 use ext::tt::macro_parser::{Success, Error, Failure};
 use ext::tt::macro_parser::{NamedMatch, MatchedSeq, MatchedNonterminal};
@@ -129,14 +129,6 @@ impl TTMacroExpander for MacroRulesMacroExpander {
     }
 }
 
-struct MacroRulesDefiner {
-    def: Option<MacroDef>
-}
-impl MacResult for MacroRulesDefiner {
-    fn make_def(&mut self) -> Option<MacroDef> {
-        Some(self.def.take().expect("empty MacroRulesDefiner"))
-    }
-}
 
 /// Given `lhses` and `rhses`, this is the new macro we create
 fn generic_extension<'cx>(cx: &'cx ExtCtxt,
@@ -279,10 +271,10 @@ pub fn add_new_extension<'cx>(cx: &'cx mut ExtCtxt,
         rhses: rhses,
     };
 
-    box MacroRulesDefiner {
-        def: Some(MacroDef {
+    box MacDef::new(
+        MacroDef {
             name: token::get_ident(name).to_string(),
             ext: NormalTT(exp, Some(sp))
-        })
-    } as Box<MacResult+'cx>
+        }
+    ) as Box<MacResult+'cx>
 }


### PR DESCRIPTION
I was experimenting writing a plugin and noticed that there were convenience types for a few of the methods in the `MacResult` trait but not for all of them.  So I added some for `make_stmt`, `make_methods`, and `make_def`.  For the last one, I noticed that essentially the same struct existed in macro_rules, so I removed it.
