### PR TITLE
slightly better deprecation message for fn syntax

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1229,7 +1229,8 @@ impl<'a> Parser<'a> {
     {
         if self.eat(&token::Lt) {
             if lifetime_defs.is_empty() {
-                self.warn("deprecated syntax, use `for` keyword now");
+                self.warn("deprecated syntax; use the `for` keyword now \
+                            (e.g. change `fn<'a>` to `for<'a> fn`)");
                 let lifetime_defs = self.parse_lifetime_defs();
                 self.expect_gt();
                 lifetime_defs


### PR DESCRIPTION
Came up on IRC that this was a bit unhelpful as to what should actually be _done_. I am new to changing compiler messages, please let me know if there's anything else that needs to be done to accomadate this change.

(My build system is still constantly crashing [Is bors contagious?], so this hasn't been formally `check`ed. I figure it's a simple enough change that any consequences [like compile-fail expected messages?] can be eyeballed by someone more experienced.)
