### PR TITLE
Fix fallout from coercion removal

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -399,7 +399,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
             procsrv::run("",
                          config.adb_path.as_slice(),
                          None,
-                         [
+                         &[
                             "push".to_string(),
                             exe_file.as_str().unwrap().to_string(),
                             config.adb_test_dir.clone()
@@ -411,7 +411,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
             procsrv::run("",
                          config.adb_path.as_slice(),
                          None,
-                         [
+                         &[
                             "forward".to_string(),
                             "tcp:5039".to_string(),
                             "tcp:5039".to_string()
@@ -432,7 +432,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                                                       config.adb_path
                                                             .as_slice(),
                                                       None,
-                                                      [
+                                                      &[
                                                         "shell".to_string(),
                                                         adb_arg.clone()
                                                       ],
@@ -746,7 +746,7 @@ fn run_debuginfo_lldb_test(config: &Config, props: &TestProps, testfile: &Path) 
         cmd.arg(lldb_script_path)
            .arg(test_executable)
            .arg(debugger_script)
-           .env_set_all([("PYTHONPATH", config.lldb_python_dir.clone().unwrap().as_slice())]);
+           .env_set_all(&[("PYTHONPATH", config.lldb_python_dir.clone().unwrap().as_slice())]);
 
         let (status, out, err) = match cmd.spawn() {
             Ok(process) => {
@@ -1142,11 +1142,11 @@ struct ProcRes {
 
 fn compile_test(config: &Config, props: &TestProps,
                 testfile: &Path) -> ProcRes {
-    compile_test_(config, props, testfile, [])
+    compile_test_(config, props, testfile, &[])
 }
 
 fn jit_test(config: &Config, props: &TestProps, testfile: &Path) -> ProcRes {
-    compile_test_(config, props, testfile, ["--jit".to_string()])
+    compile_test_(config, props, testfile, &["--jit".to_string()])
 }
 
 fn compile_test_(config: &Config, props: &TestProps,
@@ -1507,7 +1507,7 @@ fn _arm_exec_compiled_test(config: &Config,
     let copy_result = procsrv::run("",
                                    config.adb_path.as_slice(),
                                    None,
-                                   [
+                                   &[
                                     "push".to_string(),
                                     args.prog.clone(),
                                     config.adb_test_dir.clone()
@@ -1624,7 +1624,7 @@ fn _arm_push_aux_shared_library(config: &Config, testfile: &Path) {
             let copy_result = procsrv::run("",
                                            config.adb_path.as_slice(),
                                            None,
-                                           [
+                                           &[
                                             "push".to_string(),
                                             file.as_str()
                                                 .unwrap()

--- a/src/doc/guide-testing.md
+++ b/src/doc/guide-testing.md
@@ -84,7 +84,7 @@ will be counted as a failure. For example:
 #[test]
 #[should_fail]
 fn test_out_of_bounds_failure() {
-    let v: &[int] = [];
+    let v: &[int] = &[];
     v[0];
 }
 ~~~

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -267,7 +267,7 @@ impl Bitv {
     /// ```
     /// use std::collections::bitv;
     ///
-    /// let bv = bitv::from_bytes([0b01100000]);
+    /// let bv = bitv::from_bytes(&[0b01100000]);
     /// assert_eq!(bv.get(0), false);
     /// assert_eq!(bv.get(1), true);
     ///
@@ -319,9 +319,9 @@ impl Bitv {
     /// let before = 0b01100000;
     /// let after  = 0b11111111;
     ///
-    /// let mut bv = bitv::from_bytes([before]);
+    /// let mut bv = bitv::from_bytes(&[before]);
     /// bv.set_all();
-    /// assert_eq!(bv, bitv::from_bytes([after]));
+    /// assert_eq!(bv, bitv::from_bytes(&[after]));
     /// ```
     #[inline]
     pub fn set_all(&mut self) {
@@ -338,9 +338,9 @@ impl Bitv {
     /// let before = 0b01100000;
     /// let after  = 0b10011111;
     ///
-    /// let mut bv = bitv::from_bytes([before]);
+    /// let mut bv = bitv::from_bytes(&[before]);
     /// bv.negate();
-    /// assert_eq!(bv, bitv::from_bytes([after]));
+    /// assert_eq!(bv, bitv::from_bytes(&[after]));
     /// ```
     #[inline]
     pub fn negate(&mut self) {
@@ -366,11 +366,11 @@ impl Bitv {
     /// let b   = 0b01011010;
     /// let res = 0b01111110;
     ///
-    /// let mut a = bitv::from_bytes([a]);
-    /// let b = bitv::from_bytes([b]);
+    /// let mut a = bitv::from_bytes(&[a]);
+    /// let b = bitv::from_bytes(&[b]);
     ///
     /// assert!(a.union(&b));
-    /// assert_eq!(a, bitv::from_bytes([res]));
+    /// assert_eq!(a, bitv::from_bytes(&[res]));
     /// ```
     #[inline]
     pub fn union(&mut self, other: &Bitv) -> bool {
@@ -396,11 +396,11 @@ impl Bitv {
     /// let b   = 0b01011010;
     /// let res = 0b01000000;
     ///
-    /// let mut a = bitv::from_bytes([a]);
-    /// let b = bitv::from_bytes([b]);
+    /// let mut a = bitv::from_bytes(&[a]);
+    /// let b = bitv::from_bytes(&[b]);
     ///
     /// assert!(a.intersect(&b));
-    /// assert_eq!(a, bitv::from_bytes([res]));
+    /// assert_eq!(a, bitv::from_bytes(&[res]));
     /// ```
     #[inline]
     pub fn intersect(&mut self, other: &Bitv) -> bool {
@@ -427,17 +427,17 @@ impl Bitv {
     /// let a_b = 0b00100100; // a - b
     /// let b_a = 0b00011010; // b - a
     ///
-    /// let mut bva = bitv::from_bytes([a]);
-    /// let bvb = bitv::from_bytes([b]);
+    /// let mut bva = bitv::from_bytes(&[a]);
+    /// let bvb = bitv::from_bytes(&[b]);
     ///
     /// assert!(bva.difference(&bvb));
-    /// assert_eq!(bva, bitv::from_bytes([a_b]));
+    /// assert_eq!(bva, bitv::from_bytes(&[a_b]));
     ///
-    /// let bva = bitv::from_bytes([a]);
-    /// let mut bvb = bitv::from_bytes([b]);
+    /// let bva = bitv::from_bytes(&[a]);
+    /// let mut bvb = bitv::from_bytes(&[b]);
     ///
     /// assert!(bvb.difference(&bva));
-    /// assert_eq!(bvb, bitv::from_bytes([b_a]));
+    /// assert_eq!(bvb, bitv::from_bytes(&[b_a]));
     /// ```
     #[inline]
     pub fn difference(&mut self, other: &Bitv) -> bool {
@@ -474,7 +474,7 @@ impl Bitv {
     /// ```
     /// use std::collections::bitv;
     ///
-    /// let bv = bitv::from_bytes([0b01110100, 0b10010010]);
+    /// let bv = bitv::from_bytes(&[0b01110100, 0b10010010]);
     /// assert_eq!(bv.iter().filter(|x| *x).count(), 7);
     /// ```
     #[inline]
@@ -569,7 +569,7 @@ impl Bitv {
     /// ```
     /// use std::collections::bitv;
     ///
-    /// let bv = bitv::from_bytes([0b10100000]);
+    /// let bv = bitv::from_bytes(&[0b10100000]);
     /// assert_eq!(bv.to_bools(), vec!(true, false, true, false,
     ///                                false, false, false, false));
     /// ```
@@ -589,10 +589,10 @@ impl Bitv {
     /// ```
     /// use std::collections::bitv;
     ///
-    /// let bv = bitv::from_bytes([0b10100000]);
+    /// let bv = bitv::from_bytes(&[0b10100000]);
     ///
-    /// assert!(bv.eq_vec([true, false, true, false,
-    ///                    false, false, false, false]));
+    /// assert!(bv.eq_vec(&[true, false, true, false,
+    ///                     false, false, false, false]));
     /// ```
     pub fn eq_vec(&self, v: &[bool]) -> bool {
         assert_eq!(self.nbits, v.len());
@@ -614,9 +614,9 @@ impl Bitv {
     /// ```
     /// use std::collections::bitv;
     ///
-    /// let mut bv = bitv::from_bytes([0b01001011]);
+    /// let mut bv = bitv::from_bytes(&[0b01001011]);
     /// bv.truncate(2);
-    /// assert!(bv.eq_vec([false, true]));
+    /// assert!(bv.eq_vec(&[false, true]));
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn truncate(&mut self, len: uint) {
@@ -675,7 +675,7 @@ impl Bitv {
     /// ```
     /// use std::collections::bitv;
     ///
-    /// let mut bv = bitv::from_bytes([0b01001011]);
+    /// let mut bv = bitv::from_bytes(&[0b01001011]);
     /// bv.grow(2, true);
     /// assert_eq!(bv.len(), 10);
     /// assert_eq!(bv.to_bytes(), vec!(0b01001011, 0b11000000));
@@ -727,7 +727,7 @@ impl Bitv {
     /// ```
     /// use std::collections::bitv;
     ///
-    /// let mut bv = bitv::from_bytes([0b01001001]);
+    /// let mut bv = bitv::from_bytes(&[0b01001001]);
     /// assert_eq!(bv.pop(), true);
     /// assert_eq!(bv.pop(), false);
     /// assert_eq!(bv.len(), 6);
@@ -753,7 +753,7 @@ impl Bitv {
     /// let mut bv = Bitv::new();
     /// bv.push(true);
     /// bv.push(false);
-    /// assert!(bv.eq_vec([true, false]));
+    /// assert!(bv.eq_vec(&[true, false]));
     /// ```
     pub fn push(&mut self, elem: bool) {
         let insert_pos = self.nbits;
@@ -791,11 +791,11 @@ impl Bitv {
 /// ```
 /// use std::collections::bitv;
 ///
-/// let bv = bitv::from_bytes([0b10100000, 0b00010010]);
-/// assert!(bv.eq_vec([true, false, true, false,
-///                    false, false, false, false,
-///                    false, false, false, true,
-///                    false, false, true, false]));
+/// let bv = bitv::from_bytes(&[0b10100000, 0b00010010]);
+/// assert!(bv.eq_vec(&[true, false, true, false,
+///                     false, false, false, false,
+///                     false, false, false, true,
+///                     false, false, true, false]));
 /// ```
 pub fn from_bytes(bytes: &[u8]) -> Bitv {
     from_fn(bytes.len() * 8, |i| {
@@ -814,7 +814,7 @@ pub fn from_bytes(bytes: &[u8]) -> Bitv {
 /// use std::collections::bitv::from_fn;
 ///
 /// let bv = from_fn(5, |i| { i % 2 == 0 });
-/// assert!(bv.eq_vec([true, false, true, false, true]));
+/// assert!(bv.eq_vec(&[true, false, true, false, true]));
 /// ```
 pub fn from_fn(len: uint, f: |index: uint| -> bool) -> Bitv {
     let mut bitv = Bitv::with_capacity(len, false);
@@ -987,7 +987,7 @@ impl<'a> RandomAccessIterator<bool> for Bits<'a> {
 /// }
 ///
 /// // Can initialize from a `Bitv`
-/// let other = BitvSet::from_bitv(bitv::from_bytes([0b11010000]));
+/// let other = BitvSet::from_bitv(bitv::from_bytes(&[0b11010000]));
 ///
 /// s.union_with(&other);
 ///
@@ -1089,7 +1089,7 @@ impl BitvSet {
     /// ```
     /// use std::collections::{bitv, BitvSet};
     ///
-    /// let bv = bitv::from_bytes([0b01100000]);
+    /// let bv = bitv::from_bytes(&[0b01100000]);
     /// let s = BitvSet::from_bitv(bv);
     ///
     /// // Print 1, 2 in arbitrary order
@@ -1244,7 +1244,7 @@ impl BitvSet {
     /// use std::collections::BitvSet;
     /// use std::collections::bitv;
     ///
-    /// let s = BitvSet::from_bitv(bitv::from_bytes([0b01001010]));
+    /// let s = BitvSet::from_bitv(bitv::from_bytes(&[0b01001010]));
     ///
     /// // Print 1, 4, 6 in arbitrary order
     /// for x in s.iter() {
@@ -1266,8 +1266,8 @@ impl BitvSet {
     /// use std::collections::BitvSet;
     /// use std::collections::bitv;
     ///
-    /// let a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
+    /// let a = BitvSet::from_bitv(bitv::from_bytes(&[0b01101000]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes(&[0b10100000]));
     ///
     /// // Print 0, 1, 2, 4 in arbitrary order
     /// for x in a.union(&b) {
@@ -1295,8 +1295,8 @@ impl BitvSet {
     /// use std::collections::BitvSet;
     /// use std::collections::bitv;
     ///
-    /// let a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
+    /// let a = BitvSet::from_bitv(bitv::from_bytes(&[0b01101000]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes(&[0b10100000]));
     ///
     /// // Print 2
     /// for x in a.intersection(&b) {
@@ -1325,8 +1325,8 @@ impl BitvSet {
     /// use std::collections::BitvSet;
     /// use std::collections::bitv;
     ///
-    /// let a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
+    /// let a = BitvSet::from_bitv(bitv::from_bytes(&[0b01101000]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes(&[0b10100000]));
     ///
     /// // Print 1, 4 in arbitrary order
     /// for x in a.difference(&b) {
@@ -1362,8 +1362,8 @@ impl BitvSet {
     /// use std::collections::BitvSet;
     /// use std::collections::bitv;
     ///
-    /// let a = BitvSet::from_bitv(bitv::from_bytes([0b01101000]));
-    /// let b = BitvSet::from_bitv(bitv::from_bytes([0b10100000]));
+    /// let a = BitvSet::from_bitv(bitv::from_bytes(&[0b01101000]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes(&[0b10100000]));
     ///
     /// // Print 0, 1, 4 in arbitrary order
     /// for x in a.symmetric_difference(&b) {
@@ -1394,9 +1394,9 @@ impl BitvSet {
     /// let b   = 0b10100000;
     /// let res = 0b11101000;
     ///
-    /// let mut a = BitvSet::from_bitv(bitv::from_bytes([a]));
-    /// let b = BitvSet::from_bitv(bitv::from_bytes([b]));
-    /// let res = BitvSet::from_bitv(bitv::from_bytes([res]));
+    /// let mut a = BitvSet::from_bitv(bitv::from_bytes(&[a]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes(&[b]));
+    /// let res = BitvSet::from_bitv(bitv::from_bytes(&[res]));
     ///
     /// a.union_with(&b);
     /// assert_eq!(a, res);
@@ -1418,9 +1418,9 @@ impl BitvSet {
     /// let b   = 0b10100000;
     /// let res = 0b00100000;
     ///
-    /// let mut a = BitvSet::from_bitv(bitv::from_bytes([a]));
-    /// let b = BitvSet::from_bitv(bitv::from_bytes([b]));
-    /// let res = BitvSet::from_bitv(bitv::from_bytes([res]));
+    /// let mut a = BitvSet::from_bitv(bitv::from_bytes(&[a]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes(&[b]));
+    /// let res = BitvSet::from_bitv(bitv::from_bytes(&[res]));
     ///
     /// a.intersect_with(&b);
     /// assert_eq!(a, res);
@@ -1444,16 +1444,16 @@ impl BitvSet {
     /// let a_b = 0b01001000; // a - b
     /// let b_a = 0b10000000; // b - a
     ///
-    /// let mut bva = BitvSet::from_bitv(bitv::from_bytes([a]));
-    /// let bvb = BitvSet::from_bitv(bitv::from_bytes([b]));
-    /// let bva_b = BitvSet::from_bitv(bitv::from_bytes([a_b]));
-    /// let bvb_a = BitvSet::from_bitv(bitv::from_bytes([b_a]));
+    /// let mut bva = BitvSet::from_bitv(bitv::from_bytes(&[a]));
+    /// let bvb = BitvSet::from_bitv(bitv::from_bytes(&[b]));
+    /// let bva_b = BitvSet::from_bitv(bitv::from_bytes(&[a_b]));
+    /// let bvb_a = BitvSet::from_bitv(bitv::from_bytes(&[b_a]));
     ///
     /// bva.difference_with(&bvb);
     /// assert_eq!(bva, bva_b);
     ///
-    /// let bva = BitvSet::from_bitv(bitv::from_bytes([a]));
-    /// let mut bvb = BitvSet::from_bitv(bitv::from_bytes([b]));
+    /// let bva = BitvSet::from_bitv(bitv::from_bytes(&[a]));
+    /// let mut bvb = BitvSet::from_bitv(bitv::from_bytes(&[b]));
     ///
     /// bvb.difference_with(&bva);
     /// assert_eq!(bvb, bvb_a);
@@ -1476,9 +1476,9 @@ impl BitvSet {
     /// let b   = 0b10100000;
     /// let res = 0b11001000;
     ///
-    /// let mut a = BitvSet::from_bitv(bitv::from_bytes([a]));
-    /// let b = BitvSet::from_bitv(bitv::from_bytes([b]));
-    /// let res = BitvSet::from_bitv(bitv::from_bytes([res]));
+    /// let mut a = BitvSet::from_bitv(bitv::from_bytes(&[a]));
+    /// let b = BitvSet::from_bitv(bitv::from_bytes(&[b]));
+    /// let res = BitvSet::from_bitv(bitv::from_bytes(&[res]));
     ///
     /// a.symmetric_difference_with(&b);
     /// assert_eq!(a, res);
@@ -1708,9 +1708,9 @@ mod tests {
     #[test]
     fn test_1_element() {
         let mut act = Bitv::with_capacity(1u, false);
-        assert!(act.eq_vec([false]));
+        assert!(act.eq_vec(&[false]));
         act = Bitv::with_capacity(1u, true);
-        assert!(act.eq_vec([true]));
+        assert!(act.eq_vec(&[true]));
     }
 
     #[test]
@@ -1728,11 +1728,11 @@ mod tests {
 
         act = Bitv::with_capacity(10u, false);
         assert!((act.eq_vec(
-                    [false, false, false, false, false, false, false, false, false, false])));
+                    &[false, false, false, false, false, false, false, false, false, false])));
         // all 1
 
         act = Bitv::with_capacity(10u, true);
-        assert!((act.eq_vec([true, true, true, true, true, true, true, true, true, true])));
+        assert!((act.eq_vec(&[true, true, true, true, true, true, true, true, true, true])));
         // mixed
 
         act = Bitv::with_capacity(10u, false);
@@ -1741,7 +1741,7 @@ mod tests {
         act.set(2u, true);
         act.set(3u, true);
         act.set(4u, true);
-        assert!((act.eq_vec([true, true, true, true, true, false, false, false, false, false])));
+        assert!((act.eq_vec(&[true, true, true, true, true, false, false, false, false, false])));
         // mixed
 
         act = Bitv::with_capacity(10u, false);
@@ -1750,7 +1750,7 @@ mod tests {
         act.set(7u, true);
         act.set(8u, true);
         act.set(9u, true);
-        assert!((act.eq_vec([false, false, false, false, false, true, true, true, true, true])));
+        assert!((act.eq_vec(&[false, false, false, false, false, true, true, true, true, true])));
         // mixed
 
         act = Bitv::with_capacity(10u, false);
@@ -1758,7 +1758,7 @@ mod tests {
         act.set(3u, true);
         act.set(6u, true);
         act.set(9u, true);
-        assert!((act.eq_vec([true, false, false, true, false, false, true, false, false, true])));
+        assert!((act.eq_vec(&[true, false, false, true, false, false, true, false, false, true])));
     }
 
     #[test]
@@ -1768,16 +1768,16 @@ mod tests {
 
         act = Bitv::with_capacity(31u, false);
         assert!(act.eq_vec(
-                [false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, false, false, false]));
+                &[false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, false, false, false, false]));
         // all 1
 
         act = Bitv::with_capacity(31u, true);
         assert!(act.eq_vec(
-                [true, true, true, true, true, true, true, true, true, true, true, true, true,
-                true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-                true, true, true, true]));
+                &[true, true, true, true, true, true, true, true, true, true, true, true, true,
+                  true, true, true, true, true, true, true, true, true, true, true, true, true,
+                  true, true, true, true, true]));
         // mixed
 
         act = Bitv::with_capacity(31u, false);
@@ -1790,9 +1790,9 @@ mod tests {
         act.set(6u, true);
         act.set(7u, true);
         assert!(act.eq_vec(
-                [true, true, true, true, true, true, true, true, false, false, false, false, false,
-                false, false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, false]));
+                &[true, true, true, true, true, true, true, true, false, false, false, false, false,
+                  false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, false, false]));
         // mixed
 
         act = Bitv::with_capacity(31u, false);
@@ -1805,9 +1805,9 @@ mod tests {
         act.set(22u, true);
         act.set(23u, true);
         assert!(act.eq_vec(
-                [false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, true, true, true, true, true, true, true, true,
-                false, false, false, false, false, false, false]));
+                &[false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, true, true, true, true, true, true, true, true,
+                  false, false, false, false, false, false, false]));
         // mixed
 
         act = Bitv::with_capacity(31u, false);
@@ -1819,9 +1819,9 @@ mod tests {
         act.set(29u, true);
         act.set(30u, true);
         assert!(act.eq_vec(
-                [false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, false, false, false, false, false, false, false,
-                false, true, true, true, true, true, true, true]));
+                &[false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, true, true, true, true, true, true, true]));
         // mixed
 
         act = Bitv::with_capacity(31u, false);
@@ -1829,9 +1829,9 @@ mod tests {
         act.set(17u, true);
         act.set(30u, true);
         assert!(act.eq_vec(
-                [false, false, false, true, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, true, false, false, false, false, false, false,
-                false, false, false, false, false, false, true]));
+                &[false, false, false, true, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, true, false, false, false, false, false, false,
+                  false, false, false, false, false, false, true]));
     }
 
     #[test]
@@ -1841,16 +1841,16 @@ mod tests {
 
         act = Bitv::with_capacity(32u, false);
         assert!(act.eq_vec(
-                [false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, false, false, false, false]));
+                &[false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, false, false, false, false, false]));
         // all 1
 
         act = Bitv::with_capacity(32u, true);
         assert!(act.eq_vec(
-                [true, true, true, true, true, true, true, true, true, true, true, true, true,
-                true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-                true, true, true, true, true]));
+                &[true, true, true, true, true, true, true, true, true, true, true, true, true,
+                  true, true, true, true, true, true, true, true, true, true, true, true, true,
+                  true, true, true, true, true, true]));
         // mixed
 
         act = Bitv::with_capacity(32u, false);
@@ -1863,9 +1863,9 @@ mod tests {
         act.set(6u, true);
         act.set(7u, true);
         assert!(act.eq_vec(
-                [true, true, true, true, true, true, true, true, false, false, false, false, false,
-                false, false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, false, false]));
+                &[true, true, true, true, true, true, true, true, false, false, false, false, false,
+                  false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, false, false, false]));
         // mixed
 
         act = Bitv::with_capacity(32u, false);
@@ -1878,9 +1878,9 @@ mod tests {
         act.set(22u, true);
         act.set(23u, true);
         assert!(act.eq_vec(
-                [false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, true, true, true, true, true, true, true, true,
-                false, false, false, false, false, false, false, false]));
+                &[false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, true, true, true, true, true, true, true, true,
+                  false, false, false, false, false, false, false, false]));
         // mixed
 
         act = Bitv::with_capacity(32u, false);
@@ -1893,9 +1893,9 @@ mod tests {
         act.set(30u, true);
         act.set(31u, true);
         assert!(act.eq_vec(
-                [false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, false, false, false, false, false, false, false,
-                false, true, true, true, true, true, true, true, true]));
+                &[false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, true, true, true, true, true, true, true, true]));
         // mixed
 
         act = Bitv::with_capacity(32u, false);
@@ -1904,9 +1904,9 @@ mod tests {
         act.set(30u, true);
         act.set(31u, true);
         assert!(act.eq_vec(
-                [false, false, false, true, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, true, false, false, false, false, false, false,
-                false, false, false, false, false, false, true, true]));
+                &[false, false, false, true, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, true, false, false, false, false, false, false,
+                  false, false, false, false, false, false, true, true]));
     }
 
     #[test]
@@ -1916,16 +1916,16 @@ mod tests {
 
         act = Bitv::with_capacity(33u, false);
         assert!(act.eq_vec(
-                [false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, false, false, false, false, false]));
+                &[false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, false, false, false, false, false, false]));
         // all 1
 
         act = Bitv::with_capacity(33u, true);
         assert!(act.eq_vec(
-                [true, true, true, true, true, true, true, true, true, true, true, true, true,
-                true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-                true, true, true, true, true, true]));
+                &[true, true, true, true, true, true, true, true, true, true, true, true, true,
+                  true, true, true, true, true, true, true, true, true, true, true, true, true,
+                  true, true, true, true, true, true, true]));
         // mixed
 
         act = Bitv::with_capacity(33u, false);
@@ -1938,9 +1938,9 @@ mod tests {
         act.set(6u, true);
         act.set(7u, true);
         assert!(act.eq_vec(
-                [true, true, true, true, true, true, true, true, false, false, false, false, false,
-                false, false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, false, false, false]));
+                &[true, true, true, true, true, true, true, true, false, false, false, false, false,
+                  false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, false, false, false, false]));
         // mixed
 
         act = Bitv::with_capacity(33u, false);
@@ -1953,9 +1953,9 @@ mod tests {
         act.set(22u, true);
         act.set(23u, true);
         assert!(act.eq_vec(
-                [false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, true, true, true, true, true, true, true, true,
-                false, false, false, false, false, false, false, false, false]));
+                &[false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, true, true, true, true, true, true, true, true,
+                  false, false, false, false, false, false, false, false, false]));
         // mixed
 
         act = Bitv::with_capacity(33u, false);
@@ -1968,9 +1968,9 @@ mod tests {
         act.set(30u, true);
         act.set(31u, true);
         assert!(act.eq_vec(
-                [false, false, false, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, false, false, false, false, false, false, false,
-                false, true, true, true, true, true, true, true, true, false]));
+                &[false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, false, false, false, false, false, false,
+                  false, false, true, true, true, true, true, true, true, true, false]));
         // mixed
 
         act = Bitv::with_capacity(33u, false);
@@ -1980,9 +1980,9 @@ mod tests {
         act.set(31u, true);
         act.set(32u, true);
         assert!(act.eq_vec(
-                [false, false, false, true, false, false, false, false, false, false, false, false,
-                false, false, false, false, false, true, false, false, false, false, false, false,
-                false, false, false, false, false, false, true, true, true]));
+                &[false, false, false, true, false, false, false, false, false, false, false, false,
+                  false, false, false, false, false, true, false, false, false, false, false, false,
+                  false, false, false, false, false, false, true, true, true]));
     }
 
     #[test]
@@ -2027,7 +2027,7 @@ mod tests {
 
     #[test]
     fn test_from_bytes() {
-        let bitv = from_bytes([0b10110110, 0b00000000, 0b11111111]);
+        let bitv = from_bytes(&[0b10110110, 0b00000000, 0b11111111]);
         let str = format!("{}{}{}", "10110110", "00000000", "11111111");
         assert_eq!(bitv.to_string().as_slice(), str.as_slice());
     }
@@ -2065,7 +2065,7 @@ mod tests {
     #[test]
     fn test_to_bools() {
         let bools = vec!(false, false, true, false, false, true, true, false);
-        assert_eq!(from_bytes([0b00100110]).iter().collect::<Vec<bool>>(), bools);
+        assert_eq!(from_bytes(&[0b00100110]).iter().collect::<Vec<bool>>(), bools);
     }
 
     #[test]
@@ -2303,10 +2303,10 @@ mod tests {
 
     #[test]
     fn test_bitv_set_is_disjoint() {
-        let a = BitvSet::from_bitv(from_bytes([0b10100010]));
-        let b = BitvSet::from_bitv(from_bytes([0b01000000]));
+        let a = BitvSet::from_bitv(from_bytes(&[0b10100010]));
+        let b = BitvSet::from_bitv(from_bytes(&[0b01000000]));
         let c = BitvSet::new();
-        let d = BitvSet::from_bitv(from_bytes([0b00110000]));
+        let d = BitvSet::from_bitv(from_bytes(&[0b00110000]));
 
         assert!(!a.is_disjoint(&d));
         assert!(!d.is_disjoint(&a));
@@ -2326,13 +2326,13 @@ mod tests {
         a.insert(0);
         let mut b = BitvSet::new();
         b.insert(5);
-        let expected = BitvSet::from_bitv(from_bytes([0b10000100]));
+        let expected = BitvSet::from_bitv(from_bytes(&[0b10000100]));
         a.union_with(&b);
         assert_eq!(a, expected);
 
         // Standard
-        let mut a = BitvSet::from_bitv(from_bytes([0b10100010]));
-        let mut b = BitvSet::from_bitv(from_bytes([0b01100010]));
+        let mut a = BitvSet::from_bitv(from_bytes(&[0b10100010]));
+        let mut b = BitvSet::from_bitv(from_bytes(&[0b01100010]));
         let c = a.clone();
         a.union_with(&b);
         b.union_with(&c);
@@ -2343,8 +2343,8 @@ mod tests {
     #[test]
     fn test_bitv_set_intersect_with() {
         // Explicitly 0'ed bits
-        let mut a = BitvSet::from_bitv(from_bytes([0b10100010]));
-        let mut b = BitvSet::from_bitv(from_bytes([0b00000000]));
+        let mut a = BitvSet::from_bitv(from_bytes(&[0b10100010]));
+        let mut b = BitvSet::from_bitv(from_bytes(&[0b00000000]));
         let c = a.clone();
         a.intersect_with(&b);
         b.intersect_with(&c);
@@ -2352,7 +2352,7 @@ mod tests {
         assert!(b.is_empty());
 
         // Uninitialized bits should behave like 0's
-        let mut a = BitvSet::from_bitv(from_bytes([0b10100010]));
+        let mut a = BitvSet::from_bitv(from_bytes(&[0b10100010]));
         let mut b = BitvSet::new();
         let c = a.clone();
         a.intersect_with(&b);
@@ -2361,8 +2361,8 @@ mod tests {
         assert!(b.is_empty());
 
         // Standard
-        let mut a = BitvSet::from_bitv(from_bytes([0b10100010]));
-        let mut b = BitvSet::from_bitv(from_bytes([0b01100010]));
+        let mut a = BitvSet::from_bitv(from_bytes(&[0b10100010]));
+        let mut b = BitvSet::from_bitv(from_bytes(&[0b01100010]));
         let c = a.clone();
         a.intersect_with(&b);
         b.intersect_with(&c);
@@ -2373,20 +2373,20 @@ mod tests {
     #[test]
     fn test_bitv_set_difference_with() {
         // Explicitly 0'ed bits
-        let mut a = BitvSet::from_bitv(from_bytes([0b00000000]));
-        let b = BitvSet::from_bitv(from_bytes([0b10100010]));
+        let mut a = BitvSet::from_bitv(from_bytes(&[0b00000000]));
+        let b = BitvSet::from_bitv(from_bytes(&[0b10100010]));
         a.difference_with(&b);
         assert!(a.is_empty());
 
         // Uninitialized bits should behave like 0's
         let mut a = BitvSet::new();
-        let b = BitvSet::from_bitv(from_bytes([0b11111111]));
+        let b = BitvSet::from_bitv(from_bytes(&[0b11111111]));
         a.difference_with(&b);
         assert!(a.is_empty());
 
         // Standard
-        let mut a = BitvSet::from_bitv(from_bytes([0b10100010]));
-        let mut b = BitvSet::from_bitv(from_bytes([0b01100010]));
+        let mut a = BitvSet::from_bitv(from_bytes(&[0b10100010]));
+        let mut b = BitvSet::from_bitv(from_bytes(&[0b01100010]));
         let c = a.clone();
         a.difference_with(&b);
         b.difference_with(&c);
@@ -2403,19 +2403,19 @@ mod tests {
         let mut b = BitvSet::new();
         b.insert(1);
         b.insert(5);
-        let expected = BitvSet::from_bitv(from_bytes([0b10000100]));
+        let expected = BitvSet::from_bitv(from_bytes(&[0b10000100]));
         a.symmetric_difference_with(&b);
         assert_eq!(a, expected);
 
-        let mut a = BitvSet::from_bitv(from_bytes([0b10100010]));
+        let mut a = BitvSet::from_bitv(from_bytes(&[0b10100010]));
         let b = BitvSet::new();
         let c = a.clone();
         a.symmetric_difference_with(&b);
         assert_eq!(a, c);
 
         // Standard
-        let mut a = BitvSet::from_bitv(from_bytes([0b11100010]));
-        let mut b = BitvSet::from_bitv(from_bytes([0b01101010]));
+        let mut a = BitvSet::from_bitv(from_bytes(&[0b11100010]));
+        let mut b = BitvSet::from_bitv(from_bytes(&[0b01101010]));
         let c = a.clone();
         a.symmetric_difference_with(&b);
         b.symmetric_difference_with(&c);
@@ -2425,8 +2425,8 @@ mod tests {
 
     #[test]
     fn test_bitv_set_eq() {
-        let a = BitvSet::from_bitv(from_bytes([0b10100010]));
-        let b = BitvSet::from_bitv(from_bytes([0b00000000]));
+        let a = BitvSet::from_bitv(from_bytes(&[0b10100010]));
+        let b = BitvSet::from_bitv(from_bytes(&[0b00000000]));
         let c = BitvSet::new();
 
         assert!(a == a);
@@ -2439,8 +2439,8 @@ mod tests {
 
     #[test]
     fn test_bitv_set_cmp() {
-        let a = BitvSet::from_bitv(from_bytes([0b10100010]));
-        let b = BitvSet::from_bitv(from_bytes([0b00000000]));
+        let a = BitvSet::from_bitv(from_bytes(&[0b10100010]));
+        let b = BitvSet::from_bitv(from_bytes(&[0b00000000]));
         let c = BitvSet::new();
 
         assert_eq!(a.cmp(&b), Greater);
@@ -2519,17 +2519,17 @@ mod tests {
 
     #[test]
     fn test_small_bitv_tests() {
-        let v = from_bytes([0]);
+        let v = from_bytes(&[0]);
         assert!(!v.all());
         assert!(!v.any());
         assert!(v.none());
 
-        let v = from_bytes([0b00010100]);
+        let v = from_bytes(&[0b00010100]);
         assert!(!v.all());
         assert!(v.any());
         assert!(!v.none());
 
-        let v = from_bytes([0xFF]);
+        let v = from_bytes(&[0xFF]);
         assert!(v.all());
         assert!(v.any());
         assert!(!v.none());
@@ -2537,7 +2537,7 @@ mod tests {
 
     #[test]
     fn test_big_bitv_tests() {
-        let v = from_bytes([ // 88 bits
+        let v = from_bytes(&[ // 88 bits
             0, 0, 0, 0,
             0, 0, 0, 0,
             0, 0, 0]);
@@ -2545,7 +2545,7 @@ mod tests {
         assert!(!v.any());
         assert!(v.none());
 
-        let v = from_bytes([ // 88 bits
+        let v = from_bytes(&[ // 88 bits
             0, 0, 0b00010100, 0,
             0, 0, 0, 0b00110100,
             0, 0, 0]);
@@ -2553,7 +2553,7 @@ mod tests {
         assert!(v.any());
         assert!(!v.none());
 
-        let v = from_bytes([ // 88 bits
+        let v = from_bytes(&[ // 88 bits
             0xFF, 0xFF, 0xFF, 0xFF,
             0xFF, 0xFF, 0xFF, 0xFF,
             0xFF, 0xFF, 0xFF]);
@@ -2632,24 +2632,24 @@ mod tests {
 
     #[test]
     fn test_bitv_grow() {
-        let mut bitv = from_bytes([0b10110110, 0b00000000, 0b10101010]);
+        let mut bitv = from_bytes(&[0b10110110, 0b00000000, 0b10101010]);
         bitv.grow(32, true);
-        assert_eq!(bitv, from_bytes([0b10110110, 0b00000000, 0b10101010,
+        assert_eq!(bitv, from_bytes(&[0b10110110, 0b00000000, 0b10101010,
                                      0xFF, 0xFF, 0xFF, 0xFF]));
         bitv.grow(64, false);
-        assert_eq!(bitv, from_bytes([0b10110110, 0b00000000, 0b10101010,
+        assert_eq!(bitv, from_bytes(&[0b10110110, 0b00000000, 0b10101010,
                                      0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0, 0, 0, 0, 0]));
         bitv.grow(16, true);
-        assert_eq!(bitv, from_bytes([0b10110110, 0b00000000, 0b10101010,
+        assert_eq!(bitv, from_bytes(&[0b10110110, 0b00000000, 0b10101010,
                                      0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF]));
     }
 
     #[test]
     fn test_bitv_extend() {
-        let mut bitv = from_bytes([0b10110110, 0b00000000, 0b11111111]);
-        let ext = from_bytes([0b01001001, 0b10010010, 0b10111101]);
+        let mut bitv = from_bytes(&[0b10110110, 0b00000000, 0b11111111]);
+        let ext = from_bytes(&[0b01001001, 0b10010010, 0b10111101]);
         bitv.extend(ext.iter());
-        assert_eq!(bitv, from_bytes([0b10110110, 0b00000000, 0b11111111,
+        assert_eq!(bitv, from_bytes(&[0b10110110, 0b00000000, 0b11111111,
                                      0b01001001, 0b10010010, 0b10111101]));
     }
 

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -467,14 +467,14 @@ mod test {
             check(a, b, expected, |x, y, f| x.intersection(y).all(f))
         }
 
-        check_intersection([], [], []);
-        check_intersection([1, 2, 3], [], []);
-        check_intersection([], [1, 2, 3], []);
-        check_intersection([2], [1, 2, 3], [2]);
-        check_intersection([1, 2, 3], [2], [2]);
-        check_intersection([11, 1, 3, 77, 103, 5, -5],
-                           [2, 11, 77, -9, -42, 5, 3],
-                           [3, 5, 11, 77]);
+        check_intersection(&[], &[], &[]);
+        check_intersection(&[1, 2, 3], &[], &[]);
+        check_intersection(&[], &[1, 2, 3], &[]);
+        check_intersection(&[2], &[1, 2, 3], &[2]);
+        check_intersection(&[1, 2, 3], &[2], &[2]);
+        check_intersection(&[11, 1, 3, 77, 103, 5, -5],
+                           &[2, 11, 77, -9, -42, 5, 3],
+                           &[3, 5, 11, 77]);
     }
 
     #[test]
@@ -483,15 +483,15 @@ mod test {
             check(a, b, expected, |x, y, f| x.difference(y).all(f))
         }
 
-        check_difference([], [], []);
-        check_difference([1, 12], [], [1, 12]);
-        check_difference([], [1, 2, 3, 9], []);
-        check_difference([1, 3, 5, 9, 11],
-                         [3, 9],
-                         [1, 5, 11]);
-        check_difference([-5, 11, 22, 33, 40, 42],
-                         [-12, -5, 14, 23, 34, 38, 39, 50],
-                         [11, 22, 33, 40, 42]);
+        check_difference(&[], &[], &[]);
+        check_difference(&[1, 12], &[], &[1, 12]);
+        check_difference(&[], &[1, 2, 3, 9], &[]);
+        check_difference(&[1, 3, 5, 9, 11],
+                         &[3, 9],
+                         &[1, 5, 11]);
+        check_difference(&[-5, 11, 22, 33, 40, 42],
+                         &[-12, -5, 14, 23, 34, 38, 39, 50],
+                         &[11, 22, 33, 40, 42]);
     }
 
     #[test]
@@ -501,12 +501,12 @@ mod test {
             check(a, b, expected, |x, y, f| x.symmetric_difference(y).all(f))
         }
 
-        check_symmetric_difference([], [], []);
-        check_symmetric_difference([1, 2, 3], [2], [1, 3]);
-        check_symmetric_difference([2], [1, 2, 3], [1, 3]);
-        check_symmetric_difference([1, 3, 5, 9, 11],
-                                   [-2, 3, 9, 14, 22],
-                                   [-2, 1, 5, 11, 14, 22]);
+        check_symmetric_difference(&[], &[], &[]);
+        check_symmetric_difference(&[1, 2, 3], &[2], &[1, 3]);
+        check_symmetric_difference(&[2], &[1, 2, 3], &[1, 3]);
+        check_symmetric_difference(&[1, 3, 5, 9, 11],
+                                   &[-2, 3, 9, 14, 22],
+                                   &[-2, 1, 5, 11, 14, 22]);
     }
 
     #[test]
@@ -516,12 +516,12 @@ mod test {
             check(a, b, expected, |x, y, f| x.union(y).all(f))
         }
 
-        check_union([], [], []);
-        check_union([1, 2, 3], [2], [1, 2, 3]);
-        check_union([2], [1, 2, 3], [1, 2, 3]);
-        check_union([1, 3, 5, 9, 11, 16, 19, 24],
-                    [-2, 1, 5, 9, 13, 19],
-                    [-2, 1, 3, 5, 9, 11, 13, 16, 19, 24]);
+        check_union(&[], &[], &[]);
+        check_union(&[1, 2, 3], &[2], &[1, 2, 3]);
+        check_union(&[2], &[1, 2, 3], &[1, 2, 3]);
+        check_union(&[1, 3, 5, 9, 11, 16, 19, 24],
+                    &[-2, 1, 5, 9, 13, 19],
+                    &[-2, 1, 3, 5, 9, 11, 13, 16, 19, 24]);
     }
 
     #[test]

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -1088,8 +1088,8 @@ mod tests {
 
     #[test]
     fn test_merge() {
-        let mut m = list_from([0i, 1, 3, 5, 6, 7, 2]);
-        let n = list_from([-1i, 0, 0, 7, 7, 9]);
+        let mut m = list_from(&[0i, 1, 3, 5, 6, 7, 2]);
+        let n = list_from(&[-1i, 0, 0, 7, 7, 9]);
         let len = m.len() + n.len();
         m.merge(n, |a, b| a <= b);
         assert_eq!(m.len(), len);
@@ -1129,7 +1129,7 @@ mod tests {
 
     #[test]
     fn test_send() {
-        let n = list_from([1i,2,3]);
+        let n = list_from(&[1i,2,3]);
         spawn(proc() {
             check_links(&n);
             let a: &[_] = &[&1,&2,&3];
@@ -1139,16 +1139,16 @@ mod tests {
 
     #[test]
     fn test_eq() {
-        let mut n: DList<u8> = list_from([]);
-        let mut m = list_from([]);
+        let mut n: DList<u8> = list_from(&[]);
+        let mut m = list_from(&[]);
         assert!(n == m);
         n.push_front(1);
         assert!(n != m);
         m.push_back(1);
         assert!(n == m);
 
-        let n = list_from([2i,3,4]);
-        let m = list_from([1i,2,3]);
+        let n = list_from(&[2i,3,4]);
+        let m = list_from(&[1i,2,3]);
         assert!(n != m);
     }
 
@@ -1172,8 +1172,8 @@ mod tests {
 
     #[test]
     fn test_ord() {
-        let n: DList<int> = list_from([]);
-        let m = list_from([1i,2,3]);
+        let n: DList<int> = list_from(&[]);
+        let m = list_from(&[1i,2,3]);
         assert!(n < m);
         assert!(m > n);
         assert!(n <= n);
@@ -1183,29 +1183,29 @@ mod tests {
     #[test]
     fn test_ord_nan() {
         let nan = 0.0f64/0.0;
-        let n = list_from([nan]);
-        let m = list_from([nan]);
+        let n = list_from(&[nan]);
+        let m = list_from(&[nan]);
         assert!(!(n < m));
         assert!(!(n > m));
         assert!(!(n <= m));
         assert!(!(n >= m));
 
-        let n = list_from([nan]);
-        let one = list_from([1.0f64]);
+        let n = list_from(&[nan]);
+        let one = list_from(&[1.0f64]);
         assert!(!(n < one));
         assert!(!(n > one));
         assert!(!(n <= one));
         assert!(!(n >= one));
 
-        let u = list_from([1.0f64,2.0,nan]);
-        let v = list_from([1.0f64,2.0,3.0]);
+        let u = list_from(&[1.0f64,2.0,nan]);
+        let v = list_from(&[1.0f64,2.0,3.0]);
         assert!(!(u < v));
         assert!(!(u > v));
         assert!(!(u <= v));
         assert!(!(u >= v));
 
-        let s = list_from([1.0f64,2.0,4.0,2.0]);
-        let t = list_from([1.0f64,2.0,3.0,2.0]);
+        let s = list_from(&[1.0f64,2.0,4.0,2.0]);
+        let t = list_from(&[1.0f64,2.0,3.0,2.0]);
         assert!(!(s < t));
         assert!(s > one);
         assert!(!(s <= one));

--- a/src/libcollections/hash/mod.rs
+++ b/src/libcollections/hash/mod.rs
@@ -151,7 +151,7 @@ macro_rules! impl_hash_tuple(
         impl<S: Writer> Hash<S> for () {
             #[inline]
             fn hash(&self, state: &mut S) {
-                state.write([]);
+                state.write(&[]);
             }
         }
     );

--- a/src/libcollections/hash/sip.rs
+++ b/src/libcollections/hash/sip.rs
@@ -414,7 +414,7 @@ mod tests {
             assert_eq!(f, v);
 
             buf.push(t as u8);
-            state_inc.write([t as u8]);
+            state_inc.write(&[t as u8]);
 
             t += 1;
         }

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -18,7 +18,7 @@
 //! let vec = vec!(1i, 2, 3);
 //! let int_slice = vec.as_slice();
 //! // coercing an array to a slice
-//! let str_slice: &[&str] = ["one", "two", "three"];
+//! let str_slice: &[&str] = &["one", "two", "three"];
 //! ```
 //!
 //! Slices are either mutable or shared. The shared slice type is `&[T]`,
@@ -26,7 +26,7 @@
 //! block of memory that a mutable slice points to:
 //!
 //! ```rust
-//! let x: &mut[int] = [1i, 2, 3];
+//! let x: &mut[int] = &mut [1i, 2, 3];
 //! x[1] = 7;
 //! assert_eq!(x[0], 1);
 //! assert_eq!(x[1], 7);
@@ -1962,7 +1962,7 @@ mod tests {
         assert!(!b"foo".starts_with(b"foobar"));
         assert!(!b"bar".starts_with(b"foobar"));
         assert!(b"foobar".starts_with(b"foobar"));
-        let empty: &[u8] = [];
+        let empty: &[u8] = &[];
         assert!(empty.starts_with(empty));
         assert!(!empty.starts_with(b"foo"));
         assert!(b"foobar".starts_with(empty));
@@ -1976,7 +1976,7 @@ mod tests {
         assert!(!b"foo".ends_with(b"foobar"));
         assert!(!b"bar".ends_with(b"foobar"));
         assert!(b"foobar".ends_with(b"foobar"));
-        let empty: &[u8] = [];
+        let empty: &[u8] = &[];
         assert!(empty.ends_with(empty));
         assert!(!empty.ends_with(b"foo"));
         assert!(b"foobar".ends_with(empty));
@@ -2054,7 +2054,7 @@ mod tests {
         let h = x.last_mut();
         assert_eq!(*h.unwrap(), 5);
 
-        let y: &mut [int] = [];
+        let y: &mut [int] = &mut [];
         assert!(y.last_mut().is_none());
     }
 

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -923,13 +923,13 @@ mod tests {
         fn t(v: &[String], s: &str) {
             assert_eq!(v.concat().as_slice(), s);
         }
-        t([String::from_str("you"), String::from_str("know"),
-           String::from_str("I'm"),
-           String::from_str("no"), String::from_str("good")],
+        t(&[String::from_str("you"), String::from_str("know"),
+            String::from_str("I'm"),
+            String::from_str("no"), String::from_str("good")],
           "youknowI'mnogood");
-        let v: &[String] = [];
+        let v: &[String] = &[];
         t(v, "");
-        t([String::from_str("hi")], "hi");
+        t(&[String::from_str("hi")], "hi");
     }
 
     #[test]
@@ -937,13 +937,13 @@ mod tests {
         fn t(v: &[String], sep: &str, s: &str) {
             assert_eq!(v.connect(sep).as_slice(), s);
         }
-        t([String::from_str("you"), String::from_str("know"),
-           String::from_str("I'm"),
-           String::from_str("no"), String::from_str("good")],
+        t(&[String::from_str("you"), String::from_str("know"),
+            String::from_str("I'm"),
+            String::from_str("no"), String::from_str("good")],
           " ", "you know I'm no good");
-        let v: &[String] = [];
+        let v: &[String] = &[];
         t(v, " ", "");
-        t([String::from_str("hi")], " ", "hi");
+        t(&[String::from_str("hi")], " ", "hi");
     }
 
     #[test]
@@ -951,10 +951,10 @@ mod tests {
         fn t(v: &[&str], s: &str) {
             assert_eq!(v.concat().as_slice(), s);
         }
-        t(["you", "know", "I'm", "no", "good"], "youknowI'mnogood");
-        let v: &[&str] = [];
+        t(&["you", "know", "I'm", "no", "good"], "youknowI'mnogood");
+        let v: &[&str] = &[];
         t(v, "");
-        t(["hi"], "hi");
+        t(&["hi"], "hi");
     }
 
     #[test]
@@ -962,10 +962,10 @@ mod tests {
         fn t(v: &[&str], sep: &str, s: &str) {
             assert_eq!(v.connect(sep).as_slice(), s);
         }
-        t(["you", "know", "I'm", "no", "good"],
+        t(&["you", "know", "I'm", "no", "good"],
           " ", "you know I'm no good");
-        t([], " ", "");
-        t(["hi"], " ", "hi");
+        t(&[], " ", "");
+        t(&["hi"], " ", "hi");
     }
 
     #[test]
@@ -1266,26 +1266,26 @@ mod tests {
     #[test]
     fn test_is_utf8() {
         // deny overlong encodings
-        assert!(!is_utf8([0xc0, 0x80]));
-        assert!(!is_utf8([0xc0, 0xae]));
-        assert!(!is_utf8([0xe0, 0x80, 0x80]));
-        assert!(!is_utf8([0xe0, 0x80, 0xaf]));
-        assert!(!is_utf8([0xe0, 0x81, 0x81]));
-        assert!(!is_utf8([0xf0, 0x82, 0x82, 0xac]));
-        assert!(!is_utf8([0xf4, 0x90, 0x80, 0x80]));
+        assert!(!is_utf8(&[0xc0, 0x80]));
+        assert!(!is_utf8(&[0xc0, 0xae]));
+        assert!(!is_utf8(&[0xe0, 0x80, 0x80]));
+        assert!(!is_utf8(&[0xe0, 0x80, 0xaf]));
+        assert!(!is_utf8(&[0xe0, 0x81, 0x81]));
+        assert!(!is_utf8(&[0xf0, 0x82, 0x82, 0xac]));
+        assert!(!is_utf8(&[0xf4, 0x90, 0x80, 0x80]));
 
         // deny surrogates
-        assert!(!is_utf8([0xED, 0xA0, 0x80]));
-        assert!(!is_utf8([0xED, 0xBF, 0xBF]));
+        assert!(!is_utf8(&[0xED, 0xA0, 0x80]));
+        assert!(!is_utf8(&[0xED, 0xBF, 0xBF]));
 
-        assert!(is_utf8([0xC2, 0x80]));
-        assert!(is_utf8([0xDF, 0xBF]));
-        assert!(is_utf8([0xE0, 0xA0, 0x80]));
-        assert!(is_utf8([0xED, 0x9F, 0xBF]));
-        assert!(is_utf8([0xEE, 0x80, 0x80]));
-        assert!(is_utf8([0xEF, 0xBF, 0xBF]));
-        assert!(is_utf8([0xF0, 0x90, 0x80, 0x80]));
-        assert!(is_utf8([0xF4, 0x8F, 0xBF, 0xBF]));
+        assert!(is_utf8(&[0xC2, 0x80]));
+        assert!(is_utf8(&[0xDF, 0xBF]));
+        assert!(is_utf8(&[0xE0, 0xA0, 0x80]));
+        assert!(is_utf8(&[0xED, 0x9F, 0xBF]));
+        assert!(is_utf8(&[0xEE, 0x80, 0x80]));
+        assert!(is_utf8(&[0xEF, 0xBF, 0xBF]));
+        assert!(is_utf8(&[0xF0, 0x90, 0x80, 0x80]));
+        assert!(is_utf8(&[0xF4, 0x8F, 0xBF, 0xBF]));
     }
 
     #[test]
@@ -1293,58 +1293,58 @@ mod tests {
         macro_rules! pos ( ($($e:expr),*) => { { $(assert!(is_utf16($e));)* } });
 
         // non-surrogates
-        pos!([0x0000],
-             [0x0001, 0x0002],
-             [0xD7FF],
-             [0xE000]);
+        pos!(&[0x0000],
+             &[0x0001, 0x0002],
+             &[0xD7FF],
+             &[0xE000]);
 
         // surrogate pairs (randomly generated with Python 3's
         // .encode('utf-16be'))
-        pos!([0xdb54, 0xdf16, 0xd880, 0xdee0, 0xdb6a, 0xdd45],
-             [0xd91f, 0xdeb1, 0xdb31, 0xdd84, 0xd8e2, 0xde14],
-             [0xdb9f, 0xdc26, 0xdb6f, 0xde58, 0xd850, 0xdfae]);
+        pos!(&[0xdb54, 0xdf16, 0xd880, 0xdee0, 0xdb6a, 0xdd45],
+             &[0xd91f, 0xdeb1, 0xdb31, 0xdd84, 0xd8e2, 0xde14],
+             &[0xdb9f, 0xdc26, 0xdb6f, 0xde58, 0xd850, 0xdfae]);
 
         // mixtures (also random)
-        pos!([0xd921, 0xdcc2, 0x002d, 0x004d, 0xdb32, 0xdf65],
-             [0xdb45, 0xdd2d, 0x006a, 0xdacd, 0xddfe, 0x0006],
-             [0x0067, 0xd8ff, 0xddb7, 0x000f, 0xd900, 0xdc80]);
+        pos!(&[0xd921, 0xdcc2, 0x002d, 0x004d, 0xdb32, 0xdf65],
+             &[0xdb45, 0xdd2d, 0x006a, 0xdacd, 0xddfe, 0x0006],
+             &[0x0067, 0xd8ff, 0xddb7, 0x000f, 0xd900, 0xdc80]);
 
         // negative tests
         macro_rules! neg ( ($($e:expr),*) => { { $(assert!(!is_utf16($e));)* } });
 
         neg!(
             // surrogate + regular unit
-            [0xdb45, 0x0000],
+            &[0xdb45, 0x0000],
             // surrogate + lead surrogate
-            [0xd900, 0xd900],
+            &[0xd900, 0xd900],
             // unterminated surrogate
-            [0xd8ff],
+            &[0xd8ff],
             // trail surrogate without a lead
-            [0xddb7]);
+            &[0xddb7]);
 
         // random byte sequences that Python 3's .decode('utf-16be')
         // failed on
-        neg!([0x5b3d, 0x0141, 0xde9e, 0x8fdc, 0xc6e7],
-             [0xdf5a, 0x82a5, 0x62b9, 0xb447, 0x92f3],
-             [0xda4e, 0x42bc, 0x4462, 0xee98, 0xc2ca],
-             [0xbe00, 0xb04a, 0x6ecb, 0xdd89, 0xe278],
-             [0x0465, 0xab56, 0xdbb6, 0xa893, 0x665e],
-             [0x6b7f, 0x0a19, 0x40f4, 0xa657, 0xdcc5],
-             [0x9b50, 0xda5e, 0x24ec, 0x03ad, 0x6dee],
-             [0x8d17, 0xcaa7, 0xf4ae, 0xdf6e, 0xbed7],
-             [0xdaee, 0x2584, 0x7d30, 0xa626, 0x121a],
-             [0xd956, 0x4b43, 0x7570, 0xccd6, 0x4f4a],
-             [0x9dcf, 0x1b49, 0x4ba5, 0xfce9, 0xdffe],
-             [0x6572, 0xce53, 0xb05a, 0xf6af, 0xdacf],
-             [0x1b90, 0x728c, 0x9906, 0xdb68, 0xf46e],
-             [0x1606, 0xbeca, 0xbe76, 0x860f, 0xdfa5],
-             [0x8b4f, 0xde7a, 0xd220, 0x9fac, 0x2b6f],
-             [0xb8fe, 0xebbe, 0xda32, 0x1a5f, 0x8b8b],
-             [0x934b, 0x8956, 0xc434, 0x1881, 0xddf7],
-             [0x5a95, 0x13fc, 0xf116, 0xd89b, 0x93f9],
-             [0xd640, 0x71f1, 0xdd7d, 0x77eb, 0x1cd8],
-             [0x348b, 0xaef0, 0xdb2c, 0xebf1, 0x1282],
-             [0x50d7, 0xd824, 0x5010, 0xb369, 0x22ea]);
+        neg!(&[0x5b3d, 0x0141, 0xde9e, 0x8fdc, 0xc6e7],
+             &[0xdf5a, 0x82a5, 0x62b9, 0xb447, 0x92f3],
+             &[0xda4e, 0x42bc, 0x4462, 0xee98, 0xc2ca],
+             &[0xbe00, 0xb04a, 0x6ecb, 0xdd89, 0xe278],
+             &[0x0465, 0xab56, 0xdbb6, 0xa893, 0x665e],
+             &[0x6b7f, 0x0a19, 0x40f4, 0xa657, 0xdcc5],
+             &[0x9b50, 0xda5e, 0x24ec, 0x03ad, 0x6dee],
+             &[0x8d17, 0xcaa7, 0xf4ae, 0xdf6e, 0xbed7],
+             &[0xdaee, 0x2584, 0x7d30, 0xa626, 0x121a],
+             &[0xd956, 0x4b43, 0x7570, 0xccd6, 0x4f4a],
+             &[0x9dcf, 0x1b49, 0x4ba5, 0xfce9, 0xdffe],
+             &[0x6572, 0xce53, 0xb05a, 0xf6af, 0xdacf],
+             &[0x1b90, 0x728c, 0x9906, 0xdb68, 0xf46e],
+             &[0x1606, 0xbeca, 0xbe76, 0x860f, 0xdfa5],
+             &[0x8b4f, 0xde7a, 0xd220, 0x9fac, 0x2b6f],
+             &[0xb8fe, 0xebbe, 0xda32, 0x1a5f, 0x8b8b],
+             &[0x934b, 0x8956, 0xc434, 0x1881, 0xddf7],
+             &[0x5a95, 0x13fc, 0xf116, 0xd89b, 0x93f9],
+             &[0xd640, 0x71f1, 0xdd7d, 0x77eb, 0x1cd8],
+             &[0x348b, 0xaef0, 0xdb2c, 0xebf1, 0x1282],
+             &[0x50d7, 0xd824, 0x5010, 0xb369, 0x22ea]);
     }
 
     #[test]
@@ -1456,22 +1456,22 @@ mod tests {
     fn test_truncate_utf16_at_nul() {
         let v = [];
         let b: &[u16] = &[];
-        assert_eq!(truncate_utf16_at_nul(v), b);
+        assert_eq!(truncate_utf16_at_nul(&v), b);
 
         let v = [0, 2, 3];
-        assert_eq!(truncate_utf16_at_nul(v), b);
+        assert_eq!(truncate_utf16_at_nul(&v), b);
 
         let v = [1, 0, 3];
         let b: &[u16] = &[1];
-        assert_eq!(truncate_utf16_at_nul(v), b);
+        assert_eq!(truncate_utf16_at_nul(&v), b);
 
         let v = [1, 2, 0];
         let b: &[u16] = &[1, 2];
-        assert_eq!(truncate_utf16_at_nul(v), b);
+        assert_eq!(truncate_utf16_at_nul(&v), b);
 
         let v = [1, 2, 3];
         let b: &[u16] = &[1, 2, 3];
-        assert_eq!(truncate_utf16_at_nul(v), b);
+        assert_eq!(truncate_utf16_at_nul(&v), b);
     }
 
     #[test]
@@ -1585,7 +1585,7 @@ mod tests {
     fn test_chars_decoding() {
         let mut bytes = [0u8, ..4];
         for c in range(0u32, 0x110000).filter_map(|c| ::core::char::from_u32(c)) {
-            let len = c.encode_utf8(bytes).unwrap_or(0);
+            let len = c.encode_utf8(&mut bytes).unwrap_or(0);
             let s = ::core::str::from_utf8(bytes[..len]).unwrap();
             if Some(c) != s.chars().next() {
                 panic!("character {:x}={} does not decode correctly", c as u32, c);
@@ -1597,7 +1597,7 @@ mod tests {
     fn test_chars_rev_decoding() {
         let mut bytes = [0u8, ..4];
         for c in range(0u32, 0x110000).filter_map(|c| ::core::char::from_u32(c)) {
-            let len = c.encode_utf8(bytes).unwrap_or(0);
+            let len = c.encode_utf8(&mut bytes).unwrap_or(0);
             let s = ::core::str::from_utf8(bytes[..len]).unwrap();
             if Some(c) != s.chars().rev().next() {
                 panic!("character {:x}={} does not decode correctly", c as u32, c);
@@ -2114,20 +2114,20 @@ mod tests {
             let v: Vec<&str> = s.split_str(sep).collect();
             assert_eq!(v.as_slice(), u.as_slice());
         }
-        t("--1233345--", "12345", ["--1233345--"]);
-        t("abc::hello::there", "::", ["abc", "hello", "there"]);
-        t("::hello::there", "::", ["", "hello", "there"]);
-        t("hello::there::", "::", ["hello", "there", ""]);
-        t("::hello::there::", "::", ["", "hello", "there", ""]);
-        t("ประเทศไทย中华Việt Nam", "中华", ["ประเทศไทย", "Việt Nam"]);
-        t("zzXXXzzYYYzz", "zz", ["", "XXX", "YYY", ""]);
-        t("zzXXXzYYYz", "XXX", ["zz", "zYYYz"]);
-        t(".XXX.YYY.", ".", ["", "XXX", "YYY", ""]);
-        t("", ".", [""]);
-        t("zz", "zz", ["",""]);
-        t("ok", "z", ["ok"]);
-        t("zzz", "zz", ["","z"]);
-        t("zzzzz", "zz", ["","","z"]);
+        t("--1233345--", "12345", &["--1233345--"]);
+        t("abc::hello::there", "::", &["abc", "hello", "there"]);
+        t("::hello::there", "::", &["", "hello", "there"]);
+        t("hello::there::", "::", &["hello", "there", ""]);
+        t("::hello::there::", "::", &["", "hello", "there", ""]);
+        t("ประเทศไทย中华Việt Nam", "中华", &["ประเทศไทย", "Việt Nam"]);
+        t("zzXXXzzYYYzz", "zz", &["", "XXX", "YYY", ""]);
+        t("zzXXXzYYYz", "XXX", &["zz", "zYYYz"]);
+        t(".XXX.YYY.", ".", &["", "XXX", "YYY", ""]);
+        t("", ".", &[""]);
+        t("zz", "zz", &["",""]);
+        t("ok", "z", &["ok"]);
+        t("zzz", "zz", &["","z"]);
+        t("zzzzz", "zz", &["","","z"]);
     }
 
     #[test]
@@ -2149,12 +2149,12 @@ mod tests {
         }
 
         let s = String::from_str("01234");
-        assert_eq!(5, sum_len(["012", "", "34"]));
-        assert_eq!(5, sum_len([String::from_str("01").as_slice(),
-                               String::from_str("2").as_slice(),
-                               String::from_str("34").as_slice(),
-                               String::from_str("").as_slice()]));
-        assert_eq!(5, sum_len([s.as_slice()]));
+        assert_eq!(5, sum_len(&["012", "", "34"]));
+        assert_eq!(5, sum_len(&[String::from_str("01").as_slice(),
+                                String::from_str("2").as_slice(),
+                                String::from_str("34").as_slice(),
+                                String::from_str("").as_slice()]));
+        assert_eq!(5, sum_len(&[s.as_slice()]));
     }
 
     #[test]

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -244,8 +244,8 @@ impl String {
     ///
     /// ```rust
     /// // 𝄞music
-    /// let mut v = [0xD834, 0xDD1E, 0x006d, 0x0075,
-    ///              0x0073, 0x0069, 0x0063];
+    /// let mut v = &mut [0xD834, 0xDD1E, 0x006d, 0x0075,
+    ///                   0x0073, 0x0069, 0x0063];
     /// assert_eq!(String::from_utf16(v), Some("𝄞music".to_string()));
     ///
     /// // 𝄞mu<invalid>ic
@@ -270,9 +270,9 @@ impl String {
     /// # Example
     /// ```rust
     /// // 𝄞mus<invalid>ic<invalid>
-    /// let v = [0xD834, 0xDD1E, 0x006d, 0x0075,
-    ///          0x0073, 0xDD1E, 0x0069, 0x0063,
-    ///          0xD834];
+    /// let v = &[0xD834, 0xDD1E, 0x006d, 0x0075,
+    ///           0x0073, 0xDD1E, 0x0069, 0x0063,
+    ///           0xD834];
     ///
     /// assert_eq!(String::from_utf16_lossy(v),
     ///            "𝄞mus\uFFFDic\uFFFD".to_string());
@@ -287,7 +287,7 @@ impl String {
     /// # Example
     ///
     /// ```rust
-    /// let chars = ['h', 'e', 'l', 'l', 'o'];
+    /// let chars = &['h', 'e', 'l', 'l', 'o'];
     /// let s = String::from_chars(chars);
     /// assert_eq!(s.as_slice(), "hello");
     /// ```
@@ -600,7 +600,7 @@ impl String {
         assert!(self.as_slice().is_char_boundary(idx));
         self.vec.reserve(4);
         let mut bits = [0, ..4];
-        let amt = ch.encode_utf8(bits).unwrap();
+        let amt = ch.encode_utf8(&mut bits).unwrap();
 
         unsafe {
             ptr::copy_memory(self.vec.as_mut_ptr().offset((idx + amt) as int),
@@ -1016,30 +1016,30 @@ mod tests {
     fn test_utf16_invalid() {
         // completely positive cases tested above.
         // lead + eof
-        assert_eq!(String::from_utf16([0xD800]), None);
+        assert_eq!(String::from_utf16(&[0xD800]), None);
         // lead + lead
-        assert_eq!(String::from_utf16([0xD800, 0xD800]), None);
+        assert_eq!(String::from_utf16(&[0xD800, 0xD800]), None);
 
         // isolated trail
-        assert_eq!(String::from_utf16([0x0061, 0xDC00]), None);
+        assert_eq!(String::from_utf16(&[0x0061, 0xDC00]), None);
 
         // general
-        assert_eq!(String::from_utf16([0xD800, 0xd801, 0xdc8b, 0xD800]), None);
+        assert_eq!(String::from_utf16(&[0xD800, 0xd801, 0xdc8b, 0xD800]), None);
     }
 
     #[test]
     fn test_from_utf16_lossy() {
         // completely positive cases tested above.
         // lead + eof
-        assert_eq!(String::from_utf16_lossy([0xD800]), String::from_str("\uFFFD"));
+        assert_eq!(String::from_utf16_lossy(&[0xD800]), String::from_str("\uFFFD"));
         // lead + lead
-        assert_eq!(String::from_utf16_lossy([0xD800, 0xD800]), String::from_str("\uFFFD\uFFFD"));
+        assert_eq!(String::from_utf16_lossy(&[0xD800, 0xD800]), String::from_str("\uFFFD\uFFFD"));
 
         // isolated trail
-        assert_eq!(String::from_utf16_lossy([0x0061, 0xDC00]), String::from_str("a\uFFFD"));
+        assert_eq!(String::from_utf16_lossy(&[0x0061, 0xDC00]), String::from_str("a\uFFFD"));
 
         // general
-        assert_eq!(String::from_utf16_lossy([0xD800, 0xd801, 0xdc8b, 0xD800]),
+        assert_eq!(String::from_utf16_lossy(&[0xD800, 0xd801, 0xdc8b, 0xD800]),
                    String::from_str("\uFFFD𐒋\uFFFD"));
     }
 
@@ -1066,7 +1066,7 @@ mod tests {
         let mut s = String::from_str("ABC");
         unsafe {
             let mv = s.as_mut_vec();
-            mv.push_all([b'D']);
+            mv.push_all(&[b'D']);
         }
         assert_eq!(s.as_slice(), "ABCD");
     }

--- a/src/libcollections/tree/set.rs
+++ b/src/libcollections/tree/set.rs
@@ -860,14 +860,14 @@ mod test {
             check(a, b, expected, |x, y, f| x.intersection(y).all(f))
         }
 
-        check_intersection([], [], []);
-        check_intersection([1, 2, 3], [], []);
-        check_intersection([], [1, 2, 3], []);
-        check_intersection([2], [1, 2, 3], [2]);
-        check_intersection([1, 2, 3], [2], [2]);
-        check_intersection([11, 1, 3, 77, 103, 5, -5],
-                           [2, 11, 77, -9, -42, 5, 3],
-                           [3, 5, 11, 77]);
+        check_intersection(&[], &[], &[]);
+        check_intersection(&[1, 2, 3], &[], &[]);
+        check_intersection(&[], &[1, 2, 3], &[]);
+        check_intersection(&[2], &[1, 2, 3], &[2]);
+        check_intersection(&[1, 2, 3], &[2], &[2]);
+        check_intersection(&[11, 1, 3, 77, 103, 5, -5],
+                           &[2, 11, 77, -9, -42, 5, 3],
+                           &[3, 5, 11, 77]);
     }
 
     #[test]
@@ -876,15 +876,15 @@ mod test {
             check(a, b, expected, |x, y, f| x.difference(y).all(f))
         }
 
-        check_difference([], [], []);
-        check_difference([1, 12], [], [1, 12]);
-        check_difference([], [1, 2, 3, 9], []);
-        check_difference([1, 3, 5, 9, 11],
-                         [3, 9],
-                         [1, 5, 11]);
-        check_difference([-5, 11, 22, 33, 40, 42],
-                         [-12, -5, 14, 23, 34, 38, 39, 50],
-                         [11, 22, 33, 40, 42]);
+        check_difference(&[], &[], &[]);
+        check_difference(&[1, 12], &[], &[1, 12]);
+        check_difference(&[], &[1, 2, 3, 9], &[]);
+        check_difference(&[1, 3, 5, 9, 11],
+                         &[3, 9],
+                         &[1, 5, 11]);
+        check_difference(&[-5, 11, 22, 33, 40, 42],
+                         &[-12, -5, 14, 23, 34, 38, 39, 50],
+                         &[11, 22, 33, 40, 42]);
     }
 
     #[test]
@@ -894,12 +894,12 @@ mod test {
             check(a, b, expected, |x, y, f| x.symmetric_difference(y).all(f))
         }
 
-        check_symmetric_difference([], [], []);
-        check_symmetric_difference([1, 2, 3], [2], [1, 3]);
-        check_symmetric_difference([2], [1, 2, 3], [1, 3]);
-        check_symmetric_difference([1, 3, 5, 9, 11],
-                                   [-2, 3, 9, 14, 22],
-                                   [-2, 1, 5, 11, 14, 22]);
+        check_symmetric_difference(&[], &[], &[]);
+        check_symmetric_difference(&[1, 2, 3], &[2], &[1, 3]);
+        check_symmetric_difference(&[2], &[1, 2, 3], &[1, 3]);
+        check_symmetric_difference(&[1, 3, 5, 9, 11],
+                                   &[-2, 3, 9, 14, 22],
+                                   &[-2, 1, 5, 11, 14, 22]);
     }
 
     #[test]
@@ -909,12 +909,12 @@ mod test {
             check(a, b, expected, |x, y, f| x.union(y).all(f))
         }
 
-        check_union([], [], []);
-        check_union([1, 2, 3], [2], [1, 2, 3]);
-        check_union([2], [1, 2, 3], [1, 2, 3]);
-        check_union([1, 3, 5, 9, 11, 16, 19, 24],
-                    [-2, 1, 5, 9, 13, 19],
-                    [-2, 1, 3, 5, 9, 11, 13, 16, 19, 24]);
+        check_union(&[], &[], &[]);
+        check_union(&[1, 2, 3], &[2], &[1, 2, 3]);
+        check_union(&[2], &[1, 2, 3], &[1, 2, 3]);
+        check_union(&[1, 3, 5, 9, 11, 16, 19, 24],
+                    &[-2, 1, 5, 9, 13, 19],
+                    &[-2, 1, 3, 5, 9, 11, 13, 16, 19, 24]);
     }
 
     #[test]

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -47,7 +47,7 @@ use slice::{CloneSliceAllocPrelude};
 /// vec[0] = 7i;
 /// assert_eq!(vec[0], 7);
 ///
-/// vec.push_all([1, 2, 3]);
+/// vec.push_all(&[1, 2, 3]);
 ///
 /// for x in vec.iter() {
 ///     println!("{}", x);
@@ -306,7 +306,7 @@ impl<T: Clone> Vec<T> {
     ///
     /// ```
     /// let mut vec = vec![1i];
-    /// vec.push_all([2i, 3, 4]);
+    /// vec.push_all(&[2i, 3, 4]);
     /// assert_eq!(vec, vec![1, 2, 3, 4]);
     /// ```
     #[inline]
@@ -639,7 +639,7 @@ impl<T> Vec<T> {
     ///
     /// ```
     /// let mut vec: Vec<int> = Vec::with_capacity(10);
-    /// vec.push_all([1, 2, 3]);
+    /// vec.push_all(&[1, 2, 3]);
     /// assert_eq!(vec.capacity(), 10);
     /// vec.shrink_to_fit();
     /// assert!(vec.capacity() >= 3);
@@ -1682,7 +1682,7 @@ mod tests {
     #[test]
     fn test_as_vec() {
         let xs = [1u8, 2u8, 3u8];
-        assert_eq!(as_vec(xs).as_slice(), xs.as_slice());
+        assert_eq!(as_vec(&xs).as_slice(), xs.as_slice());
     }
 
     #[test]
@@ -1772,13 +1772,13 @@ mod tests {
         let mut values = vec![1u8,2,3,4,5];
         {
             let slice = values.slice_from_mut(2);
-            assert!(slice == [3, 4, 5]);
+            assert!(slice == &mut [3, 4, 5]);
             for p in slice.iter_mut() {
                 *p += 2;
             }
         }
 
-        assert!(values.as_slice() == [1, 2, 5, 6, 7]);
+        assert!(values.as_slice() == &[1, 2, 5, 6, 7]);
     }
 
     #[test]
@@ -1786,13 +1786,13 @@ mod tests {
         let mut values = vec![1u8,2,3,4,5];
         {
             let slice = values.slice_to_mut(2);
-            assert!(slice == [1, 2]);
+            assert!(slice == &mut [1, 2]);
             for p in slice.iter_mut() {
                 *p += 1;
             }
         }
 
-        assert!(values.as_slice() == [2, 3, 3, 4, 5]);
+        assert!(values.as_slice() == &[2, 3, 3, 4, 5]);
     }
 
     #[test]

--- a/src/libcore/finally.rs
+++ b/src/libcore/finally.rs
@@ -79,7 +79,7 @@ impl<T> Finally<T> for fn() -> T {
  *
  * struct State<'a> { buffer: &'a mut [u8], len: uint }
  * # let mut buf = [];
- * let mut state = State { buffer: buf, len: 0 };
+ * let mut state = State { buffer: &mut buf, len: 0 };
  * try_finally(
  *     &mut state, (),
  *     |state, ()| {

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -315,7 +315,7 @@ pub fn float_to_str_bytes_common<T: Float, U>(
                 }
             }
 
-            let mut filler = Filler { buf: buf, end: &mut end };
+            let mut filler = Filler { buf: &mut buf, end: &mut end };
             match sign {
                 SignNeg => {
                     let _ = format_args!(|args| {

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -392,7 +392,7 @@ impl<'a> Formatter<'a> {
         let write_prefix = |f: &mut Formatter| {
             for c in sign.into_iter() {
                 let mut b = [0, ..4];
-                let n = c.encode_utf8(b).unwrap_or(0);
+                let n = c.encode_utf8(&mut b).unwrap_or(0);
                 try!(f.buf.write(b[..n]));
             }
             if prefixed { f.buf.write(prefix.as_bytes()) }
@@ -497,7 +497,7 @@ impl<'a> Formatter<'a> {
         };
 
         let mut fill = [0u8, ..4];
-        let len = self.fill.encode_utf8(fill).unwrap_or(0);
+        let len = self.fill.encode_utf8(&mut fill).unwrap_or(0);
 
         for _ in range(0, pre_pad) {
             try!(self.buf.write(fill[..len]));
@@ -586,7 +586,7 @@ impl Char for char {
         use char::Char;
 
         let mut utf8 = [0u8, ..4];
-        let amt = self.encode_utf8(utf8).unwrap_or(0);
+        let amt = self.encode_utf8(&mut utf8).unwrap_or(0);
         let s: &str = unsafe { mem::transmute(utf8[..amt]) };
         String::fmt(s, f)
     }

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -228,7 +228,7 @@ extern "rust-intrinsic" {
     /// use std::mem;
     ///
     /// let v: &[u8] = unsafe { mem::transmute("L") };
-    /// assert!(v == [76u8]);
+    /// assert!(v == &[76u8]);
     /// ```
     pub fn transmute<T,U>(e: T) -> U;
 

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -270,9 +270,9 @@ impl<T> Option<T> {
     /// let mut x = Some("Diamonds");
     /// {
     ///     let v = x.as_mut_slice();
-    ///     assert!(v == ["Diamonds"]);
+    ///     assert!(v == &mut ["Diamonds"]);
     ///     v[0] = "Dirt";
-    ///     assert!(v == ["Dirt"]);
+    ///     assert!(v == &mut ["Dirt"]);
     /// }
     /// assert_eq!(x, Some("Dirt"));
     /// ```

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -451,14 +451,14 @@ impl<T, E> Result<T, E> {
     /// let mut x: Result<&str, uint> = Ok("Gold");
     /// {
     ///     let v = x.as_mut_slice();
-    ///     assert!(v == ["Gold"]);
+    ///     assert!(v == &mut ["Gold"]);
     ///     v[0] = "Silver";
-    ///     assert!(v == ["Silver"]);
+    ///     assert!(v == &mut ["Silver"]);
     /// }
     /// assert_eq!(x, Ok("Silver"));
     ///
     /// let mut x: Result<&str, uint> = Err(45);
-    /// assert!(x.as_mut_slice() == []);
+    /// assert!(x.as_mut_slice() == &mut []);
     /// ```
     #[inline]
     #[unstable = "waiting for mut conventions"]

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -973,11 +973,11 @@ pub trait CloneSlicePrelude<T> for Sized? {
     /// let mut dst = [0i, 0, 0];
     /// let src = [1i, 2];
     ///
-    /// assert!(dst.clone_from_slice(src) == 2);
+    /// assert!(dst.clone_from_slice(&src) == 2);
     /// assert!(dst == [1, 2, 0]);
     ///
     /// let src2 = [3i, 4, 5, 6];
-    /// assert!(dst.clone_from_slice(src2) == 3);
+    /// assert!(dst.clone_from_slice(&src2) == 3);
     /// assert!(dst == [3i, 4, 5]);
     /// ```
     fn clone_from_slice(&mut self, &[T]) -> uint;

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1008,7 +1008,7 @@ impl<'a> Iterator<Utf16Item> for Utf16Items<'a> {
 ///          0x0073, 0xDD1E, 0x0069, 0x0063,
 ///          0xD834];
 ///
-/// assert_eq!(str::utf16_items(v).collect::<Vec<_>>(),
+/// assert_eq!(str::utf16_items(&v).collect::<Vec<_>>(),
 ///            vec![ScalarValue('𝄞'),
 ///                 ScalarValue('m'), ScalarValue('u'), ScalarValue('s'),
 ///                 LoneSurrogate(0xDD1E),
@@ -1030,12 +1030,12 @@ pub fn utf16_items<'a>(v: &'a [u16]) -> Utf16Items<'a> {
 /// // "abcd"
 /// let mut v = ['a' as u16, 'b' as u16, 'c' as u16, 'd' as u16];
 /// // no NULs so no change
-/// assert_eq!(str::truncate_utf16_at_nul(v), v.as_slice());
+/// assert_eq!(str::truncate_utf16_at_nul(&v), v.as_slice());
 ///
 /// // "ab\0d"
 /// v[2] = 0;
 /// let b: &[_] = &['a' as u16, 'b' as u16];
-/// assert_eq!(str::truncate_utf16_at_nul(v), b);
+/// assert_eq!(str::truncate_utf16_at_nul(&v), b);
 /// ```
 pub fn truncate_utf16_at_nul<'a>(v: &'a [u16]) -> &'a [u16] {
     match v.iter().position(|c| *c == 0) {

--- a/src/libcoretest/char.rs
+++ b/src/libcoretest/char.rs
@@ -177,10 +177,10 @@ fn test_encode_utf8() {
         assert_eq!(buf[..n], expect);
     }
 
-    check('x', [0x78]);
-    check('\u00e9', [0xc3, 0xa9]);
-    check('\ua66e', [0xea, 0x99, 0xae]);
-    check('\U0001f4a9', [0xf0, 0x9f, 0x92, 0xa9]);
+    check('x', &[0x78]);
+    check('\u00e9', &[0xc3, 0xa9]);
+    check('\ua66e', &[0xea, 0x99, 0xae]);
+    check('\U0001f4a9', &[0xf0, 0x9f, 0x92, 0xa9]);
 }
 
 #[test]
@@ -191,10 +191,10 @@ fn test_encode_utf16() {
         assert_eq!(buf[..n], expect);
     }
 
-    check('x', [0x0078]);
-    check('\u00e9', [0x00e9]);
-    check('\ua66e', [0xa66e]);
-    check('\U0001f4a9', [0xd83d, 0xdca9]);
+    check('x', &[0x0078]);
+    check('\u00e9', &[0x00e9]);
+    check('\ua66e', &[0xa66e]);
+    check('\U0001f4a9', &[0xd83d, 0xdca9]);
 }
 
 #[test]

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -627,7 +627,7 @@ fn test_random_access_zip() {
 #[test]
 fn test_random_access_take() {
     let xs = [1i, 2, 3, 4, 5];
-    let empty: &[int] = [];
+    let empty: &[int] = &[];
     check_randacc_iter(xs.iter().take(3), 3);
     check_randacc_iter(xs.iter().take(20), xs.len());
     check_randacc_iter(xs.iter().take(0), 0);
@@ -637,7 +637,7 @@ fn test_random_access_take() {
 #[test]
 fn test_random_access_skip() {
     let xs = [1i, 2, 3, 4, 5];
-    let empty: &[int] = [];
+    let empty: &[int] = &[];
     check_randacc_iter(xs.iter().skip(2), xs.len() - 2);
     check_randacc_iter(empty.iter().skip(2), 0);
 }
@@ -669,7 +669,7 @@ fn test_random_access_map() {
 #[test]
 fn test_random_access_cycle() {
     let xs = [1i, 2, 3, 4, 5];
-    let empty: &[int] = [];
+    let empty: &[int] = &[];
     check_randacc_iter(xs.iter().cycle().take(27), 27);
     check_randacc_iter(empty.iter().cycle(), 0);
 }

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -454,12 +454,12 @@ mod tests {
 
     #[test]
     fn simple() {
-        same("asdf", [String("asdf")]);
-        same("a{{b", [String("a"), String("{b")]);
-        same("a}}b", [String("a"), String("}b")]);
-        same("a}}", [String("a"), String("}")]);
-        same("}}", [String("}")]);
-        same("\\}}", [String("\\"), String("}")]);
+        same("asdf", &[String("asdf")]);
+        same("a{{b", &[String("a"), String("{b")]);
+        same("a}}b", &[String("a"), String("}b")]);
+        same("a}}", &[String("a"), String("}")]);
+        same("}}", &[String("}")]);
+        same("\\}}", &[String("\\"), String("}")]);
     }
 
     #[test] fn invalid01() { musterr("{") }
@@ -470,28 +470,28 @@ mod tests {
 
     #[test]
     fn format_nothing() {
-        same("{}", [NextArgument(Argument {
+        same("{}", &[NextArgument(Argument {
             position: ArgumentNext,
             format: fmtdflt(),
         })]);
     }
     #[test]
     fn format_position() {
-        same("{3}", [NextArgument(Argument {
+        same("{3}", &[NextArgument(Argument {
             position: ArgumentIs(3),
             format: fmtdflt(),
         })]);
     }
     #[test]
     fn format_position_nothing_else() {
-        same("{3:}", [NextArgument(Argument {
+        same("{3:}", &[NextArgument(Argument {
             position: ArgumentIs(3),
             format: fmtdflt(),
         })]);
     }
     #[test]
     fn format_type() {
-        same("{3:a}", [NextArgument(Argument {
+        same("{3:a}", &[NextArgument(Argument {
             position: ArgumentIs(3),
             format: FormatSpec {
                 fill: None,
@@ -505,7 +505,7 @@ mod tests {
     }
     #[test]
     fn format_align_fill() {
-        same("{3:>}", [NextArgument(Argument {
+        same("{3:>}", &[NextArgument(Argument {
             position: ArgumentIs(3),
             format: FormatSpec {
                 fill: None,
@@ -516,7 +516,7 @@ mod tests {
                 ty: "",
             },
         })]);
-        same("{3:0<}", [NextArgument(Argument {
+        same("{3:0<}", &[NextArgument(Argument {
             position: ArgumentIs(3),
             format: FormatSpec {
                 fill: Some('0'),
@@ -527,7 +527,7 @@ mod tests {
                 ty: "",
             },
         })]);
-        same("{3:*<abcd}", [NextArgument(Argument {
+        same("{3:*<abcd}", &[NextArgument(Argument {
             position: ArgumentIs(3),
             format: FormatSpec {
                 fill: Some('*'),
@@ -541,7 +541,7 @@ mod tests {
     }
     #[test]
     fn format_counts() {
-        same("{:10s}", [NextArgument(Argument {
+        same("{:10s}", &[NextArgument(Argument {
             position: ArgumentNext,
             format: FormatSpec {
                 fill: None,
@@ -552,7 +552,7 @@ mod tests {
                 ty: "s",
             },
         })]);
-        same("{:10$.10s}", [NextArgument(Argument {
+        same("{:10$.10s}", &[NextArgument(Argument {
             position: ArgumentNext,
             format: FormatSpec {
                 fill: None,
@@ -563,7 +563,7 @@ mod tests {
                 ty: "s",
             },
         })]);
-        same("{:.*s}", [NextArgument(Argument {
+        same("{:.*s}", &[NextArgument(Argument {
             position: ArgumentNext,
             format: FormatSpec {
                 fill: None,
@@ -574,7 +574,7 @@ mod tests {
                 ty: "s",
             },
         })]);
-        same("{:.10$s}", [NextArgument(Argument {
+        same("{:.10$s}", &[NextArgument(Argument {
             position: ArgumentNext,
             format: FormatSpec {
                 fill: None,
@@ -585,7 +585,7 @@ mod tests {
                 ty: "s",
             },
         })]);
-        same("{:a$.b$s}", [NextArgument(Argument {
+        same("{:a$.b$s}", &[NextArgument(Argument {
             position: ArgumentNext,
             format: FormatSpec {
                 fill: None,
@@ -599,7 +599,7 @@ mod tests {
     }
     #[test]
     fn format_flags() {
-        same("{:-}", [NextArgument(Argument {
+        same("{:-}", &[NextArgument(Argument {
             position: ArgumentNext,
             format: FormatSpec {
                 fill: None,
@@ -610,7 +610,7 @@ mod tests {
                 ty: "",
             },
         })]);
-        same("{:+#}", [NextArgument(Argument {
+        same("{:+#}", &[NextArgument(Argument {
             position: ArgumentNext,
             format: FormatSpec {
                 fill: None,
@@ -624,7 +624,7 @@ mod tests {
     }
     #[test]
     fn format_mixture() {
-        same("abcd {3:a} efg", [String("abcd "), NextArgument(Argument {
+        same("abcd {3:a} efg", &[String("abcd "), NextArgument(Argument {
             position: ArgumentIs(3),
             format: FormatSpec {
                 fill: None,

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -55,7 +55,7 @@
 //!
 //!     let program = args[0].clone();
 //!
-//!     let opts = [
+//!     let opts = &[
 //!         optopt("o", "", "set output file name", "NAME"),
 //!         optflag("h", "help", "print this help menu")
 //!     ];
@@ -942,16 +942,16 @@ fn test_split_within() {
         each_split_within(s, i, |s| { v.push(s.to_string()); true });
         assert!(v.iter().zip(u.iter()).all(|(a,b)| a == b));
     }
-    t("", 0, []);
-    t("", 15, []);
-    t("hello", 15, ["hello".to_string()]);
-    t("\nMary had a little lamb\nLittle lamb\n", 15, [
+    t("", 0, &[]);
+    t("", 15, &[]);
+    t("hello", 15, &["hello".to_string()]);
+    t("\nMary had a little lamb\nLittle lamb\n", 15, &[
         "Mary had a".to_string(),
         "little lamb".to_string(),
         "Little lamb".to_string()
     ]);
     t("\nMary had a little lamb\nLittle lamb\n", ::std::uint::MAX,
-        ["Mary had a little lamb\nLittle lamb".to_string()]);
+        &["Mary had a little lamb\nLittle lamb".to_string()]);
 }
 
 #[cfg(test)]
@@ -1414,17 +1414,17 @@ mod tests {
           result::Ok(m) => m,
           result::Err(_) => panic!()
         };
-        assert!(matches_single.opts_present(["e".to_string()]));
-        assert!(matches_single.opts_present(["encrypt".to_string(), "e".to_string()]));
-        assert!(matches_single.opts_present(["e".to_string(), "encrypt".to_string()]));
-        assert!(!matches_single.opts_present(["encrypt".to_string()]));
-        assert!(!matches_single.opts_present(["thing".to_string()]));
-        assert!(!matches_single.opts_present([]));
+        assert!(matches_single.opts_present(&["e".to_string()]));
+        assert!(matches_single.opts_present(&["encrypt".to_string(), "e".to_string()]));
+        assert!(matches_single.opts_present(&["e".to_string(), "encrypt".to_string()]));
+        assert!(!matches_single.opts_present(&["encrypt".to_string()]));
+        assert!(!matches_single.opts_present(&["thing".to_string()]));
+        assert!(!matches_single.opts_present(&[]));
 
-        assert_eq!(matches_single.opts_str(["e".to_string()]).unwrap(), "foo".to_string());
-        assert_eq!(matches_single.opts_str(["e".to_string(), "encrypt".to_string()]).unwrap(),
+        assert_eq!(matches_single.opts_str(&["e".to_string()]).unwrap(), "foo".to_string());
+        assert_eq!(matches_single.opts_str(&["e".to_string(), "encrypt".to_string()]).unwrap(),
                    "foo".to_string());
-        assert_eq!(matches_single.opts_str(["encrypt".to_string(), "e".to_string()]).unwrap(),
+        assert_eq!(matches_single.opts_str(&["encrypt".to_string(), "e".to_string()]).unwrap(),
                    "foo".to_string());
 
         let args_both = vec!("-e".to_string(), "foo".to_string(), "--encrypt".to_string(),
@@ -1434,19 +1434,19 @@ mod tests {
           result::Ok(m) => m,
           result::Err(_) => panic!()
         };
-        assert!(matches_both.opts_present(["e".to_string()]));
-        assert!(matches_both.opts_present(["encrypt".to_string()]));
-        assert!(matches_both.opts_present(["encrypt".to_string(), "e".to_string()]));
-        assert!(matches_both.opts_present(["e".to_string(), "encrypt".to_string()]));
-        assert!(!matches_both.opts_present(["f".to_string()]));
-        assert!(!matches_both.opts_present(["thing".to_string()]));
-        assert!(!matches_both.opts_present([]));
+        assert!(matches_both.opts_present(&["e".to_string()]));
+        assert!(matches_both.opts_present(&["encrypt".to_string()]));
+        assert!(matches_both.opts_present(&["encrypt".to_string(), "e".to_string()]));
+        assert!(matches_both.opts_present(&["e".to_string(), "encrypt".to_string()]));
+        assert!(!matches_both.opts_present(&["f".to_string()]));
+        assert!(!matches_both.opts_present(&["thing".to_string()]));
+        assert!(!matches_both.opts_present(&[]));
 
-        assert_eq!(matches_both.opts_str(["e".to_string()]).unwrap(), "foo".to_string());
-        assert_eq!(matches_both.opts_str(["encrypt".to_string()]).unwrap(), "foo".to_string());
-        assert_eq!(matches_both.opts_str(["e".to_string(), "encrypt".to_string()]).unwrap(),
+        assert_eq!(matches_both.opts_str(&["e".to_string()]).unwrap(), "foo".to_string());
+        assert_eq!(matches_both.opts_str(&["encrypt".to_string()]).unwrap(), "foo".to_string());
+        assert_eq!(matches_both.opts_str(&["e".to_string(), "encrypt".to_string()]).unwrap(),
                    "foo".to_string());
-        assert_eq!(matches_both.opts_str(["encrypt".to_string(), "e".to_string()]).unwrap(),
+        assert_eq!(matches_both.opts_str(&["encrypt".to_string(), "e".to_string()]).unwrap(),
                    "foo".to_string());
     }
 
@@ -1459,10 +1459,10 @@ mod tests {
           result::Ok(m) => m,
           result::Err(_) => panic!()
         };
-        assert!(matches.opts_present(["L".to_string()]));
-        assert_eq!(matches.opts_str(["L".to_string()]).unwrap(), "foo".to_string());
-        assert!(matches.opts_present(["M".to_string()]));
-        assert_eq!(matches.opts_str(["M".to_string()]).unwrap(), ".".to_string());
+        assert!(matches.opts_present(&["L".to_string()]));
+        assert_eq!(matches.opts_str(&["L".to_string()]).unwrap(), "foo".to_string());
+        assert!(matches.opts_present(&["M".to_string()]));
+        assert_eq!(matches.opts_str(&["M".to_string()]).unwrap(), ".".to_string());
 
     }
 
@@ -1475,9 +1475,9 @@ mod tests {
           result::Ok(m) => m,
           result::Err(e) => panic!( "{}", e )
         };
-        assert!(matches.opts_present(["L".to_string()]));
-        assert_eq!(matches.opts_str(["L".to_string()]).unwrap(), "verbose".to_string());
-        assert!(matches.opts_present(["v".to_string()]));
+        assert!(matches.opts_present(&["L".to_string()]));
+        assert_eq!(matches.opts_str(&["L".to_string()]).unwrap(), "verbose".to_string());
+        assert!(matches.opts_present(&["v".to_string()]));
         assert_eq!(3, matches.opt_count("v"));
     }
 

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -514,13 +514,13 @@ pub fn render<'a, N:'a, E:'a, G:Labeller<'a,N,E>+GraphWalk<'a,N,E>, W:Writer>(
         w.write_str("    ")
     }
 
-    try!(writeln(w, ["digraph ", g.graph_id().as_slice(), " {"]));
+    try!(writeln(w, &["digraph ", g.graph_id().as_slice(), " {"]));
     for n in g.nodes().iter() {
         try!(indent(w));
         let id = g.node_id(n);
         let escaped = g.node_label(n).escape();
-        try!(writeln(w, [id.as_slice(),
-                         "[label=\"", escaped.as_slice(), "\"];"]));
+        try!(writeln(w, &[id.as_slice(),
+                          "[label=\"", escaped.as_slice(), "\"];"]));
     }
 
     for e in g.edges().iter() {
@@ -530,11 +530,11 @@ pub fn render<'a, N:'a, E:'a, G:Labeller<'a,N,E>+GraphWalk<'a,N,E>, W:Writer>(
         let target = g.target(e);
         let source_id = g.node_id(&source);
         let target_id = g.node_id(&target);
-        try!(writeln(w, [source_id.as_slice(), " -> ", target_id.as_slice(),
-                         "[label=\"", escaped_label.as_slice(), "\"];"]));
+        try!(writeln(w, &[source_id.as_slice(), " -> ", target_id.as_slice(),
+                          "[label=\"", escaped_label.as_slice(), "\"];"]));
     }
 
-    writeln(w, ["}"])
+    writeln(w, &["}"])
 }
 
 #[cfg(test)]

--- a/src/libgreen/stack.rs
+++ b/src/libgreen/stack.rs
@@ -44,8 +44,8 @@ impl Stack {
         // allocation failure, which would fail to spawn the task. But there's
         // not many sensible things to do on OOM.  Failure seems fine (and is
         // what the old stack allocation did).
-        let stack = match MemoryMap::new(size, [MapReadable, MapWritable,
-                                         MapNonStandardFlags(STACK_FLAGS)]) {
+        let stack = match MemoryMap::new(size, &[MapReadable, MapWritable,
+                                                 MapNonStandardFlags(STACK_FLAGS)]) {
             Ok(map) => map,
             Err(e) => panic!("mmap for stack of size {} failed: {}", size, e)
         };

--- a/src/librand/distributions/mod.rs
+++ b/src/librand/distributions/mod.rs
@@ -349,7 +349,7 @@ mod tests {
 
     #[test] #[should_fail]
     fn test_weighted_choice_no_items() {
-        WeightedChoice::<int>::new([]);
+        WeightedChoice::<int>::new(&mut []);
     }
     #[test] #[should_fail]
     fn test_weighted_choice_zero_weight() {

--- a/src/librand/distributions/range.rs
+++ b/src/librand/distributions/range.rs
@@ -185,9 +185,9 @@ mod tests {
         macro_rules! t (
             ($($ty:ty),*) => {{
                 $(
-                   let v: &[($ty, $ty)] = [(0, 10),
-                                           (10, 127),
-                                           (Int::min_value(), Int::max_value())];
+                   let v: &[($ty, $ty)] = &[(0, 10),
+                                            (10, 127),
+                                            (Int::min_value(), Int::max_value())];
                    for &(low, high) in v.iter() {
                         let mut sampler: Range<$ty> = Range::new(low, high);
                         for _ in range(0u, 1000) {
@@ -210,10 +210,10 @@ mod tests {
         macro_rules! t (
             ($($ty:ty),*) => {{
                 $(
-                   let v: &[($ty, $ty)] = [(0.0, 100.0),
-                                           (-1e35, -1e25),
-                                           (1e-35, 1e-25),
-                                           (-1e35, 1e35)];
+                   let v: &[($ty, $ty)] = &[(0.0, 100.0),
+                                            (-1e35, -1e25),
+                                            (1e-35, 1e-25),
+                                            (-1e35, 1e35)];
                    for &(low, high) in v.iter() {
                         let mut sampler: Range<$ty> = Range::new(low, high);
                         for _ in range(0u, 1000) {

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -142,7 +142,7 @@ pub trait Rng {
     /// use std::rand::{task_rng, Rng};
     ///
     /// let mut v = [0u8, .. 13579];
-    /// task_rng().fill_bytes(v);
+    /// task_rng().fill_bytes(&mut v);
     /// println!("{}", v.as_slice());
     /// ```
     fn fill_bytes(&mut self, dest: &mut [u8]) {
@@ -268,7 +268,7 @@ pub trait Rng {
     ///
     /// let choices = [1i, 2, 4, 8, 16, 32];
     /// let mut rng = task_rng();
-    /// println!("{}", rng.choose(choices));
+    /// println!("{}", rng.choose(&choices));
     /// assert_eq!(rng.choose(choices[..0]), None);
     /// ```
     fn choose<'a, T>(&mut self, values: &'a [T]) -> Option<&'a T> {
@@ -288,9 +288,9 @@ pub trait Rng {
     ///
     /// let mut rng = task_rng();
     /// let mut y = [1i, 2, 3];
-    /// rng.shuffle(y);
+    /// rng.shuffle(&mut y);
     /// println!("{}", y.as_slice());
-    /// rng.shuffle(y);
+    /// rng.shuffle(&mut y);
     /// println!("{}", y.as_slice());
     /// ```
     fn shuffle<T>(&mut self, values: &mut [T]) {
@@ -347,7 +347,7 @@ pub trait SeedableRng<Seed>: Rng {
     /// let seed: &[_] = &[1, 2, 3, 4];
     /// let mut rng: StdRng = SeedableRng::from_seed(seed);
     /// println!("{}", rng.gen::<f64>());
-    /// rng.reseed([5, 6, 7, 8]);
+    /// rng.reseed(&[5, 6, 7, 8]);
     /// println!("{}", rng.gen::<f64>());
     /// ```
     fn reseed(&mut self, Seed);

--- a/src/librbml/io.rs
+++ b/src/librbml/io.rs
@@ -42,7 +42,7 @@ fn combine(seek: SeekStyle, cur: uint, end: uint, offset: i64) -> IoResult<u64> 
 /// use rbml::io::SeekableMemWriter;
 ///
 /// let mut w = SeekableMemWriter::new();
-/// w.write([0, 1, 2]);
+/// w.write(&[0, 1, 2]);
 ///
 /// assert_eq!(w.unwrap(), vec!(0, 1, 2));
 /// ```
@@ -138,32 +138,32 @@ mod tests {
     fn test_seekable_mem_writer() {
         let mut writer = SeekableMemWriter::new();
         assert_eq!(writer.tell(), Ok(0));
-        writer.write([0]).unwrap();
+        writer.write(&[0]).unwrap();
         assert_eq!(writer.tell(), Ok(1));
-        writer.write([1, 2, 3]).unwrap();
-        writer.write([4, 5, 6, 7]).unwrap();
+        writer.write(&[1, 2, 3]).unwrap();
+        writer.write(&[4, 5, 6, 7]).unwrap();
         assert_eq!(writer.tell(), Ok(8));
         let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7];
         assert_eq!(writer.get_ref(), b);
 
         writer.seek(0, io::SeekSet).unwrap();
         assert_eq!(writer.tell(), Ok(0));
-        writer.write([3, 4]).unwrap();
+        writer.write(&[3, 4]).unwrap();
         let b: &[_] = &[3, 4, 2, 3, 4, 5, 6, 7];
         assert_eq!(writer.get_ref(), b);
 
         writer.seek(1, io::SeekCur).unwrap();
-        writer.write([0, 1]).unwrap();
+        writer.write(&[0, 1]).unwrap();
         let b: &[_] = &[3, 4, 2, 0, 1, 5, 6, 7];
         assert_eq!(writer.get_ref(), b);
 
         writer.seek(-1, io::SeekEnd).unwrap();
-        writer.write([1, 2]).unwrap();
+        writer.write(&[1, 2]).unwrap();
         let b: &[_] = &[3, 4, 2, 0, 1, 5, 6, 1, 2];
         assert_eq!(writer.get_ref(), b);
 
         writer.seek(1, io::SeekEnd).unwrap();
-        writer.write([1]).unwrap();
+        writer.write(&[1]).unwrap();
         let b: &[_] = &[3, 4, 2, 0, 1, 5, 6, 1, 2, 0, 1];
         assert_eq!(writer.get_ref(), b);
     }
@@ -172,7 +172,7 @@ mod tests {
     fn seek_past_end() {
         let mut r = SeekableMemWriter::new();
         r.seek(10, io::SeekSet).unwrap();
-        assert!(r.write([3]).is_ok());
+        assert!(r.write(&[3]).is_ok());
     }
 
     #[test]

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -599,7 +599,7 @@ pub mod reader {
                           f: |&mut Decoder<'doc>, bool| -> DecodeResult<T>) -> DecodeResult<T> {
             debug!("read_option()");
             self.read_enum("Option", |this| {
-                this.read_enum_variant(["None", "Some"], |this, idx| {
+                this.read_enum_variant(&["None", "Some"], |this, idx| {
                     match idx {
                         0 => f(this, false),
                         1 => f(this, true),
@@ -1062,7 +1062,7 @@ mod tests {
 
     #[test]
     fn test_vuint_at() {
-        let data = [
+        let data = &[
             0x80,
             0xff,
             0x40, 0x00,

--- a/src/librustc/back/link.rs
+++ b/src/librustc/back/link.rs
@@ -879,7 +879,7 @@ fn link_args(cmd: &mut Command,
             v.push_all(morestack.as_vec());
             cmd.arg(v.as_slice());
         } else {
-            cmd.args(["-Wl,--whole-archive", "-lmorestack", "-Wl,--no-whole-archive"]);
+            cmd.args(&["-Wl,--whole-archive", "-lmorestack", "-Wl,--no-whole-archive"]);
         }
     }
 
@@ -997,7 +997,7 @@ fn link_args(cmd: &mut Command,
     if dylib {
         // On mac we need to tell the linker to let this library be rpathed
         if sess.target.target.options.is_like_osx {
-            cmd.args(["-dynamiclib", "-Wl,-dylib"]);
+            cmd.args(&["-dynamiclib", "-Wl,-dylib"]);
 
             if sess.opts.cg.rpath {
                 let mut v = "-Wl,-install_name,@rpath/".as_bytes().to_vec();

--- a/src/librustc/driver/config.rs
+++ b/src/librustc/driver/config.rs
@@ -886,11 +886,11 @@ mod test {
     #[test]
     fn test_switch_implies_cfg_test() {
         let matches =
-            &match getopts(["--test".to_string()], optgroups().as_slice()) {
+            &match getopts(&["--test".to_string()], optgroups().as_slice()) {
               Ok(m) => m,
               Err(f) => panic!("test_switch_implies_cfg_test: {}", f)
             };
-        let registry = diagnostics::registry::Registry::new([]);
+        let registry = diagnostics::registry::Registry::new(&[]);
         let sessopts = build_session_options(matches);
         let sess = build_session(sessopts, None, registry);
         let cfg = build_configuration(&sess);
@@ -902,14 +902,14 @@ mod test {
     #[test]
     fn test_switch_implies_cfg_test_unless_cfg_test() {
         let matches =
-            &match getopts(["--test".to_string(), "--cfg=test".to_string()],
+            &match getopts(&["--test".to_string(), "--cfg=test".to_string()],
                            optgroups().as_slice()) {
               Ok(m) => m,
               Err(f) => {
                 panic!("test_switch_implies_cfg_test_unless_cfg_test: {}", f)
               }
             };
-        let registry = diagnostics::registry::Registry::new([]);
+        let registry = diagnostics::registry::Registry::new(&[]);
         let sessopts = build_session_options(matches);
         let sess = build_session(sessopts, None, registry);
         let cfg = build_configuration(&sess);

--- a/src/librustc/driver/driver.rs
+++ b/src/librustc/driver/driver.rs
@@ -543,7 +543,7 @@ pub fn phase_5_run_llvm_passes(sess: &Session,
         let output_type = write::OutputTypeAssembly;
 
         time(sess.time_passes(), "LLVM passes", (), |_|
-            write::run_passes(sess, trans, [output_type], outputs));
+            write::run_passes(sess, trans, &[output_type], outputs));
 
         write::run_assembler(sess, outputs);
 

--- a/src/librustc/driver/mod.rs
+++ b/src/librustc/driver/mod.rs
@@ -48,7 +48,7 @@ fn run_compiler(args: &[String]) {
         None => return
     };
 
-    let descriptions = diagnostics::registry::Registry::new(super::DIAGNOSTICS);
+    let descriptions = diagnostics::registry::Registry::new(&super::DIAGNOSTICS);
     match matches.opt_str("explain") {
         Some(ref code) => {
             match descriptions.find_description(code.as_slice()) {

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -345,7 +345,7 @@ fn parse_str(st: &mut PState, term: char) -> String {
     let mut result = String::new();
     while peek(st) != term {
         unsafe {
-            result.as_mut_vec().push_all([next_byte(st)])
+            result.as_mut_vec().push_all(&[next_byte(st)])
         }
     }
     next(st);

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -748,10 +748,10 @@ impl<'a> vtable_decoder_helpers for reader::Decoder<'a> {
                           tcx: &ty::ctxt, cdata: &cstore::crate_metadata)
         -> typeck::vtable_origin {
         self.read_enum("vtable_origin", |this| {
-            this.read_enum_variant(["vtable_static",
-                                    "vtable_param",
-                                    "vtable_error",
-                                    "vtable_unboxed_closure"],
+            this.read_enum_variant(&["vtable_static",
+                                     "vtable_param",
+                                     "vtable_error",
+                                     "vtable_unboxed_closure"],
                                    |this, i| {
                 Ok(match i {
                   0 => {
@@ -1402,8 +1402,8 @@ impl<'a> rbml_decoder_decoder_helpers for reader::Decoder<'a> {
                           -> typeck::MethodOrigin
     {
         self.read_enum("MethodOrigin", |this| {
-            let variants = ["MethodStatic", "MethodStaticUnboxedClosure",
-                            "MethodTypeParam", "MethodTraitObject"];
+            let variants = &["MethodStatic", "MethodStaticUnboxedClosure",
+                             "MethodTypeParam", "MethodTraitObject"];
             this.read_enum_variant(variants, |this, i| {
                 Ok(match i {
                     0 => {
@@ -1577,7 +1577,7 @@ impl<'a> rbml_decoder_decoder_helpers for reader::Decoder<'a> {
     fn read_auto_adjustment(&mut self, dcx: &DecodeContext) -> ty::AutoAdjustment {
         self.read_enum("AutoAdjustment", |this| {
             let variants = ["AutoAddEnv", "AutoDerefRef"];
-            this.read_enum_variant(variants, |this, i| {
+            this.read_enum_variant(&variants, |this, i| {
                 Ok(match i {
                     0 => {
                         let store: ty::TraitStore =
@@ -1623,7 +1623,7 @@ impl<'a> rbml_decoder_decoder_helpers for reader::Decoder<'a> {
                             "AutoUnsize",
                             "AutoUnsizeUniq",
                             "AutoUnsafe"];
-            this.read_enum_variant(variants, |this, i| {
+            this.read_enum_variant(&variants, |this, i| {
                 Ok(match i {
                     0 => {
                         let r: ty::Region =
@@ -1677,7 +1677,7 @@ impl<'a> rbml_decoder_decoder_helpers for reader::Decoder<'a> {
 
     fn read_unsize_kind(&mut self, dcx: &DecodeContext) -> ty::UnsizeKind {
         self.read_enum("UnsizeKind", |this| {
-            let variants = ["UnsizeLength", "UnsizeStruct", "UnsizeVtable"];
+            let variants = &["UnsizeLength", "UnsizeStruct", "UnsizeVtable"];
             this.read_enum_variant(variants, |this, i| {
                 Ok(match i {
                     0 => {
@@ -1727,7 +1727,7 @@ impl<'a> rbml_decoder_decoder_helpers for reader::Decoder<'a> {
                 dcx.tcx,
                 |s, a| this.convert_def_id(dcx, s, a)))
         }).unwrap();
-        let variants = [
+        let variants = &[
             "FnUnboxedClosureKind",
             "FnMutUnboxedClosureKind",
             "FnOnceUnboxedClosureKind"

--- a/src/librustc/middle/cfg/graphviz.rs
+++ b/src/librustc/middle/cfg/graphviz.rs
@@ -40,7 +40,7 @@ fn replace_newline_with_backslash_l(s: String) -> String {
         let mut last_two: Vec<_> =
             s.as_slice().chars().rev().take(2).collect();
         last_two.reverse();
-        if last_two.as_slice() != ['\\', 'l'] {
+        if last_two.as_slice() != &['\\', 'l'] {
             s.push_str("\\l");
         }
         s

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -932,7 +932,7 @@ fn check_fn(cx: &mut MatchCheckCtxt,
 
 fn is_refutable<A>(cx: &MatchCheckCtxt, pat: &Pat, refutable: |&Pat| -> A) -> Option<A> {
     let pats = Matrix(vec!(vec!(pat)));
-    match is_useful(cx, &pats, [DUMMY_WILD_PAT], ConstructWitness) {
+    match is_useful(cx, &pats, &[DUMMY_WILD_PAT], ConstructWitness) {
         UsefulWithWitness(pats) => {
             assert_eq!(pats.len(), 1);
             Some(refutable(&*pats[0]))

--- a/src/librustc/middle/graph.rs
+++ b/src/librustc/middle/graph.rs
@@ -419,31 +419,31 @@ mod test {
     fn each_adjacent_from_a() {
         let graph = create_graph();
         test_adjacent_edges(&graph, NodeIndex(0), "A",
-                            [],
-                            [("AB", "B")]);
+                            &[],
+                            &[("AB", "B")]);
     }
 
     #[test]
     fn each_adjacent_from_b() {
         let graph = create_graph();
         test_adjacent_edges(&graph, NodeIndex(1), "B",
-                            [("FB", "F"), ("AB", "A"),],
-                            [("BD", "D"), ("BC", "C"),]);
+                            &[("FB", "F"), ("AB", "A"),],
+                            &[("BD", "D"), ("BC", "C"),]);
     }
 
     #[test]
     fn each_adjacent_from_c() {
         let graph = create_graph();
         test_adjacent_edges(&graph, NodeIndex(2), "C",
-                            [("EC", "E"), ("BC", "B")],
-                            []);
+                            &[("EC", "E"), ("BC", "B")],
+                            &[]);
     }
 
     #[test]
     fn each_adjacent_from_d() {
         let graph = create_graph();
         test_adjacent_edges(&graph, NodeIndex(3), "D",
-                            [("BD", "B")],
-                            [("DE", "E")]);
+                            &[("BD", "B")],
+                            &[("DE", "E")]);
     }
 }

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -57,7 +57,7 @@ pub fn supertraits<'cx, 'tcx>(tcx: &'cx ty::ctxt<'tcx>,
      * `supertraits(Baz)` yields `[Baz, Bar, Foo, Foo]` in some order.
      */
 
-    transitive_bounds(tcx, [trait_ref])
+    transitive_bounds(tcx, &[trait_ref])
 }
 
 pub fn transitive_bounds<'cx, 'tcx>(tcx: &'cx ty::ctxt<'tcx>,

--- a/src/librustc/middle/trans/_match.rs
+++ b/src/librustc/middle/trans/_match.rs
@@ -643,8 +643,8 @@ fn bind_subslice_pat(bcx: Block,
                                 ty::mt {ty: vt.unit_ty, mutbl: ast::MutImmutable});
     let scratch = rvalue_scratch_datum(bcx, slice_ty, "");
     Store(bcx, slice_begin,
-          GEPi(bcx, scratch.val, [0u, abi::slice_elt_base]));
-    Store(bcx, slice_len, GEPi(bcx, scratch.val, [0u, abi::slice_elt_len]));
+          GEPi(bcx, scratch.val, &[0u, abi::slice_elt_base]));
+    Store(bcx, slice_len, GEPi(bcx, scratch.val, &[0u, abi::slice_elt_len]));
     scratch.val
 }
 
@@ -658,9 +658,9 @@ fn extract_vec_elems<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let vec_datum = match_datum(val, left_ty);
     let (base, len) = vec_datum.get_vec_base_and_len(bcx);
     let mut elems = vec![];
-    elems.extend(range(0, before).map(|i| GEPi(bcx, base, [i])));
+    elems.extend(range(0, before).map(|i| GEPi(bcx, base, &[i])));
     elems.extend(range(0, after).rev().map(|i| {
-        InBoundsGEP(bcx, base, [
+        InBoundsGEP(bcx, base, &[
             Sub(bcx, len, C_uint(bcx.ccx(), i + 1))
         ])
     }));
@@ -796,7 +796,7 @@ fn compare_values<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
                            format!("comparison of `{}`",
                                    cx.ty_to_string(rhs_t)).as_slice(),
                            StrEqFnLangItem);
-        callee::trans_lang_call(cx, did, [lhs, rhs], None)
+        callee::trans_lang_call(cx, did, &[lhs, rhs], None)
     }
 
     let _icx = push_ctxt("compare_values");
@@ -1390,7 +1390,7 @@ fn trans_match_inner<'blk, 'tcx>(scope_cx: Block<'blk, 'tcx>,
         && arm.pats.last().unwrap().node == ast::PatWild(ast::PatWildSingle)
     });
 
-    compile_submatch(bcx, matches.as_slice(), [discr_datum.val], &chk, has_default);
+    compile_submatch(bcx, matches.as_slice(), &[discr_datum.val], &chk, has_default);
 
     let mut arm_cxs = Vec::new();
     for arm_data in arm_datas.iter() {

--- a/src/librustc/middle/trans/adt.rs
+++ b/src/librustc/middle/trans/adt.rs
@@ -635,7 +635,7 @@ pub fn trans_get_discr(bcx: Block, r: &Repr, scrutinee: ValueRef, cast_to: Optio
             signed = ity.is_signed();
         }
         General(ity, ref cases, _) => {
-            let ptr = GEPi(bcx, scrutinee, [0, 0]);
+            let ptr = GEPi(bcx, scrutinee, &[0, 0]);
             val = load_discr(bcx, ity, ptr, 0, (cases.len() - 1) as Disr);
             signed = ity.is_signed();
         }
@@ -663,8 +663,8 @@ pub fn trans_get_discr(bcx: Block, r: &Repr, scrutinee: ValueRef, cast_to: Optio
 fn struct_wrapped_nullable_bitdiscr(bcx: Block, nndiscr: Disr, ptrfield: PointerField,
                                     scrutinee: ValueRef) -> ValueRef {
     let llptrptr = match ptrfield {
-        ThinPointer(field) => GEPi(bcx, scrutinee, [0, field]),
-        FatPointer(field) => GEPi(bcx, scrutinee, [0, field, slice_elt_base])
+        ThinPointer(field) => GEPi(bcx, scrutinee, &[0, field]),
+        FatPointer(field) => GEPi(bcx, scrutinee, &[0, field, slice_elt_base])
     };
     let llptr = Load(bcx, llptrptr);
     let cmp = if nndiscr == 0 { IntEQ } else { IntNE };
@@ -739,13 +739,13 @@ pub fn trans_set_discr(bcx: Block, r: &Repr, val: ValueRef, discr: Disr) {
                 Store(bcx, C_u8(bcx.ccx(), 1), ptr);
             }
             Store(bcx, C_integral(ll_inttype(bcx.ccx(), ity), discr as u64, true),
-                  GEPi(bcx, val, [0, 0]))
+                  GEPi(bcx, val, &[0, 0]))
         }
         Univariant(ref st, dtor) => {
             assert_eq!(discr, 0);
             if dtor {
                 Store(bcx, C_u8(bcx.ccx(), 1),
-                    GEPi(bcx, val, [0, st.fields.len() - 1]));
+                    GEPi(bcx, val, &[0, st.fields.len() - 1]));
             }
         }
         RawNullablePointer { nndiscr, nnty, ..} => {
@@ -758,10 +758,10 @@ pub fn trans_set_discr(bcx: Block, r: &Repr, val: ValueRef, discr: Disr) {
             if discr != nndiscr {
                 let (llptrptr, llptrty) = match ptrfield {
                     ThinPointer(field) =>
-                        (GEPi(bcx, val, [0, field]),
+                        (GEPi(bcx, val, &[0, field]),
                          type_of::type_of(bcx.ccx(), nonnull.fields[field])),
                     FatPointer(field) => {
-                        let v = GEPi(bcx, val, [0, field, slice_elt_base]);
+                        let v = GEPi(bcx, val, &[0, field, slice_elt_base]);
                         (v, val_ty(v).element_type())
                     }
                 };
@@ -853,7 +853,7 @@ pub fn struct_field_ptr(bcx: Block, st: &Struct, val: ValueRef,
         val
     };
 
-    GEPi(bcx, val, [0, ix])
+    GEPi(bcx, val, &[0, ix])
 }
 
 pub fn fold_variants<'blk, 'tcx>(
@@ -902,7 +902,7 @@ pub fn trans_drop_flag_ptr<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>, r: &Repr, val
     let ptr_ty = ty::mk_imm_ptr(bcx.tcx(), ty::mk_bool());
     match *r {
         Univariant(ref st, true) => {
-            let flag_ptr = GEPi(bcx, val, [0, st.fields.len() - 1]);
+            let flag_ptr = GEPi(bcx, val, &[0, st.fields.len() - 1]);
             datum::immediate_rvalue_bcx(bcx, flag_ptr, ptr_ty).to_expr_datumblock()
         }
         General(_, _, true) => {
@@ -961,7 +961,7 @@ pub fn trans_const(ccx: &CrateContext, r: &Repr, discr: Disr,
             let mut f = vec![lldiscr];
             f.push_all(vals);
             let mut contents = build_const_struct(ccx, case, f.as_slice());
-            contents.push_all([padding(ccx, max_sz - case.size)]);
+            contents.push_all(&[padding(ccx, max_sz - case.size)]);
             C_struct(ccx, contents.as_slice(), false)
         }
         Univariant(ref st, _dro) => {
@@ -1079,8 +1079,8 @@ pub fn const_get_discrim(ccx: &CrateContext, r: &Repr, val: ValueRef)
         }
         General(ity, _, _) => {
             match ity {
-                attr::SignedInt(..) => const_to_int(const_get_elt(ccx, val, [0])) as Disr,
-                attr::UnsignedInt(..) => const_to_uint(const_get_elt(ccx, val, [0])) as Disr
+                attr::SignedInt(..) => const_to_int(const_get_elt(ccx, val, &[0])) as Disr,
+                attr::UnsignedInt(..) => const_to_uint(const_get_elt(ccx, val, &[0])) as Disr
             }
         }
         Univariant(..) => 0,
@@ -1138,8 +1138,8 @@ fn const_struct_field(ccx: &CrateContext, val: ValueRef, ix: uint, sub_idx: Opti
     loop {
         loop {
             field = match sub_idx {
-                Some(si) => const_get_elt(ccx, val, [real_ix, si as u32]),
-                None => const_get_elt(ccx, val, [real_ix])
+                Some(si) => const_get_elt(ccx, val, &[real_ix, si as u32]),
+                None => const_get_elt(ccx, val, &[real_ix])
             };
             if !is_undef(field) {
                 break;

--- a/src/librustc/middle/trans/builder.rs
+++ b/src/librustc/middle/trans/builder.rs
@@ -776,11 +776,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             self.count_insn("inlineasm");
             let asm = comment_text.as_slice().with_c_str(|c| {
                 unsafe {
-                    llvm::LLVMConstInlineAsm(Type::func([], &Type::void(self.ccx)).to_ref(),
+                    llvm::LLVMConstInlineAsm(Type::func(&[], &Type::void(self.ccx)).to_ref(),
                                              c, noname(), False, False)
                 }
             });
-            self.call(asm, [], None);
+            self.call(asm, &[], None);
         }
     }
 
@@ -930,7 +930,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 llvm::LLVMGetNamedFunction(m, buf)
             });
             assert!((t as int != 0));
-            let args: &[ValueRef] = [];
+            let args: &[ValueRef] = &[];
             self.count_insn("trap");
             llvm::LLVMBuildCall(
                 self.llbuilder, t, args.as_ptr(), args.len() as c_uint, noname());

--- a/src/librustc/middle/trans/callee.rs
+++ b/src/librustc/middle/trans/callee.rs
@@ -721,9 +721,9 @@ pub fn trans_call_inner<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             // Closures are represented as (llfn, llclosure) pair:
             // load the requisite values out.
             let pair = d.to_llref();
-            let llfn = GEPi(bcx, pair, [0u, abi::fn_field_code]);
+            let llfn = GEPi(bcx, pair, &[0u, abi::fn_field_code]);
             let llfn = Load(bcx, llfn);
-            let llenv = GEPi(bcx, pair, [0u, abi::fn_field_box]);
+            let llenv = GEPi(bcx, pair, &[0u, abi::fn_field_box]);
             let llenv = Load(bcx, llenv);
             (llfn, Some(llenv), None)
         }

--- a/src/librustc/middle/trans/cleanup.rs
+++ b/src/librustc/middle/trans/cleanup.rs
@@ -785,7 +785,7 @@ impl<'blk, 'tcx> CleanupHelperMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx
         // this represents but it's determined by the personality function and
         // this is what the EH proposal example uses.
         let llretty = Type::struct_(self.ccx,
-                                    [Type::i8p(self.ccx), Type::i32(self.ccx)],
+                                    &[Type::i8p(self.ccx), Type::i32(self.ccx)],
                                     false);
 
         // The exception handling personality function.

--- a/src/librustc/middle/trans/closure.rs
+++ b/src/librustc/middle/trans/closure.rs
@@ -207,7 +207,7 @@ pub fn store_environment<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                      bv.to_string(ccx)).as_slice());
         }
 
-        let bound_data = GEPi(bcx, llbox, [0u, abi::box_field_body, i]);
+        let bound_data = GEPi(bcx, llbox, &[0u, abi::box_field_body, i]);
 
         match bv.action {
             ast::CaptureByValue => {
@@ -275,7 +275,7 @@ fn load_environment<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     // Populate the upvars from the environment
     let mut i = 0u;
     for freevar in freevars.iter() {
-        let mut upvarptr = GEPi(bcx, llcdata, [0u, i]);
+        let mut upvarptr = GEPi(bcx, llcdata, &[0u, i]);
         match store {
             ty::RegionTraitStore(..) => { upvarptr = Load(bcx, upvarptr); }
             ty::UniqTraitStore => {}
@@ -329,7 +329,7 @@ fn load_unboxed_closure_environment<'blk, 'tcx>(
     };
 
     for (i, freevar) in freevars.iter().enumerate() {
-        let mut upvar_ptr = GEPi(bcx, llenv, [0, i]);
+        let mut upvar_ptr = GEPi(bcx, llenv, &[0, i]);
         if freevar_mode == ast::CaptureByRef {
             upvar_ptr = Load(bcx, upvar_ptr);
         }
@@ -347,9 +347,9 @@ fn load_unboxed_closure_environment<'blk, 'tcx>(
 }
 
 fn fill_fn_pair(bcx: Block, pair: ValueRef, llfn: ValueRef, llenvptr: ValueRef) {
-    Store(bcx, llfn, GEPi(bcx, pair, [0u, abi::fn_field_code]));
+    Store(bcx, llfn, GEPi(bcx, pair, &[0u, abi::fn_field_code]));
     let llenvptr = PointerCast(bcx, llenvptr, Type::i8p(bcx.ccx()));
-    Store(bcx, llenvptr, GEPi(bcx, pair, [0u, abi::fn_field_box]));
+    Store(bcx, llenvptr, GEPi(bcx, pair, &[0u, abi::fn_field_box]));
 }
 
 pub fn trans_expr_fn<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
@@ -407,7 +407,7 @@ pub fn trans_expr_fn<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                   llfn,
                   bcx.fcx.param_substs,
                   id,
-                  [],
+                  &[],
                   ty::ty_fn_ret(fty),
                   ty::ty_fn_abi(fty),
                   true,
@@ -504,7 +504,7 @@ pub fn trans_unboxed_closure<'blk, 'tcx>(
                   llfn,
                   bcx.fcx.param_substs,
                   id,
-                  [],
+                  &[],
                   ty::ty_fn_ret(function_type),
                   ty::ty_fn_abi(function_type),
                   true,

--- a/src/librustc/middle/trans/common.rs
+++ b/src/librustc/middle/trans/common.rs
@@ -581,7 +581,7 @@ pub fn C_floating(s: &str, t: Type) -> ValueRef {
 }
 
 pub fn C_nil(ccx: &CrateContext) -> ValueRef {
-    C_struct(ccx, [], false)
+    C_struct(ccx, &[], false)
 }
 
 pub fn C_bool(ccx: &CrateContext, val: bool) -> ValueRef {
@@ -676,7 +676,7 @@ pub fn C_str_slice(cx: &CrateContext, s: InternedString) -> ValueRef {
         let len = s.get().len();
         let cs = llvm::LLVMConstPointerCast(C_cstr(cx, s, false),
                                             Type::i8p(cx).to_ref());
-        C_named_struct(cx.tn().find_type("str_slice").unwrap(), [cs, C_uint(cx, len)])
+        C_named_struct(cx.tn().find_type("str_slice").unwrap(), &[cs, C_uint(cx, len)])
     }
 }
 
@@ -694,7 +694,7 @@ pub fn C_binary_slice(cx: &CrateContext, data: &[u8]) -> ValueRef {
         llvm::SetLinkage(g, llvm::InternalLinkage);
 
         let cs = llvm::LLVMConstPointerCast(g, Type::i8p(cx).to_ref());
-        C_struct(cx, [cs, C_uint(cx, len)], false)
+        C_struct(cx, &[cs, C_uint(cx, len)], false)
     }
 }
 

--- a/src/librustc/middle/trans/consts.rs
+++ b/src/librustc/middle/trans/consts.rs
@@ -204,7 +204,7 @@ pub fn const_expr(cx: &CrateContext, e: &ast::Expr) -> (ValueRef, ty::t) {
                                                                    def,
                                                                    llconst,
                                                                    true);
-                    llconst = C_struct(cx, [wrapper, C_null(Type::i8p(cx))], false)
+                    llconst = C_struct(cx, &[wrapper, C_null(Type::i8p(cx))], false)
                 }
                 ty::AdjustAddEnv(store) => {
                     cx.sess()
@@ -264,7 +264,7 @@ pub fn const_expr(cx: &CrateContext, e: &ast::Expr) -> (ValueRef, ty::t) {
                                             let llptr = const_ptrcast(cx, llconst, llunitty);
                                             assert_eq!(abi::slice_elt_base, 0);
                                             assert_eq!(abi::slice_elt_len, 1);
-                                            llconst = C_struct(cx, [
+                                            llconst = C_struct(cx, &[
                                                 llptr,
                                                 C_uint(cx, len)
                                             ], false);
@@ -444,8 +444,8 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr) -> ValueRef {
                   ty::ty_vec(_, Some(u)) => (bv, C_uint(cx, u)),
                   ty::ty_open(ty) => match ty::get(ty).sty {
                       ty::ty_vec(_, None) | ty::ty_str => {
-                          let e1 = const_get_elt(cx, bv, [0]);
-                          (const_deref_ptr(cx, e1), const_get_elt(cx, bv, [1]))
+                          let e1 = const_get_elt(cx, bv, &[0]);
+                          (const_deref_ptr(cx, e1), const_get_elt(cx, bv, &[1]))
                       },
                       _ => cx.sess().span_bug(base.span,
                                               format!("index-expr base must be a vector \
@@ -484,7 +484,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr) -> ValueRef {
                   cx.sess().span_err(e.span,
                                      "const index-expr is out of bounds");
               }
-              const_get_elt(cx, arr, [iv as c_uint])
+              const_get_elt(cx, arr, &[iv as c_uint])
           }
           ast::ExprCast(ref base, _) => {
             let ety = ty::expr_ty(cx.tcx(), e);
@@ -646,7 +646,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr) -> ValueRef {
                     let vinfo = ty::enum_variant_with_id(cx.tcx(),
                                                          enum_did,
                                                          variant_did);
-                    adt::trans_const(cx, &*repr, vinfo.disr_val, [])
+                    adt::trans_const(cx, &*repr, vinfo.disr_val, &[])
                 }
                 Some(def::DefStruct(_)) => {
                     let ety = ty::expr_ty(cx.tcx(), e);

--- a/src/librustc/middle/trans/context.rs
+++ b/src/librustc/middle/trans/context.rs
@@ -434,7 +434,7 @@ impl LocalCrateContext {
                 let ccx = local_ccx.dummy_ccx(shared);
 
                 let mut str_slice_ty = Type::named_struct(&ccx, "str_slice");
-                str_slice_ty.set_struct_body([Type::i8p(&ccx), ccx.int_type()], false);
+                str_slice_ty.set_struct_body(&[Type::i8p(&ccx), ccx.int_type()], false);
                 ccx.tn().associate_type("str_slice", &str_slice_ty);
 
                 ccx.tn().associate_type("tydesc", &Type::tydesc(&ccx, str_slice_ty));
@@ -719,7 +719,7 @@ fn declare_intrinsic(ccx: &CrateContext, key: & &'static str) -> Option<ValueRef
         ($name:expr fn() -> $ret:expr) => (
             if *key == $name {
                 let f = base::decl_cdecl_fn(
-                    ccx, $name, Type::func([], &$ret),
+                    ccx, $name, Type::func(&[], &$ret),
                     ty::mk_nil(ccx.tcx()));
                 ccx.intrinsics().borrow_mut().insert($name, f.clone());
                 return Some(f);
@@ -728,14 +728,14 @@ fn declare_intrinsic(ccx: &CrateContext, key: & &'static str) -> Option<ValueRef
         ($name:expr fn($($arg:expr),*) -> $ret:expr) => (
             if *key == $name {
                 let f = base::decl_cdecl_fn(ccx, $name,
-                                  Type::func([$($arg),*], &$ret), ty::mk_nil(ccx.tcx()));
+                                  Type::func(&[$($arg),*], &$ret), ty::mk_nil(ccx.tcx()));
                 ccx.intrinsics().borrow_mut().insert($name, f.clone());
                 return Some(f);
             }
         )
     )
     macro_rules! mk_struct (
-        ($($field_ty:expr),*) => (Type::struct_(ccx, [$($field_ty),*], false))
+        ($($field_ty:expr),*) => (Type::struct_(ccx, &[$($field_ty),*], false))
     )
 
     let i8p = Type::i8p(ccx);
@@ -864,7 +864,7 @@ fn declare_intrinsic(ccx: &CrateContext, key: & &'static str) -> Option<ValueRef
                 ifn!($name fn($($arg),*) -> $ret);
             } else if *key == $name {
                 let f = base::decl_cdecl_fn(ccx, stringify!($cname),
-                                      Type::func([$($arg),*], &$ret),
+                                      Type::func(&[$($arg),*], &$ret),
                                       ty::mk_nil(ccx.tcx()));
                 ccx.intrinsics().borrow_mut().insert($name, f.clone());
                 return Some(f);

--- a/src/librustc/middle/trans/controlflow.rs
+++ b/src/librustc/middle/trans/controlflow.rs
@@ -189,7 +189,7 @@ pub fn trans_if<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             let else_bcx_in = bcx.fcx.new_id_block("else-block", elexpr.id);
             let else_bcx_out = expr::trans_into(else_bcx_in, &*elexpr, dest);
             next_bcx = bcx.fcx.join_blocks(if_id,
-                                           [then_bcx_out, else_bcx_out]);
+                                           &[then_bcx_out, else_bcx_out]);
             CondBr(bcx, cond_val, then_bcx_in.llbb, else_bcx_in.llbb);
         }
 
@@ -324,7 +324,7 @@ pub fn trans_for<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                                              None,
                                              arg_cleanup_scope)
                                      },
-                                     callee::ArgVals([lliterator]),
+                                     callee::ArgVals(&[lliterator]),
                                      Some(expr::SaveIn(lloption)));
         bcx
     }));

--- a/src/librustc/middle/trans/debuginfo.rs
+++ b/src/librustc/middle/trans/debuginfo.rs
@@ -985,7 +985,7 @@ pub fn create_match_binding_metadata(bcx: Block,
         },
         TrByMove => IndirectVariable {
             alloca: binding.llmatch,
-            address_operations: aops
+            address_operations: &aops
         },
         TrByRef => DirectVariable {
             alloca: binding.llmatch
@@ -1368,7 +1368,7 @@ pub fn create_function_debug_context(cx: &CrateContext,
                               param_substs: &param_substs,
                               error_reporting_span: Span) -> DIArray {
         if cx.sess().opts.debuginfo == LimitedDebugInfo {
-            return create_DIArray(DIB(cx), []);
+            return create_DIArray(DIB(cx), &[]);
         }
 
         let mut signature = Vec::with_capacity(fn_decl.inputs.len() + 1);
@@ -1409,7 +1409,7 @@ pub fn create_function_debug_context(cx: &CrateContext,
         let has_self_type = self_type.is_some();
 
         if !generics.is_type_parameterized() && !has_self_type {
-            return create_DIArray(DIB(cx), []);
+            return create_DIArray(DIB(cx), &[]);
         }
 
         name_to_append_suffix_to.push('<');
@@ -2645,7 +2645,7 @@ fn create_struct_stub(cx: &CrateContext,
                 // LLVMDIBuilderCreateStructType() wants an empty array. A null
                 // pointer will lead to hard to trace and debug LLVM assertions
                 // later on in llvm/lib/IR/Value.cpp.
-                let empty_array = create_DIArray(DIB(cx), []);
+                let empty_array = create_DIArray(DIB(cx), &[]);
 
                 llvm::LLVMDIBuilderCreateStructType(
                     DIB(cx),
@@ -2688,7 +2688,7 @@ fn fixed_vec_metadata(cx: &CrateContext,
             len as i64)
     };
 
-    let subscripts = create_DIArray(DIB(cx), [subrange]);
+    let subscripts = create_DIArray(DIB(cx), &[subrange]);
     let metadata = unsafe {
         llvm::LLVMDIBuilderCreateArrayType(
             DIB(cx),
@@ -2749,7 +2749,7 @@ fn vec_slice_metadata(cx: &CrateContext,
                                            slice_llvm_type,
                                            slice_type_name.as_slice(),
                                            unique_type_id,
-                                           member_descriptions,
+                                           &member_descriptions,
                                            UNKNOWN_SCOPE_METADATA,
                                            file_metadata,
                                            span);
@@ -2835,7 +2835,7 @@ fn trait_pointer_metadata(cx: &CrateContext,
                             trait_llvm_type,
                             trait_type_name.as_slice(),
                             unique_type_id,
-                            [],
+                            &[],
                             containing_scope,
                             UNKNOWN_FILE_METADATA,
                             codemap::DUMMY_SP)

--- a/src/librustc/middle/trans/expr.rs
+++ b/src/librustc/middle/trans/expr.rs
@@ -166,11 +166,11 @@ pub fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 }
 
 pub fn get_len(bcx: Block, fat_ptr: ValueRef) -> ValueRef {
-    GEPi(bcx, fat_ptr, [0u, abi::slice_elt_len])
+    GEPi(bcx, fat_ptr, &[0u, abi::slice_elt_len])
 }
 
 pub fn get_dataptr(bcx: Block, fat_ptr: ValueRef) -> ValueRef {
-    GEPi(bcx, fat_ptr, [0u, abi::slice_elt_base])
+    GEPi(bcx, fat_ptr, &[0u, abi::slice_elt_base])
 }
 
 fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
@@ -356,7 +356,7 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                        val,
                                        type_of::type_of(bcx.ccx(), unsized_ty).ptr_to()),
             &ty::UnsizeLength(..) =>
-                |bcx, val| GEPi(bcx, val, [0u, 0u]),
+                |bcx, val| GEPi(bcx, val, &[0u, 0u]),
             &ty::UnsizeVtable(..) =>
                 |_bcx, val| PointerCast(bcx, val, Type::i8p(bcx.ccx()))
         };
@@ -814,7 +814,7 @@ fn trans_index<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             let expect = ccx.get_intrinsic(&("llvm.expect.i1"));
             let expected = Call(bcx,
                                 expect,
-                                [bounds_check, C_bool(ccx, false)],
+                                &[bounds_check, C_bool(ccx, false)],
                                 None);
             bcx = with_cond(bcx, expected, |bcx| {
                 controlflow::trans_fail_bounds_check(bcx,
@@ -822,7 +822,7 @@ fn trans_index<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                                      ix_val,
                                                      len)
             });
-            let elt = InBoundsGEP(bcx, base, [ix_val]);
+            let elt = InBoundsGEP(bcx, base, &[ix_val]);
             let elt = PointerCast(bcx, elt, vt.llunit_ty.ptr_to());
             Datum::new(elt, vt.unit_ty, LvalueExpr)
         }
@@ -1758,8 +1758,8 @@ fn trans_lazy_binop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     }
 
     Br(past_rhs, join.llbb);
-    let phi = Phi(join, Type::i1(bcx.ccx()), [lhs, rhs],
-                  [past_lhs.llbb, past_rhs.llbb]);
+    let phi = Phi(join, Type::i1(bcx.ccx()), &[lhs, rhs],
+                  &[past_lhs.llbb, past_rhs.llbb]);
 
     return immediate_rvalue_bcx(join, phi, binop_ty).to_expr_datumblock();
 }

--- a/src/librustc/middle/trans/foreign.rs
+++ b/src/librustc/middle/trans/foreign.rs
@@ -610,7 +610,7 @@ pub fn trans_rust_fn_with_foreign_abi(ccx: &CrateContext,
 
         let llfn = base::decl_internal_rust_fn(ccx, t, ps.as_slice());
         base::set_llvm_fn_attrs(ccx, attrs, llfn);
-        base::trans_fn(ccx, decl, body, llfn, param_substs, id, []);
+        base::trans_fn(ccx, decl, body, llfn, param_substs, id, &[]);
         llfn
     }
 

--- a/src/librustc/middle/trans/inline.rs
+++ b/src/librustc/middle/trans/inline.rs
@@ -166,7 +166,7 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
                                  llfn,
                                  &param_substs::empty(),
                                  mth.id,
-                                 []);
+                                 &[]);
                         // Use InternalLinkage so LLVM can optimize more
                         // aggressively.
                         SetLinkage(llfn, InternalLinkage);

--- a/src/librustc/middle/trans/intrinsic.rs
+++ b/src/librustc/middle/trans/intrinsic.rs
@@ -207,7 +207,7 @@ pub fn trans_intrinsic_call<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>, node: ast::N
     // These are the only intrinsic functions that diverge.
     if name.get() == "abort" {
         let llfn = ccx.get_intrinsic(&("llvm.trap"));
-        Call(bcx, llfn, [], None);
+        Call(bcx, llfn, &[], None);
         Unreachable(bcx);
         return Result::new(bcx, C_undef(Type::nil(ccx).ptr_to()));
     } else if name.get() == "unreachable" {
@@ -242,7 +242,7 @@ pub fn trans_intrinsic_call<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>, node: ast::N
         }
         (_, "breakpoint") => {
             let llfn = ccx.get_intrinsic(&("llvm.debugtrap"));
-            Call(bcx, llfn, [], None)
+            Call(bcx, llfn, &[], None)
         }
         (_, "size_of") => {
             let tp_ty = *substs.types.get(FnSpace, 0);
@@ -291,7 +291,7 @@ pub fn trans_intrinsic_call<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>, node: ast::N
                 &ccx.link_meta().crate_hash);
             // NB: This needs to be kept in lockstep with the TypeId struct in
             //     the intrinsic module
-            C_named_struct(llret_ty, [C_u64(ccx, hash)])
+            C_named_struct(llret_ty, &[C_u64(ccx, hash)])
         }
         (_, "init") => {
             let tp_ty = *substs.types.get(FnSpace, 0);
@@ -317,7 +317,7 @@ pub fn trans_intrinsic_call<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>, node: ast::N
         (_, "offset") => {
             let ptr = llargs[0];
             let offset = llargs[1];
-            InBoundsGEP(bcx, ptr, [offset])
+            InBoundsGEP(bcx, ptr, &[offset])
         }
 
         (_, "copy_nonoverlapping_memory") => {
@@ -578,8 +578,8 @@ fn copy_intrinsic(bcx: Block, allow_overlap: bool, volatile: bool,
     let src_ptr = PointerCast(bcx, src, Type::i8p(ccx));
     let llfn = ccx.get_intrinsic(&name);
 
-    Call(bcx, llfn, [dst_ptr, src_ptr, Mul(bcx, size, count), align,
-                     C_bool(ccx, volatile)], None)
+    Call(bcx, llfn, &[dst_ptr, src_ptr, Mul(bcx, size, count), align,
+                      C_bool(ccx, volatile)], None)
 }
 
 fn memset_intrinsic(bcx: Block, volatile: bool, tp_ty: ty::t,
@@ -597,14 +597,14 @@ fn memset_intrinsic(bcx: Block, volatile: bool, tp_ty: ty::t,
     let dst_ptr = PointerCast(bcx, dst, Type::i8p(ccx));
     let llfn = ccx.get_intrinsic(&name);
 
-    Call(bcx, llfn, [dst_ptr, val, Mul(bcx, size, count), align,
-                     C_bool(ccx, volatile)], None)
+    Call(bcx, llfn, &[dst_ptr, val, Mul(bcx, size, count), align,
+                      C_bool(ccx, volatile)], None)
 }
 
 fn count_zeros_intrinsic(bcx: Block, name: &'static str, val: ValueRef) -> ValueRef {
     let y = C_bool(bcx.ccx(), false);
     let llfn = bcx.ccx().get_intrinsic(&name);
-    Call(bcx, llfn, [val, y], None)
+    Call(bcx, llfn, &[val, y], None)
 }
 
 fn with_overflow_intrinsic(bcx: Block, name: &'static str, t: ty::t,
@@ -612,7 +612,7 @@ fn with_overflow_intrinsic(bcx: Block, name: &'static str, t: ty::t,
     let llfn = bcx.ccx().get_intrinsic(&name);
 
     // Convert `i1` to a `bool`, and write it to the out parameter
-    let val = Call(bcx, llfn, [a, b], None);
+    let val = Call(bcx, llfn, &[a, b], None);
     let result = ExtractValue(bcx, val, 0);
     let overflow = ZExt(bcx, ExtractValue(bcx, val, 1), Type::bool(bcx.ccx()));
     let ret = C_undef(type_of::type_of(bcx.ccx(), t));

--- a/src/librustc/middle/trans/meth.rs
+++ b/src/librustc/middle/trans/meth.rs
@@ -89,7 +89,7 @@ pub fn trans_impl(ccx: &CrateContext,
                                  llfn,
                                  &param_substs::empty(),
                                  method.id,
-                                 []);
+                                 &[]);
                         update_linkage(ccx,
                                        llfn,
                                        Some(method.id),
@@ -479,7 +479,7 @@ pub fn trans_trait_callee_from_llval<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
     // Load the data pointer from the object.
     debug!("(translating trait callee) loading second index from pair");
-    let llboxptr = GEPi(bcx, llpair, [0u, abi::trt_field_box]);
+    let llboxptr = GEPi(bcx, llpair, &[0u, abi::trt_field_box]);
     let llbox = Load(bcx, llboxptr);
     let llself = PointerCast(bcx, llbox, Type::i8p(ccx));
 
@@ -501,9 +501,9 @@ pub fn trans_trait_callee_from_llval<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let llvtable = Load(bcx,
                         PointerCast(bcx,
                                     GEPi(bcx, llpair,
-                                         [0u, abi::trt_field_vtable]),
+                                         &[0u, abi::trt_field_vtable]),
                                     Type::vtable(ccx).ptr_to().ptr_to()));
-    let mptr = Load(bcx, GEPi(bcx, llvtable, [0u, n_method + VTABLE_OFFSET]));
+    let mptr = Load(bcx, GEPi(bcx, llvtable, &[0u, n_method + VTABLE_OFFSET]));
     let mptr = PointerCast(bcx, mptr, llcallee_ty.ptr_to());
 
     return Callee {
@@ -764,13 +764,13 @@ pub fn trans_trait_cast<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let llbox_ty = type_of(bcx.ccx(), datum_ty);
 
     // Store the pointer into the first half of pair.
-    let llboxdest = GEPi(bcx, lldest, [0u, abi::trt_field_box]);
+    let llboxdest = GEPi(bcx, lldest, &[0u, abi::trt_field_box]);
     let llboxdest = PointerCast(bcx, llboxdest, llbox_ty.ptr_to());
     bcx = datum.store_to(bcx, llboxdest);
 
     // Store the vtable into the second half of pair.
     let vtable = get_vtable(bcx, datum_ty, trait_ref);
-    let llvtabledest = GEPi(bcx, lldest, [0u, abi::trt_field_vtable]);
+    let llvtabledest = GEPi(bcx, lldest, &[0u, abi::trt_field_vtable]);
     let llvtabledest = PointerCast(bcx, llvtabledest, val_ty(vtable).ptr_to());
     Store(bcx, vtable, llvtabledest);
 

--- a/src/librustc/middle/trans/monomorphize.rs
+++ b/src/librustc/middle/trans/monomorphize.rs
@@ -179,10 +179,10 @@ pub fn monomorphic_fn(ccx: &CrateContext,
                   if needs_body {
                       if abi != abi::Rust {
                           foreign::trans_rust_fn_with_foreign_abi(
-                              ccx, &**decl, &**body, [], d, &psubsts, fn_id.node,
+                              ccx, &**decl, &**body, &[], d, &psubsts, fn_id.node,
                               Some(hash.as_slice()));
                       } else {
-                          trans_fn(ccx, &**decl, &**body, d, &psubsts, fn_id.node, []);
+                          trans_fn(ccx, &**decl, &**body, d, &psubsts, fn_id.node, &[]);
                       }
                   }
 
@@ -226,7 +226,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
                                  d,
                                  &psubsts,
                                  mth.id,
-                                 []);
+                                 &[]);
                     }
                     d
                 }
@@ -242,7 +242,7 @@ pub fn monomorphic_fn(ccx: &CrateContext,
                     let needs_body = setup_lldecl(d, mth.attrs.as_slice());
                     if needs_body {
                         trans_fn(ccx, mth.pe_fn_decl(), mth.pe_body(), d,
-                                 &psubsts, mth.id, []);
+                                 &psubsts, mth.id, &[]);
                     }
                     d
                 }

--- a/src/librustc/middle/trans/type_.rs
+++ b/src/librustc/middle/trans/type_.rs
@@ -162,7 +162,7 @@ impl Type {
     }
 
     pub fn empty_struct(ccx: &CrateContext) -> Type {
-        Type::struct_(ccx, [], false)
+        Type::struct_(ccx, &[], false)
     }
 
     pub fn vtable(ccx: &CrateContext) -> Type {
@@ -182,7 +182,7 @@ impl Type {
     }
 
     pub fn glue_fn(ccx: &CrateContext, t: Type) -> Type {
-        Type::func([t], &Type::void(ccx))
+        Type::func(&[t], &Type::void(ccx))
     }
 
     pub fn tydesc(ccx: &CrateContext, str_slice_ty: Type) -> Type {
@@ -199,7 +199,7 @@ impl Type {
                      int_ty,     // align
                      glue_fn_ty, // drop
                      str_slice_ty]; // name
-        tydesc.set_struct_body(elems, false);
+        tydesc.set_struct_body(&elems, false);
 
         tydesc
     }
@@ -214,7 +214,7 @@ impl Type {
 
     pub fn vec(ccx: &CrateContext, ty: &Type) -> Type {
         Type::struct_(ccx,
-            [Type::array(ty, 0), Type::int(ccx)],
+            &[Type::array(ty, 0), Type::int(ccx)],
         false)
     }
 
@@ -224,7 +224,7 @@ impl Type {
 
     // The box pointed to by @T.
     pub fn at_box(ccx: &CrateContext, ty: Type) -> Type {
-        Type::struct_(ccx, [
+        Type::struct_(ccx, &[
             ccx.int_type(), Type::glue_fn(ccx, Type::i8p(ccx)).ptr_to(),
             Type::i8p(ccx), Type::i8p(ccx), ty
         ], false)
@@ -235,7 +235,7 @@ impl Type {
     }
 
     pub fn opaque_trait(ccx: &CrateContext) -> Type {
-        Type::struct_(ccx, [Type::opaque_trait_data(ccx).ptr_to(), Type::vtable_ptr(ccx)], false)
+        Type::struct_(ccx, &[Type::opaque_trait_data(ccx).ptr_to(), Type::vtable_ptr(ccx)], false)
     }
 
     pub fn opaque_trait_data(ccx: &CrateContext) -> Type {

--- a/src/librustc/middle/trans/type_of.rs
+++ b/src/librustc/middle/trans/type_of.rs
@@ -195,12 +195,12 @@ pub fn sizing_type_of(cx: &CrateContext, t: ty::t) -> Type {
             if ty::type_is_sized(cx.tcx(), ty) {
                 Type::i8p(cx)
             } else {
-                Type::struct_(cx, [Type::i8p(cx), Type::i8p(cx)], false)
+                Type::struct_(cx, &[Type::i8p(cx), Type::i8p(cx)], false)
             }
         }
 
         ty::ty_bare_fn(..) => Type::i8p(cx),
-        ty::ty_closure(..) => Type::struct_(cx, [Type::i8p(cx), Type::i8p(cx)], false),
+        ty::ty_closure(..) => Type::struct_(cx, &[Type::i8p(cx), Type::i8p(cx)], false),
 
         ty::ty_vec(ty, Some(size)) => {
             let llty = sizing_type_of(cx, ty);
@@ -231,7 +231,7 @@ pub fn sizing_type_of(cx: &CrateContext, t: ty::t) -> Type {
         }
 
         ty::ty_open(_) => {
-            Type::struct_(cx, [Type::i8p(cx), Type::i8p(cx)], false)
+            Type::struct_(cx, &[Type::i8p(cx), Type::i8p(cx)], false)
         }
 
         ty::ty_infer(..) | ty::ty_param(..) | ty::ty_err(..) => {
@@ -337,7 +337,7 @@ pub fn type_of(cx: &CrateContext, t: ty::t) -> Type {
               ty::ty_trait(..) => Type::opaque_trait(cx),
               _ if !ty::type_is_sized(cx.tcx(), ty) => {
                   let p_ty = type_of(cx, ty).ptr_to();
-                  Type::struct_(cx, [p_ty, type_of_unsize_info(cx, ty)], false)
+                  Type::struct_(cx, &[p_ty, type_of_unsize_info(cx, ty)], false)
               }
               _ => type_of(cx, ty).ptr_to(),
           }
@@ -364,7 +364,7 @@ pub fn type_of(cx: &CrateContext, t: ty::t) -> Type {
       }
       ty::ty_closure(_) => {
           let fn_ty = type_of_fn_from_ty(cx, t).ptr_to();
-          Type::struct_(cx, [fn_ty, Type::i8p(cx)], false)
+          Type::struct_(cx, &[fn_ty, Type::i8p(cx)], false)
       }
       ty::ty_tup(ref tys) if tys.is_empty() => Type::nil(cx),
       ty::ty_tup(..) => {
@@ -391,15 +391,15 @@ pub fn type_of(cx: &CrateContext, t: ty::t) -> Type {
       ty::ty_open(t) => match ty::get(t).sty {
           ty::ty_struct(..) => {
               let p_ty = type_of(cx, t).ptr_to();
-              Type::struct_(cx, [p_ty, type_of_unsize_info(cx, t)], false)
+              Type::struct_(cx, &[p_ty, type_of_unsize_info(cx, t)], false)
           }
           ty::ty_vec(ty, None) => {
               let p_ty = type_of(cx, ty).ptr_to();
-              Type::struct_(cx, [p_ty, type_of_unsize_info(cx, t)], false)
+              Type::struct_(cx, &[p_ty, type_of_unsize_info(cx, t)], false)
           }
           ty::ty_str => {
               let p_ty = Type::i8p(cx);
-              Type::struct_(cx, [p_ty, type_of_unsize_info(cx, t)], false)
+              Type::struct_(cx, &[p_ty, type_of_unsize_info(cx, t)], false)
           }
           ty::ty_trait(..) => Type::opaque_trait(cx),
           _ => cx.sess().bug(format!("ty_open with sized type: {}",
@@ -472,5 +472,5 @@ pub fn llvm_type_name(cx: &CrateContext,
 
 pub fn type_of_dtor(ccx: &CrateContext, self_ty: ty::t) -> Type {
     let self_ty = type_of(ccx, self_ty).ptr_to();
-    Type::func([self_ty], &Type::void(ccx))
+    Type::func(&[self_ty], &Type::void(ccx))
 }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2656,7 +2656,7 @@ pub fn type_contents(cx: &ctxt, ty: t) -> TypeContents {
                        bounds: ExistentialBounds)
                        -> TypeContents {
         // These are the type contents of the (opaque) interior
-        kind_bounds_to_contents(cx, bounds.builtin_bounds, [])
+        kind_bounds_to_contents(cx, bounds.builtin_bounds, &[])
     }
 
     fn kind_bounds_to_contents(cx: &ctxt,
@@ -4850,7 +4850,7 @@ pub fn required_region_bounds(tcx: &ctxt,
 
     all_bounds.push_all(region_bounds);
 
-    push_region_bounds([],
+    push_region_bounds(&[],
                        builtin_bounds,
                        &mut all_bounds);
 

--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -1442,7 +1442,7 @@ pub fn compute_opt_region_bound(tcx: &ty::ctxt,
     let derived_region_bounds =
         ty::required_region_bounds(
             tcx,
-            [],
+            &[],
             builtin_bounds,
             trait_bounds);
 

--- a/src/librustc/middle/typeck/check/method.rs
+++ b/src/librustc/middle/typeck/check/method.rs
@@ -1064,7 +1064,7 @@ impl<'a, 'tcx> LookupContext<'a, 'tcx> {
 
         // First try to borrow to a slice
         let entry = self.search_for_some_kind_of_autorefd_method(
-            |r, m| AutoPtr(r, m, None), autoderefs, [MutImmutable, MutMutable],
+            |r, m| AutoPtr(r, m, None), autoderefs, &[MutImmutable, MutMutable],
             |m,r| ty::mk_slice(tcx, r,
                                ty::mt {ty:ty, mutbl:m}));
 
@@ -1075,7 +1075,7 @@ impl<'a, 'tcx> LookupContext<'a, 'tcx> {
         // Then try to borrow to a slice *and* borrow a pointer.
         self.search_for_some_kind_of_autorefd_method(
             |r, m| AutoPtr(r, ast::MutImmutable, Some( box AutoPtr(r, m, None))),
-            autoderefs, [MutImmutable, MutMutable],
+            autoderefs, &[MutImmutable, MutMutable],
             |m, r| {
                 let slice_ty = ty::mk_slice(tcx, r,
                                             ty::mt {ty:ty, mutbl:m});
@@ -1096,7 +1096,7 @@ impl<'a, 'tcx> LookupContext<'a, 'tcx> {
         // First try to borrow to an unsized vec.
         let entry = self.search_for_some_kind_of_autorefd_method(
             |_r, _m| AutoUnsize(ty::UnsizeLength(len)),
-            autoderefs, [MutImmutable, MutMutable],
+            autoderefs, &[MutImmutable, MutMutable],
             |_m, _r| ty::mk_vec(tcx, ty, None));
 
         if entry.is_some() {
@@ -1106,7 +1106,7 @@ impl<'a, 'tcx> LookupContext<'a, 'tcx> {
         // Then try to borrow to a slice.
         let entry = self.search_for_some_kind_of_autorefd_method(
             |r, m| AutoPtr(r, m, Some(box AutoUnsize(ty::UnsizeLength(len)))),
-            autoderefs, [MutImmutable, MutMutable],
+            autoderefs, &[MutImmutable, MutMutable],
             |m, r|  ty::mk_slice(tcx, r, ty::mt {ty:ty, mutbl:m}));
 
         if entry.is_some() {
@@ -1118,7 +1118,7 @@ impl<'a, 'tcx> LookupContext<'a, 'tcx> {
             |r, m| AutoPtr(r, m,
                            Some(box AutoPtr(r, m,
                                             Some(box AutoUnsize(ty::UnsizeLength(len)))))),
-            autoderefs, [MutImmutable, MutMutable],
+            autoderefs, &[MutImmutable, MutMutable],
             |m, r| {
                 let slice_ty = ty::mk_slice(tcx, r, ty::mt {ty:ty, mutbl:m});
                 ty::mk_rptr(tcx, r, ty::mt {ty:slice_ty, mutbl:MutImmutable})
@@ -1130,7 +1130,7 @@ impl<'a, 'tcx> LookupContext<'a, 'tcx> {
         debug!("auto_slice_str");
 
         let entry = self.search_for_some_kind_of_autorefd_method(
-            |r, m| AutoPtr(r, m, None), autoderefs, [MutImmutable],
+            |r, m| AutoPtr(r, m, None), autoderefs, &[MutImmutable],
             |_m, r| ty::mk_str_slice(tcx, r, MutImmutable));
 
         if entry.is_some() {
@@ -1139,7 +1139,7 @@ impl<'a, 'tcx> LookupContext<'a, 'tcx> {
 
         self.search_for_some_kind_of_autorefd_method(
             |r, m| AutoPtr(r, ast::MutImmutable, Some( box AutoPtr(r, m, None))),
-            autoderefs, [MutImmutable],
+            autoderefs, &[MutImmutable],
             |m, r| {
                 let slice_ty = ty::mk_str_slice(tcx, r, m);
                 ty::mk_rptr(tcx, r, ty::mt {ty:slice_ty, mutbl:m})
@@ -1158,7 +1158,7 @@ impl<'a, 'tcx> LookupContext<'a, 'tcx> {
                 let tcx = self.tcx();
                 self.search_for_some_kind_of_autorefd_method(
                     |r, m| AutoPtr(r, m, None),
-                    autoderefs, [MutImmutable, MutMutable],
+                    autoderefs, &[MutImmutable, MutMutable],
                     |m, r| {
                         let principal = ty::TraitRef::new(trt_did,
                                                           trt_substs.clone());
@@ -1220,7 +1220,7 @@ impl<'a, 'tcx> LookupContext<'a, 'tcx> {
             ty_unboxed_closure(..) | ty_tup(..) | ty_open(..) |
             ty_str | ty_vec(..) | ty_trait(..) | ty_closure(..) => {
                 self.search_for_some_kind_of_autorefd_method(
-                    |r, m| AutoPtr(r, m, None), autoderefs, [MutImmutable, MutMutable],
+                    |r, m| AutoPtr(r, m, None), autoderefs, &[MutImmutable, MutMutable],
                     |m,r| ty::mk_rptr(tcx, r, ty::mt {ty:self_ty, mutbl:m}))
             }
 

--- a/src/librustc/middle/typeck/check/regionmanip.rs
+++ b/src/librustc/middle/typeck/check/regionmanip.rs
@@ -412,9 +412,9 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
         // region bounds required from all of the trait types:
         let required_region_bounds =
             ty::required_region_bounds(self.tcx,
-                                       [],
+                                       &[],
                                        bounds.builtin_bounds,
-                                       []);
+                                       &[]);
         for &r_d in required_region_bounds.iter() {
             // Each of these is an instance of the `'c <= 'b`
             // constraint above

--- a/src/librustc/middle/typeck/coherence/mod.rs
+++ b/src/librustc/middle/typeck/coherence/mod.rs
@@ -152,9 +152,9 @@ impl<'a, 'tcx, 'v> visit::Visitor<'v> for CoherenceCheckVisitor<'a, 'tcx> {
             ItemImpl(_, ref opt_trait, _, _) => {
                 match opt_trait.clone() {
                     Some(opt_trait) => {
-                        self.cc.check_implementation(item, [opt_trait]);
+                        self.cc.check_implementation(item, &[opt_trait]);
                     }
-                    None => self.cc.check_implementation(item, [])
+                    None => self.cc.check_implementation(item, &[])
                 }
             }
             _ => {

--- a/src/librustc/middle/typeck/infer/test.rs
+++ b/src/librustc/middle/typeck/infer/test.rs
@@ -376,7 +376,7 @@ impl<'a, 'tcx> Env<'a, 'tcx> {
 
 #[test]
 fn contravariant_region_ptr_ok() {
-    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors([]), |env| {
+    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors(&[]), |env| {
         env.create_simple_region_hierarchy();
         let t_rptr1 = env.t_rptr_scope(1);
         let t_rptr10 = env.t_rptr_scope(10);
@@ -390,7 +390,7 @@ fn contravariant_region_ptr_ok() {
 fn contravariant_region_ptr_err() {
     test_env("contravariant_region_ptr",
              EMPTY_SOURCE_STR,
-             errors(["lifetime mismatch"]),
+             errors(&["lifetime mismatch"]),
              |env| {
                  env.create_simple_region_hierarchy();
                  let t_rptr1 = env.t_rptr_scope(1);
@@ -405,114 +405,114 @@ fn contravariant_region_ptr_err() {
 
 #[test]
 fn lub_bound_bound() {
-    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors([]), |env| {
+    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors(&[]), |env| {
         let t_rptr_bound1 = env.t_rptr_late_bound(22, 1);
         let t_rptr_bound2 = env.t_rptr_late_bound(22, 2);
-        env.check_lub(env.t_fn(22, [t_rptr_bound1], env.t_int()),
-                      env.t_fn(22, [t_rptr_bound2], env.t_int()),
-                      env.t_fn(22, [t_rptr_bound1], env.t_int()));
+        env.check_lub(env.t_fn(22, &[t_rptr_bound1], env.t_int()),
+                      env.t_fn(22, &[t_rptr_bound2], env.t_int()),
+                      env.t_fn(22, &[t_rptr_bound1], env.t_int()));
     })
 }
 
 #[test]
 fn lub_bound_free() {
-    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors([]), |env| {
+    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors(&[]), |env| {
         let t_rptr_bound1 = env.t_rptr_late_bound(22, 1);
         let t_rptr_free1 = env.t_rptr_free(0, 1);
-        env.check_lub(env.t_fn(22, [t_rptr_bound1], env.t_int()),
-                      env.t_fn(22, [t_rptr_free1], env.t_int()),
-                      env.t_fn(22, [t_rptr_free1], env.t_int()));
+        env.check_lub(env.t_fn(22, &[t_rptr_bound1], env.t_int()),
+                      env.t_fn(22, &[t_rptr_free1], env.t_int()),
+                      env.t_fn(22, &[t_rptr_free1], env.t_int()));
     })
 }
 
 #[test]
 fn lub_bound_static() {
-    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors([]), |env| {
+    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors(&[]), |env| {
         let t_rptr_bound1 = env.t_rptr_late_bound(22, 1);
         let t_rptr_static = env.t_rptr_static();
-        env.check_lub(env.t_fn(22, [t_rptr_bound1], env.t_int()),
-                      env.t_fn(22, [t_rptr_static], env.t_int()),
-                      env.t_fn(22, [t_rptr_static], env.t_int()));
+        env.check_lub(env.t_fn(22, &[t_rptr_bound1], env.t_int()),
+                      env.t_fn(22, &[t_rptr_static], env.t_int()),
+                      env.t_fn(22, &[t_rptr_static], env.t_int()));
     })
 }
 
 #[test]
 fn lub_bound_bound_inverse_order() {
-    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors([]), |env| {
+    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors(&[]), |env| {
         let t_rptr_bound1 = env.t_rptr_late_bound(22, 1);
         let t_rptr_bound2 = env.t_rptr_late_bound(22, 2);
-        env.check_lub(env.t_fn(22, [t_rptr_bound1, t_rptr_bound2], t_rptr_bound1),
-                      env.t_fn(22, [t_rptr_bound2, t_rptr_bound1], t_rptr_bound1),
-                      env.t_fn(22, [t_rptr_bound1, t_rptr_bound1], t_rptr_bound1));
+        env.check_lub(env.t_fn(22, &[t_rptr_bound1, t_rptr_bound2], t_rptr_bound1),
+                      env.t_fn(22, &[t_rptr_bound2, t_rptr_bound1], t_rptr_bound1),
+                      env.t_fn(22, &[t_rptr_bound1, t_rptr_bound1], t_rptr_bound1));
     })
 }
 
 #[test]
 fn lub_free_free() {
-    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors([]), |env| {
+    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors(&[]), |env| {
         let t_rptr_free1 = env.t_rptr_free(0, 1);
         let t_rptr_free2 = env.t_rptr_free(0, 2);
         let t_rptr_static = env.t_rptr_static();
-        env.check_lub(env.t_fn(22, [t_rptr_free1], env.t_int()),
-                      env.t_fn(22, [t_rptr_free2], env.t_int()),
-                      env.t_fn(22, [t_rptr_static], env.t_int()));
+        env.check_lub(env.t_fn(22, &[t_rptr_free1], env.t_int()),
+                      env.t_fn(22, &[t_rptr_free2], env.t_int()),
+                      env.t_fn(22, &[t_rptr_static], env.t_int()));
     })
 }
 
 #[test]
 fn lub_returning_scope() {
     test_env("contravariant_region_ptr", EMPTY_SOURCE_STR,
-             errors(["cannot infer an appropriate lifetime"]), |env| {
+             errors(&["cannot infer an appropriate lifetime"]), |env| {
                  let t_rptr_scope10 = env.t_rptr_scope(10);
                  let t_rptr_scope11 = env.t_rptr_scope(11);
 
                  // this should generate an error when regions are resolved
-                 env.make_lub_ty(env.t_fn(22, [], t_rptr_scope10),
-                                 env.t_fn(22, [], t_rptr_scope11));
+                 env.make_lub_ty(env.t_fn(22, &[], t_rptr_scope10),
+                                 env.t_fn(22, &[], t_rptr_scope11));
              })
 }
 
 #[test]
 fn glb_free_free_with_common_scope() {
-    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors([]), |env| {
+    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors(&[]), |env| {
         let t_rptr_free1 = env.t_rptr_free(0, 1);
         let t_rptr_free2 = env.t_rptr_free(0, 2);
         let t_rptr_scope = env.t_rptr_scope(0);
-        env.check_glb(env.t_fn(22, [t_rptr_free1], env.t_int()),
-                      env.t_fn(22, [t_rptr_free2], env.t_int()),
-                      env.t_fn(22, [t_rptr_scope], env.t_int()));
+        env.check_glb(env.t_fn(22, &[t_rptr_free1], env.t_int()),
+                      env.t_fn(22, &[t_rptr_free2], env.t_int()),
+                      env.t_fn(22, &[t_rptr_scope], env.t_int()));
     })
 }
 
 #[test]
 fn glb_bound_bound() {
-    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors([]), |env| {
+    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors(&[]), |env| {
         let t_rptr_bound1 = env.t_rptr_late_bound(22, 1);
         let t_rptr_bound2 = env.t_rptr_late_bound(22, 2);
-        env.check_glb(env.t_fn(22, [t_rptr_bound1], env.t_int()),
-                      env.t_fn(22, [t_rptr_bound2], env.t_int()),
-                      env.t_fn(22, [t_rptr_bound1], env.t_int()));
+        env.check_glb(env.t_fn(22, &[t_rptr_bound1], env.t_int()),
+                      env.t_fn(22, &[t_rptr_bound2], env.t_int()),
+                      env.t_fn(22, &[t_rptr_bound1], env.t_int()));
     })
 }
 
 #[test]
 fn glb_bound_free() {
-    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors([]), |env| {
+    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors(&[]), |env| {
         let t_rptr_bound1 = env.t_rptr_late_bound(22, 1);
         let t_rptr_free1 = env.t_rptr_free(0, 1);
-        env.check_glb(env.t_fn(22, [t_rptr_bound1], env.t_int()),
-                      env.t_fn(22, [t_rptr_free1], env.t_int()),
-                      env.t_fn(22, [t_rptr_bound1], env.t_int()));
+        env.check_glb(env.t_fn(22, &[t_rptr_bound1], env.t_int()),
+                      env.t_fn(22, &[t_rptr_free1], env.t_int()),
+                      env.t_fn(22, &[t_rptr_bound1], env.t_int()));
     })
 }
 
 #[test]
 fn glb_bound_static() {
-    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors([]), |env| {
+    test_env("contravariant_region_ptr", EMPTY_SOURCE_STR, errors(&[]), |env| {
         let t_rptr_bound1 = env.t_rptr_late_bound(22, 1);
         let t_rptr_static = env.t_rptr_static();
-        env.check_glb(env.t_fn(22, [t_rptr_bound1], env.t_int()),
-                      env.t_fn(22, [t_rptr_static], env.t_int()),
-                      env.t_fn(22, [t_rptr_bound1], env.t_int()));
+        env.check_glb(env.t_fn(22, &[t_rptr_bound1], env.t_int()),
+                      env.t_fn(22, &[t_rptr_static], env.t_int()),
+                      env.t_fn(22, &[t_rptr_bound1], env.t_int()));
     })
 }

--- a/src/librustc_back/archive.rs
+++ b/src/librustc_back/archive.rs
@@ -141,12 +141,12 @@ impl<'a> Archive<'a> {
 
     /// Removes a file from this archive
     pub fn remove_file(&mut self, file: &str) {
-        run_ar(self.handler, &self.maybe_ar_prog, "d", None, [&self.dst, &Path::new(file)]);
+        run_ar(self.handler, &self.maybe_ar_prog, "d", None, &[&self.dst, &Path::new(file)]);
     }
 
     /// Lists all files in an archive
     pub fn files(&self) -> Vec<String> {
-        let output = run_ar(self.handler, &self.maybe_ar_prog, "t", None, [&self.dst]);
+        let output = run_ar(self.handler, &self.maybe_ar_prog, "t", None, &[&self.dst]);
         let output = str::from_utf8(output.output.as_slice()).unwrap();
         // use lines_any because windows delimits output with `\r\n` instead of
         // just `\n`
@@ -288,7 +288,7 @@ impl<'a> ArchiveBuilder<'a> {
         // of filename collisions.
         let archive = os::make_absolute(archive);
         run_ar(self.archive.handler, &self.archive.maybe_ar_prog,
-               "x", Some(loc.path()), [&archive]);
+               "x", Some(loc.path()), &[&archive]);
 
         // Next, we must rename all of the inputs to "guaranteed unique names".
         // We move each file into `self.work_dir` under its new unique name.

--- a/src/librustc_back/rpath.rs
+++ b/src/librustc_back/rpath.rs
@@ -140,7 +140,7 @@ mod test {
 
     #[test]
     fn test_rpaths_to_flags() {
-        let flags = rpaths_to_flags([
+        let flags = rpaths_to_flags(&[
             "path1".to_string(),
             "path2".to_string()
         ]);
@@ -151,12 +151,12 @@ mod test {
 
     #[test]
     fn test_minimize1() {
-        let res = minimize_rpaths([
+        let res = minimize_rpaths(&[
             "rpath1".to_string(),
             "rpath2".to_string(),
             "rpath1".to_string()
         ]);
-        assert!(res.as_slice() == [
+        assert!(res.as_slice() == &[
             "rpath1".to_string(),
             "rpath2".to_string()
         ]);
@@ -164,7 +164,7 @@ mod test {
 
     #[test]
     fn test_minimize2() {
-        let res = minimize_rpaths([
+        let res = minimize_rpaths(&[
             "1a".to_string(),
             "2".to_string(),
             "2".to_string(),
@@ -176,7 +176,7 @@ mod test {
             "4a".to_string(),
             "3".to_string()
         ]);
-        assert!(res.as_slice() == [
+        assert!(res.as_slice() == &[
             "1a".to_string(),
             "2".to_string(),
             "4a".to_string(),

--- a/src/librustc_back/sha2.rs
+++ b/src/librustc_back/sha2.rs
@@ -139,7 +139,7 @@ impl FixedBuffer for FixedBuffer64 {
                         self.buffer[mut self.buffer_idx..size],
                         input[..buffer_remaining]);
                 self.buffer_idx = 0;
-                func(self.buffer);
+                func(&self.buffer);
                 i += buffer_remaining;
             } else {
                 copy_memory(
@@ -657,7 +657,7 @@ mod bench {
         let mut sh = Sha256::new();
         let bytes = [1u8, ..10];
         b.iter(|| {
-            sh.input(bytes);
+            sh.input(&bytes);
         });
         b.bytes = bytes.len() as u64;
     }
@@ -667,7 +667,7 @@ mod bench {
         let mut sh = Sha256::new();
         let bytes = [1u8, ..1024];
         b.iter(|| {
-            sh.input(bytes);
+            sh.input(&bytes);
         });
         b.bytes = bytes.len() as u64;
     }
@@ -677,7 +677,7 @@ mod bench {
         let mut sh = Sha256::new();
         let bytes = [1u8, ..65536];
         b.iter(|| {
-            sh.input(bytes);
+            sh.input(&bytes);
         });
         b.bytes = bytes.len() as u64;
     }

--- a/src/librustrt/c_str.rs
+++ b/src/librustrt/c_str.rs
@@ -432,7 +432,7 @@ unsafe fn with_c_str<T>(v: &[u8], checked: bool,
                         f: |*const libc::c_char| -> T) -> T {
     let c_str = if v.len() < BUF_LEN {
         let mut buf: [u8, .. BUF_LEN] = mem::uninitialized();
-        slice::bytes::copy_memory(buf, v);
+        slice::bytes::copy_memory(&mut buf, v);
         buf[v.len()] = 0;
 
         let buf = buf.as_mut_ptr();
@@ -554,7 +554,7 @@ mod tests {
 
     #[test]
     fn test_vec_to_c_str() {
-        let b: &[u8] = [];
+        let b: &[u8] = &[];
         let c_str = b.to_c_str();
         unsafe {
             assert_eq!(*c_str.as_ptr().offset(0), 0);
@@ -646,7 +646,7 @@ mod tests {
         let c_str = "hello".to_c_str();
         assert_eq!(c_str.as_bytes_no_nul(), b"hello");
         let c_str = "".to_c_str();
-        let exp: &[u8] = [];
+        let exp: &[u8] = &[];
         assert_eq!(c_str.as_bytes_no_nul(), exp);
         let c_str = b"foo\xFF".to_c_str();
         assert_eq!(c_str.as_bytes_no_nul(), b"foo\xFF");

--- a/src/librustrt/util.rs
+++ b/src/librustrt/util.rs
@@ -74,7 +74,7 @@ pub fn abort(args: &fmt::Arguments) -> ! {
 
     // Convert the arguments into a stack-allocated string
     let mut msg = [0u8, ..512];
-    let mut w = BufWriter { buf: msg, pos: 0 };
+    let mut w = BufWriter { buf: &mut msg, pos: 0 };
     let _ = write!(&mut w, "{}", args);
     let msg = str::from_utf8(w.buf[mut ..w.pos]).unwrap_or("aborted");
     let msg = if msg.is_empty() {"aborted"} else {msg};

--- a/src/libstd/io/comm_adapters.rs
+++ b/src/libstd/io/comm_adapters.rs
@@ -30,7 +30,7 @@ use vec::Vec;
 /// let mut reader = ChanReader::new(rx);
 ///
 /// let mut buf = [0u8, ..100];
-/// match reader.read(buf) {
+/// match reader.read(&mut buf) {
 ///     Ok(nread) => println!("Read {} bytes", nread),
 ///     Err(e) => println!("read error: {}", e),
 /// }
@@ -172,17 +172,17 @@ mod test {
         let mut reader = ChanReader::new(rx);
         let mut buf = [0u8, ..3];
 
-        assert_eq!(Ok(0), reader.read([]));
+        assert_eq!(Ok(0), reader.read(&mut []));
 
-        assert_eq!(Ok(3), reader.read(buf));
+        assert_eq!(Ok(3), reader.read(&mut buf));
         let a: &[u8] = &[1,2,3];
         assert_eq!(a, buf.as_slice());
 
-        assert_eq!(Ok(3), reader.read(buf));
+        assert_eq!(Ok(3), reader.read(&mut buf));
         let a: &[u8] = &[4,5,6];
         assert_eq!(a, buf.as_slice());
 
-        assert_eq!(Ok(2), reader.read(buf));
+        assert_eq!(Ok(2), reader.read(&mut buf));
         let a: &[u8] = &[7,8,6];
         assert_eq!(a, buf.as_slice());
 

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -82,9 +82,9 @@ pub fn u64_to_le_bytes<T>(n: u64, size: uint, f: |v: &[u8]| -> T) -> T {
     assert!(size <= 8u);
     match size {
       1u => f(&[n as u8]),
-      2u => f(unsafe { transmute::<_, [u8, ..2]>((n as u16).to_le()) }),
-      4u => f(unsafe { transmute::<_, [u8, ..4]>((n as u32).to_le()) }),
-      8u => f(unsafe { transmute::<_, [u8, ..8]>(n.to_le()) }),
+      2u => f(unsafe { & transmute::<_, [u8, ..2]>((n as u16).to_le()) }),
+      4u => f(unsafe { & transmute::<_, [u8, ..4]>((n as u32).to_le()) }),
+      8u => f(unsafe { & transmute::<_, [u8, ..8]>(n.to_le()) }),
       _ => {
 
         let mut bytes = vec!();
@@ -121,9 +121,9 @@ pub fn u64_to_be_bytes<T>(n: u64, size: uint, f: |v: &[u8]| -> T) -> T {
     assert!(size <= 8u);
     match size {
       1u => f(&[n as u8]),
-      2u => f(unsafe { transmute::<_, [u8, ..2]>((n as u16).to_be()) }),
-      4u => f(unsafe { transmute::<_, [u8, ..4]>((n as u32).to_be()) }),
-      8u => f(unsafe { transmute::<_, [u8, ..8]>(n.to_be()) }),
+      2u => f(unsafe { & transmute::<_, [u8, ..2]>((n as u16).to_be()) }),
+      4u => f(unsafe { & transmute::<_, [u8, ..4]>((n as u32).to_be()) }),
+      8u => f(unsafe { & transmute::<_, [u8, ..8]>(n.to_be()) }),
       _ => {
         let mut bytes = vec!();
         let mut i = size;
@@ -474,26 +474,26 @@ mod test {
         let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
 
         // Aligned access
-        assert_eq!(u64_from_be_bytes(buf, 0, 0), 0);
-        assert_eq!(u64_from_be_bytes(buf, 0, 1), 0x01);
-        assert_eq!(u64_from_be_bytes(buf, 0, 2), 0x0102);
-        assert_eq!(u64_from_be_bytes(buf, 0, 3), 0x010203);
-        assert_eq!(u64_from_be_bytes(buf, 0, 4), 0x01020304);
-        assert_eq!(u64_from_be_bytes(buf, 0, 5), 0x0102030405);
-        assert_eq!(u64_from_be_bytes(buf, 0, 6), 0x010203040506);
-        assert_eq!(u64_from_be_bytes(buf, 0, 7), 0x01020304050607);
-        assert_eq!(u64_from_be_bytes(buf, 0, 8), 0x0102030405060708);
+        assert_eq!(u64_from_be_bytes(&buf, 0, 0), 0);
+        assert_eq!(u64_from_be_bytes(&buf, 0, 1), 0x01);
+        assert_eq!(u64_from_be_bytes(&buf, 0, 2), 0x0102);
+        assert_eq!(u64_from_be_bytes(&buf, 0, 3), 0x010203);
+        assert_eq!(u64_from_be_bytes(&buf, 0, 4), 0x01020304);
+        assert_eq!(u64_from_be_bytes(&buf, 0, 5), 0x0102030405);
+        assert_eq!(u64_from_be_bytes(&buf, 0, 6), 0x010203040506);
+        assert_eq!(u64_from_be_bytes(&buf, 0, 7), 0x01020304050607);
+        assert_eq!(u64_from_be_bytes(&buf, 0, 8), 0x0102030405060708);
 
         // Unaligned access
-        assert_eq!(u64_from_be_bytes(buf, 1, 0), 0);
-        assert_eq!(u64_from_be_bytes(buf, 1, 1), 0x02);
-        assert_eq!(u64_from_be_bytes(buf, 1, 2), 0x0203);
-        assert_eq!(u64_from_be_bytes(buf, 1, 3), 0x020304);
-        assert_eq!(u64_from_be_bytes(buf, 1, 4), 0x02030405);
-        assert_eq!(u64_from_be_bytes(buf, 1, 5), 0x0203040506);
-        assert_eq!(u64_from_be_bytes(buf, 1, 6), 0x020304050607);
-        assert_eq!(u64_from_be_bytes(buf, 1, 7), 0x02030405060708);
-        assert_eq!(u64_from_be_bytes(buf, 1, 8), 0x0203040506070809);
+        assert_eq!(u64_from_be_bytes(&buf, 1, 0), 0);
+        assert_eq!(u64_from_be_bytes(&buf, 1, 1), 0x02);
+        assert_eq!(u64_from_be_bytes(&buf, 1, 2), 0x0203);
+        assert_eq!(u64_from_be_bytes(&buf, 1, 3), 0x020304);
+        assert_eq!(u64_from_be_bytes(&buf, 1, 4), 0x02030405);
+        assert_eq!(u64_from_be_bytes(&buf, 1, 5), 0x0203040506);
+        assert_eq!(u64_from_be_bytes(&buf, 1, 6), 0x020304050607);
+        assert_eq!(u64_from_be_bytes(&buf, 1, 7), 0x02030405060708);
+        assert_eq!(u64_from_be_bytes(&buf, 1, 8), 0x0203040506070809);
     }
 }
 

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -384,7 +384,7 @@ pub fn copy(from: &Path, to: &Path) -> IoResult<()> {
     let mut buf = [0, ..io::DEFAULT_BUF_SIZE];
 
     loop {
-        let amt = match reader.read(buf) {
+        let amt = match reader.read(&mut buf) {
             Ok(n) => n,
             Err(ref e) if e.kind == io::EndOfFile => { break }
             Err(e) => return update_err(Err(e), from, to)
@@ -881,7 +881,7 @@ mod test {
         {
             let mut read_stream = File::open_mode(filename, Open, Read);
             let mut read_buf = [0, .. 1028];
-            let read_str = match check!(read_stream.read(read_buf)) {
+            let read_str = match check!(read_stream.read(&mut read_buf)) {
                 -1|0 => panic!("shouldn't happen"),
                 n => str::from_utf8(read_buf[..n]).unwrap().to_string()
             };
@@ -939,7 +939,7 @@ mod test {
             }
         }
         check!(unlink(filename));
-        let read_str = str::from_utf8(read_mem).unwrap();
+        let read_str = str::from_utf8(&read_mem).unwrap();
         assert_eq!(read_str, message);
     }
 
@@ -960,11 +960,11 @@ mod test {
             let mut read_stream = File::open_mode(filename, Open, Read);
             check!(read_stream.seek(set_cursor as i64, SeekSet));
             tell_pos_pre_read = check!(read_stream.tell());
-            check!(read_stream.read(read_mem));
+            check!(read_stream.read(&mut read_mem));
             tell_pos_post_read = check!(read_stream.tell());
         }
         check!(unlink(filename));
-        let read_str = str::from_utf8(read_mem).unwrap();
+        let read_str = str::from_utf8(&read_mem).unwrap();
         assert_eq!(read_str, message.slice(4, 8));
         assert_eq!(tell_pos_pre_read, set_cursor);
         assert_eq!(tell_pos_post_read, message.len() as u64);
@@ -987,10 +987,10 @@ mod test {
         }
         {
             let mut read_stream = File::open_mode(filename, Open, Read);
-            check!(read_stream.read(read_mem));
+            check!(read_stream.read(&mut read_mem));
         }
         check!(unlink(filename));
-        let read_str = str::from_utf8(read_mem).unwrap();
+        let read_str = str::from_utf8(&read_mem).unwrap();
         assert!(read_str.as_slice() == final_msg.as_slice());
     }
 
@@ -1012,16 +1012,16 @@ mod test {
             let mut read_stream = File::open_mode(filename, Open, Read);
 
             check!(read_stream.seek(-4, SeekEnd));
-            check!(read_stream.read(read_mem));
-            assert_eq!(str::from_utf8(read_mem).unwrap(), chunk_three);
+            check!(read_stream.read(&mut read_mem));
+            assert_eq!(str::from_utf8(&read_mem).unwrap(), chunk_three);
 
             check!(read_stream.seek(-9, SeekCur));
-            check!(read_stream.read(read_mem));
-            assert_eq!(str::from_utf8(read_mem).unwrap(), chunk_two);
+            check!(read_stream.read(&mut read_mem));
+            assert_eq!(str::from_utf8(&read_mem).unwrap(), chunk_two);
 
             check!(read_stream.seek(0, SeekSet));
-            check!(read_stream.read(read_mem));
-            assert_eq!(str::from_utf8(read_mem).unwrap(), chunk_one);
+            check!(read_stream.read(&mut read_mem));
+            assert_eq!(str::from_utf8(&read_mem).unwrap(), chunk_one);
         }
         check!(unlink(filename));
     }
@@ -1107,8 +1107,8 @@ mod test {
         for f in files.iter() {
             {
                 let n = f.filestem_str();
-                check!(File::open(f).read(mem));
-                let read_str = str::from_utf8(mem).unwrap();
+                check!(File::open(f).read(&mut mem));
+                let read_str = str::from_utf8(&mem).unwrap();
                 let expected = match n {
                     None|Some("") => panic!("really shouldn't happen.."),
                     Some(n) => format!("{}{}", prefix, n),
@@ -1532,13 +1532,13 @@ mod test {
         use rand::{StdRng, Rng};
 
         let mut bytes = [0, ..1024];
-        StdRng::new().ok().unwrap().fill_bytes(bytes);
+        StdRng::new().ok().unwrap().fill_bytes(&mut bytes);
 
         let tmpdir = tmpdir();
 
-        check!(File::create(&tmpdir.join("test")).write(bytes));
+        check!(File::create(&tmpdir.join("test")).write(&bytes));
         let actual = check!(File::open(&tmpdir.join("test")).read_to_end());
-        assert!(actual.as_slice() == bytes);
+        assert!(actual.as_slice() == &bytes);
     }
 
     #[test]

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -521,7 +521,7 @@ pub trait Reader {
     /// Reads a single byte. Returns `Err` on EOF.
     fn read_byte(&mut self) -> IoResult<u8> {
         let mut buf = [0];
-        try!(self.read_at_least(1, buf));
+        try!(self.read_at_least(1, &mut buf));
         Ok(buf[0])
     }
 
@@ -1061,7 +1061,7 @@ pub trait Writer {
     /// that the `write` method is used specifically instead.
     #[inline]
     fn write_line(&mut self, s: &str) -> IoResult<()> {
-        self.write_str(s).and_then(|()| self.write([b'\n']))
+        self.write_str(s).and_then(|()| self.write(&[b'\n']))
     }
 
     /// Write a single char, encoded as UTF-8.
@@ -1217,13 +1217,13 @@ pub trait Writer {
     /// Write a u8 (1 byte).
     #[inline]
     fn write_u8(&mut self, n: u8) -> IoResult<()> {
-        self.write([n])
+        self.write(&[n])
     }
 
     /// Write an i8 (1 byte).
     #[inline]
     fn write_i8(&mut self, n: i8) -> IoResult<()> {
-        self.write([n as u8])
+        self.write(&[n as u8])
     }
 }
 
@@ -1949,7 +1949,7 @@ mod tests {
     fn test_read_at_least() {
         let mut r = BadReader::new(MemReader::new(b"hello, world!".to_vec()),
                                    vec![GoodBehavior(uint::MAX)]);
-        let mut buf = [0u8, ..5];
+        let buf = &mut [0u8, ..5];
         assert!(r.read_at_least(1, buf).unwrap() >= 1);
         assert!(r.read_exact(5).unwrap().len() == 5); // read_exact uses read_at_least
         assert!(r.read_at_least(0, buf).is_ok());

--- a/src/libstd/io/net/tcp.rs
+++ b/src/libstd/io/net/tcp.rs
@@ -42,9 +42,9 @@ use sys::tcp::TcpAcceptor as TcpAcceptorImp;
 ///
 /// let mut stream = TcpStream::connect("127.0.0.1:34254");
 ///
-/// stream.write([1]);
+/// stream.write(&[1]);
 /// let mut buf = [0];
-/// stream.read(buf);
+/// stream.read(&mut buf);
 /// drop(stream); // close the connection
 /// ```
 pub struct TcpStream {
@@ -143,7 +143,7 @@ impl TcpStream {
     ///
     /// // wait for some data, will get canceled after one second
     /// let mut buf = [0];
-    /// stream.read(buf);
+    /// stream.read(&mut buf);
     /// ```
     ///
     /// Note that this method affects all cloned handles associated with this
@@ -487,12 +487,12 @@ mod test {
 
         spawn(proc() {
             let mut stream = TcpStream::connect(("localhost", socket_addr.port));
-            stream.write([144]).unwrap();
+            stream.write(&[144]).unwrap();
         });
 
         let mut stream = acceptor.accept();
         let mut buf = [0];
-        stream.read(buf).unwrap();
+        stream.read(&mut buf).unwrap();
         assert!(buf[0] == 144);
     }
 
@@ -503,12 +503,12 @@ mod test {
 
         spawn(proc() {
             let mut stream = TcpStream::connect(("localhost", addr.port));
-            stream.write([64]).unwrap();
+            stream.write(&[64]).unwrap();
         });
 
         let mut stream = acceptor.accept();
         let mut buf = [0];
-        stream.read(buf).unwrap();
+        stream.read(&mut buf).unwrap();
         assert!(buf[0] == 64);
     }
 
@@ -519,12 +519,12 @@ mod test {
 
         spawn(proc() {
             let mut stream = TcpStream::connect(("127.0.0.1", addr.port));
-            stream.write([44]).unwrap();
+            stream.write(&[44]).unwrap();
         });
 
         let mut stream = acceptor.accept();
         let mut buf = [0];
-        stream.read(buf).unwrap();
+        stream.read(&mut buf).unwrap();
         assert!(buf[0] == 44);
     }
 
@@ -535,12 +535,12 @@ mod test {
 
         spawn(proc() {
             let mut stream = TcpStream::connect(("::1", addr.port));
-            stream.write([66]).unwrap();
+            stream.write(&[66]).unwrap();
         });
 
         let mut stream = acceptor.accept();
         let mut buf = [0];
-        stream.read(buf).unwrap();
+        stream.read(&mut buf).unwrap();
         assert!(buf[0] == 66);
     }
 
@@ -551,12 +551,12 @@ mod test {
 
         spawn(proc() {
             let mut stream = TcpStream::connect(addr);
-            stream.write([99]).unwrap();
+            stream.write(&[99]).unwrap();
         });
 
         let mut stream = acceptor.accept();
         let mut buf = [0];
-        stream.read(buf).unwrap();
+        stream.read(&mut buf).unwrap();
         assert!(buf[0] == 99);
     }
 
@@ -567,12 +567,12 @@ mod test {
 
         spawn(proc() {
             let mut stream = TcpStream::connect(addr);
-            stream.write([99]).unwrap();
+            stream.write(&[99]).unwrap();
         });
 
         let mut stream = acceptor.accept();
         let mut buf = [0];
-        stream.read(buf).unwrap();
+        stream.read(&mut buf).unwrap();
         assert!(buf[0] == 99);
     }
 
@@ -588,7 +588,7 @@ mod test {
 
         let mut stream = acceptor.accept();
         let mut buf = [0];
-        let nread = stream.read(buf);
+        let nread = stream.read(&mut buf);
         assert!(nread.is_err());
     }
 
@@ -604,7 +604,7 @@ mod test {
 
         let mut stream = acceptor.accept();
         let mut buf = [0];
-        let nread = stream.read(buf);
+        let nread = stream.read(&mut buf);
         assert!(nread.is_err());
     }
 
@@ -620,10 +620,10 @@ mod test {
 
         let mut stream = acceptor.accept();
         let mut buf = [0];
-        let nread = stream.read(buf);
+        let nread = stream.read(&mut buf);
         assert!(nread.is_err());
 
-        match stream.read(buf) {
+        match stream.read(&mut buf) {
             Ok(..) => panic!(),
             Err(ref e) => {
                 assert!(e.kind == NotConnected || e.kind == EndOfFile,
@@ -644,10 +644,10 @@ mod test {
 
         let mut stream = acceptor.accept();
         let mut buf = [0];
-        let nread = stream.read(buf);
+        let nread = stream.read(&mut buf);
         assert!(nread.is_err());
 
-        match stream.read(buf) {
+        match stream.read(&mut buf) {
             Ok(..) => panic!(),
             Err(ref e) => {
                 assert!(e.kind == NotConnected || e.kind == EndOfFile,
@@ -670,7 +670,7 @@ mod test {
         let mut stream = acceptor.accept();
         rx.recv();
         let buf = [0];
-        match stream.write(buf) {
+        match stream.write(&buf) {
             Ok(..) => {}
             Err(e) => {
                 assert!(e.kind == ConnectionReset ||
@@ -695,7 +695,7 @@ mod test {
         let mut stream = acceptor.accept();
         rx.recv();
         let buf = [0];
-        match stream.write(buf) {
+        match stream.write(&buf) {
             Ok(..) => {}
             Err(e) => {
                 assert!(e.kind == ConnectionReset ||
@@ -715,13 +715,13 @@ mod test {
         spawn(proc() {
             for _ in range(0, max) {
                 let mut stream = TcpStream::connect(addr);
-                stream.write([99]).unwrap();
+                stream.write(&[99]).unwrap();
             }
         });
 
         for ref mut stream in acceptor.incoming().take(max) {
             let mut buf = [0];
-            stream.read(buf).unwrap();
+            stream.read(&mut buf).unwrap();
             assert_eq!(buf[0], 99);
         }
     }
@@ -735,13 +735,13 @@ mod test {
         spawn(proc() {
             for _ in range(0, max) {
                 let mut stream = TcpStream::connect(addr);
-                stream.write([99]).unwrap();
+                stream.write(&[99]).unwrap();
             }
         });
 
         for ref mut stream in acceptor.incoming().take(max) {
             let mut buf = [0];
-            stream.read(buf).unwrap();
+            stream.read(&mut buf).unwrap();
             assert_eq!(buf[0], 99);
         }
     }
@@ -759,7 +759,7 @@ mod test {
                 spawn(proc() {
                     let mut stream = stream;
                     let mut buf = [0];
-                    stream.read(buf).unwrap();
+                    stream.read(&mut buf).unwrap();
                     assert!(buf[0] == i as u8);
                     debug!("read");
                 });
@@ -777,7 +777,7 @@ mod test {
                 // Connect again before writing
                 connect(i + 1, addr);
                 debug!("writing");
-                stream.write([i as u8]).unwrap();
+                stream.write(&[i as u8]).unwrap();
             });
         }
     }
@@ -795,7 +795,7 @@ mod test {
                 spawn(proc() {
                     let mut stream = stream;
                     let mut buf = [0];
-                    stream.read(buf).unwrap();
+                    stream.read(&mut buf).unwrap();
                     assert!(buf[0] == i as u8);
                     debug!("read");
                 });
@@ -813,7 +813,7 @@ mod test {
                 // Connect again before writing
                 connect(i + 1, addr);
                 debug!("writing");
-                stream.write([i as u8]).unwrap();
+                stream.write(&[i as u8]).unwrap();
             });
         }
     }
@@ -831,7 +831,7 @@ mod test {
                 spawn(proc() {
                     let mut stream = stream;
                     let mut buf = [0];
-                    stream.read(buf).unwrap();
+                    stream.read(&mut buf).unwrap();
                     assert!(buf[0] == 99);
                     debug!("read");
                 });
@@ -849,7 +849,7 @@ mod test {
                 // Connect again before writing
                 connect(i + 1, addr);
                 debug!("writing");
-                stream.write([99]).unwrap();
+                stream.write(&[99]).unwrap();
             });
         }
     }
@@ -867,7 +867,7 @@ mod test {
                 spawn(proc() {
                     let mut stream = stream;
                     let mut buf = [0];
-                    stream.read(buf).unwrap();
+                    stream.read(&mut buf).unwrap();
                     assert!(buf[0] == 99);
                     debug!("read");
                 });
@@ -885,7 +885,7 @@ mod test {
                 // Connect again before writing
                 connect(i + 1, addr);
                 debug!("writing");
-                stream.write([99]).unwrap();
+                stream.write(&[99]).unwrap();
             });
         }
     }
@@ -941,17 +941,17 @@ mod test {
             let mut srv = TcpListener::bind(addr).listen().unwrap();
             tx.send(());
             let mut cl = srv.accept().unwrap();
-            cl.write([10]).unwrap();
+            cl.write(&[10]).unwrap();
             let mut b = [0];
-            cl.read(b).unwrap();
+            cl.read(&mut b).unwrap();
             tx.send(());
         });
 
         rx.recv();
         let mut c = TcpStream::connect(addr).unwrap();
         let mut b = [0, ..10];
-        assert_eq!(c.read(b), Ok(1));
-        c.write([1]).unwrap();
+        assert_eq!(c.read(&mut b), Ok(1));
+        c.write(&[1]).unwrap();
         rx.recv();
     }
 
@@ -1002,9 +1002,9 @@ mod test {
         spawn(proc() {
             let mut s = TcpStream::connect(addr);
             let mut buf = [0, 0];
-            assert_eq!(s.read(buf), Ok(1));
+            assert_eq!(s.read(&mut buf), Ok(1));
             assert_eq!(buf[0], 1);
-            s.write([2]).unwrap();
+            s.write(&[2]).unwrap();
         });
 
         let mut s1 = acceptor.accept().unwrap();
@@ -1015,12 +1015,12 @@ mod test {
         spawn(proc() {
             let mut s2 = s2;
             rx1.recv();
-            s2.write([1]).unwrap();
+            s2.write(&[1]).unwrap();
             tx2.send(());
         });
         tx1.send(());
         let mut buf = [0, 0];
-        assert_eq!(s1.read(buf), Ok(1));
+        assert_eq!(s1.read(&mut buf), Ok(1));
         rx2.recv();
     }
 
@@ -1033,9 +1033,9 @@ mod test {
 
         spawn(proc() {
             let mut s = TcpStream::connect(addr);
-            s.write([1]).unwrap();
+            s.write(&[1]).unwrap();
             rx.recv();
-            s.write([2]).unwrap();
+            s.write(&[2]).unwrap();
             rx.recv();
         });
 
@@ -1046,12 +1046,12 @@ mod test {
         spawn(proc() {
             let mut s2 = s2;
             let mut buf = [0, 0];
-            s2.read(buf).unwrap();
+            s2.read(&mut buf).unwrap();
             tx2.send(());
             done.send(());
         });
         let mut buf = [0, 0];
-        s1.read(buf).unwrap();
+        s1.read(&mut buf).unwrap();
         tx1.send(());
 
         rx.recv();
@@ -1065,8 +1065,8 @@ mod test {
         spawn(proc() {
             let mut s = TcpStream::connect(addr);
             let mut buf = [0, 1];
-            s.read(buf).unwrap();
-            s.read(buf).unwrap();
+            s.read(&mut buf).unwrap();
+            s.read(&mut buf).unwrap();
         });
 
         let mut s1 = acceptor.accept().unwrap();
@@ -1075,10 +1075,10 @@ mod test {
         let (done, rx) = channel();
         spawn(proc() {
             let mut s2 = s2;
-            s2.write([1]).unwrap();
+            s2.write(&[1]).unwrap();
             done.send(());
         });
-        s1.write([2]).unwrap();
+        s1.write(&[2]).unwrap();
 
         rx.recv();
     }
@@ -1091,12 +1091,12 @@ mod test {
             let mut a = a;
             let mut c = a.accept().unwrap();
             assert_eq!(c.read_to_end(), Ok(vec!()));
-            c.write([1]).unwrap();
+            c.write(&[1]).unwrap();
         });
 
         let mut s = TcpStream::connect(addr).unwrap();
         assert!(s.inner.close_write().is_ok());
-        assert!(s.write([1]).is_err());
+        assert!(s.write(&[1]).is_err());
         assert_eq!(s.read_to_end(), Ok(vec!(1)));
     }
 
@@ -1161,18 +1161,18 @@ mod test {
 
         // closing should prevent reads/writes
         s.close_write().unwrap();
-        assert!(s.write([0]).is_err());
+        assert!(s.write(&[0]).is_err());
         s.close_read().unwrap();
-        assert!(s.read(b).is_err());
+        assert!(s.read(&mut b).is_err());
 
         // closing should affect previous handles
-        assert!(s2.write([0]).is_err());
-        assert!(s2.read(b).is_err());
+        assert!(s2.write(&[0]).is_err());
+        assert!(s2.read(&mut b).is_err());
 
         // closing should affect new handles
         let mut s3 = s.clone();
-        assert!(s3.write([0]).is_err());
-        assert!(s3.read(b).is_err());
+        assert!(s3.write(&[0]).is_err());
+        assert!(s3.read(&mut b).is_err());
 
         // make sure these don't die
         let _ = s2.close_read();
@@ -1197,7 +1197,7 @@ mod test {
         let (tx, rx) = channel();
         spawn(proc() {
             let mut s2 = s2;
-            assert!(s2.read([0]).is_err());
+            assert!(s2.read(&mut [0]).is_err());
             tx.send(());
         });
         // this should wake up the child task
@@ -1215,29 +1215,29 @@ mod test {
         spawn(proc() {
             let mut s = TcpStream::connect(addr).unwrap();
             rx.recv();
-            assert!(s.write([0]).is_ok());
+            assert!(s.write(&[0]).is_ok());
             let _ = rx.recv_opt();
         });
 
         let mut s = a.accept().unwrap();
         s.set_timeout(Some(20));
-        assert_eq!(s.read([0]).err().unwrap().kind, TimedOut);
-        assert_eq!(s.read([0]).err().unwrap().kind, TimedOut);
+        assert_eq!(s.read(&mut [0]).err().unwrap().kind, TimedOut);
+        assert_eq!(s.read(&mut [0]).err().unwrap().kind, TimedOut);
 
         s.set_timeout(Some(20));
         for i in range(0i, 1001) {
-            match s.write([0, .. 128 * 1024]) {
+            match s.write(&[0, .. 128 * 1024]) {
                 Ok(()) | Err(IoError { kind: ShortWrite(..), .. }) => {},
                 Err(IoError { kind: TimedOut, .. }) => break,
                 Err(e) => panic!("{}", e),
            }
            if i == 1000 { panic!("should have filled up?!"); }
         }
-        assert_eq!(s.write([0]).err().unwrap().kind, TimedOut);
+        assert_eq!(s.write(&[0]).err().unwrap().kind, TimedOut);
 
         tx.send(());
         s.set_timeout(None);
-        assert_eq!(s.read([0, 0]), Ok(1));
+        assert_eq!(s.read(&mut [0, 0]), Ok(1));
     }
 
     #[test]
@@ -1250,7 +1250,7 @@ mod test {
             rx.recv();
             let mut amt = 0;
             while amt < 100 * 128 * 1024 {
-                match s.read([0, ..128 * 1024]) {
+                match s.read(&mut [0, ..128 * 1024]) {
                     Ok(n) => { amt += n; }
                     Err(e) => panic!("{}", e),
                 }
@@ -1260,12 +1260,12 @@ mod test {
 
         let mut s = a.accept().unwrap();
         s.set_read_timeout(Some(20));
-        assert_eq!(s.read([0]).err().unwrap().kind, TimedOut);
-        assert_eq!(s.read([0]).err().unwrap().kind, TimedOut);
+        assert_eq!(s.read(&mut [0]).err().unwrap().kind, TimedOut);
+        assert_eq!(s.read(&mut [0]).err().unwrap().kind, TimedOut);
 
         tx.send(());
         for _ in range(0i, 100) {
-            assert!(s.write([0, ..128 * 1024]).is_ok());
+            assert!(s.write(&[0, ..128 * 1024]).is_ok());
         }
     }
 
@@ -1277,24 +1277,24 @@ mod test {
         spawn(proc() {
             let mut s = TcpStream::connect(addr).unwrap();
             rx.recv();
-            assert!(s.write([0]).is_ok());
+            assert!(s.write(&[0]).is_ok());
             let _ = rx.recv_opt();
         });
 
         let mut s = a.accept().unwrap();
         s.set_write_timeout(Some(20));
         for i in range(0i, 1001) {
-            match s.write([0, .. 128 * 1024]) {
+            match s.write(&[0, .. 128 * 1024]) {
                 Ok(()) | Err(IoError { kind: ShortWrite(..), .. }) => {},
                 Err(IoError { kind: TimedOut, .. }) => break,
                 Err(e) => panic!("{}", e),
            }
            if i == 1000 { panic!("should have filled up?!"); }
         }
-        assert_eq!(s.write([0]).err().unwrap().kind, TimedOut);
+        assert_eq!(s.write(&[0]).err().unwrap().kind, TimedOut);
 
         tx.send(());
-        assert!(s.read([0]).is_ok());
+        assert!(s.read(&mut [0]).is_ok());
     }
 
     #[test]
@@ -1305,7 +1305,7 @@ mod test {
         spawn(proc() {
             let mut s = TcpStream::connect(addr).unwrap();
             rx.recv();
-            assert_eq!(s.write([0]), Ok(()));
+            assert_eq!(s.write(&[0]), Ok(()));
             let _ = rx.recv_opt();
         });
 
@@ -1314,12 +1314,12 @@ mod test {
         let (tx2, rx2) = channel();
         spawn(proc() {
             let mut s2 = s2;
-            assert_eq!(s2.read([0]), Ok(1));
+            assert_eq!(s2.read(&mut [0]), Ok(1));
             tx2.send(());
         });
 
         s.set_read_timeout(Some(20));
-        assert_eq!(s.read([0]).err().unwrap().kind, TimedOut);
+        assert_eq!(s.read(&mut [0]).err().unwrap().kind, TimedOut);
         tx.send(());
 
         rx2.recv();

--- a/src/libstd/io/pipe.rs
+++ b/src/libstd/io/pipe.rs
@@ -125,12 +125,12 @@ mod test {
         let (tx, rx) = channel();
         spawn(proc() {
             let mut out = out;
-            out.write([10]).unwrap();
+            out.write(&[10]).unwrap();
             rx.recv(); // don't close the pipe until the other read has finished
         });
 
         let mut buf = [0, ..10];
-        input.read(buf).unwrap();
+        input.read(&mut buf).unwrap();
         tx.send(());
     }
 }

--- a/src/libstd/io/result.rs
+++ b/src/libstd/io/result.rs
@@ -85,7 +85,7 @@ mod test {
     #[test]
     fn test_option_writer() {
         let mut writer: io::IoResult<MemWriter> = Ok(MemWriter::new());
-        writer.write([0, 1, 2]).unwrap();
+        writer.write(&[0, 1, 2]).unwrap();
         writer.flush().unwrap();
         assert_eq!(writer.unwrap().unwrap(), vec!(0, 1, 2));
     }
@@ -95,7 +95,7 @@ mod test {
         let mut writer: io::IoResult<MemWriter> =
             Err(io::standard_error(io::EndOfFile));
 
-        match writer.write([0, 0, 0]) {
+        match writer.write(&[0, 0, 0]) {
             Ok(..) => panic!(),
             Err(e) => assert_eq!(e.kind, io::EndOfFile),
         }
@@ -110,7 +110,7 @@ mod test {
         let mut reader: io::IoResult<MemReader> =
             Ok(MemReader::new(vec!(0, 1, 2, 3)));
         let mut buf = [0, 0];
-        reader.read(buf).unwrap();
+        reader.read(&mut buf).unwrap();
         let b: &[_] = &[0, 1];
         assert_eq!(buf.as_slice(), b);
     }
@@ -121,7 +121,7 @@ mod test {
             Err(io::standard_error(io::EndOfFile));
         let mut buf = [];
 
-        match reader.read(buf) {
+        match reader.read(&mut buf) {
             Ok(..) => panic!(),
             Err(e) => assert_eq!(e.kind, io::EndOfFile),
         }

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -237,7 +237,7 @@ pub fn print(s: &str) {
 /// `\n` character is printed to the console after the string.
 pub fn println(s: &str) {
     with_task_stdout(|io| {
-        io.write(s.as_bytes()).and_then(|()| io.write([b'\n']))
+        io.write(s.as_bytes()).and_then(|()| io.write(&[b'\n']))
     })
 }
 

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -225,7 +225,7 @@ impl<R: Reader, W: Writer> Reader for TeeReader<R, W> {
 pub fn copy<R: Reader, W: Writer>(r: &mut R, w: &mut W) -> io::IoResult<()> {
     let mut buf = [0, ..super::DEFAULT_BUF_SIZE];
     loop {
-        let len = match r.read(buf) {
+        let len = match r.read(&mut buf) {
             Ok(len) => len,
             Err(ref e) if e.kind == io::EndOfFile => return Ok(()),
             Err(e) => return Err(e),
@@ -352,7 +352,7 @@ mod test {
 
         let mut multi = MultiWriter::new(vec!(box TestWriter as Box<Writer>,
                                               box TestWriter as Box<Writer>));
-        multi.write([1, 2, 3]).unwrap();
+        multi.write(&[1, 2, 3]).unwrap();
         assert_eq!(2, unsafe { writes });
         assert_eq!(0, unsafe { flushes });
         multi.flush().unwrap();
@@ -413,25 +413,25 @@ mod test {
     fn test_iter_reader() {
         let mut r = IterReader::new(range(0u8, 8));
         let mut buf = [0, 0, 0];
-        let len = r.read(buf).unwrap();
+        let len = r.read(&mut buf).unwrap();
         assert_eq!(len, 3);
         assert!(buf == [0, 1, 2]);
 
-        let len = r.read(buf).unwrap();
+        let len = r.read(&mut buf).unwrap();
         assert_eq!(len, 3);
         assert!(buf == [3, 4, 5]);
 
-        let len = r.read(buf).unwrap();
+        let len = r.read(&mut buf).unwrap();
         assert_eq!(len, 2);
         assert!(buf == [6, 7, 5]);
 
-        assert_eq!(r.read(buf).unwrap_err().kind, io::EndOfFile);
+        assert_eq!(r.read(&mut buf).unwrap_err().kind, io::EndOfFile);
     }
 
     #[test]
     fn iter_reader_zero_length() {
         let mut r = IterReader::new(range(0u8, 8));
         let mut buf = [];
-        assert_eq!(Ok(0), r.read(buf));
+        assert_eq!(Ok(0), r.read(&mut buf));
     }
 }

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -38,7 +38,7 @@ pub fn to_str_bytes<U>(n: $T, radix: uint, f: |v: &[u8]| -> U) -> U {
     // base 2 number, and then we need another for a possible '-' character.
     let mut buf = [0u8, ..65];
     let amt = {
-        let mut wr = ::io::BufWriter::new(buf);
+        let mut wr = ::io::BufWriter::new(&mut buf);
         (write!(&mut wr, "{}", ::fmt::radix(n, radix as u8))).unwrap();
         wr.tell().unwrap() as uint
     };

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1936,7 +1936,7 @@ mod tests {
     fn memory_map_rw() {
         use result::{Ok, Err};
 
-        let chunk = match os::MemoryMap::new(16, [
+        let chunk = match os::MemoryMap::new(16, &[
             os::MapReadable,
             os::MapWritable
         ]) {
@@ -1983,7 +1983,7 @@ mod tests {
             "x".with_c_str(|x| assert!(write(fd, x as *const c_void, 1) == 1));
             fd
         };
-        let chunk = match MemoryMap::new(size / 2, [
+        let chunk = match MemoryMap::new(size / 2, &[
             MapReadable,
             MapWritable,
             MapFd(fd),
@@ -2012,16 +2012,16 @@ mod tests {
                 parsed.iter().map(|s| Path::new(*s)).collect()
         }
 
-        assert!(check_parse("", [""]));
-        assert!(check_parse(r#""""#, [""]));
-        assert!(check_parse(";;", ["", "", ""]));
-        assert!(check_parse(r"c:\", [r"c:\"]));
-        assert!(check_parse(r"c:\;", [r"c:\", ""]));
+        assert!(check_parse("", &mut [""]));
+        assert!(check_parse(r#""""#, &mut [""]));
+        assert!(check_parse(";;", &mut ["", "", ""]));
+        assert!(check_parse(r"c:\", &mut [r"c:\"]));
+        assert!(check_parse(r"c:\;", &mut [r"c:\", ""]));
         assert!(check_parse(r"c:\;c:\Program Files\",
-                            [r"c:\", r"c:\Program Files\"]));
-        assert!(check_parse(r#"c:\;c:\"foo"\"#, [r"c:\", r"c:\foo\"]));
+                            &mut [r"c:\", r"c:\Program Files\"]));
+        assert!(check_parse(r#"c:\;c:\"foo"\"#, &mut [r"c:\", r"c:\foo\"]));
         assert!(check_parse(r#"c:\;c:\"foo;bar"\;c:\baz"#,
-                            [r"c:\", r"c:\foo;bar\", r"c:\baz"]));
+                            &mut [r"c:\", r"c:\foo;bar\", r"c:\baz"]));
     }
 
     #[test]
@@ -2032,11 +2032,11 @@ mod tests {
                 parsed.iter().map(|s| Path::new(*s)).collect()
         }
 
-        assert!(check_parse("", [""]));
-        assert!(check_parse("::", ["", "", ""]));
-        assert!(check_parse("/", ["/"]));
-        assert!(check_parse("/:", ["/", ""]));
-        assert!(check_parse("/:/usr/local", ["/", "/usr/local"]));
+        assert!(check_parse("", &mut [""]));
+        assert!(check_parse("::", &mut ["", "", ""]));
+        assert!(check_parse("/", &mut ["/"]));
+        assert!(check_parse("/:", &mut ["/", ""]));
+        assert!(check_parse("/:/usr/local", &mut ["/", "/usr/local"]));
     }
 
     #[test]
@@ -2046,12 +2046,12 @@ mod tests {
             join_paths(input).unwrap().as_slice() == output.as_bytes()
         }
 
-        assert!(test_eq([], ""));
-        assert!(test_eq(["/bin", "/usr/bin", "/usr/local/bin"],
-                        "/bin:/usr/bin:/usr/local/bin"));
-        assert!(test_eq(["", "/bin", "", "", "/usr/bin", ""],
-                        ":/bin:::/usr/bin:"));
-        assert!(join_paths(["/te:st"]).is_err());
+        assert!(test_eq(&[], ""));
+        assert!(test_eq(&["/bin", "/usr/bin", "/usr/local/bin"],
+                         "/bin:/usr/bin:/usr/local/bin"));
+        assert!(test_eq(&["", "/bin", "", "", "/usr/bin", ""],
+                         ":/bin:::/usr/bin:"));
+        assert!(join_paths(&["/te:st"]).is_err());
     }
 
     #[test]
@@ -2068,7 +2068,7 @@ mod tests {
                         r";c:\windows;;;c:\;"));
         assert!(test_eq([r"c:\te;st", r"c:\"],
                         r#""c:\te;st";c:\"#));
-        assert!(join_paths([r#"c:\te"st"#]).is_err());
+        assert!(join_paths(&[r#"c:\te"st"#]).is_err());
     }
 
     // More recursive_mkdir tests are in extra::tempfile

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -462,7 +462,7 @@ mod tests {
 
     #[test]
     fn test_paths() {
-        let empty: &[u8] = [];
+        let empty: &[u8] = &[];
         t!(v: Path::new(empty), b".");
         t!(v: Path::new(b"/"), b"/");
         t!(v: Path::new(b"a/b/c"), b"a/b/c");
@@ -731,14 +731,14 @@ mod tests {
             (s: $path:expr, $push:expr, $exp:expr) => (
                 {
                     let mut p = Path::new($path);
-                    p.push_many($push);
+                    p.push_many(&$push);
                     assert!(p.as_str() == Some($exp));
                 }
             );
             (v: $path:expr, $push:expr, $exp:expr) => (
                 {
                     let mut p = Path::new($path);
-                    p.push_many($push);
+                    p.push_many(&$push);
                     assert!(p.as_vec() == $exp);
                 }
             )
@@ -836,14 +836,14 @@ mod tests {
             (s: $path:expr, $join:expr, $exp:expr) => (
                 {
                     let path = Path::new($path);
-                    let res = path.join_many($join);
+                    let res = path.join_many(&$join);
                     assert!(res.as_str() == Some($exp));
                 }
             );
             (v: $path:expr, $join:expr, $exp:expr) => (
                 {
                     let path = Path::new($path);
-                    let res = path.join_many($join);
+                    let res = path.join_many(&$join);
                     assert!(res.as_vec() == $exp);
                 }
             )
@@ -859,7 +859,7 @@ mod tests {
 
     #[test]
     fn test_with_helpers() {
-        let empty: &[u8] = [];
+        let empty: &[u8] = &[];
 
         t!(v: Path::new(b"a/b/c").with_filename(b"d"), b"a/b/d");
         t!(v: Path::new(b"a/b/c\xFF").with_filename(b"\x80"), b"a/b/\x80");
@@ -1173,7 +1173,7 @@ mod tests {
                 {
                     let path = Path::new($path);
                     let comps = path.components().collect::<Vec<&[u8]>>();
-                    let exp: &[&str] = $exp;
+                    let exp: &[&str] = &$exp;
                     let exps = exp.iter().map(|x| x.as_bytes()).collect::<Vec<&[u8]>>();
                     assert!(comps == exps, "components: Expected {}, found {}",
                             comps, exps);
@@ -1187,7 +1187,7 @@ mod tests {
                 {
                     let path = Path::new($arg);
                     let comps = path.components().collect::<Vec<&[u8]>>();
-                    let exp: &[&[u8]] = [$($exp),*];
+                    let exp: &[&[u8]] = &[$($exp),*];
                     assert_eq!(comps.as_slice(), exp);
                     let comps = path.components().rev().collect::<Vec<&[u8]>>();
                     let exp = exp.iter().rev().map(|&x|x).collect::<Vec<&[u8]>>();
@@ -1219,7 +1219,7 @@ mod tests {
                 {
                     let path = Path::new($arg);
                     let comps = path.str_components().collect::<Vec<Option<&str>>>();
-                    let exp: &[Option<&str>] = $exp;
+                    let exp: &[Option<&str>] = &$exp;
                     assert_eq!(comps.as_slice(), exp);
                     let comps = path.str_components().rev().collect::<Vec<Option<&str>>>();
                     let exp = exp.iter().rev().map(|&x|x).collect::<Vec<Option<&str>>>();

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -1195,7 +1195,7 @@ mod tests {
 
     #[test]
     fn test_paths() {
-        let empty: &[u8] = [];
+        let empty: &[u8] = &[];
         t!(v: Path::new(empty), b".");
         t!(v: Path::new(b"\\"), b"\\");
         t!(v: Path::new(b"a\\b\\c"), b"a\\b\\c");
@@ -1571,14 +1571,14 @@ mod tests {
             (s: $path:expr, $push:expr, $exp:expr) => (
                 {
                     let mut p = Path::new($path);
-                    p.push_many($push);
+                    p.push_many(&$push);
                     assert_eq!(p.as_str(), Some($exp));
                 }
             );
             (v: $path:expr, $push:expr, $exp:expr) => (
                 {
                     let mut p = Path::new($path);
-                    p.push_many($push);
+                    p.push_many(&$push);
                     assert_eq!(p.as_vec(), $exp);
                 }
             )
@@ -1712,14 +1712,14 @@ mod tests {
             (s: $path:expr, $join:expr, $exp:expr) => (
                 {
                     let path = Path::new($path);
-                    let res = path.join_many($join);
+                    let res = path.join_many(&$join);
                     assert_eq!(res.as_str(), Some($exp));
                 }
             );
             (v: $path:expr, $join:expr, $exp:expr) => (
                 {
                     let path = Path::new($path);
-                    let res = path.join_many($join);
+                    let res = path.join_many(&$join);
                     assert_eq!(res.as_vec(), $exp);
                 }
             )
@@ -2252,7 +2252,7 @@ mod tests {
                     let path = Path::new($path);
                     let comps = path.str_components().map(|x|x.unwrap())
                                 .collect::<Vec<&str>>();
-                    let exp: &[&str] = $exp;
+                    let exp: &[&str] = &$exp;
                     assert_eq!(comps.as_slice(), exp);
                     let comps = path.str_components().rev().map(|x|x.unwrap())
                                 .collect::<Vec<&str>>();
@@ -2309,7 +2309,7 @@ mod tests {
                 {
                     let path = Path::new($path);
                     let comps = path.components().collect::<Vec<&[u8]>>();
-                    let exp: &[&[u8]] = $exp;
+                    let exp: &[&[u8]] = &$exp;
                     assert_eq!(comps.as_slice(), exp);
                     let comps = path.components().rev().collect::<Vec<&[u8]>>();
                     let exp = exp.iter().rev().map(|&x|x).collect::<Vec<&[u8]>>();

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -522,7 +522,7 @@ mod test {
     #[test]
     fn test_choose() {
         let mut r = task_rng();
-        assert_eq!(r.choose([1i, 1, 1]).map(|&x|x), Some(1));
+        assert_eq!(r.choose(&[1i, 1, 1]).map(|&x|x), Some(1));
 
         let v: &[int] = &[];
         assert_eq!(r.choose(v), None);
@@ -534,16 +534,16 @@ mod test {
         let empty: &mut [int] = &mut [];
         r.shuffle(empty);
         let mut one = [1i];
-        r.shuffle(one);
+        r.shuffle(&mut one);
         let b: &[_] = &[1];
         assert_eq!(one.as_slice(), b);
 
         let mut two = [1i, 2];
-        r.shuffle(two);
+        r.shuffle(&mut two);
         assert!(two == [1, 2] || two == [2, 1]);
 
         let mut x = [1i, 1, 1];
-        r.shuffle(x);
+        r.shuffle(&mut x);
         let b: &[_] = &[1, 1, 1];
         assert_eq!(x.as_slice(), b);
     }
@@ -553,7 +553,7 @@ mod test {
         let mut r = task_rng();
         r.gen::<int>();
         let mut v = [1i, 1, 1];
-        r.shuffle(v);
+        r.shuffle(&mut v);
         let b: &[_] = &[1, 1, 1];
         assert_eq!(v.as_slice(), b);
         assert_eq!(r.gen_range(0u, 1u), 0u);
@@ -673,7 +673,7 @@ mod bench {
     #[bench]
     fn rand_shuffle_100(b: &mut Bencher) {
         let mut rng = weak_rng();
-        let x : &mut[uint] = [1,..100];
+        let x : &mut[uint] = &mut [1,..100];
         b.iter(|| {
             rng.shuffle(x);
         })

--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -343,7 +343,7 @@ mod test {
         r.next_u64();
 
         let mut v = [0u8, .. 1000];
-        r.fill_bytes(v);
+        r.fill_bytes(&mut v);
     }
 
     #[test]
@@ -368,7 +368,7 @@ mod test {
                     task::deschedule();
                     r.next_u64();
                     task::deschedule();
-                    r.fill_bytes(v);
+                    r.fill_bytes(&mut v);
                     task::deschedule();
                 }
             })

--- a/src/libstd/rand/reader.rs
+++ b/src/libstd/rand/reader.rs
@@ -108,7 +108,7 @@ mod test {
         let mut w = [0u8, .. 8];
 
         let mut rng = ReaderRng::new(MemReader::new(v.as_slice().to_vec()));
-        rng.fill_bytes(w);
+        rng.fill_bytes(&mut w);
 
         assert!(v == w);
     }
@@ -118,6 +118,6 @@ mod test {
     fn test_reader_rng_insufficient_bytes() {
         let mut rng = ReaderRng::new(MemReader::new(vec!()));
         let mut v = [0u8, .. 3];
-        rng.fill_bytes(v);
+        rng.fill_bytes(&mut v);
     }
 }

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -527,7 +527,7 @@ mod imp {
             Some(string) => try!(super::demangle(w, string)),
             None => try!(write!(w, "<unknown>")),
         }
-        w.write(['\n' as u8])
+        w.write(&['\n' as u8])
     }
 
     /// Unwind library interface used for backtraces

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -359,7 +359,7 @@ pub fn read<T>(fd: sock_t,
             // With a timeout, first we wait for the socket to become
             // readable using select(), specifying the relevant timeout for
             // our previously set deadline.
-            try!(await([fd], deadline, Readable));
+            try!(await(&[fd], deadline, Readable));
 
             // At this point, we're still within the timeout, and we've
             // determined that the socket is readable (as returned by
@@ -411,7 +411,7 @@ pub fn write<T>(fd: sock_t,
         while written < buf.len() && (write_everything || written == 0) {
             // As with read(), first wait for the socket to be ready for
             // the I/O operation.
-            match await([fd], deadline, Writable) {
+            match await(&[fd], deadline, Writable) {
                 Err(ref e) if e.kind == io::EndOfFile && written > 0 => {
                     assert!(deadline.is_some());
                     return Err(short_write(written, "short write"))

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -376,7 +376,7 @@ mod tests {
 
         writer.write(b"test").ok().unwrap();
         let mut buf = [0u8, ..4];
-        match reader.read(buf) {
+        match reader.read(&mut buf) {
             Ok(4) => {
                 assert_eq!(buf[0], 't' as u8);
                 assert_eq!(buf[1], 'e' as u8);
@@ -386,7 +386,7 @@ mod tests {
             r => panic!("invalid read: {}", r),
         }
 
-        assert!(writer.read(buf).is_err());
-        assert!(reader.write(buf).is_err());
+        assert!(writer.read(&mut buf).is_err());
+        assert!(reader.write(&buf).is_err());
     }
 }

--- a/src/libstd/sys/unix/helper_signal.rs
+++ b/src/libstd/sys/unix/helper_signal.rs
@@ -21,7 +21,7 @@ pub fn new() -> (signal, signal) {
 }
 
 pub fn signal(fd: libc::c_int) {
-    FileDesc::new(fd, false).write([0]).ok().unwrap();
+    FileDesc::new(fd, false).write(&[0]).ok().unwrap();
 }
 
 pub fn close(fd: libc::c_int) {

--- a/src/libstd/sys/unix/pipe.rs
+++ b/src/libstd/sys/unix/pipe.rs
@@ -281,8 +281,8 @@ impl UnixAcceptor {
                     fd => return Ok(UnixStream::new(Arc::new(Inner::new(fd)))),
                 }
             }
-            try!(await([self.fd(), self.inner.reader.fd()],
-                             deadline, Readable));
+            try!(await(&[self.fd(), self.inner.reader.fd()],
+                       deadline, Readable));
         }
 
         Err(eof())
@@ -295,7 +295,7 @@ impl UnixAcceptor {
     pub fn close_accept(&mut self) -> IoResult<()> {
         self.inner.closed.store(true, atomic::SeqCst);
         let fd = FileDesc::new(self.inner.writer.fd(), false);
-        match fd.write([0]) {
+        match fd.write(&[0]) {
             Ok(..) => Ok(()),
             Err(..) if wouldblock() => Ok(()),
             Err(e) => Err(e),

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -107,7 +107,7 @@ impl Process {
                 } else if pid > 0 {
                     drop(output);
                     let mut bytes = [0, ..4];
-                    return match input.read(bytes) {
+                    return match input.read(&mut bytes) {
                         Ok(4) => {
                             let errno = (bytes[0] as i32 << 24) |
                                         (bytes[1] as i32 << 16) |
@@ -160,7 +160,7 @@ impl Process {
                         (errno >>  8) as u8,
                         (errno >>  0) as u8,
                     ];
-                    assert!(output.write(bytes).is_ok());
+                    assert!(output.write(&bytes).is_ok());
                     unsafe { libc::_exit(1) }
                 }
 

--- a/src/libstd/sys/unix/tcp.rs
+++ b/src/libstd/sys/unix/tcp.rs
@@ -121,8 +121,8 @@ impl TcpAcceptor {
                 -1 => return Err(last_net_error()),
                 fd => return Ok(TcpStream::new(fd as sock_t)),
             }
-            try!(await([self.fd(), self.inner.reader.fd()],
-                             deadline, Readable));
+            try!(await(&[self.fd(), self.inner.reader.fd()],
+                       deadline, Readable));
         }
 
         Err(sys_common::eof())
@@ -139,7 +139,7 @@ impl TcpAcceptor {
     pub fn close_accept(&mut self) -> IoResult<()> {
         self.inner.closed.store(true, atomic::SeqCst);
         let fd = FileDesc::new(self.inner.writer.fd(), false);
-        match fd.write([0]) {
+        match fd.write(&[0]) {
             Ok(..) => Ok(()),
             Err(..) if wouldblock() => Ok(()),
             Err(e) => Err(e),

--- a/src/libstd/sys/unix/timer.rs
+++ b/src/libstd/sys/unix/timer.rs
@@ -193,7 +193,7 @@ fn helper(input: libc::c_int, messages: Receiver<Req>, _: ()) {
 
                 // drain the file descriptor
                 let mut buf = [0];
-                assert_eq!(fd.read(buf).ok().unwrap(), 1);
+                assert_eq!(fd.read(&mut buf).ok().unwrap(), 1);
             }
 
             -1 if os::errno() == libc::EINTR as uint => {}

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -136,6 +136,7 @@ fn decodable_substructure(cx: &mut ExtCtxt, trait_span: Span,
                                                   cx.expr_ident(trait_span, variant), arms));
             let lambda = cx.lambda_expr(trait_span, vec!(blkarg, variant), result);
             let variant_vec = cx.expr_vec(trait_span, variants);
+            let variant_vec = cx.expr_addr_of(trait_span, variant_vec);
             let result = cx.expr_method_call(trait_span, blkdecoder,
                                              cx.ident_of("read_enum_variant"),
                                              vec!(variant_vec, lambda));

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -247,7 +247,7 @@ mod tests {
 
     #[test]
     fn i3 () {
-        let i : Interner<RcStr> = Interner::prefill([
+        let i : Interner<RcStr> = Interner::prefill(&[
             RcStr::new("Alan"),
             RcStr::new("Bob"),
             RcStr::new("Carol")

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -81,7 +81,7 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
                                .find_equiv("setaf")
                                .unwrap()
                                .as_slice(),
-                           [Number(color as int)], &mut Variables::new());
+                           &[Number(color as int)], &mut Variables::new());
             if s.is_ok() {
                 try!(self.out.write(s.unwrap().as_slice()));
                 return Ok(true)
@@ -98,7 +98,7 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
                                .find_equiv("setab")
                                .unwrap()
                                .as_slice(),
-                           [Number(color as int)], &mut Variables::new());
+                           &[Number(color as int)], &mut Variables::new());
             if s.is_ok() {
                 try!(self.out.write(s.unwrap().as_slice()));
                 return Ok(true)
@@ -116,7 +116,7 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
                 let parm = self.ti.strings.find_equiv(cap);
                 if parm.is_some() {
                     let s = expand(parm.unwrap().as_slice(),
-                                   [],
+                                   &[],
                                    &mut Variables::new());
                     if s.is_ok() {
                         try!(self.out.write(s.unwrap().as_slice()));
@@ -151,7 +151,7 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
             }
         }
         let s = cap.map_or(Err("can't find terminfo capability `sgr0`".to_string()), |op| {
-            expand(op.as_slice(), [], &mut Variables::new())
+            expand(op.as_slice(), &[], &mut Variables::new())
         });
         if s.is_ok() {
             return self.out.write(s.unwrap().as_slice())

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -581,13 +581,13 @@ mod test {
     #[test]
     fn test_basic_setabf() {
         let s = b"\\E[48;5;%p1%dm";
-        assert_eq!(expand(s, [Number(1)], &mut Variables::new()).unwrap(),
+        assert_eq!(expand(s, &[Number(1)], &mut Variables::new()).unwrap(),
                    "\\E[48;5;1m".bytes().collect());
     }
 
     #[test]
     fn test_multiple_int_constants() {
-        assert_eq!(expand(b"%{1}%{2}%d%d", [], &mut Variables::new()).unwrap(),
+        assert_eq!(expand(b"%{1}%{2}%d%d", &[], &mut Variables::new()).unwrap(),
                    "21".bytes().collect());
     }
 
@@ -595,9 +595,9 @@ mod test {
     fn test_op_i() {
         let mut vars = Variables::new();
         assert_eq!(expand(b"%p1%d%p2%d%p3%d%i%p1%d%p2%d%p3%d",
-                          [Number(1),Number(2),Number(3)], &mut vars),
+                          &[Number(1),Number(2),Number(3)], &mut vars),
                    Ok("123233".bytes().collect()));
-        assert_eq!(expand(b"%p1%d%p2%d%i%p1%d%p2%d", [], &mut vars),
+        assert_eq!(expand(b"%p1%d%p2%d%i%p1%d%p2%d", &[], &mut vars),
                    Ok("0011".bytes().collect()));
     }
 
@@ -615,7 +615,7 @@ mod test {
 
         let caps = ["%d", "%c", "%s", "%Pa", "%l", "%!", "%~"];
         for &cap in caps.iter() {
-            let res = get_res("", cap, [], vars);
+            let res = get_res("", cap, &[], vars);
             assert!(res.is_err(),
                     "Op {} succeeded incorrectly with 0 stack entries", cap);
             let p = if cap == "%s" || cap == "%l" {
@@ -623,19 +623,19 @@ mod test {
             } else {
                 Number(97)
             };
-            let res = get_res("%p1", cap, [p], vars);
+            let res = get_res("%p1", cap, &[p], vars);
             assert!(res.is_ok(),
                     "Op {} failed with 1 stack entry: {}", cap, res.unwrap_err());
         }
         let caps = ["%+", "%-", "%*", "%/", "%m", "%&", "%|", "%A", "%O"];
         for &cap in caps.iter() {
-            let res = expand(cap.as_bytes(), [], vars);
+            let res = expand(cap.as_bytes(), &[], vars);
             assert!(res.is_err(),
                     "Binop {} succeeded incorrectly with 0 stack entries", cap);
-            let res = get_res("%{1}", cap, [], vars);
+            let res = get_res("%{1}", cap, &[], vars);
             assert!(res.is_err(),
                     "Binop {} succeeded incorrectly with 1 stack entry", cap);
-            let res = get_res("%{1}%{2}", cap, [], vars);
+            let res = get_res("%{1}%{2}", cap, &[], vars);
             assert!(res.is_ok(),
                     "Binop {} failed with 2 stack entries: {}", cap, res.unwrap_err());
         }
@@ -643,7 +643,7 @@ mod test {
 
     #[test]
     fn test_push_bad_param() {
-        assert!(expand(b"%pa", [], &mut Variables::new()).is_err());
+        assert!(expand(b"%pa", &[], &mut Variables::new()).is_err());
     }
 
     #[test]
@@ -651,15 +651,15 @@ mod test {
         let v = [('<', [1u8, 0u8, 0u8]), ('=', [0u8, 1u8, 0u8]), ('>', [0u8, 0u8, 1u8])];
         for &(op, bs) in v.iter() {
             let s = format!("%{{1}}%{{2}}%{}%d", op);
-            let res = expand(s.as_bytes(), [], &mut Variables::new());
+            let res = expand(s.as_bytes(), &[], &mut Variables::new());
             assert!(res.is_ok(), res.unwrap_err());
             assert_eq!(res.unwrap(), vec!(b'0' + bs[0]));
             let s = format!("%{{1}}%{{1}}%{}%d", op);
-            let res = expand(s.as_bytes(), [], &mut Variables::new());
+            let res = expand(s.as_bytes(), &[], &mut Variables::new());
             assert!(res.is_ok(), res.unwrap_err());
             assert_eq!(res.unwrap(), vec!(b'0' + bs[1]));
             let s = format!("%{{2}}%{{1}}%{}%d", op);
-            let res = expand(s.as_bytes(), [], &mut Variables::new());
+            let res = expand(s.as_bytes(), &[], &mut Variables::new());
             assert!(res.is_ok(), res.unwrap_err());
             assert_eq!(res.unwrap(), vec!(b'0' + bs[2]));
         }
@@ -669,15 +669,15 @@ mod test {
     fn test_conditionals() {
         let mut vars = Variables::new();
         let s = b"\\E[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m";
-        let res = expand(s, [Number(1)], &mut vars);
+        let res = expand(s, &[Number(1)], &mut vars);
         assert!(res.is_ok(), res.unwrap_err());
         assert_eq!(res.unwrap(),
                    "\\E[31m".bytes().collect());
-        let res = expand(s, [Number(8)], &mut vars);
+        let res = expand(s, &[Number(8)], &mut vars);
         assert!(res.is_ok(), res.unwrap_err());
         assert_eq!(res.unwrap(),
                    "\\E[90m".bytes().collect());
-        let res = expand(s, [Number(42)], &mut vars);
+        let res = expand(s, &[Number(42)], &mut vars);
         assert!(res.is_ok(), res.unwrap_err());
         assert_eq!(res.unwrap(),
                    "\\E[38;5;42m".bytes().collect());
@@ -688,17 +688,17 @@ mod test {
         let mut varstruct = Variables::new();
         let vars = &mut varstruct;
         assert_eq!(expand(b"%p1%s%p2%2s%p3%2s%p4%.2s",
-                          [Words("foo".to_string()),
-                           Words("foo".to_string()),
-                           Words("f".to_string()),
-                           Words("foo".to_string())], vars),
+                          &[Words("foo".to_string()),
+                            Words("foo".to_string()),
+                            Words("f".to_string()),
+                            Words("foo".to_string())], vars),
                    Ok("foofoo ffo".bytes().collect()));
-        assert_eq!(expand(b"%p1%:-4.2s", [Words("foo".to_string())], vars),
+        assert_eq!(expand(b"%p1%:-4.2s", &[Words("foo".to_string())], vars),
                    Ok("fo  ".bytes().collect()));
 
-        assert_eq!(expand(b"%p1%d%p1%.3d%p1%5d%p1%:+d", [Number(1)], vars),
+        assert_eq!(expand(b"%p1%d%p1%.3d%p1%5d%p1%:+d", &[Number(1)], vars),
                    Ok("1001    1+1".bytes().collect()));
-        assert_eq!(expand(b"%p1%o%p1%#o%p2%6.4x%p2%#6.4X", [Number(15), Number(27)], vars),
+        assert_eq!(expand(b"%p1%o%p1%#o%p2%6.4x%p2%#6.4X", &[Number(15), Number(27)], vars),
                    Ok("17017  001b0X001B".bytes().collect()));
     }
 }

--- a/src/libterm/terminfo/searcher.rs
+++ b/src/libterm/terminfo/searcher.rs
@@ -61,13 +61,13 @@ pub fn get_dbpath_for_term(term: &str) -> Option<Box<Path>> {
     for p in dirs_to_search.iter() {
         if p.exists() {
             let f = first_char.to_string();
-            let newp = p.join_many([f.as_slice(), term]);
+            let newp = p.join_many(&[f.as_slice(), term]);
             if newp.exists() {
                 return Some(box newp);
             }
             // on some installations the dir is named after the hex of the char (e.g. OS X)
             let f = format!("{:x}", first_char as uint);
-            let newp = p.join_many([f.as_slice(), term]);
+            let newp = p.join_many(&[f.as_slice(), term]);
             if newp.exists() {
                 return Some(box newp);
             }

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1317,7 +1317,7 @@ impl Bencher {
         if n == 0 { n = 1; }
 
         let mut total_run = Duration::nanoseconds(0);
-        let samples : &mut [f64] = [0.0_f64, ..50];
+        let samples : &mut [f64] = &mut [0.0_f64, ..50];
         loop {
             let mut summ = None;
             let mut summ5 = None;

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -1034,11 +1034,11 @@ mod tests {
             assert_eq!(out, expected);
         }
 
-        t(&Summary::new([-2.0f64, -1.0f64]),
+        t(&Summary::new(&[-2.0f64, -1.0f64]),
                         "-2 |[------******#*****---]| -1".to_string());
-        t(&Summary::new([0.0f64, 2.0f64]),
+        t(&Summary::new(&[0.0f64, 2.0f64]),
                         "0 |[-------*****#*******---]| 2".to_string());
-        t(&Summary::new([-2.0f64, 0.0f64]),
+        t(&Summary::new(&[-2.0f64, 0.0f64]),
                         "-2 |[------******#******---]| 0".to_string());
 
     }

--- a/src/libtime/lib.rs
+++ b/src/libtime/lib.rs
@@ -904,7 +904,7 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ParseError> {
     fn parse_type(s: &str, pos: uint, ch: char, tm: &mut Tm)
       -> Result<uint, ParseError> {
         match ch {
-          'A' => match match_strs(s, pos, [
+          'A' => match match_strs(s, pos, &[
               ("Sunday", 0_i32),
               ("Monday", 1_i32),
               ("Tuesday", 2_i32),
@@ -916,7 +916,7 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ParseError> {
             Some(item) => { let (v, pos) = item; tm.tm_wday = v; Ok(pos) }
             None => Err(InvalidDay)
           },
-          'a' => match match_strs(s, pos, [
+          'a' => match match_strs(s, pos, &[
               ("Sun", 0_i32),
               ("Mon", 1_i32),
               ("Tue", 2_i32),
@@ -928,7 +928,7 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ParseError> {
             Some(item) => { let (v, pos) = item; tm.tm_wday = v; Ok(pos) }
             None => Err(InvalidDay)
           },
-          'B' => match match_strs(s, pos, [
+          'B' => match match_strs(s, pos, &[
               ("January", 0_i32),
               ("February", 1_i32),
               ("March", 2_i32),
@@ -945,7 +945,7 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ParseError> {
             Some(item) => { let (v, pos) = item; tm.tm_mon = v; Ok(pos) }
             None => Err(InvalidMonth)
           },
-          'b' | 'h' => match match_strs(s, pos, [
+          'b' | 'h' => match match_strs(s, pos, &[
               ("Jan", 0_i32),
               ("Feb", 1_i32),
               ("Mar", 2_i32),
@@ -1071,13 +1071,13 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ParseError> {
           }
           'n' => parse_char(s, pos, '\n'),
           'P' => match match_strs(s, pos,
-                                  [("am", 0_i32), ("pm", 12_i32)]) {
+                                  &[("am", 0_i32), ("pm", 12_i32)]) {
 
             Some(item) => { let (v, pos) = item; tm.tm_hour += v; Ok(pos) }
             None => Err(InvalidHour)
           },
           'p' => match match_strs(s, pos,
-                                  [("AM", 0_i32), ("PM", 12_i32)]) {
+                                  &[("AM", 0_i32), ("PM", 12_i32)]) {
 
             Some(item) => { let (v, pos) = item; tm.tm_hour += v; Ok(pos) }
             None => Err(InvalidHour)
@@ -1225,13 +1225,13 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ParseError> {
         let next = range.next;
 
         let mut buf = [0];
-        let c = match rdr.read(buf) {
+        let c = match rdr.read(&mut buf) {
             Ok(..) => buf[0] as char,
             Err(..) => break
         };
         match c {
             '%' => {
-                let ch = match rdr.read(buf) {
+                let ch = match rdr.read(&mut buf) {
                     Ok(..) => buf[0] as char,
                     Err(..) => break
                 };

--- a/src/test/bench/noise.rs
+++ b/src/test/bench/noise.rs
@@ -52,7 +52,7 @@ impl Noise2DContext {
         for (i, x) in permutations.iter_mut().enumerate() {
             *x = i as i32;
         }
-        rng.shuffle(permutations);
+        rng.shuffle(&mut permutations);
 
         Noise2DContext { rgradients: rgradients, permutations: permutations }
     }

--- a/src/test/bench/shootout-fannkuch-redux.rs
+++ b/src/test/bench/shootout-fannkuch-redux.rs
@@ -118,7 +118,7 @@ impl Perm {
     fn max(&self) -> u32 { self.fact[self.n as uint] }
 
     fn next(&mut self) -> P {
-        next_permutation(self.perm.p, self.cnt);
+        next_permutation(&mut self.perm.p, &mut self.cnt);
         self.permcount += 1;
 
         self.perm
@@ -141,7 +141,7 @@ fn work(mut perm: Perm, n: uint, max: uint) -> (i32, i32) {
 
         while p.p[0] != 1 {
             let k = p.p[0] as uint;
-            reverse(p.p, k);
+            reverse(&mut p.p, k);
             flips += 1;
         }
 

--- a/src/test/bench/shootout-fasta-redux.rs
+++ b/src/test/bench/shootout-fasta-redux.rs
@@ -198,7 +198,7 @@ impl<'a, W: Writer> RandomFasta<'a, W> {
                 buf[i] = self.nextc();
             }
             buf[LINE_LEN] = '\n' as u8;
-            try!(self.out.write(buf));
+            try!(self.out.write(&buf));
         }
         for i in range(0u, chars_left) {
             buf[i] = self.nextc();
@@ -225,12 +225,12 @@ fn main() {
     }
 
     out.write_line(">TWO IUB ambiguity codes").unwrap();
-    let iub = sum_and_scale(IUB);
+    let iub = sum_and_scale(&IUB);
     let mut random = RandomFasta::new(&mut out, iub.as_slice());
     random.make(n * 3).unwrap();
 
     random.out.write_line(">THREE Homo sapiens frequency").unwrap();
-    let homo_sapiens = sum_and_scale(HOMO_SAPIENS);
+    let homo_sapiens = sum_and_scale(&HOMO_SAPIENS);
     random.lookup = make_lookup(homo_sapiens.as_slice());
     random.make(n * 5).unwrap();
 

--- a/src/test/compile-fail/lint-uppercase-variables.rs
+++ b/src/test/compile-fail/lint-uppercase-variables.rs
@@ -30,7 +30,7 @@ fn main() {
 
     let mut f = File::open(&Path::new("something.txt"));
     let mut buff = [0u8, ..16];
-    match f.read(buff) {
+    match f.read(&mut buff) {
         Ok(cnt) => println!("read this many bytes: {}", cnt),
         Err(IoError{ kind: EndOfFile, .. }) => println!("Got end of file: {}", EndOfFile.to_string()),
         //~^ ERROR variable `EndOfFile` should have a snake case name such as `end_of_file`

--- a/src/test/compile-fail/non-exhaustive-pattern-witness.rs
+++ b/src/test/compile-fail/non-exhaustive-pattern-witness.rs
@@ -54,7 +54,7 @@ enum Enum {
 }
 
 fn vectors_with_nested_enums() {
-    let x: &'static [Enum] = [First, Second(false)];
+    let x: &'static [Enum] = &[First, Second(false)];
     match x {
     //~^ ERROR non-exhaustive patterns: `[Second(true), Second(false)]` not covered
         [] => (),

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -39,8 +39,9 @@ pub fn bar() {
          () => {
              #[inline]
              #[allow(dead_code)]
-             static __STATIC_FMTSTR: [&'static str, ..(1u as uint)] =
-                 ([("test" as &'static str)] as [&'static str, ..1]);
+             static __STATIC_FMTSTR: &'static [&'static str] =
+                 (&([("test" as &'static str)] as [&'static str, ..1]) as
+                     &'static [&'static str, ..1]);
              let __args_vec =
                  (&([] as [core::fmt::Argument<'_>, ..0]) as
                      &[core::fmt::Argument<'_>, ..0]);
@@ -49,7 +50,7 @@ pub fn bar() {
                       ((::std::fmt::Arguments::new as
                            unsafe fn(&'static [&'static str], &'a [core::fmt::Argument<'a>]) -> core::fmt::Arguments<'a>)((__STATIC_FMTSTR
                                                                                                                               as
-                                                                                                                              [&'static str, ..1]),
+                                                                                                                              &'static [&'static str]),
                                                                                                                           (__args_vec
                                                                                                                               as
                                                                                                                               &[core::fmt::Argument<'_>, ..0]))

--- a/src/test/run-pass/assignability-trait.rs
+++ b/src/test/run-pass/assignability-trait.rs
@@ -53,5 +53,5 @@ pub fn main() {
     // Call a method
     z.iterate(|y| { assert!(z[*y as uint] == *y); true });
     // Call a parameterized function
-    assert_eq!(length::<int, &[int]>(z), z.len());
+    assert_eq!(length::<int, &[int]>(&z), z.len());
 }

--- a/src/test/run-pass/borrowck-freeze-frozen-mut.rs
+++ b/src/test/run-pass/borrowck-freeze-frozen-mut.rs
@@ -21,7 +21,7 @@ fn get<'a, T>(ms: &'a MutSlice<'a, T>, index: uint) -> &'a T {
 pub fn main() {
     let mut data = [1i, 2, 3];
     {
-        let slice = MutSlice { data: data };
+        let slice = MutSlice { data: &mut data };
         slice.data[0] += 4;
         let index0 = get(&slice, 0);
         let index1 = get(&slice, 1);

--- a/src/test/run-pass/capture-clauses-boxed-closures.rs
+++ b/src/test/run-pass/capture-clauses-boxed-closures.rs
@@ -17,7 +17,7 @@ fn each<T>(x: &[T], f: |&T|) {
 fn main() {
     let mut sum = 0u;
     let elems = [ 1u, 2, 3, 4, 5 ];
-    each(elems, |val| sum += *val);
+    each(&elems, |val| sum += *val);
     assert_eq!(sum, 15);
 }
 

--- a/src/test/run-pass/capture-clauses-unboxed-closures.rs
+++ b/src/test/run-pass/capture-clauses-unboxed-closures.rs
@@ -19,6 +19,6 @@ fn each<'a,T,F:FnMut(&'a T)>(x: &'a [T], mut f: F) {
 fn main() {
     let mut sum = 0u;
     let elems = [ 1u, 2, 3, 4, 5 ];
-    each(elems, |&mut: val: &uint| sum += *val);
+    each(&elems, |&mut: val: &uint| sum += *val);
     assert_eq!(sum, 15);
 }

--- a/src/test/run-pass/cci_iter_exe.rs
+++ b/src/test/run-pass/cci_iter_exe.rs
@@ -15,7 +15,7 @@ extern crate cci_iter_lib;
 pub fn main() {
     //let bt0 = sys::rusti::frame_address(1u32);
     //println!("%?", bt0);
-    cci_iter_lib::iter([1i, 2, 3], |i| {
+    cci_iter_lib::iter(&[1i, 2, 3], |i| {
         println!("{}", *i);
         //assert!(bt0 == sys::rusti::frame_address(2u32));
     })

--- a/src/test/run-pass/const-str-ptr.rs
+++ b/src/test/run-pass/const-str-ptr.rs
@@ -17,13 +17,13 @@ const C: *const u8 = B as *const u8;
 pub fn main() {
     unsafe {
         let foo = &A as *const u8;
-        assert_eq!(str::raw::from_utf8(A), "hi");
+        assert_eq!(str::raw::from_utf8(&A), "hi");
         assert_eq!(string::raw::from_buf_len(foo, A.len()), "hi".to_string());
         assert_eq!(string::raw::from_buf_len(C, B.len()), "hi".to_string());
         assert!(*C == A[0]);
         assert!(*(&B[0] as *const u8) == A[0]);
 
-        let bar = str::raw::from_utf8(A).to_c_str();
+        let bar = str::raw::from_utf8(&A).to_c_str();
         assert_eq!(bar.as_str(), "hi".to_c_str().as_str());
     }
 }

--- a/src/test/run-pass/const-vec-syntax.rs
+++ b/src/test/run-pass/const-vec-syntax.rs
@@ -12,5 +12,5 @@ fn f(_: &[int]) {}
 
 pub fn main() {
     let v = [ 1, 2, 3 ];
-    f(v);
+    f(&v);
 }

--- a/src/test/run-pass/const-vecs-and-slices.rs
+++ b/src/test/run-pass/const-vecs-and-slices.rs
@@ -11,7 +11,7 @@
 static x : [int, ..4] = [1,2,3,4];
 static y : &'static [int] = &[1,2,3,4];
 static z : &'static [int, ..4] = &[1,2,3,4];
-static zz : &'static [int] = [1,2,3,4];
+static zz : &'static [int] = &[1,2,3,4];
 
 pub fn main() {
     println!("{}", x[1]);

--- a/src/test/run-pass/issue-11205.rs
+++ b/src/test/run-pass/issue-11205.rs
@@ -72,11 +72,11 @@ fn main() {
     let r = &1i;
     let r: [&Foo, ..2] = [r, ..2];
     let _n = F {
-        t: r
+        t: &r
     };
     let x: [&Foo, ..2] = [&1i, &2i];
     let _n = F {
-        t: x
+        t: &x
     };
 
     struct M<'a> {
@@ -87,6 +87,6 @@ fn main() {
     };
     let x: [Box<Foo>, ..2] = [box 1i, box 2i];
     let _n = M {
-        t: x
+        t: &x
     };
 }

--- a/src/test/run-pass/issue-12028.rs
+++ b/src/test/run-pass/issue-12028.rs
@@ -37,7 +37,7 @@ impl<S: Stream, H: StreamHasher<S>> Hash<H> for u8 {
 
 impl<S: Stream, H: StreamHasher<S>> StreamHash<S, H> for u8 {
     fn input_stream(&self, stream: &mut S) {
-        stream.input([*self]);
+        stream.input(&[*self]);
     }
 }
 

--- a/src/test/run-pass/issue-14940.rs
+++ b/src/test/run-pass/issue-14940.rs
@@ -15,7 +15,7 @@ fn main() {
     let args = os::args();
     if args.len() > 1 {
         let mut out = stdio::stdout();
-        out.write(['a' as u8, ..128 * 1024]).unwrap();
+        out.write(&['a' as u8, ..128 * 1024]).unwrap();
     } else {
         let out = Command::new(args[0].as_slice()).arg("child").output();
         let out = out.unwrap();

--- a/src/test/run-pass/issue-15080.rs
+++ b/src/test/run-pass/issue-15080.rs
@@ -26,5 +26,5 @@ fn main() {
                 break
         }
     }
-    assert!(result.as_slice() == [2, 4]);
+    assert!(result.as_slice() == &[2, 4]);
 }

--- a/src/test/run-pass/issue-2904.rs
+++ b/src/test/run-pass/issue-2904.rs
@@ -63,7 +63,7 @@ fn read_board_grid<rdr:'static + io::Reader>(mut input: rdr)
     let mut input: &mut io::Reader = &mut input;
     let mut grid = Vec::new();
     let mut line = [0, ..10];
-    input.read(line);
+    input.read(&mut line);
     let mut row = Vec::new();
     for c in line.iter() {
         row.push(square_from_char(*c as char))

--- a/src/test/run-pass/issue-7784.rs
+++ b/src/test/run-pass/issue-7784.rs
@@ -33,6 +33,6 @@ fn main() {
     let out = bar("baz", "foo");
     let [a, xs.., d] = out;
     assert_eq!(a, "baz");
-    assert!(xs == ["foo", "foo"]);
+    assert!(xs == &["foo", "foo"]);
     assert_eq!(d, "baz");
 }

--- a/src/test/run-pass/issue-8398.rs
+++ b/src/test/run-pass/issue-8398.rs
@@ -11,7 +11,7 @@
 use std::io;
 
 fn foo(a: &mut io::Writer) {
-    a.write([]).unwrap();
+    a.write(&[]).unwrap();
 }
 
 pub fn main(){}

--- a/src/test/run-pass/issue-9249.rs
+++ b/src/test/run-pass/issue-9249.rs
@@ -8,5 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-static DATA:&'static [&'static str] = ["my string"];
+static DATA:&'static [&'static str] = &["my string"];
 fn main() { }

--- a/src/test/run-pass/regions-borrow-evec-fixed.rs
+++ b/src/test/run-pass/regions-borrow-evec-fixed.rs
@@ -13,6 +13,6 @@ fn foo(x: &[int]) -> int {
 }
 
 pub fn main() {
-    let p = [1,2,3,4,5];
+    let p = &[1,2,3,4,5];
     assert_eq!(foo(p), 1);
 }

--- a/src/test/run-pass/rename-directory.rs
+++ b/src/test/run-pass/rename-directory.rs
@@ -25,7 +25,7 @@ fn rename_directory() {
 
         let tmpdir = TempDir::new("rename_directory").ok().expect("rename_directory failed");
         let tmpdir = tmpdir.path();
-        let old_path = tmpdir.join_many(["foo", "bar", "baz"]);
+        let old_path = tmpdir.join_many(&["foo", "bar", "baz"]);
         fs::mkdir_recursive(&old_path, io::USER_RWX);
         let test_file = &old_path.join("temp.txt");
 
@@ -46,11 +46,11 @@ fn rename_directory() {
         });
         assert_eq!(libc::fclose(ostream), (0u as libc::c_int));
 
-        let new_path = tmpdir.join_many(["quux", "blat"]);
+        let new_path = tmpdir.join_many(&["quux", "blat"]);
         fs::mkdir_recursive(&new_path, io::USER_RWX);
         fs::rename(&old_path, &new_path.join("newdir"));
         assert!(new_path.join("newdir").is_dir());
-        assert!(new_path.join_many(["newdir", "temp.txt"]).exists());
+        assert!(new_path.join_many(&["newdir", "temp.txt"]).exists());
     }
 }
 

--- a/src/test/run-pass/sigpipe-should-be-ignored.rs
+++ b/src/test/run-pass/sigpipe-should-be-ignored.rs
@@ -21,7 +21,7 @@ fn test() {
     let mut writer = PipeStream::open(writer);
     drop(reader);
 
-    let _ = writer.write([1]);
+    let _ = writer.write(&[1]);
 }
 
 fn main() {

--- a/src/test/run-pass/stat.rs
+++ b/src/test/run-pass/stat.rs
@@ -21,7 +21,7 @@ pub fn main() {
             Ok(f) => {
                 let mut f = f;
                 for _ in range(0u, 1000) {
-                    f.write([0]);
+                    f.write(&[0]);
                 }
             }
         }

--- a/src/test/run-pass/utf8_chars.rs
+++ b/src/test/run-pass/utf8_chars.rs
@@ -27,17 +27,17 @@ pub fn main() {
 
     assert!((str::is_utf8(s.as_bytes())));
     // invalid prefix
-    assert!((!str::is_utf8([0x80_u8])));
+    assert!((!str::is_utf8(&[0x80_u8])));
     // invalid 2 byte prefix
-    assert!((!str::is_utf8([0xc0_u8])));
-    assert!((!str::is_utf8([0xc0_u8, 0x10_u8])));
+    assert!((!str::is_utf8(&[0xc0_u8])));
+    assert!((!str::is_utf8(&[0xc0_u8, 0x10_u8])));
     // invalid 3 byte prefix
-    assert!((!str::is_utf8([0xe0_u8])));
-    assert!((!str::is_utf8([0xe0_u8, 0x10_u8])));
-    assert!((!str::is_utf8([0xe0_u8, 0xff_u8, 0x10_u8])));
+    assert!((!str::is_utf8(&[0xe0_u8])));
+    assert!((!str::is_utf8(&[0xe0_u8, 0x10_u8])));
+    assert!((!str::is_utf8(&[0xe0_u8, 0xff_u8, 0x10_u8])));
     // invalid 4 byte prefix
-    assert!((!str::is_utf8([0xf0_u8])));
-    assert!((!str::is_utf8([0xf0_u8, 0x10_u8])));
-    assert!((!str::is_utf8([0xf0_u8, 0xff_u8, 0x10_u8])));
-    assert!((!str::is_utf8([0xf0_u8, 0xff_u8, 0xff_u8, 0x10_u8])));
+    assert!((!str::is_utf8(&[0xf0_u8])));
+    assert!((!str::is_utf8(&[0xf0_u8, 0x10_u8])));
+    assert!((!str::is_utf8(&[0xf0_u8, 0xff_u8, 0x10_u8])));
+    assert!((!str::is_utf8(&[0xf0_u8, 0xff_u8, 0xff_u8, 0x10_u8])));
 }

--- a/src/test/run-pass/vec-dst.rs
+++ b/src/test/run-pass/vec-dst.rs
@@ -8,17 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn sub_expr() {
-    // Test for a &[T] => &&[T] coercion in sub-expression position
-    // (surprisingly, this can cause errors which are not caused by either of:
-    //    `let x = vec.slice_mut(0, 2);`
-    //    `foo(vec.slice_mut(0, 2));` ).
-    let mut vec: Vec<int> = vec!(1, 2, 3, 4);
-    let b: &mut [int] = [1, 2];
-    assert!(vec.slice_mut(0, 2) == b);
-}
-
-fn index() {
+pub fn main() {
     // Tests for indexing into box/& [T, ..n]
     let x: [int, ..3] = [1, 2, 3];
     let mut x: Box<[int, ..3]> = box x;
@@ -39,9 +29,4 @@ fn index() {
     assert!(x[0] == 1);
     assert!(x[1] == 45);
     assert!(x[2] == 3);
-}
-
-pub fn main() {
-    sub_expr();
-    index();
 }

--- a/src/test/run-pass/vec-matching-fold.rs
+++ b/src/test/run-pass/vec-matching-fold.rs
@@ -33,7 +33,7 @@ fn foldr<T,U:Clone>(values: &[T],
 }
 
 pub fn main() {
-    let x = [1i, 2, 3, 4, 5];
+    let x = &[1i, 2, 3, 4, 5];
 
     let product = foldl(x, 1i, |a, b| a * *b);
     assert_eq!(product, 120);


### PR DESCRIPTION
The forwards compatible parts of #18645, rebased. Converts implicit coercions from `[T, ..n]` to `&[T]` into explicit references.
