### PR TITLE
Don't inherit stability to items in a function body.

### DIFF
--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -83,10 +83,13 @@ impl<'v> Visitor<'v> for Annotator {
                 b: &'v Block, s: Span, _: NodeId) {
         match fk {
             FkMethod(_, _, meth) => {
-                self.annotate(meth.id, &meth.attrs, |v| visit::walk_fn(v, fk, fd, b, s));
+                // Methods are not already annotated, so we annotate it
+                self.annotate(meth.id, &meth.attrs, |_| {});
             }
-            _ => visit::walk_fn(self, fk, fd, b, s)
+            _ => {}
         }
+        // Items defined in a function body have no reason to have
+        // a stability attribute, so we don't recurse.
     }
 
     fn visit_trait_item(&mut self, t: &TraitItem) {

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -460,6 +460,20 @@ mod this_crate {
     }
 
     #[deprecated]
+    fn test_fn_body() {
+        fn fn_in_body() {}
+        fn_in_body();
+    }
+
+    impl MethodTester {
+        #[deprecated]
+        fn test_method_body(&self) {
+            fn fn_in_body() {}
+            fn_in_body();
+        }
+    }
+
+    #[deprecated]
     pub trait DeprecatedTrait {}
 
     struct S;


### PR DESCRIPTION
Items defined in the body of a function has no visibility outside it, and thus have no reason to inherit its stability.

Closes #17488
