### PR TITLE
libcore: add num::Int::pow() and deprecate num::pow(). 

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -37,28 +37,10 @@ pub fn div_rem<T: Div<T, T> + Rem<T, T>>(x: T, y: T) -> (T, T) {
 }
 
 /// Raises a `base` to the power of `exp`, using exponentiation by squaring.
-///
-/// # Example
-///
-/// ```rust
-/// use std::num;
-///
-/// assert_eq!(num::pow(2i, 4), 16);
-/// ```
 #[inline]
-pub fn pow<T: Int>(mut base: T, mut exp: uint) -> T {
-    if exp == 1 { base }
-    else {
-        let mut acc: T = Int::one();
-        while exp > 0 {
-            if (exp & 1) == 1 {
-                acc = acc * base;
-            }
-            base = base * base;
-            exp = exp >> 1;
-        }
-        acc
-    }
+#[deprecated = "Use Int::pow() instead, as in 2i.pow(4)"]
+pub fn pow<T: Int>(base: T, exp: uint) -> T {
+    base.pow(exp)
 }
 
 /// A built-in signed or unsigned integer.
@@ -358,6 +340,29 @@ pub trait Int
             None if other >= Int::zero() => Int::min_value(),
             None                         => Int::max_value(),
         }
+    }
+
+    /// Raises self to the power of `exp`, using exponentiation by squaring.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::num::Int;
+    ///
+    /// assert_eq!(2i.pow(4), 16);
+    /// ```
+    #[inline]
+    fn pow(self, mut exp: uint) -> Self {
+        let mut base = self;
+        let mut acc: Self = Int::one();
+        while exp > 0 {
+            if (exp & 1) == 1 {
+                acc = acc * base;
+            }
+            base = base * base;
+            exp /= 2;
+        }
+        acc
     }
 }
 

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -757,7 +757,7 @@ mod tests {
         }
         macro_rules! assert_pow(
             (($num:expr, $exp:expr) => $expected:expr) => {{
-                let result = pow($num, $exp);
+                let result = $num.pow($exp);
                 assert_eq!(result, $expected);
                 assert_eq!(result, naive_pow($num, $exp));
             }}
@@ -775,12 +775,12 @@ mod tests {
 mod bench {
     extern crate test;
     use self::test::Bencher;
-    use num;
+    use num::Int;
     use prelude::*;
 
     #[bench]
     fn bench_pow_function(b: &mut Bencher) {
         let v = Vec::from_fn(1024u, |n| n);
-        b.iter(|| {v.iter().fold(0u, |old, new| num::pow(old, *new));});
+        b.iter(|| {v.iter().fold(0u, |old, new| old.pow(*new));});
     }
 }

--- a/src/test/bench/shootout-binarytrees.rs
+++ b/src/test/bench/shootout-binarytrees.rs
@@ -93,8 +93,8 @@ fn main() {
     let long_lived_tree = bottom_up_tree(&long_lived_arena, 0, max_depth);
 
     let mut messages = range_step(min_depth, max_depth + 1, 2).map(|depth| {
-            use std::num::pow;
-            let iterations = pow(2i, (max_depth - depth + min_depth) as uint);
+            use std::num::Int;
+            let iterations = 2i.pow((max_depth - depth + min_depth) as uint);
             Future::spawn(proc() {
                 let mut chk = 0;
                 for i in range(1, iterations + 1) {

--- a/src/test/compile-fail/lint-dead-code-4.rs
+++ b/src/test/compile-fail/lint-dead-code-4.rs
@@ -14,7 +14,7 @@
 
 extern crate libc;
 
-use std::num;
+use std::num::Int;
 
 struct Foo {
     x: uint,
@@ -23,7 +23,7 @@ struct Foo {
 }
 
 fn field_read(f: Foo) -> uint {
-    num::pow(f.x, 2)
+    f.x.pow(2)
 }
 
 enum XYZ {


### PR DESCRIPTION
[breaking-change]

Deprecates `core::num::pow` in favor of `Int::pow`.
