### PR TITLE
std: Stabilize std::fmt

### DIFF
--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -109,6 +109,7 @@ radix!(UpperHex, 16, "0x", x @  0 ...  9 => b'0' + x,
 
 /// A radix with in the range of `2..36`.
 #[deriving(Clone, PartialEq)]
+#[unstable = "may be renamed or move to a different module"]
 pub struct Radix {
     base: u8,
 }
@@ -132,6 +133,7 @@ impl GenericRadix for Radix {
 }
 
 /// A helper type for formatting radixes.
+#[unstable = "may be renamed or move to a different module"]
 pub struct RadixFmt<T, R>(T, R);
 
 /// Constructs a radix formatter in the range of `2..36`.
@@ -142,6 +144,7 @@ pub struct RadixFmt<T, R>(T, R);
 /// use std::fmt::radix;
 /// assert_eq!(format!("{}", radix(55i, 36)), "1j".to_string());
 /// ```
+#[unstable = "may be renamed or move to a different module"]
 pub fn radix<T>(x: T, base: u8) -> RadixFmt<T, Radix> {
     RadixFmt(x, Radix::new(base))
 }
@@ -167,7 +170,6 @@ macro_rules! int_base {
 macro_rules! integer {
     ($Int:ident, $Uint:ident) => {
         int_base!(Show     for $Int as $Int   -> Decimal)
-        int_base!(Signed   for $Int as $Int   -> Decimal)
         int_base!(Binary   for $Int as $Uint  -> Binary)
         int_base!(Octal    for $Int as $Uint  -> Octal)
         int_base!(LowerHex for $Int as $Uint  -> LowerHex)
@@ -175,7 +177,6 @@ macro_rules! integer {
         radix_fmt!($Int as $Int, fmt_int)
 
         int_base!(Show     for $Uint as $Uint -> Decimal)
-        int_base!(Unsigned for $Uint as $Uint -> Decimal)
         int_base!(Binary   for $Uint as $Uint -> Binary)
         int_base!(Octal    for $Uint as $Uint -> Octal)
         int_base!(LowerHex for $Uint as $Uint -> LowerHex)

--- a/src/libcore/fmt/rt.rs
+++ b/src/libcore/fmt/rt.rs
@@ -14,6 +14,8 @@
 //! These definitions are similar to their `ct` equivalents, but differ in that
 //! these can be statically allocated and are slightly optimized for the runtime
 
+#![experimental = "implementation detail of the `format_args!` macro"]
+
 pub use self::Alignment::*;
 pub use self::Count::*;
 pub use self::Position::*;

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -108,7 +108,10 @@ macro_rules! try(
 /// Writing a formatted string into a writer
 #[macro_export]
 macro_rules! write(
-    ($dst:expr, $($arg:tt)*) => (format_args_method!($dst, write_fmt, $($arg)*))
+    ($dst:expr, $($arg:tt)*) => ({
+        let dst = &mut *$dst;
+        format_args!(|args| { dst.write_fmt(args) }, $($arg)*)
+    })
 )
 
 /// Writing a formatted string plus a newline into a writer
@@ -117,16 +120,6 @@ macro_rules! writeln(
     ($dst:expr, $fmt:expr $($arg:tt)*) => (
         write!($dst, concat!($fmt, "\n") $($arg)*)
     )
-)
-
-/// Write some formatted data into a stream.
-///
-/// Identical to the macro in `std::macros`
-#[macro_export]
-macro_rules! write(
-    ($dst:expr, $($arg:tt)*) => ({
-        format_args_method!($dst, write_fmt, $($arg)*)
-    })
 )
 
 #[macro_export]

--- a/src/libcoretest/fmt/num.rs
+++ b/src/libcoretest/fmt/num.rs
@@ -21,16 +21,16 @@ fn test_format_int() {
     assert!(format!("{}", 1i16).as_slice() == "1");
     assert!(format!("{}", 1i32).as_slice() == "1");
     assert!(format!("{}", 1i64).as_slice() == "1");
-    assert!(format!("{:d}", -1i).as_slice() == "-1");
-    assert!(format!("{:d}", -1i8).as_slice() == "-1");
-    assert!(format!("{:d}", -1i16).as_slice() == "-1");
-    assert!(format!("{:d}", -1i32).as_slice() == "-1");
-    assert!(format!("{:d}", -1i64).as_slice() == "-1");
-    assert!(format!("{:t}", 1i).as_slice() == "1");
-    assert!(format!("{:t}", 1i8).as_slice() == "1");
-    assert!(format!("{:t}", 1i16).as_slice() == "1");
-    assert!(format!("{:t}", 1i32).as_slice() == "1");
-    assert!(format!("{:t}", 1i64).as_slice() == "1");
+    assert!(format!("{}", -1i).as_slice() == "-1");
+    assert!(format!("{}", -1i8).as_slice() == "-1");
+    assert!(format!("{}", -1i16).as_slice() == "-1");
+    assert!(format!("{}", -1i32).as_slice() == "-1");
+    assert!(format!("{}", -1i64).as_slice() == "-1");
+    assert!(format!("{:b}", 1i).as_slice() == "1");
+    assert!(format!("{:b}", 1i8).as_slice() == "1");
+    assert!(format!("{:b}", 1i16).as_slice() == "1");
+    assert!(format!("{:b}", 1i32).as_slice() == "1");
+    assert!(format!("{:b}", 1i64).as_slice() == "1");
     assert!(format!("{:x}", 1i).as_slice() == "1");
     assert!(format!("{:x}", 1i8).as_slice() == "1");
     assert!(format!("{:x}", 1i16).as_slice() == "1");
@@ -52,16 +52,11 @@ fn test_format_int() {
     assert!(format!("{}", 1u16).as_slice() == "1");
     assert!(format!("{}", 1u32).as_slice() == "1");
     assert!(format!("{}", 1u64).as_slice() == "1");
-    assert!(format!("{:u}", 1u).as_slice() == "1");
-    assert!(format!("{:u}", 1u8).as_slice() == "1");
-    assert!(format!("{:u}", 1u16).as_slice() == "1");
-    assert!(format!("{:u}", 1u32).as_slice() == "1");
-    assert!(format!("{:u}", 1u64).as_slice() == "1");
-    assert!(format!("{:t}", 1u).as_slice() == "1");
-    assert!(format!("{:t}", 1u8).as_slice() == "1");
-    assert!(format!("{:t}", 1u16).as_slice() == "1");
-    assert!(format!("{:t}", 1u32).as_slice() == "1");
-    assert!(format!("{:t}", 1u64).as_slice() == "1");
+    assert!(format!("{:b}", 1u).as_slice() == "1");
+    assert!(format!("{:b}", 1u8).as_slice() == "1");
+    assert!(format!("{:b}", 1u16).as_slice() == "1");
+    assert!(format!("{:b}", 1u32).as_slice() == "1");
+    assert!(format!("{:b}", 1u64).as_slice() == "1");
     assert!(format!("{:x}", 1u).as_slice() == "1");
     assert!(format!("{:x}", 1u8).as_slice() == "1");
     assert!(format!("{:x}", 1u16).as_slice() == "1");
@@ -79,9 +74,9 @@ fn test_format_int() {
     assert!(format!("{:o}", 1u64).as_slice() == "1");
 
     // Test a larger number
-    assert!(format!("{:t}", 55i).as_slice() == "110111");
+    assert!(format!("{:b}", 55i).as_slice() == "110111");
     assert!(format!("{:o}", 55i).as_slice() == "67");
-    assert!(format!("{:d}", 55i).as_slice() == "55");
+    assert!(format!("{}", 55i).as_slice() == "55");
     assert!(format!("{:x}", 55i).as_slice() == "37");
     assert!(format!("{:X}", 55i).as_slice() == "37");
 }
@@ -89,15 +84,13 @@ fn test_format_int() {
 #[test]
 fn test_format_int_zero() {
     assert!(format!("{}", 0i).as_slice() == "0");
-    assert!(format!("{:d}", 0i).as_slice() == "0");
-    assert!(format!("{:t}", 0i).as_slice() == "0");
+    assert!(format!("{:b}", 0i).as_slice() == "0");
     assert!(format!("{:o}", 0i).as_slice() == "0");
     assert!(format!("{:x}", 0i).as_slice() == "0");
     assert!(format!("{:X}", 0i).as_slice() == "0");
 
     assert!(format!("{}", 0u).as_slice() == "0");
-    assert!(format!("{:u}", 0u).as_slice() == "0");
-    assert!(format!("{:t}", 0u).as_slice() == "0");
+    assert!(format!("{:b}", 0u).as_slice() == "0");
     assert!(format!("{:o}", 0u).as_slice() == "0");
     assert!(format!("{:x}", 0u).as_slice() == "0");
     assert!(format!("{:X}", 0u).as_slice() == "0");
@@ -105,11 +98,11 @@ fn test_format_int_zero() {
 
 #[test]
 fn test_format_int_flags() {
-    assert!(format!("{:3d}", 1i).as_slice() == "  1");
-    assert!(format!("{:>3d}", 1i).as_slice() == "  1");
-    assert!(format!("{:>+3d}", 1i).as_slice() == " +1");
-    assert!(format!("{:<3d}", 1i).as_slice() == "1  ");
-    assert!(format!("{:#d}", 1i).as_slice() == "1");
+    assert!(format!("{:3}", 1i).as_slice() == "  1");
+    assert!(format!("{:>3}", 1i).as_slice() == "  1");
+    assert!(format!("{:>+3}", 1i).as_slice() == " +1");
+    assert!(format!("{:<3}", 1i).as_slice() == "1  ");
+    assert!(format!("{:#}", 1i).as_slice() == "1");
     assert!(format!("{:#x}", 10i).as_slice() == "0xa");
     assert!(format!("{:#X}", 10i).as_slice() == "0xA");
     assert!(format!("{:#5x}", 10i).as_slice() == "  0xa");
@@ -119,25 +112,25 @@ fn test_format_int_flags() {
     assert!(format!("{:<8x}", 10i).as_slice() == "a       ");
     assert!(format!("{:>8x}", 10i).as_slice() == "       a");
     assert!(format!("{:#08x}", 10i).as_slice() == "0x00000a");
-    assert!(format!("{:08d}", -10i).as_slice() == "-0000010");
+    assert!(format!("{:08}", -10i).as_slice() == "-0000010");
     assert!(format!("{:x}", -1u8).as_slice() == "ff");
     assert!(format!("{:X}", -1u8).as_slice() == "FF");
-    assert!(format!("{:t}", -1u8).as_slice() == "11111111");
+    assert!(format!("{:b}", -1u8).as_slice() == "11111111");
     assert!(format!("{:o}", -1u8).as_slice() == "377");
     assert!(format!("{:#x}", -1u8).as_slice() == "0xff");
     assert!(format!("{:#X}", -1u8).as_slice() == "0xFF");
-    assert!(format!("{:#t}", -1u8).as_slice() == "0b11111111");
+    assert!(format!("{:#b}", -1u8).as_slice() == "0b11111111");
     assert!(format!("{:#o}", -1u8).as_slice() == "0o377");
 }
 
 #[test]
 fn test_format_int_sign_padding() {
-    assert!(format!("{:+5d}", 1i).as_slice() == "   +1");
-    assert!(format!("{:+5d}", -1i).as_slice() == "   -1");
-    assert!(format!("{:05d}", 1i).as_slice() == "00001");
-    assert!(format!("{:05d}", -1i).as_slice() == "-0001");
-    assert!(format!("{:+05d}", 1i).as_slice() == "+0001");
-    assert!(format!("{:+05d}", -1i).as_slice() == "-0001");
+    assert!(format!("{:+5}", 1i).as_slice() == "   +1");
+    assert!(format!("{:+5}", -1i).as_slice() == "   -1");
+    assert!(format!("{:05}", 1i).as_slice() == "00001");
+    assert!(format!("{:05}", -1i).as_slice() == "-0001");
+    assert!(format!("{:+05}", 1i).as_slice() == "+0001");
+    assert!(format!("{:+05}", -1i).as_slice() == "-0001");
 }
 
 #[test]
@@ -169,7 +162,7 @@ mod uint {
     #[bench]
     fn format_bin(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:t}", rng.gen::<uint>()); })
+        b.iter(|| { format!("{:b}", rng.gen::<uint>()); })
     }
 
     #[bench]
@@ -181,7 +174,7 @@ mod uint {
     #[bench]
     fn format_dec(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:u}", rng.gen::<uint>()); })
+        b.iter(|| { format!("{}", rng.gen::<uint>()); })
     }
 
     #[bench]
@@ -205,7 +198,7 @@ mod int {
     #[bench]
     fn format_bin(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:t}", rng.gen::<int>()); })
+        b.iter(|| { format!("{:b}", rng.gen::<int>()); })
     }
 
     #[bench]
@@ -217,7 +210,7 @@ mod int {
     #[bench]
     fn format_dec(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:d}", rng.gen::<int>()); })
+        b.iter(|| { format!("{}", rng.gen::<int>()); })
     }
 
     #[bench]

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -130,7 +130,7 @@ mod tests {
                    input.len());
             let cmp = deflate_bytes(input.as_slice()).expect("deflation failed");
             let out = inflate_bytes(cmp.as_slice()).expect("inflation failed");
-            debug!("{} bytes deflated to {} ({:.1f}% size)",
+            debug!("{} bytes deflated to {} ({:.1}% size)",
                    input.len(), cmp.len(),
                    100.0 * ((cmp.len() as f64) / (input.len() as f64)));
             assert_eq!(input.as_slice(), out.as_slice());

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -221,7 +221,7 @@ pub fn render_to<W:Writer>(output: &mut W) {
 impl<'a> dot::Labeller<'a, Nd<'a>, Ed<'a>> for Graph {
     fn graph_id(&'a self) -> dot::Id<'a> { dot::Id::new("example3").unwrap() }
     fn node_id(&'a self, n: &Nd<'a>) -> dot::Id<'a> {
-        dot::Id::new(format!("N{:u}", n.val0())).unwrap()
+        dot::Id::new(format!("N{}", n.val0())).unwrap()
     }
     fn node_label<'a>(&'a self, n: &Nd<'a>) -> dot::LabelText<'a> {
         let &(i, _) = n;
@@ -635,7 +635,7 @@ mod tests {
     }
 
     fn id_name<'a>(n: &Node) -> Id<'a> {
-        Id::new(format!("N{:u}", *n)).unwrap()
+        Id::new(format!("N{}", *n)).unwrap()
     }
 
     impl<'a> Labeller<'a, Node, &'a Edge> for LabelledGraph {

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -241,13 +241,6 @@ impl fmt::Show for LogLevel {
     }
 }
 
-impl fmt::Signed for LogLevel {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let LogLevel(level) = *self;
-        write!(fmt, "{}", level)
-    }
-}
-
 impl Logger for DefaultLogger {
     fn log(&mut self, record: &LogRecord) {
         match writeln!(&mut self.handle,

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -237,7 +237,7 @@ pub trait Rng {
     /// use std::rand::{task_rng, Rng};
     ///
     /// let mut rng = task_rng();
-    /// println!("{:b}", rng.gen_weighted_bool(3));
+    /// println!("{}", rng.gen_weighted_bool(3));
     /// ```
     fn gen_weighted_bool(&mut self, n: uint) -> bool {
         n == 0 || self.gen_range(0, n) == 0

--- a/src/librustc/middle/borrowck/mod.rs
+++ b/src/librustc/middle/borrowck/mod.rs
@@ -102,7 +102,7 @@ pub fn check_crate(tcx: &ty::ctxt) {
     fn make_stat(bccx: &BorrowckCtxt, stat: uint) -> String {
         let total = bccx.stats.guaranteed_paths as f64;
         let perc = if total == 0.0 { 0.0 } else { stat as f64 * 100.0 / total };
-        format!("{} ({:.0f}%)", stat, perc)
+        format!("{} ({:.0}%)", stat, perc)
     }
 }
 

--- a/src/librustc/middle/cfg/graphviz.rs
+++ b/src/librustc/middle/cfg/graphviz.rs
@@ -53,7 +53,7 @@ impl<'a, 'ast> dot::Labeller<'a, Node<'a>, Edge<'a>> for LabelledCFG<'a, 'ast> {
     fn graph_id(&'a self) -> dot::Id<'a> { dot::Id::new(self.name.as_slice()).unwrap() }
 
     fn node_id(&'a self, &(i,_): &Node<'a>) -> dot::Id<'a> {
-        dot::Id::new(format!("N{:u}", i.node_id())).unwrap()
+        dot::Id::new(format!("N{}", i.node_id())).unwrap()
     }
 
     fn node_label(&'a self, &(i, n): &Node<'a>) -> dot::LabelText<'a> {

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -81,8 +81,7 @@ impl<'a> fmt::Show for Matrix<'a> {
             try!(write!(f, "+"));
             for (column, pat_str) in row.into_iter().enumerate() {
                 try!(write!(f, " "));
-                f.width = Some(column_widths[column]);
-                try!(f.pad(pat_str.as_slice()));
+                try!(write!(f, "{:1$}", pat_str, column_widths[column]));
                 try!(write!(f, " +"));
             }
             try!(write!(f, "\n"));

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -194,7 +194,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
         let words_per_id = (bits_per_id + uint::BITS - 1) / uint::BITS;
         let num_nodes = cfg.graph.all_nodes().len();
 
-        debug!("DataFlowContext::new(analysis_name: {:s}, id_range={}, \
+        debug!("DataFlowContext::new(analysis_name: {}, id_range={}, \
                                      bits_per_id={}, words_per_id={}) \
                                      num_nodes: {}",
                analysis_name, id_range, bits_per_id, words_per_id,
@@ -223,7 +223,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
 
     pub fn add_gen(&mut self, id: ast::NodeId, bit: uint) {
         //! Indicates that `id` generates `bit`
-        debug!("{:s} add_gen(id={}, bit={})",
+        debug!("{} add_gen(id={}, bit={})",
                self.analysis_name, id, bit);
         assert!(self.nodeid_to_index.contains_key(&id));
         assert!(self.bits_per_id > 0);
@@ -236,7 +236,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
 
     pub fn add_kill(&mut self, id: ast::NodeId, bit: uint) {
         //! Indicates that `id` kills `bit`
-        debug!("{:s} add_kill(id={}, bit={})",
+        debug!("{} add_kill(id={}, bit={})",
                self.analysis_name, id, bit);
         assert!(self.nodeid_to_index.contains_key(&id));
         assert!(self.bits_per_id > 0);
@@ -249,7 +249,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
 
     fn apply_gen_kill(&self, cfgidx: CFGIndex, bits: &mut [uint]) {
         //! Applies the gen and kill sets for `cfgidx` to `bits`
-        debug!("{:s} apply_gen_kill(cfgidx={}, bits={}) [before]",
+        debug!("{} apply_gen_kill(cfgidx={}, bits={}) [before]",
                self.analysis_name, cfgidx, mut_bits_to_string(bits));
         assert!(self.bits_per_id > 0);
 
@@ -259,7 +259,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
         let kills = self.kills.slice(start, end);
         bitwise(bits, kills, &Subtract);
 
-        debug!("{:s} apply_gen_kill(cfgidx={}, bits={}) [after]",
+        debug!("{} apply_gen_kill(cfgidx={}, bits={}) [after]",
                self.analysis_name, cfgidx, mut_bits_to_string(bits));
     }
 
@@ -316,7 +316,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
                 temp_bits.as_slice()
             }
         };
-        debug!("{:s} each_bit_for_node({}, cfgidx={}) bits={}",
+        debug!("{} each_bit_for_node({}, cfgidx={}) bits={}",
                self.analysis_name, e, cfgidx, bits_to_string(slice));
         self.each_bit(slice, f)
     }
@@ -337,7 +337,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
         let cfgidx = to_cfgidx_or_die(id, &self.nodeid_to_index);
         let (start, end) = self.compute_id_range(cfgidx);
         let gens = self.gens.slice(start, end);
-        debug!("{:s} each_gen_bit(id={}, gens={})",
+        debug!("{} each_gen_bit(id={}, gens={})",
                self.analysis_name, id, bits_to_string(gens));
         self.each_bit(gens, f)
     }
@@ -385,7 +385,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
         //! This is usually called (if it is called at all), after
         //! all add_gen and add_kill calls, but before propagate.
 
-        debug!("{:s} add_kills_from_flow_exits", self.analysis_name);
+        debug!("{} add_kills_from_flow_exits", self.analysis_name);
         if self.bits_per_id == 0 {
             // Skip the surprisingly common degenerate case.  (Note
             // compute_id_range requires self.words_per_id > 0.)
@@ -408,7 +408,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
                         }
                     }
                     None => {
-                        debug!("{:s} add_kills_from_flow_exits flow_exit={} \
+                        debug!("{} add_kills_from_flow_exits flow_exit={} \
                                 no cfg_idx for exiting_scope={}",
                                self.analysis_name, flow_exit, node_id);
                     }
@@ -417,10 +417,10 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
 
             if changed {
                 let bits = self.kills.slice_mut(start, end);
-                debug!("{:s} add_kills_from_flow_exits flow_exit={} bits={} [before]",
+                debug!("{} add_kills_from_flow_exits flow_exit={} bits={} [before]",
                        self.analysis_name, flow_exit, mut_bits_to_string(bits));
                 bits.clone_from_slice(orig_kills.as_slice());
-                debug!("{:s} add_kills_from_flow_exits flow_exit={} bits={} [after]",
+                debug!("{} add_kills_from_flow_exits flow_exit={} bits={} [after]",
                        self.analysis_name, flow_exit, mut_bits_to_string(bits));
             }
             true
@@ -453,7 +453,7 @@ impl<'a, 'tcx, O:DataFlowOperator+Clone+'static> DataFlowContext<'a, 'tcx, O> {
             }
         }
 
-        debug!("Dataflow result for {:s}:", self.analysis_name);
+        debug!("Dataflow result for {}:", self.analysis_name);
         debug!("{}", {
             self.pretty_print_to(box io::stderr(), blk).unwrap();
             ""
@@ -474,7 +474,7 @@ impl<'a, 'b, 'tcx, O:DataFlowOperator> PropagationContext<'a, 'b, 'tcx, O> {
     fn walk_cfg(&mut self,
                 cfg: &cfg::CFG,
                 in_out: &mut [uint]) {
-        debug!("DataFlowContext::walk_cfg(in_out={}) {:s}",
+        debug!("DataFlowContext::walk_cfg(in_out={}) {}",
                bits_to_string(in_out), self.dfcx.analysis_name);
         assert!(self.dfcx.bits_per_id > 0);
 
@@ -519,7 +519,7 @@ impl<'a, 'b, 'tcx, O:DataFlowOperator> PropagationContext<'a, 'b, 'tcx, O> {
                                          edge: &cfg::CFGEdge) {
         let source = edge.source();
         let cfgidx = edge.target();
-        debug!("{:s} propagate_bits_into_entry_set_for(pred_bits={}, {} to {})",
+        debug!("{} propagate_bits_into_entry_set_for(pred_bits={}, {} to {})",
                self.dfcx.analysis_name, bits_to_string(pred_bits), source, cfgidx);
         assert!(self.dfcx.bits_per_id > 0);
 
@@ -530,7 +530,7 @@ impl<'a, 'b, 'tcx, O:DataFlowOperator> PropagationContext<'a, 'b, 'tcx, O> {
             bitwise(on_entry, pred_bits, &self.dfcx.oper)
         };
         if changed {
-            debug!("{:s} changed entry set for {} to {}",
+            debug!("{} changed entry set for {} to {}",
                    self.dfcx.analysis_name, cfgidx,
                    bits_to_string(self.dfcx.on_entry.slice(start, end)));
             self.changed = true;

--- a/src/librustc/middle/graph.rs
+++ b/src/librustc/middle/graph.rs
@@ -36,7 +36,7 @@ be indexed by the direction (see the type `Direction`).
 
 #![allow(dead_code)] // still WIP
 
-use std::fmt::{Formatter, FormatError, Show};
+use std::fmt::{Formatter, Error, Show};
 use std::uint;
 
 pub struct Graph<N,E> {
@@ -57,7 +57,7 @@ pub struct Edge<E> {
 }
 
 impl<E: Show> Show for Edge<E> {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), FormatError> {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         write!(f, "Edge {{ next_edge: [{}, {}], source: {}, target: {}, data: {} }}",
                self.next_edge[0], self.next_edge[1], self.source,
                self.target, self.data)

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2678,8 +2678,13 @@ impl ops::Sub<TypeContents,TypeContents> for TypeContents {
 }
 
 impl fmt::Show for TypeContents {
+    #[cfg(stage0)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "TypeContents({:t})", self.bits)
+    }
+    #[cfg(not(stage0))]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "TypeContents({:b})", self.bits)
     }
 }
 

--- a/src/librustc/middle/typeck/variance.rs
+++ b/src/librustc/middle/typeck/variance.rs
@@ -603,7 +603,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
 
             let is_inferred;
             macro_rules! cannot_happen { () => { {
-                panic!("invalid parent: {:s} for {:s}",
+                panic!("invalid parent: {} for {}",
                       tcx.map.node_to_string(parent_id),
                       tcx.map.node_to_string(param_id));
             } } }

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -368,7 +368,7 @@ unsafe extern "C" fn diagnostic_handler(info: DiagnosticInfoRef, user: *mut c_vo
 
             if enabled {
                 let loc = llvm::debug_loc_to_string(llcx, opt.debug_loc);
-                cgcx.handler.note(format!("optimization {:s} for {:s} at {:s}: {:s}",
+                cgcx.handler.note(format!("optimization {} for {} at {}: {}",
                                           opt.kind.describe(),
                                           pass_name,
                                           if loc.is_empty() { "[unknown]" } else { loc.as_slice() },

--- a/src/librustc_trans/driver/mod.rs
+++ b/src/librustc_trans/driver/mod.rs
@@ -224,13 +224,13 @@ Available lint options:
     };
 
     println!("Lint checks provided by rustc:\n");
-    println!("    {}  {:7.7s}  {}", padded("name"), "default", "meaning");
-    println!("    {}  {:7.7s}  {}", padded("----"), "-------", "-------");
+    println!("    {}  {:7.7}  {}", padded("name"), "default", "meaning");
+    println!("    {}  {:7.7}  {}", padded("----"), "-------", "-------");
 
     let print_lints = |lints: Vec<&Lint>| {
         for lint in lints.into_iter() {
             let name = lint.name_lower().replace("_", "-");
-            println!("    {}  {:7.7s}  {}",
+            println!("    {}  {:7.7}  {}",
                      padded(name.as_slice()), lint.default_level.as_str(), lint.desc);
         }
         println!("\n");
@@ -293,7 +293,7 @@ fn describe_debug_flags() {
     for tuple in r.iter() {
         match *tuple {
             (ref name, ref desc, _) => {
-                println!("    -Z {:>20s} -- {}", *name, *desc);
+                println!("    -Z {:>20} -- {}", *name, *desc);
             }
         }
     }
@@ -306,7 +306,7 @@ fn describe_codegen_flags() {
             Some(..) => (21, "=val"),
             None => (25, "")
         };
-        println!("    -C {:>width$s}{} -- {}", name.replace("_", "-"),
+        println!("    -C {:>width$}{} -- {}", name.replace("_", "-"),
                  extra, desc, width=width);
     }
 }

--- a/src/librustc_trans/driver/pretty.rs
+++ b/src/librustc_trans/driver/pretty.rs
@@ -355,8 +355,8 @@ impl UserIdentifiedItem {
     fn to_one_node_id(self, user_option: &str, sess: &Session, map: &ast_map::Map) -> ast::NodeId {
         let fail_because = |is_wrong_because| -> ast::NodeId {
             let message =
-                format!("{:s} needs NodeId (int) or unique \
-                         path suffix (b::c::d); got {:s}, which {:s}",
+                format!("{} needs NodeId (int) or unique \
+                         path suffix (b::c::d); got {}, which {}",
                         user_option,
                         self.reconstructed_input(),
                         is_wrong_because);

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -3135,7 +3135,7 @@ pub fn trans_crate<'tcx>(analysis: CrateAnalysis<'tcx>)
     }
     if shared_ccx.sess().count_llvm_insns() {
         for (k, v) in shared_ccx.stats().llvm_insns.borrow().iter() {
-            println!("{:7u} {}", *v, *k);
+            println!("{:7} {}", *v, *k);
         }
     }
 

--- a/src/librustc_trans/trans/cleanup.rs
+++ b/src/librustc_trans/trans/cleanup.rs
@@ -67,7 +67,7 @@ pub enum CleanupScopeKind<'blk, 'tcx: 'blk> {
 }
 
 impl<'blk, 'tcx: 'blk> fmt::Show for CleanupScopeKind<'blk, 'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::FormatError> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             CustomScopeKind => write!(f, "CustomScopeKind"),
             AstScopeKind(nid) => write!(f, "AstScopeKind({})", nid),

--- a/src/librustdoc/html/item_type.rs
+++ b/src/librustdoc/html/item_type.rs
@@ -75,12 +75,6 @@ impl fmt::Show for ItemType {
     }
 }
 
-impl fmt::Unsigned for ItemType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        (*self as uint).fmt(f)
-    }
-}
-
 pub fn shortty(item: &clean::Item) -> ItemType {
     match item.inner {
         clean::ModuleItem(..)          => Module,

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -437,8 +437,8 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> io::IoResult<String> 
         if i > 0 {
             try!(write!(&mut w, ","));
         }
-        try!(write!(&mut w, r#"[{:u},"{}","{}",{}"#,
-                    item.ty, item.name, path,
+        try!(write!(&mut w, r#"[{},"{}","{}",{}"#,
+                    item.ty as uint, item.name, path,
                     item.desc.to_json().to_string()));
         match item.parent {
             Some(nodeid) => {
@@ -457,8 +457,8 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> io::IoResult<String> 
         if i > 0 {
             try!(write!(&mut w, ","));
         }
-        try!(write!(&mut w, r#"[{:u},"{}"]"#,
-                    short, *fqp.last().unwrap()));
+        try!(write!(&mut w, r#"[{},"{}"]"#,
+                    short as uint, *fqp.last().unwrap()));
     }
 
     try!(write!(&mut w, "]}};"));
@@ -2192,7 +2192,7 @@ impl<'a> fmt::Show for Source<'a> {
         }
         try!(write!(fmt, "<pre class='line-numbers'>"));
         for i in range(1, lines + 1) {
-            try!(write!(fmt, "<span id='{0:u}'>{0:1$u}</span>\n", i, cols));
+            try!(write!(fmt, "<span id='{0}'>{0:1$}</span>\n", i, cols));
         }
         try!(write!(fmt, "</pre>"));
         try!(write!(fmt, "{}", highlight::highlight(s.as_slice(), None, None)));

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -168,11 +168,11 @@ pub fn main_args(args: &[String]) -> int {
     if matches.opt_strs("passes").as_slice() == &["list".to_string()] {
         println!("Available passes for running rustdoc:");
         for &(name, _, description) in PASSES.iter() {
-            println!("{:>20s} - {}", name, description);
+            println!("{:>20} - {}", name, description);
         }
         println!("{}", "\nDefault passes for rustdoc:"); // FIXME: #9970
         for &name in DEFAULT_PASSES.iter() {
-            println!("{:>20s}", name);
+            println!("{:>20}", name);
         }
         return 0;
     }

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -2403,7 +2403,7 @@ impl<A:ToJson> ToJson for Option<A> {
 impl fmt::Show for Json {
     /// Encodes a json value into a string
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.to_writer(f).map_err(|_| fmt::WriteError)
+        self.to_writer(f).map_err(|_| fmt::Error)
     }
 }
 

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1034,7 +1034,7 @@ pub trait Writer {
                     Ok(()) => Ok(()),
                     Err(e) => {
                         self.error = Err(e);
-                        Err(fmt::WriteError)
+                        Err(fmt::Error)
                     }
                 }
             }
@@ -1081,13 +1081,13 @@ pub trait Writer {
     /// Write the result of passing n through `int::to_str_bytes`.
     #[inline]
     fn write_int(&mut self, n: int) -> IoResult<()> {
-        write!(self, "{:d}", n)
+        write!(self, "{}", n)
     }
 
     /// Write the result of passing n through `uint::to_str_bytes`.
     #[inline]
     fn write_uint(&mut self, n: uint) -> IoResult<()> {
-        write!(self, "{:u}", n)
+        write!(self, "{}", n)
     }
 
     /// Write a little-endian uint (number of bytes depends on system).
@@ -1896,10 +1896,8 @@ impl Default for FilePermission {
 }
 
 impl fmt::Show for FilePermission {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.fill = '0';
-        formatter.width = Some(4);
-        (&self.bits as &fmt::Octal).fmt(formatter)
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:04o}", self.bits)
     }
 }
 

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -240,6 +240,7 @@ macro_rules! unimplemented(
 /// format!("x = {}, y = {y}", 10i, y = 30i);
 /// ```
 #[macro_export]
+#[stable]
 macro_rules! format(
     ($($arg:tt)*) => (
         format_args!(::std::fmt::format, $($arg)*)
@@ -259,15 +260,18 @@ macro_rules! format(
 /// write!(&mut w, "formatted {}", "arguments");
 /// ```
 #[macro_export]
+#[stable]
 macro_rules! write(
     ($dst:expr, $($arg:tt)*) => ({
-        format_args_method!($dst, write_fmt, $($arg)*)
+        let dst = &mut *$dst;
+        format_args!(|args| { dst.write_fmt(args) }, $($arg)*)
     })
 )
 
 /// Equivalent to the `write!` macro, except that a newline is appended after
 /// the message is written.
 #[macro_export]
+#[stable]
 macro_rules! writeln(
     ($dst:expr, $fmt:expr $($arg:tt)*) => (
         write!($dst, concat!($fmt, "\n") $($arg)*)
@@ -277,6 +281,7 @@ macro_rules! writeln(
 /// Equivalent to the `println!` macro except that a newline is not printed at
 /// the end of the message.
 #[macro_export]
+#[stable]
 macro_rules! print(
     ($($arg:tt)*) => (format_args!(::std::io::stdio::print_args, $($arg)*))
 )
@@ -294,6 +299,7 @@ macro_rules! print(
 /// println!("format {} arguments", "some");
 /// ```
 #[macro_export]
+#[stable]
 macro_rules! println(
     ($($arg:tt)*) => (format_args!(::std::io::stdio::println_args, $($arg)*))
 )

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -95,7 +95,7 @@ impl Ident {
     }
 
     pub fn encode_with_hygiene(&self) -> String {
-        format!("\x00name_{:u},ctxt_{:u}\x00",
+        format!("\x00name_{},ctxt_{}\x00",
                 self.name.uint(),
                 self.ctxt)
     }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -361,9 +361,6 @@ fn initial_syntax_expander_table(ecfg: &expand::ExpansionConfig) -> SyntaxEnv {
     syntax_expanders.insert(intern("format_args"),
                             builtin_normal_expander(
                                 ext::format::expand_format_args));
-    syntax_expanders.insert(intern("format_args_method"),
-                            builtin_normal_expander(
-                                ext::format::expand_format_args_method));
     syntax_expanders.insert(intern("env"),
                             builtin_normal_expander(
                                     ext::env::expand_env));

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -887,7 +887,7 @@ impl<'a> MethodDef<'a> {
         // a series of let statements mapping each self_arg to a uint
         // corresponding to its variant index.
         let vi_idents: Vec<ast::Ident> = self_arg_names.iter()
-            .map(|name| { let vi_suffix = format!("{:s}_vi", name.as_slice());
+            .map(|name| { let vi_suffix = format!("{}_vi", name.as_slice());
                           cx.ident_of(vi_suffix.as_slice()) })
             .collect::<Vec<ast::Ident>>();
 

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -237,7 +237,7 @@ impl<'a, 'b> Context<'a, 'b> {
         match arg {
             Exact(arg) => {
                 if self.args.len() <= arg {
-                    let msg = format!("invalid reference to argument `{}` ({:s})",
+                    let msg = format!("invalid reference to argument `{}` ({})",
                                       arg, self.describe_num_args());
 
                     self.ecx.span_err(self.fmtsp, msg.as_slice());
@@ -670,17 +670,11 @@ impl<'a, 'b> Context<'a, 'b> {
             Known(ref tyname) => {
                 match tyname.as_slice() {
                     ""  => "Show",
-                    "b" => "Bool",
-                    "c" => "Char",
-                    "d" | "i" => "Signed",
                     "e" => "LowerExp",
                     "E" => "UpperExp",
-                    "f" => "Float",
                     "o" => "Octal",
                     "p" => "Pointer",
-                    "s" => "String",
-                    "t" => "Binary",
-                    "u" => "Unsigned",
+                    "b" => "Binary",
                     "x" => "LowerHex",
                     "X" => "UpperHex",
                     _ => {
@@ -716,18 +710,6 @@ pub fn expand_format_args<'cx>(ecx: &'cx mut ExtCtxt, sp: Span,
                                -> Box<base::MacResult+'cx> {
 
     match parse_args(ecx, sp, false, tts) {
-        (invocation, Some((efmt, args, order, names))) => {
-            MacExpr::new(expand_preparsed_format_args(ecx, sp, invocation, efmt,
-                                                      args, order, names))
-        }
-        (_, None) => MacExpr::new(ecx.expr_uint(sp, 2))
-    }
-}
-
-pub fn expand_format_args_method<'cx>(ecx: &'cx mut ExtCtxt, sp: Span,
-                                      tts: &[ast::TokenTree]) -> Box<base::MacResult+'cx> {
-
-    match parse_args(ecx, sp, true, tts) {
         (invocation, Some((efmt, args, order, names))) => {
             MacExpr::new(expand_preparsed_format_args(ecx, sp, invocation, efmt,
                                                       args, order, names))

--- a/src/libsyntax/ext/mtwt.rs
+++ b/src/libsyntax/ext/mtwt.rs
@@ -131,7 +131,7 @@ fn new_sctable_internal() -> SCTable {
 pub fn display_sctable(table: &SCTable) {
     error!("SC table:");
     for (idx,val) in table.table.borrow().iter().enumerate() {
-        error!("{:4u} : {}",idx,val);
+        error!("{:4} : {}",idx,val);
     }
 }
 

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -497,8 +497,8 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
     let mut s = match val {
         Number(d) => {
             let s = match (op, flags.sign) {
-                (FormatDigit, true)  => format!("{:+d}", d).into_bytes(),
-                (FormatDigit, false) => format!("{:d}", d).into_bytes(),
+                (FormatDigit, true)  => format!("{:+}", d).into_bytes(),
+                (FormatDigit, false) => format!("{}", d).into_bytes(),
                 (FormatOctal, _)     => format!("{:o}", d).into_bytes(),
                 (FormatHex, _)       => format!("{:x}", d).into_bytes(),
                 (FormatHEX, _)       => format!("{:X}", d).into_bytes(),

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -687,14 +687,14 @@ impl<T: Writer> ConsoleTestState<T> {
                     improved += 1;
                     try!(self.write_plain(format!(": {}", *k).as_slice()));
                     try!(self.write_improved());
-                    try!(self.write_plain(format!(" by {:.2f}%\n",
+                    try!(self.write_plain(format!(" by {:.2}%\n",
                                                   pct as f64).as_slice()));
                 }
                 Regression(pct) => {
                     regressed += 1;
                     try!(self.write_plain(format!(": {}", *k).as_slice()));
                     try!(self.write_regressed());
-                    try!(self.write_plain(format!(" by {:.2f}%\n",
+                    try!(self.write_plain(format!(" by {:.2}%\n",
                                                   pct as f64).as_slice()));
                 }
             }

--- a/src/libtime/lib.rs
+++ b/src/libtime/lib.rs
@@ -602,8 +602,8 @@ impl<'a> fmt::Show for TmFmt<'a> {
 
             match ch {
                 'G' => write!(fmt, "{}", year),
-                'g' => write!(fmt, "{:02d}", (year % 100 + 100) % 100),
-                'V' => write!(fmt, "{:02d}", days / 7 + 1),
+                'g' => write!(fmt, "{:02}", (year % 100 + 100) % 100),
+                'V' => write!(fmt, "{:02}", days / 7 + 1),
                 _ => Ok(())
             }
         }
@@ -663,7 +663,7 @@ impl<'a> fmt::Show for TmFmt<'a> {
                 11 => "Dec",
                 _  => return die()
               },
-              'C' => return write!(fmt, "{:02d}", (tm.tm_year as int + 1900) / 100),
+              'C' => return write!(fmt, "{:02}", (tm.tm_year as int + 1900) / 100),
               'c' => {
                     try!(parse_type(fmt, 'a', tm));
                     try!(' '.fmt(fmt));
@@ -682,9 +682,9 @@ impl<'a> fmt::Show for TmFmt<'a> {
                     try!('/'.fmt(fmt));
                     return parse_type(fmt, 'y', tm);
               }
-              'd' => return write!(fmt, "{:02d}", tm.tm_mday),
-              'e' => return write!(fmt, "{:2d}", tm.tm_mday),
-              'f' => return write!(fmt, "{:09d}", tm.tm_nsec),
+              'd' => return write!(fmt, "{:02}", tm.tm_mday),
+              'e' => return write!(fmt, "{:2}", tm.tm_mday),
+              'f' => return write!(fmt, "{:09}", tm.tm_nsec),
               'F' => {
                     try!(parse_type(fmt, 'Y', tm));
                     try!('-'.fmt(fmt));
@@ -694,23 +694,23 @@ impl<'a> fmt::Show for TmFmt<'a> {
               }
               'G' => return iso_week(fmt, 'G', tm),
               'g' => return iso_week(fmt, 'g', tm),
-              'H' => return write!(fmt, "{:02d}", tm.tm_hour),
+              'H' => return write!(fmt, "{:02}", tm.tm_hour),
               'I' => {
                 let mut h = tm.tm_hour;
                 if h == 0 { h = 12 }
                 if h > 12 { h -= 12 }
-                return write!(fmt, "{:02d}", h)
+                return write!(fmt, "{:02}", h)
               }
-              'j' => return write!(fmt, "{:03d}", tm.tm_yday + 1),
-              'k' => return write!(fmt, "{:2d}", tm.tm_hour),
+              'j' => return write!(fmt, "{:03}", tm.tm_yday + 1),
+              'k' => return write!(fmt, "{:2}", tm.tm_hour),
               'l' => {
                 let mut h = tm.tm_hour;
                 if h == 0 { h = 12 }
                 if h > 12 { h -= 12 }
-                return write!(fmt, "{:2d}", h)
+                return write!(fmt, "{:2}", h)
               }
-              'M' => return write!(fmt, "{:02d}", tm.tm_min),
-              'm' => return write!(fmt, "{:02d}", tm.tm_mon + 1),
+              'M' => return write!(fmt, "{:02}", tm.tm_min),
+              'm' => return write!(fmt, "{:02}", tm.tm_mon + 1),
               'n' => "\n",
               'P' => if (tm.tm_hour as int) < 12 { "am" } else { "pm" },
               'p' => if (tm.tm_hour as int) < 12 { "AM" } else { "PM" },
@@ -728,7 +728,7 @@ impl<'a> fmt::Show for TmFmt<'a> {
                     try!(' '.fmt(fmt));
                     return parse_type(fmt, 'p', tm);
               }
-              'S' => return write!(fmt, "{:02d}", tm.tm_sec),
+              'S' => return write!(fmt, "{:02}", tm.tm_sec),
               's' => return write!(fmt, "{}", tm.to_timespec().sec),
               'T' | 'X' => {
                     try!(parse_type(fmt, 'H', tm));
@@ -738,7 +738,7 @@ impl<'a> fmt::Show for TmFmt<'a> {
                     return parse_type(fmt, 'S', tm);
               }
               't' => "\t",
-              'U' => return write!(fmt, "{:02d}", (tm.tm_yday - tm.tm_wday + 7) / 7),
+              'U' => return write!(fmt, "{:02}", (tm.tm_yday - tm.tm_wday + 7) / 7),
               'u' => {
                 let i = tm.tm_wday as int;
                 return (if i == 0 { 7 } else { i }).fmt(fmt);
@@ -752,19 +752,19 @@ impl<'a> fmt::Show for TmFmt<'a> {
                   return parse_type(fmt, 'Y', tm);
               }
               'W' => {
-                  return write!(fmt, "{:02d}",
+                  return write!(fmt, "{:02}",
                                  (tm.tm_yday - (tm.tm_wday - 1 + 7) % 7 + 7) / 7)
               }
               'w' => return (tm.tm_wday as int).fmt(fmt),
               'Y' => return (tm.tm_year as int + 1900).fmt(fmt),
-              'y' => return write!(fmt, "{:02d}", (tm.tm_year as int + 1900) % 100),
+              'y' => return write!(fmt, "{:02}", (tm.tm_year as int + 1900) % 100),
               'Z' => if tm.tm_gmtoff == 0_i32 { "GMT"} else { "" }, // FIXME (#2350): support locale
               'z' => {
                 let sign = if tm.tm_gmtoff > 0_i32 { '+' } else { '-' };
                 let mut m = tm.tm_gmtoff.abs() / 60_i32;
                 let h = m / 60_i32;
                 m -= h * 60_i32;
-                return write!(fmt, "{}{:02d}{:02d}", sign, h, m);
+                return write!(fmt, "{}{:02}{:02}", sign, h, m);
               }
               '+' => return tm.rfc3339().fmt(fmt),
               '%' => "%",
@@ -806,7 +806,7 @@ impl<'a> fmt::Show for TmFmt<'a> {
                     let mut m = self.tm.tm_gmtoff.abs() / 60_i32;
                     let h = m / 60_i32;
                     m -= h * 60_i32;
-                    write!(fmt, "{}{}{:02d}:{:02d}", s, sign, h as int, m as int)
+                    write!(fmt, "{}{}{:02}:{:02}", s, sign, h as int, m as int)
                 }
             }
         }

--- a/src/test/bench/core-set.rs
+++ b/src/test/bench/core-set.rs
@@ -148,7 +148,7 @@ fn write_header(header: &str) {
 }
 
 fn write_row(label: &str, value: Duration) {
-    println!("{:30s} {} s\n", label, value);
+    println!("{:30} {} s\n", label, value);
 }
 
 fn write_results(label: &str, results: &Results) {

--- a/src/test/bench/noise.rs
+++ b/src/test/bench/noise.rs
@@ -115,7 +115,7 @@ fn main() {
     for y in range(0u, 256) {
         for x in range(0u, 256) {
             let idx = (pixels[y*256+x] / 0.2) as uint;
-            print!("{:c}", symbols[idx]);
+            print!("{}", symbols[idx]);
         }
         print!("\n");
     }

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -63,7 +63,7 @@ fn sort_and_fmt(mm: &HashMap<Vec<u8> , uint>, total: uint) -> String {
 
    let mut buffer = String::new();
    for &(ref k, v) in pairs_sorted.iter() {
-       buffer.push_str(format!("{} {:0.3f}\n",
+       buffer.push_str(format!("{} {:0.3}\n",
                                k.as_slice()
                                .to_ascii()
                                .to_uppercase()

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -266,7 +266,7 @@ fn print_frequencies(frequencies: &Table, frame: uint) {
     }
 
     for &(count, key) in vector.iter().rev() {
-        println!("{} {:.3f}",
+        println!("{} {:.3}",
                  key.unpack(frame).as_slice(),
                  (count as f32 * 100.0) / (total_count as f32));
     }

--- a/src/test/bench/shootout-nbody.rs
+++ b/src/test/bench/shootout-nbody.rs
@@ -179,11 +179,11 @@ fn main() {
     let mut bodies = BODIES;
 
     offset_momentum(&mut bodies);
-    println!("{:.9f}", energy(&bodies));
+    println!("{:.9}", energy(&bodies));
 
     advance(&mut bodies, 0.01, n);
 
-    println!("{:.9f}", energy(&bodies));
+    println!("{:.9}", energy(&bodies));
 }
 
 /// Pop a mutable reference off the head of a slice, mutating the slice to no

--- a/src/test/bench/shootout-spectralnorm.rs
+++ b/src/test/bench/shootout-spectralnorm.rs
@@ -59,7 +59,7 @@ fn main() {
     } else {
         from_str(args[1].as_slice()).unwrap()
     });
-    println!("{:.9f}", answer);
+    println!("{:.9}", answer);
 }
 
 fn spectralnorm(n: uint) -> f64 {

--- a/src/test/compile-fail/ifmt-bad-arg.rs
+++ b/src/test/compile-fail/ifmt-bad-arg.rs
@@ -23,8 +23,8 @@ fn main() {
     format!("{foo}", 1, foo=2);        //~ ERROR: argument never used
     format!("", foo=2);                //~ ERROR: named argument never used
 
-    format!("{0:d} {0:s}", 1);         //~ ERROR: redeclared with type `s`
-    format!("{foo:d} {foo:s}", foo=1); //~ ERROR: redeclared with type `s`
+    format!("{0:x} {0:X}", 1);         //~ ERROR: redeclared with type `X`
+    format!("{foo:x} {foo:X}", foo=1); //~ ERROR: redeclared with type `X`
 
     format!("{foo}", foo=1, foo=2);    //~ ERROR: duplicate argument
     format!("", foo=1, 2);             //~ ERROR: positional arguments cannot follow

--- a/src/test/compile-fail/ifmt-unimpl.rs
+++ b/src/test/compile-fail/ifmt-unimpl.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 fn main() {
-    format!("{:d}", "3");
-    //~^ ERROR: the trait `core::fmt::Signed` is not implemented
+    format!("{:X}", "3");
+    //~^ ERROR: the trait `core::fmt::UpperHex` is not implemented
 }

--- a/src/test/compile-fail/issue-1448-2.rs
+++ b/src/test/compile-fail/issue-1448-2.rs
@@ -13,5 +13,5 @@
 fn foo(a: uint) -> uint { a }
 
 fn main() {
-    println!("{:u}", foo(10i)); //~ ERROR mismatched types
+    println!("{}", foo(10i)); //~ ERROR mismatched types
 }

--- a/src/test/compile-fail/issue-14853.rs
+++ b/src/test/compile-fail/issue-14853.rs
@@ -10,17 +10,18 @@
 
 use std::fmt::Show;
 
+trait Str {}
+
 trait Something {
-    fn yay<T: Show>(_: Option<Self>, thing: &[T]) -> String {
-    }
+    fn yay<T: Show>(_: Option<Self>, thing: &[T]);
 }
 
 struct X { data: u32 }
 
 impl Something for X {
-    fn yay<T: Str>(_:Option<X>, thing: &[T]) -> String {
-//~^ ERROR in method `yay`, type parameter 0 requires bound `core::str::Str`, which is not required
-        format!("{:s}", thing[0])
+    fn yay<T: Str>(_:Option<X>, thing: &[T]) {
+//~^ ERROR in method `yay`, type parameter 0 requires bound `Str`, which is not required
+
     }
 }
 

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -22,12 +22,12 @@ struct A;
 struct B;
 struct C;
 
-impl fmt::Signed for A {
+impl fmt::LowerHex for A {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write("aloha".as_bytes())
     }
 }
-impl fmt::Signed for B {
+impl fmt::UpperHex for B {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write("adios".as_bytes())
     }
@@ -55,71 +55,71 @@ pub fn main() {
     t!(format!("{}", 'a'), "a");
 
     // At least exercise all the formats
-    t!(format!("{:b}", true), "true");
-    t!(format!("{:c}", '☃'), "☃");
-    t!(format!("{:d}", 10i), "10");
-    t!(format!("{:i}", 10i), "10");
-    t!(format!("{:u}", 10u), "10");
+    t!(format!("{}", true), "true");
+    t!(format!("{}", '☃'), "☃");
+    t!(format!("{}", 10i), "10");
+    t!(format!("{}", 10i), "10");
+    t!(format!("{}", 10u), "10");
     t!(format!("{:o}", 10u), "12");
     t!(format!("{:x}", 10u), "a");
     t!(format!("{:X}", 10u), "A");
-    t!(format!("{:s}", "foo"), "foo");
-    t!(format!("{:s}", "foo".to_string()), "foo");
+    t!(format!("{}", "foo"), "foo");
+    t!(format!("{}", "foo".to_string()), "foo");
     t!(format!("{:p}", 0x1234 as *const int), "0x1234");
     t!(format!("{:p}", 0x1234 as *mut int), "0x1234");
-    t!(format!("{:d}", A), "aloha");
-    t!(format!("{:d}", B), "adios");
-    t!(format!("foo {:s} ☃☃☃☃☃☃", "bar"), "foo bar ☃☃☃☃☃☃");
+    t!(format!("{:x}", A), "aloha");
+    t!(format!("{:X}", B), "adios");
+    t!(format!("foo {} ☃☃☃☃☃☃", "bar"), "foo bar ☃☃☃☃☃☃");
     t!(format!("{1} {0}", 0i, 1i), "1 0");
     t!(format!("{foo} {bar}", foo=0i, bar=1i), "0 1");
     t!(format!("{foo} {1} {bar} {0}", 0i, 1i, foo=2i, bar=3i), "2 1 3 0");
     t!(format!("{} {0}", "a"), "a a");
     t!(format!("{foo_bar}", foo_bar=1i), "1");
-    t!(format!("{:d}", 5i + 5i), "10");
+    t!(format!("{}", 5i + 5i), "10");
     t!(format!("{:#4}", C), "☃123");
 
     let a: &fmt::Show = &1i;
     t!(format!("{}", a), "1");
 
     // Formatting strings and their arguments
-    t!(format!("{:s}", "a"), "a");
-    t!(format!("{:4s}", "a"), "a   ");
-    t!(format!("{:4s}", "☃"), "☃   ");
-    t!(format!("{:>4s}", "a"), "   a");
-    t!(format!("{:<4s}", "a"), "a   ");
-    t!(format!("{:^5s}", "a"),  "  a  ");
-    t!(format!("{:^5s}", "aa"), " aa  ");
-    t!(format!("{:^4s}", "a"),  " a  ");
-    t!(format!("{:^4s}", "aa"), " aa ");
-    t!(format!("{:.4s}", "a"), "a");
-    t!(format!("{:4.4s}", "a"), "a   ");
-    t!(format!("{:4.4s}", "aaaaaaaaaaaaaaaaaa"), "aaaa");
-    t!(format!("{:<4.4s}", "aaaaaaaaaaaaaaaaaa"), "aaaa");
-    t!(format!("{:>4.4s}", "aaaaaaaaaaaaaaaaaa"), "aaaa");
-    t!(format!("{:^4.4s}", "aaaaaaaaaaaaaaaaaa"), "aaaa");
-    t!(format!("{:>10.4s}", "aaaaaaaaaaaaaaaaaa"), "aaaa");
-    t!(format!("{:2.4s}", "aaaaa"), "aaaa");
-    t!(format!("{:2.4s}", "aaaa"), "aaaa");
-    t!(format!("{:2.4s}", "aaa"), "aaa");
-    t!(format!("{:2.4s}", "aa"), "aa");
-    t!(format!("{:2.4s}", "a"), "a ");
-    t!(format!("{:0>2s}", "a"), "0a");
-    t!(format!("{:.*s}", 4, "aaaaaaaaaaaaaaaaaa"), "aaaa");
-    t!(format!("{:.1$s}", "aaaaaaaaaaaaaaaaaa", 4), "aaaa");
-    t!(format!("{:.a$s}", "aaaaaaaaaaaaaaaaaa", a=4), "aaaa");
-    t!(format!("{:1$s}", "a", 4), "a   ");
-    t!(format!("{1:0$s}", 4, "a"), "a   ");
-    t!(format!("{:a$s}", "a", a=4), "a   ");
-    t!(format!("{:-#s}", "a"), "a");
-    t!(format!("{:+#s}", "a"), "a");
+    t!(format!("{}", "a"), "a");
+    t!(format!("{:4}", "a"), "a   ");
+    t!(format!("{:4}", "☃"), "☃   ");
+    t!(format!("{:>4}", "a"), "   a");
+    t!(format!("{:<4}", "a"), "a   ");
+    t!(format!("{:^5}", "a"),  "  a  ");
+    t!(format!("{:^5}", "aa"), " aa  ");
+    t!(format!("{:^4}", "a"),  " a  ");
+    t!(format!("{:^4}", "aa"), " aa ");
+    t!(format!("{:.4}", "a"), "a");
+    t!(format!("{:4.4}", "a"), "a   ");
+    t!(format!("{:4.4}", "aaaaaaaaaaaaaaaaaa"), "aaaa");
+    t!(format!("{:<4.4}", "aaaaaaaaaaaaaaaaaa"), "aaaa");
+    t!(format!("{:>4.4}", "aaaaaaaaaaaaaaaaaa"), "aaaa");
+    t!(format!("{:^4.4}", "aaaaaaaaaaaaaaaaaa"), "aaaa");
+    t!(format!("{:>10.4}", "aaaaaaaaaaaaaaaaaa"), "aaaa");
+    t!(format!("{:2.4}", "aaaaa"), "aaaa");
+    t!(format!("{:2.4}", "aaaa"), "aaaa");
+    t!(format!("{:2.4}", "aaa"), "aaa");
+    t!(format!("{:2.4}", "aa"), "aa");
+    t!(format!("{:2.4}", "a"), "a ");
+    t!(format!("{:0>2}", "a"), "0a");
+    t!(format!("{:.*}", 4, "aaaaaaaaaaaaaaaaaa"), "aaaa");
+    t!(format!("{:.1$}", "aaaaaaaaaaaaaaaaaa", 4), "aaaa");
+    t!(format!("{:.a$}", "aaaaaaaaaaaaaaaaaa", a=4), "aaaa");
+    t!(format!("{:1$}", "a", 4), "a   ");
+    t!(format!("{1:0$}", 4, "a"), "a   ");
+    t!(format!("{:a$}", "a", a=4), "a   ");
+    t!(format!("{:-#}", "a"), "a");
+    t!(format!("{:+#}", "a"), "a");
 
     // Some float stuff
-    t!(format!("{:f}", 1.0f32), "1");
-    t!(format!("{:f}", 1.0f64), "1");
-    t!(format!("{:.3f}", 1.0f64), "1.000");
-    t!(format!("{:10.3f}", 1.0f64),   "     1.000");
-    t!(format!("{:+10.3f}", 1.0f64),  "    +1.000");
-    t!(format!("{:+10.3f}", -1.0f64), "    -1.000");
+    t!(format!("{:}", 1.0f32), "1");
+    t!(format!("{:}", 1.0f64), "1");
+    t!(format!("{:.3}", 1.0f64), "1.000");
+    t!(format!("{:10.3}", 1.0f64),   "     1.000");
+    t!(format!("{:+10.3}", 1.0f64),  "    +1.000");
+    t!(format!("{:+10.3}", -1.0f64), "    -1.000");
 
     t!(format!("{:e}", 1.2345e6f32), "1.2345e6");
     t!(format!("{:e}", 1.2345e6f64), "1.2345e6");
@@ -164,7 +164,7 @@ fn test_write() {
     {
         let w = &mut buf as &mut io::Writer;
         write!(w, "{foo}", foo=4i);
-        write!(w, "{:s}", "hello");
+        write!(w, "{}", "hello");
         writeln!(w, "{}", "line");
         writeln!(w, "{foo}", foo="bar");
     }

--- a/src/test/run-pass/realloc-16687.rs
+++ b/src/test/run-pass/realloc-16687.rs
@@ -46,19 +46,19 @@ unsafe fn test_triangle() -> bool {
     static PRINT : bool = false;
 
     unsafe fn allocate(size: uint, align: uint) -> *mut u8 {
-        if PRINT { println!("allocate(size={:u} align={:u})", size, align); }
+        if PRINT { println!("allocate(size={} align={})", size, align); }
 
         let ret = heap::allocate(size, align);
         if ret.is_null() { alloc::oom() }
 
-        if PRINT { println!("allocate(size={:u} align={:u}) ret: 0x{:010x}",
+        if PRINT { println!("allocate(size={} align={}) ret: 0x{:010x}",
                             size, align, ret as uint);
         }
 
         ret
     }
     unsafe fn deallocate(ptr: *mut u8, size: uint, align: uint) {
-        if PRINT { println!("deallocate(ptr=0x{:010x} size={:u} align={:u})",
+        if PRINT { println!("deallocate(ptr=0x{:010x} size={} align={})",
                             ptr as uint, size, align);
         }
 
@@ -66,7 +66,7 @@ unsafe fn test_triangle() -> bool {
     }
     unsafe fn reallocate(ptr: *mut u8, old_size: uint, size: uint, align: uint) -> *mut u8 {
         if PRINT {
-            println!("reallocate(ptr=0x{:010x} old_size={:u} size={:u} align={:u})",
+            println!("reallocate(ptr=0x{:010x} old_size={} size={} align={})",
                      ptr as uint, old_size, size, align);
         }
 
@@ -74,7 +74,7 @@ unsafe fn test_triangle() -> bool {
         if ret.is_null() { alloc::oom() }
 
         if PRINT {
-            println!("reallocate(ptr=0x{:010x} old_size={:u} size={:u} align={:u}) \
+            println!("reallocate(ptr=0x{:010x} old_size={} size={} align={}) \
                       ret: 0x{:010x}",
                      ptr as uint, old_size, size, align, ret as uint);
         }


### PR DESCRIPTION
This commit applies the stabilization of std::fmt as outlined in [RFC 380](https://github.com/rust-lang/rfcs/blob/master/text/0380-stabilize-std-fmt.md).
There are a number of breaking changes as a part of this commit which will need
to be handled to migrated old code:
- A number of formatting traits have been removed: String, Bool, Char, Unsigned,
  Signed, and Float. It is recommended to instead use Show wherever possible or
  to use adaptor structs to implement other methods of formatting.
- The format specifier for Boolean has changed from `t` to `b`.
- The enum `FormatError` has been renamed to `Error` as well as becoming a unit
  struct instead of an enum. The `WriteError` variant no longer exists.
- The `format_args_method!` macro has been removed with no replacement. Alter
  code to use the `format_args!` macro instead.
- The public fields of a `Formatter` have become read-only with no replacement.
  Use a new formatting string to alter the formatting flags in combination with
  the `write!` macro. The fields can be accessed through accessor methods on the
  `Formatter` structure.

Other than these breaking changes, the contents of std::fmt should now also all
contain stability markers. Most of them are still #[unstable] or #[experimental]

[breaking-change]

Closes #18904
