### PR TITLE
libsyntax: Add `parse_view_item` method to Parser

### DIFF
--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -730,10 +730,11 @@ mod test {
     use attr::AttrMetaMethods;
     use parse::parser::Parser;
     use parse::token::{str_to_ident};
+    use print::pprust::view_item_to_string;
     use ptr::P;
     use util::parser_testing::{string_to_tts, string_to_parser};
     use util::parser_testing::{string_to_expr, string_to_item};
-    use util::parser_testing::string_to_stmt;
+    use util::parser_testing::{string_to_stmt, string_to_view_item};
 
     // produce a codemap::span
     fn sp(a: u32, b: u32) -> Span {
@@ -1081,6 +1082,30 @@ mod test {
                                     })),
                             vis: ast::Inherited,
                             span: sp(0,21)})));
+    }
+
+    #[test] fn parse_use() {
+        let use_s = "use foo::bar::baz;";
+        let vitem = string_to_view_item(use_s.to_string());
+        let vitem_s = view_item_to_string(&vitem);
+        assert_eq!(vitem_s.as_slice(), use_s);
+
+        let use_s = "use foo::bar as baz;";
+        let vitem = string_to_view_item(use_s.to_string());
+        let vitem_s = view_item_to_string(&vitem);
+        assert_eq!(vitem_s.as_slice(), use_s);
+    }
+
+    #[test] fn parse_extern_crate() {
+        let ex_s = "extern crate foo;";
+        let vitem = string_to_view_item(ex_s.to_string());
+        let vitem_s = view_item_to_string(&vitem);
+        assert_eq!(vitem_s.as_slice(), ex_s);
+
+        let ex_s = "extern crate \"foo\" as bar;";
+        let vitem = string_to_view_item(ex_s.to_string());
+        let vitem_s = view_item_to_string(&vitem);
+        assert_eq!(vitem_s.as_slice(), ex_s);
     }
 
     fn get_spans_of_pat_idents(src: &str) -> Vec<Span> {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5609,6 +5609,14 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Parse a ViewItem, e.g. `use foo::bar` or `extern crate foo`
+    pub fn parse_view_item(&mut self, attrs: Vec<Attribute>) -> ViewItem {
+        match self.parse_item_or_view_item(attrs, false) {
+            IoviViewItem(vi) => vi,
+            _ => self.fatal("expected `use` or `extern crate`"),
+        }
+    }
+
     /// Parse, e.g., "use a::b::{z,y}"
     fn parse_use(&mut self) -> ViewItem_ {
         return ViewItemUse(self.parse_view_path());

--- a/src/libsyntax/util/parser_testing.rs
+++ b/src/libsyntax/util/parser_testing.rs
@@ -67,6 +67,13 @@ pub fn string_to_stmt(source_str : String) -> P<ast::Stmt> {
     })
 }
 
+/// Parse a string, return a view item
+pub fn string_to_view_item (source_str : String) -> ast::ViewItem {
+    with_error_checking_parse(source_str, |p| {
+        p.parse_view_item(Vec::new())
+    })
+}
+
 /// Parse a string, return a pat. Uses "irrefutable"... which doesn't
 /// (currently) affect parsing.
 pub fn string_to_pat(source_str: String) -> P<ast::Pat> {


### PR DESCRIPTION
Allows parsing view items (`use` and `extern crate`) individually. Does not change behavior of any existing functions.

Closes #19024
