### PR TITLE
make Option::cloned generic over Deref, make cloned's tests actually run, add Cloned iterator adaptor

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -153,6 +153,7 @@ use result::{Result, Ok, Err};
 use slice;
 use slice::AsSlice;
 use clone::Clone;
+use ops::Deref;
 
 // Note that this is not a lang item per se, but it has a hidden dependency on
 // `Iterator`, which is one. The compiler assumes that the `next` method of
@@ -694,11 +695,12 @@ impl<T> Option<T> {
     }
 }
 
-impl<'a, T: Clone> Option<&'a T> {
-    /// Maps an Option<&T> to an Option<T> by cloning the contents of the Option<&T>.
+impl<'a, T: Clone, D: Deref<T>> Option<D> {
+    /// Maps an Option<D> to an Option<T> by dereffing and cloning the contents of the Option.
+    /// Useful for converting an Option<&T> to an Option<T>.
     #[unstable = "recently added as part of collections reform"]
     pub fn cloned(self) -> Option<T> {
-        self.map(|t| t.clone())
+        self.map(|t| t.deref().clone())
     }
 }
 

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -441,6 +441,23 @@ fn test_rev() {
 }
 
 #[test]
+fn test_cloned() {
+    let xs = [2u8, 4, 6, 8];
+
+    let mut it = xs.iter().cloned();
+    assert_eq!(it.len(), 4);
+    assert_eq!(it.next(), Some(2));
+    assert_eq!(it.len(), 3);
+    assert_eq!(it.next(), Some(4));
+    assert_eq!(it.len(), 2);
+    assert_eq!(it.next_back(), Some(8));
+    assert_eq!(it.len(), 1);
+    assert_eq!(it.next_back(), Some(6));
+    assert_eq!(it.len(), 0);
+    assert_eq!(it.next_back(), None);
+}
+
+#[test]
 fn test_double_ended_map() {
     let xs = [1i, 2, 3, 4, 5, 6];
     let mut it = xs.iter().map(|&x| x * -1);

--- a/src/libcoretest/option.rs
+++ b/src/libcoretest/option.rs
@@ -241,14 +241,29 @@ fn test_collect() {
     assert!(v == None);
 }
 
+#[test]
 fn test_cloned() {
-    let s = 1u32;
-    let n: Option<&'static u32> = None;
-    let o = Some(&s);
+    let val1 = 1u32;
+    let mut val2 = 2u32;
+    let val1_ref = &val1;
+    let opt_none: Option<&'static u32> = None;
+    let opt_ref = Some(&val1);
+    let opt_ref_ref = Some(&val1_ref);
+    let opt_mut_ref = Some(&mut val2);
 
-    assert_eq!(o.clone(), Some(&s));
-    assert_eq!(o.cloned(), Some(1u32));
+    // None works
+    assert_eq!(opt_none.clone(), None);
+    assert_eq!(opt_none.cloned(), None);
 
-    assert_eq!(n.clone(), None);
-    assert_eq!(n.cloned(), None);
+    // Mutable refs work
+    assert_eq!(opt_mut_ref.cloned(), Some(2u32));
+
+    // Immutable ref works
+    assert_eq!(opt_ref.clone(), Some(&val1));
+    assert_eq!(opt_ref.cloned(), Some(1u32));
+
+    // Double Immutable ref works
+    assert_eq!(opt_ref_ref.clone(), Some(&val1_ref));
+    assert_eq!(opt_ref_ref.clone().cloned(), Some(&val1));
+    assert_eq!(opt_ref_ref.cloned().cloned(), Some(1u32));
 }


### PR DESCRIPTION
Edit: whoops, didn't mean to hit post.

Anyway, this is something I tried to do when I first implemented cloned, but couldn't figure out. Somewhere between then and the PR actually landing, we got Deref of references, so now this works! :tada: 

Also turns out the test for the functionality was never marked as a #[test]. Oops!

Also added a Cloned iterator adaptor. If this isn't desirable, it can be taken out of the PR (seperate commits).
