### PR TITLE
Rename `col!` to `column!`.

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -552,17 +552,17 @@ pub mod builtin {
     /// A macro which expands to the column number on which it was invoked.
     ///
     /// The expanded expression has type `uint`, and the returned column is not
-    /// the invocation of the `col!()` macro itself, but rather the first macro
-    /// invocation leading up to the invocation of the `col!()` macro.
+    /// the invocation of the `column!()` macro itself, but rather the first macro
+    /// invocation leading up to the invocation of the `column!()` macro.
     ///
     /// # Example
     ///
     /// ```
-    /// let current_col = col!();
+    /// let current_col = column!();
     /// println!("defined on column: {}", current_col);
     /// ```
     #[macro_export]
-    macro_rules! col( () => ({ /* compiler built-in */ }) )
+    macro_rules! column( () => ({ /* compiler built-in */ }) )
 
     /// A macro which expands to the file name from which it was invoked.
     ///

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -414,9 +414,9 @@ fn initial_syntax_expander_table(ecfg: &expand::ExpansionConfig) -> SyntaxEnv {
     syntax_expanders.insert(intern("line"),
                             builtin_normal_expander(
                                     ext::source_util::expand_line));
-    syntax_expanders.insert(intern("col"),
+    syntax_expanders.insert(intern("column"),
                             builtin_normal_expander(
-                                    ext::source_util::expand_col));
+                                    ext::source_util::expand_column));
     syntax_expanders.insert(intern("file"),
                             builtin_normal_expander(
                                     ext::source_util::expand_file));

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -38,10 +38,10 @@ pub fn expand_line(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
     base::MacExpr::new(cx.expr_uint(topmost, loc.line))
 }
 
-/* col!(): expands to the current column number */
-pub fn expand_col(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
+/* column!(): expands to the current column number */
+pub fn expand_column(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                   -> Box<base::MacResult+'static> {
-    base::check_zero_tts(cx, sp, tts, "col!");
+    base::check_zero_tts(cx, sp, tts, "column!");
 
     let topmost = cx.original_span_in_file();
     let loc = cx.codemap().lookup_char_pos(topmost.lo);

--- a/src/test/run-pass/syntax-extension-source-utils.rs
+++ b/src/test/run-pass/syntax-extension-source-utils.rs
@@ -25,7 +25,7 @@ macro_rules! indirect_line( () => ( line!() ) )
 
 pub fn main() {
     assert_eq!(line!(), 27);
-    //assert!((col!() == 11));
+    //assert!((column!() == 11));
     assert_eq!(indirect_line!(), 29);
     assert!((file!().ends_with("syntax-extension-source-utils.rs")));
     assert_eq!(stringify!((2*3) + 5).to_string(), "( 2 * 3 ) + 5".to_string());


### PR DESCRIPTION
This macro is very rarely used, so there is no need (and it is better)
for it to avoid the abbreviation.

Closes rust-lang/rfcs#467.
