### PR TITLE
deriving: error out when used on a non-type

### DIFF
--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -335,7 +335,7 @@ pub fn combine_substructure<'a>(f: CombineSubstructureFunc<'a>)
 impl<'a> TraitDef<'a> {
     pub fn expand(&self,
                   cx: &mut ExtCtxt,
-                  _mitem: &ast::MetaItem,
+                  mitem: &ast::MetaItem,
                   item: &ast::Item,
                   push: |P<ast::Item>|) {
         let newitem = match item.node {
@@ -351,7 +351,10 @@ impl<'a> TraitDef<'a> {
                                      item.ident,
                                      generics)
             }
-            _ => return
+            _ => {
+                cx.span_err(mitem.span, "`deriving` may only be applied to structs and enums");
+                return;
+            }
         };
         // Keep the lint attributes of the previous item to control how the
         // generated implementations are linted

--- a/src/test/compile-fail/deriving-non-type.rs
+++ b/src/test/compile-fail/deriving-non-type.rs
@@ -1,0 +1,40 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+
+struct S;
+
+#[deriving(PartialEq)] //~ ERROR: `deriving` may only be applied to structs and enums
+trait T { }
+
+#[deriving(PartialEq)] //~ ERROR: `deriving` may only be applied to structs and enums
+impl S { }
+
+#[deriving(PartialEq)] //~ ERROR: `deriving` may only be applied to structs and enums
+impl T for S { }
+
+#[deriving(PartialEq)] //~ ERROR: `deriving` may only be applied to structs and enums
+static s: uint = 0u;
+
+#[deriving(PartialEq)] //~ ERROR: `deriving` may only be applied to structs and enums
+const c: uint = 0u;
+
+#[deriving(PartialEq)] //~ ERROR: `deriving` may only be applied to structs and enums
+mod m { }
+
+#[deriving(PartialEq)] //~ ERROR: `deriving` may only be applied to structs and enums
+extern "C" { }
+
+#[deriving(PartialEq)] //~ ERROR: `deriving` may only be applied to structs and enums
+type A = uint;
+
+#[deriving(PartialEq)] //~ ERROR: `deriving` may only be applied to structs and enums
+fn main() { }


### PR DESCRIPTION
Besides being more helpful, this gives us the flexibility to later define a meaning for something like

``` rust
#[deriving(...)]
mod bar { ... }
```
