### PR TITLE
Rename some methods in the os module

### DIFF
--- a/src/librustc/plugin/load.rs
+++ b/src/librustc/plugin/load.rs
@@ -134,7 +134,7 @@ impl<'a> PluginLoader<'a> {
     // Dynamically link a registrar function into the compiler process.
     fn dylink_registrar(&mut self, vi: &ast::ViewItem, path: Path, symbol: String) {
         // Make sure the path contains a / or the linker will search for it.
-        let path = os::make_absolute(&path).unwrap();
+        let path = os::abspath(&path).unwrap();
 
         let lib = match DynamicLibrary::open(Some(&path)) {
             Ok(lib) => lib,

--- a/src/librustc_back/archive.rs
+++ b/src/librustc_back/archive.rs
@@ -286,7 +286,7 @@ impl<'a> ArchiveBuilder<'a> {
         // First, extract the contents of the archive to a temporary directory.
         // We don't unpack directly into `self.work_dir` due to the possibility
         // of filename collisions.
-        let archive = os::make_absolute(archive).unwrap();
+        let archive = os::abspath(archive).unwrap();
         run_ar(self.archive.handler, &self.archive.maybe_ar_prog,
                "x", Some(loc.path()), &[&archive]);
 

--- a/src/librustc_back/fs.rs
+++ b/src/librustc_back/fs.rs
@@ -16,7 +16,7 @@ use std::os;
 /// returned path does not contain any symlinks in its hierarchy.
 pub fn realpath(original: &Path) -> io::IoResult<Path> {
     static MAX_LINKS_FOLLOWED: uint = 256;
-    let original = os::make_absolute(original).unwrap();
+    let original = os::abspath(original).unwrap();
 
     // Right now lstat on windows doesn't work quite well
     if cfg!(windows) {
@@ -24,7 +24,7 @@ pub fn realpath(original: &Path) -> io::IoResult<Path> {
     }
 
     let result = original.root_path();
-    let mut result = result.expect("make_absolute has no root_path");
+    let mut result = result.expect("abspath has no root_path");
     let mut followed = 0;
 
     for part in original.components() {

--- a/src/librustc_back/rpath.rs
+++ b/src/librustc_back/rpath.rs
@@ -102,9 +102,9 @@ fn get_rpath_relative_to_output(config: &mut RPathConfig,
         "$ORIGIN"
     };
 
-    let mut lib = (config.realpath)(&os::make_absolute(lib).unwrap()).unwrap();
+    let mut lib = (config.realpath)(&os::abspath(lib).unwrap()).unwrap();
     lib.pop();
-    let mut output = (config.realpath)(&os::make_absolute(&config.out_filename).unwrap()).unwrap();
+    let mut output = (config.realpath)(&os::abspath(&config.out_filename).unwrap()).unwrap();
     output.pop();
     let relative = lib.path_relative_from(&output);
     let relative = relative.expect("could not create rpath relative to output");
@@ -116,7 +116,7 @@ fn get_rpath_relative_to_output(config: &mut RPathConfig,
 
 fn get_install_prefix_rpath(config: RPathConfig) -> String {
     let path = (config.get_install_prefix_lib_path)();
-    let path = os::make_absolute(&path).unwrap();
+    let path = os::abspath(&path).unwrap();
     // FIXME (#9639): This needs to handle non-utf8 paths
     path.as_str().expect("non-utf8 component in rpath").to_string()
 }

--- a/src/libstd/io/tempfile.rs
+++ b/src/libstd/io/tempfile.rs
@@ -35,7 +35,7 @@ impl TempDir {
     /// If no directory can be created, `Err` is returned.
     pub fn new_in(tmpdir: &Path, suffix: &str) -> IoResult<TempDir> {
         if !tmpdir.is_absolute() {
-            let abs_tmpdir = try!(os::make_absolute(tmpdir));
+            let abs_tmpdir = try!(os::abspath(tmpdir));
             return TempDir::new_in(&abs_tmpdir, suffix);
         }
 

--- a/src/libstd/io/tempfile.rs
+++ b/src/libstd/io/tempfile.rs
@@ -112,6 +112,6 @@ impl Drop for TempDir {
     }
 }
 
-// the tests for this module need to change the path using change_dir,
+// the tests for this module need to change the path using chdir,
 // and this doesn't play nicely with other tests so these unit tests are located
 // in src/test/run-pass/tempfile.rs

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -849,14 +849,14 @@ pub fn tmpdir() -> Path {
 ///
 /// // Assume we're in a path like /home/someuser
 /// let rel_path = Path::new("..");
-/// let abs_path = os::make_absolute(&rel_path).unwrap();
+/// let abs_path = os::abspath(&rel_path).unwrap();
 /// println!("The absolute path is {}", abs_path.display());
 /// // Prints "The absolute path is /home"
 /// ```
 // NB: this is here rather than in path because it is a form of environment
 // querying; what it does depends on the process working directory, not just
 // the input paths.
-pub fn make_absolute(p: &Path) -> IoResult<Path> {
+pub fn abspath(p: &Path) -> IoResult<Path> {
     if p.is_absolute() {
         Ok(p.clone())
     } else {
@@ -1772,7 +1772,7 @@ mod tests {
     use prelude::*;
     use c_str::ToCStr;
     use option;
-    use os::{env, getcwd, getenv, make_absolute};
+    use os::{env, getcwd, getenv, abspath};
     use os::{split_paths, join_paths, setenv, unsetenv};
     use os;
     use rand::Rng;
@@ -1906,8 +1906,8 @@ mod tests {
         let cwd = getcwd().unwrap();
         debug!("Current working directory: {}", cwd.display());
 
-        debug!("{}", make_absolute(&Path::new("test-path")).unwrap().display());
-        debug!("{}", make_absolute(&Path::new("/usr/bin")).unwrap().display());
+        debug!("{}", abspath(&Path::new("test-path")).unwrap().display());
+        debug!("{}", abspath(&Path::new("/usr/bin")).unwrap().display());
     }
 
     #[test]

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -876,14 +876,14 @@ pub fn abspath(p: &Path) -> IoResult<Path> {
 /// use std::path::Path;
 ///
 /// let root = Path::new("/");
-/// assert!(os::change_dir(&root).is_ok());
+/// assert!(os::chdir(&root).is_ok());
 /// println!("Successfully changed working directory to {}!", root.display());
 /// ```
-pub fn change_dir(p: &Path) -> IoResult<()> {
-    return chdir(p);
+pub fn chdir(p: &Path) -> IoResult<()> {
+    return _chdir(p);
 
     #[cfg(windows)]
-    fn chdir(p: &Path) -> IoResult<()> {
+    fn _chdir(p: &Path) -> IoResult<()> {
         let mut p = p.as_str().unwrap().utf16_units().collect::<Vec<u16>>();
         p.push(0);
 
@@ -896,7 +896,7 @@ pub fn change_dir(p: &Path) -> IoResult<()> {
     }
 
     #[cfg(unix)]
-    fn chdir(p: &Path) -> IoResult<()> {
+    fn _chdir(p: &Path) -> IoResult<()> {
         p.with_c_str(|buf| {
             unsafe {
                 match libc::chdir(buf) == (0 as c_int) {

--- a/src/test/run-pass/tempfile.rs
+++ b/src/test/run-pass/tempfile.rs
@@ -12,7 +12,7 @@
 
 // These tests are here to exercise the functionality of the `tempfile` module.
 // One might expect these tests to be located in that module, but sadly they
-// cannot. The tests need to invoke `os::change_dir` which cannot be done in the
+// cannot. The tests need to invoke `os::chdir` which cannot be done in the
 // normal test infrastructure. If the tests change the current working
 // directory, then *all* tests which require relative paths suddenly break b/c
 // they're in a different location than before. Hence, these tests are all run
@@ -190,7 +190,7 @@ pub fn dont_double_panic() {
 
 fn in_tmpdir(f: ||) {
     let tmpdir = TempDir::new("test").ok().expect("can't make tmpdir");
-    assert!(os::change_dir(tmpdir.path()).is_ok());
+    assert!(os::chdir(tmpdir.path()).is_ok());
 
     f();
 }


### PR DESCRIPTION
This pull request feels a bit bikeshedding, but I think it is necessary.
- `os::make_absolute()` -> `os::abspath()`: The name "make_absolute" is too generous to hold a specific meaning. At least it should contain "path". It seems that "abspath" is a common and concise name. (Also used in Python.)
- `os::change_dir()` -> `os::chdir()`: The method names in the os module generally follow the POSIX-like convention, such as setenv, getenv, getcwd, and errno. As `os::change_dir()` internally uses `libc::chdir()` on Unix, it would be a good idea to follow the same convention.
