### PR TITLE
Expose file descriptor

### DIFF
--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -71,6 +71,9 @@ use vec::Vec;
 use sys::fs as fs_imp;
 use sys_common;
 
+pub use sys_common::AsFileDesc;
+pub use sys::fs::{fd_t, FileDesc};
+
 /// Unconstrained file access type that exposes read and write operations
 ///
 /// Can be constructed via `File::open()`, `File::create()`, and

--- a/src/libstd/io/net/pipe.rs
+++ b/src/libstd/io/net/pipe.rs
@@ -29,6 +29,9 @@ use prelude::*;
 use io::{Listener, Acceptor, IoResult, TimedOut, standard_error};
 use time::Duration;
 
+#[cfg(unix)]
+use io::fs::{AsFileDesc, FileDesc};
+
 use sys::pipe::UnixStream as UnixStreamImp;
 use sys::pipe::UnixListener as UnixListenerImp;
 use sys::pipe::UnixAcceptor as UnixAcceptorImp;
@@ -124,6 +127,13 @@ impl UnixStream {
     #[experimental = "the timeout argument may change in type and value"]
     pub fn set_write_timeout(&mut self, timeout_ms: Option<u64>) {
         self.inner.set_write_timeout(timeout_ms)
+    }
+}
+
+#[cfg(unix)]
+impl AsFileDesc for UnixStream {
+    fn as_fd(&self) -> &FileDesc {
+        self.inner.as_fd()
     }
 }
 


### PR DESCRIPTION
For FFI needs, as started by #15643, this allow `File`, `PipeStream` and `UnixStream` to export their internal file descriptor with the `AsFileDesc` trait provided by #18557.
