### PR TITLE
removed usage of struct_variant feature as it is no longer gated

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -29,7 +29,7 @@ This API is completely unstable and subject to change.
       html_root_url = "http://doc.rust-lang.org/nightly/")]
 
 #![feature(default_type_params, globs, if_let, import_shadowing, macro_rules, phase, quote)]
-#![feature(slicing_syntax, struct_variant, tuple_indexing, unsafe_destructor)]
+#![feature(slicing_syntax, tuple_indexing, unsafe_destructor)]
 #![feature(rustc_diagnostic_macros)]
 
 extern crate arena;

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -29,7 +29,7 @@ This API is completely unstable and subject to change.
       html_root_url = "http://doc.rust-lang.org/nightly/")]
 
 #![feature(default_type_params, globs, if_let, import_shadowing, macro_rules, phase, quote)]
-#![feature(slicing_syntax, struct_variant, unsafe_destructor)]
+#![feature(slicing_syntax, unsafe_destructor)]
 #![feature(rustc_diagnostic_macros)]
 
 extern crate arena;

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -16,7 +16,7 @@
 #![crate_type = "rlib"]
 
 #![allow(unknown_features)]
-#![feature(globs, struct_variant, macro_rules, phase, slicing_syntax, tuple_indexing)]
+#![feature(globs, macro_rules, phase, slicing_syntax, tuple_indexing)]
 
 extern crate arena;
 extern crate getopts;

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -25,7 +25,7 @@
 
 #![allow(unknown_features)]
 #![feature(if_let, macro_rules, globs, default_type_params, phase, slicing_syntax)]
-#![feature(quote, struct_variant, unsafe_destructor, import_shadowing)]
+#![feature(quote, unsafe_destructor, import_shadowing)]
 
 extern crate arena;
 extern crate fmt_macros;


### PR DESCRIPTION
The struct_variant is not gated anymore. This commit just removes it and the resulting warnings when compiling rust. Now compiles with the snapshot from 11/18 (as opposed to PR #19014)
