### PR TITLE
test/run-make: some test cases lacked $(EXTRACFLAGS).

### DIFF
--- a/src/test/run-make/bootstrap-from-c-with-native/Makefile
+++ b/src/test/run-make/bootstrap-from-c-with-native/Makefile
@@ -6,7 +6,7 @@ TARGET_RPATH_DIR:=$(TARGET_RPATH_DIR):$(TMPDIR)
 
 all:
 	$(RUSTC) lib.rs
-	$(CC) main.c -o $(call RUN_BINFILE,main) $(call RPATH_LINK_SEARCH,$(HOST_LIB_DIR)) -lboot
+	$(CC) main.c -o $(call RUN_BINFILE,main) $(call RPATH_LINK_SEARCH,$(HOST_LIB_DIR)) -lboot $(EXTRACFLAGS)
 	$(call RUN,main)
 	$(call REMOVE_DYLIBS,boot)
 	$(call FAIL,main)

--- a/src/test/run-make/c-link-to-rust-dylib/Makefile
+++ b/src/test/run-make/c-link-to-rust-dylib/Makefile
@@ -4,7 +4,7 @@ HOST_LIB_DIR=$(TMPDIR)/../../../stage$(RUST_BUILD_STAGE)/lib
 
 all:
 	$(RUSTC) foo.rs
-	$(CC) bar.c -lfoo -o $(call RUN_BINFILE,bar) $(call RPATH_LINK_SEARCH,$(HOST_LIB_DIR)) -Wl,-rpath,$(TMPDIR)
+	$(CC) bar.c -lfoo -o $(call RUN_BINFILE,bar) $(call RPATH_LINK_SEARCH,$(HOST_LIB_DIR)) -Wl,-rpath,$(TMPDIR) $(EXTRACFLAGS)
 	$(call RUN,bar)
 	$(call REMOVE_DYLIBS,foo)
 	$(call FAIL,bar)


### PR DESCRIPTION
Missing `$(EXTRACFLAGS)` resutled in compile failures.
