### PR TITLE
Removed unneeded conversion to a slice.

### DIFF
--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1836,7 +1836,6 @@ pub trait StrPrelude for Sized? {
     /// ```rust
     /// let string = "a\nb\nc";
     /// let lines: Vec<&str> = string.lines().collect();
-    /// let lines = lines.as_slice();
     ///
     /// assert!(string.subslice_offset(lines[0]) == 0); // &"a"
     /// assert!(string.subslice_offset(lines[1]) == 2); // &"b"


### PR DESCRIPTION
Vec<T> can index now so its a useless conversion.
