### PR TITLE
debuginfo: Add script that allows to conveniently start LLDB in "rust-mode"

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -198,6 +198,8 @@ include $(CFG_SRC_DIR)mk/rustllvm.mk
 include $(CFG_SRC_DIR)mk/docs.mk
 # LLVM
 include $(CFG_SRC_DIR)mk/llvm.mk
+# Rules for installing debugger scripts
+include $(CFG_SRC_DIR)mk/debuggers.mk
 
 ######################################################################
 # Secondary makefiles, conditionalized for speed

--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -63,6 +63,7 @@ clean-generic-$(2)-$(1):
          -name '*.lib' -o \
          -name '*.dll' -o \
          -name '*.def' -o \
+         -name '*.py' -o \
          -name '*.bc' \
          \) \
          | xargs rm -f
@@ -78,7 +79,7 @@ define CLEAN_HOST_STAGE_N
 
 clean$(1)_H_$(2): \
 	    $$(foreach crate,$$(CRATES),clean$(1)_H_$(2)-lib-$$(crate)) \
-	    $$(foreach tool,$$(TOOLS),clean$(1)_H_$(2)-tool-$$(tool))
+	    $$(foreach tool,$$(TOOLS) $$(DEBUGGER_BIN_SCRIPTS),clean$(1)_H_$(2)-tool-$$(tool))
 	$$(Q)rm -fr $(2)/rt/libbacktrace
 
 clean$(1)_H_$(2)-tool-%:
@@ -98,7 +99,7 @@ define CLEAN_TARGET_STAGE_N
 
 clean$(1)_T_$(2)_H_$(3): \
 	    $$(foreach crate,$$(CRATES),clean$(1)_T_$(2)_H_$(3)-lib-$$(crate)) \
-	    $$(foreach tool,$$(TOOLS),clean$(1)_T_$(2)_H_$(3)-tool-$$(tool))
+	    $$(foreach tool,$$(TOOLS) $$(DEBUGGER_BIN_SCRIPTS),clean$(1)_T_$(2)_H_$(3)-tool-$$(tool))
 	$$(Q)rm -f $$(TLIB$(1)_T_$(2)_H_$(3))/libmorestack.a
 	$$(Q)rm -f $$(TLIB$(1)_T_$(2)_H_$(3))/libcompiler-rt.a
 	$(Q)rm -f $$(TLIB$(1)_T_$(2)_H_$(3))/librun_pass_stage* # For unix

--- a/mk/debuggers.mk
+++ b/mk/debuggers.mk
@@ -1,0 +1,59 @@
+# Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+######################################################################
+# Copy debugger related scripts
+######################################################################
+
+DEBUGGER_RUSTLIB_ETC_SCRIPTS=lldb_rust_formatters.py
+DEBUGGER_BIN_SCRIPTS=rust-lldb
+
+DEBUGGER_RUSTLIB_ETC_SCRIPTS_ABS=$(foreach script,$(DEBUGGER_RUSTLIB_ETC_SCRIPTS), \
+                                     $(CFG_SRC_DIR)src/etc/$(script))
+DEBUGGER_BIN_SCRIPTS_ABS=$(foreach script,$(DEBUGGER_BIN_SCRIPTS), \
+                             $(CFG_SRC_DIR)src/etc/$(script))
+
+DEBUGGER_SCRIPTS_ALL=$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_ABS) $(DEBUGGER_BIN_SCRIPTS_ABS)
+
+# $(1) - the stage to copy to
+# $(2) - the host triple
+define DEF_INSTALL_DEBUGGER_SCRIPTS_HOST
+
+tmp/install-debugger-scripts$(1)_H_$(2).done: $$(DEBUGGER_SCRIPTS_ALL)
+	$(Q)mkdir -p $$(HBIN$(1)_H_$(2))
+	$(Q)mkdir -p $$(HLIB$(1)_H_$(2))/rustlib/etc
+	$(Q)install $(DEBUGGER_BIN_SCRIPTS_ABS) $$(HBIN$(1)_H_$(2))
+	$(Q)install $(DEBUGGER_RUSTLIB_ETC_SCRIPTS_ABS) $$(HLIB$(1)_H_$(2))/rustlib/etc
+	$(Q)touch $$@
+endef
+
+# Expand host make-targets for all stages
+$(foreach stage,$(STAGES), \
+  $(foreach host,$(CFG_HOST), \
+    $(eval $(call DEF_INSTALL_DEBUGGER_SCRIPTS_HOST,$(stage),$(host)))))
+
+# $(1) is the stage number
+# $(2) is the target triple
+# $(3) is the host triple
+define DEF_INSTALL_DEBUGGER_SCRIPTS_TARGET
+
+tmp/install-debugger-scripts$(1)_T_$(2)_H_$(3).done: $$(DEBUGGER_SCRIPTS_ALL)
+	$(Q)mkdir -p $$(TBIN$(1)_T_$(2)_H_$(3))
+	$(Q)mkdir -p $$(TLIB$(1)_T_$(2)_H_$(3))/rustlib/etc
+	$(Q)install $(DEBUGGER_BIN_SCRIPTS_ABS) $$(TBIN$(1)_T_$(2)_H_$(3))
+	$(Q)install $(DEBUGGER_RUSTLIB_ETC_SCRIPTS_ABS) $$(TLIB$(1)_T_$(2)_H_$(3))/rustlib/etc
+	$(Q)touch $$@
+endef
+
+# Expand target make-targets for all stages
+$(foreach stage,$(STAGES), \
+  $(foreach target,$(CFG_TARGET), \
+    $(foreach host,$(CFG_HOST), \
+      $(eval $(call DEF_INSTALL_DEBUGGER_SCRIPTS_TARGET,$(stage),$(target),$(host))))))

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -356,7 +356,8 @@ HSREQ$(1)_H_$(3) = $$(HBIN$(1)_H_$(3))/rustc$$(X_$(3))
 else
 HSREQ$(1)_H_$(3) = \
 	$$(HBIN$(1)_H_$(3))/rustc$$(X_$(3)) \
-	$$(MKFILE_DEPS)
+	$$(MKFILE_DEPS) \
+	tmp/install-debugger-scripts$(1)_H_$(3).done
 endif
 
 # Prerequisites for using the stageN compiler to build target artifacts
@@ -370,7 +371,8 @@ TSREQ$(1)_T_$(2)_H_$(3) = \
 SREQ$(1)_T_$(2)_H_$(3) = \
 	$$(TSREQ$(1)_T_$(2)_H_$(3)) \
 	$$(foreach dep,$$(TARGET_CRATES), \
-	    $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$$(dep))
+	    $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$$(dep)) \
+	tmp/install-debugger-scripts$(1)_T_$(2)_H_$(3).done
 
 # Prerequisites for a working stageN compiler and complete set of target
 # libraries

--- a/mk/prepare.mk
+++ b/mk/prepare.mk
@@ -155,7 +155,7 @@ prepare-base-$(1): PREPARE_DEST_LIB_DIR=$$(PREPARE_DEST_DIR)/$$(CFG_LIBDIR_RELAT
 prepare-base-$(1): PREPARE_DEST_MAN_DIR=$$(PREPARE_DEST_DIR)/share/man/man1
 prepare-base-$(1): prepare-everything-$(1)
 
-prepare-everything-$(1): prepare-host-$(1) prepare-targets-$(1)
+prepare-everything-$(1): prepare-host-$(1) prepare-targets-$(1) prepare-debugger-scripts-$(1)
 
 prepare-host-$(1): prepare-host-tools-$(1)
 
@@ -167,7 +167,12 @@ prepare-host-tools-$(1): \
 prepare-host-dirs-$(1): prepare-maybe-clean-$(1)
 	$$(call PREPARE_DIR,$$(PREPARE_DEST_BIN_DIR))
 	$$(call PREPARE_DIR,$$(PREPARE_DEST_LIB_DIR))
+	$$(call PREPARE_DIR,$$(PREPARE_DEST_LIB_DIR)/rustlib/etc)
 	$$(call PREPARE_DIR,$$(PREPARE_DEST_MAN_DIR))
+
+prepare-debugger-scripts-$(1): prepare-host-dirs-$(1) $(DEBUGGER_SCRIPTS_ALL)
+	$$(Q)$$(PREPARE_BIN_CMD) $(DEBUGGER_BIN_SCRIPTS_ABS) $$(PREPARE_DEST_BIN_DIR)
+	$$(Q)$$(PREPARE_LIB_CMD) $(DEBUGGER_RUSTLIB_ETC_SCRIPTS_ABS) $$(PREPARE_DEST_LIB_DIR)/rustlib/etc
 
 $$(foreach tool,$$(PREPARE_TOOLS), \
   $$(foreach host,$$(CFG_HOST), \

--- a/src/etc/lldb_rust_formatters.py
+++ b/src/etc/lldb_rust_formatters.py
@@ -69,8 +69,14 @@ def print_struct_val_starting_from(field_start_index, val, internal_dict):
   assert val.GetType().GetTypeClass() == lldb.eTypeClassStruct
 
   t = val.GetType()
-  has_field_names = type_has_field_names(t)
   type_name = extract_type_name(t.GetName())
+  num_children = val.num_children
+
+  if (num_children - field_start_index) == 0:
+    # The only field of this struct is the enum discriminant
+    return type_name
+
+  has_field_names = type_has_field_names(t)
 
   if has_field_names:
       template = "%(type_name)s {\n%(body)s\n}"
@@ -82,8 +88,6 @@ def print_struct_val_starting_from(field_start_index, val, internal_dict):
   if type_name.startswith("("):
     # this is a tuple, so don't print the type name
     type_name = ""
-
-  num_children = val.num_children
 
   def render_child(child_index):
     this = ""
@@ -104,7 +108,6 @@ def print_enum_val(val, internal_dict):
   '''Prints an enum value with Rust syntax'''
 
   assert val.GetType().GetTypeClass() == lldb.eTypeClassUnion
-
 
   if val.num_children == 1:
     # This is either an enum with just one variant, or it is an Option-like enum

--- a/src/etc/rust-lldb
+++ b/src/etc/rust-lldb
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# Exit if anything fails
+set -e
+
+# Create a tempfile containing the LLDB script we want to execute on startup
+TMPFILE=`mktemp /tmp/rust-lldb-commands.XXXXXX`
+
+# Make sure to delete the tempfile no matter what
+trap "rm -f $TMPFILE; exit" INT TERM EXIT
+
+# Find out where to look for the pretty printer Python module
+RUSTC_SYSROOT=`rustc -Zprint-sysroot`
+
+# Write the LLDB script to the tempfile
+echo "command script import \"$RUSTC_SYSROOT/lib/rustlib/etc/lldb_rust_formatters.py\"" >> $TMPFILE
+echo "type summary add --no-value --python-function lldb_rust_formatters.print_val -x \".*\" --category Rust" >> $TMPFILE
+echo "type category enable Rust" >> $TMPFILE
+
+# Call LLDB with the script added to the argument list
+lldb --source-before-file="$TMPFILE" "$@"

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -212,13 +212,14 @@ debugging_opts!(
         FLOWGRAPH_PRINT_LOANS,
         FLOWGRAPH_PRINT_MOVES,
         FLOWGRAPH_PRINT_ASSIGNS,
-        FLOWGRAPH_PRINT_ALL
+        FLOWGRAPH_PRINT_ALL,
+        PRINT_SYSROOT
     ]
     0
 )
 
 pub fn debugging_opts_map() -> Vec<(&'static str, &'static str, u64)> {
-    vec!(("verbose", "in general, enable more debug printouts", VERBOSE),
+    vec![("verbose", "in general, enable more debug printouts", VERBOSE),
      ("time-passes", "measure time of each rustc pass", TIME_PASSES),
      ("count-llvm-insns", "count where LLVM \
                            instrs originate", COUNT_LLVM_INSNS),
@@ -256,7 +257,9 @@ pub fn debugging_opts_map() -> Vec<(&'static str, &'static str, u64)> {
      ("flowgraph-print-assigns", "Include assignment analysis data in \
                        --pretty flowgraph output", FLOWGRAPH_PRINT_ASSIGNS),
      ("flowgraph-print-all", "Include all dataflow analysis data in \
-                       --pretty flowgraph output", FLOWGRAPH_PRINT_ALL))
+                       --pretty flowgraph output", FLOWGRAPH_PRINT_ALL),
+     ("print-sysroot", "Print the sysroot as used by this rustc invocation",
+      PRINT_SYSROOT)]
 }
 
 #[deriving(Clone)]

--- a/src/librustc_trans/driver/mod.rs
+++ b/src/librustc_trans/driver/mod.rs
@@ -75,6 +75,13 @@ fn run_compiler(args: &[String]) {
                 describe_lints(&ls, false);
                 return;
             }
+
+            let sess = build_session(sopts, None, descriptions);
+            if sess.debugging_opt(config::PRINT_SYSROOT) {
+                println!("{}", sess.sysroot().display());
+                return;
+            }
+
             early_error("no input filename given");
         }
         1u => {


### PR DESCRIPTION
This PR adds the `rust-lldb` script (feel free to bikeshed about the name).
The script will start LLDB and, before doing anything else, load [LLDB type summaries](http://lldb.llvm.org/varformats.html) that will make LLDB print values with Rust syntax. Just use the script like you would normally use LLDB:

```
rust-lldb executable-to-debug --and-any-other-commandline --args 
```

The script will just add one additional commandline argument to the LLDB invocation and pass along the rest of the arguments to LLDB after that.

Given the following program...

``` rust
fn main() {
    let x = Some(1u);
    let y = [0, 1, 2i];
    let z = (x, y);

    println!("{} {} {}", x, y, z);
}
```

..._without_ the 'LLDB type summaries', values will be printed something like this...

```
(lldb) p x
(core::option::Option<uint>) $3 = {
   = (RUST$ENUM$DISR = Some)
   = (RUST$ENUM$DISR = Some, 1)
}
(lldb) p y
(long [3]) $4 = ([0] = 0, [1] = 1, [2] = 2)
(lldb) p z
((core::option::Option<uint>, [int, ..3])) $5 = {
   = {
     = (RUST$ENUM$DISR = Some)
     = (RUST$ENUM$DISR = Some, 1)
  }
   = ([0] = 0, [1] = 1, [2] = 2)
}
```

..._with_ the 'LLDB type summaries', values will be printed like this:

```
(lldb) p x
(core::option::Option<uint>) $0 = Some(1)
(lldb) p y
(long [3]) $1 = [0, 1, 2]
(lldb) p z
((core::option::Option<uint>, [int, ..3])) $2 = (Some(1), [0, 1, 2])
```

The 'LLDB type summaries' used by the script have been in use for a while in the LLDB autotests but I still consider them to be of alpha-version quality. If you see anything weird when you use them, feel free to file an issue.

The script will use whatever Rust "installation" is in PATH, so whichever `rustc` will be called if you type `rustc` into the console, this is the one that the script will ask for the LLDB extension module location. The build system will take care of putting the script and LLDB python module in the right places, whether you want to use the stage1 or stage2 compiler or the one coming with `make install` / `rustup.sh`.

Since I don't have much experience with the build system, Makefiles and shell scripts, please look these changes over carefully.
