### PR TITLE
Rename unwrap functions to into_inner

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1248,7 +1248,7 @@ pub struct MoveItems<T> {
 impl<T> MoveItems<T> {
     #[inline]
     /// Drops all items that have not yet been moved and returns the empty vector.
-    pub fn unwrap(mut self) -> Vec<T> {
+    pub fn into_inner(mut self) -> Vec<T> {
         unsafe {
             for _x in self { }
             let MoveItems { allocation, cap, ptr: _ptr, end: _end } = self;
@@ -1256,6 +1256,10 @@ impl<T> MoveItems<T> {
             Vec { ptr: allocation, cap: cap, len: 0 }
         }
     }
+
+    /// Deprecated, use into_inner() instead
+    #[deprecated = "renamed to into_inner()"]
+    pub fn unwrap(self) -> Vec<T> { self.into_inner() }
 }
 
 impl<T> Iterator<T> for MoveItems<T> {

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -256,14 +256,18 @@ impl<T> RefCell<T> {
     }
 
     /// Consumes the `RefCell`, returning the wrapped value.
-    #[unstable = "may be renamed, depending on global conventions"]
-    pub fn unwrap(self) -> T {
+    #[unstable = "recently renamed per RFC 430"]
+    pub fn into_inner(self) -> T {
         // Since this function takes `self` (the `RefCell`) by value, the
         // compiler statically verifies that it is not currently borrowed.
         // Therefore the following assertion is just a `debug_assert!`.
         debug_assert!(self.borrow.get() == UNUSED);
-        unsafe{self.value.unwrap()}
+        unsafe { self.value.into_inner() }
     }
+
+    /// Deprecated, use into_inner() instead
+    #[deprecated = "renamed to into_inner()"]
+    pub fn unwrap(self) -> T { self.into_inner() }
 
     /// Attempts to immutably borrow the wrapped value.
     ///
@@ -518,5 +522,9 @@ impl<T> UnsafeCell<T> {
     #[inline]
     #[unstable = "conventions around the name `unwrap` are still under \
                   development"]
-    pub unsafe fn unwrap(self) -> T { self.value }
+    pub unsafe fn into_inner(self) -> T { self.value }
+
+    /// Deprecated, use into_inner() instead
+    #[deprecated = "renamed to into_inner()"]
+    pub unsafe fn unwrap(self) -> T { self.into_inner() }
 }

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -827,5 +827,5 @@ pub fn check_crate(tcx: &ty::ctxt,
     }
 
     tcx.sess.abort_if_errors();
-    *tcx.node_lint_levels.borrow_mut() = cx.node_levels.unwrap();
+    *tcx.node_lint_levels.borrow_mut() = cx.node_levels.into_inner();
 }

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -2148,7 +2148,7 @@ pub unsafe extern "C" fn rust_llvm_string_write_impl(sr: RustStringRef,
 pub fn build_string(f: |RustStringRef|) -> Option<String> {
     let mut buf = RefCell::new(Vec::new());
     f(&mut buf as RustStringRepr as RustStringRef);
-    String::from_utf8(buf.unwrap()).ok()
+    String::from_utf8(buf.into_inner()).ok()
 }
 
 pub unsafe fn twine_to_string(tr: TwineRef) -> String {

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -899,7 +899,7 @@ fn run_work_multithreaded(sess: &Session,
 
     let mut panicked = false;
     for future in futures.into_iter() {
-        match future.unwrap() {
+        match future.into_inner() {
             Ok(()) => {},
             Err(_) => {
                 panicked = true;

--- a/src/librustrt/c_str.rs
+++ b/src/librustrt/c_str.rs
@@ -254,10 +254,14 @@ impl CString {
     ///
     /// Prefer `.as_ptr()` when just retrieving a pointer to the
     /// string data, as that does not relinquish ownership.
-    pub unsafe fn unwrap(mut self) -> *const libc::c_char {
+    pub unsafe fn into_inner(mut self) -> *const libc::c_char {
         self.owns_buffer_ = false;
         self.buf
     }
+
+    /// Deprecated, use into_inner() instead
+    #[deprecated = "renamed to into_inner()"]
+    pub unsafe fn unwrap(self) -> *const libc::c_char { self.into_inner() }
 
     /// Return the number of bytes in the CString (not including the NUL
     /// terminator).

--- a/src/libstd/c_vec.rs
+++ b/src/libstd/c_vec.rs
@@ -138,10 +138,14 @@ impl<T> CVec<T> {
     /// Note that if you want to access the underlying pointer without
     /// cancelling the destructor, you can simply call `transmute` on the return
     /// value of `get(0)`.
-    pub unsafe fn unwrap(mut self) -> *mut T {
+    pub unsafe fn into_inner(mut self) -> *mut T {
         self.dtor = None;
         self.base
     }
+
+    /// Deprecated, use into_inner() instead
+    #[deprecated = "renamed to into_inner()"]
+    pub unsafe fn unwrap(self) -> *mut T { self.into_inner() }
 
     /// Returns the number of items in this vector.
     pub fn len(&self) -> uint { self.len }

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -83,7 +83,11 @@ impl<R: Reader> BufferedReader<R> {
     /// Unwraps this `BufferedReader`, returning the underlying reader.
     ///
     /// Note that any leftover data in the internal buffer is lost.
-    pub fn unwrap(self) -> R { self.inner }
+    pub fn into_inner(self) -> R { self.inner }
+
+    /// Deprecated, use into_inner() instead
+    #[deprecated = "renamed to into_inner()"]
+    pub fn unwrap(self) -> R { self.into_inner() }
 }
 
 impl<R: Reader> Buffer for BufferedReader<R> {
@@ -180,11 +184,15 @@ impl<W: Writer> BufferedWriter<W> {
     /// Unwraps this `BufferedWriter`, returning the underlying writer.
     ///
     /// The buffer is flushed before returning the writer.
-    pub fn unwrap(mut self) -> W {
+    pub fn into_inner(mut self) -> W {
         // FIXME(#12628): is panicking the right thing to do if flushing panicks?
         self.flush_buf().unwrap();
         self.inner.take().unwrap()
     }
+
+    /// Deprecated, use into_inner() instead
+    #[deprecated = "renamed to into_inner()"]
+    pub fn unwrap(self) -> W { self.into_inner() }
 }
 
 impl<W: Writer> Writer for BufferedWriter<W> {
@@ -244,7 +252,11 @@ impl<W: Writer> LineBufferedWriter<W> {
     /// Unwraps this `LineBufferedWriter`, returning the underlying writer.
     ///
     /// The internal buffer is flushed before returning the writer.
-    pub fn unwrap(self) -> W { self.inner.unwrap() }
+    pub fn into_inner(self) -> W { self.inner.into_inner() }
+
+    /// Deprecated, use into_inner() instead
+    #[deprecated = "renamed to into_inner()"]
+    pub fn unwrap(self) -> W { self.into_inner() }
 }
 
 impl<W: Writer> Writer for LineBufferedWriter<W> {
@@ -341,10 +353,14 @@ impl<S: Stream> BufferedStream<S> {
     ///
     /// The internal buffer is flushed before returning the stream. Any leftover
     /// data in the read buffer is lost.
-    pub fn unwrap(self) -> S {
+    pub fn into_inner(self) -> S {
         let InternalBufferedWriter(w) = self.inner.inner;
-        w.unwrap()
+        w.into_inner()
     }
+
+    /// Deprecated, use into_inner() instead
+    #[deprecated = "renamed to into_inner()"]
+    pub fn unwrap(self) -> S { self.into_inner() }
 }
 
 impl<S: Stream> Buffer for BufferedStream<S> {

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -62,7 +62,7 @@ impl Writer for Vec<u8> {
 /// let mut w = MemWriter::new();
 /// w.write(&[0, 1, 2]);
 ///
-/// assert_eq!(w.unwrap(), vec!(0, 1, 2));
+/// assert_eq!(w.into_inner(), vec!(0, 1, 2));
 /// ```
 #[deprecated = "use the Vec<u8> Writer implementation directly"]
 #[deriving(Clone)]
@@ -95,7 +95,11 @@ impl MemWriter {
 
     /// Unwraps this `MemWriter`, returning the underlying buffer
     #[inline]
-    pub fn unwrap(self) -> Vec<u8> { self.buf }
+    pub fn into_inner(self) -> Vec<u8> { self.buf }
+
+    /// Deprecated, use into_inner() instead
+    #[deprecated = "renamed to into_inner()"]
+    pub fn unwrap(self) -> Vec<u8> { self.into_inner() }
 }
 
 impl Writer for MemWriter {
@@ -150,7 +154,11 @@ impl MemReader {
 
     /// Unwraps this `MemReader`, returning the underlying buffer
     #[inline]
-    pub fn unwrap(self) -> Vec<u8> { self.buf }
+    pub fn into_inner(self) -> Vec<u8> { self.buf }
+
+    /// Deprecated, use into_inner() instead
+    #[deprecated = "renamed to into_inner()"]
+    pub fn unwrap(self) -> Vec<u8> { self.into_inner() }
 }
 
 impl Reader for MemReader {

--- a/src/libstd/io/tempfile.rs
+++ b/src/libstd/io/tempfile.rs
@@ -73,10 +73,14 @@ impl TempDir {
     /// Unwrap the wrapped `std::path::Path` from the `TempDir` wrapper.
     /// This discards the wrapper so that the automatic deletion of the
     /// temporary directory is prevented.
-    pub fn unwrap(self) -> Path {
+    pub fn into_inner(self) -> Path {
         let mut tmpdir = self;
         tmpdir.path.take().unwrap()
     }
+
+    /// Deprecated, use into_inner() instead
+    #[deprecated = "renamed to into_inner()"]
+    pub fn unwrap(self) -> Path { self.into_inner() }
 
     /// Access the wrapped `std::path::Path` to the temporary directory.
     pub fn path<'a>(&'a self) -> &'a Path {

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -28,7 +28,11 @@ impl<R: Reader> LimitReader<R> {
     }
 
     /// Consumes the `LimitReader`, returning the underlying `Reader`.
-    pub fn unwrap(self) -> R { self.inner }
+    pub fn into_inner(self) -> R { self.inner }
+
+    /// Deprecated, use into_inner() instead
+    #[deprecated = "renamed to into_inner"]
+    pub fn unwrap(self) -> R { self.into_inner() }
 
     /// Returns the number of bytes that can be read before the `LimitReader`
     /// will return EOF.
@@ -207,10 +211,14 @@ impl<R: Reader, W: Writer> TeeReader<R, W> {
 
     /// Consumes the `TeeReader`, returning the underlying `Reader` and
     /// `Writer`.
-    pub fn unwrap(self) -> (R, W) {
+    pub fn into_inner(self) -> (R, W) {
         let TeeReader { reader, writer } = self;
         (reader, writer)
     }
+
+    /// Deprecated, use into_inner() instead
+    #[deprecated = "renamed to into_inner"]
+    pub fn unwrap(self) -> (R, W) { self.into_inner() }
 }
 
 impl<R: Reader, W: Writer> Reader for TeeReader<R, W> {

--- a/src/libstd/sync/future.rs
+++ b/src/libstd/sync/future.rs
@@ -54,7 +54,7 @@ impl<A:Clone> Future<A> {
 
 impl<A> Future<A> {
     /// Gets the value from this future, forcing evaluation.
-    pub fn unwrap(mut self) -> A {
+    pub fn into_inner(mut self) -> A {
         self.get_ref();
         let state = replace(&mut self.state, Evaluating);
         match state {
@@ -62,6 +62,10 @@ impl<A> Future<A> {
             _ => panic!( "Logic error." ),
         }
     }
+
+    /// Deprecated, use into_inner() instead
+    #[deprecated = "renamed to into_inner()"]
+    pub fn unwrap(self) -> A { self.into_inner() }
 
     pub fn get_ref<'a>(&'a mut self) -> &'a A {
         /*!

--- a/src/libstd/task.rs
+++ b/src/libstd/task.rs
@@ -197,7 +197,7 @@ impl TaskBuilder {
     /// completes or panics. Equivalent to `.try_future(f).unwrap()`.
     #[unstable = "Error type may change."]
     pub fn try<T:Send>(self, f: proc():Send -> T) -> Result<T, Box<Any + Send>> {
-        self.try_future(f).unwrap()
+        self.try_future(f).into_inner()
     }
 }
 

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1059,7 +1059,7 @@ pub fn run_test(opts: &TestOpts,
             let result_future = task.try_future(testfn);
 
             let stdout = reader.read_to_end().unwrap().into_iter().collect();
-            let task_result = result_future.unwrap();
+            let task_result = result_future.into_inner();
             let test_result = calc_result(&desc, task_result.is_ok());
             monitor_ch.send((desc.clone(), test_result, stdout));
         })


### PR DESCRIPTION
This change applies the conventions to unwrap listed in [RFC 430](https://github.com/rust-lang/rfcs/pull/430) to rename
non-failing `unwrap` methods to `into_inner`. This is a breaking change, but all
`unwrap` methods are retained as `#[deprecated]` for the near future. To update
code rename `unwrap` method calls to `into_inner`.

[breaking-change]

cc #19091
