### PR TITLE
rustc_trans: Link archives with `--whole-archive`

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -115,6 +115,8 @@ pub fn oom() -> ! {
 //                reference to this symbol will cause this library's object file
 //                to get linked in to libstd successfully (the linker won't
 //                optimize it out).
+// NOTE: remove after snapshot
+#[cfg(stage0)]
 #[doc(hidden)]
 pub fn fixme_14344_be_sure_to_link_to_collections() {}
 

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -106,6 +106,8 @@ pub mod btree_set {
 #[cfg(test)] mod bench;
 
 // FIXME(#14344) this shouldn't be necessary
+// NOTE: remove after snapshot
+#[cfg(stage0)]
 #[doc(hidden)]
 pub fn fixme_14344_be_sure_to_link_to_collections() {}
 

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -4989,7 +4989,7 @@ pub mod funcs {
     }
 }
 
+// NOTE: remove after snapshot
+#[cfg(stage0)]
 #[doc(hidden)]
 pub fn issue_14344_workaround() {} // FIXME #14344 force linkage to happen correctly
-
-#[test] fn work_on_windows() { } // FIXME #10872 needed for a happy windows

--- a/src/librustrt/lib.rs
+++ b/src/librustrt/lib.rs
@@ -77,10 +77,18 @@ pub fn init(argc: int, argv: *const *const u8) {
         thread::init();
     }
 
-    // FIXME(#14344) this shouldn't be necessary
-    collections::fixme_14344_be_sure_to_link_to_collections();
-    alloc::fixme_14344_be_sure_to_link_to_collections();
-    libc::issue_14344_workaround();
+    fixme_14344();
+
+    // NOTE: remove after snapshot
+    #[cfg(stage0)]
+    fn fixme_14344() {
+        // FIXME(#14344) this shouldn't be necessary
+        collections::fixme_14344_be_sure_to_link_to_collections();
+        alloc::fixme_14344_be_sure_to_link_to_collections();
+        libc::issue_14344_workaround();
+    }
+    #[cfg(not(stage0))]
+    fn fixme_14344() {}
 }
 
 /// Enqueues a procedure to run when the runtime is cleaned up


### PR DESCRIPTION
If archives are passed to linker, linker does not add all object files
but instead scans each object in archive then adds it only if it
defines some symbols which has been undefined.
It is problematic when rlib needs to be contained in dylib, since
some portion of rlib is stripped out if unused by dylib itself.

This patch uses `--whole-archive` flag which changes linker behavior
that the linker just adds all objects in archive.
Unfortunately, ld does not accept rlib as-is because it contains
non-object files, so they are manually removed before passed to ld.

Also, this change can be problematic if several archives actually
contain same symbol. For example, this patch breaks code like:

``` Rust
    #![crate_type = "rlib"]

    // `libcfoo.a` contains `foo`.
    #![link(name = "cfoo", kind = "static")]
    extern {}

    // `foo` is also defined here!
    #[no_mangle]
    pub fn foo() {}

    // so this rlib archive has two `foo` symbols.
```

Previously it worked because linker stripped out `cfoo`.

Fixes #14344
