### PR TITLE
Fix std::fmt::Binary format char in docs

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -179,7 +179,7 @@ pub trait Octal for Sized? {
     fn fmt(&self, &mut Formatter) -> Result;
 }
 
-/// Format trait for the `t` character
+/// Format trait for the `b` character
 #[unstable = "I/O and core have yet to be reconciled"]
 pub trait Binary for Sized? {
     /// Formats the value using the given formatter.


### PR DESCRIPTION
This small piece of documentation was missed in the format character change
in 4af3494bb02e80badc978faa65e59625ade0c675.
