### PR TITLE
Align error messages for easier comparing

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4177,7 +4177,9 @@ pub fn type_err_to_str<'tcx>(cx: &ctxt<'tcx>, err: &type_err<'tcx>) -> String {
             if expected_str == found_str {
                 format!("expected {}, found a different {}", expected_str, found_str)
             } else {
-                format!("expected {}, found {}", expected_str, found_str)
+                format!("expected `{}`,\n    found `{}`", expected_str, found_str)
+            // `expected` will be preceded by either a space or a `(` so the following
+            // line needs 4 spaces to align both `{}` sets: issue 18946
             }
         }
         terr_traits(values) => {

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -372,7 +372,8 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
 
         self.tcx.sess.span_err(
             trace.origin.span(),
-            format!("{}: {} ({})",
+            format!("{}:\n {}\n({})",
+            //            ^ Space to align both sets of `{}`: issue 18946
                  message_root_str,
                  expected_found_str,
                  ty::type_err_to_str(self.tcx, terr)).as_slice());
@@ -417,7 +418,9 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
             return None;
         }
 
-        Some(format!("expected `{}`, found `{}`",
+        Some(format!("expected `{}`,\n    found `{}`",
+        // `expected` will be preceded by either a space or a `(` so the
+        // following line needs 4 spaces to align both `{}` sets: issue 18946
                      expected.user_string(self.tcx),
                      found.user_string(self.tcx)))
     }


### PR DESCRIPTION
Closes #18946

This fix is very simple. Aligns, fixes the second set of backticks, and doesn't do color changes as suggested in #18946. Aligning is definitely nice...maybe the `expected/found` lines should be tabbed out. I'm unsure.

---

Given this:

``` rust
fn test() -> Option<int> {
    Ok(7) // Should be Some(7)
}
fn main(){ 
    test();
}
```

Previously returned:

```
<anon>:2:5: 2:10 error: mismatched types: expected `core::option::Option<int>`, found `core::result::Result<_, _>` (expected enum core::option::Option, found enum core::result::Result)
<anon>:2     Ok(7)
             ^~~~~
error: aborting due to previous error
playpen: application terminated with error code 101
```

Now returns:

```
$ ./rustc test.rs
test.rs:2:5: 2:10 error: mismatched types:
 expected `core::option::Option<int>`,
    found `core::result::Result<_, _>`
(expected `enum core::option::Option`,
    found `enum core::result::Result`)
test.rs:2     Ok(7) // Should be Some(7)
              ^~~~~
error: aborting due to previous error
```
