### PR TITLE
args() doc: Fix a documentation line.

### DIFF
--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1110,7 +1110,7 @@ extern "system" {
 ///
 /// The first element is traditionally the path to the executable, but it can be
 /// set to arbitrary text, and it may not even exist, so this property should not
-//  be relied upon for security purposes.
+/// be relied upon for security purposes.
 ///
 /// The arguments are interpreted as utf-8, with invalid bytes replaced with \uFFFD.
 /// See `String::from_utf8_lossy` for details.


### PR DESCRIPTION
Catch a missed triple-slash in the docs for `std::os::args()`. Passes `make check`. (I've also eyeballed the rest of `libstd` with the aid of some funky regexes and haven't found anything similar.)
