### PR TITLE
Add `map` function to `Ref` and `MutRef` of `RefCell`

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -417,7 +417,7 @@ impl<'a, 'tcx> Context<'a, 'tcx> {
            krate: &'a ast::Crate,
            exported_items: &'a ExportedItems) -> Context<'a, 'tcx> {
         // We want to own the lint store, so move it out of the session.
-        let lint_store = mem::replace(&mut *tcx.sess.lint_store.borrow_mut(),
+        let lint_store = mem::replace(&mut **tcx.sess.lint_store.borrow_mut(),
                                       LintStore::new());
 
         Context {
@@ -827,5 +827,5 @@ pub fn check_crate(tcx: &ty::ctxt,
     }
 
     tcx.sess.abort_if_errors();
-    *tcx.node_lint_levels.borrow_mut() = cx.node_levels.unwrap();
+    **tcx.node_lint_levels.borrow_mut() = cx.node_levels.unwrap();
 }

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -128,14 +128,14 @@ impl CStore {
 
     pub fn add_used_crate_source(&self, src: CrateSource) {
         let mut used_crate_sources = self.used_crate_sources.borrow_mut();
-        if !used_crate_sources.contains(&src) {
-            used_crate_sources.push(src);
+        if !(*used_crate_sources).contains(&src) {
+            (*used_crate_sources).push(src);
         }
     }
 
     pub fn get_used_crate_source(&self, cnum: ast::CrateNum)
                                      -> Option<CrateSource> {
-        self.used_crate_sources.borrow_mut()
+        (*self.used_crate_sources.borrow_mut())
             .iter().find(|source| source.cnum == cnum)
             .map(|source| source.clone())
     }
@@ -174,7 +174,7 @@ impl CStore {
         }
         ordering.as_mut_slice().reverse();
         let ordering = ordering.as_slice();
-        let mut libs = self.used_crate_sources.borrow()
+        let mut libs = (*self.used_crate_sources.borrow())
             .iter()
             .map(|src| (src.cnum, match prefer {
                 RequireDynamic => src.dylib.clone(),

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -961,9 +961,7 @@ fn encode_repr_attrs(rbml_w: &mut Encoder,
 fn encode_inlined_item(ecx: &EncodeContext,
                        rbml_w: &mut Encoder,
                        ii: InlinedItemRef) {
-    let mut eii = ecx.encode_inlined_item.borrow_mut();
-    let eii: &mut EncodeInlinedItem = &mut *eii;
-    (*eii)(ecx, rbml_w, ii)
+    (*&mut **ecx.encode_inlined_item.borrow_mut())(ecx, rbml_w, ii)
 }
 
 const FN_FAMILY: char = 'f';
@@ -1001,7 +999,7 @@ fn encode_extension_implementations(ecx: &EncodeContext,
     match ecx.tcx.trait_impls.borrow().get(&trait_def_id) {
         None => {}
         Some(implementations) => {
-            for &impl_def_id in implementations.borrow().iter() {
+            for &impl_def_id in (*implementations.borrow()).iter() {
                 rbml_w.start_tag(tag_items_data_item_extension_impl);
                 encode_def_id(rbml_w, impl_def_id);
                 rbml_w.end_tag();
@@ -1759,8 +1757,8 @@ fn encode_lang_items(ecx: &EncodeContext, rbml_w: &mut Encoder) {
 fn encode_native_libraries(ecx: &EncodeContext, rbml_w: &mut Encoder) {
     rbml_w.start_tag(tag_native_libraries);
 
-    for &(ref lib, kind) in ecx.tcx.sess.cstore.get_used_libraries()
-                               .borrow().iter() {
+    for &(ref lib, kind) in (*ecx.tcx.sess.cstore.get_used_libraries()
+                               .borrow()).iter() {
         match kind {
             cstore::NativeStatic => {} // these libraries are not propagated
             cstore::NativeFramework | cstore::NativeUnknown => {

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -43,7 +43,7 @@ impl<'a> FileSearch<'a> {
 
         debug!("filesearch: searching additional lib search paths [{}]",
                self.addl_lib_search_paths.borrow().len());
-        for path in self.addl_lib_search_paths.borrow().iter() {
+        for path in (*self.addl_lib_search_paths.borrow()).iter() {
             match f(path) {
                 FileMatches => found = true,
                 FileDoesntMatch => ()

--- a/src/librustc/middle/borrowck/gather_loans/move_error.rs
+++ b/src/librustc/middle/borrowck/gather_loans/move_error.rs
@@ -34,7 +34,7 @@ impl<'tcx> MoveErrorCollector<'tcx> {
     }
 
     pub fn report_potential_errors<'a>(&self, bccx: &BorrowckCtxt<'a, 'tcx>) {
-        report_move_errors(bccx, self.errors.borrow().deref())
+        report_move_errors(bccx, &**self.errors.borrow())
     }
 }
 

--- a/src/librustc/middle/borrowck/move_data.rs
+++ b/src/librustc/middle/borrowck/move_data.rs
@@ -417,22 +417,22 @@ impl MoveData {
          * killed by scoping. See `doc.rs` for more details.
          */
 
-        for (i, the_move) in self.moves.borrow().iter().enumerate() {
+        for (i, the_move) in (*self.moves.borrow()).iter().enumerate() {
             dfcx_moves.add_gen(the_move.id, i);
         }
 
-        for (i, assignment) in self.var_assignments.borrow().iter().enumerate() {
+        for (i, assignment) in (*self.var_assignments.borrow()).iter().enumerate() {
             dfcx_assign.add_gen(assignment.id, i);
             self.kill_moves(assignment.path, assignment.id, dfcx_moves);
         }
 
-        for assignment in self.path_assignments.borrow().iter() {
+        for assignment in (*self.path_assignments.borrow()).iter() {
             self.kill_moves(assignment.path, assignment.id, dfcx_moves);
         }
 
         // Kill all moves related to a variable `x` when it goes out
         // of scope:
-        for path in self.paths.borrow().iter() {
+        for path in (*self.paths.borrow()).iter() {
             match *path.loan_path {
                 LpVar(id) => {
                     let kill_id = tcx.region_maps.var_scope(id);
@@ -450,7 +450,7 @@ impl MoveData {
 
         // Kill all assignments when the variable goes out of scope:
         for (assignment_index, assignment) in
-                self.var_assignments.borrow().iter().enumerate() {
+                (*self.var_assignments.borrow()).iter().enumerate() {
             match *self.path_loan_path(assignment.path) {
                 LpVar(id) => {
                     let kill_id = tcx.region_maps.var_scope(id);

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -411,7 +411,7 @@ fn create_and_seed_worklist(tcx: &ty::ctxt,
     }
 
     // Seed entry point
-    match *tcx.sess.entry_fn.borrow() {
+    match **tcx.sess.entry_fn.borrow() {
         Some((id, _)) => worklist.push(id),
         None => ()
     }

--- a/src/librustc/middle/dependency_format.rs
+++ b/src/librustc/middle/dependency_format.rs
@@ -85,7 +85,7 @@ pub type Dependencies = FnvHashMap<config::CrateType, DependencyList>;
 
 pub fn calculate(tcx: &ty::ctxt) {
     let mut fmts = tcx.dependency_formats.borrow_mut();
-    for &ty in tcx.sess.crate_types.borrow().iter() {
+    for &ty in (*tcx.sess.crate_types.borrow()).iter() {
         fmts.insert(ty, calculate_type(&tcx.sess, ty));
     }
     tcx.sess.abort_if_errors();

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -47,7 +47,7 @@ impl<'a, 'ast, 'v> Visitor<'v> for EntryContext<'a, 'ast> {
 }
 
 pub fn find_entry_point(session: &Session, ast_map: &ast_map::Map) {
-    let any_exe = session.crate_types.borrow().iter().any(|ty| {
+    let any_exe = (*session.crate_types.borrow()).iter().any(|ty| {
         *ty == config::CrateTypeExecutable
     });
     if !any_exe {
@@ -122,13 +122,13 @@ fn find_item(item: &Item, ctxt: &mut EntryContext) {
 
 fn configure_main(this: &mut EntryContext) {
     if this.start_fn.is_some() {
-        *this.session.entry_fn.borrow_mut() = this.start_fn;
+        **this.session.entry_fn.borrow_mut() = this.start_fn;
         this.session.entry_type.set(Some(config::EntryStart));
     } else if this.attr_main_fn.is_some() {
-        *this.session.entry_fn.borrow_mut() = this.attr_main_fn;
+        **this.session.entry_fn.borrow_mut() = this.attr_main_fn;
         this.session.entry_type.set(Some(config::EntryMain));
     } else if this.main_fn.is_some() {
-        *this.session.entry_fn.borrow_mut() = this.main_fn;
+        **this.session.entry_fn.borrow_mut() = this.main_fn;
         this.session.entry_type.set(Some(config::EntryMain));
     } else {
         // No main function

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -165,7 +165,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for ReachableContext<'a, 'tcx> {
 impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
     // Creates a new reachability computation context.
     fn new(tcx: &'a ty::ctxt<'tcx>) -> ReachableContext<'a, 'tcx> {
-        let any_library = tcx.sess.crate_types.borrow().iter().any(|ty| {
+        let any_library = (*tcx.sess.crate_types.borrow()).iter().any(|ty| {
             *ty != config::CrateTypeExecutable
         });
         ReachableContext {
@@ -359,7 +359,7 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
     // this properly would result in the necessity of computing *type*
     // reachability, which might result in a compile time loss.
     fn mark_destructors_reachable(&mut self) {
-        for (_, destructor_def_id) in self.tcx.destructor_for_type.borrow().iter() {
+        for (_, destructor_def_id) in (*self.tcx.destructor_for_type.borrow()).iter() {
             if destructor_def_id.krate == ast::LOCAL_CRATE {
                 self.reachable_symbols.insert(destructor_def_id.node);
             }

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -256,7 +256,7 @@ impl RegionMaps {
          * (that is, the user can give two different names to the same lifetime).
          */
 
-        can_reach(&*self.free_region_map.borrow(), sub, sup)
+        can_reach(&**self.free_region_map.borrow(), sub, sup)
     }
 
     pub fn is_subregion_of(&self,

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -662,7 +662,7 @@ impl NameBindings {
         let type_def = self.type_def.borrow().clone();
         match type_def {
             None => {
-                *self.type_def.borrow_mut() = Some(TypeNsDef {
+                **self.type_def.borrow_mut() = Some(TypeNsDef {
                     modifiers: modifiers,
                     module_def: Some(module_),
                     type_def: None,
@@ -670,7 +670,7 @@ impl NameBindings {
                 });
             }
             Some(type_def) => {
-                *self.type_def.borrow_mut() = Some(TypeNsDef {
+                **self.type_def.borrow_mut() = Some(TypeNsDef {
                     modifiers: modifiers,
                     module_def: Some(module_),
                     type_span: Some(sp),
@@ -694,7 +694,7 @@ impl NameBindings {
             None => {
                 let module = Module::new(parent_link, def_id, kind,
                                          external, is_public);
-                *self.type_def.borrow_mut() = Some(TypeNsDef {
+                **self.type_def.borrow_mut() = Some(TypeNsDef {
                     modifiers: modifiers,
                     module_def: Some(Rc::new(module)),
                     type_def: None,
@@ -709,7 +709,7 @@ impl NameBindings {
                                                  kind,
                                                  external,
                                                  is_public);
-                        *self.type_def.borrow_mut() = Some(TypeNsDef {
+                        **self.type_def.borrow_mut() = Some(TypeNsDef {
                             modifiers: modifiers,
                             module_def: Some(Rc::new(module)),
                             type_def: type_def.type_def,
@@ -729,7 +729,7 @@ impl NameBindings {
         let type_def = self.type_def.borrow().clone();
         match type_def {
             None => {
-                *self.type_def.borrow_mut() = Some(TypeNsDef {
+                **self.type_def.borrow_mut() = Some(TypeNsDef {
                     module_def: None,
                     type_def: Some(def),
                     type_span: Some(sp),
@@ -737,7 +737,7 @@ impl NameBindings {
                 });
             }
             Some(type_def) => {
-                *self.type_def.borrow_mut() = Some(TypeNsDef {
+                **self.type_def.borrow_mut() = Some(TypeNsDef {
                     type_def: Some(def),
                     type_span: Some(sp),
                     module_def: type_def.module_def,
@@ -750,7 +750,7 @@ impl NameBindings {
     /// Records a value definition.
     fn define_value(&self, def: Def, sp: Span, modifiers: DefModifiers) {
         debug!("defining value for def {} with modifiers {}", def, modifiers);
-        *self.value_def.borrow_mut() = Some(ValueNsDef {
+        **self.value_def.borrow_mut() = Some(ValueNsDef {
             def: def,
             value_span: Some(sp),
             modifiers: modifiers,
@@ -759,7 +759,7 @@ impl NameBindings {
 
     /// Returns the module node if applicable.
     fn get_module_if_available(&self) -> Option<Rc<Module>> {
-        match *self.type_def.borrow() {
+        match **self.type_def.borrow() {
             Some(ref type_def) => type_def.module_def.clone(),
             None => None
         }
@@ -792,10 +792,10 @@ impl NameBindings {
 
     fn defined_in_namespace_with(&self, namespace: Namespace, modifiers: DefModifiers) -> bool {
         match namespace {
-            TypeNS => match *self.type_def.borrow() {
+            TypeNS => match **self.type_def.borrow() {
                 Some(ref def) => def.modifiers.contains(modifiers), None => false
             },
-            ValueNS => match *self.value_def.borrow() {
+            ValueNS => match **self.value_def.borrow() {
                 Some(ref def) => def.modifiers.contains(modifiers), None => false
             }
         }
@@ -804,7 +804,7 @@ impl NameBindings {
     fn def_for_namespace(&self, namespace: Namespace) -> Option<Def> {
         match namespace {
             TypeNS => {
-                match *self.type_def.borrow() {
+                match **self.type_def.borrow() {
                     None => None,
                     Some(ref type_def) => {
                         match type_def.type_def {
@@ -825,7 +825,7 @@ impl NameBindings {
                 }
             }
             ValueNS => {
-                match *self.value_def.borrow() {
+                match **self.value_def.borrow() {
                     None => None,
                     Some(value_def) => Some(value_def.def)
                 }
@@ -837,13 +837,13 @@ impl NameBindings {
         if self.defined_in_namespace(namespace) {
             match namespace {
                 TypeNS  => {
-                    match *self.type_def.borrow() {
+                    match **self.type_def.borrow() {
                         None => None,
                         Some(ref type_def) => type_def.type_span
                     }
                 }
                 ValueNS => {
-                    match *self.value_def.borrow() {
+                    match **self.value_def.borrow() {
                         None => None,
                         Some(ref value_def) => value_def.value_span
                     }
@@ -1925,7 +1925,7 @@ impl<'a> Resolver<'a> {
             debug!("(building reduced graph for external \
                     crate) building value (fn/static) {}", final_ident);
             // impl methods have already been defined with the correct importability modifier
-            let mut modifiers = match *child_name_bindings.value_def.borrow() {
+            let mut modifiers = match **child_name_bindings.value_def.borrow() {
                 Some(ref def) => (modifiers & !IMPORTABLE) | (def.modifiers & IMPORTABLE),
                 None => modifiers
             };
@@ -2213,7 +2213,7 @@ impl<'a> Resolver<'a> {
             SingleImport(target, _) => {
                 debug!("(building import directive) building import \
                         directive: {}::{}",
-                       self.names_to_string(module_.imports.borrow().last().unwrap()
+                       self.names_to_string((*module_.imports.borrow()).last().unwrap()
                                                  .module_path.as_slice()),
                        token::get_name(target));
 
@@ -2292,7 +2292,7 @@ impl<'a> Resolver<'a> {
         self.current_module = orig_module;
 
         self.populate_module_if_necessary(&module_);
-        for (_, child_node) in module_.children.borrow().iter() {
+        for (_, child_node) in (*module_.children.borrow()).iter() {
             match child_node.get_module_if_available() {
                 None => {
                     // Nothing to do.
@@ -2303,7 +2303,7 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        for (_, child_module) in module_.anonymous_children.borrow().iter() {
+        for (_, child_module) in (*module_.anonymous_children.borrow()).iter() {
             self.resolve_imports_for_module_subtree(child_module.clone());
         }
     }
@@ -2880,8 +2880,8 @@ impl<'a> Resolver<'a> {
         // Add all children from the containing module.
         self.populate_module_if_necessary(&containing_module);
 
-        for (&name, name_bindings) in containing_module.children
-                                                       .borrow().iter() {
+        for (&name, name_bindings) in (*containing_module.children
+                                                       .borrow()).iter() {
             self.merge_import_resolution(module_,
                                          containing_module.clone(),
                                          import_directive,
@@ -2891,8 +2891,8 @@ impl<'a> Resolver<'a> {
         }
 
         // Add external module children from the containing module.
-        for (&name, module) in containing_module.external_module_children
-                                                .borrow().iter() {
+        for (&name, module) in (*containing_module.external_module_children
+                                                .borrow()).iter() {
             let name_bindings =
                 Rc::new(Resolver::create_name_bindings_from_module(module.clone()));
             self.merge_import_resolution(module_,
@@ -3041,7 +3041,7 @@ impl<'a> Resolver<'a> {
 
         match import_resolution.value_target {
             Some(ref target) if !target.shadowable => {
-                match *name_bindings.value_def.borrow() {
+                match **name_bindings.value_def.borrow() {
                     Some(ref value) => {
                         let msg = format!("import `{}` conflicts with value \
                                            in this module",
@@ -3064,7 +3064,7 @@ impl<'a> Resolver<'a> {
 
         match import_resolution.type_target {
             Some(ref target) if !target.shadowable => {
-                match *name_bindings.type_def.borrow() {
+                match **name_bindings.type_def.borrow() {
                     Some(ref ty) => {
                         match ty.module_def {
                             None => {
@@ -3245,7 +3245,7 @@ impl<'a> Resolver<'a> {
                 Success((target, used_proxy)) => {
                     // Check to see whether there are type bindings, and, if
                     // so, whether there is a module within.
-                    match *target.bindings.type_def.borrow() {
+                    match **target.bindings.type_def.borrow() {
                         Some(ref type_def) => {
                             match type_def.module_def {
                                 None => {
@@ -3548,7 +3548,7 @@ impl<'a> Resolver<'a> {
         match resolve_result {
             Success((target, _)) => {
                 let bindings = &*target.bindings;
-                match *bindings.type_def.borrow() {
+                match **bindings.type_def.borrow() {
                     Some(ref type_def) => {
                         match type_def.module_def {
                             None => {
@@ -3786,7 +3786,7 @@ impl<'a> Resolver<'a> {
         // Descend into children and anonymous children.
         self.populate_module_if_necessary(&module_);
 
-        for (_, child_node) in module_.children.borrow().iter() {
+        for (_, child_node) in (*module_.children.borrow()).iter() {
             match child_node.get_module_if_available() {
                 None => {
                     // Continue.
@@ -3797,7 +3797,7 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        for (_, module_) in module_.anonymous_children.borrow().iter() {
+        for (_, module_) in (*module_.anonymous_children.borrow()).iter() {
             self.report_unresolved_imports(module_.clone());
         }
     }
@@ -3846,7 +3846,7 @@ impl<'a> Resolver<'a> {
         self.record_exports_for_module(&*module_);
         self.populate_module_if_necessary(&module_);
 
-        for (_, child_name_bindings) in module_.children.borrow().iter() {
+        for (_, child_name_bindings) in (*module_.children.borrow()).iter() {
             match child_name_bindings.get_module_if_available() {
                 None => {
                     // Nothing to do.
@@ -3857,7 +3857,7 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        for (_, child_module) in module_.anonymous_children.borrow().iter() {
+        for (_, child_module) in (*module_.anonymous_children.borrow()).iter() {
             self.record_exports_for_module_subtree(child_module.clone());
         }
     }
@@ -3900,7 +3900,7 @@ impl<'a> Resolver<'a> {
     fn add_exports_for_module(&mut self,
                               exports2: &mut Vec<Export2> ,
                               module_: &Module) {
-        for (name, importresolution) in module_.import_resolutions.borrow().iter() {
+        for (name, importresolution) in (*module_.import_resolutions.borrow()).iter() {
             if !importresolution.is_public {
                 continue
             }
@@ -5193,7 +5193,7 @@ impl<'a> Resolver<'a> {
                          finding {} at {}",
                         token::get_name(name),
                         target.bindings.value_def.borrow());
-                match *target.bindings.value_def.borrow() {
+                match **target.bindings.value_def.borrow() {
                     None => {
                         panic!("resolved name in the value namespace to a \
                               set of name bindings with no def?!");
@@ -5623,7 +5623,7 @@ impl<'a> Resolver<'a> {
                 match this.primitive_type_table.primitive_types.get(last_name) {
                     Some(_) => None,
                     None => {
-                        match this.current_module.children.borrow().get(last_name) {
+                        match (*this.current_module.children.borrow()).get(last_name) {
                             Some(child) => child.get_module_if_available(),
                             None => None
                         }
@@ -6014,7 +6014,7 @@ impl<'a> Resolver<'a> {
             self.populate_module_if_necessary(&search_module);
 
             {
-                for (_, child_names) in search_module.children.borrow().iter() {
+                for (_, child_names) in (*search_module.children.borrow()).iter() {
                     let def = match child_names.def_for_namespace(TypeNS) {
                         Some(def) => def,
                         None => continue
@@ -6030,7 +6030,7 @@ impl<'a> Resolver<'a> {
             }
 
             // Look for imports.
-            for (_, import) in search_module.import_resolutions.borrow().iter() {
+            for (_, import) in (*search_module.import_resolutions.borrow()).iter() {
                 let target = match import.target_for_namespace(TypeNS) {
                     None => continue,
                     Some(target) => target,
@@ -6254,7 +6254,7 @@ impl<'a> Resolver<'a> {
 
         debug!("Children:");
         self.populate_module_if_necessary(&module_);
-        for (&name, _) in module_.children.borrow().iter() {
+        for (&name, _) in (*module_.children.borrow()).iter() {
             debug!("* {}", token::get_name(name));
         }
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4354,7 +4354,7 @@ pub fn impl_or_trait_item<'tcx>(cx: &ctxt<'tcx>, id: ast::DefId)
                                 -> ImplOrTraitItem<'tcx> {
     lookup_locally_or_in_crate_store("impl_or_trait_items",
                                      id,
-                                     &mut *cx.impl_or_trait_items
+                                     &mut **cx.impl_or_trait_items
                                              .borrow_mut(),
                                      || {
         csearch::get_impl_or_trait_item(cx, id)
@@ -4417,7 +4417,7 @@ pub fn trait_item_def_ids(cx: &ctxt, id: ast::DefId)
                           -> Rc<Vec<ImplOrTraitItemId>> {
     lookup_locally_or_in_crate_store("trait_item_def_ids",
                                      id,
-                                     &mut *cx.trait_item_def_ids.borrow_mut(),
+                                     &mut **cx.trait_item_def_ids.borrow_mut(),
                                      || {
         Rc::new(csearch::get_trait_item_def_ids(&cx.sess.cstore, id))
     })
@@ -4717,7 +4717,7 @@ pub fn lookup_item_type<'tcx>(cx: &ctxt<'tcx>,
                               did: ast::DefId)
                               -> Polytype<'tcx> {
     lookup_locally_or_in_crate_store(
-        "tcache", did, &mut *cx.tcache.borrow_mut(),
+        "tcache", did, &mut **cx.tcache.borrow_mut(),
         || csearch::get_type(cx, did))
 }
 
@@ -5249,7 +5249,7 @@ pub fn get_tydesc_ty<'tcx>(tcx: &ctxt<'tcx>) -> Result<Ty<'tcx>, String> {
 
 pub fn item_variances(tcx: &ctxt, item_id: ast::DefId) -> Rc<ItemVariances> {
     lookup_locally_or_in_crate_store(
-        "item_variance_map", item_id, &mut *tcx.item_variance_map.borrow_mut(),
+        "item_variance_map", item_id, &mut **tcx.item_variance_map.borrow_mut(),
         || Rc::new(csearch::get_item_variances(&tcx.sess.cstore, item_id)))
 }
 

--- a/src/librustc/middle/typeck/check/method/probe.rs
+++ b/src/librustc/middle/typeck/check/method/probe.rs
@@ -491,7 +491,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
             Some(impls) => impls,
         };
 
-        for &impl_def_id in impl_def_ids.borrow().iter() {
+        for &impl_def_id in (*impl_def_ids.borrow()).iter() {
             debug!("assemble_extension_candidates_for_trait_impl: trait_def_id={} impl_def_id={}",
                    trait_def_id.repr(self.tcx()),
                    impl_def_id.repr(self.tcx()));

--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -1946,7 +1946,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
-    pub fn item_substs<'a>(&'a self) -> Ref<'a, NodeMap<ty::ItemSubsts<'tcx>>> {
+    pub fn item_substs<'a>(&'a self) -> Ref<'a, &'a NodeMap<ty::ItemSubsts<'tcx>>> {
         self.inh.item_substs.borrow()
     }
 
@@ -4866,7 +4866,7 @@ fn check_block_with_expected<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     let prev = {
         let mut fcx_ps = fcx.ps.borrow_mut();
         let fn_style_state = fcx_ps.recurse(blk);
-        replace(&mut *fcx_ps, fn_style_state)
+        replace(&mut **fcx_ps, fn_style_state)
     };
 
     let mut warned = false;
@@ -4937,7 +4937,7 @@ fn check_block_with_expected<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
         }
     };
 
-    *fcx.ps.borrow_mut() = prev;
+    **fcx.ps.borrow_mut() = prev;
 }
 
 /// Checks a constant appearing in a type. At the moment this is just the

--- a/src/librustc/middle/typeck/coherence/mod.rs
+++ b/src/librustc/middle/typeck/coherence/mod.rs
@@ -432,7 +432,7 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
             Some(found_impls) => found_impls
         };
 
-        for &impl_did in trait_impls.borrow().iter() {
+        for &impl_did in (*trait_impls.borrow()).iter() {
             let items = &(*impl_items)[impl_did];
             if items.len() < 1 {
                 // We'll error out later. For now, just don't ICE.

--- a/src/librustc/middle/typeck/infer/region_inference/mod.rs
+++ b/src/librustc/middle/typeck/infer/region_inference/mod.rs
@@ -533,7 +533,7 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
     }
 
     pub fn resolve_var(&self, rid: RegionVid) -> ty::Region {
-        match *self.values.borrow() {
+        match **self.values.borrow() {
             None => {
                 self.tcx.sess.span_bug(
                     (*self.var_origins.borrow())[rid.index].span(),
@@ -586,7 +586,7 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
     pub fn vars_created_since_mark(&self, mark: RegionMark)
                                    -> Vec<RegionVid>
     {
-        self.undo_log.borrow()
+        (*self.undo_log.borrow())
             .slice_from(mark.length)
             .iter()
             .filter_map(|&elt| match elt {
@@ -619,7 +619,7 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
             debug!("result_index={}, r={}", result_index, r);
 
             for undo_entry in
-                self.undo_log.borrow().slice_from(mark.length).iter()
+                (*self.undo_log.borrow()).slice_from(mark.length).iter()
             {
                 match undo_entry {
                     &AddConstraint(ConstrainVarSubVar(a, b)) => {
@@ -704,7 +704,7 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
         debug!("RegionVarBindings: resolve_regions()");
         let mut errors = vec!();
         let v = self.infer_variable_values(&mut errors);
-        *self.values.borrow_mut() = Some(v);
+        **self.values.borrow_mut() = Some(v);
         errors
     }
 
@@ -1191,7 +1191,7 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
                                       errors: &mut Vec<RegionResolutionError<'tcx>>)
     {
         let mut reg_reg_dups = FnvHashSet::new();
-        for verify in self.verifys.borrow().iter() {
+        for verify in (*self.verifys.borrow()).iter() {
             match *verify {
                 VerifyRegSubReg(ref origin, sub, sup) => {
                     if self.is_subregion_of(sub, sup) {

--- a/src/librustc/middle/typeck/mod.rs
+++ b/src/librustc/middle/typeck/mod.rs
@@ -459,7 +459,7 @@ fn check_start_fn_ty(ccx: &CrateCtxt,
 
 fn check_for_entry_fn(ccx: &CrateCtxt) {
     let tcx = ccx.tcx;
-    match *tcx.sess.entry_fn.borrow() {
+    match **tcx.sess.entry_fn.borrow() {
         Some((id, sp)) => match tcx.sess.entry_type.get() {
             Some(config::EntryMain) => check_main_fn_ty(ccx, id, sp),
             Some(config::EntryStart) => check_start_fn_ty(ccx, id, sp),

--- a/src/librustc/middle/weak_lang_items.rs
+++ b/src/librustc/middle/weak_lang_items.rs
@@ -65,7 +65,7 @@ pub fn link_name(attrs: &[ast::Attribute]) -> Option<InternedString> {
 fn verify(sess: &Session, items: &lang_items::LanguageItems) {
     // We only need to check for the presence of weak lang items if we're
     // emitting something that's not an rlib.
-    let needs_check = sess.crate_types.borrow().iter().any(|kind| {
+    let needs_check = (*sess.crate_types.borrow()).iter().any(|kind| {
         match *kind {
             config::CrateTypeDylib |
             config::CrateTypeExecutable |

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -208,7 +208,7 @@ fn symbol_hash<'tcx>(tcx: &ty::ctxt<'tcx>,
     symbol_hasher.input_str(link_meta.crate_name.as_slice());
     symbol_hasher.input_str("-");
     symbol_hasher.input_str(link_meta.crate_hash.as_str());
-    for meta in tcx.sess.crate_metadata.borrow().iter() {
+    for meta in (*tcx.sess.crate_metadata.borrow()).iter() {
         symbol_hasher.input_str(meta.as_slice());
     }
     symbol_hasher.input_str("-");
@@ -226,7 +226,7 @@ fn get_symbol_hash<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> Strin
     }
 
     let mut symbol_hasher = ccx.symbol_hasher().borrow_mut();
-    let hash = symbol_hash(ccx.tcx(), &mut *symbol_hasher, t, ccx.link_meta());
+    let hash = symbol_hash(ccx.tcx(), &mut **symbol_hasher, t, ccx.link_meta());
     ccx.type_hashcodes().borrow_mut().insert(t, hash.clone());
     hash
 }
@@ -384,7 +384,7 @@ pub fn link_binary(sess: &Session,
                    outputs: &OutputFilenames,
                    crate_name: &str) -> Vec<Path> {
     let mut out_filenames = Vec::new();
-    for &crate_type in sess.crate_types.borrow().iter() {
+    for &crate_type in (*sess.crate_types.borrow()).iter() {
         if invalid_output_for_target(sess, crate_type) {
             sess.bug(format!("invalid output type `{}` for target os `{}`",
                              crate_type, sess.opts.target_triple).as_slice());
@@ -548,7 +548,7 @@ fn link_rlib<'a>(sess: &'a Session,
     let mut ab = ArchiveBuilder::create(config);
     ab.add_file(obj_filename).unwrap();
 
-    for &(ref l, kind) in sess.cstore.get_used_libraries().borrow().iter() {
+    for &(ref l, kind) in (*sess.cstore.get_used_libraries().borrow()).iter() {
         match kind {
             cstore::NativeStatic => {
                 ab.add_native_library(l.as_slice()).unwrap();
@@ -1055,7 +1055,7 @@ fn link_args(cmd: &mut Command,
 // in the current crate. Upstream crates with native library dependencies
 // may have their native library pulled in above.
 fn add_local_native_libraries(cmd: &mut Command, sess: &Session) {
-    for path in sess.opts.addl_lib_search_paths.borrow().iter() {
+    for path in (*sess.opts.addl_lib_search_paths.borrow()).iter() {
         cmd.arg("-L").arg(path);
     }
 

--- a/src/librustc_trans/back/lto.rs
+++ b/src/librustc_trans/back/lto.rs
@@ -33,7 +33,7 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
     }
 
     // Make sure we actually can run LTO
-    for crate_type in sess.crate_types.borrow().iter() {
+    for crate_type in (*sess.crate_types.borrow()).iter() {
         match *crate_type {
             config::CrateTypeExecutable | config::CrateTypeStaticlib => {}
             _ => {

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -180,7 +180,7 @@ fn create_target_machine(sess: &Session) -> TargetMachineRef {
     let no_fp_elim = (sess.opts.debuginfo != NoDebugInfo) ||
                      !sess.target.target.options.eliminate_frame_pointer;
 
-    let any_library = sess.crate_types.borrow().iter().any(|ty| {
+    let any_library = (*sess.crate_types.borrow()).iter().any(|ty| {
         *ty != config::CrateTypeExecutable
     });
 
@@ -568,7 +568,7 @@ pub fn run_passes(sess: &Session,
     // Whenever an rlib is created, the bitcode is inserted into the
     // archive in order to allow LTO against it.
     let needs_crate_bitcode =
-            sess.crate_types.borrow().contains(&config::CrateTypeRlib) &&
+            (*sess.crate_types.borrow()).contains(&config::CrateTypeRlib) &&
             sess.opts.output_types.contains(&config::OutputTypeExe);
     if needs_crate_bitcode {
         modules_config.emit_bc = true;

--- a/src/librustc_trans/driver/driver.rs
+++ b/src/librustc_trans/driver/driver.rs
@@ -178,9 +178,9 @@ pub fn phase_2_configure_and_expand(sess: &Session,
                                     -> Option<ast::Crate> {
     let time_passes = sess.time_passes();
 
-    *sess.crate_types.borrow_mut() =
+    **sess.crate_types.borrow_mut() =
         collect_crate_types(sess, krate.attrs.as_slice());
-    *sess.crate_metadata.borrow_mut() =
+    **sess.crate_metadata.borrow_mut() =
         collect_crate_metadata(sess, krate.attrs.as_slice());
 
     time(time_passes, "gated feature checking", (), |_| {
@@ -195,10 +195,10 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         }
 
         sess.abort_if_errors();
-        *sess.features.borrow_mut() = features;
+        **sess.features.borrow_mut() = features;
     });
 
-    let any_exe = sess.crate_types.borrow().iter().any(|ty| {
+    let any_exe = (*sess.crate_types.borrow()).iter().any(|ty| {
         *ty == config::CrateTypeExecutable
     });
 
@@ -255,7 +255,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
 
     // Lint plugins are registered; now we can process command line flags.
     if sess.opts.describe_lints {
-        super::describe_lints(&*sess.lint_store.borrow(), true);
+        super::describe_lints(&**sess.lint_store.borrow(), true);
         return None;
     }
     sess.lint_store.borrow_mut().process_command_line(sess);
@@ -622,7 +622,7 @@ fn write_out_deps(sess: &Session,
         let file = outputs.path(*output_type);
         match *output_type {
             config::OutputTypeExe => {
-                for output in sess.crate_types.borrow().iter() {
+                for output in (*sess.crate_types.borrow()).iter() {
                     let p = link::filename_for_input(sess, *output,
                                                      id, &file);
                     out_filenames.push(p);
@@ -653,7 +653,7 @@ fn write_out_deps(sess: &Session,
     let result = (|| -> io::IoResult<()> {
         // Build a list of files used to compile the output and
         // write Makefile-compatible dependency rules
-        let files: Vec<String> = sess.codemap().files.borrow()
+        let files: Vec<String> = (*sess.codemap().files.borrow())
                                    .iter().filter(|fmap| fmap.is_real_file())
                                    .map(|fmap| escape_dep_filename(fmap.name.as_slice()))
                                    .collect();

--- a/src/librustc_trans/driver/mod.rs
+++ b/src/librustc_trans/driver/mod.rs
@@ -387,7 +387,7 @@ fn print_crate_info(sess: &Session,
         if crate_file_name {
             let crate_types = driver::collect_crate_types(sess, attrs.as_slice());
             let metadata = driver::collect_crate_metadata(sess, attrs.as_slice());
-            *sess.crate_metadata.borrow_mut() = metadata;
+            **sess.crate_metadata.borrow_mut() = metadata;
             for &style in crate_types.iter() {
                 let fname = link::filename_for_input(sess, style, id.as_slice(),
                                                      &t_outputs.with_extension(""));

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -530,7 +530,7 @@ pub fn get_res_dtor<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                                      &[glue::get_drop_glue_type(ccx, t)],
                                      ty::mk_nil(ccx.tcx()));
         get_extern_fn(ccx,
-                      &mut *ccx.externs().borrow_mut(),
+                      &mut **ccx.externs().borrow_mut(),
                       name.as_slice(),
                       llvm::CCallConv,
                       llty,
@@ -2586,7 +2586,7 @@ pub fn register_fn_llvmty(ccx: &CrateContext,
 }
 
 pub fn is_entry_fn(sess: &Session, node_id: ast::NodeId) -> bool {
-    match *sess.entry_fn.borrow() {
+    match **sess.entry_fn.borrow() {
         Some((entry_id, _)) => node_id == entry_id,
         None => false
     }
@@ -2948,7 +2948,7 @@ pub fn crate_ctxt_to_encode_parms<'a, 'tcx>(cx: &'a SharedCrateContext<'tcx>,
 pub fn write_metadata(cx: &SharedCrateContext, krate: &ast::Crate) -> Vec<u8> {
     use flate;
 
-    let any_library = cx.sess().crate_types.borrow().iter().any(|ty| {
+    let any_library = (*cx.sess().crate_types.borrow()).iter().any(|ty| {
         *ty != config::CrateTypeExecutable
     });
     if !any_library {
@@ -3133,10 +3133,10 @@ pub fn trans_crate<'tcx>(analysis: CrateAnalysis<'tcx>)
         println!("n_inlines: {}", stats.n_inlines.get());
         println!("n_closures: {}", stats.n_closures.get());
         println!("fn stats:");
-        stats.fn_stats.borrow_mut().sort_by(|&(_, insns_a), &(_, insns_b)| {
+        (*stats.fn_stats.borrow_mut()).sort_by(|&(_, insns_a), &(_, insns_b)| {
             insns_b.cmp(&insns_a)
         });
-        for tuple in stats.fn_stats.borrow().iter() {
+        for tuple in (*stats.fn_stats.borrow()).iter() {
             match *tuple {
                 (ref name, insns) => {
                     println!("{} insns, {}", insns, *name);
@@ -3145,7 +3145,7 @@ pub fn trans_crate<'tcx>(analysis: CrateAnalysis<'tcx>)
         }
     }
     if shared_ccx.sess().count_llvm_insns() {
-        for (k, v) in shared_ccx.stats().llvm_insns.borrow().iter() {
+        for (k, v) in (*shared_ccx.stats().llvm_insns.borrow()).iter() {
             println!("{:7} {}", *v, *k);
         }
     }

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -821,7 +821,7 @@ pub fn trans_call_inner<'a, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                          llself.is_some(),
                          abi);
 
-        fcx.scopes.borrow_mut().last_mut().unwrap().drop_non_lifetime_clean();
+        (*fcx.scopes.borrow_mut()).last_mut().unwrap().drop_non_lifetime_clean();
 
         // Invoke the actual rust fn and update bcx/llresult.
         let (llret, b) = base::invoke(bcx,
@@ -862,7 +862,7 @@ pub fn trans_call_inner<'a, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                          cleanup::CustomScope(arg_cleanup_scope),
                          false,
                          abi);
-        fcx.scopes.borrow_mut().last_mut().unwrap().drop_non_lifetime_clean();
+        (*fcx.scopes.borrow_mut()).last_mut().unwrap().drop_non_lifetime_clean();
 
         bcx = foreign::trans_native_call(bcx, callee_ty,
                                          llfn, opt_llretslot.unwrap(),

--- a/src/librustc_trans/trans/debuginfo.rs
+++ b/src/librustc_trans/trans/debuginfo.rs
@@ -1366,7 +1366,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                        &*top_level_block,
                        fn_metadata,
                        fn_ast_id,
-                       &mut *fn_debug_context.scope_map.borrow_mut());
+                       &mut **fn_debug_context.scope_map.borrow_mut());
 
     return FunctionDebugContext { repr: DebugInfo(fn_debug_context) };
 

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -191,7 +191,7 @@ pub fn register_foreign_item_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     let llfn_ty = lltype_for_fn_from_foreign_types(ccx, &tys);
 
     let llfn = base::get_extern_fn(ccx,
-                                   &mut *ccx.externs().borrow_mut(),
+                                   &mut **ccx.externs().borrow_mut(),
                                    name,
                                    cc,
                                    llfn_ty,

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -90,9 +90,9 @@ pub fn get_simple_intrinsic(ccx: &CrateContext, item: &ast::ForeignItem) -> Opti
 /// Performs late verification that intrinsics are used correctly. At present,
 /// the only intrinsic that needs such verification is `transmute`.
 pub fn check_intrinsics(ccx: &CrateContext) {
-    for transmute_restriction in ccx.tcx()
+    for transmute_restriction in (*ccx.tcx()
                                     .transmute_restrictions
-                                    .borrow()
+                                    .borrow())
                                     .iter() {
         let llfromtype = type_of::sizing_type_of(ccx,
                                                  transmute_restriction.from);

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -155,12 +155,12 @@ pub fn run_core(libs: Vec<Path>, cfgs: Vec<String>, externs: Externs,
     };
 
     let external_paths = ctxt.external_paths.borrow_mut().take();
-    *analysis.external_paths.borrow_mut() = external_paths;
+    **analysis.external_paths.borrow_mut() = external_paths;
     let map = ctxt.external_traits.borrow_mut().take();
-    *analysis.external_traits.borrow_mut() = map;
+    **analysis.external_traits.borrow_mut() = map;
     let map = ctxt.external_typarams.borrow_mut().take();
-    *analysis.external_typarams.borrow_mut() = map;
+    **analysis.external_typarams.borrow_mut() = map;
     let map = ctxt.inlined.borrow_mut().take();
-    *analysis.inlined.borrow_mut() = map;
+    **analysis.inlined.borrow_mut() = map;
     (krate, analysis)
 }

--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -963,7 +963,7 @@ pub fn map_decoded_item<'ast, F: FoldOps>(map: &Map<'ast>,
     });
 
     let mut collector = NodeCollector {
-        map: mem::replace(&mut *map.map.borrow_mut(), vec![]),
+        map: mem::replace(*map.map.borrow_mut().deref_mut(), vec![]),
         parent: fld.new_id(DUMMY_NODE_ID)
     };
     let ii_parent_id = collector.parent;
@@ -996,7 +996,7 @@ pub fn map_decoded_item<'ast, F: FoldOps>(map: &Map<'ast>,
             collector.insert(i.id, NodeForeignItem(&**i));
         }
     }
-    *map.map.borrow_mut() = collector.map;
+    **map.map.borrow_mut() = collector.map;
     &ii_parent.ii
 }
 

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -333,7 +333,7 @@ impl CodeMap {
     }
 
     pub fn new_filemap(&self, filename: FileName, src: String) -> Rc<FileMap> {
-        let mut files = self.files.borrow_mut();
+        let mut files = &mut **self.files.borrow_mut();
         let start_pos = match files.last() {
             None => 0,
             Some(last) => last.start_pos.to_uint() + last.src.len(),
@@ -438,7 +438,7 @@ impl CodeMap {
     }
 
     pub fn get_filemap(&self, filename: &str) -> Rc<FileMap> {
-        for fm in self.files.borrow().iter() {
+        for fm in (*self.files.borrow()).iter() {
             if filename == fm.name.as_slice() {
                 return fm.clone();
             }
@@ -462,7 +462,7 @@ impl CodeMap {
         // The number of extra bytes due to multibyte chars in the FileMap
         let mut total_extra_bytes = 0;
 
-        for mbc in map.multibyte_chars.borrow().iter() {
+        for mbc in (*map.multibyte_chars.borrow()).iter() {
             debug!("{}-byte char at {}", mbc.bytes, mbc.pos);
             if mbc.pos < bpos {
                 // every character is at least one byte, so we only

--- a/src/libsyntax/diagnostics/plugin.rs
+++ b/src/libsyntax/diagnostics/plugin.rs
@@ -23,7 +23,7 @@ local_data_key!(used_diagnostics: RefCell<HashMap<Name, Span>>)
 
 fn with_registered_diagnostics<T>(f: |&mut HashMap<Name, Option<Name>>| -> T) -> T {
     match registered_diagnostics.get() {
-        Some(cell) => f(cell.borrow_mut().deref_mut()),
+        Some(cell) => f(&mut **cell.borrow_mut()),
         None => {
             let mut map = HashMap::new();
             let value = f(&mut map);
@@ -35,7 +35,7 @@ fn with_registered_diagnostics<T>(f: |&mut HashMap<Name, Option<Name>>| -> T) ->
 
 fn with_used_diagnostics<T>(f: |&mut HashMap<Name, Span>| -> T) -> T {
     match used_diagnostics.get() {
-        Some(cell) => f(cell.borrow_mut().deref_mut()),
+        Some(cell) => f(&mut **cell.borrow_mut()),
         None => {
             let mut map = HashMap::new();
             let value = f(&mut map);

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -575,8 +575,7 @@ impl<'a> MethodDef<'a> {
             nonself_args: nonself_args,
             fields: fields
         };
-        let mut f = self.combine_substructure.borrow_mut();
-        let f: &mut CombineSubstructureFunc = &mut *f;
+        let f: &mut CombineSubstructureFunc = &mut **self.combine_substructure.borrow_mut();;
         (*f)(cx, trait_.span, &substructure)
     }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4985,11 +4985,11 @@ impl<'a> Parser<'a> {
                               name: String,
                               id_sp: Span) -> (ast::Item_, Vec<ast::Attribute> ) {
         let mut included_mod_stack = self.sess.included_mod_stack.borrow_mut();
-        match included_mod_stack.iter().position(|p| *p == path) {
+        match (*included_mod_stack).iter().position(|p| *p == path) {
             Some(i) => {
                 let mut err = String::from_str("circular modules: ");
                 let len = included_mod_stack.len();
-                for p in included_mod_stack.slice(i, len).iter() {
+                for p in (*included_mod_stack).slice(i, len).iter() {
                     err.push_str(p.display().as_maybe_owned().as_slice());
                     err.push_str(" -> ");
                 }

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -85,8 +85,8 @@ impl<T: Eq + Hash + Clone + 'static> Interner<T> {
     }
 
     pub fn clear(&self) {
-        *self.map.borrow_mut() = HashMap::new();
-        *self.vect.borrow_mut() = Vec::new();
+        **self.map.borrow_mut() = HashMap::new();
+        **self.vect.borrow_mut() = Vec::new();
     }
 }
 
@@ -211,8 +211,8 @@ impl StrInterner {
     }
 
     pub fn clear(&self) {
-        *self.map.borrow_mut() = HashMap::new();
-        *self.vect.borrow_mut() = Vec::new();
+        **self.map.borrow_mut() = HashMap::new();
+        **self.vect.borrow_mut() = Vec::new();
     }
 }
 


### PR DESCRIPTION
This enables one to return references to things inside the primary `RefCell`
content, like this code:

```
use std::cell::RefCell;
use std::cell::Ref;

struct ContainsVector {
    vec: RefCell<Vec<u32>>,
}

impl ContainsVector {
    fn new() -> ContainsVector {
        ContainsVector { vec: RefCell::new(vec![0]) }
    }
    fn index<'a>(&'a self, i: uint) -> Ref<'a, &'a u32> {
        self.vec.borrow().map(|v| &v[i])
    }
    fn index_mut<'a>(&'a self, i: uint) -> RefMut<'a, &'a mut u32> {
        self.vec.borrow_mut().map(|v| &mut v[i])
    }
}

fn main() {
    let cv = ContainsVector::new();
    **cv.index_mut(0) = 1;
    cv.index(0);
}
```
