### PR TITLE
Mark Any::get_type_id as experimental

### DIFF
--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -88,7 +88,7 @@ use intrinsics::TypeId;
 #[stable]
 pub trait Any: 'static {
     /// Get the `TypeId` of `self`
-    #[stable]
+    #[experimental = "this method will likely be replaced by an associated static"]
     fn get_type_id(&self) -> TypeId;
 }
 


### PR DESCRIPTION
It is likely going to be removed and replaced
with an associated static.
