### PR TITLE
Any: use plain transmute instead of transmute_copy for downcasting.

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -15,7 +15,6 @@ use core::clone::Clone;
 use core::cmp::{PartialEq, PartialOrd, Eq, Ord, Ordering};
 use core::default::Default;
 use core::fmt;
-use core::intrinsics;
 use core::kinds::Sized;
 use core::mem;
 use core::option::Option;
@@ -104,17 +103,14 @@ pub trait BoxAny {
 }
 
 #[stable]
-impl BoxAny for Box<Any+'static> {
+impl BoxAny for Box<Any> {
     #[inline]
-    fn downcast<T: 'static>(self) -> Result<Box<T>, Box<Any+'static>> {
+    fn downcast<T: 'static>(self) -> Result<Box<T>, Box<Any>> {
         if self.is::<T>() {
             unsafe {
                 // Get the raw representation of the trait object
                 let to: TraitObject =
-                    *mem::transmute::<&Box<Any>, &TraitObject>(&self);
-
-                // Prevent destructor on self being run
-                intrinsics::forget(self);
+                    mem::transmute::<Box<Any>, TraitObject>(self);
 
                 // Extract the data pointer
                 Ok(mem::transmute(to.data))

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -71,7 +71,7 @@
 
 #![stable]
 
-use mem::{transmute, transmute_copy};
+use mem::{transmute};
 use option::{Option, Some, None};
 use raw::TraitObject;
 use intrinsics::TypeId;
@@ -134,7 +134,7 @@ impl<'a> AnyRefExt<'a> for &'a Any {
         if self.is::<T>() {
             unsafe {
                 // Get the raw representation of the trait object
-                let to: TraitObject = transmute_copy(&self);
+                let to: TraitObject = transmute(self);
 
                 // Extract the data pointer
                 Some(transmute(to.data))
@@ -162,7 +162,7 @@ impl<'a> AnyMutRefExt<'a> for &'a mut Any {
         if self.is::<T>() {
             unsafe {
                 // Get the raw representation of the trait object
-                let to: TraitObject = transmute_copy(&self);
+                let to: TraitObject = transmute(self);
 
                 // Extract the data pointer
                 Some(transmute(to.data))


### PR DESCRIPTION
transmute_copy is no longer needed and is just slow.
