### PR TITLE
core: add {Imm,M}utablePrimitiveSlice trait

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -107,6 +107,7 @@ pub use core::slice::{ImmutableIntSlice, MutableIntSlice};
 pub use core::slice::{MutSplits, MutChunks, Splits};
 pub use core::slice::{bytes, mut_ref_slice, ref_slice, CloneSlicePrelude};
 pub use core::slice::{Found, NotFound, from_raw_buf, from_raw_mut_buf};
+pub use core::slice::{ImmutablePrimitiveSlice, MutablePrimitiveSlice};
 
 // Functional utilities
 


### PR DESCRIPTION
Lets eligible slices be converted to a slice of bytes. Abstracts out some
sensible unsafe behavior from `rust-image`.
