### PR TITLE
DSTify Str + impl Str for &S where S: Str

### DIFF
--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -1277,14 +1277,19 @@ pub mod traits {
 }
 
 /// Any string that can be represented as a slice
-pub trait Str {
+pub trait Str for Sized? {
     /// Work with `self` as a slice.
     fn as_slice<'a>(&'a self) -> &'a str;
 }
 
-impl<'a> Str for &'a str {
+impl Str for str {
     #[inline]
-    fn as_slice<'a>(&'a self) -> &'a str { *self }
+    fn as_slice<'a>(&'a self) -> &'a str { self }
+}
+
+impl<'a, Sized? S> Str for &'a S where S: Str {
+    #[inline]
+    fn as_slice(&self) -> &str { Str::as_slice(*self) }
 }
 
 /// Methods for string slices


### PR DESCRIPTION
Just like we do with AsSlice

This comes in handy when dealing with iterator-centric APIs (`IntoIterator`!) and you want to receive an `Iterator<S> where S: Str` argument. Without this PR, e.g. you can't receive `&["a", "b"].iter()` instead you'll have to type `&["a", "b"].iter().map(|&x| x)` (A similar thing happens with `&[String]`).

r? @aturon 

Full disclaimer: I haven't run `make`/`make check` yet (All my cores are busy)
