### PR TITLE
Deprecate MaybeOwned[Vector] in favor of Cow

### DIFF
--- a/src/libcollections/hash/mod.rs
+++ b/src/libcollections/hash/mod.rs
@@ -67,6 +67,7 @@ use core::prelude::*;
 
 use alloc::boxed::Box;
 use alloc::rc::Rc;
+use core::borrow::{Cow, ToOwned};
 use core::intrinsics::TypeId;
 use core::mem;
 use core::num::Int;
@@ -281,6 +282,13 @@ impl<S: Writer, T: Hash<S>, U: Hash<S>> Hash<S> for Result<T, U> {
             Ok(ref t) => { 1u.hash(state); t.hash(state); }
             Err(ref t) => { 2u.hash(state); t.hash(state); }
         }
+    }
+}
+
+impl<'a, T, Sized? B, S> Hash<S> for Cow<'a, T, B> where B: Hash<S> + ToOwned<T> {
+    #[inline]
+    fn hash(&self, state: &mut S) {
+        Hash::hash(&**self, state)
     }
 }
 

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -16,6 +16,7 @@ use core::prelude::*;
 
 use alloc::boxed::Box;
 use alloc::heap::{EMPTY, allocate, reallocate, deallocate};
+use core::borrow::{Cow, IntoCow};
 use core::cmp::max;
 use core::default::Default;
 use core::fmt;
@@ -105,6 +106,27 @@ pub struct Vec<T> {
     ptr: *mut T,
     len: uint,
     cap: uint,
+}
+
+/// A clone-on-write vector
+pub type CowVec<'a, T> = Cow<'a, Vec<T>, [T]>;
+
+impl<'a, T> FromIterator<T> for CowVec<'a, T> where T: Clone {
+    fn from_iter<I: Iterator<T>>(it: I) -> CowVec<'a, T> {
+        Cow::Owned(FromIterator::from_iter(it))
+    }
+}
+
+impl<'a, T: 'a> IntoCow<'a, Vec<T>, [T]> for Vec<T> where T: Clone {
+    fn into_cow(self) -> CowVec<'a, T> {
+        Cow::Owned(self)
+    }
+}
+
+impl<'a, T> IntoCow<'a, Vec<T>, [T]> for &'a [T] where T: Clone {
+    fn into_cow(self) -> CowVec<'a, T> {
+        Cow::Borrowed(self)
+    }
 }
 
 impl<T> Vec<T> {

--- a/src/libgraphviz/maybe_owned_vec.rs
+++ b/src/libgraphviz/maybe_owned_vec.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![deprecated = "use std::vec::CowVec"]
+
 pub use self::MaybeOwnedVector::*;
 
 use std::default::Default;
@@ -46,12 +48,16 @@ pub trait IntoMaybeOwnedVector<'a,T> {
     fn into_maybe_owned(self) -> MaybeOwnedVector<'a,T>;
 }
 
+#[allow(deprecated)]
 impl<'a,T:'a> IntoMaybeOwnedVector<'a,T> for Vec<T> {
+    #[allow(deprecated)]
     #[inline]
     fn into_maybe_owned(self) -> MaybeOwnedVector<'a,T> { Growable(self) }
 }
 
+#[allow(deprecated)]
 impl<'a,T> IntoMaybeOwnedVector<'a,T> for &'a [T] {
+    #[allow(deprecated)]
     #[inline]
     fn into_maybe_owned(self) -> MaybeOwnedVector<'a,T> { Borrowed(self) }
 }
@@ -66,6 +72,7 @@ impl<'a,T> MaybeOwnedVector<'a,T> {
 
     pub fn len(&self) -> uint { self.as_slice().len() }
 
+    #[allow(deprecated)]
     pub fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
@@ -114,6 +121,7 @@ impl<'b,T> AsSlice<T> for MaybeOwnedVector<'b,T> {
 }
 
 impl<'a,T> FromIterator<T> for MaybeOwnedVector<'a,T> {
+    #[allow(deprecated)]
     fn from_iter<I:Iterator<T>>(iterator: I) -> MaybeOwnedVector<'a,T> {
         // If we are building from scratch, might as well build the
         // most flexible variant.
@@ -143,6 +151,7 @@ impl<'a,T:Clone> CloneSliceAllocPrelude<T> for MaybeOwnedVector<'a,T> {
 }
 
 impl<'a, T: Clone> Clone for MaybeOwnedVector<'a, T> {
+    #[allow(deprecated)]
     fn clone(&self) -> MaybeOwnedVector<'a, T> {
         match *self {
             Growable(ref v) => Growable(v.clone()),
@@ -152,6 +161,7 @@ impl<'a, T: Clone> Clone for MaybeOwnedVector<'a, T> {
 }
 
 impl<'a, T> Default for MaybeOwnedVector<'a, T> {
+    #[allow(deprecated)]
     fn default() -> MaybeOwnedVector<'a, T> {
         Growable(Vec::new())
     }

--- a/src/libregex/re.rs
+++ b/src/libregex/re.rs
@@ -13,7 +13,7 @@ pub use self::Regex::*;
 
 use std::collections::HashMap;
 use std::fmt;
-use std::str::{MaybeOwned, Owned, Slice};
+use std::str::CowString;
 
 use compile::Program;
 use parse;
@@ -565,25 +565,25 @@ pub trait Replacer {
     ///
     /// The `'a` lifetime refers to the lifetime of a borrowed string when
     /// a new owned string isn't needed (e.g., for `NoExpand`).
-    fn reg_replace<'a>(&'a mut self, caps: &Captures) -> MaybeOwned<'a>;
+    fn reg_replace<'a>(&'a mut self, caps: &Captures) -> CowString<'a>;
 }
 
 impl<'t> Replacer for NoExpand<'t> {
-    fn reg_replace<'a>(&'a mut self, _: &Captures) -> MaybeOwned<'a> {
+    fn reg_replace<'a>(&'a mut self, _: &Captures) -> CowString<'a> {
         let NoExpand(s) = *self;
-        Slice(s)
+        s.into_cow()
     }
 }
 
 impl<'t> Replacer for &'t str {
-    fn reg_replace<'a>(&'a mut self, caps: &Captures) -> MaybeOwned<'a> {
-        Owned(caps.expand(*self))
+    fn reg_replace<'a>(&'a mut self, caps: &Captures) -> CowString<'a> {
+        caps.expand(*self).into_cow()
     }
 }
 
 impl<'t> Replacer for |&Captures|: 't -> String {
-    fn reg_replace<'a>(&'a mut self, caps: &Captures) -> MaybeOwned<'a> {
-        Owned((*self)(caps))
+    fn reg_replace<'a>(&'a mut self, caps: &Captures) -> CowString<'a> {
+        (*self)(caps).into_cow()
     }
 }
 

--- a/src/librustc/middle/borrowck/graphviz.rs
+++ b/src/librustc/middle/borrowck/graphviz.rs
@@ -26,7 +26,6 @@ use middle::dataflow::{DataFlowOperator, DataFlowContext, EntryOrExit};
 use middle::dataflow;
 
 use std::rc::Rc;
-use std::str;
 
 #[deriving(Show)]
 pub enum Variant {
@@ -137,8 +136,8 @@ impl<'a, 'tcx> dot::Labeller<'a, Node<'a>, Edge<'a>> for DataflowLabeller<'a, 't
         let suffix = self.dataflow_for(dataflow::Exit, n);
         let inner_label = self.inner.node_label(n);
         inner_label
-            .prefix_line(dot::LabelStr(str::Owned(prefix)))
-            .suffix_line(dot::LabelStr(str::Owned(suffix)))
+            .prefix_line(dot::LabelStr(prefix.into_cow()))
+            .suffix_line(dot::LabelStr(suffix.into_cow()))
     }
     fn edge_label(&'a self, e: &Edge<'a>) -> dot::LabelText<'a> { self.inner.edge_label(e) }
 }

--- a/src/librustc/middle/cfg/graphviz.rs
+++ b/src/librustc/middle/cfg/graphviz.rs
@@ -58,16 +58,16 @@ impl<'a, 'ast> dot::Labeller<'a, Node<'a>, Edge<'a>> for LabelledCFG<'a, 'ast> {
 
     fn node_label(&'a self, &(i, n): &Node<'a>) -> dot::LabelText<'a> {
         if i == self.cfg.entry {
-            dot::LabelStr("entry".into_maybe_owned())
+            dot::LabelStr("entry".into_cow())
         } else if i == self.cfg.exit {
-            dot::LabelStr("exit".into_maybe_owned())
+            dot::LabelStr("exit".into_cow())
         } else if n.data.id == ast::DUMMY_NODE_ID {
-            dot::LabelStr("(dummy_node)".into_maybe_owned())
+            dot::LabelStr("(dummy_node)".into_cow())
         } else {
             let s = self.ast_map.node_to_string(n.data.id);
             // left-aligns the lines
             let s = replace_newline_with_backslash_l(s);
-            dot::EscStr(s.into_maybe_owned())
+            dot::EscStr(s.into_cow())
         }
     }
 
@@ -86,7 +86,7 @@ impl<'a, 'ast> dot::Labeller<'a, Node<'a>, Edge<'a>> for LabelledCFG<'a, 'ast> {
             label.push_str(format!("exiting scope_{} {}", i,
                                    s.as_slice()).as_slice());
         }
-        dot::EscStr(label.into_maybe_owned())
+        dot::EscStr(label.into_cow())
     }
 }
 
@@ -94,7 +94,7 @@ impl<'a> dot::GraphWalk<'a, Node<'a>, Edge<'a>> for &'a cfg::CFG {
     fn nodes(&'a self) -> dot::Nodes<'a, Node<'a>> {
         let mut v = Vec::new();
         self.graph.each_node(|i, nd| { v.push((i, nd)); true });
-        dot::maybe_owned_vec::Growable(v)
+        v.into_cow()
     }
     fn edges(&'a self) -> dot::Edges<'a, Edge<'a>> {
         self.graph.all_edges().iter().collect()

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -74,7 +74,7 @@ use fmt;
 use iter::Iterator;
 use option::{Option, None, Some};
 use str;
-use str::{MaybeOwned, Str, StrPrelude};
+use str::{CowString, MaybeOwned, Str, StrPrelude};
 use string::String;
 use slice::{AsSlice, CloneSliceAllocPrelude};
 use slice::{PartialEqSlicePrelude, SlicePrelude};
@@ -830,7 +830,7 @@ pub struct Display<'a, P:'a> {
 
 impl<'a, P: GenericPath> fmt::Show for Display<'a, P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.as_maybe_owned().as_slice().fmt(f)
+        self.as_cow().fmt(f)
     }
 }
 
@@ -840,7 +840,7 @@ impl<'a, P: GenericPath> Display<'a, P> {
     /// If the path is not UTF-8, invalid sequences will be replaced with the
     /// Unicode replacement char. This involves allocation.
     #[inline]
-    pub fn as_maybe_owned(&self) -> MaybeOwned<'a> {
+    pub fn as_cow(&self) -> CowString<'a> {
         String::from_utf8_lossy(if self.filename {
             match self.path.filename() {
                 None => {

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -551,14 +551,14 @@ mod tests {
             ($path:expr, $exp:expr) => (
                 {
                     let path = Path::new($path);
-                    let mo = path.display().as_maybe_owned();
+                    let mo = path.display().as_cow();
                     assert!(mo.as_slice() == $exp);
                 }
             );
             ($path:expr, $exp:expr, filename) => (
                 {
                     let path = Path::new($path);
-                    let mo = path.filename_display().as_maybe_owned();
+                    let mo = path.filename_display().as_cow();
                     assert!(mo.as_slice() == $exp);
                 }
             )

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -1326,10 +1326,10 @@ mod tests {
         assert_eq!(path.filename_display().to_string(), "".to_string());
 
         let path = Path::new("foo");
-        let mo = path.display().as_maybe_owned();
+        let mo = path.display().as_cow();
         assert_eq!(mo.as_slice(), "foo");
         let path = Path::new(b"\\");
-        let mo = path.filename_display().as_maybe_owned();
+        let mo = path.filename_display().as_cow();
         assert_eq!(mo.as_slice(), "");
     }
 

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -58,6 +58,7 @@
 
 #[doc(no_inline)] pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr};
 #[doc(no_inline)] pub use ascii::IntoBytes;
+#[doc(no_inline)] pub use borrow::IntoCow;
 #[doc(no_inline)] pub use c_str::ToCStr;
 #[doc(no_inline)] pub use char::{Char, UnicodeChar};
 #[doc(no_inline)] pub use clone::Clone;
@@ -78,7 +79,7 @@
 #[doc(no_inline)] pub use result::Result::{Ok, Err};
 #[doc(no_inline)] pub use io::{Buffer, Writer, Reader, Seek, BufferPrelude};
 #[doc(no_inline)] pub use str::{Str, StrVector, StrPrelude};
-#[doc(no_inline)] pub use str::{IntoMaybeOwned, StrAllocating, UnicodeStrPrelude};
+#[doc(no_inline)] pub use str::{StrAllocating, UnicodeStrPrelude};
 #[doc(no_inline)] pub use tuple::{Tuple1, Tuple2, Tuple3, Tuple4};
 #[doc(no_inline)] pub use tuple::{Tuple5, Tuple6, Tuple7, Tuple8};
 #[doc(no_inline)] pub use tuple::{Tuple9, Tuple10, Tuple11, Tuple12};

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -56,6 +56,7 @@ Several modules in `core` are clients of `rt`:
 
 #![allow(dead_code)]
 
+use borrow::IntoCow;
 use failure;
 use rustrt;
 use os;
@@ -113,7 +114,6 @@ pub fn start(argc: int, argv: *const *const u8, main: proc()) -> int {
     use prelude::*;
     use rt;
     use rustrt::task::Task;
-    use str;
 
     let something_around_the_top_of_the_stack = 1;
     let addr = &something_around_the_top_of_the_stack as *const int;
@@ -147,7 +147,7 @@ pub fn start(argc: int, argv: *const *const u8, main: proc()) -> int {
     let mut main = Some(main);
     let mut task = box Task::new(Some((my_stack_bottom, my_stack_top)),
                                  Some(rustrt::thread::main_guard_page()));
-    task.name = Some(str::Slice("<main>"));
+    task.name = Some("<main>".into_cow());
     drop(task.run(|| {
         unsafe {
             rustrt::stack::record_os_managed_stack_bounds(my_stack_bottom, my_stack_top);

--- a/src/libstd/task.rs
+++ b/src/libstd/task.rs
@@ -44,16 +44,17 @@
                will likely be renamed from `task` to `thread`."]
 
 use any::Any;
+use borrow::IntoCow;
+use boxed::Box;
 use comm::channel;
 use io::{Writer, stdio};
 use kinds::{Send, marker};
 use option::{None, Some, Option};
-use boxed::Box;
 use result::Result;
 use rustrt::local::Local;
-use rustrt::task;
 use rustrt::task::Task;
-use str::{Str, SendStr, IntoMaybeOwned};
+use rustrt::task;
+use str::{Str, SendStr};
 use string::{String, ToString};
 use sync::Future;
 
@@ -101,8 +102,8 @@ impl TaskBuilder {
     /// Name the task-to-be. Currently the name is used for identification
     /// only in panic messages.
     #[unstable = "IntoMaybeOwned will probably change."]
-    pub fn named<T: IntoMaybeOwned<'static>>(mut self, name: T) -> TaskBuilder {
-        self.name = Some(name.into_maybe_owned());
+    pub fn named<T: IntoCow<'static, String, str>>(mut self, name: T) -> TaskBuilder {
+        self.name = Some(name.into_cow());
         self
     }
 
@@ -264,12 +265,13 @@ pub fn failing() -> bool {
 #[cfg(test)]
 mod test {
     use any::{Any, AnyRefExt};
+    use borrow::IntoCow;
     use boxed::BoxAny;
-    use result;
-    use result::{Ok, Err};
-    use string::String;
-    use std::io::{ChanReader, ChanWriter};
     use prelude::*;
+    use result::{Ok, Err};
+    use result;
+    use std::io::{ChanReader, ChanWriter};
+    use string::String;
     use super::*;
 
     // !!! These tests are dangerous. If something is buggy, they will hang, !!!
@@ -298,7 +300,7 @@ mod test {
 
     #[test]
     fn test_send_named_task() {
-        TaskBuilder::new().named("ada lovelace".into_maybe_owned()).try(proc() {
+        TaskBuilder::new().named("ada lovelace".into_cow()).try(proc() {
             assert!(name().unwrap() == "ada lovelace".to_string());
         }).map_err(|_| ()).unwrap();
     }

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -272,13 +272,13 @@ impl<'a> StringReader<'a> {
 
     /// Converts CRLF to LF in the given string, raising an error on bare CR.
     fn translate_crlf<'a>(&self, start: BytePos,
-                          s: &'a str, errmsg: &'a str) -> str::MaybeOwned<'a> {
+                          s: &'a str, errmsg: &'a str) -> str::CowString<'a> {
         let mut i = 0u;
         while i < s.len() {
             let str::CharRange { ch, next } = s.char_range_at(i);
             if ch == '\r' {
                 if next < s.len() && s.char_at(next) == '\n' {
-                    return translate_crlf_(self, start, s, errmsg, i).into_maybe_owned();
+                    return translate_crlf_(self, start, s, errmsg, i).into_cow();
                 }
                 let pos = start + BytePos(i as u32);
                 let end_pos = start + BytePos(next as u32);
@@ -286,7 +286,7 @@ impl<'a> StringReader<'a> {
             }
             i = next;
         }
-        return s.into_maybe_owned();
+        return s.into_cow();
 
         fn translate_crlf_(rdr: &StringReader, start: BytePos,
                         s: &str, errmsg: &str, mut i: uint) -> String {
@@ -550,7 +550,7 @@ impl<'a> StringReader<'a> {
                 let string = if has_cr {
                     self.translate_crlf(start_bpos, string,
                                         "bare CR not allowed in block doc-comment")
-                } else { string.into_maybe_owned() };
+                } else { string.into_cow() };
                 token::DocComment(token::intern(string.as_slice()))
             } else {
                 token::Comment

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4966,10 +4966,10 @@ impl<'a> Parser<'a> {
                 let mut err = String::from_str("circular modules: ");
                 let len = included_mod_stack.len();
                 for p in included_mod_stack.slice(i, len).iter() {
-                    err.push_str(p.display().as_maybe_owned().as_slice());
+                    err.push_str(p.display().as_cow().as_slice());
                     err.push_str(" -> ");
                 }
-                err.push_str(path.display().as_maybe_owned().as_slice());
+                err.push_str(path.display().as_cow().as_slice());
                 self.span_fatal(id_sp, err.as_slice());
             }
             None => ()

--- a/src/test/run-fail/panic-task-name-send-str.rs
+++ b/src/test/run-fail/panic-task-name-send-str.rs
@@ -12,7 +12,7 @@
 
 fn main() {
     let r: Result<int,_> =
-        ::std::task::TaskBuilder::new().named("send name".into_maybe_owned())
+        ::std::task::TaskBuilder::new().named("send name".into_cow())
                                        .try(proc() {
             panic!("test");
             3i

--- a/src/test/run-pass/send_str_hashmap.rs
+++ b/src/test/run-pass/send_str_hashmap.rs
@@ -10,51 +10,51 @@
 
 extern crate collections;
 
-use std::str::{SendStr, Owned, Slice};
 use std::collections::HashMap;
 use std::option::Some;
+use std::str::SendStr;
 
 pub fn main() {
     let mut map: HashMap<SendStr, uint> = HashMap::new();
-    assert!(map.insert(Slice("foo"), 42).is_none());
-    assert!(map.insert(Owned("foo".to_string()), 42).is_some());
-    assert!(map.insert(Slice("foo"), 42).is_some());
-    assert!(map.insert(Owned("foo".to_string()), 42).is_some());
+    assert!(map.insert("foo".into_cow(), 42).is_none());
+    assert!(map.insert("foo".to_string().into_cow(), 42).is_some());
+    assert!(map.insert("foo".into_cow(), 42).is_some());
+    assert!(map.insert("foo".to_string().into_cow(), 42).is_some());
 
-    assert!(map.insert(Slice("foo"), 43).is_some());
-    assert!(map.insert(Owned("foo".to_string()), 44).is_some());
-    assert!(map.insert(Slice("foo"), 45).is_some());
-    assert!(map.insert(Owned("foo".to_string()), 46).is_some());
+    assert!(map.insert("foo".into_cow(), 43).is_some());
+    assert!(map.insert("foo".to_string().into_cow(), 44).is_some());
+    assert!(map.insert("foo".into_cow(), 45).is_some());
+    assert!(map.insert("foo".to_string().into_cow(), 46).is_some());
 
     let v = 46;
 
-    assert_eq!(map.get(&Owned("foo".to_string())), Some(&v));
-    assert_eq!(map.get(&Slice("foo")), Some(&v));
+    assert_eq!(map.get(&"foo".to_string().into_cow()), Some(&v));
+    assert_eq!(map.get(&"foo".into_cow()), Some(&v));
 
     let (a, b, c, d) = (50, 51, 52, 53);
 
-    assert!(map.insert(Slice("abc"), a).is_none());
-    assert!(map.insert(Owned("bcd".to_string()), b).is_none());
-    assert!(map.insert(Slice("cde"), c).is_none());
-    assert!(map.insert(Owned("def".to_string()), d).is_none());
+    assert!(map.insert("abc".into_cow(), a).is_none());
+    assert!(map.insert("bcd".to_string().into_cow(), b).is_none());
+    assert!(map.insert("cde".into_cow(), c).is_none());
+    assert!(map.insert("def".to_string().into_cow(), d).is_none());
 
-    assert!(map.insert(Slice("abc"), a).is_some());
-    assert!(map.insert(Owned("bcd".to_string()), b).is_some());
-    assert!(map.insert(Slice("cde"), c).is_some());
-    assert!(map.insert(Owned("def".to_string()), d).is_some());
+    assert!(map.insert("abc".into_cow(), a).is_some());
+    assert!(map.insert("bcd".to_string().into_cow(), b).is_some());
+    assert!(map.insert("cde".into_cow(), c).is_some());
+    assert!(map.insert("def".to_string().into_cow(), d).is_some());
 
-    assert!(map.insert(Owned("abc".to_string()), a).is_some());
-    assert!(map.insert(Slice("bcd"), b).is_some());
-    assert!(map.insert(Owned("cde".to_string()), c).is_some());
-    assert!(map.insert(Slice("def"), d).is_some());
+    assert!(map.insert("abc".to_string().into_cow(), a).is_some());
+    assert!(map.insert("bcd".into_cow(), b).is_some());
+    assert!(map.insert("cde".to_string().into_cow(), c).is_some());
+    assert!(map.insert("def".into_cow(), d).is_some());
 
-    assert_eq!(map.find_equiv("abc"), Some(&a));
-    assert_eq!(map.find_equiv("bcd"), Some(&b));
-    assert_eq!(map.find_equiv("cde"), Some(&c));
-    assert_eq!(map.find_equiv("def"), Some(&d));
+    assert_eq!(map.get("abc"), Some(&a));
+    assert_eq!(map.get("bcd"), Some(&b));
+    assert_eq!(map.get("cde"), Some(&c));
+    assert_eq!(map.get("def"), Some(&d));
 
-    assert_eq!(map.find_equiv(&Slice("abc")), Some(&a));
-    assert_eq!(map.find_equiv(&Slice("bcd")), Some(&b));
-    assert_eq!(map.find_equiv(&Slice("cde")), Some(&c));
-    assert_eq!(map.find_equiv(&Slice("def")), Some(&d));
+    assert_eq!(map.get(&"abc".into_cow()), Some(&a));
+    assert_eq!(map.get(&"bcd".into_cow()), Some(&b));
+    assert_eq!(map.get(&"cde".into_cow()), Some(&c));
+    assert_eq!(map.get(&"def".into_cow()), Some(&d));
 }

--- a/src/test/run-pass/send_str_treemap.rs
+++ b/src/test/run-pass/send_str_treemap.rs
@@ -10,56 +10,56 @@
 
 extern crate collections;
 
-use std::str::{SendStr, Owned, Slice};
-use std::string::ToString;
 use self::collections::TreeMap;
 use std::option::Some;
+use std::str::SendStr;
+use std::string::ToString;
 
 pub fn main() {
     let mut map: TreeMap<SendStr, uint> = TreeMap::new();
-    assert!(map.insert(Slice("foo"), 42).is_none());
-    assert!(map.insert(Owned("foo".to_string()), 42).is_some());
-    assert!(map.insert(Slice("foo"), 42).is_some());
-    assert!(map.insert(Owned("foo".to_string()), 42).is_some());
+    assert!(map.insert("foo".into_cow(), 42).is_none());
+    assert!(map.insert("foo".to_string().into_cow(), 42).is_some());
+    assert!(map.insert("foo".into_cow(), 42).is_some());
+    assert!(map.insert("foo".to_string().into_cow(), 42).is_some());
 
-    assert!(map.insert(Slice("foo"), 43).is_some());
-    assert!(map.insert(Owned("foo".to_string()), 44).is_some());
-    assert!(map.insert(Slice("foo"), 45).is_some());
-    assert!(map.insert(Owned("foo".to_string()), 46).is_some());
+    assert!(map.insert("foo".into_cow(), 43).is_some());
+    assert!(map.insert("foo".to_string().into_cow(), 44).is_some());
+    assert!(map.insert("foo".into_cow(), 45).is_some());
+    assert!(map.insert("foo".to_string().into_cow(), 46).is_some());
 
     let v = 46;
 
-    assert_eq!(map.get(&Owned("foo".to_string())), Some(&v));
-    assert_eq!(map.get(&Slice("foo")), Some(&v));
+    assert_eq!(map.get(&"foo".to_string().into_cow()), Some(&v));
+    assert_eq!(map.get(&"foo".into_cow()), Some(&v));
 
     let (a, b, c, d) = (50, 51, 52, 53);
 
-    assert!(map.insert(Slice("abc"), a).is_none());
-    assert!(map.insert(Owned("bcd".to_string()), b).is_none());
-    assert!(map.insert(Slice("cde"), c).is_none());
-    assert!(map.insert(Owned("def".to_string()), d).is_none());
+    assert!(map.insert("abc".into_cow(), a).is_none());
+    assert!(map.insert("bcd".to_string().into_cow(), b).is_none());
+    assert!(map.insert("cde".into_cow(), c).is_none());
+    assert!(map.insert("def".to_string().into_cow(), d).is_none());
 
-    assert!(map.insert(Slice("abc"), a).is_some());
-    assert!(map.insert(Owned("bcd".to_string()), b).is_some());
-    assert!(map.insert(Slice("cde"), c).is_some());
-    assert!(map.insert(Owned("def".to_string()), d).is_some());
+    assert!(map.insert("abc".into_cow(), a).is_some());
+    assert!(map.insert("bcd".to_string().into_cow(), b).is_some());
+    assert!(map.insert("cde".into_cow(), c).is_some());
+    assert!(map.insert("def".to_string().into_cow(), d).is_some());
 
-    assert!(map.insert(Owned("abc".to_string()), a).is_some());
-    assert!(map.insert(Slice("bcd"), b).is_some());
-    assert!(map.insert(Owned("cde".to_string()), c).is_some());
-    assert!(map.insert(Slice("def"), d).is_some());
+    assert!(map.insert("abc".to_string().into_cow(), a).is_some());
+    assert!(map.insert("bcd".into_cow(), b).is_some());
+    assert!(map.insert("cde".to_string().into_cow(), c).is_some());
+    assert!(map.insert("def".into_cow(), d).is_some());
 
-    assert_eq!(map.get(&Slice("abc")), Some(&a));
-    assert_eq!(map.get(&Slice("bcd")), Some(&b));
-    assert_eq!(map.get(&Slice("cde")), Some(&c));
-    assert_eq!(map.get(&Slice("def")), Some(&d));
+    assert_eq!(map.get(&"abc".into_cow()), Some(&a));
+    assert_eq!(map.get(&"bcd".into_cow()), Some(&b));
+    assert_eq!(map.get(&"cde".into_cow()), Some(&c));
+    assert_eq!(map.get(&"def".into_cow()), Some(&d));
 
-    assert_eq!(map.get(&Owned("abc".to_string())), Some(&a));
-    assert_eq!(map.get(&Owned("bcd".to_string())), Some(&b));
-    assert_eq!(map.get(&Owned("cde".to_string())), Some(&c));
-    assert_eq!(map.get(&Owned("def".to_string())), Some(&d));
+    assert_eq!(map.get(&"abc".to_string().into_cow()), Some(&a));
+    assert_eq!(map.get(&"bcd".to_string().into_cow()), Some(&b));
+    assert_eq!(map.get(&"cde".to_string().into_cow()), Some(&c));
+    assert_eq!(map.get(&"def".to_string().into_cow()), Some(&d));
 
-    assert!(map.remove(&Slice("foo")).is_some());
+    assert!(map.remove(&"foo".into_cow()).is_some());
     assert_eq!(map.into_iter().map(|(k, v)| format!("{}{}", k, v))
                               .collect::<Vec<String>>()
                               .concat(),


### PR DESCRIPTION
- Add `IntoCow` trait, and put it in the prelude
- Add `is_owned`/`is_borrowed` methods to `Cow`
- Add `CowString`/`CowVec` type aliases (to `Cow<'_, String, str>`/`Cow<'_, Vec, [T]>` respectively)
- `Cow` implements: `Show`, `Hash`, `[Partial]{Eq,Ord}`
- `impl BorrowFrom<Cow<'a, T, B>> for B`

[breaking-change]s:
- `IntoMaybeOwned` has been removed from the prelude
- libcollections: `SendStr` is now an alias to `CowString<'static>` (it was aliased to `MaybeOwned<'static>`)
- libgraphviz:
  - `LabelText` variants now wrap `CowString` instead of `MaybeOwned`
  - `Nodes` and `Edges` are now type aliases to `CowVec` (they were aliased to `MaybeOwnedVec`)
- libstd/path: `Display::as_maybe_owned` has been renamed to `Display::as_cow` and now returns a `CowString`
- These functions now accept/return `Cow` instead of `MaybeOwned[Vector]`:
  - libregex: `Replacer::reg_replace`
  - libcollections: `str::from_utf8_lossy`
  - libgraphviz: `Id::new`, `Id::name`, `LabelText::pre_escaped_content`
  - libstd: `TaskBuilder::named`

r? @aturon 
