### PR TITLE
save-analysis: emit names of items that a glob import actually imports.

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -3330,10 +3330,10 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
+    use super::*;
     use prelude::*;
     use test::Bencher;
     use test::black_box;
-    use super::*;
 
     #[bench]
     fn char_iterator(b: &mut Bencher) {

--- a/src/libgraphviz/maybe_owned_vec.rs
+++ b/src/libgraphviz/maybe_owned_vec.rs
@@ -14,7 +14,6 @@ pub use self::MaybeOwnedVector::*;
 
 use std::default::Default;
 use std::fmt;
-use std::iter::FromIterator;
 use std::path::BytesContainer;
 use std::slice;
 

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -146,6 +146,13 @@ pub fn get_impl_or_trait_item<'tcx>(tcx: &ty::ctxt<'tcx>, def: ast::DefId)
                                     tcx)
 }
 
+pub fn get_trait_name(cstore: &cstore::CStore, def: ast::DefId) -> ast::Name {
+    let cdata = cstore.get_crate_data(def.krate);
+    decoder::get_trait_name(cstore.intr.clone(),
+                            &*cdata,
+                            def.node)
+}
+
 pub fn get_trait_item_name_and_kind(cstore: &cstore::CStore, def: ast::DefId)
                                     -> (ast::Name, def::TraitItemKind) {
     let cdata = cstore.get_crate_data(def.krate);

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -781,6 +781,14 @@ pub fn get_impl_items(cdata: Cmd, impl_id: ast::NodeId)
     impl_items
 }
 
+pub fn get_trait_name(intr: Rc<IdentInterner>,
+                      cdata: Cmd,
+                      id: ast::NodeId)
+                      -> ast::Name {
+    let doc = lookup_item(id, cdata.data());
+    item_name(&*intr, doc)
+}
+
 pub fn get_trait_item_name_and_kind(intr: Rc<IdentInterner>,
                                     cdata: Cmd,
                                     id: ast::NodeId)

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -105,6 +105,7 @@ pub struct CrateAnalysis<'tcx> {
     pub ty_cx: ty::ctxt<'tcx>,
     pub reachable: NodeSet,
     pub name: String,
+    pub glob_map: Option<middle::resolve::GlobMap>,
 }
 
 #[deriving(Copy, PartialEq, Eq, Hash)]

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -77,7 +77,7 @@ use std::mem;
 use std::ops;
 use std::rc::Rc;
 use collections::enum_set::{EnumSet, CLike};
-use std::collections::hash_map::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use syntax::abi;
 use syntax::ast::{CrateNum, DefId, DUMMY_NODE_ID, Ident, ItemTrait, LOCAL_CRATE};
@@ -105,7 +105,7 @@ pub struct CrateAnalysis<'tcx> {
     pub ty_cx: ty::ctxt<'tcx>,
     pub reachable: NodeSet,
     pub name: String,
-    pub glob_map: Option<middle::resolve::GlobMap>,
+    pub glob_map: Option<GlobMap>,
 }
 
 #[deriving(Copy, PartialEq, Eq, Hash)]
@@ -6285,6 +6285,10 @@ pub type CaptureModeMap = NodeMap<ast::CaptureClause>;
 
 // Trait method resolution
 pub type TraitMap = NodeMap<Vec<DefId>>;
+
+// Map from the NodeId of a glob import to a list of items which are actually
+// imported.
+pub type GlobMap = HashMap<NodeId, HashSet<Name>>;
 
 pub fn with_freevars<T, F>(tcx: &ty::ctxt, fid: ast::NodeId, f: F) -> T where
     F: FnOnce(&[Freevar]) -> T,

--- a/src/librustc_borrowck/borrowck/check_loans.rs
+++ b/src/librustc_borrowck/borrowck/check_loans.rs
@@ -19,8 +19,6 @@
 use self::UseError::*;
 
 use borrowck::*;
-use borrowck::LoanPathElem::*;
-use borrowck::LoanPathKind::*;
 use rustc::middle::expr_use_visitor as euv;
 use rustc::middle::mem_categorization as mc;
 use rustc::middle::region;

--- a/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
@@ -11,7 +11,6 @@
 //! Computes moves.
 
 use borrowck::*;
-use borrowck::LoanPathKind::*;
 use borrowck::gather_loans::move_error::MoveSpanAndPath;
 use borrowck::gather_loans::move_error::{MoveError, MoveErrorCollector};
 use borrowck::move_data::*;

--- a/src/librustc_borrowck/borrowck/gather_loans/mod.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/mod.rs
@@ -17,7 +17,6 @@
 // sure that all of these loans are honored.
 
 use borrowck::*;
-use borrowck::LoanPathKind::*;
 use borrowck::move_data::MoveData;
 use rustc::middle::expr_use_visitor as euv;
 use rustc::middle::mem_categorization as mc;

--- a/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
@@ -13,8 +13,6 @@
 pub use self::RestrictionResult::*;
 
 use borrowck::*;
-use borrowck::LoanPathElem::*;
-use borrowck::LoanPathKind::*;
 use rustc::middle::expr_use_visitor as euv;
 use rustc::middle::mem_categorization as mc;
 use rustc::middle::ty;

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -342,9 +342,10 @@ pub fn phase_3_run_analysis_passes<'tcx>(sess: Session,
     let lang_items = time(time_passes, "language item collection", (), |_|
                           middle::lang_items::collect_language_items(krate, &sess));
 
-    let make_glob_map = match save_analysis(&sess) {
-        true => middle::resolve::MakeGlobMap::Yes,
-        false => middle::resolve::MakeGlobMap::No,
+    let make_glob_map = if save_analysis(&sess) {
+        middle::resolve::MakeGlobMap::Yes
+    } else {
+        middle::resolve::MakeGlobMap::No
     };
         def_map,
         freevars,

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -343,10 +343,11 @@ pub fn phase_3_run_analysis_passes<'tcx>(sess: Session,
                           middle::lang_items::collect_language_items(krate, &sess));
 
     let make_glob_map = if save_analysis(&sess) {
-        middle::resolve::MakeGlobMap::Yes
+        resolve::MakeGlobMap::Yes
     } else {
-        middle::resolve::MakeGlobMap::No
+        resolve::MakeGlobMap::No
     };
+    let resolve::CrateMap {
         def_map,
         freevars,
         capture_mode_map,
@@ -358,6 +359,7 @@ pub fn phase_3_run_analysis_passes<'tcx>(sess: Session,
     } =
         time(time_passes, "resolution", (),
              |_| resolve::resolve_crate(&sess,
+                                        &ast_map,
                                         &lang_items,
                                         krate,
                                         make_glob_map));

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -123,7 +123,7 @@ fn test_env<F>(source_string: &str,
     // run just enough stuff to build a tcx:
     let lang_items = lang_items::collect_language_items(krate, &sess);
     let resolve::CrateMap { def_map, freevars, capture_mode_map, .. } =
-        resolve::resolve_crate(&sess, &lang_items, krate);
+        resolve::resolve_crate(&sess, &ast_map, &lang_items, krate, resolve::MakeGlobMap::No);
     let named_region_map = resolve_lifetime::krate(&sess, krate, &def_map);
     let region_map = region::resolve_crate(&sess, krate);
     let stability_index = stability::Index::build(krate);

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -28,19 +28,19 @@ use syntax::ast::{ViewPathGlob, ViewPathList, ViewPathSimple};
 use syntax::codemap::{Span, DUMMY_SP};
 use syntax::visit::{mod, Visitor};
 
-struct UnusedImportCheckVisitor<'a, 'b:'a> {
-    resolver: &'a mut Resolver<'b>
+struct UnusedImportCheckVisitor<'a, 'b:'a, 'tcx:'b> {
+    resolver: &'a mut Resolver<'b, 'tcx>
 }
 
 // Deref and DerefMut impls allow treating UnusedImportCheckVisitor as Resolver.
-impl<'a, 'b> Deref<Resolver<'b>> for UnusedImportCheckVisitor<'a, 'b> {
-    fn deref<'c>(&'c self) -> &'c Resolver<'b> {
+impl<'a, 'b, 'tcx> Deref<Resolver<'b, 'tcx>> for UnusedImportCheckVisitor<'a, 'b, 'tcx:'b> {
+    fn deref<'c>(&'c self) -> &'c Resolver<'b, 'tcx> {
         &*self.resolver
     }
 }
 
-impl<'a, 'b> DerefMut<Resolver<'b>> for UnusedImportCheckVisitor<'a, 'b> {
-    fn deref_mut<'c>(&'c mut self) -> &'c mut Resolver<'b> {
+impl<'a, 'b, 'tcx> DerefMut<Resolver<'b, 'tcx>> for UnusedImportCheckVisitor<'a, 'b, 'tcx:'b> {
+    fn deref_mut<'c>(&'c mut self) -> &'c mut Resolver<'b, 'tcx> {
         &mut *self.resolver
     }
 }
@@ -104,7 +104,7 @@ impl<'a, 'b> UnusedImportCheckVisitor<'a, 'b> {
     }
 }
 
-impl<'a, 'b, 'v> Visitor<'v> for UnusedImportCheckVisitor<'a, 'b> {
+impl<'a, 'b, 'v, 'tcx> Visitor<'v> for UnusedImportCheckVisitor<'a, 'b, 'tcx> {
     fn visit_view_item(&mut self, vi: &ViewItem) {
         // Ignore is_public import statements because there's no way to be sure
         // whether they're used or not. Also ignore imports with a dummy span

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -33,19 +33,19 @@ struct UnusedImportCheckVisitor<'a, 'b:'a, 'tcx:'b> {
 }
 
 // Deref and DerefMut impls allow treating UnusedImportCheckVisitor as Resolver.
-impl<'a, 'b, 'tcx> Deref<Resolver<'b, 'tcx>> for UnusedImportCheckVisitor<'a, 'b, 'tcx:'b> {
+impl<'a, 'b, 'tcx:'b> Deref<Resolver<'b, 'tcx>> for UnusedImportCheckVisitor<'a, 'b, 'tcx> {
     fn deref<'c>(&'c self) -> &'c Resolver<'b, 'tcx> {
         &*self.resolver
     }
 }
 
-impl<'a, 'b, 'tcx> DerefMut<Resolver<'b, 'tcx>> for UnusedImportCheckVisitor<'a, 'b, 'tcx:'b> {
+impl<'a, 'b, 'tcx:'b> DerefMut<Resolver<'b, 'tcx>> for UnusedImportCheckVisitor<'a, 'b, 'tcx> {
     fn deref_mut<'c>(&'c mut self) -> &'c mut Resolver<'b, 'tcx> {
         &mut *self.resolver
     }
 }
 
-impl<'a, 'b> UnusedImportCheckVisitor<'a, 'b> {
+impl<'a, 'b, 'tcx> UnusedImportCheckVisitor<'a, 'b, 'tcx> {
     // We have information about whether `use` (import) directives are actually used now.
     // If an import is not used at all, we signal a lint error. If an import is only used
     // for a single namespace, we remove the other namespace from the recorded privacy

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -55,7 +55,7 @@ use rustc::middle::lang_items::LanguageItems;
 use rustc::middle::pat_util::pat_bindings;
 use rustc::middle::privacy::*;
 use rustc::middle::subst::{ParamSpace, FnSpace, TypeSpace};
-use rustc::middle::ty::{CaptureModeMap, Freevar, FreevarMap, TraitMap};
+use rustc::middle::ty::{CaptureModeMap, Freevar, FreevarMap, TraitMap, GlobMap};
 use rustc::util::nodemap::{NodeMap, NodeSet, DefIdSet, FnvHashMap};
 use rustc::util::lev_distance::lev_distance;
 
@@ -66,7 +66,7 @@ use syntax::ast::{ExprPath, ExprStruct, FnDecl};
 use syntax::ast::{ForeignItem, ForeignItemFn, ForeignItemStatic, Generics};
 use syntax::ast::{Ident, ImplItem, Item, ItemConst, ItemEnum, ItemFn};
 use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic};
-use syntax::ast::{ItemStruct, ItemTrait, ItemTy, Local};
+use syntax::ast::{ItemStruct, ItemTrait, ItemTy, Local, LOCAL_CRATE};
 use syntax::ast::{MethodImplItem, Mod, Name, NamedField, NodeId};
 use syntax::ast::{Pat, PatEnum, PatIdent, PatLit};
 use syntax::ast::{PatRange, PatStruct, Path, PathListIdent, PathListMod};
@@ -109,10 +109,6 @@ struct BindingInfo {
 
 // Map from the name in a pattern to its binding mode.
 type BindingMap = HashMap<Name, BindingInfo>;
-
-// Map from the NodeId of a glob import to a list of items which are actually
-// imported.
-pub type GlobMap = HashMap<NodeId, HashSet<Name>>;
 
 #[deriving(Copy, PartialEq)]
 enum PatternBindingMode {
@@ -970,20 +966,6 @@ impl<'a, 'b, 'v, 'tcx> Visitor<'v> for BuildReducedGraphVisitor<'a, 'b, 'tcx> {
 
 }
 
-<<<<<<< HEAD:src/librustc_resolve/lib.rs
-=======
-struct UnusedImportCheckVisitor<'a, 'b:'a, 'tcx:'b> {
-    resolver: &'a mut Resolver<'b, 'tcx>
-}
-
-impl<'a, 'b, 'v, 'tcx> Visitor<'v> for UnusedImportCheckVisitor<'a, 'b, 'tcx> {
-    fn visit_view_item(&mut self, vi: &ViewItem) {
-        self.resolver.check_for_item_unused_imports(vi);
-        visit::walk_view_item(self, vi);
-    }
-}
-
->>>>>>> save-analysis: emit names of items that a glob import actually imports.:src/librustc/middle/resolve.rs
 #[deriving(PartialEq)]
 enum FallbackChecks {
     Everything,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -346,7 +346,7 @@ impl Rib {
 }
 
 /// Whether an import can be shadowed by another import.
-#[deriving(Show,PartialEq,Clone)]
+#[deriving(Show,PartialEq,Clone,Copy)]
 enum Shadowable {
     Always,
     /// Means that the recorded import obeys the glob shadowing rules, i.e., can
@@ -6113,7 +6113,7 @@ pub struct CrateMap {
     pub glob_map: Option<GlobMap>
 }
 
-#[deriving(PartialEq)]
+#[deriving(PartialEq,Copy)]
 pub enum MakeGlobMap {
     Yes,
     No

--- a/src/librustc_resolve/record_exports.rs
+++ b/src/librustc_resolve/record_exports.rs
@@ -27,24 +27,24 @@ use syntax::parse::token;
 
 use std::rc::Rc;
 
-struct ExportRecorder<'a, 'b:'a> {
-    resolver: &'a mut Resolver<'b>
+struct ExportRecorder<'a, 'b:'a, 'tcx:'b> {
+    resolver: &'a mut Resolver<'b, 'tcx>
 }
 
 // Deref and DerefMut impls allow treating ExportRecorder as Resolver.
-impl<'a, 'b> Deref<Resolver<'b>> for ExportRecorder<'a, 'b> {
-    fn deref<'c>(&'c self) -> &'c Resolver<'b> {
+impl<'a, 'b, 'tcx:'b> Deref<Resolver<'b, 'tcx>> for ExportRecorder<'a, 'b, 'tcx> {
+    fn deref<'c>(&'c self) -> &'c Resolver<'b, 'tcx> {
         &*self.resolver
     }
 }
 
-impl<'a, 'b> DerefMut<Resolver<'b>> for ExportRecorder<'a, 'b> {
-    fn deref_mut<'c>(&'c mut self) -> &'c mut Resolver<'b> {
+impl<'a, 'b, 'tcx:'b> DerefMut<Resolver<'b, 'tcx>> for ExportRecorder<'a, 'b, 'tcx> {
+    fn deref_mut<'c>(&'c mut self) -> &'c mut Resolver<'b, 'tcx> {
         &mut *self.resolver
     }
 }
 
-impl<'a, 'b> ExportRecorder<'a, 'b> {
+impl<'a, 'b, 'tcx> ExportRecorder<'a, 'b, 'tcx> {
     fn record_exports_for_module_subtree(&mut self,
                                          module_: Rc<Module>) {
         // If this isn't a local krate, then bail out. We don't need to record

--- a/src/librustc_trans/save/recorder.rs
+++ b/src/librustc_trans/save/recorder.rs
@@ -74,6 +74,7 @@ pub enum Row {
     Impl,
     Module,
     UseAlias,
+    UseGlob,
     ExternCrate,
     Inheritance,
     MethodCall,
@@ -125,6 +126,7 @@ impl<'a> FmtStrs<'a> {
             UseAlias => ("use_alias",
                          vec!("id","refid","refidcrate","name","scopeid"),
                          true, true),
+            UseGlob => ("use_glob", vec!("id","value","scopeid"), true, true),
             ExternCrate => ("extern_crate",
                             vec!("id","name","location","crate","scopeid"),
                             true, true),
@@ -478,6 +480,18 @@ impl<'a> FmtStrs<'a> {
                               span,
                               sub_span,
                               svec!(id, mod_node, mod_crate, name, parent));
+    }
+
+    pub fn use_glob_str(&mut self,
+                        span: Span,
+                        sub_span: Option<Span>,
+                        id: NodeId,
+                        values: &str,
+                        parent: NodeId) {
+        self.check_and_record(UseGlob,
+                              span,
+                              sub_span,
+                              svec!(id, values, parent));
     }
 
     pub fn extern_crate_str(&mut self,

--- a/src/librustc_trans/save/span_utils.rs
+++ b/src/librustc_trans/save/span_utils.rs
@@ -280,6 +280,19 @@ impl<'a> SpanUtils<'a> {
         }
     }
 
+    pub fn sub_span_of_token(&self, span: Span, tok: Token) -> Option<Span> {
+        let mut toks = self.retokenise_span(span);
+        loop {
+            let next = toks.real_token();
+            if next.tok == token::Eof {
+                return None;
+            }
+            if next.tok == tok {
+                return self.make_sub_span(span, Some(next.sp));
+            }
+        }
+    }
+
     pub fn sub_span_after_keyword(&self,
                               span: Span,
                               keyword: keywords::Keyword) -> Option<Span> {

--- a/src/librustc_trans/trans/mod.rs
+++ b/src/librustc_trans/trans/mod.rs
@@ -69,4 +69,3 @@ pub struct CrateTranslation {
     pub crate_formats: dependency_format::Dependencies,
     pub no_builtins: bool,
 }
-

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -630,8 +630,8 @@ static ASCII_UPPER_MAP: [u8, ..256] = [
 
 #[cfg(test)]
 mod tests {
-    use prelude::*;
     use super::*;
+    use prelude::*;
     use char::from_u32;
 
     macro_rules! v2ascii {

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -534,12 +534,11 @@ pub unsafe fn from_c_multistring<F>(buf: *const libc::c_char,
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use prelude::*;
     use ptr;
     use thread::Thread;
     use libc;
-
-    use super::*;
 
     #[test]
     fn test_str_multistring_parsing() {

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -333,12 +333,10 @@ macro_rules! test {
         mod $name {
             #![allow(unused_imports)]
 
-            use prelude::*;
-            use rt;
-
-            use comm::*;
             use super::*;
+            use comm::*;
             use thread::Thread;
+            use prelude::*;
 
             $(#[$a])* #[test] fn f() { $b }
         }
@@ -1022,10 +1020,9 @@ impl<T: Send> Drop for Receiver<T> {
 
 #[cfg(test)]
 mod test {
-    use prelude::*;
-
-    use os;
     use super::*;
+    use prelude::*;
+    use os;
 
     pub fn stress_factor() -> uint {
         match os::getenv("RUST_TEST_STRESS") {

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -399,9 +399,9 @@ impl<'a> Buffer for BufReader<'a> {
 #[cfg(test)]
 mod test {
     extern crate "test" as test_crate;
-    use prelude::*;
     use super::*;
     use io::*;
+    use prelude::*;
     use io;
     use self::test_crate::Bencher;
 

--- a/src/libstd/io/net/pipe.rs
+++ b/src/libstd/io/net/pipe.rs
@@ -266,10 +266,10 @@ impl sys_common::AsInner<UnixAcceptorImp> for UnixAcceptor {
 #[cfg(test)]
 #[allow(experimental)]
 mod tests {
-    use prelude::*;
     use super::*;
     use io::*;
     use io::test::*;
+    use prelude::*;
     use io::fs::PathExtensions;
     use time::Duration;
 

--- a/src/libstd/io/net/udp.rs
+++ b/src/libstd/io/net/udp.rs
@@ -249,10 +249,10 @@ impl Writer for UdpStream {
 #[allow(experimental)]
 mod test {
     use super::*;
-    use prelude::*;
-    use io::*;
     use io::net::ip::*;
+    use io::*;
     use io::test::*;
+    use prelude::*;
 
     // FIXME #11530 this fails on android because tests are run as root
     #[cfg_attr(any(windows, target_os = "android"), ignore)]

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -744,9 +744,9 @@ mod tests {
     #![allow(unused_imports)]
 
     use super::*;
-    use prelude::*;
     use io::timer::*;
     use io::*;
+    use prelude::*;
     use io::fs::PathExtensions;
     use time::Duration;
     use str;

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -447,8 +447,8 @@ static dot_dot_static: &'static [u8] = b"..";
 
 #[cfg(test)]
 mod tests {
-    use prelude::*;
     use super::*;
+    use prelude::*;
     use str;
 
     macro_rules! t {

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -448,7 +448,9 @@ static dot_dot_static: &'static [u8] = b"..";
 #[cfg(test)]
 mod tests {
     use super::*;
-    use prelude::*;
+    use prelude::Option::{mod, Some, None};
+    use prelude::{Vec, Clone, AsSlice, SliceExt, CloneSliceExt, IteratorExt};
+    use prelude::{DoubleEndedIteratorExt, Str, StrExt, ToString, GenericPath};
     use str;
 
     macro_rules! t {

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -1121,8 +1121,10 @@ fn prefix_len(p: Option<PathPrefix>) -> uint {
 
 #[cfg(test)]
 mod tests {
-    use mem;
     use super::*;
+    use prelude::Option::{mod, Some, None};
+    use prelude::{Vec, Clone, AsSlice, SliceExt, CloneSliceExt, IteratorExt};
+    use prelude::{DoubleEndedIteratorExt, Str, ToString, GenericPath};
     use super::PathPrefix::*;
     use super::parse_prefix;
 

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -1121,7 +1121,7 @@ fn prefix_len(p: Option<PathPrefix>) -> uint {
 
 #[cfg(test)]
 mod tests {
-    use prelude::*;
+    use mem;
     use super::*;
     use super::PathPrefix::*;
     use super::parse_prefix;


### PR DESCRIPTION
There is also some work here to make resolve a bit more stable - it no longer overwrites a specific import with a glob import.

r?
