### PR TITLE
Fix "::::" appearing in module_path!()

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -412,12 +412,19 @@ pub fn expand_item(it: P<ast::Item>, fld: &mut MacroExpander)
     let mut new_items = match it.node {
         ast::ItemMac(..) => expand_item_mac(it, fld),
         ast::ItemMod(_) | ast::ItemForeignMod(_) => {
-            fld.cx.mod_push(it.ident);
+            let valid_ident =
+                it.ident.name != parse::token::special_idents::invalid.name;
+
+            if valid_ident {
+                fld.cx.mod_push(it.ident);
+            }
             let macro_escape = contains_macro_escape(new_attrs.as_slice());
             let result = with_exts_frame!(fld.cx.syntax_env,
                                           macro_escape,
                                           noop_fold_item(it, fld));
-            fld.cx.mod_pop();
+            if valid_ident {
+                fld.cx.mod_pop();
+            }
             result
         },
         _ => {

--- a/src/test/run-pass/issue-18859.rs
+++ b/src/test/run-pass/issue-18859.rs
@@ -1,0 +1,24 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+mod foo {
+    pub mod bar {
+        pub mod baz {
+            pub fn name() -> &'static str {
+                module_path!()
+            }
+        }
+    }
+}
+
+fn main() {
+    assert_eq!(module_path!(), "issue-18859");
+    assert_eq!(foo::bar::baz::name(), "issue-18859::foo::bar::baz");
+}


### PR DESCRIPTION
Closes #18859
