### PR TITLE
Allow const struct fields and tuple indexing

### DIFF
--- a/src/test/compile-fail/issue-19244-1.rs
+++ b/src/test/compile-fail/issue-19244-1.rs
@@ -1,0 +1,18 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(tuple_indexing)]
+
+const TUP: (uint,) = (42,);
+
+fn main() {
+    let a: [int, ..TUP.1];
+    //~^ ERROR expected constant expr for array length: tuple index out of bounds
+}

--- a/src/test/compile-fail/issue-19244-2.rs
+++ b/src/test/compile-fail/issue-19244-2.rs
@@ -1,0 +1,17 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct MyStruct { field: uint }
+const STRUCT: MyStruct = MyStruct { field: 42 };
+
+fn main() {
+    let a: [int, ..STRUCT.nonexistent_field];
+    //~^ ERROR expected constant expr for array length: nonexistent struct field
+}

--- a/src/test/run-pass/issue-19244.rs
+++ b/src/test/run-pass/issue-19244.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(tuple_indexing)]
+
+struct MyStruct { field: uint }
+const STRUCT: MyStruct = MyStruct { field: 42 };
+const TUP: (uint,) = (43,);
+
+fn main() {
+    let a = [0i, ..STRUCT.field];
+    let b = [0i, ..TUP.0];
+
+    assert!(a.len() == 42);
+    assert!(b.len() == 43);
+}


### PR DESCRIPTION
With this PR, the following code works:

```
#![feature(tuple_indexing)]
struct MyStruct { field1: uint }

const S: MyStruct = MyStruct { field1: 42u };
const T: (uint,) = (42u,);

struct ConstCheck {
    array1: [int, ..S.field1],
    array2: [int, ..T.0],
}
```

Closes https://github.com/rust-lang/rust/issues/19244
Related https://github.com/rust-lang/rust/issues/19265
