### PR TITLE
Warn about casting an enum variant function

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -208,6 +208,7 @@ impl LintStore {
                      UnusedMut,
                      UnusedAllocation,
                      Stability,
+                     EnumFunctionCasts,
         )
 
         add_builtin_with_new!(sess,

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3370,18 +3370,17 @@ pub fn unsized_part_of_type<'tcx>(cx: &ctxt<'tcx>, ty: Ty<'tcx>) -> Ty<'tcx> {
     }
 }
 
-// Whether a type is enum like, that is an enum type with only nullary
+// Whether an enum is C-like, that is, has only nullary constructors.
+pub fn enum_is_c_like(cx: &ctxt, def_id: ast::DefId) -> bool {
+    let variants = enum_variants(cx, def_id);
+    variants.len() > 0 && variants.iter().all(|v| v.args.len() == 0)
+}
+
+// Whether a type is C-enum like, that is an enum type with only nullary
 // constructors
 pub fn type_is_c_like_enum(cx: &ctxt, ty: Ty) -> bool {
     match ty.sty {
-        ty_enum(did, _) => {
-            let variants = enum_variants(cx, did);
-            if variants.len() == 0 {
-                false
-            } else {
-                variants.iter().all(|v| v.args.len() == 0)
-            }
-        }
+        ty_enum(did, _) => enum_is_c_like(cx, did),
         _ => false
     }
 }

--- a/src/test/compile-fail/enum-function-cast.rs
+++ b/src/test/compile-fail/enum-function-cast.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(warnings)]
+#![allow(dead_code)]
+
+enum Tag {
+    Dynamic,
+    Inline(u8),
+    Static,
+}
+
+fn main() {
+    let _ = Tag::Inline as uint;  //~ ERROR casting non-C-like enum constructor
+}


### PR DESCRIPTION
Closes #18154.
