### PR TITLE
remove grammar makefile rules

### DIFF
--- a/configure
+++ b/configure
@@ -624,7 +624,6 @@ probe CFG_LD               ld
 probe CFG_VALGRIND         valgrind
 probe CFG_PERF             perf
 probe CFG_ISCC             iscc
-probe CFG_LLNEXTGEN        LLnextgen
 probe CFG_JAVAC            javac
 probe CFG_ANTLR4           antlr4
 probe CFG_GRUN             grun

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -247,26 +247,6 @@ $(foreach lang,$(L10N_LANGS),$(eval $(call DEF_L10N_DOC,$(lang),guide)))
 
 
 ######################################################################
-# LLnextgen (grammar analysis from refman)
-######################################################################
-
-ifeq ($(CFG_LLNEXTGEN),)
-  $(info cfg: no llnextgen found, omitting grammar-verification)
-else
-.PHONY: verify-grammar
-
-doc/rust.g: $(D)/rust.md $(S)src/etc/extract_grammar.py
-	@$(call E, extract_grammar: $@)
-	$(Q)$(CFG_PYTHON) $(S)src/etc/extract_grammar.py $< >$@
-
-verify-grammar: doc/rust.g
-	@$(call E, LLnextgen: $<)
-	$(Q)$(CFG_LLNEXTGEN) --generate-lexer-wrapper=no $< >$@
-	$(Q)rm -f doc/rust.c doc/rust.h
-endif
-
-
-######################################################################
 # Rustdoc (libstd/extra)
 ######################################################################
 


### PR DESCRIPTION
I stumbled across this today, and it's not really working. It's been around for a very, very long time, and seems to be based on stuff we don't even have anymore. 

I asked in `#rust-internals`, and @cmr said we should just kill it, so here I am. :) I don't think that anything else uses Java, but maybe I missed something.

And if this _isn't_ what we want, I'm fine with closing too. Just some housekeeping.
