### PR TITLE
std: Export BinarySearchResult

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -106,7 +106,7 @@ pub use core::slice::{OrdSlicePrelude, SlicePrelude, Items, MutItems};
 pub use core::slice::{ImmutableIntSlice, MutableIntSlice};
 pub use core::slice::{MutSplits, MutChunks, Splits};
 pub use core::slice::{bytes, mut_ref_slice, ref_slice, CloneSlicePrelude};
-pub use core::slice::{Found, NotFound, from_raw_buf, from_raw_mut_buf};
+pub use core::slice::{from_raw_buf, from_raw_mut_buf, BinarySearchResult};
 
 // Functional utilities
 

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -34,8 +34,6 @@
 // * The `raw` and `bytes` submodules.
 // * Boilerplate trait implementations.
 
-pub use self::BinarySearchResult::*;
-
 use mem::transmute;
 use clone::Clone;
 use cmp::{PartialEq, PartialOrd, Eq, Ord, Ordering, Less, Equal, Greater, Equiv};
@@ -219,7 +217,7 @@ pub trait SlicePrelude<T> for Sized? {
     /// found; the fourth could match any position in `[1,4]`.
     ///
     /// ```rust
-    /// use std::slice::{Found, NotFound};
+    /// use std::slice::BinarySearchResult::{Found, NotFound};
     /// let s = [0i, 1, 1, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55];
     /// let s = s.as_slice();
     ///
@@ -548,7 +546,7 @@ impl<T> SlicePrelude<T> for [T] {
         while lim != 0 {
             let ix = base + (lim >> 1);
             match f(&self[ix]) {
-                Equal => return Found(ix),
+                Equal => return BinarySearchResult::Found(ix),
                 Less => {
                     base = ix + 1;
                     lim -= 1;
@@ -557,7 +555,7 @@ impl<T> SlicePrelude<T> for [T] {
             }
             lim >>= 1;
         }
-        return NotFound(base);
+        return BinarySearchResult::NotFound(base);
     }
 
     #[inline]
@@ -838,7 +836,7 @@ pub trait OrdSlicePrelude<T: Ord> for Sized? {
     /// found; the fourth could match any position in `[1,4]`.
     ///
     /// ```rust
-    /// use std::slice::{Found, NotFound};
+    /// use std::slice::BinarySearchResult::{Found, NotFound};
     /// let s = [0i, 1, 1, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55];
     /// let s = s.as_slice();
     ///
@@ -1517,8 +1515,8 @@ impl BinarySearchResult {
     /// Similar to `Result::ok`.
     pub fn found(&self) -> Option<uint> {
         match *self {
-            Found(i) => Some(i),
-            NotFound(_) => None
+            BinarySearchResult::Found(i) => Some(i),
+            BinarySearchResult::NotFound(_) => None
         }
     }
 
@@ -1526,8 +1524,8 @@ impl BinarySearchResult {
     /// Similar to `Result::err`.
     pub fn not_found(&self) -> Option<uint> {
         match *self {
-            Found(_) => None,
-            NotFound(i) => Some(i)
+            BinarySearchResult::Found(_) => None,
+            BinarySearchResult::NotFound(i) => Some(i)
         }
     }
 }

--- a/src/libregex/parse.rs
+++ b/src/libregex/parse.rs
@@ -18,7 +18,7 @@ use std::cmp;
 use std::fmt;
 use std::iter;
 use std::num;
-use std::slice;
+use std::slice::BinarySearchResult;
 
 /// Static data containing Unicode ranges for general categories and scripts.
 use unicode::regex::{UNICODE_CLASSES, PERLD, PERLS, PERLW};
@@ -1027,8 +1027,8 @@ fn is_valid_cap(c: char) -> bool {
 
 fn find_class(classes: NamedClasses, name: &str) -> Option<Vec<(char, char)>> {
     match classes.binary_search(|&(s, _)| s.cmp(name)) {
-        slice::Found(i) => Some(classes[i].val1().to_vec()),
-        slice::NotFound(_) => None,
+        BinarySearchResult::Found(i) => Some(classes[i].val1().to_vec()),
+        BinarySearchResult::NotFound(_) => None,
     }
 }
 


### PR DESCRIPTION
At the same time remove the `pub use` of the variants in favor of accessing
through the enum type itself. This is a breaking change as the `Found` and
`NotFound` variants must now be imported through `BinarySearchResult` instead of
just `std::slice`.

[breaking-change]
Closes #19271
