### PR TITLE
Use rust-installer for installation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,6 @@
 [submodule "src/jemalloc"]
 	path = src/jemalloc
 	url = https://github.com/rust-lang/jemalloc.git
+[submodule "src/rust-installer"]
+	path = src/rust-installer
+	url = https://github.com/rust-lang/rust-installer

--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -209,33 +209,40 @@ distcheck-osx: dist-osx
 # Unix binary installer tarballs
 ######################################################################
 
+NON_INSTALLED_PREFIXES=COPYRIGHT,LICENSE-APACHE,LICENSE-MIT,README.md,doc
+
 define DEF_INSTALLER
 
 $$(eval $$(call DEF_PREPARE,dir-$(1)))
 
 dist-install-dir-$(1): PREPARE_HOST=$(1)
 dist-install-dir-$(1): PREPARE_TARGETS=$(2)
-dist-install-dir-$(1): PREPARE_DEST_DIR=tmp/dist/$$(PKG_NAME)-$(1)
+dist-install-dir-$(1): PREPARE_DEST_DIR=tmp/dist/$$(PKG_NAME)-$(1)-image
 dist-install-dir-$(1): PREPARE_DIR_CMD=$(DEFAULT_PREPARE_DIR_CMD)
 dist-install-dir-$(1): PREPARE_BIN_CMD=$(DEFAULT_PREPARE_BIN_CMD)
 dist-install-dir-$(1): PREPARE_LIB_CMD=$(DEFAULT_PREPARE_LIB_CMD)
 dist-install-dir-$(1): PREPARE_MAN_CMD=$(DEFAULT_PREPARE_MAN_CMD)
 dist-install-dir-$(1): PREPARE_CLEAN=true
 dist-install-dir-$(1): prepare-base-dir-$(1) docs compiler-docs
-	$$(Q)(cd $$(PREPARE_DEST_DIR)/ && find . -type f | sed 's/^\.\///') \
-      > tmp/dist/manifest-$(1).in
-	$$(Q)mv tmp/dist/manifest-$(1).in $$(PREPARE_DEST_DIR)/$$(CFG_LIBDIR_RELATIVE)/rustlib/manifest.in
-# Add remaining non-installed files
 	$$(Q)$$(PREPARE_MAN_CMD) $$(S)COPYRIGHT $$(PREPARE_DEST_DIR)
 	$$(Q)$$(PREPARE_MAN_CMD) $$(S)LICENSE-APACHE $$(PREPARE_DEST_DIR)
 	$$(Q)$$(PREPARE_MAN_CMD) $$(S)LICENSE-MIT $$(PREPARE_DEST_DIR)
 	$$(Q)$$(PREPARE_MAN_CMD) $$(S)README.md $$(PREPARE_DEST_DIR)
 	$$(Q)cp -r doc $$(PREPARE_DEST_DIR)
-	$$(Q)$$(PREPARE_BIN_CMD) $$(S)src/etc/install.sh $$(PREPARE_DEST_DIR)
 
 dist/$$(PKG_NAME)-$(1).tar.gz: dist-install-dir-$(1)
 	@$(call E, build: $$@)
-	$$(Q)tar -czf dist/$$(PKG_NAME)-$(1).tar.gz -C tmp/dist $$(PKG_NAME)-$(1)
+	$$(Q)$$(S)src/rust-installer/gen-installer.sh \
+		--product-name=Rust \
+		--verify-bin=rustc \
+		--rel-manifest-dir=rustlib \
+		--success-message=Rust-is-ready-to-roll. \
+		--image-dir=tmp/dist/$$(PKG_NAME)-$(1)-image \
+		--work-dir=tmp/dist \
+		--output-dir=dist \
+		--non-installed-prefixes=$$(NON_INSTALLED_PREFIXES) \
+		--package-name=$$(PKG_NAME)-$(1)
+	$$(Q)rm -R tmp/dist/$$(PKG_NAME)-$(1)-image
 
 endef
 

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -25,7 +25,7 @@ endif
 # Remove tmp files because it's a decent amount of disk space
 	$(Q)rm -R tmp/dist
 
-prepare_install: dist-install-dir-$(CFG_BUILD) | tmp/empty_dir
+prepare_install: dist/$(PKG_NAME)-$(CFG_BUILD).tar.gz | tmp/empty_dir
 
 uninstall:
 ifeq (root user, $(USER) $(patsubst %,user,$(SUDO_USER)))
@@ -38,7 +38,7 @@ endif
 # Remove tmp files because it's a decent amount of disk space
 	$(Q)rm -R tmp/dist
 
-prepare_uninstall: dist-install-dir-$(CFG_BUILD) | tmp/empty_dir
+prepare_uninstall: dist/$(PKG_NAME)-$(CFG_BUILD).tar.gz | tmp/empty_dir
 
 .PHONY: install prepare_install uninstall prepare_uninstall
 


### PR DESCRIPTION
This factors out the install.sh file used by both Cargo and Rust in anticipation of creating a single combined installer for both, per https://github.com/rust-lang/rust/issues/16456.

There should be no changes in functionality.

The installation script has been moved to [a new shared project](https://github.com/rust-lang/rust-installer).

The impacts to Rust are:
- When running `make install` or `make dist`, `rust-installer` itself does yet-another copy of the installation image during its prep.
- When running `make install` the tarball is built as a side-effect, though it isn't used.

We might want to wait a week to land this since I will be OOTO from Wednesday through Sunday and unable to deal with fallout.
