### PR TITLE
Change 'Failure' to 'Panic' in Bug Report Docs

### DIFF
--- a/src/doc/complement-bugreport.md
+++ b/src/doc/complement-bugreport.md
@@ -2,7 +2,7 @@
 
 # I think I found a bug in the compiler!
 
-If you see this message: `error: internal compiler error: unexpected failure`,
+If you see this message: `error: internal compiler error: unexpected panic`,
 then you have definitely found a bug in the compiler. It's also possible that
 your code is not well-typed, but if you saw this message, it's still a bug in
 error reporting.


### PR DESCRIPTION
Just saw this when looking at #19297 and couldn't find an issue/PR dealing with this. #18773 seems to have missed this file.

Compiler output is generated [here](https://github.com/rust-lang/rust/blob/770378a313a573776b16237a46b75bafa49072c1/src/librustc_trans/driver/mod.rs#L466).

cc @steveklabnik
