### PR TITLE
WIP: Add Faux allocator API

### DIFF
--- a/src/liballoc/faux.rs
+++ b/src/liballoc/faux.rs
@@ -114,7 +114,7 @@ pub unsafe fn dealloc<T>(ptr: *mut T) {
     if size == 0 {
         // Do nothing
     } else {
-        deallocate(ptr as *mut u8, size, min_align_of::<T>());
+        heap::deallocate(ptr as *mut u8, size, min_align_of::<T>());
     }
 }
 
@@ -131,6 +131,6 @@ pub unsafe fn dealloc_array<T>(ptr: *mut T, len: uint) {
     } else {
         // No need to check size * len, must have been checked when the ptr was made, or
         // else UB anyway.
-        deallocate(ptr as *mut u8, size * len, min_align_of::<T>());
+        heap::deallocate(ptr as *mut u8, size * len, min_align_of::<T>());
     }
 }

--- a/src/liballoc/faux.rs
+++ b/src/liballoc/faux.rs
@@ -1,3 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use heap::{mod, usable_size, EMPTY};
 use core::mem::{size_of, min_align_of};
 use core::ptr::null_mut;

--- a/src/liballoc/faux.rs
+++ b/src/liballoc/faux.rs
@@ -36,16 +36,17 @@ pub unsafe fn alloc<T>() -> *mut T {
 /// Allocates and returns a ptr to memory to store a `len` elements of type T. Handles zero-sized
 /// types automatically by returning the EMPTY ptr.
 ///
+/// A `len` of 0 is Undefined Behaviour.
+///
 /// # Panics
 ///
-/// Panics if the given `len` is 0, or is size_of<T> * len overflows.
+/// Panics if size_of<T> * len overflows.
 ///
 /// # Aborts
 ///
 /// Aborts on OOM
 #[inline]
 pub unsafe fn alloc_array<T>(len: uint) -> *mut T {
-    assert!(len != 0, "Cannot allocate an array of length 0");
     let size = size_of::<T>();
     if size == 0 {
         EMPTY as *mut T
@@ -61,16 +62,17 @@ pub unsafe fn alloc_array<T>(len: uint) -> *mut T {
 /// types automatically by returning the given ptr. `old_len` must be then `len` provided to the
 /// call to `alloc_array` or `realloc_array` that created `ptr`.
 ///
+/// A len of `0` is Undefined Behaviour.
+///
 /// # Panics
 ///
-/// Panics if given `len` is 0, or is size_of<T> * len overflows.
+/// Panics if size_of<T> * len overflows.
 ///
 /// # Aborts
 ///
 /// Aborts on OOM
 #[inline]
 pub unsafe fn realloc_array<T>(ptr: *mut T, old_len: uint, len: uint) -> *mut T {
-    assert!(len != 0, "Cannot allocate an array of length 0");
     let size = size_of::<T>();
     if size == 0 {
         ptr
@@ -90,12 +92,13 @@ pub unsafe fn realloc_array<T>(ptr: *mut T, old_len: uint, len: uint) -> *mut T 
 /// `old_len` must be the `len` provided to the call to `alloc_array` or `realloc_array`
 /// that created `ptr`. Handles zero-sized types by always returning Ok(()).
 ///
+/// A `len` of 0 is Undefined Behaviour.
+///
 /// # Panics
 ///
-/// Panics if given `len` is 0, or is size_of<T> * len overflows.
+/// Panics if size_of<T> * len overflows.
 #[inline]
 pub unsafe fn realloc_array_inplace<T>(ptr: *mut T, old_len: uint, len: uint) -> Result<(), ()> {
-    assert!(len != 0, "Cannot allocate an array of length 0");
     let size = size_of::<T>();
     let align = min_align_of::<T>();
     if size == 0 {

--- a/src/liballoc/faux.rs
+++ b/src/liballoc/faux.rs
@@ -1,0 +1,136 @@
+use heap::{mod, usable_size, EMPTY};
+use core::mem::{size_of, min_align_of};
+use core::ptr::null_mut;
+use core::num::Int;
+use core::result::Result;
+use core::result::Result::{Ok, Err};
+
+/// Allocates and returns a ptr to memory to store a single element of type T. Handles zero-sized
+/// types automatically by returning the non-null EMPTY ptr.
+///
+/// # Aborts
+///
+/// Aborts on OOM
+#[inline]
+pub unsafe fn alloc<T>() -> *mut T {
+    let size = size_of::<T>();
+    if size == 0 {
+        EMPTY as *mut T
+    } else {
+        let ptr = heap::allocate(size, min_align_of::<T>()) as *mut T;
+        if ptr == null_mut() { ::oom(); }
+        ptr
+    }
+}
+
+/// Allocates and returns a ptr to memory to store a `len` elements of type T. Handles zero-sized
+/// types automatically by returning the EMPTY ptr.
+///
+/// # Panics
+///
+/// Panics if the given `len` is 0, or is size_of<T> * len overflows.
+///
+/// # Aborts
+///
+/// Aborts on OOM
+#[inline]
+pub unsafe fn alloc_array<T>(len: uint) -> *mut T {
+    assert!(len != 0, "Cannot allocate an array of length 0");
+    let size = size_of::<T>();
+    if size == 0 {
+        EMPTY as *mut T
+    } else {
+        let desired_size = size.checked_mul(len).expect("capacity overflow");
+        let ptr = heap::allocate(desired_size, min_align_of::<T>()) as *mut T;
+        if ptr == null_mut() { ::oom(); }
+        ptr
+    }
+}
+
+/// Resizes the allocation referenced by `ptr` to fit `len` elements of type T. Handles zero-sized
+/// types automatically by returning the given ptr. `old_len` must be then `len` provided to the
+/// call to `alloc_array` or `realloc_array` that created `ptr`.
+///
+/// # Panics
+///
+/// Panics if given `len` is 0, or is size_of<T> * len overflows.
+///
+/// # Aborts
+///
+/// Aborts on OOM
+#[inline]
+pub unsafe fn realloc_array<T>(ptr: *mut T, old_len: uint, len: uint) -> *mut T {
+    assert!(len != 0, "Cannot allocate an array of length 0");
+    let size = size_of::<T>();
+    if size == 0 {
+        ptr
+    } else {
+        let desired_size = size.checked_mul(len).expect("capacity overflow");
+        let align = min_align_of::<T>();
+        // No need to check old_size * len, must have been checked when the ptr was made, or
+        // else UB anyway.
+        let ptr = heap::reallocate(ptr as *mut u8, size * old_len, desired_size, align) as *mut T;
+        if ptr == null_mut() { ::oom(); }
+        ptr
+    }
+
+}
+
+/// Tries to resize the allocation referenced by `ptr` to fit `len` elements of type T.
+/// `old_len` must be the `len` provided to the call to `alloc_array` or `realloc_array`
+/// that created `ptr`. Handles zero-sized types by always returning Ok(()).
+///
+/// # Panics
+///
+/// Panics if given `len` is 0, or is size_of<T> * len overflows.
+#[inline]
+pub unsafe fn realloc_array_inplace<T>(ptr: *mut T, old_len: uint, len: uint) -> Result<(), ()> {
+    assert!(len != 0, "Cannot allocate an array of length 0");
+    let size = size_of::<T>();
+    let align = min_align_of::<T>();
+    if size == 0 {
+        Ok(())
+    } else {
+        let desired_size = size.checked_mul(len).expect("capacity overflow");
+        // No need to check old_size * len, must have been checked when the ptr was made, or
+        // else UB anyway.
+        let result_size = heap::reallocate_inplace(ptr as *mut u8, size * old_len,
+                                                    desired_size, align);
+        if result_size == usable_size(desired_size, align) {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+}
+
+/// Deallocates the memory referenced by `ptr`, assuming it was allocated with `alloc`.
+/// Handles zero-sized types automatically by doing nothing.
+///
+/// The `ptr` parameter must not be null, or previously deallocated.
+#[inline]
+pub unsafe fn dealloc<T>(ptr: *mut T) {
+    let size = size_of::<T>();
+    if size == 0 {
+        // Do nothing
+    } else {
+        deallocate(ptr as *mut u8, size, min_align_of::<T>());
+    }
+}
+
+/// Deallocates the memory referenced by `ptr`, assuming it was allocated with `alloc_array` or
+/// `realloc_array`. Handles zero-sized types automatically by doing nothing.
+///
+/// The `ptr` parameter must not be null, or previously deallocated. Then `len` must be the last
+/// value of `len` given to the function that allocated the `ptr`.
+#[inline]
+pub unsafe fn dealloc_array<T>(ptr: *mut T, len: uint) {
+    let size = size_of::<T>();
+    if size == 0 {
+        // Do nothing
+    } else {
+        // No need to check size * len, must have been checked when the ptr was made, or
+        // else UB anyway.
+        deallocate(ptr as *mut u8, size * len, min_align_of::<T>());
+    }
+}

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -85,6 +85,7 @@ pub use boxed as owned;
 // Heaps provided for low-level allocation strategies
 
 pub mod heap;
+pub mod faux;
 
 // Primitive types using the heaps above
 


### PR DESCRIPTION
This adds a alloc::faux module that implements an interpretation of @pnkfelix's proposed high-level allocator API (rust-lang/rfcs#244), optimized for the libstd usecases. This moves all of the tedious oom/zst/capacity-overflow logic into a central place, so that collections and other things don't need to think about it.

As part of this PR I have migrated RingBuf to this API as a proof of concept. Migrating Vec will likely be more tricky, because it does a lot more special tricks based on ZSTs, making the logic more tangled. It is possible that migrating to this API would cause a perf regression for duplicated checks/extra branching. However most of the checks are largely based on compile-time-constants, so I am optimistic about LLVM's ability to optimize these to death.

I guessed out the best semantics I could for some iffy things, like how the `alloc_array` API should handle `len = 0`.

I also am considering adding triple_alloc_array/triple_dealloc_array methods to handle the HashMap usecase (which BTree can also benefit from longterm).
