### PR TITLE
Fix formatting of the pointers guide.

### DIFF
--- a/src/doc/guide-pointers.md
+++ b/src/doc/guide-pointers.md
@@ -572,7 +572,7 @@ fn add_one(x: &mut int) -> int {
 fn main() {
     let x = box 5i;
 
-    println!("{}", add_one(&*x)); // error: cannot borrow immutable dereference 
+    println!("{}", add_one(&*x)); // error: cannot borrow immutable dereference
                                   // of `&`-pointer as mutable
 }
 ```
@@ -700,9 +700,9 @@ This gives you flexibility without sacrificing performance.
 
 You may think that this gives us terrible performance: return a value and then
 immediately box it up ?! Isn't that the worst of both worlds? Rust is smarter
-than that. There is no copy in this code. main allocates enough room for the
-`box , passes a pointer to that memory into foo as x, and then foo writes the
-value straight into that pointer. This writes the return value directly into
+than that. There is no copy in this code. `main` allocates enough room for the
+`box`, passes a pointer to that memory into `foo` as `x`, and then `foo` writes
+the value straight into that pointer. This writes the return value directly into
 the allocated box.
 
 This is important enough that it bears repeating: pointers are not for


### PR DESCRIPTION
The "Returning Pointers" section of the pointers guide broke from the convention of putting code between backticks. This PR fixes that. There's also a little trailing whitespace I took care of.
