### PR TITLE
Make syntax::owned_slice a Box<[T]> wrapper.

### DIFF
--- a/src/librustc/middle/typeck/check/mod.rs
+++ b/src/librustc/middle/typeck/check/mod.rs
@@ -5809,7 +5809,7 @@ pub fn check_bounds_are_used<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
         if !*b {
             span_err!(ccx.tcx.sess, span, E0091,
                 "type parameter `{}` is unused",
-                token::get_ident(tps.get(i).ident));
+                token::get_ident(tps[i].ident));
         }
     }
 }

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -85,6 +85,7 @@
 #[doc(no_inline)] pub use slice::{SlicePrelude, AsSlice, CloneSlicePrelude};
 #[doc(no_inline)] pub use slice::{VectorVector, PartialEqSlicePrelude, OrdSlicePrelude};
 #[doc(no_inline)] pub use slice::{CloneSliceAllocPrelude, OrdSliceAllocPrelude, SliceAllocPrelude};
+#[doc(no_inline)] pub use slice::{BoxedSlicePrelude};
 #[doc(no_inline)] pub use string::{IntoString, String, ToString};
 #[doc(no_inline)] pub use vec::Vec;
 

--- a/src/libsyntax/owned_slice.rs
+++ b/src/libsyntax/owned_slice.rs
@@ -10,99 +10,39 @@
 
 use std::fmt;
 use std::default::Default;
-use std::hash;
-use std::{mem, raw, ptr, slice, vec};
-use std::rt::heap::EMPTY;
+use std::vec;
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 
-/// A non-growable owned slice. This would preferably become `~[T]`
-/// under DST.
-#[unsafe_no_drop_flag] // data is set to null on destruction
+/// A non-growable owned slice. This is a separate type to allow the
+/// representation to change.
+#[deriving(Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct OwnedSlice<T> {
-    /// null iff len == 0
-    data: *mut T,
-    len: uint,
+    data: Box<[T]>
 }
 
 impl<T:fmt::Show> fmt::Show for OwnedSlice<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        try!("OwnedSlice {{".fmt(fmt));
-        for i in self.iter() {
-            try!(i.fmt(fmt));
-        }
-        try!("}}".fmt(fmt));
-        Ok(())
-    }
-}
-
-#[unsafe_destructor]
-impl<T> Drop for OwnedSlice<T> {
-    fn drop(&mut self) {
-        if self.data.is_null() { return }
-
-        // extract the vector
-        let v = mem::replace(self, OwnedSlice::empty());
-        // free via the Vec destructor
-        v.into_vec();
+        self.data.fmt(fmt)
     }
 }
 
 impl<T> OwnedSlice<T> {
     pub fn empty() -> OwnedSlice<T> {
-        OwnedSlice  { data: ptr::null_mut(), len: 0 }
+        OwnedSlice  { data: box [] }
     }
 
     #[inline(never)]
-    pub fn from_vec(mut v: Vec<T>) -> OwnedSlice<T> {
-        let len = v.len();
-
-        if len == 0 {
-            OwnedSlice::empty()
-        } else {
-            // drop excess capacity to avoid breaking sized deallocation
-            v.shrink_to_fit();
-
-            let p = v.as_mut_ptr();
-            // we own the allocation now
-            unsafe { mem::forget(v) }
-
-            OwnedSlice { data: p, len: len }
-        }
+    pub fn from_vec(v: Vec<T>) -> OwnedSlice<T> {
+        OwnedSlice { data: v.into_boxed_slice() }
     }
 
     #[inline(never)]
     pub fn into_vec(self) -> Vec<T> {
-        // null is ok, because len == 0 in that case, as required by Vec.
-        unsafe {
-            let ret = Vec::from_raw_parts(self.data, self.len, self.len);
-            // the vector owns the allocation now
-            mem::forget(self);
-            ret
-        }
+        self.data.into_vec()
     }
 
     pub fn as_slice<'a>(&'a self) -> &'a [T] {
-        let ptr = if self.data.is_null() {
-            // length zero, i.e. this will never be read as a T.
-            EMPTY as *const T
-        } else {
-            self.data as *const T
-        };
-
-        let slice: &[T] = unsafe {mem::transmute(raw::Slice {
-            data: ptr,
-            len: self.len
-        })};
-
-        slice
-    }
-
-    pub fn get<'a>(&'a self, i: uint) -> &'a T {
-        self.as_slice().get(i).expect("OwnedSlice: index out of bounds")
-    }
-
-    pub fn iter<'r>(&'r self) -> slice::Items<'r, T> {
-        self.as_slice().iter()
+        &*self.data
     }
 
     pub fn move_iter(self) -> vec::MoveItems<T> {
@@ -112,10 +52,12 @@ impl<T> OwnedSlice<T> {
     pub fn map<U>(&self, f: |&T| -> U) -> OwnedSlice<U> {
         self.iter().map(f).collect()
     }
+}
 
-    pub fn len(&self) -> uint { self.len }
-
-    pub fn is_empty(&self) -> bool { self.len == 0 }
+impl<T> Deref<[T]> for OwnedSlice<T> {
+    fn deref(&self) -> &[T] {
+        self.as_slice()
+    }
 }
 
 impl<T> Default for OwnedSlice<T> {
@@ -129,20 +71,6 @@ impl<T: Clone> Clone for OwnedSlice<T> {
         OwnedSlice::from_vec(self.as_slice().to_vec())
     }
 }
-
-impl<S: hash::Writer, T: hash::Hash<S>> hash::Hash<S> for OwnedSlice<T> {
-    fn hash(&self, state: &mut S) {
-        self.as_slice().hash(state)
-    }
-}
-
-impl<T: PartialEq> PartialEq for OwnedSlice<T> {
-    fn eq(&self, other: &OwnedSlice<T>) -> bool {
-        self.as_slice() == other.as_slice()
-    }
-}
-
-impl<T: Eq> Eq for OwnedSlice<T> {}
 
 impl<T> FromIterator<T> for OwnedSlice<T> {
     fn from_iter<I: Iterator<T>>(mut iter: I) -> OwnedSlice<T> {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2458,7 +2458,7 @@ impl<'a> State<'a> {
                 s.print_lifetime_def(lifetime)
             } else {
                 let idx = idx - generics.lifetimes.len();
-                let param = generics.ty_params.get(idx);
+                let param = &generics.ty_params[idx];
                 s.print_ty_param(param)
             }
         }));


### PR DESCRIPTION
This makes it correct (e.g. avoiding null pointers) and safe.
