### PR TITLE
Remove special casing for some meta attributes

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -777,13 +777,8 @@ metadata that influences the behavior of the compiler.
 
 ```{.rust}
 # #![allow(unused_attribute)]
-// Crate ID
-#![crate_id = "projx#2.5"]
-
-// Additional metadata attributes
-#![desc = "Project X"]
-#![license = "BSD"]
-#![comment = "This is a comment on Project X."]
+// Crate name
+#![crate_name = "projx"]
 
 // Specify the output type
 #![crate_type = "lib"]
@@ -1961,7 +1956,7 @@ An example of attributes:
 
 ```{.rust}
 // General metadata applied to the enclosing module or crate.
-#![license = "BSD"]
+#![crate_type = "lib"]
 
 // A function marked as a unit test
 #[test]

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -58,7 +58,6 @@
 
 #![crate_name = "alloc"]
 #![experimental]
-#![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -23,7 +23,6 @@
 #![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
-#![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/")]

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -16,7 +16,6 @@
 #![crate_name = "collections"]
 #![experimental]
 #![crate_type = "rlib"]
-#![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/",

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -49,7 +49,6 @@
 
 #![crate_name = "core"]
 #![experimental]
-#![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -22,7 +22,6 @@ Simple [DEFLATE][def]-based compression. This is a wrapper around the
 #![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
-#![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/")]

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -16,7 +16,6 @@
 
 #![crate_name = "fmt_macros"]
 #![experimental]
-#![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![feature(macro_rules, globs, import_shadowing)]

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -82,7 +82,6 @@
 #![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
-#![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/",

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -267,7 +267,6 @@ pub fn main() {
 #![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
-#![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/")]

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -159,7 +159,6 @@
 
 #![crate_name = "log"]
 #![experimental]
-#![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -17,7 +17,6 @@
 //! interface through `std::rand`.
 
 #![crate_name = "rand"]
-#![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -19,7 +19,6 @@
 #![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
-#![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/",

--- a/src/libregex/lib.rs
+++ b/src/libregex/lib.rs
@@ -363,7 +363,6 @@
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![experimental]
-#![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/",

--- a/src/libregex_macros/lib.rs
+++ b/src/libregex_macros/lib.rs
@@ -14,7 +14,6 @@
 #![crate_name = "regex_macros"]
 #![crate_type = "dylib"]
 #![experimental]
-#![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/")]

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -20,8 +20,6 @@ This API is completely unstable and subject to change.
 
 #![crate_name = "rustc"]
 #![experimental]
-#![comment = "The Rust compiler"]
-#![license = "MIT/ASL2"]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -635,11 +635,6 @@ impl LintPass for UnusedAttributes {
             // used in resolve
             "prelude_import",
 
-            // not used anywhere (!?) but apparently we want to keep them around
-            "comment",
-            "desc",
-            "license",
-
             // FIXME: #14407 these are only looked at on-demand so we can't
             // guarantee they'll have already been checked
             "deprecated",
@@ -658,10 +653,6 @@ impl LintPass for UnusedAttributes {
             "no_start",
             "no_main",
             "no_std",
-            "desc",
-            "comment",
-            "license",
-            "copyright",
             "no_builtins",
         ];
 

--- a/src/librustc_back/lib.rs
+++ b/src/librustc_back/lib.rs
@@ -23,8 +23,6 @@
 
 #![crate_name = "rustc_back"]
 #![experimental]
-#![comment = "The Rust compiler minimal-dependency dumping-ground"]
-#![license = "MIT/ASL2"]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -15,7 +15,6 @@
 
 #![crate_name = "rustc_llvm"]
 #![experimental]
-#![license = "MIT/ASL2"]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -20,8 +20,6 @@ This API is completely unstable and subject to change.
 
 #![crate_name = "rustc_trans"]
 #![experimental]
-#![comment = "The Rust compiler back end and driver"]
-#![license = "MIT/ASL2"]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -10,8 +10,6 @@
 
 #![crate_name = "rustdoc"]
 #![experimental]
-#![desc = "rustdoc, the Rust documentation extractor"]
-#![license = "MIT/ASL2"]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 

--- a/src/librustrt/lib.rs
+++ b/src/librustrt/lib.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 #![crate_name = "rustrt"]
-#![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -18,7 +18,6 @@ Core encoding and decoding interfaces.
 #![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
-#![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/",

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -96,8 +96,6 @@
 
 #![crate_name = "std"]
 #![unstable]
-#![comment = "The Rust standard library"]
-#![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -16,7 +16,6 @@
 
 #![crate_name = "syntax"]
 #![experimental]
-#![license = "MIT/ASL2"]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -40,8 +40,6 @@
 
 #![crate_name = "term"]
 #![experimental]
-#![comment = "Simple ANSI color library"]
-#![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -25,8 +25,6 @@
 
 #![crate_name = "test"]
 #![experimental]
-#![comment = "Rust internal test library only used by rustc"]
-#![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/libtime/lib.rs
+++ b/src/libtime/lib.rs
@@ -16,7 +16,6 @@
 
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
-#![license = "MIT/ASL2"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/",

--- a/src/libunicode/lib.rs
+++ b/src/libunicode/lib.rs
@@ -22,7 +22,6 @@
 
 #![crate_name = "unicode"]
 #![experimental]
-#![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",


### PR DESCRIPTION
Descriptions and licenses are handled by Cargo now, so there's no reason
to keep these attributes around.
