### PR TITLE
Make Rc's representation look like Arc.

### DIFF
--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(not(test))]
 use core::ptr::RawPtr;
 
 // FIXME: #13996: mark the `allocate` and `reallocate` return value as `noalias`

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -64,7 +64,8 @@
        html_root_url = "http://doc.rust-lang.org/nightly/")]
 
 #![no_std]
-#![feature(lang_items, phase, unsafe_destructor)]
+#![feature(lang_items, phase, unsafe_destructor, if_let)]
+#![allow(dead_code)]
 
 #[phase(plugin, link)]
 extern crate core;
@@ -91,6 +92,7 @@ pub mod heap;
 pub mod boxed;
 pub mod arc;
 pub mod rc;
+mod rcbox;
 
 /// Common out-of-memory routine
 #[cold]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -141,7 +141,7 @@
 
 #![stable]
 
-use arc::{mod, Arc};
+use arc::Arc;
 use rcbox::{RcBox, DecResult};
 
 use core::clone::Clone;
@@ -172,6 +172,13 @@ pub struct Rc<T> {
 }
 
 impl<T> Rc<T> {
+    #[inline]
+    #[experimental]
+    #[doc(hidden)]
+    pub unsafe fn from_raw_ptr(ptr: *mut RcBox<T>) -> Rc<T> {
+        Rc { _ptr: ptr, _nosend: marker::NoSend, _noshare: marker::NoSync }
+    }
+
     /// Constructs a new `Rc<T>`.
     ///
     /// # Examples
@@ -215,13 +222,6 @@ impl<T> Rc<T> {
 
 }
 
-#[inline]
-#[experimental]
-#[doc(hidden)]
-pub fn from_raw_ptr<T>(ptr: *mut RcBox<T>) -> Rc<T> {
-    Rc { _ptr: ptr, _nosend: marker::NoSend, _noshare: marker::NoSync }
-}
-
 /// Get the number of weak references to this value.
 #[inline]
 #[experimental]
@@ -240,7 +240,7 @@ pub fn strong_count<T>(this: &Rc<T>) -> uint { this.inner().strong_nonatomic() }
 pub fn into_arc<T: Sync + Send>(this: Rc<T>) -> Result<Arc<T>, Rc<T>> {
     unsafe {
         if is_unique(&this) {
-            let ret = arc::from_raw_ptr(this._ptr);
+            let ret = Arc::from_raw_ptr(this._ptr);
             forget(this);
             Ok(ret)
         } else {

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -228,8 +228,8 @@ pub fn strong_count<T>(this: &Rc<T>) -> uint { this.inner().strong_nonatomic() }
 /// Upgrades a unique `Rc` into an `Arc`. Returns `Err` if the `Rc` is not
 /// unique.
 /// ```
-#[experimental]
 #[inline]
+#[experimental]
 pub fn into_arc<T>(this: Rc<T>) -> Result<Arc<T>, Rc<T>> {
     unsafe {
         if is_unique(&this) {

--- a/src/liballoc/rcbox.rs
+++ b/src/liballoc/rcbox.rs
@@ -1,0 +1,209 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use core::atomic;
+use core::mem;
+use core::ptr;
+
+/// A shared representation for reference counted pointers. This is factored out
+/// to allow upgrading from one to another seamlessly.
+pub struct RcBox<T> {
+    strong: uint,
+    weak:   uint,
+    value:  T,
+}
+
+/// The result of decrementing a refcount.
+#[must_use]
+pub enum DecResult {
+    /// The caller must call deallocate.
+    NeedsFree,
+    /// There's still strong (or weak) pointers outstanding.
+    StillInUse
+}
+
+impl<T> RcBox<T> {
+    #[inline]
+    pub fn new(value: T) -> RcBox<T> {
+        RcBox {
+            strong: 1,
+            // there is an implicit weak pointer owned by all the
+            // strong pointers, which ensures that the weak
+            // destructor never frees the allocation while the
+            // strong destructor is running, even if the weak
+            // pointer is stored inside the strong one.
+            weak: 1,
+            value: value,
+        }
+    }
+
+    #[inline(always)]
+    pub fn strong_nonatomic(&self) -> uint {
+        self.strong
+    }
+
+    #[inline(always)]
+    fn set_strong_nonatomic(&self, x: uint) {
+        let strong_ref: &uint = &self.strong;
+        unsafe {
+            let strong_ptr = strong_ref as *const uint;
+            let strong_ptr = strong_ptr as *mut uint;
+            *strong_ptr = x;
+        }
+    }
+
+    #[inline(always)]
+    pub fn weak_nonatomic(&self) -> uint {
+        self.weak
+    }
+
+    #[inline(always)]
+    fn set_weak_nonatomic(&self, x: uint) {
+        let weak_ref: &uint = &self.weak;
+        unsafe {
+            let weak_ptr = weak_ref as *const uint;
+            let weak_ptr = weak_ptr as *mut uint;
+            *weak_ptr = x;
+        }
+    }
+
+    #[inline]
+    pub fn inc_strong_nonatomic(&self) {
+        let old_strong = self.strong_nonatomic();
+        self.set_strong_nonatomic(old_strong + 1);
+    }
+
+    #[inline]
+    pub fn dec_strong_nonatomic(&self) -> DecResult {
+        let old_strong = self.strong_nonatomic();
+        debug_assert!(old_strong != 0);
+        self.set_strong_nonatomic(old_strong - 1);
+        if old_strong == 1 {
+            unsafe { ptr::read(self.value()); } // destroy the contained object
+            DecResult::NeedsFree
+        } else {
+            DecResult::StillInUse
+        }
+    }
+
+    #[inline]
+    pub fn inc_weak_nonatomic(&self) {
+        let old_weak = self.weak_nonatomic();
+        self.set_weak_nonatomic(old_weak + 1);
+    }
+
+    #[inline]
+    pub fn dec_weak_nonatomic(&self) -> DecResult {
+        let old_weak = self.weak_nonatomic();
+        debug_assert!(old_weak != 0);
+        self.set_weak_nonatomic(old_weak - 1);
+        if old_weak == 1 {
+            DecResult::NeedsFree
+        } else {
+            DecResult::StillInUse
+        }
+    }
+
+
+    #[inline(always)]
+    pub unsafe fn strong_atomic<'a>(&'a self) -> &'a atomic::AtomicUint {
+        mem::transmute(&self.strong)
+    }
+
+    #[inline(always)]
+    pub unsafe fn weak_atomic<'a>(&'a self) -> &'a atomic::AtomicUint {
+        mem::transmute(&self.weak)
+    }
+
+    #[inline]
+    pub fn inc_strong_atomic(&self) {
+        // Using a relaxed ordering is alright here, as knowledge of the
+        // original reference prevents other threads from erroneously deleting
+        // the object.
+        //
+        // As explained in the [Boost documentation][1], Increasing the
+        // reference counter can always be done with memory_order_relaxed: New
+        // references to an object can only be formed from an existing
+        // reference, and passing an existing reference from one thread to
+        // another must already provide any required synchronization.
+        //
+        // [1]: (www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html)
+        unsafe {
+            self.strong_atomic().fetch_add(1, atomic::Relaxed);
+        }
+    }
+
+    #[inline]
+    pub fn dec_strong_atomic(&self) -> DecResult {
+        unsafe {
+            // Because `fetch_sub` is already atomic, we do not need to synchronize
+            // with other threads unless we are going to delete the object. This
+            // same logic applies to the below `fetch_sub` to the `weak` count.
+            if self.strong_atomic().fetch_sub(1, atomic::Release) != 1 {
+                return DecResult::StillInUse
+            }
+
+            // This fence is needed to prevent reordering of use of the data and
+            // deletion of the data. Because it is marked `Release`, the
+            // decreasing of the reference count synchronizes with this `Acquire`
+            // fence. This means that use of the data happens before decreasing
+            // the reference count, which happens before this fence, which
+            // happens before the deletion of the data.
+            //
+            // As explained in the [Boost documentation][1],
+            //
+            // It is important to enforce any possible access to the object in
+            // one thread (through an existing reference) to *happen before*
+            // deleting the object in a different thread. This is achieved by a
+            // "release" operation after dropping a reference (any access to the
+            // object through this reference must obviously happened before),
+            // and an "acquire" operation before deleting the object.
+            //
+            // [1]: (www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html)
+            atomic::fence(atomic::Acquire);
+
+            // Destroy the data at this time, even though we may not free the box
+            // allocation itself (there may still be weak pointers lying around).
+            mem::drop(ptr::read(self.value()));
+
+            DecResult::NeedsFree
+        }
+    }
+
+    #[inline]
+    pub fn inc_weak_atomic(&self) {
+        // See comments in RcBox::inc_strong_atomic() for why this is relaxed
+        unsafe {
+            self.weak_atomic().fetch_add(1, atomic::Relaxed);
+        }
+    }
+
+    #[inline]
+    pub fn dec_weak_atomic(&self) -> DecResult {
+        unsafe {
+            if self.weak_atomic().fetch_sub(1, atomic::Release) == 1 {
+                atomic::fence(atomic::Acquire);
+                DecResult::NeedsFree
+            } else {
+                DecResult::StillInUse
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
+    #[inline(always)]
+    pub fn value_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+}


### PR DESCRIPTION
This lets me do some pretty horrible things with mem::transmute to
upgrade an Rc to an Arc in "safe" situations.

Yes it's horrible. But it's also really convenient!
