### PR TITLE
rustdoc: inherited vis. for struct variant fields

### DIFF
--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -202,6 +202,10 @@ impl<'a> fold::DocFolder for Stripper<'a> {
             // implementations of traits are always public.
             clean::ImplItem(ref imp) if imp.trait_.is_some() => true,
 
+            // Struct variant fields have inherited visibility
+            clean::VariantItem(clean::Variant {
+                kind: clean::StructVariant(..)
+            }) => true,
             _ => false,
         };
 


### PR DESCRIPTION
Teach rustdoc that struct variant fields have inherited visibility.

Fix #19048
