### PR TITLE
Fix example code for unreachable!

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -217,12 +217,11 @@ macro_rules! debug_assert_eq(
 /// Iterators:
 ///
 /// ```rust
-/// fn divide_by_three(x: i32) -> i32 { // one of the poorest implementations of x/3
-///     for i in std::iter::count(0_i32, 1) {
-///         if i < 0 { panic!("i32 overflow"); }
-///         if x < 3*i { return i; }
+/// fn divide_by_three(x: u32) -> u32 { // one of the poorest implementations of x/3
+///     for i in std::iter::count(0_u32, 1) {
+///         if 3*i < i { panic!("u32 overflow"); }
+///         if x < 3*i { return i-1; }
 ///     }
-///
 ///     unreachable!();
 /// }
 /// ```


### PR DESCRIPTION
The previous code was giving an incorrect result (not x/3).

Also, this function does not work with signed integers. It now accepts `u32` instead of `i32`.
