### PR TITLE
librustrt: stack_overflow support mipsel linux

### DIFF
--- a/src/librustrt/stack_overflow.rs
+++ b/src/librustrt/stack_overflow.rs
@@ -277,6 +277,7 @@ mod imp {
               all(target_os = "linux", target_arch = "x86_64"),
               all(target_os = "linux", target_arch = "arm"), // may not match
               all(target_os = "linux", target_arch = "mips"), // may not match
+              all(target_os = "linux", target_arch = "mipsel"), // may not match
               target_os = "android"))] // may not match
     mod signal {
         use libc;


### PR DESCRIPTION
Since #19076 was merged, I believe mipsel + linux maybe need add to the list here, too.
