### PR TITLE
Fix corner case in `expr_kind`

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3873,8 +3873,8 @@ pub fn expr_kind(tcx: &ctxt, expr: &ast::Expr) -> ExprKind {
                 }
 
                 def::DefStruct(_) => {
-                    match expr_ty(tcx, expr).sty {
-                        ty_bare_fn(..) => RvalueDatumExpr,
+                    match expr_ty_opt(tcx, expr) {
+                        Some(&TyS {sty: ty_bare_fn(..), ..}) => RvalueDatumExpr,
                         _ => RvalueDpsExpr
                     }
                 }


### PR DESCRIPTION
It looks like the expression isn't getting an entry in the `node_types` map, meaning that when it checks the type of the expression in `expr_kind` to see if it should use `RvalueDatumExpr` or `RvalueDpsExpr`, it cant find the type and panics.

As far as I can tell, this only comes up in this case shown in issue #19337, a unit struct on the left-hand side of an assignment expression. The only reason this happens is because a `DefStruct` is the only case where `expr_kind` checks the type of the expression, so falling back to `RvalueDpsExpr` when no type is found should be fine.

Fixes #19337 
