### PR TITLE
RFC 248? I think you meant RFC 438.

### DIFF
--- a/src/librustc/middle/typeck/astconv.rs
+++ b/src/librustc/middle/typeck/astconv.rs
@@ -715,7 +715,7 @@ fn ast_ty_to_trait_ref<'tcx,AC,RS>(this: &AC,
             match ty.node {
                 ast::TyRptr(None, ref mut_ty) => {
                     span_note!(this.tcx().sess, ty.span,
-                               "perhaps you meant `&{}({} +{})`? (per RFC 248)",
+                               "perhaps you meant `&{}({} +{})`? (per RFC 438)",
                                ppaux::mutability_to_string(mut_ty.mutbl),
                                pprust::ty_to_string(&*mut_ty.ty),
                                pprust::bounds_to_string(bounds));
@@ -723,7 +723,7 @@ fn ast_ty_to_trait_ref<'tcx,AC,RS>(this: &AC,
 
                 ast::TyRptr(Some(ref lt), ref mut_ty) => {
                     span_note!(this.tcx().sess, ty.span,
-                               "perhaps you meant `&{} {}({} +{})`? (per RFC 248)",
+                               "perhaps you meant `&{} {}({} +{})`? (per RFC 438)",
                                pprust::lifetime_to_string(lt),
                                ppaux::mutability_to_string(mut_ty.mutbl),
                                pprust::ty_to_string(&*mut_ty.ty),
@@ -732,7 +732,7 @@ fn ast_ty_to_trait_ref<'tcx,AC,RS>(this: &AC,
 
                 _ => {
                     span_note!(this.tcx().sess, ty.span,
-                               "perhaps you forgot parentheses? (per RFC 248)");
+                               "perhaps you forgot parentheses? (per RFC 438)");
                 }
             }
             Err(ErrorReported)

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1402,7 +1402,7 @@ impl<'a> Parser<'a> {
                 // clauses (i.e., not when parsing something like
                 // `FnMut() -> T + Send`, where the `+` is legal).
                 if self.token == token::BinOp(token::Plus) {
-                    self.warn("deprecated syntax: `()` are required, see RFC 248 for details");
+                    self.warn("deprecated syntax: `()` are required, see RFC 438 for details");
                 }
 
                 Return(t)


### PR DESCRIPTION
There ain’t an RFC 248, while 438 looks to be what is being referred to:
https://github.com/rust-lang/rfcs/blob/master/text/0438-precedence-of-plus.md
