### PR TITLE
Fix a simple typo

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -922,7 +922,7 @@ or 'breaks up,' the tuple, and assigns the bits to three bindings.
 
 This pattern is very powerful, and we'll see it repeated more later.
 
-There also a few things you can do with a tuple as a whole, without
+There are also a few things you can do with a tuple as a whole, without
 destructuring. You can assign one tuple into another, if they have the same
 arity and contained types.
 


### PR DESCRIPTION
Fixes a small omission of `are` in the sentence:
`There also a few things you can do with a tuple as a whole, without...`
r @steveklabnik?
