### PR TITLE
Replace some verbose match statements with their `if let` equivalent.

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -61,23 +61,13 @@ impl LintPass for WhileTrue {
     }
 
     fn check_expr(&mut self, cx: &Context, e: &ast::Expr) {
-        match e.node {
-            ast::ExprWhile(ref cond, _, _) => {
-                match cond.node {
-                    ast::ExprLit(ref lit) => {
-                        match lit.node {
-                            ast::LitBool(true) => {
-                                cx.span_lint(WHILE_TRUE, e.span,
-                                             "denote infinite loops with loop \
-                                              { ... }");
-                            }
-                            _ => {}
-                        }
-                    }
-                    _ => ()
+        if let ast::ExprWhile(ref cond, _, _) = e.node {
+            if let ast::ExprLit(ref lit) = cond.node {
+                if let ast::LitBool(true) = lit.node {
+                    cx.span_lint(WHILE_TRUE, e.span,
+                                 "denote infinite loops with loop { ... }");
                 }
             }
-            _ => ()
         }
     }
 }
@@ -93,14 +83,11 @@ impl LintPass for UnusedCasts {
     }
 
     fn check_expr(&mut self, cx: &Context, e: &ast::Expr) {
-        match e.node {
-            ast::ExprCast(ref expr, ref ty) => {
-                let t_t = ast_ty_to_ty(cx, &infer::new_infer_ctxt(cx.tcx), &**ty);
-                if ty::expr_ty(cx.tcx, &**expr) == t_t {
-                    cx.span_lint(UNUSED_TYPECASTS, ty.span, "unnecessary type cast");
-                }
+        if let ast::ExprCast(ref expr, ref ty) = e.node {
+            let t_t = ast_ty_to_ty(cx, &infer::new_infer_ctxt(cx.tcx), &**ty);
+            if ty::expr_ty(cx.tcx, &**expr) == t_t {
+                cx.span_lint(UNUSED_TYPECASTS, ty.span, "unnecessary type cast");
             }
-            _ => ()
         }
     }
 }
@@ -540,9 +527,8 @@ struct RawPtrDerivingVisitor<'a, 'tcx: 'a> {
 impl<'a, 'tcx, 'v> Visitor<'v> for RawPtrDerivingVisitor<'a, 'tcx> {
     fn visit_ty(&mut self, ty: &ast::Ty) {
         static MSG: &'static str = "use of `#[deriving]` with a raw pointer";
-        match ty.node {
-            ast::TyPtr(..) => self.cx.span_lint(RAW_POINTER_DERIVING, ty.span, MSG),
-            _ => {}
+        if let ast::TyPtr(..) = ty.node {
+            self.cx.span_lint(RAW_POINTER_DERIVING, ty.span, MSG);
         }
         visit::walk_ty(self, ty);
     }
@@ -720,9 +706,8 @@ impl LintPass for UnusedResults {
             _ => return
         };
 
-        match expr.node {
-            ast::ExprRet(..) => return,
-            _ => {}
+        if let ast::ExprRet(..) = expr.node {
+            return;
         }
 
         let t = ty::expr_ty(cx.tcx, expr);
@@ -733,11 +718,8 @@ impl LintPass for UnusedResults {
             ty::ty_struct(did, _) |
             ty::ty_enum(did, _) => {
                 if ast_util::is_local(did) {
-                    match cx.tcx.map.get(did.node) {
-                        ast_map::NodeItem(it) => {
-                            warned |= check_must_use(cx, it.attrs.as_slice(), s.span);
-                        }
-                        _ => {}
+                    if let ast_map::NodeItem(it) = cx.tcx.map.get(did.node) {
+                        warned |= check_must_use(cx, it.attrs.as_slice(), s.span);
                     }
                 } else {
                     csearch::get_item_attrs(&cx.sess().cstore, did, |attrs| {
@@ -969,11 +951,8 @@ impl LintPass for NonSnakeCase {
     }
 
     fn check_item(&mut self, cx: &Context, it: &ast::Item) {
-        match it.node {
-            ast::ItemMod(_) => {
-                self.check_snake_case(cx, "module", it.ident, it.span);
-            }
-            _ => {}
+        if let ast::ItemMod(_) = it.node {
+            self.check_snake_case(cx, "module", it.ident, it.span);
         }
     }
 
@@ -986,27 +965,18 @@ impl LintPass for NonSnakeCase {
     }
 
     fn check_pat(&mut self, cx: &Context, p: &ast::Pat) {
-        match &p.node {
-            &ast::PatIdent(_, ref path1, _) => {
-                match cx.tcx.def_map.borrow().get(&p.id) {
-                    Some(&def::DefLocal(_)) => {
-                        self.check_snake_case(cx, "variable", path1.node, p.span);
-                    }
-                    _ => {}
-                }
+        if let &ast::PatIdent(_, ref path1, _) = &p.node {
+            if let Some(&def::DefLocal(_)) = cx.tcx.def_map.borrow().get(&p.id) {
+                self.check_snake_case(cx, "variable", path1.node, p.span);
             }
-            _ => {}
         }
     }
 
     fn check_struct_def(&mut self, cx: &Context, s: &ast::StructDef,
             _: ast::Ident, _: &ast::Generics, _: ast::NodeId) {
         for sf in s.fields.iter() {
-            match sf.node {
-                ast::StructField_ { kind: ast::NamedField(ident, _), .. } => {
-                    self.check_snake_case(cx, "structure field", ident, sf.span);
-                }
-                _ => {}
+            if let ast::StructField_ { kind: ast::NamedField(ident, _), .. } = sf.node {
+                self.check_snake_case(cx, "structure field", ident, sf.span);
             }
         }
     }
@@ -1069,16 +1039,13 @@ pub struct UnusedParens;
 impl UnusedParens {
     fn check_unused_parens_core(&self, cx: &Context, value: &ast::Expr, msg: &str,
                                      struct_lit_needs_parens: bool) {
-        match value.node {
-            ast::ExprParen(ref inner) => {
-                let necessary = struct_lit_needs_parens && contains_exterior_struct_lit(&**inner);
-                if !necessary {
-                    cx.span_lint(UNUSED_PARENS, value.span,
-                                 format!("unnecessary parentheses around {}",
-                                         msg).as_slice())
-                }
+        if let ast::ExprParen(ref inner) = value.node {
+            let necessary = struct_lit_needs_parens && contains_exterior_struct_lit(&**inner);
+            if !necessary {
+                cx.span_lint(UNUSED_PARENS, value.span,
+                             format!("unnecessary parentheses around {}",
+                                     msg).as_slice())
             }
-            _ => {}
         }
 
         /// Expressions that syntactically contain an "exterior" struct
@@ -1201,24 +1168,21 @@ impl LintPass for NonShorthandFieldPatterns {
 
     fn check_pat(&mut self, cx: &Context, pat: &ast::Pat) {
         let def_map = cx.tcx.def_map.borrow();
-        match pat.node {
-            ast::PatStruct(_, ref v, _) => {
-                for fieldpat in v.iter()
-                                 .filter(|fieldpat| !fieldpat.node.is_shorthand)
-                                 .filter(|fieldpat| def_map.get(&fieldpat.node.pat.id)
-                                    == Some(&def::DefLocal(fieldpat.node.pat.id))) {
-                    match fieldpat.node.pat.node {
-                        ast::PatIdent(_, ident, None) if ident.node.as_str()
-                                                         == fieldpat.node.ident.as_str() => {
-                            cx.span_lint(NON_SHORTHAND_FIELD_PATTERNS, fieldpat.span,
-                                         format!("the `{}:` in this pattern is redundant and can \
-                                                  be removed", ident.node.as_str()).as_slice())
-                        },
-                        _ => {},
-                    }
+        if let ast::PatStruct(_, ref v, _) = pat.node {
+            for fieldpat in v.iter()
+                             .filter(|fieldpat| !fieldpat.node.is_shorthand)
+                             .filter(|fieldpat| def_map.get(&fieldpat.node.pat.id)
+                                                == Some(&def::DefLocal(fieldpat.node.pat.id))) {
+                match fieldpat.node.pat.node {
+                    ast::PatIdent(_, ident, None) if ident.node.as_str()
+                                                     == fieldpat.node.ident.as_str() => {
+                        cx.span_lint(NON_SHORTHAND_FIELD_PATTERNS, fieldpat.span,
+                                     format!("the `{}:` in this pattern is redundant and can \
+                                              be removed", ident.node.as_str()).as_slice())
+                    },
+                    _ => {},
                 }
-            },
-            _ => {}
+            }
         }
     }
 }
@@ -1313,27 +1277,18 @@ impl LintPass for UnusedMut {
     }
 
     fn check_expr(&mut self, cx: &Context, e: &ast::Expr) {
-        match e.node {
-            ast::ExprMatch(_, ref arms, _) => {
-                for a in arms.iter() {
-                    self.check_unused_mut_pat(cx, a.pats.as_slice())
-                }
+        if let ast::ExprMatch(_, ref arms, _) = e.node {
+            for a in arms.iter() {
+                self.check_unused_mut_pat(cx, a.pats.as_slice())
             }
-            _ => {}
         }
     }
 
     fn check_stmt(&mut self, cx: &Context, s: &ast::Stmt) {
-        match s.node {
-            ast::StmtDecl(ref d, _) => {
-                match d.node {
-                    ast::DeclLocal(ref l) => {
-                        self.check_unused_mut_pat(cx, slice::ref_slice(&l.pat));
-                    },
-                    _ => {}
-                }
-            },
-            _ => {}
+        if let ast::StmtDecl(ref d, _) = s.node {
+            if let ast::DeclLocal(ref l) = d.node {
+                self.check_unused_mut_pat(cx, slice::ref_slice(&l.pat));
+            }
         }
     }
 
@@ -1362,26 +1317,20 @@ impl LintPass for UnusedAllocation {
             _ => return
         }
 
-        match cx.tcx.adjustments.borrow().get(&e.id) {
-            Some(adjustment) => {
-                match *adjustment {
-                    ty::AdjustDerefRef(ty::AutoDerefRef { ref autoref, .. }) => {
-                        match autoref {
-                            &Some(ty::AutoPtr(_, ast::MutImmutable, None)) => {
-                                cx.span_lint(UNUSED_ALLOCATION, e.span,
-                                             "unnecessary allocation, use & instead");
-                            }
-                            &Some(ty::AutoPtr(_, ast::MutMutable, None)) => {
-                                cx.span_lint(UNUSED_ALLOCATION, e.span,
-                                             "unnecessary allocation, use &mut instead");
-                            }
-                            _ => ()
-                        }
+        if let Some(adjustment) = cx.tcx.adjustments.borrow().get(&e.id) {
+            if let ty::AdjustDerefRef(ty::AutoDerefRef { ref autoref, .. }) = *adjustment {
+                match autoref {
+                    &Some(ty::AutoPtr(_, ast::MutImmutable, None)) => {
+                        cx.span_lint(UNUSED_ALLOCATION, e.span,
+                                     "unnecessary allocation, use & instead");
                     }
-                    _ => {}
+                    &Some(ty::AutoPtr(_, ast::MutMutable, None)) => {
+                        cx.span_lint(UNUSED_ALLOCATION, e.span,
+                                     "unnecessary allocation, use &mut instead");
+                    }
+                    _ => ()
                 }
             }
-            _ => ()
         }
     }
 }
@@ -1499,17 +1448,14 @@ impl LintPass for MissingDoc {
     fn check_fn(&mut self, cx: &Context,
             fk: visit::FnKind, _: &ast::FnDecl,
             _: &ast::Block, _: Span, _: ast::NodeId) {
-        match fk {
-            visit::FkMethod(_, _, m) => {
-                // If the method is an impl for a trait, don't doc.
-                if method_context(cx, m) == TraitImpl { return; }
+        if let visit::FkMethod(_, _, m) = fk {
+            // If the method is an impl for a trait, don't doc.
+            if method_context(cx, m) == TraitImpl { return; }
 
-                // Otherwise, doc according to privacy. This will also check
-                // doc for default methods defined on traits.
-                self.check_missing_docs_attrs(cx, Some(m.id), m.attrs.as_slice(),
-                                             m.span, "a method");
-            }
-            _ => {}
+            // Otherwise, doc according to privacy. This will also check
+            // doc for default methods defined on traits.
+            self.check_missing_docs_attrs(cx, Some(m.id), m.attrs.as_slice(),
+                                          m.span, "a method");
         }
     }
 

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -514,41 +514,33 @@ fn each_child_of_item_or_crate(intr: Rc<IdentInterner>,
         let inherent_impl_def_id = item_def_id(inherent_impl_def_id_doc,
                                                cdata);
         let items = reader::get_doc(rbml::Doc::new(cdata.data()), tag_items);
-        match maybe_find_item(inherent_impl_def_id.node, items) {
-            None => {}
-            Some(inherent_impl_doc) => {
-                let _ = reader::tagged_docs(inherent_impl_doc,
-                                            tag_item_impl_item,
-                                            |impl_item_def_id_doc| {
-                    let impl_item_def_id = item_def_id(impl_item_def_id_doc,
-                                                       cdata);
-                    match maybe_find_item(impl_item_def_id.node, items) {
-                        None => {}
-                        Some(impl_method_doc) => {
-                            match item_family(impl_method_doc) {
-                                StaticMethod => {
-                                    // Hand off the static method
-                                    // to the callback.
-                                    let static_method_name =
-                                        item_name(&*intr, impl_method_doc);
-                                    let static_method_def_like =
-                                        item_to_def_like(impl_method_doc,
-                                                         impl_item_def_id,
-                                                         cdata.cnum);
-                                    callback(static_method_def_like,
-                                             static_method_name,
-                                             item_visibility(impl_method_doc));
-                                }
-                                _ => {}
-                            }
+        if let Some(inherent_impl_doc) = maybe_find_item(inherent_impl_def_id.node, items) {
+            let _ = reader::tagged_docs(inherent_impl_doc,
+                                        tag_item_impl_item,
+                                        |impl_item_def_id_doc| {
+                let impl_item_def_id = item_def_id(impl_item_def_id_doc,
+                                                   cdata);
+                if let Some(impl_method_doc) = maybe_find_item(impl_item_def_id.node, items) {
+                    match item_family(impl_method_doc) {
+                        StaticMethod => {
+                            // Hand off the static method
+                            // to the callback.
+                            let static_method_name =
+                                item_name(&*intr, impl_method_doc);
+                            let static_method_def_like =
+                                item_to_def_like(impl_method_doc,
+                                                 impl_item_def_id,
+                                                 cdata.cnum);
+                            callback(static_method_def_like,
+                                     static_method_name,
+                                     item_visibility(impl_method_doc));
                         }
+                        _ => {}
                     }
-
-                    true
-                });
-            }
+                }
+                true
+            });
         }
-
         true
     });
 
@@ -578,17 +570,14 @@ fn each_child_of_item_or_crate(intr: Rc<IdentInterner>,
         let other_crates_items = reader::get_doc(rbml::Doc::new(crate_data.data()), tag_items);
 
         // Get the item.
-        match maybe_find_item(child_def_id.node, other_crates_items) {
-            None => {}
-            Some(child_item_doc) => {
-                // Hand off the item to the callback.
-                let def_like = item_to_def_like(child_item_doc,
-                                                child_def_id,
-                                                child_def_id.krate);
-                // These items have a public visibility because they're part of
-                // a public re-export.
-                callback(def_like, token::intern(name), ast::Public);
-            }
+        if let Some(child_item_doc) = maybe_find_item(child_def_id.node, other_crates_items) {
+            // Hand off the item to the callback.
+            let def_like = item_to_def_like(child_item_doc,
+                                            child_def_id,
+                                            child_def_id.krate);
+            // These items have a public visibility because they're part of
+            // a public re-export.
+            callback(def_like, token::intern(name), ast::Public);
         }
 
         true

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -521,21 +521,15 @@ fn each_child_of_item_or_crate(intr: Rc<IdentInterner>,
                 let impl_item_def_id = item_def_id(impl_item_def_id_doc,
                                                    cdata);
                 if let Some(impl_method_doc) = maybe_find_item(impl_item_def_id.node, items) {
-                    match item_family(impl_method_doc) {
-                        StaticMethod => {
-                            // Hand off the static method
-                            // to the callback.
-                            let static_method_name =
-                                item_name(&*intr, impl_method_doc);
-                            let static_method_def_like =
-                                item_to_def_like(impl_method_doc,
-                                                 impl_item_def_id,
-                                                 cdata.cnum);
-                            callback(static_method_def_like,
-                                     static_method_name,
-                                     item_visibility(impl_method_doc));
-                        }
-                        _ => {}
+                    if let StaticMethod = item_family(impl_method_doc) {
+                        // Hand off the static method to the callback.
+                        let static_method_name = item_name(&*intr, impl_method_doc);
+                        let static_method_def_like = item_to_def_like(impl_method_doc,
+                                                                      impl_item_def_id,
+                                                                      cdata.cnum);
+                        callback(static_method_def_like,
+                                 static_method_name,
+                                 item_visibility(impl_method_doc));
                     }
                 }
                 true

--- a/src/librustc/middle/borrowck/check_loans.rs
+++ b/src/librustc/middle/borrowck/check_loans.rs
@@ -892,14 +892,9 @@ impl<'a, 'tcx> CheckLoanCtxt<'a, 'tcx> {
             let guarantor = cmt.guarantor();
             debug!("check_for_aliasable_mutable_writes(cmt={}, guarantor={})",
                    cmt.repr(this.tcx()), guarantor.repr(this.tcx()));
-            match guarantor.cat {
-                mc::cat_deref(ref b, _, mc::BorrowedPtr(ty::MutBorrow, _)) => {
-                    // Statically prohibit writes to `&mut` when aliasable
-
-                    check_for_aliasability_violation(this, span, b.clone());
-                }
-
-                _ => {}
+            if let mc::cat_deref(ref b, _, mc::BorrowedPtr(ty::MutBorrow, _)) = guarantor.cat {
+                // Statically prohibit writes to `&mut` when aliasable
+                check_for_aliasability_violation(this, span, b.clone());
             }
 
             return true; // no errors reported
@@ -962,4 +957,3 @@ impl<'a, 'tcx> CheckLoanCtxt<'a, 'tcx> {
                     self.bccx.loan_path_to_string(loan_path)).as_slice());
     }
 }
-

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -278,11 +278,8 @@ impl<'a, 'tcx> ConstEvalVisitor<'a, 'tcx> {
 
 impl<'a, 'tcx, 'v> Visitor<'v> for ConstEvalVisitor<'a, 'tcx> {
     fn visit_ty(&mut self, t: &ast::Ty) {
-        match t.node {
-            ast::TyFixedLengthVec(_, ref expr) => {
-                check::check_const_in_type(self.tcx, &**expr, ty::mk_uint());
-            }
-            _ => {}
+        if let ast::TyFixedLengthVec(_, ref expr) = t.node {
+            check::check_const_in_type(self.tcx, &**expr, ty::mk_uint());
         }
 
         visit::walk_ty(self, t);
@@ -321,10 +318,9 @@ pub fn const_expr_to_pat(tcx: &ty::ctxt, expr: &Expr) -> P<ast::Pat> {
 
         ast::ExprCall(ref callee, ref args) => {
             let def = tcx.def_map.borrow()[callee.id].clone();
-            match tcx.def_map.borrow_mut().entry(expr.id) {
-              Vacant(entry) => { entry.set(def); }
-              _ => {}
-            };
+            if let Vacant(entry) = tcx.def_map.borrow_mut().entry(expr.id) {
+               entry.set(def);
+            }
             let path = match def {
                 def::DefStruct(def_id) => def_to_path(tcx, def_id),
                 def::DefVariant(_, variant_did, _) => def_to_path(tcx, variant_did),

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -71,12 +71,9 @@ impl<'a, 'tcx> EffectCheckVisitor<'a, 'tcx> {
         debug!("effect: checking index with base type {}",
                 ppaux::ty_to_string(self.tcx, base_type));
         match base_type.sty {
-            ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ty, ..}) => match ty.sty {
-                ty::ty_str => {
-                    span_err!(self.tcx.sess, e.span, E0134,
-                              "modification of string types is not allowed");
-                }
-                _ => {}
+            ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ty, ..}) => if ty::ty_str == ty.sty {
+                span_err!(self.tcx.sess, e.span, E0134,
+                          "modification of string types is not allowed");
             },
             ty::ty_str => {
                 span_err!(self.tcx.sess, e.span, E0135,
@@ -165,13 +162,9 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EffectCheckVisitor<'a, 'tcx> {
             ast::ExprUnary(ast::UnDeref, ref base) => {
                 let base_type = ty::node_id_to_type(self.tcx, base.id);
                 debug!("effect: unary case, base type is {}",
-                        ppaux::ty_to_string(self.tcx, base_type));
-                match base_type.sty {
-                    ty::ty_ptr(_) => {
-                        self.require_unsafe(expr.span,
-                                            "dereference of unsafe pointer")
-                    }
-                    _ => {}
+                       ppaux::ty_to_string(self.tcx, base_type));
+                if let ty::ty_ptr(_) = base_type.sty {
+                    self.require_unsafe(expr.span, "dereference of unsafe pointer")
                 }
             }
             ast::ExprAssign(ref base, _) | ast::ExprAssignOp(_, ref base, _) => {
@@ -181,14 +174,11 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EffectCheckVisitor<'a, 'tcx> {
                 self.check_str_index(&**base);
             }
             ast::ExprInlineAsm(..) => {
-                self.require_unsafe(expr.span, "use of inline assembly")
+                self.require_unsafe(expr.span, "use of inline assembly");
             }
             ast::ExprPath(..) => {
-                match ty::resolve_expr(self.tcx, expr) {
-                    def::DefStatic(_, true) => {
-                        self.require_unsafe(expr.span, "use of mutable static")
-                    }
-                    _ => {}
+                if let def::DefStatic(_, true) = ty::resolve_expr(self.tcx, expr) {
+                    self.require_unsafe(expr.span, "use of mutable static");
                 }
             }
             _ => {}

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -264,18 +264,12 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
             // functions may still participate in some form of native interface,
             // but all other rust-only interfaces can be private (they will not
             // participate in linkage after this product is produced)
-            match *node {
-                ast_map::NodeItem(item) => {
-                    match item.node {
-                        ast::ItemFn(_, _, abi, _, _) => {
-                            if abi != abi::Rust {
-                                self.reachable_symbols.insert(search_item);
-                            }
-                        }
-                        _ => {}
+            if let ast_map::NodeItem(item) = *node {
+                if let ast::ItemFn(_, _, abi, _, _) = item.node {
+                    if abi != abi::Rust {
+                        self.reachable_symbols.insert(search_item);
                     }
                 }
-                _ => {}
             }
         } else {
             // If we are building a library, then reachable symbols will

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -69,24 +69,18 @@ impl<'v> Visitor<'v> for Annotator {
     fn visit_item(&mut self, i: &Item) {
         self.annotate(i.id, &i.attrs, |v| visit::walk_item(v, i));
 
-        match i.node {
-            ast::ItemStruct(ref sd, _) => {
-                sd.ctor_id.map(|id| {
-                    self.annotate(id, &i.attrs, |_| {})
-                });
-            }
-            _ => {}
+        if let ast::ItemStruct(ref sd, _) = i.node {
+            sd.ctor_id.map(|id| {
+                self.annotate(id, &i.attrs, |_| {})
+            });
         }
     }
 
     fn visit_fn(&mut self, fk: FnKind<'v>, _: &'v FnDecl,
                 _: &'v Block, _: Span, _: NodeId) {
-        match fk {
-            FkMethod(_, _, meth) => {
-                // Methods are not already annotated, so we annotate it
-                self.annotate(meth.id, &meth.attrs, |_| {});
-            }
-            _ => {}
+        if let FkMethod(_, _, meth) = fk {
+            // Methods are not already annotated, so we annotate it
+            self.annotate(meth.id, &meth.attrs, |_| {});
         }
         // Items defined in a function body have no reason to have
         // a stability attribute, so we don't recurse.

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -211,9 +211,8 @@ fn push_obligations_for_param_bounds<'tcx>(
                                                       builtin_bound,
                                                       recursion_depth,
                                                       param_ty);
-        match obligation {
-            Ok(ob) => obligations.push(space, ob),
-            _ => {}
+        if let Ok(ob) = obligation {
+            obligations.push(space, ob);
         }
     }
 
@@ -383,4 +382,3 @@ impl<'tcx> Repr<'tcx> for ty::type_err<'tcx> {
         ty::type_err_to_str(tcx, self)
     }
 }
-

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1893,11 +1893,8 @@ impl FlagComputation {
             }
 
             &ty_closure(ref f) => {
-                match f.store {
-                    RegionTraitStore(r, _) => {
-                        self.add_region(r);
-                    }
-                    _ => {}
+                if let RegionTraitStore(r, _) = f.store {
+                    self.add_region(r);
                 }
                 self.add_fn_sig(&f.sig);
                 self.add_bounds(&f.bounds);
@@ -3664,9 +3661,8 @@ pub fn adjust_ty<'tcx>(cx: &ctxt<'tcx>,
                        method_type: |typeck::MethodCall| -> Option<Ty<'tcx>>)
                        -> Ty<'tcx> {
 
-    match unadjusted_ty.sty {
-        ty_err => return unadjusted_ty,
-        _ => {}
+    if let ty_err = unadjusted_ty.sty {
+        return unadjusted_ty;
     }
 
     return match adjustment {

--- a/src/librustc/middle/typeck/check/vtable.rs
+++ b/src/librustc/middle/typeck/check/vtable.rs
@@ -208,15 +208,13 @@ pub fn check_object_safety<'tcx>(tcx: &ty::ctxt<'tcx>,
         };
         let ref sig = method.fty.sig;
         for &input_ty in sig.inputs[1..].iter() {
-            match check_for_self_ty(input_ty) {
-                Some(msg) => msgs.push(msg),
-                _ => {}
+            if let Some(msg) = check_for_self_ty(input_ty) {
+                msgs.push(msg);
             }
         }
         if let ty::FnConverging(result_type) = sig.output {
-            match check_for_self_ty(result_type) {
-                Some(msg) => msgs.push(msg),
-                _ => {}
+            if let Some(msg) = check_for_self_ty(result_type) {
+                msgs.push(msg);
             }
         }
 
@@ -290,10 +288,9 @@ pub fn register_object_cast_obligations<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                                      traits::ObjectCastObligation(object_trait_ty)),
                 referent_ty,
                 builtin_bound);
-            match obligation {
-                Ok(obligation) => fcx.register_obligation(obligation),
-                _ => {}
-            }
+        if let Ok(obligation) = obligation {
+            fcx.register_obligation(obligation);
+        }
     }
 
     object_trait_ref

--- a/src/librustc/middle/typeck/check/wf.rs
+++ b/src/librustc/middle/typeck/check/wf.rs
@@ -127,9 +127,8 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
                                                                               cause,
                                                                               field.ty,
                                                                               ty::BoundSized);
-                        match obligation {
-                            Ok(obligation) => fcx.register_obligation(obligation),
-                            _ => {}
+                        if let Ok(obligation) = obligation {
+                            fcx.register_obligation(obligation);
                         }
                     }
                 }
@@ -233,9 +232,8 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
                                                                       cause,
                                                                       trait_ref.self_ty(),
                                                                       builtin_bound);
-                match obligation {
-                    Ok (obligation) => fcx.register_obligation(obligation),
-                    _ => {}
+                if let Ok(obligation) = obligation {
+                    fcx.register_obligation(obligation);
                 }
             }
             for trait_bound in trait_def.bounds.trait_bounds.iter() {
@@ -471,9 +469,8 @@ fn check_struct_safe_for_destructor<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                                                               cause,
                                                               self_ty,
                                                               ty::BoundSend);
-        match obligation {
-            Ok(obligation) => fcx.register_obligation(obligation),
-            _ => {}
+        if let Ok(obligation) = obligation {
+            fcx.register_obligation(obligation);
         }
     } else {
         span_err!(fcx.tcx().sess, span, E0141,

--- a/src/librustc/plugin/build.rs
+++ b/src/librustc/plugin/build.rs
@@ -23,14 +23,11 @@ struct RegistrarFinder {
 
 impl<'v> Visitor<'v> for RegistrarFinder {
     fn visit_item(&mut self, item: &ast::Item) {
-        match item.node {
-            ast::ItemFn(..) => {
-                if attr::contains_name(item.attrs.as_slice(),
-                                       "plugin_registrar") {
-                    self.registrars.push((item.id, item.span));
-                }
+        if let ast::ItemFn(..) = item.node {
+            if attr::contains_name(item.attrs.as_slice(),
+                                   "plugin_registrar") {
+                self.registrars.push((item.id, item.span));
             }
-            _ => {}
         }
 
         visit::walk_item(self, item);

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -1073,16 +1073,12 @@ impl<'l, 'tcx, 'v> Visitor<'v> for DxrVisitor<'l, 'tcx> {
     fn visit_generics(&mut self, generics: &ast::Generics) {
         for param in generics.ty_params.iter() {
             for bound in param.bounds.iter() {
-                match *bound {
-                    ast::TraitTyParamBound(ref trait_ref) => {
-                        self.process_trait_ref(&trait_ref.trait_ref, None);
-                    }
-                    _ => {}
+                if let ast::TraitTyParamBound(ref trait_ref) = *bound {
+                    self.process_trait_ref(&trait_ref.trait_ref, None);
                 }
             }
-            match param.default {
-                Some(ref ty) => self.visit_ty(&**ty),
-                None => {}
+            if let Some(ref ty) = param.default {
+                self.visit_ty(&**ty);
             }
         }
     }

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2212,21 +2212,18 @@ pub fn update_linkage(ccx: &CrateContext,
         OriginalTranslation => {},
     }
 
-    match id {
-        Some(id) => {
-            let item = ccx.tcx().map.get(id);
-            if let ast_map::NodeItem(i) = item {
-                if let Some(name) =  attr::first_attr_value_str_by_name(i.attrs[], "linkage") {
-                    if let Some(linkage) = llvm_linkage_by_name(name.get()) {
-                        llvm::SetLinkage(llval, linkage);
-                    } else {
-                        ccx.sess().span_fatal(i.span, "invalid linkage specified");
-                    }
-                    return;
+    if let Some(id) = id {
+        let item = ccx.tcx().map.get(id);
+        if let ast_map::NodeItem(i) = item {
+            if let Some(name) = attr::first_attr_value_str_by_name(i.attrs[], "linkage") {
+                if let Some(linkage) = llvm_linkage_by_name(name.get()) {
+                    llvm::SetLinkage(llval, linkage);
+                } else {
+                    ccx.sess().span_fatal(i.span, "invalid linkage specified");
                 }
+                return;
             }
         }
-        _ => {}
     }
 
     match id {
@@ -2492,11 +2489,8 @@ pub fn get_fn_llvm_attributes<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_ty: Ty<
                 _ => {}
             }
 
-            match ret_ty.sty {
-                ty::ty_bool => {
-                    attrs.ret(llvm::ZExtAttribute);
-                }
-                _ => {}
+            if let ty::ty_bool = ret_ty.sty {
+                attrs.ret(llvm::ZExtAttribute);
             }
         }
     }
@@ -2543,11 +2537,8 @@ pub fn get_fn_llvm_attributes<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_ty: Ty<
                     attrs.arg(idx, llvm::ReadOnlyAttribute);
                 }
 
-                match b {
-                    ReLateBound(_, BrAnon(_)) => {
-                        attrs.arg(idx, llvm::NoCaptureAttribute);
-                    }
-                    _ => {}
+                if let ReLateBound(_, BrAnon(_)) = b {
+                    attrs.arg(idx, llvm::NoCaptureAttribute);
                 }
             }
 

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -92,11 +92,8 @@ fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
     debug!("callee::trans(expr={})", expr.repr(bcx.tcx()));
 
     // pick out special kinds of expressions that can be called:
-    match expr.node {
-        ast::ExprPath(_) => {
-            return trans_def(bcx, bcx.def(expr.id), expr);
-        }
-        _ => {}
+    if let ast::ExprPath(_) = expr.node {
+        return trans_def(bcx, bcx.def(expr.id), expr);
     }
 
     // any other expressions are closures:

--- a/src/librustc_trans/trans/cleanup.rs
+++ b/src/librustc_trans/trans/cleanup.rs
@@ -236,11 +236,8 @@ impl<'blk, 'tcx> CleanupMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx> {
     /// Returns the id of the top-most loop scope
     fn top_loop_scope(&self) -> ast::NodeId {
         for scope in self.scopes.borrow().iter().rev() {
-            match scope.kind {
-                LoopScopeKind(id, _) => {
-                    return id;
-                }
-                _ => {}
+            if let LoopScopeKind(id, _) = scope.kind {
+                return id;
             }
         }
         self.ccx.sess().bug("no loop scope found");

--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -171,9 +171,8 @@ pub fn get_const_val(cx: &CrateContext,
             def_id = inline::maybe_instantiate_inline(cx, def_id);
         }
 
-        match cx.tcx().map.expect_item(def_id.node).node {
-            ast::ItemConst(..) => { base::get_item_val(cx, def_id.node); }
-            _ => {}
+        if let ast::ItemConst(..) = cx.tcx().map.expect_item(def_id.node).node {
+            base::get_item_val(cx, def_id.node);
         }
     }
 
@@ -546,12 +545,9 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr) -> ValueRef {
                   }
               }
               let opt_def = cx.tcx().def_map.borrow().get(&cur.id).cloned();
-              match opt_def {
-                  Some(def::DefStatic(def_id, _)) => {
-                      let ty = ty::expr_ty(cx.tcx(), e);
-                      return get_static_val(cx, def_id, ty);
-                  }
-                  _ => {}
+              if let Some(def::DefStatic(def_id, _)) = opt_def {
+                  let ty = ty::expr_ty(cx.tcx(), e);
+                  return get_static_val(cx, def_id, ty);
               }
 
               // If this isn't the address of a static, then keep going through

--- a/src/librustc_trans/trans/context.rs
+++ b/src/librustc_trans/trans/context.rs
@@ -519,9 +519,8 @@ impl<'b, 'tcx> CrateContext<'b, 'tcx> {
     }
 
     pub fn get_intrinsic(&self, key: & &'static str) -> ValueRef {
-        match self.intrinsics().borrow().get(key).cloned() {
-            Some(v) => return v,
-            _ => {}
+        if let Some(v) = self.intrinsics().borrow().get(key).cloned() {
+            return v;
         }
         match declare_intrinsic(self, key) {
             Some(v) => return v,

--- a/src/librustc_trans/trans/controlflow.rs
+++ b/src/librustc_trans/trans/controlflow.rs
@@ -465,17 +465,14 @@ pub fn trans_ret<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         }
         _ => expr::Ignore,
     };
-    match e {
-        Some(x) => {
-            bcx = expr::trans_into(bcx, &*x, dest);
-            match dest {
-                expr::SaveIn(slot) if fcx.needs_ret_allocas => {
-                    Store(bcx, slot, fcx.llretslotptr.get().unwrap());
-                }
-                _ => {}
+    if let Some(x) = e {
+        bcx = expr::trans_into(bcx, &*x, dest);
+        match dest {
+            expr::SaveIn(slot) if fcx.needs_ret_allocas => {
+                Store(bcx, slot, fcx.llretslotptr.get().unwrap());
             }
+            _ => {}
         }
-        _ => {}
     }
     let cleanup_llbb = fcx.return_exit_block();
     Br(bcx, cleanup_llbb);

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -209,14 +209,11 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
             // (You might think there is a more elegant way to do this than a
             // use_autoref bool, but then you remember that the borrow checker exists).
-            match (use_autoref, &adj.autoref) {
-                (true, &Some(ref a)) => {
-                    datum = unpack_datum!(bcx, apply_autoref(a,
-                                                             bcx,
-                                                             expr,
-                                                             datum));
-                }
-                _ => {}
+            if let (true, &Some(ref a)) = (use_autoref, &adj.autoref) {
+                datum = unpack_datum!(bcx, apply_autoref(a,
+                                                         bcx,
+                                                         expr,
+                                                         datum));
             }
         }
     }

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -355,9 +355,8 @@ pub fn trans_native_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         // skip padding
         if arg_ty.pad.is_some() { arg_idx += 1; }
 
-        match arg_ty.attr {
-            Some(attr) => { attrs.arg(arg_idx, attr); },
-            _ => {}
+        if let Some(attr) = arg_ty.attr {
+            attrs.arg(arg_idx, attr);
         }
 
         arg_idx += 1;
@@ -429,22 +428,19 @@ pub fn trans_foreign_mod(ccx: &CrateContext, foreign_mod: &ast::ForeignMod) {
     for foreign_item in foreign_mod.items.iter() {
         let lname = link_name(&**foreign_item);
 
-        match foreign_item.node {
-            ast::ForeignItemFn(..) => {
-                match foreign_mod.abi {
-                    Rust | RustIntrinsic => {}
-                    abi => {
-                        let ty = ty::node_id_to_type(ccx.tcx(), foreign_item.id);
-                        register_foreign_item_fn(ccx, abi, ty,
-                                                 lname.get().as_slice());
-                        // Unlike for other items, we shouldn't call
-                        // `base::update_linkage` here.  Foreign items have
-                        // special linkage requirements, which are handled
-                        // inside `foreign::register_*`.
-                    }
+        if let ast::ForeignItemFn(..) = foreign_item.node {
+            match foreign_mod.abi {
+                Rust | RustIntrinsic => {}
+                abi => {
+                    let ty = ty::node_id_to_type(ccx.tcx(), foreign_item.id);
+                    register_foreign_item_fn(ccx, abi, ty,
+                                             lname.get().as_slice());
+                    // Unlike for other items, we shouldn't call
+                    // `base::update_linkage` here.  Foreign items have
+                    // special linkage requirements, which are handled
+                    // inside `foreign::register_*`.
                 }
             }
-            _ => {}
         }
 
         ccx.item_symbols().borrow_mut().insert(foreign_item.id,

--- a/src/librustc_trans/trans/monomorphize.rs
+++ b/src/librustc_trans/trans/monomorphize.rs
@@ -84,14 +84,11 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                     fn_id)
         });
 
-    match map_node {
-        ast_map::NodeForeignItem(_) => {
-            if ccx.tcx().map.get_foreign_abi(fn_id.node) != abi::RustIntrinsic {
-                // Foreign externs don't have to be monomorphized.
-                return (get_item_val(ccx, fn_id.node), true);
-            }
+    if let ast_map::NodeForeignItem(_) = map_node {
+        if ccx.tcx().map.get_foreign_abi(fn_id.node) != abi::RustIntrinsic {
+            // Foreign externs don't have to be monomorphized.
+            return (get_item_val(ccx, fn_id.node), true);
         }
-        _ => {}
     }
 
     debug!("monomorphic_fn about to subst into {}", llitem_ty.repr(ccx.tcx()));

--- a/src/librustc_trans/trans/tvec.rs
+++ b/src/librustc_trans/trans/tvec.rs
@@ -151,21 +151,15 @@ pub fn trans_slice_vec<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let vec_ty = node_id_type(bcx, slice_expr.id);
 
     // Handle the "..." case (returns a slice since strings are always unsized):
-    match content_expr.node {
-        ast::ExprLit(ref lit) => {
-            match lit.node {
-                ast::LitStr(ref s, _) => {
-                    let scratch = rvalue_scratch_datum(bcx, vec_ty, "");
-                    bcx = trans_lit_str(bcx,
-                                        content_expr,
-                                        s.clone(),
-                                        SaveIn(scratch.val));
-                    return DatumBlock::new(bcx, scratch.to_expr_datum());
-                }
-                _ => {}
-            }
+    if let ast::ExprLit(ref lit) = content_expr.node {
+        if let ast::LitStr(ref s, _) = lit.node {
+            let scratch = rvalue_scratch_datum(bcx, vec_ty, "");
+            bcx = trans_lit_str(bcx,
+                                content_expr,
+                                s.clone(),
+                                SaveIn(scratch.val));
+            return DatumBlock::new(bcx, scratch.to_expr_datum());
         }
-        _ => {}
     }
 
     // Handle the &[...] case:

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2200,12 +2200,9 @@ fn register_def(cx: &DocContext, def: def::Def) -> ast::DefId {
         None => return did
     };
     inline::record_extern_fqn(cx, did, kind);
-    match kind {
-        TypeTrait => {
-            let t = inline::build_external_trait(cx, tcx, did);
-            cx.external_traits.borrow_mut().as_mut().unwrap().insert(did, t);
-        }
-        _ => {}
+    if let TypeTrait = kind {
+        let t = inline::build_external_trait(cx, tcx, did);
+        cx.external_traits.borrow_mut().as_mut().unwrap().insert(did, t);
     }
     return did;
 }

--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -776,11 +776,8 @@ impl<'ast> Visitor<'ast> for NodeCollector<'ast> {
             }
             ItemTrait(_, _, ref bounds, ref trait_items) => {
                 for b in bounds.iter() {
-                    match *b {
-                        TraitTyParamBound(ref t) => {
-                            self.insert(t.trait_ref.ref_id, NodeItem(i));
-                        }
-                        _ => {}
+                    if let TraitTyParamBound(ref t) = *b {
+                        self.insert(t.trait_ref.ref_id, NodeItem(i));
                     }
                 }
 

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -412,13 +412,10 @@ impl<'a, 'v, O: IdVisitingOperation> Visitor<'v> for IdVisitor<'a, O> {
         }
 
         self.operation.visit_id(item.id);
-        match item.node {
-            ItemEnum(ref enum_definition, _) => {
-                for variant in enum_definition.variants.iter() {
-                    self.operation.visit_id(variant.node.id)
-                }
+        if let ItemEnum(ref enum_definition, _) = item.node {
+            for variant in enum_definition.variants.iter() {
+                self.operation.visit_id(variant.node.id)
             }
-            _ => {}
         }
 
         visit::walk_item(self, item);
@@ -453,9 +450,8 @@ impl<'a, 'v, O: IdVisitingOperation> Visitor<'v> for IdVisitor<'a, O> {
 
     fn visit_ty(&mut self, typ: &Ty) {
         self.operation.visit_id(typ.id);
-        match typ.node {
-            TyPath(_, id) => self.operation.visit_id(id),
-            _ => {}
+        if let TyPath(_, id) = typ.node {
+            self.operation.visit_id(id);
         }
         visit::walk_ty(self, typ)
     }
@@ -500,9 +496,8 @@ impl<'a, 'v, O: IdVisitingOperation> Visitor<'v> for IdVisitor<'a, O> {
                        span);
 
         if !self.pass_through_items {
-            match function_kind {
-                visit::FkMethod(..) => self.visited_outermost = false,
-                _ => {}
+            if let visit::FkMethod(..) = function_kind {
+                self.visited_outermost = false;
             }
         }
     }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -151,13 +151,10 @@ impl<'a, 'v> Visitor<'v> for Context<'a> {
     fn visit_view_item(&mut self, i: &ast::ViewItem) {
         match i.node {
             ast::ViewItemUse(ref path) => {
-                match path.node {
-                    ast::ViewPathGlob(..) => {
-                        self.gate_feature("globs", path.span,
-                                          "glob import statements are \
-                                           experimental and possibly buggy");
-                    }
-                    _ => {}
+                if let ast::ViewPathGlob(..) = path.node {
+                    self.gate_feature("globs", path.span,
+                                      "glob import statements are \
+                                       experimental and possibly buggy");
                 }
             }
             ast::ViewItemExternCrate(..) => {
@@ -295,13 +292,10 @@ impl<'a, 'v> Visitor<'v> for Context<'a> {
     }
 
     fn visit_ty(&mut self, t: &ast::Ty) {
-        match t.node {
-            ast::TyClosure(ref closure) => {
-                // this used to be blocked by a feature gate, but it should just
-                // be plain impossible right now
-                assert!(closure.onceness != ast::Once);
-            },
-            _ => {}
+        if let ast::TyClosure(ref closure) =  t.node {
+            // this used to be blocked by a feature gate, but it should just
+            // be plain impossible right now
+            assert!(closure.onceness != ast::Once);
         }
 
         visit::walk_ty(self, t);
@@ -465,4 +459,3 @@ pub fn check_crate(span_handler: &SpanHandler, krate: &ast::Crate) -> (Features,
     },
     unknown_features)
 }
-

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -178,11 +178,8 @@ macro_rules! maybe_whole (
                 }
                 _ => None
             };
-            match found {
-                Some(token::Interpolated(token::$constructor(x))) => {
-                    return x.clone()
-                }
-                _ => {}
+            if let Some(token::Interpolated(token::$constructor(x))) = found {
+                return x.clone();
             }
         }
     );
@@ -194,11 +191,8 @@ macro_rules! maybe_whole (
                 }
                 _ => None
             };
-            match found {
-                Some(token::Interpolated(token::$constructor(x))) => {
-                    return x
-                }
-                _ => {}
+            if let Some(token::Interpolated(token::$constructor(x))) = found {
+                return x;
             }
         }
     );
@@ -210,11 +204,8 @@ macro_rules! maybe_whole (
                 }
                 _ => None
             };
-            match found {
-                Some(token::Interpolated(token::$constructor(x))) => {
-                    return (*x).clone()
-                }
-                _ => {}
+            if let Some(token::Interpolated(token::$constructor(x))) = found {
+                return (*x).clone();
             }
         }
     );
@@ -226,11 +217,8 @@ macro_rules! maybe_whole (
                 }
                 _ => None
             };
-            match found {
-                Some(token::Interpolated(token::$constructor(x))) => {
-                    return Some(x.clone()),
-                }
-                _ => {}
+            if let Some(token::Interpolated(token::$constructor(x))) = found {
+                return Some(x.clone());
             }
         }
     );
@@ -242,11 +230,8 @@ macro_rules! maybe_whole (
                 }
                 _ => None
             };
-            match found {
-                Some(token::Interpolated(token::$constructor(x))) => {
-                    return IoviItem(x.clone())
-                }
-                _ => {}
+            if let Some(token::Interpolated(token::$constructor(x))) = found {
+                return IoviItem(x.clone());
             }
         }
     );
@@ -258,11 +243,8 @@ macro_rules! maybe_whole (
                 }
                 _ => None
             };
-            match found {
-                Some(token::Interpolated(token::$constructor(x))) => {
-                    return (Vec::new(), x)
-                }
-                _ => {}
+            if let Some(token::Interpolated(token::$constructor(x))) = found {
+                return (Vec::new(), x);
             }
         }
     )
@@ -469,15 +451,11 @@ impl<'a> Parser<'a> {
     /// from anticipated input errors, discarding erroneous characters.
     pub fn commit_expr(&mut self, e: &Expr, edible: &[token::Token], inedible: &[token::Token]) {
         debug!("commit_expr {}", e);
-        match e.node {
-            ExprPath(..) => {
-                // might be unit-struct construction; check for recoverableinput error.
-                let mut expected = edible.iter().map(|x| x.clone()).collect::<Vec<_>>();
-                expected.push_all(inedible);
-                self.check_for_erroneous_unit_struct_expecting(
-                    expected.as_slice());
-            }
-            _ => {}
+        if let ExprPath(..) = e.node {
+            // might be unit-struct construction; check for recoverableinput error.
+            let mut expected = edible.iter().map(|x| x.clone()).collect::<Vec<_>>();
+            expected.push_all(inedible);
+            self.check_for_erroneous_unit_struct_expecting(expected.as_slice());
         }
         self.expect_one_of(edible, inedible)
     }
@@ -1764,11 +1742,8 @@ impl<'a> Parser<'a> {
             token::Interpolated(token::NtPath(_)) => Some(self.bump_and_get()),
             _ => None,
         };
-        match found {
-            Some(token::Interpolated(token::NtPath(box path))) => {
-                return path;
-            }
-            _ => {}
+        if let Some(token::Interpolated(token::NtPath(box path))) = found {
+            return path;
         }
 
         let lo = self.span.lo;

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -969,14 +969,11 @@ impl<'a> State<'a> {
                                                     "trait").as_slice()));
                 try!(self.print_ident(item.ident));
                 try!(self.print_generics(generics));
-                match unbound {
-                    &Some(ref tref) => {
-                        try!(space(&mut self.s));
-                        try!(self.word_space("for"));
-                        try!(self.print_trait_ref(tref));
-                        try!(word(&mut self.s, "?"));
-                    }
-                    _ => {}
+                if let &Some(ref tref) = unbound {
+                    try!(space(&mut self.s));
+                    try!(self.word_space("for"));
+                    try!(self.print_trait_ref(tref));
+                    try!(word(&mut self.s, "?"));
                 }
                 try!(self.print_bounds(":", bounds.as_slice()));
                 try!(self.print_where_clause(generics));
@@ -1761,16 +1758,14 @@ impl<'a> State<'a> {
                         try!(space(&mut self.s));
                     }
                 }
-                match start {
-                    &Some(ref e) => try!(self.print_expr(&**e)),
-                    _ => {}
+                if let &Some(ref e) = start {
+                    try!(self.print_expr(&**e));
                 }
                 if start.is_some() || end.is_some() {
                     try!(word(&mut self.s, ".."));
                 }
-                match end {
-                    &Some(ref e) => try!(self.print_expr(&**e)),
-                    _ => {}
+                if let &Some(ref e) = end {
+                    try!(self.print_expr(&**e));
                 }
                 try!(word(&mut self.s, "]"));
             }
@@ -1875,13 +1870,10 @@ impl<'a> State<'a> {
                 try!(self.ibox(indent_unit));
                 try!(self.print_local_decl(&**loc));
                 try!(self.end());
-                match loc.init {
-                    Some(ref init) => {
-                        try!(self.nbsp());
-                        try!(self.word_space("="));
-                        try!(self.print_expr(&**init));
-                    }
-                    _ => {}
+                if let Some(ref init) = loc.init {
+                    try!(self.nbsp());
+                    try!(self.word_space("="));
+                    try!(self.print_expr(&**init));
                 }
                 self.end()
             }
@@ -2404,12 +2396,9 @@ impl<'a> State<'a> {
     }
 
     pub fn print_ty_param(&mut self, param: &ast::TyParam) -> IoResult<()> {
-        match param.unbound {
-            Some(ref tref) => {
-                try!(self.print_trait_ref(tref));
-                try!(self.word_space("?"));
-            }
-            _ => {}
+        if let Some(ref tref) = param.unbound {
+            try!(self.print_trait_ref(tref));
+            try!(self.word_space("?"));
         }
         try!(self.print_ident(param.ident));
         try!(self.print_bounds(":", param.bounds.as_slice()));

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -671,11 +671,8 @@ pub fn walk_struct_def<'v, V: Visitor<'v>>(visitor: &mut V,
 
 pub fn walk_struct_field<'v, V: Visitor<'v>>(visitor: &mut V,
                                              struct_field: &'v StructField) {
-    match struct_field.node.kind {
-        NamedField(name, _) => {
-            visitor.visit_ident(struct_field.span, name)
-        }
-        _ => {}
+    if let NamedField(name, _) = struct_field.node.kind {
+        visitor.visit_ident(struct_field.span, name);
     }
 
     visitor.visit_ty(&*struct_field.node.ty);


### PR DESCRIPTION
No semantic changes, no enabling `if let` where it wasn't already enabled.
