### PR TITLE
syntax: Make `asm!` clobbers a proper vector.

### DIFF
--- a/src/librustc_trans/trans/asm.rs
+++ b/src/librustc_trans/trans/asm.rs
@@ -85,11 +85,18 @@ pub fn trans_inline_asm<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, ia: &ast::InlineAsm)
                                     .connect(",")
                                     .as_slice());
 
-    let mut clobbers = get_clobbers();
-    if !ia.clobbers.get().is_empty() && !clobbers.is_empty() {
-        clobbers = format!("{},{}", ia.clobbers.get(), clobbers);
-    } else {
-        clobbers.push_str(ia.clobbers.get());
+    let mut clobbers =
+        String::from_str(ia.clobbers.iter()
+                                    .map(|s| format!("~{{{}}}", s.get()))
+                                    .collect::<Vec<String>>()
+                                    .connect(",")
+                                    .as_slice());
+    let more_clobbers = get_clobbers();
+    if !more_clobbers.is_empty() {
+        if !clobbers.is_empty() {
+            clobbers.push(',');
+        }
+        clobbers.push_str(more_clobbers.as_slice());
     }
 
     // Add the clobbers to our constraints list

--- a/src/librustc_trans/trans/asm.rs
+++ b/src/librustc_trans/trans/asm.rs
@@ -77,20 +77,16 @@ pub fn trans_inline_asm<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, ia: &ast::InlineAsm)
     // no failure occurred preparing operands, no need to cleanup
     fcx.pop_custom_cleanup_scope(temp_scope);
 
-    let mut constraints =
-        String::from_str(constraints.iter()
-                                    .map(|s| s.get().to_string())
-                                    .chain(ext_constraints.into_iter())
-                                    .collect::<Vec<String>>()
-                                    .connect(",")
-                                    .as_slice());
+    let mut constraints = constraints.iter()
+                                     .map(|s| s.get().to_string())
+                                     .chain(ext_constraints.into_iter())
+                                     .collect::<Vec<String>>()
+                                     .connect(",");
 
-    let mut clobbers =
-        String::from_str(ia.clobbers.iter()
-                                    .map(|s| format!("~{{{}}}", s.get()))
-                                    .collect::<Vec<String>>()
-                                    .connect(",")
-                                    .as_slice());
+    let mut clobbers = ia.clobbers.iter()
+                                  .map(|s| format!("~{{{}}}", s.get()))
+                                  .collect::<Vec<String>>()
+                                  .connect(",");
     let more_clobbers = get_clobbers();
     if !more_clobbers.is_empty() {
         if !clobbers.is_empty() {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1177,7 +1177,7 @@ pub struct InlineAsm {
     pub asm_str_style: StrStyle,
     pub outputs: Vec<(InternedString, P<Expr>, bool)>,
     pub inputs: Vec<(InternedString, P<Expr>)>,
-    pub clobbers: InternedString,
+    pub clobbers: Vec<InternedString>,
     pub volatile: bool,
     pub alignstack: bool,
     pub dialect: AsmDialect,

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -53,7 +53,7 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
     let mut asm_str_style = None;
     let mut outputs = Vec::new();
     let mut inputs = Vec::new();
-    let mut cons = "".to_string();
+    let mut clobs = Vec::new();
     let mut volatile = false;
     let mut alignstack = false;
     let mut dialect = ast::AsmAtt;
@@ -138,7 +138,6 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                 }
             }
             Clobbers => {
-                let mut clobs = Vec::new();
                 while p.token != token::Eof &&
                       p.token != token::Colon &&
                       p.token != token::ModSep {
@@ -148,15 +147,12 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                     }
 
                     let (s, _str_style) = p.parse_str();
-                    let clob = format!("~{{{}}}", s);
-                    clobs.push(clob);
 
                     if OPTIONS.iter().any(|opt| s.equiv(opt)) {
                         cx.span_warn(p.last_span, "expected a clobber, found an option");
                     }
+                    clobs.push(s);
                 }
-
-                cons = clobs.connect(",");
             }
             Options => {
                 let (option, _str_style) = p.parse_str();
@@ -216,7 +212,7 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
             asm_str_style: asm_str_style.unwrap(),
             outputs: outputs,
             inputs: inputs,
-            clobbers: token::intern_and_get_ident(cons.as_slice()),
+            clobbers: clobs,
             volatile: volatile,
             alignstack: alignstack,
             dialect: dialect,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1839,7 +1839,11 @@ impl<'a> State<'a> {
                 try!(space(&mut self.s));
                 try!(self.word_space(":"));
 
-                try!(self.print_string(a.clobbers.get(), ast::CookedStr));
+                try!(self.commasep(Inconsistent, a.clobbers.as_slice(),
+                                   |s, co| {
+                    try!(s.print_string(co.get(), ast::CookedStr));
+                    Ok(())
+                }));
                 try!(self.pclose());
             }
             ast::ExprMac(ref m) => try!(self.print_mac(m)),

--- a/src/test/pretty/asm-clobbers.rs
+++ b/src/test/pretty/asm-clobbers.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(asm)]
+
+pub fn main() { unsafe { asm!("" : : : "hello", "world") }; }
+


### PR DESCRIPTION
I.e. we should not prematurely build operand constraints at the expansion time. Otherwise `--pretty expanded` diverges:

```
$ cat t.rs
#![feature(asm)]

pub fn main() { unsafe { asm!("" : : : "hello", "world") }; }

$ rustc t.rs --pretty
#![feature(asm)]

pub fn main() { unsafe { asm!("" : : : "hello" , "world") }; }

$ rustc t.rs --pretty expanded
#![feature(asm)]
#![feature(phase)]
#![no_std]
#![feature(globs)]
#[phase(plugin, link)]
extern crate "std" as std;
#[prelude_import]
use std::prelude::*;

pub fn main() { unsafe { asm!("":  :  : "~{hello},~{world}") }; }
```

(The last code _does_ compile, but won't do the expected thing.)
