### PR TITLE
Allow trailing commas in array patterns and attributes

### DIFF
--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -212,7 +212,7 @@ impl<'a> ParserAttr for Parser<'a> {
     fn parse_meta_seq(&mut self) -> Vec<P<ast::MetaItem>> {
         self.parse_seq(&token::OpenDelim(token::Paren),
                        &token::CloseDelim(token::Paren),
-                       seq_sep_trailing_disallowed(token::Comma),
+                       seq_sep_trailing_allowed(token::Comma),
                        |p| p.parse_meta_item()).node
     }
 

--- a/src/libsyntax/parse/common.rs
+++ b/src/libsyntax/parse/common.rs
@@ -19,18 +19,13 @@ pub struct SeqSep {
     pub trailing_sep_allowed: bool
 }
 
-pub fn seq_sep_trailing_disallowed(t: token::Token) -> SeqSep {
-    SeqSep {
-        sep: Some(t),
-        trailing_sep_allowed: false,
-    }
-}
 pub fn seq_sep_trailing_allowed(t: token::Token) -> SeqSep {
     SeqSep {
         sep: Some(t),
         trailing_sep_allowed: true,
     }
 }
+
 pub fn seq_sep_none() -> SeqSep {
     SeqSep {
         sep: None,

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3129,6 +3129,11 @@ impl<'a> Parser<'a> {
                 first = false;
             } else {
                 self.expect(&token::Comma);
+
+                if self.token == token::CloseDelim(token::Bracket)
+                        && (before_slice || after.len() != 0) {
+                    break
+                }
             }
 
             if before_slice {

--- a/src/test/compile-fail/trailing-comma-array-repeat.rs
+++ b/src/test/compile-fail/trailing-comma-array-repeat.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let [_, ..,] = [(), ()]; //~ ERROR unexpected token: `]`
+}

--- a/src/test/run-pass/trailing-comma.rs
+++ b/src/test/run-pass/trailing-comma.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(advanced_slice_patterns,)]
+
 fn f<T,>(_: T,) {}
 
 struct Foo<T,>;
@@ -24,9 +26,13 @@ enum Baz {
     Qux(int,),
 }
 
+#[allow(unused,)]
 pub fn main() {
     f::<int,>(0i,);
     let (_, _,) = (1i, 1i,);
+    let [_, _,] = [1i, 1,];
+    let [_, _, .., _,] = [1i, 1, 1, 1,];
+    let [_, _, _.., _,] = [1i, 1, 1, 1,];
 
     let x: Foo<int,> = Foo::<int,>;
 


### PR DESCRIPTION
The only other place I know of that doesn’t allow trailing commas is closure types (#19414), and those are a bit tricky to fix (I suspect it might be impossible without infinite lookahead) so I didn’t implement that in this patch. There are other issues surrounding closure type parsing anyway, in particular #19410.
