### PR TITLE
Adjust some error messages to start with a lowercase letter and not finish with a full stop

### DIFF
--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -3239,7 +3239,7 @@ impl<'a> Resolver<'a> {
                                             segment_name),
                         }
                     } else {
-                        format!("Could not find `{}` in `{}`.",
+                        format!("Could not find `{}` in `{}`",
                                 segment_name,
                                 module_name)
                     };
@@ -4744,7 +4744,7 @@ impl<'a> Resolver<'a> {
                         Some(&DefMod(_)) => {
                             self.resolve_error(path.span, "inherent implementations are not \
                                                            allowed for types not defined in \
-                                                           the current module.");
+                                                           the current module");
                         }
                         _ => {}
                     }
@@ -5843,12 +5843,12 @@ impl<'a> Resolver<'a> {
                                     };
 
                                     if msg.len() > 0 {
-                                        msg = format!(" Did you mean {}?", msg)
+                                        msg = format!(". Did you mean {}?", msg)
                                     }
 
                                     self.resolve_error(
                                         expr.span,
-                                        format!("unresolved name `{}`.{}",
+                                        format!("unresolved name `{}`{}",
                                                 wrong_name,
                                                 msg).as_slice());
                                 }

--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -184,7 +184,7 @@ impl<'a, 'tcx> AstConv<'tcx> for CrateCtxt<'a, 'tcx> {
 
     fn ty_infer(&self, span: Span) -> Ty<'tcx> {
         span_err!(self.tcx.sess, span, E0121,
-                  "the type placeholder `_` is not allowed within types on item signatures.");
+                  "the type placeholder `_` is not allowed within types on item signatures");
         ty::mk_err()
     }
 
@@ -1715,7 +1715,7 @@ fn add_unsized_bound<'tcx,AC>(this: &AC,
                                                        the given bound is not \
                                                        a default. \
                                                        Only `Sized?` is \
-                                                       supported.",
+                                                       supported",
                                                       desc).as_slice());
                     ty::try_add_builtin_trait(this.tcx(),
                                               kind_id,

--- a/src/librustc/middle/typeck/infer/error_reporting.rs
+++ b/src/librustc/middle/typeck/infer/error_reporting.rs
@@ -1648,7 +1648,7 @@ impl<'a, 'tcx> ErrorReportingHelpers<'tcx> for InferCtxt<'a, 'tcx> {
                 self.tcx.sess.span_note(
                     span,
                     format!("...so that the type `{}` \
-                             will meet the declared lifetime bounds.",
+                             will meet the declared lifetime bounds",
                             self.ty_to_string(t)).as_slice());
             }
             infer::RelateDefaultParamBound(span, t) => {
@@ -1656,7 +1656,7 @@ impl<'a, 'tcx> ErrorReportingHelpers<'tcx> for InferCtxt<'a, 'tcx> {
                     span,
                     format!("...so that type parameter \
                              instantiated with `{}`, \
-                             will meet its declared lifetime bounds.",
+                             will meet its declared lifetime bounds",
                             self.ty_to_string(t)).as_slice());
             }
             infer::RelateRegionParamBound(span) => {

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -64,7 +64,7 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
         match state {
             Asm => {
                 let (s, style) = match expr_to_string(cx, p.parse_expr(),
-                                                   "inline assembly must be a string literal.") {
+                                                   "inline assembly must be a string literal") {
                     Some((s, st)) => (s, st),
                     // let compilation continue
                     None => return DummyResult::expr(sp),

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -99,7 +99,7 @@ impl<'a> ParserAttr for Parser<'a> {
 
         if permit_inner && self.eat(&token::Semi) {
             self.span_warn(span, "this inner attribute syntax is deprecated. \
-                           The new syntax is `#![foo]`, with a bang and no semicolon.");
+                           The new syntax is `#![foo]`, with a bang and no semicolon");
             style = ast::AttrInner;
         }
 

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -809,7 +809,7 @@ impl<'a> StringReader<'a> {
                                     self.span_diagnostic.span_help(
                                         sp,
                                         "this is an isolated carriage return; consider checking \
-                                         your editor and version control settings.")
+                                         your editor and version control settings")
                                 }
                                 false
                             }

--- a/src/test/compile-fail-fulldeps/phase-syntax-doesnt-resolve.rs
+++ b/src/test/compile-fail-fulldeps/phase-syntax-doesnt-resolve.rs
@@ -20,5 +20,5 @@ extern crate macro_crate_test;
 fn main() {
     macro_crate_test::foo();
     //~^ ERROR failed to resolve. Use of undeclared module `macro_crate_test`
-    //~^^ ERROR unresolved name `macro_crate_test::foo`.
+    //~^^ ERROR unresolved name `macro_crate_test::foo`
 }

--- a/src/test/compile-fail/does-nothing.rs
+++ b/src/test/compile-fail/does-nothing.rs
@@ -8,5 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unresolved name `this_does_nothing_what_the`.
+// error-pattern: unresolved name `this_does_nothing_what_the`
 fn main() { println!("doing"); this_does_nothing_what_the; println!("boing"); }

--- a/src/test/compile-fail/import2.rs
+++ b/src/test/compile-fail/import2.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use baz::zed::bar;
-//~^ ERROR unresolved import `baz::zed::bar`. Could not find `zed` in `baz`.
+//~^ ERROR unresolved import `baz::zed::bar`. Could not find `zed` in `baz`
 
 
 mod baz {}

--- a/src/test/compile-fail/issue-1476.rs
+++ b/src/test/compile-fail/issue-1476.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 fn main() {
-    println!("{}", x); //~ ERROR unresolved name `x`.
+    println!("{}", x); //~ ERROR unresolved name `x`
 }

--- a/src/test/compile-fail/issue-2281-part1.rs
+++ b/src/test/compile-fail/issue-2281-part1.rs
@@ -8,6 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unresolved name `foobar`.
+// error-pattern: unresolved name `foobar`
 
 fn main() { println!("{}", foobar); }

--- a/src/test/compile-fail/issue-2356.rs
+++ b/src/test/compile-fail/issue-2356.rs
@@ -25,7 +25,7 @@ impl MaybeDog {
   fn bark() {
     // If this provides a suggestion, it's a bug as MaybeDog doesn't impl Groom
     shave();
-    //~^ ERROR: unresolved name `shave`.
+    //~^ ERROR: unresolved name `shave`
   }
 }
 
@@ -67,7 +67,7 @@ impl cat {
     grow_older();
     //~^ ERROR: unresolved name `grow_older`. Did you mean to call `cat::grow_older`
     shave();
-    //~^ ERROR: unresolved name `shave`.
+    //~^ ERROR: unresolved name `shave`
   }
 
   fn burn_whiskers(&mut self) {
@@ -85,6 +85,6 @@ impl cat {
 
 fn main() {
     self += 1;
-    //~^ ERROR: unresolved name `self`.
+    //~^ ERROR: unresolved name `self`
     // it's a bug if this suggests a missing `self` as we're not in a method
 }

--- a/src/test/compile-fail/issue-3021-b.rs
+++ b/src/test/compile-fail/issue-3021-b.rs
@@ -17,7 +17,7 @@ fn siphash(k0 : u64) {
     impl siphash {
         pub fn reset(&mut self) {
            self.v0 = k0 ^ 0x736f6d6570736575; //~ ERROR can't capture dynamic environment
-           //~^ ERROR unresolved name `k0`.
+           //~^ ERROR unresolved name `k0`
         }
     }
 }

--- a/src/test/compile-fail/issue-3021-d.rs
+++ b/src/test/compile-fail/issue-3021-d.rs
@@ -29,9 +29,9 @@ fn siphash(k0 : u64, k1 : u64) -> siphash {
    impl siphash for SipState {
         fn reset(&self) {
             self.v0 = k0 ^ 0x736f6d6570736575; //~ ERROR can't capture dynamic environment
-            //~^ ERROR unresolved name `k0`.
+            //~^ ERROR unresolved name `k0`
             self.v1 = k1 ^ 0x646f72616e646f6d; //~ ERROR can't capture dynamic environment
-            //~^ ERROR unresolved name `k1`.
+            //~^ ERROR unresolved name `k1`
         }
         fn result(&self) -> u64 { return mk_result(self); }
     }

--- a/src/test/compile-fail/issue-3021.rs
+++ b/src/test/compile-fail/issue-3021.rs
@@ -20,7 +20,7 @@ fn siphash(k0 : u64) -> SipHash {
     impl SipHash for SipState {
         fn reset(&self) {
            self.v0 = k0 ^ 0x736f6d6570736575; //~ ERROR can't capture dynamic environment
-           //~^ ERROR unresolved name `k0`.
+           //~^ ERROR unresolved name `k0`
         }
     }
     panic!();

--- a/src/test/compile-fail/issue-7607-1.rs
+++ b/src/test/compile-fail/issue-7607-1.rs
@@ -14,7 +14,7 @@ struct Foo {
     x: int
 }
 
-impl Fo { //~ERROR inherent implementations are not allowed for types not defined in the current module.
+impl Fo { //~ERROR inherent implementations are not allowed for types not defined in the current module
     fn foo() {}
 }
 

--- a/src/test/compile-fail/issue-8767.rs
+++ b/src/test/compile-fail/issue-8767.rs
@@ -10,7 +10,7 @@
 
 // ignore-tidy-linelength
 
-impl B { //~ERROR inherent implementations are not allowed for types not defined in the current module.
+impl B { //~ERROR inherent implementations are not allowed for types not defined in the current module
 }
 
 fn main() {

--- a/src/test/compile-fail/match-join.rs
+++ b/src/test/compile-fail/match-join.rs
@@ -16,6 +16,6 @@ fn my_panic() -> ! { panic!(); }
 fn main() {
     match true { false => { my_panic(); } true => { } }
 
-    println!("{}", x); //~ ERROR unresolved name `x`.
+    println!("{}", x); //~ ERROR unresolved name `x`
     let x: int;
 }

--- a/src/test/compile-fail/privacy-ns1.rs
+++ b/src/test/compile-fail/privacy-ns1.rs
@@ -28,7 +28,7 @@ pub mod foo1 {
 fn test_glob1() {
     use foo1::*;
 
-    Bar();  //~ ERROR unresolved name `Bar`.
+    Bar();  //~ ERROR unresolved name `Bar`
 }
 
 // private type, public value
@@ -58,7 +58,7 @@ pub mod foo3 {
 fn test_glob3() {
     use foo3::*;
 
-    Bar();  //~ ERROR unresolved name `Bar`.
+    Bar();  //~ ERROR unresolved name `Bar`
     let _x: Box<Bar>;  //~ ERROR  use of undeclared type name `Bar`
 }
 

--- a/src/test/compile-fail/test-cfg.rs
+++ b/src/test/compile-fail/test-cfg.rs
@@ -14,5 +14,5 @@
 fn foo() {}
 
 fn main() {
-    foo(); //~ ERROR unresolved name `foo`.
+    foo(); //~ ERROR unresolved name `foo`
 }

--- a/src/test/compile-fail/trait-or-new-type-instead.rs
+++ b/src/test/compile-fail/trait-or-new-type-instead.rs
@@ -10,7 +10,7 @@
 
 // ignore-tidy-linelength
 
-impl<T> Option<T> { //~ERROR inherent implementations are not allowed for types not defined in the current module.
+impl<T> Option<T> { //~ERROR inherent implementations are not allowed for types not defined in the current module
     pub fn foo(&self) { }
 }
 

--- a/src/test/compile-fail/typeck_type_placeholder_item.rs
+++ b/src/test/compile-fail/typeck_type_placeholder_item.rs
@@ -12,108 +12,108 @@
 // inference by using the `_` type placeholder.
 
 fn test() -> _ { 5 }
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
 fn test2() -> (_, _) { (5u, 5u) }
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
-//~^^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
 static TEST3: _ = "test";
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
 static TEST4: _ = 145u16;
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
 static TEST5: (_, _) = (1, 2);
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
-//~^^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+//~^^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
 fn test6(_: _) { }
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
 fn test7(x: _) { let _x: uint = x; }
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
 fn test8(_f: fn() -> _) { }
-//~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
 struct Test9;
 
 impl Test9 {
     fn test9(&self) -> _ { () }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
     fn test10(&self, _x : _) { }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 }
 
 impl Clone for Test9 {
     fn clone(&self) -> _ { Test9 }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
     fn clone_from(&mut self, other: _) { *self = Test9; }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 }
 
 struct Test10 {
     a: _,
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
     b: (_, _),
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
-    //~^^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^^ ERROR the type placeholder `_` is not allowed within types on item signatures
 }
 
 pub fn main() {
     fn fn_test() -> _ { 5 }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
     fn fn_test2() -> (_, _) { (5u, 5u) }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
-    //~^^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
     static FN_TEST3: _ = "test";
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
     static FN_TEST4: _ = 145u16;
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
     static FN_TEST5: (_, _) = (1, 2);
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
-    //~^^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    //~^^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
     fn fn_test6(_: _) { }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
     fn fn_test7(x: _) { let _x: uint = x; }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
     fn fn_test8(_f: fn() -> _) { }
-    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
     struct FnTest9;
 
     impl FnTest9 {
         fn fn_test9(&self) -> _ { () }
-        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
         fn fn_test10(&self, _x : _) { }
-        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
     }
 
     impl Clone for FnTest9 {
         fn clone(&self) -> _ { FnTest9 }
-        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
         fn clone_from(&mut self, other: _) { *self = FnTest9; }
-        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
     }
 
     struct FnTest10 {
         a: _,
-        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
         b: (_, _),
-        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures.
-        //~^^ ERROR the type placeholder `_` is not allowed within types on item signatures.
+        //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+        //~^^ ERROR the type placeholder `_` is not allowed within types on item signatures
     }
 
 }

--- a/src/test/compile-fail/utf8_idents.rs
+++ b/src/test/compile-fail/utf8_idents.rs
@@ -11,14 +11,14 @@
 // ignore-lexer-test FIXME #15679
 
 fn foo<
-    'β, //~ ERROR non-ascii idents are not fully supported.
-    γ  //~ ERROR non-ascii idents are not fully supported.
+    'β, //~ ERROR non-ascii idents are not fully supported
+    γ  //~ ERROR non-ascii idents are not fully supported
 >() {}
 
 struct X {
-    δ: uint //~ ERROR non-ascii idents are not fully supported.
+    δ: uint //~ ERROR non-ascii idents are not fully supported
 }
 
 pub fn main() {
-    let α = 0.00001f64; //~ ERROR non-ascii idents are not fully supported.
+    let α = 0.00001f64; //~ ERROR non-ascii idents are not fully supported
 }


### PR DESCRIPTION
This is the style followed by most other error messages.
