### PR TITLE
Back io::stdin with a global singleton BufferedReader

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -32,7 +32,7 @@
 //!     ```rust
 //!     use std::io;
 //!
-//!     for line in io::stdin().lines() {
+//!     for line in io::stdin().lock().lines() {
 //!         print!("{}", line.unwrap());
 //!     }
 //!     ```
@@ -1413,10 +1413,10 @@ pub trait Buffer: Reader {
     /// # Example
     ///
     /// ```rust
-    /// use std::io;
+    /// use std::io::BufReader;
     ///
-    /// let mut reader = io::stdin();
-    /// let input = reader.read_line().ok().unwrap_or("nothing".to_string());
+    /// let mut reader = BufReader::new(b"hello\nworld");
+    /// assert_eq!("hello\n", &*reader.read_line().unwrap());
     /// ```
     ///
     /// # Error

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -295,7 +295,7 @@ fn main() {
         let fd = std::io::File::open(&Path::new("shootout-k-nucleotide.data"));
         get_sequence(&mut std::io::BufferedReader::new(fd), ">THREE")
     } else {
-        get_sequence(&mut std::io::stdin(), ">THREE")
+        get_sequence(&mut *std::io::stdin().lock(), ">THREE")
     };
     let input = Arc::new(input);
 

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -65,7 +65,7 @@ impl Sudoku {
         return true;
     }
 
-    pub fn read(mut reader: BufferedReader<StdReader>) -> Sudoku {
+    pub fn read(mut reader: &mut BufferedReader<StdReader>) -> Sudoku {
         /* assert first line is exactly "9,9" */
         assert!(reader.read_line().unwrap() == "9,9".to_string());
 
@@ -284,7 +284,7 @@ fn main() {
     let mut sudoku = if use_default {
         Sudoku::from_vec(&DEFAULT_SUDOKU)
     } else {
-        Sudoku::read(io::stdin())
+        Sudoku::read(&mut *io::stdin().lock())
     };
     sudoku.solve();
     sudoku.write(&mut io::stdout());

--- a/src/test/compile-fail/cannot-mutate-captured-non-mut-var.rs
+++ b/src/test/compile-fail/cannot-mutate-captured-non-mut-var.rs
@@ -14,6 +14,6 @@ fn main() {
     //~^ ERROR: cannot assign to immutable captured outer variable in a proc `x`
 
     let s = std::io::stdin();
-    proc() { s.lines(); };
+    proc() { s.read_to_end(); };
     //~^ ERROR: cannot borrow immutable captured outer variable in a proc `s` as mutable
 }

--- a/src/test/run-pass/issue-13304.rs
+++ b/src/test/run-pass/issue-13304.rs
@@ -37,7 +37,7 @@ fn parent() {
 }
 
 fn child() {
-    for line in io::stdin().lines() {
+    for line in io::stdin().lock().lines() {
         println!("{}", line.unwrap());
     }
 }

--- a/src/test/run-pass/issue-14456.rs
+++ b/src/test/run-pass/issue-14456.rs
@@ -27,7 +27,7 @@ fn main() {
 fn child() {
     io::stdout().write_line("foo").unwrap();
     io::stderr().write_line("bar").unwrap();
-    assert_eq!(io::stdin().read_line().err().unwrap().kind, io::EndOfFile);
+    assert_eq!(io::stdin().lock().read_line().err().unwrap().kind, io::EndOfFile);
 }
 
 fn test() {

--- a/src/test/run-pass/issue-16671.rs
+++ b/src/test/run-pass/issue-16671.rs
@@ -19,6 +19,6 @@
 pub fn main() {
     let mut stdin = std::io::stdin();
     spawn(proc() {
-        let _ = stdin.lines();
+        let _ = stdin.read_to_end();
     });
 }


### PR DESCRIPTION
io::stdin returns a new `BufferedReader` each time it's called, which
results in some very confusing behavior with disappearing output. It now
returns a `StdinReader`, which wraps a global singleton
`Arc<Mutex<BufferedReader<StdReader>>`. `Reader` is implemented directly
on `StdinReader`. However, `Buffer` is not, as the `fill_buf` method is
fundamentaly un-thread safe. A `lock` method is defined on `StdinReader`
which returns a smart pointer wrapping the underlying `BufferedReader`
while guaranteeing mutual exclusion.

Code that treats the return value of io::stdin as implementing `Buffer`
will break. Add a call to `lock`:

``` rust
io::stdin().read_line();
// =>
io::stdin().lock().read_line();
```

Closes #14434

[breaking-change]
