### PR TITLE
make fmt_macros and rustdoc have standard doc attributes

### DIFF
--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -18,6 +18,11 @@
 #![experimental]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
+#![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
+       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
+       html_root_url = "http://doc.rust-lang.org/nightly/",
+       html_playground_url = "http://play.rust-lang.org/")]
+
 #![feature(macro_rules, globs, import_shadowing)]
 pub use self::Piece::*;
 pub use self::Position::*;

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -12,6 +12,10 @@
 #![experimental]
 #![crate_type = "dylib"]
 #![crate_type = "rlib"]
+#![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
+       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
+       html_root_url = "http://doc.rust-lang.org/nightly/",
+       html_playground_url = "http://play.rust-lang.org/")]
 
 #![allow(unknown_features)]
 #![feature(globs, if_let, macro_rules, phase, slicing_syntax, tuple_indexing)]


### PR DESCRIPTION
these are missing standard #![doc(...)]. add them
