### PR TITLE
allow macro expansions in attributes

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1669,6 +1669,12 @@ impl<'a> Parser<'a> {
     /// Matches token_lit = LIT_INTEGER | ...
     pub fn lit_from_token(&mut self, tok: &token::Token) -> Lit_ {
         match *tok {
+            token::Interpolated(token::NtExpr(ref v)) => {
+                match v.node {
+                    ExprLit(ref lit) => { lit.node.clone() }
+                    _ => { self.unexpected_last(tok); }
+                }
+            }
             token::Literal(lit, suf) => {
                 let (suffix_illegal, out) = match lit {
                     token::Byte(i) => (true, LitByte(parse::byte_lit(i.as_str()).val0())),

--- a/src/test/compile-fail/macro-attribute.rs
+++ b/src/test/compile-fail/macro-attribute.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[doc = $not_there] //~ error: unexpected token: `$`
+fn main() { }
+

--- a/src/test/run-pass/macro-attribute-expansion.rs
+++ b/src/test/run-pass/macro-attribute-expansion.rs
@@ -1,0 +1,29 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-pretty - token trees can't pretty print
+
+#![feature(macro_rules)]
+
+macro_rules! descriptions {
+    ($name:ident is $desc:expr) => {
+        // Check that we will correctly expand attributes
+        #[doc = $desc]
+        #[allow(dead_code)]
+        const $name : &'static str = $desc;
+    }
+}
+
+// item
+descriptions!(DOG is "an animal")
+descriptions!(RUST is "a language")
+
+pub fn main() {
+}


### PR DESCRIPTION
this allows one to, for example, use #[doc = $macro_var ] in macros.
