### PR TITLE
rustdoc: Use relative paths in source renders.

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -53,6 +53,7 @@ use std::rc::Rc;
 use std::u32;
 use std::str::Str as StrTrait; // Conflicts with Str variant
 use std::char::Char as CharTrait; // Conflicts with Char variant
+use std::path::Path as FsPath; // Conflicts with Path struct
 
 use core::DocContext;
 use doctree;
@@ -115,6 +116,7 @@ impl<T: Clean<U>, U> Clean<Vec<U>> for syntax::owned_slice::OwnedSlice<T> {
 #[deriving(Clone, Encodable, Decodable)]
 pub struct Crate {
     pub name: String,
+    pub src: FsPath,
     pub module: Option<Item>,
     pub externs: Vec<(ast::CrateNum, ExternalCrate)>,
     pub primitives: Vec<PrimitiveType>,
@@ -194,6 +196,7 @@ impl<'a, 'tcx> Clean<Crate> for visit_ast::RustdocVisitor<'a, 'tcx> {
 
         Crate {
             name: name.to_string(),
+            src: cx.src.clone(),
             module: Some(module),
             externs: externs,
             primitives: primitives,


### PR DESCRIPTION
Before: `doc/src/collections/home/lifthrasiir/git/rust/src/libcollections/vec.rs.html`
After: `doc/src/collections/vec.rs.html`

If the source code is in the parent dirs relative to the crate root, `..` is replaced with `up` as expected. Any other error like non-UTF-8 paths or drive-relative paths falls back to the absolute path.

There might be a way to improve on false negatives, but this alone should be enough for fixing #18370.
