### PR TITLE
libstd/io/process/Command: fully quote and escape the command and all args

### DIFF
--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -1237,4 +1237,16 @@ mod tests {
         let val = env.get(&EnvKey("PATH".to_c_str()));
         assert!(val.unwrap() == &"bar".to_c_str());
     }
+
+    fn check_show(c: &Command, v: &str) {
+        assert_eq!(format!("{}", c).as_slice(), v)
+    }
+
+    #[test]
+    fn show() {
+        check_show(Command::new("gcc ").arg("-Ifoo'bar"), "'gcc ' '-Ifoo'\\''bar'");
+        check_show(&Command::new("c99"), "'c99'");
+        check_show(&Command::new("c99 "), "'c99 '");
+        check_show(&Command::new("Can't buy me love"), "'Can'\\''t buy me love'");
+    }
 }


### PR DESCRIPTION
This makes the command (which may have trailing or leading white space
the user does not expect) unambiguous.

It also makes any usage of a literal ' (single quote) in arguments or
the command name unambiguous by escaping them in the same style as posix
shell.
