### PR TITLE
test/run-make: another missing $(EXTRACFLAGS).

### DIFF
--- a/src/test/run-make/static-dylib-by-default/Makefile
+++ b/src/test/run-make/static-dylib-by-default/Makefile
@@ -3,7 +3,7 @@
 all:
 	$(RUSTC) foo.rs
 	$(RUSTC) bar.rs
-	$(CC) main.c -o $(call RUN_BINFILE,main) -lbar
+	$(CC) main.c -o $(call RUN_BINFILE,main) -lbar $(EXTRACFLAGS)
 	rm $(TMPDIR)/*.rlib
 	rm $(call DYLIB,foo)
 	$(call RUN,main)


### PR DESCRIPTION
rust-lang/rust@102b1a5bf1a60eeafb752844e5c98fe5f4e3b992 was not enough!
