### PR TITLE
Log the current task name in the log! macros.

### DIFF
--- a/src/liblog/macros.rs
+++ b/src/liblog/macros.rs
@@ -53,14 +53,15 @@
 #[macro_export]
 macro_rules! log(
     ($lvl:expr, $($arg:tt)+) => ({
-        static LOC: ::log::LogLocation = ::log::LogLocation {
-            line: line!(),
-            file: file!(),
-            module_path: module_path!(),
-        };
         let lvl = $lvl;
         if log_enabled!(lvl) {
-            format_args!(|args| { ::log::log(lvl, &LOC, args) }, $($arg)+)
+            format_args!(|args| { ::log::log(lvl, ::log::LogLocation {
+                    line: line!(),
+                    file: file!(),
+                    module_path: module_path!(),
+                    task_name: ::std::task::name()
+                }, args)
+            }, $($arg)+)
         }
     })
 )


### PR DESCRIPTION
This requires doing an allocation on log! invocations
if the current task is named, since there is no non-allocating
way to access the name of the current task.

Fixes #2672
