### PR TITLE
Make std::io::TempDir::{new, new_in} accept a BytesContainer as a suffix

### DIFF
--- a/src/test/run-pass/tempfile.rs
+++ b/src/test/run-pass/tempfile.rs
@@ -32,6 +32,14 @@ fn test_tempdir() {
         p.clone()
     };
     assert!(!path.exists());
+
+    let path2 = {
+        let p = TempDir::new_in(&Path::new("."), "foobar".as_bytes()).unwrap();
+        let p = p.path();
+        assert!(p.as_vec().ends_with(b"foobar"));
+        p.clone()
+    };
+    assert!(!path2.exists());
 }
 
 fn test_rm_tempdir() {


### PR DESCRIPTION
This pull request addresses #19437.  It was mentioned that Paths can be constructed with any `BytesContainer`, whereas `TempDir`'s constructors specifically require an `&str`.  There's no reason that `TempDir`'s constructors shouldn't be able to accept any `BytesContainer` however, so long as the suffix is a valid UTF-8 string.

Closes #19437.
