### PR TITLE
Pop on binary heaps does not have constant time complexity.

### DIFF
--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -10,8 +10,8 @@
 
 //! A priority queue implemented with a binary heap.
 //!
-//! Insertions have `O(log n)` time complexity and checking or popping the largest element is
-//! `O(1)`. Converting a vector to a priority queue can be done in-place, and has `O(n)`
+//! Insertion and popping the largest element have `O(log n)` time complexity. Checking the largest
+//! element is `O(1)`. Converting a vector to a priority queue can be done in-place, and has `O(n)`
 //! complexity. A priority queue can also be converted to a sorted vector in-place, allowing it to
 //! be used for an `O(n log n)` in-place heapsort.
 //!


### PR DESCRIPTION
pop calls siftdown, siftdown calls siftdown_range, and siftdown_range
loops on an index that can start as low as 0 and approximately doubles
each iteration.
