### PR TITLE
rustdoc: Check for href when prepending rootPath

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -707,8 +707,8 @@
                 var code = $('<code>').append(structs[j]);
                 $.each(code.find('a'), function(idx, a) {
                     var href = $(a).attr('href');
-                    if (!href.startsWith('http')) {
-                        $(a).attr('href', rootPath + $(a).attr('href'));
+                    if (href && !href.startsWith('http')) {
+                        $(a).attr('href', rootPath + href);
                     }
                 });
                 var li = $('<li>').append(code);


### PR DESCRIPTION
Fixes the JS error in #18354 at least. I don't know if there's a more underlying issue that needs addressing.
