### PR TITLE
replace 'but' with 'and'

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -2861,7 +2861,7 @@ parts of your library. The six levels are:
 * experimental: This item was only recently introduced or is otherwise in a
   state of flux. It may change significantly, or even be removed. No guarantee
   of backwards-compatibility.
-* unstable: This item is still under development, but requires more testing to
+* unstable: This item is still under development and requires more testing to
   be considered stable. No guarantee of backwards-compatibility.
 * stable: This item is considered stable, and will not change significantly.
   Guarantee of backwards-compatibility.


### PR DESCRIPTION
Using `and` here instead of `but` sounds better to me, as but makes it sound like an item which is still under active development shouldn't normally require more testing, but this one does - or something like that :-)
@steveklabnik?
