### PR TITLE
ack parser.parse_ty change in quote_ty! (+ test)

### DIFF
--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -450,8 +450,7 @@ pub fn expand_quote_ty(cx: &mut ExtCtxt,
                        sp: Span,
                        tts: &[ast::TokenTree])
                        -> Box<base::MacResult+'static> {
-    let expanded = expand_parse_call(cx, sp, "parse_ty",
-                                     vec![], tts);
+    let expanded = expand_parse_call(cx, sp, "parse_ty", vec!(), tts);
     base::MacExpr::new(expanded)
 }
 

--- a/src/test/run-pass-fulldeps/quote-tokens.rs
+++ b/src/test/run-pass-fulldeps/quote-tokens.rs
@@ -38,6 +38,8 @@ fn syntax_extension(cx: &ExtCtxt) {
 
     let _j: P<syntax::ast::Method> = quote_method!(cx, fn foo(&self) {});
     let _k: P<syntax::ast::Method> = quote_method!(cx, #[doc = "hello"] fn foo(&self) {});
+
+    let _l: P<syntax::ast::Ty> = quote_ty!(cx, &int);
 }
 
 fn main() {


### PR DESCRIPTION
parse_ty() no longer takes a boolean parameter. quote_ty! implementation has not yet been modified accordingly. 

As a matter of fact, quote_ty! was not covered by tests. One test (called qquotes) references it, but it has been ignored for nearly one year and now need heavy refactoring.

quote_token.rs seemed like a good place to test quote_ty!, many other quote_*! macros were asserted there.
