### PR TITLE
Test for associated types ICE

### DIFF
--- a/src/test/compile-fail/issue-19121.rs
+++ b/src/test/compile-fail/issue-19121.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that a partially specified trait object with unspecified associated
+// type does not ICE.
+
+#![feature(associated_types)]
+
+trait Foo {
+    type A;
+}
+
+fn bar(x: &Foo) {} //~ERROR missing type for associated type `A`
+
+pub fn main() {}


### PR DESCRIPTION
closes #19121

r?

This won't actually pass until https://github.com/rust-lang/rust/pull/19391 lands
