### PR TITLE
syntax: support ES6-style unicode escapes

### DIFF
--- a/src/test/compile-fail/new-unicode-escapes-1.rs
+++ b/src/test/compile-fail/new-unicode-escapes-1.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    let s = "\u{2603"; //~ ERROR unterminated unicode escape (needed a `}`)
+}

--- a/src/test/compile-fail/new-unicode-escapes-2.rs
+++ b/src/test/compile-fail/new-unicode-escapes-2.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    let s = "\u{260311111111}"; //~ ERROR overlong unicode escape (can have at most 6 hex digits)
+}

--- a/src/test/compile-fail/new-unicode-escapes-3.rs
+++ b/src/test/compile-fail/new-unicode-escapes-3.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    let s = "\u{d805}"; //~ ERROR illegal unicode character escape
+}

--- a/src/test/compile-fail/new-unicode-escapes-4.rs
+++ b/src/test/compile-fail/new-unicode-escapes-4.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    let s = "\u{lol}"; //~ ERROR illegal character in unicode escape
+}

--- a/src/test/run-pass/new-unicode-escapes.rs
+++ b/src/test/run-pass/new-unicode-escapes.rs
@@ -1,0 +1,22 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    let s = "\u{2603}";
+    assert_eq!(s, "☃");
+
+    let s = "\u{2a10}\u{2A01}\u{2Aa0}";
+    assert_eq!(s, "⨐⨁⪠");
+
+    let s = "\\{20}";
+    let mut correct_s = String::from_str("\\");
+    correct_s.push_str("{20}");
+    assert_eq!(s, correct_s.as_slice());
+}


### PR DESCRIPTION
First half of bootstrapping https://github.com/rust-lang/rfcs/pull/446
