### PR TITLE
Refactor `expr_kind` and `expr_is_lval`

### DIFF
--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -88,11 +88,10 @@ impl Dest {
     }
 }
 
-/// We categorize expressions into three kinds.  The distinction between
+/// We categorize expressions into four kinds.  The distinction between
 /// lvalue/rvalue is fundamental to the language.  The distinction between the
-/// two kinds of rvalues is an artifact of trans which reflects how we will
-/// generate code for that kind of expression.  See trans/expr.rs for more
-/// information.
+/// three kinds of rvalues is an artifact of trans which reflects how we will
+/// generate code for that kind of expression.
 pub enum ExprKind {
     Lvalue,
     RvalueDps,
@@ -101,7 +100,7 @@ pub enum ExprKind {
 }
 
 pub fn expr_kind(tcx: &ty::ctxt, expr: &ast::Expr) -> ExprKind {
-    if tcx.method_map.borrow().contains_key(&typeck::MethodCall::expr(expr.id)) {
+    if tcx.method_map.borrow().contains_key(&ty::MethodCall::expr(expr.id)) {
         // Overloaded operations are generally calls, and hence they are
         // generated via DPS, but there are a few exceptions:
         return match expr.node {
@@ -157,9 +156,6 @@ pub fn expr_kind(tcx: &ty::ctxt, expr: &ast::Expr) -> ExprKind {
                 def::DefStaticMethod(..) |
                 def::DefMethod(..) => ExprKind::RvalueDatum,
 
-                // Note: there is actually a good case to be made that
-                // DefArg's, particularly those of immediate type, ought to
-                // considered rvalues.
                 def::DefStatic(..) |
                 def::DefUpvar(..) |
                 def::DefLocal(..) => ExprKind::Lvalue,
@@ -219,18 +215,7 @@ pub fn expr_kind(tcx: &ty::ctxt, expr: &ast::Expr) -> ExprKind {
                     }
                 }
                 None => {
-                    // Technically, it should not happen that the expr is not
-                    // present within the table.  However, it DOES happen
-                    // during type check, because the final types from the
-                    // expressions are not yet recorded in the tcx.  At that
-                    // time, though, we are only interested in knowing lvalue
-                    // vs rvalue.  It would be better to base this decision on
-                    // the AST type in cast node---but (at the time of this
-                    // writing) it's not easy to distinguish casts to traits
-                    // from other casts based on the AST.  This should be
-                    // easier in the future, when casts to traits
-                    // would like @Foo, Box<Foo>, or &Foo.
-                    ExprKind::RvalueDatum
+                    panic!("Cast expression not in types table");
                 }
             }
         }

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -153,7 +153,9 @@ pub fn expr_kind(tcx: &ty::ctxt, expr: &ast::Expr) -> ExprKind {
                 def::DefFn(_, true) => ExprKind::RvalueDps,
 
                 // Fn pointers are just scalar values.
-                def::DefFn(..) | def::DefStaticMethod(..) | def::DefMethod(..) => ExprKind::RvalueDatum,
+                def::DefFn(..) |
+                def::DefStaticMethod(..) |
+                def::DefMethod(..) => ExprKind::RvalueDatum,
 
                 // Note: there is actually a good case to be made that
                 // DefArg's, particularly those of immediate type, ought to

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -88,6 +88,195 @@ impl Dest {
     }
 }
 
+/// We categorize expressions into three kinds.  The distinction between
+/// lvalue/rvalue is fundamental to the language.  The distinction between the
+/// two kinds of rvalues is an artifact of trans which reflects how we will
+/// generate code for that kind of expression.  See trans/expr.rs for more
+/// information.
+pub enum ExprKind {
+    Lvalue,
+    RvalueDps,
+    RvalueDatum,
+    RvalueStmt
+}
+
+pub fn expr_kind(tcx: &ty::ctxt, expr: &ast::Expr) -> ExprKind {
+    if tcx.method_map.borrow().contains_key(&typeck::MethodCall::expr(expr.id)) {
+        // Overloaded operations are generally calls, and hence they are
+        // generated via DPS, but there are a few exceptions:
+        return match expr.node {
+            // `a += b` has a unit result.
+            ast::ExprAssignOp(..) => ExprKind::RvalueStmt,
+
+            // the deref method invoked for `*a` always yields an `&T`
+            ast::ExprUnary(ast::UnDeref, _) => ExprKind::Lvalue,
+
+            // the index method invoked for `a[i]` always yields an `&T`
+            ast::ExprIndex(..) => ExprKind::Lvalue,
+
+            // the slice method invoked for `a[..]` always yields an `&T`
+            ast::ExprSlice(..) => ExprKind::Lvalue,
+
+            // `for` loops are statements
+            ast::ExprForLoop(..) => ExprKind::RvalueStmt,
+
+            // in the general case, result could be any type, use DPS
+            _ => ExprKind::RvalueDps
+        };
+    }
+
+    match expr.node {
+        ast::ExprPath(..) => {
+            match ty::resolve_expr(tcx, expr) {
+                def::DefVariant(tid, vid, _) => {
+                    let variant_info = ty::enum_variant_with_id(tcx, tid, vid);
+                    if variant_info.args.len() > 0u {
+                        // N-ary variant.
+                        ExprKind::RvalueDatum
+                    } else {
+                        // Nullary variant.
+                        ExprKind::RvalueDps
+                    }
+                }
+
+                def::DefStruct(_) => {
+                    match ty::expr_ty(tcx, expr).sty {
+                        ty::ty_bare_fn(..) => ExprKind::RvalueDatum,
+                        _ => ExprKind::RvalueDps
+                    }
+                }
+
+                // Special case: A unit like struct's constructor must be called without () at the
+                // end (like `UnitStruct`) which means this is an ExprPath to a DefFn. But in case
+                // of unit structs this is should not be interpreted as function pointer but as
+                // call to the constructor.
+                def::DefFn(_, true) => ExprKind::RvalueDps,
+
+                // Fn pointers are just scalar values.
+                def::DefFn(..) | def::DefStaticMethod(..) | def::DefMethod(..) => ExprKind::RvalueDatum,
+
+                // Note: there is actually a good case to be made that
+                // DefArg's, particularly those of immediate type, ought to
+                // considered rvalues.
+                def::DefStatic(..) |
+                def::DefUpvar(..) |
+                def::DefLocal(..) => ExprKind::Lvalue,
+
+                def::DefConst(..) => ExprKind::RvalueDatum,
+
+                def => {
+                    tcx.sess.span_bug(
+                        expr.span,
+                        format!("uncategorized def for expr {}: {}",
+                                expr.id,
+                                def).as_slice());
+                }
+            }
+        }
+
+        ast::ExprUnary(ast::UnDeref, _) |
+        ast::ExprField(..) |
+        ast::ExprTupField(..) |
+        ast::ExprIndex(..) |
+        ast::ExprSlice(..) => {
+            ExprKind::Lvalue
+        }
+
+        ast::ExprCall(..) |
+        ast::ExprMethodCall(..) |
+        ast::ExprStruct(..) |
+        ast::ExprTup(..) |
+        ast::ExprIf(..) |
+        ast::ExprMatch(..) |
+        ast::ExprClosure(..) |
+        ast::ExprProc(..) |
+        ast::ExprBlock(..) |
+        ast::ExprRepeat(..) |
+        ast::ExprVec(..) => {
+            ExprKind::RvalueDps
+        }
+
+        ast::ExprIfLet(..) => {
+            tcx.sess.span_bug(expr.span, "non-desugared ExprIfLet");
+        }
+        ast::ExprWhileLet(..) => {
+            tcx.sess.span_bug(expr.span, "non-desugared ExprWhileLet");
+        }
+
+        ast::ExprLit(ref lit) if ast_util::lit_is_str(&**lit) => {
+            ExprKind::RvalueDps
+        }
+
+        ast::ExprCast(..) => {
+            match tcx.node_types.borrow().get(&expr.id) {
+                Some(&ty) => {
+                    if ty::type_is_trait(ty) {
+                        ExprKind::RvalueDps
+                    } else {
+                        ExprKind::RvalueDatum
+                    }
+                }
+                None => {
+                    // Technically, it should not happen that the expr is not
+                    // present within the table.  However, it DOES happen
+                    // during type check, because the final types from the
+                    // expressions are not yet recorded in the tcx.  At that
+                    // time, though, we are only interested in knowing lvalue
+                    // vs rvalue.  It would be better to base this decision on
+                    // the AST type in cast node---but (at the time of this
+                    // writing) it's not easy to distinguish casts to traits
+                    // from other casts based on the AST.  This should be
+                    // easier in the future, when casts to traits
+                    // would like @Foo, Box<Foo>, or &Foo.
+                    ExprKind::RvalueDatum
+                }
+            }
+        }
+
+        ast::ExprBreak(..) |
+        ast::ExprAgain(..) |
+        ast::ExprRet(..) |
+        ast::ExprWhile(..) |
+        ast::ExprLoop(..) |
+        ast::ExprAssign(..) |
+        ast::ExprInlineAsm(..) |
+        ast::ExprAssignOp(..) |
+        ast::ExprForLoop(..) => {
+            ExprKind::RvalueStmt
+        }
+
+        ast::ExprLit(_) | // Note: LitStr is carved out above
+        ast::ExprUnary(..) |
+        ast::ExprAddrOf(..) |
+        ast::ExprBinary(..) => {
+            ExprKind::RvalueDatum
+        }
+
+        ast::ExprBox(ref place, _) => {
+            // Special case `Box<T>` for now:
+            let definition = match tcx.def_map.borrow().get(&place.id) {
+                Some(&def) => def,
+                None => panic!("no def for place"),
+            };
+            let def_id = definition.def_id();
+            if tcx.lang_items.exchange_heap() == Some(def_id) {
+                ExprKind::RvalueDatum
+            } else {
+                ExprKind::RvalueDps
+            }
+        }
+
+        ast::ExprParen(ref e) => expr_kind(tcx, &**e),
+
+        ast::ExprMac(..) => {
+            tcx.sess.span_bug(
+                expr.span,
+                "macro expression remains after expansion");
+        }
+    }
+}
+
+
 /// This function is equivalent to `trans(bcx, expr).store_to_dest(dest)` but it may generate
 /// better optimized LLVM code.
 pub fn trans_into<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
@@ -112,15 +301,15 @@ pub fn trans_into<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     bcx.fcx.push_ast_cleanup_scope(cleanup_debug_loc);
 
     debuginfo::set_source_location(bcx.fcx, expr.id, expr.span);
-    let kind = ty::expr_kind(bcx.tcx(), expr);
+    let kind = expr_kind(bcx.tcx(), expr);
     bcx = match kind {
-        ty::LvalueExpr | ty::RvalueDatumExpr => {
+        ExprKind::Lvalue | ExprKind::RvalueDatum => {
             trans_unadjusted(bcx, expr).store_to_dest(dest, expr.id)
         }
-        ty::RvalueDpsExpr => {
+        ExprKind::RvalueDps => {
             trans_rvalue_dps_unadjusted(bcx, expr, dest)
         }
-        ty::RvalueStmtExpr => {
+        ExprKind::RvalueStmt => {
             trans_rvalue_stmt_unadjusted(bcx, expr)
         }
     };
@@ -503,8 +692,8 @@ fn trans_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
     debuginfo::set_source_location(bcx.fcx, expr.id, expr.span);
 
-    return match ty::expr_kind(bcx.tcx(), expr) {
-        ty::LvalueExpr | ty::RvalueDatumExpr => {
+    return match expr_kind(bcx.tcx(), expr) {
+        ExprKind::Lvalue | ExprKind::RvalueDatum => {
             let datum = unpack_datum!(bcx, {
                 trans_datum_unadjusted(bcx, expr)
             });
@@ -512,12 +701,12 @@ fn trans_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             DatumBlock {bcx: bcx, datum: datum}
         }
 
-        ty::RvalueStmtExpr => {
+        ExprKind::RvalueStmt => {
             bcx = trans_rvalue_stmt_unadjusted(bcx, expr);
             nil(bcx, expr_ty(bcx, expr))
         }
 
-        ty::RvalueDpsExpr => {
+        ExprKind::RvalueDps => {
             let ty = expr_ty(bcx, expr);
             if type_is_zero_size(bcx.ccx(), ty) {
                 bcx = trans_rvalue_dps_unadjusted(bcx, expr, Ignore);
@@ -1082,20 +1271,20 @@ fn trans_rvalue_dps_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                       dest)
         }
         ast::ExprBinary(_, ref lhs, ref rhs) => {
-            // if not overloaded, would be RvalueDatumExpr
+            // if not overloaded, would be ExprKind::RvalueDatum
             let lhs = unpack_datum!(bcx, trans(bcx, &**lhs));
             let rhs_datum = unpack_datum!(bcx, trans(bcx, &**rhs));
             trans_overloaded_op(bcx, expr, MethodCall::expr(expr.id), lhs,
                                 vec![(rhs_datum, rhs.id)], Some(dest)).bcx
         }
         ast::ExprUnary(_, ref subexpr) => {
-            // if not overloaded, would be RvalueDatumExpr
+            // if not overloaded, would be ExprKind::RvalueDatum
             let arg = unpack_datum!(bcx, trans(bcx, &**subexpr));
             trans_overloaded_op(bcx, expr, MethodCall::expr(expr.id),
                                 arg, Vec::new(), Some(dest)).bcx
         }
         ast::ExprIndex(ref base, ref idx) => {
-            // if not overloaded, would be RvalueDatumExpr
+            // if not overloaded, would be ExprKind::RvalueDatum
             let base = unpack_datum!(bcx, trans(bcx, &**base));
             let idx_datum = unpack_datum!(bcx, trans(bcx, &**idx));
             trans_overloaded_op(bcx, expr, MethodCall::expr(expr.id), base,
@@ -1415,11 +1604,11 @@ pub fn trans_adt<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
     for base in optbase.iter() {
         assert_eq!(discr, 0);
 
-        match ty::expr_kind(bcx.tcx(), &*base.expr) {
-            ty::RvalueDpsExpr | ty::RvalueDatumExpr if !ty::type_needs_drop(bcx.tcx(), ty) => {
+        match expr_kind(bcx.tcx(), &*base.expr) {
+            ExprKind::RvalueDps | ExprKind::RvalueDatum if !ty::type_needs_drop(bcx.tcx(), ty) => {
                 bcx = trans_into(bcx, &*base.expr, SaveIn(addr));
             },
-            ty::RvalueStmtExpr => bcx.tcx().sess.bug("unexpected expr kind for struct base expr"),
+            ExprKind::RvalueStmt => bcx.tcx().sess.bug("unexpected expr kind for struct base expr"),
             _ => {
                 let base_datum = unpack_datum!(bcx, trans_to_lvalue(bcx, &*base.expr, "base"));
                 for &(i, t) in base.fields.iter() {
@@ -1491,7 +1680,7 @@ fn trans_immediate_lit<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                    expr: &ast::Expr,
                                    lit: &ast::Lit)
                                    -> DatumBlock<'blk, 'tcx, Expr> {
-    // must not be a string constant, that is a RvalueDpsExpr
+    // must not be a string constant, that is a ExprKind::RvalueDps
     let _icx = push_ctxt("trans_immediate_lit");
     let ty = expr_ty(bcx, expr);
     let v = consts::const_lit(bcx.ccx(), expr, lit);
@@ -1511,7 +1700,7 @@ fn trans_unary<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
     // The only overloaded operator that is translated to a datum
     // is an overloaded deref, since it is always yields a `&T`.
-    // Otherwise, we should be in the RvalueDpsExpr path.
+    // Otherwise, we should be in the ExprKind::RvalueDps path.
     assert!(
         op == ast::UnDeref ||
         !ccx.tcx().method_map.borrow().contains_key(&method_call));
@@ -1752,7 +1941,7 @@ fn trans_binary<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let _icx = push_ctxt("trans_binary");
     let ccx = bcx.ccx();
 
-    // if overloaded, would be RvalueDpsExpr
+    // if overloaded, would be ExprKind::RvalueDps
     assert!(!ccx.tcx().method_map.borrow().contains_key(&MethodCall::expr(expr.id)));
 
     match op {

--- a/src/test/compile-fail/issue-19337.rs
+++ b/src/test/compile-fail/issue-19337.rs
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo;
+
+fn main() {
+    Foo = Foo;
+    //~^ ERROR: illegal left-hand side expression
+}


### PR DESCRIPTION
Instead of calling out to `expr_kind` for `expr_is_lval` handle the logic separately. This avoids a number of unneeded checks that were only there to categorise rvalues. This technically adds some maintenance overhead, but given that expr_kind was doing way more work than `expr_is_lval` needed, I think this an acceptable trade-off.

Since `expr_is_lval` was the only caller of `expr_kind` outside of `trans::expr`, I moved the function (and the enum) to that file. Most of what `expr_kind` did was for trans anyway, so it's a better place for it.
