### PR TITLE
rustdoc: Preserve query/fragment in redirects whenever possible.

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -160,6 +160,7 @@ r##"<!DOCTYPE html>
 }
 
 pub fn redirect(dst: &mut io::Writer, url: &str) -> io::IoResult<()> {
+    // <script> triggers a redirect before refresh, so this is fine.
     write!(dst,
 r##"<!DOCTYPE html>
 <html lang="en">
@@ -167,6 +168,8 @@ r##"<!DOCTYPE html>
     <meta http-equiv="refresh" content="0;URL={url}">
 </head>
 <body>
+    <p>Redirecting to <a href="{url}">{url}</a>...</p>
+    <script>location.replace("{url}" + location.search + location.hash);</script>
 </body>
 </html>"##,
     url = url,


### PR DESCRIPTION
We heavily rely on queries and fragments in the URL structure, so it is desired to preserve them even in the redirects. The generated redirect pages try to preserve them with scripts, which take precedence over the original `Refresh` metadata. Non-scripting browsers would continue to work (with no queries and fragments).

(This in turn solves a number of semi-broken links to the source code, which are actually linked to redirect pages.)
