### PR TITLE
Add BitOps for BTreeSet.

### DIFF
--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -22,7 +22,6 @@ use core::iter::Peekable;
 use core::fmt::Show;
 
 // FIXME(conventions): implement bounded iterators
-// FIXME(conventions): implement BitOr, BitAnd, BitXor, and Sub
 
 /// A set based on a B-Tree.
 ///
@@ -337,6 +336,90 @@ impl<T: Ord> Extend<T> for BTreeSet<T> {
 impl<T: Ord> Default for BTreeSet<T> {
     fn default() -> BTreeSet<T> {
         BTreeSet::new()
+    }
+}
+
+#[unstable = "matches collection reform specification, waiting for dust to settle"]
+impl<T: Ord + Clone> Sub<BTreeSet<T>,BTreeSet<T>> for BTreeSet<T> {
+    /// Returns the difference of `self` and `rhs` as a new `BTreeSet<T>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::BTreeSet;
+    ///
+    /// let a: BTreeSet<int> = vec![1,2,3].into_iter().collect();
+    /// let b: BTreeSet<int> = vec![3,4,5].into_iter().collect();
+    ///
+    /// let result: BTreeSet<int> = a - b;
+    /// let result_vec: Vec<int> = result.into_iter().collect();
+    /// assert_eq!(result_vec, vec![1,2]);
+    /// ```
+    fn sub(&self, rhs: &BTreeSet<T>) -> BTreeSet<T> {
+        self.difference(rhs).cloned().collect()
+    }
+}
+
+#[unstable = "matches collection reform specification, waiting for dust to settle"]
+impl<T: Ord + Clone> BitXor<BTreeSet<T>,BTreeSet<T>> for BTreeSet<T> {
+    /// Returns the symmetric difference of `self` and `rhs` as a new `BTreeSet<T>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::BTreeSet;
+    ///
+    /// let a: BTreeSet<int> = vec![1,2,3].into_iter().collect();
+    /// let b: BTreeSet<int> = vec![2,3,4].into_iter().collect();
+    ///
+    /// let result: BTreeSet<int> = a ^ b;
+    /// let result_vec: Vec<int> = result.into_iter().collect();
+    /// assert_eq!(result_vec, vec![1,4]);
+    /// ```
+    fn bitxor(&self, rhs: &BTreeSet<T>) -> BTreeSet<T> {
+        self.symmetric_difference(rhs).cloned().collect()
+    }
+}
+
+#[unstable = "matches collection reform specification, waiting for dust to settle"]
+impl<T: Ord + Clone> BitAnd<BTreeSet<T>,BTreeSet<T>> for BTreeSet<T> {
+    /// Returns the intersection of `self` and `rhs` as a new `BTreeSet<T>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::BTreeSet;
+    ///
+    /// let a: BTreeSet<int> = vec![1,2,3].into_iter().collect();
+    /// let b: BTreeSet<int> = vec![2,3,4].into_iter().collect();
+    ///
+    /// let result: BTreeSet<int> = a & b;
+    /// let result_vec: Vec<int> = result.into_iter().collect();
+    /// assert_eq!(result_vec, vec![2,3]);
+    /// ```
+    fn bitand(&self, rhs: &BTreeSet<T>) -> BTreeSet<T> {
+        self.intersection(rhs).cloned().collect()
+    }
+}
+
+#[unstable = "matches collection reform specification, waiting for dust to settle"]
+impl<T: Ord + Clone> BitOr<BTreeSet<T>,BTreeSet<T>> for BTreeSet<T> {
+    /// Returns the union of `self` and `rhs` as a new `BTreeSet<T>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::BTreeSet;
+    ///
+    /// let a: BTreeSet<int> = vec![1,2,3].into_iter().collect();
+    /// let b: BTreeSet<int> = vec![3,4,5].into_iter().collect();
+    ///
+    /// let result: BTreeSet<int> = a | b;
+    /// let result_vec: Vec<int> = result.into_iter().collect();
+    /// assert_eq!(result_vec, vec![1,2,3,4,5]);
+    /// ```
+    fn bitor(&self, rhs: &BTreeSet<T>) -> BTreeSet<T> {
+        self.union(rhs).cloned().collect()
     }
 }
 


### PR DESCRIPTION
I am trying to add an implementation of `bitor` for `BTreeSet`. I think I am most of the way there, but I am going to need some guidance to take it all the way.

When I run `make check`, I get:

```
error: cannot move out of dereference of `&`-pointer
self.union(_rhs).map(|&i| i).collect::<BTreeSet<T>>()
                      ^~
```

I'd appreciate any nudges in the right direction. If I can figure this one out, I am sure I will be able to implement `bitand`, `bitxor`, and `sub` as well.

/cc @Gankro 

---

**Update**

I have added implementations for `BitOr`, `BitAnd`, `BitXor`, and `Sub` for `BTreeSet`.
