### PR TITLE
No need for feature gate directives for `if_let`, `while_let`, or `tuple_indexing` anymore.

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -22,8 +22,8 @@
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://doc.rust-lang.org/nightly/")]
 
-#![feature(default_type_params, globs, if_let, import_shadowing, macro_rules, phase, quote)]
-#![feature(slicing_syntax, tuple_indexing, unsafe_destructor)]
+#![feature(default_type_params, globs, import_shadowing, macro_rules, phase, quote)]
+#![feature(slicing_syntax, unsafe_destructor)]
 #![feature(rustc_diagnostic_macros)]
 
 extern crate arena;

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -22,7 +22,7 @@
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://doc.rust-lang.org/nightly/")]
 
-#![feature(default_type_params, globs, if_let, import_shadowing, macro_rules, phase, quote)]
+#![feature(default_type_params, globs, import_shadowing, macro_rules, phase, quote)]
 #![feature(slicing_syntax, unsafe_destructor)]
 #![feature(rustc_diagnostic_macros)]
 

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -22,7 +22,7 @@
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://doc.rust-lang.org/nightly/")]
 
-#![feature(default_type_params, globs, if_let, import_shadowing, macro_rules, phase, quote)]
+#![feature(default_type_params, globs, import_shadowing, macro_rules, phase, quote)]
 #![feature(slicing_syntax, unsafe_destructor)]
 #![feature(rustc_diagnostic_macros)]
 

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -71,8 +71,8 @@ This API is completely unstable and subject to change.
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://doc.rust-lang.org/nightly/")]
 
-#![feature(default_type_params, globs, if_let, import_shadowing, macro_rules, phase, quote)]
-#![feature(slicing_syntax, tuple_indexing, unsafe_destructor)]
+#![feature(default_type_params, globs, import_shadowing, macro_rules, phase, quote)]
+#![feature(slicing_syntax, unsafe_destructor)]
 #![feature(rustc_diagnostic_macros)]
 #![allow(non_camel_case_types)]
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -18,7 +18,7 @@
        html_playground_url = "http://play.rust-lang.org/")]
 
 #![allow(unknown_features)]
-#![feature(globs, if_let, macro_rules, phase, slicing_syntax, tuple_indexing)]
+#![feature(globs, macro_rules, phase, slicing_syntax)]
 
 extern crate arena;
 extern crate getopts;

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -106,7 +106,7 @@
 #![allow(unknown_features)]
 #![feature(macro_rules, globs, linkage)]
 #![feature(default_type_params, phase, lang_items, unsafe_destructor)]
-#![feature(import_shadowing, slicing_syntax, tuple_indexing)]
+#![feature(import_shadowing, slicing_syntax)]
 
 // Don't link to std. We are std.
 #![no_std]

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -23,7 +23,7 @@
        html_root_url = "http://doc.rust-lang.org/nightly/")]
 
 #![allow(unknown_features)]
-#![feature(if_let, macro_rules, globs, default_type_params, phase, slicing_syntax)]
+#![feature(macro_rules, globs, default_type_params, phase, slicing_syntax)]
 #![feature(quote, unsafe_destructor, import_shadowing)]
 
 extern crate arena;

--- a/src/test/compile-fail/issue-19096.rs
+++ b/src/test/compile-fail/issue-19096.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
-
 fn main() {
     let t = (42i, 42i);
     t.0::<int>; //~ ERROR expected one of `.`, `;`, `}`, or an operator, found `::`

--- a/src/test/run-pass/borrow-tuple-fields.rs
+++ b/src/test/run-pass/borrow-tuple-fields.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
-
 struct Foo(int, int);
 
 fn main() {

--- a/src/test/run-pass/if-let.rs
+++ b/src/test/run-pass/if-let.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(if_let)]
-
 pub fn main() {
     let x = Some(3i);
     if let Some(y) = x {

--- a/src/test/run-pass/issue-18412.rs
+++ b/src/test/run-pass/issue-18412.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
-
 // Test that non-static methods can be assigned to local variables as
 // function pointers.
 

--- a/src/test/run-pass/issue-19244.rs
+++ b/src/test/run-pass/issue-19244.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
-
 struct MyStruct { field: uint }
 const STRUCT: MyStruct = MyStruct { field: 42 };
 const TUP: (uint,) = (43,);

--- a/src/test/run-pass/tuple-index-fat-types.rs
+++ b/src/test/run-pass/tuple-index-fat-types.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
-
 struct Foo<'a>(&'a [int]);
 
 fn main() {

--- a/src/test/run-pass/tuple-index.rs
+++ b/src/test/run-pass/tuple-index.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
-
 struct Point(int, int);
 
 fn main() {

--- a/src/test/run-pass/while-let.rs
+++ b/src/test/run-pass/while-let.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(while_let)]
-
 use std::collections::BinaryHeap;
 
 fn make_pq() -> BinaryHeap<int> {


### PR DESCRIPTION
As soon as #19472 lands (Edit: and makes it into a snapshot), we won't need to use `if let`, `while_let`, or `tuple indexing` feature gates anymore.  This removes the last remaining instances that I could find throughout the source.

Closes #19473.
