### PR TITLE
Add capacity-related functions for VecMap

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -619,9 +619,9 @@ impl<T> Vec<T> {
     /// # Example
     ///
     /// ```
-    /// let mut vec: Vec<int> = vec![1];
+    /// let mut vec = Vec::new();
     /// vec.reserve(10);
-    /// assert!(vec.capacity() >= 11);
+    /// assert!(vec.capacity() >= 9);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn reserve(&mut self, additional: uint) {
@@ -656,9 +656,9 @@ impl<T> Vec<T> {
     /// # Example
     ///
     /// ```
-    /// let mut vec: Vec<int> = vec![1];
+    /// let mut vec = Vec::new();
     /// vec.reserve_exact(10);
-    /// assert!(vec.capacity() >= 11);
+    /// assert!(vec.capacity() >= 9);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn reserve_exact(&mut self, additional: uint) {
@@ -667,6 +667,54 @@ impl<T> Vec<T> {
                 None => panic!("Vec::reserve: `uint` overflow"),
                 Some(new_cap) => self.grow_capacity(new_cap)
             }
+        }
+    }
+
+    /// Reserves the minimum capacity for an element to be inserted at `index` in the given
+    /// `Vec`. The collection may reserve more space to avoid frequent reallocations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `uint`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let mut vec = Vec::new();
+    /// vec.reserve_index(10);
+    /// assert!(vec.capacity() >= 11);
+    /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn reserve_index(&mut self, index: uint) {
+        let len = self.len();
+        if index >= len {
+            self.reserve(index - len + 1);
+        }
+    }
+
+    /// Reserves the minimum capacity for an element to be inserted at `index` in the
+    /// given `Vec`. Does nothing if the capacity is already sufficient.
+    ///
+    /// Note that the allocator may give the collection more space than it requests. Therefore
+    /// capacity can not be relied upon to be precisely minimal. Prefer `reserve_index` if future
+    /// insertions are expected.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `uint`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let mut vec = Vec::new();
+    /// vec.reserve_index_exact(10);
+    /// assert!(vec.capacity() >= 11);
+    /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn reserve_index_exact(&mut self, index: uint) {
+        let len = self.len();
+        if index >= len {
+            self.reserve_exact(index - len + 1);
         }
     }
 
@@ -1789,6 +1837,72 @@ mod tests {
         v.push(16);
 
         v.reserve(16);
+        assert!(v.capacity() >= 33)
+    }
+
+    #[test]
+    fn test_reserve_exact() {
+        let mut v = Vec::new();
+        assert_eq!(v.capacity(), 0);
+
+        v.reserve_exact(2);
+        assert!(v.capacity() >= 2);
+
+        for i in range(0i, 16) {
+            v.push(i);
+        }
+
+        assert!(v.capacity() >= 16);
+        v.reserve_exact(16);
+        assert!(v.capacity() >= 32);
+
+        v.push(16);
+
+        v.reserve_exact(16);
+        assert!(v.capacity() >= 33)
+    }
+
+    #[test]
+    fn test_reserve_index() {
+        let mut v = Vec::new();
+        assert_eq!(v.capacity(), 0);
+
+        v.reserve_index(2);
+        assert!(v.capacity() >= 3);
+
+        for i in range(0i, 16) {
+            v.push(i);
+        }
+
+        assert!(v.capacity() >= 16);
+        v.reserve_index(16);
+        assert!(v.capacity() >= 17);
+
+        v.push(16);
+
+        v.reserve_index(32);
+        assert!(v.capacity() >= 33)
+    }
+
+    #[test]
+    fn test_reserve_index_exact() {
+        let mut v = Vec::new();
+        assert_eq!(v.capacity(), 0);
+
+        v.reserve_index_exact(2);
+        assert!(v.capacity() >= 3);
+
+        for i in range(0i, 16) {
+            v.push(i);
+        }
+
+        assert!(v.capacity() >= 16);
+        v.reserve_index_exact(16);
+        assert!(v.capacity() >= 17);
+
+        v.push(16);
+
+        v.reserve_index_exact(32);
         assert!(v.capacity() >= 33)
     }
 

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -619,9 +619,9 @@ impl<T> Vec<T> {
     /// # Example
     ///
     /// ```
-    /// let mut vec: Vec<uint> = Vec::new();
+    /// let mut vec: Vec<int> = vec![1];
     /// vec.reserve(10);
-    /// assert!(vec.capacity() >= 10);
+    /// assert!(vec.capacity() >= 11);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn reserve(&mut self, additional: uint) {
@@ -656,9 +656,9 @@ impl<T> Vec<T> {
     /// # Example
     ///
     /// ```
-    /// let mut vec: Vec<uint> = Vec::new();
+    /// let mut vec: Vec<int> = vec![1];
     /// vec.reserve_exact(10);
-    /// assert!(vec.capacity() >= 10);
+    /// assert!(vec.capacity() >= 11);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn reserve_exact(&mut self, additional: uint) {
@@ -667,54 +667,6 @@ impl<T> Vec<T> {
                 None => panic!("Vec::reserve: `uint` overflow"),
                 Some(new_cap) => self.grow_capacity(new_cap)
             }
-        }
-    }
-
-    /// Reserves the minimum capacity for an element to be inserted at `index` in the given
-    /// `Vec`. The collection may reserve more space to avoid frequent reallocations.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the new capacity overflows `uint`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// let mut vec: Vec<uint> = Vec::new();
-    /// vec.reserve_index(10);
-    /// assert!(vec.capacity() >= 11);
-    /// ```
-    #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn reserve_index(&mut self, index: uint) {
-        let len = self.len();
-        if index >= len {
-            self.reserve(index - len + 1);
-        }
-    }
-
-    /// Reserves the minimum capacity for an element to be inserted at `index` in the
-    /// given `Vec`. Does nothing if the capacity is already sufficient.
-    ///
-    /// Note that the allocator may give the collection more space than it requests. Therefore
-    /// capacity can not be relied upon to be precisely minimal. Prefer `reserve_index` if future
-    /// insertions are expected.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the new capacity overflows `uint`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// let mut vec: Vec<uint> = Vec::new();
-    /// vec.reserve_index_exact(10);
-    /// assert!(vec.capacity() >= 11);
-    /// ```
-    #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn reserve_index_exact(&mut self, index: uint) {
-        let len = self.len();
-        if index >= len {
-            self.reserve_exact(index - len + 1);
         }
     }
 
@@ -1837,72 +1789,6 @@ mod tests {
         v.push(16);
 
         v.reserve(16);
-        assert!(v.capacity() >= 33)
-    }
-
-    #[test]
-    fn test_reserve_exact() {
-        let mut v = Vec::new();
-        assert_eq!(v.capacity(), 0);
-
-        v.reserve_exact(2);
-        assert!(v.capacity() >= 2);
-
-        for i in range(0i, 16) {
-            v.push(i);
-        }
-
-        assert!(v.capacity() >= 16);
-        v.reserve_exact(16);
-        assert!(v.capacity() >= 32);
-
-        v.push(16);
-
-        v.reserve_exact(16);
-        assert!(v.capacity() >= 33)
-    }
-
-    #[test]
-    fn test_reserve_index() {
-        let mut v = Vec::new();
-        assert_eq!(v.capacity(), 0);
-
-        v.reserve_index(2);
-        assert!(v.capacity() >= 3);
-
-        for i in range(0i, 16) {
-            v.push(i);
-        }
-
-        assert!(v.capacity() >= 16);
-        v.reserve_index(16);
-        assert!(v.capacity() >= 17);
-
-        v.push(16);
-
-        v.reserve_index(32);
-        assert!(v.capacity() >= 33)
-    }
-
-    #[test]
-    fn test_reserve_index_exact() {
-        let mut v = Vec::new();
-        assert_eq!(v.capacity(), 0);
-
-        v.reserve_index_exact(2);
-        assert!(v.capacity() >= 3);
-
-        for i in range(0i, 16) {
-            v.push(i);
-        }
-
-        assert!(v.capacity() >= 16);
-        v.reserve_index_exact(16);
-        assert!(v.capacity() >= 17);
-
-        v.push(16);
-
-        v.reserve_index_exact(32);
         assert!(v.capacity() >= 33)
     }
 

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -621,7 +621,7 @@ impl<T> Vec<T> {
     /// ```
     /// let mut vec: Vec<uint> = Vec::new();
     /// vec.reserve(10);
-    /// assert!(vec.capacity() >= 9);
+    /// assert!(vec.capacity() >= 10);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn reserve(&mut self, additional: uint) {
@@ -658,7 +658,7 @@ impl<T> Vec<T> {
     /// ```
     /// let mut vec: Vec<uint> = Vec::new();
     /// vec.reserve_exact(10);
-    /// assert!(vec.capacity() >= 9);
+    /// assert!(vec.capacity() >= 10);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn reserve_exact(&mut self, additional: uint) {

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -619,7 +619,7 @@ impl<T> Vec<T> {
     /// # Example
     ///
     /// ```
-    /// let mut vec = Vec::new();
+    /// let mut vec: Vec<uint> = Vec::new();
     /// vec.reserve(10);
     /// assert!(vec.capacity() >= 9);
     /// ```
@@ -656,7 +656,7 @@ impl<T> Vec<T> {
     /// # Example
     ///
     /// ```
-    /// let mut vec = Vec::new();
+    /// let mut vec: Vec<uint> = Vec::new();
     /// vec.reserve_exact(10);
     /// assert!(vec.capacity() >= 9);
     /// ```
@@ -680,7 +680,7 @@ impl<T> Vec<T> {
     /// # Example
     ///
     /// ```
-    /// let mut vec = Vec::new();
+    /// let mut vec: Vec<uint> = Vec::new();
     /// vec.reserve_index(10);
     /// assert!(vec.capacity() >= 11);
     /// ```
@@ -706,7 +706,7 @@ impl<T> Vec<T> {
     /// # Example
     ///
     /// ```
-    /// let mut vec = Vec::new();
+    /// let mut vec: Vec<uint> = Vec::new();
     /// vec.reserve_index_exact(10);
     /// assert!(vec.capacity() >= 11);
     /// ```

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -171,49 +171,6 @@ impl<V> VecMap<V> {
         self.v.reserve_exact(additional);
     }
 
-    /// Reserves the minimum capacity for an element to be inserted at `index` in the given
-    /// `VecMap`. The collection may reserve more space to avoid frequent reallocations.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the new capacity overflows `uint`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use std::collections::VecMap;
-    /// let mut map: VecMap<String> = VecMap::new();
-    /// map.reserve_index(10);
-    /// assert!(map.capacity() >= 11);
-    /// ```
-    #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn reserve_index(&mut self, index: uint) {
-        self.v.reserve_index(index);
-    }
-
-    /// Reserves the minimum capacity for an element to be inserted at `index` in the
-    /// given `VecMap`. Does nothing if the capacity is already sufficient.
-    ///
-    /// Note that the allocator may give the collection more space than it requests. Therefore
-    /// capacity can not be relied upon to be precisely minimal. Prefer `reserve_index` if future
-    /// insertions are expected.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the new capacity overflows `uint`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use std::collections::VecMap;
-    /// let mut map: VecMap<String> = VecMap::new();
-    /// map.reserve_index_exact(10);
-    /// assert!(map.capacity() >= 11);
-    /// ```
-    pub fn reserve_index_exact(&mut self, index: uint) {
-        self.v.reserve_index_exact(index);
-    }
-
     /// Returns an iterator visiting all keys in ascending order by the keys.
     /// The iterator's element type is `uint`.
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
@@ -798,94 +755,6 @@ mod test_map {
     }
 
     #[test]
-    fn test_reserve() {
-        let mut map = VecMap::new();
-        assert_eq!(map.capacity(), 0);
-
-        map.reserve(2);
-        assert!(map.capacity() >= 2);
-
-        for i in range(0u, 16) {
-            map.insert(i, "a");
-        }
-
-        assert!(map.capacity() >= 16);
-        map.reserve(16);
-        assert!(map.capacity() >= 32);
-
-        map.insert(16,"b");
-
-        map.reserve(16);
-        assert!(map.capacity() >= 33)
-    }
-
-    #[test]
-    fn test_reserve_exact() {
-        let mut map = VecMap::new();
-        assert_eq!(map.capacity(), 0);
-
-        map.reserve_exact(2);
-        assert!(map.capacity() >= 2);
-
-        for i in range(0u, 16) {
-            map.insert(i, "a");
-        }
-
-        assert!(map.capacity() >= 16);
-        map.reserve_exact(16);
-        assert!(map.capacity() >= 32);
-
-        map.insert(16,"b");
-
-        map.reserve_exact(16);
-        assert!(map.capacity() >= 33)
-    }
-
-    #[test]
-    fn test_reserve_index() {
-        let mut map = VecMap::new();
-        assert_eq!(map.capacity(), 0);
-
-        map.reserve_index(2);
-        assert!(map.capacity() >= 3);
-
-        for i in range(0u, 16) {
-            map.insert(i, "a");
-        }
-
-        assert!(map.capacity() >= 16);
-        map.reserve_index(16);
-        assert!(map.capacity() >= 17);
-
-        map.insert(16,"b");
-
-        map.reserve_index(32);
-        assert!(map.capacity() >= 33)
-    }
-
-    #[test]
-    fn test_reserve_index_exact() {
-        let mut map = VecMap::new();
-        assert_eq!(map.capacity(), 0);
-
-        map.reserve_index_exact(2);
-        assert!(map.capacity() >= 3);
-
-        for i in range(0u, 16) {
-            map.insert(i, "a");
-        }
-
-        assert!(map.capacity() >= 16);
-        map.reserve_index_exact(16);
-        assert!(map.capacity() >= 17);
-
-        map.insert(16,"b");
-
-        map.reserve_index_exact(32);
-        assert!(map.capacity() >= 33)
-    }
-
-    #[test]
     fn test_keys() {
         let mut map = VecMap::new();
         map.insert(1, 'a');
@@ -1233,4 +1102,3 @@ mod bench {
                    |m, i| { m.get(&i); });
     }
 }
-

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -125,7 +125,7 @@ impl<V> VecMap<V> {
     /// # Example
     ///
     /// ```
-    /// let mut map = VecMap::new();
+    /// let mut map: VecMap<String> = VecMap::new();
     /// map.reserve(10);
     /// assert!(map.v.capacity() >= 9);
     /// ```
@@ -144,7 +144,7 @@ impl<V> VecMap<V> {
     /// # Example
     ///
     /// ```
-    /// let mut map = VecMap::new();
+    /// let mut map: VecMap<String> = VecMap::new();
     /// map.reserve_exact(10);
     /// assert!(map.v.capacity() >= 9);
     /// ```
@@ -163,7 +163,7 @@ impl<V> VecMap<V> {
     /// # Example
     ///
     /// ```
-    /// let mut map = VecMap::new();
+    /// let mut map: VecMap<String> = VecMap::new();
     /// map.reserve_index(10);
     /// assert!(map.v.capacity() >= 11);
     /// ```
@@ -186,7 +186,7 @@ impl<V> VecMap<V> {
     /// # Example
     ///
     /// ```
-    /// let mut map = VecMap::new();
+    /// let mut map: VecMap<String> = VecMap::new();
     /// map.reserve_index_exact(10);
     /// assert!(map.v.capacity() >= 11);
     /// ```

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -127,7 +127,7 @@ impl<V> VecMap<V> {
     /// ```
     /// let mut map: VecMap<String> = VecMap::new();
     /// map.reserve(10);
-    /// assert!(map.v.capacity() >= 9);
+    /// assert!(map.v.capacity() >= 10);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn reserve(&mut self, additional: uint) {
@@ -146,7 +146,7 @@ impl<V> VecMap<V> {
     /// ```
     /// let mut map: VecMap<String> = VecMap::new();
     /// map.reserve_exact(10);
-    /// assert!(map.v.capacity() >= 9);
+    /// assert!(map.v.capacity() >= 10);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn reserve_exact(&mut self, additional: uint) {

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -115,6 +115,85 @@ impl<V> VecMap<V> {
         VecMap { v: Vec::with_capacity(capacity) }
     }
 
+    /// Reserves capacity for at least `additional` more elements to be inserted in the given
+    /// `VecMap`. The collection may reserve more space to avoid frequent reallocations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `uint`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let mut map = VecMap::new();
+    /// map.reserve(10);
+    /// assert!(map.v.capacity() >= 9);
+    /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn reserve(&mut self, additional: uint) {
+        self.v.reserve(additional);
+    }
+
+    /// Reserves the minimum capacity for exactly `additional` more elements to be inserted in the
+    /// `VecMap`. The collection may reserve more space to avoid frequent reallocations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `uint`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let mut map = VecMap::new();
+    /// map.reserve_exact(10);
+    /// assert!(map.v.capacity() >= 9);
+    /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn reserve_exact(&mut self, additional: uint) {
+        self.v.reserve_exact(additional);
+    }
+
+    /// Reserves the minimum capacity for an element to be inserted at `index` in the given
+    /// `VecMap`. The collection may reserve more space to avoid frequent reallocations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `uint`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let mut map = VecMap::new();
+    /// map.reserve_index(10);
+    /// assert!(map.v.capacity() >= 11);
+    /// ```
+    #[unstable = "matches collection reform specification, waiting for dust to settle"]
+    pub fn reserve_index(&mut self, index: uint) {
+        self.v.reserve_index(index);
+    }
+
+    /// Reserves the minimum capacity for an element to be inserted at `index` in the
+    /// given `VecMap`. Does nothing if the capacity is already sufficient.
+    ///
+    /// Note that the allocator may give the collection more space than it requests. Therefore
+    /// capacity can not be relied upon to be precisely minimal. Prefer `reserve_index` if future
+    /// insertions are expected.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows `uint`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let mut map = VecMap::new();
+    /// map.reserve_index_exact(10);
+    /// assert!(map.v.capacity() >= 11);
+    /// ```
+    pub fn reserve_index_exact(&mut self, index: uint) {
+        self.v.reserve_index_exact(index);
+    }
+
     /// Returns an iterator visiting all keys in ascending order by the keys.
     /// The iterator's element type is `uint`.
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
@@ -699,6 +778,94 @@ mod test_map {
     }
 
     #[test]
+    fn test_reserve() {
+        let mut map = VecMap::new();
+        assert_eq!(map.v.capacity(), 0);
+
+        map.reserve(2);
+        assert!(map.v.capacity() >= 2);
+
+        for i in range(0u, 16) {
+            map.insert(i, "a");
+        }
+
+        assert!(map.v.capacity() >= 16);
+        map.reserve(16);
+        assert!(map.v.capacity() >= 32);
+
+        map.insert(16,"b");
+
+        map.reserve(16);
+        assert!(map.v.capacity() >= 33)
+    }
+
+    #[test]
+    fn test_reserve_exact() {
+        let mut map = VecMap::new();
+        assert_eq!(map.v.capacity(), 0);
+
+        map.reserve_exact(2);
+        assert!(map.v.capacity() >= 2);
+
+        for i in range(0u, 16) {
+            map.insert(i, "a");
+        }
+
+        assert!(map.v.capacity() >= 16);
+        map.reserve_exact(16);
+        assert!(map.v.capacity() >= 32);
+
+        map.insert(16,"b");
+
+        map.reserve_exact(16);
+        assert!(map.v.capacity() >= 33)
+    }
+
+    #[test]
+    fn test_reserve_index() {
+        let mut map = VecMap::new();
+        assert_eq!(map.v.capacity(), 0);
+
+        map.reserve_index(2);
+        assert!(map.v.capacity() >= 3);
+
+        for i in range(0u, 16) {
+            map.insert(i, "a");
+        }
+
+        assert!(map.v.capacity() >= 16);
+        map.reserve_index(16);
+        assert!(map.v.capacity() >= 17);
+
+        map.insert(16,"b");
+
+        map.reserve_index(32);
+        assert!(map.v.capacity() >= 33)
+    }
+
+    #[test]
+    fn test_reserve_index_exact() {
+        let mut map = VecMap::new();
+        assert_eq!(map.v.capacity(), 0);
+
+        map.reserve_index_exact(2);
+        assert!(map.v.capacity() >= 3);
+
+        for i in range(0u, 16) {
+            map.insert(i, "a");
+        }
+
+        assert!(map.v.capacity() >= 16);
+        map.reserve_index_exact(16);
+        assert!(map.v.capacity() >= 17);
+
+        map.insert(16,"b");
+
+        map.reserve_index_exact(32);
+        assert!(map.v.capacity() >= 33)
+    }
+
+    #[test]
     fn test_keys() {
         let mut map = VecMap::new();
         map.insert(1, 'a');
@@ -1046,3 +1213,4 @@ mod bench {
                    |m, i| { m.get(&i); });
     }
 }
+

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -115,6 +115,22 @@ impl<V> VecMap<V> {
         VecMap { v: Vec::with_capacity(capacity) }
     }
 
+    /// Returns the number of elements the `VecMap` can hold without
+    /// reallocating.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::collections::VecMap;
+    /// let map: VecMap<String> = VecMap::with_capacity(10);
+    /// assert_eq!(map.capacity(), 10);
+    /// ```
+    #[inline]
+    #[stable]
+    pub fn capacity(&self) -> uint {
+        self.v.capacity()
+    }
+
     /// Reserves capacity for at least `additional` more elements to be inserted in the given
     /// `VecMap`. The collection may reserve more space to avoid frequent reallocations.
     ///
@@ -125,9 +141,10 @@ impl<V> VecMap<V> {
     /// # Example
     ///
     /// ```
+    /// use std::collections::VecMap;
     /// let mut map: VecMap<String> = VecMap::new();
     /// map.reserve(10);
-    /// assert!(map.v.capacity() >= 10);
+    /// assert!(map.capacity() >= 10);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn reserve(&mut self, additional: uint) {
@@ -144,9 +161,10 @@ impl<V> VecMap<V> {
     /// # Example
     ///
     /// ```
+    /// use std::collections::VecMap;
     /// let mut map: VecMap<String> = VecMap::new();
     /// map.reserve_exact(10);
-    /// assert!(map.v.capacity() >= 10);
+    /// assert!(map.capacity() >= 10);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn reserve_exact(&mut self, additional: uint) {
@@ -163,9 +181,10 @@ impl<V> VecMap<V> {
     /// # Example
     ///
     /// ```
+    /// use std::collections::VecMap;
     /// let mut map: VecMap<String> = VecMap::new();
     /// map.reserve_index(10);
-    /// assert!(map.v.capacity() >= 11);
+    /// assert!(map.capacity() >= 11);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn reserve_index(&mut self, index: uint) {
@@ -186,9 +205,10 @@ impl<V> VecMap<V> {
     /// # Example
     ///
     /// ```
+    /// use std::collections::VecMap;
     /// let mut map: VecMap<String> = VecMap::new();
     /// map.reserve_index_exact(10);
-    /// assert!(map.v.capacity() >= 11);
+    /// assert!(map.capacity() >= 11);
     /// ```
     pub fn reserve_index_exact(&mut self, index: uint) {
         self.v.reserve_index_exact(index);
@@ -780,89 +800,89 @@ mod test_map {
     #[test]
     fn test_reserve() {
         let mut map = VecMap::new();
-        assert_eq!(map.v.capacity(), 0);
+        assert_eq!(map.capacity(), 0);
 
         map.reserve(2);
-        assert!(map.v.capacity() >= 2);
+        assert!(map.capacity() >= 2);
 
         for i in range(0u, 16) {
             map.insert(i, "a");
         }
 
-        assert!(map.v.capacity() >= 16);
+        assert!(map.capacity() >= 16);
         map.reserve(16);
-        assert!(map.v.capacity() >= 32);
+        assert!(map.capacity() >= 32);
 
         map.insert(16,"b");
 
         map.reserve(16);
-        assert!(map.v.capacity() >= 33)
+        assert!(map.capacity() >= 33)
     }
 
     #[test]
     fn test_reserve_exact() {
         let mut map = VecMap::new();
-        assert_eq!(map.v.capacity(), 0);
+        assert_eq!(map.capacity(), 0);
 
         map.reserve_exact(2);
-        assert!(map.v.capacity() >= 2);
+        assert!(map.capacity() >= 2);
 
         for i in range(0u, 16) {
             map.insert(i, "a");
         }
 
-        assert!(map.v.capacity() >= 16);
+        assert!(map.capacity() >= 16);
         map.reserve_exact(16);
-        assert!(map.v.capacity() >= 32);
+        assert!(map.capacity() >= 32);
 
         map.insert(16,"b");
 
         map.reserve_exact(16);
-        assert!(map.v.capacity() >= 33)
+        assert!(map.capacity() >= 33)
     }
 
     #[test]
     fn test_reserve_index() {
         let mut map = VecMap::new();
-        assert_eq!(map.v.capacity(), 0);
+        assert_eq!(map.capacity(), 0);
 
         map.reserve_index(2);
-        assert!(map.v.capacity() >= 3);
+        assert!(map.capacity() >= 3);
 
         for i in range(0u, 16) {
             map.insert(i, "a");
         }
 
-        assert!(map.v.capacity() >= 16);
+        assert!(map.capacity() >= 16);
         map.reserve_index(16);
-        assert!(map.v.capacity() >= 17);
+        assert!(map.capacity() >= 17);
 
         map.insert(16,"b");
 
         map.reserve_index(32);
-        assert!(map.v.capacity() >= 33)
+        assert!(map.capacity() >= 33)
     }
 
     #[test]
     fn test_reserve_index_exact() {
         let mut map = VecMap::new();
-        assert_eq!(map.v.capacity(), 0);
+        assert_eq!(map.capacity(), 0);
 
         map.reserve_index_exact(2);
-        assert!(map.v.capacity() >= 3);
+        assert!(map.capacity() >= 3);
 
         for i in range(0u, 16) {
             map.insert(i, "a");
         }
 
-        assert!(map.v.capacity() >= 16);
+        assert!(map.capacity() >= 16);
         map.reserve_index_exact(16);
-        assert!(map.v.capacity() >= 17);
+        assert!(map.capacity() >= 17);
 
         map.insert(16,"b");
 
         map.reserve_index_exact(32);
-        assert!(map.v.capacity() >= 33)
+        assert!(map.capacity() >= 33)
     }
 
     #[test]

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -755,6 +755,50 @@ mod test_map {
     }
 
     #[test]
+    fn test_reserve() {
+        let mut map = VecMap::new();
+        assert_eq!(map.capacity(), 0);
+
+        map.reserve(2);
+        assert!(map.capacity() >= 2);
+
+        for i in range(0u, 16) {
+            map.insert(i, "a");
+        }
+
+        assert!(map.capacity() >= 16);
+        map.reserve(16);
+        assert!(map.capacity() >= 32);
+
+        map.insert(16,"b");
+
+        map.reserve(16);
+        assert!(map.capacity() >= 33)
+    }
+
+    #[test]
+    fn test_reserve_exact() {
+        let mut map = VecMap::new();
+        assert_eq!(map.capacity(), 0);
+
+        map.reserve_exact(2);
+        assert!(map.capacity() >= 2);
+
+        for i in range(0u, 16) {
+            map.insert(i, "a");
+        }
+
+        assert!(map.capacity() >= 16);
+        map.reserve_exact(16);
+        assert!(map.capacity() >= 32);
+
+        map.insert(16,"b");
+
+        map.reserve_exact(16);
+        assert!(map.capacity() >= 33)
+    }
+
+    #[test]
     fn test_keys() {
         let mut map = VecMap::new();
         map.insert(1, 'a');


### PR DESCRIPTION
Part of #18424

Adds functions `reserve(uint)`, `reserve_exact(uint)`,  and `capacity()` to VecMap, as per the collections reform.

(Separation of PRs from #19516)
