### PR TITLE
Tidy up DynamicLibrary API

### DIFF
--- a/src/librustc/plugin/load.rs
+++ b/src/librustc/plugin/load.rs
@@ -136,7 +136,7 @@ impl<'a> PluginLoader<'a> {
         // Make sure the path contains a / or the linker will search for it.
         let path = os::make_absolute(&path).unwrap();
 
-        let lib = match DynamicLibrary::open(Some(&path)) {
+        let lib = match DynamicLibrary::load(&path) {
             Ok(lib) => lib,
             // this is fatal: there are almost certainly macros we need
             // inside this crate, so continue would spew "macro undefined"

--- a/src/librustdoc/plugins.rs
+++ b/src/librustdoc/plugins.rs
@@ -44,7 +44,7 @@ impl PluginManager {
     /// elsewhere, libname.so.
     pub fn load_plugin(&mut self, name: String) {
         let x = self.prefix.join(libname(name));
-        let lib_result = dl::DynamicLibrary::open(Some(&x));
+        let lib_result = dl::DynamicLibrary::load(&x);
         let lib = lib_result.unwrap();
         unsafe {
             let plugin = lib.symbol("rustdoc_plugin_entrypoint").unwrap();

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -16,7 +16,6 @@
 #![allow(missing_docs)]
 
 use clone::Clone;
-use core::kinds::Sized;
 use c_str::ToCStr;
 use iter::IteratorExt;
 use mem;
@@ -70,11 +69,11 @@ impl DynamicLibrary {
     }
 
     /// Load a dynamic library.
-    pub fn load<Sized? T: ToCStr>(file_name: &T)
+    pub fn load<T: ToCStr>(file_name: T)
                         -> Result<DynamicLibrary, String> {
         unsafe {
             let maybe_library = dl::check_for_errors_in(|| {
-                dl::open_external(file_name)
+                dl::open_external(&file_name)
             });
 
             // The dynamic library must not be constructed if there is
@@ -235,14 +234,13 @@ mod test {
 pub mod dl {
     pub use self::Rtld::*;
 
-    use core::kinds::Sized;
     use c_str::{CString, ToCStr};
     use libc;
     use ptr;
     use result::*;
     use string::String;
 
-    pub unsafe fn open_external<Sized? T: ToCStr>(file_name: &T) -> *mut u8 {
+    pub unsafe fn open_external<T: ToCStr>(file_name: T) -> *mut u8 {
         file_name.with_c_str(|raw_name| {
             dlopen(raw_name, Lazy as libc::c_int) as *mut u8
         })
@@ -304,7 +302,6 @@ pub mod dl {
 #[cfg(target_os = "windows")]
 pub mod dl {
     use c_str::ToCStr;
-    use core::kinds::Sized;
     use iter::IteratorExt;
     use libc;
     use os;
@@ -316,7 +313,7 @@ pub mod dl {
     use string::String;
     use vec::Vec;
 
-    pub unsafe fn open_external<Sized? T: ToCStr>(file_name: &T) -> *mut u8 {
+    pub unsafe fn open_external<T: ToCStr>(file_name: T) -> *mut u8 {
         // Windows expects Unicode data
         let filename_cstr = file_name.to_c_str();
         let filename_str = str::from_utf8(filename_cstr.as_bytes_no_nul()).unwrap();

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -16,6 +16,7 @@
 #![allow(missing_docs)]
 
 use clone::Clone;
+use core::kinds::Sized;
 use c_str::ToCStr;
 use iter::IteratorExt;
 use mem;
@@ -45,25 +46,52 @@ impl Drop for DynamicLibrary {
 }
 
 impl DynamicLibrary {
-    // FIXME (#12938): Until DST lands, we cannot decompose &str into
-    // & and str, so we cannot usefully take ToCStr arguments by
-    // reference (without forcing an additional & around &str). So we
-    // are instead temporarily adding an instance for &Path, so that
-    // we can take ToCStr as owned. When DST lands, the &Path instance
-    // should be removed, and arguments bound by ToCStr should be
-    // passed by reference. (Here: in the `open` method.)
-
     /// Lazily open a dynamic library. When passed None it gives a
     /// handle to the calling process
+    #[deprecated="replaced by `load` and `main_program`"]
     pub fn open<T: ToCStr>(filename: Option<T>)
                         -> Result<DynamicLibrary, String> {
         unsafe {
             let mut filename = filename;
             let maybe_library = dl::check_for_errors_in(|| {
                 match filename.take() {
-                    Some(name) => dl::open_external(name),
+                    Some(name) => dl::open_external(&name),
                     None => dl::open_internal()
                 }
+            });
+            // The dynamic library must not be constructed if there is
+            // an error opening the library so the destructor does not
+            // run.
+            match maybe_library {
+                Err(err) => Err(err),
+                Ok(handle) => Ok(DynamicLibrary { handle: handle })
+            }
+        }
+    }
+
+    /// Load a dynamic library.
+    pub fn load<Sized? T: ToCStr>(file_name: &T)
+                        -> Result<DynamicLibrary, String> {
+        unsafe {
+            let maybe_library = dl::check_for_errors_in(|| {
+                dl::open_external(file_name)
+            });
+
+            // The dynamic library must not be constructed if there is
+            // an error opening the library so the destructor does not
+            // run.
+            match maybe_library {
+                Err(err) => Err(err),
+                Ok(handle) => Ok(DynamicLibrary { handle: handle })
+            }
+        }
+    }
+
+    /// Return a DynamicLibrary that represents the main program
+    pub fn main_program() -> Result<DynamicLibrary, String> {
+        unsafe {
+            let maybe_library = dl::check_for_errors_in(|| {
+                dl::open_internal()
             });
 
             // The dynamic library must not be constructed if there is
@@ -161,8 +189,7 @@ mod test {
     fn test_loading_cosine() {
         // The math library does not need to be loaded since it is already
         // statically linked in
-        let none: Option<Path> = None; // appease the typechecker
-        let libm = match DynamicLibrary::open(none) {
+        let libm = match DynamicLibrary::main_program() {
             Err(error) => panic!("Could not load self as module: {}", error),
             Ok(libm) => libm
         };
@@ -192,7 +219,7 @@ mod test {
         // Open /dev/null as a library to get an error, and make sure
         // that only causes an error, and not a crash.
         let path = Path::new("/dev/null");
-        match DynamicLibrary::open(Some(&path)) {
+        match DynamicLibrary::load(&path) {
             Err(_) => {}
             Ok(_) => panic!("Successfully opened the empty library.")
         }
@@ -208,14 +235,15 @@ mod test {
 pub mod dl {
     pub use self::Rtld::*;
 
+    use core::kinds::Sized;
     use c_str::{CString, ToCStr};
     use libc;
     use ptr;
     use result::*;
     use string::String;
 
-    pub unsafe fn open_external<T: ToCStr>(filename: T) -> *mut u8 {
-        filename.with_c_str(|raw_name| {
+    pub unsafe fn open_external<Sized? T: ToCStr>(file_name: &T) -> *mut u8 {
+        file_name.with_c_str(|raw_name| {
             dlopen(raw_name, Lazy as libc::c_int) as *mut u8
         })
     }
@@ -276,6 +304,7 @@ pub mod dl {
 #[cfg(target_os = "windows")]
 pub mod dl {
     use c_str::ToCStr;
+    use core::kinds::Sized;
     use iter::IteratorExt;
     use libc;
     use os;
@@ -287,9 +316,9 @@ pub mod dl {
     use string::String;
     use vec::Vec;
 
-    pub unsafe fn open_external<T: ToCStr>(filename: T) -> *mut u8 {
+    pub unsafe fn open_external<Sized? T: ToCStr>(file_name: &T) -> *mut u8 {
         // Windows expects Unicode data
-        let filename_cstr = filename.to_c_str();
+        let filename_cstr = file_name.to_c_str();
         let filename_str = str::from_utf8(filename_cstr.as_bytes_no_nul()).unwrap();
         let mut filename_str: Vec<u16> = filename_str.utf16_units().collect();
         filename_str.push(0);


### PR DESCRIPTION
Two main changes here:
- Split the "open" function to two, "load" and "main_program". I see no need to model this API on posix, where you can pass NULL as a parameter. Intuitively, what does it mean to "open(None)"? Also, calling it "load" since it not only opens the library file but also loads it into memory.
- DST-ify the API, take parameter as borrowed ref instead.

[breaking-change]
