### PR TITLE
Fix two bugs in HRTB

### DIFF
--- a/src/librustc/middle/typeck/collect.rs
+++ b/src/librustc/middle/typeck/collect.rs
@@ -1074,7 +1074,7 @@ pub fn convert(ccx: &CrateCtxt, it: &ast::Item) {
                       ref selfty,
                       ref impl_items) => {
             // Create generics from the generics specified in the impl head.
-            let ty_generics = ty_generics_for_type(
+            let ty_generics = ty_generics_for_impl(
                     ccx,
                     generics,
                     CreateTypeParametersForAssociatedTypes);
@@ -1674,6 +1674,24 @@ fn ty_generics_for_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     generics.types.push(subst::SelfSpace, def);
 
     generics
+}
+
+fn ty_generics_for_impl<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
+                                  generics: &ast::Generics,
+                                  create_type_parameters_for_associated_types:
+                                      CreateTypeParametersForAssociatedTypesFlag)
+                                  -> ty::Generics<'tcx>
+{
+    let early_lifetimes = resolve_lifetime::early_bound_lifetimes(generics);
+    debug!("ty_generics_for_impl: early_lifetimes={}",
+           early_lifetimes);
+    ty_generics(ccx,
+                subst::TypeSpace,
+                early_lifetimes.as_slice(),
+                generics.ty_params.as_slice(),
+                ty::Generics::empty(),
+                &generics.where_clause,
+                create_type_parameters_for_associated_types)
 }
 
 fn ty_generics_for_fn_or_method<'tcx,AC>(

--- a/src/test/compile-fail/hrtb-debruijn-in-receiver.rs
+++ b/src/test/compile-fail/hrtb-debruijn-in-receiver.rs
@@ -1,0 +1,28 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test the case where the `Self` type has a bound lifetime that must
+// be adjusted in the fn signature. Issue #19537.
+
+use std::collections::HashMap;
+
+struct Foo<'a> {
+    map: HashMap<uint, &'a str>
+}
+
+impl<'a> Foo<'a> {
+    fn new() -> Foo<'a> { panic!() }
+    fn insert(&'a mut self) { }
+}
+fn main() {
+    let mut foo = Foo::new();
+    foo.insert();
+    foo.insert(); //~ ERROR cannot borrow
+}


### PR DESCRIPTION
Fix two bugs in HRTB:
1. Categorize early-vs-late bindings on impls when constructing generics, so that we don't add unnecessary region parameters.
2. Correct the DeBruijn indices when substituting the self type into the method signature.

Previously, the DeBruijn index for the self type was not being
adjusted to account for the fn binder. This mean that when late-bound
regions were instantiated, you sometimes wind up with two distinct
lifetimes.

Fixes #19537.

r? @pcwalton 
