### PR TITLE
rustc: Prepend a length to all metadata

### DIFF
--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -227,9 +227,18 @@ impl crate_metadata {
 
 impl MetadataBlob {
     pub fn as_slice<'a>(&'a self) -> &'a [u8] {
-        match *self {
+        let slice = match *self {
             MetadataVec(ref vec) => vec.as_slice(),
             MetadataArchive(ref ar) => ar.as_slice(),
+        };
+        if slice.len() < 4 {
+            &[]
+        } else {
+            let len = ((slice[0] as u32) << 24) |
+                      ((slice[1] as u32) << 16) |
+                      ((slice[2] as u32) << 8) |
+                      ((slice[3] as u32) << 0);
+            slice.slice(4, len as uint + 4)
         }
     }
 }

--- a/src/test/run-pass-fulldeps/issue-13560.rs
+++ b/src/test/run-pass-fulldeps/issue-13560.rs
@@ -11,7 +11,6 @@
 // aux-build:issue-13560-1.rs
 // aux-build:issue-13560-2.rs
 // aux-build:issue-13560-3.rs
-// ignore-pretty FIXME #19501
 // ignore-stage1
 
 // Regression test for issue #13560, the test itself is all in the dependent


### PR DESCRIPTION
One of the causes of #19501 was that the metadata on OSX was getting corrupted.
For any one particular invocation of the compiler the metadata file inside of an
rlib archive would have extra bytes appended to the end of it. These extra bytes
end up confusing rbml and have it run off the end of the array (resulting in the
out of bounds detected).

This commit prepends the length of metadata to the start of the metadata to
ensure that we always slice the precise amount that we want, and it also
un-ignores the test from #19502.

Closes #19501
