### PR TITLE
Fix ICE related to enum struct variants

### DIFF
--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -681,14 +681,22 @@ pub fn get_enum_variants<'tcx>(intr: Rc<IdentInterner>, cdata: Cmd, id: ast::Nod
         let ctor_ty = item_type(ast::DefId { krate: cdata.cnum, node: id},
                                 item, tcx, cdata);
         let name = item_name(&*intr, item);
-        let (ctor_ty, arg_tys) = match ctor_ty.sty {
+        let (ctor_ty, arg_tys, arg_names) = match ctor_ty.sty {
             ty::ty_bare_fn(ref f) =>
-                (Some(ctor_ty), f.sig.inputs.clone()),
-            _ => // Nullary or struct enum variant.
-                (None, get_struct_fields(intr.clone(), cdata, did.node)
+                (Some(ctor_ty), f.sig.inputs.clone(), None),
+            _ => { // Nullary or struct enum variant.
+                let mut arg_names = Vec::new();
+                let arg_tys = get_struct_fields(intr.clone(), cdata, did.node)
                     .iter()
-                    .map(|field_ty| get_type(cdata, field_ty.id.node, tcx).ty)
-                    .collect())
+                    .map(|field_ty| {
+                        arg_names.push(ast::Ident::new(field_ty.name));
+                        get_type(cdata, field_ty.id.node, tcx).ty
+                    })
+                    .collect();
+                let arg_names = if arg_names.len() == 0 { None } else { Some(arg_names) };
+
+                (None, arg_tys, arg_names)
+            }
         };
         match variant_disr_val(item) {
             Some(val) => { disr_val = val; }
@@ -698,7 +706,7 @@ pub fn get_enum_variants<'tcx>(intr: Rc<IdentInterner>, cdata: Cmd, id: ast::Nod
         disr_val += 1;
         Rc::new(ty::VariantInfo {
             args: arg_tys,
-            arg_names: None,
+            arg_names: arg_names,
             ctor_ty: ctor_ty,
             name: name,
             // I'm not even sure if we encode visibility

--- a/src/test/auxiliary/issue-19340-1.rs
+++ b/src/test/auxiliary/issue-19340-1.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub enum Homura {
+    Madoka { name: String },
+}

--- a/src/test/run-pass/issue-19340-1.rs
+++ b/src/test/run-pass/issue-19340-1.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-19340-1.rs
+
+extern crate "issue-19340-1" as lib;
+
+use lib::Homura;
+
+fn main() {
+    let homura = Homura::Madoka { name: "Kaname".into_string() };
+
+    match homura {
+        Homura::Madoka { name } => (),
+    };
+}

--- a/src/test/run-pass/issue-19340-2.rs
+++ b/src/test/run-pass/issue-19340-2.rs
@@ -1,0 +1,30 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum Homura {
+    Madoka {
+        name: String,
+        age: u32,
+    },
+}
+
+fn main() {
+    let homura = Homura::Madoka {
+        name: "Akemi".into_string(),
+        age: 14,
+    };
+
+    match homura {
+        Homura::Madoka {
+            name,
+            age,
+        } => (),
+    };
+}


### PR DESCRIPTION
This pull request tries to fix #19340, which states two ICE cases related to enum struct variants.

It is my first attempt to fix the compiler. I found this solution by trial and error, so the method used to fix the issue looks very hacky. Please review it, and direct me to find a better solution.

I'm also to add test cases. Where should I put them? Maybe `src/test/run-pass/issue-19340.rs`?
