### PR TITLE
libcore: Fix `Sized` bounds on overloaded function traits.

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -812,12 +812,12 @@ pub trait FnMut<Args,Result> for Sized? {
 
 /// A version of the call operator that takes a by-value receiver.
 #[lang="fn_once"]
-pub trait FnOnce<Args,Result> for Sized? {
+pub trait FnOnce<Args,Result> {
     /// This is called when the call operator is used.
     extern "rust-call" fn call_once(self, args: Args) -> Result;
 }
 
-impl<F,A,R> FnMut<A,R> for F
+impl<Sized? F,A,R> FnMut<A,R> for F
     where F : Fn<A,R>
 {
     extern "rust-call" fn call_mut(&mut self, args: A) -> R {


### PR DESCRIPTION
- Remove the `for Sized?` bound on `core::ops::FnOnce`, as it takes `self` by value and can never be implemented by an unsized type.
- Add a missing `Sized?` bound to the blanket `core::ops::FnMut` impl, as both `Fn` and `FnMut` are `for Sized?`.
