### PR TITLE
Correct minor typos on the ownership guide.

### DIFF
--- a/src/doc/guide-ownership.md
+++ b/src/doc/guide-ownership.md
@@ -231,7 +231,7 @@ fn add_one(num: &int) -> int {
 
 Rust has a feature called 'lifetime elision,' which allows you to not write
 lifetime annotations in certain circumstances. This is one of them. Without
-eliding the liftimes, `add_one` looks like this:
+eliding the lifetimes, `add_one` looks like this:
 
 ```rust
 fn add_one<'a>(num: &'a int) -> int {
@@ -254,7 +254,7 @@ This part _declares_ our lifetimes. This says that `add_one` has one lifetime,
 fn add_two<'a, 'b>(...)
 ```
 
-Then in our parameter list, we use the liftimes we've named:
+Then in our parameter list, we use the lifetimes we've named:
 
 ```{rust,ignore}
 ...(num: &'a int) -> ...
@@ -279,7 +279,7 @@ fn main() {
 }
 ```
 
-As you can see, `struct`s can also have liftimes. In a similar way to functions,
+As you can see, `struct`s can also have lifetimes. In a similar way to functions,
 
 ```{rust}
 struct Foo<'a> {
@@ -295,7 +295,7 @@ x: &'a int,
 # }
 ```
 
-uses it. So why do we need a liftime here? We need to ensure that any reference
+uses it. So why do we need a lifetime here? We need to ensure that any reference
 to a `Foo` cannot outlive the reference to an `int` it contains.
 
 ## Thinking in scopes


### PR DESCRIPTION
Substitutes 'lifetime' for 'liftime' in a few places.

Apologies if this has already been noticed/PRQed!  I did try to do due diligence, though :grinning:
