### PR TITLE
syntax: use UFCS in the expansion of `#[deriving(Ord)]`

### DIFF
--- a/src/test/run-pass/issue-18738.rs
+++ b/src/test/run-pass/issue-18738.rs
@@ -8,18 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(PartialEq, PartialOrd)]
+#[deriving(Eq, PartialEq, PartialOrd, Ord)]
 enum Test<'a> {
     Int(&'a int),
     Slice(&'a [u8]),
 }
 
-#[deriving(PartialEq, PartialOrd)]
+#[deriving(Eq, PartialEq, PartialOrd, Ord)]
 struct Version {
     vendor_info: &'static str
 }
 
-#[deriving(PartialEq, PartialOrd)]
+#[deriving(Eq, PartialEq, PartialOrd, Ord)]
 struct Foo(&'static str);
 
 fn main() {}


### PR DESCRIPTION
cc #18755

r? @alexcrichton 
cc @bjz 
