### PR TITLE
Support gcc-less installation on Windows

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -123,7 +123,8 @@ PKG_EXE = dist/$(PKG_NAME)-$(CFG_BUILD).exe
 $(PKG_EXE): rust.iss modpath.iss upgrade.iss LICENSE.txt rust-logo.ico \
             $(CSREQ3_T_$(CFG_BUILD)_H_$(CFG_BUILD)) \
             dist-prepare-win
-	$(CFG_PYTHON) $(S)src/etc/make-win-dist.py tmp/dist/win $(CFG_BUILD)
+	$(Q)rm -rf tmp/dist/win/gcc
+	$(CFG_PYTHON) $(S)src/etc/make-win-dist.py tmp/dist/win/rust tmp/dist/win/gcc $(CFG_BUILD)
 	@$(call E, ISCC: $@)
 	$(Q)$(CFG_ISCC) $<
 
@@ -131,7 +132,7 @@ $(eval $(call DEF_PREPARE,win))
 
 dist-prepare-win: PREPARE_HOST=$(CFG_BUILD)
 dist-prepare-win: PREPARE_TARGETS=$(CFG_BUILD)
-dist-prepare-win: PREPARE_DEST_DIR=tmp/dist/win
+dist-prepare-win: PREPARE_DEST_DIR=tmp/dist/win/rust
 dist-prepare-win: PREPARE_DIR_CMD=$(DEFAULT_PREPARE_DIR_CMD)
 dist-prepare-win: PREPARE_BIN_CMD=$(DEFAULT_PREPARE_BIN_CMD)
 dist-prepare-win: PREPARE_LIB_CMD=$(DEFAULT_PREPARE_LIB_CMD)

--- a/src/etc/make-win-dist.py
+++ b/src/etc/make-win-dist.py
@@ -8,6 +8,12 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+# Script parameters:
+#     argv[1] = rust component root,
+#     argv[2] = gcc component root,
+#     argv[3] = target triple
+# The first two correspond to the two installable components defined in the setup script.
+
 import sys, os, shutil, subprocess
 
 def find_files(files, path):
@@ -22,7 +28,7 @@ def find_files(files, path):
             raise Exception("Could not find '%s' in %s" % (fname, path))
     return found
 
-def make_win_dist(dist_root, target_triple):
+def make_win_dist(rust_root, gcc_root, target_triple):
     # Ask gcc where it keeps its stuff
     gcc_out = subprocess.check_output(["gcc.exe", "-print-search-dirs"])
     bin_path = os.environ["PATH"].split(os.pathsep)
@@ -90,29 +96,29 @@ def make_win_dist(dist_root, target_triple):
     target_libs = find_files(target_libs, lib_path)
 
     # Copy runtime dlls next to rustc.exe
-    dist_bin_dir = os.path.join(dist_root, "bin")
+    dist_bin_dir = os.path.join(rust_root, "bin")
     for src in rustc_dlls:
         shutil.copy(src, dist_bin_dir)
 
     # Copy platform tools to platform-specific bin directory
-    target_bin_dir = os.path.join(dist_root, "bin", "rustlib", target_triple, "bin")
+    target_bin_dir = os.path.join(gcc_root, "bin", "rustlib", target_triple, "bin")
     if not os.path.exists(target_bin_dir):
         os.makedirs(target_bin_dir)
     for src in target_tools:
         shutil.copy(src, target_bin_dir)
 
     # Copy platform libs to platform-spcific lib directory
-    target_lib_dir = os.path.join(dist_root, "bin", "rustlib", target_triple, "lib")
+    target_lib_dir = os.path.join(gcc_root, "bin", "rustlib", target_triple, "lib")
     if not os.path.exists(target_lib_dir):
         os.makedirs(target_lib_dir)
     for src in target_libs:
         shutil.copy(src, target_lib_dir)
 
     # Copy license files
-    lic_dir = os.path.join(dist_root, "bin", "third-party")
+    lic_dir = os.path.join(rust_root, "bin", "third-party")
     if os.path.exists(lic_dir):
         shutil.rmtree(lic_dir) # copytree() won't overwrite existing files
     shutil.copytree(os.path.join(os.path.dirname(__file__), "third-party"), lic_dir)
 
 if __name__=="__main__":
-    make_win_dist(sys.argv[1], sys.argv[2])
+    make_win_dist(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/src/etc/pkg/rust.iss
+++ b/src/etc/pkg/rust.iss
@@ -14,6 +14,7 @@ AppPublisherURL=http://www.rust-lang.org
 VersionInfoVersion={#CFG_VERSION_WIN}
 LicenseFile=LICENSE.txt
 
+PrivilegesRequired=lowest
 DisableWelcomePage=true
 DisableProgramGroupPage=true
 DisableReadyPage=true
@@ -37,8 +38,13 @@ Uninstallable=yes
 [Tasks]
 Name: modifypath; Description: &Add {app}\bin to your PATH (recommended)
 
+[Components]
+Name: rust; Description: "Rust compiler and standard crates"; Types: full compact custom; Flags: fixed
+Name: gcc; Description: "Linker and platform libraries"; Types: full
+
 [Files]
-Source: "tmp/dist/win/*.*" ; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
+Source: "tmp/dist/win/rust/*.*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Components: rust
+Source: "tmp/dist/win/gcc/*.*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs; Components: gcc
 
 [Code]
 const

--- a/src/etc/pkg/rust.iss
+++ b/src/etc/pkg/rust.iss
@@ -23,7 +23,7 @@ DisableStartupPrompt=true
 OutputDir=.\dist\
 SourceDir=.\
 OutputBaseFilename={#CFG_PACKAGE_NAME}-{#CFG_BUILD}
-DefaultDirName={pf32}\Rust
+DefaultDirName={sd}\Rust-{#CFG_RELEASE}
 
 Compression=lzma2/ultra
 InternalCompressLevel=ultra


### PR DESCRIPTION
- Support gcc-less installation on Windows.  To do so in unattended mode run:`<intaller>.exe /TYPE=compact /SILENT`.
- Do not require admin privileges to install.

cc #19519
