### PR TITLE
[WIP] `str` is dead, long live `str([u8])`!

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -30,7 +30,7 @@ use std::io::process;
 use std::io::timer;
 use std::io;
 use std::os;
-use std::str;
+use std::str as str_;
 use std::string::String;
 use std::task;
 use std::time::Duration;
@@ -426,7 +426,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                                    gdbserver :5039 {}/{}",
                                   config.adb_test_dir.clone(),
                                   config.adb_test_dir.clone(),
-                                  str::from_utf8(
+                                  str_::from_utf8(
                                       exe_file.filename()
                                       .unwrap()).unwrap());
 
@@ -1731,7 +1731,7 @@ fn disassemble_extract(config: &Config, _props: &TestProps,
 
 fn count_extracted_lines(p: &Path) -> uint {
     let x = File::open(&p.with_extension("ll")).read_to_end().unwrap();
-    let x = str::from_utf8(x.as_slice()).unwrap();
+    let x = str_::from_utf8(x.as_slice()).unwrap();
     x.lines().count()
 }
 

--- a/src/doc/guide-strings.md
+++ b/src/doc/guide-strings.md
@@ -65,10 +65,10 @@ fn main() {
 You can also get a `&str` from a stack-allocated array of bytes:
 
 ```{rust}
-use std::str;
+use std::str as str_;
 
 let x: &[u8] = &[b'a', b'b'];
-let stack_str: &str = str::from_utf8(x).unwrap();
+let stack_str: &str = str_::from_utf8(x).unwrap();
 ```
 
 # Best Practices

--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -567,7 +567,7 @@ pub extern fn dot_product(a: *const u32, a_len: u32,
 
 #[lang = "panic_fmt"]
 extern fn panic_fmt(args: &core::fmt::Arguments,
-                       file: &str,
+                       file: &core::str::str,
                        line: uint) -> ! {
     loop {}
 }

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -2028,8 +2028,8 @@ mod tests {
     #[test]
     fn test_from_bytes() {
         let bitv = from_bytes(&[0b10110110, 0b00000000, 0b11111111]);
-        let str = format!("{}{}{}", "10110110", "00000000", "11111111");
-        assert_eq!(bitv.to_string().as_slice(), str.as_slice());
+        let s = format!("{}{}{}", "10110110", "00000000", "11111111");
+        assert_eq!(bitv.to_string().as_slice(), s.as_slice());
     }
 
     #[test]

--- a/src/libcollections/hash/mod.rs
+++ b/src/libcollections/hash/mod.rs
@@ -328,6 +328,7 @@ mod tests {
     #[test]
     fn test_writer_hasher() {
         use alloc::boxed::Box;
+        use core::str::str;
 
         let hasher = MyWriterHasher;
 

--- a/src/libcollections/hash/mod.rs
+++ b/src/libcollections/hash/mod.rs
@@ -69,6 +69,8 @@ use core::borrow::{Cow, ToOwned};
 use core::intrinsics::TypeId;
 use core::mem;
 use core::num::Int;
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 
 use vec::Vec;
 

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -115,4 +115,6 @@ mod std {
     pub use core::clone;    // deriving(Clone)
     pub use core::cmp;      // deriving(Eq, Ord, etc.)
     pub use hash;           // deriving(Hash)
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    pub use core::str;
 }

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -2336,6 +2336,7 @@ mod bench {
     use test::black_box;
     use super::*;
     use std::iter::{IteratorExt, DoubleEndedIteratorExt};
+    #[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
     use std::str::StrPrelude;
     use std::slice::SlicePrelude;
 

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -79,7 +79,12 @@ pub use core::str::{eq_slice, is_utf8, is_utf16, Utf16Items};
 pub use core::str::{Utf16Item, ScalarValue, LoneSurrogate, utf16_items};
 pub use core::str::{truncate_utf16_at_nul, utf8_char_width, CharRange};
 pub use core::str::{FromStr, from_str};
-pub use core::str::{Str, StrPrelude};
+pub use core::str::Str;
+// NOTE(stage0): Remove import after a snapshot
+#[cfg(stage0)]
+pub use core::str::StrPrelude;
+#[cfg(not(stage0))]  // NOTE(stage0): Remove cfg after a snapshot
+pub use core::str::str;
 pub use core::str::{from_utf8_unchecked, from_c_str};
 pub use unicode::str::{UnicodeStrPrelude, Words, Graphemes, GraphemeIndices};
 

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -14,6 +14,9 @@
 
 use core::prelude::*;
 
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
+use core::str::StrPrelude;
+
 use core::borrow::{Cow, IntoCow};
 use core::default::Default;
 use core::fmt;
@@ -22,11 +25,13 @@ use core::ptr;
 use core::ops;
 // FIXME: ICE's abound if you import the `Slice` type while importing `Slice` trait
 use core::raw::Slice as RawSlice;
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 
 use hash;
 use slice::CloneSliceAllocPrelude;
-use str;
 use str::{CharRange, CowString, FromStr, StrAllocating, Owned};
+use str as str_;
 use vec::{DerefVec, Vec, as_vec};
 
 /// A growable string stored as a UTF-8 encoded buffer.
@@ -103,7 +108,7 @@ impl String {
     #[inline]
     #[unstable = "error type may change"]
     pub fn from_utf8(vec: Vec<u8>) -> Result<String, Vec<u8>> {
-        if str::is_utf8(vec.as_slice()) {
+        if str_::is_utf8(vec.as_slice()) {
             Ok(String { vec: vec })
         } else {
             Err(vec)
@@ -122,7 +127,7 @@ impl String {
     /// ```
     #[unstable = "return type may change"]
     pub fn from_utf8_lossy<'a>(v: &'a [u8]) -> CowString<'a> {
-        if str::is_utf8(v) {
+        if str_::is_utf8(v) {
             return Cow::Borrowed(unsafe { mem::transmute(v) })
         }
 
@@ -172,7 +177,7 @@ impl String {
             if byte < 128u8 {
                 // subseqidx handles this
             } else {
-                let w = str::utf8_char_width(byte);
+                let w = str_::utf8_char_width(byte);
 
                 match w {
                     2 => {
@@ -255,10 +260,10 @@ impl String {
     #[unstable = "error value in return may change"]
     pub fn from_utf16(v: &[u16]) -> Option<String> {
         let mut s = String::with_capacity(v.len());
-        for c in str::utf16_items(v) {
+        for c in str_::utf16_items(v) {
             match c {
-                str::ScalarValue(c) => s.push(c),
-                str::LoneSurrogate(_) => return None
+                str_::ScalarValue(c) => s.push(c),
+                str_::LoneSurrogate(_) => return None
             }
         }
         Some(s)
@@ -279,7 +284,7 @@ impl String {
     /// ```
     #[stable]
     pub fn from_utf16_lossy(v: &[u16]) -> String {
-        str::utf16_items(v).map(|c| c.to_char_lossy()).collect()
+        str_::utf16_items(v).map(|c| c.to_char_lossy()).collect()
     }
 
     /// Convert a vector of `char`s to a `String`.
@@ -317,7 +322,7 @@ impl String {
     /// slice is not checked to see whether it contains valid UTF-8
     #[unstable = "just renamed from `mod raw`"]
     pub unsafe fn from_raw_buf(buf: *const u8) -> String {
-        String::from_str(str::from_c_str(buf as *const i8))
+        String::from_str(str_::from_c_str(buf as *const i8))
     }
 
     /// Creates a `String` from a `*const u8` buffer of the given length.

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -983,8 +983,10 @@ mod tests {
     use test::Bencher;
 
     use slice::CloneSliceAllocPrelude;
-    use str::{Str, StrPrelude};
-    use str;
+    use str::Str;
+    #[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
+    use str::StrPrelude;
+    use str as str_;
     use super::{as_string, String, ToString};
     use vec::Vec;
 
@@ -1016,11 +1018,11 @@ mod tests {
     #[test]
     fn test_from_utf8_lossy() {
         let xs = b"hello";
-        let ys: str::CowString = "hello".into_cow();
+        let ys: str_::CowString = "hello".into_cow();
         assert_eq!(String::from_utf8_lossy(xs), ys);
 
         let xs = "ศไทย中华Việt Nam".as_bytes();
-        let ys: str::CowString = "ศไทย中华Việt Nam".into_cow();
+        let ys: str_::CowString = "ศไทย中华Việt Nam".into_cow();
         assert_eq!(String::from_utf8_lossy(xs), ys);
 
         let xs = b"Hello\xC2 There\xFF Goodbye";
@@ -1100,7 +1102,7 @@ mod tests {
             let s_as_utf16 = s.as_slice().utf16_units().collect::<Vec<u16>>();
             let u_as_string = String::from_utf16(u.as_slice()).unwrap();
 
-            assert!(str::is_utf16(u.as_slice()));
+            assert!(str_::is_utf16(u.as_slice()));
             assert_eq!(s_as_utf16, u);
 
             assert_eq!(u_as_string, s);

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -22,6 +22,7 @@ use num::{Float, FPNaN, FPInfinite, ToPrimitive};
 use num::cast;
 use result::Ok;
 use slice::{mod, SlicePrelude};
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
 use str::StrPrelude;
 
 /// A flag that specifies whether to use exponential (scientific) notation.

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -23,7 +23,10 @@ use result::{Ok, Err};
 use result;
 use slice::SlicePrelude;
 use slice;
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
 use str::StrPrelude;
+#[cfg(not(stage0))]  // NOTE(stage0): Remove cfg after a snapshot
+use str::str;
 
 pub use self::num::radix;
 pub use self::num::Radix;

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -18,6 +18,8 @@ use fmt;
 use iter::DoubleEndedIteratorExt;
 use num::{Int, cast};
 use slice::SlicePrelude;
+#[cfg(not(stage0))]  // NOTE(stage0): Remove cfg after a snapshot
+use str::str;
 
 /// A type that represents a specific radix
 #[doc(hidden)]

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -42,6 +42,9 @@
 #![experimental]
 #![allow(missing_docs)]
 
+#[cfg(not(stage0))]  // NOTE(stage0): Remove cfg after a snapshot
+use str::str;
+
 pub type GlueFn = extern "Rust" fn(*const i8);
 
 #[lang="ty_desc"]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -142,4 +142,5 @@ mod std {
     pub use kinds;
     pub use option;
     pub use fmt;
+    pub use str;
 }

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -10,6 +10,8 @@
 
 #![macro_escape]
 
+// NOTE(stage0): Remove macro after a snapshot
+#[cfg(stage0)]
 /// Entry point of task panic, for details, see std::macros
 #[macro_export]
 macro_rules! panic(
@@ -40,6 +42,44 @@ macro_rules! panic(
         #[inline(always)]
         fn _run_fmt(fmt: &::std::fmt::Arguments) -> ! {
             static _FILE_LINE: (&'static str, uint) = (file!(), line!());
+            ::core::panicking::panic_fmt(fmt, &_FILE_LINE)
+        }
+        format_args!(_run_fmt, $fmt, $($arg)*)
+    });
+)
+
+#[cfg(not(stage0))]  // NOTE(stage0): Remove cfg after a snapshot
+/// Entry point of task panic, for details, see std::macros
+#[macro_export]
+macro_rules! panic(
+    () => (
+        panic!("{}", "explicit panic")
+    );
+    ($msg:expr) => ({
+        static _MSG_FILE_LINE: (&'static ::std::str::str, &'static ::std::str::str, uint) =
+            ($msg, file!(), line!());
+        ::core::panicking::panic(&_MSG_FILE_LINE)
+    });
+    ($fmt:expr, $($arg:tt)*) => ({
+        // a closure can't have return type !, so we need a full
+        // function to pass to format_args!, *and* we need the
+        // file and line numbers right here; so an inner bare fn
+        // is our only choice.
+        //
+        // LLVM doesn't tend to inline this, presumably because begin_unwind_fmt
+        // is #[cold] and #[inline(never)] and because this is flagged as cold
+        // as returning !. We really do want this to be inlined, however,
+        // because it's just a tiny wrapper. Small wins (156K to 149K in size)
+        // were seen when forcing this to be inlined, and that number just goes
+        // up with the number of calls to panic!()
+        //
+        // The leading _'s are to avoid dead code warnings if this is
+        // used inside a dead function. Just `#[allow(dead_code)]` is
+        // insufficient, since the user may have
+        // `#[forbid(dead_code)]` and which cannot be overridden.
+        #[inline(always)]
+        fn _run_fmt(fmt: &::std::fmt::Arguments) -> ! {
+            static _FILE_LINE: (&'static ::std::str::str, uint) = (file!(), line!());
             ::core::panicking::panic_fmt(fmt, &_FILE_LINE)
         }
         format_args!(_run_fmt, $fmt, $($arg)*)

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -21,6 +21,8 @@ use mem;
 use num::{Float, FPNormal, FPCategory, FPZero, FPSubnormal, FPInfinite, FPNaN};
 use num::from_str_radix;
 use option::Option;
+#[cfg(not(stage0))]  // NOTE(stage0): Remove cfg after a snapshot
+use str::str;
 
 #[stable]
 pub const RADIX: uint = 2u;

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -21,6 +21,8 @@ use mem;
 use num::{Float, FPNormal, FPCategory, FPZero, FPSubnormal, FPInfinite, FPNaN};
 use num::from_str_radix;
 use option::Option;
+#[cfg(not(stage0))]  // NOTE(stage0): Remove cfg after a snapshot
+use str::str;
 
 // FIXME(#5527): These constants should be deprecated once associated
 // constants are implemented in favour of referencing the respective

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -31,7 +31,11 @@ use mem::size_of;
 use ops::{Add, Sub, Mul, Div, Rem, Neg};
 use ops::{Not, BitAnd, BitOr, BitXor, Shl, Shr};
 use option::{Option, Some, None};
-use str::{FromStr, from_str, StrPrelude};
+use str::{FromStr, from_str};
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
+use str::StrPrelude;
+#[cfg(not(stage0))]  // NOTE(stage0): Remove cfg after a snapshot
+use str::str;
 
 /// Simultaneous division and remainder
 #[inline]
@@ -1437,8 +1441,8 @@ pub trait FromStrRadix {
 
 /// A utility function that just calls FromStrRadix::from_str_radix.
 #[experimental = "might need to return Result"]
-pub fn from_str_radix<T: FromStrRadix>(str: &str, radix: uint) -> Option<T> {
-    FromStrRadix::from_str_radix(str, radix)
+pub fn from_str_radix<T: FromStrRadix>(s: &str, radix: uint) -> Option<T> {
+    FromStrRadix::from_str_radix(s, radix)
 }
 
 macro_rules! from_str_radix_float_impl {

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -154,6 +154,8 @@ use slice;
 use slice::AsSlice;
 use clone::Clone;
 use ops::Deref;
+#[cfg(not(stage0))]  // NOTE(stage0): Remove cfg after a snapshot
+use str::str;
 
 // Note that this is not a lang item per se, but it has a hidden dependency on
 // `Iterator`, which is one. The compiler assumes that the `next` method of

--- a/src/libcore/panicking.rs
+++ b/src/libcore/panicking.rs
@@ -32,6 +32,8 @@
 
 use fmt;
 use intrinsics;
+#[cfg(not(stage0))]  // NOTE(stage0): Remove cfg after a snapshot
+use str::str;
 
 #[cold] #[inline(never)] // this is the slow path, always
 #[lang="panic"]

--- a/src/libcore/prelude.rs
+++ b/src/libcore/prelude.rs
@@ -60,7 +60,9 @@ pub use option::Option::{Some, None};
 pub use ptr::RawPtr;
 pub use result::Result;
 pub use result::Result::{Ok, Err};
-pub use str::{Str, StrPrelude};
+pub use str::Str;
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
+pub use str::StrPrelude;
 pub use tuple::{Tuple1, Tuple2, Tuple3, Tuple4};
 pub use tuple::{Tuple5, Tuple6, Tuple7, Tuple8};
 pub use tuple::{Tuple9, Tuple10, Tuple11, Tuple12};

--- a/src/libcore/raw.rs
+++ b/src/libcore/raw.rs
@@ -20,6 +20,8 @@
 
 use mem;
 use kinds::Sized;
+#[cfg(not(stage0))]  // NOTE(stage0): Remove cfg after a snapshot
+use str::str;
 
 /// The representation of a Rust slice
 #[repr(C)]

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -30,7 +30,7 @@ pub use self::Alignment::*;
 pub use self::Flag::*;
 pub use self::Count::*;
 
-use std::str;
+use std::str as str_;
 use std::string;
 
 /// A piece is a portion of the format string which represents the next part
@@ -136,7 +136,7 @@ pub enum Count<'a> {
 /// necessary there's probably lots of room for improvement performance-wise.
 pub struct Parser<'a> {
     input: &'a str,
-    cur: str::CharOffsets<'a>,
+    cur: str_::CharOffsets<'a>,
     /// Error messages accumulated during parsing
     pub errors: Vec<string::String>,
 }

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -548,7 +548,6 @@ mod tests {
     use super::{Id, LabelText, LabelStr, EscStr, Labeller};
     use super::{Nodes, Edges, GraphWalk, render};
     use std::io::IoResult;
-    use std::str;
 
     /// each node is an index in a vector in the graph.
     type Node = uint;

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -488,6 +488,8 @@ pub struct Closed01<F>(pub F);
 #[cfg(not(test))]
 mod std {
     pub use core::{option, fmt}; // panic!()
+    #[cfg(not(stage0))]  // NOTE(stage0): Remove cfg after a snapshot
+    pub use core::str;
 }
 
 #[cfg(test)]

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -35,7 +35,7 @@ extern crate serialize;
 pub use self::EbmlEncoderTag::*;
 pub use self::Error::*;
 
-use std::str;
+use std::str as str_;
 
 pub mod io;
 
@@ -57,7 +57,7 @@ impl<'doc> Doc<'doc> {
     }
 
     pub fn as_str_slice<'a>(&'a self) -> &'a str {
-        str::from_utf8(self.data[self.start..self.end]).unwrap()
+        str_::from_utf8(self.data[self.start..self.end]).unwrap()
     }
 
     pub fn as_str(&self) -> String {
@@ -333,10 +333,10 @@ pub mod reader {
 
                 if r_tag == (EsLabel as uint) {
                     self.pos = r_doc.end;
-                    let str = r_doc.as_str_slice();
-                    if lbl != str {
+                    let s = r_doc.as_str_slice();
+                    if lbl != s {
                         return Err(Expected(format!("Expected label {} but \
-                                                     found {}", lbl, str)));
+                                                     found {}", lbl, s)));
                     }
                 }
             }

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -895,9 +895,9 @@ impl NonSnakeCase {
             })
         }
 
-        fn to_snake_case(str: &str) -> String {
+        fn to_snake_case(s: &str) -> String {
             let mut words = vec![];
-            for s in str.split('_') {
+            for s in s.split('_') {
                 let mut last_upper = false;
                 let mut buf = String::new();
                 if s.is_empty() { continue; }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -272,7 +272,7 @@ fn enc_sty<'a, 'tcx>(w: &mut SeekableMemWriter, cx: &ctxt<'a, 'tcx>,
                 None => mywrite!(w, "|"),
             }
         }
-        ty::ty_str => {
+        ty::ty_struct(did, _) if ty::is_str(cx.tcx, did) => {
             mywrite!(w, "v");
         }
         ty::ty_closure(ref f) => {

--- a/src/librustc/middle/astconv_util.rs
+++ b/src/librustc/middle/astconv_util.rs
@@ -75,9 +75,6 @@ pub fn ast_ty_to_prim_ty<'tcx>(tcx: &ty::ctxt<'tcx>, ast_ty: &ast::Ty)
                             check_path_args(tcx, path, NO_TPS | NO_REGIONS);
                             Some(ty::mk_mach_float(ft))
                         }
-                        ast::TyStr => {
-                            Some(ty::mk_str(tcx))
-                        }
                     }
                 }
                 _ => None

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -1498,11 +1498,11 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
         }).unwrap();
 
         fn type_string(doc: rbml::Doc) -> String {
-            let mut str = String::new();
+            let mut s = String::new();
             for i in range(doc.start, doc.end) {
-                str.push(doc.data[i] as char);
+                s.push(doc.data[i] as char);
             }
-            str
+            s
         }
     }
 

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -485,7 +485,9 @@ fn construct_witness(cx: &MatchCheckCtxt, ctor: &Constructor,
                     },
                     _ => unreachable!()
                 },
-                ty::ty_str => ast::PatWild(ast::PatWildSingle),
+                ty::ty_struct(did, _) if ty::is_str(cx.tcx, did) => {
+                    ast::PatWild(ast::PatWildSingle)
+                },
 
                 _ => {
                     assert_eq!(pats_len, 1);
@@ -737,7 +739,7 @@ pub fn constructor_arity(cx: &MatchCheckCtxt, ctor: &Constructor, ty: Ty) -> uin
                 ConstantValue(_) => 0u,
                 _ => unreachable!()
             },
-            ty::ty_str => 0u,
+            ty::ty_struct(did, _) if ty::is_str(cx.tcx, did) => 0u,
             _ => 1u
         },
         ty::ty_enum(eid, _) => {

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -71,11 +71,14 @@ impl<'a, 'tcx> EffectCheckVisitor<'a, 'tcx> {
         debug!("effect: checking index with base type {}",
                 ppaux::ty_to_string(self.tcx, base_type));
         match base_type.sty {
-            ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ty, ..}) => if ty::ty_str == ty.sty {
-                span_err!(self.tcx.sess, e.span, E0134,
-                          "modification of string types is not allowed");
+            ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ty, ..}) => match ty.sty {
+                ty::ty_struct(did, _) if ty::is_str(self.tcx, did) => {
+                    span_err!(self.tcx.sess, e.span, E0134,
+                              "modification of string types is not allowed");
+                },
+                _ => {},
             },
-            ty::ty_str => {
+            ty::ty_struct(did, _) if ty::is_str(self.tcx, did) => {
                 span_err!(self.tcx.sess, e.span, E0135,
                           "modification of string types is not allowed");
             }

--- a/src/librustc/middle/fast_reject.rs
+++ b/src/librustc/middle/fast_reject.rs
@@ -54,7 +54,7 @@ pub fn simplify_type(tcx: &ty::ctxt,
         ty::ty_uint(uint_type) => Some(UintSimplifiedType(uint_type)),
         ty::ty_float(float_type) => Some(FloatSimplifiedType(float_type)),
         ty::ty_enum(def_id, _) => Some(EnumSimplifiedType(def_id)),
-        ty::ty_str => Some(StrSimplifiedType),
+        ty::ty_struct(did, _) if ty::is_str(tcx, did) => Some(StrSimplifiedType),
         ty::ty_vec(..) => Some(VecSimplifiedType),
         ty::ty_ptr(_) => Some(PtrSimplifiedType),
         ty::ty_trait(ref trait_info) => {

--- a/src/librustc/middle/infer/coercion.rs
+++ b/src/librustc/middle/infer/coercion.rs
@@ -105,7 +105,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
         match b.sty {
             ty::ty_ptr(mt_b) => {
                 match mt_b.ty.sty {
-                    ty::ty_str => {
+                    ty::ty_struct(did, _) if ty::is_str(self.0.infcx.tcx, did) => {
                         return self.unpack_actual_value(a, |sty_a| {
                             self.coerce_unsafe_ptr(a, sty_a, b, ast::MutImmutable)
                         });
@@ -132,7 +132,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
 
             ty::ty_rptr(_, mt_b) => {
                 match mt_b.ty.sty {
-                    ty::ty_str => {
+                    ty::ty_struct(did, _) if ty::is_str(self.0.infcx.tcx, did) => {
                         return self.unpack_actual_value(a, |sty_a| {
                             self.coerce_borrowed_pointer(a, sty_a, b, ast::MutImmutable)
                         });

--- a/src/librustc/middle/infer/combine.rs
+++ b/src/librustc/middle/infer/combine.rs
@@ -478,10 +478,6 @@ pub fn super_tys<'tcx, C: Combine<'tcx>>(this: &C,
         })
       }
 
-      (&ty::ty_str, &ty::ty_str) => {
-            Ok(ty::mk_str(tcx))
-      }
-
       (&ty::ty_tup(ref as_), &ty::ty_tup(ref bs)) => {
         if as_.len() == bs.len() {
             as_.iter().zip(bs.iter())

--- a/src/librustc/middle/infer/skolemize.rs
+++ b/src/librustc/middle/infer/skolemize.rs
@@ -145,7 +145,6 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeSkolemizer<'a, 'tcx> {
             ty::ty_float(..) |
             ty::ty_enum(..) |
             ty::ty_uniq(..) |
-            ty::ty_str |
             ty::ty_err |
             ty::ty_vec(..) |
             ty::ty_ptr(..) |

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -265,6 +265,7 @@ lets_do_this! {
     OrdTraitLangItem,                "ord",                     ord_trait;
 
     StrEqFnLangItem,                 "str_eq",                  str_eq_fn;
+    StrStructLangItem,               "str",                     str_struct;
 
     // A number of panic-related lang items. The `panic` item corresponds to
     // divide-by-zero and various panic cases with `match`. The

--- a/src/librustc/middle/resolve.rs
+++ b/src/librustc/middle/resolve.rs
@@ -65,7 +65,7 @@ use syntax::ast::{StructVariantKind, TraitRef, TraitTyParamBound};
 use syntax::ast::{TupleVariantKind, Ty, TyBool, TyChar, TyClosure, TyF32};
 use syntax::ast::{TyF64, TyFloat, TyI, TyI8, TyI16, TyI32, TyI64, TyInt, TyObjectSum};
 use syntax::ast::{TyParam, TyParamBound, TyPath, TyPtr, TyPolyTraitRef, TyProc, TyQPath};
-use syntax::ast::{TyRptr, TyStr, TyU, TyU8, TyU16, TyU32, TyU64, TyUint};
+use syntax::ast::{TyRptr, TyU, TyU8, TyU16, TyU32, TyU64, TyUint};
 use syntax::ast::{TypeImplItem, UnnamedField};
 use syntax::ast::{Variant, ViewItem, ViewItemExternCrate};
 use syntax::ast::{ViewItemUse, ViewPathGlob, ViewPathList, ViewPathSimple};
@@ -869,7 +869,6 @@ impl PrimitiveTypeTable {
         table.intern("i16",     TyInt(TyI16));
         table.intern("i32",     TyInt(TyI32));
         table.intern("i64",     TyInt(TyI64));
-        table.intern("str",     TyStr);
         table.intern("uint",    TyUint(TyU));
         table.intern("u8",      TyUint(TyU8));
         table.intern("u16",     TyUint(TyU16));

--- a/src/librustc/middle/traits/coherence.rs
+++ b/src/librustc/middle/traits/coherence.rs
@@ -84,10 +84,11 @@ pub fn ty_is_local<'tcx>(tcx: &ty::ctxt<'tcx>, ty: Ty<'tcx>) -> bool {
         ty::ty_char |
         ty::ty_int(..) |
         ty::ty_uint(..) |
-        ty::ty_float(..) |
-        ty::ty_str(..) => {
+        ty::ty_float(..) => {
             false
         }
+
+        ty::ty_struct(did, _) if ty::is_str(tcx, did) => { false }
 
         ty::ty_unboxed_closure(..) => {
             // This routine is invoked on types specified by users as

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1400,7 +1400,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 }
             }
 
-            ty::ty_str => {
+            ty::ty_struct(did, _) if ty::is_str(self.tcx(), did) => {
                 // Equivalent to [u8]
                 match bound {
                     ty::BoundSync |

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2390,6 +2390,13 @@ impl<'tcx> ParamBounds<'tcx> {
 
 // Type utilities
 
+pub fn is_str(cx: &ctxt, did: DefId) -> bool {
+    match cx.lang_items.require(StrStructLangItem) {
+        Ok(lang_did) => lang_did == did,
+        Err(err) => cx.sess.fatal(err.as_slice()),
+    }
+}
+
 pub fn type_is_nil(ty: Ty) -> bool {
     match ty.sty {
         ty_tup(ref tys) => tys.is_empty(),

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -46,6 +46,7 @@ use metadata::csearch;
 use middle::const_eval;
 use middle::def;
 use middle::dependency_format;
+use middle::lang_items::StrStructLangItem;
 use middle::lang_items::{FnTraitLangItem, FnMutTraitLangItem};
 use middle::lang_items::{FnOnceTraitLangItem, TyDescStructLangItem};
 use middle::mem_categorization as mc;
@@ -2149,15 +2150,14 @@ pub fn mk_mach_float<'tcx>(tm: ast::FloatTy) -> Ty<'tcx> {
 }
 
 pub fn mk_str<'tcx>(cx: &ctxt<'tcx>) -> Ty<'tcx> {
-    mk_t(cx, ty_str)
+    match cx.lang_items.require(StrStructLangItem) {
+        Ok(did) => mk_struct(cx, did, Substs::empty()),
+        Err(err) => cx.sess.fatal(err.as_slice()),
+    }
 }
 
-pub fn mk_str_slice<'tcx>(cx: &ctxt<'tcx>, r: Region, m: ast::Mutability) -> Ty<'tcx> {
-    mk_rptr(cx, r,
-            mt {
-                ty: mk_t(cx, ty_str),
-                mutbl: m
-            })
+pub fn mk_str_slice<'tcx>(cx: &ctxt<'tcx>, r: Region) -> Ty<'tcx> {
+    mk_rptr(cx, r, mt { ty: mk_str(cx), mutbl: MutImmutable })
 }
 
 pub fn mk_enum<'tcx>(cx: &ctxt<'tcx>, did: ast::DefId, substs: Substs<'tcx>) -> Ty<'tcx> {

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -631,7 +631,7 @@ pub fn super_fold_sty<'tcx, T: TypeFolder<'tcx>>(this: &mut T,
         ty::ty_unboxed_closure(did, ref region, ref substs) => {
             ty::ty_unboxed_closure(did, region.fold_with(this), substs.fold_with(this))
         }
-        ty::ty_bool | ty::ty_char | ty::ty_str |
+        ty::ty_bool | ty::ty_char |
         ty::ty_int(_) | ty::ty_uint(_) | ty::ty_float(_) |
         ty::ty_err | ty::ty_infer(_) |
         ty::ty_param(..) => {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -18,7 +18,7 @@ use middle::ty::{ReFree, ReScope, ReInfer, ReStatic, Region, ReEmpty};
 use middle::ty::{ReSkolemized, ReVar, BrEnv};
 use middle::ty::{mt, Ty, ParamTy};
 use middle::ty::{ty_bool, ty_char, ty_struct, ty_enum};
-use middle::ty::{ty_err, ty_str, ty_vec, ty_float, ty_bare_fn, ty_closure};
+use middle::ty::{ty_err, ty_vec, ty_float, ty_bare_fn, ty_closure};
 use middle::ty::{ty_param, ty_ptr, ty_rptr, ty_tup, ty_open};
 use middle::ty::{ty_unboxed_closure};
 use middle::ty::{ty_uniq, ty_trait, ty_int, ty_uint, ty_infer};
@@ -442,7 +442,6 @@ pub fn ty_to_string<'tcx>(cx: &ctxt<'tcx>, typ: &ty::TyS<'tcx>) -> String {
                     bound_sep,
                     bound_str)
         }
-        ty_str => "str".to_string(),
         ty_unboxed_closure(ref did, _, ref substs) => {
             let unboxed_closures = cx.unboxed_closures.borrow();
             unboxed_closures.get(did).map(|cl| {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -49,15 +49,15 @@ pub fn note_and_explain_region(cx: &ctxt,
                                region: ty::Region,
                                suffix: &str) -> Option<Span> {
     match explain_region_and_span(cx, region) {
-      (ref str, Some(span)) => {
+      (ref s, Some(span)) => {
         cx.sess.span_note(
             span,
-            format!("{}{}{}", prefix, *str, suffix).as_slice());
+            format!("{}{}{}", prefix, *s, suffix).as_slice());
         Some(span)
       }
-      (ref str, None) => {
+      (ref s, None) => {
         cx.sess.note(
-            format!("{}{}{}", prefix, *str, suffix).as_slice());
+            format!("{}{}{}", prefix, *s, suffix).as_slice());
         None
       }
     }

--- a/src/librustc_back/archive.rs
+++ b/src/librustc_back/archive.rs
@@ -15,7 +15,7 @@ use std::io::process::{Command, ProcessOutput};
 use std::io::{fs, TempDir};
 use std::io;
 use std::os;
-use std::str;
+use std::str as str_;
 use syntax::diagnostic::Handler as ErrorHandler;
 
 pub static METADATA_FILENAME: &'static str = "rust.metadata.bin";
@@ -77,11 +77,11 @@ fn run_ar(handler: &ErrorHandler, maybe_ar_prog: &Option<String>,
                                  cmd,
                                  o.status).as_slice());
                 handler.note(format!("stdout ---\n{}",
-                                  str::from_utf8(o.output
+                                  str_::from_utf8(o.output
                                                   .as_slice()).unwrap())
                           .as_slice());
                 handler.note(format!("stderr ---\n{}",
-                                  str::from_utf8(o.error
+                                  str_::from_utf8(o.error
                                                   .as_slice()).unwrap())
                           .as_slice());
                 handler.abort_if_errors();
@@ -147,7 +147,7 @@ impl<'a> Archive<'a> {
     /// Lists all files in an archive
     pub fn files(&self) -> Vec<String> {
         let output = run_ar(self.handler, &self.maybe_ar_prog, "t", None, &[&self.dst]);
-        let output = str::from_utf8(output.output.as_slice()).unwrap();
+        let output = str_::from_utf8(output.output.as_slice()).unwrap();
         // use lines_any because windows delimits output with `\r\n` instead of
         // just `\n`
         output.lines_any().map(|s| s.to_string()).collect()

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -29,7 +29,7 @@ use std::io::fs::PathExtensions;
 use std::io::{fs, TempDir, Command};
 use std::io;
 use std::mem;
-use std::str;
+use std::str as str_;
 use std::string::String;
 use flate;
 use serialize::hex::ToHex;
@@ -794,7 +794,7 @@ fn link_natively(sess: &Session, trans: &CrateTranslation, dylib: bool,
                 sess.note(format!("{}", &cmd).as_slice());
                 let mut output = prog.error.clone();
                 output.push_all(prog.output.as_slice());
-                sess.note(str::from_utf8(output.as_slice()).unwrap());
+                sess.note(str_::from_utf8(output.as_slice()).unwrap());
                 sess.abort_if_errors();
             }
             debug!("linker stderr:\n{}", String::from_utf8(prog.error).unwrap());

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -27,7 +27,7 @@ use std::io::Command;
 use std::io::fs;
 use std::iter::Unfold;
 use std::ptr;
-use std::str;
+use std::str as str_;
 use std::mem;
 use std::sync::{Arc, Mutex};
 use std::task::TaskBuilder;
@@ -930,7 +930,7 @@ pub fn run_assembler(sess: &Session, outputs: &OutputFilenames) {
                 sess.note(format!("{}", &cmd).as_slice());
                 let mut note = prog.error.clone();
                 note.push_all(prog.output.as_slice());
-                sess.note(str::from_utf8(note.as_slice()).unwrap());
+                sess.note(str_::from_utf8(note.as_slice()).unwrap());
                 sess.abort_if_errors();
             }
         },

--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -805,7 +805,7 @@ fn compare_values<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
                 ty::ty_uint(ast::TyU8) => {
                     // NOTE: cast &[u8] to &str and abuse the str_eq lang item,
                     // which calls memcmp().
-                    let t = ty::mk_str_slice(cx.tcx(), ty::ReStatic, ast::MutImmutable);
+                    let t = ty::mk_str_slice(cx.tcx(), ty::ReStatic);
                     let lhs = BitCast(cx, lhs, type_of::type_of(cx.ccx(), t).ptr_to());
                     let rhs = BitCast(cx, rhs, type_of::type_of(cx.ccx(), t).ptr_to());
                     compare_str(cx, lhs, rhs, rhs_t)

--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -800,7 +800,7 @@ fn compare_values<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
 
     match rhs_t.sty {
         ty::ty_rptr(_, mt) => match mt.ty.sty {
-            ty::ty_str => compare_str(cx, lhs, rhs, rhs_t),
+            ty::ty_struct(did, _) if ty::is_str(cx.tcx(), did) => compare_str(cx, lhs, rhs, rhs_t),
             ty::ty_vec(ty, _) => match ty.sty {
                 ty::ty_uint(ast::TyU8) => {
                     // NOTE: cast &[u8] to &str and abuse the str_eq lang item,

--- a/src/librustc_trans/trans/adt.rs
+++ b/src/librustc_trans/trans/adt.rs
@@ -298,7 +298,7 @@ impl<'tcx> Case<'tcx> {
                 // &T/&mut T/Box<T> could either be a thin or fat pointer depending on T
                 ty::ty_rptr(_, ty::mt { ty, .. }) | ty::ty_uniq(ty) => match ty.sty {
                     // &[T] and &str are a pointer and length pair
-                    ty::ty_vec(_, None) | ty::ty_str => return Some(FatPointer(i)),
+                    ty::ty_vec(_, None) => return Some(FatPointer(i)),
 
                     // &Trait is a pair of pointers: the actual object and a vtable
                     ty::ty_trait(..) => return Some(FatPointer(i)),

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1161,7 +1161,7 @@ pub fn memcpy_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                              t: Ty<'tcx>) {
     let _icx = push_ctxt("memcpy_ty");
     let ccx = bcx.ccx();
-    if ty::type_is_structural(t) {
+    if ty::type_is_structural(bcx.tcx(), t) {
         let llty = type_of::type_of(ccx, t);
         let llsz = llsize_of(ccx, llty);
         let llalign = type_of::align_of(ccx, t);

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -364,7 +364,7 @@ fn make_drop_glue<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, v0: ValueRef, t: Ty<'tcx>)
                 ty::ty_vec(ty, None) => {
                     tvec::make_drop_glue_unboxed(bcx, v0, ty, true)
                 }
-                ty::ty_str => {
+                ty::ty_struct(did, _) if ty::is_str(bcx.tcx(), did) => {
                     let unit_ty = ty::sequence_element_type(bcx.tcx(), content_ty);
                     tvec::make_drop_glue_unboxed(bcx, v0, unit_ty, true)
                 }
@@ -469,7 +469,7 @@ fn make_drop_glue<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, v0: ValueRef, t: Ty<'tcx>)
         _ => {
             assert!(ty::type_is_sized(bcx.tcx(), t));
             if ty::type_needs_drop(bcx.tcx(), t) &&
-                ty::type_is_structural(t) {
+                ty::type_is_structural(bcx.tcx(), t) {
                 iter_structural_ty(bcx, v0, t, |bb, vv, tt| drop_ty(bb, vv, tt, None))
             } else {
                 bcx

--- a/src/librustc_trans/trans/tvec.rs
+++ b/src/librustc_trans/trans/tvec.rs
@@ -401,13 +401,19 @@ pub fn get_base_and_len(bcx: Block,
     match vec_ty.sty {
         ty::ty_vec(_, Some(n)) => get_fixed_base_and_len(bcx, llval, n),
         ty::ty_open(ty) => match ty.sty {
-            ty::ty_vec(_, None) | ty::ty_str => get_slice_base_and_len(bcx, llval),
+            ty::ty_vec(_, None) => get_slice_base_and_len(bcx, llval),
+            ty::ty_struct(did, _) if ty::is_str(bcx.tcx(), did) => {
+                get_slice_base_and_len(bcx, llval)
+            },
             _ => ccx.sess().bug("unexpected type in get_base_and_len")
         },
 
         // Only used for pattern matching.
         ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ty, ..}) => match ty.sty {
-            ty::ty_vec(_, None) | ty::ty_str => get_slice_base_and_len(bcx, llval),
+            ty::ty_vec(_, None) => get_slice_base_and_len(bcx, llval),
+            ty::ty_struct(did, _) if ty::is_str(bcx.tcx(), did) => {
+                get_slice_base_and_len(bcx, llval)
+            },
             ty::ty_vec(_, Some(n)) => {
                 let base = GEPi(bcx, Load(bcx, llval), &[0u, 0u]);
                 (base, C_uint(ccx, n))

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -639,7 +639,10 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
         // FIXME -- Super hack. For DST types, we will convert to
         // &&[T] or &&str, as part of a kind of legacy lookup scheme.
         match step.self_ty.sty {
-            ty::ty_str | ty::ty_vec(_, None) => self.pick_autorefrefd_method(step),
+            ty::ty_vec(_, None) => self.pick_autorefrefd_method(step),
+            ty::ty_struct(did, _) if ty::is_str(self.tcx(), did) => {
+                self.pick_autorefrefd_method(step)
+            }
             _ => None
         }
     }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2844,7 +2844,7 @@ fn check_lit<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     let tcx = fcx.ccx.tcx;
 
     match lit.node {
-        ast::LitStr(..) => ty::mk_str_slice(tcx, ty::ReStatic, ast::MutImmutable),
+        ast::LitStr(..) => ty::mk_str_slice(tcx, ty::ReStatic),
         ast::LitBinary(..) => {
             ty::mk_slice(tcx, ty::ReStatic, ty::mt{ ty: ty::mk_u8(), mutbl: ast::MutImmutable })
         }

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -1224,7 +1224,11 @@ fn constrain_index<'a, 'tcx>(rcx: &mut Rcx<'a, 'tcx>,
     let r_index_expr = ty::ReScope(CodeExtent::from_node_id(index_expr.id));
     if let ty::ty_rptr(r_ptr, mt) = indexed_ty.sty {
         match mt.ty.sty {
-            ty::ty_vec(_, None) | ty::ty_str => {
+            ty::ty_vec(_, None) => {
+                rcx.fcx.mk_subr(infer::IndexSlice(index_expr.span),
+                                r_index_expr, r_ptr);
+            }
+            ty::ty_struct(did, _) if ty::is_str(rcx.tcx(), did) => {
                 rcx.fcx.mk_subr(infer::IndexSlice(index_expr.span),
                                 r_index_expr, r_ptr);
             }

--- a/src/librustc_typeck/check/regionmanip.rs
+++ b/src/librustc_typeck/check/regionmanip.rs
@@ -62,8 +62,11 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
             ty::ty_uint(..) |
             ty::ty_float(..) |
             ty::ty_bare_fn(..) |
-            ty::ty_err |
-            ty::ty_str => {
+            ty::ty_err => {
+                // No borrowed content reachable here.
+            }
+
+            ty::ty_struct(did, _) if ty::is_str(self.tcx, did) => {
                 // No borrowed content reachable here.
             }
 

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -22,7 +22,7 @@ use middle::subst;
 use middle::ty::{ImplContainer, ImplOrTraitItemId, MethodTraitItemId};
 use middle::ty::{TypeTraitItemId, lookup_item_type};
 use middle::ty::{Ty, ty_bool, ty_char, ty_enum, ty_err};
-use middle::ty::{ty_str, ty_vec, ty_float, ty_infer, ty_int, ty_open};
+use middle::ty::{ty_vec, ty_float, ty_infer, ty_int, ty_open};
 use middle::ty::{ty_param, Polytype, ty_ptr};
 use middle::ty::{ty_rptr, ty_struct, ty_trait, ty_tup};
 use middle::ty::{ty_uint, ty_unboxed_closure, ty_uniq, ty_bare_fn};
@@ -81,7 +81,7 @@ fn get_base_type<'a, 'tcx>(inference_context: &InferCtxt<'a, 'tcx>,
         }
 
         ty_bool | ty_char | ty_int(..) | ty_uint(..) | ty_float(..) |
-        ty_str(..) | ty_vec(..) | ty_bare_fn(..) | ty_closure(..) | ty_tup(..) |
+        ty_vec(..) | ty_bare_fn(..) | ty_closure(..) | ty_tup(..) |
         ty_infer(..) | ty_param(..) | ty_err | ty_open(..) | ty_uniq(_) |
         ty_ptr(_) | ty_rptr(_, _) => {
             debug!("(getting base type) no base type; found {}",

--- a/src/librustc_typeck/variance.rs
+++ b/src/librustc_typeck/variance.rs
@@ -720,7 +720,11 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
         match ty.sty {
             ty::ty_bool |
             ty::ty_char | ty::ty_int(_) | ty::ty_uint(_) |
-            ty::ty_float(_) | ty::ty_str => {
+            ty::ty_float(_) => {
+                /* leaf type -- noop */
+            }
+
+            ty::ty_struct(did, _) if ty::is_str(self.tcx(), did) => {
                 /* leaf type -- noop */
             }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1322,7 +1322,6 @@ impl<'tcx> Clean<Type> for ty::Ty<'tcx> {
             ty::ty_uint(ast::TyU64) => Primitive(U64),
             ty::ty_float(ast::TyF32) => Primitive(F32),
             ty::ty_float(ast::TyF64) => Primitive(F64),
-            ty::ty_str => Primitive(Str),
             ty::ty_uniq(t) => {
                 let box_did = cx.tcx_opt().and_then(|tcx| {
                     tcx.lang_items.owned_box()
@@ -2161,7 +2160,6 @@ fn resolve_type(cx: &DocContext,
     match def {
         def::DefSelfTy(i) => return Self(ast_util::local_def(i)),
         def::DefPrimTy(p) => match p {
-            ast::TyStr => return Primitive(Str),
             ast::TyBool => return Primitive(Bool),
             ast::TyChar => return Primitive(Char),
             ast::TyInt(ast::TyI) => return Primitive(Int),

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -32,7 +32,7 @@ use std::ascii::AsciiExt;
 use std::cell::{RefCell, Cell};
 use std::fmt;
 use std::slice;
-use std::str;
+use std::str as str_;
 use std::collections::HashMap;
 
 use html::toc::TocBuilder;
@@ -166,14 +166,14 @@ pub fn render(w: &mut fmt::Formatter, s: &str, print_toc: bool) -> fmt::Result {
             let my_opaque: &MyOpaque = &*((*opaque).opaque as *const MyOpaque);
             let text = slice::from_raw_buf(&(*orig_text).data,
                                            (*orig_text).size as uint);
-            let origtext = str::from_utf8(text).unwrap();
+            let origtext = str_::from_utf8(text).unwrap();
             debug!("docblock: ==============\n{}\n=======", text);
             let rendered = if lang.is_null() {
                 false
             } else {
                 let rlang = slice::from_raw_buf(&(*lang).data,
                                                 (*lang).size as uint);
-                let rlang = str::from_utf8(rlang).unwrap();
+                let rlang = str_::from_utf8(rlang).unwrap();
                 if LangString::parse(rlang).notrust {
                     (my_opaque.dfltblk)(ob, orig_text, lang,
                                         opaque as *mut libc::c_void);
@@ -317,14 +317,14 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector) {
             } else {
                 let lang = slice::from_raw_buf(&(*lang).data,
                                                (*lang).size as uint);
-                let s = str::from_utf8(lang).unwrap();
+                let s = str_::from_utf8(lang).unwrap();
                 LangString::parse(s)
             };
             if block_info.notrust { return }
             let text = slice::from_raw_buf(&(*text).data, (*text).size as uint);
             let opaque = opaque as *mut hoedown_html_renderer_state;
             let tests = &mut *((*opaque).opaque as *mut ::test::Collector);
-            let text = str::from_utf8(text).unwrap();
+            let text = str_::from_utf8(text).unwrap();
             let lines = text.lines().map(|l| {
                 stripped_filtered_line(l).unwrap_or(l)
             });
@@ -345,7 +345,7 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector) {
                 tests.register_header("", level as u32);
             } else {
                 let text = slice::from_raw_buf(&(*text).data, (*text).size as uint);
-                let text = str::from_utf8(text).unwrap();
+                let text = str_::from_utf8(text).unwrap();
                 tests.register_header(text, level as u32);
             }
         }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -42,7 +42,7 @@ use std::fmt;
 use std::io::fs::PathExtensions;
 use std::io::{fs, File, BufferedWriter, BufferedReader};
 use std::io;
-use std::str;
+use std::str as str_;
 use std::string::String;
 use std::sync::Arc;
 
@@ -739,7 +739,7 @@ impl<'a> SourceCollector<'a> {
                        filename.ends_with("macros>") => return Ok(()),
             Err(e) => return Err(e)
         };
-        let contents = str::from_utf8(contents.as_slice()).unwrap();
+        let contents = str_::from_utf8(contents.as_slice()).unwrap();
 
         // Remove the utf-8 BOM if any
         let contents = if contents.starts_with("\ufeff") {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -13,7 +13,7 @@ use std::dynamic_lib::DynamicLibrary;
 use std::io::{Command, TempDir};
 use std::io;
 use std::os;
-use std::str;
+use std::str as str_;
 use std::string::String;
 
 use std::collections::{HashSet, HashMap};
@@ -198,7 +198,7 @@ fn runtest(test: &str, cratename: &str, libs: Vec<Path>, externs: core::Externs,
                 panic!("test executable succeeded when it should have failed");
             } else if !should_fail && !out.status.success() {
                 panic!("test executable failed:\n{}",
-                      str::from_utf8(out.error.as_slice()));
+                      str_::from_utf8(out.error.as_slice()));
             }
         }
     }

--- a/src/librustrt/c_str.rs
+++ b/src/librustrt/c_str.rs
@@ -74,11 +74,15 @@ use core::kinds::{Sized, marker};
 use core::mem;
 use core::prelude::{Clone, Drop, Eq, Iterator};
 use core::prelude::{SlicePrelude, None, Option, Ordering, PartialEq};
-use core::prelude::{PartialOrd, RawPtr, Some, StrPrelude, range};
+use core::prelude::{PartialOrd, RawPtr, Some, range};
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
+use core::prelude::{StrPrelude};
 use core::ptr;
 use core::raw::Slice;
 use core::slice;
-use core::str;
+use core::str as str_;
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use libc;
 
 /// The representation of a C String.
@@ -228,7 +232,7 @@ impl CString {
     #[inline]
     pub fn as_str<'a>(&'a self) -> Option<&'a str> {
         let buf = self.as_bytes_no_nul();
-        str::from_utf8(buf)
+        str_::from_utf8(buf)
     }
 
     /// Return a CString iterator.

--- a/src/librustrt/lib.rs
+++ b/src/librustrt/lib.rs
@@ -127,4 +127,6 @@ pub mod shouldnt_be_public {
 #[cfg(not(test))]
 mod std {
     pub use core::{fmt, option, cmp};
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    pub use core::str;
 }

--- a/src/librustrt/unwind.rs
+++ b/src/librustrt/unwind.rs
@@ -70,6 +70,8 @@ use core::fmt;
 use core::intrinsics;
 use core::mem;
 use core::raw::Closure;
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use libc::c_void;
 
 use local::Local;

--- a/src/libserialize/base64.rs
+++ b/src/libserialize/base64.rs
@@ -73,8 +73,8 @@ impl ToBase64 for [u8] {
     /// use serialize::base64::{ToBase64, STANDARD};
     ///
     /// fn main () {
-    ///     let str = [52,32].to_base64(STANDARD);
-    ///     println!("base 64 output: {}", str);
+    ///     let s = [52,32].to_base64(STANDARD);
+    ///     println!("base 64 output: {}", s);
     /// }
     /// ```
     fn to_base64(&self, config: Config) -> String {

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -36,8 +36,8 @@ impl ToHex for [u8] {
     /// use serialize::hex::ToHex;
     ///
     /// fn main () {
-    ///     let str = [52,32].to_hex();
-    ///     println!("{}", str);
+    ///     let s = [52,32].to_hex();
+    ///     println!("{}", s);
     /// }
     /// ```
     fn to_hex(&self) -> String {

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -199,7 +199,8 @@ use self::InternalStackElement::*;
 
 use std;
 use std::collections::{HashMap, TreeMap};
-use std::{char, f64, fmt, io, num, str};
+use std::{char, f64, fmt, io, num};
+use std::str as str_;
 use std::mem::{swap, transmute};
 use std::num::{Float, FPNaN, FPInfinite, Int};
 use std::str::{FromStr, ScalarValue};
@@ -577,7 +578,7 @@ impl<'a> ::Encoder<io::IoError> for Encoder<'a> {
             let mut check_encoder = Encoder::new(&mut buf);
             try!(f(transmute(&mut check_encoder)));
         }
-        let out = str::from_utf8(buf[]).unwrap();
+        let out = str_::from_utf8(buf[]).unwrap();
         let needs_wrapping = out.char_at(0) != '"' && out.char_at_reverse(out.len()) != '"';
         if needs_wrapping { try!(write!(self.writer, "\"")); }
         try!(f(self));
@@ -838,7 +839,7 @@ impl<'a> ::Encoder<io::IoError> for PrettyEncoder<'a> {
             let mut check_encoder = PrettyEncoder::new(&mut buf);
             try!(f(transmute(&mut check_encoder)));
         }
-        let out = str::from_utf8(buf[]).unwrap();
+        let out = str_::from_utf8(buf[]).unwrap();
         let needs_wrapping = out.char_at(0) != '"' && out.char_at_reverse(out.len()) != '"';
         if needs_wrapping { try!(write!(self.writer, "\"")); }
         try!(f(self));
@@ -1162,7 +1163,7 @@ impl Stack {
         match self.stack[idx] {
             InternalIndex(i) => Index(i),
             InternalKey(start, size) => {
-                Key(str::from_utf8(
+                Key(str_::from_utf8(
                     self.str_buffer[start as uint .. start as uint + size as uint]).unwrap())
             }
         }
@@ -1204,7 +1205,7 @@ impl Stack {
             None => None,
             Some(&InternalIndex(i)) => Some(Index(i)),
             Some(&InternalKey(start, size)) => {
-                Some(Key(str::from_utf8(
+                Some(Key(str_::from_utf8(
                     self.str_buffer[start as uint .. (start+size) as uint]
                 ).unwrap()))
             }
@@ -1557,7 +1558,7 @@ impl<T: Iterator<char>> Parser<T> {
                             }
 
                             let buf = [n1, try!(self.decode_hex_escape())];
-                            match str::utf16_items(buf.as_slice()).next() {
+                            match str_::utf16_items(buf.as_slice()).next() {
                                 Some(ScalarValue(c)) => res.push(c),
                                 _ => return self.error(LoneLeadingSurrogateInHexEscape),
                             }
@@ -1906,7 +1907,7 @@ pub fn from_reader(rdr: &mut io::Reader) -> Result<Json, BuilderError> {
         Ok(c)  => c,
         Err(e) => return Err(io_error_to_error(e))
     };
-    let s = match str::from_utf8(contents.as_slice()) {
+    let s = match str_::from_utf8(contents.as_slice()) {
         Some(s) => s,
         _       => return Err(SyntaxError(NotUtf8, 0, 0))
     };
@@ -2098,7 +2099,7 @@ impl ::Decoder<DecoderError> for Decoder {
             }
         };
         let idx = match names.iter()
-                             .position(|n| str::eq_slice(*n, name.as_slice())) {
+                             .position(|n| str_::eq_slice(*n, name.as_slice())) {
             Some(idx) => idx,
             None => return Err(UnknownVariantError(name))
         };

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -16,12 +16,16 @@
 #![allow(deprecated)]
 
 use core::kinds::Sized;
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use fmt;
 use iter::IteratorExt;
 use mem;
 use option::{Option, Some, None};
 use slice::{SlicePrelude, AsSlice};
-use str::{Str, StrPrelude};
+use str::Str;
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
+use str::StrPrelude;
 use string::{String, IntoString};
 use vec::Vec;
 

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -633,6 +633,7 @@ mod tests {
     use prelude::*;
     use super::*;
     use char::from_u32;
+    #[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
     use str::StrPrelude;
 
     macro_rules! v2ascii (

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -16,6 +16,8 @@
 #![allow(missing_docs)]
 
 use clone::Clone;
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use c_str::ToCStr;
 use iter::IteratorExt;
 use mem;
@@ -25,7 +27,7 @@ use os;
 use path::{Path,GenericPath};
 use result::*;
 use slice::{AsSlice,SlicePrelude};
-use str;
+use str as str_;
 use string::String;
 use vec::Vec;
 
@@ -39,7 +41,7 @@ impl Drop for DynamicLibrary {
             }
         }) {
             Ok(()) => {},
-            Err(str) => panic!("{}", str)
+            Err(s) => panic!("{}", s)
         }
     }
 }
@@ -82,7 +84,7 @@ impl DynamicLibrary {
         search_path.insert(0, path.clone());
         let newval = DynamicLibrary::create_path(search_path.as_slice());
         os::setenv(DynamicLibrary::envvar(),
-                   str::from_utf8(newval.as_slice()).unwrap());
+                   str_::from_utf8(newval.as_slice()).unwrap());
     }
 
     /// From a slice of paths, create a new vector which is suitable to be an
@@ -282,6 +284,7 @@ pub mod dl {
     use ptr;
     use result::{Ok, Err, Result};
     use slice::SlicePrelude;
+    #[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
     use str::StrPrelude;
     use str;
     use string::String;

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -78,6 +78,8 @@
 //! }
 //! ```
 
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use option::{Option, None};
 use kinds::Send;
 use string::String;

--- a/src/libstd/failure.rs
+++ b/src/libstd/failure.rs
@@ -13,6 +13,8 @@
 use alloc::boxed::Box;
 use any::{Any, AnyRefExt};
 use cell::RefCell;
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use fmt;
 use io::{Writer, IoResult};
 use kinds::Send;

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -408,6 +408,7 @@ mod test {
     use super::super::{IoResult, EndOfFile};
     use super::super::mem::MemReader;
     use self::test::Bencher;
+    #[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
     use str::StrPrelude;
 
     /// A type, free to create, primarily intended for benchmarking creation of

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -822,11 +822,12 @@ mod test {
     use prelude::*;
     use io::{SeekSet, SeekCur, SeekEnd, Read, Open, ReadWrite, FileType};
     use io;
-    use str;
+    use str as str_;
     use io::fs::*;
     use path::Path;
     use io;
     use ops::Drop;
+    #[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
     use str::StrPrelude;
 
     macro_rules! check( ($e:expr) => (
@@ -889,7 +890,7 @@ mod test {
             let mut read_buf = [0, .. 1028];
             let read_str = match check!(read_stream.read(&mut read_buf)) {
                 -1|0 => panic!("shouldn't happen"),
-                n => str::from_utf8(read_buf[..n]).unwrap().to_string()
+                n => str_::from_utf8(read_buf[..n]).unwrap().to_string()
             };
             assert_eq!(read_str.as_slice(), message);
         }
@@ -945,7 +946,7 @@ mod test {
             }
         }
         check!(unlink(filename));
-        let read_str = str::from_utf8(&read_mem).unwrap();
+        let read_str = str_::from_utf8(&read_mem).unwrap();
         assert_eq!(read_str, message);
     }
 
@@ -970,7 +971,7 @@ mod test {
             tell_pos_post_read = check!(read_stream.tell());
         }
         check!(unlink(filename));
-        let read_str = str::from_utf8(&read_mem).unwrap();
+        let read_str = str_::from_utf8(&read_mem).unwrap();
         assert_eq!(read_str, message.slice(4, 8));
         assert_eq!(tell_pos_pre_read, set_cursor);
         assert_eq!(tell_pos_post_read, message.len() as u64);
@@ -996,13 +997,12 @@ mod test {
             check!(read_stream.read(&mut read_mem));
         }
         check!(unlink(filename));
-        let read_str = str::from_utf8(&read_mem).unwrap();
+        let read_str = str_::from_utf8(&read_mem).unwrap();
         assert!(read_str.as_slice() == final_msg.as_slice());
     }
 
     #[test]
     fn file_test_io_seek_shakedown() {
-        use str;          // 01234567890123
         let initial_msg =   "qwer-asdf-zxcv";
         let chunk_one: &str = "qwer";
         let chunk_two: &str = "asdf";
@@ -1019,15 +1019,15 @@ mod test {
 
             check!(read_stream.seek(-4, SeekEnd));
             check!(read_stream.read(&mut read_mem));
-            assert_eq!(str::from_utf8(&read_mem).unwrap(), chunk_three);
+            assert_eq!(str_::from_utf8(&read_mem).unwrap(), chunk_three);
 
             check!(read_stream.seek(-9, SeekCur));
             check!(read_stream.read(&mut read_mem));
-            assert_eq!(str::from_utf8(&read_mem).unwrap(), chunk_two);
+            assert_eq!(str_::from_utf8(&read_mem).unwrap(), chunk_two);
 
             check!(read_stream.seek(0, SeekSet));
             check!(read_stream.read(&mut read_mem));
-            assert_eq!(str::from_utf8(&read_mem).unwrap(), chunk_one);
+            assert_eq!(str_::from_utf8(&read_mem).unwrap(), chunk_one);
         }
         check!(unlink(filename));
     }
@@ -1114,7 +1114,7 @@ mod test {
             {
                 let n = f.filestem_str();
                 check!(File::open(f).read(&mut mem));
-                let read_str = str::from_utf8(&mem).unwrap();
+                let read_str = str_::from_utf8(&mem).unwrap();
                 let expected = match n {
                     None|Some("") => panic!("really shouldn't happen.."),
                     Some(n) => format!("{}{}", prefix, n),

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -50,6 +50,8 @@
 //! fs::unlink(&path);
 //! ```
 
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use clone::Clone;
 use io::standard_error;
 use io::{FilePermission, Write, Open, FileAccess, FileMode, FileType};

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -404,6 +404,7 @@ mod test {
     use io::*;
     use io;
     use self::test::Bencher;
+    #[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
     use str::StrPrelude;
 
     #[test]

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -226,6 +226,8 @@ pub use self::IoErrorKind::*;
 
 use char::Char;
 use clone::Clone;
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use default::Default;
 use error::{FromError, Error};
 use fmt;
@@ -239,8 +241,10 @@ use boxed::Box;
 use result::{Ok, Err, Result};
 use sys;
 use slice::{AsSlice, SlicePrelude};
-use str::{Str, StrPrelude};
-use str;
+use str::Str;
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
+use str::StrPrelude;
+use str as str_;
 use string::String;
 use uint;
 use unicode::char::UnicodeChar;
@@ -1496,7 +1500,7 @@ pub trait Buffer: Reader {
     /// valid utf-8 encoded codepoint as the next few bytes in the stream.
     fn read_char(&mut self) -> IoResult<char> {
         let first_byte = try!(self.read_byte());
-        let width = str::utf8_char_width(first_byte);
+        let width = str_::utf8_char_width(first_byte);
         if width == 1 { return Ok(first_byte as char) }
         if width == 0 { return Err(standard_error(InvalidInput)) } // not utf8
         let mut buf = [first_byte, 0, 0, 0];
@@ -1510,7 +1514,7 @@ pub trait Buffer: Reader {
                 }
             }
         }
-        match str::from_utf8(buf[..width]) {
+        match str_::from_utf8(buf[..width]) {
             Some(s) => Ok(s.char_at(0)),
             None => Err(standard_error(InvalidInput))
         }

--- a/src/libstd/io/net/addrinfo.rs
+++ b/src/libstd/io/net/addrinfo.rs
@@ -19,6 +19,8 @@ pub use self::SocketType::*;
 pub use self::Flag::*;
 pub use self::Protocol::*;
 
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use iter::IteratorExt;
 use io::{IoResult};
 use io::net::ip::{SocketAddr, IpAddr};

--- a/src/libstd/io/net/ip.rs
+++ b/src/libstd/io/net/ip.rs
@@ -17,13 +17,17 @@
 
 pub use self::IpAddr::*;
 
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use fmt;
 use io::{mod, IoResult, IoError};
 use io::net;
 use iter::{Iterator, IteratorExt};
 use option::{Option, None, Some};
 use result::{Ok, Err};
-use str::{FromStr, StrPrelude};
+use str::FromStr;
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
+use str::StrPrelude;
 use slice::{CloneSlicePrelude, SlicePrelude};
 use vec::Vec;
 

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -30,6 +30,8 @@ use self::StdSource::*;
 use boxed::Box;
 use cell::RefCell;
 use clone::Clone;
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use failure::LOCAL_STDERR;
 use fmt;
 use io::{Reader, Writer, IoResult, IoError, OtherIoError, Buffer,
@@ -44,6 +46,7 @@ use rustrt;
 use rustrt::local::Local;
 use rustrt::task::Task;
 use slice::SlicePrelude;
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
 use str::StrPrelude;
 use string::String;
 use sys::{fs, tty};

--- a/src/libstd/io/tempfile.rs
+++ b/src/libstd/io/tempfile.rs
@@ -10,6 +10,8 @@
 
 //! Temporary files and directories
 
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use io::{fs, IoResult};
 use io;
 use libc;

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -273,4 +273,6 @@ mod std {
 
     pub use boxed; // used for vec![]
 
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    pub use core::str;
 }

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -36,6 +36,7 @@
 /// panic!(4i); // panic with the value of 4 to be collected elsewhere
 /// panic!("this is a {} {message}", "fancy", message = "message");
 /// ```
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
 #[macro_export]
 macro_rules! panic(
     () => ({
@@ -66,6 +67,62 @@ macro_rules! panic(
         #[inline(always)]
         fn _run_fmt(fmt: &::std::fmt::Arguments) -> ! {
             static _FILE_LINE: (&'static str, uint) = (file!(), line!());
+            ::std::rt::begin_unwind_fmt(fmt, &_FILE_LINE)
+        }
+        format_args!(_run_fmt, $fmt, $($arg)*)
+    });
+)
+
+/// The entry point for panic of Rust tasks.
+///
+/// This macro is used to inject panic into a Rust task, causing the task to
+/// unwind and panic entirely. Each task's panic can be reaped as the
+/// `Box<Any>` type, and the single-argument form of the `panic!` macro will be
+/// the value which is transmitted.
+///
+/// The multi-argument form of this macro panics with a string and has the
+/// `format!` syntax for building a string.
+///
+/// # Example
+///
+/// ```should_fail
+/// # #![allow(unreachable_code)]
+/// panic!();
+/// panic!("this is a terrible mistake!");
+/// panic!(4i); // panic with the value of 4 to be collected elsewhere
+/// panic!("this is a {} {message}", "fancy", message = "message");
+/// ```
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+#[macro_export]
+macro_rules! panic(
+    () => ({
+        panic!("explicit panic")
+    });
+    ($msg:expr) => ({
+        // static requires less code at runtime, more constant data
+        static _FILE_LINE: (&'static ::std::str::str, uint) = (file!(), line!());
+        ::std::rt::begin_unwind($msg, &_FILE_LINE)
+    });
+    ($fmt:expr, $($arg:tt)*) => ({
+        // a closure can't have return type !, so we need a full
+        // function to pass to format_args!, *and* we need the
+        // file and line numbers right here; so an inner bare fn
+        // is our only choice.
+        //
+        // LLVM doesn't tend to inline this, presumably because begin_unwind_fmt
+        // is #[cold] and #[inline(never)] and because this is flagged as cold
+        // as returning !. We really do want this to be inlined, however,
+        // because it's just a tiny wrapper. Small wins (156K to 149K in size)
+        // were seen when forcing this to be inlined, and that number just goes
+        // up with the number of calls to panic!()
+        //
+        // The leading _'s are to avoid dead code warnings if this is
+        // used inside a dead function. Just `#[allow(dead_code)]` is
+        // insufficient, since the user may have
+        // `#[forbid(dead_code)]` and which cannot be overridden.
+        #[inline(always)]
+        fn _run_fmt(fmt: &::std::fmt::Arguments) -> ! {
+            static _FILE_LINE: (&'static ::std::str::str, uint) = (file!(), line!());
             ::std::rt::begin_unwind_fmt(fmt, &_FILE_LINE)
         }
         format_args!(_run_fmt, $fmt, $($arg)*)

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -21,6 +21,7 @@ use char::Char;
 use num;
 use num::{Int, Float, FPNaN, FPInfinite, ToPrimitive};
 use slice::{SlicePrelude, CloneSliceAllocPrelude};
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
 use str::StrPrelude;
 use string::String;
 use vec::Vec;

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -32,6 +32,8 @@ pub use self::MapOption::*;
 pub use self::MapError::*;
 
 use clone::Clone;
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use error::{FromError, Error};
 use fmt;
 use io::{IoResult, IoError};
@@ -50,7 +52,9 @@ use ptr;
 use result::{Err, Ok, Result};
 use slice::{AsSlice, SlicePrelude, PartialEqSlicePrelude};
 use slice::CloneSliceAllocPrelude;
-use str::{Str, StrPrelude, StrAllocating};
+use str::{Str, StrAllocating};
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
+use str::StrPrelude;
 use string::{String, ToString};
 use sync::atomic::{AtomicInt, INIT_ATOMIC_INT, SeqCst};
 use vec::Vec;
@@ -1263,7 +1267,7 @@ pub enum MapError {
 
 impl fmt::Show for MapError {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
-        let str = match *self {
+        let s = match *self {
             ErrFdNotAvail => "fd not available for reading or writing",
             ErrInvalidFd => "Invalid fd",
             ErrUnaligned => {
@@ -1289,7 +1293,7 @@ impl fmt::Show for MapError {
                 return write!(out, "MapViewOfFile failure = {}", code)
             }
         };
-        write!(out, "{}", str)
+        write!(out, "{}", s)
     }
 }
 
@@ -1536,6 +1540,9 @@ impl MemoryMap {
 
 #[cfg(target_os = "linux")]
 pub mod consts {
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    use core::str::str;
+
     pub use os::arch_consts::ARCH;
 
     pub const FAMILY: &'static str = "unix";
@@ -1567,6 +1574,9 @@ pub mod consts {
 
 #[cfg(target_os = "macos")]
 pub mod consts {
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    use core::str::str;
+
     pub use os::arch_consts::ARCH;
 
     pub const FAMILY: &'static str = "unix";
@@ -1598,6 +1608,9 @@ pub mod consts {
 
 #[cfg(target_os = "ios")]
 pub mod consts {
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    use core::str::str;
+
     pub use os::arch_consts::ARCH;
 
     pub const FAMILY: &'static str = "unix";
@@ -1617,6 +1630,9 @@ pub mod consts {
 
 #[cfg(target_os = "freebsd")]
 pub mod consts {
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    use core::str::str;
+
     pub use os::arch_consts::ARCH;
 
     pub const FAMILY: &'static str = "unix";
@@ -1648,6 +1664,9 @@ pub mod consts {
 
 #[cfg(target_os = "dragonfly")]
 pub mod consts {
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    use core::str::str;
+
     pub use os::arch_consts::ARCH;
 
     pub const FAMILY: &'static str = "unix";
@@ -1679,6 +1698,9 @@ pub mod consts {
 
 #[cfg(target_os = "android")]
 pub mod consts {
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    use core::str::str;
+
     pub use os::arch_consts::ARCH;
 
     pub const FAMILY: &'static str = "unix";
@@ -1710,6 +1732,9 @@ pub mod consts {
 
 #[cfg(target_os = "windows")]
 pub mod consts {
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    use core::str::str;
+
     pub use os::arch_consts::ARCH;
 
     pub const FAMILY: &'static str = "windows";
@@ -1741,26 +1766,41 @@ pub mod consts {
 
 #[cfg(target_arch = "x86")]
 mod arch_consts {
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    use core::str::str;
+
     pub const ARCH: &'static str = "x86";
 }
 
 #[cfg(target_arch = "x86_64")]
 mod arch_consts {
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    use core::str::str;
+
     pub const ARCH: &'static str = "x86_64";
 }
 
 #[cfg(target_arch = "arm")]
 mod arch_consts {
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    use core::str::str;
+
     pub const ARCH: &'static str = "arm";
 }
 
 #[cfg(target_arch = "mips")]
 mod arch_consts {
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    use core::str::str;
+
     pub const ARCH: &'static str = "mips";
 }
 
 #[cfg(target_arch = "mipsel")]
 mod arch_consts {
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    use core::str::str;
+
     pub const ARCH: &'static str = "mipsel";
 }
 

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -62,13 +62,17 @@
 #![experimental]
 
 use core::kinds::Sized;
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use c_str::CString;
 use clone::Clone;
 use fmt;
 use iter::IteratorExt;
 use option::{Option, None, Some};
-use str;
-use str::{CowString, MaybeOwned, Str, StrPrelude};
+use str as str_;
+use str::{CowString, MaybeOwned, Str};
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
+use str::StrPrelude;
 use string::String;
 use slice::{AsSlice, CloneSliceAllocPrelude};
 use slice::{PartialEqSlicePrelude, SlicePrelude};
@@ -196,7 +200,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// ```
     #[inline]
     fn as_str<'a>(&'a self) -> Option<&'a str> {
-        str::from_utf8(self.as_vec())
+        str_::from_utf8(self.as_vec())
     }
 
     /// Returns the path as a byte vector
@@ -292,7 +296,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// ```
     #[inline]
     fn dirname_str<'a>(&'a self) -> Option<&'a str> {
-        str::from_utf8(self.dirname())
+        str_::from_utf8(self.dirname())
     }
 
     /// Returns the file component of `self`, as a byte vector.
@@ -326,7 +330,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// ```
     #[inline]
     fn filename_str<'a>(&'a self) -> Option<&'a str> {
-        self.filename().and_then(str::from_utf8)
+        self.filename().and_then(str_::from_utf8)
     }
 
     /// Returns the stem of the filename of `self`, as a byte vector.
@@ -372,7 +376,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// ```
     #[inline]
     fn filestem_str<'a>(&'a self) -> Option<&'a str> {
-        self.filestem().and_then(str::from_utf8)
+        self.filestem().and_then(str_::from_utf8)
     }
 
     /// Returns the extension of the filename of `self`, as an optional byte vector.
@@ -419,7 +423,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// ```
     #[inline]
     fn extension_str<'a>(&'a self) -> Option<&'a str> {
-        self.extension().and_then(str::from_utf8)
+        self.extension().and_then(str_::from_utf8)
     }
 
     /// Replaces the filename portion of the path with the given byte vector or string.
@@ -792,7 +796,7 @@ pub trait BytesContainer for Sized? {
     /// Returns the receiver interpreted as a utf-8 string, if possible
     #[inline]
     fn container_as_str<'a>(&'a self) -> Option<&'a str> {
-        str::from_utf8(self.container_as_bytes())
+        str_::from_utf8(self.container_as_bytes())
     }
     /// Returns whether .container_as_str() is guaranteed to not fail
     // FIXME (#8888): Remove unused arg once ::<for T> works
@@ -896,7 +900,7 @@ impl BytesContainer for CString {
     }
 }
 
-impl<'a> BytesContainer for str::MaybeOwned<'a> {
+impl<'a> BytesContainer for str_::MaybeOwned<'a> {
     #[inline]
     fn container_as_bytes<'b>(&'b self) -> &'b [u8] {
         self.as_slice().as_bytes()
@@ -906,7 +910,7 @@ impl<'a> BytesContainer for str::MaybeOwned<'a> {
         Some(self.as_slice())
     }
     #[inline]
-    fn is_str(_: Option<&str::MaybeOwned>) -> bool { true }
+    fn is_str(_: Option<&str_::MaybeOwned>) -> bool { true }
 }
 
 impl<'a, Sized? T: BytesContainer> BytesContainer for &'a T {

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -445,7 +445,8 @@ static dot_dot_static: &'static [u8] = b"..";
 mod tests {
     use prelude::*;
     use super::*;
-    use str;
+    use str as str_;
+    #[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
     use str::StrPrelude;
 
     macro_rules! t(
@@ -609,7 +610,7 @@ mod tests {
             (s: $path:expr, $op:ident, $exp:expr, opt) => (
                 {
                     let path = Path::new($path);
-                    let left = path.$op().map(|x| str::from_utf8(x).unwrap());
+                    let left = path.$op().map(|x| str_::from_utf8(x).unwrap());
                     assert!(left == $exp);
                 }
             );

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -12,6 +12,8 @@
 
 use c_str::{CString, ToCStr};
 use clone::Clone;
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use cmp::{PartialEq, Eq, PartialOrd, Ord, Ordering};
 use hash;
 use io::Writer;
@@ -20,7 +22,7 @@ use iter::{Iterator, IteratorExt, Map};
 use option::{Option, None, Some};
 use kinds::Sized;
 use str::{FromStr, Str};
-use str;
+use str as str_;
 use slice::{CloneSliceAllocPrelude, Splits, AsSlice, VectorVector,
             PartialEqSlicePrelude, SlicePrelude};
 use vec::Vec;
@@ -400,7 +402,7 @@ impl Path {
     /// Returns an iterator that yields each component of the path as Option<&str>.
     /// See components() for details.
     pub fn str_components<'a>(&'a self) -> StrComponents<'a> {
-        self.components().map(str::from_utf8)
+        self.components().map(str_::from_utf8)
     }
 }
 

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -18,6 +18,8 @@ use ascii::AsciiCast;
 use c_str::{CString, ToCStr};
 use clone::Clone;
 use cmp::{PartialEq, Eq, PartialOrd, Ord, Ordering};
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use hash;
 use io::Writer;
 use iter::{AdditiveIterator, DoubleEndedIteratorExt, Extend};
@@ -25,7 +27,9 @@ use iter::{Iterator, IteratorExt, Map};
 use mem;
 use option::{Option, Some, None};
 use slice::{AsSlice, SlicePrelude};
-use str::{CharSplits, FromStr, Str, StrAllocating, StrVector, StrPrelude};
+use str::{CharSplits, FromStr, Str, StrAllocating, StrVector};
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
+use str::StrPrelude;
 use string::String;
 use unicode::char::UnicodeChar;
 use vec::Vec;

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -79,8 +79,12 @@
 #[doc(no_inline)] pub use result::Result;
 #[doc(no_inline)] pub use result::Result::{Ok, Err};
 #[doc(no_inline)] pub use io::{Buffer, Writer, Reader, Seek, BufferPrelude};
-#[doc(no_inline)] pub use str::{Str, StrVector, StrPrelude};
+#[doc(no_inline)] pub use str::{Str, StrVector};
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
+#[doc(no_inline)] pub use str::StrPrelude;
 #[doc(no_inline)] pub use str::{StrAllocating, UnicodeStrPrelude};
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+#[doc(no_inline)] pub use core::str::str;
 #[doc(no_inline)] pub use tuple::{Tuple1, Tuple2, Tuple3, Tuple4};
 #[doc(no_inline)] pub use tuple::{Tuple5, Tuple6, Tuple7, Tuple8};
 #[doc(no_inline)] pub use tuple::{Tuple9, Tuple10, Tuple11, Tuple12};

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -12,12 +12,16 @@
 
 #![allow(non_camel_case_types)]
 
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use io::{IoResult, Writer};
 use iter::{Iterator, IteratorExt};
 use option::{Some, None};
 use os;
 use result::{Ok, Err};
-use str::{StrPrelude, from_str};
+use str::from_str;
+#[cfg(stage0)]  // NOTE(stage0): Remove import after a snapshot
+use str::StrPrelude;
 use sync::atomic;
 use unicode::char::UnicodeChar;
 

--- a/src/libstd/sync/poison.rs
+++ b/src/libstd/sync/poison.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(not(stage0))]  // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use option::None;
 use rustrt::task::Task;
 use rustrt::local::Local;

--- a/src/libstd/task.rs
+++ b/src/libstd/task.rs
@@ -47,6 +47,8 @@ use any::Any;
 use borrow::IntoCow;
 use boxed::Box;
 use comm::channel;
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use io::{Writer, stdio};
 use kinds::{Send, marker};
 use option::{None, Some, Option};

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1090,7 +1090,6 @@ pub enum PrimTy {
     TyInt(IntTy),
     TyUint(UintTy),
     TyFloat(FloatTy),
-    TyStr,
     TyBool,
     TyChar
 }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1611,7 +1611,7 @@ mod test {
     fn run_renaming_test(t: &RenamingTest, test_idx: uint) {
         let invalid_name = token::special_idents::invalid.name;
         let (teststr, bound_connections, bound_ident_check) = match *t {
-            (ref str,ref conns, bic) => (str.to_string(), conns.clone(), bic)
+            (ref s,ref conns, bic) => (s.to_string(), conns.clone(), bic)
         };
         let cr = expand_crate_str(teststr.to_string());
         let bindings = crate_bindings(&cr);

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -512,9 +512,14 @@ impl<'a, 'b> Context<'a, 'b> {
         // format "string"
         let static_str_name = self.ecx.ident_of("__STATIC_FMTSTR");
         let static_lifetime = self.ecx.lifetime(self.fmtsp, self.ecx.ident_of("'static").name);
+        let str_path = self.ecx.path_global(self.fmtsp, vec![
+            self.ecx.ident_of("std"),
+            self.ecx.ident_of("str"),
+            self.ecx.ident_of("str"),
+        ]);
         let piece_ty = self.ecx.ty_rptr(
                 self.fmtsp,
-                self.ecx.ty_ident(self.fmtsp, self.ecx.ident_of("str")),
+                self.ecx.ty_path(str_path),
                 Some(static_lifetime),
                 ast::MutImmutable);
         lets.push(Context::item_static_array(self.ecx,

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -475,11 +475,11 @@ pub fn expand_quote_stmt(cx: &mut ExtCtxt,
 }
 
 fn ids_ext(strs: Vec<String> ) -> Vec<ast::Ident> {
-    strs.iter().map(|str| str_to_ident((*str).as_slice())).collect()
+    strs.iter().map(|s| str_to_ident((*s).as_slice())).collect()
 }
 
-fn id_ext(str: &str) -> ast::Ident {
-    str_to_ident(str)
+fn id_ext(s: &str) -> ast::Ident {
+    str_to_ident(s)
 }
 
 // Lift an ident to the expr that evaluates to that ident.

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -256,11 +256,11 @@ pub fn parse_or_else(sess: &ParseSess,
                      -> HashMap<Ident, Rc<NamedMatch>> {
     match parse(sess, cfg, rdr, ms.as_slice()) {
         Success(m) => m,
-        Failure(sp, str) => {
-            sess.span_diagnostic.span_fatal(sp, str.as_slice())
+        Failure(sp, s) => {
+            sess.span_diagnostic.span_fatal(sp, s.as_slice())
         }
-        Error(sp, str) => {
-            sess.span_diagnostic.span_fatal(sp, str.as_slice())
+        Error(sp, s) => {
+            sess.span_diagnostic.span_fatal(sp, s.as_slice())
         }
     }
 }

--- a/src/libsyntax/parse/lexer/comments.rs
+++ b/src/libsyntax/parse/lexer/comments.rs
@@ -20,7 +20,7 @@ use parse::lexer;
 use print::pprust;
 
 use std::io;
-use std::str;
+use std::str as str_;
 use std::string::String;
 use std::uint;
 
@@ -212,7 +212,7 @@ fn all_whitespace(s: &str, col: CharPos) -> Option<uint> {
     let mut col = col.to_uint();
     let mut cursor: uint = 0;
     while col > 0 && cursor < len {
-        let r: str::CharRange = s.char_range_at(cursor);
+        let r: str_::CharRange = s.char_range_at(cursor);
         if !r.ch.is_whitespace() {
             return None;
         }

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -21,7 +21,7 @@ use std::fmt;
 use std::mem::replace;
 use std::num;
 use std::rc::Rc;
-use std::str;
+use std::str as str_;
 
 pub use ext::tt::transcribe::{TtReader, new_tt_reader};
 
@@ -272,10 +272,10 @@ impl<'a> StringReader<'a> {
 
     /// Converts CRLF to LF in the given string, raising an error on bare CR.
     fn translate_crlf<'a>(&self, start: BytePos,
-                          s: &'a str, errmsg: &'a str) -> str::CowString<'a> {
+                          s: &'a str, errmsg: &'a str) -> str_::CowString<'a> {
         let mut i = 0u;
         while i < s.len() {
-            let str::CharRange { ch, next } = s.char_range_at(i);
+            let str_::CharRange { ch, next } = s.char_range_at(i);
             if ch == '\r' {
                 if next < s.len() && s.char_at(next) == '\n' {
                     return translate_crlf_(self, start, s, errmsg, i).into_cow();
@@ -293,7 +293,7 @@ impl<'a> StringReader<'a> {
             let mut buf = String::with_capacity(s.len());
             let mut j = 0;
             while i < s.len() {
-                let str::CharRange { ch, next } = s.char_range_at(i);
+                let str_::CharRange { ch, next } = s.char_range_at(i);
                 if ch == '\r' {
                     if j < i { buf.push_str(s.slice(j, i)); }
                     j = next;
@@ -357,7 +357,7 @@ impl<'a> StringReader<'a> {
         let offset = self.byte_offset(self.pos).to_uint();
         let s = self.filemap.deref().src.as_slice();
         if offset >= s.len() { return None }
-        let str::CharRange { next, .. } = s.char_range_at(offset);
+        let str_::CharRange { next, .. } = s.char_range_at(offset);
         if next < s.len() {
             Some(s.char_at(next))
         } else {

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -21,7 +21,7 @@ use std::cell::{Cell, RefCell};
 use std::io::File;
 use std::rc::Rc;
 use std::num::Int;
-use std::str;
+use std::str as str_;
 use std::iter;
 
 pub mod lexer;
@@ -255,7 +255,7 @@ pub fn file_to_filemap(sess: &ParseSess, path: &Path, spanopt: Option<Span>)
             unreachable!()
         }
     };
-    match str::from_utf8(bytes.as_slice()) {
+    match str_::from_utf8(bytes.as_slice()) {
         Some(s) => {
             return string_to_filemap(sess, s.to_string(),
                                      path.as_str().unwrap().to_string())
@@ -429,7 +429,7 @@ pub fn str_lit(lit: &str) -> String {
     let error = |i| format!("lexer should have rejected {} at {}", lit, i);
 
     /// Eat everything up to a non-whitespace
-    fn eat<'a>(it: &mut iter::Peekable<(uint, char), str::CharOffsets<'a>>) {
+    fn eat<'a>(it: &mut iter::Peekable<(uint, char), str_::CharOffsets<'a>>) {
         loop {
             match it.peek().map(|x| x.val1()) {
                 Some(' ') | Some('\n') | Some('\r') | Some('\t') => {

--- a/src/libunicode/tables.rs
+++ b/src/libunicode/tables.rs
@@ -3641,6 +3641,9 @@ pub mod property {
 }
 
 pub mod regex {
+    #[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+    use core::str::str;
+
     pub static UNICODE_CLASSES: &'static [(&'static str, &'static &'static [(char, char)])] = &[
         ("Alphabetic", &super::derived_property::Alphabetic_table), ("Arabic",
         &super::script::Arabic_table), ("Armenian", &super::script::Armenian_table), ("Avestan",

--- a/src/libunicode/u_str.rs
+++ b/src/libunicode/u_str.rs
@@ -22,7 +22,11 @@ use core::iter::{Filter, AdditiveIterator, Iterator, IteratorExt};
 use core::iter::{DoubleEndedIterator, DoubleEndedIteratorExt};
 use core::kinds::Sized;
 use core::option::{Option, None, Some};
-use core::str::{CharSplits, StrPrelude};
+use core::str::CharSplits;
+#[cfg(stage0)] // NOTE(stage0): Remove import after a snapshot
+use core::str::StrPrelude;
+#[cfg(not(stage0))] // NOTE(stage0): Remove cfg after a snapshot
+use core::str::str;
 use u_char::UnicodeChar;
 use tables::grapheme::GraphemeCat;
 

--- a/src/test/auxiliary/lang-item-public.rs
+++ b/src/test/auxiliary/lang-item-public.rs
@@ -14,6 +14,9 @@
 #[lang="sized"]
 pub trait Sized for Sized? {}
 
+#[lang="str"]
+struct str([u8]);
+
 #[lang="panic"]
 fn panic(_: &(&'static str, &'static str, uint)) -> ! { loop {} }
 

--- a/src/test/auxiliary/weak-lang-items.rs
+++ b/src/test/auxiliary/weak-lang-items.rs
@@ -32,6 +32,6 @@ pub fn foo() {
 }
 
 mod std {
-    pub use core::{option, fmt};
+    pub use core::{option, fmt, str};
 }
 

--- a/src/test/bench/shootout-chameneos-redux.rs
+++ b/src/test/bench/shootout-chameneos-redux.rs
@@ -56,12 +56,12 @@ fn print_complements() {
 enum Color { Red, Yellow, Blue }
 impl fmt::Show for Color {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let str = match *self {
+        let s = match *self {
             Red => "red",
             Yellow => "yellow",
             Blue => "blue",
         };
-        write!(f, "{}", str)
+        write!(f, "{}", s)
     }
 }
 

--- a/src/test/compile-fail/bad-mid-path-type-params.rs
+++ b/src/test/compile-fail/bad-mid-path-type-params.rs
@@ -16,6 +16,9 @@
 #[lang="sized"]
 pub trait Sized {}
 
+#[lang = "str"]
+struct str([u8]);
+
 struct S<T> {
     contents: T,
 }

--- a/src/test/compile-fail/const-cast-different-types.rs
+++ b/src/test/compile-fail/const-cast-different-types.rs
@@ -10,9 +10,9 @@
 
 static a: &'static str = "foo";
 static b: *const u8 = a as *const u8;
-//~^ ERROR mismatched types: expected `*const u8`, found `&'static str`
+//~^ ERROR mismatched types: expected `*const u8`, found `&'static core::str::str`
 static c: *const u8 = &a as *const u8;
-//~^ ERROR mismatched types: expected `*const u8`, found `&&'static str`
+//~^ ERROR mismatched types: expected `*const u8`, found `&&'static core::str::str`
 
 fn main() {
 }

--- a/src/test/compile-fail/dst-object-from-unsized-type.rs
+++ b/src/test/compile-fail/dst-object-from-unsized-type.rs
@@ -25,12 +25,12 @@ fn test2<Sized? T: Foo>(t: &T) {
 
 fn test3() {
     let _: &[&Foo] = &["hi"];
-    //~^ ERROR `core::kinds::Sized` is not implemented for the type `str`
+    //~^ ERROR `core::kinds::Sized` is not implemented for the type `core::str::str`
 }
 
 fn test4() {
     let _: &Foo = "hi" as &Foo;
-    //~^ ERROR `core::kinds::Sized` is not implemented for the type `str`
+    //~^ ERROR `core::kinds::Sized` is not implemented for the type `core::str::str`
 }
 
 fn main() { }

--- a/src/test/compile-fail/issue-14366.rs
+++ b/src/test/compile-fail/issue-14366.rs
@@ -10,6 +10,6 @@
 
 fn main() {
     let _x = "test" as &::std::any::Any;
-//~^ ERROR the trait `core::kinds::Sized` is not implemented for the type `str`
-//~^^ ERROR the trait `core::kinds::Sized` is not implemented for the type `str`
+//~^ ERROR the trait `core::kinds::Sized` is not implemented for the type `core::str::str`
+//~^^ ERROR the trait `core::kinds::Sized` is not implemented for the type `core::str::str`
 }

--- a/src/test/compile-fail/issue-14721.rs
+++ b/src/test/compile-fail/issue-14721.rs
@@ -10,6 +10,6 @@
 
 fn main() {
     let foo = "str";
-    println!("{}", foo.desc); //~ ERROR attempted access of field `desc` on type `&str`,
+    println!("{}", foo.desc); //~ ERROR attempted access of field `desc` on type `&core::str::str`,
                               //        but no field with that name was found
 }

--- a/src/test/compile-fail/issue-15783.rs
+++ b/src/test/compile-fail/issue-15783.rs
@@ -15,6 +15,6 @@ pub fn foo(params: Option<&[&str]>) -> uint {
 fn main() {
     let name = "Foo";
     let msg = foo(Some(&[name.as_slice()]));
-//~^ ERROR mismatched types: expected `core::option::Option<&[&str]>`
+//~^ ERROR mismatched types: expected `core::option::Option<&[&core::str::str]>`
     assert_eq!(msg, 3);
 }

--- a/src/test/compile-fail/issue-16338.rs
+++ b/src/test/compile-fail/issue-16338.rs
@@ -12,7 +12,7 @@ use std::raw::Slice;
 
 fn main() {
     let Slice { data: data, len: len } = "foo";
-    //~^ ERROR mismatched types: expected `&str`, found `core::raw::Slice<_>`
+    //~^ ERROR mismatched types: expected `&core::str::str`, found `core::raw::Slice<_>`
     //         (expected &-ptr, found struct core::raw::Slice)
 }
 

--- a/src/test/compile-fail/issue-2149.rs
+++ b/src/test/compile-fail/issue-2149.rs
@@ -22,5 +22,5 @@ impl<A> vec_monad<A> for Vec<A> {
 }
 fn main() {
     ["hi"].bind(|x| [x] );
-    //~^ ERROR type `[&str, ..1]` does not implement any method in scope named `bind`
+    //~^ ERROR type `[&core::str::str, ..1]` does not implement any method in scope named `bind`
 }

--- a/src/test/compile-fail/privacy1.rs
+++ b/src/test/compile-fail/privacy1.rs
@@ -14,6 +14,9 @@
 #[lang="sized"]
 pub trait Sized {}
 
+#[lang = "str"]
+struct str([u8]);
+
 mod bar {
     // shouldn't bring in too much
     pub use self::glob::*;

--- a/src/test/compile-fail/regions-bounded-method-type-parameters-trait-bound.rs
+++ b/src/test/compile-fail/regions-bounded-method-type-parameters-trait-bound.rs
@@ -18,6 +18,9 @@
 #[lang="sized"]
 trait Sized { }
 
+#[lang = "str"]
+struct str([u8]);
+
 struct Inv<'a> { // invariant w/r/t 'a
     x: &'a mut &'a int
 }

--- a/src/test/compile-fail/regions-struct-not-wf.rs
+++ b/src/test/compile-fail/regions-struct-not-wf.rs
@@ -12,6 +12,10 @@
 
 #![no_std]
 #![allow(dead_code)]
+#![feature(lang_items)]
+
+#[lang = "str"]
+struct str([u8]);
 
 struct Ref<'a, T> { //~ ERROR the parameter type `T` may not live long enough
     field: &'a T

--- a/src/test/compile-fail/repeat_count.rs
+++ b/src/test/compile-fail/repeat_count.rs
@@ -21,7 +21,7 @@ fn main() {
     let d = [0, ..0.5]; //~ ERROR expected positive integer for repeat count, found float
     //~^ ERROR: expected `uint`, found `_`
     let e = [0, .."foo"]; //~ ERROR expected positive integer for repeat count, found string
-    //~^ ERROR: expected `uint`, found `&'static str`
+    //~^ ERROR: expected `uint`, found `&'static core::str::str`
     let f = [0, ..-4];
     //~^ ERROR expected positive integer for repeat count, found negative integer
     let f = [0u, ..-1];

--- a/src/test/compile-fail/stage0-clone-contravariant-lifetime.rs
+++ b/src/test/compile-fail/stage0-clone-contravariant-lifetime.rs
@@ -23,6 +23,9 @@ pub trait Sized for Sized? {
     // Empty.
 }
 
+#[lang = "str"]
+struct str([u8]);
+
 pub mod std {
     pub mod clone {
         pub trait Clone {

--- a/src/test/compile-fail/str-idx.rs
+++ b/src/test/compile-fail/str-idx.rs
@@ -10,5 +10,5 @@
 
 pub fn main() {
     let s: &str = "hello";
-    let c: u8 = s[4]; //~ ERROR cannot index a value of type `&str`
+    let c: u8 = s[4]; //~ ERROR cannot index a value of type `&core::str::str`
 }

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -38,21 +38,22 @@ pub fn bar() {
          () => {
              #[inline]
              #[allow(dead_code)]
-             static __STATIC_FMTSTR: &'static [&'static str] =
-                 (&([("test" as &'static str)] as [&'static str, ..1]) as
-                     &'static [&'static str, ..1]);
+             static __STATIC_FMTSTR: &'static [&'static ::std::str::str] =
+                 (&([("test" as &'static core::str::str)] as
+                       [&'static core::str::str, ..1]) as
+                     &'static [&'static core::str::str, ..1]);
              let __args_vec =
                  (&([] as [core::fmt::Argument<'_>, ..0]) as
                      &[core::fmt::Argument<'_>, ..0]);
              let __args =
                  (unsafe {
                       ((::std::fmt::Arguments::new as
-                           unsafe fn(&'static [&'static str], &'a [core::fmt::Argument<'a>]) -> core::fmt::Arguments<'a>)((__STATIC_FMTSTR
-                                                                                                                              as
-                                                                                                                              &'static [&'static str]),
-                                                                                                                          (__args_vec
-                                                                                                                              as
-                                                                                                                              &[core::fmt::Argument<'_>, ..0]))
+                           unsafe fn(&'static [&'static core::str::str], &'a [core::fmt::Argument<'a>]) -> core::fmt::Arguments<'a>)((__STATIC_FMTSTR
+                                                                                                                                         as
+                                                                                                                                         &'static [&'static core::str::str]),
+                                                                                                                                     (__args_vec
+                                                                                                                                         as
+                                                                                                                                         &[core::fmt::Argument<'_>, ..0]))
                           as core::fmt::Arguments<'_>)
                   } as core::fmt::Arguments<'_>);
 

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -13,7 +13,7 @@
 use std::os;
 use std::io::process::Command;
 use std::finally::Finally;
-use std::str;
+use std::str as str_;
 
 #[inline(never)]
 fn foo() {
@@ -40,7 +40,7 @@ fn runtest(me: &str) {
     let p = template.clone().arg("fail").env("RUST_BACKTRACE", "1").spawn().unwrap();
     let out = p.wait_with_output().unwrap();
     assert!(!out.status.success());
-    let s = str::from_utf8(out.error.as_slice()).unwrap();
+    let s = str_::from_utf8(out.error.as_slice()).unwrap();
     assert!(s.contains("stack backtrace") && s.contains("foo::h"),
             "bad output: {}", s);
 
@@ -48,7 +48,7 @@ fn runtest(me: &str) {
     let p = template.clone().arg("fail").spawn().unwrap();
     let out = p.wait_with_output().unwrap();
     assert!(!out.status.success());
-    let s = str::from_utf8(out.error.as_slice()).unwrap();
+    let s = str_::from_utf8(out.error.as_slice()).unwrap();
     assert!(!s.contains("stack backtrace") && !s.contains("foo::h"),
             "bad output2: {}", s);
 
@@ -56,7 +56,7 @@ fn runtest(me: &str) {
     let p = template.clone().arg("double-fail").spawn().unwrap();
     let out = p.wait_with_output().unwrap();
     assert!(!out.status.success());
-    let s = str::from_utf8(out.error.as_slice()).unwrap();
+    let s = str_::from_utf8(out.error.as_slice()).unwrap();
     // loosened the following from double::h to double:: due to
     // spurious failures on mac, 32bit, optimized
     assert!(s.contains("stack backtrace") && s.contains("double::"),
@@ -67,7 +67,7 @@ fn runtest(me: &str) {
                                 .env("RUST_BACKTRACE", "1").spawn().unwrap();
     let out = p.wait_with_output().unwrap();
     assert!(!out.status.success());
-    let s = str::from_utf8(out.error.as_slice()).unwrap();
+    let s = str_::from_utf8(out.error.as_slice()).unwrap();
     let mut i = 0;
     for _ in range(0i, 2) {
         i += s.slice_from(i + 10).find_str("stack backtrace").unwrap() + 10;

--- a/src/test/run-pass/core-run-destroy.rs
+++ b/src/test/run-pass/core-run-destroy.rs
@@ -22,7 +22,6 @@ extern crate libc;
 
 use std::io::{Process, Command, timer};
 use std::time::Duration;
-use std::str;
 
 macro_rules! succeed( ($e:expr) => (
     match $e { Ok(..) => {}, Err(e) => panic!("panic: {}", e) }
@@ -58,7 +57,6 @@ pub fn test_destroy_actually_kills(force: bool) {
     use std::io::process::{Command, ProcessOutput, ExitStatus, ExitSignal};
     use std::io::timer;
     use libc;
-    use std::str;
 
     #[cfg(all(unix,not(target_os="android")))]
     static BLOCK_COMMAND: &'static str = "cat";

--- a/src/test/run-pass/foreign-fn-linkname.rs
+++ b/src/test/run-pass/foreign-fn-linkname.rs
@@ -22,9 +22,9 @@ mod mlibc {
     }
 }
 
-fn strlen(str: String) -> uint {
+fn strlen(s: String) -> uint {
     // C string is terminated with a zero
-    str.as_slice().with_c_str(|buf| {
+    s.as_slice().with_c_str(|buf| {
         unsafe {
             mlibc::my_strlen(buf) as uint
         }

--- a/src/test/run-pass/issue-18353.rs
+++ b/src/test/run-pass/issue-18353.rs
@@ -16,6 +16,6 @@ struct Str {
 }
 
 fn main() {
-    let str: Option<&Str> = None;
-    str.is_some();
+    let s: Option<&Str> = None;
+    s.is_some();
 }

--- a/src/test/run-pass/move-out-of-field.rs
+++ b/src/test/run-pass/move-out-of-field.rs
@@ -30,6 +30,6 @@ pub fn main() {
     };
     sb.append("Hello, ");
     sb.append("World!");
-    let str = to_string(sb);
-    assert_eq!(str.as_slice(), "Hello, World!");
+    let s = to_string(sb);
+    assert_eq!(s.as_slice(), "Hello, World!");
 }

--- a/src/test/run-pass/unsized3.rs
+++ b/src/test/run-pass/unsized3.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-test
 // Test structs with always-unsized fields.
 
 use std::mem;


### PR DESCRIPTION
This PR removes the built-in/primitive `str` type from the compiler, and replaces it with a library type: `str([u8])`. This new type is defined in the `core::str` module, and re-exported in the `collections::str` and `std::str` modules.

[breaking-change]s

For most of people:
- `str` is now a struct imported as part of the `std` prelude, this means that importing the `std::str` module or using `str` as a variable name now is a name clash, and will result in a compile error.
- The `StrPrelude` trait has been removed, and all the methods defined in it are now inherent methods of the new `str` type. This will break code that was explicitly using the `StrPrelude` trait.

For `#![non_std]` users:
- If you are _not_ using the `core` crate then you need to define the `str` type and mark it with the `"str"` lang item:

``` rust
#[lang = "str"]
struct str([u8]);
```
- The `format_args!` and `panic!` macros now use `std::str::str` instead of just `str` in their expansion, to use these macros you'll need to use the "`std` module trick":

``` rust
#[doc(hidden)]
pub mod std {
    pub use core::cmp:  // for `#[deriving(PartialOrd)]`
    pub use core::str;  // for `panic!`, `format_args!`
}
```

Closes #19036

---

This passes `make check` as it  is, but I broke the `run-pass/unsized3` test (it triggers an LLVM assertion) and I'm currently investigating how to fix it.

@nikomatsakis re: compiler. I removed the `sty::ty_str` variant and replaced it with the following check: `ty_struct(def_id, _) if ty::is_str(cx, def_id)` in most `match` expressions. But, I'm sure that I can simplify the logic (i.e. remove that match arm) in several parts of the compiler, which I'd like to do before landing this.

@aturon re: library. One annoying thing after this change is that the `str` type/struct now collides with the `std::str` module (when imported). As a "fix", instead of directly importing the module, I now import it under the `str_` name (`use std::str as str_`). From what I've seen that the main reason for importing that module is to use its free functions (e.g. `str::from_utf8`), so I'm wondering if we should convert all those free functions into inherent methods of `str`, that way `str::from_utf8` would work without needing to import `std::str`, and no collision would occur. Thoughts?
