### PR TITLE
Fix various soundness bugs in HRTB / method resolution

### DIFF
--- a/src/librustc_trans/trans/datum.rs
+++ b/src/librustc_trans/trans/datum.rs
@@ -535,10 +535,10 @@ impl<'tcx, K: KindOps + fmt::Show> Datum<'tcx, K> {
     /// Copies the value into a new location. This function always preserves the existing datum as
     /// a valid value. Therefore, it does not consume `self` and, also, cannot be applied to affine
     /// values (since they must never be duplicated).
-    pub fn shallow_copy<'blk, 'tcx>(&self,
-                                    bcx: Block<'blk, 'tcx>,
-                                    dst: ValueRef)
-                                    -> Block<'blk, 'tcx> {
+    pub fn shallow_copy<'blk>(&self,
+                              bcx: Block<'blk, 'tcx>,
+                              dst: ValueRef)
+                              -> Block<'blk, 'tcx> {
         /*!
          * Copies the value into a new location. This function always
          * preserves the existing datum as a valid value. Therefore,

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -54,6 +54,7 @@ use middle::resolve_lifetime as rl;
 use middle::subst::{FnSpace, TypeSpace, AssocSpace, SelfSpace, Subst, Substs};
 use middle::subst::{VecPerParamSpace};
 use middle::ty::{mod, Ty};
+use middle::ty_fold;
 use rscope::{mod, UnelidableRscope, RegionScope, SpecificRscope,
              ShiftedRscope, BindingRscope};
 use TypeAndSubsts;
@@ -1062,7 +1063,8 @@ fn ty_of_method_or_bare_fn<'a, 'tcx, AC: AstConv<'tcx>>(
                            opt_self_info: Option<SelfInfo<'a, 'tcx>>,
                            decl: &ast::FnDecl)
                            -> (ty::BareFnTy<'tcx>,
-                               Option<ty::ExplicitSelfCategory>) {
+                               Option<ty::ExplicitSelfCategory>)
+{
     debug!("ty_of_method_or_bare_fn");
 
     // New region names that appear inside of the arguments of the function
@@ -1078,6 +1080,11 @@ fn ty_of_method_or_bare_fn<'a, 'tcx, AC: AstConv<'tcx>>(
     let (self_ty, mut implied_output_region) = match opt_self_info {
         None => (None, None),
         Some(self_info) => {
+            // Shift regions in the self type by 1 to account for the binding
+            // level introduced by the function itself.
+            let untransformed_self_ty =
+                ty_fold::shift_regions(this.tcx(), 1, &self_info.untransformed_self_ty);
+
             // Figure out and record the explicit self category.
             let explicit_self_category =
                 determine_explicit_self_category(this, &rb, &self_info);
@@ -1087,21 +1094,19 @@ fn ty_of_method_or_bare_fn<'a, 'tcx, AC: AstConv<'tcx>>(
                     (None, None)
                 }
                 ty::ByValueExplicitSelfCategory => {
-                    (Some(self_info.untransformed_self_ty), None)
+                    (Some(untransformed_self_ty), None)
                 }
                 ty::ByReferenceExplicitSelfCategory(region, mutability) => {
                     (Some(ty::mk_rptr(this.tcx(),
                                       region,
                                       ty::mt {
-                                        ty: self_info.untransformed_self_ty,
+                                        ty: untransformed_self_ty,
                                         mutbl: mutability
                                       })),
                      Some(region))
                 }
                 ty::ByBoxExplicitSelfCategory => {
-                    (Some(ty::mk_uniq(this.tcx(),
-                                      self_info.untransformed_self_ty)),
-                     None)
+                    (Some(ty::mk_uniq(this.tcx(), untransformed_self_ty)), None)
                 }
             }
         }

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -100,6 +100,7 @@ pub fn lookup<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
            call_expr.repr(fcx.tcx()),
            self_expr.repr(fcx.tcx()));
 
+    let self_ty = fcx.infcx().resolve_type_vars_if_possible(self_ty);
     let pick = try!(probe::probe(fcx, span, method_name, self_ty, call_expr.id));
     Ok(confirm::confirm(fcx, span, self_expr, call_expr, self_ty, pick, supplied_method_types))
 }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1055,7 +1055,7 @@ pub fn convert(ccx: &CrateCtxt, it: &ast::Item) {
                       ref selfty,
                       ref impl_items) => {
             // Create generics from the generics specified in the impl head.
-            let ty_generics = ty_generics_for_type(
+            let ty_generics = ty_generics_for_impl(
                     ccx,
                     generics,
                     CreateTypeParametersForAssociatedTypes);
@@ -1653,6 +1653,24 @@ fn ty_generics_for_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     generics.types.push(subst::SelfSpace, def);
 
     generics
+}
+
+fn ty_generics_for_impl<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
+                                  generics: &ast::Generics,
+                                  create_type_parameters_for_associated_types:
+                                      CreateTypeParametersForAssociatedTypesFlag)
+                                  -> ty::Generics<'tcx>
+{
+    let early_lifetimes = resolve_lifetime::early_bound_lifetimes(generics);
+    debug!("ty_generics_for_impl: early_lifetimes={}",
+           early_lifetimes);
+    ty_generics(ccx,
+                subst::TypeSpace,
+                early_lifetimes.as_slice(),
+                generics.ty_params.as_slice(),
+                ty::Generics::empty(),
+                &generics.where_clause,
+                create_type_parameters_for_associated_types)
 }
 
 fn ty_generics_for_fn_or_method<'tcx,AC>(

--- a/src/test/compile-fail/borrowck-return-variable-on-stack-via-clone.rs
+++ b/src/test/compile-fail/borrowck-return-variable-on-stack-via-clone.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that when we clone a `&T` pointer we properly relate the
+// lifetime of the pointer which results to the pointer being cloned.
+// Bugs in method resolution have sometimes broken this connection.
+// Issue #19261.
+
+fn leak<'a, T>(x: T) -> &'a T {
+    (&x).clone() //~ ERROR `x` does not live long enough
+}
+
+fn main() { }

--- a/src/test/compile-fail/hrtb-debruijn-in-receiver.rs
+++ b/src/test/compile-fail/hrtb-debruijn-in-receiver.rs
@@ -1,0 +1,28 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test the case where the `Self` type has a bound lifetime that must
+// be adjusted in the fn signature. Issue #19537.
+
+use std::collections::HashMap;
+
+struct Foo<'a> {
+    map: HashMap<uint, &'a str>
+}
+
+impl<'a> Foo<'a> {
+    fn new() -> Foo<'a> { panic!() }
+    fn insert(&'a mut self) { }
+}
+fn main() {
+    let mut foo = Foo::new();
+    foo.insert();
+    foo.insert(); //~ ERROR cannot borrow
+}

--- a/src/test/run-pass/method-mut-self-modifies-mut-slice-lvalue.rs
+++ b/src/test/run-pass/method-mut-self-modifies-mut-slice-lvalue.rs
@@ -1,0 +1,54 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that an `&mut self` method, when invoked on an lvalue whose
+// type is `&mut [u8]`, passes in a pointer to the lvalue and not a
+// temporary. Issue #19147.
+
+use std::raw;
+use std::mem;
+use std::slice;
+use std::io::IoResult;
+
+trait MyWriter {
+    fn my_write(&mut self, buf: &[u8]) -> IoResult<()>;
+}
+
+impl<'a> MyWriter for &'a mut [u8] {
+    fn my_write(&mut self, buf: &[u8]) -> IoResult<()> {
+        slice::bytes::copy_memory(*self, buf);
+
+        let write_len = buf.len();
+        unsafe {
+            *self = mem::transmute(raw::Slice {
+                data: self.as_ptr().offset(write_len as int),
+                len: self.len() - write_len,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+fn main() {
+    let mut buf = [0_u8, .. 6];
+
+    {
+        let mut writer = buf.as_mut_slice();
+        writer.my_write(&[0, 1, 2]).unwrap();
+        writer.my_write(&[3, 4, 5]).unwrap();
+    }
+
+    // If `my_write` is not modifying `buf` in place, then we will
+    // wind up with `[3, 4, 5, 0, 0, 0]` because the first call to
+    // `my_write()` doesn't update the starting point for the write.
+
+    assert_eq!(buf, [0, 1, 2, 3, 4, 5]);
+}


### PR DESCRIPTION
**First commit.** Patch up debruijn indices. Fixes #19537. 

**Second commit.** Stop reborrowing so much. Fixes #19147. Fixes #19261.

r? @nick29581 
