### PR TITLE
documentation incorrectly described from_utf8

### DIFF
--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -76,7 +76,7 @@ impl FromStr for bool {
 Section: Creating a string
 */
 
-/// Converts a vector to a string slice without performing any allocations.
+/// Converts a slice of bytes to a string slice without performing any allocations.
 ///
 /// Once the slice has been validated as utf-8, it is transmuted in-place and
 /// returned as a '&str' instead of a '&[u8]'


### PR DESCRIPTION
Docs said from_utf8 accepts a vector when it actually accepts an array of bytes.
