### PR TITLE
Fix ICE related to tupled arguments

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2623,7 +2623,13 @@ fn check_method_argument_types<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                                          tuple_arguments: TupleArgumentsFlag)
                                          -> ty::FnOutput<'tcx> {
     if ty::type_is_error(method_fn_ty) {
-       let err_inputs = err_args(args_no_rcvr.len());
+        let err_inputs = err_args(args_no_rcvr.len());
+
+        let err_inputs = match tuple_arguments {
+            DontTupleArguments => err_inputs,
+            TupleArguments => vec![ty::mk_tup(fcx.tcx(), err_inputs)],
+        };
+
         check_argument_types(fcx,
                              sp,
                              err_inputs.as_slice(),

--- a/src/test/compile-fail/issue-19521.rs
+++ b/src/test/compile-fail/issue-19521.rs
@@ -1,0 +1,15 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unboxed_closures)]
+
+fn main() {
+    "".homura()(); //~ ERROR does not implement any method
+}


### PR DESCRIPTION
When a type error occurs, `check_method_argument_types()` tries to provide arguments filled with `ty::mk_err()`. However, if a function takes the parameters as a tuple, the arguments should be converted to a tuple before passing it to `check_argument_types()`.

Fixes #19521.
