### PR TITLE
Implemented BorrowFrom<Rc<T>> for T.

### DIFF
--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -141,6 +141,7 @@
 
 #![stable]
 
+use core::borrow::BorrowFrom;
 use core::cell::Cell;
 use core::clone::Clone;
 use core::cmp::{PartialEq, PartialOrd, Eq, Ord, Ordering};
@@ -346,6 +347,12 @@ impl<T: Clone> Rc<T> {
         // reference to the inner value.
         let inner = unsafe { &mut *self._ptr };
         &mut inner.value
+    }
+}
+
+impl<T> BorrowFrom<Rc<T>> for T {
+    fn borrow_from(owned: &Rc<T>) -> &T {
+        &**owned
     }
 }
 


### PR DESCRIPTION
This was discussed in [#rust-internals](https://botbot.me/mozilla/rust-internals/2014-12-08/?msg=27077624&page=5). It's a small change.
