### PR TITLE
Remove Result and Option reexports

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -143,7 +143,7 @@
 
 #![stable]
 
-pub use self::Option::*;
+use self::Option::*;
 
 use cmp::{Eq, Ord};
 use default::Default;

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -230,7 +230,7 @@
 
 #![stable]
 
-pub use self::Result::*;
+use self::Result::*;
 
 use std::fmt::Show;
 use slice;

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -21,9 +21,11 @@ use iter::IteratorExt;
 use mem;
 use ops::*;
 use option::*;
+use option::Option::{None, Some};
 use os;
 use path::{Path,GenericPath};
 use result::*;
+use result::Result::{Err, Ok};
 use slice::{AsSlice,SlicePrelude};
 use str;
 use string::String;
@@ -212,6 +214,7 @@ pub mod dl {
     use libc;
     use ptr;
     use result::*;
+    use result::Result::{Err, Ok};
     use string::String;
 
     pub unsafe fn open_external<T: ToCStr>(filename: T) -> *mut u8 {

--- a/src/libstd/sync/poison.rs
+++ b/src/libstd/sync/poison.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use option::None;
+use option::Option::None;
 use rustrt::task::Task;
 use rustrt::local::Local;
 


### PR DESCRIPTION
Brief note: This does _not_ affect anything in the prelude

Part of #19253

All this does is remove the reexporting of Result and Option from their
respective modules. More core reexports might be removed, but these ones
are the safest to remove since these enums (and their variants) are included in
the prelude.

Depends on https://github.com/rust-lang/rust/pull/19407 which is merged, but might need a new snapshot

[breaking-change]
