### PR TITLE
Small documentation link fix

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -3681,9 +3681,8 @@ Here's the second note, which lets us know where the first borrow would be over.
 This is useful, because if we wait to try to borrow `x` after this borrow is
 over, then everything will work.
 
-For more advanced patterns, please consult the [Lifetime
-Guide](guide-lifetimes.html).  You'll also learn what this type signature with
-the `'a` syntax is:
+For more advanced patterns, please consult the [Ownership Guide](guide-ownership.html).
+You'll also learn what this type signature with the `'a` syntax is:
 
 ```{rust,ignore}
 pub fn as_maybe_owned(&self) -> MaybeOwned<'a> { ... }


### PR DESCRIPTION
The lifetime guide was renamed to ownership guide in e2fe7a083ed63b1a739f5e0d0417cfd8a7da6510.
