### PR TITLE
Remove references to traits that no longer exist

### DIFF
--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -10,7 +10,8 @@
 
 //! A doubly-linked list with owned nodes.
 //!
-//! The `DList` allows pushing and popping elements at either end.
+//! The `DList` allows pushing and popping elements at either end and is thus
+//! efficiently usable as a double-ended queue.
 
 // DList is constructed like a singly-linked list over the field `next`.
 // including the last link being None; each Node owns its `next` field.

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -20,7 +20,7 @@ use core::num::Int;
 // FIXME(contentions): implement union family of methods? (general design may be wrong here)
 
 #[deriving(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-/// A specialized `Set` implementation to use enum types.
+/// A specialized set implementation to use enum types.
 pub struct EnumSet<E> {
     // We must maintain the invariant that no bits are set
     // for which no variant exists

--- a/src/libcollections/ring_buf.rs
+++ b/src/libcollections/ring_buf.rs
@@ -34,7 +34,7 @@ static MINIMUM_CAPACITY: uint = 2u;
 // FIXME(conventions): implement shrink_to_fit. Awkward with the current design, but it should
 // be scrapped anyway. Defer to rewrite?
 
-/// `RingBuf` is a circular buffer.
+/// `RingBuf` is a circular buffer, which can be used as a double-ended queue efficiently.
 pub struct RingBuf<T> {
     // tail and head are pointers into the buffer. Tail always points
     // to the first element that could be read, Head always points

--- a/src/libcollections/tree/mod.rs
+++ b/src/libcollections/tree/mod.rs
@@ -9,8 +9,7 @@
 // except according to those terms.
 
 //! Maps are collections of unique keys with corresponding values, and sets are
-//! just unique keys without a corresponding value. The `Map` and `Set` traits in
-//! `std::container` define the basic interface.
+//! just unique keys without a corresponding value.
 //!
 //! This crate defines the `TreeMap` and `TreeSet` types. Their keys must implement `Ord`.
 //!

--- a/src/libcollections/tree/set.rs
+++ b/src/libcollections/tree/set.rs
@@ -23,8 +23,8 @@ use tree_map::{TreeMap, Entries, RevEntries, MoveEntries};
 // FIXME(conventions): implement bounded iterators
 // FIXME(conventions): replace rev_iter(_mut) by making iter(_mut) DoubleEnded
 
-/// An implementation of the `Set` trait on top of the `TreeMap` container. The
-/// only requirement is that the type of the elements contained ascribes to the
+/// An implementation of a set on top of the `TreeMap` container. The only
+/// requirement is that the type of the elements contained ascribes to the
 /// `Ord` trait.
 ///
 /// ## Example

--- a/src/libcollections/trie/mod.rs
+++ b/src/libcollections/trie/mod.rs
@@ -9,8 +9,7 @@
 // except according to those terms.
 
 //! Maps are collections of unique keys with corresponding values, and sets are
-//! just unique keys without a corresponding value. The `Map` and `Set` traits in
-//! `std::container` define the basic interface.
+//! just unique keys without a corresponding value.
 //!
 //! This crate defines `TrieMap` and `TrieSet`, which require `uint` keys.
 //!


### PR DESCRIPTION
This specifically means:
- `Deque`
- `Map`
- `Set`
