### PR TITLE
Fix an ICE when trying to resolve a struct variant

### DIFF
--- a/src/test/compile-fail/issue-19452.rs
+++ b/src/test/compile-fail/issue-19452.rs
@@ -8,10 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-enum Foo {
-    Variant { x: uint }
+enum Homura {
+    Madoka { age: u32 }
 }
 
 fn main() {
-    let f = Foo::Variant(42u); //~ ERROR uses it like a function
+    let homura = Homura::Madoka; //~ ERROR uses it like a function
 }


### PR DESCRIPTION
Unlike a tuple variant constructor which can be called as a function, a struct variant constructor is not a function, so cannot be called.

If the user tries to assign the constructor to a variable, an ICE occurs, because there is no way to use it later. So we should stop the constructor from being used like that.

A similar mechanism already exists for a normal struct, as it prohibits a struct from being resolved. This commit does the same for a struct variant.

This commit also includes some changes to the existing tests.

Fixes #19452.
