### PR TITLE
rustdoc: warn for `notrust` tags

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -403,7 +403,11 @@ impl LangString {
                 "should_fail" => { data.should_fail = true; seen_rust_tags = true; },
                 "no_run" => { data.no_run = true; seen_rust_tags = true; },
                 "ignore" => { data.ignore = true; seen_rust_tags = true; },
-                "notrust" => { data.notrust = true; seen_rust_tags = true; },
+                "notrust" => {
+                    data.notrust = true; seen_rust_tags = true;
+                    warn!("Use of the `notrust` code tag is discouraged. \
+                           Tag the code with its language instead or use `plain`.");
+                },
                 "rust" => { data.notrust = false; seen_rust_tags = true; },
                 "test_harness" => { data.test_harness = true; seen_rust_tags = true; }
                 _ => { seen_other_tags = true }


### PR DESCRIPTION
Rustdoc should warn when `notrust` is used. The tag can be replaced by an actual code marker like `c`, `plain`, `console` etc.

One outstanding issue is that `rustdoc` has no default log level thus does not print the warning in normal use. Is there a good way to raise that?

Following the discussion here:

https://github.com/rust-lang/rfcs/issues/500
