### PR TITLE
Fix po4a conf file

### DIFF
--- a/src/doc/po4a.conf
+++ b/src/doc/po4a.conf
@@ -26,4 +26,3 @@
 [type: text] src/doc/intro.md $lang:doc/l10n/$lang/intro.md
 [type: text] src/doc/rust.md $lang:doc/l10n/$lang/rust.md
 [type: text] src/doc/rustdoc.md $lang:doc/l10n/$lang/rustdoc.md
-[type: text] src/doc/guide.md $lang:doc/l10n/$lang/guide.md


### PR DESCRIPTION
This line was declared twice, which causes the build of i10n docs to
fail.
