### PR TITLE
char_at_reverse(0) returns the first char of str

### DIFF
--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -18,7 +18,6 @@
 
 pub use self::Utf16Item::*;
 pub use self::Searcher::{Naive, TwoWay, TwoWayLong};
-
 use char::Char;
 use char;
 use cmp::{Eq, mod};
@@ -2242,7 +2241,7 @@ impl StrPrelude for str {
 
     #[inline]
     fn char_at_reverse(&self, i: uint) -> char {
-        self.char_range_at_reverse(i).ch
+        self.char_range_at_reverse(self.len() - i + 1).ch
     }
 
     #[inline]


### PR DESCRIPTION
could this be a bug? misunderstood the char_range_at_reverse methods?
