### PR TITLE
debuginfo: Make debuginfo source location assignment more stable (Pt. 1)

### DIFF
--- a/src/librustc_trans/trans/adt.rs
+++ b/src/librustc_trans/trans/adt.rs
@@ -59,6 +59,7 @@ use trans::cleanup;
 use trans::cleanup::CleanupMethods;
 use trans::common::*;
 use trans::datum;
+use trans::debuginfo::SourceLocation::NoSourceLoc;
 use trans::machine;
 use trans::type_::Type;
 use trans::type_of;
@@ -889,7 +890,7 @@ pub fn fold_variants<'blk, 'tcx>(
                 let variant_value = PointerCast(variant_cx, value, real_ty.ptr_to());
 
                 variant_cx = f(variant_cx, case, variant_value);
-                Br(variant_cx, bcx_next.llbb);
+                Br(variant_cx, bcx_next.llbb, NoSourceLoc);
             }
 
             bcx_next

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -39,6 +39,7 @@ use trans::closure;
 use trans::common;
 use trans::common::*;
 use trans::datum::*;
+use trans::debuginfo::SourceLocation::NoSourceLoc;
 use trans::expr;
 use trans::glue;
 use trans::inline;
@@ -350,7 +351,7 @@ pub fn trans_fn_pointer_shim<'a, 'tcx>(
                            ArgVals(llargs.as_slice()),
                            dest).bcx;
 
-    finish_fn(&fcx, bcx, output_ty);
+    finish_fn(&fcx, bcx, output_ty, NoSourceLoc);
 
     ccx.fn_pointer_shims().borrow_mut().insert(bare_fn_ty, llfn);
 
@@ -499,7 +500,7 @@ pub fn trans_unboxing_shim<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                            dest).bcx;
 
     bcx = fcx.pop_and_trans_custom_cleanup_scope(bcx, arg_scope);
-    finish_fn(&fcx, bcx, return_type);
+    finish_fn(&fcx, bcx, return_type, NoSourceLoc);
 
     llfn
 }

--- a/src/librustc_trans/trans/cleanup.rs
+++ b/src/librustc_trans/trans/cleanup.rs
@@ -23,6 +23,7 @@ use trans::callee;
 use trans::common;
 use trans::common::{Block, FunctionContext, ExprId, NodeInfo};
 use trans::debuginfo;
+use trans::debuginfo::SourceLocation::NoSourceLoc;
 use trans::glue;
 use middle::region;
 use trans::type_::Type;
@@ -671,7 +672,7 @@ impl<'blk, 'tcx> CleanupHelperMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx
                                                 scope.debug_loc);
                     }
                 }
-                build::Br(bcx_out, prev_llbb);
+                build::Br(bcx_out, prev_llbb, NoSourceLoc);
                 prev_llbb = bcx_in.llbb;
             } else {
                 debug!("no suitable cleanups in {}",
@@ -770,7 +771,7 @@ impl<'blk, 'tcx> CleanupHelperMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx
 
         // Generate the cleanup block and branch to it.
         let cleanup_llbb = self.trans_cleanups_to_exit_scope(UnwindExit);
-        build::Br(pad_bcx, cleanup_llbb);
+        build::Br(pad_bcx, cleanup_llbb, NoSourceLoc);
 
         return pad_bcx.llbb;
     }

--- a/src/librustc_trans/trans/closure.rs
+++ b/src/librustc_trans/trans/closure.rs
@@ -22,6 +22,7 @@ use trans::cleanup::{CleanupMethods, ScopeId};
 use trans::common::*;
 use trans::datum::{Datum, DatumBlock, Expr, Lvalue, rvalue_scratch_datum};
 use trans::debuginfo;
+use trans::debuginfo::SourceLocation::NoSourceLoc;
 use trans::expr;
 use trans::monomorphize::MonoId;
 use trans::type_of::*;
@@ -675,17 +676,17 @@ pub fn get_wrapper_for_bare_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     }
     llargs.extend(args.iter().map(|arg| arg.val));
 
-    let retval = Call(bcx, fn_ptr, llargs.as_slice(), None);
+    let retval = Call(bcx, fn_ptr, llargs.as_slice(), None, NoSourceLoc);
     match f.sig.output {
         ty::FnConverging(output_type) => {
             if return_type_is_void(ccx, output_type) || fcx.llretslotptr.get().is_some() {
-                RetVoid(bcx);
+                RetVoid(bcx, NoSourceLoc);
             } else {
-                Ret(bcx, retval);
+                Ret(bcx, retval, NoSourceLoc);
             }
         }
         ty::FnDiverging => {
-            RetVoid(bcx);
+            RetVoid(bcx, NoSourceLoc);
         }
     }
 

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -30,6 +30,7 @@ use trans::build;
 use trans::cleanup;
 use trans::datum;
 use trans::debuginfo;
+use trans::debuginfo::SourceLocation::NoSourceLoc;
 use trans::machine;
 use trans::type_::Type;
 use trans::type_of;
@@ -354,7 +355,7 @@ impl<'a, 'tcx> FunctionContext<'a, 'tcx> {
         let mut reachable = false;
         for bcx in in_cxs.iter() {
             if !bcx.unreachable.get() {
-                build::Br(*bcx, out.llbb);
+                build::Br(*bcx, out.llbb, NoSourceLoc);
                 reachable = true;
             }
         }

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -46,7 +46,8 @@ use trans::build::*;
 use trans::cleanup::{mod, CleanupMethods};
 use trans::common::*;
 use trans::datum::*;
-use trans::debuginfo;
+use trans::debuginfo::{mod, SourceLocation};
+use trans::debuginfo::SourceLocation::NoSourceLoc;
 use trans::glue;
 use trans::machine;
 use trans::meth;
@@ -802,7 +803,8 @@ fn trans_index<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             let expected = Call(bcx,
                                 expect,
                                 &[bounds_check, C_bool(ccx, false)],
-                                None);
+                                None,
+                                SourceLocation::from_expr(index_expr));
             bcx = with_cond(bcx, expected, |bcx| {
                 controlflow::trans_fail_bounds_check(bcx,
                                                      index_expr.span,
@@ -911,16 +913,16 @@ fn trans_rvalue_stmt_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             trans_into(bcx, &**e, Ignore)
         }
         ast::ExprBreak(label_opt) => {
-            controlflow::trans_break(bcx, expr.id, label_opt)
+            controlflow::trans_break(bcx, expr, label_opt)
         }
         ast::ExprAgain(label_opt) => {
-            controlflow::trans_cont(bcx, expr.id, label_opt)
+            controlflow::trans_cont(bcx, expr, label_opt)
         }
         ast::ExprRet(ref ex) => {
-            controlflow::trans_ret(bcx, ex.as_ref().map(|e| &**e))
+            controlflow::trans_ret(bcx, expr, ex.as_ref().map(|e| &**e))
         }
         ast::ExprWhile(ref cond, ref body, _) => {
-            controlflow::trans_while(bcx, expr.id, &**cond, &**body)
+            controlflow::trans_while(bcx, expr, &**cond, &**body)
         }
         ast::ExprForLoop(ref pat, ref head, ref body, _) => {
             controlflow::trans_for(bcx,
@@ -930,7 +932,7 @@ fn trans_rvalue_stmt_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                    &**body)
         }
         ast::ExprLoop(ref body, _) => {
-            controlflow::trans_loop(bcx, expr.id, &**body)
+            controlflow::trans_loop(bcx, expr, &**body)
         }
         ast::ExprAssign(ref dst, ref src) => {
             let src_datum = unpack_datum!(bcx, trans(bcx, &**src));
@@ -1520,10 +1522,12 @@ fn trans_unary<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
     let un_ty = expr_ty(bcx, expr);
 
+    let source_loc = SourceLocation::from_expr(expr);
+
     match op {
         ast::UnNot => {
             let datum = unpack_datum!(bcx, trans(bcx, sub_expr));
-            let llresult = Not(bcx, datum.to_llscalarish(bcx));
+            let llresult = Not(bcx, datum.to_llscalarish(bcx), source_loc);
             immediate_rvalue_bcx(bcx, llresult, un_ty).to_expr_datumblock()
         }
         ast::UnNeg => {
@@ -1531,9 +1535,9 @@ fn trans_unary<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             let val = datum.to_llscalarish(bcx);
             let llneg = {
                 if ty::type_is_fp(un_ty) {
-                    FNeg(bcx, val)
+                    FNeg(bcx, val, source_loc)
                 } else {
-                    Neg(bcx, val)
+                    Neg(bcx, val, source_loc)
                 }
             };
             immediate_rvalue_bcx(bcx, llneg, un_ty).to_expr_datumblock()
@@ -1632,56 +1636,69 @@ fn trans_eager_binop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
     let rhs = base::cast_shift_expr_rhs(bcx, op, lhs, rhs);
 
+    let binop_source_loc = SourceLocation::from_expr(binop_expr);
+
     let mut bcx = bcx;
     let val = match op {
       ast::BiAdd => {
-        if is_float { FAdd(bcx, lhs, rhs) }
-        else { Add(bcx, lhs, rhs) }
+        if is_float {
+            FAdd(bcx, lhs, rhs, binop_source_loc)
+        } else {
+            Add(bcx, lhs, rhs, binop_source_loc)
+        }
       }
       ast::BiSub => {
-        if is_float { FSub(bcx, lhs, rhs) }
-        else { Sub(bcx, lhs, rhs) }
+        if is_float {
+            FSub(bcx, lhs, rhs, binop_source_loc)
+        } else {
+            Sub(bcx, lhs, rhs, binop_source_loc)
+        }
       }
       ast::BiMul => {
-        if is_float { FMul(bcx, lhs, rhs) }
-        else { Mul(bcx, lhs, rhs) }
+        if is_float {
+            FMul(bcx, lhs, rhs, binop_source_loc)
+        } else {
+            Mul(bcx, lhs, rhs, binop_source_loc)
+        }
       }
       ast::BiDiv => {
         if is_float {
-            FDiv(bcx, lhs, rhs)
+            FDiv(bcx, lhs, rhs, binop_source_loc)
         } else {
             // Only zero-check integers; fp /0 is NaN
             bcx = base::fail_if_zero_or_overflows(bcx, binop_expr.span,
                                                   op, lhs, rhs, rhs_t);
             if is_signed {
-                SDiv(bcx, lhs, rhs)
+                SDiv(bcx, lhs, rhs, binop_source_loc)
             } else {
-                UDiv(bcx, lhs, rhs)
+                UDiv(bcx, lhs, rhs, binop_source_loc)
             }
         }
       }
       ast::BiRem => {
         if is_float {
-            FRem(bcx, lhs, rhs)
+            FRem(bcx, lhs, rhs, binop_source_loc)
         } else {
             // Only zero-check integers; fp %0 is NaN
             bcx = base::fail_if_zero_or_overflows(bcx, binop_expr.span,
                                                   op, lhs, rhs, rhs_t);
             if is_signed {
-                SRem(bcx, lhs, rhs)
+                SRem(bcx, lhs, rhs, binop_source_loc)
             } else {
-                URem(bcx, lhs, rhs)
+                URem(bcx, lhs, rhs, binop_source_loc)
             }
         }
       }
-      ast::BiBitOr => Or(bcx, lhs, rhs),
-      ast::BiBitAnd => And(bcx, lhs, rhs),
-      ast::BiBitXor => Xor(bcx, lhs, rhs),
-      ast::BiShl => Shl(bcx, lhs, rhs),
+      ast::BiBitOr => Or(bcx, lhs, rhs, binop_source_loc),
+      ast::BiBitAnd => And(bcx, lhs, rhs, binop_source_loc),
+      ast::BiBitXor => Xor(bcx, lhs, rhs, binop_source_loc),
+      ast::BiShl => Shl(bcx, lhs, rhs, binop_source_loc),
       ast::BiShr => {
         if is_signed {
-            AShr(bcx, lhs, rhs)
-        } else { LShr(bcx, lhs, rhs) }
+            AShr(bcx, lhs, rhs, binop_source_loc)
+        } else {
+            LShr(bcx, lhs, rhs, binop_source_loc)
+        }
       }
       ast::BiEq | ast::BiNe | ast::BiLt | ast::BiGe | ast::BiLe | ast::BiGt => {
         if ty::type_is_scalar(rhs_t) {
@@ -1727,8 +1744,8 @@ fn trans_lazy_binop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let before_rhs = fcx.new_id_block("before_rhs", b.id);
 
     match op {
-      lazy_and => CondBr(past_lhs, lhs, before_rhs.llbb, join.llbb),
-      lazy_or => CondBr(past_lhs, lhs, join.llbb, before_rhs.llbb)
+      lazy_and => CondBr(past_lhs, lhs, before_rhs.llbb, join.llbb, NoSourceLoc),
+      lazy_or => CondBr(past_lhs, lhs, join.llbb, before_rhs.llbb, NoSourceLoc)
     }
 
     let DatumBlock {bcx: past_rhs, datum: rhs} = trans(before_rhs, b);
@@ -1738,7 +1755,7 @@ fn trans_lazy_binop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         return immediate_rvalue_bcx(join, lhs, binop_ty).to_expr_datumblock();
     }
 
-    Br(past_rhs, join.llbb);
+    Br(past_rhs, join.llbb, NoSourceLoc);
     let phi = Phi(join, Type::i1(bcx.ccx()), &[lhs, rhs],
                   &[past_lhs.llbb, past_rhs.llbb]);
 

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -21,6 +21,7 @@ use trans::cleanup;
 use trans::cleanup::CleanupMethods;
 use trans::common::*;
 use trans::datum::*;
+use trans::debuginfo::SourceLocation::{mod, SourceLoc, NoSourceLoc};
 use trans::expr;
 use trans::glue;
 use trans::type_of::*;
@@ -261,10 +262,12 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
 
     fcx.pop_custom_cleanup_scope(cleanup_scope);
 
+    let call_source_location = SourceLoc(call_info.id, call_info.span);
+
     // These are the only intrinsic functions that diverge.
     if name.get() == "abort" {
         let llfn = ccx.get_intrinsic(&("llvm.trap"));
-        Call(bcx, llfn, &[], None);
+        Call(bcx, llfn, &[], None, call_source_location);
         Unreachable(bcx);
         return Result::new(bcx, C_undef(Type::nil(ccx).ptr_to()));
     } else if name.get() == "unreachable" {
@@ -295,11 +298,11 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
     let simple = get_simple_intrinsic(ccx, &*foreign_item);
     let llval = match (simple, name.get()) {
         (Some(llfn), _) => {
-            Call(bcx, llfn, llargs.as_slice(), None)
+            Call(bcx, llfn, llargs.as_slice(), None, call_source_location)
         }
         (_, "breakpoint") => {
             let llfn = ccx.get_intrinsic(&("llvm.debugtrap"));
-            Call(bcx, llfn, &[], None)
+            Call(bcx, llfn, &[], None, call_source_location)
         }
         (_, "size_of") => {
             let tp_ty = *substs.types.get(FnSpace, 0);
@@ -378,29 +381,63 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         }
 
         (_, "copy_nonoverlapping_memory") => {
-            copy_intrinsic(bcx, false, false, *substs.types.get(FnSpace, 0),
-                           llargs[0], llargs[1], llargs[2])
+            copy_intrinsic(bcx,
+                           false,
+                           false,
+                           *substs.types.get(FnSpace, 0),
+                           llargs[0],
+                           llargs[1],
+                           llargs[2],
+                           call_source_location)
         }
         (_, "copy_memory") => {
-            copy_intrinsic(bcx, true, false, *substs.types.get(FnSpace, 0),
-                           llargs[0], llargs[1], llargs[2])
+            copy_intrinsic(bcx,
+                           true,
+                           false,
+                           *substs.types.get(FnSpace, 0),
+                           llargs[0],
+                           llargs[1],
+                           llargs[2],
+                           call_source_location)
         }
         (_, "set_memory") => {
-            memset_intrinsic(bcx, false, *substs.types.get(FnSpace, 0),
-                             llargs[0], llargs[1], llargs[2])
+            memset_intrinsic(bcx,
+                             false,
+                             *substs.types.get(FnSpace, 0),
+                             llargs[0],
+                             llargs[1],
+                             llargs[2],
+                             call_source_location)
         }
 
         (_, "volatile_copy_nonoverlapping_memory") => {
-            copy_intrinsic(bcx, false, true, *substs.types.get(FnSpace, 0),
-                           llargs[0], llargs[1], llargs[2])
+            copy_intrinsic(bcx,
+                           false,
+                           true,
+                           *substs.types.get(FnSpace, 0),
+                           llargs[0],
+                           llargs[1],
+                           llargs[2],
+                           call_source_location)
         }
         (_, "volatile_copy_memory") => {
-            copy_intrinsic(bcx, true, true, *substs.types.get(FnSpace, 0),
-                           llargs[0], llargs[1], llargs[2])
+            copy_intrinsic(bcx,
+                           true,
+                           true,
+                           *substs.types.get(FnSpace, 0),
+                           llargs[0],
+                           llargs[1],
+                           llargs[2],
+                           call_source_location)
         }
         (_, "volatile_set_memory") => {
-            memset_intrinsic(bcx, true, *substs.types.get(FnSpace, 0),
-                             llargs[0], llargs[1], llargs[2])
+            memset_intrinsic(bcx,
+                             true,
+                             *substs.types.get(FnSpace, 0),
+                             llargs[0],
+                             llargs[1],
+                             llargs[2],
+                             call_source_location)
         }
         (_, "volatile_load") => {
             VolatileLoad(bcx, llargs[0])
@@ -410,93 +447,208 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
             C_nil(ccx)
         },
 
-        (_, "ctlz8") => count_zeros_intrinsic(bcx, "llvm.ctlz.i8", llargs[0]),
-        (_, "ctlz16") => count_zeros_intrinsic(bcx, "llvm.ctlz.i16", llargs[0]),
-        (_, "ctlz32") => count_zeros_intrinsic(bcx, "llvm.ctlz.i32", llargs[0]),
-        (_, "ctlz64") => count_zeros_intrinsic(bcx, "llvm.ctlz.i64", llargs[0]),
-        (_, "cttz8") => count_zeros_intrinsic(bcx, "llvm.cttz.i8", llargs[0]),
-        (_, "cttz16") => count_zeros_intrinsic(bcx, "llvm.cttz.i16", llargs[0]),
-        (_, "cttz32") => count_zeros_intrinsic(bcx, "llvm.cttz.i32", llargs[0]),
-        (_, "cttz64") => count_zeros_intrinsic(bcx, "llvm.cttz.i64", llargs[0]),
+        (_, "ctlz8") => count_zeros_intrinsic(bcx,
+                                              "llvm.ctlz.i8",
+                                              llargs[0],
+                                              call_source_location),
+        (_, "ctlz16") => count_zeros_intrinsic(bcx,
+                                               "llvm.ctlz.i16",
+                                               llargs[0],
+                                               call_source_location),
+        (_, "ctlz32") => count_zeros_intrinsic(bcx,
+                                               "llvm.ctlz.i32",
+                                               llargs[0],
+                                               call_source_location),
+        (_, "ctlz64") => count_zeros_intrinsic(bcx,
+                                               "llvm.ctlz.i64",
+                                               llargs[0],
+                                               call_source_location),
+        (_, "cttz8") => count_zeros_intrinsic(bcx,
+                                              "llvm.cttz.i8",
+                                              llargs[0],
+                                              call_source_location),
+        (_, "cttz16") => count_zeros_intrinsic(bcx,
+                                               "llvm.cttz.i16",
+                                               llargs[0],
+                                               call_source_location),
+        (_, "cttz32") => count_zeros_intrinsic(bcx,
+                                               "llvm.cttz.i32",
+                                               llargs[0],
+                                               call_source_location),
+        (_, "cttz64") => count_zeros_intrinsic(bcx,
+                                               "llvm.cttz.i64",
+                                               llargs[0],
+                                               call_source_location),
 
         (_, "i8_add_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.sadd.with.overflow.i8", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.sadd.with.overflow.i8",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "i16_add_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.sadd.with.overflow.i16", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.sadd.with.overflow.i16",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "i32_add_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.sadd.with.overflow.i32", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.sadd.with.overflow.i32",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "i64_add_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.sadd.with.overflow.i64", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.sadd.with.overflow.i64",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
 
         (_, "u8_add_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.uadd.with.overflow.i8", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.uadd.with.overflow.i8",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "u16_add_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.uadd.with.overflow.i16", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.uadd.with.overflow.i16",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "u32_add_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.uadd.with.overflow.i32", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.uadd.with.overflow.i32",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "u64_add_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.uadd.with.overflow.i64", ret_ty,
-                                   llargs[0], llargs[1]),
-
+            with_overflow_intrinsic(bcx,
+                                    "llvm.uadd.with.overflow.i64",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "i8_sub_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.ssub.with.overflow.i8", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.ssub.with.overflow.i8",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "i16_sub_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.ssub.with.overflow.i16", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.ssub.with.overflow.i16",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "i32_sub_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.ssub.with.overflow.i32", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.ssub.with.overflow.i32",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "i64_sub_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.ssub.with.overflow.i64", ret_ty,
-                                   llargs[0], llargs[1]),
-
+            with_overflow_intrinsic(bcx,
+                                    "llvm.ssub.with.overflow.i64",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "u8_sub_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.usub.with.overflow.i8", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.usub.with.overflow.i8",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "u16_sub_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.usub.with.overflow.i16", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.usub.with.overflow.i16",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "u32_sub_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.usub.with.overflow.i32", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.usub.with.overflow.i32",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "u64_sub_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.usub.with.overflow.i64", ret_ty,
-                                   llargs[0], llargs[1]),
-
+            with_overflow_intrinsic(bcx,
+                                    "llvm.usub.with.overflow.i64",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "i8_mul_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.smul.with.overflow.i8", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.smul.with.overflow.i8",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "i16_mul_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.smul.with.overflow.i16", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.smul.with.overflow.i16",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "i32_mul_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.smul.with.overflow.i32", ret_ty,
-                                   llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.smul.with.overflow.i32",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "i64_mul_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.smul.with.overflow.i64", ret_ty,
-                                   llargs[0], llargs[1]),
-
+            with_overflow_intrinsic(bcx,
+                                    "llvm.smul.with.overflow.i64",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "u8_mul_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.umul.with.overflow.i8", ret_ty,
-                                    llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.umul.with.overflow.i8",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "u16_mul_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.umul.with.overflow.i16", ret_ty,
-                                    llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.umul.with.overflow.i16",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "u32_mul_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.umul.with.overflow.i32", ret_ty,
-                                    llargs[0], llargs[1]),
+            with_overflow_intrinsic(bcx,
+                                    "llvm.umul.with.overflow.i32",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "u64_mul_with_overflow") =>
-            with_overflow_intrinsic(bcx, "llvm.umul.with.overflow.i64", ret_ty,
-                                    llargs[0], llargs[1]),
-
+            with_overflow_intrinsic(bcx,
+                                    "llvm.umul.with.overflow.i64",
+                                    ret_ty,
+                                    llargs[0],
+                                    llargs[1],
+                                    call_source_location),
         (_, "return_address") => {
             if !fcx.caller_expects_out_pointer {
                 tcx.sess.span_err(call_info.span,
@@ -611,8 +763,14 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
 }
 
 fn copy_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
-                              allow_overlap: bool, volatile: bool, tp_ty: Ty<'tcx>,
-                              dst: ValueRef, src: ValueRef, count: ValueRef) -> ValueRef {
+                              allow_overlap: bool,
+                              volatile: bool,
+                              tp_ty: Ty<'tcx>,
+                              dst: ValueRef,
+                              src: ValueRef,
+                              count: ValueRef,
+                              call_source_location: SourceLocation)
+                              -> ValueRef {
     let ccx = bcx.ccx();
     let lltp_ty = type_of::type_of(ccx, tp_ty);
     let align = C_i32(ccx, type_of::align_of(ccx, tp_ty) as i32);
@@ -636,12 +794,25 @@ fn copy_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let src_ptr = PointerCast(bcx, src, Type::i8p(ccx));
     let llfn = ccx.get_intrinsic(&name);
 
-    Call(bcx, llfn, &[dst_ptr, src_ptr, Mul(bcx, size, count), align,
-                      C_bool(ccx, volatile)], None)
+    Call(bcx,
+         llfn,
+         &[dst_ptr,
+           src_ptr,
+           Mul(bcx, size, count, NoSourceLoc),
+           align,
+           C_bool(ccx, volatile)],
+         None,
+         call_source_location)
 }
 
-fn memset_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, volatile: bool, tp_ty: Ty<'tcx>,
-                                dst: ValueRef, val: ValueRef, count: ValueRef) -> ValueRef {
+fn memset_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+                                volatile: bool,
+                                tp_ty: Ty<'tcx>,
+                                dst: ValueRef,
+                                val: ValueRef,
+                                count: ValueRef,
+                                call_source_location: SourceLocation)
+                                -> ValueRef {
     let ccx = bcx.ccx();
     let lltp_ty = type_of::type_of(ccx, tp_ty);
     let align = C_i32(ccx, type_of::align_of(ccx, tp_ty) as i32);
@@ -655,22 +826,38 @@ fn memset_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, volatile: bool, tp_ty: T
     let dst_ptr = PointerCast(bcx, dst, Type::i8p(ccx));
     let llfn = ccx.get_intrinsic(&name);
 
-    Call(bcx, llfn, &[dst_ptr, val, Mul(bcx, size, count), align,
-                      C_bool(ccx, volatile)], None)
+    Call(bcx,
+         llfn,
+         &[dst_ptr,
+           val,
+           Mul(bcx, size, count, NoSourceLoc),
+           align,
+           C_bool(ccx, volatile)],
+         None,
+         call_source_location)
 }
 
-fn count_zeros_intrinsic(bcx: Block, name: &'static str, val: ValueRef) -> ValueRef {
+fn count_zeros_intrinsic(bcx: Block,
+                         name: &'static str,
+                         val: ValueRef,
+                         call_source_location: SourceLocation)
+                         -> ValueRef {
     let y = C_bool(bcx.ccx(), false);
     let llfn = bcx.ccx().get_intrinsic(&name);
-    Call(bcx, llfn, &[val, y], None)
+    Call(bcx, llfn, &[val, y], None, call_source_location)
 }
 
-fn with_overflow_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, name: &'static str,
-                                       t: Ty<'tcx>, a: ValueRef, b: ValueRef) -> ValueRef {
+fn with_overflow_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+                                       name: &'static str,
+                                       t: Ty<'tcx>,
+                                       a: ValueRef,
+                                       b: ValueRef,
+                                       call_source_location: SourceLocation)
+                                       -> ValueRef {
     let llfn = bcx.ccx().get_intrinsic(&name);
 
     // Convert `i1` to a `bool`, and write it to the out parameter
-    let val = Call(bcx, llfn, &[a, b], None);
+    let val = Call(bcx, llfn, &[a, b], None, call_source_location);
     let result = ExtractValue(bcx, val, 0);
     let overflow = ZExt(bcx, ExtractValue(bcx, val, 1), Type::bool(bcx.ccx()));
     let ret = C_undef(type_of::type_of(bcx.ccx(), t));

--- a/src/librustc_trans/trans/tvec.rs
+++ b/src/librustc_trans/trans/tvec.rs
@@ -20,6 +20,7 @@ use trans::cleanup;
 use trans::cleanup::CleanupMethods;
 use trans::common::*;
 use trans::datum::*;
+use trans::debuginfo::SourceLocation::NoSourceLoc;
 use trans::expr::{Dest, Ignore, SaveIn};
 use trans::expr;
 use trans::glue;
@@ -77,7 +78,7 @@ pub fn make_drop_glue_unboxed<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                 let not_empty = ICmp(bcx, llvm::IntNE, len, C_uint(ccx, 0u));
                 with_cond(bcx, not_empty, |bcx| {
                     let llalign = C_uint(ccx, machine::llalign_of_min(ccx, llty));
-                    let size = Mul(bcx, C_uint(ccx, unit_size), len);
+                    let size = Mul(bcx, C_uint(ccx, unit_size), len, NoSourceLoc);
                     glue::trans_exchange_free_dyn(bcx, dataptr, size, llalign)
                 })
             } else {
@@ -435,14 +436,14 @@ pub fn iter_vec_loop<'a, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let cond_bcx = fcx.new_temp_block("expr_repeat: loop cond");
     let body_bcx = fcx.new_temp_block("expr_repeat: body: set");
     let inc_bcx = fcx.new_temp_block("expr_repeat: body: inc");
-    Br(bcx, loop_bcx.llbb);
+    Br(bcx, loop_bcx.llbb, NoSourceLoc);
 
     let loop_counter = {
         // i = 0
         let i = alloca(loop_bcx, bcx.ccx().int_type(), "__i");
         Store(loop_bcx, C_uint(bcx.ccx(), 0u), i);
 
-        Br(loop_bcx, cond_bcx.llbb);
+        Br(loop_bcx, cond_bcx.llbb, NoSourceLoc);
         i
     };
 
@@ -451,7 +452,7 @@ pub fn iter_vec_loop<'a, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         let rhs = count;
         let cond_val = ICmp(cond_bcx, llvm::IntULT, lhs, rhs);
 
-        CondBr(cond_bcx, cond_val, body_bcx.llbb, next_bcx.llbb);
+        CondBr(cond_bcx, cond_val, body_bcx.llbb, next_bcx.llbb, NoSourceLoc);
     }
 
     { // loop body
@@ -463,15 +464,15 @@ pub fn iter_vec_loop<'a, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         };
         let body_bcx = f(body_bcx, lleltptr, vt.unit_ty);
 
-        Br(body_bcx, inc_bcx.llbb);
+        Br(body_bcx, inc_bcx.llbb, NoSourceLoc);
     }
 
     { // i += 1
         let i = Load(inc_bcx, loop_counter);
-        let plusone = Add(inc_bcx, i, C_uint(bcx.ccx(), 1u));
+        let plusone = Add(inc_bcx, i, C_uint(bcx.ccx(), 1u), NoSourceLoc);
         Store(inc_bcx, plusone, loop_counter);
 
-        Br(inc_bcx, cond_bcx.llbb);
+        Br(inc_bcx, cond_bcx.llbb, NoSourceLoc);
     }
 
     next_bcx
@@ -487,7 +488,7 @@ pub fn iter_vec_raw<'a, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let fcx = bcx.fcx;
 
     let vt = vec_types(bcx, unit_ty);
-    let fill = Mul(bcx, len, vt.llunit_size);
+    let fill = Mul(bcx, len, vt.llunit_size, NoSourceLoc);
 
     if vt.llunit_alloc_size == 0 {
         // Special-case vectors with elements of size 0  so they don't go out of bounds (#9890)
@@ -501,19 +502,19 @@ pub fn iter_vec_raw<'a, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
         // Now perform the iteration.
         let header_bcx = fcx.new_temp_block("iter_vec_loop_header");
-        Br(bcx, header_bcx.llbb);
+        Br(bcx, header_bcx.llbb, NoSourceLoc);
         let data_ptr =
             Phi(header_bcx, val_ty(data_ptr), &[data_ptr], &[bcx.llbb]);
         let not_yet_at_end =
             ICmp(header_bcx, llvm::IntULT, data_ptr, data_end_ptr);
         let body_bcx = fcx.new_temp_block("iter_vec_loop_body");
         let next_bcx = fcx.new_temp_block("iter_vec_next");
-        CondBr(header_bcx, not_yet_at_end, body_bcx.llbb, next_bcx.llbb);
+        CondBr(header_bcx, not_yet_at_end, body_bcx.llbb, next_bcx.llbb, NoSourceLoc);
         let body_bcx = f(body_bcx, data_ptr, vt.unit_ty);
         AddIncomingToPhi(data_ptr, InBoundsGEP(body_bcx, data_ptr,
                                                &[C_int(bcx.ccx(), 1i)]),
                          body_bcx.llbb);
-        Br(body_bcx, header_bcx.llbb);
+        Br(body_bcx, header_bcx.llbb, NoSourceLoc);
         next_bcx
     }
 }


### PR DESCRIPTION
So far, the source location an LLVM instruction was linked to was controlled by `debuginfo::set_source_location()` and `debuginfo::clear_source_location()`. This interface mimicked how LLVM's `IRBuilder` handles debug location assignment. While this interface has some theoretical performance benefits, it also makes things terribly unstable: One sets some quasi-global state and then hopes that it is still correct when a given instruction is emitted---an assumption that has been proven to not hold a bit too often.

This patch requires the debug source location to be passed to the actual instruction emitting function. This makes source location assignment explicit and will prevent future changes to `trans` from accidentally breaking things in the majority of cases.

This patch does not yet implement the new principle for all instruction kinds but the stepping experience should have improved significantly nonetheless already.
