### PR TITLE
rustc: Start the deprecation of libserialize

### DIFF
--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -70,8 +70,28 @@ pub fn expand_meta_deriving(cx: &mut ExtCtxt,
 
                             "Hash" => expand!(hash::expand_deriving_hash),
 
-                            "Encodable" => expand!(encodable::expand_deriving_encodable),
-                            "Decodable" => expand!(decodable::expand_deriving_decodable),
+                            "RustcEncodable" => {
+                                expand!(encodable::expand_deriving_encodable)
+                            }
+                            "RustcDecodable" => {
+                                expand!(decodable::expand_deriving_decodable)
+                            }
+                            "Encodable" => {
+                                // NOTE: uncomment after a stage0 snap
+                                // cx.span_warn(titem.span,
+                                //              "deriving(Encodable) is deprecated \
+                                //               in favor of deriving(RustcEncodable)");
+
+                                expand!(encodable::expand_deriving_encodable)
+                            }
+                            "Decodable" =>
+                                // NOTE: uncomment after a stage0 snap
+                                // cx.span_warn(titem.span,
+                                //              "deriving(Decodable) is deprecated \
+                                //               in favor of deriving(RustcDecodable)");
+
+                                expand!(decodable::expand_deriving_decodable)
+                            }
 
                             "PartialEq" => expand!(eq::expand_deriving_eq),
                             "Eq" => expand!(totaleq::expand_deriving_totaleq),


### PR DESCRIPTION
The primary focus of Rust's stability story at 1.0 is the standard library.
All other libraries distributed with the Rust compiler are planned to
be #[unstable] and therfore only accessible on the nightly channel of Rust. One
of the more widely used libraries today is libserialize, Rust's current solution
for encoding and decoding types.

The current libserialize library, however, has a number of drawbacks:
- The API is not ready to be stabilize as-is and we will likely not have enough
  resources to stabilize the API for 1.0.
- The library is not necessarily the speediest implementations with alternatives
  being developed out-of-tree (e.g. serde from erickt).
- It is not clear how the API of Encodable/Decodable can evolve over time while
  maintaining backwards compatibility.

One of the major pros to the current libserialize, however, is
`deriving(Encodable, Decodable)` as short-hands for enabling serializing and
deserializing a type. This is unambiguously useful functionality, so we cannot
simply deprecate the in-tree libserialize in favor of an external crates.io
implementation.

For these reasons, this commit starts off a stability story for libserialize by
following these steps:
1. The deriving(Encodable, Decodable) modes will be deprecated in favor of a
   renamed deriving(RustcEncodable, RustcDecodable).
2. The in-tree libserialize will be deprecated in favor of an external
   rustc-serialize crate shipped on crates.io. The contents of the crate will be
   the same for now (but they can evolve separately).
3. At 1.0 serialization will be performed through
   deriving(RustcEncodable, RustcDecodable) and the rustc-serialize crate. The
   expansions for each deriving mode will change from `::serialize::foo` to
   `::rustc_serialize::foo`.

This story will require that the compiler freezes its implementation of
`RustcEncodable` deriving for all of time, but this should be a fairly minimal
maintenance burden. Otherwise the crate in crates.io must always maintain the
exact definition of its traits, but the implementation of json, for example, can
continue to evolve in the semver-sense.

The major goal for this stabilization effort is to pave the road for a new
official serialization crate which can replace the current one, solving many of
its downsides in the process. We are not assuming that this will exist for 1.0,
hence the above measures. Some possibilities for replacing libserialize include:
- If plugins have a stable API, then any crate can provide a custom `deriving`
  mode (will require some compiler work). This means that any new serialization
  crate can provide its own `deriving` with its own backing
  implementation, entirely obsoleting the current libserialize and fully
  replacing it.
- Erick is exploring the possibility of code generation via preprocessing Rust
  source files in the near term until plugins are stable. This strategy would
  provide the same ergonomic benefit that `deriving` does today in theory.

So, in summary, the current libserialize crate is being deprecated in favor of
the crates.io-based rustc-serialize crate where the `deriving` modes are
appropriately renamed. This opens up space for a later implementation of
serialization in a more official capacity while allowing alternative
implementations to be explored in the meantime.

Concretely speaking, this change adds support for the `RustcEncodable` and
`RustcDecodable` deriving modes. After a snapshot is made warnings will be
turned on for usage of `Encodable` and `Decodable` as well as deprecating the
in-tree libserialize crate to encurage users to use rustc-serialize instead.
