### PR TITLE
Rename `FPCategory`, `FP*` to `FpCategory`, `Fp*` to adhere to the naming convention

### DIFF
--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -18,8 +18,8 @@ use char;
 use char::Char;
 use fmt;
 use iter::{range, DoubleEndedIteratorExt};
-use num::{Float, FPNaN, FPInfinite, ToPrimitive};
-use num::cast;
+use num::{cast, Float, ToPrimitive};
+use num::FpCategory as Fp;
 use ops::FnOnce;
 use result::Result::Ok;
 use slice::{mod, SliceExt};
@@ -109,11 +109,11 @@ pub fn float_to_str_bytes_common<T: Float, U, F>(
     let _1: T = Float::one();
 
     match num.classify() {
-        FPNaN => return f("NaN".as_bytes()),
-        FPInfinite if num > _0 => {
+        Fp::Nan => return f("NaN".as_bytes()),
+        Fp::Infinite if num > _0 => {
             return f("inf".as_bytes());
         }
-        FPInfinite if num < _0 => {
+        Fp::Infinite if num < _0 => {
             return f("-inf".as_bytes());
         }
         _ => {}

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -18,7 +18,8 @@
 
 use intrinsics;
 use mem;
-use num::{Float, FPNormal, FPCategory, FPZero, FPSubnormal, FPInfinite, FPNaN};
+use num::Float;
+use num::FpCategory as Fp;
 use num::from_str_radix;
 use option::Option;
 
@@ -156,23 +157,23 @@ impl Float for f32 {
     /// Returns `true` if the number is neither zero, infinite, subnormal or NaN.
     #[inline]
     fn is_normal(self) -> bool {
-        self.classify() == FPNormal
+        self.classify() == Fp::Normal
     }
 
     /// Returns the floating point category of the number. If only one property
     /// is going to be tested, it is generally faster to use the specific
     /// predicate instead.
-    fn classify(self) -> FPCategory {
+    fn classify(self) -> Fp {
         const EXP_MASK: u32 = 0x7f800000;
         const MAN_MASK: u32 = 0x007fffff;
 
         let bits: u32 = unsafe { mem::transmute(self) };
         match (bits & MAN_MASK, bits & EXP_MASK) {
-            (0, 0)        => FPZero,
-            (_, 0)        => FPSubnormal,
-            (0, EXP_MASK) => FPInfinite,
-            (_, EXP_MASK) => FPNaN,
-            _             => FPNormal,
+            (0, 0)        => Fp::Zero,
+            (_, 0)        => Fp::Subnormal,
+            (0, EXP_MASK) => Fp::Infinite,
+            (_, EXP_MASK) => Fp::Nan,
+            _             => Fp::Normal,
         }
     }
 

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -18,7 +18,8 @@
 
 use intrinsics;
 use mem;
-use num::{Float, FPNormal, FPCategory, FPZero, FPSubnormal, FPInfinite, FPNaN};
+use num::Float;
+use num::FpCategory as Fp;
 use num::from_str_radix;
 use option::Option;
 
@@ -164,23 +165,23 @@ impl Float for f64 {
     /// Returns `true` if the number is neither zero, infinite, subnormal or NaN.
     #[inline]
     fn is_normal(self) -> bool {
-        self.classify() == FPNormal
+        self.classify() == Fp::Normal
     }
 
     /// Returns the floating point category of the number. If only one property
     /// is going to be tested, it is generally faster to use the specific
     /// predicate instead.
-    fn classify(self) -> FPCategory {
+    fn classify(self) -> Fp {
         const EXP_MASK: u64 = 0x7ff0000000000000;
         const MAN_MASK: u64 = 0x000fffffffffffff;
 
         let bits: u64 = unsafe { mem::transmute(self) };
         match (bits & MAN_MASK, bits & EXP_MASK) {
-            (0, 0)        => FPZero,
-            (_, 0)        => FPSubnormal,
-            (0, EXP_MASK) => FPInfinite,
-            (_, EXP_MASK) => FPNaN,
-            _             => FPNormal,
+            (0, 0)        => Fp::Zero,
+            (_, 0)        => Fp::Subnormal,
+            (0, EXP_MASK) => Fp::Infinite,
+            (_, EXP_MASK) => Fp::Nan,
+            _             => Fp::Normal,
         }
     }
 

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -15,8 +15,6 @@
 #![stable]
 #![allow(missing_docs)]
 
-pub use self::FPCategory::*;
-
 use {int, i8, i16, i32, i64};
 use {uint, u8, u16, u32, u64};
 use {f32, f64};
@@ -1222,17 +1220,17 @@ impl_num_cast! { f64,   to_f64 }
 /// Used for representing the classification of floating point numbers
 #[deriving(Copy, PartialEq, Show)]
 #[unstable = "may be renamed"]
-pub enum FPCategory {
+pub enum FpCategory {
     /// "Not a Number", often obtained by dividing by zero
-    FPNaN,
+    Nan,
     /// Positive or negative infinity
-    FPInfinite ,
+    Infinite ,
     /// Positive or negative zero
-    FPZero,
-    /// De-normalized floating point representation (less precise than `FPNormal`)
-    FPSubnormal,
+    Zero,
+    /// De-normalized floating point representation (less precise than `Normal`)
+    Subnormal,
     /// A regular floating point number
-    FPNormal,
+    Normal,
 }
 
 /// A built-in floating point number.
@@ -1277,7 +1275,7 @@ pub trait Float
     /// Returns true if this number is neither zero, infinite, denormal, or NaN.
     fn is_normal(self) -> bool;
     /// Returns the category that this number falls into.
-    fn classify(self) -> FPCategory;
+    fn classify(self) -> FpCategory;
 
     // FIXME (#5527): These should be associated constants
 

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -201,8 +201,9 @@ use std;
 use std::collections::{HashMap, BTreeMap};
 use std::{char, f64, fmt, io, num, str};
 use std::mem::{swap, transmute};
-use std::num::{Float, FPNaN, FPInfinite, Int};
-use std::str::{FromStr};
+use std::num::{Float, Int};
+use std::num::FpCategory as Fp;
+use std::str::FromStr;
 use std::string;
 use std::ops;
 use unicode::str as unicode_str;
@@ -414,7 +415,7 @@ fn spaces(wr: &mut io::Writer, mut n: uint) -> Result<(), io::IoError> {
 
 fn fmt_number_or_null(v: f64) -> string::String {
     match v.classify() {
-        FPNaN | FPInfinite => string::String::from_str("null"),
+        Fp::Nan | Fp::Infinite => string::String::from_str("null"),
         _ if v.fract() != 0f64 => f64::to_str_digits(v, 6u),
         _ => f64::to_str_digits(v, 6u) + ".0",
     }
@@ -2332,7 +2333,7 @@ impl ToJson for f32 {
 impl ToJson for f64 {
     fn to_json(&self) -> Json {
         match self.classify() {
-            FPNaN | FPInfinite => Json::Null,
+            Fp::Nan | Fp::Infinite => Json::Null,
             _                  => Json::F64(*self)
         }
     }

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -351,6 +351,7 @@ pub fn to_str_exp_digits(num: f32, dig: uint, upper: bool) -> String {
 mod tests {
     use f32::*;
     use num::*;
+    use num::FpCategory as Fp;
 
     #[test]
     fn test_min_nan() {
@@ -620,14 +621,14 @@ mod tests {
         let neg_inf: f32 = Float::neg_infinity();
         let zero: f32 = Float::zero();
         let neg_zero: f32 = Float::neg_zero();
-        assert_eq!(nan.classify(), FPNaN);
-        assert_eq!(inf.classify(), FPInfinite);
-        assert_eq!(neg_inf.classify(), FPInfinite);
-        assert_eq!(zero.classify(), FPZero);
-        assert_eq!(neg_zero.classify(), FPZero);
-        assert_eq!(1f32.classify(), FPNormal);
-        assert_eq!(1e-37f32.classify(), FPNormal);
-        assert_eq!(1e-38f32.classify(), FPSubnormal);
+        assert_eq!(nan.classify(), Fp::Nan);
+        assert_eq!(inf.classify(), Fp::Infinite);
+        assert_eq!(neg_inf.classify(), Fp::Infinite);
+        assert_eq!(zero.classify(), Fp::Zero);
+        assert_eq!(neg_zero.classify(), Fp::Zero);
+        assert_eq!(1f32.classify(), Fp::Normal);
+        assert_eq!(1e-37f32.classify(), Fp::Normal);
+        assert_eq!(1e-38f32.classify(), Fp::Subnormal);
     }
 
     #[test]

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -359,6 +359,7 @@ pub fn to_str_exp_digits(num: f64, dig: uint, upper: bool) -> String {
 mod tests {
     use f64::*;
     use num::*;
+    use num::FpCategory as Fp;
 
     #[test]
     fn test_min_nan() {
@@ -623,13 +624,13 @@ mod tests {
         let neg_inf: f64 = Float::neg_infinity();
         let zero: f64 = Float::zero();
         let neg_zero: f64 = Float::neg_zero();
-        assert_eq!(nan.classify(), FPNaN);
-        assert_eq!(inf.classify(), FPInfinite);
-        assert_eq!(neg_inf.classify(), FPInfinite);
-        assert_eq!(zero.classify(), FPZero);
-        assert_eq!(neg_zero.classify(), FPZero);
-        assert_eq!(1e-307f64.classify(), FPNormal);
-        assert_eq!(1e-308f64.classify(), FPSubnormal);
+        assert_eq!(nan.classify(), Fp::Nan);
+        assert_eq!(inf.classify(), Fp::Infinite);
+        assert_eq!(neg_inf.classify(), Fp::Infinite);
+        assert_eq!(zero.classify(), Fp::Zero);
+        assert_eq!(neg_zero.classify(), Fp::Zero);
+        assert_eq!(1e-307f64.classify(), Fp::Normal);
+        assert_eq!(1e-308f64.classify(), Fp::Subnormal);
     }
 
     #[test]

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -31,8 +31,7 @@ pub use core::num::{from_int, from_i8, from_i16, from_i32, from_i64};
 pub use core::num::{from_uint, from_u8, from_u16, from_u32, from_u64};
 pub use core::num::{from_f32, from_f64};
 pub use core::num::{FromStrRadix, from_str_radix};
-pub use core::num::{FPCategory, FPNaN, FPInfinite, FPZero, FPSubnormal};
-pub use core::num::{FPNormal, Float};
+pub use core::num::{FpCategory, Float};
 
 #[experimental = "may be removed or relocated"]
 pub mod strconv;

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -17,7 +17,8 @@ use self::SignificantDigits::*;
 use self::SignFormat::*;
 
 use char::{mod, Char};
-use num::{mod, Int, Float, FPNaN, FPInfinite, ToPrimitive};
+use num::{mod, Int, Float, ToPrimitive};
+use num::FpCategory as Fp;
 use ops::FnMut;
 use slice::{SliceExt, CloneSliceExt};
 use str::StrExt;
@@ -199,14 +200,14 @@ pub fn float_to_str_bytes_common<T: Float>(
     let _1: T = Float::one();
 
     match num.classify() {
-        FPNaN => { return (b"NaN".to_vec(), true); }
-        FPInfinite if num > _0 => {
+        Fp::Nan => { return (b"NaN".to_vec(), true); }
+        Fp::Infinite if num > _0 => {
             return match sign {
                 SignAll => (b"+inf".to_vec(), true),
                 _       => (b"inf".to_vec(), true)
             };
         }
-        FPInfinite if num < _0 => {
+        Fp::Infinite if num < _0 => {
             return match sign {
                 SignNone => (b"inf".to_vec(), true),
                 _        => (b"-inf".to_vec(), true),


### PR DESCRIPTION
This is a [breaking-change].
