### PR TITLE
Remove feature gate directives for `if_let`, `while_let`, and `tuple_indexing`.

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2549,10 +2549,6 @@ The currently implemented features of the reference compiler are:
 * `default_type_params` - Allows use of default type parameters. The future of
                           this feature is uncertain.
 
-* `if_let` - Allows use of the `if let` syntax.
-
-* `while_let` - Allows use of the `while let` syntax.
-
 * `intrinsics` - Allows use of the "rust-intrinsics" ABI. Compiler intrinsics
                  are inherently unstable and no promise about them is made.
 
@@ -2638,8 +2634,6 @@ The currently implemented features of the reference compiler are:
 * `unsafe_destructor` - Allows use of the `#[unsafe_destructor]` attribute,
                         which is considered wildly unsafe and will be
                         obsoleted by language improvements.
-
-* `tuple_indexing` - Allows use of tuple indexing (expressions like `expr.0`)
 
 * `associated_types` - Allows type aliases in traits. Experimental.
 

--- a/src/test/compile-fail/issue-19096.rs
+++ b/src/test/compile-fail/issue-19096.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
-
 fn main() {
     let t = (42i, 42i);
     t.0::<int>; //~ ERROR expected one of `.`, `;`, `}`, or an operator, found `::`

--- a/src/test/run-pass/borrow-tuple-fields.rs
+++ b/src/test/run-pass/borrow-tuple-fields.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
-
 struct Foo(int, int);
 
 fn main() {

--- a/src/test/run-pass/if-let.rs
+++ b/src/test/run-pass/if-let.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(if_let)]
-
 pub fn main() {
     let x = Some(3i);
     if let Some(y) = x {

--- a/src/test/run-pass/issue-18412.rs
+++ b/src/test/run-pass/issue-18412.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
-
 // Test that non-static methods can be assigned to local variables as
 // function pointers.
 

--- a/src/test/run-pass/issue-19244.rs
+++ b/src/test/run-pass/issue-19244.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
-
 struct MyStruct { field: uint }
 const STRUCT: MyStruct = MyStruct { field: 42 };
 const TUP: (uint,) = (43,);

--- a/src/test/run-pass/issue-19367.rs
+++ b/src/test/run-pass/issue-19367.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
 struct S {
     o: Option<String>
 }

--- a/src/test/run-pass/tuple-index-fat-types.rs
+++ b/src/test/run-pass/tuple-index-fat-types.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
-
 struct Foo<'a>(&'a [int]);
 
 fn main() {

--- a/src/test/run-pass/tuple-index.rs
+++ b/src/test/run-pass/tuple-index.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
-
 struct Point(int, int);
 
 fn main() {

--- a/src/test/run-pass/while-let.rs
+++ b/src/test/run-pass/while-let.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(while_let)]
-
 use std::collections::BinaryHeap;
 
 fn make_pq() -> BinaryHeap<int> {


### PR DESCRIPTION
This is a revival of #19517 (per request of @alexcrichton) now that the new snapshots have landed.  We can now remove the last feature gates for if_let, while_let, and tuple_indexing scattered throughout the test sources since these features have been added to Rust.

Closes #19473.
