### PR TITLE
rustdoc: Properly inline const items

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -104,6 +104,10 @@ fn try_inline_def(cx: &DocContext, tcx: &ty::ctxt,
             record_extern_fqn(cx, did, clean::TypeStatic);
             clean::StaticItem(build_static(cx, tcx, did, mtbl))
         }
+        def::DefConst(did) => {
+            record_extern_fqn(cx, did, clean::TypeConst);
+            clean::ConstantItem(build_const(cx, tcx, did))
+        }
         _ => return None,
     };
     let fqn = csearch::get_item_path(tcx, did);
@@ -384,6 +388,24 @@ fn build_module(cx: &DocContext, tcx: &ty::ctxt,
                 decoder::DlField => panic!("unimplemented field"),
             }
         });
+    }
+}
+
+fn build_const(cx: &DocContext, tcx: &ty::ctxt,
+               did: ast::DefId) -> clean::Constant {
+    use rustc::middle::const_eval;
+    use syntax::print::pprust;
+
+    let expr = const_eval::lookup_const_by_id(tcx, did).unwrap_or_else(|| {
+        panic!("expected lookup_const_by_id to succeed for {}", did);
+    });
+    debug!("converting constant expr {} to snippet", expr);
+    let sn = pprust::expr_to_string(expr);
+    debug!("got snippet {}", sn);
+
+    clean::Constant {
+        type_: ty::lookup_item_type(tcx, did).ty.clean(cx),
+        expr: sn
     }
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1185,6 +1185,7 @@ pub enum TypeKind {
     TypeEnum,
     TypeFunction,
     TypeModule,
+    TypeConst,
     TypeStatic,
     TypeStruct,
     TypeTrait,
@@ -1818,7 +1819,7 @@ impl Clean<Item> for doctree::Static {
     }
 }
 
-#[deriving(Clone, Encodable, Decodable)]
+#[deriving(Clone, Encodable, Decodable, Show)]
 pub struct Constant {
     pub type_: Type,
     pub expr: String,

--- a/src/librustdoc/html/item_type.rs
+++ b/src/librustdoc/html/item_type.rs
@@ -76,6 +76,7 @@ impl ItemType {
             clean::TypeTrait    => ItemType::Trait,
             clean::TypeModule   => ItemType::Module,
             clean::TypeStatic   => ItemType::Static,
+            clean::TypeConst    => ItemType::Constant,
             clean::TypeVariant  => ItemType::Variant,
             clean::TypeTypedef  => ItemType::Typedef,
         }


### PR DESCRIPTION
Build `clean::ConstantItem` values in the `inline` module and
pretty-print the AST for inlined const items.

Doc strings are still missing from inlined constants (see #19773).

Partially address #18156, #19722, #19185

Fix #15821

r? @alexcrichton 
