### PR TITLE
Report an error when lifetime parameters are shadowed.

### DIFF
--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -154,7 +154,7 @@ struct MaskWords<'a> {
 impl<'a> Iterator<(uint, u32)> for MaskWords<'a> {
     /// Returns (offset, word)
     #[inline]
-    fn next<'a>(&'a mut self) -> Option<(uint, u32)> {
+    fn next(&mut self) -> Option<(uint, u32)> {
         let ret = self.next_word;
         match ret {
             Some(&w) => {

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -561,7 +561,7 @@ mod stack {
     impl<'a, K, V> PartialSearchStack<'a, K, V> {
         /// Creates a new PartialSearchStack from a BTreeMap by initializing the stack with the
         /// root of the tree.
-        pub fn new<'a>(map: &'a mut BTreeMap<K, V>) -> PartialSearchStack<'a, K, V> {
+        pub fn new(map: &'a mut BTreeMap<K, V>) -> PartialSearchStack<'a, K, V> {
             let depth = map.depth;
 
             PartialSearchStack {

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -692,7 +692,7 @@ impl<'a, A> ListInsertion<A> for MutItems<'a, A> {
     }
 
     #[inline]
-    fn peek_next<'a>(&'a mut self) -> Option<&'a mut A> {
+    fn peek_next(&mut self) -> Option<&mut A> {
         if self.nelem == 0 {
             return None
         }

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -115,7 +115,7 @@ impl<'a> Argument<'a> {
         Show::fmt(x, f)
     }
 
-    fn new<'a, T>(x: &'a T, f: fn(&T, &mut Formatter) -> Result) -> Argument<'a> {
+    fn new<'b, T>(x: &'b T, f: fn(&T, &mut Formatter) -> Result) -> Argument<'b> {
         unsafe {
             Argument {
                 formatter: mem::transmute(f),
@@ -124,7 +124,7 @@ impl<'a> Argument<'a> {
         }
     }
 
-    fn from_uint<'a>(x: &'a uint) -> Argument<'a> {
+    fn from_uint(x: &uint) -> Argument {
         Argument::new(x, Argument::show_uint)
     }
 
@@ -144,8 +144,8 @@ impl<'a> Arguments<'a> {
     /// Arguments structure.
     #[doc(hidden)] #[inline]
     #[experimental = "implementation detail of the `format_args!` macro"]
-    pub fn new<'a>(pieces: &'a [&'a str],
-                   args: &'a [Argument<'a>]) -> Arguments<'a> {
+    pub fn new(pieces: &'a [&'a str],
+               args: &'a [Argument<'a>]) -> Arguments<'a> {
         Arguments {
             pieces: pieces,
             fmt: None,
@@ -161,9 +161,9 @@ impl<'a> Arguments<'a> {
     /// unsafety, but will ignore invalid .
     #[doc(hidden)] #[inline]
     #[experimental = "implementation detail of the `format_args!` macro"]
-    pub fn with_placeholders<'a>(pieces: &'a [&'a str],
-                                 fmt: &'a [rt::Argument<'a>],
-                                 args: &'a [Argument<'a>]) -> Arguments<'a> {
+    pub fn with_placeholders(pieces: &'a [&'a str],
+                             fmt: &'a [rt::Argument<'a>],
+                             args: &'a [Argument<'a>]) -> Arguments<'a> {
         Arguments {
             pieces: pieces,
             fmt: Some(fmt),

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1036,12 +1036,12 @@ impl<T> AsSlice<T> for [T] {
 
 impl<'a, T, Sized? U: AsSlice<T>> AsSlice<T> for &'a U {
     #[inline(always)]
-    fn as_slice<'a>(&'a self) -> &'a [T] { AsSlice::as_slice(*self) }
+    fn as_slice(&self) -> &[T] { AsSlice::as_slice(*self) }
 }
 
 impl<'a, T, Sized? U: AsSlice<T>> AsSlice<T> for &'a mut U {
     #[inline(always)]
-    fn as_slice<'a>(&'a self) -> &'a [T] { AsSlice::as_slice(*self) }
+    fn as_slice(&self) -> &[T] { AsSlice::as_slice(*self) }
 }
 
 #[unstable = "waiting for DST"]

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -185,7 +185,7 @@ impl<'a> Iterator<Piece<'a>> for Parser<'a> {
 
 impl<'a> Parser<'a> {
     /// Creates a new parser for the given format string
-    pub fn new<'a>(s: &'a str) -> Parser<'a> {
+    pub fn new(s: &'a str) -> Parser<'a> {
         Parser {
             input: s,
             cur: s.char_indices(),

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -165,10 +165,10 @@
 //!     fn node_id(&'a self, n: &Nd) -> dot::Id<'a> {
 //!         dot::Id::new(format!("N{}", n)).unwrap()
 //!     }
-//!     fn node_label<'a>(&'a self, n: &Nd) -> dot::LabelText<'a> {
+//!     fn node_label<'b>(&'b self, n: &Nd) -> dot::LabelText<'b> {
 //!         dot::LabelStr(self.nodes[*n].as_slice().into_cow())
 //!     }
-//!     fn edge_label<'a>(&'a self, _: &Ed) -> dot::LabelText<'a> {
+//!     fn edge_label<'b>(&'b self, _: &Ed) -> dot::LabelText<'b> {
 //!         dot::LabelStr("&sube;".into_cow())
 //!     }
 //! }
@@ -220,11 +220,11 @@
 //!     fn node_id(&'a self, n: &Nd<'a>) -> dot::Id<'a> {
 //!         dot::Id::new(format!("N{}", n.0)).unwrap()
 //!     }
-//!     fn node_label<'a>(&'a self, n: &Nd<'a>) -> dot::LabelText<'a> {
+//!     fn node_label<'b>(&'b self, n: &Nd<'b>) -> dot::LabelText<'b> {
 //!         let &(i, _) = n;
 //!         dot::LabelStr(self.nodes[i].as_slice().into_cow())
 //!     }
-//!     fn edge_label<'a>(&'a self, _: &Ed<'a>) -> dot::LabelText<'a> {
+//!     fn edge_label<'b>(&'b self, _: &Ed<'b>) -> dot::LabelText<'b> {
 //!         dot::LabelStr("&sube;".into_cow())
 //!     }
 //! }

--- a/src/libgraphviz/maybe_owned_vec.rs
+++ b/src/libgraphviz/maybe_owned_vec.rs
@@ -169,7 +169,7 @@ impl<'a, T> Default for MaybeOwnedVector<'a, T> {
 }
 
 impl<'a> BytesContainer for MaybeOwnedVector<'a, u8> {
-    fn container_as_bytes<'a>(&'a self) -> &'a [u8] {
+    fn container_as_bytes(&self) -> &[u8] {
         self.as_slice()
     }
 }

--- a/src/librand/distributions/mod.rs
+++ b/src/librand/distributions/mod.rs
@@ -114,7 +114,7 @@ impl<'a, T: Clone> WeightedChoice<'a, T> {
     /// - `v` is empty
     /// - the total weight is 0
     /// - the total weight is larger than a `uint` can contain.
-    pub fn new<'a>(items: &'a mut [Weighted<T>]) -> WeightedChoice<'a, T> {
+    pub fn new(items: &'a mut [Weighted<T>]) -> WeightedChoice<'a, T> {
         // strictly speaking, this is subsumed by the total weight == 0 case
         assert!(!items.is_empty(), "WeightedChoice::new called with no items");
 

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -601,7 +601,7 @@ fn encode_method_callee<'a, 'tcx>(ecx: &e::EncodeContext<'a, 'tcx>,
 }
 
 impl<'a, 'tcx> read_method_callee_helper<'tcx> for reader::Decoder<'a> {
-    fn read_method_callee<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
+    fn read_method_callee<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
         -> (ty::ExprAdjustment, MethodCallee<'tcx>) {
 
         self.read_struct("MethodCallee", 4, |this| {
@@ -810,7 +810,7 @@ trait get_ty_str_ctxt<'tcx> {
 }
 
 impl<'a, 'tcx> get_ty_str_ctxt<'tcx> for e::EncodeContext<'a, 'tcx> {
-    fn ty_str_ctxt<'a>(&'a self) -> tyencode::ctxt<'a, 'tcx> {
+    fn ty_str_ctxt<'b>(&'b self) -> tyencode::ctxt<'b, 'tcx> {
         tyencode::ctxt {
             diag: self.tcx.sess.diagnostic(),
             ds: e::def_to_string,
@@ -851,16 +851,16 @@ trait rbml_writer_helpers<'tcx> {
 }
 
 impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
-    fn emit_closure_type<'a>(&mut self,
-                             ecx: &e::EncodeContext<'a, 'tcx>,
+    fn emit_closure_type<'b>(&mut self,
+                             ecx: &e::EncodeContext<'b, 'tcx>,
                              closure_type: &ty::ClosureTy<'tcx>) {
         self.emit_opaque(|this| {
             Ok(e::write_closure_type(ecx, this, closure_type))
         });
     }
 
-    fn emit_method_origin<'a>(&mut self,
-                              ecx: &e::EncodeContext<'a, 'tcx>,
+    fn emit_method_origin<'b>(&mut self,
+                              ecx: &e::EncodeContext<'b, 'tcx>,
                               method_origin: &ty::MethodOrigin<'tcx>)
     {
         use serialize::Encoder;
@@ -916,20 +916,20 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
         });
     }
 
-    fn emit_ty<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>, ty: Ty<'tcx>) {
+    fn emit_ty<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>, ty: Ty<'tcx>) {
         self.emit_opaque(|this| Ok(e::write_type(ecx, this, ty)));
     }
 
-    fn emit_tys<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>, tys: &[Ty<'tcx>]) {
+    fn emit_tys<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>, tys: &[Ty<'tcx>]) {
         self.emit_from_vec(tys, |this, ty| Ok(this.emit_ty(ecx, *ty)));
     }
 
-    fn emit_trait_ref<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>,
+    fn emit_trait_ref<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>,
                           trait_ref: &ty::TraitRef<'tcx>) {
         self.emit_opaque(|this| Ok(e::write_trait_ref(ecx, this, trait_ref)));
     }
 
-    fn emit_type_param_def<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>,
+    fn emit_type_param_def<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>,
                                type_param_def: &ty::TypeParameterDef<'tcx>) {
         self.emit_opaque(|this| {
             Ok(tyencode::enc_type_param_def(this.writer,
@@ -938,7 +938,7 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
         });
     }
 
-    fn emit_predicate<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>,
+    fn emit_predicate<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>,
                           predicate: &ty::Predicate<'tcx>) {
         self.emit_opaque(|this| {
             Ok(tyencode::enc_predicate(this.writer,
@@ -947,8 +947,8 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
         });
     }
 
-    fn emit_polytype<'a>(&mut self,
-                         ecx: &e::EncodeContext<'a, 'tcx>,
+    fn emit_polytype<'b>(&mut self,
+                         ecx: &e::EncodeContext<'b, 'tcx>,
                          pty: ty::Polytype<'tcx>) {
         use serialize::Encoder;
 
@@ -990,14 +990,14 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
                                                                 bounds)));
     }
 
-    fn emit_substs<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>,
+    fn emit_substs<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>,
                        substs: &subst::Substs<'tcx>) {
         self.emit_opaque(|this| Ok(tyencode::enc_substs(this.writer,
                                                            &ecx.ty_str_ctxt(),
                                                            substs)));
     }
 
-    fn emit_auto_adjustment<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>,
+    fn emit_auto_adjustment<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>,
                                 adj: &ty::AutoAdjustment<'tcx>) {
         use serialize::Encoder;
 
@@ -1019,7 +1019,7 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
         });
     }
 
-    fn emit_autoref<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>,
+    fn emit_autoref<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>,
                         autoref: &ty::AutoRef<'tcx>) {
         use serialize::Encoder;
 
@@ -1069,7 +1069,7 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
         });
     }
 
-    fn emit_auto_deref_ref<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>,
+    fn emit_auto_deref_ref<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>,
                                auto_deref_ref: &ty::AutoDerefRef<'tcx>) {
         use serialize::Encoder;
 
@@ -1086,7 +1086,7 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
         });
     }
 
-    fn emit_unsize_kind<'a>(&mut self, ecx: &e::EncodeContext<'a, 'tcx>,
+    fn emit_unsize_kind<'b>(&mut self, ecx: &e::EncodeContext<'b, 'tcx>,
                             uk: &ty::UnsizeKind<'tcx>) {
         use serialize::Encoder;
 
@@ -1427,7 +1427,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
         }).unwrap()
     }
 
-    fn read_method_origin<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
+    fn read_method_origin<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                                   -> ty::MethodOrigin<'tcx>
     {
         self.read_enum("MethodOrigin", |this| {
@@ -1498,7 +1498,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
     }
 
 
-    fn read_ty<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>) -> Ty<'tcx> {
+    fn read_ty<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>) -> Ty<'tcx> {
         // Note: regions types embed local node ids.  In principle, we
         // should translate these node ids into the new decode
         // context.  However, we do not bother, because region types
@@ -1526,12 +1526,12 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
         }
     }
 
-    fn read_tys<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
+    fn read_tys<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                         -> Vec<Ty<'tcx>> {
         self.read_to_vec(|this| Ok(this.read_ty(dcx))).unwrap().into_iter().collect()
     }
 
-    fn read_trait_ref<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
+    fn read_trait_ref<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                               -> Rc<ty::TraitRef<'tcx>> {
         Rc::new(self.read_opaque(|this, doc| {
             let ty = tydecode::parse_trait_ref_data(
@@ -1544,7 +1544,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
         }).unwrap())
     }
 
-    fn read_type_param_def<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
+    fn read_type_param_def<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                                    -> ty::TypeParameterDef<'tcx> {
         self.read_opaque(|this, doc| {
             Ok(tydecode::parse_type_param_def_data(
@@ -1556,7 +1556,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
         }).unwrap()
     }
 
-    fn read_predicate<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
+    fn read_predicate<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                               -> ty::Predicate<'tcx>
     {
         self.read_opaque(|this, doc| {
@@ -1565,7 +1565,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
         }).unwrap()
     }
 
-    fn read_polytype<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
+    fn read_polytype<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                              -> ty::Polytype<'tcx> {
         self.read_struct("Polytype", 2, |this| {
             Ok(ty::Polytype {
@@ -1599,7 +1599,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
         }).unwrap()
     }
 
-    fn read_existential_bounds<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
+    fn read_existential_bounds<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                                        -> ty::ExistentialBounds
     {
         self.read_opaque(|this, doc| {
@@ -1611,7 +1611,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
         }).unwrap()
     }
 
-    fn read_substs<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
+    fn read_substs<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                            -> subst::Substs<'tcx> {
         self.read_opaque(|this, doc| {
             Ok(tydecode::parse_substs_data(doc.data,
@@ -1622,7 +1622,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
         }).unwrap()
     }
 
-    fn read_auto_adjustment<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
+    fn read_auto_adjustment<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                                     -> ty::AutoAdjustment<'tcx> {
         self.read_enum("AutoAdjustment", |this| {
             let variants = ["AutoAddEnv", "AutoDerefRef"];
@@ -1647,7 +1647,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
         }).unwrap()
     }
 
-    fn read_auto_deref_ref<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
+    fn read_auto_deref_ref<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                                    -> ty::AutoDerefRef<'tcx> {
         self.read_struct("AutoDerefRef", 2, |this| {
             Ok(ty::AutoDerefRef {
@@ -1667,7 +1667,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
         }).unwrap()
     }
 
-    fn read_autoref<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>) -> ty::AutoRef<'tcx> {
+    fn read_autoref<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>) -> ty::AutoRef<'tcx> {
         self.read_enum("AutoRef", |this| {
             let variants = ["AutoPtr",
                             "AutoUnsize",
@@ -1725,7 +1725,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
         }).unwrap()
     }
 
-    fn read_unsize_kind<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
+    fn read_unsize_kind<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                                 -> ty::UnsizeKind<'tcx> {
         self.read_enum("UnsizeKind", |this| {
             let variants = &["UnsizeLength", "UnsizeStruct", "UnsizeVtable"];
@@ -1768,7 +1768,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
         }).unwrap()
     }
 
-    fn read_unboxed_closure<'a, 'b>(&mut self, dcx: &DecodeContext<'a, 'b, 'tcx>)
+    fn read_unboxed_closure<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                                     -> ty::UnboxedClosure<'tcx> {
         let closure_type = self.read_opaque(|this, doc| {
             Ok(tydecode::parse_ty_closure_data(

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -151,7 +151,7 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
         }
     }
 
-    fn pats_all<'a, I: Iterator<&'a P<ast::Pat>>>(&mut self,
+    fn pats_all<'b, I: Iterator<&'b P<ast::Pat>>>(&mut self,
                                           pats: I,
                                           pred: CFGIndex) -> CFGIndex {
         //! Handles case where all of the patterns must match.
@@ -505,7 +505,7 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
         }
     }
 
-    fn call<'a, I: Iterator<&'a ast::Expr>>(&mut self,
+    fn call<'b, I: Iterator<&'b ast::Expr>>(&mut self,
             call_expr: &ast::Expr,
             pred: CFGIndex,
             func_or_rcvr: &ast::Expr,
@@ -525,7 +525,7 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
         }
     }
 
-    fn exprs<'a, I: Iterator<&'a ast::Expr>>(&mut self,
+    fn exprs<'b, I: Iterator<&'b ast::Expr>>(&mut self,
                                              exprs: I,
                                              pred: CFGIndex) -> CFGIndex {
         //! Constructs graph for `exprs` evaluated in order
@@ -539,7 +539,7 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
         opt_expr.iter().fold(pred, |p, e| self.expr(&**e, p))
     }
 
-    fn straightline<'a, I: Iterator<&'a ast::Expr>>(&mut self,
+    fn straightline<'b, I: Iterator<&'b ast::Expr>>(&mut self,
                     expr: &ast::Expr,
                     pred: CFGIndex,
                     subexprs: I) -> CFGIndex {

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -392,7 +392,7 @@ pub struct StaticInliner<'a, 'tcx: 'a> {
 }
 
 impl<'a, 'tcx> StaticInliner<'a, 'tcx> {
-    pub fn new<'a>(tcx: &'a ty::ctxt<'tcx>) -> StaticInliner<'a, 'tcx> {
+    pub fn new<'b>(tcx: &'b ty::ctxt<'tcx>) -> StaticInliner<'b, 'tcx> {
         StaticInliner {
             tcx: tcx,
             failed: false

--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -539,29 +539,29 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         }
     }
 
-    pub fn skolemizer<'a>(&'a self) -> TypeSkolemizer<'a, 'tcx> {
+    pub fn skolemizer<'b>(&'b self) -> TypeSkolemizer<'b, 'tcx> {
         skolemize::TypeSkolemizer::new(self)
     }
 
-    pub fn combine_fields<'a>(&'a self, a_is_expected: bool, trace: TypeTrace<'tcx>)
-                              -> CombineFields<'a, 'tcx> {
+    pub fn combine_fields<'b>(&'b self, a_is_expected: bool, trace: TypeTrace<'tcx>)
+                              -> CombineFields<'b, 'tcx> {
         CombineFields {infcx: self,
                        a_is_expected: a_is_expected,
                        trace: trace}
     }
 
-    pub fn equate<'a>(&'a self, a_is_expected: bool, trace: TypeTrace<'tcx>)
-                      -> Equate<'a, 'tcx> {
+    pub fn equate<'b>(&'b self, a_is_expected: bool, trace: TypeTrace<'tcx>)
+                      -> Equate<'b, 'tcx> {
         Equate(self.combine_fields(a_is_expected, trace))
     }
 
-    pub fn sub<'a>(&'a self, a_is_expected: bool, trace: TypeTrace<'tcx>)
-                   -> Sub<'a, 'tcx> {
+    pub fn sub<'b>(&'b self, a_is_expected: bool, trace: TypeTrace<'tcx>)
+                   -> Sub<'b, 'tcx> {
         Sub(self.combine_fields(a_is_expected, trace))
     }
 
-    pub fn lub<'a>(&'a self, a_is_expected: bool, trace: TypeTrace<'tcx>)
-                   -> Lub<'a, 'tcx> {
+    pub fn lub<'b>(&'b self, a_is_expected: bool, trace: TypeTrace<'tcx>)
+                   -> Lub<'b, 'tcx> {
         Lub(self.combine_fields(a_is_expected, trace))
     }
 

--- a/src/librustc/middle/infer/region_inference/mod.rs
+++ b/src/librustc/middle/infer/region_inference/mod.rs
@@ -561,8 +561,8 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
         }
     }
 
-    fn combine_map<'a>(&'a self, t: CombineMapType)
-                   -> &'a RefCell<CombineMap> {
+    fn combine_map(&self, t: CombineMapType)
+                   -> &RefCell<CombineMap> {
         match t {
             Glb => &self.glbs,
             Lub => &self.lubs,

--- a/src/librustc/middle/infer/skolemize.rs
+++ b/src/librustc/middle/infer/skolemize.rs
@@ -46,7 +46,7 @@ pub struct TypeSkolemizer<'a, 'tcx:'a> {
 }
 
 impl<'a, 'tcx> TypeSkolemizer<'a, 'tcx> {
-    pub fn new<'tcx>(infcx: &'a InferCtxt<'a, 'tcx>) -> TypeSkolemizer<'a, 'tcx> {
+    pub fn new(infcx: &'a InferCtxt<'a, 'tcx>) -> TypeSkolemizer<'a, 'tcx> {
         TypeSkolemizer {
             infcx: infcx,
             skolemization_count: 0,

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -588,7 +588,7 @@ struct SubstFolder<'a, 'tcx: 'a> {
 }
 
 impl<'a, 'tcx> TypeFolder<'tcx> for SubstFolder<'a, 'tcx> {
-    fn tcx<'a>(&'a self) -> &'a ty::ctxt<'tcx> { self.tcx }
+    fn tcx(&self) -> &ty::ctxt<'tcx> { self.tcx }
 
     fn enter_region_binder(&mut self) {
         self.region_binders_passed += 1;

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -834,7 +834,7 @@ pub fn erase_regions<'tcx, T: TypeFoldable<'tcx>>(tcx: &ty::ctxt<'tcx>, t: T) ->
 }
 
 impl<'a, 'tcx> TypeFolder<'tcx> for RegionEraser<'a, 'tcx> {
-    fn tcx<'a>(&'a self) -> &'a ty::ctxt<'tcx> { self.tcx }
+    fn tcx(&self) -> &ty::ctxt<'tcx> { self.tcx }
 
     fn fold_region(&mut self, r: ty::Region) -> ty::Region {
         match r {

--- a/src/librustc_trans/trans/cleanup.rs
+++ b/src/librustc_trans/trans/cleanup.rs
@@ -979,10 +979,10 @@ impl<'tcx> Cleanup<'tcx> for FreeSlice {
         false
     }
 
-    fn trans<'blk, 'tcx>(&self,
-                         bcx: Block<'blk, 'tcx>,
-                         debug_loc: Option<NodeInfo>)
-                      -> Block<'blk, 'tcx> {
+    fn trans<'blk>(&self,
+                   bcx: Block<'blk, 'tcx>,
+                   debug_loc: Option<NodeInfo>)
+                   -> Block<'blk, 'tcx> {
         apply_debug_loc(bcx.fcx, debug_loc);
 
         match self.heap {
@@ -1012,10 +1012,10 @@ impl<'tcx> Cleanup<'tcx> for LifetimeEnd {
         true
     }
 
-    fn trans<'blk, 'tcx>(&self,
-                         bcx: Block<'blk, 'tcx>,
-                         debug_loc: Option<NodeInfo>)
-                      -> Block<'blk, 'tcx> {
+    fn trans<'blk>(&self,
+                   bcx: Block<'blk, 'tcx>,
+                   debug_loc: Option<NodeInfo>)
+                   -> Block<'blk, 'tcx> {
         apply_debug_loc(bcx.fcx, debug_loc);
         base::call_lifetime_end(bcx, self.ptr);
         bcx

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -394,7 +394,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
         &mut self,
         bounds: &[Rc<ty::TraitRef<'tcx>>],
         num_includes_types: bool,
-        mk_cand: for<'a> |this: &mut ProbeContext<'a, 'tcx>,
+        mk_cand: for<'b> |this: &mut ProbeContext<'b, 'tcx>,
                           tr: Rc<ty::TraitRef<'tcx>>,
                           m: Rc<ty::Method<'tcx>>,
                           method_num: uint|)

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -246,7 +246,7 @@ pub struct FnCtxt<'a, 'tcx: 'a> {
 }
 
 impl<'a, 'tcx> mem_categorization::Typer<'tcx> for FnCtxt<'a, 'tcx> {
-    fn tcx<'a>(&'a self) -> &'a ty::ctxt<'tcx> {
+    fn tcx(&self) -> &ty::ctxt<'tcx> {
         self.ccx.tcx
     }
     fn node_ty(&self, id: ast::NodeId) -> McResult<Ty<'tcx>> {
@@ -256,7 +256,7 @@ impl<'a, 'tcx> mem_categorization::Typer<'tcx> for FnCtxt<'a, 'tcx> {
                       -> Option<Ty<'tcx>> {
         self.inh.method_map.borrow().get(&method_call).map(|m| m.ty)
     }
-    fn adjustments<'a>(&'a self) -> &'a RefCell<NodeMap<ty::AutoAdjustment<'tcx>>> {
+    fn adjustments(&self) -> &RefCell<NodeMap<ty::AutoAdjustment<'tcx>>> {
         &self.inh.adjustments
     }
     fn is_method_call(&self, id: ast::NodeId) -> bool {
@@ -272,8 +272,7 @@ impl<'a, 'tcx> mem_categorization::Typer<'tcx> for FnCtxt<'a, 'tcx> {
                     -> ast::CaptureClause {
         self.ccx.tcx.capture_mode(closure_expr_id)
     }
-    fn unboxed_closures<'a>(&'a self)
-                        -> &'a RefCell<DefIdMap<ty::UnboxedClosure<'tcx>>> {
+    fn unboxed_closures(&self) -> &RefCell<DefIdMap<ty::UnboxedClosure<'tcx>>> {
         &self.inh.unboxed_closures
     }
 }
@@ -1526,7 +1525,7 @@ fn check_cast(fcx: &FnCtxt,
 }
 
 impl<'a, 'tcx> AstConv<'tcx> for FnCtxt<'a, 'tcx> {
-    fn tcx<'a>(&'a self) -> &'a ty::ctxt<'tcx> { self.ccx.tcx }
+    fn tcx(&self) -> &ty::ctxt<'tcx> { self.ccx.tcx }
 
     fn get_item_ty(&self, id: ast::DefId) -> ty::Polytype<'tcx> {
         ty::lookup_item_type(self.tcx(), id)
@@ -1557,7 +1556,7 @@ impl<'a, 'tcx> AstConv<'tcx> for FnCtxt<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
-    fn tcx<'a>(&'a self) -> &'a ty::ctxt<'tcx> { self.ccx.tcx }
+    fn tcx(&self) -> &ty::ctxt<'tcx> { self.ccx.tcx }
 
     pub fn infcx<'b>(&'b self) -> &'b infer::InferCtxt<'a, 'tcx> {
         &self.inh.infcx
@@ -1879,7 +1878,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
-    pub fn item_substs<'a>(&'a self) -> Ref<'a, NodeMap<ty::ItemSubsts<'tcx>>> {
+    pub fn item_substs(&self) -> Ref<NodeMap<ty::ItemSubsts<'tcx>>> {
         self.inh.item_substs.borrow()
     }
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -153,7 +153,7 @@ impl<'a,'tcx> ToTy<'tcx> for CrateCtxt<'a,'tcx> {
 }
 
 impl<'a, 'tcx> AstConv<'tcx> for CrateCtxt<'a, 'tcx> {
-    fn tcx<'a>(&'a self) -> &'a ty::ctxt<'tcx> { self.tcx }
+    fn tcx(&self) -> &ty::ctxt<'tcx> { self.tcx }
 
     fn get_item_ty(&self, id: ast::DefId) -> ty::Polytype<'tcx> {
         if id.krate != ast::LOCAL_CRATE {
@@ -719,7 +719,7 @@ struct ImplCtxt<'a,'tcx:'a> {
 }
 
 impl<'a,'tcx> AstConv<'tcx> for ImplCtxt<'a,'tcx> {
-    fn tcx<'a>(&'a self) -> &'a ty::ctxt<'tcx> {
+    fn tcx(&self) -> &ty::ctxt<'tcx> {
         self.ccx.tcx
     }
 
@@ -808,7 +808,7 @@ struct FnCtxt<'a,'tcx:'a> {
 }
 
 impl<'a,'tcx> AstConv<'tcx> for FnCtxt<'a,'tcx> {
-    fn tcx<'a>(&'a self) -> &'a ty::ctxt<'tcx> {
+    fn tcx(&self) -> &ty::ctxt<'tcx> {
         self.ccx.tcx
     }
 
@@ -857,7 +857,7 @@ struct ImplMethodCtxt<'a,'tcx:'a> {
 }
 
 impl<'a,'tcx> AstConv<'tcx> for ImplMethodCtxt<'a,'tcx> {
-    fn tcx<'a>(&'a self) -> &'a ty::ctxt<'tcx> {
+    fn tcx(&self) -> &ty::ctxt<'tcx> {
         self.ccx.tcx
     }
 
@@ -906,7 +906,7 @@ struct TraitMethodCtxt<'a,'tcx:'a> {
 }
 
 impl<'a,'tcx> AstConv<'tcx> for TraitMethodCtxt<'a,'tcx> {
-    fn tcx<'a>(&'a self) -> &'a ty::ctxt<'tcx> {
+    fn tcx(&self) -> &ty::ctxt<'tcx> {
         self.ccx.tcx
     }
 
@@ -986,7 +986,7 @@ struct GenericsCtxt<'a,'tcx:'a,AC:'a> {
 }
 
 impl<'a,'tcx,AC:AstConv<'tcx>> AstConv<'tcx> for GenericsCtxt<'a,'tcx,AC> {
-    fn tcx<'a>(&'a self) -> &'a ty::ctxt<'tcx> {
+    fn tcx(&self) -> &ty::ctxt<'tcx> {
         self.chain.tcx()
     }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -459,7 +459,7 @@ impl attr::AttrMetaMethods for Attribute {
 impl<'a> attr::AttrMetaMethods for &'a Attribute {
     fn name(&self) -> InternedString { (**self).name() }
     fn value_str(&self) -> Option<InternedString> { (**self).value_str() }
-    fn meta_item_list<'a>(&'a self) -> Option<&'a [P<ast::MetaItem>]> { None }
+    fn meta_item_list(&self) -> Option<&[P<ast::MetaItem>]> { None }
 }
 
 #[deriving(Clone, Encodable, Decodable, PartialEq)]

--- a/src/librustrt/exclusive.rs
+++ b/src/librustrt/exclusive.rs
@@ -71,10 +71,10 @@ impl<'a, T: Send> ExclusiveGuard<'a, T> {
 }
 
 impl<'a, T: Send> Deref<T> for ExclusiveGuard<'a, T> {
-    fn deref<'a>(&'a self) -> &'a T { &*self._data }
+    fn deref(&self) -> &T { &*self._data }
 }
 impl<'a, T: Send> DerefMut<T> for ExclusiveGuard<'a, T> {
-    fn deref_mut<'a>(&'a mut self) -> &'a mut T { &mut *self._data }
+    fn deref_mut(&mut self) -> &mut T { &mut *self._data }
 }
 
 #[cfg(test)]

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -627,13 +627,13 @@ pub struct PrettyEncoder<'a> {
 
 impl<'a> PrettyEncoder<'a> {
     /// Creates a new encoder whose output will be written to the specified writer
-    pub fn new<'a>(writer: &'a mut io::Writer) -> PrettyEncoder<'a> {
+    pub fn new(writer: &'a mut io::Writer) -> PrettyEncoder<'a> {
         PrettyEncoder { writer: writer, curr_indent: 0, indent: 2, }
     }
 
     /// Set the number of spaces to indent for each level.
     /// This is safe to set during encoding.
-    pub fn set_indent<'a>(&mut self, indent: uint) {
+    pub fn set_indent(&mut self, indent: uint) {
         // self.indent very well could be 0 so we need to use checked division.
         let level = self.curr_indent.checked_div(self.indent).unwrap_or(0);
         self.indent = indent;
@@ -1103,7 +1103,7 @@ impl Json {
 }
 
 impl<'a> ops::Index<&'a str, Json>  for Json {
-    fn index<'a>(&'a self, idx: & &str) -> &'a Json {
+    fn index(&self, idx: & &str) -> &Json {
         self.find(*idx).unwrap()
     }
 }

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -226,7 +226,7 @@ impl<'a> Reader for &'a [u8] {
 
 impl<'a> Buffer for &'a [u8] {
     #[inline]
-    fn fill_buf<'a>(&'a mut self) -> IoResult<&'a [u8]> {
+    fn fill_buf(&mut self) -> IoResult<&[u8]> {
         if self.is_empty() {
             Err(io::standard_error(io::EndOfFile))
         } else {
@@ -268,7 +268,7 @@ impl<'a> BufWriter<'a> {
     /// Creates a new `BufWriter` which will wrap the specified buffer. The
     /// writer initially starts at position 0.
     #[inline]
-    pub fn new<'a>(buf: &'a mut [u8]) -> BufWriter<'a> {
+    pub fn new(buf: &'a mut [u8]) -> BufWriter<'a> {
         BufWriter {
             buf: buf,
             pos: 0
@@ -337,7 +337,7 @@ pub struct BufReader<'a> {
 impl<'a> BufReader<'a> {
     /// Creates a new buffered reader which will read the specified buffer
     #[inline]
-    pub fn new<'a>(buf: &'a [u8]) -> BufReader<'a> {
+    pub fn new(buf: &'a [u8]) -> BufReader<'a> {
         BufReader {
             buf: buf,
             pos: 0
@@ -384,7 +384,7 @@ impl<'a> Seek for BufReader<'a> {
 
 impl<'a> Buffer for BufReader<'a> {
     #[inline]
-    fn fill_buf<'a>(&'a mut self) -> IoResult<&'a [u8]> {
+    fn fill_buf(&mut self) -> IoResult<&[u8]> {
         if self.pos < self.buf.len() {
             Ok(self.buf[self.pos..])
         } else {

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -981,7 +981,7 @@ impl<'a, R: Reader> Reader for RefReader<'a, R> {
 }
 
 impl<'a, R: Buffer> Buffer for RefReader<'a, R> {
-    fn fill_buf<'a>(&'a mut self) -> IoResult<&'a [u8]> { self.inner.fill_buf() }
+    fn fill_buf(&mut self) -> IoResult<&[u8]> { self.inner.fill_buf() }
     fn consume(&mut self, amt: uint) { self.inner.consume(amt) }
 }
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -468,8 +468,8 @@ pub struct ExtCtxt<'a> {
 }
 
 impl<'a> ExtCtxt<'a> {
-    pub fn new<'a>(parse_sess: &'a parse::ParseSess, cfg: ast::CrateConfig,
-                   ecfg: expand::ExpansionConfig) -> ExtCtxt<'a> {
+    pub fn new(parse_sess: &'a parse::ParseSess, cfg: ast::CrateConfig,
+               ecfg: expand::ExpansionConfig) -> ExtCtxt<'a> {
         let env = initial_syntax_expander_table(&ecfg);
         ExtCtxt {
             parse_sess: parse_sess,

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -275,8 +275,8 @@ impl<'a> StringReader<'a> {
     }
 
     /// Converts CRLF to LF in the given string, raising an error on bare CR.
-    fn translate_crlf<'a>(&self, start: BytePos,
-                          s: &'a str, errmsg: &'a str) -> str::CowString<'a> {
+    fn translate_crlf<'b>(&self, start: BytePos,
+                          s: &'b str, errmsg: &'b str) -> str::CowString<'b> {
         let mut i = 0u;
         while i < s.len() {
             let str::CharRange { ch, next } = s.char_range_at(i);

--- a/src/test/compile-fail/generic-lifetime-trait-impl.rs
+++ b/src/test/compile-fail/generic-lifetime-trait-impl.rs
@@ -19,7 +19,7 @@
 trait Bar<'a> {}
 
 trait Foo<'a> {
-    fn bar<'a, T: Bar<'a>>(self) -> &'a str;
+    fn bar<'b, T: Bar<'b>>(self) -> &'b str;
 }
 
 impl<'a> Foo<'a> for &'a str {

--- a/src/test/compile-fail/shadowed-lifetime.rs
+++ b/src/test/compile-fail/shadowed-lifetime.rs
@@ -1,0 +1,43 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that shadowed lifetimes generate an error.
+
+struct Foo<'a>(&'a int);
+
+impl<'a> Foo<'a> {
+    //~^ HELP shadowed lifetime `'a` declared here
+    fn shadow_in_method<'a>(&'a self) -> &'a int {
+        //~^ WARNING lifetime name `'a` shadows another lifetime name that is already in scope
+        //~| HELP deprecated
+        self.0
+    }
+
+    fn shadow_in_type<'b>(&'b self) -> &'b int {
+        //~^ HELP shadowed lifetime `'b` declared here
+        let x: for<'b> fn(&'b int) = panic!();
+        //~^ WARNING lifetime name `'b` shadows another lifetime name that is already in scope
+        //~| HELP deprecated
+        self.0
+    }
+
+    fn not_shadow_in_item<'b>(&'b self) {
+        struct Bar<'a, 'b>(&'a int, &'b int); // not a shadow, separate item
+        fn foo<'a, 'b>(x: &'a int, y: &'b int) { } // same
+    }
+}
+
+fn main() {
+    // intentional error that occurs after `resolve_lifetime` runs,
+    // just to ensure that this test fails to compile; when shadowed
+    // lifetimes become either an error or a proper lint, this will
+    // not be needed.
+    let x: int = 3u; //~ ERROR mismatched types
+}

--- a/src/test/compile-fail/unboxed-closure-sugar-equiv.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-equiv.rs
@@ -35,17 +35,17 @@ fn test<'a,'b>() {
     // Test that anonymous regions in `()` form are equivalent
     // to fresh bound regions, and that we can intermingle
     // named and anonymous as we choose:
-    eq::< for<'a,'b> Foo<(&'a int,&'b uint),uint>,
-          for<'a,'b> Foo(&'a int,&'b uint) -> uint            >();
-    eq::< for<'a,'b> Foo<(&'a int,&'b uint),uint>,
-          for<'a> Foo(&'a int,&uint) -> uint                  >();
-    eq::< for<'a,'b> Foo<(&'a int,&'b uint),uint>,
-          for<'b> Foo(&int,&'b uint) -> uint                  >();
-    eq::< for<'a,'b> Foo<(&'a int,&'b uint),uint>,
+    eq::< for<'x,'y> Foo<(&'x int,&'y uint),uint>,
+          for<'x,'y> Foo(&'x int,&'y uint) -> uint            >();
+    eq::< for<'x,'y> Foo<(&'x int,&'y uint),uint>,
+          for<'x> Foo(&'x int,&uint) -> uint                  >();
+    eq::< for<'x,'y> Foo<(&'x int,&'y uint),uint>,
+          for<'y> Foo(&int,&'y uint) -> uint                  >();
+    eq::< for<'x,'y> Foo<(&'x int,&'y uint),uint>,
           Foo(&int,&uint) -> uint                             >();
 
     // lifetime elision
-    eq::< for<'a,'b> Foo<(&'a int,), &'a int>,
+    eq::< for<'x> Foo<(&'x int,), &'x int>,
           Foo(&int) -> &int                                   >();
 
     // Errors expected:

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -52,14 +52,14 @@ pub fn bar() {
              ((::std::fmt::format as
                   fn(&core::fmt::Arguments<'_>) -> collections::string::String)((&((::std::fmt::Arguments::new
                                                                                        as
-                                                                                       fn(&'a [&'a str], &'a [core::fmt::Argument<'a>]) -> core::fmt::Arguments<'a>)((__STATIC_FMTSTR
-                                                                                                                                                                         as
-                                                                                                                                                                         &'static [&'static str]),
-                                                                                                                                                                     (&([]
-                                                                                                                                                                           as
-                                                                                                                                                                           [core::fmt::Argument<'_>, ..0])
-                                                                                                                                                                         as
-                                                                                                                                                                         &[core::fmt::Argument<'_>, ..0]))
+                                                                                       fn(&[&str], &[core::fmt::Argument<'_>]) -> core::fmt::Arguments<'_>)((__STATIC_FMTSTR
+                                                                                                                                                                as
+                                                                                                                                                                &'static [&'static str]),
+                                                                                                                                                            (&([]
+                                                                                                                                                                  as
+                                                                                                                                                                  [core::fmt::Argument<'_>, ..0])
+                                                                                                                                                                as
+                                                                                                                                                                &[core::fmt::Argument<'_>, ..0]))
                                                                                       as
                                                                                       core::fmt::Arguments<'_>)
                                                                                     as

--- a/src/test/run-pass/issue-6157.rs
+++ b/src/test/run-pass/issue-6157.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub trait OpInt<'a> { fn call<'a>(&'a mut self, int, int) -> int; }
+pub trait OpInt<'a> { fn call(&mut self, int, int) -> int; }
 
 impl<'a> OpInt<'a> for |int, int|: 'a -> int {
     fn call(&mut self, a:int, b:int) -> int {


### PR DESCRIPTION
per rfc 459
cc https://github.com/rust-lang/rust/issues/19390

One question is: should we start by warning, and only switch to hard error later? I think we discussed something like this in the meeting. 

r? @alexcrichton 
