### PR TITLE
libc::c_char is not necessarily i8

### DIFF
--- a/src/librustc_trans/back/lto.rs
+++ b/src/librustc_trans/back/lto.rs
@@ -144,7 +144,7 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
     // Internalize everything but the reachable symbols of the current module
     let cstrs: Vec<::std::c_str::CString> =
         reachable.iter().map(|s| s.to_c_str()).collect();
-    let arr: Vec<*const i8> = cstrs.iter().map(|c| c.as_ptr()).collect();
+    let arr: Vec<*const libc::c_char> = cstrs.iter().map(|c| c.as_ptr()).collect();
     let ptr = arr.as_ptr();
     unsafe {
         llvm::LLVMRustRunRestrictionPass(llmod,

--- a/src/librustrt/c_str.rs
+++ b/src/librustrt/c_str.rs
@@ -578,7 +578,7 @@ mod tests {
             assert_eq!(*buf.offset(0), 'f' as libc::c_char);
             assert_eq!(*buf.offset(1), 'o' as libc::c_char);
             assert_eq!(*buf.offset(2), 'o' as libc::c_char);
-            assert_eq!(*buf.offset(3), 0xffu8 as i8);
+            assert_eq!(*buf.offset(3), 0xffu8 as libc::c_char);
             assert_eq!(*buf.offset(4), 0);
         }
     }

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -374,7 +374,7 @@ pub fn getenv_as_bytes(n: &str) -> Option<Vec<u8>> {
             if s.is_null() {
                 None
             } else {
-                Some(CString::new(s as *const i8, false).as_bytes_no_nul().to_vec())
+                Some(CString::new(s as *const libc::c_char, false).as_bytes_no_nul().to_vec())
             }
         })
     }

--- a/src/test/run-pass/variadic-ffi.rs
+++ b/src/test/run-pass/variadic-ffi.rs
@@ -19,7 +19,7 @@ extern {
 }
 
 unsafe fn check<T>(expected: &str, f: |*mut c_char| -> T) {
-    let mut x = [0i8, ..50];
+    let mut x = [0 as c_char, ..50];
     f(&mut x[0] as *mut c_char);
     let res = CString::new(&x[0], false);
     assert_eq!(expected, res.as_str().unwrap());


### PR DESCRIPTION
On AArch64, libc::c_char is u8. There are some places in the code where i8 is assumed, which causes compilation errors.

(AArch64 is not officially supported yet, but this change does not hurt any other targets and makes the code future-proof.)
