### PR TITLE
metadata: Encode attributes for const items

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1042,6 +1042,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_bounds_and_type(rbml_w, ecx, &lookup_item_type(tcx, def_id));
         encode_name(rbml_w, item.ident.name);
         encode_path(rbml_w, path);
+        encode_attributes(rbml_w, item.attrs.as_slice());
         encode_inlined_item(ecx, rbml_w, IIItemRef(item));
         encode_visibility(rbml_w, vis);
         encode_stability(rbml_w, stab);

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -104,6 +104,10 @@ fn try_inline_def(cx: &DocContext, tcx: &ty::ctxt,
             record_extern_fqn(cx, did, clean::TypeStatic);
             clean::StaticItem(build_static(cx, tcx, did, mtbl))
         }
+        def::DefConst(did) => {
+            record_extern_fqn(cx, did, clean::TypeConst);
+            clean::ConstantItem(build_const(cx, tcx, did))
+        }
         _ => return None,
     };
     let fqn = csearch::get_item_path(tcx, did);
@@ -384,6 +388,24 @@ fn build_module(cx: &DocContext, tcx: &ty::ctxt,
                 decoder::DlField => panic!("unimplemented field"),
             }
         });
+    }
+}
+
+fn build_const(cx: &DocContext, tcx: &ty::ctxt,
+               did: ast::DefId) -> clean::Constant {
+    use rustc::middle::const_eval;
+    use syntax::print::pprust;
+
+    let expr = const_eval::lookup_const_by_id(tcx, did).unwrap_or_else(|| {
+        panic!("expected lookup_const_by_id to succeed for {}", did);
+    });
+    debug!("converting constant expr {} to snippet", expr);
+    let sn = pprust::expr_to_string(expr);
+    debug!("got snippet {}", sn);
+
+    clean::Constant {
+        type_: ty::lookup_item_type(tcx, did).ty.clean(cx),
+        expr: sn
     }
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1185,6 +1185,7 @@ pub enum TypeKind {
     TypeEnum,
     TypeFunction,
     TypeModule,
+    TypeConst,
     TypeStatic,
     TypeStruct,
     TypeTrait,
@@ -1818,7 +1819,7 @@ impl Clean<Item> for doctree::Static {
     }
 }
 
-#[deriving(Clone, Encodable, Decodable)]
+#[deriving(Clone, Encodable, Decodable, Show)]
 pub struct Constant {
     pub type_: Type,
     pub expr: String,

--- a/src/librustdoc/html/item_type.rs
+++ b/src/librustdoc/html/item_type.rs
@@ -76,6 +76,7 @@ impl ItemType {
             clean::TypeTrait    => ItemType::Trait,
             clean::TypeModule   => ItemType::Module,
             clean::TypeStatic   => ItemType::Static,
+            clean::TypeConst    => ItemType::Constant,
             clean::TypeVariant  => ItemType::Variant,
             clean::TypeTypedef  => ItemType::Typedef,
         }


### PR DESCRIPTION
Fix #19773

Together with #19774 (which this is rebased on):

Fix #18156, fix #19722, fix #19185

r? @alexcrichton (since this was your suggestion!)
