### PR TITLE
Enable ignoring tests based on architecture.

### DIFF
--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -148,7 +148,8 @@ pub fn is_test_ignored(config: &Config, testfile: &Path) -> bool {
         format!("ignore-{}", util::get_os(config.target.as_slice()))
     }
     fn ignore_arch(config: &Config) -> String {
-        format!("ignore-{}", util::get_arch(config.target.as_slice()))
+        format!("ignore-{}",
+                config.target.as_slice().split('-').next().unwrap())
     }
     fn ignore_stage(config: &Config) -> String {
         format!("ignore-{}",

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -144,8 +144,11 @@ pub fn load_props(testfile: &Path) -> TestProps {
 }
 
 pub fn is_test_ignored(config: &Config, testfile: &Path) -> bool {
-    fn ignore_target(config: &Config) -> String {
+    fn ignore_os(config: &Config) -> String {
         format!("ignore-{}", util::get_os(config.target.as_slice()))
+    }
+    fn ignore_arch(config: &Config) -> String {
+        format!("ignore-{}", util::get_arch(config.target.as_slice()))
     }
     fn ignore_stage(config: &Config) -> String {
         format!("ignore-{}",
@@ -209,7 +212,8 @@ pub fn is_test_ignored(config: &Config, testfile: &Path) -> bool {
 
     let val = iter_header(testfile, |ln| {
         !parse_name_directive(ln, "ignore-test") &&
-        !parse_name_directive(ln, ignore_target(config).as_slice()) &&
+        !parse_name_directive(ln, ignore_os(config).as_slice()) &&
+        !parse_name_directive(ln, ignore_arch(config).as_slice()) &&
         !parse_name_directive(ln, ignore_stage(config).as_slice()) &&
         !(config.mode == common::Pretty && parse_name_directive(ln, "ignore-pretty")) &&
         !(config.target != config.host && parse_name_directive(ln, "ignore-cross-compile")) &&

--- a/src/compiletest/util.rs
+++ b/src/compiletest/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -25,15 +25,6 @@ static OS_TABLE: &'static [(&'static str, &'static str)] = &[
     ("dragonfly", "dragonfly"),
 ];
 
-/// Table to help extracting architecture from triple
-static ARCH_TABLE: &'static [&'static str] = &[
-    "arm",
-    "mipsel",
-    "mips",
-    "x86_64",
-    "x86",
-];
-
 pub fn get_os(triple: &str) -> &'static str {
     for &(triple_os, os) in OS_TABLE.iter() {
         if triple.contains(triple_os) {
@@ -41,15 +32,6 @@ pub fn get_os(triple: &str) -> &'static str {
         }
     }
     panic!("Cannot determine OS from triple");
-}
-
-pub fn get_arch(triple: &str) -> &'static str {
-    for &triple_arch in ARCH_TABLE.iter() {
-        if triple.contains(triple_arch) {
-            return triple_arch
-        }
-    }
-    panic!("Cannot determine architecture from triple");
 }
 
 #[cfg(target_os = "windows")]

--- a/src/compiletest/util.rs
+++ b/src/compiletest/util.rs
@@ -25,6 +25,15 @@ static OS_TABLE: &'static [(&'static str, &'static str)] = &[
     ("dragonfly", "dragonfly"),
 ];
 
+/// Table to help extracting architecture from triple
+static ARCH_TABLE: &'static [&'static str] = &[
+    "arm",
+    "mips",
+    "mipsel",
+    "x86",
+    "x86_64",
+];
+
 pub fn get_os(triple: &str) -> &'static str {
     for &(triple_os, os) in OS_TABLE.iter() {
         if triple.contains(triple_os) {
@@ -32,6 +41,15 @@ pub fn get_os(triple: &str) -> &'static str {
         }
     }
     panic!("Cannot determine OS from triple");
+}
+
+pub fn get_arch(triple: &str) -> &'static str {
+    for &triple_arch in ARCH_TABLE.iter() {
+        if triple.contains(triple_arch) {
+            return triple_arch
+        }
+    }
+    panic!("Cannot determine architecture from triple");
 }
 
 #[cfg(target_os = "windows")]

--- a/src/compiletest/util.rs
+++ b/src/compiletest/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -28,10 +28,10 @@ static OS_TABLE: &'static [(&'static str, &'static str)] = &[
 /// Table to help extracting architecture from triple
 static ARCH_TABLE: &'static [&'static str] = &[
     "arm",
-    "mips",
     "mipsel",
-    "x86",
+    "mips",
     "x86_64",
+    "x86",
 ];
 
 pub fn get_os(triple: &str) -> &'static str {


### PR DESCRIPTION
Now, tests can only be ignored on OS basis. However, some tests - e.g., compile-fail/asm-misplaced-option.rs - should be skipped because of the target architecture. 

(Note: in the case of compile-fail/asm-misplaced-option.rs, #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] pub fn main() prevents the Intel assembly to be processed on another architecture but does not prevent compiletest to find and expect the warnings within main.)

So, this PR proposes to enhance compiletest to recognize // ignore-ARCH lines as well.
