### PR TITLE
Expansion should explicitly include enum

### DIFF
--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -64,6 +64,7 @@ pub fn cs_cmp(cx: &mut ExtCtxt, span: Span,
     let equals_path = cx.path_global(span,
                                      vec!(cx.ident_of("std"),
                                           cx.ident_of("cmp"),
+                                          cx.ident_of("Ordering"),
                                           cx.ident_of("Equal")));
 
     let cmp_path = vec![


### PR DESCRIPTION
In preparation for [removing the `std::cmp::Ordering` reexport](https://github.com/rust-lang/rust/issues/19253), this needs to be done to prevent errors like:

```
note: in expansion of #[deriving]
note: expansion site
error: unresolved name `std::cmp::Equal`
#[deriving(Clone, PartialEq, PartialOrd, Eq, Ord, Show)]
                                             ^~~
```
