### PR TITLE
Detect type inference failure when auto-dereferencing a pointer

### DIFF
--- a/src/test/compile-fail/issue-19692.rs
+++ b/src/test/compile-fail/issue-19692.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Homura;
+
+fn akemi(homura: Homura) {
+    let Some(ref madoka) = Some(homura.kaname()); //~ ERROR does not implement any method
+    madoka.clone(); //~ ERROR the type of this value must be known
+}
+
+fn main() { }


### PR DESCRIPTION
`check::autoderef()` returns a `ty_err` when it fails to infer the type. `probe::probe()` should respect this failure and fail together to prevent further corruption.

Fixes #19692.
Fixes #19583.
Fixes #19297.
