### PR TITLE
Deprecate more in-tree libs for crates.io

### DIFF
--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -79,7 +79,7 @@
 //! ```
 
 #![crate_name = "getopts"]
-#![experimental]
+#![experimental = "use the crates.io `getopts` library instead"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -158,7 +158,7 @@
 //! if logging is disabled, none of the components of the log will be executed.
 
 #![crate_name = "log"]
-#![experimental]
+#![experimental = "use the crates.io `log` library instead"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",

--- a/src/libregex/lib.rs
+++ b/src/libregex/lib.rs
@@ -362,7 +362,7 @@
 #![crate_name = "regex"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
-#![experimental]
+#![experimental = "use the crates.io `regex` library instead"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/",

--- a/src/libregex_macros/lib.rs
+++ b/src/libregex_macros/lib.rs
@@ -13,7 +13,7 @@
 
 #![crate_name = "regex_macros"]
 #![crate_type = "dylib"]
-#![experimental]
+#![experimental = "use the crates.io `regex_macros` library instead"]
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/")]


### PR DESCRIPTION
This commit deprecates a few more in-tree libs for their crates.io counterparts.
Note that this commit does not make use of the #[deprecated] tag to prevent
warnings from being generated for in-tree usage. Once #[unstable] warnings are
turned on then all external users will be warned to move.

These crates have all been duplicated in rust-lang/$crate repositories so
development can happen independently of the in-tree copies. We can explore at a
later date replacing the in-tree copies with the external copies, but at this
time the libraries have changed very little over the past few months so it's
unlikely for changes to be sent to both repos.

cc #19260
