### PR TITLE
libcore: make iterator adaptors `Clone`able

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1388,6 +1388,19 @@ pub struct Map<A, B, I: Iterator<A>, F: FnMut(A) -> B> {
     f: F,
 }
 
+// FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+impl<A, B, I, F> Clone for Map<A, B, I, F> where
+    I: Clone + Iterator<A>,
+    F: Clone + FnMut(A) -> B,
+{
+    fn clone(&self) -> Map<A, B, I, F> {
+        Map {
+            iter: self.iter.clone(),
+            f: self.f.clone(),
+        }
+    }
+}
+
 impl<A, B, I, F> Map<A, B, I, F> where I: Iterator<A>, F: FnMut(A) -> B {
     #[inline]
     fn do_map(&mut self, elt: Option<A>) -> Option<B> {
@@ -1449,6 +1462,19 @@ pub struct Filter<A, I, P> where I: Iterator<A>, P: FnMut(&A) -> bool {
     predicate: P,
 }
 
+// FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+impl<A, I, P> Clone for Filter<A, I, P> where
+    I: Clone + Iterator<A>,
+    P: Clone + FnMut(&A) -> bool,
+{
+    fn clone(&self) -> Filter<A, I, P> {
+        Filter {
+            iter: self.iter.clone(),
+            predicate: self.predicate.clone(),
+        }
+    }
+}
+
 #[unstable = "trait is unstable"]
 impl<A, I, P> Iterator<A> for Filter<A, I, P> where I: Iterator<A>, P: FnMut(&A) -> bool {
     #[inline]
@@ -1492,6 +1518,19 @@ impl<A, I, P> DoubleEndedIterator<A> for Filter<A, I, P> where
 pub struct FilterMap<A, B, I, F> where I: Iterator<A>, F: FnMut(A) -> Option<B> {
     iter: I,
     f: F,
+}
+
+// FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+impl<A, B, I, F> Clone for FilterMap<A, B, I, F> where
+    I: Clone + Iterator<A>,
+    F: Clone + FnMut(A) -> Option<B>,
+{
+    fn clone(&self) -> FilterMap<A, B, I, F> {
+        FilterMap {
+            iter: self.iter.clone(),
+            f: self.f.clone(),
+        }
+    }
 }
 
 #[unstable = "trait is unstable"]
@@ -1657,6 +1696,20 @@ pub struct SkipWhile<A, I, P> where I: Iterator<A>, P: FnMut(&A) -> bool {
     predicate: P,
 }
 
+// FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+impl<A, I, P> Clone for SkipWhile<A, I, P> where
+    I: Clone + Iterator<A>,
+    P: Clone + FnMut(&A) -> bool,
+{
+    fn clone(&self) -> SkipWhile<A, I, P> {
+        SkipWhile {
+            iter: self.iter.clone(),
+            flag: self.flag,
+            predicate: self.predicate.clone(),
+        }
+    }
+}
+
 #[unstable = "trait is unstable"]
 impl<A, I, P> Iterator<A> for SkipWhile<A, I, P> where I: Iterator<A>, P: FnMut(&A) -> bool {
     #[inline]
@@ -1684,6 +1737,20 @@ pub struct TakeWhile<A, I, P> where I: Iterator<A>, P: FnMut(&A) -> bool {
     iter: I,
     flag: bool,
     predicate: P,
+}
+
+// FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+impl<A, I, P> Clone for TakeWhile<A, I, P> where
+    I: Clone + Iterator<A>,
+    P: Clone + FnMut(&A) -> bool,
+{
+    fn clone(&self) -> TakeWhile<A, I, P> {
+        TakeWhile {
+            iter: self.iter.clone(),
+            flag: self.flag,
+            predicate: self.predicate.clone(),
+        }
+    }
 }
 
 #[unstable = "trait is unstable"]
@@ -1847,6 +1914,21 @@ pub struct Scan<A, B, I, St, F> where I: Iterator<A>, F: FnMut(&mut St, A) -> Op
     pub state: St,
 }
 
+// FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+impl<A, B, I, St, F> Clone for Scan<A, B, I, St, F> where
+    I: Clone + Iterator<A>,
+    St: Clone,
+    F: Clone + FnMut(&mut St, A) -> Option<B>,
+{
+    fn clone(&self) -> Scan<A, B, I, St, F> {
+        Scan {
+            iter: self.iter.clone(),
+            f: self.f.clone(),
+            state: self.state.clone(),
+        }
+    }
+}
+
 #[unstable = "trait is unstable"]
 impl<A, B, I, St, F> Iterator<B> for Scan<A, B, I, St, F> where
     I: Iterator<A>,
@@ -1874,6 +1956,22 @@ pub struct FlatMap<A, B, I, U, F> where I: Iterator<A>, U: Iterator<B>, F: FnMut
     f: F,
     frontiter: Option<U>,
     backiter: Option<U>,
+}
+
+// FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+impl<A, B, I, U, F> Clone for FlatMap<A, B, I, U, F> where
+    I: Clone + Iterator<A>,
+    U: Clone + Iterator<B>,
+    F: Clone + FnMut(A) -> U,
+{
+    fn clone(&self) -> FlatMap<A, B, I, U, F> {
+        FlatMap {
+            iter: self.iter.clone(),
+            f: self.f.clone(),
+            frontiter: self.frontiter.clone(),
+            backiter: self.backiter.clone(),
+        }
+    }
 }
 
 #[unstable = "trait is unstable"]
@@ -2020,6 +2118,19 @@ pub struct Inspect<A, I, F> where I: Iterator<A>, F: FnMut(&A) {
     f: F,
 }
 
+// FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+impl<A, I, F> Clone for Inspect<A, I, F> where
+    I: Clone + Iterator<A>,
+    F: Clone + FnMut(&A),
+{
+    fn clone(&self) -> Inspect<A, I, F> {
+        Inspect {
+            iter: self.iter.clone(),
+            f: self.f.clone(),
+        }
+    }
+}
+
 impl<A, I, F> Inspect<A, I, F> where I: Iterator<A>, F: FnMut(&A) {
     #[inline]
     fn do_inspect(&mut self, elt: Option<A>) -> Option<A> {
@@ -2112,6 +2223,19 @@ pub struct Unfold<A, St, F> where F: FnMut(&mut St) -> Option<A> {
     f: F,
     /// Internal state that will be passed to the closure on the next iteration
     pub state: St,
+}
+
+// FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+impl<A, St, F> Clone for Unfold<A, St, F> where
+    F: Clone + FnMut(&mut St) -> Option<A>,
+    St: Clone,
+{
+    fn clone(&self) -> Unfold<A, St, F> {
+        Unfold {
+            f: self.f.clone(),
+            state: self.state.clone(),
+        }
+    }
 }
 
 #[experimental]

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1291,6 +1291,17 @@ pub struct Splits<'a, T:'a, P> where P: FnMut(&T) -> bool {
     finished: bool
 }
 
+// FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+impl<'a, T, P> Clone for Splits<'a, T, P> where P: Clone + FnMut(&T) -> bool {
+    fn clone(&self) -> Splits<'a, T, P> {
+        Splits {
+            v: self.v,
+            pred: self.pred.clone(),
+            finished: self.finished,
+        }
+    }
+}
+
 #[experimental = "needs review"]
 impl<'a, T, P> Iterator<&'a [T]> for Splits<'a, T, P> where P: FnMut(&T) -> bool {
     #[inline]

--- a/src/test/run-pass/issue-12677.rs
+++ b/src/test/run-pass/issue-12677.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let s = "Hello";
+    let first = s.bytes();
+    let second = first.clone();
+
+    assert_eq!(first.collect::<Vec<u8>>(), second.collect::<Vec<u8>>())
+}


### PR DESCRIPTION
closes #12677 (cc @Valloric)
cc #15294

r? @aturon / @alexcrichton 

(Because of #19358 I had to move the struct bounds from the `where` clause into the parameter list)
