### PR TITLE
libsyntax: Make deriving also respect where bounds.

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1070,6 +1070,7 @@ impl<'a> State<'a> {
                         span: codemap::Span) -> IoResult<()> {
         try!(self.print_ident(ident));
         try!(self.print_generics(generics));
+        try!(self.print_where_clause(generics));
         if ast_util::struct_def_is_tuple_like(struct_def) {
             if !struct_def.fields.is_empty() {
                 try!(self.popen());

--- a/src/test/run-pass/issue-19358.rs
+++ b/src/test/run-pass/issue-19358.rs
@@ -1,0 +1,29 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Trait {}
+
+#[deriving(Show)]
+struct Foo<T: Trait> {
+    foo: T,
+}
+
+#[deriving(Show)]
+struct Bar<T> where T: Trait {
+    bar: T,
+}
+
+impl Trait for int {}
+
+fn main() {
+    let a = Foo { foo: 12i };
+    let b = Bar { bar: 12i };
+    println!("{} {}", a, b);
+}


### PR DESCRIPTION
Fixes #19358.
