### PR TITLE
Remove internal uses of the `NoCopy` marker

### DIFF
--- a/src/libcollections/btree/node.rs
+++ b/src/libcollections/btree/node.rs
@@ -18,7 +18,6 @@ pub use self::TraversalItem::*;
 use core::prelude::*;
 
 use core::{slice, mem, ptr, cmp, num, raw};
-use core::kinds::marker;
 use core::iter::Zip;
 use core::borrow::BorrowFrom;
 use alloc::heap;
@@ -175,7 +174,6 @@ fn calculate_offsets_generic<K, V>(capacity: uint, is_leaf: bool) -> (uint, uint
 struct RawItems<T> {
     head: *const T,
     tail: *const T,
-    marker: marker::NoCopy
 }
 
 impl<T> RawItems<T> {
@@ -188,13 +186,11 @@ impl<T> RawItems<T> {
             RawItems {
                 head: ptr,
                 tail: (ptr as uint + len) as *const T,
-                marker: marker::NoCopy
             }
         } else {
             RawItems {
                 head: ptr,
                 tail: ptr.offset(len as int),
-                marker: marker::NoCopy
             }
         }
     }

--- a/src/libcollections/ring_buf.rs
+++ b/src/libcollections/ring_buf.rs
@@ -402,7 +402,6 @@ impl<T> RingBuf<T> {
             cap: self.cap,
             ptr: self.ptr,
             marker: marker::ContravariantLifetime::<'a>,
-            marker2: marker::NoCopy
         }
     }
 
@@ -952,7 +951,6 @@ pub struct MutItems<'a, T:'a> {
     head: uint,
     cap: uint,
     marker: marker::ContravariantLifetime<'a>,
-    marker2: marker::NoCopy
 }
 
 impl<'a, T> Iterator<&'a mut T> for MutItems<'a, T> {

--- a/src/libcore/atomic.rs
+++ b/src/libcore/atomic.rs
@@ -15,7 +15,6 @@
 pub use self::Ordering::*;
 
 use intrinsics;
-use std::kinds::marker;
 use cell::UnsafeCell;
 use kinds::Copy;
 
@@ -23,28 +22,24 @@ use kinds::Copy;
 #[stable]
 pub struct AtomicBool {
     v: UnsafeCell<uint>,
-    nocopy: marker::NoCopy
 }
 
 /// A signed integer type which can be safely shared between threads.
 #[stable]
 pub struct AtomicInt {
     v: UnsafeCell<int>,
-    nocopy: marker::NoCopy
 }
 
 /// An unsigned integer type which can be safely shared between threads.
 #[stable]
 pub struct AtomicUint {
     v: UnsafeCell<uint>,
-    nocopy: marker::NoCopy
 }
 
 /// A raw pointer type which can be safely shared between threads.
 #[stable]
 pub struct AtomicPtr<T> {
     p: UnsafeCell<uint>,
-    nocopy: marker::NoCopy
 }
 
 /// Atomic memory orderings
@@ -87,15 +82,15 @@ impl Copy for Ordering {}
 /// An `AtomicBool` initialized to `false`.
 #[unstable = "may be renamed, pending conventions for static initalizers"]
 pub const INIT_ATOMIC_BOOL: AtomicBool =
-        AtomicBool { v: UnsafeCell { value: 0 }, nocopy: marker::NoCopy };
+        AtomicBool { v: UnsafeCell { value: 0 } };
 /// An `AtomicInt` initialized to `0`.
 #[unstable = "may be renamed, pending conventions for static initalizers"]
 pub const INIT_ATOMIC_INT: AtomicInt =
-        AtomicInt { v: UnsafeCell { value: 0 }, nocopy: marker::NoCopy };
+        AtomicInt { v: UnsafeCell { value: 0 } };
 /// An `AtomicUint` initialized to `0`.
 #[unstable = "may be renamed, pending conventions for static initalizers"]
 pub const INIT_ATOMIC_UINT: AtomicUint =
-        AtomicUint { v: UnsafeCell { value: 0, }, nocopy: marker::NoCopy };
+        AtomicUint { v: UnsafeCell { value: 0, } };
 
 // NB: Needs to be -1 (0b11111111...) to make fetch_nand work correctly
 const UINT_TRUE: uint = -1;
@@ -115,7 +110,7 @@ impl AtomicBool {
     #[stable]
     pub fn new(v: bool) -> AtomicBool {
         let val = if v { UINT_TRUE } else { 0 };
-        AtomicBool { v: UnsafeCell::new(val), nocopy: marker::NoCopy }
+        AtomicBool { v: UnsafeCell::new(val) }
     }
 
     /// Loads a value from the bool.
@@ -355,7 +350,7 @@ impl AtomicInt {
     #[inline]
     #[stable]
     pub fn new(v: int) -> AtomicInt {
-        AtomicInt {v: UnsafeCell::new(v), nocopy: marker::NoCopy}
+        AtomicInt {v: UnsafeCell::new(v)}
     }
 
     /// Loads a value from the int.
@@ -541,7 +536,7 @@ impl AtomicUint {
     #[inline]
     #[stable]
     pub fn new(v: uint) -> AtomicUint {
-        AtomicUint { v: UnsafeCell::new(v), nocopy: marker::NoCopy }
+        AtomicUint { v: UnsafeCell::new(v) }
     }
 
     /// Loads a value from the uint.
@@ -728,7 +723,7 @@ impl<T> AtomicPtr<T> {
     #[inline]
     #[stable]
     pub fn new(p: *mut T) -> AtomicPtr<T> {
-        AtomicPtr { p: UnsafeCell::new(p as uint), nocopy: marker::NoCopy }
+        AtomicPtr { p: UnsafeCell::new(p as uint) }
     }
 
     /// Loads a value from the pointer.

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -234,7 +234,6 @@ impl<T:PartialEq + Copy> PartialEq for Cell<T> {
 pub struct RefCell<T> {
     value: UnsafeCell<T>,
     borrow: Cell<BorrowFlag>,
-    nocopy: marker::NoCopy,
     noshare: marker::NoSync,
 }
 
@@ -251,7 +250,6 @@ impl<T> RefCell<T> {
         RefCell {
             value: UnsafeCell::new(value),
             borrow: Cell::new(UNUSED),
-            nocopy: marker::NoCopy,
             noshare: marker::NoSync,
         }
     }

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -611,13 +611,11 @@ impl<T> SlicePrelude<T> for [T] {
             if mem::size_of::<T>() == 0 {
                 MutItems{ptr: p,
                          end: (p as uint + self.len()) as *mut T,
-                         marker: marker::ContravariantLifetime::<'a>,
-                         marker2: marker::NoCopy}
+                         marker: marker::ContravariantLifetime::<'a>}
             } else {
                 MutItems{ptr: p,
                          end: p.offset(self.len() as int),
-                         marker: marker::ContravariantLifetime::<'a>,
-                         marker2: marker::NoCopy}
+                         marker: marker::ContravariantLifetime::<'a>}
             }
         }
     }
@@ -1215,7 +1213,6 @@ pub struct MutItems<'a, T: 'a> {
     ptr: *mut T,
     end: *mut T,
     marker: marker::ContravariantLifetime<'a>,
-    marker2: marker::NoCopy
 }
 
 #[experimental]

--- a/src/librustc/util/snapshot_vec.rs
+++ b/src/librustc/util/snapshot_vec.rs
@@ -20,7 +20,6 @@
 //! those changes.
 use self::UndoLog::*;
 
-use std::kinds::marker;
 use std::mem;
 
 #[deriving(PartialEq)]
@@ -47,10 +46,9 @@ pub struct SnapshotVec<T,U,D> {
     delegate: D
 }
 
+// Snapshots are tokens that should be created/consumed linearly.
+#[allow(missing_copy_implementations)]
 pub struct Snapshot {
-    // Snapshots are tokens that should be created/consumed linearly.
-    marker: marker::NoCopy,
-
     // Length of the undo log at the time the snapshot was taken.
     length: uint,
 }
@@ -112,8 +110,7 @@ impl<T,U,D:SnapshotVecDelegate<T,U>> SnapshotVec<T,U,D> {
     pub fn start_snapshot(&mut self) -> Snapshot {
         let length = self.undo_log.len();
         self.undo_log.push(OpenSnapshot);
-        Snapshot { length: length,
-                   marker: marker::NoCopy }
+        Snapshot { length: length }
     }
 
     fn assert_open_snapshot(&self, snapshot: &Snapshot) {

--- a/src/librustrt/task.rs
+++ b/src/librustrt/task.rs
@@ -20,7 +20,6 @@ use alloc::boxed::Box;
 use core::any::Any;
 use core::atomic::{AtomicUint, SeqCst};
 use core::iter::{IteratorExt, Take};
-use core::kinds::marker;
 use core::ops::FnOnce;
 use core::mem;
 use core::ops::FnMut;
@@ -95,7 +94,6 @@ pub enum BlockedTask {
 /// Per-task state related to task death, killing, panic, etc.
 pub struct Death {
     pub on_exit: Option<Thunk<Result>>,
-    marker: marker::NoCopy,
 }
 
 pub struct BlockedTasks {
@@ -499,7 +497,7 @@ impl BlockedTask {
 
 impl Death {
     pub fn new() -> Death {
-        Death { on_exit: None, marker: marker::NoCopy }
+        Death { on_exit: None }
     }
 }
 

--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -186,9 +186,8 @@ mod imp {
     ///   service provider with the `PROV_RSA_FULL` type.
     /// - iOS: calls SecRandomCopyBytes as /dev/(u)random is sandboxed
     /// This does not block.
-    pub struct OsRng {
-        marker: marker::NoCopy
-    }
+    #[allow(missing_copy_implementations)]
+    pub struct OsRng;
 
     #[repr(C)]
     struct SecRandom;
@@ -205,7 +204,7 @@ mod imp {
     impl OsRng {
         /// Create a new `OsRng`.
         pub fn new() -> IoResult<OsRng> {
-            Ok(OsRng {marker: marker::NoCopy} )
+            Ok(OsRng)
         }
     }
 

--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -187,7 +187,10 @@ mod imp {
     /// - iOS: calls SecRandomCopyBytes as /dev/(u)random is sandboxed
     /// This does not block.
     #[allow(missing_copy_implementations)]
-    pub struct OsRng;
+    pub struct OsRng {
+        // dummy field to ensure that this struct cannot be constructed outside of this module
+        _dummy: (),
+    }
 
     #[repr(C)]
     struct SecRandom;
@@ -204,7 +207,7 @@ mod imp {
     impl OsRng {
         /// Create a new `OsRng`.
         pub fn new() -> IoResult<OsRng> {
-            Ok(OsRng)
+            Ok(OsRng { _dummy: () })
         }
     }
 

--- a/src/libstd/sys/common/thread_local.rs
+++ b/src/libstd/sys/common/thread_local.rs
@@ -58,7 +58,6 @@
 
 use prelude::*;
 
-use kinds::marker;
 use rustrt::exclusive::Exclusive;
 use sync::atomic::{mod, AtomicUint};
 use sync::{Once, ONCE_INIT};
@@ -100,7 +99,6 @@ pub struct StaticKey {
 /// Inner contents of `StaticKey`, created by the `INIT_INNER` constant.
 pub struct StaticKeyInner {
     key: AtomicUint,
-    nc: marker::NoCopy,
 }
 
 /// A type for a safely managed OS-based TLS slot.
@@ -141,7 +139,6 @@ pub const INIT: StaticKey = StaticKey {
 /// This value allows specific configuration of the destructor for a TLS key.
 pub const INIT_INNER: StaticKeyInner = StaticKeyInner {
     key: atomic::INIT_ATOMIC_UINT,
-    nc: marker::NoCopy,
 };
 
 static INIT_KEYS: Once = ONCE_INIT;

--- a/src/libstd/task.rs
+++ b/src/libstd/task.rs
@@ -49,7 +49,7 @@ use boxed::Box;
 use comm::channel;
 use core::ops::FnOnce;
 use io::{Writer, stdio};
-use kinds::{Send, marker};
+use kinds::Send;
 use option::Option;
 use option::Option::{None, Some};
 use result::Result;
@@ -83,7 +83,6 @@ pub struct TaskBuilder {
     stderr: Option<Box<Writer + Send>>,
     // Optionally wrap the eventual task body
     gen_body: Option<Thunk<Thunk, Thunk>>,
-    nocopy: marker::NoCopy,
 }
 
 impl TaskBuilder {
@@ -96,7 +95,6 @@ impl TaskBuilder {
             stdout: None,
             stderr: None,
             gen_body: None,
-            nocopy: marker::NoCopy,
         }
     }
 }
@@ -137,7 +135,7 @@ impl TaskBuilder {
         on_exit: Option<Thunk<task::Result>>)
     {
         let TaskBuilder {
-            name, stack_size, stdout, stderr, mut gen_body, nocopy: _
+            name, stack_size, stdout, stderr, mut gen_body
         } = self;
 
         let f = match gen_body.take() {

--- a/src/libstd/thread_local/mod.rs
+++ b/src/libstd/thread_local/mod.rs
@@ -185,7 +185,6 @@ macro_rules! __thread_local_inner(
                 inner: ::std::cell::UnsafeCell { value: $init },
                 dtor_registered: ::std::cell::UnsafeCell { value: false },
                 dtor_running: ::std::cell::UnsafeCell { value: false },
-                marker: ::std::kinds::marker::NoCopy,
             }
         };
 
@@ -247,7 +246,6 @@ mod imp {
 
     use cell::UnsafeCell;
     use intrinsics;
-    use kinds::marker;
     use ptr;
 
     #[doc(hidden)]
@@ -264,9 +262,6 @@ mod imp {
         // these variables are thread-local, not global.
         pub dtor_registered: UnsafeCell<bool>, // should be Cell
         pub dtor_running: UnsafeCell<bool>, // should be Cell
-
-        // These shouldn't be copied around.
-        pub marker: marker::NoCopy,
     }
 
     #[doc(hidden)]


### PR DESCRIPTION
r? @aturon / @alexcrichton
