### PR TITLE
Fix indentation in a code example in the ownership guide.

### DIFF
--- a/src/doc/guide-ownership.md
+++ b/src/doc/guide-ownership.md
@@ -341,7 +341,7 @@ fn main() {
     {                         //  |
         let y = &5i;          // ---+ y goes into scope
         let f = Foo { x: y }; // ---+ f goes into scope
-	x = &f.x;	      //  | | error here
+        x = &f.x;             //  | | error here
     }                         // ---+ f & y go out of scope
                               //  |
     println!("{}", x);        //  |


### PR DESCRIPTION
For reference, this is what the code example looks like before the change:

![screen shot 2014-12-14 at 12 12 58 pm](https://cloud.githubusercontent.com/assets/694063/5428475/ade24176-838a-11e4-870b-c7d4f55bc8d7.png)
