### PR TITLE
std: Bind port early to make a test more reliable

### DIFF
--- a/src/libstd/io/net/udp.rs
+++ b/src/libstd/io/net/udp.rs
@@ -557,11 +557,12 @@ mod test {
         let addr1 = next_test_ip4();
         let addr2 = next_test_ip4();
         let mut a = UdpSocket::bind(addr1).unwrap();
+        let a2 = UdpSocket::bind(addr2).unwrap();
 
         let (tx, rx) = channel();
         let (tx2, rx2) = channel();
         spawn(move|| {
-            let mut a = UdpSocket::bind(addr2).unwrap();
+            let mut a = a2;
             assert_eq!(a.recv_from(&mut [0]), Ok((1, addr1)));
             assert_eq!(a.send_to(&[0], addr1), Ok(()));
             rx.recv();


### PR DESCRIPTION
This test would read with a timeout and then send a UDP message, expecting the
message to be received. The receiving port, however, was bound in the child
thread so it could be the case that the timeout and send happens before the
child thread runs. To remedy this we just bind the port before the child thread
runs, moving it into the child later on.

cc #19120
