### PR TITLE
impl `Copy` for `NoSend`/`NoSync`

### DIFF
--- a/src/libcore/kinds.rs
+++ b/src/libcore/kinds.rs
@@ -264,8 +264,7 @@ pub mod marker {
     /// typically embedded in other types, such as `Gc`, to ensure that
     /// their instances remain thread-local.
     #[lang="no_send_bound"]
-    #[deriving(Clone, PartialEq, Eq, PartialOrd, Ord)]
-    #[allow(missing_copy_implementations)]
+    #[deriving(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
     pub struct NoSend;
 
     /// A type which is considered "not POD", meaning that it is not
@@ -280,8 +279,7 @@ pub mod marker {
     /// its contents are not threadsafe, hence they cannot be
     /// shared between tasks.
     #[lang="no_sync_bound"]
-    #[deriving(Clone, PartialEq, Eq, PartialOrd, Ord)]
-    #[allow(missing_copy_implementations)]
+    #[deriving(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
     pub struct NoSync;
 
     /// A type which is considered managed by the GC. This is typically


### PR DESCRIPTION
Necessary to implement `Copy` on structs like this one:

``` rust
struct Slice<'a, T> {
    _contravariant: marker::ContravariantLifetime<'a>,
    _nosend: marker::NoSend,
    data: *const T,
    length: uint,
}
```

r? @alexcrichton 
