### PR TITLE
Multi-line errors

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -966,6 +966,16 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
         line.starts_with( prefix )
     }
 
+    // A multi-line error will have followup lines which will always
+    // start with one of these strings.
+    fn continuation( line: &str) -> bool {
+        line.starts_with(" expected") ||
+        line.starts_with("    found") ||
+        //                1234
+        // Should have 4 spaces: see issue 18946
+        line.starts_with("(")
+    }
+
     // Scan and extract our error/warning messages,
     // which look like:
     //    filename:line1:col1: line2:col2: *error:* msg
@@ -981,7 +991,7 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
                        ee.kind,
                        ee.msg,
                        line);
-                if prefix_matches(line, prefixes[i].as_slice()) &&
+                if (prefix_matches(line, prefixes[i].as_slice()) || continuation(line)) &&
                     line.contains(ee.kind.as_slice()) &&
                     line.contains(ee.msg.as_slice()) {
                     found_flags[i] = true;

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -35,6 +35,7 @@ extern crate flate;
 extern crate getopts;
 extern crate graphviz;
 extern crate libc;
+extern crate regex;
 extern crate rustc_llvm;
 extern crate rustc_back;
 extern crate serialize;

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4702,7 +4702,7 @@ pub fn ty_sort_string<'tcx>(cx: &ctxt<'tcx>, ty: Ty<'tcx>) -> String {
         }
         ty_tup(ref tys) if tys.is_empty() => ::util::ppaux::ty_to_string(cx, ty),
 
-        ty_enum(id, _) => format!("enum {}", item_path_str(cx, id)),
+        ty_enum(id, _) => format!("enum `{}`", item_path_str(cx, id)),
         ty_uniq(_) => "box".to_string(),
         ty_vec(_, Some(n)) => format!("array of {} elements", n),
         ty_vec(_, None) => "slice".to_string(),
@@ -4714,7 +4714,7 @@ pub fn ty_sort_string<'tcx>(cx: &ctxt<'tcx>, ty: Ty<'tcx>) -> String {
             format!("trait {}", item_path_str(cx, inner.principal_def_id()))
         }
         ty_struct(id, _) => {
-            format!("struct {}", item_path_str(cx, id))
+            format!("struct `{}`", item_path_str(cx, id))
         }
         ty_unboxed_closure(..) => "closure".to_string(),
         ty_tup(_) => "tuple".to_string(),

--- a/src/test/compile-fail/array-not-vector.rs
+++ b/src/test/compile-fail/array-not-vector.rs
@@ -9,8 +9,18 @@
 // except according to those terms.
 
 fn main() {
-    let _x: isize = [1is, 2, 3]; //~ ERROR expected isize, found array of 3 elements
+    let _x: isize = [1is, 2, 3];
+    //~^ ERROR mismatched types
+    //~| expected `isize`
+    //~| found `[isize; 3]`
+    //~| expected isize
+    //~| found array of 3 elements
 
     let x: &[isize] = &[1, 2, 3];
-    let _y: &isize = x; //~ ERROR expected isize, found slice
+    let _y: &isize = x;
+    //~^ ERROR mismatched types
+    //~| expected `&isize`
+    //~| found `&[isize]`
+    //~| expected isize
+    //~| found slice
 }

--- a/src/test/compile-fail/associated-types-eq-3.rs
+++ b/src/test/compile-fail/associated-types-eq-3.rs
@@ -30,7 +30,12 @@ fn foo1<I: Foo<A=Bar>>(x: I) {
 }
 
 fn foo2<I: Foo>(x: I) {
-    let _: Bar = x.boo(); //~ERROR mismatched types
+    let _: Bar = x.boo();
+    //~^ ERROR mismatched types
+    //~| expected `Bar`
+    //~| found `<I as Foo>::A`
+    //~| expected struct `Bar`
+    //~| found associated type
 }
 
 
@@ -41,6 +46,12 @@ pub fn baz(x: &Foo<A=Bar>) {
 
 pub fn main() {
     let a = 42is;
-    foo1(a); //~ERROR expected usize, found struct Bar
-    baz(&a); //~ERROR expected usize, found struct Bar
+    foo1(a);
+    //~^ ERROR type mismatch resolving
+    //~| expected usize
+    //~| found struct `Bar`
+    baz(&a);
+    //~^ ERROR type mismatch resolving
+    //~| expected usize
+    //~| found struct `Bar`
 }

--- a/src/test/compile-fail/associated-types-path-2.rs
+++ b/src/test/compile-fail/associated-types-path-2.rs
@@ -25,7 +25,9 @@ pub fn f2<T: Foo>(a: T) -> T::A {
 
 pub fn f1_int_int() {
     f1(2is, 4is);
-    //~^ ERROR expected usize, found isize
+    //~^ ERROR type mismatch resolving
+    //~| expected usize
+    //~| found isize
 }
 
 pub fn f1_int_uint() {
@@ -46,7 +48,11 @@ pub fn f1_uint_int() {
 
 pub fn f2_int() {
     let _: isize = f2(2is);
-    //~^ ERROR expected `isize`, found `usize`
+    //~^ ERROR mismatched types
+    //~| expected `isize`
+    //~| found `usize`
+    //~| expected isize
+    //~| found usize
 }
 
 pub fn main() { }

--- a/src/test/compile-fail/bad-const-type.rs
+++ b/src/test/compile-fail/bad-const-type.rs
@@ -8,7 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:expected `collections::string::String`, found `isize`
-
 static i: String = 10is;
+//~^ ERROR mismatched types
+//~| expected `collections::string::String`
+//~| found `isize`
+//~| expected struct `collections::string::String`
+//~| found isize
 fn main() { println!("{}", i); }

--- a/src/test/compile-fail/block-must-not-have-result-do.rs
+++ b/src/test/compile-fail/block-must-not-have-result-do.rs
@@ -8,10 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:mismatched types: expected `()`, found `bool`
-
 fn main() {
     loop {
-        true
+        true //~  ERROR mismatched types
+             //~| expected ()
+             //~| found bool
+             //~| expected ()
+             //~| found bool
     }
 }

--- a/src/test/compile-fail/block-must-not-have-result-res.rs
+++ b/src/test/compile-fail/block-must-not-have-result-res.rs
@@ -8,13 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:mismatched types: expected `()`, found `bool`
-
 struct r;
 
 impl Drop for r {
     fn drop(&mut self) {
-        true
+        true //~  ERROR mismatched types
+             //~| expected ()
+             //~| found bool
+             //~| expected ()
+             //~| found bool
     }
 }
 

--- a/src/test/compile-fail/block-must-not-have-result-while.rs
+++ b/src/test/compile-fail/block-must-not-have-result-while.rs
@@ -8,10 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:mismatched types: expected `()`, found `bool`
-
 fn main() {
     while true {
-        true
+        true //~  ERROR mismatched types
+             //~| expected `()`
+             //~| found `bool`
+             //~| expected ()
+             //~| found bool
     }
 }

--- a/src/test/compile-fail/coercion-slice.rs
+++ b/src/test/compile-fail/coercion-slice.rs
@@ -11,5 +11,10 @@
 // Tests that we forbid coercion from `[T; n]` to `&[T]`
 
 fn main() {
-    let _: &[isize] = [0is]; //~ERROR: mismatched types: expected `&[isize]`, found `[isize; 1]`
+    let _: &[isize] = [0is];
+    //~^ ERROR mismatched types
+    //~| expected `&[isize]`
+    //~| found `[isize; 1]`
+    //~| expected &-ptr
+    //~| found array of 1 elements
 }

--- a/src/test/compile-fail/const-cast-different-types.rs
+++ b/src/test/compile-fail/const-cast-different-types.rs
@@ -10,9 +10,17 @@
 
 static a: &'static str = "foo";
 static b: *const u8 = a as *const u8;
-//~^ ERROR mismatched types: expected `*const u8`, found `&'static str`
+//~^ ERROR mismatched types
+//~| expected *const u8
+//~| found &'static str
+//~| expected u8
+//~| found str
 static c: *const u8 = &a as *const u8;
-//~^ ERROR mismatched types: expected `*const u8`, found `&&'static str`
+//~^ ERROR mismatched types
+//~| expected *const u8
+//~| found &&'static str
+//~| expected u8
+//~| found &-ptr
 
 fn main() {
 }

--- a/src/test/compile-fail/cross-borrow-trait.rs
+++ b/src/test/compile-fail/cross-borrow-trait.rs
@@ -19,6 +19,10 @@ impl Trait for Foo {}
 
 pub fn main() {
     let x: Box<Trait> = box Foo;
-    let _y: &Trait = x; //~ ERROR mismatched types: expected `&Trait`, found `Box<Trait>`
+    let _y: &Trait = x; //~  ERROR mismatched types
+                        //~| expected `&Trait`
+                        //~| found `Box<Trait>`
+                        //~| expected &-ptr
+                        //~| found box
 }
 

--- a/src/test/compile-fail/destructure-trait-ref.rs
+++ b/src/test/compile-fail/destructure-trait-ref.rs
@@ -37,7 +37,22 @@ fn main() {
     let box x = box 1is as Box<T>; //~ ERROR type `Box<T>` cannot be dereferenced
 
     // n > m
-    let &&x = &1is as &T;     //~ ERROR found &-ptr
-    let &&&x = &(&1is as &T); //~ ERROR found &-ptr
-    let box box x = box 1is as Box<T>;    //~ ERROR found box
+    let &&x = &1is as &T;
+    //~^ ERROR mismatched types
+    //~| expected `T`
+    //~| found `&_`
+    //~| expected trait T
+    //~| found &-ptr
+    let &&&x = &(&1is as &T);
+    //~^ ERROR mismatched types
+    //~| expected `T`
+    //~| found `&_`
+    //~| expected trait T
+    //~| found &-ptr
+    let box box x = box 1is as Box<T>;
+    //~^ ERROR mismatched types
+    //~| expected `T`
+    //~| found `Box<_>`
+    //~| expected trait T
+    //~| found box
 }

--- a/src/test/compile-fail/dst-bad-assign.rs
+++ b/src/test/compile-fail/dst-bad-assign.rs
@@ -44,6 +44,11 @@ pub fn main() {
     // Assignment.
     let f5: &mut Fat<ToBar> = &mut Fat { f1: 5, f2: "some str", ptr: Bar1 {f :42} };
     let z: Box<ToBar> = box Bar1 {f: 36};
-    f5.ptr = Bar1 {f: 36}; //~ ERROR mismatched types: expected `ToBar`, found `Bar1`
-    //~^ ERROR the trait `core::marker::Sized` is not implemented for the type `ToBar`
+    f5.ptr = Bar1 {f: 36};
+    //~^ ERROR mismatched types
+    //~| expected `ToBar`
+    //~| found `Bar1`
+    //~| expected trait ToBar
+    //~| found struct `Bar1`
+    //~| ERROR the trait `core::marker::Sized` is not implemented for the type `ToBar`
 }

--- a/src/test/compile-fail/dst-bad-coerce1.rs
+++ b/src/test/compile-fail/dst-bad-coerce1.rs
@@ -22,7 +22,11 @@ pub fn main() {
     let f1 = Fat { ptr: [1, 2, 3] };
     let f2: &Fat<[isize; 3]> = &f1;
     let f3: &Fat<[usize]> = f2;
-    //~^ ERROR mismatched types: expected `&Fat<[usize]>`, found `&Fat<[isize; 3]>`
+    //~^ ERROR mismatched types
+    //~| expected `&Fat<[usize]>`
+    //~| found `&Fat<[isize; 3]>`
+    //~| expected usize
+    //~| found isize
 
     // With a trait.
     let f1 = Fat { ptr: Foo };

--- a/src/test/compile-fail/dst-bad-coerce4.rs
+++ b/src/test/compile-fail/dst-bad-coerce4.rs
@@ -18,5 +18,9 @@ pub fn main() {
     // With a vec of isizes.
     let f1: &Fat<[isize]> = &Fat { ptr: [1, 2, 3] };
     let f2: &Fat<[isize; 3]> = f1;
-    //~^ ERROR mismatched types: expected `&Fat<[isize; 3]>`, found `&Fat<[isize]>`
+    //~^ ERROR mismatched types
+    //~| expected `&Fat<[isize; 3]>`
+    //~| found `&Fat<[isize]>`
+    //~| expected array of 3 elements
+    //~| found slice
 }

--- a/src/test/compile-fail/explicit-self-lifetime-mismatch.rs
+++ b/src/test/compile-fail/explicit-self-lifetime-mismatch.rs
@@ -15,8 +15,14 @@ struct Foo<'a,'b> {
 
 impl<'a,'b> Foo<'a,'b> {
     fn bar(self: Foo<'b,'a>) {}
-    //~^ ERROR mismatched types: expected `Foo<'a, 'b>`, found `Foo<'b, 'a>`
-    //~^^ ERROR mismatched types: expected `Foo<'a, 'b>`, found `Foo<'b, 'a>`
+    //~^ ERROR mismatched types
+    //~| expected `Foo<'a, 'b>`
+    //~| found `Foo<'b, 'a>`
+    //~| lifetime mismatch
+    //~| ERROR mismatched types
+    //~| expected `Foo<'a, 'b>`
+    //~| found `Foo<'b, 'a>`
+    //~| lifetime mismatch
 }
 
 fn main() {}

--- a/src/test/compile-fail/fn-item-type.rs
+++ b/src/test/compile-fail/fn-item-type.rs
@@ -18,8 +18,16 @@ fn eq<T>(x: T, y: T) { }
 
 fn main() {
     let f = if true { foo } else { bar };
-    //~^ ERROR expected fn item, found a different fn item
+    //~^ ERROR if and else have incompatible types
+    //~| expected `fn(isize) -> isize {foo}`
+    //~| found `fn(isize) -> isize {bar}`
+    //~| expected fn item,
+    //~| found a different fn item
 
     eq(foo, bar);
-    //~^ ERROR expected fn item, found a different fn item
+    //~^ ERROR mismatched types
+    //~|  expected `fn(isize) -> isize {foo}`
+    //~|  found `fn(isize) -> isize {bar}`
+    //~|  expected fn item
+    //~|  found a different fn item
 }

--- a/src/test/compile-fail/fn-trait-formatting.rs
+++ b/src/test/compile-fail/fn-trait-formatting.rs
@@ -14,12 +14,25 @@
 fn needs_fn<F>(x: F) where F: Fn(isize) -> isize {}
 
 fn main() {
-    let _: () = (box |:_: isize| {}) as Box<FnOnce(isize)>; //~ ERROR object-safe
-    //~^ ERROR Box<core::ops::FnOnce(isize)>
+    let _: () = (box |:_: isize| {}) as Box<FnOnce(isize)>;
+    //~^ ERROR object-safe
+    //~| ERROR mismatched types
+    //~| expected `()`
+    //~| found `Box<core::ops::FnOnce(isize)>`
+    //~| expected ()
+    //~| found box
     let _: () = (box |&:_: isize, isize| {}) as Box<Fn(isize, isize)>;
-    //~^ ERROR Box<core::ops::Fn(isize, isize)>
+    //~^ ERROR mismatched types
+    //~| expected `()`
+    //~| found `Box<core::ops::Fn(isize, isize)>`
+    //~| expected ()
+    //~| found box
     let _: () = (box |&mut:| -> isize unimplemented!()) as Box<FnMut() -> isize>;
-    //~^ ERROR Box<core::ops::FnMut() -> isize>
+    //~^ ERROR mismatched types
+    //~| expected `()`
+    //~| found `Box<core::ops::FnMut() -> isize>`
+    //~| expected ()
+    //~| found box
 
     needs_fn(1is); //~ ERROR `core::ops::Fn(isize) -> isize`
 }

--- a/src/test/compile-fail/fully-qualified-type-name1.rs
+++ b/src/test/compile-fail/fully-qualified-type-name1.rs
@@ -13,5 +13,9 @@
 fn main() {
     let x: Option<usize>;
     x = 5;
-    //~^ ERROR mismatched types: expected `core::option::Option<usize>`
+    //~^ ERROR mismatched types
+    //~| expected `core::option::Option<usize>`
+    //~| found `_`
+    //~| expected enum `core::option::Option`
+    //~| found integral variable
 }

--- a/src/test/compile-fail/fully-qualified-type-name2.rs
+++ b/src/test/compile-fail/fully-qualified-type-name2.rs
@@ -20,7 +20,11 @@ mod y {
 
 fn bar(x: x::foo) -> y::foo {
     return x;
-    //~^ ERROR mismatched types: expected `y::foo`, found `x::foo`
+    //~^ ERROR mismatched types
+    //~| expected `y::foo`
+    //~| found `x::foo`
+    //~| expected enum `y::foo`
+    //~| found enum `x::foo`
 }
 
 fn main() {

--- a/src/test/compile-fail/fully-qualified-type-name4.rs
+++ b/src/test/compile-fail/fully-qualified-type-name4.rs
@@ -14,7 +14,11 @@ use std::option::Option;
 
 fn bar(x: usize) -> Option<usize> {
     return x;
-    //~^ ERROR mismatched types: expected `core::option::Option<usize>`
+    //~^ ERROR mismatched types
+    //~| expected `core::option::Option<usize>`
+    //~| found `usize`
+    //~| expected enum `core::option::Option`
+    //~| found usize
 }
 
 fn main() {

--- a/src/test/compile-fail/generic-type-params-name-repr.rs
+++ b/src/test/compile-fail/generic-type-params-name-repr.rs
@@ -19,23 +19,47 @@ struct HashMap<K, V, H = Hash<K>>;
 fn main() {
     // Ensure that the printed type doesn't include the default type params...
     let _: Foo<isize> = ();
-    //~^ ERROR mismatched types: expected `Foo<isize>`, found `()`
+    //~^ ERROR mismatched types
+    //~| expected `Foo<isize>`
+    //~| found `()`
+    //~| expected struct `Foo`
+    //~| found ()
 
     // ...even when they're present, but the same types as the defaults.
     let _: Foo<isize, B, C> = ();
-    //~^ ERROR mismatched types: expected `Foo<isize>`, found `()`
+    //~^ ERROR mismatched types
+    //~| expected `Foo<isize>`
+    //~| found `()`
+    //~| expected struct `Foo`
+    //~| found ()
 
     // Including cases where the default is using previous type params.
     let _: HashMap<String, isize> = ();
-    //~^ ERROR mismatched types: expected `HashMap<collections::string::String, isize>`, found `()`
+    //~^ ERROR mismatched types
+    //~| expected `HashMap<collections::string::String, isize>`
+    //~| found `()`
+    //~| expected struct `HashMap`
+    //~| found ()
     let _: HashMap<String, isize, Hash<String>> = ();
-    //~^ ERROR mismatched types: expected `HashMap<collections::string::String, isize>`, found `()`
+    //~^ ERROR mismatched types
+    //~| expected `HashMap<collections::string::String, isize>`
+    //~| found `()`
+    //~| expected struct `HashMap`
+    //~| found ()
 
     // But not when there's a different type in between.
     let _: Foo<A, isize, C> = ();
-    //~^ ERROR mismatched types: expected `Foo<A, isize>`, found `()`
+    //~^ ERROR mismatched types
+    //~| expected `Foo<A, isize>`
+    //~| found `()`
+    //~| expected struct `Foo`
+    //~| found ()
 
     // And don't print <> at all when there's just defaults.
     let _: Foo<A, B, C> = ();
-    //~^ ERROR mismatched types: expected `Foo`, found `()`
+    //~^ ERROR mismatched types
+    //~| expected `Foo`
+    //~| found `()`
+    //~| expected struct `Foo`
+    //~| found ()
 }

--- a/src/test/compile-fail/if-branch-types.rs
+++ b/src/test/compile-fail/if-branch-types.rs
@@ -10,5 +10,9 @@
 
 fn main() {
     let x = if true { 10is } else { 10us };
-    //~^ ERROR if and else have incompatible types: expected `isize`, found `usize`
+    //~^ ERROR if and else have incompatible types
+    //~| expected `isize`
+    //~| found `usize`
+    //~| expected isize
+    //~| found usize
 }

--- a/src/test/compile-fail/if-without-else-result.rs
+++ b/src/test/compile-fail/if-without-else-result.rs
@@ -10,6 +10,10 @@
 
 fn main() {
     let a = if true { true };
-//~^ ERROR if may be missing an else clause: expected `()`, found `bool` (expected (), found bool)
+    //~^ ERROR if may be missing an else clause
+    //~| expected `()`
+    //~| found `bool`
+    //~| expected ()
+    //~| found bool
     println!("{}", a);
 }

--- a/src/test/compile-fail/integer-literal-suffix-inference.rs
+++ b/src/test/compile-fail/integer-literal-suffix-inference.rs
@@ -39,62 +39,242 @@ fn main() {
     fn id_u64(n: u64) -> u64 { n }
 
     id_i8(a8); // ok
-    id_i8(a16); //~ ERROR mismatched types: expected `i8`, found `i16`
-    id_i8(a32); //~ ERROR mismatched types: expected `i8`, found `i32`
-    id_i8(a64); //~ ERROR mismatched types: expected `i8`, found `i64`
+    id_i8(a16);
+    //~^ ERROR mismatched types
+    //~| expected `i8`
+    //~| found `i16`
+    //~| expected i8
+    //~| found i16
+    id_i8(a32);
+    //~^ ERROR mismatched types
+    //~| expected `i8`
+    //~| found `i32`
+    //~| expected i8
+    //~| found i32
+    id_i8(a64);
+    //~^ ERROR mismatched types
+    //~| expected `i8`
+    //~| found `i64`
+    //~| expected i8
+    //~| found i64
 
-    id_i16(a8); //~ ERROR mismatched types: expected `i16`, found `i8`
+    id_i16(a8);
+    //~^ ERROR mismatched types
+    //~| expected `i16`
+    //~| found `i8`
+    //~| expected i16
+    //~| found i8
     id_i16(a16); // ok
-    id_i16(a32); //~ ERROR mismatched types: expected `i16`, found `i32`
-    id_i16(a64); //~ ERROR mismatched types: expected `i16`, found `i64`
+    id_i16(a32);
+    //~^ ERROR mismatched types
+    //~| expected `i16`
+    //~| found `i32`
+    //~| expected i16
+    //~| found i32
+    id_i16(a64);
+    //~^ ERROR mismatched types
+    //~| expected `i16`
+    //~| found `i64`
+    //~| expected i16
+    //~| found i64
 
-    id_i32(a8); //~ ERROR mismatched types: expected `i32`, found `i8`
-    id_i32(a16); //~ ERROR mismatched types: expected `i32`, found `i16`
+    id_i32(a8);
+    //~^ ERROR mismatched types
+    //~| expected `i32`
+    //~| found `i8`
+    //~| expected i32
+    //~| found i8
+    id_i32(a16);
+    //~^ ERROR mismatched types
+    //~| expected `i32`
+    //~| found `i16`
+    //~| expected i32
+    //~| found i16
     id_i32(a32); // ok
-    id_i32(a64); //~ ERROR mismatched types: expected `i32`, found `i64`
+    id_i32(a64);
+    //~^ ERROR mismatched types
+    //~| expected `i32`
+    //~| found `i64`
+    //~| expected i32
+    //~| found i64
 
-    id_i64(a8); //~ ERROR mismatched types: expected `i64`, found `i8`
-    id_i64(a16); //~ ERROR mismatched types: expected `i64`, found `i16`
-    id_i64(a32); //~ ERROR mismatched types: expected `i64`, found `i32`
+    id_i64(a8);
+    //~^ ERROR mismatched types
+    //~| expected `i64`
+    //~| found `i8`
+    //~| expected i64
+    //~| found i8
+    id_i64(a16);
+    //~^ ERROR mismatched types
+    //~| expected `i64`
+    //~| found `i16`
+    //~| expected i64
+    //~| found i16
+    id_i64(a32);
+    //~^ ERROR mismatched types
+    //~| expected `i64`
+    //~| found `i32`
+    //~| expected i64
+    //~| found i32
     id_i64(a64); // ok
 
     id_i8(c8); // ok
-    id_i8(c16); //~ ERROR mismatched types: expected `i8`, found `i16`
-    id_i8(c32); //~ ERROR mismatched types: expected `i8`, found `i32`
-    id_i8(c64); //~ ERROR mismatched types: expected `i8`, found `i64`
+    id_i8(c16);
+    //~^ ERROR mismatched types
+    //~| expected `i8`
+    //~| found `i16`
+    //~| expected i8
+    //~| found i16
+    id_i8(c32);
+    //~^ ERROR mismatched types
+    //~| expected `i8`
+    //~| found `i32`
+    //~| expected i8
+    //~| found i32
+    id_i8(c64);
+    //~^ ERROR mismatched types
+    //~| expected `i8`
+    //~| found `i64`
+    //~| expected i8
+    //~| found i64
 
-    id_i16(c8); //~ ERROR mismatched types: expected `i16`, found `i8`
+    id_i16(c8);
+    //~^ ERROR mismatched types
+    //~| expected `i16`
+    //~| found `i8`
+    //~| expected i16
+    //~| found i8
     id_i16(c16); // ok
-    id_i16(c32); //~ ERROR mismatched types: expected `i16`, found `i32`
-    id_i16(c64); //~ ERROR mismatched types: expected `i16`, found `i64`
+    id_i16(c32);
+    //~^ ERROR mismatched types
+    //~| expected `i16`
+    //~| found `i32`
+    //~| expected i16
+    //~| found i32
+    id_i16(c64);
+    //~^ ERROR mismatched types
+    //~| expected `i16`
+    //~| found `i64`
+    //~| expected i16
+    //~| found i64
 
-    id_i32(c8); //~ ERROR mismatched types: expected `i32`, found `i8`
-    id_i32(c16); //~ ERROR mismatched types: expected `i32`, found `i16`
+    id_i32(c8);
+    //~^ ERROR mismatched types
+    //~| expected `i32`
+    //~| found `i8`
+    //~| expected i32
+    //~| found i8
+    id_i32(c16);
+    //~^ ERROR mismatched types
+    //~| expected `i32`
+    //~| found `i16`
+    //~| expected i32
+    //~| found i16
     id_i32(c32); // ok
-    id_i32(c64); //~ ERROR mismatched types: expected `i32`, found `i64`
+    id_i32(c64);
+    //~^ ERROR mismatched types
+    //~| expected `i32`
+    //~| found `i64`
+    //~| expected i32
+    //~| found i64
 
-    id_i64(a8); //~ ERROR mismatched types: expected `i64`, found `i8`
-    id_i64(a16); //~ ERROR mismatched types: expected `i64`, found `i16`
-    id_i64(a32); //~ ERROR mismatched types: expected `i64`, found `i32`
+    id_i64(a8);
+    //~^ ERROR mismatched types
+    //~| expected `i64`
+    //~| found `i8`
+    //~| expected i64
+    //~| found i8
+    id_i64(a16);
+    //~^ ERROR mismatched types
+    //~| expected `i64`
+    //~| found `i16`
+    //~| expected i64
+    //~| found i16
+    id_i64(a32);
+    //~^ ERROR mismatched types
+    //~| expected `i64`
+    //~| found `i32`
+    //~| expected i64
+    //~| found i32
     id_i64(a64); // ok
 
     id_u8(b8); // ok
-    id_u8(b16); //~ ERROR mismatched types: expected `u8`, found `u16`
-    id_u8(b32); //~ ERROR mismatched types: expected `u8`, found `u32`
-    id_u8(b64); //~ ERROR mismatched types: expected `u8`, found `u64`
+    id_u8(b16);
+    //~^ ERROR mismatched types
+    //~| expected `u8`
+    //~| found `u16`
+    //~| expected u8
+    //~| found u16
+    id_u8(b32);
+    //~^ ERROR mismatched types
+    //~| expected `u8`
+    //~| found `u32`
+    //~| expected u8
+    //~| found u32
+    id_u8(b64);
+    //~^ ERROR mismatched types
+    //~| expected `u8`
+    //~| found `u64`
+    //~| expected u8
+    //~| found u64
 
-    id_u16(b8); //~ ERROR mismatched types: expected `u16`, found `u8`
+    id_u16(b8);
+    //~^ ERROR mismatched types
+    //~| expected `u16`
+    //~| found `u8`
+    //~| expected u16
+    //~| found u8
     id_u16(b16); // ok
-    id_u16(b32); //~ ERROR mismatched types: expected `u16`, found `u32`
-    id_u16(b64); //~ ERROR mismatched types: expected `u16`, found `u64`
+    id_u16(b32);
+    //~^ ERROR mismatched types
+    //~| expected `u16`
+    //~| found `u32`
+    //~| expected u16
+    //~| found u32
+    id_u16(b64);
+    //~^ ERROR mismatched types
+    //~| expected `u16`
+    //~| found `u64`
+    //~| expected u16
+    //~| found u64
 
-    id_u32(b8); //~ ERROR mismatched types: expected `u32`, found `u8`
-    id_u32(b16); //~ ERROR mismatched types: expected `u32`, found `u16`
+    id_u32(b8);
+    //~^ ERROR mismatched types
+    //~| expected `u32`
+    //~| found `u8`
+    //~| expected u32
+    //~| found u8
+    id_u32(b16);
+    //~^ ERROR mismatched types
+    //~| expected `u32`
+    //~| found `u16`
+    //~| expected u32
+    //~| found u16
     id_u32(b32); // ok
-    id_u32(b64); //~ ERROR mismatched types: expected `u32`, found `u64`
+    id_u32(b64);
+    //~^ ERROR mismatched types
+    //~| expected `u32`
+    //~| found `u64`
+    //~| expected u32
+    //~| found u64
 
-    id_u64(b8); //~ ERROR mismatched types: expected `u64`, found `u8`
-    id_u64(b16); //~ ERROR mismatched types: expected `u64`, found `u16`
-    id_u64(b32); //~ ERROR mismatched types: expected `u64`, found `u32`
+    id_u64(b8);
+    //~^ ERROR mismatched types
+    //~| expected `u64`
+    //~| found `u8`
+    //~| expected u64
+    //~| found u8
+    id_u64(b16);
+    //~^ ERROR mismatched types
+    //~| expected `u64`
+    //~| found `u16`
+    //~| expected u64
+    //~| found u16
+    id_u64(b32);
+    //~^ ERROR mismatched types
+    //~| expected `u64`
+    //~| found `u32`
+    //~| expected u64
+    //~| found u32
     id_u64(b64); // ok
 }

--- a/src/test/compile-fail/integral-variable-unification-error.rs
+++ b/src/test/compile-fail/integral-variable-unification-error.rs
@@ -11,5 +11,9 @@
 fn main() {
     let mut x = 2;
     x = 5.0;
-//~^ ERROR expected `_`, found `_` (expected integral variable, found floating-point variable)
+    //~^ ERROR mismatched types
+    //~| expected `_`
+    //~| found `_`
+    //~| expected integral variable
+    //~| found floating-point variable
 }

--- a/src/test/compile-fail/issue-10176.rs
+++ b/src/test/compile-fail/issue-10176.rs
@@ -10,7 +10,11 @@
 
 fn f() -> isize {
     (return 1, return 2)
-//~^ ERROR mismatched types: expected `isize`, found `(_, _)` (expected isize, found tuple)
+//~^ ERROR mismatched types
+//~| expected `isize`
+//~| found `(_, _)`
+//~| expected isize
+//~| found tuple
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-11319.rs
+++ b/src/test/compile-fail/issue-11319.rs
@@ -10,7 +10,11 @@
 
 fn main() {
     match Some(10) {
-    //~^ ERROR match arms have incompatible types: expected `bool`, found `()`
+    //~^ ERROR match arms have incompatible types:
+    //~| expected `bool`
+    //~| found `()`
+    //~| expected bool
+    //~| found ()
         Some(5) => false,
         Some(2) => true,
         None    => (), //~ NOTE match arm with an incompatible type

--- a/src/test/compile-fail/issue-11771.rs
+++ b/src/test/compile-fail/issue-11771.rs
@@ -11,11 +11,19 @@
 fn main() {
     let x = ();
     1 +
-    x //~ ERROR mismatched types: expected `_`, found `()` (expected integral variable, found ())
+    x //~  ERROR mismatched types
+      //~| expected `_`
+      //~| found `()`
+      //~| expected integral variable
+      //~| found ()
     ;
 
     let x: () = ();
     1 +
-    x //~ ERROR mismatched types: expected `_`, found `()` (expected integral variable, found ())
+    x //~  ERROR mismatched types
+      //~| expected `_`
+      //~| found `()`
+      //~| expected integral variable
+      //~| found ()
     ;
 }

--- a/src/test/compile-fail/issue-12997-2.rs
+++ b/src/test/compile-fail/issue-12997-2.rs
@@ -12,6 +12,10 @@
 
 //! Test that makes sure wrongly-typed bench functions are rejected
 
-// error-pattern:expected &-ptr, found isize
 #[bench]
 fn bar(x: isize) { }
+//~^ ERROR mismatched types
+//~| expected `fn(&mut test::Bencher)`
+//~| found `fn(isize) {bar}`
+//~| expected &-ptr
+//~| found isize

--- a/src/test/compile-fail/issue-13058.rs
+++ b/src/test/compile-fail/issue-13058.rs
@@ -35,5 +35,9 @@ fn check<'r, I: Iterator<Item=usize>, T: Itble<'r, usize, I>>(cont: &T) -> bool
 
 fn main() {
     check((3us, 5us));
-//~^ ERROR mismatched types: expected `&_`, found `(usize, usize)` (expected &-ptr, found tuple)
+//~^ ERROR mismatched types
+//~| expected `&_`
+//~| found `(usize, usize)`
+//~| expected &-ptr
+//~| found tuple
 }

--- a/src/test/compile-fail/issue-13359.rs
+++ b/src/test/compile-fail/issue-13359.rs
@@ -14,8 +14,16 @@ fn bar(_s: u32) { }
 
 fn main() {
     foo(1*(1 as isize));
-    //~^ ERROR: mismatched types: expected `i16`, found `isize` (expected i16, found isize)
+    //~^ ERROR mismatched types
+    //~| expected `i16`
+    //~| found `isize`
+    //~| expected i16
+    //~| found isize
 
     bar(1*(1 as usize));
-    //~^ ERROR: mismatched types: expected `u32`, found `usize` (expected u32, found usize)
+    //~^ ERROR mismatched types
+    //~| expected `u32`
+    //~| found `usize`
+    //~| expected u32
+    //~| found usize
 }

--- a/src/test/compile-fail/issue-13466.rs
+++ b/src/test/compile-fail/issue-13466.rs
@@ -15,7 +15,18 @@ pub fn main() {
     // the actual arm `Result<T, E>` has two. typeck should not be
     // tricked into looking up a non-existing second type parameter.
     let _x: usize = match Some(1us) {
-        Ok(u) => u, //~ ERROR  mismatched types: expected `core::option::Option<usize>`
-        Err(e) => panic!(e)  //~ ERROR mismatched types: expected `core::option::Option<usize>`
+        Ok(u) => u,
+        //~^ ERROR mismatched types
+        //~| expected `core::option::Option<usize>`
+        //~| found `core::result::Result<_, _>`
+        //~| expected enum `core::option::Option`
+        //~| found enum `core::result::Result`
+
+        Err(e) => panic!(e)
+        //~^ ERROR mismatched types
+        //~| expected `core::option::Option<usize>`
+        //~| found `core::result::Result<_, _>`
+        //~| expected enum `core::option::Option`
+        //~| found enum `core::result::Result`
     };
 }

--- a/src/test/compile-fail/issue-13482-2.rs
+++ b/src/test/compile-fail/issue-13482-2.rs
@@ -14,8 +14,11 @@ fn main() {
     let x = [1,2];
     let y = match x {
         [] => None,
-        //~^ ERROR types: expected `[_#0i; 2]`, found `[_#7t; 0]`
-        //         (expected array of 2 elements, found array of 0 elements)
+//~^ ERROR mismatched types
+//~| expected `[_#0i; 2]`
+//~| found `[_#7t; 0]`
+//~| expected an array with a fixed size of 2 elements
+//~| found one with 0 elements
         [a,_] => Some(a)
     };
 }

--- a/src/test/compile-fail/issue-13482.rs
+++ b/src/test/compile-fail/issue-13482.rs
@@ -12,8 +12,10 @@ fn main() {
   let x = [1,2];
   let y = match x {
     [] => None,
-//~^ ERROR types: expected `[_; 2]`, found `[_; 0]`
-//         (expected array of 2 elements, found array of 0 elements)
+    //~^ ERROR mismatched types
+    //~| expected `[_; 2]`
+    //~| found `[_; 0]`
+    //~| expected array with a fixed size of 2 elements
     [a,_] => Some(a)
   };
 }

--- a/src/test/compile-fail/issue-13624.rs
+++ b/src/test/compile-fail/issue-13624.rs
@@ -15,7 +15,11 @@ mod a {
 
   pub fn get_enum_struct_variant() -> () {
     Enum::EnumStructVariant { x: 1, y: 2, z: 3 }
-//~^ ERROR mismatched types: expected `()`, found `a::Enum` (expected (), found enum a::Enum)
+    //~^ ERROR mismatched types
+    //~| expected `()`
+    //~| found `a::Enum`
+    //~| expected ()
+    //~| found enum `a::Enum`
   }
 }
 
@@ -27,8 +31,11 @@ mod b {
       let enum_struct_variant = ::a::get_enum_struct_variant();
       match enum_struct_variant {
         a::Enum::EnumStructVariant { x, y, z } => {
-        //~^ ERROR mismatched types: expected `()`, found `a::Enum`
-        //         (expected (), found enum a::Enum)
+        //~^ ERROR mismatched types
+        //~| expected `()`
+        //~| found `a::Enum`
+        //~| expected ()
+        // found enum `a::Enum`
         }
       }
     }

--- a/src/test/compile-fail/issue-14091.rs
+++ b/src/test/compile-fail/issue-14091.rs
@@ -8,6 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: expected `bool`, found `_` (expected bool, found integral variable)
+// error-pattern:mismatched types
+// error-pattern:expected `bool`
+// error-pattern:found `_`
+// error-pattern:expected bool
+// error-pattern:found integral variable
 
 fn main(){assert!(1,1);}

--- a/src/test/compile-fail/issue-14541.rs
+++ b/src/test/compile-fail/issue-14541.rs
@@ -13,8 +13,11 @@ struct vec3 { y: f32, z: f32 }
 
 fn make(v: vec2) {
     let vec3 { y: _, z: _ } = v;
-    //~^ ERROR mismatched types: expected `vec2`, found `vec3`
-    //         (expected struct vec2, found struct vec3)
+    //~^ ERROR mismatched types
+    //~| expected `vec2`
+    //~| found `vec3`
+    //~| expected struct `vec2`
+    //~| found struct `vec3`
 }
 
 fn main() { }

--- a/src/test/compile-fail/issue-14845.rs
+++ b/src/test/compile-fail/issue-14845.rs
@@ -16,9 +16,17 @@ struct X {
 fn main() {
     let x = X { a: [0] };
     let _f = &x.a as *mut u8;
-    //~^ ERROR mismatched types: expected `*mut u8`, found `&[u8; 1]`
+    //~^ ERROR mismatched types
+    //~| expected `*mut u8`
+    //~| found `&[u8; 1]`
+    //~| expected u8
+    //~| found array of 1 elements
 
     let local = [0u8];
     let _v = &local as *mut u8;
-    //~^ ERROR mismatched types: expected `*mut u8`, found `&[u8; 1]`
+    //~^ ERROR mismatched types
+    //~| expected `*mut u8`
+    //~| found `&[u8; 1]`
+    //~| expected u8,
+    //~| found array of 1 elements
 }

--- a/src/test/compile-fail/issue-15783.rs
+++ b/src/test/compile-fail/issue-15783.rs
@@ -16,6 +16,10 @@ fn main() {
     let name = "Foo";
     let x = Some(&[name.as_slice()]);
     let msg = foo(x);
-//~^ ERROR mismatched types: expected `core::option::Option<&[&str]>`
+//~^ ERROR mismatched types
+//~| expected `core::option::Option<&[&str]>`
+//~| found `core::option::Option<&[&str; 1]>`
+//~| expected slice
+//~| found array of 1 elements
     assert_eq!(msg, 3);
 }

--- a/src/test/compile-fail/issue-15896.rs
+++ b/src/test/compile-fail/issue-15896.rs
@@ -19,8 +19,11 @@ fn main() {
     let u = match e {
         E::B(
           Tau{t: x},
-          //~^ ERROR mismatched types: expected `main::R`, found `main::Tau`
-          //        (expected enum main::R, found struct main::Tau)
+          //~^ ERROR mismatched types
+          //~| expected `main::R`
+          //~| found `main::Tau`
+          //~| expected enum `main::R`
+          //~| found struct `main::Tau`
           _) => x,
     };
 }

--- a/src/test/compile-fail/issue-16338.rs
+++ b/src/test/compile-fail/issue-16338.rs
@@ -12,7 +12,10 @@ use std::raw::Slice;
 
 fn main() {
     let Slice { data: data, len: len } = "foo";
-    //~^ ERROR mismatched types: expected `&str`, found `core::raw::Slice<_>`
-    //         (expected &-ptr, found struct core::raw::Slice)
+    //~^ ERROR mismatched types
+    //~| expected `&str`
+    //~| found `core::raw::Slice<_>`
+    //~| expected &-ptr
+    //~| found struct `core::raw::Slice`
 }
 

--- a/src/test/compile-fail/issue-16401.rs
+++ b/src/test/compile-fail/issue-16401.rs
@@ -13,8 +13,11 @@ use std::raw::Slice;
 fn main() {
     match () {
         Slice { data: data, len: len } => (),
-        //~^ ERROR mismatched types: expected `()`, found `core::raw::Slice<_>`
-        //         (expected (), found struct core::raw::Slice)
+        //~^ ERROR mismatched types
+        //~| expected `()`
+        //~| found `core::raw::Slice<_>`
+        //~| expected ()
+        //~| found struct `core::raw::Slice`
         _ => unreachable!()
     }
 }

--- a/src/test/compile-fail/issue-17033.rs
+++ b/src/test/compile-fail/issue-17033.rs
@@ -11,7 +11,11 @@
 #![feature(overloaded_calls)]
 
 fn f<'r>(p: &'r mut fn(p: &mut ())) {
-    (*p)(()) //~ ERROR mismatched types: expected `&mut ()`, found `()`
+    (*p)(()) //~  ERROR mismatched types
+             //~| expected `&mut ()`
+             //~| found `()`
+             //~| expected &-ptr
+             //~| found ()
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-17283.rs
+++ b/src/test/compile-fail/issue-17283.rs
@@ -21,17 +21,29 @@ fn main() {
 
     // `x { ... }` should not be interpreted as a struct literal here
     if x = x {
-        //~^ ERROR mismatched types: expected `bool`, found `()` (expected bool, found ())
+        //~^ ERROR mismatched types
+        //~| expected `bool`
+        //~| found `()`
+        //~| expected bool
+        //~| found ()
         println!("{}", x);
     }
     // Explicit parentheses on the left should match behavior of above
     if (x = x) {
-        //~^ ERROR mismatched types: expected `bool`, found `()` (expected bool, found ())
+        //~^ ERROR mismatched types
+        //~| expected `bool`
+        //~| found `()`
+        //~| expected bool
+        //~| found ()
         println!("{}", x);
     }
     // The struct literal interpretation is fine with explicit parentheses on the right
     if y = (Foo { foo: x }) {
-        //~^ ERROR mismatched types: expected `bool`, found `()` (expected bool, found ())
+        //~^ ERROR mismatched types
+        //~| expected `bool`
+        //~| found `()`
+        //~| expected bool
+        //~| found ()
         println!("{}", x);
     }
 }

--- a/src/test/compile-fail/issue-17740.rs
+++ b/src/test/compile-fail/issue-17740.rs
@@ -14,8 +14,14 @@ struct Foo<'a> {
 
 impl <'a> Foo<'a>{
     fn bar(self: &mut Foo) {
-    //~^ mismatched types: expected `Foo<'a>`, found `Foo<'_>` (lifetime mismatch)
-    //~| mismatched types: expected `Foo<'a>`, found `Foo<'_>` (lifetime mismatch)
+    //~^ mismatched types
+    //~| expected `Foo<'a>`
+    //~| found `Foo<'_>`
+    //~| lifetime mismatch
+    //~| mismatched types
+    //~| expected `Foo<'a>`
+    //~| found `Foo<'_>`
+    //~| lifetime mismatch
     }
 }
 

--- a/src/test/compile-fail/issue-17905.rs
+++ b/src/test/compile-fail/issue-17905.rs
@@ -16,7 +16,10 @@ impl Pair<
     isize
 > {
     fn say(self: &Pair<&str, isize>) {
-//~^ ERROR mismatched types: expected `Pair<&'static str, isize>`, found `Pair<&str, isize>`
+//~^ ERROR mismatched types
+//~| expected `Pair<&'static str, isize>`
+//~| found `Pair<&str, isize>`
+//~| lifetime mismatch
         println!("{}", self);
     }
 }

--- a/src/test/compile-fail/issue-19991.rs
+++ b/src/test/compile-fail/issue-19991.rs
@@ -12,7 +12,11 @@
 // clause does not exist, instead of the unsympathetic "match arms have incompatible types"
 
 fn main() {
-    if let Some(homura) = Some("madoka") { //~ ERROR missing an else clause: expected `()`
+    if let Some(homura) = Some("madoka") { //~  ERROR missing an else clause
+                                           //~| expected `()`
+                                           //~| found `i32`
+                                           //~| expected ()
+                                           //~| found i32
         765i32
     };
 }

--- a/src/test/compile-fail/issue-2951.rs
+++ b/src/test/compile-fail/issue-2951.rs
@@ -10,7 +10,12 @@
 
 fn foo<T, U>(x: T, y: U) {
     let mut xx = x;
-    xx = y; //~ ERROR expected `T`, found `U`
+    xx = y;
+    //~^  ERROR mismatched types
+    //~| expected `T`
+    //~| found `U`
+    //~| expected type parameter
+    //~| found a different type parameter
 }
 
 fn main() {

--- a/src/test/compile-fail/issue-3477.rs
+++ b/src/test/compile-fail/issue-3477.rs
@@ -9,5 +9,10 @@
 // except according to those terms.
 
 fn main() {
-    let _p: char = 100; //~ ERROR mismatched types: expected `char`, found
+    let _p: char = 100;
+    //~^ ERROR mismatched types
+    //~| expected `char`
+    //~| found `u8`
+    //~| expected char
+    //~| found u8
 }

--- a/src/test/compile-fail/issue-3563.rs
+++ b/src/test/compile-fail/issue-3563.rs
@@ -10,8 +10,13 @@
 
 trait A {
     fn a(&self) {
-        |&:| self.b() //~ ERROR type `&Self` does not implement any method in scope named `b`
-        //~^ ERROR expected (), found closure
+        |&:| self.b()
+        //~^ ERROR type `&Self` does not implement any method in scope named `b`
+        //~| ERROR mismatched types
+        //~| expected `()`
+        //~| found closure
+        //~| expected ()
+        //~| found closure
     }
 }
 fn main() {}

--- a/src/test/compile-fail/issue-3680.rs
+++ b/src/test/compile-fail/issue-3680.rs
@@ -11,7 +11,10 @@
 fn main() {
     match None {
         Err(_) => ()
-        //~^ ERROR mismatched types: expected `core::option::Option<_>`
-        //         , found `core::result::Result<_, _>`
+        //~^ ERROR mismatched types
+        //~| expected `core::option::Option<_>`
+        //~| found `core::result::Result<_, _>`
+        //~| expected enum `core::option::Option`
+        //~| found enum `core::result::Result`
     }
 }

--- a/src/test/compile-fail/issue-4201.rs
+++ b/src/test/compile-fail/issue-4201.rs
@@ -12,7 +12,11 @@ fn main() {
     let a = if true {
         0
     } else if false {
-//~^ ERROR if may be missing an else clause: expected `()`, found `_`
+//~^ ERROR if may be missing an else clause
+//~| expected `()`
+//~| found `_`
+//~| expected ()
+//~| found integral variable
         1
     };
 }

--- a/src/test/compile-fail/issue-4517.rs
+++ b/src/test/compile-fail/issue-4517.rs
@@ -13,6 +13,9 @@ fn bar(int_param: usize) {}
 fn main() {
     let foo: [u8; 4] = [1u8; 4us];
     bar(foo);
-    //~^ ERROR mismatched types: expected `usize`, found `[u8; 4]`
-    //         (expected usize, found vector)
+    //~^ ERROR mismatched types
+    //~| expected `usize`
+    //~| found `[u8; 4]`
+    //~| expected usize
+    //~| found array of 4 elements
 }

--- a/src/test/compile-fail/issue-4968.rs
+++ b/src/test/compile-fail/issue-4968.rs
@@ -13,6 +13,9 @@
 const A: (isize,isize) = (4,2);
 fn main() {
     match 42 { A => () }
-    //~^ ERROR mismatched types: expected `_`, found `(isize, isize)`
-    //         (expected integral variable, found tuple)
+    //~^ ERROR mismatched types
+    //~| expected `_`
+    //~| found `(isize, isize)`
+    //~| expected integral variable
+    //~| found tuple
 }

--- a/src/test/compile-fail/issue-5100.rs
+++ b/src/test/compile-fail/issue-5100.rs
@@ -15,28 +15,48 @@ enum A { B, C }
 fn main() {
     match (true, false) {
         A::B => (),
-//~^ ERROR mismatched types: expected `(bool, bool)`, found `A` (expected tuple, found enum A)
+//~^ ERROR mismatched types:
+//~| expected `(bool, bool)`
+//~| found `A`
+//~| expected tuple
+//~| found enum `A`
         _ => ()
     }
 
     match (true, false) {
         (true, false, false) => ()
-//~^ ERROR mismatched types: expected `(bool, bool)`, found `(_, _, _)`
+//~^ ERROR mismatched types
+//~| expected `(bool, bool)`
+//~| found `(_, _, _)`
+//~| expected a tuple with 2 elements
+//~| found one with 3 elements
     }
 
     match (true, false) {
         (true, false, false) => ()
-//~^ ERROR (expected a tuple with 2 elements, found one with 3 elements)
+//~^ ERROR mismatched types
+//~| expected `(bool, bool)`
+//~| found `(_, _, _)`
+//~| expected a tuple with 2 elements
+//~| found one with 3 elements
     }
 
     match (true, false) {
         box (true, false) => ()
-//~^ ERROR mismatched types: expected `(bool, bool)`, found `Box<_>` (expected tuple, found box)
+//~^ ERROR mismatched types
+//~| expected `(bool, bool)`
+//~| found `Box<_>`
+//~| expected tuple
+//~| found box
     }
 
     match (true, false) {
         &(true, false) => ()
-//~^ ERROR mismatched types: expected `(bool, bool)`, found `&_` (expected tuple, found &-ptr)
+//~^ ERROR mismatched types
+//~| expected `(bool, bool)`
+//~| found `&_`
+//~| expected tuple
+//~| found &-ptr
     }
 
 
@@ -47,5 +67,9 @@ fn main() {
     for &(x,y) in v.iter() {} // should be OK
 
     // Make sure none of the errors above were fatal
-    let x: char = true; //~ ERROR expected `char`, found `bool`
+    let x: char = true; //~  ERROR mismatched types
+                        //~| expected `char`
+                        //~| found `bool`
+                        //~| expected char
+                        //~| found bool
 }

--- a/src/test/compile-fail/issue-5358-1.rs
+++ b/src/test/compile-fail/issue-5358-1.rs
@@ -13,7 +13,12 @@ struct S(Either<usize, usize>);
 
 fn main() {
     match S(Either::Left(5)) {
-        Either::Right(_) => {}  //~ ERROR mismatched types: expected `S`, found `Either
+        Either::Right(_) => {}
+        //~^ ERROR mismatched types
+        //~| expected `S`
+        //~| found `Either<_, _>`
+        //~| expected struct `S`
+        //~| found enum `Either`
         _ => {}
     }
 }

--- a/src/test/compile-fail/issue-5500.rs
+++ b/src/test/compile-fail/issue-5500.rs
@@ -10,5 +10,9 @@
 
 fn main() {
     &panic!()
-    //~^ ERROR mismatched types: expected `()`, found `&_` (expected (), found &-ptr)
+    //~^ ERROR mismatched types
+    //~| expected `()`
+    //~| found `&_`
+    //~| expected ()
+    //~| found &-ptr
 }

--- a/src/test/compile-fail/issue-7061.rs
+++ b/src/test/compile-fail/issue-7061.rs
@@ -12,7 +12,11 @@ struct BarStruct;
 
 impl<'a> BarStruct {
     fn foo(&'a mut self) -> Box<BarStruct> { self }
-    //~^ ERROR: error: mismatched types: expected `Box<BarStruct>`, found `&'a mut BarStruct
+    //~^ ERROR mismatched types
+    //~| expected `Box<BarStruct>`
+    //~| found `&'a mut BarStruct`
+    //~| expected box
+    //~| found &-ptr
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-7092.rs
+++ b/src/test/compile-fail/issue-7092.rs
@@ -14,7 +14,11 @@ enum Whatever {
 fn foo(x: Whatever) {
     match x {
         Some(field) =>
-//~^ ERROR: mismatched types: expected `Whatever`, found `core::option::Option<_>`
+//~^ ERROR mismatched types
+//~| expected `Whatever`
+//~| found `core::option::Option<_>`
+//~| expected enum `Whatever`
+//~| found enum `core::option::Option`
             field.access(), //~ ERROR the type of this value must be known in this context
     }
 }

--- a/src/test/compile-fail/issue-7867.rs
+++ b/src/test/compile-fail/issue-7867.rs
@@ -14,14 +14,27 @@ mod foo { pub fn bar() {} }
 
 fn main() {
     match (true, false) {
-        A::B => (), //~ ERROR expected `(bool, bool)`, found `A` (expected tuple, found enum A)
+        A::B => (),
+        //~^ ERROR mismatched types
+        //~| expected `(bool, bool)`
+        //~| found `A`
+        //~| expected tuple
+        //~| found enum `A`
         _ => ()
     }
 
     match &Some(42is) {
-        Some(x) => (), //~ ERROR expected `&core::option::Option<isize>`,
-                       //        found `core::option::Option<_>`
-        None => ()     //~ ERROR expected `&core::option::Option<isize>`,
-                       //        found `core::option::Option<_>`
+        Some(x) => (),
+        //~^ ERROR mismatched types
+        //~| expected `&core::option::Option<isize>`
+        //~| found `core::option::Option<_>`
+        //~| expected &-ptr
+        //~| found enum `core::option::Option`
+        None => ()
+        //~^ ERROR mismatched types
+        //~| expected `&core::option::Option<isize>`
+        //~| found `core::option::Option<_>`
+        //~| expected &-ptr
+        //~| found enum `core::option::Option`
     }
 }

--- a/src/test/compile-fail/issue-8761.rs
+++ b/src/test/compile-fail/issue-8761.rs
@@ -10,9 +10,17 @@
 
 enum Foo {
     A = 1i64,
-    //~^ ERROR mismatched types: expected `isize`, found `i64`
+    //~^ ERROR mismatched types
+    //~| expected `isize`
+    //~| found `i64`
+    //~| expected isize
+    //~| found i64
     B = 2u8
-    //~^ ERROR mismatched types: expected `isize`, found `u8`
+    //~^ ERROR mismatched types
+    //~| expected `isize`
+    //~| found `u8`
+    //~| expected isize
+    //~| found u8
 }
 
 fn main() {}

--- a/src/test/compile-fail/match-struct.rs
+++ b/src/test/compile-fail/match-struct.rs
@@ -14,7 +14,12 @@ enum E { C(isize) }
 
 fn main() {
     match (S { a: 1 }) {
-        E::C(_) => (), //~ ERROR mismatched types: expected `S`, found `E`
+        E::C(_) => (),
+        //~^ ERROR mismatched types
+        //~| expected `S`
+        //~| found `E`
+        //~| expected struct `S`
+        //~| found enum `E`
         _ => ()
     }
 }

--- a/src/test/compile-fail/match-vec-mismatch-2.rs
+++ b/src/test/compile-fail/match-vec-mismatch-2.rs
@@ -11,6 +11,10 @@
 fn main() {
     match () {
         [()] => { }
-//~^ ERROR mismatched types: expected `()`, found `&[_]` (expected (), found &-ptr)
+        //~^ ERROR mismatched types
+        //~| expected `()`
+        //~| found `&[_]`
+        //~| expected ()
+        //~| found &-ptr
     }
 }

--- a/src/test/compile-fail/method-self-arg-1.rs
+++ b/src/test/compile-fail/method-self-arg-1.rs
@@ -18,7 +18,19 @@ impl Foo {
 
 fn main() {
     let x = Foo;
-    Foo::bar(x); //~ERROR mismatched types: expected `&Foo`, found `Foo`
-    Foo::bar(&&x); //~ERROR mismatched types: expected `&Foo`, found `&&Foo`
-    Foo::bar(&42is); //~ERROR mismatched types: expected `&Foo`, found `&isize`
+    Foo::bar(x); //~  ERROR mismatched types
+                 //~| expected `&Foo`
+                 //~| found `Foo`
+                 //~| expected &-ptr
+                 //~| found struct `Foo`
+    Foo::bar(&&x); //~  ERROR mismatched types
+                   //~| expected `&Foo`
+                   //~| found `&&Foo`
+                   //~| expected struct `Foo`
+                   //~| found &-ptr
+    Foo::bar(&42is); //~  ERROR mismatched types
+                     //~| expected `&Foo`
+                     //~| found `&isize`
+                     //~| expected struct `Foo`
+                     //~| found isize
 }

--- a/src/test/compile-fail/mut-pattern-mismatched.rs
+++ b/src/test/compile-fail/mut-pattern-mismatched.rs
@@ -13,12 +13,18 @@ fn main() {
 
     // (separate lines to ensure the spans are accurate)
 
-     let &_ //~ ERROR expected `&mut isize`, found `&_`
+     let &_ //~  ERROR mismatched types
+            //~| expected `&mut isize`
+            //~| found `&_`
+            //~| values differ in mutability
         = foo;
     let &mut _ = foo;
 
     let bar = &1is;
     let &_ = bar;
-    let &mut _ //~ ERROR expected `&isize`, found `&mut _`
+    let &mut _ //~  ERROR mismatched types
+               //~| expected `&isize`
+               //~| found `&mut _`
+               //~| values differ in mutability
          = bar;
 }

--- a/src/test/compile-fail/noexporttypeexe.rs
+++ b/src/test/compile-fail/noexporttypeexe.rs
@@ -18,5 +18,9 @@ fn main() {
     // because the def_id associated with the type was
     // not convertible to a path.
   let x: isize = noexporttypelib::foo();
-    //~^ ERROR expected `isize`, found `core::option::Option<isize>`
+    //~^ ERROR mismatched types
+    //~| expected `isize`
+    //~| found `core::option::Option<isize>`
+    //~| expected isize
+    //~| found enum `core::option::Option`
 }

--- a/src/test/compile-fail/occurs-check-2.rs
+++ b/src/test/compile-fail/occurs-check-2.rs
@@ -14,5 +14,9 @@ fn main() {
     let f;
     let g;
     g = f;
-    f = box g; //~ ERROR cyclic type of infinite size
+    f = box g;
+    //~^  ERROR mismatched types
+    //~| expected `_`
+    //~| found `Box<_>`
+    //~| cyclic type of infinite size
 }

--- a/src/test/compile-fail/occurs-check.rs
+++ b/src/test/compile-fail/occurs-check.rs
@@ -12,5 +12,9 @@
 
 fn main() {
     let f;
-    f = box f; //~ ERROR cyclic type of infinite size
+    f = box f;
+    //~^ ERROR mismatched types
+    //~| expected `_`
+    //~| found `Box<_>`
+    //~| cyclic type of infinite size
 }

--- a/src/test/compile-fail/pattern-error-continue.rs
+++ b/src/test/compile-fail/pattern-error-continue.rs
@@ -30,9 +30,18 @@ fn main() {
     }
     match 'c' {
         S { .. } => (),
-        //~^ ERROR mismatched types: expected `char`, found `S` (expected char, found struct S)
+        //~^ ERROR mismatched types
+        //~| expected `char`
+        //~| found `S`
+        //~| expected char
+        //~| found struct `S`
 
         _ => ()
     }
-    f(true);            //~ ERROR mismatched types: expected `char`, found `bool`
+    f(true);
+    //~^ ERROR mismatched types
+    //~| expected `char`
+    //~| found `bool`
+    //~| expected char
+    //~| found bool
 }

--- a/src/test/compile-fail/pptypedef.rs
+++ b/src/test/compile-fail/pptypedef.rs
@@ -12,8 +12,16 @@ fn let_in<T, F>(x: T, f: F) where F: FnOnce(T) {}
 
 fn main() {
     let_in(3us, |i| { assert!(i == 3is); });
-    //~^ ERROR expected `usize`, found `isize`
+    //~^ ERROR mismatched types
+    //~| expected `usize`
+    //~| found `isize`
+    //~| expected usize
+    //~| found isize
 
     let_in(3is, |i| { assert!(i == 3us); });
-    //~^ ERROR expected `isize`, found `usize`
+    //~^ ERROR mismatched types
+    //~| expected `isize`
+    //~| found `usize`
+    //~| expected isize
+    //~| found usize
 }

--- a/src/test/compile-fail/ptr-coercion.rs
+++ b/src/test/compile-fail/ptr-coercion.rs
@@ -14,11 +14,20 @@
 pub fn main() {
     // *const -> *mut
     let x: *const isize = &42is;
-    let x: *mut isize = x; //~ERROR values differ in mutability
+    let x: *mut isize = x; //~  ERROR mismatched types
+                           //~| expected `*mut isize`
+                           //~| found `*const isize`
+                           //~| values differ in mutability
 
     // & -> *mut
-    let x: *mut isize = &42; //~ERROR values differ in mutability
+    let x: *mut isize = &42; //~  ERROR mismatched types
+                             //~| expected `*mut isize`
+                             //~| found `&isize`
+                             //~| values differ in mutability
 
     let x: *const isize = &42;
-    let x: *mut isize = x; //~ERROR values differ in mutability
+    let x: *mut isize = x; //~  ERROR mismatched types
+                           //~| expected `*mut isize`
+                           //~| found `*const isize`
+                           //~| values differ in mutability
 }

--- a/src/test/compile-fail/regions-bounds.rs
+++ b/src/test/compile-fail/regions-bounds.rs
@@ -16,11 +16,17 @@ struct an_enum<'a>(&'a isize);
 struct a_class<'a> { x:&'a isize }
 
 fn a_fn1<'a,'b>(e: an_enum<'a>) -> an_enum<'b> {
-    return e; //~ ERROR mismatched types: expected `an_enum<'b>`, found `an_enum<'a>`
+    return e; //~  ERROR mismatched types
+              //~| expected `an_enum<'b>`
+              //~| found `an_enum<'a>`
+              //~| lifetime mismatch
 }
 
 fn a_fn3<'a,'b>(e: a_class<'a>) -> a_class<'b> {
-    return e; //~ ERROR mismatched types: expected `a_class<'b>`, found `a_class<'a>`
+    return e; //~  ERROR mismatched types
+              //~| expected `a_class<'b>`
+              //~| found `a_class<'a>`
+              //~| lifetime mismatch
 }
 
 fn main() { }

--- a/src/test/compile-fail/regions-early-bound-error-method.rs
+++ b/src/test/compile-fail/regions-early-bound-error-method.rs
@@ -27,8 +27,12 @@ impl<'a> GetRef<'a> for Box<'a> {
 
 impl<'a> Box<'a> {
     fn or<'b,G:GetRef<'b>>(&self, g2: G) -> &'a isize {
-        g2.get() //~ ERROR cannot infer an appropriate lifetime for automatic coercion due to
-        //~^ ERROR mismatched types: expected `&'a isize`, found `&'b isize` (lifetime mismatch)
+        g2.get()
+        //~^ ERROR cannot infer an appropriate lifetime for automatic coercion due to
+        //~| ERROR mismatched types
+        //~| expected `&'a isize`
+        //~| found `&'b isize`
+        //~| lifetime mismatch
 
     }
 }

--- a/src/test/compile-fail/regions-early-bound-error.rs
+++ b/src/test/compile-fail/regions-early-bound-error.rs
@@ -26,8 +26,12 @@ impl<'a,T:Clone> GetRef<'a,T> for Box<'a,T> {
 }
 
 fn get<'a,'b,G:GetRef<'a, isize>>(g1: G, b: &'b isize) -> &'b isize {
-    g1.get() //~ ERROR cannot infer an appropriate lifetime for automatic coercion due to
-    //~^ ERROR mismatched types: expected `&'b isize`, found `&'a isize` (lifetime mismatch)
+    g1.get()
+    //~^ ERROR cannot infer an appropriate lifetime for automatic coercion due to
+    //~| ERROR mismatched types
+    //~| expected `&'b isize`
+    //~| found `&'a isize`
+    //~| lifetime mismatch
 }
 
 fn main() {

--- a/src/test/compile-fail/regions-fn-subtyping-return-static.rs
+++ b/src/test/compile-fail/regions-fn-subtyping-return-static.rs
@@ -53,7 +53,12 @@ fn supply_F() {
 fn supply_G() {
     want_G(foo);
     want_G(bar);
-    want_G(baz); //~ ERROR expected concrete lifetime
+    want_G(baz);
+    //~^ ERROR mismatched types
+    //~| expected `fn(&'cx S) -> &'static S`
+    //~| found `fn(&S) -> &S {baz}`
+    //~| expected concrete lifetime
+    //~| found bound lifetime parameter 'cx
 }
 
 pub fn main() {

--- a/src/test/compile-fail/regions-infer-paramd-indirect.rs
+++ b/src/test/compile-fail/regions-infer-paramd-indirect.rs
@@ -31,7 +31,10 @@ impl<'a> set_f<'a> for c<'a> {
 
     fn set_f_bad(&mut self, b: Box<b>) {
         self.f = b;
-        //~^ ERROR mismatched types: expected `Box<Box<&'a isize>>`, found `Box<Box<&isize>>`
+        //~^ ERROR mismatched types
+        //~| expected `Box<Box<&'a isize>>`
+        //~| found `Box<Box<&isize>>`
+        //~| lifetime mismatch
     }
 }
 

--- a/src/test/compile-fail/repeat_count.rs
+++ b/src/test/compile-fail/repeat_count.rs
@@ -14,14 +14,33 @@ fn main() {
     let n = 1;
     let a = [0; n]; //~ ERROR expected constant integer for repeat count, found variable
     let b = [0; ()];
-//~^ ERROR expected constant integer for repeat count, found non-constant expression
-//~^^ ERROR: expected `usize`, found `()`
-    let c = [0; true]; //~ ERROR expected positive integer for repeat count, found boolean
-    //~^ ERROR: expected `usize`, found `bool`
-    let d = [0; 0.5]; //~ ERROR expected positive integer for repeat count, found float
-    //~^ ERROR: expected `usize`, found `_`
-    let e = [0; "foo"]; //~ ERROR expected positive integer for repeat count, found string
-    //~^ ERROR: expected `usize`, found `&'static str`
+//~^ ERROR mismatched types
+//~| expected `usize`
+//~| found `()`
+//~| expected usize
+//~| found ()
+//~| ERROR expected constant integer for repeat count, found non-constant expression
+    let c = [0; true];
+    //~^ ERROR mismatched types
+    //~| expected `usize`
+    //~| found `bool`
+    //~| expected usize
+    //~| found bool
+    //~| ERROR expected positive integer for repeat count, found boolean
+    let d = [0; 0.5];
+    //~^ ERROR mismatched types
+    //~| expected `usize`
+    //~| found `_`
+    //~| expected usize
+    //~| found floating-point variable
+    //~| ERROR expected positive integer for repeat count, found float
+    let e = [0; "foo"];
+    //~^ ERROR mismatched types
+    //~| expected `usize`
+    //~| found `&'static str`
+    //~| expected usize
+    //~| found &-ptr
+    //~| ERROR expected positive integer for repeat count, found string
     let f = [0; -4];
     //~^ ERROR expected positive integer for repeat count, found negative integer
     let f = [0us; -1];

--- a/src/test/compile-fail/shift-various-bad-types.rs
+++ b/src/test/compile-fail/shift-various-bad-types.rs
@@ -36,7 +36,11 @@ fn foo(p: &Panolpy) {
 
     // Type of the result follows the LHS, not the RHS:
     let _: i32 = 22_i64 >> 1_i32;
-    //~^ ERROR mismatched types: expected `i32`, found `i64`
+    //~^ ERROR mismatched types
+    //~| expected `i32`
+    //~| found `i64`
+    //~| expected i32
+    //~| found i64)
 }
 
 fn main() {

--- a/src/test/compile-fail/slightly-nice-generic-literal-messages.rs
+++ b/src/test/compile-fail/slightly-nice-generic-literal-messages.rs
@@ -13,7 +13,11 @@ struct Foo<T,U>(T);
 fn main() {
     match Foo(1.1) {
         1 => {}
-    //~^ ERROR expected `Foo<_, _>`, found `_`
+    //~^ ERROR mismatched types
+    //~| expected `Foo<_, _>`
+    //~| found `_`
+    //~| expected struct `Foo`
+    //~| found integral variable
     }
 
 }

--- a/src/test/compile-fail/struct-base-wrong-type.rs
+++ b/src/test/compile-fail/struct-base-wrong-type.rs
@@ -12,11 +12,27 @@ struct Foo { a: isize, b: isize }
 struct Bar { x: isize }
 
 static bar: Bar = Bar { x: 5 };
-static foo: Foo = Foo { a: 2, ..bar }; //~ ERROR mismatched types: expected `Foo`, found `Bar`
-static foo_i: Foo = Foo { a: 2, ..4 }; //~ ERROR mismatched types: expected `Foo`
+static foo: Foo = Foo { a: 2, ..bar }; //~  ERROR mismatched types
+                                       //~| expected `Foo`
+                                       //~| found `Bar`
+                                       //~| expected struct `Foo`
+                                       //~| found struct `Bar`
+static foo_i: Foo = Foo { a: 2, ..4 }; //~  ERROR mismatched types
+                                       //~| expected `Foo`
+                                       //~| found `_`
+                                       //~| expected struct `Foo`
+                                       //~| found integral variable
 
 fn main() {
     let b = Bar { x: 5 };
-    let f = Foo { a: 2, ..b }; //~ ERROR mismatched types: expected `Foo`, found `Bar`
-    let f_i = Foo { a: 2, ..4 }; //~ ERROR mismatched types: expected `Foo`
+    let f = Foo { a: 2, ..b }; //~  ERROR mismatched types
+                               //~| expected `Foo`
+                               //~| found `Bar`
+                               //~| expected struct `Foo`
+                               //~| found struct `Bar`
+    let f_i = Foo { a: 2, ..4 }; //~  ERROR mismatched types
+                                 //~| expected `Foo`
+                                 //~| found `_`
+                                 //~| expected struct `Foo`
+                                 //~| found integral variable
 }

--- a/src/test/compile-fail/structure-constructor-type-mismatch.rs
+++ b/src/test/compile-fail/structure-constructor-type-mismatch.rs
@@ -24,25 +24,33 @@ type PairF<U> = Pair<f32,U>;
 
 fn main() {
     let pt = PointF {
-        //~^ ERROR expected f32, found isize
+        //~^ ERROR structure constructor specifies a structure of type
+        //~| expected f32
+        //~| found isize
         x: 1is,
         y: 2is,
     };
 
     let pt2 = Point::<f32> {
-        //~^ ERROR expected f32, found isize
+        //~^ ERROR structure constructor specifies a structure of type
+        //~| expected f32
+        //~| found isize
         x: 3is,
         y: 4is,
     };
 
     let pair = PairF {
-        //~^ ERROR expected f32, found isize
+        //~^ ERROR structure constructor specifies a structure of type
+        //~| expected f32
+        //~| found isize
         x: 5is,
         y: 6is,
     };
 
     let pair2 = PairF::<isize> {
-        //~^ ERROR expected f32, found isize
+        //~^ ERROR structure constructor specifies a structure of type
+        //~| expected f32
+        //~| found isize
         x: 7is,
         y: 8is,
     };

--- a/src/test/compile-fail/suppressed-error.rs
+++ b/src/test/compile-fail/suppressed-error.rs
@@ -10,6 +10,10 @@
 
 fn main() {
     let (x, y) = ();
-//~^ ERROR expected `()`, found `(_, _)` (expected (), found tuple)
+//~^ ERROR mismatched types
+//~| expected `()`
+//~| found `(_, _)`
+//~| expected ()
+//~| found tuple
     return x;
 }

--- a/src/test/compile-fail/tag-that-dare-not-speak-its-name.rs
+++ b/src/test/compile-fail/tag-that-dare-not-speak-its-name.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:mismatched types: expected `char`, found
 // Issue #876
 
 #![no_implicit_prelude]
@@ -21,4 +20,9 @@ fn last<T>(v: Vec<&T> ) -> std::option::Option<T> {
 fn main() {
     let y;
     let x : char = last(y);
+    //~^ ERROR mismatched types
+    //~| expected `char`
+    //~| found `core::option::Option<_>`
+    //~| expected char
+    //~| found enum `core::option::Option`
 }

--- a/src/test/compile-fail/terr-in-field.rs
+++ b/src/test/compile-fail/terr-in-field.rs
@@ -20,7 +20,11 @@ struct bar {
 
 fn want_foo(f: foo) {}
 fn have_bar(b: bar) {
-    want_foo(b); //~ ERROR (expected struct foo, found struct bar)
+    want_foo(b); //~  ERROR mismatched types
+                 //~| expected `foo`
+                 //~| found `bar`
+                 //~| expected struct `foo`
+                 //~| found struct `bar`
 }
 
 fn main() {}

--- a/src/test/compile-fail/terr-sorts.rs
+++ b/src/test/compile-fail/terr-sorts.rs
@@ -18,7 +18,11 @@ type bar = Box<foo>;
 
 fn want_foo(f: foo) {}
 fn have_bar(b: bar) {
-    want_foo(b); //~ ERROR (expected struct foo, found box)
+    want_foo(b); //~  ERROR mismatched types
+                 //~| expected `foo`
+                 //~| found `Box<foo>`
+                 //~| expected struct `foo`
+                 //~| found box
 }
 
 fn main() {}

--- a/src/test/compile-fail/trait-bounds-cant-coerce.rs
+++ b/src/test/compile-fail/trait-bounds-cant-coerce.rs
@@ -20,7 +20,11 @@ fn c(x: Box<Foo+Sync+Send>) {
 }
 
 fn d(x: Box<Foo>) {
-    a(x); //~ ERROR found no bounds
+    a(x); //~  ERROR mismatched types
+          //~| expected `Box<Foo + Send>`
+          //~| found `Box<Foo>`
+          //~| expected bounds `Send`
+          //~| found no bounds
 }
 
 fn main() { }

--- a/src/test/compile-fail/tuple-arity-mismatch.rs
+++ b/src/test/compile-fail/tuple-arity-mismatch.rs
@@ -14,8 +14,16 @@ fn first((value, _): (isize, f64)) -> isize { value }
 
 fn main() {
     let y = first ((1,2.0,3));
-    //~^ ERROR expected a tuple with 2 elements, found one with 3 elements
+    //~^ ERROR mismatched types
+    //~| expected `(isize, f64)`
+    //~| found `(isize, f64, _)`
+    //~| expected a tuple with 2 elements
+    //~| found one with 3 elements
 
     let y = first ((1,));
-    //~^ ERROR expected `(isize, f64)`, found `(isize,)`
+    //~^ ERROR mismatched types
+    //~| expected `(isize, f64)`
+    //~| found `(isize,)`
+    //~| expected a tuple with 2 elements
+    //~| found one with 1 elements
 }

--- a/src/test/compile-fail/tutorial-suffix-inference-test.rs
+++ b/src/test/compile-fail/tutorial-suffix-inference-test.rs
@@ -17,9 +17,17 @@ fn main() {
 
     identity_u8(x);  // after this, `x` is assumed to have type `u8`
     identity_u16(x);
-    //~^ ERROR mismatched types: expected `u16`, found `u8`
+    //~^ ERROR mismatched types
+    //~| expected `u16`
+    //~| found `u8`
+    //~| expected u16
+    //~| found u8
     identity_u16(y);
-    //~^ ERROR mismatched types: expected `u16`, found `i32`
+    //~^ ERROR mismatched types
+    //~| expected `u16`
+    //~| found `i32`
+    //~| expected u16
+    //~| found i32
 
     let a = 3is;
 
@@ -27,6 +35,10 @@ fn main() {
 
     identity_i(a); // ok
     identity_u16(a);
-    //~^ ERROR mismatched types: expected `u16`, found `isize`
+    //~^ ERROR mismatched types
+    //~| expected `u16`
+    //~| found `isize`
+    //~| expected u16
+    //~| found isize
 
 }

--- a/src/test/compile-fail/type-mismatch-multiple.rs
+++ b/src/test/compile-fail/type-mismatch-multiple.rs
@@ -9,7 +9,15 @@
 // except according to those terms.
 
 // Checking that the compiler reports multiple type errors at once
-// error-pattern:mismatched types: expected `bool`
-// error-pattern:mismatched types: expected `isize`
 
 fn main() { let a: bool = 1is; let b: isize = true; }
+//~^ ERROR mismatched types
+//~| expected `bool`
+//~| found `isize`
+//~| expected bool
+//~| found isize
+//~| ERROR mismatched types
+//~| expected `isize`
+//~| found `bool`
+//~| expected isize
+//~| found bool

--- a/src/test/compile-fail/type-parameter-names.rs
+++ b/src/test/compile-fail/type-parameter-names.rs
@@ -13,7 +13,11 @@
 
 fn foo<Foo, Bar>(x: Foo) -> Bar {
     x
-//~^ ERROR expected `Bar`, found `Foo` (expected type parameter, found a different type parameter)
+//~^ ERROR mismatched types
+//~| expected `Bar`
+//~| found `Foo`
+//~| expected type parameter
+//~| found a different type parameter
 }
 
 fn main() {}

--- a/src/test/compile-fail/type-params-in-different-spaces-1.rs
+++ b/src/test/compile-fail/type-params-in-different-spaces-1.rs
@@ -12,7 +12,11 @@ use std::num::Int;
 
 trait BrokenAdd: Int {
     fn broken_add<T>(&self, rhs: T) -> Self {
-        *self + rhs //~ ERROR expected `Self`, found `T`
+        *self + rhs //~  ERROR mismatched types
+                    //~| expected `Self`
+                    //~| found `T`
+                    //~| expected Self
+                    //~| found type parameter
     }
 }
 

--- a/src/test/compile-fail/typeck_type_placeholder_mismatch.rs
+++ b/src/test/compile-fail/typeck_type_placeholder_mismatch.rs
@@ -19,11 +19,19 @@ pub fn main() {
 
 fn test1() {
     let x: Foo<_> = Bar::<usize>;
-    //~^ ERROR mismatched types: expected `Foo<_>`, found `Bar<usize>`
+    //~^ ERROR mismatched types
+    //~| expected `Foo<_>`
+    //~| found `Bar<usize>`
+    //~| expected struct `Foo`
+    //~| found struct `Bar`
     let y: Foo<usize> = x;
 }
 
 fn test2() {
     let x: Foo<_> = Bar::<usize>;
-    //~^ ERROR mismatched types: expected `Foo<_>`, found `Bar<usize>`
+    //~^ ERROR mismatched types
+    //~| expected `Foo<_>`
+    //~| found `Bar<usize>`
+    //~| expected struct `Foo`
+    //~| found struct `Bar`
 }

--- a/src/test/compile-fail/ufcs-explicit-self-bad.rs
+++ b/src/test/compile-fail/ufcs-explicit-self-bad.rs
@@ -42,8 +42,15 @@ trait SomeTrait {
 impl<'a, T> SomeTrait for &'a Bar<T> {
     fn dummy1(self: &&'a Bar<T>) { }
     fn dummy2(self: &Bar<T>) {} //~ ERROR mismatched self type
-    fn dummy3(self: &&Bar<T>) {} //~ ERROR lifetime mismatch
-    //~^ ERROR lifetime mismatch
+    fn dummy3(self: &&Bar<T>) {}
+    //~^ ERROR mismatched types
+    //~| expected `&'a Bar<T>`
+    //~| found `&Bar<T>`
+    //~| lifetime mismatch
+    //~| ERROR mismatched types
+    //~| expected `&'a Bar<T>`
+    //~| found `&Bar<T>`
+    //~| lifetime mismatch
 }
 
 fn main() {

--- a/src/test/compile-fail/variadic-ffi.rs
+++ b/src/test/compile-fail/variadic-ffi.rs
@@ -24,14 +24,18 @@ fn main() {
         foo(1); //~ ERROR: this function takes at least 2 parameters but 1 parameter was supplied
 
         let x: unsafe extern "C" fn(f: isize, x: u8) = foo;
-        //~^ ERROR: mismatched types: expected `unsafe extern "C" fn(isize, u8)`
-        //         , found `unsafe extern "C" fn(isize, u8, ...)`
-        //          (expected non-variadic fn, found variadic function)
+        //~^ ERROR: mismatched types
+        //~| expected `unsafe extern "C" fn(isize, u8)`
+        //~| found `unsafe extern "C" fn(isize, u8, ...)`
+        //~| expected non-variadic fn
+        //~| found variadic function
 
         let y: unsafe extern "C" fn(f: isize, x: u8, ...) = bar;
-        //~^ ERROR: mismatched types: expected `unsafe extern "C" fn(isize, u8, ...)`
-        //         , found `extern "C" extern fn(isize, u8)`
-        //          (expected variadic fn, found non-variadic function)
+        //~^ ERROR: mismatched types
+        //~| expected `unsafe extern "C" fn(isize, u8, ...)`
+        //~| found `extern "C" fn(isize, u8) {bar}`
+        //~| expected variadic fn
+        //~| found non-variadic function
 
         foo(1, 2, 3f32); //~ ERROR: can't pass an f32 to variadic function, cast to c_double
         foo(1, 2, true); //~ ERROR: can't pass bool to variadic function, cast to c_int

--- a/src/test/compile-fail/wrong-mul-method-signature.rs
+++ b/src/test/compile-fail/wrong-mul-method-signature.rs
@@ -24,7 +24,7 @@ impl Mul<f64> for Vec1 {
     type Output = Vec1;
 
     fn mul(self, s: &f64) -> Vec1 {
-    //~^ ERROR: method `mul` has an incompatible type for trait: expected f64, found &-ptr
+    //~^ ERROR method `mul` has an incompatible type for trait
         Vec1 {
             x: self.x * *s
         }
@@ -41,7 +41,7 @@ impl Mul<Vec2> for Vec2 {
     type Output = f64;
 
     fn mul(self, s: f64) -> Vec2 {
-    //~^ ERROR: method `mul` has an incompatible type for trait: expected struct Vec2, found f64
+    //~^ ERROR method `mul` has an incompatible type for trait
         Vec2 {
             x: self.x * s,
             y: self.y * s
@@ -60,7 +60,7 @@ impl Mul<f64> for Vec3 {
     type Output = i32;
 
     fn mul(self, s: f64) -> f64 {
-    //~^ ERROR: method `mul` has an incompatible type for trait: expected i32, found f64
+    //~^ ERROR method `mul` has an incompatible type for trait
         s
     }
 }
@@ -72,7 +72,15 @@ pub fn main() {
 
     let x: Vec2 = Vec2 { x: 1.0, y: 2.0 } * 2.0; // trait had reversed order
     //~^ ERROR mismatched types
-    //~^^ ERROR mismatched types
+    //~| expected `Vec2`
+    //~| found `_`
+    //~| expected struct `Vec2`
+    //~| found floating-point variable
+    //~| ERROR mismatched types
+    //~| expected `Vec2`
+    //~| found `f64`
+    //~| expected struct `Vec2`
+    //~| found f64
 
     let x: i32 = Vec3 { x: 1.0, y: 2.0, z: 3.0 } * 2.0;
 }


### PR DESCRIPTION
#### Updated 1/12/2014

I updated the multi-line testcase to current but didn't modify the others. The spew code was broke by the `matches!` macro no longer working and I'm not interested in fixing the testcase.

I additionally added one testcase below.

Errors will in general look similar to below if the error is either `mismatched types` or a few other types. The rest are ignored.

---
#### Extra testcase:

``` rust
pub trait Foo {
    type A;
    fn boo(&self) -> <Self as Foo>::A;
}

struct Bar;

impl Foo for i32 {
    type A = u32;
    fn boo(&self) -> u32 {
        42
    }
}

fn foo1<I: Foo<A=Bar>>(x: I) {
    let _: Bar = x.boo();
}

fn foo2<I: Foo>(x: I) {
    let _: Bar = x.boo();
}


pub fn baz(x: &Foo<A=Bar>) {
    let _: Bar = x.boo();
}


pub fn main() {
    let a = 42i32;
    foo1(a);
    baz(&a);
}
```
#### Multi-line output:

``` cmd
$ ./rustc test3.rs
test3.rs:20:18: 20:25 error: mismatched types:
 expected `Bar`,
    found `<I as Foo>::A`
(expected struct `Bar`,
    found associated type)
test3.rs:20     let _: Bar = x.boo();
                             ^~~~~~~
test3.rs:31:5: 31:9 error: type mismatch resolving `<i32 as Foo>::A == Bar`:
 expected u32,
    found struct `Bar`
test3.rs:31     foo1(a);
                ^~~~
test3.rs:31:5: 31:9 note: required by `foo1`
test3.rs:31     foo1(a);
                ^~~~
test3.rs:32:9: 32:11 error: type mismatch resolving `<i32 as Foo>::A == Bar`:
 expected u32,
    found struct `Bar`
test3.rs:32     baz(&a);
                    ^~
test3.rs:32:9: 32:11 note: required for the cast to the object type `Foo`
test3.rs:32     baz(&a);
                    ^~
error: aborting due to 3 previous errors
```

---

This is a continuation of #19203 which I apparently broke by force pushing after it was closed. I'm attempting to add multi-line errors where they are largely beneficial - to help differentiate different types in compiler messages. As before, this is still a simple fix.
#### Testcase:

``` rust
struct S;

fn test() -> Option<i32> {
    let s: S;

    s
}

fn test2() -> Option<i32> {
    Ok(7) // Should be Some(7)
}

impl Iterator for S {
    type Item = i32;
    fn next(&mut self) -> Result<i32, i32> { Ok(7) }
}

fn main(){ 
    test();
    test2();

}
```

---
#### Single-line playpen errors:

``` cmd
<anon>:6:5: 6:6 error: mismatched types: expected `core::option::Option<int>`, found `S` (expected enum core::option::Option, found struct S)
<anon>:6     s
             ^
<anon>:10:5: 10:10 error: mismatched types: expected `core::option::Option<int>`, found `core::result::Result<_, _>` (expected enum core::option::Option, found enum core::result::Result)
<anon>:10     Ok(7) // Should be Some(7)
              ^~~~~
<anon>:14:5: 14:55 error: method `next` has an incompatible type for trait: expected enum core::option::Option, found enum core::result::Result [E0053]
<anon>:14     fn next(&mut self) -> Result<uint, uint> { Ok(7) }
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to 3 previous errors
playpen: application terminated with error code 101
```

---
#### Multi-line errors:

``` cmd
$ ./rustc test.rs
test.rs:6:5: 6:6 error: mismatched types:
 expected `core::option::Option<i32>`,
    found `S`
(expected enum `core::option::Option`,
    found struct `S`)
test.rs:6     s
              ^
test.rs:10:5: 10:10 error: mismatched types:
 expected `core::option::Option<i32>`,
    found `core::result::Result<_, _>`
(expected enum `core::option::Option`,
    found enum `core::result::Result`)
test.rs:10     Ok(7) // Should be Some(7)
               ^~~~~
test.rs:15:5: 15:53 error: method `next` has an incompatible type for trait: expected enum `core::option::Option`, found enum `core::result::Result` [E0053]
test.rs:15     fn next(&mut self) -> Result<i32, i32> { Ok(7) }
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to 3 previous errors
```

---
#### Positive notes
- Vim worked fine with it: https://github.com/rust-lang/rust/pull/19203#issuecomment-66861668
- `make check` didn't find any errors
- Fixed _backtick_ placement suggested by @p1start at https://github.com/rust-lang/rust/pull/19203#issuecomment-64062052
#### Negative notes
- Didn't check Emacs support but also wasn't provided a testcase...
- Needs to be tested with macro errors but I don't have a good testcase yet
- I would like to move the `E[0053]` earlier (see https://github.com/rust-lang/rust/issues/19464#issuecomment-65334301) but I don't know how
- It might be better to indent the types slightly like so (but I don't know how):

``` cmd
test.rs:6:5: 6:6 error: mismatched types:
          expected `core::option::Option<int>`,
             found `S`
         (expected enum `core::option::Option`,
             found struct `S`)
test.rs:6     s
```
- Deep whitespace indentation may be a bad idea because early wrapping will cause misalignment between lines
#### Other
- I thought that compiler flags or something else (environment variables maybe) might be required because of comments against it but now that seems too much of a burden for users and for too little gain.
- There was concern that it will make large quantities of errors difficult to distinguish but I don't find that an issue. They both look awful and multi-line errors makes the types easier to understand.

---
#### Single lined spew:

``` cmd
$ rustc test2.rs 
test2.rs:161:9: 170:10 error: method `next` has an incompatible type for trait: expected enum core::option::Option, found enum core::result::Result [E0053]
test2.rs:161         fn next(&mut self) -> Result<&'a str, int> {
test2.rs:162             self.curr = self.next;
test2.rs:163             
test2.rs:164             if let (Some(open), Some(close)) = Parens::find_parens(self.all, self.next) {
test2.rs:165                 self.next = if self.all.char_at(self.next) == '(' { close }
test2.rs:166                 else { open }
             ...
test2.rs:164:21: 164:31 error: mismatched types: expected `core::result::Result<uint, int>`, found `core::option::Option<_>` (expected enum core::result::Result, found enum core::option::Option)
test2.rs:164             if let (Some(open), Some(close)) = Parens::find_parens(self.all, self.next) {
                                 ^~~~~~~~~~
test2.rs:164:33: 164:44 error: mismatched types: expected `core::result::Result<uint, int>`, found `core::option::Option<_>` (expected enum core::result::Result, found enum core::option::Option)
test2.rs:164             if let (Some(open), Some(close)) = Parens::find_parens(self.all, self.next) {
                                             ^~~~~~~~~~~
test2.rs:169:40: 169:76 error: mismatched types: expected `core::result::Result<&'a str, int>`, found `core::option::Option<&str>` (expected enum core::result::Result, found enum core::option::Option)
test2.rs:169             if self.curr != self.len { Some(self.all[self.curr..self.next]) } else { None }
                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test2.rs:169:86: 169:90 error: mismatched types: expected `core::result::Result<&'a str, int>`, found `core::option::Option<_>` (expected enum core::result::Result, found enum core::option::Option)
test2.rs:169             if self.curr != self.len { Some(self.all[self.curr..self.next]) } else { None }
                                                                                                  ^~~~
test2.rs:205:14: 205:18 error: mismatched types: expected `core::result::Result<uint, int>`, found `core::option::Option<uint>` (expected enum core::result::Result, found enum core::option::Option)
test2.rs:205             (open, close)
                          ^~~~
test2.rs:205:20: 205:25 error: mismatched types: expected `core::result::Result<uint, int>`, found `core::option::Option<uint>` (expected enum core::result::Result, found enum core::option::Option)
test2.rs:205             (open, close)
                                ^~~~~
test2.rs:210:21: 210:31 error: mismatched types: expected `core::result::Result<uint, int>`, found `core::option::Option<_>` (expected enum core::result::Result, found enum core::option::Option)
test2.rs:210             if let (Some(open), _) = Parens::find_parens(self.all, 0) {
                                 ^~~~~~~~~~
test2.rs:210:13: 212:28 error: mismatched types: expected `core::option::Option<&'a int>`, found `core::option::Option<&str>` (expected int, found str)
test2.rs:210             if let (Some(open), _) = Parens::find_parens(self.all, 0) {
test2.rs:211                 Some(self.all[0..open])
test2.rs:212             } else { None }
test2.rs:299:48: 299:58 error: mismatched types: expected `Box<translate::Entity>`, found `collections::vec::Vec<_>` (expected box, found struct collections::vec::Vec)
test2.rs:299         pub fn new() -> Entity { Entity::Group(Vec::new()) }
                                                            ^~~~~~~~~~
test2.rs:359:51: 359:58 error: type `&mut Box<translate::Entity>` does not implement any method in scope named `push`
test2.rs:359                 Entity::Group(ref mut vec) => vec.push(e),
                                                               ^~~~~~~
test2.rs:366:51: 366:85 error: type `&mut Box<translate::Entity>` does not implement any method in scope named `push`
test2.rs:366                 Entity::Group(ref mut vec) => vec.push(Entity::Inner(s.to_string())),
                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to 12 previous errors
```

---
#### Multi-line spew:

``` cmd
$ ./rustc test2.rs 
test2.rs:161:9: 170:10 error: method `next` has an incompatible type for trait:
 expected enum `core::option::Option`,
    found enum `core::result::Result` [E0053]
test2.rs:161         fn next(&mut self) -> Result<&'a str, int> {
test2.rs:162             self.curr = self.next;
test2.rs:163             
test2.rs:164             if let (Some(open), Some(close)) = Parens::find_parens(self.all, self.next) {
test2.rs:165                 self.next = if self.all.char_at(self.next) == '(' { close }
test2.rs:166                 else { open }
             ...
test2.rs:164:21: 164:31 error: mismatched types:
 expected `core::result::Result<uint, int>`,
    found `core::option::Option<_>`
(expected enum `core::result::Result`,
    found enum `core::option::Option`)
test2.rs:164             if let (Some(open), Some(close)) = Parens::find_parens(self.all, self.next) {
                                 ^~~~~~~~~~
test2.rs:164:33: 164:44 error: mismatched types:
 expected `core::result::Result<uint, int>`,
    found `core::option::Option<_>`
(expected enum `core::result::Result`,
    found enum `core::option::Option`)
test2.rs:164             if let (Some(open), Some(close)) = Parens::find_parens(self.all, self.next) {
                                             ^~~~~~~~~~~
test2.rs:169:40: 169:76 error: mismatched types:
 expected `core::result::Result<&'a str, int>`,
    found `core::option::Option<&str>`
(expected enum `core::result::Result`,
    found enum `core::option::Option`)
test2.rs:169             if self.curr != self.len { Some(self.all[self.curr..self.next]) } else { None }
                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test2.rs:169:86: 169:90 error: mismatched types:
 expected `core::result::Result<&'a str, int>`,
    found `core::option::Option<_>`
(expected enum `core::result::Result`,
    found enum `core::option::Option`)
test2.rs:169             if self.curr != self.len { Some(self.all[self.curr..self.next]) } else { None }
                                                                                                  ^~~~
test2.rs:205:14: 205:18 error: mismatched types:
 expected `core::result::Result<uint, int>`,
    found `core::option::Option<uint>`
(expected enum `core::result::Result`,
    found enum `core::option::Option`)
test2.rs:205             (open, close)
                          ^~~~
test2.rs:205:20: 205:25 error: mismatched types:
 expected `core::result::Result<uint, int>`,
    found `core::option::Option<uint>`
(expected enum `core::result::Result`,
    found enum `core::option::Option`)
test2.rs:205             (open, close)
                                ^~~~~
test2.rs:210:21: 210:31 error: mismatched types:
 expected `core::result::Result<uint, int>`,
    found `core::option::Option<_>`
(expected enum `core::result::Result`,
    found enum `core::option::Option`)
test2.rs:210             if let (Some(open), _) = Parens::find_parens(self.all, 0) {
                                 ^~~~~~~~~~
test2.rs:210:13: 212:28 error: mismatched types:
 expected `core::option::Option<&'a int>`,
    found `core::option::Option<&str>`
(expected int,
    found str)
test2.rs:210             if let (Some(open), _) = Parens::find_parens(self.all, 0) {
test2.rs:211                 Some(self.all[0..open])
test2.rs:212             } else { None }
test2.rs:229:57: 229:96 error: the trait `core::ops::Fn<(char,), bool>` is not implemented for the type `|char| -> bool`
test2.rs:229                                              .map(|s| s.trim_chars(|c: char| c.is_whitespace()))
                                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test2.rs:238:46: 239:75 error: type `core::str::CharSplits<'_, |char| -> bool>` does not implement any method in scope named `filter_map`
test2.rs:238                                             .filter_map(|s| if !s.is_empty() { Some(s.trim_chars('\'')) }
test2.rs:239                                                             else { None })
test2.rs:237:46: 237:91 error: the trait `core::ops::Fn<(char,), bool>` is not implemented for the type `|char| -> bool`
test2.rs:237                 let vec: Vec<&str> = value[].split(|c: char| matches!(c, '(' | ')' | ','))
                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test2.rs:238:65: 238:77 error: the type of this value must be known in this context
test2.rs:238                                             .filter_map(|s| if !s.is_empty() { Some(s.trim_chars('\'')) }
                                                                             ^~~~~~~~~~~~
test2.rs:299:48: 299:58 error: mismatched types:
 expected `Box<translate::Entity>`,
    found `collections::vec::Vec<_>`
(expected box,
    found struct `collections::vec::Vec`)
test2.rs:299         pub fn new() -> Entity { Entity::Group(Vec::new()) }
                                                            ^~~~~~~~~~
test2.rs:321:36: 322:65 error: type `core::str::CharSplits<'_, |char| -> bool>` does not implement any method in scope named `filter_map`
test2.rs:321                                   .filter_map(|s| if !s.is_empty() { Some(s.trim_chars('\'')) }
test2.rs:322                                                   else { None })
test2.rs:320:36: 320:81 error: the trait `core::ops::Fn<(char,), bool>` is not implemented for the type `|char| -> bool`
test2.rs:320             let vec: Vec<&str> = s.split(|c: char| matches!(c, '(' | ')' | ','))
                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test2.rs:321:55: 321:67 error: the type of this value must be known in this context
test2.rs:321                                   .filter_map(|s| if !s.is_empty() { Some(s.trim_chars('\'')) }
                                                                   ^~~~~~~~~~~~
test2.rs:359:51: 359:58 error: type `&mut Box<translate::Entity>` does not implement any method in scope named `push`
test2.rs:359                 Entity::Group(ref mut vec) => vec.push(e),
                                                               ^~~~~~~
test2.rs:366:51: 366:85 error: type `&mut Box<translate::Entity>` does not implement any method in scope named `push`
test2.rs:366                 Entity::Group(ref mut vec) => vec.push(Entity::Inner(s.to_string())),
                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to 24 previous errors
```

Closes #18946 #19464
cc @P1start @jakub- @tomjakubowski @kballard @chris-morgan
