### PR TITLE
Removing feature directive tuple_indexing and if_let as both these features are added to Rust

### DIFF
--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -24,7 +24,7 @@
 #![allow(unknown_features)]
 #![feature(macro_rules, default_type_params, phase, globs)]
 #![feature(unsafe_destructor, import_shadowing, slicing_syntax)]
-#![feature(tuple_indexing, unboxed_closures)]
+#![feature(unboxed_closures)]
 #![no_std]
 
 #[phase(plugin, link)] extern crate core;

--- a/src/librustc_borrowck/lib.rs
+++ b/src/librustc_borrowck/lib.rs
@@ -16,8 +16,8 @@
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://doc.rust-lang.org/nightly/")]
 
-#![feature(default_type_params, globs, if_let, import_shadowing, macro_rules, phase, quote)]
-#![feature(slicing_syntax, tuple_indexing, unsafe_destructor)]
+#![feature(default_type_params, globs, import_shadowing, macro_rules, phase, quote)]
+#![feature(slicing_syntax, unsafe_destructor)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(unboxed_closures)]
 #![allow(non_camel_case_types)]

--- a/src/test/compile-fail/issue-19096.rs
+++ b/src/test/compile-fail/issue-19096.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
 
 fn main() {
     let t = (42i, 42i);

--- a/src/test/run-pass/borrow-tuple-fields.rs
+++ b/src/test/run-pass/borrow-tuple-fields.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
 
 struct Foo(int, int);
 

--- a/src/test/run-pass/issue-18412.rs
+++ b/src/test/run-pass/issue-18412.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
 
 // Test that non-static methods can be assigned to local variables as
 // function pointers.

--- a/src/test/run-pass/issue-19244.rs
+++ b/src/test/run-pass/issue-19244.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
 
 struct MyStruct { field: uint }
 const STRUCT: MyStruct = MyStruct { field: 42 };

--- a/src/test/run-pass/issue-19367.rs
+++ b/src/test/run-pass/issue-19367.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
 struct S {
     o: Option<String>
 }

--- a/src/test/run-pass/tuple-index-fat-types.rs
+++ b/src/test/run-pass/tuple-index-fat-types.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
 
 struct Foo<'a>(&'a [int]);
 

--- a/src/test/run-pass/tuple-index.rs
+++ b/src/test/run-pass/tuple-index.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(tuple_indexing)]
 
 struct Point(int, int);
 


### PR DESCRIPTION
While compiling rust, I am getting warning regarding tuple_indexing and if_let not required as added part of the Rust.   I have removed these directives.

```
rust/rust/src/librustc_borrowck/lib.rs:19:40: 19:46 warning: feature has been added to Rust, directive not necessary
rust/src/librustc_borrowck/lib.rs:19 #![feature(default_type_params, globs, if_let, import_shadowing, macro_rules, phase, quote)]
                                                                                                    ^~~~~~
rust/src/librustc_borrowck/lib.rs:20:28: 20:42 warning: feature has been added to Rust, directive not necessary
/rust/src/librustc_borrowck/lib.rs:20 #![feature(slicing_syntax, tuple_indexing, unsafe_destructor)]
```
