### PR TITLE
std: Change escape_unicode to use new escapes

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1597,17 +1597,24 @@ mod tests {
 
     #[test]
     fn test_escape_unicode() {
-        assert_eq!("abc".escape_unicode(), String::from_str("\\x61\\x62\\x63"));
-        assert_eq!("a c".escape_unicode(), String::from_str("\\x61\\x20\\x63"));
-        assert_eq!("\r\n\t".escape_unicode(), String::from_str("\\x0d\\x0a\\x09"));
-        assert_eq!("'\"\\".escape_unicode(), String::from_str("\\x27\\x22\\x5c"));
+        assert_eq!("abc".escape_unicode(),
+                   String::from_str("\\u{61}\\u{62}\\u{63}"));
+        assert_eq!("a c".escape_unicode(),
+                   String::from_str("\\u{61}\\u{20}\\u{63}"));
+        assert_eq!("\r\n\t".escape_unicode(),
+                   String::from_str("\\u{d}\\u{a}\\u{9}"));
+        assert_eq!("'\"\\".escape_unicode(),
+                   String::from_str("\\u{27}\\u{22}\\u{5c}"));
         assert_eq!("\x00\x01\u{fe}\u{ff}".escape_unicode(),
-                   String::from_str("\\x00\\x01\\u00fe\\u00ff"));
-        assert_eq!("\u{100}\u{ffff}".escape_unicode(), String::from_str("\\u0100\\uffff"));
+                   String::from_str("\\u{0}\\u{1}\\u{fe}\\u{ff}"));
+        assert_eq!("\u{100}\u{ffff}".escape_unicode(),
+                   String::from_str("\\u{100}\\u{ffff}"));
         assert_eq!("\u{10000}\u{10ffff}".escape_unicode(),
-                   String::from_str("\\U00010000\\U0010ffff"));
-        assert_eq!("ab\u{fb00}".escape_unicode(), String::from_str("\\x61\\x62\\ufb00"));
-        assert_eq!("\u{1d4ea}\r".escape_unicode(), String::from_str("\\U0001d4ea\\x0d"));
+                   String::from_str("\\u{10000}\\u{10ffff}"));
+        assert_eq!("ab\u{fb00}".escape_unicode(),
+                   String::from_str("\\u{61}\\u{62}\\u{fb00}"));
+        assert_eq!("\u{1d4ea}\r".escape_unicode(),
+                   String::from_str("\\u{1d4ea}\\u{d}"));
     }
 
     #[test]
@@ -1616,11 +1623,14 @@ mod tests {
         assert_eq!("a c".escape_default(), String::from_str("a c"));
         assert_eq!("\r\n\t".escape_default(), String::from_str("\\r\\n\\t"));
         assert_eq!("'\"\\".escape_default(), String::from_str("\\'\\\"\\\\"));
-        assert_eq!("\u{100}\u{ffff}".escape_default(), String::from_str("\\u0100\\uffff"));
+        assert_eq!("\u{100}\u{ffff}".escape_default(),
+                   String::from_str("\\u{100}\\u{ffff}"));
         assert_eq!("\u{10000}\u{10ffff}".escape_default(),
-                   String::from_str("\\U00010000\\U0010ffff"));
-        assert_eq!("ab\u{fb00}".escape_default(), String::from_str("ab\\ufb00"));
-        assert_eq!("\u{1d4ea}\r".escape_default(), String::from_str("\\U0001d4ea\\r"));
+                   String::from_str("\\u{10000}\\u{10ffff}"));
+        assert_eq!("ab\u{fb00}".escape_default(),
+                   String::from_str("ab\\u{fb00}"));
+        assert_eq!("\u{1d4ea}\r".escape_default(),
+                   String::from_str("\\u{1d4ea}\\r"));
     }
 
     #[test]

--- a/src/libcoretest/char.rs
+++ b/src/libcoretest/char.rs
@@ -135,38 +135,35 @@ fn test_escape_default() {
     let s = string('~');
     assert_eq!(s, "~");
     let s = string('\x00');
-    assert_eq!(s, "\\x00");
+    assert_eq!(s, "\\u{0}");
     let s = string('\x1f');
-    assert_eq!(s, "\\x1f");
+    assert_eq!(s, "\\u{1f}");
     let s = string('\x7f');
-    assert_eq!(s, "\\x7f");
-    let s = string('\u00ff');
-    assert_eq!(s, "\\u00ff");
-    let s = string('\u011b');
-    assert_eq!(s, "\\u011b");
-    let s = string('\U0001d4b6');
-    assert_eq!(s, "\\U0001d4b6");
+    assert_eq!(s, "\\u{7f}");
+    let s = string('\u{ff}');
+    assert_eq!(s, "\\u{ff}");
+    let s = string('\u{11b}');
+    assert_eq!(s, "\\u{11b}");
+    let s = string('\u{1d4b6}');
+    assert_eq!(s, "\\u{1d4b6}");
 }
 
 #[test]
 fn test_escape_unicode() {
-    fn string(c: char) -> String {
-        let mut result = String::new();
-        escape_unicode(c, |c| { result.push(c); });
-        return result;
-    }
+    fn string(c: char) -> String { c.escape_unicode().collect() }
+
     let s = string('\x00');
-    assert_eq!(s, "\\x00");
+    assert_eq!(s, "\\u{0}");
     let s = string('\n');
-    assert_eq!(s, "\\x0a");
+    assert_eq!(s, "\\u{a}");
     let s = string(' ');
-    assert_eq!(s, "\\x20");
+    assert_eq!(s, "\\u{20}");
     let s = string('a');
-    assert_eq!(s, "\\x61");
-    let s = string('\u011b');
-    assert_eq!(s, "\\u011b");
-    let s = string('\U0001d4b6');
-    assert_eq!(s, "\\U0001d4b6");
+    assert_eq!(s, "\\u{61}");
+    let s = string('\u{11b}');
+    assert_eq!(s, "\\u{11b}");
+    let s = string('\u{1d4b6}');
+    assert_eq!(s, "\\u{1d4b6}");
 }
 
 #[test]

--- a/src/test/compile-fail-fulldeps/macro-crate-cannot-read-embedded-ident.rs
+++ b/src/test/compile-fail-fulldeps/macro-crate-cannot-read-embedded-ident.rs
@@ -11,7 +11,7 @@
 // aux-build:macro_crate_test.rs
 // ignore-stage1
 // ignore-android
-// error-pattern: unknown start of token: \x00
+// error-pattern: unknown start of token: \u{0}
 
 // Issue #15750 and #15962 : this test is checking that the standard
 // parser rejects embedded idents.  pnkfelix did not want to attempt


### PR DESCRIPTION
This changes the `escape_unicode` method on a `char` to use the new style of
unicode escapes in the language.

Closes #19811
Closes #19879
