### PR TITLE
serialize: Change some FnOnce bounds to FnMut

### DIFF
--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -499,8 +499,9 @@ pub mod reader {
             Ok(result)
         }
 
-        fn read_enum_variant<T, F>(&mut self, _: &[&str], f: F) -> DecodeResult<T> where
-            F: FnOnce(&mut Decoder<'doc>, uint) -> DecodeResult<T>,
+        fn read_enum_variant<T, F>(&mut self, _: &[&str],
+                                   mut f: F) -> DecodeResult<T>
+            where F: FnMut(&mut Decoder<'doc>, uint) -> DecodeResult<T>,
         {
             debug!("read_enum_variant()");
             let idx = try!(self._next_uint(EsEnumVid));
@@ -526,8 +527,9 @@ pub mod reader {
             f(self)
         }
 
-        fn read_enum_struct_variant<T, F>(&mut self, _: &[&str], f: F) -> DecodeResult<T> where
-            F: FnOnce(&mut Decoder<'doc>, uint) -> DecodeResult<T>,
+        fn read_enum_struct_variant<T, F>(&mut self, _: &[&str],
+                                          mut f: F) -> DecodeResult<T>
+            where F: FnMut(&mut Decoder<'doc>, uint) -> DecodeResult<T>,
         {
             debug!("read_enum_struct_variant()");
             let idx = try!(self._next_uint(EsEnumVid));
@@ -610,8 +612,8 @@ pub mod reader {
             self.read_tuple_arg(idx, f)
         }
 
-        fn read_option<T, F>(&mut self, f: F) -> DecodeResult<T> where
-            F: FnOnce(&mut Decoder<'doc>, bool) -> DecodeResult<T>,
+        fn read_option<T, F>(&mut self, mut f: F) -> DecodeResult<T> where
+            F: FnMut(&mut Decoder<'doc>, bool) -> DecodeResult<T>,
         {
             debug!("read_option()");
             self.read_enum("Option", move |this| {

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -2082,8 +2082,9 @@ impl ::Decoder<DecoderError> for Decoder {
         f(self)
     }
 
-    fn read_enum_variant<T, F>(&mut self, names: &[&str], f: F) -> DecodeResult<T> where
-        F: FnOnce(&mut Decoder, uint) -> DecodeResult<T>,
+    fn read_enum_variant<T, F>(&mut self, names: &[&str],
+                               mut f: F) -> DecodeResult<T>
+        where F: FnMut(&mut Decoder, uint) -> DecodeResult<T>,
     {
         debug!("read_enum_variant(names={})", names);
         let name = match self.pop() {
@@ -2133,7 +2134,7 @@ impl ::Decoder<DecoderError> for Decoder {
     }
 
     fn read_enum_struct_variant<T, F>(&mut self, names: &[&str], f: F) -> DecodeResult<T> where
-        F: FnOnce(&mut Decoder, uint) -> DecodeResult<T>,
+        F: FnMut(&mut Decoder, uint) -> DecodeResult<T>,
     {
         debug!("read_enum_struct_variant(names={})", names);
         self.read_enum_variant(names, f)
@@ -2230,8 +2231,8 @@ impl ::Decoder<DecoderError> for Decoder {
         self.read_tuple_arg(idx, f)
     }
 
-    fn read_option<T, F>(&mut self, f: F) -> DecodeResult<T> where
-        F: FnOnce(&mut Decoder, bool) -> DecodeResult<T>,
+    fn read_option<T, F>(&mut self, mut f: F) -> DecodeResult<T> where
+        F: FnMut(&mut Decoder, bool) -> DecodeResult<T>,
     {
         debug!("read_option()");
         match self.pop() {

--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -120,12 +120,12 @@ pub trait Decoder<E> {
         F: FnOnce(&mut Self) -> Result<T, E>;
 
     fn read_enum_variant<T, F>(&mut self, names: &[&str], f: F) -> Result<T, E> where
-        F: FnOnce(&mut Self, uint) -> Result<T, E>;
+        F: FnMut(&mut Self, uint) -> Result<T, E>;
     fn read_enum_variant_arg<T, F>(&mut self, a_idx: uint, f: F) -> Result<T, E> where
         F: FnOnce(&mut Self) -> Result<T, E>;
 
     fn read_enum_struct_variant<T, F>(&mut self, names: &[&str], f: F) -> Result<T, E> where
-        F: FnOnce(&mut Self, uint) -> Result<T, E>;
+        F: FnMut(&mut Self, uint) -> Result<T, E>;
     fn read_enum_struct_variant_field<T, F>(&mut self,
                                             &f_name: &str,
                                             f_idx: uint,
@@ -154,7 +154,7 @@ pub trait Decoder<E> {
 
     // Specialized types:
     fn read_option<T, F>(&mut self, f: F) -> Result<T, E> where
-        F: FnOnce(&mut Self, bool) -> Result<T, E>;
+        F: FnMut(&mut Self, bool) -> Result<T, E>;
 
     fn read_seq<T, F>(&mut self, f: F) -> Result<T, E> where
         F: FnOnce(&mut Self, uint) -> Result<T, E>;


### PR DESCRIPTION
Relax some of the bounds on the decoder methods back to FnMut to help accomodate
some more flavorful variants of decoders which may need to run the closure more
than once when it, for example, attempts to find the first successful enum to
decode.
