### PR TITLE
Don't make unboxed closures implicitly copiable

### DIFF
--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1209,6 +1209,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 // is reserve judgement and then intertwine this
                 // analysis with closure inference.
                 assert_eq!(def_id.krate, ast::LOCAL_CRATE);
+
+                // Unboxed closures shouldn't be
+                // implicitly copyable
+                if bound == ty::BoundCopy {
+                    return Ok(ParameterBuiltin);
+                }
+
                 match self.tcx().freevars.borrow().get(&def_id.node) {
                     None => {
                         // No upvars.

--- a/src/test/compile-fail/unboxed-closer-non-implicit-copyable.rs
+++ b/src/test/compile-fail/unboxed-closer-non-implicit-copyable.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unboxed_closures)]
+
+fn main() {
+    let f = move|:| ();
+    f();
+    f(); //~ ERROR use of moved value
+}


### PR DESCRIPTION
The fix just checks if the bound is `Copy` and returns an `Err` if so.

Closes: #19817

@nikomatsakis r?
