### PR TITLE
std: Second-pass stabilization of `mem`/`default`

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -316,7 +316,9 @@ impl<T: fmt::Show> fmt::Show for Arc<T> {
     }
 }
 
+#[stable]
 impl<T: Default + Sync + Send> Default for Arc<T> {
+    #[stable]
     fn default() -> Arc<T> { Arc::new(Default::default()) }
 }
 

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -44,11 +44,15 @@ pub static HEAP: () = ();
 #[unstable = "custom allocators will add an additional type parameter (with default)"]
 pub struct Box<T>(*mut T);
 
+#[stable]
 impl<T: Default> Default for Box<T> {
+    #[stable]
     fn default() -> Box<T> { box Default::default() }
 }
 
+#[stable]
 impl<T> Default for Box<[T]> {
+    #[stable]
     fn default() -> Box<[T]> { box [] }
 }
 

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -447,6 +447,7 @@ impl<T: Default> Default for Rc<T> {
     /// let x: Rc<int> = Default::default();
     /// ```
     #[inline]
+    #[stable]
     fn default() -> Rc<T> {
         Rc::new(Default::default())
     }

--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -172,8 +172,10 @@ pub struct BinaryHeap<T> {
     data: Vec<T>,
 }
 
+#[stable]
 impl<T: Ord> Default for BinaryHeap<T> {
     #[inline]
+    #[stable]
     fn default() -> BinaryHeap<T> { BinaryHeap::new() }
 }
 

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -824,8 +824,10 @@ pub fn from_fn<F>(len: uint, mut f: F) -> Bitv where F: FnMut(uint) -> bool {
     bitv
 }
 
+#[stable]
 impl Default for Bitv {
     #[inline]
+    #[stable]
     fn default() -> Bitv { Bitv::new() }
 }
 

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -836,7 +836,9 @@ impl<S: Writer, K: Hash<S>, V: Hash<S>> Hash<S> for BTreeMap<K, V> {
     }
 }
 
+#[stable]
 impl<K: Ord, V> Default for BTreeMap<K, V> {
+    #[stable]
     fn default() -> BTreeMap<K, V> {
         BTreeMap::new()
     }

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -436,7 +436,9 @@ impl<T: Ord> Extend<T> for BTreeSet<T> {
     }
 }
 
+#[stable]
 impl<T: Ord> Default for BTreeSet<T> {
+    #[stable]
     fn default() -> BTreeSet<T> {
         BTreeSet::new()
     }

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -192,8 +192,10 @@ impl<T> DList<T> {
     }
 }
 
+#[stable]
 impl<T> Default for DList<T> {
     #[inline]
+    #[stable]
     fn default() -> DList<T> { DList::new() }
 }
 

--- a/src/libcollections/hash/sip.rs
+++ b/src/libcollections/hash/sip.rs
@@ -204,8 +204,10 @@ impl Clone for SipState {
     }
 }
 
+#[stable]
 impl Default for SipState {
     #[inline]
+    #[stable]
     fn default() -> SipState {
         SipState::new()
     }

--- a/src/libcollections/ring_buf.rs
+++ b/src/libcollections/ring_buf.rs
@@ -68,7 +68,9 @@ impl<T> Drop for RingBuf<T> {
     }
 }
 
+#[stable]
 impl<T> Default for RingBuf<T> {
+    #[stable]
     #[inline]
     fn default() -> RingBuf<T> { RingBuf::new() }
 }

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -826,6 +826,7 @@ impl StrAllocating for String {
 
 #[stable]
 impl Default for String {
+    #[stable]
     fn default() -> String {
         String::new()
     }

--- a/src/libcollections/tree/map.rs
+++ b/src/libcollections/tree/map.rs
@@ -185,8 +185,10 @@ impl<K: Ord + Show, V: Show> Show for TreeMap<K, V> {
     }
 }
 
+#[stable]
 impl<K: Ord, V> Default for TreeMap<K,V> {
     #[inline]
+    #[stable]
     fn default() -> TreeMap<K, V> { TreeMap::new() }
 }
 

--- a/src/libcollections/tree/set.rs
+++ b/src/libcollections/tree/set.rs
@@ -134,8 +134,10 @@ impl<T: Ord + Show> Show for TreeSet<T> {
     }
 }
 
+#[stable]
 impl<T: Ord> Default for TreeSet<T> {
     #[inline]
+    #[stable]
     fn default() -> TreeSet<T> { TreeSet::new() }
 }
 

--- a/src/libcollections/trie/map.rs
+++ b/src/libcollections/trie/map.rs
@@ -150,8 +150,10 @@ impl<T: Show> Show for TrieMap<T> {
     }
 }
 
+#[stable]
 impl<T> Default for TrieMap<T> {
     #[inline]
+    #[stable]
     fn default() -> TrieMap<T> { TrieMap::new() }
 }
 

--- a/src/libcollections/trie/set.rs
+++ b/src/libcollections/trie/set.rs
@@ -69,8 +69,10 @@ impl Show for TrieSet {
     }
 }
 
+#[stable]
 impl Default for TrieSet {
     #[inline]
+    #[stable]
     fn default() -> TrieSet { TrieSet::new() }
 }
 

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1322,6 +1322,7 @@ impl<T> Drop for Vec<T> {
 
 #[stable]
 impl<T> Default for Vec<T> {
+    #[stable]
     fn default() -> Vec<T> {
         Vec::new()
     }

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -66,7 +66,9 @@ pub struct VecMap<V> {
     v: Vec<Option<V>>,
 }
 
+#[stable]
 impl<V> Default for VecMap<V> {
+    #[stable]
     #[inline]
     fn default() -> VecMap<V> { VecMap::new() }
 }

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -215,8 +215,9 @@ impl<T:Copy> Clone for Cell<T> {
     }
 }
 
-#[unstable]
+#[stable]
 impl<T:Default + Copy> Default for Cell<T> {
+    #[stable]
     fn default() -> Cell<T> {
         Cell::new(Default::default())
     }
@@ -349,8 +350,9 @@ impl<T: Clone> Clone for RefCell<T> {
     }
 }
 
-#[unstable]
+#[stable]
 impl<T:Default> Default for RefCell<T> {
+    #[stable]
     fn default() -> RefCell<T> {
         RefCell::new(Default::default())
     }

--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -97,6 +97,7 @@
 ///     bar: f32,
 /// }
 /// ```
+#[stable]
 pub trait Default {
     /// Returns the "default value" for a type.
     ///
@@ -130,13 +131,16 @@ pub trait Default {
     ///     fn default() -> Kind { Kind::A }
     /// }
     /// ```
+    #[stable]
     fn default() -> Self;
 }
 
 macro_rules! default_impl(
     ($t:ty, $v:expr) => {
+        #[stable]
         impl Default for $t {
             #[inline]
+            #[stable]
             fn default() -> $t { $v }
         }
     }

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -217,6 +217,7 @@ extern "rust-intrinsic" {
     ///
     /// `forget` is unsafe because the caller is responsible for
     /// ensuring the argument is deallocated already.
+    #[stable]
     pub fn forget<T>(_: T) -> ();
 
     /// Unsafely transforms a value of one type into a value of another type.
@@ -232,6 +233,7 @@ extern "rust-intrinsic" {
     /// let v: &[u8] = unsafe { mem::transmute("L") };
     /// assert!(v == [76u8]);
     /// ```
+    #[stable]
     pub fn transmute<T,U>(e: T) -> U;
 
     /// Gives the address for the return value of the enclosing function.

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -13,9 +13,13 @@
 //! This module contains functions for querying the size and alignment of
 //! types, initializing and manipulating memory.
 
+#![stable]
+
+use kinds::Sized;
 use intrinsics;
 use ptr;
 
+#[stable]
 pub use intrinsics::transmute;
 
 /// Moves a thing into the void.
@@ -223,7 +227,8 @@ pub unsafe fn transmute_copy<T, U>(src: &T) -> U {
 #[inline]
 #[unstable = "this function may be removed in the future due to its \
               questionable utility"]
-pub unsafe fn copy_lifetime<'a, S, T:'a>(_ptr: &'a S, ptr: &T) -> &'a T {
+pub unsafe fn copy_lifetime<'a, Sized? S, Sized? T: 'a>(_ptr: &'a S,
+                                                        ptr: &T) -> &'a T {
     transmute(ptr)
 }
 
@@ -231,7 +236,8 @@ pub unsafe fn copy_lifetime<'a, S, T:'a>(_ptr: &'a S, ptr: &T) -> &'a T {
 #[inline]
 #[unstable = "this function may be removed in the future due to its \
               questionable utility"]
-pub unsafe fn copy_mut_lifetime<'a, S, T:'a>(_ptr: &'a mut S,
-                                          ptr: &mut T) -> &'a mut T {
+pub unsafe fn copy_mut_lifetime<'a, Sized? S, Sized? T: 'a>(_ptr: &'a mut S,
+                                                            ptr: &mut T)
+                                                            -> &'a mut T {
     transmute(ptr)
 }

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -760,6 +760,7 @@ impl<T> AsSlice<T> for Option<T> {
 
 #[stable]
 impl<T> Default for Option<T> {
+    #[stable]
     #[inline]
     fn default() -> Option<T> { None }
 }

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1044,8 +1044,9 @@ impl<'a, T, Sized? U: AsSlice<T>> AsSlice<T> for &'a mut U {
     fn as_slice<'a>(&'a self) -> &'a [T] { AsSlice::as_slice(*self) }
 }
 
-#[unstable = "waiting for DST"]
+#[stable]
 impl<'a, T> Default for &'a [T] {
+    #[stable]
     fn default() -> &'a [T] { &[] }
 }
 

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -2349,7 +2349,9 @@ impl StrPrelude for str {
     fn len(&self) -> uint { self.repr().len }
 }
 
+#[stable]
 impl<'a> Default for &'a str {
+    #[stable]
     fn default() -> &'a str { "" }
 }
 

--- a/src/libcore/tuple/mod.rs
+++ b/src/libcore/tuple/mod.rs
@@ -182,6 +182,7 @@ macro_rules! tuple_impls {
 
             #[stable]
             impl<$($T:Default),+> Default for ($($T,)+) {
+                #[stable]
                 #[inline]
                 fn default() -> ($($T,)+) {
                     ($({ let x: $T = Default::default(); x},)+)

--- a/src/librand/reseeding.rs
+++ b/src/librand/reseeding.rs
@@ -142,7 +142,9 @@ impl<R: Rng + Default> Reseeder<R> for ReseedWithDefault {
         *rng = Default::default();
     }
 }
+#[stable]
 impl Default for ReseedWithDefault {
+    #[stable]
     fn default() -> ReseedWithDefault { ReseedWithDefault }
 }
 

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1288,7 +1288,9 @@ impl<K: Eq + Hash<S> + Show, V: Show, S, H: Hasher<S>> Show for HashMap<K, V, H>
     }
 }
 
+#[stable]
 impl<K: Eq + Hash<S>, V, S, H: Hasher<S> + Default> Default for HashMap<K, V, H> {
+    #[stable]
     fn default() -> HashMap<K, V, H> {
         HashMap::with_hasher(Default::default())
     }

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -610,7 +610,9 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S> + Default> Extend<T> for HashSet<T, H> {
     }
 }
 
+#[stable]
 impl<T: Eq + Hash<S>, S, H: Hasher<S> + Default> Default for HashSet<T, H> {
+    #[stable]
     fn default() -> HashSet<T, H> {
         HashSet::with_hasher(Default::default())
     }

--- a/src/libstd/hash.rs
+++ b/src/libstd/hash.rs
@@ -95,7 +95,9 @@ impl Hasher<sip::SipState> for RandomSipHasher {
     }
 }
 
+#[stable]
 impl Default for RandomSipHasher {
+    #[stable]
     #[inline]
     fn default() -> RandomSipHasher {
         RandomSipHasher::new()

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1911,7 +1911,9 @@ bitflags! {
 }
 
 
+#[stable]
 impl Default for FilePermission {
+    #[stable]
     #[inline]
     fn default() -> FilePermission { FilePermission::empty() }
 }


### PR DESCRIPTION
This commit stabilizes the `mem` and `default` modules of std.
