### PR TITLE
Add probe and var for file to rustup.sh

### DIFF
--- a/src/etc/rustup.sh
+++ b/src/etc/rustup.sh
@@ -231,6 +231,7 @@ validate_opt() {
 
 probe_need CFG_CURL  curl
 probe_need CFG_TAR   tar
+probe_need CFG_FILE  file
 
 CFG_SRC_DIR="$(cd $(dirname $0) && pwd)/"
 CFG_SELF="$0"
@@ -359,7 +360,7 @@ esac
 # Detect 64 bit linux systems with 32 bit userland and force 32 bit compilation
 if [ $CFG_OSTYPE = unknown-linux-gnu -a $CFG_CPUTYPE = x86_64 ]
 then
-    file -L "$SHELL" | grep -q "x86[_-]64"
+    "${CFG_FILE}" -L "$SHELL" | grep -q "x86[_-]64"
     if [ $? != 0 ]; then
         CFG_CPUTYPE=i686
     fi


### PR DESCRIPTION
Was testing rustup on a very minimal Debian installation and got errors during the install process (error occurred in `install.sh` of the Rust nightly.)

Noticed that Rustup was downloading the i686 nightly instead of x86-64. Installing `file` fixed the problem, and this patch adds the probe to ensure file is installed before attempting to use it.

There may still be an issue with the i686 installation, I did not investigate further.
