### PR TITLE
Tuple test no longer needed. Is already in run-pass tests

### DIFF
--- a/src/libcoretest/tuple.rs
+++ b/src/libcoretest/tuple.rs
@@ -16,32 +16,6 @@ fn test_clone() {
 }
 
 #[test]
-fn test_getters() {
-    macro_rules! test_getter(
-        ($x:expr, $valN:ident, $refN:ident, $mutN:ident,
-         $init:expr, $incr:expr, $result:expr) => ({
-            assert_eq!($x.$valN(), $init);
-            assert_eq!(*$x.$refN(), $init);
-            *$x.$mutN() += $incr;
-            assert_eq!(*$x.$refN(), $result);
-        })
-    )
-    let mut x = (0u8, 1u16, 2u32, 3u64, 4u, 5i8, 6i16, 7i32, 8i64, 9i, 10f32, 11f64);
-    test_getter!(x, val0,  ref0,  mut0,  0,    1,   1);
-    test_getter!(x, val1,  ref1,  mut1,  1,    1,   2);
-    test_getter!(x, val2,  ref2,  mut2,  2,    1,   3);
-    test_getter!(x, val3,  ref3,  mut3,  3,    1,   4);
-    test_getter!(x, val4,  ref4,  mut4,  4,    1,   5);
-    test_getter!(x, val5,  ref5,  mut5,  5,    1,   6);
-    test_getter!(x, val6,  ref6,  mut6,  6,    1,   7);
-    test_getter!(x, val7,  ref7,  mut7,  7,    1,   8);
-    test_getter!(x, val8,  ref8,  mut8,  8,    1,   9);
-    test_getter!(x, val9,  ref9,  mut9,  9,    1,   10);
-    test_getter!(x, val10, ref10, mut10, 10.0, 1.0, 11.0);
-    test_getter!(x, val11, ref11, mut11, 11.0, 1.0, 12.0);
-}
-
-#[test]
 fn test_tuple_cmp() {
     let (small, big) = ((1u, 2u, 3u), (3u, 2u, 1u));
 


### PR DESCRIPTION
Fixes some tuple indexing deprecation warnings. Didn't test. Don't see how it could fail unless I need to modify a makefile somewhere...

r? @alexcrichton 
