### PR TITLE
`std::ascii` reform

### DIFF
--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -67,7 +67,7 @@ fn parse_expected(last_nonfollow_error: Option<uint>,
                   re: &Regex) -> Option<(WhichLine, ExpectedError)> {
     re.captures(line).and_then(|caps| {
         let adjusts = caps.name("adjusts").unwrap_or("").len();
-        let kind = caps.name("kind").unwrap_or("").to_ascii_lower();
+        let kind = caps.name("kind").unwrap_or("").to_ascii_lowercase();
         let msg = caps.name("msg").unwrap_or("").trim().to_string();
         let follow = caps.name("follow").unwrap_or("").len() > 0;
 

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -21,6 +21,8 @@ use util::logv;
 #[cfg(target_os = "windows")]
 use util;
 
+#[cfg(target_os = "windows")]
+use std::ascii::AsciiExt;
 use std::io::File;
 use std::io::fs::PathExtensions;
 use std::io::fs;
@@ -985,22 +987,9 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
         format!("{}:{}:", testfile.display(), ee.line)
     }).collect::<Vec<String> >();
 
-    #[cfg(target_os = "windows")]
-    fn to_lower( s : &str ) -> String {
-        let i = s.chars();
-        let c : Vec<char> = i.map( |c| {
-            if c.is_ascii() {
-                c.to_ascii().to_lowercase().as_char()
-            } else {
-                c
-            }
-        } ).collect();
-        String::from_chars(c.as_slice())
-    }
-
     #[cfg(windows)]
     fn prefix_matches( line : &str, prefix : &str ) -> bool {
-        to_lower(line).as_slice().starts_with(to_lower(prefix).as_slice())
+        line.to_ascii_lowercase().starts_with(prefix.to_ascii_lowercase().as_slice())
     }
 
     #[cfg(unix)]

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -68,7 +68,7 @@ pub struct Lint {
 impl Lint {
     /// Get the lint's name, with ASCII letters converted to lowercase.
     pub fn name_lower(&self) -> String {
-        self.name.to_ascii_lower()
+        self.name.to_ascii_lowercase()
     }
 }
 

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -235,7 +235,7 @@ pub fn render(w: &mut fmt::Formatter, s: &str, print_toc: bool) -> fmt::Result {
         };
 
         // Transform the contents of the header into a hyphenated string
-        let id = s.words().map(|s| s.to_ascii_lower())
+        let id = s.words().map(|s| s.to_ascii_lowercase())
             .collect::<Vec<String>>().connect("-");
 
         // This is a terrible hack working around how hoedown gives us rendered

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -108,22 +108,20 @@ impl AsciiExt<Vec<u8>> for [u8] {
 
     #[inline]
     fn to_ascii_uppercase(&self) -> Vec<u8> {
-        self.iter().map(|&byte| ASCII_UPPER_MAP[byte as uint]).collect()
+        self.iter().map(|b| b.to_ascii_uppercase()).collect()
     }
 
     #[inline]
     fn to_ascii_lowercase(&self) -> Vec<u8> {
-        self.iter().map(|&byte| ASCII_LOWER_MAP[byte as uint]).collect()
+        self.iter().map(|b| b.to_ascii_lowercase()).collect()
     }
 
     #[inline]
     fn eq_ignore_ascii_case(&self, other: &[u8]) -> bool {
         self.len() == other.len() &&
-            self.iter().zip(other.iter()).all(
-            |(byte_self, byte_other)| {
-                ASCII_LOWER_MAP[*byte_self as uint] ==
-                    ASCII_LOWER_MAP[*byte_other as uint]
-            })
+        self.iter().zip(other.iter()).all(|(a, b)| {
+            a.eq_ignore_ascii_case(b)
+        })
     }
 }
 
@@ -132,7 +130,7 @@ impl OwnedAsciiExt for Vec<u8> {
     #[inline]
     fn into_ascii_uppercase(mut self) -> Vec<u8> {
         for byte in self.iter_mut() {
-            *byte = ASCII_UPPER_MAP[*byte as uint];
+            *byte = byte.to_ascii_uppercase();
         }
         self
     }
@@ -140,7 +138,7 @@ impl OwnedAsciiExt for Vec<u8> {
     #[inline]
     fn into_ascii_lowercase(mut self) -> Vec<u8> {
         for byte in self.iter_mut() {
-            *byte = ASCII_LOWER_MAP[*byte as uint];
+            *byte = byte.to_ascii_lowercase();
         }
         self
     }
@@ -155,17 +153,17 @@ impl AsciiExt for u8 {
 
     #[inline]
     fn to_ascii_uppercase(&self) -> u8 {
-        ASCII_UPPER_MAP[*self as uint]
+        ASCII_UPPERCASE_MAP[*self as uint]
     }
 
     #[inline]
     fn to_ascii_lowercase(&self) -> u8 {
-        ASCII_LOWER_MAP[*self as uint]
+        ASCII_LOWERCASE_MAP[*self as uint]
     }
 
     #[inline]
     fn eq_ignore_ascii_case(&self, other: &u8) -> bool {
-        ASCII_LOWER_MAP[*self as uint] == ASCII_LOWER_MAP[*other as uint]
+        self.to_ascii_lowercase() == other.to_ascii_lowercase()
     }
 }
 
@@ -179,7 +177,7 @@ impl AsciiExt for char {
     #[inline]
     fn to_ascii_uppercase(&self) -> char {
         if self.is_ascii() {
-            ASCII_UPPER_MAP[*self as uint] as char
+            (*self as u8).to_ascii_uppercase() as char
         } else {
             *self
         }
@@ -188,7 +186,7 @@ impl AsciiExt for char {
     #[inline]
     fn to_ascii_lowercase(&self) -> char {
         if self.is_ascii() {
-            ASCII_UPPER_MAP[*self as uint] as char
+            (*self as u8).to_ascii_lowercase() as char
         } else {
             *self
         }
@@ -236,7 +234,7 @@ pub fn escape_default<F>(c: u8, mut f: F) where
     }
 }
 
-static ASCII_LOWER_MAP: [u8, ..256] = [
+static ASCII_LOWERCASE_MAP: [u8, ..256] = [
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
     0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
@@ -275,7 +273,7 @@ static ASCII_LOWER_MAP: [u8, ..256] = [
     0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff,
 ];
 
-static ASCII_UPPER_MAP: [u8, ..256] = [
+static ASCII_UPPERCASE_MAP: [u8, ..256] = [
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
     0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -409,12 +409,12 @@ pub trait OwnedAsciiExt {
     /// Convert the string to ASCII upper case:
     /// ASCII letters 'a' to 'z' are mapped to 'A' to 'Z',
     /// but non-ASCII letters are unchanged.
-    fn into_ascii_upper(self) -> Self;
+    fn into_ascii_uppercase(self) -> Self;
 
     /// Convert the string to ASCII lower case:
     /// ASCII letters 'A' to 'Z' are mapped to 'a' to 'z',
     /// but non-ASCII letters are unchanged.
-    fn into_ascii_lower(self) -> Self;
+    fn into_ascii_lowercase(self) -> Self;
 }
 
 /// Extension methods for ASCII-subset only operations on string slices
@@ -423,15 +423,15 @@ pub trait AsciiExt<T> for Sized? {
     /// Makes a copy of the string in ASCII upper case:
     /// ASCII letters 'a' to 'z' are mapped to 'A' to 'Z',
     /// but non-ASCII letters are unchanged.
-    fn to_ascii_upper(&self) -> T;
+    fn to_ascii_uppercase(&self) -> T;
 
     /// Makes a copy of the string in ASCII lower case:
     /// ASCII letters 'A' to 'Z' are mapped to 'a' to 'z',
     /// but non-ASCII letters are unchanged.
-    fn to_ascii_lower(&self) -> T;
+    fn to_ascii_lowercase(&self) -> T;
 
     /// Check that two strings are an ASCII case-insensitive match.
-    /// Same as `to_ascii_lower(a) == to_ascii_lower(b)`,
+    /// Same as `to_ascii_lowercase(a) == to_ascii_lower(b)`,
     /// but without allocating and copying temporary strings.
     fn eq_ignore_ascii_case(&self, other: &Self) -> bool;
 }
@@ -439,15 +439,15 @@ pub trait AsciiExt<T> for Sized? {
 #[experimental = "would prefer to do this in a more general way"]
 impl AsciiExt<String> for str {
     #[inline]
-    fn to_ascii_upper(&self) -> String {
-        // Vec<u8>::to_ascii_upper() preserves the UTF-8 invariant.
-        unsafe { String::from_utf8_unchecked(self.as_bytes().to_ascii_upper()) }
+    fn to_ascii_uppercase(&self) -> String {
+        // Vec<u8>::to_ascii_uppercase() preserves the UTF-8 invariant.
+        unsafe { String::from_utf8_unchecked(self.as_bytes().to_ascii_uppercase()) }
     }
 
     #[inline]
-    fn to_ascii_lower(&self) -> String {
-        // Vec<u8>::to_ascii_lower() preserves the UTF-8 invariant.
-        unsafe { String::from_utf8_unchecked(self.as_bytes().to_ascii_lower()) }
+    fn to_ascii_lowercase(&self) -> String {
+        // Vec<u8>::to_ascii_lowercase() preserves the UTF-8 invariant.
+        unsafe { String::from_utf8_unchecked(self.as_bytes().to_ascii_lowercase()) }
     }
 
     #[inline]
@@ -459,27 +459,27 @@ impl AsciiExt<String> for str {
 #[experimental = "would prefer to do this in a more general way"]
 impl OwnedAsciiExt for String {
     #[inline]
-    fn into_ascii_upper(self) -> String {
-        // Vec<u8>::into_ascii_upper() preserves the UTF-8 invariant.
-        unsafe { String::from_utf8_unchecked(self.into_bytes().into_ascii_upper()) }
+    fn into_ascii_uppercase(self) -> String {
+        // Vec<u8>::into_ascii_uppercase() preserves the UTF-8 invariant.
+        unsafe { String::from_utf8_unchecked(self.into_bytes().into_ascii_uppercase()) }
     }
 
     #[inline]
-    fn into_ascii_lower(self) -> String {
-        // Vec<u8>::into_ascii_lower() preserves the UTF-8 invariant.
-        unsafe { String::from_utf8_unchecked(self.into_bytes().into_ascii_lower()) }
+    fn into_ascii_lowercase(self) -> String {
+        // Vec<u8>::into_ascii_lowercase() preserves the UTF-8 invariant.
+        unsafe { String::from_utf8_unchecked(self.into_bytes().into_ascii_lowercase()) }
     }
 }
 
 #[experimental = "would prefer to do this in a more general way"]
 impl AsciiExt<Vec<u8>> for [u8] {
     #[inline]
-    fn to_ascii_upper(&self) -> Vec<u8> {
+    fn to_ascii_uppercase(&self) -> Vec<u8> {
         self.iter().map(|&byte| ASCII_UPPER_MAP[byte as uint]).collect()
     }
 
     #[inline]
-    fn to_ascii_lower(&self) -> Vec<u8> {
+    fn to_ascii_lowercase(&self) -> Vec<u8> {
         self.iter().map(|&byte| ASCII_LOWER_MAP[byte as uint]).collect()
     }
 
@@ -497,7 +497,7 @@ impl AsciiExt<Vec<u8>> for [u8] {
 #[experimental = "would prefer to do this in a more general way"]
 impl OwnedAsciiExt for Vec<u8> {
     #[inline]
-    fn into_ascii_upper(mut self) -> Vec<u8> {
+    fn into_ascii_uppercase(mut self) -> Vec<u8> {
         for byte in self.iter_mut() {
             *byte = ASCII_UPPER_MAP[*byte as uint];
         }
@@ -505,7 +505,7 @@ impl OwnedAsciiExt for Vec<u8> {
     }
 
     #[inline]
-    fn into_ascii_lower(mut self) -> Vec<u8> {
+    fn into_ascii_lowercase(mut self) -> Vec<u8> {
         for byte in self.iter_mut() {
             *byte = ASCII_LOWER_MAP[*byte as uint];
         }
@@ -775,64 +775,64 @@ mod tests {
     }
 
     #[test]
-    fn test_to_ascii_upper() {
-        assert_eq!("url()URL()uRl()ürl".to_ascii_upper(), "URL()URL()URL()üRL");
-        assert_eq!("hıKß".to_ascii_upper(), "HıKß");
+    fn test_to_ascii_uppercase() {
+        assert_eq!("url()URL()uRl()ürl".to_ascii_uppercase(), "URL()URL()URL()üRL");
+        assert_eq!("hıKß".to_ascii_uppercase(), "HıKß");
 
         let mut i = 0;
         while i <= 500 {
             let upper = if 'a' as u32 <= i && i <= 'z' as u32 { i + 'A' as u32 - 'a' as u32 }
                         else { i };
-            assert_eq!((from_u32(i).unwrap()).to_string().to_ascii_upper(),
+            assert_eq!((from_u32(i).unwrap()).to_string().to_ascii_uppercase(),
                        (from_u32(upper).unwrap()).to_string());
             i += 1;
         }
     }
 
     #[test]
-    fn test_to_ascii_lower() {
-        assert_eq!("url()URL()uRl()Ürl".to_ascii_lower(), "url()url()url()Ürl");
+    fn test_to_ascii_lowercase() {
+        assert_eq!("url()URL()uRl()Ürl".to_ascii_lowercase(), "url()url()url()Ürl");
         // Dotted capital I, Kelvin sign, Sharp S.
-        assert_eq!("HİKß".to_ascii_lower(), "hİKß");
+        assert_eq!("HİKß".to_ascii_lowercase(), "hİKß");
 
         let mut i = 0;
         while i <= 500 {
             let lower = if 'A' as u32 <= i && i <= 'Z' as u32 { i + 'a' as u32 - 'A' as u32 }
                         else { i };
-            assert_eq!((from_u32(i).unwrap()).to_string().to_ascii_lower(),
+            assert_eq!((from_u32(i).unwrap()).to_string().to_ascii_lowercase(),
                        (from_u32(lower).unwrap()).to_string());
             i += 1;
         }
     }
 
     #[test]
-    fn test_into_ascii_upper() {
-        assert_eq!(("url()URL()uRl()ürl".to_string()).into_ascii_upper(),
+    fn test_into_ascii_uppercase() {
+        assert_eq!(("url()URL()uRl()ürl".to_string()).into_ascii_uppercase(),
                    "URL()URL()URL()üRL".to_string());
-        assert_eq!(("hıKß".to_string()).into_ascii_upper(), "HıKß");
+        assert_eq!(("hıKß".to_string()).into_ascii_uppercase(), "HıKß");
 
         let mut i = 0;
         while i <= 500 {
             let upper = if 'a' as u32 <= i && i <= 'z' as u32 { i + 'A' as u32 - 'a' as u32 }
                         else { i };
-            assert_eq!((from_u32(i).unwrap()).to_string().into_ascii_upper(),
+            assert_eq!((from_u32(i).unwrap()).to_string().into_ascii_uppercase(),
                        (from_u32(upper).unwrap()).to_string());
             i += 1;
         }
     }
 
     #[test]
-    fn test_into_ascii_lower() {
-        assert_eq!(("url()URL()uRl()Ürl".to_string()).into_ascii_lower(),
+    fn test_into_ascii_lowercase() {
+        assert_eq!(("url()URL()uRl()Ürl".to_string()).into_ascii_lowercase(),
                    "url()url()url()Ürl");
         // Dotted capital I, Kelvin sign, Sharp S.
-        assert_eq!(("HİKß".to_string()).into_ascii_lower(), "hİKß");
+        assert_eq!(("HİKß".to_string()).into_ascii_lowercase(), "hİKß");
 
         let mut i = 0;
         while i <= 500 {
             let lower = if 'A' as u32 <= i && i <= 'Z' as u32 { i + 'a' as u32 - 'A' as u32 }
                         else { i };
-            assert_eq!((from_u32(i).unwrap()).to_string().into_ascii_lower(),
+            assert_eq!((from_u32(i).unwrap()).to_string().into_ascii_lowercase(),
                        (from_u32(lower).unwrap()).to_string());
             i += 1;
         }

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -14,7 +14,7 @@
 
 use self::PathPrefix::*;
 
-use ascii::AsciiCast;
+use ascii::AsciiExt;
 use c_str::{CString, ToCStr};
 use clone::Clone;
 use cmp::{PartialEq, Eq, PartialOrd, Ord, Ordering};
@@ -237,10 +237,10 @@ impl GenericPathUnsafe for Path {
             let repr = me.repr[];
             match me.prefix {
                 Some(DiskPrefix) => {
-                    repr.as_bytes()[0] == path.as_bytes()[0].to_ascii().to_uppercase().as_byte()
+                    repr.as_bytes()[0] == path.as_bytes()[0].to_ascii_uppercase()
                 }
                 Some(VerbatimDiskPrefix) => {
-                    repr.as_bytes()[4] == path.as_bytes()[0].to_ascii().to_uppercase().as_byte()
+                    repr.as_bytes()[4] == path.as_bytes()[0].to_ascii_uppercase()
                 }
                 _ => false
             }
@@ -673,17 +673,17 @@ impl Path {
         match (self.prefix, other.prefix) {
             (Some(DiskPrefix), Some(VerbatimDiskPrefix)) => {
                 self.is_absolute() &&
-                    s_repr.as_bytes()[0].to_ascii().to_lowercase() ==
-                        o_repr.as_bytes()[4].to_ascii().to_lowercase()
+                    s_repr.as_bytes()[0].to_ascii_lowercase() ==
+                        o_repr.as_bytes()[4].to_ascii_lowercase()
             }
             (Some(VerbatimDiskPrefix), Some(DiskPrefix)) => {
                 other.is_absolute() &&
-                    s_repr.as_bytes()[4].to_ascii().to_lowercase() ==
-                        o_repr.as_bytes()[0].to_ascii().to_lowercase()
+                    s_repr.as_bytes()[4].to_ascii_lowercase() ==
+                        o_repr.as_bytes()[0].to_ascii_lowercase()
             }
             (Some(VerbatimDiskPrefix), Some(VerbatimDiskPrefix)) => {
-                s_repr.as_bytes()[4].to_ascii().to_lowercase() ==
-                    o_repr.as_bytes()[4].to_ascii().to_lowercase()
+                s_repr.as_bytes()[4].to_ascii_lowercase() ==
+                    o_repr.as_bytes()[4].to_ascii_lowercase()
             }
             (Some(UNCPrefix(_,_)), Some(VerbatimUNCPrefix(_,_))) => {
                 s_repr[2..self.prefix_len()] == o_repr[8..other.prefix_len()]
@@ -750,7 +750,7 @@ impl Path {
                                 let mut s = String::from_str(s[0..len]);
                                 unsafe {
                                     let v = s.as_mut_vec();
-                                    v[0] = (*v)[0].to_ascii().to_uppercase().as_byte();
+                                    v[0] = (*v)[0].to_ascii_uppercase();
                                 }
                                 if is_abs {
                                     // normalize C:/ to C:\
@@ -765,7 +765,7 @@ impl Path {
                                 let mut s = String::from_str(s[0..len]);
                                 unsafe {
                                     let v = s.as_mut_vec();
-                                    v[4] = (*v)[4].to_ascii().to_uppercase().as_byte();
+                                    v[4] = (*v)[4].to_ascii_uppercase();
                                 }
                                 Some(s)
                             }
@@ -786,14 +786,12 @@ impl Path {
                         let mut s = String::with_capacity(n);
                         match prefix {
                             Some(DiskPrefix) => {
-                                s.push(prefix_.as_bytes()[0].to_ascii()
-                                                   .to_uppercase().as_char());
+                                s.push(prefix_.as_bytes()[0].to_ascii_uppercase() as char);
                                 s.push(':');
                             }
                             Some(VerbatimDiskPrefix) => {
                                 s.push_str(prefix_[0..4]);
-                                s.push(prefix_.as_bytes()[4].to_ascii()
-                                                   .to_uppercase().as_char());
+                                s.push(prefix_.as_bytes()[4].to_ascii_uppercase() as char);
                                 s.push_str(prefix_[5..]);
                             }
                             Some(UNCPrefix(a,b)) => {

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -56,8 +56,6 @@
 
 // Reexported types and traits
 
-#[doc(no_inline)] pub use ascii::{Ascii, AsciiCast, OwnedAsciiCast, AsciiStr};
-#[doc(no_inline)] pub use ascii::IntoBytes;
 #[doc(no_inline)] pub use borrow::IntoCow;
 #[doc(no_inline)] pub use c_str::ToCStr;
 #[doc(no_inline)] pub use char::{Char, UnicodeChar};

--- a/src/libsyntax/ext/bytes.rs
+++ b/src/libsyntax/ext/bytes.rs
@@ -15,6 +15,7 @@ use codemap::Span;
 use ext::base::*;
 use ext::base;
 use ext::build::AstBuilder;
+use std::ascii::AsciiExt;
 
 
 pub fn expand_syntax_ext<'cx>(cx: &'cx mut ExtCtxt,

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -31,6 +31,8 @@ use visit::Visitor;
 use parse::token;
 
 use std::slice;
+use std::ascii::AsciiExt;
+
 
 // if you change this list without updating src/doc/reference.md, @cmr will be sad
 static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -14,6 +14,7 @@ pub use self::Param::*;
 use self::States::*;
 use self::FormatState::*;
 use self::FormatOp::*;
+use std::ascii::OwnedAsciiExt;
 use std::mem::replace;
 
 #[deriving(Copy, PartialEq)]
@@ -530,10 +531,7 @@ fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
                     }
                 }
                 FormatHEX => {
-                    s = s.to_ascii()
-                         .iter()
-                         .map(|b| b.to_uppercase().as_byte())
-                         .collect();
+                    s = s.into_ascii_uppercase();
                     if flags.alternate {
                         let s_ = replace(&mut s, vec!(b'0', b'X'));
                         s.extend(s_.into_iter());

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -17,6 +17,7 @@
 
 extern crate collections;
 
+use std::ascii::{AsciiExt, OwnedAsciiExt};
 use std::collections::HashMap;
 use std::mem::replace;
 use std::num::Float;
@@ -64,10 +65,8 @@ fn sort_and_fmt(mm: &HashMap<Vec<u8> , uint>, total: uint) -> String {
    let mut buffer = String::new();
    for &(ref k, v) in pairs_sorted.iter() {
        buffer.push_str(format!("{} {:0.3}\n",
-                               k.as_slice()
-                               .to_ascii()
-                               .to_uppercase()
-                               .into_string(), v).as_slice());
+                               k.to_ascii_uppercase(),
+                               v).as_slice());
    }
 
    return buffer
@@ -75,7 +74,7 @@ fn sort_and_fmt(mm: &HashMap<Vec<u8> , uint>, total: uint) -> String {
 
 // given a map, search for the frequency of a pattern
 fn find(mm: &HashMap<Vec<u8> , uint>, key: String) -> uint {
-   let key = key.into_ascii().as_slice().to_lowercase().into_string();
+   let key = key.into_ascii_lowercase();
    match mm.get(key.as_bytes()) {
       option::Option::None      => { return 0u; }
       option::Option::Some(&num) => { return num; }

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -42,6 +42,7 @@
 
 #![feature(slicing_syntax)]
 
+use std::ascii::OwnedAsciiExt;
 use std::string::String;
 use std::slice;
 use std::sync::{Arc, Future};
@@ -286,10 +287,7 @@ fn get_sequence<R: Buffer>(r: &mut R, key: &str) -> Vec<u8> {
     {
         res.push_all(l.as_slice().trim().as_bytes());
     }
-    for b in res.iter_mut() {
-        *b = b.to_ascii().to_uppercase().to_byte();
-    }
-    res
+    res.into_ascii_uppercase()
 }
 
 fn main() {

--- a/src/test/run-pass/issue-10683.rs
+++ b/src/test/run-pass/issue-10683.rs
@@ -13,7 +13,7 @@ use std::ascii::AsciiExt;
 static NAME: &'static str = "hello world";
 
 fn main() {
-    match NAME.to_ascii_lower().as_slice() {
+    match NAME.to_ascii_lowercase().as_slice() {
         "foo" => {}
         _ => {}
     }


### PR DESCRIPTION
Implements [RFC 486](https://github.com/rust-lang/rfcs/pull/486). Fixes #19908.
- Rename `to_ascii_{lower,upper}` to `to_ascii_{lower,upper}case`, per #14401
- Remove the `Ascii` type and associated traits: `AsciiCast`, `OwnedAsciiCast`, `AsciiStr`, `IntoBytes`, and `IntoString`.
- As a replacement, add `.is_ascii()` to `AsciiExt`, and implement `AsciiExt` for `u8` and `char`.

[breaking-change]
