### PR TITLE
Fix `make TAGS.emacs`.

### DIFF
--- a/mk/ctags.mk
+++ b/mk/ctags.mk
@@ -27,7 +27,7 @@ CTAGS_LOCATIONS=$(patsubst ${CFG_SRC_DIR}src/llvm,, \
 				$(patsubst ${CFG_SRC_DIR}src/rt/msvc,, \
 				$(patsubst ${CFG_SRC_DIR}src/rt/vg,, \
 				$(wildcard ${CFG_SRC_DIR}src/*) $(wildcard ${CFG_SRC_DIR}src/rt/*) \
-				)))))))))
+				))))))))
 CTAGS_OPTS=--options="${CFG_SRC_DIR}src/etc/ctags.rust" --languages=-javascript --recurse ${CTAGS_LOCATIONS}
 # We could use `--languages=Rust`, but there is value in producing tags for the
 # C++ parts of the code base too (at the time of writing, those are .h and .cpp


### PR DESCRIPTION
Fix `make TAGS.emacs`.

@nikomatsakis has been complaining to me about this.  (I had not noticed since I drive `ctags` with a separate script.)

(Suitable for a rollup build.)
