### PR TITLE
rustup: add support for caching of old nightlies, download resumption and verification

### DIFF
--- a/src/etc/rustup.sh
+++ b/src/etc/rustup.sh
@@ -244,7 +244,21 @@ create_tmp_dir() {
 probe_need CFG_CURL  curl
 probe_need CFG_TAR   tar
 probe_need CFG_FILE  file
-probe_need CFG_SHASUM shasum
+
+probe CFG_SHA256SUM sha256sum
+probe CFG_SHASUM shasum
+
+if [ -z "$CFG_SHA256SUM" -a -z "$CFG_SHASUM" ]; then
+    err "unable to find either sha256sum or shasum"
+fi
+
+calculate_hash() {
+    if [ -n "$CFG_SHA256SUM" ]; then
+        ${CFG_SHA256SUM} $@
+    else
+        ${CFG_SHASUM} -a 256 $@
+    fi
+}
 
 CFG_SRC_DIR="$(cd $(dirname $0) && pwd)/"
 CFG_SELF="$0"
@@ -474,7 +488,7 @@ verify_hash() {
     fi
 
     msg "Verifying hash"
-    local_sha256=`"${CFG_SHASUM}" -a 256 "${local_file}"`
+    local_sha256=$(calculate_hash "${local_file}")
     if [ "$?" -ne 0 ]; then
         rm -Rf "${CFG_TMP_DIR}"
         err "Failed to compute hash for ${local_tarball}"

--- a/src/etc/rustup.sh
+++ b/src/etc/rustup.sh
@@ -497,15 +497,28 @@ download_package() {
     remote_sha256="${remote_tarball}.sha256"
 
     # Check if we've already downloaded this file.
-    if [ ! -e "${local_tarball}" ]; then
-        msg "Downloading ${remote_tarball} to ${local_tarball}"
+    if [ -e "${local_tarball}.tmp" ]; then
+        msg "Resuming ${remote_tarball} to ${local_tarball}"
 
-        "${CFG_CURL}" -f -o "${local_tarball} "${remote_tarball}"
+        "${CFG_CURL}" -f -C - -o "${local_tarball}.tmp" "${remote_tarball}"
         if [ $? -ne 0 ]
         then
             rm -Rf "${CFG_TMP_DIR}"
             err "failed to download installer"
         fi
+
+        mv "${local_tarball}.tmp" "${local_tarball}"
+    elif [ ! -e "${local_tarball}" ]; then
+        msg "Downloading ${remote_tarball} to ${local_tarball}"
+
+        "${CFG_CURL}" -f -o "${local_tarball}.tmp" "${remote_tarball}"
+        if [ $? -ne 0 ]
+        then
+            rm -Rf "${CFG_TMP_DIR}"
+            err "failed to download installer"
+        fi
+
+        mv "${local_tarball}.tmp" "${local_tarball}"
     fi
 
     verify_hash "${remote_sha256}" "${local_tarball}"

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -983,7 +983,7 @@ impl LitIntType {
 #[deriving(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Show)]
 pub enum Lit_ {
     LitStr(InternedString, StrStyle),
-    LitBinary(Rc<Vec<u8> >),
+    LitBinary(Rc<Vec<u8>>),
     LitByte(u8),
     LitChar(char),
     LitInt(u64, LitIntType),


### PR DESCRIPTION
This allows rustup to be used for bisecting bugs across the nightlies, which can really help to speed up tracking down bugs. In addition, this PR changes rustup to use curl's download resumption, and also adds hash verification of the downloads to make sure they are not corrupted. We still need to add GPG signing in order to protect against someone tampering with the downloads though.
