### PR TITLE
Change 'verboten' to 'prohibited'

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -450,7 +450,7 @@ mutation, then the solution is quite easy: add `mut`.
 There are other good reasons to avoid mutable state when possible, but they're
 out of the scope of this guide. In general, you can often avoid explicit
 mutation, and so it is preferable in Rust. That said, sometimes, mutation is
-what you need, so it's not verboten.
+what you need, so it's not prohibited.
 
 Let's get back to bindings. Rust variable bindings have one more aspect that
 differs from other languages: bindings are required to be initialized with a


### PR DESCRIPTION
From: `That said, sometimes, mutation is what you need, so it's not verboten.`
To: `That said, sometimes, mutation is what you need, so it's not prohibited.`

I like the word verboten, but it could distract from the content, if the reader doesn't know what it means.
