### PR TITLE
Change 'if' to lowercase, so it displays better on the site

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -538,7 +538,7 @@ format in a more detailed manner, there are a [wide number of options
 available](std/fmt/index.html). For now, we'll just stick to the default:
 integers aren't very complicated to print.
 
-# If
+# `if`
 
 Rust's take on `if` is not particularly complex, but it's much more like the
 `if` you'll find in a dynamically typed language than in a more traditional


### PR DESCRIPTION
On the [guide site](http://doc.rust-lang.org/guide.html#if) I was confused when I got to "5 If". It looked like "5 LF" in lowercase. 

Changing the if to lowercase solves this problem. I know titles are all capitalized, but I think it makes sense in this case to keep it lowercase, since `if` is a reserved word. I'd also be open to making it ``if`` but I'm not sure how that would look on the site.

Before:
![screen shot 2014-12-16 at 12 58 01](https://cloud.githubusercontent.com/assets/632942/5458866/cb34c006-8523-11e4-89ef-3a3964bcedfc.png)
After:
![screen shot 2014-12-16 at 12 58 14](https://cloud.githubusercontent.com/assets/632942/5458865/cb33c444-8523-11e4-8d95-d377ed583ed6.png)
