### PR TITLE
rustc: Add knowledge of separate lookup paths

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -19,6 +19,7 @@ pub use self::OutputType::*;
 pub use self::DebugInfoLevel::*;
 
 use session::{early_error, Session};
+use session::search_paths::SearchPaths;
 
 use rustc_back::target::Target;
 use lint;
@@ -35,7 +36,6 @@ use syntax::parse::token::InternedString;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use getopts;
-use std::cell::{RefCell};
 use std::fmt;
 
 use llvm;
@@ -86,7 +86,7 @@ pub struct Options {
     // This was mutable for rustpkg, which updates search paths based on the
     // parsed code. It remains mutable in case its replacements wants to use
     // this.
-    pub addl_lib_search_paths: RefCell<Vec<Path>>,
+    pub search_paths: SearchPaths,
     pub libs: Vec<(String, cstore::NativeLibraryKind)>,
     pub maybe_sysroot: Option<Path>,
     pub target_triple: String,
@@ -198,7 +198,7 @@ pub fn basic_options() -> Options {
         lint_opts: Vec::new(),
         describe_lints: false,
         output_types: Vec::new(),
-        addl_lib_search_paths: RefCell::new(Vec::new()),
+        search_paths: SearchPaths::new(),
         maybe_sysroot: None,
         target_triple: host_triple().to_string(),
         cfg: Vec::new(),
@@ -1007,9 +1007,10 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         }
     };
 
-    let addl_lib_search_paths = matches.opt_strs("L").iter().map(|s| {
-        Path::new(s[])
-    }).collect();
+    let mut search_paths = SearchPaths::new();
+    for s in matches.opt_strs("L").iter() {
+        search_paths.add_path(s[]);
+    }
 
     let libs = matches.opt_strs("l").into_iter().map(|s| {
         let mut parts = s.rsplitn(1, ':');
@@ -1109,7 +1110,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         lint_opts: lint_opts,
         describe_lints: describe_lints,
         output_types: output_types,
-        addl_lib_search_paths: RefCell::new(addl_lib_search_paths),
+        search_paths: search_paths,
         maybe_sysroot: sysroot_opt,
         target_triple: target,
         cfg: cfg,

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -9,9 +9,10 @@
 // except according to those terms.
 
 
+use lint;
 use metadata::cstore::CStore;
 use metadata::filesearch;
-use lint;
+use session::search_paths::PathKind;
 use util::nodemap::NodeMap;
 
 use syntax::ast::NodeId;
@@ -28,6 +29,7 @@ use std::os;
 use std::cell::{Cell, RefCell};
 
 pub mod config;
+pub mod search_paths;
 
 // Represents the data associated with a compilation
 // session for a single crate.
@@ -209,16 +211,18 @@ impl Session {
                         .expect("missing sysroot and default_sysroot in Session")
         }
     }
-    pub fn target_filesearch<'a>(&'a self) -> filesearch::FileSearch<'a> {
+    pub fn target_filesearch(&self, kind: PathKind) -> filesearch::FileSearch {
         filesearch::FileSearch::new(self.sysroot(),
                                     self.opts.target_triple[],
-                                    &self.opts.addl_lib_search_paths)
+                                    &self.opts.search_paths,
+                                    kind)
     }
-    pub fn host_filesearch<'a>(&'a self) -> filesearch::FileSearch<'a> {
+    pub fn host_filesearch(&self, kind: PathKind) -> filesearch::FileSearch {
         filesearch::FileSearch::new(
             self.sysroot(),
             config::host_triple(),
-            &self.opts.addl_lib_search_paths)
+            &self.opts.search_paths,
+            kind)
     }
 }
 

--- a/src/librustc/session/search_paths.rs
+++ b/src/librustc/session/search_paths.rs
@@ -1,0 +1,69 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::slice;
+
+#[deriving(Clone)]
+pub struct SearchPaths {
+    paths: Vec<(PathKind, Path)>,
+}
+
+pub struct Iter<'a> {
+    kind: PathKind,
+    iter: slice::Iter<'a, (PathKind, Path)>,
+}
+
+#[deriving(Eq, PartialEq, Clone, Copy)]
+pub enum PathKind {
+    Native,
+    Crate,
+    Dependency,
+    All,
+}
+
+impl SearchPaths {
+    pub fn new() -> SearchPaths {
+        SearchPaths { paths: Vec::new() }
+    }
+
+    pub fn add_path(&mut self, path: &str) {
+        let (kind, path) = if path.ends_with(":native") {
+            (PathKind::Native, path.slice_to(path.len() - ":native".len()))
+        } else if path.ends_with(":crate") {
+            (PathKind::Crate, path.slice_to(path.len() - ":crate".len()))
+        } else if path.ends_with(":dependency") {
+            (PathKind::Dependency,
+             path.slice_to(path.len() - ":dependency".len()))
+        } else if path.ends_with(":all") {
+            (PathKind::All, path.slice_to(path.len() - ":all".len()))
+        } else {
+            (PathKind::All, path)
+        };
+        self.paths.push((kind, Path::new(path)));
+    }
+
+    pub fn iter(&self, kind: PathKind) -> Iter {
+        Iter { kind: kind, iter: self.paths.iter() }
+    }
+}
+
+impl<'a> Iterator<&'a Path> for Iter<'a> {
+    fn next(&mut self) -> Option<&'a Path> {
+        loop {
+            match self.iter.next() {
+                Some(&(kind, ref p)) if self.kind == PathKind::All ||
+                                        kind == PathKind::All ||
+                                        kind == self.kind => return Some(p),
+                Some(..) => {}
+                None => return None,
+            }
+        }
+    }
+}

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -10,6 +10,7 @@
 
 use rustc::session::Session;
 use rustc::session::config::{mod, Input, OutputFilenames};
+use rustc::session::search_paths::PathKind;
 use rustc::lint;
 use rustc::metadata::creader;
 use rustc::middle::{stability, ty, reachable};
@@ -256,7 +257,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
             let mut _old_path = String::new();
             if cfg!(windows) {
                 _old_path = os::getenv("PATH").unwrap_or(_old_path);
-                let mut new_path = sess.host_filesearch().get_dylib_search_paths();
+                let mut new_path = sess.host_filesearch(PathKind::All).get_dylib_search_paths();
                 new_path.extend(os::split_paths(_old_path[]).into_iter());
                 os::setenv("PATH", os::join_paths(new_path[]).unwrap());
             }
@@ -516,7 +517,7 @@ pub fn phase_6_link_output(sess: &Session,
                            trans: &trans::CrateTranslation,
                            outputs: &OutputFilenames) {
     let old_path = os::getenv("PATH").unwrap_or_else(||String::new());
-    let mut new_path = sess.host_filesearch().get_tools_search_paths();
+    let mut new_path = sess.host_filesearch(PathKind::All).get_tools_search_paths();
     new_path.extend(os::split_paths(old_path[]).into_iter());
     os::setenv("PATH", os::join_paths(new_path[]).unwrap());
 

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -11,6 +11,7 @@ pub use self::MaybeTyped::*;
 
 use rustc_driver::driver;
 use rustc::session::{mod, config};
+use rustc::session::search_paths::SearchPaths;
 use rustc::middle::{privacy, ty};
 use rustc::lint;
 use rustc_trans::back::link;
@@ -77,7 +78,7 @@ pub struct CrateAnalysis {
 
 pub type Externs = HashMap<String, Vec<String>>;
 
-pub fn run_core(libs: Vec<Path>, cfgs: Vec<String>, externs: Externs,
+pub fn run_core(search_paths: SearchPaths, cfgs: Vec<String>, externs: Externs,
                 cpath: &Path, triple: Option<String>)
                 -> (clean::Crate, CrateAnalysis) {
 
@@ -89,7 +90,7 @@ pub fn run_core(libs: Vec<Path>, cfgs: Vec<String>, externs: Externs,
 
     let sessopts = config::Options {
         maybe_sysroot: None,
-        addl_lib_search_paths: RefCell::new(libs),
+        search_paths: search_paths,
         crate_types: vec!(config::CrateTypeRlib),
         lint_opts: vec!((warning_lint, lint::Allow)),
         externs: externs,

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -9,11 +9,11 @@
 // except according to those terms.
 
 use std::io;
-use std::string::String;
 
 use core;
 use getopts;
 use testing;
+use rustc::session::search_paths::SearchPaths;
 
 use externalfiles::ExternalHtml;
 
@@ -135,7 +135,7 @@ pub fn render(input: &str, mut output: Path, matches: &getopts::Matches,
 }
 
 /// Run any tests/code examples in the markdown file `input`.
-pub fn test(input: &str, libs: Vec<Path>, externs: core::Externs,
+pub fn test(input: &str, libs: SearchPaths, externs: core::Externs,
             mut test_args: Vec<String>) -> int {
     let input_str = load_or_return!(input, 1, 2);
 

--- a/src/test/run-make/compiler-lookup-paths/Makefile
+++ b/src/test/run-make/compiler-lookup-paths/Makefile
@@ -1,0 +1,30 @@
+-include ../tools.mk
+
+all: $(TMPDIR)/libnative.a
+	mkdir -p $(TMPDIR)/crate
+	mkdir -p $(TMPDIR)/native
+	mv $(TMPDIR)/libnative.a $(TMPDIR)/native
+	$(RUSTC) a.rs
+	mv $(TMPDIR)/liba.rlib $(TMPDIR)/crate
+	$(RUSTC) b.rs -L $(TMPDIR)/crate:native && exit 1 || exit 0
+	$(RUSTC) b.rs -L $(TMPDIR)/crate:dependency && exit 1 || exit 0
+	$(RUSTC) b.rs -L $(TMPDIR)/crate:crate
+	$(RUSTC) b.rs -L $(TMPDIR)/crate
+	$(RUSTC) c.rs -L $(TMPDIR)/crate:native && exit 1 || exit 0
+	$(RUSTC) c.rs -L $(TMPDIR)/crate:crate && exit 1 || exit 0
+	$(RUSTC) c.rs -L $(TMPDIR)/crate:dependency
+	$(RUSTC) c.rs -L $(TMPDIR)/crate
+	$(RUSTC) d.rs -L $(TMPDIR)/native:dependency && exit 1 || exit 0
+	$(RUSTC) d.rs -L $(TMPDIR)/native:crate && exit 1 || exit 0
+	$(RUSTC) d.rs -L $(TMPDIR)/native:native
+	$(RUSTC) d.rs -L $(TMPDIR)/native
+	mkdir -p $(TMPDIR)/e1
+	mkdir -p $(TMPDIR)/e2
+	$(RUSTC) e.rs -o $(TMPDIR)/e1/libe.rlib
+	$(RUSTC) e.rs -o $(TMPDIR)/e2/libe.rlib
+	$(RUSTC) f.rs -L $(TMPDIR)/e1 -L $(TMPDIR)/e2 && exit 1 || exit 0
+	$(RUSTC) f.rs -L $(TMPDIR)/e1:crate -L $(TMPDIR)/e2 && exit 1 || exit 0
+	$(RUSTC) f.rs -L $(TMPDIR)/e1:crate -L $(TMPDIR)/e2:crate && exit 1 || exit 0
+	$(RUSTC) f.rs -L $(TMPDIR)/e1:native -L $(TMPDIR)/e2
+	$(RUSTC) f.rs -L $(TMPDIR)/e1:dependency -L $(TMPDIR)/e2
+	$(RUSTC) f.rs -L $(TMPDIR)/e1:dependency -L $(TMPDIR)/e2:crate

--- a/src/test/run-make/compiler-lookup-paths/a.rs
+++ b/src/test/run-make/compiler-lookup-paths/a.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "lib"]

--- a/src/test/run-make/compiler-lookup-paths/b.rs
+++ b/src/test/run-make/compiler-lookup-paths/b.rs
@@ -1,0 +1,12 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "lib"]
+extern crate a;

--- a/src/test/run-make/compiler-lookup-paths/c.rs
+++ b/src/test/run-make/compiler-lookup-paths/c.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "lib"]
+extern crate b;
+

--- a/src/test/run-make/compiler-lookup-paths/d.rs
+++ b/src/test/run-make/compiler-lookup-paths/d.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]
+
+#[link(name = "native", kind = "static")]
+extern {}

--- a/src/test/run-make/compiler-lookup-paths/e.rs
+++ b/src/test/run-make/compiler-lookup-paths/e.rs
@@ -1,0 +1,12 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "e"]
+#![crate_type = "rlib"]

--- a/src/test/run-make/compiler-lookup-paths/f.rs
+++ b/src/test/run-make/compiler-lookup-paths/f.rs
@@ -1,0 +1,12 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]
+extern crate e;

--- a/src/test/run-make/staticlib-blank-lib/Makefile
+++ b/src/test/run-make/staticlib-blank-lib/Makefile
@@ -1,6 +1,6 @@
 -include ../tools.mk
 
 all:
-	ar crus libfoo.a foo.rs
-	ar d libfoo.a foo.rs
+	ar crus $(TMPDIR)/libfoo.a foo.rs
+	ar d $(TMPDIR)/libfoo.a foo.rs
 	$(RUSTC) foo.rs


### PR DESCRIPTION
This commit adds support for the compiler to distinguish between different forms
of lookup paths in the compiler itself. Issue #19767 has some background on this
topic, as well as some sample bugs which can occur if these lookup paths are not
separated.

This commits extends the existing command line flag `-L` with the same trailing
syntax as the `-l` flag. Each argument to `-L` can now have a trailing `:all`,
`:native`, `:crate`, or `:dependency`. This suffix indicates what form of lookup
path the compiler should add the argument to. The `dependency` lookup path is
used when looking up crate dependencies, the `crate` lookup path is used when
looking for immediate dependencies (`extern crate` statements), and the `native`
lookup path is used for probing for native libraries to insert into rlibs. Paths
with `all` are used for all of these purposes (the default).

The default compiler lookup path (the rustlib libdir) is by default added to all
of these paths. Additionally, the `RUST_PATH` lookup path is added to all of
these paths.

Closes #19767
