### PR TITLE
debuginfo: Add a rust-gdb shell script for starting GDB with Rust pretty printers

### DIFF
--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -64,6 +64,7 @@ clean-generic-$(2)-$(1):
          -name '*.dll' -o \
          -name '*.def' -o \
          -name '*.py' -o \
+         -name '*.pyc' -o \
          -name '*.bc' \
          \) \
          | xargs rm -f
@@ -79,7 +80,7 @@ define CLEAN_HOST_STAGE_N
 
 clean$(1)_H_$(2): \
 	    $$(foreach crate,$$(CRATES),clean$(1)_H_$(2)-lib-$$(crate)) \
-	    $$(foreach tool,$$(TOOLS) $$(DEBUGGER_BIN_SCRIPTS),clean$(1)_H_$(2)-tool-$$(tool))
+	    $$(foreach tool,$$(TOOLS) $$(DEBUGGER_BIN_SCRIPTS_ALL),clean$(1)_H_$(2)-tool-$$(tool))
 	$$(Q)rm -fr $(2)/rt/libbacktrace
 
 clean$(1)_H_$(2)-tool-%:
@@ -99,7 +100,7 @@ define CLEAN_TARGET_STAGE_N
 
 clean$(1)_T_$(2)_H_$(3): \
 	    $$(foreach crate,$$(CRATES),clean$(1)_T_$(2)_H_$(3)-lib-$$(crate)) \
-	    $$(foreach tool,$$(TOOLS) $$(DEBUGGER_BIN_SCRIPTS),clean$(1)_T_$(2)_H_$(3)-tool-$$(tool))
+	    $$(foreach tool,$$(TOOLS) $$(DEBUGGER_BIN_SCRIPTS_ALL),clean$(1)_T_$(2)_H_$(3)-tool-$$(tool))
 	$$(Q)rm -f $$(TLIB$(1)_T_$(2)_H_$(3))/libmorestack.a
 	$$(Q)rm -f $$(TLIB$(1)_T_$(2)_H_$(3))/libcompiler-rt.a
 	$(Q)rm -f $$(TLIB$(1)_T_$(2)_H_$(3))/librun_pass_stage* # For unix

--- a/mk/debuggers.mk
+++ b/mk/debuggers.mk
@@ -12,26 +12,77 @@
 # Copy debugger related scripts
 ######################################################################
 
-DEBUGGER_RUSTLIB_ETC_SCRIPTS=lldb_rust_formatters.py
-DEBUGGER_BIN_SCRIPTS=rust-lldb
 
-DEBUGGER_RUSTLIB_ETC_SCRIPTS_ABS=$(foreach script,$(DEBUGGER_RUSTLIB_ETC_SCRIPTS), \
-                                     $(CFG_SRC_DIR)src/etc/$(script))
-DEBUGGER_BIN_SCRIPTS_ABS=$(foreach script,$(DEBUGGER_BIN_SCRIPTS), \
-                             $(CFG_SRC_DIR)src/etc/$(script))
+## GDB ##
+DEBUGGER_RUSTLIB_ETC_SCRIPTS_GDB=gdb_load_rust_pretty_printers.py \
+                                 gdb_rust_pretty_printing.py
+DEBUGGER_RUSTLIB_ETC_SCRIPTS_GDB_ABS=\
+    $(foreach script,$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_GDB), \
+        $(CFG_SRC_DIR)src/etc/$(script))
 
-DEBUGGER_SCRIPTS_ALL=$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_ABS) $(DEBUGGER_BIN_SCRIPTS_ABS)
+DEBUGGER_BIN_SCRIPTS_GDB=rust-gdb
+DEBUGGER_BIN_SCRIPTS_GDB_ABS=\
+    $(foreach script,$(DEBUGGER_BIN_SCRIPTS_GDB), \
+        $(CFG_SRC_DIR)src/etc/$(script))
+
+
+## LLDB ##
+DEBUGGER_RUSTLIB_ETC_SCRIPTS_LLDB=lldb_rust_formatters.py
+DEBUGGER_RUSTLIB_ETC_SCRIPTS_LLDB_ABS=\
+    $(foreach script,$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_LLDB), \
+        $(CFG_SRC_DIR)src/etc/$(script))
+
+DEBUGGER_BIN_SCRIPTS_LLDB=rust-lldb
+DEBUGGER_BIN_SCRIPTS_LLDB_ABS=\
+    $(foreach script,$(DEBUGGER_BIN_SCRIPTS_LLDB), \
+        $(CFG_SRC_DIR)src/etc/$(script))
+
+
+## ALL ##
+DEBUGGER_RUSTLIB_ETC_SCRIPTS_ALL=$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_GDB) \
+                                 $(DEBUGGER_RUSTLIB_ETC_SCRIPTS_LLDB)
+DEBUGGER_RUSTLIB_ETC_SCRIPTS_ALL_ABS=$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_GDB_ABS) \
+                                     $(DEBUGGER_RUSTLIB_ETC_SCRIPTS_LLDB_ABS)
+DEBUGGER_BIN_SCRIPTS_ALL=$(DEBUGGER_BIN_SCRIPTS_GDB) \
+                         $(DEBUGGER_BIN_SCRIPTS_LLDB)
+DEBUGGER_BIN_SCRIPTS_ALL_ABS=$(DEBUGGER_BIN_SCRIPTS_GDB_ABS) \
+                             $(DEBUGGER_BIN_SCRIPTS_LLDB_ABS)
+
 
 # $(1) - the stage to copy to
 # $(2) - the host triple
 define DEF_INSTALL_DEBUGGER_SCRIPTS_HOST
 
-tmp/install-debugger-scripts$(1)_H_$(2).done: $$(DEBUGGER_SCRIPTS_ALL)
+tmp/install-debugger-scripts$(1)_H_$(2)-gdb.done: \
+  $$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_GDB_ABS) \
+  $$(DEBUGGER_BIN_SCRIPTS_GDB_ABS)
 	$(Q)mkdir -p $$(HBIN$(1)_H_$(2))
 	$(Q)mkdir -p $$(HLIB$(1)_H_$(2))/rustlib/etc
-	$(Q)install $(DEBUGGER_BIN_SCRIPTS_ABS) $$(HBIN$(1)_H_$(2))
-	$(Q)install $(DEBUGGER_RUSTLIB_ETC_SCRIPTS_ABS) $$(HLIB$(1)_H_$(2))/rustlib/etc
+	$(Q)install $$(DEBUGGER_BIN_SCRIPTS_GDB_ABS) $$(HBIN$(1)_H_$(2))
+	$(Q)install $$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_GDB_ABS) $$(HLIB$(1)_H_$(2))/rustlib/etc
 	$(Q)touch $$@
+
+tmp/install-debugger-scripts$(1)_H_$(2)-lldb.done: \
+  $$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_LLDB_ABS) \
+  $$(DEBUGGER_BIN_SCRIPTS_LLDB_ABS)
+	$(Q)mkdir -p $$(HBIN$(1)_H_$(2))
+	$(Q)mkdir -p $$(HLIB$(1)_H_$(2))/rustlib/etc
+	$(Q)install $$(DEBUGGER_BIN_SCRIPTS_LLDB_ABS) $$(HBIN$(1)_H_$(2))
+	$(Q)install $$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_LLDB_ABS) $$(HLIB$(1)_H_$(2))/rustlib/etc
+	$(Q)touch $$@
+
+tmp/install-debugger-scripts$(1)_H_$(2)-all.done: \
+  $$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_ALL_ABS) \
+  $$(DEBUGGER_BIN_SCRIPTS_ALL_ABS)
+	$(Q)mkdir -p $$(HBIN$(1)_H_$(2))
+	$(Q)mkdir -p $$(HLIB$(1)_H_$(2))/rustlib/etc
+	$(Q)install $$(DEBUGGER_BIN_SCRIPTS_ALL_ABS) $$(HBIN$(1)_H_$(2))
+	$(Q)install $$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_ALL_ABS) $$(HLIB$(1)_H_$(2))/rustlib/etc
+	$(Q)touch $$@
+
+tmp/install-debugger-scripts$(1)_H_$(2)-none.done:
+	$(Q)touch $$@
+
 endef
 
 # Expand host make-targets for all stages
@@ -44,12 +95,36 @@ $(foreach stage,$(STAGES), \
 # $(3) is the host triple
 define DEF_INSTALL_DEBUGGER_SCRIPTS_TARGET
 
-tmp/install-debugger-scripts$(1)_T_$(2)_H_$(3).done: $$(DEBUGGER_SCRIPTS_ALL)
+tmp/install-debugger-scripts$(1)_T_$(2)_H_$(3)-gdb.done: \
+  $$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_GDB_ABS) \
+  $$(DEBUGGER_BIN_SCRIPTS_GDB_ABS)
 	$(Q)mkdir -p $$(TBIN$(1)_T_$(2)_H_$(3))
 	$(Q)mkdir -p $$(TLIB$(1)_T_$(2)_H_$(3))/rustlib/etc
-	$(Q)install $(DEBUGGER_BIN_SCRIPTS_ABS) $$(TBIN$(1)_T_$(2)_H_$(3))
-	$(Q)install $(DEBUGGER_RUSTLIB_ETC_SCRIPTS_ABS) $$(TLIB$(1)_T_$(2)_H_$(3))/rustlib/etc
+	$(Q)install $(DEBUGGER_BIN_SCRIPTS_GDB_ABS) $$(TBIN$(1)_T_$(2)_H_$(3))
+	$(Q)install $(DEBUGGER_RUSTLIB_ETC_SCRIPTS_GDB_ABS) $$(TLIB$(1)_T_$(2)_H_$(3))/rustlib/etc
 	$(Q)touch $$@
+
+tmp/install-debugger-scripts$(1)_T_$(2)_H_$(3)-lldb.done: \
+  $$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_LLDB_ABS) \
+  $$(DEBUGGER_BIN_SCRIPTS_LLDB_ABS)
+	$(Q)mkdir -p $$(TBIN$(1)_T_$(2)_H_$(3))
+	$(Q)mkdir -p $$(TLIB$(1)_T_$(2)_H_$(3))/rustlib/etc
+	$(Q)install $(DEBUGGER_BIN_SCRIPTS_LLDB_ABS) $$(TBIN$(1)_T_$(2)_H_$(3))
+	$(Q)install $(DEBUGGER_RUSTLIB_ETC_SCRIPTS_LLDB_ABS) $$(TLIB$(1)_T_$(2)_H_$(3))/rustlib/etc
+	$(Q)touch $$@
+
+tmp/install-debugger-scripts$(1)_T_$(2)_H_$(3)-all.done: \
+  $$(DEBUGGER_RUSTLIB_ETC_SCRIPTS_ALL_ABS) \
+  $$(DEBUGGER_BIN_SCRIPTS_ALL_ABS)
+	$(Q)mkdir -p $$(TBIN$(1)_T_$(2)_H_$(3))
+	$(Q)mkdir -p $$(TLIB$(1)_T_$(2)_H_$(3))/rustlib/etc
+	$(Q)install $(DEBUGGER_BIN_SCRIPTS_ALL_ABS) $$(TBIN$(1)_T_$(2)_H_$(3))
+	$(Q)install $(DEBUGGER_RUSTLIB_ETC_SCRIPTS_ALL_ABS) $$(TLIB$(1)_T_$(2)_H_$(3))/rustlib/etc
+	$(Q)touch $$@
+
+tmp/install-debugger-scripts$(1)_T_$(2)_H_$(3)-none.done:
+	$(Q)touch $$@
+
 endef
 
 # Expand target make-targets for all stages

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -325,6 +325,12 @@ export CFG_DISABLE_INJECT_STD_VERSION
 # Per-stage targets and runner
 ######################################################################
 
+# Valid setting-strings are 'all', 'none', 'gdb', 'lldb'
+# This 'function' will determine which debugger scripts to copy based on a
+# target triple. See debuggers.mk for more information.
+TRIPLE_TO_DEBUGGER_SCRIPT_SETTING=\
+ $(if $(findstring windows,$(1)),none,$(if $(findstring darwin,$(1)),lldb,gdb))
+
 STAGES = 0 1 2 3
 
 define SREQ
@@ -357,7 +363,7 @@ else
 HSREQ$(1)_H_$(3) = \
 	$$(HBIN$(1)_H_$(3))/rustc$$(X_$(3)) \
 	$$(MKFILE_DEPS) \
-	tmp/install-debugger-scripts$(1)_H_$(3).done
+	tmp/install-debugger-scripts$(1)_H_$(3)-$$(call TRIPLE_TO_DEBUGGER_SCRIPT_SETTING,$(3)).done
 endif
 
 # Prerequisites for using the stageN compiler to build target artifacts
@@ -372,7 +378,7 @@ SREQ$(1)_T_$(2)_H_$(3) = \
 	$$(TSREQ$(1)_T_$(2)_H_$(3)) \
 	$$(foreach dep,$$(TARGET_CRATES), \
 	    $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$$(dep)) \
-	tmp/install-debugger-scripts$(1)_T_$(2)_H_$(3).done
+	tmp/install-debugger-scripts$(1)_T_$(2)_H_$(3)-$$(call TRIPLE_TO_DEBUGGER_SCRIPT_SETTING,$(2)).done
 
 # Prerequisites for a working stageN compiler and complete set of target
 # libraries

--- a/src/etc/gdb_load_rust_pretty_printers.py
+++ b/src/etc/gdb_load_rust_pretty_printers.py
@@ -1,0 +1,12 @@
+# Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import gdb_rust_pretty_printing
+gdb_rust_pretty_printing.register_printers(gdb.current_objfile())

--- a/src/etc/rust-gdb
+++ b/src/etc/rust-gdb
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# Exit if anything fails
+set -e
+
+# Find out where the pretty printer Python module is
+RUSTC_SYSROOT=`rustc --print=sysroot`
+GDB_PYTHON_MODULE_DIRECTORY="$RUSTC_SYSROOT/lib/rustlib/etc"
+
+# Run GDB with the additional arguments that load the pretty printers
+PYTHONPATH="$PYTHONPATH:$GDB_PYTHON_MODULE_DIRECTORY" gdb \
+  -d "$GDB_PYTHON_MODULE_DIRECTORY" \
+  -iex "add-auto-load-safe-path $GDB_PYTHON_MODULE_DIRECTORY" \
+  "$@"

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -654,6 +654,7 @@ impl LintPass for UnusedAttributes {
             "static_assert",
             "thread_local",
             "no_debug",
+            "omit_gdb_pretty_printer_section",
             "unsafe_no_drop_flag",
 
             // used in resolve

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -1743,7 +1743,8 @@ extern {
                                           isOptimized: bool,
                                           Flags: *const c_char,
                                           RuntimeVer: c_uint,
-                                          SplitName: *const c_char);
+                                          SplitName: *const c_char)
+                                          -> DIDescriptor;
 
     pub fn LLVMDIBuilderCreateFile(Builder: DIBuilderRef,
                                    Filename: *const c_char,

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2673,6 +2673,8 @@ pub fn create_entry_wrapper(ccx: &CrateContext,
         unsafe {
             llvm::LLVMPositionBuilderAtEnd(bld, llbb);
 
+            debuginfo::insert_reference_to_gdb_debug_scripts_section_global(ccx);
+
             let (start_fn, args) = if use_start_lang_item {
                 let start_def_id = match ccx.tcx().lang_items.require(StartFnLangItem) {
                     Ok(id) => id,

--- a/src/librustc_trans/trans/debuginfo.rs
+++ b/src/librustc_trans/trans/debuginfo.rs
@@ -212,7 +212,7 @@ use std::ptr;
 use std::rc::{Rc, Weak};
 use syntax::util::interner::Interner;
 use syntax::codemap::{Span, Pos};
-use syntax::{ast, codemap, ast_util, ast_map};
+use syntax::{ast, codemap, ast_util, ast_map, attr};
 use syntax::ast_util::PostExpansionMethod;
 use syntax::parse::token::{mod, special_idents};
 
@@ -740,7 +740,16 @@ pub fn finalize(cx: &CrateContext) {
     }
 
     debug!("finalize");
-    compile_unit_metadata(cx);
+    let _ = compile_unit_metadata(cx);
+
+    if needs_gdb_debug_scripts_section(cx) {
+        // Add a .debug_gdb_scripts section to this compile-unit. This will
+        // cause GDB to try and load the gdb_load_rust_pretty_printers.py file,
+        // which activates the Rust pretty printers for binary this section is
+        // contained in.
+        get_or_insert_gdb_debug_scripts_section_global(cx);
+    }
+
     unsafe {
         llvm::LLVMDIBuilderFinalize(DIB(cx));
         llvm::LLVMDIBuilderDispose(DIB(cx));
@@ -1579,7 +1588,7 @@ fn create_DIArray(builder: DIBuilderRef, arr: &[DIDescriptor]) -> DIArray {
     };
 }
 
-fn compile_unit_metadata(cx: &CrateContext) {
+fn compile_unit_metadata(cx: &CrateContext) -> DIDescriptor {
     let work_dir = &cx.sess().working_dir;
     let compile_unit_name = match cx.sess().local_crate_source_file {
         None => fallback_path(cx),
@@ -1614,7 +1623,7 @@ fn compile_unit_metadata(cx: &CrateContext) {
                            (option_env!("CFG_VERSION")).expect("CFG_VERSION"));
 
     let compile_unit_name = compile_unit_name.as_ptr();
-    work_dir.as_vec().with_c_str(|work_dir| {
+    return work_dir.as_vec().with_c_str(|work_dir| {
         producer.with_c_str(|producer| {
             "".with_c_str(|flags| {
                 "".with_c_str(|split_name| {
@@ -1628,7 +1637,7 @@ fn compile_unit_metadata(cx: &CrateContext) {
                             cx.sess().opts.optimize != config::No,
                             flags,
                             0,
-                            split_name);
+                            split_name)
                     }
                 })
             })
@@ -4103,3 +4112,76 @@ fn namespace_for_item(cx: &CrateContext, def_id: ast::DefId) -> Rc<NamespaceTree
         }
     })
 }
+
+
+//=-----------------------------------------------------------------------------
+// .debug_gdb_scripts binary section
+//=-----------------------------------------------------------------------------
+
+/// Inserts a side-effect free instruction sequence that makes sure that the
+/// .debug_gdb_scripts global is referenced, so it isn't removed by the linker.
+pub fn insert_reference_to_gdb_debug_scripts_section_global(ccx: &CrateContext) {
+    if needs_gdb_debug_scripts_section(ccx) {
+        let empty = b"".to_c_str();
+        let gdb_debug_scripts_section_global =
+            get_or_insert_gdb_debug_scripts_section_global(ccx);
+        unsafe {
+            let volative_load_instruction =
+                llvm::LLVMBuildLoad(ccx.raw_builder(),
+                                    gdb_debug_scripts_section_global,
+                                    empty.as_ptr());
+            llvm::LLVMSetVolatile(volative_load_instruction, llvm::True);
+        }
+    }
+}
+
+/// Allocates the global variable responsible for the .debug_gdb_scripts binary
+/// section.
+fn get_or_insert_gdb_debug_scripts_section_global(ccx: &CrateContext)
+                                                  -> llvm::ValueRef {
+    let section_var_name = b"__rustc_debug_gdb_scripts_section__".to_c_str();
+
+    let section_var = unsafe {
+        llvm::LLVMGetNamedGlobal(ccx.llmod(), section_var_name.as_ptr())
+    };
+
+    if section_var == ptr::null_mut() {
+        let section_name = b".debug_gdb_scripts".to_c_str();
+        let section_contents = b"\x01gdb_load_rust_pretty_printers.py\0";
+
+        unsafe {
+            let llvm_type = Type::array(&Type::i8(ccx),
+                                        section_contents.len() as u64);
+            let section_var = llvm::LLVMAddGlobal(ccx.llmod(),
+                                                  llvm_type.to_ref(),
+                                                  section_var_name.as_ptr());
+            llvm::LLVMSetSection(section_var, section_name.as_ptr());
+            llvm::LLVMSetInitializer(section_var, C_bytes(ccx, section_contents));
+            llvm::LLVMSetGlobalConstant(section_var, llvm::True);
+            llvm::LLVMSetUnnamedAddr(section_var, llvm::True);
+            llvm::SetLinkage(section_var, llvm::Linkage::LinkOnceODRLinkage);
+            // This should make sure that the whole section is not larger than
+            // the string it contains. Otherwise we get a warning from GDB.
+            llvm::LLVMSetAlignment(section_var, 1);
+            section_var
+        }
+    } else {
+        section_var
+    }
+}
+
+fn needs_gdb_debug_scripts_section(ccx: &CrateContext) -> bool {
+    let omit_gdb_pretty_printer_section =
+        attr::contains_name(ccx.tcx()
+                               .map
+                               .krate()
+                               .attrs
+                               .as_slice(),
+                            "omit_gdb_pretty_printer_section");
+
+    !omit_gdb_pretty_printer_section &&
+    !ccx.sess().target.target.options.is_like_osx &&
+    !ccx.sess().target.target.options.is_like_windows &&
+    ccx.sess().opts.debuginfo != NoDebugInfo
+}
+

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -257,7 +257,7 @@ extern "C" void LLVMDIBuilderFinalize(DIBuilderRef Builder) {
     Builder->finalize();
 }
 
-extern "C" void LLVMDIBuilderCreateCompileUnit(
+extern "C" LLVMValueRef LLVMDIBuilderCreateCompileUnit(
     DIBuilderRef Builder,
     unsigned Lang,
     const char* File,
@@ -267,8 +267,14 @@ extern "C" void LLVMDIBuilderCreateCompileUnit(
     const char* Flags,
     unsigned RuntimeVer,
     const char* SplitName) {
-    Builder->createCompileUnit(Lang, File, Dir, Producer, isOptimized,
-        Flags, RuntimeVer, SplitName);
+    return wrap(Builder->createCompileUnit(Lang,
+                                           File,
+                                           Dir,
+                                           Producer,
+                                           isOptimized,
+                                           Flags,
+                                           RuntimeVer,
+                                           SplitName));
 }
 
 extern "C" LLVMValueRef LLVMDIBuilderCreateFile(

--- a/src/test/debuginfo/basic-types-globals-metadata.rs
+++ b/src/test/debuginfo/basic-types-globals-metadata.rs
@@ -45,6 +45,7 @@
 
 #![allow(unused_variables)]
 #![allow(dead_code)]
+#![omit_gdb_pretty_printer_section]
 
 
 static B: bool = false;

--- a/src/test/debuginfo/basic-types-globals.rs
+++ b/src/test/debuginfo/basic-types-globals.rs
@@ -50,6 +50,7 @@
 // gdb-command:continue
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 static B: bool = false;
 static I: int = -1;

--- a/src/test/debuginfo/basic-types-metadata.rs
+++ b/src/test/debuginfo/basic-types-metadata.rs
@@ -48,6 +48,7 @@
 // gdb-command:continue
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 fn main() {
     let unit: () = ();

--- a/src/test/debuginfo/basic-types-mut-globals.rs
+++ b/src/test/debuginfo/basic-types-mut-globals.rs
@@ -83,6 +83,7 @@
 // gdb-check:$28 = 9.25
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 static mut B: bool = false;
 static mut I: int = -1;

--- a/src/test/debuginfo/basic-types.rs
+++ b/src/test/debuginfo/basic-types.rs
@@ -88,6 +88,7 @@
 // lldb-check:[...]$12 = 3.5
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 fn main() {
     let b: bool = false;

--- a/src/test/debuginfo/borrowed-basic.rs
+++ b/src/test/debuginfo/borrowed-basic.rs
@@ -109,6 +109,7 @@
 // lldb-check:[...]$12 = 3.5
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 fn main() {
     let bool_val: bool = true;

--- a/src/test/debuginfo/borrowed-c-style-enum.rs
+++ b/src/test/debuginfo/borrowed-c-style-enum.rs
@@ -41,6 +41,7 @@
 // lldb-check:[...]$2 = TheC
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 enum ABC { TheA, TheB, TheC }
 

--- a/src/test/debuginfo/borrowed-enum.rs
+++ b/src/test/debuginfo/borrowed-enum.rs
@@ -40,6 +40,7 @@
 // lldb-check:[...]$2 = TheOnlyCase(4820353753753434)
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 // The first element is to ensure proper alignment, irrespective of the machines word size. Since
 // the size of the discriminant value is machine dependent, this has be taken into account when

--- a/src/test/debuginfo/borrowed-struct.rs
+++ b/src/test/debuginfo/borrowed-struct.rs
@@ -64,6 +64,7 @@
 // lldb-check:[...]$6 = 26.5
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 struct SomeStruct {
     x: int,

--- a/src/test/debuginfo/borrowed-tuple.rs
+++ b/src/test/debuginfo/borrowed-tuple.rs
@@ -42,6 +42,7 @@
 
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 fn main() {
     let stack_val: (i16, f32) = (-14, -19f32);

--- a/src/test/debuginfo/borrowed-unique-basic.rs
+++ b/src/test/debuginfo/borrowed-unique-basic.rs
@@ -112,7 +112,7 @@
 // lldb-check:[...]$12 = 3.5
 
 #![allow(unused_variables)]
-
+#![omit_gdb_pretty_printer_section]
 
 fn main() {
     let bool_box: Box<bool> = box true;

--- a/src/test/debuginfo/box.rs
+++ b/src/test/debuginfo/box.rs
@@ -32,6 +32,7 @@
 // lldb-check:[...]$1 = (2, 3.5)
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 fn main() {
     let a = box 1i;

--- a/src/test/debuginfo/boxed-struct.rs
+++ b/src/test/debuginfo/boxed-struct.rs
@@ -35,6 +35,7 @@
 // lldb-check:[...]$1 = StructWithDestructor { x: 77, y: 777, z: 7777, w: 77777 }
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 struct StructWithSomePadding {
     x: i16,

--- a/src/test/debuginfo/by-value-non-immediate-argument.rs
+++ b/src/test/debuginfo/by-value-non-immediate-argument.rs
@@ -71,6 +71,8 @@
 // lldb-check:[...]$6 = Case1 { x: 0, y: 8970181431921507452 }
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
+
 #[deriving(Clone)]
 struct Struct {
     a: int,

--- a/src/test/debuginfo/by-value-self-argument-in-trait-impl.rs
+++ b/src/test/debuginfo/by-value-self-argument-in-trait-impl.rs
@@ -46,6 +46,8 @@
 // lldb-check:[...]$2 = (4444.5, 5555, 6666, 7777.5)
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
+
 trait Trait {
     fn method(self) -> Self;
 }

--- a/src/test/debuginfo/c-style-enum-in-composite.rs
+++ b/src/test/debuginfo/c-style-enum-in-composite.rs
@@ -65,6 +65,7 @@
 // lldb-check:[...]$6 = (StructWithDrop { a: OneHundred, b: Vienna }, 9)
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 use self::AnEnum::{OneHundred, OneThousand, OneMillion};
 use self::AnotherEnum::{MountainView, Toronto, Vienna};

--- a/src/test/debuginfo/c-style-enum.rs
+++ b/src/test/debuginfo/c-style-enum.rs
@@ -99,6 +99,7 @@
 
 #![allow(unused_variables)]
 #![allow(dead_code)]
+#![omit_gdb_pretty_printer_section]
 
 use self::AutoDiscriminant::{One, Two, Three};
 use self::ManualDiscriminant::{OneHundred, OneThousand, OneMillion};

--- a/src/test/debuginfo/closure-in-generic-function.rs
+++ b/src/test/debuginfo/closure-in-generic-function.rs
@@ -46,6 +46,8 @@
 // lldb-check:[...]$3 = 110
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
+
 fn some_generic_fun<T1, T2>(a: T1, b: T2) -> (T2, T1) {
 
     let closure = |x, y| {

--- a/src/test/debuginfo/destructured-fn-argument.rs
+++ b/src/test/debuginfo/destructured-fn-argument.rs
@@ -311,6 +311,7 @@
 // lldb-command:continue
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 use self::Univariant::Unit;
 

--- a/src/test/debuginfo/destructured-for-loop-variable.rs
+++ b/src/test/debuginfo/destructured-for-loop-variable.rs
@@ -152,6 +152,9 @@
 // lldb-check:[...]$23 = (34903493, 232323)
 // lldb-command:continue
 
+#![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
+
 struct Struct {
     x: i16,
     y: f32,

--- a/src/test/debuginfo/destructured-local.rs
+++ b/src/test/debuginfo/destructured-local.rs
@@ -244,6 +244,7 @@
 
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 use self::Univariant::Unit;
 

--- a/src/test/debuginfo/evec-in-struct.rs
+++ b/src/test/debuginfo/evec-in-struct.rs
@@ -51,6 +51,7 @@
 // lldb-check:[...]$4 = StructPaddedAtEnd { x: [22, 23], y: [24, 25] }
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 struct NoPadding1 {
     x: [u32; 3],

--- a/src/test/debuginfo/function-arg-initialization.rs
+++ b/src/test/debuginfo/function-arg-initialization.rs
@@ -222,10 +222,8 @@
 // lldb-command:continue
 
 
-
 #![allow(unused_variables)]
-
-
+#![omit_gdb_pretty_printer_section]
 
 fn immediate_args(a: int, b: bool, c: f64) {
     ::std::io::print("") // #break

--- a/src/test/debuginfo/function-arguments.rs
+++ b/src/test/debuginfo/function-arguments.rs
@@ -45,6 +45,9 @@
 // lldb-check:[...]$3 = 3000
 // lldb-command:continue
 
+
+#![omit_gdb_pretty_printer_section]
+
 fn main() {
 
     fun(111102, true);

--- a/src/test/debuginfo/function-prologue-stepping-no-stack-check.rs
+++ b/src/test/debuginfo/function-prologue-stepping-no-stack-check.rs
@@ -245,6 +245,7 @@
 // lldb-command:continue
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 #[no_stack_check]
 fn immediate_args(a: int, b: bool, c: f64) {

--- a/src/test/debuginfo/function-prologue-stepping-regular.rs
+++ b/src/test/debuginfo/function-prologue-stepping-regular.rs
@@ -126,6 +126,7 @@
 // lldb-command:continue
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 fn immediate_args(a: int, b: bool, c: f64) {
     ()

--- a/src/test/debuginfo/gdb-pretty-struct-and-enums-pre-gdb-7-7.rs
+++ b/src/test/debuginfo/gdb-pretty-struct-and-enums-pre-gdb-7-7.rs
@@ -17,7 +17,6 @@
 // ignore-lldb
 // ignore-android: FIXME(#10381)
 // compile-flags:-g
-// gdb-use-pretty-printer
 
 // gdb-command: run
 

--- a/src/test/debuginfo/gdb-pretty-struct-and-enums.rs
+++ b/src/test/debuginfo/gdb-pretty-struct-and-enums.rs
@@ -13,7 +13,6 @@
 // ignore-lldb
 // ignore-android: FIXME(#10381)
 // compile-flags:-g
-// gdb-use-pretty-printer
 
 // This test uses some GDB Python API features (e.g. accessing anonymous fields)
 // which are only available in newer GDB version. The following directive will

--- a/src/test/debuginfo/generic-function.rs
+++ b/src/test/debuginfo/generic-function.rs
@@ -70,6 +70,7 @@
 // lldb-check:[...]$8 = ((5, Struct { a: 6, b: 7.5 }), (Struct { a: 6, b: 7.5 }, 5))
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
 
 #[deriving(Clone)]
 struct Struct {

--- a/src/test/debuginfo/generic-functions-nested.rs
+++ b/src/test/debuginfo/generic-functions-nested.rs
@@ -70,6 +70,9 @@
 // lldb-check:[...]$7 = 2.5
 // lldb-command:continue
 
+
+#![omit_gdb_pretty_printer_section]
+
 fn outer<TA: Clone>(a: TA) {
     inner(a.clone(), 1i);
     inner(a.clone(), 2.5f64);

--- a/src/test/debuginfo/generic-method-on-generic-struct.rs
+++ b/src/test/debuginfo/generic-method-on-generic-struct.rs
@@ -112,6 +112,7 @@
 // lldb-check:[...]$14 = -10.5
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
 
 struct Struct<T> {
     x: T

--- a/src/test/debuginfo/generic-static-method-on-struct-and-enum.rs
+++ b/src/test/debuginfo/generic-static-method-on-struct-and-enum.rs
@@ -31,6 +31,9 @@
 // gdb-check:$5 = 5
 // gdb-command:continue
 
+
+#![omit_gdb_pretty_printer_section]
+
 struct Struct {
     x: int
 }

--- a/src/test/debuginfo/generic-struct-style-enum.rs
+++ b/src/test/debuginfo/generic-struct-style-enum.rs
@@ -29,6 +29,9 @@
 // gdb-command:print univariant
 // gdb-check:$4 = {{a = -1}}
 
+
+#![omit_gdb_pretty_printer_section]
+
 use self::Regular::{Case1, Case2, Case3};
 use self::Univariant::TheOnlyCase;
 

--- a/src/test/debuginfo/generic-struct.rs
+++ b/src/test/debuginfo/generic-struct.rs
@@ -41,6 +41,9 @@
 // lldb-command:print float_int_float
 // lldb-check:[...]$3 = AGenericStruct<f64, generic-struct::AGenericStruct<int, f64>> { key: 6.5, value: AGenericStruct<int, f64> { key: 7, value: 8.5 } }
 
+
+#![omit_gdb_pretty_printer_section]
+
 struct AGenericStruct<TKey, TValue> {
     key: TKey,
     value: TValue

--- a/src/test/debuginfo/generic-trait-generic-static-default-method.rs
+++ b/src/test/debuginfo/generic-trait-generic-static-default-method.rs
@@ -25,6 +25,7 @@
 // gdb-check:$4 = {3.5, {4, 5, 6}}
 // gdb-command:continue
 
+#![omit_gdb_pretty_printer_section]
 
 struct Struct {
     x: int

--- a/src/test/debuginfo/generic-tuple-style-enum.rs
+++ b/src/test/debuginfo/generic-tuple-style-enum.rs
@@ -48,6 +48,8 @@
 // lldb-command:print univariant
 // lldb-check:[...]$3 = TheOnlyCase(-1)
 
+#![omit_gdb_pretty_printer_section]
+
 use self::Regular::{Case1, Case2, Case3};
 use self::Univariant::TheOnlyCase;
 

--- a/src/test/debuginfo/include_string.rs
+++ b/src/test/debuginfo/include_string.rs
@@ -36,6 +36,7 @@
 // lldb-command:continue
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 // This test case makes sure that debug info does not ICE when include_str is
 // used multiple times (see issue #11322).

--- a/src/test/debuginfo/issue12886.rs
+++ b/src/test/debuginfo/issue12886.rs
@@ -16,8 +16,10 @@
 
 // gdb-command:run
 // gdb-command:next
-// gdb-check:[...]32[...]s
+// gdb-check:[...]34[...]s
 // gdb-command:continue
+
+#![omit_gdb_pretty_printer_section]
 
 // IF YOU MODIFY THIS FILE, BE CAREFUL TO ADAPT THE LINE NUMBERS IN THE DEBUGGER COMMANDS
 

--- a/src/test/debuginfo/lexical-scope-in-for-loop.rs
+++ b/src/test/debuginfo/lexical-scope-in-for-loop.rs
@@ -86,6 +86,8 @@
 // lldb-check:[...]$6 = 1000000
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
+
 fn main() {
 
     let range = [1i, 2, 3];

--- a/src/test/debuginfo/lexical-scope-in-if.rs
+++ b/src/test/debuginfo/lexical-scope-in-if.rs
@@ -134,6 +134,7 @@
 // lldb-check:[...]$15 = -1
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
 
 fn main() {
 

--- a/src/test/debuginfo/lexical-scope-in-match.rs
+++ b/src/test/debuginfo/lexical-scope-in-match.rs
@@ -126,6 +126,7 @@
 // lldb-check:[...]$17 = 232
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
 
 struct Struct {
     x: int,

--- a/src/test/debuginfo/lexical-scope-in-stack-closure.rs
+++ b/src/test/debuginfo/lexical-scope-in-stack-closure.rs
@@ -70,6 +70,8 @@
 // lldb-check:[...]$5 = false
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
+
 fn main() {
 
     let x = false;

--- a/src/test/debuginfo/lexical-scope-in-unconditional-loop.rs
+++ b/src/test/debuginfo/lexical-scope-in-unconditional-loop.rs
@@ -132,6 +132,8 @@
 // lldb-check:[...]$12 = 2
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
+
 fn main() {
 
     let mut x = 0i;

--- a/src/test/debuginfo/lexical-scope-in-unique-closure.rs
+++ b/src/test/debuginfo/lexical-scope-in-unique-closure.rs
@@ -70,6 +70,9 @@
 // lldb-check:[...]$5 = false
 // lldb-command:continue
 
+
+#![omit_gdb_pretty_printer_section]
+
 fn main() {
 
     let x = false;

--- a/src/test/debuginfo/lexical-scope-in-while.rs
+++ b/src/test/debuginfo/lexical-scope-in-while.rs
@@ -132,6 +132,7 @@
 // lldb-check:[...]$12 = 2
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
 
 fn main() {
 

--- a/src/test/debuginfo/lexical-scope-with-macro.rs
+++ b/src/test/debuginfo/lexical-scope-with-macro.rs
@@ -112,6 +112,7 @@
 
 
 #![feature(macro_rules)]
+#![omit_gdb_pretty_printer_section]
 
 macro_rules! trivial {
     ($e1:expr) => ($e1)

--- a/src/test/debuginfo/lexical-scopes-in-block-expression.rs
+++ b/src/test/debuginfo/lexical-scopes-in-block-expression.rs
@@ -349,6 +349,7 @@
 
 #![allow(unused_variables)]
 #![allow(unused_assignments)]
+#![omit_gdb_pretty_printer_section]
 
 static mut MUT_INT: int = 0;
 

--- a/src/test/debuginfo/limited-debuginfo.rs
+++ b/src/test/debuginfo/limited-debuginfo.rs
@@ -30,6 +30,7 @@
 
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 struct Struct {
     a: i64,

--- a/src/test/debuginfo/method-on-enum.rs
+++ b/src/test/debuginfo/method-on-enum.rs
@@ -113,6 +113,8 @@
 // lldb-check:[...]$14 = -10
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
+
 enum Enum {
     Variant1 { x: u16, y: u16 },
     Variant2 (u32)

--- a/src/test/debuginfo/method-on-generic-struct.rs
+++ b/src/test/debuginfo/method-on-generic-struct.rs
@@ -113,6 +113,8 @@
 // lldb-command:continue
 
 
+#![omit_gdb_pretty_printer_section]
+
 struct Struct<T> {
     x: T
 }

--- a/src/test/debuginfo/method-on-struct.rs
+++ b/src/test/debuginfo/method-on-struct.rs
@@ -112,6 +112,9 @@
 // lldb-check:[...]$14 = -10
 // lldb-command:continue
 
+
+#![omit_gdb_pretty_printer_section]
+
 struct Struct {
     x: int
 }

--- a/src/test/debuginfo/method-on-trait.rs
+++ b/src/test/debuginfo/method-on-trait.rs
@@ -112,6 +112,9 @@
 // lldb-check:[...]$14 = -10
 // lldb-command:continue
 
+
+#![omit_gdb_pretty_printer_section]
+
 struct Struct {
     x: int
 }

--- a/src/test/debuginfo/method-on-tuple-struct.rs
+++ b/src/test/debuginfo/method-on-tuple-struct.rs
@@ -112,6 +112,9 @@
 // lldb-check:[...]$14 = -10
 // lldb-command:continue
 
+
+#![omit_gdb_pretty_printer_section]
+
 struct TupleStruct(int, f64);
 
 impl TupleStruct {

--- a/src/test/debuginfo/multiple-functions-equal-var-names.rs
+++ b/src/test/debuginfo/multiple-functions-equal-var-names.rs
@@ -45,6 +45,7 @@
 // lldb-check:[...]$2 = 30303
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 fn function_one() {
     let abc = 10101i;

--- a/src/test/debuginfo/multiple-functions.rs
+++ b/src/test/debuginfo/multiple-functions.rs
@@ -45,6 +45,7 @@
 // lldb-check:[...]$2 = 30303
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 fn function_one() {
     let a = 10101i;

--- a/src/test/debuginfo/name-shadowing-and-scope-nesting.rs
+++ b/src/test/debuginfo/name-shadowing-and-scope-nesting.rs
@@ -94,6 +94,8 @@
 // lldb-check:[...]$11 = 20
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
+
 fn main() {
     let x = false;
     let y = true;

--- a/src/test/debuginfo/nil-enum.rs
+++ b/src/test/debuginfo/nil-enum.rs
@@ -23,6 +23,7 @@
 // gdb-check:$2 = {<No data fields>}
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 enum ANilEnum {}
 enum AnotherNilEnum {}

--- a/src/test/debuginfo/no-debug-attribute.rs
+++ b/src/test/debuginfo/no-debug-attribute.rs
@@ -24,6 +24,7 @@
 // gdb-command:continue
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 fn function_with_debuginfo() {
     let abc = 10u;

--- a/src/test/debuginfo/option-like-enum.rs
+++ b/src/test/debuginfo/option-like-enum.rs
@@ -68,6 +68,8 @@
 // lldb-check:[...]$7 = None
 
 
+#![omit_gdb_pretty_printer_section]
+
 // If a struct has exactly two variants, one of them is empty, and the other one
 // contains a non-nullable pointer, then this value is used as the discriminator.
 // The test cases in this file make sure that something readable is generated for

--- a/src/test/debuginfo/packed-struct-with-destructor.rs
+++ b/src/test/debuginfo/packed-struct-with-destructor.rs
@@ -74,6 +74,7 @@
 
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 #[repr(packed)]
 struct Packed {

--- a/src/test/debuginfo/packed-struct.rs
+++ b/src/test/debuginfo/packed-struct.rs
@@ -60,6 +60,7 @@
 // lldb-check:[...]$5 = 40
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 #[repr(packed)]
 struct Packed {

--- a/src/test/debuginfo/recursive-enum.rs
+++ b/src/test/debuginfo/recursive-enum.rs
@@ -18,6 +18,7 @@
 // is taken from issue #11083.
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 pub struct Window<'a> {
     callbacks: WindowCallbacks<'a>

--- a/src/test/debuginfo/recursive-struct.rs
+++ b/src/test/debuginfo/recursive-struct.rs
@@ -69,6 +69,7 @@
 // gdb-command:continue
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 use self::Opt::{Empty, Val};
 

--- a/src/test/debuginfo/self-in-default-method.rs
+++ b/src/test/debuginfo/self-in-default-method.rs
@@ -112,6 +112,7 @@
 // lldb-check:[...]$14 = -10
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
 
 struct Struct {
     x: int

--- a/src/test/debuginfo/self-in-generic-default-method.rs
+++ b/src/test/debuginfo/self-in-generic-default-method.rs
@@ -112,6 +112,7 @@
 // lldb-check:[...]$14 = -10.5
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
 
 struct Struct {
     x: int

--- a/src/test/debuginfo/shadowed-argument.rs
+++ b/src/test/debuginfo/shadowed-argument.rs
@@ -58,6 +58,9 @@
 // lldb-check:[...]$5 = 20
 // lldb-command:continue
 
+
+#![omit_gdb_pretty_printer_section]
+
 fn a_function(x: bool, y: bool) {
     zzz(); // #break
     sentinel();

--- a/src/test/debuginfo/shadowed-variable.rs
+++ b/src/test/debuginfo/shadowed-variable.rs
@@ -58,6 +58,8 @@
 // lldb-check:[...]$5 = 20
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
+
 fn main() {
     let x = false;
     let y = true;

--- a/src/test/debuginfo/simd.rs
+++ b/src/test/debuginfo/simd.rs
@@ -43,6 +43,7 @@
 
 #![allow(experimental)]
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 use std::simd::{i8x16, i16x8,i32x4,i64x2,u8x16,u16x8,u32x4,u64x2,f32x4,f64x2};
 

--- a/src/test/debuginfo/simple-lexical-scope.rs
+++ b/src/test/debuginfo/simple-lexical-scope.rs
@@ -78,6 +78,9 @@
 // lldb-check:[...]$6 = false
 // lldb-command:continue
 
+
+#![omit_gdb_pretty_printer_section]
+
 fn main() {
     let x = false;
 

--- a/src/test/debuginfo/simple-struct.rs
+++ b/src/test/debuginfo/simple-struct.rs
@@ -95,8 +95,9 @@
 // lldb-command:print padding_at_end
 // lldb-check:[...]$5 = PaddingAtEnd { x: -10014, y: 10015 }
 
-#![allow(unused_variables)];
-#![allow(dead_code)];
+#![allow(unused_variables)]
+#![allow(dead_code)]
+#![omit_gdb_pretty_printer_section]
 
 struct NoPadding16 {
     x: u16,

--- a/src/test/debuginfo/simple-tuple.rs
+++ b/src/test/debuginfo/simple-tuple.rs
@@ -92,6 +92,7 @@
 
 #![allow(unused_variables)]
 #![allow(dead_code)]
+#![omit_gdb_pretty_printer_section]
 
 static mut NO_PADDING_8: (i8, u8) = (-50, 50);
 static mut NO_PADDING_16: (i16, i16, u16) = (-1, 2, 3);

--- a/src/test/debuginfo/static-method-on-struct-and-enum.rs
+++ b/src/test/debuginfo/static-method-on-struct-and-enum.rs
@@ -54,6 +54,8 @@
 // lldb-check:[...]$4 = 5
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
+
 struct Struct {
     x: int
 }

--- a/src/test/debuginfo/struct-in-enum.rs
+++ b/src/test/debuginfo/struct-in-enum.rs
@@ -42,6 +42,7 @@
 // lldb-check:[...]$2 = TheOnlyCase(Struct { x: 123, y: 456, z: 789 })
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 use self::Regular::{Case1, Case2};
 use self::Univariant::TheOnlyCase;

--- a/src/test/debuginfo/struct-in-struct.rs
+++ b/src/test/debuginfo/struct-in-struct.rs
@@ -57,6 +57,7 @@
 // lldb-check:[...]$7 = Tree { x: Simple { x: 25 }, y: InternalPaddingParent { x: InternalPadding { x: 26, y: 27 }, y: InternalPadding { x: 28, y: 29 }, z: InternalPadding { x: 30, y: 31 } }, z: BagInBag { x: Bag { x: Simple { x: 32 } } } }
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 struct Simple {
     x: i32

--- a/src/test/debuginfo/struct-style-enum.rs
+++ b/src/test/debuginfo/struct-style-enum.rs
@@ -49,6 +49,7 @@
 // lldb-check:[...]$3 = TheOnlyCase { a: -1 }
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 use self::Regular::{Case1, Case2, Case3};
 use self::Univariant::TheOnlyCase;

--- a/src/test/debuginfo/struct-with-destructor.rs
+++ b/src/test/debuginfo/struct-with-destructor.rs
@@ -45,6 +45,7 @@
 // lldb-check:[...]$3 = NestedOuter { a: NestedInner { a: WithDestructor { x: 7890, y: 9870 } } }
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 struct NoDestructor {
     x: i32,

--- a/src/test/debuginfo/trait-generic-static-default-method.rs
+++ b/src/test/debuginfo/trait-generic-static-default-method.rs
@@ -45,6 +45,8 @@
 // lldb-check:[...]$3 = (1, 2, 3)
 // lldb-command:continue
 
+#![omit_gdb_pretty_printer_section]
+
 struct Struct {
     x: int
 }

--- a/src/test/debuginfo/trait-pointers.rs
+++ b/src/test/debuginfo/trait-pointers.rs
@@ -16,6 +16,7 @@
 // lldb-command:run
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 trait Trait {
     fn method(&self) -> int { 0 }

--- a/src/test/debuginfo/tuple-in-struct.rs
+++ b/src/test/debuginfo/tuple-in-struct.rs
@@ -41,6 +41,7 @@
 // gdb-check:$10 = {x = {{40, 41, 42}, {43, 44}}, y = {45, 46, 47, 48}}
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 struct NoPadding1 {
     x: (i32, i32),

--- a/src/test/debuginfo/tuple-in-tuple.rs
+++ b/src/test/debuginfo/tuple-in-tuple.rs
@@ -57,6 +57,7 @@
 // lldb-check:[...]$6 = ((21, 22), 23)
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 fn main() {
     let no_padding1: ((u32, u32), u32, u32) = ((0, 1), 2, 3);

--- a/src/test/debuginfo/tuple-struct.rs
+++ b/src/test/debuginfo/tuple-struct.rs
@@ -62,6 +62,9 @@
 // to all fields having the name "<unnamed_field>"). Otherwise they are handled the same a normal
 // structs.
 
+
+#![omit_gdb_pretty_printer_section]
+
 struct NoPadding16(u16, i16);
 struct NoPadding32(i32, f32, u32);
 struct NoPadding64(f64, i64, u64);

--- a/src/test/debuginfo/tuple-style-enum.rs
+++ b/src/test/debuginfo/tuple-style-enum.rs
@@ -49,6 +49,7 @@
 // lldb-check:[...]$3 = TheOnlyCase(-1)
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 use self::Regular::{Case1, Case2, Case3};
 use self::Univariant::TheOnlyCase;

--- a/src/test/debuginfo/type-names.rs
+++ b/src/test/debuginfo/type-names.rs
@@ -173,6 +173,8 @@
 // gdb-command:whatis stack_closure2
 // gdb-check:type = struct (&mut|i8, f32| -> f32, uint)
 
+#![omit_gdb_pretty_printer_section]
+
 use self::Enum1::{Variant1_1, Variant1_2};
 use std::ptr;
 

--- a/src/test/debuginfo/unique-enum.rs
+++ b/src/test/debuginfo/unique-enum.rs
@@ -42,6 +42,7 @@
 // lldb-check:[...]$2 = TheOnlyCase(123234)
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 // The first element is to ensure proper alignment, irrespective of the machines word size. Since
 // the size of the discriminant value is machine dependent, this has be taken into account when

--- a/src/test/debuginfo/var-captured-in-nested-closure.rs
+++ b/src/test/debuginfo/var-captured-in-nested-closure.rs
@@ -79,6 +79,7 @@
 // lldb-command:continue
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 struct Struct {
     a: int,

--- a/src/test/debuginfo/var-captured-in-sendable-closure.rs
+++ b/src/test/debuginfo/var-captured-in-sendable-closure.rs
@@ -42,6 +42,7 @@
 
 #![allow(unused_variables)]
 #![feature(unboxed_closures)]
+#![omit_gdb_pretty_printer_section]
 
 struct Struct {
     a: int,

--- a/src/test/debuginfo/var-captured-in-stack-closure.rs
+++ b/src/test/debuginfo/var-captured-in-stack-closure.rs
@@ -72,6 +72,7 @@
 
 #![feature(unboxed_closures)]
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 struct Struct {
     a: int,

--- a/src/test/debuginfo/vec-slices.rs
+++ b/src/test/debuginfo/vec-slices.rs
@@ -78,6 +78,7 @@
 
 #![allow(unused_variables)]
 #![feature(slicing_syntax)]
+#![omit_gdb_pretty_printer_section]
 
 struct AStruct {
     x: i16,

--- a/src/test/debuginfo/vec.rs
+++ b/src/test/debuginfo/vec.rs
@@ -29,6 +29,7 @@
 // lldb-check:[...]$0 = [1, 2, 3]
 
 #![allow(unused_variables)]
+#![omit_gdb_pretty_printer_section]
 
 static mut VECT: [i32; 3] = [1, 2, 3];
 


### PR DESCRIPTION
This pull request adds the `rust-gdb` shell script which starts GDB with Rust pretty printers enabled. The PR also makes `rustc` add a special `.debug_gdb_scripts` ELF section on Linux which tells GDB that the produced binary should use the Rust pretty printers.

Note that at the moment this script will only work and be installed on Linux. On Mac OS X there's `rust-lldb` which works much better there. On Windows I had too many problems making this stable. I'll give it another try soonish.

You can use this script just like you would use GDB from the command line. It will use the pretty printers from the Rust "installation" found first in PATH. E.g. if you have `~/rust/x86_64-linux-gnu/stage1/bin` in your path, it will use the pretty printer scripts in `~/rust/x86_64-linux-gnu/stage1/lib/rustlib/etc`.
