### PR TITLE
Everybody loops pprint; -Z unstable-options

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -811,10 +811,15 @@ pub fn rustc_optgroups() -> Vec<RustcOptGroup> {
                    "Pretty-print the input instead of compiling;
                    valid types are: `normal` (un-annotated source),
                    `expanded` (crates expanded),
-                   `typed` (crates expanded, with type annotations),
-                   `expanded,identified` (fully parenthesized, AST nodes with IDs), or
-                   `flowgraph=<nodeid>` (graphviz formatted flowgraph for node)",
+                   `typed` (crates expanded, with type annotations), or
+                   `expanded,identified` (fully parenthesized, AST nodes with IDs).",
                  "TYPE"),
+        opt::flagopt_u("", "xpretty",
+                     "Pretty-print the input instead of compiling, unstable variants;
+                      valid types are any of the types for `--pretty`, as well as:
+                      `flowgraph=<nodeid>` (graphviz formatted flowgraph for node), or
+                      `everybody_loops` (all function bodies replaced with `loop {}`).",
+                     "TYPE"),
         opt::flagopt("", "dep-info",
                  "Output dependency info to <filename> after compiling, \
                   in a format suitable for use by Makefiles", "FILENAME"),

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -138,8 +138,19 @@ fn run_compiler(args: &[String]) {
     }
 
     let pretty = matches.opt_default("pretty", "normal").map(|a| {
-        pretty::parse_pretty(&sess, a.as_slice())
+        // stable pretty-print variants only
+        pretty::parse_pretty(&sess, a.as_slice(), false)
     });
+    let pretty = if pretty.is_none() &&
+        sess.debugging_opt(config::UNSTABLE_OPTIONS) {
+            matches.opt_str("xpretty").map(|a| {
+                // extended with unstable pretty-print variants
+                pretty::parse_pretty(&sess, a.as_slice(), true)
+            })
+        } else {
+            pretty
+        };
+
     match pretty.into_iter().next() {
         Some((ppm, opt_uii)) => {
             pretty::pretty_print_input(sess, cfg, &input, ppm, opt_uii, ofile);

--- a/src/test/run-make/graphviz-flowgraph/Makefile
+++ b/src/test/run-make/graphviz-flowgraph/Makefile
@@ -28,7 +28,7 @@ $(TMPDIR)/%.pp: %.rs
 
 $(TMPDIR)/%.dot: %.rs
 	$(eval $(call FIND_LAST_BLOCK,$<))
-	$(RUSTC_LIB) --pretty flowgraph=$(LASTBLOCKNUM_$<) $< -o $@.tmp
+	$(RUSTC_LIB) -Z unstable-options --xpretty flowgraph=$(LASTBLOCKNUM_$<) $< -o $@.tmp
 	cat $@.tmp | sed -e 's@ (id=[0-9]*)@@g' \
                          -e 's@\[label=""\]@@' \
                          -e 's@digraph [a-zA-Z0-9_]* @digraph block @' \


### PR DESCRIPTION
This PR adds a new pretty printing mode, `everybody_loops`, which replaces every function body in the input with `loop { }`.  I have found this to be useful for building narrow test cases starting from bugs in static analyses like typeck and borrowck that are only exposed initially from complex input source crates like `librustc`.

The process to follow is:
1. You first generate the new input with every function body replaced with `loop { }`, then
2. you cut-and-paste the original function body that exposes the error, 
3. re-run the compiler on the modified output, to confirm you still see the bug -- but now you should get results faster and with much narrower debug output, since all the other function bodies are trivial.
   4., optional you iteratively delete all the other items that are now found to be no longer necessary since all of the function bodies are now just `loop { }`.

(Strictly speaking, there are bugs in the pretty printer and/or parser that make the process above not as seamless as described.  For example, it seems that `use super::{A, B};` can in some contexts be pretty-printed with whitespace separating `super` and `::` and `{A, B};`, which the parser then errors on.  But that is not an argument against the overall technique, which still appears pretty effective, though perhaps it would be even better if combined with macro-expansion in some way.)

---

Up front: I do believe this sort of local development hack should not want this option to be part of the stable public interface for `rustc`.  So while I could make a `-Z` flag just for this, I am worried that our `-Z` infrastructure is generally too weak to express the kinds of options I want to add (see e.g. #19892 where I use the hack of employing environment variables, when I really would have preferred to leverage `libgetopts`).

Thus, this PR incorporates what I believe to be a reasonable compromise: Add a single new `-Z` flag, `-Z unstable-options`, which expands the set of valid options to `rustc`.  This way, we still leverage all of the `getopts` infrastructure: for example, `rustc -Z unstable-options --help` prints out information about both the stable and unstable options (while `rustc --help` without the `-Z unstable-options` flag just prints out information about the stable options.  The main drawback that I can see is that processing such options is a little bit awkward, since you need to make sure that you check `sess.debugging_opt(config::UNSTABLE_OPTIONS)` before querying the `getopts` matches for the option in question.  But it really is not that bad; all of the ugliest stuff is paid for up front in this PR (e.g. the way I try to ensure that we do not waste time parsing the options twice in the common case where all the provided options are stable).

---

With `-Z unstable-options` in place, it is clear that pretty-print modes like `everybody_loops` belongs under an unstable option, as does the control flow graph visualizing pretty printer.  To deal with that, I added a new unstable-option, `--xpretty` and moved the latter two pretty print modes there.
