### PR TITLE
Remove wrong `&str + String` and `&[T] + Vec<T>` implementations

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -885,14 +885,6 @@ impl<'a> Add<&'a str, String> for String {
     }
 }
 
-#[cfg(not(stage0))]  // NOTE(stage0): Remove cfg after a snapshot
-impl<'a> Add<String, String> for &'a str {
-    fn add(self, mut other: String) -> String {
-        other.push_str(self);
-        other
-    }
-}
-
 impl ops::Slice<uint, str> for String {
     #[inline]
     fn as_slice_<'a>(&'a self) -> &'a str {

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1335,15 +1335,6 @@ impl<'a, T: Clone> Add<&'a [T], Vec<T>> for Vec<T> {
     }
 }
 
-#[cfg(not(stage0))]  // NOTE(stage0): Remove impl after a snapshot
-impl<'a, T: Clone> Add<Vec<T>, Vec<T>> for &'a [T] {
-    #[inline]
-    fn add(self, mut rhs: Vec<T>) -> Vec<T> {
-        rhs.push_all(self);
-        rhs
-    }
-}
-
 #[unsafe_destructor]
 impl<T> Drop for Vec<T> {
     fn drop(&mut self) {


### PR DESCRIPTION
TL;DR I wrongly implemented these two ops, namely `"prefix" + "suffix".to_string()` gives back `"suffixprefix"`. Let's remove them.

The correct implementation of these operations (`lhs.clone().push_str(rhs.as_slice())`) is really wasteful, because the lhs has to be cloned and the rhs gets moved/consumed just to be dropped (no buffer reuse). For this reason, I'd prefer to drop the implementation instead of fixing it. This leaves us with the fact that you'll be able to do `String + &str` but not `&str + String`, which may be unexpected.

r? @aturon
Closes #19952
