### PR TITLE
Add a check for uninferred type parameter

### DIFF
--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -543,7 +543,11 @@ pub fn parameterized<'tcx>(cx: &ctxt<'tcx>,
     if cx.lang_items.fn_trait_kind(did).is_some() {
         format!("{}({}){}",
                 base,
-                strs[0][1 .. strs[0].len() - (strs[0].ends_with(",)") as uint+1)],
+                if strs[0].starts_with("(") && strs[0].ends_with(",)") {
+                    strs[0][1 .. strs[0].len() - 2] // Remove '(' and ',)'
+                } else {
+                    strs[0][]
+                },
                 if &*strs[1] == "()" { String::new() } else { format!(" -> {}", strs[1]) })
     } else if strs.len() > 0 {
         format!("{}<{}>", base, strs.connect(", "))


### PR DESCRIPTION
This fixes #19978. The bug was introduced by 570325d, where if the type
of an Fn has not been inferred (strs[0] is "_") we slice from 1 to 0.
