### PR TITLE
Use `-perm /a+x` instead of `-perm +a+x` in calls to find

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -299,7 +299,7 @@ tidy:
 		| xargs -n 10 $(CFG_PYTHON) $(S)src/etc/tidy.py
 		$(Q)echo $(ALL_HS) \
 		| xargs -n 10 $(CFG_PYTHON) $(S)src/etc/tidy.py
-		$(Q)find $(S)src -type f -perm +a+x \
+		$(Q)find $(S)src -type f -perm /a+x \
 		    -not -name '*.rs' -and -not -name '*.py' \
 		    -and -not -name '*.sh' \
 		| grep '^$(S)src/jemalloc' -v \


### PR DESCRIPTION
The use of `+a+x` is deprecated.

Fixes #19981.
