### PR TITLE
Nonoptional terminal glob

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -966,8 +966,8 @@ extern crate "std" as ruststd; // linking to 'std' under another name
 use_decl : "pub" ? "use" [ path "as" ident
                           | path_glob ] ;
 
-path_glob : ident [ "::" [ path_glob
-                          | '*' ] ] ?
+path_glob : ident [ "::" ( path_glob
+                          | '*' ) ] ?
           | '{' path_item [ ',' path_item ] * '}' ;
 
 path_item : ident | "mod" ;


### PR DESCRIPTION
Unless I'm mistaken, any `use` should end in an identifier, a `'*'`, or a collection of items in `{...}`. As it stands,
`use x::;` is a valid statement which I don't think has any corresponding meaning.
