### PR TITLE
Boolean literals are not Number literals

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -518,7 +518,7 @@ This last example is different because it is not possible to use the suffix
 syntax with a floating point literal ending in a period. `2.f64` would attempt
 to call a method named `f64` on `2`.
 
-##### Boolean literals
+#### Boolean literals
 
 The two values of the boolean type are written `true` and `false`.
 


### PR DESCRIPTION
The current indentation level would indicate that Boolean literals are on the same level as Integer and Float literals under Number literals, unindenting moves it to the same scope as Character and string literals, Byte and byte string literals, and Number literals under Literals.
