### PR TITLE
std: Remove public bool,tuple,unit modules

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -107,7 +107,6 @@ pub mod default;
 
 pub mod any;
 pub mod atomic;
-pub mod bool;
 pub mod borrow;
 pub mod cell;
 pub mod char;
@@ -120,15 +119,11 @@ pub mod result;
 pub mod simd;
 pub mod slice;
 pub mod str;
-pub mod tuple;
 pub mod hash;
-// FIXME #15320: primitive documentation needs top-level modules, this
-// should be `core::tuple::unit`.
-#[path = "tuple/unit.rs"]
-pub mod unit;
 pub mod fmt;
 
 // note: does not need to be public
+mod tuple;
 mod array;
 
 #[doc(hidden)]

--- a/src/libcore/tuple.rs
+++ b/src/libcore/tuple.rs
@@ -62,12 +62,10 @@
 //! assert_eq!(d, (0u32, 0.0f32));
 //! ```
 
-#![doc(primitive = "tuple")]
 #![stable]
 
 #[unstable = "this is just a documentation module and should not be part \
               of the public api"]
-pub use unit;
 
 use clone::Clone;
 use cmp::*;

--- a/src/libstd/bool.rs
+++ b/src/libstd/bool.rs
@@ -11,6 +11,5 @@
 //! The boolean type
 
 #![doc(primitive = "bool")]
-#![unstable = "this module is purely for documentation and it will likely be \
-               removed from the public api"]
+#![stable]
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -137,7 +137,6 @@ extern crate rustrt;
 // NB: These reexports are in the order they should be listed in rustdoc
 
 pub use core::any;
-pub use core::bool;
 pub use core::borrow;
 pub use core::cell;
 pub use core::clone;
@@ -152,10 +151,6 @@ pub use core::mem;
 pub use core::ptr;
 pub use core::raw;
 pub use core::simd;
-pub use core::tuple;
-// FIXME #15320: primitive documentation needs top-level modules, this
-// should be `std::tuple::unit`.
-pub use core::unit;
 pub use core::result;
 pub use core::option;
 
@@ -245,6 +240,12 @@ pub mod comm;
 
 pub mod rt;
 mod failure;
+
+// Documentation for primitive types
+
+mod bool;
+mod unit;
+mod tuple;
 
 // A curious inner-module that's not exported that contains the binding
 // 'std' so that macro-expanded references to std::error and such

--- a/src/libstd/prelude.rs
+++ b/src/libstd/prelude.rs
@@ -81,9 +81,9 @@
 #[doc(no_inline)] pub use io::{Buffer, Writer, Reader, Seek, BufferPrelude};
 #[doc(no_inline)] pub use str::{Str, StrVector, StrPrelude};
 #[doc(no_inline)] pub use str::{StrAllocating, UnicodeStrPrelude};
-#[doc(no_inline)] pub use tuple::{Tuple1, Tuple2, Tuple3, Tuple4};
-#[doc(no_inline)] pub use tuple::{Tuple5, Tuple6, Tuple7, Tuple8};
-#[doc(no_inline)] pub use tuple::{Tuple9, Tuple10, Tuple11, Tuple12};
+#[doc(no_inline)] pub use core::prelude::{Tuple1, Tuple2, Tuple3, Tuple4};
+#[doc(no_inline)] pub use core::prelude::{Tuple5, Tuple6, Tuple7, Tuple8};
+#[doc(no_inline)] pub use core::prelude::{Tuple9, Tuple10, Tuple11, Tuple12};
 #[doc(no_inline)] pub use slice::AsSlice;
 #[doc(no_inline)] pub use slice::{VectorVector, PartialEqSliceExt};
 #[doc(no_inline)] pub use slice::{CloneSliceExt, OrdSliceExt, SliceExt};

--- a/src/libstd/tuple.rs
+++ b/src/libstd/tuple.rs
@@ -1,0 +1,66 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Operations on tuples
+//!
+//! To access a single element of a tuple one can use the following
+//! methods:
+//!
+//! * `valN` - returns a value of _N_-th element
+//! * `refN` - returns a reference to _N_-th element
+//! * `mutN` - returns a mutable reference to _N_-th element
+//!
+//! Indexing starts from zero, so `val0` returns first value, `val1`
+//! returns second value, and so on. In general, a tuple with _S_
+//! elements provides aforementioned methods suffixed with numbers
+//! from `0` to `S-1`. Traits which contain these methods are
+//! implemented for tuples with up to 12 elements.
+//!
+//! If every type inside a tuple implements one of the following
+//! traits, then a tuple itself also implements it.
+//!
+//! * `Clone`
+//! * `PartialEq`
+//! * `Eq`
+//! * `PartialOrd`
+//! * `Ord`
+//! * `Default`
+//!
+//! # Examples
+//!
+//! Using methods:
+//!
+//! ```
+//! #[allow(deprecated)]
+//! # fn main() {
+//! let pair = ("pi", 3.14f64);
+//! assert_eq!(pair.val0(), "pi");
+//! assert_eq!(pair.val1(), 3.14f64);
+//! # }
+//! ```
+//!
+//! Using traits implemented for tuples:
+//!
+//! ```
+//! use std::default::Default;
+//!
+//! let a = (1i, 2i);
+//! let b = (3i, 4i);
+//! assert!(a != b);
+//!
+//! let c = b.clone();
+//! assert!(b == c);
+//!
+//! let d : (u32, f32) = Default::default();
+//! assert_eq!(d, (0u32, 0.0f32));
+//! ```
+
+#![doc(primitive = "tuple")]
+#![stable]

--- a/src/libstd/unit.rs
+++ b/src/libstd/unit.rs
@@ -9,8 +9,7 @@
 // except according to those terms.
 
 #![doc(primitive = "unit")]
-#![unstable = "this module is purely for documentation and it will likely be \
-               removed from the public api"]
+#![stable]
 
 //! The `()` type, sometimes called "unit" or "nil".
 //!

--- a/src/test/compile-fail/issue-9957.rs
+++ b/src/test/compile-fail/issue-9957.rs
@@ -11,5 +11,5 @@
 pub extern crate core; //~ ERROR: `pub` visibility is not allowed
 
 fn main() {
-    pub use std::bool; //~ ERROR: imports in functions are never reachable
+    pub use std::uint; //~ ERROR: imports in functions are never reachable
 }


### PR DESCRIPTION
This commit modifies rustdoc to not require these empty modules to be public in
the standard library. The modules still remain as a location to attach
documentation to, but the modules themselves are now private (don't have to
commit to an API). The documentation for the standard library now shows all of
the primitive types on the main index page.
