### PR TITLE
Adding AArch64 support to tests.

### DIFF
--- a/src/test/auxiliary/extern_calling_convention.rs
+++ b/src/test/auxiliary/extern_calling_convention.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -24,7 +24,7 @@ pub extern "win64" fn foo(a: int, b: int, c: int, d: int) {
 }
 
 #[inline(never)]
-#[cfg(any(target_arch = "x86", target_arch = "arm"))]
+#[cfg(any(target_arch = "x86", target_arch = "arm", target_arch = "aarch64"))]
 pub extern fn foo(a: int, b: int, c: int, d: int) {
     assert!(a == 1);
     assert!(b == 2);

--- a/src/test/compile-fail/asm-in-bad-modifier.rs
+++ b/src/test/compile-fail/asm-in-bad-modifier.rs
@@ -14,7 +14,8 @@ fn foo(x: int) { println!("{}", x); }
 
 #[cfg(any(target_arch = "x86",
           target_arch = "x86_64",
-          target_arch = "arm"))]
+          target_arch = "arm",
+          target_arch = "aarch64"))]
 pub fn main() {
     let x: int;
     let y: int;
@@ -26,5 +27,8 @@ pub fn main() {
     foo(y);
 }
 
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm")))]
+#[cfg(not(any(target_arch = "x86",
+              target_arch = "x86_64",
+              target_arch = "arm",
+              target_arch = "aarch64")))]
 pub fn main() {}

--- a/src/test/compile-fail/asm-out-assign-imm.rs
+++ b/src/test/compile-fail/asm-out-assign-imm.rs
@@ -14,7 +14,8 @@ fn foo(x: int) { println!("{}", x); }
 
 #[cfg(any(target_arch = "x86",
           target_arch = "x86_64",
-          target_arch = "arm"))]
+          target_arch = "arm",
+          target_arch = "aarch64"))]
 pub fn main() {
     let x: int;
     x = 1; //~ NOTE prior assignment occurs here
@@ -25,5 +26,8 @@ pub fn main() {
     foo(x);
 }
 
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm")))]
+#[cfg(not(any(target_arch = "x86",
+              target_arch = "x86_64",
+              target_arch = "arm",
+              target_arch = "aarch64")))]
 pub fn main() {}

--- a/src/test/compile-fail/asm-out-no-modifier.rs
+++ b/src/test/compile-fail/asm-out-no-modifier.rs
@@ -14,7 +14,8 @@ fn foo(x: int) { println!("{}", x); }
 
 #[cfg(any(target_arch = "x86",
           target_arch = "x86_64",
-          target_arch = "arm"))]
+          target_arch = "arm",
+          target_arch = "aarch64"))]
 pub fn main() {
     let x: int;
     unsafe {
@@ -23,5 +24,8 @@ pub fn main() {
     foo(x);
 }
 
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm")))]
+#[cfg(not(any(target_arch = "x86",
+              target_arch = "x86_64",
+              target_arch = "arm",
+              target_arch = "aarch64")))]
 pub fn main() {}

--- a/src/test/compile-fail/asm-out-read-uninit.rs
+++ b/src/test/compile-fail/asm-out-read-uninit.rs
@@ -14,7 +14,8 @@ fn foo(x: int) { println!("{}", x); }
 
 #[cfg(any(target_arch = "x86",
           target_arch = "x86_64",
-          target_arch = "arm"))]
+          target_arch = "arm",
+          target_arch = "aarch64"))]
 pub fn main() {
     let x: int;
     unsafe {
@@ -23,5 +24,8 @@ pub fn main() {
     foo(x);
 }
 
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm")))]
+#[cfg(not(any(target_arch = "x86",
+              target_arch = "x86_64",
+              target_arch = "arm",
+              target_arch = "aarch64")))]
 pub fn main() {}

--- a/src/test/compile-fail/asm-src-loc.rs
+++ b/src/test/compile-fail/asm-src-loc.rs
@@ -12,6 +12,6 @@
 
 fn main() {
     unsafe {
-        asm!("nowayisthisavalidinstruction"); //~ ERROR invalid instruction
+        asm!("nowayisthisavalidinstruction"); //~ ERROR instruction
     }
 }

--- a/src/test/run-fail/bug-2470-bounds-check-overflow-3.rs
+++ b/src/test/run-fail/bug-2470-bounds-check-overflow-3.rs
@@ -32,7 +32,7 @@ fn main() {
     println!("ov3 0x%x",  x.as_slice()[idx]);
 }
 
-#[cfg(target_arch="x86_64")]
+#[cfg(any(target_arch="x86_64", target_arch = "aarch64"))]
 fn main() {
     // This version just panics anyways, for symmetry on 64-bit hosts.
     let x = vec!(1u,2u,3u);

--- a/src/test/run-pass/bitwise.rs
+++ b/src/test/run-pass/bitwise.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -14,7 +14,7 @@ fn target() {
     assert_eq!(-1000 as uint >> 3u, 536870787u);
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn target() {
     assert_eq!(-1000 as uint >> 3u, 2305843009213693827u);
 }

--- a/src/test/run-pass/conditional-compile-arch.rs
+++ b/src/test/run-pass/conditional-compile-arch.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -15,4 +15,7 @@ pub fn main() { }
 pub fn main() { }
 
 #[cfg(target_arch = "arm")]
+pub fn main() { }
+
+#[cfg(target_arch = "aarch64")]
 pub fn main() { }

--- a/src/test/run-pass/intrinsic-alignment.rs
+++ b/src/test/run-pass/intrinsic-alignment.rs
@@ -32,7 +32,7 @@ mod m {
     }
 
     #[main]
-    #[cfg(any(target_arch = "x86_64", target_arch = "arm"))]
+    #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
     pub fn main() {
         unsafe {
             assert_eq!(::rusti::pref_align_of::<u64>(), 8u);

--- a/src/test/run-pass/issue-2895.rs
+++ b/src/test/run-pass/issue-2895.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -22,7 +22,7 @@ impl Drop for Kitty {
     fn drop(&mut self) {}
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch="aarch64"))]
 pub fn main() {
     assert_eq!(mem::size_of::<Cat>(), 8 as uint);
     assert_eq!(mem::size_of::<Kitty>(), 16 as uint);

--- a/src/test/run-pass/rec-align-u32.rs
+++ b/src/test/run-pass/rec-align-u32.rs
@@ -36,7 +36,7 @@ struct Outer {
 }
 
 
-#[cfg(any(target_arch = "x86", target_arch = "arm"))]
+#[cfg(any(target_arch = "x86", target_arch = "arm", target_arch = "aarch64"))]
 mod m {
     pub fn align() -> uint { 4u }
     pub fn size() -> uint { 8u }

--- a/src/test/run-pass/rec-align-u64.rs
+++ b/src/test/run-pass/rec-align-u64.rs
@@ -47,7 +47,7 @@ mod m {
         pub fn size() -> uint { 12u }
     }
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "arm"))]
+    #[cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64"))]
     pub mod m {
         pub fn align() -> uint { 8u }
         pub fn size() -> uint { 16u }

--- a/src/test/run-pass/struct-return.rs
+++ b/src/test/run-pass/struct-return.rs
@@ -46,7 +46,7 @@ fn test1() {
     }
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn test2() {
     unsafe {
         let f = Floats { a: 1.234567890e-15_f64,


### PR DESCRIPTION
Updating architecture-dependent tests so that if and when rustc builds for AArch64 ( #19790 , #20017 ), it passes the tests as well.
