### PR TITLE
Renaming of the Iter types as in RFC #344

### DIFF
--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -239,9 +239,8 @@ impl<T: Ord> BinaryHeap<T> {
     /// }
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn iter(&self) -> Items<T> {
-        Items { iter: self.data.iter() }
-    }
+    pub fn iter(&self) -> Iter<T> {
+        Iter { iter: self.data.iter() } }
 
     /// Creates a consuming iterator, that is, one that moves each value out of
     /// the binary heap in arbitrary order.  The binary heap cannot be used
@@ -260,8 +259,8 @@ impl<T: Ord> BinaryHeap<T> {
     /// }
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn into_iter(self) -> MoveItems<T> {
-        MoveItems { iter: self.data.into_iter() }
+    pub fn into_iter(self) -> IntoIter<T> {
+        IntoIter { iter: self.data.into_iter() }
     }
 
     /// Returns the greatest item in a queue, or `None` if it is empty.
@@ -571,11 +570,11 @@ impl<T: Ord> BinaryHeap<T> {
 }
 
 /// `BinaryHeap` iterator.
-pub struct Items<'a, T: 'a> {
-    iter: slice::Items<'a, T>,
+pub struct Iter <'a, T: 'a> {
+    iter: slice::Iter<'a, T>,
 }
 
-impl<'a, T> Iterator<&'a T> for Items<'a, T> {
+impl<'a, T> Iterator<&'a T> for Iter<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<&'a T> { self.iter.next() }
 
@@ -583,19 +582,19 @@ impl<'a, T> Iterator<&'a T> for Items<'a, T> {
     fn size_hint(&self) -> (uint, Option<uint>) { self.iter.size_hint() }
 }
 
-impl<'a, T> DoubleEndedIterator<&'a T> for Items<'a, T> {
+impl<'a, T> DoubleEndedIterator<&'a T> for Iter<'a, T> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a T> { self.iter.next_back() }
 }
 
-impl<'a, T> ExactSizeIterator<&'a T> for Items<'a, T> {}
+impl<'a, T> ExactSizeIterator<&'a T> for Iter<'a, T> {}
 
 /// An iterator that moves out of a `BinaryHeap`.
-pub struct MoveItems<T> {
-    iter: vec::MoveItems<T>,
+pub struct IntoIter<T> {
+    iter: vec::IntoIter<T>,
 }
 
-impl<T> Iterator<T> for MoveItems<T> {
+impl<T> Iterator<T> for IntoIter<T> {
     #[inline]
     fn next(&mut self) -> Option<T> { self.iter.next() }
 
@@ -603,12 +602,12 @@ impl<T> Iterator<T> for MoveItems<T> {
     fn size_hint(&self) -> (uint, Option<uint>) { self.iter.size_hint() }
 }
 
-impl<T> DoubleEndedIterator<T> for MoveItems<T> {
+impl<T> DoubleEndedIterator<T> for IntoIter<T> {
     #[inline]
     fn next_back(&mut self) -> Option<T> { self.iter.next_back() }
 }
 
-impl<T> ExactSizeIterator<T> for MoveItems<T> {}
+impl<T> ExactSizeIterator<T> for IntoIter<T> {}
 
 /// An iterator that drains a `BinaryHeap`.
 pub struct Drain<'a, T: 'a> {

--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -240,7 +240,8 @@ impl<T: Ord> BinaryHeap<T> {
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter(&self) -> Iter<T> {
-        Iter { iter: self.data.iter() } }
+        Iter { iter: self.data.iter() }
+    }
 
     /// Creates a consuming iterator, that is, one that moves each value out of
     /// the binary heap in arbitrary order.  The binary heap cannot be used

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -145,7 +145,7 @@ impl Index<uint,bool> for Bitv {
 }
 
 struct MaskWords<'a> {
-    iter: slice::Items<'a, u32>,
+    iter: slice::Iter<'a, u32>,
     next_word: Option<&'a u32>,
     last_word_mask: u32,
     offset: uint

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -88,7 +88,7 @@ pub struct BTreeMap<K, V> {
 }
 
 /// An abstract base over-which all other BTree iterators are built.
-struct AbsEntries<T> {
+struct AbsIter<T> {
     lca: T,
     left: RingBuf<T>,
     right: RingBuf<T>,
@@ -96,28 +96,28 @@ struct AbsEntries<T> {
 }
 
 /// An iterator over a BTreeMap's entries.
-pub struct Entries<'a, K: 'a, V: 'a> {
-    inner: AbsEntries<Traversal<'a, K, V>>
+pub struct Iter<'a, K: 'a, V: 'a> {
+    inner: AbsIter<Traversal<'a, K, V>>
 }
 
 /// A mutable iterator over a BTreeMap's entries.
-pub struct MutEntries<'a, K: 'a, V: 'a> {
-    inner: AbsEntries<MutTraversal<'a, K, V>>
+pub struct IterMut<'a, K: 'a, V: 'a> {
+    inner: AbsIter<MutTraversal<'a, K, V>>
 }
 
 /// An owning iterator over a BTreeMap's entries.
-pub struct MoveEntries<K, V> {
-    inner: AbsEntries<MoveTraversal<K, V>>
+pub struct IntoIter<K, V> {
+    inner: AbsIter<MoveTraversal<K, V>>
 }
 
 /// An iterator over a BTreeMap's keys.
 pub struct Keys<'a, K: 'a, V: 'a> {
-    inner: Map<(&'a K, &'a V), &'a K, Entries<'a, K, V>, fn((&'a K, &'a V)) -> &'a K>
+    inner: Map<(&'a K, &'a V), &'a K, Iter<'a, K, V>, fn((&'a K, &'a V)) -> &'a K>
 }
 
 /// An iterator over a BTreeMap's values.
 pub struct Values<'a, K: 'a, V: 'a> {
-    inner: Map<(&'a K, &'a V), &'a V, Entries<'a, K, V>, fn((&'a K, &'a V)) -> &'a V>
+    inner: Map<(&'a K, &'a V), &'a V, Iter<'a, K, V>, fn((&'a K, &'a V)) -> &'a V>
 }
 
 /// A view into a single entry in a map, which may either be vacant or occupied.
@@ -929,7 +929,7 @@ enum StackOp<T> {
 }
 
 impl<K, V, E, T: Traverse<E> + DoubleEndedIterator<TraversalItem<K, V, E>>>
-        Iterator<(K, V)> for AbsEntries<T> {
+        Iterator<(K, V)> for AbsIter<T> {
     // This function is pretty long, but only because there's a lot of cases to consider.
     // Our iterator represents two search paths, left and right, to the smallest and largest
     // elements we have yet to yield. lca represents the least common ancestor of these two paths,
@@ -995,7 +995,7 @@ impl<K, V, E, T: Traverse<E> + DoubleEndedIterator<TraversalItem<K, V, E>>>
 }
 
 impl<K, V, E, T: Traverse<E> + DoubleEndedIterator<TraversalItem<K, V, E>>>
-        DoubleEndedIterator<(K, V)> for AbsEntries<T> {
+        DoubleEndedIterator<(K, V)> for AbsIter<T> {
     // next_back is totally symmetric to next
     fn next_back(&mut self) -> Option<(K, V)> {
         loop {
@@ -1032,34 +1032,34 @@ impl<K, V, E, T: Traverse<E> + DoubleEndedIterator<TraversalItem<K, V, E>>>
     }
 }
 
-impl<'a, K, V> Iterator<(&'a K, &'a V)> for Entries<'a, K, V> {
+impl<'a, K, V> Iterator<(&'a K, &'a V)> for Iter<'a, K, V> {
     fn next(&mut self) -> Option<(&'a K, &'a V)> { self.inner.next() }
     fn size_hint(&self) -> (uint, Option<uint>) { self.inner.size_hint() }
 }
-impl<'a, K, V> DoubleEndedIterator<(&'a K, &'a V)> for Entries<'a, K, V> {
+impl<'a, K, V> DoubleEndedIterator<(&'a K, &'a V)> for Iter<'a, K, V> {
     fn next_back(&mut self) -> Option<(&'a K, &'a V)> { self.inner.next_back() }
 }
-impl<'a, K, V> ExactSizeIterator<(&'a K, &'a V)> for Entries<'a, K, V> {}
+impl<'a, K, V> ExactSizeIterator<(&'a K, &'a V)> for Iter<'a, K, V> {}
 
 
-impl<'a, K, V> Iterator<(&'a K, &'a mut V)> for MutEntries<'a, K, V> {
+impl<'a, K, V> Iterator<(&'a K, &'a mut V)> for IterMut<'a, K, V> {
     fn next(&mut self) -> Option<(&'a K, &'a mut V)> { self.inner.next() }
     fn size_hint(&self) -> (uint, Option<uint>) { self.inner.size_hint() }
 }
-impl<'a, K, V> DoubleEndedIterator<(&'a K, &'a mut V)> for MutEntries<'a, K, V> {
+impl<'a, K, V> DoubleEndedIterator<(&'a K, &'a mut V)> for IterMut<'a, K, V> {
     fn next_back(&mut self) -> Option<(&'a K, &'a mut V)> { self.inner.next_back() }
 }
-impl<'a, K, V> ExactSizeIterator<(&'a K, &'a mut V)> for MutEntries<'a, K, V> {}
+impl<'a, K, V> ExactSizeIterator<(&'a K, &'a mut V)> for IterMut<'a, K, V> {}
 
 
-impl<K, V> Iterator<(K, V)> for MoveEntries<K, V> {
+impl<K, V> Iterator<(K, V)> for IntoIter<K, V> {
     fn next(&mut self) -> Option<(K, V)> { self.inner.next() }
     fn size_hint(&self) -> (uint, Option<uint>) { self.inner.size_hint() }
 }
-impl<K, V> DoubleEndedIterator<(K, V)> for MoveEntries<K, V> {
+impl<K, V> DoubleEndedIterator<(K, V)> for IntoIter<K, V> {
     fn next_back(&mut self) -> Option<(K, V)> { self.inner.next_back() }
 }
-impl<K, V> ExactSizeIterator<(K, V)> for MoveEntries<K, V> {}
+impl<K, V> ExactSizeIterator<(K, V)> for IntoIter<K, V> {}
 
 
 impl<'a, K, V> Iterator<&'a K> for Keys<'a, K, V> {
@@ -1140,10 +1140,10 @@ impl<K, V> BTreeMap<K, V> {
     /// assert_eq!((*first_key, *first_value), (1u, "a"));
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn iter<'a>(&'a self) -> Entries<'a, K, V> {
+    pub fn iter<'a>(&'a self) -> Iter<'a, K, V> {
         let len = self.len();
-        Entries {
-            inner: AbsEntries {
+        Iter {
+            inner: AbsIter {
                 lca: Traverse::traverse(&self.root),
                 left: RingBuf::new(),
                 right: RingBuf::new(),
@@ -1172,10 +1172,10 @@ impl<K, V> BTreeMap<K, V> {
     /// }
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn iter_mut<'a>(&'a mut self) -> MutEntries<'a, K, V> {
+    pub fn iter_mut<'a>(&'a mut self) -> IterMut<'a, K, V> {
         let len = self.len();
-        MutEntries {
-            inner: AbsEntries {
+        IterMut {
+            inner: AbsIter {
                 lca: Traverse::traverse(&mut self.root),
                 left: RingBuf::new(),
                 right: RingBuf::new(),
@@ -1201,10 +1201,10 @@ impl<K, V> BTreeMap<K, V> {
     /// }
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn into_iter(self) -> MoveEntries<K, V> {
+    pub fn into_iter(self) -> IntoIter<K, V> {
         let len = self.len();
-        MoveEntries {
-            inner: AbsEntries {
+        IntoIter {
+            inner: AbsIter {
                 lca: Traverse::traverse(self.root),
                 left: RingBuf::new(),
                 right: RingBuf::new(),

--- a/src/libcollections/btree/node.rs
+++ b/src/libcollections/btree/node.rs
@@ -1382,14 +1382,14 @@ pub enum TraversalItem<K, V, E> {
 }
 
 /// A traversal over a node's entries and edges
-pub type Traversal<'a, K, V> = AbsTraversal<ElemsAndEdges<Zip<slice::Items<'a, K>,
-                                                              slice::Items<'a, V>>,
-                                                              slice::Items<'a, Node<K, V>>>>;
+pub type Traversal<'a, K, V> = AbsTraversal<ElemsAndEdges<Zip<slice::Iter<'a, K>,
+                                                              slice::Iter<'a, V>>,
+                                                              slice::Iter<'a, Node<K, V>>>>;
 
 /// A mutable traversal over a node's entries and edges
-pub type MutTraversal<'a, K, V> = AbsTraversal<ElemsAndEdges<Zip<slice::Items<'a, K>,
-                                                                 slice::MutItems<'a, V>>,
-                                                                 slice::MutItems<'a, Node<K, V>>>>;
+pub type MutTraversal<'a, K, V> = AbsTraversal<ElemsAndEdges<Zip<slice::Iter<'a, K>,
+                                                                 slice::IterMut<'a, V>>,
+                                                                 slice::IterMut<'a, Node<K, V>>>>;
 
 /// An owning traversal over a node's entries and edges
 pub type MoveTraversal<K, V> = AbsTraversal<MoveTraversalImpl<K, V>>;

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -33,37 +33,37 @@ pub struct BTreeSet<T>{
 }
 
 /// An iterator over a BTreeSet's items.
-pub struct Items<'a, T: 'a> {
+pub struct Iter<'a, T: 'a> {
     iter: Keys<'a, T, ()>
 }
 
 /// An owning iterator over a BTreeSet's items.
-pub struct MoveItems<T> {
+pub struct IntoIter<T> {
     iter: Map<(T, ()), T, MoveEntries<T, ()>, fn((T, ())) -> T>
 }
 
 /// A lazy iterator producing elements in the set difference (in-order).
 pub struct DifferenceItems<'a, T:'a> {
-    a: Peekable<&'a T, Items<'a, T>>,
-    b: Peekable<&'a T, Items<'a, T>>,
+    a: Peekable<&'a T, Iter<'a, T>>,
+    b: Peekable<&'a T, Iter<'a, T>>,
 }
 
 /// A lazy iterator producing elements in the set symmetric difference (in-order).
 pub struct SymDifferenceItems<'a, T:'a> {
-    a: Peekable<&'a T, Items<'a, T>>,
-    b: Peekable<&'a T, Items<'a, T>>,
+    a: Peekable<&'a T, Iter<'a, T>>,
+    b: Peekable<&'a T, Iter<'a, T>>,
 }
 
 /// A lazy iterator producing elements in the set intersection (in-order).
 pub struct IntersectionItems<'a, T:'a> {
-    a: Peekable<&'a T, Items<'a, T>>,
-    b: Peekable<&'a T, Items<'a, T>>,
+    a: Peekable<&'a T, Iter<'a, T>>,
+    b: Peekable<&'a T, Iter<'a, T>>,
 }
 
 /// A lazy iterator producing elements in the set union (in-order).
 pub struct UnionItems<'a, T:'a> {
-    a: Peekable<&'a T, Items<'a, T>>,
-    b: Peekable<&'a T, Items<'a, T>>,
+    a: Peekable<&'a T, Iter<'a, T>>,
+    b: Peekable<&'a T, Iter<'a, T>>,
 }
 
 impl<T: Ord> BTreeSet<T> {
@@ -107,8 +107,8 @@ impl<T> BTreeSet<T> {
     /// assert_eq!(v, vec![1u,2,3,4]);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn iter<'a>(&'a self) -> Items<'a, T> {
-        Items { iter: self.map.keys() }
+    pub fn iter<'a>(&'a self) -> Iter<'a, T> {
+        Iter { iter: self.map.keys() }
     }
 
     /// Gets an iterator for moving out the BtreeSet's contents.
@@ -124,10 +124,10 @@ impl<T> BTreeSet<T> {
     /// assert_eq!(v, vec![1u,2,3,4]);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn into_iter(self) -> MoveItems<T> {
+    pub fn into_iter(self) -> IntoIter<T> {
         fn first<A, B>((a, _): (A, B)) -> A { a }
 
-        MoveItems { iter: self.map.into_iter().map(first) }
+        IntoIter { iter: self.map.into_iter().map(first) }
     }
 }
 
@@ -544,24 +544,24 @@ impl<T: Show> Show for BTreeSet<T> {
     }
 }
 
-impl<'a, T> Iterator<&'a T> for Items<'a, T> {
+impl<'a, T> Iterator<&'a T> for Iter<'a, T> {
     fn next(&mut self) -> Option<&'a T> { self.iter.next() }
     fn size_hint(&self) -> (uint, Option<uint>) { self.iter.size_hint() }
 }
-impl<'a, T> DoubleEndedIterator<&'a T> for Items<'a, T> {
+impl<'a, T> DoubleEndedIterator<&'a T> for Iter<'a, T> {
     fn next_back(&mut self) -> Option<&'a T> { self.iter.next_back() }
 }
-impl<'a, T> ExactSizeIterator<&'a T> for Items<'a, T> {}
+impl<'a, T> ExactSizeIterator<&'a T> for Iter<'a, T> {}
 
 
-impl<T> Iterator<T> for MoveItems<T> {
+impl<T> Iterator<T> for IntoIter<T> {
     fn next(&mut self) -> Option<T> { self.iter.next() }
     fn size_hint(&self) -> (uint, Option<uint>) { self.iter.size_hint() }
 }
-impl<T> DoubleEndedIterator<T> for MoveItems<T> {
+impl<T> DoubleEndedIterator<T> for IntoIter<T> {
     fn next_back(&mut self) -> Option<T> { self.iter.next_back() }
 }
-impl<T> ExactSizeIterator<T> for MoveItems<T> {}
+impl<T> ExactSizeIterator<T> for IntoIter<T> {}
 
 /// Compare `x` and `y`, but return `short` if x is None and `long` if y is None
 fn cmp_opt<T: Ord>(x: Option<&T>, y: Option<&T>,

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -13,7 +13,7 @@
 
 use core::prelude::*;
 
-use btree_map::{BTreeMap, Keys, MoveEntries};
+use btree_map::{BTreeMap, Keys};
 use std::hash::Hash;
 use core::borrow::BorrowFrom;
 use core::default::Default;
@@ -39,29 +39,29 @@ pub struct Iter<'a, T: 'a> {
 
 /// An owning iterator over a BTreeSet's items.
 pub struct IntoIter<T> {
-    iter: Map<(T, ()), T, MoveEntries<T, ()>, fn((T, ())) -> T>
+    iter: Map<(T, ()), T, ::btree_map::IntoIter<T, ()>, fn((T, ())) -> T>
 }
 
 /// A lazy iterator producing elements in the set difference (in-order).
-pub struct DifferenceItems<'a, T:'a> {
+pub struct Difference<'a, T:'a> {
     a: Peekable<&'a T, Iter<'a, T>>,
     b: Peekable<&'a T, Iter<'a, T>>,
 }
 
 /// A lazy iterator producing elements in the set symmetric difference (in-order).
-pub struct SymDifferenceItems<'a, T:'a> {
+pub struct SymmetricDifference<'a, T:'a> {
     a: Peekable<&'a T, Iter<'a, T>>,
     b: Peekable<&'a T, Iter<'a, T>>,
 }
 
 /// A lazy iterator producing elements in the set intersection (in-order).
-pub struct IntersectionItems<'a, T:'a> {
+pub struct Intersection<'a, T:'a> {
     a: Peekable<&'a T, Iter<'a, T>>,
     b: Peekable<&'a T, Iter<'a, T>>,
 }
 
 /// A lazy iterator producing elements in the set union (in-order).
-pub struct UnionItems<'a, T:'a> {
+pub struct Union<'a, T:'a> {
     a: Peekable<&'a T, Iter<'a, T>>,
     b: Peekable<&'a T, Iter<'a, T>>,
 }
@@ -151,8 +151,8 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(diff, vec![1u]);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn difference<'a>(&'a self, other: &'a BTreeSet<T>) -> DifferenceItems<'a, T> {
-        DifferenceItems{a: self.iter().peekable(), b: other.iter().peekable()}
+    pub fn difference<'a>(&'a self, other: &'a BTreeSet<T>) -> Difference<'a, T> {
+        Difference{a: self.iter().peekable(), b: other.iter().peekable()}
     }
 
     /// Visits the values representing the symmetric difference, in ascending order.
@@ -175,8 +175,8 @@ impl<T: Ord> BTreeSet<T> {
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn symmetric_difference<'a>(&'a self, other: &'a BTreeSet<T>)
-        -> SymDifferenceItems<'a, T> {
-        SymDifferenceItems{a: self.iter().peekable(), b: other.iter().peekable()}
+        -> SymmetricDifference<'a, T> {
+        SymmetricDifference{a: self.iter().peekable(), b: other.iter().peekable()}
     }
 
     /// Visits the values representing the intersection, in ascending order.
@@ -199,8 +199,8 @@ impl<T: Ord> BTreeSet<T> {
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn intersection<'a>(&'a self, other: &'a BTreeSet<T>)
-        -> IntersectionItems<'a, T> {
-        IntersectionItems{a: self.iter().peekable(), b: other.iter().peekable()}
+        -> Intersection<'a, T> {
+        Intersection{a: self.iter().peekable(), b: other.iter().peekable()}
     }
 
     /// Visits the values representing the union, in ascending order.
@@ -220,8 +220,8 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(union, vec![1u,2]);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn union<'a>(&'a self, other: &'a BTreeSet<T>) -> UnionItems<'a, T> {
-        UnionItems{a: self.iter().peekable(), b: other.iter().peekable()}
+    pub fn union<'a>(&'a self, other: &'a BTreeSet<T>) -> Union<'a, T> {
+        Union{a: self.iter().peekable(), b: other.iter().peekable()}
     }
 
     /// Return the number of elements in the set
@@ -573,7 +573,7 @@ fn cmp_opt<T: Ord>(x: Option<&T>, y: Option<&T>,
     }
 }
 
-impl<'a, T: Ord> Iterator<&'a T> for DifferenceItems<'a, T> {
+impl<'a, T: Ord> Iterator<&'a T> for Difference<'a, T> {
     fn next(&mut self) -> Option<&'a T> {
         loop {
             match cmp_opt(self.a.peek(), self.b.peek(), Less, Less) {
@@ -585,7 +585,7 @@ impl<'a, T: Ord> Iterator<&'a T> for DifferenceItems<'a, T> {
     }
 }
 
-impl<'a, T: Ord> Iterator<&'a T> for SymDifferenceItems<'a, T> {
+impl<'a, T: Ord> Iterator<&'a T> for SymmetricDifference<'a, T> {
     fn next(&mut self) -> Option<&'a T> {
         loop {
             match cmp_opt(self.a.peek(), self.b.peek(), Greater, Less) {
@@ -597,7 +597,7 @@ impl<'a, T: Ord> Iterator<&'a T> for SymDifferenceItems<'a, T> {
     }
 }
 
-impl<'a, T: Ord> Iterator<&'a T> for IntersectionItems<'a, T> {
+impl<'a, T: Ord> Iterator<&'a T> for Intersection<'a, T> {
     fn next(&mut self) -> Option<&'a T> {
         loop {
             let o_cmp = match (self.a.peek(), self.b.peek()) {
@@ -615,7 +615,7 @@ impl<'a, T: Ord> Iterator<&'a T> for IntersectionItems<'a, T> {
     }
 }
 
-impl<'a, T: Ord> Iterator<&'a T> for UnionItems<'a, T> {
+impl<'a, T: Ord> Iterator<&'a T> for Union<'a, T> {
     fn next(&mut self) -> Option<&'a T> {
         loop {
             match cmp_opt(self.a.peek(), self.b.peek(), Greater, Less) {

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -51,21 +51,21 @@ struct Node<T> {
 }
 
 /// An iterator over references to the items of a `DList`.
-pub struct Items<'a, T:'a> {
+pub struct Iter<'a, T:'a> {
     head: &'a Link<T>,
     tail: Rawlink<Node<T>>,
     nelem: uint,
 }
 
 // FIXME #11820: the &'a Option<> of the Link stops clone working.
-impl<'a, T> Clone for Items<'a, T> {
-    fn clone(&self) -> Items<'a, T> { *self }
+impl<'a, T> Clone for Iter<'a, T> {
+    fn clone(&self) -> Iter<'a, T> { *self }
 }
 
-impl<'a,T> Copy for Items<'a,T> {}
+impl<'a,T> Copy for Iter<'a,T> {}
 
 /// An iterator over mutable references to the items of a `DList`.
-pub struct MutItems<'a, T:'a> {
+pub struct IterMut<'a, T:'a> {
     list: &'a mut DList<T>,
     head: Rawlink<Node<T>>,
     tail: Rawlink<Node<T>>,
@@ -74,7 +74,7 @@ pub struct MutItems<'a, T:'a> {
 
 /// An iterator over mutable references to the items of a `DList`.
 #[deriving(Clone)]
-pub struct MoveItems<T> {
+pub struct IntoIter<T> {
     list: DList<T>
 }
 
@@ -394,19 +394,19 @@ impl<T> DList<T> {
     /// Provides a forward iterator.
     #[inline]
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn iter<'a>(&'a self) -> Items<'a, T> {
-        Items{nelem: self.len(), head: &self.list_head, tail: self.list_tail}
+    pub fn iter<'a>(&'a self) -> Iter<'a, T> {
+        Iter{nelem: self.len(), head: &self.list_head, tail: self.list_tail}
     }
 
     /// Provides a forward iterator with mutable references.
     #[inline]
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn iter_mut<'a>(&'a mut self) -> MutItems<'a, T> {
+    pub fn iter_mut<'a>(&'a mut self) -> IterMut<'a, T> {
         let head_raw = match self.list_head {
             Some(ref mut h) => Rawlink::some(&mut **h),
             None => Rawlink::none(),
         };
-        MutItems{
+        IterMut{
             nelem: self.len(),
             head: head_raw,
             tail: self.list_tail,
@@ -417,8 +417,8 @@ impl<T> DList<T> {
     /// Consumes the list into an iterator yielding elements by value.
     #[inline]
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn into_iter(self) -> MoveItems<T> {
-        MoveItems{list: self}
+    pub fn into_iter(self) -> IntoIter<T> {
+        IntoIter{list: self}
     }
 
     /// Returns `true` if the `DList` is empty.
@@ -579,7 +579,7 @@ impl<T> Drop for DList<T> {
 }
 
 
-impl<'a, A> Iterator<&'a A> for Items<'a, A> {
+impl<'a, A> Iterator<&'a A> for Iter<'a, A> {
     #[inline]
     fn next(&mut self) -> Option<&'a A> {
         if self.nelem == 0 {
@@ -598,7 +598,7 @@ impl<'a, A> Iterator<&'a A> for Items<'a, A> {
     }
 }
 
-impl<'a, A> DoubleEndedIterator<&'a A> for Items<'a, A> {
+impl<'a, A> DoubleEndedIterator<&'a A> for Iter<'a, A> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a A> {
         if self.nelem == 0 {
@@ -612,9 +612,9 @@ impl<'a, A> DoubleEndedIterator<&'a A> for Items<'a, A> {
     }
 }
 
-impl<'a, A> ExactSizeIterator<&'a A> for Items<'a, A> {}
+impl<'a, A> ExactSizeIterator<&'a A> for Iter<'a, A> {}
 
-impl<'a, A> Iterator<&'a mut A> for MutItems<'a, A> {
+impl<'a, A> Iterator<&'a mut A> for IterMut<'a, A> {
     #[inline]
     fn next(&mut self) -> Option<&'a mut A> {
         if self.nelem == 0 {
@@ -636,7 +636,7 @@ impl<'a, A> Iterator<&'a mut A> for MutItems<'a, A> {
     }
 }
 
-impl<'a, A> DoubleEndedIterator<&'a mut A> for MutItems<'a, A> {
+impl<'a, A> DoubleEndedIterator<&'a mut A> for IterMut<'a, A> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a mut A> {
         if self.nelem == 0 {
@@ -650,7 +650,7 @@ impl<'a, A> DoubleEndedIterator<&'a mut A> for MutItems<'a, A> {
     }
 }
 
-impl<'a, A> ExactSizeIterator<&'a mut A> for MutItems<'a, A> {}
+impl<'a, A> ExactSizeIterator<&'a mut A> for IterMut<'a, A> {}
 
 /// Allows mutating a `DList` while iterating.
 pub trait ListInsertion<A> {
@@ -664,8 +664,8 @@ pub trait ListInsertion<A> {
     fn peek_next<'a>(&'a mut self) -> Option<&'a mut A>;
 }
 
-// private methods for MutItems
-impl<'a, A> MutItems<'a, A> {
+// private methods for IterMut
+impl<'a, A> IterMut<'a, A> {
     fn insert_next_node(&mut self, mut ins_node: Box<Node<A>>) {
         // Insert before `self.head` so that it is between the
         // previously yielded element and self.head.
@@ -687,7 +687,7 @@ impl<'a, A> MutItems<'a, A> {
     }
 }
 
-impl<'a, A> ListInsertion<A> for MutItems<'a, A> {
+impl<'a, A> ListInsertion<A> for IterMut<'a, A> {
     #[inline]
     fn insert_next(&mut self, elt: A) {
         self.insert_next_node(box Node::new(elt))
@@ -702,7 +702,7 @@ impl<'a, A> ListInsertion<A> for MutItems<'a, A> {
     }
 }
 
-impl<A> Iterator<A> for MoveItems<A> {
+impl<A> Iterator<A> for IntoIter<A> {
     #[inline]
     fn next(&mut self) -> Option<A> { self.list.pop_front() }
 
@@ -712,7 +712,7 @@ impl<A> Iterator<A> for MoveItems<A> {
     }
 }
 
-impl<A> DoubleEndedIterator<A> for MoveItems<A> {
+impl<A> DoubleEndedIterator<A> for IntoIter<A> {
     #[inline]
     fn next_back(&mut self) -> Option<A> { self.list.pop_back() }
 }

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -178,8 +178,8 @@ impl<E:CLike> EnumSet<E> {
 
     /// Returns an iterator over an `EnumSet`.
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn iter(&self) -> Items<E> {
-        Items::new(self.bits)
+    pub fn iter(&self) -> Iter<E> {
+        Iter::new(self.bits)
     }
 }
 
@@ -208,18 +208,18 @@ impl<E:CLike> BitXor<EnumSet<E>, EnumSet<E>> for EnumSet<E> {
 }
 
 /// An iterator over an EnumSet
-pub struct Items<E> {
+pub struct Iter<E> {
     index: uint,
     bits: uint,
 }
 
-impl<E:CLike> Items<E> {
-    fn new(bits: uint) -> Items<E> {
-        Items { index: 0, bits: bits }
+impl<E:CLike> Iter<E> {
+    fn new(bits: uint) -> Iter<E> {
+        Iter { index: 0, bits: bits }
     }
 }
 
-impl<E:CLike> Iterator<E> for Items<E> {
+impl<E:CLike> Iterator<E> for Iter<E> {
     fn next(&mut self) -> Option<E> {
         if self.bits == 0 {
             return None;

--- a/src/libcollections/ring_buf.rs
+++ b/src/libcollections/ring_buf.rs
@@ -376,8 +376,8 @@ impl<T> RingBuf<T> {
     /// assert_eq!(buf.iter().collect::<Vec<&int>>().as_slice(), b);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn iter(&self) -> Items<T> {
-        Items {
+    pub fn iter(&self) -> Iter<T> {
+        Iter {
             tail: self.tail,
             head: self.head,
             ring: unsafe { self.buffer_as_slice() }
@@ -402,8 +402,8 @@ impl<T> RingBuf<T> {
     /// assert_eq!(buf.iter_mut().collect::<Vec<&mut int>>()[], b);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn iter_mut<'a>(&'a mut self) -> MutItems<'a, T> {
-        MutItems {
+    pub fn iter_mut<'a>(&'a mut self) -> IterMut<'a, T> {
+        IterMut {
             tail: self.tail,
             head: self.head,
             cap: self.cap,
@@ -414,8 +414,8 @@ impl<T> RingBuf<T> {
 
     /// Consumes the list into an iterator yielding elements by value.
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn into_iter(self) -> MoveItems<T> {
-        MoveItems {
+    pub fn into_iter(self) -> IntoIter<T> {
+        IntoIter {
             inner: self,
         }
     }
@@ -1122,13 +1122,13 @@ fn count(tail: uint, head: uint, size: uint) -> uint {
 }
 
 /// `RingBuf` iterator.
-pub struct Items<'a, T:'a> {
+pub struct Iter<'a, T:'a> {
     ring: &'a [T],
     tail: uint,
     head: uint
 }
 
-impl<'a, T> Iterator<&'a T> for Items<'a, T> {
+impl<'a, T> Iterator<&'a T> for Iter<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<&'a T> {
         if self.tail == self.head {
@@ -1146,7 +1146,7 @@ impl<'a, T> Iterator<&'a T> for Items<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator<&'a T> for Items<'a, T> {
+impl<'a, T> DoubleEndedIterator<&'a T> for Iter<'a, T> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a T> {
         if self.tail == self.head {
@@ -1157,9 +1157,9 @@ impl<'a, T> DoubleEndedIterator<&'a T> for Items<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator<&'a T> for Items<'a, T> {}
+impl<'a, T> ExactSizeIterator<&'a T> for Iter<'a, T> {}
 
-impl<'a, T> RandomAccessIterator<&'a T> for Items<'a, T> {
+impl<'a, T> RandomAccessIterator<&'a T> for Iter<'a, T> {
     #[inline]
     fn indexable(&self) -> uint {
         let (len, _) = self.size_hint();
@@ -1177,11 +1177,11 @@ impl<'a, T> RandomAccessIterator<&'a T> for Items<'a, T> {
     }
 }
 
-// FIXME This was implemented differently from Items because of a problem
+// FIXME This was implemented differently from Iter because of a problem
 //       with returning the mutable reference. I couldn't find a way to
 //       make the lifetime checker happy so, but there should be a way.
 /// `RingBuf` mutable iterator.
-pub struct MutItems<'a, T:'a> {
+pub struct IterMut<'a, T:'a> {
     ptr: *mut T,
     tail: uint,
     head: uint,
@@ -1189,7 +1189,7 @@ pub struct MutItems<'a, T:'a> {
     marker: marker::ContravariantLifetime<'a>,
 }
 
-impl<'a, T> Iterator<&'a mut T> for MutItems<'a, T> {
+impl<'a, T> Iterator<&'a mut T> for IterMut<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<&'a mut T> {
         if self.tail == self.head {
@@ -1210,7 +1210,7 @@ impl<'a, T> Iterator<&'a mut T> for MutItems<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator<&'a mut T> for MutItems<'a, T> {
+impl<'a, T> DoubleEndedIterator<&'a mut T> for IterMut<'a, T> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a mut T> {
         if self.tail == self.head {
@@ -1224,14 +1224,14 @@ impl<'a, T> DoubleEndedIterator<&'a mut T> for MutItems<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator<&'a mut T> for MutItems<'a, T> {}
+impl<'a, T> ExactSizeIterator<&'a mut T> for IterMut<'a, T> {}
 
 // A by-value RingBuf iterator
-pub struct MoveItems<T> {
+pub struct IntoIter<T> {
     inner: RingBuf<T>,
 }
 
-impl<T> Iterator<T> for MoveItems<T> {
+impl<T> Iterator<T> for IntoIter<T> {
     #[inline]
     fn next(&mut self) -> Option<T> {
         self.inner.pop_front()
@@ -1244,14 +1244,14 @@ impl<T> Iterator<T> for MoveItems<T> {
     }
 }
 
-impl<T> DoubleEndedIterator<T> for MoveItems<T> {
+impl<T> DoubleEndedIterator<T> for IntoIter<T> {
     #[inline]
     fn next_back(&mut self) -> Option<T> {
         self.inner.pop_back()
     }
 }
 
-impl<T> ExactSizeIterator<T> for MoveItems<T> {}
+impl<T> ExactSizeIterator<T> for IntoIter<T> {}
 
 /// A draining RingBuf iterator
 pub struct Drain<'a, T: 'a> {

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -37,7 +37,7 @@
 //!
 //! ## Structs
 //!
-//! There are several structs that are useful for slices, such as `Items`, which
+//! There are several structs that are useful for slices, such as `Iter`, which
 //! represents iteration over a slice.
 //!
 //! ## Traits
@@ -104,7 +104,7 @@ use self::Direction::*;
 use vec::Vec;
 
 pub use core::slice::{Chunks, AsSlice, SplitsN, Windows};
-pub use core::slice::{Items, MutItems, PartialEqSliceExt};
+pub use core::slice::{Iter, IterMut, PartialEqSliceExt};
 pub use core::slice::{ImmutableIntSlice, MutableIntSlice};
 pub use core::slice::{MutSplits, MutChunks, Splits};
 pub use core::slice::{bytes, mut_ref_slice, ref_slice};
@@ -771,7 +771,7 @@ pub trait SliceExt<T> for Sized? {
 
     /// Returns an iterator over the slice
     #[unstable = "iterator type may change"]
-    fn iter(&self) -> Items<T>;
+    fn iter(&self) -> Iter<T>;
 
     /// Returns an iterator over subslices separated by elements that match
     /// `pred`.  The matched element is not contained in the subslices.
@@ -970,7 +970,7 @@ pub trait SliceExt<T> for Sized? {
 
     /// Returns an iterator that allows modifying each value
     #[unstable = "waiting on iterator type name conventions"]
-    fn iter_mut(&mut self) -> MutItems<T>;
+    fn iter_mut(&mut self) -> IterMut<T>;
 
     /// Returns a mutable pointer to the first element of a slice, or `None` if it is empty
     #[unstable = "name may change"]
@@ -1137,7 +1137,7 @@ impl<T> SliceExt<T> for [T] {
     }
 
     #[inline]
-    fn iter<'a>(&'a self) -> Items<'a, T> {
+    fn iter<'a>(&'a self) -> Iter<'a, T> {
         core_slice::SliceExt::iter(self)
     }
 
@@ -1246,7 +1246,7 @@ impl<T> SliceExt<T> for [T] {
     }
 
     #[inline]
-    fn iter_mut<'a>(&'a mut self) -> MutItems<'a, T> {
+    fn iter_mut<'a>(&'a mut self) -> IterMut<'a, T> {
         core_slice::SliceExt::iter_mut(self)
     }
 

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -176,8 +176,8 @@ impl<V> VecMap<V> {
     /// }
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn iter<'r>(&'r self) -> Entries<'r, V> {
-        Entries {
+    pub fn iter<'r>(&'r self) -> Iter<'r, V> {
+        Iter {
             front: 0,
             back: self.v.len(),
             iter: self.v.iter()
@@ -207,8 +207,8 @@ impl<V> VecMap<V> {
     /// }
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn iter_mut<'r>(&'r mut self) -> MutEntries<'r, V> {
-        MutEntries {
+    pub fn iter_mut<'r>(&'r mut self) -> IterMut<'r, V> {
+        IterMut {
             front: 0,
             back: self.v.len(),
             iter: self.v.iter_mut()
@@ -605,34 +605,34 @@ macro_rules! double_ended_iterator {
 }
 
 /// An iterator over the key-value pairs of a map.
-pub struct Entries<'a, V:'a> {
+pub struct Iter<'a, V:'a> {
     front: uint,
     back: uint,
     iter: slice::Iter<'a, Option<V>>
 }
 
-iterator! { impl Entries -> (uint, &'a V), as_ref }
-double_ended_iterator! { impl Entries -> (uint, &'a V), as_ref }
+iterator! { impl Iter -> (uint, &'a V), as_ref }
+double_ended_iterator! { impl Iter -> (uint, &'a V), as_ref }
 
 /// An iterator over the key-value pairs of a map, with the
 /// values being mutable.
-pub struct MutEntries<'a, V:'a> {
+pub struct IterMut<'a, V:'a> {
     front: uint,
     back: uint,
     iter: slice::IterMut<'a, Option<V>>
 }
 
-iterator! { impl MutEntries -> (uint, &'a mut V), as_mut }
-double_ended_iterator! { impl MutEntries -> (uint, &'a mut V), as_mut }
+iterator! { impl IterMut -> (uint, &'a mut V), as_mut }
+double_ended_iterator! { impl IterMut -> (uint, &'a mut V), as_mut }
 
 /// An iterator over the keys of a map.
 pub struct Keys<'a, V: 'a> {
-    iter: Map<(uint, &'a V), uint, Entries<'a, V>, fn((uint, &'a V)) -> uint>
+    iter: Map<(uint, &'a V), uint, Iter<'a, V>, fn((uint, &'a V)) -> uint>
 }
 
 /// An iterator over the values of a map.
 pub struct Values<'a, V: 'a> {
-    iter: Map<(uint, &'a V), &'a V, Entries<'a, V>, fn((uint, &'a V)) -> &'a V>
+    iter: Map<(uint, &'a V), &'a V, Iter<'a, V>, fn((uint, &'a V)) -> &'a V>
 }
 
 /// A consuming iterator over the key-value pairs of a map.

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -235,13 +235,13 @@ impl<V> VecMap<V> {
     /// assert_eq!(vec, vec![(1, "a"), (2, "b"), (3, "c")]);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn into_iter(&mut self) -> MoveItems<V> {
+    pub fn into_iter(&mut self) -> IntoIter<V> {
         fn filter<A>((i, v): (uint, Option<A>)) -> Option<(uint, A)> {
             v.map(|v| (i, v))
         }
 
         let values = replace(&mut self.v, vec!());
-        MoveItems { iter: values.into_iter().enumerate().filter_map(filter) }
+        IntoIter { iter: values.into_iter().enumerate().filter_map(filter) }
     }
 
     /// Return the number of elements in the map.
@@ -608,7 +608,7 @@ macro_rules! double_ended_iterator {
 pub struct Entries<'a, V:'a> {
     front: uint,
     back: uint,
-    iter: slice::Items<'a, Option<V>>
+    iter: slice::Iter<'a, Option<V>>
 }
 
 iterator! { impl Entries -> (uint, &'a V), as_ref }
@@ -619,7 +619,7 @@ double_ended_iterator! { impl Entries -> (uint, &'a V), as_ref }
 pub struct MutEntries<'a, V:'a> {
     front: uint,
     back: uint,
-    iter: slice::MutItems<'a, Option<V>>
+    iter: slice::IterMut<'a, Option<V>>
 }
 
 iterator! { impl MutEntries -> (uint, &'a mut V), as_mut }
@@ -636,11 +636,11 @@ pub struct Values<'a, V: 'a> {
 }
 
 /// A consuming iterator over the key-value pairs of a map.
-pub struct MoveItems<V> {
+pub struct IntoIter<V> {
     iter: FilterMap<
     (uint, Option<V>),
     (uint, V),
-    Enumerate<vec::MoveItems<Option<V>>>,
+    Enumerate<vec::IntoIter<Option<V>>>,
     fn((uint, Option<V>)) -> Option<(uint, V)>>
 }
 
@@ -662,11 +662,11 @@ impl<'a, V> DoubleEndedIterator<&'a V> for Values<'a, V> {
 }
 
 
-impl<V> Iterator<(uint, V)> for MoveItems<V> {
+impl<V> Iterator<(uint, V)> for IntoIter<V> {
     fn next(&mut self) -> Option<(uint, V)> { self.iter.next() }
     fn size_hint(&self) -> (uint, Option<uint>) { self.iter.size_hint() }
 }
-impl<V> DoubleEndedIterator<(uint, V)> for MoveItems<V> {
+impl<V> DoubleEndedIterator<(uint, V)> for IntoIter<V> {
     fn next_back(&mut self) -> Option<(uint, V)> { self.iter.next_back() }
 }
 

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -89,7 +89,7 @@ pub struct Formatter<'a> {
     precision: Option<uint>,
 
     buf: &'a mut (FormatWriter+'a),
-    curarg: slice::Items<'a, Argument<'a>>,
+    curarg: slice::Iter<'a, Argument<'a>>,
     args: &'a [Argument<'a>],
 }
 

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -67,7 +67,7 @@ pub trait SliceExt<T> for Sized? {
     fn slice_from<'a>(&'a self, start: uint) -> &'a [T];
     fn slice_to<'a>(&'a self, end: uint) -> &'a [T];
     fn split_at<'a>(&'a self, mid: uint) -> (&'a [T], &'a [T]);
-    fn iter<'a>(&'a self) -> Items<'a, T>;
+    fn iter<'a>(&'a self) -> Iter<'a, T>;
     fn split<'a, P>(&'a self, pred: P) -> Splits<'a, T, P>
                     where P: FnMut(&T) -> bool;
     fn splitn<'a, P>(&'a self, n: uint, pred: P) -> SplitsN<Splits<'a, T, P>>
@@ -92,7 +92,7 @@ pub trait SliceExt<T> for Sized? {
     fn slice_mut<'a>(&'a mut self, start: uint, end: uint) -> &'a mut [T];
     fn slice_from_mut<'a>(&'a mut self, start: uint) -> &'a mut [T];
     fn slice_to_mut<'a>(&'a mut self, end: uint) -> &'a mut [T];
-    fn iter_mut<'a>(&'a mut self) -> MutItems<'a, T>;
+    fn iter_mut<'a>(&'a mut self) -> IterMut<'a, T>;
     fn head_mut<'a>(&'a mut self) -> Option<&'a mut T>;
     fn tail_mut<'a>(&'a mut self) -> &'a mut [T];
     fn init_mut<'a>(&'a mut self) -> &'a mut [T];
@@ -141,15 +141,15 @@ impl<T> SliceExt<T> for [T] {
     }
 
     #[inline]
-    fn iter<'a>(&'a self) -> Items<'a, T> {
+    fn iter<'a>(&'a self) -> Iter<'a, T> {
         unsafe {
             let p = self.as_ptr();
             if mem::size_of::<T>() == 0 {
-                Items{ptr: p,
+                Iter{ptr: p,
                       end: (p as uint + self.len()) as *const T,
                       marker: marker::ContravariantLifetime::<'a>}
             } else {
-                Items{ptr: p,
+                Iter{ptr: p,
                       end: p.offset(self.len() as int),
                       marker: marker::ContravariantLifetime::<'a>}
             }
@@ -286,15 +286,15 @@ impl<T> SliceExt<T> for [T] {
     }
 
     #[inline]
-    fn iter_mut<'a>(&'a mut self) -> MutItems<'a, T> {
+    fn iter_mut<'a>(&'a mut self) -> IterMut<'a, T> {
         unsafe {
             let p = self.as_mut_ptr();
             if mem::size_of::<T>() == 0 {
-                MutItems{ptr: p,
+                IterMut{ptr: p,
                          end: (p as uint + self.len()) as *mut T,
                          marker: marker::ContravariantLifetime::<'a>}
             } else {
-                MutItems{ptr: p,
+                IterMut{ptr: p,
                          end: p.offset(self.len() as int),
                          marker: marker::ContravariantLifetime::<'a>}
             }
@@ -655,7 +655,7 @@ impl<'a, T> Default for &'a [T] {
 // Iterators
 //
 
-// The shared definition of the `Item` and `MutItems` iterators
+// The shared definition of the `Item` and `IterMut` iterators
 macro_rules! iterator {
     (struct $name:ident -> $ptr:ty, $elem:ty) => {
         #[experimental = "needs review"]
@@ -738,14 +738,14 @@ macro_rules! make_slice {
 
 /// Immutable slice iterator
 #[experimental = "needs review"]
-pub struct Items<'a, T: 'a> {
+pub struct Iter<'a, T: 'a> {
     ptr: *const T,
     end: *const T,
     marker: marker::ContravariantLifetime<'a>
 }
 
 #[experimental]
-impl<'a, T> ops::Slice<uint, [T]> for Items<'a, T> {
+impl<'a, T> ops::Slice<uint, [T]> for Iter<'a, T> {
     fn as_slice_(&self) -> &[T] {
         self.as_slice()
     }
@@ -763,7 +763,7 @@ impl<'a, T> ops::Slice<uint, [T]> for Items<'a, T> {
     }
 }
 
-impl<'a, T> Items<'a, T> {
+impl<'a, T> Iter<'a, T> {
     /// View the underlying data as a subslice of the original data.
     ///
     /// This has the same lifetime as the original slice, and so the
@@ -774,20 +774,20 @@ impl<'a, T> Items<'a, T> {
     }
 }
 
-impl<'a,T> Copy for Items<'a,T> {}
+impl<'a,T> Copy for Iter<'a,T> {}
 
-iterator!{struct Items -> *const T, &'a T}
+iterator!{struct Iter -> *const T, &'a T}
 
 #[experimental = "needs review"]
-impl<'a, T> ExactSizeIterator<&'a T> for Items<'a, T> {}
+impl<'a, T> ExactSizeIterator<&'a T> for Iter<'a, T> {}
 
-#[stable]
-impl<'a, T> Clone for Items<'a, T> {
-    fn clone(&self) -> Items<'a, T> { *self }
+    #[experimental = "needs review"]
+impl<'a, T> Clone for Iter<'a, T> {
+    fn clone(&self) -> Iter<'a, T> { *self }
 }
 
 #[experimental = "needs review"]
-impl<'a, T> RandomAccessIterator<&'a T> for Items<'a, T> {
+impl<'a, T> RandomAccessIterator<&'a T> for Iter<'a, T> {
     #[inline]
     fn indexable(&self) -> uint {
         let (exact, _) = self.size_hint();
@@ -813,14 +813,14 @@ impl<'a, T> RandomAccessIterator<&'a T> for Items<'a, T> {
 
 /// Mutable slice iterator.
 #[experimental = "needs review"]
-pub struct MutItems<'a, T: 'a> {
+pub struct IterMut<'a, T: 'a> {
     ptr: *mut T,
     end: *mut T,
     marker: marker::ContravariantLifetime<'a>,
 }
 
 #[experimental]
-impl<'a, T> ops::Slice<uint, [T]> for MutItems<'a, T> {
+impl<'a, T> ops::Slice<uint, [T]> for IterMut<'a, T> {
     fn as_slice_<'b>(&'b self) -> &'b [T] {
         make_slice!(T -> &'b [T]: self.ptr, self.end)
     }
@@ -839,7 +839,7 @@ impl<'a, T> ops::Slice<uint, [T]> for MutItems<'a, T> {
 }
 
 #[experimental]
-impl<'a, T> ops::SliceMut<uint, [T]> for MutItems<'a, T> {
+impl<'a, T> ops::SliceMut<uint, [T]> for IterMut<'a, T> {
     fn as_mut_slice_<'b>(&'b mut self) -> &'b mut [T] {
         make_slice!(T -> &'b mut [T]: self.ptr, self.end)
     }
@@ -857,7 +857,7 @@ impl<'a, T> ops::SliceMut<uint, [T]> for MutItems<'a, T> {
     }
 }
 
-impl<'a, T> MutItems<'a, T> {
+impl<'a, T> IterMut<'a, T> {
     /// View the underlying data as a subslice of the original data.
     ///
     /// To avoid creating `&mut` references that alias, this is forced
@@ -870,10 +870,10 @@ impl<'a, T> MutItems<'a, T> {
     }
 }
 
-iterator!{struct MutItems -> *mut T, &'a mut T}
+iterator!{struct IterMut -> *mut T, &'a mut T}
 
 #[experimental = "needs review"]
-impl<'a, T> ExactSizeIterator<&'a mut T> for MutItems<'a, T> {}
+impl<'a, T> ExactSizeIterator<&'a mut T> for IterMut<'a, T> {}
 
 /// An abstraction over the splitting iterators, so that splitn, splitn_mut etc
 /// can be implemented once.

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -781,7 +781,7 @@ iterator!{struct Iter -> *const T, &'a T}
 #[experimental = "needs review"]
 impl<'a, T> ExactSizeIterator<&'a T> for Iter<'a, T> {}
 
-    #[experimental = "needs review"]
+#[stable]
 impl<'a, T> Clone for Iter<'a, T> {
     fn clone(&self) -> Iter<'a, T> { *self }
 }

--- a/src/libcore/str.rs
+++ b/src/libcore/str.rs
@@ -167,7 +167,7 @@ Section: Iterators
 /// Created with the method `.chars()`.
 #[deriving(Clone, Copy)]
 pub struct Chars<'a> {
-    iter: slice::Items<'a, u8>
+    iter: slice::Iter<'a, u8>
 }
 
 // Return the initial codepoint accumulator for the first byte.
@@ -315,7 +315,7 @@ impl<'a> DoubleEndedIterator<(uint, char)> for CharOffsets<'a> {
 
 /// External iterator for a string's bytes.
 /// Use with the `std::iter` module.
-pub type Bytes<'a> = Map<&'a u8, u8, slice::Items<'a, u8>, BytesFn>;
+pub type Bytes<'a> = Map<&'a u8, u8, slice::Iter<'a, u8>, BytesFn>;
 
 /// A temporary new type wrapper that ensures that the `Bytes` iterator
 /// is cloneable.
@@ -893,7 +893,7 @@ Section: Misc
 /// `iter` reset such that it is pointing at the first byte in the
 /// invalid sequence.
 #[inline(always)]
-fn run_utf8_validation_iterator(iter: &mut slice::Items<u8>) -> bool {
+fn run_utf8_validation_iterator(iter: &mut slice::Iter<u8>) -> bool {
     loop {
         // save the current thing we're pointing at.
         let old = *iter;
@@ -993,7 +993,7 @@ pub fn is_utf16(v: &[u16]) -> bool {
 /// of `u16`s.
 #[deriving(Clone)]
 pub struct Utf16Items<'a> {
-    iter: slice::Items<'a, u16>
+    iter: slice::Iter<'a, u16>
 }
 /// The possibilities for values decoded from a `u16` stream.
 #[deriving(Copy, PartialEq, Eq, Clone, Show)]
@@ -2366,4 +2366,3 @@ impl<'a> Default for &'a str {
     #[stable]
     fn default() -> &'a str { "" }
 }
-

--- a/src/libgraphviz/maybe_owned_vec.rs
+++ b/src/libgraphviz/maybe_owned_vec.rs
@@ -63,7 +63,7 @@ impl<'a,T> IntoMaybeOwnedVector<'a,T> for &'a [T] {
 }
 
 impl<'a,T> MaybeOwnedVector<'a,T> {
-    pub fn iter(&'a self) -> slice::Items<'a,T> {
+    pub fn iter(&'a self) -> slice::Iter<'a,T> {
         match self {
             &Growable(ref v) => v.as_slice().iter(),
             &Borrowed(ref v) => v.iter(),

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -370,7 +370,7 @@ pub fn mod_enabled(level: u32, module: &str) -> bool {
 
 fn enabled(level: u32,
            module: &str,
-           iter: slice::Items<directive::LogDirective>)
+           iter: slice::Iter<directive::LogDirective>)
            -> bool {
     // Search for the longest match, the vector is assumed to be pre-sorted.
     for directive in iter.rev() {

--- a/src/libregex/re.rs
+++ b/src/libregex/re.rs
@@ -540,8 +540,8 @@ impl Regex {
 }
 
 pub enum NamesIter<'a> {
-    NamesIterNative(::std::slice::Items<'a, Option<&'static str>>),
-    NamesIterDynamic(::std::slice::Items<'a, Option<String>>)
+    NamesIterNative(::std::slice::Iter<'a, Option<&'static str>>),
+    NamesIterDynamic(::std::slice::Iter<'a, Option<String>>)
 }
 
 impl<'a> Iterator<Option<String>> for NamesIter<'a> {

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -65,7 +65,7 @@ impl LanguageItems {
         }
     }
 
-    pub fn items<'a>(&'a self) -> Enumerate<slice::Items<'a, Option<ast::DefId>>> {
+    pub fn items<'a>(&'a self) -> Enumerate<slice::Iter<'a, Option<ast::DefId>>> {
         self.items.iter().enumerate()
     }
 

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -18,7 +18,7 @@ use middle::ty_fold::{mod, TypeFoldable, TypeFolder};
 use util::ppaux::Repr;
 
 use std::fmt;
-use std::slice::Items;
+use std::slice::Iter;
 use std::vec::Vec;
 use syntax::codemap::{Span, DUMMY_SP};
 
@@ -400,7 +400,7 @@ impl<T> VecPerParamSpace<T> {
         &self.get_slice(space)[index]
     }
 
-    pub fn iter<'a>(&'a self) -> Items<'a,T> {
+    pub fn iter<'a>(&'a self) -> Iter<'a,T> {
         self.content.iter()
     }
 

--- a/src/librustc/middle/traits/mod.rs
+++ b/src/librustc/middle/traits/mod.rs
@@ -19,7 +19,7 @@ use middle::subst;
 use middle::ty::{mod, Ty};
 use middle::infer::InferCtxt;
 use std::rc::Rc;
-use std::slice::Items;
+use std::slice::Iter;
 use syntax::ast;
 use syntax::codemap::{Span, DUMMY_SP};
 
@@ -304,7 +304,7 @@ impl<'tcx> ObligationCause<'tcx> {
 }
 
 impl<'tcx, N> Vtable<'tcx, N> {
-    pub fn iter_nested(&self) -> Items<N> {
+    pub fn iter_nested(&self) -> Iter<N> {
         match *self {
             VtableImpl(ref i) => i.iter_nested(),
             VtableFnPointer(..) => (&[]).iter(),
@@ -338,7 +338,7 @@ impl<'tcx, N> Vtable<'tcx, N> {
 }
 
 impl<'tcx, N> VtableImplData<'tcx, N> {
-    pub fn iter_nested(&self) -> Items<N> {
+    pub fn iter_nested(&self) -> Iter<N> {
         self.nested.iter()
     }
 
@@ -365,7 +365,7 @@ impl<'tcx, N> VtableImplData<'tcx, N> {
 }
 
 impl<N> VtableBuiltinData<N> {
-    pub fn iter_nested(&self) -> Items<N> {
+    pub fn iter_nested(&self) -> Iter<N> {
         self.nested.iter()
     }
 

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -914,8 +914,8 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     /// }
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn iter_mut(&mut self) -> MutEntries<K, V> {
-        MutEntries { inner: self.table.iter_mut() }
+    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+        IterMut { inner: self.table.iter_mut() }
     }
 
     /// Creates a consuming iterator, that is, one that moves each key-value
@@ -936,10 +936,10 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     /// let vec: Vec<(&str, int)> = map.into_iter().collect();
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn into_iter(self) -> MoveEntries<K, V> {
+    pub fn into_iter(self) -> IntoIter<K, V> {
         fn last_two<A, B, C>((_, b, c): (A, B, C)) -> (B, C) { (b, c) }
 
-        MoveEntries {
+        IntoIter {
             inner: self.table.into_iter().map(last_two)
         }
     }
@@ -1306,16 +1306,16 @@ pub struct Entries<'a, K: 'a, V: 'a> {
 }
 
 /// HashMap mutable values iterator
-pub struct MutEntries<'a, K: 'a, V: 'a> {
-    inner: table::MutEntries<'a, K, V>
+pub struct IterMut<'a, K: 'a, V: 'a> {
+    inner: table::IterMut<'a, K, V>
 }
 
 /// HashMap move iterator
-pub struct MoveEntries<K, V> {
+pub struct IntoIter<K, V> {
     inner: iter::Map<
         (SafeHash, K, V),
         (K, V),
-        table::MoveEntries<K, V>,
+        table::IntoIter<K, V>,
         fn((SafeHash, K, V)) -> (K, V),
     >
 }
@@ -1374,12 +1374,12 @@ impl<'a, K, V> Iterator<(&'a K, &'a V)> for Entries<'a, K, V> {
     #[inline] fn size_hint(&self) -> (uint, Option<uint>) { self.inner.size_hint() }
 }
 
-impl<'a, K, V> Iterator<(&'a K, &'a mut V)> for MutEntries<'a, K, V> {
+impl<'a, K, V> Iterator<(&'a K, &'a mut V)> for IterMut<'a, K, V> {
     #[inline] fn next(&mut self) -> Option<(&'a K, &'a mut V)> { self.inner.next() }
     #[inline] fn size_hint(&self) -> (uint, Option<uint>) { self.inner.size_hint() }
 }
 
-impl<K, V> Iterator<(K, V)> for MoveEntries<K, V> {
+impl<K, V> Iterator<(K, V)> for IntoIter<K, V> {
     #[inline] fn next(&mut self) -> Option<(K, V)> { self.inner.next() }
     #[inline] fn size_hint(&self) -> (uint, Option<uint>) { self.inner.size_hint() }
 }

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -21,7 +21,7 @@ use iter::{Iterator, IteratorExt, FromIterator, Map, Chain, Extend};
 use option::Option::{Some, None, mod};
 use result::Result::{Ok, Err};
 
-use super::map::{mod, HashMap, MoveEntries, Keys, INITIAL_CAPACITY};
+use super::map::{mod, HashMap, Keys, INITIAL_CAPACITY};
 
 // FIXME(conventions): implement BitOr, BitAnd, BitXor, and Sub
 
@@ -625,7 +625,7 @@ pub struct Iter<'a, K: 'a> {
 
 /// HashSet move iterator
 pub struct IntoIter<K> {
-    iter: Map<(K, ()), K, MoveEntries<K, ()>, fn((K, ())) -> K>
+    iter: Map<(K, ()), K, map::IntoIter<K, ()>, fn((K, ())) -> K>
 }
 
 /// HashSet drain iterator

--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -73,9 +73,9 @@ impl<'a> Iterator<PathElem> for LinkedPath<'a> {
     }
 }
 
-// HACK(eddyb) move this into libstd (value wrapper for slice::Items).
+// HACK(eddyb) move this into libstd (value wrapper for slice::Iter).
 #[deriving(Clone)]
-pub struct Values<'a, T:'a>(pub slice::Items<'a, T>);
+pub struct Values<'a, T:'a>(pub slice::Iter<'a, T>);
 
 impl<'a, T: Copy> Iterator<T> for Values<'a, T> {
     fn next(&mut self) -> Option<T> {

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -766,7 +766,7 @@ impl<'a> MethodDef<'a> {
         let fields = if raw_fields.len() > 0 {
             let mut raw_fields = raw_fields.into_iter().map(|v| v.into_iter());
             let first_field = raw_fields.next().unwrap();
-            let mut other_fields: Vec<vec::MoveItems<(Span, Option<Ident>, P<Expr>)>>
+            let mut other_fields: Vec<vec::IntoIter<(Span, Option<Ident>, P<Expr>)>>
                 = raw_fields.collect();
             first_field.map(|(span, opt_id, field)| {
                 FieldInfo {

--- a/src/libsyntax/owned_slice.rs
+++ b/src/libsyntax/owned_slice.rs
@@ -45,7 +45,7 @@ impl<T> OwnedSlice<T> {
         &*self.data
     }
 
-    pub fn move_iter(self) -> vec::MoveItems<T> {
+    pub fn move_iter(self) -> vec::IntoIter<T> {
         self.into_vec().into_iter()
     }
 

--- a/src/libsyntax/util/small_vector.rs
+++ b/src/libsyntax/util/small_vector.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 use self::SmallVectorRepr::*;
-use self::MoveItemsRepr::*;
+use self::IntoIterRepr::*;
 
 use std::mem;
 use std::slice;
@@ -111,17 +111,17 @@ impl<T> SmallVector<T> {
 
     /// Deprecated: use `into_iter`.
     #[deprecated = "use into_iter"]
-    pub fn move_iter(self) -> MoveItems<T> {
+    pub fn move_iter(self) -> IntoIter<T> {
         self.into_iter()
     }
 
-    pub fn into_iter(self) -> MoveItems<T> {
+    pub fn into_iter(self) -> IntoIter<T> {
         let repr = match self.repr {
             Zero => ZeroIterator,
             One(v) => OneIterator(v),
             Many(vs) => ManyIterator(vs.into_iter())
         };
-        MoveItems { repr: repr }
+        IntoIter { repr: repr }
     }
 
     pub fn len(&self) -> uint {
@@ -135,17 +135,17 @@ impl<T> SmallVector<T> {
     pub fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
-pub struct MoveItems<T> {
-    repr: MoveItemsRepr<T>,
+pub struct IntoIter<T> {
+    repr: IntoIterRepr<T>,
 }
 
-enum MoveItemsRepr<T> {
+enum IntoIterRepr<T> {
     ZeroIterator,
     OneIterator(T),
-    ManyIterator(vec::MoveItems<T>),
+    ManyIterator(vec::IntoIter<T>),
 }
 
-impl<T> Iterator<T> for MoveItems<T> {
+impl<T> Iterator<T> for IntoIter<T> {
     fn next(&mut self) -> Option<T> {
         match self.repr {
             ZeroIterator => None,

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -130,7 +130,7 @@ struct Table {
 
 struct Items<'a> {
     cur: Option<&'a Entry>,
-    items: slice::Items<'a, Option<Box<Entry>>>,
+    items: slice::Iter<'a, Option<Box<Entry>>>,
 }
 
 impl Table {

--- a/src/test/compile-fail/resolve-conflict-type-vs-import.rs
+++ b/src/test/compile-fail/resolve-conflict-type-vs-import.rs
@@ -8,10 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::slice::Items;
-//~^ ERROR import `Items` conflicts with type in this module
+use std::slice::Iter;
+//~^ ERROR import `Iter` conflicts with type in this module
 
-struct Items;
+struct Iter;
 
 fn main() {
 }

--- a/src/test/run-pass/issue-13167.rs
+++ b/src/test/run-pass/issue-13167.rs
@@ -11,7 +11,7 @@
 use std::slice;
 
 pub struct PhfMapEntries<'a, T: 'a> {
-    iter: slice::Items<'a, (&'static str, T)>,
+    iter: slice::Iter<'a, (&'static str, T)>,
 }
 
 impl<'a, T> Iterator<(&'static str, &'a T)> for PhfMapEntries<'a, T> {


### PR DESCRIPTION
libcore: slice::Items -> slice::Iter, slice::MutItems -> slice::IterMut
libcollections: *::Items -> *::Iter, *::MoveItems -> *::IntoIter, *::MutItems -> *::IterMut

This is of course a [breaking-change].

Some Unstable attributes of functions affected might not longer need the attribute since the return type is now correctly named.

libstd::collections::hash is left out since the rename there is handled in a different PR as far as I know.

@Gankro @aturon
