### PR TITLE
Stabilize integer modules

### DIFF
--- a/src/libcore/num/int.rs
+++ b/src/libcore/num/int.rs
@@ -10,9 +10,8 @@
 
 //! Operations and constants for architecture-sized signed integers (`int` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "int")]
 
 #[cfg(target_word_size = "32")] int_module! { int, 32 }
 #[cfg(target_word_size = "64")] int_module! { int, 64 }
-

--- a/src/libcore/num/int_macros.rs
+++ b/src/libcore/num/int_macros.rs
@@ -24,13 +24,12 @@ pub const BYTES : uint = ($bits / 8);
 
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `Bounded::min_value` function.
-#[unstable]
+#[stable]
 pub const MIN: $T = (-1 as $T) << (BITS - 1);
 // FIXME(#9837): Compute MIN like this so the high bits that shouldn't exist are 0.
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `Bounded::max_value` function.
-#[unstable]
+#[stable]
 pub const MAX: $T = !MIN;
 
 ) }
-

--- a/src/libcore/num/uint.rs
+++ b/src/libcore/num/uint.rs
@@ -10,8 +10,7 @@
 
 //! Operations and constants for architecture-sized unsigned integers (`uint` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "uint")]
 
 uint_module! { uint, int, ::int::BITS }
-

--- a/src/libcore/num/uint_macros.rs
+++ b/src/libcore/num/uint_macros.rs
@@ -18,10 +18,9 @@ pub const BITS : uint = $bits;
 #[unstable]
 pub const BYTES : uint = ($bits / 8);
 
-#[unstable]
+#[stable]
 pub const MIN: $T = 0 as $T;
-#[unstable]
+#[stable]
 pub const MAX: $T = 0 as $T - 1 as $T;
 
 ) }
-

--- a/src/libstd/num/int.rs
+++ b/src/libstd/num/int.rs
@@ -10,7 +10,7 @@
 
 //! Operations and constants for architecture-sized signed integers (`int` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "int")]
 
 pub use core::int::{BITS, BYTES, MIN, MAX};

--- a/src/libstd/num/uint.rs
+++ b/src/libstd/num/uint.rs
@@ -10,7 +10,7 @@
 
 //! Operations and constants for architecture-sized unsigned integers (`uint` type)
 
-#![unstable]
+#![stable]
 #![doc(primitive = "uint")]
 
 pub use core::uint::{BITS, BYTES, MIN, MAX};


### PR DESCRIPTION
This small patch stabilizes the names of all integer modules (including
`int` and `uint`) and the `MIN` and `MAX` constants. The `BITS` and
`BYTES` constants are left unstable for now.

r? @alexcrichton 
