### PR TITLE
Stabilize clone

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -132,7 +132,7 @@ pub fn weak_count<T>(this: &Arc<T>) -> uint { this.inner().weak.load(atomic::Seq
 #[experimental]
 pub fn strong_count<T>(this: &Arc<T>) -> uint { this.inner().strong.load(atomic::SeqCst) }
 
-#[unstable = "waiting on stability of Clone"]
+#[stable]
 impl<T> Clone for Arc<T> {
     /// Duplicate an atomically reference counted wrapper.
     ///

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -57,7 +57,7 @@ impl<T> Default for Box<[T]> {
     fn default() -> Box<[T]> { box [] }
 }
 
-#[unstable]
+#[stable]
 impl<T: Clone> Clone for Box<T> {
     /// Returns a copy of the owned box.
     #[inline]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -413,7 +413,7 @@ impl<T> Drop for Rc<T> {
     }
 }
 
-#[unstable = "Clone is unstable."]
+#[stable]
 impl<T> Clone for Rc<T> {
     /// Makes a clone of the `Rc<T>`.
     ///

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -851,6 +851,7 @@ impl Extend<bool> for Bitv {
     }
 }
 
+#[stable]
 impl Clone for Bitv {
     #[inline]
     fn clone(&self) -> Bitv {

--- a/src/libcollections/btree/node.rs
+++ b/src/libcollections/btree/node.rs
@@ -390,6 +390,7 @@ impl<K, V> Node<K, V> {
 }
 
 // FIXME(gereeter) Write an efficient clone_from
+#[stable]
 impl<K: Clone, V: Clone> Clone for Node<K, V> {
     fn clone(&self) -> Node<K, V> {
         let mut ret = if self.is_leaf() {

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -758,6 +758,7 @@ impl<A: Ord> Ord for DList<A> {
     }
 }
 
+#[stable]
 impl<A: Clone> Clone for DList<A> {
     fn clone(&self) -> DList<A> {
         self.iter().map(|x| x.clone()).collect()

--- a/src/libcollections/ring_buf.rs
+++ b/src/libcollections/ring_buf.rs
@@ -48,6 +48,7 @@ pub struct RingBuf<T> {
     ptr: *mut T
 }
 
+#[stable]
 impl<T: Clone> Clone for RingBuf<T> {
     fn clone(&self) -> RingBuf<T> {
         self.iter().map(|t| t.clone()).collect()

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -443,7 +443,7 @@ impl<T: Clone> Vec<T> {
     }
 }
 
-#[unstable]
+#[stable]
 impl<T:Clone> Clone for Vec<T> {
     fn clone(&self) -> Vec<T> { self.as_slice().to_vec() }
 

--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -25,7 +25,7 @@ use option::Option;
 macro_rules! array_impls {
     ($($N:expr)+) => {
         $(
-            #[unstable = "waiting for Clone to stabilize"]
+            #[stable]
             impl<T:Copy> Clone for [T, ..$N] {
                 fn clone(&self) -> [T, ..$N] {
                     *self
@@ -115,4 +115,3 @@ array_impls! {
     20 21 22 23 24 25 26 27 28 29
     30 31 32
 }
-

--- a/src/libcore/borrow.rs
+++ b/src/libcore/borrow.rs
@@ -137,6 +137,7 @@ pub enum Cow<'a, T, Sized? B: 'a> where B: ToOwned<T> {
     Owned(T)
 }
 
+#[stable]
 impl<'a, T, Sized? B> Clone for Cow<'a, T, B> where B: ToOwned<T> {
     fn clone(&self) -> Cow<'a, T, B> {
         match *self {

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -208,7 +208,7 @@ impl<T:Copy> Cell<T> {
     }
 }
 
-#[unstable = "waiting for `Clone` trait to become stable"]
+#[stable]
 impl<T:Copy> Clone for Cell<T> {
     fn clone(&self) -> Cell<T> {
         Cell::new(self.get())
@@ -341,7 +341,7 @@ impl<T> RefCell<T> {
     }
 }
 
-#[unstable = "waiting for `Clone` to become stable"]
+#[stable]
 impl<T: Clone> Clone for RefCell<T> {
     fn clone(&self) -> RefCell<T> {
         RefCell::new(self.borrow().clone())

--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -19,13 +19,15 @@
 //! explicitly, by convention implementing the `Clone` trait and calling
 //! the `clone` method.
 
-#![unstable]
+#![stable]
 
 use kinds::Sized;
 
 /// A common trait for cloning an object.
+#[stable]
 pub trait Clone {
     /// Returns a copy of the value.
+    #[stable]
     fn clone(&self) -> Self;
 
     /// Perform copy-assignment from `source`.
@@ -34,12 +36,13 @@ pub trait Clone {
     /// but can be overridden to reuse the resources of `a` to avoid unnecessary
     /// allocations.
     #[inline(always)]
-    #[experimental = "this function is mostly unused"]
+    #[unstable = "this function rarely unused"]
     fn clone_from(&mut self, source: &Self) {
         *self = source.clone()
     }
 }
 
+#[stable]
 impl<'a, Sized? T> Clone for &'a T {
     /// Return a shallow copy of the reference.
     #[inline]
@@ -48,6 +51,7 @@ impl<'a, Sized? T> Clone for &'a T {
 
 macro_rules! clone_impl {
     ($t:ty) => {
+        #[stable]
         impl Clone for $t {
             /// Return a deep copy of the value.
             #[inline]
@@ -95,4 +99,3 @@ extern_fn_clone! { A, B, C, D, E }
 extern_fn_clone! { A, B, C, D, E, F }
 extern_fn_clone! { A, B, C, D, E, F, G }
 extern_fn_clone! { A, B, C, D, E, F, G, H }
-

--- a/src/libcore/hash/sip.rs
+++ b/src/libcore/hash/sip.rs
@@ -195,6 +195,7 @@ impl Writer for SipState {
     }
 }
 
+#[stable]
 impl Clone for SipState {
     #[inline]
     fn clone(&self) -> SipState {

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1386,6 +1386,7 @@ pub struct Map<A, B, I: Iterator<A>, F: FnMut(A) -> B> {
 }
 
 // FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+#[stable]
 impl<A, B, I, F> Clone for Map<A, B, I, F> where
     I: Clone + Iterator<A>,
     F: Clone + FnMut(A) -> B,
@@ -1460,6 +1461,7 @@ pub struct Filter<A, I, P> where I: Iterator<A>, P: FnMut(&A) -> bool {
 }
 
 // FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+#[stable]
 impl<A, I, P> Clone for Filter<A, I, P> where
     I: Clone + Iterator<A>,
     P: Clone + FnMut(&A) -> bool,
@@ -1518,6 +1520,7 @@ pub struct FilterMap<A, B, I, F> where I: Iterator<A>, F: FnMut(A) -> Option<B> 
 }
 
 // FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+#[stable]
 impl<A, B, I, F> Clone for FilterMap<A, B, I, F> where
     I: Clone + Iterator<A>,
     F: Clone + FnMut(A) -> Option<B>,
@@ -1693,6 +1696,7 @@ pub struct SkipWhile<A, I, P> where I: Iterator<A>, P: FnMut(&A) -> bool {
 }
 
 // FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+#[stable]
 impl<A, I, P> Clone for SkipWhile<A, I, P> where
     I: Clone + Iterator<A>,
     P: Clone + FnMut(&A) -> bool,
@@ -1736,6 +1740,7 @@ pub struct TakeWhile<A, I, P> where I: Iterator<A>, P: FnMut(&A) -> bool {
 }
 
 // FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+#[stable]
 impl<A, I, P> Clone for TakeWhile<A, I, P> where
     I: Clone + Iterator<A>,
     P: Clone + FnMut(&A) -> bool,
@@ -1911,6 +1916,7 @@ pub struct Scan<A, B, I, St, F> where I: Iterator<A>, F: FnMut(&mut St, A) -> Op
 }
 
 // FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+#[stable]
 impl<A, B, I, St, F> Clone for Scan<A, B, I, St, F> where
     I: Clone + Iterator<A>,
     St: Clone,
@@ -1955,6 +1961,7 @@ pub struct FlatMap<A, B, I, U, F> where I: Iterator<A>, U: Iterator<B>, F: FnMut
 }
 
 // FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+#[stable]
 impl<A, B, I, U, F> Clone for FlatMap<A, B, I, U, F> where
     I: Clone + Iterator<A>,
     U: Clone + Iterator<B>,
@@ -2115,6 +2122,7 @@ pub struct Inspect<A, I, F> where I: Iterator<A>, F: FnMut(&A) {
 }
 
 // FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+#[stable]
 impl<A, I, F> Clone for Inspect<A, I, F> where
     I: Clone + Iterator<A>,
     F: Clone + FnMut(&A),
@@ -2222,6 +2230,7 @@ pub struct Unfold<A, St, F> where F: FnMut(&mut St) -> Option<A> {
 }
 
 // FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+#[stable]
 impl<A, St, F> Clone for Unfold<A, St, F> where
     F: Clone + FnMut(&mut St) -> Option<A>,
     St: Clone,

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -819,6 +819,7 @@ impl<'a, A> DoubleEndedIterator<&'a A> for Iter<'a, A> {
 
 impl<'a, A> ExactSizeIterator<&'a A> for Iter<'a, A> {}
 
+#[stable]
 impl<'a, A> Clone for Iter<'a, A> {
     fn clone(&self) -> Iter<'a, A> {
         Iter { inner: self.inner.clone() }

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -340,6 +340,7 @@ impl<T> Equiv<*const T> for *mut T {
     }
 }
 
+#[stable]
 impl<T> Clone for *const T {
     #[inline]
     fn clone(&self) -> *const T {
@@ -347,6 +348,7 @@ impl<T> Clone for *const T {
     }
 }
 
+#[stable]
 impl<T> Clone for *mut T {
     #[inline]
     fn clone(&self) -> *mut T {
@@ -451,4 +453,3 @@ impl<T> PartialOrd for *mut T {
     #[inline]
     fn ge(&self, other: &*mut T) -> bool { *self >= *other }
 }
-

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -781,7 +781,7 @@ iterator!{struct Items -> *const T, &'a T}
 #[experimental = "needs review"]
 impl<'a, T> ExactSizeIterator<&'a T> for Items<'a, T> {}
 
-#[experimental = "needs review"]
+#[stable]
 impl<'a, T> Clone for Items<'a, T> {
     fn clone(&self) -> Items<'a, T> { *self }
 }
@@ -893,6 +893,7 @@ pub struct Splits<'a, T:'a, P> where P: FnMut(&T) -> bool {
 }
 
 // FIXME(#19839) Remove in favor of `#[deriving(Clone)]`
+#[stable]
 impl<'a, T, P> Clone for Splits<'a, T, P> where P: Clone + FnMut(&T) -> bool {
     fn clone(&self) -> Splits<'a, T, P> {
         Splits {
@@ -1550,4 +1551,3 @@ impl_int_slice! { u16,  i16 }
 impl_int_slice! { u32,  i32 }
 impl_int_slice! { u64,  i64 }
 impl_int_slice! { uint, int }
-

--- a/src/libcore/tuple/mod.rs
+++ b/src/libcore/tuple/mod.rs
@@ -126,7 +126,7 @@ macro_rules! tuple_impls {
                 )+
             }
 
-            #[unstable = "waiting for Clone to stabilize"]
+            #[stable]
             impl<$($T:Clone),+> Clone for ($($T,)+) {
                 fn clone(&self) -> ($($T,)+) {
                     ($(e!(self.$idx.clone()),)+)
@@ -328,4 +328,3 @@ tuple_impls! {
         (val11, ref11, mut11, 11) -> L
     }
 }
-

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -628,7 +628,7 @@ impl<T: Send> Sender<T> {
     }
 }
 
-#[unstable]
+#[stable]
 impl<T: Send> Clone for Sender<T> {
     fn clone(&self) -> Sender<T> {
         let (packet, sleeper, guard) = match *unsafe { self.inner() } {
@@ -756,7 +756,7 @@ impl<T: Send> SyncSender<T> {
     }
 }
 
-#[unstable]
+#[stable]
 impl<T: Send> Clone for SyncSender<T> {
     fn clone(&self) -> SyncSender<T> {
         unsafe { (*self.inner.get()).clone_chan(); }

--- a/src/libstd/io/comm_adapters.rs
+++ b/src/libstd/io/comm_adapters.rs
@@ -132,6 +132,7 @@ impl ChanWriter {
     }
 }
 
+#[stable]
 impl Clone for ChanWriter {
     fn clone(&self) -> ChanWriter {
         ChanWriter { tx: self.tx.clone() }


### PR DESCRIPTION
This patch marks `clone` stable, as well as the `Clone` trait, but
leaves `clone_from` unstable. The latter will be decided by the beta.

The patch also marks most manual implementations of `Clone` as stable,
except where the APIs are otherwise deprecated or where there is
uncertainty about providing `Clone`.

r? @alexcrichton
