### PR TITLE
add {:?} fmt syntax

### DIFF
--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -654,6 +654,7 @@ impl<'a, 'b> Context<'a, 'b> {
             Known(ref tyname) => {
                 match tyname.as_slice() {
                     ""  => "Show",
+                    "?" => "Show",
                     "e" => "LowerExp",
                     "E" => "UpperExp",
                     "o" => "Octal",

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -60,6 +60,7 @@ pub fn main() {
     t!(format!("{}", 10i), "10");
     t!(format!("{}", 10i), "10");
     t!(format!("{}", 10u), "10");
+    t!(format!("{:?}", true), "true");
     t!(format!("{:o}", 10u), "12");
     t!(format!("{:x}", 10u), "a");
     t!(format!("{:X}", 10u), "A");


### PR DESCRIPTION
First step of #20013. This will allow (after a snapshot) to change all the debug strings from `{}` to `{:?}`.

r? @alexcrichton 
