### PR TITLE
Some fixes to improve the rustdoc story for foreign items

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1478,6 +1478,7 @@ fn encode_info_for_foreign_item(ecx: &EncodeContext,
         if abi == abi::RustIntrinsic {
             encode_inlined_item(ecx, rbml_w, IIForeignRef(nitem));
         }
+        encode_attributes(rbml_w, &*nitem.attrs);
         encode_symbol(ecx, rbml_w, nitem.id);
       }
       ast::ForeignItemStatic(_, mutbl) => {
@@ -1488,6 +1489,7 @@ fn encode_info_for_foreign_item(ecx: &EncodeContext,
         }
         encode_bounds_and_type(rbml_w, ecx,
                                &lookup_item_type(ecx.tcx,local_def(nitem.id)));
+        encode_attributes(rbml_w, &*nitem.attrs);
         encode_symbol(ecx, rbml_w, nitem.id);
         encode_name(rbml_w, nitem.ident.name);
       }

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1479,6 +1479,8 @@ fn encode_info_for_foreign_item(ecx: &EncodeContext,
             encode_inlined_item(ecx, rbml_w, IIForeignRef(nitem));
         }
         encode_attributes(rbml_w, &*nitem.attrs);
+        let stab = stability::lookup(ecx.tcx, ast_util::local_def(nitem.id));
+        encode_stability(rbml_w, stab);
         encode_symbol(ecx, rbml_w, nitem.id);
       }
       ast::ForeignItemStatic(_, mutbl) => {
@@ -1490,6 +1492,8 @@ fn encode_info_for_foreign_item(ecx: &EncodeContext,
         encode_bounds_and_type(rbml_w, ecx,
                                &lookup_item_type(ecx.tcx,local_def(nitem.id)));
         encode_attributes(rbml_w, &*nitem.attrs);
+        let stab = stability::lookup(ecx.tcx, ast_util::local_def(nitem.id));
+        encode_stability(rbml_w, stab);
         encode_symbol(ecx, rbml_w, nitem.id);
         encode_name(rbml_w, nitem.ident.name);
       }

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -111,6 +111,10 @@ impl<'v> Visitor<'v> for Annotator {
     fn visit_struct_field(&mut self, s: &StructField) {
         self.annotate(s.node.id, &s.node.attrs, |v| visit::walk_struct_field(v, s));
     }
+
+    fn visit_foreign_item(&mut self, i: &ast::ForeignItem) {
+        self.annotate(i.id, &i.attrs, |_| {});
+    }
 }
 
 impl Index {


### PR DESCRIPTION
Encode foreign item attributes and stability levels and visit foreign
items in the stability visitor.

cc @Gankro 
