### PR TITLE
Implement bounded iterators for BTree

### DIFF
--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -26,7 +26,6 @@
 #![feature(unsafe_destructor, slicing_syntax)]
 #![feature(box_syntax)]
 #![feature(unboxed_closures)]
-#![feature(old_impl_check)]
 #![allow(unknown_features)] #![feature(int_uint)]
 #![allow(unstable)]
 #![no_std]
@@ -141,4 +140,14 @@ mod prelude {
     pub use slice::SliceConcatExt;
     pub use string::{String, ToString};
     pub use vec::Vec;
+}
+
+/// An endpoint of a range of keys.
+pub enum Bound<T> {
+    /// An inclusive bound.
+    Included(T),
+    /// An exclusive bound.
+    Excluded(T),
+    /// An infinite endpoint. Indicates that there is no bound in this direction.
+    Unbounded,
 }

--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -311,6 +311,7 @@
 
 #![stable]
 
+pub use core_collections::Bound;
 pub use core_collections::{BinaryHeap, Bitv, BitvSet, BTreeMap, BTreeSet};
 pub use core_collections::{DList, RingBuf, VecMap};
 


### PR DESCRIPTION
Part of collections reform v1, #18424
Also, iteration is simplified:

```
before
test btree::map::bench::iter_1000                          ... bench:     17177 ns/iter (+/- 6302)
test btree::map::bench::iter_100000                        ... bench:   1735731 ns/iter (+/- 23908)
test btree::map::bench::iter_20                            ... bench:       386 ns/iter (+/- 148)
after
test btree::map::bench::iter_1000                          ... bench:     15777 ns/iter (+/- 346)
test btree::map::bench::iter_100000                        ... bench:   1602604 ns/iter (+/- 73629)
test btree::map::bench::iter_20                            ... bench:       339 ns/iter (+/- 91)
```

cc @gereeter @cgaebel
r? @Gankro
