### PR TITLE
rustc_typeck: don't expect rvalues to have unsized types.

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4212,10 +4212,14 @@ pub fn expr_kind(tcx: &ctxt, expr: &ast::Expr) -> ExprKind {
                 }
 
                 def::DefStruct(_) => {
-                    match expr_ty(tcx, expr).sty {
-                        ty_bare_fn(..) => RvalueDatumExpr,
-                        _ => RvalueDpsExpr
-                    }
+                    match tcx.node_types.borrow().get(&expr.id) {
+                        Some(ty) => match ty.sty {
+                            ty_bare_fn(..) => RvalueDatumExpr,
+                            _ => RvalueDpsExpr
+                        },
+                        // See ExprCast below for why types might be missing.
+                        None => RvalueDatumExpr
+                     }
                 }
 
                 // Special case: A unit like struct's constructor must be called without () at the

--- a/src/test/run-pass/coerce-expect-unsized.rs
+++ b/src/test/run-pass/coerce-expect-unsized.rs
@@ -1,0 +1,30 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::fmt::Show;
+
+// Check that coercions apply at the pointer level and don't cause
+// rvalue expressions to be unsized. See #20169 for more information.
+
+pub fn main() {
+    let _: Box<[int]> = box { [1, 2, 3] };
+    let _: Box<[int]> = box if true { [1, 2, 3] } else { [1, 3, 4] };
+    let _: Box<[int]> = box match true { true => [1, 2, 3], false => [1, 3, 4] };
+    let _: Box<Fn(int) -> _> = box { |x| (x as u8) };
+    let _: Box<Show> = box if true { false } else { true };
+    let _: Box<Show> = box match true { true => 'a', false => 'b' };
+
+    let _: &[int] = &{ [1, 2, 3] };
+    let _: &[int] = &if true { [1, 2, 3] } else { [1, 3, 4] };
+    let _: &[int] = &match true { true => [1, 2, 3], false => [1, 3, 4] };
+    let _: &Fn(int) -> _ = &{ |x| (x as u8) };
+    let _: &Show = &if true { false } else { true };
+    let _: &Show = &match true { true => 'a', false => 'b' };
+}


### PR DESCRIPTION
This fixes a few corner cases with expected type propagation, e.g.:

``` rust
fn take_int_slice(_: &[int]) {}
take_int_slice(&if 1 < 0 { [ 0, 1 ] } else { [ 0, 1 ] });
```

``` rust
<anon>:2:28: 2:36 error: mismatched types: expected `[int]`, found `[int, ..2]`
<anon>:2 take_int_slice(&if 1 < 0 { [ 0, 1 ] } else { [ 0, 1 ] });
                                    ^~~~~~~~
<anon>:2:46: 2:54 error: mismatched types: expected `[int]`, found `[int, ..2]`
<anon>:2 take_int_slice(&if 1 < 0 { [ 0, 1 ] } else { [ 0, 1 ] });
                                                      ^~~~~~~~
```

Right now we unpack the expected `&[int]` and pass down `[int]`, forcing
rvalue expressions to take unsized types, which causes mismatch errors.
Instead, I replaced that expectation with a weaker hint, for the unsized
cases - a hint is still required to infer the integer literals' types, above.

Fixes #20169.
