### PR TITLE
std: Don't parse argv as a String

### DIFF
--- a/src/libstd/rt/args.rs
+++ b/src/libstd/rt/args.rs
@@ -44,12 +44,10 @@ pub fn clone() -> Option<Vec<Vec<u8>>> { imp::clone() }
           target_os = "freebsd",
           target_os = "dragonfly"))]
 mod imp {
-    use core::prelude::*;
+    use prelude::*;
 
-    use boxed::Box;
-    use vec::Vec;
-    use string::String;
     use mem;
+    use slice;
 
     use sync::{StaticMutex, MUTEX_INIT};
 
@@ -98,7 +96,12 @@ mod imp {
 
     unsafe fn load_argc_and_argv(argc: int, argv: *const *const u8) -> Vec<Vec<u8>> {
         Vec::from_fn(argc as uint, |i| {
-            String::from_raw_buf(*argv.offset(i as int)).into_bytes()
+            let arg = *argv.offset(i as int);
+            let mut len = 0u;
+            while *arg.offset(len as int) != 0 {
+                len += 1u;
+            }
+            slice::from_raw_buf(&arg, len).to_vec()
         })
     }
 

--- a/src/test/run-pass/issue-20091.rs
+++ b/src/test/run-pass/issue-20091.rs
@@ -1,0 +1,19 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io::Command;
+use std::os;
+
+fn main() {
+    if os::args().len() == 1 {
+        assert!(Command::new(os::self_exe_name().unwrap()).arg(b"\xff")
+                        .status().unwrap().success())
+    }
+}


### PR DESCRIPTION
Instead, just pass everything through as a Vec<u8> to get worried about later.

Closes #20091
