### PR TITLE
Rename include_bin! to include_bytes!

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -640,7 +640,7 @@ names, and invoked through a consistent syntax: `name!(...)`. Examples include:
 * `stringify!` : pretty-print the Rust expression given as an argument
 * `include!` : include the Rust expression in the given file
 * `include_str!` : include the contents of the given file as a string
-* `include_bin!` : include the contents of the given file as a binary blob
+* `include_bytes!` : include the contents of the given file as a binary blob
 * `error!`, `warn!`, `info!`, `debug!` : provide diagnostic information.
 
 All of the above extensions are expressions with values.

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -491,26 +491,26 @@ fn write_shared(cx: &Context,
     // Add all the static files. These may already exist, but we just
     // overwrite them anyway to make sure that they're fresh and up-to-date.
     try!(write(cx.dst.join("jquery.js"),
-               include_bin!("static/jquery-2.1.0.min.js")));
-    try!(write(cx.dst.join("main.js"), include_bin!("static/main.js")));
-    try!(write(cx.dst.join("playpen.js"), include_bin!("static/playpen.js")));
-    try!(write(cx.dst.join("main.css"), include_bin!("static/main.css")));
+               include_bytes!("static/jquery-2.1.0.min.js")));
+    try!(write(cx.dst.join("main.js"), include_bytes!("static/main.js")));
+    try!(write(cx.dst.join("playpen.js"), include_bytes!("static/playpen.js")));
+    try!(write(cx.dst.join("main.css"), include_bytes!("static/main.css")));
     try!(write(cx.dst.join("normalize.css"),
-               include_bin!("static/normalize.css")));
+               include_bytes!("static/normalize.css")));
     try!(write(cx.dst.join("FiraSans-Regular.woff"),
-               include_bin!("static/FiraSans-Regular.woff")));
+               include_bytes!("static/FiraSans-Regular.woff")));
     try!(write(cx.dst.join("FiraSans-Medium.woff"),
-               include_bin!("static/FiraSans-Medium.woff")));
+               include_bytes!("static/FiraSans-Medium.woff")));
     try!(write(cx.dst.join("Heuristica-Italic.woff"),
-               include_bin!("static/Heuristica-Italic.woff")));
+               include_bytes!("static/Heuristica-Italic.woff")));
     try!(write(cx.dst.join("SourceSerifPro-Regular.woff"),
-               include_bin!("static/SourceSerifPro-Regular.woff")));
+               include_bytes!("static/SourceSerifPro-Regular.woff")));
     try!(write(cx.dst.join("SourceSerifPro-Bold.woff"),
-               include_bin!("static/SourceSerifPro-Bold.woff")));
+               include_bytes!("static/SourceSerifPro-Bold.woff")));
     try!(write(cx.dst.join("SourceCodePro-Regular.woff"),
-               include_bin!("static/SourceCodePro-Regular.woff")));
+               include_bytes!("static/SourceCodePro-Regular.woff")));
     try!(write(cx.dst.join("SourceCodePro-Semibold.woff"),
-               include_bin!("static/SourceCodePro-Semibold.woff")));
+               include_bytes!("static/SourceCodePro-Semibold.woff")));
 
     fn collect(path: &Path, krate: &str,
                key: &str) -> io::IoResult<Vec<String>> {

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -621,10 +621,14 @@ pub mod builtin {
     /// # Example
     ///
     /// ```rust,ignore
-    /// let secret_key = include_bin!("secret-key.bin");
+    /// let secret_key = include_bytes!("secret-key.bin");
     /// ```
     #[macro_export]
-    macro_rules! include_bin { ($file:expr) => ({ /* compiler built-in */ }) }
+    macro_rules! include_bytes { ($file:expr) => ({ /* compiler built-in */ }) }
+
+    /// Deprecated alias for `include_bytes!()`.
+    #[macro_export]
+    macro_rules! include_bin { ($file:expr) => ({ /* compiler built-in */}) }
 
     /// Expands to a string that represents the current module path.
     ///

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -442,6 +442,9 @@ fn initial_syntax_expander_table(ecfg: &expand::ExpansionConfig) -> SyntaxEnv {
     syntax_expanders.insert(intern("include_bin"),
                             builtin_normal_expander(
                                     ext::source_util::expand_include_bin));
+    syntax_expanders.insert(intern("include_bytes"),
+                            builtin_normal_expander(
+                                    ext::source_util::expand_include_bytes));
     syntax_expanders.insert(intern("module_path"),
                             builtin_normal_expander(
                                     ext::source_util::expand_mod));

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -163,7 +163,13 @@ pub fn expand_include_str(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
 
 pub fn expand_include_bin(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                           -> Box<base::MacResult+'static> {
-    let file = match get_single_str_from_tts(cx, sp, tts, "include_bin!") {
+    cx.span_warn(sp, "include_bin! is deprecated; use include_bytes! instead");
+    expand_include_bytes(cx, sp, tts)
+}
+
+pub fn expand_include_bytes(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
+                            -> Box<base::MacResult+'static> {
+    let file = match get_single_str_from_tts(cx, sp, tts, "include_bytes!") {
         Some(f) => f,
         None => return DummyResult::expr(sp)
     };

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -148,7 +148,7 @@ fn main() {
     use std::io::{stdio, MemReader, BufferedReader};
 
     let rdr = if os::getenv("RUST_BENCH").is_some() {
-        let foo = include_bin!("shootout-k-nucleotide.data");
+        let foo = include_bytes!("shootout-k-nucleotide.data");
         box MemReader::new(foo.to_vec()) as Box<Reader>
     } else {
         box stdio::stdin() as Box<Reader>

--- a/src/test/compile-fail/macros-nonfatal-errors.rs
+++ b/src/test/compile-fail/macros-nonfatal-errors.rs
@@ -43,8 +43,8 @@ fn main() {
 
     include_str!(invalid); //~ ERROR
     include_str!("i'd be quite surprised if a file with this name existed"); //~ ERROR
-    include_bin!(invalid); //~ ERROR
-    include_bin!("i'd be quite surprised if a file with this name existed"); //~ ERROR
+    include_bytes!(invalid); //~ ERROR
+    include_bytes!("i'd be quite surprised if a file with this name existed"); //~ ERROR
 
     trace_macros!(invalid); //~ ERROR
 }

--- a/src/test/run-make/symbols-are-reasonable/lib.rs
+++ b/src/test/run-make/symbols-are-reasonable/lib.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 pub static X: &'static str = "foobarbaz";
-pub static Y: &'static [u8] = include_bin!("lib.rs");
+pub static Y: &'static [u8] = include_bytes!("lib.rs");
 
 trait Foo {}
 impl Foo for uint {}

--- a/src/test/run-pass/syntax-extension-source-utils.rs
+++ b/src/test/run-pass/syntax-extension-source-utils.rs
@@ -39,7 +39,7 @@ pub fn main() {
         .as_slice()
         .starts_with("/* this is for "));
     assert!(
-        include_bin!("syntax-extension-source-utils-files/includeme.fragment")
+        include_bytes!("syntax-extension-source-utils-files/includeme.fragment")
         [1] == (42 as u8)); // '*'
     // The Windows tests are wrapped in an extra module for some reason
     assert!((m1::m2::where_am_i().as_slice().ends_with("m1::m2")));


### PR DESCRIPTION
According to [RFC 344](https://github.com/rust-lang/rfcs/blob/master/text/0344-conventions-galore.md), methods that return `&[u8]` should have names ending in `bytes`. Though `include_bin!` is a macro not a method, it seems reasonable to follow the convention anyway.

We keep the old name around for now, but trigger a deprecation warning when it is used.

[breaking-change]
