### PR TITLE
Oibit send and friends

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -129,9 +129,9 @@ pub struct Weak<T> {
     _ptr: *mut ArcInner<T>,
 }
 
-impl<T: Sync + Send> Send for Arc<T> { }
+unsafe impl<T: Sync + Send> Send for Arc<T> { }
 
-impl<T: Sync + Send> Sync for Arc<T> { }
+unsafe impl<T: Sync + Send> Sync for Arc<T> { }
 
 struct ArcInner<T> {
     strong: atomic::AtomicUint,

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -129,6 +129,10 @@ pub struct Weak<T> {
     _ptr: *mut ArcInner<T>,
 }
 
+impl<T: Sync + Send> Send for Arc<T> { }
+
+impl<T: Sync + Send> Sync for Arc<T> { }
+
 struct ArcInner<T> {
     strong: atomic::AtomicUint,
     weak: atomic::AtomicUint,

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -139,7 +139,7 @@ struct ArcInner<T> {
     data: T,
 }
 
-impl<T: Sync + Send> Arc<T> {
+impl<T> Arc<T> {
     /// Constructs a new `Arc<T>`.
     ///
     /// # Examples

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -117,6 +117,10 @@ pub struct Arc<T> {
     _ptr: *mut ArcInner<T>,
 }
 
+unsafe impl<T: Sync + Send> Send for Arc<T> { }
+unsafe impl<T: Sync + Send> Sync for Arc<T> { }
+
+
 /// A weak pointer to an `Arc`.
 ///
 /// Weak pointers will not keep the data inside of the `Arc` alive, and can be used to break cycles
@@ -129,15 +133,17 @@ pub struct Weak<T> {
     _ptr: *mut ArcInner<T>,
 }
 
-unsafe impl<T: Sync + Send> Send for Arc<T> { }
-
-unsafe impl<T: Sync + Send> Sync for Arc<T> { }
+unsafe impl<T: Sync + Send> Send for Weak<T> { }
+unsafe impl<T: Sync + Send> Sync for Weak<T> { }
 
 struct ArcInner<T> {
     strong: atomic::AtomicUint,
     weak: atomic::AtomicUint,
     data: T,
 }
+
+unsafe impl<T: Sync + Send> Send for ArcInner<T> {}
+unsafe impl<T: Sync + Send> Sync for ArcInner<T> {}
 
 impl<T> Arc<T> {
     /// Constructs a new `Arc<T>`.
@@ -591,6 +597,7 @@ mod tests {
     use std::str::Str;
     use std::sync::atomic;
     use std::task;
+    use std::kinds::Send;
     use std::vec::Vec;
     use super::{Arc, Weak, weak_count, strong_count};
     use std::sync::Mutex;

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -19,7 +19,7 @@ use core::hash::{mod, Hash};
 use core::kinds::Sized;
 use core::mem;
 use core::option::Option;
-use core::ptr::UniquePtr;
+use core::ptr::Unique;
 use core::raw::TraitObject;
 use core::result::Result;
 use core::result::Result::{Ok, Err};
@@ -45,7 +45,7 @@ pub static HEAP: () = ();
 /// A type that represents a uniquely-owned value.
 #[lang = "owned_box"]
 #[unstable = "custom allocators will add an additional type parameter (with default)"]
-pub struct Box<T>(UniquePtr<T>);
+pub struct Box<T>(Unique<T>);
 
 #[stable]
 impl<T: Default> Default for Box<T> {

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -19,6 +19,7 @@ use core::hash::{mod, Hash};
 use core::kinds::Sized;
 use core::mem;
 use core::option::Option;
+use core::ptr::OwnedPtr;
 use core::raw::TraitObject;
 use core::result::Result;
 use core::result::Result::{Ok, Err};
@@ -44,7 +45,7 @@ pub static HEAP: () = ();
 /// A type that represents a uniquely-owned value.
 #[lang = "owned_box"]
 #[unstable = "custom allocators will add an additional type parameter (with default)"]
-pub struct Box<T>(*mut T);
+pub struct Box<T>(OwnedPtr<T>);
 
 #[stable]
 impl<T: Default> Default for Box<T> {

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -19,7 +19,7 @@ use core::hash::{mod, Hash};
 use core::kinds::Sized;
 use core::mem;
 use core::option::Option;
-use core::ptr::OwnedPtr;
+use core::ptr::UniquePtr;
 use core::raw::TraitObject;
 use core::result::Result;
 use core::result::Result::{Ok, Err};
@@ -45,7 +45,7 @@ pub static HEAP: () = ();
 /// A type that represents a uniquely-owned value.
 #[lang = "owned_box"]
 #[unstable = "custom allocators will add an additional type parameter (with default)"]
-pub struct Box<T>(OwnedPtr<T>);
+pub struct Box<T>(UniquePtr<T>);
 
 #[stable]
 impl<T: Default> Default for Box<T> {

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -43,6 +43,8 @@ struct Rawlink<T> {
 }
 
 impl<T> Copy for Rawlink<T> {}
+unsafe impl<T:'static+Send> Send for Rawlink<T> {}
+unsafe impl<T:Send+Sync> Sync for Rawlink<T> {}
 
 struct Node<T> {
     next: Link<T>,

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -58,7 +58,7 @@ use core::kinds::marker::{ContravariantLifetime, InvariantType};
 use core::mem;
 use core::num::{Int, UnsignedInt};
 use core::ops;
-use core::ptr::{mod, UniquePtr};
+use core::ptr::{mod, Unique};
 use core::raw::Slice as RawSlice;
 use core::uint;
 
@@ -133,7 +133,7 @@ use slice::CloneSliceExt;
 #[unsafe_no_drop_flag]
 #[stable]
 pub struct Vec<T> {
-    ptr: UniquePtr<T>,
+    ptr: Unique<T>,
     len: uint,
     cap: uint,
 }
@@ -176,7 +176,7 @@ impl<T> Vec<T> {
         // non-null value which is fine since we never call deallocate on the ptr
         // if cap is 0. The reason for this is because the pointer of a slice
         // being NULL would break the null pointer optimization for enums.
-        Vec { ptr: UniquePtr(EMPTY as *mut T), len: 0, cap: 0 }
+        Vec { ptr: Unique(EMPTY as *mut T), len: 0, cap: 0 }
     }
 
     /// Constructs a new, empty `Vec<T>` with the specified capacity.
@@ -209,7 +209,7 @@ impl<T> Vec<T> {
     #[stable]
     pub fn with_capacity(capacity: uint) -> Vec<T> {
         if mem::size_of::<T>() == 0 {
-            Vec { ptr: UniquePtr(EMPTY as *mut T), len: 0, cap: uint::MAX }
+            Vec { ptr: Unique(EMPTY as *mut T), len: 0, cap: uint::MAX }
         } else if capacity == 0 {
             Vec::new()
         } else {
@@ -217,7 +217,7 @@ impl<T> Vec<T> {
                                .expect("capacity overflow");
             let ptr = unsafe { allocate(size, mem::min_align_of::<T>()) };
             if ptr.is_null() { ::alloc::oom() }
-            Vec { ptr: UniquePtr(ptr as *mut T), len: 0, cap: capacity }
+            Vec { ptr: Unique(ptr as *mut T), len: 0, cap: capacity }
         }
     }
 
@@ -284,7 +284,7 @@ impl<T> Vec<T> {
     #[unstable = "needs finalization"]
     pub unsafe fn from_raw_parts(ptr: *mut T, length: uint,
                                  capacity: uint) -> Vec<T> {
-        Vec { ptr: UniquePtr(ptr), len: length, cap: capacity }
+        Vec { ptr: Unique(ptr), len: length, cap: capacity }
     }
 
     /// Creates a vector by copying the elements from a raw pointer.
@@ -803,7 +803,7 @@ impl<T> Vec<T> {
             unsafe {
                 // Overflow check is unnecessary as the vector is already at
                 // least this large.
-                self.ptr = UniquePtr(reallocate(self.ptr.0 as *mut u8,
+                self.ptr = Unique(reallocate(self.ptr.0 as *mut u8,
                                                self.cap * mem::size_of::<T>(),
                                                self.len * mem::size_of::<T>(),
                                                mem::min_align_of::<T>()) as *mut T);
@@ -1110,7 +1110,7 @@ impl<T> Vec<T> {
             let size = max(old_size, 2 * mem::size_of::<T>()) * 2;
             if old_size > size { panic!("capacity overflow") }
             unsafe {
-                self.ptr = UniquePtr(alloc_or_realloc(self.ptr.0, old_size, size));
+                self.ptr = Unique(alloc_or_realloc(self.ptr.0, old_size, size));
                 if self.ptr.0.is_null() { ::alloc::oom() }
             }
             self.cap = max(self.cap, 2) * 2;
@@ -1231,7 +1231,7 @@ impl<T> Vec<T> {
             let size = capacity.checked_mul(mem::size_of::<T>())
                                .expect("capacity overflow");
             unsafe {
-                self.ptr = UniquePtr(alloc_or_realloc(self.ptr.0,
+                self.ptr = Unique(alloc_or_realloc(self.ptr.0,
                                                      self.cap * mem::size_of::<T>(),
                                                      size));
                 if self.ptr.0.is_null() { ::alloc::oom() }
@@ -1420,7 +1420,7 @@ impl<T> IntoIter<T> {
             for _x in self { }
             let IntoIter { allocation, cap, ptr: _ptr, end: _end } = self;
             mem::forget(self);
-            Vec { ptr: UniquePtr(allocation), cap: cap, len: 0 }
+            Vec { ptr: Unique(allocation), cap: cap, len: 0 }
         }
     }
 

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -58,7 +58,7 @@ use core::kinds::marker::{ContravariantLifetime, InvariantType};
 use core::mem;
 use core::num::{Int, UnsignedInt};
 use core::ops;
-use core::ptr::{mod, OwnedPtr};
+use core::ptr::{mod, UniquePtr};
 use core::raw::Slice as RawSlice;
 use core::uint;
 
@@ -133,7 +133,7 @@ use slice::CloneSliceExt;
 #[unsafe_no_drop_flag]
 #[stable]
 pub struct Vec<T> {
-    ptr: OwnedPtr<T>,
+    ptr: UniquePtr<T>,
     len: uint,
     cap: uint,
 }
@@ -176,7 +176,7 @@ impl<T> Vec<T> {
         // non-null value which is fine since we never call deallocate on the ptr
         // if cap is 0. The reason for this is because the pointer of a slice
         // being NULL would break the null pointer optimization for enums.
-        Vec { ptr: OwnedPtr(EMPTY as *mut T), len: 0, cap: 0 }
+        Vec { ptr: UniquePtr(EMPTY as *mut T), len: 0, cap: 0 }
     }
 
     /// Constructs a new, empty `Vec<T>` with the specified capacity.
@@ -209,7 +209,7 @@ impl<T> Vec<T> {
     #[stable]
     pub fn with_capacity(capacity: uint) -> Vec<T> {
         if mem::size_of::<T>() == 0 {
-            Vec { ptr: OwnedPtr(EMPTY as *mut T), len: 0, cap: uint::MAX }
+            Vec { ptr: UniquePtr(EMPTY as *mut T), len: 0, cap: uint::MAX }
         } else if capacity == 0 {
             Vec::new()
         } else {
@@ -217,7 +217,7 @@ impl<T> Vec<T> {
                                .expect("capacity overflow");
             let ptr = unsafe { allocate(size, mem::min_align_of::<T>()) };
             if ptr.is_null() { ::alloc::oom() }
-            Vec { ptr: OwnedPtr(ptr as *mut T), len: 0, cap: capacity }
+            Vec { ptr: UniquePtr(ptr as *mut T), len: 0, cap: capacity }
         }
     }
 
@@ -284,7 +284,7 @@ impl<T> Vec<T> {
     #[unstable = "needs finalization"]
     pub unsafe fn from_raw_parts(ptr: *mut T, length: uint,
                                  capacity: uint) -> Vec<T> {
-        Vec { ptr: OwnedPtr(ptr), len: length, cap: capacity }
+        Vec { ptr: UniquePtr(ptr), len: length, cap: capacity }
     }
 
     /// Creates a vector by copying the elements from a raw pointer.
@@ -803,7 +803,7 @@ impl<T> Vec<T> {
             unsafe {
                 // Overflow check is unnecessary as the vector is already at
                 // least this large.
-                self.ptr = OwnedPtr(reallocate(self.ptr.0 as *mut u8,
+                self.ptr = UniquePtr(reallocate(self.ptr.0 as *mut u8,
                                                self.cap * mem::size_of::<T>(),
                                                self.len * mem::size_of::<T>(),
                                                mem::min_align_of::<T>()) as *mut T);
@@ -1110,7 +1110,7 @@ impl<T> Vec<T> {
             let size = max(old_size, 2 * mem::size_of::<T>()) * 2;
             if old_size > size { panic!("capacity overflow") }
             unsafe {
-                self.ptr = OwnedPtr(alloc_or_realloc(self.ptr.0, old_size, size));
+                self.ptr = UniquePtr(alloc_or_realloc(self.ptr.0, old_size, size));
                 if self.ptr.0.is_null() { ::alloc::oom() }
             }
             self.cap = max(self.cap, 2) * 2;
@@ -1231,7 +1231,7 @@ impl<T> Vec<T> {
             let size = capacity.checked_mul(mem::size_of::<T>())
                                .expect("capacity overflow");
             unsafe {
-                self.ptr = OwnedPtr(alloc_or_realloc(self.ptr.0,
+                self.ptr = UniquePtr(alloc_or_realloc(self.ptr.0,
                                                      self.cap * mem::size_of::<T>(),
                                                      size));
                 if self.ptr.0.is_null() { ::alloc::oom() }
@@ -1420,7 +1420,7 @@ impl<T> IntoIter<T> {
             for _x in self { }
             let IntoIter { allocation, cap, ptr: _ptr, end: _end } = self;
             mem::forget(self);
-            Vec { ptr: OwnedPtr(allocation), cap: cap, len: 0 }
+            Vec { ptr: UniquePtr(allocation), cap: cap, len: 0 }
         }
     }
 

--- a/src/libcore/atomic.rs
+++ b/src/libcore/atomic.rs
@@ -14,32 +14,42 @@
 
 pub use self::Ordering::*;
 
+use kinds::Sync;
+
 use intrinsics;
-use cell::{UnsafeCell, RacyCell};
+use cell::UnsafeCell;
 
 /// A boolean type which can be safely shared between threads.
 #[stable]
 pub struct AtomicBool {
-    v: RacyCell<uint>,
+    v: UnsafeCell<uint>,
 }
+
+unsafe impl Sync for AtomicBool {}
 
 /// A signed integer type which can be safely shared between threads.
 #[stable]
 pub struct AtomicInt {
-    v: RacyCell<int>,
+    v: UnsafeCell<int>,
 }
+
+unsafe impl Sync for AtomicInt {}
 
 /// An unsigned integer type which can be safely shared between threads.
 #[stable]
 pub struct AtomicUint {
-    v: RacyCell<uint>,
+    v: UnsafeCell<uint>,
 }
+
+unsafe impl Sync for AtomicUint {}
 
 /// A raw pointer type which can be safely shared between threads.
 #[stable]
 pub struct AtomicPtr<T> {
-    p: RacyCell<uint>,
+    p: UnsafeCell<uint>,
 }
+
+unsafe impl<T> Sync for AtomicPtr<T> {}
 
 /// Atomic memory orderings
 ///
@@ -80,15 +90,15 @@ pub enum Ordering {
 /// An `AtomicBool` initialized to `false`.
 #[unstable = "may be renamed, pending conventions for static initalizers"]
 pub const INIT_ATOMIC_BOOL: AtomicBool =
-        AtomicBool { v: RacyCell(UnsafeCell { value: 0 }) };
+        AtomicBool { v: UnsafeCell { value: 0 } };
 /// An `AtomicInt` initialized to `0`.
 #[unstable = "may be renamed, pending conventions for static initalizers"]
 pub const INIT_ATOMIC_INT: AtomicInt =
-        AtomicInt { v: RacyCell(UnsafeCell { value: 0 }) };
+        AtomicInt { v: UnsafeCell { value: 0 } };
 /// An `AtomicUint` initialized to `0`.
 #[unstable = "may be renamed, pending conventions for static initalizers"]
 pub const INIT_ATOMIC_UINT: AtomicUint =
-        AtomicUint { v: RacyCell(UnsafeCell { value: 0 }) };
+        AtomicUint { v: UnsafeCell { value: 0, } };
 
 // NB: Needs to be -1 (0b11111111...) to make fetch_nand work correctly
 const UINT_TRUE: uint = -1;
@@ -108,7 +118,7 @@ impl AtomicBool {
     #[stable]
     pub fn new(v: bool) -> AtomicBool {
         let val = if v { UINT_TRUE } else { 0 };
-        AtomicBool { v: RacyCell::new(val) }
+        AtomicBool { v: UnsafeCell::new(val) }
     }
 
     /// Loads a value from the bool.
@@ -348,7 +358,7 @@ impl AtomicInt {
     #[inline]
     #[stable]
     pub fn new(v: int) -> AtomicInt {
-        AtomicInt {v: RacyCell::new(v)}
+        AtomicInt {v: UnsafeCell::new(v)}
     }
 
     /// Loads a value from the int.
@@ -534,7 +544,7 @@ impl AtomicUint {
     #[inline]
     #[stable]
     pub fn new(v: uint) -> AtomicUint {
-        AtomicUint { v: RacyCell::new(v) }
+        AtomicUint { v: UnsafeCell::new(v) }
     }
 
     /// Loads a value from the uint.
@@ -721,7 +731,7 @@ impl<T> AtomicPtr<T> {
     #[inline]
     #[stable]
     pub fn new(p: *mut T) -> AtomicPtr<T> {
-        AtomicPtr { p: RacyCell::new(p as uint) }
+        AtomicPtr { p: UnsafeCell::new(p as uint) }
     }
 
     /// Loads a value from the pointer.

--- a/src/libcore/atomic.rs
+++ b/src/libcore/atomic.rs
@@ -15,30 +15,30 @@
 pub use self::Ordering::*;
 
 use intrinsics;
-use cell::UnsafeCell;
+use cell::{UnsafeCell, RacyCell};
 
 /// A boolean type which can be safely shared between threads.
 #[stable]
 pub struct AtomicBool {
-    v: UnsafeCell<uint>,
+    v: RacyCell<uint>,
 }
 
 /// A signed integer type which can be safely shared between threads.
 #[stable]
 pub struct AtomicInt {
-    v: UnsafeCell<int>,
+    v: RacyCell<int>,
 }
 
 /// An unsigned integer type which can be safely shared between threads.
 #[stable]
 pub struct AtomicUint {
-    v: UnsafeCell<uint>,
+    v: RacyCell<uint>,
 }
 
 /// A raw pointer type which can be safely shared between threads.
 #[stable]
 pub struct AtomicPtr<T> {
-    p: UnsafeCell<uint>,
+    p: RacyCell<uint>,
 }
 
 /// Atomic memory orderings
@@ -80,15 +80,15 @@ pub enum Ordering {
 /// An `AtomicBool` initialized to `false`.
 #[unstable = "may be renamed, pending conventions for static initalizers"]
 pub const INIT_ATOMIC_BOOL: AtomicBool =
-        AtomicBool { v: UnsafeCell { value: 0 } };
+        AtomicBool { v: RacyCell(UnsafeCell { value: 0 }) };
 /// An `AtomicInt` initialized to `0`.
 #[unstable = "may be renamed, pending conventions for static initalizers"]
 pub const INIT_ATOMIC_INT: AtomicInt =
-        AtomicInt { v: UnsafeCell { value: 0 } };
+        AtomicInt { v: RacyCell(UnsafeCell { value: 0 }) };
 /// An `AtomicUint` initialized to `0`.
 #[unstable = "may be renamed, pending conventions for static initalizers"]
 pub const INIT_ATOMIC_UINT: AtomicUint =
-        AtomicUint { v: UnsafeCell { value: 0, } };
+        AtomicUint { v: RacyCell(UnsafeCell { value: 0 }) };
 
 // NB: Needs to be -1 (0b11111111...) to make fetch_nand work correctly
 const UINT_TRUE: uint = -1;
@@ -108,7 +108,7 @@ impl AtomicBool {
     #[stable]
     pub fn new(v: bool) -> AtomicBool {
         let val = if v { UINT_TRUE } else { 0 };
-        AtomicBool { v: UnsafeCell::new(val) }
+        AtomicBool { v: RacyCell::new(val) }
     }
 
     /// Loads a value from the bool.
@@ -348,7 +348,7 @@ impl AtomicInt {
     #[inline]
     #[stable]
     pub fn new(v: int) -> AtomicInt {
-        AtomicInt {v: UnsafeCell::new(v)}
+        AtomicInt {v: RacyCell::new(v)}
     }
 
     /// Loads a value from the int.
@@ -534,7 +534,7 @@ impl AtomicUint {
     #[inline]
     #[stable]
     pub fn new(v: uint) -> AtomicUint {
-        AtomicUint { v: UnsafeCell::new(v) }
+        AtomicUint { v: RacyCell::new(v) }
     }
 
     /// Loads a value from the uint.
@@ -721,7 +721,7 @@ impl<T> AtomicPtr<T> {
     #[inline]
     #[stable]
     pub fn new(p: *mut T) -> AtomicPtr<T> {
-        AtomicPtr { p: UnsafeCell::new(p as uint) }
+        AtomicPtr { p: RacyCell::new(p as uint) }
     }
 
     /// Loads a value from the pointer.

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -577,6 +577,6 @@ impl<T> RacyCell<T> {
     }
 }
 
-impl<T:Send> Send for RacyCell<T> { }
+unsafe impl<T:Send> Send for RacyCell<T> { }
 
-impl<T> Sync for RacyCell<T> { } // Oh dear
+unsafe impl<T> Sync for RacyCell<T> { } // Oh dear

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -158,7 +158,7 @@
 use clone::Clone;
 use cmp::PartialEq;
 use default::Default;
-use kinds::{marker, Copy, Send, Sync};
+use kinds::{marker, Copy};
 use ops::{Deref, DerefMut, Drop};
 use option::Option;
 use option::Option::{None, Some};
@@ -555,28 +555,3 @@ impl<T> UnsafeCell<T> {
     #[deprecated = "renamed to into_inner()"]
     pub unsafe fn unwrap(self) -> T { self.into_inner() }
 }
-
-/// A version of `UnsafeCell` intended for use in concurrent data
-/// structures (for example, you might put it in an `Arc`).
-pub struct RacyCell<T>(pub UnsafeCell<T>);
-
-impl<T> RacyCell<T> {
-    /// DOX
-    pub fn new(value: T) -> RacyCell<T> {
-        RacyCell(UnsafeCell { value: value })
-    }
-
-    /// DOX
-    pub unsafe fn get(&self) -> *mut T {
-        self.0.get()
-    }
-
-    /// DOX
-    pub unsafe fn into_inner(self) -> T {
-        self.0.into_inner()
-    }
-}
-
-unsafe impl<T:Send> Send for RacyCell<T> { }
-
-unsafe impl<T> Sync for RacyCell<T> { } // Oh dear

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -158,7 +158,7 @@
 use clone::Clone;
 use cmp::PartialEq;
 use default::Default;
-use kinds::{marker, Copy};
+use kinds::{marker, Copy, Send, Sync};
 use ops::{Deref, DerefMut, Drop};
 use option::Option;
 use option::Option::{None, Some};
@@ -555,3 +555,28 @@ impl<T> UnsafeCell<T> {
     #[deprecated = "renamed to into_inner()"]
     pub unsafe fn unwrap(self) -> T { self.into_inner() }
 }
+
+/// A version of `UnsafeCell` intended for use in concurrent data
+/// structures (for example, you might put it in an `Arc`).
+pub struct RacyCell<T>(pub UnsafeCell<T>);
+
+impl<T> RacyCell<T> {
+    /// DOX
+    pub fn new(value: T) -> RacyCell<T> {
+        RacyCell(UnsafeCell { value: value })
+    }
+
+    /// DOX
+    pub unsafe fn get(&self) -> *mut T {
+        self.0.get()
+    }
+
+    /// DOX
+    pub unsafe fn into_inner(self) -> T {
+        self.0.into_inner()
+    }
+}
+
+impl<T:Send> Send for RacyCell<T> { }
+
+impl<T> Sync for RacyCell<T> { } // Oh dear

--- a/src/libcore/kinds.rs
+++ b/src/libcore/kinds.rs
@@ -19,7 +19,7 @@
 
 /// Types able to be transferred across task boundaries.
 #[lang="send"]
-pub trait Send for Sized? : 'static {
+pub unsafe trait Send for Sized? : 'static {
     // empty.
 }
 
@@ -81,7 +81,7 @@ pub trait Copy for Sized? {
 /// reference; not doing this is undefined behaviour (for example,
 /// `transmute`-ing from `&T` to `&mut T` is illegal).
 #[lang="sync"]
-pub trait Sync for Sized? {
+pub unsafe trait Sync for Sized? {
     // Empty
 }
 

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -505,28 +505,28 @@ impl<T> PartialOrd for *mut T {
 
 /// A wrapper around a raw `*mut T` that indicates that the possessor
 /// of this wrapper owns the referent. This in turn implies that the
-/// `OwnedPtr<T>` is `Send`/`Sync` if `T` is `Send`/`Sync`, unlike a
+/// `UniquePtr<T>` is `Send`/`Sync` if `T` is `Send`/`Sync`, unlike a
 /// raw `*mut T` (which conveys no particular ownership semantics).
 /// Useful for building abstractions like `Vec<T>` or `Box<T>`, which
 /// internally use raw pointers to manage the memory that they own.
-pub struct OwnedPtr<T>(pub *mut T);
+pub struct UniquePtr<T>(pub *mut T);
 
-/// `OwnedPtr` pointers are `Send` if `T` is `Send` because the data they
+/// `UniquePtr` pointers are `Send` if `T` is `Send` because the data they
 /// reference is unaliased. Note that this aliasing invariant is
 /// unenforced by the type system; the abstraction using the
-/// `OwnedPtr` must enforce it.
-impl<T:Send> Send for OwnedPtr<T> { }
+/// `UniquePtr` must enforce it.
+impl<T:Send> Send for UniquePtr<T> { }
 
-/// `OwnedPtr` pointers are `Sync` if `T` is `Sync` because the data they
+/// `UniquePtr` pointers are `Sync` if `T` is `Sync` because the data they
 /// reference is unaliased. Note that this aliasing invariant is
 /// unenforced by the type system; the abstraction using the
-/// `OwnedPtr` must enforce it.
-impl<T:Sync> Sync for OwnedPtr<T> { }
+/// `UniquePtr` must enforce it.
+impl<T:Sync> Sync for UniquePtr<T> { }
 
-impl<T> OwnedPtr<T> {
-    /// Returns a null OwnedPtr.
-    pub fn null() -> OwnedPtr<T> {
-        OwnedPtr(RawPtr::null())
+impl<T> UniquePtr<T> {
+    /// Returns a null UniquePtr.
+    pub fn null() -> UniquePtr<T> {
+        UniquePtr(RawPtr::null())
     }
 
     /// Return an (unsafe) pointer into the memory owned by `self`.

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -505,28 +505,28 @@ impl<T> PartialOrd for *mut T {
 
 /// A wrapper around a raw `*mut T` that indicates that the possessor
 /// of this wrapper owns the referent. This in turn implies that the
-/// `UniquePtr<T>` is `Send`/`Sync` if `T` is `Send`/`Sync`, unlike a
+/// `Unique<T>` is `Send`/`Sync` if `T` is `Send`/`Sync`, unlike a
 /// raw `*mut T` (which conveys no particular ownership semantics).
 /// Useful for building abstractions like `Vec<T>` or `Box<T>`, which
 /// internally use raw pointers to manage the memory that they own.
-pub struct UniquePtr<T>(pub *mut T);
+pub struct Unique<T>(pub *mut T);
 
-/// `UniquePtr` pointers are `Send` if `T` is `Send` because the data they
+/// `Unique` pointers are `Send` if `T` is `Send` because the data they
 /// reference is unaliased. Note that this aliasing invariant is
 /// unenforced by the type system; the abstraction using the
-/// `UniquePtr` must enforce it.
-unsafe impl<T:Send> Send for UniquePtr<T> { }
+/// `Unique` must enforce it.
+unsafe impl<T:Send> Send for Unique<T> { }
 
-/// `UniquePtr` pointers are `Sync` if `T` is `Sync` because the data they
+/// `Unique` pointers are `Sync` if `T` is `Sync` because the data they
 /// reference is unaliased. Note that this aliasing invariant is
 /// unenforced by the type system; the abstraction using the
-/// `UniquePtr` must enforce it.
-unsafe impl<T:Sync> Sync for UniquePtr<T> { }
+/// `Unique` must enforce it.
+unsafe impl<T:Sync> Sync for Unique<T> { }
 
-impl<T> UniquePtr<T> {
-    /// Returns a null UniquePtr.
-    pub fn null() -> UniquePtr<T> {
-        UniquePtr(RawPtr::null())
+impl<T> Unique<T> {
+    /// Returns a null Unique.
+    pub fn null() -> Unique<T> {
+        Unique(RawPtr::null())
     }
 
     /// Return an (unsafe) pointer into the memory owned by `self`.

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -515,13 +515,13 @@ pub struct UniquePtr<T>(pub *mut T);
 /// reference is unaliased. Note that this aliasing invariant is
 /// unenforced by the type system; the abstraction using the
 /// `UniquePtr` must enforce it.
-impl<T:Send> Send for UniquePtr<T> { }
+unsafe impl<T:Send> Send for UniquePtr<T> { }
 
 /// `UniquePtr` pointers are `Sync` if `T` is `Sync` because the data they
 /// reference is unaliased. Note that this aliasing invariant is
 /// unenforced by the type system; the abstraction using the
 /// `UniquePtr` must enforce it.
-impl<T:Sync> Sync for UniquePtr<T> { }
+unsafe impl<T:Sync> Sync for UniquePtr<T> { }
 
 impl<T> UniquePtr<T> {
     /// Returns a null UniquePtr.

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -29,7 +29,7 @@ extern crate libc;
 
 use libc::{c_void, size_t, c_int};
 use std::c_vec::CVec;
-use std::ptr::OwnedPtr;
+use std::ptr::UniquePtr;
 
 #[link(name = "miniz", kind = "static")]
 extern {
@@ -60,7 +60,7 @@ fn deflate_bytes_internal(bytes: &[u8], flags: c_int) -> Option<CVec<u8>> {
                                              &mut outsz,
                                              flags);
         if !res.is_null() {
-            let res = OwnedPtr(res);
+            let res = UniquePtr(res);
             Some(CVec::new_with_dtor(res.0 as *mut u8, outsz as uint, move|:| libc::free(res.0)))
         } else {
             None
@@ -86,7 +86,7 @@ fn inflate_bytes_internal(bytes: &[u8], flags: c_int) -> Option<CVec<u8>> {
                                                &mut outsz,
                                                flags);
         if !res.is_null() {
-            let res = OwnedPtr(res);
+            let res = UniquePtr(res);
             Some(CVec::new_with_dtor(res.0 as *mut u8, outsz as uint, move|:| libc::free(res.0)))
         } else {
             None

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -29,7 +29,7 @@ extern crate libc;
 
 use libc::{c_void, size_t, c_int};
 use std::c_vec::CVec;
-use std::ptr::UniquePtr;
+use std::ptr::Unique;
 
 #[link(name = "miniz", kind = "static")]
 extern {
@@ -60,7 +60,7 @@ fn deflate_bytes_internal(bytes: &[u8], flags: c_int) -> Option<CVec<u8>> {
                                              &mut outsz,
                                              flags);
         if !res.is_null() {
-            let res = UniquePtr(res);
+            let res = Unique(res);
             Some(CVec::new_with_dtor(res.0 as *mut u8, outsz as uint, move|:| libc::free(res.0)))
         } else {
             None
@@ -86,7 +86,7 @@ fn inflate_bytes_internal(bytes: &[u8], flags: c_int) -> Option<CVec<u8>> {
                                                &mut outsz,
                                                flags);
         if !res.is_null() {
-            let res = UniquePtr(res);
+            let res = Unique(res);
             Some(CVec::new_with_dtor(res.0 as *mut u8, outsz as uint, move|:| libc::free(res.0)))
         } else {
             None

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -27,8 +27,9 @@
 
 extern crate libc;
 
-use std::c_vec::CVec;
 use libc::{c_void, size_t, c_int};
+use std::c_vec::CVec;
+use std::ptr::OwnedPtr;
 
 #[link(name = "miniz", kind = "static")]
 extern {
@@ -59,7 +60,8 @@ fn deflate_bytes_internal(bytes: &[u8], flags: c_int) -> Option<CVec<u8>> {
                                              &mut outsz,
                                              flags);
         if !res.is_null() {
-            Some(CVec::new_with_dtor(res as *mut u8, outsz as uint, move|:| libc::free(res)))
+            let res = OwnedPtr(res);
+            Some(CVec::new_with_dtor(res.0 as *mut u8, outsz as uint, move|:| libc::free(res.0)))
         } else {
             None
         }
@@ -84,7 +86,8 @@ fn inflate_bytes_internal(bytes: &[u8], flags: c_int) -> Option<CVec<u8>> {
                                                &mut outsz,
                                                flags);
         if !res.is_null() {
-            Some(CVec::new_with_dtor(res as *mut u8, outsz as uint, move|:| libc::free(res)))
+            let res = OwnedPtr(res);
+            Some(CVec::new_with_dtor(res.0 as *mut u8, outsz as uint, move|:| libc::free(res.0)))
         } else {
             None
         }

--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -67,5 +67,6 @@ register_diagnostics! {
     E0173,
     E0174,
     E0177,
-    E0178
+    E0178,
+    E0179
 }

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -113,7 +113,7 @@ pub struct Upvar {
 // different kinds of pointers:
 #[deriving(Clone, Copy, PartialEq, Eq, Hash, Show)]
 pub enum PointerKind {
-    OwnedPtr,
+    UniquePtr,
     BorrowedPtr(ty::BorrowKind, ty::Region),
     Implicit(ty::BorrowKind, ty::Region),     // Implicit deref of a borrowed ptr.
     UnsafePtr(ast::Mutability)
@@ -199,7 +199,7 @@ pub fn opt_deref_kind(t: Ty) -> Option<deref_kind> {
     match t.sty {
         ty::ty_uniq(_) |
         ty::ty_closure(box ty::ClosureTy {store: ty::UniqTraitStore, ..}) => {
-            Some(deref_ptr(OwnedPtr))
+            Some(deref_ptr(UniquePtr))
         }
 
         ty::ty_rptr(r, mt) => {
@@ -315,7 +315,7 @@ impl MutabilityCategory {
     pub fn from_pointer_kind(base_mutbl: MutabilityCategory,
                              ptr: PointerKind) -> MutabilityCategory {
         match ptr {
-            OwnedPtr => {
+            UniquePtr => {
                 base_mutbl.inherit()
             }
             BorrowedPtr(borrow_kind, _) | Implicit(borrow_kind, _) => {
@@ -1351,7 +1351,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                           Implicit(..) => {
                             "dereference (dereference is implicit, due to indexing)".to_string()
                           }
-                          OwnedPtr => format!("dereference of `{}`", ptr_sigil(pk)),
+                          UniquePtr => format!("dereference of `{}`", ptr_sigil(pk)),
                           _ => format!("dereference of `{}`-pointer", ptr_sigil(pk))
                       }
                   }
@@ -1412,7 +1412,7 @@ impl<'tcx> cmt_<'tcx> {
             }
             cat_downcast(ref b, _) |
             cat_interior(ref b, _) |
-            cat_deref(ref b, _, OwnedPtr) => {
+            cat_deref(ref b, _, UniquePtr) => {
                 b.guarantor()
             }
         }
@@ -1431,7 +1431,7 @@ impl<'tcx> cmt_<'tcx> {
             cat_deref(ref b, _, BorrowedPtr(ty::UniqueImmBorrow, _)) |
             cat_deref(ref b, _, Implicit(ty::UniqueImmBorrow, _)) |
             cat_downcast(ref b, _) |
-            cat_deref(ref b, _, OwnedPtr) |
+            cat_deref(ref b, _, UniquePtr) |
             cat_interior(ref b, _) => {
                 // Aliasability depends on base cmt
                 b.freely_aliasable(ctxt)
@@ -1523,7 +1523,7 @@ impl<'tcx> Repr<'tcx> for categorization<'tcx> {
 
 pub fn ptr_sigil(ptr: PointerKind) -> &'static str {
     match ptr {
-        OwnedPtr => "Box",
+        UniquePtr => "Box",
         BorrowedPtr(ty::ImmBorrow, _) |
         Implicit(ty::ImmBorrow, _) => "&",
         BorrowedPtr(ty::MutBorrow, _) |

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -113,7 +113,7 @@ pub struct Upvar {
 // different kinds of pointers:
 #[deriving(Clone, Copy, PartialEq, Eq, Hash, Show)]
 pub enum PointerKind {
-    UniquePtr,
+    Unique,
     BorrowedPtr(ty::BorrowKind, ty::Region),
     Implicit(ty::BorrowKind, ty::Region),     // Implicit deref of a borrowed ptr.
     UnsafePtr(ast::Mutability)
@@ -199,7 +199,7 @@ pub fn opt_deref_kind(t: Ty) -> Option<deref_kind> {
     match t.sty {
         ty::ty_uniq(_) |
         ty::ty_closure(box ty::ClosureTy {store: ty::UniqTraitStore, ..}) => {
-            Some(deref_ptr(UniquePtr))
+            Some(deref_ptr(Unique))
         }
 
         ty::ty_rptr(r, mt) => {
@@ -315,7 +315,7 @@ impl MutabilityCategory {
     pub fn from_pointer_kind(base_mutbl: MutabilityCategory,
                              ptr: PointerKind) -> MutabilityCategory {
         match ptr {
-            UniquePtr => {
+            Unique => {
                 base_mutbl.inherit()
             }
             BorrowedPtr(borrow_kind, _) | Implicit(borrow_kind, _) => {
@@ -1351,7 +1351,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                           Implicit(..) => {
                             "dereference (dereference is implicit, due to indexing)".to_string()
                           }
-                          UniquePtr => format!("dereference of `{}`", ptr_sigil(pk)),
+                          Unique => format!("dereference of `{}`", ptr_sigil(pk)),
                           _ => format!("dereference of `{}`-pointer", ptr_sigil(pk))
                       }
                   }
@@ -1412,7 +1412,7 @@ impl<'tcx> cmt_<'tcx> {
             }
             cat_downcast(ref b, _) |
             cat_interior(ref b, _) |
-            cat_deref(ref b, _, UniquePtr) => {
+            cat_deref(ref b, _, Unique) => {
                 b.guarantor()
             }
         }
@@ -1431,7 +1431,7 @@ impl<'tcx> cmt_<'tcx> {
             cat_deref(ref b, _, BorrowedPtr(ty::UniqueImmBorrow, _)) |
             cat_deref(ref b, _, Implicit(ty::UniqueImmBorrow, _)) |
             cat_downcast(ref b, _) |
-            cat_deref(ref b, _, UniquePtr) |
+            cat_deref(ref b, _, Unique) |
             cat_interior(ref b, _) => {
                 // Aliasability depends on base cmt
                 b.freely_aliasable(ctxt)
@@ -1523,7 +1523,7 @@ impl<'tcx> Repr<'tcx> for categorization<'tcx> {
 
 pub fn ptr_sigil(ptr: PointerKind) -> &'static str {
     match ptr {
-        UniquePtr => "Box",
+        Unique => "Box",
         BorrowedPtr(ty::ImmBorrow, _) |
         Implicit(ty::ImmBorrow, _) => "&",
         BorrowedPtr(ty::MutBorrow, _) |

--- a/src/librustc/middle/traits/error_reporting.rs
+++ b/src/librustc/middle/traits/error_reporting.rs
@@ -1,0 +1,349 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use super::{FulfillmentError, FulfillmentErrorCode,
+            ObligationCauseCode, SelectionError,
+            PredicateObligation, OutputTypeParameterMismatch};
+
+use middle::infer::InferCtxt;
+use middle::ty::{mod};
+use syntax::codemap::Span;
+use util::ppaux::{Repr, UserString};
+
+pub fn report_fulfillment_errors<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
+                                           errors: &Vec<FulfillmentError<'tcx>>) {
+    for error in errors.iter() {
+        report_fulfillment_error(infcx, error);
+    }
+}
+
+fn report_fulfillment_error<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
+                                      error: &FulfillmentError<'tcx>) {
+    match error.code {
+        FulfillmentErrorCode::CodeSelectionError(ref e) => {
+            report_selection_error(infcx, &error.obligation, e);
+        }
+        FulfillmentErrorCode::CodeAmbiguity => {
+            maybe_report_ambiguity(infcx, &error.obligation);
+        }
+    }
+}
+
+pub fn report_selection_error<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
+                                        obligation: &PredicateObligation<'tcx>,
+                                        error: &SelectionError<'tcx>)
+{
+    match *error {
+        SelectionError::Overflow => {
+            // We could track the stack here more precisely if we wanted, I imagine.
+            match obligation.trait_ref {
+                ty::Predicate::Trait(ref trait_ref) => {
+                    let trait_ref =
+                        infcx.resolve_type_vars_if_possible(&**trait_ref);
+                    infcx.tcx.sess.span_err(
+                        obligation.cause.span,
+                        format!(
+                            "overflow evaluating the trait `{}` for the type `{}`",
+                            trait_ref.user_string(infcx.tcx),
+                            trait_ref.self_ty().user_string(infcx.tcx))[]);
+                }
+
+                ty::Predicate::Equate(ref predicate) => {
+                    let predicate = infcx.resolve_type_vars_if_possible(predicate);
+                    let err = infcx.equality_predicate(obligation.cause.span,
+                                                       &predicate).unwrap_err();
+
+                    infcx.tcx.sess.span_err(
+                        obligation.cause.span,
+                        format!(
+                            "the requirement `{}` is not satisfied (`{}`)",
+                            predicate.user_string(infcx.tcx),
+                            ty::type_err_to_str(infcx.tcx, &err)).as_slice());
+                }
+
+                ty::Predicate::TypeOutlives(..) |
+                ty::Predicate::RegionOutlives(..) => {
+                    infcx.tcx.sess.span_err(
+                        obligation.cause.span,
+                        format!("overflow evaluating lifetime predicate").as_slice());
+                }
+            }
+
+            let current_limit = infcx.tcx.sess.recursion_limit.get();
+            let suggested_limit = current_limit * 2;
+            infcx.tcx.sess.span_note(
+                obligation.cause.span,
+                format!(
+                    "consider adding a `#![recursion_limit=\"{}\"]` attribute to your crate",
+                    suggested_limit)[]);
+
+            note_obligation_cause(infcx, obligation);
+        }
+        SelectionError::Unimplemented => {
+            match obligation.trait_ref {
+                ty::Predicate::Trait(ref trait_ref) => {
+                    let trait_ref =
+                        infcx.resolve_type_vars_if_possible(
+                            &**trait_ref);
+                    if !ty::type_is_error(trait_ref.self_ty()) {
+                        infcx.tcx.sess.span_err(
+                            obligation.cause.span,
+                            format!(
+                                "the trait `{}` is not implemented for the type `{}`",
+                                trait_ref.user_string(infcx.tcx),
+                                trait_ref.self_ty().user_string(infcx.tcx)).as_slice());
+                        note_obligation_cause(infcx, obligation);
+                    }
+                }
+
+                ty::Predicate::Equate(ref predicate) => {
+                    let predicate = infcx.resolve_type_vars_if_possible(predicate);
+                    let err = infcx.equality_predicate(obligation.cause.span,
+                                                       &predicate).unwrap_err();
+
+                    infcx.tcx.sess.span_err(
+                        obligation.cause.span,
+                        format!(
+                            "the requirement `{}` is not satisfied (`{}`)",
+                            predicate.user_string(infcx.tcx),
+                            ty::type_err_to_str(infcx.tcx, &err)).as_slice());
+                }
+
+                ty::Predicate::TypeOutlives(..) |
+                ty::Predicate::RegionOutlives(..) => {
+                    let predicate = infcx.resolve_type_vars_if_possible(&obligation.trait_ref);
+                    infcx.tcx.sess.span_err(
+                        obligation.cause.span,
+                        format!(
+                            "the requirement `{}` is not satisfied",
+                            predicate.user_string(infcx.tcx)).as_slice());
+                }
+            }
+        }
+        OutputTypeParameterMismatch(ref expected_trait_ref, ref actual_trait_ref, ref e) => {
+            let expected_trait_ref =
+                infcx.resolve_type_vars_if_possible(
+                    &**expected_trait_ref);
+            let actual_trait_ref =
+                infcx.resolve_type_vars_if_possible(
+                    &**actual_trait_ref);
+            if !ty::type_is_error(actual_trait_ref.self_ty()) {
+                infcx.tcx.sess.span_err(
+                    obligation.cause.span,
+                    format!(
+                        "type mismatch: the type `{}` implements the trait `{}`, \
+                         but the trait `{}` is required ({})",
+                        expected_trait_ref.self_ty().user_string(infcx.tcx),
+                        expected_trait_ref.user_string(infcx.tcx),
+                        actual_trait_ref.user_string(infcx.tcx),
+                        ty::type_err_to_str(infcx.tcx, e)).as_slice());
+                note_obligation_cause(infcx, obligation);
+            }
+        }
+    }
+}
+
+fn maybe_report_ambiguity<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
+                                    obligation: &PredicateObligation<'tcx>) {
+    // Unable to successfully determine, probably means
+    // insufficient type information, but could mean
+    // ambiguous impls. The latter *ought* to be a
+    // coherence violation, so we don't report it here.
+
+    let trait_ref = match obligation.trait_ref {
+        ty::Predicate::Trait(ref trait_ref) => {
+            infcx.resolve_type_vars_if_possible(&**trait_ref)
+        }
+        _ => {
+            infcx.tcx.sess.span_bug(
+                obligation.cause.span,
+                format!("ambiguity from something other than a trait: {}",
+                        obligation.trait_ref.repr(infcx.tcx)).as_slice());
+        }
+    };
+    let self_ty = trait_ref.self_ty();
+
+    debug!("maybe_report_ambiguity(trait_ref={}, self_ty={}, obligation={})",
+           trait_ref.repr(infcx.tcx),
+           self_ty.repr(infcx.tcx),
+           obligation.repr(infcx.tcx));
+    let all_types = &trait_ref.substs().types;
+    if all_types.iter().any(|&t| ty::type_is_error(t)) {
+    } else if all_types.iter().any(|&t| ty::type_needs_infer(t)) {
+        // This is kind of a hack: it frequently happens that some earlier
+        // error prevents types from being fully inferred, and then we get
+        // a bunch of uninteresting errors saying something like "<generic
+        // #0> doesn't implement Sized".  It may even be true that we
+        // could just skip over all checks where the self-ty is an
+        // inference variable, but I was afraid that there might be an
+        // inference variable created, registered as an obligation, and
+        // then never forced by writeback, and hence by skipping here we'd
+        // be ignoring the fact that we don't KNOW the type works
+        // out. Though even that would probably be harmless, given that
+        // we're only talking about builtin traits, which are known to be
+        // inhabited. But in any case I just threw in this check for
+        // has_errors() to be sure that compilation isn't happening
+        // anyway. In that case, why inundate the user.
+        if !infcx.tcx.sess.has_errors() {
+            if infcx.tcx.lang_items.sized_trait()
+                  .map_or(false, |sized_id| sized_id == trait_ref.def_id()) {
+                infcx.tcx.sess.span_err(
+                    obligation.cause.span,
+                    format!(
+                        "unable to infer enough type information about `{}`; type annotations \
+                         required",
+                        self_ty.user_string(infcx.tcx)).as_slice());
+            } else {
+                infcx.tcx.sess.span_err(
+                    obligation.cause.span,
+                    format!(
+                        "unable to infer enough type information to \
+                         locate the impl of the trait `{}` for \
+                         the type `{}`; type annotations required",
+                        trait_ref.user_string(infcx.tcx),
+                        self_ty.user_string(infcx.tcx))[]);
+                note_obligation_cause(infcx, obligation);
+            }
+        }
+    } else if !infcx.tcx.sess.has_errors() {
+         // Ambiguity. Coherence should have reported an error.
+        infcx.tcx.sess.span_bug(
+            obligation.cause.span,
+            format!(
+                "coherence failed to report ambiguity: \
+                 cannot locate the impl of the trait `{}` for \
+                 the type `{}`",
+                trait_ref.user_string(infcx.tcx),
+                self_ty.user_string(infcx.tcx))[]);
+    }
+}
+
+fn note_obligation_cause<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
+                                   obligation: &PredicateObligation<'tcx>)
+{
+    let trait_ref = match obligation.trait_ref {
+        ty::Predicate::Trait(ref trait_ref) => {
+            infcx.resolve_type_vars_if_possible(&**trait_ref)
+        }
+        _ => {
+            infcx.tcx.sess.span_bug(
+                obligation.cause.span,
+                format!("ambiguity from something other than a trait: {}",
+                        obligation.trait_ref.repr(infcx.tcx)).as_slice());
+        }
+    };
+
+    note_obligation_cause_code(infcx,
+                               &trait_ref,
+                               obligation.cause.span,
+                               &obligation.cause.code)
+}
+
+fn note_obligation_cause_code<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
+                                        trait_ref: &ty::PolyTraitRef<'tcx>,
+                                        cause_span: Span,
+                                        cause_code: &ObligationCauseCode<'tcx>)
+{
+    let tcx = infcx.tcx;
+    let trait_name = ty::item_path_str(tcx, trait_ref.def_id());
+    match *cause_code {
+        ObligationCauseCode::MiscObligation => { }
+        ObligationCauseCode::ItemObligation(item_def_id) => {
+            let item_name = ty::item_path_str(tcx, item_def_id);
+            tcx.sess.span_note(
+                cause_span,
+                format!(
+                    "the trait `{}` must be implemented because it is required by `{}`",
+                    trait_name,
+                    item_name).as_slice());
+        }
+        ObligationCauseCode::ObjectCastObligation(object_ty) => {
+            tcx.sess.span_note(
+                cause_span,
+                format!(
+                    "the trait `{}` must be implemented for the cast \
+                     to the object type `{}`",
+                    trait_name,
+                    infcx.ty_to_string(object_ty)).as_slice());
+        }
+        ObligationCauseCode::RepeatVec => {
+            tcx.sess.span_note(
+                cause_span,
+                "the `Copy` trait is required because the \
+                 repeated element will be copied");
+        }
+        ObligationCauseCode::VariableType(_) => {
+            tcx.sess.span_note(
+                cause_span,
+                "all local variables must have a statically known size");
+        }
+        ObligationCauseCode::ReturnType => {
+            tcx.sess.span_note(
+                cause_span,
+                "the return type of a function must have a \
+                 statically known size");
+        }
+        ObligationCauseCode::AssignmentLhsSized => {
+            tcx.sess.span_note(
+                cause_span,
+                "the left-hand-side of an assignment must have a statically known size");
+        }
+        ObligationCauseCode::StructInitializerSized => {
+            tcx.sess.span_note(
+                cause_span,
+                "structs must have a statically known size to be initialized");
+        }
+        ObligationCauseCode::ClosureCapture(var_id, closure_span, builtin_bound) => {
+            let def_id = tcx.lang_items.from_builtin_kind(builtin_bound).unwrap();
+            let trait_name = ty::item_path_str(tcx, def_id);
+            let name = ty::local_var_name_str(tcx, var_id);
+            span_note!(tcx.sess, closure_span,
+                       "the closure that captures `{}` requires that all captured variables \
+                       implement the trait `{}`",
+                       name,
+                       trait_name);
+        }
+        ObligationCauseCode::FieldSized => {
+            span_note!(tcx.sess, cause_span,
+                       "only the last field of a struct or enum variant \
+                       may have a dynamically sized type")
+        }
+        ObligationCauseCode::ObjectSized => {
+            span_note!(tcx.sess, cause_span,
+                       "only sized types can be made into objects");
+        }
+        ObligationCauseCode::SharedStatic => {
+            span_note!(tcx.sess, cause_span,
+                       "shared static variables must have a type that implements `Sync`");
+        }
+        ObligationCauseCode::BuiltinDerivedObligation(ref root_trait_ref, ref root_cause_code) => {
+            let root_trait_ref =
+                infcx.resolve_type_vars_if_possible(&**root_trait_ref);
+            span_note!(tcx.sess, cause_span,
+                       "the type `{}` must implement `{}` because it appears within the type `{}`",
+                       trait_ref.self_ty().user_string(infcx.tcx),
+                       trait_ref.user_string(infcx.tcx),
+                       root_trait_ref.self_ty().user_string(infcx.tcx));
+            note_obligation_cause_code(infcx, &root_trait_ref, cause_span, &**root_cause_code);
+        }
+        ObligationCauseCode::ImplDerivedObligation(ref root_trait_ref, ref root_cause_code) => {
+            let root_trait_ref =
+                infcx.resolve_type_vars_if_possible(&**root_trait_ref);
+            span_note!(tcx.sess, cause_span,
+                       "the type `{}` must implement `{}` due to the requirements \
+                        on the impl of `{}` for the type `{}`",
+                       trait_ref.self_ty().user_string(infcx.tcx),
+                       trait_ref.user_string(infcx.tcx),
+                       root_trait_ref.user_string(infcx.tcx),
+                       root_trait_ref.self_ty().user_string(infcx.tcx));
+            note_obligation_cause_code(infcx, &root_trait_ref, cause_span, &**root_cause_code);
+        }
+    }
+}

--- a/src/librustc/middle/traits/fulfill.rs
+++ b/src/librustc/middle/traits/fulfill.rs
@@ -305,7 +305,7 @@ fn process_predicate<'a,'tcx>(selcx: &mut SelectionContext<'a,'tcx>,
     let tcx = selcx.tcx();
     match predicate.trait_ref {
         ty::Predicate::Trait(ref trait_ref) => {
-            let trait_obligation = Obligation { cause: predicate.cause,
+            let trait_obligation = Obligation { cause: predicate.cause.clone(),
                                                 recursion_depth: predicate.recursion_depth,
                                                 trait_ref: trait_ref.clone() };
             match selcx.select(&trait_obligation) {
@@ -368,7 +368,9 @@ fn process_predicate<'a,'tcx>(selcx: &mut SelectionContext<'a,'tcx>,
                         CodeSelectionError(Unimplemented)));
             } else {
                 let ty::OutlivesPredicate(t_a, r_b) = binder.0;
-                register_region_obligation(tcx, t_a, r_b, predicate.cause, region_obligations);
+                register_region_obligation(tcx, t_a, r_b,
+                                           predicate.cause.clone(),
+                                           region_obligations);
             }
             true
         }

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1928,6 +1928,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         }
     }
 
+    #[allow(unused_comparisons)]
     fn derived_cause(&self,
                      obligation: &TraitObligation<'tcx>,
                      variant: fn(Rc<ty::Binder<ty::TraitRef<'tcx>>>,
@@ -1945,7 +1946,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
          * reporting.
          */
 
-        if obligation.recursion_depth == 0 {
+        // NOTE(flaper87): As of now, it keeps track of the whole error
+        // chain. Ideally, we should have a way to configure this either
+        // by using -Z verbose or just a CLI argument.
+        if obligation.recursion_depth >= 0 {
             ObligationCause::new(obligation.cause.span,
                                  obligation.trait_ref.def_id().node,
                                  variant(obligation.trait_ref.clone(),

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -260,7 +260,7 @@ pub fn predicates_for_generics<'tcx>(tcx: &ty::ctxt<'tcx>,
            generic_bounds.repr(tcx));
 
     generic_bounds.predicates.map(|predicate| {
-        Obligation { cause: cause,
+        Obligation { cause: cause.clone(),
                      recursion_depth: recursion_depth,
                      trait_ref: predicate.clone() }
     })

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -439,7 +439,7 @@ impl<'tcx,O> TypeFoldable<'tcx> for traits::Obligation<'tcx,O>
 {
     fn fold_with<F:TypeFolder<'tcx>>(&self, folder: &mut F) -> traits::Obligation<'tcx, O> {
         traits::Obligation {
-            cause: self.cause,
+            cause: self.cause.clone(),
             recursion_depth: self.recursion_depth,
             trait_ref: self.trait_ref.fold_with(folder),
         }

--- a/src/librustc_borrowck/borrowck/check_loans.rs
+++ b/src/librustc_borrowck/borrowck/check_loans.rs
@@ -33,11 +33,11 @@ use std::rc::Rc;
 
 // FIXME (#16118): These functions are intended to allow the borrow checker to
 // be less precise in its handling of Box while still allowing moves out of a
-// Box. They should be removed when OwnedPtr is removed from LoanPath.
+// Box. They should be removed when UniquePtr is removed from LoanPath.
 
 fn owned_ptr_base_path<'a, 'tcx>(loan_path: &'a LoanPath<'tcx>) -> &'a LoanPath<'tcx> {
-    //! Returns the base of the leftmost dereference of an OwnedPtr in
-    //! `loan_path`. If there is no dereference of an OwnedPtr in `loan_path`,
+    //! Returns the base of the leftmost dereference of an UniquePtr in
+    //! `loan_path`. If there is no dereference of an UniquePtr in `loan_path`,
     //! then it just returns `loan_path` itself.
 
     return match helper(loan_path) {
@@ -48,7 +48,7 @@ fn owned_ptr_base_path<'a, 'tcx>(loan_path: &'a LoanPath<'tcx>) -> &'a LoanPath<
     fn helper<'a, 'tcx>(loan_path: &'a LoanPath<'tcx>) -> Option<&'a LoanPath<'tcx>> {
         match loan_path.kind {
             LpVar(_) | LpUpvar(_) => None,
-            LpExtend(ref lp_base, _, LpDeref(mc::OwnedPtr)) => {
+            LpExtend(ref lp_base, _, LpDeref(mc::UniquePtr)) => {
                 match helper(&**lp_base) {
                     v @ Some(_) => v,
                     None => Some(&**lp_base)
@@ -72,7 +72,7 @@ fn owned_ptr_base_path_rc<'tcx>(loan_path: &Rc<LoanPath<'tcx>>) -> Rc<LoanPath<'
     fn helper<'tcx>(loan_path: &Rc<LoanPath<'tcx>>) -> Option<Rc<LoanPath<'tcx>>> {
         match loan_path.kind {
             LpVar(_) | LpUpvar(_) => None,
-            LpExtend(ref lp_base, _, LpDeref(mc::OwnedPtr)) => {
+            LpExtend(ref lp_base, _, LpDeref(mc::UniquePtr)) => {
                 match helper(lp_base) {
                     v @ Some(_) => v,
                     None => Some(lp_base.clone())
@@ -880,7 +880,7 @@ impl<'a, 'tcx> CheckLoanCtxt<'a, 'tcx> {
                         }
                     }
 
-                    mc::cat_deref(b, _, mc::OwnedPtr) => {
+                    mc::cat_deref(b, _, mc::UniquePtr) => {
                         assert_eq!(cmt.mutbl, mc::McInherited);
                         cmt = b;
                     }

--- a/src/librustc_borrowck/borrowck/check_loans.rs
+++ b/src/librustc_borrowck/borrowck/check_loans.rs
@@ -33,11 +33,11 @@ use std::rc::Rc;
 
 // FIXME (#16118): These functions are intended to allow the borrow checker to
 // be less precise in its handling of Box while still allowing moves out of a
-// Box. They should be removed when UniquePtr is removed from LoanPath.
+// Box. They should be removed when Unique is removed from LoanPath.
 
 fn owned_ptr_base_path<'a, 'tcx>(loan_path: &'a LoanPath<'tcx>) -> &'a LoanPath<'tcx> {
-    //! Returns the base of the leftmost dereference of an UniquePtr in
-    //! `loan_path`. If there is no dereference of an UniquePtr in `loan_path`,
+    //! Returns the base of the leftmost dereference of an Unique in
+    //! `loan_path`. If there is no dereference of an Unique in `loan_path`,
     //! then it just returns `loan_path` itself.
 
     return match helper(loan_path) {
@@ -48,7 +48,7 @@ fn owned_ptr_base_path<'a, 'tcx>(loan_path: &'a LoanPath<'tcx>) -> &'a LoanPath<
     fn helper<'a, 'tcx>(loan_path: &'a LoanPath<'tcx>) -> Option<&'a LoanPath<'tcx>> {
         match loan_path.kind {
             LpVar(_) | LpUpvar(_) => None,
-            LpExtend(ref lp_base, _, LpDeref(mc::UniquePtr)) => {
+            LpExtend(ref lp_base, _, LpDeref(mc::Unique)) => {
                 match helper(&**lp_base) {
                     v @ Some(_) => v,
                     None => Some(&**lp_base)
@@ -72,7 +72,7 @@ fn owned_ptr_base_path_rc<'tcx>(loan_path: &Rc<LoanPath<'tcx>>) -> Rc<LoanPath<'
     fn helper<'tcx>(loan_path: &Rc<LoanPath<'tcx>>) -> Option<Rc<LoanPath<'tcx>>> {
         match loan_path.kind {
             LpVar(_) | LpUpvar(_) => None,
-            LpExtend(ref lp_base, _, LpDeref(mc::UniquePtr)) => {
+            LpExtend(ref lp_base, _, LpDeref(mc::Unique)) => {
                 match helper(lp_base) {
                     v @ Some(_) => v,
                     None => Some(lp_base.clone())
@@ -880,7 +880,7 @@ impl<'a, 'tcx> CheckLoanCtxt<'a, 'tcx> {
                         }
                     }
 
-                    mc::cat_deref(b, _, mc::UniquePtr) => {
+                    mc::cat_deref(b, _, mc::Unique) => {
                         assert_eq!(cmt.mutbl, mc::McInherited);
                         cmt = b;
                     }

--- a/src/librustc_borrowck/borrowck/fragments.rs
+++ b/src/librustc_borrowck/borrowck/fragments.rs
@@ -291,9 +291,9 @@ fn add_fragment_siblings<'tcx>(this: &MoveData<'tcx>,
             add_fragment_siblings(this, tcx, gathered_fragments, loan_parent.clone(), origin_id);
         }
 
-        // *LV for UniquePtr consumes the contents of the box (at
+        // *LV for Unique consumes the contents of the box (at
         // least when it is non-copy...), so propagate inward.
-        LpExtend(ref loan_parent, _, LpDeref(mc::UniquePtr)) => {
+        LpExtend(ref loan_parent, _, LpDeref(mc::Unique)) => {
             add_fragment_siblings(this, tcx, gathered_fragments, loan_parent.clone(), origin_id);
         }
 

--- a/src/librustc_borrowck/borrowck/fragments.rs
+++ b/src/librustc_borrowck/borrowck/fragments.rs
@@ -291,9 +291,9 @@ fn add_fragment_siblings<'tcx>(this: &MoveData<'tcx>,
             add_fragment_siblings(this, tcx, gathered_fragments, loan_parent.clone(), origin_id);
         }
 
-        // *LV for OwnedPtr consumes the contents of the box (at
+        // *LV for UniquePtr consumes the contents of the box (at
         // least when it is non-copy...), so propagate inward.
-        LpExtend(ref loan_parent, _, LpDeref(mc::OwnedPtr)) => {
+        LpExtend(ref loan_parent, _, LpDeref(mc::UniquePtr)) => {
             add_fragment_siblings(this, tcx, gathered_fragments, loan_parent.clone(), origin_id);
         }
 

--- a/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
@@ -190,7 +190,7 @@ fn check_and_get_illegal_move_origin<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>,
             }
         }
 
-        mc::cat_deref(ref b, _, mc::OwnedPtr) => {
+        mc::cat_deref(ref b, _, mc::UniquePtr) => {
             check_and_get_illegal_move_origin(bccx, b)
         }
     }

--- a/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
@@ -190,7 +190,7 @@ fn check_and_get_illegal_move_origin<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>,
             }
         }
 
-        mc::cat_deref(ref b, _, mc::UniquePtr) => {
+        mc::cat_deref(ref b, _, mc::Unique) => {
             check_and_get_illegal_move_origin(bccx, b)
         }
     }

--- a/src/librustc_borrowck/borrowck/gather_loans/lifetime.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/lifetime.rs
@@ -84,7 +84,7 @@ impl<'a, 'tcx> GuaranteeLifetimeContext<'a, 'tcx> {
             }
 
             mc::cat_downcast(ref base, _) |
-            mc::cat_deref(ref base, _, mc::UniquePtr) |     // L-Deref-Send
+            mc::cat_deref(ref base, _, mc::Unique) |     // L-Deref-Send
             mc::cat_interior(ref base, _) => {             // L-Field
                 self.check(base, discr_scope)
             }
@@ -129,7 +129,7 @@ impl<'a, 'tcx> GuaranteeLifetimeContext<'a, 'tcx> {
                 r
             }
             mc::cat_downcast(ref cmt, _) |
-            mc::cat_deref(ref cmt, _, mc::UniquePtr) |
+            mc::cat_deref(ref cmt, _, mc::Unique) |
             mc::cat_interior(ref cmt, _) => {
                 self.scope(cmt)
             }

--- a/src/librustc_borrowck/borrowck/gather_loans/lifetime.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/lifetime.rs
@@ -84,7 +84,7 @@ impl<'a, 'tcx> GuaranteeLifetimeContext<'a, 'tcx> {
             }
 
             mc::cat_downcast(ref base, _) |
-            mc::cat_deref(ref base, _, mc::OwnedPtr) |     // L-Deref-Send
+            mc::cat_deref(ref base, _, mc::UniquePtr) |     // L-Deref-Send
             mc::cat_interior(ref base, _) => {             // L-Field
                 self.check(base, discr_scope)
             }
@@ -129,7 +129,7 @@ impl<'a, 'tcx> GuaranteeLifetimeContext<'a, 'tcx> {
                 r
             }
             mc::cat_downcast(ref cmt, _) |
-            mc::cat_deref(ref cmt, _, mc::OwnedPtr) |
+            mc::cat_deref(ref cmt, _, mc::UniquePtr) |
             mc::cat_interior(ref cmt, _) => {
                 self.scope(cmt)
             }

--- a/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
@@ -107,7 +107,7 @@ impl<'a, 'tcx> RestrictionsContext<'a, 'tcx> {
 
             mc::cat_deref(cmt_base, _, pk) => {
                 match pk {
-                    mc::OwnedPtr => {
+                    mc::UniquePtr => {
                         // R-Deref-Send-Pointer
                         //
                         // When we borrow the interior of an owned pointer, we

--- a/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
@@ -107,7 +107,7 @@ impl<'a, 'tcx> RestrictionsContext<'a, 'tcx> {
 
             mc::cat_deref(cmt_base, _, pk) => {
                 match pk {
-                    mc::UniquePtr => {
+                    mc::Unique => {
                         // R-Deref-Send-Pointer
                         //
                         // When we borrow the interior of an owned pointer, we

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -281,7 +281,7 @@ struct ModuleConfig {
     time_passes: bool,
 }
 
-impl Send for ModuleConfig { }
+unsafe impl Send for ModuleConfig { }
 
 impl ModuleConfig {
     fn new(tm: TargetMachineRef, passes: Vec<String>) -> ModuleConfig {

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -281,6 +281,8 @@ struct ModuleConfig {
     time_passes: bool,
 }
 
+impl Send for ModuleConfig { }
+
 impl ModuleConfig {
     fn new(tm: TargetMachineRef, passes: Vec<String>) -> ModuleConfig {
         ModuleConfig {

--- a/src/librustc_trans/trans/debuginfo.rs
+++ b/src/librustc_trans/trans/debuginfo.rs
@@ -216,32 +216,32 @@ use syntax::{ast, codemap, ast_util, ast_map};
 use syntax::ast_util::PostExpansionMethod;
 use syntax::parse::token::{mod, special_idents};
 
-static DW_LANG_RUST: c_uint = 0x9000;
+const DW_LANG_RUST: c_uint = 0x9000;
 
 #[allow(non_upper_case_globals)]
-static DW_TAG_auto_variable: c_uint = 0x100;
+const DW_TAG_auto_variable: c_uint = 0x100;
 #[allow(non_upper_case_globals)]
-static DW_TAG_arg_variable: c_uint = 0x101;
+const DW_TAG_arg_variable: c_uint = 0x101;
 
 #[allow(non_upper_case_globals)]
-static DW_ATE_boolean: c_uint = 0x02;
+const DW_ATE_boolean: c_uint = 0x02;
 #[allow(non_upper_case_globals)]
-static DW_ATE_float: c_uint = 0x04;
+const DW_ATE_float: c_uint = 0x04;
 #[allow(non_upper_case_globals)]
-static DW_ATE_signed: c_uint = 0x05;
+const DW_ATE_signed: c_uint = 0x05;
 #[allow(non_upper_case_globals)]
-static DW_ATE_unsigned: c_uint = 0x07;
+const DW_ATE_unsigned: c_uint = 0x07;
 #[allow(non_upper_case_globals)]
-static DW_ATE_unsigned_char: c_uint = 0x08;
+const DW_ATE_unsigned_char: c_uint = 0x08;
 
-static UNKNOWN_LINE_NUMBER: c_uint = 0;
-static UNKNOWN_COLUMN_NUMBER: c_uint = 0;
+const UNKNOWN_LINE_NUMBER: c_uint = 0;
+const UNKNOWN_COLUMN_NUMBER: c_uint = 0;
 
 // ptr::null() doesn't work :(
-static UNKNOWN_FILE_METADATA: DIFile = (0 as DIFile);
-static UNKNOWN_SCOPE_METADATA: DIScope = (0 as DIScope);
+const UNKNOWN_FILE_METADATA: DIFile = (0 as DIFile);
+const UNKNOWN_SCOPE_METADATA: DIScope = (0 as DIScope);
 
-static FLAGS_NONE: c_uint = 0;
+const FLAGS_NONE: c_uint = 0;
 
 //=-----------------------------------------------------------------------------
 //  Public Interface of debuginfo module

--- a/src/librustc_trans/trans/mod.rs
+++ b/src/librustc_trans/trans/mod.rs
@@ -60,6 +60,9 @@ pub struct ModuleTranslation {
     pub llmod: ModuleRef,
 }
 
+impl Send for ModuleTranslation { }
+impl Sync for ModuleTranslation { }
+
 pub struct CrateTranslation {
     pub modules: Vec<ModuleTranslation>,
     pub metadata_module: ModuleTranslation,

--- a/src/librustc_trans/trans/mod.rs
+++ b/src/librustc_trans/trans/mod.rs
@@ -60,8 +60,8 @@ pub struct ModuleTranslation {
     pub llmod: ModuleRef,
 }
 
-impl Send for ModuleTranslation { }
-impl Sync for ModuleTranslation { }
+unsafe impl Send for ModuleTranslation { }
+unsafe impl Sync for ModuleTranslation { }
 
 pub struct CrateTranslation {
     pub modules: Vec<ModuleTranslation>,

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -1460,7 +1460,7 @@ fn link_region<'a, 'tcx>(rcx: &Rcx<'a, 'tcx>,
             }
 
             mc::cat_downcast(cmt_base, _) |
-            mc::cat_deref(cmt_base, _, mc::OwnedPtr) |
+            mc::cat_deref(cmt_base, _, mc::UniquePtr) |
             mc::cat_interior(cmt_base, _) => {
                 // Borrowing interior or owned data requires the base
                 // to be valid and borrowable in the same fashion.
@@ -1684,7 +1684,7 @@ fn adjust_upvar_borrow_kind_for_mut<'a, 'tcx>(rcx: &Rcx<'a, 'tcx>,
                cmt.repr(rcx.tcx()));
 
         match cmt.cat.clone() {
-            mc::cat_deref(base, _, mc::OwnedPtr) |
+            mc::cat_deref(base, _, mc::UniquePtr) |
             mc::cat_interior(base, _) |
             mc::cat_downcast(base, _) => {
                 // Interior or owned data is mutable if base is
@@ -1731,7 +1731,7 @@ fn adjust_upvar_borrow_kind_for_unique<'a, 'tcx>(rcx: &Rcx<'a, 'tcx>, cmt: mc::c
                cmt.repr(rcx.tcx()));
 
         match cmt.cat.clone() {
-            mc::cat_deref(base, _, mc::OwnedPtr) |
+            mc::cat_deref(base, _, mc::UniquePtr) |
             mc::cat_interior(base, _) |
             mc::cat_downcast(base, _) => {
                 // Interior or owned data is unique if base is

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -1460,7 +1460,7 @@ fn link_region<'a, 'tcx>(rcx: &Rcx<'a, 'tcx>,
             }
 
             mc::cat_downcast(cmt_base, _) |
-            mc::cat_deref(cmt_base, _, mc::UniquePtr) |
+            mc::cat_deref(cmt_base, _, mc::Unique) |
             mc::cat_interior(cmt_base, _) => {
                 // Borrowing interior or owned data requires the base
                 // to be valid and borrowable in the same fashion.
@@ -1684,7 +1684,7 @@ fn adjust_upvar_borrow_kind_for_mut<'a, 'tcx>(rcx: &Rcx<'a, 'tcx>,
                cmt.repr(rcx.tcx()));
 
         match cmt.cat.clone() {
-            mc::cat_deref(base, _, mc::UniquePtr) |
+            mc::cat_deref(base, _, mc::Unique) |
             mc::cat_interior(base, _) |
             mc::cat_downcast(base, _) => {
                 // Interior or owned data is mutable if base is
@@ -1731,7 +1731,7 @@ fn adjust_upvar_borrow_kind_for_unique<'a, 'tcx>(rcx: &Rcx<'a, 'tcx>, cmt: mc::c
                cmt.repr(rcx.tcx()));
 
         match cmt.cat.clone() {
-            mc::cat_deref(base, _, mc::UniquePtr) |
+            mc::cat_deref(base, _, mc::Unique) |
             mc::cat_interior(base, _) |
             mc::cat_downcast(base, _) => {
                 // Interior or owned data is unique if base is

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -89,8 +89,8 @@ pub struct CString {
     owns_buffer_: bool,
 }
 
-impl Send for CString { }
-impl Sync for CString { }
+unsafe impl Send for CString { }
+unsafe impl Sync for CString { }
 
 impl Clone for CString {
     /// Clone this CString into a new, uniquely owned CString. For safety

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -72,13 +72,12 @@ use libc;
 
 use fmt;
 use hash;
-use kinds::marker;
 use mem;
 use ptr;
 use slice::{mod, ImmutableIntSlice};
 use str;
 use string::String;
-
+use core::kinds::marker;
 
 /// The representation of a C String.
 ///
@@ -89,6 +88,9 @@ pub struct CString {
     buf: *const libc::c_char,
     owns_buffer_: bool,
 }
+
+impl Send for CString { }
+impl Sync for CString { }
 
 impl Clone for CString {
     /// Clone this CString into a new, uniquely owned CString. For safety

--- a/src/libstd/c_vec.rs
+++ b/src/libstd/c_vec.rs
@@ -180,12 +180,12 @@ mod tests {
 
     fn malloc(n: uint) -> CVec<u8> {
         unsafe {
-            let mem = libc::malloc(n as libc::size_t);
-            if mem.is_null() { ::alloc::oom() }
+            let mem = ptr::Unique(libc::malloc(n as libc::size_t));
+            if mem.0.is_null() { ::alloc::oom() }
 
-            CVec::new_with_dtor(mem as *mut u8,
+            CVec::new_with_dtor(mem.0 as *mut u8,
                                 n,
-                                move|| { libc::free(mem as *mut libc::c_void); })
+                                move|| { libc::free(mem.0 as *mut libc::c_void); })
         }
     }
 

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -23,7 +23,7 @@ use num::{Int, UnsignedInt};
 use ops::{Deref, DerefMut, Drop};
 use option::Option;
 use option::Option::{Some, None};
-use ptr::{OwnedPtr, RawPtr, copy_nonoverlapping_memory, zero_memory};
+use ptr::{UniquePtr, RawPtr, copy_nonoverlapping_memory, zero_memory};
 use ptr;
 use rt::heap::{allocate, deallocate};
 
@@ -69,7 +69,7 @@ const EMPTY_BUCKET: u64 = 0u64;
 pub struct RawTable<K, V> {
     capacity: uint,
     size:     uint,
-    hashes:   OwnedPtr<u64>,
+    hashes:   UniquePtr<u64>,
     // Because K/V do not appear directly in any of the types in the struct,
     // inform rustc that in fact instances of K and V are reachable from here.
     marker:   marker::CovariantType<(K,V)>,
@@ -563,7 +563,7 @@ impl<K, V> RawTable<K, V> {
             return RawTable {
                 size: 0,
                 capacity: 0,
-                hashes: OwnedPtr::null(),
+                hashes: UniquePtr::null(),
                 marker: marker::CovariantType,
             };
         }
@@ -602,7 +602,7 @@ impl<K, V> RawTable<K, V> {
         RawTable {
             capacity: capacity,
             size:     0,
-            hashes:   OwnedPtr(hashes),
+            hashes:   UniquePtr(hashes),
             marker:   marker::CovariantType,
         }
     }

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -23,7 +23,7 @@ use num::{Int, UnsignedInt};
 use ops::{Deref, DerefMut, Drop};
 use option::Option;
 use option::Option::{Some, None};
-use ptr::{UniquePtr, RawPtr, copy_nonoverlapping_memory, zero_memory};
+use ptr::{Unique, RawPtr, copy_nonoverlapping_memory, zero_memory};
 use ptr;
 use rt::heap::{allocate, deallocate};
 
@@ -69,7 +69,7 @@ const EMPTY_BUCKET: u64 = 0u64;
 pub struct RawTable<K, V> {
     capacity: uint,
     size:     uint,
-    hashes:   UniquePtr<u64>,
+    hashes:   Unique<u64>,
     // Because K/V do not appear directly in any of the types in the struct,
     // inform rustc that in fact instances of K and V are reachable from here.
     marker:   marker::CovariantType<(K,V)>,
@@ -563,7 +563,7 @@ impl<K, V> RawTable<K, V> {
             return RawTable {
                 size: 0,
                 capacity: 0,
-                hashes: UniquePtr::null(),
+                hashes: Unique::null(),
                 marker: marker::CovariantType,
             };
         }
@@ -602,7 +602,7 @@ impl<K, V> RawTable<K, V> {
         RawTable {
             capacity: capacity,
             size:     0,
-            hashes:   UniquePtr(hashes),
+            hashes:   Unique(hashes),
             marker:   marker::CovariantType,
         }
     }

--- a/src/libstd/comm/blocking.rs
+++ b/src/libstd/comm/blocking.rs
@@ -17,6 +17,7 @@ use kinds::marker::{NoSend, NoSync};
 use mem;
 use clone::Clone;
 
+#[deriving(Send, Sync)]
 struct Inner {
     thread: Thread,
     woken: AtomicBool,

--- a/src/libstd/comm/blocking.rs
+++ b/src/libstd/comm/blocking.rs
@@ -13,15 +13,18 @@
 use thread::Thread;
 use sync::atomic::{AtomicBool, INIT_ATOMIC_BOOL, Ordering};
 use sync::Arc;
+use kinds::{Sync, Send};
 use kinds::marker::{NoSend, NoSync};
 use mem;
 use clone::Clone;
 
-#[deriving(Send, Sync)]
 struct Inner {
     thread: Thread,
     woken: AtomicBool,
 }
+
+unsafe impl Send for Inner {}
+unsafe impl Sync for Inner {}
 
 #[deriving(Clone)]
 pub struct SignalToken {

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -321,7 +321,7 @@ use self::Flavor::*;
 use alloc::arc::Arc;
 use core::kinds::marker;
 use core::mem;
-use core::cell::UnsafeCell;
+use core::cell::{UnsafeCell, RacyCell};
 
 pub use self::select::{Select, Handle};
 use self::select::StartResult;
@@ -359,9 +359,11 @@ mod spsc_queue;
 #[unstable]
 pub struct Receiver<T> {
     inner: UnsafeCell<Flavor<T>>,
-    // can't share in an arc
-    _marker: marker::NoSync,
 }
+
+// The receiver port can be sent from place to place, so long as it
+// is not used to receive non-sendable things.
+impl<T:Send> Send for Receiver<T> { }
 
 /// An iterator over messages on a receiver, this iterator will block
 /// whenever `next` is called, waiting for a new message, and `None` will be
@@ -376,15 +378,17 @@ pub struct Messages<'a, T:'a> {
 #[unstable]
 pub struct Sender<T> {
     inner: UnsafeCell<Flavor<T>>,
-    // can't share in an arc
-    _marker: marker::NoSync,
 }
+
+// The send port can be sent from place to place, so long as it
+// is not used to send non-sendable things.
+impl<T:Send> Send for Sender<T> { }
 
 /// The sending-half of Rust's synchronous channel type. This half can only be
 /// owned by one task, but it can be cloned to send to other tasks.
 #[unstable = "this type may be renamed, but it will always exist"]
 pub struct SyncSender<T> {
-    inner: Arc<UnsafeCell<sync::Packet<T>>>,
+    inner: Arc<RacyCell<sync::Packet<T>>>,
     // can't share in an arc
     _marker: marker::NoSync,
 }
@@ -420,10 +424,10 @@ pub enum TrySendError<T> {
 }
 
 enum Flavor<T> {
-    Oneshot(Arc<UnsafeCell<oneshot::Packet<T>>>),
-    Stream(Arc<UnsafeCell<stream::Packet<T>>>),
-    Shared(Arc<UnsafeCell<shared::Packet<T>>>),
-    Sync(Arc<UnsafeCell<sync::Packet<T>>>),
+    Oneshot(Arc<RacyCell<oneshot::Packet<T>>>),
+    Stream(Arc<RacyCell<stream::Packet<T>>>),
+    Shared(Arc<RacyCell<shared::Packet<T>>>),
+    Sync(Arc<RacyCell<sync::Packet<T>>>),
 }
 
 #[doc(hidden)]
@@ -474,7 +478,7 @@ impl<T> UnsafeFlavor<T> for Receiver<T> {
 /// ```
 #[unstable]
 pub fn channel<T: Send>() -> (Sender<T>, Receiver<T>) {
-    let a = Arc::new(UnsafeCell::new(oneshot::Packet::new()));
+    let a = Arc::new(RacyCell::new(oneshot::Packet::new()));
     (Sender::new(Oneshot(a.clone())), Receiver::new(Oneshot(a)))
 }
 
@@ -514,7 +518,7 @@ pub fn channel<T: Send>() -> (Sender<T>, Receiver<T>) {
 #[unstable = "this function may be renamed to more accurately reflect the type \
               of channel that is is creating"]
 pub fn sync_channel<T: Send>(bound: uint) -> (SyncSender<T>, Receiver<T>) {
-    let a = Arc::new(UnsafeCell::new(sync::Packet::new(bound)));
+    let a = Arc::new(RacyCell::new(sync::Packet::new(bound)));
     (SyncSender::new(a.clone()), Receiver::new(Sync(a)))
 }
 
@@ -526,7 +530,6 @@ impl<T: Send> Sender<T> {
     fn new(inner: Flavor<T>) -> Sender<T> {
         Sender {
             inner: UnsafeCell::new(inner),
-            _marker: marker::NoSync,
         }
     }
 
@@ -596,7 +599,8 @@ impl<T: Send> Sender<T> {
                     if !(*p).sent() {
                         return (*p).send(t);
                     } else {
-                        let a = Arc::new(UnsafeCell::new(stream::Packet::new()));
+                        let a =
+                            Arc::new(RacyCell::new(stream::Packet::new()));
                         match (*p).upgrade(Receiver::new(Stream(a.clone()))) {
                             oneshot::UpSuccess => {
                                 let ret = (*a.get()).send(t);
@@ -633,7 +637,7 @@ impl<T: Send> Clone for Sender<T> {
     fn clone(&self) -> Sender<T> {
         let (packet, sleeper, guard) = match *unsafe { self.inner() } {
             Oneshot(ref p) => {
-                let a = Arc::new(UnsafeCell::new(shared::Packet::new()));
+                let a = Arc::new(RacyCell::new(shared::Packet::new()));
                 unsafe {
                     let guard = (*a.get()).postinit_lock();
                     match (*p.get()).upgrade(Receiver::new(Shared(a.clone()))) {
@@ -644,7 +648,7 @@ impl<T: Send> Clone for Sender<T> {
                 }
             }
             Stream(ref p) => {
-                let a = Arc::new(UnsafeCell::new(shared::Packet::new()));
+                let a = Arc::new(RacyCell::new(shared::Packet::new()));
                 unsafe {
                     let guard = (*a.get()).postinit_lock();
                     match (*p.get()).upgrade(Receiver::new(Shared(a.clone()))) {
@@ -688,7 +692,7 @@ impl<T: Send> Drop for Sender<T> {
 ////////////////////////////////////////////////////////////////////////////////
 
 impl<T: Send> SyncSender<T> {
-    fn new(inner: Arc<UnsafeCell<sync::Packet<T>>>) -> SyncSender<T> {
+    fn new(inner: Arc<RacyCell<sync::Packet<T>>>) -> SyncSender<T> {
         SyncSender { inner: inner, _marker: marker::NoSync }
     }
 
@@ -777,7 +781,7 @@ impl<T: Send> Drop for SyncSender<T> {
 
 impl<T: Send> Receiver<T> {
     fn new(inner: Flavor<T>) -> Receiver<T> {
-        Receiver { inner: UnsafeCell::new(inner), _marker: marker::NoSync }
+        Receiver { inner: UnsafeCell::new(inner) }
     }
 
     /// Blocks waiting for a value on this receiver

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -1027,23 +1027,18 @@ impl<T: Send> Drop for Receiver<T> {
 
 /// A version of `UnsafeCell` intended for use in concurrent data
 /// structures (for example, you might put it in an `Arc`).
-pub struct RacyCell<T>(pub UnsafeCell<T>);
+struct RacyCell<T>(pub UnsafeCell<T>);
 
 impl<T> RacyCell<T> {
-    /// DOX
-    pub fn new(value: T) -> RacyCell<T> {
+
+    fn new(value: T) -> RacyCell<T> {
         RacyCell(UnsafeCell { value: value })
     }
 
-    /// DOX
-    pub unsafe fn get(&self) -> *mut T {
+    unsafe fn get(&self) -> *mut T {
         self.0.get()
     }
 
-    /// DOX
-    pub unsafe fn into_inner(self) -> T {
-        self.0.into_inner()
-    }
 }
 
 unsafe impl<T:Send> Send for RacyCell<T> { }

--- a/src/libstd/comm/mod.rs
+++ b/src/libstd/comm/mod.rs
@@ -363,7 +363,7 @@ pub struct Receiver<T> {
 
 // The receiver port can be sent from place to place, so long as it
 // is not used to receive non-sendable things.
-impl<T:Send> Send for Receiver<T> { }
+unsafe impl<T:Send> Send for Receiver<T> { }
 
 /// An iterator over messages on a receiver, this iterator will block
 /// whenever `next` is called, waiting for a new message, and `None` will be
@@ -382,7 +382,7 @@ pub struct Sender<T> {
 
 // The send port can be sent from place to place, so long as it
 // is not used to send non-sendable things.
-impl<T:Send> Send for Sender<T> { }
+unsafe impl<T:Send> Send for Sender<T> { }
 
 /// The sending-half of Rust's synchronous channel type. This half can only be
 /// owned by one task, but it can be cloned to send to other tasks.

--- a/src/libstd/comm/mpsc_queue.rs
+++ b/src/libstd/comm/mpsc_queue.rs
@@ -76,8 +76,8 @@ pub struct Queue<T> {
     tail: UnsafeCell<*mut Node<T>>,
 }
 
-impl<T:Send> Send for Queue<T> { }
-impl<T:Send> Sync for Queue<T> { }
+unsafe impl<T:Send> Send for Queue<T> { }
+unsafe impl<T:Send> Sync for Queue<T> { }
 
 impl<T> Node<T> {
     unsafe fn new(v: Option<T>) -> *mut Node<T> {

--- a/src/libstd/comm/mpsc_queue.rs
+++ b/src/libstd/comm/mpsc_queue.rs
@@ -76,6 +76,9 @@ pub struct Queue<T> {
     tail: UnsafeCell<*mut Node<T>>,
 }
 
+impl<T:Send> Send for Queue<T> { }
+impl<T:Send> Sync for Queue<T> { }
+
 impl<T> Node<T> {
     unsafe fn new(v: Option<T>) -> *mut Node<T> {
         mem::transmute(box Node {

--- a/src/libstd/comm/spsc_queue.rs
+++ b/src/libstd/comm/spsc_queue.rs
@@ -73,6 +73,10 @@ pub struct Queue<T> {
     cache_subtractions: AtomicUint,
 }
 
+impl<T: Send> Send for Queue<T> { }
+
+impl<T: Send> Sync for Queue<T> { }
+
 impl<T: Send> Node<T> {
     fn new() -> *mut Node<T> {
         unsafe {

--- a/src/libstd/comm/spsc_queue.rs
+++ b/src/libstd/comm/spsc_queue.rs
@@ -73,9 +73,9 @@ pub struct Queue<T> {
     cache_subtractions: AtomicUint,
 }
 
-impl<T: Send> Send for Queue<T> { }
+unsafe impl<T: Send> Send for Queue<T> { }
 
-impl<T: Send> Sync for Queue<T> { }
+unsafe impl<T: Send> Sync for Queue<T> { }
 
 impl<T: Send> Node<T> {
     fn new() -> *mut Node<T> {

--- a/src/libstd/comm/sync.rs
+++ b/src/libstd/comm/sync.rs
@@ -53,11 +53,10 @@ pub struct Packet<T> {
     lock: Mutex<State<T>>,
 }
 
-impl<T:Send> Send for Packet<T> { }
+unsafe impl<T:Send> Send for Packet<T> { }
 
-impl<T:Send> Sync for Packet<T> { }
+unsafe impl<T:Send> Sync for Packet<T> { }
 
-#[deriving(Send)]
 struct State<T> {
     disconnected: bool, // Is the channel disconnected yet?
     queue: Queue,       // queue of senders waiting to send data
@@ -73,6 +72,8 @@ struct State<T> {
     /// value.
     canceled: Option<&'static mut bool>,
 }
+
+unsafe impl<T: Send> Send for State<T> {}
 
 /// Possible flavors of threads who can be blocked on this channel.
 enum Blocker {
@@ -93,7 +94,7 @@ struct Node {
     next: *mut Node,
 }
 
-impl Send for Node {}
+unsafe impl Send for Node {}
 
 /// A simple ring-buffer
 struct Buffer<T> {

--- a/src/libstd/comm/sync.rs
+++ b/src/libstd/comm/sync.rs
@@ -53,6 +53,11 @@ pub struct Packet<T> {
     lock: Mutex<State<T>>,
 }
 
+impl<T:Send> Send for Packet<T> { }
+
+impl<T:Send> Sync for Packet<T> { }
+
+#[deriving(Send)]
 struct State<T> {
     disconnected: bool, // Is the channel disconnected yet?
     queue: Queue,       // queue of senders waiting to send data
@@ -87,6 +92,8 @@ struct Node {
     token: Option<SignalToken>,
     next: *mut Node,
 }
+
+impl Send for Node {}
 
 /// A simple ring-buffer
 struct Buffer<T> {

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -22,6 +22,7 @@ use result::Result::{Ok, Err};
 use slice::{SliceExt};
 use slice;
 use vec::Vec;
+use kinds::{Send,Sync};
 
 /// Wraps a Reader and buffers input from it
 ///
@@ -50,6 +51,11 @@ pub struct BufferedReader<R> {
     pos: uint,
     cap: uint,
 }
+
+
+unsafe impl<R: Send> Send for BufferedReader<R> {}
+unsafe impl<R: Send+Sync> Sync for BufferedReader<R> {}
+
 
 impl<R: Reader> BufferedReader<R> {
     /// Creates a new `BufferedReader` with the specified buffer capacity

--- a/src/libstd/rt/exclusive.rs
+++ b/src/libstd/rt/exclusive.rs
@@ -26,9 +26,9 @@ pub struct Exclusive<T> {
     data: UnsafeCell<T>,
 }
 
-impl<T:Send> Send for Exclusive<T> { }
+unsafe impl<T:Send> Send for Exclusive<T> { }
 
-impl<T:Send> Sync for Exclusive<T> { }
+unsafe impl<T:Send> Sync for Exclusive<T> { }
 
 /// An RAII guard returned via `lock`
 pub struct ExclusiveGuard<'a, T:'a> {

--- a/src/libstd/rt/exclusive.rs
+++ b/src/libstd/rt/exclusive.rs
@@ -26,6 +26,10 @@ pub struct Exclusive<T> {
     data: UnsafeCell<T>,
 }
 
+impl<T:Send> Send for Exclusive<T> { }
+
+impl<T:Send> Sync for Exclusive<T> { }
+
 /// An RAII guard returned via `lock`
 pub struct ExclusiveGuard<'a, T:'a> {
     // FIXME #12808: strange name to try to avoid interfering with

--- a/src/libstd/sync/barrier.rs
+++ b/src/libstd/sync/barrier.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use kinds::{Send, Sync};
 use sync::{Mutex, Condvar};
 
 /// A barrier enables multiple tasks to synchronize the beginning
@@ -35,11 +36,17 @@ pub struct Barrier {
     num_threads: uint,
 }
 
+unsafe impl Send for Barrier {}
+unsafe impl Sync for Barrier {}
+
 // The inner state of a double barrier
 struct BarrierState {
     count: uint,
     generation_id: uint,
 }
+
+unsafe impl Send for BarrierState {}
+unsafe impl Sync for BarrierState {}
 
 impl Barrier {
     /// Create a new barrier that can block a given number of threads.

--- a/src/libstd/sync/condvar.rs
+++ b/src/libstd/sync/condvar.rs
@@ -58,6 +58,9 @@ use time::Duration;
 /// ```
 pub struct Condvar { inner: Box<StaticCondvar> }
 
+unsafe impl Send for Condvar {}
+unsafe impl Sync for Condvar {}
+
 /// Statically allocated condition variables.
 ///
 /// This structure is identical to `Condvar` except that it is suitable for use
@@ -74,6 +77,9 @@ pub struct StaticCondvar {
     inner: sys::Condvar,
     mutex: AtomicUint,
 }
+
+unsafe impl Send for StaticCondvar {}
+unsafe impl Sync for StaticCondvar {}
 
 /// Constant initializer for a statically allocated condition variable.
 pub const CONDVAR_INIT: StaticCondvar = StaticCondvar {

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -11,7 +11,7 @@
 use prelude::*;
 
 use cell::{UnsafeCell, RacyCell};
-use kinds::marker;
+use kinds::{marker, Sync};
 use sync::{poison, AsMutexGuard};
 use sys_common::mutex as sys;
 
@@ -73,9 +73,9 @@ pub struct Mutex<T> {
     data: RacyCell<T>,
 }
 
-impl<T:Send> Send for Mutex<T> { }
+unsafe impl<T:Send> Send for Mutex<T> { }
 
-impl<T:Send> Sync for Mutex<T> { }
+unsafe impl<T:Send> Sync for Mutex<T> { }
 
 /// The static mutex type is provided to allow for static allocation of mutexes.
 ///
@@ -98,11 +98,12 @@ impl<T:Send> Sync for Mutex<T> { }
 /// }
 /// // lock is unlocked here.
 /// ```
-#[deriving(Sync)]
 pub struct StaticMutex {
     lock: sys::Mutex,
     poison: RacyCell<poison::Flag>,
 }
+
+unsafe impl Sync for StaticMutex {}
 
 /// An RAII implementation of a "scoped lock" of a mutex. When this structure is
 /// dropped (falls out of scope), the lock will be unlocked.

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -10,8 +10,9 @@
 
 use prelude::*;
 
-use cell::{UnsafeCell, RacyCell};
-use kinds::{marker, Sync};
+use comm::RacyCell;
+use cell::UnsafeCell;
+use kinds::marker;
 use sync::{poison, AsMutexGuard};
 use sys_common::mutex as sys;
 

--- a/src/libstd/sync/once.rs
+++ b/src/libstd/sync/once.rs
@@ -14,6 +14,7 @@
 //! example use case would be for initializing an FFI library.
 
 use int;
+use kinds::Sync;
 use mem::drop;
 use ops::FnOnce;
 use sync::atomic;
@@ -35,12 +36,13 @@ use sync::{StaticMutex, MUTEX_INIT};
 ///     // run initialization here
 /// });
 /// ```
-#[deriving(Sync)]
 pub struct Once {
     mutex: StaticMutex,
     cnt: atomic::AtomicInt,
     lock_cnt: atomic::AtomicInt,
 }
+
+unsafe impl Sync for Once {}
 
 /// Initialization value for static `Once` values.
 pub const ONCE_INIT: Once = Once {

--- a/src/libstd/sync/once.rs
+++ b/src/libstd/sync/once.rs
@@ -35,6 +35,7 @@ use sync::{StaticMutex, MUTEX_INIT};
 ///     // run initialization here
 /// });
 /// ```
+#[deriving(Sync)]
 pub struct Once {
     mutex: StaticMutex,
     cnt: atomic::AtomicInt,

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -60,6 +60,9 @@ pub struct RWLock<T> {
     data: UnsafeCell<T>,
 }
 
+unsafe impl<T:'static+Send> Send for RWLock<T> {}
+unsafe impl<T> Sync for RWLock<T> {}
+
 /// Structure representing a statically allocated RWLock.
 ///
 /// This structure is intended to be used inside of a `static` and will provide
@@ -87,6 +90,9 @@ pub struct StaticRWLock {
     inner: sys::RWLock,
     poison: UnsafeCell<poison::Flag>,
 }
+
+unsafe impl Send for StaticRWLock {}
+unsafe impl Sync for StaticRWLock {}
 
 /// Constant initialization for a statically-initialized rwlock.
 pub const RWLOCK_INIT: StaticRWLock = StaticRWLock {

--- a/src/libstd/sys/common/helper_thread.rs
+++ b/src/libstd/sys/common/helper_thread.rs
@@ -59,6 +59,10 @@ pub struct Helper<M> {
     pub shutdown: UnsafeCell<bool>,
 }
 
+impl<M:Send> Send for Helper<M> { }
+
+impl<M:Send> Sync for Helper<M> { }
+
 impl<M: Send> Helper<M> {
     /// Lazily boots a helper thread, becoming a no-op if the helper has already
     /// been spawned.

--- a/src/libstd/sys/common/helper_thread.rs
+++ b/src/libstd/sys/common/helper_thread.rs
@@ -59,9 +59,9 @@ pub struct Helper<M> {
     pub shutdown: UnsafeCell<bool>,
 }
 
-impl<M:Send> Send for Helper<M> { }
+unsafe impl<M:Send> Send for Helper<M> { }
 
-impl<M:Send> Sync for Helper<M> { }
+unsafe impl<M:Send> Sync for Helper<M> { }
 
 impl<M: Send> Helper<M> {
     /// Lazily boots a helper thread, becoming a no-op if the helper has already

--- a/src/libstd/sys/common/helper_thread.rs
+++ b/src/libstd/sys/common/helper_thread.rs
@@ -63,6 +63,11 @@ unsafe impl<M:Send> Send for Helper<M> { }
 
 unsafe impl<M:Send> Sync for Helper<M> { }
 
+struct RaceBox(helper_signal::signal);
+
+unsafe impl Send for RaceBox {}
+unsafe impl Sync for RaceBox {}
+
 impl<M: Send> Helper<M> {
     /// Lazily boots a helper thread, becoming a no-op if the helper has already
     /// been spawned.
@@ -85,9 +90,11 @@ impl<M: Send> Helper<M> {
                 let (receive, send) = helper_signal::new();
                 *self.signal.get() = send as uint;
 
+                let receive = RaceBox(receive);
+
                 let t = f();
                 Thread::spawn(move |:| {
-                    helper(receive, rx, t);
+                    helper(receive.0, rx, t);
                     let _g = self.lock.lock();
                     *self.shutdown.get() = true;
                     self.cond.notify_one()

--- a/src/libstd/sys/common/mutex.rs
+++ b/src/libstd/sys/common/mutex.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use kinds::Sync;
 use sys::mutex as imp;
 
 /// An OS-based mutual exclusion lock.
@@ -15,8 +16,9 @@ use sys::mutex as imp;
 /// This is the thinnest cross-platform wrapper around OS mutexes. All usage of
 /// this mutex is unsafe and it is recommended to instead use the safe wrapper
 /// at the top level of the crate instead of this type.
-#[deriving(Sync)]
 pub struct Mutex(imp::Mutex);
+
+unsafe impl Sync for Mutex {}
 
 /// Constant initializer for statically allocated mutexes.
 pub const MUTEX_INIT: Mutex = Mutex(imp::MUTEX_INIT);

--- a/src/libstd/sys/common/mutex.rs
+++ b/src/libstd/sys/common/mutex.rs
@@ -15,6 +15,7 @@ use sys::mutex as imp;
 /// This is the thinnest cross-platform wrapper around OS mutexes. All usage of
 /// this mutex is unsafe and it is recommended to instead use the safe wrapper
 /// at the top level of the crate instead of this type.
+#[deriving(Sync)]
 pub struct Mutex(imp::Mutex);
 
 /// Constant initializer for statically allocated mutexes.

--- a/src/libstd/sys/unix/c.rs
+++ b/src/libstd/sys/unix/c.rs
@@ -162,8 +162,8 @@ mod signal {
         sa_restorer: *mut libc::c_void,
     }
 
-    impl ::kinds::Send for sigaction { }
-    impl ::kinds::Sync for sigaction { }
+    unsafe impl ::kinds::Send for sigaction { }
+    unsafe impl ::kinds::Sync for sigaction { }
 
     #[repr(C)]
     #[cfg(target_word_size = "32")]

--- a/src/libstd/sys/unix/c.rs
+++ b/src/libstd/sys/unix/c.rs
@@ -162,6 +162,9 @@ mod signal {
         sa_restorer: *mut libc::c_void,
     }
 
+    impl ::kinds::Send for sigaction { }
+    impl ::kinds::Sync for sigaction { }
+
     #[repr(C)]
     #[cfg(target_word_size = "32")]
     pub struct sigset_t {
@@ -210,6 +213,9 @@ mod signal {
         sa_restorer: *mut libc::c_void,
         sa_resv: [libc::c_int, ..1],
     }
+
+    impl ::kinds::Send for sigaction { }
+    impl ::kinds::Sync for sigaction { }
 
     #[repr(C)]
     pub struct sigset_t {

--- a/src/libstd/sys/unix/mutex.rs
+++ b/src/libstd/sys/unix/mutex.rs
@@ -8,13 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use comm::RacyCell;
 use cell::UnsafeCell;
 use kinds::Sync;
 use sys::sync as ffi;
 use sys_common::mutex;
 
-pub struct Mutex { inner: RacyCell<ffi::pthread_mutex_t> }
+pub struct Mutex { inner: UnsafeCell<ffi::pthread_mutex_t> }
 
 #[inline]
 pub unsafe fn raw(m: &Mutex) -> *mut ffi::pthread_mutex_t {
@@ -22,7 +21,7 @@ pub unsafe fn raw(m: &Mutex) -> *mut ffi::pthread_mutex_t {
 }
 
 pub const MUTEX_INIT: Mutex = Mutex {
-    inner: RacyCell(UnsafeCell { value: ffi::PTHREAD_MUTEX_INITIALIZER }),
+    inner: UnsafeCell { value: ffi::PTHREAD_MUTEX_INITIALIZER },
 };
 
 unsafe impl Sync for Mutex {}

--- a/src/libstd/sys/unix/mutex.rs
+++ b/src/libstd/sys/unix/mutex.rs
@@ -8,11 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use cell::UnsafeCell;
+use cell::{UnsafeCell, RacyCell};
 use sys::sync as ffi;
 use sys_common::mutex;
 
-pub struct Mutex { inner: UnsafeCell<ffi::pthread_mutex_t> }
+#[deriving(Sync)]
+pub struct Mutex { inner: RacyCell<ffi::pthread_mutex_t> }
 
 #[inline]
 pub unsafe fn raw(m: &Mutex) -> *mut ffi::pthread_mutex_t {
@@ -20,7 +21,7 @@ pub unsafe fn raw(m: &Mutex) -> *mut ffi::pthread_mutex_t {
 }
 
 pub const MUTEX_INIT: Mutex = Mutex {
-    inner: UnsafeCell { value: ffi::PTHREAD_MUTEX_INITIALIZER },
+    inner: RacyCell(UnsafeCell { value: ffi::PTHREAD_MUTEX_INITIALIZER }),
 };
 
 impl Mutex {

--- a/src/libstd/sys/unix/mutex.rs
+++ b/src/libstd/sys/unix/mutex.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use kinds::Sync;
 use cell::{UnsafeCell, RacyCell};
 use sys::sync as ffi;
 use sys_common::mutex;
 
-#[deriving(Sync)]
 pub struct Mutex { inner: RacyCell<ffi::pthread_mutex_t> }
 
 #[inline]
@@ -23,6 +23,8 @@ pub unsafe fn raw(m: &Mutex) -> *mut ffi::pthread_mutex_t {
 pub const MUTEX_INIT: Mutex = Mutex {
     inner: RacyCell(UnsafeCell { value: ffi::PTHREAD_MUTEX_INITIALIZER }),
 };
+
+unsafe impl Sync for Mutex {}
 
 impl Mutex {
     #[inline]

--- a/src/libstd/sys/unix/mutex.rs
+++ b/src/libstd/sys/unix/mutex.rs
@@ -8,8 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use comm::RacyCell;
+use cell::UnsafeCell;
 use kinds::Sync;
-use cell::{UnsafeCell, RacyCell};
 use sys::sync as ffi;
 use sys_common::mutex;
 

--- a/src/libstd/sys/unix/pipe.rs
+++ b/src/libstd/sys/unix/pipe.rs
@@ -210,6 +210,7 @@ impl Clone for UnixStream {
 // Unix Listener
 ////////////////////////////////////////////////////////////////////////////////
 
+#[deriving(Sync)]
 pub struct UnixListener {
     inner: Inner,
     path: CString,
@@ -252,6 +253,7 @@ pub struct UnixAcceptor {
     deadline: u64,
 }
 
+#[deriving(Sync)]
 struct AcceptorInner {
     listener: UnixListener,
     reader: FileDesc,

--- a/src/libstd/sys/unix/pipe.rs
+++ b/src/libstd/sys/unix/pipe.rs
@@ -210,11 +210,12 @@ impl Clone for UnixStream {
 // Unix Listener
 ////////////////////////////////////////////////////////////////////////////////
 
-#[deriving(Sync)]
 pub struct UnixListener {
     inner: Inner,
     path: CString,
 }
+
+unsafe impl Sync for UnixListener {}
 
 impl UnixListener {
     pub fn bind(addr: &CString) -> IoResult<UnixListener> {
@@ -253,13 +254,14 @@ pub struct UnixAcceptor {
     deadline: u64,
 }
 
-#[deriving(Sync)]
 struct AcceptorInner {
     listener: UnixListener,
     reader: FileDesc,
     writer: FileDesc,
     closed: atomic::AtomicBool,
 }
+
+unsafe impl Sync for AcceptorInner {}
 
 impl UnixAcceptor {
     pub fn fd(&self) -> fd_t { self.inner.listener.fd() }

--- a/src/libstd/sys/unix/pipe.rs
+++ b/src/libstd/sys/unix/pipe.rs
@@ -117,6 +117,9 @@ pub struct UnixStream {
     write_deadline: u64,
 }
 
+unsafe impl Send for UnixStream {}
+unsafe impl Sync for UnixStream {}
+
 impl UnixStream {
     pub fn connect(addr: &CString,
                    timeout: Option<u64>) -> IoResult<UnixStream> {
@@ -215,6 +218,7 @@ pub struct UnixListener {
     path: CString,
 }
 
+unsafe impl Send for UnixListener {}
 unsafe impl Sync for UnixListener {}
 
 impl UnixListener {
@@ -261,6 +265,7 @@ struct AcceptorInner {
     closed: atomic::AtomicBool,
 }
 
+unsafe impl Send for AcceptorInner {}
 unsafe impl Sync for AcceptorInner {}
 
 impl UnixAcceptor {

--- a/src/libstd/sys/unix/stack_overflow.rs
+++ b/src/libstd/sys/unix/stack_overflow.rs
@@ -160,7 +160,7 @@ mod imp {
 
         pub static SIGSTKSZ: libc::size_t = 8192;
 
-        pub static SIG_DFL: sighandler_t = 0i as sighandler_t;
+        pub const SIG_DFL: sighandler_t = 0i as sighandler_t;
 
         // This definition is not as accurate as it could be, {si_addr} is
         // actually a giant union. Currently we're only interested in that field,

--- a/src/libstd/sys/unix/tcp.rs
+++ b/src/libstd/sys/unix/tcp.rs
@@ -29,10 +29,11 @@ pub use sys_common::net::TcpStream;
 // TCP listeners
 ////////////////////////////////////////////////////////////////////////////////
 
-#[deriving(Sync)]
 pub struct TcpListener {
     pub inner: FileDesc,
 }
+
+unsafe impl Sync for TcpListener {}
 
 impl TcpListener {
     pub fn bind(addr: ip::SocketAddr) -> IoResult<TcpListener> {
@@ -90,13 +91,14 @@ pub struct TcpAcceptor {
     deadline: u64,
 }
 
-#[deriving(Sync)]
 struct AcceptorInner {
     listener: TcpListener,
     reader: FileDesc,
     writer: FileDesc,
     closed: atomic::AtomicBool,
 }
+
+unsafe impl Sync for AcceptorInner {}
 
 impl TcpAcceptor {
     pub fn fd(&self) -> sock_t { self.inner.listener.fd() }

--- a/src/libstd/sys/unix/tcp.rs
+++ b/src/libstd/sys/unix/tcp.rs
@@ -29,6 +29,7 @@ pub use sys_common::net::TcpStream;
 // TCP listeners
 ////////////////////////////////////////////////////////////////////////////////
 
+#[deriving(Sync)]
 pub struct TcpListener {
     pub inner: FileDesc,
 }
@@ -89,6 +90,7 @@ pub struct TcpAcceptor {
     deadline: u64,
 }
 
+#[deriving(Sync)]
 struct AcceptorInner {
     listener: TcpListener,
     reader: FileDesc,

--- a/src/libstd/sys/windows/mutex.rs
+++ b/src/libstd/sys/windows/mutex.rs
@@ -22,6 +22,8 @@ pub struct Mutex { inner: atomic::AtomicUint }
 
 pub const MUTEX_INIT: Mutex = Mutex { inner: atomic::INIT_ATOMIC_UINT };
 
+unsafe impl Sync for Mutex {}
+
 #[inline]
 pub unsafe fn raw(m: &Mutex) -> ffi::LPCRITICAL_SECTION {
     m.get()

--- a/src/libstd/sys/windows/pipe.rs
+++ b/src/libstd/sys/windows/pipe.rs
@@ -559,6 +559,8 @@ pub struct UnixListener {
     name: CString,
 }
 
+unsafe impl Sync for UnixListener {}
+
 impl UnixListener {
     pub fn bind(addr: &CString) -> IoResult<UnixListener> {
         // Although we technically don't need the pipe until much later, we
@@ -603,10 +605,14 @@ pub struct UnixAcceptor {
     deadline: u64,
 }
 
+unsafe impl Sync for UnixAcceptor {}
+
 struct AcceptorState {
     abort: Event,
     closed: atomic::AtomicBool,
 }
+
+unsafe impl Sync for AcceptorState {}
 
 impl UnixAcceptor {
     pub fn accept(&mut self) -> IoResult<UnixStream> {

--- a/src/libstd/sys/windows/pipe.rs
+++ b/src/libstd/sys/windows/pipe.rs
@@ -214,6 +214,9 @@ pub struct UnixStream {
     write_deadline: u64,
 }
 
+unsafe impl Send for UnixStream {}
+unsafe impl Sync for UnixStream {}
+
 impl UnixStream {
     fn try_connect(p: *const u16) -> Option<libc::HANDLE> {
         // Note that most of this is lifted from the libuv implementation.
@@ -559,6 +562,7 @@ pub struct UnixListener {
     name: CString,
 }
 
+unsafe impl Send for UnixListener {}
 unsafe impl Sync for UnixListener {}
 
 impl UnixListener {
@@ -605,6 +609,7 @@ pub struct UnixAcceptor {
     deadline: u64,
 }
 
+unsafe impl Send for UnixAcceptor {}
 unsafe impl Sync for UnixAcceptor {}
 
 struct AcceptorState {
@@ -612,6 +617,7 @@ struct AcceptorState {
     closed: atomic::AtomicBool,
 }
 
+unsafe impl Send for AcceptorState {}
 unsafe impl Sync for AcceptorState {}
 
 impl UnixAcceptor {

--- a/src/libstd/sys/windows/tcp.rs
+++ b/src/libstd/sys/windows/tcp.rs
@@ -24,6 +24,9 @@ pub use sys_common::net::TcpStream;
 
 pub struct Event(c::WSAEVENT);
 
+unsafe impl Send for Event {}
+unsafe impl Sync for Event {}
+
 impl Event {
     pub fn new() -> IoResult<Event> {
         let event = unsafe { c::WSACreateEvent() };
@@ -48,6 +51,9 @@ impl Drop for Event {
 ////////////////////////////////////////////////////////////////////////////////
 
 pub struct TcpListener { sock: sock_t }
+
+unsafe impl Send for TcpListener {}
+unsafe impl Sync for TcpListener {}
 
 impl TcpListener {
     pub fn bind(addr: ip::SocketAddr) -> IoResult<TcpListener> {
@@ -109,12 +115,18 @@ pub struct TcpAcceptor {
     deadline: u64,
 }
 
+unsafe impl Send for TcpAcceptor {}
+unsafe impl Sync for TcpAcceptor {}
+
 struct AcceptorInner {
     listener: TcpListener,
     abort: Event,
     accept: Event,
     closed: atomic::AtomicBool,
 }
+
+unsafe impl Send for AcceptorInner {}
+unsafe impl Sync for AcceptorInner {}
 
 impl TcpAcceptor {
     pub fn socket(&self) -> sock_t { self.inner.listener.socket() }

--- a/src/libstd/sys/windows/timer.rs
+++ b/src/libstd/sys/windows/timer.rs
@@ -48,6 +48,9 @@ pub enum Req {
     RemoveTimer(libc::HANDLE, Sender<()>),
 }
 
+unsafe impl Send for Req {}
+
+
 fn helper(input: libc::HANDLE, messages: Receiver<Req>, _: ()) {
     let mut objs = vec![input];
     let mut chans = vec![];

--- a/src/libstd/thread.rs
+++ b/src/libstd/thread.rs
@@ -127,7 +127,7 @@
 use any::Any;
 use borrow::IntoCow;
 use boxed::Box;
-use cell::RacyCell;
+use comm::RacyCell;
 use clone::Clone;
 use kinds::{Send, Sync};
 use ops::{Drop, FnOnce};

--- a/src/libstd/thread.rs
+++ b/src/libstd/thread.rs
@@ -283,18 +283,21 @@ impl Builder {
     }
 }
 
-#[deriving(Sync)]
 struct Inner {
     name: Option<String>,
     lock: Mutex<bool>,          // true when there is a buffered unpark
     cvar: Condvar,
 }
 
-#[deriving(Clone, Sync)]
+unsafe impl Sync for Inner {}
+
+#[deriving(Clone)]
 /// A handle to a thread.
 pub struct Thread {
     inner: Arc<Inner>,
 }
+
+unsafe impl Sync for Thread {}
 
 impl Thread {
     // Used only internally to construct a thread object without spawning

--- a/src/libstd/thread_local/mod.rs
+++ b/src/libstd/thread_local/mod.rs
@@ -280,6 +280,8 @@ mod imp {
         pub dtor_running: UnsafeCell<bool>, // should be Cell
     }
 
+    impl<T> ::kinds::Sync for Key<T> { }
+
     #[doc(hidden)]
     impl<T> Key<T> {
         pub unsafe fn get(&'static self) -> Option<&'static T> {
@@ -409,6 +411,8 @@ mod imp {
         // OS-TLS key that we'll use to key off.
         pub os: OsStaticKey,
     }
+
+    impl<T> ::kinds::Sync for Key<T> { }
 
     struct Value<T: 'static> {
         key: &'static Key<T>,

--- a/src/libstd/thread_local/mod.rs
+++ b/src/libstd/thread_local/mod.rs
@@ -280,7 +280,7 @@ mod imp {
         pub dtor_running: UnsafeCell<bool>, // should be Cell
     }
 
-    impl<T> ::kinds::Sync for Key<T> { }
+    unsafe impl<T> ::kinds::Sync for Key<T> { }
 
     #[doc(hidden)]
     impl<T> Key<T> {
@@ -412,7 +412,7 @@ mod imp {
         pub os: OsStaticKey,
     }
 
-    impl<T> ::kinds::Sync for Key<T> { }
+    unsafe impl<T> ::kinds::Sync for Key<T> { }
 
     struct Value<T: 'static> {
         key: &'static Key<T>,

--- a/src/libstd/thread_local/scoped.rs
+++ b/src/libstd/thread_local/scoped.rs
@@ -196,10 +196,10 @@ impl<T> Key<T> {
 
 #[cfg(not(any(windows, target_os = "android", target_os = "ios")))]
 mod imp {
-    use std::comm::RacyCell;
+    use std::cell::UnsafeCell;
 
     #[doc(hidden)]
-    pub struct KeyInner<T> { pub inner: RacyCell<*mut T> }
+    pub struct KeyInner<T> { pub inner: UnsafeCell<*mut T> }
 
     unsafe impl<T> ::kinds::Sync for KeyInner<T> { }
 

--- a/src/libstd/thread_local/scoped.rs
+++ b/src/libstd/thread_local/scoped.rs
@@ -202,7 +202,7 @@ mod imp {
     #[doc(hidden)]
     pub struct KeyInner<T> { pub inner: UnsafeCell<*mut T> }
 
-    #[cfg(not(stage0))] impl<T> ::kinds::Sync for KeyInner<T> { }
+    unsafe impl<T> ::kinds::Sync for KeyInner<T> { }
 
     #[doc(hidden)]
     impl<T> KeyInner<T> {
@@ -224,7 +224,7 @@ mod imp {
         pub marker: marker::InvariantType<T>,
     }
 
-    #[cfg(not(stage0))] impl<T> ::kinds::Sync for KeyInner<T> { }
+    unsafe impl<T> ::kinds::Sync for KeyInner<T> { }
 
     #[doc(hidden)]
     impl<T> KeyInner<T> {

--- a/src/libstd/thread_local/scoped.rs
+++ b/src/libstd/thread_local/scoped.rs
@@ -196,11 +196,10 @@ impl<T> Key<T> {
 
 #[cfg(not(any(windows, target_os = "android", target_os = "ios")))]
 mod imp {
-    use std::cell::UnsafeCell;
+    use std::comm::RacyCell;
 
-    // SNAP c9f6d69 switch to `Cell`
     #[doc(hidden)]
-    pub struct KeyInner<T> { pub inner: UnsafeCell<*mut T> }
+    pub struct KeyInner<T> { pub inner: RacyCell<*mut T> }
 
     unsafe impl<T> ::kinds::Sync for KeyInner<T> { }
 

--- a/src/libstd/thread_local/scoped.rs
+++ b/src/libstd/thread_local/scoped.rs
@@ -198,9 +198,11 @@ impl<T> Key<T> {
 mod imp {
     use std::cell::UnsafeCell;
 
-    // FIXME: Should be a `Cell`, but that's not `Sync`
+    // SNAP c9f6d69 switch to `Cell`
     #[doc(hidden)]
     pub struct KeyInner<T> { pub inner: UnsafeCell<*mut T> }
+
+    #[cfg(not(stage0))] impl<T> ::kinds::Sync for KeyInner<T> { }
 
     #[doc(hidden)]
     impl<T> KeyInner<T> {
@@ -221,6 +223,8 @@ mod imp {
         pub inner: OsStaticKey,
         pub marker: marker::InvariantType<T>,
     }
+
+    #[cfg(not(stage0))] impl<T> ::kinds::Sync for KeyInner<T> { }
 
     #[doc(hidden)]
     impl<T> KeyInner<T> {

--- a/src/libsyntax/ext/deriving/bounds.rs
+++ b/src/libsyntax/ext/deriving/bounds.rs
@@ -26,8 +26,11 @@ pub fn expand_deriving_bound<F>(cx: &mut ExtCtxt,
         MetaWord(ref tname) => {
             match tname.get() {
                 "Copy" => "Copy",
-                "Send" => "Send",
-                "Sync" => "Sync",
+                "Send" | "Sync" => {
+                    return cx.span_err(span,
+                                       format!("{} is an unsafe trait and it \
+                                               should be implemented explicitly", *tname)[])
+                }
                 ref tname => {
                     cx.span_bug(span,
                                 format!("expected built-in trait name but \

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -976,6 +976,8 @@ enum TestEvent {
 
 pub type MonitorMsg = (TestDesc, TestResult, Vec<u8> );
 
+impl Send for MonitorMsg {}
+
 fn run_tests<F>(opts: &TestOpts,
                 tests: Vec<TestDescAndFn> ,
                 mut callback: F) -> io::IoResult<()> where

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -976,7 +976,7 @@ enum TestEvent {
 
 pub type MonitorMsg = (TestDesc, TestResult, Vec<u8> );
 
-impl Send for MonitorMsg {}
+unsafe impl Send for MonitorMsg {}
 
 fn run_tests<F>(opts: &TestOpts,
                 tests: Vec<TestDescAndFn> ,

--- a/src/test/compile-fail/deriving-bounds.rs
+++ b/src/test/compile-fail/deriving-bounds.rs
@@ -8,8 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Sync(Bad),Send,Copy)]
+#[deriving(Copy(Bad))]
 //~^ ERROR unexpected value in deriving, expected a trait
 struct Test;
+
+#[deriving(Sync)]
+//~^ ERROR Sync is an unsafe trait and it should be implemented explicitly
+struct Test1;
 
 pub fn main() {}

--- a/src/test/compile-fail/issue-17718-static-sync.rs
+++ b/src/test/compile-fail/issue-17718-static-sync.rs
@@ -14,6 +14,6 @@ struct Foo { marker: marker::NoSync }
 
 static FOO: uint = 3;
 static BAR: Foo = Foo { marker: marker::NoSync };
-//~^ ERROR: shared static items must have a type which implements Sync
+//~^ ERROR: the trait `core::kinds::Sync` is not implemented
 
 fn main() {}

--- a/src/test/compile-fail/issue-7013.rs
+++ b/src/test/compile-fail/issue-7013.rs
@@ -33,4 +33,5 @@ struct A {
 fn main() {
     let a = A {v: box B{v: None} as Box<Foo+Send>};
     //~^ ERROR the trait `core::kinds::Send` is not implemented
+    //~^^ ERROR the trait `core::kinds::Send` is not implemented
 }

--- a/src/test/compile-fail/issue-7364.rs
+++ b/src/test/compile-fail/issue-7364.rs
@@ -14,6 +14,8 @@ use std::cell::RefCell;
 // Regresion test for issue 7364
 static boxed: Box<RefCell<int>> = box RefCell::new(0);
 //~^ ERROR statics are not allowed to have custom pointers
-//~^^ ERROR: shared static items must have a type which implements Sync
+//~^^ ERROR: the trait `core::kinds::Sync` is not implemented for the type
+//~^^^ ERROR: the trait `core::kinds::Sync` is not implemented for the type
+//~^^^^ ERROR: the trait `core::kinds::Sync` is not implemented for the type
 
 fn main() { }

--- a/src/test/compile-fail/kindck-destructor-owned.rs
+++ b/src/test/compile-fail/kindck-destructor-owned.rs
@@ -9,19 +9,6 @@
 // except according to those terms.
 
 
-use std::rc::Rc;
-
-struct Foo {
-    f: Rc<int>,
-}
-
-impl Drop for Foo {
-//~^ ERROR the trait `core::kinds::Send` is not implemented
-//~^^ NOTE cannot implement a destructor on a structure or enumeration that does not satisfy Send
-    fn drop(&mut self) {
-    }
-}
-
 struct Bar<'a> {
     f: &'a int,
 }

--- a/src/test/compile-fail/kindck-nonsendable-1.rs
+++ b/src/test/compile-fail/kindck-nonsendable-1.rs
@@ -17,6 +17,8 @@ fn bar<F:FnOnce() + Send>(_: F) { }
 
 fn main() {
     let x = Rc::new(3u);
-    bar(move|| foo(x)); //~ ERROR `core::kinds::Send` is not implemented
+    bar(move|| foo(x));
+    //~^ ERROR `core::kinds::Send` is not implemented
+    //~^^ ERROR `core::kinds::Send` is not implemented
 }
 

--- a/src/test/compile-fail/kindck-send-unsafe.rs
+++ b/src/test/compile-fail/kindck-send-unsafe.rs
@@ -8,14 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+extern crate core;
+
 fn assert_send<T:Send>() { }
 
-// unsafe ptrs are ok unless they point at unsendable things
-fn test70() {
-    assert_send::<*mut int>();
-}
 fn test71<'a>() {
-    assert_send::<*mut &'a int>(); //~ ERROR declared lifetime bound not satisfied
+    assert_send::<*mut &'a int>();
+    //~^ ERROR the trait `core::kinds::Send` is not implemented for the type
 }
 
 fn main() {

--- a/src/test/compile-fail/mut-not-freeze.rs
+++ b/src/test/compile-fail/mut-not-freeze.rs
@@ -14,5 +14,8 @@ fn f<T: Sync>(_: T) {}
 
 fn main() {
     let x = RefCell::new(0i);
-    f(x); //~ ERROR `core::kinds::Sync` is not implemented
+    f(x);
+    //~^ ERROR `core::kinds::Sync` is not implemented
+    //~^^ ERROR `core::kinds::Sync` is not implemented
+    //~^^^ ERROR `core::kinds::Sync` is not implemented
 }

--- a/src/test/compile-fail/no-send-res-ports.rs
+++ b/src/test/compile-fail/no-send-res-ports.rs
@@ -37,6 +37,7 @@ fn main() {
 
     task::spawn(move|| {
         //~^ ERROR `core::kinds::Send` is not implemented
+        //~^^ ERROR `core::kinds::Send` is not implemented
         let y = x;
         println!("{}", y);
     });

--- a/src/test/compile-fail/no_send-rc.rs
+++ b/src/test/compile-fail/no_send-rc.rs
@@ -16,4 +16,5 @@ fn main() {
     let x = Rc::new(5i);
     bar(x);
     //~^ ERROR `core::kinds::Send` is not implemented
+    //~^^ ERROR `core::kinds::Send` is not implemented
 }

--- a/src/test/compile-fail/no_share-rc.rs
+++ b/src/test/compile-fail/no_share-rc.rs
@@ -17,4 +17,5 @@ fn main() {
     let x = Rc::new(RefCell::new(5i));
     bar(x);
     //~^ ERROR the trait `core::kinds::Sync` is not implemented
+    //~^^ ERROR the trait `core::kinds::Sync` is not implemented
 }

--- a/src/test/compile-fail/task-rng-isnt-sendable.rs
+++ b/src/test/compile-fail/task-rng-isnt-sendable.rs
@@ -17,4 +17,5 @@ fn test_send<S: Send>() {}
 pub fn main() {
     test_send::<rand::TaskRng>();
     //~^ ERROR `core::kinds::Send` is not implemented
+    //~^^ ERROR `core::kinds::Send` is not implemented
 }

--- a/src/test/compile-fail/typeck-unsafe-always-share.rs
+++ b/src/test/compile-fail/typeck-unsafe-always-share.rs
@@ -30,12 +30,15 @@ fn test<T: Sync>(s: T){
 fn main() {
     let us = UnsafeCell::new(MySync{u: UnsafeCell::new(0i)});
     test(us);
+    //~^ ERROR `core::kinds::Sync` is not implemented
 
     let uns = UnsafeCell::new(NoSync{m: marker::NoSync});
     test(uns);
+    //~^ ERROR `core::kinds::Sync` is not implemented
 
     let ms = MySync{u: uns};
     test(ms);
+    //~^ ERROR `core::kinds::Sync` is not implemented
 
     let ns = NoSync{m: marker::NoSync};
     test(ns);

--- a/src/test/compile-fail/unique-unique-kind.rs
+++ b/src/test/compile-fail/unique-unique-kind.rs
@@ -16,5 +16,7 @@ fn f<T:Send>(_i: T) {
 
 fn main() {
     let i = box Rc::new(100i);
-    f(i); //~ ERROR `core::kinds::Send` is not implemented
+    f(i);
+    //~^ ERROR `core::kinds::Send` is not implemented
+    //~^^ ERROR `core::kinds::Send` is not implemented
 }

--- a/src/test/compile-fail/unsendable-class.rs
+++ b/src/test/compile-fail/unsendable-class.rs
@@ -28,6 +28,8 @@ fn foo(i:int, j: Rc<String>) -> foo {
 
 fn main() {
   let cat = "kitty".to_string();
-  let (tx, _) = channel(); //~ ERROR `core::kinds::Send` is not implemented
+  let (tx, _) = channel();
+  //~^ ERROR `core::kinds::Send` is not implemented
+  //~^^ ERROR `core::kinds::Send` is not implemented
   tx.send(foo(42, Rc::new(cat)));
 }

--- a/src/test/run-pass/const-block.rs
+++ b/src/test/run-pass/const-block.rs
@@ -11,10 +11,14 @@
 #![allow(dead_code)]
 #![allow(unused_unsafe)]
 
+use std::kinds::Sync;
+
 struct Foo {
     a: uint,
     b: *const ()
 }
+
+impl Sync for Foo {}
 
 fn foo<T>(a: T) -> T {
     a

--- a/src/test/run-pass/const-block.rs
+++ b/src/test/run-pass/const-block.rs
@@ -18,7 +18,7 @@ struct Foo {
     b: *const ()
 }
 
-impl Sync for Foo {}
+unsafe impl Sync for Foo {}
 
 fn foo<T>(a: T) -> T {
     a

--- a/src/test/run-pass/const-cast-ptr-int.rs
+++ b/src/test/run-pass/const-cast-ptr-int.rs
@@ -14,7 +14,7 @@ struct TestStruct {
     x: *const u8
 }
 
-impl Sync for TestStruct {}
+unsafe impl Sync for TestStruct {}
 
 static a: TestStruct = TestStruct{x: 0 as *const u8};
 

--- a/src/test/run-pass/const-cast-ptr-int.rs
+++ b/src/test/run-pass/const-cast-ptr-int.rs
@@ -10,8 +10,14 @@
 
 use std::ptr;
 
-static a: *const u8 = 0 as *const u8;
+struct TestStruct {
+    x: *const u8
+}
+
+impl Sync for TestStruct {}
+
+static a: TestStruct = TestStruct{x: 0 as *const u8};
 
 pub fn main() {
-    assert_eq!(a, ptr::null());
+    assert_eq!(a.x, ptr::null());
 }

--- a/src/test/run-pass/const-cast.rs
+++ b/src/test/run-pass/const-cast.rs
@@ -14,7 +14,7 @@ struct TestStruct {
     x: *const libc::c_void
 }
 
-impl Sync for TestStruct {}
+unsafe impl Sync for TestStruct {}
 
 extern fn foo() {}
 const x: extern "C" fn() = foo;

--- a/src/test/run-pass/const-cast.rs
+++ b/src/test/run-pass/const-cast.rs
@@ -10,14 +10,16 @@
 
 extern crate libc;
 
-extern fn foo() {}
+struct TestStruct {
+    x: *const libc::c_void
+}
 
+impl Sync for TestStruct {}
+
+extern fn foo() {}
 const x: extern "C" fn() = foo;
-static y: *const libc::c_void = x as *const libc::c_void;
-const a: &'static int = &10;
-static b: *const int = a as *const int;
+static y: TestStruct = TestStruct { x: x as *const libc::c_void };
 
 pub fn main() {
-    assert_eq!(x as *const libc::c_void, y);
-    assert_eq!(a as *const int, b);
+    assert_eq!(x as *const libc::c_void, y.x);
 }

--- a/src/test/run-pass/deriving-bounds.rs
+++ b/src/test/run-pass/deriving-bounds.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[deriving(Sync,Send,Copy)]
+#[deriving(Copy)]
 struct Test;
 
 pub fn main() {}

--- a/src/test/run-pass/issue-13837.rs
+++ b/src/test/run-pass/issue-13837.rs
@@ -12,7 +12,7 @@ struct TestStruct {
     x: *const [int; 2]
 }
 
-impl Sync for TestStruct {}
+unsafe impl Sync for TestStruct {}
 
 static TEST_VALUE : TestStruct = TestStruct{x: 0x1234 as *const [int; 2]};
 

--- a/src/test/run-pass/issue-13837.rs
+++ b/src/test/run-pass/issue-13837.rs
@@ -8,6 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-static TEST_VALUE : *const [int; 2] = 0x1234 as *const [int; 2];
+struct TestStruct {
+    x: *const [int; 2]
+}
+
+impl Sync for TestStruct {}
+
+static TEST_VALUE : TestStruct = TestStruct{x: 0x1234 as *const [int; 2]};
 
 fn main() {}

--- a/src/test/run-pass/issue-17718-static-unsafe-interior.rs
+++ b/src/test/run-pass/issue-17718-static-unsafe-interior.rs
@@ -36,7 +36,7 @@ struct Wrap<T> {
     value: T
 }
 
-impl<T: Send> Sync for Wrap<T> {}
+unsafe impl<T: Send> Sync for Wrap<T> {}
 
 static UNSAFE: RacyCell<int> = RacyCell(UnsafeCell{value: 1});
 static WRAPPED_UNSAFE: Wrap<&'static RacyCell<int>> = Wrap { value: &UNSAFE };

--- a/src/test/run-pass/issue-17718-static-unsafe-interior.rs
+++ b/src/test/run-pass/issue-17718-static-unsafe-interior.rs
@@ -9,7 +9,8 @@
 // except according to those terms.
 
 use std::kinds::marker;
-use std::cell::{UnsafeCell, RacyCell};
+use std::comm::RacyCell;
+use std::cell::UnsafeCell;
 
 struct MyUnsafe<T> {
     value: RacyCell<T>

--- a/src/test/run-pass/issue-2718.rs
+++ b/src/test/run-pass/issue-2718.rs
@@ -46,7 +46,7 @@ pub mod pipes {
         payload: Option<T>
     }
 
-    impl<T:Send> Send for packet<T> {}
+    unsafe impl<T:Send> Send for packet<T> {}
 
     pub fn packet<T:Send>() -> *const packet<T> {
         unsafe {

--- a/src/test/run-pass/issue-2718.rs
+++ b/src/test/run-pass/issue-2718.rs
@@ -23,6 +23,7 @@ pub mod pipes {
     use std::mem::{replace, swap};
     use std::mem;
     use std::task;
+    use std::kinds::Send;
 
     pub struct Stuff<T> {
         state: state,
@@ -44,6 +45,8 @@ pub mod pipes {
         blocked_task: Option<Task>,
         payload: Option<T>
     }
+
+    impl<T:Send> Send for packet<T> {}
 
     pub fn packet<T:Send>() -> *const packet<T> {
         unsafe {
@@ -230,7 +233,12 @@ pub mod pingpong {
     use std::mem;
 
     pub struct ping(::pipes::send_packet<pong>);
+
+    unsafe impl Send for ping {}
+
     pub struct pong(::pipes::send_packet<ping>);
+
+    unsafe impl Send for pong {}
 
     pub fn liberate_ping(p: ping) -> ::pipes::send_packet<pong> {
         unsafe {

--- a/src/test/run-pass/typeck_type_placeholder_1.rs
+++ b/src/test/run-pass/typeck_type_placeholder_1.rs
@@ -11,7 +11,14 @@
 // This test checks that the `_` type placeholder works
 // correctly for enabling type inference.
 
-static CONSTEXPR: *const int = &413 as *const _;
+struct TestStruct {
+    x: *const int
+}
+
+impl Sync for TestStruct {}
+
+static CONSTEXPR: TestStruct = TestStruct{x: &413 as *const _};
+
 
 pub fn main() {
     let x: Vec<_> = range(0u, 5).collect();

--- a/src/test/run-pass/typeck_type_placeholder_1.rs
+++ b/src/test/run-pass/typeck_type_placeholder_1.rs
@@ -15,7 +15,7 @@ struct TestStruct {
     x: *const int
 }
 
-impl Sync for TestStruct {}
+unsafe impl Sync for TestStruct {}
 
 static CONSTEXPR: TestStruct = TestStruct{x: &413 as *const _};
 


### PR DESCRIPTION
More work on opt-in built in traits. `Send` and `Sync` are not opt-in, `OwnedPtr` renamed to `UniquePtr` and the `Send` and `Sync` traits are now unsafe.

NOTE: This likely needs to be rebased on top of the yet-to-land snapshot.

r? @nikomatsakis 

[breaking-change]

cc #13231 
