### PR TITLE
Make single-variant "c-like" enums have no size.

### DIFF
--- a/src/librustc_trans/trans/adt.rs
+++ b/src/librustc_trans/trans/adt.rs
@@ -190,6 +190,17 @@ fn represent_type_uncached<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                                   dtor);
             }
 
+            if cases.len() == 1 && cases[0].discr == 0 {
+                // Equivalent to a struct/tuple/newtype.
+                // (Typechecking will reject discriminant-sizing attrs.)
+                assert_eq!(hint, attr::ReprAny);
+                let mut ftys = cases[0].tys.clone();
+                if dtor { ftys.push(ty::mk_bool()); }
+                return Univariant(mk_struct(cx, ftys.as_slice(), false, t),
+                                  dtor);
+            }
+
+
             if !dtor && cases.iter().all(|c| c.tys.len() == 0) {
                 // All bodies empty -> intlike
                 let discrs: Vec<u64> = cases.iter().map(|c| c.discr).collect();
@@ -210,16 +221,6 @@ fn represent_type_uncached<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                                       discriminants",
                                       ty::item_path_str(cx.tcx(),
                                                         def_id)).as_slice());
-            }
-
-            if cases.len() == 1 {
-                // Equivalent to a struct/tuple/newtype.
-                // (Typechecking will reject discriminant-sizing attrs.)
-                assert_eq!(hint, attr::ReprAny);
-                let mut ftys = cases[0].tys.clone();
-                if dtor { ftys.push(ty::mk_bool()); }
-                return Univariant(mk_struct(cx, ftys.as_slice(), false, t),
-                                  dtor);
             }
 
             if !dtor && cases.len() == 2 && hint == attr::ReprAny {

--- a/src/test/run-pass/type-sizes.rs
+++ b/src/test/run-pass/type-sizes.rs
@@ -18,6 +18,14 @@ struct w {a: int, b: ()}
 struct x {a: int, b: (), c: ()}
 struct y {x: int}
 
+enum c1 {
+    c1
+}
+
+enum c2 {
+    c2 = 1
+}
+
 pub fn main() {
     assert_eq!(size_of::<u8>(), 1 as uint);
     assert_eq!(size_of::<u32>(), 4 as uint);
@@ -34,4 +42,8 @@ pub fn main() {
     assert_eq!(size_of::<w>(), size_of::<int>());
     assert_eq!(size_of::<x>(), size_of::<int>());
     assert_eq!(size_of::<int>(), size_of::<y>());
+
+    // Make sure enum sizes are correct
+    assert_eq!(size_of::<c1>(), 0 as uint);
+    assert_eq!(size_of::<c2>(), 1 as uint);
 }


### PR DESCRIPTION
This makes an enum like `enum Foo { Foo }` be zero-sized. If a
discriminant is set to non-zero, it still treats it as a c-like enum.

Fixes #15747
