### PR TITLE
Remove cmp::Ordering::* public reexport

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -41,7 +41,7 @@
 
 #![stable]
 
-pub use self::Ordering::*;
+use self::Ordering::*;
 
 use kinds::Sized;
 use option::Option::{mod, Some, None};

--- a/src/libcore/tuple.rs
+++ b/src/libcore/tuple.rs
@@ -69,6 +69,7 @@
 
 use clone::Clone;
 use cmp::*;
+use cmp::Ordering::*;
 use default::Default;
 use option::Option;
 use option::Option::Some;


### PR DESCRIPTION
Part of #19253

I would have removed this public reexport in #19842, but #19812 hadn't merged (and snapshotted) at the time

In #19407, I changed the codebase to stop utilizing this reexport

[breaking-change]
