### PR TITLE
Fix `collections::VecMap`'s `PartialEq` implementation

### DIFF
--- a/src/libcollections/ring_buf.rs
+++ b/src/libcollections/ring_buf.rs
@@ -1294,9 +1294,6 @@ impl<A: PartialEq> PartialEq for RingBuf<A> {
         self.len() == other.len() &&
             self.iter().zip(other.iter()).all(|(a, b)| a.eq(b))
     }
-    fn ne(&self, other: &RingBuf<A>) -> bool {
-        !self.eq(other)
-    }
 }
 
 impl<A: Eq> Eq for RingBuf<A> {}

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -60,7 +60,6 @@ use vec::Vec;
 /// months.clear();
 /// assert!(months.is_empty());
 /// ```
-#[deriving(PartialEq, Eq)]
 pub struct VecMap<V> {
     v: Vec<Option<V>>,
 }
@@ -488,6 +487,14 @@ impl<V:Clone> VecMap<V> {
         self.insert(key, new_val).is_none()
     }
 }
+
+impl<V: PartialEq> PartialEq for VecMap<V> {
+    fn eq(&self, other: &VecMap<V>) -> bool {
+        iter::order::eq(self.iter(), other.iter())
+    }
+}
+
+impl<V: Eq> Eq for VecMap<V> {}
 
 impl<V: PartialOrd> PartialOrd for VecMap<V> {
     #[inline]
@@ -951,6 +958,10 @@ mod test_map {
         assert!(!b.insert(0, 5).is_none());
         assert!(a != b);
         assert!(b.insert(5, 19).is_none());
+        assert!(a == b);
+
+        a = VecMap::new();
+        b = VecMap::with_capacity(1);
         assert!(a == b);
     }
 


### PR DESCRIPTION
Previously it took capacity into account.

Additionally remove the `ne` implementation of `RingBuf` which is the default
one anyway.
