### PR TITLE
Defer immediate loads in rvalue expressions

### DIFF
--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -533,19 +533,6 @@ fn trans_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                 let scratch = rvalue_scratch_datum(bcx, ty, "");
                 bcx = trans_rvalue_dps_unadjusted(
                     bcx, expr, SaveIn(scratch.val));
-
-                // Note: this is not obviously a good idea.  It causes
-                // immediate values to be loaded immediately after a
-                // return from a call or other similar expression,
-                // which in turn leads to alloca's having shorter
-                // lifetimes and hence larger stack frames.  However,
-                // in turn it can lead to more register pressure.
-                // Still, in practice it seems to increase
-                // performance, since we have fewer problems with
-                // morestack churn.
-                let scratch = unpack_datum!(
-                    bcx, scratch.to_appropriate_datum(bcx));
-
                 DatumBlock::new(bcx, scratch.to_expr_datum())
             }
         }


### PR DESCRIPTION
Commit ee4ba44 made it so immediate types are loaded immediately after
a function call or similar. This was done to reduce morestack thrashing.
However, since we do not have segmented stacks any more, this is not
necessary and the issues mentioned in the comment apply more strongly.

Defer the load until we actually need it, as it was causing LLVM to miss
some obvious optimisations.

Fixes #20149
