### PR TITLE
Support all variants of WherePredicate in clean/mod.rs

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -683,23 +683,32 @@ impl Clean<Option<Lifetime>> for ty::Region {
 }
 
 #[deriving(Clone, RustcEncodable, RustcDecodable, PartialEq)]
-pub struct WherePredicate {
-    pub ty: Type,
-    pub bounds: Vec<TyParamBound>
+pub enum WherePredicate {
+    BoundPredicate { ty: Type, bounds: Vec<TyParamBound> },
+    RegionPredicate { lifetime: Lifetime, bounds: Vec<Lifetime>},
+    // FIXME (#20041)
+    EqPredicate
 }
 
 impl Clean<WherePredicate> for ast::WherePredicate {
     fn clean(&self, cx: &DocContext) -> WherePredicate {
         match *self {
             ast::WherePredicate::BoundPredicate(ref wbp) => {
-                WherePredicate {
+                WherePredicate::BoundPredicate {
                     ty: wbp.bounded_ty.clean(cx),
                     bounds: wbp.bounds.clean(cx)
                 }
             }
-            // FIXME(#20048)
-            _ => {
-                unimplemented!();
+
+            ast::WherePredicate::RegionPredicate(ref wrp) => {
+                WherePredicate::RegionPredicate {
+                    lifetime: wrp.lifetime.clean(cx),
+                    bounds: wrp.bounds.clean(cx)
+                }
+            }
+
+            ast::WherePredicate::EqPredicate(_) => {
+                WherePredicate::EqPredicate
             }
         }
     }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -128,8 +128,26 @@ impl<'a> fmt::Show for WhereClause<'a> {
             if i > 0 {
                 try!(f.write(", ".as_bytes()));
             }
-            let bounds = pred.bounds.as_slice();
-            try!(write!(f, "{}: {}", pred.ty, TyParamBounds(bounds)));
+            match pred {
+                &clean::WherePredicate::BoundPredicate {ref ty, ref bounds } => {
+                    let bounds = bounds.as_slice();
+                    try!(write!(f, "{}: {}", ty, TyParamBounds(bounds)));
+                },
+                &clean::WherePredicate::RegionPredicate { ref lifetime,
+                                                          ref bounds } => {
+                    try!(write!(f, "{}: ", lifetime));
+                    for (i, lifetime) in bounds.iter().enumerate() {
+                        if i > 0 {
+                            try!(f.write(" + ".as_bytes()));
+                        }
+
+                        try!(write!(f, "{}", lifetime));
+                    }
+                },
+                &clean::WherePredicate::EqPredicate => {
+                    unimplemented!()
+                }
+            }
         }
         Ok(())
     }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -129,10 +129,10 @@ impl<'a> fmt::Show for WhereClause<'a> {
                 try!(f.write(", ".as_bytes()));
             }
             match pred {
-                &clean::WherePredicate::BoundPredicate {ref ty, ref bounds } => {
+                &clean::WherePredicate::BoundPredicate { ref ty, ref bounds } => {
                     let bounds = bounds.as_slice();
                     try!(write!(f, "{}: {}", ty, TyParamBounds(bounds)));
-                },
+                }
                 &clean::WherePredicate::RegionPredicate { ref lifetime,
                                                           ref bounds } => {
                     try!(write!(f, "{}: ", lifetime));
@@ -143,7 +143,7 @@ impl<'a> fmt::Show for WhereClause<'a> {
 
                         try!(write!(f, "{}", lifetime));
                     }
-                },
+                }
                 &clean::WherePredicate::EqPredicate => {
                     unimplemented!()
                 }


### PR DESCRIPTION
Add support for all variants of ast::WherePredicate in clean/mod.rs. Fixes #20048, but will need modification when EqualityPredicates are fully implemented in #20041.
