### PR TITLE
rustdoc: unmarked code fences are doctests too

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -387,7 +387,7 @@ impl LangString {
             should_fail: false,
             no_run: false,
             ignore: false,
-            rust: false,
+            rust: true,  // NB This used to be `notrust = false`
             test_harness: false,
         }
     }
@@ -413,7 +413,7 @@ impl LangString {
             }
         }
 
-        data.rust |=  !seen_other_tags || seen_rust_tags;
+        data.rust &= !seen_other_tags || seen_rust_tags;
 
         data
     }
@@ -465,17 +465,18 @@ mod tests {
             })
         }
 
-        t("", false,false,false,true,false);
-        t("rust", false,false,false,true,false);
-        t("sh", false,false,false,false,false);
-        t("ignore", false,false,true,true,false);
-        t("should_fail", true,false,false,true,false);
-        t("no_run", false,true,false,true,false);
-        t("test_harness", false,false,false,true,true);
-        t("{.no_run .example}", false,true,false,true,false);
-        t("{.sh .should_fail}", true,false,false,true,false);
-        t("{.example .rust}", false,false,false,true,false);
-        t("{.test_harness .rust}", false,false,false,true,true);
+        // marker                | should_fail | no_run | ignore | rust | test_harness
+        t("",                      false,        false,   false,   true,  false);
+        t("rust",                  false,        false,   false,   true,  false);
+        t("sh",                    false,        false,   false,   false, false);
+        t("ignore",                false,        false,   true,    true,  false);
+        t("should_fail",           true,         false,   false,   true,  false);
+        t("no_run",                false,        true,    false,   true,  false);
+        t("test_harness",          false,        false,   false,   true,  true);
+        t("{.no_run .example}",    false,        true,    false,   true,  false);
+        t("{.sh .should_fail}",    true,         false,   false,   true,  false);
+        t("{.example .rust}",      false,        false,   false,   true,  false);
+        t("{.test_harness .rust}", false,        false,   false,   true,  true);
     }
 
     #[test]


### PR DESCRIPTION
#20075 introduced a bug where unmarked code fences weren't considered as doctests. This PR fixes the logic.

---

This passed `check-stage1-rustdoc`, and I manually checked that:

`````` rust
//! ```
//! println!("Hello")
//! ```
//!
//! ``` rust
//! println!("Hello")
//! ```
//!
//! ``` sh
//! println!("Hello")
//! ```
//!
//! ``` ignore
//! println!("Hello")
//! ```
``````

Generated:

``` rust
running 3 tests
test _2 ... ignored
test _0 ... ok
test _1 ... ok
```

I'd love to add that as a test, but I have no idea how to do that with our testing infrastructure. If anyone knows how, do let me know!

r? @alexcrichton 
@seanmonstar feedback?
