### PR TITLE
core: Removed a shadowed, unused definition of `debug_assert!`.

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -61,16 +61,6 @@ macro_rules! assert {
     );
 }
 
-/// Runtime assertion, only without `--cfg ndebug`
-#[macro_export]
-macro_rules! debug_assert {
-    ($(a:tt)*) => ({
-        if cfg!(not(ndebug)) {
-            assert!($($a)*);
-        }
-    })
-}
-
 /// Runtime assertion for equality, for details see std::macros
 #[macro_export]
 macro_rules! assert_eq {
@@ -93,7 +83,7 @@ macro_rules! debug_assert_eq {
     })
 }
 
-/// Runtime assertion, disableable at compile time
+/// Runtime assertion, disableable at compile time with `--cfg ndebug`
 #[macro_export]
 macro_rules! debug_assert {
     ($($arg:tt)*) => (if cfg!(not(ndebug)) { assert!($($arg)*); })


### PR DESCRIPTION
Yes, really. That definition wouldn't work anyway.

This also fixes repeated entries for `debug_assert!` from libcore docs. Maybe we should warn such macro definitions in the first place?
