### PR TITLE
Fixes a typo in the HashMap doc

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1239,7 +1239,7 @@ impl<K: Eq + Hash<S>, V: Clone, S, H: Hasher<S>> HashMap<K, V, H> {
     /// Deprecated: Use `map.get(k).cloned()`.
     ///
     /// Return a copy of the value corresponding to the key.
-    #[deprecated = "Use `map.get(k).cloned()`"]
+    #[deprecated = "Use `map.get(k).clone()`"]
     pub fn find_copy(&self, k: &K) -> Option<V> {
         self.get(k).cloned()
     }


### PR DESCRIPTION
I bumped into this yesterday while writing some hashmap code.

This is minor, feel free to ignore if you end up removing the method anyway.
