### PR TITLE
mk: Build jemalloc with -ffunction-sections

### DIFF
--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -180,7 +180,7 @@ $$(JEMALLOC_LOCAL_$(1)): $$(JEMALLOC_DEPS) $$(MKFILE_DEPS)
 		AR="$$(AR_$(1))" \
 		RANLIB="$$(AR_$(1)) s" \
 		CPPFLAGS="-I $(S)src/rt/" \
-		EXTRA_CFLAGS="-g1"
+		EXTRA_CFLAGS="-g1 -ffunction-sections -fdata-sections"
 	$$(Q)$$(MAKE) -C "$$(JEMALLOC_BUILD_DIR_$(1))" build_lib_static
 
 ifeq ($$(CFG_DISABLE_JEMALLOC),)


### PR DESCRIPTION
It's quite possible that small programs don't use all of jemalloc, and building
with -ffunction-sections and -fdata-sections allows the linker (via
--gc-sections) to strip out all unused code at link time. This decreases the
size of a "hello world" executable for me from 716K to 482K with no measurable
impact on link time. After this patch jemalloc is still the largest portion of
our hello world executables, but this helps cut down on the size at least
somewhat!
