### PR TITLE
Map EEXIST to PathAlreadyExists error, closes #20226

### DIFF
--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -1149,6 +1149,19 @@ mod test {
     }
 
     #[test]
+    fn mkdir_path_already_exists_error() {
+        use io::{IoError, PathAlreadyExists};
+
+        let tmpdir = tmpdir();
+        let dir = &tmpdir.join("mkdir_error_twice");
+        check!(mkdir(dir, io::USER_RWX));
+        match mkdir(dir, io::USER_RWX) {
+            Err(IoError{kind:PathAlreadyExists,..}) => (),
+            _ => assert!(false)
+        };
+    }
+
+    #[test]
     fn recursive_mkdir() {
         let tmpdir = tmpdir();
         let dir = tmpdir.join("d1/d2");

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -109,6 +109,8 @@ pub fn decode_error(errno: i32) -> IoError {
              "file descriptor is not a TTY"),
         libc::ETIMEDOUT => (io::TimedOut, "operation timed out"),
         libc::ECANCELED => (io::TimedOut, "operation aborted"),
+        libc::consts::os::posix88::EEXIST =>
+            (io::PathAlreadyExists, "path already exists"),
 
         // These two constants can have the same value on some systems,
         // but different values on others, so we can't use a match

--- a/src/libstd/sys/windows/mod.rs
+++ b/src/libstd/sys/windows/mod.rs
@@ -121,6 +121,8 @@ pub fn decode_error(errno: i32) -> IoError {
              "invalid handle provided to function"),
         libc::ERROR_NOTHING_TO_TERMINATE =>
             (io::InvalidInput, "no process to kill"),
+        libc::ERROR_ALREADY_EXISTS =>
+            (io::PathAlreadyExists, "path already exists"),
 
         // libuv maps this error code to EISDIR. we do too. if it is found
         // to be incorrect, we can add in some more machinery to only


### PR DESCRIPTION
I've created a patch for #20226, which maps `EEXIST` to the `PathAlreadyExists` error on Unix. To test this, I use `mkdir`, which raises `EEXIST` if the directory already exists. 

On Windows, I map `ERROR_ALREADY_EXISTS` to `PathAlreadyExist`, but I am note sure if `mkdir` on Windows raises `ERROR_ALREADY_EXISTS` and do not have a Windows installation handy for testing.

And I noticed another thing. No error seems to map to `IoErrorKind::PathDoesntExist` and I am wondering what the difference to `FileNotFound` is?
