### PR TITLE
syntax: allow setting attributes for deriving impls

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2436,14 +2436,26 @@ impl<T: PartialEq> PartialEq for Foo<T> {
 Supported traits for `deriving` are:
 
 * Comparison traits: `PartialEq`, `Eq`, `PartialOrd`, `Ord`.
-* Serialization: `Encodable`, `Decodable`. These require `serialize`.
-* `Clone`, to create `T` from `&T` via a copy.
+* Serialization: `RustcEncodable`, `RustcDecodable`. These require `serialize`.
+* `Clone`, to create `T` from `&T` via cloning its contents.
+* `Copy`, to indicate that this type is allowed to be copied bitwise (if
+  safe).
+* `Sync`, to indicate that this type is safe to use concurrently.
+* `Send`, to indicate that this type
 * `Default`, to create an empty instance of a data type.
 * `FromPrimitive`, to create an instance from a numeric primitive.
 * `Hash`, to iterate over the bytes in a data type.
 * `Rand`, to create a random instance of a data type.
 * `Show`, to format a value using the `{}` formatter.
 * `Zero`, to create a zero instance of a numeric data type.
+
+Each derived trait can have attributes applied to the generated `impl`, such
+as:
+
+```
+#[deriving(Clone(attributes(cfg(not(windows)), unstable)))]
+struct X
+```
 
 ### Stability
 
@@ -4149,11 +4161,11 @@ Unwinding the stack of a thread is done by the thread itself, on its own control
 stack. If a value with a destructor is freed during unwinding, the code for the
 destructor is run, also on the thread's control stack. Running the destructor
 code causes a temporary transition to a *running* state, and allows the
-destructor code to cause any subsequent state transitions. The original thread 
+destructor code to cause any subsequent state transitions. The original thread
 of unwinding and panicking thereby may suspend temporarily, and may involve
 (recursive) unwinding of the stack of a failed destructor. Nonetheless, the
 outermost unwinding activity will continue until the stack is unwound and the
-thread transitions to the *dead* state. There is no way to "recover" from thread 
+thread transitions to the *dead* state. There is no way to "recover" from thread
 panics. Once a thread has temporarily suspended its unwinding in the *panicking*
 state, a panic occurring from within this destructor results in *hard* panic.
 A hard panic currently results in the process aborting.

--- a/src/libsyntax/ext/deriving/bounds.rs
+++ b/src/libsyntax/ext/deriving/bounds.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast::{MetaItem, MetaWord, Item};
+use ast::{MetaItem, MetaWord, MetaList, Item};
 use codemap::Span;
 use ext::base::ExtCtxt;
 use ext::deriving::generic::*;
@@ -23,7 +23,8 @@ pub fn expand_deriving_bound<F>(cx: &mut ExtCtxt,
     F: FnOnce(P<Item>),
 {
     let name = match mitem.node {
-        MetaWord(ref tname) => {
+        MetaWord(ref tname) |
+        MetaList(ref tname, _) => {
             match tname.get() {
                 "Copy" => "Copy",
                 "Send" | "Sync" => {

--- a/src/test/run-pass/deriving-add-attributes.rs
+++ b/src/test/run-pass/deriving-add-attributes.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[deriving(Copy(attributes(stable)), Clone(attributes(unstable)))]
+struct X;
+
+fn main() {}


### PR DESCRIPTION
The approach this takes is to extend the deriving DSL to accept the form
`TRAIT = VALUE`, where `VALUE` is one of the stability names, and the
appropriate attribute will be inserted into the AST of the generated impl.

Closes #18969
