### PR TITLE
liballoc does not need liblibc under certain configurations

### DIFF
--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -176,7 +176,9 @@ mod imp {
     pub use self::external::{usable_size, stats_print};
 }
 
-#[cfg(all(not(feature = "external_funcs"), not(feature = "external_crate"), jemalloc))]
+#[cfg(all(not(feature = "external_funcs"),
+          not(feature = "external_crate"),
+          jemalloc))]
 mod imp {
     use core::option::Option;
     use core::option::Option::None;
@@ -253,7 +255,10 @@ mod imp {
     }
 }
 
-#[cfg(all(not(feature = "external_funcs"), not(feature = "external_crate"), not(jemalloc), unix))]
+#[cfg(all(not(feature = "external_funcs"),
+          not(feature = "external_crate"),
+          not(jemalloc),
+          unix))]
 mod imp {
     use core::cmp;
     use core::ptr;
@@ -314,7 +319,10 @@ mod imp {
     pub fn stats_print() {}
 }
 
-#[cfg(all(not(feature = "external_funcs"), not(feature = "external_crate"), not(jemalloc), windows))]
+#[cfg(all(not(feature = "external_funcs"),
+          not(feature = "external_crate"),
+          not(jemalloc),
+          windows))]
 mod imp {
     use libc::{c_void, size_t};
     use libc;

--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -142,14 +142,13 @@ mod imp {
     }
 
     #[inline]
-    pub unsafe fn reallocate_inplace(ptr: *mut u8, old_size: uint, size: uint,
-                                     align: uint) -> uint {
-        rust_reallocate_inplace(ptr, old_size, size, align)
+    pub unsafe fn deallocate(ptr: *mut u8, old_size: uint, align: uint) {
+        rust_deallocate(ptr, old_size, align)
     }
 
     #[inline]
-    pub unsafe fn deallocate(ptr: *mut u8, old_size: uint, align: uint) {
-        rust_deallocate(ptr, old_size, align)
+    pub unsafe fn reallocate(ptr: *mut u8, old_size: uint, size: uint, align: uint) -> *mut u8 {
+        rust_reallocate(ptr, old_size, size, align)
     }
 
     #[inline]

--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -115,13 +115,17 @@ unsafe fn exchange_free(ptr: *mut u8, old_size: uint, align: uint) {
 // The minimum alignment guaranteed by the architecture. This value is used to
 // add fast paths for low alignment values. In practice, the alignment is a
 // constant at the call site and the branch will be optimized out.
-#[cfg(any(target_arch = "arm",
-          target_arch = "mips",
-          target_arch = "mipsel"))]
+#[cfg(all(not(feature = "external_funcs"),
+          not(feature = "external_crate"),
+          any(target_arch = "arm",
+              target_arch = "mips",
+              target_arch = "mipsel")))]
 const MIN_ALIGN: uint = 8;
-#[cfg(any(target_arch = "x86",
-          target_arch = "x86_64",
-          target_arch = "aarch64"))]
+#[cfg(all(not(feature = "external_funcs"),
+          not(feature = "external_crate"),
+          any(target_arch = "x86",
+              target_arch = "x86_64",
+              target_arch = "aarch64"))]
 const MIN_ALIGN: uint = 16;
 
 #[cfg(feature = "external_funcs")]

--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -124,7 +124,7 @@ const MIN_ALIGN: uint = 8;
           target_arch = "aarch64"))]
 const MIN_ALIGN: uint = 16;
 
-#[cfg(external_funcs)]
+#[cfg(feature = "external_funcs")]
 mod imp {
     extern {
         fn rust_allocate(size: uint, align: uint) -> *mut u8;
@@ -169,14 +169,14 @@ mod imp {
     }
 }
 
-#[cfg(external_crate)]
+#[cfg(feature = "external_crate")]
 mod imp {
     extern crate external;
     pub use self::external::{allocate, deallocate, reallocate_inplace, reallocate};
     pub use self::external::{usable_size, stats_print};
 }
 
-#[cfg(all(not(external_funcs), not(external_crate), jemalloc))]
+#[cfg(all(not(feature = "external_funcs"), not(feature = "external_crate"), jemalloc))]
 mod imp {
     use core::option::Option;
     use core::option::Option::None;
@@ -253,7 +253,7 @@ mod imp {
     }
 }
 
-#[cfg(all(not(external_funcs), not(external_crate), not(jemalloc), unix))]
+#[cfg(all(not(feature = "external_funcs"), not(feature = "external_crate"), not(jemalloc), unix))]
 mod imp {
     use core::cmp;
     use core::ptr;
@@ -314,7 +314,7 @@ mod imp {
     pub fn stats_print() {}
 }
 
-#[cfg(all(not(external_funcs), not(external_crate), not(jemalloc), windows))]
+#[cfg(all(not(feature = "external_funcs"), not(feature = "external_crate"), not(jemalloc), windows))]
 mod imp {
     use libc::{c_void, size_t};
     use libc;

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -70,7 +70,7 @@
 #[macro_use]
 extern crate core;
 
-#[cfg(all(not(external_funcs), not(external_crate)))]
+#[cfg(all(not(feature = "external_funcs"), not(feature = "external_crate")))]
 extern crate libc;
 
 // Allow testing this library

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -69,6 +69,8 @@
 
 #[macro_use]
 extern crate core;
+
+#[cfg(all(not(external_funcs), not(external_crate)))]
 extern crate libc;
 
 // Allow testing this library


### PR DESCRIPTION
libc is only used when the heap allocations are not defined externally, or defined in another crate. I assume these extern\* configurations were added for the sake of those of us experimenting with freestanding Rust. Avoiding libc where possible is often very important for us.
