### PR TITLE
Prevent Regex::new() from panicking when a non-AST item is repeated

### DIFF
--- a/src/libregex/parse.rs
+++ b/src/libregex/parse.rs
@@ -320,9 +320,10 @@ impl<'a> Parser<'a> {
     }
 
     fn push_repeater(&mut self, c: char) -> Result<(), Error> {
-        if self.stack.len() == 0 {
-            return self.err(
-                "A repeat operator must be preceded by a valid expression.")
+        match self.stack.last() {
+            Some(&Expr(..)) => (),
+            // self.stack is empty, or the top item is not an Expr
+            _ => return self.err("A repeat operator must be preceded by a valid expression."),
         }
         let rep: Repeater = match c {
             '?' => ZeroOne, '*' => ZeroMore, '+' => OneMore,

--- a/src/libregex/test/tests.rs
+++ b/src/libregex/test/tests.rs
@@ -142,6 +142,7 @@ noparse!{fail_range_end_no_class, "[a-[:lower:]]"}
 noparse!{fail_range_end_no_begin, r"[a-\A]"}
 noparse!{fail_range_end_no_end, r"[a-\z]"}
 noparse!{fail_range_end_no_boundary, r"[a-\b]"}
+noparse!{fail_repeat_no_expr, r"-|+"}
 
 macro_rules! mat {
     ($name:ident, $re:expr, $text:expr, $($loc:tt)+) => (


### PR DESCRIPTION
This bug has also affected the `regex!` macro, which has caused an ICE when such an invalid expression is provided.

Fixes #20208.
