### PR TITLE
typeck: boxed closures can't capture by value

### DIFF
--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -19,11 +19,13 @@ use middle::ty::{mod, Ty};
 use rscope::RegionScope;
 use syntax::abi;
 use syntax::ast;
+use syntax::ast::CaptureClause::*;
 use syntax::ast_util;
 use util::ppaux::Repr;
 
 pub fn check_expr_closure<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
                                    expr: &ast::Expr,
+                                   capture: ast::CaptureClause,
                                    opt_kind: Option<ast::UnboxedClosureKind>,
                                    decl: &ast::FnDecl,
                                    body: &ast::Block,
@@ -48,12 +50,24 @@ pub fn check_expr_closure<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
                                                                    fcx.infcx(),
                                                                    expr.span,
                                                                    &None);
+
                     check_boxed_closure(fcx,
                                         expr,
                                         ty::RegionTraitStore(region, ast::MutMutable),
                                         decl,
                                         body,
                                         expected);
+
+                    match capture {
+                        CaptureByValue => {
+                            fcx.ccx.tcx.sess.span_err(
+                                expr.span,
+                                "boxed closures can't capture by value, \
+                                if you want to use an unboxed closure, \
+                                explicitly annotate its kind: e.g. `move |:|`");
+                        },
+                        CaptureByRef => {}
+                    }
                 }
                 Some((sig, kind)) => {
                     check_unboxed_closure(fcx, expr, kind, decl, body, Some(sig));

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3958,8 +3958,8 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
       ast::ExprMatch(ref discrim, ref arms, match_src) => {
         _match::check_match(fcx, expr, &**discrim, arms.as_slice(), expected, match_src);
       }
-      ast::ExprClosure(_, opt_kind, ref decl, ref body) => {
-          closure::check_expr_closure(fcx, expr, opt_kind, &**decl, &**body, expected);
+      ast::ExprClosure(capture, opt_kind, ref decl, ref body) => {
+          closure::check_expr_closure(fcx, expr, capture, opt_kind, &**decl, &**body, expected);
       }
       ast::ExprBlock(ref b) => {
         check_block_with_expected(fcx, &**b, expected);

--- a/src/test/compile-fail/issue-19141.rs
+++ b/src/test/compile-fail/issue-19141.rs
@@ -8,9 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub fn main() {
-    let bar = box 3;
-    let _g = || {
-        let _h = move |:| -> int { *bar }; //~ ERROR cannot move out of captured outer variable
-    };
+fn main() {
+    let n = 0u;
+
+    let f = move || n += 1;  //~error boxed closures can't capture by value
 }

--- a/src/test/compile-fail/issue-20193.rs
+++ b/src/test/compile-fail/issue-20193.rs
@@ -8,9 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub fn main() {
-    let bar = box 3;
-    let _g = || {
-        let _h = move |:| -> int { *bar }; //~ ERROR cannot move out of captured outer variable
+fn foo(t: &mut int){
+    println!("{}", t);
+}
+
+fn main() {
+    let test = 10;
+
+    let h = move || {  //~error boxed closures can't capture by value
+        let mut r = &mut test.clone();
+        foo(r);
     };
+
+    h();
 }

--- a/src/test/compile-fail/issue-20228-1.rs
+++ b/src/test/compile-fail/issue-20228-1.rs
@@ -8,9 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub fn main() {
-    let bar = box 3;
-    let _g = || {
-        let _h = move |:| -> int { *bar }; //~ ERROR cannot move out of captured outer variable
-    };
+struct S;
+
+impl S {
+    fn foo(&self) {
+        let _ = move || { self };  //~error boxed closures can't capture by value
+    }
+}
+
+fn main() {
 }

--- a/src/test/compile-fail/issue-20228-2.rs
+++ b/src/test/compile-fail/issue-20228-2.rs
@@ -8,9 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub fn main() {
-    let bar = box 3;
-    let _g = || {
-        let _h = move |:| -> int { *bar }; //~ ERROR cannot move out of captured outer variable
-    };
+struct S;
+
+impl S {
+    fn foo(&self) {
+        let _ = move || { self.foo() };  //~error boxed closures can't capture by value
+    }
+}
+
+fn main() {
 }


### PR DESCRIPTION
closes #19141
closes #20193
closes #20228

---

Currently whenever we encounter `let f = || {/* */}`, we _always_ type check the RHS as a _boxed_ closure. This is wrong when the RHS is `move || {/* */}` (because boxed closures can't capture by value) and generates all sort of badness during trans (see issues above). What we _should_ do is always type check `move || {/* */}` as an _unboxed_ closure, but ~~I _think_ (haven't tried)~~ (2) this is not feasible right now because we have a limited form of kind (`Fn` vs `FnMut` vs `FnOnce`) inference that only works when there is an expected type (1).

In this PR, I've chosen to generate a type error whenever `let f = move || {/* */}` is encountered. The error asks the user to annotate the kind of the unboxed closure (e.g. `move |:| {/* */}`). Once annotated, the compiler will type check the RHS as an unboxed closure which is what the user wants.

r? @nikomatsakis 

(1) AIUI it only triggers in this scenario:

``` rust
fn is_uc<F>(_: F) where F: FnOnce() {}

fn main() {
    is_uc(|| {});  // type checked as unboxed closure with kind `FnOnce`
}
```

(2) I checked, and it's not possible because `check_unboxed_closure` expects a `kind` argument, but we can't supply that argument in this case (i.e. `let f = || {}`, what's the kind?). We could force the `FnOnce` kind in that case, but that's ad hoc. We should try to infer the kind depending on how the closure is used afterwards, but there is no inference mechanism to do that (at least, not right now).
