### PR TITLE
Make lexer tests runable again

### DIFF
--- a/mk/grammar.mk
+++ b/mk/grammar.mk
@@ -31,7 +31,7 @@ $(BG):
 	$(Q)mkdir -p $(BG)
 
 $(BG)RustLexer.class: $(BG) $(SG)RustLexer.g4
-	$(Q)$(CFG_ANTLR4) -o $(B)grammar $(SG)RustLexer.g4
+	$(Q)$(CFG_ANTLR4) -o $(BG) $(SG)RustLexer.g4
 	$(Q)$(CFG_JAVAC) -d $(BG) $(BG)RustLexer.java
 
 check-build-lexer-verifier: $(BG)verify


### PR DESCRIPTION
I would like to look into some issues related to the model lexer  #15883.

I stumbled upon 2 minor problems when I tried running the lexer tests:
- antlr did not put the generated files in the correct directory
- grammer/verify.rs did not work with the most recent version of rust

With these changes (and setting CLASSPATH=/usr/share/java/antlr-4.4-complete.jar:$CLASSPATH) I was able to execute the tests.

Note that I just fixed the syntax errors and added `None` as 2. argument of `Literal`. I am not sure if this is correct however. I still have to take a closer look at what verify.rs actually does. Are there any helpful pointers?
