### PR TITLE
Make lifetime elision help more useful on type signatures.

### DIFF
--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -164,10 +164,16 @@ pub fn opt_ast_region_to_region<'tcx, AC: AstConv<'tcx>, RS: RegionScope>(
                             let mut m = String::new();
                             let len = v.len();
                             for (i, (name, n)) in v.into_iter().enumerate() {
-                                m.push_str(if n == 1 {
-                                    format!("`{}`", name)
+                                let help_name = if name.is_empty() {
+                                    format!("argument {}", i + 1)
                                 } else {
-                                    format!("one of `{}`'s {} elided lifetimes", name, n)
+                                    format!("`{}`", name)
+                                };
+
+                                m.push_str(if n == 1 {
+                                    help_name
+                                } else {
+                                    format!("one of {}'s {} elided lifetimes", help_name, n)
                                 }[]);
 
                                 if len == 2 && i == 0 {

--- a/src/test/compile-fail/issue-19707.rs
+++ b/src/test/compile-fail/issue-19707.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(unboxed_closures)]
+#![allow(dead_code)]
+
+type foo = fn(&u8, &u8) -> &u8; //~ ERROR missing lifetime specifier
+//~^ HELP the signature does not say whether it is borrowed from argument 1 or argument 2
+
+fn bar<F: Fn(&u8, &u8) -> &u8>(f: &F) {} //~ ERROR missing lifetime specifier
+//~^ HELP the signature does not say whether it is borrowed from argument 1 or argument 2
+
+fn main() {}


### PR DESCRIPTION
Fixes #19707.

In terms of output, it currently uses the form `argument #1`, `argument #2`, etc. If anyone has any better suggestions I would be glad to consider them.
