### PR TITLE
Rename TaskRng to ThreadRng

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1347,7 +1347,7 @@ mod tests {
     use core::cell::Cell;
     use core::default::Default;
     use core::mem;
-    use std::rand::{Rng, task_rng};
+    use std::rand::{Rng, thread_rng};
     use std::rc::Rc;
     use super::ElementSwaps;
 
@@ -1963,7 +1963,7 @@ mod tests {
     fn test_sort() {
         for len in range(4u, 25) {
             for _ in range(0i, 100) {
-                let mut v = task_rng().gen_iter::<uint>().take(len)
+                let mut v = thread_rng().gen_iter::<uint>().take(len)
                                       .collect::<Vec<uint>>();
                 let mut v1 = v.clone();
 
@@ -1999,7 +1999,7 @@ mod tests {
                 // number this element is, i.e. the second elements
                 // will occur in sorted order.
                 let mut v = range(0, len).map(|_| {
-                        let n = task_rng().gen::<uint>() % 10;
+                        let n = thread_rng().gen::<uint>() % 10;
                         counts[n] += 1;
                         (n, counts[n])
                     }).collect::<Vec<(uint, int)>>();

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -112,7 +112,7 @@ mod tests {
 
     #[test]
     fn test_flate_round_trip() {
-        let mut r = rand::task_rng();
+        let mut r = rand::thread_rng();
         let mut words = vec!();
         for _ in range(0u, 20) {
             let range = r.gen_range(1u, 10);

--- a/src/librand/distributions/exponential.rs
+++ b/src/librand/distributions/exponential.rs
@@ -64,7 +64,7 @@ impl Rand for Exp1 {
 /// use std::rand::distributions::{Exp, IndependentSample};
 ///
 /// let exp = Exp::new(2.0);
-/// let v = exp.ind_sample(&mut rand::task_rng());
+/// let v = exp.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from a Exp(2) distribution", v);
 /// ```
 #[deriving(Copy)]

--- a/src/librand/distributions/gamma.rs
+++ b/src/librand/distributions/gamma.rs
@@ -44,7 +44,7 @@ use super::{IndependentSample, Sample, Exp};
 /// use std::rand::distributions::{IndependentSample, Gamma};
 ///
 /// let gamma = Gamma::new(2.0, 5.0);
-/// let v = gamma.ind_sample(&mut rand::task_rng());
+/// let v = gamma.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from a Gamma(2, 5) distribution", v);
 /// ```
 ///
@@ -191,7 +191,7 @@ impl IndependentSample<f64> for GammaLargeShape {
 /// use std::rand::distributions::{ChiSquared, IndependentSample};
 ///
 /// let chi = ChiSquared::new(11.0);
-/// let v = chi.ind_sample(&mut rand::task_rng());
+/// let v = chi.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from a χ²(11) distribution", v)
 /// ```
 pub struct ChiSquared {
@@ -248,7 +248,7 @@ impl IndependentSample<f64> for ChiSquared {
 /// use std::rand::distributions::{FisherF, IndependentSample};
 ///
 /// let f = FisherF::new(2.0, 32.0);
-/// let v = f.ind_sample(&mut rand::task_rng());
+/// let v = f.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from an F(2, 32) distribution", v)
 /// ```
 pub struct FisherF {
@@ -292,7 +292,7 @@ impl IndependentSample<f64> for FisherF {
 /// use std::rand::distributions::{StudentT, IndependentSample};
 ///
 /// let t = StudentT::new(11.0);
-/// let v = t.ind_sample(&mut rand::task_rng());
+/// let v = t.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from a t(11) distribution", v)
 /// ```
 pub struct StudentT {

--- a/src/librand/distributions/mod.rs
+++ b/src/librand/distributions/mod.rs
@@ -96,7 +96,7 @@ pub struct Weighted<T> {
 ///                      Weighted { weight: 4, item: 'b' },
 ///                      Weighted { weight: 1, item: 'c' });
 /// let wc = WeightedChoice::new(items.as_mut_slice());
-/// let mut rng = rand::task_rng();
+/// let mut rng = rand::thread_rng();
 /// for _ in range(0u, 16) {
 ///      // on average prints 'a' 4 times, 'b' 8 and 'c' twice.
 ///      println!("{}", wc.ind_sample(&mut rng));

--- a/src/librand/distributions/normal.rs
+++ b/src/librand/distributions/normal.rs
@@ -81,7 +81,7 @@ impl Rand for StandardNormal {
 ///
 /// // mean 2, standard deviation 3
 /// let normal = Normal::new(2.0, 3.0);
-/// let v = normal.ind_sample(&mut rand::task_rng());
+/// let v = normal.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from a N(2, 9) distribution", v)
 /// ```
 #[deriving(Copy)]
@@ -129,7 +129,7 @@ impl IndependentSample<f64> for Normal {
 ///
 /// // mean 2, standard deviation 3
 /// let log_normal = LogNormal::new(2.0, 3.0);
-/// let v = log_normal.ind_sample(&mut rand::task_rng());
+/// let v = log_normal.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from an ln N(2, 9) distribution", v)
 /// ```
 #[deriving(Copy)]

--- a/src/librand/distributions/range.rs
+++ b/src/librand/distributions/range.rs
@@ -39,7 +39,7 @@ use distributions::{Sample, IndependentSample};
 ///
 /// fn main() {
 ///     let between = Range::new(10u, 10000u);
-///     let mut rng = std::rand::task_rng();
+///     let mut rng = std::rand::thread_rng();
 ///     let mut sum = 0;
 ///     for _ in range(0u, 1000) {
 ///         sum += between.ind_sample(&mut rng);

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -138,10 +138,10 @@ pub trait Rng {
     /// # Example
     ///
     /// ```rust
-    /// use std::rand::{task_rng, Rng};
+    /// use std::rand::{thread_rng, Rng};
     ///
     /// let mut v = [0u8, .. 13579];
-    /// task_rng().fill_bytes(&mut v);
+    /// thread_rng().fill_bytes(&mut v);
     /// println!("{}", v.as_slice());
     /// ```
     fn fill_bytes(&mut self, dest: &mut [u8]) {
@@ -173,9 +173,9 @@ pub trait Rng {
     /// # Example
     ///
     /// ```rust
-    /// use std::rand::{task_rng, Rng};
+    /// use std::rand::{thread_rng, Rng};
     ///
-    /// let mut rng = task_rng();
+    /// let mut rng = thread_rng();
     /// let x: uint = rng.gen();
     /// println!("{}", x);
     /// println!("{}", rng.gen::<(f64, bool)>());
@@ -191,9 +191,9 @@ pub trait Rng {
     /// # Example
     ///
     /// ```
-    /// use std::rand::{task_rng, Rng};
+    /// use std::rand::{thread_rng, Rng};
     ///
-    /// let mut rng = task_rng();
+    /// let mut rng = thread_rng();
     /// let x = rng.gen_iter::<uint>().take(10).collect::<Vec<uint>>();
     /// println!("{}", x);
     /// println!("{}", rng.gen_iter::<(f64, bool)>().take(5)
@@ -218,9 +218,9 @@ pub trait Rng {
     /// # Example
     ///
     /// ```rust
-    /// use std::rand::{task_rng, Rng};
+    /// use std::rand::{thread_rng, Rng};
     ///
-    /// let mut rng = task_rng();
+    /// let mut rng = thread_rng();
     /// let n: uint = rng.gen_range(0u, 10);
     /// println!("{}", n);
     /// let m: f64 = rng.gen_range(-40.0f64, 1.3e5f64);
@@ -236,9 +236,9 @@ pub trait Rng {
     /// # Example
     ///
     /// ```rust
-    /// use std::rand::{task_rng, Rng};
+    /// use std::rand::{thread_rng, Rng};
     ///
-    /// let mut rng = task_rng();
+    /// let mut rng = thread_rng();
     /// println!("{}", rng.gen_weighted_bool(3));
     /// ```
     fn gen_weighted_bool(&mut self, n: uint) -> bool {
@@ -250,9 +250,9 @@ pub trait Rng {
     /// # Example
     ///
     /// ```rust
-    /// use std::rand::{task_rng, Rng};
+    /// use std::rand::{thread_rng, Rng};
     ///
-    /// let s: String = task_rng().gen_ascii_chars().take(10).collect();
+    /// let s: String = thread_rng().gen_ascii_chars().take(10).collect();
     /// println!("{}", s);
     /// ```
     fn gen_ascii_chars<'a>(&'a mut self) -> AsciiGenerator<'a, Self> {
@@ -266,10 +266,10 @@ pub trait Rng {
     /// # Example
     ///
     /// ```
-    /// use std::rand::{task_rng, Rng};
+    /// use std::rand::{thread_rng, Rng};
     ///
     /// let choices = [1i, 2, 4, 8, 16, 32];
-    /// let mut rng = task_rng();
+    /// let mut rng = thread_rng();
     /// println!("{}", rng.choose(&choices));
     /// assert_eq!(rng.choose(choices[..0]), None);
     /// ```
@@ -286,9 +286,9 @@ pub trait Rng {
     /// # Example
     ///
     /// ```rust
-    /// use std::rand::{task_rng, Rng};
+    /// use std::rand::{thread_rng, Rng};
     ///
-    /// let mut rng = task_rng();
+    /// let mut rng = thread_rng();
     /// let mut y = [1i, 2, 3];
     /// rng.shuffle(&mut y);
     /// println!("{}", y.as_slice());
@@ -520,8 +520,8 @@ mod test {
         }
     }
 
-    pub fn rng() -> MyRng<rand::TaskRng> {
-        MyRng { inner: rand::task_rng() }
+    pub fn rng() -> MyRng<rand::ThreadRng> {
+        MyRng { inner: rand::thread_rng() }
     }
 
     pub fn weak_rng() -> MyRng<rand::XorShiftRng> {

--- a/src/librand/rand_impls.rs
+++ b/src/librand/rand_impls.rs
@@ -215,7 +215,7 @@ impl<T:Rand> Rand for Option<T> {
 #[cfg(test)]
 mod tests {
     use std::prelude::*;
-    use std::rand::{Rng, task_rng, Open01, Closed01};
+    use std::rand::{Rng, thread_rng, Open01, Closed01};
 
     struct ConstantRng(u64);
     impl Rng for ConstantRng {
@@ -240,7 +240,7 @@ mod tests {
     fn rand_open() {
         // this is unlikely to catch an incorrect implementation that
         // generates exactly 0 or 1, but it keeps it sane.
-        let mut rng = task_rng();
+        let mut rng = thread_rng();
         for _ in range(0u, 1_000) {
             // strict inequalities
             let Open01(f) = rng.gen::<Open01<f64>>();
@@ -253,7 +253,7 @@ mod tests {
 
     #[test]
     fn rand_closed() {
-        let mut rng = task_rng();
+        let mut rng = thread_rng();
         for _ in range(0u, 1_000) {
             // strict inequalities
             let Closed01(f) = rng.gen::<Closed01<f64>>();

--- a/src/libregex/test/bench.rs
+++ b/src/libregex/test/bench.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 #![allow(non_snake_case)]
 
-use std::rand::{Rng, task_rng};
+use std::rand::{Rng, thread_rng};
 use stdtest::Bencher;
 
 use regex::{Regex, NoExpand};
@@ -154,7 +154,7 @@ fn medium() -> Regex { regex!("[XYZ]ABCDEFGHIJKLMNOPQRSTUVWXYZ$") }
 fn hard() -> Regex { regex!("[ -~]*ABCDEFGHIJKLMNOPQRSTUVWXYZ$") }
 
 fn gen_text(n: uint) -> String {
-    let mut rng = task_rng();
+    let mut rng = thread_rng();
     let mut bytes = rng.gen_ascii_chars().map(|n| n as u8).take(n)
                        .collect::<Vec<u8>>();
     for (i, b) in bytes.iter_mut().enumerate() {

--- a/src/libserialize/base64.rs
+++ b/src/libserialize/base64.rs
@@ -392,10 +392,10 @@ mod tests {
 
     #[test]
     fn test_base64_random() {
-        use std::rand::{task_rng, random, Rng};
+        use std::rand::{thread_rng, random, Rng};
 
         for _ in range(0u, 1000) {
-            let times = task_rng().gen_range(1u, 100);
+            let times = thread_rng().gen_range(1u, 100);
             let v = Vec::from_fn(times, |_| random::<u8>());
             assert_eq!(v.to_base64(STANDARD)
                         .from_base64()

--- a/src/libstd/hash.rs
+++ b/src/libstd/hash.rs
@@ -79,7 +79,7 @@ impl RandomSipHasher {
     /// Construct a new `RandomSipHasher` that is initialized with random keys.
     #[inline]
     pub fn new() -> RandomSipHasher {
-        let mut r = rand::task_rng();
+        let mut r = rand::thread_rng();
         let r0 = r.gen();
         let r1 = r.gen();
         RandomSipHasher {

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1438,7 +1438,7 @@ mod tests {
     }
 
     fn make_rand_name() -> String {
-        let mut rng = rand::task_rng();
+        let mut rng = rand::thread_rng();
         let n = format!("TEST{}", rng.gen_ascii_chars().take(10u)
                                      .collect::<String>());
         assert!(getenv(n.as_slice()).is_none());

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -394,7 +394,7 @@ mod tests {
         for _ in range(0, N) {
             let tx = tx.clone();
             spawn(move|| {
-                let mut rng = rand::task_rng();
+                let mut rng = rand::thread_rng();
                 for _ in range(0, M) {
                     if rng.gen_weighted_bool(N) {
                         drop(R.write());

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -724,7 +724,7 @@ pub fn fresh_name(src: &ast::Ident) -> ast::Name {
     // following: debug version. Could work in final except that it's incompatible with
     // good error messages and uses of struct names in ambiguous could-be-binding
     // locations. Also definitely destroys the guarantee given above about ptr_eq.
-    /*let num = rand::task_rng().gen_uint_range(0,0xffff);
+    /*let num = rand::thread_rng().gen_uint_range(0,0xffff);
     gensym(format!("{}_{}",ident_to_string(src),num))*/
 }
 

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -83,7 +83,7 @@ fn read_line() {
 }
 
 fn vec_plus() {
-    let mut r = rand::task_rng();
+    let mut r = rand::thread_rng();
 
     let mut v = Vec::new();
     let mut i = 0;
@@ -101,7 +101,7 @@ fn vec_plus() {
 }
 
 fn vec_append() {
-    let mut r = rand::task_rng();
+    let mut r = rand::thread_rng();
 
     let mut v = Vec::new();
     let mut i = 0;
@@ -122,7 +122,7 @@ fn vec_append() {
 }
 
 fn vec_push_all() {
-    let mut r = rand::task_rng();
+    let mut r = rand::thread_rng();
 
     let mut v = Vec::new();
     for i in range(0u, 1500) {

--- a/src/test/compile-fail/task-rng-isnt-sendable.rs
+++ b/src/test/compile-fail/task-rng-isnt-sendable.rs
@@ -8,14 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ensure that the TaskRng isn't/doesn't become accidentally sendable.
+// ensure that the ThreadRng isn't/doesn't become accidentally sendable.
 
 use std::rand;
 
 fn test_send<S: Send>() {}
 
 pub fn main() {
-    test_send::<rand::TaskRng>();
+    test_send::<rand::ThreadRng>();
     //~^ ERROR `core::kinds::Send` is not implemented
     //~^^ ERROR `core::kinds::Send` is not implemented
 }

--- a/src/test/run-make/unicode-input/multiple_files.rs
+++ b/src/test/run-make/unicode-input/multiple_files.rs
@@ -10,7 +10,7 @@
 
 use std::{char, os};
 use std::io::{File, Command};
-use std::rand::{task_rng, Rng};
+use std::rand::{thread_rng, Rng};
 
 // creates unicode_input_multiple_files_{main,chars}.rs, where the
 // former imports the latter. `_chars` just contains an identifier
@@ -19,7 +19,7 @@ use std::rand::{task_rng, Rng};
 // this span used to upset the compiler).
 
 fn random_char() -> char {
-    let mut rng = task_rng();
+    let mut rng = thread_rng();
     // a subset of the XID_start Unicode table (ensuring that the
     // compiler doesn't fail with an "unrecognised token" error)
     let (lo, hi): (u32, u32) = match rng.gen_range(1u32, 4u32 + 1) {

--- a/src/test/run-make/unicode-input/span_length.rs
+++ b/src/test/run-make/unicode-input/span_length.rs
@@ -10,7 +10,7 @@
 
 use std::{char, os};
 use std::io::{File, Command};
-use std::rand::{task_rng, Rng};
+use std::rand::{thread_rng, Rng};
 
 // creates a file with `fn main() { <random ident> }` and checks the
 // compiler emits a span of the appropriate length (for the
@@ -18,7 +18,7 @@ use std::rand::{task_rng, Rng};
 // points, but should be the number of graphemes (FIXME #7043)
 
 fn random_char() -> char {
-    let mut rng = task_rng();
+    let mut rng = thread_rng();
     // a subset of the XID_start Unicode table (ensuring that the
     // compiler doesn't fail with an "unrecognised token" error)
     let (lo, hi): (u32, u32) = match rng.gen_range(1u32, 4u32 + 1) {
@@ -38,7 +38,7 @@ fn main() {
     let main_file = tmpdir.join("span_main.rs");
 
     for _ in range(0u, 100) {
-        let n = task_rng().gen_range(3u, 20);
+        let n = thread_rng().gen_range(3u, 20);
 
         {
             let _ = write!(&mut File::create(&main_file).unwrap(),

--- a/src/test/run-pass/vector-sort-panic-safe.rs
+++ b/src/test/run-pass/vector-sort-panic-safe.rs
@@ -10,7 +10,7 @@
 
 use std::task;
 use std::sync::atomic::{AtomicUint, INIT_ATOMIC_UINT, Relaxed};
-use std::rand::{task_rng, Rng, Rand};
+use std::rand::{thread_rng, Rng, Rand};
 
 const REPEATS: uint = 5;
 const MAX_LEN: uint = 32;
@@ -59,7 +59,7 @@ pub fn main() {
             // IDs start from 0.
             creation_count.store(0, Relaxed);
 
-            let main = task_rng().gen_iter::<DropCounter>()
+            let main = thread_rng().gen_iter::<DropCounter>()
                                  .take(len)
                                  .collect::<Vec<DropCounter>>();
 


### PR DESCRIPTION
Since runtime is removed, rust has no tasks anymore and everything is moving
from being task-\* to thread-*. Let’s rename TaskRng as well!

This is a breaking change. If a breaking change for consistency is not desired, feel free to close.
