### PR TITLE
`man rustc` and `rustc --help` say options go first

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -5410,7 +5410,7 @@ fn main() {
 }
 ```
 
-You can have the macros expanded like this: `rustc print.rs --pretty=expanded`, which will
+You can have the macros expanded like this: `rustc --pretty=expanded print.rs`, which will
 give us this huge result:
 
 ```{rust,ignore}


### PR DESCRIPTION
For consistency with the documentation, _options_ should be before _filenames_.
