### PR TITLE
Indent where clause in rustdoc

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -123,7 +123,7 @@ impl<'a> fmt::Show for WhereClause<'a> {
         if gens.where_predicates.len() == 0 {
             return Ok(());
         }
-        try!(f.write(" where ".as_bytes()));
+        try!(f.write(" <span class='where'>where ".as_bytes()));
         for (i, pred) in gens.where_predicates.iter().enumerate() {
             if i > 0 {
                 try!(f.write(", ".as_bytes()));
@@ -149,6 +149,7 @@ impl<'a> fmt::Show for WhereClause<'a> {
                 }
             }
         }
+        try!(f.write("</span>".as_bytes()));
         Ok(())
     }
 }

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -306,8 +306,10 @@ nav.sub {
     font-size: 1em;
     position: relative;
 }
-/* Shift "where ..." part of method definition down a line and indent it */
-.content .method .where { display: block; padding-left: 3.75em; }
+/* Shift "where ..." part of method definition down a line */
+.content .method .where { display: block; }
+/* Bit of whitespace to indent it */
+.content .method .where::before { content: '      '; }
 
 .content .methods .docblock { margin-left: 40px; }
 

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -306,6 +306,9 @@ nav.sub {
     font-size: 1em;
     position: relative;
 }
+/* Shift "where ..." part of method definition down a line and indent it */
+.content .method .where { display: block; padding-left: 3.75em; }
+
 .content .methods .docblock { margin-left: 40px; }
 
 .content .impl-items .docblock { margin-left: 40px; }


### PR DESCRIPTION
- Add <span class=‘where’> around clause
- CSS rule to format the span

(for issue #20176)
