### PR TITLE
Update curl flag and add additional two-step installation instructions.

### DIFF
--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -23,11 +23,16 @@ Linux or a Mac, all you need to do is this (note that you don't need to type
 in the `$`s, they just indicate the start of each command):
 
 ```bash
-$ curl -s https://static.rust-lang.org/rustup.sh | sudo sh
+curl -L https://static.rust-lang.org/rustup.sh | sudo sh
 ```
 
-(If you're concerned about `curl | sudo sh`, please keep reading. Disclaimer
-below.)
+If you're concerned about the [potential insecurity](http://curlpipesh.tumblr.com/) of using `curl | sudo sh`, 
+please keep reading and see our disclaimer below. And feel free to use a two-step version of the installation and examine our installation script:
+
+```bash
+curl -L https://static.rust-lang.org/rustup.sh -o rustup.sh
+sudo sh rustup.sh
+```
 
 If you're on Windows, please download either the [32-bit
 installer](https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-gnu.exe)

--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -30,7 +30,7 @@ If you're concerned about the [potential insecurity](http://curlpipesh.tumblr.co
 please keep reading and see our disclaimer below. And feel free to use a two-step version of the installation and examine our installation script:
 
 ```bash
-curl -L https://static.rust-lang.org/rustup.sh -o rustup.sh
+curl -L https://static.rust-lang.org/rustup.sh -O
 sudo sh rustup.sh
 ```
 


### PR DESCRIPTION
Updating curl flag and instructions to follow better security practices
used by other projects: https://github.com/saltstack/salt-bootstrap

Other references:
http://www.reddit.com/r/linux/comments/1s58my/please_stop_piping_curl1_to_sh1/
http://www.seancassidy.me/dont-pipe-to-your-shell.html
https://news.ycombinator.com/item?id=8550511
http://output.chrissnell.com/post/69023793377/stop-piping-curl-1-to-sh-1
http://www.reddit.com/comments/1pqtcb
