### PR TITLE
Fix incorrect link in Makefile.in documentation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -99,7 +99,7 @@
 # This is hardly all there is to know of The Rust Build System's
 # mysteries. The tale continues on the wiki[1][2].
 #
-# [1]: https://github.com/rust-lang/rust/wiki/Note-build-system
+# [1]: https://github.com/rust-lang/rust/wiki/Note-getting-started-developing-Rust
 # [2]: https://github.com/rust-lang/rust/wiki/Note-testsuite
 #
 # If you really feel like getting your hands dirty, then:


### PR DESCRIPTION
This is a very trivial fix for a broken link that I noticed while building the compiler for the first time.  I've changed it to its presumed successor.
