### PR TITLE
Make the improper_ctypes lint more robust

### DIFF
--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -482,6 +482,7 @@ pub mod eabi {
 #[cfg(not(test))]
 /// Entry point of panic from the libcore crate.
 #[lang = "panic_fmt"]
+#[allow(improper_ctypes)] // FIXME(tomjakubowski)
 pub extern fn rust_begin_unwind(msg: fmt::Arguments,
                                 file: &'static str, line: uint) -> ! {
     begin_unwind_fmt(msg, &(file, line))
@@ -492,6 +493,7 @@ pub extern fn rust_begin_unwind(msg: fmt::Arguments,
 #[cfg(not(test))]
 /// Entry point of panic from the libcore crate.
 #[lang = "panic_fmt"]
+#[allow(improper_ctypes)] // FIXME(tomjakubowski)
 pub extern fn rust_begin_unwind(msg: &fmt::Arguments,
                                 file: &'static str, line: uint) -> ! {
     begin_unwind_fmt(msg, &(file, line))

--- a/src/test/compile-fail/lint-ctypes-xcrate-struct.rs
+++ b/src/test/compile-fail/lint-ctypes-xcrate-struct.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(improper_ctypes)]
+
+#[repr(C)]
+pub struct Foo {
+    _x: String
+}
+
+extern {
+    pub fn bad(f: Foo); //~ ERROR found type without foreign-function-safe
+}
+
+fn main() {
+}

--- a/src/test/compile-fail/lint-ctypes.rs
+++ b/src/test/compile-fail/lint-ctypes.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -12,15 +12,38 @@
 
 extern crate libc;
 
+#[deriving(Copy)]
+pub struct Bad {
+    _x: u32
+}
+
+#[deriving(Copy)]
+#[repr(C)]
+pub struct Good {
+    _x: u32
+}
+
 extern {
     pub fn bare_type1(size: int); //~ ERROR: found rust type
     pub fn bare_type2(size: uint); //~ ERROR: found rust type
     pub fn ptr_type1(size: *const int); //~ ERROR: found rust type
     pub fn ptr_type2(size: *const uint); //~ ERROR: found rust type
+    pub fn non_c_repr_type(b: Bad); //~ ERROR: found type without foreign-function-safe
 
     pub fn good1(size: *const libc::c_int);
     pub fn good2(size: *const libc::c_uint);
+    pub fn good3(g: Good);
 }
+
+pub extern fn ex_bare_type1(_: int) {} //~ ERROR: found rust type
+pub extern fn ex_bare_type2(_: uint)  {} //~ ERROR: found rust type
+pub extern fn ex_ptr_type1(_: *const int) {} //~ ERROR: found rust type
+pub extern fn ex_ptr_type2(_: *const uint) {}  //~ ERROR: found rust type
+pub extern fn ex_non_c_repr_type(_: Bad) {} //~ ERROR: found type without foreign-function-safe
+
+pub extern fn ex_good1(_: *const libc::c_int) {}
+pub extern fn ex_good2(_: *const libc::c_uint) {}
+pub extern fn ex_good3(_: Good) {}
 
 fn main() {
 }


### PR DESCRIPTION
It now checks extern fns in addition to foreign fns and checks `DefStruct`
defs as well.

There is room for improvement: for example, I believe that pointers
should be safe in extern fn signatures regardless of the pointee's
representation.

The `FIXME` on `rust_begin_unwind_fmt` is because I don't think it
should be, or needs to be, C ABI (cc @eddyb) and it takes a problematic
`fmt::Arguments` structure by value.

Fix #20098, fix #19834
