### PR TITLE
Rust installer v2

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -242,7 +242,9 @@ dist/$$(PKG_NAME)-$(1).tar.gz: dist-install-dir-$(1)
 		--work-dir=tmp/dist \
 		--output-dir=dist \
 		--non-installed-prefixes=$$(NON_INSTALLED_PREFIXES) \
-		--package-name=$$(PKG_NAME)-$(1)
+		--package-name=$$(PKG_NAME)-$(1) \
+		--component-name=rustc \
+		--legacy-manifest-dirs=rustlib,cargo
 	$$(Q)rm -R tmp/dist/$$(PKG_NAME)-$(1)-image
 
 endef

--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -321,27 +321,20 @@ distcheck-docs: dist-docs
 # Primary targets (dist, distcheck)
 ######################################################################
 
-ifdef CFG_WINDOWSY_$(CFG_BUILD)
-
-dist: dist-win dist-tar-bins
-
-distcheck: distcheck-win
-	$(Q)rm -Rf tmp/distcheck
-	@echo
-	@echo -----------------------------------------------
-	@echo "Rust ready for distribution (see ./dist)"
-	@echo -----------------------------------------------
-
-else
+MAYBE_DIST_TAR_SRC=dist-tar-src
+MAYBE_DISTCHECK_TAR_SRC=distcheck-tar-src
 
 # FIXME #13224: On OS X don't produce tarballs simply because --exclude-vcs don't work.
 # This is a huge hack because I just don't have time to figure out another solution.
 ifeq ($(CFG_OSTYPE), apple-darwin)
 MAYBE_DIST_TAR_SRC=
 MAYBE_DISTCHECK_TAR_SRC=
-else
-MAYBE_DIST_TAR_SRC=dist-tar-src
-MAYBE_DISTCHECK_TAR_SRC=distcheck-tar-src
+endif
+
+# Don't bother with source tarballs on windows just because we historically haven't.
+ifeq ($(CFG_OSTYPE), pc-windows-gnu)
+MAYBE_DIST_TAR_SRC=
+MAYBE_DISTCHECK_TAR_SRC=
 endif
 
 ifneq ($(CFG_DISABLE_DOCS),)
@@ -352,15 +345,13 @@ MAYBE_DIST_DOCS=dist-docs
 MAYBE_DISTCHECK_DOCS=distcheck-docs
 endif
 
-dist: $(MAYBE_DIST_TAR_SRC) dist-osx dist-tar-bins $(MAYBE_DIST_DOCS)
+dist: $(MAYBE_DIST_TAR_SRC) dist-osx dist-win dist-tar-bins $(MAYBE_DIST_DOCS)
 
-distcheck: $(MAYBE_DISTCHECK_TAR_SRC) distcheck-osx distcheck-tar-bins $(MAYBE_DISTCHECK_DOCS)
+distcheck: $(MAYBE_DISTCHECK_TAR_SRC) distcheck-osx distcheck-win distcheck-tar-bins $(MAYBE_DISTCHECK_DOCS)
 	$(Q)rm -Rf tmp/distcheck
 	@echo
 	@echo -----------------------------------------------
 	@echo "Rust ready for distribution (see ./dist)"
 	@echo -----------------------------------------------
-
-endif
 
 .PHONY: dist distcheck

--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -314,13 +314,12 @@ ifdef CFG_WINDOWSY_$(CFG_BUILD)
 MAYBE_MINGW_TARBALLS=$(foreach host,$(CFG_HOST),dist/$(MINGW_PKG_NAME)-$(host).tar.gz)
 endif
 
-ifneq ($(CFG_DISABLE_DOCS),)
-dist-tar-bins: $(foreach host,$(CFG_HOST),dist/$(PKG_NAME)-$(host).tar.gz) $(MAYBE_MINGW_TARBALLS)
-else
-dist-tar-bins: $(foreach host,$(CFG_HOST),dist/$(PKG_NAME)-$(host).tar.gz) \
-               $(foreach host,$(CFG_HOST),dist/$(DOC_PKG_NAME)-$(host).tar.gz) \
-               $(MAYBE_MINGW_TARBALLS)
+ifeq ($(CFG_DISABLE_DOCS),)
+MAYBE_DOC_TARBALLS=$(foreach host,$(CFG_HOST),dist/$(DOC_PKG_NAME)-$(host).tar.gz)
 endif
+
+dist-tar-bins: $(foreach host,$(CFG_HOST),dist/$(PKG_NAME)-$(host).tar.gz) \
+	$(MAYBE_DOC_TARBALLS) $(MAYBE_MINGW_TARBALLS)
 
 # Just try to run the compiler for the build host
 distcheck-tar-bins: dist-tar-bins

--- a/mk/install.mk
+++ b/mk/install.mk
@@ -21,6 +21,9 @@ ifeq (root user, $(USER) $(patsubst %,user,$(SUDO_USER)))
 else
 	$(Q)$(MAKE) prepare_install
 endif
+ifeq ($(CFG_DISABLE_DOCS),)
+	$(Q)cd tmp/empty_dir && sh ../../tmp/dist/$(DOC_PKG_NAME)-$(CFG_BUILD)/install.sh --prefix="$(DESTDIR)$(CFG_PREFIX)" --libdir="$(DESTDIR)$(CFG_LIBDIR)" --mandir="$(DESTDIR)$(CFG_MANDIR)" "$(MAYBE_DISABLE_VERIFY)"
+endif
 	$(Q)cd tmp/empty_dir && sh ../../tmp/dist/$(PKG_NAME)-$(CFG_BUILD)/install.sh --prefix="$(DESTDIR)$(CFG_PREFIX)" --libdir="$(DESTDIR)$(CFG_LIBDIR)" --mandir="$(DESTDIR)$(CFG_MANDIR)" "$(MAYBE_DISABLE_VERIFY)"
 # Remove tmp files because it's a decent amount of disk space
 	$(Q)rm -R tmp/dist
@@ -33,6 +36,9 @@ ifeq (root user, $(USER) $(patsubst %,user,$(SUDO_USER)))
 	$(Q)sudo -u "$$SUDO_USER" $(MAKE) prepare_uninstall
 else
 	$(Q)$(MAKE) prepare_uninstall
+endif
+ifeq ($(CFG_DISABLE_DOCS),)
+	$(Q)cd tmp/empty_dir && sh ../../tmp/dist/$(DOC_PKG_NAME)-$(CFG_BUILD)/install.sh --uninstall --prefix="$(DESTDIR)$(CFG_PREFIX)" --libdir="$(DESTDIR)$(CFG_LIBDIR)" --mandir="$(DESTDIR)$(CFG_MANDIR)"
 endif
 	$(Q)cd tmp/empty_dir && sh ../../tmp/dist/$(PKG_NAME)-$(CFG_BUILD)/install.sh --uninstall --prefix="$(DESTDIR)$(CFG_PREFIX)" --libdir="$(DESTDIR)$(CFG_LIBDIR)" --mandir="$(DESTDIR)$(CFG_MANDIR)"
 # Remove tmp files because it's a decent amount of disk space

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -297,6 +297,7 @@ tidy:
 		| grep '^$(S)src/doc' -v \
 		| grep '^$(S)src/compiler-rt' -v \
 		| grep '^$(S)src/libbacktrace' -v \
+		| grep '^$(S)src/rust-installer' -v \
 		| xargs $(CFG_PYTHON) $(S)src/etc/check-binaries.py
 
 endif

--- a/src/etc/make-win-dist.py
+++ b/src/etc/make-win-dist.py
@@ -114,11 +114,5 @@ def make_win_dist(rust_root, gcc_root, target_triple):
     for src in target_libs:
         shutil.copy(src, target_lib_dir)
 
-    # Copy license files
-    lic_dir = os.path.join(rust_root, "bin", "third-party")
-    if os.path.exists(lic_dir):
-        shutil.rmtree(lic_dir) # copytree() won't overwrite existing files
-    shutil.copytree(os.path.join(os.path.dirname(__file__), "third-party"), lic_dir)
-
 if __name__=="__main__":
     make_win_dist(sys.argv[1], sys.argv[2], sys.argv[3])


### PR DESCRIPTION
This upgrades to a version of [rust-installer](https://github.com/rust-lang/rust-installer) that supports multiple 'components', so that the output can be combined into a [single installer](https://github.com/rust-lang/rust-packaging) that contains both Rust and Cargo (#16456).

At the same time it also packages documentation into a component called 'rust-docs', which will again be merged into the combined installer (#14916).

It creates yet _another_ component, 'rust-mingw', to carry the optional parts of mingw necessary to link with Rust on windows, and makes distcheck build all these installer components for upload by the buildbots. It also moves the 'third-party' docs from the 'bin/' folder to 'share/doc/rust' where the rest of the docs live, temporarily removing them from the .exe installer.

This needs to be merged at roughly the same time as the [corresponding Cargo PR](https://github.com/rust-lang/cargo/pull/1102).

Next steps:
- Modify rust-packaging to produce combined .exe and .pkg installers.
- Set up automation for building rust-packaging every time a rust build is completed.
- Rename the 'rust' installer artifacts produced here to 'rustc' and the the 'rust-combined' produced by rust-packaging to just 'rust'.
- Remove the .exe and .pkg packaging from the main repo.

r? @alexcrichton p=1 please. There's a lot more to do here.
