### PR TITLE
Fix impl of Send and Sync for mips

### DIFF
--- a/src/libstd/sys/unix/c.rs
+++ b/src/libstd/sys/unix/c.rs
@@ -214,8 +214,8 @@ mod signal {
         sa_resv: [libc::c_int, ..1],
     }
 
-    impl ::kinds::Send for sigaction { }
-    impl ::kinds::Sync for sigaction { }
+    unsafe impl ::kinds::Send for sigaction { }
+    unsafe impl ::kinds::Sync for sigaction { }
 
     #[repr(C)]
     pub struct sigset_t {


### PR DESCRIPTION
In f436f9ca2, the Send and Sync traits became `unsafe`. They were updated for `target_arch = x86` and others, but `mips` was missed.
