### PR TITLE
Tweaks to beta/alpha versioning

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -15,6 +15,9 @@
 # The version number
 CFG_RELEASE_NUM=0.13.0
 
+# An optional number to put after the label, e.g. '2' -> '-beta2'
+CFG_BETA_CYCLE=1
+
 CFG_FILENAME_EXTRA=4e7c5e5c
 
 ifeq ($(CFG_RELEASE_CHANNEL),stable)
@@ -24,7 +27,7 @@ CFG_RELEASE=$(CFG_RELEASE_NUM)
 CFG_PACKAGE_VERS=$(CFG_RELEASE_NUM)
 endif
 ifeq ($(CFG_RELEASE_CHANNEL),beta)
-CFG_RELEASE=$(CFG_RELEASE_NUM)-beta
+CFG_RELEASE=$(CFG_RELEASE_NUM)-beta$(CFG_BETA_CYCLE)
 # When building beta/nightly distributables just reuse the same "beta"
 # name so when we upload we'll always override the previous
 # nighly. This doesn't actually impact the version reported by rustc -

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -27,12 +27,13 @@ CFG_RELEASE=$(CFG_RELEASE_NUM)
 CFG_PACKAGE_VERS=$(CFG_RELEASE_NUM)
 endif
 ifeq ($(CFG_RELEASE_CHANNEL),beta)
-CFG_RELEASE=$(CFG_RELEASE_NUM)-beta$(CFG_BETA_CYCLE)
+# The beta channel is temporarily called 'alpha'
+CFG_RELEASE=$(CFG_RELEASE_NUM)-alpha$(CFG_BETA_CYCLE)
 # When building beta/nightly distributables just reuse the same "beta"
 # name so when we upload we'll always override the previous
 # nighly. This doesn't actually impact the version reported by rustc -
 # it's just for file naming.
-CFG_PACKAGE_VERS=beta
+CFG_PACKAGE_VERS=alpha
 endif
 ifeq ($(CFG_RELEASE_CHANNEL),nightly)
 CFG_RELEASE=$(CFG_RELEASE_NUM)-nightly

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -16,7 +16,7 @@
 CFG_RELEASE_NUM=0.13.0
 
 # An optional number to put after the label, e.g. '2' -> '-beta2'
-CFG_BETA_CYCLE=1
+CFG_BETA_CYCLE=
 
 CFG_FILENAME_EXTRA=4e7c5e5c
 


### PR DESCRIPTION
Adds a new 'beta cycle' variable that can be appended to the '-beta' version label, e.g. '-beta1'. Changes the version label for the beta channel temporarily to 'alpha'. Changes the artifact name of the beta channel to contain the version number instead of just being called 'beta'. The beta cycle number is currently set to 1.

The impact of this is that the first alphas will be called '1.0.0-alpha1' and the artifacts will also be called '1.0.0-alpha1-*.tar.gz'. We could alternately leave out the cycle number if we are confident there will be only one alpha cycle.

r? @alexcrichton cc @nikomatsakis @huonw 
