### PR TITLE
 	Forbid static methods in object safe traits

### DIFF
--- a/src/librustc_typeck/check/vtable.rs
+++ b/src/librustc_typeck/check/vtable.rs
@@ -166,11 +166,13 @@ fn check_object_safety_inner<'tcx>(tcx: &ty::ctxt<'tcx>,
         }
     }
 
-    /// Returns a vec of error messages. If hte vec is empty - no errors!
+    /// Returns a vec of error messages. If the vec is empty - no errors!
     ///
     /// There are some limitations to calling functions through an object, because (a) the self
     /// type is not known (that's the whole point of a trait instance, after all, to obscure the
-    /// self type) and (b) the call must go through a vtable and hence cannot be monomorphized.
+    /// self type), (b) the call must go through a vtable and hence cannot be monomorphized and
+    /// (c) the trait contains static methods which can't be called because we don't know the
+    /// concrete type.
     fn check_object_safety_of_method<'tcx>(tcx: &ty::ctxt<'tcx>,
                                            method: &ty::Method<'tcx>)
                                            -> Vec<String> {
@@ -185,9 +187,11 @@ fn check_object_safety_inner<'tcx>(tcx: &ty::ctxt<'tcx>,
             }
 
             ty::StaticExplicitSelfCategory => {
-                // Static methods are always object-safe since they
-                // can't be called through a trait object
-                return msgs
+                // Static methods are never object safe (reason (c)).
+                msgs.push(format!("cannot call a static method (`{}`) \
+                                   through a trait object",
+                                  method_name));
+                return msgs;
             }
             ty::ByReferenceExplicitSelfCategory(..) |
             ty::ByBoxExplicitSelfCategory => {}

--- a/src/test/compile-fail/trait-object-safety.rs
+++ b/src/test/compile-fail/trait-object-safety.rs
@@ -8,19 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Check that object-safe methods are identified as such.
+// Check that static methods are not object-safe.
 
 trait Tr {
-    fn foo(&self);
+    fn foo();
 }
 
 struct St;
 
 impl Tr for St {
-    fn foo(&self) {}
+    fn foo() {}
 }
 
 fn main() {
-    let s: &Tr = &St;
-    s.foo();
+    let _: &Tr = &St; //~ ERROR cannot convert to a trait object because trait `Tr` is not
+    //~^ NOTE cannot call a static method (`foo`) through a trait object
 }


### PR DESCRIPTION
Closes #19949 and rust-lang/rfcs#428

[breaking change]

If you have traits used with objects with static methods, you'll need to move
the static methods to a different trait.

r? @cmr 
