### PR TITLE
mk: Append -src to source tarballs for easier identification

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -33,7 +33,7 @@ LICENSE.txt: $(S)COPYRIGHT $(S)LICENSE-APACHE $(S)LICENSE-MIT
 # Source tarball
 ######################################################################
 
-PKG_TAR = dist/$(PKG_NAME).tar.gz
+PKG_TAR = dist/$(PKG_NAME)-src.tar.gz
 
 PKG_GITMODULES := $(S)src/llvm $(S)src/compiler-rt \
 		  $(S)src/rt/hoedown $(S)src/jemalloc


### PR DESCRIPTION
Easier for scripts to figure out which artifact is the source code.
