### PR TITLE
Add verbose option to rustdoc in order to fix problem with --version

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -116,7 +116,8 @@ pub fn opts() -> Vec<getopts::OptGroup> {
     use getopts::*;
     vec!(
         optflag("h", "help", "show this help message"),
-        optflagopt("", "version", "print rustdoc's version", "verbose"),
+        optflag("V", "version", "print rustdoc's version"),
+        optflag("v", "verbose", "use verbose output"),
         optopt("r", "input-format", "the input type of the specified file",
                "[rust|json]"),
         optopt("w", "output-format", "the output type to write",


### PR DESCRIPTION
Patch for #20340. `rustdoc --version` panics because it uses `rustc_driver::version`, which in turn checks the `verbose` flag, which was not defined for rustdoc.  In this patch I have added a verbose flag to rustdoc, because I think it should be useful for other things besides --version. 

Another possible fix would be to check if a verbose option was defined in `rustc_driver` or add an extra `version` function for rustdoc.
