### PR TITLE
mk: Fix the location of a temp dir when building installer on win

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -241,8 +241,8 @@ dist/$$(PKG_NAME)-$(1).tar.gz: dist-install-dir-$(1)
 	@$(call E, build: $$@)
 # Copy essential gcc components into installer
 ifdef CFG_WINDOWSY_$(1)
-	$$(Q)rm -Rf dist/win-rust-gcc-$(1)
-	$$(Q)$$(CFG_PYTHON) $$(S)src/etc/make-win-dist.py tmp/dist/$$(PKG_NAME)-$(1)-image dist/win-rust-gcc-$(1) $(1)
+	$$(Q)rm -Rf tmp/dist/win-rust-gcc-$(1)
+	$$(Q)$$(CFG_PYTHON) $$(S)src/etc/make-win-dist.py tmp/dist/$$(PKG_NAME)-$(1)-image tmp/dist/win-rust-gcc-$(1) $(1)
 	$$(Q)cp -r $$(S)src/etc/third-party tmp/dist/$$(PKG_NAME)-$(1)-image/share/doc/
 endif
 	$$(Q)$$(S)src/rust-installer/gen-installer.sh \


### PR DESCRIPTION
Fixes the failure on the nightly builders. Doesn't need to be p=1 since I'm rebuilding the nightlies now, but every day this isn't on master will be a day that we don't get new nightlies.
