### PR TITLE
rustc: Re-jigger -L and -l for MSYS compatibility

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -743,7 +743,7 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
         opt::multi("l", "",   "Link the generated crate(s) to the specified native
                              library NAME. The optional KIND can be one of,
                              static, dylib, or framework. If omitted, dylib is
-                             assumed.", "NAME[:KIND]"),
+                             assumed.", "[KIND=]NAME"),
         opt::multi("", "crate-type", "Comma separated list of types of crates
                                     for the compiler to emit",
                    "[bin|lib|rlib|dylib|staticlib]"),
@@ -1016,6 +1016,24 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
     }
 
     let libs = matches.opt_strs("l").into_iter().map(|s| {
+        let mut parts = s.splitn(1, '=');
+        let kind = parts.next().unwrap();
+        if let Some(name) = parts.next() {
+            let kind = match kind {
+                "dylib" => cstore::NativeUnknown,
+                "framework" => cstore::NativeFramework,
+                "static" => cstore::NativeStatic,
+                s => {
+                    early_error(format!("unknown library kind `{}`, expected \
+                                         one of dylib, framework, or static",
+                                        s)[]);
+                }
+            };
+            return (name.to_string(), kind)
+        }
+
+        // FIXME(acrichto) remove this once crates have stopped using it, this
+        //                 is deprecated behavior now.
         let mut parts = s.rsplitn(1, ':');
         let kind = parts.next().unwrap();
         let (name, kind) = match (parts.next(), kind) {

--- a/src/librustc/session/search_paths.rs
+++ b/src/librustc/session/search_paths.rs
@@ -34,15 +34,14 @@ impl SearchPaths {
     }
 
     pub fn add_path(&mut self, path: &str) {
-        let (kind, path) = if path.ends_with(":native") {
-            (PathKind::Native, path.slice_to(path.len() - ":native".len()))
-        } else if path.ends_with(":crate") {
-            (PathKind::Crate, path.slice_to(path.len() - ":crate".len()))
-        } else if path.ends_with(":dependency") {
-            (PathKind::Dependency,
-             path.slice_to(path.len() - ":dependency".len()))
-        } else if path.ends_with(":all") {
-            (PathKind::All, path.slice_to(path.len() - ":all".len()))
+        let (kind, path) = if path.starts_with("native=") {
+            (PathKind::Native, path.slice_from("native=".len()))
+        } else if path.starts_with("crate=") {
+            (PathKind::Crate, path.slice_from("crate=".len()))
+        } else if path.starts_with("dependency=") {
+            (PathKind::Dependency, path.slice_from("dependency=".len()))
+        } else if path.starts_with("all=") {
+            (PathKind::All, path.slice_from("all=".len()))
         } else {
             (PathKind::All, path)
         };

--- a/src/test/run-make/compiler-lookup-paths/Makefile
+++ b/src/test/run-make/compiler-lookup-paths/Makefile
@@ -6,25 +6,25 @@ all: $(TMPDIR)/libnative.a
 	mv $(TMPDIR)/libnative.a $(TMPDIR)/native
 	$(RUSTC) a.rs
 	mv $(TMPDIR)/liba.rlib $(TMPDIR)/crate
-	$(RUSTC) b.rs -L $(TMPDIR)/crate:native && exit 1 || exit 0
-	$(RUSTC) b.rs -L $(TMPDIR)/crate:dependency && exit 1 || exit 0
-	$(RUSTC) b.rs -L $(TMPDIR)/crate:crate
-	$(RUSTC) b.rs -L $(TMPDIR)/crate
-	$(RUSTC) c.rs -L $(TMPDIR)/crate:native && exit 1 || exit 0
-	$(RUSTC) c.rs -L $(TMPDIR)/crate:crate && exit 1 || exit 0
-	$(RUSTC) c.rs -L $(TMPDIR)/crate:dependency
-	$(RUSTC) c.rs -L $(TMPDIR)/crate
-	$(RUSTC) d.rs -L $(TMPDIR)/native:dependency && exit 1 || exit 0
-	$(RUSTC) d.rs -L $(TMPDIR)/native:crate && exit 1 || exit 0
-	$(RUSTC) d.rs -L $(TMPDIR)/native:native
-	$(RUSTC) d.rs -L $(TMPDIR)/native
+	$(RUSTC) b.rs -L native=$(TMPDIR)/crate && exit 1 || exit 0
+	$(RUSTC) b.rs -L dependency=$(TMPDIR)/crate && exit 1 || exit 0
+	$(RUSTC) b.rs -L crate=$(TMPDIR)/crate
+	$(RUSTC) b.rs -L all=$(TMPDIR)/crate
+	$(RUSTC) c.rs -L native=$(TMPDIR)/crate && exit 1 || exit 0
+	$(RUSTC) c.rs -L crate=$(TMPDIR)/crate && exit 1 || exit 0
+	$(RUSTC) c.rs -L dependency=$(TMPDIR)/crate
+	$(RUSTC) c.rs -L all=$(TMPDIR)/crate
+	$(RUSTC) d.rs -L dependency=$(TMPDIR)/native && exit 1 || exit 0
+	$(RUSTC) d.rs -L crate=$(TMPDIR)/native && exit 1 || exit 0
+	$(RUSTC) d.rs -L native=$(TMPDIR)/native
+	$(RUSTC) d.rs -L all=$(TMPDIR)/native
 	mkdir -p $(TMPDIR)/e1
 	mkdir -p $(TMPDIR)/e2
 	$(RUSTC) e.rs -o $(TMPDIR)/e1/libe.rlib
 	$(RUSTC) e.rs -o $(TMPDIR)/e2/libe.rlib
 	$(RUSTC) f.rs -L $(TMPDIR)/e1 -L $(TMPDIR)/e2 && exit 1 || exit 0
-	$(RUSTC) f.rs -L $(TMPDIR)/e1:crate -L $(TMPDIR)/e2 && exit 1 || exit 0
-	$(RUSTC) f.rs -L $(TMPDIR)/e1:crate -L $(TMPDIR)/e2:crate && exit 1 || exit 0
-	$(RUSTC) f.rs -L $(TMPDIR)/e1:native -L $(TMPDIR)/e2
-	$(RUSTC) f.rs -L $(TMPDIR)/e1:dependency -L $(TMPDIR)/e2
-	$(RUSTC) f.rs -L $(TMPDIR)/e1:dependency -L $(TMPDIR)/e2:crate
+	$(RUSTC) f.rs -L crate=$(TMPDIR)/e1 -L $(TMPDIR)/e2 && exit 1 || exit 0
+	$(RUSTC) f.rs -L crate=$(TMPDIR)/e1 -L crate=$(TMPDIR)/e2 && exit 1 || exit 0
+	$(RUSTC) f.rs -L native=$(TMPDIR)/e1 -L $(TMPDIR)/e2
+	$(RUSTC) f.rs -L dependency=$(TMPDIR)/e1 -L $(TMPDIR)/e2
+	$(RUSTC) f.rs -L dependency=$(TMPDIR)/e1 -L crate=$(TMPDIR)/e2

--- a/src/test/run-make/manual-link/Makefile
+++ b/src/test/run-make/manual-link/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
 all: $(TMPDIR)/libbar.a
-	$(RUSTC) foo.rs -lbar:static
+	$(RUSTC) foo.rs -lstatic=bar
 	$(RUSTC) main.rs
 	$(call RUN,main)
 


### PR DESCRIPTION
As discovered in #20376, the MSYS shell will silently rewrite arguemnts that
look like unix paths into their windows path counterparts for compatibility, but
the recently added `:kind` syntax added to the `-L` flag does not allow for this
form of rewriting. This means that the syntax can be difficult to use at an MSYS
prompt, as well as causing tests to fail when run manuall right now.

This commit takes the other option presented in the original issue to prefix the
path with `kind=` instead of suffixing it with `:kind`. For consistence, the
`-l` flag is also now migrating to `kind=name`.

This is a breaking change due to the _removal_ of behavior with `-L`. All code
using `:kind` should now pass `kind=` for `-L` arguments. This is not currently,
but will become, a breaking change for `-l` flags. The old `name:kind` syntax is
still accepted, but all code should update to `kind=name`.

[breaking-change]
Closes #20376
