### PR TITLE
Allow Travis CI to use new infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 # RVM/bundler/ruby and whatnot. Right now 'rust' as a language actually
 # downloads a rust/cargo snapshot, which we don't really want for building rust.
 language: c
+sudo: false
 
 # The test suite is in general way too stressful for travis, especially in
 # terms of time limit and reliability. In the past we've tried to scale things


### PR DESCRIPTION
Travis recently launched their new infrastructure on Amazon EC2 with improved resources. The only limitation is that they don't support sudo. http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
I couldn't find anywhere where the build system uses sudo so I don't think that limitation affects rust builds. 
This change drops the current `make tidy` times [slightly](https://travis-ci.org/daramos/rust/builds)(travis-test branch).
