### PR TITLE
rustc_typeck: unify expected return types with formal return types to propagate coercions through calls of generic functions.

### DIFF
--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -192,11 +192,10 @@ fn confirm_builtin_call<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
         fcx.normalize_associated_types_in(call_expr.span, &fn_sig);
 
     // Call the generic checker.
-    let arg_exprs: Vec<_> = arg_exprs.iter().collect(); // for some weird reason we take &[&P<...>].
     check_argument_types(fcx,
                          call_expr.span,
                          fn_sig.inputs.as_slice(),
-                         arg_exprs.as_slice(),
+                         arg_exprs,
                          AutorefArgs::No,
                          fn_sig.variadic,
                          TupleArgumentsFlag::DontTupleArguments);
@@ -209,12 +208,11 @@ fn confirm_overloaded_call<'a,'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                                     arg_exprs: &[P<ast::Expr>],
                                     method_callee: ty::MethodCallee<'tcx>)
 {
-    let arg_exprs: Vec<_> = arg_exprs.iter().collect(); // for some weird reason we take &[&P<...>].
     let output_type = check_method_argument_types(fcx,
                                                   call_expr.span,
                                                   method_callee.ty,
                                                   call_expr,
-                                                  arg_exprs.as_slice(),
+                                                  arg_exprs,
                                                   AutorefArgs::No,
                                                   TupleArgumentsFlag::TupleArguments);
     let method_call = ty::MethodCall::expr(call_expr.id);

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -14,6 +14,8 @@ use super::check_argument_types;
 use super::check_expr;
 use super::check_method_argument_types;
 use super::err_args;
+use super::Expectation;
+use super::expected_types_for_fn_args;
 use super::FnCtxt;
 use super::LvaluePreference;
 use super::method;
@@ -65,7 +67,8 @@ pub fn check_legal_trait_for_method_call(ccx: &CrateCtxt, span: Span, trait_id: 
 pub fn check_call<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                             call_expr: &ast::Expr,
                             callee_expr: &ast::Expr,
-                            arg_exprs: &[P<ast::Expr>])
+                            arg_exprs: &[P<ast::Expr>],
+                            expected: Expectation<'tcx>)
 {
     check_expr(fcx, callee_expr);
     let original_callee_ty = fcx.expr_ty(callee_expr);
@@ -84,15 +87,15 @@ pub fn check_call<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     match result {
         None => {
             // this will report an error since original_callee_ty is not a fn
-            confirm_builtin_call(fcx, call_expr, original_callee_ty, arg_exprs);
+            confirm_builtin_call(fcx, call_expr, original_callee_ty, arg_exprs, expected);
         }
 
         Some(CallStep::Builtin) => {
-            confirm_builtin_call(fcx, call_expr, callee_ty, arg_exprs);
+            confirm_builtin_call(fcx, call_expr, callee_ty, arg_exprs, expected);
         }
 
         Some(CallStep::Overloaded(method_callee)) => {
-            confirm_overloaded_call(fcx, call_expr, arg_exprs, method_callee);
+            confirm_overloaded_call(fcx, call_expr, arg_exprs, method_callee, expected);
         }
     }
 }
@@ -153,7 +156,8 @@ fn try_overloaded_call_step<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 fn confirm_builtin_call<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
                                  call_expr: &ast::Expr,
                                  callee_ty: Ty<'tcx>,
-                                 arg_exprs: &[P<ast::Expr>])
+                                 arg_exprs: &[P<ast::Expr>],
+                                 expected: Expectation<'tcx>)
 {
     let error_fn_sig;
 
@@ -192,9 +196,15 @@ fn confirm_builtin_call<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
         fcx.normalize_associated_types_in(call_expr.span, &fn_sig);
 
     // Call the generic checker.
+    let expected_arg_tys = expected_types_for_fn_args(fcx,
+                                                      call_expr.span,
+                                                      expected,
+                                                      fn_sig.output,
+                                                      fn_sig.inputs.as_slice());
     check_argument_types(fcx,
                          call_expr.span,
                          fn_sig.inputs.as_slice(),
+                         &expected_arg_tys[],
                          arg_exprs,
                          AutorefArgs::No,
                          fn_sig.variadic,
@@ -206,7 +216,8 @@ fn confirm_builtin_call<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
 fn confirm_overloaded_call<'a,'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                                     call_expr: &ast::Expr,
                                     arg_exprs: &[P<ast::Expr>],
-                                    method_callee: ty::MethodCallee<'tcx>)
+                                    method_callee: ty::MethodCallee<'tcx>,
+                                    expected: Expectation<'tcx>)
 {
     let output_type = check_method_argument_types(fcx,
                                                   call_expr.span,
@@ -214,7 +225,8 @@ fn confirm_overloaded_call<'a,'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                                                   call_expr,
                                                   arg_exprs,
                                                   AutorefArgs::No,
-                                                  TupleArgumentsFlag::TupleArguments);
+                                                  TupleArgumentsFlag::TupleArguments,
+                                                  expected);
     let method_call = ty::MethodCall::expr(call_expr.id);
     fcx.inh.method_map.borrow_mut().insert(method_call, method_callee);
     write_call(fcx, call_expr, output_type);

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -33,7 +33,7 @@ pub fn check_expr_closure<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
            expr.repr(fcx.tcx()),
            expected.repr(fcx.tcx()));
 
-    let expected_sig_and_kind = expected.map_to_option(fcx, |ty| {
+    let expected_sig_and_kind = expected.to_option(fcx).and_then(|ty| {
         deduce_unboxed_closure_expectations_from_expected_type(fcx, ty)
     });
 

--- a/src/test/compile-fail/issue-15783.rs
+++ b/src/test/compile-fail/issue-15783.rs
@@ -14,7 +14,8 @@ pub fn foo(params: Option<&[&str]>) -> usize {
 
 fn main() {
     let name = "Foo";
-    let msg = foo(Some(&[name.as_slice()]));
+    let x = Some(&[name.as_slice()]);
+    let msg = foo(x);
 //~^ ERROR mismatched types: expected `core::option::Option<&[&str]>`
     assert_eq!(msg, 3);
 }

--- a/src/test/compile-fail/regions-early-bound-error-method.rs
+++ b/src/test/compile-fail/regions-early-bound-error-method.rs
@@ -28,6 +28,8 @@ impl<'a> GetRef<'a> for Box<'a> {
 impl<'a> Box<'a> {
     fn or<'b,G:GetRef<'b>>(&self, g2: G) -> &'a isize {
         g2.get() //~ ERROR cannot infer an appropriate lifetime for automatic coercion due to
+        //~^ ERROR mismatched types: expected `&'a isize`, found `&'b isize` (lifetime mismatch)
+
     }
 }
 

--- a/src/test/compile-fail/regions-early-bound-error.rs
+++ b/src/test/compile-fail/regions-early-bound-error.rs
@@ -27,6 +27,7 @@ impl<'a,T:Clone> GetRef<'a,T> for Box<'a,T> {
 
 fn get<'a,'b,G:GetRef<'a, isize>>(g1: G, b: &'b isize) -> &'b isize {
     g1.get() //~ ERROR cannot infer an appropriate lifetime for automatic coercion due to
+    //~^ ERROR mismatched types: expected `&'b isize`, found `&'a isize` (lifetime mismatch)
 }
 
 fn main() {

--- a/src/test/run-pass/coerce-expect-unsized.rs
+++ b/src/test/run-pass/coerce-expect-unsized.rs
@@ -30,4 +30,7 @@ pub fn main() {
     let _: &Fn(int) -> _ = &{ |x| (x as u8) };
     let _: &Show = &if true { false } else { true };
     let _: &Show = &match true { true => 'a', false => 'b' };
+
+    let _: Box<[int]> = Box::new([1, 2, 3]);
+    let _: Box<Fn(int) -> _> = Box::new(|x| (x as u8));
 }

--- a/src/test/run-pass/coerce-unify-return.rs
+++ b/src/test/run-pass/coerce-unify-return.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that coercions unify the expected return type of a polymorphic
+// function call, instead of leaving the type variables as they were.
+
+struct Foo;
+impl Foo {
+    fn foo<T>(self, x: T) -> Option<T> { Some(x) }
+}
+
+pub fn main() {
+    let _: Option<fn()> = Some(main);
+    let _: Option<fn()> = Foo.foo(main);
+
+    // The same two cases, with implicit type variables made explicit.
+    let _: Option<fn()> = Some::<_>(main);
+    let _: Option<fn()> = Foo.foo::<_>(main);
+}


### PR DESCRIPTION
This allows passing `Some(free_fn)` to something expecting `Option<fn()>`, dealing with most of the fallout from #19891.
Fixes #20178.
