### PR TITLE
std: Second pass stabilization for `boxed`

### DIFF
--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -57,6 +57,11 @@ impl<'cx, 'tcx,'v> visit::Visitor<'v> for OrphanChecker<'cx, 'tcx> {
                     ty::ty_trait(ref data) => {
                         self.check_def_id(item.span, data.principal_def_id());
                     }
+                    ty::ty_uniq(..) => {
+                        self.check_def_id(item.span,
+                                          self.tcx.lang_items.owned_box()
+                                              .unwrap());
+                    }
                     _ => {
                         span_err!(self.tcx.sess, item.span, E0118,
                                   "no base type found for inherent implementation; \


### PR DESCRIPTION
This commit performs a second pass over the `std::boxed` module, taking the
following actions:
- `boxed` is now stable
- `Box` is now stable
- `BoxAny` is removed in favor of a direct `impl Box<Any>`
- `Box::downcast` remains unstable while the name of the `downcast` family of
  methods is determined.

This is a breaking change due to the removal of the `BoxAny` trait (note that
the `downcast` method still exists), and existing consumers of `BoxAny` simply
need to remove the import in their modules.

[breaking-change]
