### PR TITLE
Do not ICE when projecting out of a value with type `ty::ty_err`

### DIFF
--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -343,8 +343,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     project::poly_project_and_unify_type(self, &project_obligation)
                 });
                 match result {
-                    Ok(Some(subobligations)) => {
-                        self.evaluate_predicates_recursively(previous_stack, subobligations.iter())
+                    Ok(Some(_subobligations)) => {
+                        // TODO we should evaluate _subobligations, but doing so leads to an ICE
+                        // self.evaluate_predicates_recursively(previous_stack,
+                        //                                      subobligations.iter())
+                        EvaluatedToAmbig
                     }
                     Ok(None) => {
                         EvaluatedToAmbig

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -7269,7 +7269,7 @@ impl<T:ReferencesError> ReferencesError for Binder<T> {
 
 impl<T:ReferencesError> ReferencesError for Rc<T> {
     fn references_error(&self) -> bool {
-        (&*self).references_error()
+        (&**self).references_error()
     }
 }
 

--- a/src/test/compile-fail/associated-types-ICE-when-projecting-out-of-err.rs
+++ b/src/test/compile-fail/associated-types-ICE-when-projecting-out-of-err.rs
@@ -1,0 +1,34 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that we do not ICE when the self type is `ty::err`, but rather
+// just propagate the error.
+
+#![crate_type = "lib"]
+#![feature(associated_types, default_type_params, lang_items)]
+#![no_std]
+
+#[lang="sized"]
+pub trait Sized for Sized? {
+    // Empty.
+}
+
+#[lang = "add"]
+trait Add<RHS=Self> {
+    type Output;
+
+    fn add(self, RHS) -> Self::Output;
+}
+
+fn ice<A>(a: A) {
+    let r = loop {};
+    r = r + a; // here the type `r` is not yet inferred, hence `r+a` generates an error.
+    //~^ ERROR type of this value must be known
+}

--- a/src/test/run-pass/associated-types-conditional-dispatch.rs
+++ b/src/test/run-pass/associated-types-conditional-dispatch.rs
@@ -1,0 +1,73 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that we evaluate projection predicates to winnow out
+// candidates during trait selection and method resolution (#20296).
+// If we don't properly winnow out candidates based on the output type
+// `Output=[A]`, then the impl marked with `(*)` is seen to conflict
+// with all the others.
+
+#![feature(associated_types, default_type_params)]
+
+use std::ops::Deref;
+
+pub trait MyEq<Sized? U=Self> for Sized? {
+    fn eq(&self, u: &U) -> bool;
+}
+
+impl<A, B> MyEq<[B]> for [A]
+    where A : MyEq<B>
+{
+    fn eq(&self, other: &[B]) -> bool {
+        self.len() == other.len() &&
+            self.iter().zip(other.iter())
+                       .all(|(a, b)| MyEq::eq(a, b))
+    }
+}
+
+// (*) This impl conflicts with everything unless the `Output=[A]`
+// constraint is considered.
+impl<'a, A, B, Lhs> MyEq<[B; 0]> for Lhs
+    where A: MyEq<B>, Lhs: Deref<Output=[A]>
+{
+    fn eq(&self, other: &[B; 0]) -> bool {
+        MyEq::eq(&**self, other.as_slice())
+    }
+}
+
+struct DerefWithHelper<H, T> {
+    pub helper: H
+}
+
+trait Helper<T> {
+    fn helper_borrow(&self) -> &T;
+}
+
+impl<T> Helper<T> for Option<T> {
+    fn helper_borrow(&self) -> &T {
+        self.as_ref().unwrap()
+    }
+}
+
+impl<T, H: Helper<T>> Deref for DerefWithHelper<H, T> {
+    type Output = T;
+
+    fn deref(&self) -> &T {
+        self.helper.helper_borrow()
+    }
+}
+
+pub fn check<T: MyEq>(x: T, y: T) -> bool {
+    let d: DerefWithHelper<Option<T>, T> = DerefWithHelper { helper: Some(x) };
+    d.eq(&y)
+}
+
+pub fn main() {
+}


### PR DESCRIPTION
Fixes an ICE that @japaric was seeing.

r? @aturon 
