### PR TITLE
Refactor upvar mode inference

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -1612,15 +1612,11 @@ impl LintPass for MissingCopyImplementations {
             }
             _ => return,
         };
-        let parameter_environment = ty::empty_parameter_environment();
-        if !ty::type_moves_by_default(cx.tcx,
-                                      ty,
-                                      &parameter_environment) {
+        let parameter_environment = ty::empty_parameter_environment(cx.tcx);
+        if !ty::type_moves_by_default(&parameter_environment, item.span, ty) {
             return
         }
-        if ty::can_type_implement_copy(cx.tcx,
-                                       ty,
-                                       &parameter_environment).is_ok() {
+        if ty::can_type_implement_copy(&parameter_environment, item.span, ty).is_ok() {
             cx.span_lint(MISSING_COPY_IMPLEMENTATIONS,
                          item.span,
                          "type could implement `Copy`; consider adding `impl \

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -1032,9 +1032,7 @@ fn check_legality_of_move_bindings(cx: &MatchCheckCtxt,
                 match p.node {
                     ast::PatIdent(ast::BindByValue(_), _, ref sub) => {
                         let pat_ty = ty::node_id_to_type(tcx, p.id);
-                        if ty::type_moves_by_default(tcx,
-                                                      pat_ty,
-                                                      &cx.param_env) {
+                        if ty::type_moves_by_default(&cx.param_env, pat.span, pat_ty) {
                             check_move(p, sub.as_ref().map(|p| &**p));
                         }
                     }

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -99,7 +99,7 @@ impl<'a> FromIterator<Vec<&'a Pat>> for Matrix<'a> {
 
 pub struct MatchCheckCtxt<'a, 'tcx: 'a> {
     pub tcx: &'a ty::ctxt<'tcx>,
-    pub param_env: ParameterEnvironment<'tcx>,
+    pub param_env: ParameterEnvironment<'a, 'tcx>,
 }
 
 #[deriving(Clone, PartialEq)]
@@ -148,7 +148,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for MatchCheckCtxt<'a, 'tcx> {
 pub fn check_crate(tcx: &ty::ctxt) {
     visit::walk_crate(&mut MatchCheckCtxt {
         tcx: tcx,
-        param_env: ty::empty_parameter_environment(),
+        param_env: ty::empty_parameter_environment(tcx),
     }, tcx.map.krate());
     tcx.sess.abort_if_errors();
 }
@@ -1061,8 +1061,7 @@ fn check_for_mutation_in_guard<'a, 'tcx>(cx: &'a MatchCheckCtxt<'a, 'tcx>,
         cx: cx,
     };
     let mut visitor = ExprUseVisitor::new(&mut checker,
-                                          checker.cx.tcx,
-                                          &cx.param_env);
+                                          &checker.cx.param_env);
     visitor.walk_expr(guard);
 }
 

--- a/src/librustc/middle/check_rvalues.rs
+++ b/src/librustc/middle/check_rvalues.rs
@@ -41,7 +41,7 @@ impl<'a, 'tcx, 'v> visit::Visitor<'v> for RvalueContext<'a, 'tcx> {
         {
             let param_env = ParameterEnvironment::for_item(self.tcx, fn_id);
             let mut delegate = RvalueContextDelegate { tcx: self.tcx, param_env: &param_env };
-            let mut euv = euv::ExprUseVisitor::new(&mut delegate, self.tcx, &param_env);
+            let mut euv = euv::ExprUseVisitor::new(&mut delegate, &param_env);
             euv.walk_fn(fd, b);
         }
         visit::walk_fn(self, fk, fd, b, s)
@@ -50,7 +50,7 @@ impl<'a, 'tcx, 'v> visit::Visitor<'v> for RvalueContext<'a, 'tcx> {
 
 struct RvalueContextDelegate<'a, 'tcx: 'a> {
     tcx: &'a ty::ctxt<'tcx>,
-    param_env: &'a ty::ParameterEnvironment<'tcx>,
+    param_env: &'a ty::ParameterEnvironment<'a,'tcx>,
 }
 
 impl<'a, 'tcx> euv::Delegate<'tcx> for RvalueContextDelegate<'a, 'tcx> {

--- a/src/librustc/middle/check_rvalues.rs
+++ b/src/librustc/middle/check_rvalues.rs
@@ -60,7 +60,7 @@ impl<'a, 'tcx> euv::Delegate<'tcx> for RvalueContextDelegate<'a, 'tcx> {
                cmt: mc::cmt<'tcx>,
                _: euv::ConsumeMode) {
         debug!("consume; cmt: {}; type: {}", *cmt, ty_to_string(self.tcx, cmt.ty));
-        if !ty::type_is_sized(self.tcx, cmt.ty, self.param_env) {
+        if !ty::type_is_sized(self.param_env, span, cmt.ty) {
             span_err!(self.tcx.sess, span, E0161,
                 "cannot move a value of type {0}: the size of {0} cannot be statically determined",
                 ty_to_string(self.tcx, cmt.ty));

--- a/src/librustc/middle/def.rs
+++ b/src/librustc/middle/def.rs
@@ -126,6 +126,12 @@ impl TraitItemKind {
 }
 
 impl Def {
+    pub fn local_node_id(&self) -> ast::NodeId {
+        let def_id = self.def_id();
+        assert_eq!(def_id.krate, ast::LOCAL_CRATE);
+        def_id.node
+    }
+
     pub fn def_id(&self) -> ast::DefId {
         match *self {
             DefFn(id, _) | DefStaticMethod(id, _) | DefMod(id) |

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -300,6 +300,20 @@ pub struct ExprUseVisitor<'d,'t,'tcx:'t,TYPER:'t> {
     mc: mc::MemCategorizationContext<'t,TYPER>,
     delegate: &'d mut (Delegate<'tcx>+'d),
     param_env: &'t ParameterEnvironment<'tcx>,
+// If the TYPER results in an error, it's because the type check
+// failed (or will fail, when the error is uncovered and reported
+// during writeback). In this case, we just ignore this part of the
+// code.
+//
+// Note that this macro appears similar to try!(), but, unlike try!(),
+// it does not propagate the error.
+macro_rules! return_if_err {
+    ($inp: expr) => (
+        match $inp {
+            Ok(v) => v,
+            Err(()) => return
+        }
+    )
 }
 
 /// Whether the elements of an overloaded operation are passed by value or by reference
@@ -332,7 +346,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                          decl: &ast::FnDecl,
                          body: &ast::Block) {
         for arg in decl.inputs.iter() {
-            let arg_ty = self.typer.node_ty(arg.pat.id);
+            let arg_ty = return_if_err!(self.typer.node_ty(arg.pat.id));
 
             let fn_body_scope = region::CodeExtent::from_node_id(body.id);
             let arg_cmt = self.mc.cat_rvalue(
@@ -369,7 +383,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
     pub fn consume_expr(&mut self, expr: &ast::Expr) {
         debug!("consume_expr(expr={})", expr.repr(self.tcx()));
 
-        let cmt = self.mc.cat_expr(expr);
+        let cmt = return_if_err!(self.mc.cat_expr(expr));
         self.delegate_consume(expr.id, expr.span, cmt);
         self.walk_expr(expr);
     }
@@ -378,7 +392,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                    assignment_expr: &ast::Expr,
                    expr: &ast::Expr,
                    mode: MutateMode) {
-        let cmt = self.mc.cat_expr(expr);
+        let cmt = return_if_err!(self.mc.cat_expr(expr));
         self.delegate.mutate(assignment_expr.id, assignment_expr.span, cmt, mode);
         self.walk_expr(expr);
     }
@@ -391,7 +405,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
         debug!("borrow_expr(expr={}, r={}, bk={})",
                expr.repr(self.tcx()), r.repr(self.tcx()), bk.repr(self.tcx()));
 
-        let cmt = self.mc.cat_expr(expr);
+        let cmt = return_if_err!(self.mc.cat_expr(expr));
         self.delegate.borrow(expr.id, expr.span, cmt, r, bk, cause);
 
         // Note: Unlike consume, we can ignore ExprParen. cat_expr
@@ -491,7 +505,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
             }
 
             ast::ExprMatch(ref discr, ref arms, _) => {
-                let discr_cmt = self.mc.cat_expr(&**discr);
+                let discr_cmt = return_if_err!(self.mc.cat_expr(&**discr));
                 self.borrow_expr(&**discr, ty::ReEmpty, ty::ImmBorrow, MatchDiscriminant);
 
                 // treatment of the discriminant is handled while walking the arms.
@@ -509,7 +523,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
             ast::ExprAddrOf(m, ref base) => {   // &base
                 // make sure that the thing we are pointing out stays valid
                 // for the lifetime `scope_r` of the resulting ptr:
-                let expr_ty = ty::expr_ty(self.tcx(), expr);
+                let expr_ty = return_if_err!(self.typer.node_ty(expr.id));
                 let r = ty::ty_region(self.tcx(), expr.span, expr_ty);
                 let bk = ty::BorrowKind::from_mutbl(m);
                 self.borrow_expr(&**base, r, bk, AddrOf);
@@ -550,7 +564,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
 
                 // Fetch the type of the value that the iteration yields to
                 // produce the pattern's categorized mutable type.
-                let pattern_type = self.typer.node_ty(pat.id);
+                let pattern_type = return_if_err!(self.typer.node_ty(pat.id));
                 let blk_scope = region::CodeExtent::from_node_id(blk.id);
                 let pat_cmt = self.mc.cat_rvalue(pat.id,
                                                  pat.span,
@@ -638,7 +652,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
     }
 
     fn walk_callee(&mut self, call: &ast::Expr, callee: &ast::Expr) {
-        let callee_ty = self.typer.expr_ty_adjusted(callee);
+        let callee_ty = return_if_err!(self.typer.expr_ty_adjusted(callee));
         debug!("walk_callee: callee={} callee_ty={}",
                callee.repr(self.tcx()), callee_ty.repr(self.tcx()));
         let call_scope = region::CodeExtent::from_node_id(call.id);
@@ -735,7 +749,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                 // "assigns", which is handled by
                 // `walk_pat`:
                 self.walk_expr(&**expr);
-                let init_cmt = self.mc.cat_expr(&**expr);
+                let init_cmt = return_if_err!(self.mc.cat_expr(&**expr));
                 self.walk_irrefutable_pat(init_cmt, &*local.pat);
             }
         }
@@ -769,7 +783,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
             None => { return; }
         };
 
-        let with_cmt = self.mc.cat_expr(&*with_expr);
+        let with_cmt = return_if_err!(self.mc.cat_expr(&*with_expr));
 
         // Select just those fields of the `with`
         // expression that will actually be used
@@ -824,7 +838,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                         // rvalue.
                         debug!("walk_adjustment(AutoAddEnv|AdjustReifyFnPointer)");
                         let cmt_unadjusted =
-                            self.mc.cat_expr_unadjusted(expr);
+                            return_if_err!(self.mc.cat_expr_unadjusted(expr));
                         self.delegate_consume(expr.id, expr.span, cmt_unadjusted);
                     }
                     ty::AdjustDerefRef(ty::AutoDerefRef {
@@ -858,7 +872,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
             match self.typer.node_method_ty(deref_id) {
                 None => {}
                 Some(method_ty) => {
-                    let cmt = self.mc.cat_expr_autoderefd(expr, i);
+                    let cmt = return_if_err!(self.mc.cat_expr_autoderefd(expr, i));
                     let self_ty = ty::ty_fn_args(method_ty)[0];
                     let (m, r) = match self_ty.sty {
                         ty::ty_rptr(r, ref m) => (m.mutbl, r),
@@ -888,14 +902,15 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                 assert!(n == 1, format!("Expected exactly 1 deref with Uniq \
                                          AutoRefs, found: {}", n));
                 let cmt_unadjusted =
-                    self.mc.cat_expr_unadjusted(expr);
+                    return_if_err!(self.mc.cat_expr_unadjusted(expr));
                 self.delegate_consume(expr.id, expr.span, cmt_unadjusted);
                 return;
             }
             _ => {}
         }
 
-        let cmt_derefd = self.mc.cat_expr_autoderefd(expr, n);
+        let cmt_derefd = return_if_err!(
+            self.mc.cat_expr_autoderefd(expr, n));
         debug!("walk_adjustment: cmt_derefd={}",
                cmt_derefd.repr(self.tcx()));
 
@@ -988,7 +1003,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                                mode: &mut TrackMatchMode<Span>) {
         debug!("determine_pat_move_mode cmt_discr={} pat={}", cmt_discr.repr(self.tcx()),
                pat.repr(self.tcx()));
-        self.mc.cat_pattern(cmt_discr, pat, |_mc, cmt_pat, pat| {
+        return_if_err!(self.mc.cat_pattern(cmt_discr, pat, |_mc, cmt_pat, pat| {
             let tcx = self.typer.tcx();
             let def_map = &self.typer.tcx().def_map;
             if pat_util::pat_is_binding(def_map, pat) {
@@ -1011,7 +1026,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                     }
                 }
             }
-        });
+        }));
     }
 
     /// The core driver for walking a pattern; `match_mode` must be
@@ -1028,8 +1043,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
         let typer = self.typer;
         let def_map = &self.typer.tcx().def_map;
         let delegate = &mut self.delegate;
-        let param_env = self.param_env;
-        mc.cat_pattern(cmt_discr.clone(), pat, |mc, cmt_pat, pat| {
+        return_if_err!(mc.cat_pattern(cmt_discr.clone(), pat, |mc, cmt_pat, pat| {
             if pat_util::pat_is_binding(def_map, pat) {
                 let tcx = typer.tcx();
 
@@ -1039,7 +1053,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                        match_mode);
 
                 // pat_ty: the type of the binding being produced.
-                let pat_ty = typer.node_ty(pat.id);
+                let pat_ty = return_if_err!(typer.node_ty(pat.id));
 
                 // Each match binding is effectively an assignment to the
                 // binding being produced.
@@ -1080,7 +1094,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                         // matched.
 
                         let (slice_cmt, slice_mutbl, slice_r) =
-                            mc.cat_slice_pattern(cmt_pat, &**slice_pat);
+                            return_if_err!(mc.cat_slice_pattern(cmt_pat, &**slice_pat));
 
                         // Note: We declare here that the borrow
                         // occurs upon entering the `[...]`
@@ -1110,13 +1124,13 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                     _ => { }
                 }
             }
-        });
+        }));
 
         // Do a second pass over the pattern, calling `matched_pat` on
         // the interior nodes (enum variants and structs), as opposed
         // to the above loop's visit of than the bindings that form
         // the leaves of the pattern tree structure.
-        mc.cat_pattern(cmt_discr, pat, |mc, cmt_pat, pat| {
+        return_if_err!(mc.cat_pattern(cmt_discr, pat, |mc, cmt_pat, pat| {
             let def_map = def_map.borrow();
             let tcx = typer.tcx();
 
@@ -1197,7 +1211,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                     // cases either.
                 }
             }
-        });
+        }));
     }
 
     fn walk_captures(&mut self, closure_expr: &ast::Expr) {
@@ -1221,9 +1235,9 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                             freevars: &[ty::Freevar]) {
         for freevar in freevars.iter() {
             let id_var = freevar.def.def_id().node;
-            let cmt_var = self.cat_captured_var(closure_expr.id,
-                                                closure_expr.span,
-                                                freevar.def);
+            let cmt_var = return_if_err!(self.cat_captured_var(closure_expr.id,
+                                                               closure_expr.span,
+                                                               freevar.def));
 
             // Lookup the kind of borrow the callee requires, as
             // inferred by regionbk
@@ -1244,11 +1258,10 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                               closure_expr: &ast::Expr,
                               freevars: &[ty::Freevar]) {
         for freevar in freevars.iter() {
-            let cmt_var = self.cat_captured_var(closure_expr.id,
-                                                closure_expr.span,
-                                                freevar.def);
-            let mode = copy_or_move(self.tcx(), cmt_var.ty,
-                                    self.param_env, CaptureMove);
+            let cmt_var = return_if_err!(self.cat_captured_var(closure_expr.id,
+                                                               closure_expr.span,
+                                                               freevar.def));
+            let mode = copy_or_move(self.typer, &cmt_var, CaptureMove);
             self.delegate.consume(closure_expr.id, freevar.span, cmt_var, mode);
         }
     }
@@ -1257,11 +1270,11 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                         closure_id: ast::NodeId,
                         closure_span: Span,
                         upvar_def: def::Def)
-                        -> mc::cmt<'tcx> {
+                        -> mc::McResult<mc::cmt<'tcx>> {
         // Create the cmt for the variable being borrowed, from the
         // caller's perspective
         let var_id = upvar_def.def_id().node;
-        let var_ty = self.typer.node_ty(var_id);
+        let var_ty = try!(self.typer.node_ty(var_id));
         self.mc.cat_def(closure_id, closure_span, var_ty, upvar_def)
     }
 }

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -23,7 +23,7 @@ use self::OverloadedCallType::*;
 use middle::{def, region, pat_util};
 use middle::mem_categorization as mc;
 use middle::mem_categorization::Typer;
-use middle::ty::{mod, ParameterEnvironment, Ty};
+use middle::ty::{mod};
 use middle::ty::{MethodCall, MethodObject, MethodTraitObject};
 use middle::ty::{MethodOrigin, MethodParam, MethodTypeParam};
 use middle::ty::{MethodStatic, MethodStaticUnboxedClosure};
@@ -299,7 +299,8 @@ pub struct ExprUseVisitor<'d,'t,'tcx:'t,TYPER:'t> {
     typer: &'t TYPER,
     mc: mc::MemCategorizationContext<'t,TYPER>,
     delegate: &'d mut (Delegate<'tcx>+'d),
-    param_env: &'t ParameterEnvironment<'tcx>,
+}
+
 // If the TYPER results in an error, it's because the type check
 // failed (or will fail, when the error is uncovered and reported
 // during writeback). In this case, we just ignore this part of the
@@ -324,14 +325,12 @@ enum PassArgs {
 
 impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
     pub fn new(delegate: &'d mut Delegate<'tcx>,
-               typer: &'t TYPER,
-               param_env: &'t ParameterEnvironment<'tcx>)
+               typer: &'t TYPER)
                -> ExprUseVisitor<'d,'t,'tcx,TYPER> {
         ExprUseVisitor {
             typer: typer,
             mc: mc::MemCategorizationContext::new(typer),
             delegate: delegate,
-            param_env: param_env,
         }
     }
 

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -41,7 +41,7 @@ struct IntrinsicCheckingVisitor<'a, 'tcx: 'a> {
     // environments for each function we encounter. When we find a
     // call to `transmute`, we can check it in the context of the top
     // of the stack (which ought not to be empty).
-    param_envs: Vec<ty::ParameterEnvironment<'tcx>>,
+    param_envs: Vec<ty::ParameterEnvironment<'a,'tcx>>,
 
     // Dummy sized/unsized types that use to substitute for type
     // parameters in order to estimate how big a type will be for any

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -75,7 +75,7 @@ use middle::def;
 use middle::region;
 use middle::ty::{mod, Ty};
 use util::nodemap::{NodeMap};
-use util::ppaux::{ty_to_string, Repr};
+use util::ppaux::{Repr};
 
 use syntax::ast::{MutImmutable, MutMutable};
 use syntax::ast;
@@ -264,6 +264,8 @@ pub struct MemCategorizationContext<'t,TYPER:'t> {
 
 impl<'t,TYPER:'t> Copy for MemCategorizationContext<'t,TYPER> {}
 
+pub type McResult<T> = Result<T, ()>;
+
 /// The `Typer` trait provides the interface for the mem-categorization
 /// module to the results of the type check. It can be used to query
 /// the type assigned to an expression node, to inquire after adjustments,
@@ -282,8 +284,10 @@ impl<'t,TYPER:'t> Copy for MemCategorizationContext<'t,TYPER> {}
 /// can be sure that only `Ok` results will occur.
 pub trait Typer<'tcx> : ty::UnboxedClosureTyper<'tcx> {
     fn tcx<'a>(&'a self) -> &'a ty::ctxt<'tcx>;
-    fn node_ty(&self, id: ast::NodeId) -> Ty<'tcx>;
-    fn expr_ty_adjusted(&self, expr: &ast::Expr) -> Ty<'tcx>;
+    fn param_env<'a>(&'a self) -> &'a ty::ParameterEnvironment<'a, 'tcx>;
+    fn node_ty(&self, id: ast::NodeId) -> McResult<Ty<'tcx>>;
+    fn expr_ty_adjusted(&self, expr: &ast::Expr) -> McResult<Ty<'tcx>>;
+    fn type_moves_by_default(&self, span: Span, ty: Ty<'tcx>) -> bool;
     fn node_method_ty(&self, method_call: ty::MethodCall) -> Option<Ty<'tcx>>;
     fn node_method_origin(&self, method_call: ty::MethodCall)
                           -> Option<ty::MethodOrigin<'tcx>>;
@@ -382,22 +386,22 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
         self.typer.tcx()
     }
 
-    fn expr_ty(&self, expr: &ast::Expr) -> Ty<'tcx> {
+    fn expr_ty(&self, expr: &ast::Expr) -> McResult<Ty<'tcx>> {
         self.typer.node_ty(expr.id)
     }
 
-    fn expr_ty_adjusted(&self, expr: &ast::Expr) -> Ty<'tcx> {
-        let unadjusted_ty = self.expr_ty(expr);
-        ty::adjust_ty(self.tcx(), expr.span, expr.id, unadjusted_ty,
-                      self.typer.adjustments().borrow().get(&expr.id),
-                      |method_call| self.typer.node_method_ty(method_call))
+    fn expr_ty_adjusted(&self, expr: &ast::Expr) -> McResult<Ty<'tcx>> {
+        let unadjusted_ty = try!(self.expr_ty(expr));
+        Ok(ty::adjust_ty(self.tcx(), expr.span, expr.id, unadjusted_ty,
+                         self.typer.adjustments().borrow().get(&expr.id),
+                         |method_call| self.typer.node_method_ty(method_call)))
     }
 
-    fn node_ty(&self, id: ast::NodeId) -> Ty<'tcx> {
+    fn node_ty(&self, id: ast::NodeId) -> McResult<Ty<'tcx>> {
         self.typer.node_ty(id)
     }
 
-    fn pat_ty(&self, pat: &ast::Pat) -> Ty<'tcx> {
+    fn pat_ty(&self, pat: &ast::Pat) -> McResult<Ty<'tcx>> {
         let tcx = self.typer.tcx();
         let base_ty = self.typer.node_ty(pat.id);
         // FIXME (Issue #18207): This code detects whether we are
@@ -420,7 +424,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
         ret_ty
     }
 
-    pub fn cat_expr(&self, expr: &ast::Expr) -> cmt<'tcx> {
+    pub fn cat_expr(&self, expr: &ast::Expr) -> McResult<cmt<'tcx>> {
         match self.typer.adjustments().borrow().get(&expr.id) {
             None => {
                 // No adjustments.
@@ -434,8 +438,8 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                                expr.repr(self.tcx()));
                         // Convert a bare fn to a closure by adding NULL env.
                         // Result is an rvalue.
-                        let expr_ty = self.expr_ty_adjusted(expr);
-                        self.cat_rvalue_node(expr.id(), expr.span(), expr_ty)
+                        let expr_ty = try!(self.expr_ty_adjusted(expr));
+                        Ok(self.cat_rvalue_node(expr.id(), expr.span(), expr_ty))
                     }
 
                     ty::AdjustDerefRef(
@@ -445,8 +449,8 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                                expr.repr(self.tcx()));
                         // Equivalent to &*expr or something similar.
                         // Result is an rvalue.
-                        let expr_ty = self.expr_ty_adjusted(expr);
-                        self.cat_rvalue_node(expr.id(), expr.span(), expr_ty)
+                        let expr_ty = try!(self.expr_ty_adjusted(expr));
+                        Ok(self.cat_rvalue_node(expr.id(), expr.span(), expr_ty))
                     }
 
                     ty::AdjustDerefRef(
@@ -463,46 +467,46 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
     pub fn cat_expr_autoderefd(&self,
                                expr: &ast::Expr,
                                autoderefs: uint)
-                               -> cmt<'tcx> {
-        let mut cmt = self.cat_expr_unadjusted(expr);
+                               -> McResult<cmt<'tcx>> {
+        let mut cmt = try!(self.cat_expr_unadjusted(expr));
         debug!("cat_expr_autoderefd: autoderefs={}, cmt={}",
                autoderefs,
                cmt.repr(self.tcx()));
         for deref in range(1u, autoderefs + 1) {
-            cmt = self.cat_deref(expr, cmt, deref, false);
+            cmt = try!(self.cat_deref(expr, cmt, deref, false));
         }
-        return cmt;
+        return Ok(cmt);
     }
 
-    pub fn cat_expr_unadjusted(&self, expr: &ast::Expr) -> cmt<'tcx> {
+    pub fn cat_expr_unadjusted(&self, expr: &ast::Expr) -> McResult<cmt<'tcx>> {
         debug!("cat_expr: id={} expr={}", expr.id, expr.repr(self.tcx()));
 
-        let expr_ty = self.expr_ty(expr);
+        let expr_ty = try!(self.expr_ty(expr));
         match expr.node {
           ast::ExprUnary(ast::UnDeref, ref e_base) => {
-            let base_cmt = self.cat_expr(&**e_base);
+            let base_cmt = try!(self.cat_expr(&**e_base));
             self.cat_deref(expr, base_cmt, 0, false)
           }
 
           ast::ExprField(ref base, f_name) => {
-            let base_cmt = self.cat_expr(&**base);
+            let base_cmt = try!(self.cat_expr(&**base));
             debug!("cat_expr(cat_field): id={} expr={} base={}",
                    expr.id,
                    expr.repr(self.tcx()),
                    base_cmt.repr(self.tcx()));
-            self.cat_field(expr, base_cmt, f_name.node.name, expr_ty)
+            Ok(self.cat_field(expr, base_cmt, f_name.node.name, expr_ty))
           }
 
           ast::ExprTupField(ref base, idx) => {
-            let base_cmt = self.cat_expr(&**base);
-            self.cat_tup_field(expr, base_cmt, idx.node, expr_ty)
+            let base_cmt = try!(self.cat_expr(&**base));
+            Ok(self.cat_tup_field(expr, base_cmt, idx.node, expr_ty))
           }
 
           ast::ExprIndex(ref base, ref idx) => {
             match idx.node {
                 ast::ExprRange(..) => {
                     // Slicing syntax special case (KILLME).
-                    self.cat_rvalue_node(expr.id(), expr.span(), expr_ty)
+                    Ok(self.cat_rvalue_node(expr.id(), expr.span(), expr_ty))
                 }
                 _ => {
                     let method_call = ty::MethodCall::expr(expr.id());
@@ -517,7 +521,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                                                                 ret_ty), 1, true)
                         }
                         None => {
-                            self.cat_index(expr, self.cat_expr(&**base))
+                            self.cat_index(expr, try!(self.cat_expr(&**base)))
                         }
                     }
                 }
@@ -545,7 +549,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
           ast::ExprAgain(..) | ast::ExprStruct(..) | ast::ExprRepeat(..) |
           ast::ExprInlineAsm(..) | ast::ExprBox(..) |
           ast::ExprForLoop(..) => {
-            self.cat_rvalue_node(expr.id(), expr.span(), expr_ty)
+            Ok(self.cat_rvalue_node(expr.id(), expr.span(), expr_ty))
           }
 
           ast::ExprIfLet(..) => {
@@ -562,43 +566,43 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                    span: Span,
                    expr_ty: Ty<'tcx>,
                    def: def::Def)
-                   -> cmt<'tcx> {
+                   -> McResult<cmt<'tcx>> {
         debug!("cat_def: id={} expr={} def={}",
                id, expr_ty.repr(self.tcx()), def);
 
         match def {
           def::DefStruct(..) | def::DefVariant(..) | def::DefFn(..) |
           def::DefStaticMethod(..) | def::DefConst(..) => {
-                self.cat_rvalue_node(id, span, expr_ty)
+                Ok(self.cat_rvalue_node(id, span, expr_ty))
           }
           def::DefMod(_) | def::DefForeignMod(_) | def::DefUse(_) |
           def::DefTrait(_) | def::DefTy(..) | def::DefPrimTy(_) |
           def::DefTyParam(..) | def::DefTyParamBinder(..) | def::DefRegion(_) |
           def::DefLabel(_) | def::DefSelfTy(..) | def::DefMethod(..) |
           def::DefAssociatedTy(..) | def::DefAssociatedPath(..)=> {
-              Rc::new(cmt_ {
+              Ok(Rc::new(cmt_ {
                   id:id,
                   span:span,
                   cat:cat_static_item,
                   mutbl: McImmutable,
                   ty:expr_ty,
                   note: NoteNone
-              })
+              }))
           }
 
           def::DefStatic(_, mutbl) => {
-              Rc::new(cmt_ {
+              Ok(Rc::new(cmt_ {
                   id:id,
                   span:span,
                   cat:cat_static_item,
                   mutbl: if mutbl { McDeclared } else { McImmutable},
                   ty:expr_ty,
                   note: NoteNone
-              })
+              }))
           }
 
           def::DefUpvar(var_id, fn_node_id, _) => {
-              let ty = self.node_ty(fn_node_id);
+              let ty = try!(self.node_ty(fn_node_id));
               match ty.sty {
                   ty::ty_closure(ref closure_ty) => {
                       // Translate old closure type info into unboxed
@@ -635,14 +639,14 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
           }
 
           def::DefLocal(vid) => {
-            Rc::new(cmt_ {
+            Ok(Rc::new(cmt_ {
                 id: id,
                 span: span,
                 cat: cat_local(vid),
                 mutbl: MutabilityCategory::from_local(self.tcx(), vid),
                 ty: expr_ty,
                 note: NoteNone
-            })
+            }))
           }
         }
     }
@@ -657,7 +661,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                  kind: ty::UnboxedClosureKind,
                  mode: ast::CaptureClause,
                  is_unboxed: bool)
-                 -> cmt<'tcx> {
+                 -> McResult<cmt<'tcx>> {
         // An upvar can have up to 3 components.  The base is a
         // `cat_upvar`.  Next, we add a deref through the implicit
         // environment pointer with an anonymous free region 'env and
@@ -679,7 +683,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
         // FnOnce         | copied               | upvar -> &'up bk
         // old stack      | N/A                  | upvar -> &'env mut -> &'up bk
         // old proc/once  | copied               | N/A
-        let var_ty = self.node_ty(var_id);
+        let var_ty = try!(self.node_ty(var_id));
 
         let upvar_id = ty::UpvarId { var_id: var_id,
                                      closure_expr_id: fn_node_id };
@@ -727,7 +731,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
         });
 
         // First, switch by capture mode
-        match mode {
+        Ok(match mode {
             ast::CaptureByValue => {
                 let mut base = cmt_ {
                     id: id,
@@ -809,7 +813,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                     note: NoteUpvarRef(upvar_id)
                 })
             }
-        }
+        })
     }
 
     pub fn cat_rvalue_node(&self,
@@ -882,7 +886,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                              base_cmt: cmt<'tcx>,
                              deref_cnt: uint,
                              implicit: bool)
-                             -> cmt<'tcx> {
+                             -> McResult<cmt<'tcx>> {
         let adjustment = match self.typer.adjustments().borrow().get(&node.id()) {
             Some(adj) if ty::adjust_is_object(adj) => ty::AutoObject,
             _ if deref_cnt != 0 => ty::AutoDeref(deref_cnt),
@@ -896,7 +900,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
         let method_ty = self.typer.node_method_ty(method_call);
 
         debug!("cat_deref: method_call={} method_ty={}",
-            method_call, method_ty.map(|ty| ty.repr(self.tcx())));
+               method_call, method_ty.map(|ty| ty.repr(self.tcx())));
 
         let base_cmt = match method_ty {
             Some(method_ty) => {
@@ -922,8 +926,9 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                                     deref_cnt: uint,
                                     deref_ty: Ty<'tcx>,
                                     implicit: bool)
-                                    -> cmt<'tcx> {
-        let (m, cat) = match deref_kind(self.tcx(), base_cmt.ty) {
+                                    -> McResult<cmt<'tcx>>
+    {
+        let (m, cat) = match try!(deref_kind(base_cmt.ty)) {
             deref_ptr(ptr) => {
                 let ptr = if implicit {
                     match ptr {
@@ -943,20 +948,20 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                 (base_cmt.mutbl.inherit(), cat_interior(base_cmt, interior))
             }
         };
-        Rc::new(cmt_ {
+        Ok(Rc::new(cmt_ {
             id: node.id(),
             span: node.span(),
             cat: cat,
             mutbl: m,
             ty: deref_ty,
             note: NoteNone
-        })
+        }))
     }
 
     pub fn cat_index<N:ast_node>(&self,
                                  elt: &N,
                                  mut base_cmt: cmt<'tcx>)
-                                 -> cmt<'tcx> {
+                                 -> McResult<cmt<'tcx>> {
         //! Creates a cmt for an indexing operation (`[]`).
         //!
         //! One subtle aspect of indexing that may not be
@@ -1021,15 +1026,16 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
     fn deref_vec<N:ast_node>(&self,
                              elt: &N,
                              base_cmt: cmt<'tcx>)
-                             -> cmt<'tcx> {
-        match deref_kind(self.tcx(), base_cmt.ty) {
+                             -> McResult<cmt<'tcx>>
+    {
+        match try!(deref_kind(base_cmt.ty)) {
             deref_ptr(ptr) => {
                 // for unique ptrs, we inherit mutability from the
                 // owning reference.
                 let m = MutabilityCategory::from_pointer_kind(base_cmt.mutbl, ptr);
 
                 // the deref is explicit in the resulting cmt
-                Rc::new(cmt_ {
+                Ok(Rc::new(cmt_ {
                     id:elt.id(),
                     span:elt.span(),
                     cat:cat_deref(base_cmt.clone(), 0, ptr),
@@ -1039,11 +1045,11 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                         None => self.tcx().sess.bug("Found non-derefable type")
                     },
                     note: NoteNone
-                })
+                }))
             }
 
             deref_interior(_) => {
-                base_cmt
+                Ok(base_cmt)
             }
         }
     }
@@ -1058,13 +1064,13 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
     pub fn cat_slice_pattern(&self,
                              vec_cmt: cmt<'tcx>,
                              slice_pat: &ast::Pat)
-                             -> (cmt<'tcx>, ast::Mutability, ty::Region) {
-        let slice_ty = self.node_ty(slice_pat.id);
+                             -> McResult<(cmt<'tcx>, ast::Mutability, ty::Region)> {
+        let slice_ty = try!(self.node_ty(slice_pat.id));
         let (slice_mutbl, slice_r) = vec_slice_info(self.tcx(),
                                                     slice_pat,
                                                     slice_ty);
-        let cmt_slice = self.cat_index(slice_pat, self.deref_vec(slice_pat, vec_cmt));
-        return (cmt_slice, slice_mutbl, slice_r);
+        let cmt_slice = try!(self.cat_index(slice_pat, try!(self.deref_vec(slice_pat, vec_cmt))));
+        return Ok((cmt_slice, slice_mutbl, slice_r));
 
         /// In a pattern like [a, b, ..c], normally `c` has slice type, but if you have [a, b,
         /// ..ref c], then the type of `ref c` will be `&&[]`, so to extract the slice details we
@@ -1119,15 +1125,16 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
         })
     }
 
-    pub fn cat_pattern<F>(&self, cmt: cmt<'tcx>, pat: &ast::Pat, mut op: F) where
-        F: FnMut(&MemCategorizationContext<'t, TYPER>, cmt<'tcx>, &ast::Pat),
+    pub fn cat_pattern<F>(&self, cmt: cmt<'tcx>, pat: &ast::Pat, mut op: F) -> McResult<()>
+        where F: FnMut(&MemCategorizationContext<'t, TYPER>, cmt<'tcx>, &ast::Pat),
     {
         self.cat_pattern_(cmt, pat, &mut op)
     }
 
     // FIXME(#19596) This is a workaround, but there should be a better way to do this
-    fn cat_pattern_<F>(&self, cmt: cmt<'tcx>, pat: &ast::Pat, op: &mut F) where
-        F: FnMut(&MemCategorizationContext<'t, TYPER>, cmt<'tcx>, &ast::Pat),
+    fn cat_pattern_<F>(&self, cmt: cmt<'tcx>, pat: &ast::Pat, op: &mut F)
+                       -> McResult<()>
+        where F : FnMut(&MemCategorizationContext<'t, TYPER>, cmt<'tcx>, &ast::Pat),
     {
         // Here, `cmt` is the categorization for the value being
         // matched and pat is the pattern it is being matched against.
@@ -1208,29 +1215,29 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                 Some(&def::DefVariant(..)) => {
                     // variant(x, y, z)
                     for (i, subpat) in subpats.iter().enumerate() {
-                        let subpat_ty = self.pat_ty(&**subpat); // see (*2)
+                        let subpat_ty = try!(self.pat_ty(&**subpat)); // see (*2)
 
                         let subcmt =
                             self.cat_imm_interior(
                                 pat, cmt.clone(), subpat_ty,
                                 InteriorField(PositionalField(i)));
 
-                        self.cat_pattern_(subcmt, &**subpat, op);
+                        try!(self.cat_pattern_(subcmt, &**subpat, op));
                     }
                 }
                 Some(&def::DefStruct(..)) => {
                     for (i, subpat) in subpats.iter().enumerate() {
-                        let subpat_ty = self.pat_ty(&**subpat); // see (*2)
+                        let subpat_ty = try!(self.pat_ty(&**subpat)); // see (*2)
                         let cmt_field =
                             self.cat_imm_interior(
                                 pat, cmt.clone(), subpat_ty,
                                 InteriorField(PositionalField(i)));
-                        self.cat_pattern_(cmt_field, &**subpat, op);
+                        try!(self.cat_pattern_(cmt_field, &**subpat, op));
                     }
                 }
                 Some(&def::DefConst(..)) => {
                     for subpat in subpats.iter() {
-                        self.cat_pattern_(cmt.clone(), &**subpat, op);
+                        try!(self.cat_pattern_(cmt.clone(), &**subpat, op));
                     }
                 }
                 _ => {
@@ -1242,7 +1249,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
           }
 
           ast::PatIdent(_, _, Some(ref subpat)) => {
-              self.cat_pattern_(cmt, &**subpat, op);
+              try!(self.cat_pattern_(cmt, &**subpat, op));
           }
 
           ast::PatIdent(_, _, None) => {
@@ -1252,42 +1259,42 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
           ast::PatStruct(_, ref field_pats, _) => {
             // {f1: p1, ..., fN: pN}
             for fp in field_pats.iter() {
-                let field_ty = self.pat_ty(&*fp.node.pat); // see (*2)
+                let field_ty = try!(self.pat_ty(&*fp.node.pat)); // see (*2)
                 let cmt_field = self.cat_field(pat, cmt.clone(), fp.node.ident.name, field_ty);
-                self.cat_pattern_(cmt_field, &*fp.node.pat, op);
+                try!(self.cat_pattern_(cmt_field, &*fp.node.pat, op));
             }
           }
 
           ast::PatTup(ref subpats) => {
             // (p1, ..., pN)
             for (i, subpat) in subpats.iter().enumerate() {
-                let subpat_ty = self.pat_ty(&**subpat); // see (*2)
+                let subpat_ty = try!(self.pat_ty(&**subpat)); // see (*2)
                 let subcmt =
                     self.cat_imm_interior(
                         pat, cmt.clone(), subpat_ty,
                         InteriorField(PositionalField(i)));
-                self.cat_pattern_(subcmt, &**subpat, op);
+                try!(self.cat_pattern_(subcmt, &**subpat, op));
             }
           }
 
           ast::PatBox(ref subpat) | ast::PatRegion(ref subpat) => {
             // @p1, ~p1, ref p1
-            let subcmt = self.cat_deref(pat, cmt, 0, false);
-            self.cat_pattern_(subcmt, &**subpat, op);
+            let subcmt = try!(self.cat_deref(pat, cmt, 0, false));
+              try!(self.cat_pattern_(subcmt, &**subpat, op));
           }
 
           ast::PatVec(ref before, ref slice, ref after) => {
-              let elt_cmt = self.cat_index(pat, self.deref_vec(pat, cmt));
+              let elt_cmt = try!(self.cat_index(pat, try!(self.deref_vec(pat, cmt))));
               for before_pat in before.iter() {
-                  self.cat_pattern_(elt_cmt.clone(), &**before_pat, op);
+                  try!(self.cat_pattern_(elt_cmt.clone(), &**before_pat, op));
               }
               for slice_pat in slice.iter() {
-                  let slice_ty = self.pat_ty(&**slice_pat);
+                  let slice_ty = try!(self.pat_ty(&**slice_pat));
                   let slice_cmt = self.cat_rvalue_node(pat.id(), pat.span(), slice_ty);
-                  self.cat_pattern_(slice_cmt, &**slice_pat, op);
+                  try!(self.cat_pattern_(slice_cmt, &**slice_pat, op));
               }
               for after_pat in after.iter() {
-                  self.cat_pattern_(elt_cmt.clone(), &**after_pat, op);
+                  try!(self.cat_pattern_(elt_cmt.clone(), &**after_pat, op));
               }
           }
 

--- a/src/librustc/middle/traits/coherence.rs
+++ b/src/librustc/middle/traits/coherence.rs
@@ -42,8 +42,8 @@ pub fn impl_can_satisfy(infcx: &InferCtxt,
 
     // Determine whether `impl2` can provide an implementation for those
     // same types.
-    let param_env = ty::empty_parameter_environment();
-    let mut selcx = SelectionContext::intercrate(infcx, &param_env, infcx.tcx);
+    let param_env = ty::empty_parameter_environment(infcx.tcx);
+    let mut selcx = SelectionContext::intercrate(infcx, &param_env);
     let obligation = Obligation::new(ObligationCause::dummy(),
                                      ty::Binder(ty::TraitPredicate {
                                          trait_ref: Rc::new(impl1_trait_ref),

--- a/src/librustc/middle/traits/error_reporting.rs
+++ b/src/librustc/middle/traits/error_reporting.rs
@@ -77,7 +77,7 @@ pub fn report_selection_error<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
                     "overflow evaluating the requirement `{}`",
                     predicate.user_string(infcx.tcx)).as_slice());
 
-            suggest_new_overflow_limit(infcx, obligation.cause.span);
+            suggest_new_overflow_limit(infcx.tcx, obligation.cause.span);
 
             note_obligation_cause(infcx, obligation);
         }
@@ -332,10 +332,10 @@ fn note_obligation_cause_code<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
     }
 }
 
-pub fn suggest_new_overflow_limit(infcx: &InferCtxt, span: Span) {
-    let current_limit = infcx.tcx.sess.recursion_limit.get();
+pub fn suggest_new_overflow_limit(tcx: &ty::ctxt, span: Span) {
+    let current_limit = tcx.sess.recursion_limit.get();
     let suggested_limit = current_limit * 2;
-    infcx.tcx.sess.span_note(
+    tcx.sess.span_note(
         span,
         format!(
             "consider adding a `#![recursion_limit=\"{}\"]` attribute to your crate",

--- a/src/librustc/middle/traits/fulfill.rs
+++ b/src/librustc/middle/traits/fulfill.rs
@@ -109,7 +109,6 @@ impl<'tcx> FulfillmentContext<'tcx> {
     /// `projection_ty` again.
     pub fn normalize_projection_type<'a>(&mut self,
                                          infcx: &InferCtxt<'a,'tcx>,
-                                         param_env: &ty::ParameterEnvironment<'tcx>,
                                          typer: &ty::UnboxedClosureTyper<'tcx>,
                                          projection_ty: ty::ProjectionTy<'tcx>,
                                          cause: ObligationCause<'tcx>)
@@ -122,7 +121,7 @@ impl<'tcx> FulfillmentContext<'tcx> {
 
         // FIXME(#20304) -- cache
 
-        let mut selcx = SelectionContext::new(infcx, param_env, typer);
+        let mut selcx = SelectionContext::new(infcx, typer);
         let normalized = project::normalize_projection_type(&mut selcx, projection_ty, cause, 0);
 
         for obligation in normalized.obligations.into_iter() {
@@ -186,11 +185,10 @@ impl<'tcx> FulfillmentContext<'tcx> {
 
     pub fn select_all_or_error<'a>(&mut self,
                                    infcx: &InferCtxt<'a,'tcx>,
-                                   param_env: &ty::ParameterEnvironment<'tcx>,
                                    typer: &ty::UnboxedClosureTyper<'tcx>)
                                    -> Result<(),Vec<FulfillmentError<'tcx>>>
     {
-        try!(self.select_where_possible(infcx, param_env, typer));
+        try!(self.select_where_possible(infcx, typer));
 
         // Anything left is ambiguous.
         let errors: Vec<FulfillmentError> =
@@ -212,21 +210,19 @@ impl<'tcx> FulfillmentContext<'tcx> {
     /// results in `O(n^2)` performance (#18208).
     pub fn select_new_obligations<'a>(&mut self,
                                       infcx: &InferCtxt<'a,'tcx>,
-                                      param_env: &ty::ParameterEnvironment<'tcx>,
                                       typer: &ty::UnboxedClosureTyper<'tcx>)
                                       -> Result<(),Vec<FulfillmentError<'tcx>>>
     {
-        let mut selcx = SelectionContext::new(infcx, param_env, typer);
+        let mut selcx = SelectionContext::new(infcx, typer);
         self.select(&mut selcx, true)
     }
 
     pub fn select_where_possible<'a>(&mut self,
                                      infcx: &InferCtxt<'a,'tcx>,
-                                     param_env: &ty::ParameterEnvironment<'tcx>,
                                      typer: &ty::UnboxedClosureTyper<'tcx>)
                                      -> Result<(),Vec<FulfillmentError<'tcx>>>
     {
-        let mut selcx = SelectionContext::new(infcx, param_env, typer);
+        let mut selcx = SelectionContext::new(infcx, typer);
         self.select(&mut selcx, false)
     }
 

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -46,7 +46,6 @@ use util::ppaux::Repr;
 
 pub struct SelectionContext<'cx, 'tcx:'cx> {
     infcx: &'cx InferCtxt<'cx, 'tcx>,
-    param_env: &'cx ty::ParameterEnvironment<'tcx>,
     closure_typer: &'cx (ty::UnboxedClosureTyper<'tcx>+'cx),
 
     /// Freshener used specifically for skolemizing entries on the
@@ -181,12 +180,10 @@ enum EvaluationResult<'tcx> {
 
 impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     pub fn new(infcx: &'cx InferCtxt<'cx, 'tcx>,
-               param_env: &'cx ty::ParameterEnvironment<'tcx>,
                closure_typer: &'cx ty::UnboxedClosureTyper<'tcx>)
                -> SelectionContext<'cx, 'tcx> {
         SelectionContext {
             infcx: infcx,
-            param_env: param_env,
             closure_typer: closure_typer,
             freshener: infcx.freshener(),
             intercrate: false,
@@ -194,12 +191,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     }
 
     pub fn intercrate(infcx: &'cx InferCtxt<'cx, 'tcx>,
-                      param_env: &'cx ty::ParameterEnvironment<'tcx>,
                       closure_typer: &'cx ty::UnboxedClosureTyper<'tcx>)
                       -> SelectionContext<'cx, 'tcx> {
         SelectionContext {
             infcx: infcx,
-            param_env: param_env,
             closure_typer: closure_typer,
             freshener: infcx.freshener(),
             intercrate: true,
@@ -210,12 +205,12 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         self.infcx
     }
 
-    pub fn param_env(&self) -> &'cx ty::ParameterEnvironment<'tcx> {
-        self.param_env
-    }
-
     pub fn tcx(&self) -> &'cx ty::ctxt<'tcx> {
         self.infcx.tcx
+    }
+
+    pub fn param_env(&self) -> &'cx ty::ParameterEnvironment<'cx, 'tcx> {
+        self.closure_typer.param_env()
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -650,7 +645,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // it's not worth going to more trouble to increase the
         // hit-rate I don't think.
         if self.intercrate {
-            return &self.param_env.selection_cache;
+            return &self.param_env().selection_cache;
         }
 
         // If the trait refers to any parameters in scope, then use
@@ -659,7 +654,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             cache_fresh_trait_pred.0.input_types().iter().any(
                 |&t| ty::type_has_self(t) || ty::type_has_params(t))
         {
-            return &self.param_env.selection_cache;
+            return &self.param_env().selection_cache;
         }
 
         // If the trait refers to unbound type variables, and there
@@ -668,11 +663,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // common case, then we can use the global environment.
         // See the discussion in doc.rs for more details.
         if
-            !self.param_env.caller_bounds.is_empty() &&
+            !self.param_env().caller_bounds.is_empty() &&
             cache_fresh_trait_pred.0.input_types().iter().any(
                 |&t| ty::type_has_ty_infer(t))
         {
-            return &self.param_env.selection_cache;
+            return &self.param_env().selection_cache;
         }
 
         // Otherwise, we can use the global cache.
@@ -902,7 +897,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                obligation.repr(self.tcx()));
 
         let caller_trait_refs: Vec<_> =
-            self.param_env.caller_bounds.predicates.iter()
+            self.param_env().caller_bounds.predicates.iter()
             .filter_map(|o| o.to_opt_poly_trait_ref())
             .collect();
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -5708,7 +5708,10 @@ pub fn unboxed_closure_upvars<'tcx>(typer: &mc::Typer<'tcx>,
             freevars.iter()
                     .map(|freevar| {
                         let freevar_def_id = freevar.def.def_id();
-                        let freevar_ty = typer.node_ty(freevar_def_id.node);
+                        let freevar_ty = match typer.node_ty(freevar_def_id.node) {
+                            Ok(t) => { t }
+                            Err(()) => { return None; }
+                        };
                         let freevar_ty = freevar_ty.subst(tcx, substs);
 
                         match capture_mode {

--- a/src/librustc_borrowck/borrowck/check_loans.rs
+++ b/src/librustc_borrowck/borrowck/check_loans.rs
@@ -87,7 +87,7 @@ struct CheckLoanCtxt<'a, 'tcx: 'a> {
     dfcx_loans: &'a LoanDataFlow<'a, 'tcx>,
     move_data: move_data::FlowedMoveData<'a, 'tcx>,
     all_loans: &'a [Loan<'tcx>],
-    param_env: &'a ty::ParameterEnvironment<'tcx>,
+    param_env: &'a ty::ParameterEnvironment<'a, 'tcx>,
 }
 
 impl<'a, 'tcx> euv::Delegate<'tcx> for CheckLoanCtxt<'a, 'tcx> {
@@ -208,9 +208,7 @@ pub fn check_loans<'a, 'b, 'c, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>,
     };
 
     {
-        let mut euv = euv::ExprUseVisitor::new(&mut clcx,
-                                               bccx.tcx,
-                                               &param_env);
+        let mut euv = euv::ExprUseVisitor::new(&mut clcx, &param_env);
         euv.walk_fn(decl, body);
     }
 }

--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -542,7 +542,7 @@ fn enter_opt<'a, 'p, 'blk, 'tcx>(
             check_match::Constructor::Variant(def_id)
     };
 
-    let param_env = ty::empty_parameter_environment();
+    let param_env = ty::empty_parameter_environment(bcx.tcx());
     let mcx = check_match::MatchCheckCtxt {
         tcx: bcx.tcx(),
         param_env: param_env,
@@ -1008,7 +1008,7 @@ fn compile_submatch_continue<'a, 'p, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
 
     let mcx = check_match::MatchCheckCtxt {
         tcx: bcx.tcx(),
-        param_env: ty::empty_parameter_environment(),
+        param_env: ty::empty_parameter_environment(bcx.tcx()),
     };
     let adt_vals = if any_irrefutable_adt_pat(bcx.tcx(), m, col) {
         let repr = adt::represent_type(bcx.ccx(), left_ty);
@@ -1262,8 +1262,7 @@ fn is_discr_reassigned(bcx: Block, discr: &ast::Expr, body: &ast::Expr) -> bool 
         reassigned: false
     };
     {
-        let param_env = ty::empty_parameter_environment();
-        let mut visitor = euv::ExprUseVisitor::new(&mut rc, bcx, &param_env);
+        let mut visitor = euv::ExprUseVisitor::new(&mut rc, bcx);
         visitor.walk_expr(body);
     }
     rc.reassigned
@@ -1321,7 +1320,7 @@ fn create_bindings_map<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, pat: &ast::Pat,
         let variable_ty = node_id_type(bcx, p_id);
         let llvariable_ty = type_of::type_of(ccx, variable_ty);
         let tcx = bcx.tcx();
-        let param_env = ty::empty_parameter_environment();
+        let param_env = ty::empty_parameter_environment(tcx);
 
         let llmatch;
         let trmode;

--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -1327,9 +1327,8 @@ fn create_bindings_map<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, pat: &ast::Pat,
         let trmode;
         match bm {
             ast::BindByValue(_)
-                if !ty::type_moves_by_default(tcx,
-                                              variable_ty,
-                                              &param_env) || reassigned => {
+                if !ty::type_moves_by_default(&param_env, span, variable_ty) || reassigned =>
+            {
                 llmatch = alloca_no_lifetime(bcx,
                                  llvariable_ty.ptr_to(),
                                  "__llmatch");

--- a/src/librustc_trans/trans/adt.rs
+++ b/src/librustc_trans/trans/adt.rs
@@ -61,7 +61,7 @@ use trans::datum;
 use trans::machine;
 use trans::type_::Type;
 use trans::type_of;
-use middle::ty::{mod, Ty};
+use middle::ty::{mod, Ty, UnboxedClosureTyper};
 use middle::ty::Disr;
 use syntax::ast;
 use syntax::attr;
@@ -168,7 +168,8 @@ fn represent_type_uncached<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             Univariant(mk_struct(cx, ftys[], packed, t), dtor)
         }
         ty::ty_unboxed_closure(def_id, _, substs) => {
-            let upvars = ty::unboxed_closure_upvars(cx.tcx(), def_id, substs).unwrap();
+            let typer = NormalizingUnboxedClosureTyper::new(cx.tcx());
+            let upvars = typer.unboxed_closure_upvars(def_id, substs).unwrap();
             let upvar_types = upvars.iter().map(|u| u.ty).collect::<Vec<_>>();
             Univariant(mk_struct(cx, upvar_types[], false, t), false)
         }

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -731,7 +731,8 @@ pub fn iter_structural_ty<'a, 'blk, 'tcx>(cx: Block<'blk, 'tcx>,
       }
       ty::ty_unboxed_closure(def_id, _, substs) => {
           let repr = adt::represent_type(cx.ccx(), t);
-          let upvars = ty::unboxed_closure_upvars(cx.tcx(), def_id, substs).unwrap();
+          let typer = common::NormalizingUnboxedClosureTyper::new(cx.tcx());
+          let upvars = typer.unboxed_closure_upvars(def_id, substs).unwrap();
           for (i, upvar) in upvars.iter().enumerate() {
               let llupvar = adt::trans_field_ptr(cx, &*repr, data_ptr, 0, i);
               cx = f(cx, llupvar, upvar.ty);
@@ -1451,6 +1452,7 @@ pub fn new_fn_ctxt<'a, 'tcx>(ccx: &'a CrateContext<'a, 'tcx>,
           llfn: llfndecl,
           llenv: None,
           llretslotptr: Cell::new(None),
+          param_env: ty::empty_parameter_environment(ccx.tcx()),
           alloca_insert_pt: Cell::new(None),
           llreturn: Cell::new(None),
           needs_ret_allocas: nested_returns,

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -625,6 +625,10 @@ impl<'blk, 'tcx> mc::Typer<'tcx> for BlockS<'blk, 'tcx> {
                     -> ast::CaptureClause {
         self.tcx().capture_modes.borrow()[closure_expr_id].clone()
     }
+
+    fn type_moves_by_default(&self, span: Span, ty: Ty<'tcx>) -> bool {
+        self.param_env().type_moves_by_default(span, ty)
+    }
 }
 
 impl<'blk, 'tcx> ty::UnboxedClosureTyper<'tcx> for BlockS<'blk, 'tcx> {

--- a/src/librustc_trans/trans/datum.rs
+++ b/src/librustc_trans/trans/datum.rs
@@ -28,6 +28,7 @@ use util::ppaux::{ty_to_string};
 
 use std::fmt;
 use syntax::ast;
+use syntax::codemap::DUMMY_SP;
 
 /// A `Datum` encapsulates the result of evaluating an expression.  It
 /// describes where the value is stored, what Rust type the value has,

--- a/src/librustc_trans/trans/datum.rs
+++ b/src/librustc_trans/trans/datum.rs
@@ -543,8 +543,9 @@ impl<'tcx, K: KindOps + fmt::Show> Datum<'tcx, K> {
          * affine values (since they must never be duplicated).
          */
 
-        let param_env = ty::empty_parameter_environment();
-        assert!(!ty::type_moves_by_default(bcx.tcx(), self.ty, &param_env));
+        assert!(!ty::type_moves_by_default(&ty::empty_parameter_environment(bcx.tcx()),
+                                           DUMMY_SP,
+                                           self.ty));
         self.shallow_copy_raw(bcx, dst)
     }
 

--- a/src/librustc_trans/trans/monomorphize.rs
+++ b/src/librustc_trans/trans/monomorphize.rs
@@ -322,9 +322,8 @@ pub fn normalize_associated_type<'tcx,T>(tcx: &ty::ctxt<'tcx>, value: &T) -> T
     // FIXME(#20304) -- cache
 
     let infcx = infer::new_infer_ctxt(tcx);
-    let param_env = ty::empty_parameter_environment();
-    let typer = NormalizingUnboxedClosureTyper::new(infcx.tcx);
-    let mut selcx = traits::SelectionContext::new(&infcx, &param_env, &typer);
+    let typer = NormalizingUnboxedClosureTyper::new(tcx);
+    let mut selcx = traits::SelectionContext::new(&infcx, &typer);
     let cause = traits::ObligationCause::dummy();
     let traits::Normalized { value: result, obligations } =
         traits::normalize(&mut selcx, cause, value);
@@ -337,7 +336,7 @@ pub fn normalize_associated_type<'tcx,T>(tcx: &ty::ctxt<'tcx>, value: &T) -> T
     for obligation in obligations.into_iter() {
         fulfill_cx.register_predicate_obligation(&infcx, obligation);
     }
-    let result = drain_fulfillment_cx(DUMMY_SP, &infcx, &param_env, &mut fulfill_cx, &result);
+    let result = drain_fulfillment_cx(DUMMY_SP, &infcx, &mut fulfill_cx, &result);
 
     result
 }

--- a/src/librustc_typeck/check/assoc.rs
+++ b/src/librustc_typeck/check/assoc.rs
@@ -18,7 +18,6 @@ use syntax::codemap::Span;
 use util::ppaux::Repr;
 
 pub fn normalize_associated_types_in<'a,'tcx,T>(infcx: &InferCtxt<'a,'tcx>,
-                                                param_env: &ty::ParameterEnvironment<'tcx>,
                                                 typer: &(ty::UnboxedClosureTyper<'tcx>+'a),
                                                 fulfillment_cx: &mut FulfillmentContext<'tcx>,
                                                 span: Span,
@@ -28,7 +27,7 @@ pub fn normalize_associated_types_in<'a,'tcx,T>(infcx: &InferCtxt<'a,'tcx>,
     where T : TypeFoldable<'tcx> + HasProjectionTypes + Clone + Repr<'tcx>
 {
     debug!("normalize_associated_types_in(value={})", value.repr(infcx.tcx));
-    let mut selcx = SelectionContext::new(infcx, param_env, typer);
+    let mut selcx = SelectionContext::new(infcx, typer);
     let cause = ObligationCause::new(span, body_id, MiscObligation);
     let Normalized { value: result, obligations } = traits::normalize(&mut selcx, cause, value);
     debug!("normalize_associated_types_in: result={} predicates={}",

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -169,9 +169,7 @@ pub fn lookup_in_trait_adjusted<'a, 'tcx>(fcx: &'a FnCtxt<'a, 'tcx>,
                                               poly_trait_ref.as_predicate());
 
     // Now we want to know if this can be matched
-    let mut selcx = traits::SelectionContext::new(fcx.infcx(),
-                                                  &fcx.inh.param_env,
-                                                  fcx);
+    let mut selcx = traits::SelectionContext::new(fcx.infcx(), fcx);
     if !selcx.evaluate_obligation(&obligation) {
         debug!("--> Cannot match obligation");
         return None; // Cannot be matched, no such method resolution is possible.

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -788,9 +788,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
                     debug!("impl_obligations={}", obligations.repr(self.tcx()));
 
                     // Evaluate those obligations to see if they might possibly hold.
-                    let mut selcx = traits::SelectionContext::new(self.infcx(),
-                                                                  &self.fcx.inh.param_env,
-                                                                  self.fcx);
+                    let mut selcx = traits::SelectionContext::new(self.infcx(), self.fcx);
                     obligations.all(|o| selcx.evaluate_obligation(o))
                 }
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -130,6 +130,7 @@ pub mod regionmanip;
 pub mod regionck;
 pub mod demand;
 pub mod method;
+mod upvar;
 pub mod wf;
 mod closure;
 mod callee;
@@ -482,6 +483,7 @@ fn check_bare_fn<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                decl, id, body, &inh);
 
             vtable::select_all_fcx_obligations_or_error(&fcx);
+            upvar::closure_analyze_fn(&fcx, id, decl, body);
             regionck::regionck_fn(&fcx, id, decl, body);
             writeback::resolve_type_vars_in_fn(&fcx, decl, body);
         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1462,7 +1462,7 @@ fn check_cast(fcx: &FnCtxt,
         return
     }
 
-    if !fcx.type_is_known_to_be_sized(t_1) {
+    if !fcx.type_is_known_to_be_sized(t_1, cast_expr.span) {
         let tstr = fcx.infcx().ty_to_string(t_1);
         fcx.type_error_message(span, |actual| {
             format!("cast to unsized type: `{}` as `{}`", actual, tstr)
@@ -1981,13 +1981,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     pub fn type_is_known_to_be_sized(&self,
-                                     ty: Ty<'tcx>)
+                                     ty: Ty<'tcx>,
+                                     span: Span)
                                      -> bool
     {
         traits::type_known_to_meet_builtin_bound(self.infcx(),
                                                  self.param_env(),
                                                  ty,
-                                                 ty::BoundSized)
+                                                 ty::BoundSized,
+                                                 span)
     }
 
     pub fn register_builtin_bound(&self,

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -140,6 +140,10 @@ use std::collections::hash_map::Entry::{Vacant, Occupied};
 use self::RepeatingScope::Repeating;
 use self::SubjectNode::Subject;
 
+// a variation on try that just returns unit
+macro_rules! ignore_err {
+    ($e:expr) => (match $e { Ok(e) => e, Err(_) => return () })
+}
 
 ///////////////////////////////////////////////////////////////////////////
 // PUBLIC ENTRY POINTS
@@ -1027,7 +1031,7 @@ fn constrain_callee(rcx: &mut Rcx,
                     // While we're here, link the closure's region with a unique
                     // immutable borrow (gathered later in borrowck)
                     let mc = mc::MemCategorizationContext::new(rcx.fcx);
-                    let expr_cmt = mc.cat_expr(callee_expr);
+                    let expr_cmt = ignore_err!(mc.cat_expr(callee_expr));
                     link_region(rcx, callee_expr.span, call_region,
                                 ty::UniqueImmBorrow, expr_cmt);
                     r
@@ -1136,7 +1140,7 @@ fn constrain_autoderefs<'a, 'tcx>(rcx: &mut Rcx<'a, 'tcx>,
                 };
                 {
                     let mc = mc::MemCategorizationContext::new(rcx.fcx);
-                    let self_cmt = mc.cat_expr_autoderefd(deref_expr, i);
+                    let self_cmt = ignore_err!(mc.cat_expr_autoderefd(deref_expr, i));
                     link_region(rcx, deref_expr.span, *r,
                                 ty::BorrowKind::from_mutbl(m), self_cmt);
                 }
@@ -1232,7 +1236,7 @@ fn link_addr_of(rcx: &mut Rcx, expr: &ast::Expr,
 
     let cmt = {
         let mc = mc::MemCategorizationContext::new(rcx.fcx);
-        mc.cat_expr(base)
+        ignore_err!(mc.cat_expr(base))
     };
     link_region_from_node_type(rcx, expr.span, expr.id, mutability, cmt);
 }
@@ -1247,7 +1251,7 @@ fn link_local(rcx: &Rcx, local: &ast::Local) {
         Some(ref expr) => &**expr,
     };
     let mc = mc::MemCategorizationContext::new(rcx.fcx);
-    let discr_cmt = mc.cat_expr(init_expr);
+    let discr_cmt = ignore_err!(mc.cat_expr(init_expr));
     link_pattern(rcx, mc, discr_cmt, &*local.pat);
 }
 
@@ -1257,7 +1261,7 @@ fn link_local(rcx: &Rcx, local: &ast::Local) {
 fn link_match(rcx: &Rcx, discr: &ast::Expr, arms: &[ast::Arm]) {
     debug!("regionck::for_match()");
     let mc = mc::MemCategorizationContext::new(rcx.fcx);
-    let discr_cmt = mc.cat_expr(discr);
+    let discr_cmt = ignore_err!(mc.cat_expr(discr));
     debug!("discr_cmt={}", discr_cmt.repr(rcx.tcx()));
     for arm in arms.iter() {
         for root_pat in arm.pats.iter() {
@@ -1303,11 +1307,14 @@ fn link_pattern<'a, 'tcx>(rcx: &Rcx<'a, 'tcx>,
 
                 // `[_, ..slice, _]` pattern
                 ast::PatVec(_, Some(ref slice_pat), _) => {
-                    let (slice_cmt, slice_mutbl, slice_r) =
-                        mc.cat_slice_pattern(sub_cmt, &**slice_pat);
-                    link_region(rcx, sub_pat.span, slice_r,
-                                ty::BorrowKind::from_mutbl(slice_mutbl),
-                                slice_cmt);
+                    match mc.cat_slice_pattern(sub_cmt, &**slice_pat) {
+                        Ok((slice_cmt, slice_mutbl, slice_r)) => {
+                            link_region(rcx, sub_pat.span, slice_r,
+                                        ty::BorrowKind::from_mutbl(slice_mutbl),
+                                        slice_cmt);
+                        }
+                        Err(()) => {}
+                    }
                 }
                 _ => {}
             }
@@ -1323,7 +1330,7 @@ fn link_autoref(rcx: &Rcx,
 
     debug!("link_autoref(autoref={})", autoref);
     let mc = mc::MemCategorizationContext::new(rcx.fcx);
-    let expr_cmt = mc.cat_expr_autoderefd(expr, autoderefs);
+    let expr_cmt = ignore_err!(mc.cat_expr_autoderefd(expr, autoderefs));
     debug!("expr_cmt={}", expr_cmt.repr(rcx.tcx()));
 
     match *autoref {
@@ -1345,7 +1352,7 @@ fn link_by_ref(rcx: &Rcx,
     debug!("link_by_ref(expr={}, callee_scope={})",
            expr.repr(tcx), callee_scope);
     let mc = mc::MemCategorizationContext::new(rcx.fcx);
-    let expr_cmt = mc.cat_expr(expr);
+    let expr_cmt = ignore_err!(mc.cat_expr(expr));
     let borrow_region = ty::ReScope(callee_scope);
     link_region(rcx, expr.span, borrow_region, ty::ImmBorrow, expr_cmt);
 }

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -1,0 +1,373 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! ### Inferring borrow kinds for upvars
+//!
+//! Whenever there is a closure expression, we need to determine how each
+//! upvar is used. We do this by initially assigning each upvar an
+//! immutable "borrow kind" (see `ty::BorrowKind` for details) and then
+//! "escalating" the kind as needed. The borrow kind proceeds according to
+//! the following lattice:
+//!
+//!     ty::ImmBorrow -> ty::UniqueImmBorrow -> ty::MutBorrow
+//!
+//! So, for example, if we see an assignment `x = 5` to an upvar `x`, we
+//! will promote its borrow kind to mutable borrow. If we see an `&mut x`
+//! we'll do the same. Naturally, this applies not just to the upvar, but
+//! to everything owned by `x`, so the result is the same for something
+//! like `x.f = 5` and so on (presuming `x` is not a borrowed pointer to a
+//! struct). These adjustments are performed in
+//! `adjust_upvar_borrow_kind()` (you can trace backwards through the code
+//! from there).
+//!
+//! The fact that we are inferring borrow kinds as we go results in a
+//! semi-hacky interaction with mem-categorization. In particular,
+//! mem-categorization will query the current borrow kind as it
+//! categorizes, and we'll return the *current* value, but this may get
+//! adjusted later. Therefore, in this module, we generally ignore the
+//! borrow kind (and derived mutabilities) that are returned from
+//! mem-categorization, since they may be inaccurate. (Another option
+//! would be to use a unification scheme, where instead of returning a
+//! concrete borrow kind like `ty::ImmBorrow`, we return a
+//! `ty::InferBorrow(upvar_id)` or something like that, but this would
+//! then mean that all later passes would have to check for these figments
+//! and report an error, and it just seems like more mess in the end.)
+
+use super::FnCtxt;
+
+use middle::expr_use_visitor as euv;
+use middle::mem_categorization as mc;
+use middle::ty::{mod};
+use middle::infer::{InferCtxt, UpvarRegion};
+use syntax::ast;
+use syntax::codemap::Span;
+use syntax::visit::{mod, Visitor};
+use util::ppaux::Repr;
+
+///////////////////////////////////////////////////////////////////////////
+// PUBLIC ENTRY POINTS
+
+pub fn closure_analyze_fn(fcx: &FnCtxt,
+                          _id: ast::NodeId,
+                          decl: &ast::FnDecl,
+                          body: &ast::Block) {
+    let mut seed = SeedBorrowKind::new(fcx);
+    seed.visit_block(body);
+
+    let mut adjust = AdjustBorrowKind::new(fcx);
+    adjust.analyze_fn(decl, body);
+}
+
+///////////////////////////////////////////////////////////////////////////
+// SEED BORROW KIND
+
+struct SeedBorrowKind<'a,'tcx:'a> {
+    fcx: &'a FnCtxt<'a,'tcx>,
+}
+
+impl<'a, 'tcx, 'v> Visitor<'v> for SeedBorrowKind<'a, 'tcx> {
+    fn visit_expr(&mut self, expr: &ast::Expr) {
+        match expr.node {
+            ast::ExprClosure(cc, _, _, ref body) => {
+                self.check_closure(expr, cc, &**body);
+            }
+
+            _ => { }
+        }
+
+        visit::walk_expr(self, expr);
+    }
+
+    fn visit_fn(&mut self,
+                fn_kind: visit::FnKind<'v>,
+                decl: &'v ast::FnDecl,
+                block: &'v ast::Block,
+                span: Span,
+                _id: ast::NodeId)
+    {
+        match fn_kind {
+            visit::FkItemFn(..) | visit::FkMethod(..) => {
+                // ignore nested fn items
+            }
+            visit::FkFnBlock => {
+                visit::walk_fn(self, fn_kind, decl, block, span);
+            }
+        }
+    }
+}
+
+impl<'a,'tcx> SeedBorrowKind<'a,'tcx> {
+    fn new(fcx: &'a FnCtxt<'a,'tcx>) -> SeedBorrowKind<'a,'tcx> {
+        SeedBorrowKind { fcx: fcx }
+    }
+
+    fn tcx(&self) -> &'a ty::ctxt<'tcx> {
+        self.fcx.tcx()
+    }
+
+    fn infcx(&self) -> &'a InferCtxt<'a,'tcx> {
+        self.fcx.infcx()
+    }
+
+    fn check_closure(&mut self,
+                     expr: &ast::Expr,
+                     capture_clause: ast::CaptureClause,
+                     _body: &ast::Block)
+    {
+        let is_old_skool_closure = match self.fcx.expr_ty(expr).sty {
+            ty::ty_closure(..) => true,
+            _ => false,
+        };
+
+        match capture_clause {
+            ast::CaptureByValue if !is_old_skool_closure => {
+            }
+            _ => {
+                ty::with_freevars(self.tcx(), expr.id, |freevars| {
+                    for freevar in freevars.iter() {
+                        let var_node_id = freevar.def.local_node_id();
+                        let upvar_id = ty::UpvarId { var_id: var_node_id,
+                                                     closure_expr_id: expr.id };
+                        debug!("seed upvar_id {}", upvar_id);
+                        let origin = UpvarRegion(upvar_id, expr.span);
+                        let freevar_region = self.infcx().next_region_var(origin);
+                        let upvar_borrow = ty::UpvarBorrow { kind: ty::ImmBorrow,
+                                                             region: freevar_region };
+                        self.fcx.inh.upvar_borrow_map.borrow_mut().insert(upvar_id,
+                                                                          upvar_borrow);
+                    }
+                });
+            }
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+// ADJUST BORROW KIND
+
+struct AdjustBorrowKind<'a,'tcx:'a> {
+    fcx: &'a FnCtxt<'a,'tcx>
+}
+
+impl<'a,'tcx> AdjustBorrowKind<'a,'tcx>{
+    fn new(fcx: &'a FnCtxt<'a,'tcx>) -> AdjustBorrowKind<'a,'tcx> {
+        AdjustBorrowKind { fcx: fcx }
+    }
+
+    fn tcx(&self) -> &'a ty::ctxt<'tcx> {
+        self.fcx.tcx()
+    }
+
+    fn analyze_fn(&mut self, decl: &ast::FnDecl, body: &ast::Block) {
+        /*!
+         * Analysis starting point.
+         */
+
+        self.visit_block(body);
+
+        debug!("analyzing fn body with id {}", body.id);
+
+        let mut euv = euv::ExprUseVisitor::new(self, self.fcx);
+        euv.walk_fn(decl, body);
+    }
+
+    /// Indicates that `cmt` is being directly mutated (e.g., assigned
+    /// to). If cmt contains any by-ref upvars, this implies that
+    /// those upvars must be borrowed using an `&mut` borow.
+    fn adjust_upvar_borrow_kind_for_mut(&mut self, cmt: mc::cmt<'tcx>) {
+        debug!("adjust_upvar_borrow_kind_for_mut(cmt={})",
+               cmt.repr(self.tcx()));
+
+        match cmt.cat.clone() {
+            mc::cat_deref(base, _, mc::Unique) |
+            mc::cat_interior(base, _) |
+            mc::cat_downcast(base, _) => {
+                // Interior or owned data is mutable if base is
+                // mutable, so iterate to the base.
+                self.adjust_upvar_borrow_kind_for_mut(base);
+            }
+
+            mc::cat_deref(base, _, mc::BorrowedPtr(..)) |
+            mc::cat_deref(base, _, mc::Implicit(..)) => {
+                if let mc::NoteUpvarRef(upvar_id) = cmt.note {
+                    // if this is an implicit deref of an
+                    // upvar, then we need to modify the
+                    // borrow_kind of the upvar to make sure it
+                    // is inferred to mutable if necessary
+                    let mut upvar_borrow_map = self.fcx.inh.upvar_borrow_map.borrow_mut();
+                    let ub = &mut upvar_borrow_map[upvar_id];
+                    self.adjust_upvar_borrow_kind(upvar_id, ub, ty::MutBorrow);
+                } else {
+                    // assignment to deref of an `&mut`
+                    // borrowed pointer implies that the
+                    // pointer itself must be unique, but not
+                    // necessarily *mutable*
+                    self.adjust_upvar_borrow_kind_for_unique(base);
+                }
+            }
+
+            mc::cat_deref(_, _, mc::UnsafePtr(..)) |
+            mc::cat_static_item |
+            mc::cat_rvalue(_) |
+            mc::cat_local(_) |
+            mc::cat_upvar(..) => {
+                return;
+            }
+        }
+    }
+
+    fn adjust_upvar_borrow_kind_for_unique(&self, cmt: mc::cmt<'tcx>) {
+        debug!("adjust_upvar_borrow_kind_for_unique(cmt={})",
+               cmt.repr(self.tcx()));
+
+        match cmt.cat.clone() {
+            mc::cat_deref(base, _, mc::Unique) |
+            mc::cat_interior(base, _) |
+            mc::cat_downcast(base, _) => {
+                // Interior or owned data is unique if base is
+                // unique.
+                self.adjust_upvar_borrow_kind_for_unique(base);
+            }
+
+            mc::cat_deref(base, _, mc::BorrowedPtr(..)) |
+            mc::cat_deref(base, _, mc::Implicit(..)) => {
+                if let mc::NoteUpvarRef(upvar_id) = cmt.note {
+                    // if this is an implicit deref of an
+                    // upvar, then we need to modify the
+                    // borrow_kind of the upvar to make sure it
+                    // is inferred to unique if necessary
+                    let mut ub = self.fcx.inh.upvar_borrow_map.borrow_mut();
+                    let ub = &mut ub[upvar_id];
+                    self.adjust_upvar_borrow_kind(upvar_id, ub, ty::UniqueImmBorrow);
+                } else {
+                    // for a borrowed pointer to be unique, its
+                    // base must be unique
+                    self.adjust_upvar_borrow_kind_for_unique(base);
+                }
+            }
+
+            mc::cat_deref(_, _, mc::UnsafePtr(..)) |
+            mc::cat_static_item |
+            mc::cat_rvalue(_) |
+            mc::cat_local(_) |
+            mc::cat_upvar(..) => {
+            }
+        }
+    }
+
+    /// We infer the borrow_kind with which to borrow upvars in a stack closure. The borrow_kind
+    /// basically follows a lattice of `imm < unique-imm < mut`, moving from left to right as needed
+    /// (but never right to left). Here the argument `mutbl` is the borrow_kind that is required by
+    /// some particular use.
+    fn adjust_upvar_borrow_kind(&self,
+                                upvar_id: ty::UpvarId,
+                                upvar_borrow: &mut ty::UpvarBorrow,
+                                kind: ty::BorrowKind) {
+        debug!("adjust_upvar_borrow_kind: id={} kind=({} -> {})",
+               upvar_id, upvar_borrow.kind, kind);
+
+        match (upvar_borrow.kind, kind) {
+            // Take RHS:
+            (ty::ImmBorrow, ty::UniqueImmBorrow) |
+            (ty::ImmBorrow, ty::MutBorrow) |
+            (ty::UniqueImmBorrow, ty::MutBorrow) => {
+                upvar_borrow.kind = kind;
+            }
+            // Take LHS:
+            (ty::ImmBorrow, ty::ImmBorrow) |
+            (ty::UniqueImmBorrow, ty::ImmBorrow) |
+            (ty::UniqueImmBorrow, ty::UniqueImmBorrow) |
+            (ty::MutBorrow, _) => {
+            }
+        }
+    }
+}
+
+impl<'a, 'tcx, 'v> Visitor<'v> for AdjustBorrowKind<'a, 'tcx> {
+    fn visit_fn(&mut self,
+                fn_kind: visit::FnKind<'v>,
+                decl: &'v ast::FnDecl,
+                body: &'v ast::Block,
+                span: Span,
+                _id: ast::NodeId)
+    {
+        match fn_kind {
+            visit::FkItemFn(..) | visit::FkMethod(..) => {
+                // ignore nested fn items
+            }
+            visit::FkFnBlock => {
+                self.analyze_fn(decl, body);
+                visit::walk_fn(self, fn_kind, decl, body, span);
+            }
+        }
+    }
+}
+
+impl<'a,'tcx> euv::Delegate<'tcx> for AdjustBorrowKind<'a,'tcx> {
+    fn consume(&mut self,
+               _consume_id: ast::NodeId,
+               _consume_span: Span,
+               _cmt: mc::cmt<'tcx>,
+               _mode: euv::ConsumeMode)
+    {}
+
+    fn matched_pat(&mut self,
+                   _matched_pat: &ast::Pat,
+                   _cmt: mc::cmt<'tcx>,
+                   _mode: euv::MatchMode)
+    {}
+
+    fn consume_pat(&mut self,
+                   _consume_pat: &ast::Pat,
+                   _cmt: mc::cmt<'tcx>,
+                   _mode: euv::ConsumeMode)
+    {}
+
+    fn borrow(&mut self,
+              borrow_id: ast::NodeId,
+              _borrow_span: Span,
+              cmt: mc::cmt<'tcx>,
+              _loan_region: ty::Region,
+              bk: ty::BorrowKind,
+              _loan_cause: euv::LoanCause)
+    {
+        debug!("borrow(borrow_id={}, cmt={}, bk={})",
+               borrow_id, cmt.repr(self.tcx()), bk);
+
+        match bk {
+            ty::ImmBorrow => { }
+            ty::UniqueImmBorrow => {
+                self.adjust_upvar_borrow_kind_for_unique(cmt);
+            }
+            ty::MutBorrow => {
+                self.adjust_upvar_borrow_kind_for_mut(cmt);
+            }
+        }
+    }
+
+    fn decl_without_init(&mut self,
+                         _id: ast::NodeId,
+                         _span: Span)
+    {}
+
+    fn mutate(&mut self,
+              _assignment_id: ast::NodeId,
+              _assignment_span: Span,
+              assignee_cmt: mc::cmt<'tcx>,
+              _mode: euv::MutateMode)
+    {
+        debug!("mutate(assignee_cmt={})",
+               assignee_cmt.repr(self.tcx()));
+
+        self.adjust_upvar_borrow_kind_for_mut(assignee_cmt);
+    }
+}
+
+

--- a/src/librustc_typeck/check/vtable.rs
+++ b/src/librustc_typeck/check/vtable.rs
@@ -287,9 +287,7 @@ pub fn select_all_fcx_obligations_or_error(fcx: &FnCtxt) {
     fcx.default_type_parameters();
 
     let mut fulfillment_cx = fcx.inh.fulfillment_cx.borrow_mut();
-    let r = fulfillment_cx.select_all_or_error(fcx.infcx(),
-                                               &fcx.inh.param_env,
-                                               fcx);
+    let r = fulfillment_cx.select_all_or_error(fcx.infcx(), fcx);
     match r {
         Ok(()) => { }
         Err(errors) => { report_fulfillment_errors(fcx.infcx(), &errors); }
@@ -302,7 +300,7 @@ pub fn select_fcx_obligations_where_possible(fcx: &FnCtxt)
     match
         fcx.inh.fulfillment_cx
         .borrow_mut()
-        .select_where_possible(fcx.infcx(), &fcx.inh.param_env, fcx)
+        .select_where_possible(fcx.infcx(), fcx)
     {
         Ok(()) => { }
         Err(errors) => { report_fulfillment_errors(fcx.infcx(), &errors); }
@@ -316,7 +314,7 @@ pub fn select_new_fcx_obligations(fcx: &FnCtxt) {
     match
         fcx.inh.fulfillment_cx
         .borrow_mut()
-        .select_new_obligations(fcx.infcx(), &fcx.inh.param_env, fcx)
+        .select_new_obligations(fcx.infcx(), fcx)
     {
         Ok(()) => { }
         Err(errors) => { report_fulfillment_errors(fcx.infcx(), &errors); }

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -482,7 +482,7 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
             debug!("check_implementations_of_copy: self_type={} (free)",
                    self_type.repr(tcx));
 
-            match ty::can_type_implement_copy(tcx, self_type, &param_env) {
+            match ty::can_type_implement_copy(&param_env, span, self_type) {
                 Ok(()) => {}
                 Err(ty::FieldDoesNotImplementCopy(name)) => {
                     tcx.sess

--- a/src/test/compile-fail/borrowck-closures-mut-of-imm.rs
+++ b/src/test/compile-fail/borrowck-closures-mut-of-imm.rs
@@ -24,6 +24,7 @@ fn a(x: &int) {
     //~^ ERROR cannot borrow
     let c2 = || set(&mut *x);
     //~^ ERROR cannot borrow
+    //~| ERROR closure requires unique access
 }
 
 fn main() {

--- a/src/test/compile-fail/issue-17551.rs
+++ b/src/test/compile-fail/issue-17551.rs
@@ -13,6 +13,6 @@
 struct B<T>;
 
 fn main() {
-    let foo = B; //~ ERROR unable to infer enough type information
-    let closure = |:| foo;
+    let foo = B;
+    let closure = |:| foo; //~ ERROR unable to infer enough type information
 }

--- a/src/test/compile-fail/privacy1.rs
+++ b/src/test/compile-fail/privacy1.rs
@@ -14,6 +14,9 @@
 #[lang="sized"]
 pub trait Sized {}
 
+#[lang="copy"]
+pub trait Copy {}
+
 mod bar {
     // shouldn't bring in too much
     pub use self::glob::*;

--- a/src/test/compile-fail/privacy4.rs
+++ b/src/test/compile-fail/privacy4.rs
@@ -12,6 +12,7 @@
 #![no_std] // makes debugging this test *a lot* easier (during resolve)
 
 #[lang = "sized"] pub trait Sized for Sized? {}
+#[lang="copy"] pub trait Copy {}
 
 // Test to make sure that private items imported through globs remain private
 // when  they're used.


### PR DESCRIPTION
Previously, the borrow mode of each upvar was inferred as part of regionck. This PR moves it into its own separate step. It also employs the `ExprUseVisitor`, further simplifying the code. The eventual goal is to support better inference of `Fn` vs `FnMut` vs `FnOnce` that is not based on the expected type, as well as supporting individual by-move upvars.

r? @eddyb 
