### PR TITLE
Fix `make install` dependencies

### DIFF
--- a/mk/install.mk
+++ b/mk/install.mk
@@ -28,11 +28,7 @@ endif
 # Remove tmp files because it's a decent amount of disk space
 	$(Q)rm -R tmp/dist
 
-ifeq ($(CFG_DISABLE_DOCS),)
-prepare_install: dist/$(PKG_NAME)-$(CFG_BUILD).tar.gz dist/$(DOC_PKG_NAME)-$(CFG_BUILD).tar.gz | tmp/empty_dir
-else
-prepare_install: dist/$(PKG_NAME)-$(CFG_BUILD).tar.gz | tmp/empty_dir
-endif
+prepare_install: dist-tar-bins | tmp/empty_dir
 
 uninstall:
 ifeq (root user, $(USER) $(patsubst %,user,$(SUDO_USER)))
@@ -48,7 +44,7 @@ endif
 # Remove tmp files because it's a decent amount of disk space
 	$(Q)rm -R tmp/dist
 
-prepare_uninstall: dist/$(PKG_NAME)-$(CFG_BUILD).tar.gz | tmp/empty_dir
+prepare_uninstall: dist-tar-bins | tmp/empty_dir
 
 .PHONY: install prepare_install uninstall prepare_uninstall
 


### PR DESCRIPTION
After 8b3c67690c4747b9fadfef407e6261524fb03f8a the `make install`
command fails if docs are not disabled through CFG_DISABLE_DOCS,
because now the `install` target uses
../../tmp/dist/$(DOC_PKG_NAME)-$(CFG_BUILD)/install.sh

Instead of explicitly depending on
dist/$(PKG_NAME)-$(CFG_BUILD).tar.gz, the `prepare_[un]install`
targets now depend on `dist-tar-bins`, which packages the appropriate
dist archives depending on the configuration.
