### PR TITLE
std: Remove assert_receiver_is_total_eq

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -91,15 +91,8 @@ pub trait PartialEq<Sized? Rhs = Self> for Sized? {
 /// - transitive: `a == b` and `b == c` implies `a == c`.
 #[stable]
 pub trait Eq for Sized?: PartialEq<Self> {
-    // FIXME #13101: this method is used solely by #[deriving] to
-    // assert that every component of a type implements #[deriving]
-    // itself, the current deriving infrastructure means doing this
-    // assertion without using a method on this trait is nearly
-    // impossible.
-    //
-    // This should never be implemented by hand.
-    #[doc(hidden)]
-    #[inline(always)]
+    #[cfg(stage0)]
+    #[allow(missing_docs)]
     fn assert_receiver_is_total_eq(&self) {}
 }
 

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -145,7 +145,7 @@
 
 use self::Option::*;
 
-use cmp::{Eq, Ord};
+use cmp::Ord;
 use default::Default;
 use iter::{Iterator, IteratorExt, DoubleEndedIterator, FromIterator};
 use iter::{ExactSizeIterator};

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -18,7 +18,7 @@
 
 use self::Searcher::{Naive, TwoWay, TwoWayLong};
 
-use cmp::{mod, Eq};
+use cmp;
 use default::Default;
 use iter::range;
 use iter::{DoubleEndedIteratorExt, ExactSizeIterator};

--- a/src/libsyntax/ext/deriving/cmp/totaleq.rs
+++ b/src/libsyntax/ext/deriving/cmp/totaleq.rs
@@ -8,13 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast::{MetaItem, Item, Expr};
+use ast::{MetaItem, Item};
 use codemap::Span;
 use ext::base::ExtCtxt;
-use ext::build::AstBuilder;
 use ext::deriving::generic::*;
 use ext::deriving::generic::ty::*;
-use parse::token::InternedString;
 use ptr::P;
 
 pub fn expand_deriving_totaleq<F>(cx: &mut ExtCtxt,
@@ -24,44 +22,13 @@ pub fn expand_deriving_totaleq<F>(cx: &mut ExtCtxt,
                                   push: F) where
     F: FnOnce(P<Item>),
 {
-    fn cs_total_eq_assert(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
-        cs_same_method(|cx, span, exprs| {
-            // create `a.<method>(); b.<method>(); c.<method>(); ...`
-            // (where method is `assert_receiver_is_total_eq`)
-            let stmts = exprs.into_iter().map(|e| cx.stmt_expr(e)).collect();
-            let block = cx.block(span, stmts, None);
-            cx.expr_block(block)
-        },
-                       |cx, sp, _, _| cx.span_bug(sp, "non matching enums in deriving(Eq)?"),
-                       cx,
-                       span,
-                       substr)
-    }
-
-    let inline = cx.meta_word(span, InternedString::new("inline"));
-    let hidden = cx.meta_word(span, InternedString::new("hidden"));
-    let doc = cx.meta_list(span, InternedString::new("doc"), vec!(hidden));
-    let attrs = vec!(cx.attribute(span, inline),
-                     cx.attribute(span, doc));
     let trait_def = TraitDef {
         span: span,
         attributes: Vec::new(),
         path: Path::new(vec!("std", "cmp", "Eq")),
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
-        methods: vec!(
-            MethodDef {
-                name: "assert_receiver_is_total_eq",
-                generics: LifetimeBounds::empty(),
-                explicit_self: borrowed_explicit_self(),
-                args: vec!(),
-                ret_ty: nil_ty(),
-                attributes: attrs,
-                combine_substructure: combine_substructure(|a, b, c| {
-                    cs_total_eq_assert(a, b, c)
-                })
-            }
-        )
+        methods: Vec::new(),
     };
     trait_def.expand(cx, mitem, item, push)
 }


### PR DESCRIPTION
I think that deriving must have made progress since it was originally written,
this was a pretty easy change!

Closes #13101
