### PR TITLE
Man page/--help dialog fix

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -34,7 +34,7 @@ Specify the name of the crate being built
 \fB\-\-emit\fR [asm|llvm-bc|llvm-ir|obj|link|dep-info]
 Configure the output that rustc will produce
 .TP
-\fB\-\-print\fR [crate-name|output-file-names|sysroot]
+\fB\-\-print\fR [crate-name|file-names|sysroot]
 Comma separated list of compiler information to print on stdout
 .TP
 \fB\-g\fR

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -755,7 +755,7 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
                  "[asm|llvm-bc|llvm-ir|obj|link|dep-info]"),
         opt::multi("", "print", "Comma separated list of compiler information to \
                                print on stdout",
-                 "[crate-name|output-file-names|sysroot]"),
+                 "[crate-name|file-names|sysroot]"),
         opt::flag("g",  "",  "Equivalent to -C debuginfo=2"),
         opt::flag("O", "", "Equivalent to -C opt-level=2"),
         opt::opt("o", "", "Write output to <filename>", "FILENAME"),


### PR DESCRIPTION
- Running rustc with the --print option will accept "file-names" but
  not "output-file-names"
- Documentation now reflects this
