### PR TITLE
Use associated types in Index[Mut]

### DIFF
--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -164,8 +164,25 @@ pub struct Bitv {
     nbits: uint
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 // FIXME(Gankro): NopeNopeNopeNopeNope (wait for IndexGet to be a thing)
 impl Index<uint,bool> for Bitv {
+    #[inline]
+    fn index(&self, i: &uint) -> &bool {
+        if self.get(*i).expect("index out of bounds") {
+            &TRUE
+        } else {
+            &FALSE
+        }
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+// FIXME(Gankro): NopeNopeNopeNopeNope (wait for IndexGet to be a thing)
+impl Index<uint> for Bitv {
+    type Output = bool;
+
     #[inline]
     fn index(&self, i: &uint) -> &bool {
         if self.get(*i).expect("index out of bounds") {

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -898,6 +898,8 @@ impl<K: Show, V: Show> Show for BTreeMap<K, V> {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 #[stable]
 impl<K: Ord, Sized? Q, V> Index<Q, V> for BTreeMap<K, V>
     where Q: BorrowFrom<K> + Ord
@@ -907,10 +909,36 @@ impl<K: Ord, Sized? Q, V> Index<Q, V> for BTreeMap<K, V>
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable]
+impl<K: Ord, Sized? Q, V> Index<Q> for BTreeMap<K, V>
+    where Q: BorrowFrom<K> + Ord
+{
+    type Output = V;
+
+    fn index(&self, key: &Q) -> &V {
+        self.get(key).expect("no entry found for key")
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 #[stable]
 impl<K: Ord, Sized? Q, V> IndexMut<Q, V> for BTreeMap<K, V>
     where Q: BorrowFrom<K> + Ord
 {
+    fn index_mut(&mut self, key: &Q) -> &mut V {
+        self.get_mut(key).expect("no entry found for key")
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable]
+impl<K: Ord, Sized? Q, V> IndexMut<Q> for BTreeMap<K, V>
+    where Q: BorrowFrom<K> + Ord
+{
+    type Output = V;
+
     fn index_mut(&mut self, key: &Q) -> &mut V {
         self.get_mut(key).expect("no entry found for key")
     }

--- a/src/libcollections/ring_buf.rs
+++ b/src/libcollections/ring_buf.rs
@@ -1364,6 +1364,8 @@ impl<S: Writer, A: Hash<S>> Hash<S> for RingBuf<A> {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 #[stable]
 impl<A> Index<uint, A> for RingBuf<A> {
     #[inline]
@@ -1372,8 +1374,32 @@ impl<A> Index<uint, A> for RingBuf<A> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable]
+impl<A> Index<uint> for RingBuf<A> {
+    type Output = A;
+
+    #[inline]
+    fn index<'a>(&'a self, i: &uint) -> &'a A {
+        self.get(*i).expect("Out of bounds access")
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 #[stable]
 impl<A> IndexMut<uint, A> for RingBuf<A> {
+    #[inline]
+    fn index_mut<'a>(&'a mut self, i: &uint) -> &'a mut A {
+        self.get_mut(*i).expect("Out of bounds access")
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable]
+impl<A> IndexMut<uint> for RingBuf<A> {
+    type Output = A;
+
     #[inline]
     fn index_mut<'a>(&'a mut self, i: &uint) -> &'a mut A {
         self.get_mut(*i).expect("Out of bounds access")

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1245,6 +1245,8 @@ impl<S: hash::Writer, T: Hash<S>> Hash<S> for Vec<T> {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 #[experimental = "waiting on Index stability"]
 impl<T> Index<uint,T> for Vec<T> {
     #[inline]
@@ -1253,7 +1255,30 @@ impl<T> Index<uint,T> for Vec<T> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[experimental = "waiting on Index stability"]
+impl<T> Index<uint> for Vec<T> {
+    type Output = T;
+
+    #[inline]
+    fn index<'a>(&'a self, index: &uint) -> &'a T {
+        &self.as_slice()[*index]
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<T> IndexMut<uint,T> for Vec<T> {
+    #[inline]
+    fn index_mut<'a>(&'a mut self, index: &uint) -> &'a mut T {
+        &mut self.as_mut_slice()[*index]
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<T> IndexMut<uint> for Vec<T> {
+    type Output = T;
+
     #[inline]
     fn index_mut<'a>(&'a mut self, index: &uint) -> &'a mut T {
         &mut self.as_mut_slice()[*index]

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -562,6 +562,8 @@ impl<V> Extend<(uint, V)> for VecMap<V> {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 #[stable]
 impl<V> Index<uint, V> for VecMap<V> {
     #[inline]
@@ -570,8 +572,31 @@ impl<V> Index<uint, V> for VecMap<V> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<V> Index<uint> for VecMap<V> {
+    type Output = V;
+
+    #[inline]
+    fn index<'a>(&'a self, i: &uint) -> &'a V {
+        self.get(i).expect("key not present")
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 #[stable]
 impl<V> IndexMut<uint, V> for VecMap<V> {
+    #[inline]
+    fn index_mut<'a>(&'a mut self, i: &uint) -> &'a mut V {
+        self.get_mut(i).expect("key not present")
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable]
+impl<V> IndexMut<uint> for VecMap<V> {
+    type Output = V;
+
     #[inline]
     fn index_mut<'a>(&'a mut self, i: &uint) -> &'a mut V {
         self.get_mut(i).expect("key not present")

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -611,6 +611,15 @@ macro_rules! shr_impl {
 
 shr_impl! { uint u8 u16 u32 u64 int i8 i16 i32 i64 }
 
+// NOTE(stage0) remove trait after a snapshot
+#[cfg(stage0)]
+#[allow(missing_docs)]
+#[lang="index"]
+pub trait Index<Sized? Index, Sized? Result> for Sized? {
+    /// The method for the indexing (`Foo[Bar]`) operation
+    fn index<'a>(&'a self, index: &Index) -> &'a Result;
+}
+
 /// The `Index` trait is used to specify the functionality of indexing operations
 /// like `arr[idx]` when used in an immutable context.
 ///
@@ -620,12 +629,16 @@ shr_impl! { uint u8 u16 u32 u64 int i8 i16 i32 i64 }
 /// calling `index`, and therefore, `main` prints `Indexing!`.
 ///
 /// ```
+/// #![feature(associated_types)]
+///
 /// use std::ops::Index;
 ///
 /// #[deriving(Copy)]
 /// struct Foo;
 ///
-/// impl Index<Foo, Foo> for Foo {
+/// impl Index<Foo> for Foo {
+///     type Output = Foo;
+///
 ///     fn index<'a>(&'a self, _index: &Foo) -> &'a Foo {
 ///         println!("Indexing!");
 ///         self
@@ -636,10 +649,22 @@ shr_impl! { uint u8 u16 u32 u64 int i8 i16 i32 i64 }
 ///     Foo[Foo];
 /// }
 /// ```
+#[cfg(not(stage0))]  // NOTE(stage0) remove cfg after a snapshot
 #[lang="index"]
-pub trait Index<Sized? Index, Sized? Result> for Sized? {
+pub trait Index<Sized? Index> for Sized? {
+    type Sized? Output;
+
     /// The method for the indexing (`Foo[Bar]`) operation
-    fn index<'a>(&'a self, index: &Index) -> &'a Result;
+    fn index<'a>(&'a self, index: &Index) -> &'a Self::Output;
+}
+
+// NOTE(stage0) remove trait after a snapshot
+#[cfg(stage0)]
+#[allow(missing_docs)]
+#[lang="index_mut"]
+pub trait IndexMut<Sized? Index, Sized? Result> for Sized? {
+    /// The method for the indexing (`Foo[Bar]`) operation
+    fn index_mut<'a>(&'a mut self, index: &Index) -> &'a mut Result;
 }
 
 /// The `IndexMut` trait is used to specify the functionality of indexing
@@ -651,12 +676,16 @@ pub trait Index<Sized? Index, Sized? Result> for Sized? {
 /// calling `index_mut`, and therefore, `main` prints `Indexing!`.
 ///
 /// ```
+/// #![feature(associated_types)]
+///
 /// use std::ops::IndexMut;
 ///
 /// #[deriving(Copy)]
 /// struct Foo;
 ///
-/// impl IndexMut<Foo, Foo> for Foo {
+/// impl IndexMut<Foo> for Foo {
+///     type Output = Foo;
+///
 ///     fn index_mut<'a>(&'a mut self, _index: &Foo) -> &'a mut Foo {
 ///         println!("Indexing!");
 ///         self
@@ -667,10 +696,13 @@ pub trait Index<Sized? Index, Sized? Result> for Sized? {
 ///     &mut Foo[Foo];
 /// }
 /// ```
+#[cfg(not(stage0))]  // NOTE(stage0) remove cfg after a snapshot
 #[lang="index_mut"]
-pub trait IndexMut<Sized? Index, Sized? Result> for Sized? {
+pub trait IndexMut<Sized? Index> for Sized? {
+    type Sized? Output;
+
     /// The method for the indexing (`Foo[Bar]`) operation
-    fn index_mut<'a>(&'a mut self, index: &Index) -> &'a mut Result;
+    fn index_mut<'a>(&'a mut self, index: &Index) -> &'a mut Self::Output;
 }
 
 /// The `Slice` trait is used to specify the functionality of slicing operations

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -531,6 +531,8 @@ impl<T> SliceExt for [T] {
     }
 }
 
+// NOTE(stage0) remove impl after a snapshot
+#[cfg(stage0)]
 impl<T> ops::Index<uint, T> for [T] {
     fn index(&self, &index: &uint) -> &T {
         assert!(index < self.len());
@@ -539,7 +541,31 @@ impl<T> ops::Index<uint, T> for [T] {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0) remove cfg after a snapshot
+impl<T> ops::Index<uint> for [T] {
+    type Output = T;
+
+    fn index(&self, &index: &uint) -> &T {
+        assert!(index < self.len());
+
+        unsafe { mem::transmute(self.repr().data.offset(index as int)) }
+    }
+}
+
+// NOTE(stage0) remove impl after a snapshot
+#[cfg(stage0)]
 impl<T> ops::IndexMut<uint, T> for [T] {
+    fn index_mut(&mut self, &index: &uint) -> &mut T {
+        assert!(index < self.len());
+
+        unsafe { mem::transmute(self.repr().data.offset(index as int)) }
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0) remove cfg after a snapshot
+impl<T> ops::IndexMut<uint> for [T] {
+    type Output = T;
+
     fn index_mut(&mut self, &index: &uint) -> &mut T {
         assert!(index < self.len());
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2524,7 +2524,6 @@ fn try_index_step<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     }
 
     let input_ty = fcx.infcx().next_ty_var();
-    let return_ty = fcx.infcx().next_ty_var();
 
     // Try `IndexMut` first, if preferred.
     let method = match (lvalue_pref, fcx.tcx().lang_items.index_mut_trait()) {
@@ -2536,7 +2535,7 @@ fn try_index_step<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                                              trait_did,
                                              adjustment.clone(),
                                              adjusted_ty,
-                                             Some(vec![input_ty, return_ty]))
+                                             Some(vec![input_ty]))
         }
         _ => None,
     };
@@ -2551,7 +2550,7 @@ fn try_index_step<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                                              trait_did,
                                              adjustment,
                                              adjusted_ty,
-                                             Some(vec![input_ty, return_ty]))
+                                             Some(vec![input_ty]))
         }
         (method, _) => method,
     };
@@ -2559,9 +2558,9 @@ fn try_index_step<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     // If some lookup succeeds, write callee into table and extract index/element
     // type from the method signature.
     // If some lookup succeeded, install method in table
-    method.map(|method| {
-        make_overloaded_lvalue_return_type(fcx, Some(method_call), Some(method));
-        (input_ty, return_ty)
+    method.and_then(|method| {
+        make_overloaded_lvalue_return_type(fcx, Some(method_call), Some(method)).
+            map(|ret| (input_ty, ret.ty))
     })
 }
 

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1123,13 +1123,38 @@ impl Json {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a> ops::Index<&'a str, Json>  for Json {
     fn index(&self, idx: & &str) -> &Json {
         self.find(*idx).unwrap()
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a> ops::Index<&'a str>  for Json {
+    type Output = Json;
+
+    fn index(&self, idx: & &str) -> &Json {
+        self.find(*idx).unwrap()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl ops::Index<uint, Json> for Json {
+    fn index<'a>(&'a self, idx: &uint) -> &'a Json {
+        match self {
+            &Json::Array(ref v) => v.index(idx),
+            _ => panic!("can only index Json with uint if it is an array")
+        }
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl ops::Index<uint> for Json {
+    type Output = Json;
+
     fn index<'a>(&'a self, idx: &uint) -> &'a Json {
         match self {
             &Json::Array(ref v) => v.index(idx),

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -25,6 +25,7 @@ Core encoding and decoding interfaces.
 #![allow(unknown_features)]
 #![feature(macro_rules, default_type_params, phase, slicing_syntax, globs)]
 #![feature(unboxed_closures)]
+#![feature(associated_types)]
 
 // test harness access
 #[cfg(test)]

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1300,6 +1300,8 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S> + Default> Default for HashMap<K, V, H>
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 #[stable]
 impl<K: Hash<S> + Eq, Sized? Q, V, S, H: Hasher<S>> Index<Q, V> for HashMap<K, V, H>
     where Q: BorrowFrom<K> + Hash<S> + Eq
@@ -1310,10 +1312,38 @@ impl<K: Hash<S> + Eq, Sized? Q, V, S, H: Hasher<S>> Index<Q, V> for HashMap<K, V
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable]
+impl<K: Hash<S> + Eq, Sized? Q, V, S, H: Hasher<S>> Index<Q> for HashMap<K, V, H>
+    where Q: BorrowFrom<K> + Hash<S> + Eq
+{
+    type Output = V;
+
+    #[inline]
+    fn index<'a>(&'a self, index: &Q) -> &'a V {
+        self.get(index).expect("no entry found for key")
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 #[stable]
 impl<K: Hash<S> + Eq, Sized? Q, V, S, H: Hasher<S>> IndexMut<Q, V> for HashMap<K, V, H>
     where Q: BorrowFrom<K> + Hash<S> + Eq
 {
+    #[inline]
+    fn index_mut<'a>(&'a mut self, index: &Q) -> &'a mut V {
+        self.get_mut(index).expect("no entry found for key")
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable]
+impl<K: Hash<S> + Eq, Sized? Q, V, S, H: Hasher<S>> IndexMut<Q> for HashMap<K, V, H>
+    where Q: BorrowFrom<K> + Hash<S> + Eq
+{
+    type Output = V;
+
     #[inline]
     fn index_mut<'a>(&'a mut self, index: &Q) -> &'a mut V {
         self.get_mut(index).expect("no entry found for key")

--- a/src/test/compile-fail/borrowck-overloaded-index-2.rs
+++ b/src/test/compile-fail/borrowck-overloaded-index-2.rs
@@ -8,13 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(associated_types)]
+
 use std::ops::Index;
 
 struct MyVec<T> {
     data: Vec<T>,
 }
 
-impl<T> Index<uint, T> for MyVec<T> {
+impl<T> Index<uint> for MyVec<T> {
+    type Output = T;
+
     fn index(&self, &i: &uint) -> &T {
         &self.data[i]
     }

--- a/src/test/compile-fail/borrowck-overloaded-index-autoderef.rs
+++ b/src/test/compile-fail/borrowck-overloaded-index-autoderef.rs
@@ -11,6 +11,8 @@
 // Test that we still see borrowck errors of various kinds when using
 // indexing and autoderef in combination.
 
+#![feature(associated_types)]
+
 use std::ops::{Index, IndexMut};
 
 struct Foo {
@@ -18,7 +20,9 @@ struct Foo {
     y: int,
 }
 
-impl Index<String,int> for Foo {
+impl Index<String> for Foo {
+    type Output = int;
+
     fn index<'a>(&'a self, z: &String) -> &'a int {
         if z.as_slice() == "x" {
             &self.x
@@ -28,7 +32,9 @@ impl Index<String,int> for Foo {
     }
 }
 
-impl IndexMut<String,int> for Foo {
+impl IndexMut<String> for Foo {
+    type Output = int;
+
     fn index_mut<'a>(&'a mut self, z: &String) -> &'a mut int {
         if z.as_slice() == "x" {
             &mut self.x

--- a/src/test/compile-fail/borrowck-overloaded-index.rs
+++ b/src/test/compile-fail/borrowck-overloaded-index.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(associated_types)]
+
 use std::ops::{Index, IndexMut};
 
 struct Foo {
@@ -15,7 +17,9 @@ struct Foo {
     y: int,
 }
 
-impl Index<String,int> for Foo {
+impl Index<String> for Foo {
+    type Output = int;
+
     fn index<'a>(&'a self, z: &String) -> &'a int {
         if z.as_slice() == "x" {
             &self.x
@@ -25,7 +29,9 @@ impl Index<String,int> for Foo {
     }
 }
 
-impl IndexMut<String,int> for Foo {
+impl IndexMut<String> for Foo {
+    type Output = int;
+
     fn index_mut<'a>(&'a mut self, z: &String) -> &'a mut int {
         if z.as_slice() == "x" {
             &mut self.x
@@ -39,7 +45,9 @@ struct Bar {
     x: int,
 }
 
-impl Index<int,int> for Bar {
+impl Index<int> for Bar {
+    type Output = int;
+
     fn index<'a>(&'a self, z: &int) -> &'a int {
         &self.x
     }

--- a/src/test/compile-fail/dst-index.rs
+++ b/src/test/compile-fail/dst-index.rs
@@ -11,6 +11,8 @@
 // Test that overloaded index expressions with DST result types
 // can't be used as rvalues
 
+#![feature(associated_types)]
+
 use std::ops::Index;
 use std::fmt::Show;
 
@@ -18,7 +20,9 @@ struct S;
 
 impl Copy for S {}
 
-impl Index<uint, str> for S {
+impl Index<uint> for S {
+    type Output = str;
+
     fn index<'a>(&'a self, _: &uint) -> &'a str {
         "hello"
     }
@@ -28,7 +32,9 @@ struct T;
 
 impl Copy for T {}
 
-impl Index<uint, Show + 'static> for T {
+impl Index<uint> for T {
+    type Output = Show + 'static;
+
     fn index<'a>(&'a self, idx: &uint) -> &'a (Show + 'static) {
         static x: uint = 42;
         &x

--- a/src/test/run-pass/dst-index.rs
+++ b/src/test/run-pass/dst-index.rs
@@ -11,12 +11,16 @@
 // Test that overloaded index expressions with DST result types
 // work and don't ICE.
 
+#![feature(associated_types)]
+
 use std::ops::Index;
 use std::fmt::Show;
 
 struct S;
 
-impl Index<uint, str> for S {
+impl Index<uint> for S {
+    type Output = str;
+
     fn index<'a>(&'a self, _: &uint) -> &'a str {
         "hello"
     }
@@ -24,7 +28,9 @@ impl Index<uint, str> for S {
 
 struct T;
 
-impl Index<uint, Show + 'static> for T {
+impl Index<uint> for T {
+    type Output = Show + 'static;
+
     fn index<'a>(&'a self, idx: &uint) -> &'a (Show + 'static) {
         static x: uint = 42;
         &x

--- a/src/test/run-pass/issue-15734.rs
+++ b/src/test/run-pass/issue-15734.rs
@@ -10,7 +10,8 @@
 
 // If `Index` used an associated type for its output, this test would
 // work more smoothly.
-#![feature(old_orphan_check)]
+
+#![feature(associated_types, old_orphan_check)]
 
 use std::ops::Index;
 
@@ -25,13 +26,17 @@ impl<T> Mat<T> {
     }
 }
 
-impl<T> Index<(uint, uint), T> for Mat<T> {
+impl<T> Index<(uint, uint)> for Mat<T> {
+    type Output = T;
+
     fn index<'a>(&'a self, &(row, col): &(uint, uint)) -> &'a T {
         &self.data[row * self.cols + col]
     }
 }
 
-impl<'a, T> Index<(uint, uint), T> for &'a Mat<T> {
+impl<'a, T> Index<(uint, uint)> for &'a Mat<T> {
+    type Output = T;
+
     fn index<'b>(&'b self, index: &(uint, uint)) -> &'b T {
         (*self).index(index)
     }
@@ -39,7 +44,9 @@ impl<'a, T> Index<(uint, uint), T> for &'a Mat<T> {
 
 struct Row<M> { mat: M, row: uint, }
 
-impl<T, M: Index<(uint, uint), T>> Index<uint, T> for Row<M> {
+impl<T, M: Index<(uint, uint), Output=T>> Index<uint> for Row<M> {
+    type Output = T;
+
     fn index<'a>(&'a self, col: &uint) -> &'a T {
         &self.mat[(self.row, *col)]
     }

--- a/src/test/run-pass/operator-overloading.rs
+++ b/src/test/run-pass/operator-overloading.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(associated_types)]
 
 use std::cmp;
 use std::ops;
@@ -42,7 +43,9 @@ impl ops::Not<Point> for Point {
     }
 }
 
-impl ops::Index<bool,int> for Point {
+impl ops::Index<bool> for Point {
+    type Output = int;
+
     fn index(&self, x: &bool) -> &int {
         if *x {
             &self.x

--- a/src/test/run-pass/overloaded-index-assoc-list.rs
+++ b/src/test/run-pass/overloaded-index-assoc-list.rs
@@ -11,6 +11,8 @@
 // Test overloading of the `[]` operator.  In particular test that it
 // takes its argument *by reference*.
 
+#![feature(associated_types)]
+
 use std::ops::Index;
 
 struct AssociationList<K,V> {
@@ -28,7 +30,9 @@ impl<K,V> AssociationList<K,V> {
     }
 }
 
-impl<K: PartialEq + std::fmt::Show, V:Clone> Index<K,V> for AssociationList<K,V> {
+impl<K: PartialEq + std::fmt::Show, V:Clone> Index<K> for AssociationList<K,V> {
+    type Output = V;
+
     fn index<'a>(&'a self, index: &K) -> &'a V {
         for pair in self.pairs.iter() {
             if pair.key == *index {

--- a/src/test/run-pass/overloaded-index-autoderef.rs
+++ b/src/test/run-pass/overloaded-index-autoderef.rs
@@ -10,6 +10,8 @@
 
 // Test overloaded indexing combined with autoderef.
 
+#![feature(associated_types)]
+
 use std::ops::{Index, IndexMut};
 
 struct Foo {
@@ -17,7 +19,9 @@ struct Foo {
     y: int,
 }
 
-impl Index<int,int> for Foo {
+impl Index<int> for Foo {
+    type Output = int;
+
     fn index(&self, z: &int) -> &int {
         if *z == 0 {
             &self.x
@@ -27,7 +31,9 @@ impl Index<int,int> for Foo {
     }
 }
 
-impl IndexMut<int,int> for Foo {
+impl IndexMut<int> for Foo {
+    type Output = int;
+
     fn index_mut(&mut self, z: &int) -> &mut int {
         if *z == 0 {
             &mut self.x

--- a/src/test/run-pass/overloaded-index-in-field.rs
+++ b/src/test/run-pass/overloaded-index-in-field.rs
@@ -11,6 +11,8 @@
 // Test using overloaded indexing when the "map" is stored in a
 // field. This caused problems at some point.
 
+#![feature(associated_types)]
+
 use std::ops::Index;
 
 struct Foo {
@@ -22,7 +24,9 @@ struct Bar {
     foo: Foo
 }
 
-impl Index<int,int> for Foo {
+impl Index<int> for Foo {
+    type Output = int;
+
     fn index(&self, z: &int) -> &int {
         if *z == 0 {
             &self.x

--- a/src/test/run-pass/overloaded-index.rs
+++ b/src/test/run-pass/overloaded-index.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(associated_types)]
+
 use std::ops::{Index, IndexMut};
 
 struct Foo {
@@ -15,7 +17,9 @@ struct Foo {
     y: int,
 }
 
-impl Index<int,int> for Foo {
+impl Index<int> for Foo {
+    type Output = int;
+
     fn index(&self, z: &int) -> &int {
         if *z == 0 {
             &self.x
@@ -25,7 +29,9 @@ impl Index<int,int> for Foo {
     }
 }
 
-impl IndexMut<int,int> for Foo {
+impl IndexMut<int> for Foo {
+    type Output = int;
+
     fn index_mut(&mut self, z: &int) -> &mut int {
         if *z == 0 {
             &mut self.x


### PR DESCRIPTION
The `Index[Mut]` traits now have one less input parameter, as the return type of the indexing operation is an associated type. This breaks all existing implementations.

[breaking-change]

---

r? @aturon 
@nikomatsakis feedback on the compiler change (first commit)?
