### PR TITLE
Fix range sugar

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -2620,10 +2620,10 @@ pub trait Step: Ord {
     /// Change self to the previous object.
     fn step_back(&mut self);
     /// The steps_between two step objects.
-    /// a should always be less than b, so the result should never be negative.
+    /// start should always be less than end, so the result should never be negative.
     /// Return None if it is not possible to calculate steps_between without
     /// overflow.
-    fn steps_between(a: &Self, b: &Self) -> Option<uint>;
+    fn steps_between(start: &Self, end: &Self) -> Option<uint>;
 }
 
 macro_rules! step_impl {
@@ -2635,9 +2635,9 @@ macro_rules! step_impl {
             #[inline]
             fn step_back(&mut self) { *self -= 1; }
             #[inline]
-            fn steps_between(a: &$t, b: &$t) -> Option<uint> {
-                debug_assert!(a < b);
-                Some((*a - *b) as uint)
+            fn steps_between(start: &$t, end: &$t) -> Option<uint> {
+                debug_assert!(end >= start);
+                Some((*end - *start) as uint)
             }
         }
     )*)
@@ -2652,7 +2652,7 @@ macro_rules! step_impl_no_between {
             #[inline]
             fn step_back(&mut self) { *self -= 1; }
             #[inline]
-            fn steps_between(_a: &$t, _b: &$t) -> Option<uint> {
+            fn steps_between(_start: &$t, _end: &$t) -> Option<uint> {
                 None
             }
         }

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -803,7 +803,7 @@ impl<Idx: Clone + Step> Iterator<Idx> for Range<Idx> {
 
     #[inline]
     fn size_hint(&self) -> (uint, Option<uint>) {
-        if let Some(hint) = Step::steps_between(&self.end, &self.start) {
+        if let Some(hint) = Step::steps_between(&self.start, &self.end) {
             (hint, Some(hint))
         } else {
             (0, None)


### PR DESCRIPTION
Range sugar was using the trait incorrectly plus the trait implementation was wrong.

Both had the arguments swapped which actually caused the tests to run but threw the debug_assert
in debug builds, causing normal builds of anything using the sugar to fail.
