### PR TITLE
Update guide index to point to the task page

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -58,7 +58,7 @@ a guide that can help you out:
 * [Strings](guide-strings.html)
 * [Pointers](guide-pointers.html)
 * [Crates and modules](guide-crates.html)
-* [Threads and Communication](guide-threads.html)
+* [Threads and Communication](guide-tasks.html)
 * [Error Handling](guide-error-handling.html)
 * [Foreign Function Interface](guide-ffi.html)
 * [Writing Unsafe and Low-Level Code](guide-unsafe.html)


### PR DESCRIPTION
When the "threads" guides were renamed to be "tasks" guides, it looks
like this link was missed.

Here's the other relevant commit.

https://github.com/rust-lang/rust/commit/b8ffad5964e328340de0c03779577eb14caa16fc

Cheers!
