### PR TITLE
Rename `raw_pointer_deriving` lint to `raw_pointer_derive`

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -550,20 +550,20 @@ impl LintPass for BoxPointers {
 }
 
 declare_lint! {
-    RAW_POINTER_DERIVING,
+    RAW_POINTER_DERIVE,
     Warn,
     "uses of #[derive] with raw pointers are rarely correct"
 }
 
-struct RawPtrDerivingVisitor<'a, 'tcx: 'a> {
+struct RawPtrDeriveVisitor<'a, 'tcx: 'a> {
     cx: &'a Context<'a, 'tcx>
 }
 
-impl<'a, 'tcx, 'v> Visitor<'v> for RawPtrDerivingVisitor<'a, 'tcx> {
+impl<'a, 'tcx, 'v> Visitor<'v> for RawPtrDeriveVisitor<'a, 'tcx> {
     fn visit_ty(&mut self, ty: &ast::Ty) {
         static MSG: &'static str = "use of `#[derive]` with a raw pointer";
         if let ast::TyPtr(..) = ty.node {
-            self.cx.span_lint(RAW_POINTER_DERIVING, ty.span, MSG);
+            self.cx.span_lint(RAW_POINTER_DERIVE, ty.span, MSG);
         }
         visit::walk_ty(self, ty);
     }
@@ -572,21 +572,21 @@ impl<'a, 'tcx, 'v> Visitor<'v> for RawPtrDerivingVisitor<'a, 'tcx> {
     fn visit_block(&mut self, _: &ast::Block) {}
 }
 
-pub struct RawPointerDeriving {
+pub struct RawPointerDerive {
     checked_raw_pointers: NodeSet,
 }
 
-impl RawPointerDeriving {
-    pub fn new() -> RawPointerDeriving {
-        RawPointerDeriving {
+impl RawPointerDerive {
+    pub fn new() -> RawPointerDerive {
+        RawPointerDerive {
             checked_raw_pointers: NodeSet::new(),
         }
     }
 }
 
-impl LintPass for RawPointerDeriving {
+impl LintPass for RawPointerDerive {
     fn get_lints(&self) -> LintArray {
-        lint_array!(RAW_POINTER_DERIVING)
+        lint_array!(RAW_POINTER_DERIVE)
     }
 
     fn check_item(&mut self, cx: &Context, item: &ast::Item) {
@@ -611,7 +611,7 @@ impl LintPass for RawPointerDeriving {
         if !self.checked_raw_pointers.insert(item.id) { return }
         match item.node {
             ast::ItemStruct(..) | ast::ItemEnum(..) => {
-                let mut visitor = RawPtrDerivingVisitor { cx: cx };
+                let mut visitor = RawPtrDeriveVisitor { cx: cx };
                 visit::walk_item(&mut visitor, &*item);
             }
             _ => {}

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -208,7 +208,7 @@ impl LintStore {
 
         add_builtin_with_new!(sess,
                               TypeLimits,
-                              RawPointerDeriving,
+                              RawPointerDerive,
                               MissingDoc,
         );
 
@@ -247,6 +247,7 @@ impl LintStore {
         self.register_renamed("unknown_crate_type", "unknown_crate_types");
         self.register_renamed("variant_size_difference", "variant_size_differences");
         self.register_renamed("transmute_fat_ptr", "fat_ptr_transmutes");
+        self.register_renamed("raw_pointer_deriving", "raw_pointer_derive");
 
     }
 

--- a/src/test/compile-fail/lint-raw-ptr-derive.rs
+++ b/src/test/compile-fail/lint-raw-ptr-derive.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![allow(dead_code)]
-#![deny(raw_pointer_deriving)]
+#![deny(raw_pointer_derive)]
 
 #[derive(Clone)]
 struct Foo {


### PR DESCRIPTION
`#[deriving]` has been changed to `#[derive]`, so we should update this lint accordingly so that it remains consistent with the language.

Also register the rename with the LintStore.

I've changed the one reference to `raw_pointer_deriving` that occurs in the tests (as well as renamed the file appropriately), but the rest of the `raw_pointer_deriving`s in the Rust codebase will need to wait for a snapshot to be changed because stage0 doesn't know about the new lint name.  I'll take care of the remaining renaming after the next snapshot.

Closes #20498.
