### PR TITLE
doc: Remove extra whitespace in the middle of lines to provide alignment

### DIFF
--- a/src/doc/trpl/arrays-vectors-and-slices.md
+++ b/src/doc/trpl/arrays-vectors-and-slices.md
@@ -5,7 +5,7 @@ things. The most basic is the *array*, a fixed-size list of elements of the
 same type. By default, arrays are immutable.
 
 ```{rust}
-let a = [1, 2, 3];     // a: [i32; 3]
+let a = [1, 2, 3]; // a: [i32; 3]
 let mut m = [1, 2, 3]; // mut m: [i32; 3]
 ```
 
@@ -68,7 +68,7 @@ let mut nums = vec![1, 2, 3]; // mut nums: Vec<i32>
 
 nums.push(4);
 
-println!("The length of nums is now {}", nums.len());   // Prints 4
+println!("The length of nums is now {}", nums.len()); // Prints 4
 ```
 
 Vectors have many more useful methods.
@@ -82,10 +82,10 @@ arrays:
 
 ```{rust}
 let a = [0, 1, 2, 3, 4];
-let middle = &a[1..4];     // A slice of a: just the elements 1, 2, and 3
+let middle = &a[1..4]; // A slice of a: just the elements 1, 2, and 3
 
 for e in middle.iter() {
-    println!("{}", e);          // Prints 1, 2, 3
+    println!("{}", e); // Prints 1, 2, 3
 }
 ```
 

--- a/src/doc/trpl/compound-data-types.md
+++ b/src/doc/trpl/compound-data-types.md
@@ -51,7 +51,7 @@ arity and contained types.
 
 ```rust
 let mut x = (1, 2); // x: (i32, i32)
-let y = (2, 3);     // y: (i32, i32)
+let y = (2, 3); // y: (i32, i32)
 
 x = y;
 ```
@@ -156,7 +156,7 @@ These two will not be equal, even if they have the same values:
 ```{rust}
 # struct Color(i32, i32, i32);
 # struct Point(i32, i32, i32);
-let black  = Color(0, 0, 0);
+let black = Color(0, 0, 0);
 let origin = Point(0, 0, 0);
 ```
 

--- a/src/doc/trpl/error-handling.md
+++ b/src/doc/trpl/error-handling.md
@@ -60,12 +60,12 @@ fn probability(_: &Event) -> f64 {
 
 fn descriptive_probability(event: Event) -> &'static str {
     match probability(&event) {
-        1.00          => "certain",
-        0.00          => "impossible",
+        1.00 => "certain",
+        0.00 => "impossible",
         0.00 ... 0.25 => "very unlikely",
         0.25 ... 0.50 => "unlikely",
         0.50 ... 0.75 => "likely",
-        0.75 ... 1.00  => "very likely",
+        0.75 ... 1.00 => "very likely",
     }
 }
 
@@ -97,12 +97,12 @@ fn probability(_: &Event) -> f64 {
 
 fn descriptive_probability(event: Event) -> &'static str {
     match probability(&event) {
-        1.00          => "certain",
-        0.00          => "impossible",
+        1.00 => "certain",
+        0.00 => "impossible",
         0.00 ... 0.25 => "very unlikely",
         0.25 ... 0.50 => "unlikely",
         0.50 ... 0.75 => "likely",
-        0.75 ... 1.00  => "very likely",
+        0.75 ... 1.00 => "very likely",
         _ => unreachable!()
     }
 }

--- a/src/doc/trpl/guessing-game.md
+++ b/src/doc/trpl/guessing-game.md
@@ -297,9 +297,9 @@ fn main() {
     println!("You guessed: {}", input);
 
     match cmp(input, secret_number) {
-        Ordering::Less    => println!("Too small!"),
+        Ordering::Less => println!("Too small!"),
         Ordering::Greater => println!("Too big!"),
-        Ordering::Equal   => println!("You win!"),
+        Ordering::Equal => println!("You win!"),
     }
 }
 
@@ -352,9 +352,9 @@ fn main() {
     println!("You guessed: {}", input);
 
     match cmp(input, secret_number) {
-        Ordering::Less    => println!("Too small!"),
+        Ordering::Less => println!("Too small!"),
         Ordering::Greater => println!("Too big!"),
-        Ordering::Equal   => println!("You win!"),
+        Ordering::Equal => println!("You win!"),
     }
 }
 
@@ -422,8 +422,8 @@ In this case, we say `x` is a `u32` explicitly, so Rust is able to properly
 tell `random()` what to generate. In a similar fashion, both of these work:
 
 ```{rust,ignore}
-let input_num = "5".parse::<u32>();         // input_num: Option<u32>
-let input_num: Option<u32> = "5".parse();   // input_num: Option<u32>
+let input_num = "5".parse::<u32>(); // input_num: Option<u32>
+let input_num: Option<u32> = "5".parse(); // input_num: Option<u32>
 ```
 
 Anyway, with us now converting our input to a number, our code looks like this:
@@ -450,9 +450,9 @@ fn main() {
     println!("You guessed: {}", input_num);
 
     match cmp(input_num, secret_number) {
-        Ordering::Less    => println!("Too small!"),
+        Ordering::Less => println!("Too small!"),
         Ordering::Greater => println!("Too big!"),
-        Ordering::Equal   => println!("You win!"),
+        Ordering::Equal => println!("You win!"),
     }
 }
 
@@ -499,7 +499,7 @@ fn main() {
 
     let num = match input_num {
         Some(num) => num,
-        None      => {
+        None => {
             println!("Please input a number!");
             return;
         }
@@ -509,9 +509,9 @@ fn main() {
     println!("You guessed: {}", num);
 
     match cmp(num, secret_number) {
-        Ordering::Less    => println!("Too small!"),
+        Ordering::Less => println!("Too small!"),
         Ordering::Greater => println!("Too big!"),
-        Ordering::Equal   => println!("You win!"),
+        Ordering::Equal => println!("You win!"),
     }
 }
 
@@ -566,7 +566,7 @@ fn main() {
 
     let num = match input_num {
         Some(num) => num,
-        None      => {
+        None => {
             println!("Please input a number!");
             return;
         }
@@ -576,9 +576,9 @@ fn main() {
     println!("You guessed: {}", num);
 
     match cmp(num, secret_number) {
-        Ordering::Less    => println!("Too small!"),
+        Ordering::Less => println!("Too small!"),
         Ordering::Greater => println!("Too big!"),
-        Ordering::Equal   => println!("You win!"),
+        Ordering::Equal => println!("You win!"),
     }
 }
 
@@ -642,7 +642,7 @@ fn main() {
 
         let num = match input_num {
             Some(num) => num,
-            None      => {
+            None => {
                 println!("Please input a number!");
                 return;
             }
@@ -652,9 +652,9 @@ fn main() {
         println!("You guessed: {}", num);
 
         match cmp(num, secret_number) {
-            Ordering::Less    => println!("Too small!"),
+            Ordering::Less => println!("Too small!"),
             Ordering::Greater => println!("Too big!"),
-            Ordering::Equal   => println!("You win!"),
+            Ordering::Equal => println!("You win!"),
         }
     }
 }
@@ -718,7 +718,7 @@ fn main() {
 
         let num = match input_num {
             Some(num) => num,
-            None      => {
+            None => {
                 println!("Please input a number!");
                 return;
             }
@@ -728,9 +728,9 @@ fn main() {
         println!("You guessed: {}", num);
 
         match cmp(num, secret_number) {
-            Ordering::Less    => println!("Too small!"),
+            Ordering::Less => println!("Too small!"),
             Ordering::Greater => println!("Too big!"),
-            Ordering::Equal   => {
+            Ordering::Equal => {
                 println!("You win!");
                 return;
             },
@@ -774,7 +774,7 @@ fn main() {
 
         let num = match input_num {
             Some(num) => num,
-            None      => {
+            None => {
                 println!("Please input a number!");
                 continue;
             }
@@ -784,9 +784,9 @@ fn main() {
         println!("You guessed: {}", num);
 
         match cmp(num, secret_number) {
-            Ordering::Less    => println!("Too small!"),
+            Ordering::Less => println!("Too small!"),
             Ordering::Greater => println!("Too big!"),
-            Ordering::Equal   => {
+            Ordering::Equal => {
                 println!("You win!");
                 return;
             },
@@ -851,7 +851,7 @@ fn main() {
 
         let num = match input_num {
             Some(num) => num,
-            None      => {
+            None => {
                 println!("Please input a number!");
                 continue;
             }
@@ -861,9 +861,9 @@ fn main() {
         println!("You guessed: {}", num);
 
         match cmp(num, secret_number) {
-            Ordering::Less    => println!("Too small!"),
+            Ordering::Less => println!("Too small!"),
             Ordering::Greater => println!("Too big!"),
-            Ordering::Equal   => {
+            Ordering::Equal => {
                 println!("You win!");
                 return;
             },

--- a/src/doc/trpl/iterators.md
+++ b/src/doc/trpl/iterators.md
@@ -143,7 +143,7 @@ let greater_than_forty_two = range(0i, 100i)
 
 match greater_than_forty_two {
     Some(_) => println!("We got some numbers!"),
-    None    => println!("No numbers found :("),
+    None => println!("No numbers found :("),
 }
 ```
 

--- a/src/doc/trpl/looping.md
+++ b/src/doc/trpl/looping.md
@@ -54,7 +54,7 @@ The other kind of looping construct in Rust is the `while` loop. It looks like
 this:
 
 ```{rust}
-let mut x = 5u32;       // mut x: u32
+let mut x = 5u32; // mut x: u32
 let mut done = false; // mut done: bool
 
 while !done {

--- a/src/doc/trpl/match.md
+++ b/src/doc/trpl/match.md
@@ -84,9 +84,9 @@ fn main() {
     let y = 10;
 
     match cmp(x, y) {
-        Ordering::Less    => println!("less"),
+        Ordering::Less => println!("less"),
         Ordering::Greater => println!("greater"),
-        Ordering::Equal   => println!("equal"),
+        Ordering::Equal => println!("equal"),
     }
 }
 ```
@@ -112,12 +112,12 @@ fn main() {
 
     match x {
         OptionalInt::Value(n) => println!("x is {}", n),
-        OptionalInt::Missing  => println!("x is missing!"),
+        OptionalInt::Missing => println!("x is missing!"),
     }
 
     match y {
         OptionalInt::Value(n) => println!("y is {}", n),
-        OptionalInt::Missing  => println!("y is missing!"),
+        OptionalInt::Missing => println!("y is missing!"),
     }
 }
 ```
@@ -146,9 +146,9 @@ fn main() {
     let y = 10;
 
     println!("{}", match cmp(x, y) {
-        Ordering::Less    => "less",
+        Ordering::Less => "less",
         Ordering::Greater => "greater",
-        Ordering::Equal   => "equal",
+        Ordering::Equal => "equal",
     });
 }
 ```

--- a/src/doc/trpl/ownership.md
+++ b/src/doc/trpl/ownership.md
@@ -517,31 +517,31 @@ Here are some examples of functions with elided lifetimes, and the version of
 what the elided lifetimes are expand to:
 
 ```{rust,ignore}
-fn print(s: &str);                                      // elided
-fn print<'a>(s: &'a str);                               // expanded
+fn print(s: &str); // elided
+fn print<'a>(s: &'a str); // expanded
 
-fn debug(lvl: u32, s: &str);                           // elided
-fn debug<'a>(lvl: u32, s: &'a str);                    // expanded
+fn debug(lvl: u32, s: &str); // elided
+fn debug<'a>(lvl: u32, s: &'a str); // expanded
 
 // In the preceeding example, `lvl` doesn't need a lifetime because it's not a
 // reference (`&`). Only things relating to references (such as a `struct`
 // which contains a reference) need lifetimes.
 
-fn substr(s: &str, until: u32) -> &str;                // elided
-fn substr<'a>(s: &'a str, until: u32) -> &'a str;      // expanded
+fn substr(s: &str, until: u32) -> &str; // elided
+fn substr<'a>(s: &'a str, until: u32) -> &'a str; // expanded
 
-fn get_str() -> &str;                                   // ILLEGAL, no inputs
+fn get_str() -> &str; // ILLEGAL, no inputs
 
-fn frob(s: &str, t: &str) -> &str;                      // ILLEGAL, two inputs
+fn frob(s: &str, t: &str) -> &str; // ILLEGAL, two inputs
 
-fn get_mut(&mut self) -> &mut T;                        // elided
-fn get_mut<'a>(&'a mut self) -> &'a mut T;              // expanded
+fn get_mut(&mut self) -> &mut T; // elided
+fn get_mut<'a>(&'a mut self) -> &'a mut T; // expanded
 
-fn args<T:ToCStr>(&mut self, args: &[T]) -> &mut Command                  // elided
+fn args<T:ToCStr>(&mut self, args: &[T]) -> &mut Command // elided
 fn args<'a, 'b, T:ToCStr>(&'a mut self, args: &'b [T]) -> &'a mut Command // expanded
 
-fn new(buf: &mut [u8]) -> BufWriter;                    // elided
-fn new<'a>(buf: &'a mut [u8]) -> BufWriter<'a>          // expanded
+fn new(buf: &mut [u8]) -> BufWriter; // elided
+fn new<'a>(buf: &'a mut [u8]) -> BufWriter<'a> // expanded
 ```
 
 # Related Resources

--- a/src/doc/trpl/patterns.md
+++ b/src/doc/trpl/patterns.md
@@ -68,7 +68,7 @@ let x = OptionalInt::Value(5i);
 
 match x {
     OptionalInt::Value(..) => println!("Got an int!"),
-    OptionalInt::Missing   => println!("No such luck."),
+    OptionalInt::Missing => println!("No such luck."),
 }
 ```
 
@@ -85,7 +85,7 @@ let x = OptionalInt::Value(5i);
 match x {
     OptionalInt::Value(i) if i > 5 => println!("Got an int bigger than five!"),
     OptionalInt::Value(..) => println!("Got an int!"),
-    OptionalInt::Missing   => println!("No such luck."),
+    OptionalInt::Missing => println!("No such luck."),
 }
 ```
 

--- a/src/doc/trpl/pointers.md
+++ b/src/doc/trpl/pointers.md
@@ -461,7 +461,7 @@ fn succ(x: &int) -> int { *x + 1 }
 
 let ref_x = &5i;
 let box_x = Box::new(5i);
-let rc_x  = Rc::new(5i);
+let rc_x = Rc::new(5i);
 
 succ(ref_x);
 succ(&*box_x);

--- a/src/doc/trpl/standard-input.md
+++ b/src/doc/trpl/standard-input.md
@@ -83,12 +83,12 @@ fn main() {
 
     match x {
         OptionalInt::Value(n) => println!("x is {}", n),
-        OptionalInt::Missing  => println!("x is missing!"),
+        OptionalInt::Missing => println!("x is missing!"),
     }
 
     match y {
         OptionalInt::Value(n) => println!("y is {}", n),
-        OptionalInt::Missing  => println!("y is missing!"),
+        OptionalInt::Missing => println!("y is missing!"),
     }
 }
 ```
@@ -141,11 +141,11 @@ use std::io;
 fn main() {
     println!("Type something!");
 
-                                                  // here, we'll show the types at each step
+    // here, we'll show the types at each step
 
-    let input = io::stdin()                       // std::io::stdio::StdinReader
-                  .read_line()                    // IoResult<String>
-                  .ok()                           // Option<String>
+    let input = io::stdin() // std::io::stdio::StdinReader
+                  .read_line() // IoResult<String>
+                  .ok() // Option<String>
                   .expect("Failed to read line"); // String
 
     println!("{}", input);

--- a/src/doc/trpl/unsafe.md
+++ b/src/doc/trpl/unsafe.md
@@ -567,8 +567,8 @@ pub extern fn dot_product(a: *const u32, a_len: u32,
 
 #[lang = "panic_fmt"]
 extern fn panic_fmt(args: &core::fmt::Arguments,
-                       file: &str,
-                       line: uint) -> ! {
+                    file: &str,
+                    line: uint) -> ! {
     loop {}
 }
 


### PR DESCRIPTION
"Idiomatic code should not use extra whitespace in the middle of a line to provide alignment."
http://aturon.github.io/style/whitespace.html

I realize the linked page still needs an RFC, but the docs should be written in accordance with the guidelines nevertheless.
