### PR TITLE
Obsolete the `for Sized?` syntax

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -120,7 +120,7 @@ pub use core::slice::{from_raw_buf, from_raw_mut_buf};
 
 /// Allocating extension methods for slices.
 #[unstable = "needs associated types, may merge with other traits"]
-pub trait SliceExt for Sized? {
+pub trait SliceExt {
     type Item;
 
     /// Sorts the slice, in place, using `compare` to compare
@@ -989,7 +989,7 @@ impl<T> SliceExt for [T] {
 ////////////////////////////////////////////////////////////////////////////////
 #[unstable = "U should be an associated type"]
 /// An extension trait for concatenating slices
-pub trait SliceConcatExt<Sized? T, U> for Sized? {
+pub trait SliceConcatExt<Sized? T, U> {
     /// Flattens a slice of `T` into a single value `U`.
     #[stable]
     fn concat(&self) -> U;

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -401,7 +401,7 @@ Section: Trait implementations
 */
 
 /// Any string that can be represented as a slice.
-pub trait StrExt for Sized?: ops::Slice<uint, str> {
+pub trait StrExt: ops::Slice<uint, str> {
     /// Escapes each char in `s` with `char::escape_default`.
     #[unstable = "return type may change to be an iterator"]
     fn escape_default(&self) -> String {

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -59,7 +59,6 @@ use core::char::CharExt;
 use core::clone::Clone;
 use core::iter::AdditiveIterator;
 use core::iter::{range, Iterator, IteratorExt};
-use core::kinds::Sized;
 use core::ops;
 use core::option::Option::{self, Some, None};
 use core::slice::AsSlice;

--- a/src/libcore/borrow.rs
+++ b/src/libcore/borrow.rs
@@ -53,13 +53,13 @@ use option::Option;
 use self::Cow::*;
 
 /// A trait for borrowing data.
-pub trait BorrowFrom<Sized? Owned> for Sized? {
+pub trait BorrowFrom<Sized? Owned> {
     /// Immutably borrow from an owned value.
     fn borrow_from(owned: &Owned) -> &Self;
 }
 
 /// A trait for mutably borrowing data.
-pub trait BorrowFromMut<Sized? Owned> for Sized? : BorrowFrom<Owned> {
+pub trait BorrowFromMut<Sized? Owned> : BorrowFrom<Owned> {
     /// Mutably borrow from an owned value.
     fn borrow_from_mut(owned: &mut Owned) -> &mut Self;
 }
@@ -103,7 +103,7 @@ impl<'a, T, Sized? B> IntoCow<'a, T, B> for Cow<'a, T, B> where B: ToOwned<T> {
 }
 
 /// A generalization of Clone to borrowed data.
-pub trait ToOwned<Owned> for Sized?: BorrowFrom<Owned> {
+pub trait ToOwned<Owned>: BorrowFrom<Owned> {
     /// Create owned data from borrowed data, usually by copying.
     fn to_owned(&self) -> Owned;
 }

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -69,7 +69,7 @@ use option::Option::{self, Some, None};
 /// only if `a != b`.
 #[lang="eq"]
 #[stable]
-pub trait PartialEq<Sized? Rhs = Self> for Sized? {
+pub trait PartialEq<Sized? Rhs = Self> {
     /// This method tests for `self` and `other` values to be equal, and is used by `==`.
     #[stable]
     fn eq(&self, other: &Rhs) -> bool;
@@ -90,7 +90,7 @@ pub trait PartialEq<Sized? Rhs = Self> for Sized? {
 /// - symmetric: `a == b` implies `b == a`; and
 /// - transitive: `a == b` and `b == c` implies `a == c`.
 #[stable]
-pub trait Eq for Sized?: PartialEq<Self> {
+pub trait Eq: PartialEq<Self> {
     // FIXME #13101: this method is used solely by #[deriving] to
     // assert that every component of a type implements #[deriving]
     // itself, the current deriving infrastructure means doing this
@@ -164,7 +164,7 @@ impl Ordering {
 /// - transitive, `a < b` and `b < c` implies `a < c`. The same must hold for
 ///   both `==` and `>`.
 #[stable]
-pub trait Ord for Sized?: Eq + PartialOrd<Self> {
+pub trait Ord: Eq + PartialOrd<Self> {
     /// This method returns an ordering between `self` and `other` values.
     ///
     /// By convention, `self.cmp(&other)` returns the ordering matching
@@ -224,7 +224,7 @@ impl PartialOrd for Ordering {
 /// 5.11).
 #[lang="ord"]
 #[stable]
-pub trait PartialOrd<Sized? Rhs = Self> for Sized?: PartialEq<Rhs> {
+pub trait PartialOrd<Sized? Rhs = Self>: PartialEq<Rhs> {
     /// This method returns an ordering between `self` and `other` values
     /// if one exists.
     #[stable]

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -222,7 +222,7 @@ impl<'a> Show for Arguments<'a> {
 /// to this trait. There is not an explicit way of selecting this trait to be
 /// used for formatting, it is only if no other format is specified.
 #[unstable = "I/O and core have yet to be reconciled"]
-pub trait Show for Sized? {
+pub trait Show {
     /// Formats the value using the given formatter.
     fn fmt(&self, &mut Formatter) -> Result;
 }
@@ -230,49 +230,49 @@ pub trait Show for Sized? {
 
 /// Format trait for the `o` character
 #[unstable = "I/O and core have yet to be reconciled"]
-pub trait Octal for Sized? {
+pub trait Octal {
     /// Formats the value using the given formatter.
     fn fmt(&self, &mut Formatter) -> Result;
 }
 
 /// Format trait for the `b` character
 #[unstable = "I/O and core have yet to be reconciled"]
-pub trait Binary for Sized? {
+pub trait Binary {
     /// Formats the value using the given formatter.
     fn fmt(&self, &mut Formatter) -> Result;
 }
 
 /// Format trait for the `x` character
 #[unstable = "I/O and core have yet to be reconciled"]
-pub trait LowerHex for Sized? {
+pub trait LowerHex {
     /// Formats the value using the given formatter.
     fn fmt(&self, &mut Formatter) -> Result;
 }
 
 /// Format trait for the `X` character
 #[unstable = "I/O and core have yet to be reconciled"]
-pub trait UpperHex for Sized? {
+pub trait UpperHex {
     /// Formats the value using the given formatter.
     fn fmt(&self, &mut Formatter) -> Result;
 }
 
 /// Format trait for the `p` character
 #[unstable = "I/O and core have yet to be reconciled"]
-pub trait Pointer for Sized? {
+pub trait Pointer {
     /// Formats the value using the given formatter.
     fn fmt(&self, &mut Formatter) -> Result;
 }
 
 /// Format trait for the `e` character
 #[unstable = "I/O and core have yet to be reconciled"]
-pub trait LowerExp for Sized? {
+pub trait LowerExp {
     /// Formats the value using the given formatter.
     fn fmt(&self, &mut Formatter) -> Result;
 }
 
 /// Format trait for the `E` character
 #[unstable = "I/O and core have yet to be reconciled"]
-pub trait UpperExp for Sized? {
+pub trait UpperExp {
     /// Formats the value using the given formatter.
     fn fmt(&self, &mut Formatter) -> Result;
 }

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -76,7 +76,7 @@ pub mod sip;
 /// A hashable type. The `S` type parameter is an abstract hash state that is
 /// used by the `Hash` to compute the hash. It defaults to
 /// `std::hash::sip::SipState`.
-pub trait Hash<S = sip::SipState> for Sized? {
+pub trait Hash<S = sip::SipState> {
     /// Computes the hash of a value.
     fn hash(&self, state: &mut S);
 }

--- a/src/libcore/kinds.rs
+++ b/src/libcore/kinds.rs
@@ -19,19 +19,19 @@
 
 /// Types able to be transferred across task boundaries.
 #[lang="send"]
-pub unsafe trait Send for Sized? : 'static {
+pub unsafe trait Send : 'static {
     // empty.
 }
 
 /// Types with a constant size known at compile-time.
 #[lang="sized"]
-pub trait Sized for Sized? {
+pub trait Sized {
     // Empty.
 }
 
 /// Types that can be copied by simply copying bits (i.e. `memcpy`).
 #[lang="copy"]
-pub trait Copy for Sized? {
+pub trait Copy {
     // Empty.
 }
 
@@ -81,7 +81,7 @@ pub trait Copy for Sized? {
 /// reference; not doing this is undefined behaviour (for example,
 /// `transmute`-ing from `&T` to `&mut T` is illegal).
 #[lang="sync"]
-pub unsafe trait Sync for Sized? {
+pub unsafe trait Sync {
     // Empty
 }
 

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -721,7 +721,7 @@ shr_impl! { uint u8 u16 u32 u64 int i8 i16 i32 i64 }
 #[cfg(stage0)]
 #[allow(missing_docs)]
 #[lang="index"]
-pub trait Index<Sized? Index, Sized? Result> for Sized? {
+pub trait Index<Sized? Index, Sized? Result> {
     /// The method for the indexing (`Foo[Bar]`) operation
     fn index<'a>(&'a self, index: &Index) -> &'a Result;
 }
@@ -757,7 +757,7 @@ pub trait Index<Sized? Index, Sized? Result> for Sized? {
 /// ```
 #[cfg(not(stage0))]  // NOTE(stage0) remove cfg after a snapshot
 #[lang="index"]
-pub trait Index<Sized? Index> for Sized? {
+pub trait Index<Sized? Index> {
     type Sized? Output;
 
     /// The method for the indexing (`Foo[Bar]`) operation
@@ -768,7 +768,7 @@ pub trait Index<Sized? Index> for Sized? {
 #[cfg(stage0)]
 #[allow(missing_docs)]
 #[lang="index_mut"]
-pub trait IndexMut<Sized? Index, Sized? Result> for Sized? {
+pub trait IndexMut<Sized? Index, Sized? Result> {
     /// The method for the indexing (`Foo[Bar]`) operation
     fn index_mut<'a>(&'a mut self, index: &Index) -> &'a mut Result;
 }
@@ -804,7 +804,7 @@ pub trait IndexMut<Sized? Index, Sized? Result> for Sized? {
 /// ```
 #[cfg(not(stage0))]  // NOTE(stage0) remove cfg after a snapshot
 #[lang="index_mut"]
-pub trait IndexMut<Sized? Index> for Sized? {
+pub trait IndexMut<Sized? Index> {
     type Sized? Output;
 
     /// The method for the indexing (`Foo[Bar]`) operation
@@ -849,7 +849,7 @@ pub trait IndexMut<Sized? Index> for Sized? {
 /// }
 /// ```
 #[lang="slice"]
-pub trait Slice<Sized? Idx, Sized? Result> for Sized? {
+pub trait Slice<Sized? Idx, Sized? Result> {
     /// The method for the slicing operation foo[]
     fn as_slice_<'a>(&'a self) -> &'a Result;
     /// The method for the slicing operation foo[from..]
@@ -898,7 +898,7 @@ pub trait Slice<Sized? Idx, Sized? Result> for Sized? {
 /// }
 /// ```
 #[lang="slice_mut"]
-pub trait SliceMut<Sized? Idx, Sized? Result> for Sized? {
+pub trait SliceMut<Sized? Idx, Sized? Result> {
     /// The method for the slicing operation foo[]
     fn as_mut_slice_<'a>(&'a mut self) -> &'a mut Result;
     /// The method for the slicing operation foo[from..]
@@ -1025,7 +1025,7 @@ pub struct RangeTo<Idx> {
 /// }
 /// ```
 #[lang="deref"]
-pub trait Deref for Sized? {
+pub trait Deref {
     type Sized? Target;
 
     /// The method called to dereference a value
@@ -1082,7 +1082,7 @@ impl<'a, Sized? T> Deref for &'a mut T {
 /// }
 /// ```
 #[lang="deref_mut"]
-pub trait DerefMut for Sized? : Deref {
+pub trait DerefMut : Deref {
     /// The method called to mutably dereference a value
     fn deref_mut<'a>(&'a mut self) -> &'a mut <Self as Deref>::Target;
 }
@@ -1093,14 +1093,14 @@ impl<'a, Sized? T> DerefMut for &'a mut T {
 
 /// A version of the call operator that takes an immutable receiver.
 #[lang="fn"]
-pub trait Fn<Args,Result> for Sized? {
+pub trait Fn<Args,Result> {
     /// This is called when the call operator is used.
     extern "rust-call" fn call(&self, args: Args) -> Result;
 }
 
 /// A version of the call operator that takes a mutable receiver.
 #[lang="fn_mut"]
-pub trait FnMut<Args,Result> for Sized? {
+pub trait FnMut<Args,Result> {
     /// This is called when the call operator is used.
     extern "rust-call" fn call_mut(&mut self, args: Args) -> Result;
 }

--- a/src/libcore/raw.rs
+++ b/src/libcore/raw.rs
@@ -52,7 +52,7 @@ pub struct TraitObject {
 
 /// This trait is meant to map equivalences between raw structs and their
 /// corresponding rust values.
-pub trait Repr<T> for Sized? {
+pub trait Repr<T> {
     /// This function "unwraps" a rust value (without consuming it) into its raw
     /// struct representation. This can be used to read/write different values
     /// for the struct. This is a safe method because by default it does not

--- a/src/libcore/raw.rs
+++ b/src/libcore/raw.rs
@@ -20,7 +20,6 @@
 
 use kinds::Copy;
 use mem;
-use kinds::Sized;
 
 /// The representation of a Rust slice
 #[repr(C)]

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -64,7 +64,7 @@ use raw::Slice as RawSlice;
 
 /// Extension methods for slices.
 #[allow(missing_docs)] // docs in libcollections
-pub trait SliceExt for Sized? {
+pub trait SliceExt {
     type Item;
 
     fn slice<'a>(&'a self, start: uint, end: uint) -> &'a [Self::Item];
@@ -636,7 +636,7 @@ impl<T> ops::SliceMut<uint, [T]> for [T] {
 
 /// Data that is viewable as a slice.
 #[experimental = "will be replaced by slice syntax"]
-pub trait AsSlice<T> for Sized? {
+pub trait AsSlice<T> {
     /// Work with `self` as a slice.
     fn as_slice<'a>(&'a self) -> &'a [T];
 }
@@ -1377,7 +1377,7 @@ pub mod bytes {
     use slice::SliceExt;
 
     /// A trait for operations on mutable `[u8]`s.
-    pub trait MutableByteVector for Sized? {
+    pub trait MutableByteVector {
         /// Sets all bytes of the receiver to the given value.
         fn set_memory(&mut self, value: u8);
     }
@@ -1461,7 +1461,7 @@ impl<T: PartialOrd> PartialOrd for [T] {
 
 /// Extension methods for slices containing integers.
 #[experimental]
-pub trait IntSliceExt<U, S> for Sized? {
+pub trait IntSliceExt<U, S> {
     /// Converts the slice to an immutable slice of unsigned integers with the same width.
     fn as_unsigned<'a>(&'a self) -> &'a [U];
     /// Converts the slice to an immutable slice of signed integers with the same width.

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1372,7 +1372,6 @@ pub unsafe fn from_raw_mut_buf<'a, T>(p: &'a *mut T, len: uint) -> &'a mut [T] {
 /// Operations on `[u8]`.
 #[experimental = "needs review"]
 pub mod bytes {
-    use kinds::Sized;
     use ptr;
     use slice::SliceExt;
 

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1130,7 +1130,7 @@ pub mod traits {
 #[unstable = "Instead of taking this bound generically, this trait will be \
               replaced with one of slicing syntax, deref coercions, or \
               a more generic conversion trait"]
-pub trait Str for Sized? {
+pub trait Str {
     /// Work with `self` as a slice.
     fn as_slice<'a>(&'a self) -> &'a str;
 }
@@ -1171,7 +1171,7 @@ delegate_iter!{pattern forward &'a str in RSplitN<'a, P>}
 
 /// Methods for string slices
 #[allow(missing_docs)]
-pub trait StrExt for Sized? {
+pub trait StrExt {
     // NB there are no docs here are they're all located on the StrExt trait in
     // libcollections, not here.
 

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -92,8 +92,8 @@ impl<'cx, 'tcx> Elaborator<'cx, 'tcx> {
                 // Only keep those bounds that we haven't already
                 // seen.  This is necessary to prevent infinite
                 // recursion in some cases.  One common case is when
-                // people define `trait Sized { }` rather than `trait
-                // Sized for Sized? { }`.
+                // people define `trait Sized: Sized { }` rather than `trait
+                // Sized { }`.
                 predicates.retain(|r| self.visited.insert(r.clone()));
 
                 self.stack.push(StackEntry { position: 0,

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -93,7 +93,7 @@ impl<'cx, 'tcx> Elaborator<'cx, 'tcx> {
                 // seen.  This is necessary to prevent infinite
                 // recursion in some cases.  One common case is when
                 // people define `trait Sized { }` rather than `trait
-                // Sized for Sized? { }`.
+                // Sized { }`.
                 predicates.retain(|r| self.visited.insert(r.clone()));
 
                 self.stack.push(StackEntry { position: 0,

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -93,7 +93,7 @@ impl<'cx, 'tcx> Elaborator<'cx, 'tcx> {
                 // seen.  This is necessary to prevent infinite
                 // recursion in some cases.  One common case is when
                 // people define `trait Sized { }` rather than `trait
-                // Sized { }`.
+                // Sized for Sized? { }`.
                 predicates.retain(|r| self.visited.insert(r.clone()));
 
                 self.stack.push(StackEntry { position: 0,

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -38,7 +38,7 @@ use syntax::{ast, ast_util};
 use syntax::owned_slice::OwnedSlice;
 
 /// Produces a string suitable for debugging output.
-pub trait Repr<'tcx> for Sized? {
+pub trait Repr<'tcx> {
     fn repr(&self, tcx: &ctxt<'tcx>) -> String;
 }
 

--- a/src/librustc_trans/trans/cabi_x86_64.rs
+++ b/src/librustc_trans/trans/cabi_x86_64.rs
@@ -63,7 +63,7 @@ impl RegClass {
     }
 }
 
-trait ClassList for Sized? {
+trait ClassList {
     fn is_pass_byval(&self) -> bool;
     fn is_ret_bysret(&self) -> bool;
 }

--- a/src/librustc_trans/trans/llrepr.rs
+++ b/src/librustc_trans/trans/llrepr.rs
@@ -12,7 +12,7 @@ use trans::context::CrateContext;
 use trans::type_::Type;
 use llvm::ValueRef;
 
-pub trait LlvmRepr for Sized? {
+pub trait LlvmRepr {
     fn llrepr(&self, ccx: &CrateContext) -> String;
 }
 

--- a/src/libserialize/base64.rs
+++ b/src/libserialize/base64.rs
@@ -70,7 +70,7 @@ static URLSAFE_CHARS: &'static[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                                        0123456789-_";
 
 /// A trait for converting a value to base64 encoding.
-pub trait ToBase64 for Sized? {
+pub trait ToBase64 {
     /// Converts the value of `self` to a base64 value following the specified
     /// format configuration, returning the owned string.
     fn to_base64(&self, config: Config) -> String;
@@ -170,7 +170,7 @@ impl ToBase64 for [u8] {
 }
 
 /// A trait for converting from base64 encoded values.
-pub trait FromBase64 for Sized? {
+pub trait FromBase64 {
     /// Converts the value of `self`, interpreted as base64 encoded data, into
     /// an owned vector of bytes, returning the vector.
     fn from_base64(&self) -> Result<Vec<u8>, FromBase64Error>;

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -18,7 +18,7 @@ use std::fmt;
 use std::error;
 
 /// A trait for converting a value to hexadecimal encoding
-pub trait ToHex for Sized? {
+pub trait ToHex {
     /// Converts the value of `self` to a hex value, returning the owned
     /// string.
     fn to_hex(&self) -> String;
@@ -54,7 +54,7 @@ impl ToHex for [u8] {
 }
 
 /// A trait for converting hexadecimal encoded values
-pub trait FromHex for Sized? {
+pub trait FromHex {
     /// Converts the value of `self`, interpreted as hexadecimal encoded data,
     /// into an owned vector of bytes, returning the vector.
     fn from_hex(&self) -> Result<Vec<u8>, FromHexError>;

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -2323,7 +2323,7 @@ impl ::Decoder for Decoder {
 }
 
 /// A trait for converting values to JSON
-pub trait ToJson for Sized? {
+pub trait ToJson {
     /// Converts the value of `self` to an instance of JSON
     fn to_json(&self) -> Json;
 }

--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -190,7 +190,7 @@ pub trait Decoder {
     fn error(&mut self, err: &str) -> Self::Error;
 }
 
-pub trait Encodable for Sized? {
+pub trait Encodable {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error>;
 }
 

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -14,7 +14,6 @@
 
 #![unstable = "unsure about placement and naming"]
 
-use core::kinds::Sized;
 use iter::IteratorExt;
 use ops::FnMut;
 use slice::SliceExt;

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -38,7 +38,7 @@ pub trait OwnedAsciiExt {
 
 /// Extension methods for ASCII-subset only operations on string slices
 #[experimental = "would prefer to do this in a more general way"]
-pub trait AsciiExt<T = Self> for Sized? {
+pub trait AsciiExt<T = Self> {
     /// Check if within the ASCII range.
     fn is_ascii(&self) -> bool;
 

--- a/src/libstd/c_str.rs
+++ b/src/libstd/c_str.rs
@@ -295,7 +295,7 @@ impl fmt::Show for CString {
 }
 
 /// A generic trait for converting a value to a CString.
-pub trait ToCStr for Sized? {
+pub trait ToCStr {
     /// Copy the receiver into a CString.
     ///
     /// # Panics

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -786,7 +786,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
 }
 
 /// A trait that represents something bytes-like (e.g. a &[u8] or a &str)
-pub trait BytesContainer for Sized? {
+pub trait BytesContainer {
     /// Returns a &[u8] representing the receiver
     fn container_as_bytes<'a>(&'a self) -> &'a [u8];
     /// Returns the receiver interpreted as a utf-8 string, if possible

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -85,14 +85,14 @@ pub mod rt {
     */
 
     // FIXME: Move this trait to pprust and get rid of *_to_str?
-    pub trait ToSource for Sized? {
+    pub trait ToSource {
         // Takes a thing and generates a string containing rust code for it.
         fn to_source(&self) -> String;
     }
 
     // FIXME (Issue #16472): This should go away after ToToken impls
     // are revised to go directly to token-trees.
-    trait ToSourceWithHygiene for Sized? : ToSource {
+    trait ToSourceWithHygiene : ToSource {
         // Takes a thing and generates a string containing rust code
         // for it, encoding Idents as special byte sequences to
         // maintain hygiene across serialization and deserialization.

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -24,6 +24,7 @@ use ptr::P;
 /// The specific types of unsupported syntax
 #[derive(Copy, PartialEq, Eq, Hash)]
 pub enum ObsoleteSyntax {
+    ObsoleteForSized,
     ObsoleteOwnedType,
     ObsoleteOwnedExpr,
     ObsoleteOwnedPattern,
@@ -55,6 +56,11 @@ impl<'a> ParserObsoleteMethods for parser::Parser<'a> {
     /// Reports an obsolete syntax non-fatal error.
     fn obsolete(&mut self, sp: Span, kind: ObsoleteSyntax) {
         let (kind_str, desc) = match kind {
+            ObsoleteForSized => (
+                "for Sized?",
+                "no longer required, traits apply to sized and unsized types by default, use \
+                `: Sized` to opt-out of unsized types",
+            ),
             ObsoleteProcType => (
                 "the `proc` type",
                 "use unboxed closures instead",

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -58,8 +58,8 @@ impl<'a> ParserObsoleteMethods for parser::Parser<'a> {
         let (kind_str, desc) = match kind {
             ObsoleteForSized => (
                 "for Sized?",
-                "no longer required, traits apply to sized and unsized types by default, use \
-                `: Sized` to opt-out of unsized types",
+                "no longer required. Traits (and their `Self` type) do not have the `Sized` bound \
+                 by default",
             ),
             ObsoleteProcType => (
                 "the `proc` type",

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5003,6 +5003,7 @@ impl<'a> Parser<'a> {
         // re-jigged shortly in any case, so leaving the hacky version for now.
         if self.eat_keyword(keywords::For) {
             let span = self.span;
+
             let mut ate_question = false;
             if self.eat(&token::Question) {
                 ate_question = true;
@@ -5020,8 +5021,11 @@ impl<'a> Parser<'a> {
                     "expected `?Sized` after `for` in trait item");
                 return None;
             }
-            let tref = Parser::trait_ref_from_ident(ident, span);
-            Some(tref)
+            let _tref = Parser::trait_ref_from_ident(ident, span);
+
+            self.obsolete(span, ObsoleteForSized);
+
+            None
         } else {
             None
         }

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -39,7 +39,7 @@ fn local_sort<T: Float>(v: &mut [T]) {
 }
 
 /// Trait that provides simple descriptive statistics on a univariate set of numeric samples.
-pub trait Stats <T: FloatMath + FromPrimitive> for Sized? {
+pub trait Stats <T: FloatMath + FromPrimitive> {
 
     /// Sum of the samples.
     ///

--- a/src/libunicode/u_str.rs
+++ b/src/libunicode/u_str.rs
@@ -37,7 +37,7 @@ pub struct Words<'a> {
 
 /// Methods for Unicode string slices
 #[allow(missing_docs)] // docs in libcollections
-pub trait UnicodeStr for Sized? {
+pub trait UnicodeStr {
     fn graphemes<'a>(&'a self, is_extended: bool) -> Graphemes<'a>;
     fn grapheme_indices<'a>(&'a self, is_extended: bool) -> GraphemeIndices<'a>;
     fn words<'a>(&'a self) -> Words<'a>;

--- a/src/test/auxiliary/lang-item-public.rs
+++ b/src/test/auxiliary/lang-item-public.rs
@@ -12,7 +12,7 @@
 #![feature(lang_items)]
 
 #[lang="sized"]
-pub trait Sized for Sized? {}
+pub trait Sized {}
 
 #[lang="panic"]
 fn panic(_: &(&'static str, &'static str, uint)) -> ! { loop {} }

--- a/src/test/compile-fail/associated-types-ICE-when-projecting-out-of-err.rs
+++ b/src/test/compile-fail/associated-types-ICE-when-projecting-out-of-err.rs
@@ -16,7 +16,7 @@
 #![no_std]
 
 #[lang="sized"]
-pub trait Sized for Sized? {
+pub trait Sized {
     // Empty.
 }
 

--- a/src/test/compile-fail/dst-object-from-unsized-type.rs
+++ b/src/test/compile-fail/dst-object-from-unsized-type.rs
@@ -10,7 +10,7 @@
 
 // Test that we cannot create objects from unsized types.
 
-trait Foo for Sized? {}
+trait Foo {}
 impl Foo for str {}
 
 fn test1<Sized? T: Foo>(t: &T) {

--- a/src/test/compile-fail/issue-18959.rs
+++ b/src/test/compile-fail/issue-18959.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub trait Foo for Sized? { fn foo<T>(&self, ext_thing: &T); }
-pub trait Bar for Sized?: Foo { }
+pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
+pub trait Bar: Foo { }
 impl<T: Foo> Bar for T { }
 
 pub struct Thing;

--- a/src/test/compile-fail/issue-19009.rs
+++ b/src/test/compile-fail/issue-19009.rs
@@ -11,7 +11,7 @@
 #![feature(lang_items)]
 #![no_std]
 #![crate_type="rlib"]
-#[lang="sized"] pub trait Sized for Sized? {}
+#[lang="sized"] pub trait Sized {}
 
 fn ice(f: for <'s> ||
     :'s //~ ERROR use of undeclared lifetime name `'s`

--- a/src/test/compile-fail/obsolete-for-sized.rs
+++ b/src/test/compile-fail/obsolete-for-sized.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that we generate obsolete syntax errors around usages of `for Sized?`
+
+trait Foo for Sized? {} //~ ERROR obsolete syntax: for Sized?
+
+trait Bar for ?Sized {} //~ ERROR obsolete syntax: for Sized?
+
+fn main() { }

--- a/src/test/compile-fail/privacy4.rs
+++ b/src/test/compile-fail/privacy4.rs
@@ -11,7 +11,7 @@
 #![feature(globs, lang_items)]
 #![no_std] // makes debugging this test *a lot* easier (during resolve)
 
-#[lang = "sized"] pub trait Sized for Sized? {}
+#[lang = "sized"] pub trait Sized {}
 #[lang="copy"] pub trait Copy {}
 
 // Test to make sure that private items imported through globs remain private

--- a/src/test/compile-fail/required-lang-item.rs
+++ b/src/test/compile-fail/required-lang-item.rs
@@ -11,7 +11,7 @@
 #![feature(lang_items)]
 #![no_std]
 
-#[lang="sized"] pub trait Sized for Sized? {}
+#[lang="sized"] pub trait Sized {}
 
 // error-pattern:requires `start` lang_item
 

--- a/src/test/compile-fail/unboxed-closure-sugar-default.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-default.rs
@@ -18,7 +18,7 @@ trait Foo<T,U,V=T> {
     fn dummy(&self, t: T, u: U, v: V);
 }
 
-trait Eq<Sized? X> for Sized? { }
+trait Eq<Sized? X> { }
 impl<Sized? X> Eq<X> for X { }
 fn eq<Sized? A,Sized? B>() where A : Eq<B> { }
 

--- a/src/test/compile-fail/unboxed-closure-sugar-equiv.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-equiv.rs
@@ -20,7 +20,7 @@ trait Foo<T,U> {
     fn dummy(&self, t: T, u: U);
 }
 
-trait Eq<Sized? X> for Sized? { }
+trait Eq<Sized? X> { }
 impl<Sized? X> Eq<X> for X { }
 fn eq<Sized? A,Sized? B:Eq<A>>() { }
 

--- a/src/test/compile-fail/unboxed-closure-sugar-lifetime-elision.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-lifetime-elision.rs
@@ -20,7 +20,7 @@ trait Foo<T,U> {
     fn dummy(&self, t: T, u: U);
 }
 
-trait Eq<Sized? X> for Sized? { }
+trait Eq<Sized? X> { }
 impl<Sized? X> Eq<X> for X { }
 fn eq<Sized? A,Sized? B:Eq<A>>() { }
 

--- a/src/test/compile-fail/unboxed-closure-sugar-region.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-region.rs
@@ -21,7 +21,7 @@ trait Foo<'a,T,U> {
     fn dummy(&'a self) -> &'a (T,U);
 }
 
-trait Eq<Sized? X> for Sized? { }
+trait Eq<Sized? X> { }
 impl<Sized? X> Eq<X> for X { }
 fn eq<Sized? A,Sized? B:Eq<A>>() { }
 

--- a/src/test/compile-fail/unsized3.rs
+++ b/src/test/compile-fail/unsized3.rs
@@ -20,7 +20,7 @@ fn f2<X>(x: &X) {
 }
 
 // Bounded.
-trait T for Sized? {}
+trait T {}
 fn f3<Sized? X: T>(x: &X) {
     f4::<X>(x);
     //~^ ERROR the trait `core::kinds::Sized` is not implemented

--- a/src/test/compile-fail/unsized6.rs
+++ b/src/test/compile-fail/unsized6.rs
@@ -11,7 +11,7 @@
 // Test `Sized?` local variables.
 
 
-trait T for Sized? {}
+trait T {}
 
 fn f1<Sized? X>(x: &X) {
     let _: X; // <-- this is OK, no bindings created, no initializer.

--- a/src/test/compile-fail/unsized7.rs
+++ b/src/test/compile-fail/unsized7.rs
@@ -10,7 +10,7 @@
 
 // Test sized-ness checking in substitution in impls.
 
-trait T for Sized? {}
+trait T {}
 
 // I would like these to fail eventually.
 // impl - bounded

--- a/src/test/run-pass/associated-types-conditional-dispatch.rs
+++ b/src/test/run-pass/associated-types-conditional-dispatch.rs
@@ -18,7 +18,7 @@
 
 use std::ops::Deref;
 
-pub trait MyEq<Sized? U=Self> for Sized? {
+pub trait MyEq<Sized? U=Self> {
     fn eq(&self, u: &U) -> bool;
 }
 

--- a/src/test/run-pass/associated-types-normalize-in-bounds-ufcs.rs
+++ b/src/test/run-pass/associated-types-normalize-in-bounds-ufcs.rs
@@ -16,7 +16,7 @@
 struct Splits<'a, T, P>;
 struct SplitsN<I>;
 
-trait SliceExt2 for Sized? {
+trait SliceExt2 {
     type Item;
 
     fn split2<'a, P>(&'a self, pred: P) -> Splits<'a, Self::Item, P>

--- a/src/test/run-pass/associated-types-normalize-in-bounds.rs
+++ b/src/test/run-pass/associated-types-normalize-in-bounds.rs
@@ -16,7 +16,7 @@
 struct Splits<'a, T, P>;
 struct SplitsN<I>;
 
-trait SliceExt2 for Sized? {
+trait SliceExt2 {
     type Item;
 
     fn split2<'a, P>(&'a self, pred: P) -> Splits<'a, Self::Item, P>


### PR DESCRIPTION
Traits and their `Self` type no longer have an implicit `Sized` bound.

If you were using the `for Sized?` syntax simply remove it from your trait:

``` rust
// change this
trait Foo for Sized? {}
// into this
trait Foo {}
```

[breaking-change]
