### PR TITLE
Ungate associated types, globs and default type parameters

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -272,7 +272,6 @@ pub fn phase_2_configure_and_expand(sess: &Session,
             }
             let cfg = syntax::ext::expand::ExpansionConfig {
                 crate_name: crate_name.to_string(),
-                deriving_hash_type_parameter: sess.features.borrow().default_type_params,
                 enable_quotes: sess.features.borrow().quote,
                 recursion_limit: sess.recursion_limit.get(),
             };

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -24,6 +24,7 @@
 #![feature(globs)]
 #![feature(link_args)]
 #![feature(unboxed_closures)]
+#![feature(old_orphan_check)]
 
 extern crate libc;
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -19,6 +19,7 @@
 #![feature(globs, phase, slicing_syntax)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(associated_types)]
+#![feature(old_orphan_check)]
 
 #[phase(plugin, link)] extern crate log;
 #[phase(plugin, link)] extern crate syntax;

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -360,14 +360,6 @@ fn create_substs_for_ast_path<'tcx,AC,RS>(
                                            supplied_ty_param_count)[]);
     }
 
-    if supplied_ty_param_count > required_ty_param_count
-        && !this.tcx().sess.features.borrow().default_type_params {
-        span_err!(this.tcx().sess, span, E0108,
-            "default type parameters are experimental and possibly buggy");
-        span_help!(this.tcx().sess, span,
-            "add #![feature(default_type_params)] to the crate attributes to enable");
-    }
-
     let mut substs = Substs::new_type(types, regions);
 
     match self_ty {

--- a/src/libsyntax/ext/deriving/hash.rs
+++ b/src/libsyntax/ext/deriving/hash.rs
@@ -25,20 +25,14 @@ pub fn expand_deriving_hash<F>(cx: &mut ExtCtxt,
     F: FnOnce(P<Item>),
 {
 
-    let (path, generics, args) = if cx.ecfg.deriving_hash_type_parameter {
-        (Path::new_(vec!("std", "hash", "Hash"), None,
-                    vec!(box Literal(Path::new_local("__S"))), true),
-         LifetimeBounds {
-             lifetimes: Vec::new(),
-             bounds: vec!(("__S",
-                           vec!(Path::new(vec!("std", "hash", "Writer"))))),
-         },
-         Path::new_local("__S"))
-    } else {
-        (Path::new(vec!("std", "hash", "Hash")),
-         LifetimeBounds::empty(),
-         Path::new(vec!("std", "hash", "sip", "SipState")))
+    let path = Path::new_(vec!("std", "hash", "Hash"), None,
+                          vec!(box Literal(Path::new_local("__S"))), true);
+    let generics = LifetimeBounds {
+        lifetimes: Vec::new(),
+        bounds: vec!(("__S",
+                      vec!(Path::new(vec!("std", "hash", "Writer"))))),
     };
+    let args = Path::new_local("__S");
     let inline = cx.meta_word(span, InternedString::new("inline"));
     let attrs = vec!(cx.attribute(span, inline));
     let hash_trait_def = TraitDef {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1161,7 +1161,6 @@ fn new_span(cx: &ExtCtxt, sp: Span) -> Span {
 
 pub struct ExpansionConfig {
     pub crate_name: String,
-    pub deriving_hash_type_parameter: bool,
     pub enable_quotes: bool,
     pub recursion_limit: uint,
 }
@@ -1170,7 +1169,6 @@ impl ExpansionConfig {
     pub fn default(crate_name: String) -> ExpansionConfig {
         ExpansionConfig {
             crate_name: crate_name,
-            deriving_hash_type_parameter: false,
             enable_quotes: false,
             recursion_limit: 64,
         }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -36,7 +36,7 @@ use std::ascii::AsciiExt;
 
 // if you change this list without updating src/doc/reference.md, @cmr will be sad
 static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[
-    ("globs", Active),
+    ("globs", Accepted),
     ("macro_rules", Active),
     ("struct_variant", Accepted),
     ("asm", Active),
@@ -232,13 +232,7 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
 
     fn visit_view_item(&mut self, i: &ast::ViewItem) {
         match i.node {
-            ast::ViewItemUse(ref path) => {
-                if let ast::ViewPathGlob(..) = path.node {
-                    self.gate_feature("globs", path.span,
-                                      "glob import statements are \
-                                       experimental and possibly buggy");
-                }
-            }
+            ast::ViewItemUse(..) => {}
             ast::ViewItemExternCrate(..) => {
                 for attr in i.attrs.iter() {
                     if attr.name().get() == "phase"{

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -67,7 +67,7 @@ static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[
     ("import_shadowing", Active),
     ("advanced_slice_patterns", Active),
     ("tuple_indexing", Accepted),
-    ("associated_types", Active),
+    ("associated_types", Accepted),
     ("visible_private_types", Active),
     ("slicing_syntax", Active),
 
@@ -294,7 +294,7 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
                 }
             }
 
-            ast::ItemImpl(_, polarity, _, _, _, ref items) => {
+            ast::ItemImpl(_, polarity, _, _, _, _) => {
                 match polarity {
                     ast::ImplPolarity::Negative => {
                         self.gate_feature("optin_builtin_traits",
@@ -313,35 +313,12 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
                                        many unsafe patterns and may be \
                                        removed in the future");
                 }
-
-                for item in items.iter() {
-                    match *item {
-                        ast::MethodImplItem(_) => {}
-                        ast::TypeImplItem(ref typedef) => {
-                            self.gate_feature("associated_types",
-                                              typedef.span,
-                                              "associated types are \
-                                               experimental")
-                        }
-                    }
-                }
             }
 
             _ => {}
         }
 
         visit::walk_item(self, i);
-    }
-
-    fn visit_trait_item(&mut self, trait_item: &ast::TraitItem) {
-        match *trait_item {
-            ast::RequiredMethod(_) | ast::ProvidedMethod(_) => {}
-            ast::TypeTraitItem(ref ti) => {
-                self.gate_feature("associated_types",
-                                  ti.ty_param.span,
-                                  "associated types are experimental")
-            }
-        }
     }
 
     fn visit_foreign_item(&mut self, i: &ast::ForeignItem) {

--- a/src/test/auxiliary/associated-types-cc-lib.rs
+++ b/src/test/auxiliary/associated-types-cc-lib.rs
@@ -12,7 +12,6 @@
 // cross-crate scenario.
 
 #![crate_type="lib"]
-#![feature(associated_types)]
 
 pub trait Bar {
     type T;

--- a/src/test/auxiliary/default_type_params_xc.rs
+++ b/src/test/auxiliary/default_type_params_xc.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(default_type_params)]
-
 pub struct Heap;
 
 pub struct FakeHeap;

--- a/src/test/auxiliary/issue-16643.rs
+++ b/src/test/auxiliary/issue-16643.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 #![crate_type = "lib"]
-#![feature(associated_types)]
 
 pub struct TreeBuilder<H>;
 

--- a/src/test/auxiliary/issue_20389.rs
+++ b/src/test/auxiliary/issue_20389.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 pub trait T {
     type C;
 }

--- a/src/test/auxiliary/issue_2316_b.rs
+++ b/src/test/auxiliary/issue_2316_b.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 #![allow(unused_imports)]
-#![feature(globs)]
 
 extern crate issue_2316_a;
 

--- a/src/test/auxiliary/macro_crate_test.rs
+++ b/src/test/auxiliary/macro_crate_test.rs
@@ -10,7 +10,7 @@
 
 // force-host
 
-#![feature(globs, plugin_registrar, macro_rules, quote)]
+#![feature(plugin_registrar, macro_rules, quote)]
 
 extern crate syntax;
 extern crate rustc;

--- a/src/test/auxiliary/namespaced_enum_emulate_flat.rs
+++ b/src/test/auxiliary/namespaced_enum_emulate_flat.rs
@@ -7,7 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(globs)]
 
 pub use Foo::*;
 
@@ -34,5 +33,3 @@ pub mod nest {
         pub fn foo() {}
     }
 }
-
-

--- a/src/test/auxiliary/overloaded_autoderef_xc.rs
+++ b/src/test/auxiliary/overloaded_autoderef_xc.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::ops::Deref;
 
 struct DerefWithHelper<H, T> {

--- a/src/test/auxiliary/syntax-extension-with-dll-deps-2.rs
+++ b/src/test/auxiliary/syntax-extension-with-dll-deps-2.rs
@@ -11,7 +11,7 @@
 // force-host
 
 #![crate_type = "dylib"]
-#![feature(plugin_registrar, quote, globs)]
+#![feature(plugin_registrar, quote)]
 
 extern crate "syntax-extension-with-dll-deps-1" as other;
 extern crate syntax;

--- a/src/test/auxiliary/trait_inheritance_overloading_xc.rs
+++ b/src/test/auxiliary/trait_inheritance_overloading_xc.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::cmp::PartialEq;
 use std::ops::{Add, Sub, Mul};
 

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -38,7 +38,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#![feature(associated_types, slicing_syntax)]
+#![feature(slicing_syntax)]
 
 use std::cmp::min;
 use std::io::{BufferedWriter, File};

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -40,7 +40,7 @@
 
 // ignore-android see #10393 #13206
 
-#![feature(associated_types, slicing_syntax)]
+#![feature(slicing_syntax)]
 
 use std::ascii::OwnedAsciiExt;
 use std::iter::repeat;

--- a/src/test/bench/shootout-meteor.rs
+++ b/src/test/bench/shootout-meteor.rs
@@ -40,8 +40,6 @@
 
 // no-pretty-expanded FIXME #15189
 
-#![feature(associated_types)]
-
 use std::iter::repeat;
 use std::sync::Arc;
 use std::sync::mpsc::channel;

--- a/src/test/bench/shootout-reverse-complement.rs
+++ b/src/test/bench/shootout-reverse-complement.rs
@@ -40,7 +40,7 @@
 
 // ignore-android see #10393 #13206
 
-#![feature(associated_types, slicing_syntax, unboxed_closures)]
+#![feature(slicing_syntax, unboxed_closures)]
 
 extern crate libc;
 

--- a/src/test/compile-fail/associated-types-ICE-when-projecting-out-of-err.rs
+++ b/src/test/compile-fail/associated-types-ICE-when-projecting-out-of-err.rs
@@ -12,7 +12,7 @@
 // just propagate the error.
 
 #![crate_type = "lib"]
-#![feature(associated_types, default_type_params, lang_items)]
+#![feature(default_type_params, lang_items)]
 #![no_std]
 
 #[lang="sized"]

--- a/src/test/compile-fail/associated-types-ICE-when-projecting-out-of-err.rs
+++ b/src/test/compile-fail/associated-types-ICE-when-projecting-out-of-err.rs
@@ -12,7 +12,7 @@
 // just propagate the error.
 
 #![crate_type = "lib"]
-#![feature(default_type_params, lang_items)]
+#![feature(lang_items)]
 #![no_std]
 
 #[lang="sized"]

--- a/src/test/compile-fail/associated-types-bound-failure.rs
+++ b/src/test/compile-fail/associated-types-bound-failure.rs
@@ -10,8 +10,6 @@
 
 // Test equality constraints on associated types in a where clause.
 
-#![feature(associated_types)]
-
 pub trait ToInt {
     fn to_int(&self) -> int;
 }

--- a/src/test/compile-fail/associated-types-eq-1.rs
+++ b/src/test/compile-fail/associated-types-eq-1.rs
@@ -11,8 +11,6 @@
 // Test equality constraints on associated types. Check that unsupported syntax
 // does not ICE.
 
-#![feature(associated_types)]
-
 pub trait Foo {
     type A;
     fn boo(&self) -> <Self as Foo>::A;

--- a/src/test/compile-fail/associated-types-eq-2.rs
+++ b/src/test/compile-fail/associated-types-eq-2.rs
@@ -11,8 +11,6 @@
 // Test equality constraints on associated types. Check we get an error when an
 // equality constraint is used in a qualified path.
 
-#![feature(associated_types)]
-
 pub trait Foo {
     type A;
     fn boo(&self) -> <Self as Foo>::A;

--- a/src/test/compile-fail/associated-types-eq-3.rs
+++ b/src/test/compile-fail/associated-types-eq-3.rs
@@ -11,8 +11,6 @@
 // Test equality constraints on associated types. Check we get type errors
 // where we should.
 
-#![feature(associated_types)]
-
 pub trait Foo {
     type A;
     fn boo(&self) -> <Self as Foo>::A;

--- a/src/test/compile-fail/associated-types-eq-expr-path.rs
+++ b/src/test/compile-fail/associated-types-eq-expr-path.rs
@@ -10,8 +10,6 @@
 
 // Check that an associated type cannot be bound in an expression path.
 
-#![feature(associated_types)]
-
 trait Foo {
     type A;
     fn bar() -> int;

--- a/src/test/compile-fail/associated-types-eq-hr.rs
+++ b/src/test/compile-fail/associated-types-eq-hr.rs
@@ -10,8 +10,6 @@
 
 // Check testing of equality constraints in a higher-ranked context.
 
-#![feature(associated_types)]
-
 pub trait TheTrait<T> {
     type A;
 

--- a/src/test/compile-fail/associated-types-for-unimpl-trait.rs
+++ b/src/test/compile-fail/associated-types-for-unimpl-trait.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Get {
     type Value;
     fn get(&self) -> <Self as Get>::Value;
@@ -22,4 +20,3 @@ trait Other {
 
 fn main() {
 }
-

--- a/src/test/compile-fail/associated-types-in-ambiguous-context.rs
+++ b/src/test/compile-fail/associated-types-in-ambiguous-context.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Get {
     type Value;
     fn get(&self) -> <Self as Get>::Value;
@@ -26,4 +24,3 @@ trait Grab {
 
 fn main() {
 }
-

--- a/src/test/compile-fail/associated-types-incomplete-object.rs
+++ b/src/test/compile-fail/associated-types-incomplete-object.rs
@@ -11,8 +11,6 @@
 // Check that the user gets an errror if they omit a binding from an
 // object type.
 
-#![feature(associated_types)]
-
 pub trait Foo {
     type A;
     type B;

--- a/src/test/compile-fail/associated-types-issue-20346.rs
+++ b/src/test/compile-fail/associated-types-issue-20346.rs
@@ -11,7 +11,6 @@
 // Test that we reliably check the value of the associated type.
 
 #![crate_type = "lib"]
-#![feature(associated_types)]
 #![no_implicit_prelude]
 
 use std::option::Option::{self, None, Some};

--- a/src/test/compile-fail/associated-types-no-suitable-bound.rs
+++ b/src/test/compile-fail/associated-types-no-suitable-bound.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Get {
     type Value;
     fn get(&self) -> <Self as Get>::Value;
@@ -26,4 +24,3 @@ impl Struct {
 
 fn main() {
 }
-

--- a/src/test/compile-fail/associated-types-no-suitable-supertrait.rs
+++ b/src/test/compile-fail/associated-types-no-suitable-supertrait.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 // Check that we get an error when you use `<Self as Get>::Value` in
 // the trait definition but `Self` does not, in fact, implement `Get`.
 

--- a/src/test/compile-fail/associated-types-path-1.rs
+++ b/src/test/compile-fail/associated-types-path-1.rs
@@ -10,8 +10,6 @@
 
 // Test that we have one and only one associated type per ref.
 
-#![feature(associated_types)]
-
 pub trait Foo {
     type A;
 }
@@ -23,4 +21,3 @@ pub fn f1<T>(a: T, x: T::A) {} //~ERROR associated type `A` not found
 pub fn f2<T: Foo + Bar>(a: T, x: T::A) {} //~ERROR ambiguous associated type `A`
 
 pub fn main() {}
-

--- a/src/test/compile-fail/associated-types-path-2.rs
+++ b/src/test/compile-fail/associated-types-path-2.rs
@@ -10,8 +10,6 @@
 
 // Test type checking of uses of associated types via sugary paths.
 
-#![feature(associated_types)]
-
 pub trait Foo {
     type A;
 }

--- a/src/test/compile-fail/associated-types-project-from-hrtb-explicit.rs
+++ b/src/test/compile-fail/associated-types-project-from-hrtb-explicit.rs
@@ -11,8 +11,6 @@
 // Test you can't use a higher-ranked trait bound inside of a qualified
 // path (just won't parse).
 
-#![feature(associated_types)]
-
 pub trait Foo<T> {
     type A;
 

--- a/src/test/compile-fail/associated-types-project-from-hrtb-in-fn-body.rs
+++ b/src/test/compile-fail/associated-types-project-from-hrtb-in-fn-body.rs
@@ -11,8 +11,6 @@
 // Check projection of an associated type out of a higher-ranked
 // trait-bound in the context of a function body.
 
-#![feature(associated_types)]
-
 pub trait Foo<T> {
     type A;
 

--- a/src/test/compile-fail/associated-types-project-from-hrtb-in-fn.rs
+++ b/src/test/compile-fail/associated-types-project-from-hrtb-in-fn.rs
@@ -11,8 +11,6 @@
 // Check projection of an associated type out of a higher-ranked trait-bound
 // in the context of a function signature.
 
-#![feature(associated_types)]
-
 pub trait Foo<T> {
     type A;
 

--- a/src/test/compile-fail/associated-types-project-from-hrtb-in-struct.rs
+++ b/src/test/compile-fail/associated-types-project-from-hrtb-in-struct.rs
@@ -11,8 +11,6 @@
 // Check projection of an associated type out of a higher-ranked trait-bound
 // in the context of a struct definition.
 
-#![feature(associated_types)]
-
 pub trait Foo<T> {
     type A;
 

--- a/src/test/compile-fail/associated-types-project-from-hrtb-in-trait-method.rs
+++ b/src/test/compile-fail/associated-types-project-from-hrtb-in-trait-method.rs
@@ -11,8 +11,6 @@
 // Check projection of an associated type out of a higher-ranked trait-bound
 // in the context of a method definition in a trait.
 
-#![feature(associated_types)]
-
 pub trait Foo<T> {
     type A;
 

--- a/src/test/compile-fail/associated-types-unconstrained.rs
+++ b/src/test/compile-fail/associated-types-unconstrained.rs
@@ -10,8 +10,6 @@
 
 // Check that an associated type cannot be bound in an expression path.
 
-#![feature(associated_types)]
-
 trait Foo {
     type A;
     fn bar() -> int;

--- a/src/test/compile-fail/associated-types-unsized.rs
+++ b/src/test/compile-fail/associated-types-unsized.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Get {
     type Sized? Value;
     fn get(&self) -> <Self as Get>::Value;
@@ -21,4 +19,3 @@ fn foo<T:Get>(t: T) {
 
 fn main() {
 }
-

--- a/src/test/compile-fail/binop-consume-args.rs
+++ b/src/test/compile-fail/binop-consume-args.rs
@@ -10,8 +10,6 @@
 
 // Test that binary operators consume their arguments
 
-#![feature(default_type_params)]
-
 use std::ops::{Add, Sub, Mul, Div, Rem, BitAnd, BitXor, BitOr, Shl, Shr};
 
 fn add<A: Add<B, Output=()>, B>(lhs: A, rhs: B) {

--- a/src/test/compile-fail/binop-consume-args.rs
+++ b/src/test/compile-fail/binop-consume-args.rs
@@ -10,7 +10,7 @@
 
 // Test that binary operators consume their arguments
 
-#![feature(associated_types, default_type_params)]
+#![feature(default_type_params)]
 
 use std::ops::{Add, Sub, Mul, Div, Rem, BitAnd, BitXor, BitOr, Shl, Shr};
 

--- a/src/test/compile-fail/binop-move-semantics.rs
+++ b/src/test/compile-fail/binop-move-semantics.rs
@@ -10,7 +10,7 @@
 
 // Test that move restrictions are enforced on overloaded binary operations
 
-#![feature(associated_types, default_type_params)]
+#![feature(default_type_params)]
 
 use std::ops::Add;
 

--- a/src/test/compile-fail/binop-move-semantics.rs
+++ b/src/test/compile-fail/binop-move-semantics.rs
@@ -10,8 +10,6 @@
 
 // Test that move restrictions are enforced on overloaded binary operations
 
-#![feature(default_type_params)]
-
 use std::ops::Add;
 
 fn double_move<T: Add<Output=()>>(x: T) {

--- a/src/test/compile-fail/borrowck-borrow-overloaded-auto-deref-mut.rs
+++ b/src/test/compile-fail/borrowck-borrow-overloaded-auto-deref-mut.rs
@@ -11,8 +11,6 @@
 // Test how overloaded deref interacts with borrows when DerefMut
 // is implemented.
 
-#![feature(associated_types)]
-
 use std::ops::{Deref, DerefMut};
 
 struct Own<T> {

--- a/src/test/compile-fail/borrowck-borrow-overloaded-auto-deref.rs
+++ b/src/test/compile-fail/borrowck-borrow-overloaded-auto-deref.rs
@@ -11,8 +11,6 @@
 // Test how overloaded deref interacts with borrows when only
 // Deref and not DerefMut is implemented.
 
-#![feature(associated_types)]
-
 use std::ops::Deref;
 
 struct Rc<T> {

--- a/src/test/compile-fail/borrowck-borrow-overloaded-deref-mut.rs
+++ b/src/test/compile-fail/borrowck-borrow-overloaded-deref-mut.rs
@@ -11,8 +11,6 @@
 // Test how overloaded deref interacts with borrows when DerefMut
 // is implemented.
 
-#![feature(associated_types)]
-
 use std::ops::{Deref, DerefMut};
 
 struct Own<T> {

--- a/src/test/compile-fail/borrowck-borrow-overloaded-deref.rs
+++ b/src/test/compile-fail/borrowck-borrow-overloaded-deref.rs
@@ -11,8 +11,6 @@
 // Test how overloaded deref interacts with borrows when only
 // Deref and not DerefMut is implemented.
 
-#![feature(associated_types)]
-
 use std::ops::Deref;
 
 struct Rc<T> {

--- a/src/test/compile-fail/borrowck-loan-in-overloaded-op.rs
+++ b/src/test/compile-fail/borrowck-loan-in-overloaded-op.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::ops::Add;
 
 #[derive(Clone)]

--- a/src/test/compile-fail/borrowck-loan-rcvr-overloaded-op.rs
+++ b/src/test/compile-fail/borrowck-loan-rcvr-overloaded-op.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types, default_type_params)]
+#![feature(default_type_params)]
 
 use std::ops::Add;
 

--- a/src/test/compile-fail/borrowck-loan-rcvr-overloaded-op.rs
+++ b/src/test/compile-fail/borrowck-loan-rcvr-overloaded-op.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(default_type_params)]
-
 use std::ops::Add;
 
 #[derive(Copy)]

--- a/src/test/compile-fail/borrowck-overloaded-index-2.rs
+++ b/src/test/compile-fail/borrowck-overloaded-index-2.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::ops::Index;
 
 struct MyVec<T> {

--- a/src/test/compile-fail/borrowck-overloaded-index-autoderef.rs
+++ b/src/test/compile-fail/borrowck-overloaded-index-autoderef.rs
@@ -11,8 +11,6 @@
 // Test that we still see borrowck errors of various kinds when using
 // indexing and autoderef in combination.
 
-#![feature(associated_types)]
-
 use std::ops::{Index, IndexMut};
 
 struct Foo {
@@ -95,5 +93,3 @@ fn test9(mut f: Box<Bar>, g: Bar, s: String) {
 
 fn main() {
 }
-
-

--- a/src/test/compile-fail/borrowck-overloaded-index.rs
+++ b/src/test/compile-fail/borrowck-overloaded-index.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::ops::{Index, IndexMut};
 
 struct Foo {
@@ -70,5 +68,3 @@ fn main() {
     s[2] = 20;
     //~^ ERROR cannot assign to immutable dereference (dereference is implicit, due to indexing)
 }
-
-

--- a/src/test/compile-fail/dst-index.rs
+++ b/src/test/compile-fail/dst-index.rs
@@ -11,8 +11,6 @@
 // Test that overloaded index expressions with DST result types
 // can't be used as rvalues
 
-#![feature(associated_types)]
-
 use std::ops::Index;
 use std::fmt::Show;
 

--- a/src/test/compile-fail/generic-impl-less-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-impl-less-params-with-defaults.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(default_type_params)]
-
 struct Foo<A, B, C = (A, B)>;
 
 impl<A, B, C = (A, B)> Foo<A, B, C> {

--- a/src/test/compile-fail/generic-impl-more-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-impl-more-params-with-defaults.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(default_type_params)]
-
 struct Heap;
 
 struct Vec<T, A = Heap>;

--- a/src/test/compile-fail/generic-non-trailing-defaults.rs
+++ b/src/test/compile-fail/generic-non-trailing-defaults.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(default_type_params)]
-
 struct Heap;
 
 struct Vec<A = Heap, T>; //~ ERROR type parameters with a default must be trailing

--- a/src/test/compile-fail/generic-type-less-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-type-less-params-with-defaults.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(default_type_params)]
-
 struct Heap;
 
 struct Vec<T, A = Heap>;

--- a/src/test/compile-fail/generic-type-more-params-with-defaults.rs
+++ b/src/test/compile-fail/generic-type-more-params-with-defaults.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(default_type_params)]
-
 struct Heap;
 
 struct Vec<T, A = Heap>;

--- a/src/test/compile-fail/generic-type-params-forward-mention.rs
+++ b/src/test/compile-fail/generic-type-params-forward-mention.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(default_type_params)]
-
 // Ensure that we get an error and not an ICE for this problematic case.
 struct Foo<T = Option<U>, U = bool>;
 //~^ ERROR type parameters with a default cannot use forward declared identifiers

--- a/src/test/compile-fail/generic-type-params-name-repr.rs
+++ b/src/test/compile-fail/generic-type-params-name-repr.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(default_type_params)]
-
 struct A;
 struct B;
 struct C;

--- a/src/test/compile-fail/glob-resolve1.rs
+++ b/src/test/compile-fail/glob-resolve1.rs
@@ -10,8 +10,6 @@
 
 // Make sure that globs only bring in public things.
 
-#![feature(globs)]
-
 use bar::*;
 
 mod bar {

--- a/src/test/compile-fail/import-glob-0.rs
+++ b/src/test/compile-fail/import-glob-0.rs
@@ -10,8 +10,6 @@
 
 // error-pattern: unresolved name
 
-#![feature(globs)]
-
 use module_of_many_things::*;
 
 mod module_of_many_things {

--- a/src/test/compile-fail/import-glob-circular.rs
+++ b/src/test/compile-fail/import-glob-circular.rs
@@ -10,8 +10,6 @@
 
 // error-pattern: unresolved
 
-#![feature(globs)]
-
 mod circ1 {
     pub use circ2::f2;
     pub fn f1() { println!("f1"); }

--- a/src/test/compile-fail/import-shadow-1.rs
+++ b/src/test/compile-fail/import-shadow-1.rs
@@ -11,7 +11,6 @@
 // Test that import shadowing using globs causes errors
 
 #![no_implicit_prelude]
-#![feature(globs)]
 
 use foo::*;
 use bar::*; //~ERROR a type named `Baz` has already been imported in this module

--- a/src/test/compile-fail/import-shadow-2.rs
+++ b/src/test/compile-fail/import-shadow-2.rs
@@ -11,7 +11,6 @@
 // Test that import shadowing using globs causes errors
 
 #![no_implicit_prelude]
-#![feature(globs)]
 
 use foo::*;
 use foo::*; //~ERROR a type named `Baz` has already been imported in this module

--- a/src/test/compile-fail/import-shadow-3.rs
+++ b/src/test/compile-fail/import-shadow-3.rs
@@ -11,7 +11,6 @@
 // Test that import shadowing using globs causes errors
 
 #![no_implicit_prelude]
-#![feature(globs)]
 
 use foo::Baz;
 use bar::*; //~ERROR a type named `Baz` has already been imported in this module

--- a/src/test/compile-fail/import-shadow-4.rs
+++ b/src/test/compile-fail/import-shadow-4.rs
@@ -11,7 +11,6 @@
 // Test that import shadowing using globs causes errors
 
 #![no_implicit_prelude]
-#![feature(globs)]
 
 use foo::*;
 use bar::Baz; //~ERROR a type named `Baz` has already been imported in this module

--- a/src/test/compile-fail/import-shadow-5.rs
+++ b/src/test/compile-fail/import-shadow-5.rs
@@ -11,7 +11,6 @@
 // Test that import shadowing using globs causes errors
 
 #![no_implicit_prelude]
-#![feature(globs)]
 
 use foo::Baz;
 use bar::Baz; //~ERROR a type named `Baz` has already been imported in this module

--- a/src/test/compile-fail/import-shadow-6.rs
+++ b/src/test/compile-fail/import-shadow-6.rs
@@ -11,7 +11,6 @@
 // Test that import shadowing using globs causes errors
 
 #![no_implicit_prelude]
-#![feature(globs)]
 
 use qux::*;
 use foo::*; //~ERROR a type named `Baz` has already been imported in this module

--- a/src/test/compile-fail/import-shadow-7.rs
+++ b/src/test/compile-fail/import-shadow-7.rs
@@ -11,7 +11,6 @@
 // Test that import shadowing using globs causes errors
 
 #![no_implicit_prelude]
-#![feature(globs)]
 
 use foo::*;
 use qux::*; //~ERROR a type named `Baz` has already been imported in this module

--- a/src/test/compile-fail/infinite-autoderef.rs
+++ b/src/test/compile-fail/infinite-autoderef.rs
@@ -10,8 +10,6 @@
 
 // error-pattern: reached the recursion limit while auto-dereferencing
 
-#![feature(associated_types)]
-
 use std::ops::Deref;
 
 struct Foo;

--- a/src/test/compile-fail/issue-1697.rs
+++ b/src/test/compile-fail/issue-1697.rs
@@ -10,8 +10,6 @@
 
 // Testing that we don't fail abnormally after hitting the errors
 
-#![feature(globs)]
-
 use unresolved::*; //~ ERROR unresolved import `unresolved::*`. Maybe a missing `extern crate unres
 
 fn main() {}

--- a/src/test/compile-fail/issue-18389.rs
+++ b/src/test/compile-fail/issue-18389.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 #![feature(unboxed_closures)]
-#![feature(associated_types)]
 
 use std::any::Any;
 use std::intrinsics::TypeId;

--- a/src/test/compile-fail/issue-18566.rs
+++ b/src/test/compile-fail/issue-18566.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::ops::Deref;
 
 struct MyPtr<'a>(&'a mut uint);

--- a/src/test/compile-fail/issue-18611.rs
+++ b/src/test/compile-fail/issue-18611.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 fn add_state(op: <int as HasState>::State) {
 //~^ ERROR the trait `HasState` is not implemented for the type `int`
 }

--- a/src/test/compile-fail/issue-18819.rs
+++ b/src/test/compile-fail/issue-18819.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Foo {
     type Item;
 }

--- a/src/test/compile-fail/issue-19883.rs
+++ b/src/test/compile-fail/issue-19883.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait From<Src> {
     type Output;
 

--- a/src/test/compile-fail/issue-20005.rs
+++ b/src/test/compile-fail/issue-20005.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait From<Src> {
     type Result;
 

--- a/src/test/compile-fail/issue-4366-2.rs
+++ b/src/test/compile-fail/issue-4366-2.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs)]
-
 // ensures that 'use foo:*' doesn't import non-public item
 
 use m1::*;
@@ -36,4 +34,3 @@ mod m1 {
 fn main() {
     foo(); //~ ERROR: unresolved name
 }
-

--- a/src/test/compile-fail/issue-4366.rs
+++ b/src/test/compile-fail/issue-4366.rs
@@ -13,8 +13,6 @@
 // ensures that 'use foo:*' doesn't import non-public 'use' statements in the
 // module 'foo'
 
-#![feature(globs)]
-
 use m1::*;
 
 mod foo {

--- a/src/test/compile-fail/issue-8208.rs
+++ b/src/test/compile-fail/issue-8208.rs
@@ -8,10 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs)]
-
 use self::*; //~ ERROR: unresolved import
 
 fn main() {
 }
-

--- a/src/test/compile-fail/lint-missing-doc.rs
+++ b/src/test/compile-fail/lint-missing-doc.rs
@@ -10,7 +10,6 @@
 
 // When denying at the crate level, be sure to not get random warnings from the
 // injected intrinsics by the compiler.
-#![feature(globs)]
 #![deny(missing_docs)]
 #![allow(dead_code)]
 #![allow(missing_copy_implementations)]

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -13,7 +13,7 @@
 // aux-build:stability_cfg1.rs
 // aux-build:stability_cfg2.rs
 
-#![feature(globs, phase)]
+#![feature(phase)]
 #![deny(unstable)]
 #![deny(deprecated)]
 #![deny(experimental)]

--- a/src/test/compile-fail/lint-unused-extern-crate.rs
+++ b/src/test/compile-fail/lint-unused-extern-crate.rs
@@ -10,7 +10,6 @@
 
 // aux-build:lint-unused-extern-crate.rs
 
-#![feature(globs)]
 #![deny(unused_extern_crates)]
 #![allow(unused_variables)]
 

--- a/src/test/compile-fail/lint-unused-imports.rs
+++ b/src/test/compile-fail/lint-unused-imports.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs)]
 #![deny(unused_imports)]
 #![allow(dead_code)]
 

--- a/src/test/compile-fail/name-clash-nullary.rs
+++ b/src/test/compile-fail/name-clash-nullary.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs)]
-
 // error-pattern:declaration of `None` shadows
 use std::option::*;
 

--- a/src/test/compile-fail/namespaced-enum-glob-import-no-impls-xcrate.rs
+++ b/src/test/compile-fail/namespaced-enum-glob-import-no-impls-xcrate.rs
@@ -9,8 +9,6 @@
 // except according to those terms.
 
 // aux-build:namespaced_enums.rs
-#![feature(globs)]
-
 extern crate namespaced_enums;
 
 mod m {
@@ -25,4 +23,3 @@ pub fn main() {
     bar(); //~ ERROR unresolved name `bar`
     m::bar(); //~ ERROR unresolved name `m::bar`
 }
-

--- a/src/test/compile-fail/namespaced-enum-glob-import-no-impls.rs
+++ b/src/test/compile-fail/namespaced-enum-glob-import-no-impls.rs
@@ -7,7 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(globs)]
 
 mod m2 {
     pub enum Foo {

--- a/src/test/compile-fail/privacy-ns1.rs
+++ b/src/test/compile-fail/privacy-ns1.rs
@@ -11,7 +11,6 @@
 // Check we do the correct privacy checks when we import a name and there is an
 // item with that name in both the value and type namespaces.
 
-#![feature(globs)]
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
@@ -64,4 +63,3 @@ fn test_glob3() {
 
 fn main() {
 }
-

--- a/src/test/compile-fail/privacy-ns2.rs
+++ b/src/test/compile-fail/privacy-ns2.rs
@@ -11,7 +11,6 @@
 // Check we do the correct privacy checks when we import a name and there is an
 // item with that name in both the value and type namespaces.
 
-#![feature(globs)]
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
@@ -88,4 +87,3 @@ fn test_list3() {
 
 fn main() {
 }
-

--- a/src/test/compile-fail/privacy1.rs
+++ b/src/test/compile-fail/privacy1.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs, lang_items)]
+#![feature(lang_items)]
 #![no_std] // makes debugging this test *a lot* easier (during resolve)
 
 #[lang="sized"]

--- a/src/test/compile-fail/privacy2.rs
+++ b/src/test/compile-fail/privacy2.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs)]
 #![no_std] // makes debugging this test *a lot* easier (during resolve)
 
 // Test to make sure that globs don't leak in regular `use` statements.
@@ -34,4 +33,3 @@ fn test2() {
 }
 
 #[start] fn main(_: int, _: *const *const u8) -> int { 3 }
-

--- a/src/test/compile-fail/privacy3.rs
+++ b/src/test/compile-fail/privacy3.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs)]
 #![no_std] // makes debugging this test *a lot* easier (during resolve)
 
 // Test to make sure that private items imported through globs remain private

--- a/src/test/compile-fail/privacy4.rs
+++ b/src/test/compile-fail/privacy4.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs, lang_items)]
+#![feature(lang_items)]
 #![no_std] // makes debugging this test *a lot* easier (during resolve)
 
 #[lang = "sized"] pub trait Sized for Sized? {}

--- a/src/test/compile-fail/static-reference-to-fn-2.rs
+++ b/src/test/compile-fail/static-reference-to-fn-2.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 struct StateMachineIter<'a> {
     statefn: &'a StateMachineFunc<'a>
 }
@@ -61,4 +59,3 @@ fn main() {
     println!("{}",it.next());
     println!("{}",it.next());
 }
-

--- a/src/test/compile-fail/std-uncopyable-atomics.rs
+++ b/src/test/compile-fail/std-uncopyable-atomics.rs
@@ -10,7 +10,6 @@
 
 // Issue #8380
 
-#![feature(globs)]
 
 use std::sync::atomic::*;
 use std::ptr;

--- a/src/test/compile-fail/unboxed-closure-sugar-default.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-default.rs
@@ -11,7 +11,7 @@
 // Test interaction between unboxed closure sugar and default type
 // parameters (should be exactly as if angle brackets were used).
 
-#![feature(default_type_params, unboxed_closures)]
+#![feature(unboxed_closures)]
 #![allow(dead_code)]
 
 trait Foo<T,U,V=T> {

--- a/src/test/compile-fail/unboxed-closure-sugar-region.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-region.rs
@@ -12,7 +12,7 @@
 // parameters (should be exactly as if angle brackets were used
 // and regions omitted).
 
-#![feature(default_type_params, unboxed_closures)]
+#![feature(unboxed_closures)]
 #![allow(dead_code)]
 
 use std::kinds::marker;

--- a/src/test/compile-fail/wrong-mul-method-signature.rs
+++ b/src/test/compile-fail/wrong-mul-method-signature.rs
@@ -13,7 +13,7 @@
 // (In this case the mul method should take &f64 and not f64)
 // See: #11450
 
-#![feature(associated_types, default_type_params)]
+#![feature(default_type_params)]
 
 use std::ops::Mul;
 

--- a/src/test/compile-fail/wrong-mul-method-signature.rs
+++ b/src/test/compile-fail/wrong-mul-method-signature.rs
@@ -13,8 +13,6 @@
 // (In this case the mul method should take &f64 and not f64)
 // See: #11450
 
-#![feature(default_type_params)]
-
 use std::ops::Mul;
 
 struct Vec1 {

--- a/src/test/run-fail/glob-use-std.rs
+++ b/src/test/run-fail/glob-use-std.rs
@@ -15,7 +15,6 @@
 // Expanded pretty printing causes resolve conflicts.
 
 // error-pattern:panic works
-#![feature(globs)]
 
 use std::*;
 

--- a/src/test/run-pass/associated-types-basic.rs
+++ b/src/test/run-pass/associated-types-basic.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Foo {
     type T;
 }
@@ -23,4 +21,3 @@ fn main() {
     let y: int = 44;
     assert_eq!(x * 2, y);
 }
-

--- a/src/test/run-pass/associated-types-binding-in-where-clause.rs
+++ b/src/test/run-pass/associated-types-binding-in-where-clause.rs
@@ -10,8 +10,6 @@
 
 // Test equality constraints on associated types in a where clause.
 
-#![feature(associated_types)]
-
 pub trait Foo {
     type A;
     fn boo(&self) -> <Self as Foo>::A;

--- a/src/test/run-pass/associated-types-bound.rs
+++ b/src/test/run-pass/associated-types-bound.rs
@@ -10,8 +10,6 @@
 
 // Test equality constraints on associated types in a where clause.
 
-#![feature(associated_types)]
-
 pub trait ToInt {
     fn to_int(&self) -> int;
 }

--- a/src/test/run-pass/associated-types-cc.rs
+++ b/src/test/run-pass/associated-types-cc.rs
@@ -13,8 +13,6 @@
 // Test that we are able to reference cross-crate traits that employ
 // associated types.
 
-#![feature(associated_types)]
-
 extern crate "associated-types-cc-lib" as bar;
 
 use bar::Bar;

--- a/src/test/run-pass/associated-types-conditional-dispatch.rs
+++ b/src/test/run-pass/associated-types-conditional-dispatch.rs
@@ -14,7 +14,7 @@
 // `Target=[A]`, then the impl marked with `(*)` is seen to conflict
 // with all the others.
 
-#![feature(associated_types, default_type_params)]
+#![feature(default_type_params)]
 
 use std::ops::Deref;
 

--- a/src/test/run-pass/associated-types-conditional-dispatch.rs
+++ b/src/test/run-pass/associated-types-conditional-dispatch.rs
@@ -14,8 +14,6 @@
 // `Target=[A]`, then the impl marked with `(*)` is seen to conflict
 // with all the others.
 
-#![feature(default_type_params)]
-
 use std::ops::Deref;
 
 pub trait MyEq<Sized? U=Self> for Sized? {

--- a/src/test/run-pass/associated-types-constant-type.rs
+++ b/src/test/run-pass/associated-types-constant-type.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait SignedUnsigned {
     type Opposite;
     fn convert(self) -> Self::Opposite;
@@ -39,4 +37,3 @@ fn main() {
     let x = get(22);
     assert_eq!(22u, x);
 }
-

--- a/src/test/run-pass/associated-types-eq-obj.rs
+++ b/src/test/run-pass/associated-types-eq-obj.rs
@@ -10,8 +10,6 @@
 
 // Test equality constraints on associated types inside of an object type
 
-#![feature(associated_types)]
-
 pub trait Foo {
     type A;
     fn boo(&self) -> <Self as Foo>::A;

--- a/src/test/run-pass/associated-types-impl-redirect.rs
+++ b/src/test/run-pass/associated-types-impl-redirect.rs
@@ -16,7 +16,7 @@
 
 // ignore-pretty -- FIXME(#17362)
 
-#![feature(associated_types, lang_items, unboxed_closures)]
+#![feature(lang_items, unboxed_closures)]
 #![no_implicit_prelude]
 
 use std::kinds::Sized;

--- a/src/test/run-pass/associated-types-in-default-method.rs
+++ b/src/test/run-pass/associated-types-in-default-method.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Get {
     type Value;
     fn get(&self) -> &<Self as Get>::Value;
@@ -35,5 +33,3 @@ fn main() {
     };
     assert_eq!(*s.grab(), 100);
 }
-
-

--- a/src/test/run-pass/associated-types-in-fn.rs
+++ b/src/test/run-pass/associated-types-in-fn.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Get {
     type Value;
     fn get(&self) -> &<Self as Get>::Value;
@@ -36,4 +34,3 @@ fn main() {
     };
     assert_eq!(*grab(&s), 100);
 }
-

--- a/src/test/run-pass/associated-types-in-impl-generics.rs
+++ b/src/test/run-pass/associated-types-in-impl-generics.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Get {
     type Value;
     fn get(&self) -> &<Self as Get>::Value;
@@ -44,4 +42,3 @@ fn main() {
     };
     assert_eq!(*s.grab(), 100);
 }
-

--- a/src/test/run-pass/associated-types-in-inherent-method.rs
+++ b/src/test/run-pass/associated-types-in-inherent-method.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Get {
     type Value;
     fn get(&self) -> &<Self as Get>::Value;
@@ -38,4 +36,3 @@ fn main() {
     };
     assert_eq!(*Struct::grab(&s), 100);
 }
-

--- a/src/test/run-pass/associated-types-issue-20371.rs
+++ b/src/test/run-pass/associated-types-issue-20371.rs
@@ -11,7 +11,6 @@
 // Test that we are able to have an impl that defines an associated type
 // before the actual trait.
 
-#![feature(associated_types)]
 impl X for f64 { type Y = int; }
 trait X {type Y; }
 fn main() {}

--- a/src/test/run-pass/associated-types-normalize-in-bounds-ufcs.rs
+++ b/src/test/run-pass/associated-types-normalize-in-bounds-ufcs.rs
@@ -11,8 +11,6 @@
 // Test that we normalize associated types that appear in bounds; if
 // we didn't, the call to `self.split2()` fails to type check.
 
-#![feature(associated_types)]
-
 struct Splits<'a, T, P>;
 struct SplitsN<I>;
 

--- a/src/test/run-pass/associated-types-normalize-in-bounds.rs
+++ b/src/test/run-pass/associated-types-normalize-in-bounds.rs
@@ -11,8 +11,6 @@
 // Test that we normalize associated types that appear in bounds; if
 // we didn't, the call to `self.split2()` fails to type check.
 
-#![feature(associated_types)]
-
 struct Splits<'a, T, P>;
 struct SplitsN<I>;
 

--- a/src/test/run-pass/associated-types-projection-bound-in-supertraits.rs
+++ b/src/test/run-pass/associated-types-projection-bound-in-supertraits.rs
@@ -13,8 +13,6 @@
 // this case, the `Result=Self` binding in the supertrait listing of
 // `Int` was being ignored.
 
-#![feature(associated_types)]
-
 trait Not {
     type Result;
 

--- a/src/test/run-pass/associated-types-qualified-path-with-trait-with-type-parameters.rs
+++ b/src/test/run-pass/associated-types-qualified-path-with-trait-with-type-parameters.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Foo<T> {
     type Bar;
     fn get_bar() -> <Self as Foo<T>>::Bar;

--- a/src/test/run-pass/associated-types-resolve-lifetime.rs
+++ b/src/test/run-pass/associated-types-resolve-lifetime.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Get<T> {
     fn get(&self) -> T;
 }

--- a/src/test/run-pass/associated-types-return.rs
+++ b/src/test/run-pass/associated-types-return.rs
@@ -10,8 +10,6 @@
 
 // Test equality constraints on associated types in a where clause.
 
-#![feature(associated_types)]
-
 pub trait Foo {
     type A;
     fn boo(&self) -> <Self as Foo>::A;

--- a/src/test/run-pass/associated-types-simple.rs
+++ b/src/test/run-pass/associated-types-simple.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Get {
     type Value;
     fn get(&self) -> &<Self as Get>::Value;
@@ -32,4 +30,3 @@ fn main() {
     };
     assert_eq!(*s.get(), 100);
 }
-

--- a/src/test/run-pass/associated-types-sugar-path.rs
+++ b/src/test/run-pass/associated-types-sugar-path.rs
@@ -10,8 +10,6 @@
 
 // Test paths to associated types using the type-parameter-only sugar.
 
-#![feature(associated_types)]
-
 pub trait Foo {
     type A;
     fn boo(&self) -> Self::A;

--- a/src/test/run-pass/associated-types-where-clause-impl-ambiguity.rs
+++ b/src/test/run-pass/associated-types-where-clause-impl-ambiguity.rs
@@ -16,7 +16,7 @@
 
 // ignore-pretty -- FIXME(#17362) pretty prints with `<<` which lexes wrong
 
-#![feature(associated_types, lang_items, unboxed_closures)]
+#![feature(lang_items, unboxed_closures)]
 #![no_implicit_prelude]
 
 use std::kinds::Sized;

--- a/src/test/run-pass/dst-deref-mut.rs
+++ b/src/test/run-pass/dst-deref-mut.rs
@@ -10,8 +10,6 @@
 
 // Test that a custom deref with a fat pointer return type does not ICE
 
-#![feature(associated_types)]
-
 use std::ops::{Deref, DerefMut};
 
 pub struct Arr {

--- a/src/test/run-pass/dst-deref.rs
+++ b/src/test/run-pass/dst-deref.rs
@@ -10,8 +10,6 @@
 
 // Test that a custom deref with a fat pointer return type does not ICE
 
-#![feature(associated_types)]
-
 use std::ops::Deref;
 
 pub struct Arr {

--- a/src/test/run-pass/dst-index.rs
+++ b/src/test/run-pass/dst-index.rs
@@ -11,8 +11,6 @@
 // Test that overloaded index expressions with DST result types
 // work and don't ICE.
 
-#![feature(associated_types)]
-
 use std::ops::Index;
 use std::fmt::Show;
 

--- a/src/test/run-pass/eq-multidispatch.rs
+++ b/src/test/run-pass/eq-multidispatch.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(default_type_params)]
-
 #[derive(PartialEq)]
 struct Bar;
 struct Baz;

--- a/src/test/run-pass/export-glob-imports-target.rs
+++ b/src/test/run-pass/export-glob-imports-target.rs
@@ -1,4 +1,3 @@
-
 // Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
@@ -13,8 +12,6 @@
 // when referenced within its own local scope.
 
 // Modified to not use export since it's going away. --pcw
-
-#![feature(globs)]
 
 mod foo {
     use foo::bar::*;

--- a/src/test/run-pass/fixup-deref-mut.rs
+++ b/src/test/run-pass/fixup-deref-mut.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::ops::{Deref, DerefMut};
 
 // Generic unique/owned smaht pointer.
@@ -55,4 +53,3 @@ fn test2(mut x: Own<Own<Own<Point>>>) {
 }
 
 fn main() {}
-

--- a/src/test/run-pass/generic-default-type-params-cross-crate.rs
+++ b/src/test/run-pass/generic-default-type-params-cross-crate.rs
@@ -10,8 +10,6 @@
 
 // aux-build:default_type_params_xc.rs
 
-#![feature(default_type_params)]
-
 extern crate default_type_params_xc;
 
 struct Vec<T, A = default_type_params_xc::Heap>;

--- a/src/test/run-pass/generic-default-type-params.rs
+++ b/src/test/run-pass/generic-default-type-params.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(default_type_params)]
-
 struct Foo<A = (int, char)> {
     a: A
 }

--- a/src/test/run-pass/import-glob-0.rs
+++ b/src/test/run-pass/import-glob-0.rs
@@ -1,4 +1,3 @@
-
 // Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
@@ -8,8 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
-#![feature(globs)]
 
 use module_of_many_things::*;
 use dug::too::greedily::and::too::deep::*;

--- a/src/test/run-pass/import-glob-crate.rs
+++ b/src/test/run-pass/import-glob-crate.rs
@@ -1,4 +1,3 @@
-
 // Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
@@ -9,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs)]
 #![allow(dead_assignment)]
 
 use std::mem::*;

--- a/src/test/run-pass/import-in-block.rs
+++ b/src/test/run-pass/import-in-block.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs)]
-
 pub fn main() {
     use std::mem::replace;
     let mut x = 5i;

--- a/src/test/run-pass/intrinsics-integer.rs
+++ b/src/test/run-pass/intrinsics-integer.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs, intrinsics)]
+#![feature(intrinsics)]
 
 mod rusti {
     extern "rust-intrinsic" {

--- a/src/test/run-pass/intrinsics-math.rs
+++ b/src/test/run-pass/intrinsics-math.rs
@@ -9,7 +9,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs, macro_rules, intrinsics)]
+#![feature(macro_rules, intrinsics)]
 
 macro_rules! assert_approx_eq(
     ($a:expr, $b:expr) => ({

--- a/src/test/run-pass/issue-11709.rs
+++ b/src/test/run-pass/issue-11709.rs
@@ -15,8 +15,6 @@
 // when this bug was opened. The cases where the compiler
 // panics before the fix have a comment.
 
-#![feature(default_type_params)]
-
 use std::thunk::Thunk;
 
 struct S {x:()}

--- a/src/test/run-pass/issue-13167.rs
+++ b/src/test/run-pass/issue-13167.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::slice;
 
 pub struct PhfMapEntries<'a, T: 'a> {

--- a/src/test/run-pass/issue-13264.rs
+++ b/src/test/run-pass/issue-13264.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::ops::Deref;
 
 struct Root {

--- a/src/test/run-pass/issue-14919.rs
+++ b/src/test/run-pass/issue-14919.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Matcher {
     fn next_match(&mut self) -> Option<(uint, uint)>;
 }

--- a/src/test/run-pass/issue-14933.rs
+++ b/src/test/run-pass/issue-14933.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(default_type_params)]
-
 pub type BigRat<T = int> = T;
 
 fn main() {}

--- a/src/test/run-pass/issue-15734.rs
+++ b/src/test/run-pass/issue-15734.rs
@@ -11,7 +11,7 @@
 // If `Index` used an associated type for its output, this test would
 // work more smoothly.
 
-#![feature(associated_types, old_orphan_check)]
+#![feature(old_orphan_check)]
 
 use std::ops::Index;
 

--- a/src/test/run-pass/issue-16596.rs
+++ b/src/test/run-pass/issue-16596.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait MatrixRow {}
 
 struct Mat;

--- a/src/test/run-pass/issue-16597.rs
+++ b/src/test/run-pass/issue-16597.rs
@@ -11,8 +11,6 @@
 // compile-flags:--test
 // ignore-pretty turns out the pretty-printer doesn't handle gensym'd things...
 
-#![feature(globs)]
-
 mod test {
     use super::*;
 

--- a/src/test/run-pass/issue-16774.rs
+++ b/src/test/run-pass/issue-16774.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types, unboxed_closures)]
+#![feature(unboxed_closures)]
 
 use std::ops::{Deref, DerefMut};
 

--- a/src/test/run-pass/issue-17732.rs
+++ b/src/test/run-pass/issue-17732.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
 trait Person {
     type string;
 }

--- a/src/test/run-pass/issue-17897.rs
+++ b/src/test/run-pass/issue-17897.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(default_type_params, unboxed_closures)]
+#![feature(unboxed_closures)]
 
 use std::thunk::Thunk;
 

--- a/src/test/run-pass/issue-18188.rs
+++ b/src/test/run-pass/issue-18188.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(default_type_params, unboxed_closures)]
+#![feature(unboxed_closures)]
 
 use std::thunk::Thunk;
 

--- a/src/test/run-pass/issue-19081.rs
+++ b/src/test/run-pass/issue-19081.rs
@@ -10,8 +10,6 @@
 
 // ignore-pretty -- FIXME(#17362) pretty prints as `Hash<<Self as Hasher...` which fails to parse
 
-#![feature(associated_types)]
-
 pub trait Hasher {
     type State;
 

--- a/src/test/run-pass/issue-19121.rs
+++ b/src/test/run-pass/issue-19121.rs
@@ -11,8 +11,6 @@
 // Test that a partially specified trait object with unspecified associated
 // type does not ICE.
 
-#![feature(associated_types)]
-
 trait Foo {
     type A;
 }

--- a/src/test/run-pass/issue-19129-1.rs
+++ b/src/test/run-pass/issue-19129-1.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Trait<Input> {
     type Output;
 

--- a/src/test/run-pass/issue-19129-2.rs
+++ b/src/test/run-pass/issue-19129-2.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Trait<Input> {
     type Output;
 

--- a/src/test/run-pass/issue-19479.rs
+++ b/src/test/run-pass/issue-19479.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
 trait Base {}
 trait AssocA {
     type X: Base;

--- a/src/test/run-pass/issue-19631.rs
+++ b/src/test/run-pass/issue-19631.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait PoolManager {
     type C;
 }

--- a/src/test/run-pass/issue-19632.rs
+++ b/src/test/run-pass/issue-19632.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait PoolManager {
     type C;
 }

--- a/src/test/run-pass/issue-19850.rs
+++ b/src/test/run-pass/issue-19850.rs
@@ -11,8 +11,6 @@
 // Test that `<Type as Trait>::Output` and `Self::Output` are accepted as type annotations in let
 // bindings
 
-#![feature(associated_types)]
-
 trait Int {
     fn one() -> Self;
     fn leading_zeros(self) -> uint;

--- a/src/test/run-pass/issue-20009.rs
+++ b/src/test/run-pass/issue-20009.rs
@@ -10,8 +10,6 @@
 
 // Check that associated types are `Sized`
 
-#![feature(associated_types)]
-
 trait Trait {
     type Output;
 

--- a/src/test/run-pass/issue-20389.rs
+++ b/src/test/run-pass/issue-20389.rs
@@ -10,7 +10,6 @@
 
 // aux-build:issue_20389.rs
 
-#![feature(associated_types)]
 extern crate issue_20389;
 
 struct Foo;

--- a/src/test/run-pass/issue-2526-a.rs
+++ b/src/test/run-pass/issue-2526-a.rs
@@ -10,7 +10,6 @@
 
 // aux-build:issue-2526.rs
 
-#![feature(globs)]
 #![allow(unused_imports)]
 
 extern crate issue_2526;

--- a/src/test/run-pass/issue-3609.rs
+++ b/src/test/run-pass/issue-3609.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(default_type_params)]
-
 use std::thread::Thread;
 use std::sync::mpsc::Sender;
 use std::thunk::Invoke;

--- a/src/test/run-pass/issue-3743.rs
+++ b/src/test/run-pass/issue-3743.rs
@@ -10,7 +10,7 @@
 
 // If `Mul` used an associated type for its output, this test would
 // work more smoothly.
-#![feature(default_type_params, old_orphan_check)]
+#![feature(old_orphan_check)]
 
 use std::ops::Mul;
 

--- a/src/test/run-pass/issue-3743.rs
+++ b/src/test/run-pass/issue-3743.rs
@@ -10,7 +10,7 @@
 
 // If `Mul` used an associated type for its output, this test would
 // work more smoothly.
-#![feature(associated_types, default_type_params, old_orphan_check)]
+#![feature(default_type_params, old_orphan_check)]
 
 use std::ops::Mul;
 

--- a/src/test/run-pass/issue-7663.rs
+++ b/src/test/run-pass/issue-7663.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs)]
 #![allow(unused_imports, dead_code)]
 
 mod test1 {

--- a/src/test/run-pass/namespaced-enum-emulate-flat.rs
+++ b/src/test/run-pass/namespaced-enum-emulate-flat.rs
@@ -7,7 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(globs)]
 
 pub use Foo::*;
 use nest::{Bar, D, E, F};

--- a/src/test/run-pass/namespaced-enum-glob-import-xcrate.rs
+++ b/src/test/run-pass/namespaced-enum-glob-import-xcrate.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 // aux-build:namespaced_enums.rs
-#![feature(globs)]
 
 extern crate namespaced_enums;
 

--- a/src/test/run-pass/namespaced-enum-glob-import.rs
+++ b/src/test/run-pass/namespaced-enum-glob-import.rs
@@ -7,7 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(globs)]
 
 mod m2 {
     pub enum Foo {

--- a/src/test/run-pass/operator-multidispatch.rs
+++ b/src/test/run-pass/operator-multidispatch.rs
@@ -11,7 +11,7 @@
 // Test that we can overload the `+` operator for points so that two
 // points can be added, and a point can be added to an integer.
 
-#![feature(associated_types, default_type_params)]
+#![feature(default_type_params)]
 
 use std::ops;
 

--- a/src/test/run-pass/operator-multidispatch.rs
+++ b/src/test/run-pass/operator-multidispatch.rs
@@ -11,8 +11,6 @@
 // Test that we can overload the `+` operator for points so that two
 // points can be added, and a point can be added to an integer.
 
-#![feature(default_type_params)]
-
 use std::ops;
 
 #[derive(Show,PartialEq,Eq)]

--- a/src/test/run-pass/operator-overloading.rs
+++ b/src/test/run-pass/operator-overloading.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::cmp;
 use std::ops;
 

--- a/src/test/run-pass/overloaded-autoderef-count.rs
+++ b/src/test/run-pass/overloaded-autoderef-count.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::cell::Cell;
 use std::ops::{Deref, DerefMut};
 

--- a/src/test/run-pass/overloaded-autoderef-indexing.rs
+++ b/src/test/run-pass/overloaded-autoderef-indexing.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::ops::Deref;
 
 struct DerefArray<'a, T:'a> {

--- a/src/test/run-pass/overloaded-autoderef-order.rs
+++ b/src/test/run-pass/overloaded-autoderef-order.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::rc::Rc;
 use std::ops::Deref;
 

--- a/src/test/run-pass/overloaded-autoderef-vtable.rs
+++ b/src/test/run-pass/overloaded-autoderef-vtable.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::ops::Deref;
 
 struct DerefWithHelper<H, T> {

--- a/src/test/run-pass/overloaded-calls-param-vtables.rs
+++ b/src/test/run-pass/overloaded-calls-param-vtables.rs
@@ -10,7 +10,7 @@
 
 // Tests that nested vtables work with overloaded calls.
 
-#![feature(default_type_params, unboxed_closures)]
+#![feature(unboxed_closures)]
 
 use std::ops::Fn;
 use std::ops::Add;
@@ -27,4 +27,3 @@ fn main() {
     // ICE trigger
     G(1i);
 }
-

--- a/src/test/run-pass/overloaded-deref-count.rs
+++ b/src/test/run-pass/overloaded-deref-count.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::cell::Cell;
 use std::ops::{Deref, DerefMut};
 use std::vec::Vec;

--- a/src/test/run-pass/overloaded-index-assoc-list.rs
+++ b/src/test/run-pass/overloaded-index-assoc-list.rs
@@ -11,8 +11,6 @@
 // Test overloading of the `[]` operator.  In particular test that it
 // takes its argument *by reference*.
 
-#![feature(associated_types)]
-
 use std::ops::Index;
 
 struct AssociationList<K,V> {

--- a/src/test/run-pass/overloaded-index-autoderef.rs
+++ b/src/test/run-pass/overloaded-index-autoderef.rs
@@ -10,8 +10,6 @@
 
 // Test overloaded indexing combined with autoderef.
 
-#![feature(associated_types)]
-
 use std::ops::{Index, IndexMut};
 
 struct Foo {
@@ -84,4 +82,3 @@ fn main() {
     assert_eq!(f[1].get(), 5);
     assert_eq!(f[1].get_from_ref(), 5);
 }
-

--- a/src/test/run-pass/overloaded-index-in-field.rs
+++ b/src/test/run-pass/overloaded-index-in-field.rs
@@ -11,8 +11,6 @@
 // Test using overloaded indexing when the "map" is stored in a
 // field. This caused problems at some point.
 
-#![feature(associated_types)]
-
 use std::ops::Index;
 
 struct Foo {
@@ -55,4 +53,3 @@ fn main() {
     } };
     assert_eq!(f.foo[1].get(), 2);
 }
-

--- a/src/test/run-pass/overloaded-index.rs
+++ b/src/test/run-pass/overloaded-index.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::ops::{Index, IndexMut};
 
 struct Foo {
@@ -75,4 +73,3 @@ fn main() {
     assert_eq!(f[1].get(), 5);
     assert_eq!(f[1].get_from_ref(), 5);
 }
-

--- a/src/test/run-pass/parse-assoc-type-lt.rs
+++ b/src/test/run-pass/parse-assoc-type-lt.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 trait Foo {
     type T;
     fn foo() -> Box<<Self as Foo>::T>;

--- a/src/test/run-pass/privacy-ns.rs
+++ b/src/test/run-pass/privacy-ns.rs
@@ -12,7 +12,6 @@
 // Check we do the correct privacy checks when we import a name and there is an
 // item with that name in both the value and type namespaces.
 
-#![feature(globs)]
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
@@ -115,4 +114,3 @@ fn test_glob3() {
 
 fn main() {
 }
-

--- a/src/test/run-pass/reexport-star.rs
+++ b/src/test/run-pass/reexport-star.rs
@@ -1,4 +1,3 @@
-
 // Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
@@ -9,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs)]
 
 mod a {
     pub fn f() {}

--- a/src/test/run-pass/regions-no-bound-in-argument-cleanup.rs
+++ b/src/test/run-pass/regions-no-bound-in-argument-cleanup.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types, unsafe_destructor)]
+#![feature(unsafe_destructor)]
 
 pub struct Foo<T>;
 

--- a/src/test/run-pass/simd-generics.rs
+++ b/src/test/run-pass/simd-generics.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-#![feature(associated_types, simd)]
+#![feature(simd)]
 
 use std::ops;
 

--- a/src/test/run-pass/tag-exports.rs
+++ b/src/test/run-pass/tag-exports.rs
@@ -1,4 +1,3 @@
-
 // Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
@@ -9,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(globs)]
 
 use alder::*;
 

--- a/src/test/run-pass/tcp-connect-timeouts.rs
+++ b/src/test/run-pass/tcp-connect-timeouts.rs
@@ -16,7 +16,7 @@
 // one test task to ensure that errors are timeouts, not file descriptor
 // exhaustion.
 
-#![feature(macro_rules, globs)]
+#![feature(macro_rules)]
 #![allow(experimental)]
 #![reexport_test_harness_main = "test_main"]
 

--- a/src/test/run-pass/trait-inheritance-overloading.rs
+++ b/src/test/run-pass/trait-inheritance-overloading.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(associated_types)]
-
 use std::cmp::PartialEq;
 use std::ops::{Add, Sub, Mul};
 


### PR DESCRIPTION
These aren't in their final form, but are all aiming to be part of 1.0, so at the very least encouraging usage now to find the bugs is nice.

Also, the widespread roll-out of associated types in the standard library indicates they're getting good, and it's lame to have to activate a feature in essentially every crate ever.
