### PR TITLE
Prohibit unused type parameters in impls.

### DIFF
--- a/src/libcollections/btree/node.rs
+++ b/src/libcollections/btree/node.rs
@@ -1417,7 +1417,7 @@ pub type MutTraversal<'a, K, V> = AbsTraversal<ElemsAndEdges<Zip<slice::Iter<'a,
 /// An owning traversal over a node's entries and edges
 pub type MoveTraversal<K, V> = AbsTraversal<MoveTraversalImpl<K, V>>;
 
-
+#[old_impl_check]
 impl<K, V, E, Impl: TraversalImpl<K, V, E>> Iterator for AbsTraversal<Impl> {
     type Item = TraversalItem<K, V, E>;
 
@@ -1433,6 +1433,7 @@ impl<K, V, E, Impl: TraversalImpl<K, V, E>> Iterator for AbsTraversal<Impl> {
     }
 }
 
+#[old_impl_check]
 impl<K, V, E, Impl: TraversalImpl<K, V, E>> DoubleEndedIterator for AbsTraversal<Impl> {
     fn next_back(&mut self) -> Option<TraversalItem<K, V, E>> {
         let tail_is_edge = self.tail_is_edge;

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -26,6 +26,7 @@
 #![feature(unsafe_destructor, slicing_syntax)]
 #![feature(unboxed_closures)]
 #![feature(old_orphan_check)]
+#![feature(old_impl_check)]
 #![feature(associated_types)]
 #![no_std]
 

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -28,6 +28,7 @@
 #![feature(rustc_diagnostic_macros)]
 #![feature(unboxed_closures)]
 #![feature(old_orphan_check)]
+#![feature(old_impl_check)]
 #![feature(associated_types)]
 
 extern crate arena;

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -669,6 +669,7 @@ impl LintPass for UnusedAttributes {
 
             // FIXME: #19470 this shouldn't be needed forever
             "old_orphan_check",
+            "old_impl_check",
         ];
 
         static CRATE_ATTRS: &'static [&'static str] = &[

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -1349,6 +1349,7 @@ impl<'tcx, T:Repr<'tcx>> Repr<'tcx> for ty::Binder<T> {
     }
 }
 
+#[old_impl_check]
 impl<'tcx, S, H, K, V> Repr<'tcx> for HashMap<K,V,H>
     where K : Hash<S> + Eq + Repr<'tcx>,
           V : Repr<'tcx>,

--- a/src/libserialize/collection_impls.rs
+++ b/src/libserialize/collection_impls.rs
@@ -156,6 +156,7 @@ impl<
     }
 }
 
+#[old_impl_check]
 impl<
     K: Encodable + Hash<X> + Eq,
     V: Encodable,
@@ -175,6 +176,7 @@ impl<
     }
 }
 
+#[old_impl_check]
 impl<
     K: Decodable + Hash<S> + Eq,
     V: Decodable,
@@ -195,6 +197,7 @@ impl<
     }
 }
 
+#[old_impl_check]
 impl<
     T: Encodable + Hash<X> + Eq,
     X,
@@ -212,6 +215,7 @@ impl<
     }
 }
 
+#[old_impl_check]
 impl<
     T: Decodable + Hash<S> + Eq,
     S,

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -26,6 +26,7 @@ Core encoding and decoding interfaces.
 #![feature(macro_rules, default_type_params, phase, slicing_syntax, globs)]
 #![feature(unboxed_closures)]
 #![feature(associated_types)]
+#![feature(old_impl_check)]
 
 // test harness access
 #[cfg(test)]

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -439,6 +439,7 @@ impl<K, V, M> SearchResult<K, V, M> {
     }
 }
 
+#[old_impl_check]
 impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     fn make_hash<X: ?Sized + Hash<S>>(&self, x: &X) -> SafeHash {
         table::make_hash(&self.hasher, x)
@@ -517,6 +518,7 @@ impl<K: Hash + Eq, V> HashMap<K, V, RandomSipHasher> {
     }
 }
 
+#[old_impl_check]
 impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> HashMap<K, V, H> {
     /// Creates an empty hashmap which will use the given hasher to hash keys.
     ///
@@ -1191,6 +1193,7 @@ fn search_entry_hashed<'a, K, V, Q: ?Sized>(table: &'a mut RawTable<K,V>, hash: 
 }
 
 #[stable]
+#[old_impl_check]
 impl<K: Eq + Hash<S>, V: PartialEq, S, H: Hasher<S>> PartialEq for HashMap<K, V, H> {
     fn eq(&self, other: &HashMap<K, V, H>) -> bool {
         if self.len() != other.len() { return false; }
@@ -1202,9 +1205,11 @@ impl<K: Eq + Hash<S>, V: PartialEq, S, H: Hasher<S>> PartialEq for HashMap<K, V,
 }
 
 #[stable]
+#[old_impl_check]
 impl<K: Eq + Hash<S>, V: Eq, S, H: Hasher<S>> Eq for HashMap<K, V, H> {}
 
 #[stable]
+#[old_impl_check]
 impl<K: Eq + Hash<S> + Show, V: Show, S, H: Hasher<S>> Show for HashMap<K, V, H> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "{{"));
@@ -1219,6 +1224,7 @@ impl<K: Eq + Hash<S> + Show, V: Show, S, H: Hasher<S>> Show for HashMap<K, V, H>
 }
 
 #[stable]
+#[old_impl_check]
 impl<K: Eq + Hash<S>, V, S, H: Hasher<S> + Default> Default for HashMap<K, V, H> {
     #[stable]
     fn default() -> HashMap<K, V, H> {
@@ -1227,6 +1233,7 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S> + Default> Default for HashMap<K, V, H>
 }
 
 #[stable]
+#[old_impl_check]
 impl<K: Hash<S> + Eq, Q: ?Sized, V, S, H: Hasher<S>> Index<Q> for HashMap<K, V, H>
     where Q: BorrowFrom<K> + Hash<S> + Eq
 {
@@ -1239,6 +1246,7 @@ impl<K: Hash<S> + Eq, Q: ?Sized, V, S, H: Hasher<S>> Index<Q> for HashMap<K, V, 
 }
 
 #[stable]
+#[old_impl_check]
 impl<K: Hash<S> + Eq, Q: ?Sized, V, S, H: Hasher<S>> IndexMut<Q> for HashMap<K, V, H>
     where Q: BorrowFrom<K> + Hash<S> + Eq
 {
@@ -1472,6 +1480,7 @@ impl<'a, Q: ?Sized + 'a + ToOwned<K>, K: 'a, V: 'a> VacantEntry<'a, Q, K, V> {
 }
 
 #[stable]
+#[old_impl_check]
 impl<K: Eq + Hash<S>, V, S, H: Hasher<S> + Default> FromIterator<(K, V)> for HashMap<K, V, H> {
     fn from_iter<T: Iterator<Item=(K, V)>>(iter: T) -> HashMap<K, V, H> {
         let lower = iter.size_hint().0;
@@ -1482,6 +1491,7 @@ impl<K: Eq + Hash<S>, V, S, H: Hasher<S> + Default> FromIterator<(K, V)> for Has
 }
 
 #[stable]
+#[old_impl_check]
 impl<K: Eq + Hash<S>, V, S, H: Hasher<S>> Extend<(K, V)> for HashMap<K, V, H> {
     fn extend<T: Iterator<Item=(K, V)>>(&mut self, mut iter: T) {
         for (k, v) in iter {

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -128,6 +128,7 @@ impl<T: Hash + Eq> HashSet<T, RandomSipHasher> {
     }
 }
 
+#[old_impl_check]
 impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
     /// Creates a new empty hash set which will use the given hasher to hash
     /// keys.
@@ -571,6 +572,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> HashSet<T, H> {
 }
 
 #[stable]
+#[old_impl_check]
 impl<T: Eq + Hash<S>, S, H: Hasher<S>> PartialEq for HashSet<T, H> {
     fn eq(&self, other: &HashSet<T, H>) -> bool {
         if self.len() != other.len() { return false; }
@@ -580,9 +582,11 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> PartialEq for HashSet<T, H> {
 }
 
 #[stable]
+#[old_impl_check]
 impl<T: Eq + Hash<S>, S, H: Hasher<S>> Eq for HashSet<T, H> {}
 
 #[stable]
+#[old_impl_check]
 impl<T: Eq + Hash<S> + fmt::Show, S, H: Hasher<S>> fmt::Show for HashSet<T, H> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "{{"));
@@ -597,6 +601,7 @@ impl<T: Eq + Hash<S> + fmt::Show, S, H: Hasher<S>> fmt::Show for HashSet<T, H> {
 }
 
 #[stable]
+#[old_impl_check]
 impl<T: Eq + Hash<S>, S, H: Hasher<S> + Default> FromIterator<T> for HashSet<T, H> {
     fn from_iter<I: Iterator<Item=T>>(iter: I) -> HashSet<T, H> {
         let lower = iter.size_hint().0;
@@ -607,6 +612,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S> + Default> FromIterator<T> for HashSet<T, 
 }
 
 #[stable]
+#[old_impl_check]
 impl<T: Eq + Hash<S>, S, H: Hasher<S>> Extend<T> for HashSet<T, H> {
     fn extend<I: Iterator<Item=T>>(&mut self, mut iter: I) {
         for k in iter {
@@ -616,6 +622,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S>> Extend<T> for HashSet<T, H> {
 }
 
 #[stable]
+#[old_impl_check]
 impl<T: Eq + Hash<S>, S, H: Hasher<S> + Default> Default for HashSet<T, H> {
     #[stable]
     fn default() -> HashSet<T, H> {
@@ -624,6 +631,7 @@ impl<T: Eq + Hash<S>, S, H: Hasher<S> + Default> Default for HashSet<T, H> {
 }
 
 #[stable]
+#[old_impl_check]
 impl<'a, 'b, T: Eq + Hash<S> + Clone, S, H: Hasher<S> + Default>
 BitOr<&'b HashSet<T, H>> for &'a HashSet<T, H> {
     type Output = HashSet<T, H>;
@@ -654,6 +662,7 @@ BitOr<&'b HashSet<T, H>> for &'a HashSet<T, H> {
 }
 
 #[stable]
+#[old_impl_check]
 impl<'a, 'b, T: Eq + Hash<S> + Clone, S, H: Hasher<S> + Default>
 BitAnd<&'b HashSet<T, H>> for &'a HashSet<T, H> {
     type Output = HashSet<T, H>;
@@ -684,6 +693,7 @@ BitAnd<&'b HashSet<T, H>> for &'a HashSet<T, H> {
 }
 
 #[stable]
+#[old_impl_check]
 impl<'a, 'b, T: Eq + Hash<S> + Clone, S, H: Hasher<S> + Default>
 BitXor<&'b HashSet<T, H>> for &'a HashSet<T, H> {
     type Output = HashSet<T, H>;
@@ -714,6 +724,7 @@ BitXor<&'b HashSet<T, H>> for &'a HashSet<T, H> {
 }
 
 #[stable]
+#[old_impl_check]
 impl<'a, 'b, T: Eq + Hash<S> + Clone, S, H: Hasher<S> + Default>
 Sub<&'b HashSet<T, H>> for &'a HashSet<T, H> {
     type Output = HashSet<T, H>;
@@ -816,6 +827,7 @@ impl<'a, K: 'a> Iterator for Drain<'a, K> {
 }
 
 #[stable]
+#[old_impl_check]
 impl<'a, T, S, H> Iterator for Intersection<'a, T, H>
     where T: Eq + Hash<S>, H: Hasher<S>
 {
@@ -839,6 +851,7 @@ impl<'a, T, S, H> Iterator for Intersection<'a, T, H>
 }
 
 #[stable]
+#[old_impl_check]
 impl<'a, T, S, H> Iterator for Difference<'a, T, H>
     where T: Eq + Hash<S>, H: Hasher<S>
 {
@@ -862,6 +875,7 @@ impl<'a, T, S, H> Iterator for Difference<'a, T, H>
 }
 
 #[stable]
+#[old_impl_check]
 impl<'a, T, S, H> Iterator for SymmetricDifference<'a, T, H>
     where T: Eq + Hash<S>, H: Hasher<S>
 {
@@ -872,6 +886,7 @@ impl<'a, T, S, H> Iterator for SymmetricDifference<'a, T, H>
 }
 
 #[stable]
+#[old_impl_check]
 impl<'a, T, S, H> Iterator for Union<'a, T, H>
     where T: Eq + Hash<S>, H: Hasher<S>
 {

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1604,6 +1604,7 @@ pub struct IncomingConnections<'a, A: ?Sized +'a> {
     inc: &'a mut A,
 }
 
+#[old_impl_check]
 impl<'a, T, A: ?Sized + Acceptor<T>> Iterator for IncomingConnections<'a, A> {
     type Item = IoResult<T>;
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -108,6 +108,7 @@
 #![feature(default_type_params, phase, lang_items, unsafe_destructor)]
 #![feature(slicing_syntax, unboxed_closures)]
 #![feature(old_orphan_check)]
+#![feature(old_impl_check)]
 #![feature(associated_types)]
 
 // Don't link to std. We are std.

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -982,8 +982,8 @@ pub enum Sign {
     Plus
 }
 
-impl<T> Sign where T: Int {
-    pub fn new(n: T) -> Sign {
+impl Sign {
+    pub fn new<T:Int>(n: T) -> Sign {
         if n < Int::zero() {
             Minus
         } else {

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -86,6 +86,9 @@ static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[
     // A way to temporarily opt out of the new orphan rules. This will *never* be accepted.
     ("old_orphan_check", Deprecated),
 
+    // A way to temporarily opt out of the new impl rules. This will *never* be accepted.
+    ("old_impl_check", Deprecated),
+
     // OIBIT specific features
     ("optin_builtin_traits", Active),
 
@@ -293,6 +296,13 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
                         "old_orphan_check",
                         i.span,
                         "the new orphan check rules will eventually be strictly enforced");
+                }
+
+                if attr::contains_name(i.attrs[],
+                                       "old_impl_check") {
+                    self.gate_feature("old_impl_check",
+                                      i.span,
+                                      "`#[old_impl_check]` will be removed in the future");
                 }
             }
 

--- a/src/test/auxiliary/nested_item.rs
+++ b/src/test/auxiliary/nested_item.rs
@@ -18,8 +18,8 @@ pub fn foo<T>() -> int {
 
 // issue 8134
 struct Foo;
-impl<T> Foo {
-    pub fn foo(&self) {
+impl Foo {
+    pub fn foo<T>(&self) {
         static X: uint = 1;
     }
 }
@@ -33,8 +33,8 @@ impl<T: std::iter::Iterator<Item=char>> Parser<T> {
 }
 
 struct Bar;
-impl<T> Foo {
-    pub fn bar(&self) {
+impl Foo {
+    pub fn bar<T>(&self) {
         static X: uint = 1;
     }
 }

--- a/src/test/compile-fail/coherence-all-remote.rs
+++ b/src/test/compile-fail/coherence-all-remote.rs
@@ -11,9 +11,9 @@
 // aux-build:coherence-lib.rs
 
 extern crate "coherence-lib" as lib;
-use lib::Remote;
+use lib::Remote1;
 
-impl<T> Remote for int { }
+impl<T> Remote1<T> for int { }
 //~^ ERROR E0117
 
 fn main() { }

--- a/src/test/compile-fail/impl-unused-tps-inherent.rs
+++ b/src/test/compile-fail/impl-unused-tps-inherent.rs
@@ -1,0 +1,35 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct MyType;
+
+struct MyType1<T>(T);
+
+trait Bar {
+    type Out;
+}
+
+impl<T> MyType {
+    //~^ ERROR  the type parameter `T` is not constrained
+}
+
+impl<T> MyType1<T> {
+    // OK, T is used in `Foo<T>`.
+}
+
+impl<T,U> MyType1<T> {
+    //~^ ERROR  the type parameter `U` is not constrained
+}
+
+impl<T,U> MyType1<T> where T: Bar<Out=U> {
+    // OK, T is used in `Foo<T>`.
+}
+
+fn main() { }

--- a/src/test/compile-fail/impl-unused-tps.rs
+++ b/src/test/compile-fail/impl-unused-tps.rs
@@ -1,0 +1,72 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo<A> {
+    fn get(&self, A: &A) { }
+}
+
+trait Bar {
+    type Out;
+}
+
+impl<T> Foo<T> for [int;0] {
+    // OK, T is used in `Foo<T>`.
+}
+
+impl<T,U> Foo<T> for [int;1] {
+    //~^ ERROR the type parameter `U` is not constrained
+}
+
+impl<T,U> Foo<T> for [int;2] where T : Bar<Out=U> {
+    // OK, `U` is now constrained by the output type parameter.
+}
+
+impl<T:Bar<Out=U>,U> Foo<T> for [int;3] {
+    // OK, same as above but written differently.
+}
+
+impl<T,U> Foo<T> for U {
+    // OK, T, U are used everywhere. Note that the coherence check
+    // hasn't executed yet, so no errors about overlap.
+}
+
+impl<T,U> Bar for T {
+    //~^ ERROR the type parameter `U` is not constrained
+
+    type Out = U;
+
+    // Using `U` in an associated type within the impl is not good enough!
+}
+
+impl<T,U> Bar for T
+    where T : Bar<Out=U>
+{
+    //~^^^ ERROR the type parameter `U` is not constrained
+
+    // This crafty self-referential attempt is still no good.
+}
+
+impl<T,U,V> Foo<T> for T
+    where (T,U): Bar<Out=V>
+{
+    //~^^^ ERROR the type parameter `U` is not constrained
+    //~|   ERROR the type parameter `V` is not constrained
+
+    // Here, `V` is bound by an output type parameter, but the inputs
+    // are not themselves constrained.
+}
+
+impl<T,U,V> Foo<(T,U)> for T
+    where (T,U): Bar<Out=V>
+{
+    // As above, but both T and U ARE constrained.
+}
+
+fn main() { }

--- a/src/test/compile-fail/issue-12028.rs
+++ b/src/test/compile-fail/issue-12028.rs
@@ -22,27 +22,28 @@ trait Stream {
     fn result(&self) -> u64;
 }
 
-trait StreamHasher<S: Stream> {
-    fn stream(&self) -> S;
+trait StreamHasher {
+    type S : Stream;
+    fn stream(&self) -> Self::S;
 }
 
 //////////////////////////////////////////////////////////////////////////////
 
-trait StreamHash<S: Stream, H: StreamHasher<S>>: Hash<H> {
-    fn input_stream(&self, stream: &mut S);
+trait StreamHash<H: StreamHasher>: Hash<H> {
+    fn input_stream(&self, stream: &mut H::S);
 }
 
-impl<S: Stream, H: StreamHasher<S>> Hash<H> for u8 {
+impl<H: StreamHasher> Hash<H> for u8 {
     fn hash2(&self, hasher: &H) -> u64 {
         let mut stream = hasher.stream();
         self.input_stream(&mut stream); //~ ERROR type annotations required
-        stream.result()
+        Stream::result(&stream)
     }
 }
 
-impl<S: Stream, H: StreamHasher<S>> StreamHash<S, H> for u8 {
-    fn input_stream(&self, stream: &mut S) {
-        stream.input(&[*self]);
+impl<H: StreamHasher> StreamHash<H> for u8 {
+    fn input_stream(&self, stream: &mut H::S) {
+        Stream::input(&*stream, &[*self]);
     }
 }
 

--- a/src/test/compile-fail/issue-13853-5.rs
+++ b/src/test/compile-fail/issue-13853-5.rs
@@ -15,7 +15,7 @@ trait Deserializable {
 }
 
 impl<'a, T: Deserializable> Deserializable for &'a str {
-    //~^ ERROR unable to infer enough type information
+    //~^ ERROR type parameter `T` is not constrained
     fn deserialize_token<D: Deserializer<'a>>(_x: D, _y: &'a str) -> &'a str {
     }
 }

--- a/src/test/compile-fail/issue-16562.rs
+++ b/src/test/compile-fail/issue-16562.rs
@@ -18,7 +18,7 @@ struct Col<D, C> {
 trait Collection { fn len(&self) -> uint; }
 
 impl<T, M: MatrixShape> Collection for Col<M, uint> {
-//~^ ERROR unable to infer enough type information
+//~^ ERROR type parameter `T` is not constrained
     fn len(&self) -> uint {
         unimplemented!()
     }

--- a/src/test/run-pass/issue-3743.rs
+++ b/src/test/run-pass/issue-3743.rs
@@ -30,17 +30,23 @@ impl Vec2 {
 }
 
 // Right-hand-side operator visitor pattern
-trait RhsOfVec2Mul<Result> { fn mul_vec2_by(&self, lhs: &Vec2) -> Result; }
+trait RhsOfVec2Mul {
+    type Result;
+
+    fn mul_vec2_by(&self, lhs: &Vec2) -> Self::Result;
+}
 
 // Vec2's implementation of Mul "from the other side" using the above trait
-impl<Res, Rhs: RhsOfVec2Mul<Res>> Mul<Rhs> for Vec2 {
+impl<Res, Rhs: RhsOfVec2Mul<Result=Res>> Mul<Rhs> for Vec2 {
     type Output = Res;
 
     fn mul(self, rhs: Rhs) -> Res { rhs.mul_vec2_by(&self) }
 }
 
 // Implementation of 'f64 as right-hand-side of Vec2::Mul'
-impl RhsOfVec2Mul<Vec2> for f64 {
+impl RhsOfVec2Mul for f64 {
+    type Result = Vec2;
+
     fn mul_vec2_by(&self, lhs: &Vec2) -> Vec2 { lhs.vmul(*self) }
 }
 


### PR DESCRIPTION
Per https://github.com/rust-lang/rfcs/pull/447 

r? @aturon 
