### PR TITLE
hash_map::OccupiedEntry::remove_entry

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1474,10 +1474,16 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
         value
     }
 
+    /// Takes the key and the value out of the entry, and returns it
+    #[unstable]
+    pub fn remove_entry(self) -> (K, V) {
+        pop_internal(self.elem)
+    }
+
     #[stable]
     /// Takes the value out of the entry, and returns it
     pub fn remove(self) -> V {
-        pop_internal(self.elem).1
+        self.remove_entry().1
     }
 }
 
@@ -2151,6 +2157,15 @@ mod test_map {
         assert_eq!(map.get(&3), None);
         assert_eq!(map.len(), 5);
 
+        // Existing key (take entry)
+        match map.entry(&4) {
+            Vacant(_) => unreachable!(),
+            Occupied(view) => {
+                assert_eq!(view.remove_entry(), (4, 40));
+            }
+        }
+        assert_eq!(map.get(&4), None);
+        assert_eq!(map.len(), 4);
 
         // Inexistent key (insert)
         match map.entry(&10) {
@@ -2160,7 +2175,7 @@ mod test_map {
             }
         }
         assert_eq!(map.get(&10).unwrap(), &1000);
-        assert_eq!(map.len(), 6);
+        assert_eq!(map.len(), 5);
     }
 
     #[test]


### PR DESCRIPTION
`remove_entry` is like to `remove`, but returns both key and value.

Sometimes key needs to be recovered, for example, when lookup key
is different from storage key.

P. S. `HashSet::remove(..)` is stable now, so it can't be changed to return contained value. What do you think about having another operation like `remove_value`. I don't need it personally, but it should probably exist for consistency and flexibility.

P. P. S. I need `remove_entry` operation to implement [LinkedHashSet](https://docs.oracle.com/javase/6/docs/api/java/util/LinkedHashSet.html) and [LinkedHashMap](https://docs.oracle.com/javase/6/docs/api/java/util/LinkedHashMap.html).
