### PR TITLE
Finalize story for libtest

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -52,7 +52,7 @@
 TARGET_CRATES := libc std flate arena term \
                  serialize getopts collections test rand \
                  log regex graphviz core rbml alloc \
-                 unicode
+                 unicode rustc_bench
 RUSTC_CRATES := rustc rustc_typeck rustc_borrowck rustc_resolve rustc_driver \
                 rustc_trans rustc_back rustc_llvm
 HOST_CRATES := syntax $(RUSTC_CRATES) rustdoc fmt_macros
@@ -90,11 +90,13 @@ DEPS_term := std log
 DEPS_getopts := std
 DEPS_collections := core alloc unicode
 DEPS_num := std
-DEPS_test := std getopts serialize rbml term regex native:rust_test_helpers
+DEPS_test := std getopts serialize rbml term regex native:rust_test_helpers \
+		rustc_bench
 DEPS_rand := core
 DEPS_log := std regex
 DEPS_regex := std
 DEPS_fmt_macros = std
+DEPS_rustc_bench := std
 
 TOOL_DEPS_compiletest := test getopts
 TOOL_DEPS_rustdoc := rustdoc

--- a/src/doc/guide-testing.md
+++ b/src/doc/guide-testing.md
@@ -1,7 +1,7 @@
 % The Rust Testing Guide
 
 > Program testing can be a very effective way to show the presence of bugs, but
-> it is hopelessly inadequate for showing their absence. 
+> it is hopelessly inadequate for showing their absence.
 >
 > Edsger W. Dijkstra, "The Humble Programmer" (1972)
 
@@ -310,7 +310,7 @@ extern crate adder;
 #[test]
 fn it_works() {
     assert_eq(4, adder::add_two(2));
-}   
+}
 ```
 
 This looks similar to our previous tests, but slightly different. We now have
@@ -442,7 +442,7 @@ code. Let's make our `src/lib.rs` look like this (comments elided):
 ```{rust,ignore}
 #![feature(globs)]
 
-extern crate test;
+extern crate rustc_bench;
 
 pub fn add_two(a: i32) -> i32 {
     a + 2
@@ -451,7 +451,7 @@ pub fn add_two(a: i32) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use test::Bencher;
+    use rustc_bench::Bencher;
 
     #[test]
     fn it_works() {
@@ -512,8 +512,8 @@ compiler might recognize that some calculation has no external effects and
 remove it entirely.
 
 ```{rust,ignore}
-extern crate test;
-use test::Bencher;
+extern crate rustc_bench;
+use rustc_bench::Bencher;
 
 #[bench]
 fn bench_xor_1000_ints(b: &mut Bencher) {
@@ -547,20 +547,19 @@ b.iter(|| {
 });
 ```
 
-Or, the other option is to call the generic `test::black_box` function, which
-is an opaque "black box" to the optimizer and so forces it to consider any
-argument as used.
+Or, the other option is to call the generic `rustc_bench::black_box` function,
+which is an opaque "black box" to the optimizer and so forces it to consider
+any argument as used.
 
 ```rust
-extern crate test;
-
+extern crate rustc_bench;
 # fn main() {
 # struct X;
 # impl X { fn iter<T, F>(&self, _: F) where F: FnMut() -> T {} } let b = X;
 b.iter(|| {
     let mut n = 1000_u32;
 
-    test::black_box(&mut n); // pretend to modify `n`
+    rustc_bench::black_box(&mut n); // pretend to modify `n`
 
     range(0, n).fold(0, |a, b| a ^ b)
 })

--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -370,8 +370,8 @@ mod imp {
 
 #[cfg(test)]
 mod test {
-    extern crate test;
-    use self::test::Bencher;
+    extern crate rustc_bench;
+    use self::rustc_bench::Bencher;
     use core::ptr::PtrExt;
     use heap;
 

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -507,8 +507,8 @@ impl<T> Drop for TypedArena<T> {
 
 #[cfg(test)]
 mod tests {
-    extern crate test;
-    use self::test::Bencher;
+    extern crate rustc_bench;
+    use self::rustc_bench::Bencher;
     use super::{Arena, TypedArena};
 
     #[allow(dead_code)]

--- a/src/libcollections/bench.rs
+++ b/src/libcollections/bench.rs
@@ -11,7 +11,7 @@
 use prelude::*;
 use std::rand;
 use std::rand::Rng;
-use test::{Bencher, black_box};
+use rustc_bench::{Bencher, black_box};
 
 pub fn insert_rand_n<M, I, R>(n: uint,
                               map: &mut M,

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -2507,7 +2507,7 @@ mod bitv_bench {
     use std::rand;
     use std::rand::Rng;
     use std::u32;
-    use test::{Bencher, black_box};
+    use rustc_bench::{Bencher, black_box};
 
     use super::Bitv;
 
@@ -2526,7 +2526,7 @@ mod bitv_bench {
             for _ in range(0u, 100) {
                 bitv |= 1 << ((r.next_u32() as uint) % u32::BITS);
             }
-            black_box(&bitv)
+            black_box(&bitv);
         });
     }
 
@@ -2538,7 +2538,7 @@ mod bitv_bench {
             for _ in range(0u, 100) {
                 bitv.set((r.next_u32() as uint) % BENCH_BITS, true);
             }
-            black_box(&bitv)
+            black_box(&bitv);
         });
     }
 
@@ -3002,7 +3002,7 @@ mod bitv_set_bench {
     use std::rand;
     use std::rand::Rng;
     use std::u32;
-    use test::{Bencher, black_box};
+    use rustc_bench::{Bencher, black_box};
 
     use super::{Bitv, BitvSet};
 

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -1614,7 +1614,7 @@ mod test {
 mod bench {
     use prelude::*;
     use std::rand::{weak_rng, Rng};
-    use test::{Bencher, black_box};
+    use rustc_bench::{Bencher, black_box};
 
     use super::BTreeMap;
     use bench::{insert_rand_n, insert_seq_n, find_rand_n, find_seq_n};

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -690,8 +690,7 @@ mod tests {
     use std::rand;
     use std::hash;
     use std::thread::Thread;
-    use test::Bencher;
-    use test;
+    use rustc_bench::Bencher;
 
     use super::{DList, Node};
 
@@ -1101,7 +1100,7 @@ mod tests {
     }
 
     #[bench]
-    fn bench_collect_into(b: &mut test::Bencher) {
+    fn bench_collect_into(b: &mut Bencher) {
         let v = &[0i; 64];
         b.iter(|| {
             let _: DList<int> = v.iter().map(|x| *x).collect();
@@ -1109,7 +1108,7 @@ mod tests {
     }
 
     #[bench]
-    fn bench_push_front(b: &mut test::Bencher) {
+    fn bench_push_front(b: &mut Bencher) {
         let mut m: DList<int> = DList::new();
         b.iter(|| {
             m.push_front(0);
@@ -1117,7 +1116,7 @@ mod tests {
     }
 
     #[bench]
-    fn bench_push_back(b: &mut test::Bencher) {
+    fn bench_push_back(b: &mut Bencher) {
         let mut m: DList<int> = DList::new();
         b.iter(|| {
             m.push_back(0);
@@ -1125,7 +1124,7 @@ mod tests {
     }
 
     #[bench]
-    fn bench_push_back_pop_back(b: &mut test::Bencher) {
+    fn bench_push_back_pop_back(b: &mut Bencher) {
         let mut m: DList<int> = DList::new();
         b.iter(|| {
             m.push_back(0);
@@ -1134,7 +1133,7 @@ mod tests {
     }
 
     #[bench]
-    fn bench_push_front_pop_front(b: &mut test::Bencher) {
+    fn bench_push_front_pop_front(b: &mut Bencher) {
         let mut m: DList<int> = DList::new();
         b.iter(|| {
             m.push_front(0);
@@ -1143,7 +1142,7 @@ mod tests {
     }
 
     #[bench]
-    fn bench_iter(b: &mut test::Bencher) {
+    fn bench_iter(b: &mut Bencher) {
         let v = &[0i; 128];
         let m: DList<int> = v.iter().map(|&x|x).collect();
         b.iter(|| {
@@ -1151,7 +1150,7 @@ mod tests {
         })
     }
     #[bench]
-    fn bench_iter_mut(b: &mut test::Bencher) {
+    fn bench_iter_mut(b: &mut Bencher) {
         let v = &[0i; 128];
         let mut m: DList<int> = v.iter().map(|&x|x).collect();
         b.iter(|| {
@@ -1159,7 +1158,7 @@ mod tests {
         })
     }
     #[bench]
-    fn bench_iter_rev(b: &mut test::Bencher) {
+    fn bench_iter_rev(b: &mut Bencher) {
         let v = &[0i; 128];
         let m: DList<int> = v.iter().map(|&x|x).collect();
         b.iter(|| {
@@ -1167,7 +1166,7 @@ mod tests {
         })
     }
     #[bench]
-    fn bench_iter_mut_rev(b: &mut test::Bencher) {
+    fn bench_iter_mut_rev(b: &mut Bencher) {
         let v = &[0i; 128];
         let mut m: DList<int> = v.iter().map(|&x|x).collect();
         b.iter(|| {

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -33,7 +33,7 @@ extern crate core;
 extern crate unicode;
 extern crate alloc;
 
-#[cfg(test)] extern crate test;
+#[cfg(test)] extern crate rustc_bench;
 #[cfg(test)] #[macro_use] extern crate std;
 #[cfg(test)] #[macro_use] extern crate log;
 

--- a/src/libcollections/ring_buf.rs
+++ b/src/libcollections/ring_buf.rs
@@ -1632,8 +1632,7 @@ mod tests {
     use core::iter;
     use std::fmt::Show;
     use std::hash;
-    use test::Bencher;
-    use test;
+    use rustc_bench::{Bencher, black_box};
 
     use super::RingBuf;
 
@@ -1750,15 +1749,15 @@ mod tests {
     }
 
     #[bench]
-    fn bench_new(b: &mut test::Bencher) {
+    fn bench_new(b: &mut Bencher) {
         b.iter(|| {
             let ring: RingBuf<u64> = RingBuf::new();
-            test::black_box(ring);
+            black_box(ring);
         })
     }
 
     #[bench]
-    fn bench_push_back_100(b: &mut test::Bencher) {
+    fn bench_push_back_100(b: &mut Bencher) {
         let mut deq = RingBuf::with_capacity(101);
         b.iter(|| {
             for i in range(0i, 100) {
@@ -1770,7 +1769,7 @@ mod tests {
     }
 
     #[bench]
-    fn bench_push_front_100(b: &mut test::Bencher) {
+    fn bench_push_front_100(b: &mut Bencher) {
         let mut deq = RingBuf::with_capacity(101);
         b.iter(|| {
             for i in range(0i, 100) {
@@ -1782,44 +1781,44 @@ mod tests {
     }
 
     #[bench]
-    fn bench_pop_back_100(b: &mut test::Bencher) {
+    fn bench_pop_back_100(b: &mut Bencher) {
         let mut deq: RingBuf<int> = RingBuf::with_capacity(101);
 
         b.iter(|| {
             deq.head = 100;
             deq.tail = 0;
             while !deq.is_empty() {
-                test::black_box(deq.pop_back());
+                black_box(deq.pop_back());
             }
         })
     }
 
     #[bench]
-    fn bench_pop_front_100(b: &mut test::Bencher) {
+    fn bench_pop_front_100(b: &mut Bencher) {
         let mut deq: RingBuf<int> = RingBuf::with_capacity(101);
 
         b.iter(|| {
             deq.head = 100;
             deq.tail = 0;
             while !deq.is_empty() {
-                test::black_box(deq.pop_front());
+                black_box(deq.pop_front());
             }
         })
     }
 
     #[bench]
-    fn bench_grow_1025(b: &mut test::Bencher) {
+    fn bench_grow_1025(b: &mut Bencher) {
         b.iter(|| {
             let mut deq = RingBuf::new();
             for i in range(0i, 1025) {
                 deq.push_front(i);
             }
-            test::black_box(deq);
+            black_box(deq);
         })
     }
 
     #[bench]
-    fn bench_iter_1000(b: &mut test::Bencher) {
+    fn bench_iter_1000(b: &mut Bencher) {
         let ring: RingBuf<int> = range(0i, 1000).collect();
 
         b.iter(|| {
@@ -1827,12 +1826,12 @@ mod tests {
             for &i in ring.iter() {
                 sum += i;
             }
-            test::black_box(sum);
+            black_box(sum);
         })
     }
 
     #[bench]
-    fn bench_mut_iter_1000(b: &mut test::Bencher) {
+    fn bench_mut_iter_1000(b: &mut Bencher) {
         let mut ring: RingBuf<int> = range(0i, 1000).collect();
 
         b.iter(|| {
@@ -1840,7 +1839,7 @@ mod tests {
             for i in ring.iter_mut() {
                 sum += *i;
             }
-            test::black_box(sum);
+            black_box(sum);
         })
     }
 

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -2730,7 +2730,7 @@ mod bench {
     use core::ptr;
     use core::iter::repeat;
     use std::rand::{weak_rng, Rng};
-    use test::{Bencher, black_box};
+    use rustc_bench::{Bencher, black_box};
 
     #[bench]
     fn iterator(b: &mut Bencher) {

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -2826,8 +2826,7 @@ mod tests {
 mod bench {
     use super::*;
     use prelude::{SliceExt, IteratorExt, SliceConcatExt};
-    use test::Bencher;
-    use test::black_box;
+    use rustc_bench::{Bencher, black_box};
 
     #[bench]
     fn char_iterator(b: &mut Bencher) {
@@ -2841,7 +2840,7 @@ mod bench {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
 
         b.iter(|| {
-            for ch in s.chars() { black_box(ch) }
+            for ch in s.chars() { black_box(ch); }
         });
     }
 
@@ -2869,7 +2868,7 @@ mod bench {
         let s = "ศไทย中华Việt Nam; Mary had a little lamb, Little lamb";
 
         b.iter(|| {
-            for ch in s.chars().rev() { black_box(ch) }
+            for ch in s.chars().rev() { black_box(ch); }
         });
     }
 

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -976,7 +976,7 @@ impl fmt::Writer for String {
 #[cfg(test)]
 mod tests {
     use prelude::*;
-    use test::Bencher;
+    use rustc_bench::Bencher;
 
     use str::Utf8Error;
     use core::iter::repeat;

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1816,7 +1816,7 @@ mod tests {
     use core::mem::size_of;
     use core::iter::repeat;
     use core::ops::FullRange;
-    use test::Bencher;
+    use rustc_bench::Bencher;
     use super::as_vec;
 
     struct DropCounter<'a> {

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -1058,7 +1058,7 @@ mod test_map {
 
 #[cfg(test)]
 mod bench {
-    use test::Bencher;
+    use rustc_bench::Bencher;
     use super::VecMap;
     use bench::{insert_rand_n, insert_seq_n, find_rand_n, find_seq_n};
 

--- a/src/libcore/hash/sip.rs
+++ b/src/libcore/hash/sip.rs
@@ -271,7 +271,7 @@ pub fn hash_with_keys<T: ?Sized + Hash<SipState>>(k0: u64, k1: u64, value: &T) -
 
 #[cfg(test)]
 mod tests {
-    use test::Bencher;
+    use rustc_bench::Bencher;
     use prelude::*;
     use std::fmt;
 

--- a/src/libcoretest/any.rs
+++ b/src/libcoretest/any.rs
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 use core::any::*;
-use test::Bencher;
-use test;
+use rustc_bench::{Bencher, black_box};
 
 #[derive(PartialEq, Show)]
 struct Test;
@@ -125,7 +124,7 @@ fn bench_downcast_ref(b: &mut Bencher) {
     b.iter(|| {
         let mut x = 0i;
         let mut y = &mut x as &mut Any;
-        test::black_box(&mut y);
-        test::black_box(y.downcast_ref::<int>() == Some(&0));
+        black_box(&mut y);
+        black_box(y.downcast_ref::<int>() == Some(&0));
     });
 }

--- a/src/libcoretest/fmt/num.rs
+++ b/src/libcoretest/fmt/num.rs
@@ -167,7 +167,7 @@ fn test_radix_base_too_large() {
 }
 
 mod uint {
-    use test::Bencher;
+    use rustc_bench::Bencher;
     use core::fmt::radix;
     use std::rand::{weak_rng, Rng};
 
@@ -209,7 +209,7 @@ mod uint {
 }
 
 mod int {
-    use test::Bencher;
+    use rustc_bench::Bencher;
     use core::fmt::radix;
     use std::rand::{weak_rng, Rng};
 

--- a/src/libcoretest/hash/sip.rs
+++ b/src/libcoretest/hash/sip.rs
@@ -7,7 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use test::Bencher;
+use rustc_bench::Bencher;
 use std::prelude::*;
 use std::fmt;
 

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -15,7 +15,7 @@ use core::num::SignedInt;
 use core::uint;
 use core::cmp;
 
-use test::Bencher;
+use rustc_bench::Bencher;
 
 #[test]
 fn test_lt() {

--- a/src/libcoretest/lib.rs
+++ b/src/libcoretest/lib.rs
@@ -11,7 +11,7 @@
 #![feature(unboxed_closures)]
 
 extern crate core;
-extern crate test;
+extern crate rustc_bench;
 extern crate libc;
 extern crate unicode;
 

--- a/src/libcoretest/mem.rs
+++ b/src/libcoretest/mem.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 use core::mem::*;
-use test::Bencher;
+use rustc_bench::Bencher;
 
 #[test]
 fn size_of_basic() {

--- a/src/libcoretest/ops.rs
+++ b/src/libcoretest/ops.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use test::Bencher;
+use rustc_bench::Bencher;
 use core::ops::{Range, FullRange, RangeFrom, RangeTo};
 
 // Overhead of dtors

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -80,7 +80,6 @@
 extern crate core;
 
 #[cfg(test)] extern crate std;
-#[cfg(test)] extern crate test;
 
 pub use self::Nullable::*;
 

--- a/src/librand/distributions/exponential.rs
+++ b/src/librand/distributions/exponential.rs
@@ -122,11 +122,11 @@ mod test {
 
 #[cfg(test)]
 mod bench {
-    extern crate test;
+    extern crate rustc_bench;
 
     use std::prelude::v1::*;
 
-    use self::test::Bencher;
+    use self::rustc_bench::Bencher;
     use std::mem::size_of;
     use super::Exp;
     use distributions::Sample;

--- a/src/librand/distributions/gamma.rs
+++ b/src/librand/distributions/gamma.rs
@@ -384,9 +384,8 @@ mod test {
 
 #[cfg(test)]
 mod bench {
-    extern crate test;
     use std::prelude::v1::*;
-    use self::test::Bencher;
+    use rustc_bench::Bencher;
     use std::mem::size_of;
     use distributions::IndependentSample;
     use super::Gamma;

--- a/src/librand/distributions/normal.rs
+++ b/src/librand/distributions/normal.rs
@@ -199,9 +199,8 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
-    extern crate test;
     use std::prelude::v1::*;
-    use self::test::Bencher;
+    use rustc_bench::Bencher;
     use std::mem::size_of;
     use distributions::{Sample};
     use super::Normal;

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -32,6 +32,8 @@ extern crate core;
 #[cfg(test)] #[macro_use] extern crate std;
 #[cfg(test)] #[macro_use] extern crate log;
 
+#[cfg(test)] extern crate rustc_bench;
+
 use core::prelude::*;
 
 pub use isaac::{IsaacRng, Isaac64Rng};

--- a/src/librbml/io.rs
+++ b/src/librbml/io.rs
@@ -130,11 +130,10 @@ impl Seek for SeekableMemWriter {
 
 #[cfg(test)]
 mod tests {
-    extern crate test;
     use super::SeekableMemWriter;
     use std::io;
     use std::iter::repeat;
-    use test::Bencher;
+    use rustc_bench::Bencher;
 
     #[test]
     fn test_seekable_mem_writer() {

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -29,7 +29,7 @@
 extern crate serialize;
 #[macro_use] extern crate log;
 
-#[cfg(test)] extern crate test;
+#[cfg(test)] extern crate rustc_bench;
 
 pub use self::EbmlEncoderTag::*;
 pub use self::Error::*;
@@ -1161,7 +1161,7 @@ mod tests {
 #[cfg(test)]
 mod bench {
     #![allow(non_snake_case)]
-    use test::Bencher;
+    use rustc_bench::Bencher;
     use super::reader;
 
     #[bench]

--- a/src/libregex/lib.rs
+++ b/src/libregex/lib.rs
@@ -27,7 +27,7 @@
 #![deny(missing_docs)]
 
 #[cfg(test)]
-extern crate "test" as stdtest;
+extern crate rustc_bench;
 #[cfg(test)]
 extern crate rand;
 

--- a/src/libregex/test/bench.rs
+++ b/src/libregex/test/bench.rs
@@ -10,7 +10,7 @@
 #![allow(non_snake_case)]
 
 use std::rand::{Rng, thread_rng};
-use stdtest::Bencher;
+use rustc_bench::Bencher;
 use std::iter::repeat;
 
 use regex::{Regex, NoExpand};

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -44,7 +44,7 @@ extern crate collections;
 extern crate "serialize" as rustc_serialize; // used by deriving
 
 #[cfg(test)]
-extern crate test;
+extern crate rustc_bench;
 
 pub use rustc_llvm as llvm;
 

--- a/src/librustc_back/sha2.rs
+++ b/src/librustc_back/sha2.rs
@@ -651,8 +651,8 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
-    extern crate test;
-    use self::test::Bencher;
+    extern crate rustc_bench;
+    use self::rustc_bench::Bencher;
     use super::{Sha256, FixedBuffer, Digest};
 
     #[bench]

--- a/src/librustc_bench/lib.rs
+++ b/src/librustc_bench/lib.rs
@@ -1,0 +1,86 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Support code for rustc's built in micro-benchmarking framework.
+//!
+//! See the [Testing Guide](../guide-testing.html) for more details.
+
+#![crate_name = "rustc_bench"]
+#![unstable]
+#![crate_type = "rlib"]
+#![crate_type = "dylib"]
+#![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
+       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
+       html_root_url = "http://doc.rust-lang.org/nightly/")]
+#![feature(asm)]
+
+use std::time::Duration;
+
+/// A function that is opaque to the optimizer, to allow benchmarks to
+/// pretend to use outputs to assist in avoiding dead-code
+/// elimination.
+///
+/// This function is a no-op, and does not even read from `dummy`.
+#[stable]
+pub fn black_box<T>(dummy: T) -> T {
+    // we need to "use" the argument in some way LLVM can't
+    // introspect.
+    unsafe {asm!("" : : "r"(&dummy))}
+    dummy
+}
+
+/// Manager of the benchmarking runs.
+///
+/// This is feed into functions marked with `#[bench]` to allow for
+/// set-up & tear-down before running a piece of code repeatedly via a
+/// call to `iter`.
+#[stable]
+#[allow(missing_copy_implementations)]
+pub struct Bencher {
+    iterations: u64,
+    dur: Duration,
+
+    /// A field to indicate the number of bytes that each iteration of the
+    /// benchmarking procedure consumed. When set to a nonzero value, the speed
+    /// of consumption can be printed in MB/s
+    #[stable]
+    pub bytes: u64,
+}
+
+impl Bencher {
+    #[experimental]
+    pub fn new() -> Bencher {
+        Bencher {
+            iterations: 0,
+            dur: Duration::seconds(0),
+            bytes: 0,
+        }
+    }
+
+    /// Callback for benchmark functions to run in their body.
+    #[stable]
+    pub fn iter<T, F>(&mut self, mut inner: F) where F: FnMut() -> T {
+        self.dur = Duration::span(|| {
+            let k = self.iterations;
+            for _ in range(0u64, k) {
+                black_box(inner());
+            }
+        });
+    }
+
+    #[experimental]
+    pub fn set_iterations(&mut self, n: u64) { self.iterations = n; }
+
+    #[experimental]
+    pub fn iterations(&self) -> u64 { self.iterations }
+
+    #[experimental]
+    pub fn dur(&self) -> Duration { self.dur }
+}

--- a/src/libserialize/base64.rs
+++ b/src/libserialize/base64.rs
@@ -297,8 +297,8 @@ impl FromBase64 for [u8] {
 
 #[cfg(test)]
 mod tests {
-    extern crate test;
-    use self::test::Bencher;
+    extern crate rustc_bench;
+    use self::rustc_bench::Bencher;
     use base64::{Config, Newline, FromBase64, ToBase64, STANDARD, URL_SAFE};
 
     #[test]

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -153,8 +153,8 @@ impl FromHex for str {
 
 #[cfg(test)]
 mod tests {
-    extern crate test;
-    use self::test::Bencher;
+    extern crate rustc_bench;
+    use self::rustc_bench::Bencher;
     use hex::{FromHex, ToHex};
 
     #[test]

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -2504,10 +2504,10 @@ impl FromStr for Json {
 
 #[cfg(test)]
 mod tests {
-    extern crate test;
+    extern crate rustc_bench;
     use self::Animal::*;
     use self::DecodeEnum::*;
-    use self::test::Bencher;
+    use self::rustc_bench::Bencher;
     use {Encodable, Decodable};
     use super::Json::*;
     use super::ErrorCode::*;

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -28,7 +28,7 @@ Core encoding and decoding interfaces.
 #![cfg_attr(stage0, allow(unused_attributes))]
 
 // test harness access
-#[cfg(test)] extern crate test;
+#[cfg(test)] extern crate rustc_bench;
 #[macro_use] extern crate log;
 
 extern crate unicode;

--- a/src/libstd/collections/hash/bench.rs
+++ b/src/libstd/collections/hash/bench.rs
@@ -10,10 +10,9 @@
 
 #![cfg(test)]
 
-extern crate test;
 use prelude::v1::*;
 
-use self::test::Bencher;
+use rustc_bench::Bencher;
 use iter::{range_inclusive};
 
 #[bench]

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -386,13 +386,12 @@ impl<S: Stream> Writer for BufferedStream<S> {
 
 #[cfg(test)]
 mod test {
-    extern crate test;
     use io;
     use prelude::v1::*;
     use super::*;
     use super::super::{IoResult, EndOfFile};
     use super::super::mem::MemReader;
-    use self::test::Bencher;
+    use rustc_bench::Bencher;
 
     /// A type, free to create, primarily intended for benchmarking creation of
     /// wrappers that, just for construction, don't need a Reader/Writer that

--- a/src/libstd/io/extensions.rs
+++ b/src/libstd/io/extensions.rs
@@ -507,10 +507,8 @@ mod test {
 
 #[cfg(test)]
 mod bench {
-    extern crate test;
-
     use prelude::v1::*;
-    use self::test::Bencher;
+    use rustc_bench::Bencher;
 
     // why is this a macro? wouldn't an inlined function work just as well?
     macro_rules! u64_from_be_bytes_bench_impl {

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -390,13 +390,12 @@ impl<'a> Buffer for BufReader<'a> {
 
 #[cfg(test)]
 mod test {
-    extern crate "test" as test_crate;
-    use io::{SeekSet, SeekCur, SeekEnd, Reader, Writer, Seek};
-    use prelude::v1::{Ok, Err, range,  Vec, Buffer,  AsSlice, SliceExt};
-    use prelude::v1::{IteratorExt, Index};
+    use prelude::v1::*;
+
+    use io::{SeekSet, SeekCur, SeekEnd};
     use io;
     use iter::repeat;
-    use self::test_crate::Bencher;
+    use rustc_bench::Bencher;
     use super::*;
 
     #[test]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -115,9 +115,8 @@
 
 #![deny(missing_docs)]
 
-#[cfg(test)]
-#[macro_use]
-extern crate log;
+#[cfg(test)] extern crate rustc_bench;
+#[cfg(test)] #[macro_use] extern crate log;
 
 #[macro_use]
 #[macro_reexport(assert, assert_eq, debug_assert, debug_assert_eq,

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -990,8 +990,7 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
-    extern crate test;
-    use self::test::Bencher;
+    use rustc_bench::Bencher;
     use num::Int;
     use prelude::v1::*;
 

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -459,10 +459,8 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
-    extern crate test;
-
     mod uint {
-        use super::test::Bencher;
+        use rustc_bench::Bencher;
         use rand::{weak_rng, Rng};
         use std::fmt;
 
@@ -503,7 +501,7 @@ mod bench {
     }
 
     mod int {
-        use super::test::Bencher;
+        use rustc_bench::Bencher;
         use rand::{weak_rng, Rng};
         use std::fmt;
 
@@ -544,7 +542,7 @@ mod bench {
     }
 
     mod f64 {
-        use super::test::Bencher;
+        use rustc_bench::Bencher;
         use rand::{weak_rng, Rng};
         use f64;
 

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -1211,8 +1211,7 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
-    extern crate test;
-    use self::test::Bencher;
+    use rustc_bench::Bencher;
     use super::*;
     use prelude::v1::{Clone, GenericPath};
 

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -615,10 +615,9 @@ static RAND_BENCH_N: u64 = 100;
 
 #[cfg(test)]
 mod bench {
-    extern crate test;
     use prelude::v1::*;
 
-    use self::test::Bencher;
+    use rustc_bench::Bencher;
     use super::{XorShiftRng, StdRng, IsaacRng, Isaac64Rng, Rng, RAND_BENCH_N};
     use super::{OsRng, weak_rng};
     use mem::size_of;

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -1057,7 +1057,7 @@ mod tests {
 
 #[cfg(test)]
 mod bench {
-    use Bencher;
+    use rustc_bench::Bencher;
     use stats::Stats;
 
     #[bench]

--- a/src/test/compile-fail/view-items-at-top.rs
+++ b/src/test/compile-fail/view-items-at-top.rs
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate test;
+extern crate rustc_bench;
 
 fn f() {
 }
 
-use test::net;    //~ ERROR `use` and `extern crate` declarations must precede items
+use rustc_bench::net;    //~ ERROR `use` and `extern crate` declarations must precede items
 
 fn main() {
 }

--- a/src/test/run-pass/attr-before-view-item.rs
+++ b/src/test/run-pass/attr-before-view-item.rs
@@ -11,7 +11,7 @@
 // error-pattern:expected item
 
 #[foo = "bar"]
-extern crate test;
+extern crate "std" as std2;
 
 pub fn main() {
 }

--- a/src/test/run-pass/attr-before-view-item2.rs
+++ b/src/test/run-pass/attr-before-view-item2.rs
@@ -12,7 +12,7 @@
 
 mod m {
     #[foo = "bar"]
-    extern crate test;
+    extern crate std;
 }
 
 pub fn main() {


### PR DESCRIPTION
One of the last remaining crates to have a stabilization story in the standard
distribution is the libtest library. This library currently provides the backing
infrastructure and test harness used when rustc generates a test execuable via
the `--test` command line flag.

It's well known that libtest is not the end-all-be-all of testing frameworks. It
is intentionally minimal and is currently quite conservative in its scope of
what it tries to accomplish as well as what it implements. A testament to this
is the fact that one very rarely writes `extern crate test`, and it almost means
that the stabilization story need not be considered for the crate at all! The
benchmarking feature of the compiler, however, is quite useful and is one of the
sole reasons for using `extern crate test`.

When benchmarking, there are a few primary interfaces to the libtest library
that are used:
- `test::Bencher` - the type for a benchmarking harness.
- `test::Bencher::iter` - a member function used to run a benchmark.
- `test::black_box` - a useful function to hinder optimizations and prevent a
  value from being optimized away.

These three pieces of information are the primary targets for the stabilization
in this commit. The rest of the testing infrastructure, while still quite useful
to some projects, is not in scope for stabilization at 1.0 and will remain
`#[experimental]` for now.

The benchmarking pieces have been moved to a new `rustc_bench` crate which will
be part of the standard distribution. In order to write a benchmark one will
need to import the crate via `extern crate rustc_bench` and otherwise all usage
remains the same. The purpose of this crate is to provide a clear area for these
benchmarking utilities as well as provide a clear name that it is _only_
intended for use via the compiler `#[bench]` attribute. The current interface is
quite minimal with only what's necessary as `#[stable]`.

It is most certainly a desire for the compiler to support other testing
frameworks other than the standard libtest. This form of infrastructure (be it a
plugin or a separate interface) is out of scope for 1.0, however, and this
commit does not attempt to resolve it.

Due to the removal of benchmarking items from libtest, this is a breaking
change. To update, rewrite imports of `extern crate test` to `extern crate
rustc_bench` and then rewrite all `use` statements as well. The public interface
of the `Bencher` struct has not changed.

[breaking-change]
