### PR TITLE
Let 'size_of' always be multiple of 'min_align_of'

### DIFF
--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -311,7 +311,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         (_, "size_of") => {
             let tp_ty = *substs.types.get(FnSpace, 0);
             let lltp_ty = type_of::type_of(ccx, tp_ty);
-            C_uint(ccx, machine::llsize_of_real(ccx, lltp_ty))
+            C_uint(ccx, machine::llsize_of_alloc(ccx, lltp_ty))
         }
         (_, "min_align_of") => {
             let tp_ty = *substs.types.get(FnSpace, 0);

--- a/src/librustc_trans/trans/machine.rs
+++ b/src/librustc_trans/trans/machine.rs
@@ -43,8 +43,10 @@ pub fn llsize_of_alloc(cx: &CrateContext, ty: Type) -> llsize {
 
 // Returns, as near as we can figure, the "real" size of a type. As in, the
 // bits in this number of bytes actually carry data related to the datum
-// with the type. Not junk, padding, accidentally-damaged words, or
-// whatever. Rounds up to the nearest byte though, so if you have a 1-bit
+// with the type. Not junk, accidentally-damaged words, or whatever.
+// Note that padding of the type will be included for structs, but not for the
+// other types (i.e. SIMD types).
+// Rounds up to the nearest byte though, so if you have a 1-bit
 // value, we return 1 here, not 0. Most of rustc works in bytes. Be warned
 // that LLVM *does* distinguish between e.g. a 1-bit value and an 8-bit value
 // at the codegen level! In general you should prefer `llbitsize_of_real`

--- a/src/test/run-pass/simd-size-align.rs
+++ b/src/test/run-pass/simd-size-align.rs
@@ -1,0 +1,70 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(simd)]
+#![allow(non_camel_case_types)]
+
+use std::mem;
+
+/// `T` should satisfy `size_of T (mod min_align_of T) === 0` to be stored at `Vec<T>` properly
+/// Please consult the issue #20460
+fn check<T>() {
+    assert_eq!(mem::size_of::<T>() % mem::min_align_of::<T>(), 0)
+}
+
+fn main() {
+    check::<u8x2>();
+    check::<u8x3>();
+    check::<u8x4>();
+    check::<u8x5>();
+    check::<u8x6>();
+    check::<u8x7>();
+    check::<u8x8>();
+
+    check::<i16x2>();
+    check::<i16x3>();
+    check::<i16x4>();
+    check::<i16x5>();
+    check::<i16x6>();
+    check::<i16x7>();
+    check::<i16x8>();
+
+    check::<f32x2>();
+    check::<f32x3>();
+    check::<f32x4>();
+    check::<f32x5>();
+    check::<f32x6>();
+    check::<f32x7>();
+    check::<f32x8>();
+}
+
+#[simd] struct u8x2(u8, u8);
+#[simd] struct u8x3(u8, u8, u8);
+#[simd] struct u8x4(u8, u8, u8, u8);
+#[simd] struct u8x5(u8, u8, u8, u8, u8);
+#[simd] struct u8x6(u8, u8, u8, u8, u8, u8);
+#[simd] struct u8x7(u8, u8, u8, u8, u8, u8, u8);
+#[simd] struct u8x8(u8, u8, u8, u8, u8, u8, u8, u8);
+
+#[simd] struct i16x2(i16, i16);
+#[simd] struct i16x3(i16, i16, i16);
+#[simd] struct i16x4(i16, i16, i16, i16);
+#[simd] struct i16x5(i16, i16, i16, i16, i16);
+#[simd] struct i16x6(i16, i16, i16, i16, i16, i16);
+#[simd] struct i16x7(i16, i16, i16, i16, i16, i16, i16);
+#[simd] struct i16x8(i16, i16, i16, i16, i16, i16, i16, i16);
+
+#[simd] struct f32x2(f32, f32);
+#[simd] struct f32x3(f32, f32, f32);
+#[simd] struct f32x4(f32, f32, f32, f32);
+#[simd] struct f32x5(f32, f32, f32, f32, f32);
+#[simd] struct f32x6(f32, f32, f32, f32, f32, f32);
+#[simd] struct f32x7(f32, f32, f32, f32, f32, f32, f32);
+#[simd] struct f32x8(f32, f32, f32, f32, f32, f32, f32, f32);


### PR DESCRIPTION
This PR fixes the issue #20460, and it doesn't touch any existing behavior except the bug of the SIMD types.

Closes #20460.
