### PR TITLE
Implement TTY::get_winsize for Windows

### DIFF
--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -84,6 +84,32 @@ pub fn fd_set(set: &mut fd_set, s: libc::SOCKET) {
     set.fd_count += 1;
 }
 
+pub type SHORT = libc::c_short;
+
+#[repr(C)]
+pub struct COORD {
+    pub X: SHORT,
+    pub Y: SHORT,
+}
+
+#[repr(C)]
+pub struct SMALL_RECT {
+    pub Left: SHORT,
+    pub Top: SHORT,
+    pub Right: SHORT,
+    pub Bottom: SHORT,
+}
+
+#[repr(C)]
+pub struct CONSOLE_SCREEN_BUFFER_INFO {
+    pub dwSize: COORD,
+    pub dwCursorPosition: COORD,
+    pub wAttributes: libc::WORD,
+    pub srWindow: SMALL_RECT,
+    pub dwMaximumWindowSize: COORD,
+}
+pub type PCONSOLE_SCREEN_BUFFER_INFO = *mut CONSOLE_SCREEN_BUFFER_INFO;
+
 #[link(name = "ws2_32")]
 extern "system" {
     pub fn WSAStartup(wVersionRequested: libc::WORD,
@@ -247,4 +273,8 @@ extern "system" {
 
     pub fn SetConsoleMode(hConsoleHandle: libc::HANDLE,
                           lpMode: libc::DWORD) -> libc::BOOL;
+    pub fn GetConsoleScreenBufferInfo(
+        hConsoleOutput: libc::HANDLE,
+        lpConsoleScreenBufferInfo: PCONSOLE_SCREEN_BUFFER_INFO,
+    ) -> libc::BOOL;
 }


### PR DESCRIPTION
This calculates the width and height using the bounding box of the window in the buffer. Bounding box coordinates are inclusive so I have to add 1 to both dimensions.
