### PR TITLE
pthread_key_t is defined as int on FreeBSD/DFly

### DIFF
--- a/src/libstd/sys/unix/thread_local.rs
+++ b/src/libstd/sys/unix/thread_local.rs
@@ -40,7 +40,12 @@ pub unsafe fn destroy(key: Key) {
 #[cfg(target_os = "macos")]
 type pthread_key_t = ::libc::c_ulong;
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+type pthread_key_t = ::libc::c_int;
+
+#[cfg(all(not(target_os = "macos"),
+          not(target_os = "freebsd"),
+          not(target_os = "dragonfly")))]
 type pthread_key_t = ::libc::c_uint;
 
 extern {


### PR DESCRIPTION
Both FreeBSD and DragonFly define pthread_key_t as int, while Linux
defines it as uint. As pthread_key_t is used as an opaque type and
storage size of both int and uint are the same, this is rather a
cosmetic change.
