### PR TITLE
Stabilize std::error

### DIFF
--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -78,12 +78,15 @@
 //! }
 //! ```
 
+#![stable]
+
 use prelude::v1::*;
 
 use str::Utf8Error;
 use string::{FromUtf8Error, FromUtf16Error};
 
 /// Base functionality for all errors in Rust.
+#[unstable = "the exact API of this trait may change"]
 pub trait Error: Send {
     /// A short description of the error; usually a static string.
     fn description(&self) -> &str;
@@ -96,18 +99,21 @@ pub trait Error: Send {
 }
 
 /// A trait for types that can be converted from a given error type `E`.
+#[stable]
 pub trait FromError<E> {
     /// Perform the conversion.
     fn from_error(err: E) -> Self;
 }
 
 // Any type is convertable from itself
+#[stable]
 impl<E> FromError<E> for E {
     fn from_error(err: E) -> E {
         err
     }
 }
 
+#[stable]
 impl Error for Utf8Error {
     fn description(&self) -> &str {
         match *self {
@@ -119,11 +125,13 @@ impl Error for Utf8Error {
     fn detail(&self) -> Option<String> { Some(self.to_string()) }
 }
 
+#[stable]
 impl Error for FromUtf8Error {
     fn description(&self) -> &str { "invalid utf-8" }
     fn detail(&self) -> Option<String> { Some(self.to_string()) }
 }
 
+#[stable]
 impl Error for FromUtf16Error {
     fn description(&self) -> &str { "invalid utf-16" }
 }


### PR DESCRIPTION
This commit is a first past stabilization of `std::error`:
- The module is stable.
- The `FromError` trait and impls are stable
- The `Error` trait itself is left unstable, pending current APIs and
  possible revisions during the alpha cycle.
