### PR TITLE
Tuning pthread_key_t 

### DIFF
--- a/src/libstd/sys/unix/thread_local.rs
+++ b/src/libstd/sys/unix/thread_local.rs
@@ -37,10 +37,18 @@ pub unsafe fn destroy(key: Key) {
     debug_assert_eq!(r, 0);
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos",
+          target_os = "ios"))]
 type pthread_key_t = ::libc::c_ulong;
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(any(target_os = "freebsd",
+          target_os = "dragonfly"))]
+type pthread_key_t = ::libc::c_int;
+
+#[cfg(not(any(target_os = "macos",
+              target_os = "ios",
+              target_os = "freebsd",
+              target_os = "dragonfly")))]
 type pthread_key_t = ::libc::c_uint;
 
 extern {


### PR DESCRIPTION
This is a manual merge of #20627 and #20634 to avoid conflicts in rollup and also avoid one roundtrip. I've leave copyright to original author.  If this one is moved to rollup original PR could be closed. cc @mneumann 

@alexcrichton r? 

Both FreeBSD and DragonFly define pthread_key_t as int, while Linux
defines it as uint. As pthread_key_t is used as an opaque type and
storage size of both int and uint are the same, this is rather a
cosmetic change.

iOS uses ulong (as OS X) so difference is critical on 64bit platforms.
