### PR TITLE
Support method notation with projected associated types

### DIFF
--- a/src/librustc/middle/infer/combine.rs
+++ b/src/librustc/middle/infer/combine.rs
@@ -427,6 +427,16 @@ impl<'tcx> Combineable<'tcx> for ty::TraitRef<'tcx> {
     }
 }
 
+impl<'tcx> Combineable<'tcx> for Ty<'tcx> {
+    fn combine<C:Combine<'tcx>>(combiner: &C,
+                                a: &Ty<'tcx>,
+                                b: &Ty<'tcx>)
+                                -> cres<'tcx, Ty<'tcx>>
+    {
+        combiner.tys(*a, *b)
+    }
+}
+
 impl<'tcx> Combineable<'tcx> for ty::ProjectionPredicate<'tcx> {
     fn combine<C:Combine<'tcx>>(combiner: &C,
                                 a: &ty::ProjectionPredicate<'tcx>,

--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -39,7 +39,7 @@ use util::ppaux::{ty_to_string};
 use util::ppaux::{Repr, UserString};
 
 use self::coercion::Coerce;
-use self::combine::{Combine, CombineFields};
+use self::combine::{Combine, Combineable, CombineFields};
 use self::region_inference::{RegionVarBindings, RegionSnapshot};
 use self::equate::Equate;
 use self::sub::Sub;
@@ -360,17 +360,9 @@ pub fn can_mk_subty<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
     })
 }
 
-pub fn can_mk_eqty<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
-                             a: Ty<'tcx>, b: Ty<'tcx>)
-                             -> ures<'tcx> {
-    debug!("can_mk_subty({} <: {})", a.repr(cx.tcx), b.repr(cx.tcx));
-    cx.probe(|_| {
-        let trace = TypeTrace {
-            origin: Misc(codemap::DUMMY_SP),
-            values: Types(expected_found(true, a, b))
-        };
-        cx.equate(true, trace).tys(a, b)
-    }).to_ures()
+pub fn can_mk_eqty<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>, a: Ty<'tcx>, b: Ty<'tcx>) -> ures<'tcx>
+{
+    cx.can_equate(&a, &b)
 }
 
 pub fn mk_subr<'a, 'tcx>(cx: &InferCtxt<'a, 'tcx>,
@@ -1071,6 +1063,23 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                bs.repr(self.tcx));
 
         self.region_vars.verify_generic_bound(origin, kind, a, bs);
+    }
+
+    pub fn can_equate<T>(&self, a: &T, b: &T) -> ures<'tcx>
+        where T : Combineable<'tcx> + Repr<'tcx>
+    {
+        debug!("can_equate({}, {})", a.repr(self.tcx), b.repr(self.tcx));
+        self.probe(|_| {
+            // Gin up a dummy trace, since this won't be committed
+            // anyhow. We should make this typetrace stuff more
+            // generic so we don't have to do anything quite this
+            // terrible.
+            let e = self.tcx.types.err;
+            let trace = TypeTrace { origin: Misc(codemap::DUMMY_SP),
+                                    values: Types(expected_found(true, e, e)) };
+            let eq = self.equate(true, trace);
+            Combineable::combine(&eq, a, b)
+        }).to_ures()
     }
 }
 

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -394,7 +394,7 @@ impl<T> VecPerParamSpace<T> {
         self.content.as_slice()
     }
 
-    pub fn to_vec(self) -> Vec<T> {
+    pub fn into_vec(self) -> Vec<T> {
         self.content
     }
 

--- a/src/librustc/middle/traits/project.rs
+++ b/src/librustc/middle/traits/project.rs
@@ -641,7 +641,7 @@ fn confirm_candidate<'cx,'tcx>(
             }
 
             match impl_ty {
-                Some(ty) => (ty, impl_vtable.nested.to_vec()),
+                Some(ty) => (ty, impl_vtable.nested.into_vec()),
                 None => {
                     // This means that the impl is missing a
                     // definition for the associated type. This error

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -835,7 +835,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                bounds.repr(self.tcx()));
 
         let matching_bound =
-            util::elaborate_predicates(self.tcx(), bounds.predicates.to_vec())
+            util::elaborate_predicates(self.tcx(), bounds.predicates.into_vec())
             .filter_to_traits()
             .find(
                 |bound| self.infcx.probe(

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1470,12 +1470,12 @@ impl<'tcx> PolyTraitRef<'tcx> {
     }
 
     pub fn substs(&self) -> &'tcx Substs<'tcx> {
-        // TODO every use of this fn is probably a bug, it should yield Binder<>
+        // FIXME(#20664) every use of this fn is probably a bug, it should yield Binder<>
         self.0.substs
     }
 
     pub fn input_types(&self) -> &[Ty<'tcx>] {
-        // TODO every use of this fn is probably a bug, it should yield Binder<>
+        // FIXME(#20664) every use of this fn is probably a bug, it should yield Binder<>
         self.0.input_types()
     }
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1077,6 +1077,12 @@ pub struct FnSig<'tcx> {
 
 pub type PolyFnSig<'tcx> = Binder<FnSig<'tcx>>;
 
+impl<'tcx> PolyFnSig<'tcx> {
+    pub fn input(&self, index: uint) -> ty::Binder<Ty<'tcx>> {
+        ty::Binder(self.0.inputs[index])
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Show)]
 pub struct ParamTy {
     pub space: subst::ParamSpace,
@@ -1464,10 +1470,12 @@ impl<'tcx> PolyTraitRef<'tcx> {
     }
 
     pub fn substs(&self) -> &'tcx Substs<'tcx> {
+        // TODO every use of this fn is probably a bug, it should yield Binder<>
         self.0.substs
     }
 
     pub fn input_types(&self) -> &[Ty<'tcx>] {
+        // TODO every use of this fn is probably a bug, it should yield Binder<>
         self.0.input_types()
     }
 
@@ -6947,6 +6955,13 @@ pub trait RegionEscape {
 impl<'tcx> RegionEscape for Ty<'tcx> {
     fn has_regions_escaping_depth(&self, depth: u32) -> bool {
         ty::type_escapes_depth(*self, depth)
+    }
+}
+
+impl<'tcx> RegionEscape for Substs<'tcx> {
+    fn has_regions_escaping_depth(&self, depth: u32) -> bool {
+        self.types.has_regions_escaping_depth(depth) ||
+            self.regions.has_regions_escaping_depth(depth)
     }
 }
 

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -645,7 +645,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
                    predicates.repr(self.tcx()));
             for poly_bound in
                 traits::elaborate_predicates(self.tcx(), predicates)
-                .filter_map(|p| p.to_opt_poly_trait_ref()) // TODO filter_to_traits()
+                .filter_map(|p| p.to_opt_poly_trait_ref())
                 .filter(|b| b.def_id() == trait_def_id)
             {
                 let bound = self.erase_late_bound_regions(&poly_bound);

--- a/src/test/run-pass/method-projection.rs
+++ b/src/test/run-pass/method-projection.rs
@@ -1,0 +1,78 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that we can use method notation to call methods based on a
+// projection bound from a trait. Issue #20469.
+
+///////////////////////////////////////////////////////////////////////////
+
+trait MakeString {
+    fn make_string(&self) -> String;
+}
+
+impl MakeString for int {
+    fn make_string(&self) -> String {
+        format!("{}", *self)
+    }
+}
+
+impl MakeString for uint {
+    fn make_string(&self) -> String {
+        format!("{}", *self)
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+trait Foo {
+    type F: MakeString;
+
+    fn get(&self) -> &Self::F;
+}
+
+fn foo<F:Foo>(f: &F) -> String {
+    f.get().make_string()
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+struct SomeStruct {
+    field: int,
+}
+
+impl Foo for SomeStruct {
+    type F = int;
+
+    fn get(&self) -> &int {
+        &self.field
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+struct SomeOtherStruct {
+    field: uint,
+}
+
+impl Foo for SomeOtherStruct {
+    type F = uint;
+
+    fn get(&self) -> &uint {
+        &self.field
+    }
+}
+
+fn main() {
+    let x = SomeStruct { field: 22 };
+    assert_eq!(foo(&x), format!("22"));
+
+    let x = SomeOtherStruct { field: 44 };
+    assert_eq!(foo(&x), format!("44"));
+}


### PR DESCRIPTION
You should be able to call `x.foo()` on the basis of a bound declared in the trait (rather than being restricted to UFCS form).

Fixes #20469.

cc @japaric
