### PR TITLE
Fix misspelled comments.

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1219,7 +1219,7 @@ the guarantee that these issues are never caused by safe code.
     (`offset` intrinsic), with
     the exception of one byte past the end which is permitted.
   * Using `std::ptr::copy_nonoverlapping_memory` (`memcpy32`/`memcpy64`
-    instrinsics) on overlapping buffers
+    intrinsics) on overlapping buffers
 * Invalid values in primitive types, even in private fields/locals:
   * Dangling/null references or boxes
   * A value other than `false` (0) or `true` (1) in a `bool`

--- a/src/libcollections/btree/node.rs
+++ b/src/libcollections/btree/node.rs
@@ -1220,7 +1220,7 @@ impl<K, V> Node<K, V> {
     /// Node is full, so split it into two nodes, and yield the middle-most key-value pair
     /// because we have one too many, and our parent now has one too few
     fn split(&mut self) -> (K, V, Node<K, V>) {
-        // Necessary for correctness, but in a private funtion
+        // Necessary for correctness, but in a private function
         debug_assert!(self.len() > 0);
 
         let mut right = if self.is_leaf() {
@@ -1259,7 +1259,7 @@ impl<K, V> Node<K, V> {
         }
     }
 
-    /// Take all the values from right, seperated by the given key and value
+    /// Take all the values from right, separated by the given key and value
     fn absorb(&mut self, key: K, val: V, mut right: Node<K, V>) {
         // Necessary for correctness, but in a private function
         // Just as a sanity check, make sure we can fit this guy in

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -987,7 +987,7 @@ impl<T> SliceExt for [T] {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Extension traits for slices over specifc kinds of data
+// Extension traits for slices over specific kinds of data
 ////////////////////////////////////////////////////////////////////////////////
 #[unstable = "U should be an associated type"]
 /// An extension trait for concatenating slices
@@ -997,7 +997,7 @@ pub trait SliceConcatExt<T: ?Sized, U> {
     fn concat(&self) -> U;
 
     /// Flattens a slice of `T` into a single value `U`, placing a
-    /// given seperator between each.
+    /// given separator between each.
     #[stable]
     fn connect(&self, sep: &T) -> U;
 }

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -97,7 +97,7 @@ use kinds::{Send, Sized, Sync};
 use cmp::{PartialEq, Eq, Ord, PartialOrd};
 use cmp::Ordering::{self, Less, Equal, Greater};
 
-// FIXME #19649: instrinsic docs don't render, so these have no docs :(
+// FIXME #19649: intrinsic docs don't render, so these have no docs :(
 
 #[unstable]
 pub use intrinsics::copy_nonoverlapping_memory;
@@ -233,7 +233,7 @@ pub unsafe fn read_and_zero<T>(dest: *mut T) -> T {
 /// not drop the contents of `dst`. This could leak allocations or resources,
 /// so care must be taken not to overwrite an object that should be dropped.
 ///
-/// This is appropriate for initializing uninitialized memory, or overwritting
+/// This is appropriate for initializing uninitialized memory, or overwriting
 /// memory that has previously been `read` from.
 #[inline]
 #[stable]

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -2034,7 +2034,7 @@ pub fn encode_metadata(parms: EncodeParams, krate: &ast::Crate) -> Vec<u8> {
 
     // And here we run into yet another obscure archive bug: in which metadata
     // loaded from archives may have trailing garbage bytes. Awhile back one of
-    // our tests was failing sporadially on the OSX 64-bit builders (both nopt
+    // our tests was failing sporadically on the OSX 64-bit builders (both nopt
     // and opt) by having rbml generate an out-of-bounds panic when looking at
     // metadata.
     //

--- a/src/librustc/middle/infer/doc.rs
+++ b/src/librustc/middle/infer/doc.rs
@@ -125,7 +125,7 @@
 //! Another option is to keep A and B as distinct variables but set their
 //! bounds in such a way that, whatever happens, we know that A <: B will hold.
 //! This can be achieved by ensuring that A.ub <: B.lb.  In practice there
-//! are two ways to do that, depicted pictorally here:
+//! are two ways to do that, depicted pictorially here:
 //!
 //! ```text
 //!     Before                Option #1            Option #2

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -37,7 +37,7 @@
 //!
 //! # Subtype Trace
 //!
-//! Determing whether `T1 <: T2` often involves a number of subtypes and
+//! Determining whether `T1 <: T2` often involves a number of subtypes and
 //! subconstraints along the way. A "TypeTrace" is an extended version
 //! of an origin that traces the types and other values that were being
 //! compared. It is not necessarily comprehensive (in fact, at the time of

--- a/src/librustc/middle/infer/higher_ranked/doc.rs
+++ b/src/librustc/middle/infer/higher_ranked/doc.rs
@@ -198,7 +198,7 @@
 //!
 //! So the way we solve this is to add a fourth step that examines the
 //! constraints that refer to skolemized names. Basically, consider a
-//! non-directed verison of the constraint graph. Let `Tainted(x)` be the
+//! non-directed version of the constraint graph. Let `Tainted(x)` be the
 //! set of all things reachable from a skolemized variable `x`.
 //! `Tainted(x)` should not contain any regions that existed before the
 //! step at which the skolemization was performed. So this case here

--- a/src/librustc/middle/infer/region_inference/doc.rs
+++ b/src/librustc/middle/infer/region_inference/doc.rs
@@ -38,7 +38,7 @@
 //! - ConstrainVarSubVar(R_i, R_j) states that region variable R_i
 //!   must be a subregion of R_j
 //! - ConstrainRegSubVar(R, R_i) states that the concrete region R
-//!   (which must not be a variable) must be a subregion of the varibale R_i
+//!   (which must not be a variable) must be a subregion of the variable R_i
 //! - ConstrainVarSubReg(R_i, R) is the inverse
 //!
 //! # Building up the constraints

--- a/src/librustc/middle/infer/region_inference/mod.rs
+++ b/src/librustc/middle/infer/region_inference/mod.rs
@@ -106,7 +106,7 @@ pub enum RegionResolutionError<'tcx> {
 
     /// `GenericBoundFailure(p, s, a, bs)
     ///
-    /// The parameter/assocated-type `p` must be known to outlive the lifetime
+    /// The parameter/associated-type `p` must be known to outlive the lifetime
     /// `a`, but it is only known to outlive `bs` (and none of the
     /// regions in `bs` outlive `a`).
     GenericBoundFailure(SubregionOrigin<'tcx>, GenericKind<'tcx>, Region, Vec<Region>),
@@ -337,7 +337,7 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
     ///
     /// The idea is to always create a snapshot. Skolemized regions
     /// can be created in the context of this snapshot, but once the
-    /// snapshot is commited or rolled back, their numbers will be
+    /// snapshot is committed or rolled back, their numbers will be
     /// recycled, so you must be finished with them. See the extensive
     /// comments in `higher_ranked.rs` to see how it works (in
     /// particular, the subtyping comparison).

--- a/src/librustc/middle/traits/doc.rs
+++ b/src/librustc/middle/traits/doc.rs
@@ -254,7 +254,7 @@ we only need to do a "shallow" selection for an obligation. That is, we wish to
 identify which impl applies, but we do not (yet) need to decide how to select
 any nested obligations. Nonetheless, we *do* currently do a complete resolution,
 and that is because it can sometimes inform the results of type inference. That is,
-we do not have the full substitutions in terms of the type varibales of the impl available
+we do not have the full substitutions in terms of the type variables of the impl available
 to us, so we must run trait selection to figure everything out.
 
 Here is an example:

--- a/src/librustc/middle/traits/object_safety.rs
+++ b/src/librustc/middle/traits/object_safety.rs
@@ -31,7 +31,7 @@ pub enum ObjectSafetyViolation<'tcx> {
     /// Self : Sized declared on the trait
     SizedSelf,
 
-    /// Method has someting illegal
+    /// Method has something illegal
     Method(Rc<ty::Method<'tcx>>, MethodViolationCode),
 }
 
@@ -256,7 +256,7 @@ fn contains_illegal_self_type_reference<'tcx>(tcx: &ty::ctxt<'tcx>,
             ty::ty_projection(ref data) => {
                 // This is a projected type `<Foo as SomeTrait>::X`.
 
-                // Compute supertraits of current trait lazilly.
+                // Compute supertraits of current trait lazily.
                 if supertraits.is_none() {
                     let trait_def = ty::lookup_trait_def(tcx, trait_def_id);
                     let trait_ref = ty::Binder(trait_def.trait_ref.clone());

--- a/src/librustc/middle/traits/project.rs
+++ b/src/librustc/middle/traits/project.rs
@@ -337,7 +337,7 @@ fn opt_normalize_projection_type<'a,'b,'tcx>(
 }
 
 /// in various error cases, we just set ty_err and return an obligation
-/// that, when fulfiled, will lead to an error
+/// that, when fulfilled, will lead to an error
 fn normalize_to_error<'a,'tcx>(selcx: &mut SelectionContext<'a,'tcx>,
                                projection_ty: ty::ProjectionTy<'tcx>,
                                cause: ObligationCause<'tcx>,

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -392,7 +392,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // `$1`), on the condition that `$1 : Eq`. We will then wind
         // up with many candidates (since that are other `Eq` impls
         // that apply) and try to winnow things down. This results in
-        // a recurssive evaluation that `$1 : Eq` -- as you can
+        // a recursive evaluation that `$1 : Eq` -- as you can
         // imagine, this is just where we started. To avoid that, we
         // check for unbound variables and return an ambiguous (hence possible)
         // match if we've seen this trait before.
@@ -604,7 +604,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         }
 
         // If there are *STILL* multiple candidates, give up and
-        // report ambiguiuty.
+        // report ambiguity.
         if candidates.len() > 1 {
             debug!("multiple matches, ambig");
             return Ok(None);
@@ -1119,7 +1119,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     ///
     /// This is generally true if either:
     /// - candidate i and candidate j are equivalent; or,
-    /// - candidate i is a conrete impl and candidate j is a where clause bound,
+    /// - candidate i is a concrete impl and candidate j is a where clause bound,
     ///   and the concrete impl is applicable to the types in the where clause bound.
     ///
     /// The last case refers to cases where there are blanket impls (often conditional

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1067,7 +1067,7 @@ impl<'tcx> FnOutput<'tcx> {
 ///
 /// - `inputs` is the list of arguments and their modes.
 /// - `output` is the return type.
-/// - `variadic` indicates whether this is a varidic function. (only true for foreign fns)
+/// - `variadic` indicates whether this is a variadic function. (only true for foreign fns)
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct FnSig<'tcx> {
     pub inputs: Vec<Ty<'tcx>>,

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -30,7 +30,7 @@
 //! In some cases, we follow a degenerate pattern where we do not have
 //! a `fold_T` nor `super_fold_T` method. Instead, `T.fold_with`
 //! traverses the structure directly. This is suboptimal because the
-//! behavior cannot be overriden, but it's much less work to implement.
+//! behavior cannot be overridden, but it's much less work to implement.
 //! If you ever *do* need an override that doesn't exist, it's not hard
 //! to convert the degenerate pattern into the proper thing.
 

--- a/src/librustc/util/snapshot_vec.rs
+++ b/src/librustc/util/snapshot_vec.rs
@@ -14,7 +14,7 @@
 //!
 //! This vector is intended to be used as part of an abstraction, not serve as a complete
 //! abstraction on its own. As such, while it will roll back most changes on its own, it also
-//! supports a `get_mut` operation that gives you an abitrary mutable pointer into the vector. To
+//! supports a `get_mut` operation that gives you an arbitrary mutable pointer into the vector. To
 //! ensure that any changes you make this with this pointer are rolled back, you must invoke
 //! `record` to record any changes you make and also supplying a delegate capable of reversing
 //! those changes.

--- a/src/librustc_back/target/arm_linux_androideabi.rs
+++ b/src/librustc_back/target/arm_linux_androideabi.rs
@@ -16,7 +16,7 @@ pub fn target() -> Target {
     // Many of the symbols defined in compiler-rt are also defined in libgcc.  Android
     // linker doesn't like that by default.
     base.pre_link_args.push("-Wl,--allow-multiple-definition".to_string());
-    // FIXME #17437 (and #17448): Android doesn't support position dependant executables anymore.
+    // FIXME #17437 (and #17448): Android doesn't support position dependent executables anymore.
     base.position_independent_executables = false;
 
     Target {

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -560,7 +560,7 @@ pub fn trans_object_shim<'a, 'tcx>(
     let object_substs = upcast_trait_ref.substs().clone().erase_regions();
     debug!("trans_object_shim: object_substs={}", object_substs.repr(tcx));
 
-    // Lookup the type of this method as deeclared in the trait and apply substitutions.
+    // Lookup the type of this method as declared in the trait and apply substitutions.
     let method_ty = match ty::trait_item(tcx, trait_id, method_offset_in_trait) {
         ty::MethodTraitItem(method) => method,
         ty::TypeTraitItem(_) => {

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -97,7 +97,7 @@ pub fn check_pat<'a, 'tcx>(pcx: &pat_ctxt<'a, 'tcx>,
 
             fcx.write_ty(pat.id, lhs_ty);
 
-            // subtyping doens't matter here, as the value is some kind of scalar
+            // subtyping doesn't matter here, as the value is some kind of scalar
             demand::eqtype(fcx, pat.span, expected, lhs_ty);
         }
         ast::PatEnum(..) | ast::PatIdent(..) if pat_is_const(&tcx.def_map, pat) => {

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -122,7 +122,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
 
         // If this is an `&mut self` method, bias the receiver
         // expression towards mutability (this will switch
-        // e.g. `Deref` to `DerefMut` in oveloaded derefs and so on).
+        // e.g. `Deref` to `DerefMut` in overloaded derefs and so on).
         self.fixup_derefs_on_method_receiver_if_necessary(&callee);
 
         callee

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -206,7 +206,7 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
             // We are stricter on the trait-ref in an impl than the
             // self-type.  In particular, we enforce region
             // relationships. The reason for this is that (at least
-            // presently) "appyling" an impl does not require that the
+            // presently) "applying" an impl does not require that the
             // application site check the well-formedness constraints on the
             // trait reference. Instead, this is done at the impl site.
             // Arguably this is wrong and we should treat the trait-reference

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -184,7 +184,7 @@ fn test_resize_policy() {
 // simply introduce a new bit to the front of the hash. Therefore, if an
 // elements has ideal index i in the old table, it can have one of two ideal
 // locations in the new table. If the new bit is 0, then the new ideal index
-// is i. If the new bit is 1, then the new ideal index is n + i. Intutively,
+// is i. If the new bit is 1, then the new ideal index is n + i. Intuitively,
 // we are producing two independent tables of size n, and for each element we
 // independently choose which table to insert it into with equal probability.
 // However the rather than wrapping around themselves on overflowing their

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -104,7 +104,7 @@ impl CString {
         unsafe { mem::transmute(self.as_slice()) }
     }
 
-    /// Equivalend to `as_slice_with_nul` except that the type returned is a
+    /// Equivalent to `as_slice_with_nul` except that the type returned is a
     /// `u8` slice instead of a `libc::c_char` slice.
     pub fn as_bytes_with_nul(&self) -> &[u8] {
         unsafe { mem::transmute(self.as_slice_with_nul()) }

--- a/src/libstd/fmt.rs
+++ b/src/libstd/fmt.rs
@@ -106,7 +106,7 @@
 //! ```
 //!
 //! This is invalid because the first argument is both referred to as a
-//! hexidecimal as well as an
+//! hexadecimal as well as an
 //! octal.
 //!
 //! There are various parameters which do require a particular type, however.

--- a/src/libstd/sys/windows/thread_local.rs
+++ b/src/libstd/sys/windows/thread_local.rs
@@ -191,7 +191,7 @@ unsafe fn unregister_dtor(key: Key) -> bool {
 //
 // The callback specified receives a number of parameters from... someone!
 // (the kernel? the runtime? I'm not qute sure!) There are a few events that
-// this gets invoked for, but we're currentl only interested on when a
+// this gets invoked for, but we're currently only interested on when a
 // thread or a process "detaches" (exits). The process part happens for the
 // last thread and the thread part happens for any normal thread.
 //

--- a/src/libstd/thread.rs
+++ b/src/libstd/thread.rs
@@ -142,7 +142,7 @@ use thunk::Thunk;
 use sys::thread as imp;
 use sys_common::{stack, thread_info};
 
-/// Thread configuation. Provides detailed control over the properties
+/// Thread configuration. Provides detailed control over the properties
 /// and behavior of new threads.
 pub struct Builder {
     // A name for the thread-to-be, for identification in panic messages

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2780,7 +2780,7 @@ impl<'a> Parser<'a> {
                 let open_span = self.span;
                 self.bump();
 
-                // Parse the token trees within the delimeters
+                // Parse the token trees within the delimiters
                 let tts = self.parse_seq_to_before_end(
                     &token::CloseDelim(delim),
                     seq_sep_none(),

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -43,7 +43,7 @@ pub enum BinOpToken {
     Shr,
 }
 
-/// A delimeter token
+/// A delimiter token
 #[derive(Clone, RustcEncodable, RustcDecodable, PartialEq, Eq, Hash, Show, Copy)]
 pub enum DelimToken {
     /// A round parenthesis: `(` or `)`
@@ -134,9 +134,9 @@ pub enum Token {
     Pound,
     Dollar,
     Question,
-    /// An opening delimeter, eg. `{`
+    /// An opening delimiter, eg. `{`
     OpenDelim(DelimToken),
-    /// A closing delimeter, eg. `}`
+    /// A closing delimiter, eg. `}`
     CloseDelim(DelimToken),
 
     /* Literals */


### PR DESCRIPTION
I cleaned up comments prior to the 1.0 alpha release.
