### PR TITLE
Fix misspelled comments in tests.

### DIFF
--- a/src/test/auxiliary/issue-17662.rs
+++ b/src/test/auxiliary/issue-17662.rs
@@ -16,7 +16,7 @@ pub trait Foo<'a, T> {
 
 pub fn foo<'a, T>(x: &'a Foo<'a, T>) -> T {
     let x: &'a Foo<T> = x;
-    //            ^ the lifetime parameter of Foo is left to be infered.
+    //            ^ the lifetime parameter of Foo is left to be inferred.
     x.foo()
     // ^ encoding this method call in metadata triggers an ICE.
 }

--- a/src/test/auxiliary/traitimpl.rs
+++ b/src/test/auxiliary/traitimpl.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test inherant trait impls work cross-crait.
+// Test inherent trait impls work cross-crait.
 
 pub trait Bar<'a> : 'a {}
 

--- a/src/test/compile-fail-fulldeps/macro-crate-cannot-read-embedded-ident.rs
+++ b/src/test/compile-fail-fulldeps/macro-crate-cannot-read-embedded-ident.rs
@@ -16,7 +16,7 @@
 // Issue #15750 and #15962 : this test is checking that the standard
 // parser rejects embedded idents.  pnkfelix did not want to attempt
 // to make a test file that itself used the embedded ident input form,
-// since he worrid that would be difficult to work with in many text
+// since he worried that would be difficult to work with in many text
 // editors, so instead he made a macro that expands into the embedded
 // ident form.
 

--- a/src/test/compile-fail/liveness-missing-ret2.rs
+++ b/src/test/compile-fail/liveness-missing-ret2.rs
@@ -11,8 +11,8 @@
 // error-pattern: not all control paths return a value
 
 fn f() -> int {
-    // Make sure typestate doesn't interpreturn this match expression
-    // as the function result
+    // Make sure typestate doesn't interpret this match expression as
+    // the function result
    match true { true => { } _ => {} };
 }
 

--- a/src/test/compile-fail/move-fragments-5.rs
+++ b/src/test/compile-fail/move-fragments-5.rs
@@ -47,7 +47,7 @@ pub fn test_move_field_to_local_to_local(p: Pair<D, D>) {
 // `test_uninitialized_local` , the instrumentation reports that `_x`
 // is moved. This is unlike `test_move_field_to_local`, where `_x` is
 // just reported as an assigned_leaf_path. Presumably because this is
-// how we represent that it did not have an initalizing expression at
+// how we represent that it did not have an initializing expression at
 // the binding site.
 
 #[rustc_move_fragments]

--- a/src/test/run-pass/issue-3753.rs
+++ b/src/test/run-pass/issue-3753.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // Issue #3656
-// Issue Name: pub method preceeded by attribute can't be parsed
+// Issue Name: pub method preceded by attribute can't be parsed
 // Abstract: Visibility parsing failed when compiler parsing
 
 use std::f64;

--- a/src/test/run-pass/regions-relate-bound-regions-on-closures-to-inference-variables.rs
+++ b/src/test/run-pass/regions-relate-bound-regions-on-closures-to-inference-variables.rs
@@ -12,7 +12,7 @@
 // typechecks. The pattern involves regions bound in closures that
 // wind up related to inference variables.
 //
-// NB. Changes to the region implementatiosn have broken this pattern
+// NB. Changes to the region implementations have broken this pattern
 // a few times, but it happens to be used in the compiler so those
 // changes were caught. However, those uses in the compiler could
 // easily get changed or refactored away in the future.

--- a/src/test/run-pass/self-impl.rs
+++ b/src/test/run-pass/self-impl.rs
@@ -12,7 +12,7 @@
 
 struct Foo;
 
-// Test uses on inherant impl.
+// Test uses on inherent impl.
 impl Foo {
     fn foo(_x: Self, _y: &Self, _z: Box<Self>) -> Self {
         Foo


### PR DESCRIPTION
I separated these changes out from the other commit to minimize issues
with tests.
