### PR TITLE
Fix JS error

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -708,7 +708,7 @@
                 var code = $('<code>').append(structs[j]);
                 $.each(code.find('a'), function(idx, a) {
                     var href = $(a).attr('href');
-                    if (href && !href.startsWith('http')) {
+                    if (href && href.indexOf('http') !== 0) {
                         $(a).attr('href', rootPath + href);
                     }
                 });


### PR DESCRIPTION
ECMAScript 6 isn't really supported anywhere

Closes #20681

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
