### PR TITLE
Fix rustdoc fallout from #20092

### DIFF
--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -157,7 +157,6 @@ nav.sub {
     left: 0;
     top: 0;
     min-height: 100%;
-    z-index: -1;
 }
 
 .content, nav { max-width: 960px; }
@@ -221,6 +220,7 @@ nav.sub {
 .content pre.line-numbers {
     float: left;
     border: none;
+    position: relative;
 
     -webkit-user-select: none;
     -moz-user-select: none;


### PR DESCRIPTION
Due to the CSS changes done by the previous patch to make the line numbers clickable (#20092), the sidebar became unclickable. This PR reverts the changes and adopts an alternative approach.

I'm very sorry for having broken things.
