### PR TITLE
test: Move some tests to scoped instead of spawn

### DIFF
--- a/src/test/run-pass/drop-trait-enum.rs
+++ b/src/test/run-pass/drop-trait-enum.rs
@@ -66,7 +66,7 @@ pub fn main() {
     assert_eq!(receiver.recv().ok(), None);
 
     let (sender, receiver) = channel();
-    let _t = Thread::spawn(move|| {
+    let _t = Thread::scoped(move|| {
         let v = Foo::FailingVariant { on_drop: SendOnDrop { sender: sender } };
     });
     assert_eq!(receiver.recv().unwrap(), Message::Dropped);
@@ -74,7 +74,7 @@ pub fn main() {
 
     let (sender, receiver) = channel();
     let _t = {
-        Thread::spawn(move|| {
+        Thread::scoped(move|| {
             let mut v = Foo::NestedVariant(box 42u, SendOnDrop {
                 sender: sender.clone()
             }, sender.clone());

--- a/src/test/run-pass/extern-stress.rs
+++ b/src/test/run-pass/extern-stress.rs
@@ -42,7 +42,7 @@ fn count(n: libc::uintptr_t) -> libc::uintptr_t {
 
 pub fn main() {
     range(0u, 100).map(|_| {
-        Thread::spawn(move|| {
+        Thread::scoped(move|| {
             assert_eq!(count(5), 16);
         })
     }).collect::<Vec<_>>();

--- a/src/test/run-pass/extern-yield.rs
+++ b/src/test/run-pass/extern-yield.rs
@@ -39,7 +39,7 @@ fn count(n: libc::uintptr_t) -> libc::uintptr_t {
 
 pub fn main() {
     range(0, 10u).map(|i| {
-        Thread::spawn(move|| {
+        Thread::scoped(move|| {
             let result = count(5);
             println!("result = {}", result);
             assert_eq!(result, 16);

--- a/src/test/run-pass/issue-9396.rs
+++ b/src/test/run-pass/issue-9396.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 pub fn main() {
     let (tx, rx) = channel();
-    let _t = Thread::spawn(move||{
+    let _t = Thread::scoped(move||{
         let mut timer = Timer::new().unwrap();
         timer.sleep(Duration::milliseconds(10));
         tx.send(()).unwrap();

--- a/src/test/run-pass/tcp-accept-stress.rs
+++ b/src/test/run-pass/tcp-accept-stress.rs
@@ -34,11 +34,11 @@ fn test() {
 
     let (srv_tx, srv_rx) = channel();
     let (cli_tx, cli_rx) = channel();
-    for _ in range(0, N) {
+    let _t = range(0, N).map(|_| {
         let a = a.clone();
         let cnt = cnt.clone();
         let srv_tx = srv_tx.clone();
-        Thread::spawn(move|| {
+        Thread::scoped(move|| {
             let mut a = a;
             loop {
                 match a.accept() {
@@ -52,18 +52,18 @@ fn test() {
                 }
             }
             srv_tx.send(());
-        });
-    }
+        })
+    }).collect::<Vec<_>>();
 
-    for _ in range(0, N) {
+    let _t = range(0, N).map(|_| {
         let cli_tx = cli_tx.clone();
-        Thread::spawn(move|| {
+        Thread::scoped(move|| {
             for _ in range(0, M) {
                 let _s = TcpStream::connect(addr).unwrap();
             }
             cli_tx.send(());
-        });
-    }
+        })
+    }).collect::<Vec<_>>();
     drop((cli_tx, srv_tx));
 
     // wait for senders

--- a/src/test/run-pass/threads.rs
+++ b/src/test/run-pass/threads.rs
@@ -13,7 +13,7 @@ use std::thread::Thread;
 pub fn main() {
     let mut i = 10;
     while i > 0 {
-        Thread::spawn({let i = i; move|| child(i)});
+        Thread::scoped({let i = i; move|| child(i)});
         i = i - 1;
     }
     println!("main thread exiting");

--- a/src/test/run-pass/unique-send-2.rs
+++ b/src/test/run-pass/unique-send-2.rs
@@ -19,13 +19,13 @@ pub fn main() {
     let (tx, rx) = channel();
     let n = 100u;
     let mut expected = 0u;
-    for i in range(0u, n) {
-        let tx = tx.clone();
-        Thread::spawn(move|| {
-            child(&tx, i)
-        });
+    let _t = range(0u, n).map(|i| {
         expected += i;
-    }
+        let tx = tx.clone();
+        Thread::scoped(move|| {
+            child(&tx, i)
+        })
+    }).collect::<Vec<_>>();
 
     let mut actual = 0u;
     for _ in range(0u, n) {

--- a/src/test/run-pass/unwind-resource.rs
+++ b/src/test/run-pass/unwind-resource.rs
@@ -37,7 +37,7 @@ fn f(tx: Sender<bool>) {
 
 pub fn main() {
     let (tx, rx) = channel();
-    let _t = Thread::spawn(move|| f(tx.clone()));
+    let _t = Thread::scoped(move|| f(tx.clone()));
     println!("hiiiiiiiii");
     assert!(rx.recv().unwrap());
 }


### PR DESCRIPTION
These tests have all been failing spuroiusly on Windows from time to time, and
one suspicion is that the shilc thread outliving the main thread somehow causes
the problem. Switch all the tests over to using Thread::scoped instead of
Thread::spawn to see if it helps the issue.

cc #19120
