### PR TITLE
Fix various ICEs relating to trans'ing fields with associated types 

### DIFF
--- a/src/librustc/middle/infer/freshen.rs
+++ b/src/librustc/middle/infer/freshen.rs
@@ -135,10 +135,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
                 t
             }
 
-            ty::ty_open(..) => {
-                self.tcx().sess.bug("Cannot freshen an open existential type");
-            }
-
+            ty::ty_open(..) |
             ty::ty_bool |
             ty::ty_char |
             ty::ty_int(..) |

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1457,11 +1457,26 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 Ok(AmbiguousBuiltin)
             }
 
+            ty::ty_open(ty) => {
+                // these only crop up in trans, and represent an
+                // "opened" unsized/existential type (one that has
+                // been dereferenced)
+                match bound {
+                    ty::BoundCopy |
+                    ty::BoundSync |
+                    ty::BoundSend => {
+                        Ok(If(vec!(ty)))
+                    }
+
+                    ty::BoundSized => {
+                        Err(Unimplemented)
+                    }
+                }
+            }
             ty::ty_err => {
                 Ok(If(Vec::new()))
             }
 
-            ty::ty_open(_) |
             ty::ty_infer(ty::FreshTy(_)) |
             ty::ty_infer(ty::FreshIntTy(_)) => {
                 self.tcx().sess.bug(

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -107,7 +107,7 @@ pub struct CrateAnalysis<'tcx> {
     pub glob_map: Option<GlobMap>,
 }
 
-#[derive(Copy, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct field<'tcx> {
     pub name: ast::Name,
     pub mt: mt<'tcx>
@@ -7212,6 +7212,12 @@ impl<'tcx> HasProjectionTypes for FnSig<'tcx> {
     }
 }
 
+impl<'tcx> HasProjectionTypes for field<'tcx> {
+    fn has_projection_types(&self) -> bool {
+        self.mt.ty.has_projection_types()
+    }
+}
+
 impl<'tcx> HasProjectionTypes for BareFnTy<'tcx> {
     fn has_projection_types(&self) -> bool {
         self.sig.has_projection_types()
@@ -7309,5 +7315,13 @@ impl<'tcx> Repr<'tcx> for UnboxedClosureUpvar<'tcx> {
         format!("UnboxedClosureUpvar({},{})",
                 self.def.repr(tcx),
                 self.ty.repr(tcx))
+    }
+}
+
+impl<'tcx> Repr<'tcx> for field<'tcx> {
+    fn repr(&self, tcx: &ctxt<'tcx>) -> String {
+        format!("field({},{})",
+                self.name.repr(tcx),
+                self.mt.repr(tcx))
     }
 }

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -273,6 +273,15 @@ impl<'tcx> TypeFoldable<'tcx> for ty::TraitRef<'tcx> {
     }
 }
 
+impl<'tcx> TypeFoldable<'tcx> for ty::field<'tcx> {
+    fn fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> ty::field<'tcx> {
+        ty::field {
+            name: self.name,
+            mt: self.mt.fold_with(folder),
+        }
+    }
+}
+
 impl<'tcx> TypeFoldable<'tcx> for ty::Region {
     fn fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> ty::Region {
         folder.fold_region(*self)

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -50,7 +50,7 @@ use std::vec::Vec;
 use syntax::ast::Ident;
 use syntax::ast;
 use syntax::ast_map::{PathElem, PathName};
-use syntax::codemap::Span;
+use syntax::codemap::{DUMMY_SP, Span};
 use syntax::parse::token::InternedString;
 use syntax::parse::token;
 use util::common::memoized;
@@ -114,8 +114,9 @@ pub fn normalize_ty<'tcx>(cx: &ty::ctxt<'tcx>, ty: Ty<'tcx>) -> Ty<'tcx> {
 }
 
 // Is the type's representation size known at compile time?
-pub fn type_is_sized<'tcx>(cx: &ty::ctxt<'tcx>, ty: Ty<'tcx>) -> bool {
-ty::type_contents(cx, ty).is_sized(cx)
+pub fn type_is_sized<'tcx>(tcx: &ty::ctxt<'tcx>, ty: Ty<'tcx>) -> bool {
+    let param_env = ty::empty_parameter_environment(tcx);
+    ty::type_is_sized(&param_env, DUMMY_SP, ty)
 }
 
 pub fn lltype_is_sized<'tcx>(cx: &ty::ctxt<'tcx>, ty: Ty<'tcx>) -> bool {

--- a/src/librustc_trans/trans/monomorphize.rs
+++ b/src/librustc_trans/trans/monomorphize.rs
@@ -300,8 +300,6 @@ pub fn apply_param_substs<'tcx,T>(tcx: &ty::ctxt<'tcx>,
                                   -> T
     where T : TypeFoldable<'tcx> + Repr<'tcx> + HasProjectionTypes + Clone
 {
-    assert!(param_substs.regions.is_erased());
-
     let substituted = value.subst(tcx, param_substs);
     normalize_associated_type(tcx, &substituted)
 }

--- a/src/test/compile-fail/recursion.rs
+++ b/src/test/compile-fail/recursion.rs
@@ -8,6 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//~^^^^^^^^^^ ERROR overflow
+//
+// We also get a second error message at the top of file (dummy
+// span). This is not helpful, but also kind of annoying to prevent,
+// so for now just live with it, since we also get a second message
+// that is more helpful.
+
 enum Nil {NilValue}
 struct Cons<T> {head:int, tail:T}
 trait Dot {fn dot(&self, other:Self) -> int;}

--- a/src/test/run-pass/associated-types-ref-from-struct.rs
+++ b/src/test/run-pass/associated-types-ref-from-struct.rs
@@ -1,0 +1,62 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test associated type references in structure fields.
+
+trait Test {
+    type V;
+
+    fn test(&self, value: &Self::V) -> bool;
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+struct TesterPair<T:Test> {
+    tester: T,
+    value: T::V,
+}
+
+impl<T:Test> TesterPair<T> {
+    fn new(tester: T, value: T::V) -> TesterPair<T> {
+        TesterPair { tester: tester, value: value }
+    }
+
+    fn test(&self) -> bool {
+        self.tester.test(&self.value)
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+struct EqU32(u32);
+impl Test for EqU32 {
+    type V = u32;
+
+    fn test(&self, value: &u32) -> bool {
+        self.0 == *value
+    }
+}
+
+struct EqI32(i32);
+impl Test for EqI32 {
+    type V = i32;
+
+    fn test(&self, value: &i32) -> bool {
+        self.0 == *value
+    }
+}
+
+fn main() {
+    let tester = TesterPair::new(EqU32(22), 23);
+    tester.test();
+
+    let tester = TesterPair::new(EqI32(22), 23);
+    tester.test();
+}

--- a/src/test/run-pass/associated-types-ref-in-struct-literal.rs
+++ b/src/test/run-pass/associated-types-ref-in-struct-literal.rs
@@ -1,0 +1,29 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test associated type references in a struct literal. Issue #20535.
+
+pub trait Foo {
+    type Bar;
+}
+
+impl Foo for int {
+    type Bar = int;
+}
+
+struct Thing<F: Foo> {
+    a: F,
+    b: F::Bar,
+}
+
+fn main() {
+    let thing = Thing{a: 1i, b: 2i};
+    assert_eq!(thing.a + 1, thing.b);
+}


### PR DESCRIPTION
There were various parts of trans that were failing to normalize associated types of fields. In addition, the use of `TypeContents` to compute whether something is sized was not able to handle projection types.

Fixes #20470.
Fixes #20368.
Fixes #20535.

r? @nick29581 
