### PR TITLE
Fix #[stable] coming before item-ending bracket instead of after

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -102,8 +102,8 @@ impl<T: ?Sized + Ord> Ord for Box<T> {
     fn cmp(&self, other: &Box<T>) -> Ordering {
         Ord::cmp(&**self, &**other)
     }
-
-#[stable]}
+}
+#[stable]
 impl<T: ?Sized + Eq> Eq for Box<T> {}
 
 impl<S: hash::Writer, T: ?Sized + Hash<S>> Hash<S> for Box<T> {


### PR DESCRIPTION
This changes a line that has `\n#[stable]}` to instead have `}\n#[stable]`.

The #[stable] has been before the bracket since https://github.com/rust-lang/rust/commit/b94bcbf56eab163517e8ffc93888284b8dbb6238.

This is a (very) minor change, and I have not built this locally because of my not-so-powerful machine.
