### PR TITLE
Feature gate box syntax

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -9,7 +9,9 @@
 // except according to those terms.
 
 #![crate_type = "bin"]
+#![allow(unknown_features)]
 #![feature(slicing_syntax, unboxed_closures)]
+#![feature(box_syntax)]
 
 #![deny(warnings)]
 

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -49,6 +49,15 @@ pub static HEAP: () = ();
 #[stable]
 pub struct Box<T>(Unique<T>);
 
+#[unstable]
+impl<T> Box<T> {
+    /// Moves `x` into a freshly allocated box on the global exchange heap.
+    #[unstable]
+    pub fn new(x: T) -> Box<T> {
+        box x
+    }
+}
+
 #[stable]
 impl<T: Default> Default for Box<T> {
     #[stable]

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -186,27 +186,27 @@ impl<T: ?Sized> DerefMut for Box<T> {
 mod test {
     #[test]
     fn test_owned_clone() {
-        let a = box 5i;
+        let a = Box::new(5i);
         let b: Box<int> = a.clone();
         assert!(a == b);
     }
 
     #[test]
     fn any_move() {
-        let a = box 8u as Box<Any>;
-        let b = box Test as Box<Any>;
+        let a = Box::new(8u) as Box<Any>;
+        let b = Box::new(Test) as Box<Any>;
 
         match a.downcast::<uint>() {
-            Ok(a) => { assert!(a == box 8u); }
+            Ok(a) => { assert!(a == Box::new(8u)); }
             Err(..) => panic!()
         }
         match b.downcast::<Test>() {
-            Ok(a) => { assert!(a == box Test); }
+            Ok(a) => { assert!(a == Box::new(Test)); }
             Err(..) => panic!()
         }
 
-        let a = box 8u as Box<Any>;
-        let b = box Test as Box<Any>;
+        let a = Box::new(8u) as Box<Any>;
+        let b = Box::new(Test) as Box<Any>;
 
         assert!(a.downcast::<Box<Test>>().is_err());
         assert!(b.downcast::<Box<uint>>().is_err());
@@ -214,8 +214,8 @@ mod test {
 
     #[test]
     fn test_show() {
-        let a = box 8u as Box<Any>;
-        let b = box Test as Box<Any>;
+        let a = Box::new(8u) as Box<Any>;
+        let b = Box::new(Test) as Box<Any>;
         let a_str = a.to_str();
         let b_str = b.to_str();
         assert_eq!(a_str, "Box<Any>");
@@ -232,6 +232,6 @@ mod test {
     #[test]
     fn deref() {
         fn homura<T: Deref<Target=i32>>(_: T) { }
-        homura(box 765i32);
+        homura(Box::new(765i32));
     }
 }

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -66,6 +66,7 @@
 #![no_std]
 #![allow(unknown_features)]
 #![feature(lang_items, unsafe_destructor)]
+#![feature(box_syntax)]
 
 #[macro_use]
 extern crate core;

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -24,6 +24,7 @@
 #![allow(unknown_features)]
 #![feature(unsafe_destructor, slicing_syntax)]
 #![feature(old_impl_check)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 #![no_std]
 

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -163,6 +163,8 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/",
        html_playground_url = "http://play.rust-lang.org/")]
+
+#![allow(unknown_features)]
 #![feature(slicing_syntax)]
 #![feature(box_syntax)]
 #![deny(missing_docs)]

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -164,6 +164,7 @@
        html_root_url = "http://doc.rust-lang.org/nightly/",
        html_playground_url = "http://play.rust-lang.org/")]
 #![feature(slicing_syntax)]
+#![feature(box_syntax)]
 #![deny(missing_docs)]
 
 extern crate regex;

--- a/src/libregex/lib.rs
+++ b/src/libregex/lib.rs
@@ -24,6 +24,7 @@
 
 #![allow(unknown_features)]
 #![feature(slicing_syntax)]
+#![feature(box_syntax)]
 #![deny(missing_docs)]
 
 #[cfg(test)]

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -25,6 +25,7 @@
 #![allow(unknown_features)]
 #![feature(quote)]
 #![feature(slicing_syntax, unsafe_destructor)]
+#![feature(box_syntax)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(old_impl_check)]
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -22,8 +22,10 @@
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://doc.rust-lang.org/nightly/")]
 
+#![allow(unknown_features)]
 #![feature(quote)]
 #![feature(slicing_syntax, unsafe_destructor)]
+#![feature(box_syntax)]
 #![feature(rustc_diagnostic_macros)]
 
 extern crate arena;

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -21,7 +21,9 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/")]
 
+#![allow(unknown_features)]
 #![feature(link_args)]
+#![feature(box_syntax)]
 
 extern crate libc;
 

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -22,6 +22,7 @@
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://doc.rust-lang.org/nightly/")]
 
+#![allow(unknown_features)]
 #![feature(quote)]
 #![feature(slicing_syntax, unsafe_destructor)]
 #![feature(box_syntax)]

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -24,6 +24,7 @@
 
 #![feature(quote)]
 #![feature(slicing_syntax, unsafe_destructor)]
+#![feature(box_syntax)]
 #![feature(rustc_diagnostic_macros)]
 
 extern crate arena;

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -73,6 +73,7 @@ This API is completely unstable and subject to change.
 
 #![feature(quote)]
 #![feature(slicing_syntax, unsafe_destructor)]
+#![feature(box_syntax)]
 #![feature(rustc_diagnostic_macros)]
 #![allow(non_camel_case_types)]
 

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -71,6 +71,7 @@ This API is completely unstable and subject to change.
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://doc.rust-lang.org/nightly/")]
 
+#![allow(unknown_features)]
 #![feature(quote)]
 #![feature(slicing_syntax, unsafe_destructor)]
 #![feature(box_syntax)]

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -17,6 +17,7 @@
        html_root_url = "http://doc.rust-lang.org/nightly/",
        html_playground_url = "http://play.rust-lang.org/")]
 #![feature(slicing_syntax)]
+#![feature(box_syntax)]
 
 extern crate arena;
 extern crate getopts;

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -24,6 +24,7 @@ Core encoding and decoding interfaces.
        html_playground_url = "http://play.rust-lang.org/")]
 #![allow(unknown_features)]
 #![feature(slicing_syntax)]
+#![feature(box_syntax)]
 #![feature(old_impl_check)]
 #![cfg_attr(stage0, allow(unused_attributes))]
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -107,6 +107,7 @@
 #![feature(linkage, thread_local, asm)]
 #![feature(lang_items, unsafe_destructor)]
 #![feature(slicing_syntax, unboxed_closures)]
+#![feature(box_syntax)]
 #![feature(old_impl_check)]
 #![cfg_attr(stage0, allow(unused_attributes))]
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -70,6 +70,7 @@ static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[
     ("associated_types", Accepted),
     ("visible_private_types", Active),
     ("slicing_syntax", Active),
+    ("box_syntax", Active),
 
     ("if_let", Accepted),
     ("while_let", Accepted),
@@ -343,6 +344,12 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
                                   e.span,
                                   "range syntax is experimental");
             }
+            ast::ExprBox(..) | ast::ExprUnary(ast::UnOp::UnUniq, _) => {
+                self.gate_feature("box_syntax",
+                                  e.span,
+                                  "box expression syntax is experimental in alpha release; \
+                                   you can call `Box::new` instead.");
+            }
             _ => {}
         }
         visit::walk_expr(self, e);
@@ -364,6 +371,11 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
                                   "multiple-element slice matches anywhere \
                                    but at the end of a slice (e.g. \
                                    `[0, ..xs, 0]` are experimental")
+            }
+            ast::PatBox(..) => {
+                self.gate_feature("box_syntax",
+                                  pattern.span,
+                                  "box pattern syntax is experimental in alpha release");
             }
             _ => {}
         }

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -24,6 +24,7 @@
 
 #![allow(unknown_features)]
 #![feature(slicing_syntax)]
+#![feature(box_syntax)]
 #![feature(quote, unsafe_destructor)]
 
 extern crate arena;

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -49,6 +49,7 @@
 
 #![allow(unknown_features)]
 #![feature(slicing_syntax)]
+#![feature(box_syntax)]
 #![deny(missing_docs)]
 
 #[macro_use] extern crate log;

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -30,6 +30,7 @@
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/")]
+#![allow(unknown_features)]
 #![feature(asm, slicing_syntax)]
 #![feature(box_syntax)]
 

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -31,6 +31,7 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/")]
 #![feature(asm, slicing_syntax)]
+#![feature(box_syntax)]
 
 extern crate getopts;
 extern crate regex;

--- a/src/test/auxiliary/cci_nested_lib.rs
+++ b/src/test/auxiliary/cci_nested_lib.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 use std::cell::RefCell;
 

--- a/src/test/auxiliary/issue-2380.rs
+++ b/src/test/auxiliary/issue-2380.rs
@@ -11,6 +11,8 @@
 #![crate_name="a"]
 #![crate_type = "lib"]
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub trait i<T> { }
 

--- a/src/test/auxiliary/method_self_arg1.rs
+++ b/src/test/auxiliary/method_self_arg1.rs
@@ -10,6 +10,9 @@
 
 #![crate_type = "lib"]
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 static mut COUNT: u64 = 1;
 
 pub fn get_count() -> u64 { unsafe { COUNT } }

--- a/src/test/auxiliary/method_self_arg2.rs
+++ b/src/test/auxiliary/method_self_arg2.rs
@@ -10,6 +10,9 @@
 
 #![crate_type = "lib"]
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 static mut COUNT: u64 = 1;
 
 pub fn get_count() -> u64 { unsafe { COUNT } }

--- a/src/test/compile-fail/autoderef-full-lval.rs
+++ b/src/test/compile-fail/autoderef-full-lval.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct clam {
     x: Box<isize>,
     y: Box<isize>,

--- a/src/test/compile-fail/borrow-tuple-fields.rs
+++ b/src/test/compile-fail/borrow-tuple-fields.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct Foo(Box<int>, int);
 
 struct Bar(int, int);

--- a/src/test/compile-fail/borrowck-array-double-move.rs
+++ b/src/test/compile-fail/borrowck-array-double-move.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn f() {
     let mut a = [box 0i, box 1i];
     drop(a[0]);

--- a/src/test/compile-fail/borrowck-loan-in-overloaded-op.rs
+++ b/src/test/compile-fail/borrowck-loan-in-overloaded-op.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_syntax)]
+
 use std::ops::Add;
 
 #[derive(Clone)]

--- a/src/test/compile-fail/borrowck-vec-pattern-nesting.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-nesting.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(advanced_slice_patterns)]
+#![feature(box_syntax)]
 
 fn a() {
     let mut vec = [box 1i, box 2, box 3];

--- a/src/test/compile-fail/destructure-trait-ref.rs
+++ b/src/test/compile-fail/destructure-trait-ref.rs
@@ -11,6 +11,8 @@
 // The regression test for #15031 to make sure destructuring trait
 // reference work properly.
 
+#![feature(box_syntax)]
+
 trait T {}
 impl T for int {}
 

--- a/src/test/compile-fail/feature-gate-box-expr.rs
+++ b/src/test/compile-fail/feature-gate-box-expr.rs
@@ -1,0 +1,23 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    use std::boxed::HEAP;
+
+    let x = box 'c'; //~ ERROR box expression syntax is experimental in alpha release
+    println!("x: {}", x);
+
+    let x = box () 'c'; //~ ERROR box expression syntax is experimental in alpha release
+    println!("x: {}", x);
+
+    let x = box (HEAP) 'c'; //~ ERROR box expression syntax is experimental in alpha release
+    println!("x: {}", x);
+}
+

--- a/src/test/compile-fail/feature-gate-box-pat.rs
+++ b/src/test/compile-fail/feature-gate-box-pat.rs
@@ -1,0 +1,14 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let box x = Box::new('c'); //~ ERROR box pattern syntax is experimental in alpha release
+    println!("x: {}", x);
+}

--- a/src/test/compile-fail/issue-12116.rs
+++ b/src/test/compile-fail/issue-12116.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_syntax)]
+
 enum IntList {
     Cons(int, Box<IntList>),
     Nil

--- a/src/test/compile-fail/issue-14084.rs
+++ b/src/test/compile-fail/issue-14084.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_syntax)]
+
 fn main() {
     box ( () ) 0;
     //~^ ERROR: only the managed heap and exchange heap are currently supported

--- a/src/test/compile-fail/issue-3601.rs
+++ b/src/test/compile-fail/issue-3601.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_syntax)]
 
 struct HTMLImageData {
     image: Option<String>

--- a/src/test/compile-fail/issue-4972.rs
+++ b/src/test/compile-fail/issue-4972.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_syntax)]
 
 trait MyTrait { }
 

--- a/src/test/compile-fail/issue-5100.rs
+++ b/src/test/compile-fail/issue-5100.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_syntax)]
+
 enum A { B, C }
 
 fn main() {

--- a/src/test/compile-fail/moves-based-on-type-block-bad.rs
+++ b/src/test/compile-fail/moves-based-on-type-block-bad.rs
@@ -10,6 +10,8 @@
 
 // ignore-tidy-linelength
 
+#![feature(box_syntax)]
+
 struct S {
     x: Box<E>
 }

--- a/src/test/compile-fail/regions-ref-in-fn-arg.rs
+++ b/src/test/compile-fail/regions-ref-in-fn-arg.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_syntax)]
 
 fn arg_item(box ref x: Box<int>) -> &'static int {
     x //~^ ERROR borrowed value does not live long enough

--- a/src/test/compile-fail/unreachable-arm.rs
+++ b/src/test/compile-fail/unreachable-arm.rs
@@ -10,6 +10,7 @@
 
 // error-pattern:unreachable pattern
 
+#![feature(box_syntax)]
 
 enum foo { a(Box<foo>, int), b(uint), }
 

--- a/src/test/run-fail/args-panic.rs
+++ b/src/test/run-fail/args-panic.rs
@@ -11,6 +11,9 @@
 
 // error-pattern:meep
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn f(_a: int, _b: int, _c: Box<int>) { panic!("moop"); }
 
 fn main() { f(1, panic!("meep"), box 42); }

--- a/src/test/run-fail/panic-macro-any-wrapped.rs
+++ b/src/test/run-fail/panic-macro-any-wrapped.rs
@@ -10,6 +10,9 @@
 
 // error-pattern:panicked at 'Box<Any>'
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn main() {
     panic!(box 612_i64);
 }

--- a/src/test/run-fail/panic-macro-any.rs
+++ b/src/test/run-fail/panic-macro-any.rs
@@ -10,6 +10,9 @@
 
 // error-pattern:panicked at 'Box<Any>'
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn main() {
     panic!(box 413i as Box<::std::any::Any+Send>);
 }

--- a/src/test/run-fail/unique-panic.rs
+++ b/src/test/run-fail/unique-panic.rs
@@ -9,4 +9,8 @@
 // except according to those terms.
 
 // error-pattern: panic
+
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn main() { box panic!(); }

--- a/src/test/run-fail/unwind-unique.rs
+++ b/src/test/run-fail/unwind-unique.rs
@@ -10,6 +10,8 @@
 
 // error-pattern:fail
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn failfn() {
     panic!();

--- a/src/test/run-pass/alignment-gep-tup-like-1.rs
+++ b/src/test/run-pass/alignment-gep-tup-like-1.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct pair<A,B> {
     a: A, b: B
 }

--- a/src/test/run-pass/assert-eq-macro-success.rs
+++ b/src/test/run-pass/assert-eq-macro-success.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 #[derive(PartialEq, Show)]
 struct Point { x : int }

--- a/src/test/run-pass/associated-type-doubleendediterator-object.rs
+++ b/src/test/run-pass/associated-type-doubleendediterator-object.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn pairwise_sub(mut t: Box<DoubleEndedIterator<Item=int>>) -> int {
     let mut result = 0;
     loop {

--- a/src/test/run-pass/autoderef-method-on-trait.rs
+++ b/src/test/run-pass/autoderef-method-on-trait.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 trait double {
     fn double(self: Box<Self>) -> uint;

--- a/src/test/run-pass/autoderef-method-priority.rs
+++ b/src/test/run-pass/autoderef-method-priority.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 trait double {
     fn double(self) -> uint;

--- a/src/test/run-pass/autoderef-method-twice-but-not-thrice.rs
+++ b/src/test/run-pass/autoderef-method-twice-but-not-thrice.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 trait double {
     fn double(self: Box<Self>) -> uint;

--- a/src/test/run-pass/autoderef-method-twice.rs
+++ b/src/test/run-pass/autoderef-method-twice.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 trait double {
     fn double(self: Box<Self>) -> uint;
 }

--- a/src/test/run-pass/autoderef-method.rs
+++ b/src/test/run-pass/autoderef-method.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 trait double {
     fn double(self: Box<Self>) -> uint;
 }

--- a/src/test/run-pass/autoref-intermediate-types-issue-3585.rs
+++ b/src/test/run-pass/autoref-intermediate-types-issue-3585.rs
@@ -9,6 +9,9 @@
 // except according to those terms.
 
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 trait Foo {
     fn foo(&self) -> String;
 }

--- a/src/test/run-pass/bitv-perf-test.rs
+++ b/src/test/run-pass/bitv-perf-test.rs
@@ -9,6 +9,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 extern crate collections;
 use std::collections::Bitv;
 

--- a/src/test/run-pass/borrowck-borrow-from-expr-block.rs
+++ b/src/test/run-pass/borrowck-borrow-from-expr-block.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn borrow<F>(x: &int, f: F) where F: FnOnce(&int) {
     f(x)

--- a/src/test/run-pass/borrowck-field-sensitivity.rs
+++ b/src/test/run-pass/borrowck-field-sensitivity.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct A { a: int, b: Box<int> }
 struct B { a: Box<int>, b: Box<int> }
 

--- a/src/test/run-pass/borrowck-macro-interaction-issue-6304.rs
+++ b/src/test/run-pass/borrowck-macro-interaction-issue-6304.rs
@@ -11,6 +11,7 @@
 // Check that we do not ICE when compiling this
 // macro, which reuses the expression `$id`
 
+#![feature(box_syntax)]
 
 struct Foo {
   a: int

--- a/src/test/run-pass/borrowck-move-by-capture-ok.rs
+++ b/src/test/run-pass/borrowck-move-by-capture-ok.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 
 pub fn main() {

--- a/src/test/run-pass/borrowck-mut-uniq.rs
+++ b/src/test/run-pass/borrowck-mut-uniq.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::mem::swap;
 
 #[derive(Show)]

--- a/src/test/run-pass/borrowck-use-mut-borrow.rs
+++ b/src/test/run-pass/borrowck-use-mut-borrow.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct A { a: int, b: Box<int> }
 
 fn field_copy_after_field_borrow() {

--- a/src/test/run-pass/cancel-clean-via-immediate-rvalue-ref.rs
+++ b/src/test/run-pass/cancel-clean-via-immediate-rvalue-ref.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn foo(x: &mut Box<u8>) {
     *x = box 5;

--- a/src/test/run-pass/capturing-logging.rs
+++ b/src/test/run-pass/capturing-logging.rs
@@ -11,6 +11,9 @@
 // ignore-android (FIXME #11419)
 // exec-env:RUST_LOG=info
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 #[macro_use]
 extern crate log;
 

--- a/src/test/run-pass/cci_borrow.rs
+++ b/src/test/run-pass/cci_borrow.rs
@@ -10,6 +10,8 @@
 
 // aux-build:cci_borrow_lib.rs
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 extern crate cci_borrow_lib;
 use cci_borrow_lib::foo;

--- a/src/test/run-pass/class-cast-to-trait-cross-crate-2.rs
+++ b/src/test/run-pass/class-cast-to-trait-cross-crate-2.rs
@@ -9,6 +9,10 @@
 // except according to those terms.
 
 // aux-build:cci_class_cast.rs
+
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 extern crate cci_class_cast;
 
 use std::string::ToString;

--- a/src/test/run-pass/class-separate-impl.rs
+++ b/src/test/run-pass/class-separate-impl.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::fmt;
 
 struct cat {

--- a/src/test/run-pass/cleanup-arm-conditional.rs
+++ b/src/test/run-pass/cleanup-arm-conditional.rs
@@ -21,6 +21,9 @@
 // Test that cleanup scope for temporaries created in a match
 // arm is confined to the match arm itself.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::os;
 
 struct Test { x: int }

--- a/src/test/run-pass/cleanup-rvalue-during-if-and-while.rs
+++ b/src/test/run-pass/cleanup-rvalue-during-if-and-while.rs
@@ -12,6 +12,8 @@
 // This test verifies that temporaries created for `while`'s and `if`
 // conditions are dropped after the condition is evaluated.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct Temporary;
 

--- a/src/test/run-pass/cleanup-rvalue-scopes.rs
+++ b/src/test/run-pass/cleanup-rvalue-scopes.rs
@@ -12,6 +12,8 @@
 // statement or end of block, as appropriate given the temporary
 // lifetime rules.
 
+#![feature(box_syntax)]
+
 use std::ops::Drop;
 
 static mut FLAGS: u64 = 0;

--- a/src/test/run-pass/cleanup-rvalue-temp-during-incomplete-alloc.rs
+++ b/src/test/run-pass/cleanup-rvalue-temp-during-incomplete-alloc.rs
@@ -24,6 +24,9 @@
 // It's unclear how likely such a bug is to recur, but it seems like a
 // scenario worth testing.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::thread::Thread;
 
 enum Conzabble {

--- a/src/test/run-pass/clone-with-exterior.rs
+++ b/src/test/run-pass/clone-with-exterior.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::thread::Thread;
 
 struct Pair {

--- a/src/test/run-pass/close-over-big-then-small-data.rs
+++ b/src/test/run-pass/close-over-big-then-small-data.rs
@@ -12,6 +12,9 @@
 // storing closure data (as we used to do), the u64 would
 // overwrite the u16.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct Pair<A,B> {
     a: A, b: B
 }

--- a/src/test/run-pass/coerce-expect-unsized.rs
+++ b/src/test/run-pass/coerce-expect-unsized.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::fmt::Show;
 
 // Check that coercions apply at the pointer level and don't cause

--- a/src/test/run-pass/coerce-match-calls.rs
+++ b/src/test/run-pass/coerce-match-calls.rs
@@ -1,0 +1,23 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that coercions are propagated through match and if expressions.
+
+use std::boxed::Box;
+
+pub fn main() {
+    let _: Box<[int]> = if true { Box::new([1i, 2, 3]) } else { Box::new([1i]) };
+
+    let _: Box<[int]> = match true { true => Box::new([1i, 2, 3]), false => Box::new([1i]) };
+
+    // Check we don't get over-keen at propagating coercions in the case of casts.
+    let x = if true { 42 } else { 42u8 } as u16;
+    let x = match true { true => 42, false => 42u8 } as u16;
+}

--- a/src/test/run-pass/coerce-match.rs
+++ b/src/test/run-pass/coerce-match.rs
@@ -10,6 +10,8 @@
 
 // Check that coercions are propagated through match and if expressions.
 
+#![feature(box_syntax)]
+
 pub fn main() {
     let _: Box<[int]> = if true { box [1i, 2, 3] } else { box [1i] };
 

--- a/src/test/run-pass/coerce-match.rs
+++ b/src/test/run-pass/coerce-match.rs
@@ -10,6 +10,7 @@
 
 // Check that coercions are propagated through match and if expressions.
 
+#![allow(unknown_features)]
 #![feature(box_syntax)]
 
 pub fn main() {

--- a/src/test/run-pass/const-bound.rs
+++ b/src/test/run-pass/const-bound.rs
@@ -11,6 +11,8 @@
 // Make sure const bounds work on things, and test that a few types
 // are const.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn foo<T: Sync>(x: T) -> T { x }
 

--- a/src/test/run-pass/crate-method-reexport-grrrrrrr.rs
+++ b/src/test/run-pass/crate-method-reexport-grrrrrrr.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 // This is a regression test that the metadata for the
 // name_pool::methods impl in the other crate is reachable from this

--- a/src/test/run-pass/deref-lval.rs
+++ b/src/test/run-pass/deref-lval.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 use std::cell::Cell;
 

--- a/src/test/run-pass/deref.rs
+++ b/src/test/run-pass/deref.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub fn main() {
     let x: Box<int> = box 10;

--- a/src/test/run-pass/deriving-default-box.rs
+++ b/src/test/run-pass/deriving-default-box.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::default::Default;
 
 #[derive(Default)]

--- a/src/test/run-pass/deriving-encodable-decodable-box.rs
+++ b/src/test/run-pass/deriving-encodable-decodable-box.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(old_orphan_check)]
 
 extern crate serialize;

--- a/src/test/run-pass/deriving-eq-ord-boxed-slice.rs
+++ b/src/test/run-pass/deriving-eq-ord-boxed-slice.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 #[derive(PartialEq, PartialOrd, Eq, Ord)]
 struct Foo(Box<[u8]>);
 

--- a/src/test/run-pass/drop-on-empty-block-exit.rs
+++ b/src/test/run-pass/drop-on-empty-block-exit.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 enum t { foo(Box<int>), }
 

--- a/src/test/run-pass/drop-struct-as-object.rs
+++ b/src/test/run-pass/drop-struct-as-object.rs
@@ -11,6 +11,9 @@
 // Test that destructor on a struct runs successfully after the struct
 // is boxed and converted to an object.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 static mut value: uint = 0;
 
 struct Cat {

--- a/src/test/run-pass/drop-trait-enum.rs
+++ b/src/test/run-pass/drop-trait-enum.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::thread::Thread;
 use std::sync::mpsc::{channel, Sender};
 

--- a/src/test/run-pass/dst-deref-mut.rs
+++ b/src/test/run-pass/dst-deref-mut.rs
@@ -10,6 +10,9 @@
 
 // Test that a custom deref with a fat pointer return type does not ICE
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::ops::{Deref, DerefMut};
 
 pub struct Arr {

--- a/src/test/run-pass/dst-deref.rs
+++ b/src/test/run-pass/dst-deref.rs
@@ -10,6 +10,9 @@
 
 // Test that a custom deref with a fat pointer return type does not ICE
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::ops::Deref;
 
 pub struct Arr {

--- a/src/test/run-pass/dst-struct.rs
+++ b/src/test/run-pass/dst-struct.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct Fat<T: ?Sized> {
     f1: int,
     f2: &'static str,

--- a/src/test/run-pass/dst-trait.rs
+++ b/src/test/run-pass/dst-trait.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct Fat<T: ?Sized> {
     f1: int,
     f2: &'static str,

--- a/src/test/run-pass/empty-allocation-non-null.rs
+++ b/src/test/run-pass/empty-allocation-non-null.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     assert!(Some(box() ()).is_some());
 

--- a/src/test/run-pass/empty-allocation-rvalue-non-null.rs
+++ b/src/test/run-pass/empty-allocation-rvalue-non-null.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let x = *box() ();
 }

--- a/src/test/run-pass/enum-nullable-simplifycfg-misopt.rs
+++ b/src/test/run-pass/enum-nullable-simplifycfg-misopt.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 /*!
  * This is a regression test for a bug in LLVM, fixed in upstream r179587,

--- a/src/test/run-pass/explicit-self-generic.rs
+++ b/src/test/run-pass/explicit-self-generic.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct LM { resize_at: uint, size: uint }
 
 impl Copy for LM {}

--- a/src/test/run-pass/explicit-self-objects-uniq.rs
+++ b/src/test/run-pass/explicit-self-objects-uniq.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 trait Foo {
     fn f(self: Box<Self>);

--- a/src/test/run-pass/explicit-self.rs
+++ b/src/test/run-pass/explicit-self.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 static tau: f64 = 2.0*3.14159265358979323;
 
 struct Point {x: f64, y: f64}

--- a/src/test/run-pass/expr-block-generic-unique1.rs
+++ b/src/test/run-pass/expr-block-generic-unique1.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn test_generic<T, F>(expected: Box<T>, eq: F) where T: Clone, F: FnOnce(Box<T>, Box<T>) -> bool {
     let actual: Box<T> = { expected.clone() };
     assert!(eq(expected, actual));

--- a/src/test/run-pass/expr-block-generic-unique2.rs
+++ b/src/test/run-pass/expr-block-generic-unique2.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn test_generic<T, F>(expected: T, eq: F) where T: Clone, F: FnOnce(T, T) -> bool {
     let actual: T = { expected.clone() };
     assert!(eq(expected, actual));

--- a/src/test/run-pass/expr-block-unique.rs
+++ b/src/test/run-pass/expr-block-unique.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 
-
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub fn main() { let x = { box 100i }; assert!((*x == 100)); }

--- a/src/test/run-pass/expr-if-unique.rs
+++ b/src/test/run-pass/expr-if-unique.rs
@@ -9,7 +9,8 @@
 // except according to those terms.
 
 
-
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 
 // Tests for if as expressions returning boxed types

--- a/src/test/run-pass/expr-match-generic-unique1.rs
+++ b/src/test/run-pass/expr-match-generic-unique1.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn test_generic<T: Clone, F>(expected: Box<T>, eq: F) where F: FnOnce(Box<T>, Box<T>) -> bool {
     let actual: Box<T> = match true {
         true => { expected.clone() },

--- a/src/test/run-pass/expr-match-generic-unique2.rs
+++ b/src/test/run-pass/expr-match-generic-unique2.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn test_generic<T: Clone, F>(expected: T, eq: F) where F: FnOnce(T, T) -> bool {
     let actual: T = match true {
         true => expected.clone(),

--- a/src/test/run-pass/expr-match-unique.rs
+++ b/src/test/run-pass/expr-match-unique.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 // Tests for match as expressions resulting in boxed types
 fn test_box() {

--- a/src/test/run-pass/fsu-moves-and-copies.rs
+++ b/src/test/run-pass/fsu-moves-and-copies.rs
@@ -11,6 +11,9 @@
 // Issue 4691: Ensure that functional-struct-updates operates
 // correctly and moves rather than copy when appropriate.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::marker::NoCopy as NP;
 
 struct ncint { np: NP, v: int }

--- a/src/test/run-pass/func-arg-incomplete-pattern.rs
+++ b/src/test/run-pass/func-arg-incomplete-pattern.rs
@@ -11,6 +11,8 @@
 // Test that we do not leak when the arg pattern must drop part of the
 // argument (in this case, the `y` field).
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct Foo {
     x: Box<uint>,

--- a/src/test/run-pass/func-arg-ref-pattern.rs
+++ b/src/test/run-pass/func-arg-ref-pattern.rs
@@ -14,6 +14,7 @@
 // boxes. Make sure that we don't free the box as we match the
 // pattern.
 
+#![feature(box_syntax)]
 
 fn getaddr(box ref x: Box<uint>) -> *const uint {
     let addr: *const uint = &*x;

--- a/src/test/run-pass/func-arg-ref-pattern.rs
+++ b/src/test/run-pass/func-arg-ref-pattern.rs
@@ -14,6 +14,7 @@
 // boxes. Make sure that we don't free the box as we match the
 // pattern.
 
+#![allow(unknown_features)]
 #![feature(box_syntax)]
 
 fn getaddr(box ref x: Box<uint>) -> *const uint {

--- a/src/test/run-pass/generic-alias-unique.rs
+++ b/src/test/run-pass/generic-alias-unique.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn id<T:Send>(t: T) -> T { return t; }
 
 pub fn main() {

--- a/src/test/run-pass/generic-exterior-unique.rs
+++ b/src/test/run-pass/generic-exterior-unique.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct Recbox<T> {x: Box<T>}
 

--- a/src/test/run-pass/generic-fn-unique.rs
+++ b/src/test/run-pass/generic-fn-unique.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn f<T>(x: Box<T>) -> Box<T> { return x; }
 
 pub fn main() { let x = f(box 3i); println!("{}", *x); }

--- a/src/test/run-pass/generic-object.rs
+++ b/src/test/run-pass/generic-object.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 trait Foo<T> {
     fn get(&self) -> T;

--- a/src/test/run-pass/generic-recursive-tag.rs
+++ b/src/test/run-pass/generic-recursive-tag.rs
@@ -10,6 +10,8 @@
 
 // ignore-pretty FIXME(#14193)
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 enum list<T> { cons(Box<T>, Box<list<T>>), nil, }
 

--- a/src/test/run-pass/generic-tag.rs
+++ b/src/test/run-pass/generic-tag.rs
@@ -10,6 +10,8 @@
 
 #![allow(dead_assignment)]
 #![allow(unused_variable)]
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 enum option<T> { some(Box<T>), none, }
 

--- a/src/test/run-pass/generic-unique.rs
+++ b/src/test/run-pass/generic-unique.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct Triple<T> { x: T, y: T, z: T }
 

--- a/src/test/run-pass/hashmap-memory.rs
+++ b/src/test/run-pass/hashmap-memory.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 
 /**

--- a/src/test/run-pass/hrtb-precedence-of-plus.rs
+++ b/src/test/run-pass/hrtb-precedence-of-plus.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 
 // Test that `Fn(int) -> int + 'static` parses as `(Fn(int) -> int) +

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -13,6 +13,8 @@
 
 #![deny(warnings)]
 #![allow(unused_must_use)]
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 use std::fmt;
 

--- a/src/test/run-pass/init-res-into-things.rs
+++ b/src/test/run-pass/init-res-into-things.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unsafe_destructor)]
 
 use std::cell::Cell;

--- a/src/test/run-pass/intrinsic-atomics.rs
+++ b/src/test/run-pass/intrinsic-atomics.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(intrinsics)]
 
 mod rusti {

--- a/src/test/run-pass/intrinsic-move-val.rs
+++ b/src/test/run-pass/intrinsic-move-val.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(intrinsics)]
 
 use std::mem::transmute;

--- a/src/test/run-pass/issue-10682.rs
+++ b/src/test/run-pass/issue-10682.rs
@@ -11,6 +11,9 @@
 // Regression test for issue #10682
 // Nested `proc` usage can't use outer owned data
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn work(_: Box<int>) {}
 fn foo<F:FnOnce()>(_: F) {}
 

--- a/src/test/run-pass/issue-10767.rs
+++ b/src/test/run-pass/issue-10767.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub fn main() {
     fn f() {

--- a/src/test/run-pass/issue-10802.rs
+++ b/src/test/run-pass/issue-10802.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct DroppableStruct;
 enum DroppableEnum {
     DroppableVariant1, DroppableVariant2

--- a/src/test/run-pass/issue-11205.rs
+++ b/src/test/run-pass/issue-11205.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 #![allow(dead_code)]
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 trait Foo {}
 impl Foo for int {}

--- a/src/test/run-pass/issue-11552.rs
+++ b/src/test/run-pass/issue-11552.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_syntax)]
 
 #[derive(Clone)]
 enum Noun

--- a/src/test/run-pass/issue-11552.rs
+++ b/src/test/run-pass/issue-11552.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
 #![feature(box_syntax)]
 
 #[derive(Clone)]

--- a/src/test/run-pass/issue-11677.rs
+++ b/src/test/run-pass/issue-11677.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 #![allow(dead_code)]
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 // this code used to cause an ICE
 

--- a/src/test/run-pass/issue-12744.rs
+++ b/src/test/run-pass/issue-12744.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn main() {
     fn test() -> Box<std::any::Any + 'static> { box 1i }
     println!("{:?}", test())

--- a/src/test/run-pass/issue-13323.rs
+++ b/src/test/run-pass/issue-13323.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct StrWrap {
     s: String
 }

--- a/src/test/run-pass/issue-13808.rs
+++ b/src/test/run-pass/issue-13808.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct Foo<'a> {
     listener: Box<FnMut() + 'a>,
 }

--- a/src/test/run-pass/issue-14399.rs
+++ b/src/test/run-pass/issue-14399.rs
@@ -13,6 +13,9 @@
 // value was coerced to a trait object. (v.clone() returns Box<B1>
 // which is coerced to Box<A>).
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 #[derive(Clone)]
 struct B1;
 

--- a/src/test/run-pass/issue-14589.rs
+++ b/src/test/run-pass/issue-14589.rs
@@ -11,6 +11,9 @@
 // All 3 expressions should work in that the argument gets
 // coerced to a trait object
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn main() {
     send::<Box<Foo>>(box Output(0));
     Test::<Box<Foo>>::foo(box Output(0));

--- a/src/test/run-pass/issue-14919.rs
+++ b/src/test/run-pass/issue-14919.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 trait Matcher {
     fn next_match(&mut self) -> Option<(uint, uint)>;
 }

--- a/src/test/run-pass/issue-15571.rs
+++ b/src/test/run-pass/issue-15571.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn match_on_local() {
     let mut foo = Some(box 5i);
     match foo {

--- a/src/test/run-pass/issue-15763.rs
+++ b/src/test/run-pass/issue-15763.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 #[derive(PartialEq, Show)]
 struct Bar {

--- a/src/test/run-pass/issue-16668.rs
+++ b/src/test/run-pass/issue-16668.rs
@@ -10,6 +10,8 @@
 
 // ignore-pretty
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 
 struct Parser<'a, I, O> {

--- a/src/test/run-pass/issue-16739.rs
+++ b/src/test/run-pass/issue-16739.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 
 // Test that unboxing shim for calling rust-call ABI methods through a

--- a/src/test/run-pass/issue-16774.rs
+++ b/src/test/run-pass/issue-16774.rs
@@ -8,8 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(unboxed_closures)]
+#![allow(unknown_features)]
 #![feature(box_syntax)]
+#![feature(unboxed_closures)]
 
 use std::ops::{Deref, DerefMut};
 

--- a/src/test/run-pass/issue-16774.rs
+++ b/src/test/run-pass/issue-16774.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(unboxed_closures)]
+#![feature(box_syntax)]
 
 use std::ops::{Deref, DerefMut};
 

--- a/src/test/run-pass/issue-17322.rs
+++ b/src/test/run-pass/issue-17322.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::io;
 
 fn f(wr: &mut Writer) {

--- a/src/test/run-pass/issue-17734.rs
+++ b/src/test/run-pass/issue-17734.rs
@@ -10,6 +10,9 @@
 
 // Test that generating drop glue for Box<str> doesn't ICE
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn f(s: Box<str>) -> Box<str> {
     s
 }

--- a/src/test/run-pass/issue-18425.rs
+++ b/src/test/run-pass/issue-18425.rs
@@ -11,6 +11,9 @@
 // Check that trans doesn't ICE when translating an array repeat
 // expression with a count of 1 and a non-Copy element type.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn main() {
     let _ = [box 1u; 1];
 }

--- a/src/test/run-pass/issue-2288.rs
+++ b/src/test/run-pass/issue-2288.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 trait clam<A> {
   fn chowder(&self, y: A);

--- a/src/test/run-pass/issue-2633-2.rs
+++ b/src/test/run-pass/issue-2633-2.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 
 fn a_val(x: Box<int>, y: Box<int>) -> int {
     *x + *y

--- a/src/test/run-pass/issue-2708.rs
+++ b/src/test/run-pass/issue-2708.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct Font {
     fontbuf: uint,

--- a/src/test/run-pass/issue-2718.rs
+++ b/src/test/run-pass/issue-2718.rs
@@ -11,6 +11,8 @@
 //
 // ignore-lexer-test FIXME #15883
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unsafe_destructor)]
 
 pub type Task = int;

--- a/src/test/run-pass/issue-2734.rs
+++ b/src/test/run-pass/issue-2734.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 trait hax { }
 impl<A> hax for A { }

--- a/src/test/run-pass/issue-2735.rs
+++ b/src/test/run-pass/issue-2735.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 trait hax { }
 impl<A> hax for A { }

--- a/src/test/run-pass/issue-2935.rs
+++ b/src/test/run-pass/issue-2935.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 //type t = { a: int };
 // type t = { a: bool };

--- a/src/test/run-pass/issue-3012-2.rs
+++ b/src/test/run-pass/issue-3012-2.rs
@@ -10,6 +10,8 @@
 
 // aux-build:issue-3012-1.rs
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 extern crate socketlib;
 extern crate libc;

--- a/src/test/run-pass/issue-3026.rs
+++ b/src/test/run-pass/issue-3026.rs
@@ -9,6 +9,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 extern crate collections;
 
 use std::collections::HashMap;

--- a/src/test/run-pass/issue-3052.rs
+++ b/src/test/run-pass/issue-3052.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 type Connection = Box<FnMut(Vec<u8>) + 'static>;
 

--- a/src/test/run-pass/issue-3121.rs
+++ b/src/test/run-pass/issue-3121.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 enum side { mayo, catsup, vinegar }
 enum order { hamburger, fries(side), shake }

--- a/src/test/run-pass/issue-3290.rs
+++ b/src/test/run-pass/issue-3290.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
    let mut x = box 3i;
    x = x;

--- a/src/test/run-pass/issue-3424.rs
+++ b/src/test/run-pass/issue-3424.rs
@@ -11,6 +11,8 @@
 
 // rustc --test ignores2.rs && ./ignores2
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 
 use std::path::{Path};

--- a/src/test/run-pass/issue-3447.rs
+++ b/src/test/run-pass/issue-3447.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 use std::cell::RefCell;
 

--- a/src/test/run-pass/issue-3609.rs
+++ b/src/test/run-pass/issue-3609.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::thread::Thread;
 use std::sync::mpsc::Sender;
 use std::thunk::Invoke;

--- a/src/test/run-pass/issue-3794.rs
+++ b/src/test/run-pass/issue-3794.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 trait T {
     fn print(&self);
 }

--- a/src/test/run-pass/issue-3878.rs
+++ b/src/test/run-pass/issue-3878.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 #![allow(path_statement)]
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub fn main() {
     let y = box 1i;

--- a/src/test/run-pass/issue-4735.rs
+++ b/src/test/run-pass/issue-4735.rs
@@ -10,6 +10,9 @@
 
 // ignore-fast doesn't like extern crate
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 extern crate libc;
 
 use std::mem::transmute;

--- a/src/test/run-pass/issue-4759.rs
+++ b/src/test/run-pass/issue-4759.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct T { a: Box<int> }
 

--- a/src/test/run-pass/issue-5192.rs
+++ b/src/test/run-pass/issue-5192.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub trait EventLoop {
 }

--- a/src/test/run-pass/issue-5666.rs
+++ b/src/test/run-pass/issue-5666.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct Dog {
     name : String

--- a/src/test/run-pass/issue-5718.rs
+++ b/src/test/run-pass/issue-5718.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct Element;
 
 macro_rules! foo {

--- a/src/test/run-pass/issue-5884.rs
+++ b/src/test/run-pass/issue-5884.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub struct Foo {
     a: int,

--- a/src/test/run-pass/issue-6117.rs
+++ b/src/test/run-pass/issue-6117.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 enum Either<T, U> { Left(T), Right(U) }
 

--- a/src/test/run-pass/issue-6128.rs
+++ b/src/test/run-pass/issue-6128.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 extern crate collections;
 
 use std::collections::HashMap;

--- a/src/test/run-pass/issue-6318.rs
+++ b/src/test/run-pass/issue-6318.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub enum Thing {
     A(Box<Foo+'static>)

--- a/src/test/run-pass/issue-6557.rs
+++ b/src/test/run-pass/issue-6557.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_syntax)]
 
 fn foo(box (_x, _y): Box<(int, int)>) {}
 

--- a/src/test/run-pass/issue-6557.rs
+++ b/src/test/run-pass/issue-6557.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
 #![feature(box_syntax)]
 
 fn foo(box (_x, _y): Box<(int, int)>) {}

--- a/src/test/run-pass/issue-7673-cast-generically-implemented-trait.rs
+++ b/src/test/run-pass/issue-7673-cast-generically-implemented-trait.rs
@@ -14,6 +14,8 @@
 
 */
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub fn main() {}
 

--- a/src/test/run-pass/issue-8498.rs
+++ b/src/test/run-pass/issue-8498.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     match &[(box 5i,box 7i)] {
         ps => {

--- a/src/test/run-pass/issue-9129.rs
+++ b/src/test/run-pass/issue-9129.rs
@@ -10,6 +10,8 @@
 
 // ignore-pretty
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub trait bomb { fn boom(&self, Ident); }
 pub struct S;

--- a/src/test/run-pass/issue-9382.rs
+++ b/src/test/run-pass/issue-9382.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 #![allow(unnecessary_allocation)]
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 // Tests for a previous bug that occurred due to an interaction
 // between struct field initialization and the auto-coercion

--- a/src/test/run-pass/kindck-owned-trait-contains-1.rs
+++ b/src/test/run-pass/kindck-owned-trait-contains-1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 trait repeat<A> { fn get(&self) -> A; }
 

--- a/src/test/run-pass/last-use-in-cap-clause.rs
+++ b/src/test/run-pass/last-use-in-cap-clause.rs
@@ -10,6 +10,8 @@
 
 // Make sure #1399 stays fixed
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 
 struct A { a: Box<int> }

--- a/src/test/run-pass/last-use-is-capture.rs
+++ b/src/test/run-pass/last-use-is-capture.rs
@@ -10,6 +10,9 @@
 
 // Make sure #1399 stays fixed
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct A { a: Box<int> }
 
 pub fn main() {

--- a/src/test/run-pass/leak-unique-as-tydesc.rs
+++ b/src/test/run-pass/leak-unique-as-tydesc.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn leaky<T>(_t: T) { }
 

--- a/src/test/run-pass/let-assignability.rs
+++ b/src/test/run-pass/let-assignability.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn f() {
     let a = box 1;
     let b: &int = &*a;

--- a/src/test/run-pass/list.rs
+++ b/src/test/run-pass/list.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 enum list { cons(int, Box<list>), nil, }
 

--- a/src/test/run-pass/match-implicit-copy-unique.rs
+++ b/src/test/run-pass/match-implicit-copy-unique.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct Pair { a: Box<int>, b: Box<int> }
 

--- a/src/test/run-pass/match-unique-bind.rs
+++ b/src/test/run-pass/match-unique-bind.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_syntax)]
+
 pub fn main() {
     match box 100i {
       box x => {

--- a/src/test/run-pass/match-unique-bind.rs
+++ b/src/test/run-pass/match-unique-bind.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
 #![feature(box_syntax)]
 
 pub fn main() {

--- a/src/test/run-pass/match-value-binding-in-guard-3291.rs
+++ b/src/test/run-pass/match-value-binding-in-guard-3291.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn foo(x: Option<Box<int>>, b: bool) -> int {
     match x {

--- a/src/test/run-pass/method-self-arg-aux1.rs
+++ b/src/test/run-pass/method-self-arg-aux1.rs
@@ -10,6 +10,9 @@
 
 // Test method calls with self as an argument (cross-crate)
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 // aux-build:method_self_arg1.rs
 extern crate method_self_arg1;
 use method_self_arg1::Foo;

--- a/src/test/run-pass/method-self-arg-aux2.rs
+++ b/src/test/run-pass/method-self-arg-aux2.rs
@@ -10,6 +10,9 @@
 
 // Test method calls with self as an argument (cross-crate)
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 // aux-build:method_self_arg2.rs
 extern crate method_self_arg2;
 use method_self_arg2::{Foo, Bar};

--- a/src/test/run-pass/method-self-arg-trait.rs
+++ b/src/test/run-pass/method-self-arg-trait.rs
@@ -10,6 +10,9 @@
 
 // Test method calls with self as an argument
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 static mut COUNT: u64 = 1;
 
 struct Foo;

--- a/src/test/run-pass/method-self-arg.rs
+++ b/src/test/run-pass/method-self-arg.rs
@@ -10,6 +10,9 @@
 
 // Test method calls with self as an argument
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 static mut COUNT: uint = 1;
 
 struct Foo;

--- a/src/test/run-pass/method-two-trait-defer-resolution-2.rs
+++ b/src/test/run-pass/method-two-trait-defer-resolution-2.rs
@@ -16,6 +16,9 @@
 // version will run (note that the `push` occurs after the call to
 // `foo()`).
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 trait Foo {
     fn foo(&self) -> int;
 }

--- a/src/test/run-pass/move-1-unique.rs
+++ b/src/test/run-pass/move-1-unique.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 #[derive(Clone)]
 struct Triple {

--- a/src/test/run-pass/move-2-unique.rs
+++ b/src/test/run-pass/move-2-unique.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct X { x: int, y: int, z: int }
 

--- a/src/test/run-pass/move-2.rs
+++ b/src/test/run-pass/move-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct X { x: int, y: int, z: int }
 

--- a/src/test/run-pass/move-3-unique.rs
+++ b/src/test/run-pass/move-3-unique.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 #[derive(Clone)]
 struct Triple {

--- a/src/test/run-pass/move-4-unique.rs
+++ b/src/test/run-pass/move-4-unique.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct Triple {a: int, b: int, c: int}
 

--- a/src/test/run-pass/move-4.rs
+++ b/src/test/run-pass/move-4.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct Triple { a: int, b: int, c: int }
 

--- a/src/test/run-pass/move-arg-2-unique.rs
+++ b/src/test/run-pass/move-arg-2-unique.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn test(foo: Box<Vec<int>> ) { assert!(((*foo)[0] == 10)); }
 

--- a/src/test/run-pass/move-arg-2.rs
+++ b/src/test/run-pass/move-arg-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn test(foo: Box<Vec<int>>) { assert!(((*foo)[0] == 10)); }
 

--- a/src/test/run-pass/mut-function-arguments.rs
+++ b/src/test/run-pass/mut-function-arguments.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn f(mut y: Box<int>) {
     *y = 5;

--- a/src/test/run-pass/new-box-syntax.rs
+++ b/src/test/run-pass/new-box-syntax.rs
@@ -11,6 +11,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+#![allow(unknown_features)]
 #![feature(box_syntax)]
 
 // Tests that the new `box` syntax works with unique pointers.

--- a/src/test/run-pass/new-box-syntax.rs
+++ b/src/test/run-pass/new-box-syntax.rs
@@ -11,6 +11,8 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+#![feature(box_syntax)]
+
 // Tests that the new `box` syntax works with unique pointers.
 
 use std::boxed::{Box, HEAP};

--- a/src/test/run-pass/new-box.rs
+++ b/src/test/run-pass/new-box.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn f(x: Box<int>) {
     let y: &int = &*x;

--- a/src/test/run-pass/newlambdas-ret-infer.rs
+++ b/src/test/run-pass/newlambdas-ret-infer.rs
@@ -11,6 +11,9 @@
 // Test that the lambda kind is inferred correctly as a return
 // expression
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn unique() -> Box<FnMut()+'static> { return box || (); }
 
 pub fn main() {

--- a/src/test/run-pass/newlambdas-ret-infer2.rs
+++ b/src/test/run-pass/newlambdas-ret-infer2.rs
@@ -11,6 +11,9 @@
 // Test that the lambda kind is inferred correctly as a return
 // expression
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn unique() -> Box<FnMut()+'static> { box || () }
 
 pub fn main() {

--- a/src/test/run-pass/nullable-pointer-iotareduction.rs
+++ b/src/test/run-pass/nullable-pointer-iotareduction.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::{option, mem};
 
 // Iota-reduction is a rule in the Calculus of (Co-)Inductive Constructions,

--- a/src/test/run-pass/object-one-type-two-traits.rs
+++ b/src/test/run-pass/object-one-type-two-traits.rs
@@ -11,6 +11,9 @@
 // Testing creating two vtables with the same self type, but different
 // traits.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::any::Any;
 
 trait Wrap {

--- a/src/test/run-pass/objects-owned-object-borrowed-method-headerless.rs
+++ b/src/test/run-pass/objects-owned-object-borrowed-method-headerless.rs
@@ -12,6 +12,9 @@
 // closed over do not contain managed values, and thus the boxes do
 // not have headers.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 
 trait FooTrait {
     fn foo(&self) -> uint;

--- a/src/test/run-pass/objects-owned-object-owned-method.rs
+++ b/src/test/run-pass/objects-owned-object-owned-method.rs
@@ -12,6 +12,8 @@
 // closed over contain managed values. This implies that the boxes
 // will have headers that must be skipped over.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 trait FooTrait {
     fn foo(self: Box<Self>) -> uint;

--- a/src/test/run-pass/output-slot-variants.rs
+++ b/src/test/run-pass/output-slot-variants.rs
@@ -10,6 +10,8 @@
 
 #![allow(dead_assignment)]
 #![allow(unused_variable)]
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct A { a: int, b: int }
 struct Abox { a: Box<int>, b: Box<int> }

--- a/src/test/run-pass/overloaded-autoderef.rs
+++ b/src/test/run-pass/overloaded-autoderef.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::num::ToPrimitive;

--- a/src/test/run-pass/overloaded-deref.rs
+++ b/src/test/run-pass/overloaded-deref.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::string::String;

--- a/src/test/run-pass/overloaded-index-autoderef.rs
+++ b/src/test/run-pass/overloaded-index-autoderef.rs
@@ -10,6 +10,9 @@
 
 // Test overloaded indexing combined with autoderef.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::ops::{Index, IndexMut};
 
 struct Foo {

--- a/src/test/run-pass/owned-implies-static.rs
+++ b/src/test/run-pass/owned-implies-static.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn f<T: 'static>(_x: T) {}
 
 pub fn main() {

--- a/src/test/run-pass/pure-sum.rs
+++ b/src/test/run-pass/pure-sum.rs
@@ -10,6 +10,8 @@
 
 // Check that functions can modify local state.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn sums_to(v: Vec<int> , sum: int) -> bool {
     let mut i = 0u;

--- a/src/test/run-pass/rcvr-borrowed-to-region.rs
+++ b/src/test/run-pass/rcvr-borrowed-to-region.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 trait get {
     fn get(self) -> int;

--- a/src/test/run-pass/regions-borrow-at.rs
+++ b/src/test/run-pass/regions-borrow-at.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn foo(x: &uint) -> uint {
     *x

--- a/src/test/run-pass/regions-borrow-uniq.rs
+++ b/src/test/run-pass/regions-borrow-uniq.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn foo(x: &uint) -> uint {
     *x
 }

--- a/src/test/run-pass/regions-close-over-type-parameter-successfully.rs
+++ b/src/test/run-pass/regions-close-over-type-parameter-successfully.rs
@@ -11,6 +11,9 @@
 // A test where we (successfully) close over a reference into
 // an object.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 trait SomeTrait { fn get(&self) -> int; }
 
 impl<'a> SomeTrait for &'a int {

--- a/src/test/run-pass/regions-copy-closure.rs
+++ b/src/test/run-pass/regions-copy-closure.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 
 struct closure_box<'a> {

--- a/src/test/run-pass/regions-dependent-addr-of.rs
+++ b/src/test/run-pass/regions-dependent-addr-of.rs
@@ -11,6 +11,7 @@
 // Test lifetimes are linked properly when we create dependent region pointers.
 // Issue #3148.
 
+#![allow(unknown_features)]
 #![feature(box_syntax)]
 
 struct A {

--- a/src/test/run-pass/regions-dependent-addr-of.rs
+++ b/src/test/run-pass/regions-dependent-addr-of.rs
@@ -11,6 +11,7 @@
 // Test lifetimes are linked properly when we create dependent region pointers.
 // Issue #3148.
 
+#![feature(box_syntax)]
 
 struct A {
     value: B

--- a/src/test/run-pass/regions-early-bound-trait-param.rs
+++ b/src/test/run-pass/regions-early-bound-trait-param.rs
@@ -11,6 +11,8 @@
 // Tests that you can use an early-bound lifetime parameter as
 // on of the generic parameters in a trait.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 trait Trait<'a> {
     fn long(&'a self) -> int;

--- a/src/test/run-pass/regions-escape-into-other-fn.rs
+++ b/src/test/run-pass/regions-escape-into-other-fn.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn foo(x: &uint) -> &uint { x }
 fn bar(x: &uint) -> uint { *x }

--- a/src/test/run-pass/regions-fn-subtyping.rs
+++ b/src/test/run-pass/regions-fn-subtyping.rs
@@ -12,6 +12,8 @@
 
 #![allow(dead_assignment)]
 #![allow(unused_variable)]
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 // Should pass region checking.
 fn ok(f: Box<FnMut(&uint)>) {

--- a/src/test/run-pass/regions-infer-borrow-scope-within-loop-ok.rs
+++ b/src/test/run-pass/regions-infer-borrow-scope-within-loop-ok.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn borrow<T>(x: &T) -> &T {x}
 
 pub fn main() {

--- a/src/test/run-pass/regions-infer-borrow-scope.rs
+++ b/src/test/run-pass/regions-infer-borrow-scope.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct Point {x: int, y: int}
 

--- a/src/test/run-pass/regions-lifetime-nonfree-late-bound.rs
+++ b/src/test/run-pass/regions-lifetime-nonfree-late-bound.rs
@@ -22,6 +22,9 @@
 // doing region-folding, when really all clients of the region-folding
 // case only want to see FREE lifetime variables, not bound ones.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     fn explicit() {
         fn test<F>(_x: Option<Box<F>>) where F: FnMut(Box<for<'a> FnMut(&'a int)>) {}

--- a/src/test/run-pass/regions-relate-bound-regions-on-closures-to-inference-variables.rs
+++ b/src/test/run-pass/regions-relate-bound-regions-on-closures-to-inference-variables.rs
@@ -17,6 +17,9 @@
 // changes were caught. However, those uses in the compiler could
 // easily get changed or refactored away in the future.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct Ctxt<'tcx> {
     x: &'tcx Vec<int>
 }

--- a/src/test/run-pass/regions-static-closure.rs
+++ b/src/test/run-pass/regions-static-closure.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 
 struct closure_box<'a> {

--- a/src/test/run-pass/rust-log-filter.rs
+++ b/src/test/run-pass/rust-log-filter.rs
@@ -10,6 +10,9 @@
 
 // exec-env:RUST_LOG=rust-log-filter/f.o
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 #[macro_use]
 extern crate log;
 

--- a/src/test/run-pass/self-impl.rs
+++ b/src/test/run-pass/self-impl.rs
@@ -10,6 +10,9 @@
 
 // Test that we can use `Self` types in impls in the expected way.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct Foo;
 
 // Test uses on inherent impl.

--- a/src/test/run-pass/self-in-mut-slot-default-method.rs
+++ b/src/test/run-pass/self-in-mut-slot-default-method.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct X {
     a: int

--- a/src/test/run-pass/self-re-assign.rs
+++ b/src/test/run-pass/self-re-assign.rs
@@ -11,6 +11,9 @@
 // Ensure assigning an owned or managed variable to itself works. In particular,
 // that we do not glue_drop before we glue_take (#3290).
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::rc::Rc;
 
 pub fn main() {

--- a/src/test/run-pass/sendfn-spawn-with-fn-arg.rs
+++ b/src/test/run-pass/sendfn-spawn-with-fn-arg.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::thread::Thread;
 
 pub fn main() { test05(); }

--- a/src/test/run-pass/show-boxed-slice.rs
+++ b/src/test/run-pass/show-boxed-slice.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 #[derive(Show)]
 struct Foo(Box<[u8]>);
 

--- a/src/test/run-pass/task-spawn-move-and-copy.rs
+++ b/src/test/run-pass/task-spawn-move-and-copy.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::thread::Thread;
 use std::sync::mpsc::channel;
 

--- a/src/test/run-pass/task-stderr.rs
+++ b/src/test/run-pass/task-stderr.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::sync::mpsc::channel;
 use std::io::{ChanReader, ChanWriter};
 use std::thread;

--- a/src/test/run-pass/trait-bounds-in-arc.rs
+++ b/src/test/run-pass/trait-bounds-in-arc.rs
@@ -13,6 +13,8 @@
 
 // ignore-pretty
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 
 use std::sync::Arc;

--- a/src/test/run-pass/trait-coercion-generic.rs
+++ b/src/test/run-pass/trait-coercion-generic.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 trait Trait<T> {
     fn f(&self, x: T);

--- a/src/test/run-pass/trait-coercion.rs
+++ b/src/test/run-pass/trait-coercion.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::io;
 
 trait Trait {

--- a/src/test/run-pass/trait-contravariant-self.rs
+++ b/src/test/run-pass/trait-contravariant-self.rs
@@ -22,6 +22,9 @@
 // 4. `Bar for Box<Foo> <: Bar for Box<Foo:Send>` because
 //    `Box<Foo:Send> <: Box<Foo>`.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 trait Foo { }
 struct SFoo;
 impl Foo for SFoo { }

--- a/src/test/run-pass/trait-object-generics.rs
+++ b/src/test/run-pass/trait-object-generics.rs
@@ -10,6 +10,8 @@
 
 // test for #8664
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub trait Trait2<A> {
     fn doit(&self);

--- a/src/test/run-pass/traits-conditional-dispatch.rs
+++ b/src/test/run-pass/traits-conditional-dispatch.rs
@@ -12,6 +12,9 @@
 // blanket impl for T:Copy coexists with an impl for Box<T>, because
 // Box does not impl Copy.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 trait Get {
     fn get(&self) -> Self;
 }

--- a/src/test/run-pass/type-param-constraints.rs
+++ b/src/test/run-pass/type-param-constraints.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn p_foo<T>(_pinned: T) { }
 fn s_foo<T>(_shared: T) { }

--- a/src/test/run-pass/typeclasses-eq-example-static.rs
+++ b/src/test/run-pass/typeclasses-eq-example-static.rs
@@ -9,6 +9,9 @@
 // except according to those terms.
 
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 // Example from lkuper's intern talk, August 2012 -- now with static
 // methods!
 use Color::{cyan, magenta, yellow, black};

--- a/src/test/run-pass/typeclasses-eq-example.rs
+++ b/src/test/run-pass/typeclasses-eq-example.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 // Example from lkuper's intern talk, August 2012.
 use Color::{cyan, magenta, yellow, black};

--- a/src/test/run-pass/ufcs-explicit-self.rs
+++ b/src/test/run-pass/ufcs-explicit-self.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct Foo {
     f: int,
 }

--- a/src/test/run-pass/unboxed-closures-boxed.rs
+++ b/src/test/run-pass/unboxed-closures-boxed.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 
 use std::ops::FnMut;

--- a/src/test/run-pass/unboxed-closures-call-sugar-object-autoderef.rs
+++ b/src/test/run-pass/unboxed-closures-call-sugar-object-autoderef.rs
@@ -10,6 +10,8 @@
 
 // Test that the call operator autoderefs when calling to an object type.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 
 use std::ops::FnMut;

--- a/src/test/run-pass/unboxed-closures-call-sugar-object.rs
+++ b/src/test/run-pass/unboxed-closures-call-sugar-object.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 
 use std::ops::FnMut;

--- a/src/test/run-pass/unboxed-closures-monomorphization.rs
+++ b/src/test/run-pass/unboxed-closures-monomorphization.rs
@@ -11,6 +11,8 @@
 // Test that unboxed closures in contexts with free type parameters
 // monomorphize correctly (issue #16791)
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 
 fn main(){

--- a/src/test/run-pass/unboxed-closures-prelude.rs
+++ b/src/test/run-pass/unboxed-closures-prelude.rs
@@ -10,6 +10,8 @@
 
 // Tests that the reexports of `FnOnce` et al from the prelude work.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 #![feature(unboxed_closures)]
 
 fn main() {

--- a/src/test/run-pass/uniq-self-in-mut-slot.rs
+++ b/src/test/run-pass/uniq-self-in-mut-slot.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 struct X {
     a: int

--- a/src/test/run-pass/unique-assign-copy.rs
+++ b/src/test/run-pass/unique-assign-copy.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let mut i = box 1i;
     // Should be a copy

--- a/src/test/run-pass/unique-assign-drop.rs
+++ b/src/test/run-pass/unique-assign-drop.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 #![allow(dead_assignment)]
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub fn main() {
     let i = box 1i;

--- a/src/test/run-pass/unique-assign-generic.rs
+++ b/src/test/run-pass/unique-assign-generic.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 
 fn f<T>(t: T) -> T {
     let t1 = t;

--- a/src/test/run-pass/unique-assign.rs
+++ b/src/test/run-pass/unique-assign.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let mut i;
     i = box 1i;

--- a/src/test/run-pass/unique-autoderef-field.rs
+++ b/src/test/run-pass/unique-autoderef-field.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct J { j: int }
 
 pub fn main() {

--- a/src/test/run-pass/unique-autoderef-index.rs
+++ b/src/test/run-pass/unique-autoderef-index.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub fn main() {
     let i = box vec!(100i);

--- a/src/test/run-pass/unique-cmp.rs
+++ b/src/test/run-pass/unique-cmp.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let i = box 100i;
     assert!(i == box 100i);

--- a/src/test/run-pass/unique-containing-tag.rs
+++ b/src/test/run-pass/unique-containing-tag.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     enum t { t1(int), t2(int), }
 

--- a/src/test/run-pass/unique-create.rs
+++ b/src/test/run-pass/unique-create.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     box 100i;
 }

--- a/src/test/run-pass/unique-decl-init-copy.rs
+++ b/src/test/run-pass/unique-decl-init-copy.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let mut i = box 1i;
     // Should be a copy

--- a/src/test/run-pass/unique-decl-init.rs
+++ b/src/test/run-pass/unique-decl-init.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let i = box 1i;
     let j = i;

--- a/src/test/run-pass/unique-decl-move.rs
+++ b/src/test/run-pass/unique-decl-move.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let i = box 100i;
     let j = i;

--- a/src/test/run-pass/unique-deref.rs
+++ b/src/test/run-pass/unique-deref.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let i = box 100i;
     assert_eq!(*i, 100);

--- a/src/test/run-pass/unique-destructure.rs
+++ b/src/test/run-pass/unique-destructure.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_syntax)]
+
 struct Foo { a: int, b: int }
 
 pub fn main() {

--- a/src/test/run-pass/unique-destructure.rs
+++ b/src/test/run-pass/unique-destructure.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
 #![feature(box_syntax)]
 
 struct Foo { a: int, b: int }

--- a/src/test/run-pass/unique-drop-complex.rs
+++ b/src/test/run-pass/unique-drop-complex.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let _x = box vec!(0i,0,0,0,0);
 }

--- a/src/test/run-pass/unique-fn-arg-move.rs
+++ b/src/test/run-pass/unique-fn-arg-move.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn f(i: Box<int>) {
     assert_eq!(*i, 100);
 }

--- a/src/test/run-pass/unique-fn-arg-mut.rs
+++ b/src/test/run-pass/unique-fn-arg-mut.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn f(i: &mut Box<int>) {
     *i = box 200;

--- a/src/test/run-pass/unique-fn-arg.rs
+++ b/src/test/run-pass/unique-fn-arg.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn f(i: Box<int>) {
     assert_eq!(*i, 100);

--- a/src/test/run-pass/unique-fn-ret.rs
+++ b/src/test/run-pass/unique-fn-ret.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 fn f() -> Box<int> {
     box 100

--- a/src/test/run-pass/unique-in-tag.rs
+++ b/src/test/run-pass/unique-in-tag.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn test1() {
     enum bar { u(Box<int>), w(int), }
 

--- a/src/test/run-pass/unique-in-vec-copy.rs
+++ b/src/test/run-pass/unique-in-vec-copy.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub fn main() {
     let mut a = vec!(box 10i);

--- a/src/test/run-pass/unique-in-vec.rs
+++ b/src/test/run-pass/unique-in-vec.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let vect = vec!(box 100i);
     assert!(vect[0] == box 100);

--- a/src/test/run-pass/unique-init.rs
+++ b/src/test/run-pass/unique-init.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let _i = box 100i;
 }

--- a/src/test/run-pass/unique-kinds.rs
+++ b/src/test/run-pass/unique-kinds.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::cmp::PartialEq;
 
 fn sendable() {

--- a/src/test/run-pass/unique-log.rs
+++ b/src/test/run-pass/unique-log.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let i = box 100i;
     println!("{}", i);

--- a/src/test/run-pass/unique-match-discrim.rs
+++ b/src/test/run-pass/unique-match-discrim.rs
@@ -10,6 +10,9 @@
 
 // Issue #961
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 fn altsimple() {
     match box true {
       _ => { }

--- a/src/test/run-pass/unique-move-drop.rs
+++ b/src/test/run-pass/unique-move-drop.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 #![allow(unused_variable)]
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub fn main() {
     let i = box 100i;

--- a/src/test/run-pass/unique-move-temp.rs
+++ b/src/test/run-pass/unique-move-temp.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let mut i;
     i = box 100i;

--- a/src/test/run-pass/unique-move.rs
+++ b/src/test/run-pass/unique-move.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let i = box 100i;
     let mut j;

--- a/src/test/run-pass/unique-mutable.rs
+++ b/src/test/run-pass/unique-mutable.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let mut i = box 0i;
     *i = 1;

--- a/src/test/run-pass/unique-object-move.rs
+++ b/src/test/run-pass/unique-object-move.rs
@@ -10,6 +10,8 @@
 
 // Issue #5192
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub trait EventLoop { }
 

--- a/src/test/run-pass/unique-pat-2.rs
+++ b/src/test/run-pass/unique-pat-2.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_syntax)]
 
 struct Foo {a: int, b: uint}
 

--- a/src/test/run-pass/unique-pat-2.rs
+++ b/src/test/run-pass/unique-pat-2.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
 #![feature(box_syntax)]
 
 struct Foo {a: int, b: uint}

--- a/src/test/run-pass/unique-pat-3.rs
+++ b/src/test/run-pass/unique-pat-3.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 enum bar { u(Box<int>), w(int), }
 
 pub fn main() {

--- a/src/test/run-pass/unique-pat.rs
+++ b/src/test/run-pass/unique-pat.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
 #![feature(box_syntax)]
 
 fn simple() {

--- a/src/test/run-pass/unique-pat.rs
+++ b/src/test/run-pass/unique-pat.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_syntax)]
+
 fn simple() {
     match box true {
       box true => { }

--- a/src/test/run-pass/unique-rec.rs
+++ b/src/test/run-pass/unique-rec.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 struct X { x: int }
 
 pub fn main() {

--- a/src/test/run-pass/unique-send-2.rs
+++ b/src/test/run-pass/unique-send-2.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::sync::mpsc::{channel, Sender};
 use std::thread::Thread;
 

--- a/src/test/run-pass/unique-send.rs
+++ b/src/test/run-pass/unique-send.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::sync::mpsc::channel;
 
 pub fn main() {

--- a/src/test/run-pass/unique-swap.rs
+++ b/src/test/run-pass/unique-swap.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::mem::swap;
 
 pub fn main() {

--- a/src/test/run-pass/unsized2.rs
+++ b/src/test/run-pass/unsized2.rs
@@ -10,6 +10,9 @@
 //
 // ignore-lexer-test FIXME #15879
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 // Test sized-ness checking in substitution.
 
 // Unbounded.

--- a/src/test/run-pass/unsized3.rs
+++ b/src/test/run-pass/unsized3.rs
@@ -10,6 +10,9 @@
 
 // Test structs with always-unsized fields.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::mem;
 use std::raw;
 

--- a/src/test/run-pass/unused-move-capture.rs
+++ b/src/test/run-pass/unused-move-capture.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     let _x = box 1i;
     let lam_move = |&:| {};

--- a/src/test/run-pass/unused-move.rs
+++ b/src/test/run-pass/unused-move.rs
@@ -13,6 +13,8 @@
 // Abstract: zero-fill to block after drop
 
 #![allow(path_statement)]
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub fn main()
 {

--- a/src/test/run-pass/unwind-unique.rs
+++ b/src/test/run-pass/unwind-unique.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 use std::thread::Thread;
 
 fn f() {

--- a/src/test/run-pass/vec-dst.rs
+++ b/src/test/run-pass/vec-dst.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_features)]
+#![feature(box_syntax)]
+
 pub fn main() {
     // Tests for indexing into box/& [T; n]
     let x: [int; 3] = [1, 2, 3];

--- a/src/test/run-pass/vector-no-ann-2.rs
+++ b/src/test/run-pass/vector-no-ann-2.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
+#![allow(unknown_features)]
+#![feature(box_syntax)]
 
 pub fn main() { let _quux: Box<Vec<uint>> = box Vec::new(); }


### PR DESCRIPTION
Added `box_syntax` feature gate; added to std and rustc crates for bootstrap.

To avoid using the feature, change uses of `box <expr>` to `Box::new(<expr>)` alternative, as noted by the feature gate message.

(Note that box patterns have no analogous trivial replacement, at least not in general; you need to revise the code to do a partial match, deref, and then the rest of the match.)

[breaking-change]
