### PR TITLE
rustdoc: Render associated type bindings

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -250,8 +250,10 @@ impl fmt::Show for clean::PathParameters {
 impl fmt::String for clean::PathParameters {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            clean::PathParameters::AngleBracketed { ref lifetimes, ref types } => {
-                if lifetimes.len() > 0 || types.len() > 0 {
+            clean::PathParameters::AngleBracketed {
+                ref lifetimes, ref types, ref bindings
+            } => {
+                if lifetimes.len() > 0 || types.len() > 0 || bindings.len() > 0 {
                     try!(f.write_str("&lt;"));
                     let mut comma = false;
                     for lifetime in lifetimes.iter() {
@@ -267,6 +269,13 @@ impl fmt::String for clean::PathParameters {
                         }
                         comma = true;
                         try!(write!(f, "{}", *ty));
+                    }
+                    for binding in bindings.iter() {
+                        if comma {
+                            try!(f.write_str(", "));
+                        }
+                        comma = true;
+                        try!(write!(f, "{}", *binding));
                     }
                     try!(f.write_str("&gt;"));
                 }
@@ -855,6 +864,7 @@ impl fmt::String for clean::ViewListIdent {
                         params: clean::PathParameters::AngleBracketed {
                             lifetimes: Vec::new(),
                             types: Vec::new(),
+                            bindings: Vec::new()
                         }
                     })
                 };
@@ -862,6 +872,19 @@ impl fmt::String for clean::ViewListIdent {
             }
             _ => write!(f, "{}", self.name),
         }
+    }
+}
+
+//NOTE(stage0): remove impl after snapshot
+impl fmt::Show for clean::TypeBinding {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::String::fmt(self, f)
+    }
+}
+
+impl fmt::String for clean::TypeBinding {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}={}", self.name, self.ty)
     }
 }
 


### PR DESCRIPTION
e.g. `Foo<Output=A>`

This does not work cross-crate unfortunately.

Part of #20646
