### PR TITLE
RFC 558: Require parentheses for chained comparisons

### DIFF
--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -85,6 +85,13 @@ pub fn is_shift_binop(b: BinOp) -> bool {
     }
 }
 
+pub fn is_comparison_binop(b: BinOp) -> bool {
+    match b {
+        BiEq | BiLt | BiLe | BiNe | BiGt | BiGe => true,
+        _ => false
+    }
+}
+
 /// Returns `true` if the binary operator takes its arguments by value
 pub fn is_by_value_binop(b: BinOp) -> bool {
     match b {
@@ -317,8 +324,7 @@ pub fn operator_prec(op: ast::BinOp) -> uint {
       BiBitAnd                  =>  8u,
       BiBitXor                  =>  7u,
       BiBitOr                   =>  6u,
-      BiLt | BiLe | BiGe | BiGt =>  4u,
-      BiEq | BiNe               =>  3u,
+      BiLt | BiLe | BiGe | BiGt | BiEq | BiNe => 3u,
       BiAnd                     =>  2u,
       BiOr                      =>  1u
   }

--- a/src/test/compile-fail/require-parens-for-chained-comparison.rs
+++ b/src/test/compile-fail/require-parens-for-chained-comparison.rs
@@ -1,0 +1,23 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn f<T>() {}
+
+fn main() {
+    false == false == false;
+    //~^ ERROR: Chained comparison operators require parentheses
+
+    false == 0 < 2;
+    //~^ ERROR: Chained comparison operators require parentheses
+
+    f<X>();
+    //~^ ERROR: Chained comparison operators require parentheses
+    //~^^ HELP: Use ::< instead of < if you meant to specify type arguments.
+}

--- a/src/test/compile-fail/unsized2.rs
+++ b/src/test/compile-fail/unsized2.rs
@@ -13,5 +13,8 @@
 fn f<X>() {}
 
 pub fn main() {
-    f<type>(); //~ ERROR expected identifier, found keyword `type`
+    f<type>();
+    //~^ ERROR expected identifier, found keyword `type`
+    //~^^ ERROR: Chained comparison operators require parentheses
+    //~^^^ HELP: Use ::< instead of < if you meant to specify type arguments.
 }


### PR DESCRIPTION
[Rendered RFC](https://github.com/rust-lang/rfcs/blob/master/text/0558-require-parentheses-for-chained-comparisons.md)
