### PR TITLE
Add missing module stability attributes

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -44,6 +44,8 @@
 //! let two = xs.pop();
 //! ```
 
+#![stable]
+
 use core::prelude::*;
 
 use alloc::boxed::Box;

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -11,6 +11,7 @@
 //! Utilities for formatting and printing strings
 
 #![allow(unused_variables)]
+#![stable]
 
 use any;
 use cell::{Cell, RefCell, Ref, RefMut};

--- a/src/libunicode/lib.rs
+++ b/src/libunicode/lib.rs
@@ -57,6 +57,7 @@ mod u_str;
 /// (inclusive) are allowed. A `char` can always be safely cast to a `u32`;
 /// however the converse is not always true due to the above range limits
 /// and, as such, should be performed via the `from_u32` function..
+#[stable]
 pub mod char {
     pub use core::char::{MAX, from_u32, from_digit};
 


### PR DESCRIPTION
Marks `vec`, `char` and `fmt` as stable module names.
