### PR TITLE
doc: Fix unresolved import in Bitv example

### DIFF
--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -134,7 +134,7 @@ static FALSE: bool = false;
 /// # Examples
 ///
 /// ```rust
-/// use collections::Bitv;
+/// use std::collections::Bitv;
 ///
 /// let mut bv = Bitv::from_elem(10, false);
 ///


### PR DESCRIPTION
Tiny change fixing an unresolved import in the first example for Bitv. 
