### PR TITLE
Enabled the `vec![]` macro to use the `[a; b]` repeat syntax.

### DIFF
--- a/src/libcollections/macros.rs
+++ b/src/libcollections/macros.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -12,6 +12,10 @@
 #[macro_export]
 #[stable]
 macro_rules! vec {
+    ($x:expr; $y:expr) => ({
+        let xs: $crate::boxed::Box<[_]> = $crate::boxed::Box::new([$x; $y]);
+        $crate::slice::SliceExt::into_vec(xs)
+    });
     ($($x:expr),*) => ({
         let xs: $crate::boxed::Box<[_]> = $crate::boxed::Box::new([$($x),*]);
         $crate::slice::SliceExt::into_vec(xs)

--- a/src/test/run-pass/vec-macro-repeat.rs
+++ b/src/test/run-pass/vec-macro-repeat.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+pub fn main() {
+    assert_eq!(vec![1; 3], vec![1, 1, 1]);
+    assert_eq!(vec![1; 2], vec![1, 1]);
+    assert_eq!(vec![1; 1], vec![1]);
+    assert_eq!(vec![1; 0], vec![]);
+}


### PR DESCRIPTION
Closes #15587
