### PR TITLE
Remove weak_rng

### DIFF
--- a/src/libcollections/bench.rs
+++ b/src/libcollections/bench.rs
@@ -10,7 +10,7 @@
 
 use prelude::*;
 use std::rand;
-use std::rand::Rng;
+use std::rand::{Rng, XorShiftRng};
 use test::{Bencher, black_box};
 
 pub fn insert_rand_n<M, I, R>(n: uint,
@@ -22,7 +22,7 @@ pub fn insert_rand_n<M, I, R>(n: uint,
     R: FnMut(&mut M, uint),
 {
     // setup
-    let mut rng = rand::weak_rng();
+    let mut rng: XorShiftRng = rand::random();
 
     for _ in range(0, n) {
         insert(map, rng.gen::<uint>() % n);
@@ -69,7 +69,7 @@ pub fn find_rand_n<M, T, I, F>(n: uint,
     F: FnMut(&M, uint) -> T,
 {
     // setup
-    let mut rng = rand::weak_rng();
+    let mut rng: XorShiftRng = rand::random();
     let mut keys = range(0, n).map(|_| rng.gen::<uint>() % n)
                               .collect::<Vec<_>>();
 

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -1827,7 +1827,7 @@ mod test {
 #[cfg(test)]
 mod bench {
     use prelude::*;
-    use std::rand::{weak_rng, Rng};
+    use std::rand::{random, XorShiftRng, Rng};
     use test::{Bencher, black_box};
 
     use super::BTreeMap;
@@ -1902,7 +1902,7 @@ mod bench {
 
     fn bench_iter(b: &mut Bencher, size: uint) {
         let mut map = BTreeMap::<uint, uint>::new();
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
 
         for _ in range(0, size) {
             map.insert(rng.gen(), rng.gen());

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -2728,7 +2728,7 @@ mod bench {
     use core::mem;
     use core::ptr;
     use core::iter::repeat;
-    use std::rand::{weak_rng, Rng};
+    use std::rand::{random, XorShiftRng, Rng};
     use test::{Bencher, black_box};
 
     #[bench]
@@ -2896,7 +2896,7 @@ mod bench {
 
     #[bench]
     fn random_inserts(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| {
             let mut v = repeat((0u, 0u)).take(30).collect::<Vec<_>>();
             for _ in range(0u, 100) {
@@ -2908,7 +2908,7 @@ mod bench {
     }
     #[bench]
     fn random_removes(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| {
             let mut v = repeat((0u, 0u)).take(130).collect::<Vec<_>>();
             for _ in range(0u, 100) {
@@ -2920,7 +2920,7 @@ mod bench {
 
     #[bench]
     fn sort_random_small(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| {
             let mut v = rng.gen_iter::<u64>().take(5).collect::<Vec<u64>>();
             v.as_mut_slice().sort();
@@ -2930,7 +2930,7 @@ mod bench {
 
     #[bench]
     fn sort_random_medium(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| {
             let mut v = rng.gen_iter::<u64>().take(100).collect::<Vec<u64>>();
             v.as_mut_slice().sort();
@@ -2940,7 +2940,7 @@ mod bench {
 
     #[bench]
     fn sort_random_large(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| {
             let mut v = rng.gen_iter::<u64>().take(10000).collect::<Vec<u64>>();
             v.as_mut_slice().sort();
@@ -2961,7 +2961,7 @@ mod bench {
 
     #[bench]
     fn sort_big_random_small(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| {
             let mut v = rng.gen_iter::<BigSortable>().take(5)
                            .collect::<Vec<BigSortable>>();
@@ -2972,7 +2972,7 @@ mod bench {
 
     #[bench]
     fn sort_big_random_medium(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| {
             let mut v = rng.gen_iter::<BigSortable>().take(100)
                            .collect::<Vec<BigSortable>>();
@@ -2983,7 +2983,7 @@ mod bench {
 
     #[bench]
     fn sort_big_random_large(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| {
             let mut v = rng.gen_iter::<BigSortable>().take(10000)
                            .collect::<Vec<BigSortable>>();

--- a/src/libcoretest/fmt/num.rs
+++ b/src/libcoretest/fmt/num.rs
@@ -169,42 +169,43 @@ fn test_radix_base_too_large() {
 mod u32 {
     use test::Bencher;
     use core::fmt::radix;
-    use std::rand::{weak_rng, Rng};
+    use std::rand::{random, XorShiftRng, Rng};
     use std::io::util::NullWriter;
 
     #[bench]
     fn format_bin(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| { write!(&mut NullWriter, "{:b}", rng.gen::<u32>()) })
     }
 
     #[bench]
     fn format_oct(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| { write!(&mut NullWriter, "{:o}", rng.gen::<u32>()) })
     }
 
     #[bench]
     fn format_dec(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| { write!(&mut NullWriter, "{}", rng.gen::<u32>()) })
     }
 
     #[bench]
     fn format_hex(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| { write!(&mut NullWriter, "{:x}", rng.gen::<u32>()) })
     }
 
     #[bench]
     fn format_show(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| { write!(&mut NullWriter, "{:?}", rng.gen::<u32>()) })
     }
 
     #[bench]
     fn format_base_36(b: &mut Bencher) {
         let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| { write!(&mut NullWriter, "{}", radix(rng.gen::<u32>(), 36)) })
     }
 }
@@ -212,42 +213,42 @@ mod u32 {
 mod i32 {
     use test::Bencher;
     use core::fmt::radix;
-    use std::rand::{weak_rng, Rng};
+    use std::rand::{random, XorShiftRng, Rng};
     use std::io::util::NullWriter;
 
     #[bench]
     fn format_bin(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| { write!(&mut NullWriter, "{:b}", rng.gen::<i32>()) })
     }
 
     #[bench]
     fn format_oct(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| { write!(&mut NullWriter, "{:o}", rng.gen::<i32>()) })
     }
 
     #[bench]
     fn format_dec(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| { write!(&mut NullWriter, "{}", rng.gen::<i32>()) })
     }
 
     #[bench]
     fn format_hex(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| { write!(&mut NullWriter, "{:x}", rng.gen::<i32>()) })
     }
 
     #[bench]
     fn format_show(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| { write!(&mut NullWriter, "{:?}", rng.gen::<i32>()) })
     }
 
     #[bench]
     fn format_base_36(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         b.iter(|| { write!(&mut NullWriter, "{}", radix(rng.gen::<i32>(), 36)) })
     }
 }

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -520,6 +520,6 @@ mod test {
     }
 
     pub fn weak_rng() -> MyRng<rand::XorShiftRng> {
-        MyRng { inner: rand::weak_rng() }
+        MyRng { inner: rand::random() }
     }
 }

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1603,7 +1603,7 @@ mod test_map {
     use super::Entry::{Occupied, Vacant};
     use iter::{range_inclusive, range_step_inclusive, repeat};
     use cell::RefCell;
-    use rand::{weak_rng, Rng};
+    use rand::{random, XorShiftRng, Rng};
 
     #[test]
     fn test_create_capacity_zero() {
@@ -2261,7 +2261,7 @@ mod test_map {
         }
 
         let mut m = HashMap::new();
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
 
         // Populate the map with some items.
         for _ in range(0u, 50) {

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -463,7 +463,7 @@ mod bench {
 
     mod uint {
         use super::test::Bencher;
-        use rand::{weak_rng, Rng};
+        use rand::{random, XorShiftRng, Rng};
         use std::fmt;
 
         #[inline]
@@ -473,38 +473,38 @@ mod bench {
 
         #[bench]
         fn to_str_bin(b: &mut Bencher) {
-            let mut rng = weak_rng();
+            let mut rng: XorShiftRng = random();
             b.iter(|| { to_string(rng.gen::<uint>(), 2); })
         }
 
         #[bench]
         fn to_str_oct(b: &mut Bencher) {
-            let mut rng = weak_rng();
+            let mut rng: XorShiftRng = random();
             b.iter(|| { to_string(rng.gen::<uint>(), 8); })
         }
 
         #[bench]
         fn to_str_dec(b: &mut Bencher) {
-            let mut rng = weak_rng();
+            let mut rng: XorShiftRng = random();
             b.iter(|| { to_string(rng.gen::<uint>(), 10); })
         }
 
         #[bench]
         fn to_str_hex(b: &mut Bencher) {
-            let mut rng = weak_rng();
+            let mut rng: XorShiftRng = random();
             b.iter(|| { to_string(rng.gen::<uint>(), 16); })
         }
 
         #[bench]
         fn to_str_base_36(b: &mut Bencher) {
-            let mut rng = weak_rng();
+            let mut rng: XorShiftRng = random();
             b.iter(|| { to_string(rng.gen::<uint>(), 36); })
         }
     }
 
     mod int {
         use super::test::Bencher;
-        use rand::{weak_rng, Rng};
+        use rand::{random, XorShiftRng, Rng};
         use std::fmt;
 
         #[inline]
@@ -514,43 +514,43 @@ mod bench {
 
         #[bench]
         fn to_str_bin(b: &mut Bencher) {
-            let mut rng = weak_rng();
+            let mut rng: XorShiftRng = random();
             b.iter(|| { to_string(rng.gen::<int>(), 2); })
         }
 
         #[bench]
         fn to_str_oct(b: &mut Bencher) {
-            let mut rng = weak_rng();
+            let mut rng: XorShiftRng = random();
             b.iter(|| { to_string(rng.gen::<int>(), 8); })
         }
 
         #[bench]
         fn to_str_dec(b: &mut Bencher) {
-            let mut rng = weak_rng();
+            let mut rng: XorShiftRng = random();
             b.iter(|| { to_string(rng.gen::<int>(), 10); })
         }
 
         #[bench]
         fn to_str_hex(b: &mut Bencher) {
-            let mut rng = weak_rng();
+            let mut rng: XorShiftRng = random();
             b.iter(|| { to_string(rng.gen::<int>(), 16); })
         }
 
         #[bench]
         fn to_str_base_36(b: &mut Bencher) {
-            let mut rng = weak_rng();
+            let mut rng: XorShiftRng = random();
             b.iter(|| { to_string(rng.gen::<int>(), 36); })
         }
     }
 
     mod f64 {
         use super::test::Bencher;
-        use rand::{weak_rng, Rng};
+        use rand::{random, XorShiftRng, Rng};
         use f64;
 
         #[bench]
         fn float_to_string(b: &mut Bencher) {
-            let mut rng = weak_rng();
+            let mut rng: XorShiftRng = random();
             b.iter(|| { f64::to_string(rng.gen()); })
         }
     }

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -291,22 +291,6 @@ impl<'a> SeedableRng<&'a [uint]> for StdRng {
     }
 }
 
-/// Create a weak random number generator with a default algorithm and seed.
-///
-/// It returns the fastest `Rng` algorithm currently available in Rust without
-/// consideration for cryptography or security. If you require a specifically
-/// seeded `Rng` for consistency over time you should pick one algorithm and
-/// create the `Rng` yourself.
-///
-/// This will read randomness from the operating system to seed the
-/// generator.
-pub fn weak_rng() -> XorShiftRng {
-    match OsRng::new() {
-        Ok(mut r) => r.gen(),
-        Err(e) => panic!("weak_rng: failed to create seeded RNG: {:?}", e)
-    }
-}
-
 /// Controls how the thread-local RNG is reseeded.
 struct ThreadRngReseeder;
 
@@ -645,7 +629,7 @@ mod bench {
 
     use self::test::Bencher;
     use super::{XorShiftRng, StdRng, IsaacRng, Isaac64Rng, Rng, RAND_BENCH_N};
-    use super::{OsRng, weak_rng};
+    use super::{OsRng, random};
     use mem::size_of;
 
     #[bench]
@@ -694,7 +678,7 @@ mod bench {
 
     #[bench]
     fn rand_shuffle_100(b: &mut Bencher) {
-        let mut rng = weak_rng();
+        let mut rng: XorShiftRng = random();
         let x : &mut[uint] = &mut [1; 100];
         b.iter(|| {
             rng.shuffle(x);


### PR DESCRIPTION
Documentation for the function claims it will return the fastest algorithm
available in Rust, but since its return type is hardcoded to XorShiftRng, it
would be an impossible [breaking-change], when, or if, a faster Rng is added to
Rust.

[breaking-change], since this removes public API.

Fixes #20484 

r? @huonw for a rollup post 1.0α.
