### PR TITLE
mk: Update prerelase versioning to conform to semver

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -15,8 +15,10 @@
 # The version number
 CFG_RELEASE_NUM=1.0.0
 
-# An optional number to put after the label, e.g. '2' -> '-beta2'
-CFG_BETA_CYCLE=
+# An optional number to put after the label, e.g. '.2' -> '-beta.2'
+# NB Make sure it starts with a dot to conform to semver pre-release
+# versions (section 9)
+CFG_PRERELEASE_VERSION=
 
 CFG_FILENAME_EXTRA=4e7c5e5c
 
@@ -29,8 +31,8 @@ CFG_DISABLE_UNSTABLE_FEATURES=1
 endif
 ifeq ($(CFG_RELEASE_CHANNEL),beta)
 # The beta channel is temporarily called 'alpha'
-CFG_RELEASE=$(CFG_RELEASE_NUM)-alpha$(CFG_BETA_CYCLE)
-CFG_PACKAGE_VERS=$(CFG_RELEASE_NUM)-alpha$(CFG_BETA_CYCLE)
+CFG_RELEASE=$(CFG_RELEASE_NUM)-alpha$(CFG_PRERELEASE_VERSION)
+CFG_PACKAGE_VERS=$(CFG_RELEASE_NUM)-alpha$(CFG_PRERELEASE_VERSION)
 CFG_DISABLE_UNSTABLE_FEATURES=1
 endif
 ifeq ($(CFG_RELEASE_CHANNEL),nightly)


### PR DESCRIPTION
prerelease versions will be e.g. `1.0.0-beta.1` instead of `1.0.0-beta1`.
