### PR TITLE
rustdoc: Stop adding #[deny(warnings)] to all tests

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -215,7 +215,6 @@ pub fn maketest(s: &str, cratename: Option<&str>, lints: bool, dont_insert_main:
     let mut prog = String::new();
     if lints {
         prog.push_str(r"
-#![deny(warnings)]
 #![allow(unused_variables, unused_assignments, unused_mut, unused_attributes, dead_code)]
 ");
     }


### PR DESCRIPTION
Because we are warning about unstable APIs and there are many
of these yet, this creates a high likelyhood doc tests will
fail.

This doesn't seem right as a blanket policy to me anyway, though
certainly we want it in std. Probably more appropriate to add
a rustdoc option.
