### PR TITLE
Make the metadata loader use the appropriate Target structure

### DIFF
--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -409,6 +409,7 @@ impl<'a> CrateReader<'a> {
                     crate_name: name,
                     hash: hash.map(|a| &*a),
                     filesearch: self.sess.target_filesearch(kind),
+                    target: &self.sess.target.target,
                     triple: &self.sess.opts.target_triple[],
                     root: root,
                     rejected_via_hash: vec!(),
@@ -472,6 +473,7 @@ impl<'a> CrateReader<'a> {
             crate_name: &name[],
             hash: None,
             filesearch: self.sess.host_filesearch(PathKind::Crate),
+            target: &self.sess.host,
             triple: config::host_triple(),
             root: &None,
             rejected_via_hash: vec!(),
@@ -486,6 +488,7 @@ impl<'a> CrateReader<'a> {
                 target_only = true;
                 should_link = info.should_link;
 
+                load_ctxt.target = &self.sess.target.target;
                 load_ctxt.triple = target_triple;
                 load_ctxt.filesearch = self.sess.target_filesearch(PathKind::Crate);
                 load_ctxt.load_library_crate()

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -225,6 +225,7 @@ use metadata::filesearch::{FileSearch, FileMatches, FileDoesntMatch};
 use syntax::codemap::Span;
 use syntax::diagnostic::SpanHandler;
 use util::fs;
+use rustc_back::target::Target;
 
 use std::ffi::CString;
 use std::cmp;
@@ -248,6 +249,8 @@ pub struct Context<'a> {
     pub ident: &'a str,
     pub crate_name: &'a str,
     pub hash: Option<&'a Svh>,
+    // points to either self.sess.target.target or self.sess.host, must match triple
+    pub target: &'a Target,
     pub triple: &'a str,
     pub filesearch: FileSearch<'a>,
     pub root: &'a Option<CratePaths>,
@@ -499,7 +502,7 @@ impl<'a> Context<'a> {
 
         for lib in m.into_iter() {
             info!("{} reading metadata from: {}", flavor, lib.display());
-            let metadata = match get_metadata_section(self.sess.target.target.options.is_like_osx,
+            let metadata = match get_metadata_section(self.target.options.is_like_osx,
                                                       &lib) {
                 Ok(blob) => {
                     if self.crate_matches(blob.as_slice(), &lib) {
@@ -588,7 +591,7 @@ impl<'a> Context<'a> {
     // Returns the corresponding (prefix, suffix) that files need to have for
     // dynamic libraries
     fn dylibname(&self) -> (String, String) {
-        let t = &self.sess.target.target;
+        let t = &self.target;
         (t.options.dll_prefix.clone(), t.options.dll_suffix.clone())
     }
 


### PR DESCRIPTION
Fixes #19907
