### PR TITLE
Remove integer suffixes from `Show` implementation

### DIFF
--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -153,11 +153,10 @@ pub fn radix<T>(x: T, base: u8) -> RadixFmt<T, Radix> {
 }
 
 macro_rules! radix_fmt {
-    ($T:ty as $U:ty, $fmt:ident, $S:expr) => {
+    ($T:ty as $U:ty, $fmt:ident) => {
         impl fmt::Show for RadixFmt<$T, Radix> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                try!(fmt::String::fmt(self, f));
-                f.write_str($S)
+                fmt::String::fmt(self, f)
             }
         }
         impl fmt::String for RadixFmt<$T, Radix> {
@@ -178,38 +177,34 @@ macro_rules! int_base {
 }
 
 macro_rules! show {
-    ($T:ident with $S:expr) => {
+    ($T:ident) => {
         impl fmt::Show for $T {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                try!(fmt::String::fmt(self, f));
-                f.write_str($S)
+                fmt::String::fmt(self, f)
             }
         }
     }
 }
 macro_rules! integer {
     ($Int:ident, $Uint:ident) => {
-        integer! { $Int, $Uint, stringify!($Int), stringify!($Uint) }
-    };
-    ($Int:ident, $Uint:ident, $SI:expr, $SU:expr) => {
         int_base! { String   for $Int as $Int   -> Decimal }
         int_base! { Binary   for $Int as $Uint  -> Binary }
         int_base! { Octal    for $Int as $Uint  -> Octal }
         int_base! { LowerHex for $Int as $Uint  -> LowerHex }
         int_base! { UpperHex for $Int as $Uint  -> UpperHex }
-        radix_fmt! { $Int as $Int, fmt_int, $SI }
-        show! { $Int with $SI }
+        radix_fmt! { $Int as $Int, fmt_int }
+        show! { $Int }
 
         int_base! { String   for $Uint as $Uint -> Decimal }
         int_base! { Binary   for $Uint as $Uint -> Binary }
         int_base! { Octal    for $Uint as $Uint -> Octal }
         int_base! { LowerHex for $Uint as $Uint -> LowerHex }
         int_base! { UpperHex for $Uint as $Uint -> UpperHex }
-        radix_fmt! { $Uint as $Uint, fmt_int, $SU }
-        show! { $Uint with $SU }
+        radix_fmt! { $Uint as $Uint, fmt_int }
+        show! { $Uint }
     }
 }
-integer! { int, uint, "i", "u" }
+integer! { int, uint }
 integer! { i8, u8 }
 integer! { i16, u16 }
 integer! { i32, u32 }

--- a/src/libcoretest/fmt/num.rs
+++ b/src/libcoretest/fmt/num.rs
@@ -16,133 +16,133 @@ fn test_format_int() {
     // Formatting integers should select the right implementation based off
     // the type of the argument. Also, hex/octal/binary should be defined
     // for integers, but they shouldn't emit the negative sign.
-    assert!(format!("{}", 1i) == "1");
+    assert!(format!("{}", 1is) == "1");
     assert!(format!("{}", 1i8) == "1");
     assert!(format!("{}", 1i16) == "1");
     assert!(format!("{}", 1i32) == "1");
     assert!(format!("{}", 1i64) == "1");
-    assert!(format!("{}", -1i) == "-1");
+    assert!(format!("{}", -1is) == "-1");
     assert!(format!("{}", -1i8) == "-1");
     assert!(format!("{}", -1i16) == "-1");
     assert!(format!("{}", -1i32) == "-1");
     assert!(format!("{}", -1i64) == "-1");
-    assert!(format!("{:?}", 1i) == "1i");
-    assert!(format!("{:?}", 1i8) == "1i8");
-    assert!(format!("{:?}", 1i16) == "1i16");
-    assert!(format!("{:?}", 1i32) == "1i32");
-    assert!(format!("{:?}", 1i64) == "1i64");
-    assert!(format!("{:b}", 1i) == "1");
+    assert!(format!("{:?}", 1is) == "1");
+    assert!(format!("{:?}", 1i8) == "1");
+    assert!(format!("{:?}", 1i16) == "1");
+    assert!(format!("{:?}", 1i32) == "1");
+    assert!(format!("{:?}", 1i64) == "1");
+    assert!(format!("{:b}", 1is) == "1");
     assert!(format!("{:b}", 1i8) == "1");
     assert!(format!("{:b}", 1i16) == "1");
     assert!(format!("{:b}", 1i32) == "1");
     assert!(format!("{:b}", 1i64) == "1");
-    assert!(format!("{:x}", 1i) == "1");
+    assert!(format!("{:x}", 1is) == "1");
     assert!(format!("{:x}", 1i8) == "1");
     assert!(format!("{:x}", 1i16) == "1");
     assert!(format!("{:x}", 1i32) == "1");
     assert!(format!("{:x}", 1i64) == "1");
-    assert!(format!("{:X}", 1i) == "1");
+    assert!(format!("{:X}", 1is) == "1");
     assert!(format!("{:X}", 1i8) == "1");
     assert!(format!("{:X}", 1i16) == "1");
     assert!(format!("{:X}", 1i32) == "1");
     assert!(format!("{:X}", 1i64) == "1");
-    assert!(format!("{:o}", 1i) == "1");
+    assert!(format!("{:o}", 1is) == "1");
     assert!(format!("{:o}", 1i8) == "1");
     assert!(format!("{:o}", 1i16) == "1");
     assert!(format!("{:o}", 1i32) == "1");
     assert!(format!("{:o}", 1i64) == "1");
 
-    assert!(format!("{}", 1u) == "1");
+    assert!(format!("{}", 1us) == "1");
     assert!(format!("{}", 1u8) == "1");
     assert!(format!("{}", 1u16) == "1");
     assert!(format!("{}", 1u32) == "1");
     assert!(format!("{}", 1u64) == "1");
-    assert!(format!("{:?}", 1u) == "1u");
-    assert!(format!("{:?}", 1u8) == "1u8");
-    assert!(format!("{:?}", 1u16) == "1u16");
-    assert!(format!("{:?}", 1u32) == "1u32");
-    assert!(format!("{:?}", 1u64) == "1u64");
-    assert!(format!("{:b}", 1u) == "1");
+    assert!(format!("{:?}", 1us) == "1");
+    assert!(format!("{:?}", 1u8) == "1");
+    assert!(format!("{:?}", 1u16) == "1");
+    assert!(format!("{:?}", 1u32) == "1");
+    assert!(format!("{:?}", 1u64) == "1");
+    assert!(format!("{:b}", 1us) == "1");
     assert!(format!("{:b}", 1u8) == "1");
     assert!(format!("{:b}", 1u16) == "1");
     assert!(format!("{:b}", 1u32) == "1");
     assert!(format!("{:b}", 1u64) == "1");
-    assert!(format!("{:x}", 1u) == "1");
+    assert!(format!("{:x}", 1us) == "1");
     assert!(format!("{:x}", 1u8) == "1");
     assert!(format!("{:x}", 1u16) == "1");
     assert!(format!("{:x}", 1u32) == "1");
     assert!(format!("{:x}", 1u64) == "1");
-    assert!(format!("{:X}", 1u) == "1");
+    assert!(format!("{:X}", 1us) == "1");
     assert!(format!("{:X}", 1u8) == "1");
     assert!(format!("{:X}", 1u16) == "1");
     assert!(format!("{:X}", 1u32) == "1");
     assert!(format!("{:X}", 1u64) == "1");
-    assert!(format!("{:o}", 1u) == "1");
+    assert!(format!("{:o}", 1us) == "1");
     assert!(format!("{:o}", 1u8) == "1");
     assert!(format!("{:o}", 1u16) == "1");
     assert!(format!("{:o}", 1u32) == "1");
     assert!(format!("{:o}", 1u64) == "1");
 
     // Test a larger number
-    assert!(format!("{:b}", 55i) == "110111");
-    assert!(format!("{:o}", 55i) == "67");
-    assert!(format!("{}", 55i) == "55");
-    assert!(format!("{:x}", 55i) == "37");
-    assert!(format!("{:X}", 55i) == "37");
+    assert!(format!("{:b}", 55) == "110111");
+    assert!(format!("{:o}", 55) == "67");
+    assert!(format!("{}", 55) == "55");
+    assert!(format!("{:x}", 55) == "37");
+    assert!(format!("{:X}", 55) == "37");
 }
 
 #[test]
 fn test_format_int_zero() {
-    assert!(format!("{}", 0i) == "0");
-    assert!(format!("{:?}", 0i) == "0i");
-    assert!(format!("{:b}", 0i) == "0");
-    assert!(format!("{:o}", 0i) == "0");
-    assert!(format!("{:x}", 0i) == "0");
-    assert!(format!("{:X}", 0i) == "0");
+    assert!(format!("{}", 0) == "0");
+    assert!(format!("{:?}", 0) == "0");
+    assert!(format!("{:b}", 0) == "0");
+    assert!(format!("{:o}", 0) == "0");
+    assert!(format!("{:x}", 0) == "0");
+    assert!(format!("{:X}", 0) == "0");
 
-    assert!(format!("{}", 0u) == "0");
-    assert!(format!("{:?}", 0u) == "0u");
-    assert!(format!("{:b}", 0u) == "0");
-    assert!(format!("{:o}", 0u) == "0");
-    assert!(format!("{:x}", 0u) == "0");
-    assert!(format!("{:X}", 0u) == "0");
+    assert!(format!("{}", 0) == "0");
+    assert!(format!("{:?}", 0) == "0");
+    assert!(format!("{:b}", 0) == "0");
+    assert!(format!("{:o}", 0) == "0");
+    assert!(format!("{:x}", 0) == "0");
+    assert!(format!("{:X}", 0) == "0");
 }
 
 #[test]
 fn test_format_int_flags() {
-    assert!(format!("{:3}", 1i) == "  1");
-    assert!(format!("{:>3}", 1i) == "  1");
-    assert!(format!("{:>+3}", 1i) == " +1");
-    assert!(format!("{:<3}", 1i) == "1  ");
-    assert!(format!("{:#}", 1i) == "1");
-    assert!(format!("{:#x}", 10i) == "0xa");
-    assert!(format!("{:#X}", 10i) == "0xA");
-    assert!(format!("{:#5x}", 10i) == "  0xa");
-    assert!(format!("{:#o}", 10i) == "0o12");
-    assert!(format!("{:08x}", 10i) == "0000000a");
-    assert!(format!("{:8x}", 10i) == "       a");
-    assert!(format!("{:<8x}", 10i) == "a       ");
-    assert!(format!("{:>8x}", 10i) == "       a");
-    assert!(format!("{:#08x}", 10i) == "0x00000a");
-    assert!(format!("{:08}", -10i) == "-0000010");
-    assert!(format!("{:x}", -1u8) == "ff");
-    assert!(format!("{:X}", -1u8) == "FF");
-    assert!(format!("{:b}", -1u8) == "11111111");
-    assert!(format!("{:o}", -1u8) == "377");
-    assert!(format!("{:#x}", -1u8) == "0xff");
-    assert!(format!("{:#X}", -1u8) == "0xFF");
-    assert!(format!("{:#b}", -1u8) == "0b11111111");
-    assert!(format!("{:#o}", -1u8) == "0o377");
+    assert!(format!("{:3}", 1) == "  1");
+    assert!(format!("{:>3}", 1) == "  1");
+    assert!(format!("{:>+3}", 1) == " +1");
+    assert!(format!("{:<3}", 1) == "1  ");
+    assert!(format!("{:#}", 1) == "1");
+    assert!(format!("{:#x}", 10) == "0xa");
+    assert!(format!("{:#X}", 10) == "0xA");
+    assert!(format!("{:#5x}", 10) == "  0xa");
+    assert!(format!("{:#o}", 10) == "0o12");
+    assert!(format!("{:08x}", 10) == "0000000a");
+    assert!(format!("{:8x}", 10) == "       a");
+    assert!(format!("{:<8x}", 10) == "a       ");
+    assert!(format!("{:>8x}", 10) == "       a");
+    assert!(format!("{:#08x}", 10) == "0x00000a");
+    assert!(format!("{:08}", -10) == "-0000010");
+    assert!(format!("{:x}", !0u8) == "ff");
+    assert!(format!("{:X}", !0u8) == "FF");
+    assert!(format!("{:b}", !0u8) == "11111111");
+    assert!(format!("{:o}", !0u8) == "377");
+    assert!(format!("{:#x}", !0u8) == "0xff");
+    assert!(format!("{:#X}", !0u8) == "0xFF");
+    assert!(format!("{:#b}", !0u8) == "0b11111111");
+    assert!(format!("{:#o}", !0u8) == "0o377");
 }
 
 #[test]
 fn test_format_int_sign_padding() {
-    assert!(format!("{:+5}", 1i) == "   +1");
-    assert!(format!("{:+5}", -1i) == "   -1");
-    assert!(format!("{:05}", 1i) == "00001");
-    assert!(format!("{:05}", -1i) == "-0001");
-    assert!(format!("{:+05}", 1i) == "+0001");
-    assert!(format!("{:+05}", -1i) == "-0001");
+    assert!(format!("{:+5}", 1) == "   +1");
+    assert!(format!("{:+5}", -1) == "   -1");
+    assert!(format!("{:05}", 1) == "00001");
+    assert!(format!("{:05}", -1) == "-0001");
+    assert!(format!("{:+05}", 1) == "+0001");
+    assert!(format!("{:+05}", -1) == "-0001");
 }
 
 #[test]
@@ -156,96 +156,98 @@ fn test_format_int_twos_complement() {
 
 #[test]
 fn test_format_radix() {
-    assert!(format!("{:04}", radix(3i, 2)) == "0011");
-    assert!(format!("{}", radix(55i, 36)) == "1j");
+    assert!(format!("{:04}", radix(3, 2)) == "0011");
+    assert!(format!("{}", radix(55, 36)) == "1j");
 }
 
 #[test]
 #[should_fail]
 fn test_radix_base_too_large() {
-    let _ = radix(55i, 37);
+    let _ = radix(55, 37);
 }
 
-mod uint {
+mod u32 {
     use test::Bencher;
     use core::fmt::radix;
     use std::rand::{weak_rng, Rng};
+    use std::io::util::NullWriter;
 
     #[bench]
     fn format_bin(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:b}", rng.gen::<uint>()); })
+        b.iter(|| { let _ = write!(&mut NullWriter, "{:b}", rng.gen::<u32>()); })
     }
 
     #[bench]
     fn format_oct(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:o}", rng.gen::<uint>()); })
+        b.iter(|| { let _ = write!(&mut NullWriter, "{:o}", rng.gen::<u32>()); })
     }
 
     #[bench]
     fn format_dec(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{}", rng.gen::<uint>()); })
+        b.iter(|| { let _ = write!(&mut NullWriter, "{}", rng.gen::<u32>()); })
     }
 
     #[bench]
     fn format_hex(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:x}", rng.gen::<uint>()); })
+        b.iter(|| { let _ = write!(&mut NullWriter, "{:x}", rng.gen::<u32>()); })
     }
 
     #[bench]
     fn format_show(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:?}", rng.gen::<uint>()); })
+        b.iter(|| { let _ = write!(&mut NullWriter, "{:?}", rng.gen::<u32>()); })
     }
 
     #[bench]
     fn format_base_36(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{}", radix(rng.gen::<uint>(), 36)); })
+        b.iter(|| { let _ = write!(&mut NullWriter, "{}", radix(rng.gen::<u32>(), 36)); })
     }
 }
 
-mod int {
+mod i32 {
     use test::Bencher;
     use core::fmt::radix;
     use std::rand::{weak_rng, Rng};
+    use std::io::util::NullWriter;
 
     #[bench]
     fn format_bin(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:b}", rng.gen::<int>()); })
+        b.iter(|| { let _ = write!(&mut NullWriter, "{:b}", rng.gen::<i32>()); })
     }
 
     #[bench]
     fn format_oct(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:o}", rng.gen::<int>()); })
+        b.iter(|| { let _ = write!(&mut NullWriter, "{:o}", rng.gen::<i32>()); })
     }
 
     #[bench]
     fn format_dec(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{}", rng.gen::<int>()); })
+        b.iter(|| { let _ = write!(&mut NullWriter, "{}", rng.gen::<i32>()); })
     }
 
     #[bench]
     fn format_hex(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:x}", rng.gen::<int>()); })
+        b.iter(|| { let _ = write!(&mut NullWriter, "{:x}", rng.gen::<i32>()); })
     }
 
     #[bench]
     fn format_show(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{:?}", rng.gen::<int>()); })
+        b.iter(|| { let _ = write!(&mut NullWriter, "{:?}", rng.gen::<i32>()); })
     }
 
     #[bench]
     fn format_base_36(b: &mut Bencher) {
         let mut rng = weak_rng();
-        b.iter(|| { format!("{}", radix(rng.gen::<int>(), 36)); })
+        b.iter(|| { let _ = write!(&mut NullWriter, "{}", radix(rng.gen::<i32>(), 36)); })
     }
 }

--- a/src/libcoretest/result.rs
+++ b/src/libcoretest/result.rs
@@ -90,11 +90,11 @@ fn test_collect() {
 
 #[test]
 pub fn test_fmt_default() {
-    let ok: Result<int, &'static str> = Ok(100);
-    let err: Result<int, &'static str> = Err("Err");
+    let ok: Result<i32, &'static str> = Ok(100);
+    let err: Result<i32, &'static str> = Err("Err");
 
     let s = format!("{:?}", ok);
-    assert_eq!(s, "Ok(100i)");
+    assert_eq!(s, "Ok(100)");
     let s = format!("{:?}", err);
     assert_eq!(s, "Err(\"Err\")");
 }

--- a/src/libcoretest/tuple.rs
+++ b/src/libcoretest/tuple.rs
@@ -59,10 +59,10 @@ fn test_tuple_cmp() {
 
 #[test]
 fn test_show() {
-    let s = format!("{:?}", (1i,));
-    assert_eq!(s, "(1i,)");
-    let s = format!("{:?}", (1i, true));
-    assert_eq!(s, "(1i, true)");
-    let s = format!("{:?}", (1i, "hi", true));
-    assert_eq!(s, "(1i, \"hi\", true)");
+    let s = format!("{:?}", (1,));
+    assert_eq!(s, "(1,)");
+    let s = format!("{:?}", (1, true));
+    assert_eq!(s, "(1, true)");
+    let s = format!("{:?}", (1, "hi", true));
+    assert_eq!(s, r#"(1, "hi", true)"#);
 }


### PR DESCRIPTION
They just clutter the output, reading

```
[0i32, 1i32, 2i32, 3i32]
```

is really hard.
