### PR TITLE
Tweaks to guides and rustbook

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -29,6 +29,12 @@ DOCS := index intro tutorial complement-bugreport \
     complement-lang-faq complement-design-faq complement-project-faq \
     rustdoc reference
 
+# Legacy guides, preserved for a while to reduce the number of 404s
+DOCS += guide-crates guide-error-handling guide-ffi guide-macros guide \
+    guide-ownership guide-plugins guide-pointers guide-strings guide-tasks \
+    guide-testing
+
+
 PDF_DOCS := reference
 
 RUSTDOC_DEPS_reference := doc/full-toc.inc

--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -283,6 +283,6 @@ compiler-docs: $(COMPILER_DOC_TARGETS)
 
 trpl: doc/book/index.html
 
-doc/book/index.html: $(RUSTBOOK_EXE) $(wildcard $(S)/src/doc/trpl/*.md)
+doc/book/index.html: $(RUSTBOOK_EXE) $(wildcard $(S)/src/doc/trpl/*.md) | doc/
 	$(Q)rm -rf doc/book
 	$(Q)$(RUSTBOOK) build $(S)src/doc/trpl doc/book

--- a/src/doc/guide-crates.md
+++ b/src/doc/guide-crates.md
@@ -1,0 +1,4 @@
+% The (old) Rust Crates and Modules Guide
+
+This content has moved into the
+[the Rust Programming Language book](book/crates-and-modules.html).

--- a/src/doc/guide-error-handling.md
+++ b/src/doc/guide-error-handling.md
@@ -1,0 +1,4 @@
+% Error Handling in Rust
+
+This content has moved into the
+[the Rust Programming Language book](book/error-handling.html).

--- a/src/doc/guide-ffi.md
+++ b/src/doc/guide-ffi.md
@@ -1,0 +1,4 @@
+% The (old) Rust Foreign Function Interface Guide
+
+This content has moved into the
+[the Rust Programming Language book](book/ffi.html).

--- a/src/doc/guide-macros.md
+++ b/src/doc/guide-macros.md
@@ -1,0 +1,4 @@
+% The (old) Rust Macros Guide
+
+This content has moved into the
+[the Rust Programming Language book](book/macros.html).

--- a/src/doc/guide-ownership.md
+++ b/src/doc/guide-ownership.md
@@ -1,0 +1,4 @@
+% The (old) Rust Ownership Guide
+
+This content has moved into the
+[the Rust Programming Language book](book/ownership.html).

--- a/src/doc/guide-plugins.md
+++ b/src/doc/guide-plugins.md
@@ -1,0 +1,4 @@
+% The (old) Rust Compiler Plugins Guide
+
+This content has moved into the
+[the Rust Programming Language book](book/plugins.html).

--- a/src/doc/guide-pointers.md
+++ b/src/doc/guide-pointers.md
@@ -1,0 +1,4 @@
+% The (old) Rust Pointer Guide
+
+This content has moved into the
+[the Rust Programming Language book](book/pointers.html).

--- a/src/doc/guide-strings.md
+++ b/src/doc/guide-strings.md
@@ -1,0 +1,4 @@
+% The (old) Guide to Rust Strings
+
+This content has moved into the
+[the Rust Programming Language book](book/strings.html).

--- a/src/doc/guide-tasks.md
+++ b/src/doc/guide-tasks.md
@@ -1,0 +1,4 @@
+% The (old) Rust Threads and Communication Guide
+
+This content has moved into the
+[the Rust Programming Language book](book/tasks.html).

--- a/src/doc/guide-testing.md
+++ b/src/doc/guide-testing.md
@@ -1,0 +1,4 @@
+% The (old) Rust Testing Guide
+
+This content has moved into the
+[the Rust Programming Language book](book/testing.html).

--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -1,0 +1,4 @@
+% Writing Safe Low-level and Unsafe Code in Rust
+
+This content has moved into the
+[the Rust Programming Language book](book/unsafe.html).

--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -1,0 +1,4 @@
+% The (old) Rust Guide
+
+This content has moved into the
+[the Rust Programming Language book](book/README.html).

--- a/src/rustbook/book.rs
+++ b/src/rustbook/book.rs
@@ -124,7 +124,7 @@ pub fn parse_summary<R: Reader>(input: R, src: &Path) -> Result<Book, Vec<String
             let path_from_root = match src.join(given_path.unwrap()).path_relative_from(src) {
                 Some(p) => p,
                 None => {
-                    errors.push(format!("Paths in SUMMARY.md must be relative, \
+                    errors.push(format!("paths in SUMMARY.md must be relative, \
                                          but path '{}' for section '{}' is not.",
                                          given_path.unwrap(), title));
                     Path::new("")
@@ -148,8 +148,9 @@ pub fn parse_summary<R: Reader>(input: R, src: &Path) -> Result<Book, Vec<String
             }).sum() / 4 + 1;
 
             if level > stack.len() + 1 {
-                // FIXME: better error message
-                errors.push(format!("Section '{}' is indented too many levels.", item.title));
+                errors.push(format!("section '{}' is indented too deeply; \
+                                     found {}, expected {} or less",
+                                    item.title, level, stack.len() + 1));
             } else if level <= stack.len() {
                 collapse(&mut stack, &mut top_items, level);
             }

--- a/src/rustbook/css.rs
+++ b/src/rustbook/css.rs
@@ -11,7 +11,7 @@
 // The rust-book CSS in string form.
 
 pub static STYLE: &'static str = r#"
-@import url("//static.rust-lang.org/doc/master/rust.css");
+@import url("../rust.css");
 
 body {
     max-width:none;

--- a/src/rustbook/error.rs
+++ b/src/rustbook/error.rs
@@ -79,4 +79,5 @@ impl Error for IoError {
     }
 }
 
+
 //fn iter_map_err<T, U, E, I: Iterator<Result<T,E>>>(iter: I,

--- a/src/rustbook/main.rs
+++ b/src/rustbook/main.rs
@@ -54,7 +54,12 @@ fn main() {
                     Ok(_) => {
                         match subcmd.execute(&mut term) {
                             Ok(_) => (),
-                            Err(_) => os::set_exit_status(-1),
+                            Err(err) => {
+                                term.err(&format!("error: {}", err.description())[]);
+                                err.detail().map(|detail| {
+                                    term.err(&format!("detail: {}", detail)[]);
+                                });
+                            }
                         }
                     }
                     Err(err) => {


### PR DESCRIPTION
There is likely to be new users with the alpha release, and there are a lot of documents on the internet (StackOverflow, reddit, blogs) that refer to these guides, so emitting a more helpful error than "404" is nice. Hence, I've temporarily reinstated stub documents for each of the old guides, referring to as relevant a part of the book as possible.

Also, rustbook was silently ignoring some errors, which lead to an inconsistency with directory creation/file writing. This meant the CSS file was not being written if no `doc` directory existed in the users build dir (e.g. the buildbots). This should mean that the CSS will appear automatically in later builds.
