### PR TITLE
Fix checking of command line expansion spans

### DIFF
--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -42,8 +42,6 @@ pub struct TestProps {
     pub pretty_compare_only: bool,
     // Patterns which must not appear in the output of a cfail test.
     pub forbid_output: Vec<String>,
-    // Ignore errors which originate from a command line span
-    pub ignore_command_line: bool,
 }
 
 // Load any test directives embedded in the file
@@ -62,8 +60,6 @@ pub fn load_props(testfile: &Path) -> TestProps {
     let mut pretty_mode = None;
     let mut pretty_compare_only = false;
     let mut forbid_output = Vec::new();
-    let mut ignore_command_line = false;
-
     iter_header(testfile, |ln| {
         match parse_error_pattern(ln) {
           Some(ep) => error_patterns.push(ep),
@@ -106,10 +102,6 @@ pub fn load_props(testfile: &Path) -> TestProps {
             pretty_compare_only = parse_pretty_compare_only(ln);
         }
 
-        if !ignore_command_line {
-            ignore_command_line = parse_ignore_command_line(ln);
-        }
-
         match parse_aux_build(ln) {
             Some(ab) => { aux_builds.push(ab); }
             None => {}
@@ -148,7 +140,6 @@ pub fn load_props(testfile: &Path) -> TestProps {
         pretty_mode: pretty_mode.unwrap_or("normal".to_string()),
         pretty_compare_only: pretty_compare_only,
         forbid_output: forbid_output,
-        ignore_command_line: ignore_command_line,
     }
 }
 
@@ -298,10 +289,6 @@ fn parse_pretty_mode(line: &str) -> Option<String> {
 
 fn parse_pretty_compare_only(line: &str) -> bool {
     parse_name_directive(line, "pretty-compare-only")
-}
-
-fn parse_ignore_command_line(line: &str) -> bool {
-    parse_name_directive(line, "ignore-command-line")
 }
 
 fn parse_exec_env(line: &str) -> Option<(String, String)> {

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -104,7 +104,7 @@ fn run_cfail_test(config: &Config, props: &TestProps, testfile: &Path) {
         if !props.error_patterns.is_empty() {
             fatal("both error pattern and expected errors specified");
         }
-        check_expected_errors(props, expected_errors, testfile, &proc_res);
+        check_expected_errors(expected_errors, testfile, &proc_res);
     } else {
         check_error_patterns(props, testfile, output_to_check.as_slice(), &proc_res);
     }
@@ -941,8 +941,7 @@ fn check_forbid_output(props: &TestProps,
     }
 }
 
-fn check_expected_errors(props: &TestProps,
-                         expected_errors: Vec<errors::ExpectedError> ,
+fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
                          testfile: &Path,
                          proc_res: &ProcRes) {
 
@@ -994,11 +993,6 @@ fn check_expected_errors(props: &TestProps,
 
         // ignore this msg which gets printed at the end
         if line.contains("aborting due to") {
-            was_expected = true;
-        }
-
-        if line.starts_with("<command line option>") &&
-           props.ignore_command_line {
             was_expected = true;
         }
 

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -13,7 +13,7 @@ pub use self::RenderSpan::*;
 pub use self::ColorConfig::*;
 use self::Destination::*;
 
-use codemap::{COMMAND_LINE_SP, Pos, Span};
+use codemap::{COMMAND_LINE_SP, COMMAND_LINE_EXPN, Pos, Span};
 use codemap;
 use diagnostics;
 
@@ -393,7 +393,10 @@ impl Emitter for EmitterWriter {
 fn emit(dst: &mut EmitterWriter, cm: &codemap::CodeMap, rsp: RenderSpan,
         msg: &str, code: Option<&str>, lvl: Level, custom: bool) -> io::IoResult<()> {
     let sp = rsp.span();
-    let ss = if sp == COMMAND_LINE_SP {
+
+    // We cannot check equality directly with COMMAND_LINE_SP
+    // since PartialEq is manually implemented to ignore the ExpnId
+    let ss = if sp.expn_id == COMMAND_LINE_EXPN {
         "<command line option>".to_string()
     } else {
         cm.span_to_string(sp)

--- a/src/test/compile-fail/recursion.rs
+++ b/src/test/compile-fail/recursion.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-command-line: See https://github.com/rust-lang/rust/issues/20747
+//~^^^^^^^^^^ ERROR overflow
 //
 // We also get a second error message at the top of file (dummy
 // span). This is not helpful, but also kind of annoying to prevent,


### PR DESCRIPTION
fixes #20747

Turns out it was my fault all along. Though the span-less error from https://github.com/nikomatsakis/rust/commit/9e4e8823c7cb553f07536ff2cbdaabdcd0dc9cc0 should probably be eventually fixed (I'll poke at it later)

r? @nikomatsakis 
