### PR TITLE
Allow `|` after `pat` in macro_rules!

### DIFF
--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -19,7 +19,7 @@ use ext::tt::macro_parser::{parse, parse_or_else};
 use parse::lexer::{new_tt_reader, new_tt_reader_with_doc_flag};
 use parse::parser::Parser;
 use parse::attr::ParserAttr;
-use parse::token::{special_idents, gensym_ident, NtTT, Token};
+use parse::token::{special_idents, gensym_ident, NtTT, Token, BinOpToken};
 use parse::token::Token::*;
 use parse::token;
 use print;
@@ -433,7 +433,7 @@ fn is_in_follow(cx: &ExtCtxt, tok: &Token, frag: &str) -> bool {
         },
         "pat" => {
             match *tok {
-                FatArrow | Comma | Eq => true,
+                FatArrow | Comma | Eq | BinOp(BinOpToken::Or) => true,
                 _ => false
             }
         },

--- a/src/test/compile-fail/macro-input-future-proofing.rs
+++ b/src/test/compile-fail/macro-input-future-proofing.rs
@@ -18,7 +18,6 @@ macro_rules! errors_everywhere {
     ($bl:block < ) => ();
     ($pa:pat >) => (); //~ ERROR `$pa:pat` is followed by `>`, which is not allowed for `pat`
     ($pa:pat , ) => ();
-    ($pa:pat | ) => (); //~ ERROR `$pa:pat` is followed by `|`
     ($pa:pat $pb:pat $ty:ty ,) => ();
     //~^ ERROR `$pa:pat` is followed by `$pb:pat`, which is not allowed
     //~^^ ERROR `$pb:pat` is followed by `$ty:ty`, which is not allowed

--- a/src/test/run-pass/matches-macro.rs
+++ b/src/test/run-pass/matches-macro.rs
@@ -1,0 +1,34 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+//! https://github.com/rust-lang/rust/pull/20824
+
+// ignore-pretty
+
+macro_rules! matches {
+    ($expression: expr, $($pattern:pat)|+) => {
+        matches!($expression, $($pattern)|+ if true)
+    };
+    ($expression: expr, $($pattern:pat)|+ if $guard: expr) => {
+        match $expression {
+            $($pattern)|+ => $guard,
+            _ => false
+        }
+    };
+}
+
+pub fn main() {
+    let foo = Some("-12");
+    assert!(matches!(foo, Some(bar) if
+        matches!(bar.char_at(0), '+' | '-') &&
+        matches!(bar.char_at(1), '0'...'9')
+    ));
+}


### PR DESCRIPTION
Per https://github.com/rust-lang/rust/pull/20563#issuecomment-69347826

This enables writing macros that accept `$($pattern:pat)|+` and expand to the same thing in a `match` statement. See for example [the `matches!` macro](https://github.com/SimonSapin/rust-std-candidates#the-matches-macro).

r? @alexcrichton 
