### PR TITLE
syntax: Add #[allow(unstable)] to --test expansion

### DIFF
--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -439,13 +439,19 @@ fn mk_test_module(cx: &mut TestCtxt) -> (P<ast::Item>, Option<ast::ViewItem>) {
     let item_ = ast::ItemMod(testmod);
 
     let mod_ident = token::gensym_ident("__test");
+    let allow_unstable = {
+        let unstable = P(nospan(ast::MetaWord(InternedString::new("unstable"))));
+        let allow = P(nospan(ast::MetaList(InternedString::new("allow"),
+                                           vec![unstable])));
+        attr::mk_attr_inner(attr::mk_attr_id(), allow)
+    };
     let item = ast::Item {
         ident: mod_ident,
-        attrs: Vec::new(),
         id: ast::DUMMY_NODE_ID,
         node: item_,
         vis: ast::Public,
         span: DUMMY_SP,
+        attrs: vec![allow_unstable],
     };
     let reexport = cx.reexport_test_harness_main.as_ref().map(|s| {
         // building `use <ident> = __test::main`

--- a/src/test/run-pass/issue-20823.rs
+++ b/src/test/run-pass/issue-20823.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test
+
+#![deny(unstable)]
+
+#[test]
+fn foo() {}


### PR DESCRIPTION
This will temporarily prevent warnings generated from expanding to code that the
test harness itself uses. This solution will require tweaking around the beta
cycle, but it will prevent spurious warnings for now.

Closes #20823
