### PR TITLE
Docs: Should be `assert_eq!` not `assert_eq`

### DIFF
--- a/src/doc/trpl/testing.md
+++ b/src/doc/trpl/testing.md
@@ -309,7 +309,7 @@ extern crate adder;
 
 #[test]
 fn it_works() {
-    assert_eq(4, adder::add_two(2));
+    assert_eq!(4, adder::add_two(2));
 }   
 ```
 


### PR DESCRIPTION
Typo in testing chapter of the book.
