### PR TITLE
Fix `playpen.js` errors on `pre`s without IDs

### DIFF
--- a/src/librustdoc/html/static/playpen.js
+++ b/src/librustdoc/html/static/playpen.js
@@ -14,6 +14,7 @@
 (function() {
     if (window.playgroundUrl) {
         $('pre.rust').hover(function() {
+            if (!$(this).attr('id')) { return; }
             var id = '#' + $(this).attr('id').replace('rendered', 'raw');
             var a = $('<a>').text('⇱').attr('class', 'test-arrow');
             var code = $(id).text();


### PR DESCRIPTION
This adds an early return to skip code blocks without IDs.

Fixes #20864.
