### PR TITLE
Feature-gate `<>` syntax used with `Fn`. Fixes #18875.

### DIFF
--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -582,6 +582,19 @@ fn ast_path_to_trait_ref<'a,'tcx>(
 
     let (regions, types, assoc_bindings) = match path.segments.last().unwrap().parameters {
         ast::AngleBracketedParameters(ref data) => {
+            // For now, require that parenthetical notation be used
+            // only with `Fn()` etc.
+            if !this.tcx().sess.features.borrow().unboxed_closures &&
+                this.tcx().lang_items.fn_trait_kind(trait_def_id).is_some()
+            {
+                this.tcx().sess.span_err(path.span,
+                                         "angle-bracket notation is not stable when \
+                                         used with the `Fn` family of traits, use parentheses");
+                span_help!(this.tcx().sess, path.span,
+                           "add `#![feature(unboxed_closures)]` to \
+                            the crate attributes to enable");
+            }
+
             convert_angle_bracketed_parameters(this, &shifted_rscope, data)
         }
         ast::ParenthesizedParameters(ref data) => {

--- a/src/test/compile-fail/feature-gate-unboxed-closures-manual-impls.rs
+++ b/src/test/compile-fail/feature-gate-unboxed-closures-manual-impls.rs
@@ -11,15 +11,15 @@
 #![allow(dead_code)]
 
 struct Foo;
-impl Fn<(), ()> for Foo { //~ ERROR manual implementations of `Fn` are experimental
+impl Fn() for Foo { //~ ERROR manual implementations of `Fn` are experimental
     extern "rust-call" fn call(&self, args: ()) -> () {}
 }
 struct Bar;
-impl FnMut<(), ()> for Bar { //~ ERROR manual implementations of `FnMut` are experimental
+impl FnMut() for Bar { //~ ERROR manual implementations of `FnMut` are experimental
     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
 }
 struct Baz;
-impl FnOnce<(), ()> for Baz { //~ ERROR manual implementations of `FnOnce` are experimental
+impl FnOnce() for Baz { //~ ERROR manual implementations of `FnOnce` are experimental
     extern "rust-call" fn call_once(&self, args: ()) -> () {}
 }
 

--- a/src/test/compile-fail/feature-gate-unboxed-closures-ufcs-calls.rs
+++ b/src/test/compile-fail/feature-gate-unboxed-closures-ufcs-calls.rs
@@ -10,7 +10,7 @@
 
 #![allow(dead_code)]
 
-fn foo<F: Fn<(), ()>>(mut f: F, mut g: F) {
+fn foo<F: Fn()>(mut f: F, mut g: F) {
     Fn::call(&g, ()); //~ ERROR explicit use of unboxed closure method `call`
     FnMut::call_mut(&mut g, ()); //~ ERROR explicit use of unboxed closure method `call_mut`
     FnOnce::call_once(g, ()); //~ ERROR explicit use of unboxed closure method `call_once`

--- a/src/test/compile-fail/unboxed-closure-sugar-not-used-on-fn.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-not-used-on-fn.rs
@@ -8,12 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(dead_code)]
 
-fn foo<F: Fn()>(mut f: F) {
-    f.call(()); //~ ERROR explicit use of unboxed closure method `call`
-    f.call_mut(()); //~ ERROR explicit use of unboxed closure method `call_mut`
-    f.call_once(()); //~ ERROR explicit use of unboxed closure method `call_once`
+// Test that the `Fn` traits require `()` form without a feature gate.
+
+fn bar1(x: &Fn<(),()>) {
+    //~^ ERROR angle-bracket notation is not stable when used with the `Fn` family
 }
 
-fn main() {}
+fn bar2<T>(x: &T) where T: Fn<(),()> {
+    //~^ ERROR angle-bracket notation is not stable when used with the `Fn` family
+}
+
+fn main() { }
+


### PR DESCRIPTION
Feature-gate `<>` syntax used with `Fn`. Fixes #18875.

r? @huonw 
