### PR TITLE
Replace AsRawFd implementations with generic AsInner<FileDesc>

### DIFF
--- a/src/libstd/sys/unix/ext.rs
+++ b/src/libstd/sys/unix/ext.rs
@@ -37,7 +37,7 @@ use sys_common::{AsInner, IntoInner, FromInner};
 use ffi::{OsStr, OsString};
 use libc;
 
-use old_io;
+use sys::fs::FileDesc;
 
 /// Raw file descriptors.
 pub type Fd = libc::c_int;
@@ -48,55 +48,7 @@ pub trait AsRawFd {
     fn as_raw_fd(&self) -> Fd;
 }
 
-impl AsRawFd for old_io::fs::File {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
-    }
-}
-
-impl AsRawFd for old_io::pipe::PipeStream {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
-    }
-}
-
-impl AsRawFd for old_io::net::pipe::UnixStream {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
-    }
-}
-
-impl AsRawFd for old_io::net::pipe::UnixListener {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
-    }
-}
-
-impl AsRawFd for old_io::net::pipe::UnixAcceptor {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
-    }
-}
-
-impl AsRawFd for old_io::net::tcp::TcpStream {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
-    }
-}
-
-impl AsRawFd for old_io::net::tcp::TcpListener {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
-    }
-}
-
-impl AsRawFd for old_io::net::tcp::TcpAcceptor {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
-    }
-}
-
-impl AsRawFd for old_io::net::udp::UdpSocket {
+impl<T> AsRawFd for T where T: AsInner<FileDesc> {
     fn as_raw_fd(&self) -> Fd {
         self.as_inner().fd()
     }


### PR DESCRIPTION
Revamp the `AsRawFd` implementations using generics.
