### PR TITLE
Add new number literal suffixes to Vim syntax highlighting

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -59,7 +59,7 @@ syn match rustMacroVariable "$\w\+"
 syn keyword   rustReservedKeyword alignof be do offsetof priv pure sizeof typeof unsized yield abstract final override macro
 
 " Built-in types {{{2
-syn keyword   rustType        int isize uint usize float char bool u8 u16 u32 u64 f32
+syn keyword   rustType        isize usize float char bool u8 u16 u32 u64 f32
 syn keyword   rustType        f64 i8 i16 i32 i64 str Self
 
 " Things from the prelude (src/libstd/prelude.rs) {{{2
@@ -139,10 +139,10 @@ syn region    rustAttribute   start="#!\?\[" end="\]" contains=rustString,rustDe
 syn region    rustDerive      start="derive(" end=")" contained contains=rustTrait
 
 " Number literals
-syn match     rustDecNumber   display "\<[0-9][0-9_]*\%([iu]\%(8\|16\|32\|64\)\=\)\="
-syn match     rustHexNumber   display "\<0x[a-fA-F0-9_]\+\%([iu]\%(8\|16\|32\|64\)\=\)\="
-syn match     rustOctNumber   display "\<0o[0-7_]\+\%([iu]\%(8\|16\|32\|64\)\=\)\="
-syn match     rustBinNumber   display "\<0b[01_]\+\%([iu]\%(8\|16\|32\|64\)\=\)\="
+syn match     rustDecNumber   display "\<[0-9][0-9_]*\%([iu]\%(s\|8\|16\|32\|64\)\)\="
+syn match     rustHexNumber   display "\<0x[a-fA-F0-9_]\+\%([iu]\%(s\|8\|16\|32\|64\)\)\="
+syn match     rustOctNumber   display "\<0o[0-7_]\+\%([iu]\%(s\|8\|16\|32\|64\)\)\="
+syn match     rustBinNumber   display "\<0b[01_]\+\%([iu]\%(s\|8\|16\|32\|64\)\)\="
 
 " Special case for numbers of the form "1." which are float literals, unless followed by
 " an identifier, which makes them integer literals with a method call or field access,

--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -95,8 +95,6 @@ syn keyword rustTrait Vec
 syn keyword rustTrait Path GenericPath
 " FIXME: remove when I/O reform lands
 syn keyword rustTrait Buffer Writer Reader Seek BufferPrelude
-" FIXME: remove when range syntax lands
-syn keyword rustFunction range
 
 " Other syntax {{{2
 syn keyword   rustSelf        self


### PR DESCRIPTION
Just a quick addition of `is` and `us` suffixes.

At some point the `i` and `u` only suffixes should be dropped, along with the `int` and `uint` types.
