### PR TITLE
upvar: Make sure that typeck succeeded before analyzing a closure

### DIFF
--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -61,8 +61,10 @@ pub fn closure_analyze_fn(fcx: &FnCtxt,
     let mut seed = SeedBorrowKind::new(fcx);
     seed.visit_block(body);
 
-    let mut adjust = AdjustBorrowKind::new(fcx);
-    adjust.analyze_fn(decl, body);
+    if fcx.err_count_since_creation() == 0 {
+        let mut adjust = AdjustBorrowKind::new(fcx);
+        adjust.analyze_fn(decl, body);
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/test/compile-fail/unexpected-callee-type-ice.rs
+++ b/src/test/compile-fail/unexpected-callee-type-ice.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Related issues: #20714, #20842, #20862
+
+fn main() {
+    let homura = ""(); //~ ERROR expected function, found
+}


### PR DESCRIPTION
If a type that cannot be called as a function is called, and the result is assigned to a variable, the "unexpected callee type" ICE occurs.

Fixes #20714.
Fixes #20842.
Fixes #20862.
