### PR TITLE
emacs: Mark _ as a word constituent to avoid highlighting parts of identifiers as keywords

### DIFF
--- a/src/etc/emacs/rust-mode.el
+++ b/src/etc/emacs/rust-mode.el
@@ -31,6 +31,11 @@
     (modify-syntax-entry ?\" "\"" table)
     (modify-syntax-entry ?\\ "\\" table)
 
+    ;; mark _ as a word constituent so that identifiers
+    ;; such as xyz_type don't cause type to be highlighted
+    ;; as a keyword
+    (modify-syntax-entry ?_ "w" table)
+
     ;; Comments
     (modify-syntax-entry ?/  ". 124b" table)
     (modify-syntax-entry ?*  ". 23"   table)


### PR DESCRIPTION
rust-mode.el recently started highlighting keywords that were substrings of identifiers. Identifiers such as `xyz_type` would have `type` highlighted, which isn't normal. This patch re-introduces `_` as a word constituent, so that keywords following a `_` don't get syntax highlighted as keywords. Fixes issue #20422
