### PR TITLE
Updates fixed-size suffix in 30 minute introduction

### DIFF
--- a/src/doc/intro.md
+++ b/src/doc/intro.md
@@ -106,9 +106,9 @@ use semver::Version;
 
 fn main() {
     assert!(Version::parse("1.2.3") == Ok(Version {
-        major: 1u,
-        minor: 2u,
-        patch: 3u,
+        major: 1u64,
+        minor: 2u64,
+        patch: 3u64,
         pre: vec!(),
         build: vec!(),
     }));


### PR DESCRIPTION
Compiler gives the following warning:
`warning: the`u`suffix on integers is deprecated; use`us`or one of the fixed-sized suffixes`
And also the errror:
`error: mismatched types: expected`u64`, found`usize`(expected u64, found usize)`

Changing the suffix to `u64` results in a successful `cargo run` outputting the desired `Versions compared successfully!`
