### PR TITLE
Permit node types to be missing if type errors occurred previously

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2097,6 +2097,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn node_ty(&self, id: ast::NodeId) -> Ty<'tcx> {
         match self.inh.node_types.borrow().get(&id) {
             Some(&t) => t,
+            None if self.err_count_since_creation() != 0 => self.tcx().types.err,
             None => {
                 self.tcx().sess.bug(
                     &format!("no type for node {}: {} in fcx {}",

--- a/src/test/compile-fail/no-type-for-node-ice.rs
+++ b/src/test/compile-fail/no-type-for-node-ice.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Related issues: #20401, #20506, #20614, #20752, #20829, #20846, #20885, #20886
+
+fn main() {
+    "".homura[""]; //~ ERROR no field with that name was found
+}


### PR DESCRIPTION
If the type of a node cannot be determined due to a previous type error, a `no type for node` ICE occurs. This commit makes it return `ty_err` instead in such a case.

Fixes #20401.
Fixes #20506.
Fixes #20614.
Fixes #20752.
Fixes #20829.
Fixes #20846.
Fixes #20885.
Fixes #20886.
Fixes #20952.
Fixes #20970.
