### PR TITLE
Cosmetic updates to TRPL text

### DIFF
--- a/src/doc/trpl/arrays-vectors-and-slices.md
+++ b/src/doc/trpl/arrays-vectors-and-slices.md
@@ -94,6 +94,6 @@ backed by arrays. Slices have type `&[T]`, which we'll talk about when we cover
 generics.
 
 We have now learned all of the most basic Rust concepts. We're ready to start
-building our guessing game, we just need to know one last thing: how to get
-input from the keyboard. You can't have a guessing game without the ability to
-guess!
+building ourselves a guessing game, we just need to know one last thing: how to
+get input from the keyboard. You can't have a guessing game without the ability
+to guess!

--- a/src/doc/trpl/comments.md
+++ b/src/doc/trpl/comments.md
@@ -40,7 +40,8 @@ fn hello(name: &str) {
 ```
 
 When writing doc comments, adding sections for any arguments, return values,
-and providing some examples of usage is very, very helpful.
+and providing some examples of usage is very, very helpful. Don't worry about
+the `&str`, we'll get to it soon.
 
 You can use the [`rustdoc`](../rustdoc.html) tool to generate HTML documentation
 from these doc comments.

--- a/src/doc/trpl/compound-data-types.md
+++ b/src/doc/trpl/compound-data-types.md
@@ -23,10 +23,10 @@ let x: (i32, &str) = (1, "hello");
 As you can see, the type of a tuple looks just like the tuple, but with each
 position having a type name rather than the value. Careful readers will also
 note that tuples are heterogeneous: we have an `i32` and a `&str` in this tuple.
-You haven't seen `&str` as a type before, and we'll discuss the details of
-strings later. In systems programming languages, strings are a bit more complex
-than in other languages. For now, just read `&str` as a *string slice*, and
-we'll learn more soon.
+You have briefly seen `&str` used as a type before, and we'll discuss the
+details of strings later. In systems programming languages, strings are a bit
+more complex than in other languages. For now, just read `&str` as a *string
+slice*, and we'll learn more soon.
 
 You can access the fields in a tuple through a *destructuring let*. Here's
 an example:

--- a/src/doc/trpl/functions.md
+++ b/src/doc/trpl/functions.md
@@ -59,7 +59,7 @@ Unlike `let`, you _must_ declare the types of function arguments. This does
 not work:
 
 ```{ignore}
-fn print_number(x, y) {
+fn print_sum(x, y) {
     println!("x is: {}", x + y);
 }
 ```
@@ -67,7 +67,7 @@ fn print_number(x, y) {
 You get this error:
 
 ```text
-hello.rs:5:18: 5:19 error: expected `:` but found `,`
+hello.rs:5:18: 5:19 expected one of `!`, `:`, or `@`, found `)`
 hello.rs:5 fn print_number(x, y) {
 ```
 

--- a/src/doc/trpl/if.md
+++ b/src/doc/trpl/if.md
@@ -126,7 +126,7 @@ let y: i32 = if x == 5 { 10; } else { 15; };
 Note the semicolons after the 10 and 15. Rust will give us the following error:
 
 ```text
-error: mismatched types: expected `i32` but found `()` (expected i32 but found ())
+error: mismatched types: expected `i32`, found `()` (expected i32, found ())
 ```
 
 We expected an integer, but we got `()`. `()` is pronounced *unit*, and is a

--- a/src/doc/trpl/variable-bindings.md
+++ b/src/doc/trpl/variable-bindings.md
@@ -98,7 +98,7 @@ let x;
 ...we'll get an error:
 
 ```text
-src/main.rs:2:9: 2:10 error: cannot determine a type for this local variable: unconstrained type
+src/main.rs:2:9: 2:10 error: unable to infer enough type information about `_`; type annotations required
 src/main.rs:2     let x;
                       ^
 ```


### PR DESCRIPTION
- Make messages match rustc's error messages
- Use correct function name in example
- Rewording to match previously presented material
