### PR TITLE
Update Token::can_begin_expr() to make it consistent with the grammar:

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2167,6 +2167,7 @@ impl<'a> Parser<'a> {
 
         let ex: Expr_;
 
+        // Note: when adding new syntax here, don't forget to adjust Token::can_begin_expr().
         match self.token {
             token::OpenDelim(token::Paren) => {
                 self.bump();
@@ -2773,6 +2774,7 @@ impl<'a> Parser<'a> {
         let lo = self.span.lo;
         let hi;
 
+        // Note: when adding new unary operators, don't forget to adjust Token::can_begin_expr()
         let ex;
         match self.token {
           token::Not => {
@@ -5590,13 +5592,6 @@ impl<'a> Parser<'a> {
         (id, ItemEnum(enum_definition, generics), None)
     }
 
-    fn fn_expr_lookahead(tok: &token::Token) -> bool {
-        match *tok {
-          token::OpenDelim(token::Paren) | token::At | token::Tilde | token::BinOp(_) => true,
-          _ => false
-        }
-    }
-
     /// Parses a string as an ABI spec on an extern type or module. Consumes
     /// the `extern` keyword, if one is found.
     fn parse_opt_abi(&mut self) -> Option<abi::Abi> {
@@ -5779,8 +5774,7 @@ impl<'a> Parser<'a> {
                                     maybe_append(attrs, extra_attrs));
             return IoviItem(item);
         }
-        if self.token.is_keyword(keywords::Fn) &&
-                self.look_ahead(1, |f| !Parser::fn_expr_lookahead(f)) {
+        if self.token.is_keyword(keywords::Fn) {
             // FUNCTION ITEM
             self.bump();
             let (ident, item_, extra_attrs) =

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -183,14 +183,14 @@ impl Token {
             Underscore                  => true,
             Tilde                       => true,
             Literal(_, _)               => true,
-            Pound                       => true,
-            At                          => true,
             Not                         => true,
             BinOp(Minus)                => true,
             BinOp(Star)                 => true,
             BinOp(And)                  => true,
             BinOp(Or)                   => true, // in lambda syntax
             OrOr                        => true, // in lambda syntax
+            AndAnd                      => true, // double borrow
+            DotDot                      => true, // range notation
             ModSep                      => true,
             Interpolated(NtExpr(..))    => true,
             Interpolated(NtIdent(..))   => true,

--- a/src/test/run-pass/range.rs
+++ b/src/test/run-pass/range.rs
@@ -12,6 +12,9 @@
 
 fn foo() -> int { 42 }
 
+// Test that range syntax works in return statements
+fn return_range_to() -> ::std::ops::RangeTo<i32> { return ..1; }
+
 pub fn main() {
     let mut count = 0;
     for i in 0u..10 {


### PR DESCRIPTION
- add `Token::AndAnd` (double borrow)
- add `Token::DotDot` (range notation)
- remove `Token::Pound` and `Token::At`

This fixes a syntax error when parsing `fn f() -> RangeTo<i32> { return ..1; }`.

Also, remove `fn_expr_lookahead`.
It's from the `fn~` days and seems to no longer be necessary.
