### PR TITLE
Process trait obligations before coercing if necessary

### DIFF
--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -20,6 +20,7 @@ use super::method;
 use super::structurally_resolved_type;
 use super::TupleArgumentsFlag;
 use super::write_call;
+use super::vtable;
 
 use middle::infer;
 use middle::ty::{self, Ty};

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -60,7 +60,7 @@ pub fn coerce<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>, sp: Span,
     debug!("demand::coerce(expected = {}, expr_ty = {})",
            expected.repr(fcx.ccx.tcx),
            expr_ty.repr(fcx.ccx.tcx));
-    let expected = fcx.infcx().resolve_type_vars_if_possible(&expected);
+    let expected = fcx.resolve_type_vars_if_possible(expected);
     match fcx.mk_assignty(expr, expr_ty, expected) {
       Ok(()) => { /* ok */ }
       Err(ref err) => {

--- a/src/test/run-pass/into-iterator-type-inference-ptr-read.rs
+++ b/src/test/run-pass/into-iterator-type-inference-ptr-read.rs
@@ -1,0 +1,41 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for type inference failure. In this case,
+// `ptr::read` expects a `*T`, but the result from the call to
+// `next.unwrap()` was a type variable that had not yet been resolved.
+// Once pending obligations are resolved, result is `&T`, which can be
+// coered to `*T`. But if we first unify the types, then the
+// resolution of the pending trait obligations fails.
+
+use std::ptr;
+
+trait IntoIterator {
+    type Iter: Iterator;
+
+    fn into_iter(self) -> Self::Iter;
+}
+
+impl<I> IntoIterator for I where I: Iterator {
+    type Iter = I;
+
+    fn into_iter(self) -> I {
+        self
+    }
+}
+
+fn desugared_for_loop_bad<T>(v: Vec<T>) {
+    let mut iter = IntoIterator::into_iter(v.iter());
+    let next = Iterator::next(&mut iter);
+    let x = next.unwrap();
+    unsafe { ptr::read(x); }
+}
+
+fn main() {}

--- a/src/test/run-pass/into-iterator-type-inference-shift.rs
+++ b/src/test/run-pass/into-iterator-type-inference-shift.rs
@@ -1,0 +1,41 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for type inference failure around shifting. In this
+// case, the iteration yields an int, but we hadn't run the full type
+// propagation yet, and so we just saw a type variable, yielding an
+// error.
+
+use std::u8;
+
+trait IntoIterator {
+    type Iter: Iterator;
+
+    fn into_iter(self) -> Self::Iter;
+}
+
+impl<I> IntoIterator for I where I: Iterator {
+    type Iter = I;
+
+    fn into_iter(self) -> I {
+        self
+    }
+}
+
+fn desugared_for_loop_bad(byte: u8) -> u8 {
+    let mut result = 0;
+    let mut x = IntoIterator::into_iter(range(0, u8::BITS));
+    let mut y = Iterator::next(&mut x);
+    let mut z = y.unwrap();
+    byte >> z;
+    1
+}
+
+fn main() {}


### PR DESCRIPTION
Fix two type inference failures uncovered by @japaric corresponding to
UFCS form. In both cases the problems came about because we were
failing to process pending trait obligations. So change code to
process pending trait obligations before coercions to ensure maximum
type information is available (and also adjust shift to do something
similar).
