### PR TITLE
Update Vim syntax file to include `s' on `us' and `is' literal

### DIFF
--- a/src/etc/vim/syntax/rust.vim
+++ b/src/etc/vim/syntax/rust.vim
@@ -139,10 +139,10 @@ syn region    rustAttribute   start="#!\?\[" end="\]" contains=rustString,rustDe
 syn region    rustDerive      start="derive(" end=")" contained contains=rustTrait
 
 " Number literals
-syn match     rustDecNumber   display "\<[0-9][0-9_]*\%([iu]\%(8\|16\|32\|64\)\=\)\="
-syn match     rustHexNumber   display "\<0x[a-fA-F0-9_]\+\%([iu]\%(8\|16\|32\|64\)\=\)\="
-syn match     rustOctNumber   display "\<0o[0-7_]\+\%([iu]\%(8\|16\|32\|64\)\=\)\="
-syn match     rustBinNumber   display "\<0b[01_]\+\%([iu]\%(8\|16\|32\|64\)\=\)\="
+syn match     rustDecNumber   display "\<[0-9][0-9_]*\%([iu]s?\%(8\|16\|32\|64\)\=\)\="
+syn match     rustHexNumber   display "\<0x[a-fA-F0-9_]\+\%([iu]s?\%(8\|16\|32\|64\)\=\)\="
+syn match     rustOctNumber   display "\<0o[0-7_]\+\%([iu]s?\%(8\|16\|32\|64\)\=\)\="
+syn match     rustBinNumber   display "\<0b[01_]\+\%([iu]s?\%(8\|16\|32\|64\)\=\)\="
 
 " Special case for numbers of the form "1." which are float literals, unless followed by
 " an identifier, which makes them integer literals with a method call or field access,


### PR DESCRIPTION
Relevant RFC: https://github.com/rust-lang/rfcs/pull/544
