### PR TITLE
test: Use Thread::scoped in two more tests

### DIFF
--- a/src/test/run-pass/unwind-unique.rs
+++ b/src/test/run-pass/unwind-unique.rs
@@ -19,5 +19,5 @@ fn f() {
 }
 
 pub fn main() {
-    let _t = Thread::spawn(f);
+    let _t = Thread::scoped(f);
 }

--- a/src/test/run-pass/weak-lang-item.rs
+++ b/src/test/run-pass/weak-lang-item.rs
@@ -15,7 +15,7 @@ extern crate "weak-lang-items" as other;
 use std::thread::Thread;
 
 fn main() {
-    let _ = Thread::spawn(move|| {
+    let _ = Thread::scoped(move|| {
         other::foo()
     });
 }


### PR DESCRIPTION
I saw these hanging on a windows bot, and the previous ones seem to have calmed
down after switching from Thread::spawn to Thread::scoped, so try that here as
well!
