### PR TITLE
Default to "x86-64" as the target cpu for x86_64 builds

### DIFF
--- a/src/librustc_back/target/apple_ios_base.rs
+++ b/src/librustc_back/target/apple_ios_base.rs
@@ -14,6 +14,7 @@ use target::TargetOptions;
 use self::Arch::*;
 
 #[allow(non_camel_case_types)]
+#[derive(Copy)]
 pub enum Arch {
     Armv7,
     Armv7s,
@@ -70,8 +71,16 @@ fn pre_link_args(arch: Arch) -> Vec<String> {
          "-Wl,-syslibroot".to_string(), get_sdk_root(sdk_name)]
 }
 
+fn target_cpu(arch: Arch) -> String {
+    match arch {
+        X86_64 => "x86-64",
+        _ => "generic",
+    }.to_string()
+}
+
 pub fn opts(arch: Arch) -> TargetOptions {
     TargetOptions {
+        cpu: target_cpu(arch),
         dynamic_linking: false,
         executables: true,
         // Although there is an experimental implementation of LLVM which

--- a/src/librustc_back/target/x86_64_apple_darwin.rs
+++ b/src/librustc_back/target/x86_64_apple_darwin.rs
@@ -12,6 +12,7 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::apple_base::opts();
+    base.cpu = "x86-64".to_string();
     base.eliminate_frame_pointer = false;
     base.pre_link_args.push("-m64".to_string());
 

--- a/src/librustc_back/target/x86_64_pc_windows_gnu.rs
+++ b/src/librustc_back/target/x86_64_pc_windows_gnu.rs
@@ -12,6 +12,7 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::windows_base::opts();
+    base.cpu = "x86-64".to_string();
     // On Win64 unwinding is handled by the OS, so we can link libgcc statically.
     base.pre_link_args.push("-static-libgcc".to_string());
     base.pre_link_args.push("-m64".to_string());

--- a/src/librustc_back/target/x86_64_unknown_dragonfly.rs
+++ b/src/librustc_back/target/x86_64_unknown_dragonfly.rs
@@ -12,6 +12,7 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::dragonfly_base::opts();
+    base.cpu = "x86-64".to_string();
     base.pre_link_args.push("-m64".to_string());
 
     Target {

--- a/src/librustc_back/target/x86_64_unknown_freebsd.rs
+++ b/src/librustc_back/target/x86_64_unknown_freebsd.rs
@@ -12,6 +12,7 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::freebsd_base::opts();
+    base.cpu = "x86-64".to_string();
     base.pre_link_args.push("-m64".to_string());
 
     Target {

--- a/src/librustc_back/target/x86_64_unknown_linux_gnu.rs
+++ b/src/librustc_back/target/x86_64_unknown_linux_gnu.rs
@@ -12,6 +12,7 @@ use target::Target;
 
 pub fn target() -> Target {
     let mut base = super::linux_base::opts();
+    base.cpu = "x86-64".to_string();
     base.pre_link_args.push("-m64".to_string());
 
     Target {


### PR DESCRIPTION
Using "generic" disables a number of features that are present on all
x86_64 cpus, the "x86-64" target cpu is the common denominator for that
arch.

Refs #20777
