### PR TITLE
Remove unused import.

### DIFF
--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -1422,7 +1422,6 @@ impl<K: Ord, V> BTreeMap<K, V> {
 #[cfg(test)]
 mod test {
     use prelude::*;
-    use std::borrow::BorrowFrom;
 
     use super::{BTreeMap, Occupied, Vacant};
 


### PR DESCRIPTION
The BorrowFrom trait was unused by the tests.
