### PR TITLE
Fix playpen links to not all be the same

### DIFF
--- a/src/librustdoc/html/static/playpen.js
+++ b/src/librustdoc/html/static/playpen.js
@@ -14,10 +14,8 @@
 (function() {
     if (window.playgroundUrl) {
         $('pre.rust').hover(function() {
-            if (!$(this).attr('id')) { return; }
-            var id = '#' + $(this).attr('id').replace('rendered', 'raw');
             var a = $('<a>').text('⇱').attr('class', 'test-arrow');
-            var code = $(id).text();
+            var code = $(this).siblings(".rusttest").text();
             a.attr('href', window.playgroundUrl + '?code=' +
                            encodeURIComponent(code));
             a.attr('target', '_blank');


### PR DESCRIPTION
In #20732, that all links in some modules point to the same code
examples was reported. The ID's generated for documents in
librustdoc are not all unique, which means the code rendered as
text is not being properly selected.

This change makes the link to the code section that is next to
the current link.
