### PR TITLE
Redo Segmented stack support for DragonFly

### DIFF
--- a/src/rustllvm/llvm-auto-clean-trigger
+++ b/src/rustllvm/llvm-auto-clean-trigger
@@ -1,4 +1,4 @@
 # If this file is modified, then llvm will be forcibly cleaned and then rebuilt.
 # The actual contents of this file do not matter, but to trigger a change on the
 # build bots then the contents should be changed so git updates the mtime.
-2015-01-13
+2015-01-18


### PR DESCRIPTION
It got accidentially reverted in 44440e5.
