### PR TITLE
s/deriving/derives in Comments/Docs

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2430,7 +2430,7 @@ There are three different types of inline attributes:
 * `#[inline(always)]` asks the compiler to always perform an inline expansion.
 * `#[inline(never)]` asks the compiler to never perform an inline expansion.
 
-### Derive
+### `derive`
 
 The `derive` attribute allows certain traits to be automatically implemented
 for data structures. For example, the following will create an `impl` for the

--- a/src/etc/generate-deriving-span-tests.py
+++ b/src/etc/generate-deriving-span-tests.py
@@ -12,8 +12,8 @@
 
 """
 This script creates a pile of compile-fail tests check that all the
-derivings have spans that point to the fields, rather than the
-#[deriving(...)] line.
+derives have spans that point to the fields, rather than the
+#[derive(...)] line.
 
 sample usage: src/etc/generate-deriving-span-tests.py
 """
@@ -46,7 +46,7 @@ fn main() {{}}
 """
 
 ENUM_STRING = """
-#[deriving({traits})]
+#[derive({traits})]
 enum Enum {{
    A(
      Error {errors}
@@ -54,7 +54,7 @@ enum Enum {{
 }}
 """
 ENUM_STRUCT_VARIANT_STRING = """
-#[deriving({traits})]
+#[derive({traits})]
 enum Enum {{
    A {{
      x: Error {errors}
@@ -62,13 +62,13 @@ enum Enum {{
 }}
 """
 STRUCT_STRING = """
-#[deriving({traits})]
+#[derive({traits})]
 struct Struct {{
     x: Error {errors}
 }}
 """
 STRUCT_TUPLE_STRING = """
-#[deriving({traits})]
+#[derive({traits})]
 struct Struct(
     Error {errors}
 );
@@ -80,14 +80,14 @@ def create_test_case(type, trait, super_traits, number_of_errors):
     string = [ENUM_STRING, ENUM_STRUCT_VARIANT_STRING, STRUCT_STRING, STRUCT_TUPLE_STRING][type]
     all_traits = ','.join([trait] + super_traits)
     super_traits = ','.join(super_traits)
-    error_deriving = '#[deriving(%s)]' % super_traits if super_traits else ''
+    error_deriving = '#[derive(%s)]' % super_traits if super_traits else ''
 
     errors = '\n'.join('//~%s ERROR' % ('^' * n) for n in range(error_count))
     code = string.format(traits = all_traits, errors = errors)
     return TEMPLATE.format(year = YEAR, error_deriving=error_deriving, code = code)
 
 def write_file(name, string):
-    test_file = os.path.join(TEST_DIR, 'deriving-span-%s.rs' % name)
+    test_file = os.path.join(TEST_DIR, 'derives-span-%s.rs' % name)
 
     # set write permission if file exists, so it can be changed
     if os.path.exists(test_file):

--- a/src/etc/unicode.py
+++ b/src/etc/unicode.py
@@ -392,7 +392,7 @@ def emit_grapheme_module(f, grapheme_table, grapheme_cats):
     use core::slice;
 
     #[allow(non_camel_case_types)]
-    #[deriving(Clone)]
+    #[derive(Clone)]
     pub enum GraphemeCat {
 """)
     for cat in grapheme_cats + ["Any"]:

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -102,10 +102,10 @@ pub fn fixme_14344_be_sure_to_link_to_collections() {}
 mod std {
     pub use core::fmt;      // necessary for panic!()
     pub use core::option;   // necessary for panic!()
-    pub use core::clone;    // deriving(Clone)
-    pub use core::cmp;      // deriving(Eq, Ord, etc.)
-    pub use core::marker;  // deriving(Copy)
-    pub use core::hash;     // deriving(Hash)
+    pub use core::clone;    // derive(Clone)
+    pub use core::cmp;      // derive(Eq, Ord, etc.)
+    pub use core::marker;  // derive(Copy)
+    pub use core::hash;     // derive(Hash)
 }
 
 #[cfg(test)]

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -156,7 +156,7 @@ mod svh_visitor {
         StrictVersionHashVisitor { st: st }
     }
 
-    // To off-load the bulk of the hash-computation on deriving(Hash),
+    // To off-load the bulk of the hash-computation on #[derive(Hash)],
     // we define a set of enums corresponding to the content that our
     // crate visitor will encounter as it traverses the ast.
     //

--- a/src/libstd/fmt.rs
+++ b/src/libstd/fmt.rs
@@ -225,7 +225,7 @@
 //! - `fmt::Show` implementations should be implemented for **all** public types.
 //!   Output will typically represent the internal state as faithfully as possible.
 //!   The purpose of the `Show` trait is to facilitate debugging Rust code. In
-//!   most cases, using `#[deriving(Show)]` is sufficient and recommended.
+//!   most cases, using `#[derive(Show)]` is sufficient and recommended.
 //!
 //! Some examples of the output from both traits:
 //!

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -80,11 +80,11 @@ fn cs_clone(
         EnumNonMatchingCollapsed (..) => {
             cx.span_bug(trait_span,
                         &format!("non-matching enum variants in \
-                                 `deriving({})`", name)[])
+                                 `derive({})`", name)[])
         }
         StaticEnum(..) | StaticStruct(..) => {
             cx.span_bug(trait_span,
-                        &format!("static method in `deriving({})`", name)[])
+                        &format!("static method in `derive({})`", name)[])
         }
     }
 
@@ -101,7 +101,7 @@ fn cs_clone(
                 None => {
                     cx.span_bug(trait_span,
                                 &format!("unnamed field in normal struct in \
-                                         `deriving({})`", name)[])
+                                         `derive({})`", name)[])
                 }
             };
             cx.field_imm(field.span, ident, subcall(field))

--- a/src/libsyntax/ext/deriving/cmp/eq.rs
+++ b/src/libsyntax/ext/deriving/cmp/eq.rs
@@ -32,7 +32,7 @@ pub fn expand_deriving_eq<F>(cx: &mut ExtCtxt,
             |cx, span, subexpr, self_f, other_fs| {
                 let other_f = match other_fs {
                     [ref o_f] => o_f,
-                    _ => cx.span_bug(span, "not exactly 2 arguments in `deriving(PartialEq)`")
+                    _ => cx.span_bug(span, "not exactly 2 arguments in `derive(PartialEq)`")
                 };
 
                 let eq = cx.expr_binary(span, ast::BiEq, self_f, other_f.clone());
@@ -49,7 +49,7 @@ pub fn expand_deriving_eq<F>(cx: &mut ExtCtxt,
             |cx, span, subexpr, self_f, other_fs| {
                 let other_f = match other_fs {
                     [ref o_f] => o_f,
-                    _ => cx.span_bug(span, "not exactly 2 arguments in `deriving(PartialEq)`")
+                    _ => cx.span_bug(span, "not exactly 2 arguments in `derive(PartialEq)`")
                 };
 
                 let eq = cx.expr_binary(span, ast::BiNe, self_f, other_f.clone());

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -152,7 +152,7 @@ pub fn cs_partial_cmp(cx: &mut ExtCtxt, span: Span,
             let new = {
                 let other_f = match other_fs {
                     [ref o_f] => o_f,
-                    _ => cx.span_bug(span, "not exactly 2 arguments in `deriving(PartialOrd)`"),
+                    _ => cx.span_bug(span, "not exactly 2 arguments in `derive(PartialOrd)`"),
                 };
 
                 let args = vec![
@@ -176,7 +176,7 @@ pub fn cs_partial_cmp(cx: &mut ExtCtxt, span: Span,
         equals_expr.clone(),
         box |cx, span, (self_args, tag_tuple), _non_self_args| {
             if self_args.len() != 2 {
-                cx.span_bug(span, "not exactly 2 arguments in `deriving(PartialOrd)`")
+                cx.span_bug(span, "not exactly 2 arguments in `derive(PartialOrd)`")
             } else {
                 some_ordering_collapsed(cx, span, PartialCmpOp, tag_tuple)
             }
@@ -210,7 +210,7 @@ fn cs_op(less: bool, equal: bool, cx: &mut ExtCtxt,
             */
             let other_f = match other_fs {
                 [ref o_f] => o_f,
-                _ => cx.span_bug(span, "not exactly 2 arguments in `deriving(PartialOrd)`")
+                _ => cx.span_bug(span, "not exactly 2 arguments in `derive(PartialOrd)`")
             };
 
             let cmp = cx.expr_binary(span, op, self_f.clone(), other_f.clone());
@@ -224,7 +224,7 @@ fn cs_op(less: bool, equal: bool, cx: &mut ExtCtxt,
         cx.expr_bool(span, equal),
         box |cx, span, (self_args, tag_tuple), _non_self_args| {
             if self_args.len() != 2 {
-                cx.span_bug(span, "not exactly 2 arguments in `deriving(PartialOrd)`")
+                cx.span_bug(span, "not exactly 2 arguments in `derive(PartialOrd)`")
             } else {
                 let op = match (less, equal) {
                     (true,  true) => LeOp, (true,  false) => LtOp,

--- a/src/libsyntax/ext/deriving/cmp/totaleq.rs
+++ b/src/libsyntax/ext/deriving/cmp/totaleq.rs
@@ -32,7 +32,7 @@ pub fn expand_deriving_totaleq<F>(cx: &mut ExtCtxt,
             let block = cx.block(span, stmts, None);
             cx.expr_block(block)
         },
-                       box |cx, sp, _, _| cx.span_bug(sp, "non matching enums in deriving(Eq)?"),
+                       box |cx, sp, _, _| cx.span_bug(sp, "non matching enums in derive(Eq)?"),
                        cx,
                        span,
                        substr)

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -108,7 +108,7 @@ pub fn cs_cmp(cx: &mut ExtCtxt, span: Span,
             let new = {
                 let other_f = match other_fs {
                     [ref o_f] => o_f,
-                    _ => cx.span_bug(span, "not exactly 2 arguments in `deriving(PartialOrd)`"),
+                    _ => cx.span_bug(span, "not exactly 2 arguments in `derive(PartialOrd)`"),
                 };
 
                 let args = vec![
@@ -132,7 +132,7 @@ pub fn cs_cmp(cx: &mut ExtCtxt, span: Span,
         cx.expr_path(equals_path.clone()),
         box |cx, span, (self_args, tag_tuple), _non_self_args| {
             if self_args.len() != 2 {
-                cx.span_bug(span, "not exactly 2 arguments in `deriving(Ord)`")
+                cx.span_bug(span, "not exactly 2 arguments in `derives(Ord)`")
             } else {
                 ordering_collapsed(cx, span, tag_tuple)
             }

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -173,7 +173,7 @@ fn decodable_substructure(cx: &mut ExtCtxt, trait_span: Span,
                 cx.lambda_expr_1(trait_span, result, blkarg)
             ))
         }
-        _ => cx.bug("expected StaticEnum or StaticStruct in deriving(Decodable)")
+        _ => cx.bug("expected StaticEnum or StaticStruct in derive(Decodable)")
     };
 }
 

--- a/src/libsyntax/ext/deriving/default.rs
+++ b/src/libsyntax/ext/deriving/default.rs
@@ -81,6 +81,6 @@ fn default_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructur
             // let compilation continue
             cx.expr_uint(trait_span, 0)
         }
-        _ => cx.span_bug(trait_span, "Non-static method in `deriving(Default)`")
+        _ => cx.span_bug(trait_span, "Non-static method in `derive(Default)`")
     };
 }

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -276,6 +276,6 @@ fn encodable_substructure(cx: &mut ExtCtxt, trait_span: Span,
             cx.expr_block(cx.block(trait_span, vec!(me), Some(ret)))
         }
 
-        _ => cx.bug("expected Struct or EnumMatching in deriving(Encodable)")
+        _ => cx.bug("expected Struct or EnumMatching in derive(Encodable)")
     };
 }

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -1191,7 +1191,7 @@ impl<'a> TraitDef<'a> {
         to_set.expn_id = cx.codemap().record_expansion(codemap::ExpnInfo {
             call_site: to_set,
             callee: codemap::NameAndSpan {
-                name: format!("deriving({})", trait_name),
+                name: format!("derive({})", trait_name),
                 format: codemap::MacroAttribute,
                 span: Some(self.span)
             }

--- a/src/libsyntax/ext/deriving/generic/ty.rs
+++ b/src/libsyntax/ext/deriving/generic/ty.rs
@@ -182,8 +182,8 @@ impl<'a> Ty<'a> {
             Literal(ref p) => {
                 p.to_path(cx, span, self_ty, self_generics)
             }
-            Ptr(..) => { cx.span_bug(span, "pointer in a path in generic `deriving`") }
-            Tuple(..) => { cx.span_bug(span, "tuple in a path in generic `deriving`") }
+            Ptr(..) => { cx.span_bug(span, "pointer in a path in generic `derive`") }
+            Tuple(..) => { cx.span_bug(span, "tuple in a path in generic `derive`") }
         }
     }
 }

--- a/src/libsyntax/ext/deriving/primitive.rs
+++ b/src/libsyntax/ext/deriving/primitive.rs
@@ -74,7 +74,7 @@ pub fn expand_deriving_from_primitive<F>(cx: &mut ExtCtxt,
 fn cs_from(name: &str, cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Expr> {
     let n = match substr.nonself_args {
         [ref n] => n,
-        _ => cx.span_bug(trait_span, "incorrect number of arguments in `deriving(FromPrimitive)`")
+        _ => cx.span_bug(trait_span, "incorrect number of arguments in `derive(FromPrimitive)`")
     };
 
     match *substr.fields {
@@ -144,6 +144,6 @@ fn cs_from(name: &str, cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure
 
             cx.expr_match(trait_span, n.clone(), arms)
         }
-        _ => cx.span_bug(trait_span, "expected StaticEnum in deriving(FromPrimitive)")
+        _ => cx.span_bug(trait_span, "expected StaticEnum in derive(FromPrimitive)")
     }
 }

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -57,7 +57,7 @@ pub fn expand_deriving_rand<F>(cx: &mut ExtCtxt,
 fn rand_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Expr> {
     let rng = match substr.nonself_args {
         [ref rng] => rng,
-        _ => cx.bug("Incorrect number of arguments to `rand` in `deriving(Rand)`")
+        _ => cx.bug("Incorrect number of arguments to `rand` in `derive(Rand)`")
     };
     let rand_ident = vec!(
         cx.ident_of("std"),
@@ -131,7 +131,7 @@ fn rand_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) 
             let block = cx.block(trait_span, vec!( let_statement ), Some(match_expr));
             cx.expr_block(block)
         }
-        _ => cx.bug("Non-static method in `deriving(Rand)`")
+        _ => cx.bug("Non-static method in `derive(Rand)`")
     };
 
     fn rand_thing<F>(cx: &mut ExtCtxt,


### PR DESCRIPTION
There are a large number of places that incorrectly refer
to deriving in comments, instead of derives.

If someone could look at src/etc/generate-deriving-span-tests.py,
I'm not sure how those tests were passing before/if they were. 
