### PR TITLE
Remove usage and reference of feature(globs) from the book

### DIFF
--- a/src/doc/trpl/testing.md
+++ b/src/doc/trpl/testing.md
@@ -254,7 +254,6 @@ a large module, and so this is a common use of the `glob` feature. Let's change
 our `src/lib.rs` to make use of it:
 
 ```{rust,ignore}
-#![feature(globs)]
 
 pub fn add_two(a: i32) -> i32 {
     a + 2
@@ -271,8 +270,7 @@ mod tests {
 }
 ```
 
-Note the `feature` attribute, as well as the different `use` line. Now we run
-our tests:
+Note the different `use` line. Now we run our tests:
 
 ```bash
 $ cargo test
@@ -370,8 +368,6 @@ with examples:
 //! assert_eq!(4, adder::add_two(2));
 //! ```
 
-#![feature(globs)]
-
 /// This function adds two to its argument.
 ///
 /// # Examples
@@ -440,8 +436,6 @@ Rust also supports benchmark tests, which can test the performance of your
 code. Let's make our `src/lib.rs` look like this (comments elided):
 
 ```{rust,ignore}
-#![feature(globs)]
-
 extern crate test;
 
 pub fn add_two(a: i32) -> i32 {

--- a/src/doc/trpl/unsafe.md
+++ b/src/doc/trpl/unsafe.md
@@ -530,7 +530,6 @@ vectors provided from C, using idiomatic Rust practices.
 
 ```
 #![no_std]
-#![feature(globs)]
 #![feature(lang_items)]
 
 # extern crate libc;


### PR DESCRIPTION
With the code samples as they are, the compiler says:
`feature has been added to Rust, directive not necessary`
