### PR TITLE
Add a macro named optimize_unreachable!()

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -243,6 +243,33 @@ macro_rules! unreachable {
     });
 }
 
+/// An unsafe utility macro for indicating unreachable code and possibly enabling
+/// compiler optimizations.
+///
+/// This macro combines the functionalities of the `std::unreachable!` macro and the
+/// `std::intrinsics::unreachable` compiler intrinsic based on the type of the build:
+///
+/// * In a debug build, the macro behaves the same way as `unreachable`
+///   &ndash; will panic if reached at runtime.
+///
+/// * In an ndebug build, the macro behaves the same as the unsafe
+///   `intrinsics::unreachable()` function which let's the compiler assume
+///   the code will never be reached and optimize accordingly.
+///   Note that reaching the macro at runtime in an ndebug build results in
+///   undefined behaviour!
+#[macro_export]
+macro_rules! optimize_unreachable {
+    ($($arg:tt)*) => ({
+        // This macro should always require an usafe block:
+        unsafe fn noop() {} noop();
+        if cfg!(ndebug) {
+            std::intrinsics::unreachable();
+        } else {
+            unreachable!($($arg)*)
+        }
+    });
+}
+
 /// A standardised placeholder for marking unfinished code. It panics with the
 /// message `"not yet implemented"` when executed.
 #[macro_export]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -123,7 +123,7 @@ extern crate log;
 
 #[macro_use]
 #[macro_reexport(assert, assert_eq, debug_assert, debug_assert_eq,
-    unreachable, unimplemented, write, writeln)]
+    unreachable, optimize_unreachable, unimplemented, write, writeln)]
 extern crate core;
 
 #[macro_use]

--- a/src/test/run-fail/optimize-unreachable.rs
+++ b/src/test/run-fail/optimize-unreachable.rs
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:internal error: entered unreachable code
+fn main() {
+    unsafe {
+        optimize_unreachable!()
+    }
+}

--- a/src/test/run-pass/optimize-unreachable.rs
+++ b/src/test/run-pass/optimize-unreachable.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:--cfg ndebug
+fn main() {
+    return;
+    unsafe {
+        optimize_unreachable!()
+    }
+}


### PR DESCRIPTION
Add a macro named `optimize_unreachable`
that combines `std::unreachable!()` and `std::intrinsics::unreachable()`
In a debug build, it forwards to `std::unreachable!()`, panics when reached.
In an ndebug build, evaluates to `std::intrinsics::unreachable()`
to enable optimizations. Unsafe in both cases.

Implements #18152

See also http://discuss.rust-lang.org/t/addition-of-a-new-unreachable-macro/1277

cc @kmcallister 
