### PR TITLE
New scoping rules for safe destruction

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -116,7 +116,10 @@ pub fn parse_config(args: Vec<String> ) -> Config {
     }
 
     fn opt_path(m: &getopts::Matches, nm: &str) -> Path {
-        Path::new(m.opt_str(nm).unwrap())
+        match m.opt_str(nm) {
+            Some(s) => Path::new(s),
+            None => panic!("no option (=path) found for {}", nm),
+        }
     }
 
     let filter = if !matches.free.is_empty() {

--- a/src/libregex/vm.rs
+++ b/src/libregex/vm.rs
@@ -120,8 +120,10 @@ impl<'r, 't> Nfa<'r, 't> {
         };
         let mut matched = false;
         let ninsts = self.prog.insts.len();
-        let mut clist = &mut Threads::new(self.which, ninsts, ncaps);
-        let mut nlist = &mut Threads::new(self.which, ninsts, ncaps);
+        let mut cthread = Threads::new(self.which, ninsts, ncaps);
+        let mut nthread = Threads::new(self.which, ninsts, ncaps);
+        let mut clist = &mut cthread;
+        let mut nlist = &mut nthread;
 
         let mut groups: Vec<_> = repeat(None).take(ncaps * 2).collect();
 

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -390,6 +390,18 @@ fn parse_scope(st: &mut PState) -> region::CodeExtent {
             let node_id = parse_uint(st) as ast::NodeId;
             region::CodeExtent::Misc(node_id)
         }
+        'D' => {
+            let node_id = parse_uint(st) as ast::NodeId;
+            region::CodeExtent::DestructionScope(node_id)
+        }
+        'B' => {
+            let node_id = parse_uint(st) as ast::NodeId;
+            let first_stmt_index = parse_uint(st);
+            let block_remainder = region::BlockRemainder {
+                block: node_id, first_statement_index: first_stmt_index,
+            };
+            region::CodeExtent::Remainder(block_remainder)
+        }
         _ => panic!("parse_scope: bad input")
     }
 }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -276,7 +276,10 @@ pub fn enc_region(w: &mut SeekableMemWriter, cx: &ctxt, r: ty::Region) {
 
 fn enc_scope(w: &mut SeekableMemWriter, _cx: &ctxt, scope: region::CodeExtent) {
     match scope {
-        region::CodeExtent::Misc(node_id) => mywrite!(w, "M{}", node_id)
+        region::CodeExtent::Misc(node_id) => mywrite!(w, "M{}", node_id),
+        region::CodeExtent::Remainder(region::BlockRemainder {
+            block: b, first_statement_index: i }) => mywrite!(w, "B{}{}", b, i),
+        region::CodeExtent::DestructionScope(node_id) => mywrite!(w, "D{}", node_id),
     }
 }
 

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -818,6 +818,8 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
         let scope_id = same_regions[0].scope_id;
         let parent = self.tcx.map.get_parent(scope_id);
         let parent_node = self.tcx.map.find(parent);
+        let taken = lifetimes_in_scope(self.tcx, scope_id);
+        let life_giver = LifeGiver::with_taken(&taken[]);
         let node_inner = match parent_node {
             Some(ref node) => match *node {
                 ast_map::NodeItem(ref item) => {
@@ -860,8 +862,6 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
         };
         let (fn_decl, generics, unsafety, ident, expl_self, span)
                                     = node_inner.expect("expect item fn");
-        let taken = lifetimes_in_scope(self.tcx, scope_id);
-        let life_giver = LifeGiver::with_taken(&taken[]);
         let rebuilder = Rebuilder::new(self.tcx, fn_decl, expl_self,
                                        generics, same_regions, &life_giver);
         let (fn_decl, expl_self, generics) = rebuilder.rebuild();

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -242,7 +242,7 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
                     }
                 }
                 SubSupConflict(var_origin, _, sub_r, _, sup_r) => {
-                    debug!("processing SubSupConflict");
+                    debug!("processing SubSupConflict sub: {:?} sup: {:?}", sub_r, sup_r);
                     match free_regions_from_same_fn(self.tcx, sub_r, sup_r) {
                         Some(ref same_frs) => {
                             var_origins.push(var_origin);
@@ -719,6 +719,22 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
                     self.tcx,
                     "type is only valid for ",
                     sup,
+                    "");
+            }
+            infer::SafeDestructor(span) => {
+                self.tcx.sess.span_err(
+                    span,
+                    "unsafe use of destructor: destructor might be called \
+                     while references are dead");
+                note_and_explain_region(
+                    self.tcx,
+                    "superregion: ",
+                    sup,
+                    "");
+                note_and_explain_region(
+                    self.tcx,
+                    "subregion: ",
+                    sub,
                     "");
             }
             infer::BindingTypeIsNotValidAtDecl(span) => {
@@ -1640,6 +1656,12 @@ impl<'a, 'tcx> ErrorReportingHelpers<'tcx> for InferCtxt<'a, 'tcx> {
                     span,
                     &format!("...so that the declared lifetime parameter bounds \
                                 are satisfied")[]);
+            }
+            infer::SafeDestructor(span) => {
+                self.tcx.sess.span_note(
+                    span,
+                    "...so that references are valid when the destructor \
+                     runs")
             }
         }
     }

--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -222,6 +222,9 @@ pub enum SubregionOrigin<'tcx> {
 
     // An auto-borrow that does not enclose the expr where it occurs
     AutoBorrow(Span),
+
+    // Region constraint arriving from destructor safety
+    SafeDestructor(Span),
 }
 
 /// Times when we replace late-bound regions with variables:
@@ -1217,6 +1220,7 @@ impl<'tcx> SubregionOrigin<'tcx> {
             CallReturn(a) => a,
             AddrOf(a) => a,
             AutoBorrow(a) => a,
+            SafeDestructor(a) => a,
         }
     }
 }
@@ -1279,6 +1283,7 @@ impl<'tcx> Repr<'tcx> for SubregionOrigin<'tcx> {
             CallReturn(a) => format!("CallReturn({})", a.repr(tcx)),
             AddrOf(a) => format!("AddrOf({})", a.repr(tcx)),
             AutoBorrow(a) => format!("AutoBorrow({})", a.repr(tcx)),
+            SafeDestructor(a) => format!("SafeDestructor({})", a.repr(tcx)),
         }
     }
 }

--- a/src/librustc/middle/infer/region_inference/graphviz.rs
+++ b/src/librustc/middle/infer/region_inference/graphviz.rs
@@ -19,12 +19,14 @@
 use graphviz as dot;
 
 use middle::ty;
+use middle::region::CodeExtent;
 use super::Constraint;
 use middle::infer::SubregionOrigin;
 use middle::infer::region_inference::RegionVarBindings;
 use util::nodemap::{FnvHashMap, FnvHashSet};
 use util::ppaux::Repr;
 
+use std::borrow::Cow;
 use std::collections::hash_map::Entry::Vacant;
 use std::io::{self, File};
 use std::os;
@@ -120,13 +122,18 @@ struct ConstraintGraph<'a, 'tcx: 'a> {
     node_ids: FnvHashMap<Node, uint>,
 }
 
-#[derive(Clone, Hash, PartialEq, Eq, Show)]
+#[derive(Clone, Hash, PartialEq, Eq, Show, Copy)]
 enum Node {
     RegionVid(ty::RegionVid),
     Region(ty::Region),
 }
 
-type Edge = Constraint;
+// type Edge = Constraint;
+#[derive(Clone, PartialEq, Eq, Show, Copy)]
+enum Edge {
+    Constraint(Constraint),
+    EnclScope(CodeExtent, CodeExtent),
+}
 
 impl<'a, 'tcx> ConstraintGraph<'a, 'tcx> {
     fn new(tcx: &'a ty::ctxt<'tcx>,
@@ -146,6 +153,11 @@ impl<'a, 'tcx> ConstraintGraph<'a, 'tcx> {
                 add_node(n1);
                 add_node(n2);
             }
+
+            tcx.region_maps.each_encl_scope(|&mut: sub, sup| {
+                add_node(Node::Region(ty::ReScope(*sub)));
+                add_node(Node::Region(ty::ReScope(*sup)));
+            });
         }
 
         ConstraintGraph { tcx: tcx,
@@ -160,7 +172,17 @@ impl<'a, 'tcx> dot::Labeller<'a, Node, Edge> for ConstraintGraph<'a, 'tcx> {
         dot::Id::new(self.graph_name.as_slice()).unwrap()
     }
     fn node_id(&self, n: &Node) -> dot::Id {
-        dot::Id::new(format!("node_{}", self.node_ids.get(n).unwrap())).unwrap()
+        let node_id = match self.node_ids.get(n) {
+            Some(node_id) => node_id,
+            None => panic!("no node_id found for node: {:?}", n),
+        };
+        let name = |&:| format!("node_{}", node_id);
+        match dot::Id::new(name()) {
+            Ok(id) => id,
+            Err(()) => {
+                panic!("failed to create graphviz node identified by {}", name());
+            }
+        }
     }
     fn node_label(&self, n: &Node) -> dot::LabelText {
         match *n {
@@ -171,7 +193,12 @@ impl<'a, 'tcx> dot::Labeller<'a, Node, Edge> for ConstraintGraph<'a, 'tcx> {
         }
     }
     fn edge_label(&self, e: &Edge) -> dot::LabelText {
-        dot::LabelText::label(format!("{}", self.map.get(e).unwrap().repr(self.tcx)))
+        match *e {
+            Edge::Constraint(ref c) =>
+                dot::LabelText::label(format!("{}", self.map.get(c).unwrap().repr(self.tcx))),
+            Edge::EnclScope(..) =>
+                dot::LabelText::label(format!("(enclosed)")),
+        }
     }
 }
 
@@ -186,28 +213,40 @@ fn constraint_to_nodes(c: &Constraint) -> (Node, Node) {
     }
 }
 
+fn edge_to_nodes(e: &Edge) -> (Node, Node) {
+    match *e {
+        Edge::Constraint(ref c) => constraint_to_nodes(c),
+        Edge::EnclScope(sub, sup) => {
+            (Node::Region(ty::ReScope(sub)), Node::Region(ty::ReScope(sup)))
+        }
+    }
+}
+
 impl<'a, 'tcx> dot::GraphWalk<'a, Node, Edge> for ConstraintGraph<'a, 'tcx> {
     fn nodes(&self) -> dot::Nodes<Node> {
         let mut set = FnvHashSet::new();
-        for constraint in self.map.keys() {
-            let (n1, n2) = constraint_to_nodes(constraint);
-            set.insert(n1);
-            set.insert(n2);
+        for node in self.node_ids.keys() {
+            set.insert(*node);
         }
         debug!("constraint graph has {} nodes", set.len());
         set.into_iter().collect()
     }
     fn edges(&self) -> dot::Edges<Edge> {
         debug!("constraint graph has {} edges", self.map.len());
-        self.map.keys().map(|e|*e).collect()
+        let mut v : Vec<_> = self.map.keys().map(|e| Edge::Constraint(*e)).collect();
+        self.tcx.region_maps.each_encl_scope(|&mut: sub, sup| {
+            v.push(Edge::EnclScope(*sub, *sup))
+        });
+        debug!("region graph has {} edges", v.len());
+        Cow::Owned(v)
     }
     fn source(&self, edge: &Edge) -> Node {
-        let (n1, _) = constraint_to_nodes(edge);
+        let (n1, _) = edge_to_nodes(edge);
         debug!("edge {:?} has source {:?}", edge, n1);
         n1
     }
     fn target(&self, edge: &Edge) -> Node {
-        let (_, n2) = constraint_to_nodes(edge);
+        let (_, n2) = edge_to_nodes(edge);
         debug!("edge {:?} has target {:?}", edge, n2);
         n2
     }

--- a/src/librustc/middle/infer/region_inference/mod.rs
+++ b/src/librustc/middle/infer/region_inference/mod.rs
@@ -1398,6 +1398,8 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
             for upper_bound in upper_bounds.iter() {
                 if !self.is_subregion_of(lower_bound.region,
                                          upper_bound.region) {
+                    debug!("pushing SubSupConflict sub: {:?} sup: {:?}",
+                           lower_bound.region, upper_bound.region);
                     errors.push(SubSupConflict(
                         (*self.var_origins.borrow())[node_idx.index as uint].clone(),
                         lower_bound.origin.clone(),

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1535,7 +1535,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
         let fn_ret =
             ty::liberate_late_bound_regions(
                 self.ir.tcx,
-                CodeExtent::from_node_id(body.id),
+                CodeExtent::DestructionScope(body.id),
                 &self.fn_ret(id));
 
         match fn_ret {

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -690,7 +690,10 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
 
             // Region of environment pointer
             let env_region = ty::ReFree(ty::FreeRegion {
-                scope: region::CodeExtent::from_node_id(fn_body_id),
+                // The environment of a closure is guaranteed to
+                // outlive any bindings introduced in the body of the
+                // closure itself.
+                scope: region::CodeExtent::DestructionScope(fn_body_id),
                 bound_region: ty::BrEnv
             });
 

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -198,7 +198,6 @@ impl DeclaringStatementContext {
 enum InnermostEnclosingExpr {
     None,
     Some(ast::NodeId),
-    DestructionScope(ast::NodeId),
     Statement(DeclaringStatementContext),
 }
 
@@ -212,8 +211,6 @@ impl InnermostEnclosingExpr {
                 s.to_code_extent(),
             InnermostEnclosingExpr::Some(parent_id) =>
                 CodeExtent::from_node_id(parent_id),
-            InnermostEnclosingExpr::DestructionScope(parent_id) =>
-                CodeExtent::DestructionScope(parent_id),
         };
         Some(extent)
     }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1184,7 +1184,9 @@ pub enum Region {
     /// region parameters.
     ReFree(FreeRegion),
 
-    /// A concrete region naming some expression within the current function.
+    /// A concrete region naming some statically determined extent
+    /// (e.g. an expression or sequence of statements) within the
+    /// current function.
     ReScope(region::CodeExtent),
 
     /// Static data that has an "infinite" lifetime. Top in the region lattice.
@@ -4233,12 +4235,15 @@ pub fn ty_region(tcx: &ctxt,
     }
 }
 
-pub fn free_region_from_def(free_id: ast::NodeId, def: &RegionParameterDef)
+pub fn free_region_from_def(outlives_extent: region::CodeExtent, def: &RegionParameterDef)
     -> ty::Region
 {
-    ty::ReFree(ty::FreeRegion { scope: region::CodeExtent::from_node_id(free_id),
-                                bound_region: ty::BrNamed(def.def_id,
-                                                          def.name) })
+    let ret =
+        ty::ReFree(ty::FreeRegion { scope: outlives_extent,
+                                    bound_region: ty::BrNamed(def.def_id,
+                                                              def.name) });
+    debug!("free_region_from_def returns {:?}", ret);
+    ret
 }
 
 // Returns the type of a pattern as a monotype. Like @expr_ty, this function
@@ -6354,23 +6359,23 @@ pub fn construct_parameter_environment<'a,'tcx>(
     let mut types = VecPerParamSpace::empty();
     push_types_from_defs(tcx, &mut types, generics.types.as_slice());
 
+    let free_id_outlive = region::CodeExtent::DestructionScope(free_id);
+
     // map bound 'a => free 'a
     let mut regions = VecPerParamSpace::empty();
-    push_region_params(&mut regions, free_id, generics.regions.as_slice());
+    push_region_params(&mut regions, free_id_outlive, generics.regions.as_slice());
 
     let free_substs = Substs {
         types: types,
         regions: subst::NonerasedRegions(regions)
     };
 
-    let free_id_scope = region::CodeExtent::from_node_id(free_id);
-
     //
     // Compute the bounds on Self and the type parameters.
     //
 
     let bounds = generics.to_bounds(tcx, &free_substs);
-    let bounds = liberate_late_bound_regions(tcx, free_id_scope, &ty::Binder(bounds));
+    let bounds = liberate_late_bound_regions(tcx, free_id_outlive, &ty::Binder(bounds));
 
     //
     // Compute region bounds. For now, these relations are stored in a
@@ -6388,17 +6393,17 @@ pub fn construct_parameter_environment<'a,'tcx>(
     return ty::ParameterEnvironment {
         tcx: tcx,
         free_substs: free_substs,
-        implicit_region_bound: ty::ReScope(free_id_scope),
+        implicit_region_bound: ty::ReScope(free_id_outlive),
         caller_bounds: bounds,
         selection_cache: traits::SelectionCache::new(),
     };
 
     fn push_region_params(regions: &mut VecPerParamSpace<ty::Region>,
-                          free_id: ast::NodeId,
+                          all_outlive_extent: region::CodeExtent,
                           region_params: &[RegionParameterDef])
     {
         for r in region_params.iter() {
-            regions.push(r.space, ty::free_region_from_def(free_id, r));
+            regions.push(r.space, ty::free_region_from_def(all_outlive_extent, r));
         }
     }
 
@@ -6679,14 +6684,14 @@ impl<'tcx> AutoDerefRef<'tcx> {
 /// `scope_id`.
 pub fn liberate_late_bound_regions<'tcx, T>(
     tcx: &ty::ctxt<'tcx>,
-    scope: region::CodeExtent,
+    all_outlive_scope: region::CodeExtent,
     value: &Binder<T>)
     -> T
     where T : TypeFoldable<'tcx> + Repr<'tcx>
 {
     replace_late_bound_regions(
         tcx, value,
-        |br| ty::ReFree(ty::FreeRegion{scope: scope, bound_region: br})).0
+        |br| ty::ReFree(ty::FreeRegion{scope: all_outlive_scope, bound_region: br})).0
 }
 
 pub fn count_late_bound_regions<'tcx, T>(

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -10,6 +10,7 @@
 
 
 use middle::def;
+use middle::region;
 use middle::subst::{VecPerParamSpace,Subst};
 use middle::subst;
 use middle::ty::{BoundRegion, BrAnon, BrNamed};
@@ -902,8 +903,21 @@ impl<'tcx> UserString<'tcx> for ty::Region {
 impl<'tcx> Repr<'tcx> for ty::FreeRegion {
     fn repr(&self, tcx: &ctxt) -> String {
         format!("ReFree({}, {})",
-                self.scope.node_id(),
+                self.scope.repr(tcx),
                 self.bound_region.repr(tcx))
+    }
+}
+
+impl<'tcx> Repr<'tcx> for region::CodeExtent {
+    fn repr(&self, _tcx: &ctxt) -> String {
+        match *self {
+            region::CodeExtent::Misc(node_id) =>
+                format!("Misc({})", node_id),
+            region::CodeExtent::DestructionScope(node_id) =>
+                format!("DestructionScope({})", node_id),
+            region::CodeExtent::Remainder(rem) =>
+                format!("Remainder({}, {})", rem.block, rem.first_statement_index),
+        }
     }
 }
 

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -99,11 +99,11 @@ pub fn compile_input(sess: Session,
                                                                  &id[]));
 
         let mut forest = ast_map::Forest::new(expanded_crate);
+        let arenas = ty::CtxtArenas::new();
         let ast_map = assign_node_ids_and_map(&sess, &mut forest);
 
         write_out_deps(&sess, input, &outputs, &id[]);
 
-        let arenas = ty::CtxtArenas::new();
         let analysis = phase_3_run_analysis_passes(sess,
                                                    ast_map,
                                                    &arenas,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1031,7 +1031,8 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             }
         }
 
-        for (_, child_module) in module_.anonymous_children.borrow().iter() {
+        let children = module_.anonymous_children.borrow();
+        for (_, child_module) in children.iter() {
             self.resolve_imports_for_module_subtree(child_module.clone());
         }
     }
@@ -2203,7 +2204,8 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
         // Search for external modules.
         if namespace == TypeNS {
-            if let Some(module) = module_.external_module_children.borrow().get(&name).cloned() {
+            let child = module_.external_module_children.borrow().get(&name).cloned();
+            if let Some(module) = child {
                 let name_bindings =
                     Rc::new(Resolver::create_name_bindings_from_module(module));
                 debug!("lower name bindings succeeded");
@@ -2485,7 +2487,8 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
         // Finally, search through external children.
         if namespace == TypeNS {
-            if let Some(module) = module_.external_module_children.borrow().get(&name).cloned() {
+            let child = module_.external_module_children.borrow().get(&name).cloned();
+            if let Some(module) = child {
                 let name_bindings =
                     Rc::new(Resolver::create_name_bindings_from_module(module));
                 return Success((Target::new(module_,
@@ -2534,7 +2537,8 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             }
         }
 
-        for (_, module_) in module_.anonymous_children.borrow().iter() {
+        let children = module_.anonymous_children.borrow();
+        for (_, module_) in children.iter() {
             self.report_unresolved_imports(module_.clone());
         }
     }

--- a/src/librustc_resolve/record_exports.rs
+++ b/src/librustc_resolve/record_exports.rs
@@ -91,7 +91,8 @@ impl<'a, 'b, 'tcx> ExportRecorder<'a, 'b, 'tcx> {
             }
         }
 
-        for (_, child_module) in module_.anonymous_children.borrow().iter() {
+        let children = module_.anonymous_children.borrow();
+        for (_, child_module) in children.iter() {
             self.record_exports_for_module_subtree(child_module.clone());
         }
     }

--- a/src/librustc_trans/trans/adt.rs
+++ b/src/librustc_trans/trans/adt.rs
@@ -931,8 +931,9 @@ pub fn trans_field_ptr<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, r: &Repr<
     }
 }
 
-pub fn struct_field_ptr<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, st: &Struct<'tcx>, val: ValueRef,
-                                    ix: uint, needs_cast: bool) -> ValueRef {
+pub fn struct_field_ptr<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
+                                          st: &Struct<'tcx>, val: ValueRef,
+                                          ix: uint, needs_cast: bool) -> ValueRef {
     let val = if needs_cast {
         let ccx = bcx.ccx();
         let fields = st.fields.iter().map(|&ty| type_of::type_of(ccx, ty)).collect::<Vec<_>>();
@@ -946,10 +947,10 @@ pub fn struct_field_ptr<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, st: &Str
 }
 
 pub fn fold_variants<'fcx, 'blk, 'tcx, F>(bcx: Block<'fcx, 'blk, 'tcx>,
-                                    r: &Repr<'tcx>,
-                                    value: ValueRef,
-                                    mut f: F)
-                                    -> Block<'fcx, 'blk, 'tcx> where
+                                          r: &Repr<'tcx>,
+                                          value: ValueRef,
+                                          mut f: F)
+                                          -> Block<'fcx, 'blk, 'tcx> where
     F: FnMut(Block<'fcx, 'blk, 'tcx>, &Struct<'tcx>, ValueRef) -> Block<'fcx, 'blk, 'tcx>,
 {
     let fcx = bcx.fcx;
@@ -989,8 +990,10 @@ pub fn fold_variants<'fcx, 'blk, 'tcx, F>(bcx: Block<'fcx, 'blk, 'tcx>,
 }
 
 /// Access the struct drop flag, if present.
-pub fn trans_drop_flag_ptr<'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>, r: &Repr<'tcx>, val: ValueRef)
-                                       -> datum::DatumBlock<'fcx, 'blk, 'tcx, datum::Expr> {
+pub fn trans_drop_flag_ptr<'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>,
+                                             r: &Repr<'tcx>,
+                                             val: ValueRef)
+                                             -> datum::DatumBlock<'fcx, 'blk, 'tcx, datum::Expr> {
     let tcx = bcx.tcx();
     let ptr_ty = ty::mk_imm_ptr(bcx.tcx(), tcx.types.bool);
     match *r {

--- a/src/librustc_trans/trans/asm.rs
+++ b/src/librustc_trans/trans/asm.rs
@@ -25,8 +25,8 @@ use std::ffi::CString;
 use libc::{c_uint, c_char};
 
 // Take an inline assembly expression and splat it out via LLVM
-pub fn trans_inline_asm<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, ia: &ast::InlineAsm)
-                                    -> Block<'blk, 'tcx> {
+pub fn trans_inline_asm<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, ia: &ast::InlineAsm)
+                                    -> Block<'fcx, 'blk, 'tcx> {
     let fcx = bcx.fcx;
     let mut bcx = bcx;
     let mut constraints = Vec::new();

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -367,7 +367,7 @@ pub fn get_extern_const<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, did: ast::DefId,
 // Returns a pointer to the body for the box. The box may be an opaque
 // box. The result will be casted to the type of body_t, if it is statically
 // known.
-pub fn at_box_body<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn at_box_body<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                body_t: Ty<'tcx>, boxptr: ValueRef) -> ValueRef {
     let _icx = push_ctxt("at_box_body");
     let ccx = bcx.ccx();
@@ -376,7 +376,7 @@ pub fn at_box_body<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     GEPi(bcx, boxptr, &[0u, abi::BOX_FIELD_BODY])
 }
 
-fn require_alloc_fn<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn require_alloc_fn<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                 info_ty: Ty<'tcx>, it: LangItem) -> ast::DefId {
     match bcx.tcx().lang_items.require(it) {
         Ok(id) => id,
@@ -391,12 +391,12 @@ fn require_alloc_fn<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 // The following malloc_raw_dyn* functions allocate a box to contain
 // a given type, but with a potentially dynamic size.
 
-pub fn malloc_raw_dyn<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn malloc_raw_dyn<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                   llty_ptr: Type,
                                   info_ty: Ty<'tcx>,
                                   size: ValueRef,
                                   align: ValueRef)
-                                  -> Result<'blk, 'tcx> {
+                                  -> Result<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("malloc_raw_exchange");
 
     // Allocate space:
@@ -559,12 +559,12 @@ pub fn maybe_name_value(cx: &CrateContext, v: ValueRef, s: &str) {
 #[derive(Copy)]
 pub enum scalar_type { nil_type, signed_int, unsigned_int, floating_point, }
 
-pub fn compare_scalar_types<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
+pub fn compare_scalar_types<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
                                         lhs: ValueRef,
                                         rhs: ValueRef,
                                         t: Ty<'tcx>,
                                         op: ast::BinOp)
-                                        -> Result<'blk, 'tcx> {
+                                        -> Result<'fcx, 'blk, 'tcx> {
     let f = |&: a| Result::new(cx, compare_scalar_values(cx, lhs, rhs, a, op));
 
     match t.sty {
@@ -580,7 +580,7 @@ pub fn compare_scalar_types<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
 
 
 // A helper function to do the actual comparison of scalar values.
-pub fn compare_scalar_values<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
+pub fn compare_scalar_values<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
                                          lhs: ValueRef,
                                          rhs: ValueRef,
                                          nt: scalar_type,
@@ -640,8 +640,8 @@ pub fn compare_scalar_values<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
     }
 }
 
-pub fn compare_simd_types<'blk, 'tcx>(
-                    cx: Block<'blk, 'tcx>,
+pub fn compare_simd_types<'fcx, 'blk, 'tcx>(
+                    cx: Block<'fcx, 'blk, 'tcx>,
                     lhs: ValueRef,
                     rhs: ValueRef,
                     t: Ty<'tcx>,
@@ -679,23 +679,23 @@ pub fn compare_simd_types<'blk, 'tcx>(
 }
 
 // Iterates through the elements of a structural type.
-pub fn iter_structural_ty<'blk, 'tcx, F>(cx: Block<'blk, 'tcx>,
+pub fn iter_structural_ty<'fcx, 'blk, 'tcx, F>(cx: Block<'fcx, 'blk, 'tcx>,
                                          av: ValueRef,
                                          t: Ty<'tcx>,
                                          mut f: F)
-                                         -> Block<'blk, 'tcx> where
-    F: FnMut(Block<'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'blk, 'tcx>,
+                                         -> Block<'fcx, 'blk, 'tcx> where
+    F: FnMut(Block<'fcx, 'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'fcx, 'blk, 'tcx>,
 {
     let _icx = push_ctxt("iter_structural_ty");
 
-    fn iter_variant<'blk, 'tcx, F>(cx: Block<'blk, 'tcx>,
+    fn iter_variant<'fcx, 'blk, 'tcx, F>(cx: Block<'fcx, 'blk, 'tcx>,
                                    repr: &adt::Repr<'tcx>,
                                    av: ValueRef,
                                    variant: &ty::VariantInfo<'tcx>,
                                    substs: &subst::Substs<'tcx>,
                                    f: &mut F)
-                                   -> Block<'blk, 'tcx> where
-        F: FnMut(Block<'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'blk, 'tcx>,
+                                   -> Block<'fcx, 'blk, 'tcx> where
+        F: FnMut(Block<'fcx, 'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'fcx, 'blk, 'tcx>,
     {
         let _icx = push_ctxt("iter_variant");
         let tcx = cx.tcx();
@@ -780,7 +780,7 @@ pub fn iter_structural_ty<'blk, 'tcx, F>(cx: Block<'blk, 'tcx>,
                   cx = f(cx, lldiscrim_a, cx.tcx().types.int);
                   let unr_cx = fcx.new_temp_block("enum-iter-unr");
                   Unreachable(unr_cx);
-                  let llswitch = Switch(cx, lldiscrim_a, unr_cx.llbb,
+                  let llswitch = Switch(cx, lldiscrim_a, unr_cx.data.llbb,
                                         n_variants);
                   let next_cx = fcx.new_temp_block("enum-iter-next");
 
@@ -792,7 +792,7 @@ pub fn iter_structural_ty<'blk, 'tcx, F>(cx: Block<'blk, 'tcx>,
                               []);
                       match adt::trans_case(cx, &*repr, variant.disr_val) {
                           _match::SingleResult(r) => {
-                              AddCase(llswitch, r.val, variant_cx.llbb)
+                              AddCase(llswitch, r.val, variant_cx.data.llbb)
                           }
                           _ => ccx.sess().unimpl("value from adt::trans_case \
                                                   in iter_structural_ty")
@@ -804,7 +804,7 @@ pub fn iter_structural_ty<'blk, 'tcx, F>(cx: Block<'blk, 'tcx>,
                                        &**variant,
                                        substs,
                                        &mut f);
-                      Br(variant_cx, next_cx.llbb);
+                      Br(variant_cx, next_cx.data.llbb);
                   }
                   cx = next_cx;
               }
@@ -870,14 +870,14 @@ pub fn cast_shift_rhs<F, G>(op: ast::BinOp,
     }
 }
 
-pub fn fail_if_zero_or_overflows<'blk, 'tcx>(
-                                cx: Block<'blk, 'tcx>,
+pub fn fail_if_zero_or_overflows<'fcx, 'blk, 'tcx>(
+                                cx: Block<'fcx, 'blk, 'tcx>,
                                 span: Span,
                                 divrem: ast::BinOp,
                                 lhs: ValueRef,
                                 rhs: ValueRef,
                                 rhs_t: Ty<'tcx>)
-                                -> Block<'blk, 'tcx> {
+                                -> Block<'fcx, 'blk, 'tcx> {
     let (zero_text, overflow_text) = if divrem == ast::BiDiv {
         ("attempted to divide by zero",
          "attempted to divide with overflow")
@@ -967,20 +967,20 @@ pub fn trans_external_path<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     }
 }
 
-pub fn invoke<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn invoke<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                           llfn: ValueRef,
                           llargs: &[ValueRef],
                           fn_ty: Ty<'tcx>,
                           call_info: Option<NodeInfo>)
-                          -> (ValueRef, Block<'blk, 'tcx>) {
+                          -> (ValueRef, Block<'fcx, 'blk, 'tcx>) {
     let _icx = push_ctxt("invoke_");
-    if bcx.unreachable.get() {
+    if bcx.data.unreachable.get() {
         return (C_null(Type::i8(bcx.ccx())), bcx);
     }
 
     let attributes = get_fn_llvm_attributes(bcx.ccx(), fn_ty);
 
-    match bcx.opt_node_id {
+    match bcx.data.opt_node_id {
         None => {
             debug!("invoke at ???");
         }
@@ -990,7 +990,7 @@ pub fn invoke<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     }
 
     if need_invoke(bcx) {
-        debug!("invoking {} at {:?}", bcx.val_to_string(llfn), bcx.llbb);
+        debug!("invoking {} at {:?}", bcx.val_to_string(llfn), bcx.data.llbb);
         for &llarg in llargs.iter() {
             debug!("arg: {}", bcx.val_to_string(llarg));
         }
@@ -1005,12 +1005,12 @@ pub fn invoke<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         let llresult = Invoke(bcx,
                               llfn,
                               &llargs[],
-                              normal_bcx.llbb,
+                              normal_bcx.data.llbb,
                               landing_pad,
                               Some(attributes));
         return (llresult, normal_bcx);
     } else {
-        debug!("calling {} at {:?}", bcx.val_to_string(llfn), bcx.llbb);
+        debug!("calling {} at {:?}", bcx.val_to_string(llfn), bcx.data.llbb);
         for &llarg in llargs.iter() {
             debug!("arg: {}", bcx.val_to_string(llarg));
         }
@@ -1031,14 +1031,14 @@ pub fn need_invoke(bcx: Block) -> bool {
     }
 
     // Avoid using invoke if we are already inside a landing pad.
-    if bcx.is_lpad {
+    if bcx.data.is_lpad {
         return false;
     }
 
     bcx.fcx.needs_invoke()
 }
 
-pub fn load_if_immediate<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
+pub fn load_if_immediate<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
                                      v: ValueRef, t: Ty<'tcx>) -> ValueRef {
     let _icx = push_ctxt("load_if_immediate");
     if type_is_immediate(cx.ccx(), t) { return load_ty(cx, v, t); }
@@ -1048,8 +1048,8 @@ pub fn load_if_immediate<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
 /// Helper for loading values from memory. Does the necessary conversion if the in-memory type
 /// differs from the type used for SSA values. Also handles various special cases where the type
 /// gives us better information about what we are loading.
-pub fn load_ty<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
-                           ptr: ValueRef, t: Ty<'tcx>) -> ValueRef {
+pub fn load_ty<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
+                                 ptr: ValueRef, t: Ty<'tcx>) -> ValueRef {
     if type_is_zero_size(cx.ccx(), t) {
         C_undef(type_of::type_of(cx.ccx(), t))
     } else if ty::type_is_bool(t) {
@@ -1070,7 +1070,7 @@ pub fn load_ty<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
 
 /// Helper for storing values in memory. Does the necessary conversion if the in-memory type
 /// differs from the type used for SSA values.
-pub fn store_ty<'blk, 'tcx>(cx: Block<'blk, 'tcx>, v: ValueRef, dst: ValueRef, t: Ty<'tcx>) {
+pub fn store_ty<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>, v: ValueRef, dst: ValueRef, t: Ty<'tcx>) {
     if ty::type_is_bool(t) {
         Store(cx, ZExt(cx, v, Type::i8(cx.ccx())), dst);
     } else if type_is_immediate(cx.ccx(), t) && type_of::type_of(cx.ccx(), t).is_aggregate() {
@@ -1083,35 +1083,35 @@ pub fn store_ty<'blk, 'tcx>(cx: Block<'blk, 'tcx>, v: ValueRef, dst: ValueRef, t
     };
 }
 
-pub fn init_local<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, local: &ast::Local)
-                              -> Block<'blk, 'tcx> {
+pub fn init_local<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, local: &ast::Local)
+                                    -> Block<'fcx, 'blk, 'tcx> {
     debug!("init_local(bcx={}, local.id={})", bcx.to_str(), local.id);
     let _indenter = indenter();
     let _icx = push_ctxt("init_local");
     _match::store_local(bcx, local)
 }
 
-pub fn raw_block<'blk, 'tcx>(fcx: &'blk FunctionContext<'blk, 'tcx>,
+pub fn raw_block<'fcx, 'blk, 'tcx>(fcx: &'fcx FunctionContext<'blk, 'tcx>,
                              is_lpad: bool,
                              llbb: BasicBlockRef)
-                             -> Block<'blk, 'tcx> {
+                             -> Block<'fcx, 'blk, 'tcx> {
     common::BlockS::new(llbb, is_lpad, None, fcx)
 }
 
-pub fn with_cond<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
+pub fn with_cond<'fcx, 'blk, 'tcx, F>(bcx: Block<'fcx, 'blk, 'tcx>,
                                 val: ValueRef,
                                 f: F)
-                                -> Block<'blk, 'tcx> where
-    F: FnOnce(Block<'blk, 'tcx>) -> Block<'blk, 'tcx>,
+                                -> Block<'fcx, 'blk, 'tcx> where
+    F: FnOnce(Block<'fcx, 'blk, 'tcx>) -> Block<'fcx, 'blk, 'tcx>,
 {
     let _icx = push_ctxt("with_cond");
     let fcx = bcx.fcx;
     let next_cx = fcx.new_temp_block("next");
     let cond_cx = fcx.new_temp_block("cond");
-    CondBr(bcx, val, cond_cx.llbb, next_cx.llbb);
+    CondBr(bcx, val, cond_cx.data.llbb, next_cx.data.llbb);
     let after_cx = f(cond_cx);
-    if !after_cx.terminated.get() {
-        Br(after_cx, next_cx.llbb);
+    if !after_cx.data.terminated.get() {
+        Br(after_cx, next_cx.data.llbb);
     }
     next_cx
 }
@@ -1161,7 +1161,7 @@ pub fn call_memcpy(cx: Block, dst: ValueRef, src: ValueRef, n_bytes: ValueRef, a
     Call(cx, memcpy, &[dst_ptr, src_ptr, size, align, volatile], None);
 }
 
-pub fn memcpy_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn memcpy_ty<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                              dst: ValueRef, src: ValueRef,
                              t: Ty<'tcx>) {
     let _icx = push_ctxt("memcpy_ty");
@@ -1176,8 +1176,8 @@ pub fn memcpy_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     }
 }
 
-pub fn zero_mem<'blk, 'tcx>(cx: Block<'blk, 'tcx>, llptr: ValueRef, t: Ty<'tcx>) {
-    if cx.unreachable.get() { return; }
+pub fn zero_mem<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>, llptr: ValueRef, t: Ty<'tcx>) {
+    if cx.data.unreachable.get() { return; }
     let _icx = push_ctxt("zero_mem");
     let bcx = cx;
     memzero(&B(bcx), llptr, t);
@@ -1209,7 +1209,7 @@ fn memzero<'a, 'tcx>(b: &Builder<'a, 'tcx>, llptr: ValueRef, ty: Ty<'tcx>) {
     b.call(llintrinsicfn, &[llptr, llzeroval, size, align, volatile], None);
 }
 
-pub fn alloc_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, name: &str) -> ValueRef {
+pub fn alloc_ty<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, t: Ty<'tcx>, name: &str) -> ValueRef {
     let _icx = push_ctxt("alloc_ty");
     let ccx = bcx.ccx();
     let ty = type_of::type_of(ccx, t);
@@ -1226,7 +1226,7 @@ pub fn alloca(cx: Block, ty: Type, name: &str) -> ValueRef {
 
 pub fn alloca_no_lifetime(cx: Block, ty: Type, name: &str) -> ValueRef {
     let _icx = push_ctxt("alloca");
-    if cx.unreachable.get() {
+    if cx.data.unreachable.get() {
         unsafe {
             return llvm::LLVMGetUndef(ty.ptr_to().to_ref());
         }
@@ -1235,10 +1235,10 @@ pub fn alloca_no_lifetime(cx: Block, ty: Type, name: &str) -> ValueRef {
     Alloca(cx, ty, name)
 }
 
-pub fn alloca_zeroed<'blk, 'tcx>(cx: Block<'blk, 'tcx>, ty: Ty<'tcx>,
+pub fn alloca_zeroed<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>, ty: Ty<'tcx>,
                                  name: &str) -> ValueRef {
     let llty = type_of::type_of(cx.ccx(), ty);
-    if cx.unreachable.get() {
+    if cx.data.unreachable.get() {
         unsafe {
             return llvm::LLVMGetUndef(llty.ptr_to().to_ref());
         }
@@ -1252,7 +1252,7 @@ pub fn alloca_zeroed<'blk, 'tcx>(cx: Block<'blk, 'tcx>, ty: Ty<'tcx>,
 
 pub fn arrayalloca(cx: Block, ty: Type, v: ValueRef) -> ValueRef {
     let _icx = push_ctxt("arrayalloca");
-    if cx.unreachable.get() {
+    if cx.data.unreachable.get() {
         unsafe {
             return llvm::LLVMGetUndef(ty.to_ref());
         }
@@ -1430,15 +1430,15 @@ fn has_nested_returns(tcx: &ty::ctxt, cfg: &cfg::CFG, blk_id: ast::NodeId) -> bo
 //
 // Be warned! You must call `init_function` before doing anything with the
 // returned function context.
-pub fn new_fn_ctxt<'a, 'tcx>(ccx: &'a CrateContext<'a, 'tcx>,
+pub fn new_fn_ctxt<'blk, 'tcx>(ccx: &'blk CrateContext<'blk, 'tcx>,
                              llfndecl: ValueRef,
                              id: ast::NodeId,
                              has_env: bool,
                              output_type: ty::FnOutput<'tcx>,
-                             param_substs: &'a Substs<'tcx>,
+                             param_substs: &'blk Substs<'tcx>,
                              sp: Option<Span>,
-                             block_arena: &'a TypedArena<common::BlockS<'a, 'tcx>>)
-                             -> FunctionContext<'a, 'tcx> {
+                             block_arena: &'blk TypedArena<common::BlockS>)
+                             -> FunctionContext<'blk, 'tcx> {
     common::validate_substs(param_substs);
 
     debug!("new_fn_ctxt(path={}, id={}, param_substs={})",
@@ -1496,17 +1496,17 @@ pub fn new_fn_ctxt<'a, 'tcx>(ccx: &'a CrateContext<'a, 'tcx>,
 
 /// Performs setup on a newly created function, creating the entry scope block
 /// and allocating space for the return pointer.
-pub fn init_function<'a, 'tcx>(fcx: &'a FunctionContext<'a, 'tcx>,
+pub fn init_function<'fcx, 'blk, 'tcx>(fcx: &'fcx FunctionContext<'blk, 'tcx>,
                                skip_retptr: bool,
                                output: ty::FnOutput<'tcx>)
-                               -> Block<'a, 'tcx> {
+                               -> Block<'fcx, 'blk, 'tcx> {
     let entry_bcx = fcx.new_temp_block("entry-block");
 
     // Use a dummy instruction as the insertion point for all allocas.
     // This is later removed in FunctionContext::cleanup.
     fcx.alloca_insert_pt.set(Some(unsafe {
         Load(entry_bcx, C_null(Type::i8p(fcx.ccx)));
-        llvm::LLVMGetFirstInstruction(entry_bcx.llbb)
+        llvm::LLVMGetFirstInstruction(entry_bcx.data.llbb)
     }));
 
     if let ty::FnConverging(output_type) = output {
@@ -1568,8 +1568,8 @@ pub fn create_datums_for_fn_args<'a, 'tcx>(fcx: &FunctionContext<'a, 'tcx>,
 /// datums.
 ///
 /// FIXME(pcwalton): Reduce the amount of code bloat this is responsible for.
-fn create_datums_for_fn_args_under_call_abi<'blk, 'tcx>(
-        mut bcx: Block<'blk, 'tcx>,
+fn create_datums_for_fn_args_under_call_abi<'fcx, 'blk, 'tcx>(
+        mut bcx: Block<'fcx, 'blk, 'tcx>,
         arg_scope: cleanup::CustomScopeIndex,
         arg_tys: &[Ty<'tcx>])
         -> Vec<RvalueDatum<'tcx>> {
@@ -1629,12 +1629,12 @@ fn create_datums_for_fn_args_under_call_abi<'blk, 'tcx>(
     result
 }
 
-fn copy_args_to_allocas<'blk, 'tcx>(fcx: &FunctionContext<'blk, 'tcx>,
+fn copy_args_to_allocas<'fcx, 'blk, 'tcx>(fcx: &FunctionContext<'blk, 'tcx>,
                                     arg_scope: cleanup::CustomScopeIndex,
-                                    bcx: Block<'blk, 'tcx>,
+                                    bcx: Block<'fcx, 'blk, 'tcx>,
                                     args: &[ast::Arg],
                                     arg_datums: Vec<RvalueDatum<'tcx>>)
-                                    -> Block<'blk, 'tcx> {
+                                    -> Block<'fcx, 'blk, 'tcx> {
     debug!("copy_args_to_allocas");
 
     let _icx = push_ctxt("copy_args_to_allocas");
@@ -1661,13 +1661,13 @@ fn copy_args_to_allocas<'blk, 'tcx>(fcx: &FunctionContext<'blk, 'tcx>,
     bcx
 }
 
-fn copy_unboxed_closure_args_to_allocas<'blk, 'tcx>(
-                                        mut bcx: Block<'blk, 'tcx>,
+fn copy_unboxed_closure_args_to_allocas<'fcx, 'blk, 'tcx>(
+                                        mut bcx: Block<'fcx, 'blk, 'tcx>,
                                         arg_scope: cleanup::CustomScopeIndex,
                                         args: &[ast::Arg],
                                         arg_datums: Vec<RvalueDatum<'tcx>>,
                                         monomorphized_arg_types: &[Ty<'tcx>])
-                                        -> Block<'blk, 'tcx> {
+                                        -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("copy_unboxed_closure_args_to_allocas");
     let arg_scope_id = cleanup::CustomScope(arg_scope);
 
@@ -1715,14 +1715,14 @@ fn copy_unboxed_closure_args_to_allocas<'blk, 'tcx>(
 
 // Ties up the llstaticallocas -> llloadenv -> lltop edges,
 // and builds the return block.
-pub fn finish_fn<'blk, 'tcx>(fcx: &'blk FunctionContext<'blk, 'tcx>,
-                             last_bcx: Block<'blk, 'tcx>,
+pub fn finish_fn<'fcx, 'blk, 'tcx>(fcx: &'fcx FunctionContext<'blk, 'tcx>,
+                             last_bcx: Block<'fcx, 'blk, 'tcx>,
                              retty: ty::FnOutput<'tcx>) {
     let _icx = push_ctxt("finish_fn");
 
     let ret_cx = match fcx.llreturn.get() {
         Some(llreturn) => {
-            if !last_bcx.terminated.get() {
+            if !last_bcx.data.terminated.get() {
                 Br(last_bcx, llreturn);
             }
             raw_block(fcx, false, llreturn)
@@ -1740,8 +1740,8 @@ pub fn finish_fn<'blk, 'tcx>(fcx: &'blk FunctionContext<'blk, 'tcx>,
 }
 
 // Builds the return block for a function.
-pub fn build_return_block<'blk, 'tcx>(fcx: &FunctionContext<'blk, 'tcx>,
-                                      ret_cx: Block<'blk, 'tcx>,
+pub fn build_return_block<'fcx, 'blk, 'tcx>(fcx: &'fcx FunctionContext<'blk, 'tcx>,
+                                      ret_cx: Block<'fcx, 'blk, 'tcx>,
                                       retty: ty::FnOutput<'tcx>) {
     if fcx.llretslotptr.get().is_none() ||
        (!fcx.needs_ret_allocas && fcx.caller_expects_out_pointer) {
@@ -1941,7 +1941,7 @@ pub fn trans_closure<'a, 'b, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     unsafe {
         let llreturn = fcx.llreturn.get();
         for &llreturn in llreturn.iter() {
-            llvm::LLVMMoveBasicBlockAfter(llreturn, bcx.llbb);
+            llvm::LLVMMoveBasicBlockAfter(llreturn, bcx.data.llbb);
         }
     }
 
@@ -1993,13 +1993,13 @@ pub fn trans_enum_variant<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         llfndecl);
 }
 
-pub fn trans_named_tuple_constructor<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
+pub fn trans_named_tuple_constructor<'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>,
                                                  ctor_ty: Ty<'tcx>,
                                                  disr: ty::Disr,
                                                  args: callee::CallArgs,
                                                  dest: expr::Dest,
                                                  call_info: Option<NodeInfo>)
-                                                 -> Result<'blk, 'tcx> {
+                                                 -> Result<'fcx, 'blk, 'tcx> {
 
     let ccx = bcx.fcx.ccx;
     let tcx = ccx.tcx();

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1070,7 +1070,10 @@ pub fn load_ty<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
 
 /// Helper for storing values in memory. Does the necessary conversion if the in-memory type
 /// differs from the type used for SSA values.
-pub fn store_ty<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>, v: ValueRef, dst: ValueRef, t: Ty<'tcx>) {
+pub fn store_ty<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
+                                  v: ValueRef,
+                                  dst: ValueRef,
+                                  t: Ty<'tcx>) {
     if ty::type_is_bool(t) {
         Store(cx, ZExt(cx, v, Type::i8(cx.ccx())), dst);
     } else if type_is_immediate(cx.ccx(), t) && type_of::type_of(cx.ccx(), t).is_aggregate() {
@@ -1209,7 +1212,9 @@ fn memzero<'a, 'tcx>(b: &Builder<'a, 'tcx>, llptr: ValueRef, ty: Ty<'tcx>) {
     b.call(llintrinsicfn, &[llptr, llzeroval, size, align, volatile], None);
 }
 
-pub fn alloc_ty<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, t: Ty<'tcx>, name: &str) -> ValueRef {
+pub fn alloc_ty<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
+                                  t: Ty<'tcx>,
+                                  name: &str) -> ValueRef {
     let _icx = push_ctxt("alloc_ty");
     let ccx = bcx.ccx();
     let ty = type_of::type_of(ccx, t);

--- a/src/librustc_trans/trans/cleanup.rs
+++ b/src/librustc_trans/trans/cleanup.rs
@@ -130,12 +130,17 @@ impl<'blk, 'tcx> CleanupMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx> {
         // this new AST scope had better be its immediate child.
         let top_scope = self.top_ast_scope();
         if top_scope.is_some() {
-            assert_eq!(self.ccx
-                           .tcx()
-                           .region_maps
-                           .opt_encl_scope(region::CodeExtent::from_node_id(debug_loc.id))
-                           .map(|s|s.node_id()),
-                       top_scope);
+            assert!((self.ccx
+                     .tcx()
+                     .region_maps
+                     .opt_encl_scope(region::CodeExtent::from_node_id(debug_loc.id))
+                     .map(|s|s.node_id()) == top_scope)
+                    ||
+                    (self.ccx
+                     .tcx()
+                     .region_maps
+                     .opt_encl_scope(region::CodeExtent::DestructionScope(debug_loc.id))
+                     .map(|s|s.node_id()) == top_scope));
         }
 
         self.push_scope(CleanupScope::new(AstScopeKind(debug_loc.id),

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -989,7 +989,8 @@ pub fn expr_ty<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, ex: &ast::Expr) -
     node_id_type(bcx, ex.id)
 }
 
-pub fn expr_ty_adjusted<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, ex: &ast::Expr) -> Ty<'tcx> {
+pub fn expr_ty_adjusted<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
+                                          ex: &ast::Expr) -> Ty<'tcx> {
     monomorphize_type(bcx, ty::expr_ty_adjusted(bcx.tcx(), ex))
 }
 

--- a/src/librustc_trans/trans/debuginfo.rs
+++ b/src/librustc_trans/trans/debuginfo.rs
@@ -854,7 +854,7 @@ pub fn create_global_var_metadata(cx: &CrateContext,
 /// local in `bcx.fcx.lllocals`.
 /// Adds the created metadata nodes directly to the crate's IR.
 pub fn create_local_var_metadata(bcx: Block, local: &ast::Local) {
-    if bcx.unreachable.get() || fn_should_be_ignored(bcx.fcx) {
+    if bcx.data.unreachable.get() || fn_should_be_ignored(bcx.fcx) {
         return;
     }
 
@@ -892,13 +892,13 @@ pub fn create_local_var_metadata(bcx: Block, local: &ast::Local) {
 /// Creates debug information for a variable captured in a closure.
 ///
 /// Adds the created metadata nodes directly to the crate's IR.
-pub fn create_captured_var_metadata<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn create_captured_var_metadata<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                                 node_id: ast::NodeId,
                                                 env_pointer: ValueRef,
                                                 env_index: uint,
                                                 captured_by_ref: bool,
                                                 span: Span) {
-    if bcx.unreachable.get() || fn_should_be_ignored(bcx.fcx) {
+    if bcx.data.unreachable.get() || fn_should_be_ignored(bcx.fcx) {
         return;
     }
 
@@ -978,10 +978,10 @@ pub fn create_captured_var_metadata<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 /// match-statement arm.
 ///
 /// Adds the created metadata nodes directly to the crate's IR.
-pub fn create_match_binding_metadata<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn create_match_binding_metadata<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                                  variable_ident: ast::Ident,
                                                  binding: BindingInfo<'tcx>) {
-    if bcx.unreachable.get() || fn_should_be_ignored(bcx.fcx) {
+    if bcx.data.unreachable.get() || fn_should_be_ignored(bcx.fcx) {
         return;
     }
 
@@ -1021,7 +1021,7 @@ pub fn create_match_binding_metadata<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 /// argument in `bcx.fcx.lllocals`.
 /// Adds the created metadata nodes directly to the crate's IR.
 pub fn create_argument_metadata(bcx: Block, arg: &ast::Arg) {
-    if bcx.unreachable.get() || fn_should_be_ignored(bcx.fcx) {
+    if bcx.data.unreachable.get() || fn_should_be_ignored(bcx.fcx) {
         return;
     }
 
@@ -1075,7 +1075,7 @@ pub fn create_argument_metadata(bcx: Block, arg: &ast::Arg) {
 /// loop variable in `bcx.fcx.lllocals`.
 /// Adds the created metadata nodes directly to the crate's IR.
 pub fn create_for_loop_var_metadata(bcx: Block, pat: &ast::Pat) {
-    if bcx.unreachable.get() || fn_should_be_ignored(bcx.fcx) {
+    if bcx.data.unreachable.get() || fn_should_be_ignored(bcx.fcx) {
         return;
     }
 
@@ -1649,7 +1649,7 @@ fn compile_unit_metadata(cx: &CrateContext) -> DIDescriptor {
     }
 }
 
-fn declare_local<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn declare_local<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                              variable_ident: ast::Ident,
                              variable_type: Ty<'tcx>,
                              scope_metadata: DIScope,
@@ -1715,7 +1715,7 @@ fn declare_local<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             DIB(cx),
             var_alloca,
             var_metadata,
-            bcx.llbb);
+            bcx.data.llbb);
 
         llvm::LLVMSetInstDebugLocation(trans::build::B(bcx).llbuilder, instr);
     }

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -212,13 +212,13 @@ pub fn register_foreign_item_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 ///   can derive these from callee_ty but in the case of variadic
 ///   functions passed_arg_tys will include the Rust type of all
 ///   the arguments including the ones not specified in the fn's signature.
-pub fn trans_native_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_native_call<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                      callee_ty: Ty<'tcx>,
                                      llfn: ValueRef,
                                      llretptr: ValueRef,
                                      llargs_rust: &[ValueRef],
                                      passed_arg_tys: Vec<Ty<'tcx>>)
-                                     -> Block<'blk, 'tcx>
+                                     -> Block<'fcx, 'blk, 'tcx>
 {
     let ccx = bcx.ccx();
     let tcx = bcx.tcx();

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -302,8 +302,10 @@ fn trans_struct_drop<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
     })
 }
 
-fn size_and_align_of_dst<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, t: Ty<'tcx>, info: ValueRef)
-                                     -> (ValueRef, ValueRef) {
+fn size_and_align_of_dst<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
+                                           t: Ty<'tcx>,
+                                           info: ValueRef)
+                                           -> (ValueRef, ValueRef) {
     debug!("calculate size of DST: {}; with lost info: {}",
            bcx.ty_to_string(t), bcx.val_to_string(info));
     if type_is_sized(bcx.tcx(), t) {

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -45,9 +45,9 @@ use std::ffi::CString;
 use syntax::ast;
 use syntax::parse::token;
 
-pub fn trans_exchange_free_dyn<'blk, 'tcx>(cx: Block<'blk, 'tcx>, v: ValueRef,
+pub fn trans_exchange_free_dyn<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>, v: ValueRef,
                                            size: ValueRef, align: ValueRef)
-                                           -> Block<'blk, 'tcx> {
+                                           -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_exchange_free");
     let ccx = cx.ccx();
     callee::trans_lang_call(cx,
@@ -56,14 +56,14 @@ pub fn trans_exchange_free_dyn<'blk, 'tcx>(cx: Block<'blk, 'tcx>, v: ValueRef,
         Some(expr::Ignore)).bcx
 }
 
-pub fn trans_exchange_free<'blk, 'tcx>(cx: Block<'blk, 'tcx>, v: ValueRef,
-                                       size: u64, align: u32) -> Block<'blk, 'tcx> {
+pub fn trans_exchange_free<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>, v: ValueRef,
+                                       size: u64, align: u32) -> Block<'fcx, 'blk, 'tcx> {
     trans_exchange_free_dyn(cx, v, C_uint(cx.ccx(), size),
                                    C_uint(cx.ccx(), align))
 }
 
-pub fn trans_exchange_free_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, ptr: ValueRef,
-                                          content_ty: Ty<'tcx>) -> Block<'blk, 'tcx> {
+pub fn trans_exchange_free_ty<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, ptr: ValueRef,
+                                          content_ty: Ty<'tcx>) -> Block<'fcx, 'blk, 'tcx> {
     assert!(type_is_sized(bcx.ccx().tcx(), content_ty));
     let sizing_type = sizing_type_of(bcx.ccx(), content_ty);
     let content_size = llsize_of_alloc(bcx.ccx(), sizing_type);
@@ -103,11 +103,11 @@ pub fn get_drop_glue_type<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     }
 }
 
-pub fn drop_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn drop_ty<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                            v: ValueRef,
                            t: Ty<'tcx>,
                            source_location: Option<NodeInfo>)
-                           -> Block<'blk, 'tcx> {
+                           -> Block<'fcx, 'blk, 'tcx> {
     // NB: v is an *alias* of type t here, not a direct value.
     debug!("drop_ty(t={})", t.repr(bcx.tcx()));
     let _icx = push_ctxt("drop_ty");
@@ -131,11 +131,11 @@ pub fn drop_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     bcx
 }
 
-pub fn drop_ty_immediate<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn drop_ty_immediate<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                      v: ValueRef,
                                      t: Ty<'tcx>,
                                      source_location: Option<NodeInfo>)
-                                     -> Block<'blk, 'tcx> {
+                                     -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("drop_ty_immediate");
     let vp = alloca(bcx, type_of(bcx.ccx(), t), "");
     store_ty(bcx, v, vp, t);
@@ -186,13 +186,13 @@ pub fn get_drop_glue<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> Val
     glue
 }
 
-fn trans_struct_drop_flag<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
+fn trans_struct_drop_flag<'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>,
                                       t: Ty<'tcx>,
                                       v0: ValueRef,
                                       dtor_did: ast::DefId,
                                       class_did: ast::DefId,
                                       substs: &subst::Substs<'tcx>)
-                                      -> Block<'blk, 'tcx> {
+                                      -> Block<'fcx, 'blk, 'tcx> {
     let repr = adt::represent_type(bcx.ccx(), t);
     let struct_data = if type_is_sized(bcx.tcx(), t) {
         v0
@@ -206,13 +206,13 @@ fn trans_struct_drop_flag<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
     })
 }
 
-fn trans_struct_drop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_struct_drop<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                  t: Ty<'tcx>,
                                  v0: ValueRef,
                                  dtor_did: ast::DefId,
                                  class_did: ast::DefId,
                                  substs: &subst::Substs<'tcx>)
-                                 -> Block<'blk, 'tcx>
+                                 -> Block<'fcx, 'blk, 'tcx>
 {
     let repr = adt::represent_type(bcx.ccx(), t);
 
@@ -302,7 +302,7 @@ fn trans_struct_drop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     })
 }
 
-fn size_and_align_of_dst<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, info: ValueRef)
+fn size_and_align_of_dst<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, t: Ty<'tcx>, info: ValueRef)
                                      -> (ValueRef, ValueRef) {
     debug!("calculate size of DST: {}; with lost info: {}",
            bcx.ty_to_string(t), bcx.val_to_string(info));
@@ -358,8 +358,8 @@ fn size_and_align_of_dst<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, info: 
     }
 }
 
-fn make_drop_glue<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, v0: ValueRef, t: Ty<'tcx>)
-                              -> Block<'blk, 'tcx> {
+fn make_drop_glue<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, v0: ValueRef, t: Ty<'tcx>)
+                              -> Block<'fcx, 'blk, 'tcx> {
     // NB: v0 is an *alias* of type t here, not a direct value.
     let _icx = push_ctxt("make_drop_glue");
     match t.sty {
@@ -527,7 +527,8 @@ fn make_generic_glue<'a, 'tcx, F>(ccx: &CrateContext<'a, 'tcx>,
                                   helper: F,
                                   name: &str)
                                   -> ValueRef where
-    F: for<'blk> FnOnce(Block<'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'blk, 'tcx>,
+    F: for<'fcx, 'blk> FnOnce(Block<'fcx, 'blk, 'tcx>, ValueRef, Ty<'tcx>)
+                              -> Block<'fcx, 'blk, 'tcx>,
 {
     let _icx = push_ctxt("make_generic_glue");
     let glue_name = format!("glue {} {}", name, ty_to_short_str(ccx.tcx(), t));

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -142,7 +142,7 @@ pub fn check_intrinsics(ccx: &CrateContext) {
     ccx.sess().abort_if_errors();
 }
 
-pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
+pub fn trans_intrinsic_call<'a, 'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>,
                                             node: ast::NodeId,
                                             callee_ty: Ty<'tcx>,
                                             cleanup_scope: cleanup::CustomScopeIndex,
@@ -150,7 +150,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                                             dest: expr::Dest,
                                             substs: subst::Substs<'tcx>,
                                             call_info: NodeInfo)
-                                            -> Result<'blk, 'tcx>
+                                            -> Result<'fcx, 'blk, 'tcx>
 {
     let fcx = bcx.fcx;
     let ccx = fcx.ccx;
@@ -620,7 +620,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
     Result::new(bcx, llresult)
 }
 
-fn copy_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn copy_intrinsic<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                               allow_overlap: bool, volatile: bool, tp_ty: Ty<'tcx>,
                               dst: ValueRef, src: ValueRef, count: ValueRef) -> ValueRef {
     let ccx = bcx.ccx();
@@ -650,7 +650,7 @@ fn copy_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                       C_bool(ccx, volatile)], None)
 }
 
-fn memset_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, volatile: bool, tp_ty: Ty<'tcx>,
+fn memset_intrinsic<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, volatile: bool, tp_ty: Ty<'tcx>,
                                 dst: ValueRef, val: ValueRef, count: ValueRef) -> ValueRef {
     let ccx = bcx.ccx();
     let lltp_ty = type_of::type_of(ccx, tp_ty);
@@ -675,7 +675,7 @@ fn count_zeros_intrinsic(bcx: Block, name: &'static str, val: ValueRef) -> Value
     Call(bcx, llfn, &[val, y], None)
 }
 
-fn with_overflow_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, name: &'static str,
+fn with_overflow_intrinsic<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, name: &'static str,
                                        t: Ty<'tcx>, a: ValueRef, b: ValueRef) -> ValueRef {
     let llfn = bcx.ccx().get_intrinsic(&name);
 

--- a/src/librustc_trans/trans/value.rs
+++ b/src/librustc_trans/trans/value.rs
@@ -58,7 +58,7 @@ impl Value {
         match self.get_single_user().and_then(|user| user.as_store_inst()) {
             Some(store) => {
                 store.get_parent().and_then(|store_bb| {
-                    let mut bb = BasicBlock(bcx.llbb);
+                    let mut bb = BasicBlock(bcx.data.llbb);
                     let mut ret = Some(store);
                     while bb.get() != store_bb.get() {
                         match bb.get_single_predecessor() {

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -119,7 +119,9 @@ fn check_unboxed_closure<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
     fcx.write_ty(expr.id, closure_type);
 
     let fn_sig =
-        ty::liberate_late_bound_regions(fcx.tcx(), CodeExtent::from_node_id(body.id), &fn_ty.sig);
+        ty::liberate_late_bound_regions(fcx.tcx(),
+                                        CodeExtent::DestructionScope(body.id),
+                                        &fn_ty.sig);
 
     check_fn(fcx.ccx,
              ast::Unsafety::Normal,

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -1,0 +1,230 @@
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use check::regionck::{Rcx};
+
+use middle::infer;
+use middle::region;
+use middle::subst;
+use middle::ty::{self, Ty};
+use util::ppaux::{Repr};
+
+use syntax::codemap::Span;
+
+pub fn check_safety_of_destructor_if_necessary<'a, 'tcx>(rcx: &mut Rcx<'a, 'tcx>,
+                                                     typ: ty::Ty<'tcx>,
+                                                     span: Span,
+                                                     scope: region::CodeExtent) {
+    debug!("check_safety_of_destructor_if_necessary typ: {} scope: {:?}",
+           typ.repr(rcx.tcx()), scope);
+
+    // types that have been traversed so far by `traverse_type_if_unseen`
+    let mut breadcrumbs: Vec<Ty<'tcx>> = Vec::new();
+
+    iterate_over_potentially_unsafe_regions_in_type(
+        rcx,
+        &mut breadcrumbs,
+        typ,
+        span,
+        scope,
+        false,
+        0);
+}
+
+fn constrain_region_for_destructor_safety(rcx: &mut Rcx,
+                                          region: ty::Region,
+                                          inner_scope: region::CodeExtent,
+                                          span: Span) {
+    debug!("constrain_region_for_destructor_safety region: {:?} inner_scope: {:?}",
+           region, inner_scope);
+
+    // Ignore bound regions.
+    match region {
+        ty::ReEarlyBound(..) | ty::ReLateBound(..) => return,
+        ty::ReFree(_) | ty::ReScope(_) | ty::ReStatic |
+        ty::ReInfer(_) | ty::ReEmpty => {}
+    }
+
+    // Get the parent scope.
+    let parent_inner_region =
+        match rcx.tcx().region_maps.opt_encl_scope(inner_scope) {
+            Some(parent_inner_scope) => ty::ReScope(parent_inner_scope),
+            None =>
+                rcx.tcx().sess.span_bug(
+                    span, format!("no enclosing scope found for inner_scope: {:?}",
+                                  inner_scope).as_slice()),
+        };
+
+    rcx.mk_subr(infer::SafeDestructor(span),
+                parent_inner_region,
+                region);
+}
+
+fn traverse_type_if_unseen<'a, 'tcx, P>(rcx: &mut Rcx<'a, 'tcx>,
+                                        breadcrumbs: &mut Vec<Ty<'tcx>>,
+                                        typ: ty::Ty<'tcx>,
+                                        keep_going: P) -> bool where
+    P: Fn(&mut Rcx<'a, 'tcx>, &mut Vec<Ty<'tcx>>) -> bool,
+{
+    // Avoid recursing forever.
+    if !breadcrumbs.contains(&typ) {
+        breadcrumbs.push(typ);
+        let keep_going = keep_going(rcx, breadcrumbs);
+
+        // You might be tempted to pop breadcrumbs here after the
+        // `keep_going` call, but then you hit exponential time
+        // blowup e.g. on compile-fail/huge-struct.rs. Instead, we
+        // do not remove anything from the breadcrumbs vector
+        // during any particular traversal, and instead clear it
+        // after the whole traversal is done.
+
+        keep_going
+    } else {
+        false
+    }
+}
+
+
+fn iterate_over_potentially_unsafe_regions_in_type<'a, 'tcx>(
+    rcx: &mut Rcx<'a, 'tcx>,
+    breadcrumbs: &mut Vec<Ty<'tcx>>,
+    typ: ty::Ty<'tcx>,
+    span: Span,
+    scope: region::CodeExtent,
+    reachable_by_destructor: bool,
+    depth: uint)
+{
+    ty::maybe_walk_ty(typ, |typ| {
+        // Avoid recursing forever.
+        traverse_type_if_unseen(rcx, breadcrumbs, typ, |rcx, breadcrumbs| {
+            debug!("iterate_over_potentially_unsafe_regions_in_type \
+                    {}typ: {} scope: {:?} reachable_by_destructor: {}",
+                   (0..depth).map(|_| ' ').collect::<String>(),
+                   typ.repr(rcx.tcx()), scope, reachable_by_destructor);
+
+            let keep_going = match typ.sty {
+                ty::ty_struct(structure_id, substitutions) => {
+                    let reachable_by_destructor =
+                        reachable_by_destructor ||
+                        ty::has_dtor(rcx.tcx(), structure_id);
+
+                    let fields =
+                        ty::lookup_struct_fields(rcx.tcx(),
+                                                 structure_id);
+                    for field in fields.iter() {
+                        let field_type =
+                            ty::lookup_field_type(rcx.tcx(),
+                                                  structure_id,
+                                                  field.id,
+                                                  substitutions);
+                        iterate_over_potentially_unsafe_regions_in_type(
+                            rcx,
+                            breadcrumbs,
+                            field_type,
+                            span,
+                            scope,
+                            reachable_by_destructor, depth+1)
+                    }
+
+                    false
+                }
+                ty::ty_enum(enumeration_id, substitutions) => {
+                    let reachable_by_destructor = reachable_by_destructor ||
+                        ty::has_dtor(rcx.tcx(), enumeration_id);
+
+                    let all_variant_info =
+                        ty::substd_enum_variants(rcx.tcx(),
+                                                 enumeration_id,
+                                                 substitutions);
+                    for variant_info in all_variant_info.iter() {
+                        for argument_type in variant_info.args.iter() {
+                            iterate_over_potentially_unsafe_regions_in_type(
+                                rcx,
+                                breadcrumbs,
+                                *argument_type,
+                                span,
+                                scope,
+                                reachable_by_destructor, depth+1)
+                        }
+                    }
+
+                    false
+                }
+                ty::ty_rptr(region, _) => {
+                    if reachable_by_destructor {
+                        constrain_region_for_destructor_safety(rcx,
+                                                               *region,
+                                                               scope,
+                                                               span)
+                    }
+                    // Don't recurse, since references do not own their
+                    // contents.
+                    false
+                }
+                ty::ty_unboxed_closure(..) => {
+                    true
+                }
+                ty::ty_trait(ref trait_type) => {
+                    if reachable_by_destructor {
+                        match trait_type.principal.substs().regions {
+                            subst::NonerasedRegions(ref regions) => {
+                                for region in regions.iter() {
+                                    constrain_region_for_destructor_safety(
+                                        rcx,
+                                        *region,
+                                        scope,
+                                        span)
+                                }
+                            }
+                            subst::ErasedRegions => {}
+                        }
+
+                        // FIXME (pnkfelix): Added by pnkfelix, but
+                        // need to double-check that this additional
+                        // constraint is necessary.
+                        constrain_region_for_destructor_safety(
+                            rcx,
+                            trait_type.bounds.region_bound,
+                            scope,
+                            span)
+                    }
+                    true
+                }
+                ty::ty_ptr(_) | ty::ty_bare_fn(..) => {
+                    // Don't recurse, since pointers, boxes, and bare
+                    // functions don't own instances of the types appearing
+                    // within them.
+                    false
+                }
+                ty::ty_bool | ty::ty_char | ty::ty_int(_) | ty::ty_uint(_) |
+                ty::ty_float(_) | ty::ty_uniq(_) | ty::ty_str |
+                ty::ty_vec(..) | ty::ty_tup(_) | ty::ty_param(_) |
+                ty::ty_infer(_) | ty::ty_open(_) | ty::ty_err => true,
+
+                ty::ty_projection(_) => {
+                    // We keep going, since we want to descend into
+                    // the substructure `Trait<..>` within the
+                    // projection `<T as Trait<..>>::N`.
+                    //
+                    // Furthermore, in the future, we are likely to
+                    // support higher-kinded projections (i.e. an
+                    // associated item that is parameterized over a
+                    // lifetime). When that is supported, we will need
+                    // to ensure that we constrain the input regions
+                    // accordingly (which might go here, or might end
+                    // up in some recursive part of the traversal).
+                    true
+                }
+            };
+
+            keep_going
+        })
+    });
+}

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -498,12 +498,14 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
                                                             trait_def_id);
 
         let trait_impls = self.tcx().trait_impls.borrow();
-        let impl_def_ids = match trait_impls.get(&trait_def_id) {
+        let impl_def_ids = trait_impls.get(&trait_def_id);
+        let impl_def_ids = match impl_def_ids {
             None => { return; }
             Some(impls) => impls,
         };
 
-        for &impl_def_id in impl_def_ids.borrow().iter() {
+        let impl_def_ids = impl_def_ids.borrow();
+        for &impl_def_id in impl_def_ids.iter() {
             debug!("assemble_extension_candidates_for_trait_impl: trait_def_id={} impl_def_id={}",
                    trait_def_id.repr(self.tcx()),
                    impl_def_id.repr(self.tcx()));
@@ -998,8 +1000,8 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
         // if there are any.
         assert_eq!(substs.types.len(subst::FnSpace), 0);
         assert_eq!(substs.regions().len(subst::FnSpace), 0);
-        let mut substs = substs;
         let placeholder;
+        let mut substs = substs;
         if
             !method.generics.types.is_empty_in(subst::FnSpace) ||
             !method.generics.regions.is_empty_in(subst::FnSpace)

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -90,7 +90,7 @@ use middle::lang_items::IteratorItem;
 use middle::mem_categorization as mc;
 use middle::mem_categorization::McResult;
 use middle::pat_util::{self, pat_id_map};
-use middle::region::CodeExtent;
+use middle::region::{self, CodeExtent};
 use middle::subst::{self, Subst, Substs, VecPerParamSpace, ParamSpace, TypeSpace};
 use middle::traits;
 use middle::ty::{FnSig, VariantInfo, TypeScheme};
@@ -478,7 +478,9 @@ fn check_bare_fn<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
             let fn_sig =
                 fn_ty.sig.subst(ccx.tcx, &inh.param_env.free_substs);
             let fn_sig =
-                liberate_late_bound_regions(ccx.tcx, CodeExtent::from_node_id(body.id), &fn_sig);
+                liberate_late_bound_regions(ccx.tcx,
+                                            CodeExtent::DestructionScope(body.id),
+                                            &fn_sig);
             let fn_sig =
                 inh.normalize_associated_types_in(&inh.param_env, body.span, body.id, &fn_sig);
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -90,7 +90,7 @@ use middle::lang_items::IteratorItem;
 use middle::mem_categorization as mc;
 use middle::mem_categorization::McResult;
 use middle::pat_util::{self, pat_id_map};
-use middle::region::{self, CodeExtent};
+use middle::region::{CodeExtent};
 use middle::subst::{self, Subst, Substs, VecPerParamSpace, ParamSpace, TypeSpace};
 use middle::traits;
 use middle::ty::{FnSig, VariantInfo, TypeScheme};

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -126,6 +126,7 @@ use syntax::ptr::P;
 use syntax::visit::{self, Visitor};
 
 mod assoc;
+pub mod dropck;
 pub mod _match;
 pub mod vtable;
 pub mod writeback;

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -90,7 +90,6 @@ use check::vtable;
 use middle::def;
 use middle::mem_categorization as mc;
 use middle::region::CodeExtent;
-use middle::subst;
 use middle::traits;
 use middle::ty::{ReScope};
 use middle::ty::{self, Ty, MethodCall};

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -22,7 +22,6 @@ use util::ppaux::Repr;
 use std::collections::HashSet;
 use syntax::ast;
 use syntax::ast_util::{local_def};
-use syntax::attr;
 use syntax::codemap::Span;
 use syntax::parse::token;
 use syntax::visit;

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -206,22 +206,6 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
                                                         &fcx.inh.param_env.free_substs,
                                                         &trait_ref);
 
-            // There are special rules that apply to drop.
-            if
-                fcx.tcx().lang_items.drop_trait() == Some(trait_ref.def_id) &&
-                !attr::contains_name(item.attrs.as_slice(), "unsafe_destructor")
-            {
-                match self_ty.sty {
-                    ty::ty_struct(def_id, _) |
-                    ty::ty_enum(def_id, _) => {
-                        check_struct_safe_for_destructor(fcx, item.span, def_id);
-                    }
-                    _ => {
-                        // Coherence already reports an error in this case.
-                    }
-                }
-            }
-
             if fcx.tcx().lang_items.copy_trait() == Some(trait_ref.def_id) {
                 // This is checked in coherence.
                 return
@@ -594,23 +578,4 @@ fn filter_to_trait_obligations<'tcx>(bounds: ty::GenericBounds<'tcx>)
         }
     }
     result
-}
-
-///////////////////////////////////////////////////////////////////////////
-// Special drop trait checking
-
-fn check_struct_safe_for_destructor<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
-                                              span: Span,
-                                              struct_did: ast::DefId) {
-    let struct_tpt = ty::lookup_item_type(fcx.tcx(), struct_did);
-    if struct_tpt.generics.has_type_params(subst::TypeSpace)
-        || struct_tpt.generics.has_region_params(subst::TypeSpace)
-    {
-        span_err!(fcx.tcx().sess, span, E0141,
-                  "cannot implement a destructor on a structure \
-                   with type parameters");
-        span_note!(fcx.tcx().sess, span,
-                   "use \"#[unsafe_destructor]\" on the implementation \
-                    to force the compiler to allow this");
-    }
 }

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -397,7 +397,8 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
             Some(found_impls) => found_impls
         };
 
-        for &impl_did in trait_impls.borrow().iter() {
+        let trait_impls = trait_impls.borrow();
+        for &impl_did in trait_impls.iter() {
             let items = &(*impl_items)[impl_did];
             if items.len() < 1 {
                 // We'll error out later. For now, just don't ICE.

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1547,7 +1547,7 @@ fn check_method_self_type<'a, 'tcx, RS:RegionScope>(
             _ => typ,
         };
 
-        let body_scope = region::CodeExtent::from_node_id(body_id);
+        let body_scope = region::CodeExtent::DestructionScope(body_id);
 
         // "Required type" comes from the trait definition. It may
         // contain late-bound regions from the method, but not the

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -300,9 +300,8 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
                                        "unsafe_destructor") {
                     self.gate_feature("unsafe_destructor",
                                       i.span,
-                                      "`#[unsafe_destructor]` allows too \
-                                       many unsafe patterns and may be \
-                                       removed in the future");
+                                      "`#[unsafe_destructor]` does nothing \
+                                       anymore")
                 }
 
                 if attr::contains_name(&i.attrs[],

--- a/src/test/auxiliary/issue-2631-a.rs
+++ b/src/test/auxiliary/issue-2631-a.rs
@@ -19,5 +19,6 @@ pub type header_map = HashMap<String, Rc<RefCell<Vec<Rc<String>>>>>;
 
 // the unused ty param is necessary so this gets monomorphized
 pub fn request<T>(req: &header_map) {
-  let _x = req["METHOD".to_string()].clone().borrow().clone()[0].clone();
+  let data = req["METHOD".to_string()].clone();
+  let _x = data.borrow().clone()[0].clone();
 }

--- a/src/test/compile-fail/destructor-restrictions.rs
+++ b/src/test/compile-fail/destructor-restrictions.rs
@@ -1,0 +1,21 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests the new destructor semantics.
+
+use std::cell::RefCell;
+
+fn main() {
+    let b = {
+        let a = box RefCell::new(4i);
+        *a.borrow() + 1i    //~ ERROR `*a` does not live long enough
+    };
+    println!("{}", b);
+}

--- a/src/test/run-pass/issue-13304.rs
+++ b/src/test/run-pass/issue-13304.rs
@@ -37,7 +37,8 @@ fn parent() {
 }
 
 fn child() {
-    for line in io::stdin().lock().lines() {
+    let mut stdin = io::stdin();
+    for line in stdin.lock().lines() {
         println!("{}", line.unwrap());
-    }
+    };
 }

--- a/src/test/run-pass/issue-14456.rs
+++ b/src/test/run-pass/issue-14456.rs
@@ -27,7 +27,8 @@ fn main() {
 fn child() {
     io::stdout().write_line("foo").unwrap();
     io::stderr().write_line("bar").unwrap();
-    assert_eq!(io::stdin().lock().read_line().err().unwrap().kind, io::EndOfFile);
+    let mut stdin = io::stdin();
+    assert_eq!(stdin.lock().read_line().err().unwrap().kind, io::EndOfFile);
 }
 
 fn test() {

--- a/src/test/run-pass/issue-3026.rs
+++ b/src/test/run-pass/issue-3026.rs
@@ -17,7 +17,7 @@ extern crate collections;
 use std::collections::HashMap;
 
 pub fn main() {
-    let mut buggy_map: HashMap<uint, &uint> = HashMap::new();
     let x = box 1;
+    let mut buggy_map: HashMap<uint, &uint> = HashMap::new();
     buggy_map.insert(42, &*x);
 }

--- a/src/test/run-pass/multidispatch-conditional-impl-not-considered.rs
+++ b/src/test/run-pass/multidispatch-conditional-impl-not-considered.rs
@@ -29,5 +29,5 @@ impl Bar {
 
 fn main() {
     let b = RefCell::new(Bar);
-    b.borrow().foo()
+    b.borrow().foo();
 }

--- a/src/test/run-pass/regions-refcell.rs
+++ b/src/test/run-pass/regions-refcell.rs
@@ -1,0 +1,36 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This is a regression test for something that only came up while
+// attempting to bootstrap librustc with new destructor lifetime
+// semantics.
+
+use std::collections::HashMap;
+use std::cell::RefCell;
+
+fn foo(map: RefCell<HashMap<&'static str, &[uint]>>) {
+    // assert_eq!(map.borrow().get("one"), Some(&1u));
+    let map = map.borrow();
+    for (i, &x) in map.get("one").unwrap().iter().enumerate() {
+        assert_eq!((i, x), (0u, 1u));
+    }
+}
+
+fn main() {
+    let zer = [0u];
+    let one = [1u];
+    let two = [2u];
+    let mut map = HashMap::new();
+    map.insert("zero", zer.as_slice());
+    map.insert("one",  one.as_slice());
+    map.insert("two",  two.as_slice());
+    let map = RefCell::new(map);
+    foo(map);
+}

--- a/src/test/run-pass/regions-trait-object-1.rs
+++ b/src/test/run-pass/regions-trait-object-1.rs
@@ -1,0 +1,43 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This is a regression test for something that only came up while
+// attempting to bootstrap libsyntax; it is adapted from
+// `syntax::ext::tt::generic_extension`.
+
+pub struct E<'a> {
+    pub f: &'a u8,
+}
+impl<'b> E<'b> {
+    pub fn m(&self) -> &'b u8 { self.f }
+}
+
+pub struct P<'c> {
+    pub g: &'c u8,
+}
+pub trait M {
+    fn n(&self) -> u8;
+}
+impl<'d> M for P<'d> {
+    fn n(&self) -> u8 { *self.g }
+}
+
+fn extension<'e>(x: &'e E<'e>) -> Box<M+'e> {
+    loop {
+        let p = P { g: x.m() };
+        return Box::new(p) as Box<M+'e>;
+    }
+}
+
+fn main() {
+    let w = E { f: &10u8 };
+    let o = extension(&w);
+    assert_eq!(o.n(), 10u8);
+}

--- a/src/test/run-pass/trait-object-with-lifetime-bound.rs
+++ b/src/test/run-pass/trait-object-with-lifetime-bound.rs
@@ -1,0 +1,42 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Uncovered during work on new scoping rules for safe destructors
+// as an important use case to support properly.
+
+pub struct E<'a> {
+    pub f: &'a u8,
+}
+impl<'b> E<'b> {
+    pub fn m(&self) -> &'b u8 { self.f }
+}
+
+pub struct P<'c> {
+    pub g: &'c u8,
+}
+pub trait M {
+    fn n(&self) -> u8;
+}
+impl<'d> M for P<'d> {
+    fn n(&self) -> u8 { *self.g }
+}
+
+fn extension<'e>(x: &'e E<'e>) -> Box<M+'e> {
+    loop {
+        let p = P { g: x.m() };
+        return Box::new(p) as Box<M+'e>;
+    }
+}
+
+fn main() {
+    let w = E { f: &10u8 };
+    let o = extension(&w);
+    assert_eq!(o.n(), 10u8);
+}


### PR DESCRIPTION
This is a resurrection and heavy revision/expansion of a PR that pcwalton did to resolve #8861.

The most relevant, user-visible semantic change is this: `#[unsafe_destructor]` is gone.  Instead, if a type expression for some value has a destructor, then any lifetimes referenced within that type expression must strictly outlive the scope of the value.

The kind of code that breaks is typically fixed by moving around bindings so that certain values (like arenas) live longer, like so:

```
         let mut forest = ast_map::Forest::new(expanded_crate);
+        let arenas = ty::CtxtArenas::new();
         let ast_map = assign_node_ids_and_map(&sess, &mut forest);

         write_out_deps(&sess, input, &outputs, &id[]);

-        let arenas = ty::CtxtArenas::new();
         let analysis = phase_3_run_analysis_passes(sess,
                                                    ast_map,
                                                    &arenas,
```

Another fun case is when you are swapping references: the finer grain scopes introduced by this PR require changes like this:

```
         };
         let mut matched = false;
         let ninsts = self.prog.insts.len();
-        let mut clist = &mut Threads::new(self.which, ninsts, ncaps);
-        let mut nlist = &mut Threads::new(self.which, ninsts, ncaps);
+        let mut cthread = Threads::new(self.which, ninsts, ncaps);
+        let mut nthread = Threads::new(self.which, ninsts, ncaps);
+        let mut clist = &mut cthread;
+        let mut nlist = &mut nthread;

         let mut groups: Vec<_> = repeat(None).take(ncaps * 2).collect();

```

[breaking-change]

Fix #8861 
