### PR TITLE
refactoring: Kill ref cycle in librustc trans

### DIFF
--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -269,7 +269,7 @@ impl<'a, 'tcx> Opt<'a, 'tcx> {
         }
     }
 
-    fn trans<'blk>(&self, mut bcx: Block<'blk, 'tcx>) -> OptResult<'blk, 'tcx> {
+    fn trans<'fcx, 'blk>(&self, mut bcx: Block<'fcx, 'blk, 'tcx>) -> OptResult<'fcx, 'blk, 'tcx> {
         let _icx = push_ctxt("match::trans_opt");
         let ccx = bcx.ccx();
         match *self {
@@ -307,10 +307,10 @@ pub enum BranchKind {
     CompareSliceLength
 }
 
-pub enum OptResult<'blk, 'tcx: 'blk> {
-    SingleResult(Result<'blk, 'tcx>),
-    RangeResult(Result<'blk, 'tcx>, Result<'blk, 'tcx>),
-    LowerBound(Result<'blk, 'tcx>)
+pub enum OptResult<'fcx, 'blk: 'fcx, 'tcx: 'blk> {
+    SingleResult(Result<'fcx, 'blk, 'tcx>),
+    RangeResult(Result<'fcx, 'blk, 'tcx>, Result<'fcx, 'blk, 'tcx>),
+    LowerBound(Result<'fcx, 'blk, 'tcx>)
 }
 
 #[derive(Clone, Copy)]
@@ -338,8 +338,8 @@ pub struct BindingInfo<'tcx> {
 
 type BindingsMap<'tcx> = FnvHashMap<Ident, BindingInfo<'tcx>>;
 
-struct ArmData<'p, 'blk, 'tcx: 'blk> {
-    bodycx: Block<'blk, 'tcx>,
+struct ArmData<'p, 'fcx, 'blk: 'fcx, 'tcx: 'blk> {
+    bodycx: Block<'fcx, 'blk, 'tcx>,
     arm: &'p ast::Arm,
     bindings_map: BindingsMap<'tcx>
 }
@@ -348,13 +348,13 @@ struct ArmData<'p, 'blk, 'tcx: 'blk> {
 /// If all `pats` are matched then arm `data` will be executed.
 /// As we proceed `bound_ptrs` are filled with pointers to values to be bound,
 /// these pointers are stored in llmatch variables just before executing `data` arm.
-struct Match<'a, 'p: 'a, 'blk: 'a, 'tcx: 'blk> {
+struct Match<'a, 'p: 'a, 'fcx: 'a, 'blk: 'fcx, 'tcx: 'blk> {
     pats: Vec<&'p ast::Pat>,
-    data: &'a ArmData<'p, 'blk, 'tcx>,
+    data: &'a ArmData<'p, 'fcx, 'blk, 'tcx>,
     bound_ptrs: Vec<(Ident, ValueRef)>,
 }
 
-impl<'a, 'p, 'blk, 'tcx> Repr<'tcx> for Match<'a, 'p, 'blk, 'tcx> {
+impl<'a, 'p, 'fcx, 'blk, 'tcx> Repr<'tcx> for Match<'a, 'p, 'fcx, 'blk, 'tcx> {
     fn repr(&self, tcx: &ty::ctxt) -> String {
         if tcx.sess.verbose() {
             // for many programs, this just take too long to serialize
@@ -375,11 +375,11 @@ fn has_nested_bindings(m: &[Match], col: uint) -> bool {
     return false;
 }
 
-fn expand_nested_bindings<'a, 'p, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
-                                              m: &[Match<'a, 'p, 'blk, 'tcx>],
+fn expand_nested_bindings<'a, 'p, 'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
+                                              m: &[Match<'a, 'p, 'fcx, 'blk, 'tcx>],
                                               col: uint,
                                               val: ValueRef)
-                                              -> Vec<Match<'a, 'p, 'blk, 'tcx>> {
+                                              -> Vec<Match<'a, 'p, 'fcx, 'blk, 'tcx>> {
     debug!("expand_nested_bindings(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -410,13 +410,13 @@ fn expand_nested_bindings<'a, 'p, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     }).collect()
 }
 
-fn enter_match<'a, 'b, 'p, 'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
+fn enter_match<'a, 'b, 'p, 'fcx, 'blk, 'tcx, F>(bcx: Block<'fcx, 'blk, 'tcx>,
                                           dm: &DefMap,
-                                          m: &[Match<'a, 'p, 'blk, 'tcx>],
+                                          m: &[Match<'a, 'p, 'fcx, 'blk, 'tcx>],
                                           col: uint,
                                           val: ValueRef,
                                           mut e: F)
-                                          -> Vec<Match<'a, 'p, 'blk, 'tcx>> where
+                                          -> Vec<Match<'a, 'p, 'fcx, 'blk, 'tcx>> where
     F: FnMut(&[&'p ast::Pat]) -> Option<Vec<&'p ast::Pat>>,
 {
     debug!("enter_match(bcx={}, m={}, col={}, val={})",
@@ -455,12 +455,12 @@ fn enter_match<'a, 'b, 'p, 'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
     }).collect()
 }
 
-fn enter_default<'a, 'p, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn enter_default<'a, 'p, 'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                      dm: &DefMap,
-                                     m: &[Match<'a, 'p, 'blk, 'tcx>],
+                                     m: &[Match<'a, 'p, 'fcx, 'blk, 'tcx>],
                                      col: uint,
                                      val: ValueRef)
-                                     -> Vec<Match<'a, 'p, 'blk, 'tcx>> {
+                                     -> Vec<Match<'a, 'p, 'fcx, 'blk, 'tcx>> {
     debug!("enter_default(bcx={}, m={}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -508,16 +508,16 @@ fn enter_default<'a, 'p, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 /// takes the complete row of patterns rather than just the first one.
 /// Also, most of the enter_() family functions have been unified with
 /// the check_match specialization step.
-fn enter_opt<'a, 'p, 'blk, 'tcx>(
-             bcx: Block<'blk, 'tcx>,
+fn enter_opt<'a, 'p, 'fcx, 'blk, 'tcx>(
+             bcx: Block<'fcx, 'blk, 'tcx>,
              _: ast::NodeId,
              dm: &DefMap,
-             m: &[Match<'a, 'p, 'blk, 'tcx>],
+             m: &[Match<'a, 'p, 'fcx, 'blk, 'tcx>],
              opt: &Opt,
              col: uint,
              variant_size: uint,
              val: ValueRef)
-             -> Vec<Match<'a, 'p, 'blk, 'tcx>> {
+             -> Vec<Match<'a, 'p, 'fcx, 'blk, 'tcx>> {
     debug!("enter_opt(bcx={}, m={}, opt={:?}, col={}, val={})",
            bcx.to_str(),
            m.repr(bcx.tcx()),
@@ -555,8 +555,8 @@ fn enter_opt<'a, 'p, 'blk, 'tcx>(
 // Returns the options in one column of matches. An option is something that
 // needs to be conditionally matched at runtime; for example, the discriminant
 // on a set of enum variants or a literal.
-fn get_branches<'a, 'p, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
-                                    m: &[Match<'a, 'p, 'blk, 'tcx>], col: uint)
+fn get_branches<'a, 'p, 'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
+                                    m: &[Match<'a, 'p, 'fcx, 'blk, 'tcx>], col: uint)
                                     -> Vec<Opt<'p, 'tcx>> {
     let tcx = bcx.tcx();
 
@@ -595,16 +595,16 @@ fn get_branches<'a, 'p, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     found
 }
 
-struct ExtractedBlock<'blk, 'tcx: 'blk> {
+struct ExtractedBlock<'fcx, 'blk: 'fcx, 'tcx: 'blk> {
     vals: Vec<ValueRef>,
-    bcx: Block<'blk, 'tcx>,
+    bcx: Block<'fcx, 'blk, 'tcx>,
 }
 
-fn extract_variant_args<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn extract_variant_args<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                     repr: &adt::Repr<'tcx>,
                                     disr_val: ty::Disr,
                                     val: ValueRef)
-                                    -> ExtractedBlock<'blk, 'tcx> {
+                                    -> ExtractedBlock<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("match::extract_variant_args");
     let args = range(0, adt::num_args(repr, disr_val)).map(|i| {
         adt::trans_field_ptr(bcx, repr, val, disr_val, i)
@@ -643,12 +643,12 @@ fn bind_subslice_pat(bcx: Block,
     scratch.val
 }
 
-fn extract_vec_elems<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn extract_vec_elems<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                  left_ty: Ty,
                                  before: uint,
                                  after: uint,
                                  val: ValueRef)
-                                 -> ExtractedBlock<'blk, 'tcx> {
+                                 -> ExtractedBlock<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("match::extract_vec_elems");
     let vec_datum = match_datum(val, left_ty);
     let (base, len) = vec_datum.get_vec_base_and_len(bcx);
@@ -776,16 +776,16 @@ fn pick_column_to_specialize(def_map: &DefMap, m: &[Match]) -> Option<uint> {
 }
 
 // Compiles a comparison between two things.
-fn compare_values<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
+fn compare_values<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
                               lhs: ValueRef,
                               rhs: ValueRef,
                               rhs_t: Ty<'tcx>)
-                              -> Result<'blk, 'tcx> {
-    fn compare_str<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
+                              -> Result<'fcx, 'blk, 'tcx> {
+    fn compare_str<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
                                lhs: ValueRef,
                                rhs: ValueRef,
                                rhs_t: Ty<'tcx>)
-                               -> Result<'blk, 'tcx> {
+                               -> Result<'fcx, 'blk, 'tcx> {
         let did = langcall(cx,
                            None,
                            &format!("comparison of `{}`",
@@ -823,10 +823,10 @@ fn compare_values<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
 }
 
 /// For each binding in `data.bindings_map`, adds an appropriate entry into the `fcx.lllocals` map
-fn insert_lllocals<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
+fn insert_lllocals<'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>,
                                bindings_map: &BindingsMap<'tcx>,
                                cs: Option<cleanup::ScopeId>)
-                               -> Block<'blk, 'tcx> {
+                               -> Block<'fcx, 'blk, 'tcx> {
     for (&ident, &binding_info) in bindings_map.iter() {
         let llval = match binding_info.trmode {
             // By value mut binding for a copy type: load from the ptr
@@ -863,14 +863,14 @@ fn insert_lllocals<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
     bcx
 }
 
-fn compile_guard<'a, 'p, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn compile_guard<'a, 'p, 'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                      guard_expr: &ast::Expr,
-                                     data: &ArmData<'p, 'blk, 'tcx>,
-                                     m: &[Match<'a, 'p, 'blk, 'tcx>],
+                                     data: &ArmData<'p, 'fcx, 'blk, 'tcx>,
+                                     m: &[Match<'a, 'p, 'fcx, 'blk, 'tcx>],
                                      vals: &[ValueRef],
                                      chk: &FailureHandler,
                                      has_genuine_default: bool)
-                                     -> Block<'blk, 'tcx> {
+                                     -> Block<'fcx, 'blk, 'tcx> {
     debug!("compile_guard(bcx={}, guard_expr={}, m={}, vals={})",
            bcx.to_str(),
            bcx.expr_to_string(guard_expr),
@@ -910,8 +910,8 @@ fn compile_guard<'a, 'p, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     })
 }
 
-fn compile_submatch<'a, 'p, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
-                                        m: &[Match<'a, 'p, 'blk, 'tcx>],
+fn compile_submatch<'a, 'p, 'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
+                                        m: &[Match<'a, 'p, 'fcx, 'blk, 'tcx>],
                                         vals: &[ValueRef],
                                         chk: &FailureHandler,
                                         has_genuine_default: bool) {
@@ -966,13 +966,13 @@ fn compile_submatch<'a, 'p, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                 }
                 _ => ()
             }
-            Br(bcx, data.bodycx.llbb);
+            Br(bcx, data.bodycx.data.llbb);
         }
     }
 }
 
-fn compile_submatch_continue<'a, 'p, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
-                                                 m: &[Match<'a, 'p, 'blk, 'tcx>],
+fn compile_submatch_continue<'a, 'p, 'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>,
+                                                 m: &[Match<'a, 'p, 'fcx, 'blk, 'tcx>],
                                                  vals: &[ValueRef],
                                                  chk: &FailureHandler,
                                                  col: uint,
@@ -1076,7 +1076,7 @@ fn compile_submatch_continue<'a, 'p, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         _ => bcx.fcx.new_temp_block("match_else")
     };
     let sw = if kind == Switch {
-        build::Switch(bcx, test_val, else_cx.llbb, opts.len())
+        build::Switch(bcx, test_val, else_cx.data.llbb, opts.len())
     } else {
         C_int(ccx, 0i) // Placeholder for when not using a switch
     };
@@ -1096,11 +1096,11 @@ fn compile_submatch_continue<'a, 'p, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         if !exhaustive || i + 1 < len {
             opt_cx = bcx.fcx.new_temp_block("match_case");
             match kind {
-                Single => Br(bcx, opt_cx.llbb),
+                Single => Br(bcx, opt_cx.data.llbb),
                 Switch => {
                     match opt.trans(bcx) {
                         SingleResult(r) => {
-                            AddCase(sw, r.val, opt_cx.llbb);
+                            AddCase(sw, r.val, opt_cx.data.llbb);
                             bcx = r.bcx;
                         }
                         _ => {
@@ -1147,14 +1147,14 @@ fn compile_submatch_continue<'a, 'p, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                     let guarded = m[i].data.arm.guard.is_some();
                     let multi_pats = m[i].pats.len() > 1;
                     if i + 1 < len && (guarded || multi_pats || kind == CompareSliceLength) {
-                        branch_chk = Some(JumpToBasicBlock(bcx.llbb));
+                        branch_chk = Some(JumpToBasicBlock(bcx.data.llbb));
                     }
-                    CondBr(after_cx, matches, opt_cx.llbb, bcx.llbb);
+                    CondBr(after_cx, matches, opt_cx.data.llbb, bcx.data.llbb);
                 }
                 _ => ()
             }
         } else if kind == Compare || kind == CompareSliceLength {
-            Br(bcx, else_cx.llbb);
+            Br(bcx, else_cx.data.llbb);
         }
 
         let mut size = 0u;
@@ -1194,7 +1194,7 @@ fn compile_submatch_continue<'a, 'p, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
     // Compile the fall-through case, if any
     if !exhaustive && kind != Single {
         if kind == Compare || kind == CompareSliceLength {
-            Br(bcx, else_cx.llbb);
+            Br(bcx, else_cx.data.llbb);
         }
         match chk {
             // If there is only one default arm left, move on to the next
@@ -1214,12 +1214,12 @@ fn compile_submatch_continue<'a, 'p, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
     }
 }
 
-pub fn trans_match<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_match<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                match_expr: &ast::Expr,
                                discr_expr: &ast::Expr,
                                arms: &[ast::Arm],
                                dest: Dest)
-                               -> Block<'blk, 'tcx> {
+                               -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("match::trans_match");
     trans_match_inner(bcx, match_expr.id, discr_expr, arms, dest)
 }
@@ -1254,7 +1254,7 @@ fn is_discr_reassigned(bcx: Block, discr: &ast::Expr, body: &ast::Expr) -> bool 
         reassigned: false
     };
     {
-        let mut visitor = euv::ExprUseVisitor::new(&mut rc, bcx);
+        let mut visitor = euv::ExprUseVisitor::new(&mut rc, &bcx);
         visitor.walk_expr(body);
     }
     rc.reassigned
@@ -1296,7 +1296,7 @@ impl<'tcx> euv::Delegate<'tcx> for ReassignmentChecker {
     }
 }
 
-fn create_bindings_map<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, pat: &ast::Pat,
+fn create_bindings_map<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, pat: &ast::Pat,
                                    discr: &ast::Expr, body: &ast::Expr)
                                    -> BindingsMap<'tcx> {
     // Create the bindings map, which is a mapping from each binding name
@@ -1354,11 +1354,11 @@ fn create_bindings_map<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, pat: &ast::Pat,
     return bindings_map;
 }
 
-fn trans_match_inner<'blk, 'tcx>(scope_cx: Block<'blk, 'tcx>,
+fn trans_match_inner<'fcx, 'blk, 'tcx>(scope_cx: Block<'fcx, 'blk, 'tcx>,
                                  match_id: ast::NodeId,
                                  discr_expr: &ast::Expr,
                                  arms: &[ast::Arm],
-                                 dest: Dest) -> Block<'blk, 'tcx> {
+                                 dest: Dest) -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("match::trans_match_inner");
     let fcx = scope_cx.fcx;
     let mut bcx = scope_cx;
@@ -1366,7 +1366,7 @@ fn trans_match_inner<'blk, 'tcx>(scope_cx: Block<'blk, 'tcx>,
 
     let discr_datum = unpack_datum!(bcx, expr::trans_to_lvalue(bcx, discr_expr,
                                                                "match"));
-    if bcx.unreachable.get() {
+    if bcx.data.unreachable.get() {
         return bcx;
     }
 
@@ -1427,17 +1427,17 @@ fn trans_match_inner<'blk, 'tcx>(scope_cx: Block<'blk, 'tcx>,
 
 /// Generates code for a local variable declaration like `let <pat>;` or `let <pat> =
 /// <opt_init_expr>`.
-pub fn store_local<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn store_local<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                local: &ast::Local)
-                               -> Block<'blk, 'tcx> {
+                               -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("match::store_local");
     let mut bcx = bcx;
     let tcx = bcx.tcx();
     let pat = &*local.pat;
 
-    fn create_dummy_locals<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
+    fn create_dummy_locals<'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>,
                                        pat: &ast::Pat)
-                                       -> Block<'blk, 'tcx> {
+                                       -> Block<'fcx, 'blk, 'tcx> {
         // create dummy memory for the variables if we have no
         // value to store into them immediately
         let tcx = bcx.tcx();
@@ -1499,11 +1499,11 @@ pub fn store_local<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 /// - `llval` is a pointer to the argument value (in other words,
 ///   if the argument type is `T`, then `llval` is a `T*`). In some
 ///   cases, this code may zero out the memory `llval` points at.
-pub fn store_arg<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
+pub fn store_arg<'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>,
                              pat: &ast::Pat,
                              arg: Datum<'tcx, Rvalue>,
                              arg_scope: cleanup::ScopeId)
-                             -> Block<'blk, 'tcx> {
+                             -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("match::store_arg");
 
     match simple_identifier(&*pat) {
@@ -1539,11 +1539,11 @@ pub fn store_arg<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
 
 /// Generates code for the pattern binding in a `for` loop like
 /// `for <pat> in <expr> { ... }`.
-pub fn store_for_loop_binding<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn store_for_loop_binding<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                           pat: &ast::Pat,
                                           llvalue: ValueRef,
                                           body_scope: cleanup::ScopeId)
-                                          -> Block<'blk, 'tcx> {
+                                          -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("match::store_for_loop_binding");
 
     if simple_identifier(&*pat).is_some() &&
@@ -1562,14 +1562,15 @@ pub fn store_for_loop_binding<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     bind_irrefutable_pat(bcx, pat, llvalue, body_scope)
 }
 
-fn mk_binding_alloca<'blk, 'tcx, A, F>(bcx: Block<'blk, 'tcx>,
+fn mk_binding_alloca<'fcx, 'blk, 'tcx, A, F>(bcx: Block<'fcx, 'blk, 'tcx>,
                                        p_id: ast::NodeId,
                                        ident: &ast::Ident,
                                        cleanup_scope: cleanup::ScopeId,
                                        arg: A,
                                        populate: F)
-                                       -> Block<'blk, 'tcx> where
-    F: FnOnce(A, Block<'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'blk, 'tcx>,
+                                       -> Block<'fcx, 'blk, 'tcx> where
+    F: FnOnce(A, Block<'fcx, 'blk, 'tcx>, ValueRef, Ty<'tcx>)
+              -> Block<'fcx, 'blk, 'tcx>,
 {
     let var_ty = node_id_type(bcx, p_id);
 
@@ -1601,11 +1602,11 @@ fn mk_binding_alloca<'blk, 'tcx, A, F>(bcx: Block<'blk, 'tcx>,
 /// - bcx: starting basic block context
 /// - pat: the irrefutable pattern being matched.
 /// - val: the value being matched -- must be an lvalue (by ref, with cleanup)
-fn bind_irrefutable_pat<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn bind_irrefutable_pat<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                     pat: &ast::Pat,
                                     val: ValueRef,
                                     cleanup_scope: cleanup::ScopeId)
-                                    -> Block<'blk, 'tcx> {
+                                    -> Block<'fcx, 'blk, 'tcx> {
     debug!("bind_irrefutable_pat(bcx={}, pat={})",
            bcx.to_str(),
            pat.repr(bcx.tcx()));

--- a/src/librustc_trans/trans/adt.rs
+++ b/src/librustc_trans/trans/adt.rs
@@ -931,8 +931,9 @@ pub fn trans_field_ptr<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, r: &Repr<
     }
 }
 
-pub fn struct_field_ptr<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, st: &Struct<'tcx>, val: ValueRef,
-                                    ix: uint, needs_cast: bool) -> ValueRef {
+pub fn struct_field_ptr<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
+                                          st: &Struct<'tcx>, val: ValueRef,
+                                          ix: uint, needs_cast: bool) -> ValueRef {
     let val = if needs_cast {
         let ccx = bcx.ccx();
         let fields = st.fields.iter().map(|&ty| type_of::type_of(ccx, ty)).collect::<Vec<_>>();
@@ -946,10 +947,10 @@ pub fn struct_field_ptr<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, st: &Str
 }
 
 pub fn fold_variants<'fcx, 'blk, 'tcx, F>(bcx: Block<'fcx, 'blk, 'tcx>,
-                                    r: &Repr<'tcx>,
-                                    value: ValueRef,
-                                    mut f: F)
-                                    -> Block<'fcx, 'blk, 'tcx> where
+                                          r: &Repr<'tcx>,
+                                          value: ValueRef,
+                                          mut f: F)
+                                          -> Block<'fcx, 'blk, 'tcx> where
     F: FnMut(Block<'fcx, 'blk, 'tcx>, &Struct<'tcx>, ValueRef) -> Block<'fcx, 'blk, 'tcx>,
 {
     let fcx = bcx.fcx;
@@ -989,8 +990,10 @@ pub fn fold_variants<'fcx, 'blk, 'tcx, F>(bcx: Block<'fcx, 'blk, 'tcx>,
 }
 
 /// Access the struct drop flag, if present.
-pub fn trans_drop_flag_ptr<'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>, r: &Repr<'tcx>, val: ValueRef)
-                                       -> datum::DatumBlock<'fcx, 'blk, 'tcx, datum::Expr> {
+pub fn trans_drop_flag_ptr<'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>,
+                                             r: &Repr<'tcx>,
+                                             val: ValueRef)
+                                             -> datum::DatumBlock<'fcx, 'blk, 'tcx, datum::Expr> {
     let tcx = bcx.tcx();
     let ptr_ty = ty::mk_imm_ptr(bcx.tcx(), tcx.types.bool);
     match *r {

--- a/src/librustc_trans/trans/asm.rs
+++ b/src/librustc_trans/trans/asm.rs
@@ -25,8 +25,8 @@ use std::ffi::CString;
 use libc::{c_uint, c_char};
 
 // Take an inline assembly expression and splat it out via LLVM
-pub fn trans_inline_asm<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, ia: &ast::InlineAsm)
-                                    -> Block<'blk, 'tcx> {
+pub fn trans_inline_asm<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, ia: &ast::InlineAsm)
+                                    -> Block<'fcx, 'blk, 'tcx> {
     let fcx = bcx.fcx;
     let mut bcx = bcx;
     let mut constraints = Vec::new();

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1056,7 +1056,10 @@ pub fn load_ty<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
 
 /// Helper for storing values in memory. Does the necessary conversion if the in-memory type
 /// differs from the type used for SSA values.
-pub fn store_ty<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>, v: ValueRef, dst: ValueRef, t: Ty<'tcx>) {
+pub fn store_ty<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
+                                  v: ValueRef,
+                                  dst: ValueRef,
+                                  t: Ty<'tcx>) {
     if ty::type_is_bool(t) {
         Store(cx, ZExt(cx, v, Type::i8(cx.ccx())), dst);
     } else if type_is_immediate(cx.ccx(), t) && type_of::type_of(cx.ccx(), t).is_aggregate() {
@@ -1195,7 +1198,9 @@ fn memzero<'a, 'tcx>(b: &Builder<'a, 'tcx>, llptr: ValueRef, ty: Ty<'tcx>) {
     b.call(llintrinsicfn, &[llptr, llzeroval, size, align, volatile], None);
 }
 
-pub fn alloc_ty<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, t: Ty<'tcx>, name: &str) -> ValueRef {
+pub fn alloc_ty<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
+                                  t: Ty<'tcx>,
+                                  name: &str) -> ValueRef {
     let _icx = push_ctxt("alloc_ty");
     let ccx = bcx.ccx();
     let ty = type_of::type_of(ccx, t);

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -365,7 +365,7 @@ pub fn get_extern_const<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, did: ast::DefId,
 // Returns a pointer to the body for the box. The box may be an opaque
 // box. The result will be casted to the type of body_t, if it is statically
 // known.
-pub fn at_box_body<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn at_box_body<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                body_t: Ty<'tcx>, boxptr: ValueRef) -> ValueRef {
     let _icx = push_ctxt("at_box_body");
     let ccx = bcx.ccx();
@@ -374,7 +374,7 @@ pub fn at_box_body<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     GEPi(bcx, boxptr, &[0u, abi::BOX_FIELD_BODY])
 }
 
-fn require_alloc_fn<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn require_alloc_fn<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                 info_ty: Ty<'tcx>, it: LangItem) -> ast::DefId {
     match bcx.tcx().lang_items.require(it) {
         Ok(id) => id,
@@ -389,12 +389,12 @@ fn require_alloc_fn<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 // The following malloc_raw_dyn* functions allocate a box to contain
 // a given type, but with a potentially dynamic size.
 
-pub fn malloc_raw_dyn<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn malloc_raw_dyn<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                   llty_ptr: Type,
                                   info_ty: Ty<'tcx>,
                                   size: ValueRef,
                                   align: ValueRef)
-                                  -> Result<'blk, 'tcx> {
+                                  -> Result<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("malloc_raw_exchange");
 
     // Allocate space:
@@ -548,12 +548,12 @@ pub fn get_res_dtor<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 #[derive(Copy)]
 pub enum scalar_type { nil_type, signed_int, unsigned_int, floating_point, }
 
-pub fn compare_scalar_types<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
+pub fn compare_scalar_types<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
                                         lhs: ValueRef,
                                         rhs: ValueRef,
                                         t: Ty<'tcx>,
                                         op: ast::BinOp)
-                                        -> Result<'blk, 'tcx> {
+                                        -> Result<'fcx, 'blk, 'tcx> {
     let f = |&: a| Result::new(cx, compare_scalar_values(cx, lhs, rhs, a, op));
 
     match t.sty {
@@ -569,7 +569,7 @@ pub fn compare_scalar_types<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
 
 
 // A helper function to do the actual comparison of scalar values.
-pub fn compare_scalar_values<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
+pub fn compare_scalar_values<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
                                          lhs: ValueRef,
                                          rhs: ValueRef,
                                          nt: scalar_type,
@@ -629,8 +629,8 @@ pub fn compare_scalar_values<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
     }
 }
 
-pub fn compare_simd_types<'blk, 'tcx>(
-                    cx: Block<'blk, 'tcx>,
+pub fn compare_simd_types<'fcx, 'blk, 'tcx>(
+                    cx: Block<'fcx, 'blk, 'tcx>,
                     lhs: ValueRef,
                     rhs: ValueRef,
                     t: Ty<'tcx>,
@@ -668,23 +668,23 @@ pub fn compare_simd_types<'blk, 'tcx>(
 }
 
 // Iterates through the elements of a structural type.
-pub fn iter_structural_ty<'blk, 'tcx, F>(cx: Block<'blk, 'tcx>,
+pub fn iter_structural_ty<'fcx, 'blk, 'tcx, F>(cx: Block<'fcx, 'blk, 'tcx>,
                                          av: ValueRef,
                                          t: Ty<'tcx>,
                                          mut f: F)
-                                         -> Block<'blk, 'tcx> where
-    F: FnMut(Block<'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'blk, 'tcx>,
+                                         -> Block<'fcx, 'blk, 'tcx> where
+    F: FnMut(Block<'fcx, 'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'fcx, 'blk, 'tcx>,
 {
     let _icx = push_ctxt("iter_structural_ty");
 
-    fn iter_variant<'blk, 'tcx, F>(cx: Block<'blk, 'tcx>,
+    fn iter_variant<'fcx, 'blk, 'tcx, F>(cx: Block<'fcx, 'blk, 'tcx>,
                                    repr: &adt::Repr<'tcx>,
                                    av: ValueRef,
                                    variant: &ty::VariantInfo<'tcx>,
                                    substs: &subst::Substs<'tcx>,
                                    f: &mut F)
-                                   -> Block<'blk, 'tcx> where
-        F: FnMut(Block<'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'blk, 'tcx>,
+                                   -> Block<'fcx, 'blk, 'tcx> where
+        F: FnMut(Block<'fcx, 'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'fcx, 'blk, 'tcx>,
     {
         let _icx = push_ctxt("iter_variant");
         let tcx = cx.tcx();
@@ -768,7 +768,7 @@ pub fn iter_structural_ty<'blk, 'tcx, F>(cx: Block<'blk, 'tcx>,
                   cx = f(cx, lldiscrim_a, cx.tcx().types.int);
                   let unr_cx = fcx.new_temp_block("enum-iter-unr");
                   Unreachable(unr_cx);
-                  let llswitch = Switch(cx, lldiscrim_a, unr_cx.llbb,
+                  let llswitch = Switch(cx, lldiscrim_a, unr_cx.data.llbb,
                                         n_variants);
                   let next_cx = fcx.new_temp_block("enum-iter-next");
 
@@ -780,7 +780,7 @@ pub fn iter_structural_ty<'blk, 'tcx, F>(cx: Block<'blk, 'tcx>,
                               []);
                       match adt::trans_case(cx, &*repr, variant.disr_val) {
                           _match::SingleResult(r) => {
-                              AddCase(llswitch, r.val, variant_cx.llbb)
+                              AddCase(llswitch, r.val, variant_cx.data.llbb)
                           }
                           _ => ccx.sess().unimpl("value from adt::trans_case \
                                                   in iter_structural_ty")
@@ -792,7 +792,7 @@ pub fn iter_structural_ty<'blk, 'tcx, F>(cx: Block<'blk, 'tcx>,
                                        &**variant,
                                        substs,
                                        &mut f);
-                      Br(variant_cx, next_cx.llbb);
+                      Br(variant_cx, next_cx.data.llbb);
                   }
                   cx = next_cx;
               }
@@ -856,14 +856,14 @@ pub fn cast_shift_rhs<F, G>(op: ast::BinOp,
     }
 }
 
-pub fn fail_if_zero_or_overflows<'blk, 'tcx>(
-                                cx: Block<'blk, 'tcx>,
+pub fn fail_if_zero_or_overflows<'fcx, 'blk, 'tcx>(
+                                cx: Block<'fcx, 'blk, 'tcx>,
                                 span: Span,
                                 divrem: ast::BinOp,
                                 lhs: ValueRef,
                                 rhs: ValueRef,
                                 rhs_t: Ty<'tcx>)
-                                -> Block<'blk, 'tcx> {
+                                -> Block<'fcx, 'blk, 'tcx> {
     let (zero_text, overflow_text) = if divrem == ast::BiDiv {
         ("attempted to divide by zero",
          "attempted to divide with overflow")
@@ -953,20 +953,20 @@ pub fn trans_external_path<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     }
 }
 
-pub fn invoke<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn invoke<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                           llfn: ValueRef,
                           llargs: &[ValueRef],
                           fn_ty: Ty<'tcx>,
                           call_info: Option<NodeInfo>)
-                          -> (ValueRef, Block<'blk, 'tcx>) {
+                          -> (ValueRef, Block<'fcx, 'blk, 'tcx>) {
     let _icx = push_ctxt("invoke_");
-    if bcx.unreachable.get() {
+    if bcx.data.unreachable.get() {
         return (C_null(Type::i8(bcx.ccx())), bcx);
     }
 
     let attributes = get_fn_llvm_attributes(bcx.ccx(), fn_ty);
 
-    match bcx.opt_node_id {
+    match bcx.data.opt_node_id {
         None => {
             debug!("invoke at ???");
         }
@@ -976,7 +976,7 @@ pub fn invoke<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     }
 
     if need_invoke(bcx) {
-        debug!("invoking {} at {:?}", bcx.val_to_string(llfn), bcx.llbb);
+        debug!("invoking {} at {:?}", bcx.val_to_string(llfn), bcx.data.llbb);
         for &llarg in llargs.iter() {
             debug!("arg: {}", bcx.val_to_string(llarg));
         }
@@ -991,12 +991,12 @@ pub fn invoke<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         let llresult = Invoke(bcx,
                               llfn,
                               &llargs[],
-                              normal_bcx.llbb,
+                              normal_bcx.data.llbb,
                               landing_pad,
                               Some(attributes));
         return (llresult, normal_bcx);
     } else {
-        debug!("calling {} at {:?}", bcx.val_to_string(llfn), bcx.llbb);
+        debug!("calling {} at {:?}", bcx.val_to_string(llfn), bcx.data.llbb);
         for &llarg in llargs.iter() {
             debug!("arg: {}", bcx.val_to_string(llarg));
         }
@@ -1017,14 +1017,14 @@ pub fn need_invoke(bcx: Block) -> bool {
     }
 
     // Avoid using invoke if we are already inside a landing pad.
-    if bcx.is_lpad {
+    if bcx.data.is_lpad {
         return false;
     }
 
     bcx.fcx.needs_invoke()
 }
 
-pub fn load_if_immediate<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
+pub fn load_if_immediate<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
                                      v: ValueRef, t: Ty<'tcx>) -> ValueRef {
     let _icx = push_ctxt("load_if_immediate");
     if type_is_immediate(cx.ccx(), t) { return load_ty(cx, v, t); }
@@ -1034,8 +1034,8 @@ pub fn load_if_immediate<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
 /// Helper for loading values from memory. Does the necessary conversion if the in-memory type
 /// differs from the type used for SSA values. Also handles various special cases where the type
 /// gives us better information about what we are loading.
-pub fn load_ty<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
-                           ptr: ValueRef, t: Ty<'tcx>) -> ValueRef {
+pub fn load_ty<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
+                                 ptr: ValueRef, t: Ty<'tcx>) -> ValueRef {
     if type_is_zero_size(cx.ccx(), t) {
         C_undef(type_of::type_of(cx.ccx(), t))
     } else if ty::type_is_bool(t) {
@@ -1056,7 +1056,7 @@ pub fn load_ty<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
 
 /// Helper for storing values in memory. Does the necessary conversion if the in-memory type
 /// differs from the type used for SSA values.
-pub fn store_ty<'blk, 'tcx>(cx: Block<'blk, 'tcx>, v: ValueRef, dst: ValueRef, t: Ty<'tcx>) {
+pub fn store_ty<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>, v: ValueRef, dst: ValueRef, t: Ty<'tcx>) {
     if ty::type_is_bool(t) {
         Store(cx, ZExt(cx, v, Type::i8(cx.ccx())), dst);
     } else if type_is_immediate(cx.ccx(), t) && type_of::type_of(cx.ccx(), t).is_aggregate() {
@@ -1069,35 +1069,35 @@ pub fn store_ty<'blk, 'tcx>(cx: Block<'blk, 'tcx>, v: ValueRef, dst: ValueRef, t
     };
 }
 
-pub fn init_local<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, local: &ast::Local)
-                              -> Block<'blk, 'tcx> {
+pub fn init_local<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, local: &ast::Local)
+                                    -> Block<'fcx, 'blk, 'tcx> {
     debug!("init_local(bcx={}, local.id={})", bcx.to_str(), local.id);
     let _indenter = indenter();
     let _icx = push_ctxt("init_local");
     _match::store_local(bcx, local)
 }
 
-pub fn raw_block<'blk, 'tcx>(fcx: &'blk FunctionContext<'blk, 'tcx>,
+pub fn raw_block<'fcx, 'blk, 'tcx>(fcx: &'fcx FunctionContext<'blk, 'tcx>,
                              is_lpad: bool,
                              llbb: BasicBlockRef)
-                             -> Block<'blk, 'tcx> {
+                             -> Block<'fcx, 'blk, 'tcx> {
     common::BlockS::new(llbb, is_lpad, None, fcx)
 }
 
-pub fn with_cond<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
+pub fn with_cond<'fcx, 'blk, 'tcx, F>(bcx: Block<'fcx, 'blk, 'tcx>,
                                 val: ValueRef,
                                 f: F)
-                                -> Block<'blk, 'tcx> where
-    F: FnOnce(Block<'blk, 'tcx>) -> Block<'blk, 'tcx>,
+                                -> Block<'fcx, 'blk, 'tcx> where
+    F: FnOnce(Block<'fcx, 'blk, 'tcx>) -> Block<'fcx, 'blk, 'tcx>,
 {
     let _icx = push_ctxt("with_cond");
     let fcx = bcx.fcx;
     let next_cx = fcx.new_temp_block("next");
     let cond_cx = fcx.new_temp_block("cond");
-    CondBr(bcx, val, cond_cx.llbb, next_cx.llbb);
+    CondBr(bcx, val, cond_cx.data.llbb, next_cx.data.llbb);
     let after_cx = f(cond_cx);
-    if !after_cx.terminated.get() {
-        Br(after_cx, next_cx.llbb);
+    if !after_cx.data.terminated.get() {
+        Br(after_cx, next_cx.data.llbb);
     }
     next_cx
 }
@@ -1147,7 +1147,7 @@ pub fn call_memcpy(cx: Block, dst: ValueRef, src: ValueRef, n_bytes: ValueRef, a
     Call(cx, memcpy, &[dst_ptr, src_ptr, size, align, volatile], None);
 }
 
-pub fn memcpy_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn memcpy_ty<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                              dst: ValueRef, src: ValueRef,
                              t: Ty<'tcx>) {
     let _icx = push_ctxt("memcpy_ty");
@@ -1162,8 +1162,8 @@ pub fn memcpy_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     }
 }
 
-pub fn zero_mem<'blk, 'tcx>(cx: Block<'blk, 'tcx>, llptr: ValueRef, t: Ty<'tcx>) {
-    if cx.unreachable.get() { return; }
+pub fn zero_mem<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>, llptr: ValueRef, t: Ty<'tcx>) {
+    if cx.data.unreachable.get() { return; }
     let _icx = push_ctxt("zero_mem");
     let bcx = cx;
     memzero(&B(bcx), llptr, t);
@@ -1195,7 +1195,7 @@ fn memzero<'a, 'tcx>(b: &Builder<'a, 'tcx>, llptr: ValueRef, ty: Ty<'tcx>) {
     b.call(llintrinsicfn, &[llptr, llzeroval, size, align, volatile], None);
 }
 
-pub fn alloc_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, name: &str) -> ValueRef {
+pub fn alloc_ty<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, t: Ty<'tcx>, name: &str) -> ValueRef {
     let _icx = push_ctxt("alloc_ty");
     let ccx = bcx.ccx();
     let ty = type_of::type_of(ccx, t);
@@ -1212,7 +1212,7 @@ pub fn alloca(cx: Block, ty: Type, name: &str) -> ValueRef {
 
 pub fn alloca_no_lifetime(cx: Block, ty: Type, name: &str) -> ValueRef {
     let _icx = push_ctxt("alloca");
-    if cx.unreachable.get() {
+    if cx.data.unreachable.get() {
         unsafe {
             return llvm::LLVMGetUndef(ty.ptr_to().to_ref());
         }
@@ -1221,10 +1221,10 @@ pub fn alloca_no_lifetime(cx: Block, ty: Type, name: &str) -> ValueRef {
     Alloca(cx, ty, name)
 }
 
-pub fn alloca_zeroed<'blk, 'tcx>(cx: Block<'blk, 'tcx>, ty: Ty<'tcx>,
+pub fn alloca_zeroed<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>, ty: Ty<'tcx>,
                                  name: &str) -> ValueRef {
     let llty = type_of::type_of(cx.ccx(), ty);
-    if cx.unreachable.get() {
+    if cx.data.unreachable.get() {
         unsafe {
             return llvm::LLVMGetUndef(llty.ptr_to().to_ref());
         }
@@ -1238,7 +1238,7 @@ pub fn alloca_zeroed<'blk, 'tcx>(cx: Block<'blk, 'tcx>, ty: Ty<'tcx>,
 
 pub fn arrayalloca(cx: Block, ty: Type, v: ValueRef) -> ValueRef {
     let _icx = push_ctxt("arrayalloca");
-    if cx.unreachable.get() {
+    if cx.data.unreachable.get() {
         unsafe {
             return llvm::LLVMGetUndef(ty.to_ref());
         }
@@ -1416,15 +1416,15 @@ fn has_nested_returns(tcx: &ty::ctxt, cfg: &cfg::CFG, blk_id: ast::NodeId) -> bo
 //
 // Be warned! You must call `init_function` before doing anything with the
 // returned function context.
-pub fn new_fn_ctxt<'a, 'tcx>(ccx: &'a CrateContext<'a, 'tcx>,
+pub fn new_fn_ctxt<'blk, 'tcx>(ccx: &'blk CrateContext<'blk, 'tcx>,
                              llfndecl: ValueRef,
                              id: ast::NodeId,
                              has_env: bool,
                              output_type: ty::FnOutput<'tcx>,
-                             param_substs: &'a Substs<'tcx>,
+                             param_substs: &'blk Substs<'tcx>,
                              sp: Option<Span>,
-                             block_arena: &'a TypedArena<common::BlockS<'a, 'tcx>>)
-                             -> FunctionContext<'a, 'tcx> {
+                             block_arena: &'blk TypedArena<common::BlockS>)
+                             -> FunctionContext<'blk, 'tcx> {
     common::validate_substs(param_substs);
 
     debug!("new_fn_ctxt(path={}, id={}, param_substs={})",
@@ -1482,17 +1482,17 @@ pub fn new_fn_ctxt<'a, 'tcx>(ccx: &'a CrateContext<'a, 'tcx>,
 
 /// Performs setup on a newly created function, creating the entry scope block
 /// and allocating space for the return pointer.
-pub fn init_function<'a, 'tcx>(fcx: &'a FunctionContext<'a, 'tcx>,
+pub fn init_function<'fcx, 'blk, 'tcx>(fcx: &'fcx FunctionContext<'blk, 'tcx>,
                                skip_retptr: bool,
                                output: ty::FnOutput<'tcx>)
-                               -> Block<'a, 'tcx> {
+                               -> Block<'fcx, 'blk, 'tcx> {
     let entry_bcx = fcx.new_temp_block("entry-block");
 
     // Use a dummy instruction as the insertion point for all allocas.
     // This is later removed in FunctionContext::cleanup.
     fcx.alloca_insert_pt.set(Some(unsafe {
         Load(entry_bcx, C_null(Type::i8p(fcx.ccx)));
-        llvm::LLVMGetFirstInstruction(entry_bcx.llbb)
+        llvm::LLVMGetFirstInstruction(entry_bcx.data.llbb)
     }));
 
     if let ty::FnConverging(output_type) = output {
@@ -1554,8 +1554,8 @@ pub fn create_datums_for_fn_args<'a, 'tcx>(fcx: &FunctionContext<'a, 'tcx>,
 /// datums.
 ///
 /// FIXME(pcwalton): Reduce the amount of code bloat this is responsible for.
-fn create_datums_for_fn_args_under_call_abi<'blk, 'tcx>(
-        mut bcx: Block<'blk, 'tcx>,
+fn create_datums_for_fn_args_under_call_abi<'fcx, 'blk, 'tcx>(
+        mut bcx: Block<'fcx, 'blk, 'tcx>,
         arg_scope: cleanup::CustomScopeIndex,
         arg_tys: &[Ty<'tcx>])
         -> Vec<RvalueDatum<'tcx>> {
@@ -1615,11 +1615,11 @@ fn create_datums_for_fn_args_under_call_abi<'blk, 'tcx>(
     result
 }
 
-fn copy_args_to_allocas<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn copy_args_to_allocas<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                     arg_scope: cleanup::CustomScopeIndex,
                                     args: &[ast::Arg],
                                     arg_datums: Vec<RvalueDatum<'tcx>>)
-                                    -> Block<'blk, 'tcx> {
+                                    -> Block<'fcx, 'blk, 'tcx> {
     debug!("copy_args_to_allocas");
 
     let _icx = push_ctxt("copy_args_to_allocas");
@@ -1643,13 +1643,13 @@ fn copy_args_to_allocas<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     bcx
 }
 
-fn copy_unboxed_closure_args_to_allocas<'blk, 'tcx>(
-                                        mut bcx: Block<'blk, 'tcx>,
+fn copy_unboxed_closure_args_to_allocas<'fcx, 'blk, 'tcx>(
+                                        mut bcx: Block<'fcx, 'blk, 'tcx>,
                                         arg_scope: cleanup::CustomScopeIndex,
                                         args: &[ast::Arg],
                                         arg_datums: Vec<RvalueDatum<'tcx>>,
                                         monomorphized_arg_types: &[Ty<'tcx>])
-                                        -> Block<'blk, 'tcx> {
+                                        -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("copy_unboxed_closure_args_to_allocas");
     let arg_scope_id = cleanup::CustomScope(arg_scope);
 
@@ -1695,14 +1695,14 @@ fn copy_unboxed_closure_args_to_allocas<'blk, 'tcx>(
 
 // Ties up the llstaticallocas -> llloadenv -> lltop edges,
 // and builds the return block.
-pub fn finish_fn<'blk, 'tcx>(fcx: &'blk FunctionContext<'blk, 'tcx>,
-                             last_bcx: Block<'blk, 'tcx>,
+pub fn finish_fn<'fcx, 'blk, 'tcx>(fcx: &'fcx FunctionContext<'blk, 'tcx>,
+                             last_bcx: Block<'fcx, 'blk, 'tcx>,
                              retty: ty::FnOutput<'tcx>) {
     let _icx = push_ctxt("finish_fn");
 
     let ret_cx = match fcx.llreturn.get() {
         Some(llreturn) => {
-            if !last_bcx.terminated.get() {
+            if !last_bcx.data.terminated.get() {
                 Br(last_bcx, llreturn);
             }
             raw_block(fcx, false, llreturn)
@@ -1720,8 +1720,8 @@ pub fn finish_fn<'blk, 'tcx>(fcx: &'blk FunctionContext<'blk, 'tcx>,
 }
 
 // Builds the return block for a function.
-pub fn build_return_block<'blk, 'tcx>(fcx: &FunctionContext<'blk, 'tcx>,
-                                      ret_cx: Block<'blk, 'tcx>,
+pub fn build_return_block<'fcx, 'blk, 'tcx>(fcx: &'fcx FunctionContext<'blk, 'tcx>,
+                                      ret_cx: Block<'fcx, 'blk, 'tcx>,
                                       retty: ty::FnOutput<'tcx>) {
     if fcx.llretslotptr.get().is_none() ||
        (!fcx.needs_ret_allocas && fcx.caller_expects_out_pointer) {
@@ -1920,7 +1920,7 @@ pub fn trans_closure<'a, 'b, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     unsafe {
         let llreturn = fcx.llreturn.get();
         for &llreturn in llreturn.iter() {
-            llvm::LLVMMoveBasicBlockAfter(llreturn, bcx.llbb);
+            llvm::LLVMMoveBasicBlockAfter(llreturn, bcx.data.llbb);
         }
     }
 
@@ -1972,13 +1972,13 @@ pub fn trans_enum_variant<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         llfndecl);
 }
 
-pub fn trans_named_tuple_constructor<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
+pub fn trans_named_tuple_constructor<'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>,
                                                  ctor_ty: Ty<'tcx>,
                                                  disr: ty::Disr,
                                                  args: callee::CallArgs,
                                                  dest: expr::Dest,
                                                  call_info: Option<NodeInfo>)
-                                                 -> Result<'blk, 'tcx> {
+                                                 -> Result<'fcx, 'blk, 'tcx> {
 
     let ccx = bcx.fcx.ccx;
     let tcx = ccx.tcx();

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -80,13 +80,13 @@ pub enum CalleeData<'tcx> {
     TraitItem(MethodData)
 }
 
-pub struct Callee<'blk, 'tcx: 'blk> {
-    pub bcx: Block<'blk, 'tcx>,
+pub struct Callee<'fcx, 'blk: 'fcx, 'tcx: 'blk> {
+    pub bcx: Block<'fcx, 'blk, 'tcx>,
     pub data: CalleeData<'tcx>,
 }
 
-fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
-                     -> Callee<'blk, 'tcx> {
+fn trans<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, expr: &ast::Expr)
+                     -> Callee<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_callee");
     debug!("callee::trans(expr={})", expr.repr(bcx.tcx()));
 
@@ -101,8 +101,8 @@ fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
     // any other expressions are closures:
     return datum_callee(bcx, expr);
 
-    fn datum_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
-                                -> Callee<'blk, 'tcx> {
+    fn datum_callee<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, expr: &ast::Expr)
+                                      -> Callee<'fcx, 'blk, 'tcx> {
         let DatumBlock { bcx, datum, .. } = expr::trans(bcx, expr);
         match datum.ty.sty {
             ty::ty_bare_fn(..) => {
@@ -122,18 +122,18 @@ fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
         }
     }
 
-    fn fn_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, llfn: ValueRef)
-                             -> Callee<'blk, 'tcx> {
+    fn fn_callee<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, llfn: ValueRef)
+                             -> Callee<'fcx, 'blk, 'tcx> {
         return Callee {
             bcx: bcx,
             data: Fn(llfn),
         };
     }
 
-    fn trans_def<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+    fn trans_def<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                              def: def::Def,
                              ref_expr: &ast::Expr)
-                             -> Callee<'blk, 'tcx> {
+                             -> Callee<'fcx, 'blk, 'tcx> {
         debug!("trans_def(def={}, ref_expr={})", def.repr(bcx.tcx()), ref_expr.repr(bcx.tcx()));
         let expr_ty = node_id_type(bcx, ref_expr.id);
         match def {
@@ -233,11 +233,11 @@ pub fn trans_fn_ref<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     trans_fn_ref_with_substs(ccx, def_id, node, param_substs, substs)
 }
 
-fn trans_fn_ref_with_substs_to_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_fn_ref_with_substs_to_callee<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                                   def_id: ast::DefId,
                                                   ref_id: ast::NodeId,
                                                   substs: subst::Substs<'tcx>)
-                                                  -> Callee<'blk, 'tcx> {
+                                                  -> Callee<'fcx, 'blk, 'tcx> {
     Callee {
         bcx: bcx,
         data: Fn(trans_fn_ref_with_substs(bcx.ccx(),
@@ -267,7 +267,6 @@ pub fn trans_fn_pointer_shim<'a, 'tcx>(
 {
     let _icx = push_ctxt("trans_fn_pointer_shim");
     let tcx = ccx.tcx();
-
     let bare_fn_ty = erase_regions(tcx, &bare_fn_ty);
     match ccx.fn_pointer_shims().borrow().get(&bare_fn_ty) {
         Some(&llval) => { return llval; }
@@ -576,12 +575,12 @@ pub fn trans_fn_ref_with_substs<'a, 'tcx>(
 // ______________________________________________________________________
 // Translating calls
 
-pub fn trans_call<'a, 'blk, 'tcx>(in_cx: Block<'blk, 'tcx>,
+pub fn trans_call<'a, 'fcx, 'blk, 'tcx>(in_cx: Block<'fcx, 'blk, 'tcx>,
                                   call_ex: &ast::Expr,
                                   f: &ast::Expr,
                                   args: CallArgs<'a, 'tcx>,
                                   dest: expr::Dest)
-                                  -> Block<'blk, 'tcx> {
+                                  -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_call");
     trans_call_inner(in_cx,
                      Some(common::expr_info(call_ex)),
@@ -591,12 +590,12 @@ pub fn trans_call<'a, 'blk, 'tcx>(in_cx: Block<'blk, 'tcx>,
                      Some(dest)).bcx
 }
 
-pub fn trans_method_call<'a, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_method_call<'a, 'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                          call_ex: &ast::Expr,
                                          rcvr: &ast::Expr,
                                          args: CallArgs<'a, 'tcx>,
                                          dest: expr::Dest)
-                                         -> Block<'blk, 'tcx> {
+                                         -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_method_call");
     debug!("trans_method_call(call_ex={})", call_ex.repr(bcx.tcx()));
     let method_call = MethodCall::expr(call_ex.id);
@@ -612,11 +611,11 @@ pub fn trans_method_call<'a, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         Some(dest)).bcx
 }
 
-pub fn trans_lang_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_lang_call<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                    did: ast::DefId,
                                    args: &[ValueRef],
                                    dest: Option<expr::Dest>)
-                                   -> Result<'blk, 'tcx> {
+                                   -> Result<'fcx, 'blk, 'tcx> {
     let fty = if did.krate == ast::LOCAL_CRATE {
         ty::node_id_to_type(bcx.tcx(), did.node)
     } else {
@@ -645,14 +644,14 @@ pub fn trans_lang_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 ///
 /// For non-lang items, `dest` is always Some, and hence the result is written into memory
 /// somewhere. Nonetheless we return the actual return value of the function.
-pub fn trans_call_inner<'a, 'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
+pub fn trans_call_inner<'a, 'fcx, 'blk, 'tcx, F>(bcx: Block<'fcx, 'blk, 'tcx>,
                                            call_info: Option<NodeInfo>,
                                            callee_ty: Ty<'tcx>,
                                            get_callee: F,
                                            args: CallArgs<'a, 'tcx>,
                                            dest: Option<expr::Dest>)
-                                           -> Result<'blk, 'tcx> where
-    F: FnOnce(Block<'blk, 'tcx>, cleanup::ScopeId) -> Callee<'blk, 'tcx>,
+                                           -> Result<'fcx, 'blk, 'tcx> where
+    F: FnOnce(Block<'fcx, 'blk, 'tcx>, cleanup::ScopeId) -> Callee<'fcx, 'blk, 'tcx>,
 {
     // Introduce a temporary cleanup scope that will contain cleanups
     // for the arguments while they are being evaluated. The purpose
@@ -862,14 +861,14 @@ pub enum CallArgs<'a, 'tcx> {
     ArgOverloadedCall(Vec<&'a ast::Expr>),
 }
 
-fn trans_args_under_call_abi<'blk, 'tcx>(
-                             mut bcx: Block<'blk, 'tcx>,
+fn trans_args_under_call_abi<'fcx, 'blk, 'tcx>(
+                             mut bcx: Block<'fcx, 'blk, 'tcx>,
                              arg_exprs: &[P<ast::Expr>],
                              fn_ty: Ty<'tcx>,
                              llargs: &mut Vec<ValueRef>,
                              arg_cleanup_scope: cleanup::ScopeId,
                              ignore_self: bool)
-                             -> Block<'blk, 'tcx>
+                             -> Block<'fcx, 'blk, 'tcx>
 {
     let args =
         ty::erase_late_bound_regions(
@@ -926,14 +925,14 @@ fn trans_args_under_call_abi<'blk, 'tcx>(
     bcx
 }
 
-fn trans_overloaded_call_args<'blk, 'tcx>(
-                              mut bcx: Block<'blk, 'tcx>,
+fn trans_overloaded_call_args<'fcx, 'blk, 'tcx>(
+                              mut bcx: Block<'fcx, 'blk, 'tcx>,
                               arg_exprs: Vec<&ast::Expr>,
                               fn_ty: Ty<'tcx>,
                               llargs: &mut Vec<ValueRef>,
                               arg_cleanup_scope: cleanup::ScopeId,
                               ignore_self: bool)
-                              -> Block<'blk, 'tcx> {
+                              -> Block<'fcx, 'blk, 'tcx> {
     // Translate the `self` argument first.
     let arg_tys = ty::erase_late_bound_regions(bcx.tcx(),  &ty::ty_fn_args(fn_ty));
     if !ignore_self {
@@ -972,14 +971,14 @@ fn trans_overloaded_call_args<'blk, 'tcx>(
     bcx
 }
 
-pub fn trans_args<'a, 'blk, 'tcx>(cx: Block<'blk, 'tcx>,
+pub fn trans_args<'a, 'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
                                   args: CallArgs<'a, 'tcx>,
                                   fn_ty: Ty<'tcx>,
                                   llargs: &mut Vec<ValueRef>,
                                   arg_cleanup_scope: cleanup::ScopeId,
                                   ignore_self: bool,
                                   abi: synabi::Abi)
-                                  -> Block<'blk, 'tcx> {
+                                  -> Block<'fcx, 'blk, 'tcx> {
     debug!("trans_args(abi={})", abi);
 
     let _icx = push_ctxt("trans_args");
@@ -1064,12 +1063,12 @@ pub enum AutorefArg {
     DoAutorefArg(ast::NodeId)
 }
 
-pub fn trans_arg_datum<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_arg_datum<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                    formal_arg_ty: Ty<'tcx>,
                                    arg_datum: Datum<'tcx, Expr>,
                                    arg_cleanup_scope: cleanup::ScopeId,
                                    autoref_arg: AutorefArg)
-                                   -> Result<'blk, 'tcx> {
+                                   -> Result<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_arg_datum");
     let mut bcx = bcx;
     let ccx = bcx.ccx();

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -992,7 +992,8 @@ pub fn expr_ty<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, ex: &ast::Expr) -
     node_id_type(bcx, ex.id)
 }
 
-pub fn expr_ty_adjusted<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, ex: &ast::Expr) -> Ty<'tcx> {
+pub fn expr_ty_adjusted<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
+                                          ex: &ast::Expr) -> Ty<'tcx> {
     monomorphize_type(bcx, ty::expr_ty_adjusted(bcx.tcx(), ex))
 }
 

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -356,7 +356,7 @@ type LvalueDatum<'tcx> = datum::Datum<'tcx, datum::Lvalue>;
 
 // Function context.  Every LLVM function we create will have one of
 // these.
-pub struct FunctionContext<'a, 'tcx: 'a> {
+pub struct FunctionContext<'blk, 'tcx: 'blk> {
     // The ValueRef returned from a call to llvm::LLVMAddFunction; the
     // address of the first instruction in the sequence of
     // instructions for this function that will go in the .text
@@ -364,7 +364,7 @@ pub struct FunctionContext<'a, 'tcx: 'a> {
     pub llfn: ValueRef,
 
     // always an empty parameter-environment
-    pub param_env: ty::ParameterEnvironment<'a, 'tcx>,
+    pub param_env: ty::ParameterEnvironment<'blk, 'tcx>,
 
     // The environment argument in a closure.
     pub llenv: Option<ValueRef>,
@@ -410,28 +410,28 @@ pub struct FunctionContext<'a, 'tcx: 'a> {
 
     // If this function is being monomorphized, this contains the type
     // substitutions used.
-    pub param_substs: &'a Substs<'tcx>,
+    pub param_substs: &'blk Substs<'tcx>,
 
     // The source span and nesting context where this function comes from, for
     // error reporting and symbol generation.
     pub span: Option<Span>,
 
     // The arena that blocks are allocated from.
-    pub block_arena: &'a TypedArena<BlockS<'a, 'tcx>>,
+    pub block_arena: &'blk TypedArena<BlockS>,
 
     // This function's enclosing crate context.
-    pub ccx: &'a CrateContext<'a, 'tcx>,
+    pub ccx: &'blk CrateContext<'blk, 'tcx>,
 
     // Used and maintained by the debuginfo module.
     pub debug_context: debuginfo::FunctionDebugContext,
 
     // Cleanup scopes.
-    pub scopes: RefCell<Vec<cleanup::CleanupScope<'a, 'tcx>>>,
+    pub scopes: RefCell<Vec<cleanup::CleanupScope<'blk, 'tcx>>>,
 
     pub cfg: Option<cfg::CFG>,
 }
 
-impl<'a, 'tcx> FunctionContext<'a, 'tcx> {
+impl<'blk, 'tcx> FunctionContext<'blk, 'tcx> {
     pub fn arg_pos(&self, arg: uint) -> uint {
         let arg = self.env_arg_pos() + arg;
         if self.llenv.is_some() {
@@ -469,7 +469,7 @@ impl<'a, 'tcx> FunctionContext<'a, 'tcx> {
         self.llreturn.get().unwrap()
     }
 
-    pub fn get_ret_slot(&self, bcx: Block<'a, 'tcx>,
+    pub fn get_ret_slot<'fcx>(&'fcx self, bcx: Block<'fcx, 'blk, 'tcx>,
                         output: ty::FnOutput<'tcx>,
                         name: &str) -> ValueRef {
         if self.needs_ret_allocas {
@@ -482,11 +482,11 @@ impl<'a, 'tcx> FunctionContext<'a, 'tcx> {
         }
     }
 
-    pub fn new_block(&'a self,
+    pub fn new_block<'fcx>(&'fcx self,
                      is_lpad: bool,
                      name: &str,
                      opt_node_id: Option<ast::NodeId>)
-                     -> Block<'a, 'tcx> {
+                     -> Block<'fcx, 'blk, 'tcx> {
         unsafe {
             let name = CString::from_slice(name.as_bytes());
             let llbb = llvm::LLVMAppendBasicBlockInContext(self.ccx.llcx(),
@@ -496,28 +496,28 @@ impl<'a, 'tcx> FunctionContext<'a, 'tcx> {
         }
     }
 
-    pub fn new_id_block(&'a self,
+    pub fn new_id_block<'fcx>(&'fcx self,
                         name: &str,
                         node_id: ast::NodeId)
-                        -> Block<'a, 'tcx> {
+                        -> Block<'fcx, 'blk, 'tcx> {
         self.new_block(false, name, Some(node_id))
     }
 
-    pub fn new_temp_block(&'a self,
+    pub fn new_temp_block<'fcx>(&'fcx self,
                           name: &str)
-                          -> Block<'a, 'tcx> {
+                          -> Block<'fcx, 'blk, 'tcx> {
         self.new_block(false, name, None)
     }
 
-    pub fn join_blocks(&'a self,
+    pub fn join_blocks<'fcx>(&'fcx self,
                        id: ast::NodeId,
-                       in_cxs: &[Block<'a, 'tcx>])
-                       -> Block<'a, 'tcx> {
+                       in_cxs: &[Block<'fcx, 'blk, 'tcx>])
+                       -> Block<'fcx, 'blk, 'tcx> {
         let out = self.new_id_block("join", id);
         let mut reachable = false;
         for bcx in in_cxs.iter() {
-            if !bcx.unreachable.get() {
-                build::Br(*bcx, out.llbb);
+            if !bcx.data.unreachable.get() {
+                build::Br(*bcx, out.data.llbb);
                 reachable = true;
             }
         }
@@ -541,7 +541,18 @@ impl<'a, 'tcx> FunctionContext<'a, 'tcx> {
 // code.  Each basic block we generate is attached to a function, typically
 // with many basic blocks per function.  All the basic blocks attached to a
 // function are organized as a directed graph.
-pub struct BlockS<'blk, 'tcx: 'blk> {
+pub struct Block<'fcx, 'blk: 'fcx, 'tcx: 'blk> {
+    // The function context for the function to which this block is
+    // attached.
+    pub fcx: &'fcx FunctionContext<'blk, 'tcx>,
+
+    // The block payload (stored in an arena).
+    pub data: &'blk BlockS,
+}
+
+impl<'fcx, 'blk, 'tcx> Copy for Block<'fcx, 'blk, 'tcx> { }
+
+pub struct BlockS {
     // The BasicBlockRef returned from a call to
     // llvm::LLVMAppendBasicBlock(llfn, name), which adds a basic
     // block to the function pointed to by llfn.  We insert
@@ -558,29 +569,9 @@ pub struct BlockS<'blk, 'tcx: 'blk> {
     // debugging purposes only.
     pub opt_node_id: Option<ast::NodeId>,
 
-    // The function context for the function to which this block is
-    // attached.
-    pub fcx: &'blk FunctionContext<'blk, 'tcx>,
 }
 
-pub type Block<'blk, 'tcx> = &'blk BlockS<'blk, 'tcx>;
-
-impl<'blk, 'tcx> BlockS<'blk, 'tcx> {
-    pub fn new(llbb: BasicBlockRef,
-               is_lpad: bool,
-               opt_node_id: Option<ast::NodeId>,
-               fcx: &'blk FunctionContext<'blk, 'tcx>)
-               -> Block<'blk, 'tcx> {
-        fcx.block_arena.alloc(BlockS {
-            llbb: llbb,
-            terminated: Cell::new(false),
-            unreachable: Cell::new(false),
-            is_lpad: is_lpad,
-            opt_node_id: opt_node_id,
-            fcx: fcx
-        })
-    }
-
+impl<'fcx, 'blk, 'tcx> Block<'fcx, 'blk, 'tcx> {
     pub fn ccx(&self) -> &'blk CrateContext<'blk, 'tcx> {
         self.fcx.ccx
     }
@@ -624,7 +615,7 @@ impl<'blk, 'tcx> BlockS<'blk, 'tcx> {
     }
 
     pub fn to_str(&self) -> String {
-        format!("[block {:p}]", self)
+        self.data.to_str()
     }
 
     pub fn monomorphize<T>(&self, value: &T) -> T
@@ -636,17 +627,40 @@ impl<'blk, 'tcx> BlockS<'blk, 'tcx> {
     }
 }
 
-impl<'blk, 'tcx> mc::Typer<'tcx> for BlockS<'blk, 'tcx> {
+impl BlockS {
+    pub fn new<'fcx, 'blk, 'tcx>(llbb: BasicBlockRef,
+               is_lpad: bool,
+               opt_node_id: Option<ast::NodeId>,
+               fcx: &'fcx FunctionContext<'blk, 'tcx>) -> Block<'fcx, 'blk, 'tcx> {
+        let data = fcx.block_arena.alloc(BlockS {
+            llbb: llbb,
+            terminated: Cell::new(false),
+            unreachable: Cell::new(false),
+            is_lpad: is_lpad,
+            opt_node_id: opt_node_id,
+        });
+        Block {
+            fcx: fcx,
+            data: data,
+        }
+    }
+
+    pub fn to_str(&self) -> String {
+        format!("[block {:p}]", self)
+    }
+}
+
+impl<'fcx, 'blk, 'tcx> mc::Typer<'tcx> for Block<'fcx, 'blk, 'tcx> {
     fn tcx<'a>(&'a self) -> &'a ty::ctxt<'tcx> {
         self.tcx()
     }
 
     fn node_ty(&self, id: ast::NodeId) -> mc::McResult<Ty<'tcx>> {
-        Ok(node_id_type(self, id))
+        Ok(node_id_type(*self, id))
     }
 
     fn expr_ty_adjusted(&self, expr: &ast::Expr) -> mc::McResult<Ty<'tcx>> {
-        Ok(expr_ty_adjusted(self, expr))
+        Ok(expr_ty_adjusted(*self, expr))
     }
 
     fn node_method_ty(&self, method_call: ty::MethodCall) -> Option<Ty<'tcx>> {
@@ -654,7 +668,7 @@ impl<'blk, 'tcx> mc::Typer<'tcx> for BlockS<'blk, 'tcx> {
             .method_map
             .borrow()
             .get(&method_call)
-            .map(|method| monomorphize_type(self, method.ty))
+            .map(|method| monomorphize_type(*self, method.ty))
     }
 
     fn node_method_origin(&self, method_call: ty::MethodCall)
@@ -693,7 +707,7 @@ impl<'blk, 'tcx> mc::Typer<'tcx> for BlockS<'blk, 'tcx> {
     }
 }
 
-impl<'blk, 'tcx> ty::UnboxedClosureTyper<'tcx> for BlockS<'blk, 'tcx> {
+impl<'fcx, 'blk, 'tcx> ty::UnboxedClosureTyper<'tcx> for Block<'fcx, 'blk, 'tcx> {
     fn param_env<'a>(&'a self) -> &'a ty::ParameterEnvironment<'a, 'tcx> {
         &self.fcx.param_env
     }
@@ -725,13 +739,13 @@ impl<'blk, 'tcx> ty::UnboxedClosureTyper<'tcx> for BlockS<'blk, 'tcx> {
     }
 }
 
-pub struct Result<'blk, 'tcx: 'blk> {
-    pub bcx: Block<'blk, 'tcx>,
+pub struct Result<'fcx, 'blk: 'fcx, 'tcx: 'blk> {
+    pub bcx: Block<'fcx, 'blk, 'tcx>,
     pub val: ValueRef
 }
 
-impl<'b, 'tcx> Result<'b, 'tcx> {
-    pub fn new(bcx: Block<'b, 'tcx>, val: ValueRef) -> Result<'b, 'tcx> {
+impl<'fcx, 'blk, 'tcx> Result<'fcx, 'blk, 'tcx> {
+    pub fn new(bcx: Block<'fcx, 'blk, 'tcx>, val: ValueRef) -> Result<'fcx, 'blk, 'tcx> {
         Result {
             bcx: bcx,
             val: val,
@@ -964,21 +978,21 @@ pub fn is_null(val: ValueRef) -> bool {
     }
 }
 
-pub fn monomorphize_type<'blk, 'tcx>(bcx: &BlockS<'blk, 'tcx>, t: Ty<'tcx>) -> Ty<'tcx> {
+pub fn monomorphize_type<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, t: Ty<'tcx>) -> Ty<'tcx> {
     bcx.fcx.monomorphize(&t)
 }
 
-pub fn node_id_type<'blk, 'tcx>(bcx: &BlockS<'blk, 'tcx>, id: ast::NodeId) -> Ty<'tcx> {
+pub fn node_id_type<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, id: ast::NodeId) -> Ty<'tcx> {
     let tcx = bcx.tcx();
     let t = ty::node_id_to_type(tcx, id);
     monomorphize_type(bcx, t)
 }
 
-pub fn expr_ty<'blk, 'tcx>(bcx: &BlockS<'blk, 'tcx>, ex: &ast::Expr) -> Ty<'tcx> {
+pub fn expr_ty<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, ex: &ast::Expr) -> Ty<'tcx> {
     node_id_type(bcx, ex.id)
 }
 
-pub fn expr_ty_adjusted<'blk, 'tcx>(bcx: &BlockS<'blk, 'tcx>, ex: &ast::Expr) -> Ty<'tcx> {
+pub fn expr_ty_adjusted<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, ex: &ast::Expr) -> Ty<'tcx> {
     monomorphize_type(bcx, ty::expr_ty_adjusted(bcx.tcx(), ex))
 }
 

--- a/src/librustc_trans/trans/controlflow.rs
+++ b/src/librustc_trans/trans/controlflow.rs
@@ -39,9 +39,9 @@ use syntax::parse::token::InternedString;
 use syntax::parse::token;
 use syntax::visit::Visitor;
 
-pub fn trans_stmt<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
+pub fn trans_stmt<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>,
                               s: &ast::Stmt)
-                              -> Block<'blk, 'tcx> {
+                              -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_stmt");
     let fcx = cx.fcx;
     debug!("trans_stmt({})", s.repr(cx.tcx()));
@@ -79,8 +79,8 @@ pub fn trans_stmt<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
     return bcx;
 }
 
-pub fn trans_stmt_semi<'blk, 'tcx>(cx: Block<'blk, 'tcx>, e: &ast::Expr)
-                                   -> Block<'blk, 'tcx> {
+pub fn trans_stmt_semi<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>, e: &ast::Expr)
+                                         -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_stmt_semi");
     let ty = expr_ty(cx, e);
     if type_needs_drop(cx.tcx(), ty) {
@@ -90,10 +90,10 @@ pub fn trans_stmt_semi<'blk, 'tcx>(cx: Block<'blk, 'tcx>, e: &ast::Expr)
     }
 }
 
-pub fn trans_block<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_block<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                b: &ast::Block,
                                mut dest: expr::Dest)
-                               -> Block<'blk, 'tcx> {
+                               -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_block");
     let fcx = bcx.fcx;
     let mut bcx = bcx;
@@ -127,7 +127,7 @@ pub fn trans_block<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             bcx = expr::trans_into(bcx, &**e, dest);
         }
         None => {
-            assert!(dest == expr::Ignore || bcx.unreachable.get());
+            assert!(dest == expr::Ignore || bcx.data.unreachable.get());
         }
     }
 
@@ -136,13 +136,13 @@ pub fn trans_block<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     return bcx;
 }
 
-pub fn trans_if<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_if<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                             if_id: ast::NodeId,
                             cond: &ast::Expr,
                             thn: &ast::Block,
                             els: Option<&ast::Expr>,
                             dest: expr::Dest)
-                            -> Block<'blk, 'tcx> {
+                            -> Block<'fcx, 'blk, 'tcx> {
     debug!("trans_if(bcx={}, if_id={}, cond={}, thn={}, dest={})",
            bcx.to_str(), if_id, bcx.expr_to_string(cond), thn.id,
            dest.to_string(bcx.ccx()));
@@ -195,13 +195,13 @@ pub fn trans_if<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             let else_bcx_out = expr::trans_into(else_bcx_in, &*elexpr, dest);
             next_bcx = bcx.fcx.join_blocks(if_id,
                                            &[then_bcx_out, else_bcx_out]);
-            CondBr(bcx, cond_val, then_bcx_in.llbb, else_bcx_in.llbb);
+            CondBr(bcx, cond_val, then_bcx_in.data.llbb, else_bcx_in.data.llbb);
         }
 
         None => {
             next_bcx = bcx.fcx.new_id_block("next-block", if_id);
-            Br(then_bcx_out, next_bcx.llbb);
-            CondBr(bcx, cond_val, then_bcx_in.llbb, next_bcx.llbb);
+            Br(then_bcx_out, next_bcx.data.llbb);
+            CondBr(bcx, cond_val, then_bcx_in.data.llbb, next_bcx.data.llbb);
         }
     }
 
@@ -212,11 +212,11 @@ pub fn trans_if<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     next_bcx
 }
 
-pub fn trans_while<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_while<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                loop_id: ast::NodeId,
                                cond: &ast::Expr,
                                body: &ast::Block)
-                               -> Block<'blk, 'tcx> {
+                               -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_while");
     let fcx = bcx.fcx;
 
@@ -235,9 +235,9 @@ pub fn trans_while<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let cond_bcx_in = fcx.new_id_block("while_cond", cond.id);
     let body_bcx_in = fcx.new_id_block("while_body", body.id);
 
-    fcx.push_loop_cleanup_scope(loop_id, [next_bcx_in, cond_bcx_in]);
+    fcx.push_loop_cleanup_scope(loop_id, [next_bcx_in.data, cond_bcx_in.data]);
 
-    Br(bcx, cond_bcx_in.llbb);
+    Br(bcx, cond_bcx_in.data.llbb);
 
     // compile the block where we will handle loop cleanups
     let cleanup_llbb = fcx.normal_exit_block(loop_id, cleanup::EXIT_BREAK);
@@ -245,23 +245,23 @@ pub fn trans_while<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     // compile the condition
     let Result {bcx: cond_bcx_out, val: cond_val} =
         expr::trans(cond_bcx_in, cond).to_llbool();
-    CondBr(cond_bcx_out, cond_val, body_bcx_in.llbb, cleanup_llbb);
+    CondBr(cond_bcx_out, cond_val, body_bcx_in.data.llbb, cleanup_llbb);
 
     // loop body:
     let body_bcx_out = trans_block(body_bcx_in, body, expr::Ignore);
-    Br(body_bcx_out, cond_bcx_in.llbb);
+    Br(body_bcx_out, cond_bcx_in.data.llbb);
 
     fcx.pop_loop_cleanup_scope(loop_id);
     return next_bcx_in;
 }
 
 /// Translates a `for` loop.
-pub fn trans_for<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
+pub fn trans_for<'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>,
                              loop_info: NodeInfo,
                              pat: &ast::Pat,
                              head: &ast::Expr,
                              body: &ast::Block)
-                             -> Block<'blk, 'tcx>
+                             -> Block<'fcx, 'blk, 'tcx>
 {
     let _icx = push_ctxt("trans_for");
 
@@ -291,8 +291,8 @@ pub fn trans_for<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
     let loopback_bcx_in = bcx.fcx.new_id_block("for_loopback", head.id);
     let body_bcx_in = bcx.fcx.new_id_block("for_body", body.id);
     bcx.fcx.push_loop_cleanup_scope(loop_info.id,
-                                    [next_bcx_in, loopback_bcx_in]);
-    Br(bcx, loopback_bcx_in.llbb);
+                                    [next_bcx_in.data, loopback_bcx_in.data]);
+    Br(bcx, loopback_bcx_in.data.llbb);
     let cleanup_llbb = bcx.fcx.normal_exit_block(loop_info.id,
                                                  cleanup::EXIT_BREAK);
 
@@ -347,7 +347,7 @@ pub fn trans_for<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                                               None);
     let i1_type = Type::i1(loopback_bcx_out.ccx());
     let llcondition = Trunc(loopback_bcx_out, lldiscriminant, i1_type);
-    CondBr(loopback_bcx_out, llcondition, body_bcx_in.llbb, cleanup_llbb);
+    CondBr(loopback_bcx_out, llcondition, body_bcx_in.data.llbb, cleanup_llbb);
 
     // Now we're in the body. Unpack the `Option` value into the programmer-
     // supplied pattern.
@@ -377,17 +377,17 @@ pub fn trans_for<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         body_bcx_out.fcx
                     .pop_and_trans_custom_cleanup_scope(body_bcx_out,
                                                         option_cleanup_scope);
-    Br(body_bcx_out, loopback_bcx_in.llbb);
+    Br(body_bcx_out, loopback_bcx_in.data.llbb);
 
     // Codegen cleanups and leave.
     next_bcx_in.fcx.pop_loop_cleanup_scope(loop_info.id);
     next_bcx_in
 }
 
-pub fn trans_loop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_loop<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                               loop_id: ast::NodeId,
                               body: &ast::Block)
-                              -> Block<'blk, 'tcx> {
+                              -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_loop");
     let fcx = bcx.fcx;
 
@@ -405,26 +405,26 @@ pub fn trans_loop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let next_bcx_in = bcx.fcx.new_id_block("loop_exit", loop_id);
     let body_bcx_in = bcx.fcx.new_id_block("loop_body", body.id);
 
-    fcx.push_loop_cleanup_scope(loop_id, [next_bcx_in, body_bcx_in]);
+    fcx.push_loop_cleanup_scope(loop_id, [next_bcx_in.data, body_bcx_in.data]);
 
-    Br(bcx, body_bcx_in.llbb);
+    Br(bcx, body_bcx_in.data.llbb);
     let body_bcx_out = trans_block(body_bcx_in, body, expr::Ignore);
-    Br(body_bcx_out, body_bcx_in.llbb);
+    Br(body_bcx_out, body_bcx_in.data.llbb);
 
     fcx.pop_loop_cleanup_scope(loop_id);
 
     return next_bcx_in;
 }
 
-pub fn trans_break_cont<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_break_cont<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                     expr_id: ast::NodeId,
                                     opt_label: Option<Ident>,
                                     exit: uint)
-                                    -> Block<'blk, 'tcx> {
+                                    -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_break_cont");
     let fcx = bcx.fcx;
 
-    if bcx.unreachable.get() {
+    if bcx.data.unreachable.get() {
         return bcx;
     }
 
@@ -449,23 +449,23 @@ pub fn trans_break_cont<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     return bcx;
 }
 
-pub fn trans_break<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_break<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                expr_id: ast::NodeId,
                                label_opt: Option<Ident>)
-                               -> Block<'blk, 'tcx> {
+                               -> Block<'fcx, 'blk, 'tcx> {
     return trans_break_cont(bcx, expr_id, label_opt, cleanup::EXIT_BREAK);
 }
 
-pub fn trans_cont<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_cont<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                               expr_id: ast::NodeId,
                               label_opt: Option<Ident>)
-                              -> Block<'blk, 'tcx> {
+                              -> Block<'fcx, 'blk, 'tcx> {
     return trans_break_cont(bcx, expr_id, label_opt, cleanup::EXIT_LOOP);
 }
 
-pub fn trans_ret<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
-                             e: Option<&ast::Expr>)
-                             -> Block<'blk, 'tcx> {
+pub fn trans_ret<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
+                            e: Option<&ast::Expr>)
+                            -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_ret");
     let fcx = bcx.fcx;
     let mut bcx = bcx;
@@ -491,10 +491,10 @@ pub fn trans_ret<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     return bcx;
 }
 
-pub fn trans_fail<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_fail<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                               sp: Span,
                               fail_str: InternedString)
-                              -> Block<'blk, 'tcx> {
+                              -> Block<'fcx, 'blk, 'tcx> {
     let ccx = bcx.ccx();
     let _icx = push_ctxt("trans_fail_value");
 
@@ -515,11 +515,11 @@ pub fn trans_fail<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     return bcx;
 }
 
-pub fn trans_fail_bounds_check<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_fail_bounds_check<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                            sp: Span,
                                            index: ValueRef,
                                            len: ValueRef)
-                                           -> Block<'blk, 'tcx> {
+                                           -> Block<'fcx, 'blk, 'tcx> {
     let ccx = bcx.ccx();
     let _icx = push_ctxt("trans_fail_bounds_check");
 

--- a/src/librustc_trans/trans/debuginfo.rs
+++ b/src/librustc_trans/trans/debuginfo.rs
@@ -854,7 +854,7 @@ pub fn create_global_var_metadata(cx: &CrateContext,
 /// local in `bcx.fcx.lllocals`.
 /// Adds the created metadata nodes directly to the crate's IR.
 pub fn create_local_var_metadata(bcx: Block, local: &ast::Local) {
-    if bcx.unreachable.get() ||
+    if bcx.data.unreachable.get() ||
        fn_should_be_ignored(bcx.fcx) ||
        bcx.sess().opts.debuginfo != FullDebugInfo  {
         return;
@@ -894,13 +894,13 @@ pub fn create_local_var_metadata(bcx: Block, local: &ast::Local) {
 /// Creates debug information for a variable captured in a closure.
 ///
 /// Adds the created metadata nodes directly to the crate's IR.
-pub fn create_captured_var_metadata<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn create_captured_var_metadata<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                                 node_id: ast::NodeId,
                                                 env_pointer: ValueRef,
                                                 env_index: uint,
                                                 captured_by_ref: bool,
                                                 span: Span) {
-    if bcx.unreachable.get() ||
+    if bcx.data.unreachable.get() ||
        fn_should_be_ignored(bcx.fcx) ||
        bcx.sess().opts.debuginfo != FullDebugInfo {
         return;
@@ -982,10 +982,10 @@ pub fn create_captured_var_metadata<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 /// match-statement arm.
 ///
 /// Adds the created metadata nodes directly to the crate's IR.
-pub fn create_match_binding_metadata<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn create_match_binding_metadata<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                                  variable_ident: ast::Ident,
                                                  binding: BindingInfo<'tcx>) {
-    if bcx.unreachable.get() ||
+    if bcx.data.unreachable.get() ||
        fn_should_be_ignored(bcx.fcx) ||
        bcx.sess().opts.debuginfo != FullDebugInfo {
         return;
@@ -1027,7 +1027,7 @@ pub fn create_match_binding_metadata<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 /// argument in `bcx.fcx.lllocals`.
 /// Adds the created metadata nodes directly to the crate's IR.
 pub fn create_argument_metadata(bcx: Block, arg: &ast::Arg) {
-    if bcx.unreachable.get() ||
+    if bcx.data.unreachable.get() ||
        fn_should_be_ignored(bcx.fcx) ||
        bcx.sess().opts.debuginfo != FullDebugInfo {
         return;
@@ -1083,7 +1083,7 @@ pub fn create_argument_metadata(bcx: Block, arg: &ast::Arg) {
 /// loop variable in `bcx.fcx.lllocals`.
 /// Adds the created metadata nodes directly to the crate's IR.
 pub fn create_for_loop_var_metadata(bcx: Block, pat: &ast::Pat) {
-    if bcx.unreachable.get() ||
+    if bcx.data.unreachable.get() ||
        fn_should_be_ignored(bcx.fcx) ||
        bcx.sess().opts.debuginfo != FullDebugInfo {
         return;
@@ -1656,7 +1656,7 @@ fn compile_unit_metadata(cx: &CrateContext) -> DIDescriptor {
     }
 }
 
-fn declare_local<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn declare_local<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                              variable_ident: ast::Ident,
                              variable_type: Ty<'tcx>,
                              scope_metadata: DIScope,
@@ -1722,7 +1722,7 @@ fn declare_local<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             DIB(cx),
             var_alloca,
             var_metadata,
-            bcx.llbb);
+            bcx.data.llbb);
 
         llvm::LLVMSetInstDebugLocation(trans::build::B(bcx).llbuilder, instr);
     }

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -93,10 +93,10 @@ impl Dest {
 
 /// This function is equivalent to `trans(bcx, expr).store_to_dest(dest)` but it may generate
 /// better optimized LLVM code.
-pub fn trans_into<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_into<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                               expr: &ast::Expr,
                               dest: Dest)
-                              -> Block<'blk, 'tcx> {
+                              -> Block<'fcx, 'blk, 'tcx> {
     let mut bcx = bcx;
 
     if bcx.tcx().adjustments.borrow().contains_key(&expr.id) {
@@ -134,9 +134,9 @@ pub fn trans_into<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 /// Translates an expression, returning a datum (and new block) encapsulating the result. When
 /// possible, it is preferred to use `trans_into`, as that may avoid creating a temporary on the
 /// stack.
-pub fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                          expr: &ast::Expr)
-                         -> DatumBlock<'blk, 'tcx, Expr> {
+                         -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     debug!("trans(expr={})", bcx.expr_to_string(expr));
 
     let mut bcx = bcx;
@@ -163,10 +163,10 @@ pub fn get_dataptr(bcx: Block, fat_ptr: ValueRef) -> ValueRef {
 
 /// Helper for trans that apply adjustments from `expr` to `datum`, which should be the unadjusted
 /// translation of `expr`.
-fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn apply_adjustments<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                  expr: &ast::Expr,
                                  datum: Datum<'tcx, Expr>)
-                                 -> DatumBlock<'blk, 'tcx, Expr> {
+                                 -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     let mut bcx = bcx;
     let mut datum = datum;
     let adjustment = match bcx.tcx().adjustments.borrow().get(&expr.id).cloned() {
@@ -234,11 +234,11 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     debug!("after adjustments, datum={}", datum.to_string(bcx.ccx()));
     return DatumBlock::new(bcx, datum);
 
-    fn apply_autoref<'blk, 'tcx>(autoref: &ty::AutoRef<'tcx>,
-                                 bcx: Block<'blk, 'tcx>,
+    fn apply_autoref<'fcx, 'blk, 'tcx>(autoref: &ty::AutoRef<'tcx>,
+                                 bcx: Block<'fcx, 'blk, 'tcx>,
                                  expr: &ast::Expr,
                                  datum: Datum<'tcx, Expr>)
-                                 -> DatumBlock<'blk, 'tcx, Expr> {
+                                 -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
         let mut bcx = bcx;
         let mut datum = datum;
 
@@ -271,10 +271,10 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         DatumBlock::new(bcx, datum)
     }
 
-    fn ref_ptr<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+    fn ref_ptr<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                            expr: &ast::Expr,
                            datum: Datum<'tcx, Expr>)
-                           -> DatumBlock<'blk, 'tcx, Expr> {
+                           -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
         debug!("ref_ptr(expr={}, datum={})",
                expr.repr(bcx.tcx()),
                datum.to_string(bcx.ccx()));
@@ -297,7 +297,7 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     // into a type to be destructed. If we want to end up with a Box pointer,
     // then mk_ty should make a Box pointer (T -> Box<T>), if we want a
     // borrowed reference then it should be T -> &T.
-    fn unsized_info<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
+    fn unsized_info<'fcx, 'blk, 'tcx, F>(bcx: Block<'fcx, 'blk, 'tcx>,
                                    kind: &ty::UnsizeKind<'tcx>,
                                    id: ast::NodeId,
                                    unadjusted_ty: Ty<'tcx>,
@@ -337,11 +337,11 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         }
     }
 
-    fn unsize_expr<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+    fn unsize_expr<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                expr: &ast::Expr,
                                datum: Datum<'tcx, Expr>,
                                k: &ty::UnsizeKind<'tcx>)
-                               -> DatumBlock<'blk, 'tcx, Expr> {
+                               -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
         let tcx = bcx.tcx();
         let datum_ty = datum.ty;
         let unsized_ty = ty::unsize_ty(tcx, datum_ty, k, expr.span);
@@ -376,10 +376,10 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         }
     }
 
-    fn ref_fat_ptr<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+    fn ref_fat_ptr<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                expr: &ast::Expr,
                                datum: Datum<'tcx, Expr>)
-                               -> DatumBlock<'blk, 'tcx, Expr> {
+                               -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
         let tcx = bcx.tcx();
         let dest_ty = ty::close_type(tcx, datum.ty);
         let base = |: bcx, val| Load(bcx, get_dataptr(bcx, val));
@@ -387,15 +387,15 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         into_fat_ptr(bcx, expr, datum, dest_ty, base, len)
     }
 
-    fn into_fat_ptr<'blk, 'tcx, F, G>(bcx: Block<'blk, 'tcx>,
+    fn into_fat_ptr<'fcx, 'blk, 'tcx, F, G>(bcx: Block<'fcx, 'blk, 'tcx>,
                                       expr: &ast::Expr,
                                       datum: Datum<'tcx, Expr>,
                                       dest_ty: Ty<'tcx>,
                                       base: F,
                                       info: G)
-                                      -> DatumBlock<'blk, 'tcx, Expr> where
-        F: FnOnce(Block<'blk, 'tcx>, ValueRef) -> ValueRef,
-        G: FnOnce(Block<'blk, 'tcx>, ValueRef) -> ValueRef,
+                                      -> DatumBlock<'fcx, 'blk, 'tcx, Expr> where
+        F: FnOnce(Block<'fcx, 'blk, 'tcx>, ValueRef) -> ValueRef,
+        G: FnOnce(Block<'fcx, 'blk, 'tcx>, ValueRef) -> ValueRef,
     {
         let mut bcx = bcx;
 
@@ -412,11 +412,11 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         DatumBlock::new(bcx, scratch.to_expr_datum())
     }
 
-    fn unsize_unique_vec<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+    fn unsize_unique_vec<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                      expr: &ast::Expr,
                                      datum: Datum<'tcx, Expr>,
                                      len: uint)
-                                     -> DatumBlock<'blk, 'tcx, Expr> {
+                                     -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
         let mut bcx = bcx;
         let tcx = bcx.tcx();
 
@@ -440,11 +440,11 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         DatumBlock::new(bcx, scratch.to_expr_datum())
     }
 
-    fn unsize_unique_expr<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+    fn unsize_unique_expr<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                       expr: &ast::Expr,
                                       datum: Datum<'tcx, Expr>,
                                       k: &ty::UnsizeKind<'tcx>)
-                                      -> DatumBlock<'blk, 'tcx, Expr> {
+                                      -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
         let mut bcx = bcx;
         let tcx = bcx.tcx();
 
@@ -483,10 +483,10 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 /// something like `x().f` is translated into roughly the equivalent of
 ///
 ///   { tmp = x(); tmp.f }
-pub fn trans_to_lvalue<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_to_lvalue<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                    expr: &ast::Expr,
                                    name: &str)
-                                   -> DatumBlock<'blk, 'tcx, Lvalue> {
+                                   -> DatumBlock<'fcx, 'blk, 'tcx, Lvalue> {
     let mut bcx = bcx;
     let datum = unpack_datum!(bcx, trans(bcx, expr));
     return datum.to_lvalue_datum(bcx, name, expr.id);
@@ -494,9 +494,9 @@ pub fn trans_to_lvalue<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
 /// A version of `trans` that ignores adjustments. You almost certainly do not want to call this
 /// directly.
-fn trans_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_unadjusted<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                 expr: &ast::Expr)
-                                -> DatumBlock<'blk, 'tcx, Expr> {
+                                -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     let mut bcx = bcx;
 
     debug!("trans_unadjusted(expr={})", bcx.expr_to_string(expr));
@@ -545,17 +545,17 @@ fn trans_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         }
     };
 
-    fn nil<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, ty: Ty<'tcx>)
-                       -> DatumBlock<'blk, 'tcx, Expr> {
+    fn nil<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, ty: Ty<'tcx>)
+                       -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
         let llval = C_undef(type_of::type_of(bcx.ccx(), ty));
         let datum = immediate_rvalue(llval, ty);
         DatumBlock::new(bcx, datum.to_expr_datum())
     }
 }
 
-fn trans_datum_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_datum_unadjusted<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                       expr: &ast::Expr)
-                                      -> DatumBlock<'blk, 'tcx, Expr> {
+                                      -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     let mut bcx = bcx;
     let fcx = bcx.fcx;
     let _icx = push_ctxt("trans_datum_unadjusted");
@@ -630,10 +630,10 @@ fn trans_datum_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     }
 }
 
-fn trans_field<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
+fn trans_field<'fcx, 'blk, 'tcx, F>(bcx: Block<'fcx, 'blk, 'tcx>,
                               base: &ast::Expr,
                               get_idx: F)
-                              -> DatumBlock<'blk, 'tcx, Expr> where
+                              -> DatumBlock<'fcx, 'blk, 'tcx, Expr> where
     F: FnOnce(&'blk ty::ctxt<'tcx>, &[ty::field<'tcx>]) -> uint,
 {
     let mut bcx = bcx;
@@ -665,27 +665,27 @@ fn trans_field<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
 }
 
 /// Translates `base.field`.
-fn trans_rec_field<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_rec_field<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                base: &ast::Expr,
                                field: ast::Ident)
-                               -> DatumBlock<'blk, 'tcx, Expr> {
+                               -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     trans_field(bcx, base, |tcx, field_tys| ty::field_idx_strict(tcx, field.name, field_tys))
 }
 
 /// Translates `base.<idx>`.
-fn trans_rec_tup_field<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_rec_tup_field<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                    base: &ast::Expr,
                                    idx: uint)
-                                   -> DatumBlock<'blk, 'tcx, Expr> {
+                                   -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     trans_field(bcx, base, |_, _| idx)
 }
 
-fn trans_index<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_index<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                            index_expr: &ast::Expr,
                            base: &ast::Expr,
                            idx: &ast::Expr,
                            method_call: MethodCall)
-                           -> DatumBlock<'blk, 'tcx, Expr> {
+                           -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     //! Translates `base[idx]`.
 
     let _icx = push_ctxt("trans_index");
@@ -795,10 +795,10 @@ fn trans_index<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     DatumBlock::new(bcx, elt_datum)
 }
 
-fn trans_def<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_def<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                          ref_expr: &ast::Expr,
                          def: def::Def)
-                         -> DatumBlock<'blk, 'tcx, Expr> {
+                         -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     //! Translates a reference to a path.
 
     let _icx = push_ctxt("trans_def_lvalue");
@@ -819,7 +819,7 @@ fn trans_def<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             //     pointer to that.
             let const_ty = expr_ty(bcx, ref_expr);
 
-            fn get_val<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, did: ast::DefId,
+            fn get_val<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, did: ast::DefId,
                                    const_ty: Ty<'tcx>) -> ValueRef {
                 // For external constants, we don't inline.
                 if did.krate == ast::LOCAL_CRATE {
@@ -873,13 +873,13 @@ fn trans_def<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     }
 }
 
-fn trans_rvalue_stmt_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_rvalue_stmt_unadjusted<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                             expr: &ast::Expr)
-                                            -> Block<'blk, 'tcx> {
+                                            -> Block<'fcx, 'blk, 'tcx> {
     let mut bcx = bcx;
     let _icx = push_ctxt("trans_rvalue_stmt");
 
-    if bcx.unreachable.get() {
+    if bcx.data.unreachable.get() {
         return bcx;
     }
 
@@ -982,10 +982,10 @@ fn trans_rvalue_stmt_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     }
 }
 
-fn trans_rvalue_dps_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_rvalue_dps_unadjusted<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                            expr: &ast::Expr,
                                            dest: Dest)
-                                           -> Block<'blk, 'tcx> {
+                                           -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_rvalue_dps_unadjusted");
     let mut bcx = bcx;
     let tcx = bcx.tcx();
@@ -1187,11 +1187,11 @@ fn trans_rvalue_dps_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     }
 }
 
-fn trans_def_dps_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_def_dps_unadjusted<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                         ref_expr: &ast::Expr,
                                         def: def::Def,
                                         dest: Dest)
-                                        -> Block<'blk, 'tcx> {
+                                        -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_def_dps_unadjusted");
 
     let lldest = match dest {
@@ -1267,7 +1267,7 @@ pub fn trans_def_fn_unadjusted<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 }
 
 /// Translates a reference to a local variable or argument. This always results in an lvalue datum.
-pub fn trans_local_var<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_local_var<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                    def: def::Def)
                                    -> Datum<'tcx, Lvalue> {
     let _icx = push_ctxt("trans_local_var");
@@ -1363,13 +1363,13 @@ pub fn with_field_tys<'tcx, R, F>(tcx: &ty::ctxt<'tcx>,
     }
 }
 
-fn trans_struct<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_struct<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                             fields: &[ast::Field],
                             base: Option<&ast::Expr>,
                             expr_span: codemap::Span,
                             expr_id: ast::NodeId,
                             ty: Ty<'tcx>,
-                            dest: Dest) -> Block<'blk, 'tcx> {
+                            dest: Dest) -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_rec");
 
     let tcx = bcx.tcx();
@@ -1442,14 +1442,14 @@ pub struct StructBaseInfo<'a, 'tcx> {
 ///
 /// - `optbase` contains information on the base struct (if any) from
 /// which remaining fields are copied; see comments on `StructBaseInfo`.
-pub fn trans_adt<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
+pub fn trans_adt<'a, 'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>,
                                  ty: Ty<'tcx>,
                                  discr: ty::Disr,
                                  fields: &[(uint, &ast::Expr)],
                                  optbase: Option<StructBaseInfo<'a, 'tcx>>,
                                  dest: Dest,
                                  source_location: Option<NodeInfo>)
-                                 -> Block<'blk, 'tcx> {
+                                 -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_adt");
     let fcx = bcx.fcx;
     let repr = adt::represent_type(bcx.ccx(), ty);
@@ -1548,10 +1548,10 @@ pub fn trans_adt<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
 }
 
 
-fn trans_immediate_lit<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_immediate_lit<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                    expr: &ast::Expr,
                                    lit: &ast::Lit)
-                                   -> DatumBlock<'blk, 'tcx, Expr> {
+                                   -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     // must not be a string constant, that is a RvalueDpsExpr
     let _icx = push_ctxt("trans_immediate_lit");
     let ty = expr_ty(bcx, expr);
@@ -1559,11 +1559,11 @@ fn trans_immediate_lit<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     immediate_rvalue_bcx(bcx, v, ty).to_expr_datumblock()
 }
 
-fn trans_unary<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_unary<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                            expr: &ast::Expr,
                            op: ast::UnOp,
                            sub_expr: &ast::Expr)
-                           -> DatumBlock<'blk, 'tcx, Expr> {
+                           -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     let ccx = bcx.ccx();
     let mut bcx = bcx;
     let _icx = push_ctxt("trans_unary_datum");
@@ -1607,11 +1607,11 @@ fn trans_unary<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     }
 }
 
-fn trans_uniq_expr<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_uniq_expr<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                box_ty: Ty<'tcx>,
                                contents: &ast::Expr,
                                contents_ty: Ty<'tcx>)
-                               -> DatumBlock<'blk, 'tcx, Expr> {
+                               -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     let _icx = push_ctxt("trans_uniq_expr");
     let fcx = bcx.fcx;
     assert!(type_is_sized(bcx.tcx(), contents_ty));
@@ -1636,10 +1636,10 @@ fn trans_uniq_expr<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     immediate_rvalue_bcx(bcx, val, box_ty).to_expr_datumblock()
 }
 
-fn trans_addr_of<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_addr_of<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                              expr: &ast::Expr,
                              subexpr: &ast::Expr)
-                             -> DatumBlock<'blk, 'tcx, Expr> {
+                             -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     let _icx = push_ctxt("trans_addr_of");
     let mut bcx = bcx;
     let sub_datum = unpack_datum!(bcx, trans_to_lvalue(bcx, subexpr, "addr_of"));
@@ -1669,7 +1669,7 @@ fn trans_addr_of<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
 // Important to get types for both lhs and rhs, because one might be _|_
 // and the other not.
-fn trans_eager_binop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_eager_binop<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                  binop_expr: &ast::Expr,
                                  binop_ty: Ty<'tcx>,
                                  op: ast::BinOp,
@@ -1677,7 +1677,7 @@ fn trans_eager_binop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                  lhs: ValueRef,
                                  rhs_t: Ty<'tcx>,
                                  rhs: ValueRef)
-                                 -> DatumBlock<'blk, 'tcx, Expr> {
+                                 -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     let _icx = push_ctxt("trans_eager_binop");
 
     let tcx = bcx.tcx();
@@ -1765,12 +1765,12 @@ enum lazy_binop_ty {
     lazy_or,
 }
 
-fn trans_lazy_binop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_lazy_binop<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                 binop_expr: &ast::Expr,
                                 op: lazy_binop_ty,
                                 a: &ast::Expr,
                                 b: &ast::Expr)
-                                -> DatumBlock<'blk, 'tcx, Expr> {
+                                -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     let _icx = push_ctxt("trans_lazy_binop");
     let binop_ty = expr_ty(bcx, binop_expr);
     let fcx = bcx.fcx;
@@ -1778,7 +1778,7 @@ fn trans_lazy_binop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let DatumBlock {bcx: past_lhs, datum: lhs} = trans(bcx, a);
     let lhs = lhs.to_llscalarish(past_lhs);
 
-    if past_lhs.unreachable.get() {
+    if past_lhs.data.unreachable.get() {
         return immediate_rvalue_bcx(past_lhs, lhs, binop_ty).to_expr_datumblock();
     }
 
@@ -1786,30 +1786,30 @@ fn trans_lazy_binop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let before_rhs = fcx.new_id_block("before_rhs", b.id);
 
     match op {
-      lazy_and => CondBr(past_lhs, lhs, before_rhs.llbb, join.llbb),
-      lazy_or => CondBr(past_lhs, lhs, join.llbb, before_rhs.llbb)
+      lazy_and => CondBr(past_lhs, lhs, before_rhs.data.llbb, join.data.llbb),
+      lazy_or => CondBr(past_lhs, lhs, join.data.llbb, before_rhs.data.llbb)
     }
 
     let DatumBlock {bcx: past_rhs, datum: rhs} = trans(before_rhs, b);
     let rhs = rhs.to_llscalarish(past_rhs);
 
-    if past_rhs.unreachable.get() {
+    if past_rhs.data.unreachable.get() {
         return immediate_rvalue_bcx(join, lhs, binop_ty).to_expr_datumblock();
     }
 
-    Br(past_rhs, join.llbb);
+    Br(past_rhs, join.data.llbb);
     let phi = Phi(join, Type::i1(bcx.ccx()), &[lhs, rhs],
-                  &[past_lhs.llbb, past_rhs.llbb]);
+                  &[past_lhs.data.llbb, past_rhs.data.llbb]);
 
     return immediate_rvalue_bcx(join, phi, binop_ty).to_expr_datumblock();
 }
 
-fn trans_binary<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_binary<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                             expr: &ast::Expr,
                             op: ast::BinOp,
                             lhs: &ast::Expr,
                             rhs: &ast::Expr)
-                            -> DatumBlock<'blk, 'tcx, Expr> {
+                            -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     let _icx = push_ctxt("trans_binary");
     let ccx = bcx.ccx();
 
@@ -1846,14 +1846,14 @@ fn trans_binary<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     }
 }
 
-fn trans_overloaded_op<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_overloaded_op<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                    expr: &ast::Expr,
                                    method_call: MethodCall,
                                    lhs: Datum<'tcx, Expr>,
                                    rhs: Vec<(Datum<'tcx, Expr>, ast::NodeId)>,
                                    dest: Option<Dest>,
                                    autoref: bool)
-                                   -> Result<'blk, 'tcx> {
+                                   -> Result<'fcx, 'blk, 'tcx> {
     let method_ty = (*bcx.tcx().method_map.borrow())[method_call].ty;
     callee::trans_call_inner(bcx,
                              Some(expr_info(expr)),
@@ -1868,12 +1868,12 @@ fn trans_overloaded_op<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                              dest)
 }
 
-fn trans_overloaded_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
+fn trans_overloaded_call<'a, 'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>,
                                          expr: &ast::Expr,
                                          callee: &'a ast::Expr,
                                          args: &'a [P<ast::Expr>],
                                          dest: Option<Dest>)
-                                         -> Block<'blk, 'tcx> {
+                                         -> Block<'fcx, 'blk, 'tcx> {
     let method_call = MethodCall::expr(expr.id);
     let method_type = (*bcx.tcx()
                            .method_map
@@ -1971,10 +1971,10 @@ fn cast_is_noop<'tcx>(t_in: Ty<'tcx>, t_out: Ty<'tcx>) -> bool {
     }
 }
 
-fn trans_imm_cast<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_imm_cast<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                               expr: &ast::Expr,
                               id: ast::NodeId)
-                              -> DatumBlock<'blk, 'tcx, Expr> {
+                              -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     let _icx = push_ctxt("trans_cast");
     let mut bcx = bcx;
     let ccx = bcx.ccx();
@@ -2063,12 +2063,12 @@ fn trans_imm_cast<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     return immediate_rvalue_bcx(bcx, newval, t_out).to_expr_datumblock();
 }
 
-fn trans_assign_op<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_assign_op<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                expr: &ast::Expr,
                                op: ast::BinOp,
                                dst: &ast::Expr,
                                src: &ast::Expr)
-                               -> Block<'blk, 'tcx> {
+                               -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_assign_op");
     let mut bcx = bcx;
 
@@ -2095,10 +2095,10 @@ fn trans_assign_op<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     return result_datum.store_to(bcx, dst_datum.val);
 }
 
-fn auto_ref<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn auto_ref<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                         datum: Datum<'tcx, Expr>,
                         expr: &ast::Expr)
-                        -> DatumBlock<'blk, 'tcx, Expr> {
+                        -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     let mut bcx = bcx;
 
     // Ensure cleanup of `datum` if not already scheduled and obtain
@@ -2119,11 +2119,11 @@ fn auto_ref<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     DatumBlock::new(bcx, Datum::new(llref, ptr_ty, RvalueExpr(Rvalue::new(ByValue))))
 }
 
-fn deref_multiple<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn deref_multiple<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                               expr: &ast::Expr,
                               datum: Datum<'tcx, Expr>,
                               times: uint)
-                              -> DatumBlock<'blk, 'tcx, Expr> {
+                              -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     let mut bcx = bcx;
     let mut datum = datum;
     for i in range(0, times) {
@@ -2133,11 +2133,11 @@ fn deref_multiple<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     DatumBlock { bcx: bcx, datum: datum }
 }
 
-fn deref_once<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn deref_once<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                           expr: &ast::Expr,
                           datum: Datum<'tcx, Expr>,
                           method_call: MethodCall)
-                          -> DatumBlock<'blk, 'tcx, Expr> {
+                          -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     let ccx = bcx.ccx();
 
     debug!("deref_once(expr={}, datum={}, method_call={:?})",
@@ -2240,11 +2240,11 @@ fn deref_once<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     /// pointer. Because the free is shallow, it is legit to return an rvalue, because we know that
     /// the contents are not yet scheduled to be freed. The language rules ensure that the contents
     /// will be used (or moved) before the free occurs.
-    fn deref_owned_pointer<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+    fn deref_owned_pointer<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                        expr: &ast::Expr,
                                        datum: Datum<'tcx, Expr>,
                                        content_ty: Ty<'tcx>)
-                                       -> DatumBlock<'blk, 'tcx, Expr> {
+                                       -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
         match datum.kind {
             RvalueExpr(Rvalue { mode: ByRef }) => {
                 let scope = cleanup::temporary_scope(bcx.tcx(), expr.id);

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -213,13 +213,13 @@ pub fn register_foreign_item_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 ///   can derive these from callee_ty but in the case of variadic
 ///   functions passed_arg_tys will include the Rust type of all
 ///   the arguments including the ones not specified in the fn's signature.
-pub fn trans_native_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_native_call<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                      callee_ty: Ty<'tcx>,
                                      llfn: ValueRef,
                                      llretptr: ValueRef,
                                      llargs_rust: &[ValueRef],
                                      passed_arg_tys: Vec<Ty<'tcx>>)
-                                     -> Block<'blk, 'tcx>
+                                     -> Block<'fcx, 'blk, 'tcx>
 {
     let ccx = bcx.ccx();
     let tcx = bcx.tcx();

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -302,8 +302,10 @@ fn trans_struct_drop<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
     })
 }
 
-fn size_and_align_of_dst<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, t: Ty<'tcx>, info: ValueRef)
-                                     -> (ValueRef, ValueRef) {
+fn size_and_align_of_dst<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
+                                           t: Ty<'tcx>,
+                                           info: ValueRef)
+                                           -> (ValueRef, ValueRef) {
     debug!("calculate size of DST: {}; with lost info: {}",
            bcx.ty_to_string(t), bcx.val_to_string(info));
     if type_is_sized(bcx.tcx(), t) {

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -45,9 +45,9 @@ use std::ffi::CString;
 use syntax::ast;
 use syntax::parse::token;
 
-pub fn trans_exchange_free_dyn<'blk, 'tcx>(cx: Block<'blk, 'tcx>, v: ValueRef,
+pub fn trans_exchange_free_dyn<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>, v: ValueRef,
                                            size: ValueRef, align: ValueRef)
-                                           -> Block<'blk, 'tcx> {
+                                           -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("trans_exchange_free");
     let ccx = cx.ccx();
     callee::trans_lang_call(cx,
@@ -56,14 +56,14 @@ pub fn trans_exchange_free_dyn<'blk, 'tcx>(cx: Block<'blk, 'tcx>, v: ValueRef,
         Some(expr::Ignore)).bcx
 }
 
-pub fn trans_exchange_free<'blk, 'tcx>(cx: Block<'blk, 'tcx>, v: ValueRef,
-                                       size: u64, align: u32) -> Block<'blk, 'tcx> {
+pub fn trans_exchange_free<'fcx, 'blk, 'tcx>(cx: Block<'fcx, 'blk, 'tcx>, v: ValueRef,
+                                       size: u64, align: u32) -> Block<'fcx, 'blk, 'tcx> {
     trans_exchange_free_dyn(cx, v, C_uint(cx.ccx(), size),
                                    C_uint(cx.ccx(), align))
 }
 
-pub fn trans_exchange_free_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, ptr: ValueRef,
-                                          content_ty: Ty<'tcx>) -> Block<'blk, 'tcx> {
+pub fn trans_exchange_free_ty<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, ptr: ValueRef,
+                                          content_ty: Ty<'tcx>) -> Block<'fcx, 'blk, 'tcx> {
     assert!(type_is_sized(bcx.ccx().tcx(), content_ty));
     let sizing_type = sizing_type_of(bcx.ccx(), content_ty);
     let content_size = llsize_of_alloc(bcx.ccx(), sizing_type);
@@ -103,11 +103,11 @@ pub fn get_drop_glue_type<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     }
 }
 
-pub fn drop_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn drop_ty<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                            v: ValueRef,
                            t: Ty<'tcx>,
                            source_location: Option<NodeInfo>)
-                           -> Block<'blk, 'tcx> {
+                           -> Block<'fcx, 'blk, 'tcx> {
     // NB: v is an *alias* of type t here, not a direct value.
     debug!("drop_ty(t={})", t.repr(bcx.tcx()));
     let _icx = push_ctxt("drop_ty");
@@ -131,11 +131,11 @@ pub fn drop_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     bcx
 }
 
-pub fn drop_ty_immediate<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn drop_ty_immediate<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                      v: ValueRef,
                                      t: Ty<'tcx>,
                                      source_location: Option<NodeInfo>)
-                                     -> Block<'blk, 'tcx> {
+                                     -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("drop_ty_immediate");
     let vp = alloca(bcx, type_of(bcx.ccx(), t), "");
     store_ty(bcx, v, vp, t);
@@ -186,13 +186,13 @@ pub fn get_drop_glue<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> Val
     glue
 }
 
-fn trans_struct_drop_flag<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
+fn trans_struct_drop_flag<'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>,
                                       t: Ty<'tcx>,
                                       v0: ValueRef,
                                       dtor_did: ast::DefId,
                                       class_did: ast::DefId,
                                       substs: &subst::Substs<'tcx>)
-                                      -> Block<'blk, 'tcx> {
+                                      -> Block<'fcx, 'blk, 'tcx> {
     let repr = adt::represent_type(bcx.ccx(), t);
     let struct_data = if type_is_sized(bcx.tcx(), t) {
         v0
@@ -206,13 +206,13 @@ fn trans_struct_drop_flag<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
     })
 }
 
-fn trans_struct_drop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_struct_drop<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                  t: Ty<'tcx>,
                                  v0: ValueRef,
                                  dtor_did: ast::DefId,
                                  class_did: ast::DefId,
                                  substs: &subst::Substs<'tcx>)
-                                 -> Block<'blk, 'tcx>
+                                 -> Block<'fcx, 'blk, 'tcx>
 {
     let repr = adt::represent_type(bcx.ccx(), t);
 
@@ -302,7 +302,7 @@ fn trans_struct_drop<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     })
 }
 
-fn size_and_align_of_dst<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, info: ValueRef)
+fn size_and_align_of_dst<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, t: Ty<'tcx>, info: ValueRef)
                                      -> (ValueRef, ValueRef) {
     debug!("calculate size of DST: {}; with lost info: {}",
            bcx.ty_to_string(t), bcx.val_to_string(info));
@@ -360,8 +360,8 @@ fn size_and_align_of_dst<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, info: 
     }
 }
 
-fn make_drop_glue<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, v0: ValueRef, t: Ty<'tcx>)
-                              -> Block<'blk, 'tcx> {
+fn make_drop_glue<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, v0: ValueRef, t: Ty<'tcx>)
+                              -> Block<'fcx, 'blk, 'tcx> {
     // NB: v0 is an *alias* of type t here, not a direct value.
     let _icx = push_ctxt("make_drop_glue");
     match t.sty {
@@ -532,7 +532,8 @@ fn make_generic_glue<'a, 'tcx, F>(ccx: &CrateContext<'a, 'tcx>,
                                   helper: F,
                                   name: &str)
                                   -> ValueRef where
-    F: for<'blk> FnOnce(Block<'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'blk, 'tcx>,
+    F: for<'fcx, 'blk> FnOnce(Block<'fcx, 'blk, 'tcx>, ValueRef, Ty<'tcx>)
+                              -> Block<'fcx, 'blk, 'tcx>,
 {
     let _icx = push_ctxt("make_generic_glue");
     let glue_name = format!("glue {} {}", name, ty_to_short_str(ccx.tcx(), t));

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -142,7 +142,7 @@ pub fn check_intrinsics(ccx: &CrateContext) {
     ccx.sess().abort_if_errors();
 }
 
-pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
+pub fn trans_intrinsic_call<'a, 'fcx, 'blk, 'tcx>(mut bcx: Block<'fcx, 'blk, 'tcx>,
                                             node: ast::NodeId,
                                             callee_ty: Ty<'tcx>,
                                             cleanup_scope: cleanup::CustomScopeIndex,
@@ -150,7 +150,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                                             dest: expr::Dest,
                                             substs: subst::Substs<'tcx>,
                                             call_info: NodeInfo)
-                                            -> Result<'blk, 'tcx>
+                                            -> Result<'fcx, 'blk, 'tcx>
 {
     let fcx = bcx.fcx;
     let ccx = fcx.ccx;
@@ -617,7 +617,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
     Result::new(bcx, llresult)
 }
 
-fn copy_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn copy_intrinsic<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                               allow_overlap: bool, volatile: bool, tp_ty: Ty<'tcx>,
                               dst: ValueRef, src: ValueRef, count: ValueRef) -> ValueRef {
     let ccx = bcx.ccx();
@@ -647,7 +647,7 @@ fn copy_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                       C_bool(ccx, volatile)], None)
 }
 
-fn memset_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, volatile: bool, tp_ty: Ty<'tcx>,
+fn memset_intrinsic<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, volatile: bool, tp_ty: Ty<'tcx>,
                                 dst: ValueRef, val: ValueRef, count: ValueRef) -> ValueRef {
     let ccx = bcx.ccx();
     let lltp_ty = type_of::type_of(ccx, tp_ty);
@@ -672,7 +672,7 @@ fn count_zeros_intrinsic(bcx: Block, name: &'static str, val: ValueRef) -> Value
     Call(bcx, llfn, &[val, y], None)
 }
 
-fn with_overflow_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, name: &'static str,
+fn with_overflow_intrinsic<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>, name: &'static str,
                                        t: Ty<'tcx>, a: ValueRef, b: ValueRef) -> ValueRef {
     let llfn = bcx.ccx().get_intrinsic(&name);
 

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -103,11 +103,11 @@ pub fn trans_impl(ccx: &CrateContext,
     }
 }
 
-pub fn trans_method_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_method_callee<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                        method_call: MethodCall,
                                        self_expr: Option<&ast::Expr>,
                                        arg_cleanup_scope: cleanup::ScopeId)
-                                       -> Callee<'blk, 'tcx> {
+                                       -> Callee<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("meth::trans_method_callee");
 
     let (origin, method_ty) =
@@ -328,12 +328,12 @@ fn method_with_name(ccx: &CrateContext, impl_id: ast::DefId, name: ast::Name)
     meth_did.def_id()
 }
 
-fn trans_monomorphized_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_monomorphized_callee<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                           method_call: MethodCall,
                                           trait_id: ast::DefId,
                                           n_method: uint,
                                           vtable: traits::Vtable<'tcx, ()>)
-                                          -> Callee<'blk, 'tcx> {
+                                          -> Callee<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("meth::trans_monomorphized_callee");
     match vtable {
         traits::VtableImpl(vtable_impl) => {
@@ -404,7 +404,7 @@ fn trans_monomorphized_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
  /// In that case, the vector we want is: `[X, M1, M2, M3]`.  Therefore, what we do now is to slice
  /// off the method type parameters and append them to the type parameters from the type that the
  /// receiver is mapped to.
-fn combine_impl_and_methods_tps<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn combine_impl_and_methods_tps<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                             node: ExprOrMethodCall,
                                             rcvr_substs: subst::Substs<'tcx>)
                                             -> subst::Substs<'tcx>
@@ -435,12 +435,12 @@ fn combine_impl_and_methods_tps<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 /// In this case, we must pull the fn pointer out of the vtable that is packaged up with the
 /// object. Objects are represented as a pair, so we first evaluate the self expression and then
 /// extract the self data and vtable out of the pair.
-fn trans_trait_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn trans_trait_callee<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                   method_ty: Ty<'tcx>,
                                   n_method: uint,
                                   self_expr: &ast::Expr,
                                   arg_cleanup_scope: cleanup::ScopeId)
-                                  -> Callee<'blk, 'tcx> {
+                                  -> Callee<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("meth::trans_trait_callee");
     let mut bcx = bcx;
 
@@ -472,11 +472,11 @@ fn trans_trait_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
 /// Same as `trans_trait_callee()` above, except that it is given a by-ref pointer to the object
 /// pair.
-pub fn trans_trait_callee_from_llval<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_trait_callee_from_llval<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                                  callee_ty: Ty<'tcx>,
                                                  n_method: uint,
                                                  llpair: ValueRef)
-                                                 -> Callee<'blk, 'tcx> {
+                                                 -> Callee<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("meth::trans_trait_callee");
     let ccx = bcx.ccx();
 
@@ -689,7 +689,7 @@ pub fn trans_object_shim<'a, 'tcx>(
 /// `trait_ref` would map `T:Trait`, but `box_ty` would be
 /// `Foo<T>`. This `box_ty` is primarily used to encode the destructor.
 /// This will hopefully change now that DST is underway.
-pub fn get_vtable<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn get_vtable<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                               box_ty: Ty<'tcx>,
                               trait_ref: ty::PolyTraitRef<'tcx>)
                               -> ValueRef
@@ -795,7 +795,7 @@ pub fn make_vtable<I: Iterator<Item=ValueRef>>(ccx: &CrateContext,
     }
 }
 
-fn emit_vtable_methods<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+fn emit_vtable_methods<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                    impl_id: ast::DefId,
                                    substs: subst::Substs<'tcx>)
                                    -> Vec<ValueRef> {
@@ -854,12 +854,12 @@ fn emit_vtable_methods<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 /// Generates the code to convert from a pointer (`Box<T>`, `&T`, etc) into an object
 /// (`Box<Trait>`, `&Trait`, etc). This means creating a pair where the first word is the vtable
 /// and the second word is the pointer.
-pub fn trans_trait_cast<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_trait_cast<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                     datum: Datum<'tcx, Expr>,
                                     id: ast::NodeId,
                                     trait_ref: ty::PolyTraitRef<'tcx>,
                                     dest: expr::Dest)
-                                    -> Block<'blk, 'tcx> {
+                                    -> Block<'fcx, 'blk, 'tcx> {
     let mut bcx = bcx;
     let _icx = push_ctxt("meth::trans_trait_cast");
 

--- a/src/librustc_trans/trans/tvec.rs
+++ b/src/librustc_trans/trans/tvec.rs
@@ -44,11 +44,11 @@ fn get_dataptr(bcx: Block, vptr: ValueRef) -> ValueRef {
     Load(bcx, expr::get_dataptr(bcx, vptr))
 }
 
-pub fn make_drop_glue_unboxed<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn make_drop_glue_unboxed<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                           vptr: ValueRef,
                                           unit_ty: Ty<'tcx>,
                                           should_deallocate: bool)
-                                          -> Block<'blk, 'tcx> {
+                                          -> Block<'fcx, 'blk, 'tcx> {
     let not_null = IsNotNull(bcx, vptr);
     with_cond(bcx, not_null, |bcx| {
         let ccx = bcx.ccx();
@@ -99,10 +99,10 @@ impl<'tcx> VecTypes<'tcx> {
     }
 }
 
-pub fn trans_fixed_vstore<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_fixed_vstore<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                       expr: &ast::Expr,
                                       dest: expr::Dest)
-                                      -> Block<'blk, 'tcx> {
+                                      -> Block<'fcx, 'blk, 'tcx> {
     //!
     //
     // [...] allocates a fixed-size array and moves it around "by value".
@@ -129,10 +129,10 @@ pub fn trans_fixed_vstore<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 /// &[...] allocates memory on the stack and writes the values into it, returning the vector (the
 /// caller must make the reference).  "..." is similar except that the memory can be statically
 /// allocated and we return a reference (strings are always by-ref).
-pub fn trans_slice_vec<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_slice_vec<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                    slice_expr: &ast::Expr,
                                    content_expr: &ast::Expr)
-                                   -> DatumBlock<'blk, 'tcx, Expr> {
+                                   -> DatumBlock<'fcx, 'blk, 'tcx, Expr> {
     let fcx = bcx.fcx;
     let ccx = fcx.ccx;
     let mut bcx = bcx;
@@ -192,11 +192,11 @@ pub fn trans_slice_vec<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
 /// Literal strings translate to slices into static memory.  This is different from
 /// trans_slice_vstore() above because it doesn't need to copy the content anywhere.
-pub fn trans_lit_str<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn trans_lit_str<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                  lit_expr: &ast::Expr,
                                  str_lit: InternedString,
                                  dest: Dest)
-                                 -> Block<'blk, 'tcx> {
+                                 -> Block<'fcx, 'blk, 'tcx> {
     debug!("trans_lit_str(lit_expr={}, dest={})",
            bcx.expr_to_string(lit_expr),
            dest.to_string(bcx.ccx()));
@@ -215,12 +215,12 @@ pub fn trans_lit_str<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     }
 }
 
-pub fn write_content<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn write_content<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                  vt: &VecTypes<'tcx>,
                                  vstore_expr: &ast::Expr,
                                  content_expr: &ast::Expr,
                                  dest: Dest)
-                                 -> Block<'blk, 'tcx> {
+                                 -> Block<'fcx, 'blk, 'tcx> {
     let _icx = push_ctxt("tvec::write_content");
     let fcx = bcx.fcx;
     let mut bcx = bcx;
@@ -311,14 +311,14 @@ pub fn write_content<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     }
 }
 
-pub fn vec_types_from_expr<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn vec_types_from_expr<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                                        vec_expr: &ast::Expr)
                                        -> VecTypes<'tcx> {
     let vec_ty = node_id_type(bcx, vec_expr.id);
     vec_types(bcx, ty::sequence_element_type(bcx.tcx(), vec_ty))
 }
 
-pub fn vec_types<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+pub fn vec_types<'fcx, 'blk, 'tcx>(bcx: Block<'fcx, 'blk, 'tcx>,
                              unit_ty: Ty<'tcx>)
                              -> VecTypes<'tcx> {
     let ccx = bcx.ccx();
@@ -404,13 +404,13 @@ pub fn get_base_and_len(bcx: Block,
     }
 }
 
-pub fn iter_vec_loop<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
+pub fn iter_vec_loop<'fcx, 'blk, 'tcx, F>(bcx: Block<'fcx, 'blk, 'tcx>,
                                      data_ptr: ValueRef,
                                      vt: &VecTypes<'tcx>,
                                      count: ValueRef,
                                      f: F)
-                                     -> Block<'blk, 'tcx> where
-    F: FnOnce(Block<'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'blk, 'tcx>,
+                                     -> Block<'fcx, 'blk, 'tcx> where
+    F: FnOnce(Block<'fcx, 'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'fcx, 'blk, 'tcx>,
 {
     let _icx = push_ctxt("tvec::iter_vec_loop");
     let fcx = bcx.fcx;
@@ -420,14 +420,14 @@ pub fn iter_vec_loop<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
     let cond_bcx = fcx.new_temp_block("expr_repeat: loop cond");
     let body_bcx = fcx.new_temp_block("expr_repeat: body: set");
     let inc_bcx = fcx.new_temp_block("expr_repeat: body: inc");
-    Br(bcx, loop_bcx.llbb);
+    Br(bcx, loop_bcx.data.llbb);
 
     let loop_counter = {
         // i = 0
         let i = alloca(loop_bcx, bcx.ccx().int_type(), "__i");
         Store(loop_bcx, C_uint(bcx.ccx(), 0u), i);
 
-        Br(loop_bcx, cond_bcx.llbb);
+        Br(loop_bcx, cond_bcx.data.llbb);
         i
     };
 
@@ -436,7 +436,7 @@ pub fn iter_vec_loop<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
         let rhs = count;
         let cond_val = ICmp(cond_bcx, llvm::IntULT, lhs, rhs);
 
-        CondBr(cond_bcx, cond_val, body_bcx.llbb, next_bcx.llbb);
+        CondBr(cond_bcx, cond_val, body_bcx.data.llbb, next_bcx.data.llbb);
     }
 
     { // loop body
@@ -448,7 +448,7 @@ pub fn iter_vec_loop<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
         };
         let body_bcx = f(body_bcx, lleltptr, vt.unit_ty);
 
-        Br(body_bcx, inc_bcx.llbb);
+        Br(body_bcx, inc_bcx.data.llbb);
     }
 
     { // i += 1
@@ -456,19 +456,19 @@ pub fn iter_vec_loop<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
         let plusone = Add(inc_bcx, i, C_uint(bcx.ccx(), 1u));
         Store(inc_bcx, plusone, loop_counter);
 
-        Br(inc_bcx, cond_bcx.llbb);
+        Br(inc_bcx, cond_bcx.data.llbb);
     }
 
     next_bcx
 }
 
-pub fn iter_vec_raw<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
+pub fn iter_vec_raw<'fcx, 'blk, 'tcx, F>(bcx: Block<'fcx, 'blk, 'tcx>,
                                    data_ptr: ValueRef,
                                    unit_ty: Ty<'tcx>,
                                    len: ValueRef,
                                    f: F)
-                                   -> Block<'blk, 'tcx> where
-    F: FnOnce(Block<'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'blk, 'tcx>,
+                                   -> Block<'fcx, 'blk, 'tcx> where
+    F: FnOnce(Block<'fcx, 'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'fcx, 'blk, 'tcx>,
 {
     let _icx = push_ctxt("tvec::iter_vec_raw");
     let fcx = bcx.fcx;
@@ -484,19 +484,19 @@ pub fn iter_vec_raw<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
 
         // Now perform the iteration.
         let header_bcx = fcx.new_temp_block("iter_vec_loop_header");
-        Br(bcx, header_bcx.llbb);
+        Br(bcx, header_bcx.data.llbb);
         let data_ptr =
-            Phi(header_bcx, val_ty(data_ptr), &[data_ptr], &[bcx.llbb]);
+            Phi(header_bcx, val_ty(data_ptr), &[data_ptr], &[bcx.data.llbb]);
         let not_yet_at_end =
             ICmp(header_bcx, llvm::IntULT, data_ptr, data_end_ptr);
         let body_bcx = fcx.new_temp_block("iter_vec_loop_body");
         let next_bcx = fcx.new_temp_block("iter_vec_next");
-        CondBr(header_bcx, not_yet_at_end, body_bcx.llbb, next_bcx.llbb);
+        CondBr(header_bcx, not_yet_at_end, body_bcx.data.llbb, next_bcx.data.llbb);
         let body_bcx = f(body_bcx, data_ptr, vt.unit_ty);
         AddIncomingToPhi(data_ptr, InBoundsGEP(body_bcx, data_ptr,
                                                &[C_int(bcx.ccx(), 1i)]),
-                         body_bcx.llbb);
-        Br(body_bcx, header_bcx.llbb);
+                         body_bcx.data.llbb);
+        Br(body_bcx, header_bcx.data.llbb);
         next_bcx
     }
 }

--- a/src/librustc_trans/trans/value.rs
+++ b/src/librustc_trans/trans/value.rs
@@ -58,7 +58,7 @@ impl Value {
         match self.get_single_user().and_then(|user| user.as_store_inst()) {
             Some(store) => {
                 store.get_parent().and_then(|store_bb| {
-                    let mut bb = BasicBlock(bcx.llbb);
+                    let mut bb = BasicBlock(bcx.data.llbb);
                     let mut ret = Some(store);
                     while bb.get() != store_bb.get() {
                         match bb.get_single_predecessor() {


### PR DESCRIPTION
This is the first commit from #21022, pulled out into a separate PR to ease future rebasing pain.

This is a semantics-preserving refactoring of the existing code.  It removes a cyclic structure from `librustc_trans`, so that the `BlockS` structures no longer carry a reference to the `FunctionContext`.
