### PR TITLE
Fixes to cfg .mk files for Windows

### DIFF
--- a/mk/cfg/i686-pc-windows-gnu.mk
+++ b/mk/cfg/i686-pc-windows-gnu.mk
@@ -8,8 +8,8 @@ CFG_LIB_NAME_i686-pc-windows-gnu=$(1).dll
 CFG_STATIC_LIB_NAME_i686-pc-windows-gnu=$(1).lib
 CFG_LIB_GLOB_i686-pc-windows-gnu=$(1)-*.dll
 CFG_LIB_DSYM_GLOB_i686-pc-windows-gnu=$(1)-*.dylib.dSYM
-CFG_JEMALLOC_CFLAGS_i686-pc-windows-gnu := -march=i686 -m32 -D_WIN32_WINNT=0x0600 $(CFLAGS)
-CFG_GCCISH_CFLAGS_i686-pc-windows-gnu := -Wall -Werror -g -m32 -D_WIN32_WINNT=0x0600 $(CFLAGS)
+CFG_JEMALLOC_CFLAGS_i686-pc-windows-gnu := -march=i686 -m32 -D_WIN32_WINNT=0x0600 -D__USE_MINGW_ANSI_STDIO=1 $(CFLAGS)
+CFG_GCCISH_CFLAGS_i686-pc-windows-gnu := -Wall -Werror -g -m32 -D_WIN32_WINNT=0x0600 -D__USE_MINGW_ANSI_STDIO=1 $(CFLAGS)
 CFG_GCCISH_CXXFLAGS_i686-pc-windows-gnu := -fno-rtti $(CXXFLAGS)
 CFG_GCCISH_LINK_FLAGS_i686-pc-windows-gnu := -shared -g -m32
 CFG_GCCISH_DEF_FLAG_i686-pc-windows-gnu :=
@@ -22,7 +22,7 @@ CFG_EXE_SUFFIX_i686-pc-windows-gnu := .exe
 CFG_WINDOWSY_i686-pc-windows-gnu := 1
 CFG_UNIXY_i686-pc-windows-gnu :=
 CFG_PATH_MUNGE_i686-pc-windows-gnu :=
-CFG_LDPATH_i686-pc-windows-gnu :=$(CFG_LDPATH_i686-pc-windows-gnu):$(PATH)
-CFG_RUN_i686-pc-windows-gnu=PATH="$(CFG_LDPATH_i686-pc-windows-gnu):$(1)" $(2)
-CFG_RUN_TARG_i686-pc-windows-gnu=$(call CFG_RUN_i686-pc-windows-gnu,$(HLIB$(1)_H_$(CFG_BUILD)),$(2))
+CFG_LDPATH_i686-pc-windows-gnu :=
+CFG_RUN_i686-pc-windows-gnu=$(2)
+CFG_RUN_TARG_i686-pc-windows-gnu=$(call CFG_RUN_i686-pc-windows-gnu,,$(2))
 CFG_GNU_TRIPLE_i686-pc-windows-gnu := i686-w64-mingw32

--- a/mk/cfg/x86_64-pc-windows-gnu.mk
+++ b/mk/cfg/x86_64-pc-windows-gnu.mk
@@ -8,8 +8,8 @@ CFG_LIB_NAME_x86_64-pc-windows-gnu=$(1).dll
 CFG_STATIC_LIB_NAME_x86_64-pc-windows-gnu=$(1).lib
 CFG_LIB_GLOB_x86_64-pc-windows-gnu=$(1)-*.dll
 CFG_LIB_DSYM_GLOB_x86_64-pc-windows-gnu=$(1)-*.dylib.dSYM
-CFG_JEMALLOC_CFLAGS_x86_64-pc-windows-gnu := -m64 -D_WIN32_WINNT=0x0600 $(CFLAGS)
-CFG_GCCISH_CFLAGS_x86_64-pc-windows-gnu := -Wall -Werror -g -m64 -D_WIN32_WINNT=0x0600 $(CFLAGS)
+CFG_JEMALLOC_CFLAGS_x86_64-pc-windows-gnu := -m64 -D_WIN32_WINNT=0x0600 -D__USE_MINGW_ANSI_STDIO=1 $(CFLAGS)
+CFG_GCCISH_CFLAGS_x86_64-pc-windows-gnu := -Wall -Werror -g -m64 -D_WIN32_WINNT=0x0600 -D__USE_MINGW_ANSI_STDIO=1 $(CFLAGS)
 CFG_GCCISH_CXXFLAGS_x86_64-pc-windows-gnu := -fno-rtti $(CXXFLAGS)
 CFG_GCCISH_LINK_FLAGS_x86_64-pc-windows-gnu := -shared -g -m64
 CFG_GCCISH_DEF_FLAG_x86_64-pc-windows-gnu :=
@@ -22,7 +22,7 @@ CFG_EXE_SUFFIX_x86_64-pc-windows-gnu := .exe
 CFG_WINDOWSY_x86_64-pc-windows-gnu := 1
 CFG_UNIXY_x86_64-pc-windows-gnu :=
 CFG_PATH_MUNGE_x86_64-pc-windows-gnu :=
-CFG_LDPATH_x86_64-pc-windows-gnu :=$(CFG_LDPATH_x86_64-pc-windows-gnu):$(PATH)
-CFG_RUN_x86_64-pc-windows-gnu=PATH="$(CFG_LDPATH_x86_64-pc-windows-gnu):$(1)" $(2)
-CFG_RUN_TARG_x86_64-pc-windows-gnu=$(call CFG_RUN_x86_64-pc-windows-gnu,$(HLIB$(1)_H_$(CFG_BUILD)),$(2))
+CFG_LDPATH_x86_64-pc-windows-gnu :=
+CFG_RUN_x86_64-pc-windows-gnu=$(2)
+CFG_RUN_TARG_x86_64-pc-windows-gnu=$(call CFG_RUN_x86_64-pc-windows-gnu,,$(2))
 CFG_GNU_TRIPLE_x86_64-pc-windows-gnu := x86_64-w64-mingw32


### PR DESCRIPTION
Removed use of unused LDPATH variable on Windows as is done for other platforms, and added GCC flag to ensure MINGW's ANSI compatible STDIO functions are used wherever available (required by jemalloc).

Without these changes it ends up setting the PATH twice, and the second time the PATH begins with `:` which is invalid.  Also the regular msvcrt printf-like functions would be used which don't understand stuff like %hhd and %z which jemalloc uses.

This change ought not to make any difference to the output but it fixes the build process for me since at least my build environment couldn't handle that broken path caused by LDPATH being empty.
