### PR TITLE
std: Deprecate `finally` module

### DIFF
--- a/src/libcore/finally.rs
+++ b/src/libcore/finally.rs
@@ -32,7 +32,7 @@
 //! # }
 //! ```
 
-#![unstable]
+#![deprecated = "this was an unsightly interface. just implement Drop"]
 
 use ops::{Drop, FnMut, FnOnce};
 

--- a/src/libcore/finally.rs
+++ b/src/libcore/finally.rs
@@ -32,7 +32,11 @@
 //! # }
 //! ```
 
-#![deprecated = "this was an unsightly interface. just implement Drop"]
+#![deprecated = "It is unclear if this module is more robust than implementing \
+                 Drop on a custom type, and this module is being removed with no \
+                 replacement. Use a custom Drop implementation to regain existing \
+                 functionality."]
+#![allow(deprecated)]
 
 use ops::{Drop, FnMut, FnOnce};
 

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -12,11 +12,47 @@
 // ignore-windows FIXME #13259
 
 #![feature(unboxed_closures)]
+#![feature(unsafe_destructor)]
 
 use std::os;
 use std::io::process::Command;
-use std::finally::Finally;
 use std::str;
+use std::ops::{Drop, FnMut, FnOnce};
+
+pub trait Finally<T> {
+    fn finally<F>(&mut self, dtor: F) -> T where F: FnMut();
+}
+
+impl<T, F> Finally<T> for F where F: FnMut() -> T {
+    fn finally<G>(&mut self, mut dtor: G) -> T where G: FnMut() {
+        try_finally(&mut (), self, |_, f| (*f)(), |_| dtor())
+    }
+}
+
+pub fn try_finally<T, U, R, F, G>(mutate: &mut T, drop: U, try_fn: F, finally_fn: G) -> R where
+    F: FnOnce(&mut T, U) -> R,
+    G: FnMut(&mut T),
+{
+    let f = Finallyalizer {
+        mutate: mutate,
+        dtor: finally_fn,
+    };
+    try_fn(&mut *f.mutate, drop)
+}
+
+struct Finallyalizer<'a, A:'a, F> where F: FnMut(&mut A) {
+    mutate: &'a mut A,
+    dtor: F,
+}
+
+#[unsafe_destructor]
+impl<'a, A, F> Drop for Finallyalizer<'a, A, F> where F: FnMut(&mut A) {
+    #[inline]
+    fn drop(&mut self) {
+        (self.dtor)(self.mutate);
+    }
+}
+
 
 #[inline(never)]
 fn foo() {


### PR DESCRIPTION
No in-tree users. Ugly interface. Closes #14332.

I just happened to notice that this module still lives and has no users. Assuming we don't want it.

r? @aturon cc @alexcrichton
