### PR TITLE
graphviz-flowgraph: add --xpretty flowgraph,unlabelled variant

### DIFF
--- a/src/librustc/middle/cfg/graphviz.rs
+++ b/src/librustc/middle/cfg/graphviz.rs
@@ -28,6 +28,8 @@ pub struct LabelledCFG<'a, 'ast: 'a> {
     pub ast_map: &'a ast_map::Map<'ast>,
     pub cfg: &'a cfg::CFG,
     pub name: String,
+    /// `labelled_edges` controls whether we emit labels on the edges
+    pub labelled_edges: bool,
 }
 
 fn replace_newline_with_backslash_l(s: String) -> String {
@@ -75,6 +77,9 @@ impl<'a, 'ast> dot::Labeller<'a, Node<'a>, Edge<'a>> for LabelledCFG<'a, 'ast> {
 
     fn edge_label(&self, e: &Edge<'a>) -> dot::LabelText<'a> {
         let mut label = String::new();
+        if !self.labelled_edges {
+            return dot::LabelText::EscStr(label.into_cow());
+        }
         let mut put_one = false;
         for (i, &node_id) in e.data.exiting_scopes.iter().enumerate() {
             if put_one {

--- a/src/test/run-make/graphviz-flowgraph/Makefile
+++ b/src/test/run-make/graphviz-flowgraph/Makefile
@@ -28,7 +28,7 @@ $(TMPDIR)/%.pp: %.rs
 
 $(TMPDIR)/%.dot: %.rs
 	$(eval $(call FIND_LAST_BLOCK,$<))
-	$(RUSTC_LIB) -Z unstable-options --xpretty flowgraph=$(LASTBLOCKNUM_$<) $< -o $@.tmp
+	$(RUSTC_LIB) -Z unstable-options --xpretty flowgraph,unlabelled=$(LASTBLOCKNUM_$<) $< -o $@.tmp
 	cat $@.tmp | sed -e 's@ (id=[0-9]*)@@g' \
                          -e 's@\[label=""\]@@' \
                          -e 's@digraph [a-zA-Z0-9_]* @digraph block @' \

--- a/src/test/run-make/graphviz-flowgraph/f12.dot-expected.dot
+++ b/src/test/run-make/graphviz-flowgraph/f12.dot-expected.dot
@@ -34,7 +34,7 @@ digraph block {
     N11 -> N12;
     N12 -> N13;
     N13 -> N14;
-    N14 -> N6[label="exiting scope_0 expr break,\lexiting scope_1 stmt break ;,\lexiting scope_2 block { break ; \"unreachable\"; },\lexiting scope_3 expr if x == 2is { break ; \"unreachable\"; },\lexiting scope_4 block { x -= 1is; if x == 2is { break ; \"unreachable\"; } }"];
+    N14 -> N6;
     N15 -> N16;
     N16 -> N17;
     N17 -> N18;

--- a/src/test/run-make/graphviz-flowgraph/f15.dot-expected.dot
+++ b/src/test/run-make/graphviz-flowgraph/f15.dot-expected.dot
@@ -61,7 +61,7 @@ digraph block {
     N12 -> N13;
     N13 -> N14;
     N14 -> N15;
-    N15 -> N9[label="exiting scope_0 expr break \'outer,\lexiting scope_1 stmt break \'outer ;,\lexiting scope_2 block { break \'outer ; \"unreachable\"; },\lexiting scope_3 expr if x == 1is { break \'outer ; \"unreachable\"; },\lexiting scope_4 stmt if x == 1is { break \'outer ; \"unreachable\"; },\lexiting scope_5 block {\l    if x == 1is { break \'outer ; \"unreachable\"; }\l    if y >= 2is { break ; \"unreachable\"; }\l    y -= 3is;\l}\l,\lexiting scope_6 expr \'inner:\l    loop  {\l        if x == 1is { break \'outer ; \"unreachable\"; }\l        if y >= 2is { break ; \"unreachable\"; }\l        y -= 3is;\l    }\l,\lexiting scope_7 stmt \'inner:\l    loop  {\l        if x == 1is { break \'outer ; \"unreachable\"; }\l        if y >= 2is { break ; \"unreachable\"; }\l        y -= 3is;\l    }\l,\lexiting scope_8 block {\l    \'inner:\l        loop  {\l            if x == 1is { break \'outer ; \"unreachable\"; }\l            if y >= 2is { break ; \"unreachable\"; }\l            y -= 3is;\l        }\l    y -= 4is;\l    x -= 5is;\l}\l"];
+    N15 -> N9;
     N16 -> N17;
     N17 -> N18;
     N18 -> N19;
@@ -73,7 +73,7 @@ digraph block {
     N23 -> N24;
     N24 -> N25;
     N25 -> N26;
-    N26 -> N11[label="exiting scope_0 expr break,\lexiting scope_1 stmt break ;,\lexiting scope_2 block { break ; \"unreachable\"; },\lexiting scope_3 expr if y >= 2is { break ; \"unreachable\"; },\lexiting scope_4 stmt if y >= 2is { break ; \"unreachable\"; },\lexiting scope_5 block {\l    if x == 1is { break \'outer ; \"unreachable\"; }\l    if y >= 2is { break ; \"unreachable\"; }\l    y -= 3is;\l}\l"];
+    N26 -> N11;
     N27 -> N28;
     N28 -> N29;
     N29 -> N30;

--- a/src/test/run-make/graphviz-flowgraph/f16.dot-expected.dot
+++ b/src/test/run-make/graphviz-flowgraph/f16.dot-expected.dot
@@ -64,7 +64,7 @@ digraph block {
     N12 -> N13;
     N13 -> N14;
     N14 -> N15;
-    N15 -> N8[label="exiting scope_0 expr continue \'outer,\lexiting scope_1 stmt continue \'outer ;,\lexiting scope_2 block { continue \'outer ; \"unreachable\"; },\lexiting scope_3 expr if x == 1is { continue \'outer ; \"unreachable\"; },\lexiting scope_4 stmt if x == 1is { continue \'outer ; \"unreachable\"; },\lexiting scope_5 block {\l    if x == 1is { continue \'outer ; \"unreachable\"; }\l    if y >= 1is { break ; \"unreachable\"; }\l    y -= 1is;\l}\l,\lexiting scope_6 expr \'inner:\l    loop  {\l        if x == 1is { continue \'outer ; \"unreachable\"; }\l        if y >= 1is { break ; \"unreachable\"; }\l        y -= 1is;\l    }\l,\lexiting scope_7 stmt \'inner:\l    loop  {\l        if x == 1is { continue \'outer ; \"unreachable\"; }\l        if y >= 1is { break ; \"unreachable\"; }\l        y -= 1is;\l    }\l,\lexiting scope_8 block {\l    \'inner:\l        loop  {\l            if x == 1is { continue \'outer ; \"unreachable\"; }\l            if y >= 1is { break ; \"unreachable\"; }\l            y -= 1is;\l        }\l    y -= 1is;\l    x -= 1is;\l}\l"];
+    N15 -> N8;
     N16 -> N17;
     N17 -> N18;
     N18 -> N19;
@@ -76,7 +76,7 @@ digraph block {
     N23 -> N24;
     N24 -> N25;
     N25 -> N26;
-    N26 -> N11[label="exiting scope_0 expr break,\lexiting scope_1 stmt break ;,\lexiting scope_2 block { break ; \"unreachable\"; },\lexiting scope_3 expr if y >= 1is { break ; \"unreachable\"; },\lexiting scope_4 stmt if y >= 1is { break ; \"unreachable\"; },\lexiting scope_5 block {\l    if x == 1is { continue \'outer ; \"unreachable\"; }\l    if y >= 1is { break ; \"unreachable\"; }\l    y -= 1is;\l}\l"];
+    N26 -> N11;
     N27 -> N28;
     N28 -> N29;
     N29 -> N30;

--- a/src/test/run-make/graphviz-flowgraph/f21.dot-expected.dot
+++ b/src/test/run-make/graphviz-flowgraph/f21.dot-expected.dot
@@ -59,7 +59,7 @@ digraph block {
     N12 -> N13;
     N13 -> N14;
     N14 -> N15;
-    N15 -> N9[label="exiting scope_0 expr break \'outer,\lexiting scope_1 stmt break \'outer ;,\lexiting scope_2 block { break \'outer ; \"unreachable\"; },\lexiting scope_3 expr if x == 1is { break \'outer ; \"unreachable\"; },\lexiting scope_4 stmt if x == 1is { break \'outer ; \"unreachable\"; },\lexiting scope_5 block {\l    if x == 1is { break \'outer ; \"unreachable\"; }\l    if y >= 2is { return; \"unreachable\"; }\l    y -= 3is;\l    x -= 5is;\l}\l,\lexiting scope_6 expr \'inner:\l    loop  {\l        if x == 1is { break \'outer ; \"unreachable\"; }\l        if y >= 2is { return; \"unreachable\"; }\l        y -= 3is;\l        x -= 5is;\l    }\l,\lexiting scope_7 stmt \'inner:\l    loop  {\l        if x == 1is { break \'outer ; \"unreachable\"; }\l        if y >= 2is { return; \"unreachable\"; }\l        y -= 3is;\l        x -= 5is;\l    }\l,\lexiting scope_8 block {\l    \'inner:\l        loop  {\l            if x == 1is { break \'outer ; \"unreachable\"; }\l            if y >= 2is { return; \"unreachable\"; }\l            y -= 3is;\l            x -= 5is;\l        }\l    \"unreachable\";\l}\l"];
+    N15 -> N9;
     N16 -> N17;
     N17 -> N18;
     N18 -> N19;
@@ -71,7 +71,7 @@ digraph block {
     N23 -> N24;
     N24 -> N25;
     N25 -> N26;
-    N26 -> N1[label="exiting scope_0 expr \'inner:\l    loop  {\l        if x == 1is { break \'outer ; \"unreachable\"; }\l        if y >= 2is { return; \"unreachable\"; }\l        y -= 3is;\l        x -= 5is;\l    }\l,\lexiting scope_1 expr \'outer:\l    loop  {\l        \'inner:\l            loop  {\l                if x == 1is { break \'outer ; \"unreachable\"; }\l                if y >= 2is { return; \"unreachable\"; }\l                y -= 3is;\l                x -= 5is;\l            }\l        \"unreachable\";\l    }\l"];
+    N26 -> N1;
     N27 -> N28;
     N28 -> N29;
     N29 -> N30;

--- a/src/test/run-make/graphviz-flowgraph/f22.dot-expected.dot
+++ b/src/test/run-make/graphviz-flowgraph/f22.dot-expected.dot
@@ -62,7 +62,7 @@ digraph block {
     N12 -> N13;
     N13 -> N14;
     N14 -> N15;
-    N15 -> N8[label="exiting scope_0 expr continue \'outer,\lexiting scope_1 stmt continue \'outer ;,\lexiting scope_2 block { continue \'outer ; \"unreachable\"; },\lexiting scope_3 expr if x == 1is { continue \'outer ; \"unreachable\"; },\lexiting scope_4 stmt if x == 1is { continue \'outer ; \"unreachable\"; },\lexiting scope_5 block {\l    if x == 1is { continue \'outer ; \"unreachable\"; }\l    if y >= 2is { return; \"unreachable\"; }\l    x -= 1is;\l    y -= 3is;\l}\l,\lexiting scope_6 expr \'inner:\l    loop  {\l        if x == 1is { continue \'outer ; \"unreachable\"; }\l        if y >= 2is { return; \"unreachable\"; }\l        x -= 1is;\l        y -= 3is;\l    }\l,\lexiting scope_7 stmt \'inner:\l    loop  {\l        if x == 1is { continue \'outer ; \"unreachable\"; }\l        if y >= 2is { return; \"unreachable\"; }\l        x -= 1is;\l        y -= 3is;\l    }\l,\lexiting scope_8 block {\l    \'inner:\l        loop  {\l            if x == 1is { continue \'outer ; \"unreachable\"; }\l            if y >= 2is { return; \"unreachable\"; }\l            x -= 1is;\l            y -= 3is;\l        }\l    \"unreachable\";\l}\l"];
+    N15 -> N8;
     N16 -> N17;
     N17 -> N18;
     N18 -> N19;
@@ -74,7 +74,7 @@ digraph block {
     N23 -> N24;
     N24 -> N25;
     N25 -> N26;
-    N26 -> N1[label="exiting scope_0 expr \'inner:\l    loop  {\l        if x == 1is { continue \'outer ; \"unreachable\"; }\l        if y >= 2is { return; \"unreachable\"; }\l        x -= 1is;\l        y -= 3is;\l    }\l,\lexiting scope_1 expr \'outer:\l    loop  {\l        \'inner:\l            loop  {\l                if x == 1is { continue \'outer ; \"unreachable\"; }\l                if y >= 2is { return; \"unreachable\"; }\l                x -= 1is;\l                y -= 3is;\l            }\l        \"unreachable\";\l    }\l"];
+    N26 -> N1;
     N27 -> N28;
     N28 -> N29;
     N29 -> N30;

--- a/src/test/run-make/graphviz-flowgraph/f23.dot-expected.dot
+++ b/src/test/run-make/graphviz-flowgraph/f23.dot-expected.dot
@@ -95,7 +95,7 @@ digraph block {
     N40 -> N41;
     N41 -> N42;
     N42 -> N43;
-    N43 -> N1[label="exiting scope_0 expr while y > 0is {\l    y -= 1is;\l    while z > 0is { z -= 1is; }\l    if x > 10is { return; \"unreachable\"; }\l}\l,\lexiting scope_1 expr while x > 0is {\l    x -= 1is;\l    while y > 0is {\l        y -= 1is;\l        while z > 0is { z -= 1is; }\l        if x > 10is { return; \"unreachable\"; }\l    }\l}\l"];
+    N43 -> N1;
     N44 -> N45;
     N45 -> N46;
     N46 -> N47;

--- a/src/test/run-make/graphviz-flowgraph/f24.dot-expected.dot
+++ b/src/test/run-make/graphviz-flowgraph/f24.dot-expected.dot
@@ -90,7 +90,7 @@ digraph block {
     N13 -> N14;
     N14 -> N15;
     N15 -> N16;
-    N16 -> N12[label="exiting scope_0 expr break,\lexiting scope_1 stmt break ;,\lexiting scope_2 block { break ; \"unreachable\"; },\lexiting scope_3 expr if x == 0is { break ; \"unreachable\"; },\lexiting scope_4 stmt if x == 0is { break ; \"unreachable\"; },\lexiting scope_5 block {\l    if x == 0is { break ; \"unreachable\"; }\l    x -= 1is;\l    loop  {\l        if y == 0is { break ; \"unreachable\"; }\l        y -= 1is;\l        loop  { if z == 0is { break ; \"unreachable\"; } z -= 1is; }\l        if x > 10is { return; \"unreachable\"; }\l    }\l}\l"];
+    N16 -> N12;
     N17 -> N18;
     N18 -> N19;
     N19 -> N20;
@@ -107,7 +107,7 @@ digraph block {
     N30 -> N31;
     N31 -> N32;
     N32 -> N33;
-    N33 -> N29[label="exiting scope_0 expr break,\lexiting scope_1 stmt break ;,\lexiting scope_2 block { break ; \"unreachable\"; },\lexiting scope_3 expr if y == 0is { break ; \"unreachable\"; },\lexiting scope_4 stmt if y == 0is { break ; \"unreachable\"; },\lexiting scope_5 block {\l    if y == 0is { break ; \"unreachable\"; }\l    y -= 1is;\l    loop  { if z == 0is { break ; \"unreachable\"; } z -= 1is; }\l    if x > 10is { return; \"unreachable\"; }\l}\l"];
+    N33 -> N29;
     N34 -> N35;
     N35 -> N36;
     N36 -> N37;
@@ -124,7 +124,7 @@ digraph block {
     N47 -> N48;
     N48 -> N49;
     N49 -> N50;
-    N50 -> N46[label="exiting scope_0 expr break,\lexiting scope_1 stmt break ;,\lexiting scope_2 block { break ; \"unreachable\"; },\lexiting scope_3 expr if z == 0is { break ; \"unreachable\"; },\lexiting scope_4 stmt if z == 0is { break ; \"unreachable\"; },\lexiting scope_5 block { if z == 0is { break ; \"unreachable\"; } z -= 1is; }"];
+    N50 -> N46;
     N51 -> N52;
     N52 -> N53;
     N53 -> N54;
@@ -143,7 +143,7 @@ digraph block {
     N64 -> N65;
     N65 -> N66;
     N66 -> N67;
-    N67 -> N1[label="exiting scope_0 expr loop  {\l    if y == 0is { break ; \"unreachable\"; }\l    y -= 1is;\l    loop  { if z == 0is { break ; \"unreachable\"; } z -= 1is; }\l    if x > 10is { return; \"unreachable\"; }\l}\l,\lexiting scope_1 expr loop  {\l    if x == 0is { break ; \"unreachable\"; }\l    x -= 1is;\l    loop  {\l        if y == 0is { break ; \"unreachable\"; }\l        y -= 1is;\l        loop  { if z == 0is { break ; \"unreachable\"; } z -= 1is; }\l        if x > 10is { return; \"unreachable\"; }\l    }\l}\l"];
+    N67 -> N1;
     N68 -> N69;
     N69 -> N70;
     N70 -> N71;

--- a/src/test/run-make/graphviz-flowgraph/f25.dot-expected.dot
+++ b/src/test/run-make/graphviz-flowgraph/f25.dot-expected.dot
@@ -90,7 +90,7 @@ digraph block {
     N13 -> N14;
     N14 -> N15;
     N15 -> N16;
-    N16 -> N12[label="exiting scope_0 expr break,\lexiting scope_1 stmt break ;,\lexiting scope_2 block { break ; \"unreachable\"; },\lexiting scope_3 expr if x == 0is { break ; \"unreachable\"; },\lexiting scope_4 stmt if x == 0is { break ; \"unreachable\"; },\lexiting scope_5 block {\l    if x == 0is { break ; \"unreachable\"; }\l    x -= 1is;\l    \'a:\l        loop  {\l            if y == 0is { break ; \"unreachable\"; }\l            y -= 1is;\l            \'a: loop  { if z == 0is { break ; \"unreachable\"; } z -= 1is; }\l            if x > 10is { continue \'a ; \"unreachable\"; }\l        }\l}\l"];
+    N16 -> N12;
     N17 -> N18;
     N18 -> N19;
     N19 -> N20;
@@ -107,7 +107,7 @@ digraph block {
     N30 -> N31;
     N31 -> N32;
     N32 -> N33;
-    N33 -> N29[label="exiting scope_0 expr break,\lexiting scope_1 stmt break ;,\lexiting scope_2 block { break ; \"unreachable\"; },\lexiting scope_3 expr if y == 0is { break ; \"unreachable\"; },\lexiting scope_4 stmt if y == 0is { break ; \"unreachable\"; },\lexiting scope_5 block {\l    if y == 0is { break ; \"unreachable\"; }\l    y -= 1is;\l    \'a: loop  { if z == 0is { break ; \"unreachable\"; } z -= 1is; }\l    if x > 10is { continue \'a ; \"unreachable\"; }\l}\l"];
+    N33 -> N29;
     N34 -> N35;
     N35 -> N36;
     N36 -> N37;
@@ -124,7 +124,7 @@ digraph block {
     N47 -> N48;
     N48 -> N49;
     N49 -> N50;
-    N50 -> N46[label="exiting scope_0 expr break,\lexiting scope_1 stmt break ;,\lexiting scope_2 block { break ; \"unreachable\"; },\lexiting scope_3 expr if z == 0is { break ; \"unreachable\"; },\lexiting scope_4 stmt if z == 0is { break ; \"unreachable\"; },\lexiting scope_5 block { if z == 0is { break ; \"unreachable\"; } z -= 1is; }"];
+    N50 -> N46;
     N51 -> N52;
     N52 -> N53;
     N53 -> N54;
@@ -143,7 +143,7 @@ digraph block {
     N64 -> N65;
     N65 -> N66;
     N66 -> N67;
-    N67 -> N28[label="exiting scope_0 expr continue \'a,\lexiting scope_1 stmt continue \'a ;,\lexiting scope_2 block { continue \'a ; \"unreachable\"; },\lexiting scope_3 expr if x > 10is { continue \'a ; \"unreachable\"; },\lexiting scope_4 block {\l    if y == 0is { break ; \"unreachable\"; }\l    y -= 1is;\l    \'a: loop  { if z == 0is { break ; \"unreachable\"; } z -= 1is; }\l    if x > 10is { continue \'a ; \"unreachable\"; }\l}\l"];
+    N67 -> N28;
     N68 -> N69;
     N69 -> N70;
     N70 -> N71;


### PR DESCRIPTION
Add `--xpretty flowgraph,unlabelled` variant to the (unstable) flowgraph printing `rustc` option.

This makes the tests much easier to maintain; the particular details of the labels attached to exiting scopes is not worth the effort required to keep it up to date as things change in the compiler internals.
