### PR TITLE
Support UFCS style calls and "impl-trait-for-trait"

### DIFF
--- a/src/test/run-pass/issue-20676.rs
+++ b/src/test/run-pass/issue-20676.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for #20676. Error was that we didn't support
+// UFCS-style calls to a method in `Trait` where `Self` was bound to a
+// trait object of type `Trait`. See also `ufcs-trait-object.rs`.
+
+use std::fmt;
+
+fn main() {
+    let a: &fmt::Show = &1_i32;
+    format!("{:?}", a);
+}

--- a/src/test/run-pass/ufcs-trait-object.rs
+++ b/src/test/run-pass/ufcs-trait-object.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that when you use ufcs form to invoke a trait method (on a
+// trait object) everything works fine.
+
+trait Foo {
+    fn test(&self) -> i32;
+}
+
+impl Foo for i32 {
+    fn test(&self) -> i32 { *self }
+}
+
+fn main() {
+    let a: &Foo = &22_i32;
+    assert_eq!(Foo::test(a), 22);
+}


### PR DESCRIPTION
Support UFCS style calls to a method defined in `Trait` where `Self` is bound to a trait object. Fixes #20676.

r? @alexcrichton 
