### PR TITLE
Add foreach to IteratorExt

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -119,6 +119,22 @@ pub trait Extend<A> {
 /// An extension trait providing numerous methods applicable to all iterators.
 #[stable]
 pub trait IteratorExt: Iterator + Sized {
+    /// Executes f foreach element for its side effect.
+    /// Syntatic suggar over a for loop. 
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let mut sum = 0i
+    /// range(0,10).foreach(|x| sum = sum + x)
+    /// assert!(sum == 55)
+    /// ```
+    fn foreach<F>(&mut self, mut f: F)
+        where F: FnMut(Self::Item) {
+        for i in *self {
+            f(i)
+        }
+    }
     /// Counts the number of elements in this iterator.
     ///
     /// # Example

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -71,6 +71,13 @@ fn test_multi_iter() {
 }
 
 #[test]
+fn test_foreach() {
+    let mut sum: i32 = 0;
+    (0..10).foreach(|x| sum = sum + x);
+    assert!(sum == 45);
+}
+
+#[test]
 fn test_counter_from_iter() {
     let it = count(0i, 5).take(10);
     let xs: Vec<int> = FromIterator::from_iter(it);


### PR DESCRIPTION
Its a common idiom in other functional languages for side effects when chaining iterator functions
