### PR TITLE
Implement ignore function on Result. Fixes #20949

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -157,6 +157,17 @@
 //! }
 //! ```
 //!
+//! If you are absolutely sure you want to ignore a result, you must
+//! do so explicitly:
+//!
+//! ```{.no_run}
+//! # use std::io::{File, Open, Write};
+//!
+//! # let mut file = File::open_mode(&Path::new("valuable_data.txt"), Open, Write);
+//! file.write_line("important message").ignore();
+//! # drop(file);
+//! ```
+//!
 //! # The `try!` macro
 //!
 //! When writing code that calls many functions that return the
@@ -350,6 +361,26 @@ impl<T, E> Result<T, E> {
         match self {
             Ok(_)  => None,
             Err(x) => Some(x),
+        }
+    }
+
+    /// Ignore this result.
+    ///
+    /// Converts `self` into (), consuming `self`, and
+    /// discarding the value or error.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let x: Result<uint, &str> = Ok(2);
+    /// x.ignore();
+    /// ```
+    #[inline]
+    #[stable]
+    pub fn ignore(self) {
+        match self {
+            Ok(_)  => (),
+            Err(_) => (),
         }
     }
 

--- a/src/libcoretest/result.rs
+++ b/src/libcoretest/result.rs
@@ -139,3 +139,12 @@ pub fn test_unwrap_or_else_panic() {
     let bad_err: Result<int, &'static str> = Err("Unrecoverable mess.");
     let _ : int = bad_err.unwrap_or_else(handler);
 }
+
+#[test]
+pub fn test_ignore() {
+    let ok: Result<int, &'static str> = Ok(100i);
+    let ok_err: Result<int, &'static str> = Err("Err");
+
+    ok.ignore();
+    ok_err.ignore();
+}


### PR DESCRIPTION
I decided to implement a fix for #20949, which adds a `.ignore` function to `Result`, because it seemed easy and fun to do. However, I'm I'll defer to Rust core devs to decide if they even want this feature. If you don't want this feature, no problem, just close the PR.

This is my first pull request, so please review mercilessly, and let me know if I should change anything.
