### PR TITLE
Remove unneeded box import in examples

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1588,7 +1588,6 @@ pointer values (pointing to a type for which an implementation of the given
 trait is in scope) to pointers to the trait name, used as a type.
 
 ```
-# use std::boxed::Box;
 # trait Shape { }
 # impl Shape for int { }
 # let mycircle = 0i;
@@ -1647,7 +1646,6 @@ fn radius_times_area<T: Circle>(c: T) -> f64 {
 Likewise, supertrait methods may also be called on trait objects.
 
 ```{.ignore}
-# use std::boxed::Box;
 # trait Shape { fn area(&self) -> f64; }
 # trait Circle : Shape { fn radius(&self) -> f64; }
 # impl Shape for int { fn area(&self) -> f64 { 0.0 } }
@@ -3799,7 +3797,6 @@ enclosing `enum` or `struct` type itself. Such recursion has restrictions:
 An example of a *recursive* type and its use:
 
 ```
-# use std::boxed::Box;
 enum List<T> {
     Nil,
     Cons(T, Box<List<T>>)
@@ -3912,7 +3909,6 @@ implementation of `R`, and the pointer value of `E`.
 An example of an object type:
 
 ```
-# use std::boxed::Box;
 trait Printable {
   fn stringify(&self) -> String;
 }
@@ -4120,7 +4116,6 @@ the type of a box is `std::owned::Box<T>`.
 An example of a box type and value:
 
 ```
-# use std::boxed::Box;
 let x: Box<int> = Box::new(10);
 ```
 
@@ -4130,7 +4125,6 @@ copy of a box to move ownership of the value. After a value has been moved,
 the source location cannot be used unless it is reinitialized.
 
 ```
-# use std::boxed::Box;
 let x: Box<int> = Box::new(10);
 let y = x;
 // attempting to use `x` will result in an error here

--- a/src/doc/trpl/ffi.md
+++ b/src/doc/trpl/ffi.md
@@ -262,8 +262,6 @@ referenced Rust object.
 Rust code:
 
 ~~~~no_run
-# use std::boxed::Box;
-
 #[repr(C)]
 struct RustObject {
     a: i32,

--- a/src/doc/trpl/ownership.md
+++ b/src/doc/trpl/ownership.md
@@ -81,7 +81,6 @@ therefore deallocates the memory for you. Here's the equivalent example in
 Rust:
 
 ```rust
-# use std::boxed::Box;
 {
     let x = Box::new(5);
 }
@@ -101,7 +100,6 @@ This is pretty straightforward, but what happens when we want to pass our box
 to a function? Let's look at some code:
 
 ```rust
-# use std::boxed::Box;
 fn main() {
     let x = Box::new(5);
 
@@ -117,7 +115,6 @@ This code works, but it's not ideal. For example, let's add one more line of
 code, where we print out the value of `x`:
 
 ```{rust,ignore}
-# use std::boxed::Box;
 fn main() {
     let x = Box::new(5);
 
@@ -151,7 +148,6 @@ To fix this, we can have `add_one` give ownership back when it's done with the
 box:
 
 ```rust
-# use std::boxed::Box;
 fn main() {
     let x = Box::new(5);
 

--- a/src/doc/trpl/pointers.md
+++ b/src/doc/trpl/pointers.md
@@ -455,7 +455,6 @@ fn rc_succ(x: Rc<int>) -> int { *x + 1 }
 Note that the caller of your function will have to modify their calls slightly:
 
 ```{rust}
-# use std::boxed::Box;
 use std::rc::Rc;
 
 fn succ(x: &int) -> int { *x + 1 }
@@ -478,7 +477,6 @@ those contents.
 heap allocation in Rust. Creating a box looks like this:
 
 ```{rust}
-# use std::boxed::Box;
 let x = Box::new(5i);
 ```
 
@@ -486,7 +484,6 @@ Boxes are heap allocated and they are deallocated automatically by Rust when
 they go out of scope:
 
 ```{rust}
-# use std::boxed::Box;
 {
     let x = Box::new(5i);
 
@@ -507,7 +504,6 @@ You don't need to fully grok the theory of affine types or regions to grok
 boxes, though. As a rough approximation, you can treat this Rust code:
 
 ```{rust}
-# use std::boxed::Box;
 {
     let x = Box::new(5i);
 
@@ -548,7 +544,6 @@ for more detail on how lifetimes work.
 Using boxes and references together is very common. For example:
 
 ```{rust}
-# use std::boxed::Box;
 fn add_one(x: &int) -> int {
     *x + 1
 }
@@ -566,7 +561,6 @@ function, and since it's only reading the value, allows it.
 We can borrow `x` multiple times, as long as it's not simultaneous:
 
 ```{rust}
-# use std::boxed::Box;
 fn add_one(x: &int) -> int {
     *x + 1
 }
@@ -583,7 +577,6 @@ fn main() {
 Or as long as it's not a mutable borrow. This will error:
 
 ```{rust,ignore}
-# use std::boxed::Box;
 fn add_one(x: &mut int) -> int {
     *x + 1
 }
@@ -610,7 +603,6 @@ Sometimes, you need a recursive data structure. The simplest is known as a
 
 
 ```{rust}
-# use std::boxed::Box;
 #[derive(Show)]
 enum List<T> {
     Cons(T, Box<List<T>>),
@@ -666,7 +658,6 @@ In many languages with pointers, you'd return a pointer from a function
 so as to avoid copying a large data structure. For example:
 
 ```{rust}
-# use std::boxed::Box;
 struct BigStruct {
     one: int,
     two: int,
@@ -695,7 +686,6 @@ than the hundred `int`s that make up the `BigStruct`.
 This is an antipattern in Rust. Instead, write this:
 
 ```{rust}
-# use std::boxed::Box;
 struct BigStruct {
     one: int,
     two: int,

--- a/src/doc/trpl/unsafe.md
+++ b/src/doc/trpl/unsafe.md
@@ -197,7 +197,6 @@ extern crate libc;
 use libc::{c_void, size_t, malloc, free};
 use std::mem;
 use std::ptr;
-# use std::boxed::Box;
 
 // Define a wrapper around the handle returned by the foreign code.
 // Unique<T> has the same semantics as Box<T>

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -66,7 +66,6 @@
 //! not (`None`).
 //!
 //! ```
-//! # use std::boxed::Box;
 //! let optional: Option<Box<int>> = None;
 //! check_optional(&optional);
 //!

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -46,7 +46,6 @@
 //! though unsafely, transformed from one type to the other.
 //!
 //! ```
-//! # use std::boxed::Box;
 //! use std::mem;
 //!
 //! unsafe {


### PR DESCRIPTION
Closes #21093.
r? @steveklabnik 
cc @alexcrichton 

I tested with `make check-docs` and this passes that.  Hope that was enough.
