### PR TITLE
[r+] Updating email address for Rohit Joshi

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -581,7 +581,7 @@ Robert Knight <robertknight@gmail.com>
 Robert Millar <robert.millar@cantab.net>
 Robin Gloster <robin@loc-com.de>
 Robin Stocker <robin@nibor.org>
-Rohit Joshi <rohit.joshi@capitalone.com>
+Rohit Joshi <rohit.c.joshi@gmail.com>
 Roland Tanglao <roland@rolandtanglao.com>
 Rolf Timmermans <rolftimmermans@voormedia.com>
 Rolf van de Krol <info@rolfvandekrol.nl>


### PR DESCRIPTION
When I submitted a PR #20326, mistakenly was committed using my work email. Correct the email address.

NOTE: Steve klabnik has updated  email address  in http://blog.rust-lang.org/2015/01/09/Rust-1.0-alpha.html
