### PR TITLE
rustc: Fix a leak in dependency= paths

### DIFF
--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -20,6 +20,7 @@ pub use self::NativeLibraryKind::*;
 use back::svh::Svh;
 use metadata::decoder;
 use metadata::loader;
+use session::search_paths::PathKind;
 use util::nodemap::{FnvHashMap, NodeMap};
 
 use std::cell::RefCell;
@@ -65,8 +66,8 @@ pub enum NativeLibraryKind {
 // must be non-None.
 #[derive(PartialEq, Clone)]
 pub struct CrateSource {
-    pub dylib: Option<Path>,
-    pub rlib: Option<Path>,
+    pub dylib: Option<(Path, PathKind)>,
+    pub rlib: Option<(Path, PathKind)>,
     pub cnum: ast::CrateNum,
 }
 
@@ -178,10 +179,10 @@ impl CStore {
         let mut libs = self.used_crate_sources.borrow()
             .iter()
             .map(|src| (src.cnum, match prefer {
-                RequireDynamic => src.dylib.clone(),
-                RequireStatic => src.rlib.clone(),
+                RequireDynamic => src.dylib.clone().map(|p| p.0),
+                RequireStatic => src.rlib.clone().map(|p| p.0),
             }))
-            .collect::<Vec<(ast::CrateNum, Option<Path>)>>();
+            .collect::<Vec<_>>();
         libs.sort_by(|&(a, _), &(b, _)| {
             ordering.position_elem(&a).cmp(&ordering.position_elem(&b))
         });

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -215,6 +215,7 @@
 use back::archive::{METADATA_FILENAME};
 use back::svh::Svh;
 use session::Session;
+use session::search_paths::PathKind;
 use llvm;
 use llvm::{False, ObjectFile, mk_section_iter};
 use llvm::archive_ro::ArchiveRO;
@@ -229,7 +230,7 @@ use rustc_back::target::Target;
 
 use std::ffi::CString;
 use std::cmp;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::io::fs::PathExtensions;
 use std::io;
 use std::ptr;
@@ -260,8 +261,8 @@ pub struct Context<'a> {
 }
 
 pub struct Library {
-    pub dylib: Option<Path>,
-    pub rlib: Option<Path>,
+    pub dylib: Option<(Path, PathKind)>,
+    pub rlib: Option<(Path, PathKind)>,
     pub metadata: MetadataBlob,
 }
 
@@ -384,7 +385,7 @@ impl<'a> Context<'a> {
         // of the crate id (path/name/id).
         //
         // The goal of this step is to look at as little metadata as possible.
-        self.filesearch.search(|path| {
+        self.filesearch.search(|path, kind| {
             let file = match path.filename_str() {
                 None => return FileDoesntMatch,
                 Some(file) => file,
@@ -404,12 +405,12 @@ impl<'a> Context<'a> {
 
             let hash_str = hash.to_string();
             let slot = candidates.entry(hash_str).get().unwrap_or_else(
-                |vacant_entry| vacant_entry.insert((HashSet::new(), HashSet::new())));
+                |vacant_entry| vacant_entry.insert((HashMap::new(), HashMap::new())));
             let (ref mut rlibs, ref mut dylibs) = *slot;
             if rlib {
-                rlibs.insert(fs::realpath(path).unwrap());
+                rlibs.insert(fs::realpath(path).unwrap(), kind);
             } else {
-                dylibs.insert(fs::realpath(path).unwrap());
+                dylibs.insert(fs::realpath(path).unwrap(), kind);
             }
 
             FileMatches
@@ -453,16 +454,16 @@ impl<'a> Context<'a> {
                 self.sess.note("candidates:");
                 for lib in libraries.iter() {
                     match lib.dylib {
-                        Some(ref p) => {
+                        Some((ref p, _)) => {
                             self.sess.note(&format!("path: {}",
                                                    p.display())[]);
                         }
                         None => {}
                     }
                     match lib.rlib {
-                        Some(ref p) => {
+                        Some((ref p, _)) => {
                             self.sess.note(&format!("path: {}",
-                                                   p.display())[]);
+                                                    p.display())[]);
                         }
                         None => {}
                     }
@@ -483,9 +484,9 @@ impl<'a> Context<'a> {
     // read the metadata from it if `*slot` is `None`. If the metadata couldn't
     // be read, it is assumed that the file isn't a valid rust library (no
     // errors are emitted).
-    fn extract_one(&mut self, m: HashSet<Path>, flavor: &str,
-                   slot: &mut Option<MetadataBlob>) -> Option<Path> {
-        let mut ret = None::<Path>;
+    fn extract_one(&mut self, m: HashMap<Path, PathKind>, flavor: &str,
+                   slot: &mut Option<MetadataBlob>) -> Option<(Path, PathKind)> {
+        let mut ret = None::<(Path, PathKind)>;
         let mut error = 0u;
 
         if slot.is_some() {
@@ -500,7 +501,7 @@ impl<'a> Context<'a> {
             }
         }
 
-        for lib in m.into_iter() {
+        for (lib, kind) in m.into_iter() {
             info!("{} reading metadata from: {}", flavor, lib.display());
             let metadata = match get_metadata_section(self.target.options.is_like_osx,
                                                       &lib) {
@@ -525,7 +526,7 @@ impl<'a> Context<'a> {
                                            self.crate_name)[]);
                 self.sess.span_note(self.span,
                                     &format!(r"candidate #1: {}",
-                                            ret.as_ref().unwrap()
+                                            ret.as_ref().unwrap().0
                                                .display())[]);
                 error = 1;
                 ret = None;
@@ -538,7 +539,7 @@ impl<'a> Context<'a> {
                 continue
             }
             *slot = Some(metadata);
-            ret = Some(lib);
+            ret = Some((lib, kind));
         }
         return if error > 0 {None} else {ret}
     }
@@ -606,8 +607,8 @@ impl<'a> Context<'a> {
         // rlibs/dylibs.
         let sess = self.sess;
         let dylibname = self.dylibname();
-        let mut rlibs = HashSet::new();
-        let mut dylibs = HashSet::new();
+        let mut rlibs = HashMap::new();
+        let mut dylibs = HashMap::new();
         {
             let mut locs = locs.iter().map(|l| Path::new(&l[])).filter(|loc| {
                 if !loc.exists() {
@@ -637,13 +638,15 @@ impl<'a> Context<'a> {
                 false
             });
 
-            // Now that we have an iterator of good candidates, make sure there's at
-            // most one rlib and at most one dylib.
+            // Now that we have an iterator of good candidates, make sure
+            // there's at most one rlib and at most one dylib.
             for loc in locs {
                 if loc.filename_str().unwrap().ends_with(".rlib") {
-                    rlibs.insert(fs::realpath(&loc).unwrap());
+                    rlibs.insert(fs::realpath(&loc).unwrap(),
+                                 PathKind::ExternFlag);
                 } else {
-                    dylibs.insert(fs::realpath(&loc).unwrap());
+                    dylibs.insert(fs::realpath(&loc).unwrap(),
+                                  PathKind::ExternFlag);
                 }
             }
         };

--- a/src/librustc/session/search_paths.rs
+++ b/src/librustc/session/search_paths.rs
@@ -25,6 +25,7 @@ pub enum PathKind {
     Native,
     Crate,
     Dependency,
+    ExternFlag,
     All,
 }
 
@@ -54,14 +55,16 @@ impl SearchPaths {
 }
 
 impl<'a> Iterator for Iter<'a> {
-    type Item = &'a Path;
+    type Item = (&'a Path, PathKind);
 
-    fn next(&mut self) -> Option<&'a Path> {
+    fn next(&mut self) -> Option<(&'a Path, PathKind)> {
         loop {
             match self.iter.next() {
                 Some(&(kind, ref p)) if self.kind == PathKind::All ||
                                         kind == PathKind::All ||
-                                        kind == self.kind => return Some(p),
+                                        kind == self.kind => {
+                    return Some((p, kind))
+                }
                 Some(..) => {}
                 None => return None,
             }

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -507,7 +507,7 @@ fn link_binary_output(sess: &Session,
 
 fn archive_search_paths(sess: &Session) -> Vec<Path> {
     let mut search = Vec::new();
-    sess.target_filesearch(PathKind::Native).for_each_lib_search_path(|path| {
+    sess.target_filesearch(PathKind::Native).for_each_lib_search_path(|path, _| {
         search.push(path.clone());
         FileDoesntMatch
     });
@@ -1043,7 +1043,7 @@ fn link_args(cmd: &mut Command,
 // in the current crate. Upstream crates with native library dependencies
 // may have their native library pulled in above.
 fn add_local_native_libraries(cmd: &mut Command, sess: &Session) {
-    sess.target_filesearch(PathKind::All).for_each_lib_search_path(|path| {
+    sess.target_filesearch(PathKind::All).for_each_lib_search_path(|path, _| {
         cmd.arg("-L").arg(path);
         FileDoesntMatch
     });
@@ -1146,10 +1146,10 @@ fn add_upstream_rust_crates(cmd: &mut Command, sess: &Session,
         let src = sess.cstore.get_used_crate_source(cnum).unwrap();
         match kind {
             cstore::RequireDynamic => {
-                add_dynamic_crate(cmd, sess, src.dylib.unwrap())
+                add_dynamic_crate(cmd, sess, src.dylib.unwrap().0)
             }
             cstore::RequireStatic => {
-                add_static_crate(cmd, sess, tmpdir, src.rlib.unwrap())
+                add_static_crate(cmd, sess, tmpdir, src.rlib.unwrap().0)
             }
         }
 

--- a/src/test/run-make/compiler-lookup-paths-2/Makefile
+++ b/src/test/run-make/compiler-lookup-paths-2/Makefile
@@ -1,0 +1,8 @@
+-include ../tools.mk
+
+all:
+	mkdir -p $(TMPDIR)/a $(TMPDIR)/b
+	$(RUSTC) a.rs && mv $(TMPDIR)/liba.rlib $(TMPDIR)/a
+	$(RUSTC) b.rs -L $(TMPDIR)/a && mv $(TMPDIR)/libb.rlib $(TMPDIR)/b
+	$(RUSTC) c.rs -L crate=$(TMPDIR)/b -L dependency=$(TMPDIR)/a \
+		&& exit 1 || exit 0

--- a/src/test/run-make/compiler-lookup-paths-2/a.rs
+++ b/src/test/run-make/compiler-lookup-paths-2/a.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![crate_name = "c"]
-#![crate_type = "rlib"]
-
-extern crate a;
-
-static FOO: usize = 3;
-
-pub fn token() -> &'static usize { &FOO }
-pub fn a_token() -> &'static usize { a::token() }
+#![crate_type = "lib"]

--- a/src/test/run-make/compiler-lookup-paths-2/b.rs
+++ b/src/test/run-make/compiler-lookup-paths-2/b.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![crate_name = "c"]
-#![crate_type = "rlib"]
-
+#![crate_type = "lib"]
 extern crate a;
-
-static FOO: usize = 3;
-
-pub fn token() -> &'static usize { &FOO }
-pub fn a_token() -> &'static usize { a::token() }

--- a/src/test/run-make/compiler-lookup-paths-2/c.rs
+++ b/src/test/run-make/compiler-lookup-paths-2/c.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![crate_name = "c"]
-#![crate_type = "rlib"]
-
+#![crate_type = "lib"]
+extern crate b;
 extern crate a;
-
-static FOO: usize = 3;
-
-pub fn token() -> &'static usize { &FOO }
-pub fn a_token() -> &'static usize { a::token() }

--- a/src/test/run-make/extern-flag-disambiguates/Makefile
+++ b/src/test/run-make/extern-flag-disambiguates/Makefile
@@ -17,8 +17,10 @@ all:
 	$(RUSTC) -C metadata=2 -C extra-filename=-2 a.rs
 	$(RUSTC) b.rs --extern a=$(TMPDIR)/liba-1.rlib
 	$(RUSTC) c.rs --extern a=$(TMPDIR)/liba-2.rlib
+	@echo before
 	$(RUSTC) --cfg before d.rs --extern a=$(TMPDIR)/liba-1.rlib
 	$(call RUN,d)
+	@echo after
 	$(RUSTC) --cfg after  d.rs --extern a=$(TMPDIR)/liba-1.rlib
 	$(call RUN,d)
 

--- a/src/test/run-make/extern-flag-disambiguates/a.rs
+++ b/src/test/run-make/extern-flag-disambiguates/a.rs
@@ -11,6 +11,6 @@
 #![crate_name = "a"]
 #![crate_type = "rlib"]
 
-static FOO: uint = 3;
+static FOO: usize = 3;
 
-pub fn token() -> &'static uint { &FOO }
+pub fn token() -> &'static usize { &FOO }

--- a/src/test/run-make/extern-flag-disambiguates/b.rs
+++ b/src/test/run-make/extern-flag-disambiguates/b.rs
@@ -13,7 +13,7 @@
 
 extern crate a;
 
-static FOO: uint = 3;
+static FOO: usize = 3;
 
-pub fn token() -> &'static uint { &FOO }
-pub fn a_token() -> &'static uint { a::token() }
+pub fn token() -> &'static usize { &FOO }
+pub fn a_token() -> &'static usize { a::token() }

--- a/src/test/run-make/extern-flag-disambiguates/d.rs
+++ b/src/test/run-make/extern-flag-disambiguates/d.rs
@@ -13,7 +13,7 @@ extern crate b;
 extern crate c;
 #[cfg(after)] extern crate a;
 
-fn t(a: &'static uint) -> uint { a as *const _ as uint }
+fn t(a: &'static usize) -> usize { a as *const _ as usize }
 
 fn main() {
     assert!(t(a::token()) == t(b::a_token()));


### PR DESCRIPTION
With the addition of separate search paths to the compiler, it was intended that
applications such as Cargo could require a `--extern` flag per `extern crate`
directive in the source. The system can currently be subverted, however, due to
the `existing_match()` logic in the crate loader.

When loading crates we first attempt to match an `extern crate` directive
against all previously loaded crates to avoid reading metadata twice. This "hit
the cache if possible" step was erroneously leaking crates across the search
path boundaries, however. For example:

```
extern crate b;
extern crate a;
```

If `b` depends on `a`, then it will load crate `a` when the `extern crate b`
directive is being processed. When the compiler reaches `extern crate a` it will
use the previously loaded version no matter what. If the compiler was not
invoked with `-L crate=path/to/a`, it will still succeed.

This behavior is allowing `extern crate` declarations in Cargo without a
corresponding declaration in the manifest of a dependency, which is considered
a bug.

This commit fixes this problem by keeping track of the origin search path for a
crate. Crates loaded from the dependency search path are not candidates for
crates which are loaded from the crate search path.
