### PR TITLE
Fix intro examples compilation warnings

### DIFF
--- a/src/doc/intro.md
+++ b/src/doc/intro.md
@@ -546,7 +546,7 @@ fn main() {
     for i in range(0u, 3) {
         Thread::spawn(move || {
             println!("{}", vec[i]);
-        }).detach();
+        });
     }
 }
 ```

--- a/src/doc/intro.md
+++ b/src/doc/intro.md
@@ -424,7 +424,7 @@ Let's see an example. This Rust code will not compile:
 use std::thread::Thread;
 
 fn main() {
-    let mut numbers = vec![1is, 2is, 3is];
+    let mut numbers = vec![1is, 2, 3];
 
     for i in 0..3 {
         Thread::spawn(move || {
@@ -438,15 +438,15 @@ It gives us this error:
 
 ```text
 6:71 error: capture of moved value: `numbers`
-    for j in range(0, 3) { numbers[j] += 1 }
-               ^~~~~~~
+    for j in 0..3 { numbers[j] += 1 }
+                    ^~~~~~~
 7:50 note: `numbers` moved into closure environment here
     spawn(move || {
-        for j in range(0, 3) { numbers[j] += 1 }
+        for j in 0..3 { numbers[j] += 1 }
     });
 6:79 error: cannot assign to immutable dereference (dereference is implicit, due to indexing)
-        for j in range(0, 3) { numbers[j] += 1 }
-                           ^~~~~~~~~~~~~~~
+        for j in 0..3 { numbers[j] += 1 }
+                        ^~~~~~~~~~~~~~~
 ```
 
 It mentions that "numbers moved into closure environment". Because we
@@ -478,7 +478,7 @@ use std::thread::Thread;
 use std::sync::{Arc,Mutex};
 
 fn main() {
-    let numbers = Arc::new(Mutex::new(vec![1is, 2is, 3is]));
+    let numbers = Arc::new(Mutex::new(vec![1is, 2, 3]));
 
     for i in 0..3 {
         let number = numbers.clone();
@@ -541,9 +541,9 @@ safety check that makes this an error about moved values:
 use std::thread::Thread;
 
 fn main() {
-    let vec = vec![1i, 2, 3];
+    let vec = vec![1is, 2, 3];
 
-    for i in range(0u, 3) {
+    for i in 0us..3 {
         Thread::spawn(move || {
             println!("{}", vec[i]);
         });
@@ -557,9 +557,9 @@ you can remove it. As an example, this is a poor way to iterate through
 a vector:
 
 ```{rust}
-let vec = vec![1i, 2, 3];
+let vec = vec![1, 2, 3];
 
-for i in range(0u, vec.len()) {
+for i in 0..vec.len() {
      println!("{}", vec[i]);
 }
 ```
@@ -569,7 +569,7 @@ that we don't try to access an invalid index. However, we can remove this
 while retaining safety. The answer is iterators:
 
 ```{rust}
-let vec = vec![1i, 2, 3];
+let vec = vec![1, 2, 3];
 
 for x in vec.iter() {
     println!("{}", x);

--- a/src/doc/intro.md
+++ b/src/doc/intro.md
@@ -424,11 +424,11 @@ Let's see an example. This Rust code will not compile:
 use std::thread::Thread;
 
 fn main() {
-    let mut numbers = vec![1i, 2i, 3i];
+    let mut numbers = vec![1is, 2is, 3is];
 
-    for i in range(0u, 3u) {
+    for i in 0..3 {
         Thread::spawn(move || {
-            for j in range(0, 3) { numbers[j] += 1 }
+            for j in 0..3 { numbers[j] += 1 }
         });
     }
 }
@@ -478,9 +478,9 @@ use std::thread::Thread;
 use std::sync::{Arc,Mutex};
 
 fn main() {
-    let numbers = Arc::new(Mutex::new(vec![1i, 2i, 3i]));
+    let numbers = Arc::new(Mutex::new(vec![1is, 2is, 3is]));
 
-    for i in range(0u, 3u) {
+    for i in 0..3 {
         let number = numbers.clone();
         Thread::spawn(move || {
             let mut array = number.lock().unwrap();


### PR DESCRIPTION
- Use range notation instead of deprecated `range()`
- Remove deprecated `u` integer suffixes used in ranges
- Replace deprecated `i` integer suffixes with `is` for vector numbers

`Thread::spawn()` still gives `warning: use of unstable item: may change with specifics of new Send semantics` warning which I hadn't found a way to fix. As long as I've found, it's related to rust-lang/rfcs#458 which hadn't been implemented yet.

Also I encountered two more example issues while going through the tutorial which aren't addressed in this PR: 
- ~~compilation error of first Safety and Speed [snippet](http://doc.rust-lang.org/intro.html#safety-<em>and</em>-speed)~~ (**update**: it should not compile, my bad)
- the fact that spawned threads are detached by default. Such behaviour causes related examples to be a little bit confusing as the text doesn't mention this fact. It looks like the example was written when `Thread::spawn` behaviour was different.

Let me know if the ~~two~~ issue should be addressed in scope of this PR or in another one.
