### PR TITLE
std: Stabilize the std::fmt module

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -12,20 +12,22 @@
 
 //! Threadsafe reference-counted boxes (the `Arc<T>` type).
 //!
-//! The `Arc<T>` type provides shared ownership of an immutable value. Destruction is
-//! deterministic, and will occur as soon as the last owner is gone. It is marked as `Send` because
-//! it uses atomic reference counting.
+//! The `Arc<T>` type provides shared ownership of an immutable value.
+//! Destruction is deterministic, and will occur as soon as the last owner is
+//! gone. It is marked as `Send` because it uses atomic reference counting.
 //!
-//! If you do not need thread-safety, and just need shared ownership, consider the [`Rc<T>`
-//! type](../rc/struct.Rc.html). It is the same as `Arc<T>`, but does not use atomics, making it
-//! both thread-unsafe as well as significantly faster when updating the reference count.
+//! If you do not need thread-safety, and just need shared ownership, consider
+//! the [`Rc<T>` type](../rc/struct.Rc.html). It is the same as `Arc<T>`, but
+//! does not use atomics, making it both thread-unsafe as well as significantly
+//! faster when updating the reference count.
 //!
-//! The `downgrade` method can be used to create a non-owning `Weak<T>` pointer to the box. A
-//! `Weak<T>` pointer can be upgraded to an `Arc<T>` pointer, but will return `None` if the value
-//! has already been dropped.
+//! The `downgrade` method can be used to create a non-owning `Weak<T>` pointer
+//! to the box. A `Weak<T>` pointer can be upgraded to an `Arc<T>` pointer, but
+//! will return `None` if the value has already been dropped.
 //!
-//! For example, a tree with parent pointers can be represented by putting the nodes behind strong
-//! `Arc<T>` pointers, and then storing the parent pointers as `Weak<T>` pointers.
+//! For example, a tree with parent pointers can be represented by putting the
+//! nodes behind strong `Arc<T>` pointers, and then storing the parent pointers
+//! as `Weak<T>` pointers.
 //!
 //! # Examples
 //!
@@ -87,8 +89,9 @@ use heap::deallocate;
 ///
 /// # Example
 ///
-/// In this example, a large vector of floats is shared between several tasks. With simple pipes,
-/// without `Arc`, a copy would have to be made for each task.
+/// In this example, a large vector of floats is shared between several tasks.
+/// With simple pipes, without `Arc`, a copy would have to be made for each
+/// task.
 ///
 /// ```rust
 /// use std::sync::Arc;
@@ -578,6 +581,7 @@ impl<T: Ord> Ord for Arc<T> {
 #[stable]
 impl<T: Eq> Eq for Arc<T> {}
 
+#[stable]
 impl<T: fmt::Show> fmt::Show for Arc<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Arc({:?})", (**self))

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -162,6 +162,7 @@ impl BoxAny for Box<Any> {
     }
 }
 
+#[stable]
 impl<T: ?Sized + fmt::Show> fmt::Show for Box<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Box({:?})", &**self)

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -615,7 +615,7 @@ impl<S: hash::Hasher, T: Hash<S>> Hash<S> for Rc<T> {
     }
 }
 
-#[unstable = "Show is experimental."]
+#[stable]
 impl<T: fmt::Show> fmt::Show for Rc<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Rc({:?})", **self)

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -1727,6 +1727,7 @@ impl BitvSet {
     }
 }
 
+#[stable]
 impl fmt::Show for BitvSet {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(fmt, "BitvSet {{"));

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -31,6 +31,7 @@ pub struct EnumSet<E> {
 
 impl<E> Copy for EnumSet<E> {}
 
+#[stable]
 impl<E:CLike+fmt::Show> fmt::Show for EnumSet<E> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(fmt, "EnumSet {{"));

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -680,6 +680,7 @@ impl FromUtf8Error {
     pub fn utf8_error(&self) -> Utf8Error { self.error }
 }
 
+#[stable]
 impl fmt::Show for FromUtf8Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::String::fmt(self, f)
@@ -693,6 +694,7 @@ impl fmt::String for FromUtf8Error {
     }
 }
 
+#[stable]
 impl fmt::Show for FromUtf16Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::String::fmt(self, f)
@@ -821,7 +823,7 @@ impl fmt::String for String {
     }
 }
 
-#[unstable = "waiting on fmt stabilization"]
+#[stable]
 impl fmt::Show for String {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -938,11 +940,14 @@ impl FromStr for String {
 }
 
 /// A generic trait for converting a value to a string
+#[stable]
 pub trait ToString {
     /// Converts the value of `self` to an owned string
+    #[stable]
     fn to_string(&self) -> String;
 }
 
+#[stable]
 impl<T: fmt::String + ?Sized> ToString for T {
     #[inline]
     fn to_string(&self) -> String {
@@ -979,6 +984,7 @@ impl<'a> Str for CowString<'a> {
     }
 }
 
+#[stable]
 impl fmt::Writer for String {
     #[inline]
     fn write_str(&mut self, s: &str) -> fmt::Result {

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1457,17 +1457,10 @@ impl<T> Default for Vec<T> {
     }
 }
 
-#[unstable = "waiting on Show stability"]
+#[stable]
 impl<T: fmt::Show> fmt::Show for Vec<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Show::fmt(self.as_slice(), f)
-    }
-}
-
-impl<'a> fmt::Writer for Vec<u8> {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.push_all(s.as_bytes());
-        Ok(())
     }
 }
 

--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -32,7 +32,7 @@ macro_rules! array_impls {
                 }
             }
 
-            #[unstable = "waiting for Show to stabilize"]
+            #[stable]
             impl<T:fmt::Show> fmt::Show for [T; $N] {
                 fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                     fmt::Show::fmt(&&self[], f)

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -154,12 +154,14 @@ pub fn radix<T>(x: T, base: u8) -> RadixFmt<T, Radix> {
 
 macro_rules! radix_fmt {
     ($T:ty as $U:ty, $fmt:ident, $S:expr) => {
+        #[stable]
         impl fmt::Show for RadixFmt<$T, Radix> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                try!(fmt::String::fmt(self, f));
+                try!(write!(f, "{}", *self));
                 f.write_str($S)
             }
         }
+        #[stable]
         impl fmt::String for RadixFmt<$T, Radix> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 match *self { RadixFmt(ref x, radix) => radix.$fmt(*x as $U, f) }
@@ -169,6 +171,7 @@ macro_rules! radix_fmt {
 }
 macro_rules! int_base {
     ($Trait:ident for $T:ident as $U:ident -> $Radix:ident) => {
+        #[stable]
         impl fmt::$Trait for $T {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 $Radix.fmt_int(*self as $U, f)
@@ -179,9 +182,10 @@ macro_rules! int_base {
 
 macro_rules! show {
     ($T:ident with $S:expr) => {
+        #[stable]
         impl fmt::Show for $T {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                try!(fmt::String::fmt(self, f));
+                try!(write!(f, "{}", self));
                 f.write_str($S)
             }
         }

--- a/src/libcore/fmt/rt/v1.rs
+++ b/src/libcore/fmt/rt/v1.rs
@@ -14,22 +14,31 @@
 //! These definitions are similar to their `ct` equivalents, but differ in that
 //! these can be statically allocated and are slightly optimized for the runtime
 
-#![unstable = "implementation detail of the `format_args!` macro"]
+#![stable]
 
-pub use self::Alignment::*;
-pub use self::Count::*;
-pub use self::Position::*;
-pub use self::Flag::*;
+#[cfg(stage0)] pub use self::Position::*;
+
+#[cfg(stage0)] pub use self::Alignment::Left as AlignLeft;
+#[cfg(stage0)] pub use self::Alignment::Right as AlignRight;
+#[cfg(stage0)] pub use self::Alignment::Center as AlignCenter;
+#[cfg(stage0)] pub use self::Alignment::Unknown as AlignUnknown;
+#[cfg(stage0)] pub use self::Count::Is as CountIs;
+#[cfg(stage0)] pub use self::Count::Implied as CountImplied;
+#[cfg(stage0)] pub use self::Count::Param as CountIsParam;
+#[cfg(stage0)] pub use self::Count::NextParam as CountIsNextParam;
+#[cfg(stage0)] pub use self::Position::Next as ArgumentNext;
+#[cfg(stage0)] pub use self::Position::At as ArgumentIs;
 
 // SNAP 9e4e524
-#[doc(hidden)]
 #[derive(Copy)]
 #[cfg(not(stage0))]
+#[stable]
 pub struct Argument {
+    #[stable]
     pub position: Position,
+    #[stable]
     pub format: FormatSpec,
 }
-#[doc(hidden)]
 #[derive(Copy)]
 #[cfg(stage0)]
 pub struct Argument<'a> {
@@ -37,58 +46,57 @@ pub struct Argument<'a> {
     pub format: FormatSpec,
 }
 
-#[doc(hidden)]
 #[derive(Copy)]
+#[stable]
 pub struct FormatSpec {
+    #[stable]
     pub fill: char,
+    #[stable]
     pub align: Alignment,
+    #[stable]
     pub flags: uint,
+    #[stable]
     pub precision: Count,
+    #[stable]
     pub width: Count,
 }
 
 /// Possible alignments that can be requested as part of a formatting directive.
 #[derive(Copy, PartialEq)]
+#[stable]
 pub enum Alignment {
     /// Indication that contents should be left-aligned.
-    AlignLeft,
+    #[stable]
+    Left,
     /// Indication that contents should be right-aligned.
-    AlignRight,
+    #[stable]
+    Right,
     /// Indication that contents should be center-aligned.
-    AlignCenter,
+    #[stable]
+    Center,
     /// No alignment was requested.
-    AlignUnknown,
+    #[stable]
+    Unknown,
 }
 
-#[doc(hidden)]
 #[derive(Copy)]
+#[stable]
 pub enum Count {
-    CountIs(uint), CountIsParam(uint), CountIsNextParam, CountImplied,
+    #[stable]
+    Is(usize),
+    #[stable]
+    Param(usize),
+    #[stable]
+    NextParam,
+    #[stable]
+    Implied,
 }
 
-#[doc(hidden)]
 #[derive(Copy)]
+#[stable]
 pub enum Position {
-    ArgumentNext, ArgumentIs(uint)
-}
-
-/// Flags which can be passed to formatting via a directive.
-///
-/// These flags are discovered through the `flags` field of the `Formatter`
-/// structure. The flag in that structure is a union of these flags into a
-/// `uint` where each flag's discriminant is the corresponding bit.
-#[derive(Copy)]
-pub enum Flag {
-    /// A flag which enables number formatting to always print the sign of a
-    /// number.
-    FlagSignPlus,
-    /// Currently not a used flag
-    FlagSignMinus,
-    /// Indicates that the "alternate formatting" for a type should be used.
-    ///
-    /// The meaning of this flag is type-specific.
-    FlagAlternate,
-    /// Indicates that padding should be done with a `0` character as well as
-    /// being aware of the sign to be printed.
-    FlagSignAwareZeroPad,
+    #[stable]
+    Next,
+    #[stable]
+    At(usize)
 }

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -905,7 +905,7 @@ pub trait IndexMut<Index: ?Sized> {
 #[unstable = "API still in development"]
 pub struct FullRange;
 
-#[unstable = "API still in development"]
+#[stable]
 impl fmt::Show for FullRange {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt::Show::fmt("..", fmt)
@@ -964,7 +964,7 @@ impl<Idx: Clone + Step> DoubleEndedIterator for Range<Idx> {
 #[unstable = "API still in development"]
 impl<Idx: Clone + Step> ExactSizeIterator for Range<Idx> {}
 
-#[unstable = "API still in development"]
+#[stable]
 impl<Idx: fmt::Show> fmt::Show for Range<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "{:?}..{:?}", self.start, self.end)
@@ -993,7 +993,7 @@ impl<Idx: Clone + Step> Iterator for RangeFrom<Idx> {
     }
 }
 
-#[unstable = "API still in development"]
+#[stable]
 impl<Idx: fmt::Show> fmt::Show for RangeFrom<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "{:?}..", self.start)
@@ -1009,7 +1009,7 @@ pub struct RangeTo<Idx> {
     pub end: Idx,
 }
 
-#[unstable = "API still in development"]
+#[stable]
 impl<Idx: fmt::Show> fmt::Show for RangeTo<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "..{:?}", self.end)

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -233,7 +233,7 @@
 use self::Result::{Ok, Err};
 
 use clone::Clone;
-use fmt::Show;
+use fmt;
 use iter::{Iterator, IteratorExt, DoubleEndedIterator, FromIterator, ExactSizeIterator};
 use ops::{FnMut, FnOnce};
 use option::Option::{self, None, Some};
@@ -718,7 +718,7 @@ impl<T, E> Result<T, E> {
 }
 
 #[stable]
-impl<T, E: Show> Result<T, E> {
+impl<T, E: fmt::String> Result<T, E> {
     /// Unwraps a result, yielding the content of an `Ok`.
     ///
     /// # Panics
@@ -743,13 +743,13 @@ impl<T, E: Show> Result<T, E> {
         match self {
             Ok(t) => t,
             Err(e) =>
-                panic!("called `Result::unwrap()` on an `Err` value: {:?}", e)
+                panic!("called `Result::unwrap()` on an `Err` value: {}", e)
         }
     }
 }
 
 #[stable]
-impl<T: Show, E> Result<T, E> {
+impl<T: fmt::String, E> Result<T, E> {
     /// Unwraps a result, yielding the content of an `Err`.
     ///
     /// # Panics
@@ -773,7 +773,7 @@ impl<T: Show, E> Result<T, E> {
     pub fn unwrap_err(self) -> E {
         match self {
             Ok(t) =>
-                panic!("called `Result::unwrap_err()` on an `Ok` value: {:?}", t),
+                panic!("called `Result::unwrap_err()` on an `Ok` value: {}", t),
             Err(e) => e
         }
     }

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -37,6 +37,7 @@ pub use self::EbmlEncoderTag::*;
 pub use self::Error::*;
 
 use std::str;
+use std::fmt;
 
 pub mod io;
 
@@ -113,6 +114,12 @@ pub enum Error {
     ApplicationError(String)
 }
 // --------------------------------------
+
+impl fmt::String for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Show::fmt(self, f)
+    }
+}
 
 pub mod reader {
     use std::char;

--- a/src/libregex/parse.rs
+++ b/src/libregex/parse.rs
@@ -30,6 +30,7 @@ static MAX_REPEAT: uint = 1000;
 ///
 /// (Once an expression is compiled, it is not possible to produce an error
 /// via searching, splitting or replacing.)
+#[derive(Show)]
 pub struct Error {
     /// The *approximate* character index of where the error occurred.
     pub pos: uint,
@@ -37,7 +38,7 @@ pub struct Error {
     pub msg: String,
 }
 
-impl fmt::Show for Error {
+impl fmt::String for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Regex syntax error near position {}: {:?}",
                self.pos, self.msg)

--- a/src/librustc/middle/cfg/graphviz.rs
+++ b/src/librustc/middle/cfg/graphviz.rs
@@ -52,10 +52,10 @@ fn replace_newline_with_backslash_l(s: String) -> String {
 }
 
 impl<'a, 'ast> dot::Labeller<'a, Node<'a>, Edge<'a>> for LabelledCFG<'a, 'ast> {
-    fn graph_id(&'a self) -> dot::Id<'a> { dot::Id::new(&self.name[]).unwrap() }
+    fn graph_id(&'a self) -> dot::Id<'a> { dot::Id::new(&self.name[]).ok().unwrap() }
 
     fn node_id(&'a self, &(i,_): &Node<'a>) -> dot::Id<'a> {
-        dot::Id::new(format!("N{}", i.node_id())).unwrap()
+        dot::Id::new(format!("N{}", i.node_id())).ok().unwrap()
     }
 
     fn node_label(&'a self, &(i, n): &Node<'a>) -> dot::LabelText<'a> {

--- a/src/librustc/middle/infer/region_inference/graphviz.rs
+++ b/src/librustc/middle/infer/region_inference/graphviz.rs
@@ -157,10 +157,10 @@ impl<'a, 'tcx> ConstraintGraph<'a, 'tcx> {
 
 impl<'a, 'tcx> dot::Labeller<'a, Node, Edge> for ConstraintGraph<'a, 'tcx> {
     fn graph_id(&self) -> dot::Id {
-        dot::Id::new(self.graph_name.as_slice()).unwrap()
+        dot::Id::new(self.graph_name.as_slice()).ok().unwrap()
     }
     fn node_id(&self, n: &Node) -> dot::Id {
-        dot::Id::new(format!("node_{}", self.node_ids.get(n).unwrap())).unwrap()
+        dot::Id::new(format!("node_{}", self.node_ids.get(n).unwrap())).ok().unwrap()
     }
     fn node_label(&self, n: &Node) -> dot::LabelText {
         match *n {

--- a/src/librustc/middle/traits/error_reporting.rs
+++ b/src/librustc/middle/traits/error_reporting.rs
@@ -188,7 +188,7 @@ pub fn report_selection_error<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
                 ty::Predicate::Equate(ref predicate) => {
                     let predicate = infcx.resolve_type_vars_if_possible(predicate);
                     let err = infcx.equality_predicate(obligation.cause.span,
-                                                             &predicate).unwrap_err();
+                                                             &predicate).err().unwrap();
                     infcx.tcx.sess.span_err(
                         obligation.cause.span,
                         format!(
@@ -200,7 +200,7 @@ pub fn report_selection_error<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
                 ty::Predicate::RegionOutlives(ref predicate) => {
                     let predicate = infcx.resolve_type_vars_if_possible(predicate);
                     let err = infcx.region_outlives_predicate(obligation.cause.span,
-                                                              &predicate).unwrap_err();
+                                                              &predicate).err().unwrap();
                     infcx.tcx.sess.span_err(
                         obligation.cause.span,
                         format!(

--- a/src/librustc_back/archive.rs
+++ b/src/librustc_back/archive.rs
@@ -59,7 +59,7 @@ fn run_ar(handler: &ErrorHandler, maybe_ar_prog: &Option<String>,
     let mut cmd = Command::new(ar);
 
     cmd.arg(args).args(paths);
-    debug!("{}", cmd);
+    debug!("{:?}", cmd);
 
     match cwd {
         Some(p) => {
@@ -73,7 +73,7 @@ fn run_ar(handler: &ErrorHandler, maybe_ar_prog: &Option<String>,
         Ok(prog) => {
             let o = prog.wait_with_output().unwrap();
             if !o.status.success() {
-                handler.err(&format!("{} failed with: {}",
+                handler.err(&format!("{:?} failed with: {}",
                                  cmd,
                                  o.status)[]);
                 handler.note(&format!("stdout ---\n{}",

--- a/src/librustc_borrowck/borrowck/gather_loans/mod.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/mod.rs
@@ -491,7 +491,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for StaticInitializerCtxt<'a, 'tcx> {
         if let ast::ExprAddrOf(mutbl, ref base) = ex.node {
             let param_env = ty::empty_parameter_environment(self.bccx.tcx);
             let mc = mc::MemCategorizationContext::new(&param_env);
-            let base_cmt = mc.cat_expr(&**base).unwrap();
+            let base_cmt = mc.cat_expr(&**base).ok().unwrap();
             let borrow_kind = ty::BorrowKind::from_mutbl(mutbl);
             // Check that we don't allow borrows of unsafe static items.
             if check_aliasability(self.bccx, ex.span, euv::AddrOf,

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -779,14 +779,14 @@ fn link_natively(sess: &Session, trans: &CrateTranslation, dylib: bool,
     }
 
     if sess.opts.debugging_opts.print_link_args {
-        println!("{}", &cmd);
+        println!("{:?}", &cmd);
     }
 
     // May have not found libraries in the right formats.
     sess.abort_if_errors();
 
     // Invoke the system linker
-    debug!("{}", &cmd);
+    debug!("{:?}", &cmd);
     let prog = time(sess.time_passes(), "running linker", (), |()| cmd.output());
     match prog {
         Ok(prog) => {
@@ -794,7 +794,7 @@ fn link_natively(sess: &Session, trans: &CrateTranslation, dylib: bool,
                 sess.err(&format!("linking with `{}` failed: {}",
                                  pname,
                                  prog.status)[]);
-                sess.note(&format!("{}", &cmd)[]);
+                sess.note(&format!("{:?}", &cmd)[]);
                 let mut output = prog.error.clone();
                 output.push_all(&prog.output[]);
                 sess.note(str::from_utf8(&output[]).unwrap());

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -716,7 +716,7 @@ pub fn run_passes(sess: &Session,
         cmd.args(&sess.target.target.options.post_link_args[]);
 
         if sess.opts.debugging_opts.print_link_args {
-            println!("{}", &cmd);
+            println!("{:?}", &cmd);
         }
 
         cmd.stdin(::std::io::process::Ignored)
@@ -725,7 +725,7 @@ pub fn run_passes(sess: &Session,
         match cmd.status() {
             Ok(status) => {
                 if !status.success() {
-                    sess.err(&format!("linking of {} with `{}` failed",
+                    sess.err(&format!("linking of {} with `{:?}` failed",
                                      output_path.display(), cmd)[]);
                     sess.abort_if_errors();
                 }
@@ -953,7 +953,7 @@ pub fn run_assembler(sess: &Session, outputs: &OutputFilenames) {
 
     cmd.arg("-c").arg("-o").arg(outputs.path(config::OutputTypeObject))
                            .arg(outputs.temp_path(config::OutputTypeAssembly));
-    debug!("{}", &cmd);
+    debug!("{:?}", &cmd);
 
     match cmd.output() {
         Ok(prog) => {
@@ -961,7 +961,7 @@ pub fn run_assembler(sess: &Session, outputs: &OutputFilenames) {
                 sess.err(&format!("linking with `{}` failed: {}",
                                  pname,
                                  prog.status)[]);
-                sess.note(&format!("{}", &cmd)[]);
+                sess.note(&format!("{:?}", &cmd)[]);
                 let mut note = prog.error.clone();
                 note.push_all(&prog.output[]);
                 sess.note(str::from_utf8(&note[]).unwrap());

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -110,7 +110,7 @@ pub fn main() {
     let res = std::thread::Builder::new().stack_size(STACK_SIZE).scoped(move || {
         main_args(std::os::args().as_slice())
     }).join();
-    std::os::set_exit_status(res.map_err(|_| ()).unwrap());
+    std::os::set_exit_status(res.ok().unwrap());
 }
 
 pub fn opts() -> Vec<getopts::OptGroup> {

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -617,13 +617,12 @@ impl<'a> ::Encoder for Encoder<'a> {
         if idx != 0 { try!(write!(self.writer, ",")) }
         // ref #12967, make sure to wrap a key in double quotes,
         // in the event that its of a type that omits them (eg numbers)
-        let mut buf = Vec::new();
+        let mut out = String::new();
         // FIXME(14302) remove the transmute and unsafe block.
         unsafe {
-            let mut check_encoder = Encoder::new(&mut buf);
+            let mut check_encoder = Encoder::new(&mut out);
             try!(f(transmute(&mut check_encoder)));
         }
-        let out = str::from_utf8(&buf[]).unwrap();
         let needs_wrapping = out.char_at(0) != '"' && out.char_at_reverse(out.len()) != '"';
         if needs_wrapping { try!(write!(self.writer, "\"")); }
         try!(f(self));
@@ -888,13 +887,12 @@ impl<'a> ::Encoder for PrettyEncoder<'a> {
         try!(spaces(self.writer, self.curr_indent));
         // ref #12967, make sure to wrap a key in double quotes,
         // in the event that its of a type that omits them (eg numbers)
-        let mut buf = Vec::new();
+        let mut out = String::new();
         // FIXME(14302) remove the transmute and unsafe block.
         unsafe {
-            let mut check_encoder = PrettyEncoder::new(&mut buf);
+            let mut check_encoder = PrettyEncoder::new(&mut out);
             try!(f(transmute(&mut check_encoder)));
         }
-        let out = str::from_utf8(&buf[]).unwrap();
         let needs_wrapping = out.char_at(0) != '"' && out.char_at_reverse(out.len()) != '"';
         if needs_wrapping { try!(write!(self.writer, "\"")); }
         try!(f(self));
@@ -2491,6 +2489,18 @@ impl<'a, T: Encodable> fmt::String for AsPrettyJson<'a, T> {
 impl FromStr for Json {
     fn from_str(s: &str) -> Option<Json> {
         from_str(s).ok()
+    }
+}
+
+impl fmt::String for DecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Show::fmt(self, f)
+    }
+}
+
+impl fmt::String for ParserError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Show::fmt(self, f)
     }
 }
 

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -121,7 +121,7 @@ impl Deref for CString {
 
 impl fmt::Show for CString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        String::from_utf8_lossy(self.as_bytes()).fmt(f)
+        fmt::String::fmt(&String::from_utf8_lossy(self.as_bytes()), f)
     }
 }
 

--- a/src/libstd/fmt.rs
+++ b/src/libstd/fmt.rs
@@ -419,9 +419,10 @@ pub use core::fmt::{Show, String, Octal, Binary};
 pub use core::fmt::{LowerHex, UpperHex, Pointer};
 pub use core::fmt::{LowerExp, UpperExp};
 pub use core::fmt::Error;
-pub use core::fmt::{Argument, Arguments, write, radix, Radix, RadixFmt};
+pub use core::fmt::{ArgumentV1, Arguments, write, radix, Radix, RadixFmt};
 
 #[doc(hidden)]
+#[cfg(stage0)]
 pub use core::fmt::{argument, argumentuint};
 
 /// The format function takes a precompiled format string and a list of
@@ -439,8 +440,7 @@ pub use core::fmt::{argument, argumentuint};
 /// let s = fmt::format(format_args!("Hello, {}!", "world"));
 /// assert_eq!(s, "Hello, world!".to_string());
 /// ```
-#[unstable = "this is an implementation detail of format! and should not \
-                  be called directly"]
+#[stable]
 pub fn format(args: Arguments) -> string::String {
     let mut output = string::String::new();
     let _ = write!(&mut output, "{}", args);

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -52,6 +52,7 @@ pub struct BufferedReader<R> {
     cap: uint,
 }
 
+#[stable]
 impl<R> fmt::Show for BufferedReader<R> where R: fmt::Show {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "BufferedReader {{ reader: {:?}, buffer: {}/{} }}",
@@ -156,6 +157,7 @@ pub struct BufferedWriter<W> {
     pos: uint
 }
 
+#[stable]
 impl<W> fmt::Show for BufferedWriter<W> where W: fmt::Show {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "BufferedWriter {{ writer: {:?}, buffer: {}/{} }}",
@@ -250,6 +252,7 @@ pub struct LineBufferedWriter<W> {
     inner: BufferedWriter<W>,
 }
 
+#[stable]
 impl<W> fmt::Show for LineBufferedWriter<W> where W: fmt::Show {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "LineBufferedWriter {{ writer: {:?}, buffer: {}/{} }}",
@@ -340,6 +343,7 @@ pub struct BufferedStream<S> {
     inner: BufferedReader<InternalBufferedWriter<S>>
 }
 
+#[stable]
 impl<S> fmt::Show for BufferedStream<S> where S: fmt::Show {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let reader = &self.inner;

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -340,6 +340,7 @@ impl IoError {
     }
 }
 
+#[stable]
 impl fmt::String for IoError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -1827,12 +1828,14 @@ impl Default for FilePermission {
     fn default() -> FilePermission { FilePermission::empty() }
 }
 
+#[stable]
 impl fmt::Show for FilePermission {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::String::fmt(self, f)
     }
 }
 
+#[stable]
 impl fmt::String for FilePermission {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:04o}", self.bits)

--- a/src/libstd/io/net/ip.rs
+++ b/src/libstd/io/net/ip.rs
@@ -38,6 +38,7 @@ pub enum IpAddr {
     Ipv6Addr(u16, u16, u16, u16, u16, u16, u16, u16)
 }
 
+#[stable]
 impl fmt::String for IpAddr {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -69,6 +70,7 @@ pub struct SocketAddr {
     pub port: Port,
 }
 
+#[stable]
 impl fmt::String for SocketAddr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.ip {

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -395,14 +395,15 @@ impl Command {
     }
 }
 
-impl fmt::String for Command {
+#[stable]
+impl fmt::Show for Command {
     /// Format the program and arguments of a Command for display. Any
     /// non-utf8 data is lossily converted using the utf8 replacement
     /// character.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "{}", String::from_utf8_lossy(self.program.as_bytes())));
+        try!(write!(f, "{:?}", self.program));
         for arg in self.args.iter() {
-            try!(write!(f, " '{}'", String::from_utf8_lossy(arg.as_bytes())));
+            try!(write!(f, " '{:?}'", arg));
         }
         Ok(())
     }
@@ -503,6 +504,7 @@ pub enum ProcessExit {
     ExitSignal(int),
 }
 
+#[stable]
 impl fmt::Show for ProcessExit {
     /// Format a ProcessExit enum, to nicely present the information.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -510,7 +512,7 @@ impl fmt::Show for ProcessExit {
     }
 }
 
-
+#[stable]
 impl fmt::String for ProcessExit {
     /// Format a ProcessExit enum, to nicely present the information.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -900,6 +900,7 @@ pub enum MapError {
     ErrMapViewOfFile(uint)
 }
 
+#[stable]
 impl fmt::Show for MapError {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
         let str = match *self {

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -823,12 +823,14 @@ pub struct Display<'a, P:'a> {
     filename: bool
 }
 
+#[stable]
 impl<'a, P: GenericPath> fmt::Show for Display<'a, P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::String::fmt(self, f)
     }
 }
 
+#[stable]
 impl<'a, P: GenericPath> fmt::String for Display<'a, P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.as_cow().fmt(f)

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -57,6 +57,7 @@ pub fn is_sep(c: char) -> bool {
     c == SEP
 }
 
+#[stable]
 impl fmt::Show for Path {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Show::fmt(&self.display(), f)

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -85,6 +85,7 @@ pub struct Path {
     sepidx: Option<uint> // index of the final separator in the non-prefix portion of repr
 }
 
+#[stable]
 impl fmt::Show for Path {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Show::fmt(&self.display(), f)

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -381,7 +381,7 @@ pub struct SyncSender<T> {
 /// A `send` operation can only fail if the receiving end of a channel is
 /// disconnected, implying that the data could never be received. The error
 /// contains the data being sent as a payload so it can be recovered.
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone, Copy, Show)]
 #[stable]
 pub struct SendError<T>(pub T);
 
@@ -389,13 +389,13 @@ pub struct SendError<T>(pub T);
 ///
 /// The `recv` operation can only fail if the sending half of a channel is
 /// disconnected, implying that no further messages will ever be received.
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Show)]
 #[stable]
 pub struct RecvError;
 
 /// This enumeration is the list of the possible reasons that try_recv could not
 /// return data when called.
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Show)]
 #[stable]
 pub enum TryRecvError {
     /// This channel is currently empty, but the sender(s) have not yet
@@ -411,7 +411,7 @@ pub enum TryRecvError {
 
 /// This enumeration is the list of the possible error outcomes for the
 /// `SyncSender::try_send` method.
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Eq, Clone, Copy, Show)]
 #[stable]
 pub enum TrySendError<T> {
     /// The data could not be sent on the channel because it would require that
@@ -980,13 +980,15 @@ unsafe impl<T:Send> Send for RacyCell<T> { }
 
 unsafe impl<T> Sync for RacyCell<T> { } // Oh dear
 
-impl<T> fmt::Show for SendError<T> {
+#[stable]
+impl<T> fmt::String for SendError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         "sending on a closed channel".fmt(f)
     }
 }
 
-impl<T> fmt::Show for TrySendError<T> {
+#[stable]
+impl<T> fmt::String for TrySendError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TrySendError::Full(..) => {
@@ -999,13 +1001,15 @@ impl<T> fmt::Show for TrySendError<T> {
     }
 }
 
-impl fmt::Show for RecvError {
+#[stable]
+impl fmt::String for RecvError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         "receiving on a closed channel".fmt(f)
     }
 }
 
-impl fmt::Show for TryRecvError {
+#[stable]
+impl fmt::String for TryRecvError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TryRecvError::Empty => {

--- a/src/libstd/sync/poison.rs
+++ b/src/libstd/sync/poison.rs
@@ -54,6 +54,7 @@ pub struct Guard {
 /// each lock, but once a lock is poisoned then all future acquisitions will
 /// return this error.
 #[stable]
+#[derive(Show)]
 pub struct PoisonError<T> {
     guard: T,
 }
@@ -61,6 +62,7 @@ pub struct PoisonError<T> {
 /// An enumeration of possible errors which can occur while calling the
 /// `try_lock` method.
 #[stable]
+#[derive(Show)]
 pub enum TryLockError<T> {
     /// The lock could not be acquired because another task failed while holding
     /// the lock.
@@ -90,7 +92,8 @@ pub type LockResult<Guard> = Result<Guard, PoisonError<Guard>>;
 #[stable]
 pub type TryLockResult<Guard> = Result<Guard, TryLockError<Guard>>;
 
-impl<T> fmt::Show for PoisonError<T> {
+#[stable]
+impl<T> fmt::String for PoisonError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         "poisoned lock: another task failed inside".fmt(f)
     }
@@ -109,7 +112,8 @@ impl<T> FromError<PoisonError<T>> for TryLockError<T> {
     }
 }
 
-impl<T> fmt::Show for TryLockError<T> {
+#[stable]
+impl<T> fmt::String for TryLockError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TryLockError::Poisoned(ref p) => p.fmt(f),

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -334,6 +334,7 @@ impl Div<i32> for Duration {
     }
 }
 
+#[stable]
 impl fmt::String for Duration {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // technically speaking, negative duration is not valid ISO 8601,

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -17,7 +17,7 @@ use ext::base::*;
 use ext::base;
 use ext::build::AstBuilder;
 use fmt_macros as parse;
-use parse::token::{InternedString, special_idents};
+use parse::token::special_idents;
 use parse::token;
 use ptr::P;
 
@@ -300,56 +300,35 @@ impl<'a, 'b> Context<'a, 'b> {
         }
     }
 
-    /// These attributes are applied to all statics that this syntax extension
-    /// will generate.
-    fn static_attrs(ecx: &ExtCtxt, fmtsp: Span) -> Vec<ast::Attribute> {
-        // Flag statics as `inline` so LLVM can merge duplicate globals as much
-        // as possible (which we're generating a whole lot of).
-        let unnamed = ecx.meta_word(fmtsp, InternedString::new("inline"));
-        let unnamed = ecx.attribute(fmtsp, unnamed);
-
-        // Do not warn format string as dead code
-        let dead_code = ecx.meta_word(fmtsp, InternedString::new("dead_code"));
-        let allow_dead_code = ecx.meta_list(fmtsp,
-                                            InternedString::new("allow"),
-                                            vec![dead_code]);
-        let allow_dead_code = ecx.attribute(fmtsp, allow_dead_code);
-        vec![unnamed, allow_dead_code]
-    }
-
     fn rtpath(ecx: &ExtCtxt, s: &str) -> Vec<ast::Ident> {
-        vec![ecx.ident_of("std"), ecx.ident_of("fmt"), ecx.ident_of("rt"), ecx.ident_of(s)]
+        vec![ecx.ident_of("std"), ecx.ident_of("fmt"), ecx.ident_of("rt"),
+             ecx.ident_of("v1"), ecx.ident_of(s)]
     }
 
     fn trans_count(&self, c: parse::Count) -> P<ast::Expr> {
         let sp = self.fmtsp;
+        let count = |: c, arg| {
+            let mut path = Context::rtpath(self.ecx, "Count");
+            path.push(self.ecx.ident_of(c));
+            match arg {
+                Some(arg) => self.ecx.expr_call_global(sp, path, vec![arg]),
+                None => self.ecx.expr_path(self.ecx.path_global(sp, path)),
+            }
+        };
         match c {
-            parse::CountIs(i) => {
-                self.ecx.expr_call_global(sp, Context::rtpath(self.ecx, "CountIs"),
-                                          vec!(self.ecx.expr_uint(sp, i)))
-            }
+            parse::CountIs(i) => count("Is", Some(self.ecx.expr_uint(sp, i))),
             parse::CountIsParam(i) => {
-                self.ecx.expr_call_global(sp, Context::rtpath(self.ecx, "CountIsParam"),
-                                          vec!(self.ecx.expr_uint(sp, i)))
+                count("Param", Some(self.ecx.expr_uint(sp, i)))
             }
-            parse::CountImplied => {
-                let path = self.ecx.path_global(sp, Context::rtpath(self.ecx,
-                                                                    "CountImplied"));
-                self.ecx.expr_path(path)
-            }
-            parse::CountIsNextParam => {
-                let path = self.ecx.path_global(sp, Context::rtpath(self.ecx,
-                                                                    "CountIsNextParam"));
-                self.ecx.expr_path(path)
-            }
+            parse::CountImplied => count("Implied", None),
+            parse::CountIsNextParam => count("NextParam", None),
             parse::CountIsName(n) => {
                 let i = match self.name_positions.get(n) {
                     Some(&i) => i,
                     None => 0, // error already emitted elsewhere
                 };
                 let i = i + self.args.len();
-                self.ecx.expr_call_global(sp, Context::rtpath(self.ecx, "CountIsParam"),
-                                          vec!(self.ecx.expr_uint(sp, i)))
+                count("Param", Some(self.ecx.expr_uint(sp, i)))
             }
         }
     }
@@ -373,27 +352,35 @@ impl<'a, 'b> Context<'a, 'b> {
             }
             parse::NextArgument(ref arg) => {
                 // Translate the position
-                let pos = match arg.position {
-                    // These two have a direct mapping
-                    parse::ArgumentNext => {
-                        let path = self.ecx.path_global(sp, Context::rtpath(self.ecx,
-                                                                            "ArgumentNext"));
-                        self.ecx.expr_path(path)
-                    }
-                    parse::ArgumentIs(i) => {
-                        self.ecx.expr_call_global(sp, Context::rtpath(self.ecx, "ArgumentIs"),
-                                                  vec!(self.ecx.expr_uint(sp, i)))
-                    }
-                    // Named arguments are converted to positional arguments at
-                    // the end of the list of arguments
-                    parse::ArgumentNamed(n) => {
-                        let i = match self.name_positions.get(n) {
-                            Some(&i) => i,
-                            None => 0, // error already emitted elsewhere
-                        };
-                        let i = i + self.args.len();
-                        self.ecx.expr_call_global(sp, Context::rtpath(self.ecx, "ArgumentIs"),
-                                                  vec!(self.ecx.expr_uint(sp, i)))
+                let pos = {
+                    let pos = |: c, arg| {
+                        let mut path = Context::rtpath(self.ecx, "Position");
+                        path.push(self.ecx.ident_of(c));
+                        match arg {
+                            Some(i) => {
+                                let arg = self.ecx.expr_uint(sp, i);
+                                self.ecx.expr_call_global(sp, path, vec![arg])
+                            }
+                            None => {
+                                self.ecx.expr_path(self.ecx.path_global(sp, path))
+                            }
+                        }
+                    };
+                    match arg.position {
+                        // These two have a direct mapping
+                        parse::ArgumentNext => pos("Next", None),
+                        parse::ArgumentIs(i) => pos("At", Some(i)),
+
+                        // Named arguments are converted to positional arguments
+                        // at the end of the list of arguments
+                        parse::ArgumentNamed(n) => {
+                            let i = match self.name_positions.get(n) {
+                                Some(&i) => i,
+                                None => 0, // error already emitted elsewhere
+                            };
+                            let i = i + self.args.len();
+                            pos("At", Some(i))
+                        }
                     }
                 };
 
@@ -417,19 +404,16 @@ impl<'a, 'b> Context<'a, 'b> {
 
                 // Translate the format
                 let fill = self.ecx.expr_lit(sp, ast::LitChar(fill));
+                let align = |:name| {
+                    let mut p = Context::rtpath(self.ecx, "Alignment");
+                    p.push(self.ecx.ident_of(name));
+                    self.ecx.path_global(sp, p)
+                };
                 let align = match arg.format.align {
-                    parse::AlignLeft => {
-                        self.ecx.path_global(sp, Context::rtpath(self.ecx, "AlignLeft"))
-                    }
-                    parse::AlignRight => {
-                        self.ecx.path_global(sp, Context::rtpath(self.ecx, "AlignRight"))
-                    }
-                    parse::AlignCenter => {
-                        self.ecx.path_global(sp, Context::rtpath(self.ecx, "AlignCenter"))
-                    }
-                    parse::AlignUnknown => {
-                        self.ecx.path_global(sp, Context::rtpath(self.ecx, "AlignUnknown"))
-                    }
+                    parse::AlignLeft => align("Left"),
+                    parse::AlignRight => align("Right"),
+                    parse::AlignCenter => align("Center"),
+                    parse::AlignUnknown => align("Unknown"),
                 };
                 let align = self.ecx.expr_path(align);
                 let flags = self.ecx.expr_uint(sp, arg.format.flags);
@@ -465,7 +449,7 @@ impl<'a, 'b> Context<'a, 'b> {
         let st = ast::ItemStatic(ty, ast::MutImmutable, slice);
 
         let name = ecx.ident_of(name);
-        let item = ecx.item(fmtsp, name, Context::static_attrs(ecx, fmtsp), st);
+        let item = ecx.item(fmtsp, name, vec![], st);
         let decl = respan(fmtsp, ast::DeclItem(item));
 
         // Wrap the declaration in a block so that it forms a single expression.
@@ -575,7 +559,7 @@ impl<'a, 'b> Context<'a, 'b> {
 
         // Now create the fmt::Arguments struct with all our locals we created.
         let (fn_name, fn_args) = if self.all_pieces_simple {
-            ("new", vec![pieces, args_slice])
+            ("new_v1", vec![pieces, args_slice])
         } else {
             // Build up the static array which will store our precompiled
             // nonstandard placeholders, if there are any.
@@ -587,7 +571,7 @@ impl<'a, 'b> Context<'a, 'b> {
                                             piece_ty,
                                             self.pieces);
 
-            ("with_placeholders", vec![pieces, fmt, args_slice])
+            ("new_v1_formatted", vec![pieces, args_slice, fmt])
         };
 
         self.ecx.expr_call_global(self.fmtsp, vec!(
@@ -624,7 +608,8 @@ impl<'a, 'b> Context<'a, 'b> {
                 return ecx.expr_call_global(sp, vec![
                         ecx.ident_of("std"),
                         ecx.ident_of("fmt"),
-                        ecx.ident_of("argumentuint")], vec![arg])
+                        ecx.ident_of("ArgumentV1"),
+                        ecx.ident_of("from_uint")], vec![arg])
             }
         };
 
@@ -636,7 +621,8 @@ impl<'a, 'b> Context<'a, 'b> {
         ecx.expr_call_global(sp, vec![
                 ecx.ident_of("std"),
                 ecx.ident_of("fmt"),
-                ecx.ident_of("argument")], vec![ecx.expr_path(format_fn), arg])
+                ecx.ident_of("ArgumentV1"),
+                ecx.ident_of("new")], vec![arg, ecx.expr_path(format_fn)])
     }
 }
 

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -197,7 +197,7 @@ impl<T: Writer+Send> TerminfoTerminal<T> {
         let mut file = entry.unwrap();
         let ti = parse(&mut file, false);
         if ti.is_err() {
-            debug!("error parsing terminfo entry: {:?}", ti.unwrap_err());
+            debug!("error parsing terminfo entry: {:?}", ti.err().unwrap());
             return None;
         }
 


### PR DESCRIPTION
This commit performs a final stabilization pass over the std::fmt module,
marking all necessary APIs as stable. One of the more interesting aspects of
this module is that it exposes a good deal of its runtime representation to the
outside world in order for `format_args!` to be able to construct the format
strings. Instead of hacking the compiler to assume that these items are stable,
this commit instead lays out a story for the stabilization and evolution of
these APIs.

There are three primary details used by the `format_args!` macro:
1. `Arguments` - an opaque package of a "compiled format string". This structure
   is passed around and the `write` function is the source of truth for
   transforming a compiled format string into a string at runtime. This must be
   able to be constructed in stable code.
2. `Argument` - an opaque structure representing an argument to a format string.
   This is _almost_ a trait object as it's just a pointer/function pair, but due
   to the function originating from one of many traits, it's not actually a
   trait object. Like `Arguments`, this must be constructed from stable code.
3. `fmt::rt` - this module contains the runtime type definitions primarily for
   the `rt::Argument` structure. Whenever an argument is formatted with
   nonstandard flags, a corresponding `rt::Argument` is generated describing how
   the argument is being formatted. This can be used to construct an
   `Arguments`.

The primary interface to `std::fmt` is the `Arguments` structure, and as such
this type name is stabilize as-is today. It is expected for libraries to pass
around an `Arguments` structure to represent a pending formatted computation.

The remaining portions are largely "cruft" which would rather not be stabilized,
but due to the stability checks they must be. As a result, almost all pieces
have been renamed to represent that they are "version 1" of the formatting
representation. The theory is that at a later date if we change the
representation of these types we can add new definitions called "version 2" and
corresponding constructors for `Arguments`.

One of the other remaining large questions about the fmt module were how the
pending I/O reform would affect the signatures of methods in the module. Due to
[RFC 526](https://github.com/rust-lang/rfcs/blob/master/text/0526-fmt-text-writer.md), however, the writers of fmt are now incompatible with the
writers of io, so this question has largely been solved. As a result the
interfaces are largely stabilized as-is today.

Specifically, the following changes were made:
- The contents of `fmt::rt` were all moved under `fmt::rt::v1`
- `fmt::rt` is stable
- `fmt::rt::v1` is stable
- `Error` is stable
- `Writer` is stable
- `Writer::write_str` is stable
- `Writer::write_fmt` is stable
- `Formatter` is stable
- `Argument` has been renamed to `ArgumentV1` and is stable
- `ArgumentV1::new` is stable
- `ArgumentV1::from_uint` is stable
- `Arguments::new_v1` is stable (renamed from `new`)
- `Arguments::new_v1_formatted` is stable (renamed from `with_placeholders`)
- All formatting traits are now stable, as well as the `fmt` method.
- `fmt::write` is stable
- `fmt::format` is stable
- `Formatter::pad_integral` is stable
- `Formatter::pad` is stable
- `Formatter::write_str` is stable
- `Formatter::write_fmt` is stable
- Some assorted top level items which were only used by `format_args!` were
  removed in favor of static functions on `ArgumentV1` as well.
- The formatting-flag-accessing methods remain unstable

Within the contents of the `fmt::rt::v1` module, the following actions were
taken:
- Reexports of all enum variants were removed
- All prefixes on enum variants were removed
- A few miscellaneous enum variants were renamed
- Otherwise all structs, fields, and variants were marked stable.

In addition to these actions in the `std::fmt` module, many implementations of
`Show` and `String` were stabilized as well.

In some other modules:
- `ToString` is now stable
- `ToString::to_string` is now stable
- `Vec` no longer implements `fmt::Writer` (this has moved to `String`)

While stabilize the formatting traits, the following change was also made to the
`result` module:
- `Result::unwrap` now requires `String` instead of `Show`
- `Result::unwrap_err` now requires `String` instead of `Show`

This is a breaking change due to all of the changes to the `fmt::rt` module, but
this likely will not have much impact on existing programs. It is also a
breaking change due to the usage of `String` for `unwrap()` on `Result` instead
of `Show`. Error types should implement `String` for human readable errors and
`Show` for inspecting their representation.

Closes #20661
[breaking-change]
