### PR TITLE
Overhaul and make Condvar::wait_timeout public

### DIFF
--- a/src/libstd/sync/poison.rs
+++ b/src/libstd/sync/poison.rs
@@ -99,8 +99,23 @@ impl<T> fmt::Show for PoisonError<T> {
 impl<T> PoisonError<T> {
     /// Consumes this error indicating that a lock is poisoned, returning the
     /// underlying guard to allow access regardless.
-    #[stable]
+    #[deprecated="renamed to into_inner"]
     pub fn into_guard(self) -> T { self.guard }
+
+    /// Consumes this error indicating that a lock is poisoned, returning the
+    /// underlying guard to allow access regardless.
+    #[unstable]
+    pub fn into_inner(self) -> T { self.guard }
+
+    /// Reaches into this error indicating that a lock is poisoned, returning a
+    /// reference to the underlying guard to allow access regardless.
+    #[unstable]
+    pub fn get_ref(&self) -> &T { &self.guard }
+
+    /// Reaches into this error indicating that a lock is poisoned, returning a
+    /// mutable reference to the underlying guard to allow access regardless.
+    #[unstable]
+    pub fn get_mut(&mut self) -> &mut T { &mut self.guard }
 }
 
 impl<T> FromError<PoisonError<T>> for TryLockError<T> {

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -52,6 +52,7 @@ pub mod sync;
 pub mod tcp;
 pub mod thread;
 pub mod thread_local;
+pub mod time;
 pub mod timer;
 pub mod tty;
 pub mod udp;

--- a/src/libstd/sys/unix/time.rs
+++ b/src/libstd/sys/unix/time.rs
@@ -1,0 +1,124 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub use self::inner::SteadyTime;
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+mod inner {
+    use libc;
+    use time::Duration;
+    use ops::Sub;
+    use sync::{Once, ONCE_INIT};
+
+    pub struct SteadyTime {
+        t: u64
+    }
+
+    extern {
+        pub fn mach_absolute_time() -> u64;
+        pub fn mach_timebase_info(info: *mut libc::mach_timebase_info) -> libc::c_int;
+    }
+
+    impl SteadyTime {
+        pub fn now() -> SteadyTime {
+            SteadyTime {
+                t: unsafe { mach_absolute_time() },
+            }
+        }
+
+        pub fn ns(&self) -> u64 {
+            let info = info();
+            self.t * info.numer as u64 / info.denom as u64
+        }
+    }
+
+    fn info() -> &'static libc::mach_timebase_info {
+        static mut INFO: libc::mach_timebase_info = libc::mach_timebase_info {
+            numer: 0,
+            denom: 0,
+        };
+        static ONCE: Once = ONCE_INIT;
+
+        unsafe {
+            ONCE.call_once(|| {
+                mach_timebase_info(&mut INFO);
+            });
+            &INFO
+        }
+    }
+
+    impl<'a> Sub for &'a SteadyTime {
+        type Output = Duration;
+
+        fn sub(self, other: &SteadyTime) -> Duration {
+            unsafe {
+                let info = info();
+                let diff = self.t as i64 - other.t as i64;
+                Duration::nanoseconds(diff * info.numer as i64 / info.denom as i64)
+            }
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+mod inner {
+    use libc;
+    use time::Duration;
+    use ops::Sub;
+
+    const NSEC_PER_SEC: i64 = 1_000_000_000;
+
+    pub struct SteadyTime {
+        t: libc::timespec,
+    }
+
+    // Apparently android provides this in some other library?
+    #[cfg(not(target_os = "android"))]
+    #[link(name = "rt")]
+    extern {}
+
+    extern {
+        fn clock_gettime(clk_id: libc::c_int, tp: *mut libc::timespec) -> libc::c_int;
+    }
+
+    impl SteadyTime {
+        pub fn now() -> SteadyTime {
+            let mut t = SteadyTime {
+                t: libc::timespec {
+                    tv_sec: 0,
+                    tv_nsec: 0,
+                }
+            };
+            unsafe {
+                assert_eq!(0, clock_gettime(libc::CLOCK_MONOTONIC, &mut t.t));
+            }
+            t
+        }
+
+        pub fn ns(&self) -> u64 {
+            self.t.tv_sec as u64 * NSEC_PER_SEC as u64 + self.t.tv_nsec as u64
+        }
+    }
+
+    impl<'a> Sub for &'a SteadyTime {
+        type Output = Duration;
+
+        fn sub(self, other: &SteadyTime) -> Duration {
+            if self.t.tv_nsec >= other.t.tv_nsec {
+                Duration::seconds(self.t.tv_sec as i64 - other.t.tv_sec as i64) +
+                    Duration::nanoseconds(self.t.tv_nsec as i64 - other.t.tv_nsec as i64)
+            } else {
+                Duration::seconds(self.t.tv_sec as i64 - 1 - other.t.tv_sec as i64) +
+                    Duration::nanoseconds(self.t.tv_nsec as i64 + NSEC_PER_SEC -
+                                          other.t.tv_nsec as i64)
+            }
+        }
+    }
+}

--- a/src/libstd/sys/windows/mod.rs
+++ b/src/libstd/sys/windows/mod.rs
@@ -50,6 +50,7 @@ pub mod rwlock;
 pub mod sync;
 pub mod stack_overflow;
 pub mod tcp;
+pub mod time;
 pub mod thread;
 pub mod thread_local;
 pub mod timer;

--- a/src/libstd/sys/windows/time.rs
+++ b/src/libstd/sys/windows/time.rs
@@ -1,0 +1,50 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+use libc;
+use ops::Sub;
+use time::Duration;
+use sync::{Once, ONCE_INIT};
+
+pub struct SteadyTime {
+    t: libc::LARGE_INTEGER,
+}
+
+impl SteadyTime {
+    pub fn now() -> SteadyTime {
+        let mut t = SteadyTime { t: 0 };
+        unsafe { libc::QueryPerformanceCounter(&mut t.t); }
+        t
+    }
+
+    pub fn ns(&self) -> u64 {
+        self.t as u64 * 1_000_000_000 / frequency() as u64
+    }
+}
+
+fn frequency() -> libc::LARGE_INTEGER {
+    static mut FREQUENCY: libc::LARGE_INTEGER = 0;
+    static ONCE: Once = ONCE_INIT;
+
+    unsafe {
+        ONCE.call_once(|| {
+            libc::QueryPerformanceFrequency(&mut FREQUENCY);
+        });
+        FREQUENCY
+    }
+}
+
+impl<'a> Sub for &'a SteadyTime {
+    type Output = Duration;
+
+    fn sub(self, other: &SteadyTime) -> Duration {
+        let diff = self.t as i64 - other.t as i64;
+        Duration::microseconds(diff * 1_000_000 / frequency() as i64)
+    }
+}

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -10,7 +10,7 @@
 
 //! Temporal quantification.
 
-use libc;
+use sys::time::SteadyTime;
 
 pub use self::duration::Duration;
 
@@ -20,69 +20,5 @@ pub mod duration;
 /// in nanoseconds since an unspecified epoch.
 // NB: this is intentionally not public, this is not ready to stabilize its api.
 fn precise_time_ns() -> u64 {
-    return os_precise_time_ns();
-
-    #[cfg(windows)]
-    fn os_precise_time_ns() -> u64 {
-        let mut ticks_per_s = 0;
-        assert_eq!(unsafe {
-            libc::QueryPerformanceFrequency(&mut ticks_per_s)
-        }, 1);
-        let ticks_per_s = if ticks_per_s == 0 {1} else {ticks_per_s};
-        let mut ticks = 0;
-        assert_eq!(unsafe {
-            libc::QueryPerformanceCounter(&mut ticks)
-        }, 1);
-
-        return (ticks as u64 * 1000000000) / (ticks_per_s as u64);
-    }
-
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
-    fn os_precise_time_ns() -> u64 {
-        use sync;
-
-        static mut TIMEBASE: libc::mach_timebase_info = libc::mach_timebase_info { numer: 0,
-                                                                                   denom: 0 };
-        static ONCE: sync::Once = sync::ONCE_INIT;
-        unsafe {
-            ONCE.call_once(|| {
-                imp::mach_timebase_info(&mut TIMEBASE);
-            });
-            let time = imp::mach_absolute_time();
-            time * TIMEBASE.numer as u64 / TIMEBASE.denom as u64
-        }
-    }
-
-    #[cfg(not(any(windows, target_os = "macos", target_os = "ios")))]
-    fn os_precise_time_ns() -> u64 {
-        let mut ts = libc::timespec { tv_sec: 0, tv_nsec: 0 };
-        unsafe {
-            imp::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
-        }
-        return (ts.tv_sec as u64) * 1000000000 + (ts.tv_nsec as u64)
-    }
-}
-
-#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios")))]
-mod imp {
-    use libc::{c_int, timespec};
-
-    // Apparently android provides this in some other library?
-    #[cfg(not(target_os = "android"))]
-    #[link(name = "rt")]
-    extern {}
-
-    extern {
-        pub fn clock_gettime(clk_id: c_int, tp: *mut timespec) -> c_int;
-    }
-
-}
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-mod imp {
-    use libc::{c_int, mach_timebase_info};
-
-    extern {
-        pub fn mach_absolute_time() -> u64;
-        pub fn mach_timebase_info(info: *mut mach_timebase_info) -> c_int;
-    }
+    SteadyTime::now().ns()
 }


### PR DESCRIPTION
**The implementation is a direct adaptation of libcxx's condition_variable implementation.**

I also added a wait_timeout_with method, which matches the second overload in C++'s condition_variable. The implementation right now is kind of dumb but it works. There is an outstanding issue with it: as is it doesn't support the use case where a user doesn't care about poisoning and wants to continue through poison.

r? @alexcrichton @aturon 
