### PR TITLE
Improve Rust Documentation & Reference on mobile

### DIFF
--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -195,6 +195,7 @@ h5 a:hover {text-decoration: none;}
 
 pre, code {
     font-family: "Source Code Pro", Menlo, Monaco, Consolas, "DejaVu Sans Mono", monospace;
+    word-wrap: break-word;
 }
 pre {
     border-left: 2px solid #eee;
@@ -204,7 +205,6 @@ pre {
     margin: 20px 0;
     font-size: 13px;
     word-break: break-all;
-    word-wrap: break-word;
 }
 code {
     padding: 0 2px;
@@ -315,6 +315,8 @@ hr {
 table {
     border-collapse: collapse;
     border-spacing: 0;
+    overflow-x: auto;
+    display: block;
 }
 
 table tr.odd {

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -91,6 +91,7 @@ pub fn render(input: &str, mut output: Path, matches: &getopts::Matches,
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="generator" content="rustdoc">
     <title>{title}</title>
 


### PR DESCRIPTION
Just a couple of tweaks to improve the appearance of pages like [The Rust Reference](http://doc.rust-lang.org/reference.html) on mobile to advance the progress of #20850. Changing the viewport wasn't quite good enough to make it mobile-friendly, as large tables forced the page to become wider than the screen width. Using `overflow-x`, tables that are too large become horizontally scrollable instead of forcing the _entire page_ to become horizontally scrollable.

Also, there was at least one case where an extremely long piece of inline code was wider than the actual width of the screen (`std::ptr::copy_nonoverlapping_memory`), so I changed `word-wrap` to allow inline code to break in the middle of words instead of only text within `pre` tags.

This isn't a change included in this PR, but rather something up for discussion. Currently, code blocks that contain long lines simply wrap onto the next line. What if rather than wrapping, they were horizontally scrollable instead? I'm not sure what the general preference is regarding this.

r? @steveklabnik 
