### PR TITLE
[r+] TRPL: Anti-example failing for the wrong reason.

### DIFF
--- a/src/doc/trpl/closures.md
+++ b/src/doc/trpl/closures.md
@@ -51,7 +51,7 @@ defined. The closure borrows any variables it uses, so this will error:
 
 ```{rust,ignore}
 fn main() {
-    let mut x = 5;
+    let mut x: i32 = 5;
 
     let printer = |&:| { println!("x is: {}", x); };
 


### PR DESCRIPTION
Really small correction.

This anti-example in the Closures section is supposed to fail because of a borrow, but it was failing at the type inference because of insufficient type information.

This makes it fail for the expected reason.
