### PR TITLE
Better error message on invalid fragment specifiers in macros

### DIFF
--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -457,7 +457,7 @@ fn is_in_follow(_: &ExtCtxt, tok: &Token, frag: &str) -> Result<bool, String> {
                 // harmless
                 Ok(true)
             },
-            _ => Err(format!("unrecognized builtin nonterminal `{}`", frag))
+            _ => Err(format!("invalid fragment specifier `{}`", frag))
         }
     }
 }

--- a/src/test/compile-fail/issue-21356.rs
+++ b/src/test/compile-fail/issue-21356.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 macro_rules! test { ($wrong:t_ty ..) => () }
-                  //~^ ERROR: unrecognized builtin nonterminal `t_ty`
+                  //~^ ERROR: invalid fragment specifier `t_ty`
 
 fn main() {}


### PR DESCRIPTION
~~Closes #21131~~
Issue #21131 is already fixed in PR #21429.

I just edited error messages to match terminology from the macros guide ("fragment specifiers")
