### PR TITLE
use UFCS in `#[derive(Hash)]`

### DIFF
--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -18,6 +18,8 @@ use core::cmp::Ordering::{self, Less, Greater, Equal};
 use core::default::Default;
 use core::fmt::Show;
 use core::fmt;
+// NOTE(stage0) remove import after a snapshot
+#[cfg(stage0)]
 use core::hash::Hash;
 use core::iter::{Peekable, Map, FromIterator};
 use core::ops::{BitOr, BitAnd, BitXor, Sub};

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -22,6 +22,8 @@ use util::nodemap::{FnvHashMap, FnvHashSet, NodeMap};
 use util::common::can_reach;
 
 use std::cell::RefCell;
+// NOTE(stage0) remove import after a snapshot
+#[cfg(stage0)]
 use std::hash::{Hash};
 use syntax::codemap::Span;
 use syntax::{ast, visit};

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -21,6 +21,8 @@ use prelude::v1::*;
 use collections::HashMap;
 use ffi::CString;
 use fmt;
+// NOTE(stage0) remove import after a snapshot
+#[cfg(stage0)]
 use hash::Hash;
 use io::pipe::{PipeStream, PipePair};
 use io::{IoResult, IoError};

--- a/src/libsyntax/ext/deriving/hash.rs
+++ b/src/libsyntax/ext/deriving/hash.rs
@@ -65,19 +65,19 @@ fn hash_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) 
         [ref state_expr] => state_expr,
         _ => cx.span_bug(trait_span, "incorrect number of arguments in `deriving(Hash)`")
     };
-    let hash_path = {
-        let strs = vec![
-            cx.ident_of("std"),
-            cx.ident_of("hash"),
-            cx.ident_of("Hash"),
-            cx.ident_of("hash"),
-        ];
-
-        cx.expr_path(cx.path_global(trait_span, strs))
-    };
     let call_hash = |&: span, thing_expr| {
+        let hash_path = {
+            let strs = vec![
+                cx.ident_of("std"),
+                cx.ident_of("hash"),
+                cx.ident_of("Hash"),
+                cx.ident_of("hash"),
+            ];
+
+            cx.expr_path(cx.path_global(span, strs))
+        };
         let ref_thing = cx.expr_addr_of(span, thing_expr);
-        let expr = cx.expr_call(span, hash_path.clone(), vec!(ref_thing, state_expr.clone()));
+        let expr = cx.expr_call(span, hash_path, vec!(ref_thing, state_expr.clone()));
         cx.stmt_expr(expr)
     };
     let mut stmts = Vec::new();

--- a/src/libsyntax/ext/deriving/hash.rs
+++ b/src/libsyntax/ext/deriving/hash.rs
@@ -65,9 +65,19 @@ fn hash_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) 
         [ref state_expr] => state_expr,
         _ => cx.span_bug(trait_span, "incorrect number of arguments in `deriving(Hash)`")
     };
-    let hash_ident = substr.method_ident;
+    let hash_path = {
+        let strs = vec![
+            cx.ident_of("std"),
+            cx.ident_of("hash"),
+            cx.ident_of("Hash"),
+            cx.ident_of("hash"),
+        ];
+
+        cx.expr_path(cx.path_global(trait_span, strs))
+    };
     let call_hash = |&: span, thing_expr| {
-        let expr = cx.expr_method_call(span, thing_expr, hash_ident, vec!(state_expr.clone()));
+        let ref_thing = cx.expr_addr_of(span, thing_expr);
+        let expr = cx.expr_call(span, hash_path.clone(), vec!(ref_thing, state_expr.clone()));
         cx.stmt_expr(expr)
     };
     let mut stmts = Vec::new();

--- a/src/test/compile-fail/issue-21160.rs
+++ b/src/test/compile-fail/issue-21160.rs
@@ -1,0 +1,21 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Bar;
+
+impl Bar {
+    fn hash<T>(&self, _: T) {}
+}
+
+#[derive(Hash)]
+//~^ error: the trait `core::hash::Hash<__S>` is not implemented for the type `Bar`
+struct Foo(Bar);
+
+fn main() {}

--- a/src/test/compile-fail/issue-21160.rs
+++ b/src/test/compile-fail/issue-21160.rs
@@ -15,7 +15,7 @@ impl Bar {
 }
 
 #[derive(Hash)]
-//~^ error: the trait `core::hash::Hash<__S>` is not implemented for the type `Bar`
 struct Foo(Bar);
+//~^ error: the trait `core::hash::Hash<__S>` is not implemented for the type `Bar`
 
 fn main() {}


### PR DESCRIPTION
expansion now uses `::std::hash::Hash::hash(&*__self_0_0, __arg_0)` instead of
`(*__self_0_0).hash(__arg_0)`

closes #21160

r? @alexcrichton 
