### PR TITLE
support deriving `Hash` for nullary structs

### DIFF
--- a/src/libsyntax/ext/deriving/hash.rs
+++ b/src/libsyntax/ext/deriving/hash.rs
@@ -63,7 +63,7 @@ pub fn expand_deriving_hash<F>(cx: &mut ExtCtxt,
 fn hash_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Expr> {
     let state_expr = match substr.nonself_args {
         [ref state_expr] => state_expr,
-        _ => cx.span_bug(trait_span, "incorrect number of arguments in `deriving(Hash)`")
+        _ => cx.span_bug(trait_span, "incorrect number of arguments in `derive(Hash)`")
     };
     let hash_ident = substr.method_ident;
     let call_hash = |&: span, thing_expr| {
@@ -86,15 +86,11 @@ fn hash_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) 
 
             fs
         }
-        _ => cx.span_bug(trait_span, "impossible substructure in `deriving(Hash)`")
+        _ => cx.span_bug(trait_span, "impossible substructure in `derive(Hash)`")
     };
 
     for &FieldInfo { ref self_, span, .. } in fields.iter() {
         stmts.push(call_hash(span, self_.clone()));
-    }
-
-    if stmts.len() == 0 {
-        cx.span_bug(trait_span, "#[derive(Hash)] needs at least one field");
     }
 
     cx.expr_block(cx.block(trait_span, stmts, None))

--- a/src/test/run-pass/issue-16530.rs
+++ b/src/test/run-pass/issue-16530.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::hash::{SipHasher, hash};
+
+#[derive(Hash)]
+struct Empty;
+
+pub fn main() {
+    assert!(hash::<_, SipHasher>(&Empty) == hash::<_, SipHasher>(&Empty));
+}


### PR DESCRIPTION
This fixes #16530 by hashing nullary structs [the same way as the empty tuple](https://github.com/rust-lang/rust/blob/master/src/libcore/hash/mod.rs#L185). Other approaches are possible, but this was the simplest.
