### PR TITLE
Doc tweak: explicitly state that vector contents are on the heap

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! A growable list type, written `Vec<T>` but pronounced 'vector.'
+//! A growable list type with heap-allocated contents, written `Vec<T>` but pronounced 'vector.'
 //!
 //! Vectors have `O(1)` indexing, push (to the end) and pop (from the end).
 //!


### PR DESCRIPTION
...to make it slightly clearer that there's not much point in boxing a vec.

On a different note, I read the contribution guidelines (https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#pull-request-procedure) which say I should update the copyright date for this file. But I can see that nobody else has done this so far this year, despite there being a fair number of commits.

Does that instruction need removing?
