### PR TITLE
Allow passing unsized types to std::intrinsics::get_tydesc

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -198,6 +198,10 @@ extern "rust-intrinsic" {
     pub fn pref_align_of<T>() -> uint;
 
     /// Get a static pointer to a type descriptor.
+    #[cfg(not(stage0))]
+    pub fn get_tydesc<T: ?Sized>() -> *const TyDesc;
+
+    #[cfg(stage0)]
     pub fn get_tydesc<T>() -> *const TyDesc;
 
     /// Gets an identifier which is globally unique to the specified type. This

--- a/src/test/run-pass/issue-21058.rs
+++ b/src/test/run-pass/issue-21058.rs
@@ -1,0 +1,30 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(unstable)]
+
+struct NT(str);
+struct DST { a: u32, b: str }
+
+fn main() {
+    // get_tydesc should support unsized types
+    assert!(unsafe {(
+        // Slice
+        (*std::intrinsics::get_tydesc::<[u8]>()).name,
+        // str
+        (*std::intrinsics::get_tydesc::<str>()).name,
+        // Trait
+        (*std::intrinsics::get_tydesc::<Copy>()).name,
+        // Newtype
+        (*std::intrinsics::get_tydesc::<NT>()).name,
+        // DST
+        (*std::intrinsics::get_tydesc::<DST>()).name
+    )} == ("[u8]", "str", "core::marker::Copy + 'static", "NT", "DST"));
+}


### PR DESCRIPTION
While it's unstable and will probably be replaced or "reformed" at some point, it's useful in the mean time to be able to introspect the type system when debugging, and not be limited to sized types.

Fixes #21058
