### PR TITLE
Revert stability for Bitv and BitvSet

### DIFF
--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -156,7 +156,7 @@ static FALSE: bool = false;
 /// println!("{:?}", bv);
 /// println!("total bits set to true: {}", bv.iter().filter(|x| *x).count());
 /// ```
-#[stable]
+#[unstable = "RFC 509"]
 pub struct Bitv {
     /// Internal representation of the bit vector
     storage: Vec<u32>,
@@ -1107,7 +1107,7 @@ impl<'a> RandomAccessIterator for Iter<'a> {
 /// assert!(bv[3]);
 /// ```
 #[derive(Clone)]
-#[stable]
+#[unstable = "RFC 509"]
 pub struct BitvSet {
     bitv: Bitv,
 }

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -70,12 +70,12 @@ pub mod string;
 pub mod vec;
 pub mod vec_map;
 
-#[stable]
+#[unstable = "RFC 509"]
 pub mod bitv {
     pub use bit::{Bitv, Iter};
 }
 
-#[stable]
+#[unstable = "RFC 509"]
 pub mod bitv_set {
     pub use bit::{BitvSet, Union, Intersection, Difference, SymmetricDifference};
     pub use bit::SetIter as Iter;


### PR DESCRIPTION
The collections were promoted to stable by mistake and do not match RFC 509.
This reverts the stability back to unstable.

[breaking-change] since previously stable API became unstable.

Fixes #21193

r? @Gankro 
