### PR TITLE
Implement core ops for references + fix core module documentation

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -120,9 +120,9 @@ macro_rules! forward_ref_unop {
     }
 }
 
-// implements the binary operator "&T op U"
-// based on "T + U" where T and U are expected `Copy`able
-macro_rules! forward_ref_val_binop {
+// implements binary operators "&T op U", "T op &U", "&T op &U"
+// based on "T op U" where T and U are expected to be `Copy`able
+macro_rules! forward_ref_binop {
     (impl $imp:ident, $method:ident for $t:ty, $u:ty) => {
         #[unstable]
         impl<'a> $imp<$u> for &'a $t {
@@ -133,13 +133,7 @@ macro_rules! forward_ref_val_binop {
                 $imp::$method(*self, other)
             }
         }
-    }
-}
 
-// implements the binary operator "T op &U"
-// based on "T + U" where T and U are expected `Copy`able
-macro_rules! forward_val_ref_binop {
-    (impl $imp:ident, $method:ident for $t:ty, $u:ty) => {
         #[unstable]
         impl<'a> $imp<&'a $u> for $t {
             type Output = <$t as $imp<$u>>::Output;
@@ -149,13 +143,7 @@ macro_rules! forward_val_ref_binop {
                 $imp::$method(self, *other)
             }
         }
-    }
-}
 
-// implements the binary operator "&T op &U"
-// based on "T + U" where T and U are expected `Copy`able
-macro_rules! forward_ref_ref_binop {
-    (impl $imp:ident, $method:ident for $t:ty, $u:ty) => {
         #[unstable]
         impl<'a, 'b> $imp<&'a $u> for &'b $t {
             type Output = <$t as $imp<$u>>::Output;
@@ -165,16 +153,6 @@ macro_rules! forward_ref_ref_binop {
                 $imp::$method(*self, *other)
             }
         }
-    }
-}
-
-// implements binary operators "&T op U", "T op &U", "&T op &U"
-// based on "T + U" where T and U are expected `Copy`able
-macro_rules! forward_ref_binop {
-    (impl $imp:ident, $method:ident for $t:ty, $u:ty) => {
-        forward_ref_val_binop! { impl $imp, $method for $t, $u }
-        forward_val_ref_binop! { impl $imp, $method for $t, $u }
-        forward_ref_ref_binop! { impl $imp, $method for $t, $u }
     }
 }
 

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -108,7 +108,7 @@ pub trait Drop {
 // based on "op T" where T is expected to be `Copy`able
 macro_rules! forward_ref_unop {
     (impl $imp:ident, $method:ident for $t:ty) => {
-        #[unstable]
+        #[unstable = "recently added, waiting for dust to settle"]
         impl<'a> $imp for &'a $t {
             type Output = <$t as $imp>::Output;
 
@@ -124,7 +124,7 @@ macro_rules! forward_ref_unop {
 // based on "T op U" where T and U are expected to be `Copy`able
 macro_rules! forward_ref_binop {
     (impl $imp:ident, $method:ident for $t:ty, $u:ty) => {
-        #[unstable]
+        #[unstable = "recently added, waiting for dust to settle"]
         impl<'a> $imp<$u> for &'a $t {
             type Output = <$t as $imp<$u>>::Output;
 
@@ -134,7 +134,7 @@ macro_rules! forward_ref_binop {
             }
         }
 
-        #[unstable]
+        #[unstable = "recently added, waiting for dust to settle"]
         impl<'a> $imp<&'a $u> for $t {
             type Output = <$t as $imp<$u>>::Output;
 
@@ -144,7 +144,7 @@ macro_rules! forward_ref_binop {
             }
         }
 
-        #[unstable]
+        #[unstable = "recently added, waiting for dust to settle"]
         impl<'a, 'b> $imp<&'a $u> for &'b $t {
             type Output = <$t as $imp<$u>>::Output;
 

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -13,11 +13,19 @@
 //! Implementing these traits allows you to get an effect similar to
 //! overloading operators.
 //!
-//! The values for the right hand side of an operator are automatically
-//! borrowed, so `a + b` is sugar for `a.add(&b)`.
-//!
-//! All of these traits are imported by the prelude, so they are available in
+//! Some of these traits are imported by the prelude, so they are available in
 //! every Rust program.
+//!
+//! Many of the operators take their operands by value. In non-generic
+//! contexts involving built-in types, this is usually not a problem.
+//! However, using these operators in generic code, requires some
+//! attention if values have to be reused as opposed to letting the operators
+//! consume them. One option is to occasionally use `clone()`.
+//! Another option is to rely on the types involved providing additional
+//! operator implementations for references. For example, for a user-defined
+//! type `T` which is supposed to support addition, it is probably a good
+//! idea to have both `T` and `&T` implement the traits `Add<T>` and `Add<&T>`
+//! so that generic code can be written without unnecessary cloning.
 //!
 //! # Example
 //!


### PR DESCRIPTION
As discussed with @aturon I added implementations of various op traits for references to built-in types which was already suggested by the ops reform RFC.

The 2nd commit updates the module documentation of core::ops to fully reflect the recent change from pass-by-reference to pass-by-value and expands on the implications for generic code.
