### PR TITLE
std: Move the bitflags! macro to a gated crate

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -52,7 +52,7 @@
 TARGET_CRATES := libc std flate arena term \
                  serialize getopts collections test rand \
                  log regex graphviz core rbml alloc \
-                 unicode
+                 unicode rustc_bitflags
 RUSTC_CRATES := rustc rustc_typeck rustc_borrowck rustc_resolve rustc_driver \
                 rustc_trans rustc_back rustc_llvm
 HOST_CRATES := syntax $(RUSTC_CRATES) rustdoc fmt_macros
@@ -64,7 +64,8 @@ DEPS_libc := core
 DEPS_unicode := core
 DEPS_alloc := core libc native:jemalloc
 DEPS_std := core libc rand alloc collections unicode \
-	native:rust_builtin native:backtrace native:rustrt_native
+	native:rust_builtin native:backtrace native:rustrt_native \
+	rustc_bitflags
 DEPS_graphviz := std
 DEPS_syntax := std term serialize log fmt_macros arena libc
 DEPS_rustc_driver := arena flate getopts graphviz libc rustc rustc_back rustc_borrowck \
@@ -80,6 +81,7 @@ DEPS_rustc_llvm := native:rustllvm libc std
 DEPS_rustc_back := std syntax rustc_llvm flate log libc
 DEPS_rustdoc := rustc rustc_driver native:hoedown serialize getopts \
                 test
+DEPS_rustc_bitflags := core
 DEPS_flate := std native:miniz
 DEPS_arena := std
 DEPS_graphviz := std
@@ -111,6 +113,7 @@ ONLY_RLIB_alloc := 1
 ONLY_RLIB_rand := 1
 ONLY_RLIB_collections := 1
 ONLY_RLIB_unicode := 1
+ONLY_RLIB_rustc_bitflags := 1
 
 ################################################################################
 # You should not need to edit below this line

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -44,6 +44,7 @@ extern crate rbml;
 extern crate collections;
 #[macro_use] extern crate log;
 #[macro_use] extern crate syntax;
+#[macro_use] #[no_link] extern crate rustc_bitflags;
 
 extern crate "serialize" as rustc_serialize; // used by deriving
 

--- a/src/librustc_bitflags/lib.rs
+++ b/src/librustc_bitflags/lib.rs
@@ -8,9 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![crate_name = "rustc_bitflags"]
 #![unstable]
+#![staged_api]
+#![crate_type = "rlib"]
+#![no_std]
 
 //! A typesafe bitmask flag generator.
+
+#[cfg(test)] #[macro_use] extern crate std;
 
 /// The `bitflags!` macro generates a `struct` that holds a set of C-style
 /// bitmask flags. It is useful for creating typesafe wrappers for C APIs.
@@ -21,6 +27,8 @@
 /// # Example
 ///
 /// ```{.rust}
+/// #[macro_use] extern crate rustc_bitflags;
+///
 /// bitflags! {
 ///     flags Flags: u32 {
 ///         const FLAG_A       = 0b00000001,
@@ -45,6 +53,8 @@
 /// The generated `struct`s can also be extended with type and trait implementations:
 ///
 /// ```{.rust}
+/// #[macro_use] extern crate rustc_bitflags;
+///
 /// use std::fmt;
 ///
 /// bitflags! {
@@ -273,8 +283,8 @@ macro_rules! bitflags {
 #[cfg(test)]
 #[allow(non_upper_case_globals)]
 mod tests {
-    use hash::{self, SipHasher};
-    use option::Option::{Some, None};
+    use std::hash::{self, SipHasher};
+    use std::option::Option::{Some, None};
 
     bitflags! {
         #[doc = "> The first principle is that you must not fool yourself — and"]

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -28,6 +28,7 @@
 #![allow(unknown_features)] #![feature(int_uint)]
 
 extern crate libc;
+#[macro_use] #[no_link] extern crate rustc_bitflags;
 
 pub use self::OtherAttribute::*;
 pub use self::SpecialAttribute::*;

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -23,6 +23,7 @@
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate syntax;
+#[macro_use] #[no_link] extern crate rustc_bitflags;
 
 extern crate rustc;
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -111,7 +111,7 @@
 #![feature(box_syntax)]
 #![feature(old_impl_check)]
 #![feature(optin_builtin_traits)]
-#![allow(unknown_features)] #![feature(int_uint)]
+#![feature(int_uint)]
 
 // Don't link to std. We are std.
 #![no_std]
@@ -135,6 +135,8 @@ extern crate "rand" as core_rand;
 extern crate alloc;
 extern crate unicode;
 extern crate libc;
+
+#[macro_use] #[no_link] extern crate rustc_bitflags;
 
 // Make std testable by not duplicating lang items. See #2912
 #[cfg(test)] extern crate "std" as realstd;
@@ -180,9 +182,6 @@ pub use unicode::char;
 
 #[macro_use]
 mod macros;
-
-#[macro_use]
-pub mod bitflags;
 
 mod rtdeps;
 

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -35,6 +35,7 @@ extern crate serialize;
 extern crate term;
 extern crate libc;
 #[macro_use] extern crate log;
+#[macro_use] #[no_link] extern crate rustc_bitflags;
 
 extern crate "serialize" as rustc_serialize; // used by deriving
 


### PR DESCRIPTION
In accordance with [collections reform part 2](https://github.com/rust-lang/rfcs/blob/master/text/0509-collections-reform-part-2.md) this macro has been moved to
an external [bitflags crate](https://github.com/rust-lang/bitflags) which is [available though
crates.io](http://crates.io/crates/bitflags). Inside the standard distribution the macro has been moved
to a crate called `rustc_bitflags` for current users to continue using.

The major user of `bitflags!` in terms of a public-facing possibly-stable API
today is the `FilePermissions` structure inside of `std::io`. This user,
however, will likely no longer use `bitflags!` after I/O reform has landed. To
prevent breaking APIs today, this structure remains as-is.

Current users of the `bitflags!` macro should add this to their `Cargo.toml`:

```
bitflags = "0.1"
```

and this to their crate root:

```
#[macro_use] extern crate bitflags;
```

Due to the removal of a public macro, this is a:

[breaking-change]
