### PR TITLE
syntax: Feature gate #[start] and #[main]

### DIFF
--- a/src/doc/trpl/unsafe.md
+++ b/src/doc/trpl/unsafe.md
@@ -447,7 +447,7 @@ in the same format as C:
 
 ```
 #![no_std]
-#![feature(lang_items)]
+#![feature(lang_items, start)]
 
 // Pull in the system libc library for what crt0.o likely requires
 extern crate libc;
@@ -475,7 +475,7 @@ compiler's name mangling too:
 ```ignore
 #![no_std]
 #![no_main]
-#![feature(lang_items)]
+#![feature(lang_items, start)]
 
 extern crate libc;
 
@@ -529,7 +529,7 @@ vectors provided from C, using idiomatic Rust practices.
 
 ```
 #![no_std]
-#![feature(lang_items)]
+#![feature(lang_items, start)]
 
 # extern crate libc;
 extern crate core;
@@ -653,7 +653,7 @@ sugar for dynamic allocations via `malloc` and `free`:
 
 ```
 #![no_std]
-#![feature(lang_items, box_syntax)]
+#![feature(lang_items, box_syntax, start)]
 
 extern crate libc;
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -77,6 +77,8 @@ static KNOWN_FEATURES: &'static [(&'static str, Status)] = &[
     ("while_let", Accepted),
 
     ("plugin", Active),
+    ("start", Active),
+    ("main", Active),
 
     // A temporary feature gate used to enable parser extensions needed
     // to bootstrap fix for #5723.
@@ -275,6 +277,18 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
                 if attr::contains_name(&i.attrs[], "plugin_registrar") {
                     self.gate_feature("plugin_registrar", i.span,
                                       "compiler plugins are experimental and possibly buggy");
+                }
+                if attr::contains_name(&i.attrs[], "start") {
+                    self.gate_feature("start", i.span,
+                                      "a #[start] function is an experimental \
+                                       feature whose signature may change \
+                                       over time");
+                }
+                if attr::contains_name(&i.attrs[], "main") {
+                    self.gate_feature("main", i.span,
+                                      "declaration of a nonstandard #[main] \
+                                       function may change over time, for now \
+                                       a top-level `fn main()` is required");
                 }
             }
 

--- a/src/test/compile-fail/feature-gate-main.rs
+++ b/src/test/compile-fail/feature-gate-main.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(main)]
-
 #[main]
-fn foo() {
-}
+fn foo() {} //~ ERROR: declaration of a nonstandard #[main] function may change over time

--- a/src/test/compile-fail/feature-gate-start.rs
+++ b/src/test/compile-fail/feature-gate-start.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(main)]
+#[start]
+fn foo() {} //~ ERROR: a #[start] function is an experimental feature
 
-#[main]
-fn foo() {
-}

--- a/src/test/compile-fail/issue-9575.rs
+++ b/src/test/compile-fail/issue-9575.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(start)]
+
 #[start]
 fn start(argc: isize, argv: *const *const u8, crate_map: *const u8) -> isize {
     //~^ ERROR incorrect number of function parameters

--- a/src/test/compile-fail/lang-item-missing.rs
+++ b/src/test/compile-fail/lang-item-missing.rs
@@ -14,6 +14,7 @@
 // error-pattern: requires `sized` lang_item
 
 #![no_std]
+#![feature(start)]
 
 #[start]
 fn start(argc: isize, argv: *const *const u8) -> isize {

--- a/src/test/compile-fail/lint-dead-code-2.rs
+++ b/src/test/compile-fail/lint-dead-code-2.rs
@@ -10,6 +10,7 @@
 
 #![allow(unused_variables)]
 #![deny(dead_code)]
+#![feature(main, start)]
 
 struct Foo;
 

--- a/src/test/compile-fail/multiple-main-2.rs
+++ b/src/test/compile-fail/multiple-main-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(main)]
+
 #[main]
 fn bar() {
 }

--- a/src/test/compile-fail/multiple-main-3.rs
+++ b/src/test/compile-fail/multiple-main-3.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(main)]
+
 #[main]
 fn main1() {
 }

--- a/src/test/compile-fail/privacy1.rs
+++ b/src/test/compile-fail/privacy1.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(lang_items)]
+#![feature(lang_items, start)]
 #![no_std] // makes debugging this test *a lot* easier (during resolve)
 
 #[lang="sized"]

--- a/src/test/compile-fail/privacy2.rs
+++ b/src/test/compile-fail/privacy2.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(start)]
 #![no_std] // makes debugging this test *a lot* easier (during resolve)
 
 // Test to make sure that globs don't leak in regular `use` statements.

--- a/src/test/compile-fail/privacy3.rs
+++ b/src/test/compile-fail/privacy3.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(start)]
 #![no_std] // makes debugging this test *a lot* easier (during resolve)
 
 // Test to make sure that private items imported through globs remain private

--- a/src/test/compile-fail/privacy4.rs
+++ b/src/test/compile-fail/privacy4.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(lang_items)]
+#![feature(lang_items, start)]
 #![no_std] // makes debugging this test *a lot* easier (during resolve)
 
 #[lang = "sized"] pub trait Sized {}

--- a/src/test/run-pass/attr-main-2.rs
+++ b/src/test/run-pass/attr-main-2.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(main)]
 
 pub fn main() {
     panic!()

--- a/src/test/run-pass/attr-main.rs
+++ b/src/test/run-pass/attr-main.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(main)]
 
 #[main]
 fn foo() {

--- a/src/test/run-pass/attr-start.rs
+++ b/src/test/run-pass/attr-start.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(start)]
 
 #[start]
 fn start(_argc: int, _argv: *const *const u8) -> int {

--- a/src/test/run-pass/intrinsic-alignment.rs
+++ b/src/test/run-pass/intrinsic-alignment.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(intrinsics)]
+#![feature(intrinsics, main)]
 
 mod rusti {
     extern "rust-intrinsic" {

--- a/src/test/run-pass/issue-16597-empty.rs
+++ b/src/test/run-pass/issue-16597-empty.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-flags:--test
+// no-pretty-expanded
 
 // This verifies that the test generation doesn't crash when we have
 // no tests - for more information, see PR #16892.

--- a/src/test/run-pass/issue-20823.rs
+++ b/src/test/run-pass/issue-20823.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-flags: --test
+// no-pretty-expanded
 
 #![deny(unstable)]
 

--- a/src/test/run-pass/lang-item-public.rs
+++ b/src/test/run-pass/lang-item-public.rs
@@ -13,7 +13,7 @@
 // ignore-windows #13361
 
 #![no_std]
-#![feature(lang_items)]
+#![feature(lang_items, start)]
 
 extern crate "lang-item-public" as lang_lib;
 

--- a/src/test/run-pass/native-print-no-runtime.rs
+++ b/src/test/run-pass/native-print-no-runtime.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(start)]
 
 #[start]
 pub fn main(_: int, _: *const *const u8) -> int {

--- a/src/test/run-pass/running-with-no-runtime.rs
+++ b/src/test/run-pass/running-with-no-runtime.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(start)]
+
 use std::ffi;
 use std::io::process::{Command, ProcessOutput};
 use std::os;

--- a/src/test/run-pass/smallest-hello-world.rs
+++ b/src/test/run-pass/smallest-hello-world.rs
@@ -13,7 +13,7 @@
 // Smallest "hello world" with a libc runtime
 
 #![no_std]
-#![feature(intrinsics, lang_items)]
+#![feature(intrinsics, lang_items, start)]
 
 extern crate libc;
 

--- a/src/test/run-pass/use.rs
+++ b/src/test/run-pass/use.rs
@@ -9,13 +9,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
 #![allow(unused_imports)]
-
+#![feature(start)]
 #![no_std]
+
 extern crate std;
 extern crate "std" as zed;
-
 
 use std::str;
 use zed::str as x;

--- a/src/test/run-pass/vec-macro-no-std.rs
+++ b/src/test/run-pass/vec-macro-no-std.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(lang_items)]
+#![feature(lang_items, start)]
 #![no_std]
 
 extern crate "std" as other;


### PR DESCRIPTION
These two attributes are used to change the entry point into a Rust program, but
for now they're being put behind feature gates until we have a chance to think
about them a little more. The #[start] attribute specifically may have its
signature changed.

This is a breaking change to due the usage of these attributes generating errors
by default now. If your crate is using these attributes, add this to your crate
root:

```
#![feature(start)] // if you're using the #[start] attribute
#![feature(main)]  // if you're using the #[main] attribute
```

cc #20064
