### PR TITLE
Deprecate `ItemModifier` and `ItemDecorator` traits

### DIFF
--- a/src/librustc/plugin/registry.rs
+++ b/src/librustc/plugin/registry.rs
@@ -14,7 +14,7 @@ use lint::{LintPassObject, LintId, Lint};
 use session::Session;
 
 use syntax::ext::base::{SyntaxExtension, NamedSyntaxExtension, NormalTT};
-use syntax::ext::base::{IdentTT, Decorator, Modifier, MultiModifier, MacroRulesTT};
+use syntax::ext::base::{IdentTT, Decorator, MultiDecorator, Modifier, MultiModifier, MacroRulesTT};
 use syntax::ext::base::{MacroExpanderFn};
 use syntax::codemap::Span;
 use syntax::parse::token;
@@ -76,11 +76,13 @@ impl<'a> Registry<'a> {
     /// Register a syntax extension of any kind.
     ///
     /// This is the most general hook into `libsyntax`'s expansion behavior.
+    #[allow(deprecated)]
     pub fn register_syntax_extension(&mut self, name: ast::Name, extension: SyntaxExtension) {
         self.syntax_exts.push((name, match extension {
             NormalTT(ext, _) => NormalTT(ext, Some(self.krate_span)),
             IdentTT(ext, _) => IdentTT(ext, Some(self.krate_span)),
             Decorator(ext) => Decorator(ext),
+            MultiDecorator(ext) => MultiDecorator(ext),
             Modifier(ext) => Modifier(ext),
             MultiModifier(ext) => MultiModifier(ext),
             MacroRulesTT => {

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -431,6 +431,7 @@ pub enum SyntaxExtension {
 
     /// A syntax extension that is attached to an item and modifies it
     /// in-place.
+    #[deprecated="Replaced by MultiModifier"]
     Modifier(Box<ItemModifier + 'static>),
 
     /// A syntax extension that is attached to an item and modifies it

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -29,6 +29,7 @@ use fold::Folder;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+#[deprecated="Replaced by MultiItemDecorator"]
 pub trait ItemDecorator {
     fn expand(&self,
               ecx: &mut ExtCtxt,

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -29,7 +29,8 @@ use fold::Folder;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-#[deprecated="Replaced by MultiItemDecorator"]
+#[unstable(feature = "rustc_private")]
+#[deprecated(since = "1.0.0", reason = "replaced by MultiItemDecorator")]
 pub trait ItemDecorator {
     fn expand(&self,
               ecx: &mut ExtCtxt,
@@ -40,7 +41,8 @@ pub trait ItemDecorator {
 }
 
 #[allow(deprecated)]
-#[deprecated="Replaced by MultiItemDecorator"]
+#[unstable(feature = "rustc_private")]
+#[deprecated(since = "1.0.0", reason = "replaced by MultiItemDecorator")]
 impl<F> ItemDecorator for F
     where F : Fn(&mut ExtCtxt, Span, &ast::MetaItem, &ast::Item, Box<FnMut(P<ast::Item>)>)
 {
@@ -54,7 +56,8 @@ impl<F> ItemDecorator for F
     }
 }
 
-#[deprecated="Replaced by MultiItemModifier"]
+#[unstable(feature = "rustc_private")]
+#[deprecated(since = "1.0.0", reason = "replaced by MultiItemModifier")]
 pub trait ItemModifier {
     fn expand(&self,
               ecx: &mut ExtCtxt,
@@ -65,7 +68,8 @@ pub trait ItemModifier {
 }
 
 #[allow(deprecated)]
-#[deprecated="Replaced by MultiItemModifier"]
+#[unstable(feature = "rustc_private")]
+#[deprecated(since = "1.0.0", reason = "replaced by MultiItemModifier")]
 impl<F> ItemModifier for F
     where F : Fn(&mut ExtCtxt, Span, &ast::MetaItem, P<ast::Item>) -> P<ast::Item>
 {
@@ -423,7 +427,8 @@ impl MacResult for DummyResult {
 pub enum SyntaxExtension {
     /// A syntax extension that is attached to an item and creates new items
     /// based upon it.
-    #[deprecated="Replaced by MultiDecorator"]
+    #[unstable(feature = "rustc_private")]
+    #[deprecated(since = "1.0.0", reason = "replaced by MultiDecorator")]
     Decorator(Box<ItemDecorator + 'static>),
 
     /// A syntax extension that is attached to an item and creates new items
@@ -434,7 +439,8 @@ pub enum SyntaxExtension {
 
     /// A syntax extension that is attached to an item and modifies it
     /// in-place.
-    #[deprecated="Replaced by MultiModifier"]
+    #[unstable(feature = "rustc_private")]
+    #[deprecated(since = "1.0.0", reason = "replaced by MultiModifier")]
     Modifier(Box<ItemModifier + 'static>),
 
     /// A syntax extension that is attached to an item and modifies it
@@ -504,7 +510,7 @@ fn initial_syntax_expander_table(ecfg: &expand::ExpansionConfig) -> SyntaxEnv {
     syntax_expanders.insert(intern("derive"),
                             MultiDecorator(box ext::deriving::expand_meta_derive));
     syntax_expanders.insert(intern("deriving"),
-                            Decorator(box ext::deriving::expand_deprecated_deriving));
+                            MultiDecorator(box ext::deriving::expand_deprecated_deriving));
 
     if ecfg.enable_quotes {
         // Quasi-quoting expanders

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -39,6 +39,8 @@ pub trait ItemDecorator {
               push: Box<FnMut(P<ast::Item>)>);
 }
 
+#[allow(deprecated)]
+#[deprecated="Replaced by MultiItemDecorator"]
 impl<F> ItemDecorator for F
     where F : Fn(&mut ExtCtxt, Span, &ast::MetaItem, &ast::Item, Box<FnMut(P<ast::Item>)>)
 {
@@ -62,6 +64,7 @@ pub trait ItemModifier {
               -> P<ast::Item>;
 }
 
+#[allow(deprecated)]
 #[deprecated="Replaced by MultiItemModifier"]
 impl<F> ItemModifier for F
     where F : Fn(&mut ExtCtxt, Span, &ast::MetaItem, P<ast::Item>) -> P<ast::Item>
@@ -157,18 +160,18 @@ pub trait MultiItemDecorator {
               sp: Span,
               meta_item: &ast::MetaItem,
               item: &Annotatable,
-              push: Box<FnMut(P<Annotatable>)>);
+              push: Box<FnMut(Annotatable)>);
 }
 
 impl<F> MultiItemDecorator for F
-    where F : Fn(&mut ExtCtxt, Span, &ast::MetaItem, &Annotatable, Box<FnMut(P<Annotatable>)>)
+    where F : Fn(&mut ExtCtxt, Span, &ast::MetaItem, &Annotatable, Box<FnMut(Annotatable)>)
 {
     fn expand(&self,
               ecx: &mut ExtCtxt,
               sp: Span,
               meta_item: &ast::MetaItem,
               item: &Annotatable,
-              push: Box<FnMut(P<Annotatable>)>) {
+              push: Box<FnMut(Annotatable)>) {
         (*self)(ecx, sp, meta_item, item, push)
     }
 }
@@ -426,7 +429,7 @@ pub enum SyntaxExtension {
     /// A syntax extension that is attached to an item and creates new items
     /// based upon it.
     ///
-    /// `#[derive(...)]` is an `ItemDecorator`.
+    /// `#[derive(...)]` is a `MultiItemDecorator`.
     MultiDecorator(Box<MultiItemDecorator + 'static>),
 
     /// A syntax extension that is attached to an item and modifies it
@@ -499,7 +502,7 @@ fn initial_syntax_expander_table(ecfg: &expand::ExpansionConfig) -> SyntaxEnv {
                             builtin_normal_expander(
                                     ext::log_syntax::expand_syntax_ext));
     syntax_expanders.insert(intern("derive"),
-                            Decorator(box ext::deriving::expand_meta_derive));
+                            MultiDecorator(box ext::deriving::expand_meta_derive));
     syntax_expanders.insert(intern("deriving"),
                             Decorator(box ext::deriving::expand_deprecated_deriving));
 
@@ -562,7 +565,7 @@ fn initial_syntax_expander_table(ecfg: &expand::ExpansionConfig) -> SyntaxEnv {
                             builtin_normal_expander(
                                     ext::cfg::expand_cfg));
     syntax_expanders.insert(intern("cfg_attr"),
-                            Modifier(box ext::cfg_attr::expand));
+                            MultiModifier(box ext::cfg_attr::expand));
     syntax_expanders.insert(intern("trace_macros"),
                             builtin_normal_expander(
                                     ext::trace_macros::expand_trace_macros));

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -420,6 +420,7 @@ impl MacResult for DummyResult {
 pub enum SyntaxExtension {
     /// A syntax extension that is attached to an item and creates new items
     /// based upon it.
+    #[deprecated="Replaced by MultiDecorator"]
     Decorator(Box<ItemDecorator + 'static>),
 
     /// A syntax extension that is attached to an item and creates new items

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -150,6 +150,29 @@ impl Annotatable {
     }
 }
 
+// A more flexible ItemDecorator.
+pub trait MultiItemDecorator {
+    fn expand(&self,
+              ecx: &mut ExtCtxt,
+              sp: Span,
+              meta_item: &ast::MetaItem,
+              item: &Annotatable,
+              push: Box<FnMut(P<Annotatable>)>);
+}
+
+impl<F> MultiItemDecorator for F
+    where F : Fn(&mut ExtCtxt, Span, &ast::MetaItem, &Annotatable, Box<FnMut(P<Annotatable>)>)
+{
+    fn expand(&self,
+              ecx: &mut ExtCtxt,
+              sp: Span,
+              meta_item: &ast::MetaItem,
+              item: &Annotatable,
+              push: Box<FnMut(P<Annotatable>)>) {
+        (*self)(ecx, sp, meta_item, item, push)
+    }
+}
+
 // A more flexible ItemModifier (ItemModifier should go away, eventually, FIXME).
 // meta_item is the annotation, item is the item being modified, parent_item
 // is the impl or trait item is declared in if item is part of such a thing.

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -420,9 +420,13 @@ impl MacResult for DummyResult {
 pub enum SyntaxExtension {
     /// A syntax extension that is attached to an item and creates new items
     /// based upon it.
+    Decorator(Box<ItemDecorator + 'static>),
+
+    /// A syntax extension that is attached to an item and creates new items
+    /// based upon it.
     ///
     /// `#[derive(...)]` is an `ItemDecorator`.
-    Decorator(Box<ItemDecorator + 'static>),
+    MultiDecorator(Box<MultiItemDecorator + 'static>),
 
     /// A syntax extension that is attached to an item and modifies it
     /// in-place.

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -51,6 +51,7 @@ impl<F> ItemDecorator for F
     }
 }
 
+#[deprecated="Replaced by MultiItemModifier"]
 pub trait ItemModifier {
     fn expand(&self,
               ecx: &mut ExtCtxt,
@@ -60,9 +61,11 @@ pub trait ItemModifier {
               -> P<ast::Item>;
 }
 
+#[deprecated="Replaced by MultiItemModifier"]
 impl<F> ItemModifier for F
     where F : Fn(&mut ExtCtxt, Span, &ast::MetaItem, P<ast::Item>) -> P<ast::Item>
 {
+
     fn expand(&self,
               ecx: &mut ExtCtxt,
               span: Span,

--- a/src/libsyntax/ext/cfg_attr.rs
+++ b/src/libsyntax/ext/cfg_attr.rs
@@ -8,27 +8,70 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast;
+use ast::{self, TraitItem, ImplItem};
 use attr;
 use codemap::Span;
-use ext::base::ExtCtxt;
+use ext::base::{Annotatable, ExtCtxt};
 use ext::build::AstBuilder;
 use ptr::P;
 
-pub fn expand(cx: &mut ExtCtxt, sp: Span, mi: &ast::MetaItem, it: P<ast::Item>) -> P<ast::Item> {
+macro_rules! fold_annotatable {
+    ($ann:expr, $item:ident => $oper:expr) => (
+        match $ann {
+            Annotatable::Item(it) => {
+                let mut $item = (*it).clone();
+                $oper;
+                Annotatable::Item(P($item))
+            }
+            Annotatable::TraitItem(it) => {
+                match it {
+                    TraitItem::RequiredMethod(mut $item) => {
+                        $oper;
+                        Annotatable::TraitItem(TraitItem::RequiredMethod($item))
+                    }
+                    TraitItem::ProvidedMethod(pm) => {
+                        let mut $item = (*pm).clone();
+                        $oper;
+                        Annotatable::TraitItem(TraitItem::ProvidedMethod(P($item)))
+                    }
+                    TraitItem::TypeTraitItem(at) => {
+                        let mut $item = (*at).clone();
+                        $oper;
+                        Annotatable::TraitItem(TraitItem::TypeTraitItem(P($item)))
+                    }
+                }
+            }
+            Annotatable::ImplItem(it) => {
+                match it {
+                    ImplItem::MethodImplItem(pm) => {
+                        let mut $item = (*pm).clone();
+                        $oper;
+                        Annotatable::ImplItem(ImplItem::MethodImplItem(P($item)))
+                    }
+                    ImplItem::TypeImplItem(at) => {
+                        let mut $item = (*at).clone();
+                        $oper;
+                        Annotatable::ImplItem(ImplItem::TypeImplItem(P($item)))
+                    }
+                }
+            }
+        }
+    );
+}
+
+pub fn expand(cx: &mut ExtCtxt, sp: Span, mi: &ast::MetaItem, ann: Annotatable) -> Annotatable {
     let (cfg, attr) = match mi.node {
         ast::MetaList(_, ref mis) if mis.len() == 2 => (&mis[0], &mis[1]),
         _ => {
             cx.span_err(sp, "expected `#[cfg_attr(<cfg pattern>, <attr>)]`");
-            return it;
+            return ann;
         }
     };
 
-    let mut out = (*it).clone();
     if attr::cfg_matches(&cx.parse_sess.span_diagnostic, cx.cfg.as_slice(), &**cfg) {
-        out.attrs.push(cx.attribute(attr.span, attr.clone()));
+        let attr = cx.attribute(attr.span, attr.clone());
+        fold_annotatable!(ann, item => item.attrs.push(attr))
+    } else {
+        ann
     }
-
-    P(out)
 }
-

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -42,8 +42,8 @@ pub mod generic;
 pub fn expand_deprecated_deriving(cx: &mut ExtCtxt,
                                   span: Span,
                                   _: &MetaItem,
-                                  _: &Item,
-                                  _: Box<FnMut(P<Item>)>) {
+                                  _: &Annotatable,
+                                  _: Box<FnMut(Annotatable)>) {
     cx.span_err(span, "`deriving` has been renamed to `derive`");
 }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -781,6 +781,7 @@ impl<'a> State<'a> {
     }
 
     fn print_typedef(&mut self, typedef: &ast::Typedef) -> IoResult<()> {
+        try!(self.print_outer_attributes(&typedef.attrs[]));
         try!(self.word_space("type"));
         try!(self.print_ident(typedef.ident));
         try!(space(&mut self.s));

--- a/src/test/auxiliary/macro_crate_test.rs
+++ b/src/test/auxiliary/macro_crate_test.rs
@@ -16,11 +16,10 @@
 extern crate syntax;
 extern crate rustc;
 
-use syntax::ast::{TokenTree, Item, MetaItem, ImplItem, TraitItem, Method};
+use syntax::ast::{self, TokenTree, Item, MetaItem, ImplItem, TraitItem, Method};
 use syntax::codemap::Span;
 use syntax::ext::base::*;
-use syntax::parse::token;
-use syntax::parse;
+use syntax::parse::{self, token};
 use syntax::ptr::P;
 use rustc::plugin::Registry;
 
@@ -40,6 +39,9 @@ pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_syntax_extension(
         token::intern("into_multi_foo"),
         MultiModifier(box expand_into_foo_multi));
+    reg.register_syntax_extension(
+        token::intern("duplicate"),
+        MultiDecorator(box expand_duplicate));
 }
 
 fn expand_make_a_1(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree])
@@ -88,6 +90,83 @@ fn expand_into_foo_multi(cx: &mut ExtCtxt,
             Annotatable::TraitItem(TraitItem::ProvidedMethod(
                 quote_method!(cx, fn foo(&self) -> i32 { 0 })
             ))
+        }
+    }
+}
+
+// Create a duplicate of the annotatable, based on the MetaItem
+fn expand_duplicate(cx: &mut ExtCtxt,
+                    sp: Span,
+                    mi: &MetaItem,
+                    it: &Annotatable,
+                    mut push: Box<FnMut(Annotatable)>)
+{
+    let copy_name = match mi.node {
+        ast::MetaItem_::MetaList(_, ref xs) => {
+            if let ast::MetaItem_::MetaWord(ref w) = xs[0].node {
+                token::str_to_ident(w.get())
+            } else {
+                cx.span_err(mi.span, "Expected word");
+                return;
+            }
+        }
+        _ => {
+            cx.span_err(mi.span, "Expected list");
+            return;
+        }
+    };
+
+    // Duplicate the item but replace its ident by the MetaItem
+    match it.clone() {
+        Annotatable::Item(it) => {
+            let mut new_it = (*it).clone();
+            new_it.attrs.clear();
+            new_it.ident = copy_name;
+            push(Annotatable::Item(P(new_it)));
+        }
+        Annotatable::ImplItem(it) => {
+            match it {
+                ImplItem::MethodImplItem(m) => {
+                    let mut new_m = (*m).clone();
+                    new_m.attrs.clear();
+                    replace_method_name(&mut new_m.node, copy_name);
+                    push(Annotatable::ImplItem(ImplItem::MethodImplItem(P(new_m))));
+                }
+                ImplItem::TypeImplItem(t) => {
+                    let mut new_t = (*t).clone();
+                    new_t.attrs.clear();
+                    new_t.ident = copy_name;
+                    push(Annotatable::ImplItem(ImplItem::TypeImplItem(P(new_t))));
+                }
+            }
+        }
+        Annotatable::TraitItem(it) => {
+            match it {
+                TraitItem::RequiredMethod(rm) => {
+                    let mut new_rm = rm.clone();
+                    new_rm.attrs.clear();
+                    new_rm.ident = copy_name;
+                    push(Annotatable::TraitItem(TraitItem::RequiredMethod(new_rm)));
+                }
+                TraitItem::ProvidedMethod(pm) => {
+                    let mut new_pm = (*pm).clone();
+                    new_pm.attrs.clear();
+                    replace_method_name(&mut new_pm.node, copy_name);
+                    push(Annotatable::TraitItem(TraitItem::ProvidedMethod(P(new_pm))));
+                }
+                TraitItem::TypeTraitItem(t) => {
+                    let mut new_t = (*t).clone();
+                    new_t.attrs.clear();
+                    new_t.ty_param.ident = copy_name;
+                    push(Annotatable::TraitItem(TraitItem::TypeTraitItem(P(new_t))));
+                }
+            }
+        }
+    }
+
+    fn replace_method_name(m: &mut ast::Method_, i: ast::Ident) {
+        if let &mut ast::Method_::MethDecl(ref mut ident, _, _, _, _, _, _, _) = m {
+            *ident = i
         }
     }
 }

--- a/src/test/run-pass-fulldeps/macro-crate-multi-decorator.rs
+++ b/src/test/run-pass-fulldeps/macro-crate-multi-decorator.rs
@@ -1,0 +1,52 @@
+// Copyright 2013-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:macro_crate_test.rs
+// ignore-stage1
+
+#![feature(plugin)]
+
+#[plugin] #[no_link]
+extern crate macro_crate_test;
+
+// The duplicate macro will create a copy of the item with the given identifier
+#[duplicate(MyCopy)]
+struct MyStruct {
+    number: i32
+}
+
+trait TestTrait {
+    #[duplicate(TestType2)]
+    type TestType;
+
+    #[duplicate(required_fn2)]
+    fn required_fn(&self);
+
+    #[duplicate(provided_fn2)]
+    fn provided_fn(&self) { }
+}
+
+impl TestTrait for MyStruct {
+    #[duplicate(TestType2)]
+    type TestType = f64;
+
+    #[duplicate(required_fn2)]
+    fn required_fn(&self) { }
+}
+
+fn main() {
+    let s = MyStruct { number: 42 };
+    s.required_fn();
+    s.required_fn2();
+    s.provided_fn();
+    s.provided_fn2();
+
+    let s = MyCopy { number: 42 };
+}


### PR DESCRIPTION
Breaking changes:
- Deprecate `ItemModifier` trait (use `MultiItemModifier` instead)
- Deprecate `ItemDecorator` trait (use `MultiItemDecorator` instead)
- Deprecate `SyntaxExtension::Decorator` and `SyntaxExtension::Modifier` (use the `MultiDecorator` and `MultiModifier` variants instead)

[breaking-change]

Fixes #21155 and #21154 
