### PR TITLE
Fixes `join_multicast` on Windows #20381

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -2206,10 +2206,10 @@ pub mod consts {
             pub const IPPROTO_TCP: c_int = 6;
             pub const IPPROTO_IP: c_int = 0;
             pub const IPPROTO_IPV6: c_int = 41;
-            pub const IP_MULTICAST_TTL: c_int = 3;
-            pub const IP_MULTICAST_LOOP: c_int = 4;
-            pub const IP_ADD_MEMBERSHIP: c_int = 5;
-            pub const IP_DROP_MEMBERSHIP: c_int = 6;
+            pub const IP_MULTICAST_TTL: c_int = 10;
+            pub const IP_MULTICAST_LOOP: c_int = 11;
+            pub const IP_ADD_MEMBERSHIP: c_int = 12;
+            pub const IP_DROP_MEMBERSHIP: c_int = 13;
             pub const IPV6_ADD_MEMBERSHIP: c_int = 5;
             pub const IPV6_DROP_MEMBERSHIP: c_int = 6;
             pub const IP_TTL: c_int = 4;


### PR DESCRIPTION
This patch fixes IP_ADD_MEMBERSHIP problem described here: https://github.com/rust-lang/rust/issues/20381

I've tested on my ProbeR project, everything seems ok.
