### PR TITLE
Book: replace deprecated `int` and `i` type annotations with explicit `i32`

### DIFF
--- a/src/doc/trpl/pointers.md
+++ b/src/doc/trpl/pointers.md
@@ -58,7 +58,7 @@ let z = &y;
 
 See the difference? Rather than contain a value, the value of a pointer is a
 location in memory. In this case, the location of `y`. `x` and `y` have the
-type `int`, but `z` has the type `&int`. We can print this location using the
+type `i32`, but `z` has the type `&i32`. We can print this location using the
 `{:p}` format string:
 
 ```{rust}
@@ -71,7 +71,7 @@ println!("{:p}", z);
 
 This would print `0xd3e028`, with our fictional memory addresses.
 
-Because `int` and `&int` are different types, we can't, for example, add them
+Because `i32` and `&i32` are different types, we can't, for example, add them
 together:
 
 ```{rust,ignore}
@@ -269,14 +269,14 @@ referent, because `println!` will automatically dereference it for us.
 Here's a function that takes a reference:
 
 ```{rust}
-fn succ(x: &int) -> int { *x + 1 }
+fn succ(x: &i32) -> i32 { *x + 1 }
 ```
 
 You can also use `&` as an operator to create a reference, so we can
 call this function in two different ways:
 
 ```{rust}
-fn succ(x: &int) -> int { *x + 1 }
+fn succ(x: &i32) -> i32 { *x + 1 }
 
 fn main() {
 
@@ -294,7 +294,7 @@ Of course, if this were real code, we wouldn't bother with the reference, and
 just write:
 
 ```{rust}
-fn succ(x: int) -> int { x + 1 }
+fn succ(x: i32) -> i32 { x + 1 }
 ```
 
 References are immutable by default:
@@ -425,13 +425,13 @@ References just borrow ownership, which is more polite if you don't need the
 ownership. In other words, prefer:
 
 ```{rust}
-fn succ(x: &int) -> int { *x + 1 }
+fn succ(x: &i32) -> i32 { *x + 1 }
 ```
 
 to
 
 ```{rust}
-fn succ(x: Box<int>) -> int { *x + 1 }
+fn succ(x: Box<i32>) -> i32 { *x + 1 }
 ```
 
 As a corollary to that rule, references allow you to accept a wide variety of
@@ -439,7 +439,7 @@ other pointers, and so are useful so that you don't have to write a number
 of variants per pointer. In other words, prefer:
 
 ```{rust}
-fn succ(x: &int) -> int { *x + 1 }
+fn succ(x: &i32) -> i32 { *x + 1 }
 ```
 
 to
@@ -447,9 +447,9 @@ to
 ```{rust}
 use std::rc::Rc;
 
-fn box_succ(x: Box<int>) -> int { *x + 1 }
+fn box_succ(x: Box<i32>) -> i32 { *x + 1 }
 
-fn rc_succ(x: Rc<int>) -> int { *x + 1 }
+fn rc_succ(x: Rc<i32>) -> i32 { *x + 1 }
 ```
 
 Note that the caller of your function will have to modify their calls slightly:
@@ -544,7 +544,7 @@ for more detail on how lifetimes work.
 Using boxes and references together is very common. For example:
 
 ```{rust}
-fn add_one(x: &int) -> int {
+fn add_one(x: &i32) -> i32 {
     *x + 1
 }
 
@@ -561,7 +561,7 @@ function, and since it's only reading the value, allows it.
 We can borrow `x` multiple times, as long as it's not simultaneous:
 
 ```{rust}
-fn add_one(x: &int) -> int {
+fn add_one(x: &i32) -> i32 {
     *x + 1
 }
 
@@ -577,7 +577,7 @@ fn main() {
 Or as long as it's not a mutable borrow. This will error:
 
 ```{rust,ignore}
-fn add_one(x: &mut int) -> int {
+fn add_one(x: &mut i32) -> i32 {
     *x + 1
 }
 
@@ -610,7 +610,7 @@ enum List<T> {
 }
 
 fn main() {
-    let list: List<int> = List::Cons(1, Box::new(List::Cons(2, Box::new(List::Cons(3, Box::new(List::Nil))))));
+    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, Box::new(List::Cons(3, Box::new(List::Nil))))));
     println!("{:?}", list);
 }
 ```
@@ -659,10 +659,10 @@ so as to avoid copying a large data structure. For example:
 
 ```{rust}
 struct BigStruct {
-    one: int,
-    two: int,
+    one: i32,
+    two: i32,
     // etc
-    one_hundred: int,
+    one_hundred: i32,
 }
 
 fn foo(x: Box<BigStruct>) -> Box<BigStruct> {
@@ -687,10 +687,10 @@ This is an antipattern in Rust. Instead, write this:
 
 ```{rust}
 struct BigStruct {
-    one: int,
-    two: int,
+    one: i32,
+    two: i32,
     // etc
-    one_hundred: int,
+    one_hundred: i32,
 }
 
 fn foo(x: Box<BigStruct>) -> BigStruct {

--- a/src/doc/trpl/pointers.md
+++ b/src/doc/trpl/pointers.md
@@ -28,8 +28,8 @@ question](http://stackoverflow.com/questions/79923/what-and-where-are-the-stack-
 as the rest of this guide assumes you know the difference.) Like this:
 
 ```{rust}
-let x = 5i;
-let y = 8i;
+let x = 5i32;
+let y = 8i32;
 ```
 | location | value |
 |----------|-------|
@@ -46,8 +46,8 @@ Let's introduce a pointer. In some languages, there is just one type of
 *reference*, which is the simplest kind of pointer.
 
 ```{rust}
-let x = 5i;
-let y = 8i;
+let x = 5i32;
+let y = 8i32;
 let z = &y;
 ```
 |location | value    |
@@ -62,8 +62,8 @@ type `int`, but `z` has the type `&int`. We can print this location using the
 `{:p}` format string:
 
 ```{rust}
-let x = 5i;
-let y = 8i;
+let x = 5i32;
+let y = 8i32;
 let z = &y;
 
 println!("{:p}", z);
@@ -75,8 +75,8 @@ Because `int` and `&int` are different types, we can't, for example, add them
 together:
 
 ```{rust,ignore}
-let x = 5i;
-let y = 8i;
+let x = 5i32;
+let y = 8i32;
 let z = &y;
 
 println!("{}", x + z);
@@ -95,8 +95,8 @@ pointer means accessing the value at the location stored in the pointer. This
 will work:
 
 ```{rust}
-let x = 5i;
-let y = 8i;
+let x = 5i32;
+let y = 8i32;
 let z = &y;
 
 println!("{}", x + *z);
@@ -252,7 +252,7 @@ The most basic type of pointer that Rust has is called a *reference*. Rust
 references look like this:
 
 ```{rust}
-let x = 5i;
+let x = 5i32;
 let y = &x;
 
 println!("{}", *y);
@@ -280,7 +280,7 @@ fn succ(x: &int) -> int { *x + 1 }
 
 fn main() {
 
-    let x = 5i;
+    let x = 5i32;
     let y = &x;
 
     println!("{}", succ(y));
@@ -300,7 +300,7 @@ fn succ(x: int) -> int { x + 1 }
 References are immutable by default:
 
 ```{rust,ignore}
-let x = 5i;
+let x = 5i32;
 let y = &x;
 
 *y = 5; // error: cannot assign to immutable dereference of `&`-pointer `*y`
@@ -310,21 +310,21 @@ They can be made mutable with `mut`, but only if its referent is also mutable.
 This works:
 
 ```{rust}
-let mut x = 5i;
+let mut x = 5i32;
 let y = &mut x;
 ```
 
 This does not:
 
 ```{rust,ignore}
-let x = 5i;
+let x = 5i32;
 let y = &mut x; // error: cannot borrow immutable local variable `x` as mutable
 ```
 
 Immutable pointers are allowed to alias:
 
 ```{rust}
-let x = 5i;
+let x = 5i32;
 let y = &x;
 let z = &x;
 ```
@@ -332,7 +332,7 @@ let z = &x;
 Mutable ones, however, are not:
 
 ```{rust,ignore}
-let mut x = 5i;
+let mut x = 5i32;
 let y = &mut x;
 let z = &mut x; // error: cannot borrow `x` as mutable more than once at a time
 ```
@@ -359,7 +359,7 @@ duration a *lifetime*. Let's try a more complex example:
 
 ```{rust}
 fn main() {
-    let x = &mut 5i;
+    let x = &mut 5i32;
 
     if *x < 10 {
         let y = &x;
@@ -380,7 +380,7 @@ mutated, and therefore, lets us pass. This wouldn't work:
 
 ```{rust,ignore}
 fn main() {
-    let x = &mut 5i;
+    let x = &mut 5i32;
 
     if *x < 10 {
         let y = &x;
@@ -459,9 +459,9 @@ use std::rc::Rc;
 
 fn succ(x: &int) -> int { *x + 1 }
 
-let ref_x = &5i;
-let box_x = Box::new(5i);
-let rc_x  = Rc::new(5i);
+let ref_x = &5i32;
+let box_x = Box::new(5i32);
+let rc_x  = Rc::new(5i32);
 
 succ(ref_x);
 succ(&*box_x);
@@ -477,7 +477,7 @@ those contents.
 heap allocation in Rust. Creating a box looks like this:
 
 ```{rust}
-let x = Box::new(5i);
+let x = Box::new(5i32);
 ```
 
 Boxes are heap allocated and they are deallocated automatically by Rust when
@@ -485,7 +485,7 @@ they go out of scope:
 
 ```{rust}
 {
-    let x = Box::new(5i);
+    let x = Box::new(5i32);
 
     // stuff happens
 
@@ -505,7 +505,7 @@ boxes, though. As a rough approximation, you can treat this Rust code:
 
 ```{rust}
 {
-    let x = Box::new(5i);
+    let x = Box::new(5i32);
 
     // stuff happens
 }
@@ -549,7 +549,7 @@ fn add_one(x: &int) -> int {
 }
 
 fn main() {
-    let x = Box::new(5i);
+    let x = Box::new(5i32);
 
     println!("{}", add_one(&*x));
 }
@@ -566,7 +566,7 @@ fn add_one(x: &int) -> int {
 }
 
 fn main() {
-    let x = Box::new(5i);
+    let x = Box::new(5i32);
 
     println!("{}", add_one(&*x));
     println!("{}", add_one(&*x));
@@ -582,7 +582,7 @@ fn add_one(x: &mut int) -> int {
 }
 
 fn main() {
-    let x = Box::new(5i);
+    let x = Box::new(5i32);
 
     println!("{}", add_one(&*x)); // error: cannot borrow immutable dereference
                                   // of `&`-pointer as mutable


### PR DESCRIPTION
All of the instances of the deprecated `i` type suffix, and the `int` type in `pointers.md` have been replaced by `i32`. This resolves warnings at compile-time in the current nightly, complaining about `i` and `int` being deprecated.
