### PR TITLE
Grammar tweak to old guide stub documents.

### DIFF
--- a/src/doc/guide-crates.md
+++ b/src/doc/guide-crates.md
@@ -1,4 +1,4 @@
 % The (old) Rust Crates and Modules Guide
 
-This content has moved into the
+This content has moved into
 [the Rust Programming Language book](book/crates-and-modules.html).

--- a/src/doc/guide-error-handling.md
+++ b/src/doc/guide-error-handling.md
@@ -1,4 +1,4 @@
 % Error Handling in Rust
 
-This content has moved into the
+This content has moved into
 [the Rust Programming Language book](book/error-handling.html).

--- a/src/doc/guide-ffi.md
+++ b/src/doc/guide-ffi.md
@@ -1,4 +1,4 @@
 % The (old) Rust Foreign Function Interface Guide
 
-This content has moved into the
+This content has moved into
 [the Rust Programming Language book](book/ffi.html).

--- a/src/doc/guide-macros.md
+++ b/src/doc/guide-macros.md
@@ -1,4 +1,4 @@
 % The (old) Rust Macros Guide
 
-This content has moved into the
+This content has moved into
 [the Rust Programming Language book](book/macros.html).

--- a/src/doc/guide-ownership.md
+++ b/src/doc/guide-ownership.md
@@ -1,4 +1,4 @@
 % The (old) Rust Ownership Guide
 
-This content has moved into the
+This content has moved into
 [the Rust Programming Language book](book/ownership.html).

--- a/src/doc/guide-plugins.md
+++ b/src/doc/guide-plugins.md
@@ -1,4 +1,4 @@
 % The (old) Rust Compiler Plugins Guide
 
-This content has moved into the
+This content has moved into
 [the Rust Programming Language book](book/plugins.html).

--- a/src/doc/guide-pointers.md
+++ b/src/doc/guide-pointers.md
@@ -1,4 +1,4 @@
 % The (old) Rust Pointer Guide
 
-This content has moved into the
+This content has moved into
 [the Rust Programming Language book](book/pointers.html).

--- a/src/doc/guide-strings.md
+++ b/src/doc/guide-strings.md
@@ -1,4 +1,4 @@
 % The (old) Guide to Rust Strings
 
-This content has moved into the
+This content has moved into
 [the Rust Programming Language book](book/strings.html).

--- a/src/doc/guide-tasks.md
+++ b/src/doc/guide-tasks.md
@@ -1,4 +1,4 @@
 % The (old) Rust Threads and Communication Guide
 
-This content has moved into the
+This content has moved into
 [the Rust Programming Language book](book/tasks.html).

--- a/src/doc/guide-testing.md
+++ b/src/doc/guide-testing.md
@@ -1,4 +1,4 @@
 % The (old) Rust Testing Guide
 
-This content has moved into the
+This content has moved into
 [the Rust Programming Language book](book/testing.html).

--- a/src/doc/guide-unsafe.md
+++ b/src/doc/guide-unsafe.md
@@ -1,4 +1,4 @@
 % Writing Safe Low-level and Unsafe Code in Rust
 
-This content has moved into the
+This content has moved into
 [the Rust Programming Language book](book/unsafe.html).

--- a/src/doc/guide.md
+++ b/src/doc/guide.md
@@ -1,4 +1,4 @@
 % The (old) Rust Guide
 
-This content has moved into the
+This content has moved into
 [the Rust Programming Language book](book/README.html).


### PR DESCRIPTION
This removes the extra "the" from the phrase "the the Rust Programming Language book", which isn't particularly grammatical, in stub documents introduced in #20802 to direct users from the old guides to the corresponding sections of the book.
