### PR TITLE
Use `zero_mem` instead of a zerointializer for `init` intrinsic

### DIFF
--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -361,12 +361,11 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         }
         (_, "init") => {
             let tp_ty = *substs.types.get(FnSpace, 0);
-            let lltp_ty = type_of::arg_type_of(ccx, tp_ty);
-            if return_type_is_void(ccx, tp_ty) {
-                C_nil(ccx)
-            } else {
-                C_null(lltp_ty)
+            if !return_type_is_void(ccx, tp_ty) {
+                // Just zero out the stack slot
+                zero_mem(bcx, llresult, tp_ty);
             }
+            C_nil(ccx)
         }
         // Effectively no-ops
         (_, "uninit") | (_, "forget") => {

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -362,7 +362,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         (_, "init") => {
             let tp_ty = *substs.types.get(FnSpace, 0);
             if !return_type_is_void(ccx, tp_ty) {
-                // Just zero out the stack slot
+                // Just zero out the stack slot. (See comment on base::memzero for explaination)
                 zero_mem(bcx, llresult, tp_ty);
             }
             C_nil(ccx)

--- a/src/test/run-pass/init-large-type.rs
+++ b/src/test/run-pass/init-large-type.rs
@@ -18,7 +18,7 @@ extern "rust-intrinsic" {
     pub fn init<T>() -> T;
 }
 
-const SIZE: usize = 512 * 1024 * 1024;
+const SIZE: usize = 1024 * 1024;
 
 fn main() {
     let _memory: [u8; SIZE] = unsafe { init() };

--- a/src/test/run-pass/init-large-type.rs
+++ b/src/test/run-pass/init-large-type.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Makes sure that zero-initializing large types is reasonably fast,
+// Doing it incorrectly causes massive slowdown in LLVM during
+// optimisation.
+
+#![feature(intrinsics)]
+
+extern "rust-intrinsic" {
+    pub fn init<T>() -> T;
+}
+
+const SIZE: usize = 512 * 1024 * 1024;
+
+fn main() {
+    let _memory: [u8; SIZE] = unsafe { init() };
+}


### PR DESCRIPTION
LLVM gets overwhelmed when presented with a zeroinitializer for a large
type. In unoptimised builds, it generates a long sequence of stores to
memory. In optmised builds, it manages to generate a standard memset of
zero values, but takes a long time doing so.

Call out to the `llvm.memset` function to zero out the memory instead.

Fixes #21264
