### PR TITLE
Remove Send bound from Error trait.

### DIFF
--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -18,7 +18,7 @@
 //! chain information:
 //!
 //! ```
-//! trait Error: Send {
+//! trait Error {
 //!     fn description(&self) -> &str;
 //!
 //!     fn detail(&self) -> Option<String> { None }
@@ -87,7 +87,7 @@ use string::{FromUtf8Error, FromUtf16Error};
 
 /// Base functionality for all errors in Rust.
 #[unstable = "the exact API of this trait may change"]
-pub trait Error: Send {
+pub trait Error {
     /// A short description of the error; usually a static string.
     fn description(&self) -> &str;
 

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -234,7 +234,7 @@ use error::{FromError, Error};
 use fmt;
 use int;
 use iter::{Iterator, IteratorExt};
-use marker::Sized;
+use marker::{Sized, Send};
 use mem::transmute;
 use ops::FnOnce;
 use option::Option;
@@ -363,8 +363,8 @@ impl Error for IoError {
     }
 }
 
-impl FromError<IoError> for Box<Error> {
-    fn from_error(err: IoError) -> Box<Error> {
+impl FromError<IoError> for Box<Error + Send> {
+    fn from_error(err: IoError) -> Box<Error + Send> {
         box err
     }
 }

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -37,7 +37,7 @@ use error::{FromError, Error};
 use fmt;
 use io::{IoResult, IoError};
 use iter::{Iterator, IteratorExt};
-use marker::Copy;
+use marker::{Copy, Send};
 use libc::{c_void, c_int, c_char};
 use libc;
 use boxed::Box;
@@ -937,8 +937,8 @@ impl Error for MapError {
     fn detail(&self) -> Option<String> { Some(format!("{:?}", self)) }
 }
 
-impl FromError<MapError> for Box<Error> {
-    fn from_error(err: MapError) -> Box<Error> {
+impl FromError<MapError> for Box<Error + Send> {
+    fn from_error(err: MapError) -> Box<Error + Send> {
         box err
     }
 }


### PR DESCRIPTION
As discussed with @aturon, this PR removes the `Send` bound from `std::error::Error`, allowing us to implement `Error` for error types containing non-`Send` types. Current examples include `PoisonError` and `TryLockError` from `std::sync` which contain a Guard that we don't want sent between tasks.

[breaking-change]
