### PR TITLE
rustdoc: add --deny-doctest-warnings option

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -817,7 +817,7 @@ endif
 ifeq ($(2),$$(CFG_BUILD))
 $$(call TEST_OK_FILE,$(1),$(2),$(3),doc-$(4)): $$(DOCTESTDEP_$(1)_$(2)_$(3)_$(4))
 	@$$(call E, run doc-$(4) [$(2)])
-	$$(Q)$$(RUSTDOC_$(1)_T_$(2)_H_$(3)) --cfg dox --test $$< \
+	$$(Q)$$(RUSTDOC_$(1)_T_$(2)_H_$(3)) --cfg dox --test --deny-doctest-warnings $$< \
 		--test-args "$$(TESTARGS)" && touch $$@
 else
 $$(call TEST_OK_FILE,$(1),$(2),$(3),doc-$(4)):
@@ -854,7 +854,7 @@ ifeq ($(2),$$(CFG_BUILD))
 $$(call TEST_OK_FILE,$(1),$(2),$(3),doc-crate-$(4)): $$(CRATEDOCTESTDEP_$(1)_$(2)_$(3)_$(4))
 	@$$(call E, run doc-crate-$(4) [$(2)])
 	$$(Q)CFG_LLVM_LINKAGE_FILE=$$(LLVM_LINKAGE_PATH_$(3)) \
-	    $$(RUSTDOC_$(1)_T_$(2)_H_$(3)) --test --cfg dox \
+	    $$(RUSTDOC_$(1)_T_$(2)_H_$(3)) --test --deny-doctest-warnings --cfg dox \
 	    	$$(CRATEFILE_$(4)) --test-args "$$(TESTARGS)" && touch $$@
 else
 $$(call TEST_OK_FILE,$(1),$(2),$(3),doc-crate-$(4)):

--- a/src/libcore/finally.rs
+++ b/src/libcore/finally.rs
@@ -20,6 +20,7 @@
 //!
 //! ```
 //! # #![feature(unboxed_closures)]
+//! #![allow(deprecated)]
 //!
 //! use std::finally::Finally;
 //!
@@ -70,9 +71,10 @@ impl<T, F> Finally<T> for F where F: FnMut() -> T {
 /// # Example
 ///
 /// ```
+/// #![allow(deprecated)]
 /// use std::finally::try_finally;
 ///
-/// struct State<'a> { buffer: &'a mut [u8], len: uint }
+/// struct State<'a> { buffer: &'a mut [u8], len: usize }
 /// # let mut buf = [];
 /// let mut state = State { buffer: &mut buf, len: 0 };
 /// try_finally(

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -16,11 +16,11 @@
 //! # Examples
 //!
 //! ```rust
-//! use std::hash::{hash, Hash, SipHasher};
+//! use std::hash::{hash, SipHasher};
 //!
 //! #[derive(Hash)]
 //! struct Person {
-//!     id: uint,
+//!     id: i32,
 //!     name: String,
 //!     phone: u64,
 //! }
@@ -38,7 +38,7 @@
 //! use std::hash::{hash, Hash, Hasher, Writer, SipHasher};
 //!
 //! struct Person {
-//!     id: uint,
+//!     id: i32,
 //!     name: String,
 //!     phone: u64,
 //! }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -199,7 +199,7 @@ pub fn render(w: &mut fmt::Formatter, s: &str, print_toc: bool) -> fmt::Result {
                         stripped_filtered_line(l).unwrap_or(l)
                     }).collect::<Vec<&str>>().connect("\n");
                     let krate = krate.as_ref().map(|s| s.as_slice());
-                    let test = test::maketest(test.as_slice(), krate, false, false);
+                    let test = test::maketest(test.as_slice(), krate, false, false, false);
                     s.push_str(format!("<span class='rusttest'>{}</span>",
                                          Escape(test.as_slice())).as_slice());
                 });

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -156,7 +156,8 @@ pub fn opts() -> Vec<getopts::OptGroup> {
                  "FILES"),
         optopt("", "markdown-playground-url",
                "URL to send code snippets to", "URL"),
-        optflag("", "markdown-no-toc", "don't include table of contents")
+        optflag("", "markdown-no-toc", "don't include table of contents"),
+        optflag("", "deny-doctest-warnings", "fail to compile on warnings in doc tests")
     )
 }
 
@@ -235,13 +236,14 @@ pub fn main_args(args: &[String]) -> int {
         None => return 3
     };
     let crate_name = matches.opt_str("crate-name");
+    let deny_warnings = matches.opt_present("deny-doctest-warnings");
 
     match (should_test, markdown_input) {
         (true, true) => {
             return markdown::test(input, libs, externs, test_args)
         }
         (true, false) => {
-            return test::run(input, cfgs, libs, externs, test_args, crate_name)
+            return test::run(input, cfgs, libs, externs, test_args, crate_name, deny_warnings)
         }
         (false, true) => return markdown::render(input, output.unwrap_or(Path::new("doc")),
                                                  &matches, &external_html,

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -60,7 +60,7 @@ use sys_common::mutex as sys;
 /// let data = Arc::new(Mutex::new(0));
 ///
 /// let (tx, rx) = channel();
-/// for _ in range(0u, 10) {
+/// for _ in range(0us, 10) {
 ///     let (data, tx) = (data.clone(), tx.clone());
 ///     Thread::spawn(move || {
 ///         // The shared static can only be accessed once the lock is held.
@@ -87,7 +87,7 @@ use sys_common::mutex as sys;
 /// use std::sync::{Arc, Mutex};
 /// use std::thread::Thread;
 ///
-/// let lock = Arc::new(Mutex::new(0u));
+/// let lock = Arc::new(Mutex::new(0us));
 /// let lock2 = lock.clone();
 ///
 /// let _ = Thread::scoped(move || -> () {
@@ -104,7 +104,7 @@ use sys_common::mutex as sys;
 /// // pattern matched on to return the underlying guard on both branches.
 /// let mut guard = match lock.lock() {
 ///     Ok(guard) => guard,
-///     Err(poisoned) => poisoned.into_guard(),
+///     Err(poisoned) => poisoned.into_inner(),
 /// };
 ///
 /// *guard += 1;


### PR DESCRIPTION
Collaboration with @rylev! Addresses #20787.

We kind of brute forced this flag into the call path for `maketest`, so we're soliciting better designs :facepunch: 

Also, we're wondering if we should turn this into a generic `-D` option, like @brson was saying. What would that look like? Would we have to implement all four flags (W, A, D, F)?
