### PR TITLE
Refine wording of Thread::panicking

### DIFF
--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -152,7 +152,7 @@ pub unsafe fn try<F: FnOnce()>(f: F) -> Result<(), Box<Any + Send>> {
     }
 }
 
-/// Test if the current thread is currently panicking.
+/// Determines whether the current thread is unwinding because of panic.
 pub fn panicking() -> bool {
     PANICKING.with(|s| s.get())
 }

--- a/src/libstd/thread.rs
+++ b/src/libstd/thread.rs
@@ -382,7 +382,7 @@ impl Thread {
         unsafe { imp::yield_now() }
     }
 
-    /// Determines whether the current thread is panicking.
+    /// Determines whether the current thread is unwinding because of panic.
     #[inline]
     #[stable]
     pub fn panicking() -> bool {


### PR DESCRIPTION
Previous wording wasn’t clear about its actual behaviour. It could be
interpreted as answering either:
- Can current thread panic?
- Is current thread unwinding because of panic?

r? @steveklabnik 
