### PR TITLE
Passable nano syntax highlighting

### DIFF
--- a/src/etc/nano/rust.nanorc
+++ b/src/etc/nano/rust.nanorc
@@ -1,0 +1,35 @@
+# Nano configuration for Rust
+# Copyright 2015 The Rust Project Developers.
+#
+# NOTE: Rules are applied in order: later rules re-colorize matching text.
+syntax "rust" "\.rs"
+
+# function definition
+color magenta "fn [a-z0-9_]+"
+
+# Reserved words
+color yellow "\<(abstract|alignof|as|be|box|break|const|continue|crate|do|else|enum|extern|false|final|fn|for|if|impl|in|let|loop|macro|match|mod|move|mut|offsetof|override|priv|pub|pure|ref|return|sizeof|static|self|struct|super|true|trait|type|typeof|unsafe|unsized|use|virtual|where|while|yield)\>"
+
+# macros
+color red "[a-z_]+!"
+
+# Constants
+color magenta "[A-Z][A-Z_]+"
+
+# Traits/Enums/Structs/Types/etc.
+color magenta "[A-Z][a-z]+"
+
+# Strings
+color green "\".*\""
+color green start="\".*\\$" end=".*\""
+# NOTE: This isn't accurate but matching "#{0,} for the end of the string is too liberal
+color green start="r#+\"" end="\"#+"
+
+# Comments
+color blue "//.*"
+
+# Attributes
+color magenta start="#!\[" end="\]"
+
+# Some common markers
+color brightcyan "(XXX|TODO|FIXME|\?\?\?)"


### PR DESCRIPTION
rust.nanorc provides syntax highlighting for Rust. An attempt has been made to make the syntax highlighting look good on both dark and light terminals. Issue #21286.

This PR is dedicated to @substars and nano-lovers everywhere.
