### PR TITLE
rustc: print filename if file cannot be written

### DIFF
--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -67,11 +67,11 @@ pub fn write_output_file(
         output: &Path,
         file_type: llvm::FileType) {
     unsafe {
-        let output = CString::from_slice(output.as_vec());
+        let output_c = CString::from_slice(output.as_vec());
         let result = llvm::LLVMRustWriteOutputFile(
-                target, pm, m, output.as_ptr(), file_type);
+                target, pm, m, output_c.as_ptr(), file_type);
         if !result {
-            llvm_err(handler, "could not write output".to_string());
+            llvm_err(handler, format!("could not write output to {}", output.display()));
         }
     }
 }


### PR DESCRIPTION
File cannot be written, for example, if directory does not exist.

Before this commit:

```
% rustc -o nonexistent/program program.rs
error: could not write output: No such file or directory
```

With this commit:

```
% rustc -o nonexistent/program program.rs
error: could not write output to nonexistent/program.0.o: No such file or directory
```

This is useful when full rust command is not displayed, or when last error is followed by thousands of warnings.
