### PR TITLE
Increase docs search box delay

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -635,7 +635,7 @@
             $('.do-search').on('click', search);
             $('.search-input').on('keyup', function() {
                 clearTimeout(keyUpTimeout);
-                keyUpTimeout = setTimeout(search, 100);
+                keyUpTimeout = setTimeout(search, 500);
             });
 
             // Push and pop states are used to add search results to the browser


### PR DESCRIPTION
Increases the delay of the search box to 500ms after key up. I tried
adding a three character minimum for setting the delay, but didn't find
it very useful.

Should close #20095

@Jurily, your input is welcome!
