### PR TITLE
Restructures the "standard input" section of the docs

### DIFF
--- a/src/doc/trpl/standard-input.md
+++ b/src/doc/trpl/standard-input.md
@@ -8,7 +8,12 @@ and then prints it back out:
 fn main() {
     println!("Type something!");
 
-    let input = std::io::stdin().read_line().ok().expect("Failed to read line");
+    let result = std::io::stdin().read_line();
+
+    let input = match result {
+        Ok(text) => text,
+        Err(_) => panic!("Failed to read line"),
+    };
 
     println!("{}", input);
 }
@@ -25,7 +30,7 @@ you can imagine, everything in `std` is provided by Rust, the 'standard
 library.' We'll talk more about the module system later.
 
 Since writing the fully qualified name all the time is annoying, we can use
-the `use` statement to import it in:
+the `use` statement to import it:
 
 ```{rust}
 use std::io::stdin;
@@ -50,7 +55,12 @@ use std::io;
 fn main() {
     println!("Type something!");
 
-    let input = io::stdin().read_line().ok().expect("Failed to read line");
+    let result = io::stdin().read_line();
+
+    let input = match result {
+        Ok(text) => text,
+        Err(_) => panic!("Failed to read line"),
+    };
 
     println!("{}", input);
 }
@@ -65,11 +75,8 @@ Next up:
 The `read_line()` method can be called on the result of `stdin()` to return
 a full line of input. Nice and easy.
 
-```{rust,ignore}
-.ok().expect("Failed to read line");
-```
-
-Do you remember this code?
+It doesn't return a `String` though — not directly, at least. The returned value
+is an `IoResult<T>`. Do you remember this code?
 
 ```{rust}
 enum OptionalInt {
@@ -93,27 +100,67 @@ fn main() {
 }
 ```
 
-We had to match each time to see if we had a value or not. In this case,
-though, we _know_ that `x` has a `Value`, but `match` forces us to handle
-the `missing` case. This is what we want 99% of the time, but sometimes, we
-know better than the compiler.
+The `OptionalInt` enum gave us a way to hold an integer if we had one, or
+otherwise say that it's missing. `IoResult<T>` does a similar thing except it is
+*generic*, which means it can be used for any type – not just `i32`s.
 
-Likewise, `read_line()` does not return a line of input. It _might_ return a
-line of input, though it might also fail to do so. This could happen if our program
-isn't running in a terminal, but as part of a cron job, or some other context
-where there's no standard input. Because of this, `read_line` returns a type
-very similar to our `OptionalInt`: an `IoResult<T>`. We haven't talked about
-`IoResult<T>` yet because it is the *generic* form of our `OptionalInt`.
-Until then, you can think of it as being the same thing, just for any type –
-not just `i32`s.
+Instead of `Value` and `Missing`, `IoResult<T>`'s values are `Ok` and `Err`. An
+`Ok` result means that the `read_line()` worked, and packed inside that `Ok` is
+the text that came from standard input. An `Err` result means that it failed for
+some reason and there is no text. This could happen if our program isn't running
+in a terminal, but as part of a cron job, or some other context where there's no
+standard input.
 
-Rust provides a method on these `IoResult<T>`s called `ok()`, which does the
-same thing as our `match` statement but assumes that we have a valid value.
-We then call `expect()` on the result, which will terminate our program if we
-don't have a valid value. In this case, if we can't get input, our program
-doesn't work, so we're okay with that. In most cases, we would want to handle
-the error case explicitly. `expect()` allows us to give an error message if
-this crash happens.
+```{rust,ignore}
+let input = match result {
+    Ok(text) => text,
+    Err(_) => panic!("Failed to read line"),
+};
+```
+
+Next we use a `match` statement to see what type of result was returned. If the
+`read_line()` was successful, it unpacks the value from inside the `Ok` and gives
+it the name `text`. This text is then assigned to the `input` binding. If it was
+unsuccessful, the `panic!()` macro terminates the program immediately with the
+supplied error message.
+
+Although this works, it would be annoying to need to write an entire `match`
+statement every time we use `read_line()`. For dealing with this common
+situation Rust has a more compact syntax which does the same thing. The
+program can instead be written like this:
+
+```{rust,ignore}
+use std::io;
+
+fn main() {
+    println!("Type something!");
+
+    let input = io::stdin().read_line().ok().expect("Failed to read line");
+
+    println!("{}", input);
+}
+```
+
+Every `IoResult<T>` has a method `ok()`. This attempts to extract the value from
+inside the `Ok` – this was called `text` in the previous version. But this isn't
+always going to work. If the `IoResult` is an `Err` type there is nothing to
+return.
+
+For this reason `ok()` doesn't return a `String` either. It returns an
+`Option<T>`. This is an enum with two possible values – `Some` or `None`. `Some`
+is a wrapper containing the value. `None` means the value does not exist. There
+is one more step of unwrapping to do!
+
+```{rust,ignore}
+.expect("Failed to read line");
+```
+
+`Option<T>` provides a helpful method `expect()`. If it is a `Some<T>` type, it
+will return the value inside it. This is the actual data the user typed, a
+`String` in this case. If it's a `None` the program will terminate immediately,
+printing the message passed in.
+
+This version does exactly the same thing but requires much less typing!
 
 We will cover the exact details of how all of this works later in the Guide.
 For now, this gives you enough of a basic understanding to work with.


### PR DESCRIPTION
As a newcomer I found the standard input section too fast-paced. The unwrapping of `IoResult` -> `Option` -> `String` only made sense after reading the std lib docs for a while. I've rewritten it to explain an example with a `match` first, then go to the compact syntax. I realise this isn't the main place to explain either Optionals or Generics but I think I've kept it pretty brief.
