### PR TITLE
Implement deref coercions.

### DIFF
--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -21,6 +21,7 @@ use super::LvaluePreference;
 use super::method;
 use super::structurally_resolved_type;
 use super::TupleArgumentsFlag;
+use super::UnresolvedTypeAction;
 use super::write_call;
 
 use middle::infer;
@@ -77,6 +78,7 @@ pub fn check_call<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                   callee_expr.span,
                   original_callee_ty,
                   Some(callee_expr),
+                  UnresolvedTypeAction::Error,
                   LvaluePreference::NoPreference,
                   |adj_ty, idx| {
                       let autoderefref = ty::AutoDerefRef { autoderefs: idx, autoref: None };

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-use check::FnCtxt;
+use check::{coercion, FnCtxt};
 use middle::ty::{self, Ty};
 use middle::infer;
 
@@ -62,7 +62,7 @@ pub fn coerce<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>, sp: Span,
            expr_ty.repr(fcx.ccx.tcx));
     let expr_ty = fcx.resolve_type_vars_if_possible(expr_ty);
     let expected = fcx.resolve_type_vars_if_possible(expected);
-    match fcx.mk_assignty(expr, expr_ty, expected) {
+    match coercion::mk_assignty(fcx, expr, expr_ty, expected) {
       Ok(()) => { /* ok */ }
       Err(ref err) => {
         fcx.report_mismatched_types(sp, expected, expr_ty, err);

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1726,24 +1726,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         infer::mk_subty(self.infcx(), a_is_expected, origin, sub, sup)
     }
 
-    pub fn mk_assignty(&self,
-                       expr: &ast::Expr,
-                       sub: Ty<'tcx>,
-                       sup: Ty<'tcx>)
-                       -> Result<(), ty::type_err<'tcx>> {
-        match try!(coercion::mk_coercety(self.infcx(),
-                                         false,
-                                         infer::ExprAssignable(expr.span),
-                                         sub,
-                                         sup)) {
-            None => {}
-            Some(adjustment) => {
-                self.write_adjustment(expr.id, expr.span, adjustment);
-            }
-        }
-        Ok(())
-    }
-
     pub fn mk_eqty(&self,
                    a_is_expected: bool,
                    origin: infer::TypeOrigin,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -132,6 +132,7 @@ pub mod vtable;
 pub mod writeback;
 pub mod regionmanip;
 pub mod regionck;
+pub mod coercion;
 pub mod demand;
 pub mod method;
 mod upvar;
@@ -1730,18 +1731,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                        sub: Ty<'tcx>,
                        sup: Ty<'tcx>)
                        -> Result<(), ty::type_err<'tcx>> {
-        match infer::mk_coercety(self.infcx(),
-                                 false,
-                                 infer::ExprAssignable(expr.span),
-                                 sub,
-                                 sup) {
-            Ok(None) => Ok(()),
-            Err(ref e) => Err((*e)),
-            Ok(Some(adjustment)) => {
+        match try!(coercion::mk_coercety(self.infcx(),
+                                         false,
+                                         infer::ExprAssignable(expr.span),
+                                         sub,
+                                         sup)) {
+            None => {}
+            Some(adjustment) => {
                 self.write_adjustment(expr.id, expr.span, adjustment);
-                Ok(())
             }
         }
+        Ok(())
     }
 
     pub fn mk_eqty(&self,

--- a/src/test/compile-fail/coerce-overloaded-autoderef.rs
+++ b/src/test/compile-fail/coerce-overloaded-autoderef.rs
@@ -1,0 +1,40 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn borrow_mut<T>(x: &mut T) -> &mut T { x }
+fn borrow<T>(x: &T) -> &T { x }
+
+fn borrow_mut2<T>(_: &mut T, _: &mut T) {}
+fn borrow2<T>(_: &mut T, _: &T) {}
+
+fn double_mut_borrow<T>(x: &mut Box<T>) {
+    let y = borrow_mut(x);
+    let z = borrow_mut(x);
+    //~^ ERROR cannot borrow `*x` as mutable more than once at a time
+}
+
+fn double_imm_borrow(x: &mut Box<i32>) {
+    let y = borrow(x);
+    let z = borrow(x);
+    **x += 1;
+    //~^ ERROR cannot assign to `**x` because it is borrowed
+}
+
+fn double_mut_borrow2<T>(x: &mut Box<T>) {
+    borrow_mut2(x, x);
+    //~^ ERROR cannot borrow `*x` as mutable more than once at a time
+}
+
+fn double_borrow2<T>(x: &mut Box<T>) {
+    borrow2(x, x);
+    //~^ ERROR cannot borrow `*x` as immutable because it is also borrowed as mutable
+}
+
+pub fn main() {}

--- a/src/test/compile-fail/method-self-arg-1.rs
+++ b/src/test/compile-fail/method-self-arg-1.rs
@@ -23,11 +23,6 @@ fn main() {
                  //~| found `Foo`
                  //~| expected &-ptr
                  //~| found struct `Foo`
-    Foo::bar(&&x); //~  ERROR mismatched types
-                   //~| expected `&Foo`
-                   //~| found `&&Foo`
-                   //~| expected struct `Foo`
-                   //~| found &-ptr
     Foo::bar(&42is); //~  ERROR mismatched types
                      //~| expected `&Foo`
                      //~| found `&isize`

--- a/src/test/run-pass/coerce-overloaded-autoderef.rs
+++ b/src/test/run-pass/coerce-overloaded-autoderef.rs
@@ -1,0 +1,69 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::rc::Rc;
+
+// Examples from the "deref coercions" RFC, at rust-lang/rfcs#241.
+
+fn use_ref<T>(_: &T) {}
+fn use_mut<T>(_: &mut T) {}
+
+fn use_rc<T>(t: Rc<T>) {
+    use_ref(&*t);  // what you have to write today
+    use_ref(&t);   // what you'd be able to write
+    use_ref(&&&&&&t);
+    use_ref(&mut &&&&&t);
+    use_ref(&&&mut &&&t);
+}
+
+fn use_mut_box<T>(mut t: &mut Box<T>) {
+    use_mut(&mut *t); // what you have to write today
+    use_mut(t);       // what you'd be able to write
+    use_mut(&mut &mut &mut t);
+
+    use_ref(&*t);      // what you have to write today
+    use_ref(t);        // what you'd be able to write
+    use_ref(&&&&&&t);
+    use_ref(&mut &&&&&t);
+    use_ref(&&&mut &&&t);
+}
+
+fn use_nested<T>(t: &Box<T>) {
+    use_ref(&**t);  // what you have to write today
+    use_ref(t);     // what you'd be able to write (note: recursive deref)
+    use_ref(&&&&&&t);
+    use_ref(&mut &&&&&t);
+    use_ref(&&&mut &&&t);
+}
+
+fn use_slice(_: &[u8]) {}
+fn use_slice_mut(_: &mut [u8]) {}
+
+fn use_vec(mut v: Vec<u8>) {
+    use_slice_mut(&mut v[]); // what you have to write today
+    use_slice_mut(&mut v);   // what you'd be able to write
+    use_slice_mut(&mut &mut &mut v);
+
+    use_slice(&v[]);    // what you have to write today
+    use_slice(&v);      // what you'd be able to write
+    use_slice(&&&&&&v);
+    use_slice(&mut &&&&&v);
+    use_slice(&&&mut &&&v);
+}
+
+fn use_vec_ref(v: &Vec<u8>) {
+    use_slice(&v[]);    // what you have to write today
+    use_slice(v);       // what you'd be able to write
+    use_slice(&&&&&&v);
+    use_slice(&mut &&&&&v);
+    use_slice(&&&mut &&&v);
+}
+
+pub fn main() {}


### PR DESCRIPTION
Coercions will now attempt to autoderef as needed before reborrowing.
This includes overloaded `Deref`, e.g. `&Rc<T>` coerces to `&T`, and
`DerefMut`, e.g. `&mut Vec<T>` coerces to `&mut [T]` (in addition to `&[T]`).
Closes #21432.
