### PR TITLE
Fix std::marker.

### DIFF
--- a/src/doc/trpl/unsafe.md
+++ b/src/doc/trpl/unsafe.md
@@ -703,10 +703,10 @@ Other features provided by lang items include:
   `deref`, and `add` respectively.
 - stack unwinding and general failure; the `eh_personality`, `fail`
   and `fail_bounds_checks` lang items.
-- the traits in `std::markers` used to indicate types of
+- the traits in `std::marker` used to indicate types of
   various kinds; lang items `send`, `sync` and `copy`.
 - the marker types and variance indicators found in
-  `std::markers`; lang items `covariant_type`,
+  `std::marker`; lang items `covariant_type`,
   `contravariant_lifetime`, `no_sync_bound`, etc.
 
 Lang items are loaded lazily by the compiler; e.g. if one never uses

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! The [`ptr`](ptr/index.html) and [`mem`](mem/index.html)
 //! modules deal with unsafe pointers and memory manipulation.
-//! [`markers`](markers/index.html) defines the special built-in traits,
+//! [`marker`](marker/index.html) defines the special built-in traits,
 //! and [`raw`](raw/index.html) the runtime representation of Rust types.
 //! These are some of the lowest-level building blocks in Rust.
 //!


### PR DESCRIPTION
From std::markers to std::marker.
