### PR TITLE
Ignore NOTEs when Travis runs `make tidy`

### DIFF
--- a/src/etc/tidy.py
+++ b/src/etc/tidy.py
@@ -8,7 +8,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import sys, fileinput, subprocess, re
+import sys, fileinput, subprocess, re, os
 from licenseck import *
 import snapshot
 
@@ -71,7 +71,7 @@ try:
             if match:
                 report_err("XXX is no longer necessary, use FIXME")
             match = re.match(r'^.*//\s*(NOTE.*)$', line)
-            if match:
+            if match and "TRAVIS" not in os.environ:
                 m = match.group(1)
                 if "snap" in m.lower():
                     report_warn(match.group(1))


### PR DESCRIPTION
Updated `tidy.py` to skip printing NOTEs if the [`TRAVIS`](http://docs.travis-ci.com/user/ci-environment/#Environment-variables) environment variable is set.
