### PR TITLE
Fix some grammar inconsistencies for the '..' range notation.

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -3135,18 +3135,17 @@ The precedence of Rust binary operators is ordered as follows, going from
 strong to weak:
 
 ```{.text .precedence}
-* / %
 as
+* / %
 + -
 << >>
 &
 ^
 |
-< > <= >=
-== !=
+== != < > <= >=
 &&
 ||
-=
+= ..
 ```
 
 Operators at the same precedence level are evaluated left-to-right. [Unary

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -336,8 +336,7 @@ pub fn operator_prec(op: ast::BinOp) -> usize {
 
 /// Precedence of the `as` operator, which is a binary operator
 /// not appearing in the prior table.
-#[allow(non_upper_case_globals)]
-pub static as_prec: usize = 12us;
+pub const AS_PREC: usize = 12us;
 
 pub fn empty_generics() -> Generics {
     Generics {

--- a/src/test/compile-fail/range-3.rs
+++ b/src/test/compile-fail/range-3.rs
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test range syntax - syntax errors.
+
+pub fn main() {
+    let r = 1..2..3;
+    //~^ ERROR expected one of `.`, `;`, or an operator, found `..`
+}

--- a/src/test/compile-fail/range-4.rs
+++ b/src/test/compile-fail/range-4.rs
@@ -1,0 +1,16 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test range syntax - syntax errors.
+
+pub fn main() {
+    let r = ..1..2;
+    //~^ ERROR expected one of `.`, `;`, or an operator, found `..`
+}

--- a/src/test/run-pass/ranges-precedence.rs
+++ b/src/test/run-pass/ranges-precedence.rs
@@ -48,5 +48,12 @@ fn main() {
     assert!(x == &a[3..]);
 
     for _i in 2+4..10-3 {}
+
+    let i = 42;
+    for _ in 1..i {}
+    for _ in 1.. { break; }
+
+    let x = [1]..[2];
+    assert!(x == (([1])..([2])));
 }
 


### PR DESCRIPTION
This PR is intended as alternative to #20958. It fixes the same grammar inconsistencies, but does not increase the operator precedence of `..`, leaving it at the same level as the assignment operator.
For previous discussion, see #20811 and #20958.

Grammar changes:
- allow `for _ in 1..i {}` (fixes #20241)
- allow `for _ in 1.. {}` as infinite loop
- prevent use of range notation in contexts where only operators of high precedence are expected (fixes #20811)

Parser code cleanup:
- remove `RESTRICTION_NO_DOTS`
- make `AS_PREC` const and follow naming convention
- make `min_prec` inclusive

r? nikomatsakis
