### PR TITLE
Use 'in' instead of 'find()' in tidy.py

### DIFF
--- a/src/etc/tidy.py
+++ b/src/etc/tidy.py
@@ -58,14 +58,14 @@ try:
     for line in fileinput.input(file_names,
                                 openhook=fileinput.hook_encoded("utf-8")):
 
-        if fileinput.filename().find("tidy.py") == -1:
-            if line.find(cr_flag) != -1:
+        if "tidy.py" not in fileinput.filename():
+            if cr_flag in line:
                 check_cr = False
-            if line.find(tab_flag) != -1:
+            if tab_flag in line:
                 check_tab = False
-            if line.find(linelength_flag) != -1:
+            if linelength_flag in line:
                 check_linelength = False
-            if line.find("TODO") != -1:
+            if "TODO" in line:
                 report_err("TODO is deprecated; use FIXME")
             match = re.match(r'^.*/(\*|/!?)\s*XXX', line)
             if match:
@@ -86,10 +86,10 @@ try:
                 if "SNAP" in line:
                     report_warn("unmatched SNAP line: " + line)
 
-        if check_tab and (line.find('\t') != -1 and
-            fileinput.filename().find("Makefile") == -1):
+        if check_tab and ('\t' in line and
+            "Makefile" not in fileinput.filename()):
             report_err("tab character")
-        if check_cr and not autocrlf and line.find('\r') != -1:
+        if check_cr and not autocrlf and '\r' in line:
             report_err("CR character")
         if line.endswith(" \n") or line.endswith("\t\n"):
             report_err("trailing whitespace")


### PR DESCRIPTION
`x in y` is more Pythonic than `y.find(x) != -1`. I believe it runs quite a bit faster as well (though it's probably not a bottleneck of the Travis builds):

``` bash
$ python -m timeit '"abc".find("a") != -1'
1000000 loops, best of 3: 0.218 usec per loop
$ python -m timeit '"a" in "abc"'
10000000 loops, best of 3: 0.0343 usec per loop
```
