### PR TITLE
Replace deprecated integer suffixes

### DIFF
--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -2622,7 +2622,7 @@ mod bitv_set_test {
         s.insert(10);
         s.insert(50);
         s.insert(2);
-        assert_eq!("BitvSet {1u, 2u, 10u, 50u}", format!("{:?}", s));
+        assert_eq!("BitvSet {1us, 2us, 10us, 50us}", format!("{:?}", s));
     }
 
     #[test]

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -892,7 +892,7 @@ mod test {
 
         let set_str = format!("{:?}", set);
 
-        assert_eq!(set_str, "BTreeSet {1i, 2i}");
+        assert_eq!(set_str, "BTreeSet {1is, 2is}");
         assert_eq!(format!("{:?}", empty), "BTreeSet {}");
     }
 }

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -1333,7 +1333,8 @@ mod tests {
     #[test]
     fn test_show() {
         let list: DList<int> = range(0i, 10).collect();
-        assert_eq!(format!("{:?}", list), "DList [0i, 1i, 2i, 3i, 4i, 5i, 6i, 7i, 8i, 9i]");
+        assert_eq!(format!("{:?}", list),
+          "DList [0is, 1is, 2is, 3is, 4is, 5is, 6is, 7is, 8is, 9is]");
 
         let list: DList<&str> = vec!["just", "one", "test", "more"].iter()
                                                                    .map(|&s| s)

--- a/src/libcollections/ring_buf.rs
+++ b/src/libcollections/ring_buf.rs
@@ -2302,7 +2302,8 @@ mod tests {
     #[test]
     fn test_show() {
         let ringbuf: RingBuf<int> = range(0i, 10).collect();
-        assert_eq!(format!("{:?}", ringbuf), "RingBuf [0i, 1i, 2i, 3i, 4i, 5i, 6i, 7i, 8i, 9i]");
+        assert_eq!(format!("{:?}", ringbuf),
+          "RingBuf [0is, 1is, 2is, 3is, 4is, 5is, 6is, 7is, 8is, 9is]");
 
         let ringbuf: RingBuf<&str> = vec!["just", "one", "test", "more"].iter()
                                                                         .map(|&s| s)

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -2476,19 +2476,19 @@ mod tests {
         }
         let empty: Vec<int> = vec![];
         test_show_vec!(empty, "[]");
-        test_show_vec!(vec![1i], "[1i]");
-        test_show_vec!(vec![1i, 2, 3], "[1i, 2i, 3i]");
-        test_show_vec!(vec![vec![], vec![1u], vec![1u, 1u]],
-                       "[[], [1u], [1u, 1u]]");
+        test_show_vec!(vec![1is], "[1is]");
+        test_show_vec!(vec![1is, 2, 3], "[1is, 2is, 3is]");
+        test_show_vec!(vec![vec![], vec![1u], vec![1us, 1us]],
+                       "[[], [1us], [1us, 1us]]");
 
         let empty_mut: &mut [int] = &mut[];
         test_show_vec!(empty_mut, "[]");
         let v: &mut[int] = &mut[1];
-        test_show_vec!(v, "[1i]");
+        test_show_vec!(v, "[1is]");
         let v: &mut[int] = &mut[1, 2, 3];
-        test_show_vec!(v, "[1i, 2i, 3i]");
-        let v: &mut [&mut[uint]] = &mut[&mut[], &mut[1u], &mut[1u, 1u]];
-        test_show_vec!(v, "[[], [1u], [1u, 1u]]");
+        test_show_vec!(v, "[1is, 2is, 3is]");
+        let v: &mut [&mut[uint]] = &mut[&mut[], &mut[1us], &mut[1us, 1us]];
+        test_show_vec!(v, "[[], [1us], [1us, 1us]]");
     }
 
     #[test]

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1295,10 +1295,10 @@ mod tests {
     fn test_vectors() {
         let x: Vec<int> = vec![];
         assert_eq!(format!("{:?}", x), "[]");
-        assert_eq!(format!("{:?}", vec![1i]), "[1i]");
-        assert_eq!(format!("{:?}", vec![1i, 2, 3]), "[1i, 2i, 3i]");
-        assert!(format!("{:?}", vec![vec![], vec![1i], vec![1i, 1]]) ==
-               "[[], [1i], [1i, 1i]]");
+        assert_eq!(format!("{:?}", vec![1is]), "[1is]");
+        assert_eq!(format!("{:?}", vec![1is, 2, 3]), "[1is, 2is, 3is]");
+        assert!(format!("{:?}", vec![vec![], vec![1is], vec![1is, 1]]) ==
+               "[[], [1is], [1is, 1is]]");
     }
 
     #[test]

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -930,7 +930,7 @@ mod test_map {
         map.insert(3, 4i);
 
         let map_str = format!("{:?}", map);
-        assert!(map_str == "VecMap {1: 2i, 3: 4i}" || map_str == "{3: 4i, 1: 2i}");
+        assert!(map_str == "VecMap {1: 2is, 3: 4is}" || map_str == "{3: 4is, 1: 2is}");
         assert_eq!(format!("{:?}", empty), "VecMap {}");
     }
 

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -209,7 +209,7 @@ macro_rules! integer {
         show! { $Uint with $SU }
     }
 }
-integer! { int, uint, "i", "u" }
+integer! { int, uint, "is", "us" }
 integer! { i8, u8 }
 integer! { i16, u16 }
 integer! { i32, u32 }

--- a/src/libcoretest/fmt/num.rs
+++ b/src/libcoretest/fmt/num.rs
@@ -26,7 +26,7 @@ fn test_format_int() {
     assert!(format!("{}", -1i16) == "-1");
     assert!(format!("{}", -1i32) == "-1");
     assert!(format!("{}", -1i64) == "-1");
-    assert!(format!("{:?}", 1i) == "1i");
+    assert!(format!("{:?}", 1is) == "1is");
     assert!(format!("{:?}", 1i8) == "1i8");
     assert!(format!("{:?}", 1i16) == "1i16");
     assert!(format!("{:?}", 1i32) == "1i32");
@@ -57,7 +57,7 @@ fn test_format_int() {
     assert!(format!("{}", 1u16) == "1");
     assert!(format!("{}", 1u32) == "1");
     assert!(format!("{}", 1u64) == "1");
-    assert!(format!("{:?}", 1u) == "1u");
+    assert!(format!("{:?}", 1us) == "1us");
     assert!(format!("{:?}", 1u8) == "1u8");
     assert!(format!("{:?}", 1u16) == "1u16");
     assert!(format!("{:?}", 1u32) == "1u32");
@@ -94,14 +94,14 @@ fn test_format_int() {
 #[test]
 fn test_format_int_zero() {
     assert!(format!("{}", 0i) == "0");
-    assert!(format!("{:?}", 0i) == "0i");
+    assert!(format!("{:?}", 0is) == "0is");
     assert!(format!("{:b}", 0i) == "0");
     assert!(format!("{:o}", 0i) == "0");
     assert!(format!("{:x}", 0i) == "0");
     assert!(format!("{:X}", 0i) == "0");
 
     assert!(format!("{}", 0u) == "0");
-    assert!(format!("{:?}", 0u) == "0u");
+    assert!(format!("{:?}", 0us) == "0us");
     assert!(format!("{:b}", 0u) == "0");
     assert!(format!("{:o}", 0u) == "0");
     assert!(format!("{:x}", 0u) == "0");

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1996,8 +1996,8 @@ mod test_map {
 
         let map_str = format!("{:?}", map);
 
-        assert!(map_str == "HashMap {1i: 2i, 3i: 4i}" ||
-                map_str == "HashMap {3i: 4i, 1i: 2i}");
+        assert!(map_str == "HashMap {1is: 2is, 3is: 4is}" ||
+                map_str == "HashMap {3is: 4is, 1is: 2is}");
         assert_eq!(format!("{:?}", empty), "HashMap {}");
     }
 

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -1179,7 +1179,7 @@ mod test_set {
 
         let set_str = format!("{:?}", set);
 
-        assert!(set_str == "HashSet {1i, 2i}" || set_str == "HashSet {2i, 1i}");
+        assert!(set_str == "HashSet {1is, 2is}" || set_str == "HashSet {2is, 1is}");
         assert_eq!(format!("{:?}", empty), "HashSet {}");
     }
 

--- a/src/test/run-fail/assert-eq-macro-panic.rs
+++ b/src/test/run-fail/assert-eq-macro-panic.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:assertion failed: `(left == right) && (right == left)` (left: `14i`, right: `15i`)
+// error-pattern:assertion failed: `(left == right) && (right == left)` (left: `4is`, right: `5is`)
 
 fn main() {
-    assert_eq!(14i,15i);
+    assert_eq!(4is,5is);
 }

--- a/src/test/run-pass/deriving-show-2.rs
+++ b/src/test/run-pass/deriving-show-2.rs
@@ -25,11 +25,9 @@ struct F(int);
 #[derive(Show)]
 struct G(int, int);
 #[derive(Show)]
-struct H { a: int }
+struct H { a: int, b: int }
 #[derive(Show)]
-struct I { a: int, b: int }
-#[derive(Show)]
-struct J(Custom);
+struct I(Custom);
 
 struct Custom;
 impl fmt::Show for Custom {
@@ -51,12 +49,12 @@ impl<T: fmt::Show> ToShow for T {
 pub fn main() {
     assert_eq!(B::B1.to_show(), "B1".to_string());
     assert_eq!(B::B2.to_show(), "B2".to_string());
-    assert_eq!(C::C1(3).to_show(), "C1(3i)".to_string());
+    assert_eq!(C::C1(3).to_show(), "C1(3is)".to_string());
     assert_eq!(C::C2(B::B2).to_show(), "C2(B2)".to_string());
-    assert_eq!(D::D1{ a: 2 }.to_show(), "D1 { a: 2i }".to_string());
+    assert_eq!(D::D1{ a: 2 }.to_show(), "D1 { a: 2is }".to_string());
     assert_eq!(E.to_show(), "E".to_string());
-    assert_eq!(F(3).to_show(), "F(3i)".to_string());
-    assert_eq!(G(3, 4).to_show(), "G(3i, 4i)".to_string());
-    assert_eq!(I{ a: 2, b: 4 }.to_show(), "I { a: 2i, b: 4i }".to_string());
-    assert_eq!(J(Custom).to_show(), "J(yay)".to_string());
+    assert_eq!(F(3).to_show(), "F(3is)".to_string());
+    assert_eq!(G(3, 4).to_show(), "G(3is, 4is)".to_string());
+    assert_eq!(H{ a: 2, b: 4 }.to_show(), "H { a: 2is, b: 4is }".to_string());
+    assert_eq!(I(Custom).to_show(), "I(yay)".to_string());
 }

--- a/src/test/run-pass/deriving-show.rs
+++ b/src/test/run-pass/deriving-show.rs
@@ -32,9 +32,9 @@ macro_rules! t {
 
 pub fn main() {
     t!(Unit, "Unit");
-    t!(Tuple(1, 2), "Tuple(1i, 2u)");
-    t!(Struct { x: 1, y: 2 }, "Struct { x: 1i, y: 2u }");
+    t!(Tuple(1, 2), "Tuple(1is, 2us)");
+    t!(Struct { x: 1, y: 2 }, "Struct { x: 1is, y: 2us }");
     t!(Enum::Nullary, "Nullary");
-    t!(Enum::Variant(1, 2), "Variant(1i, 2u)");
-    t!(Enum::StructVariant { x: 1, y: 2 }, "StructVariant { x: 1i, y: 2u }");
+    t!(Enum::Variant(1, 2), "Variant(1is, 2us)");
+    t!(Enum::StructVariant { x: 1, y: 2 }, "StructVariant { x: 1is, y: 2us }");
 }

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -63,8 +63,8 @@ pub fn main() {
     t!(format!("{}", 10i), "10");
     t!(format!("{}", 10u), "10");
     t!(format!("{:?}", '☃'), "'\\u{2603}'");
-    t!(format!("{:?}", 10i), "10i");
-    t!(format!("{:?}", 10u), "10u");
+    t!(format!("{:?}", 10i), "10is");
+    t!(format!("{:?}", 10u), "10us");
     t!(format!("{:?}", "true"), "\"true\"");
     t!(format!("{:?}", "foo\nbar"), "\"foo\\nbar\"");
     t!(format!("{:o}", 10u), "12");

--- a/src/test/run-pass/issue-3559.rs
+++ b/src/test/run-pass/issue-3559.rs
@@ -24,6 +24,6 @@ pub fn main() {
     let mut table = HashMap::new();
     table.insert("one".to_string(), 1i);
     table.insert("two".to_string(), 2i);
-    assert!(check_strs(format!("{:?}", table).as_slice(), "HashMap {\"one\": 1i, \"two\": 2i}") ||
-            check_strs(format!("{:?}", table).as_slice(), "HashMap {\"two\": 2i, \"one\": 1i}"));
+    assert!(check_strs(format!("{:?}", table).as_slice(), "HashMap {\"one\": 1is, \"two\": 2is}") ||
+            check_strs(format!("{:?}", table).as_slice(), "HashMap {\"two\": 2is, \"one\": 1is}"));
 }

--- a/src/test/run-pass/issue-8898.rs
+++ b/src/test/run-pass/issue-8898.rs
@@ -18,7 +18,7 @@ pub fn main() {
     let x  = [(), ()];
     let slice = &x[..1];
 
-    assert_repr_eq(&abc[], "[1i, 2i, 3i]".to_string());
+    assert_repr_eq(&abc[], "[1is, 2is, 3is]".to_string());
     assert_repr_eq(&tf[], "[true, false]".to_string());
     assert_repr_eq(&x[], "[(), ()]".to_string());
     assert_repr_eq(slice, "[()]".to_string());

--- a/src/test/run-pass/log-knows-the-names-of-variants-in-std.rs
+++ b/src/test/run-pass/log-knows-the-names-of-variants-in-std.rs
@@ -19,8 +19,8 @@ fn check_log<T: std::fmt::Show>(exp: String, v: T) {
 }
 
 pub fn main() {
-    let mut x = Some(foo::a(22u));
-    let exp = "Some(a(22u))".to_string();
+    let mut x = Some(foo::a(22us));
+    let exp = "Some(a(22us))".to_string();
     let act = format!("{:?}", x);
     assert_eq!(act, exp);
     check_log(exp, x);

--- a/src/test/run-pass/log-knows-the-names-of-variants.rs
+++ b/src/test/run-pass/log-knows-the-names-of-variants.rs
@@ -21,7 +21,7 @@ enum bar {
 }
 
 pub fn main() {
-    assert_eq!("a(22u)".to_string(), format!("{:?}", foo::a(22u)));
+    assert_eq!("a(22us)".to_string(), format!("{:?}", foo::a(22us)));
     assert_eq!("c".to_string(), format!("{:?}", foo::c));
     assert_eq!("d".to_string(), format!("{:?}", bar::d));
 }

--- a/src/test/run-pass/vec-to_str.rs
+++ b/src/test/run-pass/vec-to_str.rs
@@ -9,11 +9,11 @@
 // except according to those terms.
 
 pub fn main() {
-    assert_eq!(format!("{:?}", vec!(0i, 1)), "[0i, 1i]".to_string());
+    assert_eq!(format!("{:?}", vec!(0is, 1)), "[0is, 1is]".to_string());
 
-    let foo = vec!(3i, 4);
+    let foo = vec!(3is, 4);
     let bar: &[int] = &[4, 5];
 
-    assert_eq!(format!("{:?}", foo), "[3i, 4i]");
-    assert_eq!(format!("{:?}", bar), "[4i, 5i]");
+    assert_eq!(format!("{:?}", foo), "[3is, 4is]");
+    assert_eq!(format!("{:?}", bar), "[4is, 5is]");
 }


### PR DESCRIPTION
In the following example:

```
fn main() { 
    println!("{:?}", 42is);
    println!("{:?}", 42us);
} 
```

The output is:

```
42i
42u
```

This should be outputting the following instead:

```
42is
42us
```
