### PR TITLE
impl Iterator for &mut Iterator and Box<Iterator>

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -194,6 +194,10 @@ impl<'a, T> Iterator for Box<Iterator<Item=T> + 'a> {
     fn next(&mut self) -> Option<T> {
         (**self).next()
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (**self).size_hint()
+    }
 }
 
 #[cfg(test)]

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -18,6 +18,7 @@ use core::cmp::{PartialEq, PartialOrd, Eq, Ord, Ordering};
 use core::default::Default;
 use core::fmt;
 use core::hash::{self, Hash};
+use core::iter::Iterator;
 use core::marker::Sized;
 use core::mem;
 use core::option::Option;
@@ -183,6 +184,16 @@ impl<T: ?Sized> Deref for Box<T> {
 #[stable]
 impl<T: ?Sized> DerefMut for Box<T> {
     fn deref_mut(&mut self) -> &mut T { &mut **self }
+}
+
+// FIXME(#21363) remove `old_impl_check` when bug is fixed
+#[old_impl_check]
+impl<'a, T> Iterator for Box<Iterator<Item=T> + 'a> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        (**self).next()
+    }
 }
 
 #[cfg(test)]

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -70,6 +70,8 @@
 #![feature(lang_items, unsafe_destructor)]
 #![feature(box_syntax)]
 #![feature(optin_builtin_traits)]
+// FIXME(#21363) remove `old_impl_check` when bug is fixed
+#![feature(old_impl_check)]
 #![allow(unknown_features)] #![feature(int_uint)]
 
 #[macro_use]

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -99,6 +99,16 @@ pub trait Iterator {
     fn size_hint(&self) -> (uint, Option<uint>) { (0, None) }
 }
 
+// FIXME(#21363) remove `old_impl_check` when bug is fixed
+#[old_impl_check]
+impl<'a, T> Iterator for &'a mut (Iterator<Item=T> + 'a) {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        (**self).next()
+    }
+}
+
 /// Conversion from an `Iterator`
 #[stable]
 #[rustc_on_unimplemented="a collection of type `{Self}` cannot be \

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -107,6 +107,10 @@ impl<'a, T> Iterator for &'a mut (Iterator<Item=T> + 'a) {
     fn next(&mut self) -> Option<T> {
         (**self).next()
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (**self).size_hint()
+    }
 }
 
 /// Conversion from an `Iterator`

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -63,6 +63,8 @@
 #![feature(unboxed_closures)]
 #![allow(unknown_features)] #![feature(int_uint)]
 #![feature(on_unimplemented)]
+// FIXME(#21363) remove `old_impl_check` when bug is fixed
+#![feature(old_impl_check)]
 #![deny(missing_docs)]
 
 #[macro_use]

--- a/src/test/run-pass/issue-20953.rs
+++ b/src/test/run-pass/issue-20953.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let mut shrinker: Box<Iterator<Item=i32>> = Box::new(vec![1].into_iter());
+    println!("{:?}", shrinker.next());
+    for v in shrinker { assert!(false); }
+
+    let mut shrinker: &mut Iterator<Item=i32> = &mut vec![1].into_iter();
+    println!("{:?}", shrinker.next());
+    for v in shrinker { assert!(false); }
+}

--- a/src/test/run-pass/issue-21361.rs
+++ b/src/test/run-pass/issue-21361.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let v = vec![1, 2, 3];
+    let boxed: Box<Iterator<Item=i32>> = Box::new(v.into_iter());
+    assert_eq!(boxed.max(), Some(3));
+
+    let v = vec![1, 2, 3];
+    let boxed: &mut Iterator<Item=i32> = &mut v.into_iter();
+    assert_eq!(boxed.max(), Some(3));
+}


### PR DESCRIPTION
closes #20953
closes #21361 

---

In the future, we will likely derive these `impl`s via syntax extensions or using compiler magic (see #20617). For the time being we can use these manual `impl`s.

r? @aturon 
cc @burntsushi @Kroisse
