### PR TITLE
Fix `make check PLEASE_BENCH=1`

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -38,16 +38,14 @@ ifdef CHECK_IGNORED
   TESTARGS += --ignored
 endif
 
-TEST_BENCH =
 
 # Arguments to the cfail/rfail/rpass/bench tests
 ifdef CFG_VALGRIND
   CTEST_RUNTOOL = --runtool "$(CFG_VALGRIND)"
-  TEST_BENCH =
 endif
 
 ifdef PLEASE_BENCH
-  TEST_BENCH = --bench
+  TESTARGS += --bench
 endif
 
 # Arguments to the perf tests


### PR DESCRIPTION
611ef49f2fa573edf9cff4442eddb8ee7e48878d removed all the metrics stuff
from tests.mk, but this meant that `PLEASE_BENCH=1` no longer did
anything.

Fixes #21324.
