### PR TITLE
Optimize Vec::shrink_to_fit()

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1408,4 +1408,20 @@ mod tests {
             let _ = String::from_utf8_lossy(s.as_slice());
         });
     }
+
+    #[bench]
+    fn bench_exact_size_shrink_to_fit(b: &mut Bencher) {
+        let s = "Hello there, the quick brown fox jumped over the lazy dog! \
+                 Lorem ipsum dolor sit amet, consectetur. ";
+        // ensure our operation produces an exact-size string before we benchmark it
+        let mut r = String::with_capacity(s.len());
+        r.push_str(s);
+        assert_eq!(r.len(), r.capacity());
+        b.iter(|| {
+            let mut r = String::with_capacity(s.len());
+            r.push_str(s);
+            r.shrink_to_fit();
+            r
+        });
+    }
 }

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -356,7 +356,7 @@ impl<T> Vec<T> {
                 }
                 self.cap = 0;
             }
-        } else {
+        } else if self.cap != self.len {
             unsafe {
                 // Overflow check is unnecessary as the vector is already at
                 // least this large.


### PR DESCRIPTION
Don't reallocate when capacity is already equal to length

`Vec::shrink_to_fit()` may be called on vectors that are already the
correct length. Calling out to `reallocate()` in this case is a bad idea
because there is no guarantee that `reallocate()` won't allocate a new
buffer anyway, and based on performance seen in external benchmarks, it
seems likely that it is in fact reallocating a new buffer.

Before:

```
test string::tests::bench_exact_size_shrink_to_fit         ... bench:        45 ns/iter (+/- 2)
```

After:

```
test string::tests::bench_exact_size_shrink_to_fit         ... bench:        26 ns/iter (+/- 1)
```
