### PR TITLE
Add rustc --drawing to use Unicode line drawing characters for span output

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -100,6 +100,9 @@ Configure coloring of output:
     auto = colorize, if output goes to a tty (default);
     always = always colorize output;
     never = never colorize output
+.TP
+\fB\-\-drawing\fR
+Use drawing characters in diagnostic output
 
 .SH CODEGEN OPTIONS
 

--- a/src/etc/zsh/_rust
+++ b/src/etc/zsh/_rust
@@ -67,6 +67,7 @@ _rustc_opts_switches=(
     {-V,--verbose}'[use verbose output]'
     -O'[Equivalent to -C opt-level=2]'
     --test'[Build a test harness]'
+    --drawing'[Use drawing characters in diagnostic output]'
 )
 
 

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -29,7 +29,7 @@ use syntax::ast;
 use syntax::ast::{IntTy, UintTy};
 use syntax::attr;
 use syntax::attr::AttrMetaMethods;
-use syntax::diagnostic::{ColorConfig, Auto, Always, Never, SpanHandler};
+use syntax::diagnostic::{ColorConfig, SpanHandler};
 use syntax::parse;
 use syntax::parse::token::InternedString;
 
@@ -228,7 +228,7 @@ pub fn basic_options() -> Options {
         write_dependency_info: (false, None),
         prints: Vec::new(),
         cg: basic_codegen_options(),
-        color: Auto,
+        color: ColorConfig::Auto,
         show_span: None,
         externs: HashMap::new(),
         crate_name: None,
@@ -1073,11 +1073,11 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
     }
 
     let color = match matches.opt_str("color").as_ref().map(|s| &s[]) {
-        Some("auto")   => Auto,
-        Some("always") => Always,
-        Some("never")  => Never,
+        Some("auto")   => ColorConfig::Auto,
+        Some("always") => ColorConfig::Always,
+        Some("never")  => ColorConfig::Never,
 
-        None => Auto,
+        None => ColorConfig::Auto,
 
         Some(arg) => {
             early_error(&format!("argument for --color must be auto, always \

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -365,13 +365,15 @@ pub fn expect<T, M>(sess: &Session, opt: Option<T>, msg: M) -> T where
     diagnostic::expect(sess.diagnostic(), opt, msg)
 }
 
+pub fn fallback_emitter() -> diagnostic::EmitterWriter {
+    diagnostic::EmitterWriter::stderr(diagnostic::ColorConfig::Auto, None)
+}
+
 pub fn early_error(msg: &str) -> ! {
-    let mut emitter = diagnostic::EmitterWriter::stderr(diagnostic::Auto, None);
-    emitter.emit(None, msg, None, diagnostic::Fatal);
+    fallback_emitter().emit(None, msg, None, diagnostic::Fatal);
     panic!(diagnostic::FatalError);
 }
 
 pub fn early_warn(msg: &str) {
-    let mut emitter = diagnostic::EmitterWriter::stderr(diagnostic::Auto, None);
-    emitter.emit(None, msg, None, diagnostic::Warning);
+    fallback_emitter().emit(None, msg, None, diagnostic::Warning);
 }

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -31,6 +31,7 @@ use rustc_back::target::Target;
 
 use std::os;
 use std::cell::{Cell, RefCell};
+use std::default::Default;
 
 pub mod config;
 pub mod search_paths;
@@ -291,7 +292,7 @@ pub fn build_session(sopts: config::Options,
                      -> Session {
     let codemap = codemap::CodeMap::new();
     let diagnostic_handler =
-        diagnostic::default_handler(sopts.color, Some(registry));
+        diagnostic::default_handler(sopts.emit_cfg, Some(registry));
     let span_diagnostic_handler =
         diagnostic::mk_span_handler(diagnostic_handler, codemap);
 
@@ -366,7 +367,7 @@ pub fn expect<T, M>(sess: &Session, opt: Option<T>, msg: M) -> T where
 }
 
 pub fn fallback_emitter() -> diagnostic::EmitterWriter {
-    diagnostic::EmitterWriter::stderr(diagnostic::ColorConfig::Auto, None)
+    diagnostic::EmitterWriter::stderr(Default::default(), None)
 }
 
 pub fn early_error(msg: &str) -> ! {

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -222,7 +222,7 @@ impl Target {
         // this is 1. ugly, 2. error prone.
 
 
-        let handler = diagnostic::default_handler(diagnostic::ColorConfig::Auto, None);
+        let handler = diagnostic::default_handler(Default::default(), None);
 
         let get_req_field = |&: name: &str| {
             match obj.find(name)

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -222,7 +222,7 @@ impl Target {
         // this is 1. ugly, 2. error prone.
 
 
-        let handler = diagnostic::default_handler(diagnostic::Auto, None);
+        let handler = diagnostic::default_handler(diagnostic::ColorConfig::Auto, None);
 
         let get_req_field = |&: name: &str| {
             match obj.find(name)

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -71,7 +71,7 @@ use std::os;
 use std::sync::mpsc::channel;
 use std::thread;
 
-use rustc::session::early_error;
+use rustc::session::{early_error, fallback_emitter};
 
 use syntax::ast;
 use syntax::parse;
@@ -616,7 +616,7 @@ pub fn monitor<F:FnOnce()+Send>(f: F) {
         Err(value) => {
             // Thread panicked without emitting a fatal diagnostic
             if !value.is::<diagnostic::FatalError>() {
-                let mut emitter = diagnostic::EmitterWriter::stderr(diagnostic::Auto, None);
+                let mut emitter = fallback_emitter();
 
                 // a .span_bug or .bug call has already printed what
                 // it wants to print.

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -22,6 +22,7 @@ use syntax::{ast, ast_map, codemap, diagnostic};
 
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::default::Default;
 
 use visit_ast::RustdocVisitor;
 use clean;
@@ -103,7 +104,7 @@ pub fn run_core(search_paths: SearchPaths, cfgs: Vec<String>, externs: Externs,
     };
 
     let codemap = codemap::CodeMap::new();
-    let diagnostic_handler = diagnostic::default_handler(diagnostic::Auto, None);
+    let diagnostic_handler = diagnostic::default_handler(Default::default(), None);
     let span_diagnostic_handler =
         diagnostic::mk_span_handler(diagnostic_handler, codemap);
 

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -17,6 +17,7 @@ use std::os;
 use std::str;
 use std::thread::Thread;
 use std::thunk::Thunk;
+use std::default::Default;
 
 use std::collections::{HashSet, HashMap};
 use testing;
@@ -58,7 +59,7 @@ pub fn run(input: &str,
     };
 
     let codemap = CodeMap::new();
-    let diagnostic_handler = diagnostic::default_handler(diagnostic::Auto, None);
+    let diagnostic_handler = diagnostic::default_handler(Default::default(), None);
     let span_diagnostic_handler =
     diagnostic::mk_span_handler(diagnostic_handler, codemap);
 

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -10,7 +10,6 @@
 
 pub use self::Level::*;
 pub use self::RenderSpan::*;
-pub use self::ColorConfig::*;
 use self::Destination::*;
 
 use codemap::{COMMAND_LINE_SP, COMMAND_LINE_EXPN, Pos, Span};
@@ -335,9 +334,9 @@ impl EmitterWriter {
         let stderr = io::stderr();
 
         let use_color = match color_config {
-            Always => true,
-            Never  => false,
-            Auto   => stderr.get_ref().isatty()
+            ColorConfig::Always => true,
+            ColorConfig::Never  => false,
+            ColorConfig::Auto   => stderr.get_ref().isatty()
         };
 
         if use_color {

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -12,7 +12,7 @@
 
 use ast;
 use codemap::{Span, CodeMap, FileMap};
-use diagnostic::{SpanHandler, mk_span_handler, default_handler, Auto};
+use diagnostic::{SpanHandler, mk_span_handler, default_handler, ColorConfig};
 use parse::attr::ParserAttr;
 use parse::parser::Parser;
 use ptr::P;
@@ -45,7 +45,8 @@ pub struct ParseSess {
 
 pub fn new_parse_sess() -> ParseSess {
     ParseSess {
-        span_diagnostic: mk_span_handler(default_handler(Auto, None), CodeMap::new()),
+        span_diagnostic: mk_span_handler(default_handler(ColorConfig::Auto, None),
+                                         CodeMap::new()),
         included_mod_stack: RefCell::new(Vec::new()),
         node_id: Cell::new(1),
     }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -12,7 +12,7 @@
 
 use ast;
 use codemap::{Span, CodeMap, FileMap};
-use diagnostic::{SpanHandler, mk_span_handler, default_handler, ColorConfig};
+use diagnostic::{SpanHandler, mk_span_handler, default_handler};
 use parse::attr::ParserAttr;
 use parse::parser::Parser;
 use ptr::P;
@@ -21,6 +21,7 @@ use std::cell::{Cell, RefCell};
 use std::io::File;
 use std::rc::Rc;
 use std::num::Int;
+use std::default::Default;
 use std::str;
 use std::iter;
 
@@ -45,7 +46,7 @@ pub struct ParseSess {
 
 pub fn new_parse_sess() -> ParseSess {
     ParseSess {
-        span_diagnostic: mk_span_handler(default_handler(ColorConfig::Auto, None),
+        span_diagnostic: mk_span_handler(default_handler(Default::default(), None),
                                          CodeMap::new()),
         included_mod_stack: RefCell::new(Vec::new()),
         node_id: Cell::new(1),

--- a/src/test/compile-fail/drawing-spans-one-char.rs
+++ b/src/test/compile-fail/drawing-spans-one-char.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:--drawing
+// error-pattern: ▲
+
+#![deny(warnings)]
+
+fn main() {
+    let x = 3;
+}

--- a/src/test/compile-fail/drawing-spans.rs
+++ b/src/test/compile-fail/drawing-spans.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:--drawing
+// error-pattern: ┗━━━━┛
+
+#![deny(warnings)]
+
+fn main() {
+    let foobar = 3;
+}


### PR DESCRIPTION
![example](http://i.imgur.com/G2lm9I9.png)

I bet we can find other uses for these sorts of characters in clarifying type errors, etc.

This is marked as a "stable" flag for consistency with `--color`. However we should reconsider both of them as part of #19051. For these features to be conveniently available with Cargo, we may want to use environment variables or a config file.
