### PR TITLE
Initial support for aarch64-linux-android

### DIFF
--- a/mk/cfg/aarch64-linux-android.mk
+++ b/mk/cfg/aarch64-linux-android.mk
@@ -1,0 +1,30 @@
+# aarch64-linux-android configuration
+# CROSS_PREFIX_aarch64-linux-android-
+CC_aarch64-linux-android=$(CFG_ANDROID_CROSS_PATH)/bin/aarch64-linux-android-gcc
+CXX_aarch64-linux-android=$(CFG_ANDROID_CROSS_PATH)/bin/aarch64-linux-android-g++
+CPP_aarch64-linux-android=$(CFG_ANDROID_CROSS_PATH)/bin/aarch64-linux-android-gcc -E
+AR_aarch64-linux-android=$(CFG_ANDROID_CROSS_PATH)/bin/aarch64-linux-android-ar
+CFG_LIB_NAME_aarch64-linux-android=lib$(1).so
+CFG_STATIC_LIB_NAME_aarch64-linux-android=lib$(1).a
+CFG_LIB_GLOB_aarch64-linux-android=lib$(1)-*.so
+CFG_LIB_DSYM_GLOB_aarch64-linux-android=lib$(1)-*.dylib.dSYM
+CFG_JEMALLOC_CFLAGS_aarch64-linux-android := -D__aarch64__ -DANDROID -D__ANDROID__ $(CFLAGS)
+CFG_GCCISH_CFLAGS_aarch64-linux-android := -Wall -g -fPIC -D__aarch64__ -DANDROID -D__ANDROID__ $(CFLAGS)
+CFG_GCCISH_CXXFLAGS_aarch64-linux-android := -fno-rtti $(CXXFLAGS)
+CFG_GCCISH_LINK_FLAGS_aarch64-linux-android := -shared -fPIC -ldl -g -lm -lsupc++
+CFG_GCCISH_DEF_FLAG_aarch64-linux-android := -Wl,--export-dynamic,--dynamic-list=
+CFG_GCCISH_PRE_LIB_FLAGS_aarch64-linux-android := -Wl,-whole-archive
+CFG_GCCISH_POST_LIB_FLAGS_aarch64-linux-android := -Wl,-no-whole-archive
+CFG_DEF_SUFFIX_aarch64-linux-android := .android.def
+CFG_LLC_FLAGS_aarch64-linux-android :=
+CFG_INSTALL_NAME_aarch64-linux-android =
+CFG_EXE_SUFFIX_aarch64-linux-android :=
+CFG_WINDOWSY_aarch64-linux-android :=
+CFG_UNIXY_aarch64-linux-android := 1
+CFG_PATH_MUNGE_aarch64-linux-android := true
+CFG_LDPATH_aarch64-linux-android :=
+CFG_RUN_aarch64-linux-android=
+CFG_RUN_TARG_aarch64-linux-android=
+RUSTC_FLAGS_aarch64-linux-android :=
+RUSTC_CROSS_FLAGS_aarch64-linux-android :=
+CFG_GNU_TRIPLE_aarch64-linux-android := aarch64-linux-android

--- a/mk/rt.mk
+++ b/mk/rt.mk
@@ -141,6 +141,8 @@ else ifeq ($(OSTYPE_$(1)), apple-ios)
   JEMALLOC_ARGS_$(1) := --disable-tls
 else ifeq ($(OSTYPE_$(1)), linux-androideabi)
   JEMALLOC_ARGS_$(1) := --disable-tls
+else ifeq ($(OSTYPE_$(1)), linux-android)
+  JEMALLOC_ARGS_$(1) := --disable-tls
 endif
 
 ################################################################################

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -4647,13 +4647,13 @@ pub mod funcs {
             use types::os::arch::c95::c_int;
             use types::os::common::posix01::sighandler_t;
 
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(all(target_os = "android", target_arch = "arm")))]
             extern {
                 pub fn signal(signum: c_int,
                               handler: sighandler_t) -> sighandler_t;
             }
 
-            #[cfg(target_os = "android")]
+            #[cfg(all(target_os = "android", target_arch = "arm"))]
             extern {
                 #[link_name = "bsd_signal"]
                 pub fn signal(signum: c_int,

--- a/src/librustc_back/target/aarch64_linux_android.rs
+++ b/src/librustc_back/target/aarch64_linux_android.rs
@@ -1,0 +1,28 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::Target;
+
+pub fn target() -> Target {
+    let mut base = super::linux_base::opts();
+    base.pre_link_args.push("-Wl,--allow-multiple-definition".to_string());
+    base.position_independent_executables = true;
+    Target {
+        data_layout: "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-\
+                      f32:32:32-f64:64:64-v64:64:64-v128:128:128-a:0:64-\
+                      n32:64-S128".to_string(),
+        llvm_target: "aarch64-linux-android".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        arch: "aarch64".to_string(),
+        target_os: "android".to_string(),
+        options: base,
+    }
+}

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -65,6 +65,7 @@ mod arm_linux_androideabi;
 mod arm_unknown_linux_gnueabi;
 mod arm_unknown_linux_gnueabihf;
 mod aarch64_apple_ios;
+mod aarch64_linux_android;
 mod aarch64_unknown_linux_gnu;
 mod i686_apple_darwin;
 mod i686_pc_windows_gnu;
@@ -357,6 +358,7 @@ impl Target {
             i386_apple_ios,
             x86_64_apple_ios,
             aarch64_apple_ios,
+            aarch64_linux_android,
             armv7_apple_ios,
             armv7s_apple_ios,
 

--- a/src/libstd/sys/unix/backtrace.rs
+++ b/src/libstd/sys/unix/backtrace.rs
@@ -418,7 +418,7 @@ mod uw {
                                  trace_argument: *mut libc::c_void)
                     -> _Unwind_Reason_Code;
 
-        #[cfg(all(not(target_os = "android"),
+        #[cfg(all(not(all(target_os = "android", target_arch = "arm")),
                   not(all(target_os = "linux", target_arch = "arm"))))]
         pub fn _Unwind_GetIP(ctx: *mut _Unwind_Context) -> libc::uintptr_t;
 
@@ -431,7 +431,7 @@ mod uw {
     // On android, the function _Unwind_GetIP is a macro, and this is the
     // expansion of the macro. This is all copy/pasted directly from the
     // header file with the definition of _Unwind_GetIP.
-    #[cfg(any(target_os = "android",
+    #[cfg(any(all(target_os = "android", target_arch = "arm"),
               all(target_os = "linux", target_arch = "arm")))]
     pub unsafe fn _Unwind_GetIP(ctx: *mut _Unwind_Context) -> libc::uintptr_t {
         #[repr(C)]


### PR DESCRIPTION
Initial support for aarch64-linux-android (#18920)
- Add new configuration files
- Modify some options to compile & link succesfully.
  (PIE, disable tls on jemalloc, modify some external function linkage, ..)
- To build, refer to https://github.com/rust-lang/rust/wiki/Doc-building-for-android.
  (tested with platform=21 and toolchain=aarch64-linux-android-4.9)
