### PR TITLE
Avoid suggesting traits multiple times.

### DIFF
--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -145,6 +145,7 @@ fn suggest_traits_to_import<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     if !valid_out_of_scope_traits.is_empty() {
         let mut candidates = valid_out_of_scope_traits;
         candidates.sort();
+        candidates.dedup();
         let msg = format!(
             "methods from traits can only be called if the trait is in scope; \
              the following {traits_are} implemented but not in scope, \
@@ -172,6 +173,7 @@ fn suggest_traits_to_import<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     if candidates.len() > 0 {
         // sort from most relevant to least relevant
         candidates.sort_by(|a, b| a.cmp(b).reverse());
+        candidates.dedup();
 
         let msg = format!(
             "methods from traits can only be called if the trait is implemented and in scope; \

--- a/src/test/compile-fail/method-suggestion-no-duplication.rs
+++ b/src/test/compile-fail/method-suggestion-no-duplication.rs
@@ -1,0 +1,22 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// issue #21405
+
+fn foo<F>(f: F) where F: FnMut(usize) {}
+
+fn main() {
+    foo(|s| s.is_empty());
+    //~^ ERROR does not implement any method
+    //~^^ HELP #1: `core::slice::SliceExt`
+    //~^^^ HELP #2: `core::str::StrExt`
+    //~^^^^ HELP #3: `collections::slice::SliceExt`
+    //~^^^^^ HELP #4: `collections::str::StrExt`
+}


### PR DESCRIPTION
This is clearly useless, the user doesn't need to know that they could
implement/import `foo::bar::Baz` 4 times.

Fixes #21405.
