### PR TITLE
Forbid coercing &T to &mut T

### DIFF
--- a/src/librustc/middle/infer/coercion.rs
+++ b/src/librustc/middle/infer/coercion.rs
@@ -213,7 +213,12 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
 
         let inner_ty = match a.sty {
             ty::ty_uniq(_) => return Err(ty::terr_mismatch),
-            ty::ty_rptr(_, mt_a) => mt_a.ty,
+            ty::ty_rptr(_, mt_a) => {
+                if !can_coerce_mutbls(mt_a.mutbl, mutbl_b) {
+                    return Err(ty::terr_mutability);
+                }
+                mt_a.ty
+            }
             _ => {
                 return self.subtype(a, b);
             }

--- a/src/test/compile-fail/coerce-mut.rs
+++ b/src/test/compile-fail/coerce-mut.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,14 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test mutability and slicing syntax.
+fn f(x: &mut i32) {}
 
 fn main() {
-    let x: &[isize] = &[1, 2, 3, 4, 5];
-    // Immutable slices are not mutable.
-    let y: &mut[_] = &x[2..4];
+    let x = 0;
+    f(&x);
     //~^ ERROR mismatched types
-    //~| expected `&mut [_]`
+    //~| expected `&mut i32`
     //~| found `&_`
     //~| values differ in mutability
 }

--- a/src/test/compile-fail/issue-12028.rs
+++ b/src/test/compile-fail/issue-12028.rs
@@ -43,7 +43,7 @@ impl<H: StreamHasher> Hash<H> for u8 {
 
 impl<H: StreamHasher> StreamHash<H> for u8 {
     fn input_stream(&self, stream: &mut H::S) {
-        Stream::input(&*stream, &[*self]);
+        Stream::input(stream, &[*self]);
     }
 }
 

--- a/src/test/compile-fail/method-self-arg-2.rs
+++ b/src/test/compile-fail/method-self-arg-2.rs
@@ -22,6 +22,7 @@ fn main() {
     let y = &mut x;
     Foo::bar(&x); //~ERROR cannot borrow `x`
 
-    let x = Foo;
-    Foo::baz(&x); //~ERROR cannot borrow immutable borrowed content as mutable
+    let mut x = Foo;
+    let y = &mut x;
+    Foo::baz(&mut x); //~ERROR cannot borrow `x`
 }


### PR DESCRIPTION
This is caught in borrowck now, but catching in typeck is faster and improves diagnostics.

cc #17561.

r? @nikomatsakis
