### PR TITLE
Replace `0 as *const/mut T` with `ptr::null/null_mut()`

### DIFF
--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -280,7 +280,7 @@ mod imp {
         if align <= MIN_ALIGN {
             libc::malloc(size as libc::size_t) as *mut u8
         } else {
-            let mut out = 0 as *mut libc::c_void;
+            let mut out = ptr::null();
             let ret = posix_memalign(&mut out,
                                      align as libc::size_t,
                                      size as libc::size_t);

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -179,6 +179,7 @@ use std::io::LineBufferedWriter;
 use std::io;
 use std::mem;
 use std::os;
+use std::ptr;
 use std::rt;
 use std::slice;
 use std::sync::{Once, ONCE_INIT};
@@ -436,11 +437,11 @@ fn init() {
             assert!(!DIRECTIVES.is_null());
             let _directives: Box<Vec<directive::LogDirective>> =
                 mem::transmute(DIRECTIVES);
-            DIRECTIVES = 0 as *const Vec<directive::LogDirective>;
+            DIRECTIVES = ptr::null();
 
             if !FILTER.is_null() {
                 let _filter: Box<Regex> = mem::transmute(FILTER);
-                FILTER = 0 as *const _;
+                FILTER = ptr::null();
             }
         });
     }

--- a/src/librustc_llvm/diagnostic.rs
+++ b/src/librustc_llvm/diagnostic.rs
@@ -14,6 +14,7 @@ pub use self::OptimizationDiagnosticKind::*;
 pub use self::Diagnostic::*;
 
 use libc::c_char;
+use std::ptr;
 
 use {ValueRef, TwineRef, DebugLocRef, DiagnosticInfoRef};
 
@@ -52,10 +53,10 @@ impl OptimizationDiagnostic {
 
         let mut opt = OptimizationDiagnostic {
             kind: kind,
-            pass_name: 0 as *const c_char,
-            function: 0 as ValueRef,
-            debug_loc: 0 as DebugLocRef,
-            message: 0 as TwineRef,
+            pass_name: ptr::null(),
+            function: ptr::null_mut(),
+            debug_loc: ptr::null_mut(),
+            message: ptr::null_mut(),
         };
 
         super::LLVMUnpackOptimizationDiagnostic(di,

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -51,7 +51,7 @@ pub use self::Linkage::*;
 
 use std::ffi::CString;
 use std::cell::RefCell;
-use std::{raw, mem};
+use std::{raw, mem, ptr};
 use libc::{c_uint, c_ushort, uint64_t, c_int, size_t, c_char};
 use libc::{c_longlong, c_ulonglong, c_void};
 use debuginfo::{DIBuilderRef, DIDescriptor,
@@ -2260,19 +2260,18 @@ pub unsafe fn static_link_hack_this_sucks() {
     LLVMInitializePowerPCAsmPrinter();
     LLVMInitializePowerPCAsmParser();
 
-    LLVMRustSetLLVMOptions(0 as c_int,
-                                       0 as *const _);
+    LLVMRustSetLLVMOptions(0 as c_int, ptr::null());
 
-    LLVMPassManagerBuilderPopulateModulePassManager(0 as *mut _, 0 as *mut _);
-    LLVMPassManagerBuilderPopulateLTOPassManager(0 as *mut _, 0 as *mut _, False, False);
-    LLVMPassManagerBuilderPopulateFunctionPassManager(0 as *mut _, 0 as *mut _);
-    LLVMPassManagerBuilderSetOptLevel(0 as *mut _, 0 as c_uint);
-    LLVMPassManagerBuilderUseInlinerWithThreshold(0 as *mut _, 0 as c_uint);
-    LLVMWriteBitcodeToFile(0 as *mut _, 0 as *const _);
+    LLVMPassManagerBuilderPopulateModulePassManager(ptr::null_mut(), ptr::null_mut());
+    LLVMPassManagerBuilderPopulateLTOPassManager(ptr::null_mut(), ptr::null_mut(), False, False);
+    LLVMPassManagerBuilderPopulateFunctionPassManager(ptr::null_mut(), ptr::null_mut());
+    LLVMPassManagerBuilderSetOptLevel(ptr::null_mut(), 0 as c_uint);
+    LLVMPassManagerBuilderUseInlinerWithThreshold(ptr::null_mut(), 0 as c_uint);
+    LLVMWriteBitcodeToFile(ptr::null_mut(), ptr::null());
     LLVMPassManagerBuilderCreate();
-    LLVMPassManagerBuilderDispose(0 as *mut _);
+    LLVMPassManagerBuilderDispose(ptr::null_mut());
 
-    LLVMRustLinkInExternalBitcode(0 as *mut _, 0 as *const _, 0 as size_t);
+    LLVMRustLinkInExternalBitcode(ptr::null_mut(), ptr::null(), 0 as size_t);
 
     LLVMLinkInMCJIT();
     LLVMLinkInInterpreter();

--- a/src/librustc_trans/trans/type_.rs
+++ b/src/librustc_trans/trans/type_.rs
@@ -21,6 +21,7 @@ use syntax::ast;
 
 use std::ffi::CString;
 use std::mem;
+use std::ptr;
 use std::cell::RefCell;
 use std::iter::repeat;
 
@@ -296,7 +297,7 @@ impl Type {
             if n_elts == 0 {
                 return Vec::new();
             }
-            let mut elts: Vec<_> = repeat(Type { rf: 0 as TypeRef }).take(n_elts).collect();
+            let mut elts: Vec<_> = repeat(Type { rf: ptr::null_mut() }).take(n_elts).collect();
             llvm::LLVMGetStructElementTypes(self.to_ref(),
                                             elts.as_mut_ptr() as *mut TypeRef);
             elts
@@ -310,7 +311,7 @@ impl Type {
     pub fn func_params(&self) -> Vec<Type> {
         unsafe {
             let n_args = llvm::LLVMCountParamTypes(self.to_ref()) as uint;
-            let mut args: Vec<_> = repeat(Type { rf: 0 as TypeRef }).take(n_args).collect();
+            let mut args: Vec<_> = repeat(Type { rf: ptr::null_mut() }).take(n_args).collect();
             llvm::LLVMGetParamTypes(self.to_ref(),
                                     args.as_mut_ptr() as *mut TypeRef);
             args

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -40,6 +40,7 @@ use mem;
 use option::Option;
 use option::Option::{Some, None};
 use ops::{Deref, DerefMut, FnOnce};
+use ptr;
 use result::Result::{Ok, Err};
 use rt;
 use slice::SliceExt;
@@ -238,7 +239,7 @@ pub fn stdin() -> StdinReader {
             // Make sure to free it at exit
             rt::at_exit(|| {
                 mem::transmute::<_, Box<StdinReader>>(STDIN);
-                STDIN = 0 as *const _;
+                STDIN = ptr::null();
             });
         });
 

--- a/src/libstd/sync/mpsc/mpsc_queue.rs
+++ b/src/libstd/sync/mpsc/mpsc_queue.rs
@@ -46,6 +46,7 @@ use core::prelude::*;
 
 use alloc::boxed::Box;
 use core::mem;
+use core::ptr;
 use core::cell::UnsafeCell;
 
 use sync::atomic::{AtomicPtr, Ordering};
@@ -82,7 +83,7 @@ unsafe impl<T:Send> Sync for Queue<T> { }
 impl<T> Node<T> {
     unsafe fn new(v: Option<T>) -> *mut Node<T> {
         mem::transmute(box Node {
-            next: AtomicPtr::new(0 as *mut Node<T>),
+            next: AtomicPtr::new(ptr::null_mut()),
             value: v,
         })
     }

--- a/src/libstd/sync/mpsc/select.rs
+++ b/src/libstd/sync/mpsc/select.rs
@@ -59,6 +59,7 @@ use core::prelude::*;
 use core::cell::Cell;
 use core::marker;
 use core::mem;
+use core::ptr;
 use core::uint;
 
 use sync::mpsc::{Receiver, RecvError};
@@ -130,8 +131,8 @@ impl Select {
     pub fn new() -> Select {
         Select {
             marker1: marker::NoSend,
-            head: 0 as *mut Handle<'static, ()>,
-            tail: 0 as *mut Handle<'static, ()>,
+            head: ptr::null_mut(),
+            tail: ptr::null_mut(),
             next_id: Cell::new(1),
         }
     }
@@ -144,8 +145,8 @@ impl Select {
     #[cfg(not(stage0))] // NOTE remove cfg after next snapshot
     pub fn new() -> Select {
         Select {
-            head: 0 as *mut Handle<'static, ()>,
-            tail: 0 as *mut Handle<'static, ()>,
+            head: ptr::null_mut(),
+            tail: ptr::null_mut(),
             next_id: Cell::new(1),
         }
     }
@@ -159,8 +160,8 @@ impl Select {
         Handle {
             id: id,
             selector: self,
-            next: 0 as *mut Handle<'static, ()>,
-            prev: 0 as *mut Handle<'static, ()>,
+            next: ptr::null_mut(),
+            prev: ptr::null_mut(),
             added: false,
             rx: rx,
             packet: rx,
@@ -325,8 +326,8 @@ impl<'rx, T: Send> Handle<'rx, T> {
             (*self.next).prev = self.prev;
         }
 
-        self.next = 0 as *mut Handle<'static, ()>;
-        self.prev = 0 as *mut Handle<'static, ()>;
+        self.next = ptr::null_mut();
+        self.prev = ptr::null_mut();
 
         self.added = false;
     }

--- a/src/libstd/sync/mpsc/spsc_queue.rs
+++ b/src/libstd/sync/mpsc/spsc_queue.rs
@@ -39,6 +39,7 @@ use core::prelude::*;
 
 use alloc::boxed::Box;
 use core::mem;
+use core::ptr;
 use core::cell::UnsafeCell;
 
 use sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
@@ -82,7 +83,7 @@ impl<T: Send> Node<T> {
         unsafe {
             mem::transmute(box Node {
                 value: None,
-                next: AtomicPtr::new(0 as *mut Node<T>),
+                next: AtomicPtr::new(ptr::null_mut::<Node<T>>()),
             })
         }
     }
@@ -131,7 +132,7 @@ impl<T: Send> Queue<T> {
             let n = self.alloc();
             assert!((*n).value.is_none());
             (*n).value = Some(t);
-            (*n).next.store(0 as *mut Node<T>, Ordering::Relaxed);
+            (*n).next.store(ptr::null_mut(), Ordering::Relaxed);
             (**self.head.get()).next.store(n, Ordering::Release);
             *self.head.get() = n;
         }

--- a/src/libstd/sys/common/helper_thread.rs
+++ b/src/libstd/sys/common/helper_thread.rs
@@ -24,6 +24,7 @@ use prelude::v1::*;
 
 use cell::UnsafeCell;
 use mem;
+use ptr;
 use rt;
 use sync::{StaticMutex, StaticCondvar};
 use sync::mpsc::{channel, Sender, Receiver};
@@ -132,7 +133,7 @@ impl<M: Send> Helper<M> {
 
             // Close the channel by destroying it
             let chan: Box<Sender<M>> = mem::transmute(*self.chan.get());
-            *self.chan.get() = 0 as *mut Sender<M>;
+            *self.chan.get() = ptr::null_mut();
             drop(chan);
             helper_signal::signal(*self.signal.get() as helper_signal::signal);
 

--- a/src/libstd/sys/unix/backtrace.rs
+++ b/src/libstd/sys/unix/backtrace.rs
@@ -353,7 +353,7 @@ fn print(w: &mut Writer, idx: int, addr: *mut libc::c_void) -> IoResult<()> {
     if state.is_null() {
         return output(w, idx, addr, None)
     }
-    let mut data = 0 as *const libc::c_char;
+    let mut data = ptr::null();
     let data_addr = &mut data as *mut *const libc::c_char;
     let ret = unsafe {
         backtrace_syminfo(state, addr as libc::uintptr_t,

--- a/src/libstd/sys/unix/condvar.rs
+++ b/src/libstd/sys/unix/condvar.rs
@@ -10,6 +10,7 @@
 
 use cell::UnsafeCell;
 use libc;
+use ptr;
 use std::option::Option::{Some, None};
 use sys::mutex::{self, Mutex};
 use sys::time;
@@ -62,7 +63,7 @@ impl Condvar {
         // time.
         let mut sys_now = libc::timeval { tv_sec: 0, tv_usec: 0 };
         let stable_now = time::SteadyTime::now();
-        let r = ffi::gettimeofday(&mut sys_now, 0 as *mut _);
+        let r = ffi::gettimeofday(&mut sys_now, ptr::null_mut());
         debug_assert_eq!(r, 0);
 
         let seconds = NumCast::from(dur.num_seconds());

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -19,6 +19,7 @@ use io::{Read, Truncate, SeekCur, SeekSet, ReadWrite, SeekEnd, Append};
 use io;
 use libc::{self, c_int, c_void};
 use mem;
+use ptr;
 use sys::retry;
 use sys_common::{keep_going, eof, mkerr_libc};
 
@@ -207,7 +208,7 @@ pub fn readdir(p: &Path) -> IoResult<Vec<Path>> {
 
     if dir_ptr as uint != 0 {
         let mut paths = vec!();
-        let mut entry_ptr = 0 as *mut dirent_t;
+        let mut entry_ptr = ptr::null_mut();
         while unsafe { readdir_r(dir_ptr, ptr, &mut entry_ptr) == 0 } {
             if entry_ptr.is_null() { break }
             paths.push(unsafe {

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -143,7 +143,7 @@ pub unsafe fn get_env_pairs() -> Vec<Vec<u8>> {
                os::last_os_error());
     }
     let mut result = Vec::new();
-    while *environ != 0 as *const _ {
+    while *environ != ptr::null() {
         let env_pair = ffi::c_str_to_bytes(&*environ).to_vec();
         result.push(env_pair);
         environ = environ.offset(1);

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -251,7 +251,7 @@ impl Process {
                             fn setgroups(ngroups: libc::c_int,
                                          ptr: *const libc::c_void) -> libc::c_int;
                         }
-                        let _ = setgroups(0, 0 as *const libc::c_void);
+                        let _ = setgroups(0, ptr::null());
 
                         if libc::setuid(u as libc::uid_t) != 0 {
                             fail(&mut output);

--- a/src/libstd/sys/windows/backtrace.rs
+++ b/src/libstd/sys/windows/backtrace.rs
@@ -327,7 +327,7 @@ pub fn write(w: &mut Writer) -> IoResult<()> {
     let image = arch::init_frame(&mut frame, &context);
 
     // Initialize this process's symbols
-    let ret = SymInitialize(process, 0 as *mut libc::c_void, libc::TRUE);
+    let ret = SymInitialize(process, ptr::null_mut(), libc::TRUE);
     if ret != libc::TRUE { return Ok(()) }
     let _c = Cleanup { handle: process, SymCleanup: SymCleanup };
 
@@ -335,10 +335,10 @@ pub fn write(w: &mut Writer) -> IoResult<()> {
     let mut i = 0i;
     try!(write!(w, "stack backtrace:\n"));
     while StackWalk64(image, process, thread, &mut frame, &mut context,
-                      0 as *mut libc::c_void,
-                      0 as *mut libc::c_void,
-                      0 as *mut libc::c_void,
-                      0 as *mut libc::c_void) == libc::TRUE{
+                      ptr::null_mut(),
+                      ptr::null_mut(),
+                      ptr::null_mut(),
+                      ptr::null_mut()) == libc::TRUE{
         let addr = frame.AddrPC.Offset;
         if addr == frame.AddrReturn.Offset || addr == 0 ||
            frame.AddrReturn.Offset == 0 { break }

--- a/src/libstd/sys/windows/thread_local.rs
+++ b/src/libstd/sys/windows/thread_local.rs
@@ -137,7 +137,7 @@ unsafe fn init_dtors() {
     rt::at_exit(move|| {
         DTOR_LOCK.lock();
         let dtors = DTORS;
-        DTORS = 0 as *mut _;
+        DTORS = ptr::null_mut();
         mem::transmute::<_, Box<Vec<(Key, Dtor)>>>(dtors);
         assert!(DTORS.is_null()); // can't re-init after destructing
         DTOR_LOCK.unlock();
@@ -250,7 +250,7 @@ unsafe fn run_dtors() {
         for &(key, dtor) in dtors.iter() {
             let ptr = TlsGetValue(key);
             if !ptr.is_null() {
-                TlsSetValue(key, 0 as *mut _);
+                TlsSetValue(key, ptr::null_mut());
                 dtor(ptr as *mut _);
                 any_run = true;
             }

--- a/src/libstd/thread_local/mod.rs
+++ b/src/libstd/thread_local/mod.rs
@@ -425,7 +425,7 @@ mod imp {
                     dtor(ptr);
                 }
                 ptr = DTORS.get();
-                DTORS.set(0 as *mut _);
+                DTORS.set(ptr::null_mut());
             }
         }
     }
@@ -522,7 +522,7 @@ mod imp {
         let key = ptr.key;
         key.os.set(1 as *mut u8);
         drop(ptr);
-        key.os.set(0 as *mut u8);
+        key.os.set(ptr::null_mut());
     }
 }
 


### PR DESCRIPTION
Motivation:
- `ptr::null/null_mut()` are used more often in the codebase, they are more idiomatic
- `0 as *const/mut T` isn't really a conversion and skews [the conversion statistics](http://discuss.rust-lang.org/t/the-operator-as-statistics-of-usage/1353)
- some people on #rust-internals were in favor of the changes

Drawbacks:
- More `use` declarations (but no new inter-crate dependencies)
