### PR TITLE
Implement ExactSizeIterator for remaining core Iterators where applicable

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1088,10 +1088,7 @@ impl<'a, I> DoubleEndedIterator for ByRef<'a, I> where I: 'a + DoubleEndedIterat
 }
 
 #[stable]
-impl<'a, I> ExactSizeIterator for ByRef<'a, I> where I: 'a + ExactSizeIterator {
-    #[inline]
-    fn len(&self) -> uint { self.iter.len() }
-}
+impl<'a, I> ExactSizeIterator for ByRef<'a, I> where I: 'a + ExactSizeIterator {}
 
 /// A trait for iterators over elements which can be added together
 #[unstable = "needs to be re-evaluated as part of numerics reform"]
@@ -1797,14 +1794,7 @@ impl<T, I> Iterator for Peekable<T, I> where I: Iterator<Item=T> {
 }
 
 #[stable]
-impl<T, I> ExactSizeIterator for Peekable<T, I> where I: ExactSizeIterator<Item = T> {
-    #[inline]
-    fn len(&self) -> usize {
-        // This is guarenteed to not overflow because `len()` must have been able to return a valid
-        // value before we peeked.
-        self.iter.len() + if self.peeked.is_some() { 1 } else { 0 }
-    }
-}
+impl<T, I> ExactSizeIterator for Peekable<T, I> where I: ExactSizeIterator<Item = T> {}
 
 #[stable]
 impl<T, I> Peekable<T, I> where I: Iterator<Item=T> {
@@ -1999,10 +1989,7 @@ impl<I> RandomAccessIterator for Skip<I> where I: RandomAccessIterator{
 }
 
 #[stable]
-impl<I> ExactSizeIterator for Skip<I> where I: ExactSizeIterator {
-    #[inline]
-    fn len(&self) -> uint { self.iter.len().saturating_sub(self.n) }
-}
+impl<I> ExactSizeIterator for Skip<I> where I: ExactSizeIterator {}
 
 /// An iterator that only iterates over the first `n` iterations of `iter`.
 #[derive(Clone)]
@@ -2060,10 +2047,7 @@ impl<I> RandomAccessIterator for Take<I> where I: RandomAccessIterator{
 }
 
 #[stable]
-impl<I> ExactSizeIterator for Take<I> where I: ExactSizeIterator {
-    #[inline]
-    fn len(&self) -> uint { cmp::min(self.iter.len(), self.n) }
-}
+impl<I> ExactSizeIterator for Take<I> where I: ExactSizeIterator {}
 
 
 /// An iterator to maintain state while iterating another iterator
@@ -2275,10 +2259,7 @@ impl<I> RandomAccessIterator for Fuse<I> where I: RandomAccessIterator {
 }
 
 #[stable]
-impl<I> ExactSizeIterator for Fuse<I> where I: ExactSizeIterator {
-    #[inline]
-    fn len(&self) -> uint { self.iter.len() }
-}
+impl<I> ExactSizeIterator for Fuse<I> where I: ExactSizeIterator {}
 
 impl<I> Fuse<I> {
     /// Resets the fuse such that the next call to .next() or .next_back() will

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1087,6 +1087,12 @@ impl<'a, I> DoubleEndedIterator for ByRef<'a, I> where I: 'a + DoubleEndedIterat
     fn next_back(&mut self) -> Option<<I as Iterator>::Item> { self.iter.next_back() }
 }
 
+#[stable]
+impl<'a, I> ExactSizeIterator for ByRef<'a, I> where I: 'a + ExactSizeIterator {
+    #[inline]
+    fn len(&self) -> uint { self.iter.len() }
+}
+
 /// A trait for iterators over elements which can be added together
 #[unstable = "needs to be re-evaluated as part of numerics reform"]
 pub trait AdditiveIterator<A> {
@@ -1791,6 +1797,16 @@ impl<T, I> Iterator for Peekable<T, I> where I: Iterator<Item=T> {
 }
 
 #[stable]
+impl<T, I> ExactSizeIterator for Peekable<T, I> where I: ExactSizeIterator<Item = T> {
+    #[inline]
+    fn len(&self) -> usize {
+        // This is guarenteed to not overflow because `len()` must have been able to return a valid
+        // value before we peeked.
+        self.iter.len() + if self.peeked.is_some() { 1 } else { 0 }
+    }
+}
+
+#[stable]
 impl<T, I> Peekable<T, I> where I: Iterator<Item=T> {
     /// Return a reference to the next element of the iterator with out advancing it,
     /// or None if the iterator is exhausted.
@@ -1982,6 +1998,12 @@ impl<I> RandomAccessIterator for Skip<I> where I: RandomAccessIterator{
     }
 }
 
+#[stable]
+impl<I> ExactSizeIterator for Skip<I> where I: ExactSizeIterator {
+    #[inline]
+    fn len(&self) -> uint { self.iter.len().saturating_sub(self.n) }
+}
+
 /// An iterator that only iterates over the first `n` iterations of `iter`.
 #[derive(Clone)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
@@ -2035,6 +2057,12 @@ impl<I> RandomAccessIterator for Take<I> where I: RandomAccessIterator{
             self.iter.idx(index)
         }
     }
+}
+
+#[stable]
+impl<I> ExactSizeIterator for Take<I> where I: ExactSizeIterator {
+    #[inline]
+    fn len(&self) -> uint { cmp::min(self.iter.len(), self.n) }
 }
 
 
@@ -2244,6 +2272,12 @@ impl<I> RandomAccessIterator for Fuse<I> where I: RandomAccessIterator {
     fn idx(&mut self, index: uint) -> Option<<I as Iterator>::Item> {
         self.iter.idx(index)
     }
+}
+
+#[stable]
+impl<I> ExactSizeIterator for Fuse<I> where I: ExactSizeIterator {
+    #[inline]
+    fn len(&self) -> uint { self.iter.len() }
 }
 
 impl<I> Fuse<I> {

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -120,18 +120,32 @@ fn test_iterator_enumerate() {
 fn test_iterator_peekable() {
     let xs = vec![0u, 1, 2, 3, 4, 5];
     let mut it = xs.iter().map(|&x|x).peekable();
+
+    assert_eq!(it.len(), 6);
     assert_eq!(it.peek().unwrap(), &0);
+    assert_eq!(it.len(), 6);
     assert_eq!(it.next().unwrap(), 0);
+    assert_eq!(it.len(), 5);
     assert_eq!(it.next().unwrap(), 1);
+    assert_eq!(it.len(), 4);
     assert_eq!(it.next().unwrap(), 2);
+    assert_eq!(it.len(), 3);
     assert_eq!(it.peek().unwrap(), &3);
+    assert_eq!(it.len(), 3);
     assert_eq!(it.peek().unwrap(), &3);
+    assert_eq!(it.len(), 3);
     assert_eq!(it.next().unwrap(), 3);
+    assert_eq!(it.len(), 2);
     assert_eq!(it.next().unwrap(), 4);
+    assert_eq!(it.len(), 1);
     assert_eq!(it.peek().unwrap(), &5);
+    assert_eq!(it.len(), 1);
     assert_eq!(it.next().unwrap(), 5);
+    assert_eq!(it.len(), 0);
     assert!(it.peek().is_none());
+    assert_eq!(it.len(), 0);
     assert!(it.next().is_none());
+    assert_eq!(it.len(), 0);
 }
 
 #[test]
@@ -166,24 +180,45 @@ fn test_iterator_skip() {
     let ys = [13, 15, 16, 17, 19, 20, 30];
     let mut it = xs.iter().skip(5);
     let mut i = 0;
-    for &x in it {
+    while let Some(&x) = it.next() {
         assert_eq!(x, ys[i]);
         i += 1;
+        assert_eq!(it.len(), xs.len()-5-i);
     }
     assert_eq!(i, ys.len());
+    assert_eq!(it.len(), 0);
 }
 
 #[test]
 fn test_iterator_take() {
-    let xs = [0u, 1, 2, 3, 5, 13, 15, 16, 17, 19];
-    let ys = [0u, 1, 2, 3, 5];
+    let xs = [0us, 1, 2, 3, 5, 13, 15, 16, 17, 19];
+    let ys = [0us, 1, 2, 3, 5];
     let mut it = xs.iter().take(5);
     let mut i = 0;
-    for &x in it {
+    assert_eq!(it.len(), 5);
+    while let Some(&x) = it.next() {
         assert_eq!(x, ys[i]);
         i += 1;
+        assert_eq!(it.len(), 5-i);
     }
     assert_eq!(i, ys.len());
+    assert_eq!(it.len(), 0);
+}
+
+#[test]
+fn test_iterator_take_short() {
+    let xs = [0us, 1, 2, 3];
+    let ys = [0us, 1, 2, 3];
+    let mut it = xs.iter().take(5);
+    let mut i = 0;
+    assert_eq!(it.len(), 4);
+    while let Some(&x) = it.next() {
+        assert_eq!(x, ys[i]);
+        i += 1;
+        assert_eq!(it.len(), 4-i);
+    }
+    assert_eq!(i, ys.len());
+    assert_eq!(it.len(), 0);
 }
 
 #[test]
@@ -826,6 +861,24 @@ fn test_repeat() {
     assert_eq!(it.next(), Some(42u));
     assert_eq!(it.next(), Some(42u));
     assert_eq!(it.next(), Some(42u));
+}
+
+#[test]
+fn test_fuse() {
+    let mut it = 0us..3;
+    assert_eq!(it.len(), 3);
+    assert_eq!(it.next(), Some(0us));
+    assert_eq!(it.len(), 2);
+    assert_eq!(it.next(), Some(1us));
+    assert_eq!(it.len(), 1);
+    assert_eq!(it.next(), Some(2us));
+    assert_eq!(it.len(), 0);
+    assert_eq!(it.next(), None);
+    assert_eq!(it.len(), 0);
+    assert_eq!(it.next(), None);
+    assert_eq!(it.len(), 0);
+    assert_eq!(it.next(), None);
+    assert_eq!(it.len(), 0);
 }
 
 #[bench]


### PR DESCRIPTION
Specifically:
- Peekable
- ByRef
- Skip
- Take
- Fuse

Fixes  #20547
