### PR TITLE
std: Rename Show/String to Debug/Display

### DIFF
--- a/src/compiletest/common.rs
+++ b/src/compiletest/common.rs
@@ -13,7 +13,7 @@ use std::fmt;
 use std::str::FromStr;
 use regex::Regex;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum Mode {
     CompileFail,
     RunFail,
@@ -43,9 +43,9 @@ impl FromStr for Mode {
     }
 }
 
-impl fmt::String for Mode {
+impl fmt::Display for Mode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(match *self {
+        fmt::Display::fmt(match *self {
             CompileFail => "compile-fail",
             RunFail => "run-fail",
             RunPass => "run-pass",
@@ -55,12 +55,6 @@ impl fmt::String for Mode {
             DebugInfoLldb => "debuginfo-lldb",
             Codegen => "codegen",
         }, f)
-    }
-}
-
-impl fmt::Show for Mode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
     }
 }
 

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -547,7 +547,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
 
             // Add line breakpoints
             for line in breakpoint_lines.iter() {
-                script_str.push_str(&format!("break '{:?}':{}\n",
+                script_str.push_str(&format!("break '{}':{}\n",
                                              testfile.filename_display(),
                                              *line)[]);
             }
@@ -750,7 +750,7 @@ fn run_debuginfo_lldb_test(config: &Config, props: &TestProps, testfile: &Path) 
             status: status,
             stdout: out,
             stderr: err,
-            cmdline: format!("{}", cmd)
+            cmdline: format!("{:?}", cmd)
         };
     }
 }
@@ -953,7 +953,7 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
     }
 
     let prefixes = expected_errors.iter().map(|ee| {
-        format!("{:?}:{}:", testfile.display(), ee.line)
+        format!("{}:{}:", testfile.display(), ee.line)
     }).collect::<Vec<String> >();
 
     #[cfg(windows)]

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -72,7 +72,7 @@ use core::prelude::*;
 use core::atomic;
 use core::atomic::Ordering::{Relaxed, Release, Acquire, SeqCst};
 use core::borrow::BorrowFrom;
-use core::fmt::{self, Show};
+use core::fmt;
 use core::cmp::{Ordering};
 use core::default::Default;
 use core::mem::{min_align_of, size_of};
@@ -578,16 +578,17 @@ impl<T: Ord> Ord for Arc<T> {
 #[stable]
 impl<T: Eq> Eq for Arc<T> {}
 
-impl<T: fmt::Show> fmt::Show for Arc<T> {
+#[stable]
+impl<T: fmt::Display> fmt::Display for Arc<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Arc({:?})", (**self))
+        fmt::Display::fmt(&**self, f)
     }
 }
 
 #[stable]
-impl<T: fmt::String> fmt::String for Arc<T> {
+impl<T: fmt::Debug> fmt::Debug for Arc<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(&**self, f)
+        fmt::Debug::fmt(&**self, f)
     }
 }
 
@@ -806,7 +807,7 @@ mod tests {
     #[test]
     fn show_arc() {
         let a = Arc::new(5u32);
-        assert!(format!("{:?}", a) == "Arc(5u32)")
+        assert_eq!(format!("{:?}", a), "5");
     }
 
     // Make sure deriving works with Arc<T>

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -16,16 +16,17 @@ use core::any::Any;
 use core::clone::Clone;
 use core::cmp::{PartialEq, PartialOrd, Eq, Ord, Ordering};
 use core::default::Default;
+use core::error::{Error, FromError};
 use core::fmt;
 use core::hash::{self, Hash};
 use core::marker::Sized;
 use core::mem;
+use core::ops::{Deref, DerefMut};
 use core::option::Option;
 use core::ptr::Unique;
 use core::raw::TraitObject;
-use core::result::Result;
 use core::result::Result::{Ok, Err};
-use core::ops::{Deref, DerefMut};
+use core::result::Result;
 
 /// A value that represents the global exchange heap. This is the default
 /// place that the `box` keyword allocates into when no place is supplied.
@@ -156,20 +157,22 @@ impl BoxAny for Box<Any> {
     }
 }
 
-impl<T: ?Sized + fmt::Show> fmt::Show for Box<T> {
+#[stable]
+impl<T: fmt::Display + ?Sized> fmt::Display for Box<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Box({:?})", &**self)
+        fmt::Display::fmt(&**self, f)
     }
 }
 
 #[stable]
-impl<T: ?Sized + fmt::String> fmt::String for Box<T> {
+impl<T: fmt::Debug + ?Sized> fmt::Debug for Box<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(&**self, f)
+        fmt::Debug::fmt(&**self, f)
     }
 }
 
-impl fmt::Show for Box<Any> {
+#[stable]
+impl fmt::Debug for Box<Any> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad("Box<Any>")
     }
@@ -185,6 +188,12 @@ impl<T: ?Sized> Deref for Box<T> {
 #[stable]
 impl<T: ?Sized> DerefMut for Box<T> {
     fn deref_mut(&mut self) -> &mut T { &mut **self }
+}
+
+impl<'a, E: Error + 'a> FromError<E> for Box<Error + 'a> {
+    fn from_error(err: E) -> Box<Error + 'a> {
+        Box::new(err)
+    }
 }
 
 #[cfg(test)]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -693,17 +693,17 @@ impl<S: hash::Hasher, T: Hash<S>> Hash<S> for Rc<T> {
     }
 }
 
-#[unstable = "Show is experimental."]
-impl<T: fmt::Show> fmt::Show for Rc<T> {
+#[stable]
+impl<T: fmt::Display> fmt::Display for Rc<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Rc({:?})", **self)
+        fmt::Display::fmt(&**self, f)
     }
 }
 
 #[stable]
-impl<T: fmt::String> fmt::String for Rc<T> {
+impl<T: fmt::Debug> fmt::Debug for Rc<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(&**self, f)
+        fmt::Debug::fmt(&**self, f)
     }
 }
 
@@ -890,8 +890,8 @@ impl<T> Clone for Weak<T> {
     }
 }
 
-#[unstable = "Show is experimental."]
-impl<T: fmt::Show> fmt::Show for Weak<T> {
+#[stable]
+impl<T: fmt::Debug> fmt::Debug for Weak<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "(Weak)")
     }
@@ -1134,7 +1134,7 @@ mod tests {
     #[test]
     fn test_show() {
         let foo = Rc::new(75u);
-        assert!(format!("{:?}", foo) == "Rc(75u)")
+        assert_eq!(format!("{:?}", foo), "75");
     }
 
 }

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -972,7 +972,7 @@ impl Ord for Bitv {
 }
 
 #[stable]
-impl fmt::Show for Bitv {
+impl fmt::Debug for Bitv {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         for bit in self.iter() {
             try!(write!(fmt, "{}", if bit { 1u32 } else { 0u32 }));
@@ -1727,7 +1727,7 @@ impl BitvSet {
     }
 }
 
-impl fmt::Show for BitvSet {
+impl fmt::Debug for BitvSet {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(fmt, "BitvSet {{"));
         let mut first = true;
@@ -2622,7 +2622,7 @@ mod bitv_set_test {
         s.insert(10);
         s.insert(50);
         s.insert(2);
-        assert_eq!("BitvSet {1u, 2u, 10u, 50u}", format!("{:?}", s));
+        assert_eq!("BitvSet {1, 2, 10, 50}", format!("{:?}", s));
     }
 
     #[test]

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -22,7 +22,7 @@ use core::prelude::*;
 use core::borrow::BorrowFrom;
 use core::cmp::Ordering;
 use core::default::Default;
-use core::fmt::Show;
+use core::fmt::Debug;
 use core::hash::{Hash, Hasher};
 use core::iter::{Map, FromIterator};
 use core::ops::{Index, IndexMut};
@@ -871,7 +871,7 @@ impl<K: Ord, V: Ord> Ord for BTreeMap<K, V> {
 }
 
 #[stable]
-impl<K: Show, V: Show> Show for BTreeMap<K, V> {
+impl<K: Debug, V: Debug> Debug for BTreeMap<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "BTreeMap {{"));
 

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -16,7 +16,7 @@ use core::prelude::*;
 use core::borrow::BorrowFrom;
 use core::cmp::Ordering::{self, Less, Greater, Equal};
 use core::default::Default;
-use core::fmt::Show;
+use core::fmt::Debug;
 use core::fmt;
 // NOTE(stage0) remove import after a snapshot
 #[cfg(stage0)]
@@ -592,7 +592,7 @@ impl<'a, 'b, T: Ord + Clone> BitOr<&'b BTreeSet<T>> for &'a BTreeSet<T> {
 }
 
 #[stable]
-impl<T: Show> Show for BTreeSet<T> {
+impl<T: Debug> Debug for BTreeSet<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "BTreeSet {{"));
 
@@ -892,7 +892,7 @@ mod test {
 
         let set_str = format!("{:?}", set);
 
-        assert_eq!(set_str, "BTreeSet {1i, 2i}");
+        assert_eq!(set_str, "BTreeSet {1, 2}");
         assert_eq!(format!("{:?}", empty), "BTreeSet {}");
     }
 }

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -874,7 +874,7 @@ impl<A: Clone> Clone for DList<A> {
 }
 
 #[stable]
-impl<A: fmt::Show> fmt::Show for DList<A> {
+impl<A: fmt::Debug> fmt::Debug for DList<A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "DList ["));
 
@@ -1333,7 +1333,7 @@ mod tests {
     #[test]
     fn test_show() {
         let list: DList<int> = range(0i, 10).collect();
-        assert_eq!(format!("{:?}", list), "DList [0i, 1i, 2i, 3i, 4i, 5i, 6i, 7i, 8i, 9i]");
+        assert_eq!(format!("{:?}", list), "DList [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]");
 
         let list: DList<&str> = vec!["just", "one", "test", "more"].iter()
                                                                    .map(|&s| s)

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -31,7 +31,7 @@ pub struct EnumSet<E> {
 
 impl<E> Copy for EnumSet<E> {}
 
-impl<E:CLike+fmt::Show> fmt::Show for EnumSet<E> {
+impl<E:CLike + fmt::Debug> fmt::Debug for EnumSet<E> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(fmt, "EnumSet {{"));
         let mut first = true;

--- a/src/libcollections/ring_buf.rs
+++ b/src/libcollections/ring_buf.rs
@@ -1611,7 +1611,7 @@ impl<A> Extend<A> for RingBuf<A> {
 }
 
 #[stable]
-impl<T: fmt::Show> fmt::Show for RingBuf<T> {
+impl<T: fmt::Debug> fmt::Debug for RingBuf<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "RingBuf ["));
 
@@ -1630,7 +1630,7 @@ mod tests {
     use self::Taggypar::*;
     use prelude::*;
     use core::iter;
-    use std::fmt::Show;
+    use std::fmt::Debug;
     use std::hash::{self, SipHasher};
     use test::Bencher;
     use test;
@@ -1678,7 +1678,7 @@ mod tests {
     }
 
     #[cfg(test)]
-    fn test_parameterized<T:Clone + PartialEq + Show>(a: T, b: T, c: T, d: T) {
+    fn test_parameterized<T:Clone + PartialEq + Debug>(a: T, b: T, c: T, d: T) {
         let mut deq = RingBuf::new();
         assert_eq!(deq.len(), 0);
         deq.push_front(a.clone());
@@ -2302,7 +2302,7 @@ mod tests {
     #[test]
     fn test_show() {
         let ringbuf: RingBuf<int> = range(0i, 10).collect();
-        assert_eq!(format!("{:?}", ringbuf), "RingBuf [0i, 1i, 2i, 3i, 4i, 5i, 6i, 7i, 8i, 9i]");
+        assert_eq!(format!("{:?}", ringbuf), "RingBuf [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]");
 
         let ringbuf: RingBuf<&str> = vec!["just", "one", "test", "more"].iter()
                                                                         .map(|&s| s)

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -2476,19 +2476,19 @@ mod tests {
         }
         let empty: Vec<int> = vec![];
         test_show_vec!(empty, "[]");
-        test_show_vec!(vec![1i], "[1i]");
-        test_show_vec!(vec![1i, 2, 3], "[1i, 2i, 3i]");
+        test_show_vec!(vec![1i], "[1]");
+        test_show_vec!(vec![1i, 2, 3], "[1, 2, 3]");
         test_show_vec!(vec![vec![], vec![1u], vec![1u, 1u]],
-                       "[[], [1u], [1u, 1u]]");
+                       "[[], [1], [1, 1]]");
 
         let empty_mut: &mut [int] = &mut[];
         test_show_vec!(empty_mut, "[]");
         let v: &mut[int] = &mut[1];
-        test_show_vec!(v, "[1i]");
+        test_show_vec!(v, "[1]");
         let v: &mut[int] = &mut[1, 2, 3];
-        test_show_vec!(v, "[1i, 2i, 3i]");
+        test_show_vec!(v, "[1, 2, 3]");
         let v: &mut [&mut[uint]] = &mut[&mut[], &mut[1u], &mut[1u, 1u]];
-        test_show_vec!(v, "[[], [1u], [1u, 1u]]");
+        test_show_vec!(v, "[[], [1], [1, 1]]");
     }
 
     #[test]

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -18,6 +18,7 @@ use core::prelude::*;
 
 use core::borrow::{Cow, IntoCow};
 use core::default::Default;
+use core::error::Error;
 use core::fmt;
 use core::hash;
 use core::iter::FromIterator;
@@ -40,6 +41,7 @@ pub struct String {
 
 /// A possible error value from the `String::from_utf8` function.
 #[stable]
+#[derive(Show)]
 pub struct FromUtf8Error {
     bytes: Vec<u8>,
     error: Utf8Error,
@@ -48,6 +50,7 @@ pub struct FromUtf8Error {
 /// A possible error value from the `String::from_utf16` function.
 #[stable]
 #[allow(missing_copy_implementations)]
+#[derive(Show)]
 pub struct FromUtf16Error(());
 
 impl String {
@@ -680,30 +683,28 @@ impl FromUtf8Error {
     pub fn utf8_error(&self) -> Utf8Error { self.error }
 }
 
-impl fmt::Show for FromUtf8Error {
+#[stable]
+impl fmt::Display for FromUtf8Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
+        fmt::Display::fmt(&self.error, f)
     }
 }
 
 #[stable]
-impl fmt::String for FromUtf8Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(&self.error, f)
-    }
+impl Error for FromUtf8Error {
+    fn description(&self) -> &str { "invalid utf-8" }
 }
 
-impl fmt::Show for FromUtf16Error {
+#[stable]
+impl fmt::Display for FromUtf16Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
+        fmt::Display::fmt("invalid utf-16: lone surrogate found", f)
     }
 }
 
 #[stable]
-impl fmt::String for FromUtf16Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt("invalid utf-16: lone surrogate found", f)
-    }
+impl Error for FromUtf16Error {
+    fn description(&self) -> &str { "invalid utf-16" }
 }
 
 #[stable]
@@ -814,18 +815,18 @@ impl Default for String {
 }
 
 #[stable]
-impl fmt::String for String {
+impl fmt::Display for String {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(&**self, f)
+        fmt::Display::fmt(&**self, f)
     }
 }
 
-#[unstable = "waiting on fmt stabilization"]
-impl fmt::Show for String {
+#[stable]
+impl fmt::Debug for String {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Show::fmt(&**self, f)
+        fmt::Debug::fmt(&**self, f)
     }
 }
 
@@ -934,7 +935,7 @@ pub trait ToString {
     fn to_string(&self) -> String;
 }
 
-impl<T: fmt::String + ?Sized> ToString for T {
+impl<T: fmt::Display + ?Sized> ToString for T {
     #[inline]
     fn to_string(&self) -> String {
         use core::fmt::Writer;
@@ -1295,10 +1296,10 @@ mod tests {
     fn test_vectors() {
         let x: Vec<int> = vec![];
         assert_eq!(format!("{:?}", x), "[]");
-        assert_eq!(format!("{:?}", vec![1i]), "[1i]");
-        assert_eq!(format!("{:?}", vec![1i, 2, 3]), "[1i, 2i, 3i]");
+        assert_eq!(format!("{:?}", vec![1i]), "[1]");
+        assert_eq!(format!("{:?}", vec![1i, 2, 3]), "[1, 2, 3]");
         assert!(format!("{:?}", vec![vec![], vec![1i], vec![1i, 1]]) ==
-               "[[], [1i], [1i, 1i]]");
+               "[[], [1], [1, 1]]");
     }
 
     #[test]

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1486,10 +1486,10 @@ impl<T> Default for Vec<T> {
     }
 }
 
-#[unstable = "waiting on Show stability"]
-impl<T: fmt::Show> fmt::Show for Vec<T> {
+#[stable]
+impl<T: fmt::Debug> fmt::Debug for Vec<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Show::fmt(self.as_slice(), f)
+        fmt::Debug::fmt(self.as_slice(), f)
     }
 }
 

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -513,7 +513,7 @@ impl<V: Ord> Ord for VecMap<V> {
 }
 
 #[stable]
-impl<V: fmt::Show> fmt::Show for VecMap<V> {
+impl<V: fmt::Debug> fmt::Debug for VecMap<V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "VecMap {{"));
 
@@ -990,7 +990,7 @@ mod test_map {
         map.insert(3, 4i);
 
         let map_str = format!("{:?}", map);
-        assert!(map_str == "VecMap {1: 2i, 3: 4i}" || map_str == "{3: 4i, 1: 2i}");
+        assert!(map_str == "VecMap {1: 2, 3: 4}" || map_str == "{3: 4, 1: 2}");
         assert_eq!(format!("{:?}", empty), "VecMap {}");
     }
 

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -34,11 +34,11 @@
 //! use runtime reflection instead.
 //!
 //! ```rust
-//! use std::fmt::Show;
+//! use std::fmt::Debug;
 //! use std::any::Any;
 //!
-//! // Logger function for any type that implements Show.
-//! fn log<T: Any+Show>(value: &T) {
+//! // Logger function for any type that implements Debug.
+//! fn log<T: Any + Debug>(value: &T) {
 //!     let value_any = value as &Any;
 //!
 //!     // try to convert our value to a String.  If successful, we want to
@@ -55,7 +55,7 @@
 //! }
 //!
 //! // This function wants to log its parameter out prior to doing work with it.
-//! fn do_work<T: Show+'static>(value: &T) {
+//! fn do_work<T: Debug + 'static>(value: &T) {
 //!     log(value);
 //!     // ...do some other work
 //! }

--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -39,10 +39,10 @@ macro_rules! array_impls {
                 }
             }
 
-            #[unstable = "waiting for Show to stabilize"]
-            impl<T:fmt::Show> fmt::Show for [T; $N] {
+            #[stable]
+            impl<T: fmt::Debug> fmt::Debug for [T; $N] {
                 fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                    fmt::Show::fmt(&&self[], f)
+                    fmt::Debug::fmt(&&self[], f)
                 }
             }
 

--- a/src/libcore/borrow.rs
+++ b/src/libcore/borrow.rs
@@ -133,7 +133,6 @@ impl<T> ToOwned<T> for T where T: Clone {
 ///     }
 /// }
 /// ```
-#[derive(Show)]
 pub enum Cow<'a, T, B: ?Sized + 'a> where B: ToOwned<T> {
     /// Borrowed data.
     Borrowed(&'a B),
@@ -239,14 +238,27 @@ impl<'a, T, B: ?Sized> PartialOrd for Cow<'a, T, B> where B: PartialOrd + ToOwne
 }
 
 #[stable]
-impl<'a, T, B: ?Sized> fmt::String for Cow<'a, T, B> where
-    B: fmt::String + ToOwned<T>,
-    T: fmt::String,
+impl<'a, T, B: ?Sized> fmt::Debug for Cow<'a, T, B> where
+    B: fmt::Debug + ToOwned<T>,
+    T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Borrowed(ref b) => fmt::String::fmt(b, f),
-            Owned(ref o) => fmt::String::fmt(o, f),
+            Borrowed(ref b) => fmt::Debug::fmt(b, f),
+            Owned(ref o) => fmt::Debug::fmt(o, f),
+        }
+    }
+}
+
+#[stable]
+impl<'a, T, B: ?Sized> fmt::Display for Cow<'a, T, B> where
+    B: fmt::Display + ToOwned<T>,
+    T: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Borrowed(ref b) => fmt::Display::fmt(b, f),
+            Owned(ref o) => fmt::Display::fmt(o, f),
         }
     }
 }

--- a/src/libcore/error.rs
+++ b/src/libcore/error.rs
@@ -14,14 +14,15 @@
 //!
 //! `Error` is a trait representing the basic expectations for error values,
 //! i.e. values of type `E` in `Result<T, E>`. At a minimum, errors must provide
-//! a description, but they may optionally provide additional detail and cause
-//! chain information:
+//! a description, but they may optionally provide additional detail (via
+//! `Display`) and cause chain information:
 //!
 //! ```
-//! trait Error {
+//! use std::fmt::Display;
+//!
+//! trait Error: Display {
 //!     fn description(&self) -> &str;
 //!
-//!     fn detail(&self) -> Option<String> { None }
 //!     fn cause(&self) -> Option<&Error> { None }
 //! }
 //! ```
@@ -80,19 +81,14 @@
 
 #![stable]
 
-use prelude::v1::*;
-
-use str::Utf8Error;
-use string::{FromUtf8Error, FromUtf16Error};
+use prelude::*;
+use fmt::Display;
 
 /// Base functionality for all errors in Rust.
 #[unstable = "the exact API of this trait may change"]
-pub trait Error {
+pub trait Error: Display {
     /// A short description of the error; usually a static string.
     fn description(&self) -> &str;
-
-    /// A detailed description of the error, usually including dynamic information.
-    fn detail(&self) -> Option<String> { None }
 
     /// The lower-level cause of this error, if any.
     fn cause(&self) -> Option<&Error> { None }
@@ -111,27 +107,4 @@ impl<E> FromError<E> for E {
     fn from_error(err: E) -> E {
         err
     }
-}
-
-#[stable]
-impl Error for Utf8Error {
-    fn description(&self) -> &str {
-        match *self {
-            Utf8Error::TooShort => "invalid utf-8: not enough bytes",
-            Utf8Error::InvalidByte(..) => "invalid utf-8: corrupt contents",
-        }
-    }
-
-    fn detail(&self) -> Option<String> { Some(self.to_string()) }
-}
-
-#[stable]
-impl Error for FromUtf8Error {
-    fn description(&self) -> &str { "invalid utf-8" }
-    fn detail(&self) -> Option<String> { Some(self.to_string()) }
-}
-
-#[stable]
-impl Error for FromUtf16Error {
-    fn description(&self) -> &str { "invalid utf-16" }
 }

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -26,11 +26,14 @@ use ops::{Deref, FnOnce};
 use result;
 use slice::SliceExt;
 use slice;
-use str::{self, StrExt, Utf8Error};
+use str::{self, StrExt};
 
 pub use self::num::radix;
 pub use self::num::Radix;
 pub use self::num::RadixFmt;
+
+#[cfg(stage0)] pub use self::Debug as Show;
+#[cfg(stage0)] pub use self::Display as String;
 
 mod num;
 mod float;
@@ -46,7 +49,7 @@ pub type Result = result::Result<(), Error>;
 /// occurred. Any extra information must be arranged to be transmitted through
 /// some other means.
 #[unstable = "core and I/O reconciliation may alter this definition"]
-#[derive(Copy)]
+#[derive(Copy, Show)]
 pub struct Error;
 
 /// A collection of methods that are required to format a message into a stream.
@@ -133,7 +136,7 @@ pub struct Argument<'a> {
 impl<'a> Argument<'a> {
     #[inline(never)]
     fn show_uint(x: &uint, f: &mut Formatter) -> Result {
-        Show::fmt(x, f)
+        Display::fmt(x, f)
     }
 
     fn new<'b, T>(x: &'b T, f: fn(&T, &mut Formatter) -> Result) -> Argument<'b> {
@@ -214,14 +217,15 @@ pub struct Arguments<'a> {
     args: &'a [Argument<'a>],
 }
 
-impl<'a> Show for Arguments<'a> {
+#[stable]
+impl<'a> Debug for Arguments<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> Result {
-        String::fmt(self, fmt)
+        Display::fmt(self, fmt)
     }
 }
 
 #[stable]
-impl<'a> String for Arguments<'a> {
+impl<'a> Display for Arguments<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> Result {
         write(fmt.buf, *self)
     }
@@ -229,8 +233,32 @@ impl<'a> String for Arguments<'a> {
 
 /// Format trait for the `:?` format. Useful for debugging, most all types
 /// should implement this.
-#[unstable = "I/O and core have yet to be reconciled"]
+#[deprecated = "renamed to Debug"]
+#[cfg(not(stage0))]
 pub trait Show {
+    /// Formats the value using the given formatter.
+    fn fmt(&self, &mut Formatter) -> Result;
+}
+
+/// Format trait for the `:?` format. Useful for debugging, most all types
+/// should implement this.
+#[unstable = "I/O and core have yet to be reconciled"]
+pub trait Debug {
+    /// Formats the value using the given formatter.
+    fn fmt(&self, &mut Formatter) -> Result;
+}
+
+#[cfg(not(stage0))]
+impl<T: Show + ?Sized> Debug for T {
+    #[allow(deprecated)]
+    fn fmt(&self, f: &mut Formatter) -> Result { Show::fmt(self, f) }
+}
+
+/// When a value can be semantically expressed as a String, this trait may be
+/// used. It corresponds to the default format, `{}`.
+#[deprecated = "renamed to Display"]
+#[cfg(not(stage0))]
+pub trait String {
     /// Formats the value using the given formatter.
     fn fmt(&self, &mut Formatter) -> Result;
 }
@@ -238,11 +266,16 @@ pub trait Show {
 /// When a value can be semantically expressed as a String, this trait may be
 /// used. It corresponds to the default format, `{}`.
 #[unstable = "I/O and core have yet to be reconciled"]
-pub trait String {
+pub trait Display {
     /// Formats the value using the given formatter.
     fn fmt(&self, &mut Formatter) -> Result;
 }
 
+#[cfg(not(stage0))]
+impl<T: String + ?Sized> Display for T {
+    #[allow(deprecated)]
+    fn fmt(&self, f: &mut Formatter) -> Result { String::fmt(self, f) }
+}
 
 /// Format trait for the `o` character
 #[unstable = "I/O and core have yet to be reconciled"]
@@ -583,9 +616,10 @@ impl<'a> Formatter<'a> {
     pub fn precision(&self) -> Option<uint> { self.precision }
 }
 
-impl Show for Error {
+#[stable]
+impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        String::fmt("an error occurred when formatting an argument", f)
+        Display::fmt("an error occurred when formatting an argument", f)
     }
 }
 
@@ -611,9 +645,11 @@ pub fn argumentuint<'a>(s: &'a uint) -> Argument<'a> {
 macro_rules! fmt_refs {
     ($($tr:ident),*) => {
         $(
+        #[stable]
         impl<'a, T: ?Sized + $tr> $tr for &'a T {
             fn fmt(&self, f: &mut Formatter) -> Result { $tr::fmt(&**self, f) }
         }
+        #[stable]
         impl<'a, T: ?Sized + $tr> $tr for &'a mut T {
             fn fmt(&self, f: &mut Formatter) -> Result { $tr::fmt(&**self, f) }
         }
@@ -621,22 +657,24 @@ macro_rules! fmt_refs {
     }
 }
 
-fmt_refs! { Show, String, Octal, Binary, LowerHex, UpperHex, LowerExp, UpperExp }
+fmt_refs! { Debug, Display, Octal, Binary, LowerHex, UpperHex, LowerExp, UpperExp }
 
-impl Show for bool {
+#[stable]
+impl Debug for bool {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        String::fmt(self, f)
+        Display::fmt(self, f)
     }
 }
 
 #[stable]
-impl String for bool {
+impl Display for bool {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        String::fmt(if *self { "true" } else { "false" }, f)
+        Display::fmt(if *self { "true" } else { "false" }, f)
     }
 }
 
-impl Show for str {
+#[stable]
+impl Debug for str {
     fn fmt(&self, f: &mut Formatter) -> Result {
         try!(write!(f, "\""));
         for c in self.chars().flat_map(|c| c.escape_default()) {
@@ -647,13 +685,14 @@ impl Show for str {
 }
 
 #[stable]
-impl String for str {
+impl Display for str {
     fn fmt(&self, f: &mut Formatter) -> Result {
         f.pad(self)
     }
 }
 
-impl Show for char {
+#[stable]
+impl Debug for char {
     fn fmt(&self, f: &mut Formatter) -> Result {
         use char::CharExt;
         try!(write!(f, "'"));
@@ -665,15 +704,16 @@ impl Show for char {
 }
 
 #[stable]
-impl String for char {
+impl Display for char {
     fn fmt(&self, f: &mut Formatter) -> Result {
         let mut utf8 = [0u8; 4];
         let amt = self.encode_utf8(&mut utf8).unwrap_or(0);
         let s: &str = unsafe { mem::transmute(&utf8[..amt]) };
-        String::fmt(s, f)
+        Display::fmt(s, f)
     }
 }
 
+#[stable]
 impl<T> Pointer for *const T {
     fn fmt(&self, f: &mut Formatter) -> Result {
         f.flags |= 1 << (rt::FlagAlternate as uint);
@@ -683,18 +723,21 @@ impl<T> Pointer for *const T {
     }
 }
 
+#[stable]
 impl<T> Pointer for *mut T {
     fn fmt(&self, f: &mut Formatter) -> Result {
         Pointer::fmt(&(*self as *const T), f)
     }
 }
 
+#[stable]
 impl<'a, T> Pointer for &'a T {
     fn fmt(&self, f: &mut Formatter) -> Result {
         Pointer::fmt(&(*self as *const T), f)
     }
 }
 
+#[stable]
 impl<'a, T> Pointer for &'a mut T {
     fn fmt(&self, f: &mut Formatter) -> Result {
         Pointer::fmt(&(&**self as *const T), f)
@@ -703,15 +746,15 @@ impl<'a, T> Pointer for &'a mut T {
 
 macro_rules! floating { ($ty:ident) => {
 
-    impl Show for $ty {
+    #[stable]
+    impl Debug for $ty {
         fn fmt(&self, fmt: &mut Formatter) -> Result {
-            try!(String::fmt(self, fmt));
-            fmt.write_str(stringify!($ty))
+            Display::fmt(self, fmt)
         }
     }
 
     #[stable]
-    impl String for $ty {
+    impl Display for $ty {
         fn fmt(&self, fmt: &mut Formatter) -> Result {
             use num::Float;
 
@@ -732,6 +775,7 @@ macro_rules! floating { ($ty:ident) => {
         }
     }
 
+    #[stable]
     impl LowerExp for $ty {
         fn fmt(&self, fmt: &mut Formatter) -> Result {
             use num::Float;
@@ -753,6 +797,7 @@ macro_rules! floating { ($ty:ident) => {
         }
     }
 
+    #[stable]
     impl UpperExp for $ty {
         fn fmt(&self, fmt: &mut Formatter) -> Result {
             use num::Float;
@@ -777,12 +822,14 @@ macro_rules! floating { ($ty:ident) => {
 floating! { f32 }
 floating! { f64 }
 
-// Implementation of Show for various core types
+// Implementation of Display/Debug for various core types
 
-impl<T> Show for *const T {
+#[stable]
+impl<T> Debug for *const T {
     fn fmt(&self, f: &mut Formatter) -> Result { Pointer::fmt(self, f) }
 }
-impl<T> Show for *mut T {
+#[stable]
+impl<T> Debug for *mut T {
     fn fmt(&self, f: &mut Formatter) -> Result { Pointer::fmt(self, f) }
 }
 
@@ -793,7 +840,8 @@ macro_rules! peel {
 macro_rules! tuple {
     () => ();
     ( $($name:ident,)+ ) => (
-        impl<$($name:Show),*> Show for ($($name,)*) {
+        #[stable]
+        impl<$($name:Debug),*> Debug for ($($name,)*) {
             #[allow(non_snake_case, unused_assignments)]
             fn fmt(&self, f: &mut Formatter) -> Result {
                 try!(write!(f, "("));
@@ -818,11 +866,13 @@ macro_rules! tuple {
 
 tuple! { T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, }
 
-impl<'a> Show for &'a (any::Any+'a) {
+#[stable]
+impl<'a> Debug for &'a (any::Any+'a) {
     fn fmt(&self, f: &mut Formatter) -> Result { f.pad("&Any") }
 }
 
-impl<T: Show> Show for [T] {
+#[stable]
+impl<T: Debug> Debug for [T] {
     fn fmt(&self, f: &mut Formatter) -> Result {
         if f.flags & (1 << (rt::FlagAlternate as uint)) == 0 {
             try!(write!(f, "["));
@@ -843,20 +893,22 @@ impl<T: Show> Show for [T] {
     }
 }
 
-impl Show for () {
+#[stable]
+impl Debug for () {
     fn fmt(&self, f: &mut Formatter) -> Result {
         f.pad("()")
     }
 }
 
-impl<T: Copy + Show> Show for Cell<T> {
+#[stable]
+impl<T: Copy + Debug> Debug for Cell<T> {
     fn fmt(&self, f: &mut Formatter) -> Result {
         write!(f, "Cell {{ value: {:?} }}", self.get())
     }
 }
 
-#[unstable]
-impl<T: Show> Show for RefCell<T> {
+#[stable]
+impl<T: Debug> Debug for RefCell<T> {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self.try_borrow() {
             Some(val) => write!(f, "RefCell {{ value: {:?} }}", val),
@@ -865,29 +917,17 @@ impl<T: Show> Show for RefCell<T> {
     }
 }
 
-impl<'b, T: Show> Show for Ref<'b, T> {
+#[stable]
+impl<'b, T: Debug> Debug for Ref<'b, T> {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        Show::fmt(&**self, f)
-    }
-}
-
-impl<'b, T: Show> Show for RefMut<'b, T> {
-    fn fmt(&self, f: &mut Formatter) -> Result {
-        Show::fmt(&*(self.deref()), f)
+        Debug::fmt(&**self, f)
     }
 }
 
 #[stable]
-impl String for Utf8Error {
+impl<'b, T: Debug> Debug for RefMut<'b, T> {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        match *self {
-            Utf8Error::InvalidByte(n) => {
-                write!(f, "invalid utf-8: invalid byte at index {}", n)
-            }
-            Utf8Error::TooShort => {
-                write!(f, "invalid utf-8: byte slice too short")
-            }
-        }
+        Debug::fmt(&*(self.deref()), f)
     }
 }
 

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -154,13 +154,14 @@ pub fn radix<T>(x: T, base: u8) -> RadixFmt<T, Radix> {
 
 macro_rules! radix_fmt {
     ($T:ty as $U:ty, $fmt:ident, $S:expr) => {
-        impl fmt::Show for RadixFmt<$T, Radix> {
+        #[stable]
+        impl fmt::Debug for RadixFmt<$T, Radix> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                try!(fmt::String::fmt(self, f));
-                f.write_str($S)
+                fmt::Display::fmt(self, f)
             }
         }
-        impl fmt::String for RadixFmt<$T, Radix> {
+        #[stable]
+        impl fmt::Display for RadixFmt<$T, Radix> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 match *self { RadixFmt(ref x, radix) => radix.$fmt(*x as $U, f) }
             }
@@ -169,6 +170,7 @@ macro_rules! radix_fmt {
 }
 macro_rules! int_base {
     ($Trait:ident for $T:ident as $U:ident -> $Radix:ident) => {
+        #[stable]
         impl fmt::$Trait for $T {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 $Radix.fmt_int(*self as $U, f)
@@ -179,10 +181,10 @@ macro_rules! int_base {
 
 macro_rules! show {
     ($T:ident with $S:expr) => {
-        impl fmt::Show for $T {
+        #[stable]
+        impl fmt::Debug for $T {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                try!(fmt::String::fmt(self, f));
-                f.write_str($S)
+                fmt::Display::fmt(self, f)
             }
         }
     }
@@ -192,7 +194,7 @@ macro_rules! integer {
         integer! { $Int, $Uint, stringify!($Int), stringify!($Uint) }
     };
     ($Int:ident, $Uint:ident, $SI:expr, $SU:expr) => {
-        int_base! { String   for $Int as $Int   -> Decimal }
+        int_base! { Display  for $Int as $Int   -> Decimal }
         int_base! { Binary   for $Int as $Uint  -> Binary }
         int_base! { Octal    for $Int as $Uint  -> Octal }
         int_base! { LowerHex for $Int as $Uint  -> LowerHex }
@@ -200,7 +202,7 @@ macro_rules! integer {
         radix_fmt! { $Int as $Int, fmt_int, $SI }
         show! { $Int with $SI }
 
-        int_base! { String   for $Uint as $Uint -> Decimal }
+        int_base! { Display  for $Uint as $Uint -> Decimal }
         int_base! { Binary   for $Uint as $Uint -> Binary }
         int_base! { Octal    for $Uint as $Uint -> Octal }
         int_base! { LowerHex for $Uint as $Uint -> LowerHex }

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -136,6 +136,7 @@ pub mod slice;
 pub mod str;
 pub mod hash;
 pub mod fmt;
+pub mod error;
 
 // note: does not need to be public
 mod tuple;

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -885,10 +885,10 @@ pub trait IndexMut<Index: ?Sized> {
 #[unstable = "API still in development"]
 pub struct FullRange;
 
-#[unstable = "API still in development"]
-impl fmt::Show for FullRange {
+#[stable]
+impl fmt::Debug for FullRange {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Show::fmt("..", fmt)
+        fmt::Debug::fmt("..", fmt)
     }
 }
 
@@ -944,8 +944,8 @@ impl<Idx: Clone + Step> DoubleEndedIterator for Range<Idx> {
 #[unstable = "API still in development"]
 impl<Idx: Clone + Step> ExactSizeIterator for Range<Idx> {}
 
-#[unstable = "API still in development"]
-impl<Idx: fmt::Show> fmt::Show for Range<Idx> {
+#[stable]
+impl<Idx: fmt::Debug> fmt::Debug for Range<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "{:?}..{:?}", self.start, self.end)
     }
@@ -973,8 +973,8 @@ impl<Idx: Clone + Step> Iterator for RangeFrom<Idx> {
     }
 }
 
-#[unstable = "API still in development"]
-impl<Idx: fmt::Show> fmt::Show for RangeFrom<Idx> {
+#[stable]
+impl<Idx: fmt::Debug> fmt::Debug for RangeFrom<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "{:?}..", self.start)
     }
@@ -989,8 +989,8 @@ pub struct RangeTo<Idx> {
     pub end: Idx,
 }
 
-#[unstable = "API still in development"]
-impl<Idx: fmt::Show> fmt::Show for RangeTo<Idx> {
+#[stable]
+impl<Idx: fmt::Debug> fmt::Debug for RangeTo<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "..{:?}", self.end)
     }

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -229,7 +229,7 @@
 use self::Result::{Ok, Err};
 
 use clone::Clone;
-use fmt::Show;
+use fmt::Display;
 use iter::{Iterator, IteratorExt, DoubleEndedIterator, FromIterator, ExactSizeIterator};
 use ops::{FnMut, FnOnce};
 use option::Option::{self, None, Some};
@@ -714,7 +714,7 @@ impl<T, E> Result<T, E> {
 }
 
 #[stable]
-impl<T, E: Show> Result<T, E> {
+impl<T, E: Display> Result<T, E> {
     /// Unwraps a result, yielding the content of an `Ok`.
     ///
     /// # Panics
@@ -739,13 +739,13 @@ impl<T, E: Show> Result<T, E> {
         match self {
             Ok(t) => t,
             Err(e) =>
-                panic!("called `Result::unwrap()` on an `Err` value: {:?}", e)
+                panic!("called `Result::unwrap()` on an `Err` value: {}", e)
         }
     }
 }
 
 #[stable]
-impl<T: Show, E> Result<T, E> {
+impl<T: Display, E> Result<T, E> {
     /// Unwraps a result, yielding the content of an `Err`.
     ///
     /// # Panics
@@ -769,7 +769,7 @@ impl<T: Show, E> Result<T, E> {
     pub fn unwrap_err(self) -> E {
         match self {
             Ok(t) =>
-                panic!("called `Result::unwrap_err()` on an `Ok` value: {:?}", t),
+                panic!("called `Result::unwrap_err()` on an `Ok` value: {}", t),
             Err(e) => e
         }
     }

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -20,8 +20,10 @@ use self::Searcher::{Naive, TwoWay, TwoWayLong};
 
 use cmp::{self, Eq};
 use default::Default;
-use iter::range;
+use error::Error;
+use fmt;
 use iter::ExactSizeIterator;
+use iter::range;
 use iter::{Map, Iterator, IteratorExt, DoubleEndedIterator};
 use marker::Sized;
 use mem;
@@ -239,6 +241,30 @@ impl<'a> CharEq for &'a [char] {
     #[inline]
     fn only_ascii(&self) -> bool {
         self.iter().all(|m| m.only_ascii())
+    }
+}
+
+#[stable]
+impl Error for Utf8Error {
+    fn description(&self) -> &str {
+        match *self {
+            Utf8Error::TooShort => "invalid utf-8: not enough bytes",
+            Utf8Error::InvalidByte(..) => "invalid utf-8: corrupt contents",
+        }
+    }
+}
+
+#[stable]
+impl fmt::Display for Utf8Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Utf8Error::InvalidByte(n) => {
+                write!(f, "invalid utf-8: invalid byte at index {}", n)
+            }
+            Utf8Error::TooShort => {
+                write!(f, "invalid utf-8: byte slice too short")
+            }
+        }
     }
 }
 

--- a/src/libcoretest/finally.rs
+++ b/src/libcoretest/finally.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(deprecated)]
+
 use core::finally::{try_finally, Finally};
 use std::thread::Thread;
 

--- a/src/libcoretest/fmt/num.rs
+++ b/src/libcoretest/fmt/num.rs
@@ -26,11 +26,11 @@ fn test_format_int() {
     assert!(format!("{}", -1i16) == "-1");
     assert!(format!("{}", -1i32) == "-1");
     assert!(format!("{}", -1i64) == "-1");
-    assert!(format!("{:?}", 1i) == "1i");
-    assert!(format!("{:?}", 1i8) == "1i8");
-    assert!(format!("{:?}", 1i16) == "1i16");
-    assert!(format!("{:?}", 1i32) == "1i32");
-    assert!(format!("{:?}", 1i64) == "1i64");
+    assert!(format!("{:?}", 1i) == "1");
+    assert!(format!("{:?}", 1i8) == "1");
+    assert!(format!("{:?}", 1i16) == "1");
+    assert!(format!("{:?}", 1i32) == "1");
+    assert!(format!("{:?}", 1i64) == "1");
     assert!(format!("{:b}", 1i) == "1");
     assert!(format!("{:b}", 1i8) == "1");
     assert!(format!("{:b}", 1i16) == "1");
@@ -57,11 +57,11 @@ fn test_format_int() {
     assert!(format!("{}", 1u16) == "1");
     assert!(format!("{}", 1u32) == "1");
     assert!(format!("{}", 1u64) == "1");
-    assert!(format!("{:?}", 1u) == "1u");
-    assert!(format!("{:?}", 1u8) == "1u8");
-    assert!(format!("{:?}", 1u16) == "1u16");
-    assert!(format!("{:?}", 1u32) == "1u32");
-    assert!(format!("{:?}", 1u64) == "1u64");
+    assert!(format!("{:?}", 1u) == "1");
+    assert!(format!("{:?}", 1u8) == "1");
+    assert!(format!("{:?}", 1u16) == "1");
+    assert!(format!("{:?}", 1u32) == "1");
+    assert!(format!("{:?}", 1u64) == "1");
     assert!(format!("{:b}", 1u) == "1");
     assert!(format!("{:b}", 1u8) == "1");
     assert!(format!("{:b}", 1u16) == "1");
@@ -94,14 +94,14 @@ fn test_format_int() {
 #[test]
 fn test_format_int_zero() {
     assert!(format!("{}", 0i) == "0");
-    assert!(format!("{:?}", 0i) == "0i");
+    assert!(format!("{:?}", 0i) == "0");
     assert!(format!("{:b}", 0i) == "0");
     assert!(format!("{:o}", 0i) == "0");
     assert!(format!("{:x}", 0i) == "0");
     assert!(format!("{:X}", 0i) == "0");
 
     assert!(format!("{}", 0u) == "0");
-    assert!(format!("{:?}", 0u) == "0u");
+    assert!(format!("{:?}", 0u) == "0");
     assert!(format!("{:b}", 0u) == "0");
     assert!(format!("{:o}", 0u) == "0");
     assert!(format!("{:x}", 0u) == "0");

--- a/src/libcoretest/num/mod.rs
+++ b/src/libcoretest/num/mod.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use core::cmp::PartialEq;
-use core::fmt::Show;
+use core::fmt::Debug;
 use core::num::{NumCast, cast};
 use core::ops::{Add, Sub, Mul, Div, Rem};
 use core::marker::Copy;
@@ -37,7 +37,7 @@ pub fn test_num<T>(ten: T, two: T) where
     T: PartialEq + NumCast
      + Add<Output=T> + Sub<Output=T>
      + Mul<Output=T> + Div<Output=T>
-     + Rem<Output=T> + Show
+     + Rem<Output=T> + Debug
      + Copy
 {
     assert_eq!(ten.add(two),  cast(12i).unwrap());

--- a/src/libcoretest/result.rs
+++ b/src/libcoretest/result.rs
@@ -14,11 +14,11 @@ pub fn op2() -> Result<int, &'static str> { Err("sadface") }
 #[test]
 pub fn test_and() {
     assert_eq!(op1().and(Ok(667i)).unwrap(), 667);
-    assert_eq!(op1().and(Err::<(), &'static str>("bad")).unwrap_err(),
+    assert_eq!(op1().and(Err::<i32, &'static str>("bad")).unwrap_err(),
                "bad");
 
     assert_eq!(op2().and(Ok(667i)).unwrap_err(), "sadface");
-    assert_eq!(op2().and(Err::<(),&'static str>("bad")).unwrap_err(),
+    assert_eq!(op2().and(Err::<i32,&'static str>("bad")).unwrap_err(),
                "sadface");
 }
 
@@ -94,7 +94,7 @@ pub fn test_fmt_default() {
     let err: Result<int, &'static str> = Err("Err");
 
     let s = format!("{:?}", ok);
-    assert_eq!(s, "Ok(100i)");
+    assert_eq!(s, "Ok(100)");
     let s = format!("{:?}", err);
     assert_eq!(s, "Err(\"Err\")");
 }

--- a/src/libcoretest/tuple.rs
+++ b/src/libcoretest/tuple.rs
@@ -60,9 +60,9 @@ fn test_tuple_cmp() {
 #[test]
 fn test_show() {
     let s = format!("{:?}", (1i,));
-    assert_eq!(s, "(1i,)");
+    assert_eq!(s, "(1,)");
     let s = format!("{:?}", (1i, true));
-    assert_eq!(s, "(1i, true)");
+    assert_eq!(s, "(1, true)");
     let s = format!("{:?}", (1i, "hi", true));
-    assert_eq!(s, "(1i, \"hi\", true)");
+    assert_eq!(s, "(1, \"hi\", true)");
 }

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -544,7 +544,7 @@ impl Fail {
     }
 }
 
-impl fmt::String for Fail {
+impl fmt::Display for Fail {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             ArgumentMissing(ref nm) => {

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -358,19 +358,19 @@ impl<'a> Id<'a> {
     ///
     /// Passing an invalid string (containing spaces, brackets,
     /// quotes, ...) will return an empty `Err` value.
-    pub fn new<Name: IntoCow<'a, String, str>>(name: Name) -> Result<Id<'a>, ()> {
+    pub fn new<Name: IntoCow<'a, String, str>>(name: Name) -> Option<Id<'a>> {
         let name = name.into_cow();
         {
             let mut chars = name.chars();
             match chars.next() {
                 Some(c) if is_letter_or_underscore(c) => { ; },
-                _ => return Err(())
+                _ => return None
             }
             if !chars.all(is_constituent) {
-                return Err(());
+                return None
             }
         }
-        return Ok(Id{ name: name });
+        return Some(Id{ name: name });
 
         fn is_letter_or_underscore(c: char) -> bool {
             in_range('a', c, 'z') || in_range('A', c, 'Z') || c == '_'
@@ -874,8 +874,8 @@ r#"digraph syntax_tree {
     fn simple_id_construction() {
         let id1 = Id::new("hello");
         match id1 {
-            Ok(_) => {;},
-            Err(_) => panic!("'hello' is not a valid value for id anymore")
+            Some(_) => {;},
+            None => panic!("'hello' is not a valid value for id anymore")
         }
     }
 
@@ -883,8 +883,8 @@ r#"digraph syntax_tree {
     fn badly_formatted_id() {
         let id2 = Id::new("Weird { struct : ure } !!!");
         match id2 {
-            Ok(_) => panic!("graphviz id suddenly allows spaces, brackets and stuff"),
-            Err(_) => {;}
+            Some(_) => panic!("graphviz id suddenly allows spaces, brackets and stuff"),
+            None => {;}
         }
     }
 }

--- a/src/libgraphviz/maybe_owned_vec.rs
+++ b/src/libgraphviz/maybe_owned_vec.rs
@@ -124,7 +124,7 @@ impl<'a,T> FromIterator<T> for MaybeOwnedVector<'a,T> {
     }
 }
 
-impl<'a,T:fmt::Show> fmt::Show for MaybeOwnedVector<'a,T> {
+impl<'a,T:fmt::Debug> fmt::Debug for MaybeOwnedVector<'a,T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.as_slice().fmt(f)
     }

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -239,21 +239,15 @@ struct DefaultLogger {
 }
 
 /// Wraps the log level with fmt implementations.
-#[derive(Copy, PartialEq, PartialOrd)]
+#[derive(Copy, PartialEq, PartialOrd, Show)]
 pub struct LogLevel(pub u32);
 
-impl fmt::Show for LogLevel {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, fmt)
-    }
-}
-
-impl fmt::String for LogLevel {
+impl fmt::Display for LogLevel {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let LogLevel(level) = *self;
         match LOG_LEVEL_NAMES.get(level as uint - 1) {
-            Some(ref name) => fmt::String::fmt(name, fmt),
-            None => fmt::String::fmt(&level, fmt)
+            Some(ref name) => fmt::Display::fmt(name, fmt),
+            None => fmt::Display::fmt(&level, fmt)
         }
     }
 }

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -38,6 +38,7 @@ pub use self::EbmlEncoderTag::*;
 pub use self::Error::*;
 
 use std::str;
+use std::fmt;
 
 pub mod io;
 
@@ -112,6 +113,13 @@ pub enum Error {
     Expected(String),
     IoError(std::io::IoError),
     ApplicationError(String)
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // FIXME: this should be a more useful display form
+        fmt::Debug::fmt(self, f)
+    }
 }
 // --------------------------------------
 

--- a/src/libregex/parse.rs
+++ b/src/libregex/parse.rs
@@ -30,6 +30,7 @@ static MAX_REPEAT: uint = 1000;
 ///
 /// (Once an expression is compiled, it is not possible to produce an error
 /// via searching, splitting or replacing.)
+#[derive(Show)]
 pub struct Error {
     /// The *approximate* character index of where the error occurred.
     pub pos: uint,
@@ -37,7 +38,7 @@ pub struct Error {
     pub msg: String,
 }
 
-impl fmt::Show for Error {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Regex syntax error near position {}: {:?}",
                self.pos, self.msg)

--- a/src/libregex/re.rs
+++ b/src/libregex/re.rs
@@ -90,10 +90,10 @@ impl Clone for ExNative {
     }
 }
 
-impl fmt::String for Regex {
+impl fmt::Display for Regex {
     /// Shows the original regular expression.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self.as_str(), f)
+        fmt::Display::fmt(self.as_str(), f)
     }
 }
 

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -57,7 +57,7 @@ struct Matrix<'a>(Vec<Vec<&'a Pat>>);
 /// ++++++++++++++++++++++++++
 /// + _     + [_, _, ..tail] +
 /// ++++++++++++++++++++++++++
-impl<'a> fmt::Show for Matrix<'a> {
+impl<'a> fmt::Debug for Matrix<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "\n"));
 

--- a/src/librustc/middle/graph.rs
+++ b/src/librustc/middle/graph.rs
@@ -32,7 +32,7 @@
 
 #![allow(dead_code)] // still WIP
 
-use std::fmt::{Formatter, Error, Show};
+use std::fmt::{Formatter, Error, Debug};
 use std::uint;
 use std::collections::BitvSet;
 
@@ -53,7 +53,7 @@ pub struct Edge<E> {
     pub data: E,
 }
 
-impl<E: Show> Show for Edge<E> {
+impl<E: Debug> Debug for Edge<E> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         write!(f, "Edge {{ next_edge: [{:?}, {:?}], source: {:?}, target: {:?}, data: {:?} }}",
                self.next_edge[0], self.next_edge[1], self.source,
@@ -353,7 +353,7 @@ impl<E> Edge<E> {
 #[cfg(test)]
 mod test {
     use middle::graph::*;
-    use std::fmt::Show;
+    use std::fmt::Debug;
 
     type TestNode = Node<&'static str>;
     type TestEdge = Edge<&'static str>;
@@ -408,7 +408,7 @@ mod test {
         });
     }
 
-    fn test_adjacent_edges<N:PartialEq+Show,E:PartialEq+Show>(graph: &Graph<N,E>,
+    fn test_adjacent_edges<N:PartialEq+Debug,E:PartialEq+Debug>(graph: &Graph<N,E>,
                                       start_index: NodeIndex,
                                       start_data: N,
                                       expected_incoming: &[(E,N)],

--- a/src/librustc/middle/infer/unify.rs
+++ b/src/librustc/middle/infer/unify.rs
@@ -17,7 +17,7 @@ use middle::ty::{self, Ty};
 use middle::infer::{uok, ures};
 use middle::infer::InferCtxt;
 use std::cell::RefCell;
-use std::fmt::Show;
+use std::fmt::Debug;
 use syntax::ast;
 use util::ppaux::Repr;
 use util::snapshot_vec as sv;
@@ -32,7 +32,7 @@ use util::snapshot_vec as sv;
 /// (possibly not yet known) sort of integer.
 ///
 /// Implementations of this trait are at the end of this file.
-pub trait UnifyKey<'tcx, V> : Clone + Show + PartialEq + Repr<'tcx> {
+pub trait UnifyKey<'tcx, V> : Clone + Debug + PartialEq + Repr<'tcx> {
     fn index(&self) -> uint;
 
     fn from_index(u: uint) -> Self;

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -198,13 +198,13 @@ pub fn check_crate(tcx: &ty::ctxt) {
     tcx.sess.abort_if_errors();
 }
 
-impl fmt::Show for LiveNode {
+impl fmt::Debug for LiveNode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ln({})", self.get())
     }
 }
 
-impl fmt::Show for Variable {
+impl fmt::Debug for Variable {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "v({})", self.get())
     }

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -602,7 +602,7 @@ fn early_bound_lifetime_names(generics: &ast::Generics) -> Vec<ast::Name> {
     }
 }
 
-impl<'a> fmt::Show for ScopeChain<'a> {
+impl<'a> fmt::Debug for ScopeChain<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             EarlyScope(space, defs, _) => write!(fmt, "EarlyScope({:?}, {:?})", space, defs),

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -238,7 +238,7 @@ pub struct SeparateVecsPerParamSpace<T> {
     pub fns: Vec<T>,
 }
 
-impl<T:fmt::Show> fmt::Show for VecPerParamSpace<T> {
+impl<T: fmt::Debug> fmt::Debug for VecPerParamSpace<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(fmt, "VecPerParamSpace {{"));
         for space in ParamSpace::all().iter() {

--- a/src/librustc/middle/traits/error_reporting.rs
+++ b/src/librustc/middle/traits/error_reporting.rs
@@ -200,7 +200,7 @@ pub fn report_selection_error<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
                         ty::Predicate::Equate(ref predicate) => {
                             let predicate = infcx.resolve_type_vars_if_possible(predicate);
                             let err = infcx.equality_predicate(obligation.cause.span,
-                                                               &predicate).unwrap_err();
+                                                               &predicate).err().unwrap();
                             infcx.tcx.sess.span_err(
                                 obligation.cause.span,
                                 format!(
@@ -212,7 +212,7 @@ pub fn report_selection_error<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
                         ty::Predicate::RegionOutlives(ref predicate) => {
                             let predicate = infcx.resolve_type_vars_if_possible(predicate);
                             let err = infcx.region_outlives_predicate(obligation.cause.span,
-                                                                      &predicate).unwrap_err();
+                                                                      &predicate).err().unwrap();
                             infcx.tcx.sess.span_err(
                                 obligation.cause.span,
                                 format!(

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -236,13 +236,13 @@ pub fn fresh_substs_for_impl<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
     infcx.fresh_substs_for_generics(span, &impl_generics)
 }
 
-impl<'tcx, N> fmt::Show for VtableImplData<'tcx, N> {
+impl<'tcx, N> fmt::Debug for VtableImplData<'tcx, N> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "VtableImpl({:?})", self.impl_def_id)
     }
 }
 
-impl<'tcx> fmt::Show for super::VtableObjectData<'tcx> {
+impl<'tcx> fmt::Debug for super::VtableObjectData<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "VtableObject(...)")
     }
@@ -449,7 +449,7 @@ impl<'tcx> Repr<'tcx> for super::FulfillmentErrorCode<'tcx> {
     }
 }
 
-impl<'tcx> fmt::Show for super::FulfillmentErrorCode<'tcx> {
+impl<'tcx> fmt::Debug for super::FulfillmentErrorCode<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             super::CodeSelectionError(ref e) => write!(f, "{:?}", e),
@@ -465,7 +465,7 @@ impl<'tcx> Repr<'tcx> for super::MismatchedProjectionTypes<'tcx> {
     }
 }
 
-impl<'tcx> fmt::Show for super::MismatchedProjectionTypes<'tcx> {
+impl<'tcx> fmt::Debug for super::MismatchedProjectionTypes<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "MismatchedProjectionTypes(..)")
     }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -934,7 +934,7 @@ pub struct TyS<'tcx> {
     region_depth: u32,
 }
 
-impl fmt::Show for TypeFlags {
+impl fmt::Debug for TypeFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.bits)
     }
@@ -1703,37 +1703,37 @@ impl cmp::PartialEq for InferRegion {
     }
 }
 
-impl fmt::Show for TyVid {
+impl fmt::Debug for TyVid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result{
         write!(f, "_#{}t", self.index)
     }
 }
 
-impl fmt::Show for IntVid {
+impl fmt::Debug for IntVid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "_#{}i", self.index)
     }
 }
 
-impl fmt::Show for FloatVid {
+impl fmt::Debug for FloatVid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "_#{}f", self.index)
     }
 }
 
-impl fmt::Show for RegionVid {
+impl fmt::Debug for RegionVid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "'_#{}r", self.index)
     }
 }
 
-impl<'tcx> fmt::Show for FnSig<'tcx> {
+impl<'tcx> fmt::Debug for FnSig<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({:?}; variadic: {})->{:?}", self.inputs, self.variadic, self.output)
     }
 }
 
-impl fmt::Show for InferTy {
+impl fmt::Debug for InferTy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TyVar(ref v) => v.fmt(f),
@@ -1745,7 +1745,7 @@ impl fmt::Show for InferTy {
     }
 }
 
-impl fmt::Show for IntVarValue {
+impl fmt::Debug for IntVarValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             IntType(ref v) => v.fmt(f),
@@ -3319,7 +3319,7 @@ impl ops::Sub for TypeContents {
     }
 }
 
-impl fmt::Show for TypeContents {
+impl fmt::Debug for TypeContents {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "TypeContents({:b})", self.bits)
     }

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -249,7 +249,7 @@ pub enum EntryFnType {
     EntryNone,
 }
 
-#[derive(Copy, PartialEq, PartialOrd, Clone, Ord, Eq, Hash)]
+#[derive(Copy, PartialEq, PartialOrd, Clone, Ord, Eq, Hash, Show)]
 pub enum CrateType {
     CrateTypeExecutable,
     CrateTypeDylib,
@@ -1159,7 +1159,7 @@ pub fn parse_crate_types_from_list(list_list: Vec<String>) -> Result<Vec<CrateTy
     return Ok(crate_types);
 }
 
-impl fmt::Show for CrateType {
+impl fmt::Display for CrateType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             CrateTypeExecutable => "bin".fmt(f),

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -12,7 +12,7 @@
 
 use std::cell::{RefCell, Cell};
 use std::collections::HashMap;
-use std::fmt::Show;
+use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::iter::repeat;
 use std::time::Duration;
@@ -58,7 +58,7 @@ pub fn time<T, U, F>(do_it: bool, what: &str, u: U, f: F) -> T where
 }
 
 pub fn indent<R, F>(op: F) -> R where
-    R: Show,
+    R: Debug,
     F: FnOnce() -> R,
 {
     // Use in conjunction with the log post-processor like `src/etc/indenter`

--- a/src/librustc_back/archive.rs
+++ b/src/librustc_back/archive.rs
@@ -59,7 +59,7 @@ fn run_ar(handler: &ErrorHandler, maybe_ar_prog: &Option<String>,
     let mut cmd = Command::new(ar);
 
     cmd.arg(args).args(paths);
-    debug!("{}", cmd);
+    debug!("{:?}", cmd);
 
     match cwd {
         Some(p) => {
@@ -73,9 +73,7 @@ fn run_ar(handler: &ErrorHandler, maybe_ar_prog: &Option<String>,
         Ok(prog) => {
             let o = prog.wait_with_output().unwrap();
             if !o.status.success() {
-                handler.err(&format!("{} failed with: {}",
-                                 cmd,
-                                 o.status)[]);
+                handler.err(&format!("{:?} failed with: {}", cmd, o.status)[]);
                 handler.note(&format!("stdout ---\n{}",
                                   str::from_utf8(&o.output[]).unwrap())[]);
                 handler.note(&format!("stderr ---\n{}",

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -52,7 +52,7 @@ use std::iter::range_step;
 use syntax::ast;
 use syntax::visit;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Show)]
 pub struct Svh {
     hash: String,
 }
@@ -117,13 +117,7 @@ impl Svh {
     }
 }
 
-impl fmt::Show for Svh {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Svh {{ {} }}", self.as_str())
-    }
-}
-
-impl fmt::String for Svh {
+impl fmt::Display for Svh {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad(self.as_str())
     }

--- a/src/librustc_borrowck/borrowck/gather_loans/mod.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/mod.rs
@@ -491,7 +491,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for StaticInitializerCtxt<'a, 'tcx> {
         if let ast::ExprAddrOf(mutbl, ref base) = ex.node {
             let param_env = ty::empty_parameter_environment(self.bccx.tcx);
             let mc = mc::MemCategorizationContext::new(&param_env);
-            let base_cmt = mc.cat_expr(&**base).unwrap();
+            let base_cmt = mc.cat_expr(&**base).ok().unwrap();
             let borrow_kind = ty::BorrowKind::from_mutbl(mutbl);
             // Check that we don't allow borrows of unsafe static items.
             if check_aliasability(self.bccx, ex.span, euv::AddrOf,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -536,7 +536,7 @@ impl Module {
     }
 }
 
-impl fmt::Show for Module {
+impl fmt::Debug for Module {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}, kind: {:?}, {}",
                self.def_id,

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -779,14 +779,14 @@ fn link_natively(sess: &Session, trans: &CrateTranslation, dylib: bool,
     }
 
     if sess.opts.debugging_opts.print_link_args {
-        println!("{}", &cmd);
+        println!("{:?}", &cmd);
     }
 
     // May have not found libraries in the right formats.
     sess.abort_if_errors();
 
     // Invoke the system linker
-    debug!("{}", &cmd);
+    debug!("{:?}", &cmd);
     let prog = time(sess.time_passes(), "running linker", (), |()| cmd.output());
     match prog {
         Ok(prog) => {
@@ -794,7 +794,7 @@ fn link_natively(sess: &Session, trans: &CrateTranslation, dylib: bool,
                 sess.err(&format!("linking with `{}` failed: {}",
                                  pname,
                                  prog.status)[]);
-                sess.note(&format!("{}", &cmd)[]);
+                sess.note(&format!("{:?}", &cmd)[]);
                 let mut output = prog.error.clone();
                 output.push_all(&prog.output[]);
                 sess.note(str::from_utf8(&output[]).unwrap());

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -716,7 +716,7 @@ pub fn run_passes(sess: &Session,
         cmd.args(&sess.target.target.options.post_link_args[]);
 
         if sess.opts.debugging_opts.print_link_args {
-            println!("{}", &cmd);
+            println!("{:?}", &cmd);
         }
 
         cmd.stdin(::std::io::process::Ignored)
@@ -725,7 +725,7 @@ pub fn run_passes(sess: &Session,
         match cmd.status() {
             Ok(status) => {
                 if !status.success() {
-                    sess.err(&format!("linking of {} with `{}` failed",
+                    sess.err(&format!("linking of {} with `{:?}` failed",
                                      output_path.display(), cmd)[]);
                     sess.abort_if_errors();
                 }
@@ -953,7 +953,7 @@ pub fn run_assembler(sess: &Session, outputs: &OutputFilenames) {
 
     cmd.arg("-c").arg("-o").arg(outputs.path(config::OutputTypeObject))
                            .arg(outputs.temp_path(config::OutputTypeAssembly));
-    debug!("{}", &cmd);
+    debug!("{:?}", &cmd);
 
     match cmd.output() {
         Ok(prog) => {
@@ -961,7 +961,7 @@ pub fn run_assembler(sess: &Session, outputs: &OutputFilenames) {
                 sess.err(&format!("linking with `{}` failed: {}",
                                  pname,
                                  prog.status)[]);
-                sess.note(&format!("{}", &cmd)[]);
+                sess.note(&format!("{:?}", &cmd)[]);
                 let mut note = prog.error.clone();
                 note.push_all(&prog.output[]);
                 sess.note(str::from_utf8(&note[]).unwrap());

--- a/src/librustc_trans/trans/cleanup.rs
+++ b/src/librustc_trans/trans/cleanup.rs
@@ -65,7 +65,7 @@ pub enum CleanupScopeKind<'blk, 'tcx: 'blk> {
     LoopScopeKind(ast::NodeId, [Block<'blk, 'tcx>; EXIT_MAX])
 }
 
-impl<'blk, 'tcx: 'blk> fmt::Show for CleanupScopeKind<'blk, 'tcx> {
+impl<'blk, 'tcx: 'blk> fmt::Debug for CleanupScopeKind<'blk, 'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             CustomScopeKind => write!(f, "CustomScopeKind"),

--- a/src/librustc_trans/trans/datum.rs
+++ b/src/librustc_trans/trans/datum.rs
@@ -481,7 +481,7 @@ impl<'tcx> Datum<'tcx, Lvalue> {
 }
 
 /// Generic methods applicable to any sort of datum.
-impl<'tcx, K: KindOps + fmt::Show> Datum<'tcx, K> {
+impl<'tcx, K: KindOps + fmt::Debug> Datum<'tcx, K> {
     pub fn new(val: ValueRef, ty: Ty<'tcx>, kind: K) -> Datum<'tcx, K> {
         Datum { val: val, ty: ty, kind: kind }
     }
@@ -591,7 +591,7 @@ impl<'blk, 'tcx, K> DatumBlock<'blk, 'tcx, K> {
     }
 }
 
-impl<'blk, 'tcx, K: KindOps + fmt::Show> DatumBlock<'blk, 'tcx, K> {
+impl<'blk, 'tcx, K: KindOps + fmt::Debug> DatumBlock<'blk, 'tcx, K> {
     pub fn to_expr_datumblock(self) -> DatumBlock<'blk, 'tcx, Expr> {
         DatumBlock::new(self.bcx, self.datum.to_expr_datum())
     }

--- a/src/librustc_typeck/variance.rs
+++ b/src/librustc_typeck/variance.rs
@@ -240,7 +240,7 @@ enum VarianceTerm<'a> {
     InferredTerm(InferredIndex),
 }
 
-impl<'a> fmt::Show for VarianceTerm<'a> {
+impl<'a> fmt::Debug for VarianceTerm<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             ConstantTerm(c1) => write!(f, "{:?}", c1),

--- a/src/librustdoc/html/escape.rs
+++ b/src/librustdoc/html/escape.rs
@@ -19,7 +19,7 @@ use std::fmt;
 /// string when passed to a format string.
 pub struct Escape<'a>(pub &'a str);
 
-impl<'a> fmt::String for Escape<'a> {
+impl<'a> fmt::Display for Escape<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         // Because the internet is always right, turns out there's not that many
         // characters to escape: http://stackoverflow.com/questions/7381974

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -66,7 +66,7 @@ impl UnsafetySpace {
     }
 }
 
-impl<'a, T: fmt::String> fmt::String for CommaSep<'a, T> {
+impl<'a, T: fmt::Display> fmt::Display for CommaSep<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for (i, item) in self.0.iter().enumerate() {
             if i != 0 { try!(write!(f, ", ")); }
@@ -76,7 +76,7 @@ impl<'a, T: fmt::String> fmt::String for CommaSep<'a, T> {
     }
 }
 
-impl<'a> fmt::String for TyParamBounds<'a> {
+impl<'a> fmt::Display for TyParamBounds<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let &TyParamBounds(bounds) = self;
         for (i, bound) in bounds.iter().enumerate() {
@@ -89,7 +89,7 @@ impl<'a> fmt::String for TyParamBounds<'a> {
     }
 }
 
-impl fmt::String for clean::Generics {
+impl fmt::Display for clean::Generics {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.lifetimes.len() == 0 && self.type_params.len() == 0 { return Ok(()) }
         try!(f.write_str("&lt;"));
@@ -126,7 +126,7 @@ impl fmt::String for clean::Generics {
     }
 }
 
-impl<'a> fmt::String for WhereClause<'a> {
+impl<'a> fmt::Display for WhereClause<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let &WhereClause(gens) = self;
         if gens.where_predicates.len() == 0 {
@@ -163,14 +163,14 @@ impl<'a> fmt::String for WhereClause<'a> {
     }
 }
 
-impl fmt::String for clean::Lifetime {
+impl fmt::Display for clean::Lifetime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(f.write_str(self.get_ref()));
         Ok(())
     }
 }
 
-impl fmt::String for clean::PolyTrait {
+impl fmt::Display for clean::PolyTrait {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.lifetimes.len() > 0 {
             try!(f.write_str("for&lt;"));
@@ -186,7 +186,7 @@ impl fmt::String for clean::PolyTrait {
     }
 }
 
-impl fmt::String for clean::TyParamBound {
+impl fmt::Display for clean::TyParamBound {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             clean::RegionBound(ref lt) => {
@@ -203,7 +203,7 @@ impl fmt::String for clean::TyParamBound {
     }
 }
 
-impl fmt::String for clean::PathParameters {
+impl fmt::Display for clean::PathParameters {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             clean::PathParameters::AngleBracketed {
@@ -257,14 +257,14 @@ impl fmt::String for clean::PathParameters {
     }
 }
 
-impl fmt::String for clean::PathSegment {
+impl fmt::Display for clean::PathSegment {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(f.write_str(self.name.as_slice()));
         write!(f, "{}", self.params)
     }
 }
 
-impl fmt::String for clean::Path {
+impl fmt::Display for clean::Path {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.global {
             try!(f.write_str("::"))
@@ -450,7 +450,7 @@ fn tybounds(w: &mut fmt::Formatter,
     }
 }
 
-impl fmt::String for clean::Type {
+impl fmt::Display for clean::Type {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             clean::TyParamBinder(id) => {
@@ -539,7 +539,7 @@ impl fmt::String for clean::Type {
     }
 }
 
-impl fmt::String for clean::Arguments {
+impl fmt::Display for clean::Arguments {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for (i, input) in self.values.iter().enumerate() {
             if i > 0 { try!(write!(f, ", ")); }
@@ -552,7 +552,7 @@ impl fmt::String for clean::Arguments {
     }
 }
 
-impl fmt::String for clean::FunctionRetTy {
+impl fmt::Display for clean::FunctionRetTy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             clean::Return(clean::Tuple(ref tys)) if tys.is_empty() => Ok(()),
@@ -563,13 +563,13 @@ impl fmt::String for clean::FunctionRetTy {
     }
 }
 
-impl fmt::String for clean::FnDecl {
+impl fmt::Display for clean::FnDecl {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({args}){arrow}", args = self.inputs, arrow = self.output)
     }
 }
 
-impl<'a> fmt::String for Method<'a> {
+impl<'a> fmt::Display for Method<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Method(selfty, d) = *self;
         let mut args = String::new();
@@ -599,7 +599,7 @@ impl<'a> fmt::String for Method<'a> {
     }
 }
 
-impl fmt::String for VisSpace {
+impl fmt::Display for VisSpace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.get() {
             Some(ast::Public) => write!(f, "pub "),
@@ -608,7 +608,7 @@ impl fmt::String for VisSpace {
     }
 }
 
-impl fmt::String for UnsafetySpace {
+impl fmt::Display for UnsafetySpace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.get() {
             ast::Unsafety::Unsafe => write!(f, "unsafe "),
@@ -617,7 +617,7 @@ impl fmt::String for UnsafetySpace {
     }
 }
 
-impl fmt::String for clean::ViewPath {
+impl fmt::Display for clean::ViewPath {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             clean::SimpleImport(ref name, ref src) => {
@@ -644,7 +644,7 @@ impl fmt::String for clean::ViewPath {
     }
 }
 
-impl fmt::String for clean::ImportSource {
+impl fmt::Display for clean::ImportSource {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.did {
             Some(did) => resolved_path(f, did, &self.path, true),
@@ -661,7 +661,7 @@ impl fmt::String for clean::ImportSource {
     }
 }
 
-impl fmt::String for clean::ViewListIdent {
+impl fmt::Display for clean::ViewListIdent {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.source {
             Some(did) => {
@@ -683,13 +683,13 @@ impl fmt::String for clean::ViewListIdent {
     }
 }
 
-impl fmt::String for clean::TypeBinding {
+impl fmt::Display for clean::TypeBinding {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}={}", self.name, self.ty)
     }
 }
 
-impl fmt::String for MutableSpace {
+impl fmt::Display for MutableSpace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             MutableSpace(clean::Immutable) => Ok(()),
@@ -698,7 +698,7 @@ impl fmt::String for MutableSpace {
     }
 }
 
-impl fmt::String for RawMutableSpace {
+impl fmt::Display for RawMutableSpace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             RawMutableSpace(clean::Immutable) => write!(f, "const "),
@@ -707,7 +707,7 @@ impl fmt::String for RawMutableSpace {
     }
 }
 
-impl<'a> fmt::String for Stability<'a> {
+impl<'a> fmt::Display for Stability<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Stability(stab) = *self;
         match *stab {
@@ -721,7 +721,7 @@ impl<'a> fmt::String for Stability<'a> {
     }
 }
 
-impl<'a> fmt::String for ConciseStability<'a> {
+impl<'a> fmt::Display for ConciseStability<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let ConciseStability(stab) = *self;
         match *stab {
@@ -738,7 +738,7 @@ impl<'a> fmt::String for ConciseStability<'a> {
     }
 }
 
-impl fmt::String for ModuleSummary {
+impl fmt::Display for ModuleSummary {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fn fmt_inner<'a>(f: &mut fmt::Formatter,
                          context: &mut Vec<&'a str>,

--- a/src/librustdoc/html/item_type.rs
+++ b/src/librustdoc/html/item_type.rs
@@ -103,7 +103,7 @@ impl ItemType {
     }
 }
 
-impl fmt::String for ItemType {
+impl fmt::Display for ItemType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.to_static_str().fmt(f)
     }

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -30,7 +30,7 @@ pub struct Page<'a> {
     pub keywords: &'a str
 }
 
-pub fn render<T: fmt::String, S: fmt::String>(
+pub fn render<T: fmt::Display, S: fmt::Display>(
     dst: &mut io::Writer, layout: &Layout, page: &Page, sidebar: &S, t: &T)
     -> io::IoResult<()>
 {

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -426,7 +426,7 @@ pub fn reset_headers() {
     USED_HEADER_MAP.with(|s| s.borrow_mut().clear());
 }
 
-impl<'a> fmt::String for Markdown<'a> {
+impl<'a> fmt::Display for Markdown<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let Markdown(md) = *self;
         // This is actually common enough to special-case
@@ -435,7 +435,7 @@ impl<'a> fmt::String for Markdown<'a> {
     }
 }
 
-impl<'a> fmt::String for MarkdownWithToc<'a> {
+impl<'a> fmt::Display for MarkdownWithToc<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let MarkdownWithToc(md) = *self;
         render(fmt, md.as_slice(), true)

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1351,7 +1351,7 @@ impl<'a> Item<'a> {
 }
 
 
-impl<'a> fmt::String for Item<'a> {
+impl<'a> fmt::Display for Item<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         // Write the breadcrumb trail header for the top
         try!(write!(fmt, "\n<h1 class='fqn'><span class='in-band'>"));
@@ -1626,7 +1626,7 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
 
 struct Initializer<'a>(&'a str);
 
-impl<'a> fmt::String for Initializer<'a> {
+impl<'a> fmt::Display for Initializer<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Initializer(s) = *self;
         if s.len() == 0 { return Ok(()); }
@@ -2188,7 +2188,7 @@ fn item_typedef(w: &mut fmt::Formatter, it: &clean::Item,
     document(w, it)
 }
 
-impl<'a> fmt::String for Sidebar<'a> {
+impl<'a> fmt::Display for Sidebar<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let cx = self.cx;
         let it = self.item;
@@ -2243,7 +2243,7 @@ impl<'a> fmt::String for Sidebar<'a> {
     }
 }
 
-impl<'a> fmt::String for Source<'a> {
+impl<'a> fmt::Display for Source<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let Source(s) = *self;
         let lines = s.lines().count();

--- a/src/librustdoc/html/toc.rs
+++ b/src/librustdoc/html/toc.rs
@@ -176,13 +176,13 @@ impl TocBuilder {
     }
 }
 
-impl fmt::Show for Toc {
+impl fmt::Debug for Toc {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
+        fmt::Display::fmt(self, f)
     }
 }
 
-impl fmt::String for Toc {
+impl fmt::Display for Toc {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(fmt, "<ul>"));
         for entry in self.entries.iter() {

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -111,7 +111,7 @@ pub fn main() {
     let res = std::thread::Builder::new().stack_size(STACK_SIZE).scoped(move || {
         main_args(std::os::args().as_slice())
     }).join();
-    std::os::set_exit_status(res.map_err(|_| ()).unwrap());
+    std::os::set_exit_status(res.ok().unwrap());
 }
 
 pub fn opts() -> Vec<getopts::OptGroup> {

--- a/src/libserialize/base64.rs
+++ b/src/libserialize/base64.rs
@@ -177,7 +177,7 @@ pub trait FromBase64 {
 }
 
 /// Errors that can occur when decoding a base64 encoded string
-#[derive(Copy)]
+#[derive(Copy, Show)]
 pub enum FromBase64Error {
     /// The input contained a character not part of the base64 format
     InvalidBase64Byte(u8, uint),
@@ -185,7 +185,7 @@ pub enum FromBase64Error {
     InvalidBase64Length,
 }
 
-impl fmt::Show for FromBase64Error {
+impl fmt::Display for FromBase64Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             InvalidBase64Byte(ch, idx) =>
@@ -201,10 +201,6 @@ impl error::Error for FromBase64Error {
             InvalidBase64Byte(_, _) => "invalid character",
             InvalidBase64Length => "invalid length",
         }
-    }
-
-    fn detail(&self) -> Option<String> {
-        Some(format!("{:?}", self))
     }
 }
 

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -61,7 +61,7 @@ pub trait FromHex {
 }
 
 /// Errors that can occur when decoding a hex encoded string
-#[derive(Copy)]
+#[derive(Copy, Show)]
 pub enum FromHexError {
     /// The input contained a character not part of the hex format
     InvalidHexCharacter(char, uint),
@@ -69,7 +69,7 @@ pub enum FromHexError {
     InvalidHexLength,
 }
 
-impl fmt::Show for FromHexError {
+impl fmt::Display for FromHexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             InvalidHexCharacter(ch, idx) =>
@@ -85,10 +85,6 @@ impl error::Error for FromHexError {
             InvalidHexCharacter(_, _) => "invalid character",
             InvalidHexLength => "invalid length",
         }
-    }
-
-    fn detail(&self) -> Option<String> {
-        Some(format!("{:?}", self))
     }
 }
 

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -235,7 +235,7 @@ pub struct AsJson<'a, T: 'a> { inner: &'a T }
 pub struct AsPrettyJson<'a, T: 'a> { inner: &'a T, indent: Option<uint> }
 
 /// The errors that can arise while parsing a JSON stream.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Show)]
 pub enum ErrorCode {
     InvalidSyntax,
     InvalidNumber,
@@ -325,7 +325,7 @@ pub fn encode<T: ::Encodable>(object: &T) -> string::String {
     s
 }
 
-impl fmt::Show for ErrorCode {
+impl fmt::Display for ErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         error_str(*self).fmt(f)
     }
@@ -335,14 +335,33 @@ fn io_error_to_error(io: io::IoError) -> ParserError {
     IoError(io.kind, io.desc)
 }
 
+impl fmt::Display for ParserError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // FIXME this should be a nicer error
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl fmt::Display for DecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // FIXME this should be a nicer error
+        fmt::Debug::fmt(self, f)
+    }
+}
+
 impl std::error::Error for DecoderError {
     fn description(&self) -> &str { "decoder error" }
-    fn detail(&self) -> Option<std::string::String> { Some(format!("{:?}", self)) }
+}
+
+impl fmt::Display for EncoderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // FIXME this should be a nicer error
+        fmt::Debug::fmt(self, f)
+    }
 }
 
 impl std::error::Error for EncoderError {
     fn description(&self) -> &str { "encoder error" }
-    fn detail(&self) -> Option<std::string::String> { Some(format!("{:?}", self)) }
 }
 
 impl std::error::FromError<fmt::Error> for EncoderError {
@@ -2519,7 +2538,7 @@ impl<'a, 'b> fmt::Writer for FormatShim<'a, 'b> {
     }
 }
 
-impl fmt::String for Json {
+impl fmt::Display for Json {
     /// Encodes a json value into a string
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut shim = FormatShim { inner: f };
@@ -2531,7 +2550,7 @@ impl fmt::String for Json {
     }
 }
 
-impl<'a> fmt::String for PrettyJson<'a> {
+impl<'a> fmt::Display for PrettyJson<'a> {
     /// Encodes a json value into a string
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut shim = FormatShim { inner: f };
@@ -2543,7 +2562,7 @@ impl<'a> fmt::String for PrettyJson<'a> {
     }
 }
 
-impl<'a, T: Encodable> fmt::String for AsJson<'a, T> {
+impl<'a, T: Encodable> fmt::Display for AsJson<'a, T> {
     /// Encodes a json value into a string
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut shim = FormatShim { inner: f };
@@ -2563,7 +2582,7 @@ impl<'a, T> AsPrettyJson<'a, T> {
     }
 }
 
-impl<'a, T: Encodable> fmt::String for AsPrettyJson<'a, T> {
+impl<'a, T: Encodable> fmt::Display for AsPrettyJson<'a, T> {
     /// Encodes a json value into a string
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut shim = FormatShim { inner: f };
@@ -3920,7 +3939,7 @@ mod tests {
         let mut mem_buf = Vec::new();
         let mut encoder = Encoder::new(&mut mem_buf as &mut fmt::Writer);
         let result = hm.encode(&mut encoder);
-        match result.unwrap_err() {
+        match result.err().unwrap() {
             EncoderError::BadHashmapKey => (),
             _ => panic!("expected bad hash map key")
         }

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -18,7 +18,7 @@ use borrow::BorrowFrom;
 use clone::Clone;
 use cmp::{max, Eq, PartialEq};
 use default::Default;
-use fmt::{self, Show};
+use fmt::{self, Debug};
 use hash::{self, Hash, SipHasher};
 use iter::{self, Iterator, ExactSizeIterator, IteratorExt, FromIterator, Extend, Map};
 use marker::Sized;
@@ -270,7 +270,7 @@ fn test_resize_policy() {
 /// ```
 /// use std::collections::HashMap;
 ///
-/// #[derive(Hash, Eq, PartialEq, Show)]
+/// #[derive(Hash, Eq, PartialEq, Debug)]
 /// struct Viking {
 ///     name: String,
 ///     country: String,
@@ -1216,8 +1216,8 @@ impl<K, V, S, H> Eq for HashMap<K, V, S>
 {}
 
 #[stable]
-impl<K, V, S, H> Show for HashMap<K, V, S>
-    where K: Eq + Hash<H> + Show, V: Show,
+impl<K, V, S, H> Debug for HashMap<K, V, S>
+    where K: Eq + Hash<H> + Debug, V: Debug,
           S: HashState<Hasher=H>,
           H: hash::Hasher<Output=u64>
 {
@@ -1996,8 +1996,8 @@ mod test_map {
 
         let map_str = format!("{:?}", map);
 
-        assert!(map_str == "HashMap {1i: 2i, 3i: 4i}" ||
-                map_str == "HashMap {3i: 4i, 1i: 2i}");
+        assert!(map_str == "HashMap {1: 2, 3: 4}" ||
+                map_str == "HashMap {3: 4, 1: 2}");
         assert_eq!(format!("{:?}", empty), "HashMap {}");
     }
 

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -15,7 +15,7 @@ use clone::Clone;
 use cmp::{Eq, PartialEq};
 use core::marker::Sized;
 use default::Default;
-use fmt::Show;
+use fmt::Debug;
 use fmt;
 use hash::{self, Hash};
 use iter::{Iterator, ExactSizeIterator, IteratorExt, FromIterator, Map, Chain, Extend};
@@ -71,7 +71,7 @@ use super::state::HashState;
 ///
 /// ```
 /// use std::collections::HashSet;
-/// #[derive(Hash, Eq, PartialEq, Show)]
+/// #[derive(Hash, Eq, PartialEq, Debug)]
 /// struct Viking<'a> {
 ///     name: &'a str,
 ///     power: uint,
@@ -596,8 +596,8 @@ impl<T, S, H> Eq for HashSet<T, S>
 {}
 
 #[stable]
-impl<T, S, H> fmt::Show for HashSet<T, S>
-    where T: Eq + Hash<H> + fmt::Show,
+impl<T, S, H> fmt::Debug for HashSet<T, S>
+    where T: Eq + Hash<H> + fmt::Debug,
           S: HashState<Hasher=H>,
           H: hash::Hasher<Output=u64>
 {
@@ -1179,7 +1179,7 @@ mod test_set {
 
         let set_str = format!("{:?}", set);
 
-        assert!(set_str == "HashSet {1i, 2i}" || set_str == "HashSet {2i, 1i}");
+        assert!(set_str == "HashSet {1, 2}" || set_str == "HashSet {2, 1}");
         assert_eq!(format!("{:?}", empty), "HashSet {}");
     }
 

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -119,7 +119,8 @@ impl Deref for CString {
     }
 }
 
-impl fmt::Show for CString {
+#[stable]
+impl fmt::Debug for CString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         String::from_utf8_lossy(self.as_bytes()).fmt(f)
     }
@@ -214,5 +215,11 @@ mod tests {
             let s = CString::from_vec_unchecked(vec![0]);
             assert_eq!(s.as_bytes(), b"\0");
         }
+    }
+
+    #[test]
+    fn formatted() {
+        let s = CString::from_slice(b"12");
+        assert_eq!(format!("{:?}", s), "\"12\"");
     }
 }

--- a/src/libstd/fmt.rs
+++ b/src/libstd/fmt.rs
@@ -123,8 +123,8 @@
 //! This allows multiple actual types to be formatted via `{:x}` (like `i8` as
 //! well as `int`).  The current mapping of types to traits is:
 //!
-//! * *nothing* ⇒ `String`
-//! * `?` ⇒ `Show`
+//! * *nothing* ⇒ `Display`
+//! * `?` ⇒ `Debug`
 //! * `o` ⇒ `Octal`
 //! * `x` ⇒ `LowerHex`
 //! * `X` ⇒ `UpperHex`
@@ -137,7 +137,7 @@
 //! `std::fmt::Binary` trait can then be formatted with `{:b}`. Implementations
 //! are provided for these traits for a number of primitive types by the
 //! standard library as well. If no format is specified (as in `{}` or `{:6}`),
-//! then the format trait used is the `String` trait.
+//! then the format trait used is the `Display` trait.
 //!
 //! When implementing a format trait for your own type, you will have to
 //! implement a method of the signature:
@@ -145,7 +145,7 @@
 //! ```rust
 //! # use std::fmt;
 //! # struct Foo; // our custom type
-//! # impl fmt::Show for Foo {
+//! # impl fmt::Display for Foo {
 //! fn fmt(&self, f: &mut std::fmt::Formatter) -> fmt::Result {
 //! # write!(f, "testing, testing")
 //! # } }
@@ -171,13 +171,13 @@
 //! use std::f64;
 //! use std::num::Float;
 //!
-//! #[derive(Show)]
+//! #[derive(Debug)]
 //! struct Vector2D {
 //!     x: int,
 //!     y: int,
 //! }
 //!
-//! impl fmt::String for Vector2D {
+//! impl fmt::Display for Vector2D {
 //!     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 //!         // The `f` value implements the `Writer` trait, which is what the
 //!         // write! macro is expecting. Note that this formatting ignores the
@@ -211,22 +211,22 @@
 //! }
 //! ```
 //!
-//! #### fmt::String vs fmt::Show
+//! #### fmt::Display vs fmt::Debug
 //!
 //! These two formatting traits have distinct purposes:
 //!
-//! - `fmt::String` implementations assert that the type can be faithfully
+//! - `fmt::Display` implementations assert that the type can be faithfully
 //!   represented as a UTF-8 string at all times. It is **not** expected that
-//!   all types implement the `String` trait.
-//! - `fmt::Show` implementations should be implemented for **all** public types.
+//!   all types implement the `Display` trait.
+//! - `fmt::Debug` implementations should be implemented for **all** public types.
 //!   Output will typically represent the internal state as faithfully as possible.
-//!   The purpose of the `Show` trait is to facilitate debugging Rust code. In
-//!   most cases, using `#[derive(Show)]` is sufficient and recommended.
+//!   The purpose of the `Debug` trait is to facilitate debugging Rust code. In
+//!   most cases, using `#[derive(Debug)]` is sufficient and recommended.
 //!
 //! Some examples of the output from both traits:
 //!
 //! ```
-//! assert_eq!(format!("{} {:?}", 3i32, 4i32), "3 4i32");
+//! assert_eq!(format!("{} {:?}", 3i32, 4i32), "3 4");
 //! assert_eq!(format!("{} {:?}", 'a', 'b'), "a 'b'");
 //! assert_eq!(format!("{} {:?}", "foo\n", "bar\n"), "foo\n \"bar\\n\"");
 //! ```
@@ -409,6 +409,7 @@ use string;
 
 pub use core::fmt::{Formatter, Result, Writer, rt};
 pub use core::fmt::{Show, String, Octal, Binary};
+pub use core::fmt::{Display, Debug};
 pub use core::fmt::{LowerHex, UpperHex, Pointer};
 pub use core::fmt::{LowerExp, UpperExp};
 pub use core::fmt::Error;

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -52,7 +52,8 @@ pub struct BufferedReader<R> {
     cap: uint,
 }
 
-impl<R> fmt::Show for BufferedReader<R> where R: fmt::Show {
+#[stable]
+impl<R> fmt::Debug for BufferedReader<R> where R: fmt::Debug {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "BufferedReader {{ reader: {:?}, buffer: {}/{} }}",
                self.inner, self.cap - self.pos, self.buf.len())
@@ -150,7 +151,8 @@ pub struct BufferedWriter<W> {
     pos: uint
 }
 
-impl<W> fmt::Show for BufferedWriter<W> where W: fmt::Show {
+#[stable]
+impl<W> fmt::Debug for BufferedWriter<W> where W: fmt::Debug {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "BufferedWriter {{ writer: {:?}, buffer: {}/{} }}",
                self.inner.as_ref().unwrap(), self.pos, self.buf.len())
@@ -249,7 +251,8 @@ pub struct LineBufferedWriter<W> {
     inner: BufferedWriter<W>,
 }
 
-impl<W> fmt::Show for LineBufferedWriter<W> where W: fmt::Show {
+#[stable]
+impl<W> fmt::Debug for LineBufferedWriter<W> where W: fmt::Debug {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "LineBufferedWriter {{ writer: {:?}, buffer: {}/{} }}",
                self.inner.inner, self.inner.pos, self.inner.buf.len())
@@ -339,7 +342,8 @@ pub struct BufferedStream<S> {
     inner: BufferedReader<InternalBufferedWriter<S>>
 }
 
-impl<S> fmt::Show for BufferedStream<S> where S: fmt::Show {
+#[stable]
+impl<S> fmt::Debug for BufferedStream<S> where S: fmt::Debug {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let reader = &self.inner;
         let writer = &self.inner.inner.0;

--- a/src/libstd/io/fs.rs
+++ b/src/libstd/io/fs.rs
@@ -156,7 +156,7 @@ impl File {
                 })
             }
         }).update_err("couldn't open path as file", |e| {
-            format!("{}; path={:?}; mode={}; access={}", e, path.display(),
+            format!("{}; path={}; mode={}; access={}", e, path.display(),
                 mode_string(mode), access_string(access))
         })
     }
@@ -211,7 +211,7 @@ impl File {
     pub fn fsync(&mut self) -> IoResult<()> {
         self.fd.fsync()
             .update_err("couldn't fsync file",
-                        |e| format!("{}; path={:?}", e, self.path.display()))
+                        |e| format!("{}; path={}", e, self.path.display()))
     }
 
     /// This function is similar to `fsync`, except that it may not synchronize
@@ -221,7 +221,7 @@ impl File {
     pub fn datasync(&mut self) -> IoResult<()> {
         self.fd.datasync()
             .update_err("couldn't datasync file",
-                        |e| format!("{}; path={:?}", e, self.path.display()))
+                        |e| format!("{}; path={}", e, self.path.display()))
     }
 
     /// Either truncates or extends the underlying file, updating the size of
@@ -235,7 +235,7 @@ impl File {
     pub fn truncate(&mut self, size: i64) -> IoResult<()> {
         self.fd.truncate(size)
             .update_err("couldn't truncate file", |e|
-                format!("{}; path={:?}; size={:?}", e, self.path.display(), size))
+                format!("{}; path={}; size={}", e, self.path.display(), size))
     }
 
     /// Returns true if the stream has reached the end of the file.
@@ -255,7 +255,7 @@ impl File {
     pub fn stat(&self) -> IoResult<FileStat> {
         self.fd.fstat()
             .update_err("couldn't fstat file", |e|
-                format!("{}; path={:?}", e, self.path.display()))
+                format!("{}; path={}", e, self.path.display()))
     }
 }
 
@@ -283,7 +283,7 @@ impl File {
 pub fn unlink(path: &Path) -> IoResult<()> {
     fs_imp::unlink(path)
            .update_err("couldn't unlink path", |e|
-               format!("{}; path={:?}", e, path.display()))
+               format!("{}; path={}", e, path.display()))
 }
 
 /// Given a path, query the file system to get information about a file,
@@ -310,7 +310,7 @@ pub fn unlink(path: &Path) -> IoResult<()> {
 pub fn stat(path: &Path) -> IoResult<FileStat> {
     fs_imp::stat(path)
            .update_err("couldn't stat path", |e|
-               format!("{}; path={:?}", e, path.display()))
+               format!("{}; path={}", e, path.display()))
 }
 
 /// Perform the same operation as the `stat` function, except that this
@@ -324,7 +324,7 @@ pub fn stat(path: &Path) -> IoResult<FileStat> {
 pub fn lstat(path: &Path) -> IoResult<FileStat> {
     fs_imp::lstat(path)
            .update_err("couldn't lstat path", |e|
-               format!("{}; path={:?}", e, path.display()))
+               format!("{}; path={}", e, path.display()))
 }
 
 /// Rename a file or directory to a new name.
@@ -424,14 +424,14 @@ pub fn copy(from: &Path, to: &Path) -> IoResult<()> {
 pub fn chmod(path: &Path, mode: io::FilePermission) -> IoResult<()> {
     fs_imp::chmod(path, mode.bits() as uint)
            .update_err("couldn't chmod path", |e|
-               format!("{}; path={:?}; mode={:?}", e, path.display(), mode))
+               format!("{}; path={}; mode={:?}", e, path.display(), mode))
 }
 
 /// Change the user and group owners of a file at the specified path.
 pub fn chown(path: &Path, uid: int, gid: int) -> IoResult<()> {
     fs_imp::chown(path, uid, gid)
            .update_err("couldn't chown path", |e|
-               format!("{}; path={:?}; uid={}; gid={}", e, path.display(), uid, gid))
+               format!("{}; path={}; uid={}; gid={}", e, path.display(), uid, gid))
 }
 
 /// Creates a new hard link on the filesystem. The `dst` path will be a
@@ -460,7 +460,7 @@ pub fn symlink(src: &Path, dst: &Path) -> IoResult<()> {
 pub fn readlink(path: &Path) -> IoResult<Path> {
     fs_imp::readlink(path)
            .update_err("couldn't resolve symlink for path", |e|
-               format!("{}; path={:?}", e, path.display()))
+               format!("{}; path={}", e, path.display()))
 }
 
 /// Create a new, empty directory at the provided path
@@ -483,7 +483,7 @@ pub fn readlink(path: &Path) -> IoResult<Path> {
 pub fn mkdir(path: &Path, mode: FilePermission) -> IoResult<()> {
     fs_imp::mkdir(path, mode.bits() as uint)
            .update_err("couldn't create directory", |e|
-               format!("{}; path={:?}; mode={:?}", e, path.display(), mode))
+               format!("{}; path={}; mode={}", e, path.display(), mode))
 }
 
 /// Remove an existing, empty directory
@@ -505,7 +505,7 @@ pub fn mkdir(path: &Path, mode: FilePermission) -> IoResult<()> {
 pub fn rmdir(path: &Path) -> IoResult<()> {
     fs_imp::rmdir(path)
            .update_err("couldn't remove directory", |e|
-               format!("{}; path={:?}", e, path.display()))
+               format!("{}; path={}", e, path.display()))
 }
 
 /// Retrieve a vector containing all entries within a provided directory
@@ -545,7 +545,7 @@ pub fn rmdir(path: &Path) -> IoResult<()> {
 pub fn readdir(path: &Path) -> IoResult<Vec<Path>> {
     fs_imp::readdir(path)
            .update_err("couldn't read directory",
-                       |e| format!("{}; path={:?}", e, path.display()))
+                       |e| format!("{}; path={}", e, path.display()))
 }
 
 /// Returns an iterator that will recursively walk the directory structure
@@ -555,7 +555,7 @@ pub fn readdir(path: &Path) -> IoResult<Vec<Path>> {
 pub fn walk_dir(path: &Path) -> IoResult<Directories> {
     Ok(Directories {
         stack: try!(readdir(path).update_err("couldn't walk directory",
-                                             |e| format!("{}; path={:?}", e, path.display())))
+                                             |e| format!("{}; path={}", e, path.display())))
     })
 }
 
@@ -605,7 +605,7 @@ pub fn mkdir_recursive(path: &Path, mode: FilePermission) -> IoResult<()> {
 
         let result = mkdir(&curpath, mode)
             .update_err("couldn't recursively mkdir",
-                        |e| format!("{}; path={:?}", e, path.display()));
+                        |e| format!("{}; path={}", e, path.display()));
 
         match result {
             Err(mkdir_err) => {
@@ -632,7 +632,7 @@ pub fn rmdir_recursive(path: &Path) -> IoResult<()> {
     rm_stack.push(path.clone());
 
     fn rmdir_failed(err: &IoError, path: &Path) -> String {
-        format!("rmdir_recursive failed; path={:?}; cause={}",
+        format!("rmdir_recursive failed; path={}; cause={}",
                 path.display(), err)
     }
 
@@ -692,14 +692,14 @@ pub fn rmdir_recursive(path: &Path) -> IoResult<()> {
 pub fn change_file_times(path: &Path, atime: u64, mtime: u64) -> IoResult<()> {
     fs_imp::utime(path, atime, mtime)
            .update_err("couldn't change_file_times", |e|
-               format!("{}; path={:?}", e, path.display()))
+               format!("{}; path={}", e, path.display()))
 }
 
 impl Reader for File {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
         fn update_err<T>(result: IoResult<T>, file: &File) -> IoResult<T> {
             result.update_err("couldn't read file",
-                              |e| format!("{}; path={:?}",
+                              |e| format!("{}; path={}",
                                           e, file.path.display()))
         }
 
@@ -722,7 +722,7 @@ impl Writer for File {
     fn write(&mut self, buf: &[u8]) -> IoResult<()> {
         self.fd.write(buf)
             .update_err("couldn't write to file",
-                        |e| format!("{}; path={:?}", e, self.path.display()))
+                        |e| format!("{}; path={}", e, self.path.display()))
     }
 }
 
@@ -730,7 +730,7 @@ impl Seek for File {
     fn tell(&self) -> IoResult<u64> {
         self.fd.tell()
             .update_err("couldn't retrieve file cursor (`tell`)",
-                        |e| format!("{}; path={:?}", e, self.path.display()))
+                        |e| format!("{}; path={}", e, self.path.display()))
     }
 
     fn seek(&mut self, pos: i64, style: SeekStyle) -> IoResult<()> {
@@ -743,7 +743,7 @@ impl Seek for File {
             Err(e) => Err(e),
         };
         err.update_err("couldn't seek in file",
-                       |e| format!("{}; path={:?}", e, self.path.display()))
+                       |e| format!("{}; path={}", e, self.path.display()))
     }
 }
 
@@ -906,7 +906,7 @@ mod test {
         if cfg!(unix) {
             error!(result, "no such file or directory");
         }
-        error!(result, format!("path={:?}; mode=open; access=read", filename.display()));
+        error!(result, format!("path={}; mode=open; access=read", filename.display()));
     }
 
     #[test]
@@ -920,7 +920,7 @@ mod test {
         if cfg!(unix) {
             error!(result, "no such file or directory");
         }
-        error!(result, format!("path={:?}", filename.display()));
+        error!(result, format!("path={}", filename.display()));
     }
 
     #[test]
@@ -1188,7 +1188,7 @@ mod test {
         error!(result, "couldn't recursively mkdir");
         error!(result, "couldn't create directory");
         error!(result, "mode=0700");
-        error!(result, format!("path={:?}", file.display()));
+        error!(result, format!("path={}", file.display()));
     }
 
     #[test]

--- a/src/libstd/io/mem.rs
+++ b/src/libstd/io/mem.rs
@@ -432,8 +432,8 @@ mod test {
             writer.write(&[]).unwrap();
             assert_eq!(writer.tell(), Ok(8));
 
-            assert_eq!(writer.write(&[8, 9]).unwrap_err().kind, io::ShortWrite(1));
-            assert_eq!(writer.write(&[10]).unwrap_err().kind, io::EndOfFile);
+            assert_eq!(writer.write(&[8, 9]).err().unwrap().kind, io::ShortWrite(1));
+            assert_eq!(writer.write(&[10]).err().unwrap().kind, io::EndOfFile);
         }
         let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7, 8];
         assert_eq!(buf, b);

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -228,13 +228,12 @@ pub use self::FileAccess::*;
 pub use self::IoErrorKind::*;
 
 use char::CharExt;
-use clone::Clone;
 use default::Default;
-use error::{FromError, Error};
+use error::Error;
 use fmt;
 use int;
 use iter::{Iterator, IteratorExt};
-use marker::{Sized, Send};
+use marker::Sized;
 use mem::transmute;
 use ops::FnOnce;
 use option::Option;
@@ -340,7 +339,8 @@ impl IoError {
     }
 }
 
-impl fmt::String for IoError {
+#[stable]
+impl fmt::Display for IoError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             IoError { kind: OtherIoError, desc: "unknown error", detail: Some(ref detail) } =>
@@ -354,19 +354,7 @@ impl fmt::String for IoError {
 }
 
 impl Error for IoError {
-    fn description(&self) -> &str {
-        self.desc
-    }
-
-    fn detail(&self) -> Option<String> {
-        self.detail.clone()
-    }
-}
-
-impl FromError<IoError> for Box<Error + Send> {
-    fn from_error(err: IoError) -> Box<Error + Send> {
-        box err
-    }
+    fn description(&self) -> &str { self.desc }
 }
 
 /// A list specifying general categories of I/O error.
@@ -1781,6 +1769,7 @@ pub struct UnstableFileStat {
 bitflags! {
     /// A set of permissions for a file or directory is represented by a set of
     /// flags which are or'd together.
+    #[derive(Show)]
     flags FilePermission: u32 {
         const USER_READ     = 0o400,
         const USER_WRITE    = 0o200,
@@ -1822,13 +1811,8 @@ impl Default for FilePermission {
     fn default() -> FilePermission { FilePermission::empty() }
 }
 
-impl fmt::Show for FilePermission {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
-    }
-}
-
-impl fmt::String for FilePermission {
+#[stable]
+impl fmt::Display for FilePermission {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:04o}", self.bits)
     }

--- a/src/libstd/io/net/ip.rs
+++ b/src/libstd/io/net/ip.rs
@@ -38,7 +38,8 @@ pub enum IpAddr {
     Ipv6Addr(u16, u16, u16, u16, u16, u16, u16, u16)
 }
 
-impl fmt::String for IpAddr {
+#[stable]
+impl fmt::Display for IpAddr {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Ipv4Addr(a, b, c, d) =>
@@ -69,7 +70,8 @@ pub struct SocketAddr {
     pub port: Port,
 }
 
-impl fmt::String for SocketAddr {
+#[stable]
+impl fmt::Display for SocketAddr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.ip {
             Ipv4Addr(..) => write!(f, "{}:{}", self.ip, self.port),

--- a/src/libstd/io/process.rs
+++ b/src/libstd/io/process.rs
@@ -397,7 +397,7 @@ impl Command {
     }
 }
 
-impl fmt::String for Command {
+impl fmt::Debug for Command {
     /// Format the program and arguments of a Command for display. Any
     /// non-utf8 data is lossily converted using the utf8 replacement
     /// character.
@@ -496,7 +496,7 @@ pub enum StdioContainer {
 
 /// Describes the result of a process after it has terminated.
 /// Note that Windows have no signals, so the result is usually ExitStatus.
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Show)]
 pub enum ProcessExit {
     /// Normal termination with an exit status.
     ExitStatus(int),
@@ -505,15 +505,8 @@ pub enum ProcessExit {
     ExitSignal(int),
 }
 
-impl fmt::Show for ProcessExit {
-    /// Format a ProcessExit enum, to nicely present the information.
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
-    }
-}
-
-
-impl fmt::String for ProcessExit {
+#[stable]
+impl fmt::Display for ProcessExit {
     /// Format a ProcessExit enum, to nicely present the information.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -168,6 +168,7 @@ pub use core::raw;
 pub use core::simd;
 pub use core::result;
 pub use core::option;
+pub use core::error;
 
 #[cfg(not(test))] pub use alloc::boxed;
 pub use alloc::rc;
@@ -228,7 +229,6 @@ pub mod thunk;
 
 /* Common traits */
 
-pub mod error;
 pub mod num;
 
 /* Runtime and platform support */

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -16,7 +16,7 @@
 #![stable]
 #![allow(missing_docs)]
 
-#[cfg(test)] use fmt::Show;
+#[cfg(test)] use fmt::Debug;
 use ops::{Add, Sub, Mul, Div, Rem, Neg};
 
 use marker::Copy;
@@ -322,7 +322,7 @@ pub fn test_num<T>(ten: T, two: T) where
     T: PartialEq + NumCast
      + Add<Output=T> + Sub<Output=T>
      + Mul<Output=T> + Div<Output=T>
-     + Rem<Output=T> + Show
+     + Rem<Output=T> + Debug
      + Copy
 {
     assert_eq!(ten.add(two),  cast(12i).unwrap());

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -855,7 +855,7 @@ pub enum MapOption {
 impl Copy for MapOption {}
 
 /// Possible errors when creating a map.
-#[derive(Copy)]
+#[derive(Copy, Show)]
 pub enum MapError {
     /// # The following are POSIX-specific
     ///
@@ -900,7 +900,8 @@ pub enum MapError {
     ErrMapViewOfFile(uint)
 }
 
-impl fmt::Show for MapError {
+#[stable]
+impl fmt::Display for MapError {
     fn fmt(&self, out: &mut fmt::Formatter) -> fmt::Result {
         let str = match *self {
             ErrFdNotAvail => "fd not available for reading or writing",
@@ -934,13 +935,6 @@ impl fmt::Show for MapError {
 
 impl Error for MapError {
     fn description(&self) -> &str { "memory map error" }
-    fn detail(&self) -> Option<String> { Some(format!("{:?}", self)) }
-}
-
-impl FromError<MapError> for Box<Error + Send> {
-    fn from_error(err: MapError) -> Box<Error + Send> {
-        box err
-    }
 }
 
 // Round up `from` to be divisible by `to`

--- a/src/libstd/path/mod.rs
+++ b/src/libstd/path/mod.rs
@@ -823,13 +823,15 @@ pub struct Display<'a, P:'a> {
     filename: bool
 }
 
-impl<'a, P: GenericPath> fmt::Show for Display<'a, P> {
+#[stable]
+impl<'a, P: GenericPath> fmt::Debug for Display<'a, P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
+        fmt::Debug::fmt(&self.as_cow(), f)
     }
 }
 
-impl<'a, P: GenericPath> fmt::String for Display<'a, P> {
+#[stable]
+impl<'a, P: GenericPath> fmt::Display for Display<'a, P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.as_cow().fmt(f)
     }

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -57,9 +57,10 @@ pub fn is_sep(c: char) -> bool {
     c == SEP
 }
 
-impl fmt::Show for Path {
+#[stable]
+impl fmt::Debug for Path {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Show::fmt(&self.display(), f)
+        fmt::Debug::fmt(&self.display(), f)
     }
 }
 

--- a/src/libstd/path/windows.rs
+++ b/src/libstd/path/windows.rs
@@ -85,9 +85,10 @@ pub struct Path {
     sepidx: Option<uint> // index of the final separator in the non-prefix portion of repr
 }
 
-impl fmt::Show for Path {
+#[stable]
+impl fmt::Debug for Path {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Show::fmt(&self.display(), f)
+        fmt::Debug::fmt(&self.display(), f)
     }
 }
 

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -393,7 +393,7 @@ impl<T> !marker::Sync for SyncSender<T> {}
 /// A `send` operation can only fail if the receiving end of a channel is
 /// disconnected, implying that the data could never be received. The error
 /// contains the data being sent as a payload so it can be recovered.
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Show)]
 #[stable]
 pub struct SendError<T>(pub T);
 
@@ -401,13 +401,13 @@ pub struct SendError<T>(pub T);
 ///
 /// The `recv` operation can only fail if the sending half of a channel is
 /// disconnected, implying that no further messages will ever be received.
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Show)]
 #[stable]
 pub struct RecvError;
 
 /// This enumeration is the list of the possible reasons that try_recv could not
 /// return data when called.
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Clone, Copy, Show)]
 #[stable]
 pub enum TryRecvError {
     /// This channel is currently empty, but the sender(s) have not yet
@@ -423,7 +423,7 @@ pub enum TryRecvError {
 
 /// This enumeration is the list of the possible error outcomes for the
 /// `SyncSender::try_send` method.
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Show)]
 #[stable]
 pub enum TrySendError<T> {
     /// The data could not be sent on the channel because it would require that
@@ -998,13 +998,15 @@ unsafe impl<T:Send> Send for RacyCell<T> { }
 
 unsafe impl<T> Sync for RacyCell<T> { } // Oh dear
 
-impl<T> fmt::Show for SendError<T> {
+#[stable]
+impl<T> fmt::Display for SendError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         "sending on a closed channel".fmt(f)
     }
 }
 
-impl<T> fmt::Show for TrySendError<T> {
+#[stable]
+impl<T> fmt::Display for TrySendError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TrySendError::Full(..) => {
@@ -1017,13 +1019,15 @@ impl<T> fmt::Show for TrySendError<T> {
     }
 }
 
-impl fmt::Show for RecvError {
+#[stable]
+impl fmt::Display for RecvError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         "receiving on a closed channel".fmt(f)
     }
 }
 
-impl fmt::Show for TryRecvError {
+#[stable]
+impl fmt::Display for TryRecvError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TryRecvError::Empty => {

--- a/src/libstd/sync/poison.rs
+++ b/src/libstd/sync/poison.rs
@@ -53,6 +53,7 @@ pub struct Guard {
 /// is held. The precise semantics for when a lock is poisoned is documented on
 /// each lock, but once a lock is poisoned then all future acquisitions will
 /// return this error.
+#[derive(Show)]
 #[stable]
 pub struct PoisonError<T> {
     guard: T,
@@ -60,6 +61,7 @@ pub struct PoisonError<T> {
 
 /// An enumeration of possible errors which can occur while calling the
 /// `try_lock` method.
+#[derive(Show)]
 #[stable]
 pub enum TryLockError<T> {
     /// The lock could not be acquired because another task failed while holding
@@ -90,7 +92,8 @@ pub type LockResult<Guard> = Result<Guard, PoisonError<Guard>>;
 #[stable]
 pub type TryLockResult<Guard> = Result<Guard, TryLockError<Guard>>;
 
-impl<T> fmt::Show for PoisonError<T> {
+#[stable]
+impl<T> fmt::Display for PoisonError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.description().fmt(f)
     }
@@ -130,7 +133,8 @@ impl<T> FromError<PoisonError<T>> for TryLockError<T> {
     }
 }
 
-impl<T> fmt::Show for TryLockError<T> {
+#[stable]
+impl<T> fmt::Display for TryLockError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.description().fmt(f)
     }

--- a/src/libstd/thread.rs
+++ b/src/libstd/thread.rs
@@ -519,14 +519,14 @@ mod test {
     fn test_unnamed_thread() {
         Thread::scoped(move|| {
             assert!(Thread::current().name().is_none());
-        }).join().map_err(|_| ()).unwrap();
+        }).join().ok().unwrap();
     }
 
     #[test]
     fn test_named_thread() {
         Builder::new().name("ada lovelace".to_string()).scoped(move|| {
             assert!(Thread::current().name().unwrap() == "ada lovelace".to_string());
-        }).join().map_err(|_| ()).unwrap();
+        }).join().ok().unwrap();
     }
 
     #[test]
@@ -662,7 +662,7 @@ mod test {
             Err(e) => {
                 type T = &'static str;
                 assert!(e.is::<T>());
-                assert_eq!(*e.downcast::<T>().unwrap(), "static string");
+                assert_eq!(*e.downcast::<T>().ok().unwrap(), "static string");
             }
             Ok(()) => panic!()
         }
@@ -676,7 +676,7 @@ mod test {
             Err(e) => {
                 type T = String;
                 assert!(e.is::<T>());
-                assert_eq!(*e.downcast::<T>().unwrap(), "owned string".to_string());
+                assert_eq!(*e.downcast::<T>().ok().unwrap(), "owned string".to_string());
             }
             Ok(()) => panic!()
         }
@@ -690,9 +690,9 @@ mod test {
             Err(e) => {
                 type T = Box<Any + Send>;
                 assert!(e.is::<T>());
-                let any = e.downcast::<T>().unwrap();
+                let any = e.downcast::<T>().ok().unwrap();
                 assert!(any.is::<u16>());
-                assert_eq!(*any.downcast::<u16>().unwrap(), 413u16);
+                assert_eq!(*any.downcast::<u16>().ok().unwrap(), 413u16);
             }
             Ok(()) => panic!()
         }

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -334,7 +334,8 @@ impl Div<i32> for Duration {
     }
 }
 
-impl fmt::String for Duration {
+#[stable]
+impl fmt::Display for Duration {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // technically speaking, negative duration is not valid ISO 8601,
         // but we need to print it anyway.

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -15,7 +15,7 @@ pub use self::AbiArchitecture::*;
 
 use std::fmt;
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, PartialEq, Eq, Show)]
 pub enum Os {
     OsWindows,
     OsMacos,
@@ -26,7 +26,7 @@ pub enum Os {
     OsDragonfly,
 }
 
-#[derive(PartialEq, Eq, Hash, RustcEncodable, RustcDecodable, Clone, Copy)]
+#[derive(PartialEq, Eq, Hash, RustcEncodable, RustcDecodable, Clone, Copy, Show)]
 pub enum Abi {
     // NB: This ordering MUST match the AbiDatas array below.
     // (This is ensured by the test indices_are_correct().)
@@ -119,25 +119,13 @@ impl Abi {
     }
 }
 
-impl fmt::Show for Abi {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
-    }
-}
-
-impl fmt::String for Abi {
+impl fmt::Display for Abi {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "\"{}\"", self.name())
     }
 }
 
-impl fmt::Show for Os {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
-    }
-}
-
-impl fmt::String for Os {
+impl fmt::Display for Os {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             OsLinux => "linux".fmt(f),

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -100,28 +100,28 @@ impl Ident {
     }
 }
 
-impl fmt::Show for Ident {
+impl fmt::Debug for Ident {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}#{}", self.name, self.ctxt)
     }
 }
 
-impl fmt::String for Ident {
+impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(&self.name, f)
+        fmt::Display::fmt(&self.name, f)
     }
 }
 
-impl fmt::Show for Name {
+impl fmt::Debug for Name {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Name(nm) = *self;
         write!(f, "{:?}({})", token::get_name(*self).get(), nm)
     }
 }
 
-impl fmt::String for Name {
+impl fmt::Display for Name {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(token::get_name(*self).get(), f)
+        fmt::Display::fmt(token::get_name(*self).get(), f)
     }
 }
 
@@ -1100,13 +1100,13 @@ impl PartialEq for IntTy {
     }
 }
 
-impl fmt::Show for IntTy {
+impl fmt::Debug for IntTy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
+        fmt::Display::fmt(self, f)
     }
 }
 
-impl fmt::String for IntTy {
+impl fmt::Display for IntTy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ast_util::int_ty_to_string(*self, None))
     }
@@ -1155,13 +1155,13 @@ impl UintTy {
     }
 }
 
-impl fmt::Show for UintTy {
+impl fmt::Debug for UintTy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
+        fmt::Display::fmt(self, f)
     }
 }
 
-impl fmt::String for UintTy {
+impl fmt::Display for UintTy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ast_util::uint_ty_to_string(*self, None))
     }
@@ -1173,13 +1173,13 @@ pub enum FloatTy {
     TyF64,
 }
 
-impl fmt::Show for FloatTy {
+impl fmt::Debug for FloatTy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
+        fmt::Display::fmt(self, f)
     }
 }
 
-impl fmt::String for FloatTy {
+impl fmt::Display for FloatTy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", ast_util::float_ty_to_string(*self))
     }
@@ -1222,24 +1222,15 @@ pub enum PrimTy {
     TyChar
 }
 
-#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Copy)]
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Copy, Show)]
 pub enum Onceness {
     Once,
     Many
 }
 
-impl fmt::Show for Onceness {
+impl fmt::Display for Onceness {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(match *self {
-            Once => "once",
-            Many => "many",
-        }, f)
-    }
-}
-
-impl fmt::String for Onceness {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(match *self {
+        fmt::Display::fmt(match *self {
             Once => "once",
             Many => "many",
         }, f)
@@ -1358,9 +1349,9 @@ pub enum Unsafety {
     Normal,
 }
 
-impl fmt::String for Unsafety {
+impl fmt::Display for Unsafety {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(match *self {
+        fmt::Display::fmt(match *self {
             Unsafety::Normal => "normal",
             Unsafety::Unsafe => "unsafe",
         }, f)
@@ -1375,7 +1366,7 @@ pub enum ImplPolarity {
     Negative,
 }
 
-impl fmt::Show for ImplPolarity {
+impl fmt::Debug for ImplPolarity {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             ImplPolarity::Positive => "positive".fmt(f),

--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -46,7 +46,7 @@ impl PathElem {
     }
 }
 
-impl fmt::String for PathElem {
+impl fmt::Display for PathElem {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let slot = token::get_name(self.name());
         write!(f, "{}", slot)

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -358,9 +358,9 @@ pub enum StabilityLevel {
     Locked
 }
 
-impl fmt::String for StabilityLevel {
+impl fmt::Display for StabilityLevel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Show::fmt(self, f)
+        fmt::Debug::fmt(self, f)
     }
 }
 

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -235,9 +235,9 @@ pub enum Level {
     Help,
 }
 
-impl fmt::String for Level {
+impl fmt::Display for Level {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use std::fmt::String;
+        use std::fmt::Display;
 
         match *self {
             Bug => "error: internal compiler error".fmt(f),

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -99,7 +99,9 @@ pub fn expand_meta_derive(cx: &mut ExtCtxt,
 
                             "Rand" => expand!(rand::expand_deriving_rand),
 
+                            // NOTE(stage0): remove "Show"
                             "Show" => expand!(show::expand_deriving_show),
+                            "Debug" => expand!(show::expand_deriving_show),
 
                             "Default" => expand!(default::expand_deriving_default),
 

--- a/src/libsyntax/ext/deriving/show.rs
+++ b/src/libsyntax/ext/deriving/show.rs
@@ -35,7 +35,7 @@ pub fn expand_deriving_show<F>(cx: &mut ExtCtxt,
     let trait_def = TraitDef {
         span: span,
         attributes: Vec::new(),
-        path: Path::new(vec!("std", "fmt", "Show")),
+        path: Path::new(vec!("std", "fmt", "Debug")),
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         methods: vec!(
@@ -67,7 +67,7 @@ fn show_substructure(cx: &mut ExtCtxt, span: Span,
         Struct(_) => substr.type_ident,
         EnumMatching(_, v, _) => v.node.name,
         EnumNonMatchingCollapsed(..) | StaticStruct(..) | StaticEnum(..) => {
-            cx.span_bug(span, "nonsensical .fields in `#[derive(Show)]`")
+            cx.span_bug(span, "nonsensical .fields in `#[derive(Debug)]`")
         }
     };
 

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -603,8 +603,8 @@ impl<'a, 'b> Context<'a, 'b> {
         let trait_ = match *ty {
             Known(ref tyname) => {
                 match &tyname[] {
-                    ""  => "String",
-                    "?" => "Show",
+                    ""  => "Display",
+                    "?" => "Debug",
                     "e" => "LowerExp",
                     "E" => "UpperExp",
                     "o" => "Octal",

--- a/src/libsyntax/owned_slice.rs
+++ b/src/libsyntax/owned_slice.rs
@@ -22,7 +22,7 @@ pub struct OwnedSlice<T> {
     data: Box<[T]>
 }
 
-impl<T:fmt::Show> fmt::Show for OwnedSlice<T> {
+impl<T:fmt::Debug> fmt::Debug for OwnedSlice<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         self.data.fmt(fmt)
     }

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -586,10 +586,10 @@ impl<'a> StringReader<'a> {
     /// `\x00` marker.
     #[inline(never)]
     fn scan_embedded_hygienic_ident(&mut self) -> ast::Ident {
-        fn bump_expecting_char<'a,D:fmt::Show>(r: &mut StringReader<'a>,
-                                               c: char,
-                                               described_c: D,
-                                               whence: &str) {
+        fn bump_expecting_char<'a,D:fmt::Debug>(r: &mut StringReader<'a>,
+                                                c: char,
+                                                described_c: D,
+                                                whence: &str) {
             match r.curr {
                 Some(r_c) if r_c == c => r.bump(),
                 Some(r_c) => panic!("expected {:?}, hit {:?}, {}", described_c, r_c, whence),

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -375,7 +375,7 @@ pub enum Nonterminal {
     NtTT(P<ast::TokenTree>), // needs P'ed to break a circularity
 }
 
-impl fmt::Show for Nonterminal {
+impl fmt::Debug for Nonterminal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             NtItem(..) => f.pad("NtItem(..)"),
@@ -651,15 +651,15 @@ impl BytesContainer for InternedString {
     }
 }
 
-impl fmt::Show for InternedString {
+impl fmt::Debug for InternedString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self, f)
+        fmt::Debug::fmt(&self.string[], f)
     }
 }
 
-impl fmt::String for InternedString {
+impl fmt::Display for InternedString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", &self.string[])
+        fmt::Display::fmt(&self.string[], f)
     }
 }
 

--- a/src/libsyntax/ptr.rs
+++ b/src/libsyntax/ptr.rs
@@ -36,7 +36,7 @@
 //!   implementation changes (using a special thread-local heap, for example).
 //!   Moreover, a switch to, e.g. `P<'a, T>` would be easy and mostly automated.
 
-use std::fmt::{self, Show};
+use std::fmt::{self, Display, Debug};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::ptr;
@@ -100,9 +100,14 @@ impl<T: PartialEq> PartialEq for P<T> {
 
 impl<T: Eq> Eq for P<T> {}
 
-impl<T: Show> Show for P<T> {
+impl<T: Debug> Debug for P<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        (**self).fmt(f)
+        Debug::fmt(&**self, f)
+    }
+}
+impl<T: Display> Display for P<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&**self, f)
     }
 }
 

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -114,9 +114,16 @@ impl Ord for RcStr {
     }
 }
 
-impl fmt::Show for RcStr {
+impl fmt::Debug for RcStr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use std::fmt::Show;
+        use std::fmt::Debug;
+        self[].fmt(f)
+    }
+}
+
+impl fmt::Display for RcStr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use std::fmt::Display;
         self[].fmt(f)
     }
 }

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -197,7 +197,7 @@ impl<T: Writer+Send> TerminfoTerminal<T> {
         let mut file = entry.unwrap();
         let ti = parse(&mut file, false);
         if ti.is_err() {
-            debug!("error parsing terminfo entry: {:?}", ti.unwrap_err());
+            debug!("error parsing terminfo entry: {:?}", ti.err().unwrap());
             return None;
         }
 

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -624,7 +624,7 @@ mod test {
             };
             let res = get_res("%p1", cap, &[p], vars);
             assert!(res.is_ok(),
-                    "Op {} failed with 1 stack entry: {}", cap, res.unwrap_err());
+                    "Op {} failed with 1 stack entry: {}", cap, res.err().unwrap());
         }
         let caps = ["%+", "%-", "%*", "%/", "%m", "%&", "%|", "%A", "%O"];
         for &cap in caps.iter() {
@@ -636,7 +636,7 @@ mod test {
                     "Binop {} succeeded incorrectly with 1 stack entry", cap);
             let res = get_res("%{1}%{2}", cap, &[], vars);
             assert!(res.is_ok(),
-                    "Binop {} failed with 2 stack entries: {:?}", cap, res.unwrap_err());
+                    "Binop {} failed with 2 stack entries: {:?}", cap, res.err().unwrap());
         }
     }
 
@@ -651,15 +651,15 @@ mod test {
         for &(op, bs) in v.iter() {
             let s = format!("%{{1}}%{{2}}%{}%d", op);
             let res = expand(s.as_bytes(), &[], &mut Variables::new());
-            assert!(res.is_ok(), res.unwrap_err());
+            assert!(res.is_ok(), res.err().unwrap());
             assert_eq!(res.unwrap(), vec!(b'0' + bs[0]));
             let s = format!("%{{1}}%{{1}}%{}%d", op);
             let res = expand(s.as_bytes(), &[], &mut Variables::new());
-            assert!(res.is_ok(), res.unwrap_err());
+            assert!(res.is_ok(), res.err().unwrap());
             assert_eq!(res.unwrap(), vec!(b'0' + bs[1]));
             let s = format!("%{{2}}%{{1}}%{}%d", op);
             let res = expand(s.as_bytes(), &[], &mut Variables::new());
-            assert!(res.is_ok(), res.unwrap_err());
+            assert!(res.is_ok(), res.err().unwrap());
             assert_eq!(res.unwrap(), vec!(b'0' + bs[2]));
         }
     }
@@ -669,15 +669,15 @@ mod test {
         let mut vars = Variables::new();
         let s = b"\\E[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m";
         let res = expand(s, &[Number(1)], &mut vars);
-        assert!(res.is_ok(), res.unwrap_err());
+        assert!(res.is_ok(), res.err().unwrap());
         assert_eq!(res.unwrap(),
                    "\\E[31m".bytes().collect::<Vec<_>>());
         let res = expand(s, &[Number(8)], &mut vars);
-        assert!(res.is_ok(), res.unwrap_err());
+        assert!(res.is_ok(), res.err().unwrap());
         assert_eq!(res.unwrap(),
                    "\\E[90m".bytes().collect::<Vec<_>>());
         let res = expand(s, &[Number(42)], &mut vars);
-        assert!(res.is_ok(), res.unwrap_err());
+        assert!(res.is_ok(), res.err().unwrap());
         assert_eq!(res.unwrap(),
                    "\\E[38;5;42m".bytes().collect::<Vec<_>>());
     }

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -63,7 +63,6 @@ use std::any::Any;
 use std::cmp;
 use std::collections::BTreeMap;
 use std::f64;
-use std::fmt::Show;
 use std::fmt;
 use std::io::fs::PathExtensions;
 use std::io::stdio::StdWriter;
@@ -109,9 +108,9 @@ impl TestName {
         }
     }
 }
-impl fmt::String for TestName {
+impl fmt::Display for TestName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::String::fmt(self.as_slice(), f)
+        fmt::Display::fmt(self.as_slice(), f)
     }
 }
 
@@ -172,7 +171,7 @@ impl TestFn {
     }
 }
 
-impl fmt::Show for TestFn {
+impl fmt::Debug for TestFn {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match *self {
             StaticTestFn(..) => "StaticTestFn(..)",

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -333,7 +333,7 @@ pub fn winsorize<T: Float + FromPrimitive>(samples: &mut [T], pct: T) {
 }
 
 /// Render writes the min, max and quartiles of the provided `Summary` to the provided `Writer`.
-pub fn write_5_number_summary<W: Writer, T: Float + fmt::String + fmt::Show>(w: &mut W,
+pub fn write_5_number_summary<W: Writer, T: Float + fmt::Display + fmt::Debug>(w: &mut W,
                                                           s: &Summary<T>) -> io::IoResult<()> {
     let (q1,q2,q3) = s.quartiles;
     write!(w, "(min={}, q1={}, med={}, q3={}, max={})",
@@ -355,7 +355,7 @@ pub fn write_5_number_summary<W: Writer, T: Float + fmt::String + fmt::Show>(w: 
 /// ```{.ignore}
 ///   10 |        [--****#******----------]          | 40
 /// ```
-pub fn write_boxplot<W: Writer, T: Float + fmt::String + fmt::Show + FromPrimitive>(
+pub fn write_boxplot<W: Writer, T: Float + fmt::Display + fmt::Debug + FromPrimitive>(
                      w: &mut W,
                      s: &Summary<T>,
                      width_hint: uint)

--- a/src/test/compile-fail/dst-index.rs
+++ b/src/test/compile-fail/dst-index.rs
@@ -12,7 +12,7 @@
 // can't be used as rvalues
 
 use std::ops::Index;
-use std::fmt::Show;
+use std::fmt::Debug;
 
 struct S;
 
@@ -31,9 +31,9 @@ struct T;
 impl Copy for T {}
 
 impl Index<usize> for T {
-    type Output = Show + 'static;
+    type Output = Debug + 'static;
 
-    fn index<'a>(&'a self, idx: &usize) -> &'a (Show + 'static) {
+    fn index<'a>(&'a self, idx: &usize) -> &'a (Debug + 'static) {
         static x: usize = 42;
         &x
     }

--- a/src/test/compile-fail/issue-14853.rs
+++ b/src/test/compile-fail/issue-14853.rs
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::Show;
+use std::fmt::Debug;
 
 trait Str {}
 
 trait Something {
-    fn yay<T: Show>(_: Option<Self>, thing: &[T]);
+    fn yay<T: Debug>(_: Option<Self>, thing: &[T]);
 }
 
 struct X { data: u32 }

--- a/src/test/compile-fail/issue-15094.rs
+++ b/src/test/compile-fail/issue-15094.rs
@@ -12,19 +12,19 @@
 
 use std::{fmt, ops};
 
-struct Shower<T> {
+struct Debuger<T> {
     x: T
 }
 
-impl<T: fmt::Show> ops::Fn<(), ()> for Shower<T> {
+impl<T: fmt::Debug> ops::Fn<(), ()> for Debuger<T> {
     fn call(&self, _args: ()) {
 //~^ ERROR `call` has an incompatible type for trait: expected "rust-call" fn, found "Rust" fn
         println!("{:?}", self.x);
     }
 }
 
-fn make_shower<T>(x: T) -> Shower<T> {
-    Shower { x: x }
+fn make_shower<T>(x: T) -> Debuger<T> {
+    Debuger { x: x }
 }
 
 pub fn main() {

--- a/src/test/compile-fail/liveness-use-after-send.rs
+++ b/src/test/compile-fail/liveness-use-after-send.rs
@@ -8,13 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn send<T:Send + std::fmt::Show>(ch: _chan<T>, data: T) {
+fn send<T:Send + std::fmt::Debug>(ch: _chan<T>, data: T) {
     println!("{:?}", ch);
     println!("{:?}", data);
     panic!();
 }
 
-#[derive(Show)]
+#[derive(Debug)]
 struct _chan<T>(isize);
 
 // Tests that "log(debug, message);" is flagged as using

--- a/src/test/run-fail/assert-eq-macro-panic.rs
+++ b/src/test/run-fail/assert-eq-macro-panic.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:assertion failed: `(left == right) && (right == left)` (left: `14i`, right: `15i`)
+// error-pattern:assertion failed: `(left == right) && (right == left)` (left: `14`, right: `15`)
 
 fn main() {
     assert_eq!(14i,15i);

--- a/src/test/run-pass/cfg_attr.rs
+++ b/src/test/run-pass/cfg_attr.rs
@@ -10,44 +10,44 @@
 
 // compile-flags:--cfg set1 --cfg set2
 #![allow(dead_code)]
-use std::fmt::Show;
+use std::fmt::Debug;
 
-struct NotShowable;
+struct NotDebugable;
 
-#[cfg_attr(set1, derive(Show))]
+#[cfg_attr(set1, derive(Debug))]
 struct Set1;
 
-#[cfg_attr(notset, derive(Show))]
-struct Notset(NotShowable);
+#[cfg_attr(notset, derive(Debug))]
+struct Notset(NotDebugable);
 
-#[cfg_attr(not(notset), derive(Show))]
+#[cfg_attr(not(notset), derive(Debug))]
 struct NotNotset;
 
-#[cfg_attr(not(set1), derive(Show))]
-struct NotSet1(NotShowable);
+#[cfg_attr(not(set1), derive(Debug))]
+struct NotSet1(NotDebugable);
 
-#[cfg_attr(all(set1, set2), derive(Show))]
+#[cfg_attr(all(set1, set2), derive(Debug))]
 struct AllSet1Set2;
 
-#[cfg_attr(all(set1, notset), derive(Show))]
-struct AllSet1Notset(NotShowable);
+#[cfg_attr(all(set1, notset), derive(Debug))]
+struct AllSet1Notset(NotDebugable);
 
-#[cfg_attr(any(set1, notset), derive(Show))]
+#[cfg_attr(any(set1, notset), derive(Debug))]
 struct AnySet1Notset;
 
-#[cfg_attr(any(notset, notset2), derive(Show))]
-struct AnyNotsetNotset2(NotShowable);
+#[cfg_attr(any(notset, notset2), derive(Debug))]
+struct AnyNotsetNotset2(NotDebugable);
 
-#[cfg_attr(all(not(notset), any(set1, notset)), derive(Show))]
+#[cfg_attr(all(not(notset), any(set1, notset)), derive(Debug))]
 struct Complex;
 
-#[cfg_attr(any(notset, not(any(set1, notset))), derive(Show))]
-struct ComplexNot(NotShowable);
+#[cfg_attr(any(notset, not(any(set1, notset))), derive(Debug))]
+struct ComplexNot(NotDebugable);
 
-#[cfg_attr(any(target_endian = "little", target_endian = "big"), derive(Show))]
+#[cfg_attr(any(target_endian = "little", target_endian = "big"), derive(Debug))]
 struct KeyValue;
 
-fn is_show<T: Show>() {}
+fn is_show<T: Debug>() {}
 
 fn main() {
     is_show::<Set1>();

--- a/src/test/run-pass/coerce-expect-unsized.rs
+++ b/src/test/run-pass/coerce-expect-unsized.rs
@@ -11,7 +11,7 @@
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 
-use std::fmt::Show;
+use std::fmt::Debug;
 
 // Check that coercions apply at the pointer level and don't cause
 // rvalue expressions to be unsized. See #20169 for more information.
@@ -21,15 +21,15 @@ pub fn main() {
     let _: Box<[int]> = box if true { [1, 2, 3] } else { [1, 3, 4] };
     let _: Box<[int]> = box match true { true => [1, 2, 3], false => [1, 3, 4] };
     let _: Box<Fn(int) -> _> = box { |x| (x as u8) };
-    let _: Box<Show> = box if true { false } else { true };
-    let _: Box<Show> = box match true { true => 'a', false => 'b' };
+    let _: Box<Debug> = box if true { false } else { true };
+    let _: Box<Debug> = box match true { true => 'a', false => 'b' };
 
     let _: &[int] = &{ [1, 2, 3] };
     let _: &[int] = &if true { [1, 2, 3] } else { [1, 3, 4] };
     let _: &[int] = &match true { true => [1, 2, 3], false => [1, 3, 4] };
     let _: &Fn(int) -> _ = &{ |x| (x as u8) };
-    let _: &Show = &if true { false } else { true };
-    let _: &Show = &match true { true => 'a', false => 'b' };
+    let _: &Debug = &if true { false } else { true };
+    let _: &Debug = &match true { true => 'a', false => 'b' };
 
     let _: Box<[int]> = Box::new([1, 2, 3]);
     let _: Box<Fn(int) -> _> = Box::new(|x| (x as u8));

--- a/src/test/run-pass/coherence-where-clause.rs
+++ b/src/test/run-pass/coherence-where-clause.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::Show;
+use std::fmt::Debug;
 use std::default::Default;
 
 trait MyTrait {
@@ -23,7 +23,7 @@ impl<T> MyTrait for T
     }
 }
 
-#[derive(Clone,Show,PartialEq)]
+#[derive(Clone,Debug,PartialEq)]
 struct MyType {
     dummy: uint
 }
@@ -35,7 +35,7 @@ impl MyTrait for MyType {
 }
 
 fn test_eq<M>(m: M, n: M)
-where M : MyTrait + Show + PartialEq
+where M : MyTrait + Debug + PartialEq
 {
     assert_eq!(m.get(), n);
 }

--- a/src/test/run-pass/deriving-show-2.rs
+++ b/src/test/run-pass/deriving-show-2.rs
@@ -10,39 +10,39 @@
 
 use std::fmt;
 
-#[derive(Show)]
+#[derive(Debug)]
 enum A {}
-#[derive(Show)]
+#[derive(Debug)]
 enum B { B1, B2, B3 }
-#[derive(Show)]
+#[derive(Debug)]
 enum C { C1(int), C2(B), C3(String) }
-#[derive(Show)]
+#[derive(Debug)]
 enum D { D1{ a: int } }
-#[derive(Show)]
+#[derive(Debug)]
 struct E;
-#[derive(Show)]
+#[derive(Debug)]
 struct F(int);
-#[derive(Show)]
+#[derive(Debug)]
 struct G(int, int);
-#[derive(Show)]
+#[derive(Debug)]
 struct H { a: int }
-#[derive(Show)]
+#[derive(Debug)]
 struct I { a: int, b: int }
-#[derive(Show)]
+#[derive(Debug)]
 struct J(Custom);
 
 struct Custom;
-impl fmt::Show for Custom {
+impl fmt::Debug for Custom {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "yay")
     }
 }
 
-trait ToShow {
+trait ToDebug {
     fn to_show(&self) -> String;
 }
 
-impl<T: fmt::Show> ToShow for T {
+impl<T: fmt::Debug> ToDebug for T {
     fn to_show(&self) -> String {
         format!("{:?}", self)
     }
@@ -51,12 +51,12 @@ impl<T: fmt::Show> ToShow for T {
 pub fn main() {
     assert_eq!(B::B1.to_show(), "B1".to_string());
     assert_eq!(B::B2.to_show(), "B2".to_string());
-    assert_eq!(C::C1(3).to_show(), "C1(3i)".to_string());
+    assert_eq!(C::C1(3).to_show(), "C1(3)".to_string());
     assert_eq!(C::C2(B::B2).to_show(), "C2(B2)".to_string());
-    assert_eq!(D::D1{ a: 2 }.to_show(), "D1 { a: 2i }".to_string());
+    assert_eq!(D::D1{ a: 2 }.to_show(), "D1 { a: 2 }".to_string());
     assert_eq!(E.to_show(), "E".to_string());
-    assert_eq!(F(3).to_show(), "F(3i)".to_string());
-    assert_eq!(G(3, 4).to_show(), "G(3i, 4i)".to_string());
-    assert_eq!(I{ a: 2, b: 4 }.to_show(), "I { a: 2i, b: 4i }".to_string());
+    assert_eq!(F(3).to_show(), "F(3)".to_string());
+    assert_eq!(G(3, 4).to_show(), "G(3, 4)".to_string());
+    assert_eq!(I{ a: 2, b: 4 }.to_show(), "I { a: 2, b: 4 }".to_string());
     assert_eq!(J(Custom).to_show(), "J(yay)".to_string());
 }

--- a/src/test/run-pass/deriving-show.rs
+++ b/src/test/run-pass/deriving-show.rs
@@ -8,16 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(Show)]
+#[derive(Debug)]
 struct Unit;
 
-#[derive(Show)]
+#[derive(Debug)]
 struct Tuple(int, uint);
 
-#[derive(Show)]
+#[derive(Debug)]
 struct Struct { x: int, y: uint }
 
-#[derive(Show)]
+#[derive(Debug)]
 enum Enum {
     Nullary,
     Variant(int, uint),
@@ -32,9 +32,9 @@ macro_rules! t {
 
 pub fn main() {
     t!(Unit, "Unit");
-    t!(Tuple(1, 2), "Tuple(1i, 2u)");
-    t!(Struct { x: 1, y: 2 }, "Struct { x: 1i, y: 2u }");
+    t!(Tuple(1, 2), "Tuple(1, 2)");
+    t!(Struct { x: 1, y: 2 }, "Struct { x: 1, y: 2 }");
     t!(Enum::Nullary, "Nullary");
-    t!(Enum::Variant(1, 2), "Variant(1i, 2u)");
-    t!(Enum::StructVariant { x: 1, y: 2 }, "StructVariant { x: 1i, y: 2u }");
+    t!(Enum::Variant(1, 2), "Variant(1, 2)");
+    t!(Enum::StructVariant { x: 1, y: 2 }, "StructVariant { x: 1, y: 2 }");
 }

--- a/src/test/run-pass/dst-index.rs
+++ b/src/test/run-pass/dst-index.rs
@@ -12,7 +12,7 @@
 // work and don't ICE.
 
 use std::ops::Index;
-use std::fmt::Show;
+use std::fmt::Debug;
 
 struct S;
 
@@ -27,16 +27,16 @@ impl Index<uint> for S {
 struct T;
 
 impl Index<uint> for T {
-    type Output = Show + 'static;
+    type Output = Debug + 'static;
 
-    fn index<'a>(&'a self, idx: &uint) -> &'a (Show + 'static) {
+    fn index<'a>(&'a self, idx: &uint) -> &'a (Debug + 'static) {
         static X: uint = 42;
-        &X as &(Show + 'static)
+        &X as &(Debug + 'static)
     }
 }
 
 fn main() {
     assert_eq!(&S[0], "hello");
     &T[0];
-    // let x = &x as &Show;
+    // let x = &x as &Debug;
 }

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -33,7 +33,7 @@ impl fmt::UpperHex for B {
         f.write_str("adios")
     }
 }
-impl fmt::String for C {
+impl fmt::Display for C {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad_integral(true, "☃", "123")
     }
@@ -63,8 +63,8 @@ pub fn main() {
     t!(format!("{}", 10i), "10");
     t!(format!("{}", 10u), "10");
     t!(format!("{:?}", '☃'), "'\\u{2603}'");
-    t!(format!("{:?}", 10i), "10i");
-    t!(format!("{:?}", 10u), "10u");
+    t!(format!("{:?}", 10i), "10");
+    t!(format!("{:?}", 10u), "10");
     t!(format!("{:?}", "true"), "\"true\"");
     t!(format!("{:?}", "foo\nbar"), "\"foo\\nbar\"");
     t!(format!("{:o}", 10u), "12");
@@ -72,22 +72,22 @@ pub fn main() {
     t!(format!("{:X}", 10u), "A");
     t!(format!("{}", "foo"), "foo");
     t!(format!("{}", "foo".to_string()), "foo");
-    t!(format!("{:p}", 0x1234 as *const int), "0x1234");
-    t!(format!("{:p}", 0x1234 as *mut int), "0x1234");
+    t!(format!("{:p}", 0x1234 as *const isize), "0x1234");
+    t!(format!("{:p}", 0x1234 as *mut isize), "0x1234");
     t!(format!("{:x}", A), "aloha");
     t!(format!("{:X}", B), "adios");
     t!(format!("foo {} ☃☃☃☃☃☃", "bar"), "foo bar ☃☃☃☃☃☃");
     t!(format!("{1} {0}", 0i, 1i), "1 0");
-    t!(format!("{foo} {bar}", foo=0i, bar=1i), "0 1");
-    t!(format!("{foo} {1} {bar} {0}", 0i, 1i, foo=2i, bar=3i), "2 1 3 0");
+    t!(format!("{foo} {bar}", foo=0i, bar=1is), "0 1");
+    t!(format!("{foo} {1} {bar} {0}", 0is, 1is, foo=2is, bar=3is), "2 1 3 0");
     t!(format!("{} {0}", "a"), "a a");
     t!(format!("{foo_bar}", foo_bar=1i), "1");
     t!(format!("{}", 5i + 5i), "10");
     t!(format!("{:#4}", C), "☃123");
 
     // FIXME(#20676)
-    // let a: &fmt::Show = &1i;
-    // t!(format!("{:?}", a), "1i");
+    // let a: &fmt::Debug = &1i;
+    // t!(format!("{:?}", a), "1");
 
 
     // Formatting strings and their arguments
@@ -154,7 +154,7 @@ pub fn main() {
     // make sure that format! doesn't cause spurious unused-unsafe warnings when
     // it's inside of an outer unsafe block
     unsafe {
-        let a: int = ::std::mem::transmute(3u);
+        let a: isize = ::std::mem::transmute(3u);
         format!("{}", a);
     }
 
@@ -215,8 +215,8 @@ fn test_format_args() {
 fn test_order() {
     // Make sure format!() arguments are always evaluated in a left-to-right
     // ordering
-    fn foo() -> int {
-        static mut FOO: int = 0;
+    fn foo() -> isize {
+        static mut FOO: isize = 0;
         unsafe {
             FOO += 1;
             FOO

--- a/src/test/run-pass/issue-20676.rs
+++ b/src/test/run-pass/issue-20676.rs
@@ -15,6 +15,6 @@
 use std::fmt;
 
 fn main() {
-    let a: &fmt::Show = &1_i32;
+    let a: &fmt::Debug = &1_i32;
     format!("{:?}", a);
 }

--- a/src/test/run-pass/issue-3559.rs
+++ b/src/test/run-pass/issue-3559.rs
@@ -24,6 +24,6 @@ pub fn main() {
     let mut table = HashMap::new();
     table.insert("one".to_string(), 1i);
     table.insert("two".to_string(), 2i);
-    assert!(check_strs(format!("{:?}", table).as_slice(), "HashMap {\"one\": 1i, \"two\": 2i}") ||
-            check_strs(format!("{:?}", table).as_slice(), "HashMap {\"two\": 2i, \"one\": 1i}"));
+    assert!(check_strs(format!("{:?}", table).as_slice(), "HashMap {\"one\": 1, \"two\": 2}") ||
+            check_strs(format!("{:?}", table).as_slice(), "HashMap {\"two\": 2, \"one\": 1}"));
 }

--- a/src/test/run-pass/issue-4252.rs
+++ b/src/test/run-pass/issue-4252.rs
@@ -11,28 +11,28 @@
 #![feature(unsafe_destructor)]
 
 trait X {
-    fn call<T: std::fmt::Show>(&self, x: &T);
-    fn default_method<T: std::fmt::Show>(&self, x: &T) {
+    fn call<T: std::fmt::Debug>(&self, x: &T);
+    fn default_method<T: std::fmt::Debug>(&self, x: &T) {
         println!("X::default_method {:?}", x);
     }
 }
 
-#[derive(Show)]
+#[derive(Debug)]
 struct Y(int);
 
-#[derive(Show)]
+#[derive(Debug)]
 struct Z<T> {
     x: T
 }
 
 impl X for Y {
-    fn call<T: std::fmt::Show>(&self, x: &T) {
+    fn call<T: std::fmt::Debug>(&self, x: &T) {
         println!("X::call {:?} {:?}", self, x);
     }
 }
 
 #[unsafe_destructor]
-impl<T: X + std::fmt::Show> Drop for Z<T> {
+impl<T: X + std::fmt::Debug> Drop for Z<T> {
     fn drop(&mut self) {
         // These statements used to cause an ICE.
         self.x.call(self);

--- a/src/test/run-pass/issue-8898.rs
+++ b/src/test/run-pass/issue-8898.rs
@@ -8,17 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn assert_repr_eq<T: std::fmt::Show>(obj : T, expected : String) {
+fn assert_repr_eq<T: std::fmt::Debug>(obj : T, expected : String) {
     assert_eq!(expected, format!("{:?}", obj));
 }
 
 pub fn main() {
-    let abc = [1i, 2, 3];
+    let abc = [1, 2, 3];
     let tf = [true, false];
     let x  = [(), ()];
     let slice = &x[..1];
 
-    assert_repr_eq(&abc[], "[1i, 2i, 3i]".to_string());
+    assert_repr_eq(&abc[], "[1, 2, 3]".to_string());
     assert_repr_eq(&tf[], "[true, false]".to_string());
     assert_repr_eq(&x[], "[(), ()]".to_string());
     assert_repr_eq(slice, "[()]".to_string());

--- a/src/test/run-pass/log-knows-the-names-of-variants-in-std.rs
+++ b/src/test/run-pass/log-knows-the-names-of-variants-in-std.rs
@@ -8,19 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(Clone, Show)]
+#[derive(Clone, Debug)]
 enum foo {
   a(uint),
   b(String),
 }
 
-fn check_log<T: std::fmt::Show>(exp: String, v: T) {
+fn check_log<T: std::fmt::Debug>(exp: String, v: T) {
     assert_eq!(exp, format!("{:?}", v));
 }
 
 pub fn main() {
-    let mut x = Some(foo::a(22u));
-    let exp = "Some(a(22u))".to_string();
+    let mut x = Some(foo::a(22));
+    let exp = "Some(a(22))".to_string();
     let act = format!("{:?}", x);
     assert_eq!(act, exp);
     check_log(exp, x);

--- a/src/test/run-pass/log-knows-the-names-of-variants.rs
+++ b/src/test/run-pass/log-knows-the-names-of-variants.rs
@@ -8,20 +8,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(Show)]
+#[derive(Debug)]
 enum foo {
-  a(uint),
+  a(usize),
   b(String),
   c,
 }
 
-#[derive(Show)]
+#[derive(Debug)]
 enum bar {
   d, e, f
 }
 
 pub fn main() {
-    assert_eq!("a(22u)".to_string(), format!("{:?}", foo::a(22u)));
+    assert_eq!("a(22)".to_string(), format!("{:?}", foo::a(22)));
     assert_eq!("c".to_string(), format!("{:?}", foo::c));
     assert_eq!("d".to_string(), format!("{:?}", bar::d));
 }

--- a/src/test/run-pass/multidispatch1.rs
+++ b/src/test/run-pass/multidispatch1.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::Show;
+use std::fmt::Debug;
 
 trait MyTrait<T> {
     fn get(&self) -> T;
@@ -29,7 +29,7 @@ impl MyTrait<u8> for MyType {
 }
 
 fn test_eq<T,M>(m: M, v: T)
-where T : Eq + Show,
+where T : Eq + Debug,
       M : MyTrait<T>
 {
     assert_eq!(m.get(), v);

--- a/src/test/run-pass/multidispatch2.rs
+++ b/src/test/run-pass/multidispatch2.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::Show;
+use std::fmt::Debug;
 use std::default::Default;
 
 trait MyTrait<T> {
@@ -34,7 +34,7 @@ impl MyTrait<uint> for MyType {
 }
 
 fn test_eq<T,M>(m: M, v: T)
-where T : Eq + Show,
+where T : Eq + Debug,
       M : MyTrait<T>
 {
     assert_eq!(m.get(), v);

--- a/src/test/run-pass/no-landing-pads.rs
+++ b/src/test/run-pass/no-landing-pads.rs
@@ -26,6 +26,6 @@ fn main() {
     Thread::scoped(move|| -> () {
         let _a = A;
         panic!();
-    }).join().unwrap_err();
+    }).join().err().unwrap();
     assert!(unsafe { !HIT });
 }

--- a/src/test/run-pass/overloaded-index-assoc-list.rs
+++ b/src/test/run-pass/overloaded-index-assoc-list.rs
@@ -28,7 +28,7 @@ impl<K,V> AssociationList<K,V> {
     }
 }
 
-impl<K: PartialEq + std::fmt::Show, V:Clone> Index<K> for AssociationList<K,V> {
+impl<K: PartialEq + std::fmt::Debug, V:Clone> Index<K> for AssociationList<K,V> {
     type Output = V;
 
     fn index<'a>(&'a self, index: &K) -> &'a V {

--- a/src/test/run-pass/rec-align-u32.rs
+++ b/src/test/run-pass/rec-align-u32.rs
@@ -22,14 +22,14 @@ mod rusti {
 }
 
 // This is the type with the questionable alignment
-#[derive(Show)]
+#[derive(Debug)]
 struct Inner {
     c64: u32
 }
 
 // This is the type that contains the type with the
 // questionable alignment, for testing
-#[derive(Show)]
+#[derive(Debug)]
 struct Outer {
     c8: u8,
     t: Inner
@@ -66,6 +66,6 @@ pub fn main() {
         // because `inner`s alignment was 4.
         assert_eq!(mem::size_of::<Outer>(), m::size());
 
-        assert_eq!(y, "Outer { c8: 22u8, t: Inner { c64: 44u32 } }".to_string());
+        assert_eq!(y, "Outer { c8: 22, t: Inner { c64: 44 } }".to_string());
     }
 }

--- a/src/test/run-pass/rec-align-u64.rs
+++ b/src/test/run-pass/rec-align-u64.rs
@@ -22,14 +22,14 @@ mod rusti {
 }
 
 // This is the type with the questionable alignment
-#[derive(Show)]
+#[derive(Debug)]
 struct Inner {
     c64: u64
 }
 
 // This is the type that contains the type with the
 // questionable alignment, for testing
-#[derive(Show)]
+#[derive(Debug)]
 struct Outer {
     c8: u8,
     t: Inner
@@ -95,6 +95,6 @@ pub fn main() {
         // because `Inner`s alignment was 4.
         assert_eq!(mem::size_of::<Outer>(), m::m::size());
 
-        assert_eq!(y, "Outer { c8: 22u8, t: Inner { c64: 44u64 } }".to_string());
+        assert_eq!(y, "Outer { c8: 22, t: Inner { c64: 44 } }".to_string());
     }
 }

--- a/src/test/run-pass/sepcomp-unwind.rs
+++ b/src/test/run-pass/sepcomp-unwind.rs
@@ -36,5 +36,5 @@ mod b {
 }
 
 fn main() {
-    Thread::scoped(move|| { ::b::g() }).join().unwrap_err();
+    Thread::scoped(move|| { ::b::g() }).join().err().unwrap();
 }

--- a/src/test/run-pass/show-boxed-slice.rs
+++ b/src/test/run-pass/show-boxed-slice.rs
@@ -11,7 +11,7 @@
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 
-#[derive(Show)]
+#[derive(Debug)]
 struct Foo(Box<[u8]>);
 
 pub fn main() {

--- a/src/test/run-pass/small-enums-with-fields.rs
+++ b/src/test/run-pass/small-enums-with-fields.rs
@@ -10,7 +10,7 @@
 
 use std::mem::size_of;
 
-#[derive(PartialEq, Show)]
+#[derive(PartialEq, Debug)]
 enum Either<T, U> { Left(T), Right(U) }
 
 macro_rules! check {
@@ -29,14 +29,14 @@ macro_rules! check {
 pub fn main() {
     check!(Option<u8>, 2,
            None, "None",
-           Some(129u8), "Some(129u8)");
+           Some(129u8), "Some(129)");
     check!(Option<i16>, 4,
            None, "None",
-           Some(-20000i16), "Some(-20000i16)");
+           Some(-20000i16), "Some(-20000)");
     check!(Either<u8, i8>, 2,
-           Either::Left(132u8), "Left(132u8)",
-           Either::Right(-32i8), "Right(-32i8)");
+           Either::Left(132u8), "Left(132)",
+           Either::Right(-32i8), "Right(-32)");
     check!(Either<u8, i16>, 4,
-           Either::Left(132u8), "Left(132u8)",
-           Either::Right(-20000i16), "Right(-20000i16)");
+           Either::Left(132u8), "Left(132)",
+           Either::Right(-20000i16), "Right(-20000)");
 }

--- a/src/test/run-pass/tag-align-shape.rs
+++ b/src/test/run-pass/tag-align-shape.rs
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(Show)]
+#[derive(Debug)]
 enum a_tag {
     a_tag_var(u64)
 }
 
-#[derive(Show)]
+#[derive(Debug)]
 struct t_rec {
     c8: u8,
     t: a_tag
@@ -23,5 +23,5 @@ pub fn main() {
     let x = t_rec {c8: 22u8, t: a_tag::a_tag_var(44u64)};
     let y = format!("{:?}", x);
     println!("y = {:?}", y);
-    assert_eq!(y, "t_rec { c8: 22u8, t: a_tag_var(44u64) }".to_string());
+    assert_eq!(y, "t_rec { c8: 22, t: a_tag_var(44) }".to_string());
 }

--- a/src/test/run-pass/unit-like-struct-drop-run.rs
+++ b/src/test/run-pass/unit-like-struct-drop-run.rs
@@ -26,6 +26,6 @@ pub fn main() {
         let _b = Foo;
     }).join();
 
-    let s = x.unwrap_err().downcast::<&'static str>().unwrap();
+    let s = x.err().unwrap().downcast::<&'static str>().ok().unwrap();
     assert_eq!(s.as_slice(), "This panic should happen.");
 }

--- a/src/test/run-pass/vec-to_str.rs
+++ b/src/test/run-pass/vec-to_str.rs
@@ -9,11 +9,11 @@
 // except according to those terms.
 
 pub fn main() {
-    assert_eq!(format!("{:?}", vec!(0i, 1)), "[0i, 1i]".to_string());
+    assert_eq!(format!("{:?}", vec!(0i, 1)), "[0, 1]".to_string());
 
     let foo = vec!(3i, 4);
     let bar: &[int] = &[4, 5];
 
-    assert_eq!(format!("{:?}", foo), "[3i, 4i]");
-    assert_eq!(format!("{:?}", bar), "[4i, 5i]");
+    assert_eq!(format!("{:?}", foo), "[3, 4]");
+    assert_eq!(format!("{:?}", bar), "[4, 5]");
 }

--- a/src/test/run-pass/wait-forked-but-failed-child.rs
+++ b/src/test/run-pass/wait-forked-but-failed-child.rs
@@ -58,7 +58,7 @@ fn main() {
     let _failures = range(0, 100).map(|_| {
         let cmd = Command::new(too_long.as_slice());
         let failed = cmd.spawn();
-        assert!(failed.is_err(), "Make sure the command fails to spawn(): {}", cmd);
+        assert!(failed.is_err(), "Make sure the command fails to spawn(): {:?}", cmd);
         failed
     }).collect::<Vec<_>>();
 


### PR DESCRIPTION
This commit is an implementation of [RFC 565](https://github.com/rust-lang/rfcs/blob/master/text/0565-show-string-guidelines.md) which is a stabilization of
the `std::fmt` module and the implementations of various formatting traits.
Specifically, the following changes were performed:
- The `Show` trait is now deprecated, it was renamed to `Debug`
- The `String` trait is now deprecated, it was renamed to `Display`
- Many `Debug` and `Display` implementations were audited in accordance with the
  RFC and audited implementations now have the `#[stable]` attribute
  - Integers and floats no longer print a suffix
  - Smart pointers no longer print details that they are a smart pointer
  - Paths with `Debug` are now quoted and escape characters
- The `unwrap` methods on `Result` now require `Display` instead of `Debug`
- The `Error` trait no longer has a `detail` method and now requires that
  `Display` must be implemented. With the loss of `String`, this has moved into
  libcore.
- `impl<E: Error> FromError<E> for Box<Error>` now exists
- `derive(Show)` has been renamed to `derive(Debug)`. This is not currently
  warned about due to warnings being emitted on stage1+

While backwards compatibility is attempted to be maintained with a blanket
implementation of `Display` for the old `String` trait (and the same for
`Show`/`Debug`) this is still a breaking change due to primitives no longer
implementing `String` as well as modifications such as `unwrap` and the `Error`
trait. Most code is fairly straightforward to update with a rename or tweaks of
method calls.

[breaking-change]
Closes #21436
