### PR TITLE
Add `bind_reusable`method to UdpSocket

### DIFF
--- a/src/libstd/io/net/udp.rs
+++ b/src/libstd/io/net/udp.rs
@@ -71,6 +71,16 @@ impl UdpSocket {
         })
     }
 
+    /// Creates a UDP socket from the given address with `SO_REUSEADDR` set to true.
+    ///
+    /// Address type can be any implementor of `ToSocketAddr` trait. See its
+    /// documentation for concrete examples.
+    pub fn bind_reusable<A: ToSocketAddr>(addr: A) -> IoResult<UdpSocket> {
+        super::with_addresses(addr, |addr| {
+            UdpSocketImp::bind_reusable(addr).map(|s| UdpSocket { inner: s })
+        })
+    }
+
     /// Receives data from the socket. On success, returns the number of bytes
     /// read and the address from whence the data came.
     pub fn recv_from(&mut self, buf: &mut [u8]) -> IoResult<(uint, SocketAddr)> {

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -819,7 +819,7 @@ impl UdpSocket {
             write_deadline: 0,
         };
 
-        setsockopt(self.fd(), libc::SOL_SOCKET, libc::SO_REUSEADDR, on as libc::c_int);        
+        setsockopt(self.fd(), libc::SOL_SOCKET, libc::SO_REUSEADDR, true as libc::c_int);        
 
         let mut storage = unsafe { mem::zeroed() };
         let len = addr_to_sockaddr(addr, &mut storage);

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -819,7 +819,7 @@ impl UdpSocket {
             write_deadline: 0,
         };
 
-        setsockopt(fd, libc::SOL_SOCKET, libc::SO_REUSEADDR, true as libc::c_int);        
+        setsockopt(fd, libc::SOL_SOCKET, libc::SO_REUSEADDR, true as libc::c_int).unwrap();        
 
         let mut storage = unsafe { mem::zeroed() };
         let len = addr_to_sockaddr(addr, &mut storage);

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -819,7 +819,7 @@ impl UdpSocket {
             write_deadline: 0,
         };
 
-        setsockopt(fd, libc::SOL_SOCKET, libc::SO_REUSEADDR, true as libc::c_int).unwrap();        
+        setsockopt(fd, libc::SOL_SOCKET, libc::SO_REUSEADDR, true as libc::c_int).unwrap();
 
         let mut storage = unsafe { mem::zeroed() };
         let len = addr_to_sockaddr(addr, &mut storage);

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -819,7 +819,7 @@ impl UdpSocket {
             write_deadline: 0,
         };
 
-        setsockopt(self.fd(), libc::SOL_SOCKET, libc::SO_REUSEADDR, true as libc::c_int);        
+        setsockopt(fd, libc::SOL_SOCKET, libc::SO_REUSEADDR, true as libc::c_int);        
 
         let mut storage = unsafe { mem::zeroed() };
         let len = addr_to_sockaddr(addr, &mut storage);


### PR DESCRIPTION
This implements `bind_reusable` method for UdpSocket, which binds socket with SO_REUSEADDR set to `true`. Such behaviour is necessary in some cases, such as monitoring multiple multicast streams on the same machine. See also #11758
