### PR TITLE
lint: warn about #[no_mangle] fns that aren't exported

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -213,6 +213,7 @@ impl LintStore {
                      UnstableFeatures,
                      Stability,
                      UnconditionalRecursion,
+                     PrivateNoMangleFns,
         );
 
         add_builtin_with_new!(sess,

--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -254,7 +254,6 @@ pub mod eabi {
     }
 
     #[no_mangle] // referenced from rust_try.ll
-    #[allow(unexported_no_mangle)]
     pub extern "C" fn rust_eh_personality_catch(
         _version: c_int,
         actions: uw::_Unwind_Action,
@@ -293,7 +292,7 @@ pub mod eabi {
 
     #[lang="eh_personality"]
     #[no_mangle] // referenced from rust_try.ll
-    #[allow(unexported_no_mangle)]
+    #[allow(private_no_mangle_fns)]
     pub extern "C" fn rust_eh_personality(
         version: c_int,
         actions: uw::_Unwind_Action,
@@ -309,7 +308,6 @@ pub mod eabi {
     }
 
     #[no_mangle] // referenced from rust_try.ll
-    #[allow(unexported_no_mangle)]
     pub extern "C" fn rust_eh_personality_catch(
         _version: c_int,
         actions: uw::_Unwind_Action,
@@ -348,7 +346,7 @@ pub mod eabi {
 
     #[lang="eh_personality"]
     #[no_mangle] // referenced from rust_try.ll
-    #[allow(unexported_no_mangle)]
+    #[allow(private_no_mangle_fns)]
     extern "C" fn rust_eh_personality(
         state: uw::_Unwind_State,
         ue_header: *mut uw::_Unwind_Exception,
@@ -361,7 +359,6 @@ pub mod eabi {
     }
 
     #[no_mangle] // referenced from rust_try.ll
-    #[allow(unexported_no_mangle)]
     pub extern "C" fn rust_eh_personality_catch(
         state: uw::_Unwind_State,
         _ue_header: *mut uw::_Unwind_Exception,
@@ -439,7 +436,7 @@ pub mod eabi {
 
     #[lang="eh_personality"]
     #[no_mangle] // referenced from rust_try.ll
-    #[allow(unexported_no_mangle)]
+    #[allow(private_no_mangle_fns)]
     extern "C" fn rust_eh_personality(
         exceptionRecord: *mut EXCEPTION_RECORD,
         establisherFrame: *mut c_void,
@@ -454,7 +451,6 @@ pub mod eabi {
     }
 
     #[no_mangle] // referenced from rust_try.ll
-    #[allow(unexported_no_mangle)]
     pub extern "C" fn rust_eh_personality_catch(
         exceptionRecord: *mut EXCEPTION_RECORD,
         establisherFrame: *mut c_void,

--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -160,6 +160,7 @@ pub fn panicking() -> bool {
 // An uninlined, unmangled function upon which to slap yer breakpoints
 #[inline(never)]
 #[no_mangle]
+#[allow(private_no_mangle_fns)]
 fn rust_panic(cause: Box<Any + Send>) -> ! {
     rtdebug!("begin_unwind()");
 
@@ -237,6 +238,7 @@ pub mod eabi {
 
     #[lang="eh_personality"]
     #[no_mangle] // referenced from rust_try.ll
+    #[allow(private_no_mangle_fns)]
     extern fn rust_eh_personality(
         version: c_int,
         actions: uw::_Unwind_Action,
@@ -252,6 +254,7 @@ pub mod eabi {
     }
 
     #[no_mangle] // referenced from rust_try.ll
+    #[allow(unexported_no_mangle)]
     pub extern "C" fn rust_eh_personality_catch(
         _version: c_int,
         actions: uw::_Unwind_Action,
@@ -290,6 +293,7 @@ pub mod eabi {
 
     #[lang="eh_personality"]
     #[no_mangle] // referenced from rust_try.ll
+    #[allow(unexported_no_mangle)]
     pub extern "C" fn rust_eh_personality(
         version: c_int,
         actions: uw::_Unwind_Action,
@@ -305,6 +309,7 @@ pub mod eabi {
     }
 
     #[no_mangle] // referenced from rust_try.ll
+    #[allow(unexported_no_mangle)]
     pub extern "C" fn rust_eh_personality_catch(
         _version: c_int,
         actions: uw::_Unwind_Action,
@@ -343,6 +348,7 @@ pub mod eabi {
 
     #[lang="eh_personality"]
     #[no_mangle] // referenced from rust_try.ll
+    #[allow(unexported_no_mangle)]
     extern "C" fn rust_eh_personality(
         state: uw::_Unwind_State,
         ue_header: *mut uw::_Unwind_Exception,
@@ -355,6 +361,7 @@ pub mod eabi {
     }
 
     #[no_mangle] // referenced from rust_try.ll
+    #[allow(unexported_no_mangle)]
     pub extern "C" fn rust_eh_personality_catch(
         state: uw::_Unwind_State,
         _ue_header: *mut uw::_Unwind_Exception,
@@ -432,6 +439,7 @@ pub mod eabi {
 
     #[lang="eh_personality"]
     #[no_mangle] // referenced from rust_try.ll
+    #[allow(unexported_no_mangle)]
     extern "C" fn rust_eh_personality(
         exceptionRecord: *mut EXCEPTION_RECORD,
         establisherFrame: *mut c_void,
@@ -446,6 +454,7 @@ pub mod eabi {
     }
 
     #[no_mangle] // referenced from rust_try.ll
+    #[allow(unexported_no_mangle)]
     pub extern "C" fn rust_eh_personality_catch(
         exceptionRecord: *mut EXCEPTION_RECORD,
         establisherFrame: *mut c_void,

--- a/src/test/compile-fail/lint-unexported-no-mangle.rs
+++ b/src/test/compile-fail/lint-unexported-no-mangle.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:-F private_no_mangle_fns
+
+// FIXME(#19495) no_mangle'ing main ICE's.
+#[no_mangle]
+fn foo() { //~ ERROR function foo is marked #[no_mangle], but not exported
+}
+
+#[no_mangle]
+pub fn bar()  {
+}
+
+fn main() {
+    foo();
+    bar();
+}


### PR DESCRIPTION
The usecase is that functions made visible to systems outside of the
rust ecosystem require the symbol to be visible.

This adds a lint for functions that are not exported, but also not mangled.

It has some gotchas:

[ ]: There is fallout in core that needs taking care of
[ ]: I'm not convinced the error message is correct
[ ]: It has no tests

~~However, there's an underlying issue which I'd like feedback on- which is that my belief that that non-pub functions would not have their symbols exported, however that seems not to be the case in the first case that this lint turned up in rustc (`rust_fail`), which intuition suggests has been working.~~

This seems to be a separate bug in rust, wherein the symbols are exported in binaries, but not in rlibs or dylibs. This lint would catch that case.
