### PR TITLE
Prevent UAC blocking certain test executables on 32-bit Windows.

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -264,6 +264,9 @@ pub fn run_tests(config: &Config) {
     // parallel (especially when we have lots and lots of child processes).
     // For context, see #8904
     io::test::raise_fd_limit();
+    // Prevent issue #21352 UAC blocking .exe containing 'patch' etc. on Windows
+    // If #11207 is resolved (adding manifest to .exe) this becomes unnecessary
+    os::setenv("__COMPAT_LAYER", "RunAsInvoker");
     let res = test::run_tests_console(&opts, tests.into_iter().collect());
     match res {
         Ok(true) => {}


### PR DESCRIPTION
Make compiletest set an environment variable so that on Windows 32-bit test executables containing certain substrings (e.g. 'install', 'setup', 'update', 'patch') are not blocked by UAC's Installer Detection Technology.
