### PR TITLE
libsyntax: fix for `has_test_signature`

### DIFF
--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -295,6 +295,7 @@ fn is_test_fn(cx: &TestCtxt, i: &ast::Item) -> bool {
           &ast::ItemFn(ref decl, _, _, ref generics, _) => {
             let no_output = match decl.output {
                 ast::DefaultReturn(..) => true,
+                ast::Return(ref t) if t.node == ast::TyTup(vec![]) => true,
                 _ => false
             };
             if decl.inputs.is_empty()
@@ -331,6 +332,7 @@ fn is_bench_fn(cx: &TestCtxt, i: &ast::Item) -> bool {
                 let input_cnt = decl.inputs.len();
                 let no_output = match decl.output {
                     ast::DefaultReturn(..) => true,
+                    ast::Return(ref t) if t.node == ast::TyTup(vec![]) => true,
                     _ => false
                 };
                 let tparm_cnt = generics.ty_params.len();

--- a/src/test/run-pass/test-fn-signature-verification-for-explicit-return-type.rs
+++ b/src/test/run-pass/test-fn-signature-verification-for-explicit-return-type.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --test
+extern crate test;
+
+#[bench]
+fn bench_explicit_return_type(_: &mut ::test::Bencher) -> () {}
+
+#[test]
+fn test_explicit_return_type() -> () {}
+

--- a/src/test/run-pass/test-fn-signature-verification-for-explicit-return-type.rs
+++ b/src/test/run-pass/test-fn-signature-verification-for-explicit-return-type.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // compile-flags: --test
+// ignore-pretty: does not work well with `--test`
 extern crate test;
 
 #[bench]


### PR DESCRIPTION
Fix for `error: functions used as tests must have signature fn() -> ()` and `error: functions used as benches must have signature fn(&mut Bencher) -> ()` in case of explicit return type declaration.

Currently

``` rust
#[test]
fn some_test() -> () {}
```

will produce:

```
error: functions used as tests must have signature fn() -> ()
```

which is definitely wrong.
