### PR TITLE
read_until reworked so returned delimiter is explicit

### DIFF
--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -574,12 +574,24 @@ mod test {
 
     #[test]
     fn test_read_until() {
+        use io::ReadUntilHelper;
         let inner = MemReader::new(vec!(0, 1, 2, 1, 0));
         let mut reader = BufferedReader::with_capacity(2, inner);
-        assert_eq!(reader.read_until(0), Ok(vec!(0)));
-        assert_eq!(reader.read_until(2), Ok(vec!(1, 2)));
-        assert_eq!(reader.read_until(1), Ok(vec!(1)));
-        assert_eq!(reader.read_until(8), Ok(vec!(0)));
+        assert_eq!(reader.read_until(0), Ok(ReadUntilHelper::WithDelimiter(vec!(0))));
+        assert_eq!(reader.read_until(2), Ok(ReadUntilHelper::WithDelimiter(vec!(1, 2))));
+        assert_eq!(reader.read_until(1), Ok(ReadUntilHelper::WithDelimiter(vec!(1))));
+        assert_eq!(reader.read_until(8), Ok(ReadUntilHelper::WithoutDelimiter(vec!(0))));
+        assert!(reader.read_until(9).is_err());
+    }
+
+    #[test]
+    fn test_read_until_without_delimiter() {
+        let inner = MemReader::new(vec!(0, 1, 2, 1, 0));
+        let mut reader = BufferedReader::with_capacity(2, inner);
+        assert_eq!(reader.read_until(0).unwrap().without_delimiter(), vec![]);
+        assert_eq!(reader.read_until(2).unwrap().without_delimiter(), vec![1]);
+        assert_eq!(reader.read_until(1).unwrap().without_delimiter(), vec![]);
+        assert_eq!(reader.read_until(8).unwrap().without_delimiter(), vec![0]);
         assert!(reader.read_until(9).is_err());
     }
 

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -166,7 +166,7 @@ impl StdinReader {
     /// The read is performed atomically - concurrent read calls in other
     /// threads will not interleave with this one.
     pub fn read_until(&mut self, byte: u8) -> IoResult<Vec<u8>> {
-        self.inner.lock().unwrap().0.read_until(byte)
+        self.inner.lock().unwrap().0.read_until(byte).and_then(|x| Ok(x.without_delimiter()))
     }
 
     /// Like `Buffer::read_char`.

--- a/src/test/run-pass/issue-13304.rs
+++ b/src/test/run-pass/issue-13304.rs
@@ -33,7 +33,7 @@ fn parent() {
     let out = p.wait_with_output().unwrap();
     assert!(out.status.success());
     let s = str::from_utf8(out.output.as_slice()).unwrap();
-    assert_eq!(s, "test1\n\ntest2\n\ntest3\n");
+    assert_eq!(s, "test1\ntest2\ntest3\n");
 }
 
 fn child() {


### PR DESCRIPTION
read_line never returns '\n' character
read_until returns enum signifying whether delimiter is returned or not

not sure if this requires an rfc, the enum name is certainly bikesheddable.
