### PR TITLE
Better inline assembly errors

### DIFF
--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -2049,6 +2049,10 @@ extern {
                                             function_out: *mut ValueRef,
                                             debugloc_out: *mut DebugLocRef,
                                             message_out: *mut TwineRef);
+    pub fn LLVMUnpackInlineAsmDiagnostic(DI: DiagnosticInfoRef,
+                                            cookie_out: *mut c_uint,
+                                            message_out: *mut TwineRef,
+                                            instruction_out: *mut ValueRef);
 
     pub fn LLVMWriteDiagnosticInfoToString(DI: DiagnosticInfoRef, s: RustStringRef);
     pub fn LLVMGetDiagInfoSeverity(DI: DiagnosticInfoRef) -> DiagnosticSeverity;

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -894,6 +894,22 @@ LLVMUnpackOptimizationDiagnostic(
     *message_out = wrap(&opt->getMsg());
 }
 
+extern "C" void
+LLVMUnpackInlineAsmDiagnostic(
+    LLVMDiagnosticInfoRef di,
+    unsigned *cookie_out,
+    LLVMTwineRef *message_out,
+    LLVMValueRef *instruction_out)
+{
+    // Undefined to call this not on an inline assembly diagnostic!
+    llvm::DiagnosticInfoInlineAsm *ia
+        = static_cast<llvm::DiagnosticInfoInlineAsm*>(unwrap(di));
+
+    *cookie_out = ia->getLocCookie();
+    *message_out = wrap(&ia->getMsgStr());
+    *instruction_out = wrap(ia->getInstruction());
+}
+
 extern "C" void LLVMWriteDiagnosticInfoToString(LLVMDiagnosticInfoRef di, RustStringRef str) {
     raw_rust_string_ostream os(str);
     DiagnosticPrinterRawOStream dp(os);


### PR DESCRIPTION
Before:

```
error: invalid operand for inline asm constraint 'i' at line 11
```

Note that 11 is not the line the inline assembly appears in.

After:

```
src/arch/x64/multiboot/bootstrap.rs:203:5: 209:9 error: invalid operand for inline asm constraint 'i'
src/arch/x64/multiboot/bootstrap.rs:203     asm! {
src/arch/x64/multiboot/bootstrap.rs:204         [multiboot => %ecx, mod attsyntax]
src/arch/x64/multiboot/bootstrap.rs:205 
src/arch/x64/multiboot/bootstrap.rs:206         ljmp {size_of::<Descriptor>() => %i}, $bootstrap.64
src/arch/x64/multiboot/bootstrap.rs:207     }
src/arch/x64/multiboot/bootstrap.rs:208 
                                        ...
error: aborting due to previous error
```
