### PR TITLE
FIX #21475: Parsing interval match patterns with path

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3541,12 +3541,12 @@ impl<'a> Parser<'a> {
                     }
                     token::DotDotDot => {
                         let hi = self.last_span.hi;
-                        let start = self.mk_expr(lo, hi, ExprPath(enum_path));
+                        let start = self.mk_expr(lo, hi, ExprPath(None, enum_path));
                         self.eat(&token::DotDotDot);
                         let end = if self.token.is_ident() || self.token.is_path() {
                             let path = self.parse_path(LifetimeAndTypesWithColons);
                             let hi = self.span.hi;
-                            self.mk_expr(lo, hi, ExprPath(path))
+                            self.mk_expr(lo, hi, ExprPath(None, path))
                         } else {
                             self.parse_literal_maybe_minus()
                         };

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3539,6 +3539,19 @@ impl<'a> Parser<'a> {
                         self.bump();
                         pat = PatStruct(enum_path, fields, etc);
                     }
+                    token::DotDotDot => {
+                        let hi = self.last_span.hi;
+                        let start = self.mk_expr(lo, hi, ExprPath(enum_path));
+                        self.eat(&token::DotDotDot);
+                        let end = if self.token.is_ident() || self.token.is_path() {
+                            let path = self.parse_path(LifetimeAndTypesWithColons);
+                            let hi = self.span.hi;
+                            self.mk_expr(lo, hi, ExprPath(path))
+                        } else {
+                            self.parse_literal_maybe_minus()
+                        };
+                        pat = PatRange(start, end);
+                    }
                     _ => {
                         let mut args: Vec<P<Pat>> = Vec::new();
                         match self.token {

--- a/src/test/run-pass/issue-21475.rs
+++ b/src/test/run-pass/issue-21475.rs
@@ -13,9 +13,8 @@ use m::{START, END};
 fn main() {
     match 42u32 {
         m::START...m::END => {},
-        // FIXME: Should also work (now: mismatched types in range [E0031])
-        // 0u32...m::END => {},
-        // m::START...59u32 => {},
+        0u32...m::END => {},
+        m::START...59u32 => {},
         _  => {},
     }
 }

--- a/src/test/run-pass/issue-21475.rs
+++ b/src/test/run-pass/issue-21475.rs
@@ -1,0 +1,26 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use m::{START, END};
+
+fn main() {
+    match 42u32 {
+        m::START...m::END => {},
+        // FIXME: Should also work (now: mismatched types in range [E0031])
+        // 0u32...m::END => {},
+        // m::START...59u32 => {},
+        _  => {},
+    }
+}
+
+mod m {
+  pub const START: u32 = 4;
+  pub const END:   u32 = 14;
+}


### PR DESCRIPTION
Fixing #21475. Right now this code can not be parsed:

``` rust
use m::{START, END};

fn main() {
    match 42u32 {
        m::START...m::END => {}, // error: expected one of `::`, `=>`, or `|`, found `...`
        _  => {},
    }
}

mod m {
  pub const START: u32 = 4;
  pub const END:   u32 = 14;
}
```

I fixed the parser and added test for this case, but now there are still problems with mixing literals and paths in interval:

``` rust
    match 42u32 {
        0u32...m::END => {},       // mismatched types in range [E0031]
        m::START...59u32 => {},    // mismatched types in range [E0031]
        _  => {},
    }
}
```

I'll try fix this problem and need review.
