### PR TITLE
Do not propagate the region requirements on the projected type to the types it is projected from

### DIFF
--- a/src/librustc_typeck/check/regionmanip.rs
+++ b/src/librustc_typeck/check/regionmanip.rs
@@ -123,11 +123,6 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
                 // `<T as TraitRef<..>>::Name`
 
                 self.push_projection_constraint_from_top(data);
-
-                // this seems like a minimal requirement:
-                let trait_def = ty::lookup_trait_def(self.tcx, data.trait_ref.def_id);
-                self.accumulate_from_adt(ty, data.trait_ref.def_id,
-                                         &trait_def.generics, data.trait_ref.substs)
             }
 
             ty::ty_tup(ref tuptys) => {

--- a/src/test/run-pass/issue-21520.rs
+++ b/src/test/run-pass/issue-21520.rs
@@ -1,0 +1,29 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that the requirement (in `Bar`) that `T::Bar : 'static` does
+// not wind up propagating to `T`.
+
+pub trait Foo {
+    type Bar;
+
+    fn foo(&self) -> Self;
+}
+
+pub struct Static<T:'static>(T);
+
+struct Bar<T:Foo>
+    where T::Bar : 'static
+{
+    x: Static<Option<T::Bar>>
+}
+
+fn main() { }
+


### PR DESCRIPTION
Do not propagate the region requirements on the projected type to the input types it is being projected from.

Fixes #21520.

r? @aturon 
