### PR TITLE
Suppress space after idents with "ModName" style in serialization of exported macros.

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1171,7 +1171,7 @@ impl<'a> State<'a> {
             }
             try!(self.print_tt(tt));
             // There should be no space between the module name and the following `::` in paths,
-            // otherwise imported macros get re-parsed from crate metadata incorrectly (issue #20701)
+            // otherwise imported macros get re-parsed from crate metadata incorrectly (#20701)
             suppress_space = match tt {
                 &ast::TtToken(_, token::Ident(_, token::ModName)) |
                 &ast::TtToken(_, token::MatchNt(_, _, _, token::ModName)) |

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1164,11 +1164,20 @@ impl<'a> State<'a> {
 
     pub fn print_tts(&mut self, tts: &[ast::TokenTree]) -> IoResult<()> {
         try!(self.ibox(0));
+        let mut suppress_space = false;
         for (i, tt) in tts.iter().enumerate() {
-            if i != 0 {
+            if i != 0 && !suppress_space {
                 try!(space(&mut self.s));
             }
             try!(self.print_tt(tt));
+            // There should be no space between the module name and the following `::` in paths,
+            // otherwise imported macros get re-parsed from crate metadata incorrectly (issue #20701)
+            suppress_space = match tt {
+                &ast::TtToken(_, token::Ident(_, token::ModName)) |
+                &ast::TtToken(_, token::MatchNt(_, _, _, token::ModName)) |
+                &ast::TtToken(_, token::SubstNt(_, token::ModName)) => true,
+                _ => false
+            }
         }
         self.end()
     }

--- a/src/test/auxiliary/macro_with_super_1.rs
+++ b/src/test/auxiliary/macro_with_super_1.rs
@@ -11,7 +11,7 @@
 #![crate_type = "lib"]
 
 #[macro_export]
-macro_rules! declare { 
+macro_rules! declare {
     () => (
         pub fn aaa() {}
 

--- a/src/test/auxiliary/macro_with_super_1.rs
+++ b/src/test/auxiliary/macro_with_super_1.rs
@@ -1,0 +1,26 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "lib"]
+
+#[macro_export]
+macro_rules! declare { 
+    () => (
+        pub fn aaa() {}
+
+        pub mod bbb {
+            use super::aaa;
+
+            pub fn ccc() {
+                aaa();
+            }
+        }
+    )
+}

--- a/src/test/run-pass/macro_with_super_2.rs
+++ b/src/test/run-pass/macro_with_super_2.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:macro_with_super_1.rs
+
+#[macro_use]
+extern crate macro_with_super_1;
+
+declare!();
+
+fn main() {
+    bbb::ccc();
+}


### PR DESCRIPTION
... so that `super::foo` gets serialized as `super:: foo`, rather than `super :: foo`.
