### PR TITLE
Fix Unicode name mangling

### DIFF
--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -227,9 +227,8 @@ pub fn sanitize(s: &str) -> String {
         match c {
             // Escape these with $ sequences
             '@' => result.push_str("$SP$"),
-            '~' => result.push_str("$UP$"),
-            '*' => result.push_str("$RP$"),
-            '&' => result.push_str("$BP$"),
+            '*' => result.push_str("$BP$"),
+            '&' => result.push_str("$RF$"),
             '<' => result.push_str("$LT$"),
             '>' => result.push_str("$GT$"),
             '(' => result.push_str("$LP$"),
@@ -247,10 +246,14 @@ pub fn sanitize(s: &str) -> String {
             | '_' | '.' | '$' => result.push(c),
 
             _ => {
-                let mut tstr = String::new();
-                for c in c.escape_unicode() { tstr.push(c) }
                 result.push('$');
-                result.push_str(&tstr[1..]);
+                for c in c.escape_unicode().skip(1) {
+                    match c {
+                        '{' => {},
+                        '}' => result.push('$'),
+                        c => result.push(c),
+                    }
+                }
             }
         }
     }

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -57,22 +57,22 @@ mod test {
 
     #[test]
     fn demangle_dollars() {
-        t!("_ZN4$UP$E", "Box");
-        t!("_ZN8$UP$testE", "Boxtest");
-        t!("_ZN8$UP$test4foobE", "Boxtest::foob");
-        t!("_ZN10$u{20}test4foobE", " test::foob");
+        t!("_ZN4$RP$E", ")");
+        t!("_ZN8$RF$testE", "&test");
+        t!("_ZN8$BP$test4foobE", "*test::foob");
+        t!("_ZN9$u20$test4foobE", " test::foob");
     }
 
     #[test]
     fn demangle_many_dollars() {
-        t!("_ZN14test$u{20}test4foobE", "test test::foob");
-        t!("_ZN12test$UP$test4foobE", "testBoxtest::foob");
+        t!("_ZN13test$u20$test4foobE", "test test::foob");
+        t!("_ZN12test$BP$test4foobE", "test*test::foob");
     }
 
     #[test]
     fn demangle_windows() {
         t!("ZN4testE", "test");
-        t!("ZN14test$u{20}test4foobE", "test test::foob");
-        t!("ZN12test$UP$test4foobE", "testBoxtest::foob");
+        t!("ZN13test$u20$test4foobE", "test test::foob");
+        t!("ZN12test$RF$test4foobE", "test&test::foob");
     }
 }

--- a/src/libstd/sys/common/backtrace.rs
+++ b/src/libstd/sys/common/backtrace.rs
@@ -107,9 +107,8 @@ pub fn demangle(writer: &mut Writer, s: &str) -> IoResult<()> {
                     // see src/librustc/back/link.rs for these mappings
                     demangle! (
                         "$SP$", => "@",
-                        "$UP$", => "Box",
-                        "$RP$", => "*",
-                        "$BP$", => "&",
+                        "$BP$", => "*",
+                        "$RF$", => "&",
                         "$LT$", => "<",
                         "$GT$", => ">",
                         "$LP$", => "(",
@@ -118,10 +117,11 @@ pub fn demangle(writer: &mut Writer, s: &str) -> IoResult<()> {
 
                         // in theory we can demangle any Unicode code point, but
                         // for simplicity we just catch the common ones.
-                        "$u{20}", => " ",
-                        "$u{27}", => "'",
-                        "$u{5b}", => "[",
-                        "$u{5d}", => "]"
+                        "$u7e$", => "~",
+                        "$u20$", => " ",
+                        "$u27$", => "'",
+                        "$u5b$", => "[",
+                        "$u5d$", => "]"
                     )
                 } else {
                     let idx = match rest.find('$') {


### PR DESCRIPTION
`{` and `}` aren’t valid characters on ARM, so this makes Unicode characters render as, e.g., `$u38d$` instead of `$u{38d}`.

This also fixes a small bug where `)` (**r**ight **p**arenthesis) and `*` (**r**aw **p**ointer) would both mangle to `$RP$`, making `)` show up as `*` in backtraces.
