### PR TITLE
Resolve type vars when inferring borrow kinds for upvars

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1635,6 +1635,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     {
         let raw_ty = self.expr_ty(expr);
         let raw_ty = self.infcx().shallow_resolve(raw_ty);
+        let resolve_ty = |&: ty: Ty<'tcx>| self.infcx().resolve_type_vars_if_possible(&ty);
         ty::adjust_ty(self.tcx(),
                       expr.span,
                       expr.id,
@@ -1642,7 +1643,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                       adjustment,
                       |method_call| self.inh.method_map.borrow()
                                                        .get(&method_call)
-                                                       .map(|method| method.ty))
+                                                       .map(|method| resolve_ty(method.ty)))
     }
 
     pub fn node_ty(&self, id: ast::NodeId) -> Ty<'tcx> {

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -121,13 +121,8 @@ impl<'a,'tcx> SeedBorrowKind<'a,'tcx> {
                      capture_clause: ast::CaptureClause,
                      _body: &ast::Block)
     {
-        let is_old_skool_closure = match self.fcx.expr_ty(expr).sty {
-            _ => false,
-        };
-
         match capture_clause {
-            ast::CaptureByValue if !is_old_skool_closure => {
-            }
+            ast::CaptureByValue => {}
             _ => {
                 ty::with_freevars(self.tcx(), expr.id, |freevars| {
                     for freevar in freevars.iter() {

--- a/src/test/run-pass/issue-21306.rs
+++ b/src/test/run-pass/issue-21306.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::sync::Arc;
+
+fn main() {
+    let x = 5us;
+    let command = Arc::new(Box::new(|&:| { x*2 }));
+    assert_eq!(command(), 10);
+}


### PR DESCRIPTION
As part of #20432, upvar checking is now moved out of regionck to its
own pass and before regionck. But regionck has some type resolution of
its own. Without them, now separated upvar checking may be tripped over
by residue `ty_infer`.

Closes #21306
