### PR TITLE
std: Relax Result::unwrap() to Debug

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -229,7 +229,7 @@
 use self::Result::{Ok, Err};
 
 use clone::Clone;
-use fmt::Display;
+use fmt::Debug;
 use iter::{Iterator, IteratorExt, DoubleEndedIterator, FromIterator, ExactSizeIterator};
 use ops::{FnMut, FnOnce};
 use option::Option::{self, None, Some};
@@ -714,7 +714,7 @@ impl<T, E> Result<T, E> {
 }
 
 #[stable]
-impl<T, E: Display> Result<T, E> {
+impl<T, E: Debug> Result<T, E> {
     /// Unwraps a result, yielding the content of an `Ok`.
     ///
     /// # Panics
@@ -739,13 +739,13 @@ impl<T, E: Display> Result<T, E> {
         match self {
             Ok(t) => t,
             Err(e) =>
-                panic!("called `Result::unwrap()` on an `Err` value: {}", e)
+                panic!("called `Result::unwrap()` on an `Err` value: {:?}", e)
         }
     }
 }
 
 #[stable]
-impl<T: Display, E> Result<T, E> {
+impl<T: Debug, E> Result<T, E> {
     /// Unwraps a result, yielding the content of an `Err`.
     ///
     /// # Panics
@@ -769,7 +769,7 @@ impl<T: Display, E> Result<T, E> {
     pub fn unwrap_err(self) -> E {
         match self {
             Ok(t) =>
-                panic!("called `Result::unwrap_err()` on an `Ok` value: {}", t),
+                panic!("called `Result::unwrap_err()` on an `Ok` value: {:?}", t),
             Err(e) => e
         }
     }

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -382,7 +382,7 @@ impl<T> !Sync for SyncSender<T> {}
 /// A `send` operation can only fail if the receiving end of a channel is
 /// disconnected, implying that the data could never be received. The error
 /// contains the data being sent as a payload so it can be recovered.
-#[derive(PartialEq, Eq, Show)]
+#[derive(PartialEq, Eq)]
 #[stable]
 pub struct SendError<T>(pub T);
 
@@ -412,7 +412,7 @@ pub enum TryRecvError {
 
 /// This enumeration is the list of the possible error outcomes for the
 /// `SyncSender::try_send` method.
-#[derive(PartialEq, Clone, Show)]
+#[derive(PartialEq, Clone)]
 #[stable]
 pub enum TrySendError<T> {
     /// The data could not be sent on the channel because it would require that
@@ -962,9 +962,26 @@ impl<T: Send> Drop for Receiver<T> {
 }
 
 #[stable]
+impl<T> fmt::Debug for SendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        "SendError(..)".fmt(f)
+    }
+}
+
+#[stable]
 impl<T> fmt::Display for SendError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         "sending on a closed channel".fmt(f)
+    }
+}
+
+#[stable]
+impl<T> fmt::Debug for TrySendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            TrySendError::Full(..) => "Full(..)".fmt(f),
+            TrySendError::Disconnected(..) => "Disconnected(..)".fmt(f),
+        }
     }
 }
 

--- a/src/libstd/sync/poison.rs
+++ b/src/libstd/sync/poison.rs
@@ -53,7 +53,6 @@ pub struct Guard {
 /// is held. The precise semantics for when a lock is poisoned is documented on
 /// each lock, but once a lock is poisoned then all future acquisitions will
 /// return this error.
-#[derive(Show)]
 #[stable]
 pub struct PoisonError<T> {
     guard: T,
@@ -61,7 +60,6 @@ pub struct PoisonError<T> {
 
 /// An enumeration of possible errors which can occur while calling the
 /// `try_lock` method.
-#[derive(Show)]
 #[stable]
 pub enum TryLockError<T> {
     /// The lock could not be acquired because another task failed while holding
@@ -91,6 +89,13 @@ pub type LockResult<Guard> = Result<Guard, PoisonError<Guard>>;
 /// have been acquired for other reasons.
 #[stable]
 pub type TryLockResult<Guard> = Result<Guard, TryLockError<Guard>>;
+
+#[stable]
+impl<T> fmt::Debug for PoisonError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        "PoisonError { inner: .. }".fmt(f)
+    }
+}
 
 #[stable]
 impl<T> fmt::Display for PoisonError<T> {
@@ -130,6 +135,16 @@ impl<T> PoisonError<T> {
 impl<T> FromError<PoisonError<T>> for TryLockError<T> {
     fn from_error(err: PoisonError<T>) -> TryLockError<T> {
         TryLockError::Poisoned(err)
+    }
+}
+
+#[stable]
+impl<T> fmt::Debug for TryLockError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            TryLockError::Poisoned(..) => "Poisoned(..)".fmt(f),
+            TryLockError::WouldBlock => "WouldBlock".fmt(f)
+        }
     }
 }
 


### PR DESCRIPTION
This commit relaxes the bound on `Result::unwrap` and `Result::unwrap_err` from
the `Display` trait to the `Debug` trait for generating an error message about
the unwrapping operation.

This commit is a breaking change and any breakage should be mitigated by
ensuring that `Debug` is implemented on the relevant type.

[breaking-change]
