### PR TITLE
remove discuss link from the book

### DIFF
--- a/src/doc/trpl/installing-rust.md
+++ b/src/doc/trpl/installing-rust.md
@@ -83,7 +83,6 @@ If not, there are a number of places where you can get help. The easiest is
 you can access through
 [Mibbit](http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust). Click
 that link, and you'll be chatting with other Rustaceans (a silly nickname we
-call ourselves), and we can help you out. Other great resources include [our
-forum](http://discuss.rust-lang.org/), [the /r/rust
-subreddit](http://www.reddit.com/r/rust), and [Stack
+call ourselves), and we can help you out. Other great resources include [the
+/r/rust subreddit](http://www.reddit.com/r/rust), and [Stack
 Overflow](http://stackoverflow.com/questions/tagged/rust).


### PR DESCRIPTION
We've had some new people post questions to Discuss, so this should be removed for now. http://discuss.rust-lang.org/t/did-you-mean-to-point-to-discuss-rust-lang-org-as-a-user-forum/1381
