### PR TITLE
Compatibility fixes for LLVM 3.5

### DIFF
--- a/src/librustc_trans/trans/context.rs
+++ b/src/librustc_trans/trans/context.rs
@@ -876,11 +876,10 @@ fn declare_intrinsic(ccx: &CrateContext, key: & &'static str) -> Option<ValueRef
     ifn!("llvm.assume", fn(i1) -> void);
 
     // Some intrinsics were introduced in later versions of LLVM, but they have
-    // fallbacks in libc or libm and such. Currently, all of these intrinsics
-    // were introduced in LLVM 3.4, so we case on that.
+    // fallbacks in libc or libm and such.
     macro_rules! compatible_ifn {
-        ($name:expr, $cname:ident ($($arg:expr),*) -> $ret:expr) => (
-            if unsafe { llvm::LLVMVersionMinor() >= 4 } {
+        ($name:expr, $cname:ident ($($arg:expr),*) -> $ret:expr, $llvm_version:expr) => (
+            if unsafe { llvm::LLVMVersionMinor() >= $llvm_version } {
                 // The `if key == $name` is already in ifn!
                 ifn!($name, fn($($arg),*) -> $ret);
             } else if *key == $name {
@@ -893,10 +892,10 @@ fn declare_intrinsic(ccx: &CrateContext, key: & &'static str) -> Option<ValueRef
         )
     }
 
-    compatible_ifn!("llvm.copysign.f32", copysignf(t_f32, t_f32) -> t_f32);
-    compatible_ifn!("llvm.copysign.f64", copysign(t_f64, t_f64) -> t_f64);
-    compatible_ifn!("llvm.round.f32", roundf(t_f32) -> t_f32);
-    compatible_ifn!("llvm.round.f64", round(t_f64) -> t_f64);
+    compatible_ifn!("llvm.copysign.f32", copysignf(t_f32, t_f32) -> t_f32, 4);
+    compatible_ifn!("llvm.copysign.f64", copysign(t_f64, t_f64) -> t_f64, 4);
+    compatible_ifn!("llvm.round.f32", roundf(t_f32) -> t_f32, 4);
+    compatible_ifn!("llvm.round.f64", round(t_f64) -> t_f64, 4);
 
 
     if ccx.sess().opts.debuginfo != NoDebugInfo {

--- a/src/librustc_trans/trans/context.rs
+++ b/src/librustc_trans/trans/context.rs
@@ -873,7 +873,6 @@ fn declare_intrinsic(ccx: &CrateContext, key: & &'static str) -> Option<ValueRef
     ifn!("llvm.lifetime.end", fn(t_i64, i8p) -> void);
 
     ifn!("llvm.expect.i1", fn(i1, i1) -> i1);
-    ifn!("llvm.assume", fn(i1) -> void);
 
     // Some intrinsics were introduced in later versions of LLVM, but they have
     // fallbacks in libc or libm and such.
@@ -896,6 +895,7 @@ fn declare_intrinsic(ccx: &CrateContext, key: & &'static str) -> Option<ValueRef
     compatible_ifn!("llvm.copysign.f64", copysign(t_f64, t_f64) -> t_f64, 4);
     compatible_ifn!("llvm.round.f32", roundf(t_f32) -> t_f32, 4);
     compatible_ifn!("llvm.round.f64", round(t_f64) -> t_f64, 4);
+    compatible_ifn!("llvm.assume", llvmcompat_assume(i1) -> void, 6);
 
 
     if ccx.sess().opts.debuginfo != NoDebugInfo {

--- a/src/rt/rust_builtin.c
+++ b/src/rt/rust_builtin.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <assert.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 #if !defined(__WIN32__)
 #include <sys/time.h>
@@ -198,6 +199,11 @@ rust_unset_sigprocmask() {
 // no symbol exists for it.
 int *__dfly_error(void) { return __error(); }
 #endif
+
+void
+llvmcompat_assume(bool c) {
+    // empty stub for LLVM before 3.6
+}
 
 //
 // Local Variables:


### PR DESCRIPTION
This fixes building with a system-installed LLVM 3.5 and also closes #20010
