### PR TITLE
Improve mobile-friendliness of API docs

### DIFF
--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -64,7 +64,6 @@
 
 body {
     color: #333;
-    min-width: 500px;
     font: 16px/1.4 "Source Serif Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
     margin: 0;
     position: relative;
@@ -590,6 +589,14 @@ pre.rust { position: relative; }
 
     .content {
         margin-left: 0px;
+    }
+
+    .content .in-band {
+        width: 100%;
+    }
+
+    .content .out-of-band {
+        display: none;
     }
 
     .toggle-wrapper > .collapse-toggle {


### PR DESCRIPTION
This PR removes the `min-width` rule from `body` so that no horizontal scrolling is necessary on mobile, and also hides out-of-band information on mobile to create more room for the in-band information.
