### PR TITLE
Associated types support for deriving::TraitDef

### DIFF
--- a/src/libsyntax/ext/deriving/bounds.rs
+++ b/src/libsyntax/ext/deriving/bounds.rs
@@ -51,7 +51,8 @@ pub fn expand_deriving_bound<F>(cx: &mut ExtCtxt,
         path: Path::new(vec!("std", "marker", name)),
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
-        methods: vec!()
+        methods: Vec::new(),
+        associated_types: Vec::new(),
     };
 
     trait_def.expand(cx, mitem, item, push)

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -44,7 +44,8 @@ pub fn expand_deriving_clone<F>(cx: &mut ExtCtxt,
                     cs_clone("Clone", c, s, sub)
                 }),
             }
-        )
+        ),
+        associated_types: Vec::new(),
     };
 
     trait_def.expand(cx, mitem, item, push)

--- a/src/libsyntax/ext/deriving/cmp/eq.rs
+++ b/src/libsyntax/ext/deriving/cmp/eq.rs
@@ -88,7 +88,8 @@ pub fn expand_deriving_eq<F>(cx: &mut ExtCtxt,
         methods: vec!(
             md!("eq", cs_eq),
             md!("ne", cs_ne)
-        )
+        ),
+        associated_types: Vec::new(),
     };
     trait_def.expand(cx, mitem, item, push)
 }

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -78,7 +78,8 @@ pub fn expand_deriving_ord<F>(cx: &mut ExtCtxt,
             md!("le", true, true),
             md!("gt", false, false),
             md!("ge", false, true)
-        ]
+        ],
+        associated_types: Vec::new(),
     };
     trait_def.expand(cx, mitem, item, push)
 }

--- a/src/libsyntax/ext/deriving/cmp/totaleq.rs
+++ b/src/libsyntax/ext/deriving/cmp/totaleq.rs
@@ -61,7 +61,8 @@ pub fn expand_deriving_totaleq<F>(cx: &mut ExtCtxt,
                     cs_total_eq_assert(a, b, c)
                 })
             }
-        )
+        ),
+        associated_types: Vec::new(),
     };
     trait_def.expand(cx, mitem, item, push)
 }

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -45,7 +45,8 @@ pub fn expand_deriving_totalord<F>(cx: &mut ExtCtxt,
                     cs_cmp(a, b, c)
                 }),
             }
-        )
+        ),
+        associated_types: Vec::new(),
     };
 
     trait_def.expand(cx, mitem, item, push)

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -79,7 +79,9 @@ fn expand_deriving_decodable_imp<F>(cx: &mut ExtCtxt,
                 combine_substructure: combine_substructure(box |a, b, c| {
                     decodable_substructure(a, b, c, krate)
                 }),
-            })
+            }
+        ),
+        associated_types: Vec::new(),
     };
 
     trait_def.expand(cx, mitem, item, push)

--- a/src/libsyntax/ext/deriving/default.rs
+++ b/src/libsyntax/ext/deriving/default.rs
@@ -43,7 +43,9 @@ pub fn expand_deriving_default<F>(cx: &mut ExtCtxt,
                 combine_substructure: combine_substructure(box |a, b, c| {
                     default_substructure(a, b, c)
                 })
-            })
+            }
+        ),
+        associated_types: Vec::new(),
     };
     trait_def.expand(cx, mitem, item, push)
 }

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -155,7 +155,9 @@ fn expand_deriving_encodable_imp<F>(cx: &mut ExtCtxt,
                 combine_substructure: combine_substructure(box |a, b, c| {
                     encodable_substructure(a, b, c)
                 }),
-            })
+            }
+        ),
+        associated_types: Vec::new(),
     };
 
     trait_def.expand(cx, mitem, item, push)

--- a/src/libsyntax/ext/deriving/hash.rs
+++ b/src/libsyntax/ext/deriving/hash.rs
@@ -54,7 +54,8 @@ pub fn expand_deriving_hash<F>(cx: &mut ExtCtxt,
                     hash_substructure(a, b, c)
                 })
             }
-        )
+        ),
+        associated_types: Vec::new(),
     };
 
     hash_trait_def.expand(cx, mitem, item, push);

--- a/src/libsyntax/ext/deriving/primitive.rs
+++ b/src/libsyntax/ext/deriving/primitive.rs
@@ -65,7 +65,9 @@ pub fn expand_deriving_from_primitive<F>(cx: &mut ExtCtxt,
                 combine_substructure: combine_substructure(box |c, s, sub| {
                     cs_from("u64", c, s, sub)
                 }),
-            })
+            }
+        ),
+        associated_types: Vec::new(),
     };
 
     trait_def.expand(cx, mitem, item, push)

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -49,7 +49,8 @@ pub fn expand_deriving_rand<F>(cx: &mut ExtCtxt,
                     rand_substructure(a, b, c)
                 })
             }
-        )
+        ),
+        associated_types: Vec::new(),
     };
     trait_def.expand(cx, mitem, item, push)
 }

--- a/src/libsyntax/ext/deriving/show.rs
+++ b/src/libsyntax/ext/deriving/show.rs
@@ -35,10 +35,10 @@ pub fn expand_deriving_show<F>(cx: &mut ExtCtxt,
     let trait_def = TraitDef {
         span: span,
         attributes: Vec::new(),
-        path: Path::new(vec!("std", "fmt", "Debug")),
+        path: Path::new(vec!["std", "fmt", "Debug"]),
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
-        methods: vec!(
+        methods: vec![
             MethodDef {
                 name: "fmt",
                 generics: LifetimeBounds::empty(),
@@ -50,7 +50,8 @@ pub fn expand_deriving_show<F>(cx: &mut ExtCtxt,
                     show_substructure(a, b, c)
                 })
             }
-        )
+        ],
+        associated_types: Vec::new(),
     };
     trait_def.expand(cx, mitem, item, push)
 }


### PR DESCRIPTION
Fixes #21497 

I don't know if this can be tested with built-in tests.
