### PR TITLE
syntax: Don't put quotes around filenames in codemap

### DIFF
--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -364,9 +364,10 @@ impl CodeMap {
         };
 
         // Append '\n' in case it's not already there.
-        // This is a workaround to prevent CodeMap.lookup_filemap_idx from accidentally
-        // overflowing into the next filemap in case the last byte of span is also the last
-        // byte of filemap, which leads to incorrect results from CodeMap.span_to_*.
+        // This is a workaround to prevent CodeMap.lookup_filemap_idx from
+        // accidentally overflowing into the next filemap in case the last byte
+        // of span is also the last byte of filemap, which leads to incorrect
+        // results from CodeMap.span_to_*.
         if src.len() > 0 && !src.ends_with("\n") {
             src.push('\n');
         }

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -135,7 +135,7 @@ pub fn expand_include_str(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
     let bytes = match File::open(&file).read_to_end() {
         Err(e) => {
             cx.span_err(sp,
-                        &format!("couldn't read {:?}: {}",
+                        &format!("couldn't read {}: {}",
                                 file.display(),
                                 e)[]);
             return DummyResult::expr(sp);
@@ -146,7 +146,7 @@ pub fn expand_include_str(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
         Ok(src) => {
             // Add this input file to the code map to make it available as
             // dependency information
-            let filename = format!("{:?}", file.display());
+            let filename = format!("{}", file.display());
             let interned = token::intern_and_get_ident(&src[]);
             cx.codemap().new_filemap(filename, src);
 
@@ -154,7 +154,7 @@ pub fn expand_include_str(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
         }
         Err(_) => {
             cx.span_err(sp,
-                        &format!("{:?} wasn't a utf-8 file",
+                        &format!("{} wasn't a utf-8 file",
                                 file.display())[]);
             return DummyResult::expr(sp);
         }
@@ -171,7 +171,7 @@ pub fn expand_include_bytes(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
     match File::open(&file).read_to_end() {
         Err(e) => {
             cx.span_err(sp,
-                        &format!("couldn't read {:?}: {}", file.display(), e)[]);
+                        &format!("couldn't read {}: {}", file.display(), e)[]);
             return DummyResult::expr(sp);
         }
         Ok(bytes) => {


### PR DESCRIPTION
This ends up propagating all the way out to the output of dep-info which then
makes Cargo think that files are not existent (it thinks the files have quotes
in their name) when they in fact do.
