### PR TITLE
Add lint for large `const` items

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -1872,6 +1872,12 @@ declare_lint! {
     "detects potentially-forgotten implementations of `Copy`"
 }
 
+declare_lint! {
+    pub LARGE_CONST_ITEMS,
+    Warn,
+    "detects large `const` items"
+}
+
 /// Does nothing as a lint pass, but registers some `Lint`s
 /// which are used by other parts of the compiler.
 #[derive(Copy)]
@@ -1892,7 +1898,8 @@ impl LintPass for HardwiredLints {
             UNKNOWN_FEATURES,
             UNKNOWN_CRATE_TYPES,
             VARIANT_SIZE_DIFFERENCES,
-            FAT_PTR_TRANSMUTES
+            FAT_PTR_TRANSMUTES,
+            LARGE_CONST_ITEMS
         )
     }
 }

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -753,17 +753,18 @@ impl LintPass for GatherNodeLevels {
     }
 
     fn check_item(&mut self, cx: &Context, it: &ast::Item) {
-        match it.node {
-            ast::ItemEnum(..) => {
-                let lint_id = LintId::of(builtin::VARIANT_SIZE_DIFFERENCES);
-                let lvlsrc = cx.lints.get_level_source(lint_id);
-                match lvlsrc {
-                    (lvl, _) if lvl != Allow => {
-                        cx.node_levels.borrow_mut()
-                            .insert((it.id, lint_id), lvlsrc);
-                    },
-                    _ => { }
-                }
+        let lint = match it.node {
+            ast::ItemEnum(..) => builtin::VARIANT_SIZE_DIFFERENCES,
+            ast::ItemConst(..) => builtin::LARGE_CONST_ITEMS,
+            _ => return
+        };
+
+        let lint_id = LintId::of(lint);
+        let lvlsrc = cx.lints.get_level_source(lint_id);
+        match lvlsrc {
+            (lvl, _) if lvl != Allow => {
+                cx.node_levels.borrow_mut()
+                    .insert((it.id, lint_id), lvlsrc);
             },
             _ => { }
         }

--- a/src/libstd/thread_local/mod.rs
+++ b/src/libstd/thread_local/mod.rs
@@ -190,6 +190,7 @@ macro_rules! __thread_local_inner {
     );
     ($init:expr, $t:ty) => ({
         #[cfg(all(any(target_os = "macos", target_os = "linux"), not(target_arch = "aarch64")))]
+        #[cfg_attr(not(stage0), allow(large_const_items))]
         const _INIT: ::std::thread_local::__impl::KeyInner<$t> = {
             ::std::thread_local::__impl::KeyInner {
                 inner: ::std::cell::UnsafeCell { value: $init },
@@ -199,6 +200,7 @@ macro_rules! __thread_local_inner {
         };
 
         #[cfg(any(not(any(target_os = "macos", target_os = "linux")), target_arch = "aarch64"))]
+        #[cfg_attr(not(stage0), allow(large_const_items))]
         const _INIT: ::std::thread_local::__impl::KeyInner<$t> = {
             unsafe extern fn __destroy(ptr: *mut u8) {
                 ::std::thread_local::__impl::destroy_value::<$t>(ptr);

--- a/src/test/compile-fail/lint-large-const-items.rs
+++ b/src/test/compile-fail/lint-large-const-items.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![forbid(large_const_items)]
+#![allow(dead_code)]
+
+const FOO: [u8; 100] = [0; 100]; //~ ERROR using large `const` items (100 bytes) is not recommended
+
+const BAR: &'static [u8; 100] = &[0; 100];
+const BAZ: &'static str = "Hello!";
+
+fn main() { }


### PR DESCRIPTION
`const`-ants are defined to be inline rvalues and this definition sometimes leads to quite non-intuitive behavior.
For example, in this code the array `ARR` is (correctly) copied to the stack 3 times (see the unoptimized IR/asm http://is.gd/UMQz1B):

```
const ARR: [u8; 100] = [33; 100];

fn main() {
    let _a = ARR[4] + ARR[7] + ARR[47];
}
```

The lint prevents such mistakes by checking the size of a `const`-ant and warning if it's larger than `MAX_CONST_SIZE`.

In this PR the value of `MAX_CONST_SIZE` is selected to be 64 bytes, so nothing in Rust itself breaks (except for one place in libstd/thread_local), but it can (should?) be smaller.
Obviously, the value should be larger than size of fat reference, because the code like

```
const MY_STR: &'static str = "Hello!";
```

shouldn't warn.
Any ideas on what should the value of `MAX_CONST_SIZE` ideally be?
