### PR TITLE
rustc: Add error squiggles to multiline errors

### DIFF
--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -448,13 +448,40 @@ fn highlight_lines(err: &mut EmitterWriter,
                    lvl: Level,
                    lines: codemap::FileLines) -> io::IoResult<()> {
     let fm = &*lines.file;
+    let display_lines = &lines.lines[];
 
-    let mut elided = false;
-    let mut display_lines = &lines.lines[];
-    if display_lines.len() > MAX_LINES {
-        display_lines = &display_lines[0us..MAX_LINES];
-        elided = true;
+    // When there is one line put the highlighting underneath it,
+    // like `^~~~~~~~, when there are multiple lines, put the highlight
+    // above, like `.~~~~~~`.
+    // FIXME (#3260) Combining characters not handled correctly
+    let (squiggle_before_lines, lo_char_col, hi_char_col) = if display_lines.len() <= 1 {
+        // One line case is easy, hi col is the span hi_char_col
+        let lo_char_col = cm.lookup_char_pos(sp.lo).col;
+        let hi_char_col = cm.lookup_char_pos(sp.hi).col;
+        (false, lo_char_col, hi_char_col)
+    } else {
+        // In the multiline case we're highlighting only the first
+        // line (from above), so instead extend for the length
+        // of the first line.
+        let lo_char_col = cm.lookup_char_pos(sp.lo).col;
+        let hi_char_col = match fm.get_line(display_lines[0]) {
+            Some(line_str) => codemap::CharPos(line_str.chars().count()),
+            None => codemap::CharPos(0)
+        };
+        (true, lo_char_col, hi_char_col)
+    };
+
+    if squiggle_before_lines {
+        try!(write_span_squiggle(err, (lo_char_col, hi_char_col), lvl, &lines, ','));
     }
+
+    // Elide some of the lines if there are too many
+    let (display_lines, elided) = if display_lines.len() <= MAX_LINES {
+        (display_lines, false)
+    } else {
+        (&display_lines[0us..MAX_LINES], true)
+    };
+
     // Print the offending lines
     for &line_number in display_lines.iter() {
         if let Some(line) = fm.get_line(line_number) {
@@ -468,53 +495,61 @@ fn highlight_lines(err: &mut EmitterWriter,
         try!(write!(&mut err.dst, "{0:1$}...\n", "", s.len()));
     }
 
-    // FIXME (#3260)
-    // If there's one line at fault we can easily point to the problem
-    if lines.lines.len() == 1us {
-        let lo = cm.lookup_char_pos(sp.lo);
-        let mut digits = 0us;
-        let mut num = (lines.lines[0] + 1us) / 10us;
-
-        // how many digits must be indent past?
-        while num > 0us { num /= 10us; digits += 1us; }
-
-        // indent past |name:## | and the 0-offset column location
-        let left = fm.name.len() + digits + lo.col.to_usize() + 3us;
-        let mut s = String::new();
-        // Skip is the number of characters we need to skip because they are
-        // part of the 'filename:line ' part of the previous line.
-        let skip = fm.name.len() + digits + 3us;
-        for _ in range(0, skip) {
-            s.push(' ');
-        }
-        if let Some(orig) = fm.get_line(lines.lines[0]) {
-            for pos in range(0us, left - skip) {
-                let cur_char = orig.as_bytes()[pos] as char;
-                // Whenever a tab occurs on the previous line, we insert one on
-                // the error-point-squiggly-line as well (instead of a space).
-                // That way the squiggly line will usually appear in the correct
-                // position.
-                match cur_char {
-                    '\t' => s.push('\t'),
-                    _ => s.push(' '),
-                };
-            }
-        }
-
-        try!(write!(&mut err.dst, "{}", s));
-        let mut s = String::from_str("^");
-        let hi = cm.lookup_char_pos(sp.hi);
-        if hi.col != lo.col {
-            // the ^ already takes up one space
-            let num_squigglies = hi.col.to_usize() - lo.col.to_usize() - 1us;
-            for _ in range(0, num_squigglies) {
-                s.push('~');
-            }
-        }
-        try!(print_maybe_styled(err,
-                                &format!("{}\n", s)[],
-                                term::attr::ForegroundColor(lvl.color())));
+     if !squiggle_before_lines {
+        try!(write_span_squiggle(err, (lo_char_col, hi_char_col), lvl, &lines, '^'));
     }
+
+    Ok(())
+}
+
+fn write_span_squiggle(err: &mut EmitterWriter,
+                       (lo_char_col, hi_char_col): (codemap::CharPos, codemap::CharPos),
+                       lvl: Level,
+                       lines: &codemap::FileLines,
+                       arrow_char: char) -> io::IoResult<()> {
+    let fm = &*lines.file;
+
+    let mut digits = 0us;
+    let mut num = (lines.lines[0] + 1us) / 10us;
+
+    // how many digits must be indent past?
+    while num > 0us { num /= 10us; digits += 1us; }
+
+    // indent past |name:## | and the 0-offset column location
+    let left = fm.name.len() + digits + lo_char_col.to_usize() + 3us;
+    let mut s = String::new();
+    // Skip is the number of characters we need to skip because they are
+    // part of the 'filename:line ' part of the previous line.
+    let skip = fm.name.len() + digits + 3us;
+    for _ in range(0, skip) {
+        s.push(' ');
+    }
+    if let Some(orig) = fm.get_line(lines.lines[0]) {
+        for pos in range(0us, left - skip) {
+            let cur_char = orig.as_bytes()[pos] as char;
+            // Whenever a tab occurs on the previous line, we insert one on
+            // the error-point-squiggly-line as well (instead of a space).
+            // That way the squiggly line will usually appear in the correct
+            // position.
+            match cur_char {
+                '\t' => s.push('\t'),
+                _ => s.push(' '),
+            };
+        }
+    }
+
+    try!(write!(&mut err.dst, "{}", s));
+    let mut s = arrow_char.to_string();
+    if hi_char_col > lo_char_col {
+        // the ^ already takes up one space
+        let num_squigglies = hi_char_col.to_usize() - lo_char_col.to_usize() - 1us;
+        for _ in range(0, num_squigglies) {
+            s.push('~');
+        }
+    }
+    try!(print_maybe_styled(err,
+                            &format!("{}\n", s)[],
+                            term::attr::ForegroundColor(lvl.color())));
     Ok(())
 }
 

--- a/src/test/run-make/rustc-error-squigglies/Makefile
+++ b/src/test/run-make/rustc-error-squigglies/Makefile
@@ -1,0 +1,15 @@
+-include ../tools.mk
+
+# Testing that the squiggles rustc produces look right, by comparing to some
+# drawn in the source file.
+
+# This is what rustc's error messages line looks like for this test:
+# squiggle-test.rs:15:11: 15:32 [error begins here]
+# ^----------------------------^ We need to compensate for this much whitespace.
+
+OUT=$(shell $(RUSTC) squiggle-test.rs 2>&1 | grep "~" | cut -b 1-30 --complement )
+EXPECTED=$(shell cat squiggle-test.rs | grep "~" | cut -b 1-10 --complement )
+all:
+	echo OUT "$(OUT)"
+	echo EXP "$(EXPECTED)"
+	test "$(OUT)" = "$(EXPECTED)"

--- a/src/test/run-make/rustc-error-squigglies/squiggle-test.rs
+++ b/src/test/run-make/rustc-error-squigglies/squiggle-test.rs
@@ -1,0 +1,52 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo(a: i32, b: i32, c: i32, d: i32) { }
+
+fn main() {
+
+          foo(1000, 1000, 1000);
+// EXPECT ^~~~~~~~~~~~~~~~~~~~~
+
+
+// EXPECT ,~~~~~~~~~~~~~~
+          foo(1000, 1000,
+              1000);
+
+// EXPECT        ,~~~~~~~~~~~~~~
+                 foo(1000, 1000,
+          1000);
+
+// EXPECT    ,~~~~~~~~~~~~~~
+             foo(1000, 1000,
+          1000);
+
+// EXPECT     ,~~~~~~~~~~~~~~
+              foo(1000, 1000,
+          1000);
+
+// EXPECT     ,~~~~~~~~
+              foo(1000,
+                        1000,
+                              1000);
+
+// EXPECT ,~~~~~~~~
+          foo(1000,
+              1000,
+              1000,
+              1000,
+              1000,
+              1000,
+              1000);
+
+// The above is elided because it is too many lines but prints the
+// overhead squigglies
+
+}


### PR DESCRIPTION
It was bugging me that rustc wasn't squiggling my errors.

Presently, rustc only displays the `^~~~~` squiggles if the error span is a single line. This patch
adds it for multiline spans, but _before_ the code is printed and pointing down, `,~~~~`, on the
assumption that the beginning of the span is most important feature to draw attention to.

```
squiggle-test.rs:20:11: 21:20 error: this function takes 4 parameters but 3 parameters were supplied [E0061]
                              ,~~~~~~~~~~~~~~
squiggle-test.rs:20           foo(1000, 1000,
squiggle-test.rs:21               1000);
squiggle-test.rs:24:18: 25:16 error: this function takes 4 parameters but 3 parameters were supplied [E0061]
                                     ,~~~~~~~~~~~~~~
squiggle-test.rs:24                  foo(1000, 1000,
squiggle-test.rs:25           1000);
```

I played with some other ways of showing multiline span squiggles, thought this was the simplest to interpret, and am open to other ideas.

Clang has more clever ways to represent spans in errors than we do that might be better than this stil.

I did the tests with makefiles since I couldn't figure out an easier way but they're kinda ugly.
