### PR TITLE
wrmdir -> RemoveDirectoryW

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -271,6 +271,7 @@ pub use funcs::bsd43::{shutdown};
 #[cfg(windows)] pub use funcs::extra::kernel32::{GetOverlappedResult, ConnectNamedPipe};
 #[cfg(windows)] pub use funcs::extra::kernel32::{DisconnectNamedPipe, OpenProcess};
 #[cfg(windows)] pub use funcs::extra::kernel32::{MoveFileExW, VirtualProtect};
+#[cfg(windows)] pub use funcs::extra::kernel32::{RemoveDirectoryW};
 #[cfg(windows)] pub use funcs::extra::msvcrt::{get_osfhandle, open_osfhandle};
 #[cfg(windows)] pub use funcs::extra::winsock::{ioctlsocket};
 

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -342,7 +342,7 @@ pub fn chmod(p: &Path, mode: uint) -> IoResult<()> {
 
 pub fn rmdir(p: &Path) -> IoResult<()> {
     let p = try!(to_utf16(p));
-    mkerr_libc(unsafe { libc::wrmdir(p.as_ptr()) })
+    super::mkerr_winbool(unsafe { libc::RemoveDirectoryW(p.as_ptr()) })
 }
 
 pub fn chown(_p: &Path, _uid: int, _gid: int) -> IoResult<()> {


### PR DESCRIPTION
`_wrmdir` is literally just a wrapper around `RemoveDirectoryW`, so let's just use `RemoveDirectoryW`.
r? @alexcrichton 
