### PR TITLE
shell 'case' statement don't need 'break'

### DIFF
--- a/src/etc/local_stage0.sh
+++ b/src/etc/local_stage0.sh
@@ -21,19 +21,16 @@ case $OS in
     ("Linux"|"FreeBSD"|"DragonFly")
     BIN_SUF=
     LIB_SUF=.so
-    break
     ;;
     ("Darwin")
     BIN_SUF=
     LIB_SUF=.dylib
-    break
     ;;
     (*)
     BIN_SUF=.exe
     LIB_SUF=.dll
     LIB_DIR=bin
     LIB_PREFIX=
-    break
     ;;
 esac
 


### PR DESCRIPTION
the syntax of 'case' is:
`case word in [[(] pattern [| pattern] ...) list ;; ] ... esac`

`case` don't have to issue `break`. `break` is normally used to exit a
`for`, `until` or `while` loop.

`src/etc/local_stage0.sh` is used with `configure --enable-local-rust`, in order to copy local rust to stage0 directory.

Without this patch, warning message is issued (under openbsd at least): `..../src/etc/local_stage0.sh[38]: break: cannot break`

As this patch corrects a part of the build process, I can't add a regression test.
