### PR TITLE
Add "-webkit-overflow-scrolling: touch;" to book CSS

### DIFF
--- a/src/rustbook/css.rs
+++ b/src/rustbook/css.rs
@@ -40,6 +40,7 @@ body {
     bottom: 0px;
     box-sizing: border-box;
     background: none repeat scroll 0% 0% #FFF;
+    -webkit-overflow-scrolling: touch;
 }
 
 #page {

--- a/src/rustbook/css.rs
+++ b/src/rustbook/css.rs
@@ -29,6 +29,7 @@ body {
     font-size: 16px;
     background: none repeat scroll 0% 0% #FFF;
     box-sizing: border-box;
+    -webkit-overflow-scrolling: touch;
 }
 
 #page-wrapper {


### PR DESCRIPTION
Without these properties, these sections of the page in the Rust book do not have momentum scrolling in iOS which makes reading the book on iOS a fairly arduous experience. 

These commits adds the `-webkit-overflow-scrolling: touch;` property to both the TOC and the page content itself. 
