### PR TITLE
Unconditionally disable LLVM's FastISel on AArch64

### DIFF
--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -1012,6 +1012,9 @@ unsafe fn configure_llvm(sess: &Session) {
         if sess.time_llvm_passes() { add("-time-passes"); }
         if sess.print_llvm_passes() { add("-debug-pass=Structure"); }
 
+        // FIXME #21627 disable faulty FastISel on AArch64 (even for -O0)
+        if sess.target.target.arch.as_slice() == "aarch64" { add("-fast-isel=0"); }
+
         for arg in sess.opts.cg.llvm_args.iter() {
             add(&(*arg)[]);
         }


### PR DESCRIPTION
Before ca07e256f62f772d14c42f41af46f2aeacc54983, LLVM's AArch64FastISel
had a sign (and zero?) extension bug. Until rustc gets its LLVM past
that commit, the way of workaround is to pass an option to LLVM that
forces the disabling of FastISel (which would normally kick in for -O0).

Fixes #21627
