### PR TITLE
Thread native name setting

### DIFF
--- a/src/libstd/sys/common/thread_info.rs
+++ b/src/libstd/sys/common/thread_info.rs
@@ -56,6 +56,10 @@ pub fn stack_guard() -> uint {
 
 pub fn set(stack_bounds: (uint, uint), stack_guard: uint, thread: Thread) {
     THREAD_INFO.with(|c| assert!(c.borrow().is_none()));
+    match thread.name() {
+        Some(name) => unsafe { ::sys::thread::set_name(name.as_slice()); },
+        None => {}
+    }
     THREAD_INFO.with(move |c| *c.borrow_mut() = Some(ThreadInfo{
         stack_bounds: stack_bounds,
         stack_guard: stack_guard,

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -296,7 +296,7 @@ extern {
     fn pthread_set_name_np(tid: libc::pthread_t, name: *const libc::c_char);
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 extern {
     pub fn pthread_self() -> libc::pthread_t;
     pub fn pthread_get_stackaddr_np(thread: libc::pthread_t) -> *mut libc::c_void;

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -278,7 +278,7 @@ fn min_stack_size(_: *const libc::pthread_attr_t) -> libc::size_t {
     PTHREAD_STACK_MIN
 }
 
-#[cfg(any(target_os = "linux"))]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 extern {
     pub fn pthread_self() -> libc::pthread_t;
     pub fn pthread_getattr_np(native: libc::pthread_t,

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -223,9 +223,9 @@ pub unsafe fn set_name(name: &str) {
     pthread_set_name_np(pthread_self(), cname.as_ptr());
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub unsafe fn set_name(name: &str) {
-    // pthread_setname_np() since OS X 10.6
+    // pthread_setname_np() since OS X 10.6 and iOS 3.2
     let cname = CString::from_slice(name.as_bytes());
     pthread_setname_np(cname.as_ptr());
 }

--- a/src/libstd/sys/windows/thread.rs
+++ b/src/libstd/sys/windows/thread.rs
@@ -67,6 +67,13 @@ pub unsafe fn create(stack: uint, p: Thunk) -> rust_thread {
     return ret;
 }
 
+pub unsafe fn set_name(name: &str) {
+    // Windows threads are nameless
+    // The names in MSVC debugger are obtained using a "magic" exception,
+    // which requires a use of C++ macros.
+    // See https://msdn.microsoft.com/en-us/library/xcb2z8hs.aspx
+}
+
 pub unsafe fn join(native: rust_thread) {
     use libc::consts::os::extra::INFINITE;
     WaitForSingleObject(native, INFINITE);

--- a/src/libstd/sys/windows/thread.rs
+++ b/src/libstd/sys/windows/thread.rs
@@ -67,10 +67,10 @@ pub unsafe fn create(stack: uint, p: Thunk) -> rust_thread {
     return ret;
 }
 
-pub unsafe fn set_name(name: &str) {
+pub unsafe fn set_name(_name: &str) {
     // Windows threads are nameless
     // The names in MSVC debugger are obtained using a "magic" exception,
-    // which requires a use of C++ macros.
+    // which requires a use of MS C++ extensions.
     // See https://msdn.microsoft.com/en-us/library/xcb2z8hs.aspx
 }
 

--- a/src/libstd/thread.rs
+++ b/src/libstd/thread.rs
@@ -275,10 +275,6 @@ impl Builder {
             unsafe {
                 stack::record_os_managed_stack_bounds(my_stack_bottom, my_stack_top);
             }
-            match their_thread.name() {
-                Some(thename) => unsafe { imp::set_name(thename.as_slice()); },
-                None => {}
-            }
             thread_info::set(
                 (my_stack_bottom, my_stack_top),
                 unsafe { imp::guard::current() },

--- a/src/libstd/thread.rs
+++ b/src/libstd/thread.rs
@@ -275,6 +275,10 @@ impl Builder {
             unsafe {
                 stack::record_os_managed_stack_bounds(my_stack_bottom, my_stack_top);
             }
+            match their_thread.name() {
+                Some(thename) => unsafe { imp::set_name(thename.as_slice()); },
+                None => {}
+            }
             thread_info::set(
                 (my_stack_bottom, my_stack_top),
                 unsafe { imp::guard::current() },


### PR DESCRIPTION
Fixes #10302

I really am not sure I'm doing this right, so here goes nothing...

Also testing this isn't easy. I don't have any other *nix boxes besides a Linux one.

Test code:

``` rust
use std::thread;
use std::io::timer::sleep;
use std::time::duration::Duration;

fn make_thread<'a>(i: i64) -> thread::JoinGuard<'a, ()>
{
    thread::Builder::new().name(format!("MyThread{}", i).to_string()).scoped(move ||
    {
        println!("Start: {}", i);
        sleep(Duration::seconds(i));
        println!("End: {}", i);
    })
}

fn main()
{
    let mut guards = vec![make_thread(3)];

    for i in 4i64..16
    {
        guards.push(make_thread(i));
    }
}
```

GDB output on my machine:

```
(gdb) info threads
  Id   Target Id         Frame 
  15   Thread 0x7fdfbb35f700 (LWP 23575) "MyThread3" 0x00007fdfbbe35a8d in nanosleep () from /usr/lib/libpthread.so.0
  14   Thread 0x7fdfba7ff700 (LWP 23576) "MyThread4" 0x00007fdfbbe35a8d in nanosleep () from /usr/lib/libpthread.so.0
  13   Thread 0x7fdfba5fe700 (LWP 23577) "MyThread5" 0x00007fdfbbe35a8d in nanosleep () from /usr/lib/libpthread.so.0
  12   Thread 0x7fdfba3fd700 (LWP 23578) "MyThread6" 0x00007fdfbbe35a8d in nanosleep () from /usr/lib/libpthread.so.0
  11   Thread 0x7fdfb8dfe700 (LWP 23580) "MyThread4" 0x00007fdfbb746193 in select () from /usr/lib/libc.so.6
  10   Thread 0x7fdfb8fff700 (LWP 23579) "MyThread7" 0x00007fdfbbe35a8d in nanosleep () from /usr/lib/libpthread.so.0
  9    Thread 0x7fdfb8bfd700 (LWP 23581) "MyThread8" 0x00007fdfbbe35a8d in nanosleep () from /usr/lib/libpthread.so.0
  8    Thread 0x7fdfb3fff700 (LWP 23582) "MyThread9" 0x00007fdfbbe35a8d in nanosleep () from /usr/lib/libpthread.so.0
  7    Thread 0x7fdfb3dfe700 (LWP 23583) "MyThread10" 0x00007fdfbbe35a8d in nanosleep () from /usr/lib/libpthread.so.0
  6    Thread 0x7fdfb3bfd700 (LWP 23584) "MyThread11" 0x00007fdfbbe35a8d in nanosleep () from /usr/lib/libpthread.so.0
  5    Thread 0x7fdfb2bff700 (LWP 23585) "MyThread12" 0x00007fdfbbe35a8d in nanosleep () from /usr/lib/libpthread.so.0
  4    Thread 0x7fdfb29fe700 (LWP 23586) "MyThread13" 0x00007fdfbbe35a8d in nanosleep () from /usr/lib/libpthread.so.0
  3    Thread 0x7fdfb27fd700 (LWP 23587) "MyThread14" 0x00007fdfbbe35a8d in nanosleep () from /usr/lib/libpthread.so.0
  2    Thread 0x7fdfb1bff700 (LWP 23588) "MyThread15" 0x00007fdfbbe35a8d in nanosleep () from /usr/lib/libpthread.so.0
* 1    Thread 0x7fdfbc411800 (LWP 23574) "threads" 0x00007fdfbbe2e505 in pthread_join () from /usr/lib/libpthread.so.0
```

(I'm not sure why one of the threads is duplicated, but it does that without my patch too...)
