### PR TITLE
cleanup: s/`v.slice*()`/`&v[a..b]`/g + remove redundant  `as_slice()` calls

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -361,8 +361,8 @@ pub fn make_metrics_test_closure(config: &Config, testfile: &Path) -> test::Test
 fn extract_gdb_version(full_version_line: Option<String>) -> Option<String> {
     match full_version_line {
         Some(ref full_version_line)
-          if full_version_line.as_slice().trim().len() > 0 => {
-            let full_version_line = full_version_line.as_slice().trim();
+          if full_version_line.trim().len() > 0 => {
+            let full_version_line = full_version_line.trim();
 
             // used to be a regex "(^|[^0-9])([0-9]\.[0-9])([^0-9]|$)"
             for (pos, c) in full_version_line.char_indices() {
@@ -401,8 +401,8 @@ fn extract_lldb_version(full_version_line: Option<String>) -> Option<String> {
 
     match full_version_line {
         Some(ref full_version_line)
-          if full_version_line.as_slice().trim().len() > 0 => {
-            let full_version_line = full_version_line.as_slice().trim();
+          if full_version_line.trim().len() > 0 => {
+            let full_version_line = full_version_line.trim();
 
             for (pos, l) in full_version_line.char_indices() {
                 if l != 'l' && l != 'L' { continue }

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -149,7 +149,7 @@ pub fn is_test_ignored(config: &Config, testfile: &Path) -> bool {
     }
     fn ignore_stage(config: &Config) -> String {
         format!("ignore-{}",
-                config.stage_id.as_slice().split('-').next().unwrap())
+                config.stage_id.split('-').next().unwrap())
     }
     fn ignore_gdb(config: &Config, line: &str) -> bool {
         if config.mode != common::DebugInfoGdb {
@@ -231,11 +231,11 @@ fn iter_header<F>(testfile: &Path, mut it: F) -> bool where
         // module or function. This doesn't seem to be an optimization
         // with a warm page cache. Maybe with a cold one.
         let ln = ln.unwrap();
-        if ln.as_slice().starts_with("fn") ||
-                ln.as_slice().starts_with("mod") {
+        if ln.starts_with("fn") ||
+                ln.starts_with("mod") {
             return true;
         } else {
-            if !(it(ln.as_slice().trim())) {
+            if !(it(ln.trim())) {
                 return false;
             }
         }

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -777,7 +777,7 @@ fn parse_debugger_commands(file_path: &Path, debugger_prefix: &str)
     for line in reader.lines() {
         match line {
             Ok(line) => {
-                if line.as_slice().contains("#break") {
+                if line.contains("#break") {
                     breakpoint_lines.push(counter);
                 }
 
@@ -843,7 +843,7 @@ fn check_debugger_output(debugger_run_result: &ProcRes, check_lines: &[String]) 
         // check if each line in props.check_lines appears in the
         // output (in order)
         let mut i = 0u;
-        for line in debugger_run_result.stdout.as_slice().lines() {
+        for line in debugger_run_result.stdout.lines() {
             let mut rest = line.trim();
             let mut first = true;
             let mut failed = false;
@@ -895,7 +895,7 @@ fn check_error_patterns(props: &TestProps,
     let mut next_err_idx = 0u;
     let mut next_err_pat = &props.error_patterns[next_err_idx];
     let mut done = false;
-    for line in output_to_check.as_slice().lines() {
+    for line in output_to_check.lines() {
         if line.contains(next_err_pat.as_slice()) {
             debug!("found error pattern {}", next_err_pat);
             next_err_idx += 1u;
@@ -924,7 +924,7 @@ fn check_error_patterns(props: &TestProps,
 }
 
 fn check_no_compiler_crash(proc_res: &ProcRes) {
-    for line in proc_res.stderr.as_slice().lines() {
+    for line in proc_res.stderr.lines() {
         if line.starts_with("error: internal compiler error:") {
             fatal_proc_rec("compiler encountered internal error",
                           proc_res);
@@ -983,7 +983,7 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
     //    filename:line1:col1: line2:col2: *warning:* msg
     // where line1:col1: is the starting point, line2:col2:
     // is the ending point, and * represents ANSI color codes.
-    for line in proc_res.stderr.as_slice().lines() {
+    for line in proc_res.stderr.lines() {
         let mut was_expected = false;
         for (i, ee) in expected_errors.iter().enumerate() {
             if !found_flags[i] {
@@ -1536,7 +1536,7 @@ fn _arm_exec_compiled_test(config: &Config,
         .expect(format!("failed to exec `{}`", config.adb_path).as_slice());
 
     let mut exitcode: int = 0;
-    for c in exitcode_out.as_slice().chars() {
+    for c in exitcode_out.chars() {
         if !c.is_numeric() { break; }
         exitcode = exitcode * 10 + match c {
             '0' ... '9' => c as int - ('0' as int),

--- a/src/grammar/verify.rs
+++ b/src/grammar/verify.rs
@@ -43,8 +43,8 @@ fn parse_token_list(file: &str) -> HashMap<String, token::Token> {
             None => continue
         };
 
-        let val = line.slice_to(eq);
-        let num = line.slice_from(eq + 1);
+        let val = &line[..eq];
+        let num = &line[eq + 1..];
 
         let tok = match val {
             "SHR"               => token::BinOp(token::Shr),
@@ -136,27 +136,27 @@ fn str_to_binop(s: &str) -> token::BinOpToken {
 fn fix(mut lit: &str) -> ast::Name {
     if lit.char_at(0) == 'r' {
         if lit.char_at(1) == 'b' {
-            lit = lit.slice_from(2)
+            lit = &lit[2..]
         } else {
-            lit = lit.slice_from(1);
+            lit = &lit[1..];
         }
     } else if lit.char_at(0) == 'b' {
-        lit = lit.slice_from(1);
+        lit = &lit[1..];
     }
 
     let leading_hashes = count(lit);
 
     // +1/-1 to adjust for single quotes
-    parse::token::intern(lit.slice(leading_hashes + 1, lit.len() - leading_hashes - 1))
+    parse::token::intern(&lit[leading_hashes + 1..lit.len() - leading_hashes - 1])
 }
 
 /// Assuming a char/byte literal, strip the 'b' prefix and the single quotes.
 fn fixchar(mut lit: &str) -> ast::Name {
     if lit.char_at(0) == 'b' {
-        lit = lit.slice_from(1);
+        lit = &lit[1..];
     }
 
-    parse::token::intern(lit.slice(1, lit.len() - 1))
+    parse::token::intern(&lit[1..lit.len() - 1])
 }
 
 fn count(lit: &str) -> usize {
@@ -187,8 +187,7 @@ fn parse_antlr_token(s: &str, tokens: &HashMap<String, token::Token>) -> TokenAn
 
     let real_tok = match *proto_tok {
         token::BinOp(..)           => token::BinOp(str_to_binop(content)),
-        token::BinOpEq(..)         => token::BinOpEq(str_to_binop(content.slice_to(
-                                                                    content.len() - 1))),
+        token::BinOpEq(..)         => token::BinOpEq(str_to_binop(&content[..content.len() - 1])),
         token::Literal(token::Str_(..), n)      => token::Literal(token::Str_(fix(content)), n),
         token::Literal(token::StrRaw(..), n)    => token::Literal(token::StrRaw(fix(content),
                                                                              count(content)), n),
@@ -249,7 +248,7 @@ fn main() {
     let mut stdin = std::io::stdin();
     let mut lock = stdin.lock();
     let lines = lock.lines();
-    let mut antlr_tokens = lines.map(|l| parse_antlr_token(l.unwrap().as_slice().trim(),
+    let mut antlr_tokens = lines.map(|l| parse_antlr_token(l.unwrap().trim(),
                                                                    &token_map));
 
     let code = File::open(&Path::new(args[1].as_slice())).unwrap().read_to_string().unwrap();

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1475,21 +1475,21 @@ mod tests {
     #[test]
     fn test_get() {
         let mut a = vec![11i];
-        assert_eq!(a.as_slice().get(1), None);
+        assert_eq!(a.get(1), None);
         a = vec![11i, 12];
-        assert_eq!(a.as_slice().get(1).unwrap(), &12);
+        assert_eq!(a.get(1).unwrap(), &12);
         a = vec![11i, 12, 13];
-        assert_eq!(a.as_slice().get(1).unwrap(), &12);
+        assert_eq!(a.get(1).unwrap(), &12);
     }
 
     #[test]
     fn test_first() {
         let mut a = vec![];
-        assert_eq!(a.as_slice().first(), None);
+        assert_eq!(a.first(), None);
         a = vec![11i];
-        assert_eq!(a.as_slice().first().unwrap(), &11);
+        assert_eq!(a.first().unwrap(), &11);
         a = vec![11i, 12];
-        assert_eq!(a.as_slice().first().unwrap(), &11);
+        assert_eq!(a.first().unwrap(), &11);
     }
 
     #[test]
@@ -1573,11 +1573,11 @@ mod tests {
     #[test]
     fn test_last() {
         let mut a = vec![];
-        assert_eq!(a.as_slice().last(), None);
+        assert_eq!(a.last(), None);
         a = vec![11i];
-        assert_eq!(a.as_slice().last().unwrap(), &11);
+        assert_eq!(a.last().unwrap(), &11);
         a = vec![11i, 12];
-        assert_eq!(a.as_slice().last().unwrap(), &12);
+        assert_eq!(a.last().unwrap(), &12);
     }
 
     #[test]
@@ -1798,7 +1798,7 @@ mod tests {
             let (min_size, max_opt) = it.size_hint();
             assert_eq!(min_size, 1);
             assert_eq!(max_opt.unwrap(), 1);
-            assert_eq!(it.next(), Some(v.as_slice().to_vec()));
+            assert_eq!(it.next(), Some(v.to_vec()));
             assert_eq!(it.next(), None);
         }
         {
@@ -1807,7 +1807,7 @@ mod tests {
             let (min_size, max_opt) = it.size_hint();
             assert_eq!(min_size, 1);
             assert_eq!(max_opt.unwrap(), 1);
-            assert_eq!(it.next(), Some(v.as_slice().to_vec()));
+            assert_eq!(it.next(), Some(v.to_vec()));
             assert_eq!(it.next(), None);
         }
         {
@@ -1911,10 +1911,10 @@ mod tests {
         assert!([].position_elem(&1i).is_none());
 
         let v1 = vec![1i, 2, 3, 3, 2, 5];
-        assert_eq!(v1.as_slice().position_elem(&1), Some(0u));
-        assert_eq!(v1.as_slice().position_elem(&2), Some(1u));
-        assert_eq!(v1.as_slice().position_elem(&5), Some(5u));
-        assert!(v1.as_slice().position_elem(&4).is_none());
+        assert_eq!(v1.position_elem(&1), Some(0u));
+        assert_eq!(v1.position_elem(&2), Some(1u));
+        assert_eq!(v1.position_elem(&5), Some(5u));
+        assert!(v1.position_elem(&4).is_none());
     }
 
     #[test]
@@ -1985,13 +1985,13 @@ mod tests {
                 let mut v1 = v.clone();
 
                 v.sort();
-                assert!(v.as_slice().windows(2).all(|w| w[0] <= w[1]));
+                assert!(v.windows(2).all(|w| w[0] <= w[1]));
 
                 v1.sort_by(|a, b| a.cmp(b));
-                assert!(v1.as_slice().windows(2).all(|w| w[0] <= w[1]));
+                assert!(v1.windows(2).all(|w| w[0] <= w[1]));
 
                 v1.sort_by(|a, b| b.cmp(a));
-                assert!(v1.as_slice().windows(2).all(|w| w[0] >= w[1]));
+                assert!(v1.windows(2).all(|w| w[0] >= w[1]));
             }
         }
 
@@ -2030,7 +2030,7 @@ mod tests {
                 // will need to be ordered with increasing
                 // counts... i.e. exactly asserting that this sort is
                 // stable.
-                assert!(v.as_slice().windows(2).all(|w| w[0] <= w[1]));
+                assert!(v.windows(2).all(|w| w[0] <= w[1]));
             }
         }
     }
@@ -2451,14 +2451,14 @@ mod tests {
         assert!(a == [7i,2,3,4]);
         let mut a = [1i,2,3,4,5];
         let b = vec![5i,6,7,8,9,0];
-        assert_eq!(a.slice_mut(2, 4).move_from(b,1,6), 2);
+        assert_eq!(a[2..4].move_from(b,1,6), 2);
         assert!(a == [1i,2,6,7,5]);
     }
 
     #[test]
     fn test_reverse_part() {
         let mut values = [1i,2,3,4,5];
-        values.slice_mut(1, 4).reverse();
+        values[1..4].reverse();
         assert!(values == [1,4,3,2,5]);
     }
 
@@ -2505,9 +2505,9 @@ mod tests {
     fn test_bytes_set_memory() {
         use slice::bytes::MutableByteVector;
         let mut values = [1u8,2,3,4,5];
-        values.slice_mut(0, 5).set_memory(0xAB);
+        values[0..5].set_memory(0xAB);
         assert!(values == [0xAB, 0xAB, 0xAB, 0xAB, 0xAB]);
-        values.slice_mut(2, 4).set_memory(0xFF);
+        values[2..4].set_memory(0xFF);
         assert!(values == [0xAB, 0xAB, 0xFF, 0xFF, 0xAB]);
     }
 
@@ -2765,7 +2765,7 @@ mod bench {
         let xss: Vec<Vec<uint>> =
             range(0, 100u).map(|i| range(0, i).collect()).collect();
         b.iter(|| {
-            xss.as_slice().concat();
+            xss.concat();
         });
     }
 
@@ -2774,7 +2774,7 @@ mod bench {
         let xss: Vec<Vec<uint>> =
             range(0, 100u).map(|i| range(0, i).collect()).collect();
         b.iter(|| {
-            xss.as_slice().connect(&0)
+            xss.connect(&0)
         });
     }
 
@@ -2791,7 +2791,7 @@ mod bench {
     fn starts_with_same_vector(b: &mut Bencher) {
         let vec: Vec<uint> = range(0, 100).collect();
         b.iter(|| {
-            vec.as_slice().starts_with(vec.as_slice())
+            vec.starts_with(vec.as_slice())
         })
     }
 
@@ -2799,7 +2799,7 @@ mod bench {
     fn starts_with_single_element(b: &mut Bencher) {
         let vec: Vec<uint> = vec![0];
         b.iter(|| {
-            vec.as_slice().starts_with(vec.as_slice())
+            vec.starts_with(vec.as_slice())
         })
     }
 
@@ -2809,7 +2809,7 @@ mod bench {
         let mut match_vec: Vec<uint> = range(0, 99).collect();
         match_vec.push(0);
         b.iter(|| {
-            vec.as_slice().starts_with(match_vec.as_slice())
+            vec.starts_with(match_vec.as_slice())
         })
     }
 
@@ -2817,7 +2817,7 @@ mod bench {
     fn ends_with_same_vector(b: &mut Bencher) {
         let vec: Vec<uint> = range(0, 100).collect();
         b.iter(|| {
-            vec.as_slice().ends_with(vec.as_slice())
+            vec.ends_with(vec.as_slice())
         })
     }
 
@@ -2825,7 +2825,7 @@ mod bench {
     fn ends_with_single_element(b: &mut Bencher) {
         let vec: Vec<uint> = vec![0];
         b.iter(|| {
-            vec.as_slice().ends_with(vec.as_slice())
+            vec.ends_with(vec.as_slice())
         })
     }
 
@@ -2835,7 +2835,7 @@ mod bench {
         let mut match_vec: Vec<uint> = range(0, 100).collect();
         match_vec.as_mut_slice()[0] = 200;
         b.iter(|| {
-            vec.as_slice().starts_with(match_vec.as_slice())
+            vec.starts_with(match_vec.as_slice())
         })
     }
 

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1401,28 +1401,28 @@ mod tests {
         assert!("banana".find_str("apple pie").is_none());
 
         let data = "abcabc";
-        assert_eq!(data.slice(0u, 6u).find_str("ab"), Some(0u));
-        assert_eq!(data.slice(2u, 6u).find_str("ab"), Some(3u - 2u));
-        assert!(data.slice(2u, 4u).find_str("ab").is_none());
+        assert_eq!(data[0u..6u].find_str("ab"), Some(0u));
+        assert_eq!(data[2u..6u].find_str("ab"), Some(3u - 2u));
+        assert!(data[2u..4u].find_str("ab").is_none());
 
         let string = "ประเทศไทย中华Việt Nam";
         let mut data = String::from_str(string);
         data.push_str(string);
         assert!(data.find_str("ไท华").is_none());
-        assert_eq!(data.slice(0u, 43u).find_str(""), Some(0u));
-        assert_eq!(data.slice(6u, 43u).find_str(""), Some(6u - 6u));
+        assert_eq!(data[0u..43u].find_str(""), Some(0u));
+        assert_eq!(data[6u..43u].find_str(""), Some(6u - 6u));
 
-        assert_eq!(data.slice(0u, 43u).find_str("ประ"), Some( 0u));
-        assert_eq!(data.slice(0u, 43u).find_str("ทศไ"), Some(12u));
-        assert_eq!(data.slice(0u, 43u).find_str("ย中"), Some(24u));
-        assert_eq!(data.slice(0u, 43u).find_str("iệt"), Some(34u));
-        assert_eq!(data.slice(0u, 43u).find_str("Nam"), Some(40u));
+        assert_eq!(data[0u..43u].find_str("ประ"), Some( 0u));
+        assert_eq!(data[0u..43u].find_str("ทศไ"), Some(12u));
+        assert_eq!(data[0u..43u].find_str("ย中"), Some(24u));
+        assert_eq!(data[0u..43u].find_str("iệt"), Some(34u));
+        assert_eq!(data[0u..43u].find_str("Nam"), Some(40u));
 
-        assert_eq!(data.slice(43u, 86u).find_str("ประ"), Some(43u - 43u));
-        assert_eq!(data.slice(43u, 86u).find_str("ทศไ"), Some(55u - 43u));
-        assert_eq!(data.slice(43u, 86u).find_str("ย中"), Some(67u - 43u));
-        assert_eq!(data.slice(43u, 86u).find_str("iệt"), Some(77u - 43u));
-        assert_eq!(data.slice(43u, 86u).find_str("Nam"), Some(83u - 43u));
+        assert_eq!(data[43u..86u].find_str("ประ"), Some(43u - 43u));
+        assert_eq!(data[43u..86u].find_str("ทศไ"), Some(55u - 43u));
+        assert_eq!(data[43u..86u].find_str("ย中"), Some(67u - 43u));
+        assert_eq!(data[43u..86u].find_str("iệt"), Some(77u - 43u));
+        assert_eq!(data[43u..86u].find_str("Nam"), Some(83u - 43u));
     }
 
     #[test]
@@ -1908,8 +1908,8 @@ mod tests {
     #[test]
     fn test_subslice_offset() {
         let a = "kernelsprite";
-        let b = a.slice(7, a.len());
-        let c = a.slice(0, a.len() - 6);
+        let b = &a[7..a.len()];
+        let c = &a[0..a.len() - 6];
         assert_eq!(a.subslice_offset(b), 7);
         assert_eq!(a.subslice_offset(c), 0);
 

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1171,11 +1171,11 @@ mod tests {
     fn test_push_str() {
         let mut s = String::new();
         s.push_str("");
-        assert_eq!(s.slice_from(0), "");
+        assert_eq!(&s[0..], "");
         s.push_str("abc");
-        assert_eq!(s.slice_from(0), "abc");
+        assert_eq!(&s[0..], "abc");
         s.push_str("ประเทศไทย中华Việt Nam");
-        assert_eq!(s.slice_from(0), "abcประเทศไทย中华Việt Nam");
+        assert_eq!(&s[0..], "abcประเทศไทย中华Việt Nam");
     }
 
     #[test]

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -454,7 +454,7 @@ impl<T, E> Result<T, E> {
     ///     let line: IoResult<String> = buffer.read_line();
     ///     // Convert the string line to a number using `map` and `from_str`
     ///     let val: IoResult<int> = line.map(|line| {
-    ///         line.as_slice().trim_right().parse::<int>().unwrap_or(0)
+    ///         line.trim_right().parse::<int>().unwrap_or(0)
     ///     });
     ///     // Add the value if there were no errors, otherwise add 0
     ///     sum += val.ok().unwrap_or(0);

--- a/src/libcoretest/str.rs
+++ b/src/libcoretest/str.rs
@@ -19,7 +19,7 @@ fn check_contains_all_substrings(s: &str) {
     assert!(s.contains(""));
     for i in range(0, s.len()) {
         for j in range(i+1, s.len() + 1) {
-            assert!(s.contains(s.slice(i, j)));
+            assert!(s.contains(&s[i..j]));
         }
     }
 }

--- a/src/librustc_trans/back/lto.rs
+++ b/src/librustc_trans/back/lto.rs
@@ -121,7 +121,7 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
                 })
             };
 
-            let ptr = bc_decoded.as_slice().as_ptr();
+            let ptr = bc_decoded.as_ptr();
             debug!("linking {}, part {}", name, i);
             time(sess.time_passes(),
                  &format!("ll link {}.{}", name, i)[],

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -753,7 +753,7 @@ impl fmt::Display for ModuleSummary {
 
             try!(write!(f, "<tr>"));
             try!(write!(f, "<td><a href='{}'>{}</a></td>", {
-                            let mut url = context.slice_from(1).to_vec();
+                            let mut url = context[1..].to_vec();
                             url.push("index.html");
                             url.connect("/")
                         },

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1348,7 +1348,7 @@ impl<'a> Item<'a> {
             };
             Some(format!("{root}{path}/{file}?gotosrc={goto}",
                          root = root,
-                         path = path.slice_to(path.len() - 1).connect("/"),
+                         path = path[..path.len() - 1].connect("/"),
                          file = item_path(self.item),
                          goto = self.item.def_id.node))
         }
@@ -1793,7 +1793,7 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
                     cx.current.connect("/")
                 } else {
                     let path = &cache.external_paths[it.def_id];
-                    path.slice_to(path.len() - 1).connect("/")
+                    path[..path.len() - 1].connect("/")
                 },
                 ty = shortty(it).to_static_str(),
                 name = *it.name.as_ref().unwrap()));
@@ -2197,9 +2197,7 @@ impl<'a> fmt::Display for Sidebar<'a> {
                 try!(write!(fmt, "::<wbr>"));
             }
             try!(write!(fmt, "<a href='{}index.html'>{}</a>",
-                          cx.root_path
-                            .as_slice()
-                            .slice_to((cx.current.len() - i - 1) * 3),
+                          &cx.root_path[..(cx.current.len() - i - 1) * 3],
                           *name));
         }
         try!(write!(fmt, "</p>"));

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -218,7 +218,7 @@ pub fn main_args(args: &[String]) -> int {
 
     let test_args = matches.opt_strs("test-args");
     let test_args: Vec<String> = test_args.iter()
-                                          .flat_map(|s| s.as_slice().words())
+                                          .flat_map(|s| s.words())
                                           .map(|s| s.to_string())
                                           .collect();
 

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -107,7 +107,7 @@ impl FromHex for str {
     /// fn main () {
     ///     let hello_str = "Hello, World".as_bytes().to_hex();
     ///     println!("{}", hello_str);
-    ///     let bytes = hello_str.as_slice().from_hex().unwrap();
+    ///     let bytes = hello_str.from_hex().unwrap();
     ///     println!("{:?}", bytes);
     ///     let result_str = String::from_utf8(bytes).unwrap();
     ///     println!("{}", result_str);

--- a/src/libstd/old_io/fs.rs
+++ b/src/libstd/old_io/fs.rs
@@ -936,11 +936,11 @@ mod test {
         {
             let mut read_stream = File::open_mode(filename, Open, Read);
             {
-                let read_buf = read_mem.slice_mut(0, 4);
+                let read_buf = &mut read_mem[0..4];
                 check!(read_stream.read(read_buf));
             }
             {
-                let read_buf = read_mem.slice_mut(4, 8);
+                let read_buf = &mut read_mem[4..8];
                 check!(read_stream.read(read_buf));
             }
         }
@@ -971,7 +971,7 @@ mod test {
         }
         check!(unlink(filename));
         let read_str = str::from_utf8(&read_mem).unwrap();
-        assert_eq!(read_str, message.slice(4, 8));
+        assert_eq!(read_str, &message[4..8]);
         assert_eq!(tell_pos_pre_read, set_cursor);
         assert_eq!(tell_pos_post_read, message.len() as u64);
     }

--- a/src/libstd/old_io/mem.rs
+++ b/src/libstd/old_io/mem.rs
@@ -645,7 +645,7 @@ mod test {
         assert!(r.read_at_least(buf.len(), &mut buf).is_ok());
         let b: &[_] = &[1, 2, 3];
         assert_eq!(buf, b);
-        assert!(r.read_at_least(0, buf.slice_to_mut(0)).is_ok());
+        assert!(r.read_at_least(0, &mut buf[..0]).is_ok());
         assert_eq!(buf, b);
         assert!(r.read_at_least(buf.len(), &mut buf).is_ok());
         let b: &[_] = &[4, 5, 6];

--- a/src/libstd/old_io/net/udp.rs
+++ b/src/libstd/old_io/net/udp.rs
@@ -47,7 +47,7 @@ use sys_common;
 ///     match socket.recv_from(&mut buf) {
 ///         Ok((amt, src)) => {
 ///             // Send a reply to the socket we received data from
-///             let buf = buf.slice_to_mut(amt);
+///             let buf = &mut buf[..amt];
 ///             buf.reverse();
 ///             socket.send_to(buf, src);
 ///         }

--- a/src/libstd/path/posix.rs
+++ b/src/libstd/path/posix.rs
@@ -109,7 +109,7 @@ impl GenericPathUnsafe for Path {
     unsafe fn new_unchecked<T: BytesContainer>(path: T) -> Path {
         let path = Path::normalize(path.container_as_bytes());
         assert!(!path.is_empty());
-        let idx = path.as_slice().rposition_elem(&SEP_BYTE);
+        let idx = path.rposition_elem(&SEP_BYTE);
         Path{ repr: path, sepidx: idx }
     }
 
@@ -290,7 +290,7 @@ impl GenericPath for Path {
                     }
                 }
             }
-            Some(Path::new(comps.as_slice().connect(&SEP_BYTE)))
+            Some(Path::new(comps.connect(&SEP_BYTE)))
         }
     }
 

--- a/src/libstd/rand/reader.rs
+++ b/src/libstd/rand/reader.rs
@@ -107,7 +107,7 @@ mod test {
         let v = [1u8, 2, 3, 4, 5, 6, 7, 8];
         let mut w = [0u8; 8];
 
-        let mut rng = ReaderRng::new(MemReader::new(v.as_slice().to_vec()));
+        let mut rng = ReaderRng::new(MemReader::new(v.to_vec()));
         rng.fill_bytes(&mut w);
 
         assert!(v == w);

--- a/src/libstd/sys/common/backtrace.rs
+++ b/src/libstd/sys/common/backtrace.rs
@@ -94,7 +94,7 @@ pub fn demangle(writer: &mut Writer, s: &str) -> IoResult<()> {
                         ($($pat:expr, => $demangled:expr),*) => ({
                             $(if rest.starts_with($pat) {
                                 try!(writer.write_str($demangled));
-                                rest = rest.slice_from($pat.len());
+                                rest = &rest[$pat.len()..];
                               } else)*
                             {
                                 try!(writer.write_str(rest));

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -942,7 +942,7 @@ mod bench {
         let v = range(0, 500).map(|i| nums[i%5]).collect::<Vec<_>>();
 
         b.iter(|| {
-            v.as_slice().sum();
+            v.sum();
         })
     }
 }

--- a/src/test/auxiliary/roman_numerals.rs
+++ b/src/test/auxiliary/roman_numerals.rs
@@ -52,7 +52,7 @@ fn expand_rn(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
         match NUMERALS.iter().find(|&&(rn, _)| text.starts_with(rn)) {
             Some(&(rn, val)) => {
                 total += val;
-                text = text.slice_from(rn.len());
+                text = &text[rn.len()..];
             }
             None => {
                 cx.span_err(sp, "invalid Roman numeral");

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -25,7 +25,7 @@ use std::vec;
 
 fn main() {
     let argv = os::args();
-    let _tests = argv.slice(1, argv.len());
+    let _tests = &argv[1..argv.len()];
 
     macro_rules! bench {
         ($id:ident) =>

--- a/src/test/bench/shootout-fannkuch-redux.rs
+++ b/src/test/bench/shootout-fannkuch-redux.rs
@@ -50,7 +50,7 @@ fn rotate(x: &mut [i32]) {
 
 fn next_permutation(perm: &mut [i32], count: &mut [i32]) {
     for i in range(1, perm.len()) {
-        rotate(perm.slice_to_mut(i + 1));
+        rotate(&mut perm[..i + 1]);
         let count_i = &mut count[i];
         if *count_i >= i as i32 {
             *count_i = 0;
@@ -129,7 +129,7 @@ impl Perm {
 
 
 fn reverse(tperm: &mut [i32], k: uint) {
-    tperm.slice_to_mut(k).reverse()
+    tperm[..k].reverse()
 }
 
 fn work(mut perm: Perm, n: uint, max: uint) -> (i32, i32) {

--- a/src/test/bench/shootout-fasta-redux.rs
+++ b/src/test/bench/shootout-fasta-redux.rs
@@ -127,7 +127,7 @@ impl<'a, W: Writer> RepeatFasta<'a, W> {
 
         copy_memory(buf.as_mut_slice(), alu);
         let buf_len = buf.len();
-        copy_memory(buf.slice_mut(alu_len, buf_len),
+        copy_memory(&mut buf[alu_len..buf_len],
                     &alu[..LINE_LEN]);
 
         let mut pos = 0;
@@ -135,7 +135,7 @@ impl<'a, W: Writer> RepeatFasta<'a, W> {
         let mut n = n;
         while n > 0 {
             bytes = min(LINE_LEN, n);
-            try!(self.out.write(buf.slice(pos, pos + bytes)));
+            try!(self.out.write(&buf[pos..pos + bytes]));
             try!(self.out.write_u8('\n' as u8));
             pos += bytes;
             if pos > alu_len {

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -184,7 +184,7 @@ fn main() {
    let mut proc_mode = false;
 
    for line in rdr.lines() {
-       let line = line.unwrap().as_slice().trim().to_string();
+       let line = line.unwrap().trim().to_string();
 
        if line.len() == 0u { continue; }
 
@@ -192,7 +192,7 @@ fn main() {
 
            // start processing if this is the one
            ('>', false) => {
-               match line.as_slice().slice_from(1).find_str("THREE") {
+               match line[1..].find_str("THREE") {
                    Some(_) => { proc_mode = true; }
                    None    => { }
                }

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -285,9 +285,9 @@ fn print_occurrences(frequencies: &mut Table, occurrence: &'static str) {
 fn get_sequence<R: Buffer>(r: &mut R, key: &str) -> Vec<u8> {
     let mut res = Vec::new();
     for l in r.lines().map(|l| l.ok().unwrap())
-        .skip_while(|l| key != l.as_slice().slice_to(key.len())).skip(1)
+        .skip_while(|l| key != &l[..key.len()]).skip(1)
     {
-        res.push_all(l.as_slice().trim().as_bytes());
+        res.push_all(l.trim().as_bytes());
     }
     res.into_ascii_uppercase()
 }

--- a/src/test/bench/shootout-mandelbrot.rs
+++ b/src/test/bench/shootout-mandelbrot.rs
@@ -134,7 +134,7 @@ fn mandelbrot<W: old_io::Writer>(w: uint, mut out: W) -> old_io::IoResult<()> {
                 (i + 1) * chunk_size
             };
 
-            for &init_i in vec_init_i.slice(start, end).iter() {
+            for &init_i in vec_init_i[start..end].iter() {
                 write_line(init_i, init_r_slice, &mut res);
             }
 

--- a/src/test/bench/shootout-nbody.rs
+++ b/src/test/bench/shootout-nbody.rs
@@ -174,7 +174,7 @@ fn main() {
     let n = if std::os::getenv("RUST_BENCH").is_some() {
         5000000
     } else {
-        std::os::args().as_slice().get(1)
+        std::os::args().get(1)
             .and_then(|arg| arg.parse())
             .unwrap_or(1000)
     };

--- a/src/test/bench/shootout-pfib.rs
+++ b/src/test/bench/shootout-pfib.rs
@@ -55,7 +55,7 @@ fn parse_opts(argv: Vec<String> ) -> Config {
     let opts = vec!(getopts::optflag("", "stress", ""));
 
     let argv = argv.iter().map(|x| x.to_string()).collect::<Vec<_>>();
-    let opt_args = argv.slice(1, argv.len());
+    let opt_args = &argv[1..argv.len()];
 
     match getopts::getopts(opt_args, opts.as_slice()) {
       Ok(ref m) => {

--- a/src/test/bench/shootout-reverse-complement.rs
+++ b/src/test/bench/shootout-reverse-complement.rs
@@ -155,7 +155,7 @@ impl<'a> Iterator for MutDnaSeqs<'a> {
     fn next(&mut self) -> Option<&'a mut [u8]> {
         let tmp = std::mem::replace(&mut self.s, &mut []);
         let tmp = match memchr(tmp, b'\n') {
-            Some(i) => tmp.slice_from_mut(i + 1),
+            Some(i) => &mut tmp[i + 1..],
             None => return None,
         };
         let (seq, tmp) = match memchr(tmp, b'>') {

--- a/src/test/compile-fail/drop-with-active-borrows-1.rs
+++ b/src/test/compile-fail/drop-with-active-borrows-1.rs
@@ -10,7 +10,7 @@
 
 fn main() {
     let a = "".to_string();
-    let b: Vec<&str> = a.as_slice().lines().collect();
+    let b: Vec<&str> = a.lines().collect();
     drop(a);    //~ ERROR cannot move out of `a` because it is borrowed
     for s in b.iter() {
         println!("{}", *s);

--- a/src/test/compile-fail/drop-with-active-borrows-2.rs
+++ b/src/test/compile-fail/drop-with-active-borrows-2.rs
@@ -10,7 +10,7 @@
 
 fn read_lines_borrowed<'a>() -> Vec<&'a str> {
     let raw_lines: Vec<String> = vec!("foo  ".to_string(), "  bar".to_string());
-    raw_lines.iter().map(|l| l.as_slice().trim()).collect()
+    raw_lines.iter().map(|l| l.trim()).collect()
     //~^ ERROR `raw_lines` does not live long enough
 }
 

--- a/src/test/compile-fail/issue-13497-2.rs
+++ b/src/test/compile-fail/issue-13497-2.rs
@@ -11,7 +11,7 @@
 fn read_lines_borrowed<'a>() -> Vec<&'a str> {
     let rawLines: Vec<String> = vec!["foo  ".to_string(), "  bar".to_string()];
     rawLines //~ ERROR `rawLines` does not live long enough
-        .iter().map(|l| l.as_slice().trim()).collect()
+        .iter().map(|l| l.trim()).collect()
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-13497.rs
+++ b/src/test/compile-fail/issue-13497.rs
@@ -12,7 +12,7 @@ fn read_lines_borrowed1() -> Vec<
     &str //~ ERROR missing lifetime specifier
 > {
     let rawLines: Vec<String> = vec!["foo  ".to_string(), "  bar".to_string()];
-    rawLines.iter().map(|l| l.as_slice().trim()).collect()
+    rawLines.iter().map(|l| l.trim()).collect()
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-15381.rs
+++ b/src/test/compile-fail/issue-15381.rs
@@ -14,7 +14,7 @@ fn main() {
     for
         [x,y,z]
 //~^ ERROR refutable pattern in `for` loop binding: `[]` not covered
-        in values.as_slice().chunks(3).filter(|&xs| xs.len() == 3) {
+        in values.chunks(3).filter(|&xs| xs.len() == 3) {
         println!("y={}", y);
     }
 }

--- a/src/test/run-make/cannot-read-embedded-idents/create_and_compile.rs
+++ b/src/test/run-make/cannot-read-embedded-idents/create_and_compile.rs
@@ -40,5 +40,5 @@ fn main() {
 
     // positive test so that this test will be updated when the
     // compiler changes.
-    assert!(err.as_slice().contains("unknown start of token"))
+    assert!(err.contains("unknown start of token"))
 }

--- a/src/test/run-make/unicode-input/multiple_files.rs
+++ b/src/test/run-make/unicode-input/multiple_files.rs
@@ -65,6 +65,6 @@ fn main() {
 
         // positive test so that this test will be updated when the
         // compiler changes.
-        assert!(err.as_slice().contains("expected item, found"))
+        assert!(err.contains("expected item, found"))
     }
 }

--- a/src/test/run-make/unicode-input/span_length.rs
+++ b/src/test/run-make/unicode-input/span_length.rs
@@ -63,6 +63,6 @@ fn main() {
         // the span should end the line (e.g no extra ~'s)
         let expected_span = format!("^{}\n", repeat("~").take(n - 1)
                                                         .collect::<String>());
-        assert!(err.as_slice().contains(expected_span.as_slice()));
+        assert!(err.contains(expected_span.as_slice()));
     }
 }

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -78,9 +78,9 @@ fn runtest(me: &str) {
     let s = str::from_utf8(out.error.as_slice()).unwrap();
     let mut i = 0;
     for _ in range(0i, 2) {
-        i += s.slice_from(i + 10).find_str("stack backtrace").unwrap() + 10;
+        i += s[i + 10..].find_str("stack backtrace").unwrap() + 10;
     }
-    assert!(s.slice_from(i + 10).find_str("stack backtrace").is_none(),
+    assert!(s[i + 10..].find_str("stack backtrace").is_none(),
             "bad output4: {}", s);
 }
 

--- a/src/test/run-pass/borrow-by-val-method-receiver.rs
+++ b/src/test/run-pass/borrow-by-val-method-receiver.rs
@@ -19,5 +19,5 @@ impl<'a> Foo for &'a [int] {
 
 pub fn main() {
     let items = vec!( 3, 5, 1, 2, 4 );
-    items.as_slice().foo();
+    items.foo();
 }

--- a/src/test/run-pass/byte-literals.rs
+++ b/src/test/run-pass/byte-literals.rs
@@ -52,7 +52,7 @@ pub fn main() {
     }
 
     let buf = vec!(97u8, 98, 99, 100);
-    assert_eq!(match buf.slice(0, 3) {
+    assert_eq!(match &buf[0..3] {
          b"def" => 1u,
          b"abc" => 2u,
          _ => 3u

--- a/src/test/run-pass/capturing-logging.rs
+++ b/src/test/run-pass/capturing-logging.rs
@@ -41,6 +41,6 @@ fn main() {
         info!("info");
     });
     let s = r.read_to_string().unwrap();
-    assert!(s.as_slice().contains("info"));
-    assert!(!s.as_slice().contains("debug"));
+    assert!(s.contains("info"));
+    assert!(!s.contains("debug"));
 }

--- a/src/test/run-pass/drop-with-type-ascription-1.rs
+++ b/src/test/run-pass/drop-with-type-ascription-1.rs
@@ -10,7 +10,7 @@
 
 fn main() {
     let foo = "hello".to_string();
-    let foo: Vec<&str> = foo.as_slice().words().collect();
+    let foo: Vec<&str> = foo.words().collect();
     let invalid_string = &foo[0];
     assert_eq!(*invalid_string, "hello");
 }

--- a/src/test/run-pass/drop-with-type-ascription-2.rs
+++ b/src/test/run-pass/drop-with-type-ascription-2.rs
@@ -10,7 +10,7 @@
 
 fn main() {
     let args = vec!("foobie", "asdf::asdf");
-    let arr: Vec<&str> = args[1].as_slice().split_str("::").collect();
+    let arr: Vec<&str> = args[1].split_str("::").collect();
     assert_eq!(arr[0], "asdf");
     assert_eq!(arr[0], "asdf");
 }

--- a/src/test/run-pass/issue-5550.rs
+++ b/src/test/run-pass/issue-5550.rs
@@ -13,5 +13,5 @@
 pub fn main() {
     let s: String = "foobar".to_string();
     let mut t: &str = s.as_slice();
-    t = t.slice(0, 3); // for master: str::view(t, 0, 3) maybe
+    t = &t[0..3]; // for master: str::view(t, 0, 3) maybe
 }

--- a/src/test/run-pass/linear-for-loop.rs
+++ b/src/test/run-pass/linear-for-loop.rs
@@ -18,7 +18,7 @@ pub fn main() {
     assert_eq!(y, 6);
     let s = "hello there".to_string();
     let mut i: int = 0;
-    for c in s.as_slice().bytes() {
+    for c in s.bytes() {
         if i == 0 { assert!((c == 'h' as u8)); }
         if i == 1 { assert!((c == 'e' as u8)); }
         if i == 2 { assert!((c == 'l' as u8)); }

--- a/src/test/run-pass/out-of-stack-new-thread-no-split.rs
+++ b/src/test/run-pass/out-of-stack-new-thread-no-split.rs
@@ -44,6 +44,6 @@ fn main() {
         let error = String::from_utf8_lossy(recurse.error.as_slice());
         println!("wut");
         println!("`{}`", error);
-        assert!(error.as_slice().contains("has overflowed its stack"));
+        assert!(error.contains("has overflowed its stack"));
     }
 }

--- a/src/test/run-pass/out-of-stack-no-split.rs
+++ b/src/test/run-pass/out-of-stack-no-split.rs
@@ -42,6 +42,6 @@ fn main() {
         let recurse = Command::new(args[0].as_slice()).arg("recurse").output().unwrap();
         assert!(!recurse.status.success());
         let error = String::from_utf8_lossy(recurse.error.as_slice());
-        assert!(error.as_slice().contains("has overflowed its stack"));
+        assert!(error.contains("has overflowed its stack"));
     }
 }

--- a/src/test/run-pass/out-of-stack.rs
+++ b/src/test/run-pass/out-of-stack.rs
@@ -44,11 +44,11 @@ fn main() {
         let silent = Command::new(args[0].as_slice()).arg("silent").output().unwrap();
         assert!(!silent.status.success());
         let error = String::from_utf8_lossy(silent.error.as_slice());
-        assert!(error.as_slice().contains("has overflowed its stack"));
+        assert!(error.contains("has overflowed its stack"));
 
         let loud = Command::new(args[0].as_slice()).arg("loud").output().unwrap();
         assert!(!loud.status.success());
         let error = String::from_utf8_lossy(silent.error.as_slice());
-        assert!(error.as_slice().contains("has overflowed its stack"));
+        assert!(error.contains("has overflowed its stack"));
     }
 }

--- a/src/test/run-pass/process-remove-from-env.rs
+++ b/src/test/run-pass/process-remove-from-env.rs
@@ -48,6 +48,6 @@ fn main() {
     let result = prog.wait_with_output().unwrap();
     let output = String::from_utf8_lossy(result.output.as_slice());
 
-    assert!(!output.as_slice().contains("RUN_TEST_NEW_ENV"),
+    assert!(!output.contains("RUN_TEST_NEW_ENV"),
             "found RUN_TEST_NEW_ENV inside of:\n\n{}", output);
 }

--- a/src/test/run-pass/rcvr-borrowed-to-slice.rs
+++ b/src/test/run-pass/rcvr-borrowed-to-slice.rs
@@ -29,12 +29,12 @@ pub fn main() {
     assert_eq!(y, 6);
 
     let x = vec!(1, 2, 3);
-    let y = x.as_slice().sum_();
+    let y = x.sum_();
     println!("y=={}", y);
     assert_eq!(y, 6);
 
     let x = vec!(1, 2, 3);
-    let y = x.as_slice().sum_();
+    let y = x.sum_();
     println!("y=={}", y);
     assert_eq!(y, 6);
 }

--- a/src/test/run-pass/segfault-no-out-of-stack.rs
+++ b/src/test/run-pass/segfault-no-out-of-stack.rs
@@ -20,6 +20,6 @@ fn main() {
         let segfault = Command::new(args[0].as_slice()).arg("segfault").output().unwrap();
         assert!(!segfault.status.success());
         let error = String::from_utf8_lossy(segfault.error.as_slice());
-        assert!(!error.as_slice().contains("has overflowed its stack"));
+        assert!(!error.contains("has overflowed its stack"));
     }
 }

--- a/src/test/run-pass/syntax-extension-source-utils.rs
+++ b/src/test/run-pass/syntax-extension-source-utils.rs
@@ -40,7 +40,7 @@ pub fn main() {
         include_bytes!("syntax-extension-source-utils-files/includeme.fragment")
         [1] == (42 as u8)); // '*'
     // The Windows tests are wrapped in an extra module for some reason
-    assert!((m1::m2::where_am_i().as_slice().ends_with("m1::m2")));
+    assert!((m1::m2::where_am_i().ends_with("m1::m2")));
 
     assert!(match (45, "( 2 * 3 ) + 5") {
         (line!(), stringify!((2*3) + 5)) => true,

--- a/src/test/run-pass/task-stderr.rs
+++ b/src/test/run-pass/task-stderr.rs
@@ -26,5 +26,5 @@ fn main() {
     assert!(res.is_err());
 
     let output = reader.read_to_string().unwrap();
-    assert!(output.as_slice().contains("Hello, world!"));
+    assert!(output.contains("Hello, world!"));
 }

--- a/src/test/run-pass/utf8.rs
+++ b/src/test/run-pass/utf8.rs
@@ -44,7 +44,7 @@ pub fn main() {
 
     fn check_str_eq(a: String, b: String) {
         let mut i: int = 0;
-        for ab in a.as_slice().bytes() {
+        for ab in a.bytes() {
             println!("{}", i);
             println!("{}", ab);
             let bb: u8 = b.as_bytes()[i as uint];

--- a/src/test/run-pass/vec-slice.rs
+++ b/src/test/run-pass/vec-slice.rs
@@ -10,7 +10,7 @@
 
 pub fn main() {
     let  v = vec!(1i,2,3,4,5);
-    let v2 = v.slice(1, 3);
+    let v2 = &v[1..3];
     assert_eq!(v2[0], 2);
     assert_eq!(v2[1], 3);
 }

--- a/src/test/run-pass/vec-tail-matching.rs
+++ b/src/test/run-pass/vec-tail-matching.rs
@@ -31,8 +31,8 @@ pub fn main() {
                     unreachable!();
                 }
                 [Foo { string: ref a }, Foo { string: ref b }] => {
-                    assert_eq!("bar", a.as_slice().slice(0, a.len()));
-                    assert_eq!("baz", b.as_slice().slice(0, b.len()));
+                    assert_eq!("bar", &a[0..a.len()]);
+                    assert_eq!("baz", &b[0..b.len()]);
                 }
                 _ => {
                     unreachable!();


### PR DESCRIPTION
Replaces `slice_*` method calls with slicing syntax, and removes `as_slice()` calls that are redundant due to `Deref`.
