### PR TITLE
fix #[cfg(test)] warnings

### DIFF
--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(not(test))]
 use core::ptr::PtrExt;
 
 // FIXME: #13996: mark the `allocate` and `reallocate` return value as `noalias`

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -444,7 +444,7 @@ mod tests {
     use super::*;
 
     fn same(fmt: &'static str, p: &[Piece<'static>]) {
-        let mut parser = Parser::new(fmt);
+        let parser = Parser::new(fmt);
         assert!(p == parser.collect::<Vec<Piece<'static>>>());
     }
 

--- a/src/librustc_back/rpath.rs
+++ b/src/librustc_back/rpath.rs
@@ -151,7 +151,6 @@ fn minimize_rpaths(rpaths: &[String]) -> Vec<String> {
 mod test {
     use super::{RPathConfig};
     use super::{minimize_rpaths, rpaths_to_flags, get_rpath_relative_to_output};
-    use syntax::abi;
 
     #[test]
     fn test_rpaths_to_flags() {

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -2618,7 +2618,7 @@ mod tests {
     use super::JsonEvent::*;
     use super::{Json, from_str, DecodeResult, DecoderError, JsonEvent, Parser,
                 StackElement, Stack, Decoder, Encoder, EncoderError};
-    use std::{i64, u64, f32, f64, old_io};
+    use std::{i64, u64, f32, f64};
     use std::collections::BTreeMap;
     use std::num::Float;
     use std::string;
@@ -3928,7 +3928,6 @@ mod tests {
 
     #[test]
     fn test_encode_hashmap_with_arbitrary_key() {
-        use std::str::from_utf8;
         use std::old_io::Writer;
         use std::collections::HashMap;
         use std::fmt;

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1433,15 +1433,12 @@ mod test {
     use super::{pattern_bindings, expand_crate};
     use super::{PatIdentFinder, IdentRenamer, PatIdentRenamer, ExpansionConfig};
     use ast;
-    use ast::{Attribute_, AttrOuter, MetaWord, Name};
-    use attr;
+    use ast::Name;
     use codemap;
-    use codemap::Spanned;
     use ext::mtwt;
     use fold::Folder;
     use parse;
     use parse::token;
-    use ptr::P;
     use util::parser_testing::{string_to_parser};
     use util::parser_testing::{string_to_pat, string_to_crate, strs_to_idents};
     use visit;

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2975,7 +2975,6 @@ mod test {
     use ast_util;
     use codemap;
     use parse::token;
-    use ptr::P;
 
     #[test]
     fn test_fun_to_string() {

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1118,9 +1118,8 @@ pub mod bench {
 mod tests {
     use test::{TrFailed, TrIgnored, TrOk, filter_tests, parse_opts,
                TestDesc, TestDescAndFn, TestOpts, run_test,
-               Metric, MetricMap,
+               MetricMap,
                StaticTestName, DynTestName, DynTestFn, ShouldFail};
-    use std::old_io::TempDir;
     use std::thunk::Thunk;
     use std::sync::mpsc::channel;
 


### PR DESCRIPTION
Fixes some warnings (mostly unused imports) that pop up while compiling unit tests.
