### PR TITLE
Add support for default trait implementations

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -144,7 +144,7 @@
 use clone::Clone;
 use cmp::PartialEq;
 use default::Default;
-use marker::{Copy, Send};
+use marker::{Copy, Send, Sync};
 use ops::{Deref, DerefMut, Drop};
 use option::Option;
 use option::Option::{None, Some};
@@ -659,6 +659,8 @@ pub struct UnsafeCell<T> {
     #[unstable(feature = "core")]
     pub value: T,
 }
+
+impl<T> !Sync for UnsafeCell<T> {}
 
 impl<T> UnsafeCell<T> {
     /// Construct a new instance of `UnsafeCell` which will wrap the specified

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -68,6 +68,7 @@
 #![feature(staged_api)]
 #![feature(unboxed_closures)]
 #![feature(rustc_attrs)]
+#![feature(optin_builtin_traits)]
 
 #[macro_use]
 mod macros;

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -49,6 +49,9 @@ pub unsafe trait Send : MarkerTrait {
     // empty.
 }
 
+impl<T> !Send for *const T { }
+impl<T> !Send for *mut T { }
+
 /// Types with a constant size known at compile-time.
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang="sized"]
@@ -213,6 +216,9 @@ pub trait Copy : MarkerTrait {
 pub unsafe trait Sync : MarkerTrait {
     // Empty
 }
+
+impl<T> !Sync for *const T { }
+impl<T> !Sync for *mut T { }
 
 /// A type which is considered "not POD", meaning that it is not
 /// implicitly copyable. This is typically embedded in other types to

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -51,6 +51,7 @@ pub unsafe trait Send : MarkerTrait {
 
 impl<T> !Send for *const T { }
 impl<T> !Send for *mut T { }
+impl !Send for Managed { }
 
 /// Types with a constant size known at compile-time.
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -219,6 +220,7 @@ pub unsafe trait Sync : MarkerTrait {
 
 impl<T> !Sync for *const T { }
 impl<T> !Sync for *mut T { }
+impl !Sync for Managed { }
 
 /// A type which is considered "not POD", meaning that it is not
 /// implicitly copyable. This is typically embedded in other types to

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -410,3 +410,7 @@ pub fn is_associated_type(cstore: &cstore::CStore, def: ast::DefId) -> bool {
     decoder::is_associated_type(&*cdata, def.node)
 }
 
+pub fn is_default_trait(cstore: &cstore::CStore, def: ast::DefId) -> bool {
+    let cdata = cstore.get_crate_data(def.krate);
+    decoder::is_default_trait(&*cdata, def.node)
+}

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -126,6 +126,7 @@ enum Family {
     TupleVariant,          // v
     StructVariant,         // V
     Impl,                  // i
+    DefTrait,              // d
     Trait,                 // I
     Struct,                // S
     PublicField,           // g
@@ -151,6 +152,7 @@ fn item_family(item: rbml::Doc) -> Family {
       'v' => TupleVariant,
       'V' => StructVariant,
       'i' => Impl,
+      'd' => DefTrait,
       'I' => Trait,
       'S' => Struct,
       'g' => PublicField,
@@ -357,7 +359,7 @@ fn item_to_def_like(item: rbml::Doc, did: ast::DefId, cnum: ast::CrateNum)
         }
         Trait => DlDef(def::DefTrait(did)),
         Enum => DlDef(def::DefTy(did, true)),
-        Impl => DlImpl(did),
+        Impl | DefTrait => DlImpl(did),
         PublicField | InheritedField => DlField,
     }
 }
@@ -480,7 +482,7 @@ pub fn get_impl_trait<'tcx>(cdata: Cmd,
     let item_doc = lookup_item(id, cdata.data());
     let fam = item_family(item_doc);
     match fam {
-        Family::Impl => {
+        Family::Impl | Family::DefTrait => {
             reader::maybe_get_doc(item_doc, tag_item_trait_ref).map(|tp| {
                 doc_trait_ref(tp, tcx, cdata)
             })
@@ -1356,7 +1358,7 @@ pub fn get_trait_of_item(cdata: Cmd, id: ast::NodeId, tcx: &ty::ctxt)
     let parent_item_doc = lookup_item(parent_item_id.node, cdata.data());
     match item_family(parent_item_doc) {
         Trait => Some(item_def_id(parent_item_doc, cdata)),
-        Impl => {
+        Impl | DefTrait => {
             reader::maybe_get_doc(parent_item_doc, tag_item_trait_ref)
                 .map(|_| item_trait_ref(parent_item_doc, tcx, cdata).def_id)
         }

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -126,7 +126,7 @@ enum Family {
     TupleVariant,          // v
     StructVariant,         // V
     Impl,                  // i
-    DefTrait,              // d
+    DefaultImpl,              // d
     Trait,                 // I
     Struct,                // S
     PublicField,           // g
@@ -152,7 +152,7 @@ fn item_family(item: rbml::Doc) -> Family {
       'v' => TupleVariant,
       'V' => StructVariant,
       'i' => Impl,
-      'd' => DefTrait,
+      'd' => DefaultImpl,
       'I' => Trait,
       'S' => Struct,
       'g' => PublicField,
@@ -357,9 +357,9 @@ fn item_to_def_like(item: rbml::Doc, did: ast::DefId, cnum: ast::CrateNum)
             let enum_did = item_reqd_and_translated_parent_item(cnum, item);
             DlDef(def::DefVariant(enum_did, did, false))
         }
-        Trait => DlDef(def::DefTrait(did)),
+        Trait => DlDef(def::DefaultImpl(did)),
         Enum => DlDef(def::DefTy(did, true)),
-        Impl | DefTrait => DlImpl(did),
+        Impl | DefaultImpl => DlImpl(did),
         PublicField | InheritedField => DlField,
     }
 }
@@ -482,7 +482,7 @@ pub fn get_impl_trait<'tcx>(cdata: Cmd,
     let item_doc = lookup_item(id, cdata.data());
     let fam = item_family(item_doc);
     match fam {
-        Family::Impl | Family::DefTrait => {
+        Family::Impl | Family::DefaultImpl => {
             reader::maybe_get_doc(item_doc, tag_item_trait_ref).map(|tp| {
                 doc_trait_ref(tp, tcx, cdata)
             })
@@ -1358,7 +1358,7 @@ pub fn get_trait_of_item(cdata: Cmd, id: ast::NodeId, tcx: &ty::ctxt)
     let parent_item_doc = lookup_item(parent_item_id.node, cdata.data());
     match item_family(parent_item_doc) {
         Trait => Some(item_def_id(parent_item_doc, cdata)),
-        Impl | DefTrait => {
+        Impl | DefaultImpl => {
             reader::maybe_get_doc(parent_item_doc, tag_item_trait_ref)
                 .map(|_| item_trait_ref(parent_item_doc, tcx, cdata).def_id)
         }
@@ -1568,7 +1568,7 @@ pub fn is_associated_type(cdata: Cmd, id: ast::NodeId) -> bool {
 pub fn is_default_trait<'tcx>(cdata: Cmd, id: ast::NodeId) -> bool {
     let item_doc = lookup_item(id, cdata.data());
     match item_family(item_doc) {
-        Family::DefTrait => true,
+        Family::DefaultImpl => true,
         _ => false
     }
 }

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1563,3 +1563,12 @@ pub fn is_associated_type(cdata: Cmd, id: ast::NodeId) -> bool {
         Some(item) => item_sort(item) == 't',
     }
 }
+
+
+pub fn is_default_trait<'tcx>(cdata: Cmd, id: ast::NodeId) -> bool {
+    let item_doc = lookup_item(id, cdata.data());
+    match item_family(item_doc) {
+        Family::DefTrait => true,
+        _ => false
+    }
+}

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1201,6 +1201,18 @@ fn encode_info_for_item(ecx: &EncodeContext,
             None => {}
         }
       }
+      ast::ItemDefTrait(unsafety, ref ast_trait_ref) => {
+          add_to_index(item, rbml_w, index);
+          rbml_w.start_tag(tag_items_data_item);
+          encode_def_id(rbml_w, def_id);
+          encode_family(rbml_w, 'd');
+          encode_name(rbml_w, item.ident.name);
+          encode_unsafety(rbml_w, unsafety);
+
+          let trait_ref = ty::node_id_to_trait_ref(tcx, ast_trait_ref.ref_id);
+          encode_trait_ref(rbml_w, ecx, &*trait_ref, tag_item_trait_ref);
+          rbml_w.end_tag();
+      }
       ast::ItemImpl(unsafety, polarity, _, ref opt_trait, ref ty, ref ast_items) => {
         // We need to encode information about the default methods we
         // have inherited, so we drive this based on the impl structure.

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1201,7 +1201,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
             None => {}
         }
       }
-      ast::ItemDefTrait(unsafety, ref ast_trait_ref) => {
+      ast::ItemDefaultImpl(unsafety, ref ast_trait_ref) => {
           add_to_index(item, rbml_w, index);
           rbml_w.start_tag(tag_items_data_item);
           encode_def_id(rbml_w, def_id);

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -440,7 +440,7 @@ impl tr for def::Def {
           def::DefVariant(e_did, v_did, is_s) => {
             def::DefVariant(e_did.tr(dcx), v_did.tr(dcx), is_s)
           },
-          def::DefTrait(did) => def::DefTrait(did.tr(dcx)),
+          def::DefaultImpl(did) => def::DefaultImpl(did.tr(dcx)),
           def::DefTy(did, is_enum) => def::DefTy(did.tr(dcx), is_enum),
           def::DefAssociatedTy(did) => def::DefAssociatedTy(did.tr(dcx)),
           def::DefAssociatedPath(def::TyParamProvenance::FromSelf(did), ident) =>

--- a/src/librustc/middle/def.rs
+++ b/src/librustc/middle/def.rs
@@ -38,7 +38,7 @@ pub enum Def {
     // type `U` (indicated by the Ident).
     // FIXME(#20301) -- should use Name
     DefAssociatedPath(TyParamProvenance, ast::Ident),
-    DefTrait(ast::DefId),
+    DefaultImpl(ast::DefId),
     DefPrimTy(ast::PrimTy),
     DefTyParam(ParamSpace, u32, ast::DefId, ast::Name),
     DefUse(ast::DefId),
@@ -135,7 +135,7 @@ impl Def {
             DefFn(id, _) | DefStaticMethod(id, _) | DefMod(id) |
             DefForeignMod(id) | DefStatic(id, _) |
             DefVariant(_, id, _) | DefTy(id, _) | DefAssociatedTy(id) |
-            DefTyParam(_, _, id, _) | DefUse(id) | DefStruct(id) | DefTrait(id) |
+            DefTyParam(_, _, id, _) | DefUse(id) | DefStruct(id) | DefaultImpl(id) |
             DefMethod(id, _, _) | DefConst(id) |
             DefAssociatedPath(TyParamProvenance::FromSelf(id), _) |
             DefAssociatedPath(TyParamProvenance::FromParam(id), _) => {

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -579,7 +579,7 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
                 Ok(self.cat_rvalue_node(id, span, expr_ty))
           }
           def::DefMod(_) | def::DefForeignMod(_) | def::DefUse(_) |
-          def::DefTrait(_) | def::DefTy(..) | def::DefPrimTy(_) |
+          def::DefaultImpl(_) | def::DefTy(..) | def::DefPrimTy(_) |
           def::DefTyParam(..) | def::DefTyParamBinder(..) | def::DefRegion(_) |
           def::DefLabel(_) | def::DefSelfTy(..) |
           def::DefAssociatedTy(..) | def::DefAssociatedPath(..)=> {

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -302,7 +302,7 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
                     ast::ItemMod(..) | ast::ItemForeignMod(..) |
                     ast::ItemImpl(..) | ast::ItemTrait(..) |
                     ast::ItemStruct(..) | ast::ItemEnum(..) |
-                    ast::ItemDefTrait(..) => {}
+                    ast::ItemDefaultImpl(..) => {}
 
                     _ => {
                         self.tcx.sess.span_bug(item.span,

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -301,7 +301,8 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
                     ast::ItemTy(..) | ast::ItemStatic(_, _, _) |
                     ast::ItemMod(..) | ast::ItemForeignMod(..) |
                     ast::ItemImpl(..) | ast::ItemTrait(..) |
-                    ast::ItemStruct(..) | ast::ItemEnum(..) => {}
+                    ast::ItemStruct(..) | ast::ItemEnum(..) |
+                    ast::ItemDefTrait(..) => {}
 
                     _ => {
                         self.tcx.sess.span_bug(item.span,

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -115,7 +115,7 @@ impl<'a, 'v> Visitor<'v> for LifetimeContext<'a> {
                 ast::ItemUse(_) |
                 ast::ItemMod(..) |
                 ast::ItemMac(..) |
-                ast::ItemDefTrait(..) |
+                ast::ItemDefaultImpl(..) |
                 ast::ItemForeignMod(..) |
                 ast::ItemStatic(..) |
                 ast::ItemConst(..) => {
@@ -169,7 +169,7 @@ impl<'a, 'v> Visitor<'v> for LifetimeContext<'a> {
                 // if this path references a trait, then this will resolve to
                 // a trait ref, which introduces a binding scope.
                 match self.def_map.borrow().get(&id) {
-                    Some(&def::DefTrait(..)) => {
+                    Some(&def::DefaultImpl(..)) => {
                         self.with(LateScope(&Vec::new(), self.scope), |_, this| {
                             this.visit_path(path, id);
                         });

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -115,6 +115,7 @@ impl<'a, 'v> Visitor<'v> for LifetimeContext<'a> {
                 ast::ItemUse(_) |
                 ast::ItemMod(..) |
                 ast::ItemMac(..) |
+                ast::ItemDefTrait(..) |
                 ast::ItemForeignMod(..) |
                 ast::ItemStatic(..) |
                 ast::ItemConst(..) => {

--- a/src/librustc/middle/traits/mod.rs
+++ b/src/librustc/middle/traits/mod.rs
@@ -222,6 +222,9 @@ pub enum Vtable<'tcx, N> {
     VtableImpl(VtableImplData<'tcx, N>),
 
     /// Vtable for default trait implementations
+    /// This carries the information and nested obligations with regards
+    /// to a default implementation for a trait `Trait`. The nested obligations
+    /// ensure the trait implementation holds for all the constituent types.
     VtableDefaultImpl(VtableDefaultImplData<N>),
 
     /// Successful resolution to an obligation provided by the caller

--- a/src/librustc/middle/traits/mod.rs
+++ b/src/librustc/middle/traits/mod.rs
@@ -265,7 +265,7 @@ pub struct VtableImplData<'tcx, N> {
 #[derive(Debug,Clone)]
 pub struct VtableDefaultTraitData<N> {
     pub trait_def_id: ast::DefId,
-    pub nested: subst::VecPerParamSpace<N>
+    pub nested: Vec<N>
 }
 
 #[derive(Debug,Clone)]
@@ -594,7 +594,7 @@ impl<N> VtableDefaultTraitData<N> {
     {
         VtableDefaultTraitData {
             trait_def_id: self.trait_def_id,
-            nested: self.nested.map(op)
+            nested: self.nested.iter().map(op).collect()
         }
     }
 
@@ -604,7 +604,7 @@ impl<N> VtableDefaultTraitData<N> {
         let VtableDefaultTraitData { trait_def_id, nested } = self;
         VtableDefaultTraitData {
             trait_def_id: trait_def_id,
-            nested: nested.map_move(op)
+            nested: nested.into_iter().map(op).collect()
         }
     }
 }

--- a/src/librustc/middle/traits/mod.rs
+++ b/src/librustc/middle/traits/mod.rs
@@ -222,7 +222,7 @@ pub enum Vtable<'tcx, N> {
     VtableImpl(VtableImplData<'tcx, N>),
 
     /// Vtable for default trait implementations
-    VtableDefaultTrait(VtableDefaultTraitData<N>),
+    VtableDefaultImpl(VtableDefaultImplData<N>),
 
     /// Successful resolution to an obligation provided by the caller
     /// for some type parameter. The `Vec<N>` represents the
@@ -263,7 +263,7 @@ pub struct VtableImplData<'tcx, N> {
 }
 
 #[derive(Debug,Clone)]
-pub struct VtableDefaultTraitData<N> {
+pub struct VtableDefaultImplData<N> {
     pub trait_def_id: ast::DefId,
     pub nested: Vec<N>
 }
@@ -525,7 +525,7 @@ impl<'tcx, N> Vtable<'tcx, N> {
             VtableParam(ref n) => n.iter(),
             VtableBuiltin(ref i) => i.iter_nested(),
             VtableObject(_) |
-            VtableDefaultTrait(..) | VtableFnPointer(..) |
+            VtableDefaultImpl(..) | VtableFnPointer(..) |
             VtableClosure(..) => (&[]).iter(),
         }
     }
@@ -533,7 +533,7 @@ impl<'tcx, N> Vtable<'tcx, N> {
     pub fn map_nested<M, F>(&self, op: F) -> Vtable<'tcx, M> where F: FnMut(&N) -> M {
         match *self {
             VtableImpl(ref i) => VtableImpl(i.map_nested(op)),
-            VtableDefaultTrait(ref t) => VtableDefaultTrait(t.map_nested(op)),
+            VtableDefaultImpl(ref t) => VtableDefaultImpl(t.map_nested(op)),
             VtableFnPointer(ref sig) => VtableFnPointer((*sig).clone()),
             VtableClosure(d, ref s) => VtableClosure(d, s.clone()),
             VtableParam(ref n) => VtableParam(n.iter().map(op).collect()),
@@ -549,7 +549,7 @@ impl<'tcx, N> Vtable<'tcx, N> {
             VtableImpl(i) => VtableImpl(i.map_move_nested(op)),
             VtableFnPointer(sig) => VtableFnPointer(sig),
             VtableClosure(d, s) => VtableClosure(d, s),
-            VtableDefaultTrait(t) => VtableDefaultTrait(t.map_move_nested(op)),
+            VtableDefaultImpl(t) => VtableDefaultImpl(t.map_move_nested(op)),
             VtableParam(n) => VtableParam(n.into_iter().map(op).collect()),
             VtableObject(p) => VtableObject(p),
             VtableBuiltin(no) => VtableBuiltin(no.map_move_nested(op)),
@@ -584,25 +584,25 @@ impl<'tcx, N> VtableImplData<'tcx, N> {
     }
 }
 
-impl<N> VtableDefaultTraitData<N> {
+impl<N> VtableDefaultImplData<N> {
     pub fn iter_nested(&self) -> Iter<N> {
         self.nested.iter()
     }
 
-    pub fn map_nested<M, F>(&self, op: F) -> VtableDefaultTraitData<M> where
+    pub fn map_nested<M, F>(&self, op: F) -> VtableDefaultImplData<M> where
         F: FnMut(&N) -> M,
     {
-        VtableDefaultTraitData {
+        VtableDefaultImplData {
             trait_def_id: self.trait_def_id,
             nested: self.nested.iter().map(op).collect()
         }
     }
 
-    pub fn map_move_nested<M, F>(self, op: F) -> VtableDefaultTraitData<M> where
+    pub fn map_move_nested<M, F>(self, op: F) -> VtableDefaultImplData<M> where
         F: FnMut(N) -> M,
     {
-        let VtableDefaultTraitData { trait_def_id, nested } = self;
-        VtableDefaultTraitData {
+        let VtableDefaultImplData { trait_def_id, nested } = self;
+        VtableDefaultImplData {
             trait_def_id: trait_def_id,
             nested: nested.into_iter().map(op).collect()
         }

--- a/src/librustc/middle/traits/project.rs
+++ b/src/librustc/middle/traits/project.rs
@@ -709,6 +709,7 @@ fn assemble_candidates_from_impls<'cx,'tcx>(
             // projection. And the projection where clause is handled
             // in `assemble_candidates_from_param_env`.
         }
+        super::VtableDefaultTrait(..) |
         super::VtableBuiltin(..) => {
             // These traits have no associated types.
             selcx.tcx().sess.span_bug(

--- a/src/librustc/middle/traits/project.rs
+++ b/src/librustc/middle/traits/project.rs
@@ -709,7 +709,7 @@ fn assemble_candidates_from_impls<'cx,'tcx>(
             // projection. And the projection where clause is handled
             // in `assemble_candidates_from_param_env`.
         }
-        super::VtableDefaultTrait(..) |
+        super::VtableDefaultImpl(..) |
         super::VtableBuiltin(..) => {
             // These traits have no associated types.
             selcx.tcx().sess.span_bug(

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1143,8 +1143,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         }
 
         match self_ty.sty {
-            ty::ty_infer(ty::TyVar(_)) |
             ty::ty_trait(..) => {},
+            ty::ty_infer(ty::TyVar(_)) => {
+                // the defaulted impl might apply, we don't know
+                if ty::trait_has_default_impl(self.tcx(), def_id) {
+                    candidates.ambiguous = true;
+                }
+            }
             _ => {
                 if ty::trait_has_default_impl(self.tcx(), def_id) {
                     candidates.vec.push(DefaultImplCandidate(def_id.clone()))

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1918,7 +1918,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             Err(ErrorReported) => Vec::new()
         };
 
-        let obligations = VecPerParamSpace::new(obligations, Vec::new(), Vec::new());
         debug!("vtable_default_impl_data: obligations={}", obligations.repr(self.tcx()));
 
         VtableDefaultTraitData {

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1377,8 +1377,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
                     ty::BoundSync |
                     ty::BoundSend => {
-                        // sync and send are not implemented for *const, *mut
-                        Err(Unimplemented)
+                        self.tcx().sess.bug(
+                            &format!(
+                                "raw pointers should have a negative \
+                                 impl for `Send` and `Sync`")[]);
                     }
                 }
             }

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1626,6 +1626,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 Vec::new()
             }
 
+            ty::ty_trait(..) |
             ty::ty_projection(..) |
             ty::ty_param(..) |
             ty::ty_infer(..) => {
@@ -1637,18 +1638,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
             ty::ty_uniq(referent_ty) => {  // Box<T>
                 vec![referent_ty]
-            }
-
-
-            ty::ty_trait(ref data) => {
-                // Recursively check all supertraits to find out if any further
-                // bounds are required and thus we must fulfill.
-                let principal =
-                    data.principal_trait_ref_with_self_ty(self.tcx(),
-                                                          self.tcx().types.err);
-
-
-                util::supertraits(self.tcx(), principal).map(|tr| tr.self_ty()).collect()
             }
 
             ty::ty_open(element_ty) => {vec![element_ty]},

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1149,7 +1149,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             });
         }
 
-        if self.tcx().default_trait_impls.borrow().contains(&def_id) {
+        if ty::trait_has_default_impl(self.tcx(), def_id) {
             candidates.vec.push(DefaultTraitCandidate(def_id.clone()))
         }
 

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1683,7 +1683,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             ty::ty_trait(..) |
             ty::ty_param(..) |
             ty::ty_projection(..) |
-            ty::ty_infer(ty::TyVar(_)) => {
+            ty::ty_infer(ty::TyVar(_)) |
+            ty::ty_infer(ty::FreshTy(_)) |
+            ty::ty_infer(ty::FreshIntTy(_)) => {
                 self.tcx().sess.bug(
                     &format!(
                         "asked to assemble constituent types of unexpected type: {}",

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -826,6 +826,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             }
             Some(bound @ ty::BoundSend) |
             Some(bound @ ty::BoundSync) => {
+                // Ideally, we shouldn't sepcial case Send/Sync. This will be unified
+                // as soon as default trait implementations for these traits land.
                 try!(self.assemble_candidates_from_impls(obligation, &mut candidates));
 
                 // No explicit impls were declared for this type, consider the fallback rules.
@@ -1599,27 +1601,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                               -> Result<BuiltinBoundConditions<'tcx>,SelectionError<'tcx>>
         {
             // First check for markers and other nonsense.
-            let tcx = this.tcx();
             match bound {
-                ty::BoundSend => {
-                    if Some(def_id) == tcx.lang_items.managed_bound() {
-                        return Err(Unimplemented)
-                    }
-                }
-
                 ty::BoundCopy => {
                     return Ok(ParameterBuiltin)
                 }
 
-                ty::BoundSync => {
-                    if
-                        Some(def_id) == tcx.lang_items.managed_bound() ||
-                        Some(def_id) == tcx.lang_items.unsafe_cell_type()
-                    {
-                        return Err(Unimplemented)
-                    }
-                }
-
+                ty::BoundSend |
+                ty::BoundSync |
                 ty::BoundSized => { }
             }
 

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1273,6 +1273,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 // #18453.
                 true
             }
+            (&DefaultTraitCandidate(_), _) => {
+                // Prefer other candidates over default implementations.
+                true
+            }
             (&ProjectionCandidate, &ParamCandidate(_)) => {
                 // FIXME(#20297) -- this gives where clauses precedent
                 // over projections. Really these are just two means

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1642,13 +1642,15 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             ty::ty_str |
             ty::ty_err |
             ty::ty_param(..) |
+            ty::ty_infer(ty::IntVar(_)) |
+            ty::ty_infer(ty::FloatVar(_)) |
             ty::ty_char => {
                 Some(Vec::new())
             }
 
             ty::ty_trait(..) |
             ty::ty_projection(..) |
-            ty::ty_infer(..) => {
+            ty::ty_infer(_) => {
                 self.tcx().sess.bug(
                     &format!(
                         "asked to assemble constituent types of unexpected type: {}",

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -20,7 +20,7 @@ use util::nodemap::FnvHashSet;
 use util::ppaux::Repr;
 
 use super::{Obligation, ObligationCause, PredicateObligation,
-            VtableImpl, VtableParam, VtableImplData, VtableDefaultTraitData};
+            VtableImpl, VtableParam, VtableImplData, VtableDefaultImplData};
 
 struct PredicateSet<'a,'tcx:'a> {
     tcx: &'a ty::ctxt<'tcx>,
@@ -469,7 +469,7 @@ impl<'tcx, N:Repr<'tcx>> Repr<'tcx> for super::Vtable<'tcx, N> {
             super::VtableImpl(ref v) =>
                 v.repr(tcx),
 
-            super::VtableDefaultTrait(ref t) =>
+            super::VtableDefaultImpl(ref t) =>
                 t.repr(tcx),
 
             super::VtableClosure(ref d, ref s) =>
@@ -511,9 +511,9 @@ impl<'tcx, N:Repr<'tcx>> Repr<'tcx> for super::VtableBuiltinData<N> {
     }
 }
 
-impl<'tcx, N:Repr<'tcx>> Repr<'tcx> for super::VtableDefaultTraitData<N> {
+impl<'tcx, N:Repr<'tcx>> Repr<'tcx> for super::VtableDefaultImplData<N> {
     fn repr(&self, tcx: &ty::ctxt<'tcx>) -> String {
-        format!("VtableDefaultTraitData(trait_def_id={}, nested={})",
+        format!("VtableDefaultImplData(trait_def_id={}, nested={})",
                 self.trait_def_id.repr(tcx),
                 self.nested.repr(tcx))
     }

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -444,6 +444,9 @@ impl<'tcx, N:Repr<'tcx>> Repr<'tcx> for super::Vtable<'tcx, N> {
             super::VtableImpl(ref v) =>
                 v.repr(tcx),
 
+            super::VtableDefaultTrait(ref t) =>
+                format!("VtableDefaultTrait({:?})", t),
+
             super::VtableClosure(ref d, ref s) =>
                 format!("VtableClosure({},{})",
                         d.repr(tcx),

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -323,8 +323,8 @@ pub fn trait_ref_for_builtin_bound<'tcx>(
     }
 }
 
+
 pub fn predicate_for_trait_ref<'tcx>(
-    tcx: &ty::ctxt<'tcx>,
     cause: ObligationCause<'tcx>,
     trait_ref: Rc<ty::TraitRef<'tcx>>,
     recursion_depth: uint)
@@ -349,7 +349,7 @@ pub fn predicate_for_default_trait_impl<'tcx>(
         def_id: trait_def_id,
         substs: tcx.mk_substs(Substs::empty().with_self_ty(param_ty))
     });
-    predicate_for_trait_ref(tcx, cause, trait_ref, recursion_depth)
+    predicate_for_trait_ref(cause, trait_ref, recursion_depth)
 }
 
 pub fn predicate_for_builtin_bound<'tcx>(
@@ -361,7 +361,7 @@ pub fn predicate_for_builtin_bound<'tcx>(
     -> Result<PredicateObligation<'tcx>, ErrorReported>
 {
     let trait_ref = try!(trait_ref_for_builtin_bound(tcx, builtin_bound, param_ty));
-    predicate_for_trait_ref(tcx, cause, trait_ref, recursion_depth)
+    predicate_for_trait_ref(cause, trait_ref, recursion_depth)
 }
 
 /// Cast a trait reference into a reference to one of its super

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -20,7 +20,7 @@ use util::nodemap::FnvHashSet;
 use util::ppaux::Repr;
 
 use super::{Obligation, ObligationCause, PredicateObligation,
-            VtableImpl, VtableParam, VtableImplData};
+            VtableImpl, VtableParam, VtableImplData, VtableDefaultTraitData};
 
 struct PredicateSet<'a,'tcx:'a> {
     tcx: &'a ty::ctxt<'tcx>,
@@ -323,6 +323,35 @@ pub fn trait_ref_for_builtin_bound<'tcx>(
     }
 }
 
+pub fn predicate_for_trait_ref<'tcx>(
+    tcx: &ty::ctxt<'tcx>,
+    cause: ObligationCause<'tcx>,
+    trait_ref: Rc<ty::TraitRef<'tcx>>,
+    recursion_depth: uint)
+    -> Result<PredicateObligation<'tcx>, ErrorReported>
+{
+    Ok(Obligation {
+        cause: cause,
+        recursion_depth: recursion_depth,
+        predicate: trait_ref.as_predicate(),
+    })
+}
+
+pub fn predicate_for_default_trait_impl<'tcx>(
+    tcx: &ty::ctxt<'tcx>,
+    cause: ObligationCause<'tcx>,
+    trait_def_id: ast::DefId,
+    recursion_depth: uint,
+    param_ty: Ty<'tcx>)
+    -> Result<PredicateObligation<'tcx>, ErrorReported>
+{
+    let trait_ref = Rc::new(ty::TraitRef {
+        def_id: trait_def_id,
+        substs: tcx.mk_substs(Substs::empty().with_self_ty(param_ty))
+    });
+    predicate_for_trait_ref(tcx, cause, trait_ref, recursion_depth)
+}
+
 pub fn predicate_for_builtin_bound<'tcx>(
     tcx: &ty::ctxt<'tcx>,
     cause: ObligationCause<'tcx>,
@@ -332,11 +361,7 @@ pub fn predicate_for_builtin_bound<'tcx>(
     -> Result<PredicateObligation<'tcx>, ErrorReported>
 {
     let trait_ref = try!(trait_ref_for_builtin_bound(tcx, builtin_bound, param_ty));
-    Ok(Obligation {
-        cause: cause,
-        recursion_depth: recursion_depth,
-        predicate: trait_ref.as_predicate(),
-    })
+    predicate_for_trait_ref(tcx, cause, trait_ref, recursion_depth)
 }
 
 /// Cast a trait reference into a reference to one of its super
@@ -445,7 +470,7 @@ impl<'tcx, N:Repr<'tcx>> Repr<'tcx> for super::Vtable<'tcx, N> {
                 v.repr(tcx),
 
             super::VtableDefaultTrait(ref t) =>
-                format!("VtableDefaultTrait({:?})", t),
+                t.repr(tcx),
 
             super::VtableClosure(ref d, ref s) =>
                 format!("VtableClosure({},{})",
@@ -482,6 +507,14 @@ impl<'tcx, N:Repr<'tcx>> Repr<'tcx> for super::VtableImplData<'tcx, N> {
 impl<'tcx, N:Repr<'tcx>> Repr<'tcx> for super::VtableBuiltinData<N> {
     fn repr(&self, tcx: &ty::ctxt<'tcx>) -> String {
         format!("VtableBuiltin(nested={})",
+                self.nested.repr(tcx))
+    }
+}
+
+impl<'tcx, N:Repr<'tcx>> Repr<'tcx> for super::VtableDefaultTraitData<N> {
+    fn repr(&self, tcx: &ty::ctxt<'tcx>) -> String {
+        format!("VtableDefaultTraitData(trait_def_id={}, nested={})",
+                self.trait_def_id.repr(tcx),
                 self.nested.repr(tcx))
     }
 }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -6007,7 +6007,10 @@ pub fn trait_default_impl(tcx: &ctxt, trait_def_id: DefId) -> Option<ast::DefId>
 }
 
 pub fn trait_has_default_impl(tcx: &ctxt, trait_def_id: DefId) -> bool {
-    tcx.default_trait_impls.borrow().contains_key(&trait_def_id)
+    match tcx.lang_items.to_builtin_kind(trait_def_id) {
+        Some(BoundSend) | Some(BoundSync) => true,
+        _ => tcx.default_trait_impls.borrow().contains_key(&trait_def_id)
+    }
 }
 
 /// Records a trait-to-implementation mapping.

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -5175,7 +5175,7 @@ pub fn impl_trait_ref<'tcx>(cx: &ctxt<'tcx>, id: ast::DefId)
                                 &None => None
                             }
                         }
-                        ast::ItemDefTrait(_, ref ast_trait_ref) => {
+                        ast::ItemDefaultImpl(_, ref ast_trait_ref) => {
                             Some(ty::node_id_to_trait_ref(cx, ast_trait_ref.ref_id))
                         }
                         _ => None

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -5175,6 +5175,9 @@ pub fn impl_trait_ref<'tcx>(cx: &ctxt<'tcx>, id: ast::DefId)
                                 &None => None
                             }
                         }
+                        ast::ItemDefTrait(_, ref ast_trait_ref) => {
+                            Some(ty::node_id_to_trait_ref(cx, ast_trait_ref.ref_id))
+                        }
                         _ => None
                     }
                 }
@@ -5999,7 +6002,6 @@ pub fn item_variances(tcx: &ctxt, item_id: ast::DefId) -> Rc<ItemVariances> {
 /// Records a trait-to-implementation mapping.
 pub fn record_default_trait_implementation(tcx: &ctxt, trait_def_id: DefId) {
 
-    //assert!(did.krate != ast::LOCAL_CRATE);
     if tcx.default_trait_impls.borrow().contains(&trait_def_id) {
         return;
     }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -758,7 +758,7 @@ pub struct ctxt<'tcx> {
     pub trait_impls: RefCell<DefIdMap<Rc<RefCell<Vec<ast::DefId>>>>>,
 
     /// Maps a trait onto a list of *default* trait implementations
-    pub default_trait_impls: RefCell<DefIdSet>,
+    default_trait_impls: RefCell<DefIdSet>,
 
     /// Maps a DefId of a type to a list of its inherent impls.
     /// Contains implementations of methods that are inherent to a type.
@@ -5997,6 +5997,10 @@ pub fn item_variances(tcx: &ctxt, item_id: ast::DefId) -> Rc<ItemVariances> {
     lookup_locally_or_in_crate_store(
         "item_variance_map", item_id, &mut *tcx.item_variance_map.borrow_mut(),
         || Rc::new(csearch::get_item_variances(&tcx.sess.cstore, item_id)))
+}
+
+pub fn trait_has_default_impl(tcx: &ctxt, trait_def_id: DefId) -> bool {
+    tcx.default_trait_impls.borrow().contains(&trait_def_id)
 }
 
 /// Records a trait-to-implementation mapping.

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -507,9 +507,9 @@ impl<'tcx, N: TypeFoldable<'tcx>> TypeFoldable<'tcx> for traits::VtableImplData<
     }
 }
 
-impl<'tcx, N: TypeFoldable<'tcx>> TypeFoldable<'tcx> for traits::VtableDefaultTraitData<N> {
-    fn fold_with<F:TypeFolder<'tcx>>(&self, folder: &mut F) -> traits::VtableDefaultTraitData<N> {
-        traits::VtableDefaultTraitData {
+impl<'tcx, N: TypeFoldable<'tcx>> TypeFoldable<'tcx> for traits::VtableDefaultImplData<N> {
+    fn fold_with<F:TypeFolder<'tcx>>(&self, folder: &mut F) -> traits::VtableDefaultImplData<N> {
+        traits::VtableDefaultImplData {
             trait_def_id: self.trait_def_id,
             nested: self.nested.fold_with(folder),
         }
@@ -528,7 +528,7 @@ impl<'tcx, N: TypeFoldable<'tcx>> TypeFoldable<'tcx> for traits::Vtable<'tcx, N>
     fn fold_with<F:TypeFolder<'tcx>>(&self, folder: &mut F) -> traits::Vtable<'tcx, N> {
         match *self {
             traits::VtableImpl(ref v) => traits::VtableImpl(v.fold_with(folder)),
-            traits::VtableDefaultTrait(ref t) => traits::VtableDefaultTrait(t.fold_with(folder)),
+            traits::VtableDefaultImpl(ref t) => traits::VtableDefaultImpl(t.fold_with(folder)),
             traits::VtableClosure(d, ref s) => {
                 traits::VtableClosure(d, s.fold_with(folder))
             }

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -507,6 +507,15 @@ impl<'tcx, N: TypeFoldable<'tcx>> TypeFoldable<'tcx> for traits::VtableImplData<
     }
 }
 
+impl<'tcx, N: TypeFoldable<'tcx>> TypeFoldable<'tcx> for traits::VtableDefaultTraitData<N> {
+    fn fold_with<F:TypeFolder<'tcx>>(&self, folder: &mut F) -> traits::VtableDefaultTraitData<N> {
+        traits::VtableDefaultTraitData {
+            trait_def_id: self.trait_def_id,
+            nested: self.nested.fold_with(folder),
+        }
+    }
+}
+
 impl<'tcx, N: TypeFoldable<'tcx>> TypeFoldable<'tcx> for traits::VtableBuiltinData<N> {
     fn fold_with<F:TypeFolder<'tcx>>(&self, folder: &mut F) -> traits::VtableBuiltinData<N> {
         traits::VtableBuiltinData {
@@ -519,7 +528,7 @@ impl<'tcx, N: TypeFoldable<'tcx>> TypeFoldable<'tcx> for traits::Vtable<'tcx, N>
     fn fold_with<F:TypeFolder<'tcx>>(&self, folder: &mut F) -> traits::Vtable<'tcx, N> {
         match *self {
             traits::VtableImpl(ref v) => traits::VtableImpl(v.fold_with(folder)),
-            traits::VtableDefaultTrait(t) => traits::VtableDefaultTrait(t),
+            traits::VtableDefaultTrait(ref t) => traits::VtableDefaultTrait(t.fold_with(folder)),
             traits::VtableClosure(d, ref s) => {
                 traits::VtableClosure(d, s.fold_with(folder))
             }

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -519,6 +519,7 @@ impl<'tcx, N: TypeFoldable<'tcx>> TypeFoldable<'tcx> for traits::Vtable<'tcx, N>
     fn fold_with<F:TypeFolder<'tcx>>(&self, folder: &mut F) -> traits::Vtable<'tcx, N> {
         match *self {
             traits::VtableImpl(ref v) => traits::VtableImpl(v.fold_with(folder)),
+            traits::VtableDefaultTrait(t) => traits::VtableDefaultTrait(t),
             traits::VtableClosure(d, ref s) => {
                 traits::VtableClosure(d, s.fold_with(folder))
             }

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -206,7 +206,7 @@ impl<'a, 'tcx> Env<'a, 'tcx> {
 
                 ast::ItemEnum(..) | ast::ItemStruct(..) |
                 ast::ItemTrait(..) | ast::ItemImpl(..) |
-                ast::ItemMac(..) => {
+                ast::ItemMac(..) | ast::ItemDefaultImpl(..) => {
                     None
                 }
 

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -209,7 +209,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EmbargoVisitor<'a, 'tcx> {
         match item.node {
             // impls/extern blocks do not break the "public chain" because they
             // cannot have visibility qualifiers on them anyway
-            ast::ItemImpl(..) | ast::ItemForeignMod(..) => {}
+            ast::ItemImpl(..) | ast::ItemDefTrait(..) | ast::ItemForeignMod(..) => {}
 
             // Traits are a little special in that even if they themselves are
             // not public they may still be exported.
@@ -1145,6 +1145,7 @@ impl<'a, 'tcx> SanePrivacyVisitor<'a, 'tcx> {
                 }
             }
 
+            ast::ItemDefTrait(..) |
             ast::ItemConst(..) | ast::ItemStatic(..) | ast::ItemStruct(..) |
             ast::ItemFn(..) | ast::ItemMod(..) | ast::ItemTy(..) |
             ast::ItemExternCrate(_) | ast::ItemUse(_) | ast::ItemMac(..) => {}
@@ -1204,7 +1205,7 @@ impl<'a, 'tcx> SanePrivacyVisitor<'a, 'tcx> {
                 }
             }
 
-            ast::ItemExternCrate(_) | ast::ItemUse(_) |
+            ast::ItemDefTrait(..) | ast::ItemExternCrate(_) | ast::ItemUse(_) |
             ast::ItemStatic(..) | ast::ItemConst(..) |
             ast::ItemFn(..) | ast::ItemMod(..) | ast::ItemTy(..) |
             ast::ItemMac(..) => {}

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -209,7 +209,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EmbargoVisitor<'a, 'tcx> {
         match item.node {
             // impls/extern blocks do not break the "public chain" because they
             // cannot have visibility qualifiers on them anyway
-            ast::ItemImpl(..) | ast::ItemDefTrait(..) | ast::ItemForeignMod(..) => {}
+            ast::ItemImpl(..) | ast::ItemDefaultImpl(..) | ast::ItemForeignMod(..) => {}
 
             // Traits are a little special in that even if they themselves are
             // not public they may still be exported.
@@ -802,7 +802,7 @@ impl<'a, 'tcx> PrivacyVisitor<'a, 'tcx> {
             def::DefVariant(..) => ck("variant"),
             def::DefTy(_, false) => ck("type"),
             def::DefTy(_, true) => ck("enum"),
-            def::DefTrait(..) => ck("trait"),
+            def::DefaultImpl(..) => ck("trait"),
             def::DefStruct(..) => ck("struct"),
             def::DefMethod(_, Some(..), _) => ck("trait method"),
             def::DefMethod(..) => ck("method"),
@@ -1145,7 +1145,7 @@ impl<'a, 'tcx> SanePrivacyVisitor<'a, 'tcx> {
                 }
             }
 
-            ast::ItemDefTrait(..) |
+            ast::ItemDefaultImpl(..) |
             ast::ItemConst(..) | ast::ItemStatic(..) | ast::ItemStruct(..) |
             ast::ItemFn(..) | ast::ItemMod(..) | ast::ItemTy(..) |
             ast::ItemExternCrate(_) | ast::ItemUse(_) | ast::ItemMac(..) => {}
@@ -1205,7 +1205,7 @@ impl<'a, 'tcx> SanePrivacyVisitor<'a, 'tcx> {
                 }
             }
 
-            ast::ItemDefTrait(..) | ast::ItemExternCrate(_) | ast::ItemUse(_) |
+            ast::ItemDefaultImpl(..) | ast::ItemExternCrate(_) | ast::ItemUse(_) |
             ast::ItemStatic(..) | ast::ItemConst(..) |
             ast::ItemFn(..) | ast::ItemMod(..) | ast::ItemTy(..) |
             ast::ItemMac(..) => {}

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -40,7 +40,7 @@ use syntax::ast::{Block, Crate};
 use syntax::ast::{DeclItem, DefId};
 use syntax::ast::{ForeignItem, ForeignItemFn, ForeignItemStatic};
 use syntax::ast::{Item, ItemConst, ItemEnum, ItemExternCrate, ItemFn};
-use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefTrait};
+use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefaultImpl};
 use syntax::ast::{ItemStruct, ItemTrait, ItemTy, ItemUse};
 use syntax::ast::{MethodImplItem, Name, NamedField, NodeId};
 use syntax::ast::{PathListIdent, PathListMod};
@@ -656,7 +656,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                 parent.clone()
             }
 
-            ItemDefTrait(_, _) |
+            ItemDefaultImpl(_, _) |
             ItemImpl(_, _, _, Some(_), _, _) => parent.clone(),
 
             ItemTrait(_, _, _, ref items) => {
@@ -736,7 +736,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                     self.trait_item_map.insert((name, def_id), kind);
                 }
 
-                name_bindings.define_type(DefTrait(def_id), sp, modifiers);
+                name_bindings.define_type(DefaultImpl(def_id), sp, modifiers);
                 parent.clone()
             }
             ItemMac(..) => parent.clone()
@@ -918,7 +918,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
             }
             child_name_bindings.define_value(def, DUMMY_SP, modifiers);
           }
-          DefTrait(def_id) => {
+          DefaultImpl(def_id) => {
               debug!("(building reduced graph for external \
                       crate) building type {}", final_ident);
 

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -40,7 +40,7 @@ use syntax::ast::{Block, Crate};
 use syntax::ast::{DeclItem, DefId};
 use syntax::ast::{ForeignItem, ForeignItemFn, ForeignItemStatic};
 use syntax::ast::{Item, ItemConst, ItemEnum, ItemExternCrate, ItemFn};
-use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic};
+use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefTrait};
 use syntax::ast::{ItemStruct, ItemTrait, ItemTy, ItemUse};
 use syntax::ast::{MethodImplItem, Name, NamedField, NodeId};
 use syntax::ast::{PathListIdent, PathListMod};
@@ -656,6 +656,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                 parent.clone()
             }
 
+            ItemDefTrait(_, _) |
             ItemImpl(_, _, _, Some(_), _, _) => parent.clone(),
 
             ItemTrait(_, _, _, ref items) => {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -70,7 +70,7 @@ use syntax::ast::{ExprClosure, ExprLoop, ExprWhile, ExprMethodCall};
 use syntax::ast::{ExprPath, ExprQPath, ExprStruct, FnDecl};
 use syntax::ast::{ForeignItemFn, ForeignItemStatic, Generics};
 use syntax::ast::{Ident, ImplItem, Item, ItemConst, ItemEnum, ItemExternCrate};
-use syntax::ast::{ItemFn, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic};
+use syntax::ast::{ItemFn, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefTrait};
 use syntax::ast::{ItemStruct, ItemTrait, ItemTy, ItemUse};
 use syntax::ast::{Local, MethodImplItem, Mod, Name, NodeId};
 use syntax::ast::{Pat, PatEnum, PatIdent, PatLit};
@@ -2840,6 +2840,9 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 });
             }
 
+            ItemDefTrait(_, ref trait_ref) => {
+                self.resolve_trait_reference(item.id, trait_ref, TraitImplementation);
+            }
             ItemImpl(_, _,
                      ref generics,
                      ref implemented_traits,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -70,7 +70,7 @@ use syntax::ast::{ExprClosure, ExprLoop, ExprWhile, ExprMethodCall};
 use syntax::ast::{ExprPath, ExprQPath, ExprStruct, FnDecl};
 use syntax::ast::{ForeignItemFn, ForeignItemStatic, Generics};
 use syntax::ast::{Ident, ImplItem, Item, ItemConst, ItemEnum, ItemExternCrate};
-use syntax::ast::{ItemFn, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefTrait};
+use syntax::ast::{ItemFn, ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefaultImpl};
 use syntax::ast::{ItemStruct, ItemTrait, ItemTy, ItemUse};
 use syntax::ast::{Local, MethodImplItem, Mod, Name, NodeId};
 use syntax::ast::{Pat, PatEnum, PatIdent, PatLit};
@@ -2840,7 +2840,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 });
             }
 
-            ItemDefTrait(_, ref trait_ref) => {
+            ItemDefaultImpl(_, ref trait_ref) => {
                 self.resolve_trait_reference(item.id, trait_ref, TraitImplementation);
             }
             ItemImpl(_, _,
@@ -3199,7 +3199,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             }
             Some(def) => {
                 match def {
-                    (DefTrait(_), _) => {
+                    (DefaultImpl(_), _) => {
                         debug!("(resolving trait) found trait def: {:?}", def);
                         self.record_def(trait_reference.ref_id, def);
                     }
@@ -4675,7 +4675,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         None => continue
                     };
                     let trait_def_id = match def {
-                        DefTrait(trait_def_id) => trait_def_id,
+                        DefaultImpl(trait_def_id) => trait_def_id,
                         _ => continue,
                     };
                     if self.trait_item_map.contains_key(&(name, trait_def_id)) {
@@ -4691,7 +4691,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     Some(target) => target,
                 };
                 let did = match target.bindings.def_for_namespace(TypeNS) {
-                    Some(DefTrait(trait_def_id)) => trait_def_id,
+                    Some(DefaultImpl(trait_def_id)) => trait_def_id,
                     Some(..) | None => continue,
                 };
                 if self.trait_item_map.contains_key(&(name, did)) {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2989,7 +2989,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 // check for imports shadowing primitive types
                 if let ast::ViewPathSimple(ident, _) = view_path.node {
                     match self.def_map.borrow().get(&item.id) {
-                        Some(&DefTy(..)) | Some(&DefStruct(..)) | Some(&DefTrait(..)) | None => {
+                        Some(&DefTy(..)) | Some(&DefStruct(..)) | Some(&DefaultImpl(..)) | None => {
                             self.check_if_primitive_type_name(ident.name, item.span);
                         }
                         _ => {}

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -239,7 +239,7 @@ impl <'l, 'tcx> DxrVisitor<'l, 'tcx> {
             def::DefTy(..) |
             def::DefAssociatedTy(..) |
             def::DefAssociatedPath(..) |
-            def::DefTrait(_) => Some(recorder::TypeRef),
+            def::DefaultImpl(_) => Some(recorder::TypeRef),
             def::DefStatic(_, _) |
             def::DefConst(_) |
             def::DefLocal(_) |

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -207,7 +207,7 @@ fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
             def::DefUpvar(..) => {
                 datum_callee(bcx, ref_expr)
             }
-            def::DefMod(..) | def::DefForeignMod(..) | def::DefTrait(..) |
+            def::DefMod(..) | def::DefForeignMod(..) | def::DefaultImpl(..) |
             def::DefTy(..) | def::DefPrimTy(..) | def::DefAssociatedTy(..) |
             def::DefUse(..) | def::DefTyParamBinder(..) |
             def::DefRegion(..) | def::DefLabel(..) | def::DefTyParam(..) |

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -390,7 +390,7 @@ fn trans_monomorphized_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             Callee { bcx: bcx, data: Fn(llfn) }
         }
         traits::VtableBuiltin(..) |
-        traits::VtableDefaultTrait(..) |
+        traits::VtableDefaultImpl(..) |
         traits::VtableParam(..) => {
             bcx.sess().bug(
                 &format!("resolved vtable bad vtable {} in trans",
@@ -716,7 +716,7 @@ pub fn get_vtable<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         let vtable = fulfill_obligation(ccx, DUMMY_SP, trait_ref.clone());
         match vtable {
             // Should default trait error here?
-            traits::VtableDefaultTrait(_) |
+            traits::VtableDefaultImpl(_) |
             traits::VtableBuiltin(_) => {
                 Vec::new().into_iter()
             }

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -390,6 +390,7 @@ fn trans_monomorphized_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             Callee { bcx: bcx, data: Fn(llfn) }
         }
         traits::VtableBuiltin(..) |
+        traits::VtableDefaultTrait(..) |
         traits::VtableParam(..) => {
             bcx.sess().bug(
                 &format!("resolved vtable bad vtable {} in trans",
@@ -714,6 +715,8 @@ pub fn get_vtable<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     let methods = traits::supertraits(tcx, trait_ref.clone()).flat_map(|trait_ref| {
         let vtable = fulfill_obligation(ccx, DUMMY_SP, trait_ref.clone());
         match vtable {
+            // Should default trait error here?
+            traits::VtableDefaultTrait(_) |
             traits::VtableBuiltin(_) => {
                 Vec::new().into_iter()
             }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -617,7 +617,7 @@ pub fn instantiate_trait_ref<'tcx>(
     -> Rc<ty::TraitRef<'tcx>>
 {
     match ::lookup_def_tcx(this.tcx(), ast_trait_ref.path.span, ast_trait_ref.ref_id) {
-        def::DefTrait(trait_def_id) => {
+        def::DefaultImpl(trait_def_id) => {
             let trait_ref = ast_path_to_trait_ref(this,
                                                   rscope,
                                                   trait_def_id,
@@ -931,7 +931,7 @@ fn ast_ty_to_trait_ref<'tcx>(this: &AstConv<'tcx>,
     match ty.node {
         ast::TyPath(ref path, id) => {
             match this.tcx().def_map.borrow().get(&id) {
-                Some(&def::DefTrait(trait_def_id)) => {
+                Some(&def::DefaultImpl(trait_def_id)) => {
                     let mut projection_bounds = Vec::new();
                     let trait_ref = object_path_to_poly_trait_ref(this,
                                                                   rscope,
@@ -1211,7 +1211,7 @@ pub fn ast_ty_to_ty<'tcx>(this: &AstConv<'tcx>,
                     Some(&d) => d
                 };
                 match a_def {
-                    def::DefTrait(trait_def_id) => {
+                    def::DefaultImpl(trait_def_id) => {
                         // N.B. this case overlaps somewhat with
                         // TyObjectSum, see that fn for details
                         let mut projection_bounds = Vec::new();
@@ -1821,7 +1821,7 @@ pub fn partition_bounds<'a>(tcx: &ty::ctxt,
         match *ast_bound {
             ast::TraitTyParamBound(ref b, ast::TraitBoundModifier::None) => {
                 match ::lookup_def_tcx(tcx, b.trait_ref.path.span, b.trait_ref.ref_id) {
-                    def::DefTrait(trait_did) => {
+                    def::DefaultImpl(trait_did) => {
                         match trait_def_ids.get(&trait_did) {
                             // Already seen this trait. We forbid
                             // duplicates in the list (for some

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -435,7 +435,7 @@ pub fn check_pat_struct<'a, 'tcx>(pcx: &pat_ctxt<'a, 'tcx>, pat: &'tcx ast::Pat,
 
     let def = tcx.def_map.borrow()[pat.id].clone();
     let (enum_def_id, variant_def_id) = match def {
-        def::DefTrait(_) => {
+        def::DefaultImpl(_) => {
             let name = pprust::path_to_string(path);
             span_err!(tcx.sess, pat.span, E0168,
                 "use of trait `{}` in a struct pattern", name);

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -330,7 +330,7 @@ pub fn all_traits<'a>(ccx: &'a CrateCtxt) -> AllTraits<'a> {
                                cstore: &cstore::CStore,
                                dl: decoder::DefLike) {
             match dl {
-                decoder::DlDef(def::DefTrait(did)) => {
+                decoder::DlDef(def::DefaultImpl(did)) => {
                     traits.push(TraitInfo::new(did));
                 }
                 decoder::DlDef(def::DefMod(did)) => {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3858,7 +3858,7 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                                           variant_id, &fields[..]);
                 enum_id
             }
-            Some(def::DefTrait(def_id)) => {
+            Some(def::DefaultImpl(def_id)) => {
                 span_err!(tcx.sess, path.span, E0159,
                     "use of trait `{}` as a struct constructor",
                     pprust::path_to_string(path));
@@ -4630,7 +4630,7 @@ fn type_scheme_and_predicates_for_def<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
         def::DefStruct(id) | def::DefConst(id) => {
             (ty::lookup_item_type(fcx.tcx(), id), ty::lookup_predicates(fcx.tcx(), id))
         }
-        def::DefTrait(_) |
+        def::DefaultImpl(_) |
         def::DefTy(..) |
         def::DefAssociatedTy(..) |
         def::DefAssociatedPath(..) |
@@ -4734,7 +4734,7 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
         def::DefTy(..) |
         def::DefAssociatedTy(..) |
         def::DefAssociatedPath(..) |
-        def::DefTrait(..) |
+        def::DefaultImpl(..) |
         def::DefPrimTy(..) |
         def::DefTyParam(..) => {
             // Everything but the final segment should have no

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -96,7 +96,7 @@ impl<'cx, 'tcx,'v> visit::Visitor<'v> for OrphanChecker<'cx, 'tcx> {
                     }
                 }
             }
-            ast::ItemDefTrait(_, ref ast_trait_ref) => {
+            ast::ItemDefaultImpl(_, ref ast_trait_ref) => {
                 // "Trait" impl
                 debug!("coherence2::orphan check: default trait impl {}", item.repr(self.tcx));
                 let trait_ref = ty::node_id_to_trait_ref(self.tcx, ast_trait_ref.ref_id);

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -101,7 +101,7 @@ impl<'cx, 'tcx,'v> visit::Visitor<'v> for OrphanChecker<'cx, 'tcx> {
                 debug!("coherence2::orphan check: default trait impl {}", item.repr(self.tcx));
                 let trait_ref = ty::node_id_to_trait_ref(self.tcx, ast_trait_ref.ref_id);
                 if trait_ref.def_id.krate != ast::LOCAL_CRATE {
-                    span_err!(self.tcx.sess, item.span, E0316,
+                    span_err!(self.tcx.sess, item.span, E0318,
                               "cannot create default implementations for traits outside the \
                                crate they're defined in; define a new trait instead.");
                 }

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -96,6 +96,16 @@ impl<'cx, 'tcx,'v> visit::Visitor<'v> for OrphanChecker<'cx, 'tcx> {
                     }
                 }
             }
+            ast::ItemDefTrait(_, ref ast_trait_ref) => {
+                // "Trait" impl
+                debug!("coherence2::orphan check: default trait impl {}", item.repr(self.tcx));
+                let trait_ref = ty::node_id_to_trait_ref(self.tcx, ast_trait_ref.ref_id);
+                if trait_ref.def_id.krate != ast::LOCAL_CRATE {
+                    span_err!(self.tcx.sess, item.span, E0316,
+                              "cannot create default implementations for traits outside the \
+                               crate they're defined in; define a new trait instead.");
+                }
+            }
             _ => {
                 // Not an impl
             }

--- a/src/librustc_typeck/coherence/overlap.rs
+++ b/src/librustc_typeck/coherence/overlap.rs
@@ -141,7 +141,7 @@ impl<'cx, 'tcx,'v> visit::Visitor<'v> for OverlapChecker<'cx, 'tcx> {
                             ty::ty_struct(..) | ty::ty_enum(..) => {},
                             _ => {
                                 let impl_def_id = ast_util::local_def(item.id);
-                                span_err!(self.tcx.sess, self.span_of_impl(impl_def_id), E0317,
+                                span_err!(self.tcx.sess, self.span_of_impl(impl_def_id), E0319,
                                           "implementations for traits providing default \
                                            implementations are only allowed on structs and enums");
 

--- a/src/librustc_typeck/coherence/overlap.rs
+++ b/src/librustc_typeck/coherence/overlap.rs
@@ -25,6 +25,9 @@ use util::ppaux::Repr;
 pub fn check(tcx: &ty::ctxt) {
     let mut overlap = OverlapChecker { tcx: tcx };
     overlap.check_for_overlapping_impls();
+
+    // this secondary walk specifically checks for impls of defaulted
+    // traits, for which additional overlap rules exist
     visit::walk_crate(&mut overlap, tcx.map.krate());
 }
 

--- a/src/librustc_typeck/coherence/overlap.rs
+++ b/src/librustc_typeck/coherence/overlap.rs
@@ -17,12 +17,18 @@ use middle::infer::{self, new_infer_ctxt};
 use syntax::ast::{DefId};
 use syntax::ast::{LOCAL_CRATE};
 use syntax::ast;
+use syntax::ast_util;
+use syntax::visit;
 use syntax::codemap::Span;
 use util::ppaux::Repr;
 
 pub fn check(tcx: &ty::ctxt) {
-    let overlap = OverlapChecker { tcx: tcx };
+    let mut overlap = OverlapChecker { tcx: tcx };
     overlap.check_for_overlapping_impls();
+
+    // this secondary walk specifically checks for impls of defaulted
+    // traits, for which additional overlap rules exist
+    visit::walk_crate(&mut overlap, tcx.map.krate());
 }
 
 struct OverlapChecker<'cx, 'tcx:'cx> {
@@ -120,5 +126,35 @@ impl<'cx, 'tcx> OverlapChecker<'cx, 'tcx> {
     fn span_of_impl(&self, impl_did: ast::DefId) -> Span {
         assert_eq!(impl_did.krate, ast::LOCAL_CRATE);
         self.tcx.map.span(impl_did.node)
+    }
+}
+
+
+impl<'cx, 'tcx,'v> visit::Visitor<'v> for OverlapChecker<'cx, 'tcx> {
+    fn visit_item(&mut self, item: &'v ast::Item) {
+        match item.node {
+            ast::ItemDefaultImpl(_, _) => {
+                let impl_def_id = ast_util::local_def(item.id);
+                match ty::impl_trait_ref(self.tcx, impl_def_id) {
+                    Some(ref trait_ref) => {
+                        match ty::trait_default_impl(self.tcx, trait_ref.def_id) {
+                            Some(other_impl) if other_impl != impl_def_id => {
+                                self.report_overlap_error(trait_ref.def_id,
+                                                          other_impl,
+                                                          impl_def_id);
+                            }
+                            Some(_) => {}
+                            None => {
+                                self.tcx.sess.bug(
+                                          &format!("no default implementation recorded for `{:?}`",
+                                          item)[]);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
     }
 }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -649,7 +649,10 @@ fn convert_item(ccx: &CollectCtxt, it: &ast::Item) {
                                    &enum_definition.variants);
         },
         ast::ItemDefTrait(_, ref ast_trait_ref) => {
+            let trait_ref = astconv::instantiate_trait_ref(ccx, &ExplicitRscope,
+                                                           ast_trait_ref, None, None);
 
+            ty::record_default_trait_implementation(tcx, trait_ref.def_id)
         }
         ast::ItemImpl(_, _,
                       ref generics,

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -648,6 +648,9 @@ fn convert_item(ccx: &CollectCtxt, it: &ast::Item) {
                                    predicates,
                                    &enum_definition.variants);
         },
+        ast::ItemDefTrait(_, ref ast_trait_ref) => {
+
+        }
         ast::ItemImpl(_, _,
                       ref generics,
                       ref opt_trait_ref,
@@ -1141,6 +1144,7 @@ fn compute_type_scheme_of_item<'a,'tcx>(ccx: &CollectCtxt<'a,'tcx>,
             let t = ty::mk_struct(tcx, local_def(it.id), tcx.mk_substs(substs));
             ty::TypeScheme { ty: t, generics: ty_generics }
         }
+        ast::ItemDefTrait(..) |
         ast::ItemTrait(..) |
         ast::ItemImpl(..) |
         ast::ItemMod(..) |

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -648,7 +648,7 @@ fn convert_item(ccx: &CollectCtxt, it: &ast::Item) {
                                    predicates,
                                    &enum_definition.variants);
         },
-        ast::ItemDefTrait(_, ref ast_trait_ref) => {
+        ast::ItemDefaultImpl(_, ref ast_trait_ref) => {
             let trait_ref = astconv::instantiate_trait_ref(ccx, &ExplicitRscope,
                                                            ast_trait_ref, None, None);
 
@@ -1147,7 +1147,7 @@ fn compute_type_scheme_of_item<'a,'tcx>(ccx: &CollectCtxt<'a,'tcx>,
             let t = ty::mk_struct(tcx, local_def(it.id), tcx.mk_substs(substs));
             ty::TypeScheme { ty: t, generics: ty_generics }
         }
-        ast::ItemDefTrait(..) |
+        ast::ItemDefaultImpl(..) |
         ast::ItemTrait(..) |
         ast::ItemImpl(..) |
         ast::ItemMod(..) |

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -652,7 +652,7 @@ fn convert_item(ccx: &CollectCtxt, it: &ast::Item) {
             let trait_ref = astconv::instantiate_trait_ref(ccx, &ExplicitRscope,
                                                            ast_trait_ref, None, None);
 
-            ty::record_default_trait_implementation(tcx, trait_ref.def_id)
+            ty::record_default_trait_implementation(tcx, trait_ref.def_id, local_def(it.id))
         }
         ast::ItemImpl(_, _,
                       ref generics,
@@ -1190,6 +1190,7 @@ fn convert_typed_item<'a, 'tcx>(ccx: &CollectCtxt<'a, 'tcx>,
         ast::ItemStruct(_, ref generics) => {
             ty_generic_bounds_for_type_or_impl(ccx, &scheme.generics, generics)
         }
+        ast::ItemDefaultImpl(..) |
         ast::ItemTrait(..) |
         ast::ItemExternCrate(..) |
         ast::ItemUse(..) |

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -172,8 +172,8 @@ register_diagnostics! {
     E0248, // found value name used as a type
     E0249, // expected constant expr for array length
     E0250, // expected constant expr for array length
-    E0316,  // can't create default impls for traits outside their crates
-    E0317
+    E0318, // can't create default impls for traits outside their crates
+    E0319  // trait impls for defaulted traits allowed just for structs/enums
 }
 
 __build_diagnostic_array! { DIAGNOSTICS }

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -172,7 +172,8 @@ register_diagnostics! {
     E0248, // found value name used as a type
     E0249, // expected constant expr for array length
     E0250, // expected constant expr for array length
-    E0316  // can't create default impls for traits outside their crates
+    E0316,  // can't create default impls for traits outside their crates
+    E0317
 }
 
 __build_diagnostic_array! { DIAGNOSTICS }

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -171,7 +171,8 @@ register_diagnostics! {
     E0247, // found module name used as a type
     E0248, // found value name used as a type
     E0249, // expected constant expr for array length
-    E0250  // expected constant expr for array length
+    E0250, // expected constant expr for array length
+    E0316  // can't create default impls for traits outside their crates
 }
 
 __build_diagnostic_array! { DIAGNOSTICS }

--- a/src/librustc_typeck/variance.rs
+++ b/src/librustc_typeck/variance.rs
@@ -476,7 +476,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for TermsContext<'a, 'tcx> {
 
             ast::ItemExternCrate(_) |
             ast::ItemUse(_) |
-            ast::ItemDefTrait(..) |
+            ast::ItemDefaultImpl(..) |
             ast::ItemImpl(..) |
             ast::ItemStatic(..) |
             ast::ItemConst(..) |
@@ -627,7 +627,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for ConstraintContext<'a, 'tcx> {
             ast::ItemForeignMod(..) |
             ast::ItemTy(..) |
             ast::ItemImpl(..) |
-            ast::ItemDefTrait(..) |
+            ast::ItemDefaultImpl(..) |
             ast::ItemMac(..) => {
             }
         }

--- a/src/librustc_typeck/variance.rs
+++ b/src/librustc_typeck/variance.rs
@@ -476,6 +476,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for TermsContext<'a, 'tcx> {
 
             ast::ItemExternCrate(_) |
             ast::ItemUse(_) |
+            ast::ItemDefTrait(..) |
             ast::ItemImpl(..) |
             ast::ItemStatic(..) |
             ast::ItemConst(..) |
@@ -626,6 +627,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for ConstraintContext<'a, 'tcx> {
             ast::ItemForeignMod(..) |
             ast::ItemTy(..) |
             ast::ItemImpl(..) |
+            ast::ItemDefTrait(..) |
             ast::ItemMac(..) => {
             }
         }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -69,7 +69,7 @@ fn try_inline_def(cx: &DocContext, tcx: &ty::ctxt,
     let mut ret = Vec::new();
     let did = def.def_id();
     let inner = match def {
-        def::DefTrait(did) => {
+        def::DefaultImpl(did) => {
             record_extern_fqn(cx, did, clean::TypeTrait);
             clean::TraitItem(build_external_trait(cx, tcx, did))
         }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2431,7 +2431,7 @@ fn register_def(cx: &DocContext, def: def::Def) -> ast::DefId {
         def::DefFn(i, _) => (i, TypeFunction),
         def::DefTy(i, false) => (i, TypeTypedef),
         def::DefTy(i, true) => (i, TypeEnum),
-        def::DefTrait(i) => (i, TypeTrait),
+        def::DefaultImpl(i) => (i, TypeTrait),
         def::DefStruct(i) => (i, TypeStruct),
         def::DefMod(i) => (i, TypeModule),
         def::DefStatic(i, _) => (i, TypeStatic),

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -39,6 +39,7 @@ pub struct Module {
     pub vis: ast::Visibility,
     pub stab: Option<attr::Stability>,
     pub impls: Vec<Impl>,
+    pub def_traits: Vec<DefaultTrait>,
     pub foreigns: Vec<ast::ForeignMod>,
     pub macros: Vec<Macro>,
     pub is_crate: bool,
@@ -65,6 +66,7 @@ impl Module {
             constants  : Vec::new(),
             traits     : Vec::new(),
             impls      : Vec::new(),
+            def_traits : Vec::new(),
             foreigns   : Vec::new(),
             macros     : Vec::new(),
             is_crate   : false,
@@ -193,6 +195,12 @@ pub struct Impl {
     pub whence: Span,
     pub vis: ast::Visibility,
     pub stab: Option<attr::Stability>,
+    pub id: ast::NodeId,
+}
+
+pub struct DefaultTrait {
+    pub unsafety: ast::Unsafety,
+    pub trait_: ast::TraitRef,
     pub id: ast::NodeId,
 }
 

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -39,7 +39,7 @@ pub struct Module {
     pub vis: ast::Visibility,
     pub stab: Option<attr::Stability>,
     pub impls: Vec<Impl>,
-    pub def_traits: Vec<DefaultTrait>,
+    pub def_traits: Vec<DefaultImpl>,
     pub foreigns: Vec<ast::ForeignMod>,
     pub macros: Vec<Macro>,
     pub is_crate: bool,
@@ -198,7 +198,7 @@ pub struct Impl {
     pub id: ast::NodeId,
 }
 
-pub struct DefaultTrait {
+pub struct DefaultImpl {
     pub unsafety: ast::Unsafety,
     pub trait_: ast::TraitRef,
     pub id: ast::NodeId,

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -358,8 +358,8 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 };
                 om.impls.push(i);
             },
-            ast::ItemDefTrait(unsafety, ref trait_ref) => {
-                let i = DefaultTrait {
+            ast::ItemDefaultImpl(unsafety, ref trait_ref) => {
+                let i = DefaultImpl {
                     unsafety: unsafety,
                     trait_: trait_ref.clone(),
                     id: item.id

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -358,6 +358,14 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 };
                 om.impls.push(i);
             },
+            ast::ItemDefTrait(unsafety, ref trait_ref) => {
+                let i = DefaultTrait {
+                    unsafety: unsafety,
+                    trait_: trait_ref.clone(),
+                    id: item.id
+                };
+                om.def_traits.push(i);
+            }
             ast::ItemForeignMod(ref fm) => {
                 om.foreigns.push(fm.clone());
             }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1644,7 +1644,7 @@ pub enum Item_ {
 
     // Default trait implementations
     // `impl Trait for ..`
-    ItemDefTrait(Unsafety, TraitRef),
+    ItemDefaultImpl(Unsafety, TraitRef),
     ItemImpl(Unsafety,
              ImplPolarity,
              Generics,
@@ -1671,7 +1671,7 @@ impl Item_ {
             ItemTrait(..) => "trait",
             ItemMac(..) |
             ItemImpl(..) |
-            ItemDefTrait(..) => "item"
+            ItemDefaultImpl(..) => "item"
         }
     }
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1641,6 +1641,10 @@ pub enum Item_ {
               Generics,
               TyParamBounds,
               Vec<TraitItem>),
+
+    // Default trait implementations
+    // `impl Trait for ..`
+    ItemDefTrait(Unsafety, TraitRef),
     ItemImpl(Unsafety,
              ImplPolarity,
              Generics,
@@ -1666,7 +1670,8 @@ impl Item_ {
             ItemStruct(..) => "struct",
             ItemTrait(..) => "trait",
             ItemMac(..) |
-            ItemImpl(..) => "item"
+            ItemImpl(..) |
+            ItemDefTrait(..) => "item"
         }
     }
 }

--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -1044,6 +1044,7 @@ fn node_id_to_string(map: &Map, id: NodeId, include_id: bool) -> String {
                 ItemStruct(..) => "struct",
                 ItemTrait(..) => "trait",
                 ItemImpl(..) => "impl",
+                ItemDefTrait(..) => "default impl",
                 ItemMac(..) => "macro"
             };
             format!("{} {}{}", item_str, path_str, id_str)

--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -1044,7 +1044,7 @@ fn node_id_to_string(map: &Map, id: NodeId, include_id: bool) -> String {
                 ItemStruct(..) => "struct",
                 ItemTrait(..) => "trait",
                 ItemImpl(..) => "impl",
-                ItemDefTrait(..) => "default impl",
+                ItemDefaultImpl(..) => "default impl",
                 ItemMac(..) => "macro"
             };
             format!("{} {}{}", item_str, path_str, id_str)

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -252,8 +252,12 @@ pub fn name_to_dummy_lifetime(name: Name) -> Lifetime {
 /// hint of where they came from, (previously they would all just be
 /// listed as `__extensions__::method_name::hash`, with no indication
 /// of the type).
-pub fn impl_pretty_name(trait_ref: &Option<TraitRef>, ty: &Ty) -> Ident {
-    let mut pretty = pprust::ty_to_string(ty);
+pub fn impl_pretty_name(trait_ref: &Option<TraitRef>, ty: Option<&Ty>) -> Ident {
+    let mut pretty = match ty {
+        Some(t) => pprust::ty_to_string(t),
+        None => String::from_str("..")
+    };
+
     match *trait_ref {
         Some(ref trait_ref) => {
             pretty.push('.');

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -498,7 +498,7 @@ impl<'a> TraitDef<'a> {
         // Just mark it now since we know that it'll end up used downstream
         attr::mark_used(&attr);
         let opt_trait_ref = Some(trait_ref);
-        let ident = ast_util::impl_pretty_name(&opt_trait_ref, &*self_type);
+        let ident = ast_util::impl_pretty_name(&opt_trait_ref, Some(&*self_type));
         let mut a = vec![attr];
         a.extend(self.attributes.iter().cloned());
         cx.item(

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -999,6 +999,9 @@ pub fn noop_fold_item_underscore<T: Folder>(i: Item_, folder: &mut T) -> Item_ {
             let struct_def = folder.fold_struct_def(struct_def);
             ItemStruct(struct_def, folder.fold_generics(generics))
         }
+        ItemDefTrait(unsafety, ref trait_ref) => {
+            ItemDefTrait(unsafety, folder.fold_trait_ref((*trait_ref).clone()))
+        }
         ItemImpl(unsafety, polarity, generics, ifce, ty, impl_items) => {
             let new_impl_items = impl_items.into_iter().flat_map(|item| {
                 folder.fold_impl_item(item).into_iter()
@@ -1150,7 +1153,7 @@ pub fn noop_fold_item_simple<T: Folder>(Item {id, ident, attrs, node, vis, span}
     let ident = match node {
         // The node may have changed, recompute the "pretty" impl name.
         ItemImpl(_, _, _, ref maybe_trait, ref ty, _) => {
-            ast_util::impl_pretty_name(maybe_trait, &**ty)
+            ast_util::impl_pretty_name(maybe_trait, Some(&**ty))
         }
         _ => ident
     };

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -999,8 +999,8 @@ pub fn noop_fold_item_underscore<T: Folder>(i: Item_, folder: &mut T) -> Item_ {
             let struct_def = folder.fold_struct_def(struct_def);
             ItemStruct(struct_def, folder.fold_generics(generics))
         }
-        ItemDefTrait(unsafety, ref trait_ref) => {
-            ItemDefTrait(unsafety, folder.fold_trait_ref((*trait_ref).clone()))
+        ItemDefaultImpl(unsafety, ref trait_ref) => {
+            ItemDefaultImpl(unsafety, folder.fold_trait_ref((*trait_ref).clone()))
         }
         ItemImpl(unsafety, polarity, generics, ifce, ty, impl_items) => {
             let new_impl_items = impl_items.into_iter().flat_map(|item| {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -31,7 +31,7 @@ use ast::{ExprVec, ExprWhile, ExprWhileLet, ExprForLoop, Field, FnDecl};
 use ast::{ForeignItem, ForeignItemStatic, ForeignItemFn, ForeignMod, FunctionRetTy};
 use ast::{Ident, Inherited, ImplItem, Item, Item_, ItemStatic};
 use ast::{ItemEnum, ItemFn, ItemForeignMod, ItemImpl, ItemConst};
-use ast::{ItemMac, ItemMod, ItemStruct, ItemTrait, ItemTy, ItemDefTrait};
+use ast::{ItemMac, ItemMod, ItemStruct, ItemTrait, ItemTy, ItemDefaultImpl};
 use ast::{ItemExternCrate, ItemUse};
 use ast::{LifetimeDef, Lit, Lit_};
 use ast::{LitBool, LitChar, LitByte, LitBinary};
@@ -4843,7 +4843,7 @@ impl<'a> Parser<'a> {
             self.expect(&token::OpenDelim(token::Brace));
             self.expect(&token::CloseDelim(token::Brace));
             (ast_util::impl_pretty_name(&opt_trait, None),
-             ItemDefTrait(unsafety, opt_trait.unwrap()), None)
+             ItemDefaultImpl(unsafety, opt_trait.unwrap()), None)
         } else {
             if opt_trait.is_some() {
                 ty = self.parse_ty_sum();

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -31,7 +31,7 @@ use ast::{ExprVec, ExprWhile, ExprWhileLet, ExprForLoop, Field, FnDecl};
 use ast::{ForeignItem, ForeignItemStatic, ForeignItemFn, ForeignMod, FunctionRetTy};
 use ast::{Ident, Inherited, ImplItem, Item, Item_, ItemStatic};
 use ast::{ItemEnum, ItemFn, ItemForeignMod, ItemImpl, ItemConst};
-use ast::{ItemMac, ItemMod, ItemStruct, ItemTrait, ItemTy};
+use ast::{ItemMac, ItemMod, ItemStruct, ItemTrait, ItemTy, ItemDefTrait};
 use ast::{ItemExternCrate, ItemUse};
 use ast::{LifetimeDef, Lit, Lit_};
 use ast::{LitBool, LitChar, LitByte, LitBinary};
@@ -4783,10 +4783,13 @@ impl<'a> Parser<'a> {
         (impl_items, inner_attrs)
     }
 
-    /// Parses two variants (with the region/type params always optional):
+    /// Parses items implementations variants
     ///    impl<T> Foo { ... }
-    ///    impl<T> ToString for ~[T] { ... }
+    ///    impl<T> ToString for &'static T { ... }
+    ///    impl Send for .. {}
     fn parse_item_impl(&mut self, unsafety: ast::Unsafety) -> ItemInfo {
+        let impl_span = self.span;
+
         // First, parse type parameters if necessary.
         let mut generics = self.parse_generics();
 
@@ -4807,7 +4810,7 @@ impl<'a> Parser<'a> {
         // Parse traits, if necessary.
         let opt_trait = if could_be_trait && self.eat_keyword(keywords::For) {
             // New-style trait. Reinterpret the type as a trait.
-            let opt_trait_ref = match ty.node {
+            match ty.node {
                 TyPath(ref path, node_id) => {
                     Some(TraitRef {
                         path: (*path).clone(),
@@ -4818,10 +4821,7 @@ impl<'a> Parser<'a> {
                     self.span_err(ty.span, "not a trait");
                     None
                 }
-            };
-
-            ty = self.parse_ty_sum();
-            opt_trait_ref
+            }
         } else {
             match polarity {
                 ast::ImplPolarity::Negative => {
@@ -4834,14 +4834,27 @@ impl<'a> Parser<'a> {
             None
         };
 
-        self.parse_where_clause(&mut generics);
-        let (impl_items, attrs) = self.parse_impl_items();
+        if self.eat(&token::DotDot) {
+            if generics.is_parameterized() {
+                self.span_err(impl_span, "default trait implementations are not \
+                                          allowed to have genercis");
+            }
 
-        let ident = ast_util::impl_pretty_name(&opt_trait, &*ty);
+            self.expect(&token::OpenDelim(token::Brace));
+            self.expect(&token::CloseDelim(token::Brace));
+            (ast_util::impl_pretty_name(&opt_trait, None),
+             ItemDefTrait(unsafety, opt_trait.unwrap()), None)
+        } else {
+            if opt_trait.is_some() {
+                ty = self.parse_ty_sum();
+            }
+            self.parse_where_clause(&mut generics);
+            let (impl_items, attrs) = self.parse_impl_items();
 
-        (ident,
-         ItemImpl(unsafety, polarity, generics, opt_trait, ty, impl_items),
-         Some(attrs))
+            (ast_util::impl_pretty_name(&opt_trait, Some(&*ty)),
+             ItemImpl(unsafety, polarity, generics, opt_trait, ty, impl_items),
+             Some(attrs))
+        }
     }
 
     /// Parse a::B<String,i32>

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -926,6 +926,18 @@ impl<'a> State<'a> {
                 try!(self.print_struct(&**struct_def, generics, item.ident, item.span));
             }
 
+            ast::ItemDefTrait(unsafety, ref trait_ref) => {
+                try!(self.head(""));
+                try!(self.print_visibility(item.vis));
+                try!(self.print_unsafety(unsafety));
+                try!(self.word_nbsp("impl"));
+                try!(self.print_trait_ref(trait_ref));
+                try!(space(&mut self.s));
+                try!(self.word_space("for"));
+                try!(self.word_space(".."));
+                try!(self.bopen());
+                try!(self.bclose(item.span));
+            }
             ast::ItemImpl(unsafety,
                           polarity,
                           ref generics,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -926,7 +926,7 @@ impl<'a> State<'a> {
                 try!(self.print_struct(&**struct_def, generics, item.ident, item.span));
             }
 
-            ast::ItemDefTrait(unsafety, ref trait_ref) => {
+            ast::ItemDefaultImpl(unsafety, ref trait_ref) => {
                 try!(self.head(""));
                 try!(self.print_visibility(item.vis));
                 try!(self.print_unsafety(unsafety));

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -282,7 +282,7 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
             visitor.visit_generics(type_parameters);
             walk_enum_def(visitor, enum_definition, type_parameters)
         }
-        ItemDefTrait(_, ref trait_ref) => {
+        ItemDefaultImpl(_, ref trait_ref) => {
             visitor.visit_trait_ref(trait_ref)
         }
         ItemImpl(_, _,

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -282,6 +282,9 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
             visitor.visit_generics(type_parameters);
             walk_enum_def(visitor, enum_definition, type_parameters)
         }
+        ItemDefTrait(_, ref trait_ref) => {
+            visitor.visit_trait_ref(trait_ref)
+        }
         ItemImpl(_, _,
                  ref type_parameters,
                  ref trait_reference,

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -332,6 +332,7 @@ pub fn winsorize<T: Float + FromPrimitive>(samples: &mut [T], pct: T) {
 
 /// Returns a HashMap with the number of occurrences of every element in the
 /// sequence that the iterator exposes.
+#[cfg(not(stage0))]
 pub fn freq_count<T, U>(iter: T) -> hash_map::HashMap<U, uint>
   where T: Iterator<Item=U>, U: Eq + Clone + Hash
 {

--- a/src/test/compile-fail/coherence-default-trait-impl.rs
+++ b/src/test/compile-fail/coherence-default-trait-impl.rs
@@ -12,7 +12,9 @@
 
 #![feature(optin_builtin_traits)]
 
-trait MyTrait {}
+use std::marker::MarkerTrait;
+
+trait MyTrait: MarkerTrait {}
 
 impl MyTrait for .. {}
 

--- a/src/test/compile-fail/coherence-default-trait-impl.rs
+++ b/src/test/compile-fail/coherence-default-trait-impl.rs
@@ -21,7 +21,4 @@ impl MyTrait for .. {}
 impl MyTrait for .. {}
 //~^ ERROR conflicting implementations for trait `MyTrait`
 
-impl MyTrait for (i32, i32) {}
-//~^ ERROR implementations for traits providing default implementations are only allowed on
-
 fn main() {}

--- a/src/test/compile-fail/coherence-default-trait-impl.rs
+++ b/src/test/compile-fail/coherence-default-trait-impl.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-tidy-linelength
+
+#![feature(optin_builtin_traits)]
+
+trait MyTrait {}
+
+impl MyTrait for .. {}
+
+impl MyTrait for .. {}
+//~^ ERROR conflicting implementations for trait `MyTrait`
+
+impl MyTrait for (i32, i32) {}
+//~^ ERROR implementations for traits providing default implementations are only allowed on
+
+fn main() {}

--- a/src/test/compile-fail/coherence-impls-builtin.rs
+++ b/src/test/compile-fail/coherence-impls-builtin.rs
@@ -34,6 +34,7 @@ unsafe impl Send for [MyType] {}
 
 unsafe impl Send for &'static [NotSync] {}
 //~^ ERROR builtin traits can only be implemented on structs or enums
+//~^^ ERROR conflicting implementations for trait `core::marker::Send`
 
 fn is_send<T: Send>() {}
 

--- a/src/test/compile-fail/recursion_limit.rs
+++ b/src/test/compile-fail/recursion_limit.rs
@@ -47,4 +47,7 @@ fn main() {
     //~^^^^ ERROR overflow evaluating
     //~^^^^^ NOTE consider adding a `#![recursion_limit="20"]` attribute to your crate
     //~^^^^^^ NOTE required by `is_send`
+    //~^^^^^^^ ERROR overflow evaluating
+    //~^^^^^^^^ NOTE consider adding a `#![recursion_limit="20"]` attribute to your crate
+    //~^^^^^^^^^ NOTE required by `is_send`
 }

--- a/src/test/compile-fail/syntaxt-default-trait-impls.rs
+++ b/src/test/compile-fail/syntaxt-default-trait-impls.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(optin_builtin_traits)]
+
+trait MyDefaultImpl {}
+
+impl<T> MyDefaultImpl for .. {}
+//~^ ERROR default trait implementations are not allowed to have genercis
+
+fn main() {}

--- a/src/test/compile-fail/typeck-default-trait-impl-assoc-type.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-assoc-type.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that we do not consider associated types to be sendable without
+// some applicable trait bound (and we don't ICE).
+
+trait Trait {
+    type AssocType;
+    fn dummy(&self) { }
+}
+fn bar<T:Trait+Send>() {
+    is_send::<T::AssocType>(); //~ ERROR not implemented
+}
+
+fn is_send<T:Send>() {
+}
+
+fn main() { }

--- a/src/test/compile-fail/typeck-default-trait-impl-constituent-types-2.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-constituent-types-2.rs
@@ -1,0 +1,30 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(optin_builtin_traits)]
+
+trait MyTrait {}
+
+impl MyTrait for .. {}
+
+struct MyS;
+
+struct MyS2;
+
+impl !MyTrait for MyS2 {}
+
+fn is_mytrait<T: MyTrait>() {}
+
+fn main() {
+    is_mytrait::<MyS>();
+
+    is_mytrait::<(MyS2, MyS)>();
+    //~^ ERROR the trait `MyTrait` is not implemented for the type `MyS2`
+}

--- a/src/test/compile-fail/typeck-default-trait-impl-constituent-types-2.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-constituent-types-2.rs
@@ -10,7 +10,9 @@
 
 #![feature(optin_builtin_traits)]
 
-trait MyTrait {}
+use std::marker::MarkerTrait;
+
+trait MyTrait: MarkerTrait {}
 
 impl MyTrait for .. {}
 

--- a/src/test/compile-fail/typeck-default-trait-impl-constituent-types.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-constituent-types.rs
@@ -1,0 +1,36 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(optin_builtin_traits)]
+
+trait MyTrait {}
+
+impl MyTrait for .. {}
+impl<T> !MyTrait for *mut T {}
+
+struct MyS;
+
+struct MyS2;
+
+impl !MyTrait for MyS2 {}
+
+struct MyS3;
+
+fn is_mytrait<T: MyTrait>() {}
+
+fn main() {
+    is_mytrait::<MyS>();
+
+    is_mytrait::<MyS2>();
+    //~^ ERROR the trait `MyTrait` is not implemented for the type `MyS2`
+
+    is_mytrait::<Vec<MyS3>>();
+    //~^ ERROR the trait `MyTrait` is not implemented for the type `*mut MyS3`
+}

--- a/src/test/compile-fail/typeck-default-trait-impl-constituent-types.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-constituent-types.rs
@@ -10,7 +10,9 @@
 
 #![feature(optin_builtin_traits)]
 
-trait MyTrait {}
+use std::marker::MarkerTrait;
+
+trait MyTrait: MarkerTrait {}
 
 impl MyTrait for .. {}
 impl<T> !MyTrait for *mut T {}
@@ -30,7 +32,4 @@ fn main() {
 
     is_mytrait::<MyS2>();
     //~^ ERROR the trait `MyTrait` is not implemented for the type `MyS2`
-
-    is_mytrait::<Vec<MyS3>>();
-    //~^ ERROR the trait `MyTrait` is not implemented for the type `*mut MyS3`
 }

--- a/src/test/compile-fail/typeck-default-trait-impl-negation-send.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-negation-send.rs
@@ -1,0 +1,31 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(optin_builtin_traits)]
+
+struct MySendable {
+   t: *mut u8
+}
+
+unsafe impl Send for MySendable {}
+
+struct MyNotSendable {
+   t: *mut u8
+}
+
+impl !Send for MyNotSendable {}
+
+fn is_send<T: Send>() {}
+
+fn main() {
+    is_send::<MySendable>();
+    is_send::<MyNotSendable>();
+    //~^ ERROR the trait `core::marker::Send` is not implemented for the type `MyNotSendable`
+}

--- a/src/test/compile-fail/typeck-default-trait-impl-negation-sync.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-negation-sync.rs
@@ -1,0 +1,50 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-tidy-linelength
+
+#![feature(optin_builtin_traits)]
+
+use std::marker::Managed;
+use std::cell::UnsafeCell;
+
+struct MySync {
+   t: *mut u8
+}
+
+unsafe impl Sync for MySync {}
+
+struct MyNotSync {
+   t: *mut u8
+}
+
+impl !Sync for MyNotSync {}
+
+struct MyTypeWUnsafe {
+   t: UnsafeCell<u8>
+}
+
+struct MyTypeManaged {
+   t: Managed
+}
+
+fn is_sync<T: Sync>() {}
+
+fn main() {
+    is_sync::<MySync>();
+    is_sync::<MyNotSync>();
+    //~^ ERROR the trait `core::marker::Sync` is not implemented for the type `MyNotSync`
+
+    is_sync::<MyTypeWUnsafe>();
+    //~^ ERROR the trait `core::marker::Sync` is not implemented for the type `core::cell::UnsafeCell<u8>`
+
+    is_sync::<MyTypeManaged>();
+    //~^ ERROR the trait `core::marker::Sync` is not implemented for the type `core::marker::Managed`
+}

--- a/src/test/compile-fail/typeck-default-trait-impl-negation.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-negation.rs
@@ -1,0 +1,42 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(optin_builtin_traits)]
+
+trait MyTrait {}
+
+impl MyTrait for .. {}
+
+unsafe trait MyUnsafeTrait {}
+
+unsafe impl MyUnsafeTrait for .. {}
+
+struct ThisImplsTrait;
+
+impl !MyUnsafeTrait for ThisImplsTrait {}
+
+
+struct ThisImplsUnsafeTrait;
+
+impl !MyTrait for ThisImplsUnsafeTrait {}
+
+fn is_my_trait<T: MyTrait>() {}
+fn is_my_unsafe_trait<T: MyUnsafeTrait>() {}
+
+fn main() {
+    is_my_trait::<ThisImplsTrait>();
+    is_my_trait::<ThisImplsUnsafeTrait>();
+    //~^ ERROR the trait `MyTrait` is not implemented for the type `ThisImplsUnsafeTrait`
+
+    is_my_unsafe_trait::<ThisImplsTrait>();
+    //~^ ERROR the trait `MyUnsafeTrait` is not implemented for the type `ThisImplsTrait`
+
+    is_my_unsafe_trait::<ThisImplsUnsafeTrait>();
+}

--- a/src/test/compile-fail/typeck-default-trait-impl-negation.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-negation.rs
@@ -10,11 +10,13 @@
 
 #![feature(optin_builtin_traits)]
 
-trait MyTrait {}
+use std::marker::MarkerTrait;
+
+trait MyTrait: MarkerTrait {}
 
 impl MyTrait for .. {}
 
-unsafe trait MyUnsafeTrait {}
+unsafe trait MyUnsafeTrait: MarkerTrait {}
 
 unsafe impl MyUnsafeTrait for .. {}
 

--- a/src/test/compile-fail/typeck-default-trait-impl-outside-crate.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-outside-crate.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-tidy-linelength
+
+#![feature(optin_builtin_traits)]
+
+impl Copy for .. {}
+//~^ ERROR cannot create default implementations for traits outside the crate they're defined in; define a new trait instead.
+
+fn main() {}

--- a/src/test/compile-fail/typeck-default-trait-impl-precedence.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-precedence.rs
@@ -29,4 +29,5 @@ impl Signed for i32 { }
 fn main() {
     is_defaulted::<&'static i32>();
     is_defaulted::<&'static u32>();
+    //~^ ERROR the trait `Signed` is not implemented for the type `u32`
 }

--- a/src/test/compile-fail/typeck-default-trait-impl-precedence.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-precedence.rs
@@ -1,0 +1,32 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that declaring that `&T` is `Defaulted` if `T:Signed` implies
+// that other `&T` is NOT `Defaulted` if `T:Signed` does not hold. In
+// other words, the `..` impl only applies if there are no existing
+// impls whose types unify.
+
+#![feature(optin_builtin_traits)]
+
+use std::marker::MarkerTrait;
+
+trait Defaulted : MarkerTrait { }
+impl Defaulted for .. { }
+impl<'a,T:Signed> Defaulted for &'a T { }
+impl<'a,T:Signed> Defaulted for &'a mut T { }
+fn is_defaulted<T:Defaulted>() { }
+
+trait Signed : MarkerTrait { }
+impl Signed for i32 { }
+
+fn main() {
+    is_defaulted::<&'static i32>();
+    is_defaulted::<&'static u32>();
+}

--- a/src/test/compile-fail/typeck-default-trait-impl-send-param.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-send-param.rs
@@ -1,0 +1,21 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that we do not consider parameter types to be sendable without
+// an explicit trait bound.
+
+fn foo<T>() {
+    is_send::<T>() //~ ERROR not implemented
+}
+
+fn is_send<T:Send>() {
+}
+
+fn main() { }

--- a/src/test/compile-fail/typeck-default-trait-impl-superregion.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-superregion.rs
@@ -1,0 +1,29 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that when a `..` impl applies, we also check that any
+// supertrait conditions are met.
+
+#![feature(optin_builtin_traits)]
+
+use std::marker::MarkerTrait;
+
+trait MyTrait : 'static {}
+
+impl MyTrait for .. {}
+
+fn foo<T:MyTrait>() { }
+
+fn bar<'a>() {
+    foo::<&'a ()>(); //~ ERROR does not fulfill the required lifetime
+}
+
+fn main() {
+}

--- a/src/test/compile-fail/typeck-default-trait-impl-supertrait.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-supertrait.rs
@@ -24,6 +24,6 @@ fn foo<T:MyTrait>() { bar::<T>() }
 fn bar<T:NotImplemented>() { }
 
 fn main() {
-    foo::<i32>(); //~ ERROR XXX
-    bar::<i32>(); //~ ERROR XXX
+    foo::<i32>(); //~ ERROR the trait `NotImplemented` is not implemented for the type `i32`
+    bar::<i64>(); //~ ERROR the trait `NotImplemented` is not implemented for the type `i64`
 }

--- a/src/test/compile-fail/typeck-default-trait-impl-supertrait.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-supertrait.rs
@@ -13,7 +13,9 @@
 
 #![feature(optin_builtin_traits)]
 
-trait NotImplemented { }
+use std::marker::MarkerTrait;
+
+trait NotImplemented: MarkerTrait { }
 
 trait MyTrait : NotImplemented {}
 

--- a/src/test/compile-fail/typeck-default-trait-impl-supertrait.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-supertrait.rs
@@ -1,0 +1,29 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that when a `..` impl applies, we also check that any
+// supertrait conditions are met.
+
+#![feature(optin_builtin_traits)]
+
+trait NotImplemented { }
+
+trait MyTrait : NotImplemented {}
+
+impl MyTrait for .. {}
+
+fn foo<T:MyTrait>() { bar::<T>() }
+
+fn bar<T:NotImplemented>() { }
+
+fn main() {
+    foo::<i32>(); //~ ERROR XXX
+    bar::<i32>(); //~ ERROR XXX
+}

--- a/src/test/compile-fail/typeck-default-trait-impl-trait-where-clause.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-trait-where-clause.rs
@@ -25,14 +25,19 @@ impl MyTrait for .. {}
 
 fn foo<T:MyTrait>() {
     bar::<Option<T>>()
-        //~^ ERROR not implemented for the type `Option<T>`
-        //
-        // This should probably typecheck. This is #20671.
+    //~^ ERROR the trait `NotImplemented` is not implemented for the type `core::option::Option<T>`
+    //
+    // This should probably typecheck. This is #20671.
 }
 
 fn bar<T:NotImplemented>() { }
 
+fn test() {
+    bar::<Option<i32>>();
+    //~^ ERROR the trait `NotImplemented` is not implemented for the type `core::option::Option<i32>`
+}
+
 fn main() {
-    foo::<i32>(); //~ ERROR not implemented for the type `i32`
-    bar::<Option<i32>>(); //~ ERROR not implemented for the type `Option<i32>`
+    foo::<i32>();
+    //~^ ERROR the trait `NotImplemented` is not implemented for the type `core::option::Option<i32>`
 }

--- a/src/test/compile-fail/typeck-default-trait-impl-trait-where-clause.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-trait-where-clause.rs
@@ -1,0 +1,38 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that when a `..` impl applies, we also check that any
+// supertrait conditions are met.
+
+#![feature(optin_builtin_traits)]
+
+trait NotImplemented { }
+
+trait MyTrait
+    where Option<Self> : NotImplemented
+{}
+
+impl NotImplemented for i32 {}
+
+impl MyTrait for .. {}
+
+fn foo<T:MyTrait>() {
+    bar::<Option<T>>()
+        //~^ ERROR not implemented for the type `Option<T>`
+        //
+        // This should probably typecheck. This is #20671.
+}
+
+fn bar<T:NotImplemented>() { }
+
+fn main() {
+    foo::<i32>(); //~ ERROR not implemented for the type `i32`
+    bar::<Option<i32>>(); //~ ERROR not implemented for the type `Option<i32>`
+}

--- a/src/test/compile-fail/typeck-default-trait-impl-trait-where-clause.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-trait-where-clause.rs
@@ -15,9 +15,11 @@
 
 #![feature(optin_builtin_traits)]
 
-trait NotImplemented { }
+use std::marker::MarkerTrait;
 
-trait MyTrait
+trait NotImplemented: MarkerTrait { }
+
+trait MyTrait: MarkerTrait
     where Option<Self> : NotImplemented
 {}
 

--- a/src/test/compile-fail/typeck-default-trait-impl-trait-where-clause.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-trait-where-clause.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-tidy-linelength
+
 // Test that when a `..` impl applies, we also check that any
 // supertrait conditions are met.
 

--- a/src/test/compile-fail/typeck-negative-impls-builtin.rs
+++ b/src/test/compile-fail/typeck-negative-impls-builtin.rs
@@ -17,6 +17,6 @@ trait TestTrait {
 }
 
 impl !TestTrait for TestType {}
-//~^ ERROR  negative impls are currently allowed just for `Send` and `Sync`
+//~^ ERROR negative impls are only allowed for traits with default impls (e.g., `Send` and `Sync`)
 
 fn main() {}

--- a/src/test/parse-fail/empty-impl-semicolon.rs
+++ b/src/test/parse-fail/empty-impl-semicolon.rs
@@ -8,4 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-impl Foo; //~ ERROR expected one of `(`, `+`, `::`, `<`, `for`, `where`, or `{`, found `;`
+impl Foo; //~ ERROR expected one of `(`, `+`, `..`, `::`, `<`, `for`, `where`, or `{`, found `;`

--- a/src/test/parse-fail/multitrait.rs
+++ b/src/test/parse-fail/multitrait.rs
@@ -13,7 +13,7 @@ struct S {
 }
 
 impl Cmp, ToString for S {
-//~^ ERROR: expected one of `(`, `+`, `::`, `<`, `for`, `where`, or `{`, found `,`
+//~^ ERROR: expected one of `(`, `+`, `..`, `::`, `<`, `for`, `where`, or `{`, found `,`
   fn eq(&&other: S) { false }
   fn to_string(&self) -> String { "hi".to_string() }
 }

--- a/src/test/parse-fail/trait-bounds-not-on-impl.rs
+++ b/src/test/parse-fail/trait-bounds-not-on-impl.rs
@@ -13,7 +13,9 @@ trait Foo {
 
 struct Bar;
 
-impl Foo + Owned for Bar { //~ ERROR not a trait
+impl Foo + Owned for Bar {
+//~^ ERROR not a trait
+//~^^ ERROR expected one of `..`, `where`, or `{`, found `Bar`
 }
 
 fn main() { }

--- a/src/test/pretty/default-trait-impl.rs
+++ b/src/test/pretty/default-trait-impl.rs
@@ -1,0 +1,19 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(optin_builtin_traits)]
+
+// pp-exact
+
+trait MyTrait { }
+
+impl MyTrait for .. { }
+
+pub fn main() { }

--- a/src/test/pretty/default-trait-impl.rs
+++ b/src/test/pretty/default-trait-impl.rs
@@ -12,7 +12,9 @@
 
 // pp-exact
 
-trait MyTrait { }
+use std::marker::MarkerTrait;
+
+trait MyTrait: MarkerTrait { }
 
 impl MyTrait for .. { }
 


### PR DESCRIPTION
This is one more step towards completing #13231

This series of commits add support for default trait implementations. The changes in this PR don't break existing code and they are expected to preserve the existing behavior in the compiler as far as built-in bounds checks go.

The PR adds negative implementations of `Send`/`Sync` for some types and it removes the special cases for `Send`/`Sync` during the trait obligations checks. That is, it now fully relies on the traits check rather than lang items.

Once this patch lands and a new snapshot is created, it'll be possible to add default impls for `Send` and `Sync` and remove entirely the use of `BuiltinBound::{BoundSend,BoundSync}` for positive implementations as well.

This PR also removes the restriction on negative implementations. That is, it is now possible to add negative implementations for traits other than `Send`/`Sync`
