### PR TITLE
rustdoc: Render new `self` syntax in `use`

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2244,7 +2244,7 @@ impl Clean<ViewListIdent> for ast::PathListItem {
                 source: resolve_def(cx, id)
             },
             ast::PathListMod { id } => ViewListIdent {
-                name: "mod".to_string(),
+                name: "self".to_string(),
                 source: resolve_def(cx, id)
             }
         }

--- a/src/test/run-make/rustdoc-viewpath-self/Makefile
+++ b/src/test/run-make/rustdoc-viewpath-self/Makefile
@@ -1,0 +1,6 @@
+-include ../tools.mk
+
+all: foo.rs
+	$(HOST_RPATH_ENV) $(RUSTDOC) -w html -o $(TMPDIR)/doc foo.rs
+	$(HTMLDOCCK) $(TMPDIR)/doc foo.rs
+

--- a/src/test/run-make/rustdoc-viewpath-self/foo.rs
+++ b/src/test/run-make/rustdoc-viewpath-self/foo.rs
@@ -1,0 +1,26 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub mod io {
+    pub trait Reader { }
+}
+
+pub enum Maybe<A> {
+    Just(A),
+    Nothing
+}
+
+// @has foo/prelude/index.html
+pub mod prelude {
+    // @has foo/prelude/index.html '//code' 'pub use io::{self, Reader}'
+    #[doc(no_inline)] pub use io::{self, Reader};
+    // @has foo/prelude/index.html '//code' 'pub use Maybe::{self, Just, Nothing}'
+    #[doc(no_inline)] pub use Maybe::{self, Just, Nothing};
+}


### PR DESCRIPTION
Fix #21442
