### PR TITLE
Fix up check to bypass internal buffer

### DIFF
--- a/src/libstd/old_io/buffered.rs
+++ b/src/libstd/old_io/buffered.rs
@@ -111,7 +111,7 @@ impl<R: Reader> Buffer for BufferedReader<R> {
 
 impl<R: Reader> Reader for BufferedReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
-        if self.pos == self.cap && buf.len() >= self.buf.capacity() {
+        if self.pos == self.cap && buf.len() >= self.buf.len() {
             return self.inner.read(buf);
         }
         let nread = {


### PR DESCRIPTION
We don't care about how much space the allocation has, but the actual
usable space in the buffer.

r? @alexcrichton 
