### PR TITLE
rustc: Print out a prettier version of crate types

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -882,7 +882,7 @@ pub fn collect_crate_types(session: &Session,
         let res = !link::invalid_output_for_target(session, *crate_type);
 
         if !res {
-            session.warn(&format!("dropping unsupported crate type `{:?}` \
+            session.warn(&format!("dropping unsupported crate type `{}` \
                                    for target `{}`",
                                  *crate_type, session.opts.target_triple)[]);
         }


### PR DESCRIPTION
Closes rust-lang/cargo#1234
