### PR TITLE
Add a few missing stability attributes

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -46,6 +46,7 @@ use super::table::BucketState::{
 use super::state::HashState;
 
 const INITIAL_LOG2_CAP: uint = 5;
+#[unstable(feature = "std_misc")]
 pub const INITIAL_CAPACITY: uint = 1 << INITIAL_LOG2_CAP; // 2^5
 
 /// The default behavior of HashMap implements a load factor of 90.9%.
@@ -1596,6 +1597,8 @@ impl Default for RandomState {
 /// typically declare an ability to explicitly hash into this particular type,
 /// but rather in a `H: hash::Writer` type parameter.
 #[allow(missing_copy_implementations)]
+#[unstable(feature = "std_misc",
+           reason = "hashing an hash maps may be altered")]
 pub struct Hasher { inner: SipHasher }
 
 impl hash::Writer for Hasher {

--- a/src/libstd/collections/hash/state.rs
+++ b/src/libstd/collections/hash/state.rs
@@ -24,6 +24,7 @@ use hash;
 /// algorithm can implement the `Default` trait and create hash maps with the
 /// `DefaultState` structure. This state is 0-sized and will simply delegate
 /// to `Default` when asked to create a hasher.
+#[unstable(feature = "std_misc", reason = "hasher stuff is unclear")]
 pub trait HashState {
     type Hasher: hash::Hasher;
 
@@ -35,6 +36,7 @@ pub trait HashState {
 /// default trait.
 ///
 /// This struct has is 0-sized and does not need construction.
+#[unstable(feature = "std_misc", reason = "hasher stuff is unclear")]
 pub struct DefaultState<H>;
 
 impl<H: Default + hash::Hasher> HashState for DefaultState<H> {

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -45,6 +45,7 @@ macro_rules! try_opt {
 
 /// ISO 8601 time duration with nanosecond precision.
 /// This also allows for the negative duration; see individual methods for details.
+#[unstable(feature = "std_misc")]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct Duration {
     secs: i64,
@@ -52,12 +53,14 @@ pub struct Duration {
 }
 
 /// The minimum possible `Duration`: `i64::MIN` milliseconds.
+#[unstable(feature = "std_misc")]
 pub const MIN: Duration = Duration {
     secs: i64::MIN / MILLIS_PER_SEC - 1,
     nanos: NANOS_PER_SEC + (i64::MIN % MILLIS_PER_SEC) as i32 * NANOS_PER_MILLI
 };
 
 /// The maximum possible `Duration`: `i64::MAX` milliseconds.
+#[unstable(feature = "std_misc")]
 pub const MAX: Duration = Duration {
     secs: i64::MAX / MILLIS_PER_SEC,
     nanos: (i64::MAX % MILLIS_PER_SEC) as i32 * NANOS_PER_MILLI
@@ -68,6 +71,7 @@ impl Duration {
     /// Equivalent to `Duration::seconds(weeks * 7 * 24 * 60 * 60), with overflow checks.
     /// Panics when the duration is out of bounds.
     #[inline]
+    #[unstable(feature = "std_misc")]
     pub fn weeks(weeks: i64) -> Duration {
         let secs = weeks.checked_mul(SECS_PER_WEEK).expect("Duration::weeks out of bounds");
         Duration::seconds(secs)
@@ -77,6 +81,7 @@ impl Duration {
     /// Equivalent to `Duration::seconds(days * 24 * 60 * 60)` with overflow checks.
     /// Panics when the duration is out of bounds.
     #[inline]
+    #[unstable(feature = "std_misc")]
     pub fn days(days: i64) -> Duration {
         let secs = days.checked_mul(SECS_PER_DAY).expect("Duration::days out of bounds");
         Duration::seconds(secs)
@@ -86,6 +91,7 @@ impl Duration {
     /// Equivalent to `Duration::seconds(hours * 60 * 60)` with overflow checks.
     /// Panics when the duration is out of bounds.
     #[inline]
+    #[unstable(feature = "std_misc")]
     pub fn hours(hours: i64) -> Duration {
         let secs = hours.checked_mul(SECS_PER_HOUR).expect("Duration::hours ouf of bounds");
         Duration::seconds(secs)
@@ -95,6 +101,7 @@ impl Duration {
     /// Equivalent to `Duration::seconds(minutes * 60)` with overflow checks.
     /// Panics when the duration is out of bounds.
     #[inline]
+    #[unstable(feature = "std_misc")]
     pub fn minutes(minutes: i64) -> Duration {
         let secs = minutes.checked_mul(SECS_PER_MINUTE).expect("Duration::minutes out of bounds");
         Duration::seconds(secs)
@@ -104,6 +111,7 @@ impl Duration {
     /// Panics when the duration is more than `i64::MAX` milliseconds
     /// or less than `i64::MIN` milliseconds.
     #[inline]
+    #[unstable(feature = "std_misc")]
     pub fn seconds(seconds: i64) -> Duration {
         let d = Duration { secs: seconds, nanos: 0 };
         if d < MIN || d > MAX {
@@ -114,6 +122,7 @@ impl Duration {
 
     /// Makes a new `Duration` with given number of milliseconds.
     #[inline]
+    #[unstable(feature = "std_misc")]
     pub fn milliseconds(milliseconds: i64) -> Duration {
         let (secs, millis) = div_mod_floor_64(milliseconds, MILLIS_PER_SEC);
         let nanos = millis as i32 * NANOS_PER_MILLI;
@@ -122,6 +131,7 @@ impl Duration {
 
     /// Makes a new `Duration` with given number of microseconds.
     #[inline]
+    #[unstable(feature = "std_misc")]
     pub fn microseconds(microseconds: i64) -> Duration {
         let (secs, micros) = div_mod_floor_64(microseconds, MICROS_PER_SEC);
         let nanos = micros as i32 * NANOS_PER_MICRO;
@@ -130,6 +140,7 @@ impl Duration {
 
     /// Makes a new `Duration` with given number of nanoseconds.
     #[inline]
+    #[unstable(feature = "std_misc")]
     pub fn nanoseconds(nanos: i64) -> Duration {
         let (secs, nanos) = div_mod_floor_64(nanos, NANOS_PER_SEC as i64);
         Duration { secs: secs, nanos: nanos as i32 }
@@ -137,6 +148,7 @@ impl Duration {
 
     /// Runs a closure, returning the duration of time it took to run the
     /// closure.
+    #[unstable(feature = "std_misc")]
     pub fn span<F>(f: F) -> Duration where F: FnOnce() {
         let before = super::precise_time_ns();
         f();
@@ -145,28 +157,33 @@ impl Duration {
 
     /// Returns the total number of whole weeks in the duration.
     #[inline]
+    #[unstable(feature = "std_misc")]
     pub fn num_weeks(&self) -> i64 {
         self.num_days() / 7
     }
 
     /// Returns the total number of whole days in the duration.
+    #[unstable(feature = "std_misc")]
     pub fn num_days(&self) -> i64 {
         self.num_seconds() / SECS_PER_DAY
     }
 
     /// Returns the total number of whole hours in the duration.
     #[inline]
+    #[unstable(feature = "std_misc")]
     pub fn num_hours(&self) -> i64 {
         self.num_seconds() / SECS_PER_HOUR
     }
 
     /// Returns the total number of whole minutes in the duration.
     #[inline]
+    #[unstable(feature = "std_misc")]
     pub fn num_minutes(&self) -> i64 {
         self.num_seconds() / SECS_PER_MINUTE
     }
 
     /// Returns the total number of whole seconds in the duration.
+    #[unstable(feature = "std_misc")]
     pub fn num_seconds(&self) -> i64 {
         // If secs is negative, nanos should be subtracted from the duration.
         if self.secs < 0 && self.nanos > 0 {
@@ -188,6 +205,7 @@ impl Duration {
     }
 
     /// Returns the total number of whole milliseconds in the duration,
+    #[unstable(feature = "std_misc")]
     pub fn num_milliseconds(&self) -> i64 {
         // A proper Duration will not overflow, because MIN and MAX are defined
         // such that the range is exactly i64 milliseconds.
@@ -198,6 +216,7 @@ impl Duration {
 
     /// Returns the total number of whole microseconds in the duration,
     /// or `None` on overflow (exceeding 2^63 microseconds in either direction).
+    #[unstable(feature = "std_misc")]
     pub fn num_microseconds(&self) -> Option<i64> {
         let secs_part = try_opt!(self.num_seconds().checked_mul(MICROS_PER_SEC));
         let nanos_part = self.nanos_mod_sec() / NANOS_PER_MICRO;
@@ -206,6 +225,7 @@ impl Duration {
 
     /// Returns the total number of whole nanoseconds in the duration,
     /// or `None` on overflow (exceeding 2^63 nanoseconds in either direction).
+    #[unstable(feature = "std_misc")]
     pub fn num_nanoseconds(&self) -> Option<i64> {
         let secs_part = try_opt!(self.num_seconds().checked_mul(NANOS_PER_SEC as i64));
         let nanos_part = self.nanos_mod_sec();
@@ -213,6 +233,7 @@ impl Duration {
     }
 
     /// Add two durations, returning `None` if overflow occured.
+    #[unstable(feature = "std_misc")]
     pub fn checked_add(&self, rhs: &Duration) -> Option<Duration> {
         let mut secs = try_opt!(self.secs.checked_add(rhs.secs));
         let mut nanos = self.nanos + rhs.nanos;
@@ -227,6 +248,7 @@ impl Duration {
     }
 
     /// Subtract two durations, returning `None` if overflow occured.
+    #[unstable(feature = "std_misc")]
     pub fn checked_sub(&self, rhs: &Duration) -> Option<Duration> {
         let mut secs = try_opt!(self.secs.checked_sub(rhs.secs));
         let mut nanos = self.nanos - rhs.nanos;
@@ -242,25 +264,30 @@ impl Duration {
 
     /// The minimum possible `Duration`: `i64::MIN` milliseconds.
     #[inline]
+    #[unstable(feature = "std_misc")]
     pub fn min_value() -> Duration { MIN }
 
     /// The maximum possible `Duration`: `i64::MAX` milliseconds.
     #[inline]
+    #[unstable(feature = "std_misc")]
     pub fn max_value() -> Duration { MAX }
 
     /// A duration where the stored seconds and nanoseconds are equal to zero.
     #[inline]
+    #[unstable(feature = "std_misc")]
     pub fn zero() -> Duration {
         Duration { secs: 0, nanos: 0 }
     }
 
     /// Returns `true` if the duration equals `Duration::zero()`.
     #[inline]
+    #[unstable(feature = "std_misc")]
     pub fn is_zero(&self) -> bool {
         self.secs == 0 && self.nanos == 0
     }
 }
 
+#[unstable(feature = "std_misc")]
 impl Neg for Duration {
     type Output = Duration;
 
@@ -274,6 +301,7 @@ impl Neg for Duration {
     }
 }
 
+#[unstable(feature = "std_misc")]
 impl Add for Duration {
     type Output = Duration;
 
@@ -288,6 +316,7 @@ impl Add for Duration {
     }
 }
 
+#[unstable(feature = "std_misc")]
 impl Sub for Duration {
     type Output = Duration;
 
@@ -302,6 +331,7 @@ impl Sub for Duration {
     }
 }
 
+#[unstable(feature = "std_misc")]
 impl Mul<i32> for Duration {
     type Output = Duration;
 
@@ -314,6 +344,7 @@ impl Mul<i32> for Duration {
     }
 }
 
+#[unstable(feature = "std_misc")]
 impl Div<i32> for Duration {
     type Output = Duration;
 

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -10,6 +10,8 @@
 
 //! Temporal quantification.
 
+#![unstable(feature = "std_misc")]
+
 use sys::time::SteadyTime;
 
 pub use self::duration::Duration;


### PR DESCRIPTION
I’d kind of like to be able to use HashState in AnyMap, which I can’t do without a stability attribute on it. While I was at it I looked around and found a few more missing.

Closes https://github.com/rust-lang/rust/issues/21883.
