### PR TITLE
Fix unknown option message for -Z

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -333,8 +333,8 @@ macro_rules! options {
                 break;
             }
             if !found {
-                early_error(&format!("unknown codegen option: `{}`",
-                                    key)[]);
+                early_error(&format!("unknown {} option: `{}`",
+                                    $outputname, key)[]);
             }
         }
         return op;


### PR DESCRIPTION
Before, unknown -Z option would result in a "error: unknown codegen option"
message instead of "error: unknown debugging option".
