### PR TITLE
rustc: Use --extern to always override

### DIFF
--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -330,6 +330,7 @@ impl<'a> CrateReader<'a> {
                 if found {
                     ret = Some(cnum);
                 }
+                return
             }
 
             // Alright, so we've gotten this far which means that `data` has the

--- a/src/test/run-make/extern-overrides-distribution/Makefile
+++ b/src/test/run-make/extern-overrides-distribution/Makefile
@@ -1,0 +1,5 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) libc.rs
+	$(RUSTC) main.rs --extern libc=$(TMPDIR)/liblibc.rlib

--- a/src/test/run-make/extern-overrides-distribution/libc.rs
+++ b/src/test/run-make/extern-overrides-distribution/libc.rs
@@ -1,0 +1,13 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "lib"]
+
+pub fn foo() {}

--- a/src/test/run-make/extern-overrides-distribution/main.rs
+++ b/src/test/run-make/extern-overrides-distribution/main.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate libc;
+
+fn main() {
+    libc::foo();
+}
+


### PR DESCRIPTION
Previously if --extern was specified it would not override crates in the
standard distribution, leading to issues like #21771. This commit alters the
behavior such that if --extern is passed then it will always override any other
choice of crates and no previous match will be used (unless it is the same path
as --extern).

Closes #21771
