### PR TITLE
Update the coherence rules to "covered first"

### DIFF
--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -77,14 +77,12 @@ impl<'cx, 'tcx,'v> visit::Visitor<'v> for OrphanChecker<'cx, 'tcx> {
                     Ok(()) => { }
                     Err(traits::OrphanCheckErr::NoLocalInputType) => {
                         if !ty::has_attr(self.tcx, trait_def_id, "old_orphan_check") {
-                            let self_ty = ty::lookup_item_type(self.tcx, def_id).ty;
                             span_err!(
                                 self.tcx.sess, item.span, E0117,
-                                "the type `{}` does not reference any \
+                                "the impl does not reference any \
                                  types defined in this crate; \
                                  only traits defined in the current crate can be \
-                                 implemented for arbitrary types",
-                                self_ty.user_string(self.tcx));
+                                 implemented for arbitrary types");
                         }
                     }
                     Err(traits::OrphanCheckErr::UncoveredTy(param_ty)) => {

--- a/src/test/compile-fail/coherence-cow-no-cover.rs
+++ b/src/test/compile-fail/coherence-cow-no-cover.rs
@@ -10,11 +10,14 @@
 
 // aux-build:coherence-lib.rs
 
+// Test that it's not ok for U to appear uncovered
+
 extern crate "coherence-lib" as lib;
-use lib::Remote1;
+use lib::{Remote,Pair};
 
-pub struct BigInt;
+pub struct Cover<T>(T);
 
-impl Remote1<BigInt> for isize { } //~ ERROR E0117
+impl<T,U> Remote for Pair<Cover<T>,U> { }
+//~^ ERROR type parameter `U` is not constrained by any local type
 
 fn main() { }

--- a/src/test/compile-fail/coherence-orphan.rs
+++ b/src/test/compile-fail/coherence-orphan.rs
@@ -21,7 +21,7 @@ struct TheType;
 
 impl TheTrait<usize> for isize { } //~ ERROR E0117
 
-impl TheTrait<TheType> for isize { } //~ ERROR E0117
+impl TheTrait<TheType> for isize { }
 
 impl TheTrait<isize> for TheType { }
 

--- a/src/test/compile-fail/coherence-pair-covered-uncovered-1.rs
+++ b/src/test/compile-fail/coherence-pair-covered-uncovered-1.rs
@@ -8,13 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Test that the same coverage rules apply even if the local type appears in the
+// list of type parameters, not the self type.
+
 // aux-build:coherence-lib.rs
 
 extern crate "coherence-lib" as lib;
-use lib::Remote1;
+use lib::{Remote1, Pair};
 
-pub struct BigInt;
+pub struct Local<T>(T);
 
-impl Remote1<BigInt> for Vec<isize> { } //~ ERROR E0117
+impl<T,U> Remote1<Pair<T,Local<U>>> for i32 { }
+//~^ ERROR type parameter `T` is not constrained
 
 fn main() { }

--- a/src/test/run-pass/coherence-bigint-int.rs
+++ b/src/test/run-pass/coherence-bigint-int.rs
@@ -13,7 +13,8 @@
 extern crate "coherence-lib" as lib;
 use lib::Remote1;
 
-impl<T> Remote1<T> for isize { }
-//~^ ERROR E0210
+pub struct BigInt;
+
+impl Remote1<BigInt> for isize { }
 
 fn main() { }

--- a/src/test/run-pass/coherence-bigint-vecint.rs
+++ b/src/test/run-pass/coherence-bigint-vecint.rs
@@ -13,7 +13,8 @@
 extern crate "coherence-lib" as lib;
 use lib::Remote1;
 
-impl<T> Remote1<T> for isize { }
-//~^ ERROR E0210
+pub struct BigInt;
+
+impl Remote1<BigInt> for Vec<isize> { }
 
 fn main() { }

--- a/src/test/run-pass/coherence-cow-1.rs
+++ b/src/test/run-pass/coherence-cow-1.rs
@@ -10,10 +10,14 @@
 
 // aux-build:coherence-lib.rs
 
-extern crate "coherence-lib" as lib;
-use lib::Remote1;
+// Test that it's ok for T to appear first in the self-type, as long
+// as it's covered somewhere.
 
-impl<T> Remote1<T> for isize { }
-//~^ ERROR E0210
+extern crate "coherence-lib" as lib;
+use lib::{Remote,Pair};
+
+pub struct Cover<T>(T);
+
+impl<T> Remote for Pair<T,Cover<T>> { }
 
 fn main() { }

--- a/src/test/run-pass/coherence-cow-2.rs
+++ b/src/test/run-pass/coherence-cow-2.rs
@@ -10,10 +10,14 @@
 
 // aux-build:coherence-lib.rs
 
-extern crate "coherence-lib" as lib;
-use lib::Remote1;
+// Test that it's ok for T to appear second in the self-type, as long
+// as it's covered somewhere.
 
-impl<T> Remote1<T> for isize { }
-//~^ ERROR E0210
+extern crate "coherence-lib" as lib;
+use lib::{Remote,Pair};
+
+pub struct Cover<T>(T);
+
+impl<T> Remote for Pair<Cover<T>,T> { }
 
 fn main() { }


### PR DESCRIPTION
Update the coherence rules to "covered first" -- the first type parameter to contain either a local type or a type parameter must contain only covered type parameters.

cc #19470.
Fixes #20974.
Fixes #20749.

r? @aturon 
