### PR TITLE
rustc: Make unused_features lint warn by default

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -1984,7 +1984,7 @@ declare_lint! {
 
 declare_lint! {
     pub UNUSED_FEATURES,
-    Deny,
+    Warn,
     "unused or unknown features found in crate-level #[feature] directives"
 }
 


### PR DESCRIPTION
When it was un_known__features it was reasonable to be deny by default.

cc #21798

r? @alexcrichton 
