### PR TITLE
updating the link to rustdoc

### DIFF
--- a/src/doc/trpl/comments.md
+++ b/src/doc/trpl/comments.md
@@ -43,5 +43,5 @@ When writing doc comments, adding sections for any arguments, return values,
 and providing some examples of usage is very, very helpful. Don't worry about
 the `&str`, we'll get to it soon.
 
-You can use the [`rustdoc`](../rustdoc.html) tool to generate HTML documentation
+You can use the [`rustdoc`](documentation.html) tool to generate HTML documentation
 from these doc comments.


### PR DESCRIPTION
http://doc.rust-lang.org/rustdoc.html states that its content was moved to http://doc.rust-lang.org/book/documentation.html
