### PR TITLE
remove Copy impls from remaining iterators

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1824,6 +1824,7 @@ impl<I> RandomAccessIterator for Enumerate<I> where I: RandomAccessIterator {
 }
 
 /// An iterator with a `peek()` that returns an optional reference to the next element.
+#[derive(Clone)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Peekable<T, I> where I: Iterator<Item=T> {

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -977,7 +977,7 @@ impl fmt::Debug for RangeFull {
 }
 
 /// A (half-open) range which is bounded at both ends.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 #[lang="range"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Range<Idx> {
@@ -995,7 +995,7 @@ impl<Idx: fmt::Debug> fmt::Debug for Range<Idx> {
 }
 
 /// A range which is only bounded below.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 #[lang="range_from"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RangeFrom<Idx> {


### PR DESCRIPTION
Removes `Copy` from `ops::Range` (`a..b`) and `ops::RangeFrom` (`a..`)

[breaking-change]

---

I forgot about these two in #20790, this PR also adds `Clone` to the `Peekable` adapter which used to be `Copy`able.

r? @nikomatsakis or anyone
