### PR TITLE
Make use of a binary operator's RHS type for LHS inference

### DIFF
--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -102,6 +102,20 @@ pub fn is_by_value_binop(b: BinOp_) -> bool {
     }
 }
 
+/// Returns `true` if the binary operator is symmetric in the sense that LHS
+/// and RHS must have the same type. So the type of LHS can serve as an hint
+/// for the type of RHS and vice versa.
+pub fn is_symmetric_binop(b: BinOp_) -> bool {
+    match b {
+        BiAdd | BiSub | BiMul | BiDiv | BiRem |
+        BiBitXor | BiBitAnd | BiBitOr |
+        BiEq | BiLt | BiLe | BiNe | BiGt | BiGe => {
+            true
+        }
+        _ => false
+    }
+}
+
 /// Returns `true` if the unary operator takes its argument by value
 pub fn is_by_value_unop(u: UnOp) -> bool {
     match u {

--- a/src/test/compile-fail/associated-types-ICE-when-projecting-out-of-err.rs
+++ b/src/test/compile-fail/associated-types-ICE-when-projecting-out-of-err.rs
@@ -29,6 +29,6 @@ trait Add<RHS=Self> {
 
 fn ice<A>(a: A) {
     let r = loop {};
-    r = r + a; // here the type `r` is not yet inferred, hence `r+a` generates an error.
-    //~^ ERROR type of this value must be known
+    r = r + a;
+    //~^ ERROR binary operation `+` cannot be applied to type `A`
 }

--- a/src/test/compile-fail/issue-2149.rs
+++ b/src/test/compile-fail/issue-2149.rs
@@ -16,7 +16,7 @@ impl<A> vec_monad<A> for Vec<A> {
     fn bind<B, F>(&self, mut f: F) where F: FnMut(A) -> Vec<B> {
         let mut r = panic!();
         for elt in self.iter() { r = r + f(*elt); }
-        //~^ ERROR the type of this value must be known
+        //~^ ERROR binary operation `+` cannot be applied to type `collections::vec::Vec<B>`
    }
 }
 fn main() {

--- a/src/test/run-pass/issue-21634.rs
+++ b/src/test/run-pass/issue-21634.rs
@@ -1,0 +1,22 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+fn main() {
+    if let Ok(x) = "3.1415".parse() {
+        assert_eq!(false, x <= 0.0);
+    }
+    if let Ok(x) = "3.1415".parse() {
+        assert_eq!(3.1415, x + 0.0);
+    }
+    if let Ok(mut x) = "3.1415".parse() {
+        assert_eq!(8.1415, { x += 5.0; x });
+    }
+}


### PR DESCRIPTION
For "symmetric" binary operators, meaning the types of two sides must be
equal, if the type of LHS doesn't know yet but RHS does, use that as an
hint to infer LHS' type.

Closes #21634
