### PR TITLE
Fix comment in Use Declarations section of Rust Reference

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1061,7 +1061,7 @@ mod foo {
     extern crate core;
 
     use foo::core::iter; // good: foo is at crate root
-//  use core::iter;      // bad:  native is not at the crate root
+//  use core::iter;      // bad:  core is not at the crate root
     use self::baz::foobaz;  // good: self refers to module 'foo'
     use foo::bar::foobar;   // good: foo is at crate root
 


### PR DESCRIPTION
as titled.  See issue #21770 
