### PR TITLE
Updated documentation to use range notation syntax

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -3005,7 +3005,7 @@ Some examples of call expressions:
 # fn add(x: i32, y: i32) -> i32 { 0 }
 
 let x: i32 = add(1i32, 2i32);
-let pi: Option<f32> = "3.14".parse();
+let pi: Result<f32, _> = "3.14".parse();
 ```
 
 ### Lambda expressions

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -3005,7 +3005,7 @@ Some examples of call expressions:
 # fn add(x: i32, y: i32) -> i32 { 0 }
 
 let x: i32 = add(1i32, 2i32);
-let pi: Option<f32> = "3.14".parse().ok();
+let pi: Option<f32> = "3.14".parse();
 ```
 
 ### Lambda expressions
@@ -3148,7 +3148,7 @@ An example of a for loop over a series of integers:
 
 ```
 # fn bar(b:usize) { }
-for i in range(0us, 256) {
+for i in 0us..256 {
     bar(i);
 }
 ```
@@ -3532,7 +3532,7 @@ An example of each kind:
 ```{rust}
 let vec: Vec<i32> = vec![1, 2, 3];
 let arr: [i32; 3] = [1, 2, 3];
-let s: &[i32] = &vec;
+let s: &[i32] = &vec[];
 ```
 
 As you can see, the `vec!` macro allows you to create a `Vec<T>` easily. The

--- a/src/doc/trpl/concurrency.md
+++ b/src/doc/trpl/concurrency.md
@@ -354,7 +354,7 @@ use std::sync::mpsc;
 fn main() {
     let (tx, rx) = mpsc::channel();
 
-    for _ in range(0, 10) {
+    for _ in 0..10 {
         let tx = tx.clone();
 
         Thread::spawn(move || {

--- a/src/doc/trpl/guessing-game.md
+++ b/src/doc/trpl/guessing-game.md
@@ -400,7 +400,7 @@ a function for that:
 let input = old_io::stdin().read_line()
                        .ok()
                        .expect("Failed to read line");
-let input_num: Option<u32> = input.parse().ok();
+let input_num: Result<u32, _> = input.parse();
 ```
 
 The `parse` function takes in a `&str` value and converts it into something.
@@ -422,8 +422,8 @@ In this case, we say `x` is a `u32` explicitly, so Rust is able to properly
 tell `random()` what to generate. In a similar fashion, both of these work:
 
 ```{rust,ignore}
-let input_num = "5".parse::<u32>().ok(); // input_num: Option<u32>
-let input_num: Option<u32> = "5".parse().ok(); // input_num: Option<u32>
+let input_num = "5".parse::<u32>(); // input_num: Option<u32>
+let input_num: Result<u32, _> = "5".parse(); // input_num: Result<u32, <u32 as FromStr>::Err>
 ```
 
 Here we're converting the `Result` returned by `parse` to an `Option` by using
@@ -447,9 +447,9 @@ fn main() {
     let input = old_io::stdin().read_line()
                            .ok()
                            .expect("Failed to read line");
-    let input_num: Option<u32> = input.parse().ok();
+    let input_num: Result<u32, _> = input.parse();
 
-    println!("You guessed: {}", input_num);
+    println!("You guessed: {:?}", input_num);
 
     match cmp(input_num, secret_number) {
         Ordering::Less => println!("Too small!"),
@@ -497,11 +497,11 @@ fn main() {
     let input = old_io::stdin().read_line()
                            .ok()
                            .expect("Failed to read line");
-    let input_num: Option<u32> = input.parse().ok();
+    let input_num: Result<u32, _> = input.parse();
 
     let num = match input_num {
-        Some(num) => num,
-        None => {
+        Ok(num) => num,
+        Err(_) => {
             println!("Please input a number!");
             return;
         }
@@ -564,11 +564,11 @@ fn main() {
     let input = old_io::stdin().read_line()
                            .ok()
                            .expect("Failed to read line");
-    let input_num: Option<u32> = input.trim().parse().ok();
+    let input_num: Result<u32, _> = input.trim().parse();
 
     let num = match input_num {
-        Some(num) => num,
-        None => {
+        Ok(num) => num,
+        Err(_) => {
             println!("Please input a number!");
             return;
         }
@@ -640,11 +640,11 @@ fn main() {
         let input = old_io::stdin().read_line()
                                .ok()
                                .expect("Failed to read line");
-        let input_num: Option<u32> = input.trim().parse().ok();
+        let input_num: Result<u32, _> = input.trim().parse();
 
         let num = match input_num {
-            Some(num) => num,
-            None => {
+            Ok(num) => num,
+            Err(_) => {
                 println!("Please input a number!");
                 return;
             }
@@ -716,11 +716,11 @@ fn main() {
         let input = old_io::stdin().read_line()
                                .ok()
                                .expect("Failed to read line");
-        let input_num: Option<u32> = input.trim().parse().ok();
+        let input_num: Result<u32, _> = input.trim().parse();
 
         let num = match input_num {
-            Some(num) => num,
-            None => {
+            Ok(num) => num,
+            Err(_) => {
                 println!("Please input a number!");
                 return;
             }
@@ -772,11 +772,11 @@ fn main() {
         let input = old_io::stdin().read_line()
                                .ok()
                                .expect("Failed to read line");
-        let input_num: Option<u32> = input.trim().parse().ok();
+        let input_num: Result<u32, _> = input.trim().parse();
 
         let num = match input_num {
-            Some(num) => num,
-            None => {
+            Ok(num) => num,
+            Err(_) => {
                 println!("Please input a number!");
                 continue;
             }
@@ -849,11 +849,11 @@ fn main() {
         let input = old_io::stdin().read_line()
                                .ok()
                                .expect("Failed to read line");
-        let input_num: Option<u32> = input.trim().parse().ok();
+        let input_num: Result<u32, _> = input.trim().parse();
 
         let num = match input_num {
-            Some(num) => num,
-            None => {
+            Ok(num) => num,
+            Err(_) => {
                 println!("Please input a number!");
                 continue;
             }

--- a/src/doc/trpl/iterators.md
+++ b/src/doc/trpl/iterators.md
@@ -5,7 +5,7 @@ Let's talk about loops.
 Remember Rust's `for` loop? Here's an example:
 
 ```{rust}
-for x in range(0, 10) {
+for x in 0..10 {
     println!("{}", x);
 }
 ```
@@ -17,7 +17,7 @@ call the `.next()` method on repeatedly, and it gives us a sequence of things.
 Like this:
 
 ```{rust}
-let mut range = range(0, 10);
+let mut range = 0..10;
 
 loop {
     match range.next() {
@@ -52,7 +52,7 @@ a vector, you may be tempted to write this:
 ```{rust}
 let nums = vec![1, 2, 3];
 
-for i in range(0, nums.len()) {
+for i in 0..nums.len() {
     println!("{}", nums[i]);
 }
 ```
@@ -118,7 +118,7 @@ The most common consumer is `collect()`. This code doesn't quite compile,
 but it shows the intention:
 
 ```{rust,ignore}
-let one_to_one_hundred = range(1, 101).collect();
+let one_to_one_hundred = (1..101i32).collect();
 ```
 
 As you can see, we call `collect()` on our iterator. `collect()` takes
@@ -128,7 +128,7 @@ type of things you want to collect, and so you need to let it know.
 Here's the version that does compile:
 
 ```{rust}
-let one_to_one_hundred = range(1, 101).collect::<Vec<i32>>();
+let one_to_one_hundred = (1..101i32).collect::<Vec<i32>>();
 ```
 
 If you remember, the `::<>` syntax allows us to give a type hint,
@@ -138,7 +138,7 @@ and so we tell it that we want a vector of integers.
 is one:
 
 ```{rust}
-let greater_than_forty_two = range(0, 100)
+let greater_than_forty_two = (0..100i32)
                              .find(|x| *x > 42);
 
 match greater_than_forty_two {
@@ -155,7 +155,7 @@ element, `find` returns an `Option` rather than the element itself.
 Another important consumer is `fold`. Here's what it looks like:
 
 ```{rust}
-let sum = range(1, 4)
+let sum = (1..4)
               .fold(0, |sum, x| sum + x);
 ```
 
@@ -179,7 +179,7 @@ in this iterator:
 We called `fold()` with these arguments:
 
 ```{rust}
-# range(1, 4)
+# (1..4)
 .fold(0, |sum, x| sum + x);
 ```
 
@@ -210,20 +210,20 @@ This code, for example, does not actually generate the numbers
 `1-100`, and just creates a value that represents the sequence:
 
 ```{rust}
-let nums = range(1, 100);
+let nums = 1..100;
 ```
 
 Since we didn't do anything with the range, it didn't generate the sequence.
 Let's add the consumer:
 
 ```{rust}
-let nums = range(1, 100).collect::<Vec<i32>>();
+let nums = (1..100).collect::<Vec<i32>>();
 ```
 
-Now, `collect()` will require that `range()` give it some numbers, and so
+Now, `collect()` will require that the range gives it some numbers, and so
 it will do the work of generating the sequence.
 
-`range` is one of two basic iterators that you'll see. The other is `iter()`,
+A range is one of two basic iterators that you'll see. The other is `iter()`,
 which you've used before. `iter()` can turn a vector into a simple iterator
 that gives you each element in turn:
 
@@ -256,7 +256,7 @@ we need to talk about with regards to iterators. Let's get to it!
 a new iterator. The simplest one is called `map`:
 
 ```{rust,ignore}
-range(1, 100).map(|x| x + 1);
+(1..100i32).map(|x| x + 1);
 ```
 
 `map` is called upon another iterator, and produces a new iterator where each
@@ -267,7 +267,7 @@ compile the example, you'll get a warning:
 ```{notrust,ignore}
 warning: unused result which must be used: iterator adaptors are lazy and
          do nothing unless consumed, #[warn(unused_must_use)] on by default
- range(1, 100).map(|x| x + 1);
+(1..100).map(|x| x + 1);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
 
@@ -275,7 +275,7 @@ Laziness strikes again! That closure will never execute. This example
 doesn't print any numbers:
 
 ```{rust,ignore}
-range(1, 100).map(|x| println!("{}", x));
+(1..100).map(|x| println!("{}", x));
 ```
 
 If you are trying to execute a closure on an iterator for its side effects,
@@ -307,7 +307,7 @@ returns `true` or `false`. The new iterator `filter()` produces
 only the elements that that closure returns `true` for:
 
 ```{rust}
-for i in range(1, 100).filter(|&x| x % 2 == 0) {
+for i in (1..100i32).filter(|&x| x % 2 == 0) {
     println!("{}", i);
 }
 ```
@@ -322,7 +322,7 @@ You can chain all three things together: start with an iterator, adapt it
 a few times, and then consume the result. Check it out:
 
 ```{rust}
-range(1, 1000)
+(1..1000i32)
     .filter(|&x| x % 2 == 0)
     .filter(|&x| x % 3 == 0)
     .take(5)

--- a/src/doc/trpl/ownership.md
+++ b/src/doc/trpl/ownership.md
@@ -418,7 +418,7 @@ struct Wheel {
 fn main() {
     let car = Car { name: "DeLorean".to_string() };
 
-    for _ in range(0, 4) {
+    for _ in 0..4 {
         Wheel { size: 360, owner: car };
     }
 }
@@ -456,7 +456,7 @@ fn main() {
 
     let car_owner = Rc::new(car);
 
-    for _ in range(0, 4) {
+    for _ in 0..4 {
         Wheel { size: 360, owner: car_owner.clone() };
     }
 }

--- a/src/doc/trpl/testing.md
+++ b/src/doc/trpl/testing.md
@@ -512,7 +512,7 @@ use test::Bencher;
 #[bench]
 fn bench_xor_1000_ints(b: &mut Bencher) {
     b.iter(|| {
-        range(0, 1000).fold(0, |old, new| old ^ new);
+        (0..1000).fold(0, |old, new| old ^ new);
     });
 }
 ```
@@ -537,7 +537,7 @@ computation entirely. This could be done for the example above by adjusting the
 # impl X { fn iter<T, F>(&self, _: F) where F: FnMut() -> T {} } let b = X;
 b.iter(|| {
     // note lack of `;` (could also use an explicit `return`).
-    range(0, 1000).fold(0, |old, new| old ^ new)
+    (0..1000).fold(0, |old, new| old ^ new)
 });
 ```
 
@@ -554,7 +554,7 @@ extern crate test;
 b.iter(|| {
     let n = test::black_box(1000);
 
-    range(0, n).fold(0, |a, b| a ^ b)
+    (0..n).fold(0, |a, b| a ^ b)
 })
 # }
 ```


### PR DESCRIPTION
Replaced outdated use of the `range(start, end)` function where appropriate with `start..end`, and tweaked the examples to compile and run with the latest rust. I also fixed two periphery compile issues in reference.md which were occluding whether there were any new errors created by these changes.
