### PR TITLE
Reject syntax like `use foo::bar::;` and `use foo:: as bar;`

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5912,9 +5912,9 @@ impl<'a> Parser<'a> {
                 self.bump();
 
                 match self.token {
-                  token::Ident(i, _) => {
-                    self.bump();
-                    path.push(i);
+                  token::Ident(..) => {
+                    let ident = self.parse_ident();
+                    path.push(ident);
                   }
 
                   // foo::bar::{a,b,c}
@@ -5952,6 +5952,11 @@ impl<'a> Parser<'a> {
                         }).collect()
                     };
                     return P(spanned(lo, self.span.hi, ViewPathGlob(path)));
+                  }
+
+                  // fall-through for case foo::bar::;
+                  token::Semi => {
+                    self.span_err(self.span, "expected identifier or `{` or `*`, found `;`");
                   }
 
                   _ => break

--- a/src/test/compile-fail/use-as-where-use-ends-with-mod-sep.rs
+++ b/src/test/compile-fail/use-as-where-use-ends-with-mod-sep.rs
@@ -1,0 +1,11 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::any:: as foo; //~ ERROR expected identifier or `{` or `*`, found `as`

--- a/src/test/compile-fail/use-ends-with-mod-sep.rs
+++ b/src/test/compile-fail/use-ends-with-mod-sep.rs
@@ -1,0 +1,11 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::any::; //~ ERROR expected identifier or `{` or `*`, found `;`


### PR DESCRIPTION
syntax like `use foo::bar::;` and `use foo:: as bar;` should be rejected, see issue #21629
