### PR TITLE
Revert "remove Copy impls from remaining iterators"

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -977,7 +977,7 @@ impl fmt::Debug for RangeFull {
 }
 
 /// A (half-open) range which is bounded at both ends.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[lang="range"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Range<Idx> {
@@ -995,7 +995,7 @@ impl<Idx: fmt::Debug> fmt::Debug for Range<Idx> {
 }
 
 /// A range which is only bounded below.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[lang="range_from"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RangeFrom<Idx> {


### PR DESCRIPTION
This reverts commit c3841b9c9f35f4e7fed9894558cbe1f068a3e01a.

The commit made it impossible to copy the pretty fundamental data type `Range` and `RangeFrom`, which e.g. means that they can't be used in otherwise copyable structures anymore (or `Cell`s for that matter), where the reason for removal was that it can _also be used as an iterator_.

CC @japaric
#21809
