### PR TITLE
rustc: Change an unconditional `warn` to a `note`

### DIFF
--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -740,7 +740,7 @@ fn link_staticlib(sess: &Session, obj_filename: &Path, out_filename: &Path) {
     let _ = ab.build();
 
     if !all_native_libs.is_empty() {
-        sess.warn("link against the following native artifacts when linking against \
+        sess.note("link against the following native artifacts when linking against \
                   this static library");
         sess.note("the order and any duplication can be significant on some platforms, \
                   and so may need to be preserved");


### PR DESCRIPTION
There [have been reports](https://github.com/rust-lang/cargo/issues/1260) of an unconditional warning causing tooling to
go awry. This isn't actually a warning per se, it's more of a note anyway!

Closes rust-lang/cargo#1260
