### PR TITLE
std: Mark the `IntoIterator` trait as stable

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -298,6 +298,7 @@ pub trait Show {
 #[lang = "debug_trait"]
 pub trait Debug {
     /// Formats the value using the given formatter.
+    #[stable(feature = "rust1", since = "1.0.0")]
     fn fmt(&self, &mut Formatter) -> Result;
 }
 
@@ -324,6 +325,7 @@ pub trait String {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Display {
     /// Formats the value using the given formatter.
+    #[stable(feature = "rust1", since = "1.0.0")]
     fn fmt(&self, &mut Formatter) -> Result;
 }
 

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -119,6 +119,7 @@ impl<'a, T> Iterator for &'a mut (Iterator<Item=T> + 'a) {
                           built from an iterator over elements of type `{A}`"]
 pub trait FromIterator<A> {
     /// Build a container with elements from an external iterator.
+    #[stable(feature = "rust1", since = "1.0.0")]
     fn from_iter<T: Iterator<Item=A>>(iterator: T) -> Self;
 }
 
@@ -1866,6 +1867,7 @@ impl<T, I> Peekable<T, I> where I: Iterator<Item=T> {
     /// Return a reference to the next element of the iterator with out advancing it,
     /// or None if the iterator is exhausted.
     #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn peek(&mut self) -> Option<&T> {
         if self.peeked.is_none() {
             self.peeked = self.iter.next();

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -124,10 +124,13 @@ pub trait FromIterator<A> {
 }
 
 /// Conversion into an `Iterator`
+#[stable(feature = "rust1", since = "1.0.0")]
 pub trait IntoIterator {
+    #[stable(feature = "rust1", since = "1.0.0")]
     type Iter: Iterator;
 
     /// Consumes `Self` and returns an iterator over it
+    #[stable(feature = "rust1", since = "1.0.0")]
     fn into_iter(self) -> Self::Iter;
 }
 


### PR DESCRIPTION
This commit marks the trait `IntoIterator` as well as the associated type `Iter`
and method `into_iter` all as stable.

This also fixes up some missing stability on some other assorted traits.
