### PR TITLE
lint: Deny #[no_mangle] const items

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -2066,6 +2066,12 @@ declare_lint! {
 }
 
 declare_lint! {
+    PRIVATE_NO_MANGLE_STATICS,
+    Warn,
+    "statics marked #[no_mangle] should be exported"
+}
+
+declare_lint! {
     NO_MANGLE_CONST_ITEMS,
     Deny,
     "const items will not have their symbols exported"
@@ -2077,6 +2083,7 @@ pub struct InvalidNoMangleItems;
 impl LintPass for InvalidNoMangleItems {
     fn get_lints(&self) -> LintArray {
         lint_array!(PRIVATE_NO_MANGLE_FNS,
+                    PRIVATE_NO_MANGLE_STATICS,
                     NO_MANGLE_CONST_ITEMS)
     }
 
@@ -2088,6 +2095,14 @@ impl LintPass for InvalidNoMangleItems {
                     let msg = format!("function {} is marked #[no_mangle], but not exported",
                                       it.ident);
                     cx.span_lint(PRIVATE_NO_MANGLE_FNS, it.span, msg.as_slice());
+                }
+            },
+            ast::ItemStatic(..) => {
+                if attr::contains_name(it.attrs.as_slice(), "no_mangle") &&
+                       !cx.exported_items.contains(&it.id) {
+                    let msg = format!("static {} is marked #[no_mangle], but not exported",
+                                      it.ident);
+                    cx.span_lint(PRIVATE_NO_MANGLE_STATICS, it.span, msg.as_slice());
                 }
             },
             ast::ItemConst(..) => {

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -2107,7 +2107,10 @@ impl LintPass for InvalidNoMangleItems {
             },
             ast::ItemConst(..) => {
                 if attr::contains_name(it.attrs.as_slice(), "no_mangle") {
-                    let msg = "const items should never be #[no_mangle]";
+                    // Const items do not refer to a particular location in memory, and therefore
+                    // don't have anything to attach a symbol to
+                    let msg = "const items should never be #[no_mangle], consider instead using \
+                        `pub static`";
                     cx.span_lint(NO_MANGLE_CONST_ITEMS, it.span, msg);
                 }
             }

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -213,7 +213,7 @@ impl LintStore {
                      UnstableFeatures,
                      Stability,
                      UnconditionalRecursion,
-                     PrivateNoMangleFns,
+                     InvalidNoMangleItems,
         );
 
         add_builtin_with_new!(sess,

--- a/src/test/compile-fail/lint-unexported-no-mangle.rs
+++ b/src/test/compile-fail/lint-unexported-no-mangle.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags:-F private_no_mangle_fns -F no_mangle_const_items
+// compile-flags:-F private_no_mangle_fns -F no_mangle_const_items -F private_no_mangle_statics
 
 // FIXME(#19495) no_mangle'ing main ICE's.
 #[no_mangle]
@@ -25,6 +25,14 @@ pub const PUB_FOO: u64 = 1; //~ ERROR const items should never be #[no_mangle]
 #[no_mangle]
 pub fn bar()  {
 }
+
+#[no_mangle]
+pub static BAR: u64 = 1;
+
+#[allow(dead_code)]
+#[no_mangle]
+static PRIVATE_BAR: u64 = 1; //~ ERROR static PRIVATE_BAR is marked #[no_mangle], but not exported
+
 
 fn main() {
     foo();

--- a/src/test/compile-fail/lint-unexported-no-mangle.rs
+++ b/src/test/compile-fail/lint-unexported-no-mangle.rs
@@ -8,12 +8,19 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags:-F private_no_mangle_fns
+// compile-flags:-F private_no_mangle_fns -F no_mangle_const_items
 
 // FIXME(#19495) no_mangle'ing main ICE's.
 #[no_mangle]
 fn foo() { //~ ERROR function foo is marked #[no_mangle], but not exported
 }
+
+#[allow(dead_code)]
+#[no_mangle]
+const FOO: u64 = 1; //~ ERROR const items should never be #[no_mangle]
+
+#[no_mangle]
+pub const PUB_FOO: u64 = 1; //~ ERROR const items should never be #[no_mangle]
 
 #[no_mangle]
 pub fn bar()  {


### PR DESCRIPTION
This renames the PrivateNoMangleFns lint to allow both to happen in a
single pass, since they do roughly the same work.

Closes #21856

Open questions:

[ ]: Do the tests actually pass (I'm running make check and running out the door now)
[ ]: Is the name of this lint ok. it seems to mostly be fine with [convention](https://github.com/rust-lang/rfcs/blob/cc53afbe5dea41e1f7d1c3dce71e013abe025211/text/0344-conventions-galore.md#lints)
[ ]: I'm not super thrilled about the warning text

r? @kmcallister (Shamelessly nominating because you were looking at my other ticket)
