### PR TITLE
Improved assert_approx_eq!() + doc

### DIFF
--- a/src/libstd/num/float_macros.rs
+++ b/src/libstd/num/float_macros.rs
@@ -9,13 +9,30 @@
 // except according to those terms.
 
 #![unstable(feature = "std_misc")]
-#![doc(hidden)]
 
+/// (Almost) assert_eq!() for floats.
+/// Succeeds if `abs(a - b) < 10^-6` or if `abs(a/b - 1) < 10^-6`.
+///
+/// # Example
+///
+/// ```
+/// assert_approx_eq!(5.0, 5.0);
+/// assert_approx_eq!(1000000.0, 1000000.9);
+/// assert_approx_eq!(0.0, 0.0000009);
+/// ```
+///
+/// ```should_fail
+/// assert_approx_eq!(1.0, 2.0);
+/// assert_approx_eq!(1000000.0, 1000001.0);
+/// assert_approx_eq!(0.0, 0.000001);
+/// ```
+#[macro_export]
 macro_rules! assert_approx_eq {
     ($a:expr, $b:expr) => ({
-        use num::Float;
+        use ::std::num::Float;
         let (a, b) = (&$a, &$b);
-        assert!((*a - *b).abs() < 1.0e-6,
-                "{} is not approximately equal to {}", *a, *b);
+        let abs_okay = (*a - *b).abs() < 1.0e-6;
+        let rel_okay = (*a / *b - 1.0).abs()  < 1.0e-6;
+        assert!(abs_okay || rel_okay, "{} is not approximately equal to {}", *a, *b);
     })
 }


### PR DESCRIPTION
This pull request is to:
-   adjust assert_approx_eq!() to a form which has worked well for me in other unit tests
-   add documentation and export the macro

Question: does the intention need further discussion (elsewhere)?

Question: what other changes are needed? E.g. also adjust `libcore/num/float_macros.rs`, moving to `libstd/macros.rs`?

Possible extension: a `assert_approx_tol!()` version taking two tolerance arguments (to replace uses of `1e-6`).
