### PR TITLE
Fix memory unsafety in `Reader::push` by simply removing it

### DIFF
--- a/src/libstd/old_io/mod.rs
+++ b/src/libstd/old_io/mod.rs
@@ -547,26 +547,6 @@ pub trait Reader {
         Ok(buf[0])
     }
 
-    /// Reads up to `len` bytes and appends them to a vector.
-    /// Returns the number of bytes read. The number of bytes read may be
-    /// less than the number requested, even 0. Returns Err on EOF.
-    ///
-    /// # Error
-    ///
-    /// If an error occurs during this I/O operation, then it is returned
-    /// as `Err(IoError)`. See `read()` for more details.
-    fn push(&mut self, len: uint, buf: &mut Vec<u8>) -> IoResult<uint> {
-        let start_len = buf.len();
-        buf.reserve(len);
-
-        let n = {
-            let s = unsafe { slice_vec_capacity(buf, start_len, start_len + len) };
-            try!(self.read(s))
-        };
-        unsafe { buf.set_len(start_len + n) };
-        Ok(n)
-    }
-
     /// Reads at least `min` bytes, but no more than `len`, and appends them to
     /// a vector.
     /// Returns the number of bytes read.


### PR DESCRIPTION
The memory unsafety was caused by the fact that it passed an uninitialized
buffer to a different function (`Reader::read`) which might not give the
(unsafe) guarantee that it doesn't touch the uninitalized bytes.

If one removes this unsafety, the function is no better than creating an
initialized vector and passing it to the `Reader::read` function, so it was
removed completely.

Fixes #21896.
