### PR TITLE
std: Remove `iter::ByRef` and generalize impls

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -45,22 +45,18 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use core::prelude::*;
+
 use core::any::Any;
-use core::clone::Clone;
-use core::cmp::{PartialEq, PartialOrd, Eq, Ord, Ordering};
+use core::cmp::Ordering;
 use core::default::Default;
 use core::error::{Error, FromError};
 use core::fmt;
 use core::hash::{self, Hash};
-use core::iter::Iterator;
-use core::marker::Sized;
 use core::mem;
 use core::ops::{Deref, DerefMut};
-use core::option::Option;
 use core::ptr::Unique;
 use core::raw::TraitObject;
-use core::result::Result::{Ok, Err};
-use core::result::Result;
 
 /// A value that represents the heap. This is the default place that the `box` keyword allocates
 /// into when no place is supplied.
@@ -296,18 +292,20 @@ impl<T: ?Sized> DerefMut for Box<T> {
     fn deref_mut(&mut self) -> &mut T { &mut **self }
 }
 
-impl<'a, T> Iterator for Box<Iterator<Item=T> + 'a> {
-    type Item = T;
-
-    fn next(&mut self) -> Option<T> {
-        (**self).next()
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (**self).size_hint()
-    }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<I: Iterator + ?Sized> Iterator for Box<I> {
+    type Item = I::Item;
+    fn next(&mut self) -> Option<I::Item> { (**self).next() }
+    fn size_hint(&self) -> (usize, Option<usize>) { (**self).size_hint() }
 }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for Box<I> {
+    fn next_back(&mut self) -> Option<I::Item> { (**self).next_back() }
+}
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<I: ExactSizeIterator + ?Sized> ExactSizeIterator for Box<I> {}
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, E: Error + 'a> FromError<E> for Box<Error + 'a> {
     fn from_error(err: E) -> Box<Error + 'a> {
         Box::new(err)

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -101,16 +101,11 @@ pub trait Iterator {
     fn size_hint(&self) -> (usize, Option<usize>) { (0, None) }
 }
 
-impl<'a, T> Iterator for &'a mut (Iterator<Item=T> + 'a) {
-    type Item = T;
-
-    fn next(&mut self) -> Option<T> {
-        (**self).next()
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (**self).size_hint()
-    }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a, I: Iterator + ?Sized> Iterator for &'a mut I {
+    type Item = I::Item;
+    fn next(&mut self) -> Option<I::Item> { (**self).next() }
+    fn size_hint(&self) -> (usize, Option<usize>) { (**self).size_hint() }
 }
 
 /// Conversion from an `Iterator`
@@ -548,9 +543,7 @@ pub trait IteratorExt: Iterator + Sized {
     /// assert!(it.next() == Some(5));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn by_ref<'r>(&'r mut self) -> ByRef<'r, Self> {
-        ByRef{iter: self}
-    }
+    fn by_ref(&mut self) -> &mut Self { self }
 
     /// Loops through the entire iterator, collecting all of the elements into
     /// a container implementing `FromIterator`.
@@ -1017,13 +1010,20 @@ impl<I> IteratorExt for I where I: Iterator {}
 
 /// A range iterator able to yield elements from both ends
 ///
-/// A `DoubleEndedIterator` can be thought of as a deque in that `next()` and `next_back()` exhaust
-/// elements from the *same* range, and do not work independently of each other.
+/// A `DoubleEndedIterator` can be thought of as a deque in that `next()` and
+/// `next_back()` exhaust elements from the *same* range, and do not work
+/// independently of each other.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait DoubleEndedIterator: Iterator {
-    /// Yield an element from the end of the range, returning `None` if the range is empty.
+    /// Yield an element from the end of the range, returning `None` if the
+    /// range is empty.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn next_back(&mut self) -> Option<Self::Item>;
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a, I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for &'a mut I {
+    fn next_back(&mut self) -> Option<I::Item> { (**self).next_back() }
 }
 
 /// An object implementing random access indexing by `usize`
@@ -1064,6 +1064,9 @@ pub trait ExactSizeIterator: Iterator {
         lower
     }
 }
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a, I: ExactSizeIterator + ?Sized> ExactSizeIterator for &'a mut I {}
 
 // All adaptors that preserve the size of the wrapped iterator are fine
 // Adaptors that may overflow in `size_hint` are not, i.e. `Chain`.
@@ -1116,32 +1119,6 @@ impl<I> RandomAccessIterator for Rev<I> where I: DoubleEndedIterator + RandomAcc
         self.iter.idx(amt - index - 1)
     }
 }
-
-/// A mutable reference to an iterator
-#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[stable(feature = "rust1", since = "1.0.0")]
-pub struct ByRef<'a, I:'a> {
-    iter: &'a mut I,
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, I> Iterator for ByRef<'a, I> where I: 'a + Iterator {
-    type Item = <I as Iterator>::Item;
-
-    #[inline]
-    fn next(&mut self) -> Option<<I as Iterator>::Item> { self.iter.next() }
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, I> DoubleEndedIterator for ByRef<'a, I> where I: 'a + DoubleEndedIterator {
-    #[inline]
-    fn next_back(&mut self) -> Option<<I as Iterator>::Item> { self.iter.next_back() }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, I> ExactSizeIterator for ByRef<'a, I> where I: 'a + ExactSizeIterator {}
 
 /// A trait for iterators over elements which can be added together
 #[unstable(feature = "core",


### PR DESCRIPTION
This removes the `ByRef` iterator adaptor to stay in line with the changes to
`std::io`. The `by_ref` method instead just returns `&mut Self`.

This also removes the implementation of `Iterator for &mut Iterator` and instead
generalizes it to `Iterator for &mut I` where `I: Iterator + ?Sized`. The
`Box<I>` implementations were also updated.
