### PR TITLE
cleanup: replace `as[_mut]_slice()` calls with deref coercions/slicing syntax

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -97,22 +97,22 @@ pub fn parse_config(args: Vec<String> ) -> Config {
     assert!(!args.is_empty());
     let argv0 = args[0].clone();
     let args_ = args.tail();
-    if args[1].as_slice() == "-h" || args[1].as_slice() == "--help" {
+    if args[1] == "-h" || args[1] == "--help" {
         let message = format!("Usage: {} [OPTIONS] [TESTNAME...]", argv0);
-        println!("{}", getopts::usage(message.as_slice(), groups.as_slice()));
+        println!("{}", getopts::usage(&message, &groups));
         println!("");
         panic!()
     }
 
     let matches =
-        &match getopts::getopts(args_.as_slice(), groups.as_slice()) {
+        &match getopts::getopts(args_, &groups) {
           Ok(m) => m,
           Err(f) => panic!("{:?}", f)
         };
 
     if matches.opt_present("h") || matches.opt_present("help") {
         let message = format!("Usage: {} [OPTIONS]  [TESTNAME...]", argv0);
-        println!("{}", getopts::usage(message.as_slice(), groups.as_slice()));
+        println!("{}", getopts::usage(&message, &groups));
         println!("");
         panic!()
     }
@@ -156,9 +156,9 @@ pub fn parse_config(args: Vec<String> ) -> Config {
         adb_test_dir: opt_str2(matches.opt_str("adb-test-dir")),
         adb_device_status:
             "arm-linux-androideabi" ==
-                opt_str2(matches.opt_str("target")).as_slice() &&
+                opt_str2(matches.opt_str("target")) &&
             "(none)" !=
-                opt_str2(matches.opt_str("adb-test-dir")).as_slice() &&
+                opt_str2(matches.opt_str("adb-test-dir")) &&
             !opt_str2(matches.opt_str("adb-test-dir")).is_empty(),
         lldb_python_dir: matches.opt_str("lldb-python-dir"),
         verbose: matches.opt_present("verbose"),
@@ -201,7 +201,7 @@ pub fn log_config(config: &Config) {
 pub fn opt_str<'a>(maybestr: &'a Option<String>) -> &'a str {
     match *maybestr {
         None => "(none)",
-        Some(ref s) => s.as_slice(),
+        Some(ref s) => s,
     }
 }
 
@@ -213,7 +213,7 @@ pub fn opt_str2(maybestr: Option<String>) -> String {
 }
 
 pub fn run_tests(config: &Config) {
-    if config.target.as_slice() == "arm-linux-androideabi" {
+    if config.target == "arm-linux-androideabi" {
         match config.mode {
             DebugInfoGdb => {
                 println!("arm-linux-androideabi debug-info \
@@ -306,13 +306,13 @@ pub fn is_test(config: &Config, testfile: &Path) -> bool {
     let mut valid = false;
 
     for ext in &valid_extensions {
-        if name.ends_with(ext.as_slice()) {
+        if name.ends_with(ext) {
             valid = true;
         }
     }
 
     for pre in &invalid_prefixes {
-        if name.starts_with(pre.as_slice()) {
+        if name.starts_with(pre) {
             valid = false;
         }
     }

--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -44,7 +44,7 @@ pub fn load_errors(testfile: &Path) -> Vec<ExpectedError> {
     rdr.lines().enumerate().filter_map(|(line_no, ln)| {
         parse_expected(last_nonfollow_error,
                        line_no + 1,
-                       ln.unwrap().as_slice())
+                       &ln.unwrap())
             .map(|(which, error)| {
                 match which {
                     FollowPrevious(_) => {}

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -145,7 +145,7 @@ pub fn load_props(testfile: &Path) -> TestProps {
 
 pub fn is_test_ignored(config: &Config, testfile: &Path) -> bool {
     fn ignore_target(config: &Config) -> String {
-        format!("ignore-{}", util::get_os(config.target.as_slice()))
+        format!("ignore-{}", util::get_os(&config.target))
     }
     fn ignore_stage(config: &Config) -> String {
         format!("ignore-{}",
@@ -169,8 +169,8 @@ pub fn is_test_ignored(config: &Config, testfile: &Path) -> bool {
                                           .expect("Malformed GDB version directive");
                     // Ignore if actual version is smaller the minimum required
                     // version
-                    gdb_version_to_int(actual_version.as_slice()) <
-                        gdb_version_to_int(min_version.as_slice())
+                    gdb_version_to_int(actual_version) <
+                        gdb_version_to_int(min_version)
                 } else {
                     false
                 }
@@ -197,8 +197,8 @@ pub fn is_test_ignored(config: &Config, testfile: &Path) -> bool {
                                           .expect("Malformed lldb version directive");
                     // Ignore if actual version is smaller the minimum required
                     // version
-                    lldb_version_to_int(actual_version.as_slice()) <
-                        lldb_version_to_int(min_version.as_slice())
+                    lldb_version_to_int(actual_version) <
+                        lldb_version_to_int(min_version)
                 } else {
                     false
                 }
@@ -209,8 +209,8 @@ pub fn is_test_ignored(config: &Config, testfile: &Path) -> bool {
 
     let val = iter_header(testfile, |ln| {
         !parse_name_directive(ln, "ignore-test") &&
-        !parse_name_directive(ln, ignore_target(config).as_slice()) &&
-        !parse_name_directive(ln, ignore_stage(config).as_slice()) &&
+        !parse_name_directive(ln, &ignore_target(config)) &&
+        !parse_name_directive(ln, &ignore_stage(config)) &&
         !(config.mode == common::Pretty && parse_name_directive(ln, "ignore-pretty")) &&
         !(config.target != config.host && parse_name_directive(ln, "ignore-cross-compile")) &&
         !ignore_gdb(config, ln) &&
@@ -294,7 +294,7 @@ fn parse_pretty_compare_only(line: &str) -> bool {
 fn parse_exec_env(line: &str) -> Option<(String, String)> {
     parse_name_value_directive(line, "exec-env").map(|nv| {
         // nv is either FOO or FOO=BAR
-        let mut strs: Vec<String> = nv.as_slice()
+        let mut strs: Vec<String> = nv
                                       .splitn(1, '=')
                                       .map(|s| s.to_string())
                                       .collect();
@@ -330,7 +330,7 @@ fn parse_name_directive(line: &str, directive: &str) -> bool {
 pub fn parse_name_value_directive(line: &str, directive: &str)
                                   -> Option<String> {
     let keycolon = format!("{}:", directive);
-    match line.find_str(keycolon.as_slice()) {
+    match line.find_str(&keycolon) {
         Some(colon) => {
             let value = line[(colon + keycolon.len()) .. line.len()].to_string();
             debug!("{}: {}", directive, value);
@@ -344,7 +344,7 @@ pub fn gdb_version_to_int(version_string: &str) -> int {
     let error_string = format!(
         "Encountered GDB version string with unexpected format: {}",
         version_string);
-    let error_string = error_string.as_slice();
+    let error_string = error_string;
 
     let components: Vec<&str> = version_string.trim().split('.').collect();
 
@@ -352,8 +352,8 @@ pub fn gdb_version_to_int(version_string: &str) -> int {
         panic!("{}", error_string);
     }
 
-    let major: int = components[0].parse().ok().expect(error_string);
-    let minor: int = components[1].parse().ok().expect(error_string);
+    let major: int = components[0].parse().ok().expect(&error_string);
+    let minor: int = components[1].parse().ok().expect(&error_string);
 
     return major * 1000 + minor;
 }
@@ -362,7 +362,7 @@ pub fn lldb_version_to_int(version_string: &str) -> int {
     let error_string = format!(
         "Encountered LLDB version string with unexpected format: {}",
         version_string);
-    let error_string = error_string.as_slice();
-    let major: int = version_string.parse().ok().expect(error_string);
+    let error_string = error_string;
+    let major: int = version_string.parse().ok().expect(&error_string);
     return major;
 }

--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -23,7 +23,7 @@ fn add_target_env(cmd: &mut Command, lib_path: &str, aux_path: Option<&str>) {
 
     // Add the new dylib search path var
     let var = DynamicLibrary::envvar();
-    let newpath = DynamicLibrary::create_path(path.as_slice());
+    let newpath = DynamicLibrary::create_path(&path);
     let newpath = String::from_utf8(newpath).unwrap();
     cmd.env(var.to_string(), newpath);
 }

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -40,7 +40,7 @@ use std::time::Duration;
 use test::MetricMap;
 
 pub fn run(config: Config, testfile: String) {
-    match config.target.as_slice() {
+    match &*config.target {
 
         "arm-linux-androideabi" => {
             if !config.adb_device_status {
@@ -106,10 +106,10 @@ fn run_cfail_test(config: &Config, props: &TestProps, testfile: &Path) {
         }
         check_expected_errors(expected_errors, testfile, &proc_res);
     } else {
-        check_error_patterns(props, testfile, output_to_check.as_slice(), &proc_res);
+        check_error_patterns(props, testfile, &output_to_check, &proc_res);
     }
     check_no_compiler_crash(&proc_res);
-    check_forbid_output(props, output_to_check.as_slice(), &proc_res);
+    check_forbid_output(props, &output_to_check, &proc_res);
 }
 
 fn run_rfail_test(config: &Config, props: &TestProps, testfile: &Path) {
@@ -133,7 +133,7 @@ fn run_rfail_test(config: &Config, props: &TestProps, testfile: &Path) {
 
     let output_to_check = get_output(props, &proc_res);
     check_correct_failure_status(&proc_res);
-    check_error_patterns(props, testfile, output_to_check.as_slice(), &proc_res);
+    check_error_patterns(props, testfile, &output_to_check, &proc_res);
 }
 
 fn check_correct_failure_status(proc_res: &ProcRes) {
@@ -141,8 +141,8 @@ fn check_correct_failure_status(proc_res: &ProcRes) {
     static RUST_ERR: int = 101;
     if !proc_res.status.matches_exit_status(RUST_ERR) {
         fatal_proc_rec(
-            format!("failure produced the wrong error: {:?}",
-                    proc_res.status).as_slice(),
+            &format!("failure produced the wrong error: {:?}",
+                     proc_res.status),
             proc_res);
     }
 }
@@ -211,11 +211,10 @@ fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
                                     props,
                                     testfile,
                                     srcs[round].to_string(),
-                                    props.pretty_mode.as_slice());
+                                    &props.pretty_mode);
 
         if !proc_res.status.success() {
-            fatal_proc_rec(format!("pretty-printing failed in round {}",
-                                   round).as_slice(),
+            fatal_proc_rec(&format!("pretty-printing failed in round {}", round),
                           &proc_res);
         }
 
@@ -237,11 +236,11 @@ fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
     if props.pp_exact.is_some() {
         // Now we have to care about line endings
         let cr = "\r".to_string();
-        actual = actual.replace(cr.as_slice(), "").to_string();
-        expected = expected.replace(cr.as_slice(), "").to_string();
+        actual = actual.replace(&cr, "").to_string();
+        expected = expected.replace(&cr, "").to_string();
     }
 
-    compare_source(expected.as_slice(), actual.as_slice());
+    compare_source(&expected, &actual);
 
     // If we're only making sure that the output matches then just stop here
     if props.pretty_compare_only { return; }
@@ -282,7 +281,7 @@ fn run_pretty_test(config: &Config, props: &TestProps, testfile: &Path) {
                                      testfile,
                                      pretty_type.to_string()),
                         props.exec_env.clone(),
-                        config.compile_lib_path.as_slice(),
+                        &config.compile_lib_path,
                         Some(aux_dir.as_str().unwrap()),
                         Some(src))
     }
@@ -335,9 +334,9 @@ actual:\n\
     fn make_typecheck_args(config: &Config, props: &TestProps, testfile: &Path) -> ProcArgs {
         let aux_dir = aux_output_dir_name(config, testfile);
         let target = if props.force_host {
-            config.host.as_slice()
+            &*config.host
         } else {
-            config.target.as_slice()
+            &*config.target
         };
         // FIXME (#9639): This needs to handle non-utf8 paths
         let mut args = vec!("-".to_string(),
@@ -382,7 +381,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
     let exe_file = make_exe_name(config, testfile);
 
     let debugger_run_result;
-    match config.target.as_slice() {
+    match &*config.target {
         "arm-linux-androideabi" => {
 
             cmds = cmds.replace("run", "continue").to_string();
@@ -397,12 +396,12 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
             debug!("script_str = {}", script_str);
             dump_output_file(config,
                              testfile,
-                             script_str.as_slice(),
+                             &script_str,
                              "debugger.script");
 
 
             procsrv::run("",
-                         config.adb_path.as_slice(),
+                         &config.adb_path,
                          None,
                          &[
                             "push".to_string(),
@@ -411,10 +410,10 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                          ],
                          vec!(("".to_string(), "".to_string())),
                          Some("".to_string()))
-                .expect(format!("failed to exec `{:?}`", config.adb_path).as_slice());
+                .expect(&format!("failed to exec `{:?}`", config.adb_path));
 
             procsrv::run("",
-                         config.adb_path.as_slice(),
+                         &config.adb_path,
                          None,
                          &[
                             "forward".to_string(),
@@ -423,7 +422,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                          ],
                          vec!(("".to_string(), "".to_string())),
                          Some("".to_string()))
-                .expect(format!("failed to exec `{:?}`", config.adb_path).as_slice());
+                .expect(&format!("failed to exec `{:?}`", config.adb_path));
 
             let adb_arg = format!("export LD_LIBRARY_PATH={}; \
                                    gdbserver :5039 {}/{}",
@@ -434,8 +433,8 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                                       .unwrap()).unwrap());
 
             let mut process = procsrv::run_background("",
-                                                      config.adb_path
-                                                            .as_slice(),
+                                                      &config.adb_path
+                                                            ,
                                                       None,
                                                       &[
                                                         "shell".to_string(),
@@ -444,7 +443,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                                                       vec!(("".to_string(),
                                                             "".to_string())),
                                                       Some("".to_string()))
-                .expect(format!("failed to exec `{:?}`", config.adb_path).as_slice());
+                .expect(&format!("failed to exec `{:?}`", config.adb_path));
             loop {
                 //waiting 1 second for gdbserver start
                 timer::sleep(Duration::milliseconds(1000));
@@ -477,16 +476,16 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                 err,
                 status
             } = procsrv::run("",
-                             gdb_path.as_slice(),
+                             &gdb_path,
                              None,
-                             debugger_opts.as_slice(),
+                             &debugger_opts,
                              vec!(("".to_string(), "".to_string())),
                              None)
-                .expect(format!("failed to exec `{:?}`", gdb_path).as_slice());
+                .expect(&format!("failed to exec `{:?}`", gdb_path));
             let cmdline = {
                 let cmdline = make_cmdline("",
                                            "arm-linux-androideabi-gdb",
-                                           debugger_opts.as_slice());
+                                           &debugger_opts);
                 logv(config, format!("executing {}", cmdline));
                 cmdline
             };
@@ -517,16 +516,16 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
             match config.gdb_version {
                 Some(ref version) => {
                     println!("NOTE: compiletest thinks it is using GDB version {}",
-                             version.as_slice());
+                             version);
 
-                    if header::gdb_version_to_int(version.as_slice()) >
+                    if header::gdb_version_to_int(version) >
                         header::gdb_version_to_int("7.4") {
                         // Add the directory containing the pretty printers to
                         // GDB's script auto loading safe path
                         script_str.push_str(
-                            format!("add-auto-load-safe-path {}\n",
-                                    rust_pp_module_abs_path.replace("\\", "\\\\").as_slice())
-                                .as_slice());
+                            &format!("add-auto-load-safe-path {}\n",
+                                     rust_pp_module_abs_path.replace("\\", "\\\\"))
+                                );
                     }
                 }
                 _ => {
@@ -553,13 +552,13 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                                              *line)[]);
             }
 
-            script_str.push_str(cmds.as_slice());
+            script_str.push_str(&cmds);
             script_str.push_str("quit\n");
 
             debug!("script_str = {}", script_str);
             dump_output_file(config,
                              testfile,
-                             script_str.as_slice(),
+                             &script_str,
                              "debugger.script");
 
             // run debugger script with gdb
@@ -592,7 +591,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
                                                   testfile,
                                                   proc_args,
                                                   environment,
-                                                  config.run_lib_path.as_slice(),
+                                                  &config.run_lib_path,
                                                   None,
                                                   None);
         }
@@ -602,7 +601,7 @@ fn run_debuginfo_gdb_test(config: &Config, props: &TestProps, testfile: &Path) {
         fatal("gdb failed to execute");
     }
 
-    check_debugger_output(&debugger_run_result, check_lines.as_slice());
+    check_debugger_output(&debugger_run_result, &check_lines);
 }
 
 fn find_rust_src_root(config: &Config) -> Option<Path> {
@@ -644,7 +643,7 @@ fn run_debuginfo_lldb_test(config: &Config, props: &TestProps, testfile: &Path) 
     match config.lldb_version {
         Some(ref version) => {
             println!("NOTE: compiletest thinks it is using LLDB version {}",
-                     version.as_slice());
+                     version);
         }
         _ => {
             println!("NOTE: compiletest does not know which version of \
@@ -684,13 +683,12 @@ fn run_debuginfo_lldb_test(config: &Config, props: &TestProps, testfile: &Path) 
 
     // Set breakpoints on every line that contains the string "#break"
     for line in &breakpoint_lines {
-        script_str.push_str(format!("breakpoint set --line {}\n",
-                                    line).as_slice());
+        script_str.push_str(&format!("breakpoint set --line {}\n", line));
     }
 
     // Append the other commands
     for line in &commands {
-        script_str.push_str(line.as_slice());
+        script_str.push_str(line);
         script_str.push_str("\n");
     }
 
@@ -701,7 +699,7 @@ fn run_debuginfo_lldb_test(config: &Config, props: &TestProps, testfile: &Path) 
     debug!("script_str = {}", script_str);
     dump_output_file(config,
                      testfile,
-                     script_str.as_slice(),
+                     &script_str,
                      "debugger.script");
     let debugger_script = make_out_name(config, testfile, "debugger.script");
 
@@ -715,7 +713,7 @@ fn run_debuginfo_lldb_test(config: &Config, props: &TestProps, testfile: &Path) 
         fatal_proc_rec("Error while running LLDB", &debugger_run_result);
     }
 
-    check_debugger_output(&debugger_run_result, check_lines.as_slice());
+    check_debugger_output(&debugger_run_result, &check_lines);
 
     fn run_lldb(config: &Config,
                 test_executable: &Path,
@@ -729,7 +727,7 @@ fn run_debuginfo_lldb_test(config: &Config, props: &TestProps, testfile: &Path) 
         cmd.arg(lldb_script_path)
            .arg(test_executable)
            .arg(debugger_script)
-           .env_set_all(&[("PYTHONPATH", config.lldb_python_dir.clone().unwrap().as_slice())]);
+           .env_set_all(&[("PYTHONPATH", config.lldb_python_dir.clone().unwrap())]);
 
         let (status, out, err) = match cmd.spawn() {
             Ok(process) => {
@@ -741,12 +739,12 @@ fn run_debuginfo_lldb_test(config: &Config, props: &TestProps, testfile: &Path) 
                  String::from_utf8(error).unwrap())
             },
             Err(e) => {
-                fatal(format!("Failed to setup Python process for \
-                               LLDB script: {}", e).as_slice())
+                fatal(&format!("Failed to setup Python process for \
+                                LLDB script: {}", e))
             }
         };
 
-        dump_output(config, test_executable, out.as_slice(), err.as_slice());
+        dump_output(config, test_executable, &out, &err);
         return ProcRes {
             status: status,
             stdout: out,
@@ -782,20 +780,19 @@ fn parse_debugger_commands(file_path: &Path, debugger_prefix: &str)
                 }
 
                 header::parse_name_value_directive(
-                        line.as_slice(),
-                        command_directive.as_slice()).map(|cmd| {
+                        &line,
+                        &command_directive).map(|cmd| {
                     commands.push(cmd)
                 });
 
                 header::parse_name_value_directive(
-                        line.as_slice(),
-                        check_directive.as_slice()).map(|cmd| {
+                        &line,
+                        &check_directive).map(|cmd| {
                     check_lines.push(cmd)
                 });
             }
             Err(e) => {
-                fatal(format!("Error while parsing debugger commands: {}",
-                              e).as_slice())
+                fatal(&format!("Error while parsing debugger commands: {}", e))
             }
         }
         counter += 1;
@@ -834,7 +831,7 @@ fn check_debugger_output(debugger_run_result: &ProcRes, check_lines: &[String]) 
         // bits in the wrong case of an enum) with the notation "[...]".
         let check_fragments: Vec<Vec<String>> =
             check_lines.iter().map(|s| {
-                s.as_slice()
+                s
                  .trim()
                  .split_str("[...]")
                  .map(|x| x.to_string())
@@ -849,13 +846,13 @@ fn check_debugger_output(debugger_run_result: &ProcRes, check_lines: &[String]) 
             let mut failed = false;
             for frag in &check_fragments[i] {
                 let found = if first {
-                    if rest.starts_with(frag.as_slice()) {
+                    if rest.starts_with(frag) {
                         Some(0)
                     } else {
                         None
                     }
                 } else {
-                    rest.find_str(frag.as_slice())
+                    rest.find_str(frag)
                 };
                 match found {
                     None => {
@@ -877,8 +874,8 @@ fn check_debugger_output(debugger_run_result: &ProcRes, check_lines: &[String]) 
             }
         }
         if i != num_check_lines {
-            fatal_proc_rec(format!("line not found in debugger output: {}",
-                                  check_lines.get(i).unwrap()).as_slice(),
+            fatal_proc_rec(&format!("line not found in debugger output: {}",
+                                    check_lines.get(i).unwrap()),
                           debugger_run_result);
         }
     }
@@ -889,14 +886,13 @@ fn check_error_patterns(props: &TestProps,
                         output_to_check: &str,
                         proc_res: &ProcRes) {
     if props.error_patterns.is_empty() {
-        fatal(format!("no error pattern specified in {:?}",
-                      testfile.display()).as_slice());
+        fatal(&format!("no error pattern specified in {:?}", testfile.display()));
     }
     let mut next_err_idx = 0;
     let mut next_err_pat = &props.error_patterns[next_err_idx];
     let mut done = false;
     for line in output_to_check.lines() {
-        if line.contains(next_err_pat.as_slice()) {
+        if line.contains(next_err_pat) {
             debug!("found error pattern {}", next_err_pat);
             next_err_idx += 1;
             if next_err_idx == props.error_patterns.len() {
@@ -911,13 +907,11 @@ fn check_error_patterns(props: &TestProps,
 
     let missing_patterns = &props.error_patterns[next_err_idx..];
     if missing_patterns.len() == 1 {
-        fatal_proc_rec(format!("error pattern '{}' not found!",
-                              missing_patterns[0]).as_slice(),
+        fatal_proc_rec(&format!("error pattern '{}' not found!", missing_patterns[0]),
                       proc_res);
     } else {
         for pattern in missing_patterns {
-            error(format!("error pattern '{}' not found!",
-                          *pattern).as_slice());
+            error(&format!("error pattern '{}' not found!", *pattern));
         }
         fatal_proc_rec("multiple error patterns not found", proc_res);
     }
@@ -936,7 +930,7 @@ fn check_forbid_output(props: &TestProps,
                        output_to_check: &str,
                        proc_res: &ProcRes) {
     for pat in &props.forbid_output {
-        if output_to_check.contains(pat.as_slice()) {
+        if output_to_check.contains(pat) {
             fatal_proc_rec("forbidden pattern found in compiler output", proc_res);
         }
     }
@@ -959,7 +953,7 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
 
     #[cfg(windows)]
     fn prefix_matches( line : &str, prefix : &str ) -> bool {
-        line.to_ascii_lowercase().starts_with(prefix.to_ascii_lowercase().as_slice())
+        line.to_ascii_lowercase().starts_with(&prefix.to_ascii_lowercase())
     }
 
     #[cfg(unix)]
@@ -988,13 +982,13 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
         for (i, ee) in expected_errors.iter().enumerate() {
             if !found_flags[i] {
                 debug!("prefix={} ee.kind={} ee.msg={} line={}",
-                       prefixes[i].as_slice(),
+                       prefixes[i],
                        ee.kind,
                        ee.msg,
                        line);
-                if (prefix_matches(line, prefixes[i].as_slice()) || continuation(line)) &&
-                    line.contains(ee.kind.as_slice()) &&
-                    line.contains(ee.msg.as_slice()) {
+                if (prefix_matches(line, &prefixes[i]) || continuation(line)) &&
+                    line.contains(&ee.kind) &&
+                    line.contains(&ee.msg) {
                     found_flags[i] = true;
                     was_expected = true;
                     break;
@@ -1008,8 +1002,8 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
         }
 
         if !was_expected && is_compiler_error_or_warning(line) {
-            fatal_proc_rec(format!("unexpected compiler error or warning: '{}'",
-                                  line).as_slice(),
+            fatal_proc_rec(&format!("unexpected compiler error or warning: '{}'",
+                                    line),
                           proc_res);
         }
     }
@@ -1017,8 +1011,8 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
     for (i, &flag) in found_flags.iter().enumerate() {
         if !flag {
             let ee = &expected_errors[i];
-            fatal_proc_rec(format!("expected {} on line {} not found: {}",
-                                  ee.kind, ee.line, ee.msg).as_slice(),
+            fatal_proc_rec(&format!("expected {} on line {} not found: {}",
+                                    ee.kind, ee.line, ee.msg),
                           proc_res);
         }
     }
@@ -1139,7 +1133,7 @@ fn exec_compiled_test(config: &Config, props: &TestProps,
 
     let env = props.exec_env.clone();
 
-    match config.target.as_slice() {
+    match &*config.target {
 
         "arm-linux-androideabi" => {
             _arm_exec_compiled_test(config, props, testfile, env)
@@ -1151,7 +1145,7 @@ fn exec_compiled_test(config: &Config, props: &TestProps,
                             testfile,
                             make_run_args(config, props, testfile),
                             env,
-                            config.run_lib_path.as_slice(),
+                            &config.run_lib_path,
                             Some(aux_dir.as_str().unwrap()),
                             None)
         }
@@ -1174,7 +1168,7 @@ fn compose_and_run_compiler(
     let extra_link_args = vec!("-L".to_string(), aux_dir.as_str().unwrap().to_string());
 
     for rel_ab in &props.aux_builds {
-        let abs_ab = config.aux_base.join(rel_ab.as_slice());
+        let abs_ab = config.aux_base.join(rel_ab);
         let aux_props = header::load_props(&abs_ab);
         let mut crate_type = if aux_props.no_prefer_dynamic {
             Vec::new()
@@ -1195,17 +1189,17 @@ fn compose_and_run_compiler(
                                      &abs_ab,
                                      aux_args,
                                      Vec::new(),
-                                     config.compile_lib_path.as_slice(),
+                                     &config.compile_lib_path,
                                      Some(aux_dir.as_str().unwrap()),
                                      None);
         if !auxres.status.success() {
             fatal_proc_rec(
-                format!("auxiliary build of {:?} failed to compile: ",
-                        abs_ab.display()).as_slice(),
+                &format!("auxiliary build of {:?} failed to compile: ",
+                        abs_ab.display()),
                 &auxres);
         }
 
-        match config.target.as_slice() {
+        match &*config.target {
             "arm-linux-androideabi" => {
                 _arm_push_aux_shared_library(config, testfile);
             }
@@ -1217,7 +1211,7 @@ fn compose_and_run_compiler(
                     testfile,
                     args,
                     Vec::new(),
-                    config.compile_lib_path.as_slice(),
+                    &config.compile_lib_path,
                     Some(aux_dir.as_str().unwrap()),
                     input)
 }
@@ -1252,16 +1246,16 @@ fn make_compile_args<F>(config: &Config,
 {
     let xform_file = xform(config, testfile);
     let target = if props.force_host {
-        config.host.as_slice()
+        &*config.host
     } else {
-        config.target.as_slice()
+        &*config.target
     };
     // FIXME (#9639): This needs to handle non-utf8 paths
     let mut args = vec!(testfile.as_str().unwrap().to_string(),
                         "-L".to_string(),
                         config.build_base.as_str().unwrap().to_string(),
                         format!("--target={}", target));
-    args.push_all(extras.as_slice());
+    args.push_all(&extras);
     if !props.no_prefer_dynamic {
         args.push("-C".to_string());
         args.push("prefer-dynamic".to_string());
@@ -1329,7 +1323,7 @@ fn make_run_args(config: &Config, props: &TestProps, testfile: &Path) ->
 fn split_maybe_args(argstr: &Option<String>) -> Vec<String> {
     match *argstr {
         Some(ref s) => {
-            s.as_slice()
+            s
              .split(' ')
              .filter_map(|s| {
                  if s.chars().all(|c| c.is_whitespace()) {
@@ -1350,8 +1344,8 @@ fn program_output(config: &Config, testfile: &Path, lib_path: &str, prog: String
     let cmdline =
         {
             let cmdline = make_cmdline(lib_path,
-                                       prog.as_slice(),
-                                       args.as_slice());
+                                       &prog,
+                                       &args);
             logv(config, format!("executing {}", cmdline));
             cmdline
         };
@@ -1360,12 +1354,12 @@ fn program_output(config: &Config, testfile: &Path, lib_path: &str, prog: String
         err,
         status
     } = procsrv::run(lib_path,
-                     prog.as_slice(),
+                     &prog,
                      aux_path,
-                     args.as_slice(),
+                     &args,
                      env,
-                     input).expect(format!("failed to exec `{}`", prog).as_slice());
-    dump_output(config, testfile, out.as_slice(), err.as_slice());
+                     input).expect(&format!("failed to exec `{}`", prog));
+    dump_output(config, testfile, &out, &err);
     return ProcRes {
         status: status,
         stdout: out,
@@ -1422,7 +1416,7 @@ fn output_testname(testfile: &Path) -> Path {
 fn output_base_name(config: &Config, testfile: &Path) -> Path {
     config.build_base
         .join(&output_testname(testfile))
-        .with_extension(config.stage_id.as_slice())
+        .with_extension(&config.stage_id)
 }
 
 fn maybe_dump_to_stdout(config: &Config, out: &str, err: &str) {
@@ -1465,12 +1459,11 @@ fn _arm_exec_compiled_test(config: &Config,
                            -> ProcRes {
     let args = make_run_args(config, props, testfile);
     let cmdline = make_cmdline("",
-                               args.prog.as_slice(),
-                               args.args.as_slice());
+                               &args.prog,
+                               &args.args);
 
     // get bare program string
     let mut tvec: Vec<String> = args.prog
-                                    .as_slice()
                                     .split('/')
                                     .map(|ts| ts.to_string())
                                     .collect();
@@ -1478,7 +1471,7 @@ fn _arm_exec_compiled_test(config: &Config,
 
     // copy to target
     let copy_result = procsrv::run("",
-                                   config.adb_path.as_slice(),
+                                   &config.adb_path,
                                    None,
                                    &[
                                     "push".to_string(),
@@ -1487,7 +1480,7 @@ fn _arm_exec_compiled_test(config: &Config,
                                    ],
                                    vec!(("".to_string(), "".to_string())),
                                    Some("".to_string()))
-        .expect(format!("failed to exec `{}`", config.adb_path).as_slice());
+        .expect(&format!("failed to exec `{}`", config.adb_path));
 
     if config.verbose {
         println!("push ({}) {} {} {}",
@@ -1514,11 +1507,11 @@ fn _arm_exec_compiled_test(config: &Config,
         runargs.push(tv.to_string());
     }
     procsrv::run("",
-                 config.adb_path.as_slice(),
+                 &config.adb_path,
                  None,
-                 runargs.as_slice(),
+                 &runargs,
                  vec!(("".to_string(), "".to_string())), Some("".to_string()))
-        .expect(format!("failed to exec `{}`", config.adb_path).as_slice());
+        .expect(&format!("failed to exec `{}`", config.adb_path));
 
     // get exitcode of result
     runargs = Vec::new();
@@ -1528,12 +1521,12 @@ fn _arm_exec_compiled_test(config: &Config,
 
     let procsrv::Result{ out: exitcode_out, err: _, status: _ } =
         procsrv::run("",
-                     config.adb_path.as_slice(),
+                     &config.adb_path,
                      None,
-                     runargs.as_slice(),
+                     &runargs,
                      vec!(("".to_string(), "".to_string())),
                      Some("".to_string()))
-        .expect(format!("failed to exec `{}`", config.adb_path).as_slice());
+        .expect(&format!("failed to exec `{}`", config.adb_path));
 
     let mut exitcode: int = 0;
     for c in exitcode_out.chars() {
@@ -1552,12 +1545,12 @@ fn _arm_exec_compiled_test(config: &Config,
 
     let procsrv::Result{ out: stdout_out, err: _, status: _ } =
         procsrv::run("",
-                     config.adb_path.as_slice(),
+                     &config.adb_path,
                      None,
-                     runargs.as_slice(),
+                     &runargs,
                      vec!(("".to_string(), "".to_string())),
                      Some("".to_string()))
-        .expect(format!("failed to exec `{}`", config.adb_path).as_slice());
+        .expect(&format!("failed to exec `{}`", config.adb_path));
 
     // get stderr of result
     runargs = Vec::new();
@@ -1567,17 +1560,17 @@ fn _arm_exec_compiled_test(config: &Config,
 
     let procsrv::Result{ out: stderr_out, err: _, status: _ } =
         procsrv::run("",
-                     config.adb_path.as_slice(),
+                     &config.adb_path,
                      None,
-                     runargs.as_slice(),
+                     &runargs,
                      vec!(("".to_string(), "".to_string())),
                      Some("".to_string()))
-        .expect(format!("failed to exec `{}`", config.adb_path).as_slice());
+        .expect(&format!("failed to exec `{}`", config.adb_path));
 
     dump_output(config,
                 testfile,
-                stdout_out.as_slice(),
-                stderr_out.as_slice());
+                &stdout_out,
+                &stderr_out);
 
     ProcRes {
         status: process::ProcessExit::ExitStatus(exitcode),
@@ -1595,7 +1588,7 @@ fn _arm_push_aux_shared_library(config: &Config, testfile: &Path) {
         if file.extension_str() == Some("so") {
             // FIXME (#9639): This needs to handle non-utf8 paths
             let copy_result = procsrv::run("",
-                                           config.adb_path.as_slice(),
+                                           &config.adb_path,
                                            None,
                                            &[
                                             "push".to_string(),
@@ -1607,7 +1600,7 @@ fn _arm_push_aux_shared_library(config: &Config, testfile: &Path) {
                                            vec!(("".to_string(),
                                                  "".to_string())),
                                            Some("".to_string()))
-                .expect(format!("failed to exec `{}`", config.adb_path).as_slice());
+                .expect(&format!("failed to exec `{}`", config.adb_path));
 
             if config.verbose {
                 println!("push ({}) {:?} {} {}",
@@ -1702,7 +1695,7 @@ fn disassemble_extract(config: &Config, _props: &TestProps,
 
 fn count_extracted_lines(p: &Path) -> uint {
     let x = File::open(&p.with_extension("ll")).read_to_end().unwrap();
-    let x = str::from_utf8(x.as_slice()).unwrap();
+    let x = str::from_utf8(&x).unwrap();
     x.lines().count()
 }
 

--- a/src/grammar/verify.rs
+++ b/src/grammar/verify.rs
@@ -179,7 +179,7 @@ fn parse_antlr_token(s: &str, tokens: &HashMap<String, token::Token>) -> TokenAn
     let toknum = &s[content_end + 3 .. toknum_end];
 
     let proto_tok = tokens.get(toknum).expect(format!("didn't find token {:?} in the map",
-                                                              toknum).as_slice());
+                                                              toknum));
 
     let nm = parse::token::intern(content);
 
@@ -242,8 +242,8 @@ fn main() {
 
     let args = std::os::args();
 
-    let mut token_file = File::open(&Path::new(args[2].as_slice()));
-    let token_map = parse_token_list(token_file.read_to_string().unwrap().as_slice());
+    let mut token_file = File::open(&Path::new(args[2]));
+    let token_map = parse_token_list(token_file.read_to_string().unwrap());
 
     let mut stdin = std::io::stdin();
     let mut lock = stdin.lock();
@@ -251,7 +251,7 @@ fn main() {
     let mut antlr_tokens = lines.map(|l| parse_antlr_token(l.unwrap().trim(),
                                                                    &token_map));
 
-    let code = File::open(&Path::new(args[1].as_slice())).unwrap().read_to_string().unwrap();
+    let code = File::open(&Path::new(args[1])).unwrap().read_to_string().unwrap();
     let options = config::basic_options();
     let session = session::build_session(options, None,
                                          syntax::diagnostics::registry::Registry::new(&[]));

--- a/src/libcollections/bench.rs
+++ b/src/libcollections/bench.rs
@@ -77,7 +77,7 @@ pub fn find_rand_n<M, T, I, F>(n: uint,
         insert(map, *k);
     }
 
-    rng.shuffle(keys.as_mut_slice());
+    rng.shuffle(&mut keys);
 
     // measure
     let mut i = 0;

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -1910,7 +1910,7 @@ mod tests {
     fn test_0_elements() {
         let act = Bitv::new();
         let exp = Vec::new();
-        assert!(act.eq_vec(exp.as_slice()));
+        assert!(act.eq_vec(&exp));
         assert!(act.none() && act.all());
     }
 

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -1054,12 +1054,12 @@ mod tests {
         // Non-empty to non-empty
         let v = vec![1,2,3,4,5];
         let u = vec![9,8,1,2,3,4,5];
-        let mut m = list_from(v.as_slice());
-        let mut n = list_from(u.as_slice());
+        let mut m = list_from(&v);
+        let mut n = list_from(&u);
         m.append(&mut n);
         check_links(&m);
         let mut sum = v;
-        sum.push_all(u.as_slice());
+        sum.push_all(&u);
         assert_eq!(sum.len(), m.len());
         for elt in sum {
             assert_eq!(m.pop_front(), Some(elt))
@@ -1090,7 +1090,7 @@ mod tests {
         // not singleton, forwards
         {
             let u = vec![1,2,3,4,5];
-            let mut m = list_from(u.as_slice());
+            let mut m = list_from(&u);
             let mut n = m.split_off(2);
             assert_eq!(m.len(), 2);
             assert_eq!(n.len(), 3);
@@ -1104,7 +1104,7 @@ mod tests {
         // not singleton, backwards
         {
             let u = vec![1,2,3,4,5];
-            let mut m = list_from(u.as_slice());
+            let mut m = list_from(&u);
             let mut n = m.split_off(4);
             assert_eq!(m.len(), 4);
             assert_eq!(n.len(), 1);

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1528,7 +1528,7 @@ mod tests {
         // Test on-stack from_fn.
         let mut v = (0u..3).map(square).collect::<Vec<_>>();
         {
-            let v = v.as_slice();
+            let v = v;
             assert_eq!(v.len(), 3u);
             assert_eq!(v[0], 0u);
             assert_eq!(v[1], 1u);
@@ -1538,7 +1538,7 @@ mod tests {
         // Test on-heap from_fn.
         v = (0u..5).map(square).collect::<Vec<_>>();
         {
-            let v = v.as_slice();
+            let v = v;
             assert_eq!(v.len(), 5u);
             assert_eq!(v[0], 0u);
             assert_eq!(v[1], 1u);
@@ -1553,7 +1553,7 @@ mod tests {
         // Test on-stack from_elem.
         let mut v = vec![10u, 10u];
         {
-            let v = v.as_slice();
+            let v = v;
             assert_eq!(v.len(), 2u);
             assert_eq!(v[0], 10u);
             assert_eq!(v[1], 10u);
@@ -1562,7 +1562,7 @@ mod tests {
         // Test on-heap from_elem.
         v = vec![20u, 20u, 20u, 20u, 20u, 20u];
         {
-            let v = v.as_slice();
+            let v = v;
             assert_eq!(v[0], 20u);
             assert_eq!(v[1], 20u);
             assert_eq!(v[2], 20u);
@@ -1715,7 +1715,7 @@ mod tests {
         let vec_fixed = [1, 2, 3, 4];
         let v_a = vec_fixed[1u..vec_fixed.len()].to_vec();
         assert_eq!(v_a.len(), 3u);
-        let v_a = v_a.as_slice();
+        let v_a = v_a;
         assert_eq!(v_a[0], 2);
         assert_eq!(v_a[1], 3);
         assert_eq!(v_a[2], 4);
@@ -1724,7 +1724,7 @@ mod tests {
         let vec_stack: &[_] = &[1, 2, 3];
         let v_b = vec_stack[1u..3u].to_vec();
         assert_eq!(v_b.len(), 2u);
-        let v_b = v_b.as_slice();
+        let v_b = v_b;
         assert_eq!(v_b[0], 2);
         assert_eq!(v_b[1], 3);
 
@@ -1732,7 +1732,7 @@ mod tests {
         let vec_unique = vec![1, 2, 3, 4, 5, 6];
         let v_d = vec_unique[1u..6u].to_vec();
         assert_eq!(v_d.len(), 5u);
-        let v_d = v_d.as_slice();
+        let v_d = v_d;
         assert_eq!(v_d[0], 2);
         assert_eq!(v_d[1], 3);
         assert_eq!(v_d[2], 4);
@@ -1813,20 +1813,20 @@ mod tests {
         let mut v = vec![];
         v.push(1);
         assert_eq!(v.len(), 1u);
-        assert_eq!(v.as_slice()[0], 1);
+        assert_eq!(v[0], 1);
 
         // Test on-heap push().
         v.push(2);
         assert_eq!(v.len(), 2u);
-        assert_eq!(v.as_slice()[0], 1);
-        assert_eq!(v.as_slice()[1], 2);
+        assert_eq!(v[0], 1);
+        assert_eq!(v[1], 2);
     }
 
     #[test]
     fn test_truncate() {
         let mut v = vec![box 6,box 5,box 4];
         v.truncate(1);
-        let v = v.as_slice();
+        let v = v;
         assert_eq!(v.len(), 1);
         assert_eq!(*(v[0]), 6);
         // If the unsafe block didn't drop things properly, we blow up here.
@@ -2587,7 +2587,7 @@ mod tests {
             ($x:expr, $x_str:expr) => ({
                 let (x, x_str) = ($x, $x_str);
                 assert_eq!(format!("{:?}", x), x_str);
-                assert_eq!(format!("{:?}", x.as_slice()), x_str);
+                assert_eq!(format!("{:?}", x), x_str);
             })
         }
         let empty: Vec<int> = vec![];
@@ -2910,7 +2910,7 @@ mod bench {
     fn starts_with_same_vector(b: &mut Bencher) {
         let vec: Vec<uint> = (0u..100).collect();
         b.iter(|| {
-            vec.starts_with(vec.as_slice())
+            vec.starts_with(&vec)
         })
     }
 
@@ -2918,7 +2918,7 @@ mod bench {
     fn starts_with_single_element(b: &mut Bencher) {
         let vec: Vec<uint> = vec![0];
         b.iter(|| {
-            vec.starts_with(vec.as_slice())
+            vec.starts_with(&vec)
         })
     }
 
@@ -2928,7 +2928,7 @@ mod bench {
         let mut match_vec: Vec<uint> = (0u..99).collect();
         match_vec.push(0);
         b.iter(|| {
-            vec.starts_with(match_vec.as_slice())
+            vec.starts_with(&match_vec)
         })
     }
 
@@ -2936,7 +2936,7 @@ mod bench {
     fn ends_with_same_vector(b: &mut Bencher) {
         let vec: Vec<uint> = (0u..100).collect();
         b.iter(|| {
-            vec.ends_with(vec.as_slice())
+            vec.ends_with(&vec)
         })
     }
 
@@ -2944,7 +2944,7 @@ mod bench {
     fn ends_with_single_element(b: &mut Bencher) {
         let vec: Vec<uint> = vec![0];
         b.iter(|| {
-            vec.ends_with(vec.as_slice())
+            vec.ends_with(&vec)
         })
     }
 
@@ -2952,9 +2952,9 @@ mod bench {
     fn ends_with_diff_one_element_at_beginning(b: &mut Bencher) {
         let vec: Vec<uint> = (0u..100).collect();
         let mut match_vec: Vec<uint> = (0u..100).collect();
-        match_vec.as_mut_slice()[0] = 200;
+        match_vec[0] = 200;
         b.iter(|| {
-            vec.starts_with(match_vec.as_slice())
+            vec.starts_with(&match_vec)
         })
     }
 
@@ -3042,7 +3042,7 @@ mod bench {
         let mut rng = weak_rng();
         b.iter(|| {
             let mut v = rng.gen_iter::<u64>().take(5).collect::<Vec<u64>>();
-            v.as_mut_slice().sort();
+            v.sort();
         });
         b.bytes = 5 * mem::size_of::<u64>() as u64;
     }
@@ -3052,7 +3052,7 @@ mod bench {
         let mut rng = weak_rng();
         b.iter(|| {
             let mut v = rng.gen_iter::<u64>().take(100).collect::<Vec<u64>>();
-            v.as_mut_slice().sort();
+            v.sort();
         });
         b.bytes = 100 * mem::size_of::<u64>() as u64;
     }
@@ -3062,7 +3062,7 @@ mod bench {
         let mut rng = weak_rng();
         b.iter(|| {
             let mut v = rng.gen_iter::<u64>().take(10000).collect::<Vec<u64>>();
-            v.as_mut_slice().sort();
+            v.sort();
         });
         b.bytes = 10000 * mem::size_of::<u64>() as u64;
     }

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -203,7 +203,7 @@ impl<'a> Iterator for Decompositions<'a> {
                         let class =
                             unicode::char::canonical_combining_class(d);
                         if class == 0 && !*sorted {
-                            canonical_sort(buffer.as_mut_slice());
+                            canonical_sort(buffer);
                             *sorted = true;
                         }
                         buffer.push((d, class));
@@ -224,7 +224,7 @@ impl<'a> Iterator for Decompositions<'a> {
         }
 
         if !self.sorted {
-            canonical_sort(self.buffer.as_mut_slice());
+            canonical_sort(&mut self.buffer);
             self.sorted = true;
         }
 
@@ -1480,7 +1480,7 @@ mod tests {
     fn test_concat_for_different_types() {
         test_concat!("ab", vec![s("a"), s("b")]);
         test_concat!("ab", vec!["a", "b"]);
-        test_concat!("ab", vec!["a", "b"].as_slice());
+        test_concat!("ab", vec!["a", "b"]);
         test_concat!("ab", vec![s("a"), s("b")]);
     }
 
@@ -1506,9 +1506,9 @@ mod tests {
     fn test_connect_for_different_types() {
         test_connect!("a-b", ["a", "b"], "-");
         let hyphen = "-".to_string();
-        test_connect!("a-b", [s("a"), s("b")], hyphen.as_slice());
-        test_connect!("a-b", vec!["a", "b"], hyphen.as_slice());
-        test_connect!("a-b", vec!["a", "b"].as_slice(), "-");
+        test_connect!("a-b", [s("a"), s("b")], &*hyphen);
+        test_connect!("a-b", vec!["a", "b"], &*hyphen);
+        test_connect!("a-b", &*vec!["a", "b"], "-");
         test_connect!("a-b", vec![s("a"), s("b")], "-");
     }
 
@@ -1960,7 +1960,7 @@ mod tests {
         let s1: String = String::from_str("All mimsy were the borogoves");
 
         let v: Vec<u8> = s1.as_bytes().to_vec();
-        let s2: String = String::from_str(from_utf8(v.as_slice()).unwrap());
+        let s2: String = String::from_str(from_utf8(&v).unwrap());
         let mut i: uint = 0u;
         let n1: uint = s1.len();
         let n2: uint = v.len();
@@ -2791,11 +2791,11 @@ mod tests {
 
         let s = String::from_str("01234");
         assert_eq!(5, sum_len(&["012", "", "34"]));
-        assert_eq!(5, sum_len(&[String::from_str("01").as_slice(),
-                                String::from_str("2").as_slice(),
-                                String::from_str("34").as_slice(),
-                                String::from_str("").as_slice()]));
-        assert_eq!(5, sum_len(&[s.as_slice()]));
+        assert_eq!(5, sum_len(&[&String::from_str("01"),
+                                &String::from_str("2"),
+                                &String::from_str("34"),
+                                &String::from_str("")]));
+        assert_eq!(5, sum_len(&[&s]));
     }
 
     #[test]

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -123,7 +123,7 @@ macro_rules! impl_hash {
                 let a: [u8; ::$ty::BYTES] = unsafe {
                     mem::transmute((*self as $uty).to_le() as $ty)
                 };
-                state.write(a.as_slice())
+                state.write(&a)
             }
         }
     }

--- a/src/libcoretest/char.rs
+++ b/src/libcoretest/char.rs
@@ -166,7 +166,7 @@ fn test_escape_unicode() {
 fn test_encode_utf8() {
     fn check(input: char, expect: &[u8]) {
         let mut buf = [0u8; 4];
-        let n = input.encode_utf8(buf.as_mut_slice()).unwrap_or(0);
+        let n = input.encode_utf8(&mut buf).unwrap_or(0);
         assert_eq!(&buf[..n], expect);
     }
 
@@ -180,7 +180,7 @@ fn test_encode_utf8() {
 fn test_encode_utf16() {
     fn check(input: char, expect: &[u16]) {
         let mut buf = [0u16; 2];
-        let n = input.encode_utf16(buf.as_mut_slice()).unwrap_or(0);
+        let n = input.encode_utf16(&mut buf).unwrap_or(0);
         assert_eq!(&buf[..n], expect);
     }
 

--- a/src/libcoretest/hash/sip.rs
+++ b/src/libcoretest/hash/sip.rs
@@ -110,7 +110,7 @@ fn test_siphash() {
     fn to_hex_str(r: &[u8; 8]) -> String {
         let mut s = String::new();
         for b in r {
-            s.push_str(format!("{}", fmt::radix(*b, 16)).as_slice());
+            s.push_str(format!("{}", fmt::radix(*b, 16)));
         }
         s
     }
@@ -131,7 +131,7 @@ fn test_siphash() {
         let r = result_bytes(h);
         let mut s = String::new();
         for b in &r {
-            s.push_str(format!("{}", fmt::radix(*b, 16)).as_slice());
+            s.push_str(format!("{}", fmt::radix(*b, 16)));
         }
         s
     }
@@ -139,12 +139,12 @@ fn test_siphash() {
     while t < 64 {
         debug!("siphash test {}: {}", t, buf);
         let vec = u8to64_le!(vecs[t], 0);
-        let out = hash_with_keys(k0, k1, &Bytes(buf.as_slice()));
+        let out = hash_with_keys(k0, k1, &Bytes(buf));
         debug!("got {}, expected {}", out, vec);
         assert_eq!(vec, out);
 
         state_full.reset();
-        state_full.write(buf.as_slice());
+        state_full.write(buf);
         let f = result_str(state_full.result());
         let i = result_str(state_inc.result());
         let v = to_hex_str(&vecs[t]);

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -147,24 +147,24 @@ mod tests {
         for _ in 0..20 {
             let mut input = vec![];
             for _ in 0..2000 {
-                input.push_all(r.choose(words.as_slice()).unwrap().as_slice());
+                input.push_all(r.choose(&words).unwrap());
             }
             debug!("de/inflate of {} bytes of random word-sequences",
                    input.len());
-            let cmp = deflate_bytes(input.as_slice()).expect("deflation failed");
-            let out = inflate_bytes(cmp.as_slice()).expect("inflation failed");
+            let cmp = deflate_bytes(&input).expect("deflation failed");
+            let out = inflate_bytes(&cmp).expect("inflation failed");
             debug!("{} bytes deflated to {} ({:.1}% size)",
                    input.len(), cmp.len(),
                    100.0 * ((cmp.len() as f64) / (input.len() as f64)));
-            assert_eq!(input, out.as_slice());
+            assert_eq!(&*input, &*out);
         }
     }
 
     #[test]
     fn test_zlib_flate() {
         let bytes = vec!(1, 2, 3, 4, 5);
-        let deflated = deflate_bytes(bytes.as_slice()).expect("deflation failed");
-        let inflated = inflate_bytes(deflated.as_slice()).expect("inflation failed");
-        assert_eq!(inflated.as_slice(), bytes);
+        let deflated = deflate_bytes(&bytes).expect("deflation failed");
+        let inflated = inflate_bytes(&deflated).expect("inflation failed");
+        assert_eq!(&*inflated, &*bytes);
     }
 }

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -316,7 +316,7 @@ impl Matches {
     /// Returns true if any of several options were matched.
     pub fn opts_present(&self, names: &[String]) -> bool {
         for nm in names {
-            match find_opt(self.opts.as_slice(), Name::from_str(&nm[])) {
+            match find_opt(&self.opts, Name::from_str(&**nm)) {
                 Some(id) if !self.vals[id].is_empty() => return true,
                 _ => (),
             };
@@ -627,7 +627,7 @@ pub fn getopts(args: &[String], optgrps: &[OptGroup]) -> Result {
                        interpreted correctly
                     */
 
-                    let opt_id = match find_opt(opts.as_slice(), opt.clone()) {
+                    let opt_id = match find_opt(&opts, opt.clone()) {
                       Some(id) => id,
                       None => return Err(UnrecognizedOption(opt.to_string()))
                     };
@@ -650,7 +650,7 @@ pub fn getopts(args: &[String], optgrps: &[OptGroup]) -> Result {
             let mut name_pos = 0;
             for nm in &names {
                 name_pos += 1;
-                let optid = match find_opt(opts.as_slice(), (*nm).clone()) {
+                let optid = match find_opt(&opts, (*nm).clone()) {
                   Some(id) => id,
                   None => return Err(UnrecognizedOption(nm.to_string()))
                 };
@@ -981,7 +981,7 @@ mod tests {
     fn test_reqopt() {
         let long_args = vec!("--test=20".to_string());
         let opts = vec!(reqopt("t", "test", "testing", "TEST"));
-        let rs = getopts(long_args.as_slice(), opts.as_slice());
+        let rs = getopts(&long_args, &opts);
         match rs {
           Ok(ref m) => {
             assert!(m.opt_present("test"));
@@ -992,7 +992,7 @@ mod tests {
           _ => { panic!("test_reqopt failed (long arg)"); }
         }
         let short_args = vec!("-t".to_string(), "20".to_string());
-        match getopts(short_args.as_slice(), opts.as_slice()) {
+        match getopts(&short_args, &opts) {
           Ok(ref m) => {
             assert!((m.opt_present("test")));
             assert_eq!(m.opt_str("test").unwrap(), "20");
@@ -1007,7 +1007,7 @@ mod tests {
     fn test_reqopt_missing() {
         let args = vec!("blah".to_string());
         let opts = vec!(reqopt("t", "test", "testing", "TEST"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Err(OptionMissing(_)) => {},
           _ => panic!()
@@ -1018,13 +1018,13 @@ mod tests {
     fn test_reqopt_no_arg() {
         let long_args = vec!("--test".to_string());
         let opts = vec!(reqopt("t", "test", "testing", "TEST"));
-        let rs = getopts(long_args.as_slice(), opts.as_slice());
+        let rs = getopts(&long_args, &opts);
         match rs {
           Err(ArgumentMissing(_)) => {},
           _ => panic!()
         }
         let short_args = vec!("-t".to_string());
-        match getopts(short_args.as_slice(), opts.as_slice()) {
+        match getopts(&short_args, &opts) {
           Err(ArgumentMissing(_)) => {},
           _ => panic!()
         }
@@ -1034,7 +1034,7 @@ mod tests {
     fn test_reqopt_multi() {
         let args = vec!("--test=20".to_string(), "-t".to_string(), "30".to_string());
         let opts = vec!(reqopt("t", "test", "testing", "TEST"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Err(OptionDuplicated(_)) => {},
           _ => panic!()
@@ -1046,7 +1046,7 @@ mod tests {
     fn test_optopt() {
         let long_args = vec!("--test=20".to_string());
         let opts = vec!(optopt("t", "test", "testing", "TEST"));
-        let rs = getopts(long_args.as_slice(), opts.as_slice());
+        let rs = getopts(&long_args, &opts);
         match rs {
           Ok(ref m) => {
             assert!(m.opt_present("test"));
@@ -1057,7 +1057,7 @@ mod tests {
           _ => panic!()
         }
         let short_args = vec!("-t".to_string(), "20".to_string());
-        match getopts(short_args.as_slice(), opts.as_slice()) {
+        match getopts(&short_args, &opts) {
           Ok(ref m) => {
             assert!((m.opt_present("test")));
             assert_eq!(m.opt_str("test").unwrap(), "20");
@@ -1072,7 +1072,7 @@ mod tests {
     fn test_optopt_missing() {
         let args = vec!("blah".to_string());
         let opts = vec!(optopt("t", "test", "testing", "TEST"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Ok(ref m) => {
             assert!(!m.opt_present("test"));
@@ -1086,13 +1086,13 @@ mod tests {
     fn test_optopt_no_arg() {
         let long_args = vec!("--test".to_string());
         let opts = vec!(optopt("t", "test", "testing", "TEST"));
-        let rs = getopts(long_args.as_slice(), opts.as_slice());
+        let rs = getopts(&long_args, &opts);
         match rs {
           Err(ArgumentMissing(_)) => {},
           _ => panic!()
         }
         let short_args = vec!("-t".to_string());
-        match getopts(short_args.as_slice(), opts.as_slice()) {
+        match getopts(&short_args, &opts) {
           Err(ArgumentMissing(_)) => {},
           _ => panic!()
         }
@@ -1102,7 +1102,7 @@ mod tests {
     fn test_optopt_multi() {
         let args = vec!("--test=20".to_string(), "-t".to_string(), "30".to_string());
         let opts = vec!(optopt("t", "test", "testing", "TEST"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Err(OptionDuplicated(_)) => {},
           _ => panic!()
@@ -1114,7 +1114,7 @@ mod tests {
     fn test_optflag() {
         let long_args = vec!("--test".to_string());
         let opts = vec!(optflag("t", "test", "testing"));
-        let rs = getopts(long_args.as_slice(), opts.as_slice());
+        let rs = getopts(&long_args, &opts);
         match rs {
           Ok(ref m) => {
             assert!(m.opt_present("test"));
@@ -1123,7 +1123,7 @@ mod tests {
           _ => panic!()
         }
         let short_args = vec!("-t".to_string());
-        match getopts(short_args.as_slice(), opts.as_slice()) {
+        match getopts(&short_args, &opts) {
           Ok(ref m) => {
             assert!(m.opt_present("test"));
             assert!(m.opt_present("t"));
@@ -1136,7 +1136,7 @@ mod tests {
     fn test_optflag_missing() {
         let args = vec!("blah".to_string());
         let opts = vec!(optflag("t", "test", "testing"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Ok(ref m) => {
             assert!(!m.opt_present("test"));
@@ -1150,7 +1150,7 @@ mod tests {
     fn test_optflag_long_arg() {
         let args = vec!("--test=20".to_string());
         let opts = vec!(optflag("t", "test", "testing"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Err(UnexpectedArgument(_)) => {},
           _ => panic!()
@@ -1161,7 +1161,7 @@ mod tests {
     fn test_optflag_multi() {
         let args = vec!("--test".to_string(), "-t".to_string());
         let opts = vec!(optflag("t", "test", "testing"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Err(OptionDuplicated(_)) => {},
           _ => panic!()
@@ -1172,7 +1172,7 @@ mod tests {
     fn test_optflag_short_arg() {
         let args = vec!("-t".to_string(), "20".to_string());
         let opts = vec!(optflag("t", "test", "testing"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Ok(ref m) => {
             // The next variable after the flag is just a free argument
@@ -1188,7 +1188,7 @@ mod tests {
     fn test_optflagmulti_short1() {
         let args = vec!("-v".to_string());
         let opts = vec!(optflagmulti("v", "verbose", "verbosity"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Ok(ref m) => {
             assert_eq!(m.opt_count("v"), 1);
@@ -1201,7 +1201,7 @@ mod tests {
     fn test_optflagmulti_short2a() {
         let args = vec!("-v".to_string(), "-v".to_string());
         let opts = vec!(optflagmulti("v", "verbose", "verbosity"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Ok(ref m) => {
             assert_eq!(m.opt_count("v"), 2);
@@ -1214,7 +1214,7 @@ mod tests {
     fn test_optflagmulti_short2b() {
         let args = vec!("-vv".to_string());
         let opts = vec!(optflagmulti("v", "verbose", "verbosity"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Ok(ref m) => {
             assert_eq!(m.opt_count("v"), 2);
@@ -1227,7 +1227,7 @@ mod tests {
     fn test_optflagmulti_long1() {
         let args = vec!("--verbose".to_string());
         let opts = vec!(optflagmulti("v", "verbose", "verbosity"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Ok(ref m) => {
             assert_eq!(m.opt_count("verbose"), 1);
@@ -1240,7 +1240,7 @@ mod tests {
     fn test_optflagmulti_long2() {
         let args = vec!("--verbose".to_string(), "--verbose".to_string());
         let opts = vec!(optflagmulti("v", "verbose", "verbosity"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Ok(ref m) => {
             assert_eq!(m.opt_count("verbose"), 2);
@@ -1254,7 +1254,7 @@ mod tests {
         let args = vec!("--verbose".to_string(), "-v".to_string(),
                         "-vv".to_string(), "verbose".to_string());
         let opts = vec!(optflagmulti("v", "verbose", "verbosity"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Ok(ref m) => {
             assert_eq!(m.opt_count("verbose"), 4);
@@ -1269,7 +1269,7 @@ mod tests {
     fn test_optmulti() {
         let long_args = vec!("--test=20".to_string());
         let opts = vec!(optmulti("t", "test", "testing", "TEST"));
-        let rs = getopts(long_args.as_slice(), opts.as_slice());
+        let rs = getopts(&long_args, &opts);
         match rs {
           Ok(ref m) => {
             assert!((m.opt_present("test")));
@@ -1280,7 +1280,7 @@ mod tests {
           _ => panic!()
         }
         let short_args = vec!("-t".to_string(), "20".to_string());
-        match getopts(short_args.as_slice(), opts.as_slice()) {
+        match getopts(&short_args, &opts) {
           Ok(ref m) => {
             assert!((m.opt_present("test")));
             assert_eq!(m.opt_str("test").unwrap(), "20");
@@ -1295,7 +1295,7 @@ mod tests {
     fn test_optmulti_missing() {
         let args = vec!("blah".to_string());
         let opts = vec!(optmulti("t", "test", "testing", "TEST"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Ok(ref m) => {
             assert!(!m.opt_present("test"));
@@ -1309,13 +1309,13 @@ mod tests {
     fn test_optmulti_no_arg() {
         let long_args = vec!("--test".to_string());
         let opts = vec!(optmulti("t", "test", "testing", "TEST"));
-        let rs = getopts(long_args.as_slice(), opts.as_slice());
+        let rs = getopts(&long_args, &opts);
         match rs {
           Err(ArgumentMissing(_)) => {},
           _ => panic!()
         }
         let short_args = vec!("-t".to_string());
-        match getopts(short_args.as_slice(), opts.as_slice()) {
+        match getopts(&short_args, &opts) {
           Err(ArgumentMissing(_)) => {},
           _ => panic!()
         }
@@ -1325,7 +1325,7 @@ mod tests {
     fn test_optmulti_multi() {
         let args = vec!("--test=20".to_string(), "-t".to_string(), "30".to_string());
         let opts = vec!(optmulti("t", "test", "testing", "TEST"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Ok(ref m) => {
               assert!(m.opt_present("test"));
@@ -1344,13 +1344,13 @@ mod tests {
     fn test_unrecognized_option() {
         let long_args = vec!("--untest".to_string());
         let opts = vec!(optmulti("t", "test", "testing", "TEST"));
-        let rs = getopts(long_args.as_slice(), opts.as_slice());
+        let rs = getopts(&long_args, &opts);
         match rs {
           Err(UnrecognizedOption(_)) => {},
           _ => panic!()
         }
         let short_args = vec!("-u".to_string());
-        match getopts(short_args.as_slice(), opts.as_slice()) {
+        match getopts(&short_args, &opts) {
           Err(UnrecognizedOption(_)) => {},
           _ => panic!()
         }
@@ -1383,7 +1383,7 @@ mod tests {
               optmulti("m", "", "mmmmmm", "YUM"),
               optmulti("n", "", "nothing", "NOTHING"),
               optopt("", "notpresent", "nothing to see here", "NOPE"));
-        let rs = getopts(args.as_slice(), opts.as_slice());
+        let rs = getopts(&args, &opts);
         match rs {
           Ok(ref m) => {
             assert!(m.free[0] == "prog");
@@ -1412,8 +1412,7 @@ mod tests {
                      optopt("f", "", "flag", "FLAG"));
 
         let args_single = vec!("-e".to_string(), "foo".to_string());
-        let matches_single = &match getopts(args_single.as_slice(),
-                                            opts.as_slice()) {
+        let matches_single = &match getopts(&args_single, &opts) {
           result::Result::Ok(m) => m,
           result::Result::Err(_) => panic!()
         };
@@ -1432,8 +1431,7 @@ mod tests {
 
         let args_both = vec!("-e".to_string(), "foo".to_string(), "--encrypt".to_string(),
                              "foo".to_string());
-        let matches_both = &match getopts(args_both.as_slice(),
-                                          opts.as_slice()) {
+        let matches_both = &match getopts(&args_both, &opts) {
           result::Result::Ok(m) => m,
           result::Result::Err(_) => panic!()
         };
@@ -1458,7 +1456,7 @@ mod tests {
         let args = vec!("-Lfoo".to_string(), "-M.".to_string());
         let opts = vec!(optmulti("L", "", "library directory", "LIB"),
                      optmulti("M", "", "something", "MMMM"));
-        let matches = &match getopts(args.as_slice(), opts.as_slice()) {
+        let matches = &match getopts(&args, &opts) {
           result::Result::Ok(m) => m,
           result::Result::Err(_) => panic!()
         };
@@ -1474,7 +1472,7 @@ mod tests {
         let args = vec!("-vvLverbose".to_string(), "-v".to_string() );
         let opts = vec!(optmulti("L", "", "library directory", "LIB"),
                      optflagmulti("v", "verbose", "Verbose"));
-        let matches = &match getopts(args.as_slice(), opts.as_slice()) {
+        let matches = &match getopts(&args, &opts) {
           result::Result::Ok(m) => m,
           result::Result::Err(e) => panic!( "{}", e )
         };
@@ -1508,7 +1506,7 @@ mod tests {
 
         let args = vec!("-a".to_string(), "--apple".to_string(), "-a".to_string());
 
-        let matches = getopts(args.as_slice(), opts.as_slice()).unwrap();
+        let matches = getopts(&args, &opts).unwrap();
         assert_eq!(3, matches.opt_count("a"));
         assert_eq!(3, matches.opt_count("apple"));
     }
@@ -1535,7 +1533,7 @@ Options:
     -l VAL              Desc
 ";
 
-        let generated_usage = usage("Usage: fruits", optgroups.as_slice());
+        let generated_usage = usage("Usage: fruits", &optgroups);
 
         debug!("expected: <<{}>>", expected);
         debug!("generated: <<{}>>", generated_usage);
@@ -1562,7 +1560,7 @@ Options:
                         wrapped..+..
 ";
 
-        let usage = usage("Usage: fruits", optgroups.as_slice());
+        let usage = usage("Usage: fruits", &optgroups);
 
         debug!("expected: <<{}>>", expected);
         debug!("generated: <<{}>>", usage);
@@ -1588,7 +1586,7 @@ Options:
                         some parts of Europe.
 ";
 
-        let usage = usage("Usage: fruits", optgroups.as_slice());
+        let usage = usage("Usage: fruits", &optgroups);
 
         debug!("expected: <<{}>>", expected);
         debug!("generated: <<{}>>", usage);
@@ -1606,7 +1604,7 @@ Options:
             optmulti("l", "", "Desc", "VAL"));
 
         let expected = "Usage: fruits -b VAL [-a VAL] [-k] [-p [VAL]] [-l VAL]..".to_string();
-        let generated_usage = short_usage("fruits", optgroups.as_slice());
+        let generated_usage = short_usage("fruits", &optgroups);
 
         debug!("expected: <<{}>>", expected);
         debug!("generated: <<{}>>", generated_usage);

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -565,7 +565,7 @@ pub fn render_opts<'a, N:Clone+'a, E:Clone+'a, G:Labeller<'a,N,E>+GraphWalk<'a,N
         } else {
             let escaped = g.node_label(n).escape();
             try!(writeln(w, &[id.as_slice(),
-                              "[label=\"", escaped.as_slice(), "\"];"]));
+                              "[label=\"", &escaped, "\"];"]));
         }
     }
 
@@ -582,7 +582,7 @@ pub fn render_opts<'a, N:Clone+'a, E:Clone+'a, G:Labeller<'a,N,E>+GraphWalk<'a,N
         } else {
             try!(writeln(w, &[source_id.as_slice(),
                               " -> ", target_id.as_slice(),
-                              "[label=\"", escaped_label.as_slice(), "\"];"]));
+                              "[label=\"", &escaped_label, "\"];"]));
         }
     }
 
@@ -746,7 +746,7 @@ mod tests {
     fn test_input(g: LabelledGraph) -> IoResult<String> {
         let mut writer = Vec::new();
         render(&g, &mut writer).unwrap();
-        (&mut writer.as_slice()).read_to_string()
+        (&mut &*writer).read_to_string()
     }
 
     // All of the tests use raw-strings as the format for the expected outputs,
@@ -858,7 +858,7 @@ r#"digraph hasse_diagram {
                  edge(1, 3, ";"),    edge(2, 3, ";"   )));
 
         render(&g, &mut writer).unwrap();
-        let r = (&mut writer.as_slice()).read_to_string();
+        let r = (&mut &*writer).read_to_string();
 
         assert_eq!(r.unwrap(),
 r#"digraph syntax_tree {

--- a/src/librand/chacha.rs
+++ b/src/librand/chacha.rs
@@ -213,8 +213,8 @@ mod test {
     #[test]
     fn test_rng_rand_seeded() {
         let s = ::test::rng().gen_iter::<u32>().take(8).collect::<Vec<u32>>();
-        let mut ra: ChaChaRng = SeedableRng::from_seed(s.as_slice());
-        let mut rb: ChaChaRng = SeedableRng::from_seed(s.as_slice());
+        let mut ra: ChaChaRng = SeedableRng::from_seed(&*s);
+        let mut rb: ChaChaRng = SeedableRng::from_seed(&*s);
         assert!(order::equals(ra.gen_ascii_chars().take(100),
                               rb.gen_ascii_chars().take(100)));
     }
@@ -231,10 +231,10 @@ mod test {
     #[test]
     fn test_rng_reseed() {
         let s = ::test::rng().gen_iter::<u32>().take(8).collect::<Vec<u32>>();
-        let mut r: ChaChaRng = SeedableRng::from_seed(s.as_slice());
+        let mut r: ChaChaRng = SeedableRng::from_seed(&*s);
         let string1: String = r.gen_ascii_chars().take(100).collect();
 
-        r.reseed(s.as_slice());
+        r.reseed(&s);
 
         let string2: String = r.gen_ascii_chars().take(100).collect();
         assert_eq!(string1, string2);

--- a/src/librand/distributions/mod.rs
+++ b/src/librand/distributions/mod.rs
@@ -300,7 +300,7 @@ mod tests {
         macro_rules! t {
             ($items:expr, $expected:expr) => {{
                 let mut items = $items;
-                let wc = WeightedChoice::new(items.as_mut_slice());
+                let wc = WeightedChoice::new(&mut items);
                 let expected = $expected;
 
                 let mut rng = CountingRng { i: 0 };

--- a/src/librand/isaac.rs
+++ b/src/librand/isaac.rs
@@ -514,16 +514,16 @@ mod test {
     #[test]
     fn test_rng_32_rand_seeded() {
         let s = ::test::rng().gen_iter::<u32>().take(256).collect::<Vec<u32>>();
-        let mut ra: IsaacRng = SeedableRng::from_seed(s.as_slice());
-        let mut rb: IsaacRng = SeedableRng::from_seed(s.as_slice());
+        let mut ra: IsaacRng = SeedableRng::from_seed(&*s);
+        let mut rb: IsaacRng = SeedableRng::from_seed(&*s);
         assert!(order::equals(ra.gen_ascii_chars().take(100),
                               rb.gen_ascii_chars().take(100)));
     }
     #[test]
     fn test_rng_64_rand_seeded() {
         let s = ::test::rng().gen_iter::<u64>().take(256).collect::<Vec<u64>>();
-        let mut ra: Isaac64Rng = SeedableRng::from_seed(s.as_slice());
-        let mut rb: Isaac64Rng = SeedableRng::from_seed(s.as_slice());
+        let mut ra: Isaac64Rng = SeedableRng::from_seed(&*s);
+        let mut rb: Isaac64Rng = SeedableRng::from_seed(&*s);
         assert!(order::equals(ra.gen_ascii_chars().take(100),
                               rb.gen_ascii_chars().take(100)));
     }
@@ -548,10 +548,10 @@ mod test {
     #[test]
     fn test_rng_32_reseed() {
         let s = ::test::rng().gen_iter::<u32>().take(256).collect::<Vec<u32>>();
-        let mut r: IsaacRng = SeedableRng::from_seed(s.as_slice());
+        let mut r: IsaacRng = SeedableRng::from_seed(&*s);
         let string1: String = r.gen_ascii_chars().take(100).collect();
 
-        r.reseed(s.as_slice());
+        r.reseed(&s);
 
         let string2: String = r.gen_ascii_chars().take(100).collect();
         assert_eq!(string1, string2);
@@ -559,10 +559,10 @@ mod test {
     #[test]
     fn test_rng_64_reseed() {
         let s = ::test::rng().gen_iter::<u64>().take(256).collect::<Vec<u64>>();
-        let mut r: Isaac64Rng = SeedableRng::from_seed(s.as_slice());
+        let mut r: Isaac64Rng = SeedableRng::from_seed(&*s);
         let string1: String = r.gen_ascii_chars().take(100).collect();
 
-        r.reseed(s.as_slice());
+        r.reseed(&s);
 
         let string2: String = r.gen_ascii_chars().take(100).collect();
         assert_eq!(string1, string2);

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -504,6 +504,7 @@ mod std {
     pub use core::marker;
     // for-loops
     pub use core::iter;
+    pub use core::ops; // slicing syntax
 }
 
 #[cfg(test)]

--- a/src/librand/reseeding.rs
+++ b/src/librand/reseeding.rs
@@ -216,7 +216,7 @@ mod test {
     #[test]
     fn test_rng_fill_bytes() {
         let mut v = repeat(0u8).take(FILL_BYTES_V_LEN).collect::<Vec<_>>();
-        ::test::rng().fill_bytes(v.as_mut_slice());
+        ::test::rng().fill_bytes(&mut v);
 
         // Sanity test: if we've gotten here, `fill_bytes` has not infinitely
         // recursed.

--- a/src/librbml/io.rs
+++ b/src/librbml/io.rs
@@ -71,7 +71,7 @@ impl SeekableMemWriter {
     /// No method is exposed for acquiring a mutable reference to the buffer
     /// because it could corrupt the state of this `MemWriter`.
     #[inline]
-    pub fn get_ref<'a>(&'a self) -> &'a [u8] { self.buf.as_slice() }
+    pub fn get_ref<'a>(&'a self) -> &'a [u8] { &self.buf }
 
     /// Unwraps this `SeekableMemWriter`, returning the underlying buffer
     #[inline]
@@ -190,7 +190,7 @@ mod tests {
         b.iter(|| {
             let mut wr = SeekableMemWriter::new();
             for _ in 0..times {
-                wr.write(src.as_slice()).unwrap();
+                wr.write(&src).unwrap();
             }
 
             let v = wr.unwrap();

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -1194,7 +1194,7 @@ mod bench {
         b.iter(|| {
             let mut i = 0;
             while i < data.len() {
-                sum += reader::vuint_at(data.as_slice(), i).unwrap().val;
+                sum += reader::vuint_at(&data, i).unwrap().val;
                 i += 4;
             }
         });
@@ -1212,7 +1212,7 @@ mod bench {
         b.iter(|| {
             let mut i = 1;
             while i < data.len() {
-                sum += reader::vuint_at(data.as_slice(), i).unwrap().val;
+                sum += reader::vuint_at(&data, i).unwrap().val;
                 i += 4;
             }
         });
@@ -1231,7 +1231,7 @@ mod bench {
         b.iter(|| {
             let mut i = 0;
             while i < data.len() {
-                sum += reader::vuint_at(data.as_slice(), i).unwrap().val;
+                sum += reader::vuint_at(&data, i).unwrap().val;
                 i += 4;
             }
         });
@@ -1250,7 +1250,7 @@ mod bench {
         b.iter(|| {
             let mut i = 1;
             while i < data.len() {
-                sum += reader::vuint_at(data.as_slice(), i).unwrap().val;
+                sum += reader::vuint_at(&data, i).unwrap().val;
                 i += 4;
             }
         });

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -1082,12 +1082,12 @@ impl NonUpperCaseGlobals {
                                            .map(|c| c.to_uppercase()).collect();
             if uc != s.get() {
                 cx.span_lint(NON_UPPER_CASE_GLOBALS, span,
-                    format!("{} `{}` should have an upper case name such as `{}`",
-                            sort, s, uc).as_slice());
+                    &format!("{} `{}` should have an upper case name such as `{}`",
+                             sort, s, uc));
             } else {
                 cx.span_lint(NON_UPPER_CASE_GLOBALS, span,
-                    format!("{} `{}` should have an upper case name",
-                            sort, s).as_slice());
+                    &format!("{} `{}` should have an upper case name",
+                             sort, s));
             }
         }
     }
@@ -2084,11 +2084,11 @@ impl LintPass for PrivateNoMangleFns {
     fn check_item(&mut self, cx: &Context, it: &ast::Item) {
         match it.node {
             ast::ItemFn(..) => {
-                if attr::contains_name(it.attrs.as_slice(), "no_mangle") &&
+                if attr::contains_name(&it.attrs, "no_mangle") &&
                        !cx.exported_items.contains(&it.id) {
                     let msg = format!("function {} is marked #[no_mangle], but not exported",
                                       it.ident);
-                    cx.span_lint(PRIVATE_NO_MANGLE_FNS, it.span, msg.as_slice());
+                    cx.span_lint(PRIVATE_NO_MANGLE_FNS, it.span, &msg);
                 }
             },
             _ => {},

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -509,8 +509,8 @@ impl<'a, 'tcx> Context<'a, 'tcx> {
                                                       .collect(),
                                 None => {
                                     self.span_lint(builtin::UNKNOWN_LINTS, span,
-                                               format!("unknown `{}` attribute: `{}`",
-                                                       level.as_str(), lint_name).as_slice());
+                                                   &format!("unknown `{}` attribute: `{}`",
+                                                            level.as_str(), lint_name));
                                     continue;
                                 }
                             }
@@ -797,8 +797,8 @@ pub fn check_crate(tcx: &ty::ctxt,
     for (id, v) in &*tcx.sess.lints.borrow() {
         for &(lint, span, ref msg) in v {
             tcx.sess.span_bug(span,
-                              format!("unprocessed lint {} at {}: {}",
-                                      lint.as_str(), tcx.map.node_to_string(*id), *msg).as_slice())
+                              &format!("unprocessed lint {} at {}: {}",
+                                       lint.as_str(), tcx.map.node_to_string(*id), *msg))
         }
     }
 

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -93,7 +93,7 @@ pub fn get_item_path(tcx: &ty::ctxt, def: ast::DefId) -> Vec<ast_map::PathElem> 
     // FIXME #1920: This path is not always correct if the crate is not linked
     // into the root namespace.
     let mut r = vec![ast_map::PathMod(token::intern(&cdata.name[]))];
-    r.push_all(path.as_slice());
+    r.push_all(&path);
     r
 }
 

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1044,7 +1044,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         encode_bounds_and_type(rbml_w, ecx, &lookup_item_type(tcx, def_id));
         encode_name(rbml_w, item.ident.name);
         encode_path(rbml_w, path);
-        encode_attributes(rbml_w, item.attrs.as_slice());
+        encode_attributes(rbml_w, &item.attrs);
         encode_inlined_item(ecx, rbml_w, IIItemRef(item));
         encode_visibility(rbml_w, vis);
         encode_stability(rbml_w, stab);
@@ -1307,7 +1307,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
         let trait_def = ty::lookup_trait_def(tcx, def_id);
         encode_unsafety(rbml_w, trait_def.unsafety);
         encode_paren_sugar(rbml_w, trait_def.paren_sugar);
-        encode_associated_type_names(rbml_w, trait_def.associated_type_names.as_slice());
+        encode_associated_type_names(rbml_w, &trait_def.associated_type_names);
         encode_generics(rbml_w, ecx, &trait_def.generics, tag_item_generics);
         encode_trait_ref(rbml_w, ecx, &*trait_def.trait_ref, tag_item_trait_ref);
         encode_name(rbml_w, item.ident.name);

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -394,8 +394,8 @@ impl<'a> Context<'a> {
                     file.ends_with(".rlib") {
                 (&file[(rlib_prefix.len()) .. (file.len() - ".rlib".len())],
                  true)
-            } else if file.starts_with(dylib_prefix.as_slice()) &&
-                      file.ends_with(dypair.1.as_slice()) {
+            } else if file.starts_with(&dylib_prefix) &&
+                      file.ends_with(&dypair.1) {
                 (&file[(dylib_prefix.len()) .. (file.len() - dypair.1.len())],
                  false)
             } else {

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -555,7 +555,7 @@ fn parse_ty_<'a, 'tcx, F>(st: &mut PState<'a, 'tcx>, conv: &mut F) -> Ty<'tcx> w
       'P' => {
           assert_eq!(next(st), '[');
           let trait_ref = parse_trait_ref_(st, conv);
-          let name = token::intern(parse_str(st, ']').as_slice());
+          let name = token::intern(&parse_str(st, ']'));
           return ty::mk_projection(tcx, trait_ref, name);
       }
       'e' => {
@@ -781,7 +781,7 @@ fn parse_projection_predicate_<'a,'tcx, F>(
     ty::ProjectionPredicate {
         projection_ty: ty::ProjectionTy {
             trait_ref: parse_trait_ref_(st, conv),
-            item_name: token::str_to_ident(parse_str(st, '|').as_slice()).name,
+            item_name: token::str_to_ident(&parse_str(st, '|')).name,
         },
         ty: parse_ty_(st, conv),
     }

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -1185,7 +1185,7 @@ fn encode_side_tables_for_id(ecx: &e::EncodeContext,
         rbml_w.tag(c::tag_table_freevars, |rbml_w| {
             rbml_w.id(id);
             rbml_w.tag(c::tag_table_val, |rbml_w| {
-                rbml_w.emit_from_vec(fv.as_slice(), |rbml_w, fv_entry| {
+                rbml_w.emit_from_vec(fv, |rbml_w, fv_entry| {
                     Ok(encode_freevar_entry(rbml_w, fv_entry))
                 });
             })

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -310,7 +310,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
             Entry => on_entry,
             Exit => {
                 let mut t = on_entry.to_vec();
-                self.apply_gen_kill(cfgidx, t.as_mut_slice());
+                self.apply_gen_kill(cfgidx, &mut t);
                 temp_bits = t;
                 &temp_bits[]
             }
@@ -405,7 +405,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
                     Some(cfg_idx) => {
                         let (start, end) = self.compute_id_range(cfg_idx);
                         let kills = &self.kills[start.. end];
-                        if bitwise(orig_kills.as_mut_slice(), kills, &Union) {
+                        if bitwise(&mut orig_kills, kills, &Union) {
                             changed = true;
                         }
                     }
@@ -450,8 +450,8 @@ impl<'a, 'tcx, O:DataFlowOperator+Clone+'static> DataFlowContext<'a, 'tcx, O> {
             let mut temp: Vec<_> = repeat(0).take(words_per_id).collect();
             while propcx.changed {
                 propcx.changed = false;
-                propcx.reset(temp.as_mut_slice());
-                propcx.walk_cfg(cfg, temp.as_mut_slice());
+                propcx.reset(&mut temp);
+                propcx.walk_cfg(cfg, &mut temp);
             }
         }
 

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -287,7 +287,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for MarkSymbolVisitor<'a, 'tcx> {
         let def_map = &self.tcx.def_map;
         match pat.node {
             ast::PatStruct(_, ref fields, _) => {
-                self.handle_field_pattern_match(pat, fields.as_slice());
+                self.handle_field_pattern_match(pat, fields);
             }
             _ if pat_util::pat_is_const(def_map, pat) => {
                 // it might be the only use of a const
@@ -313,7 +313,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for MarkSymbolVisitor<'a, 'tcx> {
 }
 
 fn has_allow_dead_code_or_lang_attr(attrs: &[ast::Attribute]) -> bool {
-    if attr::contains_name(attrs.as_slice(), "lang") {
+    if attr::contains_name(attrs, "lang") {
         return true;
     }
 
@@ -347,7 +347,7 @@ struct LifeSeeder {
 
 impl<'v> Visitor<'v> for LifeSeeder {
     fn visit_item(&mut self, item: &ast::Item) {
-        let allow_dead_code = has_allow_dead_code_or_lang_attr(item.attrs.as_slice());
+        let allow_dead_code = has_allow_dead_code_or_lang_attr(&item.attrs);
         if allow_dead_code {
             self.worklist.push(item.id);
         }
@@ -376,7 +376,7 @@ impl<'v> Visitor<'v> for LifeSeeder {
         // Check for method here because methods are not ast::Item
         match fk {
             visit::FkMethod(_, _, method) => {
-                if has_allow_dead_code_or_lang_attr(method.attrs.as_slice()) {
+                if has_allow_dead_code_or_lang_attr(&method.attrs) {
                     self.worklist.push(id);
                 }
             }
@@ -467,12 +467,12 @@ impl<'a, 'tcx> DeadVisitor<'a, 'tcx> {
         is_named
             && !self.symbol_is_live(node.id, None)
             && !is_marker_field
-            && !has_allow_dead_code_or_lang_attr(node.attrs.as_slice())
+            && !has_allow_dead_code_or_lang_attr(&node.attrs)
     }
 
     fn should_warn_about_variant(&mut self, variant: &ast::Variant_) -> bool {
         !self.symbol_is_live(variant.id, None)
-            && !has_allow_dead_code_or_lang_attr(variant.attrs.as_slice())
+            && !has_allow_dead_code_or_lang_attr(&variant.attrs)
     }
 
     // id := node id of an item's definition.

--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -56,7 +56,7 @@ pub fn find_entry_point(session: &Session, ast_map: &ast_map::Map) {
     }
 
     // If the user wants no main function at all, then stop here.
-    if attr::contains_name(ast_map.krate().attrs.as_slice(), "no_main") {
+    if attr::contains_name(&ast_map.krate().attrs, "no_main") {
         session.entry_type.set(Some(config::EntryNone));
         return
     }
@@ -96,7 +96,7 @@ fn find_item(item: &Item, ctxt: &mut EntryContext) {
                 });
             }
 
-            if attr::contains_name(item.attrs.as_slice(), "main") {
+            if attr::contains_name(&item.attrs, "main") {
                 if ctxt.attr_main_fn.is_none() {
                     ctxt.attr_main_fn = Some((item.id, item.span));
                 } else {
@@ -105,7 +105,7 @@ fn find_item(item: &Item, ctxt: &mut EntryContext) {
                 }
             }
 
-            if attr::contains_name(item.attrs.as_slice(), "start") {
+            if attr::contains_name(&item.attrs, "start") {
                 if ctxt.start_fn.is_none() {
                     ctxt.start_fn = Some((item.id, item.span));
                 } else {

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -639,8 +639,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                         None => {
                             self.tcx().sess.span_bug(
                                 callee.span,
-                                format!("unexpected callee type {}",
-                                        callee_ty.repr(self.tcx())).as_slice())
+                                &format!("unexpected callee type {}", callee_ty.repr(self.tcx())))
                         }
                     };
                 match overloaded_call_type {
@@ -1150,7 +1149,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                                 let msg = format!("Pattern has unexpected type: {:?} and type {}",
                                                   def,
                                                   cmt_pat.ty.repr(tcx));
-                                tcx.sess.span_bug(pat.span, msg.as_slice())
+                                tcx.sess.span_bug(pat.span, &msg)
                             }
                         }
 

--- a/src/librustc/middle/graph.rs
+++ b/src/librustc/middle/graph.rs
@@ -112,14 +112,12 @@ impl<N,E> Graph<N,E> {
 
     #[inline]
     pub fn all_nodes<'a>(&'a self) -> &'a [Node<N>] {
-        let nodes: &'a [Node<N>] = self.nodes.as_slice();
-        nodes
+        &self.nodes
     }
 
     #[inline]
     pub fn all_edges<'a>(&'a self) -> &'a [Edge<E>] {
-        let edges: &'a [Edge<E>] = self.edges.as_slice();
-        edges
+        &self.edges
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/librustc/middle/infer/combine.rs
+++ b/src/librustc/middle/infer/combine.rs
@@ -208,8 +208,8 @@ pub trait Combine<'tcx> : Sized {
         }
 
         let inputs = try!(argvecs(self,
-                                  a.inputs.as_slice(),
-                                  b.inputs.as_slice()));
+                                  &a.inputs,
+                                  &b.inputs));
 
         let output = try!(match (a.output, b.output) {
             (ty::FnConverging(a_ty), ty::FnConverging(b_ty)) =>

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -1707,7 +1707,7 @@ fn lifetimes_in_scope(tcx: &ty::ctxt,
             Some(node) => match node {
                 ast_map::NodeItem(item) => match item.node {
                     ast::ItemImpl(_, _, ref gen, _, _, _) => {
-                        taken.push_all(gen.lifetimes.as_slice());
+                        taken.push_all(&gen.lifetimes);
                     }
                     _ => ()
                 },

--- a/src/librustc/middle/infer/freshen.rs
+++ b/src/librustc/middle/infer/freshen.rs
@@ -127,10 +127,10 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
             ty::ty_infer(ty::FreshIntTy(c)) => {
                 if c >= self.freshen_count {
                     self.tcx().sess.bug(
-                        format!("Encountered a freshend type with id {} \
-                                 but our counter is only at {}",
-                                c,
-                                self.freshen_count).as_slice());
+                        &format!("Encountered a freshend type with id {} \
+                                  but our counter is only at {}",
+                                 c,
+                                 self.freshen_count));
                 }
                 t
             }

--- a/src/librustc/middle/infer/higher_ranked/mod.rs
+++ b/src/librustc/middle/infer/higher_ranked/mod.rs
@@ -133,7 +133,7 @@ impl<'tcx,C> HigherRankedRelations<'tcx> for C
                     self.tcx(),
                     &result0,
                     |r, debruijn| generalize_region(self.infcx(), span, snapshot, debruijn,
-                                                    new_vars.as_slice(), &a_map, r));
+                                                    &new_vars, &a_map, r));
 
             debug!("lub({},{}) = {}",
                    a.repr(self.tcx()),
@@ -227,8 +227,8 @@ impl<'tcx,C> HigherRankedRelations<'tcx> for C
                     self.tcx(),
                     &result0,
                     |r, debruijn| generalize_region(self.infcx(), span, snapshot, debruijn,
-                                                    new_vars.as_slice(),
-                                                    &a_map, a_vars.as_slice(), b_vars.as_slice(),
+                                                    &new_vars,
+                                                    &a_map, &a_vars, &b_vars,
                                                     r));
 
             debug!("glb({},{}) = {}",

--- a/src/librustc/middle/infer/region_inference/graphviz.rs
+++ b/src/librustc/middle/infer/region_inference/graphviz.rs
@@ -71,7 +71,7 @@ pub fn maybe_print_constraints_for<'a, 'tcx>(region_vars: &RegionVarBindings<'a,
 
     let output_path = {
         let output_template = match requested_output {
-            Some(ref s) if s.as_slice() == "help" => {
+            Some(ref s) if &**s == "help" => {
                 static PRINTED_YET: AtomicBool = ATOMIC_BOOL_INIT;
                 if !PRINTED_YET.load(Ordering::SeqCst) {
                     print_help_message();
@@ -92,7 +92,7 @@ pub fn maybe_print_constraints_for<'a, 'tcx>(region_vars: &RegionVarBindings<'a,
             let mut new_str = String::new();
             for c in output_template.chars() {
                 if c == '%' {
-                    new_str.push_str(subject_node.to_string().as_slice());
+                    new_str.push_str(&subject_node.to_string());
                 } else {
                     new_str.push(c);
                 }
@@ -104,11 +104,11 @@ pub fn maybe_print_constraints_for<'a, 'tcx>(region_vars: &RegionVarBindings<'a,
     };
 
     let constraints = &*region_vars.constraints.borrow();
-    match dump_region_constraints_to(tcx, constraints, output_path.as_slice()) {
+    match dump_region_constraints_to(tcx, constraints, &output_path) {
         Ok(()) => {}
         Err(e) => {
             let msg = format!("io error dumping region constraints: {}", e);
-            region_vars.tcx.sess.err(msg.as_slice())
+            region_vars.tcx.sess.err(&msg)
         }
     }
 }
@@ -157,7 +157,7 @@ impl<'a, 'tcx> ConstraintGraph<'a, 'tcx> {
 
 impl<'a, 'tcx> dot::Labeller<'a, Node, Edge> for ConstraintGraph<'a, 'tcx> {
     fn graph_id(&self) -> dot::Id {
-        dot::Id::new(self.graph_name.as_slice()).ok().unwrap()
+        dot::Id::new(&*self.graph_name).ok().unwrap()
     }
     fn node_id(&self, n: &Node) -> dot::Id {
         dot::Id::new(format!("node_{}", self.node_ids.get(n).unwrap())).ok().unwrap()

--- a/src/librustc/middle/infer/region_inference/mod.rs
+++ b/src/librustc/middle/infer/region_inference/mod.rs
@@ -973,8 +973,8 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
         debug!("----() End constraint listing {:?}---", self.dump_constraints());
         graphviz::maybe_print_constraints_for(self, subject);
 
-        self.expansion(var_data.as_mut_slice());
-        self.contraction(var_data.as_mut_slice());
+        self.expansion(&mut var_data);
+        self.contraction(&mut var_data);
         let values =
             self.extract_values_and_collect_conflicts(&var_data[],
                                                       errors);
@@ -1303,12 +1303,12 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
                     match var_data[idx].classification {
                         Expanding => {
                             self.collect_error_for_expanding_node(
-                                graph, var_data, dup_vec.as_mut_slice(),
+                                graph, var_data, &mut dup_vec,
                                 node_vid, errors);
                         }
                         Contracting => {
                             self.collect_error_for_contracting_node(
-                                graph, var_data, dup_vec.as_mut_slice(),
+                                graph, var_data, &mut dup_vec,
                                 node_vid, errors);
                         }
                     }

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -147,7 +147,7 @@ struct LanguageItemCollector<'a> {
 
 impl<'a, 'v> Visitor<'v> for LanguageItemCollector<'a> {
     fn visit_item(&mut self, item: &ast::Item) {
-        match extract(item.attrs.as_slice()) {
+        match extract(&item.attrs) {
             Some(value) => {
                 let item_index = self.item_refs.get(value.get()).map(|x| *x);
 

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -456,13 +456,13 @@ impl<'a> LifetimeContext<'a> {
                     if let Some((_, lifetime_def)) = search_lifetimes(lifetimes, lifetime) {
                         self.sess.span_warn(
                             lifetime.span,
-                            format!("lifetime name `{}` shadows another \
-                                    lifetime name that is already in scope",
-                                    token::get_name(lifetime.name)).as_slice());
+                            &format!("lifetime name `{}` shadows another \
+                                     lifetime name that is already in scope",
+                                     token::get_name(lifetime.name)));
                         self.sess.span_note(
                             lifetime_def.span,
-                            format!("shadowed lifetime `{}` declared here",
-                                    token::get_name(lifetime.name)).as_slice());
+                            &format!("shadowed lifetime `{}` declared here",
+                                     token::get_name(lifetime.name)));
                         self.sess.span_note(
                             lifetime.span,
                             "shadowed lifetimes are deprecated \

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -57,7 +57,7 @@ impl<'a> Annotator<'a> {
                    attrs: &Vec<Attribute>, item_sp: Span, f: F, required: bool) where
         F: FnOnce(&mut Annotator),
     {
-        match attr::find_stability(self.sess.diagnostic(), attrs.as_slice(), item_sp) {
+        match attr::find_stability(self.sess.diagnostic(), attrs, item_sp) {
             Some(stab) => {
                 self.index.local.insert(id, stab.clone());
 

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -406,7 +406,7 @@ impl<T> VecPerParamSpace<T> {
     }
 
     pub fn as_slice(&self) -> &[T] {
-        self.content.as_slice()
+        &self.content
     }
 
     pub fn into_vec(self) -> Vec<T> {

--- a/src/librustc/middle/traits/doc.rs
+++ b/src/librustc/middle/traits/doc.rs
@@ -24,7 +24,7 @@ reference to a trait. So, for example, if there is a generic function like:
 
 and then a call to that function:
 
-    let v: Vec<int> = clone_slice([1, 2, 3].as_slice())
+    let v: Vec<int> = clone_slice([1, 2, 3])
 
 it is the job of trait resolution to figure out (in which case)
 whether there exists an impl of `int : Clone`

--- a/src/librustc/middle/traits/error_reporting.rs
+++ b/src/librustc/middle/traits/error_reporting.rs
@@ -93,7 +93,7 @@ fn report_on_unimplemented<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
                         Piece::String(s) => Some(s),
                         Piece::NextArgument(a) => match a.position {
                             Position::ArgumentNamed(s) => match generic_map.get(s) {
-                                Some(val) => Some(val.as_slice()),
+                                Some(val) => Some(val),
                                 None => {
                                     span_err!(infcx.tcx.sess, err_sp, E0272,
                                                    "the #[rustc_on_unimplemented] \
@@ -181,7 +181,7 @@ pub fn report_selection_error<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
                                                                           obligation.cause.span);
                                 if let Some(s) = custom_note {
                                     infcx.tcx.sess.span_note(obligation.cause.span,
-                                                             s.as_slice());
+                                                             &s);
                                 }
                             }
                         }
@@ -289,12 +289,12 @@ pub fn maybe_report_ambiguity<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
                 // Ambiguity. Coherence should have reported an error.
                 infcx.tcx.sess.span_bug(
                     obligation.cause.span,
-                    format!(
+                    &format!(
                         "coherence failed to report ambiguity: \
                          cannot locate the impl of the trait `{}` for \
                          the type `{}`",
                         trait_ref.user_string(infcx.tcx),
-                        self_ty.user_string(infcx.tcx)).as_slice());
+                        self_ty.user_string(infcx.tcx)));
             }
         }
 
@@ -330,14 +330,14 @@ fn note_obligation_cause_code<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
             let item_name = ty::item_path_str(tcx, item_def_id);
             tcx.sess.span_note(
                 cause_span,
-                format!("required by `{}`", item_name).as_slice());
+                &format!("required by `{}`", item_name));
         }
         ObligationCauseCode::ObjectCastObligation(object_ty) => {
             tcx.sess.span_note(
                 cause_span,
-                format!(
+                &format!(
                     "required for the cast to the object type `{}`",
-                    infcx.ty_to_string(object_ty)).as_slice());
+                    infcx.ty_to_string(object_ty)));
         }
         ObligationCauseCode::RepeatVec => {
             tcx.sess.span_note(

--- a/src/librustc/middle/traits/fulfill.rs
+++ b/src/librustc/middle/traits/fulfill.rs
@@ -180,7 +180,7 @@ impl<'tcx> FulfillmentContext<'tcx> {
     {
         match self.region_obligations.get(&body_id) {
             None => Default::default(),
-            Some(vec) => vec.as_slice(),
+            Some(vec) => vec,
         }
     }
 

--- a/src/librustc/middle/traits/project.rs
+++ b/src/librustc/middle/traits/project.rs
@@ -605,8 +605,8 @@ fn assemble_candidates_from_object_type<'cx,'tcx>(
         _ => {
             selcx.tcx().sess.span_bug(
                 obligation.cause.span,
-                format!("assemble_candidates_from_object_type called with non-object: {}",
-                        object_ty.repr(selcx.tcx())).as_slice());
+                &format!("assemble_candidates_from_object_type called with non-object: {}",
+                         object_ty.repr(selcx.tcx())));
         }
     };
     let projection_bounds = data.projection_bounds_with_self_ty(selcx.tcx(), object_ty);
@@ -693,8 +693,8 @@ fn assemble_candidates_from_impls<'cx,'tcx>(
             // These traits have no associated types.
             selcx.tcx().sess.span_bug(
                 obligation.cause.span,
-                format!("Cannot project an associated type from `{}`",
-                        vtable.repr(selcx.tcx())).as_slice());
+                &format!("Cannot project an associated type from `{}`",
+                         vtable.repr(selcx.tcx())));
         }
     }
 
@@ -813,10 +813,10 @@ fn confirm_param_env_candidate<'cx,'tcx>(
         Err(e) => {
             selcx.tcx().sess.span_bug(
                 obligation.cause.span,
-                format!("Failed to unify `{}` and `{}` in projection: {}",
-                        obligation.repr(selcx.tcx()),
-                        projection.repr(selcx.tcx()),
-                        ty::type_err_to_str(selcx.tcx(), &e)).as_slice());
+                &format!("Failed to unify `{}` and `{}` in projection: {}",
+                         obligation.repr(selcx.tcx()),
+                         projection.repr(selcx.tcx()),
+                         ty::type_err_to_str(selcx.tcx(), &e)));
         }
     }
 

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -933,9 +933,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             _ => {
                 self.tcx().sess.span_bug(
                     obligation.cause.span,
-                    format!("match_projection_obligation_against_bounds_from_trait() called \
-                             but self-ty not a projection: {}",
-                            skol_trait_predicate.trait_ref.self_ty().repr(self.tcx())).as_slice());
+                    &format!("match_projection_obligation_against_bounds_from_trait() called \
+                              but self-ty not a projection: {}",
+                             skol_trait_predicate.trait_ref.self_ty().repr(self.tcx())));
             }
         };
         debug!("match_projection_obligation_against_bounds_from_trait: \
@@ -1787,9 +1787,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             Ok(obligations) => obligations,
             Err(()) => {
                 self.tcx().sess.bug(
-                    format!("Where clause `{}` was applicable to `{}` but now is not",
-                            param.repr(self.tcx()),
-                            obligation.repr(self.tcx())).as_slice());
+                    &format!("Where clause `{}` was applicable to `{}` but now is not",
+                             param.repr(self.tcx()),
+                             obligation.repr(self.tcx())));
             }
         }
     }
@@ -1953,9 +1953,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             Some(r) => r,
             None => {
                 self.tcx().sess.span_bug(obligation.cause.span,
-                                         format!("unable to upcast from {} to {}",
-                                                 poly_trait_ref.repr(self.tcx()),
-                                                 obligation_def_id.repr(self.tcx())).as_slice());
+                                         &format!("unable to upcast from {} to {}",
+                                                  poly_trait_ref.repr(self.tcx()),
+                                                  obligation_def_id.repr(self.tcx())));
             }
         };
 

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -279,7 +279,7 @@ pub fn trait_ref_for_builtin_bound<'tcx>(
             }))
         }
         Err(e) => {
-            tcx.sess.err(e.as_slice());
+            tcx.sess.err(&e);
             Err(ErrorReported)
         }
     }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2793,7 +2793,7 @@ pub fn mk_trait<'tcx>(cx: &ctxt<'tcx>,
                       bounds: ExistentialBounds<'tcx>)
                       -> Ty<'tcx>
 {
-    assert!(bound_list_is_sorted(bounds.projection_bounds.as_slice()));
+    assert!(bound_list_is_sorted(&bounds.projection_bounds));
 
     let inner = box TyTrait {
         principal: principal,
@@ -3406,8 +3406,8 @@ pub fn type_contents<'tcx>(cx: &ctxt<'tcx>, ty: Ty<'tcx>) -> TypeContents {
                 // FIXME(#14449): `borrowed_contents` below assumes `&mut` closure.
                 let param_env = ty::empty_parameter_environment(cx);
                 let upvars = closure_upvars(&param_env, did, substs).unwrap();
-                TypeContents::union(upvars.as_slice(),
-                                    |f| tc_ty(cx, f.ty, cache))
+                TypeContents::union(&upvars,
+                                    |f| tc_ty(cx, &f.ty, cache))
                     | borrowed_contents(*r, MutMutable)
             }
 
@@ -3672,8 +3672,7 @@ pub fn is_instantiable<'tcx>(cx: &ctxt<'tcx>, r_ty: Ty<'tcx>) -> bool {
             ty_closure(..) => {
                 // this check is run on type definitions, so we don't expect to see
                 // inference by-products or closure types
-                cx.sess.bug(format!("requires check invoked on inapplicable type: {:?}",
-                                    ty).as_slice())
+                cx.sess.bug(&format!("requires check invoked on inapplicable type: {:?}", ty))
             }
 
             ty_tup(ref ts) => {
@@ -3766,8 +3765,7 @@ pub fn is_type_representable<'tcx>(cx: &ctxt<'tcx>, sp: Span, ty: Ty<'tcx>)
             ty_closure(..) => {
                 // this check is run on type definitions, so we don't expect
                 // to see closure types
-                cx.sess.bug(format!("requires check invoked on inapplicable type: {:?}",
-                                    ty).as_slice())
+                cx.sess.bug(&format!("requires check invoked on inapplicable type: {:?}", ty))
             }
             _ => Representable,
         }
@@ -6365,9 +6363,9 @@ pub fn construct_parameter_environment<'a,'tcx>(
                         _ => {
                             // All named regions are instantiated with free regions.
                             tcx.sess.bug(
-                                format!("record_region_bounds: non free region: {} / {}",
-                                        r_a.repr(tcx),
-                                        r_b.repr(tcx)).as_slice());
+                                &format!("record_region_bounds: non free region: {} / {}",
+                                         r_a.repr(tcx),
+                                         r_b.repr(tcx)));
                         }
                     }
                 }

--- a/src/librustc/middle/ty_walk.rs
+++ b/src/librustc/middle/ty_walk.rs
@@ -39,9 +39,9 @@ impl<'tcx> TypeWalker<'tcx> {
             }
             ty::ty_trait(box ty::TyTrait { ref principal, ref bounds }) => {
                 self.push_reversed(principal.substs().types.as_slice());
-                self.push_reversed(bounds.projection_bounds.iter().map(|pred| {
+                self.push_reversed(&bounds.projection_bounds.iter().map(|pred| {
                     pred.0.ty
-                }).collect::<Vec<_>>().as_slice());
+                }).collect::<Vec<_>>());
             }
             ty::ty_enum(_, ref substs) |
             ty::ty_struct(_, ref substs) |
@@ -49,7 +49,7 @@ impl<'tcx> TypeWalker<'tcx> {
                 self.push_reversed(substs.types.as_slice());
             }
             ty::ty_tup(ref ts) => {
-                self.push_reversed(ts.as_slice());
+                self.push_reversed(ts);
             }
             ty::ty_bare_fn(_, ref ft) => {
                 self.push_sig_subtypes(&ft.sig);
@@ -62,7 +62,7 @@ impl<'tcx> TypeWalker<'tcx> {
             ty::FnConverging(output) => { self.stack.push(output); }
             ty::FnDiverging => { }
         }
-        self.push_reversed(sig.0.inputs.as_slice());
+        self.push_reversed(&sig.0.inputs);
     }
 
     fn push_reversed(&mut self, tys: &[Ty<'tcx>]) {

--- a/src/librustc/middle/weak_lang_items.rs
+++ b/src/librustc/middle/weak_lang_items.rs
@@ -85,8 +85,8 @@ fn verify(sess: &Session, items: &lang_items::LanguageItems) {
 
     $(
         if missing.contains(&lang_items::$item) && items.$name().is_none() {
-            sess.err(format!("language item required, but not found: `{}`",
-                             stringify!($name)).as_slice());
+            sess.err(&format!("language item required, but not found: `{}`",
+                              stringify!($name)));
 
         }
     )*
@@ -108,7 +108,7 @@ impl<'a> Context<'a> {
 
 impl<'a, 'v> Visitor<'v> for Context<'a> {
     fn visit_foreign_item(&mut self, i: &ast::ForeignItem) {
-        match lang_items::extract(i.attrs.as_slice()) {
+        match lang_items::extract(&i.attrs) {
             None => {}
             Some(lang_item) => self.register(lang_item.get(), i.span),
         }

--- a/src/librustc/plugin/build.rs
+++ b/src/librustc/plugin/build.rs
@@ -24,7 +24,7 @@ struct RegistrarFinder {
 impl<'v> Visitor<'v> for RegistrarFinder {
     fn visit_item(&mut self, item: &ast::Item) {
         if let ast::ItemFn(..) = item.node {
-            if attr::contains_name(item.attrs.as_slice(),
+            if attr::contains_name(&item.attrs,
                                    "plugin_registrar") {
                 self.registrars.push((item.id, item.span));
             }

--- a/src/librustc/plugin/load.rs
+++ b/src/librustc/plugin/load.rs
@@ -82,8 +82,8 @@ pub fn load_plugins(sess: &Session, krate: &ast::Crate,
     visit::walk_crate(&mut loader, krate);
 
     if let Some(plugins) = addl_plugins {
-        for plugin in &plugins {
-            loader.load_plugin(CrateOrString::Str(plugin.as_slice()),
+        for plugin in plugins {
+            loader.load_plugin(CrateOrString::Str(&plugin),
                                                   None, None, None)
         }
     }

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -638,7 +638,7 @@ pub fn build_target_config(opts: &Options, sp: &SpanHandler) -> Config {
     let target = match Target::search(&opts.target_triple[]) {
         Ok(t) => t,
         Err(e) => {
-            sp.handler().fatal((format!("Error loading target specification: {}", e)).as_slice());
+            sp.handler().fatal(&format!("Error loading target specification: {}", e));
     }
     };
 
@@ -856,7 +856,7 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         let unparsed_output_types = matches.opt_strs("emit");
         for unparsed_output_type in &unparsed_output_types {
             for part in unparsed_output_type.split(',') {
-                let output_type = match part.as_slice() {
+                let output_type = match part {
                     "asm" => OutputTypeAssembly,
                     "llvm-ir" => OutputTypeLlvmAssembly,
                     "llvm-bc" => OutputTypeBitcode,
@@ -897,9 +897,9 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
                 Some(2) => Default,
                 Some(3) => Aggressive,
                 Some(arg) => {
-                    early_error(format!("optimization level needs to be \
-                                         between 0-3 (instead was `{}`)",
-                                        arg).as_slice());
+                    early_error(&format!("optimization level needs to be \
+                                          between 0-3 (instead was `{}`)",
+                                         arg));
                 }
             }
         }
@@ -916,9 +916,9 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
             Some(1) => LimitedDebugInfo,
             Some(2) => FullDebugInfo,
             Some(arg) => {
-                early_error(format!("debug info level needs to be between \
-                                     0-2 (instead was `{}`)",
-                                    arg).as_slice());
+                early_error(&format!("debug info level needs to be between \
+                                      0-2 (instead was `{}`)",
+                                     arg));
             }
         }
     };
@@ -937,9 +937,9 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
                 "framework" => cstore::NativeFramework,
                 "static" => cstore::NativeStatic,
                 s => {
-                    early_error(format!("unknown library kind `{}`, expected \
-                                         one of dylib, framework, or static",
-                                        s).as_slice());
+                    early_error(&format!("unknown library kind `{}`, expected \
+                                          one of dylib, framework, or static",
+                                         s));
                 }
             };
             return (name.to_string(), kind)
@@ -968,12 +968,12 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
     let write_dependency_info = (output_types.contains(&OutputTypeDepInfo), None);
 
     let prints = matches.opt_strs("print").into_iter().map(|s| {
-        match s.as_slice() {
+        match &*s {
             "crate-name" => PrintRequest::CrateName,
             "file-names" => PrintRequest::FileNames,
             "sysroot" => PrintRequest::Sysroot,
             req => {
-                early_error(format!("unknown print request `{}`", req).as_slice())
+                early_error(&format!("unknown print request `{}`", req))
             }
         }
     }).collect::<Vec<_>>();

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -332,7 +332,7 @@ pub fn build_session_(sopts: config::Options,
         Ok(t) => t,
         Err(e) => {
             span_diagnostic.handler()
-                .fatal((format!("Error loading host specification: {}", e)).as_slice());
+                .fatal(&format!("Error loading host specification: {}", e));
     }
     };
     let target_cfg = config::build_target_config(&sopts, &span_diagnostic);

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -116,7 +116,7 @@ pub fn explain_region_and_span(cx: &ctxt, region: ty::Region)
             region::CodeExtent::Remainder(r) => {
                 new_string = format!("block suffix following statement {}",
                                      r.first_statement_index);
-                new_string.as_slice()
+                &*new_string
             }
         };
         explain_span(cx, scope_decorated_tag, span)
@@ -263,7 +263,7 @@ pub fn ty_to_string<'tcx>(cx: &ctxt<'tcx>, typ: &ty::TyS<'tcx>) -> String {
         match unsafety {
             ast::Unsafety::Normal => {}
             ast::Unsafety::Unsafe => {
-                s.push_str(unsafety.to_string().as_slice());
+                s.push_str(&unsafety.to_string());
                 s.push(' ');
             }
         };
@@ -315,7 +315,7 @@ pub fn ty_to_string<'tcx>(cx: &ctxt<'tcx>, typ: &ty::TyS<'tcx>) -> String {
             .iter()
             .map(|a| ty_to_string(cx, *a))
             .collect::<Vec<_>>();
-        s.push_str(strs.connect(", ").as_slice());
+        s.push_str(&strs.connect(", "));
         if sig.0.variadic {
             s.push_str(", ...");
         }
@@ -392,7 +392,7 @@ pub fn ty_to_string<'tcx>(cx: &ctxt<'tcx>, typ: &ty::TyS<'tcx>) -> String {
         ty_enum(did, substs) | ty_struct(did, substs) => {
             let base = ty::item_path_str(cx, did);
             let generics = ty::lookup_item_type(cx, did).generics;
-            parameterized(cx, base.as_slice(), substs, &generics, did, &[])
+            parameterized(cx, &base, substs, &generics, did, &[])
         }
         ty_trait(ref data) => {
             data.user_string(cx)
@@ -643,7 +643,7 @@ impl<'tcx> UserString<'tcx> for TraitAndProjections<'tcx> {
         let base = ty::item_path_str(tcx, trait_ref.def_id);
         let trait_def = ty::lookup_trait_def(tcx, trait_ref.def_id);
         parameterized(tcx,
-                      base.as_slice(),
+                      &base,
                       trait_ref.substs,
                       &trait_def.generics,
                       trait_ref.def_id,
@@ -780,7 +780,7 @@ impl<'tcx> Repr<'tcx> for ty::TraitRef<'tcx> {
         let trait_def = ty::lookup_trait_def(tcx, self.def_id);
         format!("TraitRef({}, {})",
                 self.substs.self_ty().repr(tcx),
-                parameterized(tcx, base.as_slice(), self.substs,
+                parameterized(tcx, &base, self.substs,
                               &trait_def.generics, self.def_id, &[]))
     }
 }
@@ -1235,7 +1235,7 @@ impl<'tcx> UserString<'tcx> for ty::TraitRef<'tcx> {
     fn user_string(&self, tcx: &ctxt<'tcx>) -> String {
         let path_str = ty::item_path_str(tcx, self.def_id);
         let trait_def = ty::lookup_trait_def(tcx, self.def_id);
-        parameterized(tcx, path_str.as_slice(), self.substs,
+        parameterized(tcx, &path_str, self.substs,
                       &trait_def.generics, self.def_id, &[])
     }
 }

--- a/src/librustc_back/sha2.rs
+++ b/src/librustc_back/sha2.rs
@@ -259,7 +259,7 @@ pub trait Digest {
     /// newly allocated vec of bytes.
     fn result_bytes(&mut self) -> Vec<u8> {
         let mut buf: Vec<u8> = repeat(0u8).take((self.output_bits()+7)/8).collect();
-        self.result(buf.as_mut_slice());
+        self.result(&mut buf);
         buf
     }
 
@@ -560,7 +560,7 @@ mod tests {
         // Test that it works when accepting the message all at once
         for t in tests {
             sh.reset();
-            sh.input_str(t.input.as_slice());
+            sh.input_str(&t.input);
             let out_str = sh.result_str();
             assert!(out_str == t.output_str);
         }
@@ -606,7 +606,7 @@ mod tests {
 
         let mut sh = box Sha256::new();
 
-        test_hash(&mut *sh, tests.as_slice());
+        test_hash(&mut *sh, &tests);
     }
 
     /// Feed 1,000,000 'a's into the digest with varying input sizes and check that the result is
@@ -630,7 +630,7 @@ mod tests {
         let result_str = digest.result_str();
         let result_bytes = digest.result_bytes();
 
-        assert_eq!(expected, result_str.as_slice());
+        assert_eq!(expected, result_str);
 
         let expected_vec: Vec<u8> = expected.from_hex()
                                             .unwrap()

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -798,8 +798,8 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
             }
             mc::AliasableClosure(id) => {
                 self.tcx.sess.span_err(span,
-                                       format!("{} in a captured outer \
-                                               variable in an `Fn` closure", prefix).as_slice());
+                                       &format!("{} in a captured outer \
+                                                variable in an `Fn` closure", prefix));
                 if let BorrowViolation(euv::ClosureCapture(_)) = kind {
                     // The aliasability violation with closure captures can
                     // happen for nested closures, so we know the enclosing

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -350,7 +350,7 @@ pub fn phase_1_parse_input(sess: &Session, cfg: ast::CrateConfig, input: &Input)
     }
 
     if let Some(ref s) = sess.opts.show_span {
-        syntax::show_span::run(sess.diagnostic(), s.as_slice(), &krate);
+        syntax::show_span::run(sess.diagnostic(), s, &krate);
     }
 
     krate

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -93,7 +93,7 @@ pub mod driver;
 pub mod pretty;
 
 pub fn run(args: Vec<String>) -> int {
-    monitor(move || run_compiler(args.as_slice()));
+    monitor(move || run_compiler(&args));
     0
 }
 
@@ -165,7 +165,7 @@ fn run_compiler(args: &[String]) {
     let pretty = if sess.opts.debugging_opts.unstable_options {
         matches.opt_default("pretty", "normal").map(|a| {
             // stable pretty-print variants only
-            pretty::parse_pretty(&sess, a.as_slice(), false)
+            pretty::parse_pretty(&sess, &a, false)
         })
     } else {
         None
@@ -174,7 +174,7 @@ fn run_compiler(args: &[String]) {
         sess.unstable_options() {
             matches.opt_str("xpretty").map(|a| {
                 // extended with unstable pretty-print variants
-                pretty::parse_pretty(&sess, a.as_slice(), true)
+                pretty::parse_pretty(&sess, &a, true)
             })
         } else {
             pretty
@@ -313,7 +313,7 @@ Additional help:
     -C help             Print codegen options
     -W help             Print 'lint' options and default settings
     -Z help             Print internal options for debugging rustc{}\n",
-              getopts::usage(message.as_slice(), groups.as_slice()),
+              getopts::usage(&message, &groups),
               extra_help);
 }
 
@@ -481,20 +481,20 @@ pub fn handle_options(mut args: Vec<String>) -> Option<getopts::Matches> {
                 // unstable ones.
                 let all_groups : Vec<getopts::OptGroup>
                     = config::rustc_optgroups().into_iter().map(|x|x.opt_group).collect();
-                match getopts::getopts(args.as_slice(), all_groups.as_slice()) {
+                match getopts::getopts(&args, &all_groups) {
                     Ok(m_unstable) => {
                         let r = m_unstable.opt_strs("Z");
                         let include_unstable_options = r.iter().any(|x| *x == "unstable-options");
                         if include_unstable_options {
                             m_unstable
                         } else {
-                            early_error(f_stable_attempt.to_string().as_slice());
+                            early_error(&f_stable_attempt.to_string());
                         }
                     }
                     Err(_) => {
                         // ignore the error from the unstable attempt; just
                         // pass the error we got from the first try.
-                        early_error(f_stable_attempt.to_string().as_slice());
+                        early_error(&f_stable_attempt.to_string());
                     }
                 }
             }
@@ -552,13 +552,13 @@ fn print_crate_info(sess: &Session,
                     Some(input) => input,
                     None => early_error("no input file provided"),
                 };
-                let attrs = attrs.as_ref().unwrap().as_slice();
+                let attrs = attrs.as_ref().unwrap();
                 let t_outputs = driver::build_output_filenames(input,
                                                                odir,
                                                                ofile,
                                                                attrs,
                                                                sess);
-                let id = link::find_crate_name(Some(sess), attrs.as_slice(),
+                let id = link::find_crate_name(Some(sess), attrs,
                                                input);
                 if *req == PrintRequest::CrateName {
                     println!("{}", id);
@@ -569,7 +569,7 @@ fn print_crate_info(sess: &Session,
                 *sess.crate_metadata.borrow_mut() = metadata;
                 for &style in &crate_types {
                     let fname = link::filename_for_input(sess, style,
-                                                         id.as_slice(),
+                                                         &id,
                                                          &t_outputs.with_extension(""));
                     println!("{}", fname.filename_display());
                 }

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -87,15 +87,15 @@ pub fn parse_pretty(sess: &Session,
         ("flowgraph,unlabelled", true)    => PpmFlowGraph(PpFlowGraphMode::UnlabelledEdges),
         _ => {
             if extended {
-                sess.fatal(format!(
+                sess.fatal(&format!(
                     "argument to `xpretty` must be one of `normal`, \
                      `expanded`, `flowgraph[,unlabelled]=<nodeid>`, `typed`, `identified`, \
-                     `expanded,identified`, or `everybody_loops`; got {}", name).as_slice());
+                     `expanded,identified`, or `everybody_loops`; got {}", name));
             } else {
-                sess.fatal(format!(
+                sess.fatal(&format!(
                     "argument to `pretty` must be one of `normal`, \
                      `expanded`, `typed`, `identified`, \
-                     or `expanded,identified`; got {}", name).as_slice());
+                     or `expanded,identified`; got {}", name));
             }
         }
     };
@@ -517,7 +517,7 @@ pub fn pretty_print_input(sess: Session,
         krate
     };
 
-    let id = link::find_crate_name(Some(&sess), krate.attrs.as_slice(), input);
+    let id = link::find_crate_name(Some(&sess), &krate.attrs, input);
 
     let is_expanded = needs_expansion(&ppm);
     let compute_ast_map = needs_ast_map(&ppm, &opt_uii);

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -56,7 +56,7 @@ fn remove_message(e: &mut ExpectErrorEmitter, msg: &str, lvl: Level) {
     }
 
     debug!("Error: {}", msg);
-    match e.messages.iter().position(|m| msg.contains(m.as_slice())) {
+    match e.messages.iter().position(|m| msg.contains(m)) {
         Some(i) => {
             e.messages.remove(i);
         }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1726,7 +1726,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                            in this module",
                                           namespace_name,
                                           token::get_name(name).get());
-                        span_err!(self.session, import_directive.span, E0251, "{}", msg.as_slice());
+                        span_err!(self.session, import_directive.span, E0251, "{}", msg);
                     } else {
                         let target = Target::new(containing_module.clone(),
                                                  name_bindings.clone(),
@@ -3756,15 +3756,14 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         }
                         Some(_) => {
                             self.resolve_error(path.span,
-                                format!("`{}` is not an enum variant, struct or const",
+                                &format!("`{}` is not an enum variant, struct or const",
                                     token::get_ident(
-                                        path.segments.last().unwrap().identifier)).as_slice());
+                                        path.segments.last().unwrap().identifier)));
                         }
                         None => {
                             self.resolve_error(path.span,
-                                format!("unresolved enum variant, struct or const `{}`",
-                                    token::get_ident(
-                                        path.segments.last().unwrap().identifier)).as_slice());
+                                &format!("unresolved enum variant, struct or const `{}`",
+                                    token::get_ident(path.segments.last().unwrap().identifier)));
                         }
                     }
 
@@ -4061,7 +4060,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     Some((span, msg)) => (span, msg),
                     None => {
                         let msg = format!("Use of undeclared type or module `{}`",
-                                          self.names_to_string(module_path.as_slice()));
+                                          self.names_to_string(&module_path));
                         (path.span, msg)
                     }
                 };
@@ -4163,7 +4162,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         let search_result = match namespace {
             ValueNS => {
                 let renamed = mtwt::resolve(ident);
-                self.search_ribs(self.value_ribs.as_slice(), renamed, span)
+                self.search_ribs(&self.value_ribs, renamed, span)
             }
             TypeNS => {
                 let name = ident.name;
@@ -4424,15 +4423,15 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     Some((DefVariant(_, _, true), _)) => {
                         let path_name = self.path_names_to_string(path);
                         self.resolve_error(expr.span,
-                                format!("`{}` is a struct variant name, but \
-                                         this expression \
-                                         uses it like a function name",
-                                        path_name).as_slice());
+                                &format!("`{}` is a struct variant name, but \
+                                          this expression \
+                                          uses it like a function name",
+                                         path_name));
 
                         self.session.span_help(expr.span,
-                            format!("Did you mean to write: \
-                                    `{} {{ /* fields */ }}`?",
-                                    path_name).as_slice());
+                            &format!("Did you mean to write: \
+                                     `{} {{ /* fields */ }}`?",
+                                     path_name));
                     }
                     Some(def) => {
                         // Write the result into the def map.
@@ -4452,15 +4451,15 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                             Some((DefTy(struct_id, _), _))
                               if self.structs.contains_key(&struct_id) => {
                                 self.resolve_error(expr.span,
-                                        format!("`{}` is a structure name, but \
-                                                 this expression \
-                                                 uses it like a function name",
-                                                path_name).as_slice());
+                                        &format!("`{}` is a structure name, but \
+                                                  this expression \
+                                                  uses it like a function name",
+                                                 path_name));
 
                                 self.session.span_help(expr.span,
-                                    format!("Did you mean to write: \
-                                            `{} {{ /* fields */ }}`?",
-                                            path_name).as_slice());
+                                    &format!("Did you mean to write: \
+                                             `{} {{ /* fields */ }}`?",
+                                             path_name));
 
                             }
                             _ => {
@@ -4489,7 +4488,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                         NoSuggestion => {
                                             // limit search to 5 to reduce the number
                                             // of stupid suggestions
-                                            self.find_best_match_for_name(path_name.as_slice(), 5)
+                                            self.find_best_match_for_name(&path_name, 5)
                                                                 .map_or("".to_string(),
                                                                         |x| format!("`{}`", x))
                                         }
@@ -4509,9 +4508,9 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
                                     self.resolve_error(
                                         expr.span,
-                                        format!("unresolved name `{}`{}",
-                                                path_name,
-                                                msg).as_slice());
+                                        &format!("unresolved name `{}`{}",
+                                                 path_name,
+                                                 msg));
                                 }
                             }
                         }

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -609,7 +609,7 @@ fn link_rlib<'a>(sess: &'a Session,
                 // extension to it. This is to work around a bug in LLDB that
                 // would cause it to crash if the name of a file in an archive
                 // was exactly 16 bytes.
-                let bc_filename = obj_filename.with_extension(format!("{}.bc", i).as_slice());
+                let bc_filename = obj_filename.with_extension(&format!("{}.bc", i));
                 let bc_deflated_filename = obj_filename.with_extension(
                     &format!("{}.bytecode.deflate", i)[]);
 
@@ -1087,8 +1087,8 @@ fn add_local_native_libraries(cmd: &mut Command, sess: &Session) {
             // -force_load is the OSX equivalent of --whole-archive, but it
             // involves passing the full path to the library to link.
             let lib = archive::find_library(&l[],
-                                            sess.target.target.options.staticlib_prefix.as_slice(),
-                                            sess.target.target.options.staticlib_suffix.as_slice(),
+                                            &sess.target.target.options.staticlib_prefix,
+                                            &sess.target.target.options.staticlib_suffix,
                                             &search_path[],
                                             &sess.diagnostic().handler);
             let mut v = b"-Wl,-force_load,".to_vec();

--- a/src/librustc_trans/back/lto.rs
+++ b/src/librustc_trans/back/lto.rs
@@ -64,7 +64,7 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
         debug!("reading {}", file);
         for i in iter::count(0us, 1) {
             let bc_encoded = time(sess.time_passes(),
-                                  format!("check for {}.{}.bytecode.deflate", name, i).as_slice(),
+                                  &format!("check for {}.{}.bytecode.deflate", name, i),
                                   (),
                                   |_| {
                                       archive.read(&format!("{}.{}.bytecode.deflate",
@@ -84,7 +84,7 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
             };
 
             let bc_decoded = if is_versioned_bytecode_format(bc_encoded) {
-                time(sess.time_passes(), format!("decode {}.{}.bc", file, i).as_slice(), (), |_| {
+                time(sess.time_passes(), &format!("decode {}.{}.bc", file, i), (), |_| {
                     // Read the version
                     let version = extract_bytecode_format_version(bc_encoded);
 
@@ -108,7 +108,7 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
                     }
                 })
             } else {
-                time(sess.time_passes(), format!("decode {}.{}.bc", file, i).as_slice(), (), |_| {
+                time(sess.time_passes(), &format!("decode {}.{}.bc", file, i), (), |_| {
                 // the object must be in the old, pre-versioning format, so simply
                 // inflate everything and let LLVM decide if it can make sense of it
                     match flate::inflate_bytes(bc_encoded) {

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -309,7 +309,7 @@ impl <'l, 'tcx> DxrVisitor<'l, 'tcx> {
                                 Some(def_id) => {
                                     result.push_str(" as ");
                                     result.push_str(
-                                        ty::item_path_str(&self.analysis.ty_cx, def_id).as_slice());
+                                        &ty::item_path_str(&self.analysis.ty_cx, def_id));
                                 },
                                 None => {}
                             }
@@ -643,7 +643,7 @@ impl <'l, 'tcx> DxrVisitor<'l, 'tcx> {
                         item.id);
 
                     for field in &struct_def.fields {
-                        self.process_struct_field_def(field, qualname.as_slice(), variant.node.id);
+                        self.process_struct_field_def(field, &qualname, variant.node.id);
                         self.visit_ty(&*field.node.ty);
                     }
                 }
@@ -795,7 +795,7 @@ impl <'l, 'tcx> DxrVisitor<'l, 'tcx> {
         let def_map = self.analysis.ty_cx.def_map.borrow();
         if !def_map.contains_key(&id) {
             self.sess.span_bug(span,
-                               format!("def_map has no key for {} in visit_expr", id).as_slice());
+                               &format!("def_map has no key for {} in visit_expr", id));
         }
         let def = &(*def_map)[id];
         let sub_span = self.span.span_for_last_ident(span);
@@ -1117,7 +1117,7 @@ impl<'l, 'tcx, 'v> Visitor<'v> for DxrVisitor<'l, 'tcx> {
                         self.fmt.use_glob_str(path.span,
                                               sub_span,
                                               item.id,
-                                              name_string.as_slice(),
+                                              &name_string,
                                               self.cur_scope);
                         self.write_sub_paths(path, true);
                     }
@@ -1200,7 +1200,7 @@ impl<'l, 'tcx, 'v> Visitor<'v> for DxrVisitor<'l, 'tcx> {
                                      &value[]);
 
                 self.visit_ty(&**ty);
-                self.process_generic_params(ty_params, item.span, qualname.as_slice(), item.id);
+                self.process_generic_params(ty_params, item.span, &qualname, item.id);
             },
             ast::ItemMac(_) => (),
             _ => visit::walk_item(self, item),

--- a/src/librustc_trans/save/recorder.rs
+++ b/src/librustc_trans/save/recorder.rs
@@ -229,8 +229,8 @@ impl<'a> FmtStrs<'a> {
 
         if !needs_span {
             self.span.sess.span_bug(span,
-                                    format!("Called record_with_span for '{}' \
-                                             which does not require a span", label).as_slice());
+                                    &format!("Called record_with_span for '{}' \
+                                              which does not require a span", label));
         }
 
         let values_str = match self.make_values_str(label, fields, values, span) {

--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -1029,8 +1029,8 @@ fn compile_submatch_continue<'a, 'p, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                                         field_vals.len())
             );
             let mut vals = field_vals;
-            vals.push_all(vals_left.as_slice());
-            compile_submatch(bcx, pats.as_slice(), vals.as_slice(), chk, has_genuine_default);
+            vals.push_all(&vals_left);
+            compile_submatch(bcx, &pats, &vals, chk, has_genuine_default);
             return;
         }
         _ => ()

--- a/src/librustc_trans/trans/adt.rs
+++ b/src/librustc_trans/trans/adt.rs
@@ -265,9 +265,9 @@ fn represent_type_uncached<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             // Use the minimum integer type we figured out above
             let fields : Vec<_> = cases.iter().map(|c| {
                 let mut ftys = vec!(ty_of_inttype(cx.tcx(), min_ity));
-                ftys.push_all(c.tys.as_slice());
+                ftys.push_all(&c.tys);
                 if dtor { ftys.push(cx.tcx().types.bool); }
-                mk_struct(cx, ftys.as_slice(), false, t)
+                mk_struct(cx, &ftys, false, t)
             }).collect();
 
 
@@ -283,7 +283,7 @@ fn represent_type_uncached<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             // This check is needed to avoid increasing the size of types when
             // the alignment of the first field is smaller than the overall
             // alignment of the type.
-            let (_, align) = union_size_and_align(fields.as_slice());
+            let (_, align) = union_size_and_align(&fields);
             let mut use_align = true;
             for st in &fields {
                 // Get the first non-zero-sized field

--- a/src/librustc_trans/trans/asm.rs
+++ b/src/librustc_trans/trans/asm.rs
@@ -125,7 +125,7 @@ pub fn trans_inline_asm<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, ia: &ast::InlineAsm)
     let r = InlineAsmCall(bcx,
                           asm.as_ptr(),
                           constraints.as_ptr(),
-                          inputs.as_slice(),
+                          &inputs,
                           output_type,
                           ia.volatile,
                           ia.alignstack,

--- a/src/librustc_trans/trans/cabi_mips.rs
+++ b/src/librustc_trans/trans/cabi_mips.rs
@@ -159,7 +159,7 @@ fn coerce_to_int(ccx: &CrateContext, size: uint) -> Vec<Type> {
 
 fn struct_ty(ccx: &CrateContext, ty: Type) -> Type {
     let size = ty_size(ty) * 8;
-    Type::struct_(ccx, coerce_to_int(ccx, size).as_slice(), false)
+    Type::struct_(ccx, &coerce_to_int(ccx, size), false)
 }
 
 pub fn compute_abi_info(ccx: &CrateContext,

--- a/src/librustc_trans/trans/cabi_powerpc.rs
+++ b/src/librustc_trans/trans/cabi_powerpc.rs
@@ -154,7 +154,7 @@ fn coerce_to_int(ccx: &CrateContext, size: uint) -> Vec<Type> {
 
 fn struct_ty(ccx: &CrateContext, ty: Type) -> Type {
     let size = ty_size(ty) * 8;
-    Type::struct_(ccx, coerce_to_int(ccx, size).as_slice(), false)
+    Type::struct_(ccx, &coerce_to_int(ccx, size), false)
 }
 
 pub fn compute_abi_info(ccx: &CrateContext,

--- a/src/librustc_trans/trans/cabi_x86_64.rs
+++ b/src/librustc_trans/trans/cabi_x86_64.rs
@@ -237,7 +237,7 @@ fn classify_ty(ty: Type) -> Vec<RegClass> {
                 unify(cls, ix + off / 8, SSEDs);
             }
             Struct => {
-                classify_struct(ty.field_types().as_slice(), cls, ix, off, ty.is_packed());
+                classify_struct(&ty.field_types(), cls, ix, off, ty.is_packed());
             }
             Array => {
                 let len = ty.array_length();
@@ -322,11 +322,11 @@ fn classify_ty(ty: Type) -> Vec<RegClass> {
     let words = (ty_size(ty) + 7) / 8;
     let mut cls: Vec<_> = repeat(NoClass).take(words).collect();
     if words > 4 {
-        all_mem(cls.as_mut_slice());
+        all_mem(&mut cls);
         return cls;
     }
-    classify(ty, cls.as_mut_slice(), 0, 0);
-    fixup(ty, cls.as_mut_slice());
+    classify(ty, &mut cls, 0, 0);
+    fixup(ty, &mut cls);
     return cls;
 }
 
@@ -381,7 +381,7 @@ fn llreg_ty(ccx: &CrateContext, cls: &[RegClass]) -> Type {
         // if the type contains only a vector, pass it as that vector.
         tys[0]
     } else {
-        Type::struct_(ccx, tys.as_slice(), false)
+        Type::struct_(ccx, &tys, false)
     }
 }
 
@@ -398,11 +398,11 @@ pub fn compute_abi_info(ccx: &CrateContext,
     {
         if !ty.is_reg_ty() {
             let cls = classify_ty(ty);
-            if is_mem_cls(cls.as_slice()) {
+            if is_mem_cls(&cls) {
                 ArgType::indirect(ty, Some(ind_attr))
             } else {
                 ArgType::direct(ty,
-                                Some(llreg_ty(ccx, cls.as_slice())),
+                                Some(llreg_ty(ccx, &cls)),
                                 None,
                                 None)
             }

--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -582,7 +582,7 @@ fn const_expr_unadjusted(cx: &CrateContext, e: &ast::Expr) -> ValueRef {
               })
           }
           ast::ExprVec(ref es) => {
-            const_vec(cx, e, es.as_slice()).0
+            const_vec(cx, e, es).0
           }
           ast::ExprRepeat(ref elem, ref count) => {
             let vec_ty = ty::expr_ty(cx.tcx(), e);

--- a/src/librustc_trans/trans/context.rs
+++ b/src/librustc_trans/trans/context.rs
@@ -224,11 +224,11 @@ unsafe fn create_context_and_module(sess: &Session, mod_name: &str) -> (ContextR
     let mod_name = CString::from_slice(mod_name.as_bytes());
     let llmod = llvm::LLVMModuleCreateWithNameInContext(mod_name.as_ptr(), llcx);
 
-    let data_layout = sess.target.target.data_layout.as_slice();
+    let data_layout = &*sess.target.target.data_layout;
     let data_layout = CString::from_slice(data_layout.as_bytes());
     llvm::LLVMSetDataLayout(llmod, data_layout.as_ptr());
 
-    let llvm_target = sess.target.target.llvm_target.as_slice();
+    let llvm_target = &*sess.target.target.llvm_target;
     let llvm_target = CString::from_slice(llvm_target.as_bytes());
     llvm::LLVMRustSetNormalizedTarget(llmod, llvm_target.as_ptr());
     (llcx, llmod)

--- a/src/librustc_trans/trans/debuginfo.rs
+++ b/src/librustc_trans/trans/debuginfo.rs
@@ -1246,7 +1246,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
 
     let (ident, fn_decl, generics, top_level_block, span, has_path) = match fnitem {
         ast_map::NodeItem(ref item) => {
-            if contains_nodebug_attribute(item.attrs.as_slice()) {
+            if contains_nodebug_attribute(&item.attrs) {
                 return FunctionDebugContext::FunctionWithoutDebugInfo;
             }
 
@@ -1263,7 +1263,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         ast_map::NodeImplItem(ref item) => {
             match **item {
                 ast::MethodImplItem(ref method) => {
-                    if contains_nodebug_attribute(method.attrs.as_slice()) {
+                    if contains_nodebug_attribute(&method.attrs) {
                         return FunctionDebugContext::FunctionWithoutDebugInfo;
                     }
 
@@ -1302,7 +1302,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
         ast_map::NodeTraitItem(ref trait_method) => {
             match **trait_method {
                 ast::ProvidedMethod(ref method) => {
-                    if contains_nodebug_attribute(method.attrs.as_slice()) {
+                    if contains_nodebug_attribute(&method.attrs) {
                         return FunctionDebugContext::FunctionWithoutDebugInfo;
                     }
 
@@ -1399,7 +1399,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
     };
 
     let scope_map = create_scope_map(cx,
-                                     fn_decl.inputs.as_slice(),
+                                     &fn_decl.inputs,
                                      &*top_level_block,
                                      fn_metadata,
                                      fn_ast_id);
@@ -2483,7 +2483,7 @@ fn prepare_enum_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                         UNKNOWN_LINE_NUMBER,
                         bytes_to_bits(discriminant_size),
                         bytes_to_bits(discriminant_align),
-                        create_DIArray(DIB(cx), enumerators_metadata.as_slice()),
+                        create_DIArray(DIB(cx), &enumerators_metadata),
                         discriminant_base_type_metadata)
                 };
 
@@ -3764,7 +3764,7 @@ fn push_debuginfo_type_name<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
 
             match optional_length {
                 Some(len) => {
-                    output.push_str(format!("; {}", len).as_slice());
+                    output.push_str(&format!("; {}", len));
                 }
                 None => { /* nothing to do */ }
             };
@@ -4070,11 +4070,10 @@ fn get_or_insert_gdb_debug_scripts_section_global(ccx: &CrateContext)
 
 fn needs_gdb_debug_scripts_section(ccx: &CrateContext) -> bool {
     let omit_gdb_pretty_printer_section =
-        attr::contains_name(ccx.tcx()
-                               .map
-                               .krate()
-                               .attrs
-                               .as_slice(),
+        attr::contains_name(&ccx.tcx()
+                                .map
+                                .krate()
+                                .attrs,
                             "omit_gdb_pretty_printer_section");
 
     !omit_gdb_pretty_printer_section &&

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -1056,7 +1056,7 @@ fn trans_rvalue_dps_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             if let Some(did) = did {
                 let substs = Substs::new_type(ty_params, vec![]);
                 trans_struct(bcx,
-                             fields.as_slice(),
+                             &fields,
                              None,
                              expr.span,
                              expr.id,
@@ -1398,7 +1398,7 @@ fn trans_struct<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         trans_adt(bcx,
                   ty,
                   discr,
-                  numbered_fields.as_slice(),
+                  &numbered_fields,
                   optbase,
                   dest,
                   DebugLoc::At(expr_id, expr_span))

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -788,7 +788,7 @@ pub fn trans_rust_fn_with_foreign_abi<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         debug!("calling llrustfn = {}, t = {}",
                ccx.tn().val_to_string(llrustfn), t.repr(ccx.tcx()));
         let attributes = base::get_fn_llvm_attributes(ccx, t);
-        let llrust_ret_val = builder.call(llrustfn, llrust_args.as_slice(), Some(attributes));
+        let llrust_ret_val = builder.call(llrustfn, &llrust_args, Some(attributes));
 
         // Get the return value where the foreign fn expects it.
         let llforeign_ret_ty = match tys.fn_ty.ret_ty.cast {
@@ -898,7 +898,7 @@ fn foreign_types_for_fn_ty<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         _ => ccx.sess().bug("foreign_types_for_fn_ty called on non-function type")
     };
     let fn_sig = ty::erase_late_bound_regions(ccx.tcx(), fn_sig);
-    let llsig = foreign_signature(ccx, &fn_sig, fn_sig.inputs.as_slice());
+    let llsig = foreign_signature(ccx, &fn_sig, &fn_sig.inputs);
     let fn_ty = cabi::compute_abi_info(ccx,
                                        &llsig.llarg_tys[],
                                        llsig.llret_ty,
@@ -911,7 +911,7 @@ fn foreign_types_for_fn_ty<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
            ty.repr(ccx.tcx()),
            ccx.tn().types_to_str(&llsig.llarg_tys[]),
            ccx.tn().type_to_string(llsig.llret_ty),
-           ccx.tn().types_to_str(fn_ty.arg_tys.iter().map(|t| t.ty).collect::<Vec<_>>().as_slice()),
+           ccx.tn().types_to_str(&fn_ty.arg_tys.iter().map(|t| t.ty).collect::<Vec<_>>()),
            ccx.tn().type_to_string(fn_ty.ret_ty.ty),
            llsig.ret_def);
 
@@ -959,7 +959,7 @@ fn lltype_for_fn_from_foreign_types(ccx: &CrateContext, tys: &ForeignTypes) -> T
     }
 
     if tys.fn_sig.variadic {
-        Type::variadic_func(llargument_tys.as_slice(), &llreturn_ty)
+        Type::variadic_func(&llargument_tys, &llreturn_ty)
     } else {
         Type::func(&llargument_tys[], &llreturn_ty)
     }

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -118,25 +118,25 @@ pub fn check_intrinsics(ccx: &CrateContext) {
             if transmute_restriction.original_from != transmute_restriction.substituted_from {
                 ccx.sess().span_err(
                     transmute_restriction.span,
-                    format!("transmute called on types with potentially different sizes: \
-                             {} (could be {} bit{}) to {} (could be {} bit{})",
-                            ty_to_string(ccx.tcx(), transmute_restriction.original_from),
-                            from_type_size as uint,
-                            if from_type_size == 1 {""} else {"s"},
-                            ty_to_string(ccx.tcx(), transmute_restriction.original_to),
-                            to_type_size as uint,
-                            if to_type_size == 1 {""} else {"s"}).as_slice());
+                    &format!("transmute called on types with potentially different sizes: \
+                              {} (could be {} bit{}) to {} (could be {} bit{})",
+                             ty_to_string(ccx.tcx(), transmute_restriction.original_from),
+                             from_type_size as uint,
+                             if from_type_size == 1 {""} else {"s"},
+                             ty_to_string(ccx.tcx(), transmute_restriction.original_to),
+                             to_type_size as uint,
+                             if to_type_size == 1 {""} else {"s"}));
             } else {
                 ccx.sess().span_err(
                     transmute_restriction.span,
-                    format!("transmute called on types with different sizes: \
-                             {} ({} bit{}) to {} ({} bit{})",
-                            ty_to_string(ccx.tcx(), transmute_restriction.original_from),
-                            from_type_size as uint,
-                            if from_type_size == 1 {""} else {"s"},
-                            ty_to_string(ccx.tcx(), transmute_restriction.original_to),
-                            to_type_size as uint,
-                            if to_type_size == 1 {""} else {"s"}).as_slice());
+                    &format!("transmute called on types with different sizes: \
+                              {} ({} bit{}) to {} ({} bit{})",
+                             ty_to_string(ccx.tcx(), transmute_restriction.original_from),
+                             from_type_size as uint,
+                             if from_type_size == 1 {""} else {"s"},
+                             ty_to_string(ccx.tcx(), transmute_restriction.original_to),
+                             to_type_size as uint,
+                             if to_type_size == 1 {""} else {"s"}));
             }
         }
     }
@@ -309,7 +309,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
     let simple = get_simple_intrinsic(ccx, &*foreign_item);
     let llval = match (simple, name.get()) {
         (Some(llfn), _) => {
-            Call(bcx, llfn, llargs.as_slice(), None, call_debug_location)
+            Call(bcx, llfn, &llargs, None, call_debug_location)
         }
         (_, "breakpoint") => {
             let llfn = ccx.get_intrinsic(&("llvm.debugtrap"));

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -567,8 +567,8 @@ pub fn trans_object_shim<'a, 'tcx>(
                 data.principal_trait_ref_with_self_ty(tcx, object_ty)
             }
             _ => {
-                tcx.sess.bug(format!("trans_object_shim() called on non-object: {}",
-                                     object_ty.repr(tcx)).as_slice());
+                tcx.sess.bug(&format!("trans_object_shim() called on non-object: {}",
+                                      object_ty.repr(tcx)));
             }
         };
 
@@ -595,7 +595,7 @@ pub fn trans_object_shim<'a, 'tcx>(
     let function_name =
         link::mangle_internal_name_by_type_and_seq(ccx, method_bare_fn_ty, "object_shim");
     let llfn =
-        decl_internal_rust_fn(ccx, method_bare_fn_ty, function_name.as_slice());
+        decl_internal_rust_fn(ccx, method_bare_fn_ty, &function_name);
 
     let sig = ty::erase_late_bound_regions(ccx.tcx(), &fty.sig);
 
@@ -624,11 +624,11 @@ pub fn trans_object_shim<'a, 'tcx>(
             RustCall => {
                 // unpack the tuple to extract the input type arguments:
                 match sig.inputs[1].sty {
-                    ty::ty_tup(ref tys) => tys.as_slice(),
+                    ty::ty_tup(ref tys) => &**tys,
                     _ => {
                         bcx.sess().bug(
-                            format!("rust-call expects a tuple not {}",
-                                    sig.inputs[1].repr(tcx)).as_slice());
+                            &format!("rust-call expects a tuple not {}",
+                                     sig.inputs[1].repr(tcx)));
                     }
                 }
             }
@@ -673,7 +673,7 @@ pub fn trans_object_shim<'a, 'tcx>(
                                                                   method_bare_fn_ty,
                                                                   method_offset_in_vtable,
                                                                   llobject),
-                           ArgVals(llargs.as_slice()),
+                           ArgVals(&llargs),
                            dest).bcx;
 
     finish_fn(&fcx, bcx, sig.output, DebugLoc::None);
@@ -744,8 +744,8 @@ pub fn get_vtable<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                 // an object type; this cannot happen because we
                 // cannot cast an unsized type into a trait object
                 bcx.sess().bug(
-                    format!("cannot get vtable for an object type: {}",
-                            data.repr(bcx.tcx())).as_slice());
+                    &format!("cannot get vtable for an object type: {}",
+                             data.repr(bcx.tcx())));
             }
             traits::VtableParam(..) => {
                 bcx.sess().bug(

--- a/src/librustc_trans/trans/type_of.rs
+++ b/src/librustc_trans/trans/type_of.rs
@@ -113,7 +113,7 @@ pub fn type_of_rust_fn<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
     let mut atys: Vec<Type> = Vec::new();
 
     // First, munge the inputs, if this has the `rust-call` ABI.
-    let inputs = untuple_arguments_if_necessary(cx, sig.inputs.as_slice(), abi);
+    let inputs = untuple_arguments_if_necessary(cx, &sig.inputs, abi);
 
     // Arg 0: Output pointer.
     // (if the output type is non-immediate)

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -272,7 +272,7 @@ pub fn ast_path_substs_for_ty<'tcx>(
         }
     };
 
-    prohibit_projections(this.tcx(), assoc_bindings.as_slice());
+    prohibit_projections(this.tcx(), &assoc_bindings);
 
     create_substs_for_ast_path(this,
                                rscope,
@@ -656,7 +656,7 @@ fn ast_path_to_trait_ref<'a,'tcx>(
 
     match projections {
         None => {
-            prohibit_projections(this.tcx(), assoc_bindings.as_slice());
+            prohibit_projections(this.tcx(), &assoc_bindings);
         }
         Some(ref mut v) => {
             for binding in &assoc_bindings {
@@ -960,7 +960,7 @@ fn associated_path_def_to_ty<'tcx>(this: &AstConv<'tcx>,
 
         // FIXME(#20300) -- search where clauses, not bounds
         suitable_bounds =
-            traits::transitive_bounds(tcx, ty_param_def.bounds.trait_bounds.as_slice())
+            traits::transitive_bounds(tcx, &ty_param_def.bounds.trait_bounds)
             .filter(|b| trait_defines_associated_type_named(this, b.def_id(), assoc_name))
             .collect();
     }
@@ -1595,11 +1595,11 @@ pub fn conv_existential_bounds_from_partitioned_bounds<'tcx>(
     let region_bound = compute_region_bound(this,
                                             rscope,
                                             span,
-                                            region_bounds.as_slice(),
+                                            &region_bounds,
                                             principal_trait_ref,
                                             builtin_bounds);
 
-    ty::sort_bounds_list(projection_bounds.as_mut_slice());
+    ty::sort_bounds_list(&mut projection_bounds);
 
     ty::ExistentialBounds {
         region_bound: region_bound,

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -164,7 +164,7 @@ pub fn check_pat<'a, 'tcx>(pcx: &pat_ctxt<'a, 'tcx>,
             check_pat_enum(pcx, pat, path, subpats, expected);
         }
         ast::PatStruct(ref path, ref fields, etc) => {
-            check_pat_struct(pcx, pat, path, fields.as_slice(), etc, expected);
+            check_pat_struct(pcx, pat, path, fields, etc, expected);
         }
         ast::PatTup(ref elements) => {
             let element_tys: Vec<_> =
@@ -480,7 +480,7 @@ pub fn check_pat_struct<'a, 'tcx>(pcx: &pat_ctxt<'a, 'tcx>, pat: &'tcx ast::Pat,
         .unwrap_or_else(|| Substs::empty());
 
     let struct_fields = ty::struct_fields(tcx, variant_def_id, &item_substs);
-    check_struct_pat_fields(pcx, pat.span, fields, struct_fields.as_slice(),
+    check_struct_pat_fields(pcx, pat.span, fields, &struct_fields,
                             variant_def_id, etc);
 }
 

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -252,10 +252,10 @@ fn confirm_builtin_call<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
                                                       call_expr.span,
                                                       expected,
                                                       fn_sig.output,
-                                                      fn_sig.inputs.as_slice());
+                                                      &fn_sig.inputs);
     check_argument_types(fcx,
                          call_expr.span,
-                         fn_sig.inputs.as_slice(),
+                         &fn_sig.inputs,
                          &expected_arg_tys[],
                          arg_exprs,
                          AutorefArgs::No,

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -655,9 +655,9 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
             None => {
                 self.tcx().sess.span_bug(
                     self.span,
-                    format!("cannot upcast `{}` to `{}`",
-                            source_trait_ref.repr(self.tcx()),
-                            target_trait_def_id.repr(self.tcx())).as_slice());
+                    &format!("cannot upcast `{}` to `{}`",
+                             source_trait_ref.repr(self.tcx()),
+                             target_trait_def_id.repr(self.tcx())));
             }
         }
     }

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -368,7 +368,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
             })
             .collect();
 
-        self.elaborate_bounds(bounds.as_slice(), |this, poly_trait_ref, m, method_num| {
+        self.elaborate_bounds(&bounds, |this, poly_trait_ref, m, method_num| {
             let trait_ref =
                 this.erase_late_bound_regions(&poly_trait_ref);
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -730,7 +730,7 @@ pub fn check_item<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx ast::Item) {
                 check_impl_items_against_trait(ccx,
                                                it.span,
                                                &*impl_trait_ref,
-                                               impl_items.as_slice());
+                                               impl_items);
               }
               None => { }
           }
@@ -806,7 +806,7 @@ fn check_trait_on_unimplemented<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     }) {
         if let Some(ref istring) = attr.value_str() {
             let parser = Parser::new(istring.get());
-            let types = generics.ty_params.as_slice();
+            let types = &*generics.ty_params;
             for token in parser {
                 match token {
                     Piece::String(_) => (), // Normal string, no need to check it
@@ -908,9 +908,9 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                 // caught in resolve.
                                 tcx.sess.span_bug(
                                     impl_method.span,
-                                    format!("item `{}` is of a different kind from its trait `{}`",
-                                            token::get_name(impl_item_ty.name()),
-                                            impl_trait_ref.repr(tcx)).as_slice());
+                                    &format!("item `{}` is of a different kind from its trait `{}`",
+                                             token::get_name(impl_item_ty.name()),
+                                             impl_trait_ref.repr(tcx)));
                             }
                         }
                     }
@@ -919,9 +919,9 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                         // caught in resolve.
                         tcx.sess.span_bug(
                             impl_method.span,
-                            format!("method `{}` is not a member of trait `{}`",
-                                    token::get_name(impl_item_ty.name()),
-                                    impl_trait_ref.repr(tcx)).as_slice());
+                            &format!("method `{}` is not a member of trait `{}`",
+                                     token::get_name(impl_item_ty.name()),
+                                     impl_trait_ref.repr(tcx)));
                     }
                 }
             }
@@ -944,9 +944,9 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                 // already been caught in resolve.
                                 tcx.sess.span_bug(
                                     typedef.span,
-                                    format!("item `{}` is of a different kind from its trait `{}`",
-                                            token::get_name(typedef_ty.name()),
-                                            impl_trait_ref.repr(tcx)).as_slice());
+                                    &format!("item `{}` is of a different kind from its trait `{}`",
+                                             token::get_name(typedef_ty.name()),
+                                             impl_trait_ref.repr(tcx)));
                             }
                         }
                     }
@@ -955,11 +955,11 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                         // caught in resolve.
                         tcx.sess.span_bug(
                             typedef.span,
-                            format!(
+                            &format!(
                                 "associated type `{}` is not a member of \
                                  trait `{}`",
                                 token::get_name(typedef_ty.name()),
-                                impl_trait_ref.repr(tcx)).as_slice());
+                                impl_trait_ref.repr(tcx)));
                     }
                 }
             }
@@ -3123,7 +3123,7 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
         }
         if let Some(n) = best {
             tcx.sess.span_help(field.span,
-                format!("did you mean `{}`?", n).as_slice());
+                &format!("did you mean `{}`?", n));
         }
     }
 
@@ -3734,7 +3734,7 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
         }
       }
       ast::ExprMatch(ref discrim, ref arms, match_src) => {
-        _match::check_match(fcx, expr, &**discrim, arms.as_slice(), expected, match_src);
+        _match::check_match(fcx, expr, &**discrim, arms, expected, match_src);
       }
       ast::ExprClosure(capture, ref decl, ref body) => {
           closure::check_expr_closure(fcx, expr, capture, &**decl, &**body, expected);
@@ -5217,7 +5217,7 @@ pub fn check_bounds_are_used<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 
 pub fn check_intrinsic_type(ccx: &CrateCtxt, it: &ast::ForeignItem) {
     fn param<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>, n: u32) -> Ty<'tcx> {
-        let name = token::intern(format!("P{}", n).as_slice());
+        let name = token::intern(&format!("P{}", n));
         ty::mk_param(ccx.tcx, subst::FnSpace, n, name)
     }
 

--- a/src/librustc_typeck/check/vtable.rs
+++ b/src/librustc_typeck/check/vtable.rs
@@ -153,31 +153,31 @@ pub fn check_object_safety<'tcx>(tcx: &ty::ctxt<'tcx>,
             ObjectSafetyViolation::Method(method, MethodViolationCode::ByValueSelf) => {
                 tcx.sess.span_note(
                     span,
-                    format!("method `{}` has a receiver type of `Self`, \
-                             which cannot be used with a trait object",
-                            method.name.user_string(tcx)).as_slice());
+                    &format!("method `{}` has a receiver type of `Self`, \
+                              which cannot be used with a trait object",
+                             method.name.user_string(tcx)));
             }
 
             ObjectSafetyViolation::Method(method, MethodViolationCode::StaticMethod) => {
                 tcx.sess.span_note(
                     span,
-                    format!("method `{}` has no receiver",
-                            method.name.user_string(tcx)).as_slice());
+                    &format!("method `{}` has no receiver",
+                             method.name.user_string(tcx)));
             }
 
             ObjectSafetyViolation::Method(method, MethodViolationCode::ReferencesSelf) => {
                 tcx.sess.span_note(
                     span,
-                    format!("method `{}` references the `Self` type \
-                             in its arguments or return type",
-                            method.name.user_string(tcx)).as_slice());
+                    &format!("method `{}` references the `Self` type \
+                              in its arguments or return type",
+                             method.name.user_string(tcx)));
             }
 
             ObjectSafetyViolation::Method(method, MethodViolationCode::Generic) => {
                 tcx.sess.span_note(
                     span,
-                    format!("method `{}` has generic type parameters",
-                            method.name.user_string(tcx)).as_slice());
+                    &format!("method `{}` has generic type parameters",
+                             method.name.user_string(tcx)));
             }
         }
     }

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -170,7 +170,7 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
                 variants.iter().flat_map(|v| v.fields.iter().map(|f| f.ty)).collect();
 
             regionck::regionck_ensure_component_tys_wf(
-                fcx, item.span, field_tys.as_slice());
+                fcx, item.span, &field_tys);
         });
     }
 
@@ -227,7 +227,7 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
             // There are special rules that apply to drop.
             if
                 fcx.tcx().lang_items.drop_trait() == Some(trait_ref.def_id) &&
-                !attr::contains_name(item.attrs.as_slice(), "unsafe_destructor")
+                !attr::contains_name(&item.attrs, "unsafe_destructor")
             {
                 match self_ty.sty {
                     ty::ty_struct(def_id, _) |

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -94,9 +94,9 @@ impl<'cx, 'tcx,'v> visit::Visitor<'v> for OrphanChecker<'cx, 'tcx> {
                                     param_ty.user_string(self.tcx));
                             self.tcx.sess.span_note(
                                 item.span,
-                                format!("for a limited time, you can add \
-                                         `#![feature(old_orphan_check)]` to your crate \
-                                         to disable this rule").as_slice());
+                                &format!("for a limited time, you can add \
+                                          `#![feature(old_orphan_check)]` to your crate \
+                                          to disable this rule"));
                         }
                     }
                 }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -169,9 +169,9 @@ impl<'a, 'tcx> AstConv<'tcx> for CollectCtxt<'a, 'tcx> {
                 ty_of_foreign_item(self, &*foreign_item, abi)
             }
             x => {
-                self.tcx.sess.bug(format!("unexpected sort of node \
-                                           in get_item_type_scheme(): {:?}",
-                                          x).as_slice());
+                self.tcx.sess.bug(&format!("unexpected sort of node \
+                                            in get_item_type_scheme(): {:?}",
+                                           x));
             }
         }
     }
@@ -562,7 +562,7 @@ fn convert(ccx: &CollectCtxt, it: &ast::Item) {
             write_ty_to_tcx(tcx, it.id, scheme.ty);
             get_enum_variant_types(ccx,
                                    scheme.ty,
-                                   enum_definition.variants.as_slice(),
+                                   &enum_definition.variants,
                                    generics);
         },
         ast::ItemImpl(_, _,
@@ -846,7 +846,7 @@ fn trait_def_of_item<'a, 'tcx>(ccx: &CollectCtxt<'a, 'tcx>,
                        ref generics,
                        ref supertraits,
                        ref items) => {
-            (unsafety, generics, supertraits, items.as_slice())
+            (unsafety, generics, supertraits, items)
         }
         ref s => {
             tcx.sess.span_bug(
@@ -878,7 +878,7 @@ fn trait_def_of_item<'a, 'tcx>(ccx: &CollectCtxt<'a, 'tcx>,
 
     let bounds = compute_bounds(ccx,
                                 self_param_ty.to_ty(ccx.tcx),
-                                bounds.as_slice(),
+                                bounds,
                                 SizedByDefault::No,
                                 it.span);
 
@@ -1136,7 +1136,7 @@ fn ty_generics_for_trait<'a, 'tcx>(ccx: &CollectCtxt<'a, 'tcx>,
 
                 let bounds = compute_bounds(ccx,
                                             assoc_ty,
-                                            assoc_type_def.bounds.as_slice(),
+                                            &*assoc_type_def.bounds,
                                             SizedByDefault::Yes,
                                             assoc_type_def.span);
 
@@ -1448,7 +1448,7 @@ fn conv_param_bounds<'a,'tcx>(ccx: &CollectCtxt<'a,'tcx>,
     let astconv::PartitionedBounds { builtin_bounds,
                                      trait_bounds,
                                      region_bounds } =
-        astconv::partition_bounds(ccx.tcx, span, ast_bounds.as_slice());
+        astconv::partition_bounds(ccx.tcx, span, ast_bounds);
 
     let mut projection_bounds = Vec::new();
 
@@ -1701,9 +1701,9 @@ fn enforce_impl_ty_params_are_constrained<'tcx>(tcx: &ty::ctxt<'tcx>,
             if ty::has_attr(tcx, impl_def_id, "old_impl_check") {
                 tcx.sess.span_warn(
                     ty_param.span,
-                    format!("the type parameter `{}` is not constrained by the \
-                             impl trait, self type, or predicates",
-                            param_ty.user_string(tcx)).as_slice());
+                    &format!("the type parameter `{}` is not constrained by the \
+                              impl trait, self type, or predicates",
+                             param_ty.user_string(tcx)));
             } else {
                 span_err!(tcx.sess, ty_param.span, E0207,
                     "the type parameter `{}` is not constrained by the \
@@ -1711,8 +1711,8 @@ fn enforce_impl_ty_params_are_constrained<'tcx>(tcx: &ty::ctxt<'tcx>,
                             param_ty.user_string(tcx));
                 tcx.sess.span_help(
                     ty_param.span,
-                    format!("you can temporarily opt out of this rule by placing \
-                             the `#[old_impl_check]` attribute on the impl").as_slice());
+                    &format!("you can temporarily opt out of this rule by placing \
+                              the `#[old_impl_check]` attribute on the impl"));
             }
         }
     }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -195,7 +195,7 @@ fn build_struct(cx: &DocContext, tcx: &ty::ctxt, did: ast::DefId) -> clean::Stru
     let fields = ty::lookup_struct_fields(tcx, did);
 
     clean::Struct {
-        struct_type: match fields.as_slice() {
+        struct_type: match &*fields {
             [] => doctree::Unit,
             [ref f] if f.name == unnamed_field.name => doctree::Newtype,
             [ref f, ..] if f.name == unnamed_field.name => doctree::Tuple,
@@ -340,7 +340,7 @@ fn build_impl(cx: &DocContext, tcx: &ty::ctxt,
     let polarity = csearch::get_impl_polarity(tcx, did);
     return Some(clean::Item {
         inner: clean::ImplItem(clean::Impl {
-            derived: clean::detect_derived(attrs.as_slice()),
+            derived: clean::detect_derived(&attrs),
             trait_: associated_trait.clean(cx).map(|bound| {
                 match bound {
                     clean::TraitBound(polyt, _) => polyt.trait_,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -119,10 +119,10 @@ pub fn run_core(search_paths: SearchPaths, cfgs: Vec<String>, externs: Externs,
 
     let krate = driver::phase_1_parse_input(&sess, cfg, &input);
 
-    let name = link::find_crate_name(Some(&sess), krate.attrs.as_slice(),
+    let name = link::find_crate_name(Some(&sess), &krate.attrs,
                                      &input);
 
-    let krate = driver::phase_2_configure_and_expand(&sess, krate, name.as_slice(), None)
+    let krate = driver::phase_2_configure_and_expand(&sess, krate, &name, None)
                     .expect("phase_2_configure_and_expand aborted in rustdoc!");
 
     let mut forest = ast_map::Forest::new(krate);

--- a/src/librustdoc/externalfiles.rs
+++ b/src/librustdoc/externalfiles.rs
@@ -36,7 +36,7 @@ impl ExternalHtml {
 pub fn load_string(input: &Path) -> old_io::IoResult<Option<String>> {
     let mut f = try!(old_io::File::open(input));
     let d = try!(f.read_to_end());
-    Ok(str::from_utf8(d.as_slice()).map(|s| s.to_string()).ok())
+    Ok(str::from_utf8(&d).map(|s| s.to_string()).ok())
 }
 
 macro_rules! load_or_return {
@@ -63,7 +63,7 @@ macro_rules! load_or_return {
 pub fn load_external_files(names: &[String]) -> Option<String> {
     let mut out = String::new();
     for name in names {
-        out.push_str(load_or_return!(name.as_slice(), None, None).as_slice());
+        out.push_str(&*load_or_return!(&name, None, None));
         out.push('\n');
     }
     Some(out)

--- a/src/librustdoc/html/escape.rs
+++ b/src/librustdoc/html/escape.rs
@@ -24,7 +24,7 @@ impl<'a> fmt::Display for Escape<'a> {
         // Because the internet is always right, turns out there's not that many
         // characters to escape: http://stackoverflow.com/questions/7381974
         let Escape(s) = *self;
-        let pile_o_bits = s.as_slice();
+        let pile_o_bits = s;
         let mut last = 0;
         for (i, ch) in s.bytes().enumerate() {
             match ch as char {

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -67,12 +67,12 @@ fn doit(sess: &parse::ParseSess, mut lexer: lexer::StringReader,
 
         let klass = match next.tok {
             token::Whitespace => {
-                try!(write!(out, "{}", Escape(snip(next.sp).as_slice())));
+                try!(write!(out, "{}", Escape(&snip(next.sp))));
                 continue
             },
             token::Comment => {
                 try!(write!(out, "<span class='comment'>{}</span>",
-                            Escape(snip(next.sp).as_slice())));
+                            Escape(&snip(next.sp))));
                 continue
             },
             token::Shebang(s) => {
@@ -179,10 +179,10 @@ fn doit(sess: &parse::ParseSess, mut lexer: lexer::StringReader,
         // stringifying this token
         let snip = sess.span_diagnostic.cm.span_to_snippet(next.sp).unwrap();
         if klass == "" {
-            try!(write!(out, "{}", Escape(snip.as_slice())));
+            try!(write!(out, "{}", Escape(&snip)));
         } else {
             try!(write!(out, "<span class='{}'>{}</span>", klass,
-                          Escape(snip.as_slice())));
+                          Escape(&snip)));
         }
     }
 

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -224,15 +224,13 @@ pub fn render(w: &mut fmt::Formatter, s: &str, print_toc: bool) -> fmt::Result {
                     let test = origtext.lines().map(|l| {
                         stripped_filtered_line(l).unwrap_or(l)
                     }).collect::<Vec<&str>>().connect("\n");
-                    let krate = krate.as_ref().map(|s| s.as_slice());
-                    let test = test::maketest(test.as_slice(), krate, false, false);
-                    s.push_str(format!("<span class='rusttest'>{}</span>",
-                                         Escape(test.as_slice())).as_slice());
+                    let krate = krate.as_ref().map(|s| &**s);
+                    let test = test::maketest(&test, krate, false, false);
+                    s.push_str(&format!("<span class='rusttest'>{}</span>", Escape(&test)));
                 });
-                s.push_str(highlight::highlight(text.as_slice(),
-                                                None,
-                                                Some("rust-example-rendered"))
-                             .as_slice());
+                s.push_str(&highlight::highlight(&text,
+                                                 None,
+                                                 Some("rust-example-rendered")));
                 let output = CString::from_vec(s.into_bytes());
                 hoedown_buffer_puts(ob, output.as_ptr());
             })
@@ -459,14 +457,14 @@ impl<'a> fmt::Display for Markdown<'a> {
         let Markdown(md) = *self;
         // This is actually common enough to special-case
         if md.len() == 0 { return Ok(()) }
-        render(fmt, md.as_slice(), false)
+        render(fmt, md, false)
     }
 }
 
 impl<'a> fmt::Display for MarkdownWithToc<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let MarkdownWithToc(md) = *self;
-        render(fmt, md.as_slice(), true)
+        render(fmt, md, true)
     }
 }
 
@@ -555,7 +553,7 @@ mod tests {
     #[test]
     fn issue_17736() {
         let markdown = "# title";
-        format!("{}", Markdown(markdown.as_slice()));
+        format!("{}", Markdown(markdown));
     }
 
     #[test]

--- a/src/librustdoc/html/toc.rs
+++ b/src/librustdoc/html/toc.rs
@@ -145,8 +145,7 @@ impl TocBuilder {
                     (0, &self.top_level)
                 }
                 Some(entry) => {
-                    sec_number = String::from_str(entry.sec_number
-                                                       .as_slice());
+                    sec_number = String::from_str(&entry.sec_number);
                     sec_number.push_str(".");
                     (entry.level, &entry.children)
                 }
@@ -158,7 +157,7 @@ impl TocBuilder {
                 sec_number.push_str("0.");
             }
             let number = toc.count_entries_with_level(level);
-            sec_number.push_str(format!("{}", number + 1).as_slice())
+            sec_number.push_str(&format!("{}", number + 1))
         }
 
         self.chain.push(TocEntry {
@@ -172,7 +171,7 @@ impl TocBuilder {
         // get the thing we just pushed, so we can borrow the string
         // out of it with the right lifetime
         let just_inserted = self.chain.last_mut().unwrap();
-        just_inserted.sec_number.as_slice()
+        &just_inserted.sec_number
     }
 }
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -178,12 +178,12 @@ pub fn opts() -> Vec<getopts::OptGroup> {
 
 pub fn usage(argv0: &str) {
     println!("{}",
-             getopts::usage(format!("{} [options] <input>", argv0).as_slice(),
-                            opts().as_slice()));
+             getopts::usage(&format!("{} [options] <input>", argv0),
+                            &opts()));
 }
 
 pub fn main_args(args: &[String]) -> int {
-    let matches = match getopts::getopts(args.tail(), opts().as_slice()) {
+    let matches = match getopts::getopts(args.tail(), &opts()) {
         Ok(m) => m,
         Err(err) => {
             println!("{}", err);
@@ -191,7 +191,7 @@ pub fn main_args(args: &[String]) -> int {
         }
     };
     if matches.opt_present("h") || matches.opt_present("help") {
-        usage(args[0].as_slice());
+        usage(&args[0]);
         return 0;
     } else if matches.opt_present("version") {
         rustc_driver::version("rustdoc", &matches);
@@ -217,11 +217,11 @@ pub fn main_args(args: &[String]) -> int {
         println!("only one input file may be specified");
         return 1;
     }
-    let input = matches.free[0].as_slice();
+    let input = &matches.free[0];
 
     let mut libs = SearchPaths::new();
     for s in &matches.opt_strs("L") {
-        libs.add_path(s.as_slice());
+        libs.add_path(s);
     }
     let externs = match parse_externs(&matches) {
         Ok(ex) => ex,
@@ -244,9 +244,9 @@ pub fn main_args(args: &[String]) -> int {
     let cfgs = matches.opt_strs("cfg");
 
     let external_html = match ExternalHtml::load(
-            matches.opt_strs("html-in-header").as_slice(),
-            matches.opt_strs("html-before-content").as_slice(),
-            matches.opt_strs("html-after-content").as_slice()) {
+            &matches.opt_strs("html-in-header"),
+            &matches.opt_strs("html-before-content"),
+            &matches.opt_strs("html-after-content")) {
         Some(eh) => eh,
         None => return 3
     };
@@ -274,7 +274,7 @@ pub fn main_args(args: &[String]) -> int {
     };
     let Output { krate, json_plugins, passes, } = out;
     info!("going to format");
-    match matches.opt_str("w").as_ref().map(|s| s.as_slice()) {
+    match matches.opt_str("w").as_ref().map(|s| &**s) {
         Some("html") | None => {
             match html::render::run(krate, &external_html, output.unwrap_or(Path::new("doc")),
                                     passes.into_iter().collect()) {
@@ -303,7 +303,7 @@ pub fn main_args(args: &[String]) -> int {
 fn acquire_input(input: &str,
                  externs: core::Externs,
                  matches: &getopts::Matches) -> Result<Output, String> {
-    match matches.opt_str("r").as_ref().map(|s| s.as_slice()) {
+    match matches.opt_str("r").as_ref().map(|s| &**s) {
         Some("rust") => Ok(rust_input(input, externs, matches)),
         Some("json") => json_input(input),
         Some(s) => Err(format!("unknown input format: {}", s)),
@@ -357,7 +357,7 @@ fn rust_input(cratefile: &str, externs: core::Externs, matches: &getopts::Matche
     // First, parse the crate and extract all relevant information.
     let mut paths = SearchPaths::new();
     for s in &matches.opt_strs("L") {
-        paths.add_path(s.as_slice());
+        paths.add_path(s);
     }
     let cfgs = matches.opt_strs("cfg");
     let triple = matches.opt_str("target");
@@ -512,7 +512,7 @@ fn json_output(krate: clean::Crate, res: Vec<plugins::PluginJson> ,
     // FIXME #8335: yuck, Rust -> str -> JSON round trip! No way to .encode
     // straight to the Rust JSON representation.
     let crate_json_str = format!("{}", json::as_json(&krate));
-    let crate_json = match json::from_str(crate_json_str.as_slice()) {
+    let crate_json = match json::from_str(&crate_json_str) {
         Ok(j) => j,
         Err(e) => panic!("Rust generated JSON is invalid: {:?}", e)
     };

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -49,7 +49,7 @@ pub fn render(input: &str, mut output: Path, matches: &getopts::Matches,
     let mut css = String::new();
     for name in &matches.opt_strs("markdown-css") {
         let s = format!("<link rel=\"stylesheet\" type=\"text/css\" href=\"{}\">\n", name);
-        css.push_str(s.as_slice())
+        css.push_str(&s)
     }
 
     let input_str = load_or_return!(input, 1, 2);
@@ -69,13 +69,13 @@ pub fn render(input: &str, mut output: Path, matches: &getopts::Matches,
         Ok(f) => f
     };
 
-    let (metadata, text) = extract_leading_metadata(input_str.as_slice());
+    let (metadata, text) = extract_leading_metadata(&input_str);
     if metadata.len() == 0 {
         let _ = writeln!(&mut old_io::stderr(),
                          "invalid markdown file: expecting initial line with `% ...TITLE...`");
         return 5;
     }
-    let title = metadata[0].as_slice();
+    let title = metadata[0];
 
     reset_headers();
 
@@ -141,8 +141,8 @@ pub fn test(input: &str, libs: SearchPaths, externs: core::Externs,
     let input_str = load_or_return!(input, 1, 2);
 
     let mut collector = Collector::new(input.to_string(), libs, externs, true);
-    find_testable_code(input_str.as_slice(), &mut collector);
+    find_testable_code(&input_str, &mut collector);
     test_args.insert(0, "rustdoctest".to_string());
-    testing::test_main(test_args.as_slice(), collector.tests);
+    testing::test_main(&test_args, collector.tests);
     0
 }

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -260,7 +260,7 @@ pub fn unindent_comments(krate: clean::Crate) -> plugins::PluginResult {
                     &clean::NameValue(ref x, ref s)
                             if "doc" == *x => {
                         avec.push(clean::NameValue("doc".to_string(),
-                                                   unindent(s.as_slice())))
+                                                   unindent(s)))
                     }
                     x => avec.push(x.clone())
                 }
@@ -284,7 +284,7 @@ pub fn collapse_docs(krate: clean::Crate) -> plugins::PluginResult {
                 match *attr {
                     clean::NameValue(ref x, ref s)
                             if "doc" == *x => {
-                        docstr.push_str(s.as_slice());
+                        docstr.push_str(s);
                         docstr.push('\n');
                     },
                     _ => ()
@@ -352,14 +352,14 @@ pub fn unindent(s: &str) -> String {
 
     if lines.len() >= 1 {
         let mut unindented = vec![ lines[0].trim().to_string() ];
-        unindented.push_all(lines.tail().iter().map(|&line| {
+        unindented.push_all(&lines.tail().iter().map(|&line| {
             if line.chars().all(|c| c.is_whitespace()) {
                 line.to_string()
             } else {
                 assert!(line.len() >= min_indent);
                 line[min_indent..].to_string()
             }
-        }).collect::<Vec<_>>().as_slice());
+        }).collect::<Vec<_>>());
         unindented.connect("\n")
     } else {
         s.to_string()
@@ -373,14 +373,14 @@ mod unindent_tests {
     #[test]
     fn should_unindent() {
         let s = "    line1\n    line2".to_string();
-        let r = unindent(s.as_slice());
+        let r = unindent(&s);
         assert_eq!(r, "line1\nline2");
     }
 
     #[test]
     fn should_unindent_multiple_paragraphs() {
         let s = "    line1\n\n    line2".to_string();
-        let r = unindent(s.as_slice());
+        let r = unindent(&s);
         assert_eq!(r, "line1\n\nline2");
     }
 
@@ -389,7 +389,7 @@ mod unindent_tests {
         // Line 2 is indented another level beyond the
         // base indentation and should be preserved
         let s = "    line1\n\n        line2".to_string();
-        let r = unindent(s.as_slice());
+        let r = unindent(&s);
         assert_eq!(r, "line1\n\n    line2");
     }
 
@@ -401,14 +401,14 @@ mod unindent_tests {
         // #[doc = "Start way over here
         //          and continue here"]
         let s = "line1\n    line2".to_string();
-        let r = unindent(s.as_slice());
+        let r = unindent(&s);
         assert_eq!(r, "line1\nline2");
     }
 
     #[test]
     fn should_not_ignore_first_line_indent_in_a_single_line_para() {
         let s = "line1\n\n    line2".to_string();
-        let r = unindent(s.as_slice());
+        let r = unindent(&s);
         assert_eq!(r, "line1\n\n    line2");
     }
 }

--- a/src/librustdoc/plugins.rs
+++ b/src/librustdoc/plugins.rs
@@ -88,7 +88,7 @@ fn libname(mut n: String) -> String {
 #[cfg(all(not(target_os="windows"), not(target_os="macos")))]
 fn libname(n: String) -> String {
     let mut i = String::from_str("lib");
-    i.push_str(n.as_slice());
+    i.push_str(&n);
     i.push_str(".so");
     i
 }

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -68,7 +68,7 @@ pub fn run(input: &str,
 
     let mut cfg = config::build_configuration(&sess);
     cfg.extend(cfgs.into_iter().map(|cfg_| {
-        let cfg_ = token::intern_and_get_ident(cfg_.as_slice());
+        let cfg_ = token::intern_and_get_ident(&cfg_);
         P(dummy_spanned(ast::MetaWord(cfg_)))
     }));
     let krate = driver::phase_1_parse_input(&sess, cfg, &input);
@@ -105,7 +105,7 @@ pub fn run(input: &str,
 
     test_args.insert(0, "rustdoctest".to_string());
 
-    testing::test_main(test_args.as_slice(),
+    testing::test_main(&test_args,
                        collector.tests.into_iter().collect());
     0
 }
@@ -194,9 +194,9 @@ fn runtest(test: &str, cratename: &str, libs: SearchPaths,
     let newpath = {
         let mut path = DynamicLibrary::search_path();
         path.insert(0, libdir.clone());
-        DynamicLibrary::create_path(path.as_slice())
+        DynamicLibrary::create_path(&path)
     };
-    cmd.env(DynamicLibrary::envvar(), newpath.as_slice());
+    cmd.env(DynamicLibrary::envvar(), newpath);
 
     match cmd.output() {
         Err(e) => panic!("couldn't run the test: {}{}", e,
@@ -208,7 +208,7 @@ fn runtest(test: &str, cratename: &str, libs: SearchPaths,
                 panic!("test executable succeeded when it should have failed");
             } else if !should_fail && !out.status.success() {
                 panic!("test executable failed:\n{:?}",
-                      str::from_utf8(out.error.as_slice()));
+                      str::from_utf8(&out.error));
             }
         }
     }
@@ -228,8 +228,8 @@ pub fn maketest(s: &str, cratename: Option<&str>, lints: bool, dont_insert_main:
         match cratename {
             Some(cratename) => {
                 if s.contains(cratename) {
-                    prog.push_str(format!("extern crate {};\n",
-                                          cratename).as_slice());
+                    prog.push_str(&format!("extern crate {};\n",
+                                           cratename));
                 }
             }
             None => {}
@@ -239,7 +239,7 @@ pub fn maketest(s: &str, cratename: Option<&str>, lints: bool, dont_insert_main:
         prog.push_str(s);
     } else {
         prog.push_str("fn main() {\n    ");
-        prog.push_str(s.replace("\n", "\n    ").as_slice());
+        prog.push_str(&s.replace("\n", "\n    "));
         prog.push_str("\n}");
     }
 
@@ -275,7 +275,7 @@ impl Collector {
     pub fn add_test(&mut self, test: String,
                     should_fail: bool, no_run: bool, should_ignore: bool, as_test_harness: bool) {
         let name = if self.use_headers {
-            let s = self.current_header.as_ref().map(|s| s.as_slice()).unwrap_or("");
+            let s = self.current_header.as_ref().map(|s| &**s).unwrap_or("");
             format!("{}_{}", s, self.cnt)
         } else {
             format!("{}_{}", self.names.connect("::"), self.cnt)
@@ -292,8 +292,8 @@ impl Collector {
                 should_fail: testing::ShouldFail::No, // compiler failures are test failures
             },
             testfn: testing::DynTestFn(Thunk::new(move|| {
-                runtest(test.as_slice(),
-                        cratename.as_slice(),
+                runtest(&test,
+                        &cratename,
                         libs,
                         externs,
                         should_fail,

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -2061,7 +2061,7 @@ pub fn from_reader(rdr: &mut old_io::Reader) -> Result<Json, BuilderError> {
         Ok(c)  => c,
         Err(e) => return Err(io_error_to_error(e))
     };
-    let s = match str::from_utf8(contents.as_slice()).ok() {
+    let s = match str::from_utf8(&contents).ok() {
         Some(s) => s,
         _       => return Err(SyntaxError(NotUtf8, 0, 0))
     };
@@ -3550,7 +3550,7 @@ mod tests {
         map.insert(Enum::Foo, 0);
         let result = json::encode(&map).unwrap();
         assert_eq!(&result[], r#"{"Foo":0}"#);
-        let decoded: HashMap<Enum, _> = json::decode(result.as_slice()).unwrap();
+        let decoded: HashMap<Enum, _> = json::decode(&result).unwrap();
         assert_eq!(map, decoded);
     }
 
@@ -3591,7 +3591,7 @@ mod tests {
                 None => { break; }
             };
             let (ref expected_evt, ref expected_stack) = expected[i];
-            if !parser.stack().is_equal_to(expected_stack.as_slice()) {
+            if !parser.stack().is_equal_to(expected_stack) {
                 panic!("Parser stack is not equal to {:?}", expected_stack);
             }
             assert_eq!(&evt, expected_evt);
@@ -4022,6 +4022,6 @@ mod tests {
     #[bench]
     fn bench_large(b: &mut Bencher) {
         let src = big_json();
-        b.iter( || { let _ = from_str(src.as_slice()); });
+        b.iter( || { let _ = from_str(&src); });
     }
 }

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -421,7 +421,7 @@ mod tests {
             let lower = if 'A' as u32 <= c && c <= 'Z' as u32 { c + 'a' as u32 - 'A' as u32 }
                         else { c };
             assert!((from_u32(i).unwrap()).to_string().eq_ignore_ascii_case(
-                    (from_u32(lower).unwrap()).to_string().as_slice()));
+                    &from_u32(lower).unwrap().to_string()));
             i += 1;
         }
     }

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -67,9 +67,9 @@ impl DynamicLibrary {
     pub fn prepend_search_path(path: &Path) {
         let mut search_path = DynamicLibrary::search_path();
         search_path.insert(0, path.clone());
-        let newval = DynamicLibrary::create_path(search_path.as_slice());
+        let newval = DynamicLibrary::create_path(&search_path);
         env::set_var(DynamicLibrary::envvar(),
-                     str::from_utf8(newval.as_slice()).unwrap());
+                     str::from_utf8(&newval).unwrap());
     }
 
     /// From a slice of paths, create a new vector which is suitable to be an

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -13,7 +13,7 @@ use iter::IteratorExt;
 use libc;
 use mem;
 use ops::Deref;
-use slice::{self, SliceExt, AsSlice};
+use slice::{self, SliceExt};
 use string::String;
 use vec::Vec;
 
@@ -96,12 +96,12 @@ impl CString {
 
     /// Create a view into this C string which includes the trailing nul
     /// terminator at the end of the string.
-    pub fn as_slice_with_nul(&self) -> &[libc::c_char] { self.inner.as_slice() }
+    pub fn as_slice_with_nul(&self) -> &[libc::c_char] { &self.inner }
 
     /// Similar to the `as_slice` method, but returns a `u8` slice instead of a
     /// `libc::c_char` slice.
     pub fn as_bytes(&self) -> &[u8] {
-        unsafe { mem::transmute(self.as_slice()) }
+        unsafe { mem::transmute(&**self) }
     }
 
     /// Equivalent to `as_slice_with_nul` except that the type returned is a
@@ -197,7 +197,7 @@ mod tests {
         assert_eq!(s.as_bytes(), b"1234");
         assert_eq!(s.as_bytes_with_nul(), b"1234\0");
         unsafe {
-            assert_eq!(s.as_slice(),
+            assert_eq!(&*s,
                        mem::transmute::<_, &[libc::c_char]>(b"1234"));
             assert_eq!(s.as_slice_with_nul(),
                        mem::transmute::<_, &[libc::c_char]>(b"1234\0"));

--- a/src/libstd/old_io/buffered.rs
+++ b/src/libstd/old_io/buffered.rs
@@ -97,7 +97,7 @@ impl<R: Reader> BufferedReader<R> {
 impl<R: Reader> Buffer for BufferedReader<R> {
     fn fill_buf<'a>(&'a mut self) -> IoResult<&'a [u8]> {
         if self.pos == self.cap {
-            self.cap = try!(self.inner.read(self.buf.as_mut_slice()));
+            self.cap = try!(self.inner.read(&mut self.buf));
             self.pos = 0;
         }
         Ok(&self.buf[self.pos..self.cap])

--- a/src/libstd/old_io/comm_adapters.rs
+++ b/src/libstd/old_io/comm_adapters.rs
@@ -191,14 +191,14 @@ mod test {
         let a: &[u8] = &[7,8,6];
         assert_eq!(a, buf);
 
-        match reader.read(buf.as_mut_slice()) {
+        match reader.read(&mut buf) {
             Ok(..) => panic!(),
             Err(e) => assert_eq!(e.kind, old_io::EndOfFile),
         }
         assert_eq!(a, buf);
 
         // Ensure it continues to panic in the same way.
-        match reader.read(buf.as_mut_slice()) {
+        match reader.read(&mut buf) {
             Ok(..) => panic!(),
             Err(e) => assert_eq!(e.kind, old_io::EndOfFile),
         }

--- a/src/libstd/old_io/extensions.rs
+++ b/src/libstd/old_io/extensions.rs
@@ -24,7 +24,7 @@ use option::Option;
 use option::Option::{Some, None};
 use ptr::PtrExt;
 use result::Result::{Ok, Err};
-use slice::{SliceExt, AsSlice};
+use slice::SliceExt;
 
 /// An iterator that reads a single byte on each iteration,
 /// until `.read_byte()` returns `EndOfFile`.
@@ -101,7 +101,7 @@ pub fn u64_to_le_bytes<T, F>(n: u64, size: uint, f: F) -> T where
             n >>= 8;
             i -= 1u;
         }
-        f(bytes.as_slice())
+        f(&bytes)
       }
     }
 }
@@ -140,7 +140,7 @@ pub fn u64_to_be_bytes<T, F>(n: u64, size: uint, f: F) -> T where
             bytes.push((n >> shift) as u8);
             i -= 1u;
         }
-        f(bytes.as_slice())
+        f(&bytes)
       }
     }
 }
@@ -455,7 +455,7 @@ mod test {
         let buf = vec![0x41, 0x02, 0x00, 0x00];
 
         let mut writer = Vec::new();
-        writer.write(buf.as_slice()).unwrap();
+        writer.write(&buf).unwrap();
 
         let mut reader = MemReader::new(writer);
         let f = reader.read_be_f32().unwrap();
@@ -523,7 +523,7 @@ mod bench {
             $b.iter(|| {
                 let mut i = $start_index;
                 while i < data.len() {
-                    sum += u64_from_be_bytes(data.as_slice(), i, $size);
+                    sum += u64_from_be_bytes(&data, i, $size);
                     i += $stride;
                 }
             });

--- a/src/libstd/old_io/fs.rs
+++ b/src/libstd/old_io/fs.rs
@@ -840,7 +840,7 @@ mod test {
     macro_rules! error { ($e:expr, $s:expr) => (
         match $e {
             Ok(_) => panic!("Unexpected success. Should've been: {:?}", $s),
-            Err(ref err) => assert!(err.to_string().contains($s.as_slice()),
+            Err(ref err) => assert!(err.to_string().contains($s),
                                     format!("`{}` did not contain `{}`", err, $s))
         }
     ) }
@@ -892,7 +892,7 @@ mod test {
                 -1|0 => panic!("shouldn't happen"),
                 n => str::from_utf8(&read_buf[..n]).unwrap().to_string()
             };
-            assert_eq!(read_str.as_slice(), message);
+            assert_eq!(read_str, message);
         }
         check!(unlink(filename));
     }
@@ -907,7 +907,7 @@ mod test {
         if cfg!(unix) {
             error!(result, "no such file or directory");
         }
-        error!(result, format!("path={}; mode=open; access=read", filename.display()));
+        error!(result, &format!("path={}; mode=open; access=read", filename.display()));
     }
 
     #[test]
@@ -921,7 +921,7 @@ mod test {
         if cfg!(unix) {
             error!(result, "no such file or directory");
         }
-        error!(result, format!("path={}", filename.display()));
+        error!(result, &format!("path={}", filename.display()));
     }
 
     #[test]
@@ -1120,7 +1120,7 @@ mod test {
                     None|Some("") => panic!("really shouldn't happen.."),
                     Some(n) => format!("{}{}", prefix, n),
                 };
-                assert_eq!(expected.as_slice(), read_str);
+                assert_eq!(expected, read_str);
             }
             check!(unlink(f));
         }
@@ -1189,7 +1189,7 @@ mod test {
         error!(result, "couldn't recursively mkdir");
         error!(result, "couldn't create directory");
         error!(result, "mode=0700");
-        error!(result, format!("path={}", file.display()));
+        error!(result, &format!("path={}", file.display()));
     }
 
     #[test]
@@ -1255,9 +1255,9 @@ mod test {
         let to = Path::new("test/other-bogus-path");
 
         error!(copy(&from, &to),
-            format!("couldn't copy path (the source path is not an \
-                    existing file; from={:?}; to={:?})",
-                    from.display(), to.display()));
+            &format!("couldn't copy path (the source path is not an \
+                     existing file; from={:?}; to={:?})",
+                     from.display(), to.display()));
 
         match copy(&from, &to) {
             Ok(..) => panic!(),
@@ -1277,7 +1277,7 @@ mod test {
         check!(File::create(&input).write(b"hello"));
         check!(copy(&input, &out));
         let contents = check!(File::open(&out).read_to_end());
-        assert_eq!(contents.as_slice(), b"hello");
+        assert_eq!(contents, b"hello");
 
         assert_eq!(check!(input.stat()).perm, check!(out.stat()).perm);
     }

--- a/src/libstd/old_io/mod.rs
+++ b/src/libstd/old_io/mod.rs
@@ -1076,7 +1076,7 @@ pub trait Writer {
     #[inline]
     fn write_char(&mut self, c: char) -> IoResult<()> {
         let mut buf = [0u8; 4];
-        let n = c.encode_utf8(buf.as_mut_slice()).unwrap_or(0);
+        let n = c.encode_utf8(&mut buf).unwrap_or(0);
         self.write_all(&buf[..n])
     }
 
@@ -1870,7 +1870,7 @@ mod tests {
                     // fall back on good
                     return r.read(buf);
                 }
-                match behavior.as_mut_slice()[0] {
+                match (&mut **behavior)[0] {
                     GoodBehavior(0) => (),
                     GoodBehavior(ref mut x) => {
                         *x -= 1;

--- a/src/libstd/old_io/process.rs
+++ b/src/libstd/old_io/process.rs
@@ -239,8 +239,8 @@ impl Command {
                 // if the env is currently just inheriting from the parent's,
                 // materialize the parent's env into a hashtable.
                 self.env = Some(os::env_as_bytes().into_iter().map(|(k, v)| {
-                    (EnvKey(CString::from_slice(k.as_slice())),
-                     CString::from_slice(v.as_slice()))
+                    (EnvKey(CString::from_slice(&k)),
+                     CString::from_slice(&v))
                 }).collect());
                 self.env.as_mut().unwrap()
             }
@@ -440,7 +440,7 @@ impl sys::process::ProcessConfig<EnvKey, CString> for Command {
         &self.program
     }
     fn args(&self) -> &[CString] {
-        self.args.as_slice()
+        &self.args
     }
     fn env(&self) -> Option<&EnvMap> {
         self.env.as_ref()
@@ -915,7 +915,7 @@ mod tests {
     fn test_process_output_output() {
         let ProcessOutput {status, output, error}
              = Command::new("echo").arg("hello").output().unwrap();
-        let output_str = str::from_utf8(output.as_slice()).unwrap();
+        let output_str = str::from_utf8(&output).unwrap();
 
         assert!(status.success());
         assert_eq!(output_str.trim().to_string(), "hello");
@@ -956,7 +956,7 @@ mod tests {
     fn test_wait_with_output_once() {
         let prog = Command::new("echo").arg("hello").spawn().unwrap();
         let ProcessOutput {status, output, error} = prog.wait_with_output().unwrap();
-        let output_str = str::from_utf8(output.as_slice()).unwrap();
+        let output_str = str::from_utf8(&output).unwrap();
 
         assert!(status.success());
         assert_eq!(output_str.trim().to_string(), "hello");
@@ -1049,7 +1049,7 @@ mod tests {
         for &(ref k, ref v) in &r {
             // don't check windows magical empty-named variables
             assert!(k.is_empty() ||
-                    output.contains(format!("{}={}", *k, *v).as_slice()),
+                    output.contains(&format!("{}={}", *k, *v)),
                     "output doesn't contain `{}={}`\n{}",
                     k, v, output);
         }
@@ -1067,12 +1067,12 @@ mod tests {
         for &(ref k, ref v) in &r {
             // don't check android RANDOM variables
             if *k != "RANDOM".to_string() {
-                assert!(output.contains(format!("{}={}",
-                                                *k,
-                                                *v).as_slice()) ||
-                        output.contains(format!("{}=\'{}\'",
-                                                *k,
-                                                *v).as_slice()));
+                assert!(output.contains(&format!("{}={}",
+                                                 *k,
+                                                 *v)) ||
+                        output.contains(&format!("{}=\'{}\'",
+                                                 *k,
+                                                 *v)));
             }
         }
     }
@@ -1091,13 +1091,13 @@ mod tests {
             None => {}
             Some(val) => {
                 path_val = val;
-                new_env.push(("PATH", path_val.as_slice()))
+                new_env.push(("PATH", &path_val))
             }
         }
 
-        let prog = env_cmd().env_set_all(new_env.as_slice()).spawn().unwrap();
+        let prog = env_cmd().env_set_all(&new_env).spawn().unwrap();
         let result = prog.wait_with_output().unwrap();
-        let output = String::from_utf8_lossy(result.output.as_slice()).to_string();
+        let output = String::from_utf8_lossy(&result.output).to_string();
 
         assert!(output.contains("RUN_TEST_NEW_ENV=123"),
                 "didn't find RUN_TEST_NEW_ENV inside of:\n\n{}", output);
@@ -1107,7 +1107,7 @@ mod tests {
     fn test_add_to_env() {
         let prog = env_cmd().env("RUN_TEST_NEW_ENV", "123").spawn().unwrap();
         let result = prog.wait_with_output().unwrap();
-        let output = String::from_utf8_lossy(result.output.as_slice()).to_string();
+        let output = String::from_utf8_lossy(&result.output).to_string();
 
         assert!(output.contains("RUN_TEST_NEW_ENV=123"),
                 "didn't find RUN_TEST_NEW_ENV inside of:\n\n{}", output);

--- a/src/libstd/old_io/result.rs
+++ b/src/libstd/old_io/result.rs
@@ -112,7 +112,7 @@ mod test {
         let mut buf = [0, 0];
         reader.read(&mut buf).unwrap();
         let b: &[_] = &[0, 1];
-        assert_eq!(buf.as_slice(), b);
+        assert_eq!(buf, b);
     }
 
     #[test]

--- a/src/libstd/old_io/util.rs
+++ b/src/libstd/old_io/util.rs
@@ -101,7 +101,7 @@ impl Reader for ZeroReader {
 impl Buffer for ZeroReader {
     fn fill_buf<'a>(&'a mut self) -> old_io::IoResult<&'a [u8]> {
         static DATA: [u8; 64] = [0; 64];
-        Ok(DATA.as_slice())
+        Ok(&DATA)
     }
 
     fn consume(&mut self, _amt: uint) {}
@@ -321,7 +321,7 @@ mod test {
     fn test_null_writer() {
         let mut s = NullWriter;
         let buf = vec![0, 0, 0];
-        s.write_all(buf.as_slice()).unwrap();
+        s.write_all(&buf).unwrap();
         s.flush().unwrap();
     }
 
@@ -329,7 +329,7 @@ mod test {
     fn test_zero_reader() {
         let mut s = ZeroReader;
         let mut buf = vec![1, 2, 3];
-        assert_eq!(s.read(buf.as_mut_slice()), Ok(3));
+        assert_eq!(s.read(&mut buf), Ok(3));
         assert_eq!(vec![0, 0, 0], buf);
     }
 
@@ -337,7 +337,7 @@ mod test {
     fn test_null_reader() {
         let mut r = NullReader;
         let mut buf = vec![0];
-        assert!(r.read(buf.as_mut_slice()).is_err());
+        assert!(r.read(&mut buf).is_err());
     }
 
     #[test]

--- a/src/libstd/old_path/windows.rs
+++ b/src/libstd/old_path/windows.rs
@@ -1337,10 +1337,10 @@ mod tests {
 
         let path = Path::new("foo");
         let mo = path.display().as_cow();
-        assert_eq!(mo.as_slice(), "foo");
+        assert_eq!(mo, "foo");
         let path = Path::new(b"\\");
         let mo = path.filename_display().as_cow();
-        assert_eq!(mo.as_slice(), "");
+        assert_eq!(mo, "");
     }
 
     #[test]

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -649,7 +649,7 @@ fn real_args_as_bytes() -> Vec<Vec<u8>> {
 fn real_args() -> Vec<String> {
     real_args_as_bytes().into_iter()
                         .map(|v| {
-                            String::from_utf8_lossy(v.as_slice()).into_owned()
+                            String::from_utf8_lossy(&v).into_owned()
                         }).collect()
 }
 
@@ -1442,7 +1442,7 @@ mod tests {
         let mut rng = rand::thread_rng();
         let n = format!("TEST{}", rng.gen_ascii_chars().take(10u)
                                      .collect::<String>());
-        assert!(getenv(n.as_slice()).is_none());
+        assert!(getenv(&n).is_none());
         n
     }
 
@@ -1454,27 +1454,27 @@ mod tests {
     #[test]
     fn test_setenv() {
         let n = make_rand_name();
-        setenv(n.as_slice(), "VALUE");
-        assert_eq!(getenv(n.as_slice()), Some("VALUE".to_string()));
+        setenv(&n, "VALUE");
+        assert_eq!(getenv(&n), Some("VALUE".to_string()));
     }
 
     #[test]
     fn test_unsetenv() {
         let n = make_rand_name();
-        setenv(n.as_slice(), "VALUE");
-        unsetenv(n.as_slice());
-        assert_eq!(getenv(n.as_slice()), None);
+        setenv(&n, "VALUE");
+        unsetenv(&n);
+        assert_eq!(getenv(&n), None);
     }
 
     #[test]
     #[ignore]
     fn test_setenv_overwrite() {
         let n = make_rand_name();
-        setenv(n.as_slice(), "1");
-        setenv(n.as_slice(), "2");
-        assert_eq!(getenv(n.as_slice()), Some("2".to_string()));
-        setenv(n.as_slice(), "");
-        assert_eq!(getenv(n.as_slice()), Some("".to_string()));
+        setenv(&n, "1");
+        setenv(&n, "2");
+        assert_eq!(getenv(&n), Some("2".to_string()));
+        setenv(&n, "");
+        assert_eq!(getenv(&n), Some("".to_string()));
     }
 
     // Windows GetEnvironmentVariable requires some extra work to make sure
@@ -1489,9 +1489,9 @@ mod tests {
             i += 1;
         }
         let n = make_rand_name();
-        setenv(n.as_slice(), s.as_slice());
+        setenv(&n, &s);
         debug!("{}", s.clone());
-        assert_eq!(getenv(n.as_slice()), Some(s));
+        assert_eq!(getenv(&n), Some(s));
     }
 
     #[test]
@@ -1524,7 +1524,7 @@ mod tests {
         for p in &e {
             let (n, v) = (*p).clone();
             debug!("{}", n);
-            let v2 = getenv(n.as_slice());
+            let v2 = getenv(&n);
             // MingW seems to set some funky environment variables like
             // "=C:=C:\MinGW\msys\1.0\bin" and "!::=::\" that are returned
             // from env() but not visible from getenv().
@@ -1536,10 +1536,10 @@ mod tests {
     fn test_env_set_get_huge() {
         let n = make_rand_name();
         let s = repeat("x").take(10000).collect::<String>();
-        setenv(n.as_slice(), s.as_slice());
-        assert_eq!(getenv(n.as_slice()), Some(s));
-        unsetenv(n.as_slice());
-        assert_eq!(getenv(n.as_slice()), None);
+        setenv(&n, &s);
+        assert_eq!(getenv(&n), Some(s));
+        unsetenv(&n);
+        assert_eq!(getenv(&n), None);
     }
 
     #[test]
@@ -1547,7 +1547,7 @@ mod tests {
         let n = make_rand_name();
 
         let mut e = env();
-        setenv(n.as_slice(), "VALUE");
+        setenv(&n, "VALUE");
         assert!(!e.contains(&(n.clone(), "VALUE".to_string())));
 
         e = env();
@@ -1577,7 +1577,7 @@ mod tests {
         assert!(os::homedir().is_none());
 
         if let Some(s) = oldhome {
-            setenv("HOME", s.as_slice());
+            setenv("HOME", s);
         }
     }
 
@@ -1606,10 +1606,10 @@ mod tests {
         assert!(os::homedir() == Some(Path::new("/home/MountainView")));
 
         if let Some(s) = oldhome {
-            setenv("HOME", s.as_slice());
+            setenv("HOME", &s);
         }
         if let Some(s) = olduserprofile {
-            setenv("USERPROFILE", s.as_slice());
+            setenv("USERPROFILE", &s);
         }
     }
 

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -469,7 +469,7 @@ mod test {
                        80, 81, 82, 83, 84, 85, 86, 87];
         for &n in &lengths {
             let mut v = repeat(0u8).take(n).collect::<Vec<_>>();
-            r.fill_bytes(v.as_mut_slice());
+            r.fill_bytes(&mut v);
 
             // use this to get nicer error messages.
             for (i, &byte) in v.iter().enumerate() {
@@ -619,8 +619,8 @@ mod test {
     #[test]
     fn test_std_rng_seeded() {
         let s = thread_rng().gen_iter::<uint>().take(256).collect::<Vec<uint>>();
-        let mut ra: StdRng = SeedableRng::from_seed(s.as_slice());
-        let mut rb: StdRng = SeedableRng::from_seed(s.as_slice());
+        let mut ra: StdRng = SeedableRng::from_seed(&*s);
+        let mut rb: StdRng = SeedableRng::from_seed(&*s);
         assert!(order::equals(ra.gen_ascii_chars().take(100),
                               rb.gen_ascii_chars().take(100)));
     }
@@ -628,10 +628,10 @@ mod test {
     #[test]
     fn test_std_rng_reseed() {
         let s = thread_rng().gen_iter::<uint>().take(256).collect::<Vec<uint>>();
-        let mut r: StdRng = SeedableRng::from_seed(s.as_slice());
+        let mut r: StdRng = SeedableRng::from_seed(&*s);
         let string1 = r.gen_ascii_chars().take(100).collect::<String>();
 
-        r.reseed(s.as_slice());
+        r.reseed(&s);
 
         let string2 = r.gen_ascii_chars().take(100).collect::<String>();
         assert_eq!(string1, string2);

--- a/src/libstd/sync/mpsc/spsc_queue.rs
+++ b/src/libstd/sync/mpsc/spsc_queue.rs
@@ -274,7 +274,7 @@ mod test {
 
             // Ensure the borrowchecker works
             match queue.peek() {
-                Some(vec) => match vec.as_slice() {
+                Some(vec) => match &**vec {
                     // Note that `pop` is not allowed here due to borrow
                     [1] => {}
                     _ => return

--- a/src/libstd/sys/common/thread_info.rs
+++ b/src/libstd/sys/common/thread_info.rs
@@ -57,7 +57,7 @@ pub fn stack_guard() -> uint {
 pub fn set(stack_bounds: (uint, uint), stack_guard: uint, thread: Thread) {
     THREAD_INFO.with(|c| assert!(c.borrow().is_none()));
     match thread.name() {
-        Some(name) => unsafe { ::sys::thread::set_name(name.as_slice()); },
+        Some(name) => unsafe { ::sys::thread::set_name(name); },
         None => {}
     }
     THREAD_INFO.with(move |c| *c.borrow_mut() = Some(ThreadInfo{

--- a/src/libstd/sys/unix/os_str.rs
+++ b/src/libstd/sys/unix/os_str.rs
@@ -51,7 +51,7 @@ impl Buf {
     }
 
     pub fn as_slice(&self) -> &Slice {
-        unsafe { mem::transmute(self.inner.as_slice()) }
+        unsafe { mem::transmute(&*self.inner) }
     }
 
     pub fn into_string(self) -> Result<String, Buf> {

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -389,7 +389,7 @@ fn make_command_line(prog: &CString, args: &[CString]) -> String {
         }
         let argvec: Vec<char> = arg.chars().collect();
         for i in 0u..argvec.len() {
-            append_char_at(cmd, argvec.as_slice(), i);
+            append_char_at(cmd, &argvec, i);
         }
         if quote {
             cmd.push('"');
@@ -485,10 +485,9 @@ mod tests {
     fn test_make_command_line() {
         fn test_wrapper(prog: &str, args: &[&str]) -> String {
             make_command_line(&CString::from_slice(prog.as_bytes()),
-                              args.iter()
-                                  .map(|a| CString::from_slice(a.as_bytes()))
-                                  .collect::<Vec<CString>>()
-                                  .as_slice())
+                              &args.iter()
+                                   .map(|a| CString::from_slice(a.as_bytes()))
+                                   .collect::<Vec<CString>>())
         }
 
         assert_eq!(

--- a/src/libstd/sys/windows/tty.rs
+++ b/src/libstd/sys/windows/tty.rs
@@ -104,7 +104,7 @@ impl TTY {
                 _ => (),
             };
             utf16.truncate(num as uint);
-            let utf8 = match String::from_utf16(utf16.as_slice()) {
+            let utf8 = match String::from_utf16(&utf16) {
                 Ok(utf8) => utf8.into_bytes(),
                 Err(..) => return Err(invalid_encoding()),
             };

--- a/src/libstd/thread.rs
+++ b/src/libstd/thread.rs
@@ -156,7 +156,6 @@ use ops::{Drop, FnOnce};
 use option::Option::{self, Some, None};
 use result::Result::{Err, Ok};
 use sync::{Mutex, Condvar, Arc};
-use str::Str;
 use string::String;
 use rt::{self, unwind};
 use old_io::{Writer, stdio};
@@ -452,7 +451,7 @@ impl Thread {
     /// Get the thread's name.
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn name(&self) -> Option<&str> {
-        self.inner.name.as_ref().map(|s| s.as_slice())
+        self.inner.name.as_ref().map(|s| &**s)
     }
 }
 
@@ -574,7 +573,7 @@ mod test {
     fn test_join_success() {
         match Thread::scoped(move|| -> String {
             "Success!".to_string()
-        }).join().as_ref().map(|s| s.as_slice()) {
+        }).join().as_ref().map(|s| &**s) {
             result::Result::Ok("Success!") => (),
             _ => panic!()
         }

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -338,7 +338,7 @@ pub fn cfg_matches(diagnostic: &SpanHandler, cfgs: &[P<MetaItem>], cfg: &ast::Me
             !cfg_matches(diagnostic, cfgs, &*mis[0])
         }
         ast::MetaList(ref pred, _) => {
-            diagnostic.span_err(cfg.span, format!("invalid predicate `{}`", pred).as_slice());
+            diagnostic.span_err(cfg.span, &format!("invalid predicate `{}`", pred));
             false
         },
         ast::MetaWord(_) | ast::MetaNameValue(..) => contains(cfgs, cfg),

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -27,7 +27,7 @@ struct Context<F> where F: FnMut(&[ast::Attribute]) -> bool {
 // any items that do not belong in the current configuration
 pub fn strip_unconfigured_items(diagnostic: &SpanHandler, krate: ast::Crate) -> ast::Crate {
     let config = krate.config.clone();
-    strip_items(krate, |attrs| in_cfg(diagnostic, config.as_slice(), attrs))
+    strip_items(krate, |attrs| in_cfg(diagnostic, &config, attrs))
 }
 
 impl<F> fold::Folder for Context<F> where F: FnMut(&[ast::Attribute]) -> bool {
@@ -132,7 +132,7 @@ fn fold_item_underscore<F>(cx: &mut Context<F>, item: ast::Item_) -> ast::Item_ 
         }
         ast::ItemEnum(def, generics) => {
             let variants = def.variants.into_iter().filter_map(|v| {
-                if !(cx.in_cfg)(v.node.attrs.as_slice()) {
+                if !(cx.in_cfg)(&v.node.attrs) {
                     None
                 } else {
                     Some(v.map(|Spanned {node: ast::Variant_ {id, name, attrs, kind,
@@ -172,7 +172,7 @@ fn fold_struct<F>(cx: &mut Context<F>, def: P<ast::StructDef>) -> P<ast::StructD
     def.map(|ast::StructDef { fields, ctor_id }| {
         ast::StructDef {
             fields: fields.into_iter().filter(|m| {
-                (cx.in_cfg)(m.node.attrs.as_slice())
+                (cx.in_cfg)(&m.node.attrs)
             }).collect(),
             ctor_id: ctor_id,
         }
@@ -223,7 +223,7 @@ fn fold_expr<F>(cx: &mut Context<F>, expr: P<ast::Expr>) -> P<ast::Expr> where
             node: match node {
                 ast::ExprMatch(m, arms, source) => {
                     ast::ExprMatch(m, arms.into_iter()
-                                        .filter(|a| (cx.in_cfg)(a.attrs.as_slice()))
+                                        .filter(|a| (cx.in_cfg)(&a.attrs))
                                         .collect(), source)
                 }
                 _ => node
@@ -236,22 +236,22 @@ fn fold_expr<F>(cx: &mut Context<F>, expr: P<ast::Expr>) -> P<ast::Expr> where
 fn item_in_cfg<F>(cx: &mut Context<F>, item: &ast::Item) -> bool where
     F: FnMut(&[ast::Attribute]) -> bool
 {
-    return (cx.in_cfg)(item.attrs.as_slice());
+    return (cx.in_cfg)(&item.attrs);
 }
 
 fn foreign_item_in_cfg<F>(cx: &mut Context<F>, item: &ast::ForeignItem) -> bool where
     F: FnMut(&[ast::Attribute]) -> bool
 {
-    return (cx.in_cfg)(item.attrs.as_slice());
+    return (cx.in_cfg)(&item.attrs);
 }
 
 fn trait_method_in_cfg<F>(cx: &mut Context<F>, meth: &ast::TraitItem) -> bool where
     F: FnMut(&[ast::Attribute]) -> bool
 {
     match *meth {
-        ast::RequiredMethod(ref meth) => (cx.in_cfg)(meth.attrs.as_slice()),
-        ast::ProvidedMethod(ref meth) => (cx.in_cfg)(meth.attrs.as_slice()),
-        ast::TypeTraitItem(ref typ) => (cx.in_cfg)(typ.attrs.as_slice()),
+        ast::RequiredMethod(ref meth) => (cx.in_cfg)(&meth.attrs),
+        ast::ProvidedMethod(ref meth) => (cx.in_cfg)(&meth.attrs),
+        ast::TypeTraitItem(ref typ) => (cx.in_cfg)(&typ.attrs),
     }
 }
 
@@ -259,8 +259,8 @@ fn impl_item_in_cfg<F>(cx: &mut Context<F>, impl_item: &ast::ImplItem) -> bool w
     F: FnMut(&[ast::Attribute]) -> bool
 {
     match *impl_item {
-        ast::MethodImplItem(ref meth) => (cx.in_cfg)(meth.attrs.as_slice()),
-        ast::TypeImplItem(ref typ) => (cx.in_cfg)(typ.attrs.as_slice()),
+        ast::MethodImplItem(ref meth) => (cx.in_cfg)(&meth.attrs),
+        ast::TypeImplItem(ref typ) => (cx.in_cfg)(&typ.attrs),
     }
 }
 

--- a/src/libsyntax/diagnostics/macros.rs
+++ b/src/libsyntax/diagnostics/macros.rs
@@ -18,7 +18,7 @@ macro_rules! register_diagnostic {
 macro_rules! span_fatal {
     ($session:expr, $span:expr, $code:ident, $($message:tt)*) => ({
         __diagnostic_used!($code);
-        $session.span_fatal_with_code($span, format!($($message)*).as_slice(), stringify!($code))
+        $session.span_fatal_with_code($span, &format!($($message)*), stringify!($code))
     })
 }
 
@@ -26,7 +26,7 @@ macro_rules! span_fatal {
 macro_rules! span_err {
     ($session:expr, $span:expr, $code:ident, $($message:tt)*) => ({
         __diagnostic_used!($code);
-        $session.span_err_with_code($span, format!($($message)*).as_slice(), stringify!($code))
+        $session.span_err_with_code($span, &format!($($message)*), stringify!($code))
     })
 }
 
@@ -34,21 +34,21 @@ macro_rules! span_err {
 macro_rules! span_warn {
     ($session:expr, $span:expr, $code:ident, $($message:tt)*) => ({
         __diagnostic_used!($code);
-        $session.span_warn_with_code($span, format!($($message)*).as_slice(), stringify!($code))
+        $session.span_warn_with_code($span, &format!($($message)*), stringify!($code))
     })
 }
 
 #[macro_export]
 macro_rules! span_note {
     ($session:expr, $span:expr, $($message:tt)*) => ({
-        ($session).span_note($span, format!($($message)*).as_slice())
+        ($session).span_note($span, &format!($($message)*))
     })
 }
 
 #[macro_export]
 macro_rules! span_help {
     ($session:expr, $span:expr, $($message:tt)*) => ({
-        ($session).span_help($span, format!($($message)*).as_slice())
+        ($session).span_help($span, &format!($($message)*))
     })
 }
 

--- a/src/libsyntax/ext/cfg.rs
+++ b/src/libsyntax/ext/cfg.rs
@@ -34,6 +34,6 @@ pub fn expand_cfg<'cx>(cx: &mut ExtCtxt,
         return DummyResult::expr(sp);
     }
 
-    let matches_cfg = attr::cfg_matches(&cx.parse_sess.span_diagnostic, cx.cfg.as_slice(), &*cfg);
+    let matches_cfg = attr::cfg_matches(&cx.parse_sess.span_diagnostic, &cx.cfg, &*cfg);
     MacExpr::new(cx.expr_bool(sp, matches_cfg))
 }

--- a/src/libsyntax/ext/cfg_attr.rs
+++ b/src/libsyntax/ext/cfg_attr.rs
@@ -25,7 +25,7 @@ pub fn expand(cx: &mut ExtCtxt, sp: Span, mi: &ast::MetaItem, it: P<ast::Item>) 
     };
 
     let mut out = (*it).clone();
-    if attr::cfg_matches(&cx.parse_sess.span_diagnostic, cx.cfg.as_slice(), &**cfg) {
+    if attr::cfg_matches(&cx.parse_sess.span_diagnostic, &cx.cfg, &**cfg) {
         out.attrs.push(cx.attribute(attr.span, attr.clone()));
     }
 

--- a/src/libsyntax/ext/deriving/bounds.rs
+++ b/src/libsyntax/ext/deriving/bounds.rs
@@ -28,14 +28,14 @@ pub fn expand_deriving_bound<F>(cx: &mut ExtCtxt,
                 "Copy" => "Copy",
                 "Send" | "Sync" => {
                     return cx.span_err(span,
-                                       format!("{} is an unsafe trait and it \
-                                                should be implemented explicitly",
-                                               *tname).as_slice())
+                                       &format!("{} is an unsafe trait and it \
+                                                 should be implemented explicitly",
+                                                *tname))
                 }
                 ref tname => {
                     cx.span_bug(span,
-                                format!("expected built-in trait name but \
-                                         found {}", *tname).as_slice())
+                                &format!("expected built-in trait name but \
+                                          found {}", *tname))
                 }
             }
         },

--- a/src/libsyntax/ext/deriving/generic/ty.rs
+++ b/src/libsyntax/ext/deriving/generic/ty.rs
@@ -247,7 +247,7 @@ impl<'a> LifetimeBounds<'a> {
                     mk_ty_param(cx,
                                 span,
                                 *name,
-                                bounds.as_slice(),
+                                bounds,
                                 self_ty,
                                 self_generics)
                 }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -664,7 +664,7 @@ pub fn expand_item_mac(it: P<ast::Item>,
                         id: ast::DUMMY_NODE_ID,
                         span: it.span,
                         imported_from: None,
-                        export: attr::contains_name(it.attrs.as_slice(), "macro_export"),
+                        export: attr::contains_name(&it.attrs, "macro_export"),
                         use_locally: true,
                         body: tts,
                     };

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -319,11 +319,11 @@ fn check_matcher<'a, I>(cx: &mut ExtCtxt, matcher: I, follow: &Token)
                     Some(&&TtToken(_, ref tok)) => tok.clone(),
                     Some(&&TtSequence(sp, _)) => {
                         cx.span_err(sp,
-                                    format!("`${0}:{1}` is followed by a \
-                                             sequence repetition, which is not \
-                                             allowed for `{1}` fragments",
-                                            name.as_str(), frag_spec.as_str())
-                                        .as_slice());
+                                    &format!("`${0}:{1}` is followed by a \
+                                              sequence repetition, which is not \
+                                              allowed for `{1}` fragments",
+                                             name.as_str(), frag_spec.as_str())
+                                        );
                         Eof
                     },
                     // die next iteration
@@ -338,14 +338,14 @@ fn check_matcher<'a, I>(cx: &mut ExtCtxt, matcher: I, follow: &Token)
                     (&Eof, _) => return Some((sp, tok.clone())),
                     (_, Ok(true)) => continue,
                     (next, Ok(false)) => {
-                        cx.span_err(sp, format!("`${0}:{1}` is followed by `{2}`, which \
-                                                 is not allowed for `{1}` fragments",
+                        cx.span_err(sp, &format!("`${0}:{1}` is followed by `{2}`, which \
+                                                  is not allowed for `{1}` fragments",
                                                  name.as_str(), frag_spec.as_str(),
-                                                 token_to_string(next)).as_slice());
+                                                 token_to_string(next)));
                         continue
                     },
                     (_, Err(msg)) => {
-                        cx.span_err(sp, msg.as_slice());
+                        cx.span_err(sp, &msg);
                         continue
                     }
                 }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -338,7 +338,7 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
                     _ => {}
                 }
 
-                if attr::contains_name(i.attrs.as_slice(),
+                if attr::contains_name(&i.attrs,
                                        "unsafe_destructor") {
                     self.gate_feature("unsafe_destructor",
                                       i.span,
@@ -376,7 +376,7 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
                                and not portable across platforms")
         }
 
-        let links_to_llvm = match attr::first_attr_value_str_by_name(i.attrs.as_slice(),
+        let links_to_llvm = match attr::first_attr_value_str_by_name(&i.attrs,
                                                                      "link_name") {
             Some(val) => val.get().starts_with("llvm."),
             _ => false

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -592,7 +592,7 @@ pub fn noop_fold_mac<T: Folder>(Spanned {node, span}: Mac, fld: &mut T) -> Mac {
     Spanned {
         node: match node {
             MacInvocTT(p, tts, ctxt) => {
-                MacInvocTT(fld.fold_path(p), fld.fold_tts(tts.as_slice()), ctxt)
+                MacInvocTT(fld.fold_path(p), fld.fold_tts(&tts), ctxt)
             }
         },
         span: fld.new_span(span)
@@ -629,7 +629,7 @@ pub fn noop_fold_tt<T: Folder>(tt: &TokenTree, fld: &mut T) -> TokenTree {
                             Delimited {
                                 delim: delimed.delim,
                                 open_span: delimed.open_span,
-                                tts: fld.fold_tts(delimed.tts.as_slice()),
+                                tts: fld.fold_tts(&delimed.tts),
                                 close_span: delimed.close_span,
                             }
                         ))
@@ -637,7 +637,7 @@ pub fn noop_fold_tt<T: Folder>(tt: &TokenTree, fld: &mut T) -> TokenTree {
         TtSequence(span, ref seq) =>
             TtSequence(span,
                        Rc::new(SequenceRepetition {
-                           tts: fld.fold_tts(seq.tts.as_slice()),
+                           tts: fld.fold_tts(&seq.tts),
                            separator: seq.separator.clone().map(|tok| fld.fold_token(tok)),
                            ..**seq
                        })),
@@ -1441,7 +1441,7 @@ mod test {
     // this version doesn't care about getting comments or docstrings in.
     fn fake_print_crate(s: &mut pprust::State,
                         krate: &ast::Crate) -> old_io::IoResult<()> {
-        s.print_mod(&krate.module, krate.attrs.as_slice())
+        s.print_mod(&krate.module, &krate.attrs)
     }
 
     // change every identifier to "zz"
@@ -1463,7 +1463,7 @@ mod test {
                 let pred_val = $pred;
                 let a_val = $a;
                 let b_val = $b;
-                if !(pred_val(a_val.as_slice(),b_val.as_slice())) {
+                if !(pred_val(&a_val, &b_val)) {
                     panic!("expected args satisfying {}, got {} and {}",
                           $predname, a_val, b_val);
                 }

--- a/src/libsyntax/owned_slice.rs
+++ b/src/libsyntax/owned_slice.rs
@@ -72,7 +72,7 @@ impl<T> Default for OwnedSlice<T> {
 
 impl<T: Clone> Clone for OwnedSlice<T> {
     fn clone(&self) -> OwnedSlice<T> {
-        OwnedSlice::from_vec(self.as_slice().to_vec())
+        OwnedSlice::from_vec(self.to_vec())
     }
 }
 
@@ -84,7 +84,7 @@ impl<T> FromIterator<T> for OwnedSlice<T> {
 
 impl<T: Encodable> Encodable for OwnedSlice<T> {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-       self.as_slice().encode(s)
+        Encodable::encode(&**self, s)
     }
 }
 

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -360,7 +360,7 @@ impl<'a> StringReader<'a> {
 
     pub fn nextnextch(&self) -> Option<char> {
         let offset = self.byte_offset(self.pos).to_usize();
-        let s = self.filemap.src.as_slice();
+        let s = &*self.filemap.src;
         if offset >= s.len() { return None }
         let str::CharRange { next, .. } = s.char_range_at(offset);
         if next < s.len() {

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -454,7 +454,7 @@ pub fn str_lit(lit: &str) -> String {
                 match c {
                     '\\' => {
                         let ch = chars.peek().unwrap_or_else(|| {
-                            panic!("{}", error(i).as_slice())
+                            panic!("{}", error(i))
                         }).1;
 
                         if ch == '\n' {
@@ -462,7 +462,7 @@ pub fn str_lit(lit: &str) -> String {
                         } else if ch == '\r' {
                             chars.next();
                             let ch = chars.peek().unwrap_or_else(|| {
-                                panic!("{}", error(i).as_slice())
+                                panic!("{}", error(i))
                             }).1;
 
                             if ch != '\n' {
@@ -480,7 +480,7 @@ pub fn str_lit(lit: &str) -> String {
                     },
                     '\r' => {
                         let ch = chars.peek().unwrap_or_else(|| {
-                            panic!("{}", error(i).as_slice())
+                            panic!("{}", error(i))
                         }).1;
 
                         if ch != '\n' {
@@ -622,11 +622,11 @@ pub fn binary_lit(lit: &str) -> Rc<Vec<u8>> {
         match chars.next() {
             Some((i, b'\\')) => {
                 let em = error(i);
-                match chars.peek().expect(em.as_slice()).1 {
+                match chars.peek().expect(&em).1 {
                     b'\n' => eat(&mut chars),
                     b'\r' => {
                         chars.next();
-                        if chars.peek().expect(em.as_slice()).1 != b'\n' {
+                        if chars.peek().expect(&em).1 != b'\n' {
                             panic!("lexer accepted bare CR");
                         }
                         eat(&mut chars);
@@ -644,7 +644,7 @@ pub fn binary_lit(lit: &str) -> Rc<Vec<u8>> {
             },
             Some((i, b'\r')) => {
                 let em = error(i);
-                if chars.peek().expect(em.as_slice()).1 != b'\n' {
+                if chars.peek().expect(&em).1 != b'\n' {
                     panic!("lexer accepted bare CR");
                 }
                 chars.next();
@@ -1200,7 +1200,7 @@ mod test {
         let name = "<source>".to_string();
         let source = "/// doc comment\r\nfn foo() {}".to_string();
         let item = parse_item_from_source_str(name.clone(), source, Vec::new(), &sess).unwrap();
-        let doc = first_attr_value_str_by_name(item.attrs.as_slice(), "doc").unwrap();
+        let doc = first_attr_value_str_by_name(&item.attrs, "doc").unwrap();
         assert_eq!(doc.get(), "/// doc comment");
 
         let source = "/// doc comment\r\n/// line 2\r\nfn foo() {}".to_string();
@@ -1212,7 +1212,7 @@ mod test {
 
         let source = "/** doc comment\r\n *  with CRLF */\r\nfn foo() {}".to_string();
         let item = parse_item_from_source_str(name, source, Vec::new(), &sess).unwrap();
-        let doc = first_attr_value_str_by_name(item.attrs.as_slice(), "doc").unwrap();
+        let doc = first_attr_value_str_by_name(&item.attrs, "doc").unwrap();
         assert_eq!(doc.get(), "/** doc comment\n *  with CRLF */");
     }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1681,7 +1681,7 @@ impl<'a> Parser<'a> {
 
                     token::Str_(s) => {
                         (true,
-                         LitStr(token::intern_and_get_ident(parse::str_lit(s.as_str()).as_slice()),
+                         LitStr(token::intern_and_get_ident(&parse::str_lit(s.as_str())),
                                 ast::CookedStr))
                     }
                     token::StrRaw(s, n) => {
@@ -2596,7 +2596,7 @@ impl<'a> Parser<'a> {
                         |p| p.parse_token_tree()
                     );
                     let (sep, repeat) = self.parse_sep_and_kleene_op();
-                    let name_num = macro_parser::count_names(seq.as_slice());
+                    let name_num = macro_parser::count_names(&seq);
                     return TtSequence(mk_sp(sp.lo, seq_span.hi),
                                       Rc::new(SequenceRepetition {
                                           tts: seq,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1485,7 +1485,7 @@ impl<'a> State<'a> {
                     token::Bracket => try!(word(&mut self.s, "[")),
                     token::Brace => try!(self.bopen()),
                 }
-                try!(self.print_tts(tts.as_slice()));
+                try!(self.print_tts(tts));
                 match delim {
                     token::Paren => self.pclose(),
                     token::Bracket => word(&mut self.s, "]"),
@@ -2502,7 +2502,7 @@ impl<'a> State<'a> {
                                                                               ref bounds,
                                                                               ..}) => {
                     try!(self.print_type(&**bounded_ty));
-                    try!(self.print_bounds(":", bounds.as_slice()));
+                    try!(self.print_bounds(":", bounds));
                 }
                 &ast::WherePredicate::RegionPredicate(ast::WhereRegionPredicate{ref lifetime,
                                                                                 ref bounds,
@@ -2760,7 +2760,7 @@ impl<'a> State<'a> {
                              &format!("-{}", istr)[])
                     }
                     ast::UnsignedIntLit(ut) => {
-                        word(&mut self.s, ast_util::uint_ty_to_string(ut, Some(i)).as_slice())
+                        word(&mut self.s, &ast_util::uint_ty_to_string(ut, Some(i)))
                     }
                     ast::UnsuffixedIntLit(ast::Plus) => {
                         word(&mut self.s, &format!("{}", i)[])
@@ -2937,7 +2937,7 @@ impl<'a> State<'a> {
                                 opt_unsafety: Option<ast::Unsafety>,
                                 abi: abi::Abi,
                                 vis: ast::Visibility) -> IoResult<()> {
-        try!(word(&mut self.s, visibility_qualified(vis, "").as_slice()));
+        try!(word(&mut self.s, &visibility_qualified(vis, "")));
         try!(self.print_opt_unsafety(opt_unsafety));
 
         if abi != abi::Rust {

--- a/src/libsyntax/util/small_vector.rs
+++ b/src/libsyntax/util/small_vector.rs
@@ -65,7 +65,7 @@ impl<T> SmallVector<T> {
                 result
             }
             One(ref v) => slice::ref_slice(v),
-            Many(ref vs) => vs.as_slice()
+            Many(ref vs) => vs
         }
     }
 

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -762,7 +762,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             visitor.visit_expr(&**subexpression)
         }
         ExprVec(ref subexpressions) => {
-            walk_exprs(visitor, subexpressions.as_slice())
+            walk_exprs(visitor, subexpressions)
         }
         ExprRepeat(ref element, ref count) => {
             visitor.visit_expr(&**element);
@@ -787,7 +787,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             visitor.visit_expr(&**callee_expression)
         }
         ExprMethodCall(_, ref types, ref arguments) => {
-            walk_exprs(visitor, arguments.as_slice());
+            walk_exprs(visitor, arguments);
             for typ in types {
                 visitor.visit_ty(&**typ)
             }

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -80,10 +80,10 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
                                .strings
                                .get("setaf")
                                .unwrap()
-                               .as_slice(),
+                               ,
                            &[Number(color as int)], &mut Variables::new());
             if s.is_ok() {
-                try!(self.out.write_all(s.unwrap().as_slice()));
+                try!(self.out.write_all(&s.unwrap()));
                 return Ok(true)
             }
         }
@@ -97,10 +97,10 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
                                .strings
                                .get("setab")
                                .unwrap()
-                               .as_slice(),
+                               ,
                            &[Number(color as int)], &mut Variables::new());
             if s.is_ok() {
-                try!(self.out.write_all(s.unwrap().as_slice()));
+                try!(self.out.write_all(&s.unwrap()));
                 return Ok(true)
             }
         }
@@ -115,11 +115,11 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
                 let cap = cap_for_attr(attr);
                 let parm = self.ti.strings.get(cap);
                 if parm.is_some() {
-                    let s = expand(parm.unwrap().as_slice(),
+                    let s = expand(parm.unwrap(),
                                    &[],
                                    &mut Variables::new());
                     if s.is_ok() {
-                        try!(self.out.write_all(s.unwrap().as_slice()));
+                        try!(self.out.write_all(&s.unwrap()));
                         return Ok(true)
                     }
                 }
@@ -151,10 +151,10 @@ impl<T: Writer+Send> Terminal<T> for TerminfoTerminal<T> {
             }
         }
         let s = cap.map_or(Err("can't find terminfo capability `sgr0`".to_string()), |op| {
-            expand(op.as_slice(), &[], &mut Variables::new())
+            expand(op, &[], &mut Variables::new())
         });
         if s.is_ok() {
-            return self.out.write_all(s.unwrap().as_slice())
+            return self.out.write_all(&s.unwrap())
         }
         Ok(())
     }

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -257,7 +257,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                         let flags = Flags::new();
                         let res = format(stack.pop().unwrap(), FormatOp::from_char(cur), flags);
                         if res.is_err() { return res }
-                        output.push_all(res.unwrap().as_slice())
+                        output.push_all(&res.unwrap())
                     } else { return Err("stack is empty".to_string()) },
                     ':'|'#'|' '|'.'|'0'...'9' => {
                         let mut flags = Flags::new();
@@ -355,7 +355,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     (_,'d')|(_,'o')|(_,'x')|(_,'X')|(_,'s') => if stack.len() > 0 {
                         let res = format(stack.pop().unwrap(), FormatOp::from_char(cur), *flags);
                         if res.is_err() { return res }
-                        output.push_all(res.unwrap().as_slice());
+                        output.push_all(&res.unwrap());
                         // will cause state to go to Nothing
                         old_state = FormatPattern(*flags, *fstate);
                     } else { return Err("stack is empty".to_string()) },
@@ -609,7 +609,7 @@ mod test {
         {
             let mut u8v: Vec<_> = fmt.bytes().collect();
             u8v.extend(cap.as_bytes().iter().map(|&b| b));
-            expand(u8v.as_slice(), params, vars)
+            expand(&u8v, params, vars)
         }
 
         let caps = ["%d", "%c", "%s", "%Pa", "%l", "%!", "%~"];

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -260,19 +260,19 @@ impl<T: Float + FromPrimitive> Stats<T> for [T] {
 
     fn percentile(&self, pct: T) -> T {
         let mut tmp = self.to_vec();
-        local_sort(tmp.as_mut_slice());
-        percentile_of_sorted(tmp.as_slice(), pct)
+        local_sort(&mut tmp);
+        percentile_of_sorted(&tmp, pct)
     }
 
     fn quartiles(&self) -> (T,T,T) {
         let mut tmp = self.to_vec();
-        local_sort(tmp.as_mut_slice());
+        local_sort(&mut tmp);
         let first = FromPrimitive::from_uint(25).unwrap();
-        let a = percentile_of_sorted(tmp.as_slice(), first);
+        let a = percentile_of_sorted(&tmp, first);
         let secound = FromPrimitive::from_uint(50).unwrap();
-        let b = percentile_of_sorted(tmp.as_slice(), secound);
+        let b = percentile_of_sorted(&tmp, secound);
         let third = FromPrimitive::from_uint(75).unwrap();
-        let c = percentile_of_sorted(tmp.as_slice(), third);
+        let c = percentile_of_sorted(&tmp, third);
         (a,b,c)
     }
 
@@ -317,10 +317,10 @@ fn percentile_of_sorted<T: Float + FromPrimitive>(sorted_samples: &[T],
 /// See: http://en.wikipedia.org/wiki/Winsorising
 pub fn winsorize<T: Float + FromPrimitive>(samples: &mut [T], pct: T) {
     let mut tmp = samples.to_vec();
-    local_sort(tmp.as_mut_slice());
-    let lo = percentile_of_sorted(tmp.as_slice(), pct);
+    local_sort(&mut tmp);
+    let lo = percentile_of_sorted(&tmp, pct);
     let hundred: T = FromPrimitive::from_uint(100).unwrap();
-    let hi = percentile_of_sorted(tmp.as_slice(), hundred-pct);
+    let hi = percentile_of_sorted(&tmp, hundred-pct);
     for samp in samples {
         if *samp > hi {
             *samp = hi

--- a/src/libunicode/u_str.rs
+++ b/src/libunicode/u_str.rs
@@ -527,7 +527,7 @@ impl<I> Iterator for Utf16Encoder<I> where I: Iterator<Item=char> {
 
         let mut buf = [0u16; 2];
         self.chars.next().map(|ch| {
-            let n = CharExt::encode_utf16(ch, buf.as_mut_slice()).unwrap_or(0);
+            let n = CharExt::encode_utf16(ch, &mut buf).unwrap_or(0);
             if n == 2 { self.extra = buf[1]; }
             buf[0]
         })

--- a/src/test/auxiliary/plugin_args.rs
+++ b/src/test/auxiliary/plugin_args.rs
@@ -38,7 +38,7 @@ impl TTMacroExpander for Expander {
 
         let attr = ecx.attribute(sp, self.args.clone());
         let src = pprust::attribute_to_string(&attr);
-        let interned = token::intern_and_get_ident(src.as_slice());
+        let interned = token::intern_and_get_ident(&src);
         MacExpr::new(ecx.expr_str(sp, interned))
     }
 }

--- a/src/test/auxiliary/roman_numerals.rs
+++ b/src/test/auxiliary/roman_numerals.rs
@@ -46,7 +46,7 @@ fn expand_rn(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
         }
     };
 
-    let mut text = text.as_slice();
+    let mut text = &*text;
     let mut total = 0u;
     while !text.is_empty() {
         match NUMERALS.iter().find(|&&(rn, _)| text.starts_with(rn)) {

--- a/src/test/auxiliary/static-methods-crate.rs
+++ b/src/test/auxiliary/static-methods-crate.rs
@@ -25,7 +25,7 @@ impl read for int {
 
 impl read for bool {
     fn readMaybe(s: String) -> Option<bool> {
-        match s.as_slice() {
+        match &*s {
           "true" => Some(true),
           "false" => Some(false),
           _ => None

--- a/src/test/bench/core-map.rs
+++ b/src/test/bench/core-map.rs
@@ -102,7 +102,7 @@ fn vector<M: MutableMap>(map: &mut M, n_keys: uint, dist: &[uint]) {
 
 fn main() {
     let args = os::args();
-    let args = args.as_slice();
+    let args = args;
     let n_keys = {
         if args.len() == 2 {
             args[1].parse::<uint>().unwrap()
@@ -143,7 +143,7 @@ fn main() {
     {
         println!(" Random integers:");
         let mut map: BTreeMap<uint,uint> = BTreeMap::new();
-        vector(&mut map, n_keys, rand.as_slice());
+        vector(&mut map, n_keys, &rand);
     }
 
     // FIXME: #9970
@@ -162,6 +162,6 @@ fn main() {
     {
         println!(" Random integers:");
         let mut map: HashMap<uint,uint> = HashMap::new();
-        vector(&mut map, n_keys, rand.as_slice());
+        vector(&mut map, n_keys, &rand);
     }
 }

--- a/src/test/bench/core-set.rs
+++ b/src/test/bench/core-set.rs
@@ -180,7 +180,7 @@ fn empty_results() -> Results {
 
 fn main() {
     let args = os::args();
-    let args = args.as_slice();
+    let args = args;
     let num_keys = {
         if args.len() == 2 {
             args[1].parse::<uint>().unwrap()

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -29,7 +29,7 @@ fn main() {
 
     macro_rules! bench {
         ($id:ident) =>
-            (maybe_run_test(argv.as_slice(),
+            (maybe_run_test(&argv,
                             stringify!($id).to_string(),
                             $id))
     }
@@ -94,7 +94,7 @@ fn vec_plus() {
             v.extend(rv.into_iter());
         } else {
             let mut rv = rv.clone();
-            rv.push_all(v.as_slice());
+            rv.push_all(&v);
             v = rv;
         }
         i += 1;
@@ -110,12 +110,12 @@ fn vec_append() {
         let rv = repeat(i).take(r.gen_range(0u, i + 1)).collect::<Vec<_>>();
         if r.gen() {
             let mut t = v.clone();
-            t.push_all(rv.as_slice());
+            t.push_all(&rv);
             v = t;
         }
         else {
             let mut t = rv.clone();
-            t.push_all(v.as_slice());
+            t.push_all(&v);
             v = t;
         }
         i += 1;
@@ -129,11 +129,11 @@ fn vec_push_all() {
     for i in 0u..1500 {
         let mut rv = repeat(i).take(r.gen_range(0u, i + 1)).collect::<Vec<_>>();
         if r.gen() {
-            v.push_all(rv.as_slice());
+            v.push_all(&rv);
         }
         else {
             swap(&mut v, &mut rv);
-            v.push_all(rv.as_slice());
+            v.push_all(&rv);
         }
     }
 }
@@ -142,7 +142,7 @@ fn is_utf8_ascii() {
     let mut v : Vec<u8> = Vec::new();
     for _ in 0u..20000 {
         v.push('b' as u8);
-        if str::from_utf8(v.as_slice()).is_err() {
+        if str::from_utf8(&v).is_err() {
             panic!("from_utf8 panicked");
         }
     }
@@ -153,7 +153,7 @@ fn is_utf8_multibyte() {
     let mut v : Vec<u8> = Vec::new();
     for _ in 0u..5000 {
         v.push_all(s.as_bytes());
-        if str::from_utf8(v.as_slice()).is_err() {
+        if str::from_utf8(&v).is_err() {
             panic!("from_utf8 panicked");
         }
     }

--- a/src/test/bench/msgsend-pipes-shared.rs
+++ b/src/test/bench/msgsend-pipes-shared.rs
@@ -103,5 +103,5 @@ fn main() {
     };
 
     println!("{:?}", args);
-    run(args.as_slice());
+    run(&args);
 }

--- a/src/test/bench/msgsend-pipes.rs
+++ b/src/test/bench/msgsend-pipes.rs
@@ -110,5 +110,5 @@ fn main() {
     };
 
     println!("{:?}", args);
-    run(args.as_slice());
+    run(&args);
 }

--- a/src/test/bench/rt-messaging-ping-pong.rs
+++ b/src/test/bench/rt-messaging-ping-pong.rs
@@ -65,7 +65,7 @@ fn ping_pong_bench(n: uint, m: uint) {
 fn main() {
 
     let args = os::args();
-    let args = args.as_slice();
+    let args = args;
     let n = if args.len() == 3 {
         args[1].parse::<uint>().unwrap()
     } else {

--- a/src/test/bench/rt-parfib.rs
+++ b/src/test/bench/rt-parfib.rs
@@ -32,7 +32,7 @@ fn parfib(n: uint) -> uint {
 fn main() {
 
     let args = os::args();
-    let args = args.as_slice();
+    let args = args;
     let n = if args.len() == 2 {
         args[1].parse::<uint>().unwrap()
     } else {

--- a/src/test/bench/shootout-binarytrees.rs
+++ b/src/test/bench/shootout-binarytrees.rs
@@ -85,7 +85,7 @@ fn inner(depth: i32, iterations: i32) -> String {
 
 fn main() {
     let args = std::os::args();
-    let args = args.as_slice();
+    let args = args;
     let n = if std::os::getenv("RUST_BENCH").is_some() {
         17
     } else if args.len() <= 1u {

--- a/src/test/bench/shootout-chameneos-redux.rs
+++ b/src/test/bench/shootout-chameneos-redux.rs
@@ -82,7 +82,7 @@ fn show_color_list(set: Vec<Color>) -> String {
     let mut out = String::new();
     for col in &set {
         out.push(' ');
-        out.push_str(format!("{:?}", col).as_slice());
+        out.push_str(&format!("{:?}", col));
     }
     out
 }
@@ -230,7 +230,7 @@ fn main() {
     let nn = if std::os::getenv("RUST_BENCH").is_some() {
         200000
     } else {
-        std::os::args().as_slice()
+        std::os::args()
                        .get(1)
                        .and_then(|arg| arg.parse().ok())
                        .unwrap_or(600u)

--- a/src/test/bench/shootout-fannkuch-redux.rs
+++ b/src/test/bench/shootout-fannkuch-redux.rs
@@ -180,7 +180,7 @@ fn fannkuch(n: i32) -> (i32, i32) {
 }
 
 fn main() {
-    let n = std::os::args().as_slice()
+    let n = std::os::args()
         .get(1)
         .and_then(|arg| arg.parse().ok())
         .unwrap_or(2i32);

--- a/src/test/bench/shootout-fasta-redux.rs
+++ b/src/test/bench/shootout-fasta-redux.rs
@@ -124,7 +124,7 @@ impl<'a, W: Writer> RepeatFasta<'a, W> {
         let mut buf = repeat(0u8).take(alu_len + LINE_LEN).collect::<Vec<_>>();
         let alu: &[u8] = self.alu.as_bytes();
 
-        copy_memory(buf.as_mut_slice(), alu);
+        copy_memory(&mut buf, alu);
         let buf_len = buf.len();
         copy_memory(&mut buf[alu_len..buf_len],
                     &alu[..LINE_LEN]);
@@ -209,7 +209,7 @@ impl<'a, W: Writer> RandomFasta<'a, W> {
 
 fn main() {
     let args = os::args();
-    let args = args.as_slice();
+    let args = args;
     let n = if args.len() > 1 {
         args[1].parse::<uint>().unwrap()
     } else {
@@ -226,12 +226,12 @@ fn main() {
 
     out.write_line(">TWO IUB ambiguity codes").unwrap();
     let iub = sum_and_scale(&IUB);
-    let mut random = RandomFasta::new(&mut out, iub.as_slice());
+    let mut random = RandomFasta::new(&mut out, &iub);
     random.make(n * 3).unwrap();
 
     random.out.write_line(">THREE Homo sapiens frequency").unwrap();
     let homo_sapiens = sum_and_scale(&HOMO_SAPIENS);
-    random.lookup = make_lookup(homo_sapiens.as_slice());
+    random.lookup = make_lookup(&homo_sapiens);
     random.make(n * 5).unwrap();
 
     random.out.write_str("\n").unwrap();

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -104,7 +104,7 @@ fn make_fasta<W: Writer, I: Iterator<Item=u8>>(
 
 fn run<W: Writer>(writer: &mut W) -> std::old_io::IoResult<()> {
     let args = os::args();
-    let args = args.as_slice();
+    let args = args;
     let n = if os::getenv("RUST_BENCH").is_some() {
         25000000
     } else if args.len() <= 1u {

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -64,9 +64,9 @@ fn sort_and_fmt(mm: &HashMap<Vec<u8> , uint>, total: uint) -> String {
 
    let mut buffer = String::new();
    for &(ref k, v) in &pairs_sorted {
-       buffer.push_str(format!("{:?} {:0.3}\n",
-                               k.to_ascii_uppercase(),
-                               v).as_slice());
+       buffer.push_str(&format!("{:?} {:0.3}\n",
+                                k.to_ascii_uppercase(),
+                                v));
    }
 
    return buffer
@@ -122,8 +122,8 @@ fn make_sequence_processor(sz: uint,
        line = from_parent.recv().unwrap();
        if line == Vec::new() { break; }
 
-       carry.push_all(line.as_slice());
-       carry = windows_with_carry(carry.as_slice(), sz, |window| {
+       carry.push_all(&line);
+       carry = windows_with_carry(&carry, sz, |window| {
            update_freq(&mut freqs, window);
            total += 1u;
        });

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -261,7 +261,7 @@ fn print_frequencies(frequencies: &Table, frame: uint) {
     for entry in frequencies.iter() {
         vector.push((entry.count, entry.code));
     }
-    vector.as_mut_slice().sort();
+    vector.sort();
 
     let mut total_count = 0;
     for &(count, _) in &vector {
@@ -270,7 +270,7 @@ fn print_frequencies(frequencies: &Table, frame: uint) {
 
     for &(count, key) in vector.iter().rev() {
         println!("{} {:.3}",
-                 key.unpack(frame).as_slice(),
+                 key.unpack(frame),
                  (count as f32 * 100.0) / (total_count as f32));
     }
     println!("");
@@ -301,11 +301,11 @@ fn main() {
 
     let nb_freqs: Vec<_> = (1u..3).map(|i| {
         let input = input.clone();
-        (i, Thread::scoped(move|| generate_frequencies(input.as_slice(), i)))
+        (i, Thread::scoped(move|| generate_frequencies(&input, i)))
     }).collect();
     let occ_freqs: Vec<_> = OCCURRENCES.iter().map(|&occ| {
         let input = input.clone();
-        Thread::scoped(move|| generate_frequencies(input.as_slice(), occ.len()))
+        Thread::scoped(move|| generate_frequencies(&input, occ.len()))
     }).collect();
 
     for (i, freq) in nb_freqs {

--- a/src/test/bench/shootout-mandelbrot.rs
+++ b/src/test/bench/shootout-mandelbrot.rs
@@ -124,7 +124,7 @@ fn mandelbrot<W: old_io::Writer>(w: usize, mut out: W) -> old_io::IoResult<()> {
 
         Thread::scoped(move|| {
             let mut res: Vec<u8> = Vec::with_capacity((chunk_size * w) / 8);
-            let init_r_slice = vec_init_r.as_slice();
+            let init_r_slice = vec_init_r;
 
             let start = i * chunk_size;
             let end = if i == (WORKERS - 1) {
@@ -134,7 +134,7 @@ fn mandelbrot<W: old_io::Writer>(w: usize, mut out: W) -> old_io::IoResult<()> {
             };
 
             for &init_i in &vec_init_i[start..end] {
-                write_line(init_i, init_r_slice, &mut res);
+                write_line(init_i, &init_r_slice, &mut res);
             }
 
             res
@@ -143,7 +143,7 @@ fn mandelbrot<W: old_io::Writer>(w: usize, mut out: W) -> old_io::IoResult<()> {
 
     try!(writeln!(&mut out as &mut Writer, "P4\n{} {}", w, h));
     for res in data {
-        try!(out.write(res.join().ok().unwrap().as_slice()));
+        try!(out.write(&res.join().ok().unwrap()));
     }
     out.flush()
 }

--- a/src/test/bench/shootout-nbody.rs
+++ b/src/test/bench/shootout-nbody.rs
@@ -103,7 +103,7 @@ struct Planet {
 
 fn advance(bodies: &mut [Planet;N_BODIES], dt: f64, steps: int) {
     for _ in 0..steps {
-        let mut b_slice = bodies.as_mut_slice();
+        let mut b_slice: &mut [_] = bodies;
         loop {
             let bi = match shift_mut_ref(&mut b_slice) {
                 Some(bi) => bi,

--- a/src/test/bench/shootout-pfib.rs
+++ b/src/test/bench/shootout-pfib.rs
@@ -57,7 +57,7 @@ fn parse_opts(argv: Vec<String> ) -> Config {
     let argv = argv.iter().map(|x| x.to_string()).collect::<Vec<_>>();
     let opt_args = &argv[1..argv.len()];
 
-    match getopts::getopts(opt_args, opts.as_slice()) {
+    match getopts::getopts(opt_args, &opts) {
       Ok(ref m) => {
           return Config {stress: m.opt_present("stress")}
       }

--- a/src/test/bench/shootout-reverse-complement.rs
+++ b/src/test/bench/shootout-reverse-complement.rs
@@ -251,6 +251,6 @@ fn parallel<'a, I, T, F>(iter: I, f: F)
 fn main() {
     let mut data = read_to_end(&mut stdin_raw()).unwrap();
     let tables = &Tables::new();
-    parallel(mut_dna_seqs(data.as_mut_slice()), |seq| reverse_complement(seq, tables));
-    stdout_raw().write(data.as_mut_slice()).unwrap();
+    parallel(mut_dna_seqs(&mut data), |seq| reverse_complement(seq, tables));
+    stdout_raw().write(&data).unwrap();
 }

--- a/src/test/bench/shootout-spectralnorm.rs
+++ b/src/test/bench/shootout-spectralnorm.rs
@@ -69,10 +69,10 @@ fn spectralnorm(n: uint) -> f64 {
     let mut v = u.clone();
     let mut tmp = v.clone();
     for _ in 0u..10 {
-        mult_AtAv(u.as_slice(), v.as_mut_slice(), tmp.as_mut_slice());
-        mult_AtAv(v.as_slice(), u.as_mut_slice(), tmp.as_mut_slice());
+        mult_AtAv(&u, &mut v, &mut tmp);
+        mult_AtAv(&v, &mut u, &mut tmp);
     }
-    (dot(u.as_slice(), v.as_slice()) / dot(v.as_slice(), v.as_slice())).sqrt()
+    (dot(&u, &v) / dot(&v, &v)).sqrt()
 }
 
 fn mult_AtAv(v: &[f64], out: &mut [f64], tmp: &mut [f64]) {

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -63,7 +63,7 @@ impl Sudoku {
                           .take(10).collect::<Vec<_>>();
         for line in reader.lines() {
             let line = line.unwrap();
-            let comps: Vec<&str> = line.as_slice()
+            let comps: Vec<&str> = line
                                        .trim()
                                        .split(',')
                                        .collect();

--- a/src/test/compile-fail/borrowck-assign-comp-idx.rs
+++ b/src/test/compile-fail/borrowck-assign-comp-idx.rs
@@ -33,7 +33,7 @@ fn b() {
     let mut p = vec!(1);
 
     borrow(
-        p.as_slice(),
+        &p,
         || p[0] = 5); //~ ERROR cannot borrow `p` as mutable
 }
 
@@ -41,7 +41,7 @@ fn c() {
     // Legal because the scope of the borrow does not include the
     // modification:
     let mut p = vec!(1);
-    borrow(p.as_slice(), ||{});
+    borrow(&p, ||{});
     p[0] = 5;
 }
 

--- a/src/test/compile-fail/borrowck-borrowed-uniq-rvalue-2.rs
+++ b/src/test/compile-fail/borrowck-borrowed-uniq-rvalue-2.rs
@@ -30,7 +30,7 @@ fn defer<'r>(x: &'r [&'r str]) -> defer<'r> {
 }
 
 fn main() {
-    let x = defer(vec!("Goodbye", "world!").as_slice());
+    let x = defer(&vec!("Goodbye", "world!"));
     //~^ ERROR borrowed value does not live long enough
     x.x[0];
 }

--- a/src/test/compile-fail/borrowck-move-out-of-vec-tail.rs
+++ b/src/test/compile-fail/borrowck-move-out-of-vec-tail.rs
@@ -21,7 +21,7 @@ pub fn main() {
         Foo { string: "bar".to_string() },
         Foo { string: "baz".to_string() }
     );
-    let x: &[Foo] = x.as_slice();
+    let x: &[Foo] = &x;
     match x {
         [_, tail..] => {
             match tail {

--- a/src/test/compile-fail/borrowck-mut-slice-of-imm-vec.rs
+++ b/src/test/compile-fail/borrowck-mut-slice-of-imm-vec.rs
@@ -14,5 +14,5 @@ fn write(v: &mut [isize]) {
 
 fn main() {
     let v = vec!(1, 2, 3);
-    write(v.as_mut_slice()); //~ ERROR cannot borrow
+    write(&mut v); //~ ERROR cannot borrow
 }

--- a/src/test/compile-fail/borrowck-overloaded-index-autoderef.rs
+++ b/src/test/compile-fail/borrowck-overloaded-index-autoderef.rs
@@ -22,7 +22,7 @@ impl Index<String> for Foo {
     type Output = isize;
 
     fn index<'a>(&'a self, z: &String) -> &'a isize {
-        if z.as_slice() == "x" {
+        if *z == "x" {
             &self.x
         } else {
             &self.y
@@ -34,7 +34,7 @@ impl IndexMut<String> for Foo {
     type Output = isize;
 
     fn index_mut<'a>(&'a mut self, z: &String) -> &'a mut isize {
-        if z.as_slice() == "x" {
+        if *z == "x" {
             &mut self.x
         } else {
             &mut self.y

--- a/src/test/compile-fail/borrowck-overloaded-index.rs
+++ b/src/test/compile-fail/borrowck-overloaded-index.rs
@@ -19,7 +19,7 @@ impl Index<String> for Foo {
     type Output = isize;
 
     fn index<'a>(&'a self, z: &String) -> &'a isize {
-        if z.as_slice() == "x" {
+        if *z == "x" {
             &self.x
         } else {
             &self.y
@@ -31,7 +31,7 @@ impl IndexMut<String> for Foo {
     type Output = isize;
 
     fn index_mut<'a>(&'a mut self, z: &String) -> &'a mut isize {
-        if z.as_slice() == "x" {
+        if *z == "x" {
             &mut self.x
         } else {
             &mut self.y

--- a/src/test/compile-fail/borrowck-vec-pattern-element-loan.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-element-loan.rs
@@ -12,7 +12,7 @@
 
 fn a<'a>() -> &'a [isize] {
     let vec = vec!(1, 2, 3, 4);
-    let vec: &[isize] = vec.as_slice(); //~ ERROR does not live long enough
+    let vec: &[isize] = &vec; //~ ERROR does not live long enough
     let tail = match vec {
         [_, tail..] => tail,
         _ => panic!("a")
@@ -22,7 +22,7 @@ fn a<'a>() -> &'a [isize] {
 
 fn b<'a>() -> &'a [isize] {
     let vec = vec!(1, 2, 3, 4);
-    let vec: &[isize] = vec.as_slice(); //~ ERROR does not live long enough
+    let vec: &[isize] = &vec; //~ ERROR does not live long enough
     let init = match vec {
         [init.., _] => init,
         _ => panic!("b")
@@ -32,7 +32,7 @@ fn b<'a>() -> &'a [isize] {
 
 fn c<'a>() -> &'a [isize] {
     let vec = vec!(1, 2, 3, 4);
-    let vec: &[isize] = vec.as_slice(); //~ ERROR does not live long enough
+    let vec: &[isize] = &vec; //~ ERROR does not live long enough
     let slice = match vec {
         [_, slice.., _] => slice,
         _ => panic!("c")

--- a/src/test/compile-fail/borrowck-vec-pattern-loan-from-mut.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-loan-from-mut.rs
@@ -10,7 +10,7 @@
 
 fn a() {
     let mut v = vec!(1, 2, 3);
-    let vb: &mut [isize] = v.as_mut_slice();
+    let vb: &mut [isize] = &mut v;
     match vb {
         [_a, tail..] => {
             v.push(tail[0] + tail[1]); //~ ERROR cannot borrow

--- a/src/test/compile-fail/borrowck-vec-pattern-nesting.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-nesting.rs
@@ -22,7 +22,7 @@ fn a() {
 
 fn b() {
     let mut vec = vec!(box 1, box 2, box 3);
-    let vec: &mut [Box<isize>] = vec.as_mut_slice();
+    let vec: &mut [Box<isize>] = &mut vec;
     match vec {
         [_b..] => {
             vec[0] = box 4; //~ ERROR cannot assign
@@ -32,7 +32,7 @@ fn b() {
 
 fn c() {
     let mut vec = vec!(box 1, box 2, box 3);
-    let vec: &mut [Box<isize>] = vec.as_mut_slice();
+    let vec: &mut [Box<isize>] = &mut vec;
     match vec {
         [_a,         //~ ERROR cannot move out
          _b..] => {  //~^ NOTE attempting to move value to here
@@ -50,7 +50,7 @@ fn c() {
 
 fn d() {
     let mut vec = vec!(box 1, box 2, box 3);
-    let vec: &mut [Box<isize>] = vec.as_mut_slice();
+    let vec: &mut [Box<isize>] = &mut vec;
     match vec {
         [_a..,     //~ ERROR cannot move out
          _b] => {} //~ NOTE attempting to move value to here
@@ -61,7 +61,7 @@ fn d() {
 
 fn e() {
     let mut vec = vec!(box 1, box 2, box 3);
-    let vec: &mut [Box<isize>] = vec.as_mut_slice();
+    let vec: &mut [Box<isize>] = &mut vec;
     match vec {
         [_a, _b, _c] => {}  //~ ERROR cannot move out
         //~^ NOTE attempting to move value to here

--- a/src/test/compile-fail/borrowck-vec-pattern-tail-element-loan.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-tail-element-loan.rs
@@ -10,7 +10,7 @@
 
 fn a<'a>() -> &'a isize {
     let vec = vec!(1, 2, 3, 4);
-    let vec: &[isize] = vec.as_slice(); //~ ERROR `vec` does not live long enough
+    let vec: &[isize] = &vec; //~ ERROR `vec` does not live long enough
     let tail = match vec {
         [_a, tail..] => &tail[0],
         _ => panic!("foo")

--- a/src/test/compile-fail/estr-subtyping.rs
+++ b/src/test/compile-fail/estr-subtyping.rs
@@ -13,12 +13,12 @@ fn wants_slice(x: &str) { }
 
 fn has_uniq(x: String) {
    wants_uniq(x);
-   wants_slice(x.as_slice());
+   wants_slice(&*x);
 }
 
 fn has_slice(x: &str) {
    wants_uniq(x); //~ ERROR mismatched types
-   wants_slice(x);
+   wants_slice(x.as_slice());
 }
 
 fn main() {

--- a/src/test/compile-fail/integral-indexing.rs
+++ b/src/test/compile-fail/integral-indexing.rs
@@ -11,15 +11,15 @@
 pub fn main() {
     let v: Vec<isize> = vec!(0, 1, 2, 3, 4, 5);
     let s: String = "abcdef".to_string();
-    v.as_slice()[3us];
-    v.as_slice()[3];
-    v.as_slice()[3u8];  //~ERROR the trait `core::ops::Index<u8>` is not implemented
+    v[3us];
+    v[3];
+    v[3u8];  //~ERROR the trait `core::ops::Index<u8>` is not implemented
     //~^ ERROR the trait `core::ops::Index<u8>` is not implemented
-    v.as_slice()[3i8];  //~ERROR the trait `core::ops::Index<i8>` is not implemented
+    v[3i8];  //~ERROR the trait `core::ops::Index<i8>` is not implemented
     //~^ ERROR the trait `core::ops::Index<i8>` is not implemented
-    v.as_slice()[3u32]; //~ERROR the trait `core::ops::Index<u32>` is not implemented
+    v[3u32]; //~ERROR the trait `core::ops::Index<u32>` is not implemented
     //~^ ERROR the trait `core::ops::Index<u32>` is not implemented
-    v.as_slice()[3i32]; //~ERROR the trait `core::ops::Index<i32>` is not implemented
+    v[3i32]; //~ERROR the trait `core::ops::Index<i32>` is not implemented
     //~^ ERROR the trait `core::ops::Index<i32>` is not implemented
     s.as_bytes()[3us];
     s.as_bytes()[3];

--- a/src/test/compile-fail/issue-11374.rs
+++ b/src/test/compile-fail/issue-11374.rs
@@ -33,5 +33,5 @@ pub fn for_stdin<'a>() -> Container<'a> {
 fn main() {
     let mut c = for_stdin();
     let mut v = Vec::new();
-    c.read_to(v.as_mut_slice());
+    c.read_to(v);
 }

--- a/src/test/compile-fail/issue-12369.rs
+++ b/src/test/compile-fail/issue-12369.rs
@@ -10,7 +10,7 @@
 
 fn main() {
     let sl = vec![1,2,3];
-    let v: isize = match sl.as_slice() {
+    let v: isize = match &*sl {
         [] => 0,
         [a,b,c] => 3,
         [a, rest..] => a,

--- a/src/test/compile-fail/issue-15783.rs
+++ b/src/test/compile-fail/issue-15783.rs
@@ -14,7 +14,7 @@ pub fn foo(params: Option<&[&str]>) -> usize {
 
 fn main() {
     let name = "Foo";
-    let x = Some(&[name.as_slice()]);
+    let x = Some(&[name]);
     let msg = foo(x);
 //~^ ERROR mismatched types
 //~| expected `core::option::Option<&[&str]>`

--- a/src/test/compile-fail/issue-17728.rs
+++ b/src/test/compile-fail/issue-17728.rs
@@ -100,7 +100,7 @@ impl TraversesWorld for Player {
 impl Debug for Player {
     fn fmt(&self, formatter: &mut Formatter) -> Result<(), Error> {
         formatter.write_str("Player{ name:");
-        formatter.write_str(self.name.as_slice());
+        formatter.write_str(&self.name);
         formatter.write_str(" }");
         Ok(())
     }

--- a/src/test/compile-fail/lub-if.rs
+++ b/src/test/compile-fail/lub-if.rs
@@ -16,14 +16,14 @@ pub fn opt_str0<'a>(maybestr: &'a Option<String>) -> &'a str {
     if maybestr.is_none() {
         "(none)"
     } else {
-        let s: &'a str = maybestr.as_ref().unwrap().as_slice();
+        let s: &'a str = maybestr.as_ref().unwrap();
         s
     }
 }
 
 pub fn opt_str1<'a>(maybestr: &'a Option<String>) -> &'a str {
     if maybestr.is_some() {
-        let s: &'a str = maybestr.as_ref().unwrap().as_slice();
+        let s: &'a str = maybestr.as_ref().unwrap();
         s
     } else {
         "(none)"
@@ -34,14 +34,14 @@ pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
     if maybestr.is_none() {
         "(none)"
     } else {
-        let s: &'a str = maybestr.as_ref().unwrap().as_slice();
+        let s: &'a str = maybestr.as_ref().unwrap();
         s  //~ ERROR cannot infer an appropriate lifetime for automatic coercion due to conflicting
     }
 }
 
 pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {
     if maybestr.is_some() {
-        let s: &'a str = maybestr.as_ref().unwrap().as_slice();
+        let s: &'a str = maybestr.as_ref().unwrap();
         s  //~ ERROR cannot infer an appropriate lifetime for automatic coercion due to conflicting
     } else {
         "(none)"

--- a/src/test/compile-fail/lub-match.rs
+++ b/src/test/compile-fail/lub-match.rs
@@ -15,7 +15,7 @@
 pub fn opt_str0<'a>(maybestr: &'a Option<String>) -> &'a str {
     match *maybestr {
         Some(ref s) => {
-            let s: &'a str = s.as_slice();
+            let s: &'a str = s;
             s
         }
         None => "(none)",
@@ -26,7 +26,7 @@ pub fn opt_str1<'a>(maybestr: &'a Option<String>) -> &'a str {
     match *maybestr {
         None => "(none)",
         Some(ref s) => {
-            let s: &'a str = s.as_slice();
+            let s: &'a str = s;
             s
         }
     }
@@ -36,7 +36,7 @@ pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
     match *maybestr {
         None => "(none)",
         Some(ref s) => {
-            let s: &'a str = s.as_slice();
+            let s: &'a str = s;
             s
             //~^ ERROR cannot infer an appropriate lifetime
         }
@@ -46,7 +46,7 @@ pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
 pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {
     match *maybestr {
         Some(ref s) => {
-            let s: &'a str = s.as_slice();
+            let s: &'a str = s;
             s
             //~^ ERROR cannot infer an appropriate lifetime
         }

--- a/src/test/compile-fail/match-vec-unreachable.rs
+++ b/src/test/compile-fail/match-vec-unreachable.rs
@@ -11,7 +11,7 @@
 
 fn main() {
     let x: Vec<(isize, isize)> = Vec::new();
-    let x: &[(isize, isize)] = x.as_slice();
+    let x: &[(isize, isize)] = &x;
     match x {
         [a, (2, 3), _] => (),
         [(1, 2), (2, 3), b] => (), //~ ERROR unreachable pattern
@@ -21,7 +21,7 @@ fn main() {
     let x: Vec<String> = vec!["foo".to_string(),
                               "bar".to_string(),
                               "baz".to_string()];
-    let x: &[String] = x.as_slice();
+    let x: &[String] = &x;
     match x {
         [a, _, _, ..] => { println!("{}", a); }
         [_, _, _, _, _] => { } //~ ERROR unreachable pattern
@@ -29,7 +29,7 @@ fn main() {
     }
 
     let x: Vec<char> = vec!('a', 'b', 'c');
-    let x: &[char] = x.as_slice();
+    let x: &[char] = &x;
     match x {
         ['a', 'b', 'c', _tail..] => {}
         ['a', 'b', 'c'] => {} //~ ERROR unreachable pattern

--- a/src/test/compile-fail/moves-based-on-type-exprs.rs
+++ b/src/test/compile-fail/moves-based-on-type-exprs.rs
@@ -95,7 +95,7 @@ fn f110() {
 
 fn f120() {
     let mut x = vec!("hi".to_string(), "ho".to_string());
-    x.as_mut_slice().swap(0, 1);
+    x.swap(0, 1);
     touch(&x[0]);
     touch(&x[1]);
 }

--- a/src/test/compile-fail/non-exhaustive-match.rs
+++ b/src/test/compile-fail/non-exhaustive-match.rs
@@ -36,20 +36,20 @@ fn main() {
       (t::b, t::b) => {}
     }
     let vec = vec!(Some(42), None, Some(21));
-    let vec: &[Option<isize>] = vec.as_slice();
+    let vec: &[Option<isize>] = &vec;
     match vec { //~ ERROR non-exhaustive patterns: `[]` not covered
         [Some(..), None, tail..] => {}
         [Some(..), Some(..), tail..] => {}
         [None] => {}
     }
     let vec = vec!(1);
-    let vec: &[isize] = vec.as_slice();
+    let vec: &[isize] = &vec;
     match vec {
         [_, tail..] => (),
         [] => ()
     }
     let vec = vec!(0.5f32);
-    let vec: &[f32] = vec.as_slice();
+    let vec: &[f32] = &vec;
     match vec { //~ ERROR non-exhaustive patterns: `[_, _, _, _]` not covered
         [0.1, 0.2, 0.3] => (),
         [0.1, 0.2] => (),
@@ -57,7 +57,7 @@ fn main() {
         [] => ()
     }
     let vec = vec!(Some(42), None, Some(21));
-    let vec: &[Option<isize>] = vec.as_slice();
+    let vec: &[Option<isize>] = &vec;
     match vec {
         [Some(..), None, tail..] => {}
         [Some(..), Some(..), tail..] => {}

--- a/src/test/compile-fail/regions-glb-free-free.rs
+++ b/src/test/compile-fail/regions-glb-free-free.rs
@@ -35,5 +35,5 @@ mod argparse {
 fn main () {
     let f : argparse::Flag = argparse::flag("flag", "My flag");
     let updated_flag = f.set_desc("My new flag");
-    assert_eq!(updated_flag.desc.as_slice(), "My new flag");
+    assert_eq!(updated_flag.desc, "My new flag");
 }

--- a/src/test/compile-fail/regions-pattern-typing-issue-19552.rs
+++ b/src/test/compile-fail/regions-pattern-typing-issue-19552.rs
@@ -12,7 +12,7 @@ fn assert_send<T: Send>(_t: T) {}
 
 fn main() {
     let line = String::new();
-    match [line.as_slice()] { //~ ERROR `line` does not live long enough
+    match [&*line] { //~ ERROR `line` does not live long enough
         [ word ] => { assert_send(word); }
     }
 }

--- a/src/test/compile-fail/trait-coercion-generic-regions.rs
+++ b/src/test/compile-fail/trait-coercion-generic-regions.rs
@@ -26,7 +26,7 @@ impl Trait<&'static str> for Struct {
 
 fn main() {
     let person = "Fred".to_string();
-    let person: &str = person.as_slice();  //~ ERROR `person` does not live long enough
+    let person: &str = &person;  //~ ERROR `person` does not live long enough
     let s: Box<Trait<&'static str>> = box Struct { person: person };
 }
 

--- a/src/test/debuginfo/type-names.rs
+++ b/src/test/debuginfo/type-names.rs
@@ -283,9 +283,9 @@ fn main() {
     let fixed_size_vec2 = ([0u, 1u, 2u], 0i16);
 
     let vec1 = vec![0u, 2u, 3u];
-    let slice1 = vec1.as_slice();
+    let slice1 = &*vec1;
     let vec2 = vec![Mod1::Variant2_2(Struct1)];
-    let slice2 = vec2.as_slice();
+    let slice2 = &*vec2;
 
     // Trait Objects
     let box_trait = (box 0) as Box<Trait1>;

--- a/src/test/run-fail/bug-2470-bounds-check-overflow-3.rs
+++ b/src/test/run-fail/bug-2470-bounds-check-overflow-3.rs
@@ -29,12 +29,12 @@ fn main() {
            idx as uint);
 
     // This should panic.
-    println!("ov3 0x%x",  x.as_slice()[idx]);
+    println!("ov3 0x%x",  x[idx]);
 }
 
 #[cfg(any(target_arch="x86_64", target_arch = "aarch64"))]
 fn main() {
     // This version just panics anyways, for symmetry on 64-bit hosts.
     let x = vec!(1u,2u,3u);
-    error!("ov3 0x%x",  x.as_slice()[200]);
+    error!("ov3 0x%x",  x[200]);
 }

--- a/src/test/run-make/cannot-read-embedded-idents/create_and_compile.rs
+++ b/src/test/run-make/cannot-read-embedded-idents/create_and_compile.rs
@@ -17,8 +17,8 @@ use std::old_io::{File, Command};
 
 fn main() {
     let args = os::args();
-    let rustc = args[1].as_slice();
-    let tmpdir = Path::new(args[2].as_slice());
+    let rustc = &args[1];
+    let tmpdir = Path::new(&args[2]);
 
     let main_file = tmpdir.join("broken.rs");
     let _ = File::create(&main_file).unwrap()
@@ -31,12 +31,12 @@ fn main() {
     // can't exec it directly
     let result = Command::new("sh")
         .arg("-c")
-        .arg(format!("{} {}",
-                     rustc,
-                     main_file.as_str()
-                     .unwrap()).as_slice())
+        .arg(&format!("{} {}",
+                      rustc,
+                      main_file.as_str()
+                      .unwrap()))
         .output().unwrap();
-    let err = String::from_utf8_lossy(result.error.as_slice());
+    let err = String::from_utf8_lossy(&result.error);
 
     // positive test so that this test will be updated when the
     // compiler changes.

--- a/src/test/run-make/issue-19371/foo.rs
+++ b/src/test/run-make/issue-19371/foo.rs
@@ -28,9 +28,9 @@ fn main() {
         panic!("expected rustc path");
     }
 
-    let tmpdir = Path::new(args[1].as_slice());
+    let tmpdir = Path::new(&args[1]);
 
-    let mut sysroot = Path::new(args[3].as_slice());
+    let mut sysroot = Path::new(&args[3]);
     sysroot.pop();
     sysroot.pop();
 

--- a/src/test/run-make/save-analysis/foo.rs
+++ b/src/test/run-make/save-analysis/foo.rs
@@ -106,7 +106,7 @@ trait SomeTrait: SuperTrait {
     fn Method(&self, x: u32) -> u32;
 
     fn prov(&self, x: u32) -> u32 {
-        println(x.to_string().as_slice());
+        println(&x.to_string());
         42
     }
     fn provided_method(&self) -> u32 {
@@ -122,7 +122,7 @@ trait SubTrait: SomeTrait {
 
 impl SomeTrait for some_fields {
     fn Method(&self, x: u32) -> u32 {
-        println(x.to_string().as_slice());
+        println(&x.to_string());
         self.field1
     }
 }
@@ -134,7 +134,7 @@ impl SubTrait for some_fields {}
 
 impl some_fields {
     fn stat(x: u32) -> u32 {
-        println(x.to_string().as_slice());
+        println(&x.to_string());
         42
     }
     fn stat2(x: &some_fields) -> u32 {
@@ -194,20 +194,20 @@ enum SomeStructEnum {
 
 fn matchSomeEnum(val: SomeEnum) {
     match val {
-        SomeEnum::Ints(int1, int2) => { println((int1+int2).to_string().as_slice()); }
-        SomeEnum::Floats(float1, float2) => { println((float2*float1).to_string().as_slice()); }
+        SomeEnum::Ints(int1, int2) => { println(&(int1+int2).to_string()); }
+        SomeEnum::Floats(float1, float2) => { println(&(float2*float1).to_string()); }
         SomeEnum::Strings(_, _, s3) => { println(s3); }
         SomeEnum::MyTypes(mt1, mt2) => {
-            println((mt1.field1 - mt2.field1).to_string().as_slice());
+            println(&(mt1.field1 - mt2.field1).to_string());
         }
     }
 }
 
 fn matchSomeStructEnum(se: SomeStructEnum) {
     match se {
-        SomeStructEnum::EnumStruct{a:a, ..} => println(a.to_string().as_slice()),
-        SomeStructEnum::EnumStruct2{f1:f1, f2:f_2} => println(f_2.field1.to_string().as_slice()),
-        SomeStructEnum::EnumStruct3{f1, ..} => println(f1.field1.to_string().as_slice()),
+        SomeStructEnum::EnumStruct{a:a, ..} => println(&a.to_string()),
+        SomeStructEnum::EnumStruct2{f1:f1, f2:f_2} => println(&f_2.field1.to_string()),
+        SomeStructEnum::EnumStruct3{f1, ..} => println(&f1.field1.to_string()),
     }
 }
 
@@ -215,9 +215,9 @@ fn matchSomeStructEnum(se: SomeStructEnum) {
 fn matchSomeStructEnum2(se: SomeStructEnum) {
     use SomeStructEnum::*;
     match se {
-        EnumStruct{a: ref aaa, ..} => println(aaa.to_string().as_slice()),
-        EnumStruct2{f1, f2: f2} => println(f1.field1.to_string().as_slice()),
-        EnumStruct3{f1, f3: SomeEnum::Ints(_, _), f2} => println(f1.field1.to_string().as_slice()),
+        EnumStruct{a: ref aaa, ..} => println(&aaa.to_string()),
+        EnumStruct2{f1, f2: f2} => println(&f1.field1.to_string()),
+        EnumStruct3{f1, f3: SomeEnum::Ints(_, _), f2} => println(&f1.field1.to_string()),
         _ => {},
     }
 }
@@ -233,12 +233,12 @@ fn matchSomeOtherEnum(val: SomeOtherEnum) {
 fn hello<X: SomeTrait>((z, a) : (u32, String), ex: X) {
     SameDir2::hello(43);
 
-    println(yy.to_string().as_slice());
+    println(&yy.to_string());
     let (x, y): (u32, u32) = (5, 3);
-    println(x.to_string().as_slice());
-    println(z.to_string().as_slice());
+    println(&x.to_string());
+    println(&z.to_string());
     let x: u32 = x;
-    println(x.to_string().as_slice());
+    println(&x.to_string());
     let x = "hello";
     println(x);
 
@@ -311,7 +311,7 @@ fn main() { // foo
     let s3: some_fields = some_fields{ field1: 55};
     let s4: msalias::nested_struct = sub::sub2::nested_struct{ field2: 55};
     let s4: msalias::nested_struct = sub2::nested_struct{ field2: 55};
-    println(s2.field1.to_string().as_slice());
+    println(&s2.field1.to_string());
     let s5: MyType = box some_fields{ field1: 55};
     let s = SameDir::SameStruct{name: "Bob".to_string()};
     let s = SubDir::SubStruct{name:"Bob".to_string()};

--- a/src/test/run-make/unicode-input/multiple_files.rs
+++ b/src/test/run-make/unicode-input/multiple_files.rs
@@ -34,8 +34,8 @@ fn random_char() -> char {
 
 fn main() {
     let args = os::args();
-    let rustc = args[1].as_slice();
-    let tmpdir = Path::new(args[2].as_slice());
+    let rustc = &args[1];
+    let tmpdir = Path::new(&args[2]);
 
     let main_file = tmpdir.join("unicode_input_multiple_files_main.rs");
     {
@@ -56,12 +56,12 @@ fn main() {
         // can't exec it directly
         let result = Command::new("sh")
                              .arg("-c")
-                             .arg(format!("{} {}",
-                                          rustc,
-                                          main_file.as_str()
-                                                   .unwrap()).as_slice())
+                             .arg(&format!("{} {}",
+                                           rustc,
+                                           main_file.as_str()
+                                                    .unwrap()))
                              .output().unwrap();
-        let err = String::from_utf8_lossy(result.error.as_slice());
+        let err = String::from_utf8_lossy(&result.error);
 
         // positive test so that this test will be updated when the
         // compiler changes.

--- a/src/test/run-make/unicode-input/span_length.rs
+++ b/src/test/run-make/unicode-input/span_length.rs
@@ -34,8 +34,8 @@ fn random_char() -> char {
 
 fn main() {
     let args = os::args();
-    let rustc = args[1].as_slice();
-    let tmpdir = Path::new(args[2].as_slice());
+    let rustc = &args[1];
+    let tmpdir = Path::new(&args[2]);
     let main_file = tmpdir.join("span_main.rs");
 
     for _ in 0u..100 {
@@ -52,18 +52,18 @@ fn main() {
         // can't exec it directly
         let result = Command::new("sh")
                              .arg("-c")
-                             .arg(format!("{} {}",
-                                          rustc,
-                                          main_file.as_str()
-                                                   .unwrap()).as_slice())
+                             .arg(&format!("{} {}",
+                                           rustc,
+                                           main_file.as_str()
+                                                    .unwrap()))
                              .output().unwrap();
 
-        let err = String::from_utf8_lossy(result.error.as_slice());
+        let err = String::from_utf8_lossy(&result.error);
 
         // the span should end the line (e.g no extra ~'s)
         let expected_span = format!("^{}\n", repeat("~").take(n - 1)
                                                         .collect::<String>());
-        assert!(err.contains(expected_span.as_slice()));
+        assert!(err.contains(&expected_span));
     }
 
     // Test multi-column characters and tabs

--- a/src/test/run-pass/assignability-trait.rs
+++ b/src/test/run-pass/assignability-trait.rs
@@ -47,7 +47,7 @@ pub fn main() {
     assert_eq!(length(x.clone()), x.len());
     // Call a parameterized function, with type arguments that require
     // a borrow
-    assert_eq!(length::<int, &[int]>(x.as_slice()), x.len());
+    assert_eq!(length::<int, &[int]>(&*x), x.len());
 
     // Now try it with a type that *needs* to be borrowed
     let z = [0,1,2,3];

--- a/src/test/run-pass/associated-types-conditional-dispatch.rs
+++ b/src/test/run-pass/associated-types-conditional-dispatch.rs
@@ -36,7 +36,7 @@ impl<'a, A, B, Lhs> MyEq<[B; 0]> for Lhs
     where A: MyEq<B>, Lhs: Deref<Target=[A]>
 {
     fn eq(&self, other: &[B; 0]) -> bool {
-        MyEq::eq(&**self, other.as_slice())
+        MyEq::eq(&**self, other)
     }
 }
 

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -48,7 +48,7 @@ fn runtest(me: &str) {
     let p = template.clone().arg("fail").env("RUST_BACKTRACE", "1").spawn().unwrap();
     let out = p.wait_with_output().unwrap();
     assert!(!out.status.success());
-    let s = str::from_utf8(out.error.as_slice()).unwrap();
+    let s = str::from_utf8(&out.error).unwrap();
     assert!(s.contains("stack backtrace") && s.contains("foo::h"),
             "bad output: {}", s);
 
@@ -56,7 +56,7 @@ fn runtest(me: &str) {
     let p = template.clone().arg("fail").spawn().unwrap();
     let out = p.wait_with_output().unwrap();
     assert!(!out.status.success());
-    let s = str::from_utf8(out.error.as_slice()).unwrap();
+    let s = str::from_utf8(&out.error).unwrap();
     assert!(!s.contains("stack backtrace") && !s.contains("foo::h"),
             "bad output2: {}", s);
 
@@ -64,7 +64,7 @@ fn runtest(me: &str) {
     let p = template.clone().arg("double-fail").spawn().unwrap();
     let out = p.wait_with_output().unwrap();
     assert!(!out.status.success());
-    let s = str::from_utf8(out.error.as_slice()).unwrap();
+    let s = str::from_utf8(&out.error).unwrap();
     // loosened the following from double::h to double:: due to
     // spurious failures on mac, 32bit, optimized
     assert!(s.contains("stack backtrace") && s.contains("double::"),
@@ -75,7 +75,7 @@ fn runtest(me: &str) {
                                 .env("RUST_BACKTRACE", "1").spawn().unwrap();
     let out = p.wait_with_output().unwrap();
     assert!(!out.status.success());
-    let s = str::from_utf8(out.error.as_slice()).unwrap();
+    let s = str::from_utf8(&out.error).unwrap();
     let mut i = 0;
     for _ in 0..2 {
         i += s[i + 10..].find_str("stack backtrace").unwrap() + 10;
@@ -86,12 +86,12 @@ fn runtest(me: &str) {
 
 fn main() {
     let args = os::args();
-    let args = args.as_slice();
-    if args.len() >= 2 && args[1].as_slice() == "fail" {
+    let args = args;
+    if args.len() >= 2 && args[1] == "fail" {
         foo();
-    } else if args.len() >= 2 && args[1].as_slice() == "double-fail" {
+    } else if args.len() >= 2 && args[1] == "double-fail" {
         double();
     } else {
-        runtest(args[0].as_slice());
+        runtest(&args[0]);
     }
 }

--- a/src/test/run-pass/bare-fn-implements-fn-mut.rs
+++ b/src/test/run-pass/bare-fn-implements-fn-mut.rs
@@ -26,13 +26,13 @@ fn call_g<G:FnMut(String,String) -> String>(mut g: G, x: String, y: String)
 }
 
 fn g(mut x: String, y: String) -> String {
-    x.push_str(y.as_slice());
+    x.push_str(&y);
     x
 }
 
 fn main() {
     call_f(f);
-    assert_eq!(call_g(g, "foo".to_string(), "bar".to_string()).as_slice(),
+    assert_eq!(call_g(g, "foo".to_string(), "bar".to_string()),
                "foobar");
 }
 

--- a/src/test/run-pass/bool.rs
+++ b/src/test/run-pass/bool.rs
@@ -53,9 +53,9 @@ fn main() {
     assert_eq!(!false, true);
 
     let s = false.to_string();
-    assert_eq!(s.as_slice(), "false");
+    assert_eq!(s, "false");
     let s = true.to_string();
-    assert_eq!(s.as_slice(), "true");
+    assert_eq!(s, "true");
 
     assert!(true > false);
     assert!(!(false > true));

--- a/src/test/run-pass/borrowck-binding-mutbl.rs
+++ b/src/test/run-pass/borrowck-binding-mutbl.rs
@@ -19,7 +19,7 @@ pub fn main() {
 
     match x {
       F {f: ref mut v} => {
-        impure(v.as_slice());
+        impure(v);
       }
     }
 }

--- a/src/test/run-pass/borrowck-mut-vec-as-imm-slice.rs
+++ b/src/test/run-pass/borrowck-mut-vec-as-imm-slice.rs
@@ -16,7 +16,7 @@ fn want_slice(v: &[int]) -> int {
 }
 
 fn has_mut_vec(v: Vec<int> ) -> int {
-    want_slice(v.as_slice())
+    want_slice(&v)
 }
 
 pub fn main() {

--- a/src/test/run-pass/borrowed-ptr-pattern-2.rs
+++ b/src/test/run-pass/borrowed-ptr-pattern-2.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 fn foo(s: &String) -> bool {
-    match s.as_slice() {
+    match &**s {
         "kitty" => true,
         _ => false
     }

--- a/src/test/run-pass/cleanup-rvalue-temp-during-incomplete-alloc.rs
+++ b/src/test/run-pass/cleanup-rvalue-temp-during-incomplete-alloc.rs
@@ -44,7 +44,7 @@ fn get_bar(x: uint) -> Vec<uint> { vec!(x * 2) }
 pub fn fails() {
     let x = 2;
     let mut y = Vec::new();
-    y.push(box Conzabble::Bickwick(do_it(get_bar(x).as_slice())));
+    y.push(box Conzabble::Bickwick(do_it(&get_bar(x))));
 }
 
 pub fn main() {

--- a/src/test/run-pass/cleanup-shortcircuit.rs
+++ b/src/test/run-pass/cleanup-shortcircuit.rs
@@ -24,7 +24,7 @@ use std::os;
 
 pub fn main() {
     let args = os::args();
-    let args = args.as_slice();
+    let args = args;
 
     // Here, the rvalue `"signal".to_string()` requires cleanup. Older versions
     // of the code had a problem that the cleanup scope for this
@@ -32,7 +32,7 @@ pub fn main() {
     // expression was never evaluated, we wound up trying to clean
     // uninitialized memory.
 
-    if args.len() >= 2 && args[1].as_slice() == "signal" {
+    if args.len() >= 2 && args[1] == "signal" {
         // Raise a segfault.
         unsafe { *(0 as *mut int) = 0; }
     }

--- a/src/test/run-pass/coerce-reborrow-imm-vec-rcvr.rs
+++ b/src/test/run-pass/coerce-reborrow-imm-vec-rcvr.rs
@@ -19,6 +19,6 @@ fn bip(v: &[uint]) -> Vec<uint> {
 
 pub fn main() {
     let mut the_vec = vec!(1u, 2, 3, 100);
-    assert_eq!(the_vec.clone(), bar(the_vec.as_mut_slice()));
-    assert_eq!(the_vec.clone(), bip(the_vec.as_slice()));
+    assert_eq!(the_vec.clone(), bar(&mut the_vec));
+    assert_eq!(the_vec.clone(), bip(&the_vec));
 }

--- a/src/test/run-pass/coerce-reborrow-mut-vec-arg.rs
+++ b/src/test/run-pass/coerce-reborrow-mut-vec-arg.rs
@@ -21,6 +21,6 @@ fn bar(v: &mut [uint]) {
 
 pub fn main() {
     let mut the_vec = vec!(1, 2, 3, 100);
-    bar(the_vec.as_mut_slice());
+    bar(&mut the_vec);
     assert_eq!(the_vec, vec!(100, 3, 2, 1));
 }

--- a/src/test/run-pass/coerce-reborrow-mut-vec-rcvr.rs
+++ b/src/test/run-pass/coerce-reborrow-mut-vec-rcvr.rs
@@ -17,6 +17,6 @@ fn bar(v: &mut [uint]) {
 
 pub fn main() {
     let mut the_vec = vec!(1, 2, 3, 100);
-    bar(the_vec.as_mut_slice());
+    bar(&mut the_vec);
     assert_eq!(the_vec, vec!(100, 3, 2, 1));
 }

--- a/src/test/run-pass/deriving-encodable-decodable-box.rs
+++ b/src/test/run-pass/deriving-encodable-decodable-box.rs
@@ -25,6 +25,6 @@ struct A {
 fn main() {
     let obj = A { foo: box [true, false] };
     let s = json::encode(&obj).unwrap();
-    let obj2: A = json::decode(s.as_slice()).unwrap();
+    let obj2: A = json::decode(&s).unwrap();
     assert!(obj.foo == obj2.foo);
 }

--- a/src/test/run-pass/deriving-encodable-decodable-cell-refcell.rs
+++ b/src/test/run-pass/deriving-encodable-decodable-cell-refcell.rs
@@ -36,7 +36,7 @@ fn main() {
         bar: RefCell::new( A { baz: 2 } )
     };
     let s = json::encode(&obj).unwrap();
-    let obj2: B = json::decode(s.as_slice()).unwrap();
+    let obj2: B = json::decode(&s).unwrap();
     assert!(obj.foo.get() == obj2.foo.get());
     assert!(obj.bar.borrow().baz == obj2.bar.borrow().baz);
 }

--- a/src/test/run-pass/getopts_ref.rs
+++ b/src/test/run-pass/getopts_ref.rs
@@ -16,7 +16,7 @@ pub fn main() {
     let args = Vec::new();
     let opts = vec!(optopt("b", "", "something", "SMTHNG"));
 
-    match getopts(args.as_slice(), opts.as_slice()) {
+    match getopts(&args, &opts) {
         Ok(ref m)  =>
             assert!(!m.opt_present("b")),
         Err(ref f) => panic!("{}", *f)

--- a/src/test/run-pass/hashmap-memory.rs
+++ b/src/test/run-pass/hashmap-memory.rs
@@ -84,8 +84,7 @@ mod map_reduce {
               ctrl_proto::mapper_done => { num_mappers -= 1; }
               ctrl_proto::find_reducer(k, cc) => {
                 let mut c;
-                match reducers.get(&str::from_utf8(
-                        k.as_slice()).unwrap().to_string()) {
+                match reducers.get(&str::from_utf8(&k).unwrap().to_string()) {
                   Some(&_c) => { c = _c; }
                   None => { c = 0; }
                 }

--- a/src/test/run-pass/if-let.rs
+++ b/src/test/run-pass/if-let.rs
@@ -50,7 +50,7 @@ pub fn main() {
     } else if let Foo::Two(_x) = foo {
         panic!("bad pattern match");
     } else if let Foo::Three(s, _) = foo {
-        assert_eq!(s.as_slice(), "three");
+        assert_eq!(s, "three");
     } else {
         panic!("bad else");
     }

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -39,7 +39,7 @@ impl fmt::Display for C {
 }
 
 macro_rules! t {
-    ($a:expr, $b:expr) => { assert_eq!($a.as_slice(), $b) }
+    ($a:expr, $b:expr) => { assert_eq!($a, $b) }
 }
 
 pub fn main() {

--- a/src/test/run-pass/inconsistent-lifetime-mismatch.rs
+++ b/src/test/run-pass/inconsistent-lifetime-mismatch.rs
@@ -15,7 +15,7 @@ fn bad(a: &str, b: &str) {
 }
 
 fn good(a: &str, b: &str) {
-    foo(&[a.as_slice(), b.as_slice()]);
+    foo(&[a, b]);
 }
 
 fn main() {}

--- a/src/test/run-pass/issue-10626.rs
+++ b/src/test/run-pass/issue-10626.rs
@@ -17,8 +17,8 @@ use std::old_io::process;
 
 pub fn main () {
     let args = os::args();
-    let args = args.as_slice();
-    if args.len() > 1 && args[1].as_slice() == "child" {
+    let args = args;
+    if args.len() > 1 && args[1] == "child" {
         for _ in 0..1000 {
             println!("hello?");
         }
@@ -28,7 +28,7 @@ pub fn main () {
         return;
     }
 
-    let mut p = process::Command::new(args[0].as_slice());
+    let mut p = process::Command::new(&args[0]);
     p.arg("child").stdout(process::Ignored).stderr(process::Ignored);
     println!("{:?}", p.spawn().unwrap().wait());
 }

--- a/src/test/run-pass/issue-10683.rs
+++ b/src/test/run-pass/issue-10683.rs
@@ -13,7 +13,7 @@ use std::ascii::AsciiExt;
 static NAME: &'static str = "hello world";
 
 fn main() {
-    match NAME.to_ascii_lowercase().as_slice() {
+    match &*NAME.to_ascii_lowercase() {
         "foo" => {}
         _ => {}
     }

--- a/src/test/run-pass/issue-11869.rs
+++ b/src/test/run-pass/issue-11869.rs
@@ -13,7 +13,7 @@ struct A {
 }
 
 fn borrow<'a>(binding: &'a A) -> &'a str {
-    match binding.a.as_slice() {
+    match &*binding.a {
         "in" => "in_",
         "ref" => "ref_",
         ident => ident

--- a/src/test/run-pass/issue-13027.rs
+++ b/src/test/run-pass/issue-13027.rs
@@ -179,7 +179,7 @@ fn misc() {
     // This test basically mimics how trace_macros! macro is implemented,
     // which is a rare combination of vector patterns, multiple wild-card
     // patterns and guard functions.
-    let r = match [Foo::Bar(0, false)].as_slice() {
+    let r = match [Foo::Bar(0, false)] {
         [Foo::Bar(_, pred)] if pred => 1,
         [Foo::Bar(_, pred)] if !pred => 2,
         _ => 0,

--- a/src/test/run-pass/issue-13304.rs
+++ b/src/test/run-pass/issue-13304.rs
@@ -16,8 +16,8 @@ use std::str;
 
 fn main() {
     let args = os::args();
-    let args = args.as_slice();
-    if args.len() > 1 && args[1].as_slice() == "child" {
+    let args = args;
+    if args.len() > 1 && args[1] == "child" {
         child();
     } else {
         parent();
@@ -26,13 +26,13 @@ fn main() {
 
 fn parent() {
     let args = os::args();
-    let args = args.as_slice();
-    let mut p = old_io::process::Command::new(args[0].as_slice())
+    let args = args;
+    let mut p = old_io::process::Command::new(&args[0])
                                      .arg("child").spawn().unwrap();
     p.stdin.as_mut().unwrap().write_str("test1\ntest2\ntest3").unwrap();
     let out = p.wait_with_output().unwrap();
     assert!(out.status.success());
-    let s = str::from_utf8(out.output.as_slice()).unwrap();
+    let s = str::from_utf8(&out.output).unwrap();
     assert_eq!(s, "test1\n\ntest2\n\ntest3\n");
 }
 

--- a/src/test/run-pass/issue-13323.rs
+++ b/src/test/run-pass/issue-13323.rs
@@ -21,7 +21,7 @@ impl StrWrap {
     }
 
     fn get_s<'a>(&'a self) -> &'a str {
-        self.s.as_slice()
+        &self.s
     }
 }
 

--- a/src/test/run-pass/issue-14021.rs
+++ b/src/test/run-pass/issue-14021.rs
@@ -22,7 +22,7 @@ pub fn main() {
     let obj = UnitLikeStruct;
     let json_str: String = json::encode(&obj).unwrap();
 
-    let json_object = json::from_str(json_str.as_slice());
+    let json_object = json::from_str(&json_str);
     let mut decoder = json::Decoder::new(json_object.unwrap());
     let mut decoded_obj: UnitLikeStruct = Decodable::decode(&mut decoder).unwrap();
 

--- a/src/test/run-pass/issue-14456.rs
+++ b/src/test/run-pass/issue-14456.rs
@@ -16,7 +16,7 @@ use std::os;
 
 fn main() {
     let args = os::args();
-    if args.len() > 1 && args[1].as_slice() == "child" {
+    if args.len() > 1 && args[1] == "child" {
         return child()
     }
 
@@ -32,7 +32,7 @@ fn child() {
 
 fn test() {
     let args = os::args();
-    let mut p = Command::new(args[0].as_slice()).arg("child")
+    let mut p = Command::new(&args[0]).arg("child")
                                      .stdin(process::Ignored)
                                      .stdout(process::Ignored)
                                      .stderr(process::Ignored)

--- a/src/test/run-pass/issue-14936.rs
+++ b/src/test/run-pass/issue-14936.rs
@@ -31,7 +31,7 @@ macro_rules! demo {
             }
             assert_eq!((x,y), (1,1));
             let b: &[_] = &["out", "in"];
-            assert_eq!(history.as_slice(), b);
+            assert_eq!(history, b);
         }
     }
 }

--- a/src/test/run-pass/issue-14940.rs
+++ b/src/test/run-pass/issue-14940.rs
@@ -17,7 +17,7 @@ fn main() {
         let mut out = stdio::stdout();
         out.write(&['a' as u8; 128 * 1024]).unwrap();
     } else {
-        let out = Command::new(args[0].as_slice()).arg("child").output();
+        let out = Command::new(&args[0]).arg("child").output();
         let out = out.unwrap();
         assert!(out.status.success());
     }

--- a/src/test/run-pass/issue-15149.rs
+++ b/src/test/run-pass/issue-15149.rs
@@ -17,7 +17,7 @@ use std::rand::random;
 fn main() {
     // If we're the child, make sure we were invoked correctly
     let args = os::args();
-    if args.len() > 1 && args[1].as_slice() == "child" {
+    if args.len() > 1 && args[1] == "child" {
         // FIXME: This should check the whole `args[0]` instead of just
         // checking that it ends_with the executable name. This
         // is needed because of Windows, which has a different behavior.
@@ -45,9 +45,9 @@ fn test() {
     // Append the new directory to our own PATH.
     let mut path = os::split_paths(os::getenv("PATH").unwrap_or(String::new()));
     path.push(child_dir.clone());
-    let path = os::join_paths(path.as_slice()).unwrap();
+    let path = os::join_paths(&path).unwrap();
 
-    let child_output = Command::new("mytest").env("PATH", path.as_slice())
+    let child_output = Command::new("mytest").env("PATH", path)
                                              .arg("child")
                                              .output().unwrap();
 

--- a/src/test/run-pass/issue-16783.rs
+++ b/src/test/run-pass/issue-16783.rs
@@ -10,5 +10,5 @@
 
 pub fn main() {
     let x = [1, 2, 3];
-    let y = x.as_slice();
+    let y = x;
 }

--- a/src/test/run-pass/issue-17734.rs
+++ b/src/test/run-pass/issue-17734.rs
@@ -21,6 +21,6 @@ fn main() {
     // There is currently no safe way to construct a `Box<str>`, so improvise
     let box_arr: Box<[u8]> = box ['h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8];
     let box_str: Box<str> = unsafe { std::mem::transmute(box_arr) };
-    assert_eq!(box_str.as_slice(), "hello");
+    assert_eq!(&*box_str, "hello");
     f(box_str);
 }

--- a/src/test/run-pass/issue-18352.rs
+++ b/src/test/run-pass/issue-18352.rs
@@ -11,7 +11,7 @@
 const X: &'static str = "12345";
 
 fn test(s: String) -> bool {
-    match s.as_slice() {
+    match &*s {
         X => true,
         _ => false
     }

--- a/src/test/run-pass/issue-3559.rs
+++ b/src/test/run-pass/issue-3559.rs
@@ -24,6 +24,6 @@ pub fn main() {
     let mut table = HashMap::new();
     table.insert("one".to_string(), 1);
     table.insert("two".to_string(), 2);
-    assert!(check_strs(format!("{:?}", table).as_slice(), "HashMap {\"one\": 1, \"two\": 2}") ||
-            check_strs(format!("{:?}", table).as_slice(), "HashMap {\"two\": 2, \"one\": 1}"));
+    assert!(check_strs(&format!("{:?}", table), "HashMap {\"one\": 1, \"two\": 2}") ||
+            check_strs(&format!("{:?}", table), "HashMap {\"two\": 2, \"one\": 1}"));
 }

--- a/src/test/run-pass/issue-3563-3.rs
+++ b/src/test/run-pass/issue-3563-3.rs
@@ -162,7 +162,7 @@ pub fn check_strs(actual: &str, expected: &str) -> bool {
 
 fn test_ascii_art_ctor() {
     let art = AsciiArt(3, 3, '*');
-    assert!(check_strs(art.to_string().as_slice(), "...\n...\n..."));
+    assert!(check_strs(&art.to_string(), "...\n...\n..."));
 }
 
 
@@ -171,7 +171,7 @@ fn test_add_pt() {
     art.add_pt(0, 0);
     art.add_pt(0, -10);
     art.add_pt(1, 2);
-    assert!(check_strs(art.to_string().as_slice(), "*..\n...\n.*."));
+    assert!(check_strs(&art.to_string(), "*..\n...\n.*."));
 }
 
 
@@ -179,7 +179,7 @@ fn test_shapes() {
     let mut art = AsciiArt(4, 4, '*');
     art.add_rect(Rect {top_left: Point {x: 0, y: 0}, size: Size {width: 4, height: 4}});
     art.add_point(Point {x: 2, y: 2});
-    assert!(check_strs(art.to_string().as_slice(), "****\n*..*\n*.**\n****"));
+    assert!(check_strs(&art.to_string(), "****\n*..*\n*.**\n****"));
 }
 
 pub fn main() {

--- a/src/test/run-pass/issue-4541.rs
+++ b/src/test/run-pass/issue-4541.rs
@@ -10,11 +10,11 @@
 
 fn parse_args() -> String {
     let args = ::std::os::args();
-    let args = args.as_slice();
+    let args = args;
     let mut n = 0;
 
     while n < args.len() {
-        match args[n].as_slice() {
+        match &*args[n] {
             "-v" => (),
             s => {
                 return s.to_string();

--- a/src/test/run-pass/issue-5550.rs
+++ b/src/test/run-pass/issue-5550.rs
@@ -12,6 +12,6 @@
 
 pub fn main() {
     let s: String = "foobar".to_string();
-    let mut t: &str = s.as_slice();
+    let mut t: &str = &s;
     t = &t[0..3]; // for master: str::view(t, 0, 3) maybe
 }

--- a/src/test/run-pass/issue-9259.rs
+++ b/src/test/run-pass/issue-9259.rs
@@ -19,5 +19,5 @@ pub fn main() {
         a: &["test".to_string()],
         b: Some(b),
     };
-    assert_eq!(a.b.as_ref().unwrap()[0].as_slice(), "foo");
+    assert_eq!(a.b.as_ref().unwrap()[0], "foo");
 }

--- a/src/test/run-pass/issue-9382.rs
+++ b/src/test/run-pass/issue-9382.rs
@@ -34,7 +34,7 @@ pub fn main() {
         bar: box 32,
     };
     Thing1 {
-        baz: Vec::new().as_slice(),
+        baz: &Vec::new(),
         bar: box 32,
     };
     let _t2_fixed = Thing2 {
@@ -42,7 +42,7 @@ pub fn main() {
         bar: 32,
     };
     Thing2 {
-        baz: Vec::new().as_slice(),
+        baz: &Vec::new(),
         bar: 32,
     };
 }

--- a/src/test/run-pass/istr.rs
+++ b/src/test/run-pass/istr.rs
@@ -37,19 +37,19 @@ fn test_heap_log() {
 fn test_append() {
     let mut s = String::new();
     s.push_str("a");
-    assert_eq!(s.as_slice(), "a");
+    assert_eq!(s, "a");
 
     let mut s = String::from_str("a");
     s.push_str("b");
     println!("{}", s.clone());
-    assert_eq!(s.as_slice(), "ab");
+    assert_eq!(s, "ab");
 
     let mut s = String::from_str("c");
     s.push_str("offee");
-    assert!(s.as_slice() == "coffee");
+    assert!(s == "coffee");
 
     s.push_str("&tea");
-    assert!(s.as_slice() == "coffee&tea");
+    assert!(s == "coffee&tea");
 }
 
 pub fn main() {

--- a/src/test/run-pass/lambda-infer-unresolved.rs
+++ b/src/test/run-pass/lambda-infer-unresolved.rs
@@ -17,6 +17,6 @@ struct Refs { refs: Vec<int> , n: int }
 pub fn main() {
     let mut e = Refs{refs: vec!(), n: 0};
     let _f = || println!("{}", e.n);
-    let x: &[int] = e.refs.as_slice();
+    let x: &[int] = &e.refs;
     assert_eq!(x.len(), 0);
 }

--- a/src/test/run-pass/logging-separate-lines.rs
+++ b/src/test/run-pass/logging-separate-lines.rs
@@ -21,18 +21,18 @@ use std::str;
 
 fn main() {
     let args = os::args();
-    let args = args.as_slice();
-    if args.len() > 1 && args[1].as_slice() == "child" {
+    let args = args;
+    if args.len() > 1 && args[1] == "child" {
         debug!("foo");
         debug!("bar");
         return
     }
 
-    let p = Command::new(args[0].as_slice())
+    let p = Command::new(&args[0])
                     .arg("child")
                     .spawn().unwrap().wait_with_output().unwrap();
     assert!(p.status.success());
-    let mut lines = str::from_utf8(p.error.as_slice()).unwrap().lines();
+    let mut lines = str::from_utf8(&p.error).unwrap().lines();
     assert!(lines.next().unwrap().contains("foo"));
     assert!(lines.next().unwrap().contains("bar"));
 }

--- a/src/test/run-pass/match-str.rs
+++ b/src/test/run-pass/match-str.rs
@@ -18,8 +18,8 @@ pub fn main() {
 
     match t::tag1("test".to_string()) {
       t::tag2 => panic!(),
-      t::tag1(ref s) if "test" != s.as_slice() => panic!(),
-      t::tag1(ref s) if "test" == s.as_slice() => (),
+      t::tag1(ref s) if "test" != &**s => panic!(),
+      t::tag1(ref s) if "test" == &**s => (),
       _ => panic!()
     }
 

--- a/src/test/run-pass/method-mut-self-modifies-mut-slice-lvalue.rs
+++ b/src/test/run-pass/method-mut-self-modifies-mut-slice-lvalue.rs
@@ -41,7 +41,7 @@ fn main() {
     let mut buf = [0_u8; 6];
 
     {
-        let mut writer = buf.as_mut_slice();
+        let mut writer: &mut [_] = &mut buf;
         writer.my_write(&[0, 1, 2]).unwrap();
         writer.my_write(&[3, 4, 5]).unwrap();
     }

--- a/src/test/run-pass/move-out-of-field.rs
+++ b/src/test/run-pass/move-out-of-field.rs
@@ -31,5 +31,5 @@ pub fn main() {
     sb.append("Hello, ");
     sb.append("World!");
     let str = to_string(sb);
-    assert_eq!(str.as_slice(), "Hello, World!");
+    assert_eq!(str, "Hello, World!");
 }

--- a/src/test/run-pass/new-unicode-escapes.rs
+++ b/src/test/run-pass/new-unicode-escapes.rs
@@ -18,5 +18,5 @@ pub fn main() {
     let s = "\\{20}";
     let mut correct_s = String::from_str("\\");
     correct_s.push_str("{20}");
-    assert_eq!(s, correct_s.as_slice());
+    assert_eq!(s, correct_s);
 }

--- a/src/test/run-pass/order-drop-with-match.rs
+++ b/src/test/run-pass/order-drop-with-match.rs
@@ -60,6 +60,6 @@ fn main() {
     }
     unsafe {
         let expected: &[_] = &[1, 2, 3];
-        assert_eq!(expected, ORDER.as_slice());
+        assert_eq!(expected, ORDER);
     }
 }

--- a/src/test/run-pass/out-of-stack-new-thread-no-split.rs
+++ b/src/test/run-pass/out-of-stack-new-thread-no-split.rs
@@ -35,13 +35,13 @@ fn recurse() {
 
 fn main() {
     let args = os::args();
-    let args = args.as_slice();
-    if args.len() > 1 && args[1].as_slice() == "recurse" {
+    let args = args;
+    if args.len() > 1 && args[1] == "recurse" {
         let _t = Thread::scoped(recurse);
     } else {
-        let recurse = Command::new(args[0].as_slice()).arg("recurse").output().unwrap();
+        let recurse = Command::new(&args[0]).arg("recurse").output().unwrap();
         assert!(!recurse.status.success());
-        let error = String::from_utf8_lossy(recurse.error.as_slice());
+        let error = String::from_utf8_lossy(&recurse.error);
         println!("wut");
         println!("`{}`", error);
         assert!(error.contains("has overflowed its stack"));

--- a/src/test/run-pass/out-of-stack-no-split.rs
+++ b/src/test/run-pass/out-of-stack-no-split.rs
@@ -35,13 +35,12 @@ fn recurse() {
 
 fn main() {
     let args = os::args();
-    let args = args.as_slice();
-    if args.len() > 1 && args[1].as_slice() == "recurse" {
+    if args.len() > 1 && args[1] == "recurse" {
         recurse();
     } else {
-        let recurse = Command::new(args[0].as_slice()).arg("recurse").output().unwrap();
+        let recurse = Command::new(&args[0]).arg("recurse").output().unwrap();
         assert!(!recurse.status.success());
-        let error = String::from_utf8_lossy(recurse.error.as_slice());
+        let error = String::from_utf8_lossy(&recurse.error);
         assert!(error.contains("has overflowed its stack"));
     }
 }

--- a/src/test/run-pass/out-of-stack.rs
+++ b/src/test/run-pass/out-of-stack.rs
@@ -35,20 +35,20 @@ fn loud_recurse() {
 
 fn main() {
     let args = os::args();
-    let args = args.as_slice();
-    if args.len() > 1 && args[1].as_slice() == "silent" {
+    let args = args;
+    if args.len() > 1 && args[1] == "silent" {
         silent_recurse();
-    } else if args.len() > 1 && args[1].as_slice() == "loud" {
+    } else if args.len() > 1 && args[1] == "loud" {
         loud_recurse();
     } else {
-        let silent = Command::new(args[0].as_slice()).arg("silent").output().unwrap();
+        let silent = Command::new(&args[0]).arg("silent").output().unwrap();
         assert!(!silent.status.success());
-        let error = String::from_utf8_lossy(silent.error.as_slice());
+        let error = String::from_utf8_lossy(&silent.error);
         assert!(error.contains("has overflowed its stack"));
 
-        let loud = Command::new(args[0].as_slice()).arg("loud").output().unwrap();
+        let loud = Command::new(&args[0]).arg("loud").output().unwrap();
         assert!(!loud.status.success());
-        let error = String::from_utf8_lossy(silent.error.as_slice());
+        let error = String::from_utf8_lossy(&silent.error);
         assert!(error.contains("has overflowed its stack"));
     }
 }

--- a/src/test/run-pass/overloaded-autoderef.rs
+++ b/src/test/run-pass/overloaded-autoderef.rs
@@ -34,13 +34,13 @@ pub fn main() {
     assert_eq!((i_value, *i.borrow()), (2, 5));
 
     let s = Rc::new("foo".to_string());
-    assert_eq!(s.as_slice(), "foo");
+    assert_eq!(&**s, "foo");
 
     let mut_s = Rc::new(RefCell::new(String::from_str("foo")));
     mut_s.borrow_mut().push_str("bar");
     // HACK assert_eq! would panic here because it stores the LHS and RHS in two locals.
-    assert!(mut_s.borrow().as_slice() == "foobar");
-    assert!(mut_s.borrow_mut().as_slice() == "foobar");
+    assert!(&**mut_s.borrow() == "foobar");
+    assert!(&**mut_s.borrow_mut() == "foobar");
 
     let p = Rc::new(RefCell::new(Point {x: 1, y: 2}));
     p.borrow_mut().x = 3;

--- a/src/test/run-pass/overloaded-deref-count.rs
+++ b/src/test/run-pass/overloaded-deref-count.rs
@@ -82,5 +82,5 @@ pub fn main() {
     // Check the final states.
     assert_eq!(*n, 2);
     let expected: &[_] = &[1, 2];
-    assert_eq!((*v).as_slice(), expected);
+    assert_eq!((*v), expected);
 }

--- a/src/test/run-pass/overloaded-deref.rs
+++ b/src/test/run-pass/overloaded-deref.rs
@@ -33,13 +33,13 @@ pub fn main() {
 
     let s = Rc::new("foo".to_string());
     assert_eq!(*s, "foo".to_string());
-    assert_eq!((*s).as_slice(), "foo");
+    assert_eq!((*s), "foo");
 
     let mut_s = Rc::new(RefCell::new(String::from_str("foo")));
     (*(*mut_s).borrow_mut()).push_str("bar");
     // assert_eq! would panic here because it stores the LHS and RHS in two locals.
-    assert!((*(*mut_s).borrow()).as_slice() == "foobar");
-    assert!((*(*mut_s).borrow_mut()).as_slice() == "foobar");
+    assert!((*(*mut_s).borrow()) == "foobar");
+    assert!((*(*mut_s).borrow_mut()) == "foobar");
 
     let p = Rc::new(RefCell::new(Point {x: 1, y: 2}));
     (*(*p).borrow_mut()).x = 3;

--- a/src/test/run-pass/process-remove-from-env.rs
+++ b/src/test/run-pass/process-remove-from-env.rs
@@ -41,12 +41,12 @@ fn main() {
     // restore original environment
     match old_env {
         None => os::unsetenv("RUN_TEST_NEW_ENV"),
-        Some(val) => os::setenv("RUN_TEST_NEW_ENV", val.as_slice())
+        Some(val) => os::setenv("RUN_TEST_NEW_ENV", val)
     }
 
     let prog = cmd.spawn().unwrap();
     let result = prog.wait_with_output().unwrap();
-    let output = String::from_utf8_lossy(result.output.as_slice());
+    let output = String::from_utf8_lossy(&result.output);
 
     assert!(!output.contains("RUN_TEST_NEW_ENV"),
             "found RUN_TEST_NEW_ENV inside of:\n\n{}", output);

--- a/src/test/run-pass/process-spawn-with-unicode-params.rs
+++ b/src/test/run-pass/process-spawn-with-unicode-params.rs
@@ -58,12 +58,12 @@ fn main() {
         let p = Command::new(&child_path)
                         .arg(arg)
                         .cwd(&cwd)
-                        .env_set_all(my_env.as_slice())
+                        .env_set_all(&my_env)
                         .spawn().unwrap().wait_with_output().unwrap();
 
         // display the output
-        assert!(old_io::stdout().write(p.output.as_slice()).is_ok());
-        assert!(old_io::stderr().write(p.error.as_slice()).is_ok());
+        assert!(old_io::stdout().write(&p.output).is_ok());
+        assert!(old_io::stderr().write(&p.error).is_ok());
 
         // make sure the child succeeded
         assert!(p.status.success());
@@ -74,7 +74,7 @@ fn main() {
         assert!(my_cwd.ends_with_path(&Path::new(child_dir)));
 
         // check arguments
-        assert_eq!(my_args[1].as_slice(), arg);
+        assert_eq!(&*my_args[1], arg);
 
         // check environment variable
         assert!(my_env.contains(&env));

--- a/src/test/run-pass/rcvr-borrowed-to-slice.rs
+++ b/src/test/run-pass/rcvr-borrowed-to-slice.rs
@@ -24,7 +24,7 @@ fn call_sum(x: &[int]) -> int { x.sum_() }
 
 pub fn main() {
     let x = vec!(1, 2, 3);
-    let y = call_sum(x.as_slice());
+    let y = call_sum(&x);
     println!("y=={}", y);
     assert_eq!(y, 6);
 

--- a/src/test/run-pass/realloc-16687.rs
+++ b/src/test/run-pass/realloc-16687.rs
@@ -28,7 +28,7 @@ fn main() {
 unsafe fn test_triangle() -> bool {
     static COUNT : uint = 16;
     let mut ascend = repeat(ptr::null_mut()).take(COUNT).collect::<Vec<_>>();
-    let ascend = ascend.as_mut_slice();
+    let ascend = &mut *ascend;
     static ALIGN : uint = 1;
 
     // Checks that `ascend` forms triangle of ascending size formed
@@ -103,7 +103,7 @@ unsafe fn test_triangle() -> bool {
         }
     }
 
-    sanity_check(ascend.as_slice());
+    sanity_check(&*ascend);
     test_1(ascend); // triangle -> square
     test_2(ascend); // square -> triangle
     test_3(ascend); // triangle -> square
@@ -128,10 +128,10 @@ unsafe fn test_triangle() -> bool {
             assert!(old_size < new_size);
 
             ascend[2*i] = reallocate(p0, old_size, new_size, ALIGN);
-            sanity_check(ascend.as_slice());
+            sanity_check(&*ascend);
 
             ascend[2*i+1] = reallocate(p1, old_size, new_size, ALIGN);
-            sanity_check(ascend.as_slice());
+            sanity_check(&*ascend);
         }
     }
 
@@ -143,10 +143,10 @@ unsafe fn test_triangle() -> bool {
             assert!(new_size < old_size);
 
             ascend[2*i] = reallocate(p0, old_size, new_size, ALIGN);
-            sanity_check(ascend.as_slice());
+            sanity_check(&*ascend);
 
             ascend[2*i+1] = reallocate(p1, old_size, new_size, ALIGN);
-            sanity_check(ascend.as_slice());
+            sanity_check(&*ascend);
         }
     }
 
@@ -158,10 +158,10 @@ unsafe fn test_triangle() -> bool {
             assert!(old_size < new_size);
 
             ascend[2*i+1] = reallocate(p1, old_size, new_size, ALIGN);
-            sanity_check(ascend.as_slice());
+            sanity_check(&*ascend);
 
             ascend[2*i] = reallocate(p0, old_size, new_size, ALIGN);
-            sanity_check(ascend.as_slice());
+            sanity_check(&*ascend);
         }
     }
 
@@ -173,10 +173,10 @@ unsafe fn test_triangle() -> bool {
             assert!(new_size < old_size);
 
             ascend[2*i+1] = reallocate(p1, old_size, new_size, ALIGN);
-            sanity_check(ascend.as_slice());
+            sanity_check(&*ascend);
 
             ascend[2*i] = reallocate(p0, old_size, new_size, ALIGN);
-            sanity_check(ascend.as_slice());
+            sanity_check(&*ascend);
         }
     }
 }

--- a/src/test/run-pass/regions-borrow-evec-uniq.rs
+++ b/src/test/run-pass/regions-borrow-evec-uniq.rs
@@ -15,10 +15,10 @@ fn foo(x: &[int]) -> int {
 
 pub fn main() {
     let p = vec!(1,2,3,4,5);
-    let r = foo(p.as_slice());
+    let r = foo(&p);
     assert_eq!(r, 1);
 
     let p = vec!(5,4,3,2,1);
-    let r = foo(p.as_slice());
+    let r = foo(&p);
     assert_eq!(r, 5);
 }

--- a/src/test/run-pass/regions-dependent-autoslice.rs
+++ b/src/test/run-pass/regions-dependent-autoslice.rs
@@ -20,5 +20,5 @@ fn both<'r>(v: &'r [uint]) -> &'r [uint] {
 
 pub fn main() {
     let v = vec!(1,2,3);
-    both(v.as_slice());
+    both(&v);
 }

--- a/src/test/run-pass/regions-infer-borrow-scope-view.rs
+++ b/src/test/run-pass/regions-infer-borrow-scope-view.rs
@@ -13,7 +13,7 @@ fn view<T>(x: &[T]) -> &[T] {x}
 
 pub fn main() {
     let v = vec!(1, 2, 3);
-    let x = view(v.as_slice());
-    let y = view(x.as_slice());
+    let x = view(&v);
+    let y = view(x);
     assert!((v[0] == x[0]) && (v[0] == y[0]));
 }

--- a/src/test/run-pass/running-with-no-runtime.rs
+++ b/src/test/run-pass/running-with-no-runtime.rs
@@ -41,7 +41,7 @@ fn start(argc: int, argv: *const *const u8) -> int {
             ffi::c_str_to_bytes(&ptr).to_vec()
         }).collect::<Vec<_>>()
     };
-    let me = args[0].as_slice();
+    let me = &*args[0];
 
     let x: &[u8] = &[1u8];
     pass(Command::new(me).arg(x).output().unwrap());
@@ -59,7 +59,7 @@ fn start(argc: int, argv: *const *const u8) -> int {
 
 fn pass(output: ProcessOutput) {
     if !output.status.success() {
-        println!("{:?}", str::from_utf8(output.output.as_slice()));
-        println!("{:?}", str::from_utf8(output.error.as_slice()));
+        println!("{:?}", str::from_utf8(&output.output));
+        println!("{:?}", str::from_utf8(&output.error));
     }
 }

--- a/src/test/run-pass/rust-log-filter.rs
+++ b/src/test/run-pass/rust-log-filter.rs
@@ -48,8 +48,8 @@ pub fn main() {
         info!("bar foo");
     });
 
-    assert_eq!(rx.recv().unwrap().as_slice(), "foo");
-    assert_eq!(rx.recv().unwrap().as_slice(), "foo bar");
-    assert_eq!(rx.recv().unwrap().as_slice(), "bar foo");
+    assert_eq!(rx.recv().unwrap(), "foo");
+    assert_eq!(rx.recv().unwrap(), "foo bar");
+    assert_eq!(rx.recv().unwrap(), "bar foo");
     assert!(rx.recv().is_err());
 }

--- a/src/test/run-pass/segfault-no-out-of-stack.rs
+++ b/src/test/run-pass/segfault-no-out-of-stack.rs
@@ -13,13 +13,12 @@ use std::os;
 
 fn main() {
     let args = os::args();
-    let args = args.as_slice();
-    if args.len() > 1 && args[1].as_slice() == "segfault" {
+    if args.len() > 1 && args[1] == "segfault" {
         unsafe { *(0 as *mut int) = 1 }; // trigger a segfault
     } else {
-        let segfault = Command::new(args[0].as_slice()).arg("segfault").output().unwrap();
+        let segfault = Command::new(&args[0]).arg("segfault").output().unwrap();
         assert!(!segfault.status.success());
-        let error = String::from_utf8_lossy(segfault.error.as_slice());
+        let error = String::from_utf8_lossy(&segfault.error);
         assert!(!error.contains("has overflowed its stack"));
     }
 }

--- a/src/test/run-pass/signal-exit-status.rs
+++ b/src/test/run-pass/signal-exit-status.rs
@@ -15,12 +15,12 @@ use std::old_io::process::{Command, ExitSignal, ExitStatus};
 
 pub fn main() {
     let args = os::args();
-    let args = args.as_slice();
-    if args.len() >= 2 && args[1].as_slice() == "signal" {
+    let args = args;
+    if args.len() >= 2 && args[1] == "signal" {
         // Raise a segfault.
         unsafe { *(0 as *mut int) = 0; }
     } else {
-        let status = Command::new(args[0].as_slice()).arg("signal").status().unwrap();
+        let status = Command::new(&args[0]).arg("signal").status().unwrap();
         // Windows does not have signal, so we get exit status 0xC0000028 (STATUS_BAD_STACK).
         match status {
             ExitSignal(_) if cfg!(unix) => {},

--- a/src/test/run-pass/sigpipe-should-be-ignored.rs
+++ b/src/test/run-pass/sigpipe-should-be-ignored.rs
@@ -26,12 +26,12 @@ fn test() {
 
 fn main() {
     let args = os::args();
-    let args = args.as_slice();
-    if args.len() > 1 && args[1].as_slice() == "test" {
+    let args = args;
+    if args.len() > 1 && args[1] == "test" {
         return test();
     }
 
-    let mut p = Command::new(args[0].as_slice())
+    let mut p = Command::new(&args[0])
                         .arg("test").spawn().unwrap();
     assert!(p.wait().unwrap().success());
 }

--- a/src/test/run-pass/small-enums-with-fields.rs
+++ b/src/test/run-pass/small-enums-with-fields.rs
@@ -20,8 +20,8 @@ macro_rules! check {
             static S: $t = $e;
             let v: $t = $e;
             assert_eq!(S, v);
-            assert_eq!(format!("{:?}", v).as_slice(), $s);
-            assert_eq!(format!("{:?}", S).as_slice(), $s);
+            assert_eq!(format!("{:?}", v), $s);
+            assert_eq!(format!("{:?}", S), $s);
         });*
     }}
 }

--- a/src/test/run-pass/swap-2.rs
+++ b/src/test/run-pass/swap-2.rs
@@ -12,7 +12,7 @@ use std::mem::swap;
 
 pub fn main() {
     let mut a: Vec<int> = vec!(0, 1, 2, 3, 4, 5, 6);
-    a.as_mut_slice().swap(2, 4);
+    a.swap(2, 4);
     assert_eq!(a[2], 4);
     assert_eq!(a[4], 2);
     let mut n = 42;

--- a/src/test/run-pass/trait-bounds-in-arc.rs
+++ b/src/test/run-pass/trait-bounds-in-arc.rs
@@ -44,19 +44,19 @@ struct Goldfyshe {
 }
 
 impl Pet for Catte {
-    fn name(&self, mut blk: Box<FnMut(&str)>) { blk(self.name.as_slice()) }
+    fn name(&self, mut blk: Box<FnMut(&str)>) { blk(&self.name) }
     fn num_legs(&self) -> uint { 4 }
     fn of_good_pedigree(&self) -> bool { self.num_whiskers >= 4 }
 }
 impl Pet for Dogge {
-    fn name(&self, mut blk: Box<FnMut(&str)>) { blk(self.name.as_slice()) }
+    fn name(&self, mut blk: Box<FnMut(&str)>) { blk(&self.name) }
     fn num_legs(&self) -> uint { 4 }
     fn of_good_pedigree(&self) -> bool {
         self.bark_decibels < 70 || self.tricks_known > 20
     }
 }
 impl Pet for Goldfyshe {
-    fn name(&self, mut blk: Box<FnMut(&str)>) { blk(self.name.as_slice()) }
+    fn name(&self, mut blk: Box<FnMut(&str)>) { blk(&self.name) }
     fn num_legs(&self) -> uint { 0 }
     fn of_good_pedigree(&self) -> bool { self.swim_speed >= 500 }
 }

--- a/src/test/run-pass/typeck_type_placeholder_1.rs
+++ b/src/test/run-pass/typeck_type_placeholder_1.rs
@@ -23,10 +23,10 @@ static CONSTEXPR: TestStruct = TestStruct{x: &413 as *const _};
 pub fn main() {
     let x: Vec<_> = (0u..5).collect();
     let expected: &[uint] = &[0,1,2,3,4];
-    assert_eq!(x.as_slice(), expected);
+    assert_eq!(x, expected);
 
     let x = (0u..5).collect::<Vec<_>>();
-    assert_eq!(x.as_slice(), expected);
+    assert_eq!(x, expected);
 
     let y: _ = "hello";
     assert_eq!(y.len(), 5);

--- a/src/test/run-pass/unit-like-struct-drop-run.rs
+++ b/src/test/run-pass/unit-like-struct-drop-run.rs
@@ -27,5 +27,5 @@ pub fn main() {
     }).join();
 
     let s = x.err().unwrap().downcast::<&'static str>().ok().unwrap();
-    assert_eq!(s.as_slice(), "This panic should happen.");
+    assert_eq!(&**s, "This panic should happen.");
 }

--- a/src/test/run-pass/vec-concat.rs
+++ b/src/test/run-pass/vec-concat.rs
@@ -14,7 +14,7 @@ pub fn main() {
     let a: Vec<int> = vec!(1, 2, 3, 4, 5);
     let b: Vec<int> = vec!(6, 7, 8, 9, 0);
     let mut v: Vec<int> = a;
-    v.push_all(b.as_slice());
+    v.push_all(&b);
     println!("{}", v[9]);
     assert_eq!(v[0], 1);
     assert_eq!(v[7], 8);

--- a/src/test/run-pass/vector-sort-panic-safe.rs
+++ b/src/test/run-pass/vector-sort-panic-safe.rs
@@ -68,7 +68,7 @@ pub fn main() {
             // work out the total number of comparisons required to sort
             // this array...
             let mut count = 0us;
-            main.clone().as_mut_slice().sort_by(|a, b| { count += 1; a.cmp(b) });
+            main.clone().sort_by(|a, b| { count += 1; a.cmp(b) });
 
             // ... and then panic on each and every single one.
             for panic_countdown in 0..count {
@@ -82,7 +82,7 @@ pub fn main() {
                 let _ = Thread::scoped(move|| {
                     let mut v = v;
                     let mut panic_countdown = panic_countdown;
-                    v.as_mut_slice().sort_by(|a, b| {
+                    v.sort_by(|a, b| {
                         if panic_countdown == 0 {
                             panic!()
                         }

--- a/src/test/run-pass/wait-forked-but-failed-child.rs
+++ b/src/test/run-pass/wait-forked-but-failed-child.rs
@@ -35,7 +35,7 @@ fn find_zombies() {
 
     // http://pubs.opengroup.org/onlinepubs/9699919799/utilities/ps.html
     let ps_cmd_output = Command::new("ps").args(&["-A", "-o", "pid,ppid,args"]).output().unwrap();
-    let ps_output = String::from_utf8_lossy(ps_cmd_output.output.as_slice());
+    let ps_output = String::from_utf8_lossy(&ps_cmd_output.output);
 
     for (line_no, line) in ps_output.split('\n').enumerate() {
         if 0 < line_no && 0 < line.len() &&
@@ -56,7 +56,7 @@ fn main() {
     let too_long = format!("/NoSuchCommand{:0300}", 0u8);
 
     let _failures = (0..100).map(|_| {
-        let cmd = Command::new(too_long.as_slice());
+        let cmd = Command::new(&too_long);
         let failed = cmd.spawn();
         assert!(failed.is_err(), "Make sure the command fails to spawn(): {:?}", cmd);
         failed


### PR DESCRIPTION
r? @alexcrichton 
cc @eddyb 
