### PR TITLE
Replace `be` with `become`

### DIFF
--- a/src/doc/grammar.md
+++ b/src/doc/grammar.md
@@ -157,7 +157,7 @@ token : simple_token | ident | literal | symbol | whitespace token ;
 
 |          |          |          |          |        |
 |----------|----------|----------|----------|--------|
-| abstract | alignof  | as       | be       | box    |
+| abstract | alignof  | as       | become   | box    |
 | break    | const    | continue | crate    | do     |
 | else     | enum     | extern   | false    | final  |
 | fn       | for      | if       | impl     | in     |

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -189,7 +189,7 @@ grammar as double-quoted strings. Other tokens have exact rules given.
 
 |          |          |          |          |         |
 |----------|----------|----------|----------|---------|
-| abstract | alignof  | as       | be       | box     |
+| abstract | alignof  | as       | become   | box     |
 | break    | const    | continue | crate    | do      |
 | else     | enum     | extern   | false    | final   |
 | fn       | for      | if       | impl     | in      |

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -562,7 +562,7 @@ declare_special_idents_and_keywords! {
         (45,                         Where,      "where");
         'reserved:
         (46,                         Alignof,    "alignof");
-        (47,                         Be,         "be");
+        (47,                         Become,     "become");
         (48,                         Offsetof,   "offsetof");
         (49,                         Priv,       "priv");
         (50,                         Pure,       "pure");

--- a/src/test/compile-fail/reserved-become.rs
+++ b/src/test/compile-fail/reserved-become.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 fn main() {
-    let be = 0;
-    //~^ ERROR `be` is a reserved keyword
+    let become = 0;
+    //~^ ERROR `become` is a reserved keyword
 }


### PR DESCRIPTION
As per rust-lang/rfcs#601, replace `be` with `become` as reserved
keyword for tail call optimization.

Fixes #22141. _(Added by @nikomatsakis)_
