### PR TITLE
Switch missing_copy_implementations to default-allow

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1813,7 +1813,6 @@ default visibility with the `priv` keyword. When an item is declared as `pub`,
 it can be thought of as being accessible to the outside world. For example:
 
 ```
-# #![allow(missing_copy_implementations)]
 # fn main() {}
 // Declare a private struct
 struct Foo;

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -49,7 +49,6 @@ pub struct FromUtf8Error {
 
 /// A possible error value from the `String::from_utf16` function.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[allow(missing_copy_implementations)]
 #[derive(Debug)]
 pub struct FromUtf16Error(());
 

--- a/src/libcore/hash/sip.rs
+++ b/src/libcore/hash/sip.rs
@@ -30,7 +30,6 @@ use super::{Hasher, Writer};
 /// strong, this implementation has not been reviewed for such purposes.
 /// As such, all cryptographic uses of this implementation are strongly
 /// discouraged.
-#[allow(missing_copy_implementations)]
 pub struct SipHasher {
     k0: u64,
     k1: u64,

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -396,7 +396,6 @@ pub struct InvariantLifetime<'a>;
            reason = "likely to change with new variance strategy")]
 #[lang="no_copy_bound"]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[allow(missing_copy_implementations)]
 pub struct NoCopy;
 
 /// A type which is considered managed by the GC. This is typically
@@ -405,5 +404,4 @@ pub struct NoCopy;
            reason = "likely to change with new variance strategy")]
 #[lang="managed_bound"]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[allow(missing_copy_implementations)]
 pub struct Managed;

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -149,7 +149,6 @@ impl FromStr for bool {
 
 /// An error returned when parsing a `bool` from a string fails.
 #[derive(Debug, Clone, PartialEq)]
-#[allow(missing_copy_implementations)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct ParseBoolError { _priv: () }
 

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -332,15 +332,12 @@ pub mod types {
             /// variants, because the compiler complains about the repr attribute
             /// otherwise.
             #[repr(u8)]
-            #[allow(missing_copy_implementations)]
             pub enum c_void {
                 __variant1,
                 __variant2,
             }
 
-            #[allow(missing_copy_implementations)]
             pub enum FILE {}
-            #[allow(missing_copy_implementations)]
             pub enum fpos_t {}
         }
         pub mod c99 {
@@ -354,9 +351,7 @@ pub mod types {
             pub type uint64_t = u64;
         }
         pub mod posix88 {
-            #[allow(missing_copy_implementations)]
             pub enum DIR {}
-            #[allow(missing_copy_implementations)]
             pub enum dirent_t {}
         }
         pub mod posix01 {}

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -383,7 +383,6 @@ pub trait SeedableRng<Seed>: Rng {
 /// [1]: Marsaglia, George (July 2003). ["Xorshift
 /// RNGs"](http://www.jstatsoft.org/v08/i14/paper). *Journal of
 /// Statistical Software*. Vol. 8 (Issue 14).
-#[allow(missing_copy_implementations)]
 #[derive(Clone)]
 pub struct XorShiftRng {
     x: u32,

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -2038,7 +2038,7 @@ declare_lint! {
 
 declare_lint! {
     pub MISSING_COPY_IMPLEMENTATIONS,
-    Warn,
+    Allow,
     "detects potentially-forgotten implementations of `Copy`"
 }
 

--- a/src/librustc/middle/infer/region_inference/mod.rs
+++ b/src/librustc/middle/infer/region_inference/mod.rs
@@ -224,7 +224,6 @@ pub struct RegionVarBindings<'a, 'tcx: 'a> {
 }
 
 #[derive(Debug)]
-#[allow(missing_copy_implementations)]
 pub struct RegionSnapshot {
     length: uint,
     skolemization_count: u32,

--- a/src/librustc/middle/traits/coherence.rs
+++ b/src/librustc/middle/traits/coherence.rs
@@ -59,7 +59,6 @@ pub fn impl_can_satisfy(infcx: &InferCtxt,
             |o| selcx.evaluate_obligation(o))
 }
 
-#[allow(missing_copy_implementations)]
 pub enum OrphanCheckErr<'tcx> {
     NoLocalInputType,
     UncoveredTy(Ty<'tcx>),

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -132,7 +132,6 @@ pub enum UnstableFeatures {
 }
 
 #[derive(Clone, PartialEq, Eq)]
-#[allow(missing_copy_implementations)]
 pub enum PrintRequest {
     FileNames,
     Sysroot,
@@ -290,7 +289,6 @@ macro_rules! options {
      $($opt:ident : $t:ty = ($init:expr, $parse:ident, $desc:expr)),* ,) =>
 (
     #[derive(Clone)]
-    #[allow(missing_copy_implementations)]
     pub struct $struct_name { $(pub $opt: $t),* }
 
     pub fn $defaultfn() -> $struct_name {

--- a/src/librustc/util/nodemap.rs
+++ b/src/librustc/util/nodemap.rs
@@ -46,7 +46,6 @@ pub fn DefIdSet() -> DefIdSet { FnvHashSet() }
 ///
 /// This uses FNV hashing, as described here:
 /// http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
-#[allow(missing_copy_implementations)]
 pub struct FnvHasher(u64);
 
 impl Default for FnvHasher {

--- a/src/librustc/util/snapshot_vec.rs
+++ b/src/librustc/util/snapshot_vec.rs
@@ -46,7 +46,6 @@ pub struct SnapshotVec<D:SnapshotVecDelegate> {
 }
 
 // Snapshots are tokens that should be created/consumed linearly.
-#[allow(missing_copy_implementations)]
 pub struct Snapshot {
     // Length of the undo log at the time the snapshot was taken.
     length: uint,

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -464,7 +464,6 @@ pub fn opt_loan_path<'tcx>(cmt: &mc::cmt<'tcx>) -> Option<Rc<LoanPath<'tcx>>> {
 
 // Errors that can occur
 #[derive(PartialEq)]
-#[allow(missing_copy_implementations)]
 pub enum bckerr_code {
     err_mutbl,
     err_out_of_scope(ty::Region, ty::Region), // superscope, subscope

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -430,73 +430,50 @@ pub enum DiagnosticKind {
 }
 
 // Opaque pointer types
-#[allow(missing_copy_implementations)]
 pub enum Module_opaque {}
 pub type ModuleRef = *mut Module_opaque;
-#[allow(missing_copy_implementations)]
 pub enum Context_opaque {}
 pub type ContextRef = *mut Context_opaque;
-#[allow(missing_copy_implementations)]
 pub enum Type_opaque {}
 pub type TypeRef = *mut Type_opaque;
-#[allow(missing_copy_implementations)]
 pub enum Value_opaque {}
 pub type ValueRef = *mut Value_opaque;
-#[allow(missing_copy_implementations)]
 pub enum Metadata_opaque {}
 pub type MetadataRef = *mut Metadata_opaque;
-#[allow(missing_copy_implementations)]
 pub enum BasicBlock_opaque {}
 pub type BasicBlockRef = *mut BasicBlock_opaque;
-#[allow(missing_copy_implementations)]
 pub enum Builder_opaque {}
 pub type BuilderRef = *mut Builder_opaque;
-#[allow(missing_copy_implementations)]
 pub enum ExecutionEngine_opaque {}
 pub type ExecutionEngineRef = *mut ExecutionEngine_opaque;
-#[allow(missing_copy_implementations)]
 pub enum RustJITMemoryManager_opaque {}
 pub type RustJITMemoryManagerRef = *mut RustJITMemoryManager_opaque;
-#[allow(missing_copy_implementations)]
 pub enum MemoryBuffer_opaque {}
 pub type MemoryBufferRef = *mut MemoryBuffer_opaque;
-#[allow(missing_copy_implementations)]
 pub enum PassManager_opaque {}
 pub type PassManagerRef = *mut PassManager_opaque;
-#[allow(missing_copy_implementations)]
 pub enum PassManagerBuilder_opaque {}
 pub type PassManagerBuilderRef = *mut PassManagerBuilder_opaque;
-#[allow(missing_copy_implementations)]
 pub enum Use_opaque {}
 pub type UseRef = *mut Use_opaque;
-#[allow(missing_copy_implementations)]
 pub enum TargetData_opaque {}
 pub type TargetDataRef = *mut TargetData_opaque;
-#[allow(missing_copy_implementations)]
 pub enum ObjectFile_opaque {}
 pub type ObjectFileRef = *mut ObjectFile_opaque;
-#[allow(missing_copy_implementations)]
 pub enum SectionIterator_opaque {}
 pub type SectionIteratorRef = *mut SectionIterator_opaque;
-#[allow(missing_copy_implementations)]
 pub enum Pass_opaque {}
 pub type PassRef = *mut Pass_opaque;
-#[allow(missing_copy_implementations)]
 pub enum TargetMachine_opaque {}
 pub type TargetMachineRef = *mut TargetMachine_opaque;
-#[allow(missing_copy_implementations)]
 pub enum Archive_opaque {}
 pub type ArchiveRef = *mut Archive_opaque;
-#[allow(missing_copy_implementations)]
 pub enum Twine_opaque {}
 pub type TwineRef = *mut Twine_opaque;
-#[allow(missing_copy_implementations)]
 pub enum DiagnosticInfo_opaque {}
 pub type DiagnosticInfoRef = *mut DiagnosticInfo_opaque;
-#[allow(missing_copy_implementations)]
 pub enum DebugLoc_opaque {}
 pub type DebugLocRef = *mut DebugLoc_opaque;
-#[allow(missing_copy_implementations)]
 pub enum SMDiagnostic_opaque {}
 pub type SMDiagnosticRef = *mut SMDiagnostic_opaque;
 
@@ -507,7 +484,6 @@ pub mod debuginfo {
     pub use self::DIDescriptorFlags::*;
     use super::{MetadataRef};
 
-    #[allow(missing_copy_implementations)]
     pub enum DIBuilder_opaque {}
     pub type DIBuilderRef = *mut DIBuilder_opaque;
 
@@ -2209,7 +2185,6 @@ pub fn get_param(llfn: ValueRef, index: c_uint) -> ValueRef {
     }
 }
 
-#[allow(missing_copy_implementations)]
 pub enum RustString_opaque {}
 pub type RustStringRef = *mut RustString_opaque;
 type RustStringRepr = *mut RefCell<Vec<u8>>;

--- a/src/librustc_trans/trans/value.rs
+++ b/src/librustc_trans/trans/value.rs
@@ -150,7 +150,6 @@ impl Use {
 }
 
 /// Iterator for the users of a value
-#[allow(missing_copy_implementations)]
 pub struct Users {
     next: Option<Use>
 }

--- a/src/librustc_typeck/rscope.rs
+++ b/src/librustc_typeck/rscope.rs
@@ -79,7 +79,6 @@ impl RegionScope for UnelidableRscope {
 // A scope in which any omitted region defaults to `default`. This is
 // used after the `->` in function signatures, but also for backwards
 // compatibility with object types. The latter use may go away.
-#[allow(missing_copy_implementations)]
 pub struct SpecificRscope {
     default: ty::Region
 }

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1580,7 +1580,6 @@ impl<K, V, S, H> Extend<(K, V)> for HashMap<K, V, S>
 /// `Hasher`, but the hashers created by two different `RandomState`
 /// instances are unlikely to produce the same result for the same values.
 #[derive(Clone)]
-#[allow(missing_copy_implementations)]
 #[unstable(feature = "std_misc",
            reason = "hashing an hash maps may be altered")]
 pub struct RandomState {
@@ -1622,7 +1621,6 @@ impl Default for RandomState {
 /// This is the default hasher used in a `HashMap` to hash keys. Types do not
 /// typically declare an ability to explicitly hash into this particular type,
 /// but rather in a `H: hash::Writer` type parameter.
-#[allow(missing_copy_implementations)]
 #[unstable(feature = "std_misc",
            reason = "hashing an hash maps may be altered")]
 pub struct Hasher { inner: SipHasher }

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -22,7 +22,6 @@ use mem;
 use env;
 use str;
 
-#[allow(missing_copy_implementations)]
 pub struct DynamicLibrary {
     handle: *mut u8
 }

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -759,7 +759,6 @@ pub fn page_size() -> uint {
 ///
 /// The memory map is released (unmapped) when the destructor is run, so don't
 /// let it leave scope by accident if you want it to stick around.
-#[allow(missing_copy_implementations)]
 pub struct MemoryMap {
     data: *mut u8,
     len: uint,

--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -206,7 +206,6 @@ mod imp {
     /// - iOS: calls SecRandomCopyBytes as /dev/(u)random is sandboxed.
     ///
     /// This does not block.
-    #[allow(missing_copy_implementations)]
     pub struct OsRng {
         // dummy field to ensure that this struct cannot be constructed outside of this module
         _dummy: (),

--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -390,13 +390,10 @@ pub mod eabi {
     use libc::{c_void, c_int};
 
     #[repr(C)]
-    #[allow(missing_copy_implementations)]
     pub struct EXCEPTION_RECORD;
     #[repr(C)]
-    #[allow(missing_copy_implementations)]
     pub struct CONTEXT;
     #[repr(C)]
-    #[allow(missing_copy_implementations)]
     pub struct DISPATCHER_CONTEXT;
 
     #[repr(C)]

--- a/src/libstd/rt/util.rs
+++ b/src/libstd/rt/util.rs
@@ -88,7 +88,6 @@ pub fn default_sched_threads() -> uint {
 pub const ENFORCE_SANITY: bool = true || !cfg!(rtopt) || cfg!(rtdebug) ||
                                   cfg!(rtassert);
 
-#[allow(missing_copy_implementations)]
 pub struct Stdio(libc::c_int);
 
 #[allow(non_upper_case_globals)]

--- a/src/libstd/sync/barrier.rs
+++ b/src/libstd/sync/barrier.rs
@@ -46,7 +46,6 @@ struct BarrierState {
 ///
 /// Currently this opaque structure only has one method, `.is_leader()`. Only
 /// one thread will receive a result that will return `true` from this function.
-#[allow(missing_copy_implementations)]
 pub struct BarrierWaitResult(bool);
 
 impl Barrier {

--- a/src/libstd/sync/poison.rs
+++ b/src/libstd/sync/poison.rs
@@ -42,7 +42,6 @@ impl Flag {
     }
 }
 
-#[allow(missing_copy_implementations)]
 pub struct Guard {
     panicking: bool,
 }

--- a/src/test/compile-fail/lint-dead-code-1.rs
+++ b/src/test/compile-fail/lint-dead-code-1.rs
@@ -12,7 +12,6 @@
 #![allow(unused_variables)]
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
-#![allow(missing_copy_implementations)]
 #![deny(dead_code)]
 #![feature(core)]
 

--- a/src/test/compile-fail/lint-missing-doc.rs
+++ b/src/test/compile-fail/lint-missing-doc.rs
@@ -12,7 +12,6 @@
 // injected intrinsics by the compiler.
 #![deny(missing_docs)]
 #![allow(dead_code)]
-#![allow(missing_copy_implementations)]
 
 //! Some garbage docs for the crate here
 #![doc="More garbage"]

--- a/src/test/compile-fail/missing_debug_impls.rs
+++ b/src/test/compile-fail/missing_debug_impls.rs
@@ -10,7 +10,7 @@
 
 // compile-flags: --crate-type lib
 #![deny(missing_debug_implementations)]
-#![allow(unused, missing_copy_implementations)]
+#![allow(unused)]
 
 use std::fmt;
 


### PR DESCRIPTION
This was particularly helpful in the time just after OIBIT's
implementation to make sure things that were supposed to be Copy
continued to be, but it's now creates a lot of noise for types that
intentionally don't want to be Copy.

r? @alexcrichton 
