### PR TITLE
std::os::errno returns platform specific value. fixes #21898

### DIFF
--- a/src/libstd/old_io/mod.rs
+++ b/src/libstd/old_io/mod.rs
@@ -337,7 +337,7 @@ impl IoError {
     /// If `detail` is `true`, the `detail` field of the `IoError`
     /// struct is filled with an allocated string describing the error
     /// in more detail, retrieved from the operating system.
-    pub fn from_errno(errno: uint, detail: bool) -> IoError {
+    pub fn from_errno(errno: i32, detail: bool) -> IoError {
         let mut err = sys::decode_error(errno as i32);
         if detail && err.kind == OtherIoError {
             err.detail = Some(os::error_string(errno).chars()
@@ -353,7 +353,7 @@ impl IoError {
     /// operating system) between the call(s) for which errors are
     /// being checked and the call of this function.
     pub fn last_error() -> IoError {
-        IoError::from_errno(os::errno() as uint, true)
+        IoError::from_errno(os::errno() as i32, true)
     }
 }
 

--- a/src/libstd/old_io/mod.rs
+++ b/src/libstd/old_io/mod.rs
@@ -353,7 +353,7 @@ impl IoError {
     /// operating system) between the call(s) for which errors are
     /// being checked and the call of this function.
     pub fn last_error() -> IoError {
-        IoError::from_errno(os::errno() as i32, true)
+        IoError::from_errno(os::errno(), true)
     }
 }
 

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -527,12 +527,12 @@ pub fn errno() -> i32 {
 /// println!("{}", os::error_string(os::errno() as i32));
 /// ```
 pub fn error_string(errnum: i32) -> String {
-    return sys::os::error_string(errnum as i32);
+    return sys::os::error_string(errnum);
 }
 
 /// Get a string representing the platform-dependent last error
 pub fn last_os_error() -> String {
-    error_string(errno() as i32)
+    error_string(errno())
 }
 
 /// Sets the process exit code

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -513,8 +513,8 @@ pub fn change_dir(p: &Path) -> IoResult<()> {
 }
 
 /// Returns the platform-specific value of errno
-pub fn errno() -> uint {
-    sys::os::errno() as uint
+pub fn errno() -> i32 {
+    sys::os::errno() as i32
 }
 
 /// Return the string corresponding to an `errno()` value of `errnum`.
@@ -524,15 +524,15 @@ pub fn errno() -> uint {
 /// use std::os;
 ///
 /// // Same as println!("{}", last_os_error());
-/// println!("{}", os::error_string(os::errno() as uint));
+/// println!("{}", os::error_string(os::errno() as i32));
 /// ```
-pub fn error_string(errnum: uint) -> String {
+pub fn error_string(errnum: i32) -> String {
     return sys::os::error_string(errnum as i32);
 }
 
 /// Get a string representing the platform-dependent last error
 pub fn last_os_error() -> String {
-    error_string(errno() as uint)
+    error_string(errno() as i32)
 }
 
 /// Sets the process exit code

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -845,13 +845,13 @@ pub enum MapError {
     ErrAlreadyExists,
     /// Unrecognized error from `VirtualAlloc`. The inner value is the return
     /// value of GetLastError.
-    ErrVirtualAlloc(uint),
+    ErrVirtualAlloc(i32),
     /// Unrecognized error from `CreateFileMapping`. The inner value is the
     /// return value of `GetLastError`.
-    ErrCreateFileMappingW(uint),
+    ErrCreateFileMappingW(i32),
     /// Unrecognized error from `MapViewOfFile`. The inner value is the return
     /// value of `GetLastError`.
-    ErrMapViewOfFile(uint)
+    ErrMapViewOfFile(i32)
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -388,7 +388,7 @@ impl Process {
                 match unsafe { c::select(max, &mut set, ptr::null_mut(),
                                          ptr::null_mut(), p) } {
                     // interrupted, retry
-                    -1 if os::errno() == libc::EINTR as uint => continue,
+                    -1 if os::errno() == libc::EINTR as i32 => continue,
 
                     // We read something, break out and process
                     1 | 2 => {}

--- a/src/libstd/sys/unix/timer.rs
+++ b/src/libstd/sys/unix/timer.rs
@@ -198,7 +198,7 @@ fn helper(input: libc::c_int, messages: Receiver<Req>, _: ()) {
                 assert_eq!(fd.read(&mut buf).ok().unwrap(), 1);
             }
 
-            -1 if os::errno() == libc::EINTR as uint => {}
+            -1 if os::errno() == libc::EINTR as i32 => {}
             n => panic!("helper thread failed in select() with error: {} ({})",
                        n, os::last_os_error())
         }


### PR DESCRIPTION
Changes std::os::errno to return i32, the return type used by the function being delegated to.

This is my first contribution, so feel free to give me advice. I'll be happy to correct things.
