### PR TITLE
std: Add reexports for core parse errors

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -80,7 +80,7 @@ pub use core::str::{Lines, LinesAny, MatchIndices, SplitStr, CharRange};
 pub use core::str::{Split, SplitTerminator};
 pub use core::str::{SplitN, RSplitN};
 pub use core::str::{from_utf8, CharEq, Chars, CharIndices, Bytes};
-pub use core::str::{from_utf8_unchecked, from_c_str};
+pub use core::str::{from_utf8_unchecked, from_c_str, ParseBoolError};
 pub use unicode::str::{Words, Graphemes, GraphemeIndices};
 
 /*

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -29,7 +29,7 @@ pub use core::num::{from_int, from_i8, from_i16, from_i32, from_i64};
 pub use core::num::{from_uint, from_u8, from_u16, from_u32, from_u64};
 pub use core::num::{from_f32, from_f64};
 pub use core::num::{FromStrRadix, from_str_radix};
-pub use core::num::{FpCategory};
+pub use core::num::{FpCategory, ParseIntError, ParseFloatError};
 
 use option::Option;
 


### PR DESCRIPTION
These were forgotten reexports from #21718

Closes #21929
