### PR TITLE
Avoid unnecessary codegen in with_cond()

### DIFF
--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -889,11 +889,13 @@ fn compile_guard<'a, 'p, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         }
     }
 
+    for (_, &binding_info) in &data.bindings_map {
+        bcx.fcx.lllocals.borrow_mut().remove(&binding_info.id);
+    }
+
     with_cond(bcx, Not(bcx, val, guard_expr.debug_loc()), |bcx| {
-        // Guard does not match: remove all bindings from the lllocals table
         for (_, &binding_info) in &data.bindings_map {
             call_lifetime_end(bcx, binding_info.llmatch);
-            bcx.fcx.lllocals.borrow_mut().remove(&binding_info.id);
         }
         match chk {
             // If the default arm is the only one left, move on to the next

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1079,6 +1079,12 @@ pub fn with_cond<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
     F: FnOnce(Block<'blk, 'tcx>) -> Block<'blk, 'tcx>,
 {
     let _icx = push_ctxt("with_cond");
+
+    if bcx.unreachable.get() ||
+            (common::is_const(val) && common::const_to_uint(val) == 0) {
+        return bcx;
+    }
+
     let fcx = bcx.fcx;
     let next_cx = fcx.new_temp_block("next");
     let cond_cx = fcx.new_temp_block("cond");


### PR DESCRIPTION
Currently "k / 2" generates one (k: uint) or two (k: int) "br false,
..." instructions and the corresponding basic blocks, producing quite
some noise and making the code unnecessarily hard to read.

Additionally we can skip translation if the code would end up
unreachable anyway.
