### PR TITLE
rustc: Recognize `-L framework=foo`

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -18,10 +18,15 @@ Display the help message
 \fB\-\-cfg\fR SPEC
 Configure the compilation environment
 .TP
-\fB\-L\fR PATH
-Add a directory to the library search path
+\fB\-L\fR [KIND=]PATH
+Add a directory to the library search path. The optional KIND can be one of:
+    dependency = only lookup transitive dependencies here
+    crate = only lookup local `extern crate` directives here
+    native = only lookup native libraries here
+    framework = only look for OSX frameworks here
+    all = look for anything here (the default)
 .TP
-\fB\-l\fR NAME[:KIND]
+\fB\-l\fR [KIND=]NAME
 Link the generated crate(s) to the specified native library NAME. The optional
 KIND can be one of, static, dylib, or framework. If omitted, dylib is assumed.
 .TP

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -738,7 +738,8 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
     vec![
         opt::flag("h", "help", "Display this message"),
         opt::multi("", "cfg", "Configure the compilation environment", "SPEC"),
-        opt::multi("L", "",   "Add a directory to the library search path", "PATH"),
+        opt::multi("L", "",   "Add a directory to the library search path",
+                   "[KIND=]PATH"),
         opt::multi("l", "",   "Link the generated crate(s) to the specified native
                              library NAME. The optional KIND can be one of,
                              static, dylib, or framework. If omitted, dylib is

--- a/src/librustc/session/search_paths.rs
+++ b/src/librustc/session/search_paths.rs
@@ -25,6 +25,7 @@ pub enum PathKind {
     Native,
     Crate,
     Dependency,
+    Framework,
     ExternFlag,
     All,
 }
@@ -41,6 +42,8 @@ impl SearchPaths {
             (PathKind::Crate, &path["crate=".len()..])
         } else if path.starts_with("dependency=") {
             (PathKind::Dependency, &path["dependency=".len()..])
+        } else if path.starts_with("framework=") {
+            (PathKind::Framework, &path["framework=".len()..])
         } else if path.starts_with("all=") {
             (PathKind::All, &path["all=".len()..])
         } else {

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -1041,8 +1041,11 @@ fn link_args(cmd: &mut Command,
 // in the current crate. Upstream crates with native library dependencies
 // may have their native library pulled in above.
 fn add_local_native_libraries(cmd: &mut Command, sess: &Session) {
-    sess.target_filesearch(PathKind::All).for_each_lib_search_path(|path, _| {
-        cmd.arg("-L").arg(path);
+    sess.target_filesearch(PathKind::All).for_each_lib_search_path(|path, k| {
+        match k {
+            PathKind::Framework => { cmd.arg("-F").arg(path); }
+            _ => { cmd.arg("-L").arg(path); }
+        }
         FileDoesntMatch
     });
 


### PR DESCRIPTION
On OSX the linker has a separate framework lookup path which is specified via
the `-F` flag. This adds a new kind of `-L` path recognized by the compiler for
frameworks to be passed through to the linker.

Closes #20259
