### PR TITLE
Fix for misspelled comments.

### DIFF
--- a/src/doc/trpl/ownership.md
+++ b/src/doc/trpl/ownership.md
@@ -523,7 +523,7 @@ fn print<'a>(s: &'a str); // expanded
 fn debug(lvl: u32, s: &str); // elided
 fn debug<'a>(lvl: u32, s: &'a str); // expanded
 
-// In the preceeding example, `lvl` doesn't need a lifetime because it's not a
+// In the preceding example, `lvl` doesn't need a lifetime because it's not a
 // reference (`&`). Only things relating to references (such as a `struct`
 // which contains a reference) need lifetimes.
 

--- a/src/grammar/parser-lalr.y
+++ b/src/grammar/parser-lalr.y
@@ -1195,7 +1195,7 @@ maybe_stmts
 //
 // There are also two other expr subtypes: first, nonparen_expr
 // disallows exprs surrounded by parens (including tuple expressions),
-// this is neccesary for BOX (place) expressions, so a parens expr
+// this is necessary for BOX (place) expressions, so a parens expr
 // following the BOX is always parsed as the place. There is also
 // expr_norange used in index_expr, which disallows '..' in
 // expressions as that has special meaning inside of brackets.

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -311,7 +311,7 @@ impl<T: Sync + Send> Drop for Arc<T> {
     ///
     ///     // stuff
     ///
-    ///     drop(five); // explict drop
+    ///     drop(five); // explicit drop
     /// }
     /// {
     ///     let five = Arc::new(5);
@@ -441,7 +441,7 @@ impl<T: Sync + Send> Drop for Weak<T> {
     ///
     ///     // stuff
     ///
-    ///     drop(weak_five); // explict drop
+    ///     drop(weak_five); // explicit drop
     /// }
     /// {
     ///     let five = Arc::new(5);

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -382,7 +382,7 @@ impl<T> Drop for Rc<T> {
     ///
     ///     // stuff
     ///
-    ///     drop(five); // explict drop
+    ///     drop(five); // explicit drop
     /// }
     /// {
     ///     let five = Rc::new(5);
@@ -687,7 +687,7 @@ impl<T> Drop for Weak<T> {
     ///
     ///     // stuff
     ///
-    ///     drop(weak_five); // explict drop
+    ///     drop(weak_five); // explicit drop
     /// }
     /// {
     ///     let five = Rc::new(5);

--- a/src/libcollections/btree/node.rs
+++ b/src/libcollections/btree/node.rs
@@ -669,7 +669,7 @@ impl<'a, K: 'a, V: 'a> Handle<&'a mut Node<K, V>, handle::Edge, handle::Internal
 
 impl<K, V, NodeRef: Deref<Target=Node<K, V>>> Handle<NodeRef, handle::Edge, handle::Internal> {
     // This doesn't exist because there are no uses for it,
-    // but is fine to add, analagous to edge_mut.
+    // but is fine to add, analogous to edge_mut.
     //
     // /// Returns a reference to the edge pointed-to by this handle. This should not be
     // /// confused with `node`, which references the parent node of what is returned here.

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -260,7 +260,7 @@ pub trait IteratorExt: Iterator + Sized {
     }
 
     /// Creates an iterator that applies the predicate to each element returned
-    /// by this iterator. The only elements that will be yieled are those that
+    /// by this iterator. The only elements that will be yielded are those that
     /// make the predicate evaluate to `true`.
     ///
     /// # Examples

--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -14,9 +14,9 @@ register_long_diagnostics! {
     E0001: r##"
     This error suggests that the expression arm corresponding to the noted pattern
     will never be reached as for all possible values of the expression being matched,
-    one of the preceeding patterns will match.
+    one of the preceding patterns will match.
 
-    This means that perhaps some of the preceeding patterns are too general, this
+    This means that perhaps some of the preceding patterns are too general, this
     one is too specific or the ordering is incorrect.
 "##,
 

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -775,7 +775,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                      -> bool
     {
         // In general, it's a good idea to cache results, even
-        // ambigious ones, to save us some trouble later. But we have
+        // ambiguous ones, to save us some trouble later. But we have
         // to be careful not to cache results that could be
         // invalidated later by advances in inference. Normally, this
         // is not an issue, because any inference variables whose
@@ -1273,7 +1273,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     ///
     /// - The impl is conditional, in which case we may not have winnowed it out
     ///   because we don't know if the conditions apply, but the where clause is basically
-    ///   telling us taht there is some impl, though not necessarily the one we see.
+    ///   telling us that there is some impl, though not necessarily the one we see.
     ///
     /// In both cases we prefer to take the where clause, which is
     /// essentially harmless.  See issue #18453 for more details of

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2520,7 +2520,7 @@ impl FlagComputation {
     fn add_bound_computation(&mut self, computation: &FlagComputation) {
         self.add_flags(computation.flags);
 
-        // The types that contributed to `computation` occured within
+        // The types that contributed to `computation` occurred within
         // a region binder, so subtract one from the region depth
         // within when adding the depth to `self`.
         let depth = computation.depth;

--- a/src/librustc_borrowck/borrowck/doc.rs
+++ b/src/librustc_borrowck/borrowck/doc.rs
@@ -142,7 +142,7 @@
 //! which contains an empty set of actions, still has a purpose---it
 //! prevents moves from `LV`. I chose not to make `MOVE` a fourth kind of
 //! action because that would imply that sometimes moves are permitted
-//! from restrictived values, which is not the case.
+//! from restricted values, which is not the case.
 //!
 //! #### Example
 //!

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -171,7 +171,7 @@ pub fn source_name(input: &Input) -> String {
 /// CompileController is used to customise compilation, it allows compilation to
 /// be stopped and/or to call arbitrary code at various points in compilation.
 /// It also allows for various flags to be set to influence what information gets
-/// colelcted during compilation.
+/// collected during compilation.
 ///
 /// This is a somewhat higher level controller than a Session - the Session
 /// controls what happens in each phase, whereas the CompileController controls

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -20,7 +20,7 @@ register_diagnostics! {
     E0254, // import conflicts with imported crate in this module
     E0255, // import conflicts with value in this module
     E0256, // import conflicts with type in this module
-    E0257, // inherent implementations are only allowen on types defined in the current module
+    E0257, // inherent implementations are only allowed on types defined in the current module
     E0258, // import conflicts with existing submodule
     E0259, // an extern crate has already been imported into this module
     E0260 // name conflicts with an external crate that has been imported into this module

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -365,7 +365,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         (_, "init") => {
             let tp_ty = *substs.types.get(FnSpace, 0);
             if !return_type_is_void(ccx, tp_ty) {
-                // Just zero out the stack slot. (See comment on base::memzero for explaination)
+                // Just zero out the stack slot. (See comment on base::memzero for explanation)
                 zero_mem(bcx, llresult, tp_ty);
             }
             C_nil(ccx)

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -159,11 +159,11 @@ pub fn compare_impl_method<'tcx>(tcx: &ty::ctxt<'tcx>,
     // vs 'b).  However, the normal subtyping rules on fn types handle
     // this kind of equivalency just fine.
     //
-    // We now use these subsititions to ensure that all declared bounds are
+    // We now use these substitutions to ensure that all declared bounds are
     // satisfied by the implementation's method.
     //
     // We do this by creating a parameter environment which contains a
-    // substition corresponding to impl_to_skol_substs. We then build
+    // substitution corresponding to impl_to_skol_substs. We then build
     // trait_to_skol_substs and use it to convert the predicates contained
     // in the trait_m.generics to the skolemized form.
     //

--- a/src/librustc_typeck/check/vtable.rs
+++ b/src/librustc_typeck/check/vtable.rs
@@ -288,7 +288,7 @@ pub fn select_all_fcx_obligations_and_apply_defaults(fcx: &FnCtxt) {
 pub fn select_all_fcx_obligations_or_error(fcx: &FnCtxt) {
     debug!("select_all_fcx_obligations_or_error");
 
-    // upvar inference should have ensured that all deferrred call
+    // upvar inference should have ensured that all deferred call
     // resolutions are handled by now.
     assert!(fcx.inh.deferred_call_resolutions.borrow().is_empty());
 

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -108,7 +108,7 @@ register_diagnostics! {
     E0189, // can only cast a boxed pointer to a boxed object
     E0190, // can only cast a &-pointer to an &-object
     E0191, // value of the associated type must be specified
-    E0192, // negative imples are allowed just fo `Send` and `Sync`
+    E0192, // negative imples are allowed just for `Send` and `Sync`
     E0193, // cannot bound type where clause bounds may only be attached to types
            // involving type parameters
     E0194,
@@ -119,7 +119,7 @@ register_diagnostics! {
     E0199, // implementing trait is not unsafe
     E0200, // trait requires an `unsafe impl` declaration
     E0201, // duplicate method in trait impl
-    E0202, // associated items are not allowed in inherint impls
+    E0202, // associated items are not allowed in inherent impls
     E0203, // type parameter has more than one relaxed default bound,
            // and only one is supported
     E0204, // trait `Copy` may not be implemented for this type; field

--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -313,7 +313,7 @@
 //!
 //! assert_eq!(count.get(&'s'), Some(&8));
 //!
-//! println!("Number of occurences of each character");
+//! println!("Number of occurrences of each character");
 //! for (char, count) in count.iter() {
 //!     println!("{}: {}", char, count);
 //! }

--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -337,7 +337,7 @@ pub fn temp_dir() -> Path {
 ///
 /// # Errors
 ///
-/// Acquring the path to the current executable is a platform-specific operation
+/// Acquiring the path to the current executable is a platform-specific operation
 /// that can fail for a good number of reasons. Some errors can include, but not
 /// be limited to filesystem operations failing or general syscall failures.
 ///

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -97,7 +97,7 @@ fn with_end_to_cap<F>(v: &mut Vec<u8>, f: F) -> Result<usize>
 //
 // To this end, we use an RAII guard (to protect against panics) which updates
 // the length of the string when it is dropped. This guard initially truncates
-// the string to the prior length and only afer we've validated that the
+// the string to the prior length and only after we've validated that the
 // new contents are valid UTF-8 do we allow it to set a longer length.
 //
 // The unsafety in this function is twofold:
@@ -664,7 +664,7 @@ impl<T> Take<T> {
     ///
     /// # Note
     ///
-    /// This instance may reach EOF after reading fewer bytes than indiccated by
+    /// This instance may reach EOF after reading fewer bytes than indicated by
     /// this method if the underlying `Read` instance reaches EOF.
     pub fn limit(&self) -> u64 { self.limit }
 }

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -922,7 +922,7 @@ impl PathBuf {
     ///
     /// If `self.file_name()` is `None`, does nothing and returns `false`.
     ///
-    /// Otherwise, returns `tru`; if `self.exension()` is `None`, the extension
+    /// Otherwise, returns `true`; if `self.extension()` is `None`, the extension
     /// is added; otherwise it is replaced.
     pub fn set_extension<S: ?Sized + AsOsStr>(&mut self, extension: &S) -> bool {
         if self.file_name().is_none() { return false; }
@@ -1062,7 +1062,7 @@ impl Path {
         PathBuf::new(self)
     }
 
-    /// A path is *absolute* if it is indepedent of the current directory.
+    /// A path is *absolute* if it is independent of the current directory.
     ///
     /// * On Unix, a path is absolute if it starts with the root, so
     /// `is_absolute` and `has_root` are equivalent.

--- a/src/libstd/sync/mpsc/oneshot.rs
+++ b/src/libstd/sync/mpsc/oneshot.rs
@@ -45,7 +45,7 @@ use core::mem;
 use sync::atomic::{AtomicUsize, Ordering};
 
 // Various states you can find a port in.
-const EMPTY: uint = 0;          // initial state: no data, no blocked reciever
+const EMPTY: uint = 0;          // initial state: no data, no blocked receiver
 const DATA: uint = 1;           // data ready for receiver to take
 const DISCONNECTED: uint = 2;   // channel is disconnected OR upgraded
 // Any other value represents a pointer to a SignalToken value. The

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -84,7 +84,7 @@ impl CodePoint {
 
     /// Create a new `CodePoint` from a `char`.
     ///
-    /// Since all Unicode scalar values are code points, this always succeds.
+    /// Since all Unicode scalar values are code points, this always succeeds.
     #[inline]
     pub fn from_char(value: char) -> CodePoint {
         CodePoint { value: value as u32 }

--- a/src/libstd/sys/windows/thread_local.rs
+++ b/src/libstd/sys/windows/thread_local.rs
@@ -191,7 +191,7 @@ unsafe fn unregister_dtor(key: Key) -> bool {
 // # What's up with this callback?
 //
 // The callback specified receives a number of parameters from... someone!
-// (the kernel? the runtime? I'm not qute sure!) There are a few events that
+// (the kernel? the runtime? I'm not quite sure!) There are a few events that
 // this gets invoked for, but we're currently only interested on when a
 // thread or a process "detaches" (exits). The process part happens for the
 // last thread and the thread part happens for any normal thread.

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -232,7 +232,7 @@ impl Duration {
         secs_part.checked_add(nanos_part as i64)
     }
 
-    /// Add two durations, returning `None` if overflow occured.
+    /// Add two durations, returning `None` if overflow occurred.
     #[unstable(feature = "std_misc")]
     pub fn checked_add(&self, rhs: &Duration) -> Option<Duration> {
         let mut secs = try_opt!(self.secs.checked_add(rhs.secs));
@@ -247,7 +247,7 @@ impl Duration {
         if d < MIN || d > MAX { None } else { Some(d) }
     }
 
-    /// Subtract two durations, returning `None` if overflow occured.
+    /// Subtract two durations, returning `None` if overflow occurred.
     #[unstable(feature = "std_misc")]
     pub fn checked_sub(&self, rhs: &Duration) -> Option<Duration> {
         let mut secs = try_opt!(self.secs.checked_sub(rhs.secs));

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -109,7 +109,7 @@ static KNOWN_FEATURES: &'static [(&'static str, &'static str, Status)] = &[
     // int and uint are now deprecated
     ("int_uint", "1.0.0", Active),
 
-    // macro reexport needs more discusion and stabilization
+    // macro reexport needs more discussion and stabilization
     ("macro_reexport", "1.0.0", Active),
 
     // These are used to test this portion of the compiler, they don't actually

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -560,7 +560,7 @@ fn filtered_float_lit(data: token::InternedString, suffix: Option<&str>,
 }
 pub fn float_lit(s: &str, suffix: Option<&str>, sd: &SpanHandler, sp: Span) -> ast::Lit_ {
     debug!("float_lit: {:?}, {:?}", s, suffix);
-    // FIXME #2252: bounds checking float literals is defered until trans
+    // FIXME #2252: bounds checking float literals is deferred until trans
     let s = s.chars().filter(|&c| c != '_').collect::<String>();
     let data = token::intern_and_get_ident(&*s);
     filtered_float_lit(data, suffix, sd, sp)

--- a/src/rustbook/javascript.rs
+++ b/src/rustbook/javascript.rs
@@ -43,7 +43,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
   // of each of the sections.
   // It works by extracting the current page based on the url and iterates over
   // the menu links until it finds the menu item for the current page. We then
-  // create a copy of the preceeding and following menu links and add the
+  // create a copy of the preceding and following menu links and add the
   // correct css class and insert them into the bottom of the page.
   var toc = document.getElementById('toc').getElementsByTagName('a');
   var href = document.location.pathname.split('/').pop();


### PR DESCRIPTION
The spelling corrections were made in both documentation comments and
regular comments.
