### PR TITLE
Fix for misspelled comments in tests.

### DIFF
--- a/src/test/bench/shootout-reverse-complement.rs
+++ b/src/test/bench/shootout-reverse-complement.rs
@@ -90,12 +90,12 @@ impl Tables {
         }
     }
 
-    /// Retreives the complement for `i`.
+    /// Retrieves the complement for `i`.
     fn cpl8(&self, i: u8) -> u8 {
         self.table8[i as uint]
     }
 
-    /// Retreives the complement for `i`.
+    /// Retrieves the complement for `i`.
     fn cpl16(&self, i: u16) -> u16 {
         self.table16[i as uint]
     }

--- a/src/test/compile-fail/assoc-inherent.rs
+++ b/src/test/compile-fail/assoc-inherent.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test associated types are forbidden in inherant impls.
+// Test associated types are forbidden in inherent impls.
 
 struct Foo;
 

--- a/src/test/compile-fail/issue-7364.rs
+++ b/src/test/compile-fail/issue-7364.rs
@@ -12,7 +12,7 @@
 
 use std::cell::RefCell;
 
-// Regresion test for issue 7364
+// Regression test for issue 7364
 static boxed: Box<RefCell<isize>> = box RefCell::new(0);
 //~^ ERROR statics are not allowed to have custom pointers
 //~| ERROR: the trait `core::marker::Sync` is not implemented for the type

--- a/src/test/compile-fail/issue-9243.rs
+++ b/src/test/compile-fail/issue-9243.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Regresion test for issue 9243
+// Regression test for issue 9243
 
 struct Test {
     mem: isize,

--- a/src/test/run-pass/issue-7660.rs
+++ b/src/test/run-pass/issue-7660.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Regresion test for issue 7660
+// Regression test for issue 7660
 // rvalue lifetime too short when equivalent `match` works
 
 extern crate collections;


### PR DESCRIPTION
Just spelling corrections.
