### PR TITLE
Add a lint for writing `#[feature]` for stable features, warn by default...

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -2019,6 +2019,12 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub STABLE_FEATURES,
+    Warn,
+    "stable features found in #[feature] directive"
+}
+
+declare_lint! {
     pub UNKNOWN_CRATE_TYPES,
     Deny,
     "unknown crate type found in #[crate_type] directive"
@@ -2060,6 +2066,7 @@ impl LintPass for HardwiredLints {
             UNREACHABLE_CODE,
             WARNINGS,
             UNUSED_FEATURES,
+            STABLE_FEATURES,
             UNKNOWN_CRATE_TYPES,
             VARIANT_SIZE_DIFFERENCES,
             FAT_PTR_TRANSMUTES

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -668,8 +668,8 @@ pub fn phase_3_run_analysis_passes<'tcx>(sess: Session,
         time(time_passes, "stability checking", (), |_|
              stability::check_unstable_api_usage(&ty_cx));
 
-    time(time_passes, "unused feature checking", (), |_|
-         stability::check_unused_features(
+    time(time_passes, "unused lib feature checking", (), |_|
+         stability::check_unused_or_stable_features(
              &ty_cx.sess, lib_features_used));
 
     time(time_passes, "lint checking", (), |_|

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -149,7 +149,10 @@ pub struct Features {
     pub old_orphan_check: bool,
     pub simd_ffi: bool,
     pub unmarked_api: bool,
-    pub lib_features: Vec<(InternedString, Span)>
+    /// spans of #![feature] attrs for stable language features. for error reporting
+    pub declared_stable_lang_features: Vec<Span>,
+    /// #![feature] attrs for non-language (library) features
+    pub declared_lib_features: Vec<(InternedString, Span)>
 }
 
 impl Features {
@@ -162,7 +165,8 @@ impl Features {
             old_orphan_check: false,
             simd_ffi: false,
             unmarked_api: false,
-            lib_features: Vec::new()
+            declared_stable_lang_features: Vec::new(),
+            declared_lib_features: Vec::new()
         }
     }
 }
@@ -511,6 +515,7 @@ fn check_crate_inner<F>(cm: &CodeMap, span_handler: &SpanHandler, krate: &ast::C
         cm: cm,
     };
 
+    let mut accepted_features = Vec::new();
     let mut unknown_features = Vec::new();
 
     for attr in &krate.attrs {
@@ -550,8 +555,7 @@ fn check_crate_inner<F>(cm: &CodeMap, span_handler: &SpanHandler, krate: &ast::C
                             span_handler.span_err(mi.span, "feature has been removed");
                         }
                         Some(&(_, _, Accepted)) => {
-                            span_handler.span_warn(mi.span, "feature has been added to Rust, \
-                                                             directive not necessary");
+                            accepted_features.push(mi.span);
                         }
                         None => {
                             unknown_features.push((name, mi.span));
@@ -572,7 +576,8 @@ fn check_crate_inner<F>(cm: &CodeMap, span_handler: &SpanHandler, krate: &ast::C
         old_orphan_check: cx.has_feature("old_orphan_check"),
         simd_ffi: cx.has_feature("simd_ffi"),
         unmarked_api: cx.has_feature("unmarked_api"),
-        lib_features: unknown_features
+        declared_stable_lang_features: accepted_features,
+        declared_lib_features: unknown_features
     }
 }
 

--- a/src/test/compile-fail/stable-features.rs
+++ b/src/test/compile-fail/stable-features.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(
-    foo_bar_baz,
-    foo(bar),
-    foo = "baz"
-)]
-//~^^^ ERROR: malformed feature
-//~^^^ ERROR: malformed feature
+// Testing that the stable_features lint catches use of stable
+// language and lib features.
 
-#![feature] //~ ERROR: malformed feature
-#![feature = "foo"] //~ ERROR: malformed feature
+#![deny(stable_features)]
+#![feature(test_accepted_feature)] //~ ERROR this feature is stable
+#![feature(rust1)] //~ ERROR this feature is stable
 
-#![feature(test_removed_feature)] //~ ERROR: feature has been removed
+fn main() {
+    let _foo: Vec<()> = Vec::new();
+}


### PR DESCRIPTION
....

The 'stable_features' lint helps people progress from unstable to
stable Rust by telling them when they no longer need a `feature`
attribute because upstream Rust has declared it stable.

This compares to the existing 'unstable_features' lint, which is used
to implement feature staging, and triggers on _any_ use
of `#[feature]`.
