### PR TITLE
unbreak tree for openbsd after #21787

### DIFF
--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -563,6 +563,38 @@ pub mod consts {
 }
 
 /// Constants associated with the current target
+#[cfg(target_os = "openbsd")]
+pub mod consts {
+    pub use super::arch_consts::ARCH;
+
+    pub const FAMILY: &'static str = "unix";
+
+    /// A string describing the specific operating system in use: in this
+    /// case, `dragonfly`.
+    pub const OS: &'static str = "openbsd";
+
+    /// Specifies the filename prefix used for shared libraries on this
+    /// platform: in this case, `lib`.
+    pub const DLL_PREFIX: &'static str = "lib";
+
+    /// Specifies the filename suffix used for shared libraries on this
+    /// platform: in this case, `.so`.
+    pub const DLL_SUFFIX: &'static str = ".so";
+
+    /// Specifies the file extension used for shared libraries on this
+    /// platform that goes after the dot: in this case, `so`.
+    pub const DLL_EXTENSION: &'static str = "so";
+
+    /// Specifies the filename suffix used for executable binaries on this
+    /// platform: in this case, the empty string.
+    pub const EXE_SUFFIX: &'static str = "";
+
+    /// Specifies the file extension, if any, used for executable binaries
+    /// on this platform: in this case, the empty string.
+    pub const EXE_EXTENSION: &'static str = "";
+}
+
+/// Constants associated with the current target
 #[cfg(target_os = "android")]
 pub mod consts {
     pub use super::arch_consts::ARCH;

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1289,6 +1289,8 @@ pub mod consts {
 }
 
 #[cfg(target_os = "openbsd")]
+#[deprecated(since = "1.0.0", reason = "renamed to env::consts")]
+#[unstable(feature = "os")]
 pub mod consts {
     pub use os::arch_consts::ARCH;
 

--- a/src/libstd/sys/unix/c.rs
+++ b/src/libstd/sys/unix/c.rs
@@ -74,6 +74,8 @@ pub const _SC_GETPW_R_SIZE_MAX: libc::c_int = 70;
 #[cfg(any(target_os = "macos",
           target_os = "freebsd"))]
 pub const _SC_GETPW_R_SIZE_MAX: libc::c_int = 71;
+#[cfg(target_os = "openbsd")]
+pub const _SC_GETPW_R_SIZE_MAX: libc::c_int = 101;
 #[cfg(target_os = "android")]
 pub const _SC_GETPW_R_SIZE_MAX: libc::c_int = 0x0048;
 
@@ -91,7 +93,8 @@ pub struct passwd {
 
 #[repr(C)]
 #[cfg(any(target_os = "macos",
-          target_os = "freebsd"))]
+          target_os = "freebsd",
+          target_os = "openbsd"))]
 pub struct passwd {
     pub pw_name: *mut libc::c_char,
     pub pw_passwd: *mut libc::c_char,

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -197,23 +197,23 @@ pub fn current_exe() -> IoResult<Path> {
 }
 
 #[cfg(target_os = "openbsd")]
-pub fn load_self() -> Option<Vec<u8>> {
+pub fn current_exe() -> IoResult<Path> {
     use sync::{StaticMutex, MUTEX_INIT};
 
     static LOCK: StaticMutex = MUTEX_INIT;
 
     extern {
-        fn rust_load_self() -> *const c_char;
+        fn rust_current_exe() -> *const c_char;
     }
 
     let _guard = LOCK.lock();
 
     unsafe {
-        let v = rust_load_self();
+        let v = rust_current_exe();
         if v.is_null() {
-            None
+            Err(IoError::last_error())
         } else {
-            Some(ffi::c_str_to_bytes(&v).to_vec())
+            Ok(Path::new(ffi::c_str_to_bytes(&v).to_vec()))
         }
     }
 }
@@ -333,7 +333,8 @@ pub fn args() -> Args {
 #[cfg(any(target_os = "linux",
           target_os = "android",
           target_os = "freebsd",
-          target_os = "dragonfly"))]
+          target_os = "dragonfly",
+          target_os = "openbsd"))]
 pub fn args() -> Args {
     use rt;
     let bytes = rt::args::clone().unwrap_or(Vec::new());

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -47,13 +47,9 @@ pub fn errno() -> i32 {
     }
 
     #[cfg(target_os = "openbsd")]
-    fn errno_location() -> *const c_int {
-        extern {
-            fn __errno() -> *const c_int;
-        }
-        unsafe {
-            __errno()
-        }
+    unsafe fn errno_location() -> *const c_int {
+        extern { fn __errno() -> *const c_int; }
+        __errno()
     }
 
     #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/src/rt/rust_builtin.c
+++ b/src/rt/rust_builtin.c
@@ -204,7 +204,7 @@ int *__dfly_error(void) { return __error(); }
 #include <sys/sysctl.h>
 #include <limits.h>
 
-const char * rust_load_self() {
+const char * rust_current_exe() {
     static char *self = NULL;
 
     if (self == NULL) {


### PR DESCRIPTION
- add `_SC_GETPW_R_SIZE_MAX` constant
- declare `struct passwd`
- convert `load_self` to `current_exe`

Note: OpenBSD don't provide system function to return a valuable Path
for `env::current_exe`. The implementation is currently based on the
value of `argv[0]`, which couldn't be used when executable is called via
PATH.
