### PR TITLE
Make rustdoc method HTML anchor IDs/links unique (#20700)

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2083,7 +2083,7 @@ fn render_methods(w: &mut fmt::Formatter, it: &clean::Item) -> fmt::Result {
 }
 
 fn render_impl(w: &mut fmt::Formatter, i: &Impl) -> fmt::Result {
-    let method_context: &str = "";
+    let mut method_context: &str = "";
     
     try!(write!(w, "<h3 class='impl'>{}<code>impl{} ",
                 ConciseStability(&i.stability),
@@ -2093,6 +2093,7 @@ fn render_impl(w: &mut fmt::Formatter, i: &Impl) -> fmt::Result {
                          try!(write!(w, "{} for ", *ty))},
         None => {}
     }
+    method_context = format!("{}:{}", i.impl_.for_, method_context).as_slice();
     try!(write!(w, "{}{}</code></h3>", i.impl_.for_, WhereClause(&i.impl_.generics)));
     match i.dox {
         Some(ref dox) => {


### PR DESCRIPTION
This pull request makes rustdoc's rendered method anchor IDs and links unique, so clicking on a particular method link will take you to that specific method description, and not the first similarly-named method description on the page, as is the current behavior.

The link anchors should now have a contextual prefix added to them, so each anchor is unique and refers only to the corresponding method.

This build was tested working under the most recent rust 1.0.0-nightly as of today.

Solves issue #20700.
