### PR TITLE
When elaborating predicates, purge duplicates from the initial vector.

### DIFF
--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1335,25 +1335,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 // the where clauses are in scope.
                 true
             }
-            (&ParamCandidate(ref bound1), &ParamCandidate(ref bound2)) => {
-                self.infcx.probe(|_| {
-                    let bound1 =
-                        project::normalize_with_depth(self,
-                                                      stack.obligation.cause.clone(),
-                                                      stack.obligation.recursion_depth+1,
-                                                      bound1);
-                    let bound2 =
-                        project::normalize_with_depth(self,
-                                                      stack.obligation.cause.clone(),
-                                                      stack.obligation.recursion_depth+1,
-                                                      bound2);
-                    let origin =
-                        infer::RelateOutputImplTypes(stack.obligation.cause.span);
-                    self.infcx
-                        .sub_poly_trait_refs(false, origin, bound1.value, bound2.value)
-                        .is_ok()
-                })
-            }
             _ => {
                 false
             }

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -22,6 +22,47 @@ use util::ppaux::Repr;
 use super::{Obligation, ObligationCause, PredicateObligation,
             VtableImpl, VtableParam, VtableImplData};
 
+struct PredicateSet<'a,'tcx:'a> {
+    tcx: &'a ty::ctxt<'tcx>,
+    set: FnvHashSet<ty::Predicate<'tcx>>,
+}
+
+impl<'a,'tcx> PredicateSet<'a,'tcx> {
+    fn new(tcx: &'a ty::ctxt<'tcx>) -> PredicateSet<'a,'tcx> {
+        PredicateSet { tcx: tcx, set: FnvHashSet() }
+    }
+
+    fn insert(&mut self, pred: &ty::Predicate<'tcx>) -> bool {
+        // We have to be careful here because we want
+        //
+        //    for<'a> Foo<&'a int>
+        //
+        // and
+        //
+        //    for<'b> Foo<&'b int>
+        //
+        // to be considered equivalent. So normalize all late-bound
+        // regions before we throw things into the underlying set.
+        let normalized_pred = match *pred {
+            ty::Predicate::Trait(ref data) =>
+                ty::Predicate::Trait(ty::anonymize_late_bound_regions(self.tcx, data)),
+
+            ty::Predicate::Equate(ref data) =>
+                ty::Predicate::Equate(ty::anonymize_late_bound_regions(self.tcx, data)),
+
+            ty::Predicate::RegionOutlives(ref data) =>
+                ty::Predicate::RegionOutlives(ty::anonymize_late_bound_regions(self.tcx, data)),
+
+            ty::Predicate::TypeOutlives(ref data) =>
+                ty::Predicate::TypeOutlives(ty::anonymize_late_bound_regions(self.tcx, data)),
+
+            ty::Predicate::Projection(ref data) =>
+                ty::Predicate::Projection(ty::anonymize_late_bound_regions(self.tcx, data)),
+        };
+        self.set.insert(normalized_pred)
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // `Elaboration` iterator
 ///////////////////////////////////////////////////////////////////////////
@@ -36,7 +77,7 @@ use super::{Obligation, ObligationCause, PredicateObligation,
 pub struct Elaborator<'cx, 'tcx:'cx> {
     tcx: &'cx ty::ctxt<'tcx>,
     stack: Vec<StackEntry<'tcx>>,
-    visited: FnvHashSet<ty::Predicate<'tcx>>,
+    visited: PredicateSet<'cx,'tcx>,
 }
 
 struct StackEntry<'tcx> {
@@ -68,8 +109,8 @@ pub fn elaborate_predicates<'cx, 'tcx>(
     mut predicates: Vec<ty::Predicate<'tcx>>)
     -> Elaborator<'cx, 'tcx>
 {
-    let mut visited = FnvHashSet();
-    predicates.retain(|pred| visited.insert(pred.clone()));
+    let mut visited = PredicateSet::new(tcx);
+    predicates.retain(|pred| visited.insert(pred));
     let entry = StackEntry { position: 0, predicates: predicates };
     Elaborator { tcx: tcx, stack: vec![entry], visited: visited }
 }
@@ -91,7 +132,7 @@ impl<'cx, 'tcx> Elaborator<'cx, 'tcx> {
                 // recursion in some cases.  One common case is when
                 // people define `trait Sized: Sized { }` rather than `trait
                 // Sized { }`.
-                predicates.retain(|r| self.visited.insert(r.clone()));
+                predicates.retain(|r| self.visited.insert(r));
 
                 self.stack.push(StackEntry { position: 0,
                                              predicates: predicates });

--- a/src/test/compile-fail/issue-21974.rs
+++ b/src/test/compile-fail/issue-21974.rs
@@ -1,0 +1,28 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that (for now) we report an ambiguity error here, because
+// specific trait relationships are ignored for the purposes of trait
+// matching. This behavior should likely be improved such that this
+// test passes. See #21974 for more details.
+
+trait Foo {
+    fn foo(self);
+}
+
+fn foo<'a,'b,T>(x: &'a T, y: &'b T)
+    where &'a T : Foo,
+          &'b T : Foo
+{
+    x.foo(); //~ ERROR type annotations required
+    y.foo();
+}
+
+fn main() { }

--- a/src/test/run-pass/associated-types-duplicate-binding-in-env-hrtb.rs
+++ b/src/test/run-pass/associated-types-duplicate-binding-in-env-hrtb.rs
@@ -1,0 +1,9 @@
+fn foo<T>(t: T) -> i32
+    where T : for<'a> Fn(&'a u8) -> i32,
+          T : for<'b> Fn(&'b u8) -> i32,
+{
+    t(&3)
+}
+
+fn main() {
+}

--- a/src/test/run-pass/associated-types-duplicate-binding-in-env-hrtb.rs
+++ b/src/test/run-pass/associated-types-duplicate-binding-in-env-hrtb.rs
@@ -1,3 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that we do not report ambiguities when equivalent predicates
+// (modulo bound lifetime names) appears in the environment
+// twice. Issue #21965.
+
 fn foo<T>(t: T) -> i32
     where T : for<'a> Fn(&'a u8) -> i32,
           T : for<'b> Fn(&'b u8) -> i32,

--- a/src/test/run-pass/associated-types-duplicate-binding-in-env.rs
+++ b/src/test/run-pass/associated-types-duplicate-binding-in-env.rs
@@ -1,0 +1,27 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that we do not report ambiguities when the same predicate
+// appears in the environment twice. Issue #21965.
+
+trait Foo {
+    type B;
+
+    fn get() -> Self::B;
+}
+
+fn foo<T>() -> ()
+    where T : Foo<B=()>, T : Foo<B=()>
+{
+    <T as Foo>::get()
+}
+
+fn main() {
+}


### PR DESCRIPTION
We were already building a hashset to check for duplicates, but we assumed that the initial vector had no duplicates. Fixes #21965.

r? @pnkfelix 
