### PR TITLE
Changed HashMap's internal layout. Cleanup.

### DIFF
--- a/src/libstd/collections/hash/bench.rs
+++ b/src/libstd/collections/hash/bench.rs
@@ -56,6 +56,24 @@ fn grow_by_insertion(b: &mut Bencher) {
 }
 
 #[bench]
+fn grow_by_insertion_large(b: &mut Bencher) {
+    use super::map::HashMap;
+
+    let mut m = HashMap::new();
+
+    for i in range_inclusive(1, 1000) {
+        m.insert(i, (String::new(), String::new()));
+    }
+
+    let mut k = 1001;
+
+    b.iter(|| {
+        m.insert(k, (String::new(), String::new()));
+        k += 1;
+    });
+}
+
+#[bench]
 fn find_existing(b: &mut Bencher) {
     use super::map::HashMap;
 


### PR DESCRIPTION
Changes HashMap's memory layout from `[hhhh...KKKK...VVVV...]` to `[KVKVKVKV...hhhh...]`. This makes in-place growth easy to implement (and efficient).

The removal of `find_with_or_insert_with` has made more cleanup possible.

20 benchmark runs, averaged:

```
                           before         after
bench::find_existing       40573.50 ns    41227.65 ns
bench::find_nonexisting    41815.45 ns    42362.60 ns
bench::get_remove_insert     197.85 ns      198.60 ns
bench::grow_by_insertion     171.05 ns      154.05 ns
bench::hashmap_as_queue      112.85 ns      112.65 ns
bench::new_drop               79.40 ns       79.20 ns
bench::new_insert_drop       179.40 ns      149.05 ns
```

thanks to @Gankro for the Entry interface, and to @thestinger for improving jemalloc's in-place realloc!
cc @cgaebel
r? @Gankro 
