### PR TITLE
Make the lifetime anchor immutable on std::mem::copy_mut_lifetime

### DIFF
--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -331,8 +331,9 @@ pub unsafe fn copy_lifetime<'a, S: ?Sized, T: ?Sized + 'a>(_ptr: &'a S,
 #[unstable(feature = "core",
            reason = "this function may be removed in the future due to its \
                      questionable utility")]
-pub unsafe fn copy_mut_lifetime<'a, S: ?Sized, T: ?Sized + 'a>(_ptr: &'a mut S,
-                                                            ptr: &mut T)
-                                                            -> &'a mut T {
+pub unsafe fn copy_mut_lifetime<'a, S: ?Sized, T: ?Sized + 'a>(_ptr: &'a S,
+                                                               ptr: &mut T)
+                                                              -> &'a mut T
+{
     transmute(ptr)
 }


### PR DESCRIPTION
Part of #21923
