### PR TITLE
Improve error message, when found staticlib instead crate

### DIFF
--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -419,6 +419,7 @@ impl<'a> CrateReader<'a> {
                     root: root,
                     rejected_via_hash: vec!(),
                     rejected_via_triple: vec!(),
+                    rejected_via_kind: vec!(),
                     should_match_name: true,
                 };
                 let library = load_ctxt.load_library_crate();
@@ -483,6 +484,7 @@ impl<'a> CrateReader<'a> {
             root: &None,
             rejected_via_hash: vec!(),
             rejected_via_triple: vec!(),
+            rejected_via_kind: vec!(),
             should_match_name: true,
         };
         let library = match load_ctxt.maybe_load_library_crate() {

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -257,6 +257,7 @@ pub struct Context<'a> {
     pub root: &'a Option<CratePaths>,
     pub rejected_via_hash: Vec<CrateMismatch>,
     pub rejected_via_triple: Vec<CrateMismatch>,
+    pub rejected_via_kind: Vec<CrateMismatch>,
     pub should_match_name: bool,
 }
 
@@ -311,6 +312,8 @@ impl<'a> Context<'a> {
         } else if self.rejected_via_triple.len() > 0 {
             format!("couldn't find crate `{}` with expected target triple {}",
                     self.ident, self.triple)
+        } else if self.rejected_via_kind.len() > 0 {
+            format!("found staticlib `{}` instead of rlib or dylib", self.ident)
         } else {
             format!("can't find crate for `{}`", self.ident)
         };
@@ -335,8 +338,8 @@ impl<'a> Context<'a> {
             let mismatches = self.rejected_via_hash.iter();
             for (i, &CrateMismatch{ ref path, .. }) in mismatches.enumerate() {
                 self.sess.fileline_note(self.span,
-                    &format!("crate `{}` path {}{}: {}",
-                            self.ident, "#", i+1, path.display())[]);
+                    &format!("crate `{}` path #{}: {}",
+                            self.ident, i+1, path.display())[]);
             }
             match self.root {
                 &None => {}
@@ -347,6 +350,16 @@ impl<'a> Context<'a> {
                                     r.ident, i+1, path.display())[]);
                     }
                 }
+            }
+        }
+        if self.rejected_via_kind.len() > 0 {
+            self.sess.span_help(self.span, "please recompile this crate using \
+                                            --crate-type lib");
+            let mismatches = self.rejected_via_kind.iter();
+            for (i, &CrateMismatch { ref path, .. }) in mismatches.enumerate() {
+                self.sess.fileline_note(self.span,
+                                        &format!("crate `{}` path #{}: {}",
+                                                 self.ident, i+1, path.display())[]);
             }
         }
         self.sess.abort_if_errors();
@@ -369,8 +382,10 @@ impl<'a> Context<'a> {
         // want: crate_name.dir_part() + prefix + crate_name.file_part + "-"
         let dylib_prefix = format!("{}{}", dypair.0, self.crate_name);
         let rlib_prefix = format!("lib{}", self.crate_name);
+        let staticlib_prefix = format!("lib{}", self.crate_name);
 
         let mut candidates = HashMap::new();
+        let mut staticlibs = vec!();
 
         // First, find all possible candidate rlibs and dylibs purely based on
         // the name of the files themselves. We're trying to match against an
@@ -391,7 +406,7 @@ impl<'a> Context<'a> {
                 Some(file) => file,
             };
             let (hash, rlib) = if file.starts_with(&rlib_prefix[]) &&
-                    file.ends_with(".rlib") {
+                                  file.ends_with(".rlib") {
                 (&file[(rlib_prefix.len()) .. (file.len() - ".rlib".len())],
                  true)
             } else if file.starts_with(&dylib_prefix) &&
@@ -399,6 +414,13 @@ impl<'a> Context<'a> {
                 (&file[(dylib_prefix.len()) .. (file.len() - dypair.1.len())],
                  false)
             } else {
+                if file.starts_with(&staticlib_prefix[]) &&
+                   file.ends_with(".a") {
+                    staticlibs.push(CrateMismatch {
+                        path: path.clone(),
+                        got: "static".to_string()
+                    });
+                }
                 return FileDoesntMatch
             };
             info!("lib candidate: {}", path.display());
@@ -415,6 +437,7 @@ impl<'a> Context<'a> {
 
             FileMatches
         });
+        self.rejected_via_kind.extend(staticlibs.into_iter());
 
         // We have now collected all known libraries into a set of candidates
         // keyed of the filename hash listed. For each filename, we also have a

--- a/src/test/run-make/error-found-staticlib-instead-crate/Makefile
+++ b/src/test/run-make/error-found-staticlib-instead-crate/Makefile
@@ -1,0 +1,5 @@
+-include ../tools.mk
+
+all:
+	$(RUSTC) foo.rs --crate-type staticlib
+	$(RUSTC) bar.rs 2>&1 | grep "error: found staticlib"

--- a/src/test/run-make/error-found-staticlib-instead-crate/bar.rs
+++ b/src/test/run-make/error-found-staticlib-instead-crate/bar.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate foo;
+
+fn main() {
+    foo::foo();
+}

--- a/src/test/run-make/error-found-staticlib-instead-crate/foo.rs
+++ b/src/test/run-make/error-found-staticlib-instead-crate/foo.rs
@@ -1,0 +1,11 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn foo() {}


### PR DESCRIPTION
Add special error for this case and help message `please recompile this crate using --crate-type lib`, also list found candidates.

See issue #14416

r? @alexcrichton
