### PR TITLE
improve `compiletest` error message when path option missing.

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -118,7 +118,10 @@ pub fn parse_config(args: Vec<String> ) -> Config {
     }
 
     fn opt_path(m: &getopts::Matches, nm: &str) -> Path {
-        Path::new(m.opt_str(nm).unwrap())
+        match m.opt_str(nm) {
+            Some(s) => Path::new(s),
+            None => panic!("no option (=path) found for {}", nm),
+        }
     }
 
     let filter = if !matches.free.is_empty() {


### PR DESCRIPTION
improve `compiletest` error message when path option missing.

I often run `compiletest` by hand by cut-and-pasting from what `make` runs, (which I observe via `remake --trace`), but then I need to tweak it (cut out options) and its useful to be told when I have removed an option that is actually required, such as `--android-cross-path=path`.)
