### PR TITLE
make `for PAT in ITER_EXPR { ... }` a terminating-scope for ITER_EXPR.

### DIFF
--- a/src/test/run-pass/loop-label-shadowing.rs
+++ b/src/test/run-pass/loop-label-shadowing.rs
@@ -13,7 +13,7 @@
 fn main() {
     let mut foo = Vec::new();
     'foo: for i in &[1, 2, 3] {
-        foo.push(i);
+        foo.push(*i);
     }
 }
 


### PR DESCRIPTION
make `for PAT in ITER_EXPR { ... }` a terminating-scope for ITER_EXPR.

In effect, temporary anonymous values created during the evaluation of ITER_EXPR no longer not live for the entirety of the block surrounding the for-loop; instead they only live for the extent of the for-loop itself, and no longer.

---

There is one case I know of that this breaks, demonstrated to me by @nikomatsakis  (but it is also a corner-case that is useless in practice).  Here is that case:

```
fn main() {
    let mut foo: Vec<&i8> = Vec::new();
    for i in &[1, 2, 3] { foo.push(i) }
}
```

Note that if you add any code following the for-loop above, or even a semicolon to the end of it, then the code will stop compiling (i.e., it gathers a vector of references but the gathered vector cannot actually be used.)

(The above code, despite being useless, did occur in one run-pass test by accident; that test is updated here to accommodate the new striction.)

---

So, technically this is a:

[breaking-change]
