### PR TITLE
Fix an ICE when translating some static expressions.

### DIFF
--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -241,8 +241,10 @@ pub fn const_expr<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, e: &ast::Expr)
                                         ty::ty_vec(unit_ty, Some(len)) => {
                                             let llunitty = type_of::type_of(cx, unit_ty);
                                             let llptr = ptrcast(llconst, llunitty.ptr_to());
-                                            assert!(cx.const_globals().borrow_mut()
-                                                      .insert(llptr as int, llconst).is_none());
+                                            let prev_const = cx.const_globals().borrow_mut()
+                                                             .insert(llptr as int, llconst);
+                                            assert!(prev_const.is_none() ||
+                                                    prev_const == Some(llconst));
                                             assert_eq!(abi::FAT_PTR_ADDR, 0);
                                             assert_eq!(abi::FAT_PTR_EXTRA, 1);
                                             llconst = C_struct(cx, &[

--- a/src/test/run-pass/issue-21891.rs
+++ b/src/test/run-pass/issue-21891.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+static foo: [uint; 3] = [1, 2, 3];
+
+static slice_1: &'static [uint] = &foo;
+static slice_2: &'static [uint] = &foo;
+
+fn main() {}


### PR DESCRIPTION
Creating two identical static expressions involving casts of pointers to arrays
caused an assertion failure in librustc_trans.

cc @eddyb 
