### PR TITLE
Fix name of variable referenced in featureck.py

### DIFF
--- a/src/etc/featureck.py
+++ b/src/etc/featureck.py
@@ -190,9 +190,9 @@ for name in lib_feature_stats:
         if not name in joint_features:
             print "error: feature '" + name + "' is both a lang and lib feature but not whitelisted"
             errors = True
-        lang_status = lang_feature_stats[name][3]
+        lang_status = language_feature_stats[name][3]
         lib_status = lib_feature_stats[name][3]
-        lang_stable_since = lang_feature_stats[name][4]
+        lang_stable_since = language_feature_stats[name][4]
         lib_stable_since = lib_feature_stats[name][4]
 
         if lang_status != lib_status and lib_status != "deprecated":


### PR DESCRIPTION
It seems that `lang_feature_stats` was supposed to refer to `language_feature_stats` instead.

r? @brson
