### PR TITLE
Remove duplicate syntax word from obsolete syntax messages

### DIFF
--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -63,15 +63,15 @@ impl<'a> ParserObsoleteMethods for parser::Parser<'a> {
                 "use a `move ||` expression instead",
             ),
             ObsoleteSyntax::ClosureType => (
-                "`|usize| -> bool` closure type syntax",
+                "`|usize| -> bool` closure type",
                 "use unboxed closures instead, no type annotation needed"
             ),
             ObsoleteSyntax::ClosureKind => (
-                "`:`, `&mut:`, or `&:` syntax",
+                "`:`, `&mut:`, or `&:`",
                 "rely on inference instead"
             ),
             ObsoleteSyntax::Sized => (
-                "`Sized? T` syntax for removing the `Sized` bound",
+                "`Sized? T` for removing the `Sized` bound",
                 "write `T: ?Sized` instead"
             ),
         };


### PR DESCRIPTION
The word is repeated twice in the message like:

```
error: obsolete syntax: `:`, `&mut:`, or `&:` syntax
```

This removes the word syntax that appears in messages after the second colon (:).
