### PR TITLE
No checkin: overloaded-`box` protocol changes

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -81,6 +81,7 @@ use core::nonzero::NonZero;
 use core::ops::Deref;
 use core::ptr;
 use core::hash::{Hash, Hasher};
+use boxed::Box;
 use heap::deallocate;
 
 /// An atomically reference counted wrapper for shared state.
@@ -160,7 +161,7 @@ impl<T> Arc<T> {
     pub fn new(data: T) -> Arc<T> {
         // Start the weak pointer count as 1 which is the weak pointer that's
         // held by all the strong pointers (kinda), see std/rc.rs for more info
-        let x = box ArcInner {
+        let x : Box<_> = box ArcInner {
             strong: atomic::AtomicUsize::new(1),
             weak: atomic::AtomicUsize::new(1),
             data: data,

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -58,7 +58,7 @@ use core::iter::Iterator;
 use core::marker::{Copy, Sized};
 use core::mem;
 use core::ops::{Deref, DerefMut, Drop};
-use core::ops::{Placer, Boxed, Place, InPlace};
+use core::ops::{Placer, Boxed, Place, InPlace, BoxPlace};
 use core::option::Option;
 use core::ptr::PtrExt;
 use core::ptr::Unique;
@@ -148,6 +148,10 @@ fn make_place<T>() -> IntermediateBox<T> {
     };
 
     IntermediateBox { ptr: p, size: size, align: align }
+}
+
+impl<T> BoxPlace<T> for IntermediateBox<T> {
+    fn make_place() -> IntermediateBox<T> { make_place() }
 }
 
 impl<T> InPlace<T> for IntermediateBox<T> {

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -91,8 +91,13 @@ pub mod heap;
 
 // Primitive types using the heaps above
 
+// Need to conditionally define the mod from `boxed.rs` to avoid
+// duplicating the lang-items when building in test cfg; but also need
+// to allow code to have `use boxed::HEAP;` declaration.
 #[cfg(not(test))]
 pub mod boxed;
+#[cfg(test)]
+mod boxed { pub use std::boxed::HEAP; }
 #[cfg(test)]
 mod boxed_test;
 pub mod arc;
@@ -127,5 +132,7 @@ pub fn fixme_14344_be_sure_to_link_to_collections() {}
 #[doc(hidden)]
 mod std {
     pub use core::fmt;
+    pub use core::ops;
     pub use core::option;
+    pub use core::ptr;
 }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -161,6 +161,7 @@ use core::ptr::{self, PtrExt};
 use core::result::Result;
 use core::result::Result::{Ok, Err};
 
+use boxed::HEAP;
 use heap::deallocate;
 
 struct RcBox<T> {
@@ -202,7 +203,10 @@ impl<T> Rc<T> {
                 // there is an implicit weak pointer owned by all the strong pointers, which
                 // ensures that the weak destructor never frees the allocation while the strong
                 // destructor is running, even if the weak pointer is stored inside the strong one.
-                _ptr: NonZero::new(transmute(box RcBox {
+                //
+                // SNAP 9006c3c
+                // Change `box (HEAP)` to `in (HEAP)` after snapshot.
+                _ptr: NonZero::new(transmute(box (HEAP) RcBox {
                     value: value,
                     strong: Cell::new(1),
                     weak: Cell::new(1)

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -106,6 +106,8 @@ mod std {
     pub use core::cmp;      // derive(Eq, Ord, etc.)
     pub use core::marker;  // derive(Copy)
     pub use core::hash;     // derive(Hash)
+    pub use core::ops;      // necessary for box <expr>
+    pub use core::ptr;      // necessary for box <expr>
 }
 
 #[cfg(test)]

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -514,7 +514,7 @@ impl<T> PartialOrd for *mut T {
 /// Useful for building abstractions like `Vec<T>` or `Box<T>`, which
 /// internally use raw pointers to manage the memory that they own.
 #[unstable = "recently added to this module"]
-pub struct Unique<T>(pub *mut T);
+pub struct Unique<T: ?Sized>(pub *mut T);
 
 /// `Unique` pointers are `Send` if `T` is `Send` because the data they
 /// reference is unaliased. Note that this aliasing invariant is

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -171,7 +171,7 @@ impl LintStore {
         macro_rules! add_builtin {
             ($sess:ident, $($name:ident),*,) => (
                 {$(
-                    self.register_pass($sess, false, box builtin::$name as LintPassObject);
+                    self.register_pass($sess, false, Box::new(builtin::$name) as LintPassObject);
                 )*}
             )
         }
@@ -179,7 +179,7 @@ impl LintStore {
         macro_rules! add_builtin_with_new {
             ($sess:ident, $($name:ident),*,) => (
                 {$(
-                    self.register_pass($sess, false, box builtin::$name::new() as LintPassObject);
+                    self.register_pass($sess, false, Box::new(builtin::$name::new()) as LintPassObject);
                 )*}
             )
         }
@@ -231,7 +231,7 @@ impl LintStore {
                         UNUSED_UNSAFE, PATH_STATEMENTS);
 
         // We have one lint pass defined in this module.
-        self.register_pass(sess, false, box GatherNodeLevels as LintPassObject);
+        self.register_pass(sess, false, Box::new(GatherNodeLevels) as LintPassObject);
 
         // Insert temporary renamings for a one-time deprecation
         self.register_renamed("raw_pointer_deriving", "raw_pointer_derive");

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -132,7 +132,7 @@ fn lookup_variant_by_id<'a>(tcx: &'a ty::ctxt,
             None => {}
         }
         let expr_id = match csearch::maybe_get_item_ast(tcx, enum_def,
-            box |a, b, c, d| astencode::decode_inlined_item(a, b, c, d)) {
+            Box::new( |a, b, c, d| astencode::decode_inlined_item(a, b, c, d))) {
             csearch::found(&ast::IIItem(ref item)) => match item.node {
                 ast::ItemEnum(ast::EnumDef { ref variants }, _) => {
                     // NOTE this doesn't do the right thing, it compares inlined
@@ -172,7 +172,7 @@ pub fn lookup_const_by_id<'a>(tcx: &'a ty::ctxt, def_id: ast::DefId)
             None => {}
         }
         let expr_id = match csearch::maybe_get_item_ast(tcx, def_id,
-            box |a, b, c, d| astencode::decode_inlined_item(a, b, c, d)) {
+            Box::new( |a, b, c, d| astencode::decode_inlined_item(a, b, c, d))) {
             csearch::found(&ast::IIItem(ref item)) => match item.node {
                 ast::ItemConst(_, ref const_expr) => Some(const_expr.id),
                 _ => None

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -457,7 +457,7 @@ impl<'a, 'tcx, O:DataFlowOperator+Clone+'static> DataFlowContext<'a, 'tcx, O> {
 
         debug!("Dataflow result for {}:", self.analysis_name);
         debug!("{}", {
-            self.pretty_print_to(box io::stderr(), blk).unwrap();
+            self.pretty_print_to(Box::new(io::stderr()), blk).unwrap();
             ""
         });
     }

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -621,6 +621,11 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                     None => {}
                 }
                 self.consume_expr(&**base);
+                if place.is_some() {
+                    self.tcx().sess.span_bug(
+                        expr.span,
+                        "box with explicit place remains after expansion");
+                }
             }
 
             ast::ExprMac(..) => {

--- a/src/librustc/plugin/registry.rs
+++ b/src/librustc/plugin/registry.rs
@@ -96,7 +96,7 @@ impl<'a> Registry<'a> {
     /// It builds for you a `NormalTT` that calls `expander`,
     /// and also takes care of interning the macro's name.
     pub fn register_macro(&mut self, name: &str, expander: MacroExpanderFn) {
-        self.register_syntax_extension(token::intern(name), NormalTT(box expander, None));
+        self.register_syntax_extension(token::intern(name), NormalTT(Box::new(expander), None));
     }
 
     /// Register a compiler lint pass.

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -213,7 +213,7 @@ impl<'a> PhaseController<'a> {
     pub fn basic() -> PhaseController<'a> {
         PhaseController {
             stop: false,
-            callback: box |&: _| {},
+            callback: Box::new(|&: _| {}),
         }
     }
 }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -224,13 +224,13 @@ fn build_controller<'a>(sess: &Session) -> CompileController<'a> {
     }
 
     if sess.opts.debugging_opts.save_analysis {
-        control.after_analysis.callback = box |state| {
+        control.after_analysis.callback = Box::new(|state| {
             time(state.session.time_passes(), "save analysis", state.krate.unwrap(), |krate|
                  save::process_crate(state.session,
                                      krate,
                                      state.analysis.unwrap(),
                                      state.out_dir));
-        };
+        });
         control.make_glob_map = resolve::MakeGlobMap::Yes;
     }
 
@@ -614,7 +614,7 @@ pub fn monitor<F:FnOnce()+Send>(f: F) {
         cfg = cfg.stack_size(STACK_SIZE);
     }
 
-    match cfg.scoped(move || { std::io::stdio::set_stderr(box w); f() }).join() {
+    match cfg.scoped(move || { std::io::stdio::set_stderr(Box::new(w)); f() }).join() {
         Ok(()) => { /* fallthrough */ }
         Err(value) => {
             // Thread panicked without emitting a fatal diagnostic
@@ -656,7 +656,7 @@ pub fn monitor<F:FnOnce()+Send>(f: F) {
             // Panic so the process returns a failure code, but don't pollute the
             // output with some unnecessary panic messages, we've already
             // printed everything that we needed to.
-            io::stdio::set_stderr(box io::util::NullWriter);
+            io::stdio::set_stderr(Box::new(io::util::NullWriter));
             panic!();
         }
     }

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -548,11 +548,11 @@ pub fn pretty_print_input(sess: Session,
     let mut rdr = MemReader::new(src);
 
     let out = match ofile {
-        None => box io::stdout() as Box<Writer+'static>,
+        None => Box::new(io::stdout()) as Box<Writer+'static>,
         Some(p) => {
             let r = io::File::create(&p);
             match r {
-                Ok(w) => box w as Box<Writer+'static>,
+                Ok(w) => Box::new(w) as Box<Writer+'static>,
                 Err(e) => panic!("print-print failed to open {} due to {}",
                                 p.display(), e),
             }

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -246,12 +246,12 @@ impl AttrBuilder {
     }
 
     pub fn arg<'a, T: AttrHelper + 'static>(&'a mut self, idx: uint, a: T) -> &'a mut AttrBuilder {
-        self.attrs.push((idx, box a as Box<AttrHelper+'static>));
+        self.attrs.push((idx, Box::new(a) as Box<AttrHelper+'static>));
         self
     }
 
     pub fn ret<'a, T: AttrHelper + 'static>(&'a mut self, a: T) -> &'a mut AttrBuilder {
-        self.attrs.push((ReturnIndex as uint, box a as Box<AttrHelper+'static>));
+        self.attrs.push((ReturnIndex as uint, Box::new(a) as Box<AttrHelper+'static>));
         self
     }
 

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -911,7 +911,7 @@ fn run_work_multithreaded(sess: &Session,
         futures.push(rx);
 
         thread::Builder::new().name(format!("codegen-{}", i)).spawn(move |:| {
-            let diag_handler = mk_handler(box diag_emitter);
+            let diag_handler = mk_handler(Box::new(diag_emitter));
 
             // Must construct cgcx inside the proc because it has non-Send
             // fields.

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -1548,7 +1548,7 @@ pub fn process_crate(sess: &Session,
     out_name.push_str(".csv");
     root_path.push(out_name);
     let output_file = match File::create(&root_path) {
-        Ok(f) => box f,
+        Ok(f) => Box::new(f),
         Err(e) => {
             let disp = root_path.display();
             sess.fatal(&format!("Could not open {}: {}", disp, e)[]);

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2962,7 +2962,7 @@ pub fn write_metadata(cx: &SharedCrateContext, krate: &ast::Crate) -> Vec<u8> {
     }
 
     let encode_inlined_item: encoder::EncodeInlinedItem =
-        box |ecx, rbml_w, ii| astencode::encode_inlined_item(ecx, rbml_w, ii);
+        Box::new( |ecx, rbml_w, ii| astencode::encode_inlined_item(ecx, rbml_w, ii));
 
     let encode_parms = crate_ctxt_to_encode_parms(cx, encode_inlined_item);
     let metadata = encoder::encode_metadata(encode_parms, krate);

--- a/src/librustc_trans/trans/cleanup.rs
+++ b/src/librustc_trans/trans/cleanup.rs
@@ -262,9 +262,9 @@ impl<'blk, 'tcx> CleanupMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx> {
     fn schedule_lifetime_end(&self,
                              cleanup_scope: ScopeId,
                              val: ValueRef) {
-        let drop = box LifetimeEnd {
+        let drop = Box::new(LifetimeEnd {
             ptr: val,
-        };
+        });
 
         debug!("schedule_lifetime_end({:?}, val={})",
                cleanup_scope,
@@ -279,13 +279,13 @@ impl<'blk, 'tcx> CleanupMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx> {
                          val: ValueRef,
                          ty: Ty<'tcx>) {
         if !common::type_needs_drop(self.ccx.tcx(), ty) { return; }
-        let drop = box DropValue {
+        let drop = Box::new(DropValue {
             is_immediate: false,
             must_unwind: common::type_needs_unwind_cleanup(self.ccx, ty),
             val: val,
             ty: ty,
             zero: false
-        };
+        });
 
         debug!("schedule_drop_mem({:?}, val={}, ty={})",
                cleanup_scope,
@@ -301,13 +301,13 @@ impl<'blk, 'tcx> CleanupMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx> {
                                   val: ValueRef,
                                   ty: Ty<'tcx>) {
         if !common::type_needs_drop(self.ccx.tcx(), ty) { return; }
-        let drop = box DropValue {
+        let drop = Box::new(DropValue {
             is_immediate: false,
             must_unwind: common::type_needs_unwind_cleanup(self.ccx, ty),
             val: val,
             ty: ty,
             zero: true
-        };
+        });
 
         debug!("schedule_drop_and_zero_mem({:?}, val={}, ty={}, zero={})",
                cleanup_scope,
@@ -325,13 +325,13 @@ impl<'blk, 'tcx> CleanupMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx> {
                                ty: Ty<'tcx>) {
 
         if !common::type_needs_drop(self.ccx.tcx(), ty) { return; }
-        let drop = box DropValue {
+        let drop = Box::new(DropValue {
             is_immediate: true,
             must_unwind: common::type_needs_unwind_cleanup(self.ccx, ty),
             val: val,
             ty: ty,
             zero: false
-        };
+        });
 
         debug!("schedule_drop_immediate({:?}, val={}, ty={:?})",
                cleanup_scope,
@@ -347,7 +347,7 @@ impl<'blk, 'tcx> CleanupMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx> {
                            val: ValueRef,
                            heap: Heap,
                            content_ty: Ty<'tcx>) {
-        let drop = box FreeValue { ptr: val, heap: heap, content_ty: content_ty };
+        let drop = Box::new(FreeValue { ptr: val, heap: heap, content_ty: content_ty });
 
         debug!("schedule_free_value({:?}, val={}, heap={:?})",
                cleanup_scope,
@@ -364,7 +364,7 @@ impl<'blk, 'tcx> CleanupMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx> {
                            size: ValueRef,
                            align: ValueRef,
                            heap: Heap) {
-        let drop = box FreeSlice { ptr: val, size: size, align: align, heap: heap };
+        let drop = Box::new(FreeSlice { ptr: val, size: size, align: align, heap: heap });
 
         debug!("schedule_free_slice({:?}, val={}, heap={:?})",
                cleanup_scope,

--- a/src/librustc_trans/trans/inline.rs
+++ b/src/librustc_trans/trans/inline.rs
@@ -40,7 +40,7 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
     let csearch_result =
         csearch::maybe_get_item_ast(
             ccx.tcx(), fn_id,
-            box |a,b,c,d| astencode::decode_inlined_item(a, b, c, d));
+            Box::new( |a,b,c,d| astencode::decode_inlined_item(a, b, c, d)));
 
     let inline_def = match csearch_result {
         csearch::not_found => {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -147,7 +147,7 @@ fn runtest(test: &str, cratename: &str, libs: SearchPaths,
     let (tx, rx) = channel();
     let w1 = io::ChanWriter::new(tx);
     let w2 = w1.clone();
-    let old = io::stdio::set_stderr(box w1);
+    let old = io::stdio::set_stderr(Box::new(w1));
     Thread::spawn(move |:| {
         let mut p = io::ChanReader::new(rx);
         let mut err = match old {
@@ -156,15 +156,15 @@ fn runtest(test: &str, cratename: &str, libs: SearchPaths,
                 let old: Box<Writer> = old;
                 old
             }
-            None => box io::stderr() as Box<Writer>,
+            None => Box::new(io::stderr()) as Box<Writer>,
         };
         io::util::copy(&mut p, &mut err).unwrap();
     });
-    let emitter = diagnostic::EmitterWriter::new(box w2, None);
+    let emitter = diagnostic::EmitterWriter::new(Box::new(w2), None);
 
     // Compile the code
     let codemap = CodeMap::new();
-    let diagnostic_handler = diagnostic::mk_handler(box emitter);
+    let diagnostic_handler = diagnostic::mk_handler(Box::new(emitter));
     let span_diagnostic_handler =
         diagnostic::mk_span_handler(diagnostic_handler, codemap);
 

--- a/src/libstd/io/net/ip.rs
+++ b/src/libstd/io/net/ip.rs
@@ -325,7 +325,7 @@ impl<'a> Parser<'a> {
     fn read_ip_addr(&mut self) -> Option<IpAddr> {
         let ipv4_addr = |&mut: p: &mut Parser| p.read_ipv4_addr();
         let ipv6_addr = |&mut: p: &mut Parser| p.read_ipv6_addr();
-        self.read_or(&mut [box ipv4_addr, box ipv6_addr])
+        self.read_or(&mut [Box::new(ipv4_addr), Box::new(ipv6_addr)])
     }
 
     fn read_socket_addr(&mut self) -> Option<SocketAddr> {
@@ -338,7 +338,7 @@ impl<'a> Parser<'a> {
                 p.read_seq_3::<char, IpAddr, char, _, _, _>(open_br, ip_addr, clos_br)
                         .map(|t| match t { (_, ip, _) => ip })
             };
-            p.read_or(&mut [box ipv4_p, box ipv6_p])
+            p.read_or(&mut [Box::new(ipv4_p), Box::new(ipv6_p)])
         };
         let colon = |&: p: &mut Parser| p.read_given_char(':');
         let port  = |&: p: &mut Parser| p.read_number(10, 5, 0x10000).map(|n| n as u16);

--- a/src/libstd/io/timer.rs
+++ b/src/libstd/io/timer.rs
@@ -15,6 +15,7 @@
 
 // FIXME: These functions take Durations but only pass ms to the backend impls.
 
+use boxed::{HEAP};
 use sync::mpsc::{Receiver, Sender, channel};
 use time::Duration;
 use io::IoResult;
@@ -143,7 +144,7 @@ impl Timer {
         let (tx, rx) = channel();
         // Short-circuit the timer backend for 0 duration
         if in_ms_u64(duration) != 0 {
-            self.inner.oneshot(in_ms_u64(duration), box TimerCallback { tx: tx });
+            self.inner.oneshot(in_ms_u64(duration), box (HEAP) TimerCallback { tx: tx });
         } else {
             tx.send(()).unwrap();
         }
@@ -204,7 +205,7 @@ impl Timer {
         // not clear what use a 0ms period is anyway...
         let ms = if ms == 0 { 1 } else { ms };
         let (tx, rx) = channel();
-        self.inner.period(ms, box TimerCallback { tx: tx });
+        self.inner.period(ms, box (HEAP) TimerCallback { tx: tx });
         return rx
     }
 }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -292,6 +292,7 @@ mod std {
     pub use thread_local; // used for thread_local!
     pub use marker;  // used for tls!
     pub use ops; // used for bitflags!
+    pub use ptr; // necessary for box <expr>
 
     // The test runner calls ::std::os::args() but really wants realstd
     #[cfg(test)] pub use realstd::os as os;

--- a/src/libstd/sync/mpsc/mpsc_queue.rs
+++ b/src/libstd/sync/mpsc/mpsc_queue.rs
@@ -44,7 +44,7 @@ pub use self::PopResult::*;
 
 use core::prelude::*;
 
-use alloc::boxed::Box;
+use alloc::boxed::{Box, HEAP};
 use core::mem;
 use core::ptr;
 use core::cell::UnsafeCell;
@@ -82,7 +82,9 @@ unsafe impl<T:Send> Sync for Queue<T> { }
 
 impl<T> Node<T> {
     unsafe fn new(v: Option<T>) -> *mut Node<T> {
-        mem::transmute(box Node {
+        // SNAP 9006c3c
+        // Change `box (HEAP)` to `in (HEAP) ..` after snapshot.
+        mem::transmute(box (HEAP) Node {
             next: AtomicPtr::new(ptr::null_mut()),
             value: v,
         })
@@ -161,12 +163,13 @@ mod tests {
     use super::{Queue, Data, Empty, Inconsistent};
     use sync::Arc;
     use thread::Thread;
+    use alloc::boxed::{HEAP};
 
     #[test]
     fn test_full() {
         let q = Queue::new();
-        q.push(box 1i);
-        q.push(box 2i);
+        q.push(box (HEAP) 1i);
+        q.push(box (HEAP) 2i);
     }
 
     #[test]

--- a/src/libstd/sync/mpsc/spsc_queue.rs
+++ b/src/libstd/sync/mpsc/spsc_queue.rs
@@ -37,7 +37,7 @@
 
 use core::prelude::*;
 
-use alloc::boxed::Box;
+use alloc::boxed::{Box, HEAP};
 use core::mem;
 use core::ptr;
 use core::cell::UnsafeCell;
@@ -81,7 +81,9 @@ unsafe impl<T: Send> Sync for Queue<T> { }
 impl<T: Send> Node<T> {
     fn new() -> *mut Node<T> {
         unsafe {
-            mem::transmute(box Node {
+            // SNAP 9006c3c
+            // Change `box (HEAP)` to `in (HEAP) ..` after snapshot.
+            mem::transmute(box (HEAP) Node {
                 value: None,
                 next: AtomicPtr::new(ptr::null_mut::<Node<T>>()),
             })
@@ -244,6 +246,7 @@ impl<T: Send> Drop for Queue<T> {
 mod test {
     use prelude::v1::*;
 
+    use alloc::boxed::{HEAP};
     use sync::Arc;
     use super::Queue;
     use thread::Thread;
@@ -290,8 +293,8 @@ mod test {
     fn drop_full() {
         unsafe {
             let q = Queue::new(0);
-            q.push(box 1i);
-            q.push(box 2i);
+            q.push(box (HEAP) 1i);
+            q.push(box (HEAP) 2i);
         }
     }
 

--- a/src/libstd/sys/common/helper_thread.rs
+++ b/src/libstd/sys/common/helper_thread.rs
@@ -22,6 +22,7 @@
 
 use prelude::v1::*;
 
+use boxed::{HEAP};
 use cell::UnsafeCell;
 use mem;
 use ptr;
@@ -88,7 +89,9 @@ impl<M: Send> Helper<M> {
             let _guard = self.lock.lock().unwrap();
             if !*self.initialized.get() {
                 let (tx, rx) = channel();
-                *self.chan.get() = mem::transmute(box tx);
+                // SNAP 9006c3c
+                // Change `box (HEAP)` to `in (HEAP) ..` after snapshot.
+                *self.chan.get() = mem::transmute(box (HEAP) tx);
                 let (receive, send) = helper_signal::new();
                 *self.signal.get() = send as uint;
 

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -10,7 +10,7 @@
 
 use core::prelude::*;
 
-use boxed::Box;
+use boxed::{Box, HEAP};
 use cmp;
 use mem;
 use ptr;
@@ -194,7 +194,9 @@ pub unsafe fn create(stack: uint, p: Thunk) -> rust_thread {
         },
     };
 
-    let arg: *mut libc::c_void = mem::transmute(box p); // must box since sizeof(p)=2*uint
+    // SNAP 9006c3c
+    // Change `box (HEAP)` to `in (HEAP)` after snapshot.
+    let arg: *mut libc::c_void = mem::transmute(box (HEAP) p); // must box since sizeof(p)=2*uint
     let ret = pthread_create(&mut native, &attr, thread_start, arg);
     assert_eq!(pthread_attr_destroy(&mut attr), 0);
 

--- a/src/libstd/thunk.rs
+++ b/src/libstd/thunk.rs
@@ -31,8 +31,9 @@ impl<A,R> Thunk<A,R> {
     pub fn with_arg<F>(func: F) -> Thunk<A,R>
         where F : FnOnce(A) -> R, F : Send
     {
+        let func: Box<_> = box func;
         Thunk {
-            invoke: box func
+            invoke: func
         }
     }
 

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -219,7 +219,7 @@ pub fn mk_span_handler(handler: Handler, cm: codemap::CodeMap) -> SpanHandler {
 
 pub fn default_handler(color_config: ColorConfig,
                        registry: Option<diagnostics::registry::Registry>) -> Handler {
-    mk_handler(box EmitterWriter::stderr(color_config, registry))
+    mk_handler(Box::new(EmitterWriter::stderr(color_config, registry)))
 }
 
 pub fn mk_handler(e: Box<Emitter + Send>) -> Handler {
@@ -347,11 +347,11 @@ impl EmitterWriter {
         if use_color {
             let dst = match term::stderr() {
                 Some(t) => Terminal(t),
-                None    => Raw(box stderr),
+                None    => Raw(Box::new(stderr)),
             };
             EmitterWriter { dst: dst, registry: registry }
         } else {
-            EmitterWriter { dst: Raw(box stderr), registry: registry }
+            EmitterWriter { dst: Raw(Box::new(stderr)), registry: registry }
         }
     }
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -265,7 +265,7 @@ pub struct MacExpr {
 }
 impl MacExpr {
     pub fn new(e: P<ast::Expr>) -> Box<MacResult+'static> {
-        box MacExpr { e: e } as Box<MacResult+'static>
+        Box::new(MacExpr { e: e }) as Box<MacResult+'static>
     }
 }
 impl MacResult for MacExpr {
@@ -289,7 +289,7 @@ pub struct MacPat {
 }
 impl MacPat {
     pub fn new(p: P<ast::Pat>) -> Box<MacResult+'static> {
-        box MacPat { p: p } as Box<MacResult+'static>
+        Box::new(MacPat { p: p }) as Box<MacResult+'static>
     }
 }
 impl MacResult for MacPat {
@@ -304,7 +304,7 @@ pub struct MacItems {
 
 impl MacItems {
     pub fn new<I: Iterator<Item=P<ast::Item>>>(it: I) -> Box<MacResult+'static> {
-        box MacItems { items: it.collect() } as Box<MacResult+'static>
+        Box::new(MacItems { items: it.collect() }) as Box<MacResult+'static>
     }
 }
 
@@ -328,7 +328,7 @@ impl DummyResult {
     /// Use this as a return value after hitting any errors and
     /// calling `span_err`.
     pub fn any(sp: Span) -> Box<MacResult+'static> {
-        box DummyResult { expr_only: false, span: sp } as Box<MacResult+'static>
+        Box::new(DummyResult { expr_only: false, span: sp }) as Box<MacResult+'static>
     }
 
     /// Create a default MacResult that can only be an expression.
@@ -337,7 +337,7 @@ impl DummyResult {
     /// if an error is encountered internally, the user will receive
     /// an error that they also used it in the wrong place.
     pub fn expr(sp: Span) -> Box<MacResult+'static> {
-        box DummyResult { expr_only: true, span: sp } as Box<MacResult+'static>
+        Box::new(DummyResult { expr_only: true, span: sp }) as Box<MacResult+'static>
     }
 
     /// A plain dummy expression.
@@ -442,7 +442,7 @@ impl BlockInfo {
 fn initial_syntax_expander_table(ecfg: &expand::ExpansionConfig) -> SyntaxEnv {
     // utility function to simplify creating NormalTT syntax extensions
     fn builtin_normal_expander(f: MacroExpanderFn) -> SyntaxExtension {
-        NormalTT(box f, None)
+        NormalTT(Box::new(f), None)
     }
 
     let mut syntax_expanders = SyntaxEnv::new();
@@ -466,9 +466,9 @@ fn initial_syntax_expander_table(ecfg: &expand::ExpansionConfig) -> SyntaxEnv {
                             builtin_normal_expander(
                                     ext::log_syntax::expand_syntax_ext));
     syntax_expanders.insert(intern("derive"),
-                            Decorator(box ext::deriving::expand_meta_derive));
+                            Decorator(Box::new(ext::deriving::expand_meta_derive)));
     syntax_expanders.insert(intern("deriving"),
-                            Decorator(box ext::deriving::expand_deprecated_deriving));
+                            Decorator(Box::new(ext::deriving::expand_deprecated_deriving)));
 
     if ecfg.enable_quotes {
         // Quasi-quoting expanders
@@ -529,7 +529,7 @@ fn initial_syntax_expander_table(ecfg: &expand::ExpansionConfig) -> SyntaxEnv {
                             builtin_normal_expander(
                                     ext::cfg::expand_cfg));
     syntax_expanders.insert(intern("cfg_attr"),
-                            Modifier(box ext::cfg_attr::expand));
+                            Modifier(Box::new(ext::cfg_attr::expand)));
     syntax_expanders.insert(intern("trace_macros"),
                             builtin_normal_expander(
                                     ext::trace_macros::expand_trace_macros));

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -40,9 +40,9 @@ pub fn expand_deriving_clone<F>(cx: &mut ExtCtxt,
                 args: Vec::new(),
                 ret_ty: Self,
                 attributes: attrs,
-                combine_substructure: combine_substructure(box |c, s, sub| {
+                combine_substructure: combine_substructure(Box::new( |c, s, sub| {
                     cs_clone("Clone", c, s, sub)
-                }),
+                })),
             }
         )
     };

--- a/src/libsyntax/ext/deriving/cmp/eq.rs
+++ b/src/libsyntax/ext/deriving/cmp/eq.rs
@@ -40,7 +40,7 @@ pub fn expand_deriving_eq<F>(cx: &mut ExtCtxt,
                 cx.expr_binary(span, ast::BiAnd, subexpr, eq)
             },
             cx.expr_bool(span, true),
-            box |cx, span, _, _| cx.expr_bool(span, false),
+            Box::new( |cx, span, _, _| cx.expr_bool(span, false)),
             cx, span, substr)
     }
     fn cs_ne(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
@@ -57,7 +57,7 @@ pub fn expand_deriving_eq<F>(cx: &mut ExtCtxt,
                 cx.expr_binary(span, ast::BiOr, subexpr, eq)
             },
             cx.expr_bool(span, false),
-            box |cx, span, _, _| cx.expr_bool(span, true),
+            Box::new( |cx, span, _, _| cx.expr_bool(span, true)),
             cx, span, substr)
     }
 
@@ -72,9 +72,9 @@ pub fn expand_deriving_eq<F>(cx: &mut ExtCtxt,
                 args: vec!(borrowed_self()),
                 ret_ty: Literal(Path::new(vec!("bool"))),
                 attributes: attrs,
-                combine_substructure: combine_substructure(box |a, b, c| {
+                combine_substructure: combine_substructure(Box::new( |a, b, c| {
                     $f(a, b, c)
-                })
+                }))
             }
         } }
     }

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -38,9 +38,9 @@ pub fn expand_deriving_ord<F>(cx: &mut ExtCtxt,
                 args: vec!(borrowed_self()),
                 ret_ty: Literal(Path::new(vec!("bool"))),
                 attributes: attrs,
-                combine_substructure: combine_substructure(box |cx, span, substr| {
+                combine_substructure: combine_substructure(Box::new( |cx, span, substr| {
                     cs_op($op, $equal, cx, span, substr)
-                })
+                }))
             }
         } }
     }
@@ -48,7 +48,7 @@ pub fn expand_deriving_ord<F>(cx: &mut ExtCtxt,
     let ordering_ty = Literal(Path::new(vec!["std", "cmp", "Ordering"]));
     let ret_ty = Literal(Path::new_(vec!["std", "option", "Option"],
                                     None,
-                                    vec![box ordering_ty],
+                                    vec![Box::new(ordering_ty)],
                                     true));
 
     let inline = cx.meta_word(span, InternedString::new("inline"));
@@ -61,9 +61,9 @@ pub fn expand_deriving_ord<F>(cx: &mut ExtCtxt,
         args: vec![borrowed_self()],
         ret_ty: ret_ty,
         attributes: attrs,
-        combine_substructure: combine_substructure(box |cx, span, substr| {
+        combine_substructure: combine_substructure(Box::new( |cx, span, substr| {
             cs_partial_cmp(cx, span, substr)
-        })
+        }))
     };
 
     let trait_def = TraitDef {
@@ -174,13 +174,13 @@ pub fn cs_partial_cmp(cx: &mut ExtCtxt, span: Span,
             cx.expr_block(cx.block(span, vec!(assign), Some(if_)))
         },
         equals_expr.clone(),
-        box |cx, span, (self_args, tag_tuple), _non_self_args| {
+        Box::new( |cx, span, (self_args, tag_tuple), _non_self_args| {
             if self_args.len() != 2 {
                 cx.span_bug(span, "not exactly 2 arguments in `derive(PartialOrd)`")
             } else {
                 some_ordering_collapsed(cx, span, PartialCmpOp, tag_tuple)
             }
-        },
+        }),
         cx, span, substr)
 }
 
@@ -222,7 +222,7 @@ fn cs_op(less: bool, equal: bool, cx: &mut ExtCtxt,
             cx.expr_binary(span, ast::BiOr, cmp, and)
         },
         cx.expr_bool(span, equal),
-        box |cx, span, (self_args, tag_tuple), _non_self_args| {
+        Box::new( |cx, span, (self_args, tag_tuple), _non_self_args| {
             if self_args.len() != 2 {
                 cx.span_bug(span, "not exactly 2 arguments in `derive(PartialOrd)`")
             } else {
@@ -232,6 +232,6 @@ fn cs_op(less: bool, equal: bool, cx: &mut ExtCtxt,
                 };
                 some_ordering_collapsed(cx, span, op, tag_tuple)
             }
-        },
+        }),
         cx, span, substr)
 }

--- a/src/libsyntax/ext/deriving/cmp/totaleq.rs
+++ b/src/libsyntax/ext/deriving/cmp/totaleq.rs
@@ -32,7 +32,7 @@ pub fn expand_deriving_totaleq<F>(cx: &mut ExtCtxt,
             let block = cx.block(span, stmts, None);
             cx.expr_block(block)
         },
-                       box |cx, sp, _, _| cx.span_bug(sp, "non matching enums in derive(Eq)?"),
+                       Box::new( |cx, sp, _, _| cx.span_bug(sp, "non matching enums in derive(Eq)?")),
                        cx,
                        span,
                        substr)
@@ -57,9 +57,9 @@ pub fn expand_deriving_totaleq<F>(cx: &mut ExtCtxt,
                 args: vec!(),
                 ret_ty: nil_ty(),
                 attributes: attrs,
-                combine_substructure: combine_substructure(box |a, b, c| {
+                combine_substructure: combine_substructure(Box::new( |a, b, c| {
                     cs_total_eq_assert(a, b, c)
-                })
+                }))
             }
         )
     };

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -41,9 +41,9 @@ pub fn expand_deriving_totalord<F>(cx: &mut ExtCtxt,
                 args: vec!(borrowed_self()),
                 ret_ty: Literal(Path::new(vec!("std", "cmp", "Ordering"))),
                 attributes: attrs,
-                combine_substructure: combine_substructure(box |a, b, c| {
+                combine_substructure: combine_substructure(Box::new( |a, b, c| {
                     cs_cmp(a, b, c)
-                }),
+                })),
             }
         )
     };
@@ -130,12 +130,12 @@ pub fn cs_cmp(cx: &mut ExtCtxt, span: Span,
             cx.expr_block(cx.block(span, vec!(assign), Some(if_)))
         },
         cx.expr_path(equals_path.clone()),
-        box |cx, span, (self_args, tag_tuple), _non_self_args| {
+        Box::new( |cx, span, (self_args, tag_tuple), _non_self_args| {
             if self_args.len() != 2 {
                 cx.span_bug(span, "not exactly 2 arguments in `derives(Ord)`")
             } else {
                 ordering_collapsed(cx, span, tag_tuple)
             }
-        },
+        }),
         cx, span, substr)
 }

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -76,9 +76,9 @@ fn expand_deriving_decodable_imp<F>(cx: &mut ExtCtxt,
                     true
                 )),
                 attributes: Vec::new(),
-                combine_substructure: combine_substructure(box |a, b, c| {
+                combine_substructure: combine_substructure(Box::new( |a, b, c| {
                     decodable_substructure(a, b, c, krate)
-                }),
+                })),
             })
     };
 

--- a/src/libsyntax/ext/deriving/default.rs
+++ b/src/libsyntax/ext/deriving/default.rs
@@ -40,9 +40,9 @@ pub fn expand_deriving_default<F>(cx: &mut ExtCtxt,
                 args: Vec::new(),
                 ret_ty: Self,
                 attributes: attrs,
-                combine_substructure: combine_substructure(box |a, b, c| {
+                combine_substructure: combine_substructure(Box::new( |a, b, c| {
                     default_substructure(a, b, c)
-                })
+                }))
             })
     };
     trait_def.expand(cx, mitem, item, push)

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -152,9 +152,9 @@ fn expand_deriving_encodable_imp<F>(cx: &mut ExtCtxt,
                     true
                 )),
                 attributes: Vec::new(),
-                combine_substructure: combine_substructure(box |a, b, c| {
+                combine_substructure: combine_substructure(Box::new( |a, b, c| {
                     encodable_substructure(a, b, c)
-                }),
+                })),
             })
     };
 

--- a/src/libsyntax/ext/deriving/hash.rs
+++ b/src/libsyntax/ext/deriving/hash.rs
@@ -50,9 +50,9 @@ pub fn expand_deriving_hash<F>(cx: &mut ExtCtxt,
                 args: vec!(Ptr(box Literal(args), Borrowed(None, MutMutable))),
                 ret_ty: nil_ty(),
                 attributes: attrs,
-                combine_substructure: combine_substructure(box |a, b, c| {
+                combine_substructure: combine_substructure(Box::new( |a, b, c| {
                     hash_substructure(a, b, c)
-                })
+                }))
             }
         )
     };

--- a/src/libsyntax/ext/deriving/primitive.rs
+++ b/src/libsyntax/ext/deriving/primitive.rs
@@ -46,9 +46,9 @@ pub fn expand_deriving_from_primitive<F>(cx: &mut ExtCtxt,
                                            true)),
                 // #[inline] liable to cause code-bloat
                 attributes: attrs.clone(),
-                combine_substructure: combine_substructure(box |c, s, sub| {
+                combine_substructure: combine_substructure(Box::new( |c, s, sub| {
                     cs_from("i64", c, s, sub)
-                }),
+                })),
             },
             MethodDef {
                 name: "from_u64",
@@ -62,9 +62,9 @@ pub fn expand_deriving_from_primitive<F>(cx: &mut ExtCtxt,
                                            true)),
                 // #[inline] liable to cause code-bloat
                 attributes: attrs,
-                combine_substructure: combine_substructure(box |c, s, sub| {
+                combine_substructure: combine_substructure(Box::new( |c, s, sub| {
                     cs_from("u64", c, s, sub)
-                }),
+                })),
             })
     };
 

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -45,9 +45,9 @@ pub fn expand_deriving_rand<F>(cx: &mut ExtCtxt,
                 ),
                 ret_ty: Self,
                 attributes: Vec::new(),
-                combine_substructure: combine_substructure(box |a, b, c| {
+                combine_substructure: combine_substructure(Box::new( |a, b, c| {
                     rand_substructure(a, b, c)
-                })
+                }))
             }
         )
     };

--- a/src/libsyntax/ext/deriving/show.rs
+++ b/src/libsyntax/ext/deriving/show.rs
@@ -46,9 +46,9 @@ pub fn expand_deriving_show<F>(cx: &mut ExtCtxt,
                 args: vec!(fmtr),
                 ret_ty: Literal(Path::new(vec!("std", "fmt", "Result"))),
                 attributes: Vec::new(),
-                combine_substructure: combine_substructure(box |a, b, c| {
+                combine_substructure: combine_substructure(Box::new( |a, b, c| {
                     show_substructure(a, b, c)
-                })
+                }))
             }
         )
     };

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1212,7 +1212,7 @@ fn expand_annotatable(a: Annotatable,
                     // but that double-mut-borrows fld
                     let mut items: SmallVector<P<ast::Item>> = SmallVector::zero();
                     dec.expand(fld.cx, attr.span, &*attr.node.value, &**it,
-                               box |&mut: item| items.push(item));
+                               Box::new( |&mut: item| items.push(item)));
                     decorator_items.extend(items.into_iter()
                         .flat_map(|item| expand_item(item, fld).into_iter()));
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -57,6 +57,7 @@ pub fn expand_type(t: P<ast::Ty>,
 }
 
 pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
+    let expr_span = e.span;
     e.and_then(|ast::Expr {id, node, span}| match node {
 
         // expr_mac should really be expr_ext or something; it's the
@@ -83,48 +84,31 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
             })
         }
 
-        // FIXME (pnkfelix): The code below is designed to handle
-        // *both* `box <value>` and `box (<place>) <value>`, but for
-        // now the desugaring will only apply to the latter.
-        //
-        // The motivation is mostly to make it easier to land without
-        // having to update many tests that are not expecting to deal
-        // with the desugared form in terms of (1.) error messages and
-        // (2.) the dependencies on `::std::ops::placer`.
-        //
-        // To re-enable the more general code paths, just change the
-        // `Some(place)` in this binding to `maybe_place`, and revise
-        // the `let maybe_place = ...` to call `fld.fold_expr(place)`
-        // directly.
-
-        // Desugar ExprBox: `box (<place_expr>) <value_expr>`
-        ast::ExprBox(Some(place), value_expr) => {
-            let value_span = value_expr.span;
-            let place_span = place.span;
-
-            let maybe_place : Option<P<ast::Expr>> = Some(fld.fold_expr(place));
-            let value_expr = fld.fold_expr(value_expr);
-
-            // Desugar `box (<place_expr>) <value_expr>` to something
-            // analogous to:
+        // Desugar ExprBox: `in (PLACE) EXPR`
+        ast::ExprBox(Some(placer), value_expr) => {
+            // to:
             //
-            // {
-            //     let place /* : impl Placer */ = <place_expr>;
-            //     let agent = place.make_place();
-            //     let raw_place = agent.pointer();
-            //     let value = <value_expr>
-            //     unsafe {
-            //         ptr::write(raw_place, value);
-            //         agent.finalize()
-            //     }
+            // let p = PLACE;
+            // let mut place = Placer::make_place(p);
+            // let raw_place = InPlace::pointer(&mut place);
+            // let value = EXPR;
+            // unsafe {
+            //     std::ptr::write(raw_place, value);
+            //     InPlace::finalize(place)
             // }
 
-            let place_ident = token::gensym_ident("place");
-            let agent_ident = token::gensym_ident("agent");
+            let value_span = value_expr.span;
+            let placer_span = placer.span;
+
+            let placer_expr = fld.fold_expr(placer);
+            let value_expr = fld.fold_expr(value_expr);
+
+            let placer_ident = token::gensym_ident("placer");
+            let agent_ident = token::gensym_ident("place");
             let value_ident = token::gensym_ident("value");
             let p_ptr_ident = token::gensym_ident("p_ptr");
 
-            let place = fld.cx.expr_ident(span, place_ident);
+            let placer = fld.cx.expr_ident(span, placer_ident);
             let agent = fld.cx.expr_ident(span, agent_ident);
             let value = fld.cx.expr_ident(span, value_ident);
             let p_ptr = fld.cx.expr_ident(span, p_ptr_ident);
@@ -143,77 +127,55 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
                 }
             }
 
-            // NOTE: clients using `box <expr>` short-hand need to
-            // either use `libstd` or must make their own local
-            //
-            // ```
-            // mod std { mod boxed { pub use ... as HEAP; }
-            //           mod ops { mod placer { ... } }
-            //           mod ptr { pub use ... as write; } }
-            // ```
-            //
-            // as appropriate.
-
-            let boxed_heap = |:| -> ast::Path {
-                let idents = ["std", "boxed", "HEAP"];
-                mk_path_for_idents(place_span, &idents[])
-            };
-
             let placer_make_place = |:| -> ast::Path {
                 let idents = ["std", "ops", "Placer", "make_place"];
-                mk_path_for_idents(place_span, &idents[])
+                mk_path_for_idents(placer_span, &idents[])
             };
 
-            let placer_pointer = |:| -> ast::Path {
-                let idents = ["std", "ops", "PlacementAgent", "pointer"];
-                mk_path_for_idents(place_span, &idents[])
+            let place_pointer = |:| -> ast::Path {
+                let idents = ["std", "ops", "Place", "pointer"];
+                mk_path_for_idents(placer_span, &idents[])
             };
 
-            let placer_finalize = |:| -> ast::Path {
-                let idents = ["std", "ops", "PlacementAgent", "finalize"];
-                mk_path_for_idents(place_span, &idents[])
+            let place_finalize = |:| -> ast::Path {
+                let idents = ["std", "ops", "InPlace", "finalize"];
+                mk_path_for_idents(placer_span, &idents[])
             };
 
             let ptr_write = |:| -> ast::Path {
                 let idents = ["std", "ptr", "write"];
-                mk_path_for_idents(place_span, &idents[])
+                mk_path_for_idents(placer_span, &idents[])
             };
 
             let make_call = |&: f: ast::Path, args: Vec<P<ast::Expr>>| -> P<ast::Expr> {
                 fld.cx.expr_call(span, fld.cx.expr_path(f), args)
             };
 
-            let stmt_let = |&: span, bind, expr| fld.cx.stmt_let(span, false, bind, expr);
-            let stmt_let_mut = |: span, bind, expr| fld.cx.stmt_let(span, true, bind, expr);
+            let stmt_let = |&: bind, expr| fld.cx.stmt_let(placer_span, false, bind, expr);
+            let stmt_let_mut = |: bind, expr| fld.cx.stmt_let(placer_span, true, bind, expr);
 
             fld.cx.expr_block(fld.cx.block_all(
                 span,
                 vec![
-                    // let place = <place_expr> ; // default of ::std::boxed::HEAP
-                    stmt_let(place_span,
-                             place_ident,
-                             match maybe_place {
-                                 Some(place_expr) => place_expr,
-                                 None => fld.cx.expr_path(boxed_heap()),
-                             }),
+                    // let placer = <placer_expr> ;
+                    stmt_let(placer_ident, placer_expr),
 
-                    // let mut agent = Placer::make_place(place);
-                    stmt_let_mut(place_span, agent_ident,
-                                 make_call(placer_make_place(), vec![place])),
+                    // let mut place = Placer::make_place(placer);
+                    stmt_let_mut(agent_ident,
+                                 make_call(placer_make_place(), vec![placer])),
 
-                    // let p_ptr = PlacementAgent::pointer(&mut agent);
-                    stmt_let(place_span,
-                             p_ptr_ident,
-                             make_call(placer_pointer(),
-                                       vec![fld.cx.expr_mut_addr_of(place_span,
+                    // let p_ptr = Place::pointer(&mut place);
+                    stmt_let(p_ptr_ident,
+                             make_call(place_pointer(),
+                                       vec![fld.cx.expr_mut_addr_of(placer_span,
                                                                     agent.clone())])),
 
                     // let value = <value_expr>;
-                    stmt_let(value_span, value_ident, value_expr)
+                    fld.cx.stmt_let(value_span, false, value_ident, value_expr)
 
                     ],
 
-                // unsafe { ptr::write(p_ptr, value); PlacementAgent::finalize(agent) }
+                // unsafe { ptr::write(p_ptr, value); InPlace::finalize(place) }
                 {
                     let call_ptr_write =
                         StmtSemi(make_call(ptr_write(), vec![p_ptr, value]),
@@ -223,7 +185,108 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
 
                     Some(fld.cx.expr_block(P(ast::Block {
                         stmts: vec![P(call_ptr_write)],
-                        expr: Some(make_call(placer_finalize(), vec![agent])),
+                        expr: Some(make_call(place_finalize(), vec![agent])),
+                        id: ast::DUMMY_NODE_ID,
+                        rules: ast::UnsafeBlock(ast::CompilerGenerated),
+                        span: span,
+                    })))
+                }))
+        }
+
+        // Desugar ExprBox: `box EXPR`
+        ast::ExprBox(None, value_expr) => {
+            // to:
+            //
+            // let mut place = BoxPlace::make_place();
+            // let raw_place = Place::pointer(&mut place);
+            // let value = $value;
+            // unsafe {
+            //     ::std::ptr::write(raw_place, value);
+            //     Boxed::finalize(place)
+            // }
+
+            let value_span = value_expr.span;
+
+            let value_expr = fld.fold_expr(value_expr);
+
+            let agent_ident = token::gensym_ident("place");
+            let value_ident = token::gensym_ident("value");
+            let p_ptr_ident = token::gensym_ident("p_ptr");
+
+            let agent = fld.cx.expr_ident(span, agent_ident);
+            let value = fld.cx.expr_ident(span, value_ident);
+            let p_ptr = fld.cx.expr_ident(span, p_ptr_ident);
+
+            fn mk_path_for_idents(span: Span,
+                                  idents: &[&'static str]) -> ast::Path {
+                let segments : Vec<ast::PathSegment> =
+                    idents.iter().map(|s| {
+                        ast::PathSegment {
+                            identifier: token::str_to_ident(*s),
+                            parameters: ast::PathParameters::none(),
+                        }
+                    }).collect();
+                ast::Path {
+                    span: span, global: true, segments: segments,
+                }
+            }
+
+            let make_place = |:| -> ast::Path {
+                let idents = ["std", "ops", "BoxPlace", "make_place"];
+                mk_path_for_idents(expr_span, &idents[])
+            };
+
+            let place_pointer = |:| -> ast::Path {
+                let idents = ["std", "ops", "Place", "pointer"];
+                mk_path_for_idents(expr_span, &idents[])
+            };
+
+            let boxed_finalize = |:| -> ast::Path {
+                let idents = ["std", "ops", "Boxed", "finalize"];
+                mk_path_for_idents(expr_span, &idents[])
+            };
+
+            let ptr_write = |:| -> ast::Path {
+                let idents = ["std", "ptr", "write"];
+                mk_path_for_idents(expr_span, &idents[])
+            };
+
+            let make_call = |&: f: ast::Path, args: Vec<P<ast::Expr>>| -> P<ast::Expr> {
+                fld.cx.expr_call(span, fld.cx.expr_path(f), args)
+            };
+
+            let stmt_let = |&: bind, expr| fld.cx.stmt_let(expr_span, false, bind, expr);
+            let stmt_let_mut = |: bind, expr| fld.cx.stmt_let(expr_span, true, bind, expr);
+
+            fld.cx.expr_block(fld.cx.block_all(
+                span,
+                vec![
+                    // let mut place = BoxPlace::make_place();
+                    stmt_let_mut(agent_ident, make_call(make_place(), vec![])),
+
+                    // let p_ptr = Place::pointer(&mut place);
+                    stmt_let(
+                        p_ptr_ident, make_call(
+                            place_pointer(),
+                            vec![fld.cx.expr_mut_addr_of(expr_span,
+                                                         agent.clone())])),
+
+                    // let value = <value_expr>;
+                    fld.cx.stmt_let(value_span, false, value_ident, value_expr)
+
+                    ],
+
+                // unsafe { ptr::write(p_ptr, value); Boxed::finalize(place) }
+                {
+                    let call_ptr_write =
+                        StmtSemi(make_call(ptr_write(), vec![p_ptr, value]),
+                                 ast::DUMMY_NODE_ID);
+                    let call_ptr_write =
+                        codemap::respan(value_span, call_ptr_write);
+
+                    Some(fld.cx.expr_block(P(ast::Block {
+                        stmts: vec![P(call_ptr_write)],
+                        expr: Some(make_call(boxed_finalize(), vec![agent])),
                         id: ast::DUMMY_NODE_ID,
                         rules: ast::UnsafeBlock(ast::CompilerGenerated),
                         span: span,

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -121,7 +121,7 @@ pub fn expand_include<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree
         }
     }
 
-    box ExpandResult { p: p }
+    Box::new(ExpandResult { p: p })
 }
 
 // include_str! : read the given file, insert it as a literal string expr

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -479,7 +479,7 @@ pub fn parse(sess: &ParseSess,
                 }
                 rdr.next_token();
             } else /* bb_eis.len() == 1 */ {
-                let mut rust_parser = Parser::new(sess, cfg.clone(), box rdr.clone());
+                let mut rust_parser = Parser::new(sess, cfg.clone(), Box::new(rdr.clone()));
 
                 let mut ei = bb_eis.pop().unwrap();
                 match ei.top_elts.get_tt(ei.idx) {

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -181,13 +181,13 @@ fn generic_extension<'cx>(cx: &'cx ExtCtxt,
                                            Some(named_matches),
                                            imported_from,
                                            rhs);
-                let mut p = Parser::new(cx.parse_sess(), cx.cfg(), box trncbr);
+                let mut p = Parser::new(cx.parse_sess(), cx.cfg(), Box::new(trncbr));
                 p.check_unknown_macro_variable();
                 // Let the context choose how to interpret the result.
                 // Weird, but useful for X-macros.
-                return box ParserAnyMacro {
+                return Box::new(ParserAnyMacro {
                     parser: RefCell::new(p),
-                } as Box<MacResult+'cx>
+                }) as Box<MacResult+'cx>
               }
               Failure(sp, ref msg) => if sp.lo >= best_fail_spot.lo {
                 best_fail_spot = sp;
@@ -268,12 +268,12 @@ pub fn compile<'cx>(cx: &'cx mut ExtCtxt,
         _ => cx.span_bug(def.span, "wrong-structured rhs")
     };
 
-    let exp = box MacroRulesMacroExpander {
+    let exp = Box::new(MacroRulesMacroExpander {
         name: def.ident,
         imported_from: def.imported_from,
         lhses: lhses,
         rhses: rhses,
-    };
+    });
 
     NormalTT(exp, Some(def.span))
 }

--- a/src/libsyntax/owned_slice.rs
+++ b/src/libsyntax/owned_slice.rs
@@ -30,7 +30,7 @@ impl<T:fmt::Debug> fmt::Debug for OwnedSlice<T> {
 
 impl<T> OwnedSlice<T> {
     pub fn empty() -> OwnedSlice<T> {
-        OwnedSlice  { data: box [] }
+        OwnedSlice  { data: Box::new([]) }
     }
 
     #[inline(never)]

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -286,7 +286,7 @@ pub fn filemap_to_tts(sess: &ParseSess, filemap: Rc<FileMap>)
     // parsing tt's probably shouldn't require a parser at all.
     let cfg = Vec::new();
     let srdr = lexer::StringReader::new(&sess.span_diagnostic, filemap);
-    let mut p1 = Parser::new(sess, cfg, box srdr);
+    let mut p1 = Parser::new(sess, cfg, Box::new(srdr));
     p1.parse_all_token_trees()
 }
 
@@ -295,7 +295,7 @@ pub fn tts_to_parser<'a>(sess: &'a ParseSess,
                          tts: Vec<ast::TokenTree>,
                          cfg: ast::CrateConfig) -> Parser<'a> {
     let trdr = lexer::new_tt_reader(&sess.span_diagnostic, None, None, tts);
-    let mut p = Parser::new(sess, cfg, box trdr);
+    let mut p = Parser::new(sess, cfg, Box::new(trdr));
     p.check_unknown_macro_variable();
     p
 }
@@ -358,7 +358,7 @@ pub mod with_hygiene {
         use super::lexer::make_reader_with_embedded_idents as make_reader;
         let cfg = Vec::new();
         let srdr = make_reader(&sess.span_diagnostic, filemap);
-        let mut p1 = Parser::new(sess, cfg, box srdr);
+        let mut p1 = Parser::new(sess, cfg, Box::new(srdr));
         p1.parse_all_token_trees()
     }
 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -56,7 +56,7 @@ use ast::{TupleVariantKind, Ty, Ty_, TypeBinding};
 use ast::{TyFixedLengthVec, TyBareFn};
 use ast::{TyTypeof, TyInfer, TypeMethod};
 use ast::{TyParam, TyParamBound, TyParen, TyPath, TyPolyTraitRef, TyPtr, TyQPath};
-use ast::{TyRptr, TyTup, TyU32, TyVec, UnUniq};
+use ast::{TyRptr, TyTup, TyU32, TyVec};
 use ast::{TypeImplItem, TypeTraitItem, Typedef, ClosureKind};
 use ast::{UnnamedField, UnsafeBlock};
 use ast::{ViewPath, ViewPathGlob, ViewPathList, ViewPathSimple};
@@ -2801,12 +2801,14 @@ impl<'a> Parser<'a> {
                 self.abort_if_errors();
               }
               if !is_in {
-                let box_span = mk_sp(lo, self.last_span.hi);
-                self.span_warn(
-                    box_span,
-                    "deprecated syntax; use the `in` keyword now \
-                           (e.g. change `box (<expr>) <expr>` to \
-                                        `in (<expr>) <expr>`)");
+                // SNAP 9006c3c
+                // Enable this warning after snapshot
+                // let box_span = mk_sp(lo, self.last_span.hi);
+                // self.span_warn(
+                //     box_span,
+                //     "deprecated syntax; use the `in` keyword now \
+                //            (e.g. change `box (<expr>) <expr>` to \
+                //                         `in (<expr>) <expr>`)");
               }
               let subexpression = self.parse_prefix_expr();
               hi = subexpression.span.hi;
@@ -2816,10 +2818,7 @@ impl<'a> Parser<'a> {
                 // Otherwise, we use the unique pointer default.
                 let subexpression = self.parse_prefix_expr();
                 hi = subexpression.span.hi;
-                // FIXME (pnkfelix): After working out kinks with box
-                // desugaring, should be `ExprBox(None, subexpression)`
-                // instead.
-                ex = self.mk_unary(UnUniq, subexpression);
+                ex = ExprBox(None, subexpression);
             }
           }
           _ => return self.parse_dot_or_call_expr()

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -169,7 +169,7 @@ pub fn to_string<F>(f: F) -> String where
     F: FnOnce(&mut State) -> IoResult<()>,
 {
     use std::raw::TraitObject;
-    let mut s = rust_printer(box Vec::new());
+    let mut s = rust_printer(Box::new(Vec::new()));
     f(&mut s).unwrap();
     eof(&mut s.s).unwrap();
     let wr = unsafe {

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -61,6 +61,7 @@ pub use terminfo::TerminfoTerminal;
 #[cfg(windows)]
 pub use win::WinConsole;
 
+use std::boxed::HEAP;
 use std::io::IoResult;
 
 pub mod terminfo;
@@ -91,7 +92,7 @@ impl Writer for WriterWrapper {
 /// opened.
 pub fn stdout() -> Option<Box<Terminal<WriterWrapper> + Send>> {
     TerminfoTerminal::new(WriterWrapper {
-        wrapped: box std::io::stdout() as Box<Writer + Send>,
+        wrapped: box (HEAP) std::io::stdout() as Box<Writer + Send>,
     })
 }
 
@@ -100,14 +101,14 @@ pub fn stdout() -> Option<Box<Terminal<WriterWrapper> + Send>> {
 /// opened.
 pub fn stdout() -> Option<Box<Terminal<WriterWrapper> + Send>> {
     let ti = TerminfoTerminal::new(WriterWrapper {
-        wrapped: box std::io::stdout() as Box<Writer + Send>,
+        wrapped: box (HEAP) std::io::stdout() as Box<Writer + Send>,
     });
 
     match ti {
         Some(t) => Some(t),
         None => {
             WinConsole::new(WriterWrapper {
-                wrapped: box std::io::stdout() as Box<Writer + Send>,
+                wrapped: box (HEAP) std::io::stdout() as Box<Writer + Send>,
             })
         }
     }
@@ -118,7 +119,7 @@ pub fn stdout() -> Option<Box<Terminal<WriterWrapper> + Send>> {
 /// opened.
 pub fn stderr() -> Option<Box<Terminal<WriterWrapper> + Send>> {
     TerminfoTerminal::new(WriterWrapper {
-        wrapped: box std::io::stderr() as Box<Writer + Send>,
+        wrapped: box (HEAP) std::io::stderr() as Box<Writer + Send>,
     })
 }
 
@@ -127,14 +128,14 @@ pub fn stderr() -> Option<Box<Terminal<WriterWrapper> + Send>> {
 /// opened.
 pub fn stderr() -> Option<Box<Terminal<WriterWrapper> + Send>> {
     let ti = TerminfoTerminal::new(WriterWrapper {
-        wrapped: box std::io::stderr() as Box<Writer + Send>,
+        wrapped: box (HEAP) std::io::stderr() as Box<Writer + Send>,
     });
 
     match ti {
         Some(t) => Some(t),
         None => {
             WinConsole::new(WriterWrapper {
-                wrapped: box std::io::stderr() as Box<Writer + Send>,
+                wrapped: box (HEAP) std::io::stderr() as Box<Writer + Send>,
             })
         }
     }

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -10,6 +10,7 @@
 
 //! Terminfo database interface.
 
+use std::boxed::HEAP;
 use std::collections::HashMap;
 use std::io::IoResult;
 use std::os;
@@ -186,7 +187,7 @@ impl<T: Writer+Send> TerminfoTerminal<T> {
                     "mintty.exe" == s
                 }) {
                 // msys terminal
-                return Some(box TerminfoTerminal {out: out,
+                return Some(box (HEAP) TerminfoTerminal {out: out,
                                                   ti: msys_terminfo(),
                                                   num_colors: 8} as Box<Terminal<T>+Send>);
             }
@@ -207,7 +208,7 @@ impl<T: Writer+Send> TerminfoTerminal<T> {
                      inf.numbers.get("colors").map_or(0, |&n| n)
                  } else { 0 };
 
-        return Some(box TerminfoTerminal {out: out,
+        return Some(box (HEAP) TerminfoTerminal {out: out,
                                           ti: inf,
                                           num_colors: nc} as Box<Terminal<T>+Send>);
     }

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -886,8 +886,8 @@ pub fn run_test(opts: &TestOpts,
             if nocapture {
                 drop((stdout, stderr));
             } else {
-                cfg = cfg.stdout(box stdout as Box<Writer + Send>);
-                cfg = cfg.stderr(box stderr as Box<Writer + Send>);
+                cfg = cfg.stdout(Box::new(stdout) as Box<Writer + Send>);
+                cfg = cfg.stderr(Box::new(stderr) as Box<Writer + Send>);
             }
 
             let result_guard = cfg.scoped(move || { testfn.invoke(()) });

--- a/src/rustbook/build.rs
+++ b/src/rustbook/build.rs
@@ -28,7 +28,7 @@ struct Build;
 
 pub fn parse_cmd(name: &str) -> Option<Box<Subcommand>> {
     if name == "build" {
-        Some(box Build as Box<Subcommand>)
+        Some(Box::new(Build) as Box<Subcommand>)
     } else {
         None
     }
@@ -134,7 +134,7 @@ fn render(book: &Book, tgt: &Path) -> CliResult<()> {
         if output_result != 0 {
             let message = format!("Could not execute `rustdoc` with {:?}: {}",
                                   rustdoc_args, output_result);
-            return Err(box message as Box<Error>);
+            return Err(Box::new(message) as Box<Error>);
         }
     }
 
@@ -181,7 +181,7 @@ impl Subcommand for Build {
                     term.err(&format!("error: {}", err)[]);
                 }
 
-                Err(box format!("{} errors occurred", n) as Box<Error>)
+                Err(Box::new(format!("{} errors occurred", n)) as Box<Error>)
             }
         }
     }

--- a/src/rustbook/error.rs
+++ b/src/rustbook/error.rs
@@ -40,7 +40,7 @@ impl Show for Box<Error + 'static> {
 
 impl<E: Error + 'static> FromError<E> for Box<Error + 'static> {
     fn from_err(err: E) -> Box<Error + 'static> {
-        box err as Box<Error>
+        Box::new(err) as Box<Error>
     }
 }
 

--- a/src/rustbook/help.rs
+++ b/src/rustbook/help.rs
@@ -19,7 +19,7 @@ struct Help;
 
 pub fn parse_cmd(name: &str) -> Option<Box<Subcommand>> {
     match name {
-        "help" | "--help" | "-h" | "-?" => Some(box Help as Box<Subcommand>),
+        "help" | "--help" | "-h" | "-?" => Some(Box::new(Help) as Box<Subcommand>),
         _ => None
     }
 }

--- a/src/rustbook/serve.rs
+++ b/src/rustbook/serve.rs
@@ -19,7 +19,7 @@ struct Serve;
 
 pub fn parse_cmd(name: &str) -> Option<Box<Subcommand>> {
     if name == "serve" {
-        Some(box Serve as Box<Subcommand>)
+        Some(Box::new(Serve) as Box<Subcommand>)
     } else {
         None
     }

--- a/src/rustbook/term.rs
+++ b/src/rustbook/term.rs
@@ -21,7 +21,7 @@ pub struct Term {
 impl Term {
     pub fn new() -> Term {
         Term {
-            err: box stdio::stderr() as Box<Writer>,
+            err: Box::new(stdio::stderr()) as Box<Writer>,
         }
     }
 

--- a/src/rustbook/test.rs
+++ b/src/rustbook/test.rs
@@ -23,7 +23,7 @@ struct Test;
 
 pub fn parse_cmd(name: &str) -> Option<Box<Subcommand>> {
     if name == "test" {
-        Some(box Test as Box<Subcommand>)
+        Some(Box::new(Test) as Box<Subcommand>)
     } else {
         None
     }
@@ -52,13 +52,13 @@ impl Subcommand for Test {
                                 term.err(&format!("{}\n{}",
                                          String::from_utf8_lossy(&output.output[]),
                                          String::from_utf8_lossy(&output.error[]))[]);
-                                return Err(box "Some tests failed." as Box<Error>);
+                                return Err(Box::new("Some tests failed.") as Box<Error>);
                             }
 
                         }
                         Err(e) => {
                             let message = format!("Could not execute `rustdoc`: {}", e);
-                            return Err(box message as Box<Error>);
+                            return Err(Box::new(message) as Box<Error>);
                         }
                     }
                 }
@@ -67,7 +67,7 @@ impl Subcommand for Test {
                 for err in errors.into_iter() {
                     term.err(&err[]);
                 }
-                return Err(box "There was an error." as Box<Error>);
+                return Err(Box::new("There was an error.") as Box<Error>);
             }
         }
         Ok(()) // lol


### PR DESCRIPTION
This is a bootstrapping illustration of the new box prototype.  The main point is to illustrate the fallout that occurs with the compiler type inference as it stands today.

(Notably, we do not infer `Box<_>` for `box <expr>` in the context of `(box <expr> as Box<Trait>)`, and this weakness is a cause of a lot of the fallout below.)

pnkfelix is trying to see if he can revise `vtable::check_object_cast` to remove the above limitation, which would let us revert a lot of the fallout below.

---

see also https://github.com/rust-lang/rfcs/pull/809 (which is not merged as of this writing).
