### PR TITLE
Make bottom type fallback lazy

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1338,23 +1338,19 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     /// Apply "fallbacks" to some types
-    /// ! gets replaced with (), unconstrained ints with i32, and unconstrained floats with f64.
+    /// Unconstrained ints gets replaced with i32, and unconstrained floats with f64.
     pub fn default_type_parameters(&self) {
         use middle::ty::UnconstrainedNumeric::{UnconstrainedInt, UnconstrainedFloat, Neither};
         for (_, &mut ref ty) in &mut *self.inh.node_types.borrow_mut() {
             let resolved = self.infcx().resolve_type_vars_if_possible(ty);
-            if self.infcx().type_var_diverges(resolved) {
-                demand::eqtype(self, codemap::DUMMY_SP, *ty, ty::mk_nil(self.tcx()));
-            } else {
-                match self.infcx().type_is_unconstrained_numeric(resolved) {
-                    UnconstrainedInt => {
-                        demand::eqtype(self, codemap::DUMMY_SP, *ty, self.tcx().types.i32)
-                    },
-                    UnconstrainedFloat => {
-                        demand::eqtype(self, codemap::DUMMY_SP, *ty, self.tcx().types.f64)
-                    }
-                    Neither => { }
+            match self.infcx().type_is_unconstrained_numeric(resolved) {
+                UnconstrainedInt => {
+                    demand::eqtype(self, codemap::DUMMY_SP, *ty, self.tcx().types.i32)
+                },
+                UnconstrainedFloat => {
+                    demand::eqtype(self, codemap::DUMMY_SP, *ty, self.tcx().types.f64)
                 }
+                Neither => { }
             }
         }
     }

--- a/src/test/compile-fail/bot-ambig.rs
+++ b/src/test/compile-fail/bot-ambig.rs
@@ -1,0 +1,27 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Make sure that bottom type fallback doesn't introduce type system
+// holes. See issue #21878 for more details.
+
+trait Foo {}
+impl Foo for () {}
+impl Foo for i32 {}
+
+struct Error;
+impl Error {
+    fn foo(&self) -> ! { loop {} }
+}
+
+fn bar<T: Foo>() -> Result<T, Error> { loop {} }
+
+fn main() {
+    let _ = bar().unwrap_or_else(|e| e.foo());  //~ ERROR unable to infer enough type information
+}

--- a/src/test/compile-fail/bot-wrong-annotation.rs
+++ b/src/test/compile-fail/bot-wrong-annotation.rs
@@ -1,0 +1,28 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Make sure that bottom type fallback doesn't introduce type system
+// holes. See issue #21878 for more details.
+
+trait Foo {}
+impl Foo for () {}
+impl Foo for i32 {}
+
+struct Error;
+impl Error {
+    fn foo(&self) -> ! { loop {} }
+}
+
+fn bar<T: Foo>() -> Result<T, Error> { loop {} }
+
+fn main() {
+    let _: u8 = bar().unwrap_or_else(|e| e.foo());
+    //~^ ERROR the trait `Foo` is not implemented for the type `u8`
+}

--- a/src/test/compile-fail/issue-6458-1.rs
+++ b/src/test/compile-fail/issue-6458-1.rs
@@ -1,0 +1,12 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo<T>(t: T) {}
+fn main() { foo(panic!()) } //~ ERROR unable to infer enough type information

--- a/src/test/run-fail/bot-annotated.rs
+++ b/src/test/run-fail/bot-annotated.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,22 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Make sure that bottom type fallback doesn't introduce type system
+// holes. See issue #21878 for more details.
+
 // error-pattern:explicit panic
 
-fn foo<T>(t: T) {}
-fn main() { foo(panic!()) }
+trait Foo {}
+impl Foo for () {}
+impl Foo for i32 {}
+
+struct Error;
+impl Error {
+    fn foo(&self) -> ! { panic!() }
+}
+
+fn bar<T: Foo>() -> Result<T, Error> { panic!() }
+
+fn main() {
+    let _: i32 = bar().unwrap_or_else(|e| e.foo());
+}


### PR DESCRIPTION
PR #17603 introduced bottom type fallback but did it a bit too
eagerly. This patch makes the fallback lazy so that `typeck` can run
its cause and detect as many type errors as possible with regard to
diverging types.

Closes #21878
