### PR TITLE
Remove `noalias` on return values

### DIFF
--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -336,11 +336,9 @@ pub fn trans_native_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     if fn_type.ret_ty.is_indirect() {
         let llret_sz = machine::llsize_of_real(ccx, fn_type.ret_ty.ty);
 
-        // The outptr can be noalias and nocapture because it's entirely
-        // invisible to the program. We also know it's nonnull as well
-        // as how many bytes we can dereference
-        attrs.arg(1, llvm::NoAliasAttribute)
-             .arg(1, llvm::NoCaptureAttribute)
+        // The outptr can be nocapture because it's entirely invisible to the program. We also know
+        // it's nonnull as well as how many bytes we can dereference
+        attrs.arg(1, llvm::NoCaptureAttribute)
              .arg(1, llvm::DereferenceableAttribute(llret_sz));
     };
 


### PR DESCRIPTION
On return values `noalias` has a stricter meaning than on arguments. It
means that the function is malloc-like. To quote the LLVM docs:

```
Furthermore, the semantics of the noalias attribute on return values
are stronger than the semantics of the attribute when used on
function arguments. On function return values, the noalias attribute
indicates that the function acts like a system memory allocation
function, returning a pointer to allocated storage disjoint from the
storage for any other object accessible to the caller.
```

We use it for all kinds of functions, which is wrong, so let's stop
doing that.

Fixes #21996
