### PR TITLE
rustc: Don't fall back to -L if using --extern

### DIFF
--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -357,9 +357,8 @@ impl<'a> Context<'a> {
         // must be loaded via -L plus some filtering.
         if self.hash.is_none() {
             self.should_match_name = false;
-            match self.find_commandline_library() {
-                Some(l) => return Some(l),
-                None => {}
+            if let Some(s) = self.sess.opts.externs.get(self.crate_name) {
+                return self.find_commandline_library(s);
             }
             self.should_match_name = true;
         }
@@ -596,12 +595,7 @@ impl<'a> Context<'a> {
         (t.options.dll_prefix.clone(), t.options.dll_suffix.clone())
     }
 
-    fn find_commandline_library(&mut self) -> Option<Library> {
-        let locs = match self.sess.opts.externs.get(self.crate_name) {
-            Some(s) => s,
-            None => return None,
-        };
-
+    fn find_commandline_library(&mut self, locs: &[String]) -> Option<Library> {
         // First, filter out all libraries that look suspicious. We only accept
         // files which actually exist that have the correct naming scheme for
         // rlibs/dylibs.

--- a/src/test/run-make/use-extern-for-plugins/Makefile
+++ b/src/test/run-make/use-extern-for-plugins/Makefile
@@ -1,0 +1,13 @@
+-include ../tools.mk
+
+HOST := $(shell $(RUSTC) -vV | grep 'host:' | sed 's/host: //')
+ifeq ($(findstring i686,$(HOST)),i686)
+TARGET := $(subst i686,x86_64,$(HOST))
+else
+TARGET := $(subst x86_64,i686,$(HOST))
+endif
+
+all:
+	$(RUSTC) foo.rs -C extra-filename=-host
+	$(RUSTC) bar.rs -C extra-filename=-targ --target $(TARGET)
+	$(RUSTC) baz.rs --extern a=$(TMPDIR)/liba-targ.rlib --target $(TARGET)

--- a/src/test/run-make/use-extern-for-plugins/bar.rs
+++ b/src/test/run-make/use-extern-for-plugins/bar.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(no_std)]
+#![no_std]
+#![crate_type = "lib"]
+#![crate_name = "a"]
+
+#[macro_export]
+macro_rules! bar {
+    () => ()
+}

--- a/src/test/run-make/use-extern-for-plugins/baz.rs
+++ b/src/test/run-make/use-extern-for-plugins/baz.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(no_std)]
+#![no_std]
+#![crate_type = "lib"]
+
+#[macro_use]
+extern crate a;
+
+bar!();

--- a/src/test/run-make/use-extern-for-plugins/foo.rs
+++ b/src/test/run-make/use-extern-for-plugins/foo.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(no_std)]
+#![no_std]
+#![crate_type = "lib"]
+#![crate_name = "a"]
+
+#[macro_export]
+macro_rules! foo {
+    () => ()
+}


### PR DESCRIPTION
The compiler would previously fall back to using `-L` and normal lookup paths if
a `--extern` path was specified but it did not match (wrong architecture, for
example). This commit removes this behavior and forces the hand of the crate
loader to _always_ use the `--extern` path if specified, no matter whether it is
correct or not.

This fixes a bug today where the compiler's own libraries are favored in cross
compilation by accident. For example when a crate using the crates.io version of
`log` was cross compiled, Cargo would compile `log` for the target architecture.
When loading the macros, however, the compiler currently favors using the _host_
architecture (for plugins), and because the `--extern log=...` pointed at an
rlib for the target architecture, that lookup failed. The crate loader  then
fell back on `-L` paths to find the compiler-used `log` crate (the wrong one!)
and then a compile failure happened because the logging macros are slightly
different.
