### PR TITLE
std: Stabilize the `ascii` module

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -1761,7 +1761,7 @@ impl LintPass for Stability {
     }
 
     fn check_item(&mut self, cx: &Context, item: &ast::Item) {
-        stability::check_item(cx.tcx, item,
+        stability::check_item(cx.tcx, item, false,
                               &mut |id, sp, stab| self.lint(cx, id, sp, stab));
     }
 

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -817,7 +817,9 @@ impl<'a, S: Writer + Hasher> Hash<S> for Wtf8 {
     }
 }
 
-impl AsciiExt<Wtf8Buf> for Wtf8 {
+impl AsciiExt for Wtf8 {
+    type Owned = Wtf8Buf;
+
     fn is_ascii(&self) -> bool {
         self.bytes.is_ascii()
     }
@@ -830,6 +832,9 @@ impl AsciiExt<Wtf8Buf> for Wtf8 {
     fn eq_ignore_ascii_case(&self, other: &Wtf8) -> bool {
         self.bytes.eq_ignore_ascii_case(&other.bytes)
     }
+
+    fn make_ascii_uppercase(&mut self) { self.bytes.make_ascii_uppercase() }
+    fn make_ascii_lowercase(&mut self) { self.bytes.make_ascii_lowercase() }
 }
 
 #[cfg(test)]

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2761,15 +2761,13 @@ impl<'a> State<'a> {
             ast::LitStr(ref st, style) => self.print_string(&st, style),
             ast::LitByte(byte) => {
                 let mut res = String::from_str("b'");
-                ascii::escape_default(byte, |c| res.push(c as char));
+                res.extend(ascii::escape_default(byte).map(|c| c as char));
                 res.push('\'');
                 word(&mut self.s, &res[])
             }
             ast::LitChar(ch) => {
                 let mut res = String::from_str("'");
-                for c in ch.escape_default() {
-                    res.push(c);
-                }
+                res.extend(ch.escape_default());
                 res.push('\'');
                 word(&mut self.s, &res[])
             }
@@ -2809,8 +2807,8 @@ impl<'a> State<'a> {
             ast::LitBinary(ref v) => {
                 let mut escaped: String = String::new();
                 for &ch in &**v {
-                    ascii::escape_default(ch as u8,
-                                          |ch| escaped.push(ch as char));
+                    escaped.extend(ascii::escape_default(ch as u8)
+                                         .map(|c| c as char));
                 }
                 word(&mut self.s, &format!("b\"{}\"", escaped)[])
             }

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -58,7 +58,6 @@
 #![feature(path)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
-#![feature(std_misc)]
 #![feature(unicode)]
 #![feature(env)]
 #![cfg_attr(windows, feature(libc))]

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -133,6 +133,11 @@ mod cross_crate {
     impl UnstableTrait for S { } //~ WARNING use of unstable library feature
 
     trait LocalTrait : UnstableTrait { } //~ WARNING use of unstable library feature
+
+    impl Trait for S {
+        fn trait_stable(&self) {}
+        fn trait_unstable(&self) {} //~ WARNING use of unstable library feature
+    }
 }
 
 mod inheritance {


### PR DESCRIPTION
- Move the type parameter on the `AsciiExt` trait to an associated type named
  `Owned`.
- Move `ascii::escape_default` to using an iterator.

This is a breaking change due to the removal of the type parameter on the
`AsciiExt` trait as well as the modifications to the `escape_default` function
to returning an iterator. Manual implementations of `AsciiExt` (or `AsciiExt`
bounds) should be adjusted to remove the type parameter and using the new
`escape_default` should be relatively straightforward.

[breaking-change]
