### PR TITLE
Use the local cache for trait selection in all non-empty environments

### DIFF
--- a/src/test/run-pass/traits-issue-22019.rs
+++ b/src/test/run-pass/traits-issue-22019.rs
@@ -1,0 +1,41 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test an issue where global caching was causing free regions from
+// distinct scopes to be compared (`'g` and `'h`). The only important
+// thing is that compilation succeeds here.
+
+#![allow(missing_copy_implementations)]
+#![allow(unused_variables)]
+
+use std::borrow::ToOwned;
+
+pub struct CFGNode;
+
+pub type Node<'a> = &'a CFGNode;
+
+pub trait GraphWalk<'c, N> {
+    /// Returns all the nodes in this graph.
+    fn nodes(&'c self) where [N]:ToOwned<Vec<N>>;
+}
+
+impl<'g> GraphWalk<'g, Node<'g>> for u32
+{
+    fn nodes(&'g self) where [Node<'g>]:ToOwned<Vec<Node<'g>>>
+    { loop { } }
+}
+
+impl<'h> GraphWalk<'h, Node<'h>> for u64
+{
+    fn nodes(&'h self) where [Node<'h>]:ToOwned<Vec<Node<'h>>>
+    { loop { } }
+}
+
+fn main()  { }


### PR DESCRIPTION
Simplify cache selection by just using the local cache whenever there
are any where-clauses at all. This seems to be the simplest possible
rule and will (hopefully!) put an end to these annoying "cache leak"
bugs. Fixes #22019.

r? @aturon 
