### PR TITLE
compatibility issues in configure and make tidy

### DIFF
--- a/configure
+++ b/configure
@@ -1380,7 +1380,8 @@ do
 done
 
 # Munge any paths that appear in config.mk back to posix-y
-sed -i.bak -e 's@ \([a-zA-Z]\):[/\\]@ /\1/@g;' config.tmp
+cp config.tmp config.tmp.bak
+sed -e 's@ \([a-zA-Z]\):[/\\]@ /\1/@g;' <config.tmp.bak >config.tmp
 rm -f config.tmp.bak
 
 msg


### PR DESCRIPTION
the sed option `--in-place` (or `-i`) is a GNU extension, and it is not
portable to BSD system (openbsd and freebsd checked).

use an alternate construction in order to keep the semantic.
