### PR TITLE
Make the live code analysis visit method declarations.

### DIFF
--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -234,7 +234,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
             ast_map::NodeImplItem(impl_item) => {
                 match *impl_item {
                     ast::MethodImplItem(ref method) => {
-                        visit::walk_block(self, method.pe_body());
+                        visit::walk_method_helper(self, method);
                     }
                     ast::TypeImplItem(_) => {}
                 }

--- a/src/test/run-pass/issue-20343.rs
+++ b/src/test/run-pass/issue-20343.rs
@@ -1,0 +1,38 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for Issue #20343.
+
+#![deny(dead_code)]
+
+struct B { b: u32 }
+struct C;
+struct D;
+
+trait T<A> {}
+impl<A> T<A> for () {}
+
+impl B {
+    // test for unused code in arguments
+    fn foo(B { b }: B) -> u32 { b }
+
+    // test for unused code in return type
+    fn bar() -> C { unsafe { ::std::mem::transmute(()) } }
+
+    // test for unused code in generics
+    fn baz<A: T<D>>() {}
+}
+
+pub fn main() {
+    let b = B { b: 3 };
+    B::foo(b);
+    B::bar();
+    B::baz::<()>();
+}


### PR DESCRIPTION
The live code analysis only visited the function's body when visiting a
method, and not the FnDecl and the generics, resulting in code to be
incorrectly marked as unused when it only appeared in the generics, the
arguments, or the return type, whereas the same code in non-method
functions was correctly detected as used. Fixes #20343.

Originally I just added a call to `walk_generics` and `walk_fndecl` alongside `walk_block` but then I noticed the `walk_method_helper` function did pretty much the same thing. The only difference is that it also calls `visit_mac`, but since this is not going to happen at this stage, I think it's ok. However let me know if this was not the right thing to do.
