### PR TITLE
Link to rustdoc page in the Rust book directly

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -59,8 +59,7 @@ tools we have are really nice.
 [Cargo](http://crates.io) is Rust's package manager, and its website contains
 lots of good documentation.
 
-[The `rustdoc` manual](rustdoc.html) contains information about Rust's
-documentation tool.
+[`rustdoc`](book/documentation.html) is used to generate documentation for Rust code.
 
 # FAQs
 


### PR DESCRIPTION
No point sending people to a page which just says "this is now part of
the Rust book" (that page being http://doc.rust-lang.org/rustdoc.html).
