### PR TITLE
Fix handling of parse errors when using `include!()`.

### DIFF
--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -111,10 +111,14 @@ pub fn expand_include<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree
         fn make_items(mut self: Box<ExpandResult<'a>>)
                       -> Option<SmallVector<P<ast::Item>>> {
             let mut ret = SmallVector::zero();
-            loop {
+            while self.p.token != token::Eof {
                 match self.p.parse_item_with_outer_attributes() {
                     Some(item) => ret.push(item),
-                    None => break
+                    None => self.p.span_fatal(
+                        self.p.span,
+                        &format!("expected item, found `{}`",
+                                 self.p.this_token_to_string())[]
+                    )
                 }
             }
             Some(ret)

--- a/src/test/auxiliary/issue-21146-inc.rs
+++ b/src/test/auxiliary/issue-21146-inc.rs
@@ -1,0 +1,13 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// include file for issue-21146.rs
+
+parse_error

--- a/src/test/compile-fail/issue-21146.rs
+++ b/src/test/compile-fail/issue-21146.rs
@@ -1,0 +1,13 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: expected item, found `parse_error`
+include!("../auxiliary/issue-21146-inc.rs");
+fn main() {}


### PR DESCRIPTION
Makes the compilation abort when a parse error is encountered while
trying to parse an item in an included file. The previous behaviour was
to stop processing the file when a token that can't start an item was
encountered, without producing any error. Fixes #21146.
