### PR TITLE
Eliminate assoc type projection predicate candidate duplicates

### DIFF
--- a/src/librustc/middle/traits/mod.rs
+++ b/src/librustc/middle/traits/mod.rs
@@ -63,7 +63,7 @@ mod util;
 /// either identifying an `impl` (e.g., `impl Eq for int`) that
 /// provides the required vtable, or else finding a bound that is in
 /// scope. The eventual result is usually a `Selection` (defined below).
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Obligation<'tcx, T> {
     pub cause: ObligationCause<'tcx>,
     pub recursion_depth: uint,
@@ -74,7 +74,7 @@ pub type PredicateObligation<'tcx> = Obligation<'tcx, ty::Predicate<'tcx>>;
 pub type TraitObligation<'tcx> = Obligation<'tcx, ty::PolyTraitPredicate<'tcx>>;
 
 /// Why did we incur this obligation? Used for error reporting.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ObligationCause<'tcx> {
     pub span: Span,
 
@@ -89,7 +89,7 @@ pub struct ObligationCause<'tcx> {
     pub code: ObligationCauseCode<'tcx>
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum ObligationCauseCode<'tcx> {
     /// Not well classified or should be obvious from span.
     MiscObligation,
@@ -129,7 +129,7 @@ pub enum ObligationCauseCode<'tcx> {
     CompareImplMethodObligation,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct DerivedObligationCause<'tcx> {
     /// The trait reference of the parent obligation that led to the
     /// current obligation. Note that only trait obligations lead to
@@ -251,7 +251,7 @@ pub enum Vtable<'tcx, N> {
 /// is `Obligation`, as one might expect. During trans, however, this
 /// is `()`, because trans only requires a shallow resolution of an
 /// impl, and nested obligations are satisfied later.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct VtableImplData<'tcx, N> {
     pub impl_def_id: ast::DefId,
     pub substs: subst::Substs<'tcx>,

--- a/src/test/run-pass/issue-22036.rs
+++ b/src/test/run-pass/issue-22036.rs
@@ -1,0 +1,33 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait DigitCollection: Sized {
+    type Iter: Iterator<Item = u8>;
+    fn digit_iter(self) -> Self::Iter;
+
+    fn digit_sum(self) -> u32 {
+        self.digit_iter()
+            .map(|digit: u8| digit as u32)
+            .fold(0, |sum, digit| sum + digit)
+    }
+}
+
+impl<I> DigitCollection for I where I: Iterator<Item=u8> {
+    type Iter = I;
+
+    fn digit_iter(self) -> I {
+        self
+    }
+}
+
+fn main() {
+    let xs = vec![1u8, 2, 3, 4, 5];
+    assert_eq!(xs.into_iter().digit_sum(), 15);
+}


### PR DESCRIPTION
When projecting associate types for a trait's default methods, the
trait itself was added to the predicate candidate list twice: one from
parameter environment, the other from trait definition. Then the
duplicates were deemed as code ambiguity and the compiler rejected the
code. Simply checking and dropping the duplicates solves the issue.

Closes #22036
