### PR TITLE
Add lint to detect tuple-like structs

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -2103,6 +2103,30 @@ impl LintPass for PrivateNoMangleFns {
     }
 }
 
+#[derive(Copy)]
+pub struct UsingTupleStructs;
+
+declare_lint!(USING_TUPLE_STRUCTS, Allow,
+              "detects tuple-like structures");
+
+impl LintPass for UsingTupleStructs {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(USING_TUPLE_STRUCTS)
+    }
+
+    fn check_item(&mut self, cx: &Context, it: &ast::Item) {
+        if it.vis == ast::Visibility::Public {
+            if let ast::ItemStruct(ref def, _) = it.node {
+                if def.is_tuple_like() {
+                    cx.span_lint(USING_TUPLE_STRUCTS, it.span,
+                        "standard library should not use tuple-like structures; \
+                         it hampers backward compatibility")
+                }
+            }
+        }
+    }
+}
+
 /// Forbids using the `#[feature(...)]` attribute
 #[derive(Copy)]
 pub struct UnstableFeatures;

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -214,6 +214,7 @@ impl LintStore {
                      Stability,
                      UnconditionalRecursion,
                      PrivateNoMangleFns,
+                     UsingTupleStructs,
         );
 
         add_builtin_with_new!(sess,

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1596,6 +1596,12 @@ pub struct StructDef {
     pub ctor_id: Option<NodeId>,
 }
 
+impl StructDef {
+    pub fn is_tuple_like(&self) -> bool {
+        self.fields.len() > 0 && self.fields[0].node.kind.is_unnamed()
+    }
+}
+
 /*
   FIXME (#3300): Should allow items to be anonymous. Right now
   we just use dummy names for anon items.

--- a/src/test/compile-fail/lint-tuple-structs.rs
+++ b/src/test/compile-fail/lint-tuple-structs.rs
@@ -1,0 +1,26 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(using_tuple_structs)]
+#![allow(dead_code)]
+
+// regular struct is okay
+pub struct S { x: usize, y: usize }
+
+// enum-like struct is okay, too
+pub struct ES;
+
+// tuple-like struct is not
+pub struct TS(usize);   //~ ERROR standard library should not use tuple-like
+
+// but non-public one is
+struct TSPrivate(usize);
+
+fn main() {}


### PR DESCRIPTION
It is benign and could be activated by individual crates.

cc #22045
