### PR TITLE
Implement equality constraints in where clauses

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2382,12 +2382,17 @@ The currently implemented features of the reference compiler are:
           semantics are likely to change, so this macro usage must be opted
           into.
 
+* `associated_types` - Allows type aliases in traits. Experimental.
+
 * `concat_idents` - Allows use of the `concat_idents` macro, which is in many
                     ways insufficient for concatenating identifiers, and may be
                     removed entirely for something more wholesome.
 
 * `default_type_params` - Allows use of default type parameters. The future of
                           this feature is uncertain.
+
+* `equality_constraints` - Allows the use of `=` in where clauses. This
+  allows a user to demand that two type's normal forms are equal.
 
 * `intrinsics` - Allows use of the "rust-intrinsics" ABI. Compiler intrinsics
                  are inherently unstable and no promise about them is made.
@@ -2464,8 +2469,6 @@ The currently implemented features of the reference compiler are:
                    which have not been marked with a stability marker.
                    Such items should not be allowed by the compiler to exist,
                    so if you need this there probably is a compiler bug.
-
-* `associated_types` - Allows type aliases in traits. Experimental.
 
 If a feature is promoted to a language feature, then all existing programs will
 start to receive compilation warnings about #[feature] directives which enabled

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -211,12 +211,11 @@ impl<'a, 'v> Visitor<'v> for LifetimeContext<'a> {
                         self.visit_lifetime_ref(bound);
                     }
                 }
-                &ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{ id,
-                                                                         ref path,
-                                                                         ref ty,
+                &ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{ ref ty_left,
+                                                                         ref ty_right,
                                                                          .. }) => {
-                    self.visit_path(path, id);
-                    self.visit_ty(&**ty);
+                    self.visit_ty(&**ty_left);
+                    self.visit_ty(&**ty_right);
                 }
             }
         }

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -554,7 +554,12 @@ fn early_bound_lifetime_names(generics: &ast::Generics) -> Vec<ast::Name> {
                         collector.visit_lifetime_ref(bound);
                     }
                 }
-                &ast::WherePredicate::EqPredicate(_) => unimplemented!()
+                &ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{ref ty_left,
+                                                                        ref ty_right,
+                                                                        ..}) => {
+                    collector.visit_ty(&**ty_left);
+                    collector.visit_ty(&**ty_right);
+                }
             }
         }
     }

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1453,7 +1453,8 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
                 }
                 &ast::WherePredicate::RegionPredicate(_) => {}
                 &ast::WherePredicate::EqPredicate(ref eq_pred) => {
-                    self.visit_ty(&*eq_pred.ty);
+                    self.visit_ty(&*eq_pred.ty_left);
+                    self.visit_ty(&*eq_pred.ty_right);
                 }
             }
         }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3205,17 +3205,8 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 }
                 &ast::WherePredicate::RegionPredicate(_) => {}
                 &ast::WherePredicate::EqPredicate(ref eq_pred) => {
-                    match self.resolve_path(eq_pred.id, &eq_pred.path, TypeNS, true) {
-                        Some((def @ DefTyParam(..), last_private)) => {
-                            self.record_def(eq_pred.id, (def, last_private));
-                        }
-                        _ => {
-                            self.resolve_error(eq_pred.path.span,
-                                               "undeclared associated type");
-                        }
-                    }
-
-                    self.resolve_type(&*eq_pred.ty);
+                    self.resolve_type(&*eq_pred.ty_left);
+                    self.resolve_type(&*eq_pred.ty_right);
                 }
             }
         }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1293,10 +1293,9 @@ fn ty_generics<'a,'tcx>(ccx: &CollectCtxt<'a,'tcx>,
             }
 
             &ast::WherePredicate::EqPredicate(ref eq_pred) => {
-                // FIXME(#20041)
-                ccx.tcx.sess.span_bug(eq_pred.span,
-                                         "Equality constraints are not yet \
-                                            implemented (#20041)")
+                let ty_left = ast_ty_to_ty(ccx, &ExplicitRscope, &*eq_pred.ty_left);
+                let ty_right = ast_ty_to_ty(ccx, &ExplicitRscope, &*eq_pred.ty_right);
+                result.predicates.push(space, ty::Predicate::Equate(ty::Binder(ty::EquatePredicate(ty_left, ty_right))));
             }
         }
     }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1295,7 +1295,9 @@ fn ty_generics<'a,'tcx>(ccx: &CollectCtxt<'a,'tcx>,
             &ast::WherePredicate::EqPredicate(ref eq_pred) => {
                 let ty_left = ast_ty_to_ty(ccx, &ExplicitRscope, &*eq_pred.ty_left);
                 let ty_right = ast_ty_to_ty(ccx, &ExplicitRscope, &*eq_pred.ty_right);
-                result.predicates.push(space, ty::Predicate::Equate(ty::Binder(ty::EquatePredicate(ty_left, ty_right))));
+                result.predicates.push(space, ty::Predicate::Equate(
+                    ty::Binder(ty::EquatePredicate(ty_left, ty_right))
+                ));
             }
         }
     }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -458,8 +458,8 @@ pub struct WhereRegionPredicate {
 pub struct WhereEqPredicate {
     pub id: NodeId,
     pub span: Span,
-    pub path: Path,
-    pub ty: P<Ty>,
+    pub ty_left: P<Ty>,
+    pub ty_right: P<Ty>,
 }
 
 /// The set of MetaItems that define the compilation environment of the crate,

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -458,8 +458,8 @@ impl<'a> TraitDef<'a> {
                     ast::WherePredicate::EqPredicate(ast::WhereEqPredicate {
                         id: ast::DUMMY_NODE_ID,
                         span: self.span,
-                        path: we.path.clone(),
-                        ty: we.ty.clone()
+                        ty_right: we.ty_right.clone(),
+                        ty_left: we.ty_left.clone()
                     })
                 }
             }

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -825,13 +825,13 @@ pub fn noop_fold_where_predicate<T: Folder>(
             })
         }
         ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{id,
-                                                               path,
-                                                               ty,
+                                                               ty_left,
+                                                               ty_right,
                                                                span}) => {
             ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{
                 id: fld.new_id(id),
-                path: fld.fold_path(path),
-                ty:fld.fold_ty(ty),
+                ty_left: fld.fold_ty(ty_left),
+                ty_right: fld.fold_ty(ty_right),
                 span: fld.new_span(span)
             })
         }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4245,21 +4245,20 @@ impl<'a> Parser<'a> {
 
                         parsed_something = true;
                     } else if self.eat(&token::Eq) {
-                        // let ty = self.parse_ty();
+                        let ty = self.parse_ty();
                         let hi = self.span.hi;
                         let span = mk_sp(lo, hi);
-                        // generics.where_clause.predicates.push(
-                        //     ast::WherePredicate::EqPredicate(ast::WhereEqPredicate {
-                        //         id: ast::DUMMY_NODE_ID,
-                        //         span: span,
-                        //         path: panic!("NYI"), //bounded_ty,
-                        //         ty: ty,
-                        // }));
-                        // parsed_something = true;
-                        // // FIXME(#18433)
-                        self.span_err(span,
-                                     "equality constraints are not yet supported \
-                                     in where clauses (#20041)");
+                        generics.where_clause.predicates.push(
+                            ast::WherePredicate::EqPredicate(ast::WhereEqPredicate {
+                                id: ast::DUMMY_NODE_ID,
+                                span: span,
+                                ty_left: bounded_ty,
+                                ty_right: ty,
+                        }));
+                        parsed_something = true;
+                         // self.span_err(span,
+                         //          "equality constraints are not yet supported \
+                         //             in where clauses (#20041)");
                     } else {
                         let last_span = self.last_span;
                         self.span_err(last_span,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2516,7 +2516,9 @@ impl<'a> State<'a> {
                         }
                     }
                 }
-                &ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{ref ty_left, ref ty_right, ..}) => {
+                &ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{ref ty_left,
+                                                                        ref ty_right,
+                                                                        ..}) => {
                     try!(self.print_type(&**ty_left));
                     try!(space(&mut self.s));
                     try!(self.word_space("="));

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2516,11 +2516,11 @@ impl<'a> State<'a> {
                         }
                     }
                 }
-                &ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{ref path, ref ty, ..}) => {
-                    try!(self.print_path(path, false));
+                &ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{ref ty_left, ref ty_right, ..}) => {
+                    try!(self.print_type(&**ty_left));
                     try!(space(&mut self.s));
                     try!(self.word_space("="));
-                    try!(self.print_type(&**ty));
+                    try!(self.print_type(&**ty_right));
                 }
             }
         }

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -597,12 +597,11 @@ pub fn walk_generics<'v, V: Visitor<'v>>(visitor: &mut V, generics: &'v Generics
                     visitor.visit_lifetime_ref(bound);
                 }
             }
-            &ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{id,
-                                                                    ref path,
-                                                                    ref ty,
+            &ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{ref ty_left,
+                                                                    ref ty_right,
                                                                     ..}) => {
-                visitor.visit_path(path, id);
-                visitor.visit_ty(&**ty);
+                visitor.visit_ty(&**ty_left);
+                visitor.visit_ty(&**ty_right);
             }
         }
     }

--- a/src/test/compile-fail/where-clause-equality-constraint.rs
+++ b/src/test/compile-fail/where-clause-equality-constraint.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(equality_constraints)]
 
 trait Foo<A> where A = isize {
     type Inner;

--- a/src/test/compile-fail/where-clause-equality-constraint.rs
+++ b/src/test/compile-fail/where-clause-equality-constraint.rs
@@ -1,0 +1,29 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+trait Foo<A> where A = isize {
+    type Inner;
+
+    fn foo_bar(&self) where Self::Inner = String {}
+}
+
+// Failure to meet equality constraint on a trait definiton.
+impl Foo<String> for () {
+    //~^ the requirement `collections::string::String == isize` is not satisfied
+    type Inner = bool;
+
+    fn foo_bar(&self) {}
+}
+
+fn main() {
+    // Failure to meet associated type constraint on a method
+    ().foo_bar()
+}

--- a/src/test/run-pass/where-clause-equality-constraint.rs
+++ b/src/test/run-pass/where-clause-equality-constraint.rs
@@ -1,0 +1,26 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+trait Foo<A> where A = isize {
+    type Inner;
+
+    fn foo_bar(&self) where Self::Inner = String {}
+}
+
+impl Foo<isize> for () {
+    type Inner = String;
+
+    fn foo_bar(&self) {}
+}
+
+fn main() {
+    ().foo_bar()
+}

--- a/src/test/run-pass/where-clause-equality-constraint.rs
+++ b/src/test/run-pass/where-clause-equality-constraint.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(equality_constraints)]
 
 trait Foo<A> where A = isize {
     type Inner;


### PR DESCRIPTION
This fixes #20041. I was thinking that the necessary machinery this required must be in place for associated types. So I went ahead and implemented the parsing and translation in collect when I was bored last night. 

I currently have syntax of the form: `where A = T` since it seemed cleaner, as well as consistent with the associated types syntax of `Foo<A=T>` while not introducing ambiguity. If that is not what we want I'm happy to use the `==` syntax originally present in the RFC.

r? @nikomatsakis 

I think this should cover everything let me know otherwise.

cc @darinmorrison
