### PR TITLE
Correct fns exp2 that were calling exp

### DIFF
--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -173,7 +173,7 @@ impl Float for f32 {
     #[inline]
     fn exp(self) -> f32 { num::Float::exp(self) }
     #[inline]
-    fn exp2(self) -> f32 { num::Float::exp(self) }
+    fn exp2(self) -> f32 { num::Float::exp2(self) }
     #[inline]
     fn ln(self) -> f32 { num::Float::ln(self) }
     #[inline]
@@ -552,6 +552,33 @@ mod tests {
         assert_approx_eq!((-1.3f32).fract(), -0.3f32);
         assert_approx_eq!((-1.5f32).fract(), -0.5f32);
         assert_approx_eq!((-1.7f32).fract(), -0.7f32);
+    }
+
+    #[test]
+    fn test_exp() {
+        assert_eq!(1.0, 0.0f32.exp());
+        assert_approx_eq!(2.718282, 1.0f32.exp());
+        assert_approx_eq!(148.413162, 5.0f32.exp());
+
+        let inf: f32 = Float::infinity();
+        let neg_inf: f32 = Float::neg_infinity();
+        let nan: f32 = Float::nan();
+        assert_eq!(inf, inf.exp());
+        assert_eq!(0.0, neg_inf.exp());
+        assert!(nan.exp().is_nan());
+    }
+
+    #[test]
+    fn test_exp2() {
+        assert_eq!(32.0, 5.0f32.exp2());
+        assert_eq!(1.0, 0.0f32.exp2());
+
+        let inf: f32 = Float::infinity();
+        let neg_inf: f32 = Float::neg_infinity();
+        let nan: f32 = Float::nan();
+        assert_eq!(inf, inf.exp2());
+        assert_eq!(0.0, neg_inf.exp2());
+        assert!(nan.exp2().is_nan());
     }
 
     #[test]

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -183,7 +183,7 @@ impl Float for f64 {
     #[inline]
     fn exp(self) -> f64 { num::Float::exp(self) }
     #[inline]
-    fn exp2(self) -> f64 { num::Float::exp(self) }
+    fn exp2(self) -> f64 { num::Float::exp2(self) }
     #[inline]
     fn ln(self) -> f64 { num::Float::ln(self) }
     #[inline]
@@ -561,6 +561,33 @@ mod tests {
         assert_approx_eq!((-1.3f64).fract(), -0.3f64);
         assert_approx_eq!((-1.5f64).fract(), -0.5f64);
         assert_approx_eq!((-1.7f64).fract(), -0.7f64);
+    }
+
+    #[test]
+    fn test_exp() {
+        assert_eq!(1.0, 0.0f64.exp());
+        assert_approx_eq!(2.718282, 1.0f64.exp());
+        assert_approx_eq!(148.413159, 5.0f64.exp());
+
+        let inf: f64 = Float::infinity();
+        let neg_inf: f64 = Float::neg_infinity();
+        let nan: f64 = Float::nan();
+        assert_eq!(inf, inf.exp());
+        assert_eq!(0.0, neg_inf.exp());
+        assert!(nan.exp().is_nan());
+    }
+
+    #[test]
+    fn test_exp2() {
+        assert_eq!(32.0, 5.0f64.exp2());
+        assert_eq!(1.0, 0.0f64.exp2());
+
+        let inf: f64 = Float::infinity();
+        let neg_inf: f64 = Float::neg_infinity();
+        let nan: f64 = Float::nan();
+        assert_eq!(inf, inf.exp2());
+        assert_eq!(0.0, neg_inf.exp2());
+        assert!(nan.exp2().is_nan());
     }
 
     #[test]


### PR DESCRIPTION
Fixes  #22080.

I was working on adding examples to the documentation in `std::num::Float`. I got to `exp2`, which says "Returns 2 raised to the power of the number, `2^(self)`."

So I tried running this code:

```
use std::num::Float;

#[test]
fn test_exp2() {
    assert_eq!(32.0, 5.0.exp2());
}
```

and it resulted in a failure of `(left: `32`, right: `148.413159`)`. That 148.413159 is the value for e^5, which is `exp()`, not `exp2()`.

Sure enough, `exp2` is calling `exp` and shouldn't be, looks like a copy-paste error. 

I haven't added any tests for this since it's unlikely to break again, but I will happily do so if people think that would be a good idea. The doc examples are coming :)

I scanned through the other functions in these files for similar sorts of errors and didn't notice any.
