### PR TITLE
Added a `unsafe_ffi_drop_implementations` lint.

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -214,6 +214,7 @@ impl LintStore {
                      Stability,
                      UnconditionalRecursion,
                      PrivateNoMangleFns,
+                     UnsafeFfiDropImplementations,
         );
 
         add_builtin_with_new!(sess,

--- a/src/libstd/sys/windows/backtrace.rs
+++ b/src/libstd/sys/windows/backtrace.rs
@@ -284,7 +284,6 @@ mod arch {
     }
 }
 
-#[repr(C)]
 struct Cleanup {
     handle: libc::HANDLE,
     SymCleanup: SymCleanupFn,

--- a/src/test/compile-fail/issue-18308.rs
+++ b/src/test/compile-fail/issue-18308.rs
@@ -1,0 +1,37 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(unsafe_ffi_drop_implementations)]
+#![allow(dead_code)]
+
+extern {
+    fn f(x: *const FfiUnsafeStruct, y: *const FfiUnsafeEnum);
+}
+
+#[repr(C)]
+struct FfiUnsafeStruct { //~ ERROR: unexpected size and layout
+    i: i32,
+}
+
+impl Drop for FfiUnsafeStruct {
+    fn drop(&mut self) {}
+}
+
+#[repr(C)]
+enum FfiUnsafeEnum { //~ ERROR: unexpected size and layout
+    Kaboom = 0,
+    Splang = 1,
+}
+
+impl Drop for FfiUnsafeEnum {
+    fn drop(&mut self) {}
+}
+
+fn main() {}

--- a/src/test/run-pass/issue-18308.rs
+++ b/src/test/run-pass/issue-18308.rs
@@ -1,0 +1,51 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(unsafe_ffi_drop_implementations)]
+#![allow(dead_code)]
+
+extern {
+    fn f(x: *const FfiSafeStruct, y: *const FfiSafeEnum);
+}
+
+#[repr(C)]
+#[unsafe_no_drop_flag]
+struct FfiSafeStruct {
+    i: i32,
+}
+
+impl Drop for FfiSafeStruct {
+    fn drop(&mut self) {}
+}
+
+#[repr(C)]
+#[unsafe_no_drop_flag]
+enum FfiSafeEnum {
+    Kaboom = 0,
+    Splang = 1,
+}
+
+impl Drop for FfiSafeEnum {
+    fn drop(&mut self) {}
+}
+
+// These two should not be affected as they have no Drop impl.
+#[repr(C)]
+struct FfiSafeStructNoDrop {
+    i: i32,
+}
+
+#[repr(C)]
+enum FfiSafeEnumNoDrop {
+    Peace = 0,
+    WhaleSong = 1,
+}
+
+fn main() {}


### PR DESCRIPTION
This detects cases where a struct or enum are annotated with `#[repr(C)]`,
and _do not_ have `#[unsafe_no_drop_flag]`, whereby it warns the user that
the type may not have the expected size or layout.

The lint was set to "Warn" by default as I wasn't sure if "Deny" would be too strong.

A tangential change was to remove `#[repr(C)]` from `Cleanup` in `src/libstd/sys/windows/backtrace.rs`.  I believe this to be justified in that `Cleanup` is only ever used exactly once as an RAII handle, and is never passed to any FFI function.

Two tests including to ensure the lint triggers when `#[unsafe_no_drop_flag]` is missing, and does not trigger if it is present.

Addresses rust-lang/rust#18380.
