### PR TITLE
overloaded-`box` protocol changes

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -361,9 +361,9 @@ pub fn make_test_closure(config: &Config, testfile: &Path) -> test::TestFn {
 pub fn make_metrics_test_closure(config: &Config, testfile: &Path) -> test::TestFn {
     let config = (*config).clone();
     let testfile = testfile.to_path_buf();
-    test::DynMetricFn(box move |mm: &mut test::MetricMap| {
+    test::DynMetricFn(Box::new(move |mm: &mut test::MetricMap| {
         runtest::run_metrics(config, &testfile, mm)
-    })
+    }))
 }
 
 fn extract_gdb_version(full_version_line: Option<String>) -> Option<String> {

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -63,18 +63,19 @@ use core::ops::{Placer, Boxed, Place, InPlace, BoxPlace};
 use core::ptr::Unique;
 use core::raw::TraitObject;
 
-/// A value that represents the heap. This is the default place that the `box`
-/// keyword allocates into when no place is supplied.
+/// A value that represents the heap. This is the place that the `box`
+/// keyword allocates into.
 ///
 /// The following two examples are equivalent:
 ///
 /// ```rust
 /// #![feature(box_syntax)]
+/// #![feature(placement_in_syntax)]
 /// use std::boxed::HEAP;
 ///
 /// fn main() {
-///     let foo = box(HEAP) 5;
-///     let foo = box 5;
+///     let foo = in HEAP { 5 };
+///     let foo: Box<_> = box 5;
 /// }
 /// ```
 #[lang = "exchange_heap"]

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -72,6 +72,7 @@
 #![feature(lang_items, unsafe_destructor)]
 #![feature(box_syntax)]
 #![feature(optin_builtin_traits)]
+#![feature(placement_in_syntax)]
 #![feature(unboxed_closures)]
 #![feature(unsafe_no_drop_flag)]
 #![feature(core)]

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -1187,3 +1187,115 @@ impl<F,A> FnOnce<A> for F
         self.call_mut(args)
     }
 }
+
+/// Both `in (PLACE) EXPR` and `box EXPR` desugar into expressions
+/// that allocate an intermediate "place" that holds uninitialized
+/// state.  The desugaring evaluates EXPR, and writes the result at
+/// the address returned by the `pointer` method of this trait.
+///
+/// A `Place` can be thought of as a special representation for a
+/// hypothetical `&uninit` reference (which Rust cannot currently
+/// express directly). That is, it represents a pointer to
+/// uninitialized storage.
+///
+/// The client is responsible for two steps: First, initializing the
+/// payload (it can access its address via `pointer`). Second,
+/// converting the agent to an instance of the owning pointer, via the
+/// appropriate `finalize` method (see the `InPlace`.
+///
+/// If evaluating EXPR fails, then the destructor for the
+/// implementation of Place to clean up any intermediate state
+/// (e.g. deallocate box storage, pop a stack, etc).
+pub trait Place<Data: ?Sized> {
+    /// Returns the address where the input value will be written.
+    /// Note that the data at this address is generally uninitialized,
+    /// and thus one should use `ptr::write` for initializing it.
+    fn pointer(&mut self) -> *mut Data;
+}
+
+/// Interface to implementations of  `in (PLACE) EXPR`.
+///
+/// `in (PLACE) EXPR` effectively desugars into:
+///
+/// ```rust,ignore
+/// let p = PLACE;
+/// let mut place = Placer::make_place(p);
+/// let raw_place = Place::pointer(&mut place);
+/// let value = EXPR;
+/// unsafe {
+///     std::ptr::write(raw_place, value);
+///     InPlace::finalize(place)
+/// }
+/// ```
+///
+/// The type of `in (PLACE) EXPR` is derived from the type of `PLACE`;
+/// if the type of `PLACE` is `P`, then the final type of the whole
+/// expression is `P::Place::Owner` (see the `InPlace` and `Boxed`
+/// traits).
+///
+/// Values for types implementing this trait usually are transient
+/// intermediate values (e.g. the return value of `Vec::emplace_back`)
+/// or `Copy`, since the `make_place` method takes `self` by value.
+pub trait Placer<Data: ?Sized> {
+    /// `Place` is the intermedate agent guarding the
+    /// uninitialized state for `Data`.
+    type Place: InPlace<Data>;
+
+    /// Creates a fresh place from `self`.
+    fn make_place(self) -> Self::Place;
+}
+
+/// Specialization of `Place` trait supporting `in (PLACE) EXPR`.
+pub trait InPlace<Data: ?Sized>: Place<Data> {
+    /// `Owner` is the type of the end value of `in (PLACE) EXPR`
+    ///
+    /// Note that when `in (PLACE) EXPR` is solely used for
+    /// side-effecting an existing data-structure,
+    /// e.g. `Vec::emplace_back`, then `Owner` need not carry any
+    /// information at all (e.g. it can be the unit type `()` in that
+    /// case).
+    type Owner;
+
+    /// Converts self into the final value, shifting
+    /// deallocation/cleanup responsibilities (if any remain), over to
+    /// the returned instance of `Owner` and forgetting self.
+    unsafe fn finalize(self) -> Self::Owner;
+}
+
+/// Core trait for the `box EXPR` form.
+///
+/// `box EXPR` effectively desugars into:
+///
+/// ```rust,ignore
+/// let mut place = BoxPlace::make_place();
+/// let raw_place = Place::pointer(&mut place);
+/// let value = EXPR;
+/// unsafe {
+///     ::std::ptr::write(raw_place, value);
+///     Boxed::finalize(place)
+/// }
+/// ```
+///
+/// The type of `box EXPR` is supplied from its surrounding
+/// context; in the above expansion, the result type `T` is used
+/// to determine which implementation of `Boxed` to use, and that
+/// `<T as Boxed>` in turn dictates determines which
+/// implementation of `BoxPlace` to use, namely:
+/// `<<T as Boxed>::Place as BoxPlace>`.
+pub trait Boxed {
+    /// The kind of data that is stored in this kind of box.
+    type Data;  /* (`Data` unused b/c cannot yet express below bound.) */
+    /// The place that will negotiate the storage of the data.
+    type Place; /* should be bounded by BoxPlace<Self::Data> */
+
+    /// Converts filled place into final owning value, shifting
+    /// deallocation/cleanup responsibilities (if any remain), over to
+    /// returned instance of `Self` and forgetting `filled`.
+    unsafe fn finalize(filled: Self::Place) -> Self;
+}
+
+/// Specialization of `Place` trait supporting `box EXPR`.
+pub trait BoxPlace<Data: ?Sized> : Place<Data> {
+    /// Creates a globally fresh place.
+    fn make_place() -> Self;
+}

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -486,7 +486,7 @@ impl<'a, 'tcx, O:DataFlowOperator+Clone+'static> DataFlowContext<'a, 'tcx, O> {
         debug!("Dataflow result for {}:", self.analysis_name);
         debug!("{}", {
             let mut v = Vec::new();
-            self.pretty_print_to(box &mut v, blk).unwrap();
+            self.pretty_print_to(Box::new(&mut v), blk).unwrap();
             println!("{}", String::from_utf8(v).unwrap());
             ""
         });

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -605,6 +605,11 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                     None => {}
                 }
                 self.consume_expr(&**base);
+                if place.is_some() {
+                    self.tcx().sess.span_bug(
+                        expr.span,
+                        "box with explicit place remains after expansion");
+                }
             }
 
             ast::ExprMac(..) => {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -217,7 +217,7 @@ impl<'a> PhaseController<'a> {
     pub fn basic() -> PhaseController<'a> {
         PhaseController {
             stop: Compilation::Continue,
-            callback: box |_| {},
+            callback: Box::new(|_| {}),
         }
     }
 }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -378,7 +378,7 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
         }
 
         if sess.opts.debugging_opts.save_analysis {
-            control.after_analysis.callback = box |state| {
+            control.after_analysis.callback = Box::new(|state| {
                 time(state.session.time_passes(),
                      "save analysis",
                      state.expanded_crate.unwrap(),
@@ -386,7 +386,7 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
                                                  krate,
                                                  state.analysis.unwrap(),
                                                  state.out_dir));
-            };
+            });
             control.make_glob_map = resolve::MakeGlobMap::Yes;
         }
 
@@ -807,7 +807,8 @@ pub fn monitor<F:FnOnce()+Send+'static>(f: F) {
         cfg = cfg.stack_size(STACK_SIZE);
     }
 
-    match cfg.spawn(move || { stdio::set_stderr(box w); f() }).unwrap().join() {
+    // FIXME (#22405): Replace `Box::new` with `box` here when/if possible.
+    match cfg.spawn(move || { stdio::set_stderr(Box::new(w)); f() }).unwrap().join() {
         Ok(()) => { /* fallthrough */ }
         Err(value) => {
             // Thread panicked without emitting a fatal diagnostic
@@ -849,7 +850,7 @@ pub fn monitor<F:FnOnce()+Send+'static>(f: F) {
             // Panic so the process returns a failure code, but don't pollute the
             // output with some unnecessary panic messages, we've already
             // printed everything that we needed to.
-            old_io::stdio::set_stderr(box old_io::util::NullWriter);
+            old_io::stdio::set_stderr(Box::new(old_io::util::NullWriter));
             panic!();
         }
     }

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -558,7 +558,7 @@ pub fn pretty_print_input(sess: Session,
         (PpmSource(s), None) => {
             let out: &mut Write = &mut out;
             s.call_with_pp_support(
-                sess, ast_map, &arenas, id, box out, |annotation, out| {
+                sess, ast_map, &arenas, id, Box::new(out), |annotation, out| {
                     debug!("pretty printing source code {:?}", s);
                     let sess = annotation.sess();
                     pprust::print_crate(sess.codemap(),
@@ -585,7 +585,7 @@ pub fn pretty_print_input(sess: Session,
                                                       sess.diagnostic(),
                                                       src_name.to_string(),
                                                       &mut rdr,
-                                                      box out,
+                                                      Box::new(out),
                                                       annotation.pp_ann(),
                                                       is_expanded);
                     for node_id in uii.all_matching_node_ids(ast_map) {

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -914,7 +914,7 @@ fn run_work_multithreaded(sess: &Session,
         futures.push(rx);
 
         thread::Builder::new().name(format!("codegen-{}", i)).spawn(move || {
-            let diag_handler = mk_handler(true, box diag_emitter);
+            let diag_handler = mk_handler(true, Box::new(diag_emitter));
 
             // Must construct cgcx inside the proc because it has non-Send
             // fields.

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -1531,7 +1531,7 @@ pub fn process_crate(sess: &Session,
     let mut out_name = cratename.clone();
     out_name.push_str(".csv");
     root_path.push(&out_name);
-    let output_file = match File::create(&root_path) {
+    let output_file: Box<_> = match File::create(&root_path) {
         Ok(f) => box f,
         Err(e) => {
             let disp = root_path.display();

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -150,7 +150,8 @@ fn runtest(test: &str, cratename: &str, libs: SearchPaths,
     let (tx, rx) = channel();
     let w1 = old_io::ChanWriter::new(tx);
     let w2 = w1.clone();
-    let old = old_io::stdio::set_stderr(box w1);
+    // FIXME (#22405): Replace `Box::new` with `box` here when/if possible.
+    let old = old_io::stdio::set_stderr(Box::new(w1));
     thread::spawn(move || {
         let mut p = old_io::ChanReader::new(rx);
         let mut err = match old {
@@ -163,11 +164,11 @@ fn runtest(test: &str, cratename: &str, libs: SearchPaths,
         };
         old_io::util::copy(&mut p, &mut err).unwrap();
     });
-    let emitter = diagnostic::EmitterWriter::new(box w2, None);
+    let emitter = diagnostic::EmitterWriter::new(Box::new(w2), None);
 
     // Compile the code
     let codemap = CodeMap::new();
-    let diagnostic_handler = diagnostic::mk_handler(true, box emitter);
+    let diagnostic_handler = diagnostic::mk_handler(true, Box::new(emitter));
     let span_diagnostic_handler =
         diagnostic::mk_span_handler(diagnostic_handler, codemap);
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -116,6 +116,7 @@
 #![feature(linkage, thread_local, asm)]
 #![feature(old_impl_check)]
 #![feature(optin_builtin_traits)]
+#![feature(placement_in_syntax)]
 #![feature(rand)]
 #![feature(staged_api)]
 #![feature(unboxed_closures)]

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -110,6 +110,12 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
             //     InPlace::finalize(place)
             // }
 
+            // Ensure feature-gate is enabled
+            feature_gate::check_for_placement_in(
+                fld.cx.ecfg.features,
+                &fld.cx.parse_sess.span_diagnostic,
+                expr_span);
+
             let value_span = value_expr.span;
             let placer_span = placer.span;
 
@@ -194,6 +200,12 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
             //     ::std::ptr::write(raw_place, value);
             //     Boxed::finalize(place)
             // }
+
+            // Ensure feature-gate is enabled
+            feature_gate::check_for_box_syntax(
+                fld.cx.ecfg.features,
+                &fld.cx.parse_sess.span_diagnostic,
+                expr_span);
 
             let value_span = value_expr.span;
 

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -128,7 +128,7 @@ pub fn expand_include<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree
         }
     }
 
-    box ExpandResult { p: p }
+    Box::new(ExpandResult { p: p })
 }
 
 // include_str! : read the given file, insert it as a literal string expr

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -288,7 +288,7 @@ pub fn filemap_to_tts(sess: &ParseSess, filemap: Rc<FileMap>)
     // parsing tt's probably shouldn't require a parser at all.
     let cfg = Vec::new();
     let srdr = lexer::StringReader::new(&sess.span_diagnostic, filemap);
-    let mut p1 = Parser::new(sess, cfg, box srdr);
+    let mut p1 = Parser::new(sess, cfg, Box::new(srdr));
     p1.parse_all_token_trees()
 }
 
@@ -297,7 +297,7 @@ pub fn tts_to_parser<'a>(sess: &'a ParseSess,
                          tts: Vec<ast::TokenTree>,
                          cfg: ast::CrateConfig) -> Parser<'a> {
     let trdr = lexer::new_tt_reader(&sess.span_diagnostic, None, None, tts);
-    let mut p = Parser::new(sess, cfg, box trdr);
+    let mut p = Parser::new(sess, cfg, Box::new(trdr));
     p.check_unknown_macro_variable();
     p
 }
@@ -360,7 +360,7 @@ pub mod with_hygiene {
         use super::lexer::make_reader_with_embedded_idents as make_reader;
         let cfg = Vec::new();
         let srdr = make_reader(&sess.span_diagnostic, filemap);
-        let mut p1 = Parser::new(sess, cfg, box srdr);
+        let mut p1 = Parser::new(sess, cfg, Box::new(srdr));
         p1.parse_all_token_trees()
     }
 }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -187,7 +187,7 @@ pub fn to_string<F>(f: F) -> String where
     F: FnOnce(&mut State) -> io::Result<()>,
 {
     use std::raw::TraitObject;
-    let mut s = rust_printer(box Vec::new());
+    let mut s = rust_printer(Box::new(Vec::new()));
     f(&mut s).unwrap();
     eof(&mut s.s).unwrap();
     let wr = unsafe {

--- a/src/test/auxiliary/custom_derive_plugin.rs
+++ b/src/test/auxiliary/custom_derive_plugin.rs
@@ -11,7 +11,6 @@
 // force-host
 
 #![feature(plugin_registrar)]
-#![feature(box_syntax)]
 #![feature(rustc_private)]
 
 extern crate syntax;
@@ -31,7 +30,7 @@ use rustc::plugin::Registry;
 pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_syntax_extension(
         token::intern("derive_TotalSum"),
-        Decorator(box expand));
+        Decorator(Box::new(expand)));
 }
 
 fn expand(cx: &mut ExtCtxt,
@@ -54,7 +53,7 @@ fn expand(cx: &mut ExtCtxt,
                 args: vec![],
                 ret_ty: Literal(Path::new_local("isize")),
                 attributes: vec![],
-                combine_substructure: combine_substructure(box |cx, span, substr| {
+                combine_substructure: combine_substructure(Box::new(|cx, span, substr| {
                     let zero = cx.expr_int(span, 0);
                     cs_fold(false,
                             |cx, span, subexpr, field, _| {
@@ -63,9 +62,9 @@ fn expand(cx: &mut ExtCtxt,
                                         token::str_to_ident("total_sum"), vec![]))
                             },
                             zero,
-                            box |cx, span, _, _| { cx.span_bug(span, "wtf??"); },
+                            Box::new(|cx, span, _, _| { cx.span_bug(span, "wtf??"); }),
                             cx, span, substr)
-                }),
+                })),
             },
         ],
     };

--- a/src/test/compile-fail/check-static-values-constraints.rs
+++ b/src/test/compile-fail/check-static-values-constraints.rs
@@ -99,7 +99,22 @@ static STATIC10: UnsafeStruct = UnsafeStruct;
 struct MyOwned;
 
 static STATIC11: Box<MyOwned> = box MyOwned;
-//~^ ERROR allocations are not allowed in statics
+//~^ ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR references in statics may only refer to immutable values
 
 // The following examples test that mutable structs are just forbidden
 // to have types with destructors
@@ -121,13 +136,77 @@ static mut STATIC14: SafeStruct = SafeStruct {
 };
 
 static STATIC15: &'static [Box<MyOwned>] = &[
-    box MyOwned, //~ ERROR allocations are not allowed in statics
-    box MyOwned, //~ ERROR allocations are not allowed in statics
+    box MyOwned,
+    //~^ ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR references in statics may only refer to immutable values
+    box MyOwned,
+    //~^ ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR references in statics may only refer to immutable values
 ];
 
 static STATIC16: (&'static Box<MyOwned>, &'static Box<MyOwned>) = (
-    &box MyOwned, //~ ERROR allocations are not allowed in statics
-    &box MyOwned, //~ ERROR allocations are not allowed in statics
+    &box MyOwned,
+    //~^ ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR references in statics may only refer to immutable values
+    &box MyOwned,
+    //~^ ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR references in statics may only refer to immutable values
 );
 
 static mut STATIC17: SafeEnum = SafeEnum::Variant1;
@@ -135,9 +214,39 @@ static mut STATIC17: SafeEnum = SafeEnum::Variant1;
 
 static STATIC19: Box<isize> =
     box 3;
-//~^ ERROR allocations are not allowed in statics
+//~^ ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR references in statics may only refer to immutable values
 
 pub fn main() {
     let y = { static x: Box<isize> = box 3; x };
-    //~^ ERROR allocations are not allowed in statics
+    //~^ ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR references in statics may only refer to immutable values
 }

--- a/src/test/compile-fail/dst-rvalue.rs
+++ b/src/test/compile-fail/dst-rvalue.rs
@@ -14,11 +14,15 @@
 
 pub fn main() {
     let _x: Box<str> = box *"hello world";
-    //~^ ERROR E0161
-    //~^^ ERROR cannot move out of borrowed content
+    //~^ ERROR E0277
+    //~| ERROR the trait `core::marker::Sized` is not implemented for the type `str`
+    //~| ERROR the trait `core::marker::Sized` is not implemented for the type `str`
+    //~| ERROR the trait `core::marker::Sized` is not implemented for the type `str`
 
     let array: &[isize] = &[1, 2, 3];
     let _x: Box<[isize]> = box *array;
-    //~^ ERROR E0161
-    //~^^ ERROR cannot move out of borrowed content
+    //~^ ERROR E0277
+    //~| ERROR the trait `core::marker::Sized` is not implemented for the type `[isize]`
+    //~| ERROR the trait `core::marker::Sized` is not implemented for the type `[isize]`
+    //~| ERROR the trait `core::marker::Sized` is not implemented for the type `[isize]`
 }

--- a/src/test/compile-fail/feature-gate-box-expr.rs
+++ b/src/test/compile-fail/feature-gate-box-expr.rs
@@ -17,7 +17,10 @@ fn main() {
     let x = box () 'c'; //~ ERROR box expression syntax is experimental
     println!("x: {}", x);
 
-    let x = box (HEAP) 'c'; //~ ERROR box expression syntax is experimental
+    let x = box (HEAP) 'c'; //~ ERROR placement-in expression syntax is experimental
+    println!("x: {}", x);
+
+    let x = in HEAP { 'c' }; //~ ERROR placement-in expression syntax is experimental
     println!("x: {}", x);
 }
 

--- a/src/test/compile-fail/issue-14084.rs
+++ b/src/test/compile-fail/issue-14084.rs
@@ -8,9 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(box_syntax)]
+#![feature(placement_in_syntax)]
 
 fn main() {
-    box ( () ) 0;
-    //~^ ERROR: only the managed heap and exchange heap are currently supported
+    let _bx: Box<_> = box ( () ) 0;
+    //~^ ERROR: the trait `core::ops::Placer<_>` is not implemented for the type `()`
+    //~| ERROR: the trait `core::ops::Placer<_>` is not implemented for the type `()`
 }

--- a/src/test/compile-fail/issue-7364.rs
+++ b/src/test/compile-fail/issue-7364.rs
@@ -14,9 +14,24 @@ use std::cell::RefCell;
 
 // Regression test for issue 7364
 static boxed: Box<RefCell<isize>> = box RefCell::new(0);
-//~^ ERROR allocations are not allowed in statics
+//~^ ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
 //~| ERROR the trait `core::marker::Sync` is not implemented for the type
 //~| ERROR the trait `core::marker::Sync` is not implemented for the type
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
 //~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR references in statics may only refer to immutable values
 
 fn main() { }

--- a/src/test/compile-fail/lint-owned-heap-memory.rs
+++ b/src/test/compile-fail/lint-owned-heap-memory.rs
@@ -11,6 +11,7 @@
 #![allow(dead_code)]
 #![forbid(box_pointers)]
 #![feature(box_syntax)]
+#![feature(core)]
 
 struct Foo {
     x: Box<isize> //~ ERROR type uses owned
@@ -19,4 +20,7 @@ struct Foo {
 fn main() {
     let _x : Foo = Foo {x : box 10};
     //~^ ERROR type uses owned
+    //~| ERROR type uses owned
+    //~| ERROR type uses owned
+    //~| ERROR type uses owned
 }

--- a/src/test/compile-fail/occurs-check-2.rs
+++ b/src/test/compile-fail/occurs-check-2.rs
@@ -11,12 +11,21 @@
 #![feature(box_syntax)]
 
 fn main() {
-    let f;
+    let f: Box<_>;
     let g;
     g = f;
     f = box g;
-    //~^  ERROR mismatched types
-    //~| expected `_`
-    //~| found `Box<_>`
-    //~| cyclic type of infinite size
+    //~^ ERROR the trait `core::ops::Place<Box<_>>` is not implemented for the type
+
+    // (At one time, we produced a nicer error message like below.
+    //  but right now, the desugaring produces the above error instead
+    //  for the cyclic type here; its especially unfortunate because
+    //  printed error leaves out the information necessary for one to
+    //  deduce that the necessary type for the given impls *is*
+    //  cyclic.)
+    //
+    // ^  ERROR mismatched types
+    // | expected `_`
+    // | found `Box<_>`
+    // | cyclic type of infinite size
 }

--- a/src/test/compile-fail/occurs-check.rs
+++ b/src/test/compile-fail/occurs-check.rs
@@ -11,10 +11,19 @@
 #![feature(box_syntax)]
 
 fn main() {
-    let f;
+    let f: Box<_>;
     f = box f;
-    //~^ ERROR mismatched types
-    //~| expected `_`
-    //~| found `Box<_>`
-    //~| cyclic type of infinite size
+    //~^ ERROR the trait `core::ops::Place<Box<_>>` is not implemented for the type
+
+    // (At one time, we produced a nicer error message like below.
+    //  but right now, the desugaring produces the above error instead
+    //  for the cyclic type here; its especially unfortunate because
+    //  printed error leaves out the information necessary for one to
+    //  deduce that the necessary type for the given impls *is*
+    //  cyclic.)
+    //
+    // ^ ERROR mismatched types
+    // | expected `_`
+    // | found `Box<_>`
+    // | cyclic type of infinite size
 }

--- a/src/test/compile-fail/static-mut-not-constant.rs
+++ b/src/test/compile-fail/static-mut-not-constant.rs
@@ -11,7 +11,23 @@
 #![feature(box_syntax)]
 
 static mut a: Box<isize> = box 3;
-//~^ ERROR allocations are not allowed in statics
-//~^^ ERROR mutable statics are not allowed to have owned pointers
+//~^ ERROR mutable statics are not allowed to have owned pointers
+//~| ERROR statics are not allowed to have destructors
+//^| ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR references in statics may only refer to immutable values
 
 fn main() {}

--- a/src/test/debuginfo/box.rs
+++ b/src/test/debuginfo/box.rs
@@ -32,11 +32,14 @@
 
 #![allow(unused_variables)]
 #![feature(box_syntax)]
+#![feature(placement_in_syntax)]
 #![omit_gdb_pretty_printer_section]
 
+use std::boxed::HEAP;
+
 fn main() {
-    let a = box 1;
-    let b = box() (2, 3.5f64);
+    let a: Box<_> = box 1;
+    let b = in HEAP { (2, 3.5f64) };
 
     zzz(); // #break
 }

--- a/src/test/parse-fail/parenthesized-box-expr-message.rs
+++ b/src/test/parse-fail/parenthesized-box-expr-message.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 fn main() {
-    box(1 + 1) //~ HELP perhaps you meant `box() (foo)` instead?
+    box(1 + 1) //~ HELP perhaps you meant `in <place> { <expr> }` instead?
     ; //~ ERROR expected expression, found `;`
 }

--- a/src/test/run-pass/alignment-gep-tup-like-1.rs
+++ b/src/test/run-pass/alignment-gep-tup-like-1.rs
@@ -31,10 +31,11 @@ impl<A:Clone> Invokable<A> for Invoker<A> {
 }
 
 fn f<A:Clone + 'static>(a: A, b: u16) -> Box<Invokable<A>+'static> {
-    box Invoker {
+    // FIXME(22450): workaround pretty-printer deficiency via parens.
+    (box Invoker {
         a: a,
         b: b,
-    } as (Box<Invokable<A>+'static>)
+    }) as (Box<Invokable<A>+'static>)
 }
 
 pub fn main() {

--- a/src/test/run-pass/close-over-big-then-small-data.rs
+++ b/src/test/run-pass/close-over-big-then-small-data.rs
@@ -35,10 +35,11 @@ impl<A:Clone> Invokable<A> for Invoker<A> {
 }
 
 fn f<A:Clone + 'static>(a: A, b: u16) -> Box<Invokable<A>+'static> {
-    box Invoker {
+    // FIXME(22450): workaround pretty-printer deficiency via parens.
+    (box Invoker {
         a: a,
         b: b,
-    } as (Box<Invokable<A>+'static>)
+    }) as (Box<Invokable<A>+'static>)
 }
 
 pub fn main() {

--- a/src/test/run-pass/drop-struct-as-object.rs
+++ b/src/test/run-pass/drop-struct-as-object.rs
@@ -14,7 +14,13 @@
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 
-static mut value: uint = 0;
+mod s {
+    // FIXME(22181,22462) workaround hygiene issues between box
+    // desugaring, macro-hygiene (or lack thereof) and static bindings
+    // by forcing the static binding `value` into its own module.
+
+    pub static mut value: uint = 0;
+}
 
 struct Cat {
     name : uint,
@@ -30,7 +36,7 @@ impl Dummy for Cat {
 
 impl Drop for Cat {
     fn drop(&mut self) {
-        unsafe { value = self.name; }
+        unsafe { s::value = self.name; }
     }
 }
 
@@ -40,6 +46,6 @@ pub fn main() {
         let nyan: Box<Dummy> = x as Box<Dummy>;
     }
     unsafe {
-        assert_eq!(value, 22);
+        assert_eq!(s::value, 22);
     }
 }

--- a/src/test/run-pass/issue-2734.rs
+++ b/src/test/run-pass/issue-2734.rs
@@ -17,7 +17,8 @@ trait hax {
 impl<A> hax for A { }
 
 fn perform_hax<T: 'static>(x: Box<T>) -> Box<hax+'static> {
-    box x as Box<hax+'static>
+    // FIXME(22450): workaround pretty-printer deficiency via parens.
+    (box x) as Box<hax+'static>
 }
 
 fn deadcode() {

--- a/src/test/run-pass/issue-2735.rs
+++ b/src/test/run-pass/issue-2735.rs
@@ -17,7 +17,8 @@ trait hax {
 impl<A> hax for A { }
 
 fn perform_hax<T: 'static>(x: Box<T>) -> Box<hax+'static> {
-    box x as Box<hax+'static>
+    // FIXME(22450): workaround pretty-printer deficiency via parens.
+    (box x) as Box<hax+'static>
 }
 
 fn deadcode() {

--- a/src/test/run-pass/issue-7673-cast-generically-implemented-trait.rs
+++ b/src/test/run-pass/issue-7673-cast-generically-implemented-trait.rs
@@ -26,4 +26,5 @@ trait A {
 impl<T: 'static> A for T {}
 
 fn owned2<T: 'static>(a: Box<T>) { a as Box<A>; }
-fn owned3<T: 'static>(a: Box<T>) { box a as Box<A>; }
+// FIXME(22450): workaround pretty-printer deficiency via parens.
+fn owned3<T: 'static>(a: Box<T>) { (box a) as Box<A>; }

--- a/src/test/run-pass/kindck-owned-trait-contains-1.rs
+++ b/src/test/run-pass/kindck-owned-trait-contains-1.rs
@@ -20,7 +20,8 @@ impl<A:Clone + 'static> repeat<A> for Box<A> {
 }
 
 fn repeater<A:Clone + 'static>(v: Box<A>) -> Box<repeat<A>+'static> {
-    box v as Box<repeat<A>+'static> // No
+    // FIXME(22450): workaround pretty-printer deficiency via parens.
+    (box v) as Box<repeat<A>+'static> // No
 }
 
 pub fn main() {

--- a/src/test/run-pass/new-box-syntax.rs
+++ b/src/test/run-pass/new-box-syntax.rs
@@ -13,6 +13,7 @@
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]
+#![feature(placement_in_syntax)]
 
 // Tests that the new `box` syntax works with unique pointers.
 
@@ -24,8 +25,8 @@ struct Structure {
 }
 
 pub fn main() {
-    let x: Box<int> = box(HEAP) 2;
+    let x: Box<int> = in HEAP { 2 };
     let y: Box<int> = box 2;
-    let b: Box<int> = box()(1 + 2);
-    let c = box()(3 + 4);
+    let b: Box<int> = box () (1 + 2);
+    let c: Box<_> = box () (3 + 4);
 }

--- a/src/test/run-pass/regions-close-over-type-parameter-successfully.rs
+++ b/src/test/run-pass/regions-close-over-type-parameter-successfully.rs
@@ -23,7 +23,8 @@ impl<'a> SomeTrait for &'a int {
 }
 
 fn make_object<'a,A:SomeTrait+'a>(v: A) -> Box<SomeTrait+'a> {
-    box v as Box<SomeTrait+'a>
+    // FIXME(22450): workaround pretty-printer deficiency via parens.
+    (box v) as Box<SomeTrait+'a>
 }
 
 fn main() {

--- a/src/test/run-pass/regions-early-bound-trait-param.rs
+++ b/src/test/run-pass/regions-early-bound-trait-param.rs
@@ -81,7 +81,8 @@ impl<'s> Trait<'s> for (int,int) {
 }
 
 impl<'t> MakerTrait for Box<Trait<'t>+'static> {
-    fn mk() -> Box<Trait<'t>+'static> { box() (4,5) as Box<Trait> }
+    // FIXME(22450): workaround pretty-printer deficiency via parens.
+    fn mk() -> Box<Trait<'t>+'static> { (box() (4,5)) as Box<Trait> }
 }
 
 enum List<'l> {


### PR DESCRIPTION
This is a bootstrapping illustration of the new box prototype.  The main point is to illustrate the fallout that occurs with the compiler type inference as it (nearly) stands today.  (Note that much of that fallout has now landed in PR #23002.)

This PR is a revised version of PR #22006, building upon PR #22012 to remove much (but certainly not all) of the fallout observed there.

Now most of the fallout in this PR is from where `box <expr>` was being used in contexts that are implicitly coerced to `Box<Trait>`, which is not compatible with the new box protocol (at least, not yet), since the use of coercion there subverts the box-protocol's attempt to infer the appropriate boxed-type to create.  (This is noted at [this comment](https://github.com/rust-lang/rfcs/pull/809#issuecomment-73335012) on the RFC.)
- [Here is a self-contained gist](https://gist.github.com/pnkfelix/abee2f0cbdca677b6f01), runnable in the playpen, that demonstrates the issue (though note the `cfg(works)` only actually "works" atop PR #22012), with method names that reflect where I originally found in this in the `libsyntax` crate.
- And [here is a second gist](https://gist.github.com/pnkfelix/ab38c798aecaeaf48e57) that is a bit more narrowly focused on the `impl` I found of `Default for Box<[T]>`, which may or may not be an instance of the same problem.

For now, I am usually getting around this by using `Box::new(..)`;
- it is worth noting that `in HEAP { <expr> }` can often fix such cases, but not always;
- `Box::new(<expr>)` always works, though it may introduce an intermediate copy that could have been otherwise avoided.

---

see also https://github.com/rust-lang/rfcs/pull/809 (which is now merged as of this (updated) writing).

---

oh, and 

[breaking-change]
