### PR TITLE
Make Int::pow() take exp as u32 instead usize

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -372,9 +372,10 @@ pub trait Int
     #[unstable(feature = "core",
                reason = "pending integer conventions")]
     #[inline]
-    fn pow(self, mut exp: uint) -> Self {
+    fn pow(self, mut exp: u32) -> Self {
         let mut base = self;
         let mut acc: Self = Int::one();
+
         while exp > 0 {
             if (exp & 1) == 1 {
                 acc = acc * base;

--- a/src/libcoretest/num/int_macros.rs
+++ b/src/libcoretest/num/int_macros.rs
@@ -201,6 +201,17 @@ mod tests {
         assert_eq!(FromStrRadix::from_str_radix("Z", 35).ok(), None::<$T>);
         assert_eq!(FromStrRadix::from_str_radix("-9", 2).ok(), None::<$T>);
     }
+
+    #[test]
+    fn test_pow() {
+        let mut r = 2 as $T;
+
+        assert_eq!(r.pow(2u32), 4 as $T);
+        assert_eq!(r.pow(0u32), 1 as $T);
+        r = -2 as $T;
+        assert_eq!(r.pow(2u32), 4 as $T);
+        assert_eq!(r.pow(3u32), -8 as $T);
+    }
 }
 
 )}

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -1830,6 +1830,6 @@ mod bench {
     #[bench]
     fn bench_pow_function(b: &mut Bencher) {
         let v = (0..1024).collect::<Vec<_>>();
-        b.iter(|| {v.iter().fold(0, |old, new| old.pow(*new));});
+        b.iter(|| {v.iter().fold(0, |old, new| old.pow(*new as u32));});
     }
 }

--- a/src/test/bench/shootout-binarytrees.rs
+++ b/src/test/bench/shootout-binarytrees.rs
@@ -109,7 +109,7 @@ fn main() {
 
     let messages = range_step(min_depth, max_depth + 1, 2).map(|depth| {
         use std::num::Int;
-        let iterations = 2.pow((max_depth - depth + min_depth) as usize);
+        let iterations = 2.pow((max_depth - depth + min_depth) as u32);
         thread::scoped(move || inner(depth, iterations))
     }).collect::<Vec<_>>();
 


### PR DESCRIPTION
Fixes issue #22016
