### PR TITLE
adapt run-make test suite for openbsd

### DIFF
--- a/src/test/run-make/c-link-to-rust-staticlib/Makefile
+++ b/src/test/run-make/c-link-to-rust-staticlib/Makefile
@@ -1,9 +1,7 @@
 -include ../tools.mk
 
 ifndef IS_WINDOWS
-ifneq ($(shell uname),Darwin)
-	EXTRAFLAGS := -lm -lrt -ldl -lpthread
-endif
+EXTRAFLAGS := $(EXTRACFLAGS)
 endif
 
 # FIXME: ignore freebsd

--- a/src/test/run-make/no-stack-check/Makefile
+++ b/src/test/run-make/no-stack-check/Makefile
@@ -1,6 +1,7 @@
 -include ../tools.mk
 
 ifndef IS_WINDOWS
+ifneq ($(UNAME),OpenBSD)
 all:
 	$(RUSTC) -O --emit asm attr.rs
 	! grep -q morestack $(TMPDIR)/attr.s
@@ -8,6 +9,10 @@ all:
 	grep -q morestack $(TMPDIR)/flag.s
 	$(RUSTC) -O --emit asm -C no-stack-check flag.rs
 	! grep -q morestack $(TMPDIR)/flag.s
+else
+# On OpenBSD, morestack isn't used as the segmented stacks are disabled
+all:
+endif
 else
 # On Windows we use __chkstk and it only appears in functions with large allocations,
 # so this test wouldn't be reliable.

--- a/src/test/run-make/symbols-are-reasonable/Makefile
+++ b/src/test/run-make/symbols-are-reasonable/Makefile
@@ -10,6 +10,6 @@ OUT=$(TMPDIR)/lib.s
 all:
 	$(RUSTC) lib.rs --emit=asm --crate-type=staticlib
 	# just check for symbol declarations with the names we're expecting.
-	grep 'str[0-9]\+:' $(OUT)
-	grep 'binary[0-9]\+:' $(OUT)
-	grep 'vtable[0-9]\+' $(OUT)
+	grep 'str[0-9][0-9]*:' $(OUT)
+	grep 'binary[0-9][0-9]*:' $(OUT)
+	grep 'vtable[0-9][0-9]*' $(OUT)

--- a/src/test/run-make/target-specs/Makefile
+++ b/src/test/run-make/target-specs/Makefile
@@ -1,11 +1,11 @@
 -include ../tools.mk
 all:
 	$(RUSTC) foo.rs --target=my-awesome-platform.json --crate-type=lib --emit=asm
-	grep --quiet --invert-match morestack < $(TMPDIR)/foo.s
+	grep -q -v morestack < $(TMPDIR)/foo.s
 	$(RUSTC) foo.rs --target=my-invalid-platform.json 2>&1 | grep --quiet "Error loading target specification"
 	$(RUSTC) foo.rs --target=my-incomplete-platform.json 2>&1 | grep 'Field llvm-target'
 	RUST_TARGET_PATH=. $(RUSTC) foo.rs --target=my-awesome-platform --crate-type=lib --emit=asm
 	RUST_TARGET_PATH=. $(RUSTC) foo.rs --target=x86_64-unknown-linux-gnu --crate-type=lib --emit=asm
 	# The built-in target *should* override the one we have here, and thus we
 	# should have morestack
-	grep --quiet morestack < $(TMPDIR)/foo.s
+	grep -q morestack < $(TMPDIR)/foo.s

--- a/src/test/run-make/use-extern-for-plugins/Makefile
+++ b/src/test/run-make/use-extern-for-plugins/Makefile
@@ -1,5 +1,6 @@
 -include ../tools.mk
 
+ifneq ($(UNAME),OpenBSD)
 HOST := $(shell $(RUSTC) -vV | grep 'host:' | sed 's/host: //')
 ifeq ($(findstring i686,$(HOST)),i686)
 TARGET := $(subst i686,x86_64,$(HOST))
@@ -11,3 +12,7 @@ all:
 	$(RUSTC) foo.rs -C extra-filename=-host
 	$(RUSTC) bar.rs -C extra-filename=-targ --target $(TARGET)
 	$(RUSTC) baz.rs --extern a=$(TMPDIR)/liba-targ.rlib --target $(TARGET)
+else
+# OpenBSD support only x86_64 architecture for now
+all:
+endif


### PR DESCRIPTION
- c-link-to-rust-staticlib: use `EXTRACFLAGS` defined by tools.mk for
  choose the good libraries to link to.

tools.mk define a variable `EXTRACFLAGS` that contains the needed library per target. So it is better to use it, instead of duplicate the code here. I keep the `ifndef IS_WINDOWS` has tools.mk define something for WINDOWS... so I don't change things that I couldn't test.
- no-stack-check: disabled for openbsd (no segmented stacks here)
- symbols-are-reasonable: use portable grep pattern
- target-specs: use POSIX form for options when invoking grep
- use-extern-for-plugins: disable as OpenBSD only support x86_64 for now
