### PR TITLE
Rename Show to Debug, String to Display

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2354,8 +2354,8 @@ Supported traits for `derive` are:
 * `FromPrimitive`, to create an instance from a numeric primitive.
 * `Hash`, to iterate over the bytes in a data type.
 * `Rand`, to create a random instance of a data type.
-* `Show`, to format a value using the `{}` formatter.
-* `Zero`, to create a zero instance of a numeric data type.
+* `Debug`, to format a value using the `{:?}` formatter.
+* `Copy`, for "Plain Old Data" types which can be copied by simply moving bits.
 
 ### Compiler Features
 

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -27,7 +27,7 @@
 //! # Examples
 //!
 //! Consider a situation where we want to log out a value passed to a function.
-//! We know the value we're working on implements Show, but we don't know its
+//! We know the value we're working on implements Debug, but we don't know its
 //! concrete type.  We want to give special treatment to certain types: in this
 //! case printing out the length of String values prior to their value.
 //! We don't know the concrete type of our value at compile time, so we need to

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -195,7 +195,7 @@ pub struct Matches {
 }
 
 /// The type returned when the command line does not conform to the
-/// expected format. Use the `Show` implementation to output detailed
+/// expected format. Use the `Debug` implementation to output detailed
 /// information.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Fail {
@@ -545,7 +545,7 @@ impl Fail {
     /// Convert a `Fail` enum into an error string.
     #[unstable(feature = "rustc_private")]
     #[deprecated(since = "1.0.0",
-                 reason = "use `fmt::String` (`{}` format specifier)")]
+                 reason = "use `fmt::Display` (`{}` format specifier)")]
     pub fn to_err_msg(self) -> String {
         self.to_string()
     }
@@ -579,7 +579,7 @@ impl fmt::Display for Fail {
 /// `opt_str`, etc. to interrogate results.
 /// # Panics
 ///
-/// Returns `Err(Fail)` on failure: use the `Show` implementation of `Fail` to display
+/// Returns `Err(Fail)` on failure: use the `Debug` implementation of `Fail` to display
 /// information about it.
 pub fn getopts(args: &[String], optgrps: &[OptGroup]) -> Result {
     let opts: Vec<Opt> = optgrps.iter().map(|x| x.long_to_short()).collect();

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -70,7 +70,7 @@ use arena::TypedArena;
 use std::borrow::{BorrowFrom, Cow};
 use std::cell::{Cell, RefCell};
 use std::cmp;
-use std::fmt::{self, Show};
+use std::fmt;
 use std::hash::{Hash, Writer, SipHasher, Hasher};
 use std::mem;
 use std::ops;

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -10,7 +10,7 @@
 
 //! HTML formatting module
 //!
-//! This module contains a large number of `fmt::String` implementations for
+//! This module contains a large number of `fmt::Display` implementations for
 //! various types in `rustdoc::clean`. These implementations all currently
 //! assume that HTML output is desired, although it may be possible to redesign
 //! them in the future to instead emit any format desired.

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1032,7 +1032,7 @@ pub fn as_pretty_json<T>(t: &T) -> AsPrettyJson<T> {
 
 impl Json {
     /// Borrow this json object as a pretty object to generate a pretty
-    /// representation for it via `Show`.
+    /// representation for it via `Display`.
     pub fn pretty(&self) -> PrettyJson {
         PrettyJson { inner: self }
     }
@@ -3540,7 +3540,7 @@ mod tests {
     fn test_hashmap_with_enum_key() {
         use std::collections::HashMap;
         use json;
-        #[derive(RustcEncodable, Eq, Hash, PartialEq, RustcDecodable, Show)]
+        #[derive(RustcEncodable, Eq, Hash, PartialEq, RustcDecodable, Debug)]
         enum Enum {
             Foo,
             #[allow(dead_code)]

--- a/src/libstd/old_path/mod.rs
+++ b/src/libstd/old_path/mod.rs
@@ -228,7 +228,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// ```
     fn into_vec(self) -> Vec<u8>;
 
-    /// Returns an object that implements `Show` for printing paths
+    /// Returns an object that implements `Display` for printing paths
     ///
     /// # Example
     ///
@@ -244,7 +244,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
         Display{ path: self, filename: false }
     }
 
-    /// Returns an object that implements `Show` for printing filenames
+    /// Returns an object that implements `Display` for printing filenames
     ///
     /// If there is no filename, nothing will be printed.
     ///

--- a/src/libstd/sys/windows/os.rs
+++ b/src/libstd/sys/windows/os.rs
@@ -191,7 +191,7 @@ impl<'a> Iterator for SplitPaths<'a> {
     }
 }
 
-#[derive(Show)]
+#[derive(Debug)]
 pub struct JoinPathsError;
 
 pub fn join_paths<I, T>(paths: I) -> Result<OsString, JoinPathsError>

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -64,7 +64,6 @@ use parse::token;
 use ptr::P;
 
 use std::fmt;
-use std::fmt::Show;
 use std::num::Int;
 use std::rc::Rc;
 use serialize::{Encodable, Decodable, Encoder, Decoder};


### PR DESCRIPTION
Rename several remaining `Show`s to Debug, `String`s to Display (mostly in comments and docs).
Update reference.md:
- derive() no longer supports Zero trait
- derive() now supports Copy trait
