### PR TITLE
Make docs fallback font 'serif', rather than 'sans-serif'

### DIFF
--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -58,7 +58,7 @@
 body {
     margin: 0 auto;
     padding: 0 15px;
-    font-family: "Source Serif Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: "Source Serif Pro", Georgia, Times, "Times New Roman", serif;
     font-size: 18px;
     color: #333;
     line-height: 1.428571429;

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -64,7 +64,7 @@
 
 body {
     color: #333;
-    font: 16px/1.4 "Source Serif Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font: 16px/1.4 "Source Serif Pro", Georgia, Times, "Times New Roman", serif;
     margin: 0;
     position: relative;
     padding: 10px 15px 20px 15px;


### PR DESCRIPTION
The fallback font for a serif font should also be serif, not sans serif.
