### PR TITLE
Include "flatmap" in docs of Option::and_then

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -605,6 +605,8 @@ impl<T> Option<T> {
     /// Returns `None` if the option is `None`, otherwise calls `f` with the
     /// wrapped value and returns the result.
     ///
+    /// Some languages call this operation flatmap.
+    ///
     /// # Example
     ///
     /// ```


### PR DESCRIPTION
Some newcomers might look for a "flatMap" method on Option. Include the
reference so that searching the page would find "and_then".
