### PR TITLE
std: Display primitive documentation for char

### DIFF
--- a/src/libunicode/lib.rs
+++ b/src/libunicode/lib.rs
@@ -62,6 +62,7 @@ mod u_str;
 /// however the converse is not always true due to the above range limits
 /// and, as such, should be performed via the `from_u32` function..
 #[stable(feature = "rust1", since = "1.0.0")]
+#[doc(primitive = "char")]
 pub mod char {
     pub use core::char::{MAX, from_u32, from_digit};
 


### PR DESCRIPTION
This ended up just being a forgotten attribute on the `char` module in
libunicode.

Closes #22084
