### PR TITLE
Deduplicate --crate-type arguments

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1061,7 +1061,9 @@ pub fn parse_crate_types_from_list(list_list: Vec<String>) -> Result<Vec<CrateTy
                                        part));
                 }
             };
-            crate_types.push(new_part)
+            if !crate_types.contains(&new_part) {
+                crate_types.push(new_part)
+            }
         }
     }
 

--- a/src/test/run-make/duplicate-output-flavors/Makefile
+++ b/src/test/run-make/duplicate-output-flavors/Makefile
@@ -2,3 +2,4 @@ include ../tools.mk
 
 all:
 	$(RUSTC) --crate-type=rlib foo.rs
+	$(RUSTC) --crate-type=rlib,rlib foo.rs


### PR DESCRIPTION
Crate types from multiple sources appear to be deduplicated properly, but not
deduplicated if they come from the command line arguments. At worst, this used
to cause compiler failures when `--crate-type=lib,rlib` (the same as
`--crate-type=rlib,rlib`, at least at the time of this commit) is provided and
generate the output multiple times otherwise.

r? @alexcrichton 
