### PR TITLE
Return nonzero exit code if there are errors at a stop point

### DIFF
--- a/src/test/compile-fail/mod_file_disambig.rs
+++ b/src/test/compile-fail/mod_file_disambig.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 mod mod_file_disambig_aux; //~ ERROR file for module `mod_file_disambig_aux` found at both
 
 fn main() {

--- a/src/test/compile-fail/mod_file_not_owning.rs
+++ b/src/test/compile-fail/mod_file_not_owning.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern: cannot declare a new module at this location
 
 mod mod_file_not_owning_aux1;

--- a/src/test/parse-fail/array-old-syntax-1.rs
+++ b/src/test/parse-fail/array-old-syntax-1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Test that the old fixed length array syntax is a parsing error.
 
 fn main() {

--- a/src/test/parse-fail/ascii-only-character-escape.rs
+++ b/src/test/parse-fail/ascii-only-character-escape.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     let x = "\x80"; //~ ERROR may only be used
     let y = "\xff"; //~ ERROR may only be used

--- a/src/test/parse-fail/associated-types-project-from-hrtb-explicit.rs
+++ b/src/test/parse-fail/associated-types-project-from-hrtb-explicit.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Test you can't use a higher-ranked trait bound inside of a qualified
 // path (just won't parse).
 

--- a/src/test/parse-fail/attr-bad-meta.rs
+++ b/src/test/parse-fail/attr-bad-meta.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern:expected `]`
 
 // asterisk is bogus

--- a/src/test/parse-fail/attr-before-eof.rs
+++ b/src/test/parse-fail/attr-before-eof.rs
@@ -8,4 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 #[derive(Debug)] //~ERROR expected item after attributes

--- a/src/test/parse-fail/attr-before-ext.rs
+++ b/src/test/parse-fail/attr-before-ext.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     #[attr] //~ ERROR expected item after attributes
     println!("hi");

--- a/src/test/parse-fail/attr-before-let.rs
+++ b/src/test/parse-fail/attr-before-let.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     #[attr] //~ ERROR expected item
     let __isize = 0;

--- a/src/test/parse-fail/attr-before-stmt.rs
+++ b/src/test/parse-fail/attr-before-stmt.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern:expected item
 
 fn f() {

--- a/src/test/parse-fail/attr-dangling-in-fn.rs
+++ b/src/test/parse-fail/attr-dangling-in-fn.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern:expected item
 
 fn f() {

--- a/src/test/parse-fail/attr-dangling-in-mod.rs
+++ b/src/test/parse-fail/attr-dangling-in-mod.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern:expected item
 
 fn main() {

--- a/src/test/parse-fail/attr.rs
+++ b/src/test/parse-fail/attr.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 #![feature(lang_items)]
 
 fn main() {}

--- a/src/test/parse-fail/attrs-after-extern-mod.rs
+++ b/src/test/parse-fail/attrs-after-extern-mod.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Constants (static variables) can be used to match in patterns, but mutable
 // statics cannot. This ensures that there's some form of error if this is
 // attempted.

--- a/src/test/parse-fail/bad-char-literals.rs
+++ b/src/test/parse-fail/bad-char-literals.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // ignore-tidy-cr
 // ignore-tidy-tab
 fn main() {

--- a/src/test/parse-fail/bad-lit-suffixes.rs
+++ b/src/test/parse-fail/bad-lit-suffixes.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 
 extern
     "C"suffix //~ ERROR ABI spec with a suffix is illegal

--- a/src/test/parse-fail/bad-match.rs
+++ b/src/test/parse-fail/bad-match.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern: expected
 
 fn main() {

--- a/src/test/parse-fail/bad-name.rs
+++ b/src/test/parse-fail/bad-name.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern: expected
 
 fn main() {

--- a/src/test/parse-fail/bad-value-ident-false.rs
+++ b/src/test/parse-fail/bad-value-ident-false.rs
@@ -8,5 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn false() { } //~ ERROR expected identifier, found keyword `false`
 fn main() { }

--- a/src/test/parse-fail/bad-value-ident-true.rs
+++ b/src/test/parse-fail/bad-value-ident-true.rs
@@ -8,5 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn true() { } //~ ERROR expected identifier, found keyword `true`
 fn main() { }

--- a/src/test/parse-fail/better-expected.rs
+++ b/src/test/parse-fail/better-expected.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     let x: [isize 3]; //~ ERROR expected one of `(`, `+`, `::`, `;`, `<`, or `]`, found `3`
 }

--- a/src/test/parse-fail/bind-struct-early-modifiers.rs
+++ b/src/test/parse-fail/bind-struct-early-modifiers.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     struct Foo { x: isize }
     match (Foo { x: 10 }) {

--- a/src/test/parse-fail/byte-literals.rs
+++ b/src/test/parse-fail/byte-literals.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 
 // ignore-tidy-tab
 

--- a/src/test/parse-fail/byte-string-literals.rs
+++ b/src/test/parse-fail/byte-string-literals.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 
 // ignore-tidy-tab
 

--- a/src/test/parse-fail/circular_modules_hello.rs
+++ b/src/test/parse-fail/circular_modules_hello.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // ignore-test: this is an auxiliary file for circular-modules-main.rs
 
 mod circular_modules_main;

--- a/src/test/parse-fail/circular_modules_main.rs
+++ b/src/test/parse-fail/circular_modules_main.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 #[path = "circular_modules_hello.rs"]
 mod circular_modules_hello; //~ ERROR: circular modules
 

--- a/src/test/parse-fail/class-implements-bad-trait.rs
+++ b/src/test/parse-fail/class-implements-bad-trait.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern:nonexistent
 class cat : nonexistent {
   let meows: usize;

--- a/src/test/parse-fail/column-offset-1-based.rs
+++ b/src/test/parse-fail/column-offset-1-based.rs
@@ -8,4 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-# //~ ERROR 11:1: 11:2 error: expected `[`, found `<eof>`
+// compile-flags: -Z parse-only
+
+# //~ ERROR 13:1: 13:2 error: expected `[`, found `<eof>`

--- a/src/test/parse-fail/doc-before-attr.rs
+++ b/src/test/parse-fail/doc-before-attr.rs
@@ -8,5 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 /// hi
 #[derive(Debug)] //~ERROR expected item after attributes

--- a/src/test/parse-fail/doc-before-eof.rs
+++ b/src/test/parse-fail/doc-before-eof.rs
@@ -8,4 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 /// hi //~ERROR expected item after doc comment

--- a/src/test/parse-fail/doc-before-extern-rbrace.rs
+++ b/src/test/parse-fail/doc-before-extern-rbrace.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 extern {
     /// hi
 }

--- a/src/test/parse-fail/doc-before-macro.rs
+++ b/src/test/parse-fail/doc-before-macro.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     /// hi
     println!("hi");

--- a/src/test/parse-fail/doc-before-rbrace.rs
+++ b/src/test/parse-fail/doc-before-rbrace.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     println!("Hi"); /// hi
     //~^ ERROR expected item after doc comment

--- a/src/test/parse-fail/doc-before-semi.rs
+++ b/src/test/parse-fail/doc-before-semi.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     /// hi
     ;

--- a/src/test/parse-fail/duplicate-visibility.rs
+++ b/src/test/parse-fail/duplicate-visibility.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern:unmatched visibility `pub`
 extern {
     pub pub fn foo();

--- a/src/test/parse-fail/empty-impl-semicolon.rs
+++ b/src/test/parse-fail/empty-impl-semicolon.rs
@@ -8,4 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 impl Foo; //~ ERROR expected one of `(`, `+`, `..`, `::`, `<`, `for`, `where`, or `{`, found `;`

--- a/src/test/parse-fail/extern-expected-fn-or-brace.rs
+++ b/src/test/parse-fail/extern-expected-fn-or-brace.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Verifies that the expected token errors for `extern crate` are
 // raised
 

--- a/src/test/parse-fail/extern-foreign-crate.rs
+++ b/src/test/parse-fail/extern-foreign-crate.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Verifies that the expected token errors for `extern crate` are
 // raised
 

--- a/src/test/parse-fail/extern-no-fn.rs
+++ b/src/test/parse-fail/extern-no-fn.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 extern {
     f(); //~ ERROR expected one of `fn`, `pub`, `static`, `unsafe`, or `}`, found `f`
 }

--- a/src/test/parse-fail/generic-non-trailing-defaults.rs
+++ b/src/test/parse-fail/generic-non-trailing-defaults.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Heap;
 
 struct Vec<A = Heap, T>; //~ ERROR type parameters with a default must be trailing

--- a/src/test/parse-fail/import-from-path.rs
+++ b/src/test/parse-fail/import-from-path.rs
@@ -8,5 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern:expected
 use foo::{bar}::baz

--- a/src/test/parse-fail/import-from-rename.rs
+++ b/src/test/parse-fail/import-from-rename.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern:expected
 
 use foo::{bar} as baz;

--- a/src/test/parse-fail/import-glob-path.rs
+++ b/src/test/parse-fail/import-glob-path.rs
@@ -8,5 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern:expected
 use foo::*::bar

--- a/src/test/parse-fail/import-glob-rename.rs
+++ b/src/test/parse-fail/import-glob-rename.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern:expected
 
 use foo::* as baz;

--- a/src/test/parse-fail/int-literal-too-large-span.rs
+++ b/src/test/parse-fail/int-literal-too-large-span.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // issue #17123
 
 fn main() {

--- a/src/test/parse-fail/issue-10392-2.rs
+++ b/src/test/parse-fail/issue-10392-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct A { foo: isize }
 
 fn a() -> A { panic!() }

--- a/src/test/parse-fail/issue-10392.rs
+++ b/src/test/parse-fail/issue-10392.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct A { foo: isize }
 
 fn a() -> A { panic!() }

--- a/src/test/parse-fail/issue-10412.rs
+++ b/src/test/parse-fail/issue-10412.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 
 trait Serializable<'self, T> { //~ ERROR no longer a special lifetime
     fn serialize(val : &'self T) -> Vec<u8> ; //~ ERROR no longer a special lifetime

--- a/src/test/parse-fail/issue-10636-1.rs
+++ b/src/test/parse-fail/issue-10636-1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Obj { //~ NOTE: unclosed delimiter
     member: usize
 ) //~ ERROR: incorrect close delimiter

--- a/src/test/parse-fail/issue-10636-2.rs
+++ b/src/test/parse-fail/issue-10636-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 pub fn trace_option(option: Option<isize>) {
     option.map(|some| 42; //~ NOTE: unclosed delimiter
 } //~ ERROR: incorrect close delimiter

--- a/src/test/parse-fail/issue-12560-1.rs
+++ b/src/test/parse-fail/issue-12560-1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // For style and consistency reasons, non-parametrized enum variants must
 // be used simply as `ident` instead of `ident ()`.
 // This test-case covers enum declaration.

--- a/src/test/parse-fail/issue-14182.rs
+++ b/src/test/parse-fail/issue-14182.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // ignore-test FIXME(japari) remove test
 
 struct Foo {

--- a/src/test/parse-fail/issue-14303-enum.rs
+++ b/src/test/parse-fail/issue-14303-enum.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 enum X<'a, T, 'b> {
 //~^ ERROR lifetime parameters must be declared prior to type parameters
     A(&'a T)

--- a/src/test/parse-fail/issue-14303-fn-def.rs
+++ b/src/test/parse-fail/issue-14303-fn-def.rs
@@ -8,5 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn foo<'a, T, 'b>(x: &'a T) {}
 //~^ ERROR lifetime parameters must be declared prior to type parameters

--- a/src/test/parse-fail/issue-14303-fncall.rs
+++ b/src/test/parse-fail/issue-14303-fncall.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     (0..4)
     .map(|x| x * 2)

--- a/src/test/parse-fail/issue-14303-impl.rs
+++ b/src/test/parse-fail/issue-14303-impl.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct X { x: isize }
 
 impl<'a, T, 'b> X {}

--- a/src/test/parse-fail/issue-14303-path.rs
+++ b/src/test/parse-fail/issue-14303-path.rs
@@ -8,5 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn bar<'a, T>(x: mymodule::X<'a, T, 'b, 'c>) {}
 //~^ ERROR lifetime parameters must be declared prior to type parameters

--- a/src/test/parse-fail/issue-14303-struct.rs
+++ b/src/test/parse-fail/issue-14303-struct.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct X<'a, T, 'b> {
 //~^ ERROR lifetime parameters must be declared prior to type parameters
     x: &'a T

--- a/src/test/parse-fail/issue-14303-trait.rs
+++ b/src/test/parse-fail/issue-14303-trait.rs
@@ -8,5 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 trait Foo<'a, T, 'b> {}
 //~^ ERROR lifetime parameters must be declared prior to type parameters

--- a/src/test/parse-fail/issue-15914.rs
+++ b/src/test/parse-fail/issue-15914.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     let ref
         (); //~ ERROR expected identifier, found `(`

--- a/src/test/parse-fail/issue-1655.rs
+++ b/src/test/parse-fail/issue-1655.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern:expected `[`, found `vec`
 mod blade_runner {
     #vec[doc(

--- a/src/test/parse-fail/issue-17383.rs
+++ b/src/test/parse-fail/issue-17383.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 enum X {
     A =
         b'a' //~ ERROR discriminator values can only be used with a c-like enum

--- a/src/test/parse-fail/issue-17718-const-mut.rs
+++ b/src/test/parse-fail/issue-17718-const-mut.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 const
 mut //~ ERROR: const globals cannot be mutable
 //~^ HELP did you mean to declare a static?

--- a/src/test/parse-fail/issue-17904.rs
+++ b/src/test/parse-fail/issue-17904.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Baz<U> where U: Eq(U); //This is parsed as the new Fn* style parenthesis syntax.
 struct Baz<U> where U: Eq(U) -> R; // Notice this parses as well.
 struct Baz<U>(U) where U: Eq; // This rightfully signals no error as well.

--- a/src/test/parse-fail/issue-1802-1.rs
+++ b/src/test/parse-fail/issue-1802-1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern:no valid digits found for number
 fn main() {
     log(error, 0b);

--- a/src/test/parse-fail/issue-1802-2.rs
+++ b/src/test/parse-fail/issue-1802-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern:no valid digits found for number
 fn main() {
     log(error, 0b_usize);

--- a/src/test/parse-fail/issue-19096.rs
+++ b/src/test/parse-fail/issue-19096.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     let t = (42, 42);
     t.0::<isize>; //~ ERROR expected one of `.`, `;`, `}`, or an operator, found `::`

--- a/src/test/parse-fail/issue-19398.rs
+++ b/src/test/parse-fail/issue-19398.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 trait T {
     extern "Rust" unsafe fn foo(); //~ ERROR expected `fn`, found `unsafe`
 }

--- a/src/test/parse-fail/issue-20711-2.rs
+++ b/src/test/parse-fail/issue-20711-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Foo;
 
 impl Foo {

--- a/src/test/parse-fail/issue-20711.rs
+++ b/src/test/parse-fail/issue-20711.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Foo;
 
 impl Foo {

--- a/src/test/parse-fail/issue-21153.rs
+++ b/src/test/parse-fail/issue-21153.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 trait MyTrait<T>: Iterator {
     Item = T; //~ ERROR expected one of `extern`, `fn`, `type`, or `unsafe`, found `Item`
 }

--- a/src/test/parse-fail/issue-2354-1.rs
+++ b/src/test/parse-fail/issue-2354-1.rs
@@ -8,4 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 static foo: isize = 2; } //~ ERROR incorrect close delimiter:

--- a/src/test/parse-fail/issue-2354.rs
+++ b/src/test/parse-fail/issue-2354.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn foo() { //~ HELP did you mean to close this delimiter?
   match Some(x) {
       Some(y) { panic!(); }

--- a/src/test/parse-fail/issue-3036.rs
+++ b/src/test/parse-fail/issue-3036.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Testing that semicolon tokens are printed correctly in errors
 
 fn main()

--- a/src/test/parse-fail/issue-5544-a.rs
+++ b/src/test/parse-fail/issue-5544-a.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     let __isize = 18446744073709551616; // 2^64
     //~^ ERROR int literal is too large

--- a/src/test/parse-fail/issue-5544-b.rs
+++ b/src/test/parse-fail/issue-5544-b.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     let __isize = 0xff_ffff_ffff_ffff_ffff;
     //~^ ERROR int literal is too large

--- a/src/test/parse-fail/issue-5806.rs
+++ b/src/test/parse-fail/issue-5806.rs
@@ -13,6 +13,8 @@
 // ignore-openbsd
 // ignore-bitrig
 
+// compile-flags: -Z parse-only
+
 #[path = "../compile-fail"]
 mod foo; //~ ERROR: a directory
 

--- a/src/test/parse-fail/issue-6610.rs
+++ b/src/test/parse-fail/issue-6610.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 trait Foo { fn a() } //~ ERROR expected `;` or `{`, found `}`
 
 fn main() {}

--- a/src/test/parse-fail/issue-8537.rs
+++ b/src/test/parse-fail/issue-8537.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 pub extern
   "invalid-ab_isize" //~ ERROR illegal ABI
 fn foo() {}

--- a/src/test/parse-fail/keyword-abstract.rs
+++ b/src/test/parse-fail/keyword-abstract.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     let abstract = (); //~ ERROR `abstract` is a reserved keyword
 }

--- a/src/test/parse-fail/keyword-as-as-identifier.rs
+++ b/src/test/parse-fail/keyword-as-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py as'
 
 fn main() {

--- a/src/test/parse-fail/keyword-break-as-identifier.rs
+++ b/src/test/parse-fail/keyword-break-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py break'
 
 fn main() {

--- a/src/test/parse-fail/keyword-do-as-identifier.rs
+++ b/src/test/parse-fail/keyword-do-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     let do = "bar"; //~ error: ident
 }

--- a/src/test/parse-fail/keyword-else-as-identifier.rs
+++ b/src/test/parse-fail/keyword-else-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py else'
 
 fn main() {

--- a/src/test/parse-fail/keyword-enum-as-identifier.rs
+++ b/src/test/parse-fail/keyword-enum-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py enum'
 
 fn main() {

--- a/src/test/parse-fail/keyword-extern-as-identifier.rs
+++ b/src/test/parse-fail/keyword-extern-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py extern'
 
 fn main() {

--- a/src/test/parse-fail/keyword-final.rs
+++ b/src/test/parse-fail/keyword-final.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     let final = (); //~ ERROR `final` is a reserved keyword
 }

--- a/src/test/parse-fail/keyword-fn-as-identifier.rs
+++ b/src/test/parse-fail/keyword-fn-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py fn'
 
 fn main() {

--- a/src/test/parse-fail/keyword-for-as-identifier.rs
+++ b/src/test/parse-fail/keyword-for-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py for'
 
 fn main() {

--- a/src/test/parse-fail/keyword-if-as-identifier.rs
+++ b/src/test/parse-fail/keyword-if-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py if'
 
 fn main() {

--- a/src/test/parse-fail/keyword-impl-as-identifier.rs
+++ b/src/test/parse-fail/keyword-impl-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py impl'
 
 fn main() {

--- a/src/test/parse-fail/keyword-let-as-identifier.rs
+++ b/src/test/parse-fail/keyword-let-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py let'
 
 fn main() {

--- a/src/test/parse-fail/keyword-loop-as-identifier.rs
+++ b/src/test/parse-fail/keyword-loop-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py loop'
 
 fn main() {

--- a/src/test/parse-fail/keyword-match-as-identifier.rs
+++ b/src/test/parse-fail/keyword-match-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py match'
 
 fn main() {

--- a/src/test/parse-fail/keyword-mod-as-identifier.rs
+++ b/src/test/parse-fail/keyword-mod-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py mod'
 
 fn main() {

--- a/src/test/parse-fail/keyword-mut-as-identifier.rs
+++ b/src/test/parse-fail/keyword-mut-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py mut'
 
 fn main() {

--- a/src/test/parse-fail/keyword-override.rs
+++ b/src/test/parse-fail/keyword-override.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     let override = (); //~ ERROR `override` is a reserved keyword
 }

--- a/src/test/parse-fail/keyword-priv-as-identifier.rs
+++ b/src/test/parse-fail/keyword-priv-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py priv'
 
 fn main() {

--- a/src/test/parse-fail/keyword-pub-as-identifier.rs
+++ b/src/test/parse-fail/keyword-pub-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py pub'
 
 fn main() {

--- a/src/test/parse-fail/keyword-ref-as-identifier.rs
+++ b/src/test/parse-fail/keyword-ref-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py ref'
 
 fn main() {

--- a/src/test/parse-fail/keyword-return-as-identifier.rs
+++ b/src/test/parse-fail/keyword-return-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py return'
 
 fn main() {

--- a/src/test/parse-fail/keyword-self-as-identifier.rs
+++ b/src/test/parse-fail/keyword-self-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py self'
 
 fn main() {

--- a/src/test/parse-fail/keyword-static-as-identifier.rs
+++ b/src/test/parse-fail/keyword-static-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py static'
 
 fn main() {

--- a/src/test/parse-fail/keyword-struct-as-identifier.rs
+++ b/src/test/parse-fail/keyword-struct-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py struct'
 
 fn main() {

--- a/src/test/parse-fail/keyword-super-as-identifier.rs
+++ b/src/test/parse-fail/keyword-super-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py super'
 
 fn main() {

--- a/src/test/parse-fail/keyword-super.rs
+++ b/src/test/parse-fail/keyword-super.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     let super: isize; //~ ERROR expected identifier, found keyword `super`
 }

--- a/src/test/parse-fail/keyword-trait-as-identifier.rs
+++ b/src/test/parse-fail/keyword-trait-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py trait'
 
 fn main() {

--- a/src/test/parse-fail/keyword-type-as-identifier.rs
+++ b/src/test/parse-fail/keyword-type-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py type'
 
 fn main() {

--- a/src/test/parse-fail/keyword-typeof.rs
+++ b/src/test/parse-fail/keyword-typeof.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     let typeof = (); //~ ERROR `typeof` is a reserved keyword
 }

--- a/src/test/parse-fail/keyword-unsafe-as-identifier.rs
+++ b/src/test/parse-fail/keyword-unsafe-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py unsafe'
 
 fn main() {

--- a/src/test/parse-fail/keyword-use-as-identifier.rs
+++ b/src/test/parse-fail/keyword-use-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py use'
 
 fn main() {

--- a/src/test/parse-fail/keyword-while-as-identifier.rs
+++ b/src/test/parse-fail/keyword-while-as-identifier.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // This file was auto-generated using 'src/etc/generate-keyword-tests.py while'
 
 fn main() {

--- a/src/test/parse-fail/keyword.rs
+++ b/src/test/parse-fail/keyword.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 pub mod break {
     //~^ ERROR expected identifier, found keyword `break`
 }

--- a/src/test/parse-fail/keywords-followed-by-double-colon.rs
+++ b/src/test/parse-fail/keywords-followed-by-double-colon.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     struct::foo();  //~ ERROR expected identifier
     mut::baz(); //~ ERROR expected identifier

--- a/src/test/parse-fail/lex-bad-char-literals.rs
+++ b/src/test/parse-fail/lex-bad-char-literals.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
 static c3: char =
     '\x1' //~ ERROR: numeric character escape is too short
 ;

--- a/src/test/parse-fail/lex-bad-numeric-literals.rs
+++ b/src/test/parse-fail/lex-bad-numeric-literals.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     0o1.0; //~ ERROR: octal float literal is not supported
     0o2f32; //~ ERROR: octal float literal is not supported

--- a/src/test/parse-fail/lex-bad-token.rs
+++ b/src/test/parse-fail/lex-bad-token.rs
@@ -8,4 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 ● //~ ERROR: unknown start of token

--- a/src/test/parse-fail/lex-bare-cr-string-literal-doc-comment.rs
+++ b/src/test/parse-fail/lex-bare-cr-string-literal-doc-comment.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // ignore-tidy-cr
 
 /// doc comment with bare CR: ''

--- a/src/test/parse-fail/lifetime-no-keyword.rs
+++ b/src/test/parse-fail/lifetime-no-keyword.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn foo<'a>(a: &'a isize) { }
 fn bar(a: &'static isize) { }
 fn baz(a: &'let isize) { } //~ ERROR invalid lifetime name

--- a/src/test/parse-fail/lifetime-obsoleted-self.rs
+++ b/src/test/parse-fail/lifetime-obsoleted-self.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn baz(a: &'self isize) { } //~ ERROR invalid lifetime name: 'self is no longer a special lifetime
 
 fn main() { }

--- a/src/test/parse-fail/macro-attribute.rs
+++ b/src/test/parse-fail/macro-attribute.rs
@@ -8,5 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 #[doc = $not_there] //~ error: unexpected token: `$`
 fn main() { }

--- a/src/test/parse-fail/macro-bad-delimiter-ident.rs
+++ b/src/test/parse-fail/macro-bad-delimiter-ident.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     foo! bar < //~ ERROR expected `(` or `{`, found `<`
 }

--- a/src/test/parse-fail/macro-keyword.rs
+++ b/src/test/parse-fail/macro-keyword.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn macro() {  //~ ERROR `macro` is a reserved keyword
 }
 

--- a/src/test/parse-fail/macro-mismatched-delim-brace-paren.rs
+++ b/src/test/parse-fail/macro-mismatched-delim-brace-paren.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     foo! {
         bar, "baz", 1, 2.0

--- a/src/test/parse-fail/macro-mismatched-delim-paren-brace.rs
+++ b/src/test/parse-fail/macro-mismatched-delim-paren-brace.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     foo! (
         bar, "baz", 1, 2.0

--- a/src/test/parse-fail/macros-no-semicolon-items.rs
+++ b/src/test/parse-fail/macros-no-semicolon-items.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 macro_rules! foo()  //~ ERROR semicolon
 
 fn main() {

--- a/src/test/parse-fail/macros-no-semicolon.rs
+++ b/src/test/parse-fail/macros-no-semicolon.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     assert!(1 == 2)
     assert!(3 == 4) //~ ERROR expected one of `.`, `;`, `}`, or an operator, found `assert`

--- a/src/test/parse-fail/match-arrows-block-then-binop.rs
+++ b/src/test/parse-fail/match-arrows-block-then-binop.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
 
     match 0 {

--- a/src/test/parse-fail/match-vec-invalid.rs
+++ b/src/test/parse-fail/match-vec-invalid.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     let a = Vec::new();
     match a {

--- a/src/test/parse-fail/mod_file_not_exist.rs
+++ b/src/test/parse-fail/mod_file_not_exist.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
 //~^ HELP name the file either not_a_real_file.rs or not_a_real_file/mod.rs inside the directory
 

--- a/src/test/parse-fail/mod_file_with_path_attr.rs
+++ b/src/test/parse-fail/mod_file_with_path_attr.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 #[path = "not_a_real_file.rs"]
 mod m; //~ ERROR not_a_real_file.rs
 

--- a/src/test/parse-fail/multitrait.rs
+++ b/src/test/parse-fail/multitrait.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct S {
  y: isize
 }

--- a/src/test/parse-fail/mut-patterns.rs
+++ b/src/test/parse-fail/mut-patterns.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Can't put mut in non-ident pattern
 
 pub fn main() {

--- a/src/test/parse-fail/new-unicode-escapes-1.rs
+++ b/src/test/parse-fail/new-unicode-escapes-1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 pub fn main() {
     let s = "\u{2603"; //~ ERROR unterminated unicode escape (needed a `}`)
 }

--- a/src/test/parse-fail/new-unicode-escapes-2.rs
+++ b/src/test/parse-fail/new-unicode-escapes-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 pub fn main() {
     let s = "\u{260311111111}"; //~ ERROR overlong unicode escape (can have at most 6 hex digits)
 }

--- a/src/test/parse-fail/new-unicode-escapes-3.rs
+++ b/src/test/parse-fail/new-unicode-escapes-3.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 pub fn main() {
     let s = "\u{d805}"; //~ ERROR illegal unicode character escape
 }

--- a/src/test/parse-fail/new-unicode-escapes-4.rs
+++ b/src/test/parse-fail/new-unicode-escapes-4.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 pub fn main() {
     let s = "\u{lol}";
      //~^ ERROR illegal character in unicode escape: l

--- a/src/test/parse-fail/no-binary-float-literal.rs
+++ b/src/test/parse-fail/no-binary-float-literal.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern:binary float literal is not supported
 
 fn main() {

--- a/src/test/parse-fail/no-hex-float-literal.rs
+++ b/src/test/parse-fail/no-hex-float-literal.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern:hexadecimal float literal is not supported
 
 fn main() {

--- a/src/test/parse-fail/no-unsafe-self.rs
+++ b/src/test/parse-fail/no-unsafe-self.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 trait A {
     fn foo(*mut self); //~ ERROR cannot pass self by unsafe pointer
     fn bar(*self); //~ ERROR cannot pass self by unsafe pointer

--- a/src/test/parse-fail/non-str-meta.rs
+++ b/src/test/parse-fail/non-str-meta.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Issue #623 - non-string meta items are not serialized correctly;
 // for now just forbid them
 

--- a/src/test/parse-fail/not-a-pred.rs
+++ b/src/test/parse-fail/not-a-pred.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // error-pattern: lt
 
 fn f(a: isize, b: isize) : lt(a, b) { }

--- a/src/test/parse-fail/obsolete-proc.rs
+++ b/src/test/parse-fail/obsolete-proc.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Test that we generate obsolete syntax errors around usages of `proc`.
 
 fn foo(p: proc()) { } //~ ERROR `proc` is a reserved keyword

--- a/src/test/parse-fail/omitted-arg-in-item-fn.rs
+++ b/src/test/parse-fail/omitted-arg-in-item-fn.rs
@@ -8,5 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn foo(x) { //~ ERROR expected one of `:` or `@`, found `)`
 }

--- a/src/test/parse-fail/paamayim-nekudotayim.rs
+++ b/src/test/parse-fail/paamayim-nekudotayim.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // http://phpsadness.com/sad/1
 
 fn main() {

--- a/src/test/parse-fail/parenthesized-box-expr-message.rs
+++ b/src/test/parse-fail/parenthesized-box-expr-message.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn main() {
     box(1 + 1) //~ HELP perhaps you meant `box() (foo)` instead?
     ; //~ ERROR expected expression, found `;`

--- a/src/test/parse-fail/pat-range-bad-dots.rs
+++ b/src/test/parse-fail/pat-range-bad-dots.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 pub fn main() {
     match 22 {
         0 .. 3 => {} //~ ERROR expected one of `...`, `=>`, `if`, or `|`, found `..`

--- a/src/test/parse-fail/pat-ref-enum.rs
+++ b/src/test/parse-fail/pat-ref-enum.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn matcher(x: Option<isize>) {
     match x {
       ref Some(i) => {} //~ ERROR expected identifier, found enum pattern

--- a/src/test/parse-fail/qquote-1.rs
+++ b/src/test/parse-fail/qquote-1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // ignore-test Can't use syntax crate here
 
 #![feature(quote)]

--- a/src/test/parse-fail/qquote-2.rs
+++ b/src/test/parse-fail/qquote-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // ignore-test Can't use syntax crate here
 
 #![feature(quote)]

--- a/src/test/parse-fail/range-3.rs
+++ b/src/test/parse-fail/range-3.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Test range syntax - syntax errors.
 
 pub fn main() {

--- a/src/test/parse-fail/range-4.rs
+++ b/src/test/parse-fail/range-4.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Test range syntax - syntax errors.
 
 pub fn main() {

--- a/src/test/parse-fail/raw-byte-string-eof.rs
+++ b/src/test/parse-fail/raw-byte-string-eof.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 
 pub fn main() {
     br##"a"#;  //~ unterminated raw string

--- a/src/test/parse-fail/raw-byte-string-literals.rs
+++ b/src/test/parse-fail/raw-byte-string-literals.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 
 pub fn main() {
     br"é";  //~ raw byte string must be ASCII

--- a/src/test/parse-fail/raw-str-delim.rs
+++ b/src/test/parse-fail/raw-str-delim.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 static s: &'static str =
     r#x"#"x# //~ ERROR only `#` is allowed in raw string delimitation; found illegal character
 ;

--- a/src/test/parse-fail/raw-str-unbalanced.rs
+++ b/src/test/parse-fail/raw-str-unbalanced.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 static s: &'static str =
     r#"
       "## //~ ERROR expected one of `.`, `;`, or an operator, found `#`

--- a/src/test/parse-fail/raw-str-unterminated.rs
+++ b/src/test/parse-fail/raw-str-unterminated.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 static s: &'static str =
     r#" string literal goes on
         and on

--- a/src/test/parse-fail/regions-fn-bound.rs
+++ b/src/test/parse-fail/regions-fn-bound.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // ignore-test
 // ignored because the first error does not show up.
 
@@ -20,6 +22,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+// compile-flags: -Z parse-only
 
 fn of<T>() -> |T| { panic!(); }
 fn subtype<T>(x: |T|) { panic!(); }

--- a/src/test/parse-fail/regions-infer-paramd-method.rs
+++ b/src/test/parse-fail/regions-infer-paramd-method.rs
@@ -21,6 +21,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Here: foo is parameterized because it contains a method that
 // refers to self.
 

--- a/src/test/parse-fail/regions-out-of-scope-slice.rs
+++ b/src/test/parse-fail/regions-out-of-scope-slice.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // ignore-test blk region isn't supported in the front-end
 
 fn foo(cond: bool) {

--- a/src/test/parse-fail/regions-trait-2.rs
+++ b/src/test/parse-fail/regions-trait-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // ignore-test #5723
 
 // Test that you cannot escape a reference

--- a/src/test/parse-fail/regions-trait-3.rs
+++ b/src/test/parse-fail/regions-trait-3.rs
@@ -21,6 +21,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 trait get_ctxt<'a> {
     fn get_ctxt(self) -> &'a usize;
 }

--- a/src/test/parse-fail/removed-syntax-closure-lifetime.rs
+++ b/src/test/parse-fail/removed-syntax-closure-lifetime.rs
@@ -8,4 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 type closure = Box<lt/fn()>; //~ ERROR expected one of `(`, `+`, `,`, `::`, `<`, or `>`, found `/`

--- a/src/test/parse-fail/removed-syntax-enum-newtype.rs
+++ b/src/test/parse-fail/removed-syntax-enum-newtype.rs
@@ -8,4 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 enum e = isize; //~ ERROR expected one of `<`, `where`, or `{`, found `=`

--- a/src/test/parse-fail/removed-syntax-extern-const.rs
+++ b/src/test/parse-fail/removed-syntax-extern-const.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 extern {
     const i: isize;
     //~^ ERROR expected one of `fn`, `pub`, `static`, `unsafe`, or `}`, found `const`

--- a/src/test/parse-fail/removed-syntax-field-let.rs
+++ b/src/test/parse-fail/removed-syntax-field-let.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct s {
     let foo: (),
     //~^  ERROR expected identifier, found keyword `let`

--- a/src/test/parse-fail/removed-syntax-field-semicolon.rs
+++ b/src/test/parse-fail/removed-syntax-field-semicolon.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct s {
     bar: ();
     //~^ ERROR expected `,`, or `}`, found `;`

--- a/src/test/parse-fail/removed-syntax-fixed-vec.rs
+++ b/src/test/parse-fail/removed-syntax-fixed-vec.rs
@@ -8,4 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 type v = [isize * 3]; //~ ERROR expected one of `(`, `+`, `::`, `;`, `<`, or `]`, found `*`

--- a/src/test/parse-fail/removed-syntax-fn-pure.rs
+++ b/src/test/parse-fail/removed-syntax-fn-pure.rs
@@ -8,4 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 pure fn f() {} //~ ERROR expected item, found `pure`

--- a/src/test/parse-fail/removed-syntax-fn-sigil.rs
+++ b/src/test/parse-fail/removed-syntax-fn-sigil.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn f() {
     let x: fn~() = || (); //~ ERROR expected `(`, found `~`
 }

--- a/src/test/parse-fail/removed-syntax-larrow-init.rs
+++ b/src/test/parse-fail/removed-syntax-larrow-init.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn removed_moves() {
     let mut x = 0;
     let y <- x;

--- a/src/test/parse-fail/removed-syntax-larrow-move.rs
+++ b/src/test/parse-fail/removed-syntax-larrow-move.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn removed_moves() {
     let mut x = 0;
     let y = 0;

--- a/src/test/parse-fail/removed-syntax-mode.rs
+++ b/src/test/parse-fail/removed-syntax-mode.rs
@@ -8,4 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn f(+x: isize) {} //~ ERROR unexpected token: `+`

--- a/src/test/parse-fail/removed-syntax-mut-vec-expr.rs
+++ b/src/test/parse-fail/removed-syntax-mut-vec-expr.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn f() {
     let v = [mut 1, 2, 3, 4];
     //~^  ERROR expected identifier, found keyword `mut`

--- a/src/test/parse-fail/removed-syntax-mut-vec-ty.rs
+++ b/src/test/parse-fail/removed-syntax-mut-vec-ty.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 type v = [mut isize];
     //~^  ERROR expected identifier, found keyword `mut`
     //~^^ ERROR expected one of `(`, `+`, `::`, `;`, `<`, or `]`, found `isize`

--- a/src/test/parse-fail/removed-syntax-ptr-lifetime.rs
+++ b/src/test/parse-fail/removed-syntax-ptr-lifetime.rs
@@ -8,4 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 type bptr = &lifetime/isize; //~ ERROR expected one of `(`, `+`, `::`, `;`, or `<`, found `/`

--- a/src/test/parse-fail/removed-syntax-record.rs
+++ b/src/test/parse-fail/removed-syntax-record.rs
@@ -8,4 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 type t = { f: () }; //~ ERROR expected type, found `{`

--- a/src/test/parse-fail/removed-syntax-static-fn.rs
+++ b/src/test/parse-fail/removed-syntax-static-fn.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct S;
 
 impl S {

--- a/src/test/parse-fail/removed-syntax-uniq-mut-expr.rs
+++ b/src/test/parse-fail/removed-syntax-uniq-mut-expr.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn f() {
     let a_box = box mut 42;
     //~^  ERROR expected identifier, found keyword `mut`

--- a/src/test/parse-fail/removed-syntax-uniq-mut-ty.rs
+++ b/src/test/parse-fail/removed-syntax-uniq-mut-ty.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 type mut_box = Box<mut isize>;
     //~^  ERROR expected identifier, found keyword `mut`
     //~^^ ERROR expected one of `(`, `+`, `,`, `::`, `<`, or `>`, found `isize`

--- a/src/test/parse-fail/removed-syntax-with-1.rs
+++ b/src/test/parse-fail/removed-syntax-with-1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn removed_with() {
     struct S {
         foo: (),

--- a/src/test/parse-fail/removed-syntax-with-2.rs
+++ b/src/test/parse-fail/removed-syntax-with-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn removed_with() {
     struct S {
         foo: (),

--- a/src/test/parse-fail/require-parens-for-chained-comparison.rs
+++ b/src/test/parse-fail/require-parens-for-chained-comparison.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn f<T>() {}
 
 fn main() {

--- a/src/test/parse-fail/struct-literal-in-for.rs
+++ b/src/test/parse-fail/struct-literal-in-for.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Foo {
     x: isize,
 }

--- a/src/test/parse-fail/struct-literal-in-if.rs
+++ b/src/test/parse-fail/struct-literal-in-if.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Foo {
     x: isize,
 }

--- a/src/test/parse-fail/struct-literal-in-match-discriminant.rs
+++ b/src/test/parse-fail/struct-literal-in-match-discriminant.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Foo {
     x: isize,
 }

--- a/src/test/parse-fail/struct-literal-in-while.rs
+++ b/src/test/parse-fail/struct-literal-in-while.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Foo {
     x: isize,
 }

--- a/src/test/parse-fail/struct-no-fields-2.rs
+++ b/src/test/parse-fail/struct-no-fields-2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Foo;
 
 fn f2() {

--- a/src/test/parse-fail/struct-no-fields-3.rs
+++ b/src/test/parse-fail/struct-no-fields-3.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Foo;
 
 fn g3() {

--- a/src/test/parse-fail/struct-no-fields-4.rs
+++ b/src/test/parse-fail/struct-no-fields-4.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Foo;
 
 fn h4() {

--- a/src/test/parse-fail/struct-no-fields-5.rs
+++ b/src/test/parse-fail/struct-no-fields-5.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Foo;
 
 fn i5() {

--- a/src/test/parse-fail/struct-no-fields-enumlike.rs
+++ b/src/test/parse-fail/struct-no-fields-enumlike.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Foo(); //~ ERROR unit-like struct definition should be written as `struct Foo;`
 
 fn main() {}

--- a/src/test/parse-fail/struct-no-fields.rs
+++ b/src/test/parse-fail/struct-no-fields.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Foo {}
 //~^ ERROR: unit-like struct definition should be written as `struct Foo;`
 

--- a/src/test/parse-fail/struct-variant-no-fields.rs
+++ b/src/test/parse-fail/struct-variant-no-fields.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 enum Foo {
     Bar {} //~ ERROR unit-like struct variant should be written without braces, as `Bar,`
 }

--- a/src/test/parse-fail/struct-variant-no-pub.rs
+++ b/src/test/parse-fail/struct-variant-no-pub.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 enum Foo {
     Bar {
         pub a: isize //~ ERROR: `pub` is not allowed here

--- a/src/test/parse-fail/syntax-trait-polarity.rs
+++ b/src/test/parse-fail/syntax-trait-polarity.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 #![feature(optin_builtin_traits)]
 
 use std::marker::Send;

--- a/src/test/parse-fail/tag-variant-disr-non-nullary.rs
+++ b/src/test/parse-fail/tag-variant-disr-non-nullary.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 //error-pattern: discriminator values can only be used with a c-like enum
 
 enum color {

--- a/src/test/parse-fail/trailing-carriage-return-in-string.rs
+++ b/src/test/parse-fail/trailing-carriage-return-in-string.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // ignore-tidy-cr
 // Issue #11669
 

--- a/src/test/parse-fail/trailing-plus-in-bounds.rs
+++ b/src/test/parse-fail/trailing-plus-in-bounds.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 use std::fmt::Debug;
 
 fn main() {

--- a/src/test/parse-fail/trait-bounds-not-on-impl.rs
+++ b/src/test/parse-fail/trait-bounds-not-on-impl.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 trait Foo {
 }
 

--- a/src/test/parse-fail/trait-keyword.rs
+++ b/src/test/parse-fail/trait-keyword.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 iface foo { } //~ ERROR iface
 
 fn main() {}

--- a/src/test/parse-fail/type-parameters-in-field-exprs.rs
+++ b/src/test/parse-fail/type-parameters-in-field-exprs.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 struct Foo {
     x: isize,
     y: isize,

--- a/src/test/parse-fail/unbalanced-doublequote.rs
+++ b/src/test/parse-fail/unbalanced-doublequote.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 
 // error-pattern: unterminated double quote string
 

--- a/src/test/parse-fail/unboxed-closure-sugar-used-on-struct-3.rs
+++ b/src/test/parse-fail/unboxed-closure-sugar-used-on-struct-3.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Test that parentheses form doesn't work in expression paths.
 
 struct Bar<A,R> {

--- a/src/test/parse-fail/unsized.rs
+++ b/src/test/parse-fail/unsized.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Test syntax checks for `type` keyword.
 
 struct S1 for type; //~ ERROR expected `where`, `{`, `(`, or `;` after struct name, found `for`

--- a/src/test/parse-fail/unsized2.rs
+++ b/src/test/parse-fail/unsized2.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Test syntax checks for `type` keyword.
 
 fn f<X>() {}

--- a/src/test/parse-fail/use-as-where-use-ends-with-mod-sep.rs
+++ b/src/test/parse-fail/use-as-where-use-ends-with-mod-sep.rs
@@ -8,5 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 use std::any:: as foo; //~ ERROR expected identifier, found keyword `as`
 //~^ ERROR: expected one of `::`, `;`, or `as`, found `foo`

--- a/src/test/parse-fail/use-ends-with-mod-sep.rs
+++ b/src/test/parse-fail/use-ends-with-mod-sep.rs
@@ -8,4 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 use std::any::; //~ ERROR expected identifier or `{` or `*`, found `;`

--- a/src/test/parse-fail/use-mod-4.rs
+++ b/src/test/parse-fail/use-mod-4.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 use foo::self;
 //~^ ERROR expected identifier, found keyword `self`
 

--- a/src/test/parse-fail/variadic-ffi-1.rs
+++ b/src/test/parse-fail/variadic-ffi-1.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 extern {
     fn printf(...); //~ ERROR: variadic function must be declared with at least one named argument
     fn printf(..., foo: isize); //~ ERROR: `...` must be last in argument list for variadic function

--- a/src/test/parse-fail/variadic-ffi-3.rs
+++ b/src/test/parse-fail/variadic-ffi-3.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn foo(x: isize, ...) {
     //~^ ERROR: only foreign functions are allowed to be variadic
 }

--- a/src/test/parse-fail/variadic-ffi-4.rs
+++ b/src/test/parse-fail/variadic-ffi-4.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 extern "C" fn foo(x: isize, ...) {
     //~^ ERROR: only foreign functions are allowed to be variadic
 }

--- a/src/test/parse-fail/virtual-structs.rs
+++ b/src/test/parse-fail/virtual-structs.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 // Test diagnostics for the removed struct inheritance feature.
 #![feature(struct_inherit)]
 

--- a/src/test/parse-fail/where-clauses-no-bounds-or-predicates.rs
+++ b/src/test/parse-fail/where-clauses-no-bounds-or-predicates.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Z parse-only
+
 fn equal1<T>(_: &T, _: &T) -> bool where {
 //~^ ERROR a `where` clause must have at least one predicate in it
     true


### PR DESCRIPTION
At the moment, when compilation is stopped at a stop point (like `-Z parse-only`), `rustc` does not return an nonzero exit code even if there are errors (expect fatal ones, that cause it to panic immediately). As an example, compiling `src/test/compile-fail/doc-before-semi.rs` with `-Z parse-only` raises an error, but exists with 0.

Note that I could not use `sess.abort_if_errors()` in the macro, because `sess` is passed by value and move at some point.
