### PR TITLE
std: Small stability tweaks to iter

### DIFF
--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -656,7 +656,7 @@ impl<T: Ord> FromIterator<T> for BinaryHeap<T> {
 }
 
 impl<T: Ord> IntoIterator for BinaryHeap<T> {
-    type Iter = IntoIter<T>;
+    type IntoIter = IntoIter<T>;
 
     fn into_iter(self) -> IntoIter<T> {
         self.into_iter()
@@ -664,7 +664,7 @@ impl<T: Ord> IntoIterator for BinaryHeap<T> {
 }
 
 impl<'a, T> IntoIterator for &'a BinaryHeap<T> where T: Ord {
-    type Iter = Iter<'a, T>;
+    type IntoIter = Iter<'a, T>;
 
     fn into_iter(self) -> Iter<'a, T> {
         self.iter()

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -1071,7 +1071,7 @@ impl<'a> RandomAccessIterator for Iter<'a> {
 }
 
 impl<'a> IntoIterator for &'a Bitv {
-    type Iter = Iter<'a>;
+    type IntoIter = Iter<'a>;
 
     fn into_iter(self) -> Iter<'a> {
         self.iter()
@@ -1883,7 +1883,7 @@ impl<'a> Iterator for SymmetricDifference<'a> {
 }
 
 impl<'a> IntoIterator for &'a BitvSet {
-    type Iter = SetIter<'a>;
+    type IntoIter = SetIter<'a>;
 
     fn into_iter(self) -> SetIter<'a> {
         self.iter()

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -463,7 +463,7 @@ impl<K: Ord, V> BTreeMap<K, V> {
 }
 
 impl<K, V> IntoIterator for BTreeMap<K, V> {
-    type Iter = IntoIter<K, V>;
+    type IntoIter = IntoIter<K, V>;
 
     fn into_iter(self) -> IntoIter<K, V> {
         self.into_iter()
@@ -471,7 +471,7 @@ impl<K, V> IntoIterator for BTreeMap<K, V> {
 }
 
 impl<'a, K, V> IntoIterator for &'a BTreeMap<K, V> {
-    type Iter = Iter<'a, K, V>;
+    type IntoIter = Iter<'a, K, V>;
 
     fn into_iter(self) -> Iter<'a, K, V> {
         self.iter()
@@ -479,7 +479,7 @@ impl<'a, K, V> IntoIterator for &'a BTreeMap<K, V> {
 }
 
 impl<'a, K, V> IntoIterator for &'a mut BTreeMap<K, V> {
-    type Iter = IterMut<'a, K, V>;
+    type IntoIter = IterMut<'a, K, V>;
 
     fn into_iter(mut self) -> IterMut<'a, K, V> {
         self.iter_mut()

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -481,7 +481,7 @@ impl<T: Ord> FromIterator<T> for BTreeSet<T> {
 }
 
 impl<T> IntoIterator for BTreeSet<T> {
-    type Iter = IntoIter<T>;
+    type IntoIter = IntoIter<T>;
 
     fn into_iter(self) -> IntoIter<T> {
         self.into_iter()
@@ -489,7 +489,7 @@ impl<T> IntoIterator for BTreeSet<T> {
 }
 
 impl<'a, T> IntoIterator for &'a BTreeSet<T> {
-    type Iter = Iter<'a, T>;
+    type IntoIter = Iter<'a, T>;
 
     fn into_iter(self) -> Iter<'a, T> {
         self.iter()

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -831,7 +831,7 @@ impl<A> FromIterator<A> for DList<A> {
 }
 
 impl<T> IntoIterator for DList<T> {
-    type Iter = IntoIter<T>;
+    type IntoIter = IntoIter<T>;
 
     fn into_iter(self) -> IntoIter<T> {
         self.into_iter()
@@ -839,7 +839,7 @@ impl<T> IntoIterator for DList<T> {
 }
 
 impl<'a, T> IntoIterator for &'a DList<T> {
-    type Iter = Iter<'a, T>;
+    type IntoIter = Iter<'a, T>;
 
     fn into_iter(self) -> Iter<'a, T> {
         self.iter()
@@ -847,7 +847,7 @@ impl<'a, T> IntoIterator for &'a DList<T> {
 }
 
 impl<'a, T> IntoIterator for &'a mut DList<T> {
-    type Iter = IterMut<'a, T>;
+    type IntoIter = IterMut<'a, T>;
 
     fn into_iter(mut self) -> IterMut<'a, T> {
         self.iter_mut()

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -258,7 +258,7 @@ impl<E:CLike> FromIterator<E> for EnumSet<E> {
 }
 
 impl<'a, E> IntoIterator for &'a EnumSet<E> where E: CLike {
-    type Iter = Iter<E>;
+    type IntoIter = Iter<E>;
 
     fn into_iter(self) -> Iter<E> {
         self.iter()

--- a/src/libcollections/ring_buf.rs
+++ b/src/libcollections/ring_buf.rs
@@ -1608,7 +1608,7 @@ impl<A> FromIterator<A> for RingBuf<A> {
 }
 
 impl<T> IntoIterator for RingBuf<T> {
-    type Iter = IntoIter<T>;
+    type IntoIter = IntoIter<T>;
 
     fn into_iter(self) -> IntoIter<T> {
         self.into_iter()
@@ -1616,7 +1616,7 @@ impl<T> IntoIterator for RingBuf<T> {
 }
 
 impl<'a, T> IntoIterator for &'a RingBuf<T> {
-    type Iter = Iter<'a, T>;
+    type IntoIter = Iter<'a, T>;
 
     fn into_iter(self) -> Iter<'a, T> {
         self.iter()
@@ -1624,7 +1624,7 @@ impl<'a, T> IntoIterator for &'a RingBuf<T> {
 }
 
 impl<'a, T> IntoIterator for &'a mut RingBuf<T> {
-    type Iter = IterMut<'a, T>;
+    type IntoIter = IterMut<'a, T>;
 
     fn into_iter(mut self) -> IterMut<'a, T> {
         self.iter_mut()

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1388,7 +1388,7 @@ impl<T> FromIterator<T> for Vec<T> {
 }
 
 impl<T> IntoIterator for Vec<T> {
-    type Iter = IntoIter<T>;
+    type IntoIter = IntoIter<T>;
 
     fn into_iter(self) -> IntoIter<T> {
         self.into_iter()
@@ -1396,7 +1396,7 @@ impl<T> IntoIterator for Vec<T> {
 }
 
 impl<'a, T> IntoIterator for &'a Vec<T> {
-    type Iter = slice::Iter<'a, T>;
+    type IntoIter = slice::Iter<'a, T>;
 
     fn into_iter(self) -> slice::Iter<'a, T> {
         self.iter()
@@ -1404,7 +1404,7 @@ impl<'a, T> IntoIterator for &'a Vec<T> {
 }
 
 impl<'a, T> IntoIterator for &'a mut Vec<T> {
-    type Iter = slice::IterMut<'a, T>;
+    type IntoIter = slice::IterMut<'a, T>;
 
     fn into_iter(mut self) -> slice::IterMut<'a, T> {
         self.iter_mut()

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -669,7 +669,7 @@ impl<V> FromIterator<(usize, V)> for VecMap<V> {
 }
 
 impl<T> IntoIterator for VecMap<T> {
-    type Iter = IntoIter<T>;
+    type IntoIter = IntoIter<T>;
 
     fn into_iter(self) -> IntoIter<T> {
         self.into_iter()
@@ -677,7 +677,7 @@ impl<T> IntoIterator for VecMap<T> {
 }
 
 impl<'a, T> IntoIterator for &'a VecMap<T> {
-    type Iter = Iter<'a, T>;
+    type IntoIter = Iter<'a, T>;
 
     fn into_iter(self) -> Iter<'a, T> {
         self.iter()
@@ -685,7 +685,7 @@ impl<'a, T> IntoIterator for &'a VecMap<T> {
 }
 
 impl<'a, T> IntoIterator for &'a mut VecMap<T> {
-    type Iter = IterMut<'a, T>;
+    type IntoIter = IterMut<'a, T>;
 
     fn into_iter(mut self) -> IterMut<'a, T> {
         self.iter_mut()

--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -49,7 +49,7 @@ macro_rules! array_impls {
             }
 
             impl<'a, T> IntoIterator for &'a [T; $N] {
-                type Iter = Iter<'a, T>;
+                type IntoIter = Iter<'a, T>;
 
                 fn into_iter(self) -> Iter<'a, T> {
                     self.iter()
@@ -57,7 +57,7 @@ macro_rules! array_impls {
             }
 
             impl<'a, T> IntoIterator for &'a mut [T; $N] {
-                type Iter = IterMut<'a, T>;
+                type IntoIter = IterMut<'a, T>;
 
                 fn into_iter(self) -> IterMut<'a, T> {
                     self.iter_mut()

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -120,14 +120,14 @@ pub trait FromIterator<A> {
 
 /// Conversion into an `Iterator`
 pub trait IntoIterator {
-    type Iter: Iterator;
+    type IntoIter: Iterator;
 
     /// Consumes `Self` and returns an iterator over it
-    fn into_iter(self) -> Self::Iter;
+    fn into_iter(self) -> Self::IntoIter;
 }
 
 impl<I> IntoIterator for I where I: Iterator {
-    type Iter = I;
+    type IntoIter = I;
 
     fn into_iter(self) -> I {
         self

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -967,10 +967,9 @@ pub trait IteratorExt: Iterator + Sized {
     /// Creates an iterator that clones the elements it yields. Useful for converting an
     /// Iterator<&T> to an Iterator<T>.
     #[unstable(feature = "core", reason = "recent addition")]
-    fn cloned<T, D>(self) -> Cloned<Self> where
-        Self: Iterator<Item=D>,
-        D: Deref<Target=T>,
-        T: Clone,
+    fn cloned(self) -> Cloned<Self> where
+        Self::Item: Deref,
+        <Self::Item as Deref>::Output: Clone,
     {
         Cloned { it: self }
     }

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -123,6 +123,7 @@ pub trait IntoIterator {
     type IntoIter: Iterator;
 
     /// Consumes `Self` and returns an iterator over it
+    #[stable(feature = "rust1", since = "1.0.0")]
     fn into_iter(self) -> Self::IntoIter;
 }
 

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -628,7 +628,7 @@ impl<'a, T> Default for &'a [T] {
 //
 
 impl<'a, T> IntoIterator for &'a [T] {
-    type Iter = Iter<'a, T>;
+    type IntoIter = Iter<'a, T>;
 
     fn into_iter(self) -> Iter<'a, T> {
         self.iter()
@@ -636,7 +636,7 @@ impl<'a, T> IntoIterator for &'a [T] {
 }
 
 impl<'a, T> IntoIterator for &'a mut [T] {
-    type Iter = IterMut<'a, T>;
+    type IntoIter = IterMut<'a, T>;
 
     fn into_iter(self) -> IterMut<'a, T> {
         self.iter_mut()

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1377,7 +1377,7 @@ impl<'a, K, V, S, H> IntoIterator for &'a HashMap<K, V, S>
           S: HashState<Hasher=H>,
           H: hash::Hasher<Output=u64>
 {
-    type Iter = Iter<'a, K, V>;
+    type IntoIter = Iter<'a, K, V>;
 
     fn into_iter(self) -> Iter<'a, K, V> {
         self.iter()
@@ -1389,7 +1389,7 @@ impl<'a, K, V, S, H> IntoIterator for &'a mut HashMap<K, V, S>
           S: HashState<Hasher=H>,
           H: hash::Hasher<Output=u64>
 {
-    type Iter = IterMut<'a, K, V>;
+    type IntoIter = IterMut<'a, K, V>;
 
     fn into_iter(mut self) -> IterMut<'a, K, V> {
         self.iter_mut()
@@ -1401,7 +1401,7 @@ impl<K, V, S, H> IntoIterator for HashMap<K, V, S>
           S: HashState<Hasher=H>,
           H: hash::Hasher<Output=u64>
 {
-    type Iter = IntoIter<K, V>;
+    type IntoIter = IntoIter<K, V>;
 
     fn into_iter(self) -> IntoIter<K, V> {
         self.into_iter()

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -840,7 +840,7 @@ impl<'a, T, S, H> IntoIterator for &'a HashSet<T, S>
           S: HashState<Hasher=H>,
           H: hash::Hasher<Output=u64>
 {
-    type Iter = Iter<'a, T>;
+    type IntoIter = Iter<'a, T>;
 
     fn into_iter(self) -> Iter<'a, T> {
         self.iter()
@@ -852,7 +852,7 @@ impl<T, S, H> IntoIterator for HashSet<T, S>
           S: HashState<Hasher=H>,
           H: hash::Hasher<Output=u64>
 {
-    type Iter = IntoIter<T>;
+    type IntoIter = IntoIter<T>;
 
     fn into_iter(self) -> IntoIter<T> {
         self.into_iter()


### PR DESCRIPTION
- Remove type parameters from `IteratorExt::cloned`
- Rename `IntoIterator::Iter` to `IntoIterator::IntoIter`
- Mark `IntoIterator::into_iter` as stable (but not the trait, only the method).
