### PR TITLE
rustc: Fix a number of stability lint holes

### DIFF
--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -401,7 +401,7 @@
 //! them with the same character. For example, the `{` character is escaped with
 //! `{{` and the `}` character is escaped with `}}`.
 
-#![unstable(feature = "std_misc")]
+#![stable(feature = "rust1", since = "1.0.0")]
 
 pub use core::fmt::{Formatter, Result, Writer, rt};
 pub use core::fmt::{Show, String, Octal, Binary};

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -268,6 +268,7 @@ pub trait Debug {
     fn fmt(&self, &mut Formatter) -> Result;
 }
 
+#[allow(deprecated)]
 impl<T: Show + ?Sized> Debug for T {
     #[allow(deprecated)]
     fn fmt(&self, f: &mut Formatter) -> Result { Show::fmt(self, f) }
@@ -295,6 +296,7 @@ pub trait Display {
     fn fmt(&self, &mut Formatter) -> Result;
 }
 
+#[allow(deprecated)]
 impl<T: String + ?Sized> Display for T {
     #[allow(deprecated)]
     fn fmt(&self, f: &mut Formatter) -> Result { String::fmt(self, f) }

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -1119,8 +1119,7 @@ impl<'a, T: ?Sized> DerefMut for &'a mut T {
 
 /// A version of the call operator that takes an immutable receiver.
 #[lang="fn"]
-#[unstable(feature = "core",
-           reason = "uncertain about variadic generics, input versus associated types")]
+#[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_paren_sugar]
 pub trait Fn<Args> {
     type Output;
@@ -1131,8 +1130,7 @@ pub trait Fn<Args> {
 
 /// A version of the call operator that takes a mutable receiver.
 #[lang="fn_mut"]
-#[unstable(feature = "core",
-           reason = "uncertain about variadic generics, input versus associated types")]
+#[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_paren_sugar]
 pub trait FnMut<Args> {
     type Output;
@@ -1143,8 +1141,7 @@ pub trait FnMut<Args> {
 
 /// A version of the call operator that takes a by-value receiver.
 #[lang="fn_once"]
-#[unstable(feature = "core",
-           reason = "uncertain about variadic generics, input versus associated types")]
+#[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_paren_sugar]
 pub trait FnOnce<Args> {
     type Output;

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -34,7 +34,7 @@ use ptr::PtrExt;
 use raw::{Repr, Slice};
 use result::Result::{self, Ok, Err};
 use slice::{self, SliceExt};
-use uint;
+use usize;
 
 macro_rules! delegate_iter {
     (exact $te:ty : $ti:ty) => {
@@ -783,7 +783,7 @@ impl TwoWaySearcher {
                 byteset: byteset,
 
                 position: 0,
-                memory: uint::MAX // Dummy value to signify that the period is long
+                memory: usize::MAX // Dummy value to signify that the period is long
             }
         }
     }
@@ -911,7 +911,7 @@ impl Searcher {
             Naive(NaiveSearcher::new())
         } else {
             let searcher = TwoWaySearcher::new(needle);
-            if searcher.memory == uint::MAX { // If the period is long
+            if searcher.memory == usize::MAX { // If the period is long
                 TwoWayLong(searcher)
             } else {
                 TwoWay(searcher)

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -130,7 +130,7 @@ impl fmt::Display for Error {
 pub mod reader {
     use std::char;
 
-    use std::int;
+    use std::isize;
     use std::old_io::extensions::u64_from_be_bytes;
     use std::mem::transmute;
     use std::num::Int;
@@ -440,7 +440,7 @@ pub mod reader {
         fn read_u8 (&mut self) -> DecodeResult<u8 > { Ok(doc_as_u8 (try!(self.next_doc(EsU8 )))) }
         fn read_uint(&mut self) -> DecodeResult<uint> {
             let v = doc_as_u64(try!(self.next_doc(EsUint)));
-            if v > (::std::uint::MAX as u64) {
+            if v > (::std::usize::MAX as u64) {
                 Err(IntTooBig(v as uint))
             } else {
                 Ok(v as uint)
@@ -461,7 +461,7 @@ pub mod reader {
         }
         fn read_int(&mut self) -> DecodeResult<int> {
             let v = doc_as_u64(try!(self.next_doc(EsInt))) as i64;
-            if v > (int::MAX as i64) || v < (int::MIN as i64) {
+            if v > (isize::MAX as i64) || v < (isize::MIN as i64) {
                 debug!("FIXME \\#6122: Removing this makes this function miscompile");
                 Err(IntTooBig(v as uint))
             } else {

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -1768,6 +1768,11 @@ impl LintPass for Stability {
         stability::check_expr(cx.tcx, e,
                               &mut |id, sp, stab| self.lint(cx, id, sp, stab));
     }
+
+    fn check_path(&mut self, cx: &Context, path: &ast::Path, id: ast::NodeId) {
+        stability::check_path(cx.tcx, path, id,
+                              &mut |id, sp, stab| self.lint(cx, id, sp, stab));
+    }
 }
 
 declare_lint! {

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -20,7 +20,7 @@ use middle::cfg;
 use middle::cfg::CFGIndex;
 use middle::ty;
 use std::old_io;
-use std::uint;
+use std::usize;
 use std::iter::repeat;
 use syntax::ast;
 use syntax::ast_util::IdRange;
@@ -48,7 +48,7 @@ pub struct DataFlowContext<'a, 'tcx: 'a, O> {
     bits_per_id: uint,
 
     /// number of words we will use to store bits_per_id.
-    /// equal to bits_per_id/uint::BITS rounded up.
+    /// equal to bits_per_id/usize::BITS rounded up.
     words_per_id: uint,
 
     // mapping from node to cfg node index
@@ -193,7 +193,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
                oper: O,
                id_range: IdRange,
                bits_per_id: uint) -> DataFlowContext<'a, 'tcx, O> {
-        let words_per_id = (bits_per_id + uint::BITS - 1) / uint::BITS;
+        let words_per_id = (bits_per_id + usize::BITS - 1) / usize::BITS;
         let num_nodes = cfg.graph.all_nodes().len();
 
         debug!("DataFlowContext::new(analysis_name: {}, id_range={:?}, \
@@ -202,7 +202,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
                analysis_name, id_range, bits_per_id, words_per_id,
                num_nodes);
 
-        let entry = if oper.initial_value() { uint::MAX } else {0};
+        let entry = if oper.initial_value() { usize::MAX } else {0};
 
         let gens: Vec<_> = repeat(0).take(num_nodes * words_per_id).collect();
         let kills: Vec<_> = repeat(0).take(num_nodes * words_per_id).collect();
@@ -351,13 +351,13 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
 
         for (word_index, &word) in words.iter().enumerate() {
             if word != 0 {
-                let base_index = word_index * uint::BITS;
-                for offset in 0..uint::BITS {
+                let base_index = word_index * usize::BITS;
+                for offset in 0..usize::BITS {
                     let bit = 1 << offset;
                     if (word & bit) != 0 {
                         // NB: we round up the total number of bits
                         // that we store in any given bit set so that
-                        // it is an even multiple of uint::BITS.  This
+                        // it is an even multiple of usize::BITS.  This
                         // means that there may be some stray bits at
                         // the end that do not correspond to any
                         // actual value.  So before we callback, check
@@ -500,7 +500,7 @@ impl<'a, 'b, 'tcx, O:DataFlowOperator> PropagationContext<'a, 'b, 'tcx, O> {
     }
 
     fn reset(&mut self, bits: &mut [uint]) {
-        let e = if self.dfcx.oper.initial_value() {uint::MAX} else {0};
+        let e = if self.dfcx.oper.initial_value() {usize::MAX} else {0};
         for b in bits {
             *b = e;
         }
@@ -552,7 +552,7 @@ fn bits_to_string(words: &[uint]) -> String {
 
     for &word in words {
         let mut v = word;
-        for _ in 0..uint::BYTES {
+        for _ in 0..usize::BYTES {
             result.push(sep);
             result.push_str(&format!("{:02x}", v & 0xFF)[]);
             v >>= 8;
@@ -581,8 +581,8 @@ fn bitwise<Op:BitwiseOperator>(out_vec: &mut [uint],
 fn set_bit(words: &mut [uint], bit: uint) -> bool {
     debug!("set_bit: words={} bit={}",
            mut_bits_to_string(words), bit_str(bit));
-    let word = bit / uint::BITS;
-    let bit_in_word = bit % uint::BITS;
+    let word = bit / usize::BITS;
+    let bit_in_word = bit % usize::BITS;
     let bit_mask = 1 << bit_in_word;
     debug!("word={} bit_in_word={} bit_mask={}", word, bit_in_word, word);
     let oldv = words[word];

--- a/src/librustc/middle/graph.rs
+++ b/src/librustc/middle/graph.rs
@@ -33,7 +33,7 @@
 #![allow(dead_code)] // still WIP
 
 use std::fmt::{Formatter, Error, Debug};
-use std::uint;
+use std::usize;
 use std::collections::BitvSet;
 
 pub struct Graph<N,E> {
@@ -64,12 +64,12 @@ impl<E: Debug> Debug for Edge<E> {
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct NodeIndex(pub uint);
 #[allow(non_upper_case_globals)]
-pub const InvalidNodeIndex: NodeIndex = NodeIndex(uint::MAX);
+pub const InvalidNodeIndex: NodeIndex = NodeIndex(usize::MAX);
 
 #[derive(Copy, PartialEq, Debug)]
 pub struct EdgeIndex(pub uint);
 #[allow(non_upper_case_globals)]
-pub const InvalidEdgeIndex: EdgeIndex = EdgeIndex(uint::MAX);
+pub const InvalidEdgeIndex: EdgeIndex = EdgeIndex(usize::MAX);
 
 // Use a private field here to guarantee no more instances are created:
 #[derive(Copy, Debug)]

--- a/src/librustc_borrowck/borrowck/move_data.rs
+++ b/src/librustc_borrowck/borrowck/move_data.rs
@@ -24,7 +24,7 @@ use rustc::util::nodemap::{FnvHashMap, NodeSet};
 use rustc::util::ppaux::Repr;
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::uint;
+use std::usize;
 use syntax::ast;
 use syntax::ast_util;
 use syntax::codemap::Span;
@@ -92,7 +92,7 @@ impl Clone for MovePathIndex {
 
 #[allow(non_upper_case_globals)]
 static InvalidMovePathIndex: MovePathIndex =
-    MovePathIndex(uint::MAX);
+    MovePathIndex(usize::MAX);
 
 /// Index into `MoveData.moves`, used like a pointer
 #[derive(Copy, PartialEq)]
@@ -106,7 +106,7 @@ impl MoveIndex {
 
 #[allow(non_upper_case_globals)]
 static InvalidMoveIndex: MoveIndex =
-    MoveIndex(uint::MAX);
+    MoveIndex(usize::MAX);
 
 pub struct MovePath<'tcx> {
     /// Loan path corresponding to this move path

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -101,7 +101,7 @@ use std::cell::{Cell, RefCell};
 use std::fmt;
 use std::mem::replace;
 use std::rc::{Rc, Weak};
-use std::uint;
+use std::usize;
 
 // NB: This module needs to be declared first so diagnostics are
 // registered before they are used.
@@ -4366,7 +4366,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         for rib in this.value_ribs.iter().rev() {
             for (&k, _) in &rib.bindings {
                 maybes.push(token::get_name(k));
-                values.push(uint::MAX);
+                values.push(usize::MAX);
             }
         }
 
@@ -4380,7 +4380,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         }
 
         if values.len() > 0 &&
-            values[smallest] != uint::MAX &&
+            values[smallest] != usize::MAX &&
             values[smallest] < name.len() + 2 &&
             values[smallest] <= max_distance &&
             name != &maybes[smallest][] {

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -79,6 +79,7 @@ This API is completely unstable and subject to change.
 #![feature(collections)]
 #![feature(core)]
 #![feature(int_uint)]
+#![feature(std_misc)]
 #![feature(quote)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(rustc_private)]

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -12,7 +12,7 @@ use std::collections::HashSet;
 use rustc::util::nodemap::NodeSet;
 use std::cmp;
 use std::string::String;
-use std::uint;
+use std::usize;
 use syntax::ast;
 use syntax::ast_util;
 
@@ -310,7 +310,7 @@ pub fn unindent(s: &str) -> String {
     let lines = s.lines_any().collect::<Vec<&str> >();
     let mut saw_first_line = false;
     let mut saw_second_line = false;
-    let min_indent = lines.iter().fold(uint::MAX, |min_indent, line| {
+    let min_indent = lines.iter().fold(usize::MAX, |min_indent, line| {
 
         // After we see the first non-whitespace line, look at
         // the line we have. If it is not whitespace, and therefore
@@ -322,7 +322,7 @@ pub fn unindent(s: &str) -> String {
             !line.chars().all(|c| c.is_whitespace());
 
         let min_indent = if ignore_previous_indents {
-            uint::MAX
+            usize::MAX
         } else {
             min_indent
         };

--- a/src/libserialize/collection_impls.rs
+++ b/src/libserialize/collection_impls.rs
@@ -10,7 +10,7 @@
 
 //! Implementations of serialization for structures found in libcollections
 
-use std::uint;
+use std::usize;
 use std::default::Default;
 use std::hash::{Hash, Hasher};
 use std::collections::hash_state::HashState;
@@ -148,7 +148,7 @@ impl<
     fn decode<D: Decoder>(d: &mut D) -> Result<EnumSet<T>, D::Error> {
         let bits = try!(d.read_uint());
         let mut set = EnumSet::new();
-        for bit in 0..uint::BITS {
+        for bit in 0..usize::BITS {
             if bits & (1 << bit) != 0 {
                 set.insert(CLike::from_usize(1 << bit));
             }

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -31,6 +31,7 @@ Core encoding and decoding interfaces.
 #![feature(int_uint)]
 #![feature(io)]
 #![feature(path)]
+#![feature(hash)]
 #![feature(rustc_private)]
 #![feature(slicing_syntax)]
 #![feature(staged_api)]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -164,6 +164,7 @@ pub use core::cell;
 pub use core::clone;
 #[cfg(not(test))] pub use core::cmp;
 pub use core::default;
+#[allow(deprecated)]
 pub use core::finally;
 pub use core::hash;
 pub use core::intrinsics;
@@ -306,8 +307,8 @@ mod std {
     pub use marker;  // used for tls!
     pub use ops; // used for bitflags!
 
-    // The test runner calls ::std::os::args() but really wants realstd
-    #[cfg(test)] pub use realstd::os as os;
+    // The test runner calls ::std::env::args() but really wants realstd
+    #[cfg(test)] pub use realstd::env as env;
     // The test runner requires std::slice::Vector, so re-export std::slice just for it.
     //
     // It is also used in vec![]

--- a/src/libstd/old_io/mem.rs
+++ b/src/libstd/old_io/mem.rs
@@ -66,6 +66,7 @@ impl Writer for Vec<u8> {
 #[deprecated(since = "1.0.0",
              reason = "use the Vec<u8> Writer implementation directly")]
 #[derive(Clone)]
+#[allow(deprecated)]
 pub struct MemWriter {
     buf: Vec<u8>,
 }

--- a/src/libstd/old_io/mod.rs
+++ b/src/libstd/old_io/mod.rs
@@ -249,7 +249,7 @@ use char::CharExt;
 use default::Default;
 use error::Error;
 use fmt;
-use int;
+use isize;
 use iter::{Iterator, IteratorExt};
 use marker::Sized;
 use mem::transmute;
@@ -265,7 +265,7 @@ use slice::SliceExt;
 use str::StrExt;
 use str;
 use string::String;
-use uint;
+use usize;
 use unicode;
 use vec::Vec;
 
@@ -711,28 +711,28 @@ pub trait Reader {
     ///
     /// The number of bytes returned is system-dependent.
     fn read_le_uint(&mut self) -> IoResult<uint> {
-        self.read_le_uint_n(uint::BYTES).map(|i| i as uint)
+        self.read_le_uint_n(usize::BYTES).map(|i| i as uint)
     }
 
     /// Reads a little-endian integer.
     ///
     /// The number of bytes returned is system-dependent.
     fn read_le_int(&mut self) -> IoResult<int> {
-        self.read_le_int_n(int::BYTES).map(|i| i as int)
+        self.read_le_int_n(isize::BYTES).map(|i| i as int)
     }
 
     /// Reads a big-endian unsigned integer.
     ///
     /// The number of bytes returned is system-dependent.
     fn read_be_uint(&mut self) -> IoResult<uint> {
-        self.read_be_uint_n(uint::BYTES).map(|i| i as uint)
+        self.read_be_uint_n(usize::BYTES).map(|i| i as uint)
     }
 
     /// Reads a big-endian integer.
     ///
     /// The number of bytes returned is system-dependent.
     fn read_be_int(&mut self) -> IoResult<int> {
-        self.read_be_int_n(int::BYTES).map(|i| i as int)
+        self.read_be_int_n(isize::BYTES).map(|i| i as int)
     }
 
     /// Reads a big-endian `u64`.
@@ -1095,25 +1095,25 @@ pub trait Writer {
     /// Write a little-endian uint (number of bytes depends on system).
     #[inline]
     fn write_le_uint(&mut self, n: uint) -> IoResult<()> {
-        extensions::u64_to_le_bytes(n as u64, uint::BYTES, |v| self.write_all(v))
+        extensions::u64_to_le_bytes(n as u64, usize::BYTES, |v| self.write_all(v))
     }
 
     /// Write a little-endian int (number of bytes depends on system).
     #[inline]
     fn write_le_int(&mut self, n: int) -> IoResult<()> {
-        extensions::u64_to_le_bytes(n as u64, int::BYTES, |v| self.write_all(v))
+        extensions::u64_to_le_bytes(n as u64, isize::BYTES, |v| self.write_all(v))
     }
 
     /// Write a big-endian uint (number of bytes depends on system).
     #[inline]
     fn write_be_uint(&mut self, n: uint) -> IoResult<()> {
-        extensions::u64_to_be_bytes(n as u64, uint::BYTES, |v| self.write_all(v))
+        extensions::u64_to_be_bytes(n as u64, usize::BYTES, |v| self.write_all(v))
     }
 
     /// Write a big-endian int (number of bytes depends on system).
     #[inline]
     fn write_be_int(&mut self, n: int) -> IoResult<()> {
-        extensions::u64_to_be_bytes(n as u64, int::BYTES, |v| self.write_all(v))
+        extensions::u64_to_be_bytes(n as u64, isize::BYTES, |v| self.write_all(v))
     }
 
     /// Write a big-endian u64 (8 bytes).
@@ -1843,7 +1843,7 @@ mod tests {
     use self::BadReaderBehavior::*;
     use super::{IoResult, Reader, MemReader, NoProgress, InvalidInput, Writer};
     use prelude::v1::{Ok, Vec, Buffer, SliceExt};
-    use uint;
+    use usize;
 
     #[derive(Clone, PartialEq, Debug)]
     enum BadReaderBehavior {
@@ -1890,24 +1890,24 @@ mod tests {
     #[test]
     fn test_read_at_least() {
         let mut r = BadReader::new(MemReader::new(b"hello, world!".to_vec()),
-                                   vec![GoodBehavior(uint::MAX)]);
+                                   vec![GoodBehavior(usize::MAX)]);
         let buf = &mut [0u8; 5];
         assert!(r.read_at_least(1, buf).unwrap() >= 1);
         assert!(r.read_exact(5).unwrap().len() == 5); // read_exact uses read_at_least
         assert!(r.read_at_least(0, buf).is_ok());
 
         let mut r = BadReader::new(MemReader::new(b"hello, world!".to_vec()),
-                                   vec![BadBehavior(50), GoodBehavior(uint::MAX)]);
+                                   vec![BadBehavior(50), GoodBehavior(usize::MAX)]);
         assert!(r.read_at_least(1, buf).unwrap() >= 1);
 
         let mut r = BadReader::new(MemReader::new(b"hello, world!".to_vec()),
                                    vec![BadBehavior(1), GoodBehavior(1),
-                                        BadBehavior(50), GoodBehavior(uint::MAX)]);
+                                        BadBehavior(50), GoodBehavior(usize::MAX)]);
         assert!(r.read_at_least(1, buf).unwrap() >= 1);
         assert!(r.read_at_least(1, buf).unwrap() >= 1);
 
         let mut r = BadReader::new(MemReader::new(b"hello, world!".to_vec()),
-                                   vec![BadBehavior(uint::MAX)]);
+                                   vec![BadBehavior(usize::MAX)]);
         assert_eq!(r.read_at_least(1, buf).unwrap_err().kind, NoProgress);
 
         let mut r = MemReader::new(b"hello, world!".to_vec());
@@ -1918,23 +1918,23 @@ mod tests {
     #[test]
     fn test_push_at_least() {
         let mut r = BadReader::new(MemReader::new(b"hello, world!".to_vec()),
-                                   vec![GoodBehavior(uint::MAX)]);
+                                   vec![GoodBehavior(usize::MAX)]);
         let mut buf = Vec::new();
         assert!(r.push_at_least(1, 5, &mut buf).unwrap() >= 1);
         assert!(r.push_at_least(0, 5, &mut buf).is_ok());
 
         let mut r = BadReader::new(MemReader::new(b"hello, world!".to_vec()),
-                                   vec![BadBehavior(50), GoodBehavior(uint::MAX)]);
+                                   vec![BadBehavior(50), GoodBehavior(usize::MAX)]);
         assert!(r.push_at_least(1, 5, &mut buf).unwrap() >= 1);
 
         let mut r = BadReader::new(MemReader::new(b"hello, world!".to_vec()),
                                    vec![BadBehavior(1), GoodBehavior(1),
-                                        BadBehavior(50), GoodBehavior(uint::MAX)]);
+                                        BadBehavior(50), GoodBehavior(usize::MAX)]);
         assert!(r.push_at_least(1, 5, &mut buf).unwrap() >= 1);
         assert!(r.push_at_least(1, 5, &mut buf).unwrap() >= 1);
 
         let mut r = BadReader::new(MemReader::new(b"hello, world!".to_vec()),
-                                   vec![BadBehavior(uint::MAX)]);
+                                   vec![BadBehavior(usize::MAX)]);
         assert_eq!(r.push_at_least(1, 5, &mut buf).unwrap_err().kind, NoProgress);
 
         let mut r = MemReader::new(b"hello, world!".to_vec());

--- a/src/libstd/old_io/stdio.rs
+++ b/src/libstd/old_io/stdio.rs
@@ -48,7 +48,7 @@ use str::StrExt;
 use string::String;
 use sys::{fs, tty};
 use sync::{Arc, Mutex, MutexGuard, Once, ONCE_INIT};
-use uint;
+use usize;
 use vec::Vec;
 
 // And so begins the tale of acquiring a uv handle to a stdio stream on all
@@ -383,12 +383,14 @@ pub fn println(s: &str) {
 
 /// Similar to `print`, but takes a `fmt::Arguments` structure to be compatible
 /// with the `format_args!` macro.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub fn print_args(fmt: fmt::Arguments) {
     with_task_stdout(|io| write!(io, "{}", fmt))
 }
 
 /// Similar to `println`, but takes a `fmt::Arguments` structure to be
 /// compatible with the `format_args!` macro.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub fn println_args(fmt: fmt::Arguments) {
     with_task_stdout(|io| writeln!(io, "{}", fmt))
 }
@@ -510,7 +512,7 @@ impl Writer for StdWriter {
         //
         // [1]: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/1232
         // [2]: http://www.mail-archive.com/log4net-dev@logging.apache.org/msg00661.html
-        let max_size = if cfg!(windows) {8192} else {uint::MAX};
+        let max_size = if cfg!(windows) {8192} else {usize::MAX};
         for chunk in buf.chunks(max_size) {
             try!(match self.inner {
                 TTY(ref mut tty) => tty.write(chunk),

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -317,6 +317,7 @@ pub unsafe fn pipe() -> IoResult<Pipe> {
 #[cfg(not(target_os="ios"))]
 #[deprecated(since = "1.0.0", reason = "this function will be removed, use the constants directly")]
 #[unstable(feature = "os")]
+#[allow(deprecated)]
 pub fn dll_filename(base: &str) -> String {
     format!("{}{}{}", consts::DLL_PREFIX, base, consts::DLL_SUFFIX)
 }

--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -494,6 +494,7 @@ pub extern fn rust_begin_unwind(msg: fmt::Arguments,
 /// on (e.g.) the inlining of other functions as possible), by moving
 /// the actual formatting into this shared place.
 #[inline(never)] #[cold]
+#[stable(since = "1.0.0", feature = "rust1")]
 pub fn begin_unwind_fmt(msg: fmt::Arguments, file_line: &(&'static str, uint)) -> ! {
     use fmt::Writer;
 
@@ -509,6 +510,7 @@ pub fn begin_unwind_fmt(msg: fmt::Arguments, file_line: &(&'static str, uint)) -
 
 /// This is the entry point of unwinding for panic!() and assert!().
 #[inline(never)] #[cold] // avoid code bloat at the call sites as much as possible
+#[stable(since = "1.0.0", feature = "rust1")]
 pub fn begin_unwind<M: Any + Send>(msg: M, file_line: &(&'static str, uint)) -> ! {
     // Note that this should be the only allocation performed in this code path.
     // Currently this means that panic!() on OOM will invoke this code path,

--- a/src/libstd/sync/mpsc/select.rs
+++ b/src/libstd/sync/mpsc/select.rs
@@ -61,7 +61,7 @@ use core::cell::Cell;
 use core::marker;
 use core::mem;
 use core::ptr;
-use core::uint;
+use core::usize;
 
 use sync::mpsc::{Receiver, RecvError};
 use sync::mpsc::blocking::{self, SignalToken};
@@ -228,7 +228,7 @@ impl Select {
             // A rewrite should focus on avoiding a yield loop, and for now this
             // implementation is tying us over to a more efficient "don't
             // iterate over everything every time" implementation.
-            let mut ready_id = uint::MAX;
+            let mut ready_id = usize::MAX;
             for handle in self.iter() {
                 if (*handle).packet.abort_selection() {
                     ready_id = (*handle).id;
@@ -236,7 +236,7 @@ impl Select {
             }
 
             // We must have found a ready receiver
-            assert!(ready_id != uint::MAX);
+            assert!(ready_id != usize::MAX);
             return ready_id;
         }
     }

--- a/src/libstd/sync/mpsc/shared.rs
+++ b/src/libstd/sync/mpsc/shared.rs
@@ -23,7 +23,7 @@ pub use self::Failure::*;
 use core::prelude::*;
 
 use core::cmp;
-use core::int;
+use core::isize;
 
 use sync::atomic::{AtomicUsize, AtomicIsize, AtomicBool, Ordering};
 use sync::mpsc::blocking::{self, SignalToken};
@@ -33,17 +33,17 @@ use sync::mpsc::select::StartResult;
 use sync::{Mutex, MutexGuard};
 use thread::Thread;
 
-const DISCONNECTED: int = int::MIN;
-const FUDGE: int = 1024;
+const DISCONNECTED: isize = isize::MIN;
+const FUDGE: isize = 1024;
 #[cfg(test)]
-const MAX_STEALS: int = 5;
+const MAX_STEALS: isize = 5;
 #[cfg(not(test))]
-const MAX_STEALS: int = 1 << 20;
+const MAX_STEALS: isize = 1 << 20;
 
 pub struct Packet<T> {
     queue: mpsc::Queue<T>,
     cnt: AtomicIsize, // How many items are on this channel
-    steals: int, // How many times has a port received without blocking?
+    steals: isize, // How many times has a port received without blocking?
     to_wake: AtomicUsize, // SignalToken for wake up
 
     // The number of channels which are currently using this packet.

--- a/src/libstd/sync/mpsc/stream.rs
+++ b/src/libstd/sync/mpsc/stream.rs
@@ -25,7 +25,7 @@ use self::Message::*;
 use core::prelude::*;
 
 use core::cmp;
-use core::int;
+use core::isize;
 use thread::Thread;
 
 use sync::atomic::{AtomicIsize, AtomicUsize, Ordering, AtomicBool};
@@ -33,11 +33,11 @@ use sync::mpsc::Receiver;
 use sync::mpsc::blocking::{self, SignalToken};
 use sync::mpsc::spsc_queue as spsc;
 
-const DISCONNECTED: int = int::MIN;
+const DISCONNECTED: isize = isize::MIN;
 #[cfg(test)]
-const MAX_STEALS: int = 5;
+const MAX_STEALS: isize = 5;
 #[cfg(not(test))]
-const MAX_STEALS: int = 1 << 20;
+const MAX_STEALS: isize = 1 << 20;
 
 pub struct Packet<T> {
     queue: spsc::Queue<Message<T>>, // internal queue for all message

--- a/src/libstd/sync/once.rs
+++ b/src/libstd/sync/once.rs
@@ -13,7 +13,7 @@
 //! This primitive is meant to be used to run one-time initialization. An
 //! example use case would be for initializing an FFI library.
 
-use int;
+use isize;
 use marker::Sync;
 use mem::drop;
 use ops::FnOnce;
@@ -99,9 +99,9 @@ impl Once {
 
         let prev = self.cnt.fetch_add(1, Ordering::SeqCst);
         if prev < 0 {
-            // Make sure we never overflow, we'll never have int::MIN
+            // Make sure we never overflow, we'll never have isize::MIN
             // simultaneous calls to `call_once` to make this value go back to 0
-            self.cnt.store(int::MIN, Ordering::SeqCst);
+            self.cnt.store(isize::MIN, Ordering::SeqCst);
             return
         }
 
@@ -111,7 +111,7 @@ impl Once {
         let guard = self.mutex.lock();
         if self.cnt.load(Ordering::SeqCst) > 0 {
             f();
-            let prev = self.cnt.swap(int::MIN, Ordering::SeqCst);
+            let prev = self.cnt.swap(isize::MIN, Ordering::SeqCst);
             self.lock_cnt.store(prev, Ordering::SeqCst);
         }
         drop(guard);

--- a/src/libstd/sys/common/thread.rs
+++ b/src/libstd/sys/common/thread.rs
@@ -12,7 +12,7 @@ use core::prelude::*;
 
 use boxed::Box;
 use mem;
-use uint;
+use usize;
 use libc;
 use thunk::Thunk;
 use sys_common::stack;
@@ -25,7 +25,7 @@ use sys::{thread, stack_overflow};
 #[no_stack_check]
 pub fn start_thread(main: *mut libc::c_void) -> thread::rust_thread_return {
     unsafe {
-        stack::record_os_managed_stack_bounds(0, uint::MAX);
+        stack::record_os_managed_stack_bounds(0, usize::MAX);
         let handler = stack_overflow::Handler::new();
         let f: Box<Thunk> = mem::transmute(main);
         f.invoke(());

--- a/src/libstd/sys/unix/c.rs
+++ b/src/libstd/sys/unix/c.rs
@@ -179,20 +179,20 @@ mod select {
           target_os = "openbsd",
           target_os = "linux"))]
 mod select {
-    use uint;
+    use usize;
     use libc;
 
-    pub const FD_SETSIZE: uint = 1024;
+    pub const FD_SETSIZE: usize = 1024;
 
     #[repr(C)]
     pub struct fd_set {
         // FIXME: shouldn't this be a c_ulong?
-        fds_bits: [libc::uintptr_t; (FD_SETSIZE / uint::BITS)]
+        fds_bits: [libc::uintptr_t; (FD_SETSIZE / usize::BITS)]
     }
 
     pub fn fd_set(set: &mut fd_set, fd: i32) {
         let fd = fd as uint;
-        set.fds_bits[fd / uint::BITS] |= 1 << (fd % uint::BITS);
+        set.fds_bits[fd / usize::BITS] |= 1 << (fd % usize::BITS);
     }
 }
 

--- a/src/libstd/thread_local/mod.rs
+++ b/src/libstd/thread_local/mod.rs
@@ -335,6 +335,7 @@ mod imp {
     use ptr;
 
     #[doc(hidden)]
+    #[stable(since = "1.0.0", feature = "rust1")]
     pub struct Key<T> {
         // Place the inner bits in an `UnsafeCell` to currently get around the
         // "only Sync statics" restriction. This allows any type to be placed in
@@ -342,11 +343,14 @@ mod imp {
         //
         // Note that all access requires `T: 'static` so it can't be a type with
         // any borrowed pointers still.
+        #[stable(since = "1.0.0", feature = "rust1")]
         pub inner: UnsafeCell<T>,
 
         // Metadata to keep track of the state of the destructor. Remember that
         // these variables are thread-local, not global.
+        #[stable(since = "1.0.0", feature = "rust1")]
         pub dtor_registered: UnsafeCell<bool>, // should be Cell
+        #[stable(since = "1.0.0", feature = "rust1")]
         pub dtor_running: UnsafeCell<bool>, // should be Cell
     }
 
@@ -468,12 +472,15 @@ mod imp {
     use sys_common::thread_local::StaticKey as OsStaticKey;
 
     #[doc(hidden)]
+    #[stable(since = "1.0.0", feature = "rust1")]
     pub struct Key<T> {
         // Statically allocated initialization expression, using an `UnsafeCell`
         // for the same reasons as above.
+        #[stable(since = "1.0.0", feature = "rust1")]
         pub inner: UnsafeCell<T>,
 
         // OS-TLS key that we'll use to key off.
+        #[stable(since = "1.0.0", feature = "rust1")]
         pub os: OsStaticKey,
     }
 

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -436,40 +436,28 @@ fn mk_main(cx: &mut TestCtxt) -> P<ast::Item> {
     let sp = ignored_span(cx, DUMMY_SP);
     let ecx = &cx.ext_cx;
 
-    // std::slice::AsSlice
-    let as_slice_path = ecx.path(sp, vec![token::str_to_ident("std"),
-                                          token::str_to_ident("slice"),
-                                          token::str_to_ident("AsSlice")]);
     // test::test_main_static
     let test_main_path = ecx.path(sp, vec![token::str_to_ident("test"),
                                            token::str_to_ident("test_main_static")]);
-    // ::std::os::args
+    // ::std::env::args
     let os_args_path = ecx.path_global(sp, vec![token::str_to_ident("std"),
-                                                token::str_to_ident("os"),
+                                                token::str_to_ident("env"),
                                                 token::str_to_ident("args")]);
-    // use std::slice::AsSlice
-    let as_slice_path = P(nospan(ast::ViewPathSimple(token::str_to_ident("AsSlice"),
-                                                     as_slice_path)));
-    let use_as_slice = ecx.item_use(sp, ast::Inherited, as_slice_path);
-    let use_as_slice = ecx.stmt_item(sp, use_as_slice);
-    // ::std::os::args()
+    // ::std::env::args()
     let os_args_path_expr = ecx.expr_path(os_args_path);
     let call_os_args = ecx.expr_call(sp, os_args_path_expr, vec![]);
-    // ::std::os::args().as_slice()
-    let call_as_slice = ecx.expr_method_call(sp, call_os_args,
-                                             token::str_to_ident("as_slice"), vec![]);
     // test::test_main_static(...)
     let test_main_path_expr = ecx.expr_path(test_main_path);
     let tests_ident_expr = ecx.expr_ident(sp, token::str_to_ident("TESTS"));
     let call_test_main = ecx.expr_call(sp, test_main_path_expr,
-                                       vec![call_as_slice, tests_ident_expr]);
+                                       vec![call_os_args, tests_ident_expr]);
     let call_test_main = ecx.stmt_expr(call_test_main);
     // #![main]
     let main_meta = ecx.meta_word(sp, token::intern_and_get_ident("main"));
     let main_attr = ecx.attribute(sp, main_meta);
     // pub fn main() { ... }
     let main_ret_ty = ecx.ty(sp, ast::TyTup(vec![]));
-    let main_body = ecx.block_all(sp, vec![use_as_slice, call_test_main], None);
+    let main_body = ecx.block_all(sp, vec![call_test_main], None);
     let main = ast::ItemFn(ecx.fn_decl(vec![], main_ret_ty),
                            ast::Unsafety::Normal, ::abi::Rust, empty_generics(), main_body);
     let main = P(ast::Item {

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -50,6 +50,7 @@
        html_playground_url = "http://play.rust-lang.org/")]
 #![deny(missing_docs)]
 
+#![feature(core)]
 #![feature(box_syntax)]
 #![feature(collections)]
 #![feature(int_uint)]

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -40,6 +40,7 @@
 #![feature(hash)]
 #![feature(int_uint)]
 #![feature(io)]
+#![feature(os)]
 #![feature(path)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
@@ -265,7 +266,8 @@ pub fn test_main(args: &[String], tests: Vec<TestDescAndFn> ) {
 // a ~[TestDescAndFn] is used in order to effect ownership-transfer
 // semantics into parallel test runners, which in turn requires a ~[]
 // rather than a &[].
-pub fn test_main_static(args: &[String], tests: &[TestDescAndFn]) {
+pub fn test_main_static(args: env::Args, tests: &[TestDescAndFn]) {
+    let args = args.map(|s| s.into_string().unwrap()).collect::<Vec<_>>();
     let owned_tests = tests.iter().map(|t| {
         match t.testfn {
             StaticTestFn(f) => TestDescAndFn { testfn: StaticTestFn(f), desc: t.desc.clone() },
@@ -273,7 +275,7 @@ pub fn test_main_static(args: &[String], tests: &[TestDescAndFn]) {
             _ => panic!("non-static tests passed to test::test_main_static")
         }
     }).collect();
-    test_main(args, owned_tests)
+    test_main(&args, owned_tests)
 }
 
 #[derive(Copy)]

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -98,12 +98,10 @@ mod cross_crate {
         // Eventually, we will want to lint the contents of the
         // macro in the module *defining* it. Also, stability levels
         // on macros themselves are not yet linted.
-        macro_test!();
         macro_test_arg!(deprecated_text()); //~ ERROR use of deprecated item: text
         macro_test_arg!(deprecated_unstable_text()); //~ ERROR use of deprecated item: text
         //~^ WARNING use of unstable library feature
         macro_test_arg!(macro_test_arg!(deprecated_text())); //~ ERROR use of deprecated item: text
-        macro_test_arg_nested!(deprecated_text);
     }
 
     fn test_method_param<F: Trait>(foo: F) {
@@ -139,7 +137,7 @@ mod cross_crate {
 
 mod inheritance {
     extern crate inherited_stability; //~ WARNING: use of unstable library feature
-    use self::inherited_stability::*;
+    use self::inherited_stability::*; //~ WARNING: use of unstable library feature
 
     fn test_inheritance() {
         unstable(); //~ WARNING use of unstable library feature

--- a/src/test/compile-fail/lint-stability2.rs
+++ b/src/test/compile-fail/lint-stability2.rs
@@ -8,19 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(simd, core)]
-#![allow(dead_code)]
+// aux-build:lint_stability.rs
+// error-pattern: use of deprecated item
 
-use std::simd::f32x4;
+#![deny(deprecated)]
 
-#[simd] #[derive(Copy)] #[repr(C)] struct LocalSimd(u8, u8);
+#[macro_use]
+extern crate lint_stability;
 
-extern {
-    fn foo() -> f32x4; //~ ERROR use of SIMD type
-    fn bar(x: f32x4); //~ ERROR use of SIMD type
+use lint_stability::*;
 
-    fn baz() -> LocalSimd; //~ ERROR use of SIMD type
-    fn qux(x: LocalSimd); //~ ERROR use of SIMD type
+fn main() {
+    macro_test!();
 }
-
-fn main() {}

--- a/src/test/compile-fail/lint-stability3.rs
+++ b/src/test/compile-fail/lint-stability3.rs
@@ -8,19 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(simd, core)]
-#![allow(dead_code)]
+// aux-build:lint_stability.rs
+// error-pattern: use of deprecated item
 
-use std::simd::f32x4;
+#![deny(deprecated)]
+#![allow(warnings)]
 
-#[simd] #[derive(Copy)] #[repr(C)] struct LocalSimd(u8, u8);
+#[macro_use]
+extern crate lint_stability;
 
-extern {
-    fn foo() -> f32x4; //~ ERROR use of SIMD type
-    fn bar(x: f32x4); //~ ERROR use of SIMD type
+use lint_stability::*;
 
-    fn baz() -> LocalSimd; //~ ERROR use of SIMD type
-    fn qux(x: LocalSimd); //~ ERROR use of SIMD type
+fn main() {
+    macro_test_arg_nested!(deprecated_text);
 }
 
-fn main() {}


### PR DESCRIPTION
There are a number of holes that the stability lint did not previously cover,
including:
- Types
- Bounds on type parameters on functions and impls
- Where clauses
- Imports
- Patterns (structs and enums)

These holes have all been fixed by overriding the `visit_path` function on the
AST visitor instead of a few specialized cases. This change also necessitated a
few stability changes:
- The `collections::fmt` module is now stable (it was already supposed to be).
- The `thread_local::imp::Key` type is now stable (it was already supposed to
  be).
- The `std::rt::{begin_unwind, begin_unwind_fmt}` functions are now stable.
  These are required via the `panic!` macro.
- The `std::old_io::stdio::{println, println_args}` functions are now stable.
  These are required by the `print!` and `println!` macros.
- The `ops::{FnOnce, FnMut, Fn}` traits are now `#[stable]`. This is required to
  make bounds with these traits stable. Note that manual implementations of
  these traits are still gated by default, this stability only allows bounds
  such as `F: FnOnce()`.

Closes #8962
Closes #16360
Closes #20327
