### PR TITLE
parse cfgspecs passed to rustdoc

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -24,11 +24,8 @@ use rustc::session::{self, config};
 use rustc::session::config::get_unstable_features_setting;
 use rustc::session::search_paths::{SearchPaths, PathKind};
 use rustc_driver::{driver, Compilation};
-use syntax::ast;
-use syntax::codemap::{CodeMap, dummy_spanned};
+use syntax::codemap::CodeMap;
 use syntax::diagnostic;
-use syntax::parse::token;
-use syntax::ptr::P;
 
 use core;
 use clean;
@@ -67,10 +64,7 @@ pub fn run(input: &str,
                                       span_diagnostic_handler);
 
     let mut cfg = config::build_configuration(&sess);
-    cfg.extend(cfgs.into_iter().map(|cfg_| {
-        let cfg_ = token::intern_and_get_ident(&cfg_);
-        P(dummy_spanned(ast::MetaWord(cfg_)))
-    }));
+    cfg.extend(config::parse_cfgspecs(cfgs).into_iter());
     let krate = driver::phase_1_parse_input(&sess, cfg, &input);
     let krate = driver::phase_2_configure_and_expand(&sess, krate,
                                                      "rustdoc-test", None)

--- a/src/test/run-make/issue-22131/Makefile
+++ b/src/test/run-make/issue-22131/Makefile
@@ -1,0 +1,6 @@
+-include ../tools.mk
+
+all: foo.rs
+	$(RUSTC) --cfg 'feature="bar"' --crate-type lib foo.rs
+	$(RUSTDOC) --test --cfg 'feature="bar"' -L $(TMPDIR) foo.rs |\
+	grep --quiet 'test foo_0 ... ok'

--- a/src/test/run-make/issue-22131/foo.rs
+++ b/src/test/run-make/issue-22131/foo.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name="foo"]
+
+/// ```rust
+/// assert_eq!(foo::foo(), 1);
+/// ```
+#[cfg(feature = "bar")]
+pub fn foo() -> i32 { 1 }


### PR DESCRIPTION
fixes #22131 
