### PR TITLE
Add error message (i.e. do not ICE) when moving out of unsafe pointers.

### DIFF
--- a/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
@@ -118,6 +118,7 @@ fn report_cannot_move_out_of<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>,
     match move_from.cat {
         mc::cat_deref(_, _, mc::BorrowedPtr(..)) |
         mc::cat_deref(_, _, mc::Implicit(..)) |
+        mc::cat_deref(_, _, mc::UnsafePtr(..)) |
         mc::cat_static_item => {
             bccx.span_err(move_from.span,
                           &format!("cannot move out of {}",

--- a/src/test/compile-fail/issue-20801.rs
+++ b/src/test/compile-fail/issue-20801.rs
@@ -1,0 +1,47 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// We used to ICE when moving out of a `*mut T` or `*const T`.
+
+struct T(u8);
+
+static mut GLOBAL_MUT_T: T = T(0);
+
+static GLOBAL_T: T = T(0);
+
+fn imm_ref() -> &'static T {
+    unsafe { &GLOBAL_T }
+}
+
+fn mut_ref() -> &'static mut T {
+    unsafe { &mut GLOBAL_MUT_T }
+}
+
+fn mut_ptr() -> *mut T {
+    unsafe { 0u8 as *mut T }
+}
+
+fn const_ptr() -> *const T {
+    unsafe { 0u8 as *const T }
+}
+
+pub fn main() {
+    let a = unsafe { *mut_ref() };
+    //~^ ERROR cannot move out of dereference of borrowed content
+
+    let b = unsafe { *imm_ref() };
+    //~^ ERROR cannot move out of dereference of borrowed content
+
+    let c = unsafe { *mut_ptr() };
+    //~^ ERROR cannot move out of dereference of unsafe pointer
+
+    let d = unsafe { *const_ptr() };
+    //~^ ERROR cannot move out of dereference of unsafe pointer
+}


### PR DESCRIPTION
Add error message (i.e. do not ICE) when moving out of unsafe pointers.

Fix #20801.
