### PR TITLE
Fix ICE when compiling "extern" rust functions

### DIFF
--- a/src/test/run-pass/extern-rust.rs
+++ b/src/test/run-pass/extern-rust.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[repr(C)]
+pub struct Foo(u32);
+
+// ICE trigger, bad handling of differing types between rust and external ABIs
+pub extern fn bar() -> Foo {
+    Foo(0)
+}
+
+fn main() {}


### PR DESCRIPTION
As the function comment already says, the types generated in the
foreign_signture function don't necessarily match the types used for a
corresponding rust function. Therefore we can't just use these types to
guide the translation of the wrapper function that bridges between the
external ABI and the rust ABI. Instead, we can query LLVM about the
types used in the rust function and use those to generate an appropriate
wrapper.

Fixes #21454
