### PR TITLE
Remove FIXME in librbml

### DIFF
--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -738,7 +738,6 @@ pub mod writer {
         })
     }
 
-    // FIXME (#2741): Provide a function to write the standard rbml header.
     impl<'a, W: Writer + Seek> Encoder<'a, W> {
         pub fn new(w: &'a mut W) -> Encoder<'a, W> {
             Encoder {


### PR DESCRIPTION
Given that this is entirely internal, this enhancement isn't going to be needed. And if it is, we'll add it.

Closes #2741.
