### PR TITLE
Grammar updates

### DIFF
--- a/src/grammar/parser-lalr.y
+++ b/src/grammar/parser-lalr.y
@@ -177,6 +177,8 @@ extern char *yytext;
 
 %precedence '{' '[' '(' '.'
 
+%precedence RANGE
+
 %start crate
 
 %%
@@ -1475,7 +1477,7 @@ expr_nostruct
 | expr_nostruct '*' expr_nostruct                     { $$ = mk_node("ExprBinary", 3, mk_atom("BiMul"), $1, $3); }
 | expr_nostruct '/' expr_nostruct                     { $$ = mk_node("ExprBinary", 3, mk_atom("BiDiv"), $1, $3); }
 | expr_nostruct '%' expr_nostruct                     { $$ = mk_node("ExprBinary", 3, mk_atom("BiRem"), $1, $3); }
-| expr_nostruct DOTDOT                                { $$ = mk_node("ExprRange", 2, $1, mk_none()); }
+| expr_nostruct DOTDOT               %prec RANGE      { $$ = mk_node("ExprRange", 2, $1, mk_none()); }
 | expr_nostruct DOTDOT expr_nostruct                  { $$ = mk_node("ExprRange", 2, $1, $3); }
 |               DOTDOT expr_nostruct                  { $$ = mk_node("ExprRange", 2, mk_none(), $2); }
 |               DOTDOT                                { $$ = mk_node("ExprRange", 2, mk_none(), mk_none()); }

--- a/src/grammar/parser-lalr.y
+++ b/src/grammar/parser-lalr.y
@@ -1309,6 +1309,7 @@ nonblock_expr
 | nonblock_expr AS ty                                           { $$ = mk_node("ExprCast", 2, $1, $3); }
 | BOX nonparen_expr                                             { $$ = mk_node("ExprBox", 1, $2); }
 | %prec BOXPLACE BOX '(' maybe_expr ')' nonblock_expr           { $$ = mk_node("ExprBox", 2, $3, $5); }
+| expr_qualified_path
 | nonblock_prefix_expr
 ;
 
@@ -1367,6 +1368,7 @@ expr
 | expr AS ty                                          { $$ = mk_node("ExprCast", 2, $1, $3); }
 | BOX nonparen_expr                                   { $$ = mk_node("ExprBox", 1, $2); }
 | %prec BOXPLACE BOX '(' maybe_expr ')' expr          { $$ = mk_node("ExprBox", 2, $3, $5); }
+| expr_qualified_path
 | block_expr
 | block
 | nonblock_prefix_expr
@@ -1426,6 +1428,7 @@ nonparen_expr
 | nonparen_expr AS ty                                 { $$ = mk_node("ExprCast", 2, $1, $3); }
 | BOX nonparen_expr                                   { $$ = mk_node("ExprBox", 1, $2); }
 | %prec BOXPLACE BOX '(' maybe_expr ')' expr          { $$ = mk_node("ExprBox", 1, $3, $5); }
+| expr_qualified_path
 | block_expr
 | block
 | nonblock_prefix_expr
@@ -1485,6 +1488,7 @@ expr_nostruct
 | expr_nostruct AS ty                                 { $$ = mk_node("ExprCast", 2, $1, $3); }
 | BOX nonparen_expr                                   { $$ = mk_node("ExprBox", 1, $2); }
 | %prec BOXPLACE BOX '(' maybe_expr ')' expr_nostruct { $$ = mk_node("ExprBox", 1, $3, $5); }
+| expr_qualified_path
 | block_expr
 | block
 | nonblock_prefix_expr_nostruct
@@ -1511,6 +1515,33 @@ nonblock_prefix_expr
 | MOVE lambda_expr                 { $$ = $2; }
 | proc_expr
 ;
+
+expr_qualified_path
+: '<' ty_sum AS trait_ref '>' MOD_SEP ident
+{
+  $$ = mk_node("ExprQualifiedPath", 3, $2, $4, $7);
+}
+| '<' ty_sum AS trait_ref '>' MOD_SEP ident generic_args
+{
+  $$ = mk_node("ExprQualifiedPath", 4, $2, $4, $7, $8);
+}
+| SHL ty_sum AS trait_ref '>' MOD_SEP ident AS trait_ref '>' MOD_SEP ident
+{
+  $$ = mk_node("ExprQualifiedPath", 3, mk_node("ExprQualifiedPath", 3, $2, $4, $7), $9, $12);
+}
+| SHL ty_sum AS trait_ref '>' MOD_SEP ident generic_args AS trait_ref '>' MOD_SEP ident
+{
+  $$ = mk_node("ExprQualifiedPath", 3, mk_node("ExprQualifiedPath", 4, $2, $4, $7, $8), $10, $13);
+}
+| SHL ty_sum AS trait_ref '>' MOD_SEP ident AS trait_ref '>' MOD_SEP ident generic_args
+{
+  $$ = mk_node("ExprQualifiedPath", 4, mk_node("ExprQualifiedPath", 3, $2, $4, $7), $9, $12, $13);
+}
+| SHL ty_sum AS trait_ref '>' MOD_SEP ident generic_args AS trait_ref '>' MOD_SEP ident generic_args
+{
+  $$ = mk_node("ExprQualifiedPath", 4, mk_node("ExprQualifiedPath", 4, $2, $4, $7, $8), $10, $13, $14);
+}
+
 
 lambda_expr
 : %prec LAMBDA

--- a/src/grammar/parser-lalr.y
+++ b/src/grammar/parser-lalr.y
@@ -258,11 +258,7 @@ mod_item
 
 // items that can appear outside of a fn block
 item
-: item_static
-| item_const
-| item_type
-| block_item
-| view_item
+: stmt_item
 | item_macro
 ;
 
@@ -272,8 +268,7 @@ stmt_item
 | item_const
 | item_type
 | block_item
-| use_item
-| extern_fn_item
+| view_item
 ;
 
 item_static
@@ -295,7 +290,6 @@ view_item
 : use_item
 | extern_fn_item
 | EXTERN CRATE ident ';'                      { $$ = mk_node("ViewItemExternCrate", 1, $3); }
-| EXTERN CRATE ident '=' str ';'              { $$ = mk_node("ViewItemExternCrate", 2, $3, $5); }
 | EXTERN CRATE str AS ident ';'               { $$ = mk_node("ViewItemExternCrate", 2, $3, $5); }
 ;
 


### PR DESCRIPTION
Updates to the bison grammar:
- Fixes to range syntax - allow `expr[..]`, and fix precedence to allow `for _ in i.. { }`
- Allow "extern crate" in stmts
- Add qualified path expressions (`<TYPE as TRAIT_REF>::item`)
