### PR TITLE
docs: disable PDF docs when latex _isn't_ present

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -87,7 +87,7 @@ endif
 
 # Check for xelatex
 
-ifeq ($(CFG_XELATEX),)
+ifneq ($(CFG_XELATEX),)
     CFG_LATEX := $(CFG_XELATEX)
     XELATEX = 1
   else


### PR DESCRIPTION
`make docs` fails when (xe)latex is not installed. The output is pretty weird, looks like it's doing some `eval` tricks but something is blank:

```
/bin/sh: -output-directory=.: command not found
/home/tim/dev/rust/rust/mk/docs.mk:220: recipe for target 'doc/reference.pdf' failed
```

I have neither latex or xelatex installed. It seems like the following snippet is meant for me, but the logic is backwards:

```
ifeq ($(CFG_XELATEX),)
    CFG_LATEX := $(CFG_XELATEX)
    XELATEX = 1
  else
    $(info cfg: no xelatex found, disabling LaTeX docs)
    NO_PDF_DOCS = 1
endif
```

I verified with:

```
$ make doc/reference.pdf CFG_XELATEX=/bin/foo
cfg: no xelatex found, disabling LaTeX docs
```
