### PR TITLE
Feature gate `box` patterns

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -3196,6 +3196,7 @@ stands for a *single* data field, whereas a wildcard `..` stands for *all* the
 fields of a particular variant. For example:
 
 ```
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 enum List<X> { Nil, Cons(X, Box<List<X>>) }
 
@@ -3259,6 +3260,7 @@ the inside of the match.
 An example of a `match` expression:
 
 ```
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 # fn process_pair(a: i32, b: i32) { }
 # fn process_ten() { }
@@ -3294,6 +3296,7 @@ Subpatterns can also be bound to variables by the use of the syntax `variable @
 subpattern`. For example:
 
 ```
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 enum List { Nil, Cons(uint, Box<List>) }

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -24,6 +24,7 @@
 
 #![feature(alloc)]
 #![feature(box_syntax)]
+#![feature(box_patterns)]
 #![feature(core)]
 #![feature(hash)]
 #![feature(staged_api)]

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -23,6 +23,7 @@
       html_favicon_url = "http://www.rust-lang.org/favicon.ico",
       html_root_url = "http://doc.rust-lang.org/nightly/")]
 
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(collections)]
 #![feature(core)]

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -24,6 +24,7 @@
       html_root_url = "http://doc.rust-lang.org/nightly/")]
 
 #![feature(alloc)]
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(collections)]
 #![feature(core)]

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -74,6 +74,7 @@ This API is completely unstable and subject to change.
 
 #![allow(non_camel_case_types)]
 
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(collections)]
 #![feature(core)]

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -18,6 +18,7 @@
        html_root_url = "http://doc.rust-lang.org/nightly/",
        html_playground_url = "http://play.rust-lang.org/")]
 
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(collections)]
 #![feature(core)]

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -491,7 +491,7 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
             ast::PatBox(..) => {
                 self.gate_feature("box_patterns",
                                   pattern.span,
-                                  "box pattern syntax is experimental in alpha release");
+                                  "box pattern syntax is experimental");
             }
             _ => {}
         }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -126,6 +126,9 @@ static KNOWN_FEATURES: &'static [(&'static str, &'static str, Status)] = &[
 
     // Allows using #![no_std]
     ("no_std", "1.0.0", Active),
+
+    // Allows using `box` in patterns; RFC 469
+    ("box_patterns", "1.0.0", Active),
 ];
 
 enum Status {
@@ -486,7 +489,7 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
                                    `[0, ..xs, 0]` are experimental")
             }
             ast::PatBox(..) => {
-                self.gate_feature("box_syntax",
+                self.gate_feature("box_patterns",
                                   pattern.span,
                                   "box pattern syntax is experimental in alpha release");
             }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -430,7 +430,7 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
             ast::ExprBox(..) | ast::ExprUnary(ast::UnOp::UnUniq, _) => {
                 self.gate_feature("box_syntax",
                                   e.span,
-                                  "box expression syntax is experimental in alpha release; \
+                                  "box expression syntax is experimental; \
                                    you can call `Box::new` instead.");
             }
             ast::ExprLit(ref lit) => {

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -23,6 +23,7 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/nightly/")]
 
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(collections)]
 #![feature(core)]

--- a/src/test/compile-fail/borrowck-loan-in-overloaded-op.rs
+++ b/src/test/compile-fail/borrowck-loan-in-overloaded-op.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 use std::ops::Add;

--- a/src/test/compile-fail/borrowck-vec-pattern-nesting.rs
+++ b/src/test/compile-fail/borrowck-vec-pattern-nesting.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(advanced_slice_patterns)]
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 fn a() {

--- a/src/test/compile-fail/destructure-trait-ref.rs
+++ b/src/test/compile-fail/destructure-trait-ref.rs
@@ -11,6 +11,7 @@
 // The regression test for #15031 to make sure destructuring trait
 // reference work properly.
 
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 trait T {}

--- a/src/test/compile-fail/feature-gate-box-expr.rs
+++ b/src/test/compile-fail/feature-gate-box-expr.rs
@@ -11,13 +11,13 @@
 fn main() {
     use std::boxed::HEAP;
 
-    let x = box 'c'; //~ ERROR box expression syntax is experimental in alpha release
+    let x = box 'c'; //~ ERROR box expression syntax is experimental
     println!("x: {}", x);
 
-    let x = box () 'c'; //~ ERROR box expression syntax is experimental in alpha release
+    let x = box () 'c'; //~ ERROR box expression syntax is experimental
     println!("x: {}", x);
 
-    let x = box (HEAP) 'c'; //~ ERROR box expression syntax is experimental in alpha release
+    let x = box (HEAP) 'c'; //~ ERROR box expression syntax is experimental
     println!("x: {}", x);
 }
 

--- a/src/test/compile-fail/feature-gate-box-pat.rs
+++ b/src/test/compile-fail/feature-gate-box-pat.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 fn main() {
-    let box x = Box::new('c'); //~ ERROR box pattern syntax is experimental in alpha release
+    let box x = Box::new('c'); //~ ERROR box pattern syntax is experimental
     println!("x: {}", x);
 }

--- a/src/test/compile-fail/issue-12116.rs
+++ b/src/test/compile-fail/issue-12116.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 enum IntList {

--- a/src/test/compile-fail/issue-3601.rs
+++ b/src/test/compile-fail/issue-3601.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 struct HTMLImageData {

--- a/src/test/compile-fail/issue-4972.rs
+++ b/src/test/compile-fail/issue-4972.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 trait MyTrait { }

--- a/src/test/compile-fail/issue-5100.rs
+++ b/src/test/compile-fail/issue-5100.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 enum A { B, C }

--- a/src/test/compile-fail/moves-based-on-type-block-bad.rs
+++ b/src/test/compile-fail/moves-based-on-type-block-bad.rs
@@ -10,6 +10,7 @@
 
 // ignore-tidy-linelength
 
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 struct S {

--- a/src/test/compile-fail/regions-ref-in-fn-arg.rs
+++ b/src/test/compile-fail/regions-ref-in-fn-arg.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 fn arg_item(box ref x: Box<isize>) -> &'static isize {

--- a/src/test/compile-fail/unreachable-arm.rs
+++ b/src/test/compile-fail/unreachable-arm.rs
@@ -10,6 +10,7 @@
 
 // error-pattern:unreachable pattern
 
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 enum foo { a(Box<foo>, isize), b(usize), }

--- a/src/test/debuginfo/destructured-fn-argument.rs
+++ b/src/test/debuginfo/destructured-fn-argument.rs
@@ -311,6 +311,7 @@
 // lldb-command:continue
 
 #![allow(unused_variables)]
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 #![omit_gdb_pretty_printer_section]
 

--- a/src/test/debuginfo/destructured-for-loop-variable.rs
+++ b/src/test/debuginfo/destructured-for-loop-variable.rs
@@ -153,6 +153,7 @@
 // lldb-command:continue
 
 #![allow(unused_variables)]
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 #![omit_gdb_pretty_printer_section]
 

--- a/src/test/debuginfo/destructured-local.rs
+++ b/src/test/debuginfo/destructured-local.rs
@@ -244,6 +244,7 @@
 
 
 #![allow(unused_variables)]
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 #![omit_gdb_pretty_printer_section]
 

--- a/src/test/run-pass/borrowck-macro-interaction-issue-6304.rs
+++ b/src/test/run-pass/borrowck-macro-interaction-issue-6304.rs
@@ -11,6 +11,7 @@
 // Check that we do not ICE when compiling this
 // macro, which reuses the expression `$id`
 
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 struct Foo {

--- a/src/test/run-pass/cleanup-rvalue-scopes.rs
+++ b/src/test/run-pass/cleanup-rvalue-scopes.rs
@@ -12,6 +12,7 @@
 // statement or end of block, as appropriate given the temporary
 // lifetime rules.
 
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 use std::ops::Drop;

--- a/src/test/run-pass/func-arg-ref-pattern.rs
+++ b/src/test/run-pass/func-arg-ref-pattern.rs
@@ -15,6 +15,7 @@
 // pattern.
 
 #![allow(unknown_features)]
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 fn getaddr(box ref x: Box<uint>) -> *const uint {

--- a/src/test/run-pass/issue-11552.rs
+++ b/src/test/run-pass/issue-11552.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(unknown_features)]
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 #[derive(Clone)]

--- a/src/test/run-pass/issue-16774.rs
+++ b/src/test/run-pass/issue-16774.rs
@@ -10,6 +10,7 @@
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]
+#![feature(box_patterns)]
 #![feature(unboxed_closures)]
 
 use std::ops::{Deref, DerefMut};

--- a/src/test/run-pass/issue-21033.rs
+++ b/src/test/run-pass/issue-21033.rs
@@ -7,6 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 enum E {

--- a/src/test/run-pass/issue-6557.rs
+++ b/src/test/run-pass/issue-6557.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(unknown_features)]
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 fn foo(box (_x, _y): Box<(int, int)>) {}

--- a/src/test/run-pass/match-unique-bind.rs
+++ b/src/test/run-pass/match-unique-bind.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(unknown_features)]
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 pub fn main() {

--- a/src/test/run-pass/regions-dependent-addr-of.rs
+++ b/src/test/run-pass/regions-dependent-addr-of.rs
@@ -12,6 +12,7 @@
 // Issue #3148.
 
 #![allow(unknown_features)]
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 struct A {

--- a/src/test/run-pass/unique-destructure.rs
+++ b/src/test/run-pass/unique-destructure.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(unknown_features)]
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 struct Foo { a: int, b: int }

--- a/src/test/run-pass/unique-pat-2.rs
+++ b/src/test/run-pass/unique-pat-2.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(unknown_features)]
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 struct Foo {a: int, b: uint}

--- a/src/test/run-pass/unique-pat.rs
+++ b/src/test/run-pass/unique-pat.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(unknown_features)]
+#![feature(box_patterns)]
 #![feature(box_syntax)]
 
 fn simple() {


### PR DESCRIPTION
Feature gate `box` patterns.

Note that this adds a new feature gate, `box_patterns` specific to e.g. `let box i = ...`, while leaving  `box` expressions (alone) still guarded via the preexisting `box_syntax`.

Fix #21931
