### PR TITLE
Feature-gate the `#[unsafe_no_drop_flag]` attribute.

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -71,6 +71,7 @@
 #![feature(box_syntax)]
 #![feature(optin_builtin_traits)]
 #![feature(unboxed_closures)]
+#![feature(unsafe_no_drop_flag)]
 #![feature(core)]
 #![feature(hash)]
 #![cfg_attr(all(not(feature = "external_funcs"), not(feature = "external_crate")),

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -26,10 +26,12 @@
 #![feature(box_syntax)]
 #![feature(core)]
 #![feature(hash)]
+#![feature(slicing_syntax)]
 #![feature(staged_api)]
 #![feature(unboxed_closures)]
 #![feature(unicode)]
-#![feature(unsafe_destructor, slicing_syntax)]
+#![feature(unsafe_destructor)]
+#![feature(unsafe_no_drop_flag)]
 #![cfg_attr(test, feature(rand, rustc_private, test))]
 #![cfg_attr(test, allow(deprecated))] // rand
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -111,7 +111,7 @@
 #![feature(core)]
 #![feature(hash)]
 #![feature(int_uint)]
-#![feature(lang_items, unsafe_destructor)]
+#![feature(lang_items)]
 #![feature(libc)]
 #![feature(linkage, thread_local, asm)]
 #![feature(old_impl_check)]
@@ -120,6 +120,8 @@
 #![feature(staged_api)]
 #![feature(unboxed_closures)]
 #![feature(unicode)]
+#![feature(unsafe_destructor)]
+#![feature(unsafe_no_drop_flag)]
 #![feature(macro_reexport)]
 #![cfg_attr(test, feature(test))]
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -126,6 +126,10 @@ static KNOWN_FEATURES: &'static [(&'static str, &'static str, Status)] = &[
 
     // Allows using #![no_std]
     ("no_std", "1.0.0", Active),
+
+    // Allows using the unsafe_no_drop_flag attribute (unlikely to
+    // switch to Accepted; see RFC 320)
+    ("unsafe_no_drop_flag", "1.0.0", Active),
 ];
 
 enum Status {
@@ -473,6 +477,12 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
         if attr.check_name("no_std") {
             self.gate_feature("no_std", attr.span,
                               "no_std is experimental");
+        }
+
+        if attr.check_name("unsafe_no_drop_flag") {
+            self.gate_feature("unsafe_no_drop_flag", attr.span,
+                              "unsafe_no_drop_flag has unstable semantics \
+                               and may be removed in the future");
         }
     }
 

--- a/src/test/auxiliary/issue-10028.rs
+++ b/src/test/auxiliary/issue-10028.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(unsafe_no_drop_flag)]
+
 #[unsafe_no_drop_flag]
 pub struct ZeroLengthThingWithDestructor;
 impl Drop for ZeroLengthThingWithDestructor {

--- a/src/test/run-pass/attr-no-drop-flag-size.rs
+++ b/src/test/run-pass/attr-no-drop-flag-size.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(unsafe_destructor)]
+#![feature(unsafe_no_drop_flag)]
 
 use std::mem::size_of;
 

--- a/src/test/run-pass/issue-10734.rs
+++ b/src/test/run-pass/issue-10734.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(unsafe_no_drop_flag)]
+
 static mut drop_count: uint = 0;
 
 #[unsafe_no_drop_flag]

--- a/src/test/run-pass/zero-size-type-destructors.rs
+++ b/src/test/run-pass/zero-size-type-destructors.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(unsafe_no_drop_flag)]
+
 static mut destructions : int = 3;
 
 pub fn foo() {


### PR DESCRIPTION
Feature-gate the `#[unsafe_no_drop_flag]` attribute.

See RFC 320, "Non-zeroing dynamic drops."

Fix #22173

[breaking-change]
