### PR TITLE
Revert #22051

### DIFF
--- a/src/librustc/middle/entry.rs
+++ b/src/librustc/middle/entry.rs
@@ -50,10 +50,7 @@ pub fn find_entry_point(session: &Session, ast_map: &ast_map::Map) {
     let any_exe = session.crate_types.borrow().iter().any(|ty| {
         *ty == config::CrateTypeExecutable
     });
-    let emit_link = session.opts.output_types.iter().any(|ty| {
-        *ty == config::OutputTypeExe
-    });
-    if !any_exe || !emit_link {
+    if !any_exe {
         // No need to find a main function
         return
     }

--- a/src/test/run-make/empty-file/Makefile
+++ b/src/test/run-make/empty-file/Makefile
@@ -1,5 +1,0 @@
--include ../tools.mk
-
-all:
-	$(RUSTC) --emit=asm,llvm-bc,llvm-ir,obj,dep-info empty.rs
-	$(RUSTC) --emit=link --crate-type=rlib,dylib,staticlib empty.rs


### PR DESCRIPTION
This resulted in some very unexpected fallout such as empty llvm-ir, llvm-bc and asm in some cases.
See #22183 for related info.

r? @alexcrichton 
