### PR TITLE
std: Tweak the std::env OsString/String interface

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -14,7 +14,6 @@
 #![feature(collections)]
 #![feature(int_uint)]
 #![feature(io)]
-#![feature(os)]
 #![feature(path)]
 #![feature(rustc_private)]
 #![feature(slicing_syntax, unboxed_closures)]
@@ -48,8 +47,7 @@ pub mod common;
 pub mod errors;
 
 pub fn main() {
-    let args = env::args().map(|s| s.into_string().unwrap()).collect();;
-    let config = parse_config(args);
+    let config = parse_config(env::args().collect());
 
     if config.valgrind_path.is_none() && config.force_valgrind {
         panic!("Can't find Valgrind to run Valgrind tests");

--- a/src/compiletest/util.rs
+++ b/src/compiletest/util.rs
@@ -40,7 +40,7 @@ pub fn make_new_path(path: &str) -> String {
 
     // Windows just uses PATH as the library search path, so we have to
     // maintain the current value while adding our own
-    match env::var_string(lib_path_env_var()) {
+    match env::var(lib_path_env_var()) {
       Ok(curr) => {
         format!("{}{}{}", path, path_div(), curr)
       }

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -397,7 +397,7 @@ fn enabled(level: u32,
 /// This is not threadsafe at all, so initialization is performed through a
 /// `Once` primitive (and this function is called from that primitive).
 fn init() {
-    let (mut directives, filter) = match env::var_string("RUST_LOG") {
+    let (mut directives, filter) = match env::var("RUST_LOG") {
         Ok(spec) => directive::parse_logging_spec(&spec[]),
         Err(..) => (Vec::new(), None),
     };

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -207,7 +207,7 @@ static PATH_ENTRY_SEPARATOR: &'static str = ":";
 
 /// Returns RUST_PATH as a string, without default paths added
 pub fn get_rust_path() -> Option<String> {
-    env::var_string("RUST_PATH").ok()
+    env::var("RUST_PATH").ok()
 }
 
 /// Returns the value of RUST_PATH, as a list

--- a/src/librustc/middle/infer/region_inference/graphviz.rs
+++ b/src/librustc/middle/infer/region_inference/graphviz.rs
@@ -61,13 +61,13 @@ pub fn maybe_print_constraints_for<'a, 'tcx>(region_vars: &RegionVarBindings<'a,
     }
 
     let requested_node : Option<ast::NodeId> =
-        env::var_string("RUST_REGION_GRAPH_NODE").ok().and_then(|s| s.parse().ok());
+        env::var("RUST_REGION_GRAPH_NODE").ok().and_then(|s| s.parse().ok());
 
     if requested_node.is_some() && requested_node != Some(subject_node) {
         return;
     }
 
-    let requested_output = env::var_string("RUST_REGION_GRAPH").ok();
+    let requested_output = env::var("RUST_REGION_GRAPH").ok();
     debug!("requested_output: {:?} requested_node: {:?}",
            requested_output, requested_node);
 

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1052,7 +1052,7 @@ pub fn get_unstable_features_setting() -> UnstableFeatures {
     // subverting the unstable features lints
     let bootstrap_secret_key = option_env!("CFG_BOOTSTRAP_KEY");
     // The matching key to the above, only known by the build system
-    let bootstrap_provided_key = env::var_string("RUSTC_BOOTSTRAP_KEY").ok();
+    let bootstrap_provided_key = env::var("RUSTC_BOOTSTRAP_KEY").ok();
     match (disable_unstable_features, bootstrap_secret_key, bootstrap_provided_key) {
         (_, Some(ref s), Some(ref p)) if s == p => UnstableFeatures::Cheat,
         (true, _, _) => UnstableFeatures::Disallow,

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -384,7 +384,7 @@ impl Target {
             Path::new(target)
         };
 
-        let target_path = env::var("RUST_TARGET_PATH")
+        let target_path = env::var_os("RUST_TARGET_PATH")
                               .unwrap_or(OsString::from_str(""));
 
         // FIXME 16351: add a sane default search path?

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -464,7 +464,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
             // compiler, not for the target.
             let mut _old_path = OsString::from_str("");
             if cfg!(windows) {
-                _old_path = env::var("PATH").unwrap_or(_old_path);
+                _old_path = env::var_os("PATH").unwrap_or(_old_path);
                 let mut new_path = sess.host_filesearch(PathKind::All).get_dylib_search_paths();
                 new_path.extend(env::split_paths(&_old_path));
                 env::set_var("PATH", &env::join_paths(new_path.iter()).unwrap());
@@ -737,7 +737,7 @@ pub fn phase_5_run_llvm_passes(sess: &Session,
 pub fn phase_6_link_output(sess: &Session,
                            trans: &trans::CrateTranslation,
                            outputs: &OutputFilenames) {
-    let old_path = env::var("PATH").unwrap_or(OsString::from_str(""));
+    let old_path = env::var_os("PATH").unwrap_or(OsString::from_str(""));
     let mut new_path = sess.host_filesearch(PathKind::All).get_tools_search_paths();
     new_path.extend(env::split_paths(&old_path));
     env::set_var("PATH", &env::join_paths(new_path.iter()).unwrap());

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -771,7 +771,7 @@ pub fn monitor<F:FnOnce()+Send>(f: F) {
 
     // FIXME: Hacks on hacks. If the env is trying to override the stack size
     // then *don't* set it explicitly.
-    if env::var("RUST_MIN_STACK").is_none() {
+    if env::var_os("RUST_MIN_STACK").is_none() {
         cfg = cfg.stack_size(STACK_SIZE);
     }
 
@@ -835,8 +835,7 @@ pub fn diagnostics_registry() -> diagnostics::registry::Registry {
 }
 
 pub fn main() {
-    let args = env::args().map(|s| s.into_string().unwrap());
-    let result = run(args.collect());
+    let result = run(env::args().collect());
     std::env::set_exit_status(result as i32);
 }
 

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -1551,7 +1551,7 @@ pub fn process_crate(sess: &Session,
     info!("Dumping crate {}", cratename);
 
     // find a path to dump our data to
-    let mut root_path = match env::var_string("DXR_RUST_TEMP_FOLDER") {
+    let mut root_path = match env::var("DXR_RUST_TEMP_FOLDER") {
         Ok(val) => Path::new(val),
         Err(..) => match odir {
             Some(val) => val.join("dxr"),

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -122,10 +122,10 @@ struct Output {
 }
 
 pub fn main() {
-    static STACK_SIZE: uint = 32000000; // 32MB
+    const STACK_SIZE: usize = 32000000; // 32MB
     let res = std::thread::Builder::new().stack_size(STACK_SIZE).scoped(move || {
-        let s = env::args().map(|s| s.into_string().unwrap());
-        main_args(&s.collect::<Vec<_>>())
+        let s = env::args().collect::<Vec<_>>();
+        main_args(&s)
     }).join();
     env::set_exit_status(res.ok().unwrap() as i32);
 }

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -101,7 +101,7 @@ impl DynamicLibrary {
     /// Returns the current search path for dynamic libraries being used by this
     /// process
     pub fn search_path() -> Vec<Path> {
-        match env::var(DynamicLibrary::envvar()) {
+        match env::var_os(DynamicLibrary::envvar()) {
             Some(var) => env::split_paths(&var).collect(),
             None => Vec::new(),
         }

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -125,7 +125,7 @@ pub fn getcwd() -> IoResult<Path> {
 #[deprecated(since = "1.0.0", reason = "use env::vars instead")]
 #[unstable(feature = "os")]
 pub fn env() -> Vec<(String,String)> {
-    env::vars().map(|(k, v)| {
+    env::vars_os().map(|(k, v)| {
         (k.to_string_lossy().into_owned(), v.to_string_lossy().into_owned())
     }).collect()
 }
@@ -135,7 +135,7 @@ pub fn env() -> Vec<(String,String)> {
 #[deprecated(since = "1.0.0", reason = "use env::vars instead")]
 #[unstable(feature = "os")]
 pub fn env_as_bytes() -> Vec<(Vec<u8>, Vec<u8>)> {
-    env::vars().map(|(k, v)| (byteify(k), byteify(v))).collect()
+    env::vars_os().map(|(k, v)| (byteify(k), byteify(v))).collect()
 }
 
 /// Fetches the environment variable `n` from the current process, returning
@@ -159,10 +159,10 @@ pub fn env_as_bytes() -> Vec<(Vec<u8>, Vec<u8>)> {
 ///     None => println!("{} is not defined in the environment.", key)
 /// }
 /// ```
-#[deprecated(since = "1.0.0", reason = "use env::var or env::var_string instead")]
+#[deprecated(since = "1.0.0", reason = "use env::var or env::var_os instead")]
 #[unstable(feature = "os")]
 pub fn getenv(n: &str) -> Option<String> {
-    env::var_string(n).ok()
+    env::var(n).ok()
 }
 
 /// Fetches the environment variable `n` byte vector from the current process,
@@ -174,7 +174,7 @@ pub fn getenv(n: &str) -> Option<String> {
 #[deprecated(since = "1.0.0", reason = "use env::var instead")]
 #[unstable(feature = "os")]
 pub fn getenv_as_bytes(n: &str) -> Option<Vec<u8>> {
-    env::var(n).map(byteify)
+    env::var_os(n).map(byteify)
 }
 
 #[cfg(unix)]

--- a/src/libstd/rt/backtrace.rs
+++ b/src/libstd/rt/backtrace.rs
@@ -29,7 +29,7 @@ pub fn log_enabled() -> bool {
         _ => {}
     }
 
-    let val = match env::var("RUST_BACKTRACE") {
+    let val = match env::var_os("RUST_BACKTRACE") {
         Some(..) => 2,
         None => 1,
     };

--- a/src/libstd/rt/util.rs
+++ b/src/libstd/rt/util.rs
@@ -52,7 +52,7 @@ pub fn min_stack() -> uint {
         0 => {}
         n => return n - 1,
     }
-    let amt = env::var_string("RUST_MIN_STACK").ok().and_then(|s| s.parse().ok());
+    let amt = env::var("RUST_MIN_STACK").ok().and_then(|s| s.parse().ok());
     let amt = amt.unwrap_or(2 * 1024 * 1024);
     // 0 is our sentinel value, so ensure that we'll never see 0 after
     // initialization has run
@@ -63,7 +63,7 @@ pub fn min_stack() -> uint {
 /// Get's the number of scheduler threads requested by the environment
 /// either `RUST_THREADS` or `num_cpus`.
 pub fn default_sched_threads() -> uint {
-    match env::var_string("RUST_THREADS") {
+    match env::var("RUST_THREADS") {
         Ok(nstr) => {
             let opt_n: Option<uint> = nstr.parse().ok();
             match opt_n {

--- a/src/libsyntax/ext/env.rs
+++ b/src/libsyntax/ext/env.rs
@@ -30,7 +30,7 @@ pub fn expand_option_env<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenT
         Some(v) => v
     };
 
-    let e = match env::var_string(&var[]) {
+    let e = match env::var(&var[]) {
       Err(..) => {
           cx.expr_path(cx.path_all(sp,
                                    true,
@@ -101,7 +101,7 @@ pub fn expand_env<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
         }
     }
 
-    let e = match env::var_string(&var[]) {
+    let e = match env::var(&var[]) {
         Err(_) => {
             cx.span_err(sp, &msg);
             cx.expr_usize(sp, 0)

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -172,7 +172,7 @@ impl<T: Writer+Send> TerminfoTerminal<T> {
     /// Returns `None` whenever the terminal cannot be created for some
     /// reason.
     pub fn new(out: T) -> Option<Box<Terminal<T>+Send+'static>> {
-        let term = match env::var_string("TERM") {
+        let term = match env::var("TERM") {
             Ok(t) => t,
             Err(..) => {
                 debug!("TERM environment variable not defined");
@@ -182,7 +182,7 @@ impl<T: Writer+Send> TerminfoTerminal<T> {
 
         let entry = open(&term[]);
         if entry.is_err() {
-            if env::var_string("MSYSCON").ok().map_or(false, |s| {
+            if env::var("MSYSCON").ok().map_or(false, |s| {
                     "mintty.exe" == s
                 }) {
                 // msys terminal

--- a/src/libterm/terminfo/searcher.rs
+++ b/src/libterm/terminfo/searcher.rs
@@ -28,14 +28,14 @@ pub fn get_dbpath_for_term(term: &str) -> Option<Box<Path>> {
     let first_char = term.char_at(0);
 
     // Find search directory
-    match env::var_string("TERMINFO") {
+    match env::var("TERMINFO") {
         Ok(dir) => dirs_to_search.push(Path::new(dir)),
         Err(..) => {
             if homedir.is_some() {
                 // ncurses compatibility;
                 dirs_to_search.push(homedir.unwrap().join(".terminfo"))
             }
-            match env::var_string("TERMINFO_DIRS") {
+            match env::var("TERMINFO_DIRS") {
                 Ok(dirs) => for i in dirs.split(':') {
                     if i == "" {
                         dirs_to_search.push(Path::new("/usr/share/terminfo"));

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -385,7 +385,7 @@ pub fn parse_opts(args: &[String]) -> Option<OptRes> {
 
     let mut nocapture = matches.opt_present("nocapture");
     if !nocapture {
-        nocapture = env::var("RUST_TEST_NOCAPTURE").is_some();
+        nocapture = env::var("RUST_TEST_NOCAPTURE").is_ok();
     }
 
     let color = match matches.opt_str("color").as_ref().map(|s| &**s) {
@@ -811,7 +811,7 @@ fn run_tests<F>(opts: &TestOpts,
 
 fn get_concurrency() -> uint {
     use std::rt;
-    match env::var_string("RUST_TEST_TASKS") {
+    match env::var("RUST_TEST_TASKS") {
         Ok(s) => {
             let opt_n: Option<uint> = s.parse().ok();
             match opt_n {

--- a/src/test/run-pass/env-vars.rs
+++ b/src/test/run-pass/env-vars.rs
@@ -11,8 +11,8 @@
 use std::env::*;
 
 fn main() {
-    for (k, v) in vars() {
-        let v2 = var(&k);
+    for (k, v) in vars_os() {
+        let v2 = var_os(&k);
         // MingW seems to set some funky environment variables like
         // "=C:=C:\MinGW\msys\1.0\bin" and "!::=::\" that are returned
         // from vars() but not visible from var().


### PR DESCRIPTION
This commit tweaks the interface of the `std::env` module to make it more
ergonomic for common usage:
- `env::var` was renamed to `env::var_os`
- `env::var_string` was renamed to `env::var`
- `env::args` was renamed to `env::args_os`
- `env::args` was re-added as a panicking iterator over string values
- `env::vars` was renamed to `env::vars_os`
- `env::vars` was re-added as a panicking iterator over string values.

This should make common usage (e.g. unicode values everywhere) more ergonomic
as well as "the default". This is also a breaking change due to the differences
of what's yielded from each of these functions, but migration should be fairly
easy as the defaults operate over `String` which is a common type to use.

[breaking-change]
