### PR TITLE
remove support for dynamic choice of B in BTree, significantly reducing ...

### DIFF
--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -70,7 +70,6 @@ pub struct BTreeMap<K, V> {
     root: Node<K, V>,
     length: usize,
     depth: usize,
-    b: usize,
 }
 
 /// An abstract base over-which all other BTree iterators are built.
@@ -149,19 +148,10 @@ impl<K: Ord, V> BTreeMap<K, V> {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new() -> BTreeMap<K, V> {
         //FIXME(Gankro): Tune this as a function of size_of<K/V>?
-        BTreeMap::with_b(6)
-    }
-
-    /// Makes a new empty BTreeMap with the given B.
-    ///
-    /// B cannot be less than 2.
-    pub fn with_b(b: usize) -> BTreeMap<K, V> {
-        assert!(b > 1, "B must be greater than 1");
         BTreeMap {
             length: 0,
             depth: 1,
-            root: Node::make_leaf_root(b),
-            b: b,
+            root: Node::make_leaf_root(),
         }
     }
 
@@ -179,9 +169,8 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn clear(&mut self) {
-        let b = self.b;
         // avoid recursive destructors by manually traversing the tree
-        for _ in mem::replace(self, BTreeMap::with_b(b)) {};
+        for _ in mem::replace(self, BTreeMap::new()) {};
     }
 
     // Searching in a B-Tree is pretty straightforward.
@@ -798,7 +787,7 @@ mod stack {
                                 // The stack was empty; we've split the root, and need to make a
                                 // a new one. This is done in-place because we can't move the
                                 // root out of a reference to the tree.
-                                Node::make_internal_root(&mut self.map.root, self.map.b,
+                                Node::make_internal_root(&mut self.map.root,
                                                          key, val, right);
 
                                 self.map.depth += 1;

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -95,15 +95,6 @@ impl<T: Ord> BTreeSet<T> {
     pub fn new() -> BTreeSet<T> {
         BTreeSet { map: BTreeMap::new() }
     }
-
-    /// Makes a new BTreeSet with the given B.
-    ///
-    /// B cannot be less than 2.
-    #[unstable(feature = "collections",
-               reason = "probably want this to be on the type, eventually")]
-    pub fn with_b(b: usize) -> BTreeSet<T> {
-        BTreeSet { map: BTreeMap::with_b(b) }
-    }
 }
 
 impl<T> BTreeSet<T> {


### PR DESCRIPTION
...memory footprint at no perf cost

This was done in 4 phases, giving detailed performance data:
- Old design unchanged
- Make B a const
- Collapse the ptrs into one
- Shrink the `len` field

```
Old design:
test map::bench::find_rand_100      ... bench:        51 ns/iter (+/- 5)
test map::bench::find_rand_10_000   ... bench:       120 ns/iter (+/- 2)
test map::bench::find_seq_100       ... bench:        53 ns/iter (+/- 1)
test map::bench::find_seq_10_000    ... bench:        87 ns/iter (+/- 0)
test map::bench::insert_rand_100    ... bench:       144 ns/iter (+/- 4)
test map::bench::insert_rand_10_000 ... bench:       258 ns/iter (+/- 11)
test map::bench::insert_seq_100     ... bench:       264 ns/iter (+/- 5)
test map::bench::insert_seq_10_000  ... bench:       325 ns/iter (+/- 3)
test map::bench::iter_1000          ... bench:     27715 ns/iter (+/- 1646)
test map::bench::iter_100_000       ... bench:   2501840 ns/iter (+/- 40847)
test map::bench::iter_20            ... bench:       655 ns/iter (+/- 57)

Const B:
test map::bench::find_rand_100      ... bench:        52 ns/iter (+/- 5)
test map::bench::find_rand_10_000   ... bench:       120 ns/iter (+/- 1)
test map::bench::find_seq_100       ... bench:        54 ns/iter (+/- 1)
test map::bench::find_seq_10_000    ... bench:        87 ns/iter (+/- 1)
test map::bench::insert_rand_100    ... bench:       140 ns/iter (+/- 0)
test map::bench::insert_rand_10_000 ... bench:       254 ns/iter (+/- 12)
test map::bench::insert_seq_100     ... bench:       264 ns/iter (+/- 3)
test map::bench::insert_seq_10_000  ... bench:       329 ns/iter (+/- 2)
test map::bench::iter_1000          ... bench:     25093 ns/iter (+/- 592)
test map::bench::iter_100_000       ... bench:   2495100 ns/iter (+/- 150901)
test map::bench::iter_20            ... bench:       592 ns/iter (+/- 63)

Squish Ptrs:
test map::bench::find_rand_100      ... bench:        51 ns/iter (+/- 5)
test map::bench::find_rand_10_000   ... bench:       124 ns/iter (+/- 3)
test map::bench::find_seq_100       ... bench:        51 ns/iter (+/- 1)
test map::bench::find_seq_10_000    ... bench:        76 ns/iter (+/- 2)
test map::bench::insert_rand_100    ... bench:       145 ns/iter (+/- 2)
test map::bench::insert_rand_10_000 ... bench:       301 ns/iter (+/- 16)
test map::bench::insert_seq_100     ... bench:       260 ns/iter (+/- 8)
test map::bench::insert_seq_10_000  ... bench:       320 ns/iter (+/- 8)
test map::bench::iter_1000          ... bench:     27106 ns/iter (+/- 3298)
test map::bench::iter_100_000       ... bench:   2914572 ns/iter (+/- 183145)
test map::bench::iter_20            ... bench:       636 ns/iter (+/- 114)
```

For the final form, I profiled various choices of B:

```

B = 100
test map::bench::find_rand_100      ... bench:        91 ns/iter (+/- 14)
test map::bench::find_rand_10_000   ... bench:       252 ns/iter (+/- 18)
test map::bench::find_seq_100       ... bench:       128 ns/iter (+/- 1)
test map::bench::find_seq_10_000    ... bench:       238 ns/iter (+/- 2)
test map::bench::insert_rand_100    ... bench:       144 ns/iter (+/- 3)
test map::bench::insert_rand_10_000 ... bench:       813 ns/iter (+/- 11)
test map::bench::insert_seq_100     ... bench:       557 ns/iter (+/- 49)
test map::bench::insert_seq_10_000  ... bench:       659 ns/iter (+/- 5)
test map::bench::iter_1000          ... bench:     22404 ns/iter (+/- 3319)
test map::bench::iter_100_000       ... bench:   2037716 ns/iter (+/- 286812)
test map::bench::iter_20            ... bench:       488 ns/iter (+/- 9)

B = 20
test map::bench::find_rand_100      ... bench:        67 ns/iter (+/- 7)
test map::bench::find_rand_10_000   ... bench:       129 ns/iter (+/- 3)
test map::bench::find_seq_100       ... bench:        51 ns/iter (+/- 1)
test map::bench::find_seq_10_000    ... bench:       113 ns/iter (+/- 2)
test map::bench::insert_rand_100    ... bench:       142 ns/iter (+/- 3)
test map::bench::insert_rand_10_000 ... bench:       418 ns/iter (+/- 16)
test map::bench::insert_seq_100     ... bench:       342 ns/iter (+/- 13)
test map::bench::insert_seq_10_000  ... bench:       435 ns/iter (+/- 16)
test map::bench::iter_1000          ... bench:     21747 ns/iter (+/- 669)
test map::bench::iter_100_000       ... bench:   2173041 ns/iter (+/- 214782)
test map::bench::iter_20            ... bench:       487 ns/iter (+/- 24)

B = 9
test map::bench::find_rand_100      ... bench:        52 ns/iter (+/- 5)
test map::bench::find_rand_10_000   ... bench:       118 ns/iter (+/- 5)
test map::bench::find_seq_100       ... bench:        51 ns/iter (+/- 0)
test map::bench::find_seq_10_000    ... bench:        88 ns/iter (+/- 5)
test map::bench::insert_rand_100    ... bench:       141 ns/iter (+/- 3)
test map::bench::insert_rand_10_000 ... bench:       307 ns/iter (+/- 24)
test map::bench::insert_seq_100     ... bench:       257 ns/iter (+/- 11)
test map::bench::insert_seq_10_000  ... bench:       333 ns/iter (+/- 14)
test map::bench::iter_1000          ... bench:     23128 ns/iter (+/- 771)
test map::bench::iter_100_000       ... bench:   2317773 ns/iter (+/- 192077)
test map::bench::iter_20            ... bench:       587 ns/iter (+/- 28)

B = 8
test map::bench::find_rand_100      ... bench:        52 ns/iter (+/- 5)
test map::bench::find_rand_10_000   ... bench:       123 ns/iter (+/- 2)
test map::bench::find_seq_100       ... bench:        54 ns/iter (+/- 2)
test map::bench::find_seq_10_000    ... bench:        79 ns/iter (+/- 0)
test map::bench::insert_rand_100    ... bench:       140 ns/iter (+/- 3)
test map::bench::insert_rand_10_000 ... bench:       318 ns/iter (+/- 16)
test map::bench::insert_seq_100     ... bench:       249 ns/iter (+/- 4)
test map::bench::insert_seq_10_000  ... bench:       344 ns/iter (+/- 3)
test map::bench::iter_1000          ... bench:     23761 ns/iter (+/- 563)
test map::bench::iter_100_000       ... bench:   2372726 ns/iter (+/- 94588)
test map::bench::iter_20            ... bench:       589 ns/iter (+/- 25)

B = 7
test map::bench::find_rand_100      ... bench:        50 ns/iter (+/- 5)
test map::bench::find_rand_10_000   ... bench:       115 ns/iter (+/- 6)
test map::bench::find_seq_100       ... bench:        51 ns/iter (+/- 2)
test map::bench::find_seq_10_000    ... bench:        81 ns/iter (+/- 1)
test map::bench::insert_rand_100    ... bench:       142 ns/iter (+/- 6)
test map::bench::insert_rand_10_000 ... bench:       337 ns/iter (+/- 14)
test map::bench::insert_seq_100     ... bench:       250 ns/iter (+/- 3)
test map::bench::insert_seq_10_000  ... bench:       336 ns/iter (+/- 6)
test map::bench::iter_1000          ... bench:     24332 ns/iter (+/- 1415)
test map::bench::iter_100_000       ... bench:   2638069 ns/iter (+/- 289258)
test map::bench::iter_20            ... bench:       597 ns/iter (+/- 23)

B = 6
test map::bench::find_rand_100      ... bench:        50 ns/iter (+/- 4)
test map::bench::find_rand_10_000   ... bench:       116 ns/iter (+/- 2)
test map::bench::find_seq_100       ... bench:        53 ns/iter (+/- 1)
test map::bench::find_seq_10_000    ... bench:        77 ns/iter (+/- 1)
test map::bench::insert_rand_100    ... bench:       140 ns/iter (+/- 1)
test map::bench::insert_rand_10_000 ... bench:       252 ns/iter (+/- 12)
test map::bench::insert_seq_100     ... bench:       257 ns/iter (+/- 8)
test map::bench::insert_seq_10_000  ... bench:       321 ns/iter (+/- 11)
test map::bench::iter_1000          ... bench:     24719 ns/iter (+/- 2973)
test map::bench::iter_100_000       ... bench:   2496480 ns/iter (+/- 286592)
test map::bench::iter_20            ... bench:       590 ns/iter (+/- 55)

B = 5
test map::bench::find_rand_100      ... bench:        50 ns/iter (+/- 5)
test map::bench::find_rand_10_000   ... bench:       123 ns/iter (+/- 4)
test map::bench::find_seq_100       ... bench:        52 ns/iter (+/- 1)
test map::bench::find_seq_10_000    ... bench:        79 ns/iter (+/- 2)
test map::bench::insert_rand_100    ... bench:       140 ns/iter (+/- 5)
test map::bench::insert_rand_10_000 ... bench:       273 ns/iter (+/- 11)
test map::bench::insert_seq_100     ... bench:       258 ns/iter (+/- 5)
test map::bench::insert_seq_10_000  ... bench:       336 ns/iter (+/- 6)
test map::bench::iter_1000          ... bench:     25958 ns/iter (+/- 761)
test map::bench::iter_100_000       ... bench:   2611977 ns/iter (+/- 87232)
test map::bench::iter_20            ... bench:       636 ns/iter (+/- 37)

B = 4
test map::bench::find_rand_100      ... bench:        50 ns/iter (+/- 4)
test map::bench::find_rand_10_000   ... bench:       131 ns/iter (+/- 4)
test map::bench::find_seq_100       ... bench:        52 ns/iter (+/- 1)
test map::bench::find_seq_10_000    ... bench:        82 ns/iter (+/- 4)
test map::bench::insert_rand_100    ... bench:       143 ns/iter (+/- 3)
test map::bench::insert_rand_10_000 ... bench:       334 ns/iter (+/- 11)
test map::bench::insert_seq_100     ... bench:       259 ns/iter (+/- 9)
test map::bench::insert_seq_10_000  ... bench:       349 ns/iter (+/- 7)
test map::bench::iter_1000          ... bench:     27685 ns/iter (+/- 716)
test map::bench::iter_100_000       ... bench:   2835892 ns/iter (+/- 77269)
test map::bench::iter_20            ... bench:       626 ns/iter (+/- 61)

B = 3
test map::bench::find_rand_100      ... bench:        48 ns/iter (+/- 4)
test map::bench::find_rand_10_000   ... bench:       139 ns/iter (+/- 5)
test map::bench::find_seq_100       ... bench:        59 ns/iter (+/- 1)
test map::bench::find_seq_10_000    ... bench:        86 ns/iter (+/- 2)
test map::bench::insert_rand_100    ... bench:       145 ns/iter (+/- 1)
test map::bench::insert_rand_10_000 ... bench:       356 ns/iter (+/- 19)
test map::bench::insert_seq_100     ... bench:       261 ns/iter (+/- 8)
test map::bench::insert_seq_10_000  ... bench:       367 ns/iter (+/- 25)
test map::bench::iter_1000          ... bench:     32013 ns/iter (+/- 1707)
test map::bench::iter_100_000       ... bench:   3287997 ns/iter (+/- 195732)
test map::bench::iter_20            ... bench:       709 ns/iter (+/- 104)

B = 2
test map::bench::find_rand_100      ... bench:        51 ns/iter (+/- 4)
test map::bench::find_rand_10_000   ... bench:       149 ns/iter (+/- 4)
test map::bench::find_seq_100       ... bench:        58 ns/iter (+/- 2)
test map::bench::find_seq_10_000    ... bench:       107 ns/iter (+/- 3)
test map::bench::insert_rand_100    ... bench:       156 ns/iter (+/- 15)
test map::bench::insert_rand_10_000 ... bench:       471 ns/iter (+/- 21)
test map::bench::insert_seq_100     ... bench:       304 ns/iter (+/- 14)
test map::bench::insert_seq_10_000  ... bench:       438 ns/iter (+/- 24)
test map::bench::iter_1000          ... bench:     40143 ns/iter (+/- 2316)
test map::bench::iter_100_000       ... bench:   4332654 ns/iter (+/- 1266146)
test map::bench::iter_20            ... bench:       848 ns/iter (+/- 109)
```

From these numbers, it would seem that the more optimized design leaves the choice B largely "in the noise". 6 was the old value and it still seems to be a good choice.

Note that the `rand` benches have proven to be _very_ high variance between runs in my testing, making their values largely useless. It's also possible that the current microbenches aren't fully capturing the performance characteristics of the tree, because part of the BTree argument is about avoiding constant allocations, and these generally won't trigger many allocations.

If anyone is interested in further profiling these changes, I have a crate with only the BTree and the preserved change history at https://github.com/Gankro/btree-fiddles

The last 4 commits are exactly the states described above.
