### PR TITLE
Change target-word-size to target-pointer-width

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -645,7 +645,7 @@ pub fn build_target_config(opts: &Options, sp: &SpanHandler) -> Config {
         "32" => (ast::TyI32, ast::TyU32),
         "64" => (ast::TyI64, ast::TyU64),
         w    => sp.handler().fatal(&format!("target specification was invalid: unrecognized \
-                                            target-word-size {}", w)[])
+                                             target-pointer-width {}", w)[])
     };
 
     Config {

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -40,7 +40,7 @@
 //! this module defines the format the JSON file should take, though each
 //! underscore in the field names should be replaced with a hyphen (`-`) in the
 //! JSON file. Some fields are required in every target specification, such as
-//! `data-layout`, `llvm-target`, `target-endian`, `target-word-size`, and
+//! `data-layout`, `llvm-target`, `target-endian`, `target-pointer-width`, and
 //! `arch`. In general, options passed to rustc with `-C` override the target's
 //! settings, though `target-feature` and `link-args` will *add* to the list
 //! specified by the target, rather than replace.
@@ -241,7 +241,7 @@ impl Target {
             data_layout: get_req_field("data-layout"),
             llvm_target: get_req_field("llvm-target"),
             target_endian: get_req_field("target-endian"),
-            target_pointer_width: get_req_field("target-word-size"),
+            target_pointer_width: get_req_field("target-pointer-width"),
             arch: get_req_field("arch"),
             target_os: get_req_field("os"),
             options: Default::default(),

--- a/src/test/run-make/target-specs/my-awesome-platform.json
+++ b/src/test/run-make/target-specs/my-awesome-platform.json
@@ -2,7 +2,7 @@
     "data-layout": "e-p:32:32-f64:32:64-i64:32:64-f80:32:32-n8:16:32",
     "llvm-target": "i686-unknown-linux-gnu",
     "target-endian": "little",
-    "target-word-size": "32",
+    "target-pointer-width": "32",
     "arch": "x86",
     "os": "linux",
     "morestack": false

--- a/src/test/run-make/target-specs/my-incomplete-platform.json
+++ b/src/test/run-make/target-specs/my-incomplete-platform.json
@@ -1,7 +1,7 @@
 {
     "data-layout": "e-p:32:32-f64:32:64-i64:32:64-f80:32:32-n8:16:32",
     "target-endian": "little",
-    "target-word-size": "32",
+    "target-pointer-width": "32",
     "arch": "x86",
     "os": "foo",
     "morestack": false

--- a/src/test/run-make/target-specs/x86_64-unknown-linux-gnu.json
+++ b/src/test/run-make/target-specs/x86_64-unknown-linux-gnu.json
@@ -3,7 +3,7 @@
     "data-layout": "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128",
     "llvm-target": "x86_64-unknown-linux-gnu",
     "target-endian": "little",
-    "target-word-size": "64",
+    "target-pointer-width": "64",
     "arch": "x86_64",
     "os": "linux",
     "morestack": false


### PR DESCRIPTION
This aligns json target specification to match terminology used elsewhere in the code base.

[breaking-change] for custom target json users. Change all appearances of target-word-size
to target-pointer-width.
