### PR TITLE
rustc: Do not link to plugins

### DIFF
--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -462,7 +462,7 @@ impl<'a> CrateReader<'a> {
                      name: s.to_string(),
                      ident: s.to_string(),
                      id: ast::DUMMY_NODE_ID,
-                     should_link: true,
+                     should_link: false,
                  }, sp)
             }
         };


### PR DESCRIPTION
This flag seems to have erroneously been set to `true`.
