### PR TITLE
borrowck: Prevent partial reinitialization of uninitialized structures

### DIFF
--- a/src/librustc_borrowck/borrowck/check_loans.rs
+++ b/src/librustc_borrowck/borrowck/check_loans.rs
@@ -699,6 +699,11 @@ impl<'a, 'tcx> CheckLoanCtxt<'a, 'tcx> {
                               lp: &Rc<LoanPath<'tcx>>) {
         debug!("check_if_path_is_moved(id={}, use_kind={:?}, lp={})",
                id, use_kind, lp.repr(self.bccx.tcx));
+
+        // FIXME (22079): if you find yourself tempted to cut and paste
+        // the body below and then specializing the error reporting,
+        // consider refactoring this instead!
+
         let base_lp = owned_ptr_base_path_rc(lp);
         self.move_data.each_move_of(id, &base_lp, |the_move, moved_lp| {
             self.bccx.report_use_of_moved_value(
@@ -751,6 +756,9 @@ impl<'a, 'tcx> CheckLoanCtxt<'a, 'tcx> {
                             // In the case where the owner implements drop, then
                             // the path must be initialized to prevent a case of
                             // partial reinitialization
+                            //
+                            // FIXME (22079): could refactor via hypothetical
+                            // generalized check_if_path_is_moved
                             let loan_path = owned_ptr_base_path_rc(lp_base);
                             self.move_data.each_move_of(id, &loan_path, |_, _| {
                                 self.bccx

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -686,6 +686,18 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
         }
     }
 
+    pub fn report_partial_reinitialization_of_uninitialized_structure(
+            &self,
+            span: Span,
+            lp: &LoanPath<'tcx>) {
+        self.tcx
+            .sess
+            .span_err(span,
+                      (format!("partial reinitialization of uninitialized \
+                               structure `{}`",
+                               self.loan_path_to_string(lp))).as_slice());
+    }
+
     pub fn report_reassigned_immutable_variable(&self,
                                                 span: Span,
                                                 lp: &LoanPath<'tcx>,

--- a/src/test/compile-fail/borrowck-partial-reinit-1.rs
+++ b/src/test/compile-fail/borrowck-partial-reinit-1.rs
@@ -1,0 +1,49 @@
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Test;
+
+struct Test2 {
+    b: Option<Test>,
+}
+
+struct Test3(Option<Test>);
+
+impl Drop for Test {
+    fn drop(&mut self) {
+        println!("dropping!");
+    }
+}
+
+impl Drop for Test2 {
+    fn drop(&mut self) {}
+}
+
+impl Drop for Test3 {
+    fn drop(&mut self) {}
+}
+
+fn stuff() {
+    let mut t = Test2 { b: None };
+    let u = Test;
+    drop(t);
+    t.b = Some(u);
+    //~^ ERROR partial reinitialization of uninitialized structure `t`
+
+    let mut t = Test3(None);
+    let u = Test;
+    drop(t);
+    t.0 = Some(u);
+    //~^ ERROR partial reinitialization of uninitialized structure `t`
+}
+
+fn main() {
+    stuff()
+}

--- a/src/test/compile-fail/borrowck-partial-reinit-2.rs
+++ b/src/test/compile-fail/borrowck-partial-reinit-2.rs
@@ -1,0 +1,34 @@
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Test {
+    a: isize,
+    b: Option<Box<Test>>,
+}
+
+impl Drop for Test {
+    fn drop(&mut self) {
+        println!("Dropping {}", self.a);
+    }
+}
+
+fn stuff() {
+    let mut t = Test { a: 1, b: None};
+    let mut u = Test { a: 2, b: Some(Box::new(t))};
+    t.b = Some(Box::new(u));
+    //~^ ERROR partial reinitialization of uninitialized structure `t`
+    println!("done");
+}
+
+fn main() {
+    stuff();
+    println!("Hello, world!")
+}
+

--- a/src/test/compile-fail/borrowck-partial-reinit-3.rs
+++ b/src/test/compile-fail/borrowck-partial-reinit-3.rs
@@ -1,0 +1,22 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+use std::mem;
+
+struct Test { f: usize }
+impl Drop for Test {
+    fn drop(&mut self) {}
+}
+
+fn main() {
+    let mut x = (Test { f: 2 }, Test { f: 4 });
+    mem::drop(x.0);
+    x.0.f = 3;
+    //~^ ERROR partial reinitialization of uninitialized structure `x.0`
+}

--- a/src/test/compile-fail/borrowck-partial-reinit-4.rs
+++ b/src/test/compile-fail/borrowck-partial-reinit-4.rs
@@ -1,0 +1,33 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Test;
+
+struct Test2(Option<Test>);
+
+impl Drop for Test {
+    fn drop(&mut self) {
+        println!("dropping!");
+    }
+}
+
+impl Drop for Test2 {
+    fn drop(&mut self) {}
+}
+
+fn stuff() {
+    let mut x : (Test2, Test2);
+    (x.0).0 = Some(Test);
+    //~^ ERROR partial reinitialization of uninitialized structure `x.0`
+}
+
+fn main() {
+    stuff()
+}


### PR DESCRIPTION
borrowck: Prevent partial reinitialization of uninitialized structures

This is a pnkfelix-swiped squash of #22079, which was a rebase and revision of #18963

Fixes #18571.
