### PR TITLE
rustdoc: Show must_use attribute

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1849,6 +1849,7 @@ fn render_method(w: &mut fmt::Formatter, meth: &clean::Item) -> fmt::Result {
 fn item_struct(w: &mut fmt::Formatter, it: &clean::Item,
                s: &clean::Struct) -> fmt::Result {
     try!(write!(w, "<pre class='rust struct'>"));
+    try!(render_attributes(w, it));
     try!(render_struct(w,
                        it,
                        Some(&s.generics),
@@ -1885,7 +1886,9 @@ fn item_struct(w: &mut fmt::Formatter, it: &clean::Item,
 
 fn item_enum(w: &mut fmt::Formatter, it: &clean::Item,
              e: &clean::Enum) -> fmt::Result {
-    try!(write!(w, "<pre class='rust enum'>{}enum {}{}{}",
+    try!(write!(w, "<pre class='rust enum'>"));
+    try!(render_attributes(w, it));
+    try!(write!(w, "{}enum {}{}{}",
                   VisSpace(it.visibility),
                   it.name.as_ref().unwrap(),
                   e.generics,
@@ -1979,6 +1982,21 @@ fn item_enum(w: &mut fmt::Formatter, it: &clean::Item,
 
     }
     try!(render_methods(w, it));
+    Ok(())
+}
+
+fn render_attributes(w: &mut fmt::Formatter, it: &clean::Item) -> fmt::Result {
+    for attr in &it.attrs {
+        match *attr {
+            clean::Word(ref s) if *s == "must_use" => {
+                try!(write!(w, "#[{}]\n", s));
+            }
+            clean::NameValue(ref k, ref v) if *k == "must_use" => {
+                try!(write!(w, "#[{} = \"{}\"]\n", k, v));
+            }
+            _ => ()
+        }
+    }
     Ok(())
 }
 

--- a/src/test/run-make/rustdoc-must-use/Makefile
+++ b/src/test/run-make/rustdoc-must-use/Makefile
@@ -1,0 +1,5 @@
+-include ../tools.mk
+
+all: lib.rs
+	$(HOST_RPATH_ENV) $(RUSTDOC) -w html -o $(TMPDIR)/doc lib.rs
+	$(HTMLDOCCK) $(TMPDIR)/doc lib.rs

--- a/src/test/run-make/rustdoc-must-use/lib.rs
+++ b/src/test/run-make/rustdoc-must-use/lib.rs
@@ -1,0 +1,23 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="lib"]
+
+// @has lib/struct.Struct.html //pre '#[must_use]'
+#[must_use]
+pub struct Struct {
+    field: i32,
+}
+
+// @has lib/enum.Enum.html //pre '#[must_use = "message"]'
+#[must_use = "message"]
+pub enum Enum {
+    Variant(i32),
+}


### PR DESCRIPTION
Fix #20109.
