### PR TITLE
Object lifetime defaults (RFC 599)

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -824,6 +824,7 @@ fn parse_type_param_def_<'a, 'tcx, F>(st: &mut PState<'a, 'tcx>, conv: &mut F)
     assert_eq!(next(st), '|');
     let bounds = parse_bounds_(st, conv);
     let default = parse_opt(st, |st| parse_ty_(st, conv));
+    let object_lifetime_default = parse_object_lifetime_default(st, conv);
 
     ty::TypeParameterDef {
         name: name,
@@ -831,7 +832,24 @@ fn parse_type_param_def_<'a, 'tcx, F>(st: &mut PState<'a, 'tcx>, conv: &mut F)
         space: space,
         index: index,
         bounds: bounds,
-        default: default
+        default: default,
+        object_lifetime_default: object_lifetime_default,
+    }
+}
+
+fn parse_object_lifetime_default<'a,'tcx, F>(st: &mut PState<'a,'tcx>,
+                                             conv: &mut F)
+                                             -> Option<ty::ObjectLifetimeDefault>
+    where F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
+{
+    match next(st) {
+        'n' => None,
+        'a' => Some(ty::ObjectLifetimeDefault::Ambiguous),
+        's' => {
+            let region = parse_region_(st, conv);
+            Some(ty::ObjectLifetimeDefault::Specific(region))
+        }
+        _ => panic!("parse_object_lifetime_default: bad input")
     }
 }
 

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -414,6 +414,21 @@ pub fn enc_type_param_def<'a, 'tcx>(w: &mut SeekableMemWriter, cx: &ctxt<'a, 'tc
              v.space.to_uint(), v.index);
     enc_bounds(w, cx, &v.bounds);
     enc_opt(w, v.default, |w, t| enc_ty(w, cx, t));
+    enc_object_lifetime_default(w, cx, v.object_lifetime_default);
+}
+
+fn enc_object_lifetime_default<'a, 'tcx>(w: &mut SeekableMemWriter,
+                                         cx: &ctxt<'a, 'tcx>,
+                                         default: Option<ty::ObjectLifetimeDefault>)
+{
+    match default {
+        None => mywrite!(w, "n"),
+        Some(ty::ObjectLifetimeDefault::Ambiguous) => mywrite!(w, "a"),
+        Some(ty::ObjectLifetimeDefault::Specific(r)) => {
+            mywrite!(w, "s");
+            enc_region(w, cx, r);
+        }
+    }
 }
 
 pub fn enc_predicate<'a, 'tcx>(w: &mut SeekableMemWriter,

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -619,7 +619,7 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
             infer::RelateRegionParamBound(span) => {
                 self.tcx.sess.span_err(
                     span,
-                    "declared lifetime bound not satisfied");
+                    "lifetime bound not satisfied");
                 note_and_explain_region(
                     self.tcx,
                     "lifetime parameter instantiated with ",
@@ -1629,7 +1629,7 @@ impl<'a, 'tcx> ErrorReportingHelpers<'tcx> for InferCtxt<'a, 'tcx> {
                 self.tcx.sess.span_note(
                     span,
                     &format!("...so that the type `{}` \
-                             will meet the declared lifetime bounds",
+                             will meet its required lifetime bounds",
                             self.ty_to_string(t))[]);
             }
             infer::RelateDefaultParamBound(span, t) => {

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -379,6 +379,19 @@ impl<'tcx> TypeFoldable<'tcx> for ty::TypeParameterDef<'tcx> {
             index: self.index,
             bounds: self.bounds.fold_with(folder),
             default: self.default.fold_with(folder),
+            object_lifetime_default: self.object_lifetime_default.fold_with(folder),
+        }
+    }
+}
+
+impl<'tcx> TypeFoldable<'tcx> for ty::ObjectLifetimeDefault {
+    fn fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> ty::ObjectLifetimeDefault {
+        match *self {
+            ty::ObjectLifetimeDefault::Ambiguous =>
+                ty::ObjectLifetimeDefault::Ambiguous,
+
+            ty::ObjectLifetimeDefault::Specific(r) =>
+                ty::ObjectLifetimeDefault::Specific(r.fold_with(folder)),
         }
     }
 }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1754,6 +1754,12 @@ fn compute_object_lifetime_bound<'tcx>(
     return r;
 }
 
+/// Given an object type like `SomeTrait+Send`, computes the lifetime
+/// bounds that must hold on the elided self type. These are derived
+/// from the declarations of `SomeTrait`, `Send`, and friends -- if
+/// they declare `trait SomeTrait : 'static`, for example, then
+/// `'static` would appear in the list. The hard work is done by
+/// `ty::required_region_bounds`, see that for more information.
 pub fn object_region_bounds<'tcx>(
     tcx: &ty::ctxt<'tcx>,
     principal: &ty::PolyTraitRef<'tcx>,

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -56,7 +56,7 @@ use middle::subst::{FnSpace, TypeSpace, SelfSpace, Subst, Substs};
 use middle::traits;
 use middle::ty::{self, RegionEscape, ToPolyTraitRef, Ty};
 use rscope::{self, UnelidableRscope, RegionScope, ElidableRscope,
-             ShiftedRscope, BindingRscope};
+             ObjectLifetimeDefaultRscope, ShiftedRscope, BindingRscope};
 use TypeAndSubsts;
 use util::common::{ErrorReported, FN_OUTPUT_NAME};
 use util::nodemap::DefIdMap;
@@ -1084,7 +1084,11 @@ pub fn ast_ty_to_ty<'tcx>(
             ast::TyRptr(ref region, ref mt) => {
                 let r = opt_ast_region_to_region(this, rscope, ast_ty.span, region);
                 debug!("ty_rptr r={}", r.repr(this.tcx()));
-                let t = ast_ty_to_ty(this, rscope, &*mt.ty);
+                let rscope1 =
+                    &ObjectLifetimeDefaultRscope::new(
+                        rscope,
+                        Some(ty::ObjectLifetimeDefault::Specific(r)));
+                let t = ast_ty_to_ty(this, rscope1, &*mt.ty);
                 ty::mk_rptr(tcx, tcx.mk_region(r), ty::mt {ty: t, mutbl: mt.mutbl})
             }
             ast::TyTup(ref fields) => {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1891,6 +1891,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
 impl<'a, 'tcx> RegionScope for FnCtxt<'a, 'tcx> {
     fn object_lifetime_default(&self, span: Span) -> Option<ty::Region> {
+        // TODO. RFC #599 specifies that object lifetime defaults take
+        // precedence over other defaults. *However,* within a fn
+        // body, we typically use inference to allow users to elide
+        // lifetimes whenever they like, and then just infer it to
+        // whatever it must be. So I interpret that as applying only
+        // to fn sigs.
         Some(self.infcx().next_region_var(infer::MiscVariable(span)))
     }
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1890,7 +1890,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> RegionScope for FnCtxt<'a, 'tcx> {
-    fn default_region_bound(&self, span: Span) -> Option<ty::Region> {
+    fn object_lifetime_default(&self, span: Span) -> Option<ty::Region> {
         Some(self.infcx().next_region_var(infer::MiscVariable(span)))
     }
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1891,12 +1891,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
 impl<'a, 'tcx> RegionScope for FnCtxt<'a, 'tcx> {
     fn object_lifetime_default(&self, span: Span) -> Option<ty::Region> {
-        // TODO. RFC #599 specifies that object lifetime defaults take
-        // precedence over other defaults. *However,* within a fn
-        // body, we typically use inference to allow users to elide
-        // lifetimes whenever they like, and then just infer it to
-        // whatever it must be. So I interpret that as applying only
-        // to fn sigs.
+        // RFC #599 specifies that object lifetime defaults take
+        // precedence over other defaults. But within a fn body we
+        // don't have a *default* region, rather we use inference to
+        // find the *correct* region, which is strictly more general
+        // (and anyway, within a fn body the right region may not even
+        // be something the user can write explicitly, since it might
+        // be some expression).
         Some(self.infcx().next_region_var(infer::MiscVariable(span)))
     }
 

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -154,7 +154,7 @@ pub fn regionck_ensure_component_tys_wf<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
         // empty region is a subregion of all others, this can't fail
         // unless the type does not meet the well-formedness
         // requirements.
-        type_must_outlive(&mut rcx, infer::RelateRegionParamBound(span),
+        type_must_outlive(&mut rcx, infer::RelateParamBound(span, component_ty),
                           component_ty, ty::ReEmpty);
     }
 }
@@ -305,7 +305,7 @@ impl<'a, 'tcx> Rcx<'a, 'tcx> {
             debug!("visit_region_obligations: r_o={}",
                    r_o.repr(self.tcx()));
             let sup_type = self.resolve_type(r_o.sup_type);
-            let origin = infer::RelateRegionParamBound(r_o.cause.span);
+            let origin = infer::RelateParamBound(r_o.cause.span, sup_type);
             type_must_outlive(self, origin, sup_type, r_o.sub_region);
         }
 

--- a/src/librustc_typeck/check/regionmanip.rs
+++ b/src/librustc_typeck/check/regionmanip.rs
@@ -12,6 +12,7 @@
 
 pub use self::WfConstraint::*;
 
+use astconv::object_region_bounds;
 use middle::infer::GenericKind;
 use middle::subst::{ParamSpace, Subst, Substs};
 use middle::ty::{self, Ty};
@@ -95,7 +96,7 @@ impl<'a, 'tcx> Wf<'a, 'tcx> {
 
             ty::ty_trait(ref t) => {
                 let required_region_bounds =
-                    ty::object_region_bounds(self.tcx, Some(&t.principal), t.bounds.builtin_bounds);
+                    object_region_bounds(self.tcx, &t.principal, t.bounds.builtin_bounds);
                 self.accumulate_from_object_ty(ty, t.bounds.region_bound, required_region_bounds)
             }
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -35,18 +35,18 @@ pub trait ItemDecorator {
               sp: Span,
               meta_item: &ast::MetaItem,
               item: &ast::Item,
-              push: Box<FnMut(P<ast::Item>)>);
+              push: &mut FnMut(P<ast::Item>));
 }
 
 impl<F> ItemDecorator for F
-    where F : Fn(&mut ExtCtxt, Span, &ast::MetaItem, &ast::Item, Box<FnMut(P<ast::Item>)>)
+    where F : Fn(&mut ExtCtxt, Span, &ast::MetaItem, &ast::Item, &mut FnMut(P<ast::Item>))
 {
     fn expand(&self,
               ecx: &mut ExtCtxt,
               sp: Span,
               meta_item: &ast::MetaItem,
               item: &ast::Item,
-              push: Box<FnMut(P<ast::Item>)>) {
+              push: &mut FnMut(P<ast::Item>)) {
         (*self)(ecx, sp, meta_item, item, push)
     }
 }

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -72,7 +72,7 @@ pub fn expand_deprecated_deriving(cx: &mut ExtCtxt,
                                   span: Span,
                                   _: &MetaItem,
                                   _: &Item,
-                                  _: Box<FnMut(P<Item>)>) {
+                                  _: &mut FnMut(P<Item>)) {
     cx.span_err(span, "`deriving` has been renamed to `derive`");
 }
 
@@ -80,7 +80,7 @@ pub fn expand_meta_derive(cx: &mut ExtCtxt,
                           _span: Span,
                           mitem: &MetaItem,
                           item: &Item,
-                          mut push: Box<FnMut(P<Item>)>) {
+                          push: &mut FnMut(P<Item>)) {
     match mitem.node {
         MetaNameValue(_, ref l) => {
             cx.span_err(l.span, "unexpected value in `derive`");

--- a/src/test/compile-fail/builtin-superkinds-simple.rs
+++ b/src/test/compile-fail/builtin-superkinds-simple.rs
@@ -14,6 +14,6 @@
 trait Foo : Send { }
 
 impl <'a> Foo for &'a mut () { }
-//~^ ERROR declared lifetime bound not satisfied
+//~^ ERROR the type `&'a mut ()` does not fulfill the required lifetime
 
 fn main() { }

--- a/src/test/compile-fail/issue-11374.rs
+++ b/src/test/compile-fail/issue-11374.rs
@@ -12,7 +12,7 @@ use std::old_io;
 use std::vec;
 
 pub struct Container<'a> {
-    reader: &'a mut Reader //~ ERROR explicit lifetime bound required
+    reader: &'a mut Reader
 }
 
 impl<'a> Container<'a> {
@@ -33,5 +33,5 @@ pub fn for_stdin<'a>() -> Container<'a> {
 fn main() {
     let mut c = for_stdin();
     let mut v = Vec::new();
-    c.read_to(v);
+    c.read_to(v); //~ ERROR mismatched types
 }

--- a/src/test/compile-fail/issue-5216.rs
+++ b/src/test/compile-fail/issue-5216.rs
@@ -9,12 +9,12 @@
 // except according to those terms.
 
 fn f() { }
-struct S(Box<FnMut()>); //~ ERROR explicit lifetime bound required
-pub static C: S = S(f);
+struct S(Box<FnMut()>);
+pub static C: S = S(f); //~ ERROR mismatched types
 
 
 fn g() { }
-type T = Box<FnMut()>;  //~ ERROR explicit lifetime bound required
-pub static D: T = g;
+type T = Box<FnMut()>;
+pub static D: T = g; //~ ERROR mismatched types
 
 fn main() {}

--- a/src/test/compile-fail/kindck-impl-type-params.rs
+++ b/src/test/compile-fail/kindck-impl-type-params.rs
@@ -36,7 +36,7 @@ fn g<T>(val: T) {
 fn foo<'a>() {
     let t: S<&'a isize> = S;
     let a = &t as &Gettable<&'a isize>;
-    //~^ ERROR declared lifetime bound not satisfied
+    //~^ ERROR the type `&'a isize` does not fulfill the required lifetime
 }
 
 fn foo2<'a>() {

--- a/src/test/compile-fail/kindck-send-object1.rs
+++ b/src/test/compile-fail/kindck-send-object1.rs
@@ -22,7 +22,7 @@ fn test51<'a>() {
 }
 fn test52<'a>() {
     assert_send::<&'a (Dummy+Send)>();
-    //~^ ERROR declared lifetime bound not satisfied
+    //~^ ERROR does not fulfill the required lifetime
 }
 
 // ...unless they are properly bounded

--- a/src/test/compile-fail/kindck-send-owned.rs
+++ b/src/test/compile-fail/kindck-send-owned.rs
@@ -19,7 +19,7 @@ fn test32() { assert_send::<Vec<isize> >(); }
 
 // but not if they own a bad thing
 fn test40<'a>(_: &'a isize) {
-    assert_send::<Box<&'a isize>>(); //~ ERROR declared lifetime bound not satisfied
+    assert_send::<Box<&'a isize>>(); //~ ERROR does not fulfill the required lifetime
 }
 
 fn main() { }

--- a/src/test/compile-fail/kindck-send-region-pointers.rs
+++ b/src/test/compile-fail/kindck-send-region-pointers.rs
@@ -22,13 +22,13 @@ fn test10() { assert_send::<&'static mut isize>(); }
 
 // otherwise lifetime pointers are not ok
 fn test20<'a>(_: &'a isize) {
-    assert_send::<&'a isize>(); //~ ERROR declared lifetime bound not satisfied
+    assert_send::<&'a isize>(); //~ ERROR does not fulfill the required lifetime
 }
 fn test21<'a>(_: &'a isize) {
-    assert_send::<&'a str>(); //~ ERROR declared lifetime bound not satisfied
+    assert_send::<&'a str>(); //~ ERROR does not fulfill the required lifetime
 }
 fn test22<'a>(_: &'a isize) {
-    assert_send::<&'a [isize]>(); //~ ERROR declared lifetime bound not satisfied
+    assert_send::<&'a [isize]>(); //~ ERROR does not fulfill the required lifetime
 }
 
 fn main() { }

--- a/src/test/compile-fail/object-lifetime-default-ambiguous.rs
+++ b/src/test/compile-fail/object-lifetime-default-ambiguous.rs
@@ -49,7 +49,8 @@ fn d(t: Ref2<Ref1<Test>>) {
 fn e(t: Ref2<Ref0<Test>>) {
     //~^ ERROR lifetime bound for this object type cannot be deduced from context
     //
-    // In this case, Ref0 just inherits.
+    // In this case, Ref2 is ambiguous, and Ref0 inherits the
+    // ambiguity.
 }
 
 fn f(t: &Ref2<Test>) {

--- a/src/test/compile-fail/object-lifetime-default-ambiguous.rs
+++ b/src/test/compile-fail/object-lifetime-default-ambiguous.rs
@@ -1,0 +1,60 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that if a struct declares multiple region bounds for a given
+// type parameter, an explicit lifetime bound is required on object
+// lifetimes within.
+
+#![allow(dead_code)]
+
+trait Test {
+    fn foo(&self) { }
+}
+
+struct Ref0<T:?Sized> {
+    r: *mut T
+}
+
+struct Ref1<'a,T:'a+?Sized> {
+    r: &'a T
+}
+
+struct Ref2<'a,'b:'a,T:'a+'b+?Sized> {
+    r: &'a &'b T
+}
+
+fn a<'a,'b>(t: Ref2<'a,'b,Test>) {
+    //~^ ERROR lifetime bound for this object type cannot be deduced from context
+}
+
+fn b(t: Ref2<Test>) {
+    //~^ ERROR lifetime bound for this object type cannot be deduced from context
+}
+
+fn c(t: Ref2<&Test>) {
+    // In this case, the &'a overrides.
+}
+
+fn d(t: Ref2<Ref1<Test>>) {
+    // In this case, the lifetime parameter from the Ref1 overrides.
+}
+
+fn e(t: Ref2<Ref0<Test>>) {
+    //~^ ERROR lifetime bound for this object type cannot be deduced from context
+    //
+    // In this case, Ref0 just inherits.
+}
+
+fn f(t: &Ref2<Test>) {
+    //~^ ERROR lifetime bound for this object type cannot be deduced from context
+}
+
+fn main() {
+}

--- a/src/test/compile-fail/object-lifetime-default-elision.rs
+++ b/src/test/compile-fail/object-lifetime-default-elision.rs
@@ -1,0 +1,89 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test various cases where the old rules under lifetime elision
+// yield slightly different results than the new rules.
+
+#![allow(dead_code)]
+
+trait SomeTrait {
+    fn dummy(&self) { }
+}
+
+struct SomeStruct<'a> {
+    r: Box<SomeTrait+'a>
+}
+
+fn deref<T>(ss: &T) -> T {
+    // produces the type of a deref without worrying about whether a
+    // move out would actually be legal
+    loop { }
+}
+
+fn load0<'a>(ss: &'a Box<SomeTrait>) -> Box<SomeTrait> {
+    // Under old rules, the fully elaborated types of input/output were:
+    //
+    // for<'a,'b> fn(&'a Box<SomeTrait+'b>) -> Box<SomeTrait+'a>
+    //
+    // Under new rules the result is:
+    //
+    // for<'a> fn(&'a Box<SomeTrait+'a>) -> Box<SomeTrait+'static>
+    //
+    // Therefore, we get a type error attempting to return `deref(ss)`
+    // since `SomeTrait+'a <: SomeTrait+'static` does not hold.
+
+    deref(ss)
+        //~^ ERROR cannot infer
+}
+
+fn load1(ss: &SomeTrait) -> &SomeTrait {
+    // Under old rules, the fully elaborated types of input/output were:
+    //
+    // for<'a,'b> fn(&'a (SomeTrait+'b)) -> &'a (SomeTrait+'a)
+    //
+    // Under new rules the result is:
+    //
+    // for<'a> fn(&'a (SomeTrait+'a)) -> &'a (SomeTrait+'a)
+    //
+    // In both cases, returning `ss` is legal.
+
+    ss
+}
+
+fn load2<'a>(ss: &'a SomeTrait) -> &SomeTrait {
+    // Same as `load1` but with an explicit name thrown in for fun.
+
+    ss
+}
+
+fn load3<'a,'b>(ss: &'a SomeTrait) -> &'b SomeTrait {
+    // Under old rules, the fully elaborated types of input/output were:
+    //
+    // for<'a,'b,'c>fn(&'a (SomeTrait+'c)) -> &'b (SomeTrait+'a)
+    //
+    // Based on the input/output types, the compiler could infer that
+    //     'c : 'a
+    //     'b : 'a
+    // must hold, and therefore it permitted `&'a (Sometrait+'c)` to be
+    // coerced to `&'b (SomeTrait+'a)`.
+    //
+    // Under the newer defaults, though, we get:
+    //
+    // for<'a,'b> fn(&'a (SomeTrait+'a)) -> &'b (SomeTrait+'b)
+    //
+    // which fails to type check.
+
+    ss
+        //~^ ERROR cannot infer
+        //~| ERROR mismatched types
+}
+
+fn main() {
+}

--- a/src/test/compile-fail/object-lifetime-default-from-box-error.rs
+++ b/src/test/compile-fail/object-lifetime-default-from-box-error.rs
@@ -1,0 +1,45 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test various cases where the defaults should lead to errors being
+// reported.
+
+#![allow(dead_code)]
+
+trait SomeTrait {
+    fn dummy(&self) { }
+}
+
+struct SomeStruct<'a> {
+    r: Box<SomeTrait+'a>
+}
+
+fn load(ss: &mut SomeStruct) -> Box<SomeTrait> {
+    // `Box<SomeTrait>` defaults to a `'static` bound, so this return
+    // is illegal.
+
+    ss.r //~ ERROR mismatched types
+}
+
+fn store(ss: &mut SomeStruct, b: Box<SomeTrait>) {
+    // No error: b is bounded by 'static which outlives the
+    // (anonymous) lifetime on the struct.
+
+    ss.r = b;
+}
+
+fn store1<'b>(ss: &mut SomeStruct, b: Box<SomeTrait+'b>) {
+    // Here we override the lifetimes explicitly, and so naturally we get an error.
+
+    ss.r = b; //~ ERROR mismatched types
+}
+
+fn main() {
+}

--- a/src/test/compile-fail/object-lifetime-default-mybox.rs
+++ b/src/test/compile-fail/object-lifetime-default-mybox.rs
@@ -1,0 +1,44 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test a "pass-through" object-lifetime-default that produces errors.
+
+#![allow(dead_code)]
+
+trait SomeTrait {
+    fn dummy(&self) { }
+}
+
+struct MyBox<T:?Sized> {
+    r: Box<T>
+}
+
+fn deref<T>(ss: &T) -> T {
+    // produces the type of a deref without worrying about whether a
+    // move out would actually be legal
+    loop { }
+}
+
+fn load0(ss: &MyBox<SomeTrait>) -> MyBox<SomeTrait> {
+    deref(ss) //~ ERROR cannot infer
+}
+
+fn load1<'a,'b>(a: &'a MyBox<SomeTrait>,
+                b: &'b MyBox<SomeTrait>)
+                -> &'b MyBox<SomeTrait>
+{
+    a
+      //~^ ERROR cannot infer
+      //~| ERROR mismatched types
+      //~| ERROR mismatched types
+}
+
+fn main() {
+}

--- a/src/test/compile-fail/object-lifetime-default.rs
+++ b/src/test/compile-fail/object-lifetime-default.rs
@@ -1,0 +1,32 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[rustc_object_lifetime_default]
+struct A<T>(T); //~ ERROR None
+
+#[rustc_object_lifetime_default]
+struct B<'a,T>(&'a (), T); //~ ERROR None
+
+#[rustc_object_lifetime_default]
+struct C<'a,T:'a>(&'a T); //~ ERROR 'a
+
+#[rustc_object_lifetime_default]
+struct D<'a,'b,T:'a+'b>(&'a T, &'b T); //~ ERROR Ambiguous
+
+#[rustc_object_lifetime_default]
+struct E<'a,'b:'a,T:'b>(&'a T, &'b T); //~ ERROR 'b
+
+#[rustc_object_lifetime_default]
+struct F<'a,'b,T:'a,U:'b>(&'a T, &'b U); //~ ERROR 'a,'b
+
+#[rustc_object_lifetime_default]
+struct G<'a,'b,T:'a,U:'a+'b>(&'a T, &'b U); //~ ERROR 'a,Ambiguous
+
+fn main() { }

--- a/src/test/compile-fail/region-bounds-on-objects-and-type-parameters.rs
+++ b/src/test/compile-fail/region-bounds-on-objects-and-type-parameters.rs
@@ -25,7 +25,7 @@ struct Foo<'a,'b,'c> {
     c: Box<Is<'a>>,
     d: Box<IsSend>,
     e: Box<Is<'a>+Send>, // we can derive two bounds, but one is 'static, so ok
-    f: Box<SomeTrait>, //~ ERROR explicit lifetime bound required
+    f: Box<SomeTrait>,   // OK, defaults to 'static due to RFC 599.
     g: Box<SomeTrait+'a>,
 
     z: Box<Is<'a>+'b+'c>, //~ ERROR only a single explicit lifetime bound is permitted

--- a/src/test/compile-fail/region-object-lifetime-2.rs
+++ b/src/test/compile-fail/region-object-lifetime-2.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,23 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Tests for "default" bounds inferred for traits with no bounds list.
+// Various tests related to testing how region inference works
+// with respect to the object receivers.
 
-
-trait Foo {}
-
-fn a(_x: Box<Foo+Send>) {
+trait Foo {
+    fn borrowed<'a>(&'a self) -> &'a ();
 }
 
-fn b(_x: &'static (Foo+'static)) {
-}
-
-fn c(x: Box<Foo+Sync>) {
-    a(x); //~ ERROR mismatched types
-}
-
-fn d(x: &'static (Foo+Sync)) {
-    b(x);
+// Borrowed receiver but two distinct lifetimes, we get an error.
+fn borrowed_receiver_different_lifetimes<'a,'b>(x: &'a Foo) -> &'b () {
+    x.borrowed() //~ ERROR cannot infer
 }
 
 fn main() {}
+

--- a/src/test/compile-fail/region-object-lifetime-3.rs
+++ b/src/test/compile-fail/region-object-lifetime-3.rs
@@ -17,9 +17,9 @@ trait Foo {
     fn borrowed<'a>(&'a self) -> &'a ();
 }
 
-// Here the receiver and return value all have the same lifetime,
-// so no error results.
-fn borrowed_receiver_same_lifetime<'a>(x: &'a Foo) -> &'a () {
+// Borrowed receiver with two distinct lifetimes, but we know that
+// 'b:'a, hence &'a () is permitted.
+fn borrowed_receiver_related_lifetimes<'a,'b>(x: &'a (Foo+'b)) -> &'a () {
     x.borrowed()
 }
 

--- a/src/test/compile-fail/region-object-lifetime-4.rs
+++ b/src/test/compile-fail/region-object-lifetime-4.rs
@@ -11,18 +11,16 @@
 // Various tests related to testing how region inference works
 // with respect to the object receivers.
 
-#![allow(warnings)]
-
 trait Foo {
     fn borrowed<'a>(&'a self) -> &'a ();
 }
 
-// Here the receiver and return value all have the same lifetime,
-// so no error results.
-fn borrowed_receiver_same_lifetime<'a>(x: &'a Foo) -> &'a () {
-    x.borrowed()
+// Here we have two distinct lifetimes, but we try to return a pointer
+// with the longer lifetime when (from the signature) we only know
+// that it lives as long as the shorter lifetime. Therefore, error.
+fn borrowed_receiver_related_lifetimes2<'a,'b>(x: &'a (Foo+'b)) -> &'b () {
+    x.borrowed() //~ ERROR cannot infer
 }
 
-#[rustc_error]
-fn main() {} //~ ERROR compilation successful
+fn main() {}
 

--- a/src/test/compile-fail/region-object-lifetime-5.rs
+++ b/src/test/compile-fail/region-object-lifetime-5.rs
@@ -11,18 +11,15 @@
 // Various tests related to testing how region inference works
 // with respect to the object receivers.
 
-#![allow(warnings)]
-
 trait Foo {
     fn borrowed<'a>(&'a self) -> &'a ();
 }
 
-// Here the receiver and return value all have the same lifetime,
-// so no error results.
-fn borrowed_receiver_same_lifetime<'a>(x: &'a Foo) -> &'a () {
-    x.borrowed()
+// Here, the object is bounded by an anonymous lifetime and returned
+// as `&'static`, so you get an error.
+fn owned_receiver(x: Box<Foo>) -> &'static () {
+    x.borrowed() //~ ERROR `*x` does not live long enough
 }
 
-#[rustc_error]
-fn main() {} //~ ERROR compilation successful
+fn main() {}
 

--- a/src/test/compile-fail/region-object-lifetime-in-coercion.rs
+++ b/src/test/compile-fail/region-object-lifetime-in-coercion.rs
@@ -17,22 +17,22 @@ trait Foo {}
 impl<'a> Foo for &'a [u8] {}
 
 fn a(v: &[u8]) -> Box<Foo + 'static> {
-    let x: Box<Foo + 'static> = box v; //~ ERROR declared lifetime bound not satisfied
+    let x: Box<Foo + 'static> = box v; //~ ERROR does not fulfill the required lifetime
     x
 }
 
 fn b(v: &[u8]) -> Box<Foo + 'static> {
-    box v //~ ERROR declared lifetime bound not satisfied
+    box v //~ ERROR does not fulfill the required lifetime
 }
 
 fn c(v: &[u8]) -> Box<Foo> {
     // same as previous case due to RFC 599
 
-    box v //~ ERROR declared lifetime bound not satisfied
+    box v //~ ERROR does not fulfill the required lifetime
 }
 
 fn d<'a,'b>(v: &'a [u8]) -> Box<Foo+'b> {
-    box v //~ ERROR declared lifetime bound not satisfied
+    box v //~ ERROR does not fulfill the required lifetime
 }
 
 fn e<'a:'b,'b>(v: &'a [u8]) -> Box<Foo+'b> {

--- a/src/test/compile-fail/region-object-lifetime-in-coercion.rs
+++ b/src/test/compile-fail/region-object-lifetime-in-coercion.rs
@@ -26,7 +26,9 @@ fn b(v: &[u8]) -> Box<Foo + 'static> {
 }
 
 fn c(v: &[u8]) -> Box<Foo> {
-    box v // OK thanks to lifetime elision
+    // same as previous case due to RFC 599
+
+    box v //~ ERROR declared lifetime bound not satisfied
 }
 
 fn d<'a,'b>(v: &'a [u8]) -> Box<Foo+'b> {

--- a/src/test/compile-fail/regions-bounded-by-send.rs
+++ b/src/test/compile-fail/regions-bounded-by-send.rs
@@ -32,15 +32,15 @@ fn static_lifime_ok<'a,T,U:Send>(_: &'a isize) {
 // otherwise lifetime pointers are not ok
 
 fn param_not_ok<'a>(x: &'a isize) {
-    assert_send::<&'a isize>(); //~ ERROR declared lifetime bound not satisfied
+    assert_send::<&'a isize>(); //~ ERROR does not fulfill the required lifetime
 }
 
 fn param_not_ok1<'a>(_: &'a isize) {
-    assert_send::<&'a str>(); //~ ERROR declared lifetime bound not satisfied
+    assert_send::<&'a str>(); //~ ERROR does not fulfill the required lifetime
 }
 
 fn param_not_ok2<'a>(_: &'a isize) {
-    assert_send::<&'a [isize]>(); //~ ERROR declared lifetime bound not satisfied
+    assert_send::<&'a [isize]>(); //~ ERROR does not fulfill the required lifetime
 }
 
 // boxes are ok
@@ -54,7 +54,7 @@ fn box_ok() {
 // but not if they own a bad thing
 
 fn box_with_region_not_ok<'a>() {
-    assert_send::<Box<&'a isize>>(); //~ ERROR declared lifetime bound not satisfied
+    assert_send::<Box<&'a isize>>(); //~ ERROR does not fulfill the required lifetime
 }
 
 // objects with insufficient bounds no ok
@@ -66,7 +66,7 @@ fn object_with_random_bound_not_ok<'a>() {
 
 fn object_with_send_bound_not_ok<'a>() {
     assert_send::<&'a (Dummy+Send)>();
-    //~^ ERROR declared lifetime bound not satisfied
+    //~^ ERROR does not fulfill the required lifetime
 }
 
 // unsafe pointers are ok unless they point at unsendable things

--- a/src/test/compile-fail/regions-bounded-by-trait-requiring-static.rs
+++ b/src/test/compile-fail/regions-bounded-by-trait-requiring-static.rs
@@ -29,15 +29,15 @@ fn static_lifime_ok<'a,T,U:Send>(_: &'a isize) {
 // otherwise lifetime pointers are not ok
 
 fn param_not_ok<'a>(x: &'a isize) {
-    assert_send::<&'a isize>(); //~ ERROR declared lifetime bound not satisfied
+    assert_send::<&'a isize>(); //~ ERROR does not fulfill the required lifetime
 }
 
 fn param_not_ok1<'a>(_: &'a isize) {
-    assert_send::<&'a str>(); //~ ERROR declared lifetime bound not satisfied
+    assert_send::<&'a str>(); //~ ERROR does not fulfill the required lifetime
 }
 
 fn param_not_ok2<'a>(_: &'a isize) {
-    assert_send::<&'a [isize]>(); //~ ERROR declared lifetime bound not satisfied
+    assert_send::<&'a [isize]>(); //~ ERROR does not fulfill the required lifetime
 }
 
 // boxes are ok
@@ -51,7 +51,7 @@ fn box_ok() {
 // but not if they own a bad thing
 
 fn box_with_region_not_ok<'a>() {
-    assert_send::<Box<&'a isize>>(); //~ ERROR declared lifetime bound not satisfied
+    assert_send::<Box<&'a isize>>(); //~ ERROR does not fulfill the required lifetime
 }
 
 // unsafe pointers are ok unless they point at unsendable things
@@ -62,11 +62,11 @@ fn unsafe_ok1<'a>(_: &'a isize) {
 }
 
 fn unsafe_ok2<'a>(_: &'a isize) {
-    assert_send::<*const &'a isize>(); //~ ERROR declared lifetime bound not satisfied
+    assert_send::<*const &'a isize>(); //~ ERROR does not fulfill the required lifetime
 }
 
 fn unsafe_ok3<'a>(_: &'a isize) {
-    assert_send::<*mut &'a isize>(); //~ ERROR declared lifetime bound not satisfied
+    assert_send::<*mut &'a isize>(); //~ ERROR does not fulfill the required lifetime
 }
 
 fn main() {

--- a/src/test/compile-fail/regions-bounded-method-type-parameters.rs
+++ b/src/test/compile-fail/regions-bounded-method-type-parameters.rs
@@ -20,7 +20,7 @@ impl Foo {
 
 fn caller<'a>(x: &isize) {
     Foo.some_method::<&'a isize>();
-    //~^ ERROR declared lifetime bound not satisfied
+    //~^ ERROR does not fulfill the required lifetime
 }
 
 fn main() { }

--- a/src/test/compile-fail/regions-close-object-into-object-1.rs
+++ b/src/test/compile-fail/regions-close-object-into-object-1.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,23 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Tests for "default" bounds inferred for traits with no bounds list.
+#![feature(box_syntax)]
+#![allow(warnings)]
 
+trait A<T> {}
+struct B<'a, T>(&'a (A<T>+'a));
 
-trait Foo {}
+trait X {}
+impl<'a, T> X for B<'a, T> {}
 
-fn a(_x: Box<Foo+Send>) {
-}
-
-fn b(_x: &'static (Foo+'static)) {
-}
-
-fn c(x: Box<Foo+Sync>) {
-    a(x); //~ ERROR mismatched types
-}
-
-fn d(x: &'static (Foo+Sync)) {
-    b(x);
+fn f<'a, T, U>(v: Box<A<T>+'static>) -> Box<X+'static> {
+    box B(&*v) as Box<X> //~ ERROR `*v` does not live long enough
 }
 
 fn main() {}
+

--- a/src/test/compile-fail/regions-close-object-into-object-2.rs
+++ b/src/test/compile-fail/regions-close-object-into-object-2.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,23 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Tests for "default" bounds inferred for traits with no bounds list.
+#![feature(box_syntax)]
 
+trait A<T> {}
+struct B<'a, T>(&'a (A<T>+'a));
 
-trait Foo {}
+trait X {}
+impl<'a, T> X for B<'a, T> {}
 
-fn a(_x: Box<Foo+Send>) {
+fn g<'a, T: 'static>(v: Box<A<T>+'a>) -> Box<X+'static> {
+    box B(&*v) as Box<X> //~ ERROR cannot infer
 }
 
-fn b(_x: &'static (Foo+'static)) {
-}
-
-fn c(x: Box<Foo+Sync>) {
-    a(x); //~ ERROR mismatched types
-}
-
-fn d(x: &'static (Foo+Sync)) {
-    b(x);
-}
-
-fn main() {}
+fn main() { }

--- a/src/test/compile-fail/regions-close-object-into-object-3.rs
+++ b/src/test/compile-fail/regions-close-object-into-object-3.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(box_syntax)]
+#![allow(warnings)]
 
 trait A<T> {}
 struct B<'a, T>(&'a (A<T>+'a));
@@ -16,20 +17,8 @@ struct B<'a, T>(&'a (A<T>+'a));
 trait X {}
 impl<'a, T> X for B<'a, T> {}
 
-fn f<'a, T, U>(v: Box<A<T>+'static>) -> Box<X+'static> {
-    box B(&*v) as Box<X>
-}
-
-fn g<'a, T: 'static>(v: Box<A<T>>) -> Box<X+'static> {
-    box B(&*v) as Box<X> //~ ERROR cannot infer
-}
-
 fn h<'a, T, U>(v: Box<A<U>+'static>) -> Box<X+'static> {
-    box B(&*v) as Box<X>
-}
-
-fn i<'a, T, U>(v: Box<A<U>>) -> Box<X+'static> {
-    box B(&*v) as Box<X> //~ ERROR cannot infer
+    box B(&*v) as Box<X> //~ ERROR `*v` does not live long enough
 }
 
 fn main() {}

--- a/src/test/compile-fail/regions-close-object-into-object-4.rs
+++ b/src/test/compile-fail/regions-close-object-into-object-4.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,23 +8,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Tests for "default" bounds inferred for traits with no bounds list.
+#![feature(box_syntax)]
 
+trait A<T> {}
+struct B<'a, T>(&'a (A<T>+'a));
 
-trait Foo {}
+trait X {}
+impl<'a, T> X for B<'a, T> {}
 
-fn a(_x: Box<Foo+Send>) {
-}
-
-fn b(_x: &'static (Foo+'static)) {
-}
-
-fn c(x: Box<Foo+Sync>) {
-    a(x); //~ ERROR mismatched types
-}
-
-fn d(x: &'static (Foo+Sync)) {
-    b(x);
+fn i<'a, T, U>(v: Box<A<U>+'a>) -> Box<X+'static> {
+    box B(&*v) as Box<X> //~ ERROR cannot infer
 }
 
 fn main() {}
+

--- a/src/test/compile-fail/seq-args.rs
+++ b/src/test/compile-fail/seq-args.rs
@@ -14,7 +14,7 @@ trait seq { }
 impl<T> seq<T> for Vec<T> { //~ ERROR wrong number of type arguments
     /* ... */
 }
-impl seq<bool> for u32 {
+impl seq<bool> for u32 { //~ ERROR wrong number of type arguments
    /* Treat the integer as a sequence of bits */
 }
 

--- a/src/test/compile-fail/structure-constructor-type-mismatch.rs
+++ b/src/test/compile-fail/structure-constructor-type-mismatch.rs
@@ -57,6 +57,7 @@ fn main() {
 
     let pt3 = PointF::<i32> {
         //~^ ERROR wrong number of type arguments
+        //~| ERROR structure constructor specifies a structure of type
         x: 9i32,
         y: 10i32,
     };

--- a/src/test/compile-fail/trait-bounds-cant-coerce.rs
+++ b/src/test/compile-fail/trait-bounds-cant-coerce.rs
@@ -22,7 +22,7 @@ fn c(x: Box<Foo+Sync+Send>) {
 fn d(x: Box<Foo>) {
     a(x); //~  ERROR mismatched types
           //~| expected `Box<Foo + Send>`
-          //~| found `Box<Foo>`
+          //~| found `Box<Foo + 'static>`
           //~| expected bounds `Send`
           //~| found no bounds
 }

--- a/src/test/compile-fail/unboxed-closure-sugar-wrong-number-number-type-parameters-3.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-wrong-number-number-type-parameters-3.rs
@@ -12,7 +12,9 @@
 
 trait Three<A,B,C> { fn dummy(&self) -> (A,B,C); }
 
-fn foo(_: &Three()) //~ ERROR wrong number of type arguments
+fn foo(_: &Three())
+//~^ ERROR wrong number of type arguments
+//~| ERROR no associated type `Output`
 {}
 
 fn main() { }

--- a/src/test/compile-fail/unboxed-closure-sugar-wrong-number-number-type-parameters.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-wrong-number-number-type-parameters.rs
@@ -12,7 +12,9 @@
 
 trait Zero { fn dummy(&self); }
 
-fn foo(_: Zero()) //~ ERROR wrong number of type arguments
+fn foo(_: Zero())
+    //~^ ERROR wrong number of type arguments
+    //~| ERROR no associated type `Output` defined in `Zero`
 {}
 
 fn main() { }

--- a/src/test/compile-fail/unboxed-closure-sugar-wrong-trait.rs
+++ b/src/test/compile-fail/unboxed-closure-sugar-wrong-trait.rs
@@ -14,6 +14,7 @@ trait Trait {}
 
 fn f<F:Trait(isize) -> isize>(x: F) {}
 //~^ ERROR wrong number of type arguments: expected 0, found 1
+//~| ERROR no associated type `Output`
 
 fn main() {}
 

--- a/src/test/run-pass/object-lifetime-default-default-to-static.rs
+++ b/src/test/run-pass/object-lifetime-default-default-to-static.rs
@@ -1,0 +1,42 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that `Box<Test>` is equivalent to `Box<Test+'static>`, both in
+// fields and fn arguments.
+
+#![allow(dead_code)]
+
+trait Test {
+    fn foo(&self) { }
+}
+
+struct SomeStruct {
+    t: Box<Test>,
+    u: Box<Test+'static>,
+}
+
+fn a(t: Box<Test>, mut ss: SomeStruct) {
+    ss.t = t;
+}
+
+fn b(t: Box<Test+'static>, mut ss: SomeStruct) {
+    ss.t = t;
+}
+
+fn c(t: Box<Test>, mut ss: SomeStruct) {
+    ss.u = t;
+}
+
+fn d(t: Box<Test+'static>, mut ss: SomeStruct) {
+    ss.u = t;
+}
+
+fn main() {
+}

--- a/src/test/run-pass/object-lifetime-default-from-ref-struct.rs
+++ b/src/test/run-pass/object-lifetime-default-from-ref-struct.rs
@@ -1,0 +1,47 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that the lifetime of the enclosing `&` is used for the object
+// lifetime bound.
+
+#![allow(dead_code)]
+
+trait Test {
+    fn foo(&self) { }
+}
+
+struct Ref<'a,T:'a+?Sized> {
+    r: &'a T
+}
+
+struct SomeStruct<'a> {
+    t: Ref<'a,Test>,
+    u: Ref<'a,Test+'a>,
+}
+
+fn a<'a>(t: Ref<'a,Test>, mut ss: SomeStruct<'a>) {
+    ss.t = t;
+}
+
+fn b<'a>(t: Ref<'a,Test>, mut ss: SomeStruct<'a>) {
+    ss.u = t;
+}
+
+fn c<'a>(t: Ref<'a,Test+'a>, mut ss: SomeStruct<'a>) {
+    ss.t = t;
+}
+
+fn d<'a>(t: Ref<'a,Test+'a>, mut ss: SomeStruct<'a>) {
+    ss.u = t;
+}
+
+
+fn main() {
+}

--- a/src/test/run-pass/object-lifetime-default-from-rptr-box.rs
+++ b/src/test/run-pass/object-lifetime-default-from-rptr-box.rs
@@ -1,0 +1,42 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that the lifetime from the enclosing `&` is "inherited"
+// through the `Box` struct.
+
+#![allow(dead_code)]
+
+trait Test {
+    fn foo(&self) { }
+}
+
+struct SomeStruct<'a> {
+    t: &'a Box<Test>,
+    u: &'a Box<Test+'a>,
+}
+
+fn a<'a>(t: &'a Box<Test>, mut ss: SomeStruct<'a>) {
+    ss.t = t;
+}
+
+fn b<'a>(t: &'a Box<Test>, mut ss: SomeStruct<'a>) {
+    ss.u = t;
+}
+
+fn c<'a>(t: &'a Box<Test+'a>, mut ss: SomeStruct<'a>) {
+    ss.t = t;
+}
+
+fn d<'a>(t: &'a Box<Test+'a>, mut ss: SomeStruct<'a>) {
+    ss.u = t;
+}
+
+fn main() {
+}

--- a/src/test/run-pass/object-lifetime-default-from-rptr-mut.rs
+++ b/src/test/run-pass/object-lifetime-default-from-rptr-mut.rs
@@ -1,0 +1,43 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that the lifetime of the enclosing `&` is used for the object
+// lifetime bound.
+
+#![allow(dead_code)]
+
+trait Test {
+    fn foo(&self) { }
+}
+
+struct SomeStruct<'a> {
+    t: &'a mut Test,
+    u: &'a mut (Test+'a),
+}
+
+fn a<'a>(t: &'a mut Test, mut ss: SomeStruct<'a>) {
+    ss.t = t;
+}
+
+fn b<'a>(t: &'a mut Test, mut ss: SomeStruct<'a>) {
+    ss.u = t;
+}
+
+fn c<'a>(t: &'a mut (Test+'a), mut ss: SomeStruct<'a>) {
+    ss.t = t;
+}
+
+fn d<'a>(t: &'a mut (Test+'a), mut ss: SomeStruct<'a>) {
+    ss.u = t;
+}
+
+
+fn main() {
+}

--- a/src/test/run-pass/object-lifetime-default-from-rptr-struct.rs
+++ b/src/test/run-pass/object-lifetime-default-from-rptr-struct.rs
@@ -1,0 +1,46 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that the lifetime from the enclosing `&` is "inherited"
+// through the `MyBox` struct.
+
+#![allow(dead_code)]
+
+trait Test {
+    fn foo(&self) { }
+}
+
+struct SomeStruct<'a> {
+    t: &'a MyBox<Test>,
+    u: &'a MyBox<Test+'a>,
+}
+
+struct MyBox<T:?Sized> {
+    b: Box<T>
+}
+
+fn a<'a>(t: &'a MyBox<Test>, mut ss: SomeStruct<'a>) {
+    ss.t = t;
+}
+
+fn b<'a>(t: &'a MyBox<Test>, mut ss: SomeStruct<'a>) {
+    ss.u = t;
+}
+
+fn c<'a>(t: &'a MyBox<Test+'a>, mut ss: SomeStruct<'a>) {
+    ss.t = t;
+}
+
+fn d<'a>(t: &'a MyBox<Test+'a>, mut ss: SomeStruct<'a>) {
+    ss.u = t;
+}
+
+fn main() {
+}

--- a/src/test/run-pass/object-lifetime-default-from-rptr.rs
+++ b/src/test/run-pass/object-lifetime-default-from-rptr.rs
@@ -1,0 +1,43 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that the lifetime of the enclosing `&` is used for the object
+// lifetime bound.
+
+#![allow(dead_code)]
+
+trait Test {
+    fn foo(&self) { }
+}
+
+struct SomeStruct<'a> {
+    t: &'a Test,
+    u: &'a (Test+'a),
+}
+
+fn a<'a>(t: &'a Test, mut ss: SomeStruct<'a>) {
+    ss.t = t;
+}
+
+fn b<'a>(t: &'a Test, mut ss: SomeStruct<'a>) {
+    ss.u = t;
+}
+
+fn c<'a>(t: &'a (Test+'a), mut ss: SomeStruct<'a>) {
+    ss.t = t;
+}
+
+fn d<'a>(t: &'a (Test+'a), mut ss: SomeStruct<'a>) {
+    ss.u = t;
+}
+
+
+fn main() {
+}


### PR DESCRIPTION
Implement rules described in rust-lang/rfcs#599.

Fixes https://github.com/rust-lang/rust/issues/22211.

~~Based atop PR https://github.com/rust-lang/rust/pull/22182, so the first few commits (up to and including "Pacify the mercilous nrc") have already been reviewed.~~
