### PR TITLE
find macro-feature occurrences within macro args

### DIFF
--- a/src/test/compile-fail/issue-22234.rs
+++ b/src/test/compile-fail/issue-22234.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that macro-invocations within macro-invocations still cause
+// feature-gate checks to fire.
+
+fn main() {
+    unsafe {
+        print!("Hello {:?}", asm!("")); //~ ERROR inline assembly is not stable
+    }
+}


### PR DESCRIPTION
In feature_gate::MacroVisitor, find feature occurrences within macro arguments.

Fix #22234
