### PR TITLE
Remove `_VALUE` from the float extremes constants.

### DIFF
--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -35,13 +35,26 @@ pub const EPSILON: f32 = 1.19209290e-07_f32;
 
 /// Smallest finite f32 value
 #[stable(feature = "rust1", since = "1.0.0")]
+#[deprecated(since = "1.0.0", reason = "use `std::f32::MIN`")]
 pub const MIN_VALUE: f32 = -3.40282347e+38_f32;
 /// Smallest positive, normalized f32 value
 #[stable(feature = "rust1", since = "1.0.0")]
+#[deprecated(since = "1.0.0", reason = "use `std::f32::MIN_POSITIVE`")]
 pub const MIN_POS_VALUE: f32 = 1.17549435e-38_f32;
 /// Largest finite f32 value
 #[stable(feature = "rust1", since = "1.0.0")]
+#[deprecated(since = "1.0.0", reason = "use `std::f32::MAX`")]
 pub const MAX_VALUE: f32 = 3.40282347e+38_f32;
+
+/// Smallest finite f32 value
+#[stable(feature = "rust1", since = "1.0.0")]
+pub const MIN: f32 = -3.40282347e+38_f32;
+/// Smallest positive, normalized f32 value
+#[stable(feature = "rust1", since = "1.0.0")]
+pub const MIN_POSITIVE: f32 = 1.17549435e-38_f32;
+/// Largest finite f32 value
+#[stable(feature = "rust1", since = "1.0.0")]
+pub const MAX: f32 = 3.40282347e+38_f32;
 
 #[unstable(feature = "core", reason = "pending integer conventions")]
 pub const MIN_EXP: int = -125;
@@ -215,17 +228,17 @@ impl Float for f32 {
     #[inline]
     #[unstable(feature = "core")]
     #[deprecated(since = "1.0.0")]
-    fn min_value() -> f32 { MIN_VALUE }
+    fn min_value() -> f32 { MIN }
 
     #[inline]
     #[unstable(feature = "core")]
     #[deprecated(since = "1.0.0")]
-    fn min_pos_value(_: Option<f32>) -> f32 { MIN_POS_VALUE }
+    fn min_pos_value(_: Option<f32>) -> f32 { MIN_POSITIVE }
 
     #[inline]
     #[unstable(feature = "core")]
     #[deprecated(since = "1.0.0")]
-    fn max_value() -> f32 { MAX_VALUE }
+    fn max_value() -> f32 { MAX }
 
     /// Returns the mantissa, exponent and sign as integers.
     fn integer_decode(self) -> (u64, i16, i8) {

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -38,13 +38,26 @@ pub const EPSILON: f64 = 2.2204460492503131e-16_f64;
 
 /// Smallest finite f64 value
 #[stable(feature = "rust1", since = "1.0.0")]
+#[deprecated(since = "1.0.0", reason = "use `std::f64::MIN`")]
 pub const MIN_VALUE: f64 = -1.7976931348623157e+308_f64;
 /// Smallest positive, normalized f64 value
 #[stable(feature = "rust1", since = "1.0.0")]
+#[deprecated(since = "1.0.0", reason = "use `std::f64::MIN_POSITIVE`")]
 pub const MIN_POS_VALUE: f64 = 2.2250738585072014e-308_f64;
 /// Largest finite f64 value
 #[stable(feature = "rust1", since = "1.0.0")]
+#[deprecated(since = "1.0.0", reason = "use `std::f64::MAX`")]
 pub const MAX_VALUE: f64 = 1.7976931348623157e+308_f64;
+
+/// Smallest finite f64 value
+#[stable(feature = "rust1", since = "1.0.0")]
+pub const MIN: f64 = -1.7976931348623157e+308_f64;
+/// Smallest positive, normalized f64 value
+#[stable(feature = "rust1", since = "1.0.0")]
+pub const MIN_POSITIVE: f64 = 2.2250738585072014e-308_f64;
+/// Largest finite f64 value
+#[stable(feature = "rust1", since = "1.0.0")]
+pub const MAX: f64 = 1.7976931348623157e+308_f64;
 
 #[unstable(feature = "core", reason = "pending integer conventions")]
 pub const MIN_EXP: int = -1021;
@@ -222,17 +235,17 @@ impl Float for f64 {
     #[inline]
     #[unstable(feature = "core")]
     #[deprecated(since = "1.0.0")]
-    fn min_value() -> f64 { MIN_VALUE }
+    fn min_value() -> f64 { MIN }
 
     #[inline]
     #[unstable(feature = "core")]
     #[deprecated(since = "1.0.0")]
-    fn min_pos_value(_: Option<f64>) -> f64 { MIN_POS_VALUE }
+    fn min_pos_value(_: Option<f64>) -> f64 { MIN_POSITIVE }
 
     #[inline]
     #[unstable(feature = "core")]
     #[deprecated(since = "1.0.0")]
-    fn max_value() -> f64 { MAX_VALUE }
+    fn max_value() -> f64 { MAX }
 
     /// Returns the mantissa, exponent and sign as integers.
     fn integer_decode(self) -> (u64, i16, i8) {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -956,7 +956,7 @@ macro_rules! impl_to_primitive_float_to_float {
             Some($slf as $DstT)
         } else {
             let n = $slf as f64;
-            let max_value: $SrcT = ::$SrcT::MAX_VALUE;
+            let max_value: $SrcT = ::$SrcT::MAX;
             if -max_value as f64 <= n && n <= max_value as f64 {
                 Some($slf as $DstT)
             } else {
@@ -1331,18 +1331,18 @@ pub trait Float
     /// Returns the smallest finite value that this type can represent.
     #[unstable(feature = "core")]
     #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::MIN_VALUE` or `std::f64::MIN_VALUE` as appropriate")]
+                 reason = "use `std::f32::MIN` or `std::f64::MIN` as appropriate")]
     fn min_value() -> Self;
     /// Returns the smallest normalized positive number that this type can represent.
     #[unstable(feature = "core")]
     #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::MIN_POS_VALUE` or \
-                           `std::f64::MIN_POS_VALUE` as appropriate")]
+                 reason = "use `std::f32::MIN_POSITIVE` or \
+                           `std::f64::MIN_POSITIVE` as appropriate")]
     fn min_pos_value(unused_self: Option<Self>) -> Self;
     /// Returns the largest finite value that this type can represent.
     #[unstable(feature = "core")]
     #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::MAX_VALUE` or `std::f64::MAX_VALUE` as appropriate")]
+                 reason = "use `std::f32::MAX` or `std::f64::MAX` as appropriate")]
     fn max_value() -> Self;
 
     /// Returns true if this value is NaN and false otherwise.

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -318,8 +318,8 @@ impl LintPass for TypeLimits {
 
         fn float_ty_range(float_ty: ast::FloatTy) -> (f64, f64) {
             match float_ty {
-                ast::TyF32  => (f32::MIN_VALUE as f64, f32::MAX_VALUE as f64),
-                ast::TyF64  => (f64::MIN_VALUE,        f64::MAX_VALUE)
+                ast::TyF32  => (f32::MIN as f64, f32::MAX as f64),
+                ast::TyF64  => (f64::MIN,        f64::MAX)
             }
         }
 

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -30,6 +30,7 @@ use core::num;
 pub use core::f32::{RADIX, MANTISSA_DIGITS, DIGITS, EPSILON, MIN_VALUE};
 pub use core::f32::{MIN_POS_VALUE, MAX_VALUE, MIN_EXP, MAX_EXP, MIN_10_EXP};
 pub use core::f32::{MAX_10_EXP, NAN, INFINITY, NEG_INFINITY};
+pub use core::f32::{MIN, MIN_POSITIVE, MAX};
 pub use core::f32::consts;
 
 #[allow(dead_code)]

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -29,6 +29,7 @@ use core::num;
 pub use core::f64::{RADIX, MANTISSA_DIGITS, DIGITS, EPSILON, MIN_VALUE};
 pub use core::f64::{MIN_POS_VALUE, MAX_VALUE, MIN_EXP, MAX_EXP, MIN_10_EXP};
 pub use core::f64::{MAX_10_EXP, NAN, INFINITY, NEG_INFINITY};
+pub use core::f64::{MIN, MIN_POSITIVE, MAX};
 pub use core::f64::consts;
 
 #[allow(dead_code)]


### PR DESCRIPTION
In `std::f32` and `std::f64`:
- `MIN_VALUE` → `MIN`
- `MAX_VALUE` → `MAX`
- `MIN_POS_VALUE` → `MIN_POSITIVE`

This matches the corresponding integer constants.

[breaking-change]
