### PR TITLE
Installer updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,10 @@ documentation.
 
 ## Quick Start
 
-1. Download a [binary installer][installer] for your platform.
-2. Read [The Rust Programming Language][trpl].
-3. Enjoy!
+Read ["Installing Rust"][install] from [The Book][trpl].
 
-> ***Note:*** Windows users can read the detailed
-> [using Rust on Windows][win-wiki] notes on the wiki.
-
-[installer]: http://www.rust-lang.org/install.html
+[install]: http://doc.rust-lang.org/book/installing-rust.html
 [trpl]: http://doc.rust-lang.org/book/index.html
-[win-wiki]: https://github.com/rust-lang/rust/wiki/Using-Rust-on-Windows
 
 ## Building from Source
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ Read ["Installing Rust"][install] from [The Book][trpl].
     When complete, `make install` will place several programs into
     `/usr/local/bin`: `rustc`, the Rust compiler, and `rustdoc`, the
     API-documentation tool.
-3. Read [The Rust Programming Language][trpl].
-4. Enjoy!
 
 ### Building on Windows
 
@@ -75,7 +73,6 @@ $ pacman -S base-devel
 
 [repo]: https://github.com/rust-lang/rust
 [tarball]: https://static.rust-lang.org/dist/rustc-nightly-src.tar.gz
-[trpl]: http://doc.rust-lang.org/book/index.html
 
 ## Notes
 

--- a/src/doc/trpl/installing-rust.md
+++ b/src/doc/trpl/installing-rust.md
@@ -24,11 +24,11 @@ installer](https://static.rust-lang.org/dist/rust-nightly-x86_64-pc-windows-gnu.
 and run it.
 
 If you decide you don't want Rust anymore, we'll be a bit sad, but that's okay.
-Not every programming language is great for everyone. Just pass an argument to
-the script:
+Not every programming language is great for everyone. Just run the uninstall
+script:
 
 ```bash
-$ curl -s https://static.rust-lang.org/rustup.sh | sudo sh -s -- --uninstall
+$ sudo /usr/local/lib/rustlib/uninstall.sh
 ```
 
 If you used the Windows installer, just re-run the `.exe` and it will give you


### PR DESCRIPTION
Highlights:
- Adds an 'uninstall.sh' script to `/usr/local/lib/rustlib/uninstall.sh`, the path to which is printed during installation.
- Components can be deselected during install, like `install.sh --without=rust-docs`.
- Components can be listed with `install.sh --list-components`.
- Vastly reduces spew during install (but supporting a `--verbose` option).

Typicall install run looks like:

```
brian@brianX1:~/dev/multirust⟫ sudo ./install.sh 
[sudo] password for brian:
install: creating uninstall script at /usr/local/lib/rustlib/uninstall.sh
install: installing component 'rustc'
install: installing component 'cargo'
install: installing component 'rust-docs'

    Rust is ready to roll.
```

Needs to be merged right before corresponding PRs to cargo and rust-packaging.

Fixes https://github.com/rust-lang/rust/issues/21117
Fixes https://github.com/rust-lang/rust/issues/20283
