### PR TITLE
Rename the "unsafe" lang item to "unsafe_cell"

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -649,7 +649,8 @@ impl<'b, T> DerefMut for RefMut<'b, T> {
 ///
 /// **NOTE:** `UnsafeCell<T>`'s fields are public to allow static initializers. It is not
 /// recommended to access its fields directly, `get` should be used instead.
-#[lang="unsafe"]
+#[cfg_attr(stage0, lang="unsafe")]  // NOTE: remove after next snapshot
+#[cfg_attr(not(stage0), lang="unsafe_cell")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct UnsafeCell<T> {
     /// Wrapped value

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -271,7 +271,7 @@ lets_do_this! {
     RangeToStructLangItem,           "range_to",                range_to_struct;
     RangeFullStructLangItem,         "range_full",              range_full_struct;
 
-    UnsafeTypeLangItem,              "unsafe",                  unsafe_type;
+    UnsafeCellTypeLangItem,          "unsafe_cell",             unsafe_cell_type;
 
     DerefTraitLangItem,              "deref",                   deref_trait;
     DerefMutTraitLangItem,           "deref_mut",               deref_mut_trait;

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1654,7 +1654,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 ty::BoundSync => {
                     if
                         Some(def_id) == tcx.lang_items.managed_bound() ||
-                        Some(def_id) == tcx.lang_items.unsafe_type()
+                        Some(def_id) == tcx.lang_items.unsafe_cell_type()
                     {
                         return Err(Unimplemented)
                     }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3577,7 +3577,7 @@ pub fn type_contents<'tcx>(cx: &ctxt<'tcx>, ty: Ty<'tcx>) -> TypeContents {
                         -> TypeContents {
         if Some(did) == cx.lang_items.managed_bound() {
             tc | TC::Managed
-        } else if Some(did) == cx.lang_items.unsafe_type() {
+        } else if Some(did) == cx.lang_items.unsafe_cell_type() {
             tc | TC::InteriorUnsafe
         } else {
             tc

--- a/src/librustc_typeck/variance.rs
+++ b/src/librustc_typeck/variance.rs
@@ -453,7 +453,7 @@ fn add_constraints_from_crate<'a, 'tcx>(terms_cx: TermsContext<'a, 'tcx>,
     invariant_lang_items[RegionParam as uint] =
         terms_cx.tcx.lang_items.invariant_lifetime();
 
-    let unsafe_lang_item = terms_cx.tcx.lang_items.unsafe_type();
+    let unsafe_lang_item = terms_cx.tcx.lang_items.unsafe_cell_type();
 
     let covariant = terms_cx.arena.alloc(ConstantTerm(ty::Covariant));
     let contravariant = terms_cx.arena.alloc(ConstantTerm(ty::Contravariant));

--- a/src/librustc_typeck/variance.rs
+++ b/src/librustc_typeck/variance.rs
@@ -412,7 +412,7 @@ struct ConstraintContext<'a, 'tcx: 'a> {
     invariant_lang_items: [Option<ast::DefId>; 2],
     covariant_lang_items: [Option<ast::DefId>; 2],
     contravariant_lang_items: [Option<ast::DefId>; 2],
-    unsafe_lang_item: Option<ast::DefId>,
+    unsafe_cell_lang_item: Option<ast::DefId>,
 
     // These are pointers to common `ConstantTerm` instances
     covariant: VarianceTermPtr<'a>,
@@ -453,7 +453,7 @@ fn add_constraints_from_crate<'a, 'tcx>(terms_cx: TermsContext<'a, 'tcx>,
     invariant_lang_items[RegionParam as uint] =
         terms_cx.tcx.lang_items.invariant_lifetime();
 
-    let unsafe_lang_item = terms_cx.tcx.lang_items.unsafe_cell_type();
+    let unsafe_cell_lang_item = terms_cx.tcx.lang_items.unsafe_cell_type();
 
     let covariant = terms_cx.arena.alloc(ConstantTerm(ty::Covariant));
     let contravariant = terms_cx.arena.alloc(ConstantTerm(ty::Contravariant));
@@ -465,7 +465,7 @@ fn add_constraints_from_crate<'a, 'tcx>(terms_cx: TermsContext<'a, 'tcx>,
         invariant_lang_items: invariant_lang_items,
         covariant_lang_items: covariant_lang_items,
         contravariant_lang_items: contravariant_lang_items,
-        unsafe_lang_item: unsafe_lang_item,
+        unsafe_cell_lang_item: unsafe_cell_lang_item,
 
         covariant: covariant,
         contravariant: contravariant,
@@ -654,7 +654,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
             self.covariant
         } else if self.contravariant_lang_items[kind as uint] == Some(item_def_id) {
             self.contravariant
-        } else if kind == TypeParam && Some(item_def_id) == self.unsafe_lang_item {
+        } else if kind == TypeParam && Some(item_def_id) == self.unsafe_cell_lang_item {
             self.invariant
         } else if param_def_id.krate == ast::LOCAL_CRATE {
             // Parameter on an item defined within current crate:


### PR DESCRIPTION
`Unsafe` was renamed to `UnsafeCell` a while ago, but the corresponding lang item kept the old name. This patch fixes the inconsistency.

r? @eddyb
