### PR TITLE
Remove link to mailing list in bug report submission page

### DIFF
--- a/src/doc/complement-bugreport.md
+++ b/src/doc/complement-bugreport.md
@@ -56,8 +56,6 @@ $ RUST_BACKTRACE=1 rustc ...
 
 # I submitted a bug, but nobody has commented on it!
 
-This is sad, but does happen sometimes, since we're short-staffed. If you
-submit a bug and you haven't received a comment on it within 3 business days,
-it's entirely reasonable to either ask on the #rust IRC channel,
-or post on the [rust-dev mailing list](https://mail.mozilla.org/listinfo/rust-dev)
-to ask what the status of the bug is.
+This is sad, but does happen sometimes, since we're short-staffed. If you submit a
+bug and you haven't received a comment on it within 3 business days, it's entirely
+reasonable to ask about the status of the bug in #rust on irc.mozilla.org.


### PR DESCRIPTION
Removes the link to the rust-dev mailing list in the bug report submission page and also adds the address of the IRC server (`irc.mozilla.org`). Addresses #22249.
