### PR TITLE
Make if after colon lowercase

### DIFF
--- a/src/doc/trpl/more-strings.md
+++ b/src/doc/trpl/more-strings.md
@@ -91,7 +91,7 @@ and only moving to this:
 fn foo(s: String) {
 ```
 
-If you have good reason. It's not polite to hold on to ownership you don't
+if you have good reason. It's not polite to hold on to ownership you don't
 need, and it can make your lifetimes more complex.
 
 ## Generic functions


### PR DESCRIPTION
While having a look at the Rust book I found this tiny error. In my opinion this if should be all lowercase, because it follows a colon, but I am no native speaker, so I am probably wrong. Also it is a very tiny change, so feel free to include it in any bigger documentation patch.
