### PR TITLE
Count and show the deprecated attribute again

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2490,6 +2490,7 @@ pub struct Stability {
     pub level: attr::StabilityLevel,
     pub feature: String,
     pub since: String,
+    pub deprecated_since: String,
     pub reason: String
 }
 
@@ -2500,6 +2501,8 @@ impl Clean<Stability> for attr::Stability {
             feature: self.feature.to_string(),
             since: self.since.as_ref().map_or("".to_string(),
                                               |interned| interned.to_string()),
+            deprecated_since: self.deprecated_since.as_ref().map_or("".to_string(),
+                                                                    |istr| istr.to_string()),
             reason: self.reason.as_ref().map_or("".to_string(),
                                                 |interned| interned.to_string()),
         }


### PR DESCRIPTION
Since we don’t have Deprecated stability level anymore, the only other source of information is
deprecated-since version, which conveniently to us, only exists if the symbol is deprecated.

Fixes #21789
