### PR TITLE
Re-tag `slicing_syntax` as `Accepted`.

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -79,7 +79,7 @@ static KNOWN_FEATURES: &'static [(&'static str, &'static str, Status)] = &[
     ("tuple_indexing", "1.0.0", Accepted),
     ("associated_types", "1.0.0", Accepted),
     ("visible_private_types", "1.0.0", Active),
-    ("slicing_syntax", "1.0.0", Active),
+    ("slicing_syntax", "1.0.0", Accepted),
     ("box_syntax", "1.0.0", Active),
     ("on_unimplemented", "1.0.0", Active),
     ("simd_ffi", "1.0.0", Active),


### PR DESCRIPTION
Re-tag `slicing_syntax` as `Accepted`.

Rollup merge (373cbab5b08d6630da58f28d2166c19afc327fa6) of PR #20723
accidentally reverted a portion of commit
8327bcc167661c26ca5c6b967309ff745d302329 which shifted
`slicing_syntax` from Active to Accepted.
