### PR TITLE
Add `#[rustc_error]` annotation, which causes trans to signal an error

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -674,6 +674,7 @@ impl LintPass for UnusedAttributes {
             "stable",
             "unstable",
             "rustc_on_unimplemented",
+            "rustc_error",
 
             // FIXME: #19470 this shouldn't be needed forever
             "old_orphan_check",

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2425,6 +2425,14 @@ fn finish_register_fn(ccx: &CrateContext, sp: Span, sym: String, node_id: ast::N
 
 
     if is_entry_fn(ccx.sess(), node_id) {
+        // check for the #[rustc_error] annotation, which forces an
+        // error in trans. This is used to write compile-fail tests
+        // that actually test that compilation succeeds without
+        // reporting an error.
+        if ty::has_attr(ccx.tcx(), local_def(node_id), "rustc_error") {
+            ccx.tcx().sess.span_fatal(sp, "compilation successful");
+        }
+
         create_entry_wrapper(ccx, sp, llfn);
     }
 }

--- a/src/test/compile-fail/rustc-error.rs
+++ b/src/test/compile-fail/rustc-error.rs
@@ -1,0 +1,14 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[rustc_error]
+fn main() {
+    //~^ ERROR compilation successful
+}


### PR DESCRIPTION
Add `#[rustc_error]` annotation, which causes trans to signal an error
if found on the `main()` function. This lets you write tests that live
in `compile-fail` but are expected to compile successfully. This is
handy when you have many small variations on a theme that you want to
keep together, and you are just testing the type checker, not the
runtime semantics.

r? @pnkfelix 
