### PR TITLE
Forbid `pub mymacro!();`

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4621,6 +4621,17 @@ impl<'a> Parser<'a> {
         self.parse_method(attrs, visa)
     }
 
+    fn complain_if_pub_macro(&mut self, visa: Visibility, span: Span) {
+        match visa {
+            Public => {
+                self.span_err(span, "can't qualify macro invocation with `pub`");
+                self.span_help(span, "try adjusting the macro to put `pub` inside \
+                                      the invocation");
+            }
+            Inherited => (),
+        }
+    }
+
     /// Parse a method in a trait impl, starting with `attrs` attributes.
     pub fn parse_method(&mut self,
                         attrs: Vec<Attribute>,
@@ -4635,6 +4646,10 @@ impl<'a> Parser<'a> {
                 && (self.look_ahead(2, |t| *t == token::OpenDelim(token::Paren))
                     || self.look_ahead(2, |t| *t == token::OpenDelim(token::Brace))) {
                 // method macro.
+
+                let last_span = self.last_span;
+                self.complain_if_pub_macro(visa, last_span);
+
                 let pth = self.parse_path(NoTypesAllowed);
                 self.expect(&token::Not);
 
@@ -5837,6 +5852,9 @@ impl<'a> Parser<'a> {
                     || self.look_ahead(2, |t| *t == token::OpenDelim(token::Paren))
                     || self.look_ahead(2, |t| *t == token::OpenDelim(token::Brace))) {
             // MACRO INVOCATION ITEM
+
+            let last_span = self.last_span;
+            self.complain_if_pub_macro(visibility, last_span);
 
             // item macro.
             let pth = self.parse_path(NoTypesAllowed);

--- a/src/test/compile-fail/pub-item-macro.rs
+++ b/src/test/compile-fail/pub-item-macro.rs
@@ -1,0 +1,28 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #14660
+
+macro_rules! priv_x { () => {
+    static x: u32 = 0;
+}}
+
+macro_rules! pub_x { () => {
+    pub priv_x!(); //~ ERROR can't qualify macro invocation with `pub`
+    //~^ HELP try adjusting the macro to put `pub` inside the invocation
+}}
+
+mod foo {
+    pub_x!();
+}
+
+fn main() {
+    let y: u32 = foo::x;
+}

--- a/src/test/compile-fail/pub-method-macro.rs
+++ b/src/test/compile-fail/pub-method-macro.rs
@@ -1,0 +1,34 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #18317
+
+mod bleh {
+    macro_rules! defn {
+        ($n:ident) => (
+            fn $n (&self) -> i32 {
+                println!("{}", stringify!($n));
+                1
+            }
+        )
+    }
+
+    #[derive(Copy)]
+    pub struct S;
+
+    impl S {
+        pub defn!(f); //~ ERROR can't qualify macro invocation with `pub`
+        //~^ HELP try adjusting the macro to put `pub` inside the invocation
+    }
+}
+
+fn main() {
+    bleh::S.f();
+}

--- a/src/test/run-pass/pub-item-inside-macro.rs
+++ b/src/test/run-pass/pub-item-inside-macro.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #14660
+
+mod bleh {
+    macro_rules! foo {
+        () => {
+            pub fn bar() { }
+        }
+    }
+
+    foo!();
+}
+
+fn main() {
+    bleh::bar();
+}


### PR DESCRIPTION
It's not clear what this means, because a macro in item position can expand to zero or more items.  For now we disallow it, which is technically a

```
[breaking-change]
```

but is landing without an RFC.  The `pub` keyword previously had no effect, which seems quite unintended.

Fixes #18317.
Fixes #14660.
