### PR TITLE
Replace os::getenv with env::var{,_os}

### DIFF
--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -384,8 +384,7 @@ impl Target {
             Path::new(target)
         };
 
-        let target_path = env::var_os("RUST_TARGET_PATH")
-                              .unwrap_or(OsString::from_str(""));
+        let target_path = env::var_os("RUST_TARGET_PATH").unwrap_or(OsString::from_str(""));
 
         // FIXME 16351: add a sane default search path?
 

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -1024,14 +1024,14 @@ impl fmt::Display for TryRecvError {
 mod test {
     use prelude::v1::*;
 
-    use os;
+    use std::env;
     use super::*;
     use thread::Thread;
 
     pub fn stress_factor() -> uint {
-        match os::getenv("RUST_TEST_STRESS") {
-            Some(val) => val.parse().unwrap(),
-            None => 1,
+        match env::var("RUST_TEST_STRESS") {
+            Ok(val) => val.parse().unwrap(),
+            Err(..) => 1,
         }
     }
 
@@ -1546,14 +1546,14 @@ mod test {
 mod sync_tests {
     use prelude::v1::*;
 
-    use os;
+    use std::env;
     use thread::Thread;
     use super::*;
 
     pub fn stress_factor() -> uint {
-        match os::getenv("RUST_TEST_STRESS") {
-            Some(val) => val.parse().unwrap(),
-            None => 1,
+        match env::var("RUST_TEST_STRESS") {
+            Ok(val) => val.parse().unwrap(),
+            Err(..) => 1,
         }
     }
 

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -17,6 +17,7 @@ use std::old_io::File;
 use std::iter::repeat;
 use std::mem::swap;
 use std::os;
+use std::env;
 use std::rand::Rng;
 use std::rand;
 use std::str;
@@ -46,7 +47,7 @@ fn main() {
 fn maybe_run_test<F>(argv: &[String], name: String, test: F) where F: FnOnce() {
     let mut run_test = false;
 
-    if os::getenv("RUST_BENCH").is_some() {
+    if env::var_os("RUST_BENCH").is_some() {
         run_test = true
     } else if argv.len() > 0 {
         run_test = argv.iter().any(|x| x == &"all".to_string()) || argv.iter().any(|x| x == &name)

--- a/src/test/bench/core-uint-to-str.rs
+++ b/src/test/bench/core-uint-to-str.rs
@@ -9,10 +9,11 @@
 // except according to those terms.
 
 use std::os;
+use std::env;
 
 fn main() {
     let args = os::args();
-    let args = if os::getenv("RUST_BENCH").is_some() {
+    let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "10000000".to_string())
     } else if args.len() <= 1u {
         vec!("".to_string(), "100000".to_string())

--- a/src/test/bench/msgsend-pipes-shared.rs
+++ b/src/test/bench/msgsend-pipes-shared.rs
@@ -20,6 +20,7 @@
 
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::os;
+use std::env;
 use std::thread::Thread;
 use std::time::Duration;
 
@@ -94,7 +95,7 @@ fn run(args: &[String]) {
 
 fn main() {
     let args = os::args();
-    let args = if os::getenv("RUST_BENCH").is_some() {
+    let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "1000000".to_string(), "10000".to_string())
     } else if args.len() <= 1u {
         vec!("".to_string(), "10000".to_string(), "4".to_string())

--- a/src/test/bench/msgsend-pipes.rs
+++ b/src/test/bench/msgsend-pipes.rs
@@ -16,6 +16,7 @@
 
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::os;
+use std::env;
 use std::thread::Thread;
 use std::time::Duration;
 
@@ -101,7 +102,7 @@ fn run(args: &[String]) {
 
 fn main() {
     let args = os::args();
-    let args = if os::getenv("RUST_BENCH").is_some() {
+    let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "1000000".to_string(), "8".to_string())
     } else if args.len() <= 1u {
         vec!("".to_string(), "10000".to_string(), "4".to_string())

--- a/src/test/bench/msgsend-ring-mutex-arcs.rs
+++ b/src/test/bench/msgsend-ring-mutex-arcs.rs
@@ -19,6 +19,7 @@
 // ignore-lexer-test FIXME #15679
 
 use std::os;
+use std::env;
 use std::sync::{Arc, Future, Mutex, Condvar};
 use std::time::Duration;
 
@@ -64,7 +65,7 @@ fn thread_ring(i: uint, count: uint, num_chan: pipe, num_port: pipe) {
 
 fn main() {
     let args = os::args();
-    let args = if os::getenv("RUST_BENCH").is_some() {
+    let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "100".to_string(), "10000".to_string())
     } else if args.len() <= 1u {
         vec!("".to_string(), "10".to_string(), "100".to_string())

--- a/src/test/bench/shootout-ackermann.rs
+++ b/src/test/bench/shootout-ackermann.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use std::os;
+use std::env;
 
 fn ack(m: int, n: int) -> int {
     if m == 0 {
@@ -24,7 +25,7 @@ fn ack(m: int, n: int) -> int {
 
 fn main() {
     let args = os::args();
-    let args = if os::getenv("RUST_BENCH").is_some() {
+    let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "12".to_string())
     } else if args.len() <= 1u {
         vec!("".to_string(), "8".to_string())

--- a/src/test/bench/shootout-binarytrees.rs
+++ b/src/test/bench/shootout-binarytrees.rs
@@ -86,7 +86,7 @@ fn inner(depth: i32, iterations: i32) -> String {
 fn main() {
     let args = std::os::args();
     let args = args;
-    let n = if std::os::getenv("RUST_BENCH").is_some() {
+    let n = if std::env::var_os("RUST_BENCH").is_some() {
         17
     } else if args.len() <= 1u {
         8

--- a/src/test/bench/shootout-chameneos-redux.rs
+++ b/src/test/bench/shootout-chameneos-redux.rs
@@ -227,7 +227,7 @@ fn rendezvous(nn: uint, set: Vec<Color>) {
 }
 
 fn main() {
-    let nn = if std::os::getenv("RUST_BENCH").is_some() {
+    let nn = if std::env::var_os("RUST_BENCH").is_some() {
         200000
     } else {
         std::os::args()

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -43,6 +43,7 @@ use std::old_io::{BufferedWriter, File};
 use std::old_io;
 use std::num::Float;
 use std::os;
+use std::env;
 
 const LINE_LENGTH: uint = 60;
 const IM: u32 = 139968;
@@ -105,7 +106,7 @@ fn make_fasta<W: Writer, I: Iterator<Item=u8>>(
 fn run<W: Writer>(writer: &mut W) -> std::old_io::IoResult<()> {
     let args = os::args();
     let args = args;
-    let n = if os::getenv("RUST_BENCH").is_some() {
+    let n = if env::var_os("RUST_BENCH").is_some() {
         25000000
     } else if args.len() <= 1u {
         1000
@@ -143,7 +144,7 @@ fn run<W: Writer>(writer: &mut W) -> std::old_io::IoResult<()> {
 }
 
 fn main() {
-    let res = if os::getenv("RUST_BENCH").is_some() {
+    let res = if env::var_os("RUST_BENCH").is_some() {
         let mut file = BufferedWriter::new(File::create(&Path::new("./shootout-fasta.data")));
         run(&mut file)
     } else {

--- a/src/test/bench/shootout-fibo.rs
+++ b/src/test/bench/shootout-fibo.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use std::os;
+use std::env;
 
 fn fib(n: int) -> int {
     if n < 2 {
@@ -20,7 +21,7 @@ fn fib(n: int) -> int {
 
 fn main() {
     let args = os::args();
-    let args = if os::getenv("RUST_BENCH").is_some() {
+    let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "40".to_string())
     } else if args.len() <= 1u {
         vec!("".to_string(), "30".to_string())

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -22,6 +22,7 @@ use std::mem::replace;
 use std::num::Float;
 use std::option;
 use std::os;
+use std::env;
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::thread::Thread;
 
@@ -148,7 +149,7 @@ fn make_sequence_processor(sz: uint,
 fn main() {
     use std::old_io::{stdio, MemReader, BufferedReader};
 
-    let rdr = if os::getenv("RUST_BENCH").is_some() {
+    let rdr = if env::var_os("RUST_BENCH").is_some() {
         let foo = include_bytes!("shootout-k-nucleotide.data");
         box MemReader::new(foo.to_vec()) as Box<Reader>
     } else {

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -291,7 +291,7 @@ fn get_sequence<R: Buffer>(r: &mut R, key: &str) -> Vec<u8> {
 }
 
 fn main() {
-    let input = if std::os::getenv("RUST_BENCH").is_some() {
+    let input = if std::env::var_os("RUST_BENCH").is_some() {
         let fd = std::old_io::File::open(&Path::new("shootout-k-nucleotide.data"));
         get_sequence(&mut std::old_io::BufferedReader::new(fd), ">THREE")
     } else {

--- a/src/test/bench/shootout-nbody.rs
+++ b/src/test/bench/shootout-nbody.rs
@@ -170,7 +170,7 @@ fn offset_momentum(bodies: &mut [Planet;N_BODIES]) {
 }
 
 fn main() {
-    let n = if std::os::getenv("RUST_BENCH").is_some() {
+    let n = if std::env::var_os("RUST_BENCH").is_some() {
         5000000
     } else {
         std::os::args().get(1)

--- a/src/test/bench/shootout-pfib.rs
+++ b/src/test/bench/shootout-pfib.rs
@@ -22,6 +22,7 @@ extern crate getopts;
 
 use std::sync::mpsc::{channel, Sender};
 use std::os;
+use std::env;
 use std::result::Result::{Ok, Err};
 use std::thread::Thread;
 use std::time::Duration;
@@ -89,7 +90,7 @@ fn stress(num_tasks: int) {
 
 fn main() {
     let args = os::args();
-    let args = if os::getenv("RUST_BENCH").is_some() {
+    let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "20".to_string())
     } else if args.len() <= 1u {
         vec!("".to_string(), "8".to_string())

--- a/src/test/bench/shootout-spectralnorm.rs
+++ b/src/test/bench/shootout-spectralnorm.rs
@@ -48,12 +48,13 @@ use std::thread::Thread;
 use std::mem;
 use std::num::Float;
 use std::os;
+use std::env;
 use std::raw::Repr;
 use std::simd::f64x2;
 
 fn main() {
     let args = os::args();
-    let answer = spectralnorm(if os::getenv("RUST_BENCH").is_some() {
+    let answer = spectralnorm(if env::var_os("RUST_BENCH").is_some() {
         5500
     } else if args.len() < 2 {
         2000

--- a/src/test/bench/shootout-threadring.rs
+++ b/src/test/bench/shootout-threadring.rs
@@ -65,7 +65,7 @@ fn roundtrip(id: i32, tx: Sender<i32>, rx: Receiver<i32>) {
 
 fn main() {
     let args = std::os::args();
-    let token = if std::os::getenv("RUST_BENCH").is_some() {
+    let token = if std::env::var_os("RUST_BENCH").is_some() {
         2000000
     } else {
         args.get(1).and_then(|arg| arg.parse().ok()).unwrap_or(1000)

--- a/src/test/bench/std-smallintmap.rs
+++ b/src/test/bench/std-smallintmap.rs
@@ -12,6 +12,7 @@
 
 use std::collections::VecMap;
 use std::os;
+use std::env;
 use std::time::Duration;
 
 fn append_sequential(min: uint, max: uint, map: &mut VecMap<uint>) {
@@ -28,7 +29,7 @@ fn check_sequential(min: uint, max: uint, map: &VecMap<uint>) {
 
 fn main() {
     let args = os::args();
-    let args = if os::getenv("RUST_BENCH").is_some() {
+    let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "100000".to_string(), "100".to_string())
     } else if args.len() <= 1u {
         vec!("".to_string(), "10000".to_string(), "50".to_string())

--- a/src/test/bench/task-perf-alloc-unwind.rs
+++ b/src/test/bench/task-perf-alloc-unwind.rs
@@ -10,7 +10,7 @@
 
 #![feature(unsafe_destructor, box_syntax)]
 
-use std::os;
+use std::env;
 use std::thread::Thread;
 use std::time::Duration;
 
@@ -20,7 +20,7 @@ enum List<T> {
 }
 
 fn main() {
-    let (repeat, depth) = if os::getenv("RUST_BENCH").is_some() {
+    let (repeat, depth) = if env::var_os("RUST_BENCH").is_some() {
         (50, 1000)
     } else {
         (10, 10)

--- a/src/test/bench/task-perf-jargon-metal-smoke.rs
+++ b/src/test/bench/task-perf-jargon-metal-smoke.rs
@@ -19,6 +19,7 @@
 
 use std::sync::mpsc::{channel, Sender};
 use std::os;
+use std::env;
 use std::thread::Thread;
 
 fn child_generation(gens_left: uint, tx: Sender<()>) {
@@ -39,7 +40,7 @@ fn child_generation(gens_left: uint, tx: Sender<()>) {
 
 fn main() {
     let args = os::args();
-    let args = if os::getenv("RUST_BENCH").is_some() {
+    let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "100000".to_string())
     } else if args.len() <= 1 {
         vec!("".to_string(), "100".to_string())

--- a/src/test/bench/task-perf-spawnalot.rs
+++ b/src/test/bench/task-perf-spawnalot.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use std::os;
+use std::env;
 use std::thread::Thread;
 
 fn f(n: uint) {
@@ -23,7 +24,7 @@ fn g() { }
 
 fn main() {
     let args = os::args();
-    let args = if os::getenv("RUST_BENCH").is_some() {
+    let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "400".to_string())
     } else if args.len() <= 1u {
         vec!("".to_string(), "10".to_string())

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -15,6 +15,7 @@
 #![feature(unsafe_destructor)]
 
 use std::os;
+use std::env;
 use std::old_io::process::Command;
 use std::str;
 use std::ops::{Drop, FnMut, FnOnce};
@@ -22,7 +23,7 @@ use std::ops::{Drop, FnMut, FnOnce};
 #[inline(never)]
 fn foo() {
     let _v = vec![1, 2, 3];
-    if os::getenv("IS_TEST").is_some() {
+    if env::var_os("IS_TEST").is_some() {
         panic!()
     }
 }

--- a/src/test/run-pass/exec-env.rs
+++ b/src/test/run-pass/exec-env.rs
@@ -10,8 +10,8 @@
 
 // exec-env:TEST_EXEC_ENV=22
 
-use std::os;
+use std::env;
 
 pub fn main() {
-    assert_eq!(os::getenv("TEST_EXEC_ENV"), Some("22".to_string()));
+    assert_eq!(env::var("TEST_EXEC_ENV"), Ok("22".to_string()));
 }

--- a/src/test/run-pass/issue-15149.rs
+++ b/src/test/run-pass/issue-15149.rs
@@ -13,6 +13,7 @@
 use std::slice::SliceExt;
 use std::old_io::{Command, fs, USER_RWX};
 use std::os;
+use std::env;
 use std::old_path::BytesContainer;
 use std::rand::random;
 
@@ -45,7 +46,7 @@ fn test() {
     fs::copy(&my_path, &child_path).unwrap();
 
     // Append the new directory to our own PATH.
-    let mut path = os::split_paths(os::getenv("PATH").unwrap_or(String::new()));
+    let mut path = os::split_paths(env::var("PATH").ok().unwrap_or(String::new()));
     path.push(child_dir.clone());
     let path = os::join_paths(&path).unwrap();
 

--- a/src/test/run-pass/process-remove-from-env.rs
+++ b/src/test/run-pass/process-remove-from-env.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use std::old_io::Command;
-use std::os;
+use std::env;
 
 #[cfg(all(unix, not(target_os="android")))]
 pub fn env_cmd() -> Command {
@@ -31,17 +31,17 @@ pub fn env_cmd() -> Command {
 
 fn main() {
     // save original environment
-    let old_env = os::getenv("RUN_TEST_NEW_ENV");
+    let old_env = env::var_os("RUN_TEST_NEW_ENV");
 
-    os::setenv("RUN_TEST_NEW_ENV", "123");
+    env::set_var("RUN_TEST_NEW_ENV", "123");
 
     let mut cmd = env_cmd();
     cmd.env_remove("RUN_TEST_NEW_ENV");
 
     // restore original environment
     match old_env {
-        None => os::unsetenv("RUN_TEST_NEW_ENV"),
-        Some(val) => os::setenv("RUN_TEST_NEW_ENV", val)
+        None => env::remove_var("RUN_TEST_NEW_ENV"),
+        Some(val) => env::set_var("RUN_TEST_NEW_ENV", &val)
     }
 
     let prog = cmd.spawn().unwrap();


### PR DESCRIPTION
This PR replaces uses of `os::getenv` with newly introduced `env::var{,_os}`.

Mostly did this as a background activity to procrastinate from procrastinating.

Tests appear to build and run fine. This includes benchmarks from test/bench directory.
