### PR TITLE
Remove ExactSizeIterator from 64-bit ranges.

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -2676,9 +2676,9 @@ impl<A: Int> Iterator for ::ops::Range<A> {
     }
 }
 
+// Ranges of u64 and i64 are excluded because they cannot guarantee having
+// a length <= usize::MAX, which is required by ExactSizeIterator.
 range_exact_iter_impl!(usize u8 u16 u32 isize i8 i16 i32);
-#[cfg(target_pointer_width = "64")]
-range_exact_iter_impl!(u64 i64);
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: Int> DoubleEndedIterator for ::ops::Range<A> {


### PR DESCRIPTION
Fixes #22047

`Range<u64>` and `Range<i64>` may be longer than usize::MAX on 32-bit
platforms, and thus they cannot fulfill the protocol for
ExactSizeIterator. We don't want a nonobvious platform dependency in
basic iterator traits, so the trait impl is removed.

The logic of this change assumes that usize is at least 32-bit.

This is technically a breaking change; note that `Range<usize>` and
`Range<isize>` are always ExactSizeIterators.

[breaking-change]
