### PR TITLE
Parse `pub` in the expansion of a method macro

### DIFF
--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -89,8 +89,7 @@ impl<'a> MacResult for ParserAnyMacro<'a> {
             match parser.token {
                 token::Eof => break,
                 _ => {
-                    let attrs = parser.parse_outer_attributes();
-                    ret.push(parser.parse_method(attrs, ast::Inherited))
+                    ret.push(parser.parse_method_with_outer_attributes());
                 }
             }
         }

--- a/src/test/run-pass/pub-method-inside-macro.rs
+++ b/src/test/run-pass/pub-method-inside-macro.rs
@@ -1,0 +1,29 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #17436
+
+mod bleh {
+    macro_rules! foo {
+        () => {
+            pub fn bar(&self) { }
+        }
+    }
+
+    pub struct S;
+
+    impl S {
+        foo!();
+    }
+}
+
+fn main() {
+    bleh::S.bar();
+}


### PR DESCRIPTION
Fixes #17436.
