### PR TITLE
Integer audit: libstd/failure

### DIFF
--- a/src/libstd/failure.rs
+++ b/src/libstd/failure.rs
@@ -33,7 +33,7 @@ impl Writer for Stdio {
     }
 }
 
-pub fn on_fail(obj: &(Any+Send), file: &'static str, line: uint) {
+pub fn on_fail(obj: &(Any+Send), file: &'static str, line: u64) {
     let msg = match obj.downcast_ref::<&'static str>() {
         Some(s) => *s,
         None => match obj.downcast_ref::<String>() {


### PR DESCRIPTION
This integer refers to a line of source code, and so should be a u64.
