### PR TITLE
add an associated `Item` type to `IntoIterator`

### DIFF
--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -655,6 +655,8 @@ impl<T: Ord> FromIterator<T> for BinaryHeap<T> {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<T: Ord> IntoIterator for BinaryHeap<T> {
     type IntoIter = IntoIter<T>;
 
@@ -663,7 +665,29 @@ impl<T: Ord> IntoIterator for BinaryHeap<T> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<T: Ord> IntoIterator for BinaryHeap<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> IntoIter<T> {
+        self.into_iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, T> IntoIterator for &'a BinaryHeap<T> where T: Ord {
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Iter<'a, T> {
+        self.iter()
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, T> IntoIterator for &'a BinaryHeap<T> where T: Ord {
+    type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
     fn into_iter(self) -> Iter<'a, T> {

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -1070,7 +1070,19 @@ impl<'a> RandomAccessIterator for Iter<'a> {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a> IntoIterator for &'a Bitv {
+    type IntoIter = Iter<'a>;
+
+    fn into_iter(self) -> Iter<'a> {
+        self.iter()
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a> IntoIterator for &'a Bitv {
+    type Item = bool;
     type IntoIter = Iter<'a>;
 
     fn into_iter(self) -> Iter<'a> {
@@ -1882,7 +1894,19 @@ impl<'a> Iterator for SymmetricDifference<'a> {
     #[inline] fn size_hint(&self) -> (usize, Option<usize>) { self.0.size_hint() }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a> IntoIterator for &'a BitvSet {
+    type IntoIter = SetIter<'a>;
+
+    fn into_iter(self) -> SetIter<'a> {
+        self.iter()
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a> IntoIterator for &'a BitvSet {
+    type Item = usize;
     type IntoIter = SetIter<'a>;
 
     fn into_iter(self) -> SetIter<'a> {

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -462,6 +462,8 @@ impl<K: Ord, V> BTreeMap<K, V> {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<K, V> IntoIterator for BTreeMap<K, V> {
     type IntoIter = IntoIter<K, V>;
 
@@ -470,6 +472,18 @@ impl<K, V> IntoIterator for BTreeMap<K, V> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<K, V> IntoIterator for BTreeMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = IntoIter<K, V>;
+
+    fn into_iter(self) -> IntoIter<K, V> {
+        self.into_iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, K, V> IntoIterator for &'a BTreeMap<K, V> {
     type IntoIter = Iter<'a, K, V>;
 
@@ -478,7 +492,29 @@ impl<'a, K, V> IntoIterator for &'a BTreeMap<K, V> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, K, V> IntoIterator for &'a BTreeMap<K, V> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
+
+    fn into_iter(self) -> Iter<'a, K, V> {
+        self.iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, K, V> IntoIterator for &'a mut BTreeMap<K, V> {
+    type IntoIter = IterMut<'a, K, V>;
+
+    fn into_iter(mut self) -> IterMut<'a, K, V> {
+        self.iter_mut()
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, K, V> IntoIterator for &'a mut BTreeMap<K, V> {
+    type Item = (&'a K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
 
     fn into_iter(mut self) -> IterMut<'a, K, V> {

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -480,6 +480,8 @@ impl<T: Ord> FromIterator<T> for BTreeSet<T> {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<T> IntoIterator for BTreeSet<T> {
     type IntoIter = IntoIter<T>;
 
@@ -488,7 +490,29 @@ impl<T> IntoIterator for BTreeSet<T> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<T> IntoIterator for BTreeSet<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> IntoIter<T> {
+        self.into_iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, T> IntoIterator for &'a BTreeSet<T> {
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Iter<'a, T> {
+        self.iter()
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, T> IntoIterator for &'a BTreeSet<T> {
+    type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
     fn into_iter(self) -> Iter<'a, T> {

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -830,6 +830,8 @@ impl<A> FromIterator<A> for DList<A> {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<T> IntoIterator for DList<T> {
     type IntoIter = IntoIter<T>;
 
@@ -838,6 +840,18 @@ impl<T> IntoIterator for DList<T> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<T> IntoIterator for DList<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> IntoIter<T> {
+        self.into_iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, T> IntoIterator for &'a DList<T> {
     type IntoIter = Iter<'a, T>;
 
@@ -846,7 +860,29 @@ impl<'a, T> IntoIterator for &'a DList<T> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, T> IntoIterator for &'a DList<T> {
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Iter<'a, T> {
+        self.iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, T> IntoIterator for &'a mut DList<T> {
+    type IntoIter = IterMut<'a, T>;
+
+    fn into_iter(mut self) -> IterMut<'a, T> {
+        self.iter_mut()
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, T> IntoIterator for &'a mut DList<T> {
+    type Item = &'a mut T;
     type IntoIter = IterMut<'a, T>;
 
     fn into_iter(mut self) -> IterMut<'a, T> {

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -257,7 +257,19 @@ impl<E:CLike> FromIterator<E> for EnumSet<E> {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, E> IntoIterator for &'a EnumSet<E> where E: CLike {
+    type IntoIter = Iter<E>;
+
+    fn into_iter(self) -> Iter<E> {
+        self.iter()
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, E> IntoIterator for &'a EnumSet<E> where E: CLike {
+    type Item = E;
     type IntoIter = Iter<E>;
 
     fn into_iter(self) -> Iter<E> {

--- a/src/libcollections/ring_buf.rs
+++ b/src/libcollections/ring_buf.rs
@@ -1607,6 +1607,8 @@ impl<A> FromIterator<A> for RingBuf<A> {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<T> IntoIterator for RingBuf<T> {
     type IntoIter = IntoIter<T>;
 
@@ -1615,6 +1617,18 @@ impl<T> IntoIterator for RingBuf<T> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<T> IntoIterator for RingBuf<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> IntoIter<T> {
+        self.into_iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, T> IntoIterator for &'a RingBuf<T> {
     type IntoIter = Iter<'a, T>;
 
@@ -1623,7 +1637,29 @@ impl<'a, T> IntoIterator for &'a RingBuf<T> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, T> IntoIterator for &'a RingBuf<T> {
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Iter<'a, T> {
+        self.iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, T> IntoIterator for &'a mut RingBuf<T> {
+    type IntoIter = IterMut<'a, T>;
+
+    fn into_iter(mut self) -> IterMut<'a, T> {
+        self.iter_mut()
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, T> IntoIterator for &'a mut RingBuf<T> {
+    type Item = &'a mut T;
     type IntoIter = IterMut<'a, T>;
 
     fn into_iter(mut self) -> IterMut<'a, T> {

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1393,6 +1393,8 @@ impl<T> FromIterator<T> for Vec<T> {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<T> IntoIterator for Vec<T> {
     type IntoIter = IntoIter<T>;
 
@@ -1401,6 +1403,18 @@ impl<T> IntoIterator for Vec<T> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<T> IntoIterator for Vec<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> IntoIter<T> {
+        self.into_iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, T> IntoIterator for &'a Vec<T> {
     type IntoIter = slice::Iter<'a, T>;
 
@@ -1409,7 +1423,29 @@ impl<'a, T> IntoIterator for &'a Vec<T> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, T> IntoIterator for &'a Vec<T> {
+    type Item = &'a T;
+    type IntoIter = slice::Iter<'a, T>;
+
+    fn into_iter(self) -> slice::Iter<'a, T> {
+        self.iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, T> IntoIterator for &'a mut Vec<T> {
+    type IntoIter = slice::IterMut<'a, T>;
+
+    fn into_iter(mut self) -> slice::IterMut<'a, T> {
+        self.iter_mut()
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, T> IntoIterator for &'a mut Vec<T> {
+    type Item = &'a mut T;
     type IntoIter = slice::IterMut<'a, T>;
 
     fn into_iter(mut self) -> slice::IterMut<'a, T> {

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -668,6 +668,8 @@ impl<V> FromIterator<(usize, V)> for VecMap<V> {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<T> IntoIterator for VecMap<T> {
     type IntoIter = IntoIter<T>;
 
@@ -676,6 +678,18 @@ impl<T> IntoIterator for VecMap<T> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<T> IntoIterator for VecMap<T> {
+    type Item = (usize, T);
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> IntoIter<T> {
+        self.into_iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, T> IntoIterator for &'a VecMap<T> {
     type IntoIter = Iter<'a, T>;
 
@@ -684,7 +698,29 @@ impl<'a, T> IntoIterator for &'a VecMap<T> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, T> IntoIterator for &'a VecMap<T> {
+    type Item = (usize, &'a T);
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Iter<'a, T> {
+        self.iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, T> IntoIterator for &'a mut VecMap<T> {
+    type IntoIter = IterMut<'a, T>;
+
+    fn into_iter(mut self) -> IterMut<'a, T> {
+        self.iter_mut()
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, T> IntoIterator for &'a mut VecMap<T> {
+    type Item = (usize, &'a mut T);
     type IntoIter = IterMut<'a, T>;
 
     fn into_iter(mut self) -> IterMut<'a, T> {

--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -48,6 +48,8 @@ macro_rules! array_impls {
                 }
             }
 
+            // NOTE(stage0): remove impl after a snapshot
+            #[cfg(stage0)]
             impl<'a, T> IntoIterator for &'a [T; $N] {
                 type IntoIter = Iter<'a, T>;
 
@@ -56,7 +58,29 @@ macro_rules! array_impls {
                 }
             }
 
+            #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+            impl<'a, T> IntoIterator for &'a [T; $N] {
+                type Item = &'a T;
+                type IntoIter = Iter<'a, T>;
+
+                fn into_iter(self) -> Iter<'a, T> {
+                    self.iter()
+                }
+            }
+
+            // NOTE(stage0): remove impl after a snapshot
+            #[cfg(stage0)]
             impl<'a, T> IntoIterator for &'a mut [T; $N] {
+                type IntoIter = IterMut<'a, T>;
+
+                fn into_iter(self) -> IterMut<'a, T> {
+                    self.iter_mut()
+                }
+            }
+
+            #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+            impl<'a, T> IntoIterator for &'a mut [T; $N] {
+                type Item = &'a mut T;
                 type IntoIter = IterMut<'a, T>;
 
                 fn into_iter(self) -> IterMut<'a, T> {

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -118,6 +118,8 @@ pub trait FromIterator<A> {
     fn from_iter<T: Iterator<Item=A>>(iterator: T) -> Self;
 }
 
+// NOTE(stage0): remove trait after a snapshot
+#[cfg(stage0)]
 /// Conversion into an `Iterator`
 pub trait IntoIterator {
     type IntoIter: Iterator;
@@ -127,7 +129,30 @@ pub trait IntoIterator {
     fn into_iter(self) -> Self::IntoIter;
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+/// Conversion into an `Iterator`
+pub trait IntoIterator {
+    type Item;
+    type IntoIter: Iterator<Item=Self::Item>;
+
+    /// Consumes `Self` and returns an iterator over it
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn into_iter(self) -> Self::IntoIter;
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<I> IntoIterator for I where I: Iterator {
+    type IntoIter = I;
+
+    fn into_iter(self) -> I {
+        self
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<I: Iterator> IntoIterator for I {
+    type Item = I::Item;
     type IntoIter = I;
 
     fn into_iter(self) -> I {

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -626,6 +626,8 @@ impl<'a, T> Default for &'a [T] {
 // Iterators
 //
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, T> IntoIterator for &'a [T] {
     type IntoIter = Iter<'a, T>;
 
@@ -634,7 +636,29 @@ impl<'a, T> IntoIterator for &'a [T] {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, T> IntoIterator for &'a [T] {
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Iter<'a, T> {
+        self.iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, T> IntoIterator for &'a mut [T] {
+    type IntoIter = IterMut<'a, T>;
+
+    fn into_iter(self) -> IterMut<'a, T> {
+        self.iter_mut()
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, T> IntoIterator for &'a mut [T] {
+    type Item = &'a mut T;
     type IntoIter = IterMut<'a, T>;
 
     fn into_iter(self) -> IterMut<'a, T> {

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -530,6 +530,8 @@ impl<'a,T> Iterator for EnumeratedItems<'a,T> {
     }
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<T> IntoIterator for VecPerParamSpace<T> {
     type IntoIter = IntoIter<T>;
 
@@ -538,7 +540,29 @@ impl<T> IntoIterator for VecPerParamSpace<T> {
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<T> IntoIterator for VecPerParamSpace<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> IntoIter<T> {
+        self.into_vec().into_iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a,T> IntoIterator for &'a VecPerParamSpace<T> {
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Iter<'a, T> {
+        self.as_slice().into_iter()
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a,T> IntoIterator for &'a VecPerParamSpace<T> {
+    type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
     fn into_iter(self) -> Iter<'a, T> {

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1372,6 +1372,8 @@ enum VacantEntryState<K, V, M> {
     NoElem(EmptyBucket<K, V, M>),
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, K, V, S, H> IntoIterator for &'a HashMap<K, V, S>
     where K: Eq + Hash<H>,
           S: HashState<Hasher=H>,
@@ -1384,6 +1386,22 @@ impl<'a, K, V, S, H> IntoIterator for &'a HashMap<K, V, S>
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, K, V, S, H> IntoIterator for &'a HashMap<K, V, S>
+    where K: Eq + Hash<H>,
+          S: HashState<Hasher=H>,
+          H: hash::Hasher<Output=u64>
+{
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
+
+    fn into_iter(self) -> Iter<'a, K, V> {
+        self.iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, K, V, S, H> IntoIterator for &'a mut HashMap<K, V, S>
     where K: Eq + Hash<H>,
           S: HashState<Hasher=H>,
@@ -1396,11 +1414,41 @@ impl<'a, K, V, S, H> IntoIterator for &'a mut HashMap<K, V, S>
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, K, V, S, H> IntoIterator for &'a mut HashMap<K, V, S>
+    where K: Eq + Hash<H>,
+          S: HashState<Hasher=H>,
+          H: hash::Hasher<Output=u64>
+{
+    type Item = (&'a K, &'a mut V);
+    type IntoIter = IterMut<'a, K, V>;
+
+    fn into_iter(mut self) -> IterMut<'a, K, V> {
+        self.iter_mut()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<K, V, S, H> IntoIterator for HashMap<K, V, S>
     where K: Eq + Hash<H>,
           S: HashState<Hasher=H>,
           H: hash::Hasher<Output=u64>
 {
+    type IntoIter = IntoIter<K, V>;
+
+    fn into_iter(self) -> IntoIter<K, V> {
+        self.into_iter()
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<K, V, S, H> IntoIterator for HashMap<K, V, S>
+    where K: Eq + Hash<H>,
+          S: HashState<Hasher=H>,
+          H: hash::Hasher<Output=u64>
+{
+    type Item = (K, V);
     type IntoIter = IntoIter<K, V>;
 
     fn into_iter(self) -> IntoIter<K, V> {

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -835,6 +835,8 @@ pub struct Union<'a, T: 'a, S: 'a> {
     iter: Chain<Iter<'a, T>, Difference<'a, T, S>>
 }
 
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<'a, T, S, H> IntoIterator for &'a HashSet<T, S>
     where T: Eq + Hash<H>,
           S: HashState<Hasher=H>,
@@ -847,11 +849,41 @@ impl<'a, T, S, H> IntoIterator for &'a HashSet<T, S>
     }
 }
 
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<'a, T, S, H> IntoIterator for &'a HashSet<T, S>
+    where T: Eq + Hash<H>,
+          S: HashState<Hasher=H>,
+          H: hash::Hasher<Output=u64>
+{
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Iter<'a, T> {
+        self.iter()
+    }
+}
+
+// NOTE(stage0): remove impl after a snapshot
+#[cfg(stage0)]
 impl<T, S, H> IntoIterator for HashSet<T, S>
     where T: Eq + Hash<H>,
           S: HashState<Hasher=H>,
           H: hash::Hasher<Output=u64>
 {
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> IntoIter<T> {
+        self.into_iter()
+    }
+}
+
+#[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+impl<T, S, H> IntoIterator for HashSet<T, S>
+    where T: Eq + Hash<H>,
+          S: HashState<Hasher=H>,
+          H: hash::Hasher<Output=u64>
+{
+    type Item = T;
     type IntoIter = IntoIter<T>;
 
     fn into_iter(self) -> IntoIter<T> {


### PR DESCRIPTION
`IntoIterator` now has an extra associated item:

``` rust
trait IntoIterator {
    type Item;
    type IntoIter: Iterator<Self=Self::Item>;
}
```

This lets you bind the iterator "`Item`" directly when writing generic functions:

``` rust
// hypothetical change, not included in this PR
impl Extend<T> for Vec<T> {
    // you can now write
    fn extend<I>(&mut self, it: I) where I: IntoIterator<Item=T> { .. }
    // instead of
    fn extend<I: IntoIterator>(&mut self, it: I) where I::IntoIter: Iterator<Item=T> { .. }
}
```

The downside is that now you have to write an extra associated type in your `IntoIterator` implementations:

``` diff
 impl<T> IntoIterator for Vec<T> {
+    type Item = T;
     type IntoIter = IntoIter<T>;

     fn into_iter(self) -> IntoIter<T> { .. }
 }
```

Because this breaks all downstream implementations of `IntoIterator`, this is a [breaking-change]

---

r? @aturon
