### PR TITLE
Tweaks to equality comparisons for slices/arrays/vectors

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1501,68 +1501,33 @@ impl<T> Extend<T> for Vec<T> {
     }
 }
 
-impl<A, B> PartialEq<Vec<B>> for Vec<A> where A: PartialEq<B> {
-    #[inline]
-    fn eq(&self, other: &Vec<B>) -> bool { PartialEq::eq(&**self, &**other) }
-    #[inline]
-    fn ne(&self, other: &Vec<B>) -> bool { PartialEq::ne(&**self, &**other) }
-}
+__impl_slice_eq1! { Vec<A>, Vec<B> }
+__impl_slice_eq2! { Vec<A>, &'b [B] }
+__impl_slice_eq2! { Vec<A>, &'b mut [B] }
+__impl_slice_eq2! { CowVec<'a, A>, &'b [B], Clone }
+__impl_slice_eq2! { CowVec<'a, A>, &'b mut [B], Clone }
+__impl_slice_eq2! { CowVec<'a, A>, Vec<B>, Clone }
 
-macro_rules! impl_eq {
-    ($lhs:ty, $rhs:ty) => {
-        impl<'b, A, B> PartialEq<$rhs> for $lhs where A: PartialEq<B> {
-            #[inline]
-            fn eq(&self, other: &$rhs) -> bool { PartialEq::eq(&**self, &**other) }
-            #[inline]
-            fn ne(&self, other: &$rhs) -> bool { PartialEq::ne(&**self, &**other) }
-        }
-
-        impl<'b, A, B> PartialEq<$lhs> for $rhs where B: PartialEq<A> {
-            #[inline]
-            fn eq(&self, other: &$lhs) -> bool { PartialEq::eq(&**self, &**other) }
-            #[inline]
-            fn ne(&self, other: &$lhs) -> bool { PartialEq::ne(&**self, &**other) }
-        }
+macro_rules! array_impls {
+    ($($N: expr)+) => {
+        $(
+            // NOTE: some less important impls are omitted to reduce code bloat
+            __impl_slice_eq2! { Vec<A>, [B; $N] }
+            __impl_slice_eq2! { Vec<A>, &'b [B; $N] }
+            // __impl_slice_eq2! { Vec<A>, &'b mut [B; $N] }
+            // __impl_slice_eq2! { CowVec<'a, A>, [B; $N], Clone }
+            // __impl_slice_eq2! { CowVec<'a, A>, &'b [B; $N], Clone }
+            // __impl_slice_eq2! { CowVec<'a, A>, &'b mut [B; $N], Clone }
+        )+
     }
 }
 
-impl_eq! { Vec<A>, &'b [B] }
-impl_eq! { Vec<A>, &'b mut [B] }
-
-impl<'a, A, B> PartialEq<Vec<B>> for Cow<'a, [A]> where A: PartialEq<B> + Clone {
-    #[inline]
-    fn eq(&self, other: &Vec<B>) -> bool { PartialEq::eq(&**self, &**other) }
-    #[inline]
-    fn ne(&self, other: &Vec<B>) -> bool { PartialEq::ne(&**self, &**other) }
+array_impls! {
+     0  1  2  3  4  5  6  7  8  9
+    10 11 12 13 14 15 16 17 18 19
+    20 21 22 23 24 25 26 27 28 29
+    30 31 32
 }
-
-impl<'a, A, B> PartialEq<Cow<'a, [A]>> for Vec<B> where A: Clone, B: PartialEq<A> {
-    #[inline]
-    fn eq(&self, other: &Cow<'a, [A]>) -> bool { PartialEq::eq(&**self, &**other) }
-    #[inline]
-    fn ne(&self, other: &Cow<'a, [A]>) -> bool { PartialEq::ne(&**self, &**other) }
-}
-
-macro_rules! impl_eq_for_cowvec {
-    ($rhs:ty) => {
-        impl<'a, 'b, A, B> PartialEq<$rhs> for Cow<'a, [A]> where A: PartialEq<B> + Clone {
-            #[inline]
-            fn eq(&self, other: &$rhs) -> bool { PartialEq::eq(&**self, &**other) }
-            #[inline]
-            fn ne(&self, other: &$rhs) -> bool { PartialEq::ne(&**self, &**other) }
-        }
-
-        impl<'a, 'b, A, B> PartialEq<Cow<'a, [A]>> for $rhs where A: Clone, B: PartialEq<A> {
-            #[inline]
-            fn eq(&self, other: &Cow<'a, [A]>) -> bool { PartialEq::eq(&**self, &**other) }
-            #[inline]
-            fn ne(&self, other: &Cow<'a, [A]>) -> bool { PartialEq::ne(&**self, &**other) }
-        }
-    }
-}
-
-impl_eq_for_cowvec! { &'b [B] }
-impl_eq_for_cowvec! { &'b mut [B] }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: PartialOrd> PartialOrd for Vec<T> {
@@ -2480,7 +2445,7 @@ mod tests {
     fn test_into_boxed_slice() {
         let xs = vec![1, 2, 3];
         let ys = xs.into_boxed_slice();
-        assert_eq!(ys, [1, 2, 3]);
+        assert_eq!(&*ys, [1, 2, 3]);
     }
 
     #[test]

--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -19,8 +19,7 @@ use cmp::{PartialEq, Eq, PartialOrd, Ord, Ordering};
 use fmt;
 use hash::{Hash, self};
 use iter::IntoIterator;
-use marker::Copy;
-use ops::Deref;
+use marker::{Copy, Sized};
 use option::Option;
 use slice::{Iter, IterMut, SliceExt};
 
@@ -76,47 +75,13 @@ macro_rules! array_impls {
                 }
             }
 
-            #[stable(feature = "rust1", since = "1.0.0")]
-            impl<A, B> PartialEq<[B; $N]> for [A; $N] where A: PartialEq<B> {
-                #[inline]
-                fn eq(&self, other: &[B; $N]) -> bool {
-                    &self[..] == &other[..]
-                }
-                #[inline]
-                fn ne(&self, other: &[B; $N]) -> bool {
-                    &self[..] != &other[..]
-                }
-            }
-
-            #[stable(feature = "rust1", since = "1.0.0")]
-            impl<'a, A, B, Rhs> PartialEq<Rhs> for [A; $N] where
-                A: PartialEq<B>,
-                Rhs: Deref<Target=[B]>,
-            {
-                #[inline(always)]
-                fn eq(&self, other: &Rhs) -> bool {
-                    PartialEq::eq(&self[..], &**other)
-                }
-                #[inline(always)]
-                fn ne(&self, other: &Rhs) -> bool {
-                    PartialEq::ne(&self[..], &**other)
-                }
-            }
-
-            #[stable(feature = "rust1", since = "1.0.0")]
-            impl<'a, A, B, Lhs> PartialEq<[B; $N]> for Lhs where
-                A: PartialEq<B>,
-                Lhs: Deref<Target=[A]>
-            {
-                #[inline(always)]
-                fn eq(&self, other: &[B; $N]) -> bool {
-                    PartialEq::eq(&**self, &other[..])
-                }
-                #[inline(always)]
-                fn ne(&self, other: &[B; $N]) -> bool {
-                    PartialEq::ne(&**self, &other[..])
-                }
-            }
+            // NOTE: some less important impls are omitted to reduce code bloat
+            __impl_slice_eq1! { [A; $N], [B; $N] }
+            __impl_slice_eq2! { [A; $N], [B] }
+            __impl_slice_eq2! { [A; $N], &'b [B] }
+            __impl_slice_eq2! { [A; $N], &'b mut [B] }
+            // __impl_slice_eq2! { [A; $N], &'b [B; $N] }
+            // __impl_slice_eq2! { [A; $N], &'b mut [B; $N] }
 
             #[stable(feature = "rust1", since = "1.0.0")]
             impl<T:Eq> Eq for [T; $N] { }

--- a/src/libcore/cmp_macros.rs
+++ b/src/libcore/cmp_macros.rs
@@ -1,0 +1,50 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Utility macros for implementing PartialEq on slice-like types
+
+#![doc(hidden)]
+
+#[macro_export]
+macro_rules! __impl_slice_eq1 {
+    ($Lhs: ty, $Rhs: ty) => {
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl<'a, 'b, A, B> PartialEq<$Rhs> for $Lhs where A: PartialEq<B> {
+            #[inline]
+            fn eq(&self, other: &$Rhs) -> bool { &self[..] == &other[..] }
+            #[inline]
+            fn ne(&self, other: &$Rhs) -> bool { &self[..] != &other[..] }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! __impl_slice_eq2 {
+    ($Lhs: ty, $Rhs: ty) => {
+        __impl_slice_eq2! { $Lhs, $Rhs, Sized }
+    };
+    ($Lhs: ty, $Rhs: ty, $Bound: ident) => {
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl<'a, 'b, A: $Bound, B> PartialEq<$Rhs> for $Lhs where A: PartialEq<B> {
+            #[inline]
+            fn eq(&self, other: &$Rhs) -> bool { &self[..] == &other[..] }
+            #[inline]
+            fn ne(&self, other: &$Rhs) -> bool { &self[..] != &other[..] }
+        }
+
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl<'a, 'b, A: $Bound, B> PartialEq<$Lhs> for $Rhs where B: PartialEq<A> {
+            #[inline]
+            fn eq(&self, other: &$Lhs) -> bool { &self[..] == &other[..] }
+            #[inline]
+            fn ne(&self, other: &$Lhs) -> bool { &self[..] != &other[..] }
+        }
+    }
+}

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -72,6 +72,9 @@
 #[macro_use]
 mod macros;
 
+#[macro_use]
+mod cmp_macros;
+
 #[path = "num/float_macros.rs"]
 #[macro_use]
 mod float_macros;

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -371,7 +371,7 @@ impl CStr {
 
 impl PartialEq for CStr {
     fn eq(&self, other: &CStr) -> bool {
-        self.to_bytes().eq(&other.to_bytes())
+        self.to_bytes().eq(other.to_bytes())
     }
 }
 impl Eq for CStr {}


### PR DESCRIPTION
All types that are "slices in disguise" - `[T]`, `[T; N]`, `Vec<T>` etc and sometimes references to them (see #21725) should be equality comparable to each other.
Many of them are already comparable, but some are not and this PR patches the holes in the impls of `PartialEq` for slice-like entities.

Ideally, the problem could be solved by an impl roughly looking like

```
impl<T, U, A, B> PartialEq<U> for T where T: BorrowSlice<A>,
                  U: BorrowSlice<B>,
                  A: PartialEq<B> {
    fn eq(&self, other: &U) -> bool { self.borrow_slice() == other.borrow_slice() }
    fn ne(&self, other: &U) -> bool { self.borrow_slice() != other.borrow_slice() }
}
```

, but the type system would never allow such a simple and obvious solution.
Therefore, the patch follows this approach, but implements it with macros and not generics.

The applied changes are conservative, in particular, the smart pointers aren't touched at all.
But the comparisons for `Box<[T]>`, `Rc<[T]>` and `Arc<[T]>` seem trivial to add. (Should I do it?)

This PR partially address #21725

Technically this is a [breaking-change], because the impls for fixed-size arrays are more conservative now.

Note: There are blanket impls of `PartialEq` in libcore/cmp.rs (see https://github.com/rust-lang/rust/blob/master/src/libcore/cmp.rs#L432 and below), they strip an _equal_ number of references from both operands and then compare the remains. It would be much better to strip _all_ the references before the comparison in the blanket impls to reduce the number of concrete impls, but I haven't found a way to do it without specialization/negative bounds.

r? @aturon 
cc @Gankro 
