### PR TITLE
core and std: Optimize write*!() and print*!() for a single argument

### DIFF
--- a/src/libcollections/macros.rs
+++ b/src/libcollections/macros.rs
@@ -33,8 +33,21 @@ macro_rules! vec {
 /// format!("hello {}", "world!");
 /// format!("x = {}, y = {y}", 10, y = 30);
 /// ```
+#[cfg(stage0)]
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
 macro_rules! format {
     ($($arg:tt)*) => ($crate::fmt::format(format_args!($($arg)*)))
+}
+
+#[cfg(not(stage0))]
+#[macro_export]
+#[stable(feature = "rust1", since = "1.0.0")]
+macro_rules! format {
+    ($fmt:expr) => {
+        format_arg!($fmt).to_string()
+    };
+    ($fmt:expr, $($arg:tt)+) => {
+        $crate::fmt::format(format_args!($fmt, $($arg)*))
+    }
 }

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -177,9 +177,21 @@ macro_rules! try {
 /// write!(&mut w, "test");
 /// write!(&mut w, "formatted {}", "arguments");
 /// ```
+#[cfg(stage0)]
 #[macro_export]
 macro_rules! write {
     ($dst:expr, $($arg:tt)*) => ((&mut *$dst).write_fmt(format_args!($($arg)*)))
+}
+
+#[cfg(not(stage0))]
+#[macro_export]
+macro_rules! write {
+    ($dst:expr, $fmt:expr) => {
+        (&mut *$dst).write_str(format_arg!($fmt))
+    };
+    ($dst:expr, $fmt:expr, $($arg:tt)+) => {
+        (&mut *$dst).write_fmt(format_args!($fmt, $($arg)*))
+    };
 }
 
 /// Equivalent to the `write!` macro, except that a newline is appended after

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -79,10 +79,23 @@ macro_rules! format {
 
 /// Equivalent to the `println!` macro except that a newline is not printed at
 /// the end of the message.
+#[cfg(stage0)]
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
 macro_rules! print {
     ($($arg:tt)*) => ($crate::old_io::stdio::print_args(format_args!($($arg)*)))
+}
+
+#[cfg(not(stage0))]
+#[macro_export]
+#[stable(feature = "rust1", since = "1.0.0")]
+macro_rules! print {
+    ($fmt:expr) => {
+        $crate::old_io::stdio::print(format_arg!($fmt))
+    };
+    ($fmt:expr, $($arg:tt)+) => {
+        $crate::old_io::stdio::print_args(format_args!($fmt, $($arg)*))
+    };
 }
 
 /// Macro for printing to a task's stdout handle.
@@ -97,10 +110,23 @@ macro_rules! print {
 /// println!("hello there!");
 /// println!("format {} arguments", "some");
 /// ```
+#[cfg(stage0)]
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
 macro_rules! println {
     ($($arg:tt)*) => ($crate::old_io::stdio::println_args(format_args!($($arg)*)))
+}
+
+#[cfg(not(stage0))]
+#[macro_export]
+#[stable(feature = "rust1", since = "1.0.0")]
+macro_rules! println {
+    ($fmt:expr) => {
+        $crate::old_io::stdio::println(format_arg!($fmt))
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        $crate::old_io::stdio::println_args(format_args!($fmt, $($arg)*))
+    };
 }
 
 /// Helper macro for unwrapping `Result` values while returning early with an
@@ -185,6 +211,28 @@ macro_rules! log {
 /// into libsyntax itself.
 #[cfg(dox)]
 pub mod builtin {
+    /// Parse a `&'static str` with a compatible format to `format_args!()`.
+    ///
+    /// This macro produces a value of type `&'static str`, and is intended to
+    /// be used by the other formatting macros (`format!`, `write!`, `println!`)
+    /// are proxied through this one.
+    ///
+    /// For more information, see the documentation in `std::fmt`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::fmt;
+    ///
+    /// let s = format_arg!("hello");
+    /// assert_eq!(s, format!("hello"));
+    ///
+    /// ```
+    #[macro_export]
+    macro_rules! format_arg { ($fmt:expr) => ({
+        /* compiler built-in */
+    }) }
+
     /// The core macro for formatted string creation & output.
     ///
     /// This macro produces a value of type `fmt::Arguments`. This value can be

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -447,6 +447,9 @@ fn initial_syntax_expander_table(ecfg: &expand::ExpansionConfig) -> SyntaxEnv {
 
     let mut syntax_expanders = SyntaxEnv::new();
     syntax_expanders.insert(intern("macro_rules"), MacroRulesTT);
+    syntax_expanders.insert(intern("format_arg"),
+                            builtin_normal_expander(
+                                ext::format::expand_format_arg));
     syntax_expanders.insert(intern("format_args"),
                             builtin_normal_expander(
                                 ext::format::expand_format_args));

--- a/src/test/compile-fail/ifmt-bad-format-args.rs
+++ b/src/test/compile-fail/ifmt-bad-format-args.rs
@@ -9,6 +9,9 @@
 // except according to those terms.
 
 fn main() {
+    format_arg!(); //~ ERROR: requires at least a format string argument
+    format_arg!("{}", "bar"); //~ ERROR: requires no arguments, found 1.
+
     format_args!(); //~ ERROR: requires at least a format string argument
     format_args!(|| {}); //~ ERROR: must be a string literal
 }

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -157,6 +157,7 @@ pub fn main() {
         format!("{}", a);
     }
 
+    test_format_arg();
     test_format_args();
 
     // test that trailing commas are acceptable
@@ -172,13 +173,17 @@ fn test_write() {
     write!(&mut buf, "{}", 3);
     {
         let w = &mut buf;
+        write!(w, "{{");
+        write!(w, "foo");
         write!(w, "{foo}", foo=4);
         write!(w, "{}", "hello");
+        writeln!(w, "line");
         writeln!(w, "{}", "line");
         writeln!(w, "{foo}", foo="bar");
+        writeln!(w, "}}");
     }
 
-    t!(buf, "34helloline\nbar\n");
+    t!(buf, "{{foo34helloline\nbar\n}}\n");
 }
 
 // Just make sure that the macros are defined, there's not really a lot that we
@@ -198,12 +203,18 @@ fn test_format_args() {
     let mut buf = String::new();
     {
         let w = &mut buf;
+        write!(w, "{{");
         write!(w, "{}", format_args!("{}", 1));
         write!(w, "{}", format_args!("test"));
         write!(w, "{}", format_args!("{test}", test=3));
+        write!(w, "}}");
     }
     let s = buf;
-    t!(s, "1test3");
+    t!(s, "{1test3}");
+
+    t!(format_args!("hello"), "hello");
+    t!(format_args!("{{"), "{");
+    t!(format_args!("}}"), "}");
 
     let s = fmt::format(format_args!("hello {}", "world"));
     t!(s, "hello world");


### PR DESCRIPTION
Before this patch, `write!(wr, "foo")` was not as fast as `wr.write_all("foo".as_bytes())` because the underlying write_fmt has some overhead in order to work with multiple arguments. This PR speeds that up by optimizing this specific case.
