### PR TITLE
Feature gate attributes starting with `rustc_`. 

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -67,6 +67,7 @@
 #![feature(simd, unsafe_destructor, slicing_syntax)]
 #![feature(staged_api)]
 #![feature(unboxed_closures)]
+#![feature(rustc_attrs)]
 
 #[macro_use]
 mod macros;

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -91,6 +91,8 @@ static KNOWN_FEATURES: &'static [(&'static str, &'static str, Status)] = &[
     ("start", "1.0.0", Active),
     ("main", "1.0.0", Active),
 
+    ("rustc_attrs", "1.0.0", Active),
+
     // A temporary feature gate used to enable parser extensions needed
     // to bootstrap fix for #5723.
     ("issue_5723_bootstrap", "1.0.0", Accepted),
@@ -287,6 +289,10 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
                 self.gate_feature("on_unimplemented", i.span,
                                   "the `#[rustc_on_unimplemented]` attribute \
                                   is an experimental feature")
+            } else if attr.name().starts_with("rustc_") {
+                self.gate_feature("rustc_attrs", i.span,
+                                  "unless otherwise specified, attributes with the prefix `rustc_` \
+                                   are reserved for internal compiler diagnostics")
             }
         }
         match i.node {

--- a/src/test/compile-fail/move-fragments-1.rs
+++ b/src/test/compile-fail/move-fragments-1.rs
@@ -18,6 +18,8 @@
 // These are all fairly trivial cases: unused variables or direct
 // drops of substructure.
 
+#![feature(rustc_attrs)]
+
 pub struct D { d: isize }
 impl Drop for D { fn drop(&mut self) { } }
 

--- a/src/test/compile-fail/move-fragments-2.rs
+++ b/src/test/compile-fail/move-fragments-2.rs
@@ -18,6 +18,8 @@
 // These are checking that enums are tracked; note that their output
 // paths include "downcasts" of the path to a particular enum.
 
+#![feature(rustc_attrs)]
+
 use self::Lonely::{Zero, One, Two};
 
 pub struct D { d: isize }

--- a/src/test/compile-fail/move-fragments-3.rs
+++ b/src/test/compile-fail/move-fragments-3.rs
@@ -18,6 +18,8 @@
 // This checks the handling of `_` within variants, especially when mixed
 // with bindings.
 
+#![feature(rustc_attrs)]
+
 use self::Lonely::{Zero, One, Two};
 
 pub struct D { d: isize }

--- a/src/test/compile-fail/move-fragments-4.rs
+++ b/src/test/compile-fail/move-fragments-4.rs
@@ -19,6 +19,8 @@
 // early draft of the code did not properly traverse up through all of
 // the parents of the leaf fragment.)
 
+#![feature(rustc_attrs)]
+
 pub struct D { d: isize }
 impl Drop for D { fn drop(&mut self) { } }
 

--- a/src/test/compile-fail/move-fragments-5.rs
+++ b/src/test/compile-fail/move-fragments-5.rs
@@ -17,6 +17,8 @@
 
 // This is the first test that checks moving into local variables.
 
+#![feature(rustc_attrs)]
+
 pub struct D { d: isize }
 impl Drop for D { fn drop(&mut self) { } }
 

--- a/src/test/compile-fail/move-fragments-6.rs
+++ b/src/test/compile-fail/move-fragments-6.rs
@@ -18,6 +18,8 @@
 // Test that moving into a field (i.e. overwriting it) fragments the
 // receiver.
 
+#![feature(rustc_attrs)]
+
 use std::mem::drop;
 
 pub struct Pair<X,Y> { x: X, y: Y }

--- a/src/test/compile-fail/move-fragments-7.rs
+++ b/src/test/compile-fail/move-fragments-7.rs
@@ -19,6 +19,8 @@
 // both moving out of the structure (i.e. reading `*p.x`) and writing
 // into the container (i.e. writing `*p.x`).
 
+#![feature(rustc_attrs)]
+
 pub struct D { d: isize }
 impl Drop for D { fn drop(&mut self) { } }
 

--- a/src/test/compile-fail/move-fragments-8.rs
+++ b/src/test/compile-fail/move-fragments-8.rs
@@ -22,6 +22,8 @@
 // also that in this case we cannot do a move out of `&T`, so we only
 // test writing `*p.x` here.
 
+#![feature(rustc_attrs)]
+
 pub struct D { d: isize }
 impl Drop for D { fn drop(&mut self) { } }
 

--- a/src/test/compile-fail/move-fragments-9.rs
+++ b/src/test/compile-fail/move-fragments-9.rs
@@ -14,6 +14,8 @@
 // Note also that the `test_move_array_then_overwrite` tests represent
 // cases that we probably should make illegal.
 
+#![feature(rustc_attrs)]
+
 pub struct D { d: isize }
 impl Drop for D { fn drop(&mut self) { } }
 

--- a/src/test/compile-fail/variance-associated-types.rs
+++ b/src/test/compile-fail/variance-associated-types.rs
@@ -11,6 +11,8 @@
 // Test that the variance computation considers types/regions that
 // appear in projections to be invariant.
 
+#![feature(rustc_attrs)]
+
 trait Trait<'a> {
     type Type;
 

--- a/src/test/compile-fail/variance-object-types.rs
+++ b/src/test/compile-fail/variance-object-types.rs
@@ -11,6 +11,8 @@
 // Test that Cell is considered invariant with respect to its
 // type.
 
+#![feature(rustc_attrs)]
+
 use std::cell::Cell;
 
 // For better or worse, associated types are invariant, and hence we

--- a/src/test/compile-fail/variance-regions-direct.rs
+++ b/src/test/compile-fail/variance-regions-direct.rs
@@ -13,6 +13,8 @@
 
 // Regions that just appear in normal spots are contravariant:
 
+#![feature(rustc_attrs)]
+
 #[rustc_variance]
 struct Test2<'a, 'b, 'c> { //~ ERROR regions=[[-, -, -];[];[]]
     x: &'a isize,

--- a/src/test/compile-fail/variance-regions-indirect.rs
+++ b/src/test/compile-fail/variance-regions-indirect.rs
@@ -12,6 +12,8 @@
 // case that involve multiple intricate types.
 // Try enums too.
 
+#![feature(rustc_attrs)]
+
 #[rustc_variance]
 enum Base<'a, 'b, 'c:'b, 'd> { //~ ERROR regions=[[+, -, o, *];[];[]]
     Test8A(extern "Rust" fn(&'a isize)),

--- a/src/test/compile-fail/variance-trait-object-bound.rs
+++ b/src/test/compile-fail/variance-trait-object-bound.rs
@@ -14,6 +14,8 @@
 //
 // Issue #18262.
 
+#![feature(rustc_attrs)]
+
 use std::mem;
 
 trait T { fn foo(); }


### PR DESCRIPTION
This can be considered a downpayment on rust-lang/rfcs#572.

r? @brson 
cc @pnkfelix 
