### PR TITLE
Normalize parameter environment with its own substitution

### DIFF
--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -157,6 +157,12 @@ impl<'tcx> Substs<'tcx> {
                                   |r, m_regions| r.with_vec(FnSpace, m_regions));
         Substs { types: types, regions: regions }
     }
+
+    pub fn with_method_from(self, other: &Substs<'tcx>) -> Substs<'tcx> {
+        let types = other.types.get_slice(FnSpace).to_vec();
+        let regions = other.regions().get_slice(FnSpace).to_vec();
+        self.with_method(types, regions)
+    }
 }
 
 impl RegionSubsts {

--- a/src/librustc/middle/traits/mod.rs
+++ b/src/librustc/middle/traits/mod.rs
@@ -413,10 +413,10 @@ pub fn normalize_param_env_or_error<'a,'tcx>(unnormalized_env: ty::ParameterEnvi
     }
 }
 
-pub fn normalize_param_env<'a,'tcx>(param_env: &ty::ParameterEnvironment<'a,'tcx>,
-                                    cause: ObligationCause<'tcx>)
-                                    -> Result<ty::ParameterEnvironment<'a,'tcx>,
-                                              Vec<FulfillmentError<'tcx>>>
+fn normalize_param_env<'a,'tcx>(param_env: &ty::ParameterEnvironment<'a,'tcx>,
+                                cause: ObligationCause<'tcx>)
+                                -> Result<ty::ParameterEnvironment<'a,'tcx>,
+                                          Vec<FulfillmentError<'tcx>>>
 {
     let tcx = param_env.tcx;
 

--- a/src/librustc/middle/traits/project.rs
+++ b/src/librustc/middle/traits/project.rs
@@ -561,8 +561,7 @@ fn assemble_candidates_from_trait_def<'cx,'tcx>(
     };
 
     // If so, extract what we know from the trait and try to come up with a good answer.
-    let trait_predicates = ty::lookup_predicates(selcx.tcx(), trait_ref.def_id);
-    let bounds = trait_predicates.instantiate(selcx.tcx(), trait_ref.substs);
+    let bounds = selcx.instantiate_trait_predicates(&trait_ref);
     assemble_candidates_from_predicates(selcx, obligation, obligation_trait_ref,
                                         candidate_set, bounds.predicates.into_vec());
 }

--- a/src/librustc/middle/traits/project.rs
+++ b/src/librustc/middle/traits/project.rs
@@ -21,7 +21,7 @@ use super::VtableImplData;
 use super::util;
 
 use middle::infer;
-use middle::subst::{Subst, Substs};
+use middle::subst::Substs;
 use middle::ty::{self, AsPredicate, ReferencesError, RegionEscape,
                  HasProjectionTypes, ToPolyTraitRef, Ty};
 use middle::ty_fold::{self, TypeFoldable, TypeFolder};
@@ -849,36 +849,38 @@ fn confirm_impl_candidate<'cx,'tcx>(
     impl_vtable: VtableImplData<'tcx, PredicateObligation<'tcx>>)
     -> (Ty<'tcx>, Vec<PredicateObligation<'tcx>>)
 {
+    let tcx = selcx.tcx();
     // there don't seem to be nicer accessors to these:
-    let impl_items_map = selcx.tcx().impl_items.borrow();
-    let impl_or_trait_items_map = selcx.tcx().impl_or_trait_items.borrow();
+    let impl_items_map = tcx.impl_items.borrow();
+    let impl_or_trait_items_map = tcx.impl_or_trait_items.borrow();
 
     let impl_items = &impl_items_map[impl_vtable.impl_def_id];
-    let mut impl_ty = None;
-    for impl_item in impl_items {
-        let assoc_type = match impl_or_trait_items_map[impl_item.def_id()] {
-            ty::TypeTraitItem(ref assoc_type) => assoc_type.clone(),
-            ty::MethodTraitItem(..) => { continue; }
-        };
+    let assoc_type =
+        impl_items
+            .iter()
+            .filter_map(|item| {
+                match impl_or_trait_items_map[item.def_id()] {
+                    ty::TypeTraitItem(ref assoc_type)
+                    if assoc_type.name == obligation.predicate.item_name => {
+                        Some(assoc_type)
+                    }
+                    _ => None
+                }
+            })
+            .next();
 
-        if assoc_type.name != obligation.predicate.item_name {
-            continue;
-        }
-
-        let impl_poly_ty = ty::lookup_item_type(selcx.tcx(), assoc_type.def_id);
-        impl_ty = Some(impl_poly_ty.ty.subst(selcx.tcx(), &impl_vtable.substs));
-        break;
-    }
-
-    match impl_ty {
-        Some(ty) => (ty, impl_vtable.nested.into_vec()),
+    match assoc_type {
+        Some(assoc_type) => {
+            let impl_ty = selcx.instantiate_assoc_type(assoc_type,
+                                                       &impl_vtable.substs);
+            (impl_ty, impl_vtable.nested.into_vec())
+        },
         None => {
-            // This means that the impl is missing a
-            // definition for the associated type. This error
-            // ought to be reported by the type checker method
-            // `check_impl_items_against_trait`, so here we
-            // just return ty_err.
-            (selcx.tcx().types.err, vec!())
+            // This means that the impl is missing a definition for the
+            // associated type. This error ought to be reported by the
+            // type checker method `check_impl_items_against_trait`, so
+            // here we just return ty_err.
+            (tcx.types.err, vec![])
         }
     }
 }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -5116,19 +5116,6 @@ pub fn is_associated_type(cx: &ctxt, id: ast::DefId) -> bool {
     })
 }
 
-/// Returns the parameter index that the given associated type corresponds to.
-pub fn associated_type_parameter_index(cx: &ctxt,
-                                       trait_def: &TraitDef,
-                                       associated_type_id: ast::DefId)
-                                       -> uint {
-    for type_parameter_def in trait_def.generics.types.iter() {
-        if type_parameter_def.def_id == associated_type_id {
-            return type_parameter_def.index as uint
-        }
-    }
-    cx.sess.bug("couldn't find associated type parameter index")
-}
-
 pub fn trait_item_def_ids(cx: &ctxt, id: ast::DefId)
                           -> Rc<Vec<ImplOrTraitItemId>> {
     lookup_locally_or_in_crate_store("trait_item_def_ids",

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4295,8 +4295,8 @@ pub fn ty_region(tcx: &ctxt,
     }
 }
 
-pub fn free_region_from_def(outlives_extent: region::DestructionScopeData,
-                            def: &RegionParameterDef)
+fn free_region_from_def(outlives_extent: region::DestructionScopeData,
+                        def: &RegionParameterDef)
     -> ty::Region
 {
     let ret =
@@ -6342,7 +6342,7 @@ pub fn construct_free_substs<'a,'tcx>(
                           region_params: &[RegionParameterDef])
     {
         for r in region_params {
-            regions.push(r.space, ty::free_region_from_def(all_outlive_extent, r));
+            regions.push(r.space, free_region_from_def(all_outlive_extent, r));
         }
     }
 

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -575,18 +575,6 @@ impl<'tcx> TypeFoldable<'tcx> for ty::ClosureUpvar<'tcx> {
     }
 }
 
-impl<'a, 'tcx> TypeFoldable<'tcx> for ty::ParameterEnvironment<'a, 'tcx> where 'tcx: 'a {
-    fn fold_with<F:TypeFolder<'tcx>>(&self, folder: &mut F) -> ty::ParameterEnvironment<'a, 'tcx> {
-        ty::ParameterEnvironment {
-            tcx: self.tcx,
-            free_substs: self.free_substs.fold_with(folder),
-            implicit_region_bound: self.implicit_region_bound.fold_with(folder),
-            caller_bounds: self.caller_bounds.fold_with(folder),
-            selection_cache: traits::SelectionCache::new(),
-        }
-    }
-}
-
 ///////////////////////////////////////////////////////////////////////////
 // "super" routines: these are the default implementations for TypeFolder.
 //

--- a/src/librustc_typeck/check/assoc.rs
+++ b/src/librustc_typeck/check/assoc.rs
@@ -29,7 +29,8 @@ pub fn normalize_associated_types_in<'a,'tcx,T>(infcx: &InferCtxt<'a,'tcx>,
     debug!("normalize_associated_types_in(value={})", value.repr(infcx.tcx));
     let mut selcx = SelectionContext::new(infcx, typer);
     let cause = ObligationCause::new(span, body_id, MiscObligation);
-    let Normalized { value: result, obligations } = traits::normalize(&mut selcx, cause, value);
+    let Normalized { value: result,
+                     obligations } = traits::normalize(&mut selcx, cause, value);
     debug!("normalize_associated_types_in: result={} predicates={}",
            result.repr(infcx.tcx),
            obligations.repr(infcx.tcx));

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -139,6 +139,7 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
         reject_non_type_param_bounds(ccx.tcx, item.span, &type_predicates);
         let param_env =
             ty::construct_parameter_environment(ccx.tcx,
+                                                item_def_id,
                                                 item.span,
                                                 &type_scheme.generics,
                                                 &type_predicates,

--- a/src/test/compile-fail/issue-22077.rs
+++ b/src/test/compile-fail/issue-22077.rs
@@ -1,0 +1,26 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Fun {
+    type Output;
+    fn call<'x>(&'x self) -> Self::Output;
+}
+
+struct Holder { x: String }
+
+impl<'a> Fun for Holder {
+    type Output = &'a str;
+    fn call<'b>(&'b self) -> &'b str {
+    //~^ ERROR method `call` has an incompatible type for trait
+        &self.x[..]
+    }
+}
+
+fn main() {}

--- a/src/test/compile-fail/regions-assoc-type-region-bound-in-trait-not-met.rs
+++ b/src/test/compile-fail/regions-assoc-type-region-bound-in-trait-not-met.rs
@@ -22,12 +22,12 @@ impl<'a> Foo<'a> for &'a i16 {
 }
 
 impl<'a> Foo<'static> for &'a i32 {
-    //~^ ERROR cannot infer
+    //~^ ERROR does not fulfill the required lifetime
     type Value = &'a i32;
 }
 
 impl<'a,'b> Foo<'b> for &'a i64 {
-    //~^ ERROR cannot infer
+    //~^ ERROR does not fulfill the required lifetime
     type Value = &'a i32;
 }
 

--- a/src/test/run-pass/issue-21750.rs
+++ b/src/test/run-pass/issue-21750.rs
@@ -1,0 +1,36 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait Arg<A> {
+    fn arg(&self) -> A;
+}
+
+pub trait Traversal {
+    type Item;
+    fn foreach<F: Arg<Self::Item>>(F);
+}
+
+impl<'a> Traversal for i32 {
+    type Item = &'a i32;
+    fn foreach<F: Arg<&'a i32>>(f: F) {
+        f.arg();
+    }
+}
+
+impl<'a> Traversal for u8 {
+    type Item = &'a u8;
+    // A more verbose way to refer to the associated type. Should also work
+    // nonetheless.
+    fn foreach<F: Arg<<Self as Traversal>::Item>>(f: F) {
+        let _ = f.arg();
+    }
+}
+
+fn main() {}

--- a/src/test/run-pass/issue-22066.rs
+++ b/src/test/run-pass/issue-22066.rs
@@ -8,22 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test that the compiler checks that the 'static bound declared in
-// the trait must be satisfied on the impl. Issue #20890.
+pub trait LineFormatter<'a> {
+    type Iter: Iterator<Item=&'a str> + 'a;
+    fn iter(&'a self, line: &'a str) -> Self::Iter;
 
-trait Foo {
-    type Value: 'static;
-    fn dummy(&self) { }
+    fn dimensions(&'a self, line: &'a str) {
+        for grapheme in self.iter(line) {
+            let _ = grapheme.len();
+        }
+    }
 }
 
-impl<'a> Foo for &'a i32 {
-    //~^ ERROR does not fulfill the required lifetime
-    type Value = &'a i32;
-}
-
-impl<'a> Foo for i32 {
-    // OK.
-    type Value = i32;
-}
-
-fn main() { }
+fn main() {}


### PR DESCRIPTION
Otherwise, the substitution is carried out from outside perspective,
which would be against the very purpose of `ParameterEnvironment`.

Closes #21750
Closes #22066
Closes #22077
