### PR TITLE
Audit integer types in libunicode, libcore/(char, str) and libstd/ascii

### DIFF
--- a/src/etc/unicode.py
+++ b/src/etc/unicode.py
@@ -366,7 +366,7 @@ def emit_conversions_module(f, lowerupper, upperlower):
         }
     }
 
-    fn bsearch_case_table(c: char, table: &'static [(char, char)]) -> Option<uint> {
+    fn bsearch_case_table(c: char, table: &'static [(char, char)]) -> Option<usize> {
         match table.binary_search(|&(key, _)| {
             if c == key { Equal }
             else if key < c { Less }
@@ -449,13 +449,13 @@ def emit_charwidth_module(f, width_table):
 """)
 
     f.write("""
-    pub fn width(c: char, is_cjk: bool) -> Option<uint> {
-        match c as uint {
+    pub fn width(c: char, is_cjk: bool) -> Option<usize> {
+        match c as usize {
             _c @ 0 => Some(0),          // null is zero width
             cu if cu < 0x20 => None,    // control sequences have no width
             cu if cu < 0x7F => Some(1), // ASCII
             cu if cu < 0xA0 => None,    // more control sequences
-            _ => Some(bsearch_range_value_table(c, is_cjk, charwidth_table) as uint)
+            _ => Some(bsearch_range_value_table(c, is_cjk, charwidth_table) as usize)
         }
     }
 
@@ -610,7 +610,7 @@ if __name__ == "__main__":
         rf.write("""
 /// The version of [Unicode](http://www.unicode.org/)
 /// that the `UnicodeChar` and `UnicodeStrPrelude` traits are based on.
-pub const UNICODE_VERSION: (uint, uint, uint) = (%s, %s, %s);
+pub const UNICODE_VERSION: (u64, u64, u64) = (%s, %s, %s);
 """ % unicode_version)
         (canon_decomp, compat_decomp, gencats, combines,
                 lowerupper, upperlower) = load_unicode_data("UnicodeData.txt")

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -119,16 +119,16 @@ pub fn from_u32(i: u32) -> Option<char> {
 /// ```
 #[inline]
 #[unstable(feature = "core", reason = "pending integer conventions")]
-pub fn from_digit(num: uint, radix: uint) -> Option<char> {
+pub fn from_digit(num: u32, radix: u32) -> Option<char> {
     if radix > 36 {
         panic!("from_digit: radix is too high (maximum 36)");
     }
     if num < radix {
         unsafe {
             if num < 10 {
-                Some(transmute(('0' as uint + num) as u32))
+                Some(transmute('0' as u32 + num))
             } else {
-                Some(transmute(('a' as uint + num - 10) as u32))
+                Some(transmute('a' as u32 + num - 10))
             }
         }
     } else {
@@ -164,7 +164,7 @@ pub trait CharExt {
     /// ```
     #[unstable(feature = "core",
                reason = "pending integer conventions")]
-    fn is_digit(self, radix: uint) -> bool;
+    fn is_digit(self, radix: u32) -> bool;
 
     /// Converts a character to the corresponding digit.
     ///
@@ -189,7 +189,7 @@ pub trait CharExt {
     /// ```
     #[unstable(feature = "core",
                reason = "pending integer conventions")]
-    fn to_digit(self, radix: uint) -> Option<uint>;
+    fn to_digit(self, radix: u32) -> Option<u32>;
 
     /// Returns an iterator that yields the hexadecimal Unicode escape of a character, as `char`s.
     ///
@@ -275,7 +275,7 @@ pub trait CharExt {
     /// assert_eq!(n, 2);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn len_utf8(self) -> uint;
+    fn len_utf8(self) -> usize;
 
     /// Returns the number of bytes this character would need if encoded in UTF-16.
     ///
@@ -287,7 +287,7 @@ pub trait CharExt {
     /// assert_eq!(n, 1);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn len_utf16(self) -> uint;
+    fn len_utf16(self) -> usize;
 
     /// Encodes this character as UTF-8 into the provided byte buffer, and then returns the number
     /// of bytes written.
@@ -317,7 +317,7 @@ pub trait CharExt {
     /// assert_eq!(result, None);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn encode_utf8(self, dst: &mut [u8]) -> Option<uint>;
+    fn encode_utf8(self, dst: &mut [u8]) -> Option<usize>;
 
     /// Encodes this character as UTF-16 into the provided `u16` buffer, and then returns the
     /// number of `u16`s written.
@@ -347,27 +347,27 @@ pub trait CharExt {
     /// assert_eq!(result, None);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn encode_utf16(self, dst: &mut [u16]) -> Option<uint>;
+    fn encode_utf16(self, dst: &mut [u16]) -> Option<usize>;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl CharExt for char {
     #[unstable(feature = "core",
                reason = "pending integer conventions")]
-    fn is_digit(self, radix: uint) -> bool {
+    fn is_digit(self, radix: u32) -> bool {
         self.to_digit(radix).is_some()
     }
 
     #[unstable(feature = "core",
                reason = "pending integer conventions")]
-    fn to_digit(self, radix: uint) -> Option<uint> {
+    fn to_digit(self, radix: u32) -> Option<u32> {
         if radix > 36 {
             panic!("to_digit: radix is too high (maximum 36)");
         }
         let val = match self {
-          '0' ... '9' => self as uint - ('0' as uint),
-          'a' ... 'z' => self as uint + 10 - ('a' as uint),
-          'A' ... 'Z' => self as uint + 10 - ('A' as uint),
+          '0' ... '9' => self as u32 - '0' as u32,
+          'a' ... 'z' => self as u32 - 'a' as u32 + 10,
+          'A' ... 'Z' => self as u32 - 'A' as u32 + 10,
           _ => return None,
         };
         if val < radix { Some(val) }
@@ -396,7 +396,7 @@ impl CharExt for char {
 
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn len_utf8(self) -> uint {
+    fn len_utf8(self) -> usize {
         let code = self as u32;
         match () {
             _ if code < MAX_ONE_B   => 1,
@@ -408,7 +408,7 @@ impl CharExt for char {
 
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn len_utf16(self) -> uint {
+    fn len_utf16(self) -> usize {
         let ch = self as u32;
         if (ch & 0xFFFF_u32) == ch { 1 } else { 2 }
     }
@@ -416,14 +416,14 @@ impl CharExt for char {
     #[inline]
     #[unstable(feature = "core",
                reason = "pending decision about Iterator/Writer/Reader")]
-    fn encode_utf8(self, dst: &mut [u8]) -> Option<uint> {
+    fn encode_utf8(self, dst: &mut [u8]) -> Option<usize> {
         encode_utf8_raw(self as u32, dst)
     }
 
     #[inline]
     #[unstable(feature = "core",
                reason = "pending decision about Iterator/Writer/Reader")]
-    fn encode_utf16(self, dst: &mut [u16]) -> Option<uint> {
+    fn encode_utf16(self, dst: &mut [u16]) -> Option<usize> {
         encode_utf16_raw(self as u32, dst)
     }
 }
@@ -435,7 +435,7 @@ impl CharExt for char {
 /// and a `None` will be returned.
 #[inline]
 #[unstable(feature = "core")]
-pub fn encode_utf8_raw(code: u32, dst: &mut [u8]) -> Option<uint> {
+pub fn encode_utf8_raw(code: u32, dst: &mut [u8]) -> Option<usize> {
     // Marked #[inline] to allow llvm optimizing it away
     if code < MAX_ONE_B && dst.len() >= 1 {
         dst[0] = code as u8;
@@ -467,7 +467,7 @@ pub fn encode_utf8_raw(code: u32, dst: &mut [u8]) -> Option<uint> {
 /// and a `None` will be returned.
 #[inline]
 #[unstable(feature = "core")]
-pub fn encode_utf16_raw(mut ch: u32, dst: &mut [u16]) -> Option<uint> {
+pub fn encode_utf16_raw(mut ch: u32, dst: &mut [u16]) -> Option<usize> {
     // Marked #[inline] to allow llvm optimizing it away
     if (ch & 0xFFFF_u32) == ch  && dst.len() >= 1 {
         // The BMP falls through (assuming non-surrogate, as it should)
@@ -499,7 +499,7 @@ enum EscapeUnicodeState {
     Backslash,
     Type,
     LeftBrace,
-    Value(uint),
+    Value(usize),
     RightBrace,
     Done,
 }

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -53,7 +53,7 @@ pub enum SignFormat {
     SignNeg
 }
 
-static DIGIT_E_RADIX: uint = ('e' as uint) - ('a' as uint) + 11;
+static DIGIT_E_RADIX: u32 = ('e' as u32) - ('a' as u32) + 11;
 
 /// Converts a number to its string representation as a byte vector.
 /// This is meant to be a common base implementation for all numeric string
@@ -87,7 +87,7 @@ static DIGIT_E_RADIX: uint = ('e' as uint) - ('a' as uint) + 11;
 ///   between digit and exponent sign `'p'`.
 pub fn float_to_str_bytes_common<T: Float, U, F>(
     num: T,
-    radix: uint,
+    radix: u32,
     negative_zero: bool,
     sign: SignFormat,
     digits: SignificantDigits,
@@ -156,7 +156,7 @@ pub fn float_to_str_bytes_common<T: Float, U, F>(
         deccum = deccum / radix_gen;
         deccum = deccum.trunc();
 
-        let c = char::from_digit(current_digit.to_int().unwrap() as uint, radix);
+        let c = char::from_digit(current_digit.to_int().unwrap() as u32, radix);
         buf[end] = c.unwrap() as u8;
         end += 1;
 
@@ -211,7 +211,7 @@ pub fn float_to_str_bytes_common<T: Float, U, F>(
             // See note in first loop.
             let current_digit = deccum.trunc().abs();
 
-            let c = char::from_digit(current_digit.to_int().unwrap() as uint,
+            let c = char::from_digit(current_digit.to_int().unwrap() as u32,
                                      radix);
             buf[end] = c.unwrap() as u8;
             end += 1;
@@ -228,7 +228,7 @@ pub fn float_to_str_bytes_common<T: Float, U, F>(
             let ascii2value = |chr: u8| {
                 (chr as char).to_digit(radix).unwrap()
             };
-            let value2ascii = |val: uint| {
+            let value2ascii = |val: u32| {
                 char::from_digit(val, radix).unwrap() as u8
             };
 

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1432,12 +1432,12 @@ pub trait Float
 #[unstable(feature = "core", reason = "needs reevaluation")]
 pub trait FromStrRadix {
     type Err;
-    fn from_str_radix(str: &str, radix: uint) -> Result<Self, Self::Err>;
+    fn from_str_radix(str: &str, radix: u32) -> Result<Self, Self::Err>;
 }
 
 /// A utility function that just calls FromStrRadix::from_str_radix.
 #[unstable(feature = "core", reason = "needs reevaluation")]
-pub fn from_str_radix<T: FromStrRadix>(str: &str, radix: uint)
+pub fn from_str_radix<T: FromStrRadix>(str: &str, radix: u32)
                                        -> Result<T, T::Err> {
     FromStrRadix::from_str_radix(str, radix)
 }
@@ -1501,7 +1501,7 @@ macro_rules! from_str_radix_float_impl {
             /// `None` if the string did not represent a valid number.
             /// Otherwise, `Some(n)` where `n` is the floating-point number
             /// represented by `src`.
-            fn from_str_radix(src: &str, radix: uint)
+            fn from_str_radix(src: &str, radix: u32)
                               -> Result<$T, ParseFloatError> {
                 use self::FloatErrorKind::*;
                 use self::ParseFloatError as PFE;
@@ -1661,7 +1661,7 @@ macro_rules! from_str_radix_int_impl {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl FromStrRadix for $T {
             type Err = ParseIntError;
-            fn from_str_radix(src: &str, radix: uint)
+            fn from_str_radix(src: &str, radix: u32)
                               -> Result<$T, ParseIntError> {
                 use self::IntErrorKind::*;
                 use self::ParseIntError as PIE;

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -422,7 +422,7 @@ impl<'a> Parser<'a> {
                 Some((_, c)) => {
                     match c.to_digit(10) {
                         Some(i) => {
-                            cur = cur * 10 + i;
+                            cur = cur * 10 + i as usize;
                             found = true;
                             self.cur.next();
                         }

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -159,12 +159,12 @@ impl AsciiExt for u8 {
 
     #[inline]
     fn to_ascii_uppercase(&self) -> u8 {
-        ASCII_UPPERCASE_MAP[*self as uint]
+        ASCII_UPPERCASE_MAP[*self as usize]
     }
 
     #[inline]
     fn to_ascii_lowercase(&self) -> u8 {
-        ASCII_LOWERCASE_MAP[*self as uint]
+        ASCII_LOWERCASE_MAP[*self as usize]
     }
 
     #[inline]

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -369,7 +369,7 @@ impl Float for f32 {
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
 pub fn to_string(num: f32) -> String {
     let (r, _) = strconv::float_to_str_common(
-        num, 10u, true, SignNeg, DigAll, ExpNone, false);
+        num, 10, true, SignNeg, DigAll, ExpNone, false);
     r
 }
 
@@ -382,7 +382,7 @@ pub fn to_string(num: f32) -> String {
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
 pub fn to_str_hex(num: f32) -> String {
     let (r, _) = strconv::float_to_str_common(
-        num, 16u, true, SignNeg, DigAll, ExpNone, false);
+        num, 16, true, SignNeg, DigAll, ExpNone, false);
     r
 }
 
@@ -395,7 +395,7 @@ pub fn to_str_hex(num: f32) -> String {
 /// * radix - The base to use
 #[inline]
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
-pub fn to_str_radix_special(num: f32, rdx: uint) -> (String, bool) {
+pub fn to_str_radix_special(num: f32, rdx: u32) -> (String, bool) {
     strconv::float_to_str_common(num, rdx, true, SignNeg, DigAll, ExpNone, false)
 }
 
@@ -410,7 +410,7 @@ pub fn to_str_radix_special(num: f32, rdx: uint) -> (String, bool) {
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
 pub fn to_str_exact(num: f32, dig: uint) -> String {
     let (r, _) = strconv::float_to_str_common(
-        num, 10u, true, SignNeg, DigExact(dig), ExpNone, false);
+        num, 10, true, SignNeg, DigExact(dig), ExpNone, false);
     r
 }
 
@@ -425,7 +425,7 @@ pub fn to_str_exact(num: f32, dig: uint) -> String {
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
 pub fn to_str_digits(num: f32, dig: uint) -> String {
     let (r, _) = strconv::float_to_str_common(
-        num, 10u, true, SignNeg, DigMax(dig), ExpNone, false);
+        num, 10, true, SignNeg, DigMax(dig), ExpNone, false);
     r
 }
 
@@ -441,7 +441,7 @@ pub fn to_str_digits(num: f32, dig: uint) -> String {
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
 pub fn to_str_exp_exact(num: f32, dig: uint, upper: bool) -> String {
     let (r, _) = strconv::float_to_str_common(
-        num, 10u, true, SignNeg, DigExact(dig), ExpDec, upper);
+        num, 10, true, SignNeg, DigExact(dig), ExpDec, upper);
     r
 }
 
@@ -457,7 +457,7 @@ pub fn to_str_exp_exact(num: f32, dig: uint, upper: bool) -> String {
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
 pub fn to_str_exp_digits(num: f32, dig: uint, upper: bool) -> String {
     let (r, _) = strconv::float_to_str_common(
-        num, 10u, true, SignNeg, DigMax(dig), ExpDec, upper);
+        num, 10, true, SignNeg, DigMax(dig), ExpDec, upper);
     r
 }
 

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -378,7 +378,7 @@ impl Float for f64 {
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
 pub fn to_string(num: f64) -> String {
     let (r, _) = strconv::float_to_str_common(
-        num, 10u, true, SignNeg, DigAll, ExpNone, false);
+        num, 10, true, SignNeg, DigAll, ExpNone, false);
     r
 }
 
@@ -391,7 +391,7 @@ pub fn to_string(num: f64) -> String {
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
 pub fn to_str_hex(num: f64) -> String {
     let (r, _) = strconv::float_to_str_common(
-        num, 16u, true, SignNeg, DigAll, ExpNone, false);
+        num, 16, true, SignNeg, DigAll, ExpNone, false);
     r
 }
 
@@ -404,7 +404,7 @@ pub fn to_str_hex(num: f64) -> String {
 /// * radix - The base to use
 #[inline]
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
-pub fn to_str_radix_special(num: f64, rdx: uint) -> (String, bool) {
+pub fn to_str_radix_special(num: f64, rdx: u32) -> (String, bool) {
     strconv::float_to_str_common(num, rdx, true, SignNeg, DigAll, ExpNone, false)
 }
 
@@ -419,7 +419,7 @@ pub fn to_str_radix_special(num: f64, rdx: uint) -> (String, bool) {
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
 pub fn to_str_exact(num: f64, dig: uint) -> String {
     let (r, _) = strconv::float_to_str_common(
-        num, 10u, true, SignNeg, DigExact(dig), ExpNone, false);
+        num, 10, true, SignNeg, DigExact(dig), ExpNone, false);
     r
 }
 
@@ -434,7 +434,7 @@ pub fn to_str_exact(num: f64, dig: uint) -> String {
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
 pub fn to_str_digits(num: f64, dig: uint) -> String {
     let (r, _) = strconv::float_to_str_common(
-        num, 10u, true, SignNeg, DigMax(dig), ExpNone, false);
+        num, 10, true, SignNeg, DigMax(dig), ExpNone, false);
     r
 }
 
@@ -450,7 +450,7 @@ pub fn to_str_digits(num: f64, dig: uint) -> String {
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
 pub fn to_str_exp_exact(num: f64, dig: uint, upper: bool) -> String {
     let (r, _) = strconv::float_to_str_common(
-        num, 10u, true, SignNeg, DigExact(dig), ExpDec, upper);
+        num, 10, true, SignNeg, DigExact(dig), ExpDec, upper);
     r
 }
 
@@ -466,7 +466,7 @@ pub fn to_str_exp_exact(num: f64, dig: uint, upper: bool) -> String {
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
 pub fn to_str_exp_digits(num: f64, dig: uint, upper: bool) -> String {
     let (r, _) = strconv::float_to_str_common(
-        num, 10u, true, SignNeg, DigMax(dig), ExpDec, upper);
+        num, 10, true, SignNeg, DigMax(dig), ExpDec, upper);
     r
 }
 

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -182,7 +182,7 @@ fn int_to_str_bytes_common<T, F>(num: T, radix: uint, sign: SignFormat, mut f: F
 /// - Panics if `radix` > 25 and `exp_format` is `ExpBin` due to conflict
 ///   between digit and exponent sign `'p'`.
 pub fn float_to_str_bytes_common<T: Float>(
-        num: T, radix: uint, negative_zero: bool,
+        num: T, radix: u32, negative_zero: bool,
         sign: SignFormat, digits: SignificantDigits, exp_format: ExponentFormat, exp_upper: bool
         ) -> (Vec<u8>, bool) {
     assert!(2 <= radix && radix <= 36);
@@ -253,7 +253,7 @@ pub fn float_to_str_bytes_common<T: Float>(
         deccum = deccum / radix_gen;
         deccum = deccum.trunc();
 
-        buf.push(char::from_digit(current_digit.to_int().unwrap() as uint, radix)
+        buf.push(char::from_digit(current_digit.to_int().unwrap() as u32, radix)
              .unwrap() as u8);
 
         // No more digits to calculate for the non-fractional part -> break
@@ -310,7 +310,7 @@ pub fn float_to_str_bytes_common<T: Float>(
             let current_digit = deccum.trunc().abs();
 
             buf.push(char::from_digit(
-                current_digit.to_int().unwrap() as uint, radix).unwrap() as u8);
+                current_digit.to_int().unwrap() as u32, radix).unwrap() as u8);
 
             // Decrease the deccumulator one fractional digit at a time
             deccum = deccum.fract();
@@ -324,7 +324,7 @@ pub fn float_to_str_bytes_common<T: Float>(
             let ascii2value = |chr: u8| {
                 (chr as char).to_digit(radix).unwrap()
             };
-            let value2ascii = |val: uint| {
+            let value2ascii = |val: u32| {
                 char::from_digit(val, radix).unwrap() as u8
             };
 
@@ -412,7 +412,7 @@ pub fn float_to_str_bytes_common<T: Float>(
 /// `to_str_bytes_common()`, for details see there.
 #[inline]
 pub fn float_to_str_common<T: Float>(
-        num: T, radix: uint, negative_zero: bool,
+        num: T, radix: u32, negative_zero: bool,
         sign: SignFormat, digits: SignificantDigits, exp_format: ExponentFormat, exp_capital: bool
         ) -> (String, bool) {
     let (bytes, special) = float_to_str_bytes_common(num, radix,
@@ -422,8 +422,8 @@ pub fn float_to_str_common<T: Float>(
 
 // Some constants for from_str_bytes_common's input validation,
 // they define minimum radix values for which the character is a valid digit.
-static DIGIT_P_RADIX: uint = ('p' as uint) - ('a' as uint) + 11u;
-static DIGIT_E_RADIX: uint = ('e' as uint) - ('a' as uint) + 11u;
+static DIGIT_P_RADIX: u32 = ('p' as u32) - ('a' as u32) + 11;
+static DIGIT_E_RADIX: u32 = ('e' as u32) - ('a' as u32) + 11;
 
 #[cfg(test)]
 mod tests {

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -645,7 +645,7 @@ impl<'a> StringReader<'a> {
 
     /// Scan through any digits (base `radix`) or underscores, and return how
     /// many digits there were.
-    fn scan_digits(&mut self, radix: usize) -> usize {
+    fn scan_digits(&mut self, radix: u32) -> usize {
         let mut len = 0;
         loop {
             let c = self.curr;

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -297,7 +297,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
             PushParam => {
                 // params are 1-indexed
                 stack.push(mparams[match cur.to_digit(10) {
-                    Some(d) => d - 1,
+                    Some(d) => d as usize - 1,
                     None => return Err("bad param number".to_string())
                 }].clone());
             },

--- a/src/libunicode/lib.rs
+++ b/src/libunicode/lib.rs
@@ -32,7 +32,6 @@
 #![feature(no_std)]
 #![no_std]
 #![feature(slicing_syntax)]
-#![feature(int_uint)]
 #![feature(core)]
 
 extern crate core;

--- a/src/libunicode/tables.rs
+++ b/src/libunicode/tables.rs
@@ -14,7 +14,7 @@
 
 /// The version of [Unicode](http://www.unicode.org/)
 /// that the unicode parts of `CharExt` and `UnicodeStrPrelude` traits are based on.
-pub const UNICODE_VERSION: (uint, uint, uint) = (7, 0, 0);
+pub const UNICODE_VERSION: (u64, u64, u64) = (7, 0, 0);
 
 fn bsearch_range_table(c: char, r: &'static [(char,char)]) -> bool {
     use core::cmp::Ordering::{Equal, Less, Greater};
@@ -6977,7 +6977,7 @@ pub mod conversions {
         }
     }
 
-    fn bsearch_case_table(c: char, table: &'static [(char, char)]) -> Option<uint> {
+    fn bsearch_case_table(c: char, table: &'static [(char, char)]) -> Option<usize> {
         match table.binary_search_by(|&(key, _)| {
             if c == key { Equal }
             else if key < c { Less }
@@ -7613,13 +7613,13 @@ pub mod charwidth {
         }
     }
 
-    pub fn width(c: char, is_cjk: bool) -> Option<uint> {
-        match c as uint {
+    pub fn width(c: char, is_cjk: bool) -> Option<usize> {
+        match c as usize {
             _c @ 0 => Some(0),          // null is zero width
             cu if cu < 0x20 => None,    // control sequences have no width
             cu if cu < 0x7F => Some(1), // ASCII
             cu if cu < 0xA0 => None,    // more control sequences
-            _ => Some(bsearch_range_value_table(c, is_cjk, charwidth_table) as uint)
+            _ => Some(bsearch_range_value_table(c, is_cjk, charwidth_table) as usize)
         }
     }
 

--- a/src/libunicode/u_char.rs
+++ b/src/libunicode/u_char.rs
@@ -36,7 +36,7 @@ pub trait CharExt {
     /// Panics if given a radix > 36.
     #[unstable(feature = "unicode",
                reason = "pending integer conventions")]
-    fn is_digit(self, radix: uint) -> bool;
+    fn is_digit(self, radix: u32) -> bool;
 
     /// Converts a character to the corresponding digit.
     ///
@@ -51,7 +51,7 @@ pub trait CharExt {
     /// Panics if given a radix outside the range [0..36].
     #[unstable(feature = "unicode",
                reason = "pending integer conventions")]
-    fn to_digit(self, radix: uint) -> Option<uint>;
+    fn to_digit(self, radix: u32) -> Option<u32>;
 
     /// Returns an iterator that yields the hexadecimal Unicode escape
     /// of a character, as `char`s.
@@ -80,12 +80,12 @@ pub trait CharExt {
     /// Returns the amount of bytes this character would need if encoded in
     /// UTF-8.
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn len_utf8(self) -> uint;
+    fn len_utf8(self) -> usize;
 
     /// Returns the amount of bytes this character would need if encoded in
     /// UTF-16.
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn len_utf16(self) -> uint;
+    fn len_utf16(self) -> usize;
 
     /// Encodes this character as UTF-8 into the provided byte buffer,
     /// and then returns the number of bytes written.
@@ -94,7 +94,7 @@ pub trait CharExt {
     /// and a `None` will be returned.
     #[unstable(feature = "unicode",
                reason = "pending decision about Iterator/Writer/Reader")]
-    fn encode_utf8(self, dst: &mut [u8]) -> Option<uint>;
+    fn encode_utf8(self, dst: &mut [u8]) -> Option<usize>;
 
     /// Encodes this character as UTF-16 into the provided `u16` buffer,
     /// and then returns the number of `u16`s written.
@@ -103,7 +103,7 @@ pub trait CharExt {
     /// and a `None` will be returned.
     #[unstable(feature = "unicode",
                reason = "pending decision about Iterator/Writer/Reader")]
-    fn encode_utf16(self, dst: &mut [u16]) -> Option<uint>;
+    fn encode_utf16(self, dst: &mut [u16]) -> Option<usize>;
 
     /// Returns whether the specified character is considered a Unicode
     /// alphabetic code point.
@@ -216,31 +216,31 @@ pub trait CharExt {
     /// `is_cjk` = `false`) if the context cannot be reliably determined.
     #[unstable(feature = "unicode",
                reason = "needs expert opinion. is_cjk flag stands out as ugly")]
-    fn width(self, is_cjk: bool) -> Option<uint>;
+    fn width(self, is_cjk: bool) -> Option<usize>;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl CharExt for char {
     #[unstable(feature = "unicode",
                reason = "pending integer conventions")]
-    fn is_digit(self, radix: uint) -> bool { C::is_digit(self, radix) }
+    fn is_digit(self, radix: u32) -> bool { C::is_digit(self, radix) }
     #[unstable(feature = "unicode",
                reason = "pending integer conventions")]
-    fn to_digit(self, radix: uint) -> Option<uint> { C::to_digit(self, radix) }
+    fn to_digit(self, radix: u32) -> Option<u32> { C::to_digit(self, radix) }
     #[stable(feature = "rust1", since = "1.0.0")]
     fn escape_unicode(self) -> char::EscapeUnicode { C::escape_unicode(self) }
     #[stable(feature = "rust1", since = "1.0.0")]
     fn escape_default(self) -> char::EscapeDefault { C::escape_default(self) }
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn len_utf8(self) -> uint { C::len_utf8(self) }
+    fn len_utf8(self) -> usize { C::len_utf8(self) }
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn len_utf16(self) -> uint { C::len_utf16(self) }
+    fn len_utf16(self) -> usize { C::len_utf16(self) }
     #[unstable(feature = "unicode",
                reason = "pending decision about Iterator/Writer/Reader")]
-    fn encode_utf8(self, dst: &mut [u8]) -> Option<uint> { C::encode_utf8(self, dst) }
+    fn encode_utf8(self, dst: &mut [u8]) -> Option<usize> { C::encode_utf8(self, dst) }
     #[unstable(feature = "unicode",
                reason = "pending decision about Iterator/Writer/Reader")]
-    fn encode_utf16(self, dst: &mut [u16]) -> Option<uint> { C::encode_utf16(self, dst) }
+    fn encode_utf16(self, dst: &mut [u16]) -> Option<usize> { C::encode_utf16(self, dst) }
 
     #[stable(feature = "rust1", since = "1.0.0")]
     fn is_alphabetic(self) -> bool {
@@ -313,5 +313,5 @@ impl CharExt for char {
 
     #[unstable(feature = "unicode",
                reason = "needs expert opinion. is_cjk flag stands out as ugly")]
-    fn width(self, is_cjk: bool) -> Option<uint> { charwidth::width(self, is_cjk) }
+    fn width(self, is_cjk: bool) -> Option<usize> { charwidth::width(self, is_cjk) }
 }

--- a/src/libunicode/u_str.rs
+++ b/src/libunicode/u_str.rs
@@ -43,7 +43,7 @@ pub trait UnicodeStr {
     fn words<'a>(&'a self) -> Words<'a>;
     fn is_whitespace(&self) -> bool;
     fn is_alphanumeric(&self) -> bool;
-    fn width(&self, is_cjk: bool) -> uint;
+    fn width(&self, is_cjk: bool) -> usize;
     fn trim<'a>(&'a self) -> &'a str;
     fn trim_left<'a>(&'a self) -> &'a str;
     fn trim_right<'a>(&'a self) -> &'a str;
@@ -57,7 +57,7 @@ impl UnicodeStr for str {
 
     #[inline]
     fn grapheme_indices(&self, is_extended: bool) -> GraphemeIndices {
-        GraphemeIndices { start_offset: self.as_ptr() as uint, iter: self.graphemes(is_extended) }
+        GraphemeIndices { start_offset: self.as_ptr() as usize, iter: self.graphemes(is_extended) }
     }
 
     #[inline]
@@ -78,7 +78,7 @@ impl UnicodeStr for str {
     fn is_alphanumeric(&self) -> bool { self.chars().all(|c| c.is_alphanumeric()) }
 
     #[inline]
-    fn width(&self, is_cjk: bool) -> uint {
+    fn width(&self, is_cjk: bool) -> usize {
         self.chars().map(|c| c.width(is_cjk).unwrap_or(0)).sum()
     }
 
@@ -101,28 +101,28 @@ impl UnicodeStr for str {
 /// External iterator for grapheme clusters and byte offsets.
 #[derive(Clone)]
 pub struct GraphemeIndices<'a> {
-    start_offset: uint,
+    start_offset: usize,
     iter: Graphemes<'a>,
 }
 
 impl<'a> Iterator for GraphemeIndices<'a> {
-    type Item = (uint, &'a str);
+    type Item = (usize, &'a str);
 
     #[inline]
-    fn next(&mut self) -> Option<(uint, &'a str)> {
-        self.iter.next().map(|s| (s.as_ptr() as uint - self.start_offset, s))
+    fn next(&mut self) -> Option<(usize, &'a str)> {
+        self.iter.next().map(|s| (s.as_ptr() as usize - self.start_offset, s))
     }
 
     #[inline]
-    fn size_hint(&self) -> (uint, Option<uint>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
 }
 
 impl<'a> DoubleEndedIterator for GraphemeIndices<'a> {
     #[inline]
-    fn next_back(&mut self) -> Option<(uint, &'a str)> {
-        self.iter.next_back().map(|s| (s.as_ptr() as uint - self.start_offset, s))
+    fn next_back(&mut self) -> Option<(usize, &'a str)> {
+        self.iter.next_back().map(|s| (s.as_ptr() as usize - self.start_offset, s))
     }
 }
 
@@ -151,7 +151,7 @@ impl<'a> Iterator for Graphemes<'a> {
     type Item = &'a str;
 
     #[inline]
-    fn size_hint(&self) -> (uint, Option<uint>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         let slen = self.string.len();
         (cmp::min(slen, 1), Some(slen))
     }
@@ -378,8 +378,8 @@ static UTF8_CHAR_WIDTH: [u8; 256] = [
 
 /// Given a first byte, determine how many bytes are in this UTF-8 character
 #[inline]
-pub fn utf8_char_width(b: u8) -> uint {
-    return UTF8_CHAR_WIDTH[b as uint] as uint;
+pub fn utf8_char_width(b: u8) -> usize {
+    return UTF8_CHAR_WIDTH[b as usize] as usize;
 }
 
 /// Determines if a vector of `u16` contains valid UTF-16
@@ -468,7 +468,7 @@ impl<'a> Iterator for Utf16Items<'a> {
     }
 
     #[inline]
-    fn size_hint(&self) -> (uint, Option<uint>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         let (low, high) = self.iter.size_hint();
         // we could be entirely valid surrogates (2 elements per
         // char), or entirely non-surrogates (1 element per char)
@@ -534,7 +534,7 @@ impl<I> Iterator for Utf16Encoder<I> where I: Iterator<Item=char> {
     }
 
     #[inline]
-    fn size_hint(&self) -> (uint, Option<uint>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         let (low, high) = self.chars.size_hint();
         // every char gets either one u16 or two u16,
         // so this iterator is between 1 or 2 times as

--- a/src/test/run-pass/exponential-notation.rs
+++ b/src/test/run-pass/exponential-notation.rs
@@ -19,18 +19,18 @@ macro_rules! t {
 
 pub fn main() {
     // Basic usage
-    t!(to_string(1.2345678e-5f64, 10u, true, SignNeg, DigMax(6), ExpDec, false),
+    t!(to_string(1.2345678e-5f64, 10, true, SignNeg, DigMax(6), ExpDec, false),
              "1.234568e-5");
 
     // Hexadecimal output
-    t!(to_string(7.281738281250e+01f64, 16u, true, SignAll, DigMax(6), ExpBin, false),
+    t!(to_string(7.281738281250e+01f64, 16, true, SignAll, DigMax(6), ExpBin, false),
               "+1.2345p+6");
-    t!(to_string(-1.777768135071e-02f64, 16u, true, SignAll, DigMax(6), ExpBin, false),
+    t!(to_string(-1.777768135071e-02f64, 16, true, SignAll, DigMax(6), ExpBin, false),
              "-1.2345p-6");
 
     // Some denormals
-    t!(to_string(4.9406564584124654e-324f64, 10u, true, SignNeg, DigMax(6), ExpBin, false),
+    t!(to_string(4.9406564584124654e-324f64, 10, true, SignNeg, DigMax(6), ExpBin, false),
              "1p-1074");
-    t!(to_string(2.2250738585072009e-308f64, 10u, true, SignNeg, DigMax(6), ExpBin, false),
+    t!(to_string(2.2250738585072009e-308f64, 10, true, SignNeg, DigMax(6), ExpBin, false),
              "1p-1022");
 }


### PR DESCRIPTION
Some function signatures have changed, so this is a [breaking-change].
In particular, radixes and numerical values of digits are represented by `u32` now. 

Part of #22240
