### PR TITLE
Only set --bench for crate tests when PLEASE_BENCH is set

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -38,14 +38,9 @@ ifdef CHECK_IGNORED
   TESTARGS += --ignored
 endif
 
-
 # Arguments to the cfail/rfail/rpass/bench tests
 ifdef CFG_VALGRIND
   CTEST_RUNTOOL = --runtool "$(CFG_VALGRIND)"
-endif
-
-ifdef PLEASE_BENCH
-  TESTARGS += --bench
 endif
 
 # Arguments to the perf tests
@@ -54,6 +49,11 @@ ifdef CFG_PERF_TOOL
 endif
 
 CTEST_TESTARGS := $(TESTARGS)
+
+# --bench is only relevant for crate tests, not for the compile tests
+ifdef PLEASE_BENCH
+  TESTARGS += --bench
+endif
 
 ifdef VERBOSE
   CTEST_TESTARGS += --verbose


### PR DESCRIPTION
This is a patch for #22291. 

PLEASE_BENCH=1 adds --bench to the arguments passed to the executable to be tested. At the moment, compiletest does not accept a --bench argument, because it is not needed for any test in src/test/, even the tests in src/test/bench do not use #[bench].

I have updated the makefile to only add the --bench flag for crate tests. I do not think that changing compiletest add --bench to the run arguments of all compile tests makes sense, because it would mess up tests which check command line arguments. Also the bench option can be added as comment in a compile test as well.
