### PR TITLE
Stabilise ExactSizeIterator::len

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1055,6 +1055,7 @@ pub trait RandomAccessIterator: Iterator {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait ExactSizeIterator: Iterator {
     #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
     /// Return the exact length of the iterator.
     fn len(&self) -> usize {
         let (lower, upper) = self.size_hint();


### PR DESCRIPTION
Appears to be just an oversight given it is the only method in a stable trait.

r? @aturon because you did final alpha stabilisation of iterators.
