### PR TITLE
Rename std::failure to std::panicking

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -278,7 +278,7 @@ pub mod sync;
 #[path = "sys/common/mod.rs"] mod sys_common;
 
 pub mod rt;
-mod failure;
+mod panicking;
 
 // Documentation for primitive types
 

--- a/src/libstd/old_io/stdio.rs
+++ b/src/libstd/old_io/stdio.rs
@@ -30,7 +30,7 @@ use self::StdSource::*;
 use boxed::Box;
 use cell::RefCell;
 use clone::Clone;
-use failure::LOCAL_STDERR;
+use panicking::LOCAL_STDERR;
 use fmt;
 use old_io::{Reader, Writer, IoResult, IoError, OtherIoError, Buffer,
          standard_error, EndOfFile, LineBufferedWriter, BufferedReader};

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -33,7 +33,7 @@ impl Writer for Stdio {
     }
 }
 
-pub fn on_fail(obj: &(Any+Send), file: &'static str, line: uint) {
+pub fn on_panic(obj: &(Any+Send), file: &'static str, line: uint) {
     let msg = match obj.downcast_ref::<&'static str>() {
         Some(s) => *s,
         None => match obj.downcast_ref::<String>() {

--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -62,7 +62,7 @@ use prelude::v1::*;
 use any::Any;
 use cell::Cell;
 use cmp;
-use failure;
+use panicking;
 use fmt;
 use intrinsics;
 use libc::c_void;
@@ -534,10 +534,10 @@ pub fn begin_unwind<M: Any + Send>(msg: M, file_line: &(&'static str, uint)) -> 
 /// }` from ~1900/3700 (-O/no opts) to 180/590.
 #[inline(never)] #[cold] // this is the slow path, please never inline this
 fn begin_unwind_inner(msg: Box<Any + Send>, file_line: &(&'static str, uint)) -> ! {
-    // Make sure the default failure handler is registered before we look at the
+    // Make sure the default panic handler is registered before we look at the
     // callbacks.
     static INIT: Once = ONCE_INIT;
-    INIT.call_once(|| unsafe { register(failure::on_fail); });
+    INIT.call_once(|| unsafe { register(panicking::on_panic); });
 
     // First, invoke call the user-defined callbacks triggered on thread panic.
     //


### PR DESCRIPTION
Rename `libstd/failure.rs` to `libstd/panicking.rs` and `on_fail` to `on_panic`. Closes #22306.
