### PR TITLE
lint: allow specific functions to be tagged `#[must_use]`

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -319,6 +319,8 @@ impl<T, E> Result<T, E> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[must_use = "`ok` only discards the contents of the `Err` variant, \
+                  it does not emit an error if the `Result` is not `Ok`"]
     pub fn ok(self) -> Option<T> {
         match self {
             Ok(x)  => Some(x),
@@ -342,6 +344,8 @@ impl<T, E> Result<T, E> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[must_use = "`err` only discards the contents of the `Ok` variant, \
+                  it does not emit an error if the `Result` is not `Err`"]
     pub fn err(self) -> Option<E> {
         match self {
             Ok(_)  => None,

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -5575,15 +5575,37 @@ pub fn predicates<'tcx>(
     vec
 }
 
-/// Get the attributes of a definition.
-pub fn get_attrs<'tcx>(tcx: &'tcx ctxt, did: DefId)
-                       -> CowVec<'tcx, ast::Attribute> {
-    if is_local(did) {
-        let item = tcx.map.expect_item(did.node);
-        Cow::Borrowed(&item.attrs[])
+/// Get the attributes of a definition, returning `None` if `did`
+/// refers to nothing or something that cannot have attributes.
+pub fn get_attrs_opt<'tcx>(tcx: &'tcx ctxt, did: DefId)
+                       -> Option<CowVec<'tcx, ast::Attribute>> {
+    let attrs: CowVec<'tcx, ast::Attribute> = if is_local(did) {
+        match tcx.map.find(did.node) {
+            Some(ast_map::NodeItem(item)) => Cow::Borrowed(&item.attrs),
+            Some(ast_map::NodeForeignItem(item)) => Cow::Borrowed(&item.attrs),
+            Some(ast_map::NodeTraitItem(item)) => match *item {
+                ast::RequiredMethod(ref ty_meth) => Cow::Borrowed(&ty_meth.attrs),
+                ast::ProvidedMethod(ref meth) => Cow::Borrowed(&meth.attrs),
+                ast::TypeTraitItem(ref ty) => Cow::Borrowed(&ty.attrs),
+            },
+            Some(ast_map::NodeImplItem(item)) => match *item {
+                ast::MethodImplItem(ref meth) => Cow::Borrowed(&meth.attrs),
+                ast::TypeImplItem(ref ty) => Cow::Borrowed(&ty.attrs),
+            },
+            Some(ast_map::NodeVariant(variant)) => Cow::Borrowed(&variant.node.attrs),
+            _ => return None
+        }
     } else {
         Cow::Owned(csearch::get_item_attrs(&tcx.sess.cstore, did))
-    }
+    };
+    Some(attrs)
+}
+
+/// Get the attributes of a definition.
+pub fn get_attrs<'tcx>(tcx: &'tcx ctxt, did: DefId) -> CowVec<'tcx, ast::Attribute> {
+    get_attrs_opt(tcx, did).unwrap_or_else(|| {
+        tcx.sess.bug("get_attrs: DefId without attributes")
+    })
 }
 
 /// Determine whether an item is annotated with an attribute

--- a/src/test/compile-fail/unused-result.rs
+++ b/src/test/compile-fail/unused-result.rs
@@ -23,11 +23,28 @@ fn bar() -> isize { return foo::<isize>(); }
 fn baz() -> MustUse { return foo::<MustUse>(); }
 fn qux() -> MustUseMsg { return foo::<MustUseMsg>(); }
 
+#[must_use]
+fn func() -> bool { true }
+#[must_use = "some message"]
+fn func_msg() -> i32 { 1 }
+
+impl MustUse {
+    #[must_use]
+    fn method(&self) -> f64 { 0.0 }
+    #[must_use = "some message"]
+    fn method_msg(&self) -> &str { "foo" }
+}
+
 #[allow(unused_results)]
 fn test() {
     foo::<isize>();
     foo::<MustUse>(); //~ ERROR: unused result which must be used
     foo::<MustUseMsg>(); //~ ERROR: unused result which must be used: some message
+    func(); //~ ERROR: unused result which must be used
+    func_msg(); //~ ERROR: unused result which must be used: some message
+
+    MustUse::Test.method(); //~ ERROR: unused result which must be used
+    MustUse::Test.method_msg(); //~ ERROR: unused result which must be used: some message
 }
 
 #[allow(unused_results, unused_must_use)]
@@ -35,14 +52,26 @@ fn test2() {
     foo::<isize>();
     foo::<MustUse>();
     foo::<MustUseMsg>();
+    func();
+    func_msg();
+    MustUse::Test.method();
+    MustUse::Test.method_msg();
 }
 
 fn main() {
     foo::<isize>(); //~ ERROR: unused result
     foo::<MustUse>(); //~ ERROR: unused result which must be used
     foo::<MustUseMsg>(); //~ ERROR: unused result which must be used: some message
+    func(); //~ ERROR: unused result which must be used
+    func_msg(); //~ ERROR: unused result which must be used: some message
+    MustUse::Test.method(); //~ ERROR: unused result which must be used
+    MustUse::Test.method_msg(); //~ ERROR: unused result which must be used: some message
 
     let _ = foo::<isize>();
     let _ = foo::<MustUse>();
     let _ = foo::<MustUseMsg>();
+    let _ = func();
+    let _ = func_msg();
+    let _ = MustUse::Test.method();
+    let _ = MustUse::Test.method_msg();
 }


### PR DESCRIPTION
A function marked with `#[must_use]` behaves as if it returns a
`#[must_use]` type, no matter what the actual return type is, e.g.

```
#[must_use}
fn foo() -> i32 { 1 }

foo(); // error: unused result which must be used
```

The #[must_use] lint is currently restricted to types; types that should
_usually_ not be ignored can be tagged with it to warn the user. This
serves most purposes well, but it doesn't always work, since a
function/method may be just acting as a go-between for a must-use type
and a more general/flexible one, without doing anything
significant (i.e. not really counting as a "use" of the must-use type).

In this case, the function can be marked `#[must_use]` to ensure that
its own result can be used, and avoid accidental ignoring of must-use
types.

The second commit marks `Result::{ok, err}` `#[must_use]` since they're "pure" `Result` adaptors.
