### PR TITLE
we forgot to make `Path` implement `Hash`

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1033,6 +1033,7 @@ impl AsOsStr for PathBuf {
 /// let parent_dir = path.parent();
 /// ```
 ///
+#[derive(Hash)]
 pub struct Path {
     inner: OsStr
 }


### PR DESCRIPTION
`PathBuf` does implement `Hash`, but `Path` doesn't. This makes it
annoying if you have a `HashMap` with `PathBuf`s as keys, because
it means you have to convert a `Path` into a `PathBuf` and get a
reference to it simply to perform operations on the `HashMap`!
