### PR TITLE
fix for issue 22187

### DIFF
--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -641,13 +641,16 @@ impl<'tcx> UserString<'tcx> for TraitAndProjections<'tcx> {
     fn user_string(&self, tcx: &ctxt<'tcx>) -> String {
         let &(ref trait_ref, ref projection_bounds) = self;
         let base = ty::item_path_str(tcx, trait_ref.def_id);
-        let trait_def = ty::lookup_trait_def(tcx, trait_ref.def_id);
-        parameterized(tcx,
-                      &base,
-                      trait_ref.substs,
-                      &trait_def.generics,
-                      trait_ref.def_id,
-                      &projection_bounds[])
+        if let Some(trait_def) = try_lookup_trait_def(tcx, trait_ref.def_id) {
+            parameterized(tcx,
+                          &base,
+                          trait_ref.substs,
+                          &trait_def.generics,
+                          trait_ref.def_id,
+                          &projection_bounds[])
+        } else {
+            format!("local_trait_not_ready({:?})", trait_ref.def_id)
+        }
     }
 }
 
@@ -777,11 +780,14 @@ impl<'tcx> Repr<'tcx> for ty::TraitRef<'tcx> {
         // to enumerate the `for<...>` etc because the debruijn index
         // tells you everything you need to know.
         let base = ty::item_path_str(tcx, self.def_id);
-        let trait_def = ty::lookup_trait_def(tcx, self.def_id);
-        format!("TraitRef({}, {})",
-                self.substs.self_ty().repr(tcx),
-                parameterized(tcx, &base, self.substs,
-                              &trait_def.generics, self.def_id, &[]))
+        if let Some(trait_def) = try_lookup_trait_def(tcx, self.def_id) {
+            format!("TraitRef({}, {})",
+                    self.substs.self_ty().repr(tcx),
+                    parameterized(tcx, &base, self.substs,
+                                  &trait_def.generics, self.def_id, &[]))
+        } else {
+            format!("local_trait_not_ready({:?})", self.def_id)
+        }
     }
 }
 
@@ -1234,9 +1240,12 @@ impl<'tcx, T> UserString<'tcx> for ty::Binder<T>
 impl<'tcx> UserString<'tcx> for ty::TraitRef<'tcx> {
     fn user_string(&self, tcx: &ctxt<'tcx>) -> String {
         let path_str = ty::item_path_str(tcx, self.def_id);
-        let trait_def = ty::lookup_trait_def(tcx, self.def_id);
-        parameterized(tcx, &path_str, self.substs,
-                      &trait_def.generics, self.def_id, &[])
+        if let Some(trait_def) = try_lookup_trait_def(tcx, self.def_id) {
+            parameterized(tcx, &path_str, self.substs,
+                          &trait_def.generics, self.def_id, &[])
+        } else {
+            format!("local_trait_not_ready({:?})", self.def_id)
+        }
     }
 }
 
@@ -1485,5 +1494,18 @@ impl<'tcx> UserString<'tcx> for ty::Predicate<'tcx> {
             ty::Predicate::TypeOutlives(ref predicate) => predicate.user_string(tcx),
             ty::Predicate::Projection(ref predicate) => predicate.user_string(tcx),
         }
+    }
+}
+
+// Wrapper around lookup_trait_def that can handle when the trait is
+// defined in the local crate. Returns Option<_> because this function
+// can be called while the trait_defs map is being built, so that
+// looking up the trait_def in the local crate can sometimes fail.
+fn try_lookup_trait_def<'tcx>(tcx: &ctxt<'tcx>, did: ast::DefId)
+                              -> Option<Rc<ty::TraitDef<'tcx>>> {
+    if did.krate == ast::LOCAL_CRATE {
+        tcx.trait_defs.borrow().get(&did).map(|r| r.clone())
+    } else {
+        Some(ty::lookup_trait_def(tcx, did))
     }
 }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -669,12 +669,16 @@ impl<'tcx> UserString<'tcx> for TraitAndProjections<'tcx> {
     fn user_string(&self, tcx: &ctxt<'tcx>) -> String {
         let &(ref trait_ref, ref projection_bounds) = self;
         let base = ty::item_path_str(tcx, trait_ref.def_id);
-        parameterized(tcx,
-                      &base,
-                      trait_ref.substs,
-                      trait_ref.def_id,
-                      &projection_bounds[],
-                      || ty::lookup_trait_def(tcx, trait_ref.def_id).generics.clone())
+        if let Some(trait_def) = try_lookup_trait_def(tcx, trait_ref.def_id) {
+            parameterized(tcx,
+                          &base,
+                          trait_ref.substs,
+                          trait_ref.def_id,
+                          &projection_bounds[],
+                          || trait_def.generics.clone())
+        } else {
+            format!("local_trait_not_ready({:?})", trait_ref.def_id)
+        }
     }
 }
 
@@ -803,8 +807,12 @@ impl<'tcx> Repr<'tcx> for ty::TraitRef<'tcx> {
         // to enumerate the `for<...>` etc because the debruijn index
         // tells you everything you need to know.
         let base = ty::item_path_str(tcx, self.def_id);
-        parameterized(tcx, &base, self.substs, self.def_id, &[],
-                      || ty::lookup_trait_def(tcx, self.def_id).generics.clone())
+        if let Some(trait_def) = try_lookup_trait_def(tcx, self.def_id) {
+            parameterized(tcx, &base, self.substs, self.def_id, &[],
+                          || trait_def.generics.clone())
+        } else {
+            format!("local_trait_not_ready({:?})", self.def_id)
+        }
     }
 }
 
@@ -1274,8 +1282,12 @@ impl<'tcx, T> UserString<'tcx> for ty::Binder<T>
 impl<'tcx> UserString<'tcx> for ty::TraitRef<'tcx> {
     fn user_string(&self, tcx: &ctxt<'tcx>) -> String {
         let path_str = ty::item_path_str(tcx, self.def_id);
-        parameterized(tcx, &path_str, self.substs, self.def_id, &[],
-                      || ty::lookup_trait_def(tcx, self.def_id).generics.clone())
+        if let Some(trait_def) = try_lookup_trait_def(tcx, self.def_id) {
+            parameterized(tcx, &path_str, self.substs, self.def_id, &[],
+                          || trait_def.generics.clone())
+        } else {
+            format!("local_trait_not_ready({:?})", self.def_id)
+        }
     }
 }
 
@@ -1524,5 +1536,18 @@ impl<'tcx> UserString<'tcx> for ty::Predicate<'tcx> {
             ty::Predicate::TypeOutlives(ref predicate) => predicate.user_string(tcx),
             ty::Predicate::Projection(ref predicate) => predicate.user_string(tcx),
         }
+    }
+}
+
+// Wrapper around lookup_trait_def that can handle when the trait is
+// defined in the local crate. Returns Option<_> because this function
+// can be called while the trait_defs map is being built, so that
+// looking up the trait_def in the local crate can sometimes fail.
+fn try_lookup_trait_def<'tcx>(tcx: &ctxt<'tcx>, did: ast::DefId)
+                              -> Option<Rc<ty::TraitDef<'tcx>>> {
+    if did.krate == ast::LOCAL_CRATE {
+        tcx.trait_defs.borrow().get(&did).map(|r| r.clone())
+    } else {
+        Some(ty::lookup_trait_def(tcx, did))
     }
 }


### PR DESCRIPTION
ppaux.rs now uses an internal `lookup_trait_def` implementation, which can handle look-ups in the local crate.
