### PR TITLE
openbsd: disable test_file_desc test

### DIFF
--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -364,7 +364,10 @@ mod tests {
     use os;
     use prelude::v1::*;
 
-    #[cfg_attr(target_os = "freebsd", ignore)] // hmm, maybe pipes have a tiny buffer
+    #[cfg_attr(any(target_os = "freebsd",
+                   target_os = "openbsd"),
+               ignore)]
+    // under some system, pipe(2) will return a bidrectionnal pipe
     #[test]
     fn test_file_desc() {
         // Run this test with some pipes so we don't have to mess around with


### PR DESCRIPTION
`pipe(2)`, under FreeBSD and OpenBSD return a bidirectionnal pipe. So
reading from the writer would block (waiting data) instead of returning
an error.

like for FreeBSD, disable the test for OpenBSD.
