### PR TITLE
Configs link

### DIFF
--- a/src/doc/trpl/hello-world.md
+++ b/src/doc/trpl/hello-world.md
@@ -89,7 +89,7 @@ This line does all of the work in our little program. There are a number of
 details that are important here. The first is that it's indented with four
 spaces, not tabs. Please configure your editor of choice to insert four spaces
 with the tab key. We provide some [sample configurations for various
-editors](https://github.com/rust-lang/rust/tree/master/src/etc).
+editors](https://github.com/rust-lang/rust/tree/master/src/etc/CONFIGS.md).
 
 The second point is the `println!()` part. This is calling a Rust *macro*,
 which is how metaprogramming is done in Rust. If it were a function instead, it

--- a/src/etc/CONFIGS.md
+++ b/src/etc/CONFIGS.md
@@ -1,0 +1,10 @@
+# Configs
+
+Here are some links to repos with configs which ease the use of rust:
+
+* [rust.vim](https://github.com/rust-lang/rust.vim)
+* [emacs rust-mode](https://github.com/rust-lang/rust-mode)
+* [gedit-config](https://github.com/rust-lang/gedit-config)
+* [kate-config](https://github.com/rust-lang/kate-config)
+* [nano-config](https://github.com/rust-lang/nano-config)
+* [zsh-config](https://github.com/rust-lang/zsh-config)


### PR DESCRIPTION
The book in "hello-world" tells that there are configs for some programs and gives a link to main repo's src/etc. Actually, these configs moved to separate repos some days ago. This PR adds a markdown file with links and moves "hello-world" link about editors to point directly to this new file.
