### PR TITLE
Apply adjustments to the retslot type in trans_ret

### DIFF
--- a/src/librustc_trans/trans/controlflow.rs
+++ b/src/librustc_trans/trans/controlflow.rs
@@ -339,7 +339,7 @@ pub fn trans_ret<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let mut bcx = bcx;
     let dest = match (fcx.llretslotptr.get(), retval_expr) {
         (Some(_), Some(retval_expr)) => {
-            let ret_ty = expr_ty(bcx, &*retval_expr);
+            let ret_ty = expr_ty_adjusted(bcx, &*retval_expr);
             expr::SaveIn(fcx.get_ret_slot(bcx, ty::FnConverging(ret_ty), "ret_slot"))
         }
         _ => expr::Ignore,

--- a/src/test/run-pass/issue22346.rs
+++ b/src/test/run-pass/issue22346.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This used to cause an ICE because the retslot for the "return" had the wrong type
+fn testcase<'a>() -> Box<Iterator<Item=usize> + 'a> {
+    return Box::new(range(0, 3).map(|i| { return i; }));
+}
+
+fn main() {
+}


### PR DESCRIPTION
Without the adjustments the retslot might have the wrong type, e.g. when
the return value is implicitly coerced to a trait object.

Fixes #22346
