### PR TITLE
Handle RUST_TEST_NOCAPTURE in compiletest and set add if to run env

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -267,7 +267,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         logfile: config.logfile.clone(),
         run_tests: true,
         run_benchmarks: true,
-        nocapture: false,
+        nocapture: env::var("RUST_TEST_NOCAPTURE").is_ok(),
         color: test::AutoColor,
     }
 }

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::env;
+
 use common::Config;
 use common;
 use util;
@@ -124,6 +126,16 @@ pub fn load_props(testfile: &Path) -> TestProps {
 
         true
     });
+
+    for key in vec!["RUST_TEST_NOCAPTURE", "RUST_TEST_TASKS"] {
+        match env::var(key) {
+            Ok(val) =>
+                if exec_env.iter().find(|&&(ref x, _)| *x == key.to_string()).is_none() {
+                    exec_env.push((key.to_string(), val))
+                },
+            Err(..) => {}
+        }
+    }
 
     TestProps {
         error_patterns: error_patterns,


### PR DESCRIPTION
This is a patch for #17829.

In `compiletest` there are multiple layers which capture the output. The first layer is  `run_tests_console` which is used to execute all tests.

Then there are some tests that contain unit tests, which by default also captures output. Therefore `compiletest` adds `RUST_TEST_NOCAPTURE` (and `RUST_TEST_TASKS` for completeness) to the run environment of the task.

Finally, the task used to execute a test redirects stdout and stdin. At the moment, the `VERBOSE=1` prints all captured output of the task (but has to print stdout and stderr separately). So at the moment using `RUST_TEST_NOCAPTURE=1` only makes sense when also using `VERBOSE=1` which seems a little bit cumbersome.

Should I update the patch to only print the output of the tasks that actually execute the test (`VERBOSE=1` includes other stuff, like the output of the task used to compile the test)? This will probably involve adding an extra flag to some functions in `src/compiletest/runtest.rs` to distinguish compilation runs from runs that execute the actual tests.
