### PR TITLE
lint: fixup extraneous #[allow]

### DIFF
--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -292,7 +292,6 @@ pub mod eabi {
 
     #[lang="eh_personality"]
     #[no_mangle] // referenced from rust_try.ll
-    #[allow(private_no_mangle_fns)]
     pub extern "C" fn rust_eh_personality(
         version: c_int,
         actions: uw::_Unwind_Action,


### PR DESCRIPTION
This snuck through my refactor.

Would it be worth the effort to have a test pass that attempts to lint the code for all targets, even if it's not feasible to actually build and test it?
