### PR TITLE
reference: fix outdated link for Compiler plugins

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -647,7 +647,7 @@ All of the above extensions are expressions with values.
 
 Users of `rustc` can define new syntax extensions in two ways:
 
-* [Compiler plugins](book/syntax-extensions.html) can include arbitrary
+* [Compiler plugins][plugin] can include arbitrary
   Rust code that manipulates syntax trees at compile time.
 
 * [Macros](book/macros.html) define new syntax in a higher-level,


### PR DESCRIPTION
book/syntax-extensions.html was renamed to book/plugins.html,
the link should be also updated.

Signed-off-by: Lai Jiangshan laijs@cn.fujitsu.com
