### PR TITLE
Audit core `mem`, `nonzero`, and `cell` modules for proper integer usage

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -78,12 +78,12 @@
 //! use std::cell::RefCell;
 //!
 //! struct Graph {
-//!     edges: Vec<(uint, uint)>,
-//!     span_tree_cache: RefCell<Option<Vec<(uint, uint)>>>
+//!     edges: Vec<(i32, i32)>,
+//!     span_tree_cache: RefCell<Option<Vec<(i32, i32)>>>
 //! }
 //!
 //! impl Graph {
-//!     fn minimum_spanning_tree(&self) -> Vec<(uint, uint)> {
+//!     fn minimum_spanning_tree(&self) -> Vec<(i32, i32)> {
 //!         // Create a new scope to contain the lifetime of the
 //!         // dynamic borrow
 //!         {
@@ -104,7 +104,7 @@
 //!         // This is the major hazard of using `RefCell`.
 //!         self.minimum_spanning_tree()
 //!     }
-//! #   fn calc_span_tree(&self) -> Vec<(uint, uint)> { vec![] }
+//! #   fn calc_span_tree(&self) -> Vec<(i32, i32)> { vec![] }
 //! }
 //! ```
 //!
@@ -125,7 +125,7 @@
 //!
 //! struct RcBox<T> {
 //!     value: T,
-//!     refcount: Cell<uint>
+//!     refcount: Cell<usize>
 //! }
 //!
 //! impl<T> Clone for Rc<T> {
@@ -279,8 +279,8 @@ pub enum BorrowState {
 }
 
 // Values [1, MAX-1] represent the number of `Ref` active
-// (will not outgrow its range since `uint` is the size of the address space)
-type BorrowFlag = uint;
+// (will not outgrow its range since `usize` is the size of the address space)
+type BorrowFlag = usize;
 const UNUSED: BorrowFlag = 0;
 const WRITING: BorrowFlag = -1;
 

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -43,7 +43,7 @@ pub use intrinsics::forget;
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn size_of<T>() -> uint {
+pub fn size_of<T>() -> usize {
     unsafe { intrinsics::size_of::<T>() }
 }
 
@@ -58,7 +58,7 @@ pub fn size_of<T>() -> uint {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn size_of_val<T>(_val: &T) -> uint {
+pub fn size_of_val<T>(_val: &T) -> usize {
     size_of::<T>()
 }
 
@@ -75,7 +75,7 @@ pub fn size_of_val<T>(_val: &T) -> uint {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn min_align_of<T>() -> uint {
+pub fn min_align_of<T>() -> usize {
     unsafe { intrinsics::min_align_of::<T>() }
 }
 
@@ -90,7 +90,7 @@ pub fn min_align_of<T>() -> uint {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn min_align_of_val<T>(_val: &T) -> uint {
+pub fn min_align_of_val<T>(_val: &T) -> usize {
     min_align_of::<T>()
 }
 
@@ -108,7 +108,7 @@ pub fn min_align_of_val<T>(_val: &T) -> uint {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn align_of<T>() -> uint {
+pub fn align_of<T>() -> usize {
     // We use the preferred alignment as the default alignment for a type. This
     // appears to be what clang migrated towards as well:
     //
@@ -130,7 +130,7 @@ pub fn align_of<T>() -> uint {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn align_of_val<T>(_val: &T) -> uint {
+pub fn align_of_val<T>(_val: &T) -> usize {
     align_of::<T>()
 }
 
@@ -150,7 +150,7 @@ pub fn align_of_val<T>(_val: &T) -> uint {
 /// ```
 /// use std::mem;
 ///
-/// let x: int = unsafe { mem::zeroed() };
+/// let x: i32 = unsafe { mem::zeroed() };
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -171,7 +171,7 @@ pub unsafe fn zeroed<T>() -> T {
 /// ```
 /// use std::mem;
 ///
-/// let x: int = unsafe { mem::uninitialized() };
+/// let x: i32 = unsafe { mem::uninitialized() };
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/nonzero.rs
+++ b/src/libcore/nonzero.rs
@@ -19,8 +19,8 @@ pub unsafe trait Zeroable {}
 unsafe impl<T> Zeroable for *const T {}
 unsafe impl<T> Zeroable for *mut T {}
 unsafe impl<T> Zeroable for Unique<T> { }
-unsafe impl Zeroable for int {}
-unsafe impl Zeroable for uint {}
+unsafe impl Zeroable for isize {}
+unsafe impl Zeroable for usize {}
 unsafe impl Zeroable for i8 {}
 unsafe impl Zeroable for u8 {}
 unsafe impl Zeroable for i16 {}


### PR DESCRIPTION
cc #22240 
