### PR TITLE
 Replace some uses of deprecated os (mostly os::args) functions

### DIFF
--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -488,10 +488,18 @@ impl Iterator for Args {
     fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
 }
 
+impl ExactSizeIterator for Args {
+    fn len(&self) -> usize { self.inner.len() }
+}
+
 impl Iterator for ArgsOs {
     type Item = OsString;
     fn next(&mut self) -> Option<OsString> { self.inner.next() }
     fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
+}
+
+impl ExactSizeIterator for ArgsOs {
+    fn len(&self) -> usize { self.inner.len() }
 }
 
 /// Returns the page size of the current architecture in bytes.

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -247,6 +247,10 @@ impl Iterator for Args {
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
+impl ExactSizeIterator for Args {
+    fn len(&self) -> usize { self.iter.len() }
+}
+
 /// Returns the command line arguments
 ///
 /// Returns a list of the command line arguments.

--- a/src/libstd/sys/windows/os.rs
+++ b/src/libstd/sys/windows/os.rs
@@ -18,7 +18,7 @@ use os::windows::*;
 use error::Error as StdError;
 use ffi::{OsString, OsStr, AsOsStr};
 use fmt;
-use iter::Range;
+use ops::Range;
 use libc::types::os::arch::extra::LPWCH;
 use libc::{self, c_int, c_void};
 use mem;
@@ -319,7 +319,7 @@ pub fn args() -> Args {
         let lpCmdLine = c::GetCommandLineW();
         let szArgList = c::CommandLineToArgvW(lpCmdLine, &mut nArgs);
 
-        Args { cur: szArgList, range: range(0, nArgs as isize) }
+        Args { cur: szArgList, range: 0..(nArgs as isize) }
     }
 }
 

--- a/src/libstd/sys/windows/os.rs
+++ b/src/libstd/sys/windows/os.rs
@@ -303,6 +303,10 @@ impl Iterator for Args {
     fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
 }
 
+impl ExactSizeIterator for Args {
+    fn len(&self) -> usize { self.range.len() }
+}
+
 impl Drop for Args {
     fn drop(&mut self) {
         unsafe { c::LocalFree(self.cur as *mut c_void); }

--- a/src/rustbook/build.rs
+++ b/src/rustbook/build.rs
@@ -11,6 +11,7 @@
 //! Implementation of the `build` subcommand, used to compile a book.
 
 use std::os;
+use std::env;
 use std::old_io;
 use std::old_io::{fs, File, BufferedWriter, TempDir, IoResult};
 
@@ -80,10 +81,10 @@ fn render(book: &Book, tgt: &Path) -> CliResult<()> {
         let out_path = tgt.join(item.path.dirname());
 
         let src;
-        if os::args().len() < 3 {
+        if env::args().len() < 3 {
             src = os::getcwd().unwrap().clone();
         } else {
-            src = Path::new(os::args()[2].clone());
+            src = Path::new(env::args().nth(2).unwrap().clone());
         }
         // preprocess the markdown, rerouting markdown references to html references
         let markdown_data = try!(File::open(&src.join(&item.path)).read_to_string());
@@ -153,16 +154,16 @@ impl Subcommand for Build {
         let src;
         let tgt;
 
-        if os::args().len() < 3 {
+        if env::args().len() < 3 {
             src = cwd.clone();
         } else {
-            src = Path::new(os::args()[2].clone());
+            src = Path::new(env::args().nth(2).unwrap().clone());
         }
 
-        if os::args().len() < 4 {
+        if env::args().len() < 4 {
             tgt = cwd.join("_book");
         } else {
-            tgt = Path::new(os::args()[3].clone());
+            tgt = Path::new(env::args().nth(3).unwrap().clone());
         }
 
         try!(fs::mkdir(&tgt, old_io::USER_DIR));

--- a/src/rustbook/main.rs
+++ b/src/rustbook/main.rs
@@ -13,12 +13,13 @@
 #![feature(core)]
 #![feature(io)]
 #![feature(os)]
+#![feature(env)]
 #![feature(path)]
 #![feature(rustdoc)]
 
 extern crate rustdoc;
 
-use std::os;
+use std::env;
 use subcommand::Subcommand;
 use term::Term;
 
@@ -48,7 +49,7 @@ mod javascript;
 #[cfg(not(test))] // thanks #12327
 fn main() {
     let mut term = Term::new();
-    let cmd = os::args();
+    let cmd: Vec<_> = env::args().collect();
 
     if cmd.len() < 1 {
         help::usage()

--- a/src/rustbook/term.rs
+++ b/src/rustbook/term.rs
@@ -11,7 +11,7 @@
 //! An abstraction of the terminal. Eventually, provide color and
 //! verbosity support. For now, just a wrapper around stdout/stderr.
 
-use std::os;
+use std::env;
 use std::old_io::stdio;
 
 pub struct Term {
@@ -28,6 +28,6 @@ impl Term {
     pub fn err(&mut self, msg: &str) {
         // swallow any errors
         let _ = self.err.write_line(msg);
-        os::set_exit_status(101);
+        env::set_exit_status(101);
     }
 }

--- a/src/test/bench/core-map.rs
+++ b/src/test/bench/core-map.rs
@@ -11,7 +11,7 @@
 #![feature(unboxed_closures)]
 
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::os;
+use std::env;
 use std::rand::{Rng, IsaacRng, SeedableRng};
 use std::time::Duration;
 
@@ -20,33 +20,33 @@ fn timed<F>(label: &str, f: F) where F: FnMut() {
 }
 
 trait MutableMap {
-    fn insert(&mut self, k: uint, v: uint);
-    fn remove(&mut self, k: &uint) -> bool;
-    fn find(&self, k: &uint) -> Option<&uint>;
+    fn insert(&mut self, k: usize, v: usize);
+    fn remove(&mut self, k: &usize) -> bool;
+    fn find(&self, k: &usize) -> Option<&usize>;
 }
 
-impl MutableMap for BTreeMap<uint, uint> {
-    fn insert(&mut self, k: uint, v: uint) { self.insert(k, v); }
-    fn remove(&mut self, k: &uint) -> bool { self.remove(k).is_some() }
-    fn find(&self, k: &uint) -> Option<&uint> { self.get(k) }
+impl MutableMap for BTreeMap<usize, usize> {
+    fn insert(&mut self, k: usize, v: usize) { self.insert(k, v); }
+    fn remove(&mut self, k: &usize) -> bool { self.remove(k).is_some() }
+    fn find(&self, k: &usize) -> Option<&usize> { self.get(k) }
 }
-impl MutableMap for HashMap<uint, uint> {
-    fn insert(&mut self, k: uint, v: uint) { self.insert(k, v); }
-    fn remove(&mut self, k: &uint) -> bool { self.remove(k).is_some() }
-    fn find(&self, k: &uint) -> Option<&uint> { self.get(k) }
+impl MutableMap for HashMap<usize, usize> {
+    fn insert(&mut self, k: usize, v: usize) { self.insert(k, v); }
+    fn remove(&mut self, k: &usize) -> bool { self.remove(k).is_some() }
+    fn find(&self, k: &usize) -> Option<&usize> { self.get(k) }
 }
 
-fn ascending<M: MutableMap>(map: &mut M, n_keys: uint) {
+fn ascending<M: MutableMap>(map: &mut M, n_keys: usize) {
     println!(" Ascending integers:");
 
     timed("insert", || {
-        for i in 0u..n_keys {
+        for i in 0..n_keys {
             map.insert(i, i + 1);
         }
     });
 
     timed("search", || {
-        for i in 0u..n_keys {
+        for i in 0..n_keys {
             assert_eq!(map.find(&i).unwrap(), &(i + 1));
         }
     });
@@ -58,7 +58,7 @@ fn ascending<M: MutableMap>(map: &mut M, n_keys: uint) {
     });
 }
 
-fn descending<M: MutableMap>(map: &mut M, n_keys: uint) {
+fn descending<M: MutableMap>(map: &mut M, n_keys: usize) {
     println!(" Descending integers:");
 
     timed("insert", || {
@@ -80,32 +80,31 @@ fn descending<M: MutableMap>(map: &mut M, n_keys: uint) {
     });
 }
 
-fn vector<M: MutableMap>(map: &mut M, n_keys: uint, dist: &[uint]) {
+fn vector<M: MutableMap>(map: &mut M, n_keys: usize, dist: &[usize]) {
     timed("insert", || {
-        for i in 0u..n_keys {
+        for i in 0..n_keys {
             map.insert(dist[i], i + 1);
         }
     });
 
     timed("search", || {
-        for i in 0u..n_keys {
+        for i in 0..n_keys {
             assert_eq!(map.find(&dist[i]).unwrap(), &(i + 1));
         }
     });
 
     timed("remove", || {
-        for i in 0u..n_keys {
+        for i in 0..n_keys {
             assert!(map.remove(&dist[i]));
         }
     });
 }
 
 fn main() {
-    let args = os::args();
-    let args = args;
+    let mut args = env::args();
     let n_keys = {
         if args.len() == 2 {
-            args[1].parse::<uint>().unwrap()
+            args.nth(1).unwrap().parse::<usize>().unwrap()
         } else {
             1000000
         }
@@ -131,18 +130,18 @@ fn main() {
     println!("{}", "\nBTreeMap:");
 
     {
-        let mut map: BTreeMap<uint,uint> = BTreeMap::new();
+        let mut map: BTreeMap<usize,usize> = BTreeMap::new();
         ascending(&mut map, n_keys);
     }
 
     {
-        let mut map: BTreeMap<uint,uint> = BTreeMap::new();
+        let mut map: BTreeMap<usize,usize> = BTreeMap::new();
         descending(&mut map, n_keys);
     }
 
     {
         println!(" Random integers:");
-        let mut map: BTreeMap<uint,uint> = BTreeMap::new();
+        let mut map: BTreeMap<usize,usize> = BTreeMap::new();
         vector(&mut map, n_keys, &rand);
     }
 
@@ -150,18 +149,18 @@ fn main() {
     println!("{}", "\nHashMap:");
 
     {
-        let mut map: HashMap<uint,uint> = HashMap::new();
+        let mut map: HashMap<usize,usize> = HashMap::new();
         ascending(&mut map, n_keys);
     }
 
     {
-        let mut map: HashMap<uint,uint> = HashMap::new();
+        let mut map: HashMap<usize,usize> = HashMap::new();
         descending(&mut map, n_keys);
     }
 
     {
         println!(" Random integers:");
-        let mut map: HashMap<uint,uint> = HashMap::new();
+        let mut map: HashMap<usize,usize> = HashMap::new();
         vector(&mut map, n_keys, &rand);
     }
 }

--- a/src/test/bench/core-set.rs
+++ b/src/test/bench/core-set.rs
@@ -20,7 +20,7 @@ use std::collections::BitvSet;
 use std::collections::HashSet;
 use std::collections::hash_map::Hasher;
 use std::hash::Hash;
-use std::os;
+use std::env;
 use std::time::Duration;
 
 struct Results {
@@ -53,29 +53,29 @@ impl<T: Ord> MutableSet<T> for BTreeSet<T> {
     fn remove(&mut self, k: &T) -> bool { self.remove(k) }
     fn contains(&self, k: &T) -> bool { self.contains(k) }
 }
-impl MutableSet<uint> for BitvSet {
-    fn insert(&mut self, k: uint) { self.insert(k); }
-    fn remove(&mut self, k: &uint) -> bool { self.remove(k) }
-    fn contains(&self, k: &uint) -> bool { self.contains(k) }
+impl MutableSet<usize> for BitvSet {
+    fn insert(&mut self, k: usize) { self.insert(k); }
+    fn remove(&mut self, k: &usize) -> bool { self.remove(k) }
+    fn contains(&self, k: &usize) -> bool { self.contains(k) }
 }
 
 impl Results {
-    pub fn bench_int<T:MutableSet<uint>,
+    pub fn bench_int<T:MutableSet<usize>,
                      R:rand::Rng,
                      F:FnMut() -> T>(
                      &mut self,
                      rng: &mut R,
-                     num_keys: uint,
-                     rand_cap: uint,
+                     num_keys: usize,
+                     rand_cap: usize,
                      mut f: F) {
         {
             let mut set = f();
             timed(&mut self.sequential_ints, || {
-                for i in 0u..num_keys {
+                for i in 0..num_keys {
                     set.insert(i);
                 }
 
-                for i in 0u..num_keys {
+                for i in 0..num_keys {
                     assert!(set.contains(&i));
                 }
             })
@@ -85,19 +85,19 @@ impl Results {
             let mut set = f();
             timed(&mut self.random_ints, || {
                 for _ in 0..num_keys {
-                    set.insert(rng.gen::<uint>() % rand_cap);
+                    set.insert(rng.gen::<usize>() % rand_cap);
                 }
             })
         }
 
         {
             let mut set = f();
-            for i in 0u..num_keys {
+            for i in 0..num_keys {
                 set.insert(i);
             }
 
             timed(&mut self.delete_ints, || {
-                for i in 0u..num_keys {
+                for i in 0..num_keys {
                     assert!(set.remove(&i));
                 }
             })
@@ -109,16 +109,16 @@ impl Results {
                      F:FnMut() -> T>(
                      &mut self,
                      rng: &mut R,
-                     num_keys: uint,
+                     num_keys: usize,
                      mut f: F) {
         {
             let mut set = f();
             timed(&mut self.sequential_strings, || {
-                for i in 0u..num_keys {
+                for i in 0..num_keys {
                     set.insert(i.to_string());
                 }
 
-                for i in 0u..num_keys {
+                for i in 0..num_keys {
                     assert!(set.contains(&i.to_string()));
                 }
             })
@@ -128,7 +128,7 @@ impl Results {
             let mut set = f();
             timed(&mut self.random_strings, || {
                 for _ in 0..num_keys {
-                    let s = rng.gen::<uint>().to_string();
+                    let s = rng.gen::<usize>().to_string();
                     set.insert(s);
                 }
             })
@@ -136,11 +136,11 @@ impl Results {
 
         {
             let mut set = f();
-            for i in 0u..num_keys {
+            for i in 0..num_keys {
                 set.insert(i.to_string());
             }
             timed(&mut self.delete_strings, || {
-                for i in 0u..num_keys {
+                for i in 0..num_keys {
                     assert!(set.remove(&i.to_string()));
                 }
             })
@@ -179,11 +179,10 @@ fn empty_results() -> Results {
 }
 
 fn main() {
-    let args = os::args();
-    let args = args;
+    let mut args = env::args();
     let num_keys = {
         if args.len() == 2 {
-            args[1].parse::<uint>().unwrap()
+            args.nth(1).unwrap().parse::<usize>().unwrap()
         } else {
             100 // woefully inadequate for any real measurement
         }
@@ -196,7 +195,7 @@ fn main() {
         let mut rng: rand::IsaacRng = rand::SeedableRng::from_seed(seed);
         let mut results = empty_results();
         results.bench_int(&mut rng, num_keys, max, || {
-            let s: HashSet<uint> = HashSet::new();
+            let s: HashSet<usize> = HashSet::new();
             s
         });
         results.bench_str(&mut rng, num_keys, || {
@@ -210,7 +209,7 @@ fn main() {
         let mut rng: rand::IsaacRng = rand::SeedableRng::from_seed(seed);
         let mut results = empty_results();
         results.bench_int(&mut rng, num_keys, max, || {
-            let s: BTreeSet<uint> = BTreeSet::new();
+            let s: BTreeSet<usize> = BTreeSet::new();
             s
         });
         results.bench_str(&mut rng, num_keys, || {

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -16,7 +16,6 @@
 use std::old_io::File;
 use std::iter::repeat;
 use std::mem::swap;
-use std::os;
 use std::env;
 use std::rand::Rng;
 use std::rand;
@@ -25,8 +24,7 @@ use std::time::Duration;
 use std::vec;
 
 fn main() {
-    let argv = os::args();
-    let _tests = &argv[1..argv.len()];
+    let argv: Vec<String> = env::args().collect();
 
     macro_rules! bench {
         ($id:ident) =>

--- a/src/test/bench/core-uint-to-str.rs
+++ b/src/test/bench/core-uint-to-str.rs
@@ -8,17 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os;
 use std::env;
 
 fn main() {
-    let args = os::args();
+    let args = env::args();
     let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "10000000".to_string())
     } else if args.len() <= 1u {
         vec!("".to_string(), "100000".to_string())
     } else {
-        args.into_iter().collect()
+        args.collect()
     };
 
     let n = args[1].parse().unwrap();

--- a/src/test/bench/msgsend-pipes-shared.rs
+++ b/src/test/bench/msgsend-pipes-shared.rs
@@ -19,7 +19,6 @@
 // version.
 
 use std::sync::mpsc::{channel, Sender, Receiver};
-use std::os;
 use std::env;
 use std::thread::Thread;
 use std::time::Duration;
@@ -94,13 +93,13 @@ fn run(args: &[String]) {
 }
 
 fn main() {
-    let args = os::args();
+    let args = env::args();
     let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "1000000".to_string(), "10000".to_string())
-    } else if args.len() <= 1u {
+    } else if args.len() <= 1 {
         vec!("".to_string(), "10000".to_string(), "4".to_string())
     } else {
-        args.into_iter().map(|x| x.to_string()).collect()
+        args.map(|x| x.to_string()).collect()
     };
 
     println!("{:?}", args);

--- a/src/test/bench/msgsend-pipes.rs
+++ b/src/test/bench/msgsend-pipes.rs
@@ -15,7 +15,6 @@
 // I *think* it's the same, more or less.
 
 use std::sync::mpsc::{channel, Sender, Receiver};
-use std::os;
 use std::env;
 use std::thread::Thread;
 use std::time::Duration;
@@ -101,13 +100,13 @@ fn run(args: &[String]) {
 }
 
 fn main() {
-    let args = os::args();
+    let args = env::args();
     let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "1000000".to_string(), "8".to_string())
-    } else if args.len() <= 1u {
+    } else if args.len() <= 1 {
         vec!("".to_string(), "10000".to_string(), "4".to_string())
     } else {
-        args.clone().into_iter().map(|x| x.to_string()).collect()
+        args.map(|x| x.to_string()).collect()
     };
 
     println!("{:?}", args);

--- a/src/test/bench/msgsend-ring-mutex-arcs.rs
+++ b/src/test/bench/msgsend-ring-mutex-arcs.rs
@@ -18,7 +18,6 @@
 // no-pretty-expanded FIXME #15189
 // ignore-lexer-test FIXME #15679
 
-use std::os;
 use std::env;
 use std::sync::{Arc, Future, Mutex, Condvar};
 use std::time::Duration;
@@ -64,13 +63,13 @@ fn thread_ring(i: uint, count: uint, num_chan: pipe, num_port: pipe) {
 }
 
 fn main() {
-    let args = os::args();
+    let args = env::args();
     let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "100".to_string(), "10000".to_string())
-    } else if args.len() <= 1u {
+    } else if args.len() <= 1 {
         vec!("".to_string(), "10".to_string(), "100".to_string())
     } else {
-        args.clone().into_iter().collect()
+        args.collect()
     };
 
     let num_tasks = args[1].parse::<uint>().unwrap();

--- a/src/test/bench/rt-messaging-ping-pong.rs
+++ b/src/test/bench/rt-messaging-ping-pong.rs
@@ -18,7 +18,7 @@
 // except according to those terms.
 
 use std::sync::mpsc::channel;
-use std::os;
+use std::env;
 use std::thread::Thread;
 
 // This is a simple bench that creates M pairs of tasks. These
@@ -26,10 +26,10 @@ use std::thread::Thread;
 // canonical message-passing benchmark as it heavily strains message
 // passing and almost nothing else.
 
-fn ping_pong_bench(n: uint, m: uint) {
+fn ping_pong_bench(n: usize, m: usize) {
 
     // Create pairs of tasks that pingpong back and forth.
-    fn run_pair(n: uint) {
+    fn run_pair(n: usize) {
         // Create a channel: A->B
         let (atx, arx) = channel();
         // Create a channel: B->A
@@ -63,19 +63,13 @@ fn ping_pong_bench(n: uint, m: uint) {
 
 
 fn main() {
-
-    let args = os::args();
-    let args = args;
-    let n = if args.len() == 3 {
-        args[1].parse::<uint>().unwrap()
+    let mut args = env::args();
+    let (n, m) = if args.len() == 3 {
+        let n = args.nth(1).unwrap().parse::<usize>().unwrap();
+        let m = args.next().unwrap().parse::<usize>().unwrap();
+        (n, m)
     } else {
-        10000
-    };
-
-    let m = if args.len() == 3 {
-        args[2].parse::<uint>().unwrap()
-    } else {
-        4
+        (10000, 4)
     };
 
     ping_pong_bench(n, m);

--- a/src/test/bench/rt-parfib.rs
+++ b/src/test/bench/rt-parfib.rs
@@ -9,14 +9,14 @@
 // except according to those terms.
 
 use std::sync::mpsc::channel;
-use std::os;
+use std::env;
 use std::thread::Thread;
 
 // A simple implementation of parfib. One subtree is found in a new
 // task and communicated over a oneshot pipe, the other is found
 // locally. There is no sequential-mode threshold.
 
-fn parfib(n: uint) -> uint {
+fn parfib(n: u64) -> u64 {
     if n == 0 || n == 1 {
         return 1;
     }
@@ -30,11 +30,9 @@ fn parfib(n: uint) -> uint {
 }
 
 fn main() {
-
-    let args = os::args();
-    let args = args;
+    let mut args = env::args();
     let n = if args.len() == 2 {
-        args[1].parse::<uint>().unwrap()
+        args.nth(1).unwrap().parse::<u64>().unwrap()
     } else {
         10
     };

--- a/src/test/bench/shootout-ackermann.rs
+++ b/src/test/bench/shootout-ackermann.rs
@@ -8,10 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os;
 use std::env;
 
-fn ack(m: int, n: int) -> int {
+fn ack(m: i64, n: i64) -> i64 {
     if m == 0 {
         return n + 1
     } else {
@@ -24,13 +23,13 @@ fn ack(m: int, n: int) -> int {
 }
 
 fn main() {
-    let args = os::args();
+    let mut args = env::args();
     let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "12".to_string())
-    } else if args.len() <= 1u {
+    } else if args.len() <= 1 {
         vec!("".to_string(), "8".to_string())
     } else {
-        args.into_iter().collect()
+        args.collect()
     };
     let n = args[1].parse().unwrap();
     println!("Ack(3,{}): {}\n", n, ack(3, n));

--- a/src/test/bench/shootout-binarytrees.rs
+++ b/src/test/bench/shootout-binarytrees.rs
@@ -84,14 +84,13 @@ fn inner(depth: i32, iterations: i32) -> String {
 }
 
 fn main() {
-    let args = std::os::args();
-    let args = args;
+    let mut args = std::env::args();
     let n = if std::env::var_os("RUST_BENCH").is_some() {
         17
-    } else if args.len() <= 1u {
+    } else if args.len() <= 1 {
         8
     } else {
-        args[1].parse().unwrap()
+        args.nth(1).unwrap().parse().unwrap()
     };
     let min_depth = 4;
     let max_depth = if min_depth + 2 > n {min_depth + 2} else {n};

--- a/src/test/bench/shootout-chameneos-redux.rs
+++ b/src/test/bench/shootout-chameneos-redux.rs
@@ -230,10 +230,10 @@ fn main() {
     let nn = if std::env::var_os("RUST_BENCH").is_some() {
         200000
     } else {
-        std::os::args()
-                       .get(1)
+        std::env::args()
+                       .nth(1)
                        .and_then(|arg| arg.parse().ok())
-                       .unwrap_or(600u)
+                       .unwrap_or(600us)
     };
 
     print_complements();

--- a/src/test/bench/shootout-fannkuch-redux.rs
+++ b/src/test/bench/shootout-fannkuch-redux.rs
@@ -180,8 +180,8 @@ fn fannkuch(n: i32) -> (i32, i32) {
 }
 
 fn main() {
-    let n = std::os::args()
-        .get(1)
+    let n = std::env::args()
+        .nth(1)
         .and_then(|arg| arg.parse().ok())
         .unwrap_or(2i32);
 

--- a/src/test/bench/shootout-fasta-redux.rs
+++ b/src/test/bench/shootout-fasta-redux.rs
@@ -41,11 +41,11 @@
 use std::cmp::min;
 use std::old_io::{stdout, IoResult};
 use std::iter::repeat;
-use std::os;
+use std::env;
 use std::slice::bytes::copy_memory;
 
-const LINE_LEN: uint = 60;
-const LOOKUP_SIZE: uint = 4 * 1024;
+const LINE_LEN: usize = 60;
+const LOOKUP_SIZE: usize = 4 * 1024;
 const LOOKUP_SCALE: f32 = (LOOKUP_SIZE - 1) as f32;
 
 // Random number generator constants
@@ -119,7 +119,7 @@ impl<'a, W: Writer> RepeatFasta<'a, W> {
         RepeatFasta { alu: alu, out: w }
     }
 
-    fn make(&mut self, n: uint) -> IoResult<()> {
+    fn make(&mut self, n: usize) -> IoResult<()> {
         let alu_len = self.alu.len();
         let mut buf = repeat(0u8).take(alu_len + LINE_LEN).collect::<Vec<_>>();
         let alu: &[u8] = self.alu.as_bytes();
@@ -188,19 +188,19 @@ impl<'a, W: Writer> RandomFasta<'a, W> {
         0
     }
 
-    fn make(&mut self, n: uint) -> IoResult<()> {
+    fn make(&mut self, n: usize) -> IoResult<()> {
         let lines = n / LINE_LEN;
         let chars_left = n % LINE_LEN;
         let mut buf = [0;LINE_LEN + 1];
 
         for _ in 0..lines {
-            for i in 0u..LINE_LEN {
+            for i in 0..LINE_LEN {
                 buf[i] = self.nextc();
             }
             buf[LINE_LEN] = '\n' as u8;
             try!(self.out.write(&buf));
         }
-        for i in 0u..chars_left {
+        for i in 0..chars_left {
             buf[i] = self.nextc();
         }
         self.out.write(&buf[..chars_left])
@@ -208,10 +208,9 @@ impl<'a, W: Writer> RandomFasta<'a, W> {
 }
 
 fn main() {
-    let args = os::args();
-    let args = args;
+    let mut args = env::args();
     let n = if args.len() > 1 {
-        args[1].parse::<uint>().unwrap()
+        args.nth(1).unwrap().parse::<usize>().unwrap()
     } else {
         5
     };

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -42,10 +42,9 @@ use std::cmp::min;
 use std::old_io::{BufferedWriter, File};
 use std::old_io;
 use std::num::Float;
-use std::os;
 use std::env;
 
-const LINE_LENGTH: uint = 60;
+const LINE_LENGTH: usize = 60;
 const IM: u32 = 139968;
 
 struct MyRandom {
@@ -86,7 +85,7 @@ impl<'a> Iterator for AAGen<'a> {
 }
 
 fn make_fasta<W: Writer, I: Iterator<Item=u8>>(
-    wr: &mut W, header: &str, mut it: I, mut n: uint)
+    wr: &mut W, header: &str, mut it: I, mut n: usize)
     -> std::old_io::IoResult<()>
 {
     try!(wr.write(header.as_bytes()));
@@ -104,14 +103,13 @@ fn make_fasta<W: Writer, I: Iterator<Item=u8>>(
 }
 
 fn run<W: Writer>(writer: &mut W) -> std::old_io::IoResult<()> {
-    let args = os::args();
-    let args = args;
+    let mut args = env::args();
     let n = if env::var_os("RUST_BENCH").is_some() {
         25000000
-    } else if args.len() <= 1u {
+    } else if args.len() <= 1 {
         1000
     } else {
-        args[1].parse().unwrap()
+        args.nth(1).unwrap().parse().unwrap()
     };
 
     let rng = &mut MyRandom::new();

--- a/src/test/bench/shootout-fibo.rs
+++ b/src/test/bench/shootout-fibo.rs
@@ -8,10 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os;
 use std::env;
 
-fn fib(n: int) -> int {
+fn fib(n: i64) -> i64 {
     if n < 2 {
         return 1;
     } else {
@@ -20,13 +19,13 @@ fn fib(n: int) -> int {
 }
 
 fn main() {
-    let args = os::args();
+    let args = env::args();
     let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "40".to_string())
-    } else if args.len() <= 1u {
+    } else if args.len() <= 1 {
         vec!("".to_string(), "30".to_string())
     } else {
-        args.into_iter().collect()
+        args.collect()
     };
     let n = args[1].parse().unwrap();
     println!("{}\n", fib(n));

--- a/src/test/bench/shootout-mandelbrot.rs
+++ b/src/test/bench/shootout-mandelbrot.rs
@@ -43,7 +43,7 @@
 // ignore-pretty very bad with line comments
 
 use std::old_io;
-use std::os;
+use std::env;
 use std::simd::f64x2;
 use std::sync::Arc;
 use std::thread::Thread;
@@ -197,13 +197,13 @@ fn write_line(init_i: f64, vec_init_r: &[f64], res: &mut Vec<u8>) {
 }
 
 fn main() {
-    let args = os::args();
+    let mut args = env::args();
     let res = if args.len() < 2 {
         println!("Test mode: do not dump the image because it's not utf8, \
                   which interferes with the test runner.");
         mandelbrot(1000, old_io::util::NullWriter)
     } else {
-        mandelbrot(args[1].parse().unwrap(), old_io::stdout())
+        mandelbrot(args.nth(1).unwrap().parse().unwrap(), old_io::stdout())
     };
     res.unwrap();
 }

--- a/src/test/bench/shootout-nbody.rs
+++ b/src/test/bench/shootout-nbody.rs
@@ -173,7 +173,7 @@ fn main() {
     let n = if std::env::var_os("RUST_BENCH").is_some() {
         5000000
     } else {
-        std::os::args().get(1)
+        std::env::args().nth(1)
             .and_then(|arg| arg.parse().ok())
             .unwrap_or(1000)
     };

--- a/src/test/bench/shootout-pfib.rs
+++ b/src/test/bench/shootout-pfib.rs
@@ -21,14 +21,13 @@
 extern crate getopts;
 
 use std::sync::mpsc::{channel, Sender};
-use std::os;
 use std::env;
 use std::result::Result::{Ok, Err};
 use std::thread::Thread;
 use std::time::Duration;
 
-fn fib(n: int) -> int {
-    fn pfib(tx: &Sender<int>, n: int) {
+fn fib(n: isize) -> isize {
+    fn pfib(tx: &Sender<isize>, n: isize) {
         if n == 0 {
             tx.send(0).unwrap();
         } else if n <= 2 {
@@ -66,7 +65,7 @@ fn parse_opts(argv: Vec<String> ) -> Config {
     }
 }
 
-fn stress_task(id: int) {
+fn stress_task(id: isize) {
     let mut i = 0;
     loop {
         let n = 15;
@@ -89,13 +88,13 @@ fn stress(num_tasks: int) {
 }
 
 fn main() {
-    let args = os::args();
+    let args = env::args();
     let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "20".to_string())
-    } else if args.len() <= 1u {
+    } else if args.len() <= 1 {
         vec!("".to_string(), "8".to_string())
     } else {
-        args.into_iter().map(|x| x.to_string()).collect()
+        args.map(|x| x.to_string()).collect()
     };
 
     let opts = parse_opts(args.clone());
@@ -103,12 +102,12 @@ fn main() {
     if opts.stress {
         stress(2);
     } else {
-        let max = args[1].parse::<int>().unwrap();
+        let max = args[1].parse::<isize>().unwrap();
 
         let num_trials = 10;
 
         for n in 1..max + 1 {
-            for _ in 0u..num_trials {
+            for _ in 0..num_trials {
                 let mut fibn = None;
                 let dur = Duration::span(|| fibn = Some(fib(n)));
                 let fibn = fibn.unwrap();

--- a/src/test/bench/shootout-spectralnorm.rs
+++ b/src/test/bench/shootout-spectralnorm.rs
@@ -53,13 +53,13 @@ use std::raw::Repr;
 use std::simd::f64x2;
 
 fn main() {
-    let args = os::args();
+    let mut args = env::args();
     let answer = spectralnorm(if env::var_os("RUST_BENCH").is_some() {
         5500
     } else if args.len() < 2 {
         2000
     } else {
-        args[1].parse().unwrap()
+        args.nth(1).unwrap().parse().unwrap()
     });
     println!("{:.9}", answer);
 }

--- a/src/test/bench/shootout-threadring.rs
+++ b/src/test/bench/shootout-threadring.rs
@@ -64,13 +64,13 @@ fn roundtrip(id: i32, tx: Sender<i32>, rx: Receiver<i32>) {
 }
 
 fn main() {
-    let args = std::os::args();
+    let mut args = std::env::args();
     let token = if std::env::var_os("RUST_BENCH").is_some() {
         2000000
     } else {
-        args.get(1).and_then(|arg| arg.parse().ok()).unwrap_or(1000)
+        args.nth(1).and_then(|arg| arg.parse().ok()).unwrap_or(1000)
     };
-    let n_tasks = args.get(2)
+    let n_tasks = args.next()
                       .and_then(|arg| arg.parse().ok())
                       .unwrap_or(503);
 

--- a/src/test/bench/std-smallintmap.rs
+++ b/src/test/bench/std-smallintmap.rs
@@ -11,41 +11,40 @@
 // Microbenchmark for the smallintmap library
 
 use std::collections::VecMap;
-use std::os;
 use std::env;
 use std::time::Duration;
 
-fn append_sequential(min: uint, max: uint, map: &mut VecMap<uint>) {
+fn append_sequential(min: usize, max: usize, map: &mut VecMap<usize>) {
     for i in min..max {
-        map.insert(i, i + 22u);
+        map.insert(i, i + 22);
     }
 }
 
-fn check_sequential(min: uint, max: uint, map: &VecMap<uint>) {
+fn check_sequential(min: usize, max: usize, map: &VecMap<usize>) {
     for i in min..max {
-        assert_eq!(map[i], i + 22u);
+        assert_eq!(map[i], i + 22);
     }
 }
 
 fn main() {
-    let args = os::args();
+    let args = env::args();
     let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "100000".to_string(), "100".to_string())
-    } else if args.len() <= 1u {
+    } else if args.len() <= 1 {
         vec!("".to_string(), "10000".to_string(), "50".to_string())
     } else {
-        args.into_iter().collect()
+        args.collect()
     };
-    let max = args[1].parse::<uint>().unwrap();
-    let rep = args[2].parse::<uint>().unwrap();
+    let max = args[1].parse::<usize>().unwrap();
+    let rep = args[2].parse::<usize>().unwrap();
 
     let mut checkf = Duration::seconds(0);
     let mut appendf = Duration::seconds(0);
 
-    for _ in 0u..rep {
+    for _ in 0..rep {
         let mut map = VecMap::new();
-        let d1 = Duration::span(|| append_sequential(0u, max, &mut map));
-        let d2 = Duration::span(|| check_sequential(0u, max, &map));
+        let d1 = Duration::span(|| append_sequential(0, max, &mut map));
+        let d2 = Duration::span(|| check_sequential(0, max, &map));
 
         checkf = checkf + d2;
         appendf = appendf + d1;

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -18,7 +18,7 @@ use std::old_io::stdio::StdReader;
 use std::old_io;
 use std::iter::repeat;
 use std::num::Int;
-use std::os;
+use std::env;
 
 // Computes a single solution to a given 9x9 sudoku
 //
@@ -269,8 +269,8 @@ fn check_DEFAULT_SUDOKU_solution() {
 }
 
 fn main() {
-    let args        = os::args();
-    let use_default = args.len() == 1u;
+    let args        = env::args();
+    let use_default = args.len() == 1;
     let mut sudoku = if use_default {
         Sudoku::from_vec(&DEFAULT_SUDOKU)
     } else {

--- a/src/test/bench/task-perf-jargon-metal-smoke.rs
+++ b/src/test/bench/task-perf-jargon-metal-smoke.rs
@@ -18,7 +18,6 @@
 // ignore-pretty very bad with line comments
 
 use std::sync::mpsc::{channel, Sender};
-use std::os;
 use std::env;
 use std::thread::Thread;
 
@@ -39,13 +38,13 @@ fn child_generation(gens_left: uint, tx: Sender<()>) {
 }
 
 fn main() {
-    let args = os::args();
+    let args = env::args();
     let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "100000".to_string())
     } else if args.len() <= 1 {
         vec!("".to_string(), "100".to_string())
     } else {
-        args.clone().into_iter().collect()
+        args.collect()
     };
 
     let (tx, rx) = channel();

--- a/src/test/bench/task-perf-spawnalot.rs
+++ b/src/test/bench/task-perf-spawnalot.rs
@@ -8,11 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os;
 use std::env;
 use std::thread::Thread;
 
-fn f(n: uint) {
+fn f(n: usize) {
     let mut i = 0u;
     while i < n {
         let _ = Thread::scoped(move|| g()).join();
@@ -23,15 +22,15 @@ fn f(n: uint) {
 fn g() { }
 
 fn main() {
-    let args = os::args();
+    let args = env::args();
     let args = if env::var_os("RUST_BENCH").is_some() {
         vec!("".to_string(), "400".to_string())
-    } else if args.len() <= 1u {
+    } else if args.len() <= 1 {
         vec!("".to_string(), "10".to_string())
     } else {
-        args.into_iter().collect()
+        args.collect()
     };
     let n = args[1].parse().unwrap();
-    let mut i = 0u;
+    let mut i = 0;
     while i < n { Thread::spawn(move|| f(n) ); i += 1u; }
 }

--- a/src/test/run-fail/tls-exit-status.rs
+++ b/src/test/run-fail/tls-exit-status.rs
@@ -11,9 +11,9 @@
 // error-pattern:nonzero
 // exec-env:RUST_NEWRT=1
 
-use std::os;
+use std::env;
 
 fn main() {
-    os::args();
+    env::args();
     panic!("please have a nonzero exit status");
 }

--- a/src/test/run-make/cannot-read-embedded-idents/create_and_compile.rs
+++ b/src/test/run-make/cannot-read-embedded-idents/create_and_compile.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os;
+use std::env;
 use std::old_io::{File, Command};
 
 // creates broken.rs, which has the Ident \x00name_0,ctxt_0\x00
@@ -16,7 +16,7 @@ use std::old_io::{File, Command};
 // provided `rustc`
 
 fn main() {
-    let args = os::args();
+    let args: Vec<String> = env::args().collect();
     let rustc = &args[1];
     let tmpdir = Path::new(&args[2]);
 

--- a/src/test/run-make/issue-19371/foo.rs
+++ b/src/test/run-make/issue-19371/foo.rs
@@ -22,7 +22,7 @@ fn main() {
     fn main() {}
     "#;
 
-    let args = std::os::args();
+    let args: Vec<String> = std::env::args().collect();
 
     if args.len() < 4 {
         panic!("expected rustc path");

--- a/src/test/run-make/unicode-input/multiple_files.rs
+++ b/src/test/run-make/unicode-input/multiple_files.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{char, os};
+use std::{char, env};
 use std::old_io::{File, Command};
 use std::rand::{thread_rng, Rng};
 
@@ -33,7 +33,7 @@ fn random_char() -> char {
 }
 
 fn main() {
-    let args = os::args();
+    let args: Vec<String> = env::args().collect();
     let rustc = &args[1];
     let tmpdir = Path::new(&args[2]);
 

--- a/src/test/run-make/unicode-input/span_length.rs
+++ b/src/test/run-make/unicode-input/span_length.rs
@@ -11,7 +11,7 @@
 use std::old_io::{File, Command};
 use std::iter::repeat;
 use std::rand::{thread_rng, Rng};
-use std::{char, os};
+use std::{char, env};
 
 // creates a file with `fn main() { <random ident> }` and checks the
 // compiler emits a span of the appropriate length (for the
@@ -33,7 +33,7 @@ fn random_char() -> char {
 }
 
 fn main() {
-    let args = os::args();
+    let args: Vec<String> = env::args().collect();
     let rustc = &args[1];
     let tmpdir = Path::new(&args[2]);
     let main_file = tmpdir.join("span_main.rs");

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -14,7 +14,6 @@
 #![feature(unboxed_closures)]
 #![feature(unsafe_destructor)]
 
-use std::os;
 use std::env;
 use std::old_io::process::Command;
 use std::str;
@@ -86,8 +85,7 @@ fn runtest(me: &str) {
 }
 
 fn main() {
-    let args = os::args();
-    let args = args;
+    let args: Vec<String> = env::args().collect();
     if args.len() >= 2 && args[1] == "fail" {
         foo();
     } else if args.len() >= 2 && args[1] == "double-fail" {

--- a/src/test/run-pass/cleanup-shortcircuit.rs
+++ b/src/test/run-pass/cleanup-shortcircuit.rs
@@ -20,11 +20,10 @@
 
 // Test that cleanups for the RHS of shortcircuiting operators work.
 
-use std::os;
+use std::env;
 
 pub fn main() {
-    let args = os::args();
-    let args = args;
+    let args: Vec<String> = env::args().collect();
 
     // Here, the rvalue `"signal".to_string()` requires cleanup. Older versions
     // of the code had a problem that the cleanup scope for this

--- a/src/test/run-pass/issue-10626.rs
+++ b/src/test/run-pass/issue-10626.rs
@@ -12,12 +12,11 @@
 // Make sure that if a process doesn't have its stdio/stderr descriptors set up
 // that we don't die in a large ball of fire
 
-use std::os;
+use std::env;
 use std::old_io::process;
 
 pub fn main () {
-    let args = os::args();
-    let args = args;
+    let args: Vec<String> = env::args().collect();
     if args.len() > 1 && args[1] == "child" {
         for _ in 0..1000 {
             println!("hello?");

--- a/src/test/run-pass/issue-13304.rs
+++ b/src/test/run-pass/issue-13304.rs
@@ -10,13 +10,12 @@
 
 // ignore-fast
 
-use std::os;
+use std::env;
 use std::old_io;
 use std::str;
 
 fn main() {
-    let args = os::args();
-    let args = args;
+    let args: Vec<String> = env::args().collect();
     if args.len() > 1 && args[1] == "child" {
         child();
     } else {
@@ -25,8 +24,7 @@ fn main() {
 }
 
 fn parent() {
-    let args = os::args();
-    let args = args;
+    let args: Vec<String> = env::args().collect();
     let mut p = old_io::process::Command::new(&args[0])
                                      .arg("child").spawn().unwrap();
     p.stdin.as_mut().unwrap().write_str("test1\ntest2\ntest3").unwrap();

--- a/src/test/run-pass/issue-14456.rs
+++ b/src/test/run-pass/issue-14456.rs
@@ -12,10 +12,10 @@
 use std::old_io::process;
 use std::old_io::Command;
 use std::old_io;
-use std::os;
+use std::env;
 
 fn main() {
-    let args = os::args();
+    let args: Vec<String> = env::args().collect();
     if args.len() > 1 && args[1] == "child" {
         return child()
     }
@@ -32,7 +32,7 @@ fn child() {
 }
 
 fn test() {
-    let args = os::args();
+    let args: Vec<String> = env::args().collect();
     let mut p = Command::new(&args[0]).arg("child")
                                      .stdin(process::Ignored)
                                      .stdout(process::Ignored)

--- a/src/test/run-pass/issue-14940.rs
+++ b/src/test/run-pass/issue-14940.rs
@@ -8,16 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os;
+use std::env;
 use std::old_io::{stdio, Command};
 
 fn main() {
-    let args = os::args();
+    let mut args = env::args();
     if args.len() > 1 {
         let mut out = stdio::stdout();
         out.write(&['a' as u8; 128 * 1024]).unwrap();
     } else {
-        let out = Command::new(&args[0]).arg("child").output();
+        let out = Command::new(&args.next().unwrap()).arg("child").output();
         let out = out.unwrap();
         assert!(out.status.success());
     }

--- a/src/test/run-pass/issue-16272.rs
+++ b/src/test/run-pass/issue-16272.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 use std::old_io::{process, Command};
-use std::os;
+use std::env;
 
 fn main() {
-    let len = os::args().len();
+    let len = env::args().len();
 
     if len == 1 {
         test();
@@ -22,7 +22,7 @@ fn main() {
 }
 
 fn test() {
-    let status = Command::new(os::self_exe_name().unwrap())
+    let status = Command::new(env::current_exe().unwrap())
                          .arg("foo").arg("")
                          .stdout(process::InheritFd(1))
                          .stderr(process::InheritFd(2))

--- a/src/test/run-pass/issue-20091.rs
+++ b/src/test/run-pass/issue-20091.rs
@@ -11,11 +11,11 @@
 // ignore-windows currently windows requires UTF-8 for spawning processes
 
 use std::old_io::Command;
-use std::os;
+use std::env;
 
 fn main() {
-    if os::args().len() == 1 {
-        assert!(Command::new(os::self_exe_name().unwrap()).arg(b"\xff")
+    if env::args().len() == 1 {
+        assert!(Command::new(env::current_exe().unwrap()).arg(b"\xff")
                         .status().unwrap().success())
     }
 }

--- a/src/test/run-pass/issue-4541.rs
+++ b/src/test/run-pass/issue-4541.rs
@@ -9,8 +9,7 @@
 // except according to those terms.
 
 fn parse_args() -> String {
-    let args = ::std::os::args();
-    let args = args;
+    let args: Vec<_> = ::std::env::args().collect();
     let mut n = 0;
 
     while n < args.len() {

--- a/src/test/run-pass/issue-4542.rs
+++ b/src/test/run-pass/issue-4542.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os;
+use std::env;
 
 pub fn main() {
-    for arg in &os::args() {
-        match (*arg).clone() {
+    for arg in env::args() {
+        match arg.clone() {
             _s => { }
         }
     }

--- a/src/test/run-pass/logging-separate-lines.rs
+++ b/src/test/run-pass/logging-separate-lines.rs
@@ -16,12 +16,11 @@
 extern crate log;
 
 use std::old_io::Command;
-use std::os;
+use std::env;
 use std::str;
 
 fn main() {
-    let args = os::args();
-    let args = args;
+    let args: Vec<String> = env::args().collect();
     if args.len() > 1 && args[1] == "child" {
         debug!("foo");
         debug!("bar");

--- a/src/test/run-pass/out-of-stack-new-thread-no-split.rs
+++ b/src/test/run-pass/out-of-stack-new-thread-no-split.rs
@@ -16,7 +16,7 @@
 #![feature(asm)]
 
 use std::old_io::process::Command;
-use std::os;
+use std::env;
 use std::thread::Thread;
 
 // lifted from the test module
@@ -34,8 +34,7 @@ fn recurse() {
 }
 
 fn main() {
-    let args = os::args();
-    let args = args;
+    let args: Vec<String> = env::args().collect();
     if args.len() > 1 && args[1] == "recurse" {
         let _t = Thread::scoped(recurse);
     } else {

--- a/src/test/run-pass/out-of-stack-no-split.rs
+++ b/src/test/run-pass/out-of-stack-no-split.rs
@@ -17,7 +17,7 @@
 #![feature(asm)]
 
 use std::old_io::process::Command;
-use std::os;
+use std::env;
 
 // lifted from the test module
 // Inlining to avoid llvm turning the recursive functions into tail calls,
@@ -34,7 +34,7 @@ fn recurse() {
 }
 
 fn main() {
-    let args = os::args();
+    let args: Vec<String> = env::args().collect();
     if args.len() > 1 && args[1] == "recurse" {
         recurse();
     } else {

--- a/src/test/run-pass/out-of-stack.rs
+++ b/src/test/run-pass/out-of-stack.rs
@@ -13,7 +13,7 @@
 #![feature(asm)]
 
 use std::old_io::process::Command;
-use std::os;
+use std::env;
 
 // lifted from the test module
 // Inlining to avoid llvm turning the recursive functions into tail calls,
@@ -34,8 +34,7 @@ fn loud_recurse() {
 }
 
 fn main() {
-    let args = os::args();
-    let args = args;
+    let args: Vec<String> = env::args().collect();
     if args.len() > 1 && args[1] == "silent" {
         silent_recurse();
     } else if args.len() > 1 && args[1] == "loud" {

--- a/src/test/run-pass/process-spawn-with-unicode-params.rs
+++ b/src/test/run-pass/process-spawn-with-unicode-params.rs
@@ -20,12 +20,13 @@ use std::old_io;
 use std::old_io::fs;
 use std::old_io::Command;
 use std::os;
+use std::env;
 use std::old_path::Path;
 
 fn main() {
-    let my_args = os::args();
+    let my_args = env::args().collect::<Vec<_>>();
     let my_cwd  = os::getcwd().unwrap();
-    let my_env  = os::env();
+    let my_env  = env::vars().collect::<Vec<_>>();
     let my_path = Path::new(os::self_exe_name().unwrap());
     let my_dir  = my_path.dir_path();
     let my_ext  = my_path.extension_str().unwrap_or("");

--- a/src/test/run-pass/segfault-no-out-of-stack.rs
+++ b/src/test/run-pass/segfault-no-out-of-stack.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 use std::old_io::process::Command;
-use std::os;
+use std::env;
 
 fn main() {
-    let args = os::args();
+    let args: Vec<String> = env::args().collect();
     if args.len() > 1 && args[1] == "segfault" {
         unsafe { *(0 as *mut int) = 1 }; // trigger a segfault
     } else {

--- a/src/test/run-pass/signal-exit-status.rs
+++ b/src/test/run-pass/signal-exit-status.rs
@@ -10,12 +10,11 @@
 
 // ignore-windows
 
-use std::os;
+use std::env;
 use std::old_io::process::{Command, ExitSignal, ExitStatus};
 
 pub fn main() {
-    let args = os::args();
-    let args = args;
+    let args: Vec<String> = env::args().collect();
     if args.len() >= 2 && args[1] == "signal" {
         // Raise a segfault.
         unsafe { *(0 as *mut int) = 0; }

--- a/src/test/run-pass/sigpipe-should-be-ignored.rs
+++ b/src/test/run-pass/sigpipe-should-be-ignored.rs
@@ -12,6 +12,7 @@
 // doesn't die in a ball of fire, but rather it's gracefully handled.
 
 use std::os;
+use std::env;
 use std::old_io::PipeStream;
 use std::old_io::Command;
 
@@ -25,8 +26,7 @@ fn test() {
 }
 
 fn main() {
-    let args = os::args();
-    let args = args;
+    let args: Vec<String> = env::args().collect();
     if args.len() > 1 && args[1] == "test" {
         return test();
     }


### PR DESCRIPTION
This commit mostly replaces some of the uses of os::args with env::args.

This, for obvious reasons is based on top of #22400. Do not r+ before that lands.
