### PR TITLE
change the signal used to test signal_reported_right

### DIFF
--- a/src/libstd/old_io/process.rs
+++ b/src/libstd/old_io/process.rs
@@ -800,12 +800,12 @@ mod tests {
     #[cfg(all(unix, not(target_os="android")))]
     #[test]
     fn signal_reported_right() {
-        let p = Command::new("/bin/sh").arg("-c").arg("kill -1 $$").spawn();
+        let p = Command::new("/bin/sh").arg("-c").arg("kill -9 $$").spawn();
         assert!(p.is_ok());
         let mut p = p.unwrap();
         match p.wait().unwrap() {
-            process::ExitSignal(1) => {},
-            result => panic!("not terminated by signal 1 (instead, {})", result),
+            process::ExitSignal(9) => {},
+            result => panic!("not terminated by signal 9 (instead, {})", result),
         }
     }
 

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -537,12 +537,12 @@ mod tests {
     fn signal_reported_right() {
         use os::unix::ExitStatusExt;
 
-        let p = Command::new("/bin/sh").arg("-c").arg("kill -1 $$").spawn();
+        let p = Command::new("/bin/sh").arg("-c").arg("kill -9 $$").spawn();
         assert!(p.is_ok());
         let mut p = p.unwrap();
         match p.wait().unwrap().signal() {
-            Some(1) => {},
-            result => panic!("not terminated by signal 1 (instead, {:?})", result),
+            Some(9) => {},
+            result => panic!("not terminated by signal 9 (instead, {:?})", result),
         }
     }
 


### PR DESCRIPTION
The test "signal_reported_right" send a signal `1` to `/bin/sh`, and check
the status code to check if the signal is reported right.

Under OpenBSD, the signal `1` (`SIGHUP`) is catched by `/bin/sh`,
resulting the test failed.

Use the uncatchable signal `9` (`SIGKILL`) for test.
