### PR TITLE
Stop advertisting the `old_impl_check` feature. 

### DIFF
--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1903,10 +1903,6 @@ fn enforce_impl_ty_params_are_constrained<'tcx>(tcx: &ty::ctxt<'tcx>,
                     "the type parameter `{}` is not constrained by the \
                              impl trait, self type, or predicates",
                             param_ty.user_string(tcx));
-                tcx.sess.span_help(
-                    ty_param.span,
-                    &format!("you can temporarily opt out of this rule by placing \
-                              the `#[old_impl_check]` attribute on the impl"));
             }
         }
     }


### PR DESCRIPTION
Stop advertisting the `old_impl_check` feature. We can't ENTIRELY remove it yet, but we don't have to add new uses.

r? @aturon 
