### PR TITLE
openbsd: adapt connect_error test

### DIFF
--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -247,7 +247,8 @@ mod tests {
     fn connect_error() {
         match TcpStream::connect("0.0.0.0:1") {
             Ok(..) => panic!(),
-            Err(e) => assert_eq!(e.kind(), ErrorKind::ConnectionRefused),
+            Err(e) => assert!((e.kind() == ErrorKind::ConnectionRefused)
+                              || (e.kind() == ErrorKind::InvalidInput)),
         }
     }
 

--- a/src/libstd/old_io/net/tcp.rs
+++ b/src/libstd/old_io/net/tcp.rs
@@ -494,6 +494,7 @@ mod test {
     use old_io::{EndOfFile, TimedOut, ShortWrite, IoError};
     use old_io::{ConnectionRefused, BrokenPipe, ConnectionAborted};
     use old_io::{ConnectionReset, NotConnected, PermissionDenied, OtherIoError};
+    use old_io::{InvalidInput};
     use old_io::{Acceptor, Listener};
 
     // FIXME #11530 this fails on android because tests are run as root
@@ -510,7 +511,8 @@ mod test {
     fn connect_error() {
         match TcpStream::connect("0.0.0.0:1") {
             Ok(..) => panic!(),
-            Err(e) => assert_eq!(e.kind, ConnectionRefused),
+            Err(e) => assert!((e.kind == ConnectionRefused)
+                              || (e.kind == InvalidInput)),
         }
     }
 


### PR DESCRIPTION
The `connect_error` test check if connecting to "0.0.0.0:1" works (it
shouldn't). And in case of error, the test expects a `ConnectionRefused`
error.

Under OpenBSD, trying to connect to "0.0.0.0" isn't a `ConnectionRefused`:
it is an `InvalidInput` error.

The patch allow the error to be `ConnectionRefused` or `InvalidInput`.

Another possibility is to check connecting to "127.0.0.1:1" and expects only `ConnectionRefused` error.
