### PR TITLE
std: Stabilize the IntoIterator trait

### DIFF
--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -666,6 +666,7 @@ impl<T: Ord> IntoIterator for BinaryHeap<T> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Ord> IntoIterator for BinaryHeap<T> {
     type Item = T;
     type IntoIter = IntoIter<T>;
@@ -686,6 +687,7 @@ impl<'a, T> IntoIterator for &'a BinaryHeap<T> where T: Ord {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> IntoIterator for &'a BinaryHeap<T> where T: Ord {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -1081,6 +1081,7 @@ impl<'a> IntoIterator for &'a Bitv {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> IntoIterator for &'a Bitv {
     type Item = bool;
     type IntoIter = Iter<'a>;
@@ -1905,6 +1906,7 @@ impl<'a> IntoIterator for &'a BitvSet {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> IntoIterator for &'a BitvSet {
     type Item = usize;
     type IntoIter = SetIter<'a>;

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -473,6 +473,7 @@ impl<K, V> IntoIterator for BTreeMap<K, V> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<K, V> IntoIterator for BTreeMap<K, V> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V>;
@@ -493,6 +494,7 @@ impl<'a, K, V> IntoIterator for &'a BTreeMap<K, V> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, K, V> IntoIterator for &'a BTreeMap<K, V> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;
@@ -513,6 +515,7 @@ impl<'a, K, V> IntoIterator for &'a mut BTreeMap<K, V> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, K, V> IntoIterator for &'a mut BTreeMap<K, V> {
     type Item = (&'a K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -491,6 +491,7 @@ impl<T> IntoIterator for BTreeSet<T> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> IntoIterator for BTreeSet<T> {
     type Item = T;
     type IntoIter = IntoIter<T>;
@@ -511,6 +512,7 @@ impl<'a, T> IntoIterator for &'a BTreeSet<T> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> IntoIterator for &'a BTreeSet<T> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;

--- a/src/libcollections/dlist.rs
+++ b/src/libcollections/dlist.rs
@@ -848,6 +848,7 @@ impl<T> IntoIterator for DList<T> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> IntoIterator for DList<T> {
     type Item = T;
     type IntoIter = IntoIter<T>;
@@ -868,6 +869,7 @@ impl<'a, T> IntoIterator for &'a DList<T> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> IntoIterator for &'a DList<T> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -268,6 +268,7 @@ impl<'a, E> IntoIterator for &'a EnumSet<E> where E: CLike {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, E> IntoIterator for &'a EnumSet<E> where E: CLike {
     type Item = E;
     type IntoIter = Iter<E>;

--- a/src/libcollections/ring_buf.rs
+++ b/src/libcollections/ring_buf.rs
@@ -1710,6 +1710,7 @@ impl<T> IntoIterator for RingBuf<T> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> IntoIterator for RingBuf<T> {
     type Item = T;
     type IntoIter = IntoIter<T>;
@@ -1730,6 +1731,7 @@ impl<'a, T> IntoIterator for &'a RingBuf<T> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> IntoIterator for &'a RingBuf<T> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
@@ -1750,6 +1752,7 @@ impl<'a, T> IntoIterator for &'a mut RingBuf<T> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> IntoIterator for &'a mut RingBuf<T> {
     type Item = &'a mut T;
     type IntoIter = IterMut<'a, T>;

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1425,6 +1425,7 @@ impl<T> IntoIterator for Vec<T> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> IntoIterator for Vec<T> {
     type Item = T;
     type IntoIter = IntoIter<T>;
@@ -1445,6 +1446,7 @@ impl<'a, T> IntoIterator for &'a Vec<T> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> IntoIterator for &'a Vec<T> {
     type Item = &'a T;
     type IntoIter = slice::Iter<'a, T>;
@@ -1465,6 +1467,7 @@ impl<'a, T> IntoIterator for &'a mut Vec<T> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> IntoIterator for &'a mut Vec<T> {
     type Item = &'a mut T;
     type IntoIter = slice::IterMut<'a, T>;

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -679,6 +679,7 @@ impl<T> IntoIterator for VecMap<T> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T> IntoIterator for VecMap<T> {
     type Item = (usize, T);
     type IntoIter = IntoIter<T>;
@@ -699,6 +700,7 @@ impl<'a, T> IntoIterator for &'a VecMap<T> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> IntoIterator for &'a VecMap<T> {
     type Item = (usize, &'a T);
     type IntoIter = Iter<'a, T>;
@@ -719,6 +721,7 @@ impl<'a, T> IntoIterator for &'a mut VecMap<T> {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> IntoIterator for &'a mut VecMap<T> {
     type Item = (usize, &'a mut T);
     type IntoIter = IterMut<'a, T>;

--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -59,6 +59,7 @@ macro_rules! array_impls {
             }
 
             #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+            #[stable(feature = "rust1", since = "1.0.0")]
             impl<'a, T> IntoIterator for &'a [T; $N] {
                 type Item = &'a T;
                 type IntoIter = Iter<'a, T>;
@@ -79,6 +80,7 @@ macro_rules! array_impls {
             }
 
             #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+            #[stable(feature = "rust1", since = "1.0.0")]
             impl<'a, T> IntoIterator for &'a mut [T; $N] {
                 type Item = &'a mut T;
                 type IntoIter = IterMut<'a, T>;

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -131,8 +131,12 @@ pub trait IntoIterator {
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
 /// Conversion into an `Iterator`
+#[stable(feature = "rust1", since = "1.0.0")]
 pub trait IntoIterator {
+    #[stable(feature = "rust1", since = "1.0.0")]
     type Item;
+
+    #[stable(feature = "rust1", since = "1.0.0")]
     type IntoIter: Iterator<Item=Self::Item>;
 
     /// Consumes `Self` and returns an iterator over it
@@ -151,6 +155,7 @@ impl<I> IntoIterator for I where I: Iterator {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<I: Iterator> IntoIterator for I {
     type Item = I::Item;
     type IntoIter = I;

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -637,6 +637,7 @@ impl<'a, T> IntoIterator for &'a [T] {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> IntoIterator for &'a [T] {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
@@ -657,6 +658,7 @@ impl<'a, T> IntoIterator for &'a mut [T] {
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> IntoIterator for &'a mut [T] {
     type Item = &'a mut T;
     type IntoIter = IterMut<'a, T>;

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1387,6 +1387,7 @@ impl<'a, K, V, S, H> IntoIterator for &'a HashMap<K, V, S>
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, K, V, S, H> IntoIterator for &'a HashMap<K, V, S>
     where K: Eq + Hash<H>,
           S: HashState<Hasher=H>,
@@ -1415,6 +1416,7 @@ impl<'a, K, V, S, H> IntoIterator for &'a mut HashMap<K, V, S>
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, K, V, S, H> IntoIterator for &'a mut HashMap<K, V, S>
     where K: Eq + Hash<H>,
           S: HashState<Hasher=H>,
@@ -1443,6 +1445,7 @@ impl<K, V, S, H> IntoIterator for HashMap<K, V, S>
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<K, V, S, H> IntoIterator for HashMap<K, V, S>
     where K: Eq + Hash<H>,
           S: HashState<Hasher=H>,

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -850,6 +850,7 @@ impl<'a, T, S, H> IntoIterator for &'a HashSet<T, S>
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T, S, H> IntoIterator for &'a HashSet<T, S>
     where T: Eq + Hash<H>,
           S: HashState<Hasher=H>,
@@ -878,6 +879,7 @@ impl<T, S, H> IntoIterator for HashSet<T, S>
 }
 
 #[cfg(not(stage0))]  // NOTE(stage0): remove cfg after a snapshot
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<T, S, H> IntoIterator for HashSet<T, S>
     where T: Eq + Hash<H>,
           S: HashState<Hasher=H>,


### PR DESCRIPTION
Now that the necessary associated types exist for the `IntoIterator` trait this
commit stabilizes the trait as-is as well as all existing implementations.
