### PR TITLE
Rc itself isn't immutable.

### DIFF
--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -170,7 +170,7 @@ struct RcBox<T> {
     weak: Cell<usize>
 }
 
-/// An immutable reference-counted pointer type.
+/// A reference-counted pointer type over an immutable value.
 ///
 /// See the [module level documentation](./index.html) for more details.
 #[unsafe_no_drop_flag]


### PR DESCRIPTION
An "immutable reference-counted pointer" is confusing, one might think that the `Rc` itself is immutable which isn't the case.
cf. http://www.reddit.com/r/rust/comments/2w75wr/how_do_i_read_immutable_vector_inside_a_spawned/coo6mm2
