### PR TITLE
Audit core `borrow`, `cmp`, `default`, and `intrinsics` modules for proper integer usage

### DIFF
--- a/src/libcore/borrow.rs
+++ b/src/libcore/borrow.rs
@@ -124,7 +124,7 @@ impl<T> ToOwned<T> for T where T: Clone {
 /// ```rust
 /// use std::borrow::Cow;
 ///
-/// fn abs_all(input: &mut Cow<Vec<int>, [int]>) {
+/// fn abs_all(input: &mut Cow<Vec<i32>, [i32]>) {
 ///     for i in 0..input.len() {
 ///         let v = input[i];
 ///         if v < 0 {

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -215,7 +215,7 @@ impl Ord for Ordering {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn cmp(&self, other: &Ordering) -> Ordering {
-        (*self as int).cmp(&(*other as int))
+        (*self as i32).cmp(&(*other as i32))
     }
 }
 
@@ -224,7 +224,7 @@ impl PartialOrd for Ordering {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn partial_cmp(&self, other: &Ordering) -> Option<Ordering> {
-        (*self as int).partial_cmp(&(*other as int))
+        (*self as i32).partial_cmp(&(*other as i32))
     }
 }
 
@@ -482,7 +482,7 @@ mod impls {
     }
 
     partial_eq_impl! {
-        bool char uint u8 u16 u32 u64 int i8 i16 i32 i64 f32 f64
+        bool char usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64
     }
 
     macro_rules! eq_impl {
@@ -492,7 +492,7 @@ mod impls {
         )*)
     }
 
-    eq_impl! { () bool char uint u8 u16 u32 u64 int i8 i16 i32 i64 }
+    eq_impl! { () bool char usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
 
     macro_rules! partial_ord_impl {
         ($($t:ty)*) => ($(
@@ -535,7 +535,7 @@ mod impls {
         }
     }
 
-    partial_ord_impl! { char uint u8 u16 u32 u64 int i8 i16 i32 i64 f32 f64 }
+    partial_ord_impl! { char usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 
     macro_rules! ord_impl {
         ($($t:ty)*) => ($(
@@ -565,7 +565,7 @@ mod impls {
         }
     }
 
-    ord_impl! { char uint u8 u16 u32 u64 int i8 i16 i32 i64 }
+    ord_impl! { char usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
 
     // & pointers
 

--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -16,7 +16,7 @@
 //!
 //! ```
 //! struct SomeOptions {
-//!     foo: int,
+//!     foo: i32,
 //!     bar: f32,
 //! }
 //! ```
@@ -28,7 +28,7 @@
 //!
 //! #[derive(Default)]
 //! struct SomeOptions {
-//!     foo: int,
+//!     foo: i32,
 //!     bar: f32,
 //! }
 //!
@@ -56,7 +56,7 @@
 //!
 //! #[derive(Default)]
 //! struct SomeOptions {
-//!     foo: int,
+//!     foo: i32,
 //!     bar: f32,
 //!     baz: Kind,
 //! }
@@ -73,7 +73,7 @@
 //! # use std::default::Default;
 //! # #[derive(Default)]
 //! # struct SomeOptions {
-//! #     foo: int,
+//! #     foo: i32,
 //! #     bar: f32,
 //! # }
 //! fn main() {
@@ -93,7 +93,7 @@
 /// ```
 /// #[derive(Default)]
 /// struct SomeOptions {
-///     foo: int,
+///     foo: i32,
 ///     bar: f32,
 /// }
 /// ```
@@ -113,7 +113,7 @@ pub trait Default {
     ///
     /// let i: i8 = Default::default();
     /// let (x, y): (Option<String>, f64) = Default::default();
-    /// let (a, b, (c, d)): (int, uint, (bool, bool)) = Default::default();
+    /// let (a, b, (c, d)): (i32, u32, (bool, bool)) = Default::default();
     /// ```
     ///
     /// Making your own:
@@ -150,13 +150,13 @@ default_impl! { (), () }
 default_impl! { bool, false }
 default_impl! { char, '\x00' }
 
-default_impl! { uint, 0 }
+default_impl! { usize, 0 }
 default_impl! { u8, 0 }
 default_impl! { u16, 0 }
 default_impl! { u32, 0 }
 default_impl! { u64, 0 }
 
-default_impl! { int, 0 }
+default_impl! { isize, 0 }
 default_impl! { i8, 0 }
 default_impl! { i16, 0 }
 default_impl! { i32, 0 }

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -50,10 +50,10 @@ pub type GlueFn = extern "Rust" fn(*const i8);
 #[derive(Copy)]
 pub struct TyDesc {
     // sizeof(T)
-    pub size: uint,
+    pub size: usize,
 
     // alignof(T)
-    pub align: uint,
+    pub align: usize,
 
     // Called when a value of type `T` is no longer needed
     pub drop_glue: GlueFn,
@@ -186,15 +186,15 @@ extern "rust-intrinsic" {
     /// would *exactly* overwrite a value. When laid out in vectors
     /// and structures there may be additional padding between
     /// elements.
-    pub fn size_of<T>() -> uint;
+    pub fn size_of<T>() -> usize;
 
     /// Move a value to an uninitialized memory location.
     ///
     /// Drop glue is not run on the destination.
     pub fn move_val_init<T>(dst: &mut T, src: T);
 
-    pub fn min_align_of<T>() -> uint;
-    pub fn pref_align_of<T>() -> uint;
+    pub fn min_align_of<T>() -> usize;
+    pub fn pref_align_of<T>() -> usize;
 
     /// Get a static pointer to a type descriptor.
     pub fn get_tydesc<T: ?Sized>() -> *const TyDesc;
@@ -253,7 +253,7 @@ extern "rust-intrinsic" {
     ///
     /// This is implemented as an intrinsic to avoid converting to and from an
     /// integer, since the conversion would throw away aliasing information.
-    pub fn offset<T>(dst: *const T, offset: int) -> *const T;
+    pub fn offset<T>(dst: *const T, offset: isize) -> *const T;
 
     /// Copies `count * size_of<T>` bytes from `src` to `dst`. The source
     /// and destination may *not* overlap.
@@ -294,7 +294,7 @@ extern "rust-intrinsic" {
     /// }
     /// ```
     #[unstable(feature = "core")]
-    pub fn copy_nonoverlapping_memory<T>(dst: *mut T, src: *const T, count: uint);
+    pub fn copy_nonoverlapping_memory<T>(dst: *mut T, src: *const T, count: usize);
 
     /// Copies `count * size_of<T>` bytes from `src` to `dst`. The source
     /// and destination may overlap.
@@ -324,13 +324,13 @@ extern "rust-intrinsic" {
     /// ```
     ///
     #[unstable(feature = "core")]
-    pub fn copy_memory<T>(dst: *mut T, src: *const T, count: uint);
+    pub fn copy_memory<T>(dst: *mut T, src: *const T, count: usize);
 
     /// Invokes memset on the specified pointer, setting `count * size_of::<T>()`
     /// bytes of memory starting at `dst` to `c`.
     #[unstable(feature = "core",
                reason = "uncertain about naming and semantics")]
-    pub fn set_memory<T>(dst: *mut T, val: u8, count: uint);
+    pub fn set_memory<T>(dst: *mut T, val: u8, count: usize);
 
     /// Equivalent to the appropriate `llvm.memcpy.p0i8.0i8.*` intrinsic, with
     /// a size of `count` * `size_of::<T>()` and an alignment of
@@ -338,19 +338,19 @@ extern "rust-intrinsic" {
     ///
     /// The volatile parameter parameter is set to `true`, so it will not be optimized out.
     pub fn volatile_copy_nonoverlapping_memory<T>(dst: *mut T, src: *const T,
-                                                  count: uint);
+                                                  count: usize);
     /// Equivalent to the appropriate `llvm.memmove.p0i8.0i8.*` intrinsic, with
     /// a size of `count` * `size_of::<T>()` and an alignment of
     /// `min_align_of::<T>()`
     ///
     /// The volatile parameter parameter is set to `true`, so it will not be optimized out.
-    pub fn volatile_copy_memory<T>(dst: *mut T, src: *const T, count: uint);
+    pub fn volatile_copy_memory<T>(dst: *mut T, src: *const T, count: usize);
     /// Equivalent to the appropriate `llvm.memset.p0i8.*` intrinsic, with a
     /// size of `count` * `size_of::<T>()` and an alignment of
     /// `min_align_of::<T>()`.
     ///
     /// The volatile parameter parameter is set to `true`, so it will not be optimized out.
-    pub fn volatile_set_memory<T>(dst: *mut T, val: u8, count: uint);
+    pub fn volatile_set_memory<T>(dst: *mut T, val: u8, count: usize);
 
     /// Perform a volatile load from the `src` pointer.
     pub fn volatile_load<T>(src: *const T) -> T;


### PR DESCRIPTION
cc #22240 
