### PR TITLE
deprecate --help -v

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -655,14 +655,6 @@ pub fn build_target_config(opts: &Options, sp: &SpanHandler) -> Config {
     }
 }
 
-/// Returns all of the stable rustc command line options.
-pub fn optgroups() -> Vec<getopts::OptGroup> {
-    rustc_optgroups().into_iter()
-        .filter(|g|g.is_stable())
-        .map(|g|g.opt_group)
-        .collect()
-}
-
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum OptionStability { Stable, Unstable }
 

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -655,14 +655,6 @@ pub fn build_target_config(opts: &Options, sp: &SpanHandler) -> Config {
     }
 }
 
-/// Returns the "short" subset of the stable rustc command line options.
-pub fn short_optgroups() -> Vec<getopts::OptGroup> {
-    rustc_short_optgroups().into_iter()
-        .filter(|g|g.is_stable())
-        .map(|g|g.opt_group)
-        .collect()
-}
-
 /// Returns all of the stable rustc command line options.
 pub fn optgroups() -> Vec<getopts::OptGroup> {
     rustc_optgroups().into_iter()
@@ -730,10 +722,10 @@ mod opt {
     pub fn flagopt_u(a: S, b: S, c: S, d: S) -> R { unstable(getopts::optflagopt(a, b, c, d)) }
 }
 
-/// Returns the "short" subset of the rustc command line options,
-/// including metadata for each option, such as whether the option is
-/// part of the stable long-term interface for rustc.
-pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
+/// Returns all rustc command line options, including metadata for
+/// each option, such as whether the option is part of the stable
+/// long-term interface for rustc.
+pub fn rustc_optgroups() -> Vec<RustcOptGroup> {
     vec![
         opt::flag("h", "help", "Display this message"),
         opt::multi("", "cfg", "Configure the compilation environment", "SPEC"),
@@ -774,15 +766,6 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
         opt::multi("C", "codegen", "Set a codegen option", "OPT[=VALUE]"),
         opt::flag("V", "version", "Print version info and exit"),
         opt::flag("v", "verbose", "Use verbose output"),
-    ]
-}
-
-/// Returns all rustc command line options, including metadata for
-/// each option, such as whether the option is part of the stable
-/// long-term interface for rustc.
-pub fn rustc_optgroups() -> Vec<RustcOptGroup> {
-    let mut opts = rustc_short_optgroups();
-    opts.push_all(&[
         opt::multi("", "extern", "Specify where an external rust library is \
                                 located",
                  "NAME=PATH"),
@@ -807,8 +790,7 @@ pub fn rustc_optgroups() -> Vec<RustcOptGroup> {
                       `everybody_loops` (all function bodies replaced with `loop {}`).",
                      "TYPE"),
         opt::opt_u("", "show-span", "Show spans for compiler debugging", "expr|pat|ty"),
-    ]);
-    opts
+    ]
 }
 
 // Convert strings provided as --cfg [cfgspec] into a crate_cfg

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -498,28 +498,17 @@ pub fn version(binary: &str, matches: &getopts::Matches) {
 }
 
 fn usage(verbose: bool, include_unstable_options: bool) {
-    let groups = if verbose {
-        config::rustc_optgroups()
-    } else {
-        config::rustc_short_optgroups()
-    };
-    let groups : Vec<_> = groups.into_iter()
+    let groups : Vec<_> = config::rustc_optgroups().into_iter()
         .filter(|x| include_unstable_options || x.is_stable())
         .map(|x|x.opt_group)
         .collect();
     let message = format!("Usage: rustc [OPTIONS] INPUT");
-    let extra_help = if verbose {
-        ""
-    } else {
-        "\n    --help -v           Print the full set of options rustc accepts"
-    };
     println!("{}\n\
 Additional help:
     -C help             Print codegen options
     -W help             Print 'lint' options and default settings
-    -Z help             Print internal options for debugging rustc{}\n",
-              getopts::usage(&message, &groups),
-              extra_help);
+    -Z help             Print internal options for debugging rustc\n",
+              getopts::usage(&message, &groups));
 }
 
 fn describe_lints(lint_store: &lint::LintStore, loaded_plugins: bool) {

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -497,7 +497,7 @@ pub fn version(binary: &str, matches: &getopts::Matches) {
     }
 }
 
-fn usage(verbose: bool, include_unstable_options: bool) {
+fn usage(include_unstable_options: bool) {
     let groups : Vec<_> = config::rustc_optgroups().into_iter()
         .filter(|x| include_unstable_options || x.is_stable())
         .map(|x|x.opt_group)
@@ -662,7 +662,7 @@ pub fn handle_options(mut args: Vec<String>) -> Option<getopts::Matches> {
     if args.is_empty() {
         // user did not write `-v` nor `-Z unstable-options`, so do not
         // include that extra information.
-        usage(false, false);
+        usage(false);
         return None;
     }
 
@@ -698,7 +698,7 @@ pub fn handle_options(mut args: Vec<String>) -> Option<getopts::Matches> {
     let include_unstable_options = r.iter().any(|x| *x == "unstable-options");
 
     if matches.opt_present("h") || matches.opt_present("help") {
-        usage(matches.opt_present("verbose"), include_unstable_options);
+        usage(include_unstable_options);
         return None;
     }
 


### PR DESCRIPTION
the verbose option to help shows only a few extra lines, so just show
them all by default and save some time and keystrokes

The diff that `-v` introduced on the output of `rustc --help` was only:

``` diff
--- /tmp/help   2015-02-18 10:49:59.000000000 -0800
+++ /tmp/help-v 2015-02-18 10:50:03.000000000 -0800
@@ -34,10 +34,16 @@
                         Set a codegen option
     -V --version        Print version info and exit
     -v --verbose        Use verbose output
+    --extern NAME=PATH  Specify where an external rust library is located
+    --sysroot PATH      Override the system root
+    -Z FLAG             Set internal debugging options
+    --color auto|always|never
+                        Configure coloring of output: auto = colorize, if
+                        output goes to a tty (default); always = always
+                        colorize output; never = never colorize output

 Additional help:
     -C help             Print codegen options
     -W help             Print 'lint' options and default settings
     -Z help             Print internal options for debugging rustc
-    --help -v           Print the full set of options rustc accepts
```
