### PR TITLE
Removes suggestions for misspelled private fields for structs defined in non-local crates

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -117,7 +117,7 @@ use std::iter::repeat;
 use std::slice;
 use syntax::{self, abi, attr};
 use syntax::attr::AttrMetaMethods;
-use syntax::ast::{self, ProvidedMethod, RequiredMethod, TypeTraitItem, DefId};
+use syntax::ast::{self, ProvidedMethod, RequiredMethod, TypeTraitItem, DefId, Visibility};
 use syntax::ast_util::{self, local_def, PostExpansionMethod};
 use syntax::codemap::{self, Span};
 use syntax::owned_slice::OwnedSlice;
@@ -3115,6 +3115,10 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
             let n = elem.name.as_str();
             // ignore already set fields
             if skip.iter().any(|&x| x == n) {
+                continue;
+            }
+            // ignore private fields from non-local crates
+            if id.krate != ast::LOCAL_CRATE && elem.vis != Visibility::Public {
                 continue;
             }
             let dist = lev_distance(n, name);

--- a/src/test/compile-fail/suggest-private-fields.rs
+++ b/src/test/compile-fail/suggest-private-fields.rs
@@ -1,3 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 // aux-build:struct-field-privacy.rs
 
 extern crate "struct-field-privacy" as xc;

--- a/src/test/compile-fail/suggest-private-fields.rs
+++ b/src/test/compile-fail/suggest-private-fields.rs
@@ -4,10 +4,23 @@ extern crate "struct-field-privacy" as xc;
 
 use xc::B;
 
+struct A {
+    pub a: u32,
+    b: u32,
+}
+
 fn main () {
+    // external crate struct
     let k = B {
         aa: 20, //~ ERROR structure `struct-field-privacy::B` has no field named `aa`
         //~^ HELP did you mean `a`?
         bb: 20, //~ ERROR structure `struct-field-privacy::B` has no field named `bb`
+    };
+    // local crate struct
+    let l = A {
+        aa: 20, //~ ERROR structure `A` has no field named `aa`
+        //~^ HELP did you mean `a`?
+        bb: 20, //~ ERROR structure `A` has no field named `bb`
+        //~^ HELP did you mean `b`?
     };
 }

--- a/src/test/compile-fail/suggest-private-fields.rs
+++ b/src/test/compile-fail/suggest-private-fields.rs
@@ -1,0 +1,13 @@
+// aux-build:struct-field-privacy.rs
+
+extern crate "struct-field-privacy" as xc;
+
+use xc::B;
+
+fn main () {
+    let k = B {
+        aa: 20, //~ ERROR structure `struct-field-privacy::B` has no field named `aa`
+        //~^ HELP did you mean `a`?
+        bb: 20, //~ ERROR structure `struct-field-privacy::B` has no field named `bb`
+    };
+}


### PR DESCRIPTION
 closes #22421
