### PR TITLE
Implement arithmetic overflow changes

### DIFF
--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -818,11 +818,11 @@ impl BitVec {
         let full_value = if value { !0 } else { 0 };
 
         // Correct the old tail word, setting or clearing formerly unused bits
-        let old_last_word = blocks_for_bits(self.nbits) - 1;
+        let num_cur_blocks = blocks_for_bits(self.nbits);
         if self.nbits % u32::BITS as usize > 0 {
             let mask = mask_for_bits(self.nbits);
             if value {
-                self.storage[old_last_word] |= !mask;
+                self.storage[num_cur_blocks - 1] |= !mask;
             } else {
                 // Extra bits are already zero by invariant.
             }
@@ -830,7 +830,7 @@ impl BitVec {
 
         // Fill in words after the old tail word
         let stop_idx = cmp::min(self.storage.len(), new_nblocks);
-        for idx in old_last_word + 1..stop_idx {
+        for idx in num_cur_blocks..stop_idx {
             self.storage[idx] = full_value;
         }
 

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -25,7 +25,7 @@ use core::fmt::Debug;
 use core::hash::{Hash, Hasher};
 use core::iter::{Map, FromIterator, IntoIterator};
 use core::ops::{Index, IndexMut};
-use core::{iter, fmt, mem};
+use core::{iter, fmt, mem, usize};
 use Bound::{self, Included, Excluded, Unbounded};
 
 use borrow::Borrow;
@@ -1467,7 +1467,7 @@ macro_rules! range_impl {
             $Range {
                 inner: AbsIter {
                     traversals: traversals,
-                    size: 0, // unused
+                    size: usize::MAX, // unused
                 }
             }
         }

--- a/src/libcollections/btree/node.rs
+++ b/src/libcollections/btree/node.rs
@@ -1215,7 +1215,8 @@ impl<K, V> Node<K, V> {
         ptr::copy(
             self.edges_mut().as_mut_ptr().offset(index as isize),
             self.edges().as_ptr().offset(index as isize + 1),
-            self.len() - index + 1
+            // index can be == len+1, so do the +1 first to avoid underflow.
+            (self.len() + 1) - index
         );
 
         edge

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -96,6 +96,7 @@ use core::iter::{range_step, MultiplicativeIterator};
 use core::marker::Sized;
 use core::mem::size_of;
 use core::mem;
+use core::num::wrapping::WrappingOps;
 use core::ops::FnMut;
 use core::option::Option::{self, Some, None};
 use core::ptr::PtrExt;
@@ -1209,10 +1210,14 @@ struct SizeDirection {
 impl Iterator for ElementSwaps {
     type Item = (usize, usize);
 
-    #[inline]
+    // #[inline]
     fn next(&mut self) -> Option<(usize, usize)> {
+        fn new_pos_wrapping(i: usize, s: Direction) -> usize {
+            i.wrapping_add(match s { Pos => 1, Neg => -1 })
+        }
+
         fn new_pos(i: usize, s: Direction) -> usize {
-            i + match s { Pos => 1, Neg => -1 }
+            match s { Pos => i + 1, Neg => i - 1 }
         }
 
         // Find the index of the largest mobile element:
@@ -1220,7 +1225,7 @@ impl Iterator for ElementSwaps {
         // swap should be with a smaller `size` element.
         let max = self.sdir.iter().cloned().enumerate()
                            .filter(|&(i, sd)|
-                                new_pos(i, sd.dir) < self.sdir.len() &&
+                                new_pos_wrapping(i, sd.dir) < self.sdir.len() &&
                                 self.sdir[new_pos(i, sd.dir)].size < sd.size)
                            .max_by(|&(_, sd)| sd.size);
         match max {

--- a/src/libcore/hash/sip.rs
+++ b/src/libcore/hash/sip.rs
@@ -14,7 +14,7 @@
 
 use prelude::*;
 use default::Default;
-
+use num::wrapping::WrappingOps;
 use super::Hasher;
 
 /// An implementation of SipHash 2-4.
@@ -71,17 +71,17 @@ macro_rules! u8to64_le {
 
 macro_rules! rotl {
     ($x:expr, $b:expr) =>
-    (($x << $b) | ($x >> (64 - $b)))
+    (($x << $b) | ($x >> (64.wrapping_sub($b))))
 }
 
 macro_rules! compress {
     ($v0:expr, $v1:expr, $v2:expr, $v3:expr) =>
     ({
-        $v0 += $v1; $v1 = rotl!($v1, 13); $v1 ^= $v0;
+        $v0 = $v0.wrapping_add($v1); $v1 = rotl!($v1, 13); $v1 ^= $v0;
         $v0 = rotl!($v0, 32);
-        $v2 += $v3; $v3 = rotl!($v3, 16); $v3 ^= $v2;
-        $v0 += $v3; $v3 = rotl!($v3, 21); $v3 ^= $v0;
-        $v2 += $v1; $v1 = rotl!($v1, 17); $v1 ^= $v2;
+        $v2 = $v2.wrapping_add($v3); $v3 = rotl!($v3, 16); $v3 ^= $v2;
+        $v0 = $v0.wrapping_add($v3); $v3 = rotl!($v3, 21); $v3 ^= $v0;
+        $v2 = $v2.wrapping_add($v1); $v1 = rotl!($v1, 17); $v1 ^= $v2;
         $v2 = rotl!($v2, 32);
     })
 }

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -546,3 +546,14 @@ extern "rust-intrinsic" {
     /// Performs checked `u64` multiplication.
     pub fn u64_mul_with_overflow(x: u64, y: u64) -> (u64, bool);
 }
+
+// SNAP 880fb89
+#[cfg(not(stage0))]
+extern "rust-intrinsic" {
+    /// Returns (a + b) mod 2^N, where N is the width of N in bits.
+    pub fn overflowing_add<T>(a: T, b: T) -> T;
+    /// Returns (a - b) mod 2^N, where N is the width of N in bits.
+    pub fn overflowing_sub<T>(a: T, b: T) -> T;
+    /// Returns (a * b) mod 2^N, where N is the width of N in bits.
+    pub fn overflowing_mul<T>(a: T, b: T) -> T;
+}

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1130,7 +1130,11 @@ impl<I> RandomAccessIterator for Rev<I> where I: DoubleEndedIterator + RandomAcc
     #[inline]
     fn idx(&mut self, index: usize) -> Option<<I as Iterator>::Item> {
         let amt = self.indexable();
-        self.iter.idx(amt - index - 1)
+        if amt > index {
+            self.iter.idx(amt - index - 1)
+        } else {
+            None
+        }
     }
 }
 

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -728,10 +728,11 @@ pub trait IteratorExt: Iterator + Sized {
         P: FnMut(Self::Item) -> bool,
         Self: ExactSizeIterator + DoubleEndedIterator
     {
-        let mut i = self.len() - 1;
+        let mut i = self.len();
+
         while let Some(v) = self.next_back() {
             if predicate(v) {
-                return Some(i);
+                return Some(i - 1);
             }
             i -= 1;
         }

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -69,6 +69,7 @@
 #![feature(unboxed_closures)]
 #![feature(rustc_attrs)]
 #![feature(optin_builtin_traits)]
+#![feature(concat_idents)]
 
 #[macro_use]
 mod macros;

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -15,6 +15,8 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]
 
+use self::wrapping::{OverflowingOps, WrappingOps};
+
 use char::CharExt;
 use clone::Clone;
 use cmp::{PartialEq, Eq, PartialOrd, Ord};
@@ -51,6 +53,8 @@ pub trait Int
     + BitXor<Output=Self>
     + Shl<uint, Output=Self>
     + Shr<uint, Output=Self>
+    + WrappingOps
+    + OverflowingOps
 {
     /// Returns the `0` value of this integer type.
     // FIXME (#5527): Should be an associated constant
@@ -379,11 +383,23 @@ pub trait Int
         let mut base = self;
         let mut acc: Self = Int::one();
 
+        let mut prev_base = self;
+        let mut base_oflo = false;
         while exp > 0 {
             if (exp & 1) == 1 {
-                acc = acc * base;
+                if base_oflo {
+                    // ensure overflow occurs in the same manner it
+                    // would have otherwise (i.e. signal any exception
+                    // it would have otherwise).
+                    acc = acc * (prev_base * prev_base);
+                } else {
+                    acc = acc * base;
+                }
             }
-            base = base * base;
+            prev_base = base;
+            let (new_base, new_base_oflo) = base.overflowing_mul(base);
+            base = new_base;
+            base_oflo = new_base_oflo;
             exp /= 2;
         }
         acc
@@ -694,12 +710,12 @@ signed_int_impl! { int }
 
 /// A built-in unsigned integer.
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait UnsignedInt: Int {
+pub trait UnsignedInt: Int + WrappingOps {
     /// Returns `true` iff `self == 2^k` for some `k`.
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     fn is_power_of_two(self) -> bool {
-        (self - Int::one()) & self == Int::zero() && !(self == Int::zero())
+        (self.wrapping_sub(Int::one())) & self == Int::zero() && !(self == Int::zero())
     }
 
     /// Returns the smallest power of two greater than or equal to `self`.
@@ -709,7 +725,7 @@ pub trait UnsignedInt: Int {
     fn next_power_of_two(self) -> Self {
         let bits = size_of::<Self>() * 8;
         let one: Self = Int::one();
-        one << ((bits - (self - one).leading_zeros() as usize) % bits)
+        one << ((bits - self.wrapping_sub(one).leading_zeros() as usize) % bits)
     }
 
     /// Returns the smallest power of two greater than or equal to `n`. If the

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -30,6 +30,9 @@ use option::Option::{self, Some, None};
 use result::Result::{self, Ok, Err};
 use str::{FromStr, StrExt};
 
+#[unstable(feature = "core", reason = "may be removed or relocated")]
+pub mod wrapping;
+
 /// A built-in signed or unsigned integer.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Int

--- a/src/libcore/num/uint_macros.rs
+++ b/src/libcore/num/uint_macros.rs
@@ -20,6 +20,6 @@ pub const BYTES : u32 = ($bits / 8);
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN: $T = 0 as $T;
 #[stable(feature = "rust1", since = "1.0.0")]
-pub const MAX: $T = 0 as $T - 1 as $T;
+pub const MAX: $T = !0 as $T;
 
 ) }

--- a/src/libcore/num/wrapping.rs
+++ b/src/libcore/num/wrapping.rs
@@ -1,0 +1,153 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![allow(missing_docs)]
+
+use ops::*;
+
+#[cfg(not(stage0))]
+use intrinsics::{overflowing_add, overflowing_sub, overflowing_mul};
+
+pub trait WrappingOps {
+    fn wrapping_add(self, rhs: Self) -> Self;
+    fn wrapping_sub(self, rhs: Self) -> Self;
+    fn wrapping_mul(self, rhs: Self) -> Self;
+}
+
+#[cfg(not(stage0))]
+macro_rules! wrapping_impl {
+    ($($t:ty)*) => ($(
+        impl WrappingOps for $t {
+            #[inline(always)]
+            fn wrapping_add(self, rhs: $t) -> $t {
+                unsafe {
+                    overflowing_add(self, rhs)
+                }
+            }
+            #[inline(always)]
+            fn wrapping_sub(self, rhs: $t) -> $t {
+                unsafe {
+                    overflowing_sub(self, rhs)
+                }
+            }
+            #[inline(always)]
+            fn wrapping_mul(self, rhs: $t) -> $t {
+                unsafe {
+                    overflowing_mul(self, rhs)
+                }
+            }
+        }
+    )*)
+}
+
+#[cfg(stage0)]
+macro_rules! wrapping_impl {
+    ($($t:ty)*) => ($(
+        impl WrappingOps for $t {
+            #[inline(always)]
+            fn wrapping_add(self, rhs: $t) -> $t {
+                self + rhs
+            }
+            #[inline(always)]
+            fn wrapping_sub(self, rhs: $t) -> $t {
+                self - rhs
+            }
+            #[inline(always)]
+            fn wrapping_mul(self, rhs: $t) -> $t {
+                self * rhs
+            }
+        }
+    )*)
+}
+
+wrapping_impl! { uint u8 u16 u32 u64 int i8 i16 i32 i64 }
+
+#[unstable(feature = "core", reason = "may be removed, renamed, or relocated")]
+#[derive(PartialEq,Eq,PartialOrd,Ord,Clone,Copy)]
+pub struct Wrapping<T>(pub T);
+
+impl<T:WrappingOps> Add for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline(always)]
+    fn add(self, other: Wrapping<T>) -> Wrapping<T> {
+        Wrapping(self.0.wrapping_add(other.0))
+    }
+}
+
+impl<T:WrappingOps> Sub for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline(always)]
+    fn sub(self, other: Wrapping<T>) -> Wrapping<T> {
+        Wrapping(self.0.wrapping_sub(other.0))
+    }
+}
+
+impl<T:WrappingOps> Mul for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline(always)]
+    fn mul(self, other: Wrapping<T>) -> Wrapping<T> {
+        Wrapping(self.0.wrapping_mul(other.0))
+    }
+}
+
+impl<T:WrappingOps+Not<Output=T>> Not for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    fn not(self) -> Wrapping<T> {
+        Wrapping(!self.0)
+    }
+}
+
+impl<T:WrappingOps+BitXor<Output=T>> BitXor for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline(always)]
+    fn bitxor(self, other: Wrapping<T>) -> Wrapping<T> {
+        Wrapping(self.0 ^ other.0)
+    }
+}
+
+impl<T:WrappingOps+BitOr<Output=T>> BitOr for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline(always)]
+    fn bitor(self, other: Wrapping<T>) -> Wrapping<T> {
+        Wrapping(self.0 | other.0)
+    }
+}
+
+impl<T:WrappingOps+BitAnd<Output=T>> BitAnd for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline(always)]
+    fn bitand(self, other: Wrapping<T>) -> Wrapping<T> {
+        Wrapping(self.0 & other.0)
+    }
+}
+
+impl<T:WrappingOps+Shl<uint,Output=T>> Shl<uint> for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline(always)]
+    fn shl(self, other: uint) -> Wrapping<T> {
+        Wrapping(self.0 << other)
+    }
+}
+
+impl<T:WrappingOps+Shr<uint,Output=T>> Shr<uint> for Wrapping<T> {
+    type Output = Wrapping<T>;
+
+    #[inline(always)]
+    fn shr(self, other: uint) -> Wrapping<T> {
+        Wrapping(self.0 >> other)
+    }
+}

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -830,6 +830,7 @@ impl TwoWaySearcher {
     #[inline]
     #[allow(dead_code)]
     fn maximal_suffix(arr: &[u8], reversed: bool) -> (usize, usize) {
+        use num::wrapping::WrappingOps;
         let mut left = -1; // Corresponds to i in the paper
         let mut right = 0; // Corresponds to j in the paper
         let mut offset = 1; // Corresponds to k in the paper
@@ -839,17 +840,17 @@ impl TwoWaySearcher {
             let a;
             let b;
             if reversed {
-                a = arr[left + offset];
+                a = arr[left.wrapping_add(offset)];
                 b = arr[right + offset];
             } else {
                 a = arr[right + offset];
-                b = arr[left + offset];
+                b = arr[left.wrapping_add(offset)];
             }
             if a < b {
                 // Suffix is smaller, period is entire prefix so far.
                 right += offset;
                 offset = 1;
-                period = right - left;
+                period = right.wrapping_sub(left);
             } else if a == b {
                 // Advance through repetition of the current period.
                 if offset == period {
@@ -866,7 +867,7 @@ impl TwoWaySearcher {
                 period = 1;
             }
         }
-        (left + 1, period)
+        (left.wrapping_add(1), period)
     }
 }
 

--- a/src/libcoretest/num/mod.rs
+++ b/src/libcoretest/num/mod.rs
@@ -92,7 +92,7 @@ mod test {
         assert_eq!("127".parse::<i8>().ok(), Some(i8_val));
         assert_eq!("128".parse::<i8>().ok(), None);
 
-        i8_val += 1 as i8;
+        i8_val = i8_val.wrapping_add(1);
         assert_eq!("-128".parse::<i8>().ok(), Some(i8_val));
         assert_eq!("-129".parse::<i8>().ok(), None);
 
@@ -100,7 +100,7 @@ mod test {
         assert_eq!("32767".parse::<i16>().ok(), Some(i16_val));
         assert_eq!("32768".parse::<i16>().ok(), None);
 
-        i16_val += 1 as i16;
+        i16_val = i16_val.wrapping_add(1);
         assert_eq!("-32768".parse::<i16>().ok(), Some(i16_val));
         assert_eq!("-32769".parse::<i16>().ok(), None);
 
@@ -108,7 +108,7 @@ mod test {
         assert_eq!("2147483647".parse::<i32>().ok(), Some(i32_val));
         assert_eq!("2147483648".parse::<i32>().ok(), None);
 
-        i32_val += 1 as i32;
+        i32_val = i32_val.wrapping_add(1);
         assert_eq!("-2147483648".parse::<i32>().ok(), Some(i32_val));
         assert_eq!("-2147483649".parse::<i32>().ok(), None);
 
@@ -116,7 +116,7 @@ mod test {
         assert_eq!("9223372036854775807".parse::<i64>().ok(), Some(i64_val));
         assert_eq!("9223372036854775808".parse::<i64>().ok(), None);
 
-        i64_val += 1 as i64;
+        i64_val = i64_val.wrapping_add(1);
         assert_eq!("-9223372036854775808".parse::<i64>().ok(), Some(i64_val));
         assert_eq!("-9223372036854775809".parse::<i64>().ok(), None);
     }

--- a/src/librand/chacha.rs
+++ b/src/librand/chacha.rs
@@ -12,6 +12,7 @@
 
 use core::prelude::*;
 use core::num::Int;
+use core::num::wrapping::WrappingOps;
 use {Rng, SeedableRng, Rand};
 
 const KEY_WORDS    : uint =  8; // 8 words for the 256-bit key
@@ -43,10 +44,10 @@ static EMPTY: ChaChaRng = ChaChaRng {
 
 macro_rules! quarter_round{
     ($a: expr, $b: expr, $c: expr, $d: expr) => {{
-        $a += $b; $d ^= $a; $d = $d.rotate_left(16);
-        $c += $d; $b ^= $c; $b = $b.rotate_left(12);
-        $a += $b; $d ^= $a; $d = $d.rotate_left( 8);
-        $c += $d; $b ^= $c; $b = $b.rotate_left( 7);
+        $a = $a.wrapping_add($b); $d = $d ^ $a; $d = $d.rotate_left(16);
+        $c = $c.wrapping_add($d); $b = $b ^ $c; $b = $b.rotate_left(12);
+        $a = $a.wrapping_add($b); $d = $d ^ $a; $d = $d.rotate_left( 8);
+        $c = $c.wrapping_add($d); $b = $b ^ $c; $b = $b.rotate_left( 7);
     }}
 }
 
@@ -74,7 +75,7 @@ fn core(output: &mut [u32; STATE_WORDS], input: &[u32; STATE_WORDS]) {
     }
 
     for i in 0..STATE_WORDS {
-        output[i] += input[i];
+        output[i] = output[i].wrapping_add(input[i]);
     }
 }
 

--- a/src/librand/distributions/range.rs
+++ b/src/librand/distributions/range.rs
@@ -123,7 +123,7 @@ macro_rules! integer_impl {
                     // be uniformly distributed)
                     if v < r.accept_zone as $unsigned {
                         // and return it, with some adjustments
-                        return r.low + (v % r.range as $unsigned) as $ty;
+                        return r.low.wrapping_add((v % r.range as $unsigned) as $ty);
                     }
                 }
             }

--- a/src/librand/distributions/range.rs
+++ b/src/librand/distributions/range.rs
@@ -14,6 +14,7 @@
 
 use core::prelude::{PartialOrd};
 use core::num::Int;
+use core::num::wrapping::WrappingOps;
 
 use Rng;
 use distributions::{Sample, IndependentSample};
@@ -97,7 +98,7 @@ macro_rules! integer_impl {
             // bijection.
 
             fn construct_range(low: $ty, high: $ty) -> Range<$ty> {
-                let range = high as $unsigned - low as $unsigned;
+                let range = (high as $unsigned).wrapping_sub(low as $unsigned);
                 let unsigned_max: $unsigned = Int::max_value();
 
                 // this is the largest number that fits into $unsigned

--- a/src/librand/isaac.rs
+++ b/src/librand/isaac.rs
@@ -304,7 +304,7 @@ impl Isaac64Rng {
     fn init(&mut self, use_rsl: bool) {
         macro_rules! init {
             ($var:ident) => (
-                let mut $var = 0x9e3779b97f4a7c13;
+                let mut $var = Wrapping(0x9e3779b97f4a7c13);
             )
         }
         init!(a); init!(b); init!(c); init!(d);
@@ -312,14 +312,14 @@ impl Isaac64Rng {
 
         macro_rules! mix {
             () => {{
-                a-=e; f^=h>>9;  h+=a;
-                b-=f; g^=a<<9;  a+=b;
-                c-=g; h^=b>>23; b+=c;
-                d-=h; a^=c<<15; c+=d;
-                e-=a; b^=d>>14; d+=e;
-                f-=b; c^=e<<20; e+=f;
-                g-=c; d^=f>>17; f+=g;
-                h-=d; e^=g<<14; g+=h;
+                a=a-e; f=f^h>>9;  h=h+a;
+                b=b-f; g=g^a<<9;  a=a+b;
+                c=c-g; h=h^b>>23; b=b+c;
+                d=d-h; a=a^c<<15; c=c+d;
+                e=e-a; b=b^d>>14; d=d+e;
+                f=f-b; c=c^e<<20; e=e+f;
+                g=g-c; d=d^f>>17; f=f+g;
+                h=h-d; e=e^g<<14; g=g+h;
             }}
         }
 
@@ -331,15 +331,15 @@ impl Isaac64Rng {
             macro_rules! memloop {
                 ($arr:expr) => {{
                     for i in (0..RAND_SIZE_64 / 8).map(|i| i * 8) {
-                        a+=$arr[i  ]; b+=$arr[i+1];
-                        c+=$arr[i+2]; d+=$arr[i+3];
-                        e+=$arr[i+4]; f+=$arr[i+5];
-                        g+=$arr[i+6]; h+=$arr[i+7];
+                        a=a+Wrapping($arr[i  ]); b=b+Wrapping($arr[i+1]);
+                        c=c+Wrapping($arr[i+2]); d=d+Wrapping($arr[i+3]);
+                        e=e+Wrapping($arr[i+4]); f=f+Wrapping($arr[i+5]);
+                        g=g+Wrapping($arr[i+6]); h=h+Wrapping($arr[i+7]);
                         mix!();
-                        self.mem[i  ]=a; self.mem[i+1]=b;
-                        self.mem[i+2]=c; self.mem[i+3]=d;
-                        self.mem[i+4]=e; self.mem[i+5]=f;
-                        self.mem[i+6]=g; self.mem[i+7]=h;
+                        self.mem[i  ]=a.0; self.mem[i+1]=b.0;
+                        self.mem[i+2]=c.0; self.mem[i+3]=d.0;
+                        self.mem[i+4]=e.0; self.mem[i+5]=f.0;
+                        self.mem[i+6]=g.0; self.mem[i+7]=h.0;
                     }
                 }}
             }
@@ -349,10 +349,10 @@ impl Isaac64Rng {
         } else {
             for i in (0..RAND_SIZE_64 / 8).map(|i| i * 8) {
                 mix!();
-                self.mem[i  ]=a; self.mem[i+1]=b;
-                self.mem[i+2]=c; self.mem[i+3]=d;
-                self.mem[i+4]=e; self.mem[i+5]=f;
-                self.mem[i+6]=g; self.mem[i+7]=h;
+                self.mem[i  ]=a.0; self.mem[i+1]=b.0;
+                self.mem[i+2]=c.0; self.mem[i+3]=d.0;
+                self.mem[i+4]=e.0; self.mem[i+5]=f.0;
+                self.mem[i+6]=g.0; self.mem[i+7]=h.0;
             }
         }
 
@@ -363,8 +363,8 @@ impl Isaac64Rng {
     fn isaac64(&mut self) {
         self.c += 1;
         // abbreviations
-        let mut a = self.a;
-        let mut b = self.b + self.c;
+        let mut a = Wrapping(self.a);
+        let mut b = Wrapping(self.b) + Wrapping(self.c);
         const MIDPOINT: uint =  RAND_SIZE_64 / 2;
         const MP_VEC: [(uint, uint); 2] = [(0,MIDPOINT), (MIDPOINT, 0)];
         macro_rules! ind {
@@ -383,13 +383,13 @@ impl Isaac64Rng {
                         let mix = if $j == 0 {!mix} else {mix};
 
                         unsafe {
-                            let x = *self.mem.get_unchecked(base + mr_offset);
-                            a = mix + *self.mem.get_unchecked(base + m2_offset);
-                            let y = ind!(x) + a + b;
-                            *self.mem.get_unchecked_mut(base + mr_offset) = y;
+                            let x = Wrapping(*self.mem.get_unchecked(base + mr_offset));
+                            a = mix + Wrapping(*self.mem.get_unchecked(base + m2_offset));
+                            let y = Wrapping(ind!(x.0)) + a + b;
+                            *self.mem.get_unchecked_mut(base + mr_offset) = y.0;
 
-                            b = ind!(y >> RAND_SIZE_64_LEN) + x;
-                            *self.rsl.get_unchecked_mut(base + mr_offset) = b;
+                            b = Wrapping(ind!(y.0 >> RAND_SIZE_64_LEN)) + x;
+                            *self.rsl.get_unchecked_mut(base + mr_offset) = b.0;
                         }
                     }}
                 }
@@ -401,13 +401,13 @@ impl Isaac64Rng {
                         let mix = if $j == 0 {!mix} else {mix};
 
                         unsafe {
-                            let x = *self.mem.get_unchecked(base + mr_offset);
-                            a = mix + *self.mem.get_unchecked(base + m2_offset);
-                            let y = ind!(x) + a + b;
-                            *self.mem.get_unchecked_mut(base + mr_offset) = y;
+                            let x = Wrapping(*self.mem.get_unchecked(base + mr_offset));
+                            a = mix + Wrapping(*self.mem.get_unchecked(base + m2_offset));
+                            let y = Wrapping(ind!(x.0)) + a + b;
+                            *self.mem.get_unchecked_mut(base + mr_offset) = y.0;
 
-                            b = ind!(y >> RAND_SIZE_64_LEN) + x;
-                            *self.rsl.get_unchecked_mut(base + mr_offset) = b;
+                            b = Wrapping(ind!(y.0 >> RAND_SIZE_64_LEN)) + x;
+                            *self.rsl.get_unchecked_mut(base + mr_offset) = b.0;
                         }
                     }}
                 }
@@ -419,8 +419,8 @@ impl Isaac64Rng {
             }
         }
 
-        self.a = a;
-        self.b = b;
+        self.a = a.0;
+        self.b = b.0;
         self.cnt = RAND_SIZE_64;
     }
 }

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -783,7 +783,7 @@ pub fn get_enum_variants<'tcx>(intr: Rc<IdentInterner>, cdata: Cmd, id: ast::Nod
             _         => { /* empty */ }
         }
         let old_disr_val = disr_val;
-        disr_val += 1;
+        disr_val = disr_val.wrapping_add(1);
         Rc::new(ty::VariantInfo {
             args: arg_tys,
             arg_names: arg_names,

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -347,7 +347,7 @@ fn encode_enum_variant_info(ecx: &EncodeContext,
 
         ecx.tcx.map.with_path(variant.node.id, |path| encode_path(rbml_w, path));
         rbml_w.end_tag();
-        disr_val += 1;
+        disr_val = disr_val.wrapping_add(1);
         i += 1;
     }
 }

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -204,7 +204,9 @@ impl<'a, 'b, 'tcx> DecodeContext<'a, 'b, 'tcx> {
     pub fn tr_id(&self, id: ast::NodeId) -> ast::NodeId {
         // from_id_range should be non-empty
         assert!(!self.from_id_range.empty());
-        (id - self.from_id_range.min + self.to_id_range.min)
+        // Use wrapping arithmetic because otherwise it introduces control flow.
+        // Maybe we should just have the control flow? -- aatch
+        (id.wrapping_sub(self.from_id_range.min).wrapping_add(self.to_id_range.min))
     }
 
     /// Translates an EXTERNAL def-id, converting the crate number from the one used in the encoded

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -307,8 +307,9 @@ impl<'a, 'tcx, 'v> Visitor<'v> for CheckCrateVisitor<'a, 'tcx> {
                             match const_eval::eval_const_expr_partial(self.tcx, ex, None) {
                                 Ok(_) => {}
                                 Err(msg) => {
-                                    span_err!(self.tcx.sess, ex.span, E0020,
-                                              "{} in a constant expression", msg)
+                                    span_err!(self.tcx.sess, msg.span, E0020,
+                                              "{} in a constant expression",
+                                              msg.description())
                                 }
                             }
                         }

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -283,106 +283,40 @@ impl ConstEvalErr {
     }
 }
 
-fn invalid_op_for_bools(e: &Expr, op: ast::BinOp_) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::InvalidOpForBools(op) }
-}
-fn invalid_op_for_floats(e: &Expr, op: ast::BinOp_) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::InvalidOpForFloats(op) }
-}
-fn invalid_op_for_int_uint(e: &Expr, op: ast::BinOp_) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::InvalidOpForIntUint(op) }
-}
-fn invalid_op_for_uint_int(e: &Expr, op: ast::BinOp_) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::InvalidOpForUintInt(op) }
-}
-fn negate_on_string(e: &Expr) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::NegateOnString }
-}
-fn negate_on_boolean(e: &Expr) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::NegateOnBoolean }
-}
-fn not_on_float(e: &Expr) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::NotOnFloat }
-}
-fn not_on_string(e: &Expr) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::NotOnString }
-}
+macro_rules! signal {
+    ($e:expr, $ctor:ident) => {
+        return Err(ConstEvalErr { span: $e.span, kind: ErrKind::$ctor })
+    };
 
-fn addi_with_overflow(e: &Expr, a: i64, b: i64) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::AddiWithOverflow(a, b) }
+    ($e:expr, $ctor:ident($($arg:expr),*)) => {
+        return Err(ConstEvalErr { span: $e.span, kind: ErrKind::$ctor($($arg),*) })
+    }
 }
-fn subi_with_overflow(e: &Expr, a: i64, b: i64) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::SubiWithOverflow(a, b) }
-}
-fn muli_with_overflow(e: &Expr, a: i64, b: i64) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::MuliWithOverflow(a, b) }
-}
-fn addu_with_overflow(e: &Expr, a: u64, b: u64) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::AdduWithOverflow(a, b) }
-}
-fn subu_with_overflow(e: &Expr, a: u64, b: u64) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::SubuWithOverflow(a, b) }
-}
-fn mulu_with_overflow(e: &Expr, a: u64, b: u64) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::MuluWithOverflow(a, b) }
-}
-fn divide_by_zero(e: &Expr) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::DivideByZero }
-}
-fn divide_with_overflow(e: &Expr) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::DivideWithOverflow }
-}
-fn modulo_by_zero(e: &Expr) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::ModuloByZero }
-}
-fn modulo_with_overflow(e: &Expr) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::ModuloWithOverflow }
-}
-fn missing_struct_field(e: &Expr) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::MissingStructField }
-}
-fn non_const_path(e: &Expr) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::NonConstPath }
-}
-fn non_const_struct(e: &Expr) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::NonConstStruct }
-}
-fn tuple_index_out_of_bounds(e: &Expr) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::TupleIndexOutOfBounds }
-}
-
-fn misc_binary_op(e: &Expr) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::MiscBinaryOp }
-}
-fn misc_catch_all(e: &Expr) -> ConstEvalErr {
-    ConstEvalErr { span: e.span, kind: ErrKind::MiscCatchAll }
-}
-
 
 fn checked_add_int(e: &Expr, a: i64, b: i64) -> Result<const_val, ConstEvalErr> {
     let (ret, oflo) = a.overflowing_add(b);
-    if !oflo { Ok(const_int(ret)) } else { Err(addi_with_overflow(e, a, b)) }
+    if !oflo { Ok(const_int(ret)) } else { signal!(e, AddiWithOverflow(a, b)) }
 }
 fn checked_sub_int(e: &Expr, a: i64, b: i64) -> Result<const_val, ConstEvalErr> {
     let (ret, oflo) = a.overflowing_sub(b);
-    if !oflo { Ok(const_int(ret)) } else { Err(subi_with_overflow(e, a, b)) }
+    if !oflo { Ok(const_int(ret)) } else { signal!(e, SubiWithOverflow(a, b)) }
 }
 fn checked_mul_int(e: &Expr, a: i64, b: i64) -> Result<const_val, ConstEvalErr> {
     let (ret, oflo) = a.overflowing_mul(b);
-    if !oflo { Ok(const_int(ret)) } else { Err(muli_with_overflow(e, a, b)) }
+    if !oflo { Ok(const_int(ret)) } else { signal!(e, MuliWithOverflow(a, b)) }
 }
 
 fn checked_add_uint(e: &Expr, a: u64, b: u64) -> Result<const_val, ConstEvalErr> {
     let (ret, oflo) = a.overflowing_add(b);
-    if !oflo { Ok(const_uint(ret)) } else { Err(addu_with_overflow(e, a, b)) }
+    if !oflo { Ok(const_uint(ret)) } else { signal!(e, AdduWithOverflow(a, b)) }
 }
 fn checked_sub_uint(e: &Expr, a: u64, b: u64) -> Result<const_val, ConstEvalErr> {
     let (ret, oflo) = a.overflowing_sub(b);
-    if !oflo { Ok(const_uint(ret)) } else { Err(subu_with_overflow(e, a, b)) }
+    if !oflo { Ok(const_uint(ret)) } else { signal!(e, SubuWithOverflow(a, b)) }
 }
 fn checked_mul_uint(e: &Expr, a: u64, b: u64) -> Result<const_val, ConstEvalErr> {
     let (ret, oflo) = a.overflowing_mul(b);
-    if !oflo { Ok(const_uint(ret)) } else { Err(mulu_with_overflow(e, a, b)) }
+    if !oflo { Ok(const_uint(ret)) } else { signal!(e, MuluWithOverflow(a, b)) }
 }
 
 
@@ -400,8 +334,8 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
           Ok(const_float(f)) => Ok(const_float(-f)),
           Ok(const_int(i)) => Ok(const_int(-i)),
           Ok(const_uint(i)) => Ok(const_uint(-i)),
-          Ok(const_str(_)) => Err(negate_on_string(e)),
-          Ok(const_bool(_)) => Err(negate_on_boolean(e)),
+          Ok(const_str(_)) => signal!(e, NegateOnString),
+          Ok(const_bool(_)) => signal!(e, NegateOnBoolean),
           err => err
         }
       }
@@ -410,8 +344,8 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
           Ok(const_int(i)) => Ok(const_int(!i)),
           Ok(const_uint(i)) => Ok(const_uint(!i)),
           Ok(const_bool(b)) => Ok(const_bool(!b)),
-          Ok(const_str(_)) => Err(not_on_string(e)),
-          Ok(const_float(_)) => Err(not_on_float(e)),
+          Ok(const_str(_)) => signal!(e, NotOnString),
+          Ok(const_float(_)) => signal!(e, NotOnFloat),
           err => err
         }
       }
@@ -435,7 +369,7 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
               ast::BiNe => fromb(a != b),
               ast::BiGe => fromb(a >= b),
               ast::BiGt => fromb(a > b),
-              _ => Err(invalid_op_for_floats(e, op.node)),
+              _ => signal!(e, InvalidOpForFloats(op.node))
             }
           }
           (Ok(const_int(a)), Ok(const_int(b))) => {
@@ -463,18 +397,18 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
               ast::BiMul => checked_mul_int(e, a, b),
               ast::BiDiv => {
                   if b == 0 {
-                      Err(divide_by_zero(e))
+                      signal!(e, DivideByZero);
                   } else if b == -1 && is_a_min_value() {
-                      Err(divide_with_overflow(e))
+                      signal!(e, DivideWithOverflow);
                   } else {
                       Ok(const_int(a / b))
                   }
               }
               ast::BiRem => {
                   if b == 0 {
-                      Err(modulo_by_zero(e))
+                      signal!(e, ModuloByZero)
                   } else if b == -1 && is_a_min_value() {
-                      Err(modulo_with_overflow(e))
+                      signal!(e, ModuloWithOverflow)
                   } else {
                       Ok(const_int(a % b))
                   }
@@ -497,9 +431,9 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
               ast::BiAdd => checked_add_uint(e, a, b),
               ast::BiSub => checked_sub_uint(e, a, b),
               ast::BiMul => checked_mul_uint(e, a, b),
-              ast::BiDiv if b == 0 => Err(divide_by_zero(e)),
+              ast::BiDiv if b == 0 => signal!(e, DivideByZero),
               ast::BiDiv => Ok(const_uint(a / b)),
-              ast::BiRem if b == 0 => Err(modulo_by_zero(e)),
+              ast::BiRem if b == 0 => signal!(e, ModuloByZero),
               ast::BiRem => Ok(const_uint(a % b)),
               ast::BiAnd | ast::BiBitAnd => Ok(const_uint(a & b)),
               ast::BiOr | ast::BiBitOr => Ok(const_uint(a | b)),
@@ -519,14 +453,14 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
             match op.node {
               ast::BiShl => Ok(const_int(a << b as uint)),
               ast::BiShr => Ok(const_int(a >> b as uint)),
-              _ => Err(invalid_op_for_int_uint(e, op.node)),
+              _ => signal!(e, InvalidOpForIntUint(op.node)),
             }
           }
           (Ok(const_uint(a)), Ok(const_int(b))) => {
             match op.node {
               ast::BiShl => Ok(const_uint(a << b as uint)),
               ast::BiShr => Ok(const_uint(a >> b as uint)),
-              _ => Err(invalid_op_for_uint_int(e, op.node)),
+              _ => signal!(e, InvalidOpForUintInt(op.node)),
             }
           }
           (Ok(const_bool(a)), Ok(const_bool(b))) => {
@@ -538,13 +472,13 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
               ast::BiBitOr => a | b,
               ast::BiEq => a == b,
               ast::BiNe => a != b,
-              _ => return Err(invalid_op_for_bools(e, op.node)),
+              _ => signal!(e, InvalidOpForBools(op.node)),
              }))
           }
           (err @ Err(..), _) |
           (_, err @ Err(..)) => err,
 
-          _ => Err(misc_binary_op(e)),
+          _ => signal!(e, MiscBinaryOp),
         }
       }
       ast::ExprCast(ref base, ref target_ty) => {
@@ -589,7 +523,7 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
           };
           let const_expr = match const_expr {
               Some(actual_e) => actual_e,
-              None => return Err(non_const_path(e)),
+              None => signal!(e, NonConstPath)
           };
           let ety = ety.or_else(|| const_ty.and_then(|ty| ast_ty_to_prim_ty(tcx, ty)));
           eval_const_expr_partial(tcx, const_expr, ety)
@@ -611,11 +545,11 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
             if fields.len() > index.node {
                 return eval_const_expr_partial(tcx, &*fields[index.node], None)
             } else {
-                return Err(tuple_index_out_of_bounds(e))
+                signal!(e, TupleIndexOutOfBounds);
             }
         }
 
-        Err(non_const_struct(e))
+        signal!(e, NonConstStruct);
       }
       ast::ExprField(ref base, field_name) => {
         // Get the base expression if it is a struct and it is constant
@@ -626,13 +560,13 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
                                            f.ident.node.as_str() == field_name.node.as_str()) {
                 return eval_const_expr_partial(tcx, &*f.expr, None)
             } else {
-                return Err(missing_struct_field(e));
+                signal!(e, MissingStructField);
             }
         }
 
-        Err(non_const_struct(e))
+        signal!(e, NonConstStruct);
       }
-      _ => Err(misc_catch_all(e))
+      _ => signal!(e, MiscCatchAll)
     }
 }
 

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -225,8 +225,10 @@ pub enum ErrKind {
     InvalidOpForUintInt(ast::BinOp_),
     NegateOnString,
     NegateOnBoolean,
+    NegateOnBinary,
     NotOnFloat,
     NotOnString,
+    NotOnBinary,
 
     AddiWithOverflow(i64, i64),
     SubiWithOverflow(i64, i64),
@@ -259,8 +261,10 @@ impl ConstEvalErr {
             InvalidOpForUintInt(..) => "can't do this op on a uint and int".into_cow(),
             NegateOnString => "negate on string".into_cow(),
             NegateOnBoolean => "negate on boolean".into_cow(),
+            NegateOnBinary => "negate on binary literal".into_cow(),
             NotOnFloat => "not on float or string".into_cow(),
             NotOnString => "not on float or string".into_cow(),
+            NotOnBinary => "not on binary literal".into_cow(),
 
             AddiWithOverflow(..) => "attempted to add with overflow".into_cow(),
             SubiWithOverflow(..) => "attempted to sub with overflow".into_cow(),
@@ -324,29 +328,29 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
                                      e: &Expr,
                                      ty_hint: Option<Ty<'tcx>>)
                                      -> Result<const_val, ConstEvalErr> {
-    fn fromb<T>(b: bool) -> Result<const_val, T> { Ok(const_int(b as i64)) }
+    fn fromb(b: bool) -> const_val { const_int(b as i64) }
 
     let ety = ty_hint.or_else(|| ty::expr_ty_opt(tcx, e));
 
-    match e.node {
+    let result = match e.node {
       ast::ExprUnary(ast::UnNeg, ref inner) => {
-        match eval_const_expr_partial(tcx, &**inner, ety) {
-          Ok(const_float(f)) => Ok(const_float(-f)),
-          Ok(const_int(i)) => Ok(const_int(-i)),
-          Ok(const_uint(i)) => Ok(const_uint(-i)),
-          Ok(const_str(_)) => signal!(e, NegateOnString),
-          Ok(const_bool(_)) => signal!(e, NegateOnBoolean),
-          err => err
+        match try!(eval_const_expr_partial(tcx, &**inner, ety)) {
+          const_float(f) => const_float(-f),
+          const_int(i) => const_int(-i),
+          const_uint(i) => const_uint(-i),
+          const_str(_) => signal!(e, NegateOnString),
+          const_bool(_) => signal!(e, NegateOnBoolean),
+          const_binary(_) => signal!(e, NegateOnBinary),
         }
       }
       ast::ExprUnary(ast::UnNot, ref inner) => {
-        match eval_const_expr_partial(tcx, &**inner, ety) {
-          Ok(const_int(i)) => Ok(const_int(!i)),
-          Ok(const_uint(i)) => Ok(const_uint(!i)),
-          Ok(const_bool(b)) => Ok(const_bool(!b)),
-          Ok(const_str(_)) => signal!(e, NotOnString),
-          Ok(const_float(_)) => signal!(e, NotOnFloat),
-          err => err
+        match try!(eval_const_expr_partial(tcx, &**inner, ety)) {
+          const_int(i) => const_int(!i),
+          const_uint(i) => const_uint(!i),
+          const_bool(b) => const_bool(!b),
+          const_str(_) => signal!(e, NotOnString),
+          const_float(_) => signal!(e, NotOnFloat),
+          const_binary(_) => signal!(e, NotOnBinary),
         }
       }
       ast::ExprBinary(op, ref a, ref b) => {
@@ -354,15 +358,15 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
             ast::BiShl | ast::BiShr => Some(tcx.types.uint),
             _ => ety
         };
-        match (eval_const_expr_partial(tcx, &**a, ety),
-               eval_const_expr_partial(tcx, &**b, b_ty)) {
-          (Ok(const_float(a)), Ok(const_float(b))) => {
+        match (try!(eval_const_expr_partial(tcx, &**a, ety)),
+               try!(eval_const_expr_partial(tcx, &**b, b_ty))) {
+          (const_float(a), const_float(b)) => {
             match op.node {
-              ast::BiAdd => Ok(const_float(a + b)),
-              ast::BiSub => Ok(const_float(a - b)),
-              ast::BiMul => Ok(const_float(a * b)),
-              ast::BiDiv => Ok(const_float(a / b)),
-              ast::BiRem => Ok(const_float(a % b)),
+              ast::BiAdd => const_float(a + b),
+              ast::BiSub => const_float(a - b),
+              ast::BiMul => const_float(a * b),
+              ast::BiDiv => const_float(a / b),
+              ast::BiRem => const_float(a % b),
               ast::BiEq => fromb(a == b),
               ast::BiLt => fromb(a < b),
               ast::BiLe => fromb(a <= b),
@@ -372,7 +376,7 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
               _ => signal!(e, InvalidOpForFloats(op.node))
             }
           }
-          (Ok(const_int(a)), Ok(const_int(b))) => {
+          (const_int(a), const_int(b)) => {
             let is_a_min_value = || {
                 let int_ty = match ty::expr_ty_opt(tcx, e).map(|ty| &ty.sty) {
                     Some(&ty::ty_int(int_ty)) => int_ty,
@@ -392,16 +396,16 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
                 }
             };
             match op.node {
-              ast::BiAdd => checked_add_int(e, a, b),
-              ast::BiSub => checked_sub_int(e, a, b),
-              ast::BiMul => checked_mul_int(e, a, b),
+              ast::BiAdd => try!(checked_add_int(e, a, b)),
+              ast::BiSub => try!(checked_sub_int(e, a, b)),
+              ast::BiMul => try!(checked_mul_int(e, a, b)),
               ast::BiDiv => {
                   if b == 0 {
                       signal!(e, DivideByZero);
                   } else if b == -1 && is_a_min_value() {
                       signal!(e, DivideWithOverflow);
                   } else {
-                      Ok(const_int(a / b))
+                      const_int(a / b)
                   }
               }
               ast::BiRem => {
@@ -410,14 +414,14 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
                   } else if b == -1 && is_a_min_value() {
                       signal!(e, ModuloWithOverflow)
                   } else {
-                      Ok(const_int(a % b))
+                      const_int(a % b)
                   }
               }
-              ast::BiAnd | ast::BiBitAnd => Ok(const_int(a & b)),
-              ast::BiOr | ast::BiBitOr => Ok(const_int(a | b)),
-              ast::BiBitXor => Ok(const_int(a ^ b)),
-              ast::BiShl => Ok(const_int(a << b as uint)),
-              ast::BiShr => Ok(const_int(a >> b as uint)),
+              ast::BiAnd | ast::BiBitAnd => const_int(a & b),
+              ast::BiOr | ast::BiBitOr => const_int(a | b),
+              ast::BiBitXor => const_int(a ^ b),
+              ast::BiShl => const_int(a << b as uint),
+              ast::BiShr => const_int(a >> b as uint),
               ast::BiEq => fromb(a == b),
               ast::BiLt => fromb(a < b),
               ast::BiLe => fromb(a <= b),
@@ -426,20 +430,20 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
               ast::BiGt => fromb(a > b)
             }
           }
-          (Ok(const_uint(a)), Ok(const_uint(b))) => {
+          (const_uint(a), const_uint(b)) => {
             match op.node {
-              ast::BiAdd => checked_add_uint(e, a, b),
-              ast::BiSub => checked_sub_uint(e, a, b),
-              ast::BiMul => checked_mul_uint(e, a, b),
+              ast::BiAdd => try!(checked_add_uint(e, a, b)),
+              ast::BiSub => try!(checked_sub_uint(e, a, b)),
+              ast::BiMul => try!(checked_mul_uint(e, a, b)),
               ast::BiDiv if b == 0 => signal!(e, DivideByZero),
-              ast::BiDiv => Ok(const_uint(a / b)),
+              ast::BiDiv => const_uint(a / b),
               ast::BiRem if b == 0 => signal!(e, ModuloByZero),
-              ast::BiRem => Ok(const_uint(a % b)),
-              ast::BiAnd | ast::BiBitAnd => Ok(const_uint(a & b)),
-              ast::BiOr | ast::BiBitOr => Ok(const_uint(a | b)),
-              ast::BiBitXor => Ok(const_uint(a ^ b)),
-              ast::BiShl => Ok(const_uint(a << b as uint)),
-              ast::BiShr => Ok(const_uint(a >> b as uint)),
+              ast::BiRem => const_uint(a % b),
+              ast::BiAnd | ast::BiBitAnd => const_uint(a & b),
+              ast::BiOr | ast::BiBitOr => const_uint(a | b),
+              ast::BiBitXor => const_uint(a ^ b),
+              ast::BiShl => const_uint(a << b as uint),
+              ast::BiShr => const_uint(a >> b as uint),
               ast::BiEq => fromb(a == b),
               ast::BiLt => fromb(a < b),
               ast::BiLe => fromb(a <= b),
@@ -449,22 +453,22 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
             }
           }
           // shifts can have any integral type as their rhs
-          (Ok(const_int(a)), Ok(const_uint(b))) => {
+          (const_int(a), const_uint(b)) => {
             match op.node {
-              ast::BiShl => Ok(const_int(a << b as uint)),
-              ast::BiShr => Ok(const_int(a >> b as uint)),
+              ast::BiShl => const_int(a << b as uint),
+              ast::BiShr => const_int(a >> b as uint),
               _ => signal!(e, InvalidOpForIntUint(op.node)),
             }
           }
-          (Ok(const_uint(a)), Ok(const_int(b))) => {
+          (const_uint(a), const_int(b)) => {
             match op.node {
-              ast::BiShl => Ok(const_uint(a << b as uint)),
-              ast::BiShr => Ok(const_uint(a >> b as uint)),
+              ast::BiShl => const_uint(a << b as uint),
+              ast::BiShr => const_uint(a >> b as uint),
               _ => signal!(e, InvalidOpForUintInt(op.node)),
             }
           }
-          (Ok(const_bool(a)), Ok(const_bool(b))) => {
-            Ok(const_bool(match op.node {
+          (const_bool(a), const_bool(b)) => {
+            const_bool(match op.node {
               ast::BiAnd => a && b,
               ast::BiOr => a || b,
               ast::BiBitXor => a ^ b,
@@ -473,10 +477,8 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
               ast::BiEq => a == b,
               ast::BiNe => a != b,
               _ => signal!(e, InvalidOpForBools(op.node)),
-             }))
+             })
           }
-          (err @ Err(..), _) |
-          (_, err @ Err(..)) => err,
 
           _ => signal!(e, MiscBinaryOp),
         }
@@ -494,8 +496,8 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
         let base_hint = ty::expr_ty_opt(tcx, &**base).unwrap_or(ety);
         let val = try!(eval_const_expr_partial(tcx, &**base, Some(base_hint)));
         match cast_const(val, ety) {
-            Ok(val) => Ok(val),
-            Err(kind) => Err(ConstEvalErr { span: e.span, kind: kind }),
+            Ok(val) => val,
+            Err(kind) => return Err(ConstEvalErr { span: e.span, kind: kind }),
         }
       }
       ast::ExprPath(..) => {
@@ -526,16 +528,16 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
               None => signal!(e, NonConstPath)
           };
           let ety = ety.or_else(|| const_ty.and_then(|ty| ast_ty_to_prim_ty(tcx, ty)));
-          eval_const_expr_partial(tcx, const_expr, ety)
+          try!(eval_const_expr_partial(tcx, const_expr, ety))
       }
       ast::ExprLit(ref lit) => {
-          Ok(lit_to_const(&**lit, ety))
+          lit_to_const(&**lit, ety)
       }
-      ast::ExprParen(ref e)     => eval_const_expr_partial(tcx, &**e, ety),
+      ast::ExprParen(ref e) => try!(eval_const_expr_partial(tcx, &**e, ety)),
       ast::ExprBlock(ref block) => {
         match block.expr {
-            Some(ref expr) => eval_const_expr_partial(tcx, &**expr, ety),
-            None => Ok(const_int(0i64))
+            Some(ref expr) => try!(eval_const_expr_partial(tcx, &**expr, ety)),
+            None => const_int(0i64)
         }
       }
       ast::ExprTupField(ref base, index) => {
@@ -543,7 +545,7 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
         if let Some(&ast::ExprTup(ref fields)) = lookup_const(tcx, &**base).map(|s| &s.node) {
             // Check that the given index is within bounds and evaluate its value
             if fields.len() > index.node {
-                return eval_const_expr_partial(tcx, &*fields[index.node], None)
+                return eval_const_expr_partial(tcx, &*fields[index.node], None);
             } else {
                 signal!(e, TupleIndexOutOfBounds);
             }
@@ -558,7 +560,7 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
             // Check that the given field exists and evaluate it
             if let Some(f) = fields.iter().find(|f|
                                            f.ident.node.as_str() == field_name.node.as_str()) {
-                return eval_const_expr_partial(tcx, &*f.expr, None)
+                return eval_const_expr_partial(tcx, &*f.expr, None);
             } else {
                 signal!(e, MissingStructField);
             }
@@ -567,7 +569,9 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
         signal!(e, NonConstStruct);
       }
       _ => signal!(e, MiscCatchAll)
-    }
+    };
+
+    Ok(result)
 }
 
 fn cast_const(val: const_val, ty: Ty) -> Result<const_val, ErrKind> {

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -25,6 +25,7 @@ use syntax::parse::token::InternedString;
 use syntax::ptr::P;
 use syntax::{ast_map, ast_util, codemap};
 
+use std::borrow::{Cow, IntoCow};
 use std::num::wrapping::OverflowingOps;
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry::Vacant;
@@ -203,42 +204,193 @@ pub fn const_expr_to_pat(tcx: &ty::ctxt, expr: &Expr, span: Span) -> P<ast::Pat>
 pub fn eval_const_expr(tcx: &ty::ctxt, e: &Expr) -> const_val {
     match eval_const_expr_partial(tcx, e, None) {
         Ok(r) => r,
-        Err(s) => tcx.sess.span_fatal(e.span, &s[..])
+        Err(s) => tcx.sess.span_fatal(s.span, s.description().as_slice())
     }
 }
 
-fn checked_add_int(a: i64, b: i64) -> Result<const_val, String> {
-    let (ret, oflo) = a.overflowing_add(b);
-    if !oflo { Ok(const_int(ret)) } else { Err(format!("constant arithmetic overflow")) }
-}
-fn checked_sub_int(a: i64, b: i64) -> Result<const_val, String> {
-    let (ret, oflo) = a.overflowing_sub(b);
-    if !oflo { Ok(const_int(ret)) } else { Err(format!("constant arithmetic overflow")) }
-}
-fn checked_mul_int(a: i64, b: i64) -> Result<const_val, String> {
-    let (ret, oflo) = a.overflowing_mul(b);
-    if !oflo { Ok(const_int(ret)) } else { Err(format!("constant arithmetic overflow")) }
+
+#[derive(Clone)]
+pub struct ConstEvalErr {
+    pub span: Span,
+    pub kind: ErrKind,
 }
 
-fn checked_add_uint(a: u64, b: u64) -> Result<const_val, String> {
+#[derive(Clone)]
+pub enum ErrKind {
+    CannotCast,
+    CannotCastTo(&'static str),
+    InvalidOpForBools(ast::BinOp_),
+    InvalidOpForFloats(ast::BinOp_),
+    InvalidOpForIntUint(ast::BinOp_),
+    InvalidOpForUintInt(ast::BinOp_),
+    NegateOnString,
+    NegateOnBoolean,
+    NotOnFloat,
+    NotOnString,
+
+    AddiWithOverflow(i64, i64),
+    SubiWithOverflow(i64, i64),
+    MuliWithOverflow(i64, i64),
+    AdduWithOverflow(u64, u64),
+    SubuWithOverflow(u64, u64),
+    MuluWithOverflow(u64, u64),
+    DivideByZero,
+    DivideWithOverflow,
+    ModuloByZero,
+    ModuloWithOverflow,
+    MissingStructField,
+    NonConstPath,
+    NonConstStruct,
+    TupleIndexOutOfBounds,
+
+    MiscBinaryOp,
+    MiscCatchAll,
+}
+
+impl ConstEvalErr {
+    pub fn description(&self) -> Cow<str> {
+        use self::ErrKind::*;
+        match self.kind {
+            CannotCast => "can't cast this type".into_cow(),
+            CannotCastTo(s) => format!("can't cast this type to {}", s).into_cow(),
+            InvalidOpForBools(_) =>  "can't do this op on bools".into_cow(),
+            InvalidOpForFloats(_) => "can't do this op on floats".into_cow(),
+            InvalidOpForIntUint(..) => "can't do this op on an int and uint".into_cow(),
+            InvalidOpForUintInt(..) => "can't do this op on a uint and int".into_cow(),
+            NegateOnString => "negate on string".into_cow(),
+            NegateOnBoolean => "negate on boolean".into_cow(),
+            NotOnFloat => "not on float or string".into_cow(),
+            NotOnString => "not on float or string".into_cow(),
+
+            AddiWithOverflow(..) => "attempted to add with overflow".into_cow(),
+            SubiWithOverflow(..) => "attempted to sub with overflow".into_cow(),
+            MuliWithOverflow(..) => "attempted to mul with overflow".into_cow(),
+            AdduWithOverflow(..) => "attempted to add with overflow".into_cow(),
+            SubuWithOverflow(..) => "attempted to sub with overflow".into_cow(),
+            MuluWithOverflow(..) => "attempted to mul with overflow".into_cow(),
+            DivideByZero         => "attempted to divide by zero".into_cow(),
+            DivideWithOverflow   => "attempted to divide with overflow".into_cow(),
+            ModuloByZero         => "attempted remainder with a divisor of zero".into_cow(),
+            ModuloWithOverflow   => "attempted remainder with overflow".into_cow(),
+            MissingStructField  => "nonexistent struct field".into_cow(),
+            NonConstPath        => "non-constant path in constant expr".into_cow(),
+            NonConstStruct      => "non-constant struct in constant expr".into_cow(),
+            TupleIndexOutOfBounds => "tuple index out of bounds".into_cow(),
+
+            MiscBinaryOp => "bad operands for binary".into_cow(),
+            MiscCatchAll => "unsupported constant expr".into_cow(),
+        }
+    }
+}
+
+fn invalid_op_for_bools(e: &Expr, op: ast::BinOp_) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::InvalidOpForBools(op) }
+}
+fn invalid_op_for_floats(e: &Expr, op: ast::BinOp_) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::InvalidOpForFloats(op) }
+}
+fn invalid_op_for_int_uint(e: &Expr, op: ast::BinOp_) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::InvalidOpForIntUint(op) }
+}
+fn invalid_op_for_uint_int(e: &Expr, op: ast::BinOp_) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::InvalidOpForUintInt(op) }
+}
+fn negate_on_string(e: &Expr) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::NegateOnString }
+}
+fn negate_on_boolean(e: &Expr) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::NegateOnBoolean }
+}
+fn not_on_float(e: &Expr) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::NotOnFloat }
+}
+fn not_on_string(e: &Expr) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::NotOnString }
+}
+
+fn addi_with_overflow(e: &Expr, a: i64, b: i64) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::AddiWithOverflow(a, b) }
+}
+fn subi_with_overflow(e: &Expr, a: i64, b: i64) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::SubiWithOverflow(a, b) }
+}
+fn muli_with_overflow(e: &Expr, a: i64, b: i64) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::MuliWithOverflow(a, b) }
+}
+fn addu_with_overflow(e: &Expr, a: u64, b: u64) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::AdduWithOverflow(a, b) }
+}
+fn subu_with_overflow(e: &Expr, a: u64, b: u64) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::SubuWithOverflow(a, b) }
+}
+fn mulu_with_overflow(e: &Expr, a: u64, b: u64) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::MuluWithOverflow(a, b) }
+}
+fn divide_by_zero(e: &Expr) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::DivideByZero }
+}
+fn divide_with_overflow(e: &Expr) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::DivideWithOverflow }
+}
+fn modulo_by_zero(e: &Expr) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::ModuloByZero }
+}
+fn modulo_with_overflow(e: &Expr) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::ModuloWithOverflow }
+}
+fn missing_struct_field(e: &Expr) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::MissingStructField }
+}
+fn non_const_path(e: &Expr) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::NonConstPath }
+}
+fn non_const_struct(e: &Expr) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::NonConstStruct }
+}
+fn tuple_index_out_of_bounds(e: &Expr) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::TupleIndexOutOfBounds }
+}
+
+fn misc_binary_op(e: &Expr) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::MiscBinaryOp }
+}
+fn misc_catch_all(e: &Expr) -> ConstEvalErr {
+    ConstEvalErr { span: e.span, kind: ErrKind::MiscCatchAll }
+}
+
+
+fn checked_add_int(e: &Expr, a: i64, b: i64) -> Result<const_val, ConstEvalErr> {
     let (ret, oflo) = a.overflowing_add(b);
-    if !oflo { Ok(const_uint(ret)) } else { Err(format!("constant arithmetic overflow")) }
+    if !oflo { Ok(const_int(ret)) } else { Err(addi_with_overflow(e, a, b)) }
 }
-fn checked_sub_uint(a: u64, b: u64) -> Result<const_val, String> {
+fn checked_sub_int(e: &Expr, a: i64, b: i64) -> Result<const_val, ConstEvalErr> {
     let (ret, oflo) = a.overflowing_sub(b);
-    if !oflo { Ok(const_uint(ret)) } else { Err(format!("constant arithmetic overflow")) }
+    if !oflo { Ok(const_int(ret)) } else { Err(subi_with_overflow(e, a, b)) }
 }
-fn checked_mul_uint(a: u64, b: u64) -> Result<const_val, String> {
+fn checked_mul_int(e: &Expr, a: i64, b: i64) -> Result<const_val, ConstEvalErr> {
     let (ret, oflo) = a.overflowing_mul(b);
-    if !oflo { Ok(const_uint(ret)) } else { Err(format!("constant arithmetic overflow")) }
+    if !oflo { Ok(const_int(ret)) } else { Err(muli_with_overflow(e, a, b)) }
+}
+
+fn checked_add_uint(e: &Expr, a: u64, b: u64) -> Result<const_val, ConstEvalErr> {
+    let (ret, oflo) = a.overflowing_add(b);
+    if !oflo { Ok(const_uint(ret)) } else { Err(addu_with_overflow(e, a, b)) }
+}
+fn checked_sub_uint(e: &Expr, a: u64, b: u64) -> Result<const_val, ConstEvalErr> {
+    let (ret, oflo) = a.overflowing_sub(b);
+    if !oflo { Ok(const_uint(ret)) } else { Err(subu_with_overflow(e, a, b)) }
+}
+fn checked_mul_uint(e: &Expr, a: u64, b: u64) -> Result<const_val, ConstEvalErr> {
+    let (ret, oflo) = a.overflowing_mul(b);
+    if !oflo { Ok(const_uint(ret)) } else { Err(mulu_with_overflow(e, a, b)) }
 }
 
 
 pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
                                      e: &Expr,
                                      ty_hint: Option<Ty<'tcx>>)
-                                     -> Result<const_val, String> {
-    fn fromb(b: bool) -> Result<const_val, String> { Ok(const_int(b as i64)) }
+                                     -> Result<const_val, ConstEvalErr> {
+    fn fromb<T>(b: bool) -> Result<const_val, T> { Ok(const_int(b as i64)) }
 
     let ety = ty_hint.or_else(|| ty::expr_ty_opt(tcx, e));
 
@@ -248,9 +400,9 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
           Ok(const_float(f)) => Ok(const_float(-f)),
           Ok(const_int(i)) => Ok(const_int(-i)),
           Ok(const_uint(i)) => Ok(const_uint(-i)),
-          Ok(const_str(_)) => Err("negate on string".to_string()),
-          Ok(const_bool(_)) => Err("negate on boolean".to_string()),
-          ref err => ((*err).clone())
+          Ok(const_str(_)) => Err(negate_on_string(e)),
+          Ok(const_bool(_)) => Err(negate_on_boolean(e)),
+          err => err
         }
       }
       ast::ExprUnary(ast::UnNot, ref inner) => {
@@ -258,7 +410,9 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
           Ok(const_int(i)) => Ok(const_int(!i)),
           Ok(const_uint(i)) => Ok(const_uint(!i)),
           Ok(const_bool(b)) => Ok(const_bool(!b)),
-          _ => Err("not on float or string".to_string())
+          Ok(const_str(_)) => Err(not_on_string(e)),
+          Ok(const_float(_)) => Err(not_on_float(e)),
+          err => err
         }
       }
       ast::ExprBinary(op, ref a, ref b) => {
@@ -281,7 +435,7 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
               ast::BiNe => fromb(a != b),
               ast::BiGe => fromb(a >= b),
               ast::BiGt => fromb(a > b),
-              _ => Err("can't do this op on floats".to_string())
+              _ => Err(invalid_op_for_floats(e, op.node)),
             }
           }
           (Ok(const_int(a)), Ok(const_int(b))) => {
@@ -304,23 +458,23 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
                 }
             };
             match op.node {
-              ast::BiAdd => checked_add_int(a, b),
-              ast::BiSub => checked_sub_int(a, b),
-              ast::BiMul => checked_mul_int(a, b),
+              ast::BiAdd => checked_add_int(e, a, b),
+              ast::BiSub => checked_sub_int(e, a, b),
+              ast::BiMul => checked_mul_int(e, a, b),
               ast::BiDiv => {
                   if b == 0 {
-                      Err("attempted to divide by zero".to_string())
+                      Err(divide_by_zero(e))
                   } else if b == -1 && is_a_min_value() {
-                      Err("attempted to divide with overflow".to_string())
+                      Err(divide_with_overflow(e))
                   } else {
                       Ok(const_int(a / b))
                   }
               }
               ast::BiRem => {
                   if b == 0 {
-                      Err("attempted remainder with a divisor of zero".to_string())
+                      Err(modulo_by_zero(e))
                   } else if b == -1 && is_a_min_value() {
-                      Err("attempted remainder with overflow".to_string())
+                      Err(modulo_with_overflow(e))
                   } else {
                       Ok(const_int(a % b))
                   }
@@ -340,17 +494,12 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
           }
           (Ok(const_uint(a)), Ok(const_uint(b))) => {
             match op.node {
-              ast::BiAdd => checked_add_uint(a, b),
-              ast::BiSub => checked_sub_uint(a, b),
-              ast::BiMul => checked_mul_uint(a, b),
-              ast::BiDiv if b == 0 => {
-                  Err("attempted to divide by zero".to_string())
-              }
+              ast::BiAdd => checked_add_uint(e, a, b),
+              ast::BiSub => checked_sub_uint(e, a, b),
+              ast::BiMul => checked_mul_uint(e, a, b),
+              ast::BiDiv if b == 0 => Err(divide_by_zero(e)),
               ast::BiDiv => Ok(const_uint(a / b)),
-              ast::BiRem if b == 0 => {
-                  Err("attempted remainder with a divisor of \
-                       zero".to_string())
-              }
+              ast::BiRem if b == 0 => Err(modulo_by_zero(e)),
               ast::BiRem => Ok(const_uint(a % b)),
               ast::BiAnd | ast::BiBitAnd => Ok(const_uint(a & b)),
               ast::BiOr | ast::BiBitOr => Ok(const_uint(a | b)),
@@ -370,14 +519,14 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
             match op.node {
               ast::BiShl => Ok(const_int(a << b as uint)),
               ast::BiShr => Ok(const_int(a >> b as uint)),
-              _ => Err("can't do this op on an int and uint".to_string())
+              _ => Err(invalid_op_for_int_uint(e, op.node)),
             }
           }
           (Ok(const_uint(a)), Ok(const_int(b))) => {
             match op.node {
               ast::BiShl => Ok(const_uint(a << b as uint)),
               ast::BiShr => Ok(const_uint(a >> b as uint)),
-              _ => Err("can't do this op on a uint and int".to_string())
+              _ => Err(invalid_op_for_uint_int(e, op.node)),
             }
           }
           (Ok(const_bool(a)), Ok(const_bool(b))) => {
@@ -389,10 +538,13 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
               ast::BiBitOr => a | b,
               ast::BiEq => a == b,
               ast::BiNe => a != b,
-              _ => return Err("can't do this op on bools".to_string())
+              _ => return Err(invalid_op_for_bools(e, op.node)),
              }))
           }
-          _ => Err("bad operands for binary".to_string())
+          (err @ Err(..), _) |
+          (_, err @ Err(..)) => err,
+
+          _ => Err(misc_binary_op(e)),
         }
       }
       ast::ExprCast(ref base, ref target_ty) => {
@@ -407,7 +559,10 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
         // Prefer known type to noop, but always have a type hint.
         let base_hint = ty::expr_ty_opt(tcx, &**base).unwrap_or(ety);
         let val = try!(eval_const_expr_partial(tcx, &**base, Some(base_hint)));
-        cast_const(val, ety)
+        match cast_const(val, ety) {
+            Ok(val) => Ok(val),
+            Err(kind) => Err(ConstEvalErr { span: e.span, kind: kind }),
+        }
       }
       ast::ExprPath(..) => {
           let opt_def = tcx.def_map.borrow().get(&e.id).map(|d| d.full_def());
@@ -434,7 +589,7 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
           };
           let const_expr = match const_expr {
               Some(actual_e) => actual_e,
-              None => return Err("non-constant path in constant expr".to_string())
+              None => return Err(non_const_path(e)),
           };
           let ety = ety.or_else(|| const_ty.and_then(|ty| ast_ty_to_prim_ty(tcx, ty)));
           eval_const_expr_partial(tcx, const_expr, ety)
@@ -456,11 +611,11 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
             if fields.len() > index.node {
                 return eval_const_expr_partial(tcx, &*fields[index.node], None)
             } else {
-                return Err("tuple index out of bounds".to_string())
+                return Err(tuple_index_out_of_bounds(e))
             }
         }
 
-        Err("non-constant struct in constant expr".to_string())
+        Err(non_const_struct(e))
       }
       ast::ExprField(ref base, field_name) => {
         // Get the base expression if it is a struct and it is constant
@@ -471,17 +626,17 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
                                            f.ident.node.as_str() == field_name.node.as_str()) {
                 return eval_const_expr_partial(tcx, &*f.expr, None)
             } else {
-                return Err("nonexistent struct field".to_string())
+                return Err(missing_struct_field(e));
             }
         }
 
-        Err("non-constant struct in constant expr".to_string())
+        Err(non_const_struct(e))
       }
-      _ => Err("unsupported constant expr".to_string())
+      _ => Err(misc_catch_all(e))
     }
 }
 
-fn cast_const(val: const_val, ty: Ty) -> Result<const_val, String> {
+fn cast_const(val: const_val, ty: Ty) -> Result<const_val, ErrKind> {
     macro_rules! define_casts {
         ($($ty_pat:pat => (
             $intermediate_ty:ty,
@@ -494,11 +649,10 @@ fn cast_const(val: const_val, ty: Ty) -> Result<const_val, String> {
                     const_uint(u) => Ok($const_type(u as $intermediate_ty as $target_ty)),
                     const_int(i) => Ok($const_type(i as $intermediate_ty as $target_ty)),
                     const_float(f) => Ok($const_type(f as $intermediate_ty as $target_ty)),
-                    _ => Err(concat!("can't cast this type to ",
-                                     stringify!($const_type)).to_string())
+                    _ => Err(ErrKind::CannotCastTo(stringify!($const_type))),
                 }
             },)*
-            _ => Err("can't cast this type".to_string())
+            _ => Err(ErrKind::CannotCast),
         })
     }
 
@@ -572,15 +726,15 @@ pub fn compare_lit_exprs<'tcx>(tcx: &ty::ctxt<'tcx>,
                                -> Option<Ordering> {
     let a = match eval_const_expr_partial(tcx, a, ty_hint) {
         Ok(a) => a,
-        Err(s) => {
-            tcx.sess.span_err(a.span, &s[..]);
+        Err(e) => {
+            tcx.sess.span_err(a.span, e.description().as_slice());
             return None;
         }
     };
     let b = match eval_const_expr_partial(tcx, b, ty_hint) {
         Ok(b) => b,
-        Err(s) => {
-            tcx.sess.span_err(b.span, &s[..]);
+        Err(e) => {
+            tcx.sess.span_err(b.span, e.description().as_slice());
             return None;
         }
     };

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -5366,8 +5366,9 @@ pub fn enum_variants<'tcx>(cx: &ctxt<'tcx>, id: ast::DefId)
                                                       "expected signed integer constant");
                                         }
                                         Err(err) => {
-                                            span_err!(cx.sess, e.span, E0305,
-                                                      "expected constant: {}", err);
+                                            span_err!(cx.sess, err.span, E0305,
+                                                      "constant evaluation error: {}",
+                                                      err.description().as_slice());
                                         }
                                     }
                                 } else {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -5333,6 +5333,7 @@ pub fn type_is_empty(cx: &ctxt, ty: Ty) -> bool {
 
 pub fn enum_variants<'tcx>(cx: &ctxt<'tcx>, id: ast::DefId)
                            -> Rc<Vec<Rc<VariantInfo<'tcx>>>> {
+    use std::num::Int; // For checked_add
     memoized(&cx.enum_var_cache, id, |id: ast::DefId| {
         if ast::LOCAL_CRATE != id.krate {
             Rc::new(csearch::get_enum_variants(cx, id))
@@ -5349,11 +5350,7 @@ pub fn enum_variants<'tcx>(cx: &ctxt<'tcx>, id: ast::DefId)
                             let mut last_discriminant: Option<Disr> = None;
                             Rc::new(enum_definition.variants.iter().map(|variant| {
 
-                                let mut discriminant = match last_discriminant {
-                                    Some(val) => val + 1,
-                                    None => INITIAL_DISCRIMINANT_VALUE
-                                };
-
+                                let mut discriminant = INITIAL_DISCRIMINANT_VALUE;
                                 if let Some(ref e) = variant.node.disr_expr {
                                     // Preserve all values, and prefer signed.
                                     let ty = Some(cx.types.i64);
@@ -5373,7 +5370,19 @@ pub fn enum_variants<'tcx>(cx: &ctxt<'tcx>, id: ast::DefId)
                                                       "expected constant: {}", err);
                                         }
                                     }
-                                };
+                                } else {
+                                    if let Some(val) = last_discriminant {
+                                        if let Some(v) = val.checked_add(1) {
+                                            discriminant = v
+                                        } else {
+                                            cx.sess.span_err(
+                                                variant.span,
+                                                &format!("Discriminant overflowed!"));
+                                        }
+                                    } else {
+                                        discriminant = INITIAL_DISCRIMINANT_VALUE;
+                                    }
+                                }
 
                                 last_discriminant = Some(discriminant);
                                 Rc::new(VariantInfo::from_ast_variant(cx, &**variant,

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -259,7 +259,6 @@ pub enum CrateType {
     CrateTypeStaticlib,
 }
 
-
 #[derive(Clone)]
 pub enum Passes {
     SomePasses(Vec<String>),
@@ -585,6 +584,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
           "Adds unstable command line options to rustc interface"),
     print_enum_sizes: bool = (false, parse_bool,
           "Print the size of enums and their variants"),
+    force_overflow_checks: Option<bool> = (None, parse_opt_bool,
+          "Force overflow checks on or off"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -348,7 +348,8 @@ macro_rules! options {
     #[allow(non_upper_case_globals, dead_code)]
     mod $mod_desc {
         pub const parse_bool: Option<&'static str> = None;
-        pub const parse_opt_bool: Option<&'static str> = None;
+        pub const parse_opt_bool: Option<&'static str> =
+            Some("one of: `y`, `yes`, `on`, `n`, `no`, or `off`");
         pub const parse_string: Option<&'static str> = Some("a string");
         pub const parse_opt_string: Option<&'static str> = Some("a string");
         pub const parse_list: Option<&'static str> = Some("a space-separated list of strings");
@@ -379,7 +380,19 @@ macro_rules! options {
 
         fn parse_opt_bool(slot: &mut Option<bool>, v: Option<&str>) -> bool {
             match v {
-                Some(..) => false,
+                Some(s) => {
+                    match s {
+                        "n" | "no" | "off" => {
+                            *slot = Some(false);
+                        }
+                        "y" | "yes" | "on" => {
+                            *slot = Some(true);
+                        }
+                        _ => { return false; }
+                    }
+
+                    true
+                },
                 None => { *slot = Some(true); true }
             }
         }

--- a/src/librustc/util/nodemap.rs
+++ b/src/librustc/util/nodemap.rs
@@ -57,7 +57,7 @@ impl Hasher for FnvHasher {
         let FnvHasher(mut hash) = *self;
         for byte in bytes {
             hash = hash ^ (*byte as u64);
-            hash = hash * 0x100000001b3;
+            hash = hash.wrapping_mul(0x100000001b3);
         }
         *self = FnvHasher(hash);
     }

--- a/src/librustc_back/sha2.rs
+++ b/src/librustc_back/sha2.rs
@@ -347,17 +347,19 @@ impl Engine256State {
         // Sha-512 and Sha-256 use basically the same calculations which are implemented
         // by these macros. Inlining the calculations seems to result in better generated code.
         macro_rules! schedule_round { ($t:expr) => (
-                w[$t] = sigma1(w[$t - 2]) + w[$t - 7] + sigma0(w[$t - 15]) + w[$t - 16];
-                )
+            w[$t] = sigma1(w[$t - 2]).wrapping_add(w[$t - 7])
+                .wrapping_add(sigma0(w[$t - 15])).wrapping_add(w[$t - 16]);
+            )
         }
 
         macro_rules! sha2_round {
             ($A:ident, $B:ident, $C:ident, $D:ident,
              $E:ident, $F:ident, $G:ident, $H:ident, $K:ident, $t:expr) => (
                 {
-                    $H += sum1($E) + ch($E, $F, $G) + $K[$t] + w[$t];
-                    $D += $H;
-                    $H += sum0($A) + maj($A, $B, $C);
+                    $H = $H.wrapping_add(sum1($E)).wrapping_add(ch($E, $F, $G))
+                        .wrapping_add($K[$t]).wrapping_add(w[$t]);
+                    $D = $D.wrapping_add($H);
+                    $H = $H.wrapping_add(sum0($A)).wrapping_add(maj($A, $B, $C));
                 }
              )
         }
@@ -397,14 +399,14 @@ impl Engine256State {
             sha2_round!(b, c, d, e, f, g, h, a, K32, t + 7);
         }
 
-        self.h0 += a;
-        self.h1 += b;
-        self.h2 += c;
-        self.h3 += d;
-        self.h4 += e;
-        self.h5 += f;
-        self.h6 += g;
-        self.h7 += h;
+        self.h0 = self.h0.wrapping_add(a);
+        self.h1 = self.h1.wrapping_add(b);
+        self.h2 = self.h2.wrapping_add(c);
+        self.h3 = self.h3.wrapping_add(d);
+        self.h4 = self.h4.wrapping_add(e);
+        self.h5 = self.h5.wrapping_add(f);
+        self.h6 = self.h6.wrapping_add(g);
+        self.h7 = self.h7.wrapping_add(h);
     }
 }
 

--- a/src/librustc_trans/trans/adt.rs
+++ b/src/librustc_trans/trans/adt.rs
@@ -778,7 +778,9 @@ fn load_discr(bcx: Block, ity: IntType, ptr: ValueRef, min: Disr, max: Disr)
     assert!(bits <= 64);
     let  bits = bits as uint;
     let mask = (-1u64 >> (64 - bits)) as Disr;
-    if (max + 1) & mask == min & mask {
+    // For a (max) discr of -1, max will be `-1 as usize`, which overflows.
+    // However, that is fine here (it would still represent the full range),
+    if (max.wrapping_add(1)) & mask == min & mask {
         // i.e., if the range is everything.  The lo==hi case would be
         // rejected by the LLVM verifier (it would mean either an
         // empty set, which is impossible, or the entire range of the
@@ -787,7 +789,7 @@ fn load_discr(bcx: Block, ity: IntType, ptr: ValueRef, min: Disr, max: Disr)
     } else {
         // llvm::ConstantRange can deal with ranges that wrap around,
         // so an overflow on (max + 1) is fine.
-        LoadRangeAssert(bcx, ptr, min, (max+1), /* signed: */ True)
+        LoadRangeAssert(bcx, ptr, min, (max.wrapping_add(1)), /* signed: */ True)
     }
 }
 

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -3102,6 +3102,12 @@ pub fn trans_crate<'tcx>(analysis: ty::CrateAnalysis<'tcx>)
     let ty::CrateAnalysis { ty_cx: tcx, export_map, reachable, name, .. } = analysis;
     let krate = tcx.map.krate();
 
+    let check_overflow = if let Some(v) = tcx.sess.opts.debugging_opts.force_overflow_checks {
+        v
+    } else {
+        !attr::contains_name(&krate.config, "ndebug")
+    };
+
     // Before we touch LLVM, make sure that multithreading is enabled.
     unsafe {
         use std::sync::{Once, ONCE_INIT};
@@ -3129,7 +3135,8 @@ pub fn trans_crate<'tcx>(analysis: ty::CrateAnalysis<'tcx>)
                                              export_map,
                                              Sha256::new(),
                                              link_meta.clone(),
-                                             reachable);
+                                             reachable,
+                                             check_overflow);
 
     {
         let ccx = shared_ccx.get_ccx(0);

--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -462,9 +462,9 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
 
           ast::ExprIndex(ref base, ref index) => {
               let (bv, bt) = const_expr(cx, &**base, param_substs);
-              let iv = match const_eval::eval_const_expr(cx.tcx(), &**index) {
-                  const_eval::const_int(i) => i as u64,
-                  const_eval::const_uint(u) => u,
+              let iv = match const_eval::eval_const_expr_partial(cx.tcx(), &**index, None) {
+                  Ok(const_eval::const_int(i)) => i as u64,
+                  Ok(const_eval::const_uint(u)) => u,
                   _ => cx.sess().span_bug(index.span,
                                           "index is not an integer-constant expression")
               };
@@ -650,9 +650,9 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
           ast::ExprRepeat(ref elem, ref count) => {
             let unit_ty = ty::sequence_element_type(cx.tcx(), ety);
             let llunitty = type_of::type_of(cx, unit_ty);
-            let n = match const_eval::eval_const_expr(cx.tcx(), &**count) {
-                const_eval::const_int(i)  => i as uint,
-                const_eval::const_uint(i) => i as uint,
+            let n = match const_eval::eval_const_expr_partial(cx.tcx(), &**count, None) {
+                Ok(const_eval::const_int(i))  => i as uint,
+                Ok(const_eval::const_uint(i)) => i as uint,
                 _ => cx.sess().span_bug(count.span, "count must be integral const expression.")
             };
             let unit_val = const_expr(cx, &**elem, param_substs).0;

--- a/src/librustc_trans/trans/context.rs
+++ b/src/librustc_trans/trans/context.rs
@@ -69,6 +69,7 @@ pub struct SharedCrateContext<'tcx> {
     symbol_hasher: RefCell<Sha256>,
     tcx: ty::ctxt<'tcx>,
     stats: Stats,
+    check_overflow: bool,
 
     available_monomorphizations: RefCell<FnvHashSet<String>>,
     available_drop_glues: RefCell<FnvHashMap<Ty<'tcx>, String>>,
@@ -245,7 +246,8 @@ impl<'tcx> SharedCrateContext<'tcx> {
                export_map: ExportMap,
                symbol_hasher: Sha256,
                link_meta: LinkMeta,
-               reachable: NodeSet)
+               reachable: NodeSet,
+               check_overflow: bool)
                -> SharedCrateContext<'tcx> {
         let (metadata_llcx, metadata_llmod) = unsafe {
             create_context_and_module(&tcx.sess, "metadata")
@@ -274,6 +276,7 @@ impl<'tcx> SharedCrateContext<'tcx> {
                 llvm_insns: RefCell::new(FnvHashMap()),
                 fn_stats: RefCell::new(Vec::new()),
             },
+            check_overflow: check_overflow,
             available_monomorphizations: RefCell::new(FnvHashSet()),
             available_drop_glues: RefCell::new(FnvHashMap()),
         };
@@ -742,6 +745,10 @@ impl<'b, 'tcx> CrateContext<'b, 'tcx> {
         self.sess().fatal(
             &format!("the type `{}` is too big for the current architecture",
                     obj.repr(self.tcx())))
+    }
+
+    pub fn check_overflow(&self) -> bool {
+        self.shared.check_overflow
     }
 }
 

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -660,6 +660,11 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                                     llargs[0],
                                     llargs[1],
                                     call_debug_location),
+
+        (_, "overflowing_add") => Add(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "overflowing_sub") => Sub(bcx, llargs[0], llargs[1], call_debug_location),
+        (_, "overflowing_mul") => Mul(bcx, llargs[0], llargs[1], call_debug_location),
+
         (_, "return_address") => {
             if !fcx.caller_expects_out_pointer {
                 tcx.sess.span_err(call_info.span,

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1399,7 +1399,7 @@ pub fn ast_ty_to_ty<'tcx>(this: &AstConv<'tcx>,
                 Err(ref r) => {
                     let subspan  =
                         ast_ty.span.lo <= r.span.lo && r.span.hi <= ast_ty.span.hi;
-                    span_err!(tcx.sess, ast_ty.span, E0250,
+                    span_err!(tcx.sess, r.span, E0250,
                               "array length constant evaluation error: {}",
                               r.description().as_slice());
                     if !subspan {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1233,17 +1233,18 @@ pub fn finish_resolving_def_to_ty<'tcx>(this: &AstConv<'tcx>,
             if segments.is_empty() {
                 opt_self_ty.expect("missing T in <T>::a::b::c")
             } else {
-                tcx.sess.span_bug(span,
-                                  &format!("found module name used as a type: {}",
-                                           tcx.map.node_to_string(id.node)));
+                span_err!(tcx.sess, span, E0247, "found module name used as a type: {}",
+                          tcx.map.node_to_string(id.node));
+                return this.tcx().types.err;
             }
         }
         def::DefPrimTy(prim_ty) => {
             prim_ty_to_ty(tcx, segments, prim_ty)
         }
         _ => {
-            span_fatal!(tcx.sess, span, E0248,
-                        "found value name used as a type: {:?}", *def);
+            span_err!(tcx.sess, span, E0248,
+                      "found value name used as a type: {:?}", *def);
+            return this.tcx().types.err;
         }
     };
 
@@ -1278,10 +1279,11 @@ pub fn ast_ty_to_ty<'tcx>(this: &AstConv<'tcx>,
     match ast_ty_to_ty_cache.get(&ast_ty.id) {
         Some(&ty::atttce_resolved(ty)) => return ty,
         Some(&ty::atttce_unresolved) => {
-            span_fatal!(tcx.sess, ast_ty.span, E0246,
+            span_err!(tcx.sess, ast_ty.span, E0246,
                                 "illegal recursive type; insert an enum \
                                  or struct in the cycle, if this is \
                                  desired");
+            return this.tcx().types.err;
         }
         None => { /* go on */ }
     }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -205,9 +205,9 @@ pub fn opt_ast_region_to_region<'tcx>(
 
                                 if len == 2 && i == 0 {
                                     m.push_str(" or ");
-                                } else if i == len - 2 {
+                                } else if i + 2 == len {
                                     m.push_str(", or ");
-                                } else if i != len - 1 {
+                                } else if i + 1 != len {
                                     m.push_str(", ");
                                 }
                             }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1390,14 +1390,22 @@ pub fn ast_ty_to_ty<'tcx>(this: &AstConv<'tcx>,
                             ty::mk_vec(tcx, ast_ty_to_ty(this, rscope, &**ty),
                                         Some(i as uint)),
                         _ => {
-                            span_fatal!(tcx.sess, ast_ty.span, E0249,
-                                        "expected constant expr for array length");
+                            span_err!(tcx.sess, ast_ty.span, E0249,
+                                      "expected constant expr for array length");
+                            this.tcx().types.err
                         }
                     }
                 }
-                Err(r) => {
-                    span_fatal!(tcx.sess, ast_ty.span, E0250,
-                                "expected constant expr for array length: {}", r);
+                Err(ref r) => {
+                    let subspan  =
+                        ast_ty.span.lo <= r.span.lo && r.span.hi <= ast_ty.span.hi;
+                    span_err!(tcx.sess, ast_ty.span, E0250,
+                              "array length constant evaluation error: {}",
+                              r.description().as_slice());
+                    if !subspan {
+                        span_note!(tcx.sess, ast_ty.span, "for array length here")
+                    }
+                    this.tcx().types.err
                 }
             }
         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4554,6 +4554,7 @@ pub fn check_enum_variants<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
                           id: ast::NodeId,
                           hint: attr::ReprAttr)
                           -> Vec<Rc<ty::VariantInfo<'tcx>>> {
+        use std::num::Int;
 
         let rty = ty::node_id_to_type(ccx.tcx, id);
         let mut variants: Vec<Rc<ty::VariantInfo>> = Vec::new();
@@ -4565,7 +4566,13 @@ pub fn check_enum_variants<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
             // If the discriminant value is specified explicitly in the enum check whether the
             // initialization expression is valid, otherwise use the last value plus one.
             let mut current_disr_val = match prev_disr_val {
-                Some(prev_disr_val) => prev_disr_val + 1,
+                Some(prev_disr_val) => {
+                    if let Some(v) = prev_disr_val.checked_add(1) {
+                        v
+                    } else {
+                        ty::INITIAL_DISCRIMINANT_VALUE
+                    }
+                }
                 None => ty::INITIAL_DISCRIMINANT_VALUE
             };
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5491,6 +5491,9 @@ pub fn check_intrinsic_type(ccx: &CrateCtxt, it: &ast::ForeignItem) {
                 (0, vec!(tcx.types.u64, tcx.types.u64),
                 ty::mk_tup(tcx, vec!(tcx.types.u64, tcx.types.bool))),
 
+            "overflowing_add" | "overflowing_sub" | "overflowing_mul" =>
+                (1, vec![param(ccx, 0), param(ccx, 0)], param(ccx, 0)),
+
             "return_address" => (0, vec![], ty::mk_imm_ptr(tcx, tcx.types.u8)),
 
             "assume" => (0, vec![tcx.types.bool], ty::mk_nil(tcx)),

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1363,10 +1363,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         match self.inh.locals.borrow().get(&nid) {
             Some(&t) => t,
             None => {
-                self.tcx().sess.span_bug(
+                self.tcx().sess.span_err(
                     span,
-                    &format!("no type for local variable {}",
-                            nid));
+                    &format!("no type for local variable {}", nid));
+                self.tcx().types.err
             }
         }
     }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4604,8 +4604,9 @@ pub fn check_enum_variants<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
                                 "expected signed integer constant");
                         }
                         Err(ref err) => {
-                            span_err!(ccx.tcx.sess, e.span, E0080,
-                                "expected constant: {}", *err);
+                            span_err!(ccx.tcx.sess, err.span, E0080,
+                                      "constant evaluation error: {}",
+                                      err.description().as_slice());
                         }
                     }
                 },

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1569,8 +1569,8 @@ impl<T: Iterator<Item=char>> Parser<T> {
                 while !self.eof() {
                     match self.ch_or_null() {
                         c @ '0' ... '9' => {
-                            accum *= 10;
-                            accum += (c as u64) - ('0' as u64);
+                            accum = accum.wrapping_mul(10);
+                            accum = accum.wrapping_add((c as u64) - ('0' as u64));
 
                             // Detect overflow by comparing to the last value.
                             if accum <= last_accum { return self.error(InvalidNumber); }

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -314,6 +314,13 @@ fn search_hashed<K, V, M, F>(table: M,
     M: Deref<Target=RawTable<K, V>>,
     F: FnMut(&K) -> bool,
 {
+    // This is the only function where capacity can be zero. To avoid
+    // undefined behaviour when Bucket::new gets the raw bucket in this
+    // case, immediately return the appropriate search result.
+    if table.capacity() == 0 {
+        return TableRef(table);
+    }
+
     let size = table.size();
     let mut probe = Bucket::new(table, hash);
     let ib = probe.index();

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -30,6 +30,7 @@ pub use core::num::{from_uint, from_u8, from_u16, from_u32, from_u64};
 pub use core::num::{from_f32, from_f64};
 pub use core::num::{FromStrRadix, from_str_radix};
 pub use core::num::{FpCategory, ParseIntError, ParseFloatError};
+pub use core::num::wrapping;
 
 use option::Option;
 

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -1758,25 +1758,25 @@ mod tests {
         let mut u8_val: u8 = 255_u8;
         assert_eq!(u8_val.to_string(), "255");
 
-        u8_val += 1 as u8;
+        u8_val = u8_val.wrapping_add(1);
         assert_eq!(u8_val.to_string(), "0");
 
         let mut u16_val: u16 = 65_535_u16;
         assert_eq!(u16_val.to_string(), "65535");
 
-        u16_val += 1 as u16;
+        u16_val = u16_val.wrapping_add(1);
         assert_eq!(u16_val.to_string(), "0");
 
         let mut u32_val: u32 = 4_294_967_295_u32;
         assert_eq!(u32_val.to_string(), "4294967295");
 
-        u32_val += 1 as u32;
+        u32_val = u32_val.wrapping_add(1);
         assert_eq!(u32_val.to_string(), "0");
 
         let mut u64_val: u64 = 18_446_744_073_709_551_615_u64;
         assert_eq!(u64_val.to_string(), "18446744073709551615");
 
-        u64_val += 1 as u64;
+        u64_val = u64_val.wrapping_add(1);
         assert_eq!(u64_val.to_string(), "0");
     }
 
@@ -1790,7 +1790,7 @@ mod tests {
         assert_eq!(from_str::<u8>("255"), Some(u8_val));
         assert_eq!(from_str::<u8>("256"), None);
 
-        u8_val += 1 as u8;
+        u8_val = u8_val.wrapping_add(1);
         assert_eq!(from_str::<u8>("0"), Some(u8_val));
         assert_eq!(from_str::<u8>("-1"), None);
 
@@ -1798,7 +1798,7 @@ mod tests {
         assert_eq!(from_str::<u16>("65535"), Some(u16_val));
         assert_eq!(from_str::<u16>("65536"), None);
 
-        u16_val += 1 as u16;
+        u16_val = u16_val.wrapping_add(1);
         assert_eq!(from_str::<u16>("0"), Some(u16_val));
         assert_eq!(from_str::<u16>("-1"), None);
 
@@ -1806,7 +1806,7 @@ mod tests {
         assert_eq!(from_str::<u32>("4294967295"), Some(u32_val));
         assert_eq!(from_str::<u32>("4294967296"), None);
 
-        u32_val += 1 as u32;
+        u32_val = u32_val.wrapping_add(1);
         assert_eq!(from_str::<u32>("0"), Some(u32_val));
         assert_eq!(from_str::<u32>("-1"), None);
 
@@ -1814,7 +1814,7 @@ mod tests {
         assert_eq!(from_str::<u64>("18446744073709551615"), Some(u64_val));
         assert_eq!(from_str::<u64>("18446744073709551616"), None);
 
-        u64_val += 1 as u64;
+        u64_val = u64_val.wrapping_add(1);
         assert_eq!(from_str::<u64>("0"), Some(u64_val));
         assert_eq!(from_str::<u64>("-1"), None);
     }

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -427,6 +427,7 @@ static DIGIT_E_RADIX: u32 = ('e' as u32) - ('a' as u32) + 11;
 
 #[cfg(test)]
 mod tests {
+    use core::num::wrapping::WrappingOps;
     use string::ToString;
 
     #[test]
@@ -434,25 +435,25 @@ mod tests {
         let mut i8_val: i8 = 127_i8;
         assert_eq!(i8_val.to_string(), "127");
 
-        i8_val += 1 as i8;
+        i8_val = i8_val.wrapping_add(1);
         assert_eq!(i8_val.to_string(), "-128");
 
         let mut i16_val: i16 = 32_767_i16;
         assert_eq!(i16_val.to_string(), "32767");
 
-        i16_val += 1 as i16;
+        i16_val = i16_val.wrapping_add(1);
         assert_eq!(i16_val.to_string(), "-32768");
 
         let mut i32_val: i32 = 2_147_483_647_i32;
         assert_eq!(i32_val.to_string(), "2147483647");
 
-        i32_val += 1 as i32;
+        i32_val = i32_val.wrapping_add(1);
         assert_eq!(i32_val.to_string(), "-2147483648");
 
         let mut i64_val: i64 = 9_223_372_036_854_775_807_i64;
         assert_eq!(i64_val.to_string(), "9223372036854775807");
 
-        i64_val += 1 as i64;
+        i64_val = i64_val.wrapping_add(1);
         assert_eq!(i64_val.to_string(), "-9223372036854775808");
     }
 }

--- a/src/libstd/prelude/v1.rs
+++ b/src/libstd/prelude/v1.rs
@@ -58,3 +58,5 @@
 #[doc(no_inline)] pub use old_io::{Buffer, Writer, Reader, Seek, BufferPrelude};
 // NB: remove when range syntax lands
 #[doc(no_inline)] pub use iter::range;
+
+#[doc(no_inline)] pub use num::wrapping::{Wrapping, WrappingOps};

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -386,8 +386,8 @@ impl Rng for ThreadRng {
 /// ```
 /// use std::rand;
 ///
-/// let x = rand::random();
-/// println!("{}", 2u8 * x);
+/// let x: u8 = rand::random();
+/// println!("{}", 2 * x as u16);
 ///
 /// let y = rand::random::<f64>();
 /// println!("{}", y);

--- a/src/libstd/sys/unix/backtrace.rs
+++ b/src/libstd/sys/unix/backtrace.rs
@@ -176,7 +176,7 @@ pub fn write(w: &mut Writer) -> IoResult<()> {
         let mut ip = unsafe {
             uw::_Unwind_GetIPInfo(ctx, &mut ip_before_insn) as *mut libc::c_void
         };
-        if ip_before_insn == 0 {
+        if !ip.is_null() && ip_before_insn == 0 {
             // this is a non-signaling frame, so `ip` refers to the address
             // after the calling instruction. account for that.
             ip = (ip as usize - 1) as *mut _;

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -181,7 +181,6 @@ fn encodable_substructure(cx: &mut ExtCtxt, trait_span: Span,
         Struct(ref fields) => {
             let emit_struct_field = cx.ident_of("emit_struct_field");
             let mut stmts = Vec::new();
-            let last = fields.len() - 1;
             for (i, &FieldInfo {
                     name,
                     ref self_,
@@ -204,6 +203,7 @@ fn encodable_substructure(cx: &mut ExtCtxt, trait_span: Span,
                                                  lambda));
 
                 // last call doesn't need a try!
+                let last = fields.len() - 1;
                 let call = if i != last {
                     cx.expr_try(span, call)
                 } else {

--- a/src/test/compile-fail/const-len-underflow-separate-spans.rs
+++ b/src/test/compile-fail/const-len-underflow-separate-spans.rs
@@ -1,0 +1,23 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that an constant-evaluation underflow highlights the correct
+// spot (where the underflow occurred), while also providing the
+// overall context for what caused the evaluation.
+
+const ONE: usize = 1;
+const TWO: usize = 2;
+const LEN: usize = ONE - TWO;
+//~^ ERROR array length constant evaluation error: attempted to sub with overflow [E0250]
+
+fn main() {
+    let a: [i8; LEN] = unimplemented!();
+    //~^ NOTE for array length here
+}

--- a/src/test/compile-fail/const-len-underflow-subspans.rs
+++ b/src/test/compile-fail/const-len-underflow-subspans.rs
@@ -1,0 +1,20 @@
+// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that an constant-evaluation underflow highlights the correct
+// spot (where the underflow occurred).
+
+const ONE: usize = 1;
+const TWO: usize = 2;
+
+fn main() {
+    let a: [i8; ONE - TWO] = unimplemented!();
+    //~^ ERROR array length constant evaluation error: attempted to sub with overflow [E0250]
+}

--- a/src/test/compile-fail/eval-enum.rs
+++ b/src/test/compile-fail/eval-enum.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 
 enum test {
-    div_zero = 1/0, //~ERROR expected constant: attempted to divide by zero
-    rem_zero = 1%0  //~ERROR expected constant: attempted remainder with a divisor of zero
+    div_zero = 1/0, //~ERROR constant evaluation error: attempted to divide by zero
+    rem_zero = 1%0  //~ERROR constant evaluation error: attempted remainder with a divisor of zero
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-18389.rs
+++ b/src/test/compile-fail/issue-18389.rs
@@ -23,6 +23,7 @@ pub trait Public: Private<
     <Self as Public>::P,
 //~^ ERROR illegal recursive type; insert an enum or struct in the cycle, if this is desired
     <Self as Public>::R
+//~^ ERROR unsupported cyclic reference between types/traits detected
 > {
     type P;
     type R;

--- a/src/test/compile-fail/issue-19244-1.rs
+++ b/src/test/compile-fail/issue-19244-1.rs
@@ -12,5 +12,7 @@ const TUP: (usize,) = (42,);
 
 fn main() {
     let a: [isize; TUP.1];
-    //~^ ERROR expected constant expr for array length: tuple index out of bounds
+    //~^ ERROR array length constant evaluation error: tuple index out of bounds
+    //~| ERROR attempted out-of-bounds tuple index
+    //~| ERROR attempted out-of-bounds tuple index
 }

--- a/src/test/compile-fail/issue-19244-2.rs
+++ b/src/test/compile-fail/issue-19244-2.rs
@@ -13,5 +13,7 @@ const STRUCT: MyStruct = MyStruct { field: 42 };
 
 fn main() {
     let a: [isize; STRUCT.nonexistent_field];
-    //~^ ERROR expected constant expr for array length: nonexistent struct field
+    //~^ ERROR array length constant evaluation error: nonexistent struct field
+    //~| ERROR attempted access of field `nonexistent_field`
+    //~| ERROR attempted access of field `nonexistent_field`
 }

--- a/src/test/compile-fail/non-constant-expr-for-fixed-len-vec.rs
+++ b/src/test/compile-fail/non-constant-expr-for-fixed-len-vec.rs
@@ -13,6 +13,7 @@
 fn main() {
     fn bar(n: isize) {
         let _x: [isize; n];
-        //~^ ERROR expected constant expr for array length: non-constant path in constant expr
+        //~^ ERROR no type for local variable
+        //~| ERROR array length constant evaluation error: non-constant path in constant expr
     }
 }

--- a/src/test/run-fail/overflowing-add.rs
+++ b/src/test/run-fail/overflowing-add.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:thread '<main>' panicked at 'arithmatic operation overflowed'
+
+fn main() {
+    let x = 200u8 + 200u8 + 200u8;
+}

--- a/src/test/run-fail/overflowing-add.rs
+++ b/src/test/run-fail/overflowing-add.rs
@@ -8,8 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:thread '<main>' panicked at 'arithmatic operation overflowed'
+// error-pattern:thread '<main>' panicked at 'arithmetic operation overflowed'
+
+// (Work around constant-evaluation)
+fn value() -> u8 { 200 }
 
 fn main() {
-    let x = 200u8 + 200u8 + 200u8;
+    let _x = value() + value() + value();
 }

--- a/src/test/run-fail/overflowing-mul.rs
+++ b/src/test/run-fail/overflowing-mul.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:thread '<main>' panicked at 'arithmatic operation overflowed'
+
+fn main() {
+    let x = 200u8 + 4u8;
+}

--- a/src/test/run-fail/overflowing-mul.rs
+++ b/src/test/run-fail/overflowing-mul.rs
@@ -8,8 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:thread '<main>' panicked at 'arithmatic operation overflowed'
+// error-pattern:thread '<main>' panicked at 'arithmetic operation overflowed'
+
+// (Work around constant-evaluation)
+fn value() -> u8 { 200 }
 
 fn main() {
-    let x = 200u8 + 4u8;
+    let x = value() * 4;
 }

--- a/src/test/run-fail/overflowing-sub.rs
+++ b/src/test/run-fail/overflowing-sub.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:thread '<main>' panicked at 'arithmatic operation overflowed'
+
+fn main() {
+    let x = 42u8 - 43u8;
+}

--- a/src/test/run-fail/overflowing-sub.rs
+++ b/src/test/run-fail/overflowing-sub.rs
@@ -8,8 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:thread '<main>' panicked at 'arithmatic operation overflowed'
+// error-pattern:thread '<main>' panicked at 'arithmetic operation overflowed'
+
+// (Work around constant-evaluation)
+fn value() -> u8 { 42 }
 
 fn main() {
-    let x = 42u8 - 43u8;
+    let _x = value() - (value() + 1);
 }

--- a/src/test/run-pass/backtrace-debuginfo.rs
+++ b/src/test/run-pass/backtrace-debuginfo.rs
@@ -68,7 +68,7 @@ fn dump_filelines(filelines: &[Pos]) {
 }
 
 #[inline(never)]
-fn inner(counter: &mut u32, main_pos: Pos, outer_pos: Pos) {
+fn inner(counter: &mut i32, main_pos: Pos, outer_pos: Pos) {
     check!(counter; main_pos, outer_pos);
     check!(counter; main_pos, outer_pos);
     let inner_pos = pos!(); aux::callback(|aux_pos| {
@@ -80,12 +80,12 @@ fn inner(counter: &mut u32, main_pos: Pos, outer_pos: Pos) {
 }
 
 #[inline(always)]
-fn inner_inlined(counter: &mut u32, main_pos: Pos, outer_pos: Pos) {
+fn inner_inlined(counter: &mut i32, main_pos: Pos, outer_pos: Pos) {
     check!(counter; main_pos, outer_pos);
     check!(counter; main_pos, outer_pos);
 
     #[inline(always)]
-    fn inner_further_inlined(counter: &mut u32, main_pos: Pos, outer_pos: Pos, inner_pos: Pos) {
+    fn inner_further_inlined(counter: &mut i32, main_pos: Pos, outer_pos: Pos, inner_pos: Pos) {
         check!(counter; main_pos, outer_pos, inner_pos);
     }
     inner_further_inlined(counter, main_pos, outer_pos, pos!());
@@ -103,7 +103,7 @@ fn inner_inlined(counter: &mut u32, main_pos: Pos, outer_pos: Pos) {
 }
 
 #[inline(never)]
-fn outer(mut counter: u32, main_pos: Pos) {
+fn outer(mut counter: i32, main_pos: Pos) {
     inner(&mut counter, main_pos, pos!());
     inner_inlined(&mut counter, main_pos, pos!());
 }

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -53,7 +53,9 @@ fn runtest(me: &str) {
             "bad output: {}", s);
 
     // Make sure the stack trace is *not* printed
-    let p = template.clone().arg("fail").spawn().unwrap();
+    // (Remove RUST_BACKTRACE from our own environment, in case developer
+    // is running `make check` with it on.)
+    let p = template.clone().arg("fail").env_remove("RUST_BACKTRACE").spawn().unwrap();
     let out = p.wait_with_output().unwrap();
     assert!(!out.status.success());
     let s = str::from_utf8(&out.error).unwrap();

--- a/src/test/run-pass/generic-extern-mangle.rs
+++ b/src/test/run-pass/generic-extern-mangle.rs
@@ -10,7 +10,7 @@
 
 use std::num::Int;
 
-extern "C" fn foo<T: Int>(a: T, b: T) -> T { a + b }
+extern "C" fn foo<T: WrappingOps>(a: T, b: T) -> T { a.wrapping_add(b) }
 
 fn main() {
     assert_eq!(99u8, foo(255u8, 100u8));


### PR DESCRIPTION
Rebase and follow-through on work done by @cmr and @aatch.

Implements most of rust-lang/rfcs#560. Errors encountered from the checks during building were fixed.

The checks for division, remainder and bit-shifting have not been implemented yet.

See also PR #20795, as well as the tracking issue #22020

cc @Aatch ; cc @nikomatsakis
