### PR TITLE
Fix ICE for unexpected `<` in pattern

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3496,6 +3496,9 @@ impl<'a> Parser<'a> {
                     };
                     pat = PatIdent(BindByValue(MutImmutable), pth1, sub);
                 }
+            } else if self.look_ahead(1, |t| *t == token::Lt) {
+                self.bump();
+                self.unexpected()
             } else {
                 // parse an enum pat
                 let enum_path = self.parse_path(LifetimeAndTypesWithColons);

--- a/src/test/compile-fail/issue-22426-1.rs
+++ b/src/test/compile-fail/issue-22426-1.rs
@@ -10,7 +10,8 @@
 
 fn main() {
   match 42 {
-    x < 7 => (), //~ ERROR unexpected token `<`
+    x < 7 => (),
+   //~^ error: unexpected token: `<`
     _ => ()
   }
 }

--- a/src/test/compile-fail/issue-22426-1.rs
+++ b/src/test/compile-fail/issue-22426-1.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+  match 42 {
+    x < 7 => (), //~ ERROR unexpected token `<`
+    _ => ()
+  }
+}

--- a/src/test/compile-fail/issue-22426-2.rs
+++ b/src/test/compile-fail/issue-22426-2.rs
@@ -1,0 +1,11 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn a(B<) {} //~ ERROR unexpected token `<`

--- a/src/test/compile-fail/issue-22426-2.rs
+++ b/src/test/compile-fail/issue-22426-2.rs
@@ -8,4 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn a(B<) {} //~ ERROR unexpected token `<`
+fn a(B<) {}
+   //~^ error: unexpected token: `<`

--- a/src/test/compile-fail/issue-22426-3.rs
+++ b/src/test/compile-fail/issue-22426-3.rs
@@ -13,7 +13,8 @@ struct Foo<T>(T, T);
 impl<T> Foo<T> {
     fn foo(&self) {
         match *self {
-            Foo<T>(x, y) => { //~ ERROR unexpected token `<`
+            Foo<T>(x, y) => {
+            //~^ error: unexpected token: `<`
               println!("Goodbye, World!")
             }
         }

--- a/src/test/compile-fail/issue-22426.rs
+++ b/src/test/compile-fail/issue-22426.rs
@@ -1,0 +1,21 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo<T>(T, T);
+
+impl<T> Foo<T> {
+    fn foo(&self) {
+        match *self {
+            Foo<T>(x, y) => { //~ ERROR unexpected token `<`
+              println!("Goodbye, World!")
+            }
+        }
+    }
+}

--- a/src/test/run-pass/issue-22426.rs
+++ b/src/test/run-pass/issue-22426.rs
@@ -1,0 +1,21 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo<T>(T, T);
+
+impl<T> Foo<T> {
+    fn foo(&self) {
+        match *self {
+            Foo::<T>(ref x, ref y) => { //~ ERROR unexpected token `<`
+              println!("Goodbye, World!")
+            }
+        }
+    }
+}

--- a/src/test/run-pass/issue-22426.rs
+++ b/src/test/run-pass/issue-22426.rs
@@ -8,18 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct Foo<T>(T, T);
-
-impl<T> Foo<T> {
-    fn foo(&self) {
-        match *self {
-            Foo::<T>(ref x, ref y) => {
-              println!("Goodbye, World!")
-            }
-        }
-    }
-}
-
 fn main() {
   match 42 {
     x if x < 7 => (),

--- a/src/test/run-pass/issue-22426.rs
+++ b/src/test/run-pass/issue-22426.rs
@@ -13,9 +13,16 @@ struct Foo<T>(T, T);
 impl<T> Foo<T> {
     fn foo(&self) {
         match *self {
-            Foo::<T>(ref x, ref y) => { //~ ERROR unexpected token `<`
+            Foo::<T>(ref x, ref y) => {
               println!("Goodbye, World!")
             }
         }
     }
+}
+
+fn main() {
+  match 42 {
+    x if x < 7 => (),
+    _ => ()
+  }
 }


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/22426

I'm not sure which is better:
- simply "unexpected token `<`"
- "unexpected token `<`, expect one of `=>`, `:`, `(`"

But this PR is actually mergable now
