### PR TITLE
book: Minor clarifications about strings

### DIFF
--- a/src/doc/trpl/crates-and-modules.md
+++ b/src/doc/trpl/crates-and-modules.md
@@ -12,7 +12,7 @@ Rust has two distinct terms that relate to the module system: *crate* and
 *module*. A crate is synonymous with a *library* or *package* in other
 languages. Hence "Cargo" as the name of Rust's package management tool: you
 ship your crates to others with Cargo. Crates can produce an executable or a
-shared library, depending on the project.
+library, depending on the project.
 
 Each crate has an implicit *root module* that contains the code for that crate.
 You can then define a tree of sub-modules under that root module. Modules allow

--- a/src/doc/trpl/more-strings.md
+++ b/src/doc/trpl/more-strings.md
@@ -38,8 +38,9 @@ string literal or a `String`.
 
 # String
 
-A `String` is a heap-allocated string. This string is growable, and is also
-guaranteed to be UTF-8.
+A `String` is a heap-allocated string. This string is growable, and is
+also guaranteed to be UTF-8. `String`s are commonly created by
+converting from a string slice using the `to_string` method.
 
 ```
 let mut s = "Hello".to_string();
@@ -49,7 +50,7 @@ s.push_str(", world.");
 println!("{}", s);
 ```
 
-You can coerce a `String` into a `&str` by dereferencing it:
+A reference to a `String` will automatically coerce to a string slice:
 
 ```
 fn takes_slice(slice: &str) {
@@ -58,7 +59,7 @@ fn takes_slice(slice: &str) {
 
 fn main() {
     let s = "Hello".to_string();
-    takes_slice(&*s);
+    takes_slice(&s);
 }
 ```
 

--- a/src/doc/trpl/strings.md
+++ b/src/doc/trpl/strings.md
@@ -25,8 +25,10 @@ compiled program, and exists for the entire duration it runs. The `string`
 binding is a reference to this statically allocated string. String slices
 have a fixed size, and cannot be mutated.
 
-A `String`, on the other hand, is an in-memory string.  This string is
-growable, and is also guaranteed to be UTF-8.
+A `String`, on the other hand, is a heap-allocated string. This string
+is growable, and is also guaranteed to be UTF-8. `String`s are
+commonly created by converting from a string slice using the
+`to_string` method.
 
 ```{rust}
 let mut s = "Hello".to_string(); // mut s: String


### PR DESCRIPTION
Clarify that `to_string` is how you make `String`. Use a coercion in an example.

r? @steveklabnik 
