### PR TITLE
fix markup of "just one effect, unsafe"

### DIFF
--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 //! Enforces the Rust effect system. Currently there is just one effect,
-/// `unsafe`.
+//! `unsafe`.
 use self::UnsafeContext::*;
 
 use middle::def;


### PR DESCRIPTION
the punch line was cut off!

p.s. I wonder if I should have updated the copyright date too.
