### PR TITLE
Add DatatypeDef

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -138,6 +138,7 @@ pub mod util {
     pub mod nodemap;
     pub mod snapshot_vec;
     pub mod lev_distance;
+    pub mod ivar;
 }
 
 pub mod lib {

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -13,7 +13,6 @@
 use metadata::common::*;
 use metadata::cstore;
 use metadata::decoder;
-use middle::def;
 use middle::lang_items;
 use middle::ty;
 

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -36,6 +36,14 @@ pub struct MethodInfo {
     pub vis: ast::Visibility,
 }
 
+#[derive(Copy)]
+pub struct FieldInfo {
+    pub name: ast::Name,
+    pub def_id: ast::DefId,
+    pub vis: ast::Visibility,
+    pub origin: ast::DefId,
+}
+
 pub fn get_symbol(cstore: &cstore::CStore, def: ast::DefId) -> String {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_symbol(cdata.data(), def.node)
@@ -114,19 +122,6 @@ pub fn maybe_get_item_ast<'tcx>(tcx: &ty::ctxt<'tcx>, def: ast::DefId,
     decoder::maybe_get_item_ast(&*cdata, tcx, def.node, decode_inlined_item)
 }
 
-pub fn get_enum_variant_defs(cstore: &cstore::CStore, enum_id: ast::DefId)
-                             -> Vec<(def::Def, ast::Name, ast::Visibility)> {
-    let cdata = cstore.get_crate_data(enum_id.krate);
-    decoder::get_enum_variant_defs(&*cstore.intr, &*cdata, enum_id.node)
-}
-
-pub fn get_enum_variants<'tcx>(tcx: &ty::ctxt<'tcx>, def: ast::DefId)
-                               -> Vec<Rc<ty::VariantInfo<'tcx>>> {
-    let cstore = &tcx.sess.cstore;
-    let cdata = cstore.get_crate_data(def.krate);
-    decoder::get_enum_variants(cstore.intr.clone(), &*cdata, def.node, tcx)
-}
-
 /// Returns information about the given implementation.
 pub fn get_impl_items(cstore: &cstore::CStore, impl_def_id: ast::DefId)
                       -> Vec<ty::ImplOrTraitItemId> {
@@ -203,9 +198,16 @@ pub fn get_item_attrs(cstore: &cstore::CStore,
     decoder::get_item_attrs(&*cdata, def_id.node)
 }
 
-pub fn get_struct_fields(cstore: &cstore::CStore,
-                         def: ast::DefId)
-                      -> Vec<ty::field_ty> {
+pub fn get_datatype_def<'tcx>(tcx: &ty::ctxt<'tcx>,
+                            def: ast::DefId) -> &'tcx ty::DatatypeDef<'tcx> {
+    let cstore = &tcx.sess.cstore;
+    let cdata = cstore.get_crate_data(def.krate);
+    decoder::get_datatype_def(tcx, cstore.intr.clone(), &*cdata, def.node)
+}
+
+/// Get the fields for the struct. Use this when you don't have a type context to
+/// pass to `ty::lookup_struct_def`.
+pub fn get_struct_fields(cstore: &cstore::CStore, def: ast::DefId) -> Vec<FieldInfo> {
     let cdata = cstore.get_crate_data(def.krate);
     decoder::get_struct_fields(cstore.intr.clone(), &*cdata, def.node)
 }

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1052,7 +1052,6 @@ fn get_struct_datatype_def<'tcx>(tcx: &ty::ctxt<'tcx>, intr: &IdentInterner,
             name: name,
             disr_val: 0,
             fields: fields,
-            vis: ast::Public,
         }]
     });
 
@@ -1093,7 +1092,6 @@ fn get_enum_datatype_def<'tcx>(tcx: &ty::ctxt<'tcx>, intr: &IdentInterner,
             name: vname,
             disr_val: disr_val,
             fields: fields,
-            vis: ast::Public,
         }
     }).collect();
 

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -18,7 +18,7 @@ use self::Family::*;
 use back::svh::Svh;
 use metadata::cstore::crate_metadata;
 use metadata::common::*;
-use metadata::csearch::MethodInfo;
+use metadata::csearch::{FieldInfo, MethodInfo};
 use metadata::csearch;
 use metadata::cstore;
 use metadata::tydecode::{parse_ty_data, parse_region_data, parse_def_id,
@@ -727,72 +727,6 @@ pub fn maybe_get_item_ast<'tcx>(cdata: Cmd, tcx: &ty::ctxt<'tcx>, id: ast::NodeI
     }
 }
 
-pub fn get_enum_variant_defs(intr: &IdentInterner,
-                             cdata: Cmd,
-                             id: ast::NodeId)
-                             -> Vec<(def::Def, ast::Name, ast::Visibility)> {
-    let data = cdata.data();
-    let items = reader::get_doc(rbml::Doc::new(data), tag_items);
-    let item = find_item(id, items);
-    enum_variant_ids(item, cdata).iter().map(|did| {
-        let item = find_item(did.node, items);
-        let name = item_name(intr, item);
-        let visibility = item_visibility(item);
-        match item_to_def_like(item, *did, cdata.cnum) {
-            DlDef(def @ def::DefVariant(..)) => (def, name, visibility),
-            _ => unreachable!()
-        }
-    }).collect()
-}
-
-pub fn get_enum_variants<'tcx>(intr: Rc<IdentInterner>, cdata: Cmd, id: ast::NodeId,
-                               tcx: &ty::ctxt<'tcx>) -> Vec<Rc<ty::VariantInfo<'tcx>>> {
-    let data = cdata.data();
-    let items = reader::get_doc(rbml::Doc::new(data), tag_items);
-    let item = find_item(id, items);
-    let mut disr_val = 0;
-    enum_variant_ids(item, cdata).iter().map(|did| {
-        let item = find_item(did.node, items);
-        let ctor_ty = item_type(ast::DefId { krate: cdata.cnum, node: id},
-                                item, tcx, cdata);
-        let name = item_name(&*intr, item);
-        let (ctor_ty, arg_tys, arg_names) = match ctor_ty.sty {
-            ty::ty_bare_fn(_, ref f) =>
-                (Some(ctor_ty), f.sig.0.inputs.clone(), None),
-            _ => { // Nullary or struct enum variant.
-                let mut arg_names = Vec::new();
-                let arg_tys = get_struct_fields(intr.clone(), cdata, did.node)
-                    .iter()
-                    .map(|field_ty| {
-                        arg_names.push(ast::Ident::new(field_ty.name));
-                        get_type(cdata, field_ty.id.node, tcx).ty
-                    })
-                    .collect();
-                let arg_names = if arg_names.len() == 0 { None } else { Some(arg_names) };
-
-                (None, arg_tys, arg_names)
-            }
-        };
-        match variant_disr_val(item) {
-            Some(val) => { disr_val = val; }
-            _         => { /* empty */ }
-        }
-        let old_disr_val = disr_val;
-        disr_val += 1;
-        Rc::new(ty::VariantInfo {
-            args: arg_tys,
-            arg_names: arg_names,
-            ctor_ty: ctor_ty,
-            name: name,
-            // I'm not even sure if we encode visibility
-            // for variants -- TEST -- tjc
-            id: *did,
-            disr_val: old_disr_val,
-            vis: ast::Inherited
-        })
-    }).collect()
-}
-
 fn get_explicit_self(item: rbml::Doc) -> ty::ExplicitSelfCategory {
     fn get_mutability(ch: u8) -> ast::Mutability {
         match ch as char {
@@ -1089,40 +1023,166 @@ fn struct_field_family_to_visibility(family: Family) -> ast::Visibility {
     }
 }
 
-pub fn get_struct_fields(intr: Rc<IdentInterner>, cdata: Cmd, id: ast::NodeId)
-    -> Vec<ty::field_ty> {
+pub fn get_datatype_def<'tcx>(tcx: &ty::ctxt<'tcx>, intr: Rc<IdentInterner>,
+                              cdata: Cmd, id: ast::NodeId) -> &'tcx ty::DatatypeDef<'tcx> {
     let data = cdata.data();
     let item = lookup_item(id, data);
-    let mut result = Vec::new();
+
+    let family = item_family(item);
+    match family {
+        Enum => get_enum_datatype_def(tcx, &*intr, cdata, id),
+        Struct => get_struct_datatype_def(tcx, &*intr, cdata, id),
+        _ => tcx.sess.bug("Non data-type item family in get_datatype_def")
+    }
+}
+
+fn get_struct_datatype_def<'tcx>(tcx: &ty::ctxt<'tcx>, intr: &IdentInterner,
+                                 cdata: Cmd, id: ast::NodeId) -> &'tcx ty::DatatypeDef<'tcx> {
+    let data = cdata.data();
+    let item = lookup_item(id, data);
+
+    let name = item_name(intr, item);
+    let def_id = item_def_id(item, cdata);
+
+    let fields = get_variant_fields(tcx, intr, cdata, item);
+    let def = tcx.mk_datatype_def(ty::DatatypeDef {
+        def_id: def_id,
+        variants: vec![ty::VariantDef {
+            id: def_id,
+            name: name,
+            disr_val: 0,
+            fields: fields,
+            vis: ast::Public,
+        }]
+    });
+
+    tcx.datatype_defs.borrow_mut().insert(def_id, def);
+
+    for fld in def.variants.iter().flat_map(|v| v.fields.iter()) {
+        // FIXME(aatch) I shouldn't have to use get_type here, but using item_type seems
+        // to break things (Like cause infinite recursion in trans)
+        let ty = get_type(cdata, fld.id.node, tcx).ty;
+        fld.set_ty(ty);
+    }
+
+    def
+}
+
+fn get_enum_datatype_def<'tcx>(tcx: &ty::ctxt<'tcx>, intr: &IdentInterner,
+                               cdata: Cmd, id: ast::NodeId) -> &'tcx ty::DatatypeDef<'tcx> {
+    let data = cdata.data();
+    let item = lookup_item(id, data);
+
+    let def_id = item_def_id(item, cdata);
+
+    let variants_doc = reader::get_doc(rbml::Doc::new(data), tag_items);
+
+    let mut disr_val = 0;
+    let variants = enum_variant_ids(item, cdata).iter().map(|did| {
+        let item = find_item(did.node, variants_doc);
+        let vname = item_name(intr, item);
+        match variant_disr_val(item) {
+            Some(val) => { disr_val = val; }
+            _ => {}
+        }
+
+        let fields = get_variant_fields(tcx, intr, cdata, item);
+
+        ty::VariantDef {
+            id: *did,
+            name: vname,
+            disr_val: disr_val,
+            fields: fields,
+            vis: ast::Public,
+        }
+    }).collect();
+
+    let def = tcx.mk_datatype_def(ty::DatatypeDef {
+        def_id: def_id,
+        variants: variants,
+    });
+
+    tcx.datatype_defs.borrow_mut().insert(def_id, def);
+    for fld in def.variants.iter().flat_map(|v| v.fields.iter()) {
+        // FIXME(aatch) I shouldn't have to use get_type here, but using item_type seems
+        // to break things (Like cause infinite recursion in trans)
+        let ty = get_type(cdata, fld.id.node, tcx).ty;
+        fld.set_ty(ty);
+    }
+
+    def
+}
+
+fn get_variant_fields<'tcx>(tcx: &ty::ctxt<'tcx>, intr: &IdentInterner, cdata: Cmd,
+                            item: rbml::Doc) -> Vec<ty::FieldTy<'tcx>> {
+
+    let mut fields = Vec::new();
     reader::tagged_docs(item, tag_item_field, |an_item| {
         let f = item_family(an_item);
-        if f == PublicField || f == InheritedField {
-            let name = item_name(&*intr, an_item);
-            let did = item_def_id(an_item, cdata);
-            let tagdoc = reader::get_doc(an_item, tag_item_field_origin);
-            let origin_id =  translate_def_id(cdata, reader::with_doc_data(tagdoc, parse_def_id));
-            result.push(ty::field_ty {
-                name: name,
-                id: did,
-                vis: struct_field_family_to_visibility(f),
-                origin: origin_id,
-            });
-        }
+        let name = item_name(intr, an_item);
+        let did = item_def_id(an_item, cdata);
+
+        let tagdoc = reader::get_doc(an_item, tag_item_field_origin);
+        let origin_id = translate_def_id(cdata, reader::with_doc_data(tagdoc, parse_def_id));
+        let fld = ty::FieldTy::new(tcx, did, name,
+                                   struct_field_family_to_visibility(f),
+                                   origin_id);
+        fields.push(fld);
         true
     });
+
     reader::tagged_docs(item, tag_item_unnamed_field, |an_item| {
         let did = item_def_id(an_item, cdata);
         let tagdoc = reader::get_doc(an_item, tag_item_field_origin);
         let f = item_family(an_item);
         let origin_id =  translate_def_id(cdata, reader::with_doc_data(tagdoc, parse_def_id));
-        result.push(ty::field_ty {
-            name: special_idents::unnamed_field.name,
-            id: did,
+        let fld = ty::FieldTy::new(tcx, did, special_idents::unnamed_field.name,
+                                   struct_field_family_to_visibility(f),
+                                   origin_id);
+        fields.push(fld);
+        true
+    });
+
+    return fields;
+}
+
+pub fn get_struct_fields(intr: Rc<IdentInterner>,
+                              cdata: Cmd, id: ast::NodeId) -> Vec<FieldInfo> {
+    let data = cdata.data();
+    let item = lookup_item(id, data);
+    let mut result = Vec::new();
+    reader::tagged_docs(item, tag_item_field, |an_item| {
+        let f = item_family(an_item);
+        let name = item_name(&*intr, an_item);
+        let did = item_def_id(an_item, cdata);
+
+        let tagdoc = reader::get_doc(an_item, tag_item_field_origin);
+        let origin_id =  translate_def_id(cdata, reader::with_doc_data(tagdoc, parse_def_id));
+
+        result.push(FieldInfo {
+            name: name,
+            def_id: did,
             vis: struct_field_family_to_visibility(f),
             origin: origin_id,
         });
         true
     });
+    reader::tagged_docs(item, tag_item_unnamed_field, |an_item| {
+        let did = item_def_id(an_item, cdata);
+        let f = item_family(an_item);
+
+        let tagdoc = reader::get_doc(an_item, tag_item_field_origin);
+        let origin_id =  translate_def_id(cdata, reader::with_doc_data(tagdoc, parse_def_id));
+
+        result.push(FieldInfo {
+            name: special_idents::unnamed_field.name,
+            def_id: did,
+            vis: struct_field_family_to_visibility(f),
+            origin: origin_id,
+        });
+        true
+    });
+
     result
 }
 

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -1044,7 +1044,7 @@ fn get_struct_datatype_def<'tcx>(tcx: &ty::ctxt<'tcx>, intr: &IdentInterner,
     let name = item_name(intr, item);
     let def_id = item_def_id(item, cdata);
 
-    let fields = get_variant_fields(tcx, intr, cdata, item);
+    let fields = get_variant_fields(intr, cdata, item);
     let def = tcx.mk_datatype_def(ty::DatatypeDef {
         def_id: def_id,
         variants: vec![ty::VariantDef {
@@ -1086,7 +1086,7 @@ fn get_enum_datatype_def<'tcx>(tcx: &ty::ctxt<'tcx>, intr: &IdentInterner,
             _ => {}
         }
 
-        let fields = get_variant_fields(tcx, intr, cdata, item);
+        let fields = get_variant_fields(intr, cdata, item);
 
         ty::VariantDef {
             id: *did,
@@ -1113,7 +1113,7 @@ fn get_enum_datatype_def<'tcx>(tcx: &ty::ctxt<'tcx>, intr: &IdentInterner,
     def
 }
 
-fn get_variant_fields<'tcx>(tcx: &ty::ctxt<'tcx>, intr: &IdentInterner, cdata: Cmd,
+fn get_variant_fields<'tcx>(intr: &IdentInterner, cdata: Cmd,
                             item: rbml::Doc) -> Vec<ty::FieldTy<'tcx>> {
 
     let mut fields = Vec::new();
@@ -1124,7 +1124,7 @@ fn get_variant_fields<'tcx>(tcx: &ty::ctxt<'tcx>, intr: &IdentInterner, cdata: C
 
         let tagdoc = reader::get_doc(an_item, tag_item_field_origin);
         let origin_id = translate_def_id(cdata, reader::with_doc_data(tagdoc, parse_def_id));
-        let fld = ty::FieldTy::new(tcx, did, name,
+        let fld = ty::FieldTy::new(did, name,
                                    struct_field_family_to_visibility(f),
                                    origin_id);
         fields.push(fld);
@@ -1136,7 +1136,7 @@ fn get_variant_fields<'tcx>(tcx: &ty::ctxt<'tcx>, intr: &IdentInterner, cdata: C
         let tagdoc = reader::get_doc(an_item, tag_item_field_origin);
         let f = item_family(an_item);
         let origin_id =  translate_def_id(cdata, reader::with_doc_data(tagdoc, parse_def_id));
-        let fld = ty::FieldTy::new(tcx, did, special_idents::unnamed_field.name,
+        let fld = ty::FieldTy::new(did, special_idents::unnamed_field.name,
                                    struct_field_family_to_visibility(f),
                                    origin_id);
         fields.push(fld);

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1136,19 +1136,19 @@ fn encode_info_for_item(ecx: &EncodeContext,
           let def = ty::lookup_datatype_def(tcx, def_id);
           let fields = &def.variants[0].fields[..];
 
-          /* First, encode the fields
-          These come first because we need to write them to make
-          the index, and the index needs to be in the item for the
-          class itself */
+          // First, encode the fields
+          // These come first because we need to write them to make
+          // the index, and the index needs to be in the item for the
+          // class itself
           let idx = encode_info_for_struct(ecx,
                                            rbml_w,
                                            fields,
                                            index);
 
-          /* Index the class*/
+          // Index the class
           add_to_index(item, rbml_w, index);
 
-          /* Now, make an item for the class itself */
+          // Now, make an item for the class itself
           rbml_w.start_tag(tag_items_data_item);
           encode_def_id(rbml_w, def_id);
           encode_family(rbml_w, 'S');
@@ -1162,9 +1162,9 @@ fn encode_info_for_item(ecx: &EncodeContext,
           encode_visibility(rbml_w, vis);
           encode_repr_attrs(rbml_w, ecx, &item.attrs[]);
 
-          /* Encode def_ids for each field and method
-          for methods, write all the stuff get_trait_method
-          needs to know*/
+          // Encode def_ids for each field and method
+          // for methods, write all the stuff get_trait_method
+          // needs to know
           encode_struct_fields(rbml_w, fields, def_id);
 
           encode_inlined_item(ecx, rbml_w, IIItemRef(item));
@@ -1172,7 +1172,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
           // Encode inherent implementations for this structure.
           encode_inherent_implementations(ecx, rbml_w, def_id);
 
-          /* Each class has its own index -- encode it */
+          // Each class has its own index -- encode it
           encode_index(rbml_w, idx, write_i64);
           rbml_w.end_tag();
 

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -295,9 +295,9 @@ fn encode_parent_item(rbml_w: &mut Encoder, id: DefId) {
     rbml_w.end_tag();
 }
 
-fn encode_struct_fields(rbml_w: &mut Encoder,
-                        fields: &[ty::field_ty],
-                        origin: DefId) {
+fn encode_struct_fields<'tcx>(rbml_w: &mut Encoder,
+                                  fields: &[ty::FieldTy<'tcx>],
+                                  origin: DefId) {
     for f in fields {
         if f.name == special_idents::unnamed_field.name {
             rbml_w.start_tag(tag_item_unnamed_field);
@@ -322,10 +322,10 @@ fn encode_enum_variant_info(ecx: &EncodeContext,
                             index: &mut Vec<entry<i64>>) {
     debug!("encode_enum_variant_info(id={})", id);
 
-    let mut disr_val = 0;
     let mut i = 0;
-    let vi = ty::enum_variants(ecx.tcx,
-                               DefId { krate: ast::LOCAL_CRATE, node: id });
+    let def = ty::lookup_datatype_def(ecx.tcx,
+                                      DefId { krate: ast::LOCAL_CRATE, node: id });
+    let vi = &def.variants[];
     for variant in variants {
         let def_id = local_def(variant.node.id);
         index.push(entry {
@@ -347,27 +347,19 @@ fn encode_enum_variant_info(ecx: &EncodeContext,
         let stab = stability::lookup(ecx.tcx, ast_util::local_def(variant.node.id));
         encode_stability(rbml_w, stab);
 
-        match variant.node.kind {
-            ast::TupleVariantKind(_) => {},
-            ast::StructVariantKind(_) => {
-                let fields = ty::lookup_struct_fields(ecx.tcx, def_id);
-                let idx = encode_info_for_struct(ecx,
-                                                 rbml_w,
-                                                 &fields[..],
-                                                 index);
-                encode_struct_fields(rbml_w, &fields[..], def_id);
-                encode_index(rbml_w, idx, write_i64);
-            }
-        }
-        if (*vi)[i].disr_val != disr_val {
-            encode_disr_val(ecx, rbml_w, (*vi)[i].disr_val);
-            disr_val = (*vi)[i].disr_val;
-        }
-        encode_bounds_and_type_for_item(rbml_w, ecx, def_id.local_id());
+        let fields = &vi[i].fields[];
+        let idx = encode_info_for_struct(ecx,
+                                         rbml_w,
+                                         fields,
+                                         index);
+        encode_struct_fields(rbml_w, fields, def_id);
+        encode_index(rbml_w, idx, write_i64);
+
+        encode_disr_val(ecx, rbml_w, (*vi)[i].disr_val);
+        encode_bounds_and_type_for_item(rbml_w, ecx, variant.node.id);
 
         ecx.tcx.map.with_path(variant.node.id, |path| encode_path(rbml_w, path));
         rbml_w.end_tag();
-        disr_val += 1;
         i += 1;
     }
 }
@@ -683,11 +675,10 @@ fn encode_provided_source(rbml_w: &mut Encoder,
 }
 
 /* Returns an index of items in this class */
-fn encode_info_for_struct(ecx: &EncodeContext,
-                          rbml_w: &mut Encoder,
-                          fields: &[ty::field_ty],
-                          global_index: &mut Vec<entry<i64>>)
-                          -> Vec<entry<i64>> {
+fn encode_info_for_struct<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
+                                    rbml_w: &mut Encoder,
+                                    fields: &[ty::FieldTy<'tcx>],
+                                    global_index: &mut Vec<entry<i64>>) -> Vec<entry<i64>> {
     /* Each class has its own index, since different classes
        may have fields with the same name */
     let mut index = Vec::new();
@@ -1142,56 +1133,57 @@ fn encode_info_for_item(ecx: &EncodeContext,
                                  index);
       }
       ast::ItemStruct(ref struct_def, _) => {
-        let fields = ty::lookup_struct_fields(tcx, def_id);
+          let def = ty::lookup_datatype_def(tcx, def_id);
+          let fields = &def.variants[0].fields[..];
 
-        /* First, encode the fields
-           These come first because we need to write them to make
-           the index, and the index needs to be in the item for the
-           class itself */
-        let idx = encode_info_for_struct(ecx,
-                                         rbml_w,
-                                         &fields[..],
-                                         index);
+          /* First, encode the fields
+          These come first because we need to write them to make
+          the index, and the index needs to be in the item for the
+          class itself */
+          let idx = encode_info_for_struct(ecx,
+                                           rbml_w,
+                                           fields,
+                                           index);
 
-        /* Index the class*/
-        add_to_index(item, rbml_w, index);
+          /* Index the class*/
+          add_to_index(item, rbml_w, index);
 
-        /* Now, make an item for the class itself */
-        rbml_w.start_tag(tag_items_data_item);
-        encode_def_id(rbml_w, def_id);
-        encode_family(rbml_w, 'S');
-        encode_bounds_and_type_for_item(rbml_w, ecx, item.id);
+          /* Now, make an item for the class itself */
+          rbml_w.start_tag(tag_items_data_item);
+          encode_def_id(rbml_w, def_id);
+          encode_family(rbml_w, 'S');
+          encode_bounds_and_type_for_item(rbml_w, ecx, item.id);
 
-        encode_item_variances(rbml_w, ecx, item.id);
-        encode_name(rbml_w, item.ident.name);
-        encode_attributes(rbml_w, &item.attrs);
-        encode_path(rbml_w, path.clone());
-        encode_stability(rbml_w, stab);
-        encode_visibility(rbml_w, vis);
-        encode_repr_attrs(rbml_w, ecx, &item.attrs);
+          encode_item_variances(rbml_w, ecx, item.id);
+          encode_name(rbml_w, item.ident.name);
+          encode_attributes(rbml_w, &item.attrs[]);
+          encode_path(rbml_w, path.clone());
+          encode_stability(rbml_w, stab);
+          encode_visibility(rbml_w, vis);
+          encode_repr_attrs(rbml_w, ecx, &item.attrs[]);
 
-        /* Encode def_ids for each field and method
-         for methods, write all the stuff get_trait_method
-        needs to know*/
-        encode_struct_fields(rbml_w, &fields[..], def_id);
+          /* Encode def_ids for each field and method
+          for methods, write all the stuff get_trait_method
+          needs to know*/
+          encode_struct_fields(rbml_w, fields, def_id);
 
-        encode_inlined_item(ecx, rbml_w, IIItemRef(item));
+          encode_inlined_item(ecx, rbml_w, IIItemRef(item));
 
-        // Encode inherent implementations for this structure.
-        encode_inherent_implementations(ecx, rbml_w, def_id);
+          // Encode inherent implementations for this structure.
+          encode_inherent_implementations(ecx, rbml_w, def_id);
 
-        /* Each class has its own index -- encode it */
-        encode_index(rbml_w, idx, write_i64);
-        rbml_w.end_tag();
+          /* Each class has its own index -- encode it */
+          encode_index(rbml_w, idx, write_i64);
+          rbml_w.end_tag();
 
-        // If this is a tuple-like struct, encode the type of the constructor.
-        match struct_def.ctor_id {
-            Some(ctor_id) => {
-                encode_info_for_struct_ctor(ecx, rbml_w, item.ident,
-                                            ctor_id, index, def_id.node);
-            }
-            None => {}
-        }
+          // If this is a tuple-like struct, encode the type of the constructor.
+          match struct_def.ctor_id {
+              Some(ctor_id) => {
+                  encode_info_for_struct_ctor(ecx, rbml_w, item.ident,
+                                              ctor_id, index, def_id.node);
+              }
+              None => {}
+          }
       }
       ast::ItemDefaultImpl(unsafety, _) => {
           add_to_index(item, rbml_w, index);

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -84,7 +84,7 @@ pub fn enc_ty<'a, 'tcx>(w: &mut SeekableMemWriter, cx: &ctxt<'a, 'tcx>, t: Ty<'t
             }
         }
         ty::ty_enum(def, substs) => {
-            mywrite!(w, "t[{}|", (cx.ds)(def));
+            mywrite!(w, "t[{}|", (cx.ds)(def.def_id));
             enc_substs(w, cx, substs);
             mywrite!(w, "]");
         }
@@ -135,7 +135,7 @@ pub fn enc_ty<'a, 'tcx>(w: &mut SeekableMemWriter, cx: &ctxt<'a, 'tcx>, t: Ty<'t
             mywrite!(w, "p[{}|{}|{}]", idx, space.to_uint(), token::get_name(name))
         }
         ty::ty_struct(def, substs) => {
-            mywrite!(w, "a[{}|", (cx.ds)(def));
+            mywrite!(w, "a[{}|", (cx.ds)(def.def_id));
             enc_substs(w, cx, substs);
             mywrite!(w, "]");
         }

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -376,8 +376,8 @@ impl<'a, 'tcx, 'v> Visitor<'v> for CheckCrateVisitor<'a, 'tcx> {
 fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>,
                         e: &ast::Expr, node_ty: Ty<'tcx>) {
     match node_ty.sty {
-        ty::ty_struct(did, _) |
-        ty::ty_enum(did, _) if ty::has_dtor(v.tcx, did) => {
+        ty::ty_struct(def, _) |
+        ty::ty_enum(def, _) if ty::has_dtor(v.tcx, def.def_id) => {
             v.add_qualif(NEEDS_DROP);
             if v.mode != Mode::Var {
                 v.tcx.sess.span_err(e.span,

--- a/src/librustc/middle/fast_reject.rs
+++ b/src/librustc/middle/fast_reject.rs
@@ -53,15 +53,15 @@ pub fn simplify_type(tcx: &ty::ctxt,
         ty::ty_int(int_type) => Some(IntSimplifiedType(int_type)),
         ty::ty_uint(uint_type) => Some(UintSimplifiedType(uint_type)),
         ty::ty_float(float_type) => Some(FloatSimplifiedType(float_type)),
-        ty::ty_enum(def_id, _) => Some(EnumSimplifiedType(def_id)),
+        ty::ty_enum(def, _) => Some(EnumSimplifiedType(def.def_id)),
         ty::ty_str => Some(StrSimplifiedType),
         ty::ty_vec(..) => Some(VecSimplifiedType),
         ty::ty_ptr(_) => Some(PtrSimplifiedType),
         ty::ty_trait(ref trait_info) => {
             Some(TraitSimplifiedType(trait_info.principal_def_id()))
         }
-        ty::ty_struct(def_id, _) => {
-            Some(StructSimplifiedType(def_id))
+        ty::ty_struct(def, _) => {
+            Some(StructSimplifiedType(def.def_id))
         }
         ty::ty_rptr(_, mt) => {
             // since we introduce auto-refs during method lookup, we
@@ -96,4 +96,3 @@ pub fn simplify_type(tcx: &ty::ctxt,
         ty::ty_infer(_) | ty::ty_err => None,
     }
 }
-

--- a/src/librustc/middle/infer/combine.rs
+++ b/src/librustc/middle/infer/combine.rs
@@ -484,10 +484,12 @@ pub fn super_tys<'tcx, C>(this: &C,
         (&ty::ty_param(ref a_p), &ty::ty_param(ref b_p)) if
           a_p.idx == b_p.idx && a_p.space == b_p.space => Ok(a),
 
-        (&ty::ty_enum(a_id, a_substs), &ty::ty_enum(b_id, b_substs))
-          if a_id == b_id => {
-            let substs = try!(this.substs(a_id, a_substs, b_substs));
-            Ok(ty::mk_enum(tcx, a_id, tcx.mk_substs(substs)))
+        (&ty::ty_enum(def_a, a_substs), &ty::ty_enum(def_b, b_substs))
+          if def_a.def_id == def_b.def_id => {
+            let substs = try!(this.substs(def_a.def_id,
+                                          a_substs,
+                                          b_substs));
+            Ok(ty::mk_enum(tcx, def_a, tcx.mk_substs(substs)))
         }
 
         (&ty::ty_trait(ref a_), &ty::ty_trait(ref b_)) => {
@@ -497,10 +499,10 @@ pub fn super_tys<'tcx, C>(this: &C,
             Ok(ty::mk_trait(tcx, principal, bounds))
         }
 
-        (&ty::ty_struct(a_id, a_substs), &ty::ty_struct(b_id, b_substs))
-          if a_id == b_id => {
-            let substs = try!(this.substs(a_id, a_substs, b_substs));
-            Ok(ty::mk_struct(tcx, a_id, tcx.mk_substs(substs)))
+        (&ty::ty_struct(def_a, a_substs), &ty::ty_struct(def_b, b_substs))
+          if def_a.def_id == def_b.def_id => {
+            let substs = try!(this.substs(def_a.def_id, a_substs, b_substs));
+            Ok(ty::mk_struct(tcx, def_a, tcx.mk_substs(substs)))
         }
 
         (&ty::ty_closure(a_id, a_region, a_substs),

--- a/src/librustc/middle/traits/coherence.rs
+++ b/src/librustc/middle/traits/coherence.rs
@@ -195,9 +195,9 @@ fn ty_is_local_constructor<'tcx>(tcx: &ty::ctxt<'tcx>, ty: Ty<'tcx>) -> bool {
             false
         }
 
-        ty::ty_enum(def_id, _) |
-        ty::ty_struct(def_id, _) => {
-            def_id.krate == ast::LOCAL_CRATE
+        ty::ty_enum(def, _) |
+        ty::ty_struct(def, _) => {
+            def.def_id.krate == ast::LOCAL_CRATE
         }
 
         ty::ty_uniq(_) => { // treat ~T like Box<T>

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1567,21 +1567,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     }
                 }
             }
-
-            ty::ty_struct(def_id, substs) => {
-                let types: Vec<Ty> =
-                    ty::struct_fields(self.tcx(), def_id, substs).iter()
-                                                                 .map(|f| f.mt.ty)
-                                                                 .collect();
-                nominal(bound, types)
-            }
-
-            ty::ty_enum(def_id, substs) => {
-                let types: Vec<Ty> =
-                    ty::substd_enum_variants(self.tcx(), def_id, substs)
-                    .iter()
-                    .flat_map(|variant| variant.args.iter())
-                    .cloned()
+            ty::ty_enum(def, substs) |
+            ty::ty_struct(def, substs) => {
+                let types: Vec<Ty> = def.variants.iter()
+                    .flat_map(|v| v.subst_fields(self.tcx(), substs))
                     .collect();
                 nominal(bound, types)
             }
@@ -1700,18 +1689,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 }
             }
 
-            ty::ty_struct(def_id, substs) => {
-                Some(ty::struct_fields(self.tcx(), def_id, substs).iter()
-                     .map(|f| f.mt.ty)
-                     .collect())
-            }
-
-            ty::ty_enum(def_id, substs) => {
-                Some(ty::substd_enum_variants(self.tcx(), def_id, substs)
-                     .iter()
-                     .flat_map(|variant| variant.args.iter())
-                     .map(|&ty| ty)
-                     .collect())
+            ty::ty_enum(def, substs) |
+            ty::ty_struct(def, substs) => {
+                Some(def.variants.iter()
+                     .flat_map(|v| v.subst_fields(self.tcx(), substs)).collect())
             }
         }
     }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2281,7 +2281,6 @@ pub struct VariantDef<'tcx> {
     pub name: Name,
     pub disr_val: Disr,
     pub fields: Vec<FieldTy<'tcx>>,
-    pub vis: Visibility,
 }
 
 

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -265,8 +265,7 @@ impl<'tcx> TypeFoldable<'tcx> for ty::TraitRef<'tcx> {
 
 impl<'tcx> TypeFoldable<'tcx> for ty::FieldTy<'tcx> {
     fn fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> ty::FieldTy<'tcx> {
-        let ty = ty::FieldTy::new(folder.tcx(),
-                                  self.id, self.name, self.vis, self.origin);
+        let ty = ty::FieldTy::new(self.id, self.name, self.vis, self.origin);
         ty.set_ty(self.ty().fold_with(folder));
         ty
     }

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -263,12 +263,12 @@ impl<'tcx> TypeFoldable<'tcx> for ty::TraitRef<'tcx> {
     }
 }
 
-impl<'tcx> TypeFoldable<'tcx> for ty::field<'tcx> {
-    fn fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> ty::field<'tcx> {
-        ty::field {
-            name: self.name,
-            mt: self.mt.fold_with(folder),
-        }
+impl<'tcx> TypeFoldable<'tcx> for ty::FieldTy<'tcx> {
+    fn fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> ty::FieldTy<'tcx> {
+        let ty = ty::FieldTy::new(folder.tcx(),
+                                  self.id, self.name, self.vis, self.origin);
+        ty.set_ty(self.ty().fold_with(folder));
+        ty
     }
 }
 

--- a/src/librustc/util/ivar.rs
+++ b/src/librustc/util/ivar.rs
@@ -1,0 +1,41 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::cell::Cell;
+
+pub struct Ivar<T:Copy> {
+    data: Cell<Option<T>>
+}
+
+impl<T:Copy> Ivar<T> {
+    pub fn new() -> Ivar<T> {
+        Ivar {
+            data: Cell::new(None)
+        }
+    }
+
+    pub fn get(&self) -> Option<T> {
+        self.data.get()
+    }
+
+    pub fn fulfill(&self, value: T) {
+        assert!(self.data.get().is_none(),
+                "Value already set!");
+        self.data.set(Some(value));
+    }
+
+    pub fn fulfilled(&self) -> bool {
+        self.data.get().is_some()
+    }
+
+    pub fn unwrap(&self) -> T {
+        self.get().unwrap()
+    }
+}

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -391,10 +391,10 @@ pub fn ty_to_string<'tcx>(cx: &ctxt<'tcx>, typ: &ty::TyS<'tcx>) -> String {
                 param_ty.user_string(cx)
             }
         }
-        ty_enum(did, substs) | ty_struct(did, substs) => {
-            let base = ty::item_path_str(cx, did);
-            parameterized(cx, &base, substs, did, &[],
-                          || ty::lookup_item_type(cx, did).generics)
+        ty_enum(def, substs) | ty_struct(def, substs) => {
+            let base = ty::item_path_str(cx, def.def_id);
+            parameterized(cx, &base, substs, def.def_id, &[],
+                          || ty::lookup_item_type(cx, def.def_id).generics)
         }
         ty_trait(ref data) => {
             data.user_string(cx)

--- a/src/librustc_borrowck/borrowck/check_loans.rs
+++ b/src/librustc_borrowck/borrowck/check_loans.rs
@@ -751,8 +751,8 @@ impl<'a, 'tcx> CheckLoanCtxt<'a, 'tcx> {
             }
             LpExtend(ref lp_base, _, LpInterior(InteriorField(_))) => {
                 match lp_base.to_type().sty {
-                    ty::ty_struct(def_id, _) | ty::ty_enum(def_id, _) => {
-                        if ty::has_dtor(self.tcx(), def_id) {
+                    ty::ty_struct(def, _) | ty::ty_enum(def, _) => {
+                        if ty::has_dtor(self.tcx(), def.def_id) {
                             // In the case where the owner implements drop, then
                             // the path must be initialized to prevent a case of
                             // partial reinitialization

--- a/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
@@ -179,8 +179,8 @@ fn check_and_get_illegal_move_origin<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>,
         mc::cat_interior(ref b, mc::InteriorField(_)) |
         mc::cat_interior(ref b, mc::InteriorElement(Kind::Pattern, _)) => {
             match b.ty.sty {
-                ty::ty_struct(did, _) | ty::ty_enum(did, _) => {
-                    if ty::has_dtor(bccx.tcx, did) {
+                ty::ty_struct(def, _) | ty::ty_enum(def, _) => {
+                    if ty::has_dtor(bccx.tcx, def.def_id) {
                         Some(cmt.clone())
                     } else {
                         check_and_get_illegal_move_origin(bccx, b)

--- a/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
@@ -137,8 +137,8 @@ fn report_cannot_move_out_of<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>,
         mc::cat_downcast(ref b, _) |
         mc::cat_interior(ref b, mc::InteriorField(_)) => {
             match b.ty.sty {
-                ty::ty_struct(did, _) |
-                ty::ty_enum(did, _) if ty::has_dtor(bccx.tcx, did) => {
+                ty::ty_struct(def, _) |
+                ty::ty_enum(def, _) if ty::has_dtor(bccx.tcx, def.def_id) => {
                     bccx.span_err(
                         move_from.span,
                         &format!("cannot move out of type `{}`, \

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -879,6 +879,9 @@ impl<'a, 'tcx, 'v> Visitor<'v> for PrivacyVisitor<'a, 'tcx> {
             ast::ExprStruct(_, ref fields, _) => {
                 match ty::expr_ty(self.tcx, expr).sty {
                     ty::ty_struct(def, _) => {
+                        // RFC 736: ensure all unmentioned fields are visible.
+                        // Rather than computing the set of unmentioned fields
+                        // (i.e. `all_fields - fields`, just check them all.
                         for field in &def.variants[0].fields {
                             self.check_field(expr.span, def, def.def_id,
                                              NamedField(field.name));

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -781,20 +781,19 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
               child_name_bindings.define_type(def, DUMMY_SP, modifiers);
           }
           DefStruct(def_id) => {
-            debug!("(building reduced graph for external \
-                    crate) building type and value for {}",
-                   final_ident);
-            child_name_bindings.define_type(def, DUMMY_SP, modifiers);
-            let fields = csearch::get_struct_fields(&self.session.cstore, def_id).iter().map(|f| {
-                f.name
-            }).collect::<Vec<_>>();
+              debug!("(building reduced graph for external \
+                     crate) building type and value for {}",
+                     final_ident);
+              child_name_bindings.define_type(def, DUMMY_SP, modifiers);
+              let fields : Vec<_> = csearch::get_struct_fields(&self.session.cstore, def_id)
+                  .into_iter().map(|f| f.name ).collect();
 
-            if fields.len() == 0 {
-                child_name_bindings.define_value(def, DUMMY_SP, modifiers);
-            }
+              if fields.len() == 0 {
+                  child_name_bindings.define_value(def, DUMMY_SP, modifiers);
+              }
 
-            // Record the def ID and fields of this struct.
-            self.structs.insert(def_id, fields);
+              // Record the def ID and fields of this struct.
+              self.structs.insert(def_id, fields);
           }
           DefLocal(..) | DefPrimTy(..) | DefTyParam(..) |
           DefUse(..) | DefUpvar(..) | DefRegion(..) |

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -177,17 +177,17 @@ fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
                                                                 bcx.fcx.param_substs).val)
             }
             def::DefVariant(tid, vid, _) => {
-                let vinfo = ty::enum_variant_with_id(bcx.tcx(), tid, vid);
-                let substs = common::node_id_substs(bcx.ccx(),
-                                                    ExprId(ref_expr.id),
-                                                    bcx.fcx.param_substs);
+                let enum_def = ty::lookup_datatype_def(bcx.tcx(), tid);
+                let variant = enum_def.get_variant(vid).expect("variant not in enum");
+                let substs = common::node_id_substs(bcx.ccx(), ExprId(ref_expr.id),
+                                            bcx.fcx.param_substs);
 
                 // Nullary variants are not callable
-                assert!(vinfo.args.len() > 0);
+                assert!(variant.fields.len() > 0u);
 
                 Callee {
                     bcx: bcx,
-                    data: NamedTupleConstructor(substs, vinfo.disr_val)
+                    data: NamedTupleConstructor(substs, variant.disr_val)
                 }
             }
             def::DefStruct(_) => {

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -888,7 +888,7 @@ fn foreign_signature<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     let llarg_tys = arg_tys.iter().map(|&arg| foreign_arg_type_of(ccx, arg)).collect();
     let (llret_ty, ret_def) = match fn_sig.output {
         ty::FnConverging(ret_ty) =>
-            (type_of::foreign_arg_type_of(ccx, ret_ty), !return_type_is_void(ccx, ret_ty)),
+            (type_of::foreign_arg_type_of(ccx, ret_ty), !return_type_is_void(ret_ty)),
         ty::FnDiverging =>
             (Type::nil(ccx), false)
     };

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -319,7 +319,7 @@ fn size_and_align_of_dst<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, info: 
         return (size, align);
     }
     match t.sty {
-        ty::ty_struct(id, substs) => {
+        ty::ty_struct(def, substs) => {
             let ccx = bcx.ccx();
             // First get the size of all statically known fields.
             // Don't use type_of::sizing_type_of because that expects t to be sized.
@@ -331,9 +331,8 @@ fn size_and_align_of_dst<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, info: 
 
             // Recurse to get the size of the dynamically sized field (must be
             // the last field).
-            let fields = ty::struct_fields(bcx.tcx(), id, substs);
-            let last_field = fields[fields.len()-1];
-            let field_ty = last_field.mt.ty;
+            let last_field = &def.variants[0].fields[def.variants[0].fields.len()-1];
+            let field_ty = last_field.subst_ty(bcx.tcx(), substs);
             let (unsized_size, unsized_align) = size_and_align_of_dst(bcx, field_ty, info);
 
             // Return the sum of sizes and max of aligns.
@@ -424,7 +423,8 @@ fn make_drop_glue<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, v0: ValueRef, t: Ty<'tcx>)
                 }
             }
         }
-        ty::ty_struct(did, substs) | ty::ty_enum(did, substs) => {
+        ty::ty_struct(def, substs) | ty::ty_enum(def, substs) => {
+            let did = def.def_id;
             let tcx = bcx.tcx();
             match ty::ty_dtor(tcx, did) {
                 ty::TraitDtor(dtor, true) => {

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -364,7 +364,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         }
         (_, "init") => {
             let tp_ty = *substs.types.get(FnSpace, 0);
-            if !return_type_is_void(ccx, tp_ty) {
+            if !return_type_is_void(tp_ty) {
                 // Just zero out the stack slot. (See comment on base::memzero for explanation)
                 zero_mem(bcx, llresult, tp_ty);
             }

--- a/src/librustc_typeck/check/implicator.rs
+++ b/src/librustc_typeck/check/implicator.rs
@@ -122,10 +122,10 @@ impl<'a, 'tcx> Implicator<'a, 'tcx> {
                 self.accumulate_from_object_ty(ty, t.bounds.region_bound, required_region_bounds)
             }
 
-            ty::ty_enum(def_id, substs) |
-            ty::ty_struct(def_id, substs) => {
-                let item_scheme = ty::lookup_item_type(self.tcx(), def_id);
-                self.accumulate_from_adt(ty, def_id, &item_scheme.generics, substs)
+            ty::ty_enum(def, substs) |
+            ty::ty_struct(def, substs) => {
+                let item_scheme = ty::lookup_item_type(self.tcx(), def.def_id);
+                self.accumulate_from_adt(ty, def.def_id, &item_scheme.generics, substs)
             }
 
             ty::ty_vec(t, _) |

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -276,8 +276,10 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
                 self.assemble_inherent_candidates_from_object(self_ty, data);
                 self.assemble_inherent_impl_candidates_for_type(data.principal_def_id());
             }
-            ty::ty_enum(did, _) |
-            ty::ty_struct(did, _) |
+            ty::ty_enum(def, _) |
+            ty::ty_struct(def, _) => {
+                self.assemble_inherent_impl_candidates_for_type(def.def_id);
+            }
             ty::ty_closure(did, _, _) => {
                 self.assemble_inherent_impl_candidates_for_type(did);
             }

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -58,8 +58,8 @@ pub fn report_error<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                 None);
 
             // If the method has the name of a field, give a help note
-            if let (&ty::ty_struct(did, _), Some(_)) = (&rcvr_ty.sty, rcvr_expr) {
-                let fields = ty::lookup_struct_fields(cx, did);
+            if let (&ty::ty_struct(def, _), Some(_)) = (&rcvr_ty.sty, rcvr_expr) {
+                let fields = &def.variants[0].fields[..];
                 if fields.iter().any(|f| f.name == method_name) {
                     cx.sess.span_note(span,
                         &format!("use `(s.{0})(...)` if you meant to call the \
@@ -235,7 +235,7 @@ fn type_derefs_to_local<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                                   rcvr_expr: Option<&ast::Expr>) -> bool {
     fn is_local(ty: Ty) -> bool {
         match ty.sty {
-            ty::ty_enum(did, _) | ty::ty_struct(did, _) => ast_util::is_local(did),
+            ty::ty_enum(def, _) | ty::ty_struct(def, _) => ast_util::is_local(def.def_id),
 
             ty::ty_trait(ref tr) => ast_util::is_local(tr.principal_def_id()),
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -86,7 +86,7 @@ use astconv::{self, ast_region_to_region, ast_ty_to_ty, AstConv, PathParamMode};
 use check::_match::pat_ctxt;
 use fmt_macros::{Parser, Piece, Position};
 use middle::astconv_util::{check_path_args, NO_TPS, NO_REGIONS};
-use middle::{const_eval, def};
+use middle::{def};
 use middle::infer;
 use middle::mem_categorization as mc;
 use middle::mem_categorization::McResult;

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -95,7 +95,7 @@ use middle::privacy::{AllPublic, LastMod};
 use middle::region::{self, CodeExtent};
 use middle::subst::{self, Subst, Substs, VecPerParamSpace, ParamSpace, TypeSpace};
 use middle::traits;
-use middle::ty::{FnSig, GenericPredicates, VariantInfo, TypeScheme};
+use middle::ty::{FnSig, GenericPredicates, TypeScheme};
 use middle::ty::{Disr, ParamTy, ParameterEnvironment};
 use middle::ty::{self, HasProjectionTypes, RegionEscape, ToPolyTraitRef, Ty};
 use middle::ty::liberate_late_bound_regions;
@@ -1072,7 +1072,7 @@ fn check_cast_inner<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     let t_e_is_scalar = ty::type_is_scalar(t_e);
     let t_e_is_integral = ty::type_is_integral(t_e);
     let t_e_is_float = ty::type_is_floating_point(t_e);
-    let t_e_is_c_enum = ty::type_is_c_like_enum(fcx.tcx(), t_e);
+    let t_e_is_c_enum = ty::type_is_c_like_enum(t_e);
 
     let t_1_is_scalar = ty::type_is_scalar(t_1);
     let t_1_is_char = ty::type_is_char(t_1);
@@ -1463,7 +1463,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                   -> T
         where T : TypeFoldable<'tcx> + Clone + HasProjectionTypes + Repr<'tcx>
     {
-        let value = value.subst(self.tcx(), substs);
+        let value = value.subst_spanned(self.tcx(), substs, Some(span));
         let result = self.normalize_associated_types_in(span, &value);
         debug!("instantiate_type_scheme(value={}, substs={}) = {}",
                value.repr(self.tcx()),
@@ -1883,27 +1883,25 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     // Indifferent to privacy flags
     pub fn lookup_field_ty(&self,
                            span: Span,
-                           class_id: ast::DefId,
-                           items: &[ty::field_ty],
+                           items: &[ty::FieldTy<'tcx>],
                            fieldname: ast::Name,
                            substs: &subst::Substs<'tcx>)
                            -> Option<Ty<'tcx>>
     {
         let o_field = items.iter().find(|f| f.name == fieldname);
-        o_field.map(|f| ty::lookup_field_type(self.tcx(), class_id, f.id, substs))
+        o_field.map(|f| f.subst_ty_spanned(self.tcx(), substs, span))
                .map(|t| self.normalize_associated_types_in(span, &t))
     }
 
     pub fn lookup_tup_field_ty(&self,
                                span: Span,
-                               class_id: ast::DefId,
-                               items: &[ty::field_ty],
+                               items: &[ty::FieldTy<'tcx>],
                                idx: uint,
                                substs: &subst::Substs<'tcx>)
                                -> Option<Ty<'tcx>>
     {
         let o_field = if idx < items.len() { Some(&items[idx]) } else { None };
-        o_field.map(|f| ty::lookup_field_type(self.tcx(), class_id, f.id, substs))
+        o_field.map(|f| f.subst_ty_spanned(self.tcx(), substs, span))
                .map(|t| self.normalize_associated_types_in(span, &t))
     }
 }
@@ -2926,7 +2924,7 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                 ast::BiEq | ast::BiNe | ast::BiLt | ast::BiLe | ast::BiGe |
                 ast::BiGt => {
                     if ty::type_is_simd(tcx, lhs_t) {
-                        if ty::type_is_fp(ty::simd_type(tcx, lhs_t)) {
+                        if ty::type_is_fp(ty::simd_type(lhs_t)) {
                             fcx.type_error_message(expr.span,
                                 |actual| {
                                     format!("binary comparison \
@@ -3071,10 +3069,10 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                                                   lvalue_pref,
                                                   |base_t, _| {
                 match base_t.sty {
-                    ty::ty_struct(base_id, substs) => {
+                    ty::ty_struct(def, substs) => {
                         debug!("struct named {}", ppaux::ty_to_string(tcx, base_t));
-                        let fields = ty::lookup_struct_fields(tcx, base_id);
-                        fcx.lookup_field_ty(expr.span, base_id, &fields[..],
+                        let fields = &def.variants[0].fields[..];
+                        fcx.lookup_field_ty(expr.span, fields,
                                             field.node.name, &(*substs))
                     }
                     _ => None
@@ -3112,8 +3110,8 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                             actual)
                 },
                 expr_t, None);
-            if let Some(t) = ty::ty_to_def_id(expr_t) {
-                suggest_field_names(t, field, tcx, vec![]);
+            if let ty::ty_struct(def, _) = expr_t.sty {
+                suggest_field_names(def, field, tcx, vec![]);
             }
         }
 
@@ -3121,7 +3119,7 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
     }
 
     // displays hints about the closest matches in field names
-    fn suggest_field_names<'tcx>(id : DefId,
+    fn suggest_field_names<'tcx>(struct_def : &'tcx ty::DatatypeDef<'tcx>,
                                  field : &ast::SpannedIdent,
                                  tcx : &ty::ctxt<'tcx>,
                                  skip : Vec<&str>) {
@@ -3129,16 +3127,16 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
         let name = &ident;
         // only find fits with at least one matching letter
         let mut best_dist = name.len();
-        let fields = ty::lookup_struct_fields(tcx, id);
+        let fields = &struct_def.variants[0].fields[];
         let mut best = None;
-        for elem in &fields {
+        for elem in fields {
             let n = elem.name.as_str();
             // ignore already set fields
             if skip.iter().any(|&x| x == n) {
                 continue;
             }
             // ignore private fields from non-local crates
-            if id.krate != ast::LOCAL_CRATE && elem.vis != Visibility::Public {
+            if !ast_util::is_local(elem.id) && elem.vis != Visibility::Public {
                 continue;
             }
             let dist = lev_distance(n, name);
@@ -3173,13 +3171,12 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                                                   lvalue_pref,
                                                   |base_t, _| {
                 match base_t.sty {
-                    ty::ty_struct(base_id, substs) => {
-                        tuple_like = ty::is_tuple_struct(tcx, base_id);
+                    ty::ty_struct(def, substs) => {
+                        tuple_like = def.is_tuple_variant(0);
                         if tuple_like {
                             debug!("tuple struct named {}", ppaux::ty_to_string(tcx, base_t));
-                            let fields = ty::lookup_struct_fields(tcx, base_id);
-                            fcx.lookup_tup_field_ty(expr.span, base_id, &fields[..],
-                                                    idx.node, &(*substs))
+                            let fields = &def.variants[0].fields[..];
+                            fcx.lookup_tup_field_ty(expr.span, fields, idx.node, &(*substs))
                         } else {
                             None
                         }
@@ -3222,19 +3219,22 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
     fn check_struct_or_variant_fields<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                                                 struct_ty: Ty<'tcx>,
                                                 span: Span,
-                                                class_id: ast::DefId,
                                                 node_id: ast::NodeId,
                                                 substitutions: &'tcx subst::Substs<'tcx>,
-                                                field_types: &[ty::field_ty],
+                                                data_def: &'tcx ty::DatatypeDef<'tcx>,
+                                                variant_id: ast::DefId,
                                                 ast_fields: &'tcx [ast::Field],
-                                                check_completeness: bool,
-                                                enum_id_opt: Option<ast::DefId>)  {
+                                                check_completeness: bool)  {
         let tcx = fcx.ccx.tcx;
+
+        let variant = data_def.get_variant(variant_id).expect("variant not in enum");
+        let field_types = &variant.fields[];
 
         let mut class_field_map = FnvHashMap();
         let mut fields_found = 0;
         for field in field_types {
-            class_field_map.insert(field.name, (field.id, false));
+            class_field_map.insert(field.name,
+                                   (field.subst_ty(tcx, substitutions), false));
         }
 
         let mut error_happened = false;
@@ -3248,18 +3248,14 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                 None => {
                     fcx.type_error_message(
                         field.ident.span,
-                        |actual| match enum_id_opt {
-                            Some(enum_id) => {
-                                let variant_type = ty::enum_variant_with_id(tcx,
-                                                                            enum_id,
-                                                                            class_id);
-                                format!("struct variant `{}::{}` has no field named `{}`",
-                                        actual, variant_type.name.as_str(),
-                                        token::get_ident(field.ident.node))
-                            }
-                            None => {
+                        |actual| {
+                            if variant.id == data_def.def_id {
                                 format!("structure `{}` has no field named `{}`",
                                         actual,
+                                        token::get_ident(field.ident.node))
+                            } else {
+                                format!("struct variant `{}::{}` has no field named `{}`",
+                                        actual, variant.name.as_str(),
                                         token::get_ident(field.ident.node))
                             }
                         },
@@ -3267,11 +3263,17 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                         None);
                     // prevent all specified fields from being suggested
                     let skip_fields = ast_fields.iter().map(|ref x| x.ident.node.name.as_str());
-                    let actual_id = match enum_id_opt {
-                        Some(_) => class_id,
-                        None => ty::ty_to_def_id(struct_ty).unwrap()
+                    let actual_def = if variant.id == data_def.def_id {
+                        if let ty::ty_struct(def, _) = struct_ty.sty {
+                            def
+                        } else {
+                            tcx.sess.span_bug(field.ident.span, "`struct_ty` is not a struct type?")
+                        }
+                    } else {
+                        data_def
                     };
-                    suggest_field_names(actual_id, &field.ident, tcx, skip_fields.collect());
+
+                    suggest_field_names(actual_def, &field.ident, tcx, skip_fields.collect());
                     error_happened = true;
                 }
                 Some((_, true)) => {
@@ -3280,15 +3282,12 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                         token::get_ident(field.ident.node));
                     error_happened = true;
                 }
-                Some((field_id, false)) => {
-                    expected_field_type =
-                        ty::lookup_field_type(
-                            tcx, class_id, field_id, substitutions);
+                Some((field_ty, false)) => {
                     expected_field_type =
                         fcx.normalize_associated_types_in(
-                            field.span, &expected_field_type);
+                            field.span, &field_ty);
                     class_field_map.insert(
-                        field.ident.node.name, (field_id, true));
+                        field.ident.node.name, (expected_field_type, true));
                     fields_found += 1;
                 }
             }
@@ -3324,8 +3323,7 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
         }
 
         if !error_happened {
-            fcx.write_ty(node_id, ty::mk_struct(fcx.ccx.tcx,
-                                class_id, substitutions));
+            fcx.write_ty(node_id, ty::mk_struct(fcx.ccx.tcx, data_def, substitutions));
         }
     }
 
@@ -3344,17 +3342,16 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
         } = fcx.instantiate_type(span, class_id);
 
         // Look up and check the fields.
-        let class_fields = ty::lookup_struct_fields(tcx, class_id);
+        let struct_def= ty::lookup_datatype_def(tcx, class_id);
         check_struct_or_variant_fields(fcx,
                                        struct_type,
                                        span,
-                                       class_id,
                                        id,
                                        fcx.ccx.tcx.mk_substs(struct_substs),
-                                       &class_fields[..],
+                                       struct_def,
+                                       class_id,
                                        fields,
-                                       base_expr.is_none(),
-                                       None);
+                                       base_expr.is_none());
         if ty::type_is_error(fcx.node_ty(id)) {
             struct_type = tcx.types.err;
         }
@@ -3387,17 +3384,17 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
         } = fcx.instantiate_type(span, enum_id);
 
         // Look up and check the enum variant fields.
-        let variant_fields = ty::lookup_struct_fields(tcx, variant_id);
+
+        let struct_def = ty::lookup_datatype_def(tcx, enum_id);
         check_struct_or_variant_fields(fcx,
                                        enum_type,
                                        span,
-                                       variant_id,
                                        id,
                                        fcx.ccx.tcx.mk_substs(substitutions),
-                                       &variant_fields[..],
+                                       struct_def,
+                                       variant_id,
                                        fields,
-                                       true,
-                                       Some(enum_id));
+                                       true);
         fcx.write_ty(id, enum_type);
     }
 
@@ -3526,8 +3523,8 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                             Some(mt) => mt.ty,
                             None => {
                                 let is_newtype = match oprnd_t.sty {
-                                    ty::ty_struct(did, substs) => {
-                                        let fields = ty::struct_fields(fcx.tcx(), did, substs);
+                                    ty::ty_struct(def, _) => {
+                                        let fields = &def.variants[0].fields[];
                                         fields.len() == 1
                                         && fields[0].name ==
                                         token::special_idents::unnamed_field.name
@@ -3935,11 +3932,11 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                 // Verify that this was actually a struct.
                 let typ = ty::lookup_item_type(fcx.ccx.tcx, def.def_id());
                 match typ.ty.sty {
-                    ty::ty_struct(struct_did, _) => {
+                    ty::ty_struct(def, _) => {
                         check_struct_constructor(fcx,
                                                  id,
                                                  expr.span,
-                                                 struct_did,
+                                                 def.def_id,
                                                  &fields[..],
                                                  base_expr.as_ref().map(|e| &**e));
                     }
@@ -4100,7 +4097,9 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                                                      traits::ItemObligation(did)),
                         &bounds);
 
-                    ty::mk_struct(tcx, did, tcx.mk_substs(substs))
+                    let def = ty::lookup_datatype_def(tcx, did);
+
+                    ty::mk_struct(tcx, def, tcx.mk_substs(substs))
                 } else {
                     span_err!(tcx.sess, expr.span, E0236, "no lang item for range syntax");
                     fcx.tcx().types.err
@@ -4110,7 +4109,8 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                 // Neither start nor end => RangeFull
                 if let Some(did) = tcx.lang_items.range_full_struct() {
                     let substs = Substs::new_type(vec![], vec![]);
-                    ty::mk_struct(tcx, did, tcx.mk_substs(substs))
+                    let def = ty::lookup_datatype_def(tcx, did);
+                    ty::mk_struct(tcx, def, tcx.mk_substs(substs))
                 } else {
                     span_err!(tcx.sess, expr.span, E0237, "no lang item for range syntax");
                     fcx.tcx().types.err
@@ -4495,15 +4495,15 @@ pub fn check_simd(tcx: &ty::ctxt, sp: Span, id: ast::NodeId) {
         return;
     }
     match t.sty {
-        ty::ty_struct(did, substs) => {
-            let fields = ty::lookup_struct_fields(tcx, did);
+        ty::ty_struct(def, substs) => {
+            let fields = &def.variants[0].fields[];
             if fields.is_empty() {
                 span_err!(tcx.sess, sp, E0075, "SIMD vector cannot be empty");
                 return;
             }
-            let e = ty::lookup_field_type(tcx, did, fields[0].id, substs);
+            let e = fields[0].subst_ty_spanned(tcx, substs, sp);
             if !fields.iter().all(
-                         |f| ty::lookup_field_type(tcx, did, f.id, substs) == e) {
+                         |f| f.subst_ty_spanned(tcx, substs, sp) == e) {
                 span_err!(tcx.sess, sp, E0076, "SIMD vector should be homogeneous");
                 return;
             }
@@ -4549,30 +4549,24 @@ pub fn check_enum_variants<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
         }
     }
 
-    fn do_check<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                          vs: &'tcx [P<ast::Variant>],
-                          id: ast::NodeId,
-                          hint: attr::ReprAttr)
-                          -> Vec<Rc<ty::VariantInfo<'tcx>>> {
+    fn check_variants<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
+                                vs: &'tcx [P<ast::Variant>],
+                                id: ast::NodeId,
+                                hint: attr::ReprAttr) {
 
         let rty = ty::node_id_to_type(ccx.tcx, id);
-        let mut variants: Vec<Rc<ty::VariantInfo>> = Vec::new();
-        let mut disr_vals: Vec<ty::Disr> = Vec::new();
-        let mut prev_disr_val: Option<ty::Disr> = None;
+        let def = match rty.sty {
+            ty::ty_enum(def, _) => def,
+            _ => ccx.tcx.sess.bug("Checking variants of a non-enum type"),
+        };
 
-        for v in vs {
+        let mut disr_vals: FnvHashMap<ty::Disr, Span> = FnvHashMap();
 
-            // If the discriminant value is specified explicitly in the enum check whether the
-            // initialization expression is valid, otherwise use the last value plus one.
-            let mut current_disr_val = match prev_disr_val {
-                Some(prev_disr_val) => prev_disr_val + 1,
-                None => ty::INITIAL_DISCRIMINANT_VALUE
-            };
+        for (i, v) in vs.iter().enumerate() {
+            let variant = &def.variants[i];
 
             match v.node.disr_expr {
                 Some(ref e) => {
-                    debug!("disr expr, checking {}", pprust::expr_to_string(&**e));
-
                     let inh = static_inherited_fields(ccx);
                     let fcx = blank_fn_ctxt(ccx, &inh, ty::FnConverging(rty), e.id);
                     let declty = match hint {
@@ -4585,41 +4579,25 @@ pub fn check_enum_variants<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
                         },
                     };
                     check_const_with_ty(&fcx, e.span, &**e, declty);
-                    // check_expr (from check_const pass) doesn't guarantee
-                    // that the expression is in a form that eval_const_expr can
-                    // handle, so we may still get an internal compiler error
-
-                    match const_eval::eval_const_expr_partial(ccx.tcx, &**e, Some(declty)) {
-                        Ok(const_eval::const_int(val)) => current_disr_val = val as Disr,
-                        Ok(const_eval::const_uint(val)) => current_disr_val = val as Disr,
-                        Ok(_) => {
-                            span_err!(ccx.tcx.sess, e.span, E0079,
-                                "expected signed integer constant");
-                        }
-                        Err(ref err) => {
-                            span_err!(ccx.tcx.sess, e.span, E0080,
-                                "expected constant: {}", *err);
-                        }
-                    }
-                },
-                None => ()
-            };
-
-            // Check for duplicate discriminant values
-            match disr_vals.iter().position(|&x| x == current_disr_val) {
-                Some(i) => {
-                    span_err!(ccx.tcx.sess, v.span, E0081,
-                        "discriminant value `{}` already exists", disr_vals[i]);
-                    span_note!(ccx.tcx.sess, ccx.tcx.map.span(variants[i].id.node),
-                        "conflicting discriminant here")
                 }
                 None => {}
+            }
+
+            // Check for duplicate discriminant values
+            match disr_vals.entry(variant.disr_val).get() {
+                Ok(span) => {
+                    span_err!(ccx.tcx.sess, v.span, E0081,
+                        "discriminant value `{}` already exists", variant.disr_val);
+                    span_note!(ccx.tcx.sess, *span,
+                        "conflicting discriminant here");
+                }
+                Err(e) => { e.insert(v.span); }
             }
             // Check for unrepresentable discriminant values
             match hint {
                 attr::ReprAny | attr::ReprExtern => (),
                 attr::ReprInt(sp, ity) => {
-                    if !disr_in_range(ccx, ity, current_disr_val) {
+                    if !disr_in_range(ccx, ity, variant.disr_val) {
                         span_err!(ccx.tcx.sess, v.span, E0082,
                             "discriminant value outside specified type");
                         span_note!(ccx.tcx.sess, sp,
@@ -4630,16 +4608,7 @@ pub fn check_enum_variants<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
                     ccx.tcx.sess.bug("range_to_inttype: found ReprPacked on an enum");
                 }
             }
-            disr_vals.push(current_disr_val);
-
-            let variant_info = Rc::new(VariantInfo::from_ast_variant(ccx.tcx, &**v,
-                                                                     current_disr_val));
-            prev_disr_val = Some(current_disr_val);
-
-            variants.push(variant_info);
         }
-
-        return variants;
     }
 
     let hint = *ty::lookup_repr_hints(ccx.tcx, ast::DefId { krate: ast::LOCAL_CRATE, node: id })
@@ -4655,10 +4624,7 @@ pub fn check_enum_variants<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
         };
     }
 
-    let variants = do_check(ccx, vs, id, hint);
-
-    // cache so that ty::enum_variants won't repeat this work
-    ccx.tcx.enum_var_cache.borrow_mut().insert(local_def(id), Rc::new(variants));
+    check_variants(ccx, vs, id, hint);
 
     check_representable(ccx.tcx, sp, id, "enum");
 

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -248,9 +248,9 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
                 !attr::contains_name(&item.attrs, "unsafe_destructor")
             {
                 match self_ty.sty {
-                    ty::ty_struct(def_id, _) |
-                    ty::ty_enum(def_id, _) => {
-                        check_struct_safe_for_destructor(fcx, item.span, def_id);
+                    ty::ty_struct(def, _) |
+                    ty::ty_enum(def, _) => {
+                        check_struct_safe_for_destructor(fcx, item.span, def.def_id);
                     }
                     _ => {
                         // Coherence already reports an error in this case.
@@ -614,8 +614,9 @@ impl<'cx,'tcx> TypeFolder<'tcx> for BoundsChecker<'cx,'tcx> {
         }
 
         match t.sty{
-            ty::ty_struct(type_id, substs) |
-            ty::ty_enum(type_id, substs) => {
+            ty::ty_struct(type_def, substs) |
+            ty::ty_enum(type_def, substs) => {
+                let type_id = type_def.def_id;
                 let type_predicates = ty::lookup_predicates(self.fcx.tcx(), type_id);
                 let bounds = self.fcx.instantiate_bounds(self.span, substs,
                                                          &type_predicates);

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -60,9 +60,9 @@ fn get_base_type_def_id<'a, 'tcx>(inference_context: &InferCtxt<'a, 'tcx>,
                                   ty: Ty<'tcx>)
                                   -> Option<DefId> {
     match ty.sty {
-        ty_enum(def_id, _) |
-        ty_struct(def_id, _) => {
-            Some(def_id)
+        ty_enum(def, _) |
+        ty_struct(def, _) => {
+            Some(def.def_id)
         }
 
         ty_trait(ref t) => {
@@ -395,8 +395,8 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
 
             let self_type = self.get_self_type_for_implementation(impl_did);
             match self_type.ty.sty {
-                ty::ty_enum(type_def_id, _) |
-                ty::ty_struct(type_def_id, _) |
+                ty::ty_enum(&ty::DatatypeDef { def_id: type_def_id, ..}, _) |
+                ty::ty_struct(&ty::DatatypeDef { def_id: type_def_id, ..}, _) |
                 ty::ty_closure(type_def_id, _, _) => {
                     tcx.destructor_for_type
                        .borrow_mut()

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -49,9 +49,9 @@ impl<'cx, 'tcx,'v> visit::Visitor<'v> for OrphanChecker<'cx, 'tcx> {
                 debug!("coherence2::orphan check: inherent impl {}", item.repr(self.tcx));
                 let self_ty = ty::lookup_item_type(self.tcx, def_id).ty;
                 match self_ty.sty {
-                    ty::ty_enum(def_id, _) |
-                    ty::ty_struct(def_id, _) => {
-                        self.check_def_id(item, def_id);
+                    ty::ty_enum(def, _) |
+                    ty::ty_struct(def, _) => {
+                        self.check_def_id(item, def.def_id);
                     }
                     ty::ty_trait(ref data) => {
                         self.check_def_id(item, data.principal_def_id());

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1552,10 +1552,10 @@ fn get_struct_def<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                     Err(e) => { e.insert(f.span); }
                 }
 
-                ty::FieldTy::new(tcx, local_def(f.node.id), ident.name, visibility, def_id)
+                ty::FieldTy::new(local_def(f.node.id), ident.name, visibility, def_id)
             }
             ast::UnnamedField(visibility) => {
-                ty::FieldTy::new(tcx, local_def(f.node.id),
+                ty::FieldTy::new(local_def(f.node.id),
                                  special_idents::unnamed_field.name,
                                  visibility, def_id)
             }
@@ -1627,7 +1627,7 @@ fn get_enum_def<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>, def_id: ast::DefId,
         match v.node.kind {
             ast::TupleVariantKind(ref args) if args.len() > 0 => {
                 let fields = args.iter().map(|f| {
-                    ty::FieldTy::new(tcx, local_def(f.id),
+                    ty::FieldTy::new(local_def(f.id),
                                      special_idents::unnamed_field.name,
                                      ast::Public,
                                      def_id)
@@ -1664,11 +1664,11 @@ fn get_enum_def<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>, def_id: ast::DefId,
                                 Err(e) => { e.insert(f.span); }
                             }
 
-                            ty::FieldTy::new(tcx, local_def(f.node.id),
+                            ty::FieldTy::new(local_def(f.node.id),
                                              ident.name, visibility, def_id)
                         }
                         ast::UnnamedField(visibility) => {
-                            ty::FieldTy::new(tcx, local_def(f.node.id),
+                            ty::FieldTy::new(local_def(f.node.id),
                                              special_idents::unnamed_field.name,
                                              visibility, def_id)
                         }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1570,7 +1570,6 @@ fn get_struct_def<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
             name: name,
             disr_val: 0,
             fields: fields,
-            vis: ast::Public,
         }]
     });
 
@@ -1637,7 +1636,6 @@ fn get_enum_def<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>, def_id: ast::DefId,
                     name: v.node.name.name,
                     disr_val: discriminant,
                     fields: fields,
-                    vis: ast::Public,
                 }
             }
             ast::TupleVariantKind(_) => {
@@ -1646,7 +1644,6 @@ fn get_enum_def<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>, def_id: ast::DefId,
                     name: v.node.name.name,
                     disr_val: discriminant,
                     fields: Vec::new(),
-                    vis: ast::Public,
                 }
             }
             ast::StructVariantKind(ref struct_def) => {
@@ -1681,7 +1678,6 @@ fn get_enum_def<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>, def_id: ast::DefId,
                     name: v.node.name.name,
                     disr_val: discriminant,
                     fields: fields,
-                    vis: ast::Public,
                 }
             }
         }

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -82,6 +82,7 @@ register_diagnostics! {
     E0122,
     E0123,
     E0124,
+    E0125,
     E0127,
     E0128,
     E0129,
@@ -173,9 +174,10 @@ register_diagnostics! {
     E0248, // found value name used as a type
     E0249, // expected constant expr for array length
     E0250, // expected constant expr for array length
+    E0264, // expected integer constant for discriminant value
+    E0265, // expected constant for discriminant value
     E0318, // can't create default impls for traits outside their crates
     E0319  // trait impls for defaulted traits allowed just for structs/enums
 }
 
 __build_diagnostic_array! { DIAGNOSTICS }
-


### PR DESCRIPTION
Add a DatatypeDef type that contains information for both structs and enums. Most places already treated structs like single-variant enums or vice-versa, so this actually simplifies a lot of code.

There is a small but significant performance increase in typechecking and translation (pre-optimisations) of about 5% in both phases. All the other phases seemed to have some performance improvements too, but the differences were too small to be meaningful.

This change is also a step towards overall simplification of the type system code. Given how many places are now treating enums and structs completely identically, a move towards a unified `ty_data` type is somewhat feasible.
