### PR TITLE
unbreak openbsd build after 1860ee52

### DIFF
--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -211,7 +211,7 @@ pub fn current_exe() -> IoResult<Path> {
         if v.is_null() {
             Err(IoError::last_error())
         } else {
-            Ok(Path::new(CStr::from_ptr(&v).to_bytes().to_vec()))
+            Ok(Path::new(CStr::from_ptr(v).to_bytes().to_vec()))
         }
     }
 }


### PR DESCRIPTION
The commit 1860ee52 has break the openbsd build.
Repair it.
