### PR TITLE
std: Ensure fs::{DirEntry, ReadDir} are Send/Sync

### DIFF
--- a/src/test/run-pass/issue-22577.rs
+++ b/src/test/run-pass/issue-22577.rs
@@ -1,0 +1,29 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{fs, net};
+
+fn assert_both<T: Send + Sync>() {}
+
+fn main() {
+    assert_both::<fs::File>();
+    assert_both::<fs::Metadata>();
+    assert_both::<fs::ReadDir>();
+    assert_both::<fs::DirEntry>();
+    assert_both::<fs::WalkDir>();
+    assert_both::<fs::OpenOptions>();
+    assert_both::<fs::Permissions>();
+
+    assert_both::<net::TcpStream>();
+    assert_both::<net::TcpListener>();
+    assert_both::<net::UdpSocket>();
+    assert_both::<net::SocketAddr>();
+    assert_both::<net::IpAddr>();
+}


### PR DESCRIPTION
The windows/unix modules were currently inconsistent about the traits being
implemented for `DirEntry` and there isn't much particular reason why the traits
_couldn't_ be implemented for `ReadDir` and `DirEntry`, so this commit ensures
that they are implemented.

Closes #22577
