### PR TITLE
Fix typo in deprecation msg

### DIFF
--- a/src/libstd/thread.rs
+++ b/src/libstd/thread.rs
@@ -465,16 +465,16 @@ impl Thread {
         }
     }
 
-    /// Deprecated: use module-level free fucntion.
-    #[deprecated(since = "1.0.0", reason = "use module-level free fucntion")]
+    /// Deprecated: use module-level free function.
+    #[deprecated(since = "1.0.0", reason = "use module-level free function")]
     #[unstable(feature = "std_misc",
                reason = "may change with specifics of new Send semantics")]
     pub fn spawn<F>(f: F) -> Thread where F: FnOnce(), F: Send + 'static {
         Builder::new().spawn(f).unwrap().thread().clone()
     }
 
-    /// Deprecated: use module-level free fucntion.
-    #[deprecated(since = "1.0.0", reason = "use module-level free fucntion")]
+    /// Deprecated: use module-level free function.
+    #[deprecated(since = "1.0.0", reason = "use module-level free function")]
     #[unstable(feature = "std_misc",
                reason = "may change with specifics of new Send semantics")]
     pub fn scoped<'a, T, F>(f: F) -> JoinGuard<'a, T> where
@@ -483,30 +483,30 @@ impl Thread {
         Builder::new().scoped(f).unwrap()
     }
 
-    /// Deprecated: use module-level free fucntion.
-    #[deprecated(since = "1.0.0", reason = "use module-level free fucntion")]
+    /// Deprecated: use module-level free function.
+    #[deprecated(since = "1.0.0", reason = "use module-level free function")]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn current() -> Thread {
         thread_info::current_thread()
     }
 
-    /// Deprecated: use module-level free fucntion.
-    #[deprecated(since = "1.0.0", reason = "use module-level free fucntion")]
+    /// Deprecated: use module-level free function.
+    #[deprecated(since = "1.0.0", reason = "use module-level free function")]
     #[unstable(feature = "std_misc", reason = "name may change")]
     pub fn yield_now() {
         unsafe { imp::yield_now() }
     }
 
-    /// Deprecated: use module-level free fucntion.
-    #[deprecated(since = "1.0.0", reason = "use module-level free fucntion")]
+    /// Deprecated: use module-level free function.
+    #[deprecated(since = "1.0.0", reason = "use module-level free function")]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn panicking() -> bool {
         unwind::panicking()
     }
 
-    /// Deprecated: use module-level free fucntion.
-    #[deprecated(since = "1.0.0", reason = "use module-level free fucntion")]
+    /// Deprecated: use module-level free function.
+    #[deprecated(since = "1.0.0", reason = "use module-level free function")]
     #[unstable(feature = "std_misc", reason = "recently introduced")]
     pub fn park() {
         let thread = current();
@@ -517,8 +517,8 @@ impl Thread {
         *guard = false;
     }
 
-    /// Deprecated: use module-level free fucntion.
-    #[deprecated(since = "1.0.0", reason = "use module-level free fucntion")]
+    /// Deprecated: use module-level free function.
+    #[deprecated(since = "1.0.0", reason = "use module-level free function")]
     #[unstable(feature = "std_misc", reason = "recently introduced")]
     pub fn park_timeout(dur: Duration) {
         let thread = current();


### PR DESCRIPTION
Essentially `s/fucntion/function/g` in `src/libstd/thread.rs`.
