### PR TITLE
Un-ignore lang-item-public test.

### DIFF
--- a/src/test/run-pass/lang-item-public.rs
+++ b/src/test/run-pass/lang-item-public.rs
@@ -10,7 +10,6 @@
 
 // aux-build:lang-item-public.rs
 // ignore-android
-// ignore-windows #13361
 
 #![feature(lang_items, start, no_std)]
 #![no_std]


### PR DESCRIPTION
This test appears to pass cleanly on master.
Closes #13361
