### PR TITLE
Allow Float::ldexp to be called as a method

### DIFF
--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -191,8 +191,8 @@ impl Float for f32 {
     /// Constructs a floating point number by multiplying `x` by 2 raised to the
     /// power of `exp`
     #[inline]
-    fn ldexp(x: f32, exp: int) -> f32 {
-        unsafe { cmath::ldexpf(x, exp as c_int) }
+    fn ldexp(self, exp: isize) -> f32 {
+        unsafe { cmath::ldexpf(self, exp as c_int) }
     }
 
     /// Breaks the number into a normalized fraction and a base-2 exponent,
@@ -2208,8 +2208,8 @@ mod tests {
         let f1: f32 = FromStrRadix::from_str_radix("1p-123", 16).unwrap();
         let f2: f32 = FromStrRadix::from_str_radix("1p-111", 16).unwrap();
         let f3: f32 = FromStrRadix::from_str_radix("1.Cp-12", 16).unwrap();
-        assert_eq!(Float::ldexp(1f32, -123), f1);
-        assert_eq!(Float::ldexp(1f32, -111), f2);
+        assert_eq!(1f32.ldexp(-123), f1);
+        assert_eq!(1f32.ldexp(-111), f2);
         assert_eq!(Float::ldexp(1.75f32, -12), f3);
 
         assert_eq!(Float::ldexp(0f32, -123), 0f32);

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -200,8 +200,8 @@ impl Float for f64 {
     fn to_radians(self) -> f64 { num::Float::to_radians(self) }
 
     #[inline]
-    fn ldexp(x: f64, exp: int) -> f64 {
-        unsafe { cmath::ldexp(x, exp as c_int) }
+    fn ldexp(self, exp: isize) -> f64 {
+        unsafe { cmath::ldexp(self, exp as c_int) }
     }
 
     /// Breaks the number into a normalized fraction and a base-2 exponent,
@@ -2215,8 +2215,8 @@ mod tests {
         let f1: f64 = FromStrRadix::from_str_radix("1p-123", 16).unwrap();
         let f2: f64 = FromStrRadix::from_str_radix("1p-111", 16).unwrap();
         let f3: f64 = FromStrRadix::from_str_radix("1.Cp-12", 16).unwrap();
-        assert_eq!(Float::ldexp(1f64, -123), f1);
-        assert_eq!(Float::ldexp(1f64, -111), f2);
+        assert_eq!(1f64.ldexp(-123), f1);
+        assert_eq!(1f64.ldexp(-111), f2);
         assert_eq!(Float::ldexp(1.75f64, -12), f3);
 
         assert_eq!(Float::ldexp(0f64, -123), 0f64);

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -702,7 +702,7 @@ pub trait Float
     /// ```
     #[unstable(feature = "std_misc",
                reason = "pending integer conventions")]
-    fn ldexp(x: Self, exp: isize) -> Self;
+    fn ldexp(self, exp: isize) -> Self;
     /// Breaks the number into a normalized fraction and a base-2 exponent,
     /// satisfying:
     ///


### PR DESCRIPTION
Fixes #22098.
