### PR TITLE
Kill fmt::Show and fmt::String with fire!

### DIFF
--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -404,7 +404,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 pub use core::fmt::{Formatter, Result, Write, rt};
-pub use core::fmt::{Show, String, Octal, Binary};
+pub use core::fmt::{Octal, Binary};
 pub use core::fmt::{Display, Debug};
 pub use core::fmt::{LowerHex, UpperHex, Pointer};
 pub use core::fmt::{LowerExp, UpperExp};

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -248,38 +248,12 @@ impl<'a> Display for Arguments<'a> {
 
 /// Format trait for the `:?` format. Useful for debugging, all types
 /// should implement this.
-#[deprecated(since = "1.0.0", reason = "renamed to Debug")]
-#[unstable(feature = "old_fmt")]
-pub trait Show {
-    /// Formats the value using the given formatter.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    fn fmt(&self, &mut Formatter) -> Result;
-}
-
-/// Format trait for the `:?` format. Useful for debugging, all types
-/// should implement this.
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_on_unimplemented = "`{Self}` cannot be formatted using `:?`; if it is \
                             defined in your crate, add `#[derive(Debug)]` or \
                             manually implement it"]
 #[lang = "debug_trait"]
 pub trait Debug {
-    /// Formats the value using the given formatter.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    fn fmt(&self, &mut Formatter) -> Result;
-}
-
-#[allow(deprecated)]
-impl<T: Show + ?Sized> Debug for T {
-    #[allow(deprecated)]
-    fn fmt(&self, f: &mut Formatter) -> Result { Show::fmt(self, f) }
-}
-
-/// When a value can be semantically expressed as a String, this trait may be
-/// used. It corresponds to the default format, `{}`.
-#[deprecated(since = "1.0.0", reason = "renamed to Display")]
-#[unstable(feature = "old_fmt")]
-pub trait String {
     /// Formats the value using the given formatter.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn fmt(&self, &mut Formatter) -> Result;
@@ -295,12 +269,6 @@ pub trait Display {
     /// Formats the value using the given formatter.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn fmt(&self, &mut Formatter) -> Result;
-}
-
-#[allow(deprecated)]
-impl<T: String + ?Sized> Display for T {
-    #[allow(deprecated)]
-    fn fmt(&self, f: &mut Formatter) -> Result { String::fmt(self, f) }
 }
 
 /// Format trait for the `o` character

--- a/src/test/auxiliary/cci_class_cast.rs
+++ b/src/test/auxiliary/cci_class_cast.rs
@@ -17,7 +17,7 @@ pub mod kitty {
       pub name : String,
     }
 
-    impl fmt::String for cat {
+    impl fmt::Display for cat {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "{}", self.name)
         }

--- a/src/test/compile-fail/coherence-blanket-conflicts-with-blanket-implemented.rs
+++ b/src/test/compile-fail/coherence-blanket-conflicts-with-blanket-implemented.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::Show;
+use std::fmt::Debug;
 use std::default::Default;
 use std::marker::MarkerTrait;
 

--- a/src/test/compile-fail/coherence-blanket-conflicts-with-blanket-unimplemented.rs
+++ b/src/test/compile-fail/coherence-blanket-conflicts-with-blanket-unimplemented.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::Show;
+use std::fmt::Debug;
 use std::default::Default;
 
 // Test that two blanket impls conflict (at least without negative

--- a/src/test/compile-fail/coherence-blanket-conflicts-with-specific-cross-crate.rs
+++ b/src/test/compile-fail/coherence-blanket-conflicts-with-specific-cross-crate.rs
@@ -13,7 +13,7 @@
 extern crate go_trait;
 
 use go_trait::{Go,GoMut};
-use std::fmt::Show;
+use std::fmt::Debug;
 use std::default::Default;
 
 struct MyThingy;

--- a/src/test/compile-fail/coherence-blanket-conflicts-with-specific-multidispatch.rs
+++ b/src/test/compile-fail/coherence-blanket-conflicts-with-specific-multidispatch.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::Show;
+use std::fmt::Debug;
 use std::default::Default;
 
 // Test that a blank impl for all T conflicts with an impl for some

--- a/src/test/compile-fail/coherence-blanket-conflicts-with-specific.rs
+++ b/src/test/compile-fail/coherence-blanket-conflicts-with-specific.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::Show;
+use std::fmt::Debug;
 use std::default::Default;
 
 // Test that a blank impl for all T conflicts with an impl for some

--- a/src/test/compile-fail/coherence-tuple-conflict.rs
+++ b/src/test/compile-fail/coherence-tuple-conflict.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::Show;
+use std::fmt::Debug;
 use std::default::Default;
 
 // Test that a blank impl for all T conflicts with an impl for some

--- a/src/test/compile-fail/issue-17441.rs
+++ b/src/test/compile-fail/issue-17441.rs
@@ -14,11 +14,11 @@ fn main() {
     let _foo = &[1_usize, 2] as [usize];
     //~^ ERROR cast to unsized type: `&[usize; 2]` as `[usize]`
     //~^^ HELP consider using an implicit coercion to `&[usize]` instead
-    let _bar = box 1_usize as std::fmt::Show;
-    //~^ ERROR cast to unsized type: `Box<usize>` as `core::fmt::Show`
-    //~^^ HELP did you mean `Box<core::fmt::Show>`?
-    let _baz = 1_usize as std::fmt::Show;
-    //~^ ERROR cast to unsized type: `usize` as `core::fmt::Show`
+    let _bar = box 1_usize as std::fmt::Debug;
+    //~^ ERROR cast to unsized type: `Box<usize>` as `core::fmt::Debug`
+    //~^^ HELP did you mean `Box<core::fmt::Debug>`?
+    let _baz = 1_usize as std::fmt::Debug;
+    //~^ ERROR cast to unsized type: `usize` as `core::fmt::Debug`
     //~^^ HELP consider using a box or reference as appropriate
     let _quux = [1_usize, 2] as [usize];
     //~^ ERROR cast to unsized type: `[usize; 2]` as `[usize]`

--- a/src/test/compile-fail/use-after-move-implicity-coerced-object.rs
+++ b/src/test/compile-fail/use-after-move-implicity-coerced-object.rs
@@ -18,7 +18,7 @@ struct Number {
     n: i64
 }
 
-impl fmt::String for Number {
+impl fmt::Display for Number {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.n)
     }

--- a/src/test/parse-fail/trailing-plus-in-bounds.rs
+++ b/src/test/parse-fail/trailing-plus-in-bounds.rs
@@ -8,11 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::Show;
+use std::fmt::Debug;
 
 fn main() {
-    let x: Box<Show+> = box 3 as Box<Show+>;
+    let x: Box<Debug+> = box 3 as Box<Debug+>;
     //~^ ERROR at least one type parameter bound must be specified
     //~^^ ERROR at least one type parameter bound must be specified
 }
-

--- a/src/test/run-pass/class-separate-impl.rs
+++ b/src/test/run-pass/class-separate-impl.rs
@@ -54,7 +54,7 @@ fn cat(in_x : uint, in_y : int, in_name: String) -> cat {
     }
 }
 
-impl fmt::String for cat {
+impl fmt::Display for cat {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.name)
     }

--- a/src/test/run-pass/coherence-multidispatch-tuple.rs
+++ b/src/test/run-pass/coherence-multidispatch-tuple.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt::Show;
+use std::fmt::Debug;
 use std::default::Default;
 
 // Test that an impl for homogeneous pairs does not conflict with a

--- a/src/test/run-pass/issue-3563-3.rs
+++ b/src/test/run-pass/issue-3563-3.rs
@@ -101,7 +101,7 @@ impl AsciiArt {
 
 // Allows AsciiArt to be converted to a string using the libcore ToString trait.
 // Note that the %s fmt! specifier will not call this automatically.
-impl fmt::String for AsciiArt {
+impl fmt::Display for AsciiArt {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Convert each line into a string.
         let lines = self.lines.iter()


### PR DESCRIPTION
Toss the tomatoes!

r? @aturon 

Fixes #22478. The underlying bug(?) behind that issue still exists though and there’s another issue that reports it.
