### PR TITLE
Remove mention of non-existing AtomicOption in docs

### DIFF
--- a/src/libcore/atomic.rs
+++ b/src/libcore/atomic.rs
@@ -15,7 +15,7 @@
 //! types.
 //!
 //! This module defines atomic versions of a select number of primitive
-//! types, including `AtomicBool`, `AtomicIsize`, `AtomicUsize`, and `AtomicOption`.
+//! types, including `AtomicBool`, `AtomicIsize`, and `AtomicUsize`.
 //! Atomic types present operations that, when used correctly, synchronize
 //! updates between threads.
 //!


### PR DESCRIPTION
AtomicOption was removed in 7d8d06f86b48520814596bd5363d2b82bc619774
but the docs weren't updated.

Fixes #22586
