### PR TITLE
Remove last traces of BitV and BitVSet from documentation

### DIFF
--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -110,7 +110,7 @@ fn reverse_bits(byte: u8) -> u8 {
     result
 }
 
-// Take two BitV's, and return iterators of their words, where the shorter one
+// Take two BitVec's, and return iterators of their words, where the shorter one
 // has been padded with 0's
 fn match_words <'a,'b>(a: &'a BitVec, b: &'b BitVec) -> (MatchWords<'a>, MatchWords<'b>) {
     let a_len = a.storage.len();

--- a/src/libstd/collections/mod.rs
+++ b/src/libstd/collections/mod.rs
@@ -23,9 +23,9 @@
 //!
 //! Rust's collections can be grouped into four major categories:
 //!
-//! * Sequences: `Vec`, `VecDeque`, `LinkedList`, `BitV`
+//! * Sequences: `Vec`, `VecDeque`, `LinkedList`, `BitVec`
 //! * Maps: `HashMap`, `BTreeMap`, `VecMap`
-//! * Sets: `HashSet`, `BTreeSet`, `BitVSet`
+//! * Sets: `HashSet`, `BTreeSet`, `BitSet`
 //! * Misc: `BinaryHeap`
 //!
 //! # When Should You Use Which Collection?
@@ -73,11 +73,11 @@
 //! * There is no meaningful value to associate with your keys.
 //! * You just want a set.
 //!
-//! ### Use a `BitV` when:
+//! ### Use a `BitVec` when:
 //! * You want to store an unbounded number of booleans in a small space.
 //! * You want a bit vector.
 //!
-//! ### Use a `BitVSet` when:
+//! ### Use a `BitSet` when:
 //! * You want a `VecSet`.
 //!
 //! ### Use a `BinaryHeap` when:


### PR DESCRIPTION
It looks like a few spots in the documentation were missed when renaming `Bitv` and `BitvSet`. This fixes the docs to use their current names.
