### PR TITLE
Fix for intermittent Windows failures, see #22628

### DIFF
--- a/src/test/run-pass/unwind-resource.rs
+++ b/src/test/run-pass/unwind-resource.rs
@@ -40,4 +40,16 @@ pub fn main() {
     let _t = thread::spawn(move|| f(tx.clone()));
     println!("hiiiiiiiii");
     assert!(rx.recv().unwrap());
+
+    #[cfg(windows)]
+    {
+        // Quick fix for an intermittent failure
+        // We don't want to exit the test till we know that the
+        // child has finished unwinding, because Windows blocks the
+        // test libraries till the thread exits
+        // FIXME #22628
+        use std::old_io::timer::sleep;
+        use std::time::duration::Duration;
+        sleep(Duration::seconds(20));
+    }
 }

--- a/src/test/run-pass/unwind-unique.rs
+++ b/src/test/run-pass/unwind-unique.rs
@@ -20,4 +20,16 @@ fn f() {
 
 pub fn main() {
     let _t = thread::spawn(f);
+
+    #[cfg(windows)]
+    {
+        // Quick fix for an intermittent failure
+        // We don't want to exit the test till we know that the
+        // child has finished unwinding, because Windows blocks the
+        // test libraries till the thread exits
+        // FIXME #22628
+        use std::old_io::timer::sleep;
+        use std::time::duration::Duration;
+        sleep(Duration::seconds(20));
+    }
 }


### PR DESCRIPTION
The Windows failures in #22628 are caused by leftover threads blocking `stdtest.exe`; in both of these tests a thread is spawned that may outlive the main thread. We can't use a scoped thread here because these both test the behavior of panics in spawned threads, and with scoped threads we cannot panic the child without the parent panicking too.

A twenty-second sleep for Windows ensures that the spawned thread will have exited.

This is only temporary (and is very much a hack), we probably should find a better solution to the issue of exes being blocked because they are in use, perhaps via the test runner.
