### PR TITLE
Include tuple indexing in the Reference.

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -3554,7 +3554,8 @@ Tuple types and values are denoted by listing the types or values of their
 elements, respectively, in a parenthesized, comma-separated list.
 
 Because tuple elements don't have a name, they can only be accessed by
-pattern-matching.
+pattern-matching or by using `N` directly as a field to access the
+`N`th element.
 
 An example of a tuple type and its use:
 
@@ -3563,6 +3564,7 @@ type Pair<'a> = (i32, &'a str);
 let p: Pair<'static> = (10, "hello");
 let (a, b) = p;
 assert!(b != "world");
+assert!(p.0 == 10);
 ```
 
 ### Array, and Slice types


### PR DESCRIPTION
The Rust Reference should include the tuple indexing (using a number
as a field) notation; currently it is only available on
http://doc.rust-lang.org/std/primitive.tuple.html and not easily
searchable.
