### PR TITLE
Disallow crate names with leading hyphens

### DIFF
--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -81,11 +81,13 @@ pub fn validate_crate_name(sess: Option<&Session>, s: &str, sp: Option<Span>) {
     };
     if s.len() == 0 {
         err("crate name must not be empty");
+    } else if s.char_at(0) == '-' {
+        err(&format!("crate name cannot start with a hyphen: {}", s));
     }
     for c in s.chars() {
         if c.is_alphanumeric() { continue }
         if c == '_' || c == '-' { continue }
-        err(&format!("invalid character `{}` in crate name: `{}`", c, s)[]);
+        err(&format!("invalid character `{}` in crate name: `{}`", c, s));
     }
     match sess {
         Some(sess) => sess.abort_if_errors(),

--- a/src/test/run-make/weird-output-filenames/Makefile
+++ b/src/test/run-make/weird-output-filenames/Makefile
@@ -10,3 +10,6 @@ all:
 	cp foo.rs $(TMPDIR)/+foo+bar
 	$(RUSTC) $(TMPDIR)/+foo+bar 2>&1 \
 		| grep "invalid character.*in crate name:"
+	cp foo.rs $(TMPDIR)/-foo.rs
+	$(RUSTC) $(TMPDIR)/-foo.rs 2>&1 \
+		| grep "crate name cannot start with a hyphen:"


### PR DESCRIPTION
Leading hyphens already don't work (#22661), so no code should break from this change.

Closes #22661.
