### PR TITLE
Do not permit type parameters on builtin bounds

### DIFF
--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1847,8 +1847,14 @@ pub fn partition_bounds<'a>(tcx: &ty::ctxt,
                         if ty::try_add_builtin_trait(tcx,
                                                      trait_did,
                                                      &mut builtin_bounds) {
-                            // FIXME(#20302) -- we should check for things like Copy<T>
-                            continue; // success
+                            let segments = &b.trait_ref.path.segments;
+                            let parameters = &segments[segments.len() - 1].parameters;
+                            if parameters.is_empty() {
+                                continue; // success
+                            }
+                            span_err!(tcx.sess, b.trait_ref.path.span, E0316,
+                                      "builtin bounds do not require arguments, {} given",
+                                      parameters.types().len());
                         }
                     }
                     _ => {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1849,12 +1849,12 @@ pub fn partition_bounds<'a>(tcx: &ty::ctxt,
                                                      &mut builtin_bounds) {
                             let segments = &b.trait_ref.path.segments;
                             let parameters = &segments[segments.len() - 1].parameters;
-                            if parameters.is_empty() {
-                                continue; // success
+                            if !parameters.is_empty() {
+                                span_err!(tcx.sess, b.trait_ref.path.span, E0316,
+                                          "builtin bounds do not require arguments, {} given",
+                                          parameters.lifetimes().len() + parameters.types().len());
                             }
-                            span_err!(tcx.sess, b.trait_ref.path.span, E0316,
-                                      "builtin bounds do not require arguments, {} given",
-                                      parameters.types().len());
+                            continue; // success
                         }
                     }
                     _ => {

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -171,7 +171,8 @@ register_diagnostics! {
     E0247, // found module name used as a type
     E0248, // found value name used as a type
     E0249, // expected constant expr for array length
-    E0250  // expected constant expr for array length
+    E0250, // expected constant expr for array length
+    E0316  // wrong number of type arguments to a built-in trait
 }
 
 __build_diagnostic_array! { DIAGNOSTICS }

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -172,7 +172,6 @@ register_diagnostics! {
     E0248, // found value name used as a type
     E0249, // expected constant expr for array length
     E0250, // expected constant expr for array length
-    E0316  // wrong number of type arguments to a built-in trait
 }
 
 __build_diagnostic_array! { DIAGNOSTICS }

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -332,6 +332,7 @@ pub fn winsorize<T: Float + FromPrimitive>(samples: &mut [T], pct: T) {
 
 /// Returns a HashMap with the number of occurrences of every element in the
 /// sequence that the iterator exposes.
+#[cfg(not(stage0))]
 pub fn freq_count<T, U>(iter: T) -> hash_map::HashMap<U, uint>
   where T: Iterator<Item=U>, U: Eq + Clone + Hash
 {

--- a/src/test/compile-fail/typeck-builtin-bound-type-parameters.rs
+++ b/src/test/compile-fail/typeck-builtin-bound-type-parameters.rs
@@ -15,13 +15,13 @@ trait Trait: Copy<Send> {}
 //~^ ERROR: builtin bounds do not require arguments, 1 given
 
 struct MyStruct1<T: Copy<T>>;
-//~^ ERROR: builtin bounds do not require arguments, 1 given
+//~^ ERROR builtin bounds do not require arguments, 1 given
 
 struct MyStruct2<'a, T: Copy<'a>>;
 //~^ ERROR: builtin bounds do not require arguments, 1 given
 
 fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
-//~^ ERROR: builtin bounds do not require arguments, 1 given
+//~^ ERROR builtin bounds do not require arguments, 2 given
 
 fn main() {
 }

--- a/src/test/compile-fail/typeck-builtin-bound-type-parameters.rs
+++ b/src/test/compile-fail/typeck-builtin-bound-type-parameters.rs
@@ -1,0 +1,27 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo1<T:Copy<U>, U>(x: T) {}
+//~^ ERROR: builtin bounds do not require arguments, 1 given
+
+trait Trait: Copy<Send> {}
+//~^ ERROR: builtin bounds do not require arguments, 1 given
+
+struct MyStruct1<T: Copy<T>>;
+//~^ ERROR: builtin bounds do not require arguments, 1 given
+
+struct MyStruct2<'a, T: Copy<'a>>;
+//~^ ERROR: builtin bounds do not require arguments, 1 given
+
+fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
+//~^ ERROR: builtin bounds do not require arguments, 1 given
+
+fn main() {
+}

--- a/src/test/compile-fail/typeck-builtin-bound-type-parameters.rs
+++ b/src/test/compile-fail/typeck-builtin-bound-type-parameters.rs
@@ -9,19 +9,20 @@
 // except according to those terms.
 
 fn foo1<T:Copy<U>, U>(x: T) {}
-//~^ ERROR: builtin bounds do not require arguments, 1 given
+//~^ ERROR: wrong number of type arguments: expected 0, found 1
 
 trait Trait: Copy<Send> {}
-//~^ ERROR: builtin bounds do not require arguments, 1 given
+//~^ ERROR: wrong number of type arguments: expected 0, found 1
 
 struct MyStruct1<T: Copy<T>>;
-//~^ ERROR builtin bounds do not require arguments, 1 given
+//~^ ERROR wrong number of type arguments: expected 0, found 1
 
 struct MyStruct2<'a, T: Copy<'a>>;
-//~^ ERROR: builtin bounds do not require arguments, 1 given
+//~^ ERROR: wrong number of lifetime parameters: expected 0, found 1
 
 fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
-//~^ ERROR builtin bounds do not require arguments, 2 given
+//~^ ERROR: wrong number of type arguments: expected 0, found 1
+//~^^ ERROR: wrong number of lifetime parameters: expected 0, found 1
 
 fn main() {
 }


### PR DESCRIPTION
Fixes #20302
