### PR TITLE
Optimize implementations of FromIterator and Extend for Vec

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1429,7 +1429,7 @@ impl<T> FromIterator<T> for Vec<T> {
                 vector
             }
         };
-        vector.extend(iterable);
+        vector.extend_desugared(iterator);
         vector
     }
 }
@@ -1466,9 +1466,14 @@ impl<'a, T> IntoIterator for &'a mut Vec<T> {
 
 #[unstable(feature = "collections", reason = "waiting on Extend stability")]
 impl<T> Extend<T> for Vec<T> {
+    #[inline]
     fn extend<I: IntoIterator<Item=T>>(&mut self, iterable: I) {
-        let mut iterator = iterable.into_iter();
+        self.extend_desugared(iterable.into_iter())
+    }
+}
 
+impl<T> Vec<T> {
+    fn extend_desugared<I: Iterator<Item=T>>(&mut self, mut iterator: I) {
         // This function should be the moral equivalent of:
         //
         //      for item in iterator {

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1479,22 +1479,15 @@ impl<T> Vec<T> {
         //      for item in iterator {
         //          self.push(item);
         //      }
-        loop {
-            match iterator.next() {
-                None => {
-                    break;
-                }
-                Some(element) => {
-                    let len = self.len();
-                    if len == self.capacity() {
-                        let (lower, _) = iterator.size_hint();
-                        self.reserve(lower + 1);
-                    }
-                    unsafe {
-                        ptr::write(self.get_unchecked_mut(len), element);
-                        self.set_len(len + 1);
-                    }
-                }
+        while let Some(element) = iterator.next() {
+            let len = self.len();
+            if len == self.capacity() {
+                let (lower, _) = iterator.size_hint();
+                self.reserve(lower + 1);
+            }
+            unsafe {
+                ptr::write(self.get_unchecked_mut(len), element);
+                self.set_len(len + 1);
             }
         }
     }


### PR DESCRIPTION
Instead of a fast branch with a sized iterator falling back to a potentially poorly optimized iterate-and-push loop, a single efficient loop can serve all cases.

In my benchmark runs, I see some good gains, but also some regressions, possibly due to different inlining choices by the compiler. YMMV.
