### PR TITLE
Use boxed functions instead of transmute in the standard libraries

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -114,6 +114,7 @@ impl<T : ?Sized> Box<T> {
     /// function is called twice on the same raw pointer.
     #[unstable(feature = "alloc",
                reason = "may be renamed or moved out of Box scope")]
+    #[inline]
     pub unsafe fn from_raw(raw: *mut T) -> Self {
         mem::transmute(raw)
     }
@@ -141,6 +142,7 @@ impl<T : ?Sized> Box<T> {
 /// ```
 #[unstable(feature = "alloc",
            reason = "may be renamed")]
+#[inline]
 pub unsafe fn into_raw<T : ?Sized>(b: Box<T>) -> *mut T {
     mem::transmute(b)
 }

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -105,9 +105,9 @@ impl<T : ?Sized> Box<T> {
     /// After this function call, pointer is owned by resulting box.
     /// In particular, it means that `Box` destructor calls destructor
     /// of `T` and releases memory. Since the way `Box` allocates and
-    /// releases memory is unspecified, so the only valid pointer to
-    /// pass to this function is the one taken from another `Box` with
-    /// `box::into_raw` function.
+    /// releases memory is unspecified, the only valid pointer to pass
+    /// to this function is the one taken from another `Box` with
+    /// `boxed::into_raw` function.
     ///
     /// Function is unsafe, because improper use of this function may
     /// lead to memory problems like double-free, for example if the

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -250,11 +250,12 @@ impl BoxAny for Box<Any> {
         if self.is::<T>() {
             unsafe {
                 // Get the raw representation of the trait object
+                let raw = into_raw(self);
                 let to: TraitObject =
-                    mem::transmute::<Box<Any>, TraitObject>(self);
+                    mem::transmute::<*mut Any, TraitObject>(raw);
 
                 // Extract the data pointer
-                Ok(mem::transmute(to.data))
+                Ok(Box::from_raw(to.data as *mut T))
             }
         } else {
             Err(self)

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -144,6 +144,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use boxed;
 use core::cell::Cell;
 use core::clone::Clone;
 use core::cmp::{PartialEq, PartialOrd, Eq, Ord, Ordering};
@@ -151,7 +152,7 @@ use core::default::Default;
 use core::fmt;
 use core::hash::{Hasher, Hash};
 use core::marker;
-use core::mem::{transmute, min_align_of, size_of, forget};
+use core::mem::{min_align_of, size_of, forget};
 use core::nonzero::NonZero;
 use core::ops::{Deref, Drop};
 use core::option::Option;
@@ -201,7 +202,7 @@ impl<T> Rc<T> {
                 // there is an implicit weak pointer owned by all the strong pointers, which
                 // ensures that the weak destructor never frees the allocation while the strong
                 // destructor is running, even if the weak pointer is stored inside the strong one.
-                _ptr: NonZero::new(transmute(box RcBox {
+                _ptr: NonZero::new(boxed::into_raw(box RcBox {
                     value: value,
                     strong: Cell::new(1),
                     weak: Cell::new(1)

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -388,7 +388,7 @@ impl<T> Vec<T> {
     pub fn into_boxed_slice(mut self) -> Box<[T]> {
         self.shrink_to_fit();
         unsafe {
-            let xs: Box<[T]> = mem::transmute(&mut *self);
+            let xs: Box<[T]> = Box::from_raw(&mut *self);
             mem::forget(self);
             xs
         }

--- a/src/libstd/rt/at_exit_imp.rs
+++ b/src/libstd/rt/at_exit_imp.rs
@@ -14,9 +14,9 @@
 
 use core::prelude::*;
 
+use boxed;
 use boxed::Box;
 use vec::Vec;
-use mem;
 use thunk::Thunk;
 use sys_common::mutex::{Mutex, MUTEX_INIT};
 
@@ -32,7 +32,7 @@ static mut QUEUE: *mut Queue = 0 as *mut Queue;
 unsafe fn init() {
     if QUEUE.is_null() {
         let state: Box<Queue> = box Vec::new();
-        QUEUE = mem::transmute(state);
+        QUEUE = boxed::into_raw(state);
     } else {
         // can't re-init after a cleanup
         rtassert!(QUEUE as uint != 1);
@@ -57,7 +57,7 @@ pub fn cleanup() {
 
         // If we never called init, not need to cleanup!
         if queue as uint != 0 {
-            let queue: Box<Queue> = mem::transmute(queue);
+            let queue: Box<Queue> = Box::from_raw(queue);
             for to_run in *queue {
                 to_run.invoke(());
             }

--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -60,6 +60,7 @@
 use prelude::v1::*;
 
 use any::Any;
+use boxed;
 use cell::Cell;
 use cmp;
 use panicking;
@@ -173,7 +174,8 @@ fn rust_panic(cause: Box<Any + Send + 'static>) -> ! {
             },
             cause: Some(cause),
         };
-        let error = uw::_Unwind_RaiseException(mem::transmute(exception));
+        let exception_param = boxed::into_raw(exception) as *mut uw::_Unwind_Exception;
+        let error = uw::_Unwind_RaiseException(exception_param);
         rtabort!("Could not unwind stack, error = {}", error as int)
     }
 
@@ -181,7 +183,7 @@ fn rust_panic(cause: Box<Any + Send + 'static>) -> ! {
                                 exception: *mut uw::_Unwind_Exception) {
         rtdebug!("exception_cleanup()");
         unsafe {
-            let _: Box<Exception> = mem::transmute(exception);
+            let _: Box<Exception> = Box::from_raw(exception as *mut Exception);
         }
     }
 }

--- a/src/libstd/sys/common/helper_thread.rs
+++ b/src/libstd/sys/common/helper_thread.rs
@@ -22,8 +22,8 @@
 
 use prelude::v1::*;
 
+use boxed;
 use cell::UnsafeCell;
-use mem;
 use ptr;
 use rt;
 use sync::{StaticMutex, StaticCondvar};
@@ -88,7 +88,7 @@ impl<M: Send> Helper<M> {
             let _guard = self.lock.lock().unwrap();
             if !*self.initialized.get() {
                 let (tx, rx) = channel();
-                *self.chan.get() = mem::transmute(box tx);
+                *self.chan.get() = boxed::into_raw(box tx);
                 let (receive, send) = helper_signal::new();
                 *self.signal.get() = send as uint;
 
@@ -132,7 +132,7 @@ impl<M: Send> Helper<M> {
             let mut guard = self.lock.lock().unwrap();
 
             // Close the channel by destroying it
-            let chan: Box<Sender<M>> = mem::transmute(*self.chan.get());
+            let chan: Box<Sender<M>> = Box::from_raw(*self.chan.get());
             *self.chan.get() = ptr::null_mut();
             drop(chan);
             helper_signal::signal(*self.signal.get() as helper_signal::signal);

--- a/src/libstd/sys/common/thread.rs
+++ b/src/libstd/sys/common/thread.rs
@@ -27,7 +27,7 @@ pub fn start_thread(main: *mut libc::c_void) -> thread::rust_thread_return {
     unsafe {
         stack::record_os_managed_stack_bounds(0, usize::MAX);
         let handler = stack_overflow::Handler::new();
-        let f: Box<Thunk> = mem::transmute(main);
+        let f: Box<Thunk> = Box::from_raw(main as *mut Thunk);
         f.invoke(());
         drop(handler);
         mem::transmute(0 as thread::rust_thread_return)

--- a/src/libstd/sys/windows/thread_local.rs
+++ b/src/libstd/sys/windows/thread_local.rs
@@ -133,13 +133,13 @@ unsafe fn init_dtors() {
     if !DTORS.is_null() { return }
 
     let dtors = box Vec::<(Key, Dtor)>::new();
-    DTORS = mem::transmute(dtors);
+    DTORS = boxed::into_raw(dtors);
 
     rt::at_exit(move|| {
         DTOR_LOCK.lock();
         let dtors = DTORS;
         DTORS = ptr::null_mut();
-        mem::transmute::<_, Box<Vec<(Key, Dtor)>>>(dtors);
+        Boxed::from_raw(dtors);
         assert!(DTORS.is_null()); // can't re-init after destructing
         DTOR_LOCK.unlock();
     });


### PR DESCRIPTION
e. g.

```
let b: Box<Foo> = Box::from_raw(p);
```

instead of

```
let b: Box<Foo> = mem::transmute(p);
```

Patch also changes closure release code in `src/libstd/sys/unix/thread.rs`
when `pthread_create` failed. Raw pointer was transmuted to box of
`FnOnce()` instead of `Thunk`. This code was probably never executed,
because `pthread_create` rarely fails.

(And there are two more patches in PR: fix typo in doc and mark `from_raw` and `into_raw` functions inline.)
