### PR TITLE
test: Make two tests less flaky on windows

### DIFF
--- a/src/test/run-pass/unwind-resource.rs
+++ b/src/test/run-pass/unwind-resource.rs
@@ -37,7 +37,8 @@ fn f(tx: Sender<bool>) {
 
 pub fn main() {
     let (tx, rx) = channel();
-    let _t = thread::spawn(move|| f(tx.clone()));
+    let t = thread::spawn(move|| f(tx.clone()));
     println!("hiiiiiiiii");
     assert!(rx.recv().unwrap());
+    drop(t.join());
 }

--- a/src/test/run-pass/unwind-unique.rs
+++ b/src/test/run-pass/unwind-unique.rs
@@ -19,5 +19,6 @@ fn f() {
 }
 
 pub fn main() {
-    let _t = thread::spawn(f);
+    let t = thread::spawn(f);
+    drop(t.join());
 }


### PR DESCRIPTION
If these tests exit while a thread is panicking it often leads to situations
like #22628.
