### PR TITLE
openbsd: restore linker option

### DIFF
--- a/src/librustc_back/target/openbsd_base.rs
+++ b/src/librustc_back/target/openbsd_base.rs
@@ -20,6 +20,11 @@ pub fn opts() -> TargetOptions {
         linker_is_gnu: true,
         has_rpath: true,
         pre_link_args: vec!(
+            // GNU-style linkers will use this to omit linking to libraries
+            // which don't actually fulfill any relocations, but only for
+            // libraries which follow this flag.  Thus, use it before
+            // specifying libraries to link to.
+            "-Wl,--as-needed".to_string(),
         ),
         position_independent_executables: true,
         .. Default::default()


### PR DESCRIPTION
The `-Wl,--as-needed` option was removed during first stages of
bootstrapping between Linux and OpenBSD.

Restore it, as it seems to be ok now.
