### PR TITLE
std::io: panic on overconsumed Cursor

### DIFF
--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -470,6 +470,20 @@ mod tests {
     }
 
     #[test]
+    #[should_fail]
+    fn test_buffered_reader_overconsumed() {
+        let inner: &[u8] = &[1, 2, 3, 4];
+        let mut reader = BufReader::with_capacity(2, inner);
+        assert_eq!(reader.fill_buf().unwrap().len(), 2);
+        // If the debug assertion is disabled in consume(),
+        // the following assertions fail on unwanted outcomes.
+        reader.consume(3);
+        let mut buf = [0];
+        assert_eq!(reader.read(&mut buf), Ok(1));
+        assert_eq!(buf[0], 4);
+    }
+
+    #[test]
     fn test_buffered_writer() {
         let inner = Vec::new();
         let mut writer = BufWriter::with_capacity(2, inner);

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -305,6 +305,18 @@ mod tests {
     }
 
     #[test]
+    #[should_fail]
+    fn overconsume() {
+        let in_buf = vec![0xffu8];
+        let mut reader = Cursor::new(&in_buf[..]);
+        assert_eq!(reader.fill_buf(), Ok(&in_buf[..]));
+        // If the debug assertion in consume() is not compiled in,
+        // the next fill_buf() should panic.
+        reader.consume(2);
+        reader.fill_buf().unwrap();
+    }
+
+    #[test]
     fn test_slice_reader() {
         let in_buf = vec![0u8, 1, 2, 3, 4, 5, 6, 7];
         let mut reader = &mut in_buf.as_slice();

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -151,7 +151,7 @@ impl<'a> BufRead for Cursor<&'a mut [u8]> {
 }
 impl<'a> BufRead for Cursor<Vec<u8>> {
     fill_buf!(clamp_pos_to_end);
-    consume!(clamp_pos_to_end);
+    consume!(assert_pos_bound);
 }
 
 impl<'a> Write for Cursor<&'a mut [u8]> {


### PR DESCRIPTION
The truncation of offset in `fill_buf` adds a branch penalizing any correct usage and makes `BufReader` spuriously report EOF after the input is overconsumed.
I think it better to treat overconsumption as a programmer error and produce a helpful panic message in debug builds.

The implementation of `Seek` is changed to not rely on the former behavior.
Instead, `Seek` on non-growable buffers has the position truncated to the length of the buffer.
