### PR TITLE
std: Handle a trailing slash in create_dir_all

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -540,7 +540,14 @@ pub fn create_dir_all<P: AsPath + ?Sized>(path: &P) -> io::Result<()> {
         Some(p) if p != path => try!(create_dir_all(p)),
         _ => {}
     }
-    create_dir(path)
+    // If the file name of the given `path` is blank then the creation of the
+    // parent directory will have taken care of the whole path for us, so we're
+    // good to go.
+    if path.file_name().is_none() {
+        Ok(())
+    } else {
+        create_dir(path)
+    }
 }
 
 /// Remove an existing, empty directory
@@ -1499,5 +1506,12 @@ mod tests {
         perm.set_readonly(true);
         check!(fs::set_permissions(&path, perm));
         check!(fs::remove_file(&path));
+    }
+
+    #[test]
+    fn mkdir_trailing_slash() {
+        let tmpdir = tmpdir();
+        let path = tmpdir.join("file");
+        check!(fs::create_dir_all(&path.join("a/")));
     }
 }


### PR DESCRIPTION
If the filename for a path is `None` then we know that the creation of the
parent directory created the whole path so there's no need to retry the call to
`create_dir`.

Closes #22737
