### PR TITLE
std: Expose a `mode` accessor for Permissions on unix

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -325,6 +325,10 @@ impl FromInner<fs_imp::FilePermissions> for Permissions {
     }
 }
 
+impl AsInner<fs_imp::FilePermissions> for Permissions {
+    fn as_inner(&self) -> &fs_imp::FilePermissions { &self.0 }
+}
+
 impl Iterator for ReadDir {
     type Item = io::Result<DirEntry>;
 

--- a/src/libstd/sys/unix/ext.rs
+++ b/src/libstd/sys/unix/ext.rs
@@ -173,10 +173,13 @@ impl OsStrExt for OsStr {
 
 // Unix-specific extensions to `Permissions`
 pub trait PermissionsExt {
+    fn mode(&self) -> i32;
     fn set_mode(&mut self, mode: i32);
 }
 
 impl PermissionsExt for Permissions {
+    fn mode(&self) -> i32 { self.as_inner().mode() }
+
     fn set_mode(&mut self, mode: i32) {
         *self = FromInner::from_inner(FromInner::from_inner(mode));
     }

--- a/src/libstd/sys/unix/fs2.rs
+++ b/src/libstd/sys/unix/fs2.rs
@@ -86,6 +86,7 @@ impl FilePermissions {
             self.mode |= 0o222;
         }
     }
+    pub fn mode(&self) -> i32 { self.mode as i32 }
 }
 
 impl FromInner<i32> for FilePermissions {


### PR DESCRIPTION
Currently we have a `set_mode` mutator, so this just adds the pairing of a
`mode` accessor to read the value.

Closes #22738
