### PR TITLE
Stop parsing "-" as integer, fixes #22745

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1672,6 +1672,7 @@ macro_rules! from_str_radix_int_impl {
                 let is_signed_ty = (0 as $T) > Int::min_value();
 
                 match src.slice_shift_char() {
+                    Some(('-', "")) => Err(PIE { kind: Empty }),
                     Some(('-', src)) if is_signed_ty => {
                         // The number is negative
                         let mut result = 0;

--- a/src/libcoretest/num/mod.rs
+++ b/src/libcoretest/num/mod.rs
@@ -122,4 +122,9 @@ mod test {
         assert_eq!("-9223372036854775808".parse::<i64>().ok(), Some(i64_val));
         assert_eq!("-9223372036854775809".parse::<i64>().ok(), None);
     }
+
+    #[test]
+    test_int_from_minus_sign() {
+        assert_eq!("-".parse::<i32>().ok(), None);
+    }
 }

--- a/src/libcoretest/num/mod.rs
+++ b/src/libcoretest/num/mod.rs
@@ -124,7 +124,7 @@ mod test {
     }
 
     #[test]
-    test_int_from_minus_sign() {
+    fn test_int_from_minus_sign() {
         assert_eq!("-".parse::<i32>().ok(), None);
     }
 }


### PR DESCRIPTION
Makes Rust less amusing by fixing [#22745](https://github.com/rust-lang/rust/issues/22745)
