### PR TITLE
Added documentation of backslash ending string literals.

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -320,9 +320,9 @@ next line to be ignored.
 let a = "foobar";
 let b = "foo\
          bar";
-```
 
-`a` is equivalent to `b`.
+assert_eq!(a,b);
+```
 
 ##### Character escapes
 

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -302,7 +302,7 @@ nonzero_dec: '1' | '2' | '3' | '4'
 
 A _character literal_ is a single Unicode character enclosed within two
 `U+0027` (single-quote) characters, with the exception of `U+0027` itself,
-which must be _escaped_ by a preceding U+005C character (`\`).
+which must be _escaped_ by a preceding `U+005C` character (`\`).
 
 ##### String literals
 
@@ -310,6 +310,19 @@ A _string literal_ is a sequence of any Unicode characters enclosed within two
 `U+0022` (double-quote) characters, with the exception of `U+0022` itself,
 which must be _escaped_ by a preceding `U+005C` character (`\`), or a _raw
 string literal_.
+
+A multi-line string literal may be defined by terminating each line with a
+`U+005C` character (`\`) immediately before the newline. This causes the
+`U+005C` character, the newline, and all whitespace at the beginning of the
+next line to be ignored.
+
+```rust
+let a = "foobar";
+let b = "foo\
+         bar";
+```
+
+`a` is equivalent to `b`.
 
 ##### Character escapes
 


### PR DESCRIPTION
r? @steveklabnik 

Closes #22698

I wasn't sure that this was appropriate for the book, but I've added this to the reference. I also noticed that one of the U+ symbols in the character literals section was missing the graves.
