### PR TITLE
Catch attempts to project nonexistent associated items from a trait.

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -978,7 +978,7 @@ pub trait IteratorExt: Iterator + Sized {
     #[unstable(feature = "core", reason = "recent addition")]
     fn cloned(self) -> Cloned<Self> where
         Self::Item: Deref,
-        <Self::Item as Deref>::Output: Clone,
+        <Self::Item as Deref>::Target: Clone,
     {
         Cloned { it: self }
     }

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -173,7 +173,8 @@ register_diagnostics! {
     E0249, // expected constant expr for array length
     E0250, // expected constant expr for array length
     E0318, // can't create default impls for traits outside their crates
-    E0319  // trait impls for defaulted traits allowed just for structs/enums
+    E0319, // trait impls for defaulted traits allowed just for structs/enums
+    E0320  // Trait does not provide binding for Type in `<T as Trait>::Type`
 }
 
 __build_diagnostic_array! { DIAGNOSTICS }

--- a/src/test/compile-fail/issue-19883.rs
+++ b/src/test/compile-fail/issue-19883.rs
@@ -18,13 +18,11 @@ trait To {
     // This is a typo, the return type should be `<Dst as From<Self>>::Output`
     fn to<Dst: From<Self>>(
         self
-        //~^ error: the trait `core::marker::Sized` is not implemented
     ) ->
         <Dst as From<Self>>::Dst
-        //~^ error: the trait `core::marker::Sized` is not implemented
+        //~^ error: cannot find binding for item `Dst` within trait `From<Self>`
     {
         From::from(
-            //~^ error: the trait `core::marker::Sized` is not implemented
             self
         )
     }


### PR DESCRIPTION
Catch attempts to project nonexistent associated items from a trait.

(Also, fix an instance of this mistake this fix uncovered in `iter.rs`)

Fix #22731.
