### PR TITLE
Deprecate std::sync::TaskPool

### DIFF
--- a/src/libstd/sync/task_pool.rs
+++ b/src/libstd/sync/task_pool.rs
@@ -12,8 +12,8 @@
 
 #![deprecated(since = "1.0.0",
               reason = "This kind of API needs some time to bake in \
-                        crates.io. Consider trying \
-                        https://github.com/carllerche/syncbox")]
+                        crates.io. This functionality is available through \
+                        https://crates.io/crates/threadpool")]
 #![unstable(feature = "std_misc")]
 
 use core::prelude::*;

--- a/src/libstd/sync/task_pool.rs
+++ b/src/libstd/sync/task_pool.rs
@@ -10,11 +10,11 @@
 
 //! Abstraction of a thread pool for basic parallelism.
 
-#![unstable(feature = "std_misc",
-            reason = "the semantics of a failing task and whether a thread is \
-                      re-attached to a thread pool are somewhat unclear, and the \
-                      utility of this type in `std::sync` is questionable with \
-                      respect to the jobs of other primitives")]
+#![deprecated(since = "1.0.0",
+              reason = "This kind of API needs some time to bake in \
+                        crates.io. Consider trying \
+                        https://github.com/carllerche/syncbox")]
+#![unstable(feature = "std_misc")]
 
 use core::prelude::*;
 


### PR DESCRIPTION
Rather than stabilize on the current API, we're going to punt this
concern to crates.io, to allow for faster iteration.

[breaking-change]
