### PR TITLE
Fix "How to submit a bug report" link

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -68,7 +68,7 @@ There are questions that are asked quite often, and so we've made FAQs for them:
 * [Language Design FAQ](complement-design-faq.html)
 * [Language FAQ](complement-lang-faq.html)
 * [Project FAQ](complement-project-faq.html)
-* [How to submit a bug report](complement-bugreport.html)
+* [How to submit a bug report](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports)
 
 # The standard library
 


### PR DESCRIPTION
According to #22650 and bb0bbf639eafdd79380a3b1e2e92263a2aa914f9 the
link changed.
I think this should fix the link on http://doc.rust-lang.org/#faqs
