### PR TITLE
unbreak openbsd after nacl intergration

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -1362,7 +1362,6 @@ pub mod types {
                 use types::os::arch::c95::{c_long};
                 pub type off_t = i64;
                 pub type dev_t = i32;
-                pub type ino_t = u64;
                 pub type pid_t = i32;
                 pub type uid_t = u32;
                 pub type gid_t = u32;


### PR DESCRIPTION
The recent commit on liblibc for nacl break the compilation for OpenBSD (and Bitrig too, I think).

The problem is `ino_t` come from another block too now. This patch remove the extra declaration.

```
.../src/liblibc/lib.rs:98:9: 98:37 error: a type named `ino_t` has already been imported in this module [E0251]
.../src/liblibc/lib.rs:98 pub use types::os::arch::posix01::*;
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to previous error
```

@dhuseby do you have this problem too ? and if yes, does this patch correct it ?
