### PR TITLE
std: Implement stdio for `std::io`

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -201,10 +201,11 @@ impl<T> Arc<T> {
 impl<T> Arc<T> {
     #[inline]
     fn inner(&self) -> &ArcInner<T> {
-        // This unsafety is ok because while this arc is alive we're guaranteed that the inner
-        // pointer is valid. Furthermore, we know that the `ArcInner` structure itself is `Sync`
-        // because the inner data is `Sync` as well, so we're ok loaning out an immutable pointer
-        // to these contents.
+        // This unsafety is ok because while this arc is alive we're guaranteed
+        // that the inner pointer is valid. Furthermore, we know that the
+        // `ArcInner` structure itself is `Sync` because the inner data is
+        // `Sync` as well, so we're ok loaning out an immutable pointer to these
+        // contents.
         unsafe { &**self._ptr }
     }
 }
@@ -236,13 +237,15 @@ impl<T> Clone for Arc<T> {
     /// ```
     #[inline]
     fn clone(&self) -> Arc<T> {
-        // Using a relaxed ordering is alright here, as knowledge of the original reference
-        // prevents other threads from erroneously deleting the object.
+        // Using a relaxed ordering is alright here, as knowledge of the
+        // original reference prevents other threads from erroneously deleting
+        // the object.
         //
-        // As explained in the [Boost documentation][1], Increasing the reference counter can
-        // always be done with memory_order_relaxed: New references to an object can only be formed
-        // from an existing reference, and passing an existing reference from one thread to another
-        // must already provide any required synchronization.
+        // As explained in the [Boost documentation][1], Increasing the
+        // reference counter can always be done with memory_order_relaxed: New
+        // references to an object can only be formed from an existing
+        // reference, and passing an existing reference from one thread to
+        // another must already provide any required synchronization.
         //
         // [1]: (www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html)
         self.inner().strong.fetch_add(1, Relaxed);

--- a/src/libstd/io/lazy.rs
+++ b/src/libstd/io/lazy.rs
@@ -1,0 +1,59 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use prelude::v1::*;
+
+use boxed;
+use cell::UnsafeCell;
+use rt;
+use sync::{StaticMutex, Arc};
+
+pub struct Lazy<T> {
+    pub lock: StaticMutex,
+    pub ptr: UnsafeCell<*mut Arc<T>>,
+    pub init: fn() -> Arc<T>,
+}
+
+unsafe impl<T> Sync for Lazy<T> {}
+
+macro_rules! lazy_init {
+    ($init:expr) => (::io::lazy::Lazy {
+        lock: ::sync::MUTEX_INIT,
+        ptr: ::cell::UnsafeCell { value: 0 as *mut _ },
+        init: $init,
+    })
+}
+
+impl<T: Send + Sync + 'static> Lazy<T> {
+    pub fn get(&'static self) -> Option<Arc<T>> {
+        let _g = self.lock.lock();
+        unsafe {
+            let mut ptr = *self.ptr.get();
+            if ptr.is_null() {
+                ptr = boxed::into_raw(self.init());
+                *self.ptr.get() = ptr;
+            } else if ptr as usize == 1 {
+                return None
+            }
+            Some((*ptr).clone())
+        }
+    }
+
+    fn init(&'static self) -> Box<Arc<T>> {
+        rt::at_exit(move || unsafe {
+            let g = self.lock.lock();
+            let ptr = *self.ptr.get();
+            *self.ptr.get() = 1 as *mut _;
+            drop(g);
+            drop(Box::from_raw(ptr))
+        });
+        Box::new((self.init)())
+    }
+}

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -39,6 +39,10 @@ pub use self::buffered::IntoInnerError;
 pub use self::cursor::Cursor;
 pub use self::error::{Result, Error, ErrorKind};
 pub use self::util::{copy, sink, Sink, empty, Empty, repeat, Repeat};
+pub use self::stdio::{stdin, stdout, stderr, Stdin, Stdout, Stderr};
+pub use self::stdio::{StdoutLock, StderrLock, StdinLock};
+
+#[macro_use] mod lazy;
 
 pub mod prelude;
 mod buffered;
@@ -46,6 +50,7 @@ mod cursor;
 mod error;
 mod impls;
 mod util;
+mod stdio;
 
 const DEFAULT_BUF_SIZE: usize = 64 * 1024;
 

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -1,0 +1,325 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use prelude::v1::*;
+use io::prelude::*;
+
+use cmp;
+use fmt;
+use io::lazy::Lazy;
+use io::{self, BufReader, LineWriter};
+use sync::{Arc, Mutex, MutexGuard};
+use sys::stdio;
+
+/// A handle to a raw instance of the standard input stream of this process.
+///
+/// This handle is not synchronized or buffered in any fashion. Constructed via
+/// the `std::io::stdin_raw` function.
+pub struct StdinRaw(stdio::Stdin);
+
+/// A handle to a raw instance of the standard output stream of this process.
+///
+/// This handle is not synchronized or buffered in any fashion. Constructed via
+/// the `std::io::stdout_raw` function.
+pub struct StdoutRaw(stdio::Stdout);
+
+/// A handle to a raw instance of the standard output stream of this process.
+///
+/// This handle is not synchronized or buffered in any fashion. Constructed via
+/// the `std::io::stderr_raw` function.
+pub struct StderrRaw(stdio::Stderr);
+
+/// Construct a new raw handle to the standard input of this process.
+///
+/// The returned handle does not interact with any other handles created nor
+/// handles returned by `std::io::stdin`. Data buffered by the `std::io::stdin`
+/// handles is **not** available to raw handles returned from this function.
+///
+/// The returned handle has no external synchronization or buffering.
+pub fn stdin_raw() -> StdinRaw { StdinRaw(stdio::Stdin::new()) }
+
+/// Construct a new raw handle to the standard input stream of this process.
+///
+/// The returned handle does not interact with any other handles created nor
+/// handles returned by `std::io::stdout`. Note that data is buffered by the
+/// `std::io::stdin` handles so writes which happen via this raw handle may
+/// appear before previous writes.
+///
+/// The returned handle has no external synchronization or buffering layered on
+/// top.
+pub fn stdout_raw() -> StdoutRaw { StdoutRaw(stdio::Stdout::new()) }
+
+/// Construct a new raw handle to the standard input stream of this process.
+///
+/// The returned handle does not interact with any other handles created nor
+/// handles returned by `std::io::stdout`.
+///
+/// The returned handle has no external synchronization or buffering layered on
+/// top.
+pub fn stderr_raw() -> StderrRaw { StderrRaw(stdio::Stderr::new()) }
+
+impl Read for StdinRaw {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.0.read(buf) }
+}
+impl Write for StdoutRaw {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> { self.0.write(buf) }
+    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+}
+impl Write for StderrRaw {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> { self.0.write(buf) }
+    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+}
+
+/// A handle to the standard input stream of a process.
+///
+/// Each handle is a shared reference to a global buffer of input data to this
+/// process. A handle can be `lock`'d to gain full access to `BufRead` methods
+/// (e.g. `.lines()`). Writes to this handle are otherwise locked with respect
+/// to other writes.
+///
+/// This handle implements the `Read` trait, but beware that concurrent reads
+/// of `Stdin` must be executed with care.
+pub struct Stdin {
+    inner: Arc<Mutex<BufReader<StdinRaw>>>,
+}
+
+/// A locked reference to the a `Stdin` handle.
+///
+/// This handle implements both the `Read` and `BufRead` traits and is
+/// constructed via the `lock` method on `Stdin`.
+pub struct StdinLock<'a> {
+    inner: MutexGuard<'a, BufReader<StdinRaw>>,
+}
+
+/// Create a new handle to the global standard input stream of this process.
+///
+/// The handle returned refers to a globally shared buffer between all threads.
+/// Access is synchronized and can be explicitly controlled with the `lock()`
+/// method.
+///
+/// The `Read` trait is implemented for the returned value but the `BufRead`
+/// trait is not due to the global nature of the standard input stream. The
+/// locked version, `StdinLock`, implements both `Read` and `BufRead`, however.
+///
+/// To avoid locking and buffering altogether, it is recommended to use the
+/// `stdin_raw` constructor.
+pub fn stdin() -> Stdin {
+    static INSTANCE: Lazy<Mutex<BufReader<StdinRaw>>> = lazy_init!(stdin_init);
+    return Stdin {
+        inner: INSTANCE.get().expect("cannot access stdin during shutdown"),
+    };
+
+    fn stdin_init() -> Arc<Mutex<BufReader<StdinRaw>>> {
+        // The default buffer capacity is 64k, but apparently windows
+        // doesn't like 64k reads on stdin. See #13304 for details, but the
+        // idea is that on windows we use a slightly smaller buffer that's
+        // been seen to be acceptable.
+        Arc::new(Mutex::new(if cfg!(windows) {
+            BufReader::with_capacity(8 * 1024, stdin_raw())
+        } else {
+            BufReader::new(stdin_raw())
+        }))
+    }
+}
+
+impl Stdin {
+    /// Lock this handle to the standard input stream, returning a readable
+    /// guard.
+    ///
+    /// The lock is released when the returned lock goes out of scope. The
+    /// returned guard also implements the `Read` and `BufRead` traits for
+    /// accessing the underlying data.
+    pub fn lock(&self) -> StdinLock {
+        StdinLock { inner: self.inner.lock().unwrap() }
+    }
+}
+
+impl Read for Stdin {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.lock().read(buf)
+    }
+
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<()> {
+        self.lock().read_to_end(buf)
+    }
+
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<()> {
+        self.lock().read_to_string(buf)
+    }
+}
+
+impl<'a> Read for StdinLock<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // Flush stdout so that weird issues like a print!'d prompt not being
+        // shown until after the user hits enter.
+        drop(stdout().flush());
+        self.inner.read(buf)
+    }
+}
+impl<'a> BufRead for StdinLock<'a> {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> { self.inner.fill_buf() }
+    fn consume(&mut self, n: usize) { self.inner.consume(n) }
+}
+
+// As with stdin on windows, stdout often can't handle writes of large
+// sizes. For an example, see #14940. For this reason, don't try to
+// write the entire output buffer on windows. On unix we can just
+// write the whole buffer all at once.
+//
+// For some other references, it appears that this problem has been
+// encountered by others [1] [2]. We choose the number 8KB just because
+// libuv does the same.
+//
+// [1]: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/1232
+// [2]: http://www.mail-archive.com/log4net-dev@logging.apache.org/msg00661.html
+#[cfg(windows)]
+const OUT_MAX: usize = 8192;
+#[cfg(unix)]
+const OUT_MAX: usize = ::usize::MAX;
+
+/// A handle to the global standard output stream of the current process.
+///
+/// Each handle shares a global buffer of data to be written to the standard
+/// output stream. Access is also synchronized via a lock and explicit control
+/// over locking is available via the `lock` method.
+pub struct Stdout {
+    // FIXME: this should be LineWriter or BufWriter depending on the state of
+    //        stdout (tty or not). Note that if this is not line buffered it
+    //        should also flush-on-panic or some form of flush-on-abort.
+    inner: Arc<Mutex<LineWriter<StdoutRaw>>>,
+}
+
+/// A locked reference to the a `Stdout` handle.
+///
+/// This handle implements the `Write` trait and is constructed via the `lock`
+/// method on `Stdout`.
+pub struct StdoutLock<'a> {
+    inner: MutexGuard<'a, LineWriter<StdoutRaw>>,
+}
+
+/// Constructs a new reference to the standard output of the current process.
+///
+/// Each handle returned is a reference to a shared global buffer whose access
+/// is synchronized via a mutex. Explicit control over synchronization is
+/// provided via the `lock` method.
+///
+/// The returned handle implements the `Write` trait.
+///
+/// To avoid locking and buffering altogether, it is recommended to use the
+/// `stdout_raw` constructor.
+pub fn stdout() -> Stdout {
+    static INSTANCE: Lazy<Mutex<LineWriter<StdoutRaw>>> = lazy_init!(stdout_init);
+    return Stdout {
+        inner: INSTANCE.get().expect("cannot access stdout during shutdown"),
+    };
+
+    fn stdout_init() -> Arc<Mutex<LineWriter<StdoutRaw>>> {
+        Arc::new(Mutex::new(LineWriter::new(stdout_raw())))
+    }
+}
+
+impl Stdout {
+    /// Lock this handle to the standard output stream, returning a writable
+    /// guard.
+    ///
+    /// The lock is released when the returned lock goes out of scope. The
+    /// returned guard also implements the `Write` trait for writing data.
+    pub fn lock(&self) -> StdoutLock {
+        StdoutLock { inner: self.inner.lock().unwrap() }
+    }
+}
+
+impl Write for Stdout {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.lock().write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.lock().flush()
+    }
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.lock().write_all(buf)
+    }
+    fn write_fmt(&mut self, fmt: fmt::Arguments) -> io::Result<()> {
+        self.lock().write_fmt(fmt)
+    }
+}
+impl<'a> Write for StdoutLock<'a> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(&buf[..cmp::min(buf.len(), OUT_MAX)])
+    }
+    fn flush(&mut self) -> io::Result<()> { self.inner.flush() }
+}
+
+/// A handle to the standard error stream of a process.
+///
+/// For more information, see `stderr`
+pub struct Stderr {
+    inner: Arc<Mutex<StderrRaw>>,
+}
+
+/// A locked reference to the a `Stderr` handle.
+///
+/// This handle implements the `Write` trait and is constructed via the `lock`
+/// method on `Stderr`.
+pub struct StderrLock<'a> {
+    inner: MutexGuard<'a, StderrRaw>,
+}
+
+/// Constructs a new reference to the standard error stream of a process.
+///
+/// Each returned handle is synchronized amongst all other handles created from
+/// this function. No handles are buffered, however.
+///
+/// The returned handle implements the `Write` trait.
+///
+/// To avoid locking altogether, it is recommended to use the `stderr_raw`
+/// constructor.
+pub fn stderr() -> Stderr {
+    static INSTANCE: Lazy<Mutex<StderrRaw>> = lazy_init!(stderr_init);
+    return Stderr {
+        inner: INSTANCE.get().expect("cannot access stderr during shutdown"),
+    };
+
+    fn stderr_init() -> Arc<Mutex<StderrRaw>> {
+        Arc::new(Mutex::new(stderr_raw()))
+    }
+}
+
+impl Stderr {
+    /// Lock this handle to the standard error stream, returning a writable
+    /// guard.
+    ///
+    /// The lock is released when the returned lock goes out of scope. The
+    /// returned guard also implements the `Write` trait for writing data.
+    pub fn lock(&self) -> StderrLock {
+        StderrLock { inner: self.inner.lock().unwrap() }
+    }
+}
+
+impl Write for Stderr {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.lock().write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.lock().flush()
+    }
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.lock().write_all(buf)
+    }
+    fn write_fmt(&mut self, fmt: fmt::Arguments) -> io::Result<()> {
+        self.lock().write_fmt(fmt)
+    }
+}
+impl<'a> Write for StderrLock<'a> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(&buf[..cmp::min(buf.len(), OUT_MAX)])
+    }
+    fn flush(&mut self) -> io::Result<()> { self.inner.flush() }
+}

--- a/src/libstd/old_io/stdio.rs
+++ b/src/libstd/old_io/stdio.rs
@@ -224,10 +224,10 @@ pub fn stdin() -> StdinReader {
 
     unsafe {
         ONCE.call_once(|| {
-            // The default buffer capacity is 64k, but apparently windows doesn't like
-            // 64k reads on stdin. See #13304 for details, but the idea is that on
-            // windows we use a slightly smaller buffer that's been seen to be
-            // acceptable.
+            // The default buffer capacity is 64k, but apparently windows
+            // doesn't like 64k reads on stdin. See #13304 for details, but the
+            // idea is that on windows we use a slightly smaller buffer that's
+            // been seen to be acceptable.
             let stdin = if cfg!(windows) {
                 BufferedReader::with_capacity(8 * 1024, stdin_raw())
             } else {

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -63,6 +63,7 @@ pub mod time;
 pub mod timer;
 pub mod tty;
 pub mod udp;
+pub mod stdio;
 
 pub mod addrinfo {
     pub use sys_common::net::get_host_addresses;

--- a/src/libstd/sys/unix/stdio.rs
+++ b/src/libstd/sys/unix/stdio.rs
@@ -1,0 +1,52 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use prelude::v1::*;
+
+use io;
+use libc;
+use sys::fd::FileDesc;
+
+pub struct Stdin(());
+pub struct Stdout(());
+pub struct Stderr(());
+
+impl Stdin {
+    pub fn new() -> Stdin { Stdin(()) }
+
+    pub fn read(&self, data: &mut [u8]) -> io::Result<usize> {
+        let fd = FileDesc::new(libc::STDIN_FILENO);
+        let ret = fd.read(data);
+        fd.into_raw();
+        return ret;
+    }
+}
+
+impl Stdout {
+    pub fn new() -> Stdout { Stdout(()) }
+
+    pub fn write(&self, data: &[u8]) -> io::Result<usize> {
+        let fd = FileDesc::new(libc::STDOUT_FILENO);
+        let ret = fd.write(data);
+        fd.into_raw();
+        return ret;
+    }
+}
+
+impl Stderr {
+    pub fn new() -> Stderr { Stderr(()) }
+
+    pub fn write(&self, data: &[u8]) -> io::Result<usize> {
+        let fd = FileDesc::new(libc::STDERR_FILENO);
+        let ret = fd.write(data);
+        fd.into_raw();
+        return ret;
+    }
+}

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -48,6 +48,11 @@ pub const WSAESHUTDOWN: libc::c_int = 10058;
 pub const ERROR_NO_MORE_FILES: libc::DWORD = 18;
 pub const TOKEN_READ: libc::DWORD = 0x20008;
 
+// Note that these are not actually HANDLEs, just values to pass to GetStdHandle
+pub const STD_INPUT_HANDLE: libc::DWORD = -10;
+pub const STD_OUTPUT_HANDLE: libc::DWORD = -11;
+pub const STD_ERROR_HANDLE: libc::DWORD = -12;
+
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 pub struct WSADATA {
@@ -427,6 +432,7 @@ extern "system" {
                             DesiredAccess: libc::DWORD,
                             TokenHandle: *mut libc::HANDLE) -> libc::BOOL;
     pub fn GetCurrentProcess() -> libc::HANDLE;
+    pub fn GetStdHandle(which: libc::DWORD) -> libc::HANDLE;
 }
 
 #[link(name = "userenv")]

--- a/src/libstd/sys/windows/handle.rs
+++ b/src/libstd/sys/windows/handle.rs
@@ -10,9 +10,10 @@
 
 use prelude::v1::*;
 
-use libc::{self, HANDLE};
-use io;
 use io::ErrorKind;
+use io;
+use libc::{self, HANDLE};
+use mem;
 use ptr;
 use sys::cvt;
 
@@ -27,6 +28,12 @@ impl Handle {
     }
 
     pub fn raw(&self) -> HANDLE { self.0 }
+
+    pub fn into_raw(self) -> HANDLE {
+        let ret = self.0;
+        unsafe { mem::forget(self) }
+        return ret;
+    }
 
     pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
         read(self.0, buf)

--- a/src/libstd/sys/windows/mod.rs
+++ b/src/libstd/sys/windows/mod.rs
@@ -61,6 +61,7 @@ pub mod time;
 pub mod timer;
 pub mod tty;
 pub mod udp;
+pub mod stdio;
 
 pub mod addrinfo {
     pub use sys_common::net::get_host_addresses;

--- a/src/libstd/sys/windows/stdio.rs
+++ b/src/libstd/sys/windows/stdio.rs
@@ -1,0 +1,155 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use prelude::v1::*;
+use io::prelude::*;
+
+use io::{self, Cursor};
+use iter::repeat;
+use libc;
+use ptr;
+use str;
+use sync::Mutex;
+use sys::c;
+use sys::cvt;
+use sys::handle::Handle;
+
+struct NoClose(Option<Handle>);
+
+enum Output {
+    Console(NoClose),
+    Pipe(NoClose),
+}
+
+pub struct Stdin {
+    handle: Output,
+    utf8: Mutex<io::Cursor<Vec<u8>>>,
+}
+pub struct Stdout(Output);
+pub struct Stderr(Output);
+
+fn get(handle: libc::DWORD) -> io::Result<Output> {
+    let handle = unsafe { c::GetStdHandle(handle) };
+    if handle == libc::INVALID_HANDLE_VALUE {
+        Err(io::Error::last_os_error())
+    } else if handle.is_null() {
+        Err(io::Error::new(io::ErrorKind::Other,
+                           "no stdio handle available for this process", None))
+    } else {
+        let ret = NoClose::new(handle);
+        let mut out = 0;
+        match unsafe { c::GetConsoleMode(handle, &mut out) } {
+            0 => Ok(Output::Pipe(ret)),
+            _ => Ok(Output::Console(ret)),
+        }
+    }
+}
+
+fn write(out: &Output, data: &[u8]) -> io::Result<usize> {
+    let handle = match *out {
+        Output::Console(ref c) => c.get().raw(),
+        Output::Pipe(ref p) => return p.get().write(data),
+    };
+    let utf16 = match str::from_utf8(data).ok() {
+        Some(utf8) => utf8.utf16_units().collect::<Vec<u16>>(),
+        None => return Err(invalid_encoding()),
+    };
+    let mut written = 0;
+    try!(cvt(unsafe {
+        c::WriteConsoleW(handle,
+                         utf16.as_ptr() as libc::LPCVOID,
+                         utf16.len() as u32,
+                         &mut written,
+                         ptr::null_mut())
+    }));
+
+    // FIXME if this only partially writes the utf16 buffer then we need to
+    //       figure out how many bytes of `data` were actually written
+    assert_eq!(written as usize, utf16.len());
+    Ok(data.len())
+}
+
+impl Stdin {
+    pub fn new() -> Stdin {
+        Stdin {
+            handle: get(c::STD_INPUT_HANDLE).unwrap(),
+            utf8: Mutex::new(Cursor::new(Vec::new())),
+        }
+    }
+
+    pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+        let handle = match self.handle {
+            Output::Console(ref c) => c.get().raw(),
+            Output::Pipe(ref p) => return p.get().read(buf),
+        };
+        let mut utf8 = self.utf8.lock().unwrap();
+        // Read more if the buffer is empty
+        if utf8.position() as usize == utf8.get_ref().len() {
+            let mut utf16: Vec<u16> = repeat(0u16).take(0x1000).collect();
+            let mut num = 0;
+            try!(cvt(unsafe {
+                c::ReadConsoleW(handle,
+                                utf16.as_mut_ptr() as libc::LPVOID,
+                                utf16.len() as u32,
+                                &mut num,
+                                ptr::null_mut())
+            }));
+            utf16.truncate(num as usize);
+            // FIXME: what to do about this data that has already been read?
+            let data = match String::from_utf16(&utf16) {
+                Ok(utf8) => utf8.into_bytes(),
+                Err(..) => return Err(invalid_encoding()),
+            };
+            *utf8 = Cursor::new(data);
+        }
+
+        // MemReader shouldn't error here since we just filled it
+        utf8.read(buf)
+    }
+}
+
+impl Stdout {
+    pub fn new() -> Stdout {
+        Stdout(get(c::STD_OUTPUT_HANDLE).unwrap())
+    }
+
+    pub fn write(&self, data: &[u8]) -> io::Result<usize> {
+        write(&self.0, data)
+    }
+}
+
+impl Stderr {
+    pub fn new() -> Stderr {
+        Stderr(get(c::STD_ERROR_HANDLE).unwrap())
+    }
+
+    pub fn write(&self, data: &[u8]) -> io::Result<usize> {
+        write(&self.0, data)
+    }
+}
+
+impl NoClose {
+    fn new(handle: libc::HANDLE) -> NoClose {
+        NoClose(Some(Handle::new(handle)))
+    }
+
+    fn get(&self) -> &Handle { self.0.as_ref().unwrap() }
+}
+
+impl Drop for NoClose {
+    fn drop(&mut self) {
+        self.0.take().unwrap().into_raw();
+    }
+}
+
+fn invalid_encoding() -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, "text was not valid unicode",
+                   None)
+}

--- a/src/test/run-pass-valgrind/cleanup-stdin.rs
+++ b/src/test/run-pass-valgrind/cleanup-stdin.rs
@@ -10,4 +10,5 @@
 
 fn main() {
     let _ = std::old_io::stdin();
+    let _ = std::io::stdin();
 }

--- a/src/test/run-pass/issue-14456.rs
+++ b/src/test/run-pass/issue-14456.rs
@@ -8,11 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-use std::old_io::process;
-use std::old_io::Command;
-use std::old_io;
 use std::env;
+use std::io::prelude::*;
+use std::io;
+use std::process::{Command, Stdio};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -21,22 +20,23 @@ fn main() {
     }
 
     test();
-
 }
 
 fn child() {
-    old_io::stdout().write_line("foo").unwrap();
-    old_io::stderr().write_line("bar").unwrap();
-    let mut stdin = old_io::stdin();
-    assert_eq!(stdin.lock().read_line().err().unwrap().kind, old_io::EndOfFile);
+    writeln!(&mut io::stdout(), "foo").unwrap();
+    writeln!(&mut io::stderr(), "bar").unwrap();
+    let mut stdin = io::stdin();
+    let mut s = String::new();
+    stdin.lock().read_line(&mut s).unwrap();
+    assert_eq!(s.len(), 0);
 }
 
 fn test() {
     let args: Vec<String> = env::args().collect();
     let mut p = Command::new(&args[0]).arg("child")
-                                     .stdin(process::Ignored)
-                                     .stdout(process::Ignored)
-                                     .stderr(process::Ignored)
+                                     .stdin(Stdio::capture())
+                                     .stdout(Stdio::capture())
+                                     .stderr(Stdio::capture())
                                      .spawn().unwrap();
     assert!(p.wait().unwrap().success());
 }

--- a/src/test/run-pass/issue-16671.rs
+++ b/src/test/run-pass/issue-16671.rs
@@ -17,11 +17,13 @@
 // A var moved into a proc, that has a mutable loan path should
 // not trigger a misleading unused_mut warning.
 
+use std::io::prelude::*;
 use std::thread;
 
 pub fn main() {
-    let mut stdin = std::old_io::stdin();
+    let mut stdin = std::io::stdin();
     thread::spawn(move|| {
-        let _ = stdin.read_to_end();
-    });
+        let mut v = Vec::new();
+        let _ = stdin.read_to_end(&mut v);
+    }).join().ok().unwrap();
 }

--- a/src/test/run-pass/issue-17322.rs
+++ b/src/test/run-pass/issue-17322.rs
@@ -11,13 +11,13 @@
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 
-use std::old_io;
+use std::io::{self, Write};
 
-fn f(wr: &mut Writer) {
-    wr.write_str("hello").ok().expect("failed");
+fn f(wr: &mut Write) {
+    wr.write_all(b"hello").ok().expect("failed");
 }
 
 fn main() {
-    let mut wr = box old_io::stdout() as Box<Writer + 'static>;
+    let mut wr = box io::stdout() as Box<Write>;
     f(&mut wr);
 }

--- a/src/test/run-pass/issue-4333.rs
+++ b/src/test/run-pass/issue-4333.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::old_io;
+use std::io;
 
 pub fn main() {
-    let stdout = &mut old_io::stdout() as &mut old_io::Writer;
+    let stdout = &mut io::stdout() as &mut io::Write;
     stdout.write(b"Hello!");
 }


### PR DESCRIPTION
This is an implementation of RFC 899 and adds stdio functionality to the new
`std::io` module. Details of the API can be found on the RFC, but from a high
level:
- `io::{stdin, stdout, stderr}` constructors are now available. There are also
  `*_raw` variants for unbuffered and unlocked access.
- All handles are globally shared (excluding raw variants).
- The stderr handle is no longer buffered.
- All handles can be explicitly locked (excluding the raw variants).

The `print!` and `println!` machinery has not yet been hooked up to these
streams just yet. The `std::fmt::output` module has also not yet been
implemented as part of this commit.
