### PR TITLE
[RFC] Try to ensure we don’t emit duplicate symbols

### DIFF
--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -925,6 +925,7 @@ extern {
     pub fn LLVMSetThreadLocal(GlobalVar: ValueRef, IsThreadLocal: Bool);
     pub fn LLVMIsGlobalConstant(GlobalVar: ValueRef) -> Bool;
     pub fn LLVMSetGlobalConstant(GlobalVar: ValueRef, IsConstant: Bool);
+    pub fn LLVMGetNamedValue(M: ModuleRef, Name: *const c_char) -> ValueRef;
 
     /* Operations on aliases */
     pub fn LLVMAddAlias(M: ModuleRef,
@@ -944,9 +945,6 @@ extern {
     pub fn LLVMGetNextFunction(Fn: ValueRef) -> ValueRef;
     pub fn LLVMGetPreviousFunction(Fn: ValueRef) -> ValueRef;
     pub fn LLVMDeleteFunction(Fn: ValueRef);
-    pub fn LLVMGetNamedValue(M: ModuleRef,
-                             Name: *const c_char)
-                             -> ValueRef;
     pub fn LLVMGetOrInsertFunction(M: ModuleRef,
                                    Name: *const c_char,
                                    FunctionTy: TypeRef)

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -944,6 +944,9 @@ extern {
     pub fn LLVMGetNextFunction(Fn: ValueRef) -> ValueRef;
     pub fn LLVMGetPreviousFunction(Fn: ValueRef) -> ValueRef;
     pub fn LLVMDeleteFunction(Fn: ValueRef);
+    pub fn LLVMGetNamedValue(M: ModuleRef,
+                             Name: *const c_char)
+                             -> ValueRef;
     pub fn LLVMGetOrInsertFunction(M: ModuleRef,
                                    Name: *const c_char,
                                    FunctionTy: TypeRef)

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2940,8 +2940,7 @@ fn register_method(ccx: &CrateContext, id: ast::NodeId,
 
     let sym = exported_name(ccx, id, mty, &m.attrs);
     if ccx.symbol_value(sym.to_string()).is_some() {
-        ccx.sess().span_fatal(i.span, &format!("symbol {} is already declared",
-                                               sym));
+        ccx.sess().span_fatal(m.span, &format!("symbol {} is already declared", sym));
     }
 
 

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2710,7 +2710,7 @@ fn exported_name<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, id: ast::NodeId,
         None => {}
     }
 
-    match attr::first_attr_value_str_by_name(attrs, "export_name") {
+    match attr::find_export_name_attr(ccx.sess().diagnostic(), attrs) {
         // Use provided name
         Some(name) => name.to_string(),
 

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -185,6 +185,7 @@ impl<'a, 'tcx> Drop for StatRecorder<'a, 'tcx> {
 // only use this for foreign function ABIs and glue, use `decl_rust_fn` for Rust functions
 pub fn decl_fn(ccx: &CrateContext, name: &str, cc: llvm::CallConv,
                ty: Type, output: ty::FnOutput) -> ValueRef {
+    ccx.assert_unique_symbol(name.to_string());
 
     let buf = CString::new(name).unwrap();
     let llfn: ValueRef = unsafe {
@@ -481,16 +482,6 @@ pub fn unset_split_stack(f: ValueRef) {
                                            "split-stack\0".as_ptr() as *const _);
     }
 }
-
-// Double-check that we never ask LLVM to declare the same symbol twice. It
-// silently mangles such symbols, breaking our linkage model.
-pub fn note_unique_llvm_symbol(ccx: &CrateContext, sym: String) {
-    if ccx.all_llvm_symbols().borrow().contains(&sym) {
-        ccx.sess().bug(&format!("duplicate LLVM symbol: {}", sym));
-    }
-    ccx.all_llvm_symbols().borrow_mut().insert(sym);
-}
-
 
 pub fn get_res_dtor<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                               did: ast::DefId,
@@ -1751,9 +1742,9 @@ pub fn build_return_block<'blk, 'tcx>(fcx: &FunctionContext<'blk, 'tcx>,
     }
 }
 
-// trans_closure: Builds an LLVM function out of a source function.
-// If the function closes over its environment a closure will be
-// returned.
+/// Builds an LLVM function out of a source function.
+///
+/// If the function closes over its environment a closure will be returned.
 pub fn trans_closure<'a, 'b, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                                    decl: &ast::FnDecl,
                                    body: &ast::Block,
@@ -1901,8 +1892,7 @@ pub fn trans_closure<'a, 'b, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     finish_fn(&fcx, bcx, output_type, ret_debug_loc);
 }
 
-// trans_fn: creates an LLVM function corresponding to a source language
-// function.
+/// Creates an LLVM function corresponding to a source language function.
 pub fn trans_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                           decl: &ast::FnDecl,
                           body: &ast::Block,
@@ -2713,7 +2703,6 @@ fn exported_name<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, id: ast::NodeId,
     match attr::find_export_name_attr(ccx.sess().diagnostic(), attrs) {
         // Use provided name
         Some(name) => name.to_string(),
-
         _ => ccx.tcx().map.with_path(id, |path| {
             if attr::contains_name(attrs, "no_mangle") {
                 // Don't mangle
@@ -2752,15 +2741,14 @@ pub fn get_item_val(ccx: &CrateContext, id: ast::NodeId) -> ValueRef {
 
             let v = match i.node {
                 ast::ItemStatic(_, _, ref expr) => {
-                    // If this static came from an external crate, then
-                    // we need to get the symbol from csearch instead of
-                    // using the current crate's name/version
-                    // information in the hash of the symbol
+                    // If this static came from an external crate, then we need to get the symbol
+                    // from csearch instead of using the current crate's name/version information
+                    // in the hash of the symbol
                     let sym = sym();
                     debug!("making {}", sym);
 
-                    // We need the translated value here, because for enums the
-                    // LLVM type is not fully determined by the Rust type.
+                    // We need the translated value here, because for enums the LLVM type is not
+                    // fully determined by the Rust type.
                     let empty_substs = ccx.tcx().mk_substs(Substs::trans_empty());
                     let (v, ty) = consts::const_expr(ccx, &**expr, empty_substs);
                     ccx.static_values().borrow_mut().insert(id, v);

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -111,6 +111,7 @@ pub fn register_static(ccx: &CrateContext,
     let llty = type_of::type_of(ccx, ty);
 
     let ident = link_name(foreign_item);
+    ccx.assert_unique_symbol(ident.to_string());
     match attr::first_attr_value_str_by_name(&foreign_item.attrs,
                                              "linkage") {
         // If this is a static with a linkage specified, then we need to handle
@@ -624,7 +625,7 @@ pub fn trans_rust_fn_with_foreign_abi<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                                       t: Ty<'tcx>) {
         if llvm::LLVMCountBasicBlocks(llwrapfn) != 0 {
             ccx.sess().bug("wrapping a function inside non-empty wrapper, most likely cause is \
-                           multiple functions are being wrapped");
+                           multiple functions being wrapped");
         }
 
         let _icx = push_ctxt(

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -622,6 +622,11 @@ pub fn trans_rust_fn_with_foreign_abi<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                                       llwrapfn: ValueRef,
                                       tys: &ForeignTypes<'tcx>,
                                       t: Ty<'tcx>) {
+        if llvm::LLVMCountBasicBlocks(llwrapfn) != 0 {
+            ccx.sess().bug("wrapping a function inside non-empty wrapper, most likely cause is \
+                           multiple functions are being wrapped");
+        }
+
         let _icx = push_ctxt(
             "foreign::trans_rust_fn_with_foreign_abi::build_wrap_fn");
         let tcx = ccx.tcx();
@@ -641,7 +646,6 @@ pub fn trans_rust_fn_with_foreign_abi<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         //         foo0(&r, NULL, i);
         //         return r;
         //     }
-
         let ptr = "the block\0".as_ptr();
         let the_block = llvm::LLVMAppendBasicBlockInContext(ccx.llcx(), llwrapfn,
                                                             ptr as *const _);

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -518,7 +518,7 @@ pub fn declare_tydesc<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>)
         llvm::LLVMAddGlobal(ccx.llmod(), ccx.tydesc_type().to_ref(),
                             buf.as_ptr())
     };
-    note_unique_llvm_symbol(ccx, name);
+    ccx.assert_unique_symbol(name.to_string());
 
     let ty_name = token::intern_and_get_ident(
         &ppaux::ty_to_string(ccx.tcx(), t));
@@ -542,7 +542,6 @@ fn declare_generic_glue<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>,
         t,
         &format!("glue_{}", name));
     let llfn = decl_cdecl_fn(ccx, &fn_nm[..], llfnty, ty::mk_nil(ccx.tcx()));
-    note_unique_llvm_symbol(ccx, fn_nm.clone());
     return (fn_nm, llfn);
 }
 

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -283,6 +283,23 @@ pub fn find_crate_name(attrs: &[Attribute]) -> Option<InternedString> {
     first_attr_value_str_by_name(attrs, "crate_name")
 }
 
+/// Find the value of #[export_name=*] attribute and check its validity.
+pub fn find_export_name_attr(diag: &SpanHandler, attrs: &[Attribute]) -> Option<InternedString> {
+    attrs.iter().fold(None, |ia,attr| {
+        if attr.check_name("export_name") {
+            if let s@Some(_) = attr.value_str() {
+                s
+            } else {
+                diag.span_err(attr.span, "export_name attribute has invalid format");
+                diag.handler.help("use #[export_name=\"*\"]");
+                None
+            }
+        } else {
+            ia
+        }
+    })
+}
+
 #[derive(Copy, PartialEq)]
 pub enum InlineAttr {
     InlineNone,

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -94,6 +94,11 @@ extern "C" void LLVMRustPrintPassTimings() {
   TimerGroup::printAll(OS);
 }
 
+extern "C" LLVMValueRef LLVMGetNamedValue(LLVMModuleRef M,
+                                          const char* Name) {
+    return wrap(unwrap(M)->getNamedValue(Name));
+}
+
 extern "C" LLVMValueRef LLVMGetOrInsertFunction(LLVMModuleRef M,
                                                 const char* Name,
                                                 LLVMTypeRef FunctionTy) {

--- a/src/test/compile-fail/dupe-symbols-1.rs
+++ b/src/test/compile-fail/dupe-symbols-1.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![crate_type="rlib"]
+#![allow(warnings)]
+
+#[export_name="fail"]
+pub fn a() {
+}
+
+#[export_name="fail"]
+pub fn b() {
+//~^ symbol fail is already declared
+}

--- a/src/test/compile-fail/dupe-symbols-2.rs
+++ b/src/test/compile-fail/dupe-symbols-2.rs
@@ -1,0 +1,24 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![crate_type="rlib"]
+#![allow(warnings)]
+
+mod a {
+    #[no_mangle]
+    pub extern fn fail() {
+    }
+}
+
+mod b {
+    #[no_mangle]
+    pub extern fn fail() {
+    //~^ symbol fail is already declared
+    }
+}

--- a/src/test/compile-fail/dupe-symbols-3.rs
+++ b/src/test/compile-fail/dupe-symbols-3.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![crate_type="rlib"]
+#![allow(warnings)]
+
+#[export_name="fail"]
+pub fn a() {
+}
+
+#[no_mangle]
+pub fn fail() {
+//~^ symbol fail is already declared
+}

--- a/src/test/compile-fail/dupe-symbols-4.rs
+++ b/src/test/compile-fail/dupe-symbols-4.rs
@@ -1,0 +1,30 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![crate_type="rlib"]
+#![allow(warnings)]
+
+
+pub trait A {
+    fn fail(self);
+}
+
+struct B;
+struct C;
+
+impl A for B {
+    #[no_mangle]
+    fn fail(self) {}
+}
+
+impl A for C {
+    #[no_mangle]
+    fn fail(self) {}
+    //~^ symbol fail is already declared
+}

--- a/src/test/compile-fail/dupe-symbols-5.rs
+++ b/src/test/compile-fail/dupe-symbols-5.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![crate_type="rlib"]
+#![allow(warnings)]
+
+#[export_name="fail"]
+static HELLO: u8 = 0;
+
+#[export_name="fail"]
+pub fn b() {
+//~^ symbol fail is already declared
+}

--- a/src/test/compile-fail/dupe-symbols-6.rs
+++ b/src/test/compile-fail/dupe-symbols-6.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![crate_type="rlib"]
+#![allow(warnings)]
+
+#[export_name="fail"]
+static HELLO: u8 = 0;
+
+#[export_name="fail"]
+static HELLO_TWICE: u16 = 0;
+//~^ symbol fail is already declared

--- a/src/test/compile-fail/dupe-symbols-7.rs
+++ b/src/test/compile-fail/dupe-symbols-7.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![crate_type="rlib"]
+#![allow(warnings)]
+
+extern {
+    fn fail();
+}
+
+#[export_name="fail"]
+pub fn a() {
+//~^ symbol fail is already declared
+}

--- a/src/test/run-pass/issue-15562.rs
+++ b/src/test/run-pass/issue-15562.rs
@@ -13,9 +13,6 @@
 extern crate "issue-15562" as i;
 
 pub fn main() {
-    extern {
-        fn transmute();
-    }
     unsafe {
         transmute();
         i::transmute();


### PR DESCRIPTION
Ok, this was a hard one, and the description will also be somewhat long. We provide tools to tell what exact symbols to emit for any `fn` or `static`, but don’t quite check if that won’t cause any issues later on. Some of the issues include LLVM mangling our names again and our names pointing to wrong locations, us generating [dumb foreign call wrappers](https://gist.github.com/nagisa/8185783075626d98e094), linker errors, extern functions resolving to different symbols altogether (`extern {fn fail();} fail();` in some cases calling `fail1()`), etc. 

Before the commit we had a function called `note_unique_llvm_symbol`, so it is clear somebody was aware of the issue at some point, but the function was barely used, mostly in irrelevant locations.

I published this PR mainly as RFC, because I’m not sure about approach taken here, and want to hear people’s involved with trans thoughts in general.

P.S. This is [breaking-change] because it makes dumbly written code (such as issue-15562.rs test) properly invalid.
P.S.S. this in its current form fixes all those issues about #[no_mangle] on trait methods.
P.S.S.S. were this PR received positively, I’d like to clean it up some before merge.
