### PR TITLE
std: Deprecate the std::old_io::net primitives

### DIFF
--- a/src/libstd/old_io/net/mod.rs
+++ b/src/libstd/old_io/net/mod.rs
@@ -10,6 +10,10 @@
 
 //! Networking I/O
 
+#![deprecated(since = "1.0.0",
+              reason = "replaced with new I/O primitives in `std::net`")]
+#![unstable(feature = "old_io")]
+
 use old_io::{IoError, IoResult, InvalidInput};
 use ops::FnMut;
 use option::Option::None;

--- a/src/libstd/old_io/net/pipe.rs
+++ b/src/libstd/old_io/net/pipe.rs
@@ -19,6 +19,12 @@
 //! instances as clients.
 
 #![allow(missing_docs)]
+#![deprecated(since = "1.0.0",
+              reason = "will be removed to be reintroduced at a later date; \
+                        in the meantime consider using the `unix_socket` crate \
+                        for unix sockets; there is currently no replacement \
+                        for named pipes")]
+#![unstable(feature = "old_io")]
 
 use prelude::v1::*;
 

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(deprecated)]
+
 use prelude::v1::*;
 use self::SocketStatus::*;
 use self::InAddr::*;

--- a/src/libstd/sys/unix/ext.rs
+++ b/src/libstd/sys/unix/ext.rs
@@ -73,42 +73,49 @@ impl AsRawFd for old_io::pipe::PipeStream {
     }
 }
 
+#[allow(deprecated)]
 impl AsRawFd for old_io::net::pipe::UnixStream {
     fn as_raw_fd(&self) -> Fd {
         self.as_inner().fd()
     }
 }
 
+#[allow(deprecated)]
 impl AsRawFd for old_io::net::pipe::UnixListener {
     fn as_raw_fd(&self) -> Fd {
         self.as_inner().fd()
     }
 }
 
+#[allow(deprecated)]
 impl AsRawFd for old_io::net::pipe::UnixAcceptor {
     fn as_raw_fd(&self) -> Fd {
         self.as_inner().fd()
     }
 }
 
+#[allow(deprecated)]
 impl AsRawFd for old_io::net::tcp::TcpStream {
     fn as_raw_fd(&self) -> Fd {
         self.as_inner().fd()
     }
 }
 
+#[allow(deprecated)]
 impl AsRawFd for old_io::net::tcp::TcpListener {
     fn as_raw_fd(&self) -> Fd {
         self.as_inner().fd()
     }
 }
 
+#[allow(deprecated)]
 impl AsRawFd for old_io::net::tcp::TcpAcceptor {
     fn as_raw_fd(&self) -> Fd {
         self.as_inner().fd()
     }
 }
 
+#[allow(deprecated)]
 impl AsRawFd for old_io::net::udp::UdpSocket {
     fn as_raw_fd(&self) -> Fd {
         self.as_inner().fd()

--- a/src/libstd/sys/unix/tcp.rs
+++ b/src/libstd/sys/unix/tcp.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(deprecated)]
+
 use prelude::v1::*;
 
 use old_io::net::ip;

--- a/src/libstd/sys/windows/ext.rs
+++ b/src/libstd/sys/windows/ext.rs
@@ -58,18 +58,21 @@ impl AsRawHandle for old_io::pipe::PipeStream {
     }
 }
 
+#[allow(deprecated)]
 impl AsRawHandle for old_io::net::pipe::UnixStream {
     fn as_raw_handle(&self) -> Handle {
         self.as_inner().handle()
     }
 }
 
+#[allow(deprecated)]
 impl AsRawHandle for old_io::net::pipe::UnixListener {
     fn as_raw_handle(&self) -> Handle {
         self.as_inner().handle()
     }
 }
 
+#[allow(deprecated)]
 impl AsRawHandle for old_io::net::pipe::UnixAcceptor {
     fn as_raw_handle(&self) -> Handle {
         self.as_inner().handle()
@@ -81,24 +84,28 @@ pub trait AsRawSocket {
     fn as_raw_socket(&self) -> Socket;
 }
 
+#[allow(deprecated)]
 impl AsRawSocket for old_io::net::tcp::TcpStream {
     fn as_raw_socket(&self) -> Socket {
         self.as_inner().fd()
     }
 }
 
+#[allow(deprecated)]
 impl AsRawSocket for old_io::net::tcp::TcpListener {
     fn as_raw_socket(&self) -> Socket {
         self.as_inner().socket()
     }
 }
 
+#[allow(deprecated)]
 impl AsRawSocket for old_io::net::tcp::TcpAcceptor {
     fn as_raw_socket(&self) -> Socket {
         self.as_inner().socket()
     }
 }
 
+#[allow(deprecated)]
 impl AsRawSocket for old_io::net::udp::UdpSocket {
     fn as_raw_socket(&self) -> Socket {
         self.as_inner().fd()

--- a/src/libstd/sys/windows/tcp.rs
+++ b/src/libstd/sys/windows/tcp.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(deprecated)]
+
 use old_io::net::ip;
 use old_io::IoResult;
 use libc;


### PR DESCRIPTION
The `std::net` primitives should be ready for use now and as a result the old
ones are now deprecated and slated for removal. Most TCP/UDP functionality is
now available through `std::net` but the `std::old_io::net::pipe` module is
removed entirely from the standard library.

Unix socket funtionality can be found in sfackler's [`unix_socket`](https://crates.io/crates/unix_socket) crate
and there is currently no replacement for named pipes on Windows.

[breaking-change]
