### PR TITLE
Rename LintPass::check_trait_method to check_trait_item

### DIFF
--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -612,7 +612,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for Context<'a, 'tcx> {
     }
 
     fn visit_trait_item(&mut self, m: &ast::TraitItem) {
-        run_lints!(self, check_trait_method, m);
+        run_lints!(self, check_trait_item, m);
         visit::walk_trait_item(self, m);
     }
 

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -144,7 +144,7 @@ pub trait LintPass {
     fn check_fn(&mut self, _: &Context,
         _: FnKind, _: &ast::FnDecl, _: &ast::Block, _: Span, _: ast::NodeId) { }
     fn check_ty_method(&mut self, _: &Context, _: &ast::TypeMethod) { }
-    fn check_trait_method(&mut self, _: &Context, _: &ast::TraitItem) { }
+    fn check_trait_item(&mut self, _: &Context, _: &ast::TraitItem) { }
     fn check_struct_def(&mut self, _: &Context,
         _: &ast::StructDef, _: ast::Ident, _: &ast::Generics, _: ast::NodeId) { }
     fn check_struct_def_post(&mut self, _: &Context,

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1577,7 +1577,7 @@ impl LintPass for MissingDoc {
                                      tm.span, "a type method");
     }
 
-    fn check_trait_method(&mut self, cx: &Context, it: &ast::TraitItem) {
+    fn check_trait_item(&mut self, cx: &Context, it: &ast::TraitItem) {
         if let ast::TraitItem::TypeTraitItem(ref ty) = *it {
             let assoc_ty = &ty.ty_param;
             self.check_missing_docs_attrs(cx, Some(assoc_ty.id), &ty.attrs,


### PR DESCRIPTION
Traits can have associated types and not just methods. This
clarification reflects the the type of the input the method accepts.

[breaking-change]
