### PR TITLE
Fix up build warnings about use of []

### DIFF
--- a/src/librustc/middle/astconv_util.rs
+++ b/src/librustc/middle/astconv_util.rs
@@ -68,7 +68,7 @@ pub fn ast_ty_to_prim_ty<'tcx>(tcx: &ty::ctxt<'tcx>, ast_ty: &ast::Ty)
             Some(d) => d.full_def()
         };
         if let def::DefPrimTy(nty) = def {
-            Some(prim_ty_to_ty(tcx, &path.segments[], nty))
+            Some(prim_ty_to_ty(tcx, &path.segments[..], nty))
         } else {
             None
         }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2985,7 +2985,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         } else {
             let msg = format!("use of undeclared trait name `{}`",
                               self.path_names_to_string(trait_path, path_depth));
-            self.resolve_error(trait_path.span, &msg[]);
+            self.resolve_error(trait_path.span, &msg[..]);
             Err(())
         }
     }


### PR DESCRIPTION
Simple PR to fix some build warnings on a clean clone of master.

```
/home/ubuntu/src/rust/src/librustc/middle/astconv_util.rs:71:51: 71:53 warning: obsolete syntax: []
/home/ubuntu/src/rust/src/librustc/middle/astconv_util.rs:71             Some(prim_ty_to_ty(tcx, &path.segments[], nty))
                                                                                                               ^~
note: write `[..]` instead
...
/home/ubuntu/src/rust/src/librustc_resolve/lib.rs:2988:53: 2988:55 warning: obsolete syntax: []
/home/ubuntu/src/rust/src/librustc_resolve/lib.rs:2988             self.resolve_error(trait_path.span, &msg[]);
                                                                                                           ^~
note: write `[..]` instead
```
