### PR TITLE
Fix installing into --libdir other than .../lib

### DIFF
--- a/mk/prepare.mk
+++ b/mk/prepare.mk
@@ -172,7 +172,8 @@ prepare-base-$(1): PREPARE_SOURCE_BIN_DIR=$$(PREPARE_SOURCE_DIR)/bin
 prepare-base-$(1): PREPARE_SOURCE_LIB_DIR=$$(PREPARE_SOURCE_DIR)/$$(CFG_LIBDIR_RELATIVE)
 prepare-base-$(1): PREPARE_SOURCE_MAN_DIR=$$(S)/man
 prepare-base-$(1): PREPARE_DEST_BIN_DIR=$$(PREPARE_DEST_DIR)/bin
-prepare-base-$(1): PREPARE_DEST_LIB_DIR=$$(PREPARE_DEST_DIR)/$$(CFG_LIBDIR_RELATIVE)
+# NB: this is /lib, not /$$(CFG_LIBDIR_RELATIVE). install.sh moves into --libdir
+prepare-base-$(1): PREPARE_DEST_LIB_DIR=$$(PREPARE_DEST_DIR)/lib
 prepare-base-$(1): PREPARE_DEST_MAN_DIR=$$(PREPARE_DEST_DIR)/share/man/man1
 prepare-base-$(1): prepare-everything-$(1)
 


### PR DESCRIPTION
Currently, --libdir path rewriting happens twice:
1. 'prepare' make target places files into file tree and builds tarball
2. rust-installer copies from tarball paths into final filesystem

_Both_ these steps are attempting to handle --libdir.  The installer assumes
lib paths are 'lib/' (the default) and when they aren't you can end up with
duplicated $(LIBDIR_RELATIVE)/$(LIBDIR_RELATIVE)/ paths.

This patch addresses this by making step (1) always install into lib/ and
performing --libdir handling only during step (2).
