### PR TITLE
remove the redundant else branch

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1637,8 +1637,6 @@ impl<I: Iterator, P> Iterator for Filter<I, P> where P: FnMut(&I::Item) -> bool 
         for x in self.iter.by_ref() {
             if (self.predicate)(&x) {
                 return Some(x);
-            } else {
-                continue
             }
         }
         None


### PR DESCRIPTION
The branch "else { continue }" is the last code inside a loop body,
it is just useless.

Signed-off-by: Lai Jiangshan laijs@cn.fujitsu.com
