### PR TITLE
flush output after writing less than a line

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -506,16 +506,25 @@ impl<T: Writer> ConsoleTestState<T> {
                 if self.use_color {
                     try!(term.reset());
                 }
-                Ok(())
+                term.flush()
             }
-            Raw(ref mut stdout) => stdout.write_all(word.as_bytes())
+            Raw(ref mut stdout) => {
+                try!(stdout.write_all(word.as_bytes()));
+                stdout.flush()
+            }
         }
     }
 
     pub fn write_plain(&mut self, s: &str) -> old_io::IoResult<()> {
         match self.out {
-            Pretty(ref mut term) => term.write_all(s.as_bytes()),
-            Raw(ref mut stdout) => stdout.write_all(s.as_bytes())
+            Pretty(ref mut term) => {
+                try!(term.write_all(s.as_bytes()));
+                term.flush()
+            },
+            Raw(ref mut stdout) => {
+                try!(stdout.write_all(s.as_bytes()));
+                stdout.flush()
+            },
         }
     }
 


### PR DESCRIPTION
See https://github.com/rust-lang/rust/blob/41f8b1e89b5ca0c79d7bca782ca44085624d4564/src/libtest/lib.rs#L783-L788
