### PR TITLE
Revert hacks and add test for LLVM aborts due to empty aggregates.

### DIFF
--- a/src/librand/reseeding.rs
+++ b/src/librand/reseeding.rs
@@ -134,11 +134,7 @@ pub trait Reseeder<R> {
 /// Reseed an RNG using a `Default` instance. This reseeds by
 /// replacing the RNG with the result of a `Default::default` call.
 #[derive(Copy)]
-pub struct ReseedWithDefault { __hack: [u8; 0] }
-// FIXME(#21721) used to be an unit struct but that can cause
-// certain LLVM versions to abort during optimizations.
-#[allow(non_upper_case_globals)]
-pub const ReseedWithDefault: ReseedWithDefault = ReseedWithDefault { __hack: [] };
+pub struct ReseedWithDefault;
 
 impl<R: Rng + Default> Reseeder<R> for ReseedWithDefault {
     fn reseed(&mut self, rng: &mut R) {

--- a/src/test/bench/task-perf-alloc-unwind.rs
+++ b/src/test/bench/task-perf-alloc-unwind.rs
@@ -40,9 +40,7 @@ fn run(repeat: int, depth: int) {
     }
 }
 
-// FIXME(#21721) used to be `List<()>` but that can cause
-// certain LLVM versions to abort during optimizations.
-type nillist = List<[u8; 0]>;
+type nillist = List<()>;
 
 // Filled with things that have to be unwound
 
@@ -83,11 +81,11 @@ fn recurse_or_panic(depth: int, st: Option<State>) {
             }
             Some(st) => {
                 let mut v = st.vec.clone();
-                v.push_all(&[box List::Cons([], st.vec.last().unwrap().clone())]);
+                v.push_all(&[box List::Cons((), st.vec.last().unwrap().clone())]);
                 State {
-                    unique: box List::Cons([], box *st.unique),
+                    unique: box List::Cons((), box *st.unique),
                     vec: v,
-                    res: r(box List::Cons([], st.res._l.clone())),
+                    res: r(box List::Cons((), st.res._l.clone())),
                 }
             }
         };

--- a/src/test/run-pass/issue-17216.rs
+++ b/src/test/run-pass/issue-17216.rs
@@ -25,9 +25,7 @@ fn main() {
     let mut dropped = false;
     {
         let leak = Leak { dropped: &mut dropped };
-        // FIXME(#21721) "hack" used to be () but that can cause
-        // certain LLVM versions to abort during optimizations.
-        for (_, leaked) in Some(("hack", leak)).into_iter() {}
+        for ((), leaked) in Some(((), leak)).into_iter() {}
     }
 
     assert!(dropped);

--- a/src/test/run-pass/issue-21721.rs
+++ b/src/test/run-pass/issue-21721.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    static NONE: Option<((), &'static u8)> = None;
+    let ptr = unsafe {
+        *(&NONE as *const _ as *const *const u8)
+    };
+    assert!(ptr.is_null());
+}


### PR DESCRIPTION
Closes #21721.
