### PR TITLE
Fixed-size byte string literals (RFC 339)

### DIFF
--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -23,10 +23,34 @@ use marker::{Copy, Sized};
 use option::Option;
 use slice::{Iter, IterMut, SliceExt};
 
+/// Utility trait implemented only on arrays of fixed size
+///
+/// This trait can be used to implement other traits on fixed-size arrays
+/// without causing much metadata bloat.
+#[unstable(feature = "core")]
+pub trait FixedSizeArray<T> {
+    /// Converts the array to immutable slice
+    fn as_slice(&self) -> &[T];
+    /// Converts the array to mutable slice
+    fn as_mut_slice(&mut self) -> &mut [T];
+}
+
 // macro for implementing n-ary tuple functions and operations
 macro_rules! array_impls {
     ($($N:expr)+) => {
         $(
+            #[unstable(feature = "core")]
+            impl<T> FixedSizeArray<T> for [T; $N] {
+                #[inline]
+                fn as_slice(&self) -> &[T] {
+                    &self[..]
+                }
+                #[inline]
+                fn as_mut_slice(&mut self) -> &mut [T] {
+                    &mut self[..]
+                }
+            }
+
             #[stable(feature = "rust1", since = "1.0.0")]
             impl<T:Copy> Clone for [T; $N] {
                 fn clone(&self) -> [T; $N] {

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -129,6 +129,7 @@ pub mod default;
 /* Core types and methods on primitives */
 
 pub mod any;
+pub mod array;
 pub mod atomic;
 pub mod cell;
 pub mod char;
@@ -151,7 +152,6 @@ mod bool {
 
 // note: does not need to be public
 mod tuple;
-mod array;
 
 #[doc(hidden)]
 mod core {

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -448,7 +448,8 @@ impl<T, E> Result<T, E> {
     /// ```
     /// use std::old_io::IoResult;
     ///
-    /// let mut buffer = &mut b"1\n2\n3\n4\n";
+    /// let mut buffer: &[u8] = b"1\n2\n3\n4\n";
+    /// let mut buffer = &mut buffer;
     ///
     /// let mut sum = 0;
     ///

--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -75,14 +75,7 @@ pub fn const_lit(cx: &CrateContext, e: &ast::Expr, lit: &ast::Lit)
         ast::LitBool(b) => C_bool(cx, b),
         ast::LitStr(ref s, _) => C_str_slice(cx, (*s).clone()),
         ast::LitBinary(ref data) => {
-            let g = addr_of(cx, C_bytes(cx, &data[..]), "binary", e.id);
-            let base = ptrcast(g, Type::i8p(cx));
-            let prev_const = cx.const_unsized().borrow_mut()
-                               .insert(base, g);
-            assert!(prev_const.is_none() || prev_const == Some(g));
-            assert_eq!(abi::FAT_PTR_ADDR, 0);
-            assert_eq!(abi::FAT_PTR_EXTRA, 1);
-            C_struct(cx, &[base, C_uint(cx, data.len())], false)
+            addr_of(cx, C_bytes(cx, &data[..]), "binary", e.id)
         }
     }
 }

--- a/src/librustc_trans/trans/debuginfo.rs
+++ b/src/librustc_trans/trans/debuginfo.rs
@@ -4054,7 +4054,7 @@ fn namespace_for_item(cx: &CrateContext, def_id: ast::DefId) -> Rc<NamespaceTree
 /// .debug_gdb_scripts global is referenced, so it isn't removed by the linker.
 pub fn insert_reference_to_gdb_debug_scripts_section_global(ccx: &CrateContext) {
     if needs_gdb_debug_scripts_section(ccx) {
-        let empty = CString::new(b"").unwrap();
+        let empty = CString::new("").unwrap();
         let gdb_debug_scripts_section_global =
             get_or_insert_gdb_debug_scripts_section_global(ccx);
         unsafe {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2505,10 +2505,11 @@ fn check_lit<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 
     match lit.node {
         ast::LitStr(..) => ty::mk_str_slice(tcx, tcx.mk_region(ty::ReStatic), ast::MutImmutable),
-        ast::LitBinary(..) => {
-            ty::mk_slice(tcx,
-                         tcx.mk_region(ty::ReStatic),
-                         ty::mt{ ty: tcx.types.u8, mutbl: ast::MutImmutable })
+        ast::LitBinary(ref v) => {
+            ty::mk_rptr(tcx, tcx.mk_region(ty::ReStatic), ty::mt {
+                ty: ty::mk_vec(tcx, tcx.types.u8, Some(v.len())),
+                mutbl: ast::MutImmutable,
+            })
         }
         ast::LitByte(_) => tcx.types.u8,
         ast::LitChar(_) => tcx.types.char,

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -451,6 +451,23 @@ impl IntoBytes for Vec<u8> {
     fn into_bytes(self) -> Vec<u8> { self }
 }
 
+macro_rules! array_impls {
+    ($($N: expr)+) => {
+        $(
+            impl<'a> IntoBytes for &'a [u8; $N] {
+                fn into_bytes(self) -> Vec<u8> { self.to_vec() }
+            }
+        )+
+    }
+}
+
+array_impls! {
+     0  1  2  3  4  5  6  7  8  9
+    10 11 12 13 14 15 16 17 18 19
+    20 21 22 23 24 25 26 27 28 29
+    30 31 32
+}
+
 #[cfg(test)]
 mod tests {
     use prelude::v1::*;

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -11,7 +11,6 @@
 #![unstable(feature = "std_misc")]
 
 use cmp::{PartialEq, Eq, PartialOrd, Ord, Ordering};
-use core::array::FixedSizeArray;
 use error::{Error, FromError};
 use fmt;
 use io;
@@ -59,7 +58,7 @@ use vec::Vec;
 ///     fn my_printer(s: *const libc::c_char);
 /// }
 ///
-/// let to_print = b"Hello, world!";
+/// let to_print = &b"Hello, world!"[..];
 /// let c_to_print = CString::new(to_print).unwrap();
 /// unsafe {
 ///     my_printer(c_to_print.as_ptr());
@@ -451,9 +450,6 @@ impl IntoBytes for String {
 impl IntoBytes for Vec<u8> {
     fn into_bytes(self) -> Vec<u8> { self }
 }
-impl<'a, T: FixedSizeArray<u8>> IntoBytes for &'a T {
-    fn into_bytes(self) -> Vec<u8> { self.as_slice().to_vec() }
-}
 
 #[cfg(test)]
 mod tests {
@@ -473,14 +469,14 @@ mod tests {
 
     #[test]
     fn simple() {
-        let s = CString::new(b"1234").unwrap();
+        let s = CString::new("1234").unwrap();
         assert_eq!(s.as_bytes(), b"1234");
         assert_eq!(s.as_bytes_with_nul(), b"1234\0");
     }
 
     #[test]
     fn build_with_zero1() {
-        assert!(CString::new(b"\0").is_err());
+        assert!(CString::new(&b"\0"[..]).is_err());
     }
     #[test]
     fn build_with_zero2() {
@@ -497,7 +493,7 @@ mod tests {
 
     #[test]
     fn formatted() {
-        let s = CString::new(b"12").unwrap();
+        let s = CString::new(&b"12"[..]).unwrap();
         assert_eq!(format!("{:?}", s), "\"12\"");
     }
 

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -11,6 +11,7 @@
 #![unstable(feature = "std_misc")]
 
 use cmp::{PartialEq, Eq, PartialOrd, Ord, Ordering};
+use core::array::FixedSizeArray;
 use error::{Error, FromError};
 use fmt;
 use io;
@@ -450,22 +451,8 @@ impl IntoBytes for String {
 impl IntoBytes for Vec<u8> {
     fn into_bytes(self) -> Vec<u8> { self }
 }
-
-macro_rules! array_impls {
-    ($($N: expr)+) => {
-        $(
-            impl<'a> IntoBytes for &'a [u8; $N] {
-                fn into_bytes(self) -> Vec<u8> { self.to_vec() }
-            }
-        )+
-    }
-}
-
-array_impls! {
-     0  1  2  3  4  5  6  7  8  9
-    10 11 12 13 14 15 16 17 18 19
-    20 21 22 23 24 25 26 27 28 29
-    30 31 32
+impl<'a, T: FixedSizeArray<u8>> IntoBytes for &'a T {
+    fn into_bytes(self) -> Vec<u8> { self.as_slice().to_vec() }
 }
 
 #[cfg(test)]

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -622,7 +622,7 @@ mod tests {
 
     #[test]
     fn test_read_line() {
-        let in_buf = b"a\nb\nc";
+        let in_buf: &[u8] = b"a\nb\nc";
         let mut reader = BufReader::with_capacity(2, in_buf);
         let mut s = String::new();
         reader.read_line(&mut s).unwrap();
@@ -640,7 +640,7 @@ mod tests {
 
     #[test]
     fn test_lines() {
-        let in_buf = b"a\nb\nc";
+        let in_buf: &[u8] = b"a\nb\nc";
         let reader = BufReader::with_capacity(2, in_buf);
         let mut it = reader.lines();
         assert_eq!(it.next(), Some(Ok("a".to_string())));

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -129,6 +129,23 @@ impl<'a> BufRead for Cursor<&'a mut [u8]> { buffer!(); }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> BufRead for Cursor<Vec<u8>> { buffer!(); }
 
+macro_rules! array_impls {
+    ($($N: expr)+) => {
+        $(
+            impl<'a> io::Seek for Cursor<&'a [u8; $N]> { seek!(); }
+            impl<'a> Read for Cursor<&'a [u8; $N]> { read!(); }
+            impl<'a> BufRead for Cursor<&'a [u8; $N]> { buffer!(); }
+        )+
+    }
+}
+
+array_impls! {
+     0  1  2  3  4  5  6  7  8  9
+    10 11 12 13 14 15 16 17 18 19
+    20 21 22 23 24 25 26 27 28 29
+    30 31 32
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Write for Cursor<&'a mut [u8]> {
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -933,12 +933,12 @@ mod tests {
 
     #[test]
     fn read_until() {
-        let mut buf = Cursor::new(b"12");
+        let mut buf = Cursor::new(&b"12"[..]);
         let mut v = Vec::new();
         assert_eq!(buf.read_until(b'3', &mut v), Ok(2));
         assert_eq!(v, b"12");
 
-        let mut buf = Cursor::new(b"1233");
+        let mut buf = Cursor::new(&b"1233"[..]);
         let mut v = Vec::new();
         assert_eq!(buf.read_until(b'3', &mut v), Ok(3));
         assert_eq!(v, b"123");
@@ -952,12 +952,12 @@ mod tests {
 
     #[test]
     fn split() {
-        let buf = Cursor::new(b"12");
+        let buf = Cursor::new(&b"12"[..]);
         let mut s = buf.split(b'3');
         assert_eq!(s.next(), Some(Ok(vec![b'1', b'2'])));
         assert_eq!(s.next(), None);
 
-        let buf = Cursor::new(b"1233");
+        let buf = Cursor::new(&b"1233"[..]);
         let mut s = buf.split(b'3');
         assert_eq!(s.next(), Some(Ok(vec![b'1', b'2'])));
         assert_eq!(s.next(), Some(Ok(vec![])));
@@ -966,12 +966,12 @@ mod tests {
 
     #[test]
     fn read_line() {
-        let mut buf = Cursor::new(b"12");
+        let mut buf = Cursor::new(&b"12"[..]);
         let mut v = String::new();
         assert_eq!(buf.read_line(&mut v), Ok(2));
         assert_eq!(v, "12");
 
-        let mut buf = Cursor::new(b"12\n\n");
+        let mut buf = Cursor::new(&b"12\n\n"[..]);
         let mut v = String::new();
         assert_eq!(buf.read_line(&mut v), Ok(3));
         assert_eq!(v, "12\n");
@@ -985,12 +985,12 @@ mod tests {
 
     #[test]
     fn lines() {
-        let buf = Cursor::new(b"12");
+        let buf = Cursor::new(&b"12"[..]);
         let mut s = buf.lines();
         assert_eq!(s.next(), Some(Ok("12".to_string())));
         assert_eq!(s.next(), None);
 
-        let buf = Cursor::new(b"12\n\n");
+        let buf = Cursor::new(&b"12\n\n"[..]);
         let mut s = buf.lines();
         assert_eq!(s.next(), Some(Ok("12".to_string())));
         assert_eq!(s.next(), Some(Ok(String::new())));
@@ -999,12 +999,12 @@ mod tests {
 
     #[test]
     fn read_to_end() {
-        let mut c = Cursor::new(b"");
+        let mut c = Cursor::new(&b""[..]);
         let mut v = Vec::new();
         assert_eq!(c.read_to_end(&mut v), Ok(0));
         assert_eq!(v, []);
 
-        let mut c = Cursor::new(b"1");
+        let mut c = Cursor::new(&b"1"[..]);
         let mut v = Vec::new();
         assert_eq!(c.read_to_end(&mut v), Ok(1));
         assert_eq!(v, b"1");
@@ -1012,17 +1012,17 @@ mod tests {
 
     #[test]
     fn read_to_string() {
-        let mut c = Cursor::new(b"");
+        let mut c = Cursor::new(&b""[..]);
         let mut v = String::new();
         assert_eq!(c.read_to_string(&mut v), Ok(0));
         assert_eq!(v, "");
 
-        let mut c = Cursor::new(b"1");
+        let mut c = Cursor::new(&b"1"[..]);
         let mut v = String::new();
         assert_eq!(c.read_to_string(&mut v), Ok(1));
         assert_eq!(v, "1");
 
-        let mut c = Cursor::new(b"\xff");
+        let mut c = Cursor::new(&b"\xff"[..]);
         let mut v = String::new();
         assert!(c.read_to_string(&mut v).is_err());
     }

--- a/src/libstd/old_io/process.rs
+++ b/src/libstd/old_io/process.rs
@@ -1231,7 +1231,7 @@ mod tests {
         cmd.env("path", "foo");
         cmd.env("Path", "bar");
         let env = &cmd.env.unwrap();
-        let val = env.get(&EnvKey(CString::new(b"PATH").unwrap()));
-        assert!(val.unwrap() == &CString::new(b"bar").unwrap());
+        let val = env.get(&EnvKey(CString::new("PATH").unwrap()));
+        assert!(val.unwrap() == &CString::new("bar").unwrap());
     }
 }

--- a/src/libstd/old_io/util.rs
+++ b/src/libstd/old_io/util.rs
@@ -445,7 +445,8 @@ mod test {
 
     #[test]
     fn limit_reader_buffer() {
-        let r = &mut b"0123456789\n0123456789\n";
+        let mut r: &[u8] = b"0123456789\n0123456789\n";
+        let r = &mut r;
         {
             let mut r = LimitReader::new(r.by_ref(), 3);
             assert_eq!(r.read_line(), Ok("012".to_string()));

--- a/src/libstd/old_path/mod.rs
+++ b/src/libstd/old_path/mod.rs
@@ -64,6 +64,7 @@
 #![allow(deprecated)] // seriously this is all deprecated
 #![allow(unused_imports)]
 
+use core::array::FixedSizeArray;
 use core::marker::Sized;
 use ffi::CString;
 use clone::Clone;
@@ -895,24 +896,11 @@ impl BytesContainer for [u8] {
     }
 }
 
-macro_rules! array_impls {
-    ($($N: expr)+) => {
-        $(
-            impl BytesContainer for [u8; $N] {
-                #[inline]
-                fn container_as_bytes(&self) -> &[u8] {
-                    &self[..]
-                }
-            }
-        )+
+impl<T: FixedSizeArray<u8>> BytesContainer for T {
+    #[inline]
+    fn container_as_bytes(&self) -> &[u8] {
+        self.as_slice()
     }
-}
-
-array_impls! {
-     0  1  2  3  4  5  6  7  8  9
-    10 11 12 13 14 15 16 17 18 19
-    20 21 22 23 24 25 26 27 28 29
-    30 31 32
 }
 
 impl BytesContainer for Vec<u8> {

--- a/src/libstd/old_path/mod.rs
+++ b/src/libstd/old_path/mod.rs
@@ -895,6 +895,26 @@ impl BytesContainer for [u8] {
     }
 }
 
+macro_rules! array_impls {
+    ($($N: expr)+) => {
+        $(
+            impl BytesContainer for [u8; $N] {
+                #[inline]
+                fn container_as_bytes(&self) -> &[u8] {
+                    &self[..]
+                }
+            }
+        )+
+    }
+}
+
+array_impls! {
+     0  1  2  3  4  5  6  7  8  9
+    10 11 12 13 14 15 16 17 18 19
+    20 21 22 23 24 25 26 27 28 29
+    30 31 32
+}
+
 impl BytesContainer for Vec<u8> {
     #[inline]
     fn container_as_bytes(&self) -> &[u8] {

--- a/src/libstd/old_path/mod.rs
+++ b/src/libstd/old_path/mod.rs
@@ -64,7 +64,6 @@
 #![allow(deprecated)] // seriously this is all deprecated
 #![allow(unused_imports)]
 
-use core::array::FixedSizeArray;
 use core::marker::Sized;
 use ffi::CString;
 use clone::Clone;
@@ -893,13 +892,6 @@ impl BytesContainer for [u8] {
     #[inline]
     fn container_as_bytes(&self) -> &[u8] {
         self
-    }
-}
-
-impl<T: FixedSizeArray<u8>> BytesContainer for T {
-    #[inline]
-    fn container_as_bytes(&self) -> &[u8] {
-        self.as_slice()
     }
 }
 

--- a/src/libstd/old_path/mod.rs
+++ b/src/libstd/old_path/mod.rs
@@ -311,7 +311,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
     /// let p = Path::new("abc/def/ghi");
-    /// assert_eq!(p.filename(), Some(b"ghi"));
+    /// assert_eq!(p.filename(), Some(&b"ghi"[..]));
     /// # }
     /// ```
     fn filename<'a>(&'a self) -> Option<&'a [u8]>;
@@ -345,7 +345,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
     /// let p = Path::new("/abc/def.txt");
-    /// assert_eq!(p.filestem(), Some(b"def"));
+    /// assert_eq!(p.filestem(), Some(&b"def"[..]));
     /// # }
     /// ```
     fn filestem<'a>(&'a self) -> Option<&'a [u8]> {
@@ -392,7 +392,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
     /// let p = Path::new("abc/def.txt");
-    /// assert_eq!(p.extension(), Some(b"txt"));
+    /// assert_eq!(p.extension(), Some(&b"txt"[..]));
     /// # }
     /// ```
     fn extension<'a>(&'a self) -> Option<&'a [u8]> {

--- a/src/libstd/old_path/posix.rs
+++ b/src/libstd/old_path/posix.rs
@@ -477,11 +477,11 @@ mod tests {
     fn test_paths() {
         let empty: &[u8] = &[];
         t!(v: Path::new(empty), b".");
-        t!(v: Path::new(b"/"), b"/");
-        t!(v: Path::new(b"a/b/c"), b"a/b/c");
-        t!(v: Path::new(b"a/b/c\xFF"), b"a/b/c\xFF");
-        t!(v: Path::new(b"\xFF/../foo\x80"), b"foo\x80");
-        let p = Path::new(b"a/b/c\xFF");
+        t!(v: Path::new(&b"/"[..]), b"/");
+        t!(v: Path::new(&b"a/b/c"[..]), b"a/b/c");
+        t!(v: Path::new(&b"a/b/c\xFF"[..]), b"a/b/c\xFF");
+        t!(v: Path::new(&b"\xFF/../foo\x80"[..]), b"foo\x80");
+        let p = Path::new(&b"a/b/c\xFF"[..]);
         assert!(p.as_str().is_none());
 
         t!(s: Path::new(""), ".");
@@ -507,18 +507,18 @@ mod tests {
         t!(s: Path::new("foo/../../.."), "../..");
         t!(s: Path::new("foo/../../bar"), "../bar");
 
-        assert_eq!(Path::new(b"foo/bar").into_vec(), b"foo/bar");
-        assert_eq!(Path::new(b"/foo/../../bar").into_vec(),
+        assert_eq!(Path::new(&b"foo/bar"[..]).into_vec(), b"foo/bar");
+        assert_eq!(Path::new(&b"/foo/../../bar"[..]).into_vec(),
                    b"/bar");
 
-        let p = Path::new(b"foo/bar\x80");
+        let p = Path::new(&b"foo/bar\x80"[..]);
         assert!(p.as_str().is_none());
     }
 
     #[test]
     fn test_opt_paths() {
-        assert!(Path::new_opt(b"foo/bar\0").is_none());
-        t!(v: Path::new_opt(b"foo/bar").unwrap(), b"foo/bar");
+        assert!(Path::new_opt(&b"foo/bar\0"[..]).is_none());
+        t!(v: Path::new_opt(&b"foo/bar"[..]).unwrap(), b"foo/bar");
         assert!(Path::new_opt("foo/bar\0").is_none());
         t!(s: Path::new_opt("foo/bar").unwrap(), "foo/bar");
     }
@@ -527,17 +527,17 @@ mod tests {
     fn test_null_byte() {
         use thread;
         let result = thread::spawn(move|| {
-            Path::new(b"foo/bar\0");
+            Path::new(&b"foo/bar\0"[..]);
         }).join();
         assert!(result.is_err());
 
         let result = thread::spawn(move|| {
-            Path::new("test").set_filename(b"f\0o")
+            Path::new("test").set_filename(&b"f\0o"[..])
         }).join();
         assert!(result.is_err());
 
         let result = thread::spawn(move|| {
-            Path::new("test").push(b"f\0o");
+            Path::new("test").push(&b"f\0o"[..]);
         }).join();
         assert!(result.is_err());
     }
@@ -553,11 +553,11 @@ mod tests {
             )
         }
         t!("foo", display, "foo");
-        t!(b"foo\x80", display, "foo\u{FFFD}");
-        t!(b"foo\xFFbar", display, "foo\u{FFFD}bar");
-        t!(b"foo\xFF/bar", filename_display, "bar");
-        t!(b"foo/\xFFbar", filename_display, "\u{FFFD}bar");
-        t!(b"/", filename_display, "");
+        t!(&b"foo\x80"[..], display, "foo\u{FFFD}");
+        t!(&b"foo\xFFbar"[..], display, "foo\u{FFFD}bar");
+        t!(&b"foo\xFF/bar"[..], filename_display, "bar");
+        t!(&b"foo/\xFFbar"[..], filename_display, "\u{FFFD}bar");
+        t!(&b"/"[..], filename_display, "");
 
         macro_rules! t {
             ($path:expr, $exp:expr) => (
@@ -577,11 +577,11 @@ mod tests {
         }
 
         t!("foo", "foo");
-        t!(b"foo\x80", "foo\u{FFFD}");
-        t!(b"foo\xFFbar", "foo\u{FFFD}bar");
-        t!(b"foo\xFF/bar", "bar", filename);
-        t!(b"foo/\xFFbar", "\u{FFFD}bar", filename);
-        t!(b"/", "", filename);
+        t!(&b"foo\x80"[..], "foo\u{FFFD}");
+        t!(&b"foo\xFFbar"[..], "foo\u{FFFD}bar");
+        t!(&b"foo\xFF/bar"[..], "bar", filename);
+        t!(&b"foo/\xFFbar"[..], "\u{FFFD}bar", filename);
+        t!(&b"/"[..], "", filename);
     }
 
     #[test]
@@ -598,13 +598,13 @@ mod tests {
             )
         }
 
-        t!(b"foo", "foo", "foo");
-        t!(b"foo/bar", "foo/bar", "bar");
-        t!(b"/", "/", "");
-        t!(b"foo\xFF", "foo\u{FFFD}", "foo\u{FFFD}");
-        t!(b"foo\xFF/bar", "foo\u{FFFD}/bar", "bar");
-        t!(b"foo/\xFFbar", "foo/\u{FFFD}bar", "\u{FFFD}bar");
-        t!(b"\xFFfoo/bar\xFF", "\u{FFFD}foo/bar\u{FFFD}", "bar\u{FFFD}");
+        t!(&b"foo"[..], "foo", "foo");
+        t!(&b"foo/bar"[..], "foo/bar", "bar");
+        t!(&b"/"[..], "/", "");
+        t!(&b"foo\xFF"[..], "foo\u{FFFD}", "foo\u{FFFD}");
+        t!(&b"foo\xFF/bar"[..], "foo\u{FFFD}/bar", "bar");
+        t!(&b"foo/\xFFbar"[..], "foo/\u{FFFD}bar", "\u{FFFD}bar");
+        t!(&b"\xFFfoo/bar\xFF"[..], "\u{FFFD}foo/bar\u{FFFD}", "bar\u{FFFD}");
     }
 
     #[test]
@@ -632,9 +632,9 @@ mod tests {
             );
         }
 
-        t!(v: b"a/b/c", filename, Some(&b"c"[..]));
-        t!(v: b"a/b/c\xFF", filename, Some(&b"c\xFF"[..]));
-        t!(v: b"a/b\xFF/c", filename, Some(&b"c"[..]));
+        t!(v: &b"a/b/c"[..], filename, Some(&b"c"[..]));
+        t!(v: &b"a/b/c\xFF"[..], filename, Some(&b"c\xFF"[..]));
+        t!(v: &b"a/b\xFF/c"[..], filename, Some(&b"c"[..]));
         t!(s: "a/b/c", filename, Some("c"), opt);
         t!(s: "/a/b/c", filename, Some("c"), opt);
         t!(s: "a", filename, Some("a"), opt);
@@ -644,9 +644,9 @@ mod tests {
         t!(s: "..", filename, None, opt);
         t!(s: "../..", filename, None, opt);
 
-        t!(v: b"a/b/c", dirname, b"a/b");
-        t!(v: b"a/b/c\xFF", dirname, b"a/b");
-        t!(v: b"a/b\xFF/c", dirname, b"a/b\xFF");
+        t!(v: &b"a/b/c"[..], dirname, b"a/b");
+        t!(v: &b"a/b/c\xFF"[..], dirname, b"a/b");
+        t!(v: &b"a/b\xFF/c"[..], dirname, b"a/b\xFF");
         t!(s: "a/b/c", dirname, "a/b");
         t!(s: "/a/b/c", dirname, "/a/b");
         t!(s: "a", dirname, ".");
@@ -656,9 +656,9 @@ mod tests {
         t!(s: "..", dirname, "..");
         t!(s: "../..", dirname, "../..");
 
-        t!(v: b"hi/there.txt", filestem, Some(&b"there"[..]));
-        t!(v: b"hi/there\x80.txt", filestem, Some(&b"there\x80"[..]));
-        t!(v: b"hi/there.t\x80xt", filestem, Some(&b"there"[..]));
+        t!(v: &b"hi/there.txt"[..], filestem, Some(&b"there"[..]));
+        t!(v: &b"hi/there\x80.txt"[..], filestem, Some(&b"there\x80"[..]));
+        t!(v: &b"hi/there.t\x80xt"[..], filestem, Some(&b"there"[..]));
         t!(s: "hi/there.txt", filestem, Some("there"), opt);
         t!(s: "hi/there", filestem, Some("there"), opt);
         t!(s: "there.txt", filestem, Some("there"), opt);
@@ -672,11 +672,11 @@ mod tests {
         t!(s: "..", filestem, None, opt);
         t!(s: "../..", filestem, None, opt);
 
-        t!(v: b"hi/there.txt", extension, Some(&b"txt"[..]));
-        t!(v: b"hi/there\x80.txt", extension, Some(&b"txt"[..]));
-        t!(v: b"hi/there.t\x80xt", extension, Some(&b"t\x80xt"[..]));
-        t!(v: b"hi/there", extension, None);
-        t!(v: b"hi/there\x80", extension, None);
+        t!(v: &b"hi/there.txt"[..], extension, Some(&b"txt"[..]));
+        t!(v: &b"hi/there\x80.txt"[..], extension, Some(&b"txt"[..]));
+        t!(v: &b"hi/there.t\x80xt"[..], extension, Some(&b"t\x80xt"[..]));
+        t!(v: &b"hi/there"[..], extension, None);
+        t!(v: &b"hi/there\x80"[..], extension, None);
         t!(s: "hi/there.txt", extension, Some("txt"), opt);
         t!(s: "hi/there", extension, None, opt);
         t!(s: "there.txt", extension, Some("txt"), opt);
@@ -756,9 +756,9 @@ mod tests {
         t!(s: "a/b/c", ["d", "/e"], "/e");
         t!(s: "a/b/c", ["d", "/e", "f"], "/e/f");
         t!(s: "a/b/c", ["d".to_string(), "e".to_string()], "a/b/c/d/e");
-        t!(v: b"a/b/c", [&b"d"[..], &b"e"[..]], b"a/b/c/d/e");
-        t!(v: b"a/b/c", [&b"d"[..], &b"/e"[..], &b"f"[..]], b"/e/f");
-        t!(v: b"a/b/c", [b"d".to_vec(), b"e".to_vec()], b"a/b/c/d/e");
+        t!(v: &b"a/b/c"[..], [&b"d"[..], &b"e"[..]], b"a/b/c/d/e");
+        t!(v: &b"a/b/c"[..], [&b"d"[..], &b"/e"[..], &b"f"[..]], b"/e/f");
+        t!(v: &b"a/b/c"[..], [b"d".to_vec(), b"e".to_vec()], b"a/b/c/d/e");
     }
 
     #[test]
@@ -782,15 +782,15 @@ mod tests {
             )
         }
 
-        t!(b: b"a/b/c", b"a/b", true);
-        t!(b: b"a", b".", true);
-        t!(b: b".", b".", false);
-        t!(b: b"/a", b"/", true);
-        t!(b: b"/", b"/", false);
-        t!(b: b"a/b/c\x80", b"a/b", true);
-        t!(b: b"a/b\x80/c", b"a/b\x80", true);
-        t!(b: b"\xFF", b".", true);
-        t!(b: b"/\xFF", b"/", true);
+        t!(b: &b"a/b/c"[..], b"a/b", true);
+        t!(b: &b"a"[..], b".", true);
+        t!(b: &b"."[..], b".", false);
+        t!(b: &b"/a"[..], b"/", true);
+        t!(b: &b"/"[..], b"/", false);
+        t!(b: &b"a/b/c\x80"[..], b"a/b", true);
+        t!(b: &b"a/b\x80/c"[..], b"a/b\x80", true);
+        t!(b: &b"\xFF"[..], b".", true);
+        t!(b: &b"/\xFF"[..], b"/", true);
         t!(s: "a/b/c", "a/b", true);
         t!(s: "a", ".", true);
         t!(s: ".", ".", false);
@@ -800,15 +800,15 @@ mod tests {
 
     #[test]
     fn test_root_path() {
-        assert_eq!(Path::new(b"a/b/c").root_path(), None);
-        assert_eq!(Path::new(b"/a/b/c").root_path(), Some(Path::new("/")));
+        assert_eq!(Path::new(&b"a/b/c"[..]).root_path(), None);
+        assert_eq!(Path::new(&b"/a/b/c"[..]).root_path(), Some(Path::new("/")));
     }
 
     #[test]
     fn test_join() {
-        t!(v: Path::new(b"a/b/c").join(b".."), b"a/b");
-        t!(v: Path::new(b"/a/b/c").join(b"d"), b"/a/b/c/d");
-        t!(v: Path::new(b"a/\x80/c").join(b"\xFF"), b"a/\x80/c/\xFF");
+        t!(v: Path::new(&b"a/b/c"[..]).join(&b".."[..]), b"a/b");
+        t!(v: Path::new(&b"/a/b/c"[..]).join(&b"d"[..]), b"/a/b/c/d");
+        t!(v: Path::new(&b"a/\x80/c"[..]).join(&b"\xFF"[..]), b"a/\x80/c/\xFF");
         t!(s: Path::new("a/b/c").join(".."), "a/b");
         t!(s: Path::new("/a/b/c").join("d"), "/a/b/c/d");
         t!(s: Path::new("a/b").join("c/d"), "a/b/c/d");
@@ -861,17 +861,17 @@ mod tests {
         t!(s: "a/b/c", ["..", "d"], "a/b/d");
         t!(s: "a/b/c", ["d", "/e", "f"], "/e/f");
         t!(s: "a/b/c", ["d".to_string(), "e".to_string()], "a/b/c/d/e");
-        t!(v: b"a/b/c", [b"d", b"e"], b"a/b/c/d/e");
-        t!(v: b"a/b/c", [b"d".to_vec(), b"e".to_vec()], b"a/b/c/d/e");
+        t!(v: &b"a/b/c"[..], [&b"d"[..], &b"e"[..]], b"a/b/c/d/e");
+        t!(v: &b"a/b/c"[..], [b"d".to_vec(), b"e".to_vec()], b"a/b/c/d/e");
     }
 
     #[test]
     fn test_with_helpers() {
         let empty: &[u8] = &[];
 
-        t!(v: Path::new(b"a/b/c").with_filename(b"d"), b"a/b/d");
-        t!(v: Path::new(b"a/b/c\xFF").with_filename(b"\x80"), b"a/b/\x80");
-        t!(v: Path::new(b"/\xFF/foo").with_filename(b"\xCD"),
+        t!(v: Path::new(&b"a/b/c"[..]).with_filename(&b"d"[..]), b"a/b/d");
+        t!(v: Path::new(&b"a/b/c\xFF"[..]).with_filename(&b"\x80"[..]), b"a/b/\x80");
+        t!(v: Path::new(&b"/\xFF/foo"[..]).with_filename(&b"\xCD"[..]),
               b"/\xFF/\xCD");
         t!(s: Path::new("a/b/c").with_filename("d"), "a/b/d");
         t!(s: Path::new(".").with_filename("foo"), "foo");
@@ -893,13 +893,13 @@ mod tests {
         t!(s: Path::new("..").with_filename(""), "..");
         t!(s: Path::new("../..").with_filename(""), "../..");
 
-        t!(v: Path::new(b"hi/there\x80.txt").with_extension(b"exe"),
+        t!(v: Path::new(&b"hi/there\x80.txt"[..]).with_extension(&b"exe"[..]),
               b"hi/there\x80.exe");
-        t!(v: Path::new(b"hi/there.txt\x80").with_extension(b"\xFF"),
+        t!(v: Path::new(&b"hi/there.txt\x80"[..]).with_extension(&b"\xFF"[..]),
               b"hi/there.\xFF");
-        t!(v: Path::new(b"hi/there\x80").with_extension(b"\xFF"),
+        t!(v: Path::new(&b"hi/there\x80"[..]).with_extension(&b"\xFF"[..]),
               b"hi/there\x80.\xFF");
-        t!(v: Path::new(b"hi/there.\xFF").with_extension(empty), b"hi/there");
+        t!(v: Path::new(&b"hi/there.\xFF"[..]).with_extension(empty), b"hi/there");
         t!(s: Path::new("hi/there.txt").with_extension("exe"), "hi/there.exe");
         t!(s: Path::new("hi/there.txt").with_extension(""), "hi/there");
         t!(s: Path::new("hi/there.txt").with_extension("."), "hi/there..");
@@ -941,17 +941,17 @@ mod tests {
             )
         }
 
-        t!(v: b"a/b/c", set_filename, with_filename, b"d");
-        t!(v: b"/", set_filename, with_filename, b"foo");
-        t!(v: b"\x80", set_filename, with_filename, b"\xFF");
+        t!(v: &b"a/b/c"[..], set_filename, with_filename, &b"d"[..]);
+        t!(v: &b"/"[..], set_filename, with_filename, &b"foo"[..]);
+        t!(v: &b"\x80"[..], set_filename, with_filename, &b"\xFF"[..]);
         t!(s: "a/b/c", set_filename, with_filename, "d");
         t!(s: "/", set_filename, with_filename, "foo");
         t!(s: ".", set_filename, with_filename, "foo");
         t!(s: "a/b", set_filename, with_filename, "");
         t!(s: "a", set_filename, with_filename, "");
 
-        t!(v: b"hi/there.txt", set_extension, with_extension, b"exe");
-        t!(v: b"hi/there.t\x80xt", set_extension, with_extension, b"exe\xFF");
+        t!(v: &b"hi/there.txt"[..], set_extension, with_extension, &b"exe"[..]);
+        t!(v: &b"hi/there.t\x80xt"[..], set_extension, with_extension, &b"exe\xFF"[..]);
         t!(s: "hi/there.txt", set_extension, with_extension, "exe");
         t!(s: "hi/there.", set_extension, with_extension, "txt");
         t!(s: "hi/there", set_extension, with_extension, "txt");
@@ -983,9 +983,9 @@ mod tests {
             )
         }
 
-        t!(v: Path::new(b"a/b/c"), Some(&b"c"[..]), b"a/b", Some(&b"c"[..]), None);
-        t!(v: Path::new(b"a/b/\xFF"), Some(&b"\xFF"[..]), b"a/b", Some(&b"\xFF"[..]), None);
-        t!(v: Path::new(b"hi/there.\xFF"), Some(&b"there.\xFF"[..]), b"hi",
+        t!(v: Path::new(&b"a/b/c"[..]), Some(&b"c"[..]), b"a/b", Some(&b"c"[..]), None);
+        t!(v: Path::new(&b"a/b/\xFF"[..]), Some(&b"\xFF"[..]), b"a/b", Some(&b"\xFF"[..]), None);
+        t!(v: Path::new(&b"hi/there.\xFF"[..]), Some(&b"there.\xFF"[..]), b"hi",
               Some(&b"there"[..]), Some(&b"\xFF"[..]));
         t!(s: Path::new("a/b/c"), Some("c"), Some("a/b"), Some("c"), None);
         t!(s: Path::new("."), None, Some("."), None, None);
@@ -1000,16 +1000,16 @@ mod tests {
         t!(s: Path::new("hi/.there"), Some(".there"), Some("hi"), Some(".there"), None);
         t!(s: Path::new("hi/..there"), Some("..there"), Some("hi"),
               Some("."), Some("there"));
-        t!(s: Path::new(b"a/b/\xFF"), None, Some("a/b"), None, None);
-        t!(s: Path::new(b"a/b/\xFF.txt"), None, Some("a/b"), None, Some("txt"));
-        t!(s: Path::new(b"a/b/c.\x80"), None, Some("a/b"), Some("c"), None);
-        t!(s: Path::new(b"\xFF/b"), Some("b"), None, Some("b"), None);
+        t!(s: Path::new(&b"a/b/\xFF"[..]), None, Some("a/b"), None, None);
+        t!(s: Path::new(&b"a/b/\xFF.txt"[..]), None, Some("a/b"), None, Some("txt"));
+        t!(s: Path::new(&b"a/b/c.\x80"[..]), None, Some("a/b"), Some("c"), None);
+        t!(s: Path::new(&b"\xFF/b"[..]), Some("b"), None, Some("b"), None);
     }
 
     #[test]
     fn test_dir_path() {
-        t!(v: Path::new(b"hi/there\x80").dir_path(), b"hi");
-        t!(v: Path::new(b"hi\xFF/there").dir_path(), b"hi\xFF");
+        t!(v: Path::new(&b"hi/there\x80"[..]).dir_path(), b"hi");
+        t!(v: Path::new(&b"hi\xFF/there"[..]).dir_path(), b"hi\xFF");
         t!(s: Path::new("hi/there").dir_path(), "hi");
         t!(s: Path::new("hi").dir_path(), ".");
         t!(s: Path::new("/hi").dir_path(), "/");
@@ -1107,9 +1107,9 @@ mod tests {
         t!(s: "/a/b/c", "d/e/f", false);
         t!(s: "a/b/c", "a/b", false);
         t!(s: "a/b/c", "b", false);
-        t!(v: b"a/b/c", b"b/c", true);
-        t!(v: b"a/b/\xFF", b"\xFF", true);
-        t!(v: b"a/b/\xFF", b"b/\xFF", true);
+        t!(v: &b"a/b/c"[..], &b"b/c"[..], true);
+        t!(v: &b"a/b/\xFF"[..], &b"\xFF"[..], true);
+        t!(v: &b"a/b/\xFF"[..], &b"b/\xFF"[..], true);
     }
 
     #[test]
@@ -1185,9 +1185,9 @@ mod tests {
             )
         }
 
-        t!(b: b"a/b/c", [b"a", b"b", b"c"]);
-        t!(b: b"/\xFF/a/\x80", [b"\xFF", b"a", b"\x80"]);
-        t!(b: b"../../foo\xCDbar", [b"..", b"..", b"foo\xCDbar"]);
+        t!(b: &b"a/b/c"[..], [b"a", b"b", b"c"]);
+        t!(b: &b"/\xFF/a/\x80"[..], [b"\xFF", b"a", b"\x80"]);
+        t!(b: &b"../../foo\xCDbar"[..], [b"..", b"..", b"foo\xCDbar"]);
         t!(s: "a/b/c", ["a", "b", "c"]);
         t!(s: "a/b/d", ["a", "b", "d"]);
         t!(s: "a/b/cd", ["a", "b", "cd"]);
@@ -1217,9 +1217,9 @@ mod tests {
             )
         }
 
-        t!(b: b"a/b/c", [Some("a"), Some("b"), Some("c")]);
-        t!(b: b"/\xFF/a/\x80", [None, Some("a"), None]);
-        t!(b: b"../../foo\xCDbar", [Some(".."), Some(".."), None]);
+        t!(b: &b"a/b/c"[..], [Some("a"), Some("b"), Some("c")]);
+        t!(b: &b"/\xFF/a/\x80"[..], [None, Some("a"), None]);
+        t!(b: &b"../../foo\xCDbar"[..], [Some(".."), Some(".."), None]);
         // str_components is a wrapper around components, so no need to do
         // the full set of tests
     }

--- a/src/libstd/old_path/posix.rs
+++ b/src/libstd/old_path/posix.rs
@@ -632,9 +632,9 @@ mod tests {
             );
         }
 
-        t!(v: b"a/b/c", filename, Some(b"c"));
-        t!(v: b"a/b/c\xFF", filename, Some(b"c\xFF"));
-        t!(v: b"a/b\xFF/c", filename, Some(b"c"));
+        t!(v: b"a/b/c", filename, Some(&b"c"[..]));
+        t!(v: b"a/b/c\xFF", filename, Some(&b"c\xFF"[..]));
+        t!(v: b"a/b\xFF/c", filename, Some(&b"c"[..]));
         t!(s: "a/b/c", filename, Some("c"), opt);
         t!(s: "/a/b/c", filename, Some("c"), opt);
         t!(s: "a", filename, Some("a"), opt);
@@ -656,9 +656,9 @@ mod tests {
         t!(s: "..", dirname, "..");
         t!(s: "../..", dirname, "../..");
 
-        t!(v: b"hi/there.txt", filestem, Some(b"there"));
-        t!(v: b"hi/there\x80.txt", filestem, Some(b"there\x80"));
-        t!(v: b"hi/there.t\x80xt", filestem, Some(b"there"));
+        t!(v: b"hi/there.txt", filestem, Some(&b"there"[..]));
+        t!(v: b"hi/there\x80.txt", filestem, Some(&b"there\x80"[..]));
+        t!(v: b"hi/there.t\x80xt", filestem, Some(&b"there"[..]));
         t!(s: "hi/there.txt", filestem, Some("there"), opt);
         t!(s: "hi/there", filestem, Some("there"), opt);
         t!(s: "there.txt", filestem, Some("there"), opt);
@@ -672,9 +672,9 @@ mod tests {
         t!(s: "..", filestem, None, opt);
         t!(s: "../..", filestem, None, opt);
 
-        t!(v: b"hi/there.txt", extension, Some(b"txt"));
-        t!(v: b"hi/there\x80.txt", extension, Some(b"txt"));
-        t!(v: b"hi/there.t\x80xt", extension, Some(b"t\x80xt"));
+        t!(v: b"hi/there.txt", extension, Some(&b"txt"[..]));
+        t!(v: b"hi/there\x80.txt", extension, Some(&b"txt"[..]));
+        t!(v: b"hi/there.t\x80xt", extension, Some(&b"t\x80xt"[..]));
         t!(v: b"hi/there", extension, None);
         t!(v: b"hi/there\x80", extension, None);
         t!(s: "hi/there.txt", extension, Some("txt"), opt);
@@ -756,8 +756,8 @@ mod tests {
         t!(s: "a/b/c", ["d", "/e"], "/e");
         t!(s: "a/b/c", ["d", "/e", "f"], "/e/f");
         t!(s: "a/b/c", ["d".to_string(), "e".to_string()], "a/b/c/d/e");
-        t!(v: b"a/b/c", [b"d", b"e"], b"a/b/c/d/e");
-        t!(v: b"a/b/c", [b"d", b"/e", b"f"], b"/e/f");
+        t!(v: b"a/b/c", [&b"d"[..], &b"e"[..]], b"a/b/c/d/e");
+        t!(v: b"a/b/c", [&b"d"[..], &b"/e"[..], &b"f"[..]], b"/e/f");
         t!(v: b"a/b/c", [b"d".to_vec(), b"e".to_vec()], b"a/b/c/d/e");
     }
 
@@ -983,10 +983,10 @@ mod tests {
             )
         }
 
-        t!(v: Path::new(b"a/b/c"), Some(b"c"), b"a/b", Some(b"c"), None);
-        t!(v: Path::new(b"a/b/\xFF"), Some(b"\xFF"), b"a/b", Some(b"\xFF"), None);
-        t!(v: Path::new(b"hi/there.\xFF"), Some(b"there.\xFF"), b"hi",
-              Some(b"there"), Some(b"\xFF"));
+        t!(v: Path::new(b"a/b/c"), Some(&b"c"[..]), b"a/b", Some(&b"c"[..]), None);
+        t!(v: Path::new(b"a/b/\xFF"), Some(&b"\xFF"[..]), b"a/b", Some(&b"\xFF"[..]), None);
+        t!(v: Path::new(b"hi/there.\xFF"), Some(&b"there.\xFF"[..]), b"hi",
+              Some(&b"there"[..]), Some(&b"\xFF"[..]));
         t!(s: Path::new("a/b/c"), Some("c"), Some("a/b"), Some("c"), None);
         t!(s: Path::new("."), None, Some("."), None, None);
         t!(s: Path::new("/"), None, Some("/"), None, None);

--- a/src/libstd/old_path/windows.rs
+++ b/src/libstd/old_path/windows.rs
@@ -1217,8 +1217,8 @@ mod tests {
     fn test_paths() {
         let empty: &[u8] = &[];
         t!(v: Path::new(empty), b".");
-        t!(v: Path::new(b"\\"), b"\\");
-        t!(v: Path::new(b"a\\b\\c"), b"a\\b\\c");
+        t!(v: Path::new(&b"\\"[..]), b"\\");
+        t!(v: Path::new(&b"a\\b\\c"[..]), b"a\\b\\c");
 
         t!(s: Path::new(""), ".");
         t!(s: Path::new("\\"), "\\");
@@ -1250,8 +1250,8 @@ mod tests {
         t!(s: Path::new("foo\\..\\..\\.."), "..\\..");
         t!(s: Path::new("foo\\..\\..\\bar"), "..\\bar");
 
-        assert_eq!(Path::new(b"foo\\bar").into_vec(), b"foo\\bar");
-        assert_eq!(Path::new(b"\\foo\\..\\..\\bar").into_vec(), b"\\bar");
+        assert_eq!(Path::new(&b"foo\\bar"[..]).into_vec(), b"foo\\bar");
+        assert_eq!(Path::new(&b"\\foo\\..\\..\\bar"[..]).into_vec(), b"\\bar");
 
         t!(s: Path::new("\\\\a"), "\\a");
         t!(s: Path::new("\\\\a\\"), "\\a");
@@ -1304,9 +1304,9 @@ mod tests {
 
     #[test]
     fn test_opt_paths() {
-        assert!(Path::new_opt(b"foo\\bar\0") == None);
-        assert!(Path::new_opt(b"foo\\bar\x80") == None);
-        t!(v: Path::new_opt(b"foo\\bar").unwrap(), b"foo\\bar");
+        assert!(Path::new_opt(&b"foo\\bar\0"[..]) == None);
+        assert!(Path::new_opt(&b"foo\\bar\x80"[..]) == None);
+        t!(v: Path::new_opt(&b"foo\\bar"[..]).unwrap(), b"foo\\bar");
         assert!(Path::new_opt("foo\\bar\0") == None);
         t!(s: Path::new_opt("foo\\bar").unwrap(), "foo\\bar");
     }
@@ -1315,17 +1315,17 @@ mod tests {
     fn test_null_byte() {
         use thread;
         let result = thread::spawn(move|| {
-            Path::new(b"foo/bar\0");
+            Path::new(&b"foo/bar\0"[..]);
         }).join();
         assert!(result.is_err());
 
         let result = thread::spawn(move|| {
-            Path::new("test").set_filename(b"f\0o")
+            Path::new("test").set_filename(&b"f\0o"[..])
         }).join();
         assert!(result.is_err());
 
         let result = thread::spawn(move || {
-            Path::new("test").push(b"f\0o");
+            Path::new("test").push(&b"f\0o"[..]);
         }).join();
         assert!(result.is_err());
     }
@@ -1333,20 +1333,20 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_not_utf8_panics() {
-        Path::new(b"hello\x80.txt");
+        Path::new(&b"hello\x80.txt"[..]);
     }
 
     #[test]
     fn test_display_str() {
         let path = Path::new("foo");
         assert_eq!(path.display().to_string(), "foo");
-        let path = Path::new(b"\\");
+        let path = Path::new(&b"\\"[..]);
         assert_eq!(path.filename_display().to_string(), "");
 
         let path = Path::new("foo");
         let mo = path.display().as_cow();
         assert_eq!(mo, "foo");
-        let path = Path::new(b"\\");
+        let path = Path::new(&b"\\"[..]);
         let mo = path.filename_display().as_cow();
         assert_eq!(mo, "");
     }
@@ -1397,7 +1397,7 @@ mod tests {
             )
         }
 
-        t!(v: b"a\\b\\c", filename, Some(&b"c"[..]));
+        t!(v: &b"a\\b\\c"[..], filename, Some(&b"c"[..]));
         t!(s: "a\\b\\c", filename_str, "c");
         t!(s: "\\a\\b\\c", filename_str, "c");
         t!(s: "a", filename_str, "a");
@@ -1430,7 +1430,7 @@ mod tests {
         t!(s: "\\\\.\\", filename_str, None, opt);
         t!(s: "\\\\?\\a\\b\\", filename_str, "b");
 
-        t!(v: b"a\\b\\c", dirname, b"a\\b");
+        t!(v: &b"a\\b\\c"[..], dirname, b"a\\b");
         t!(s: "a\\b\\c", dirname_str, "a\\b");
         t!(s: "\\a\\b\\c", dirname_str, "\\a\\b");
         t!(s: "a", dirname_str, ".");
@@ -1461,7 +1461,7 @@ mod tests {
         t!(s: "\\\\.\\foo", dirname_str, "\\\\.\\foo");
         t!(s: "\\\\?\\a\\b\\", dirname_str, "\\\\?\\a");
 
-        t!(v: b"hi\\there.txt", filestem, Some(&b"there"[..]));
+        t!(v: &b"hi\\there.txt"[..], filestem, Some(&b"there"[..]));
         t!(s: "hi\\there.txt", filestem_str, "there");
         t!(s: "hi\\there", filestem_str, "there");
         t!(s: "there.txt", filestem_str, "there");
@@ -1476,8 +1476,8 @@ mod tests {
         t!(s: "..\\..", filestem_str, None, opt);
         // filestem is based on filename, so we don't need the full set of prefix tests
 
-        t!(v: b"hi\\there.txt", extension, Some(&b"txt"[..]));
-        t!(v: b"hi\\there", extension, None);
+        t!(v: &b"hi\\there.txt"[..], extension, Some(&b"txt"[..]));
+        t!(v: &b"hi\\there"[..], extension, None);
         t!(s: "hi\\there.txt", extension_str, Some("txt"), opt);
         t!(s: "hi\\there", extension_str, None, opt);
         t!(s: "there.txt", extension_str, Some("txt"), opt);
@@ -1603,9 +1603,9 @@ mod tests {
         t!(s: "a\\b\\c", ["d", "\\e"], "\\e");
         t!(s: "a\\b\\c", ["d", "\\e", "f"], "\\e\\f");
         t!(s: "a\\b\\c", ["d".to_string(), "e".to_string()], "a\\b\\c\\d\\e");
-        t!(v: b"a\\b\\c", [&b"d"[..], &b"e"[..]], b"a\\b\\c\\d\\e");
-        t!(v: b"a\\b\\c", [&b"d"[..], &b"\\e"[..], &b"f"[..]], b"\\e\\f");
-        t!(v: b"a\\b\\c", [b"d".to_vec(), b"e".to_vec()],
+        t!(v: &b"a\\b\\c"[..], [&b"d"[..], &b"e"[..]], b"a\\b\\c\\d\\e");
+        t!(v: &b"a\\b\\c"[..], [&b"d"[..], &b"\\e"[..], &b"f"[..]], b"\\e\\f");
+        t!(v: &b"a\\b\\c"[..], [b"d".to_vec(), b"e".to_vec()],
            b"a\\b\\c\\d\\e");
     }
 
@@ -1637,11 +1637,11 @@ mod tests {
         t!(s: ".", ".", false);
         t!(s: "\\a", "\\", true);
         t!(s: "\\", "\\", false);
-        t!(b: b"a\\b\\c", b"a\\b", true);
-        t!(b: b"a", b".", true);
-        t!(b: b".", b".", false);
-        t!(b: b"\\a", b"\\", true);
-        t!(b: b"\\", b"\\", false);
+        t!(b: &b"a\\b\\c"[..], b"a\\b", true);
+        t!(b: &b"a"[..], b".", true);
+        t!(b: &b"."[..], b".", false);
+        t!(b: &b"\\a"[..], b"\\", true);
+        t!(b: &b"\\"[..], b"\\", false);
 
         t!(s: "C:\\a\\b", "C:\\a", true);
         t!(s: "C:\\a", "C:\\", true);
@@ -1690,8 +1690,8 @@ mod tests {
         t!(s: Path::new("a\\b").join("\\c\\d"), "\\c\\d");
         t!(s: Path::new(".").join("a\\b"), "a\\b");
         t!(s: Path::new("\\").join("a\\b"), "\\a\\b");
-        t!(v: Path::new(b"a\\b\\c").join(b".."), b"a\\b");
-        t!(v: Path::new(b"\\a\\b\\c").join(b"d"), b"\\a\\b\\c\\d");
+        t!(v: Path::new(&b"a\\b\\c"[..]).join(&b".."[..]), b"a\\b");
+        t!(v: Path::new(&b"\\a\\b\\c"[..]).join(&b"d"[..]), b"\\a\\b\\c\\d");
         // full join testing is covered under test_push_path, so no need for
         // the full set of prefix tests
     }
@@ -1742,8 +1742,8 @@ mod tests {
         t!(s: "a\\b\\c", ["..", "d"], "a\\b\\d");
         t!(s: "a\\b\\c", ["d", "\\e", "f"], "\\e\\f");
         t!(s: "a\\b\\c", ["d".to_string(), "e".to_string()], "a\\b\\c\\d\\e");
-        t!(v: b"a\\b\\c", [b"d", b"e"], b"a\\b\\c\\d\\e");
-        t!(v: b"a\\b\\c", [b"d".to_vec(), b"e".to_vec()],
+        t!(v: &b"a\\b\\c"[..], [&b"d"[..], &b"e"[..]], b"a\\b\\c\\d\\e");
+        t!(v: &b"a\\b\\c"[..], [b"d".to_vec(), b"e".to_vec()],
            b"a\\b\\c\\d\\e");
     }
 
@@ -1855,15 +1855,15 @@ mod tests {
             )
         }
 
-        t!(v: b"a\\b\\c", set_filename, with_filename, b"d");
-        t!(v: b"\\", set_filename, with_filename, b"foo");
+        t!(v: &b"a\\b\\c"[..], set_filename, with_filename, &b"d"[..]);
+        t!(v: &b"\\"[..], set_filename, with_filename, &b"foo"[..]);
         t!(s: "a\\b\\c", set_filename, with_filename, "d");
         t!(s: "\\", set_filename, with_filename, "foo");
         t!(s: ".", set_filename, with_filename, "foo");
         t!(s: "a\\b", set_filename, with_filename, "");
         t!(s: "a", set_filename, with_filename, "");
 
-        t!(v: b"hi\\there.txt", set_extension, with_extension, b"exe");
+        t!(v: &b"hi\\there.txt"[..], set_extension, with_extension, &b"exe"[..]);
         t!(s: "hi\\there.txt", set_extension, with_extension, "exe");
         t!(s: "hi\\there.", set_extension, with_extension, "txt");
         t!(s: "hi\\there", set_extension, with_extension, "txt");
@@ -1898,7 +1898,7 @@ mod tests {
             )
         }
 
-        t!(v: Path::new(b"a\\b\\c"), Some(&b"c"[..]), b"a\\b", Some(&b"c"[..]), None);
+        t!(v: Path::new(&b"a\\b\\c"[..]), Some(&b"c"[..]), b"a\\b", Some(&b"c"[..]), None);
         t!(s: Path::new("a\\b\\c"), Some("c"), Some("a\\b"), Some("c"), None);
         t!(s: Path::new("."), None, Some("."), None, None);
         t!(s: Path::new("\\"), None, Some("\\"), None, None);
@@ -2240,7 +2240,7 @@ mod tests {
             );
         }
 
-        t!(s: b"a\\b\\c", ["a", "b", "c"]);
+        t!(s: &b"a\\b\\c"[..], ["a", "b", "c"]);
         t!(s: "a\\b\\c", ["a", "b", "c"]);
         t!(s: "a\\b\\d", ["a", "b", "d"]);
         t!(s: "a\\b\\cd", ["a", "b", "cd"]);

--- a/src/libstd/old_path/windows.rs
+++ b/src/libstd/old_path/windows.rs
@@ -1397,7 +1397,7 @@ mod tests {
             )
         }
 
-        t!(v: b"a\\b\\c", filename, Some(b"c"));
+        t!(v: b"a\\b\\c", filename, Some(&b"c"[..]));
         t!(s: "a\\b\\c", filename_str, "c");
         t!(s: "\\a\\b\\c", filename_str, "c");
         t!(s: "a", filename_str, "a");
@@ -1461,7 +1461,7 @@ mod tests {
         t!(s: "\\\\.\\foo", dirname_str, "\\\\.\\foo");
         t!(s: "\\\\?\\a\\b\\", dirname_str, "\\\\?\\a");
 
-        t!(v: b"hi\\there.txt", filestem, Some(b"there"));
+        t!(v: b"hi\\there.txt", filestem, Some(&b"there"[..]));
         t!(s: "hi\\there.txt", filestem_str, "there");
         t!(s: "hi\\there", filestem_str, "there");
         t!(s: "there.txt", filestem_str, "there");
@@ -1476,7 +1476,7 @@ mod tests {
         t!(s: "..\\..", filestem_str, None, opt);
         // filestem is based on filename, so we don't need the full set of prefix tests
 
-        t!(v: b"hi\\there.txt", extension, Some(b"txt"));
+        t!(v: b"hi\\there.txt", extension, Some(&b"txt"[..]));
         t!(v: b"hi\\there", extension, None);
         t!(s: "hi\\there.txt", extension_str, Some("txt"), opt);
         t!(s: "hi\\there", extension_str, None, opt);
@@ -1603,8 +1603,8 @@ mod tests {
         t!(s: "a\\b\\c", ["d", "\\e"], "\\e");
         t!(s: "a\\b\\c", ["d", "\\e", "f"], "\\e\\f");
         t!(s: "a\\b\\c", ["d".to_string(), "e".to_string()], "a\\b\\c\\d\\e");
-        t!(v: b"a\\b\\c", [b"d", b"e"], b"a\\b\\c\\d\\e");
-        t!(v: b"a\\b\\c", [b"d", b"\\e", b"f"], b"\\e\\f");
+        t!(v: b"a\\b\\c", [&b"d"[..], &b"e"[..]], b"a\\b\\c\\d\\e");
+        t!(v: b"a\\b\\c", [&b"d"[..], &b"\\e"[..], &b"f"[..]], b"\\e\\f");
         t!(v: b"a\\b\\c", [b"d".to_vec(), b"e".to_vec()],
            b"a\\b\\c\\d\\e");
     }
@@ -1898,7 +1898,7 @@ mod tests {
             )
         }
 
-        t!(v: Path::new(b"a\\b\\c"), Some(b"c"), b"a\\b", Some(b"c"), None);
+        t!(v: Path::new(b"a\\b\\c"), Some(&b"c"[..]), b"a\\b", Some(&b"c"[..]), None);
         t!(s: Path::new("a\\b\\c"), Some("c"), Some("a\\b"), Some("c"), None);
         t!(s: Path::new("."), None, Some("."), None, None);
         t!(s: Path::new("\\"), None, Some("\\"), None, None);

--- a/src/test/run-pass/byte-literals.rs
+++ b/src/test/run-pass/byte-literals.rs
@@ -58,13 +58,12 @@ pub fn main() {
         _ => panic!(),
     }
 
-    // FIXME: There are no DST coercions &[T; N] -> &[T] in patterns
-    // let buf = vec!(97u8, 98, 99, 100);
-    // assert_eq!(match &buf[0..3] {
-    //      b"def" => 1_usize,
-    //      b"abc" => 2_usize,
-    //      _ => 3_usize
-    // }, 2);
+    let buf = vec!(97u8, 98, 99, 100);
+    assert_eq!(match &buf[0..3] {
+         b"def" => 1,
+         b"abc" => 2,
+         _ => 3
+    }, 2);
 
     let expected: &[_] = &[97u8, 92u8, 110u8];
     assert_eq!(BAZ, expected);

--- a/src/test/run-pass/byte-literals.rs
+++ b/src/test/run-pass/byte-literals.rs
@@ -13,9 +13,13 @@
 
 static FOO: u8 = b'\xF0';
 static BAR: &'static [u8] = b"a\xF0\t";
+static BAR_FIXED: &'static [u8; 3] = b"a\xF0\t";
 static BAZ: &'static [u8] = br"a\n";
 
 pub fn main() {
+    let bar: &'static [u8] = b"a\xF0\t";
+    let bar_fixed: &'static [u8; 3] = b"a\xF0\t";
+
     assert_eq!(b'a', 97u8);
     assert_eq!(b'\n', 10u8);
     assert_eq!(b'\r', 13u8);
@@ -44,19 +48,23 @@ pub fn main() {
                  b", expected);
     let expected: &[_] = &[97u8, 240u8, 9u8];
     assert_eq!(BAR, expected);
+    assert_eq!(BAR_FIXED, expected);
+    assert_eq!(bar, expected);
+    assert_eq!(bar_fixed, expected);
 
-    let val: &[_] = &[97u8, 10u8];
+    let val = &[97u8, 10u8];
     match val {
         b"a\n" => {},
         _ => panic!(),
     }
 
-    let buf = vec!(97u8, 98, 99, 100);
-    assert_eq!(match &buf[0..3] {
-         b"def" => 1_usize,
-         b"abc" => 2_usize,
-         _ => 3_usize
-    }, 2);
+    // FIXME: There are no DST coercions &[T; N] -> &[T] in patterns
+    // let buf = vec!(97u8, 98, 99, 100);
+    // assert_eq!(match &buf[0..3] {
+    //      b"def" => 1_usize,
+    //      b"abc" => 2_usize,
+    //      _ => 3_usize
+    // }, 2);
 
     let expected: &[_] = &[97u8, 92u8, 110u8];
     assert_eq!(BAZ, expected);

--- a/src/test/run-pass/issue-17233.rs
+++ b/src/test/run-pass/issue-17233.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const X1: &'static [u8] = &[b'1'];
+const X2: &'static [u8] = b"1";
+const X3: &'static [u8; 1] = &[b'1'];
+const X4: &'static [u8; 1] = b"1";
+
+static Y1: u8 = X1[0];
+static Y2: u8 = X2[0];
+static Y3: u8 = X3[0];
+static Y4: u8 = X4[0];
+
+fn main() {
+    assert_eq!(Y1, Y2);
+    assert_eq!(Y1, Y3);
+    assert_eq!(Y1, Y4);
+}

--- a/src/test/run-pass/rename-directory.rs
+++ b/src/test/run-pass/rename-directory.rs
@@ -32,11 +32,11 @@ fn rename_directory() {
 
         /* Write the temp input file */
         let fromp = CString::new(test_file.as_vec()).unwrap();
-        let modebuf = CString::new(b"w+b").unwrap();
+        let modebuf = CString::new(&b"w+b"[..]).unwrap();
         let ostream = libc::fopen(fromp.as_ptr(), modebuf.as_ptr());
         assert!((ostream as uint != 0));
         let s = "hello".to_string();
-        let buf = CString::new(b"hello").unwrap();
+        let buf = CString::new(&b"hello"[..]).unwrap();
         let write_len = libc::fwrite(buf.as_ptr() as *mut _,
                                      1_usize as libc::size_t,
                                      (s.len() + 1_usize) as libc::size_t,

--- a/src/test/run-pass/variadic-ffi.rs
+++ b/src/test/run-pass/variadic-ffi.rs
@@ -28,11 +28,11 @@ pub fn main() {
 
     unsafe {
         // Call with just the named parameter
-        let c = CString::new(b"Hello World\n").unwrap();
+        let c = CString::new(&b"Hello World\n"[..]).unwrap();
         check("Hello World\n", |s| sprintf(s, c.as_ptr()));
 
         // Call with variable number of arguments
-        let c = CString::new(b"%d %f %c %s\n").unwrap();
+        let c = CString::new(&b"%d %f %c %s\n"[..]).unwrap();
         check("42 42.500000 a %d %f %c %s\n\n", |s| {
             sprintf(s, c.as_ptr(), 42, 42.5f64, 'a' as c_int, c.as_ptr());
         });
@@ -43,11 +43,11 @@ pub fn main() {
         // A function that takes a function pointer
         unsafe fn call(p: unsafe extern fn(*mut c_char, *const c_char, ...) -> c_int) {
             // Call with just the named parameter
-            let c = CString::new(b"Hello World\n").unwrap();
+            let c = CString::new(&b"Hello World\n"[..]).unwrap();
             check("Hello World\n", |s| sprintf(s, c.as_ptr()));
 
             // Call with variable number of arguments
-            let c = CString::new(b"%d %f %c %s\n").unwrap();
+            let c = CString::new(&b"%d %f %c %s\n"[..]).unwrap();
             check("42 42.500000 a %d %f %c %s\n\n", |s| {
                 sprintf(s, c.as_ptr(), 42, 42.5f64, 'a' as c_int, c.as_ptr());
             });


### PR DESCRIPTION
This patch changes the type of byte string literals from `&[u8]` to `&[u8; N]`.
It also implements some necessary traits (`IntoBytes`, `Seek`, `Read`, `BufRead`) for fixed-size arrays (also related to #21725) and adds test for #17233, which seems to be resolved.

Fixes #18465
[breaking-change]
