### PR TITLE
fixing a few bitrig build breakers

### DIFF
--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -291,29 +291,14 @@ fn mkstat(stat: &libc::stat) -> FileStat {
     // FileStat times are in milliseconds
     fn mktime(secs: u64, nsecs: u64) -> u64 { secs * 1000 + nsecs / 1000000 }
 
-    #[cfg(target_os = "bitrig")]
-    fn ctime(stat: &libc::stat) -> u64 {
-      mktime(stat.st_ctim.tv_sec as u64, stat.st_ctim.tv_nsec as u64)
-    }
-    #[cfg(not(target_os = "bitrig"))]
     fn ctime(stat: &libc::stat) -> u64 {
       mktime(stat.st_ctime as u64, stat.st_ctime_nsec as u64)
     }
 
-    #[cfg(target_os = "bitrig")]
-    fn atime(stat: &libc::stat) -> u64 {
-      mktime(stat.st_atim.tv_sec as u64, stat.st_atim.tv_nsec as u64)
-    }
-    #[cfg(not(target_os = "bitrig"))]
     fn atime(stat: &libc::stat) -> u64 {
       mktime(stat.st_atime as u64, stat.st_atime_nsec as u64)
     }
 
-    #[cfg(target_os = "bitrig")]
-    fn mtime(stat: &libc::stat) -> u64 {
-      mktime(stat.st_mtim.tv_sec as u64, stat.st_mtim.tv_nsec as u64)
-    }
-    #[cfg(not(target_os = "bitrig"))]
     fn mtime(stat: &libc::stat) -> u64 {
       mktime(stat.st_mtime as u64, stat.st_mtime_nsec as u64)
     }

--- a/src/libstd/sys/unix/process2.rs
+++ b/src/libstd/sys/unix/process2.rs
@@ -439,6 +439,7 @@ fn translate_status(status: c_int) -> ExitStatus {
               target_os = "ios",
               target_os = "freebsd",
               target_os = "dragonfly",
+              target_os = "bitrig",
               target_os = "openbsd"))]
     mod imp {
         pub fn WIFEXITED(status: i32) -> bool { (status & 0x7f) == 0 }


### PR DESCRIPTION
This patch contains a couple time fixes to make Rust compile on Bitrig again.  This does not affect OpenBSD.
