### PR TITLE
Implement proper file closing

### DIFF
--- a/src/libstd/fs/mod.rs
+++ b/src/libstd/fs/mod.rs
@@ -126,6 +126,14 @@ impl File {
         OpenOptions::new().write(true).create(true).truncate(true).open(path)
     }
 
+    /// Close the file.
+    ///
+    /// Use this function if you want to avoid panicking when the destructor of
+    /// the file is run.
+    pub fn close(self) -> io::Result<()> {
+        self.inner.close()
+    }
+
     /// Returns the original path that was used to open this file.
     pub fn path(&self) -> Option<&Path> {
         Some(&self.path)
@@ -262,8 +270,8 @@ impl OpenOptions {
     ///
     /// * Opening a file that does not exist with read access.
     /// * Attempting to open a file with access that the user lacks
-    ///   permissions for
-    /// * Filesystem-level errors (full disk, etc)
+    ///   permissions for.
+    /// * Filesystem-level errors (full disk, etc).
     pub fn open<P: AsPath + ?Sized>(&self, path: &P) -> io::Result<File> {
         let path = path.as_path();
         let inner = try!(fs_imp::File::open(path, &self.0));
@@ -273,7 +281,7 @@ impl OpenOptions {
         // tradition before the introduction of opendir(3).  We explicitly
         // reject it because there are few use cases.
         if cfg!(not(any(target_os = "linux", target_os = "android"))) &&
-           try!(inner.file_attr()).is_dir() {
+            try!(inner.file_attr()).is_dir() {
             Err(Error::new(ErrorKind::InvalidInput, "is a directory", None))
         } else {
             Ok(File { path: path.to_path_buf(), inner: inner })

--- a/src/libstd/sys/unix/fd.rs
+++ b/src/libstd/sys/unix/fd.rs
@@ -26,6 +26,26 @@ impl FileDesc {
         FileDesc { fd: fd }
     }
 
+    pub fn close(self) -> io::Result<()> {
+        let fd = self.fd;
+        // Don't run the destructor after running the `close` function.
+        unsafe { mem::forget(self) };
+
+        // Closing stdio file handles makes no sense, so never do it. Note that
+        // this is relied upon in the destructor.
+        if fd <= libc::STDERR_FILENO {
+            return Ok(());
+        }
+
+        // Also, note that closing the file descriptor is never retried on
+        // error. The reason for this is that if an error occurs, we don't
+        // actually know if the file descriptor was closed or not, and if we
+        // retried (for something like EINTR), we might close another valid
+        // file descriptor (opened after we closed ours).
+        try!(cvt(unsafe { libc::close(fd) }));
+        Ok(())
+    }
+
     pub fn raw(&self) -> c_int { self.fd }
 
     /// Extract the actual filedescriptor without closing it.
@@ -60,14 +80,8 @@ impl AsInner<c_int> for FileDesc {
 
 impl Drop for FileDesc {
     fn drop(&mut self) {
-        // closing stdio file handles makes no sense, so never do it. Also, note
-        // that errors are ignored when closing a file descriptor. The reason
-        // for this is that if an error occurs we don't actually know if the
-        // file descriptor was closed or not, and if we retried (for something
-        // like EINTR), we might close another valid file descriptor (opened
-        // after we closed ours.
-        if self.fd > libc::STDERR_FILENO {
-            let _ = unsafe { libc::close(self.fd) };
-        }
+        // Close the file descriptor.
+        let fd = mem::replace(self, FileDesc::new(libc::STDIN_FILENO));
+        fd.close().unwrap();
     }
 }

--- a/src/libstd/sys/unix/fs2.rs
+++ b/src/libstd/sys/unix/fs2.rs
@@ -218,6 +218,10 @@ impl File {
         Ok(File(FileDesc::new(fd)))
     }
 
+    pub fn close(self) -> io::Result<()> {
+        self.0.close()
+    }
+
     pub fn file_attr(&self) -> io::Result<FileAttr> {
         let mut stat: libc::stat = unsafe { mem::zeroed() };
         try!(cvt(unsafe { libc::fstat(self.0.raw(), &mut stat) }));


### PR DESCRIPTION
If you don't want to panic in the destructor, you can implement a wrapper
struct that logs the error or similar. By making the explicit error the
default, the user is forced to make an active decision about how they deal with
errors on file closing.
