### PR TITLE
std: Don't accidentally truncate *T formatting

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -715,7 +715,7 @@ impl Display for char {
 impl<T> Pointer for *const T {
     fn fmt(&self, f: &mut Formatter) -> Result {
         f.flags |= 1 << (FlagV1::Alternate as u32);
-        let ret = LowerHex::fmt(&(*self as u32), f);
+        let ret = LowerHex::fmt(&(*self as usize), f);
         f.flags &= !(1 << (FlagV1::Alternate as u32));
         ret
     }


### PR DESCRIPTION
Just a mistaken u32 cast instead of usize

Closes #22854
