### PR TITLE
std: Draw from the same port pool during tests

### DIFF
--- a/src/libstd/net/test.rs
+++ b/src/libstd/net/test.rs
@@ -14,14 +14,14 @@ use env;
 use net::{SocketAddr, IpAddr};
 use sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 
+static PORT: AtomicUsize = ATOMIC_USIZE_INIT;
+
 pub fn next_test_ip4() -> SocketAddr {
-    static PORT: AtomicUsize = ATOMIC_USIZE_INIT;
     SocketAddr::new(IpAddr::new_v4(127, 0, 0, 1),
                     PORT.fetch_add(1, Ordering::SeqCst) as u16 + base_port())
 }
 
 pub fn next_test_ip6() -> SocketAddr {
-    static PORT: AtomicUsize = ATOMIC_USIZE_INIT;
     SocketAddr::new(IpAddr::new_v6(0, 0, 0, 0, 0, 0, 0, 1),
                     PORT.fetch_add(1, Ordering::SeqCst) as u16 + base_port())
 }


### PR DESCRIPTION
Instead of allocating the same ports for ipv4 and ipv6 tests, instead draw all
ports from the same pool. Some tests connect to just "localhost" on a particular
port which may accidentally be interacting with other tests as the ipv-what-ness
isn't specified with the string "localhost"

Relevant logs:
- [Deadlock of the `net::tcp::tests::listen_localhost` test](https://gist.github.com/alexcrichton/349c7ce7c620c1adb2f2)
- [Failure of the `fast_rebind` test](https://gist.github.com/alexcrichton/7e3611faae2e1edaee6f)
- [Failure of `multiple_connect_interleaved_lazy_schedule_ip4`](https://gist.github.com/alexcrichton/4f5f87749af3ad0f9851)
