### PR TITLE
impl Clone for Command

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -117,6 +117,7 @@ impl Read for ChildStderr {
 /// });
 /// let hello = output.stdout;
 /// ```
+#[derive(Clone)]
 pub struct Command {
     inner: CommandImp,
 


### PR DESCRIPTION
[dejavu](https://github.com/rust-lang/rust/pull/15566)

Both (unix/windows) underlying `Command` implementations are already `Clone`.

r? @alexcrichton 
