### PR TITLE
Update expected output of `rustc --version` in TRPL

### DIFF
--- a/src/doc/trpl/installing-rust.md
+++ b/src/doc/trpl/installing-rust.md
@@ -70,10 +70,10 @@ If you've got Rust installed, you can open up a shell, and type this:
 $ rustc --version
 ```
 
-You should see some output that looks something like this:
+You should see the version number, commit hash, commit date and build date:
 
 ```bash
-rustc 1.0.0-nightly (f11f3e7ba 2015-01-04 20:02:14 +0000)
+rustc 1.0.0-nightly (f11f3e7ba 2015-01-04) (built 2015-01-06)
 ```
 
 If you did, Rust has been installed successfully! Congrats!


### PR DESCRIPTION
The format of `rustc --version` was changed in #21957; this PR updates TRPL accordingly.
