### PR TITLE
std: Deprecated the `old_io::extensions` module

### DIFF
--- a/src/libstd/old_io/extensions.rs
+++ b/src/libstd/old_io/extensions.rs
@@ -11,6 +11,10 @@
 //! Utility mixins that apply to all Readers and Writers
 
 #![allow(missing_docs)]
+#![unstable(feature = "old_io")]
+#![deprecated(since = "1.0.0",
+              reason = "functionality will be removed with no immediate \
+                        replacement")]
 
 // FIXME: Not sure how this should be structured
 // FIXME: Iteration should probably be considered separately


### PR DESCRIPTION
The `u64_from_be_bytes` and `u64_to_be_bytes` functions are being deprecated
with no replacement for now.

[breaking-change]
