### PR TITLE
obsolete `|&:|` syntax

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -3752,9 +3752,9 @@ An example of creating and calling a closure:
 ```rust
 let captured_var = 10;
 
-let closure_no_args = |&:| println!("captured_var={}", captured_var);
+let closure_no_args = || println!("captured_var={}", captured_var);
 
-let closure_args = |&: arg: i32| -> i32 {
+let closure_args = |arg: i32| -> i32 {
   println!("captured_var={}, arg={}", captured_var, arg);
   arg // Note lack of semicolon after 'arg'
 };

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -257,7 +257,7 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
             }
           }
           (Ok(const_int(a)), Ok(const_int(b))) => {
-            let is_a_min_value = |&:| {
+            let is_a_min_value = || {
                 let int_ty = match ty::expr_ty_opt(tcx, e).map(|ty| &ty.sty) {
                     Some(&ty::ty_int(int_ty)) => int_ty,
                     _ => return false

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -45,7 +45,7 @@ fn iterate_over_potentially_unsafe_regions_in_type<'a, 'tcx>(
     scope: region::CodeExtent,
     depth: uint)
 {
-    let origin = |&:| infer::SubregionOrigin::SafeDestructor(span);
+    let origin = || infer::SubregionOrigin::SafeDestructor(span);
     let mut walker = ty_root.walk();
     let opt_phantom_data_def_id = rcx.tcx().lang_items.phantom_data();
 

--- a/src/libstd/sys/unix/process2.rs
+++ b/src/libstd/sys/unix/process2.rs
@@ -274,7 +274,7 @@ impl Process {
                 // file descriptor. Otherwise, the first file descriptor opened
                 // up in the child would be numbered as one of the stdio file
                 // descriptors, which is likely to wreak havoc.
-                let setup = |&: src: Option<AnonPipe>, dst: c_int| {
+                let setup = |src: Option<AnonPipe>, dst: c_int| {
                     let src = match src {
                         None => {
                             let flags = if dst == libc::STDIN_FILENO {

--- a/src/libstd/sys/windows/process2.rs
+++ b/src/libstd/sys/windows/process2.rs
@@ -160,7 +160,7 @@ impl Process {
             // Similarly to unix, we don't actually leave holes for the stdio file
             // descriptors, but rather open up /dev/null equivalents. These
             // equivalents are drawn from libuv's windows process spawning.
-            let set_fd = |&: fd: &Option<AnonPipe>, slot: &mut HANDLE,
+            let set_fd = |fd: &Option<AnonPipe>, slot: &mut HANDLE,
                           is_stdin: bool| {
                 match *fd {
                     None => {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1163,7 +1163,6 @@ impl<'a> Parser<'a> {
         {
             self.bump();
             self.bump();
-            return;
         } else if
             self.eat(&token::Colon)
         {

--- a/src/test/parse-fail/obsolete-closure-kind.rs
+++ b/src/test/parse-fail/obsolete-closure-kind.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that we generate obsolete syntax errors around usages of closure kinds: `|:|`, `|&:|` and
+// `|&mut:|`.
+
+fn main() {
+    let a = |:| {};  //~ ERROR obsolete syntax: `:`, `&mut:`, or `&:`
+    let a = |&:| {};  //~ ERROR obsolete syntax: `:`, `&mut:`, or `&:`
+    let a = |&mut:| {};  //~ ERROR obsolete syntax: `:`, `&mut:`, or `&:`
+}


### PR DESCRIPTION
This is leftover from #21843

If you still have `|&:| {}` closures in your code, simply remove the `&:` part.

[breaking-change]
