### PR TITLE
Fix {:p} truncating pointers to 32 bits

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -700,7 +700,7 @@ impl Display for char {
 impl<T> Pointer for *const T {
     fn fmt(&self, f: &mut Formatter) -> Result {
         f.flags |= 1 << (FlagV1::Alternate as u32);
-        let ret = LowerHex::fmt(&(*self as u32), f);
+        let ret = LowerHex::fmt(&(*self as usize), f);
         f.flags &= !(1 << (FlagV1::Alternate as u32));
         ret
     }

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -137,6 +137,13 @@ pub fn main() {
     t!(format!("{:+10.3e}", 1.2345e6f64),  "  +1.234e6");
     t!(format!("{:+10.3e}", -1.2345e6f64), "  -1.234e6");
 
+    // Test that pointers don't get truncated.
+    {
+        let val = usize::MAX;
+        let exp = format!("{:#x}", val);
+        t!(format!("{:p}", val as *const isize), exp);
+    }
+
     // Escaping
     t!(format!("{{"), "{");
     t!(format!("}}"), "}");


### PR DESCRIPTION
A misplaced uint->u32 instead of usize in fmt::Pointer. Added a basic test.
