### PR TITLE
openbsd: adjust page guard address

### DIFF
--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -164,7 +164,7 @@ pub mod guard {
 
         if pthread_main_np() == 1 {
             // main thread
-            current_stack.ss_sp as uint - current_stack.ss_size as uint + 3 * PAGE_SIZE as uint
+            current_stack.ss_sp as uint - current_stack.ss_size as uint + PAGE_SIZE as uint
 
         } else {
             // new thread


### PR DESCRIPTION
some commits in OpenBSD OS have corrected a problem of stack position.
Now, we can adjust more accurately the page guard in rust.

@dhuseby I am not sure that bitrig have already integrated these changes (the `$OpenBSD$` header in sys/kern/kern_exec.c is too old). But when they do, you may want this patch too.
