### PR TITLE
Change slithtly -> slightly in README.md

### DIFF
--- a/src/doc/intro.md
+++ b/src/doc/intro.md
@@ -511,7 +511,7 @@ numbers[0] is 2
 ```
 
 Each time, we can get a slightly different output because the threads are not
-quaranteed to run in any set order. If you get the same order every time it is
+guaranteed to run in any set order. If you get the same order every time it is
 because each of these threads are very small and complete too fast for their
 indeterminate behavior to surface.
 

--- a/src/doc/intro.md
+++ b/src/doc/intro.md
@@ -510,10 +510,10 @@ numbers[1] is 3
 numbers[0] is 2
 ```
 
-Each time, we can get a slithtly different output because the threads
-are not quaranteed to run in any set order. If you get the same order
-every time it is because each of these threads are very small and
-complete too fast for their indeterminate behavior to surface.
+Each time, we can get a slightly different output because the threads are not
+quaranteed to run in any set order. If you get the same order every time it is
+because each of these threads are very small and complete too fast for their
+indeterminate behavior to surface.
 
 The important part here is that the Rust compiler was able to use ownership to
 give us assurance _at compile time_ that we weren't doing something incorrect


### PR DESCRIPTION
Typo fix for the "30 Minute Intro".

CONTRIBUTING guide says I should do this:

r? @steveklabnik
