### PR TITLE
Error out when using static_assert on a non-boolean value

### DIFF
--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2332,6 +2332,11 @@ pub fn trans_item(ccx: &CrateContext, item: &ast::Item) {
           // Do static_assert checking. It can't really be done much earlier
           // because we need to get the value of the bool out of LLVM
           if attr::contains_name(&item.attrs, "static_assert") {
+              if !ty::type_is_bool(ty::expr_ty(ccx.tcx(), expr)) {
+                  ccx.sess().span_fatal(expr.span,
+                                        "can only have static_assert on a static \
+                                         with type `bool`");
+              }
               if m == ast::MutMutable {
                   ccx.sess().span_fatal(expr.span,
                                         "cannot have static_assert on a mutable \

--- a/src/test/compile-fail/nonbool_static_assert.rs
+++ b/src/test/compile-fail/nonbool_static_assert.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+
+#[static_assert]
+static E: i32 = 1; //~ ERROR can only have static_assert on a static with type `bool`
+
+fn main() {}


### PR DESCRIPTION
static_assert is documented as working on static with type `bool`, but
we currently accept it on any const static and crash when the const has
an non-integral type.

This is a breaking-change for anyone who used static_assert on types
likes i32, which happened to work but seems like an unintended
consequence of the missing error checking.

[breaking-change]

Fixes #22056
