### PR TITLE
Fix incorrectly parsed markdown link

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1455,9 +1455,9 @@ pub trait StrExt: Index<RangeFull, Output = str> {
     ///
     /// `is_cjk` determines behavior for characters in the Ambiguous category: if `is_cjk` is
     /// `true`, these are 2 columns wide; otherwise, they are 1. In CJK locales, `is_cjk` should be
-    /// `true`, else it should be `false`. [Unicode Standard Annex
-    /// #11](http://www.unicode.org/reports/tr11/) recommends that these characters be treated as 1
-    /// column (i.e., `is_cjk` = `false`) if the locale is unknown.
+    /// `true`, else it should be `false`.
+    /// [Unicode Standard Annex #11](http://www.unicode.org/reports/tr11/) recommends that these
+    /// characters be treated as 1 column (i.e., `is_cjk = false`) if the locale is unknown.
     #[unstable(feature = "collections",
                reason = "this functionality may only be provided by libunicode")]
     fn width(&self, is_cjk: bool) -> usize {


### PR DESCRIPTION
The markdown listing the link in [StrExt::width](http://doc.rust-lang.org/std/str/trait.StrExt.html#tymethod.width) isn't being parsed properly. I'm expecting it's because the `[ ]` is across 2 lines so this changes that. This is untested though.
