### PR TITLE
Re-enable -Z time-llvm-passes when using a single codegen unit

### DIFF
--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -851,7 +851,9 @@ pub fn run_passes(sess: &Session,
 
     // FIXME: time_llvm_passes support - does this use a global context or
     // something?
-    //if sess.time_llvm_passes() { llvm::LLVMRustPrintPassTimings(); }
+    if sess.opts.cg.codegen_units == 1 && sess.time_llvm_passes() {
+        unsafe { llvm::LLVMRustPrintPassTimings(); }
+    }
 }
 
 struct WorkItem {


### PR DESCRIPTION
The timing code break when using multiple codegen units, but that
shouldn't stop us from using it with a single codegen unit.
