### PR TITLE
std::net: lookup_host_as_family

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -2304,6 +2304,7 @@ pub mod consts {
         pub mod bsd44 {
             use types::os::arch::c95::c_int;
 
+            pub const AF_UNSPEC: c_int = 0;
             pub const AF_INET: c_int = 2;
             pub const AF_INET6: c_int = 23;
             pub const SOCK_STREAM: c_int = 1;
@@ -3196,6 +3197,7 @@ pub mod consts {
 
             pub const IFF_LOOPBACK: c_int = 0x8;
 
+            pub const AF_UNSPEC: c_int = 0;
             pub const AF_UNIX: c_int = 1;
             pub const AF_INET: c_int = 2;
             pub const AF_INET6: c_int = 10;
@@ -3242,6 +3244,7 @@ pub mod consts {
             pub const MADV_UNMERGEABLE : c_int = 13;
             pub const MADV_HWPOISON : c_int = 100;
 
+            pub const AF_UNSPEC: c_int = 0;
             pub const AF_UNIX: c_int = 1;
             pub const AF_INET: c_int = 2;
             pub const AF_INET6: c_int = 10;
@@ -3732,6 +3735,7 @@ pub mod consts {
             pub const MINCORE_MODIFIED_OTHER : c_int = 0x10;
             pub const MINCORE_SUPER : c_int = 0x20;
 
+            pub const AF_UNSPEC: c_int = 0;
             pub const AF_INET: c_int = 2;
             pub const AF_INET6: c_int = 28;
             pub const AF_UNIX: c_int = 1;
@@ -4114,6 +4118,7 @@ pub mod consts {
             pub const MADV_DONTNEED : c_int = 4;
             pub const MADV_FREE : c_int = 6;
 
+            pub const AF_UNSPEC: c_int = 0;
             pub const AF_UNIX: c_int = 1;
             pub const AF_INET: c_int = 2;
             pub const AF_INET6: c_int = 24;
@@ -4511,6 +4516,7 @@ pub mod consts {
             pub const MINCORE_REFERENCED_OTHER : c_int = 0x8;
             pub const MINCORE_MODIFIED_OTHER : c_int = 0x10;
 
+            pub const AF_UNSPEC: c_int = 0;
             pub const AF_UNIX: c_int = 1;
             pub const AF_INET: c_int = 2;
             pub const AF_INET6: c_int = 30;

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -41,6 +41,15 @@ pub enum Ipv6MulticastScope {
     Global
 }
 
+/// IP address family: IPv4 or IPv6
+#[derive(Copy, PartialEq, Eq, Clone, Hash, Debug)]
+pub enum IpAddrFamily {
+    /// IPv4
+    V4,
+    /// IPv6
+    V6
+}
+
 /// Enumeration of possible IP addresses
 #[derive(Copy, PartialEq, Eq, Clone, Hash, Debug)]
 pub enum IpAddr {
@@ -64,6 +73,14 @@ impl IpAddr {
     pub fn new_v6(a: u16, b: u16, c: u16, d: u16, e: u16, f: u16, g: u16,
                   h: u16) -> IpAddr {
         IpAddr::V6(Ipv6Addr::new(a, b, c, d, e, f, g, h))
+    }
+
+    /// Get address family for the address.
+    pub fn family(&self) -> IpAddrFamily {
+        match *self {
+            IpAddr::V4(..) => IpAddrFamily::V4,
+            IpAddr::V6(..) => IpAddrFamily::V6,
+        }
     }
 }
 
@@ -447,5 +464,17 @@ impl AsInner<libc::in6_addr> for Ipv6Addr {
 impl FromInner<libc::in6_addr> for Ipv6Addr {
     fn from_inner(addr: libc::in6_addr) -> Ipv6Addr {
         Ipv6Addr { inner: addr }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prelude::v1::*;
+    use net::*;
+
+    #[test]
+    fn ip_addr_get_family() {
+        assert_eq!(IpAddrFamily::V4, IpAddr::new_v4(10, 20, 30, 40).family());
+        assert_eq!(IpAddrFamily::V6, IpAddr::new_v6(10, 20, 30, 40, 50, 60, 70, 80).family());
     }
 }

--- a/src/libstd/net/mod.rs
+++ b/src/libstd/net/mod.rs
@@ -22,7 +22,7 @@ use io::{self, Error, ErrorKind};
 use num::Int;
 use sys_common::net2 as net_imp;
 
-pub use self::ip::{IpAddr, Ipv4Addr, Ipv6Addr, Ipv6MulticastScope};
+pub use self::ip::{IpAddr, IpAddrFamily, Ipv4Addr, Ipv6Addr, Ipv6MulticastScope};
 pub use self::addr::{SocketAddr, ToSocketAddrs};
 pub use self::tcp::{TcpStream, TcpListener};
 pub use self::udp::UdpSocket;

--- a/src/libstd/net/mod.rs
+++ b/src/libstd/net/mod.rs
@@ -97,3 +97,16 @@ impl Iterator for LookupHost {
 pub fn lookup_host(host: &str) -> io::Result<LookupHost> {
     net_imp::lookup_host(host).map(LookupHost)
 }
+
+#[cfg(test)]
+mod test_of_this {
+    use prelude::v1::*;
+    use net;
+
+    #[test]
+    fn test_lookup_host() {
+        let mut addrs = net::lookup_host("localhost").unwrap();
+        assert!(addrs.any(|a| a.unwrap().ip() == net::IpAddr::new_v4(127, 0, 0, 1)));
+    }
+
+}

--- a/src/libstd/net/mod.rs
+++ b/src/libstd/net/mod.rs
@@ -95,7 +95,29 @@ impl Iterator for LookupHost {
 /// # }
 /// ```
 pub fn lookup_host(host: &str) -> io::Result<LookupHost> {
-    net_imp::lookup_host(host).map(LookupHost)
+    net_imp::lookup_host(host, None).map(LookupHost)
+}
+
+/// Resolve the host specified by `host` as a number of `SocketAddr`
+/// instances as the specified address `family`.
+///
+/// This method may perform a DNS query to resolve `host` and may also
+/// inspect system configuration to resolve the specified hostname.
+///
+/// # Example
+///
+/// ```no_run
+/// use std::net;
+///
+/// # fn foo() -> std::io::Result<()> {
+/// for host in try!(net::lookup_host_as_family("rust-lang.org", net::IpAddrFamily::V4)) {
+///     println!("found address: {}", try!(host));
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub fn lookup_host_as_family(host: &str, family: IpAddrFamily) -> io::Result<LookupHost> {
+    net_imp::lookup_host(host, Some(family)).map(LookupHost)
 }
 
 #[cfg(test)]
@@ -109,4 +131,9 @@ mod test_of_this {
         assert!(addrs.any(|a| a.unwrap().ip() == net::IpAddr::new_v4(127, 0, 0, 1)));
     }
 
+    #[test]
+    fn test_lookup_host_as_family() {
+        let mut addrs = net::lookup_host_as_family("localhost", net::IpAddrFamily::V4).unwrap();
+        assert!(addrs.any(|a| a.unwrap().ip() == net::IpAddr::new_v4(127, 0, 0, 1)));
+    }
 }


### PR DESCRIPTION
Sometimes you need to resolve address as specific address family.
- `enum IpAddrFamily`
- add simple test of `lookup_host`
- `lookup_host_as_family` function that takes `IpAddrFamily` as second parameter
