### PR TITLE
Fix missed doc grammar rule rename from vec_elems to array_elems

### DIFF
--- a/src/doc/grammar.md
+++ b/src/doc/grammar.md
@@ -514,7 +514,7 @@ field_expr : expr '.' ident ;
 ### Array expressions
 
 ```antlr
-array_expr : '[' "mut" ? vec_elems? ']' ;
+array_expr : '[' "mut" ? array_elems? ']' ;
 
 array_elems : [expr [',' expr]*] | [expr ',' ".." expr] ;
 ```

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2821,7 +2821,7 @@ automatically dereferenced to make the field access possible.
 ### Array expressions
 
 ```{.ebnf .gram}
-array_expr : '[' "mut" ? vec_elems? ']' ;
+array_expr : '[' "mut" ? array_elems? ']' ;
 
 array_elems : [expr [',' expr]*] | [expr ';' expr] ;
 ```


### PR DESCRIPTION
The docs currently define `array_expr`s as:

```
array_expr : '[' "mut" ? vec_elems? ']' ;
array_elems : [expr [',' expr]*] | [expr ',' ".." expr] ;
```

`vec_elems` is not defined anywhere else so it is probably a typo for `array_elems`.
