### PR TITLE
unbreak dragonfly build after nacl integration

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -1115,7 +1115,6 @@ pub mod types {
             pub mod posix88 {
                 pub type off_t = i64;
                 pub type dev_t = u32;
-                pub type ino_t = u32;
                 pub type pid_t = i32;
                 pub type uid_t = u32;
                 pub type gid_t = u32;


### PR DESCRIPTION
this is the same problem as openbsd (#22792).
without the patch, liblibc don't build.

@mneumann please comment.
I have encountered this problem while building some rust libs with `target=x86_64-unknown-dragonfly` (while working on #22794)
