### PR TITLE
Enable recursion for visit_ty in lint visitor

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -756,6 +756,7 @@ pub trait StrExt: Index<RangeFull, Output = str> {
     /// ```
     #[unstable(feature = "collections")]
     #[deprecated(since = "1.0.0", reason = "use `split()` with a `&str`")]
+    #[allow(deprecated) /* for SplitStr */]
     fn split_str<'a, P: Pattern<'a>>(&'a self, pat: P) -> SplitStr<'a, P> {
         core_str::StrExt::split_str(&self[..], pat)
     }

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1499,9 +1499,9 @@ impl<T> Extend<T> for Vec<T> {
 __impl_slice_eq1! { Vec<A>, Vec<B> }
 __impl_slice_eq2! { Vec<A>, &'b [B] }
 __impl_slice_eq2! { Vec<A>, &'b mut [B] }
-__impl_slice_eq2! { CowVec<'a, A>, &'b [B], Clone }
-__impl_slice_eq2! { CowVec<'a, A>, &'b mut [B], Clone }
-__impl_slice_eq2! { CowVec<'a, A>, Vec<B>, Clone }
+__impl_slice_eq2! { Cow<'a, [A]>, &'b [B], Clone }
+__impl_slice_eq2! { Cow<'a, [A]>, &'b mut [B], Clone }
+__impl_slice_eq2! { Cow<'a, [A]>, Vec<B>, Clone }
 
 macro_rules! array_impls {
     ($($N: expr)+) => {
@@ -1510,9 +1510,9 @@ macro_rules! array_impls {
             __impl_slice_eq2! { Vec<A>, [B; $N] }
             __impl_slice_eq2! { Vec<A>, &'b [B; $N] }
             // __impl_slice_eq2! { Vec<A>, &'b mut [B; $N] }
-            // __impl_slice_eq2! { CowVec<'a, A>, [B; $N], Clone }
-            // __impl_slice_eq2! { CowVec<'a, A>, &'b [B; $N], Clone }
-            // __impl_slice_eq2! { CowVec<'a, A>, &'b mut [B; $N], Clone }
+            // __impl_slice_eq2! { Cow<'a, [A]>, [B; $N], Clone }
+            // __impl_slice_eq2! { Cow<'a, [A]>, &'b [B; $N], Clone }
+            // __impl_slice_eq2! { Cow<'a, [A]>, &'b mut [B; $N], Clone }
         )+
     }
 }

--- a/src/libcore/atomic.rs
+++ b/src/libcore/atomic.rs
@@ -1067,6 +1067,7 @@ pub struct AtomicInt {
     v: UnsafeCell<int>,
 }
 
+#[allow(deprecated)]
 unsafe impl Sync for AtomicInt {}
 
 #[unstable(feature = "core")]
@@ -1077,6 +1078,7 @@ pub struct AtomicUint {
     v: UnsafeCell<uint>,
 }
 
+#[allow(deprecated)]
 unsafe impl Sync for AtomicUint {}
 
 #[unstable(feature = "core")]

--- a/src/libcore/raw.rs
+++ b/src/libcore/raw.rs
@@ -70,6 +70,7 @@ impl<T> Copy for Slice<T> {}
 #[deprecated(reason = "unboxed new closures do not have a universal representation; \
                        `&Fn` (etc) trait objects should use `TraitObject` instead",
              since= "1.0.0")]
+#[allow(deprecated) /* for deriving Copy impl */]
 pub struct Closure {
     pub code: *mut (),
     pub env: *mut (),

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -935,6 +935,7 @@ impl<'a, P: Pattern<'a>> Iterator for MatchIndices<'a, P> {
 #[unstable(feature = "core")]
 #[deprecated(since = "1.0.0", reason = "use `Split` with a `&str`")]
 pub struct SplitStr<'a, P: Pattern<'a>>(Split<'a, P>);
+#[allow(deprecated)]
 impl<'a, P: Pattern<'a>> Iterator for SplitStr<'a, P> {
     type Item = &'a str;
 
@@ -1325,6 +1326,7 @@ pub trait StrExt {
     fn split_terminator<'a, P: Pattern<'a>>(&'a self, pat: P) -> SplitTerminator<'a, P>;
     fn rsplitn<'a, P: Pattern<'a>>(&'a self, count: usize, pat: P) -> RSplitN<'a, P>;
     fn match_indices<'a, P: Pattern<'a>>(&'a self, pat: P) -> MatchIndices<'a, P>;
+    #[allow(deprecated) /* for SplitStr */]
     fn split_str<'a, P: Pattern<'a>>(&'a self, pat: P) -> SplitStr<'a, P>;
     fn lines<'a>(&'a self) -> Lines<'a>;
     fn lines_any<'a>(&'a self) -> LinesAny<'a>;

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -37,7 +37,7 @@
 //! Each node label is derived directly from the int representing the node,
 //! while the edge labels are all empty strings.
 //!
-//! This example also illustrates how to use `CowVec` to return
+//! This example also illustrates how to use `Cow<[T]>` to return
 //! an owned vector or a borrowed slice as appropriate: we construct the
 //! node vector from scratch, but borrow the edge list (rather than
 //! constructing a copy of all the edges from scratch).
@@ -502,7 +502,7 @@ pub type Edges<'a,E> = Cow<'a,[E]>;
 /// that is bound by the self lifetime `'a`.
 ///
 /// The `nodes` and `edges` method each return instantiations of
-/// `CowVec` to leave implementers the freedom to create
+/// `Cow<[T]>` to leave implementers the freedom to create
 /// entirely new vectors or to pass back slices into internally owned
 /// vectors.
 pub trait GraphWalk<'a, N, E> {

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -568,9 +568,9 @@ impl<'a, 'tcx, 'v> Visitor<'v> for Context<'a, 'tcx> {
         })
     }
 
-    // FIXME(#10894) should continue recursing
     fn visit_ty(&mut self, t: &ast::Ty) {
         run_lints!(self, check_ty, t);
+        visit::walk_ty(self, t);
     }
 
     fn visit_ident(&mut self, sp: Span, id: ast::Ident) {

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -76,7 +76,7 @@ use std::hash::{Hash, SipHasher, Hasher};
 use std::mem;
 use std::ops;
 use std::rc::Rc;
-use std::vec::{CowVec, IntoIter};
+use std::vec::IntoIter;
 use collections::enum_set::{EnumSet, CLike};
 use std::collections::{HashMap, HashSet};
 use syntax::abi;
@@ -5580,7 +5580,7 @@ pub fn predicates<'tcx>(
 
 /// Get the attributes of a definition.
 pub fn get_attrs<'tcx>(tcx: &'tcx ctxt, did: DefId)
-                       -> CowVec<'tcx, ast::Attribute> {
+                       -> Cow<'tcx, [ast::Attribute]> {
     if is_local(did) {
         let item = tcx.map.expect_item(did.node);
         Cow::Borrowed(&item.attrs)

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -34,10 +34,10 @@
 
 use core::prelude::*;
 
-use borrow::{Borrow, ToOwned};
+use borrow::{Borrow, Cow, ToOwned};
 use fmt::{self, Debug};
 use mem;
-use string::{String, CowString};
+use string::String;
 use ops;
 use cmp;
 use hash::{Hash, Hasher};
@@ -183,10 +183,10 @@ impl OsStr {
         self.inner.to_str()
     }
 
-    /// Convert an `OsStr` to a `CowString`.
+    /// Convert an `OsStr` to a `Cow<str>`.
     ///
     /// Any non-Unicode sequences are replaced with U+FFFD REPLACEMENT CHARACTER.
-    pub fn to_string_lossy(&self) -> CowString {
+    pub fn to_string_lossy(&self) -> Cow<str> {
         self.inner.to_string_lossy()
     }
 

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -38,7 +38,7 @@ use num::Int;
 use ops;
 use slice;
 use str;
-use string::{String, CowString};
+use string::String;
 use sys_common::AsInner;
 use unicode::str::{Utf16Item, utf16_items};
 use vec::Vec;
@@ -530,7 +530,7 @@ impl Wtf8 {
     /// Surrogates are replaced with `"\u{FFFD}"` (the replacement character “�”).
     ///
     /// This only copies the data if necessary (if it contains any surrogate).
-    pub fn to_string_lossy(&self) -> CowString {
+    pub fn to_string_lossy(&self) -> Cow<str> {
         let surrogate_pos = match self.next_surrogate(0) {
             None => return Cow::Borrowed(unsafe { str::from_utf8_unchecked(&self.bytes) }),
             Some((pos, _)) => pos,
@@ -844,7 +844,6 @@ mod tests {
     use borrow::Cow;
     use super::*;
     use mem::transmute;
-    use string::CowString;
 
     #[test]
     fn code_point_from_u32() {
@@ -1224,7 +1223,7 @@ mod tests {
         assert_eq!(Wtf8::from_str("aé 💩").to_string_lossy(), Cow::Borrowed("aé 💩"));
         let mut string = Wtf8Buf::from_str("aé 💩");
         string.push(CodePoint::from_u32(0xD800).unwrap());
-        let expected: CowString = Cow::Owned(String::from_str("aé 💩�"));
+        let expected: Cow<str> = Cow::Owned(String::from_str("aé 💩�"));
         assert_eq!(string.to_string_lossy(), expected);
     }
 

--- a/src/libstd/sys/unix/os_str.rs
+++ b/src/libstd/sys/unix/os_str.rs
@@ -13,11 +13,12 @@
 
 use core::prelude::*;
 
+use borrow::Cow;
 use fmt::{self, Debug};
 use vec::Vec;
 use slice::SliceExt as StdSliceExt;
 use str;
-use string::{String, CowString};
+use string::String;
 use mem;
 
 #[derive(Clone, Hash)]
@@ -76,7 +77,7 @@ impl Slice {
         str::from_utf8(&self.inner).ok()
     }
 
-    pub fn to_string_lossy(&self) -> CowString {
+    pub fn to_string_lossy(&self) -> Cow<str> {
         String::from_utf8_lossy(&self.inner)
     }
 

--- a/src/libstd/sys/windows/os_str.rs
+++ b/src/libstd/sys/windows/os_str.rs
@@ -11,9 +11,10 @@
 /// The underlying OsString/OsStr implementation on Windows is a
 /// wrapper around the "WTF-8" encoding; see the `wtf8` module for more.
 
+use borrow::Cow;
 use fmt::{self, Debug};
 use sys_common::wtf8::{Wtf8, Wtf8Buf};
-use string::{String, CowString};
+use string::String;
 use result::Result;
 use option::Option;
 use mem;
@@ -70,7 +71,7 @@ impl Slice {
         self.inner.as_str()
     }
 
-    pub fn to_string_lossy(&self) -> CowString {
+    pub fn to_string_lossy(&self) -> Cow<str> {
         self.inner.to_string_lossy()
     }
 

--- a/src/libstd/thread_local/scoped.rs
+++ b/src/libstd/thread_local/scoped.rs
@@ -119,7 +119,7 @@ macro_rules! __scoped_thread_local_inner {
         const _INIT: __Key<$t> = __Key {
             inner: ::std::thread_local::scoped::__impl::KeyInner {
                 inner: ::std::thread_local::scoped::__impl::OS_INIT,
-                marker: ::std::marker::InvariantType,
+                marker: ::std::marker::PhantomData::<::std::cell::Cell<$t>>,
             }
         };
 
@@ -244,12 +244,13 @@ mod imp {
           target_arch = "aarch64"))]
 mod imp {
     use marker;
+    use std::cell::Cell;
     use sys_common::thread_local::StaticKey as OsStaticKey;
 
     #[doc(hidden)]
     pub struct KeyInner<T> {
         pub inner: OsStaticKey,
-        pub marker: marker::InvariantType<T>,
+        pub marker: marker::PhantomData<Cell<T>>,
     }
 
     unsafe impl<T> ::marker::Sync for KeyInner<T> { }

--- a/src/test/compile-fail/huge-array-simple.rs
+++ b/src/test/compile-fail/huge-array-simple.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // error-pattern: too big for the current
+#![allow(exceeding_bitshifts)]
 
 fn main() {
    let fat : [u8; (1<<61)+(1<<31)] = [0; (1u64<<61) as usize +(1u64<<31) as usize];


### PR DESCRIPTION
- The lint visitor's visit_ty method did not recurse, and had a
  reference to the now closed #10894
- The newly enabled recursion has only affected the `deprectated` lint
  which now detects uses of deprecated items in trait impls and
  function return types
- Renamed some references to `CowString` and `CowVec` to `Cow<str>` and
  `Cow<[T]>`, respectively, which appear outside of the crate which
  defines them
- Replaced a few instances of `InvariantType<T>` with
  `PhantomData<Cell<T>>`
- Disabled the `deprecated` lint in several places that
  reference/implement traits on deprecated items which will get cleaned
  up in the future
- Unfortunately, this means that if a library declares
  `#![deny(deprecated)]` and marks anything as deprecated, it will have
  to disable the lint for any uses of said item, e.g. any impl the now
  deprecated item

For any library that denies deprecated items but has deprecated items
of its own, this is a [breaking-change]

I had originally intended for the lint to ignore uses of deprecated items that are declared in the same crate, but this goes against some previous test cases that expect the lint to capture _all_ uses of deprecated items, so I maintained the previous approach to avoid changing the expected behavior of the lint.

Tested locally on OS X, so hopefully there aren't any deprecated item uses behind a `cfg` that I may have missed.
