### PR TITLE
Fix unknown attribute in test

### DIFF
--- a/src/test/run-pass/macro-attributes.rs
+++ b/src/test/run-pass/macro-attributes.rs
@@ -10,6 +10,8 @@
 
 // ignore-pretty - token trees can't pretty print
 
+#![feature(custom_attribute)]
+
 macro_rules! compiles_fine {
     (#[$at:meta]) => {
         // test that the different types of attributes work


### PR DESCRIPTION
Been breaking tests lately. Somehow nondeterministic?
