### PR TITLE
Fixed typo and example in the introduction.

### DIFF
--- a/src/doc/intro.md
+++ b/src/doc/intro.md
@@ -428,7 +428,8 @@ fn main() {
 
     let guards: Vec<_> = (0..3).map(|i| {
         Thread::scoped(move || {
-            for j in 0..3 { numbers[j] += 1 }
+            numbers[i] += 1;
+            println!("numbers[{}] is {}", i, numbers[i]);
         });
     }).collect();
 }
@@ -437,10 +438,12 @@ fn main() {
 It gives us this error:
 
 ```text
-7:29: 9:10 error: cannot move out of captured outer variable in an `FnMut` closure
-7         Thread::scoped(move || {
-8             for j in 0..3 { numbers[j] += 1 }
-9         });
+7:25: 10:6 error: cannot move out of captured outer variable in an `FnMut` closure
+7     Thread::scoped(move || {
+8       numbers[i] += 1;
+9       println!("numbers[{}] is {}", i, numbers[i]);
+10     });
+error: aborting due to previous error
 ```
 
 It mentions that "captured outer variable in an `FnMut` closure".


### PR DESCRIPTION
Changed guaranteed for "quaranteed", and
Made failing/working examples look alike.

r? @steveklabnik
