### PR TITLE
Reduce code size overhead from core::panicking::panic

### DIFF
--- a/src/libcore/panicking.rs
+++ b/src/libcore/panicking.rs
@@ -35,8 +35,14 @@ use fmt;
 #[cold] #[inline(never)] // this is the slow path, always
 #[lang="panic"]
 pub fn panic(expr_file_line: &(&'static str, &'static str, u32)) -> ! {
+    // Use Arguments::new_v1 instead of format_args!("{}", expr) to potentially
+    // reduce size overhead. The format_args! macro uses str's Display trait to
+    // write expr, which calls Formatter::pad, which must accommodate string
+    // truncation and padding (even though none is used here). Using
+    // Arguments::new_v1 may allow the compiler to omit Formatter::pad from the
+    // output binary, saving up to a few kilobytes.
     let (expr, file, line) = *expr_file_line;
-    panic_fmt(format_args!("{}", expr), &(file, line))
+    panic_fmt(fmt::Arguments::new_v1(&[expr], &[]), &(file, line))
 }
 
 #[cold] #[inline(never)]


### PR DESCRIPTION
Reduce code size overhead from core::panicking::panic

core::panicking::panic currently creates an Arguments structure using
format_args!("{}", expr), which formats the expr str using the Display::fmt.
Display::fmt pulls in Formatter::pad, which then also pulls in string-related
code for truncation and padding.

If core::panicking::panic instead creates an Arguments structure with a string
piece, it is possible that the Display::fmt function for str can be optimized
out of the program.

In my testing with a 32-bit x86 bare metal program, the change tended to save
between ~100 bytes and ~5500 bytes, depending on what other panic\* functions
the program invokes and whether the panic_fmt lang item uses the Arguments
value.
