### PR TITLE
str: fix comments for FromStr for bool

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -134,10 +134,19 @@ impl FromStr for bool {
 
     /// Parse a `bool` from a string.
     ///
-    /// Yields an `Option<bool>`, because `s` may or may not actually be
-    /// parseable.
+    /// Yields a `Result<bool, ParseBoolError>`, because `s` may or may not
+    /// actually be parseable.
     ///
     /// # Examples
+    ///
+    /// ```rust
+    /// assert_eq!(from_str::<bool>("true"), OK(true));
+    /// assert_eq!(from_str::<bool>("false"), OK(false));
+    /// assert!(from_str::<bool>("not even a boolean").is_err());
+    /// ```
+    ///
+    /// Note, in many cases, the StrExt::parse() which is based on
+    /// this FromStr::from_str() is proper.
     ///
     /// ```rust
     /// assert_eq!("true".parse(), Ok(true));


### PR DESCRIPTION
Fix the return type in the comments.

An old commit 082bfde41217 ("Fallout of std::str stabilization") removed
the example of FromStr::from_str(), this commit adds it back. But
the example of StrExt::parse() is still kept with an additinal note.

Signed-off-by: Lai Jiangshan laijs@cn.fujitsu.com
