### PR TITLE
Feature gate `#[static_assert]`.

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2495,6 +2495,12 @@ The currently implemented features of the reference compiler are:
 
 * `staged_api` - Allows usage of stability markers and `#![staged_api]` in a crate
 
+* `static_assert` - The `#[static_assert]` functionality is experimental and
+                    unstable. The attribute can be attached to a `static` of
+                    type `bool` and the compiler will error if the `bool` is
+                    `false` at compile time. This version of this functionality
+                    is unintuitive and suboptimal.
+
 * `start` - Allows use of the `#[start]` attribute, which changes the entry point
             into a Rust program. This capabiilty, especially the signature for the
             annotated function, is subject to change.

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -139,6 +139,9 @@ static KNOWN_FEATURES: &'static [(&'static str, &'static str, Status)] = &[
 
     // Allows the use of rustc_* attributes; RFC 572
     ("rustc_attrs", "1.0.0", Active),
+
+    // Allows the use of `static_assert`
+    ("static_assert", "1.0.0", Active),
 ];
 // (changing above list without updating src/doc/reference.md makes @cmr sad)
 
@@ -241,7 +244,8 @@ pub static KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType)] = &[
     ("no_split_stack", Whitelisted),
     ("no_stack_check", Whitelisted),
     ("packed", Whitelisted),
-    ("static_assert", Whitelisted),
+    ("static_assert", Gated("static_assert",
+                            "`#[static_assert]` is an experimental feature, and has a poor API")),
     ("no_debug", Whitelisted),
     ("omit_gdb_pretty_printer_section", Whitelisted),
     ("unsafe_no_drop_flag", Gated("unsafe_no_drop_flag",
@@ -769,4 +773,3 @@ pub fn check_crate(cm: &CodeMap, span_handler: &SpanHandler, krate: &ast::Crate)
                       |ctx, krate| visit::walk_crate(&mut PostExpansionVisitor { context: ctx },
                                                      krate))
 }
-

--- a/src/test/compile-fail/asm-misplaced-option.rs
+++ b/src/test/compile-fail/asm-misplaced-option.rs
@@ -10,13 +10,14 @@
 
 // ignore-android
 
-#![feature(asm)]
+#![feature(asm, rustc_attrs)]
 
 #![allow(dead_code, non_upper_case_globals)]
 
 #[cfg(any(target_arch = "x86",
           target_arch = "x86_64"))]
-pub fn main() {
+#[rustc_error]
+pub fn main() { //~ ERROR compilation successful
     // assignment not dead
     let mut x: isize = 0;
     unsafe {
@@ -33,7 +34,3 @@ pub fn main() {
     }
     assert_eq!(x, 13);
 }
-
-// At least one error is needed so that compilation fails
-#[static_assert]
-static b: bool = false; //~ ERROR static assertion failed

--- a/src/test/compile-fail/feature-gate-static-assert.rs
+++ b/src/test/compile-fail/feature-gate-static-assert.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(static_assert)]
-#![allow(dead_code)]
-
-#[static_assert]
-static E: bool = 1 == 2; //~ ERROR static assertion failed
+#[static_assert] //~ ERROR `#[static_assert]` is an experimental feature
+static X: bool = true;
 
 fn main() {}

--- a/src/test/compile-fail/issue-6804.rs
+++ b/src/test/compile-fail/issue-6804.rs
@@ -8,13 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(rustc_attrs)]
 #![allow(dead_code)]
 
 // Matching against NaN should result in a warning
 
 use std::f64::NAN;
 
-fn main() {
+#[rustc_error]
+fn main() { //~ ERROR compilation successful
     let x = NAN;
     match x {
         NAN => {},
@@ -27,7 +29,3 @@ fn main() {
     };
     //~^^^ WARNING unmatchable NaN in pattern, use the is_nan method in a guard instead
 }
-
-// At least one error is needed so that compilation fails
-#[static_assert]
-static B: bool = false; //~ ERROR static assertion failed

--- a/src/test/compile-fail/nonbool_static_assert.rs
+++ b/src/test/compile-fail/nonbool_static_assert.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(static_assert)]
 #![allow(dead_code)]
 
 #[static_assert]

--- a/src/test/compile-fail/static-assert.rs
+++ b/src/test/compile-fail/static-assert.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(static_assert)]
 #![allow(dead_code)]
 
 #[static_assert]

--- a/src/test/run-pass/static-assert.rs
+++ b/src/test/run-pass/static-assert.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(static_assert)]
+
 #[static_assert]
 static b: bool = true;
 


### PR DESCRIPTION
The API this exposes is a little strange (being attached to `static`s),
so it makes sense to conservatively feature gate it. If it is highly
popular, it is possible to reverse this gating.
