### PR TITLE
Make `test/run-pass/backtrace.rs` more robust about own host environment

### DIFF
--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -53,7 +53,9 @@ fn runtest(me: &str) {
             "bad output: {}", s);
 
     // Make sure the stack trace is *not* printed
-    let p = template.clone().arg("fail").spawn().unwrap();
+    // (Remove RUST_BACKTRACE from our own environment, in case developer
+    // is running `make check` with it on.)
+    let p = template.clone().arg("fail").env_remove("RUST_BACKTRACE").spawn().unwrap();
     let out = p.wait_with_output().unwrap();
     assert!(!out.status.success());
     let s = str::from_utf8(&out.error).unwrap();


### PR DESCRIPTION
Make `test/run-pass/backtrace.rs` more robust about own host environment

Namely, I have been annoyed in the past when I have done `RUST_BACKTRACE=1 make check` only to discover (again) that such a trick causes this test to fail, because it assumes that the `RUST_BACKTRACE` environment variable is not set.

Fix #22870
