### PR TITLE
Readd int_uint feature to libstd

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -123,6 +123,7 @@
 #![feature(unsafe_no_drop_flag)]
 #![feature(macro_reexport)]
 #![feature(hash)]
+#![feature(int_uint)]
 #![feature(unique)]
 #![cfg_attr(test, feature(test, rustc_private, env))]
 


### PR DESCRIPTION
Reverts a small part of c74d49c804c3 because compilation pukes with warnings now.
