### PR TITLE
std: Stabilize the `ffi` module

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -22,7 +22,6 @@
 #![feature(unicode)]
 #![feature(core)]
 #![feature(path)]
-#![feature(os)]
 #![feature(io)]
 #![feature(fs)]
 #![feature(net)]

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -20,7 +20,6 @@ use procsrv;
 use util::logv;
 
 use std::env;
-use std::ffi::OsStr;
 use std::fmt;
 use std::fs::{self, File};
 use std::io::BufReader;
@@ -1323,7 +1322,7 @@ fn make_exe_name(config: &Config, testfile: &Path) -> PathBuf {
     let mut f = output_base_name(config, testfile);
     if !env::consts::EXE_SUFFIX.is_empty() {
         let mut fname = f.file_name().unwrap().to_os_string();
-        fname.push_os_str(OsStr::from_str(env::consts::EXE_SUFFIX));
+        fname.push(env::consts::EXE_SUFFIX);
         f.set_file_name(&fname);
     }
     f
@@ -1433,7 +1432,7 @@ fn make_out_name(config: &Config, testfile: &Path, extension: &str) -> PathBuf {
 fn aux_output_dir_name(config: &Config, testfile: &Path) -> PathBuf {
     let f = output_base_name(config, testfile);
     let mut fname = f.file_name().unwrap().to_os_string();
-    fname.push_os_str(OsStr::from_str("libaux"));
+    fname.push("libaux");
     f.with_file_name(&fname)
 }
 
@@ -1647,8 +1646,8 @@ fn append_suffix_to_stem(p: &Path, suffix: &str) -> PathBuf {
         p.to_path_buf()
     } else {
         let mut stem = p.file_stem().unwrap().to_os_string();
-        stem.push_os_str(OsStr::from_str("-"));
-        stem.push_os_str(OsStr::from_str(suffix));
+        stem.push("-");
+        stem.push(suffix);
         p.with_file_name(&stem)
     }
 }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -38,7 +38,6 @@
 #![feature(unsafe_destructor)]
 #![feature(staged_api)]
 #![feature(std_misc)]
-#![feature(os)]
 #![feature(path)]
 #![feature(fs)]
 #![feature(io)]

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -29,7 +29,6 @@
 #![feature(int_uint)]
 #![feature(old_io)]
 #![feature(libc)]
-#![feature(os)]
 #![feature(quote)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(rustc_private)]

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -27,7 +27,7 @@ use util::common::time;
 use util::ppaux;
 use util::sha2::{Digest, Sha256};
 
-use std::ffi::{AsOsStr, OsString};
+use std::ffi::OsString;
 use std::fs::{self, TempDir, PathExt};
 use std::io::{self, Read, Write};
 use std::mem;
@@ -882,7 +882,7 @@ fn link_args(cmd: &mut Command,
             let morestack = lib_path.join("libmorestack.a");
 
             let mut v = OsString::from_str("-Wl,-force_load,");
-            v.push_os_str(morestack.as_os_str());
+            v.push(&morestack);
             cmd.arg(&v);
         } else {
             cmd.args(&["-Wl,--whole-archive", "-lmorestack", "-Wl,--no-whole-archive"]);
@@ -1007,7 +1007,7 @@ fn link_args(cmd: &mut Command,
 
             if sess.opts.cg.rpath {
                 let mut v = OsString::from_str("-Wl,-install_name,@rpath/");
-                v.push_os_str(out_filename.file_name().unwrap());
+                v.push(out_filename.file_name().unwrap());
                 cmd.arg(&v);
             }
         } else {
@@ -1107,7 +1107,7 @@ fn add_local_native_libraries(cmd: &mut Command, sess: &Session) {
                                             &search_path[..],
                                             &sess.diagnostic().handler);
             let mut v = OsString::from_str("-Wl,-force_load,");
-            v.push_os_str(lib.as_os_str());
+            v.push(&lib);
             cmd.arg(&v);
         }
     }

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -35,12 +35,10 @@
 #![feature(rustc_private)]
 #![feature(unsafe_destructor)]
 #![feature(staged_api)]
-#![feature(std_misc)]
 #![feature(unicode)]
 #![feature(io)]
 #![feature(fs)]
 #![feature(path)]
-#![feature(os)]
 #![feature(tempdir)]
 
 extern crate arena;

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -38,7 +38,6 @@ use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::default::Default;
-use std::ffi::OsStr;
 use std::fmt;
 use std::fs::{self, File};
 use std::io::prelude::*;
@@ -770,7 +769,7 @@ impl<'a> SourceCollector<'a> {
 
         let mut fname = p.file_name().expect("source has no filename")
                          .to_os_string();
-        fname.push_os_str(OsStr::from_str(".html"));
+        fname.push(".html");
         cur.push(&fname);
         let mut w = BufWriter::new(try!(File::create(&cur)));
 

--- a/src/libstd/ffi/mod.rs
+++ b/src/libstd/ffi/mod.rs
@@ -10,17 +10,19 @@
 
 //! Utilities related to FFI bindings.
 
-#![unstable(feature = "std_misc",
-            reason = "module just underwent fairly large reorganization and the dust \
-                      still needs to settle")]
+#![stable(feature = "rust1", since = "1.0.0")]
 
-pub use self::c_str::{CString, CStr, NulError, IntoBytes};
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use self::c_str::{CString, CStr};
+pub use self::c_str::{NulError, IntoBytes};
 #[allow(deprecated)]
 pub use self::c_str::c_str_to_bytes;
 #[allow(deprecated)]
 pub use self::c_str::c_str_to_bytes_with_nul;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::os_str::OsString;
+#[stable(feature = "rust1", since = "1.0.0")]
 pub use self::os_str::OsStr;
 
 mod c_str;
@@ -28,6 +30,7 @@ mod os_str;
 
 // FIXME (#21670): these should be defined in the os_str module
 /// Freely convertible to an `&OsStr` slice.
+#[unstable(feature = "std_misc")]
 pub trait AsOsStr {
     /// Convert to an `&OsStr` slice.
     fn as_os_str(&self) -> &OsStr;

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -49,17 +49,20 @@ use super::AsOsStr;
 
 /// Owned, mutable OS strings.
 #[derive(Clone)]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub struct OsString {
     inner: Buf
 }
 
 /// Slices into OS strings.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub struct OsStr {
     inner: Slice
 }
 
 impl OsString {
     /// Constructs an `OsString` at no cost by consuming a `String`.
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn from_string(s: String) -> OsString {
         OsString { inner: Buf::from_string(s) }
     }
@@ -67,11 +70,13 @@ impl OsString {
     /// Constructs an `OsString` by copying from a `&str` slice.
     ///
     /// Equivalent to: `OsString::from_string(String::from_str(s))`.
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn from_str(s: &str) -> OsString {
         OsString { inner: Buf::from_str(s) }
     }
 
     /// Constructs a new empty `OsString`.
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new() -> OsString {
         OsString { inner: Buf::from_string(String::new()) }
     }
@@ -79,16 +84,26 @@ impl OsString {
     /// Convert the `OsString` into a `String` if it contains valid Unicode data.
     ///
     /// On failure, ownership of the original `OsString` is returned.
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn into_string(self) -> Result<String, OsString> {
         self.inner.into_string().map_err(|buf| OsString { inner: buf} )
     }
 
     /// Extend the string with the given `&OsStr` slice.
+    #[deprecated(since = "1.0.0", reason = "renamed to `push`")]
+    #[unstable(feature = "os")]
     pub fn push_os_str(&mut self, s: &OsStr) {
         self.inner.push_slice(&s.inner)
     }
+
+    /// Extend the string with the given `&OsStr` slice.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub fn push<T: AsOsStr + ?Sized>(&mut self, s: &T) {
+        self.inner.push_slice(&s.as_os_str().inner)
+    }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl ops::Index<ops::RangeFull> for OsString {
     type Output = OsStr;
 
@@ -98,6 +113,7 @@ impl ops::Index<ops::RangeFull> for OsString {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl ops::Deref for OsString {
     type Target = OsStr;
 
@@ -107,32 +123,38 @@ impl ops::Deref for OsString {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Debug for OsString {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         fmt::Debug::fmt(&**self, formatter)
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl PartialEq for OsString {
     fn eq(&self, other: &OsString) -> bool {
         &**self == &**other
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl PartialEq<str> for OsString {
     fn eq(&self, other: &str) -> bool {
         &**self == other
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl PartialEq<OsString> for str {
     fn eq(&self, other: &OsString) -> bool {
         &**other == self
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Eq for OsString {}
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl PartialOrd for OsString {
     #[inline]
     fn partial_cmp(&self, other: &OsString) -> Option<cmp::Ordering> {
@@ -148,6 +170,7 @@ impl PartialOrd for OsString {
     fn ge(&self, other: &OsString) -> bool { &**self >= &**other }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl PartialOrd<str> for OsString {
     #[inline]
     fn partial_cmp(&self, other: &str) -> Option<cmp::Ordering> {
@@ -155,6 +178,7 @@ impl PartialOrd<str> for OsString {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Ord for OsString {
     #[inline]
     fn cmp(&self, other: &OsString) -> cmp::Ordering {
@@ -172,6 +196,7 @@ impl Hash for OsString {
 
 impl OsStr {
     /// Coerce directly from a `&str` slice to a `&OsStr` slice.
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn from_str(s: &str) -> &OsStr {
         unsafe { mem::transmute(Slice::from_str(s)) }
     }
@@ -179,6 +204,7 @@ impl OsStr {
     /// Yield a `&str` slice if the `OsStr` is valid unicode.
     ///
     /// This conversion may entail doing a check for UTF-8 validity.
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn to_str(&self) -> Option<&str> {
         self.inner.to_str()
     }
@@ -186,11 +212,13 @@ impl OsStr {
     /// Convert an `OsStr` to a `Cow<str>`.
     ///
     /// Any non-Unicode sequences are replaced with U+FFFD REPLACEMENT CHARACTER.
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn to_string_lossy(&self) -> Cow<str> {
         self.inner.to_string_lossy()
     }
 
     /// Copy the slice into an owned `OsString`.
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn to_os_string(&self) -> OsString {
         OsString { inner: self.inner.to_owned() }
     }
@@ -204,26 +232,31 @@ impl OsStr {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl PartialEq for OsStr {
     fn eq(&self, other: &OsStr) -> bool {
         self.bytes().eq(other.bytes())
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl PartialEq<str> for OsStr {
     fn eq(&self, other: &str) -> bool {
         *self == *OsStr::from_str(other)
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl PartialEq<OsStr> for str {
     fn eq(&self, other: &OsStr) -> bool {
         *other == *OsStr::from_str(self)
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Eq for OsStr {}
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl PartialOrd for OsStr {
     #[inline]
     fn partial_cmp(&self, other: &OsStr) -> Option<cmp::Ordering> {
@@ -239,6 +272,7 @@ impl PartialOrd for OsStr {
     fn ge(&self, other: &OsStr) -> bool { self.bytes().ge(other.bytes()) }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl PartialOrd<str> for OsStr {
     #[inline]
     fn partial_cmp(&self, other: &str) -> Option<cmp::Ordering> {
@@ -249,6 +283,7 @@ impl PartialOrd<str> for OsStr {
 // FIXME (#19470): cannot provide PartialOrd<OsStr> for str until we
 // have more flexible coherence rules.
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Ord for OsStr {
     #[inline]
     fn cmp(&self, other: &OsStr) -> cmp::Ordering { self.bytes().cmp(other.bytes()) }
@@ -262,21 +297,25 @@ impl Hash for OsStr {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Debug for OsStr {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         self.inner.fmt(formatter)
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Borrow<OsStr> for OsString {
     fn borrow(&self) -> &OsStr { &self[..] }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl ToOwned for OsStr {
     type Owned = OsString;
     fn to_owned(&self) -> OsString { self.to_os_string() }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T: AsOsStr + ?Sized> AsOsStr for &'a T {
     fn as_os_str(&self) -> &OsStr {
         (*self).as_os_str()
@@ -307,15 +346,12 @@ impl AsOsStr for String {
     }
 }
 
-#[cfg(unix)]
 impl AsOsStr for Path {
+    #[cfg(unix)]
     fn as_os_str(&self) -> &OsStr {
         unsafe { mem::transmute(self.as_vec()) }
     }
-}
-
-#[cfg(windows)]
-impl AsOsStr for Path {
+    #[cfg(windows)]
     fn as_os_str(&self) -> &OsStr {
         // currently .as_str() is actually infallible on windows
         OsStr::from_str(self.as_str().unwrap())

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -872,10 +872,10 @@ impl PathBuf {
 
         // `path` is a pure relative path
         } else if need_sep {
-            self.inner.push_os_str(OsStr::from_str(MAIN_SEP_STR));
+            self.inner.push(MAIN_SEP_STR);
         }
 
-        self.inner.push_os_str(path.as_os_str());
+        self.inner.push(path);
     }
 
     /// Truncate `self` to `self.parent()`.
@@ -937,8 +937,8 @@ impl PathBuf {
 
         let extension = extension.as_os_str();
         if os_str_as_u8_slice(extension).len() > 0 {
-            stem.push_os_str(OsStr::from_str("."));
-            stem.push_os_str(extension.as_os_str());
+            stem.push(".");
+            stem.push(extension);
         }
         self.set_file_name(&stem);
 


### PR DESCRIPTION
The two main sub-modules, `c_str` and `os_str`, have now had some time to bake
in the standard library. This commits performs a sweep over the modules adding
various stability tags.

The following APIs are now marked `#[stable]`
- `OsString`
- `OsStr`
- `OsString::from_string`
- `OsString::from_str`
- `OsString::new`
- `OsString::into_string`
- `OsString::push` (renamed from `push_os_str`, added an `AsOsStr` bound)
- various trait implementations for `OsString`
- `OsStr::from_str`
- `OsStr::to_str`
- `OsStr::to_string_lossy`
- `OsStr::to_os_string`
- various trait implementations for `OsStr`
- `CString`
- `CStr`
- `NulError`
- `CString::new` - this API's implementation may change as a result of
  rust-lang/rfcs#912 but the usage of `CString::new(thing)` looks like it is
  unlikely to change. Additionally, the `IntoBytes` bound is also likely to
  change but the set of implementors for the trait will not change (despite the
  trait perhaps being renamed).
- `CString::from_vec_unchecked`
- `CString::as_bytes`
- `CString::as_bytes_with_nul`
- `NulError::nul_position`
- `NulError::into_vec`
- `CStr::from_ptr`
- `CStr::to_bytes`
- `CStr::to_bytes_with_nul`
- various trait implementations for `CStr`

The following APIs remain `#[unstable]`
- `OsStr*Ext` traits remain unstable as the organization of `os::platform` is
  uncertain still and the traits may change location.
- `AsOsStr` remains unstable as generic conversion traits are likely to be
  rethought soon.

The following APIs were deprecated
- `OsString::push_os_str` is now called `push` and takes `T: AsOsStr` instead (a
  superset of the previous functionality).

[breaking-change]
