### PR TITLE
update privacy checker to work with associated types

### DIFF
--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1376,10 +1376,11 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
                             }
                         }
                         Some(ref tr) => {
-                            // Any private types in a trait impl fall into two
+                            // Any private types in a trait impl fall into three
                             // categories.
                             // 1. mentioned in the trait definition
                             // 2. mentioned in the type params/generics
+                            // 3. mentioned in the associated types of the impl
                             //
                             // Those in 1. can only occur if the trait is in
                             // this crate and will've been warned about on the
@@ -1389,6 +1390,16 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
                             // Those in 2. are warned via walk_generics and this
                             // call here.
                             visit::walk_path(self, &tr.path);
+
+                            // Those in 3. are warned with this call.
+                            for impl_item in impl_items {
+                                match *impl_item {
+                                    ast::MethodImplItem(..) => {},
+                                    ast::TypeImplItem(ref typedef) => {
+                                        self.visit_ty(&typedef.typ);
+                                    }
+                                }
+                            }
                         }
                     }
                 } else if trait_ref.is_none() && self_is_public_path {

--- a/src/test/compile-fail/issue-22912.rs
+++ b/src/test/compile-fail/issue-22912.rs
@@ -1,0 +1,41 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct PublicType;
+struct PrivateType;
+
+pub trait PublicTrait {
+    type Item;
+}
+
+trait PrivateTrait {
+    type Item;
+}
+
+impl PublicTrait for PublicType {
+    type Item = PrivateType;  //~ ERROR private type in exported type signature
+}
+
+// OK
+impl PublicTrait for PrivateType {
+    type Item = PrivateType;
+}
+
+// OK
+impl PrivateTrait for PublicType {
+    type Item = PrivateType;
+}
+
+// OK
+impl PrivateTrait for PrivateType {
+    type Item = PrivateType;
+}
+
+fn main() {}

--- a/src/test/run-pass/associated-types-binding-in-where-clause.rs
+++ b/src/test/run-pass/associated-types-binding-in-where-clause.rs
@@ -16,7 +16,7 @@ pub trait Foo {
 }
 
 #[derive(PartialEq)]
-struct Bar;
+pub struct Bar;
 
 impl Foo for int {
     type A = uint;

--- a/src/test/run-pass/associated-types-eq-obj.rs
+++ b/src/test/run-pass/associated-types-eq-obj.rs
@@ -15,7 +15,7 @@ pub trait Foo {
     fn boo(&self) -> <Self as Foo>::A;
 }
 
-struct Bar;
+pub struct Bar;
 
 impl Foo for char {
     type A = Bar;

--- a/src/test/run-pass/associated-types-return.rs
+++ b/src/test/run-pass/associated-types-return.rs
@@ -16,7 +16,7 @@ pub trait Foo {
 }
 
 #[derive(PartialEq)]
-struct Bar;
+pub struct Bar;
 
 impl Foo for int {
     type A = uint;


### PR DESCRIPTION
Associated types are now treated as part of the public API by the privacy checker.

If you were exposing a private type in your public API via an associated type, make that type public:

``` diff
  pub struct PublicType { .. }

- struct Struct { .. }
+ pub struct Struct { .. }

  pub trait PublicTrait {
      type Output;

      fn foo(&self) -> Self::Output;
  }

  impl PublicTrait for PublicType {
      type Output = Struct;

      fn foo(&self) -> Struct {  // `Struct` is part of the public API, it must be marked as `pub`lic
          ..
      }
  }
```

[breaking-change]

---

r? @nikomatsakis 
closes #22912
