### PR TITLE
std: Mark `Index::Output` as a stable associated type

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -913,6 +913,7 @@ shr_impl_all! { u8 u16 u32 u64 usize i8 i16 i32 i64 isize }
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Index<Idx: ?Sized> {
     /// The returned type after indexing
+    #[stable(feature = "rust1", since = "1.0.0")]
     type Output: ?Sized;
 
     /// The method for the indexing (`Foo[Bar]`) operation


### PR DESCRIPTION
This stability attribute was left out by accident and the stability pass has
since picked up the ability to check for this. As a result, crates are currently
getting warnings for implementations of `Index`.
