### PR TITLE
std: Stabilize portions of the `io` module

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -769,6 +769,7 @@ fn parse_crate_attrs(sess: &Session, input: &Input) ->
 ///
 /// The diagnostic emitter yielded to the procedure should be used for reporting
 /// errors of the compiler.
+#[allow(deprecated)]
 pub fn monitor<F:FnOnce()+Send+'static>(f: F) {
     const STACK_SIZE: uint = 8 * 1024 * 1024; // 8MB
 

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -106,6 +106,7 @@ pub fn run(input: &str,
     0
 }
 
+#[allow(deprecated)]
 fn runtest(test: &str, cratename: &str, libs: SearchPaths,
            externs: core::Externs,
            should_fail: bool, no_run: bool, as_test_harness: bool) {

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(missing_copy_implementations)]
-
 use prelude::v1::*;
 use io::prelude::*;
 
@@ -32,6 +30,7 @@ use slice;
 /// Implementations of the I/O traits for `Cursor<T>` are not currently generic
 /// over `T` itself. Instead, specific implementations are provided for various
 /// in-memory buffer types like `Vec<u8>` and `&[u8]`.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub struct Cursor<T> {
     inner: T,
     pos: u64,
@@ -39,26 +38,32 @@ pub struct Cursor<T> {
 
 impl<T> Cursor<T> {
     /// Create a new cursor wrapping the provided underlying I/O object.
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new(inner: T) -> Cursor<T> {
         Cursor { pos: 0, inner: inner }
     }
 
     /// Consume this cursor, returning the underlying value.
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn into_inner(self) -> T { self.inner }
 
     /// Get a reference to the underlying value in this cursor.
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get_ref(&self) -> &T { &self.inner }
 
     /// Get a mutable reference to the underlying value in this cursor.
     ///
     /// Care should be taken to avoid modifying the internal I/O state of the
     /// underlying value as it may corrupt this cursor's position.
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get_mut(&mut self) -> &mut T { &mut self.inner }
 
     /// Returns the current value of this cursor
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn position(&self) -> u64 { self.pos }
 
     /// Sets the value of this cursor
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn set_position(&mut self, pos: u64) { self.pos = pos; }
 }
 
@@ -83,8 +88,11 @@ macro_rules! seek {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> io::Seek for Cursor<&'a [u8]> { seek!(); }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> io::Seek for Cursor<&'a mut [u8]> { seek!(); }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl io::Seek for Cursor<Vec<u8>> { seek!(); }
 
 macro_rules! read {
@@ -97,8 +105,11 @@ macro_rules! read {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Read for Cursor<&'a [u8]> { read!(); }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Read for Cursor<&'a mut [u8]> { read!(); }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Read for Cursor<Vec<u8>> { read!(); }
 
 macro_rules! buffer {
@@ -111,10 +122,14 @@ macro_rules! buffer {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> BufRead for Cursor<&'a [u8]> { buffer!(); }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> BufRead for Cursor<&'a mut [u8]> { buffer!(); }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> BufRead for Cursor<Vec<u8>> { buffer!(); }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Write for Cursor<&'a mut [u8]> {
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
         let pos = cmp::min(self.pos, self.inner.len() as u64);
@@ -125,6 +140,7 @@ impl<'a> Write for Cursor<&'a mut [u8]> {
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Write for Cursor<Vec<u8>> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         // Make sure the internal buffer is as least as big as where we

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -22,57 +22,88 @@ use vec::Vec;
 // =============================================================================
 // Forwarding implementations
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, R: Read + ?Sized> Read for &'a mut R {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { (**self).read(buf) }
-
-    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<()> { (**self).read_to_end(buf) }
-
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        (**self).read(buf)
+    }
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<()> {
+        (**self).read_to_end(buf)
+    }
     fn read_to_string(&mut self, buf: &mut String) -> io::Result<()> {
         (**self).read_to_string(buf)
     }
 }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, W: Write + ?Sized> Write for &'a mut W {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
-
-    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> { (**self).write_all(buf) }
-
-    fn write_fmt(&mut self, fmt: fmt::Arguments) -> io::Result<()> { (**self).write_fmt(fmt) }
-
     fn flush(&mut self) -> io::Result<()> { (**self).flush() }
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        (**self).write_all(buf)
+    }
+    fn write_fmt(&mut self, fmt: fmt::Arguments) -> io::Result<()> {
+        (**self).write_fmt(fmt)
+    }
 }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, S: Seek + ?Sized> Seek for &'a mut S {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> { (**self).seek(pos) }
 }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, B: BufRead + ?Sized> BufRead for &'a mut B {
     fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
-
     fn consume(&mut self, amt: usize) { (**self).consume(amt) }
-
     fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> io::Result<()> {
         (**self).read_until(byte, buf)
     }
-
-    fn read_line(&mut self, buf: &mut String) -> io::Result<()> { (**self).read_line(buf) }
+    fn read_line(&mut self, buf: &mut String) -> io::Result<()> {
+        (**self).read_line(buf)
+    }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<R: Read + ?Sized> Read for Box<R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { (**self).read(buf) }
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        (**self).read(buf)
+    }
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<()> {
+        (**self).read_to_end(buf)
+    }
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<()> {
+        (**self).read_to_string(buf)
+    }
 }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<W: Write + ?Sized> Write for Box<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
     fn flush(&mut self) -> io::Result<()> { (**self).flush() }
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        (**self).write_all(buf)
+    }
+    fn write_fmt(&mut self, fmt: fmt::Arguments) -> io::Result<()> {
+        (**self).write_fmt(fmt)
+    }
 }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<S: Seek + ?Sized> Seek for Box<S> {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> { (**self).seek(pos) }
 }
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<B: BufRead + ?Sized> BufRead for Box<B> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> { (**self).fill_buf() }
     fn consume(&mut self, amt: usize) { (**self).consume(amt) }
+    fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> io::Result<()> {
+        (**self).read_until(byte, buf)
+    }
+    fn read_line(&mut self, buf: &mut String) -> io::Result<()> {
+        (**self).read_line(buf)
+    }
 }
 
 // =============================================================================
 // In-memory buffer implementations
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Read for &'a [u8] {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let amt = cmp::min(buf.len(), self.len());
@@ -83,11 +114,13 @@ impl<'a> Read for &'a [u8] {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> BufRead for &'a [u8] {
     fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(*self) }
     fn consume(&mut self, amt: usize) { *self = &self[amt..]; }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Write for &'a mut [u8] {
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
         let amt = cmp::min(data.len(), self.len());
@@ -108,6 +141,7 @@ impl<'a> Write for &'a mut [u8] {
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Write for Vec<u8> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.push_all(buf);
@@ -115,7 +149,7 @@ impl Write for Vec<u8> {
     }
 
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        try!(self.write(buf));
+        self.push_all(buf);
         Ok(())
     }
 

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -12,7 +12,7 @@
 
 use prelude::v1::*;
 
-use io::{self, Read, Write, ErrorKind};
+use io::{self, Read, Write, ErrorKind, BufRead};
 
 /// Copies the entire contents of a reader into a writer.
 ///
@@ -27,6 +27,7 @@ use io::{self, Read, Write, ErrorKind};
 /// This function will return an error immediately if any call to `read` or
 /// `write` returns an error. All instances of `ErrorKind::Interrupted` are
 /// handled by this function and the underlying operation is retried.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub fn copy<R: Read, W: Write>(r: &mut R, w: &mut W) -> io::Result<u64> {
     let mut buf = [0; super::DEFAULT_BUF_SIZE];
     let mut written = 0;
@@ -43,26 +44,37 @@ pub fn copy<R: Read, W: Write>(r: &mut R, w: &mut W) -> io::Result<u64> {
 }
 
 /// A reader which is always at EOF.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub struct Empty { _priv: () }
 
 /// Creates an instance of an empty reader.
 ///
 /// All reads from the returned reader will return `Ok(0)`.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub fn empty() -> Empty { Empty { _priv: () } }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Read for Empty {
     fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> { Ok(0) }
 }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl BufRead for Empty {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> { Ok(&[]) }
+    fn consume(&mut self, _n: usize) {}
+}
 
 /// A reader which infinitely yields one byte.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub struct Repeat { byte: u8 }
 
 /// Creates an instance of a reader that infinitely repeats one byte.
 ///
 /// All reads from this reader will succeed by filling the specified buffer with
 /// the given byte.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub fn repeat(byte: u8) -> Repeat { Repeat { byte: byte } }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Read for Repeat {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         for slot in buf.iter_mut() {
@@ -73,14 +85,17 @@ impl Read for Repeat {
 }
 
 /// A writer which will move data into the void.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub struct Sink { _priv: () }
 
 /// Creates an instance of a writer which will successfully consume all data.
 ///
 /// All calls to `write` on the returned instance will return `Ok(buf.len())`
 /// and the contents of the buffer will not be inspected.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub fn sink() -> Sink { Sink { _priv: () } }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 impl Write for Sink {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
     fn flush(&mut self) -> io::Result<()> { Ok(()) }

--- a/src/libstd/old_io/util.rs
+++ b/src/libstd/old_io/util.rs
@@ -10,6 +10,8 @@
 
 //! Utility implementations of Reader and Writer
 
+#![allow(deprecated)]
+
 use prelude::v1::*;
 use cmp;
 use old_io;
@@ -17,13 +19,19 @@ use slice::bytes::MutableByteVector;
 
 /// Wraps a `Reader`, limiting the number of bytes that can be read from it.
 #[derive(Debug)]
+#[deprecated(since = "1.0.0", reason = "use std::io::Take")]
+#[unstable(feature = "old_io")]
 pub struct LimitReader<R> {
     limit: uint,
     inner: R
 }
 
+#[deprecated(since = "1.0.0", reason = "use std::io::Take")]
+#[unstable(feature = "old_io")]
 impl<R: Reader> LimitReader<R> {
     /// Creates a new `LimitReader`
+    #[deprecated(since = "1.0.0", reason = "use std::io's take method instead")]
+    #[unstable(feature = "old_io")]
     pub fn new(r: R, limit: uint) -> LimitReader<R> {
         LimitReader { limit: limit, inner: r }
     }
@@ -41,6 +49,8 @@ impl<R: Reader> LimitReader<R> {
     pub fn limit(&self) -> uint { self.limit }
 }
 
+#[deprecated(since = "1.0.0", reason = "use std::io's take method instead")]
+#[unstable(feature = "old_io")]
 impl<R: Reader> Reader for LimitReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> old_io::IoResult<uint> {
         if self.limit == 0 {
@@ -57,6 +67,8 @@ impl<R: Reader> Reader for LimitReader<R> {
     }
 }
 
+#[deprecated(since = "1.0.0", reason = "use std::io's take method instead")]
+#[unstable(feature = "old_io")]
 impl<R: Buffer> Buffer for LimitReader<R> {
     fn fill_buf<'a>(&'a mut self) -> old_io::IoResult<&'a [u8]> {
         let amt = try!(self.inner.fill_buf());
@@ -79,8 +91,12 @@ impl<R: Buffer> Buffer for LimitReader<R> {
 
 /// A `Writer` which ignores bytes written to it, like /dev/null.
 #[derive(Copy, Debug)]
+#[deprecated(since = "1.0.0", reason = "use std::io::sink() instead")]
+#[unstable(feature = "old_io")]
 pub struct NullWriter;
 
+#[deprecated(since = "1.0.0", reason = "use std::io::sink() instead")]
+#[unstable(feature = "old_io")]
 impl Writer for NullWriter {
     #[inline]
     fn write_all(&mut self, _buf: &[u8]) -> old_io::IoResult<()> { Ok(()) }
@@ -88,8 +104,12 @@ impl Writer for NullWriter {
 
 /// A `Reader` which returns an infinite stream of 0 bytes, like /dev/zero.
 #[derive(Copy, Debug)]
+#[deprecated(since = "1.0.0", reason = "use std::io::repeat(0) instead")]
+#[unstable(feature = "old_io")]
 pub struct ZeroReader;
 
+#[deprecated(since = "1.0.0", reason = "use std::io::repeat(0) instead")]
+#[unstable(feature = "old_io")]
 impl Reader for ZeroReader {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> old_io::IoResult<uint> {
@@ -98,6 +118,8 @@ impl Reader for ZeroReader {
     }
 }
 
+#[deprecated(since = "1.0.0", reason = "use std::io::repeat(0) instead")]
+#[unstable(feature = "old_io")]
 impl Buffer for ZeroReader {
     fn fill_buf<'a>(&'a mut self) -> old_io::IoResult<&'a [u8]> {
         static DATA: [u8; 64] = [0; 64];
@@ -109,8 +131,12 @@ impl Buffer for ZeroReader {
 
 /// A `Reader` which is always at EOF, like /dev/null.
 #[derive(Copy, Debug)]
+#[deprecated(since = "1.0.0", reason = "use std::io::empty() instead")]
+#[unstable(feature = "old_io")]
 pub struct NullReader;
 
+#[deprecated(since = "1.0.0", reason = "use std::io::empty() instead")]
+#[unstable(feature = "old_io")]
 impl Reader for NullReader {
     #[inline]
     fn read(&mut self, _buf: &mut [u8]) -> old_io::IoResult<uint> {
@@ -118,6 +144,8 @@ impl Reader for NullReader {
     }
 }
 
+#[deprecated(since = "1.0.0", reason = "use std::io::empty() instead")]
+#[unstable(feature = "old_io")]
 impl Buffer for NullReader {
     fn fill_buf<'a>(&'a mut self) -> old_io::IoResult<&'a [u8]> {
         Err(old_io::standard_error(old_io::EndOfFile))
@@ -130,17 +158,23 @@ impl Buffer for NullReader {
 /// The `Writer`s are delegated to in order. If any `Writer` returns an error,
 /// that error is returned immediately and remaining `Writer`s are not called.
 #[derive(Debug)]
+#[deprecated(since = "1.0.0", reason = "use std::io::Broadcast instead")]
+#[unstable(feature = "old_io")]
 pub struct MultiWriter<W> {
     writers: Vec<W>
 }
 
 impl<W> MultiWriter<W> where W: Writer {
     /// Creates a new `MultiWriter`
+    #[deprecated(since = "1.0.0", reason = "use std::io's broadcast method instead")]
+    #[unstable(feature = "old_io")]
     pub fn new(writers: Vec<W>) -> MultiWriter<W> {
         MultiWriter { writers: writers }
     }
 }
 
+#[deprecated(since = "1.0.0", reason = "use std::io::Broadcast instead")]
+#[unstable(feature = "old_io")]
 impl<W> Writer for MultiWriter<W> where W: Writer {
     #[inline]
     fn write_all(&mut self, buf: &[u8]) -> old_io::IoResult<()> {
@@ -162,6 +196,8 @@ impl<W> Writer for MultiWriter<W> where W: Writer {
 /// A `Reader` which chains input from multiple `Reader`s, reading each to
 /// completion before moving onto the next.
 #[derive(Clone, Debug)]
+#[deprecated(since = "1.0.0", reason = "use std::io::Chain instead")]
+#[unstable(feature = "old_io")]
 pub struct ChainedReader<I, R> {
     readers: I,
     cur_reader: Option<R>,
@@ -169,12 +205,16 @@ pub struct ChainedReader<I, R> {
 
 impl<R: Reader, I: Iterator<Item=R>> ChainedReader<I, R> {
     /// Creates a new `ChainedReader`
+    #[deprecated(since = "1.0.0", reason = "use std::io's chain method instead")]
+    #[unstable(feature = "old_io")]
     pub fn new(mut readers: I) -> ChainedReader<I, R> {
         let r = readers.next();
         ChainedReader { readers: readers, cur_reader: r }
     }
 }
 
+#[deprecated(since = "1.0.0", reason = "use std::io::Chain instead")]
+#[unstable(feature = "old_io")]
 impl<R: Reader, I: Iterator<Item=R>> Reader for ChainedReader<I, R> {
     fn read(&mut self, buf: &mut [u8]) -> old_io::IoResult<uint> {
         loop {
@@ -201,13 +241,19 @@ impl<R: Reader, I: Iterator<Item=R>> Reader for ChainedReader<I, R> {
 /// A `Reader` which forwards input from another `Reader`, passing it along to
 /// a `Writer` as well. Similar to the `tee(1)` command.
 #[derive(Debug)]
+#[deprecated(since = "1.0.0", reason = "use std::io::Tee instead")]
+#[unstable(feature = "old_io")]
 pub struct TeeReader<R, W> {
     reader: R,
     writer: W,
 }
 
+#[deprecated(since = "1.0.0", reason = "use std::io::Tee instead")]
+#[unstable(feature = "old_io")]
 impl<R: Reader, W: Writer> TeeReader<R, W> {
     /// Creates a new `TeeReader`
+    #[deprecated(since = "1.0.0", reason = "use std::io's tee method instead")]
+    #[unstable(feature = "old_io")]
     pub fn new(r: R, w: W) -> TeeReader<R, W> {
         TeeReader { reader: r, writer: w }
     }
@@ -220,6 +266,8 @@ impl<R: Reader, W: Writer> TeeReader<R, W> {
     }
 }
 
+#[deprecated(since = "1.0.0", reason = "use std::io::Tee instead")]
+#[unstable(feature = "old_io")]
 impl<R: Reader, W: Writer> Reader for TeeReader<R, W> {
     fn read(&mut self, buf: &mut [u8]) -> old_io::IoResult<uint> {
         self.reader.read(buf).and_then(|len| {
@@ -229,6 +277,8 @@ impl<R: Reader, W: Writer> Reader for TeeReader<R, W> {
 }
 
 /// Copies all data from a `Reader` to a `Writer`.
+#[deprecated(since = "1.0.0", reason = "use std::io's copy function instead")]
+#[unstable(feature = "old_io")]
 pub fn copy<R: Reader, W: Writer>(r: &mut R, w: &mut W) -> old_io::IoResult<()> {
     let mut buf = [0; super::DEFAULT_BUF_SIZE];
     loop {


### PR DESCRIPTION
The new `io` module has had some time to bake and this commit stabilizes some of
the utilities associated with it. This commit also deprecates a number of
`std::old_io::util` functions and structures.

These items are now `#[stable]`
- `Cursor`
- `Cursor::{new, into_inner, get_ref, get_mut, position, set_position}`
- Implementations of I/O traits for `Cursor<T>`
- Delegating implementations of I/O traits for references and `Box` pointers
- Implementations of I/O traits for primitives like slices and `Vec<T>`
- `ReadExt::bytes`
- `Bytes` (and impls)
- `ReadExt::chain`
- `Chain` (and impls)
- `ReadExt::take` (and impls)
- `BufReadExt::lines`
- `Lines` (and impls)
- `io::copy`
- `io::{empty, Empty}` (and impls)
- `io::{sink, Sink}` (and impls)
- `io::{repeat, Repeat}` (and impls)

These items remain `#[unstable]`
- Core I/O traits. These may want a little bit more time to bake along with the
  commonly used methods like `read_to_end`.
- `BufReadExt::split` - this function may be renamed to not conflict with
  `SliceExt::split`.
- `Error` - there are a number of questions about its representation,
  `ErrorKind`, and usability.

These items are now `#[deprecated]` in `old_io`
- `LimitReader` - use `take` instead
- `NullWriter` - use `io::sink` instead
- `ZeroReader` - use `io::repeat` instead
- `NullReader` - use `io::empty` instead
- `MultiWriter` - use `broadcast` instead
- `ChainedReader` - use `chain` instead
- `TeeReader` - use `tee` instead
- `copy` - use `io::copy` instead

[breaking-change]
