### PR TITLE
[RFC] Split `Copy` trait in two traits: `Pod` and `Copy`

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1705,6 +1705,7 @@ specific type.
 Implementations are defined with the keyword `impl`.
 
 ```
+# use std::marker::Pod;
 # #[derive(Copy)]
 # struct Point {x: f64, y: f64};
 # type Surface = i32;
@@ -1716,6 +1717,7 @@ struct Circle {
     center: Point,
 }
 
+impl Pod for Circle {}
 impl Copy for Circle {}
 
 impl Shape for Circle {

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -31,6 +31,8 @@ pub struct EnumSet<E> {
     marker: marker::PhantomData<E>,
 }
 
+#[cfg(not(stage0))]
+impl<E> marker::Pod for EnumSet<E> {}
 impl<E> Copy for EnumSet<E> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcollections/linked_list.rs
+++ b/src/libcollections/linked_list.rs
@@ -31,6 +31,8 @@ use core::hash::{Hasher, Hash};
 use core::iter::{self, FromIterator, IntoIterator};
 use core::mem;
 use core::ptr;
+#[cfg(not(stage0))]
+use core::marker::Pod;
 
 #[deprecated(since = "1.0.0", reason = "renamed to LinkedList")]
 #[unstable(feature = "collections")]
@@ -50,6 +52,8 @@ struct Rawlink<T> {
     p: *mut T,
 }
 
+#[cfg(not(stage0))]
+impl<T> Pod for Rawlink<T> {}
 impl<T> Copy for Rawlink<T> {}
 unsafe impl<T:Send> Send for Rawlink<T> {}
 unsafe impl<T:Sync> Sync for Rawlink<T> {}

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -51,6 +51,7 @@ pub trait Sized : MarkerTrait {
     // Empty.
 }
 
+#[cfg(stage0)]
 /// Types that can be copied by simply copying bits (i.e. `memcpy`).
 ///
 /// By default, variable bindings have 'move semantics.' In other
@@ -154,6 +155,20 @@ pub trait Sized : MarkerTrait {
 #[lang="copy"]
 pub trait Copy : MarkerTrait {
     // Empty.
+}
+
+/// TODO(japaric) docs
+#[cfg(not(stage0))]
+#[lang="copy"]
+pub trait Copy: Pod {
+    // Empty
+}
+
+/// TODO(japaric) docs
+#[cfg(not(stage0))]
+#[lang="pod"]
+pub trait Pod: MarkerTrait {
+    // Empty
 }
 
 /// Types that can be safely shared between threads when aliased.

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -273,6 +273,8 @@ macro_rules! impls{
             }
         }
 
+        #[cfg(not(stage0))]
+        impl<T:?Sized> Pod for $t<T> { }
         impl<T:?Sized> Copy for $t<T> { }
 
         impl<T:?Sized> Clone for $t<T> {

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -977,8 +977,21 @@ impl fmt::Debug for RangeFull {
     }
 }
 
+#[cfg(stage0)]
 /// A (half-open) range which is bounded at both ends.
 #[derive(Clone, PartialEq, Eq)]
+#[lang="range"]
+#[stable(feature = "rust1", since = "1.0.0")]
+pub struct Range<Idx> {
+    /// The lower bound of the range (inclusive).
+    pub start: Idx,
+    /// The upper bound of the range (exclusive).
+    pub end: Idx,
+}
+
+#[cfg(not(stage0))]
+/// A (half-open) range which is bounded at both ends.
+#[derive(Clone, Eq, PartialEq, Pod)]
 #[lang="range"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Range<Idx> {

--- a/src/libcore/raw.rs
+++ b/src/libcore/raw.rs
@@ -19,6 +19,8 @@
 //! Their definition should always match the ABI defined in `rustc::back::abi`.
 
 use marker::Copy;
+#[cfg(not(stage0))]
+use marker::Pod;
 use mem;
 
 /// The representation of a slice like `&[T]`.
@@ -62,6 +64,8 @@ pub struct Slice<T> {
 }
 
 impl<T> Copy for Slice<T> {}
+#[cfg(not(stage0))]
+impl<T> Pod for Slice<T> {}
 
 /// The representation of an old closure.
 #[repr(C)]

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -891,8 +891,11 @@ fn parse_builtin_bounds_<F>(st: &mut PState, _conv: &mut F) -> ty::BuiltinBounds
             'Z' => {
                 builtin_bounds.insert(ty::BoundSized);
             }
-            'P' => {
+            'C' => {
                 builtin_bounds.insert(ty::BoundCopy);
+            }
+            'P' => {
+                builtin_bounds.insert(ty::BoundPod);
             }
             'T' => {
                 builtin_bounds.insert(ty::BoundSync);

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -365,7 +365,8 @@ pub fn enc_builtin_bounds(w: &mut Encoder, _cx: &ctxt, bs: &ty::BuiltinBounds) {
         match bound {
             ty::BoundSend => mywrite!(w, "S"),
             ty::BoundSized => mywrite!(w, "Z"),
-            ty::BoundCopy => mywrite!(w, "P"),
+            ty::BoundCopy => mywrite!(w, "C"),
+            ty::BoundPod => mywrite!(w, "P"),
             ty::BoundSync => mywrite!(w, "T"),
         }
     }

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -95,6 +95,7 @@ impl LanguageItems {
             ty::BoundSend => self.require(SendTraitLangItem),
             ty::BoundSized => self.require(SizedTraitLangItem),
             ty::BoundCopy => self.require(CopyTraitLangItem),
+            ty::BoundPod => self.require(PodTraitLangItem),
             ty::BoundSync => self.require(SyncTraitLangItem),
         }
     }
@@ -106,6 +107,8 @@ impl LanguageItems {
             Some(ty::BoundSized)
         } else if Some(id) == self.copy_trait() {
             Some(ty::BoundCopy)
+        } else if Some(id) == self.pod_trait() {
+            Some(ty::BoundPod)
         } else if Some(id) == self.sync_trait() {
             Some(ty::BoundSync)
         } else {
@@ -242,6 +245,7 @@ lets_do_this! {
     SendTraitLangItem,               "send",                    send_trait;
     SizedTraitLangItem,              "sized",                   sized_trait;
     CopyTraitLangItem,               "copy",                    copy_trait;
+    PodTraitLangItem,                "pod",                     pod_trait;
     SyncTraitLangItem,               "sync",                    sync_trait;
 
     DropTraitLangItem,               "drop",                    drop_trait;

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -86,6 +86,8 @@ use syntax::print::pprust;
 use syntax::parse::token;
 
 use std::cell::RefCell;
+#[cfg(not(stage0))]
+use std::marker::Pod;
 use std::rc::Rc;
 
 #[derive(Clone, PartialEq, Debug)]
@@ -260,6 +262,8 @@ pub struct MemCategorizationContext<'t,TYPER:'t> {
     typer: &'t TYPER
 }
 
+#[cfg(not(stage0))]
+impl<'t,TYPER:'t> Pod for MemCategorizationContext<'t,TYPER> {}
 impl<'t,TYPER:'t> Copy for MemCategorizationContext<'t,TYPER> {}
 
 pub type McResult<T> = Result<T, ()>;

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -36,7 +36,7 @@ pub use self::IntVarValue::*;
 pub use self::ExprAdjustment::*;
 pub use self::vtable_origin::*;
 pub use self::MethodOrigin::*;
-pub use self::CopyImplementationError::*;
+pub use self::PodImplementationError::*;
 
 use back::svh::Svh;
 use session::Session;
@@ -834,6 +834,11 @@ pub struct ctxt<'tcx> {
     /// results are dependent on the parameter environment.
     pub type_impls_copy_cache: RefCell<HashMap<Ty<'tcx>,bool>>,
 
+    /// Caches whether types are known to impl Pod. Note that type
+    /// parameters are never placed into this cache, because their
+    /// results are dependent on the parameter environment.
+    pub type_impls_pod_cache: RefCell<HashMap<Ty<'tcx>,bool>>,
+
     /// Caches whether types are known to impl Sized. Note that type
     /// parameters are never placed into this cache, because their
     /// results are dependent on the parameter environment.
@@ -1601,6 +1606,7 @@ pub enum BuiltinBound {
     BoundSend,
     BoundSized,
     BoundCopy,
+    BoundPod,
     BoundSync,
 }
 
@@ -2612,6 +2618,7 @@ pub fn mk_ctxt<'tcx>(s: Session,
         selection_cache: traits::SelectionCache::new(),
         repr_hint_cache: RefCell::new(DefIdMap()),
         type_impls_copy_cache: RefCell::new(HashMap::new()),
+        type_impls_pod_cache: RefCell::new(HashMap::new()),
         type_impls_sized_cache: RefCell::new(HashMap::new()),
         object_safety_cache: RefCell::new(DefIdMap()),
         const_qualif_map: RefCell::new(NodeMap()),
@@ -3747,7 +3754,7 @@ pub fn type_contents<'tcx>(cx: &ctxt<'tcx>, ty: Ty<'tcx>) -> TypeContents {
         let mut tc = TC::All - TC::InteriorParam;
         for bound in &bounds.builtin_bounds {
             tc = tc - match bound {
-                BoundSync | BoundSend | BoundCopy => TC::None,
+                BoundSync | BoundSend | BoundCopy | BoundPod => TC::None,
                 BoundSized => TC::Nonsized,
             };
         }
@@ -3801,6 +3808,15 @@ pub fn type_moves_by_default<'a,'tcx>(param_env: &ParameterEnvironment<'a,'tcx>,
 {
     let tcx = param_env.tcx;
     !type_impls_bound(param_env, &tcx.type_impls_copy_cache, ty, ty::BoundCopy, span)
+}
+
+pub fn type_is_pod<'a,'tcx>(param_env: &ParameterEnvironment<'a,'tcx>,
+                            span: Span,
+                            ty: Ty<'tcx>)
+                            -> bool
+{
+    let tcx = param_env.tcx;
+    !type_impls_bound(param_env, &tcx.type_impls_pod_cache, ty, ty::BoundPod, span)
 }
 
 pub fn type_is_sized<'a,'tcx>(param_env: &ParameterEnvironment<'a,'tcx>,
@@ -6968,17 +6984,17 @@ pub fn make_substs_for_receiver_types<'tcx>(tcx: &ty::ctxt<'tcx>,
 }
 
 #[derive(Copy)]
-pub enum CopyImplementationError {
-    FieldDoesNotImplementCopy(ast::Name),
-    VariantDoesNotImplementCopy(ast::Name),
+pub enum PodImplementationError {
+    FieldDoesNotImplementPod(ast::Name),
+    VariantDoesNotImplementPod(ast::Name),
     TypeIsStructural,
     TypeHasDestructor,
 }
 
-pub fn can_type_implement_copy<'a,'tcx>(param_env: &ParameterEnvironment<'a, 'tcx>,
-                                        span: Span,
-                                        self_type: Ty<'tcx>)
-                                        -> Result<(),CopyImplementationError>
+pub fn can_type_implement_pod<'a,'tcx>(param_env: &ParameterEnvironment<'a, 'tcx>,
+                                       span: Span,
+                                       self_type: Ty<'tcx>)
+                                       -> Result<(), PodImplementationError>
 {
     let tcx = param_env.tcx;
 
@@ -6986,8 +7002,8 @@ pub fn can_type_implement_copy<'a,'tcx>(param_env: &ParameterEnvironment<'a, 'tc
         ty::ty_struct(struct_did, substs) => {
             let fields = ty::struct_fields(tcx, struct_did, substs);
             for field in &fields {
-                if type_moves_by_default(param_env, span, field.mt.ty) {
-                    return Err(FieldDoesNotImplementCopy(field.name))
+                if type_is_pod(param_env, span, field.mt.ty) {
+                    return Err(FieldDoesNotImplementPod(field.name))
                 }
             }
             struct_did
@@ -6998,8 +7014,8 @@ pub fn can_type_implement_copy<'a,'tcx>(param_env: &ParameterEnvironment<'a, 'tc
                 for variant_arg_type in &variant.args {
                     let substd_arg_type =
                         variant_arg_type.subst(tcx, substs);
-                    if type_moves_by_default(param_env, span, substd_arg_type) {
-                        return Err(VariantDoesNotImplementCopy(variant.name))
+                    if type_is_pod(param_env, span, substd_arg_type) {
+                        return Err(VariantDoesNotImplementPod(variant.name))
                     }
                 }
             }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -789,6 +789,7 @@ impl<'tcx> Repr<'tcx> for ty::BuiltinBounds {
                 ty::BoundSend => "Send".to_string(),
                 ty::BoundSized => "Sized".to_string(),
                 ty::BoundCopy => "Copy".to_string(),
+                ty::BoundPod => "Pod".to_string(),
                 ty::BoundSync => "Sync".to_string(),
             });
         }
@@ -1181,6 +1182,7 @@ impl<'tcx> UserString<'tcx> for ty::BuiltinBound {
             ty::BoundSend => "Send".to_string(),
             ty::BoundSized => "Sized".to_string(),
             ty::BoundCopy => "Copy".to_string(),
+            ty::BoundPod => "Pod".to_string(),
             ty::BoundSync => "Sync".to_string(),
         }
     }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -605,10 +605,12 @@ impl LintPass for RawPointerDerive {
         }
         let did = match item.node {
             ast::ItemImpl(_, _, _, ref t_ref_opt, _, _) => {
-                // Deriving the Copy trait does not cause a warning
+                // Deriving the Copy/Pod trait does not cause a warning
                 if let &Some(ref trait_ref) = t_ref_opt {
                     let def_id = ty::trait_ref_to_def_id(cx.tcx, trait_ref);
-                    if Some(def_id) == cx.tcx.lang_items.copy_trait() {
+                    if Some(def_id) == cx.tcx.lang_items.copy_trait() ||
+                        Some(def_id) == cx.tcx.lang_items.pod_trait()
+                    {
                         return;
                     }
                 }
@@ -1674,11 +1676,11 @@ impl LintPass for MissingCopyImplementations {
         if !ty::type_moves_by_default(&parameter_environment, item.span, ty) {
             return;
         }
-        if ty::can_type_implement_copy(&parameter_environment, item.span, ty).is_ok() {
+        if ty::can_type_implement_pod(&parameter_environment, item.span, ty).is_ok() {
             cx.span_lint(MISSING_COPY_IMPLEMENTATIONS,
                          item.span,
-                         "type could implement `Copy`; consider adding `impl \
-                          Copy`")
+                         "type could implement `Pod`; consider adding `impl \
+                          Pod`")
         }
     }
 }

--- a/src/librustc_llvm/diagnostic.rs
+++ b/src/librustc_llvm/diagnostic.rs
@@ -69,13 +69,12 @@ impl OptimizationDiagnostic {
     }
 }
 
+#[derive(Copy)]
 pub struct InlineAsmDiagnostic {
     pub cookie: c_uint,
     pub message: TwineRef,
     pub instruction: ValueRef,
 }
-
-impl Copy for InlineAsmDiagnostic {}
 
 impl InlineAsmDiagnostic {
     unsafe fn unpack(di: DiagnosticInfoRef)

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -231,6 +231,7 @@ fn iterate_over_potentially_unsafe_regions_in_type<'a, 'tcx>(
                             Some(ty::BoundSend) |
                             Some(ty::BoundSized) |
                             Some(ty::BoundCopy) |
+                            Some(ty::BoundPod) |
                             Some(ty::BoundSync) => false,
                             _ => true,
                         }

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -266,7 +266,7 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
                 }
             }
 
-            if fcx.tcx().lang_items.copy_trait() == Some(trait_ref.def_id) {
+            if fcx.tcx().lang_items.pod_trait() == Some(trait_ref.def_id) {
                 // This is checked in coherence.
                 return
             }

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -141,8 +141,8 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
         // the coherence tables contain the trait -> type mappings.
         self.populate_destructor_table();
 
-        // Check to make sure implementations of `Copy` are legal.
-        self.check_implementations_of_copy();
+        // Check to make sure implementations of `Pod` are legal.
+        self.check_implementations_of_pod();
     }
 
     fn check_implementation(&self, item: &Item, opt_trait: Option<&TraitRef>) {
@@ -429,21 +429,21 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
         }
     }
 
-    /// Ensures that implementations of the built-in trait `Copy` are legal.
-    fn check_implementations_of_copy(&self) {
+    /// Ensures that implementations of the built-in trait `Pod` are legal.
+    fn check_implementations_of_pod(&self) {
         let tcx = self.crate_context.tcx;
-        let copy_trait = match tcx.lang_items.copy_trait() {
+        let pod_trait = match tcx.lang_items.pod_trait() {
             Some(id) => id,
             None => return,
         };
 
         let trait_impls = match tcx.trait_impls
                                    .borrow()
-                                   .get(&copy_trait)
+                                   .get(&pod_trait)
                                    .cloned() {
             None => {
-                debug!("check_implementations_of_copy(): no types with \
-                        implementations of `Copy` found");
+                debug!("check_implementations_of_pod(): no types with \
+                        implementations of `Pod` found");
                 return
             }
             Some(found_impls) => found_impls
@@ -453,17 +453,17 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
         let trait_impls = trait_impls.borrow().clone();
 
         for &impl_did in &trait_impls {
-            debug!("check_implementations_of_copy: impl_did={}",
+            debug!("check_implementations_of_pod: impl_did={}",
                    impl_did.repr(tcx));
 
             if impl_did.krate != ast::LOCAL_CRATE {
-                debug!("check_implementations_of_copy(): impl not in this \
+                debug!("check_implementations_of_pod(): impl not in this \
                         crate");
                 continue
             }
 
             let self_type = self.get_self_type_for_implementation(impl_did);
-            debug!("check_implementations_of_copy: self_type={} (bound)",
+            debug!("check_implementations_of_pod: self_type={} (bound)",
                    self_type.repr(tcx));
 
             let span = tcx.map.span(impl_did.node);
@@ -471,34 +471,34 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
             let self_type = self_type.ty.subst(tcx, &param_env.free_substs);
             assert!(!self_type.has_escaping_regions());
 
-            debug!("check_implementations_of_copy: self_type={} (free)",
+            debug!("check_implementations_of_pod: self_type={} (free)",
                    self_type.repr(tcx));
 
-            match ty::can_type_implement_copy(&param_env, span, self_type) {
+            match ty::can_type_implement_pod(&param_env, span, self_type) {
                 Ok(()) => {}
-                Err(ty::FieldDoesNotImplementCopy(name)) => {
+                Err(ty::FieldDoesNotImplementPod(name)) => {
                        span_err!(tcx.sess, span, E0204,
-                                 "the trait `Copy` may not be \
+                                 "the trait `Pod` may not be \
                                           implemented for this type; field \
-                                          `{}` does not implement `Copy`",
+                                          `{}` does not implement `Pod`",
                                          token::get_name(name))
                 }
-                Err(ty::VariantDoesNotImplementCopy(name)) => {
+                Err(ty::VariantDoesNotImplementPod(name)) => {
                        span_err!(tcx.sess, span, E0205,
-                                 "the trait `Copy` may not be \
+                                 "the trait `Pod` may not be \
                                           implemented for this type; variant \
-                                          `{}` does not implement `Copy`",
+                                          `{}` does not implement `Pod`",
                                          token::get_name(name))
                 }
                 Err(ty::TypeIsStructural) => {
                        span_err!(tcx.sess, span, E0206,
-                                 "the trait `Copy` may not be implemented \
+                                 "the trait `Pod` may not be implemented \
                                   for this type; type is not a structure or \
                                   enumeration")
                 }
                 Err(ty::TypeHasDestructor) => {
                     span_err!(tcx.sess, span, E0184,
-                              "the trait `Copy` may not be implemented for this type; \
+                              "the trait `Pod` may not be implemented for this type; \
                                the type has a destructor");
                 }
             }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -597,6 +597,9 @@ impl Clean<TyParamBound> for ty::BuiltinBound {
             ty::BoundCopy =>
                 (tcx.lang_items.copy_trait().unwrap(),
                  external_path(cx, "Copy", None, vec![], &empty)),
+            ty::BoundPod =>
+                (tcx.lang_items.pod_trait().unwrap(),
+                 external_path(cx, "Pod", None, vec![], &empty)),
             ty::BoundSync =>
                 (tcx.lang_items.sync_trait().unwrap(),
                  external_path(cx, "Sync", None, vec![], &empty)),

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -17,6 +17,8 @@ use cmp;
 use hash::{Hash, Hasher};
 use iter::{Iterator, IteratorExt, ExactSizeIterator, count};
 use marker::{Copy, Send, Sync, Sized, self};
+#[cfg(not(stage0))]
+use marker::Pod;
 use mem::{min_align_of, size_of};
 use mem;
 use num::{Int, UnsignedInt};
@@ -87,6 +89,8 @@ struct RawBucket<K, V> {
     _marker: marker::PhantomData<(K,V)>,
 }
 
+#[cfg(not(stage0))]
+impl<K,V> Pod for RawBucket<K,V> {}
 impl<K,V> Copy for RawBucket<K,V> {}
 
 pub struct Bucket<K, V, M> {
@@ -95,6 +99,9 @@ pub struct Bucket<K, V, M> {
     table: M
 }
 
+// XXX(japaric) needs auditing
+#[cfg(not(stage0))]
+impl<K,V,M:Copy> Pod for Bucket<K,V,M> {}
 impl<K,V,M:Copy> Copy for Bucket<K,V,M> {}
 
 pub struct EmptyBucket<K, V, M> {

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -17,19 +17,18 @@ use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 use ptr::P;
 
-pub fn expand_deriving_clone<F>(cx: &mut ExtCtxt,
-                                span: Span,
-                                mitem: &MetaItem,
-                                item: &Item,
-                                push: F) where
-    F: FnOnce(P<Item>),
-{
+pub fn expand_deriving_clone(cx: &mut ExtCtxt,
+                             span: Span,
+                             mitem: &MetaItem,
+                             item: &Item,
+                             push: &mut FnMut(P<Item>)) {
     let inline = cx.meta_word(span, InternedString::new("inline"));
     let attrs = vec!(cx.attribute(span, inline));
     let trait_def = TraitDef {
         span: span,
         attributes: Vec::new(),
         path: path_std!(cx, core::clone::Clone),
+        bound_self: true,
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         methods: vec!(

--- a/src/libsyntax/ext/deriving/cmp/eq.rs
+++ b/src/libsyntax/ext/deriving/cmp/eq.rs
@@ -17,13 +17,11 @@ use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 use ptr::P;
 
-pub fn expand_deriving_eq<F>(cx: &mut ExtCtxt,
-                             span: Span,
-                             mitem: &MetaItem,
-                             item: &Item,
-                             push: F) where
-    F: FnOnce(P<Item>),
-{
+pub fn expand_deriving_eq(cx: &mut ExtCtxt,
+                          span: Span,
+                          mitem: &MetaItem,
+                          item: &Item,
+                          push: &mut FnMut(P<Item>)) {
     // structures are equal if all fields are equal, and non equal, if
     // any fields are not equal or if the enum variants are different
     fn cs_eq(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
@@ -83,6 +81,7 @@ pub fn expand_deriving_eq<F>(cx: &mut ExtCtxt,
         span: span,
         attributes: Vec::new(),
         path: path_std!(cx, core::cmp::PartialEq),
+        bound_self: true,
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         methods: vec!(

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -20,13 +20,11 @@ use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 use ptr::P;
 
-pub fn expand_deriving_ord<F>(cx: &mut ExtCtxt,
-                              span: Span,
-                              mitem: &MetaItem,
-                              item: &Item,
-                              push: F) where
-    F: FnOnce(P<Item>),
-{
+pub fn expand_deriving_ord(cx: &mut ExtCtxt,
+                           span: Span,
+                           mitem: &MetaItem,
+                           item: &Item,
+                           push: &mut FnMut(P<Item>)) {
     macro_rules! md {
         ($name:expr, $op:expr, $equal:expr) => { {
             let inline = cx.meta_word(span, InternedString::new("inline"));
@@ -70,6 +68,7 @@ pub fn expand_deriving_ord<F>(cx: &mut ExtCtxt,
         span: span,
         attributes: vec![],
         path: path_std!(cx, core::cmp::PartialOrd),
+        bound_self: true,
         additional_bounds: vec![],
         generics: LifetimeBounds::empty(),
         methods: vec![

--- a/src/libsyntax/ext/deriving/cmp/totaleq.rs
+++ b/src/libsyntax/ext/deriving/cmp/totaleq.rs
@@ -17,13 +17,11 @@ use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 use ptr::P;
 
-pub fn expand_deriving_totaleq<F>(cx: &mut ExtCtxt,
-                                  span: Span,
-                                  mitem: &MetaItem,
-                                  item: &Item,
-                                  push: F) where
-    F: FnOnce(P<Item>),
-{
+pub fn expand_deriving_totaleq(cx: &mut ExtCtxt,
+                               span: Span,
+                               mitem: &MetaItem,
+                               item: &Item,
+                               push: &mut FnMut(P<Item>)) {
     fn cs_total_eq_assert(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
         cs_same_method(|cx, span, exprs| {
             // create `a.<method>(); b.<method>(); c.<method>(); ...`
@@ -48,6 +46,7 @@ pub fn expand_deriving_totaleq<F>(cx: &mut ExtCtxt,
         span: span,
         attributes: Vec::new(),
         path: path_std!(cx, core::cmp::Eq),
+        bound_self: true,
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         methods: vec!(

--- a/src/libsyntax/ext/deriving/cmp/totalord.rs
+++ b/src/libsyntax/ext/deriving/cmp/totalord.rs
@@ -18,19 +18,18 @@ use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 use ptr::P;
 
-pub fn expand_deriving_totalord<F>(cx: &mut ExtCtxt,
-                                   span: Span,
-                                   mitem: &MetaItem,
-                                   item: &Item,
-                                   push: F) where
-    F: FnOnce(P<Item>),
-{
+pub fn expand_deriving_totalord(cx: &mut ExtCtxt,
+                                span: Span,
+                                mitem: &MetaItem,
+                                item: &Item,
+                                push: &mut FnMut(P<Item>)) {
     let inline = cx.meta_word(span, InternedString::new("inline"));
     let attrs = vec!(cx.attribute(span, inline));
     let trait_def = TraitDef {
         span: span,
         attributes: Vec::new(),
         path: path_std!(cx, core::cmp::Ord),
+        bound_self: true,
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         methods: vec!(

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -21,34 +21,28 @@ use parse::token::InternedString;
 use parse::token;
 use ptr::P;
 
-pub fn expand_deriving_rustc_decodable<F>(cx: &mut ExtCtxt,
-                                          span: Span,
-                                          mitem: &MetaItem,
-                                          item: &Item,
-                                          push: F) where
-    F: FnOnce(P<Item>),
-{
+pub fn expand_deriving_rustc_decodable(cx: &mut ExtCtxt,
+                                       span: Span,
+                                       mitem: &MetaItem,
+                                       item: &Item,
+                                       push: &mut FnMut(P<Item>)) {
     expand_deriving_decodable_imp(cx, span, mitem, item, push, "rustc_serialize")
 }
 
-pub fn expand_deriving_decodable<F>(cx: &mut ExtCtxt,
-                                    span: Span,
-                                    mitem: &MetaItem,
-                                    item: &Item,
-                                    push: F) where
-    F: FnOnce(P<Item>),
-{
+pub fn expand_deriving_decodable(cx: &mut ExtCtxt,
+                                 span: Span,
+                                 mitem: &MetaItem,
+                                 item: &Item,
+                                 push: &mut FnMut(P<Item>)) {
     expand_deriving_decodable_imp(cx, span, mitem, item, push, "serialize")
 }
 
-fn expand_deriving_decodable_imp<F>(cx: &mut ExtCtxt,
-                                    span: Span,
-                                    mitem: &MetaItem,
-                                    item: &Item,
-                                    push: F,
-                                    krate: &'static str) where
-    F: FnOnce(P<Item>),
-{
+fn expand_deriving_decodable_imp(cx: &mut ExtCtxt,
+                                 span: Span,
+                                 mitem: &MetaItem,
+                                 item: &Item,
+                                 push: &mut FnMut(P<Item>),
+                                 krate: &'static str) {
     if !cx.use_std {
         // FIXME(#21880): lift this requirement.
         cx.span_err(span, "this trait cannot be derived with #![no_std]");
@@ -59,6 +53,7 @@ fn expand_deriving_decodable_imp<F>(cx: &mut ExtCtxt,
         span: span,
         attributes: Vec::new(),
         path: Path::new_(vec!(krate, "Decodable"), None, vec!(), true),
+        bound_self: true,
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         methods: vec!(

--- a/src/libsyntax/ext/deriving/default.rs
+++ b/src/libsyntax/ext/deriving/default.rs
@@ -17,19 +17,18 @@ use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 use ptr::P;
 
-pub fn expand_deriving_default<F>(cx: &mut ExtCtxt,
-                                  span: Span,
-                                  mitem: &MetaItem,
-                                  item: &Item,
-                                  push: F) where
-    F: FnOnce(P<Item>),
-{
+pub fn expand_deriving_default(cx: &mut ExtCtxt,
+                               span: Span,
+                               mitem: &MetaItem,
+                               item: &Item,
+                               push: &mut FnMut(P<Item>)) {
     let inline = cx.meta_word(span, InternedString::new("inline"));
     let attrs = vec!(cx.attribute(span, inline));
     let trait_def = TraitDef {
         span: span,
         attributes: Vec::new(),
         path: path_std!(cx, core::default::Default),
+        bound_self: true,
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         methods: vec!(

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -97,34 +97,28 @@ use ext::deriving::generic::ty::*;
 use parse::token;
 use ptr::P;
 
-pub fn expand_deriving_rustc_encodable<F>(cx: &mut ExtCtxt,
-                                          span: Span,
-                                          mitem: &MetaItem,
-                                          item: &Item,
-                                          push: F) where
-    F: FnOnce(P<Item>),
-{
+pub fn expand_deriving_rustc_encodable(cx: &mut ExtCtxt,
+                                       span: Span,
+                                       mitem: &MetaItem,
+                                       item: &Item,
+                                       push: &mut FnMut(P<Item>)) {
     expand_deriving_encodable_imp(cx, span, mitem, item, push, "rustc_serialize")
 }
 
-pub fn expand_deriving_encodable<F>(cx: &mut ExtCtxt,
-                                    span: Span,
-                                    mitem: &MetaItem,
-                                    item: &Item,
-                                    push: F) where
-    F: FnOnce(P<Item>),
-{
+pub fn expand_deriving_encodable(cx: &mut ExtCtxt,
+                                 span: Span,
+                                 mitem: &MetaItem,
+                                 item: &Item,
+                                 push: &mut FnMut(P<Item>)) {
     expand_deriving_encodable_imp(cx, span, mitem, item, push, "serialize")
 }
 
-fn expand_deriving_encodable_imp<F>(cx: &mut ExtCtxt,
-                                    span: Span,
-                                    mitem: &MetaItem,
-                                    item: &Item,
-                                    push: F,
-                                    krate: &'static str) where
-    F: FnOnce(P<Item>),
-{
+fn expand_deriving_encodable_imp(cx: &mut ExtCtxt,
+                                 span: Span,
+                                 mitem: &MetaItem,
+                                 item: &Item,
+                                 push: &mut FnMut(P<Item>),
+                                 krate: &'static str) {
     if !cx.use_std {
         // FIXME(#21880): lift this requirement.
         cx.span_err(span, "this trait cannot be derived with #![no_std]");
@@ -135,6 +129,7 @@ fn expand_deriving_encodable_imp<F>(cx: &mut ExtCtxt,
         span: span,
         attributes: Vec::new(),
         path: Path::new_(vec!(krate, "Encodable"), None, vec!(), true),
+        bound_self: true,
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         methods: vec!(

--- a/src/libsyntax/ext/deriving/hash.rs
+++ b/src/libsyntax/ext/deriving/hash.rs
@@ -16,13 +16,11 @@ use ext::deriving::generic::*;
 use ext::deriving::generic::ty::*;
 use ptr::P;
 
-pub fn expand_deriving_hash<F>(cx: &mut ExtCtxt,
-                               span: Span,
-                               mitem: &MetaItem,
-                               item: &Item,
-                               push: F) where
-    F: FnOnce(P<Item>),
-{
+pub fn expand_deriving_hash(cx: &mut ExtCtxt,
+                            span: Span,
+                            mitem: &MetaItem,
+                            item: &Item,
+                            push: &mut FnMut(P<Item>)) {
 
     let path = Path::new_(pathvec_std!(cx, core::hash::Hash), None,
                           vec!(), true);
@@ -31,6 +29,7 @@ pub fn expand_deriving_hash<F>(cx: &mut ExtCtxt,
         span: span,
         attributes: Vec::new(),
         path: path,
+        bound_self: true,
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         methods: vec!(

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -141,7 +141,7 @@ macro_rules! derive_traits {
                               item: &Item,
                               push: &mut FnMut(P<Item>)) {
                         warn_if_deprecated(ecx, sp, $name);
-                        $func(ecx, sp, mitem, item, |i| push(i));
+                        $func(ecx, sp, mitem, item, push);
                     }
                 }
 
@@ -189,6 +189,7 @@ derive_traits! {
     "Send" => bounds::expand_deriving_unsafe_bound,
     "Sync" => bounds::expand_deriving_unsafe_bound,
     "Copy" => bounds::expand_deriving_copy,
+    "Pod" => bounds::expand_deriving_pod,
 
     // deprecated
     "Show" => show::expand_deriving_show,

--- a/src/libsyntax/ext/deriving/primitive.rs
+++ b/src/libsyntax/ext/deriving/primitive.rs
@@ -18,19 +18,18 @@ use ext::deriving::generic::ty::*;
 use parse::token::InternedString;
 use ptr::P;
 
-pub fn expand_deriving_from_primitive<F>(cx: &mut ExtCtxt,
-                                         span: Span,
-                                         mitem: &MetaItem,
-                                         item: &Item,
-                                         push: F) where
-    F: FnOnce(P<Item>),
-{
+pub fn expand_deriving_from_primitive(cx: &mut ExtCtxt,
+                                      span: Span,
+                                      mitem: &MetaItem,
+                                      item: &Item,
+                                      push: &mut FnMut(P<Item>)) {
     let inline = cx.meta_word(span, InternedString::new("inline"));
     let attrs = vec!(cx.attribute(span, inline));
     let trait_def = TraitDef {
         span: span,
         attributes: Vec::new(),
         path: path_std!(cx, core::num::FromPrimitive),
+        bound_self: true,
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         methods: vec!(

--- a/src/libsyntax/ext/deriving/rand.rs
+++ b/src/libsyntax/ext/deriving/rand.rs
@@ -17,13 +17,11 @@ use ext::deriving::generic::*;
 use ext::deriving::generic::ty::*;
 use ptr::P;
 
-pub fn expand_deriving_rand<F>(cx: &mut ExtCtxt,
-                               span: Span,
-                               mitem: &MetaItem,
-                               item: &Item,
-                               push: F) where
-    F: FnOnce(P<Item>),
-{
+pub fn expand_deriving_rand(cx: &mut ExtCtxt,
+                            span: Span,
+                            mitem: &MetaItem,
+                            item: &Item,
+                            push: &mut FnMut(P<Item>)) {
     cx.span_warn(span,
                  "`#[derive(Rand)]` is deprecated in favour of `#[derive_Rand]` from \
                   `rand_macros` on crates.io");
@@ -38,6 +36,7 @@ pub fn expand_deriving_rand<F>(cx: &mut ExtCtxt,
         span: span,
         attributes: Vec::new(),
         path: path!(std::rand::Rand),
+        bound_self: true,
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         methods: vec!(

--- a/src/libsyntax/ext/deriving/show.rs
+++ b/src/libsyntax/ext/deriving/show.rs
@@ -21,13 +21,11 @@ use ptr::P;
 
 use std::collections::HashMap;
 
-pub fn expand_deriving_show<F>(cx: &mut ExtCtxt,
-                               span: Span,
-                               mitem: &MetaItem,
-                               item: &Item,
-                               push: F) where
-    F: FnOnce(P<Item>),
-{
+pub fn expand_deriving_show(cx: &mut ExtCtxt,
+                            span: Span,
+                            mitem: &MetaItem,
+                            item: &Item,
+                            push: &mut FnMut(P<Item>)) {
     // &mut ::std::fmt::Formatter
     let fmtr = Ptr(box Literal(path_std!(cx, core::fmt::Formatter)),
                    Borrowed(None, ast::MutMutable));
@@ -36,6 +34,7 @@ pub fn expand_deriving_show<F>(cx: &mut ExtCtxt,
         span: span,
         attributes: Vec::new(),
         path: path_std!(cx, core::fmt::Debug),
+        bound_self: true,
         additional_bounds: Vec::new(),
         generics: LifetimeBounds::empty(),
         methods: vec![

--- a/src/test/compile-fail/exclusive-drop-and-copy.rs
+++ b/src/test/compile-fail/exclusive-drop-and-copy.rs
@@ -12,14 +12,14 @@
 
 // issue #20126
 
-#[derive(Copy)] //~ ERROR the trait `Copy` may not be implemented
+#[derive(Copy)] //~ ERROR the trait `Pod` may not be implemented
 struct Foo;
 
 impl Drop for Foo {
     fn drop(&mut self) {}
 }
 
-#[derive(Copy)] //~ ERROR the trait `Copy` may not be implemented
+#[derive(Copy)] //~ ERROR the trait `Pod` may not be implemented
 struct Bar<T>(::std::marker::PhantomData<T>);
 
 #[unsafe_destructor]

--- a/src/test/compile-fail/opt-in-copy.rs
+++ b/src/test/compile-fail/opt-in-copy.rs
@@ -15,7 +15,7 @@ struct IWantToCopyThis {
 }
 
 impl Copy for IWantToCopyThis {}
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `core::marker::Pod` is not implemented
 
 enum CantCopyThisEither {
     A,
@@ -27,7 +27,7 @@ enum IWantToCopyThisToo {
 }
 
 impl Copy for IWantToCopyThisToo {}
-//~^ ERROR the trait `Copy` may not be implemented for this type
+//~^ ERROR the trait `core::marker::Pod` is not implemented
 
 fn main() {}
 

--- a/src/test/compile-fail/pod-is-not-implicitly-copyable.rs
+++ b/src/test/compile-fail/pod-is-not-implicitly-copyable.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::marker::Pod;
+
+fn drop<T>(_: T) {}
+
+fn double_move<T: Pod>(x: T) {
+    drop(x);
+    drop(x);  //~ ERROR use of moved value: `x`
+}
+
+fn main() {}

--- a/src/test/compile-fail/type-with-destructor-cant-impl-pod.rs
+++ b/src/test/compile-fail/type-with-destructor-cant-impl-pod.rs
@@ -1,0 +1,26 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::marker::Pod;
+
+struct Atom {
+    data: u64,
+}
+
+impl Drop for Atom {
+    fn drop(&mut self) {
+        // decrease refcount
+    }
+}
+
+impl Pod for Atom {}
+//~^ error: the trait `Pod` may not be implemented for this type; the type has a destructor
+
+fn main() {}

--- a/src/test/run-make/simd-ffi/simd.rs
+++ b/src/test/run-make/simd-ffi/simd.rs
@@ -75,6 +75,9 @@ pub trait Sized : PhantomFn<Self> {}
 #[lang = "copy"]
 pub trait Copy : PhantomFn<Self> {}
 
+#[lang = "pod"]
+pub trait Pod : PhantomFn<Self> {}
+
 #[lang="phantom_fn"]
 pub trait PhantomFn<A:?Sized,R:?Sized=()> { }
 impl<A:?Sized, R:?Sized, U:?Sized> PhantomFn<A,R> for U { }
@@ -82,5 +85,6 @@ impl<A:?Sized, R:?Sized, U:?Sized> PhantomFn<A,R> for U { }
 mod core {
     pub mod marker {
         pub use Copy;
+        pub use Pod;
     }
 }

--- a/src/test/run-pass/copy-out-of-array-1.rs
+++ b/src/test/run-pass/copy-out-of-array-1.rs
@@ -12,8 +12,11 @@
 //
 // (Compare with compile-fail/move-out-of-array-1.rs)
 
+use std::marker::Pod;
+
 struct C { _x: u8 }
 
+impl Pod for C { }
 impl Copy for C { }
 
 fn main() {

--- a/src/test/run-pass/derive-copy-on-pod-type.rs
+++ b/src/test/run-pass/derive-copy-on-pod-type.rs
@@ -1,0 +1,23 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This is not implicitly copyable
+#[derive(Pod)]
+struct Stuff {
+    x: u8,
+}
+
+// But this can be implicitly copyable
+#[derive(Copy)]
+struct Copyable {
+    pod: Stuff,
+}
+
+fn main() {}

--- a/src/test/run-pass/issue-22536-copy-mustnt-zero.rs
+++ b/src/test/run-pass/issue-22536-copy-mustnt-zero.rs
@@ -11,6 +11,8 @@
 // Regression test for Issue #22536: If a type implements Copy, then
 // moving it must not zero the original memory.
 
+use std::marker::Pod;
+
 trait Resources {
     type Buffer: Copy;
     fn foo(&self) {}
@@ -19,12 +21,14 @@ trait Resources {
 struct BufferHandle<R: Resources> {
     raw: <R as Resources>::Buffer,
 }
+impl<R: Resources> Pod for BufferHandle<R> {}
 impl<R: Resources> Copy for BufferHandle<R> {}
 
 enum Res {}
 impl Resources for Res {
     type Buffer = u32;
 }
+impl Pod for Res { }
 impl Copy for Res { }
 
 fn main() {

--- a/src/test/run-pass/regions-early-bound-used-in-bound.rs
+++ b/src/test/run-pass/regions-early-bound-used-in-bound.rs
@@ -11,6 +11,8 @@
 // Tests that you can use a fn lifetime parameter as part of
 // the value for a type parameter in a bound.
 
+use std::marker::Pod;
+
 trait GetRef<'a, T> {
     fn get(&self) -> &'a T;
 }
@@ -19,6 +21,7 @@ struct Box<'a, T:'a> {
     t: &'a T
 }
 
+impl<'a,T:'a> Pod for Box<'a,T> {}
 impl<'a,T:'a> Copy for Box<'a,T> {}
 
 impl<'a,T:Clone> GetRef<'a,T> for Box<'a,T> {


### PR DESCRIPTION
### DO NOT MERGE NEEDS AN APPROVED RFC.
- The `Pod` trait is used to mark types that can be cloned by simply copying its bytes on the stack.
- The `Copy` trait is used to mark types that are implictly copyable.
- `Pod` can only be derived by structs/enums whose fields are also `Pod`
- `Copy` can only be derived by types that are `Pod`, i.e. `trait Copy: Pod {}`
- To avoid a massive breakage, the `#[derive(Copy)]` syntax extension now derives _both_ the `Pod` and `Copy` traits.
- A `#[derive(Pod)]` syntax extension have been added to derive the `Pod` trait
- `Cell<T>`'s `T: Copy` bound has been relaxed to `T: Pod`, this lets you use it with a wider variety of types like iterators, which are not implicitly copyable.

[breaking-change]s
- If you were manually implementing the `Copy` trait, you'll have to manually implement `Pod` as well:

``` diff
  impl<T> Copy for MyType<T> {}
+ impl<T> Pod for MyType<T> {}
```
- To have `#![derive(Copy)]` expand into _two_ items, it was necessary to change the unstable `#[derive]` API. This will likely break third-party `#[derive]` extensions.

---

~~I plon to finish writing a proper RFC by tomorrow, but here's the [current draft](https://gist.github.com/japaric/7357578eec950cb89339).~~
[RFC](https://github.com/rust-lang/rfcs/pull/936)

cc @aturon @nikomatsakis @tbu-
cc #21846
