### PR TITLE
Minor refactoring/modernization/reintegration/enhancement of --pretty.

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -580,6 +580,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "Include assignment analysis data in --pretty flowgraph output"),
     flowgraph_print_all: bool = (false, parse_bool,
         "Include all dataflow analysis data in --pretty flowgraph output"),
+    pretty_keep_going: bool = (false, parse_bool,
+        "Do not stop after pretty-printing (use with --pretty)"),
     print_region_graph: bool = (false, parse_bool,
          "Prints region inference graph. \
           Use with RUST_REGION_GRAPH=help for more info"),

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -582,6 +582,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "Include all dataflow analysis data in --pretty flowgraph output"),
     pretty_keep_going: bool = (false, parse_bool,
         "Do not stop after pretty-printing (use with --pretty)"),
+    pretty_dump_dir: Option<String> = (None, parse_opt_string,
+        "The directory where --pretty output will be saved"),
     print_region_graph: bool = (false, parse_bool,
          "Prints region inference graph. \
           Use with RUST_REGION_GRAPH=help for more info"),

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -108,6 +108,7 @@ pub fn compile_input(sess: Session,
                                                                  &sess,
                                                                  outdir,
                                                                  output,
+                                                                 &outputs,
                                                                  &expanded_crate,
                                                                  &id[..]));
 
@@ -122,6 +123,7 @@ pub fn compile_input(sess: Session,
                                                                      &sess,
                                                                      outdir,
                                                                      output,
+                                                                     &outputs,
                                                                      &ast_map,
                                                                      &ast_map.krate(),
                                                                      &id[..]));
@@ -137,6 +139,7 @@ pub fn compile_input(sess: Session,
                                                                    &analysis.ty_cx.sess,
                                                                    outdir,
                                                                    output,
+                                                                   &outputs,
                                                                    analysis.ty_cx.map.krate(),
                                                                    &analysis,
                                                                    &analysis.ty_cx));
@@ -164,6 +167,7 @@ pub fn compile_input(sess: Session,
                                                            &sess,
                                                            outdir,
                                                            output,
+                                                           &outputs,
                                                            &trans));
 
     phase_6_link_output(&sess, &trans, &outputs);
@@ -259,17 +263,18 @@ impl<'a, 'tcx> CompileState<'a, 'tcx> {
     fn empty(input: &'a Input,
              session: &'a Session,
              out_dir: &'a Option<Path>,
-             output: &'a Option<Path>)
+             output: &'a Option<Path>,
+             output_filenames: Option<&'a OutputFilenames>)
              -> CompileState<'a, 'tcx> {
         CompileState {
             input: input,
             session: session,
             out_dir: out_dir.as_ref(),
             output: output.as_ref(),
+            output_filenames: output_filenames,
             cfg: None,
             krate: None,
             crate_name: None,
-            output_filenames: None,
             expanded_crate: None,
             ast_map: None,
             analysis: None,
@@ -286,7 +291,7 @@ impl<'a, 'tcx> CompileState<'a, 'tcx> {
                          -> CompileState<'a, 'tcx> {
         CompileState {
             krate: Some(krate),
-            .. CompileState::empty(input, session, out_dir, output)
+            .. CompileState::empty(input, session, out_dir, output, None)
         }
     }
 
@@ -294,13 +299,15 @@ impl<'a, 'tcx> CompileState<'a, 'tcx> {
                           session: &'a Session,
                           out_dir: &'a Option<Path>,
                           output: &'a Option<Path>,
+                          output_filenames: &'a OutputFilenames,
                           expanded_crate: &'a ast::Crate,
                           crate_name: &'a str)
                           -> CompileState<'a, 'tcx> {
         CompileState {
             crate_name: Some(crate_name),
             expanded_crate: Some(expanded_crate),
-            .. CompileState::empty(input, session, out_dir, output)
+            .. CompileState::empty(input, session, out_dir, output,
+                                   Some(output_filenames))
         }
     }
 
@@ -308,6 +315,7 @@ impl<'a, 'tcx> CompileState<'a, 'tcx> {
                               session: &'a Session,
                               out_dir: &'a Option<Path>,
                               output: &'a Option<Path>,
+                              output_filenames: &'a OutputFilenames,
                               ast_map: &'a ast_map::Map<'tcx>,
                               expanded_crate: &'a ast::Crate,
                               crate_name: &'a str)
@@ -316,7 +324,8 @@ impl<'a, 'tcx> CompileState<'a, 'tcx> {
             crate_name: Some(crate_name),
             ast_map: Some(ast_map),
             expanded_crate: Some(expanded_crate),
-            .. CompileState::empty(input, session, out_dir, output)
+            .. CompileState::empty(input, session, out_dir, output,
+                                   Some(output_filenames))
         }
     }
 
@@ -324,6 +333,7 @@ impl<'a, 'tcx> CompileState<'a, 'tcx> {
                             session: &'a Session,
                             out_dir: &'a Option<Path>,
                             output: &'a Option<Path>,
+                            output_filenames: &'a OutputFilenames,
                             expanded_crate: &'a ast::Crate,
                             analysis: &'a ty::CrateAnalysis<'tcx>,
                             tcx: &'a ty::ctxt<'tcx>)
@@ -332,7 +342,8 @@ impl<'a, 'tcx> CompileState<'a, 'tcx> {
             analysis: Some(analysis),
             tcx: Some(tcx),
             expanded_crate: Some(expanded_crate),
-            .. CompileState::empty(input, session, out_dir, output)
+            .. CompileState::empty(input, session, out_dir, output,
+                                   Some(output_filenames))
         }
     }
 
@@ -341,11 +352,13 @@ impl<'a, 'tcx> CompileState<'a, 'tcx> {
                         session: &'a Session,
                         out_dir: &'a Option<Path>,
                         output: &'a Option<Path>,
+                        output_filenames: &'a OutputFilenames,
                         trans: &'a trans::CrateTranslation)
                         -> CompileState<'a, 'tcx> {
         CompileState {
             trans: Some(trans),
-            .. CompileState::empty(input, session, out_dir, output)
+            .. CompileState::empty(input, session, out_dir, output,
+                                   Some(output_filenames))
         }
     }
 }

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -336,7 +336,7 @@ pub fn phase_1_parse_input(sess: &Session, cfg: ast::CrateConfig, input: &Input)
     syntax::ext::mtwt::reset_tables();
     token::reset_ident_interner();
 
-    let krate = time(sess.time_passes(), "parsing", (), |_| {
+    let krate = time(sess.time_passes(), "parsing", || {
         match *input {
             Input::File(ref file) => {
                 parse::parse_crate_from_file(&(*file), cfg.clone(), &sess.parse_sess)
@@ -383,7 +383,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
     *sess.crate_metadata.borrow_mut() =
         collect_crate_metadata(sess, &krate.attrs);
 
-    time(time_passes, "recursion limit", (), |_| {
+    time(time_passes, "recursion limit", || {
         middle::recursion_limit::update_recursion_limit(sess, &krate);
     });
 
@@ -395,7 +395,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
     //
     // baz! should not use this definition unless foo is enabled.
 
-    time(time_passes, "gated macro checking", (), |_| {
+    time(time_passes, "gated macro checking", || {
         let features =
             syntax::feature_gate::check_crate_macros(sess.codemap(),
                                                      &sess.parse_sess.span_diagnostic,
@@ -406,23 +406,23 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         sess.abort_if_errors();
     });
 
-    krate = time(time_passes, "configuration 1", krate, |krate|
+    krate = time(time_passes, "configuration 1", ||
                  syntax::config::strip_unconfigured_items(sess.diagnostic(), krate));
 
-    krate = time(time_passes, "crate injection", krate, |krate|
+    krate = time(time_passes, "crate injection", ||
                  syntax::std_inject::maybe_inject_crates_ref(krate,
                                                              sess.opts.alt_std_name.clone()));
 
-    let macros = time(time_passes, "macro loading", (), |_|
+    let macros = time(time_passes, "macro loading", ||
         metadata::macro_import::read_macro_defs(sess, &krate));
 
     let mut addl_plugins = Some(addl_plugins);
-    let registrars = time(time_passes, "plugin loading", (), |_|
+    let registrars = time(time_passes, "plugin loading", ||
         plugin::load::load_plugins(sess, &krate, addl_plugins.take().unwrap()));
 
     let mut registry = Registry::new(sess, &krate);
 
-    time(time_passes, "plugin registration", registrars, |registrars| {
+    time(time_passes, "plugin registration", || {
         if sess.features.borrow().rustc_diagnostic_macros {
             registry.register_macro("__diagnostic_used",
                 diagnostics::plugin::expand_diagnostic_used);
@@ -461,40 +461,38 @@ pub fn phase_2_configure_and_expand(sess: &Session,
     // Abort if there are errors from lint processing or a plugin registrar.
     sess.abort_if_errors();
 
-    krate = time(time_passes, "expansion", (krate, macros, syntax_exts),
-        |(krate, macros, syntax_exts)| {
-            // Windows dlls do not have rpaths, so they don't know how to find their
-            // dependencies. It's up to us to tell the system where to find all the
-            // dependent dlls. Note that this uses cfg!(windows) as opposed to
-            // targ_cfg because syntax extensions are always loaded for the host
-            // compiler, not for the target.
-            let mut _old_path = OsString::from_str("");
-            if cfg!(windows) {
-                _old_path = env::var_os("PATH").unwrap_or(_old_path);
-                let mut new_path = sess.host_filesearch(PathKind::All).get_dylib_search_paths();
-                new_path.extend(os::split_paths(_old_path.to_str().unwrap()).into_iter());
-                env::set_var("PATH", &env::join_paths(new_path.iter()).unwrap());
-            }
-            let features = sess.features.borrow();
-            let cfg = syntax::ext::expand::ExpansionConfig {
-                crate_name: crate_name.to_string(),
-                features: Some(&features),
-                recursion_limit: sess.recursion_limit.get(),
-            };
-            let ret = syntax::ext::expand::expand_crate(&sess.parse_sess,
-                                              cfg,
-                                              macros,
-                                              syntax_exts,
-                                              krate);
-            if cfg!(windows) {
-                env::set_var("PATH", &_old_path);
-            }
-            ret
+    krate = time(time_passes, "expansion", || {
+        // Windows dlls do not have rpaths, so they don't know how to find their
+        // dependencies. It's up to us to tell the system where to find all the
+        // dependent dlls. Note that this uses cfg!(windows) as opposed to
+        // targ_cfg because syntax extensions are always loaded for the host
+        // compiler, not for the target.
+        let mut _old_path = OsString::from_str("");
+        if cfg!(windows) {
+            _old_path = env::var_os("PATH").unwrap_or(_old_path);
+            let mut new_path = sess.host_filesearch(PathKind::All).get_dylib_search_paths();
+            new_path.extend(os::split_paths(_old_path.to_str().unwrap()).into_iter());
+            env::set_var("PATH", &env::join_paths(new_path.iter()).unwrap());
         }
-    );
+        let features = sess.features.borrow();
+        let cfg = syntax::ext::expand::ExpansionConfig {
+            crate_name: crate_name.to_string(),
+            features: Some(&features),
+            recursion_limit: sess.recursion_limit.get(),
+        };
+        let ret = syntax::ext::expand::expand_crate(&sess.parse_sess,
+                                                    cfg,
+                                                    macros,
+                                                    syntax_exts,
+                                                    krate);
+        if cfg!(windows) {
+            env::set_var("PATH", &_old_path);
+        }
+        ret
+    });
 
     // Needs to go *after* expansion to be able to check the results of macro expansion.
-    time(time_passes, "complete gated feature checking", (), |_| {
+    time(time_passes, "complete gated feature checking", || {
         let features =
             syntax::feature_gate::check_crate(sess.codemap(),
                                           &sess.parse_sess.span_diagnostic,
@@ -506,20 +504,20 @@ pub fn phase_2_configure_and_expand(sess: &Session,
     // JBC: make CFG processing part of expansion to avoid this problem:
 
     // strip again, in case expansion added anything with a #[cfg].
-    krate = time(time_passes, "configuration 2", krate, |krate|
+    krate = time(time_passes, "configuration 2", ||
                  syntax::config::strip_unconfigured_items(sess.diagnostic(), krate));
 
-    krate = time(time_passes, "maybe building test harness", krate, |krate|
+    krate = time(time_passes, "maybe building test harness", ||
                  syntax::test::modify_for_testing(&sess.parse_sess,
                                                   &sess.opts.cfg,
                                                   krate,
                                                   sess.diagnostic()));
 
-    krate = time(time_passes, "prelude injection", krate, |krate|
+    krate = time(time_passes, "prelude injection", ||
                  syntax::std_inject::maybe_inject_prelude(krate));
 
-    time(time_passes, "checking that all macro invocations are gone", &krate, |krate|
-         syntax::ext::expand::check_for_macros(&sess.parse_sess, krate));
+    time(time_passes, "checking that all macro invocations are gone", ||
+         syntax::ext::expand::check_for_macros(&sess.parse_sess, &krate));
 
     Some(krate)
 }
@@ -538,7 +536,7 @@ pub fn assign_node_ids_and_map<'ast>(sess: &Session,
         }
     }
 
-    let map = time(sess.time_passes(), "assigning node ids and indexing ast", forest, |forest|
+    let map = time(sess.time_passes(), "assigning node ids and indexing ast", move ||
                    ast_map::map_crate(forest, NodeIdAssigner { sess: sess }));
 
     if sess.opts.debugging_opts.ast_json {
@@ -560,10 +558,10 @@ pub fn phase_3_run_analysis_passes<'tcx>(sess: Session,
     let time_passes = sess.time_passes();
     let krate = ast_map.krate();
 
-    time(time_passes, "external crate/lib resolution", (), |_|
+    time(time_passes, "external crate/lib resolution", ||
          CrateReader::new(&sess).read_crates(krate));
 
-    let lang_items = time(time_passes, "language item collection", (), |_|
+    let lang_items = time(time_passes, "language item collection", ||
                           middle::lang_items::collect_language_items(krate, &sess));
 
     let resolve::CrateMap {
@@ -573,35 +571,34 @@ pub fn phase_3_run_analysis_passes<'tcx>(sess: Session,
         trait_map,
         external_exports,
         glob_map,
-    } =
-        time(time_passes, "resolution", (),
-             |_| resolve::resolve_crate(&sess,
-                                        &ast_map,
-                                        &lang_items,
-                                        krate,
-                                        make_glob_map));
+    } = time(time_passes, "resolution", ||
+             resolve::resolve_crate(&sess,
+                                    &ast_map,
+                                    &lang_items,
+                                    krate,
+                                    make_glob_map));
 
     // Discard MTWT tables that aren't required past resolution.
     syntax::ext::mtwt::clear_tables();
 
-    let named_region_map = time(time_passes, "lifetime resolution", (),
-                                |_| middle::resolve_lifetime::krate(&sess, krate, &def_map));
+    let named_region_map = time(time_passes, "lifetime resolution", ||
+                                middle::resolve_lifetime::krate(&sess, krate, &def_map));
 
-    time(time_passes, "looking for entry point", (),
-         |_| middle::entry::find_entry_point(&sess, &ast_map));
+    time(time_passes, "looking for entry point", ||
+         middle::entry::find_entry_point(&sess, &ast_map));
 
     sess.plugin_registrar_fn.set(
-        time(time_passes, "looking for plugin registrar", (), |_|
+        time(time_passes, "looking for plugin registrar", ||
             plugin::build::find_plugin_registrar(
                 sess.diagnostic(), krate)));
 
-    let region_map = time(time_passes, "region resolution", (), |_|
+    let region_map = time(time_passes, "region resolution", ||
                           middle::region::resolve_crate(&sess, krate));
 
-    time(time_passes, "loop checking", (), |_|
+    time(time_passes, "loop checking", ||
          middle::check_loop::check_crate(&sess, krate));
 
-    time(time_passes, "static item recursion checking", (), |_|
+    time(time_passes, "static item recursion checking", ||
          middle::check_static_recursion::check_crate(&sess, krate, &def_map, &ast_map));
 
     let ty_cx = ty::mk_ctxt(sess,
@@ -617,33 +614,33 @@ pub fn phase_3_run_analysis_passes<'tcx>(sess: Session,
     // passes are timed inside typeck
     typeck::check_crate(&ty_cx, trait_map);
 
-    time(time_passes, "const checking", (), |_|
+    time(time_passes, "const checking", ||
          middle::check_const::check_crate(&ty_cx));
 
     let (exported_items, public_items) =
-            time(time_passes, "privacy checking", (), |_|
+            time(time_passes, "privacy checking", ||
                  rustc_privacy::check_crate(&ty_cx, &export_map, external_exports));
 
     // Do not move this check past lint
-    time(time_passes, "stability index", (), |_|
+    time(time_passes, "stability index", ||
          ty_cx.stability.borrow_mut().build(&ty_cx.sess, krate, &public_items));
 
-    time(time_passes, "intrinsic checking", (), |_|
+    time(time_passes, "intrinsic checking", ||
          middle::intrinsicck::check_crate(&ty_cx));
 
-    time(time_passes, "effect checking", (), |_|
+    time(time_passes, "effect checking", ||
          middle::effect::check_crate(&ty_cx));
 
-    time(time_passes, "match checking", (), |_|
+    time(time_passes, "match checking", ||
          middle::check_match::check_crate(&ty_cx));
 
-    time(time_passes, "liveness checking", (), |_|
+    time(time_passes, "liveness checking", ||
          middle::liveness::check_crate(&ty_cx));
 
-    time(time_passes, "borrow checking", (), |_|
+    time(time_passes, "borrow checking", ||
          borrowck::check_crate(&ty_cx));
 
-    time(time_passes, "rvalue checking", (), |_|
+    time(time_passes, "rvalue checking", ||
          middle::check_rvalues::check_crate(&ty_cx, krate));
 
     // Avoid overwhelming user with errors if type checking failed.
@@ -654,24 +651,24 @@ pub fn phase_3_run_analysis_passes<'tcx>(sess: Session,
     ty_cx.sess.abort_if_errors();
 
     let reachable_map =
-        time(time_passes, "reachability checking", (), |_|
+        time(time_passes, "reachability checking", ||
              reachable::find_reachable(&ty_cx, &exported_items));
 
-    time(time_passes, "death checking", (), |_| {
+    time(time_passes, "death checking", || {
         middle::dead::check_crate(&ty_cx,
                                   &exported_items,
                                   &reachable_map)
     });
 
     let ref lib_features_used =
-        time(time_passes, "stability checking", (), |_|
+        time(time_passes, "stability checking", ||
              stability::check_unstable_api_usage(&ty_cx));
 
-    time(time_passes, "unused lib feature checking", (), |_|
+    time(time_passes, "unused lib feature checking", ||
          stability::check_unused_or_stable_features(
              &ty_cx.sess, lib_features_used));
 
-    time(time_passes, "lint checking", (), |_|
+    time(time_passes, "lint checking", ||
          lint::check_crate(&ty_cx, &exported_items));
 
     // The above three passes generate errors w/o aborting
@@ -694,11 +691,11 @@ pub fn phase_4_translate_to_llvm<'tcx>(analysis: ty::CrateAnalysis<'tcx>)
                                        -> (ty::ctxt<'tcx>, trans::CrateTranslation) {
     let time_passes = analysis.ty_cx.sess.time_passes();
 
-    time(time_passes, "resolving dependency formats", (), |_|
+    time(time_passes, "resolving dependency formats", ||
          dependency_format::calculate(&analysis.ty_cx));
 
     // Option dance to work around the lack of stack once closures.
-    time(time_passes, "translation", analysis, |analysis|
+    time(time_passes, "translation", ||
          trans::trans_crate(analysis))
 }
 
@@ -710,7 +707,7 @@ pub fn phase_5_run_llvm_passes(sess: &Session,
     if sess.opts.cg.no_integrated_as {
         let output_type = config::OutputTypeAssembly;
 
-        time(sess.time_passes(), "LLVM passes", (), |_|
+        time(sess.time_passes(), "LLVM passes", ||
             write::run_passes(sess, trans, &[output_type], outputs));
 
         write::run_assembler(sess, outputs);
@@ -720,7 +717,7 @@ pub fn phase_5_run_llvm_passes(sess: &Session,
             fs::unlink(&outputs.temp_path(config::OutputTypeAssembly)).unwrap();
         }
     } else {
-        time(sess.time_passes(), "LLVM passes", (), |_|
+        time(sess.time_passes(), "LLVM passes", ||
             write::run_passes(sess,
                               trans,
                               &sess.opts.output_types,
@@ -740,7 +737,7 @@ pub fn phase_6_link_output(sess: &Session,
     new_path.extend(os::split_paths(old_path.to_str().unwrap()).into_iter());
     env::set_var("PATH", &env::join_paths(new_path.iter()).unwrap());
 
-    time(sess.time_passes(), "linking", (), |_|
+    time(sess.time_passes(), "linking", ||
          link::link_binary(sess,
                            trans,
                            outputs,

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -144,13 +144,9 @@ pub fn run_compiler<'a>(args: &[String],
 
     // It is somewhat unfortunate that this is hardwired in - this is forced by
     // the fact that pretty_print_input requires the session by value.
-    let pretty = callbacks.parse_pretty(&sess, &matches);
-    match pretty {
-        Some((ppm, opt_uii)) => {
-            pretty::pretty_print_input(sess, cfg, &input, ppm, opt_uii, ofile);
-            return;
-        }
-        None => {/* continue */ }
+    if let Some((ppm, opt_uii)) = callbacks.parse_pretty(&sess, &matches) {
+        pretty::pretty_print_input(sess, cfg, &input, ppm, opt_uii, ofile).unwrap();
+        return;
     }
 
     let plugins = sess.opts.debugging_opts.extra_plugins.clone();

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -377,12 +377,11 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
         if sess.opts.debugging_opts.save_analysis {
             control.after_analysis.callback = box |state| {
                 time(state.session.time_passes(),
-                     "save analysis",
-                     state.expanded_crate.unwrap(),
-                     |krate| save::process_crate(state.session,
-                                                 krate,
-                                                 state.analysis.unwrap(),
-                                                 state.out_dir));
+                     "save analysis", ||
+                     save::process_crate(state.session,
+                                         state.expanded_crate.unwrap(),
+                                         state.analysis.unwrap(),
+                                         state.out_dir));
             };
             control.make_glob_map = resolve::MakeGlobMap::Yes;
         }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -342,7 +342,10 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
                 let output = state.output;
                 pretty::print_from_phase(state, ppm, opt_uii.as_ref(), output).unwrap();
             };
-            phase.stop = Compilation::Stop;
+
+            if !sess.opts.debugging_opts.pretty_keep_going {
+                phase.stop = Compilation::Stop;
+            }
         }
 
         if self.save_analysis {

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -98,7 +98,7 @@ const BUG_REPORT_URL: &'static str =
 
 
 pub fn run(args: Vec<String>) -> int {
-    monitor(move || run_compiler(&args, &mut RustcDefaultCalls));
+    monitor(move || run_compiler(&args, &mut RustcDefaultCalls::new()));
     0
 }
 
@@ -141,13 +141,6 @@ pub fn run_compiler<'a>(args: &[String],
     let cfg = config::build_configuration(&sess);
 
     do_or_return!(callbacks.late_callback(&matches, &sess, &input, &odir, &ofile));
-
-    // It is somewhat unfortunate that this is hardwired in - this is forced by
-    // the fact that pretty_print_input requires the session by value.
-    if let Some((ppm, opt_uii)) = callbacks.parse_pretty(&sess, &matches) {
-        pretty::pretty_print_input(sess, cfg, &input, ppm, opt_uii, ofile).unwrap();
-        return;
-    }
 
     let plugins = sess.opts.debugging_opts.extra_plugins.clone();
     let control = callbacks.build_controller(&sess);
@@ -235,33 +228,15 @@ pub trait CompilerCalls<'a> {
                 &diagnostics::registry::Registry)
                 -> Option<(Input, Option<Path>)>;
 
-    // Parse pretty printing information from the arguments. The implementer can
-    // choose to ignore this (the default will return None) which will skip pretty
-    // printing. If you do want to pretty print, it is recommended to use the
-    // implementation of this method from RustcDefaultCalls.
-    // FIXME, this is a terrible bit of API. Parsing of pretty printing stuff
-    // should be done as part of the framework and the implementor should customise
-    // handling of it. However, that is not possible atm because pretty printing
-    // essentially goes off and takes another path through the compiler which
-    // means the session is either moved or not depending on what parse_pretty
-    // returns (we could fix this by cloning, but it's another hack). The proper
-    // solution is to handle pretty printing as if it were a compiler extension,
-    // extending CompileController to make this work (see for example the treatment
-    // of save-analysis in RustcDefaultCalls::build_controller).
-    fn parse_pretty(&mut self,
-                    _sess: &Session,
-                    _matches: &getopts::Matches)
-                    -> Option<(PpMode, Option<UserIdentifiedItem>)> {
-        None
-    }
-
     // Create a CompilController struct for controlling the behaviour of compilation.
     fn build_controller(&mut self, &Session) -> CompileController<'a>;
 }
 
 // CompilerCalls instance for a regular rustc build.
-#[derive(Copy)]
-pub struct RustcDefaultCalls;
+pub struct RustcDefaultCalls {
+    save_analysis: bool,
+    pretty_print: Option<(PpMode, Option<UserIdentifiedItem>)>
+}
 
 impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
     fn early_callback(&mut self,
@@ -316,28 +291,6 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
         None
     }
 
-    fn parse_pretty(&mut self,
-                    sess: &Session,
-                    matches: &getopts::Matches)
-                    -> Option<(PpMode, Option<UserIdentifiedItem>)> {
-        let pretty = if sess.opts.debugging_opts.unstable_options {
-            matches.opt_default("pretty", "normal").map(|a| {
-                // stable pretty-print variants only
-                pretty::parse_pretty(sess, &a, false)
-            })
-        } else {
-            None
-        };
-        if pretty.is_none() && sess.unstable_options() {
-            matches.opt_str("xpretty").map(|a| {
-                // extended with unstable pretty-print variants
-                pretty::parse_pretty(sess, &a, true)
-            })
-        } else {
-            pretty
-        }
-    }
-
     fn late_callback(&mut self,
                      matches: &getopts::Matches,
                      sess: &Session,
@@ -345,6 +298,18 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
                      odir: &Option<Path>,
                      ofile: &Option<Path>)
                      -> Compilation {
+        self.save_analysis = sess.opts.debugging_opts.save_analysis;
+
+        if sess.unstable_options() {
+            self.pretty_print = matches.opt_default("pretty", "normal").map(|a| {
+                // stable pretty-print variants only
+                pretty::parse_pretty(sess, &a, false)
+            }).or_else(|| matches.opt_str("xpretty").map(|a| {
+                // extended with unstable pretty-print variants
+                pretty::parse_pretty(sess, &a, true)
+            }));
+        }
+
         RustcDefaultCalls::print_crate_info(sess, Some(input), odir, ofile).and_then(
             || RustcDefaultCalls::list_metadata(sess, matches, input))
     }
@@ -370,7 +335,17 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
             control.after_llvm.stop = Compilation::Stop;
         }
 
-        if sess.opts.debugging_opts.save_analysis {
+        if let Some((ppm, opt_uii)) = self.pretty_print.take() {
+            let phase = pretty::printing_phase(&mut control, ppm, opt_uii.as_ref());
+
+            phase.callback = box move |state| {
+                let output = state.output;
+                pretty::print_from_phase(state, ppm, opt_uii.as_ref(), output).unwrap();
+            };
+            phase.stop = Compilation::Stop;
+        }
+
+        if self.save_analysis {
             control.after_analysis.callback = box |state| {
                 time(state.session.time_passes(),
                      "save analysis", ||
@@ -387,6 +362,13 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
 }
 
 impl RustcDefaultCalls {
+    pub fn new() -> RustcDefaultCalls {
+        RustcDefaultCalls {
+            save_analysis: false,
+            pretty_print: None
+        }
+    }
+
     pub fn list_metadata(sess: &Session,
                          matches: &getopts::Matches,
                          input: &Input)

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -181,9 +181,7 @@ impl<'a, 'tcx> pprust::PpAnn for TypedAnnotation<'a, 'tcx> {
             node: pprust::AnnNode) -> old_io::IoResult<()> {
         match node {
             pprust::NodeExpr(expr) => {
-                try!(pp::space(&mut s.s));
-                try!(pp::word(&mut s.s, "as"));
-                try!(pp::space(&mut s.s));
+                try!(s.word_space(":"));
                 try!(pp::word(&mut s.s,
                               &ppaux::ty_to_string(
                                   self.tcx,

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -788,7 +788,7 @@ fn link_natively(sess: &Session, trans: &CrateTranslation, dylib: bool,
 
     // Invoke the system linker
     debug!("{:?}", &cmd);
-    let prog = time(sess.time_passes(), "running linker", (), |()| cmd.output());
+    let prog = time(sess.time_passes(), "running linker", || cmd.output());
     match prog {
         Ok(prog) => {
             if !prog.status.success() {
@@ -1190,7 +1190,7 @@ fn add_upstream_rust_crates(cmd: &mut Command, sess: &Session,
             let name = &name[3..name.len() - 5]; // chop off lib/.rlib
             time(sess.time_passes(),
                  &format!("altering {}.rlib", name),
-                 (), |()| {
+                 || {
                 let dst = tmpdir.join(cratepath.filename().unwrap());
                 match fs::copy(&cratepath, &dst) {
                     Ok(..) => {}

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -460,9 +460,9 @@ unsafe fn optimize_and_codegen(cgcx: &CodegenContext,
             }
 
             // Finally, run the actual optimization passes
-            time(config.time_passes, "llvm function passes", (), |()|
+            time(config.time_passes, "llvm function passes", ||
                  llvm::LLVMRustRunFunctionPassManager(fpm, llmod));
-            time(config.time_passes, "llvm module passes", (), |()|
+            time(config.time_passes, "llvm module passes", ||
                  llvm::LLVMRunPassManager(mpm, llmod));
 
             // Deallocate managers that we're now done with
@@ -471,7 +471,7 @@ unsafe fn optimize_and_codegen(cgcx: &CodegenContext,
 
             match cgcx.lto_ctxt {
                 Some((sess, reachable)) if sess.lto() =>  {
-                    time(sess.time_passes(), "all lto passes", (), |()|
+                    time(sess.time_passes(), "all lto passes", ||
                          lto::run(sess, llmod, tm, reachable));
 
                     if config.emit_lto_bc {
@@ -515,7 +515,7 @@ unsafe fn optimize_and_codegen(cgcx: &CodegenContext,
         llvm::LLVMWriteBitcodeToFile(llmod, out.as_ptr());
     }
 
-    time(config.time_passes, "codegen passes", (), |()| {
+    time(config.time_passes, "codegen passes", || {
         if config.emit_ir {
             let ext = format!("{}.ll", name_extra);
             let out = output_names.with_extension(&ext);

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -326,20 +326,20 @@ pub fn check_crate(tcx: &ty::ctxt, trait_map: ty::TraitMap) {
         tcx: tcx
     };
 
-    time(time_passes, "type collecting", (), |_|
+    time(time_passes, "type collecting", ||
          collect::collect_item_types(tcx));
 
     // this ensures that later parts of type checking can assume that items
     // have valid types and not error
     tcx.sess.abort_if_errors();
 
-    time(time_passes, "variance inference", (), |_|
+    time(time_passes, "variance inference", ||
          variance::infer_variance(tcx));
 
-    time(time_passes, "coherence checking", (), |_|
+    time(time_passes, "coherence checking", ||
         coherence::check_coherence(&ccx));
 
-    time(time_passes, "type checking", (), |_|
+    time(time_passes, "type checking", ||
         check::check_item_types(&ccx));
 
     check_for_entry_fn(&ccx);

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -199,7 +199,7 @@ pub mod rt {
         fn to_source(&self) -> String {
             let lit = dummy_spanned(ast::LitStr(
                     token::intern_and_get_ident(self), ast::CookedStr));
-            pprust::lit_to_string(&lit)
+            pprust::lit_to_string(&lit).into_owned()
         }
     }
     impl ToSourceWithHygiene for str {
@@ -222,7 +222,7 @@ pub mod rt {
     impl ToSource for bool {
         fn to_source(&self) -> String {
             let lit = dummy_spanned(ast::LitBool(*self));
-            pprust::lit_to_string(&lit)
+            pprust::lit_to_string(&lit).into_owned()
         }
     }
     impl ToSourceWithHygiene for bool {
@@ -234,7 +234,7 @@ pub mod rt {
     impl ToSource for char {
         fn to_source(&self) -> String {
             let lit = dummy_spanned(ast::LitChar(*self));
-            pprust::lit_to_string(&lit)
+            pprust::lit_to_string(&lit).into_owned()
         }
     }
     impl ToSourceWithHygiene for char {
@@ -249,7 +249,7 @@ pub mod rt {
                 fn to_source(&self) -> String {
                     let lit = ast::LitInt(*self as u64, ast::SignedIntLit($tag,
                                                                           ast::Sign::new(*self)));
-                    pprust::lit_to_string(&dummy_spanned(lit))
+                    pprust::lit_to_string(&dummy_spanned(lit)).into_owned()
                 }
             }
             impl ToSourceWithHygiene for $t {
@@ -262,7 +262,7 @@ pub mod rt {
             impl ToSource for $t {
                 fn to_source(&self) -> String {
                     let lit = ast::LitInt(*self as u64, ast::UnsignedIntLit($tag));
-                    pprust::lit_to_string(&dummy_spanned(lit))
+                    pprust::lit_to_string(&dummy_spanned(lit)).into_owned()
                 }
             }
             impl ToSourceWithHygiene for $t {

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -20,18 +20,18 @@ extern crate "std" as std;
 
 // #4264 fixed-length vector types
 
-pub fn foo(_: [i32; (3 as usize)]) { }
+pub fn foo(_: [i32; (3: usize)]) { }
 
 pub fn bar() {
-    const FOO: usize = ((5 as usize) - (4 as usize) as usize);
-    let _: [(); (FOO as usize)] = ([(() as ())] as [(); 1]);
+    const FOO: usize = ((5: usize) - (4: usize): usize);
+    let _: [(); (FOO: usize)] = ([((): ())]: [(); 1]);
 
-    let _: [(); (1usize as usize)] = ([(() as ())] as [(); 1]);
+    let _: [(); (1usize: usize)] = ([((): ())]: [(); 1]);
 
     let _ =
-        (((&((([(1 as i32), (2 as i32), (3 as i32)] as [i32; 3])) as [i32; 3])
-              as &[i32; 3]) as *const _ as *const [i32; 3]) as
-            *const [i32; (3usize as usize)] as *const [i32; 3]);
+        (((&((([(1: i32), (2: i32), (3: i32)]: [i32; 3])): [i32; 3]):
+              &[i32; 3]) as *const _: *const [i32; 3]) as
+            *const [i32; (3usize: usize)]: *const [i32; 3]);
 
 
 
@@ -41,56 +41,44 @@ pub fn bar() {
 
 
 
-    ((::std::fmt::format as
-         fn(core::fmt::Arguments<'_>) -> collections::string::String {collections::fmt::format})(((::std::fmt::Arguments::new_v1
-                                                                                                      as
+    ((::std::fmt::format:
+         fn(core::fmt::Arguments<'_>) -> collections::string::String {collections::fmt::format})(((::std::fmt::Arguments::new_v1:
                                                                                                       fn(&[&str], &[core::fmt::ArgumentV1<'_>]) -> core::fmt::Arguments<'_> {core::fmt::Arguments<'a>::new_v1})(({
                                                                                                                                                                                                                      static __STATIC_FMTSTR:
                                                                                                                                                                                                                             &'static [&'static str]
                                                                                                                                                                                                                             =
-                                                                                                                                                                                                                         (&([("test"
-                                                                                                                                                                                                                                 as
-                                                                                                                                                                                                                                 &'static str)]
-                                                                                                                                                                                                                               as
-                                                                                                                                                                                                                               [&'static str; 1])
-                                                                                                                                                                                                                             as
+                                                                                                                                                                                                                         (&([("test":
+                                                                                                                                                                                                                                 &'static str)]:
+                                                                                                                                                                                                                               [&'static str; 1]):
                                                                                                                                                                                                                              &'static [&'static str; 1]);
-                                                                                                                                                                                                                     (__STATIC_FMTSTR
-                                                                                                                                                                                                                         as
+                                                                                                                                                                                                                     (__STATIC_FMTSTR:
                                                                                                                                                                                                                          &'static [&'static str])
-                                                                                                                                                                                                                 }
-                                                                                                                                                                                                                    as
+                                                                                                                                                                                                                 }:
                                                                                                                                                                                                                     &[&str]),
-                                                                                                                                                                                                                (&(match (()
-                                                                                                                                                                                                                             as
+                                                                                                                                                                                                                (&(match (():
                                                                                                                                                                                                                              ())
                                                                                                                                                                                                                        {
                                                                                                                                                                                                                        ()
                                                                                                                                                                                                                        =>
-                                                                                                                                                                                                                       ([]
-                                                                                                                                                                                                                           as
+                                                                                                                                                                                                                       ([]:
                                                                                                                                                                                                                            [core::fmt::ArgumentV1<'_>; 0]),
-                                                                                                                                                                                                                   }
-                                                                                                                                                                                                                      as
-                                                                                                                                                                                                                      [core::fmt::ArgumentV1<'_>; 0])
-                                                                                                                                                                                                                    as
-                                                                                                                                                                                                                    &[core::fmt::ArgumentV1<'_>; 0]))
-                                                                                                     as
-                                                                                                     core::fmt::Arguments<'_>))
-        as collections::string::String);
+                                                                                                                                                                                                                   }:
+                                                                                                                                                                                                                      [core::fmt::ArgumentV1<'_>; 0]):
+                                                                                                                                                                                                                    &[core::fmt::ArgumentV1<'_>; 0])):
+                                                                                                     core::fmt::Arguments<'_>)):
+        collections::string::String);
 }
-pub type Foo = [i32; (3 as usize)];
+pub type Foo = [i32; (3: usize)];
 pub struct Bar {
-    pub x: [i32; (3 as usize)],
+    pub x: [i32; (3: usize)],
 }
-pub struct TupleBar([i32; (4 as usize)]);
-pub enum Baz { BazVariant([i32; (5 as usize)]), }
-pub fn id<T>(x: T) -> T { (x as T) }
+pub struct TupleBar([i32; (4: usize)]);
+pub enum Baz { BazVariant([i32; (5: usize)]), }
+pub fn id<T>(x: T) -> T { (x: T) }
 pub fn use_id() {
     let _ =
-        ((id::<[i32; (3 as usize)]> as
-             fn([i32; 3]) -> [i32; 3] {id})(([(1 as i32), (2 as i32),
-                                              (3 as i32)] as [i32; 3])) as
-            [i32; 3]);
+        ((id::<[i32; (3: usize)]>:
+             fn([i32; 3]) -> [i32; 3] {id})(([(1: i32), (2: i32), (3: i32)]:
+                                                [i32; 3])): [i32; 3]);
 }
 fn main() { }


### PR DESCRIPTION
**TODO**: explain the new options.
Adds `-Z pretty-keep-going`, `-Z pretty-dump-dir=dir`, `--xpretty=typed,unsuffixed_literals` and `RUSTC_PRETTY_DUMP=mode,dir`.
These features made #22501 possible and if/when they get into a nightly, we can apply it to all cargo crates ever, even if only to gather statistics.

r? @nrc @pnkfelix
