### PR TITLE
Allow quasi-quoting Question tokens (issue #22957)

### DIFF
--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -635,9 +635,10 @@ fn mk_token(cx: &ExtCtxt, sp: Span, tok: &token::Token) -> P<ast::Expr> {
         token::FatArrow     => "FatArrow",
         token::Pound        => "Pound",
         token::Dollar       => "Dollar",
+        token::Question     => "Question",
         token::Underscore   => "Underscore",
         token::Eof          => "Eof",
-        _                   => panic!(),
+        _                   => panic!("Expected valid token, found {:?}", *tok),
     };
     mk_token_path(cx, sp, name)
 }

--- a/src/test/run-pass-fulldeps/issue-22957.rs
+++ b/src/test/run-pass-fulldeps/issue-22957.rs
@@ -1,0 +1,26 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test quasiquoting `?Sized` trait bound.
+
+#![feature(quote)]
+
+extern crate syntax;
+
+use syntax::ext::base::ExtCtxt;
+
+#[allow(dead_code)]
+fn create_item(context: &mut ExtCtxt) {
+    quote_item!(context,
+      fn foo<T: ?Sized>() { }
+    );
+}
+
+fn main() { }

--- a/src/test/run-pass-fulldeps/issue-22957.rs
+++ b/src/test/run-pass-fulldeps/issue-22957.rs
@@ -19,7 +19,7 @@ use syntax::ext::base::ExtCtxt;
 #[allow(dead_code)]
 fn create_item(context: &mut ExtCtxt) {
     quote_item!(context,
-      fn foo<T: ?Sized>() { }
+        fn foo<T: ?Sized>() { }
     );
 }
 


### PR DESCRIPTION
Resolves #22957 by adding Question to the list of token names used by the quasi-quote token builder.

Should the associated test be given any directives for ignore-pretty or ignore-android like [similar tests?](https://github.com/rust-lang/rust/blob/master/src/test/run-pass-fulldeps/issue-16992.rs)
