### PR TITLE
Fix Duration::weeks docs

### DIFF
--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -68,7 +68,7 @@ pub const MAX: Duration = Duration {
 
 impl Duration {
     /// Makes a new `Duration` with given number of weeks.
-    /// Equivalent to `Duration::seconds(weeks * 7 * 24 * 60 * 60), with overflow checks.
+    /// Equivalent to `Duration::seconds(weeks * 7 * 24 * 60 * 60)` with overflow checks.
     /// Panics when the duration is out of bounds.
     #[inline]
     #[unstable(feature = "std_misc")]


### PR DESCRIPTION
The docs for `std::time::duration::Duration::weeks` were formatted incorrectly.
