### PR TITLE
Use ast_map in ty::get_attrs to enable querying attributes for any type of node.

### DIFF
--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -5592,8 +5592,7 @@ pub fn predicates<'tcx>(
 pub fn get_attrs<'tcx>(tcx: &'tcx ctxt, did: DefId)
                        -> Cow<'tcx, [ast::Attribute]> {
     if is_local(did) {
-        let item = tcx.map.expect_item(did.node);
-        Cow::Borrowed(&item.attrs)
+        Cow::Borrowed(tcx.map.attrs(did.node))
     } else {
         Cow::Owned(csearch::get_item_attrs(&tcx.sess.cstore, did))
     }


### PR DESCRIPTION
This is more flexible and less error-prone. `get_attrs` and
`get_attrs_opt` can be used on many more items than the old `get_attrs`
could.

This is all courtesy of @huonw, and directly taken from here:
https://github.com/rust-lang/rust/pull/22348/files#diff-0f85fcb07fb739876892e633fa0e2be6R5575

Also thanks to @Manishearth for pointing it out to me.
