### PR TITLE
[RFC] add the `?` postfix operator

### DIFF
--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -243,6 +243,10 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
                 self.tcx.sess.span_bug(expr.span, "non-desugared ExprForLoop");
             }
 
+            ast::ExprQuestion(..) => {
+                self.tcx.sess.span_bug(expr.span, "non-desugared ExprQuestion");
+            }
+
             ast::ExprLoop(ref body, _) => {
                 //
                 //     [pred]

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -596,6 +596,7 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>,
         ast::ExprBreak(_) |
         ast::ExprAgain(_) |
         ast::ExprRet(_) |
+        ast::ExprQuestion(_) |
 
         // Miscellaneous expressions that could be implemented.
         ast::ExprRange(..) |

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -539,6 +539,10 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                 self.tcx().sess.span_bug(expr.span, "non-desugared ExprForLoop");
             }
 
+            ast::ExprQuestion(..) => {
+                self.tcx().sess.span_bug(expr.span, "non-desugared ExprQuestion");
+            }
+
             ast::ExprUnary(op, ref lhs) => {
                 let pass_args = if ast_util::is_by_value_unop(op) {
                     PassArgs::ByValue

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -491,6 +491,9 @@ fn visit_expr(ir: &mut IrMaps, expr: &Expr) {
       ast::ExprForLoop(..) => {
           ir.tcx.sess.span_bug(expr.span, "non-desugared ExprForLoop");
       }
+      ast::ExprQuestion(..) => {
+          ir.tcx.sess.span_bug(expr.span, "non-desugared ExprQuestion");
+      }
       ast::ExprBinary(op, _, _) if ast_util::lazy_binop(op.node) => {
         ir.add_live_node_for_node(expr.id, ExprNode(expr.span));
         visit::walk_expr(ir, expr);
@@ -1025,6 +1028,10 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
               self.ir.tcx.sess.span_bug(expr.span, "non-desugared ExprForLoop");
           }
 
+          ast::ExprQuestion(..) => {
+              self.ir.tcx.sess.span_bug(expr.span, "non-desugared ExprQuestion");
+          }
+
           // Note that labels have been resolved, so we don't need to look
           // at the label ident
           ast::ExprLoop(ref blk, _) => {
@@ -1479,6 +1486,9 @@ fn check_expr(this: &mut Liveness, expr: &Expr) {
       }
       ast::ExprForLoop(..) => {
         this.ir.tcx.sess.span_bug(expr.span, "non-desugared ExprForLoop");
+      }
+      ast::ExprQuestion(..) => {
+        this.ir.tcx.sess.span_bug(expr.span, "non-desugared ExprQuestion");
       }
     }
 }

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -561,6 +561,9 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
           ast::ExprForLoop(..) => {
             self.tcx().sess.span_bug(expr.span, "non-desugared ExprForLoop");
           }
+          ast::ExprQuestion(..) => {
+            self.tcx().sess.span_bug(expr.span, "non-desugared ExprQuestion");
+          }
         }
     }
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -4646,6 +4646,10 @@ pub fn expr_kind(tcx: &ctxt, expr: &ast::Expr) -> ExprKind {
             tcx.sess.span_bug(expr.span, "non-desugared ExprForLoop");
         }
 
+        ast::ExprQuestion(..) => {
+            tcx.sess.span_bug(expr.span, "non-desugared ExprQuestion");
+        }
+
         ast::ExprLit(ref lit) if lit_is_str(&**lit) => {
             RvalueDpsExpr
         }

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -291,6 +291,7 @@ mod svh_visitor {
             ExprIfLet(..)            => unreachable!(),
             ExprWhileLet(..)         => unreachable!(),
             ExprMac(..)              => unreachable!(),
+            ExprQuestion(..)              => unreachable!(),
         }
     }
 

--- a/src/librustc_trans/trans/debuginfo.rs
+++ b/src/librustc_trans/trans/debuginfo.rs
@@ -3586,6 +3586,11 @@ fn create_scope_map(cx: &CrateContext,
                                               Found unexpanded macro.");
             }
 
+            ast::ExprQuestion(..) => {
+                cx.sess().span_bug(exp.span, "debuginfo::create_scope_map() - \
+                                              Found unexpanded `expr?`.");
+            }
+
             ast::ExprLoop(ref block, _) |
             ast::ExprBlock(ref block)   => {
                 with_new_scope(cx,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3775,6 +3775,9 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
       ast::ExprForLoop(..) => {
         tcx.sess.span_bug(expr.span, "non-desugared ExprForLoop");
       }
+      ast::ExprQuestion(..) => {
+        tcx.sess.span_bug(expr.span, "non-desugared ExprQuestion");
+      }
       ast::ExprLoop(ref body, _) => {
         check_block_no_value(fcx, &**body);
         if !may_break(tcx, expr.id, &**body) {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -774,7 +774,10 @@ pub enum Expr_ {
     ExprRepeat(P<Expr> /* element */, P<Expr> /* count */),
 
     /// No-op: used solely so we can pretty-print faithfully
-    ExprParen(P<Expr>)
+    ExprParen(P<Expr>),
+
+    /// `expr?`
+    ExprQuestion(P<Expr>),
 }
 
 /// The explicit Self type in a "qualified path". The actual

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -1311,6 +1311,9 @@ pub fn noop_fold_expr<T: Folder>(Expr {id, node, span}: Expr, folder: &mut T) ->
                             folder.fold_block(body),
                             opt_ident.map(|i| folder.fold_ident(i)))
             }
+            ExprQuestion(e) => {
+                ExprQuestion(folder.fold_expr(e))
+            }
             ExprLoop(body, opt_ident) => {
                 ExprLoop(folder.fold_block(body),
                         opt_ident.map(|i| folder.fold_ident(i)))

--- a/src/libsyntax/parse/classify.rs
+++ b/src/libsyntax/parse/classify.rs
@@ -30,6 +30,7 @@ pub fn expr_requires_semi_to_be_stmt(e: &ast::Expr) -> bool {
         | ast::ExprWhile(..)
         | ast::ExprWhileLet(..)
         | ast::ExprLoop(..)
+        | ast::ExprQuestion(..)
         | ast::ExprForLoop(..) => false,
         _ => true
     }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1760,6 +1760,10 @@ impl<'a> State<'a> {
                 try!(space(&mut self.s));
                 try!(self.print_block(&**blk));
             }
+            ast::ExprQuestion(ref expr) => {
+                try!(self.print_expr(&**expr));
+                try!(word(&mut self.s, "?"))
+            }
             ast::ExprLoop(ref blk, opt_ident) => {
                 if let Some(ident) = opt_ident {
                     try!(self.print_ident(ident));

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -821,6 +821,9 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             visitor.visit_expr(&**subexpression);
             visitor.visit_block(&**block)
         }
+        ExprQuestion(ref expr) => {
+            visitor.visit_expr(&**expr);
+        }
         ExprLoop(ref block, _) => visitor.visit_block(&**block),
         ExprMatch(ref subexpression, ref arms, _) => {
             visitor.visit_expr(&**subexpression);

--- a/src/test/run-pass/question-operator.rs
+++ b/src/test/run-pass/question-operator.rs
@@ -1,0 +1,71 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::error::FromError;
+use std::fs::File;
+use std::io::{Read, self};
+use std::num::ParseIntError;
+use std::str::FromStr;
+
+fn parse<T: FromStr>(s: &str) -> Result<T, T::Err> {
+    s.parse()
+}
+
+fn on_method() -> Result<i32, ParseIntError> {
+    Ok("1".parse::<i32>()? + "2".parse()?)
+}
+
+fn in_chain() -> Result<String, ParseIntError> {
+    Ok("3".parse::<i32>()?.to_string())
+}
+
+fn on_call() -> Result<i32, ParseIntError> {
+    Ok(parse("4")?)
+}
+
+fn nested() -> Result<i32, ParseIntError> {
+    Ok("5".parse::<i32>()?.to_string().parse()?)
+}
+
+fn main() {
+    assert_eq!(Ok(3), on_method());
+
+    assert_eq!(Ok("3".to_string()), in_chain());
+
+    assert_eq!(Ok(4), on_call());
+
+    assert_eq!(Ok(5), nested());
+}
+
+enum Error {
+    Io(io::Error),
+    Parse(ParseIntError),
+}
+
+// just type check
+fn merge_error() -> Result<i32, Error> {
+    let mut s = String::new();
+
+    File::open("foo.txt")?.read_to_string(&mut s)?;
+
+    Ok(s.parse::<i32>()? + 1)
+}
+
+impl FromError<io::Error> for Error {
+    fn from_error(e: io::Error) -> Error {
+        Error::Io(e)
+    }
+}
+
+impl FromError<ParseIntError> for Error {
+    fn from_error(e: ParseIntError) -> Error {
+        Error::Parse(e)
+    }
+}


### PR DESCRIPTION
# DO NOT MERGE NEEDS AN APPROVED RFC

The `?` postfix operator is sugar equivalent to the `try!` macro, but is more amenable to chaining: `File::open("foo")?.metadata()?.is_dir()`. Currently the syntax is accepted in two places:
- method calls: `x.foo()?`, and
- function calls: `foo()?`

But it could be extended to idents: `let x = y?;` or `foo(x?, y?)`.

---

cc @aturon @nikomatsakis 
