### PR TITLE
Fix broken link in old rust guide

### DIFF
--- a/src/doc/guide-tasks.md
+++ b/src/doc/guide-tasks.md
@@ -1,4 +1,4 @@
 % The (old) Rust Threads and Communication Guide
 
 This content has moved into
-[the Rust Programming Language book](book/tasks.html).
+[the Rust Programming Language book](book/concurrency.html).


### PR DESCRIPTION
Having come back to rust recently after > 6months I was looking for docs
on tasks and stumbled upon this broken link.
