### PR TITLE
debuginfo: Fix constant related ICE.

### DIFF
--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -173,7 +173,7 @@ pub fn get_const_expr<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
         &**expr
     } else {
         ccx.sess().span_bug(ref_expr.span,
-                            &format!("get_const_val given non-constant item {}",
+                            &format!("get_const_expr given non-constant item {}",
                                      item.repr(ccx.tcx())));
     }
 }

--- a/src/test/debuginfo/constant-debug-locs.rs
+++ b/src/test/debuginfo/constant-debug-locs.rs
@@ -1,0 +1,67 @@
+// Copyright 2013-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// ignore-android: FIXME(#10381)
+// min-lldb-version: 310
+
+// compile-flags:-g
+
+#![allow(unused_variables)]
+#![allow(dead_code)]
+#![omit_gdb_pretty_printer_section]
+
+// This test makes sure that the compiler doesn't crash when trying to assign
+// debug locations to const-expressions.
+
+use std::sync::MUTEX_INIT;
+use std::cell::UnsafeCell;
+
+const CONSTANT: u64 = 3 + 4;
+
+struct Struct {
+    a: isize,
+    b: usize,
+}
+const STRUCT: Struct = Struct { a: 1, b: 2 };
+
+struct TupleStruct(u32);
+const TUPLE_STRUCT: TupleStruct = TupleStruct(4);
+
+enum Enum {
+    Variant1(char),
+    Variant2 { a: u8 },
+    Variant3
+}
+
+const VARIANT1: Enum = Enum::Variant1('v');
+const VARIANT2: Enum = Enum::Variant2 { a: 2 };
+const VARIANT3: Enum = Enum::Variant3;
+
+const STRING: &'static str = "String";
+
+const VEC: [u32; 8] = [0; 8];
+
+const NESTED: (Struct, TupleStruct) = (STRUCT, TUPLE_STRUCT);
+
+const UNSAFE_CELL: UnsafeCell<bool> = UnsafeCell { value: false };
+
+fn main() {
+    let mut _constant = CONSTANT;
+    let mut _struct = STRUCT;
+    let mut _tuple_struct = TUPLE_STRUCT;
+    let mut _variant1 = VARIANT1;
+    let mut _variant2 = VARIANT2;
+    let mut _variant3 = VARIANT3;
+    let mut _string = STRING;
+    let mut _vec = VEC;
+    let mut _nested = NESTED;
+    let mut _extern = MUTEX_INIT;
+    let mut _unsafe_cell = UNSAFE_CELL;
+}

--- a/src/test/debuginfo/extern-c-fn.rs
+++ b/src/test/debuginfo/extern-c-fn.rs
@@ -1,0 +1,68 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// min-lldb-version: 310
+
+// compile-flags:-g
+
+// === GDB TESTS ===================================================================================
+// gdb-command:run
+
+// gdb-command:print s
+// gdb-check:$1 = [...]"abcd"
+// gdb-command:print len
+// gdb-check:$2 = 20
+// gdb-command:print local0
+// gdb-check:$3 = 19
+// gdb-command:print local1
+// gdb-check:$4 = true
+// gdb-command:print local2
+// gdb-check:$5 = 20.5
+
+// gdb-command:continue
+
+// === LLDB TESTS ==================================================================================
+// lldb-command:run
+
+// lldb-command:print len
+// lldb-check:[...]$0 = 20
+// lldb-command:print local0
+// lldb-check:[...]$1 = 19
+// lldb-command:print local1
+// lldb-check:[...]$2 = true
+// lldb-command:print local2
+// lldb-check:[...]$3 = 20.5
+
+// lldb-command:continue
+
+#![allow(unused_variables)]
+#![allow(dead_code)]
+#![omit_gdb_pretty_printer_section]
+
+
+#[no_mangle]
+pub unsafe extern "C" fn fn_with_c_abi(s: *const u8, len: i32) -> i32 {
+    let local0 = len - 1;
+    let local1 = len > 2;
+    let local2 = (len as f64) + 0.5;
+
+    zzz(); // #break
+
+    return 0;
+}
+
+fn main() {
+    unsafe {
+        fn_with_c_abi(b"abcd\0".as_ptr(), 20);
+    }
+}
+
+#[inline(never)]
+fn zzz() {()}


### PR DESCRIPTION
With this PR in-place constants are handled correctly with respect to debug location assignment.
The PR also adds an (unrelated) test case for debug locations in `extern "C"` functions.

Fixes #22432
