### PR TITLE
compilation error in std for target_os="ios"

### DIFF
--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -616,6 +616,9 @@ mod os {
 mod os {
     pub const FAMILY: &'static str = "unix";
     pub const OS: &'static str = "ios";
+    pub const DLL_PREFIX: &'static str = "lib";
+    pub const DLL_SUFFIX: &'static str = ".dylib";
+    pub const DLL_EXTENSION: &'static str = "dylib";
     pub const EXE_SUFFIX: &'static str = "";
     pub const EXE_EXTENSION: &'static str = "";
 }


### PR DESCRIPTION
This patch corrects the following errors:

```
../src/libstd/env.rs:569:42: 569:63 error: unresolved name `super::os::DLL_PREFIX`
../src/libstd/env.rs:569     pub const DLL_PREFIX: &'static str = super::os::DLL_PREFIX;
                                                                  ^~~~~~~~~~~~~~~~~~~~~
../src/libstd/env.rs:574:42: 574:63 error: unresolved name `super::os::DLL_SUFFIX`
../src/libstd/env.rs:574     pub const DLL_SUFFIX: &'static str = super::os::DLL_SUFFIX;
                                                                  ^~~~~~~~~~~~~~~~~~~~~
../src/libstd/env.rs:579:45: 579:69 error: unresolved name `super::os::DLL_EXTENSION`
../src/libstd/env.rs:579     pub const DLL_EXTENSION: &'static str = super::os::DLL_EXTENSION;
                                                                     ^~~~~~~~~~~~~~~~~~~~~~~~
```

The patch is untested: only the compilation was done. The code follow "macos" definition.
