### PR TITLE
std: Deprecate the old_io::process module

### DIFF
--- a/src/librustc_back/target/apple_ios_base.rs
+++ b/src/librustc_back/target/apple_ios_base.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::old_io::{Command, IoError, OtherIoError};
+use std::io;
+use std::process::Command;
 use target::TargetOptions;
 
 use self::Arch::*;
@@ -40,16 +41,15 @@ pub fn get_sdk_root(sdk_name: &str) -> String {
                       .arg("--show-sdk-path")
                       .arg("-sdk")
                       .arg(sdk_name)
-                      .spawn()
-                      .and_then(|c| c.wait_with_output())
+                      .output()
                       .and_then(|output| {
                           if output.status.success() {
-                              Ok(String::from_utf8(output.output).unwrap())
+                              Ok(String::from_utf8(output.stdout).unwrap())
                           } else {
-                              Err(IoError {
-                                  kind: OtherIoError,
-                                  desc: "process exit with error",
-                                  detail: String::from_utf8(output.error).ok()})
+                              let error = String::from_utf8(output.stderr);
+                              Err(io::Error::new(io::ErrorKind::Other,
+                                                 "process exit with error",
+                                                 error.ok()))
                           }
                       });
 

--- a/src/libstd/old_io/process.rs
+++ b/src/libstd/old_io/process.rs
@@ -11,6 +11,9 @@
 //! Bindings for executing child processes
 
 #![allow(non_upper_case_globals)]
+#![unstable(feature = "old_io")]
+#![deprecated(since = "1.0.0",
+              reason = "replaced with the std::process module")]
 
 pub use self::StdioContainer::*;
 pub use self::ProcessExit::*;

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(deprecated)]
+
 use prelude::v1::*;
 use self::Req::*;
 

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(deprecated)]
+
 use prelude::v1::*;
 
 use collections;


### PR DESCRIPTION
This module is now superseded by the `std::process` module. This module still
has some room to expand to get quite back up to parity with the `old_io`
version, and there is a [tracking issue](https://github.com/rust-lang/rfcs/issues/941) for feature requests as well as
known room for expansion.

[breaking-change]
