### PR TITLE
Fix Playpen Links Containing Multiple Examples

### DIFF
--- a/src/librustdoc/html/static/playpen.js
+++ b/src/librustdoc/html/static/playpen.js
@@ -15,7 +15,7 @@
     if (window.playgroundUrl) {
         $('pre.rust').hover(function() {
             var a = $('<a>').text('⇱').attr('class', 'test-arrow');
-            var code = $(this).siblings(".rusttest").text();
+            var code = $(this).prev(".rusttest").text();
             a.attr('href', window.playgroundUrl + '?code=' +
                            encodeURIComponent(code));
             a.attr('target', '_blank');


### PR DESCRIPTION
This should fix #22615. Previously, the playpen links grabbed the content of all `.rusttest` containers on the same level to build the URL. Now they just select the one before the `pre` they are shown in.

I have only tested this by changing the file in my local build of the docs (not by running rustdoc itself).
