### PR TITLE
OIBIT: for `PhantomData<T>` check `T` rather than the struct itself

### DIFF
--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1700,6 +1700,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 }
             }
 
+            // for `PhantomData<T>`, we pass `T`
+            ty::ty_struct(def_id, substs)
+                if Some(def_id) == self.tcx().lang_items.phantom_data() =>
+            {
+                Some(substs.types.get_slice(TypeSpace).to_vec())
+            }
+
             ty::ty_struct(def_id, substs) => {
                 Some(ty::struct_fields(self.tcx(), def_id, substs).iter()
                      .map(|f| f.mt.ty)

--- a/src/test/compile-fail/phantom-oibit.rs
+++ b/src/test/compile-fail/phantom-oibit.rs
@@ -1,0 +1,41 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Ensure that OIBIT checks `T` when it encounters a `PhantomData<T>` field, instead of checking
+// the `PhantomData<T>` type itself (which almost always implements a "default" trait
+// (`impl Trait for ..`))
+
+#![feature(optin_builtin_traits)]
+
+use std::marker::{MarkerTrait, PhantomData};
+
+unsafe trait Zen: MarkerTrait {}
+
+unsafe impl Zen for .. {}
+
+unsafe impl<'a, T: 'a> Zen for &'a T where T: Sync {}
+
+struct Guard<'a, T: 'a> {
+    _marker: PhantomData<&'a T>,
+}
+
+struct Nested<T>(T);
+
+fn is_zen<T: Zen>(_: T) {}
+
+fn not_sync<T>(x: Guard<T>) {
+    is_zen(x)  //~ error: the trait `core::marker::Sync` is not implemented for the type `T`
+}
+
+fn nested_not_sync<T>(x: Nested<Guard<T>>) {
+    is_zen(x)  //~ error: the trait `core::marker::Sync` is not implemented for the type `T`
+}
+
+fn main() {}


### PR DESCRIPTION
r? @nikomatsakis See the cfail test, it compiles without this patch
cc #13231
