### PR TITLE
std: Fix peeling ports from addresses

### DIFF
--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -293,7 +293,7 @@ impl ToSocketAddrs for str {
         }
 
         // split the string by ':' and convert the second part to u16
-        let mut parts_iter = self.rsplitn(2, ':');
+        let mut parts_iter = self.rsplitn(1, ':');
         let port_str = try_opt!(parts_iter.next(), "invalid socket address");
         let host = try_opt!(parts_iter.next(), "invalid socket address");
         let port: u16 = try_opt!(port_str.parse().ok(), "invalid port value");
@@ -589,5 +589,10 @@ mod tests {
 
         let a = SocketAddr::new(IpAddr::new_v4(127, 0, 0, 1), 23924);
         assert!(tsa("localhost:23924").unwrap().contains(&a));
+    }
+
+    #[test]
+    fn to_socket_addr_str_bad() {
+        assert!(tsa("1200::AB00:1234::2552:7777:1313:34300").is_err());
     }
 }


### PR DESCRIPTION
The `rsplitn` call was called with 2 instead of 1 so the iterator would yield 3
items in some cases, not the 2 that it should have.

Closes #23076
