### PR TITLE
test: Fix an overflow on empty benchmarks

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1108,7 +1108,14 @@ impl Bencher {
                 return summ5;
             }
 
-            n *= 2;
+            // If we overflow here just return the results so far. We check a
+            // multiplier of 10 because we're about to multiply by 2 and the
+            // next iteration of the loop will also multiply by 5 (to calculate
+            // the summ5 result)
+            n = match n.checked_mul(10) {
+                Some(_) => n * 2,
+                None => return summ5,
+            };
         }
     }
 }


### PR DESCRIPTION
Right now the rust upgrade in cargo is blocked on fixing this overflow. If a
this benchmark is run it will trigger an overflow error today:

```
#[bench]
fn foo(b: &mut test::Bencher) {}
```

This commit adds a check on each iteration of the loop that the maximum
multiplier (10) doesn't overflow, and if it does just return the results so far.
