### PR TITLE
 Make #[derive(Anything)] into sugar for #[derive_Anything]

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2429,6 +2429,10 @@ The currently implemented features of the reference compiler are:
                        so that new attributes can be added in a bacwards compatible
                        manner (RFC 572).
 
+* `custom_derive` - Allows the use of `#[derive(Foo,Bar)]` as sugar for
+                    `#[derive_Foo] #[derive_Bar]`, which can be user-defined syntax
+                    extensions.
+
 * `intrinsics` - Allows use of the "rust-intrinsics" ABI. Compiler intrinsics
                  are inherently unstable and no promise about them is made.
 

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -491,10 +491,8 @@ fn initial_syntax_expander_table<'feat>(ecfg: &expand::ExpansionConfig<'feat>)
     syntax_expanders.insert(intern("log_syntax"),
                             builtin_normal_expander(
                                     ext::log_syntax::expand_syntax_ext));
-    syntax_expanders.insert(intern("derive"),
-                            Decorator(Box::new(ext::deriving::expand_meta_derive)));
-    syntax_expanders.insert(intern("deriving"),
-                            Decorator(Box::new(ext::deriving::expand_deprecated_deriving)));
+
+    ext::deriving::register_all(&mut syntax_expanders);
 
     if ecfg.enable_quotes() {
         // Quasi-quoting expanders

--- a/src/libsyntax/ext/deriving/bounds.rs
+++ b/src/libsyntax/ext/deriving/bounds.rs
@@ -8,47 +8,34 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ast::{MetaItem, MetaWord, Item};
+use ast::{MetaItem, Item};
 use codemap::Span;
 use ext::base::ExtCtxt;
 use ext::deriving::generic::*;
 use ext::deriving::generic::ty::*;
 use ptr::P;
 
-pub fn expand_deriving_bound<F>(cx: &mut ExtCtxt,
-                                span: Span,
-                                mitem: &MetaItem,
-                                item: &Item,
-                                push: F) where
+pub fn expand_deriving_unsafe_bound<F>(cx: &mut ExtCtxt,
+                                       span: Span,
+                                       _: &MetaItem,
+                                       _: &Item,
+                                       _: F) where
     F: FnOnce(P<Item>),
 {
-    let name = match mitem.node {
-        MetaWord(ref tname) => {
-            match &tname[..] {
-                "Copy" => "Copy",
-                "Send" | "Sync" => {
-                    return cx.span_err(span,
-                                       &format!("{} is an unsafe trait and it \
-                                                 should be implemented explicitly",
-                                                *tname))
-                }
-                ref tname => {
-                    cx.span_bug(span,
-                                &format!("expected built-in trait name but \
-                                          found {}", *tname))
-                }
-            }
-        },
-        _ => {
-            return cx.span_err(span, "unexpected value in deriving, expected \
-                                      a trait")
-        }
-    };
+    cx.span_err(span, "this unsafe trait should be implemented explicitly");
+}
 
+pub fn expand_deriving_copy<F>(cx: &mut ExtCtxt,
+                               span: Span,
+                               mitem: &MetaItem,
+                               item: &Item,
+                               push: F) where
+    F: FnOnce(P<Item>),
+{
     let path = Path::new(vec![
         if cx.use_std { "std" } else { "core" },
         "marker",
-        name
+        "Copy",
     ]);
 
     let trait_def = TraitDef {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1447,6 +1447,19 @@ pub struct ExpansionConfig<'feat> {
     pub recursion_limit: usize,
 }
 
+macro_rules! feature_tests {
+    ($( fn $getter:ident = $field:ident, )*) => {
+        $(
+            pub fn $getter(&self) -> bool {
+                match self.features {
+                    Some(&Features { $field: true, .. }) => true,
+                    _ => false,
+                }
+            }
+        )*
+    }
+}
+
 impl<'feat> ExpansionConfig<'feat> {
     pub fn default(crate_name: String) -> ExpansionConfig<'static> {
         ExpansionConfig {
@@ -1456,46 +1469,13 @@ impl<'feat> ExpansionConfig<'feat> {
         }
     }
 
-    pub fn enable_quotes(&self) -> bool {
-        match self.features {
-            Some(&Features { allow_quote: true, .. }) => true,
-            _ => false,
-        }
-    }
-
-    pub fn enable_asm(&self) -> bool {
-        match self.features {
-            Some(&Features { allow_asm: true, .. }) => true,
-            _ => false,
-        }
-    }
-
-    pub fn enable_log_syntax(&self) -> bool {
-        match self.features {
-            Some(&Features { allow_log_syntax: true, .. }) => true,
-            _ => false,
-        }
-    }
-
-    pub fn enable_concat_idents(&self) -> bool {
-        match self.features {
-            Some(&Features { allow_concat_idents: true, .. }) => true,
-            _ => false,
-        }
-    }
-
-    pub fn enable_trace_macros(&self) -> bool {
-        match self.features {
-            Some(&Features { allow_trace_macros: true, .. }) => true,
-            _ => false,
-        }
-    }
-
-    pub fn enable_allow_internal_unstable(&self) -> bool {
-        match self.features {
-            Some(&Features { allow_internal_unstable: true, .. }) => true,
-            _ => false
-        }
+    feature_tests! {
+        fn enable_quotes = allow_quote,
+        fn enable_asm = allow_asm,
+        fn enable_log_syntax = allow_log_syntax,
+        fn enable_concat_idents = allow_concat_idents,
+        fn enable_trace_macros = allow_trace_macros,
+        fn enable_allow_internal_unstable = allow_internal_unstable,
     }
 }
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1476,6 +1476,7 @@ impl<'feat> ExpansionConfig<'feat> {
         fn enable_concat_idents = allow_concat_idents,
         fn enable_trace_macros = allow_trace_macros,
         fn enable_allow_internal_unstable = allow_internal_unstable,
+        fn enable_custom_derive = allow_custom_derive,
     }
 }
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -137,6 +137,10 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Status)] = &[
     // Allows the use of custom attributes; RFC 572
     ("custom_attribute", "1.0.0", Active),
 
+    // Allows the use of #[derive(Anything)] as sugar for
+    // #[derive_Anything].
+    ("custom_derive", "1.0.0", Active),
+
     // Allows the use of rustc_* attributes; RFC 572
     ("rustc_attrs", "1.0.0", Active),
 
@@ -319,6 +323,7 @@ pub struct Features {
     pub allow_concat_idents: bool,
     pub allow_trace_macros: bool,
     pub allow_internal_unstable: bool,
+    pub allow_custom_derive: bool,
     pub old_orphan_check: bool,
     pub simd_ffi: bool,
     pub unmarked_api: bool,
@@ -340,6 +345,7 @@ impl Features {
             allow_concat_idents: false,
             allow_trace_macros: false,
             allow_internal_unstable: false,
+            allow_custom_derive: false,
             old_orphan_check: false,
             simd_ffi: false,
             unmarked_api: false,
@@ -391,6 +397,10 @@ impl<'a> Context<'a> {
                               "unless otherwise specified, attributes \
                                with the prefix `rustc_` \
                                are reserved for internal compiler diagnostics");
+        } else if name.starts_with("derive_") {
+            self.gate_feature("custom_derive", attr.span,
+                              "attributes of the form `#[derive_*]` are reserved
+                               for the compiler");
         } else {
             self.gate_feature("custom_attribute", attr.span,
                        format!("The attribute `{}` is currently \
@@ -431,6 +441,9 @@ pub const EXPLAIN_TRACE_MACROS: &'static str =
     "`trace_macros` is not stable enough for use and is subject to change";
 pub const EXPLAIN_ALLOW_INTERNAL_UNSTABLE: &'static str =
     "allow_internal_unstable side-steps feature gating and stability checks";
+
+pub const EXPLAIN_CUSTOM_DERIVE: &'static str =
+    "`#[derive]` for custom traits is not stable enough for use and is subject to change";
 
 struct MacroVisitor<'a> {
     context: &'a Context<'a>
@@ -780,6 +793,7 @@ fn check_crate_inner<F>(cm: &CodeMap, span_handler: &SpanHandler, krate: &ast::C
         allow_concat_idents: cx.has_feature("concat_idents"),
         allow_trace_macros: cx.has_feature("trace_macros"),
         allow_internal_unstable: cx.has_feature("allow_internal_unstable"),
+        allow_custom_derive: cx.has_feature("custom_derive"),
         old_orphan_check: cx.has_feature("old_orphan_check"),
         simd_ffi: cx.has_feature("simd_ffi"),
         unmarked_api: cx.has_feature("unmarked_api"),

--- a/src/test/auxiliary/custom_derive_plugin.rs
+++ b/src/test/auxiliary/custom_derive_plugin.rs
@@ -1,0 +1,74 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+
+#![feature(plugin_registrar)]
+#![feature(box_syntax)]
+#![feature(rustc_private)]
+
+extern crate syntax;
+extern crate rustc;
+
+use syntax::ast;
+use syntax::codemap::Span;
+use syntax::ext::base::{Decorator, ExtCtxt};
+use syntax::ext::build::AstBuilder;
+use syntax::ext::deriving::generic::{cs_fold, TraitDef, MethodDef, combine_substructure};
+use syntax::ext::deriving::generic::ty::{Literal, LifetimeBounds, Path, borrowed_explicit_self};
+use syntax::parse::token;
+use syntax::ptr::P;
+use rustc::plugin::Registry;
+
+#[plugin_registrar]
+pub fn plugin_registrar(reg: &mut Registry) {
+    reg.register_syntax_extension(
+        token::intern("derive_TotalSum"),
+        Decorator(box expand));
+}
+
+fn expand(cx: &mut ExtCtxt,
+          span: Span,
+          mitem: &ast::MetaItem,
+          item: &ast::Item,
+          push: &mut FnMut(P<ast::Item>)) {
+    let trait_def = TraitDef {
+        span: span,
+        attributes: vec![],
+        path: Path::new(vec!["TotalSum"]),
+        additional_bounds: vec![],
+        generics: LifetimeBounds::empty(),
+        associated_types: vec![],
+        methods: vec![
+            MethodDef {
+                name: "total_sum",
+                generics: LifetimeBounds::empty(),
+                explicit_self: borrowed_explicit_self(),
+                args: vec![],
+                ret_ty: Literal(Path::new_local("isize")),
+                attributes: vec![],
+                combine_substructure: combine_substructure(box |cx, span, substr| {
+                    let zero = cx.expr_int(span, 0);
+                    cs_fold(false,
+                            |cx, span, subexpr, field, _| {
+                                cx.expr_binary(span, ast::BiAdd, subexpr,
+                                    cx.expr_method_call(span, field,
+                                        token::str_to_ident("total_sum"), vec![]))
+                            },
+                            zero,
+                            box |cx, span, _, _| { cx.span_bug(span, "wtf??"); },
+                            cx, span, substr)
+                }),
+            },
+        ],
+    };
+
+    trait_def.expand(cx, mitem, item, |i| push(i))
+}

--- a/src/test/compile-fail/deprecated-phase.rs
+++ b/src/test/compile-fail/deprecated-phase.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(custom_attribute)]
+
 #[phase(blah)]
 //~^ ERROR #[phase] is deprecated
 extern crate foo;

--- a/src/test/compile-fail/deriving-meta-unknown-trait.rs
+++ b/src/test/compile-fail/deriving-meta-unknown-trait.rs
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(Eqr)] //~ ERROR unknown `derive` trait: `Eqr`
+#[derive(Eqr)]
+//~^ ERROR `#[derive]` for custom traits is not stable enough for use and is subject to change
 struct Foo;
 
 pub fn main() {}

--- a/src/test/compile-fail/feature-gate-intrinsics.rs
+++ b/src/test/compile-fail/feature-gate-intrinsics.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(plugin)]
-#![plugin(foo="bleh")] //~ ERROR malformed plugin attribute
+extern "rust-intrinsic" {   //~ ERROR intrinsics are subject to change
+    fn bar();
+}
 
-fn main() {}
+extern "rust-intrinsic" fn baz() {  //~ ERROR intrinsics are subject to change
+}
+
+fn main() {
+}

--- a/src/test/compile-fail/feature-gate-lang-items.rs
+++ b/src/test/compile-fail/feature-gate-lang-items.rs
@@ -11,13 +11,5 @@
 #[lang="foo"]   //~ ERROR language items are subject to change
 trait Foo {}
 
-extern "rust-intrinsic" {   //~ ERROR intrinsics are subject to change
-    fn bar();
-}
-
-extern "rust-intrinsic" fn baz() {  //~ ERROR intrinsics are subject to change
-}
-
 fn main() {
 }
-

--- a/src/test/compile-fail/linkage1.rs
+++ b/src/test/compile-fail/linkage1.rs
@@ -11,5 +11,4 @@
 extern {
     #[linkage = "extern_weak"] static foo: isize;
     //~^ ERROR: the `linkage` attribute is experimental and not portable
-    //~^^ ERROR: the `linkage` attribute is experimental and not portable
 }

--- a/src/test/compile-fail/malformed-derive-entry.rs
+++ b/src/test/compile-fail/malformed-derive-entry.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(Send)]
-//~^ ERROR this unsafe trait should be implemented explicitly
-struct Test;
-
-#[derive(Sync)]
-//~^ ERROR this unsafe trait should be implemented explicitly
+#[derive(Copy(Bad))]
+//~^ ERROR malformed `derive` entry
 struct Test1;
 
-pub fn main() {}
+#[derive(Copy="bad")]
+//~^ ERROR malformed `derive` entry
+struct Test2;
+
+#[derive()]
+//~^ WARNING empty trait list
+struct Test3;
+
+#[derive]
+//~^ WARNING empty trait list
+struct Test4;

--- a/src/test/compile-fail/malformed-plugin-1.rs
+++ b/src/test/compile-fail/malformed-plugin-1.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(plugin)]
 #![plugin] //~ ERROR malformed plugin attribute
 
 fn main() {}

--- a/src/test/compile-fail/malformed-plugin-2.rs
+++ b/src/test/compile-fail/malformed-plugin-2.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(plugin)]
 #![plugin="bleh"] //~ ERROR malformed plugin attribute
 
 fn main() {}

--- a/src/test/compile-fail/plugin-extern-crate-attr-deprecated.rs
+++ b/src/test/compile-fail/plugin-extern-crate-attr-deprecated.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(plugin)]
+
 #[plugin]  //~ ERROR #[plugin] on `extern crate` is deprecated
 //~^ HELP use a crate attribute instead, i.e. #![plugin(std)]
 extern crate std;

--- a/src/test/compile-fail/reserved-attr-on-macro.rs
+++ b/src/test/compile-fail/reserved-attr-on-macro.rs
@@ -8,7 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(plugin)]
-#![plugin(foo="bleh")] //~ ERROR malformed plugin attribute
+#[rustc_attribute_should_be_reserved] //~ ERROR attributes with the prefix `rustc_` are reserved
+macro_rules! foo {
+    () => (());
+}
 
-fn main() {}
+fn main() {
+    foo!();
+}

--- a/src/test/compile-fail/single-derive-attr.rs
+++ b/src/test/compile-fail/single-derive-attr.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(Send)]
-//~^ ERROR this unsafe trait should be implemented explicitly
+#[derive_Clone]
+//~^ ERROR attributes of the form `#[derive_*]` are reserved
 struct Test;
-
-#[derive(Sync)]
-//~^ ERROR this unsafe trait should be implemented explicitly
-struct Test1;
 
 pub fn main() {}

--- a/src/test/run-pass-fulldeps/derive-totalsum.rs
+++ b/src/test/run-pass-fulldeps/derive-totalsum.rs
@@ -1,0 +1,59 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:custom_derive_plugin.rs
+// ignore-stage1
+
+#![feature(plugin, custom_derive)]
+#![plugin(custom_derive_plugin)]
+
+trait TotalSum {
+    fn total_sum(&self) -> isize;
+}
+
+impl TotalSum for isize {
+    fn total_sum(&self) -> isize {
+        *self
+    }
+}
+
+struct Seven;
+
+impl TotalSum for Seven {
+    fn total_sum(&self) -> isize {
+        7
+    }
+}
+
+#[derive(TotalSum)]
+struct Foo {
+    seven: Seven,
+    bar: Bar,
+    baz: isize,
+}
+
+#[derive(TotalSum)]
+struct Bar {
+    quux: isize,
+    bleh: isize,
+}
+
+
+pub fn main() {
+    let v = Foo {
+        seven: Seven,
+        bar: Bar {
+            quux: 9,
+            bleh: 3,
+        },
+        baz: 80,
+    };
+    assert_eq!(v.total_sum(), 99);
+}

--- a/src/test/run-pass-fulldeps/macro-crate.rs
+++ b/src/test/run-pass-fulldeps/macro-crate.rs
@@ -11,7 +11,7 @@
 // aux-build:macro_crate_test.rs
 // ignore-stage1
 
-#![feature(plugin)]
+#![feature(plugin, custom_attribute)]
 #![plugin(macro_crate_test)]
 
 #[macro_use] #[no_link]

--- a/src/test/run-pass/deprecated-derive.rs
+++ b/src/test/run-pass/deprecated-derive.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(Send)]
-//~^ ERROR this unsafe trait should be implemented explicitly
-struct Test;
-
-#[derive(Sync)]
-//~^ ERROR this unsafe trait should be implemented explicitly
+#[derive(Show)]
+//~^ WARNING derive(Show) is deprecated
 struct Test1;
 
-pub fn main() {}
+fn main() { }

--- a/src/test/run-pass/single-derive-attr-with-gate.rs
+++ b/src/test/run-pass/single-derive-attr-with-gate.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(Send)]
-//~^ ERROR this unsafe trait should be implemented explicitly
+#![feature(custom_derive)]
+
+#[derive_Clone]
 struct Test;
 
-#[derive(Sync)]
-//~^ ERROR this unsafe trait should be implemented explicitly
-struct Test1;
-
-pub fn main() {}
+pub fn main() {
+    Test.clone();
+}


### PR DESCRIPTION
This is a hack, but I don't think we can do much better as long as `derive` is running at the syntax expansion phase.

If the `custom_derive` feature gate is enabled, this works with user-defined traits and syntax extensions. Without the gate, you can't use e.g. `#[derive_Clone]` directly, so this does not change the stable language.

To make this effective, we now check gated attributes both before and after macro expansion. This uncovered a number of tests that were missing feature gates.

This PR also cleans up the deriving code somewhat, and forbids some previously-meaningless attribute syntax. For this reason it's technically a

```
[breaking-change]
```

r? @sfackler 
