### PR TITLE
disable test for issue-5806 on openbsd

### DIFF
--- a/src/test/parse-fail/issue-5806.rs
+++ b/src/test/parse-fail/issue-5806.rs
@@ -10,6 +10,7 @@
 
 // ignore-windows
 // ignore-freebsd
+// ignore-openbsd
 
 #[path = "../compile-fail"]
 mod foo; //~ ERROR: a directory


### PR DESCRIPTION
follow freebsd due to last deprecation of `std::old_io::fs`
