### PR TITLE
rustdoc: Fixed an asynchronous loading of rustdoc sidebars.

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2247,7 +2247,7 @@ impl<'a> fmt::Display for Sidebar<'a> {
             // there is no sidebar-items.js beyond the crate root path
             // FIXME maybe dynamic crate loading can be merged here
         } else {
-            try!(write!(fmt, "<script async src=\"{path}sidebar-items.js\"></script>",
+            try!(write!(fmt, "<script defer src=\"{path}sidebar-items.js\"></script>",
                         path = relpath));
         }
 


### PR DESCRIPTION
We require the _deferred_ loading, not just an opportunistic asynchronous loading. (Yes, that was my oversight, as I only checked it locally...) I think `<script defer>` is safe to use, according to http://caniuse.com/#feat=script-defer.
