### PR TITLE
Fixes the `is_null` method in PtrExt for fat pointers.

### DIFF
--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -320,7 +320,12 @@ impl<T: ?Sized> PtrExt for *const T {
 
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn is_null(self) -> bool { self == 0 as *const T }
+    fn is_null(self) -> bool {
+        unsafe {
+            let ptr_ptr: *const usize = mem::transmute(&self);
+            *ptr_ptr == 0
+        }
+    }
 
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -347,7 +352,7 @@ impl<T: ?Sized> PtrExt for *mut T {
 
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn is_null(self) -> bool { self == 0 as *mut T }
+    fn is_null(self) -> bool { (self as *const T).is_null() }
 
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcoretest/ptr.rs
+++ b/src/libcoretest/ptr.rs
@@ -11,6 +11,7 @@
 use core::ptr::*;
 use core::mem;
 use std::iter::repeat;
+use core::slice;
 
 #[test]
 fn test() {
@@ -66,6 +67,17 @@ fn test_is_null() {
 
     let mq = unsafe { mp.offset(1) };
     assert!(!mq.is_null());
+
+    unsafe {
+        let sn = slice::from_raw_parts(null(), 0) as *const [u32];
+        assert!(sn.is_null());
+
+        let s = &[1, 2, 3] as *const [u32];
+        assert!(!s.is_null());
+    }
+
+    let s: *const str = "rust" as *const str;
+    assert!(!s.is_null());
 }
 
 #[test]
@@ -89,6 +101,15 @@ fn test_as_ref() {
             let p: *const int = &u as *const _;
             assert_eq!(p.as_ref().unwrap(), &2);
         }
+
+        let sn = slice::from_raw_parts(null(), 0) as *const [u32];
+        assert_eq!(sn.as_ref(), None);
+
+        let sl = &[1, 2, 3] as *const [u32];
+        assert_eq!(sl.as_ref().unwrap(), &[1, 2, 3]);
+
+        let s = "rust" as *const str;
+        assert_eq!(s.as_ref().unwrap(), "rust");
     }
 }
 
@@ -107,6 +128,12 @@ fn test_as_mut() {
             let p: *mut int = &mut u as *mut _;
             assert!(p.as_mut().unwrap() == &mut 2);
         }
+
+        let sn = slice::from_raw_parts_mut(null_mut(), 0) as *mut [u32];
+        assert_eq!(sn.as_ref(), None);
+
+        let s = &mut [1, 2, 3] as *mut [u32];
+        assert_eq!(s.as_mut().unwrap(), &mut [1, 2, 3]);
     }
 }
 


### PR DESCRIPTION
The current implementation of `is_null` attempts to cast `0` to the
pointer type of `*const T` or `*mut T` for any T. This is incorrect when the
pointer type is not the size of some integer, as is the case for *const [T]
and *mut [T], and leads to an ICE.

This commit fixes this issue by looking at the first pointer size integer of
the pointer itself which in fat pointers is a pointer to the location of the data
and in regular pointers is the pointer itself.

The following program can be used to verify the ICE and the fix:

``` rust
fn main() {
    let s = &[1, 2, 3] as *const [u32];
    println!("{}", s.is_null());
}
```
