### PR TITLE
Fix #23166. Get the Compiler Plugins example compiling again.

### DIFF
--- a/src/doc/trpl/plugins.md
+++ b/src/doc/trpl/plugins.md
@@ -63,7 +63,7 @@ that implements Roman numeral integer literals.
 
 ```ignore
 #![crate_type="dylib"]
-#![feature(plugin_registrar)]
+#![feature(plugin_registrar, rustc_private)]
 
 extern crate syntax;
 extern crate rustc;
@@ -92,13 +92,13 @@ fn expand_rn(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
         }
     };
 
-    let mut text = &text;
+    let mut text = &*text;
     let mut total = 0;
     while !text.is_empty() {
         match NUMERALS.iter().find(|&&(rn, _)| text.starts_with(rn)) {
             Some(&(rn, val)) => {
                 total += val;
-                text = text.slice_from(rn.len());
+                text = &text[rn.len()..];
             }
             None => {
                 cx.span_err(sp, "invalid Roman numeral");
@@ -107,7 +107,7 @@ fn expand_rn(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
         }
     }
 
-    MacEager::expr(cx.expr_usize(sp, total))
+    MacEager::expr(cx.expr_u32(sp, total))
 }
 
 #[plugin_registrar]


### PR DESCRIPTION
- "let mut text" was previously of &String type.  Now it is of &str type.
- Update the slicing syntax.  Both &text[] and text.slice_from() evaluate
  to a &str.
- We were passing a u32 to expr_usize.  Call expr_u32 instead.

r? @steveklabnik
Fixes #23166
