### PR TITLE
Introduction concurrent examples aren't actually concurrent

### DIFF
--- a/src/doc/intro.md
+++ b/src/doc/intro.md
@@ -389,11 +389,11 @@ safe concurrent programs.
 Here's an example of a concurrent Rust program:
 
 ```{rust}
-use std::thread::Thread;
+use std::thread;
 
 fn main() {
     let guards: Vec<_> = (0..10).map(|_| {
-        Thread::scoped(|| {
+        thread::scoped(|| {
             println!("Hello, world!");
         })
     }).collect();
@@ -421,13 +421,13 @@ problem.
 Let's see an example. This Rust code will not compile:
 
 ```{rust,ignore}
-use std::thread::Thread;
+use std::thread;
 
 fn main() {
     let mut numbers = vec![1, 2, 3];
 
     let guards: Vec<_> = (0..3).map(|i| {
-        Thread::scoped(move || {
+        thread::scoped(move || {
             numbers[i] += 1;
             println!("numbers[{}] is {}", i, numbers[i]);
         });
@@ -439,7 +439,7 @@ It gives us this error:
 
 ```text
 7:25: 10:6 error: cannot move out of captured outer variable in an `FnMut` closure
-7     Thread::scoped(move || {
+7     thread::scoped(move || {
 8       numbers[i] += 1;
 9       println!("numbers[{}] is {}", i, numbers[i]);
 10     });
@@ -471,7 +471,7 @@ mutation doesn't cause a data race.
 Here's what using an Arc with a Mutex looks like:
 
 ```{rust}
-use std::thread::Thread;
+use std::thread;
 use std::sync::{Arc,Mutex};
 
 fn main() {
@@ -479,7 +479,7 @@ fn main() {
 
     let guards: Vec<_> = (0..3).map(|i| {
         let number = numbers.clone();
-        Thread::scoped(move || {
+        thread::scoped(move || {
             let mut array = number.lock().unwrap();
             array[i] += 1;
             println!("numbers[{}] is {}", i, array[i]);
@@ -535,13 +535,13 @@ As an example, Rust's ownership system is _entirely_ at compile time. The
 safety check that makes this an error about moved values:
 
 ```{rust,ignore}
-use std::thread::Thread;
+use std::thread;
 
 fn main() {
     let numbers = vec![1, 2, 3];
 
     let guards: Vec<_> = (0..3).map(|i| {
-        Thread::scoped(move || {
+        thread::scoped(move || {
             println!("{}", numbers[i]);
         });
     }).collect();

--- a/src/doc/intro.md
+++ b/src/doc/intro.md
@@ -430,7 +430,7 @@ fn main() {
         thread::scoped(move || {
             numbers[i] += 1;
             println!("numbers[{}] is {}", i, numbers[i]);
-        });
+        })
     }).collect();
 }
 ```
@@ -442,7 +442,7 @@ It gives us this error:
 7     thread::scoped(move || {
 8       numbers[i] += 1;
 9       println!("numbers[{}] is {}", i, numbers[i]);
-10     });
+10     })
 error: aborting due to previous error
 ```
 
@@ -483,7 +483,7 @@ fn main() {
             let mut array = number.lock().unwrap();
             array[i] += 1;
             println!("numbers[{}] is {}", i, array[i]);
-        });
+        })
     }).collect();
 }
 ```
@@ -543,7 +543,7 @@ fn main() {
     let guards: Vec<_> = (0..3).map(|i| {
         thread::scoped(move || {
             println!("{}", numbers[i]);
-        });
+        })
     }).collect();
 }
 ```


### PR DESCRIPTION
If we end the `scoped` call with a semicolon, the `JoinGuard` will be
dropped and not returned from the `map`. The thread will start up and
we immediately block, making for a very expensive sequential loop.
