### PR TITLE
rustc: Fix an ICE when -o bare-path

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -927,7 +927,7 @@ pub fn build_output_filenames(input: &Input,
             // We want to toss everything after the final '.'
             let dirpath = match *odir {
                 Some(ref d) => d.clone(),
-                None => PathBuf::new(".")
+                None => PathBuf::new("")
             };
 
             // If a crate name is present, we use it as the link name

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -954,8 +954,11 @@ pub fn build_output_filenames(input: &Input,
             if *odir != None {
                 sess.warn("ignoring --out-dir flag due to -o flag.");
             }
+
+            let cur_dir = Path::new("");
+
             OutputFilenames {
-                out_directory: out_file.parent().unwrap().to_path_buf(),
+                out_directory: out_file.parent().unwrap_or(cur_dir).to_path_buf(),
                 out_filestem: out_file.file_stem().unwrap()
                                       .to_str().unwrap().to_string(),
                 single_output_file: ofile,

--- a/src/test/run-make/bare-outfile/Makefile
+++ b/src/test/run-make/bare-outfile/Makefile
@@ -1,0 +1,4 @@
+-include ../tools.mk
+
+all:
+	$(rustc) -o foo foo.rs

--- a/src/test/run-make/bare-outfile/foo.rs
+++ b/src/test/run-make/bare-outfile/foo.rs
@@ -1,0 +1,12 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+}


### PR DESCRIPTION
rustc will ICE if you specify an outfile path that is bare without a
directory. As a workaround, before this -o ./foo will work

It wasn't clear to me where I could put a test that actually invokes rustc from a shell, although I think I can add doctests to that machinery in librustc_driver that will arrange for this to be called with arguments that would trigger the ICE
