### PR TITLE
Fix [src] hyperlinks in rustdoc

### DIFF
--- a/src/test/run-make/rustdoc-src-links/Makefile
+++ b/src/test/run-make/rustdoc-src-links/Makefile
@@ -1,0 +1,5 @@
+-include ../tools.mk
+all:
+	$(HOST_RPATH_ENV) $(RUSTDOC) -w html -o $(TMPDIR)/doc foo.rs
+	$(HTMLDOCCK) $(TMPDIR)/doc foo.rs
+	$(HTMLDOCCK) $(TMPDIR)/doc qux/mod.rs

--- a/src/test/run-make/rustdoc-src-links/foo.rs
+++ b/src/test/run-make/rustdoc-src-links/foo.rs
@@ -1,0 +1,43 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "foo"]
+
+//! Dox
+// @has src/foo/foo.rs.html
+// @has foo/index.html '//a/@href' '../src/foo/foo.rs.html'
+
+pub mod qux;
+
+// @has foo/bar/index.html '//a/@href' '../../src/foo/foo.rs.html'
+pub mod bar {
+
+    /// Dox
+    // @has foo/bar/baz/index.html '//a/@href' '../../../src/foo/foo.rs.html'
+    pub mod baz {
+        /// Dox
+        // @has foo/bar/baz/fn.baz.html '//a/@href' '../../../src/foo/foo.rs.html'
+        pub fn baz() { }
+    }
+
+    /// Dox
+    // @has foo/bar/trait.Foobar.html '//a/@href' '../../src/foo/foo.rs.html'
+    pub trait Foobar { fn dummy(&self) { } }
+
+    // @has foo/bar/struct.Foo.html '//a/@href' '../../src/foo/foo.rs.html'
+    pub struct Foo { x: i32, y: u32 }
+
+    // @has foo/bar/fn.prawns.html '//a/@href' '../../src/foo/foo.rs.html'
+    pub fn prawns((a, b): (i32, u32), Foo { x, y }: Foo) { }
+}
+
+/// Dox
+// @has foo/fn.modfn.html '//a/@href' '../src/foo/foo.rs.html'
+pub fn modfn() { }

--- a/src/test/run-make/rustdoc-src-links/qux/mod.rs
+++ b/src/test/run-make/rustdoc-src-links/qux/mod.rs
@@ -1,0 +1,39 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Dox
+// @has src/foo/qux/mod.rs.html
+// @has foo/qux/index.html '//a/@href' '../../src/foo/qux/mod.rs.html'
+
+// @has foo/qux/bar/index.html '//a/@href' '../../../src/foo/qux/mod.rs.html'
+pub mod bar {
+
+    /// Dox
+    // @has foo/qux/bar/baz/index.html '//a/@href' '../../../../src/foo/qux/mod.rs.html'
+    pub mod baz {
+        /// Dox
+        // @has foo/qux/bar/baz/fn.baz.html '//a/@href' '../../../../src/foo/qux/mod.rs.html'
+        pub fn baz() { }
+    }
+
+    /// Dox
+    // @has foo/qux/bar/trait.Foobar.html '//a/@href' '../../../src/foo/qux/mod.rs.html'
+    pub trait Foobar { fn dummy(&self) { } }
+
+    // @has foo/qux/bar/struct.Foo.html '//a/@href' '../../../src/foo/qux/mod.rs.html'
+    pub struct Foo { x: i32, y: u32 }
+
+    // @has foo/qux/bar/fn.prawns.html '//a/@href' '../../../src/foo/qux/mod.rs.html'
+    pub fn prawns((a, b): (i32, u32), Foo { x, y }: Foo) { }
+}
+
+/// Dox
+// @has foo/qux/fn.modfn.html '//a/@href' '../../src/foo/qux/mod.rs.html'
+pub fn modfn() { }


### PR DESCRIPTION
- rustdoc was doubly appending the file name to the path of where to
  generate the source files, meanwhile, the [src] hyperlinks were not
- Added a flag to rustdoc::html::render::clean_srcpath to ignore the
  last path component, i.e. the file name itself to prevent the issue
- This also avoids creating directories with the same name as source
  files, and it makes sure the link to `main.css` is correct as well.

Fixes #23192
