### PR TITLE
Add tests checking that a number of feature gates are gating their features

### DIFF
--- a/src/test/compile-fail-fulldeps/gated-quote.rs
+++ b/src/test/compile-fail-fulldeps/gated-quote.rs
@@ -1,0 +1,50 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that `quote`-related macro are gated by `quote` feature gate.
+
+// (To sanity-check the code, uncomment this.)
+// #![feature(quote)]
+
+// FIXME the error message that is current emitted seems pretty bad.
+
+#![feature(rustc_private)]
+#![allow(dead_code, unused_imports, unused_variables)]
+
+#[macro_use]
+extern crate syntax;
+
+use syntax::ast;
+use syntax::codemap::Span;
+use syntax::parse;
+
+struct ParseSess;
+
+impl ParseSess {
+    fn cfg(&self) -> ast::CrateConfig { loop { } }
+    fn parse_sess<'a>(&'a self) -> &'a parse::ParseSess { loop { } }
+    fn call_site(&self) -> Span { loop { } }
+    fn ident_of(&self, st: &str) -> ast::Ident { loop { } }
+    fn name_of(&self, st: &str) -> ast::Name { loop { } }
+}
+
+pub fn main() {
+    let ecx = &ParseSess;
+    let x = quote_tokens!(ecx, 3);   //~ ERROR macro undefined: 'quote_tokens!'
+    let x = quote_expr!(ecx, 3);     //~ ERROR macro undefined: 'quote_expr!'
+    let x = quote_ty!(ecx, 3);       //~ ERROR macro undefined: 'quote_ty!'
+    let x = quote_method!(ecx, 3);   //~ ERROR macro undefined: 'quote_method!'
+    let x = quote_item!(ecx, 3);     //~ ERROR macro undefined: 'quote_item!'
+    let x = quote_pat!(ecx, 3);      //~ ERROR macro undefined: 'quote_pat!'
+    let x = quote_arm!(ecx, 3);      //~ ERROR macro undefined: 'quote_arm!'
+    let x = quote_stmt!(ecx, 3);     //~ ERROR macro undefined: 'quote_stmt!'
+    let x = quote_matcher!(ecx, 3);  //~ ERROR macro undefined: 'quote_matcher!'
+    let x = quote_attr!(ecx, 3);     //~ ERROR macro undefined: 'quote_attr!'
+}

--- a/src/test/compile-fail/gated-link-args.rs
+++ b/src/test/compile-fail/gated-link-args.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test that `#[plugin_registrar]` attribute is gated by `plugin_registrar`
+// Test that `#[link_args]` attribute is gated by `link_args`
 // feature gate.
 
-// the registration function isn't typechecked yet
-#[plugin_registrar]
-pub fn registrar() {}
-//~^ ERROR compiler plugins are experimental
-//~| HELP add #![feature(plugin_registrar)] to the crate attributes to enable
-fn main() {}
+#[link_args = "aFdEfSeVEEE"]
+extern {}
+//~^ ERROR the `link_args` attribute is not portable across platforms
+//~| HELP add #![feature(link_args)] to the crate attributes to enable
+
+fn main() { }

--- a/src/test/compile-fail/gated-link-llvm-intrinsics.rs
+++ b/src/test/compile-fail/gated-link-llvm-intrinsics.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test that `#[plugin_registrar]` attribute is gated by `plugin_registrar`
-// feature gate.
+extern {
+    #[link_name = "llvm.sqrt.f32"]
+    fn sqrt(x: f32) -> f32;
+    //~^ ERROR linking to LLVM intrinsics is experimental
+    //~| HELP add #![feature(link_llvm_intrinsics)] to the crate attributes
+}
 
-// the registration function isn't typechecked yet
-#[plugin_registrar]
-pub fn registrar() {}
-//~^ ERROR compiler plugins are experimental
-//~| HELP add #![feature(plugin_registrar)] to the crate attributes to enable
-fn main() {}
+fn main(){
+}

--- a/src/test/compile-fail/gated-thread-local.rs
+++ b/src/test/compile-fail/gated-thread-local.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that `#[thread_local]` attribute is gated by `thread_local`
+// feature gate.
+//
+// (Note that the `thread_local!` macro is explicitly *not* gated; it
+// is given permission to expand into this unstable attribute even
+// when the surrounding context does not have permission to use it.)
+
+#[thread_local] //~ ERROR `#[thread_local]` is an experimental feature
+static FOO: i32 = 3;
+
+pub fn main() {
+    FOO.with(|x| {
+        println!("x: {}", x);
+    });
+}

--- a/src/test/compile-fail/gated-unsafe-destructor.rs
+++ b/src/test/compile-fail/gated-unsafe-destructor.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Test that `#[plugin_registrar]` attribute is gated by `plugin_registrar`
+// Test that `#[unsafe_destructor]` attribute is gated by `unsafe_destructor`
 // feature gate.
 
-// the registration function isn't typechecked yet
-#[plugin_registrar]
-pub fn registrar() {}
-//~^ ERROR compiler plugins are experimental
-//~| HELP add #![feature(plugin_registrar)] to the crate attributes to enable
-fn main() {}
+struct D<'a>(&'a u32);
+
+#[unsafe_destructor]
+impl<'a> Drop for D<'a> {
+    //~^ ERROR `#[unsafe_destructor]` allows too many unsafe patterns
+    fn drop(&mut self) { }
+}
+//~^ HELP: add #![feature(unsafe_destructor)] to the crate attributes to enable
+
+pub fn main() { }


### PR DESCRIPTION
Add tests checking that a number of feature gates are gating their features

Namely:
- `quote`
- `link_args`
- `link_llvm_intrinsics`
- `thread_local`
- `unsafe_destructor`

Also updates test for `plugin_registrar` to make it clear that
it is only testing the `plugin_registrar` feature gate.

Cc #22820.  (Latter is not fixed, since there are still a bunch more feature-gates that need tests. But I wanted to stop here and move on to something else.)
