### PR TITLE
std: Remove #[allow] directives in sys modules

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -273,12 +273,13 @@ pub mod collections;
 pub mod thread;
 pub mod sync;
 
+#[macro_use]
+#[path = "sys/common/mod.rs"] mod sys_common;
+
 #[cfg(unix)]
 #[path = "sys/unix/mod.rs"] mod sys;
 #[cfg(windows)]
 #[path = "sys/windows/mod.rs"] mod sys;
-
-#[path = "sys/common/mod.rs"] mod sys_common;
 
 pub mod rt;
 mod panicking;

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -108,9 +108,7 @@ fn lang_start(main: *const u8, argc: int, argv: *const *const u8) -> int {
         // but we just do this to name the main thread and to give it correct
         // info about the stack bounds.
         let thread: Thread = NewThread::new(Some("<main>".to_string()));
-        thread_info::set((my_stack_bottom, my_stack_top),
-                         sys::thread::guard::main(),
-                         thread);
+        thread_info::set(sys::thread::guard::main(), thread);
 
         // By default, some platforms will send a *signal* when a EPIPE error
         // would otherwise be delivered. This runtime doesn't install a SIGPIPE

--- a/src/libstd/sys/common/helper_thread.rs
+++ b/src/libstd/sys/common/helper_thread.rs
@@ -70,6 +70,17 @@ struct RaceBox(helper_signal::signal);
 unsafe impl Send for RaceBox {}
 unsafe impl Sync for RaceBox {}
 
+macro_rules! helper_init { (static $name:ident: Helper<$m:ty>) => (
+    static $name: Helper<$m> = Helper {
+        lock: ::sync::MUTEX_INIT,
+        cond: ::sync::CONDVAR_INIT,
+        chan: ::cell::UnsafeCell { value: 0 as *mut Sender<$m> },
+        signal: ::cell::UnsafeCell { value: 0 },
+        initialized: ::cell::UnsafeCell { value: false },
+        shutdown: ::cell::UnsafeCell { value: false },
+    };
+) }
+
 impl<M: Send> Helper<M> {
     /// Lazily boots a helper thread, becoming a no-op if the helper has already
     /// been spawned.

--- a/src/libstd/sys/common/mod.rs
+++ b/src/libstd/sys/common/mod.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 #![allow(missing_docs)]
-#![allow(dead_code)]
 
 use old_io::{self, IoError, IoResult};
 use prelude::v1::*;
@@ -19,9 +18,10 @@ use num::Int;
 use old_path::BytesContainer;
 use collections;
 
+#[macro_use] pub mod helper_thread;
+
 pub mod backtrace;
 pub mod condvar;
-pub mod helper_thread;
 pub mod mutex;
 pub mod net;
 pub mod net2;

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -26,7 +26,9 @@ use str;
 use sys::{self, retry, c, sock_t, last_error, last_net_error, last_gai_error, close_sock,
           wrlen, msglen_t, os, wouldblock, set_nonblocking, timer, ms_to_timeval,
           decode_error_detailed};
-use sync::{Arc, Mutex, MutexGuard};
+use sync::{Arc, Mutex};
+#[cfg(not(target_os = "linux"))]
+use sync::MutexGuard;
 use sys_common::{self, keep_going, short_write, timeout};
 use cmp;
 use old_io;
@@ -620,11 +622,13 @@ impl Drop for Inner {
     fn drop(&mut self) { unsafe { close_sock(self.fd); } }
 }
 
+#[cfg(not(target_os = "linux"))]
 pub struct Guard<'a> {
     pub fd: sock_t,
     pub guard: MutexGuard<'a, ()>,
 }
 
+#[cfg(not(target_os = "linux"))]
 #[unsafe_destructor]
 impl<'a> Drop for Guard<'a> {
     fn drop(&mut self) {

--- a/src/libstd/sys/common/net2.rs
+++ b/src/libstd/sys/common/net2.rs
@@ -15,7 +15,6 @@ use io::{self, Error, ErrorKind};
 use libc::{self, c_int, c_char, c_void, socklen_t};
 use mem;
 use net::{IpAddr, SocketAddr, Shutdown};
-use num::Int;
 use sys::c;
 use sys::net::{cvt, cvt_r, cvt_gai, Socket, init, wrlen_t};
 use sys_common::{AsInner, FromInner, IntoInner};
@@ -23,9 +22,6 @@ use sys_common::{AsInner, FromInner, IntoInner};
 ////////////////////////////////////////////////////////////////////////////////
 // sockaddr and misc bindings
 ////////////////////////////////////////////////////////////////////////////////
-
-fn hton<I: Int>(i: I) -> I { i.to_be() }
-fn ntoh<I: Int>(i: I) -> I { Int::from_be(i) }
 
 fn setsockopt<T>(sock: &Socket, opt: c_int, val: c_int,
                      payload: T) -> io::Result<()> {
@@ -39,7 +35,7 @@ fn setsockopt<T>(sock: &Socket, opt: c_int, val: c_int,
 
 #[allow(dead_code)]
 fn getsockopt<T: Copy>(sock: &Socket, opt: c_int,
-                           val: c_int) -> io::Result<T> {
+                       val: c_int) -> io::Result<T> {
     unsafe {
         let mut slot: T = mem::zeroed();
         let mut len = mem::size_of::<T>() as socklen_t;

--- a/src/libstd/sys/common/thread_info.rs
+++ b/src/libstd/sys/common/thread_info.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)] // stack_guard isn't used right now on all platforms
+
 use core::prelude::*;
 
 use cell::RefCell;
@@ -16,10 +18,6 @@ use thread::Thread;
 use thread_local::State;
 
 struct ThreadInfo {
-    // This field holds the known bounds of the stack in (lo, hi)
-    // form. Not all threads necessarily know their precise bounds,
-    // hence this is optional.
-    stack_bounds: (uint, uint),
     stack_guard: uint,
     thread: Thread,
 }
@@ -36,7 +34,6 @@ impl ThreadInfo {
         THREAD_INFO.with(move |c| {
             if c.borrow().is_none() {
                 *c.borrow_mut() = Some(ThreadInfo {
-                    stack_bounds: (0, 0),
                     stack_guard: 0,
                     thread: NewThread::new(None),
                 })
@@ -54,10 +51,9 @@ pub fn stack_guard() -> uint {
     ThreadInfo::with(|info| info.stack_guard)
 }
 
-pub fn set(stack_bounds: (uint, uint), stack_guard: uint, thread: Thread) {
+pub fn set(stack_guard: uint, thread: Thread) {
     THREAD_INFO.with(|c| assert!(c.borrow().is_none()));
     THREAD_INFO.with(move |c| *c.borrow_mut() = Some(ThreadInfo{
-        stack_bounds: stack_bounds,
         stack_guard: stack_guard,
         thread: thread,
     }));

--- a/src/libstd/sys/common/thread_local.rs
+++ b/src/libstd/sys/common/thread_local.rs
@@ -56,6 +56,7 @@
 
 #![allow(non_camel_case_types)]
 #![unstable(feature = "thread_local_internals")]
+#![allow(dead_code)] // sys isn't exported yet
 
 use prelude::v1::*;
 

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -21,6 +21,10 @@
 //! nor can it decode WTF-8 from arbitrary bytes.
 //! WTF-8 strings can be obtained from UTF-8, UTF-16, or code points.
 
+// this module is imported from @SimonSapin's repo and has tons of dead code on
+// unix (it's mostly used on windows), so don't worry about dead code here.
+#![allow(dead_code)]
+
 use core::prelude::*;
 
 use core::char::{encode_utf8_raw, encode_utf16_raw};

--- a/src/libstd/sys/unix/backtrace.rs
+++ b/src/libstd/sys/unix/backtrace.rs
@@ -84,9 +84,8 @@
 /// all unix platforms we support right now, so it at least gets the job done.
 
 use prelude::v1::*;
-use os::unix::prelude::*;
 
-use ffi::{CStr, AsOsStr};
+use ffi::CStr;
 use old_io::IoResult;
 use libc;
 use mem;
@@ -151,7 +150,7 @@ pub fn write(w: &mut Writer) -> IoResult<()> {
     // I/O done here is blocking I/O, not green I/O, so we don't have to
     // worry about this being a native vs green mutex.
     static LOCK: StaticMutex = MUTEX_INIT;
-    let _g = unsafe { LOCK.lock() };
+    let _g = LOCK.lock();
 
     try!(writeln!(w, "stack backtrace:"));
 
@@ -253,6 +252,8 @@ fn print(w: &mut Writer, idx: int, addr: *mut libc::c_void,
 fn print(w: &mut Writer, idx: int, addr: *mut libc::c_void,
          symaddr: *mut libc::c_void) -> IoResult<()> {
     use env;
+    use ffi::AsOsStr;
+    use os::unix::prelude::*;
     use ptr;
 
     ////////////////////////////////////////////////////////////////////////

--- a/src/libstd/sys/unix/fd.rs
+++ b/src/libstd/sys/unix/fd.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use core::prelude::*;
-use io::prelude::*;
 
 use io;
 use libc::{self, c_int, size_t, c_void};

--- a/src/libstd/sys/unix/fs2.rs
+++ b/src/libstd/sys/unix/fs2.rs
@@ -13,8 +13,8 @@ use io::prelude::*;
 use os::unix::prelude::*;
 
 use ffi::{CString, CStr, OsString, AsOsStr, OsStr};
-use io::{self, Error, Seek, SeekFrom};
-use libc::{self, c_int, c_void, size_t, off_t, c_char, mode_t};
+use io::{self, Error, SeekFrom};
+use libc::{self, c_int, size_t, off_t, c_char, mode_t};
 use mem;
 use path::{Path, PathBuf};
 use ptr;
@@ -321,14 +321,6 @@ pub fn set_perm(p: &Path, perm: FilePermissions) -> io::Result<()> {
 pub fn rmdir(p: &Path) -> io::Result<()> {
     let p = try!(cstr(p));
     try!(cvt(unsafe { libc::rmdir(p.as_ptr()) }));
-    Ok(())
-}
-
-pub fn chown(p: &Path, uid: isize, gid: isize) -> io::Result<()> {
-    let p = try!(cstr(p));
-    try!(cvt_r(|| unsafe {
-        libc::chown(p.as_ptr(), uid as libc::uid_t, gid as libc::gid_t)
-    }));
     Ok(())
 }
 

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -10,10 +10,6 @@
 
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
-#![allow(unused_unsafe)]
-#![allow(unused_mut)]
 
 use prelude::v1::*;
 
@@ -21,21 +17,9 @@ use ffi::CStr;
 use io::{self, ErrorKind};
 use libc;
 use num::{Int, SignedInt};
-use num;
-use old_io::{self, IoResult, IoError};
+use old_io::{self, IoError};
 use str;
 use sys_common::mkerr_libc;
-
-macro_rules! helper_init { (static $name:ident: Helper<$m:ty>) => (
-    static $name: Helper<$m> = Helper {
-        lock: ::sync::MUTEX_INIT,
-        cond: ::sync::CONDVAR_INIT,
-        chan: ::cell::UnsafeCell { value: 0 as *mut Sender<$m> },
-        signal: ::cell::UnsafeCell { value: 0 },
-        initialized: ::cell::UnsafeCell { value: false },
-        shutdown: ::cell::UnsafeCell { value: false },
-    };
-) }
 
 pub mod backtrace;
 pub mod c;

--- a/src/libstd/sys/unix/mutex.rs
+++ b/src/libstd/sys/unix/mutex.rs
@@ -12,7 +12,6 @@ use prelude::v1::*;
 
 use cell::UnsafeCell;
 use sys::sync as ffi;
-use sys_common::mutex;
 
 pub struct Mutex { inner: UnsafeCell<ffi::pthread_mutex_t> }
 
@@ -28,6 +27,7 @@ pub const MUTEX_INIT: Mutex = Mutex {
 unsafe impl Send for Mutex {}
 unsafe impl Sync for Mutex {}
 
+#[allow(dead_code)] // sys isn't exported yet
 impl Mutex {
     #[inline]
     pub unsafe fn new() -> Mutex {

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -10,6 +10,8 @@
 
 //! Implementation of `std::os` functionality for unix systems
 
+#![allow(unused_imports)] // lots of cfg code here
+
 use prelude::v1::*;
 use os::unix::*;
 
@@ -482,7 +484,7 @@ pub fn home_dir() -> Option<PathBuf> {
     #[cfg(not(any(target_os = "android",
                   target_os = "ios")))]
     unsafe fn fallback() -> Option<OsString> {
-        let mut amt = match libc::sysconf(c::_SC_GETPW_R_SIZE_MAX) {
+        let amt = match libc::sysconf(c::_SC_GETPW_R_SIZE_MAX) {
             n if n < 0 => 512 as usize,
             n => n as usize,
         };

--- a/src/libstd/sys/unix/os_str.rs
+++ b/src/libstd/sys/unix/os_str.rs
@@ -70,7 +70,7 @@ impl Slice {
     }
 
     pub fn from_str(s: &str) -> &Slice {
-        unsafe { mem::transmute(s.as_bytes()) }
+        Slice::from_u8_slice(s.as_bytes())
     }
 
     pub fn to_str(&self) -> Option<&str> {

--- a/src/libstd/sys/unix/pipe.rs
+++ b/src/libstd/sys/unix/pipe.rs
@@ -143,7 +143,7 @@ impl UnixStream {
     fn lock_nonblocking<'a>(&'a self) -> Guard<'a> {
         let ret = Guard {
             fd: self.fd(),
-            guard: unsafe { self.inner.lock.lock().unwrap() },
+            guard: self.inner.lock.lock().unwrap(),
         };
         set_nonblocking(self.fd(), true);
         ret

--- a/src/libstd/sys/unix/process2.rs
+++ b/src/libstd/sys/unix/process2.rs
@@ -14,18 +14,13 @@ use collections::HashMap;
 use env;
 use ffi::{OsString, OsStr, CString};
 use fmt;
-use hash::Hash;
 use io::{self, Error, ErrorKind};
 use libc::{self, pid_t, c_void, c_int, gid_t, uid_t};
 use mem;
-use old_io;
-use os;
 use os::unix::OsStrExt;
 use ptr;
-use sync::mpsc::{channel, Sender, Receiver};
 use sys::pipe2::AnonPipe;
-use sys::{self, retry, c, wouldblock, set_nonblocking, ms_to_timeval, cvt};
-use sys_common::AsInner;
+use sys::{self, retry, c, cvt};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Command
@@ -127,10 +122,6 @@ pub struct Process {
 const CLOEXEC_MSG_FOOTER: &'static [u8] = b"NOEX";
 
 impl Process {
-    pub fn id(&self) -> pid_t {
-        self.pid
-    }
-
     pub unsafe fn kill(&self) -> io::Result<()> {
         try!(cvt(libc::funcs::posix88::signal::kill(self.pid, libc::SIGKILL)));
         Ok(())

--- a/src/libstd/sys/unix/rwlock.rs
+++ b/src/libstd/sys/unix/rwlock.rs
@@ -24,12 +24,6 @@ unsafe impl Sync for RWLock {}
 
 impl RWLock {
     #[inline]
-    pub unsafe fn new() -> RWLock {
-        // Might be moved and address is changing it is better to avoid
-        // initialization of potentially opaque OS data before it landed
-        RWLOCK_INIT
-    }
-    #[inline]
     pub unsafe fn read(&self) {
         let r = ffi::pthread_rwlock_rdlock(self.inner.get());
         debug_assert_eq!(r, 0);

--- a/src/libstd/sys/unix/stack_overflow.rs
+++ b/src/libstd/sys/unix/stack_overflow.rs
@@ -37,7 +37,6 @@ impl Drop for Handler {
           target_os = "bitrig",
           target_os = "openbsd"))]
 mod imp {
-    use core::prelude::*;
     use sys_common::stack;
 
     use super::Handler;

--- a/src/libstd/sys/unix/tcp.rs
+++ b/src/libstd/sys/unix/tcp.rs
@@ -139,10 +139,6 @@ impl TcpAcceptor {
         Err(sys_common::eof())
     }
 
-    pub fn socket_name(&mut self) -> IoResult<ip::SocketAddr> {
-        net::sockname(self.fd(), libc::getsockname)
-    }
-
     pub fn set_timeout(&mut self, timeout: Option<u64>) {
         self.deadline = timeout.map(|a| sys::timer::now() + a).unwrap_or(0);
     }

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+
 use core::prelude::*;
 
 use io;
@@ -262,15 +264,15 @@ pub unsafe fn set_name(name: &str) {
     // pthread_setname_np() since glibc 2.12
     // availability autodetected via weak linkage
     let cname = CString::new(name).unwrap();
-    type F = unsafe extern "C" fn(libc::pthread_t, *const libc::c_char) -> libc::c_int;
+    type F = unsafe extern "C" fn(libc::pthread_t, *const libc::c_char)
+                                  -> libc::c_int;
     extern {
         #[linkage = "extern_weak"]
         static pthread_setname_np: *const ();
     }
     if !pthread_setname_np.is_null() {
-        unsafe {
-            mem::transmute::<*const (), F>(pthread_setname_np)(pthread_self(), cname.as_ptr());
-        }
+        mem::transmute::<*const (), F>(pthread_setname_np)(pthread_self(),
+                                                           cname.as_ptr());
     }
 }
 
@@ -300,6 +302,7 @@ pub unsafe fn detach(native: rust_thread) {
 }
 
 pub unsafe fn yield_now() { assert_eq!(sched_yield(), 0); }
+
 // glibc >= 2.15 has a __pthread_get_minstack() function that returns
 // PTHREAD_STACK_MIN plus however many bytes are needed for thread-local
 // storage.  We need that information to avoid blowing up when a small stack

--- a/src/libstd/sys/unix/time.rs
+++ b/src/libstd/sys/unix/time.rs
@@ -58,11 +58,9 @@ mod inner {
         type Output = Duration;
 
         fn sub(self, other: &SteadyTime) -> Duration {
-            unsafe {
-                let info = info();
-                let diff = self.t as i64 - other.t as i64;
-                Duration::nanoseconds(diff * info.numer as i64 / info.denom as i64)
-            }
+            let info = info();
+            let diff = self.t as i64 - other.t as i64;
+            Duration::nanoseconds(diff * info.numer as i64 / info.denom as i64)
         }
     }
 }

--- a/src/libstd/sys/unix/timer.rs
+++ b/src/libstd/sys/unix/timer.rs
@@ -100,7 +100,7 @@ pub fn now() -> u64 {
 fn helper(input: libc::c_int, messages: Receiver<Req>, _: ()) {
     let mut set: c::fd_set = unsafe { mem::zeroed() };
 
-    let mut fd = FileDesc::new(input, true);
+    let fd = FileDesc::new(input, true);
     let mut timeout: libc::timeval = unsafe { mem::zeroed() };
 
     // active timers are those which are able to be selected upon (and it's a

--- a/src/libstd/sys/unix/tty.rs
+++ b/src/libstd/sys/unix/tty.rs
@@ -11,7 +11,7 @@
 use prelude::v1::*;
 
 use sys::fs::FileDesc;
-use libc::{self, c_int, c_ulong, funcs};
+use libc::{self, c_int, c_ulong};
 use old_io::{self, IoResult, IoError};
 use sys::c;
 use sys_common;
@@ -86,6 +86,4 @@ impl TTY {
     pub fn get_winsize(&mut self) -> IoResult<(int, int)> {
         Err(sys_common::unimpl())
     }
-
-    pub fn isatty(&self) -> bool { false }
 }

--- a/src/libstd/sys/windows/backtrace.rs
+++ b/src/libstd/sys/windows/backtrace.rs
@@ -24,19 +24,16 @@
 
 #![allow(dead_code)]
 
+use prelude::v1::*;
+
 use dynamic_lib::DynamicLibrary;
 use ffi::CStr;
 use intrinsics;
-use old_io::{IoResult, Writer};
+use old_io::IoResult;
 use libc;
 use mem;
-use ops::Drop;
-use option::Option::{Some};
-use old_path::Path;
 use ptr;
-use result::Result::{Ok, Err};
-use slice::SliceExt;
-use str::{self, StrExt};
+use str;
 use sync::{StaticMutex, MUTEX_INIT};
 
 use sys_common::backtrace::*;

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -18,7 +18,7 @@ use old_io;
 
 use prelude::v1::*;
 use sys;
-use sys_common::{mkerr_libc};
+use sys_common::{self, mkerr_libc};
 
 use old_io::{FilePermission, Write, UnstableFileStat, Open, FileAccess, FileMode};
 use old_io::{IoResult, IoError, FileStat, SeekStyle};
@@ -434,7 +434,7 @@ pub fn stat(p: &Path) -> IoResult<FileStat> {
 // FIXME: move this to platform-specific modules (for now)?
 pub fn lstat(_p: &Path) -> IoResult<FileStat> {
     // FIXME: implementation is missing
-    Err(super::unimpl())
+    Err(sys_common::unimpl())
 }
 
 pub fn utime(p: &Path, atime: u64, mtime: u64) -> IoResult<()> {

--- a/src/libstd/sys/windows/mod.rs
+++ b/src/libstd/sys/windows/mod.rs
@@ -24,17 +24,6 @@ use os::windows::{OsStrExt, OsStringExt};
 use path::PathBuf;
 use sync::{Once, ONCE_INIT};
 
-macro_rules! helper_init { (static $name:ident: Helper<$m:ty>) => (
-    static $name: Helper<$m> = Helper {
-        lock: ::sync::MUTEX_INIT,
-        cond: ::sync::CONDVAR_INIT,
-        chan: ::cell::UnsafeCell { value: 0 as *mut ::sync::mpsc::Sender<$m> },
-        signal: ::cell::UnsafeCell { value: 0 },
-        initialized: ::cell::UnsafeCell { value: false },
-        shutdown: ::cell::UnsafeCell { value: false },
-    };
-) }
-
 pub mod backtrace;
 pub mod c;
 pub mod condvar;
@@ -216,15 +205,7 @@ pub fn init_net() {
     }
 }
 
-pub fn unimpl() -> IoError {
-    IoError {
-        kind: old_io::IoUnavailable,
-        desc: "operation is not implemented",
-        detail: None,
-    }
-}
-
-fn to_utf16(s: Option<&str>) -> IoResult<Vec<u16>> {
+pub fn to_utf16(s: Option<&str>) -> IoResult<Vec<u16>> {
     match s {
         Some(s) => Ok(to_utf16_os(OsStr::from_str(s))),
         None => Err(IoError {

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -29,7 +29,6 @@ use ptr;
 use str;
 use sync::{StaticMutex, MUTEX_INIT};
 use sys::fs::FileDesc;
-
 use sys::timer;
 use sys_common::{AsInner, timeout};
 
@@ -129,8 +128,6 @@ impl Process {
         use libc::funcs::extra::msvcrt::get_osfhandle;
 
         use mem;
-        use iter::IteratorExt;
-        use str::StrExt;
 
         if cfg.gid().is_some() || cfg.uid().is_some() {
             return Err(IoError {

--- a/src/libstd/sys/windows/tcp.rs
+++ b/src/libstd/sys/windows/tcp.rs
@@ -10,12 +10,13 @@
 
 #![allow(deprecated)]
 
+use prelude::v1::*;
+
 use old_io::net::ip;
 use old_io::IoResult;
 use libc;
 use mem;
 use ptr;
-use prelude::v1::*;
 use super::{last_error, last_net_error, sock_t};
 use sync::Arc;
 use sync::atomic::{AtomicBool, Ordering};

--- a/src/libstd/sys/windows/timer.rs
+++ b/src/libstd/sys/windows/timer.rs
@@ -20,15 +20,15 @@
 //! Other than that, the implementation is pretty straightforward in terms of
 //! the other two implementations of timers with nothing *that* new showing up.
 
-use self::Req::*;
 use prelude::v1::*;
+use self::Req::*;
 
 use libc;
 use ptr;
 
 use old_io::IoResult;
-use sync::mpsc::{channel, Sender, Receiver, TryRecvError};
 use sys_common::helper_thread::Helper;
+use sync::mpsc::{channel, TryRecvError, Sender, Receiver};
 
 helper_init! { static HELPER: Helper<Req> }
 

--- a/src/libstd/sys/windows/tty.rs
+++ b/src/libstd/sys/windows/tty.rs
@@ -38,7 +38,7 @@ use str::from_utf8;
 use super::c::{ENABLE_ECHO_INPUT, ENABLE_EXTENDED_FLAGS};
 use super::c::{ENABLE_INSERT_MODE, ENABLE_LINE_INPUT};
 use super::c::{ENABLE_PROCESSED_INPUT, ENABLE_QUICK_EDIT_MODE};
-use super::c::{CONSOLE_SCREEN_BUFFER_INFO};
+use super::c::CONSOLE_SCREEN_BUFFER_INFO;
 use super::c::{ReadConsoleW, WriteConsoleW, GetConsoleMode, SetConsoleMode};
 use super::c::{GetConsoleScreenBufferInfo};
 

--- a/src/libstd/thread.rs
+++ b/src/libstd/thread.rs
@@ -281,17 +281,13 @@ impl Builder {
             let my_stack_top = addr as usize;
             let my_stack_bottom = my_stack_top - stack_size + 1024;
             unsafe {
-                stack::record_os_managed_stack_bounds(my_stack_bottom, my_stack_top);
+                if let Some(name) = their_thread.name() {
+                    imp::set_name(name);
+                }
+                stack::record_os_managed_stack_bounds(my_stack_bottom,
+                                                      my_stack_top);
+                thread_info::set(imp::guard::current(), their_thread);
             }
-            match their_thread.name() {
-                Some(name) => unsafe { imp::set_name(name); },
-                None => {}
-            }
-            thread_info::set(
-                (my_stack_bottom, my_stack_top),
-                unsafe { imp::guard::current() },
-                their_thread
-            );
 
             let mut output = None;
             let f: Thunk<(), T> = if stdout.is_some() || stderr.is_some() {


### PR DESCRIPTION
These were suppressing lots of interesting warnings! Turns out there was also
quite a bit of dead code.
