### PR TITLE
rustdoc: get back 'plain summary line' in sidebar

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1264,7 +1264,7 @@ impl Context {
             let short = short.to_string();
             let v = map.entry(short).get().unwrap_or_else(
                 |vacant_entry| vacant_entry.insert(Vec::with_capacity(1)));
-            v.push((myname, Some(shorter_line(item.doc_value()))));
+            v.push((myname, Some(plain_summary_line(item.doc_value()))));
         }
 
         for (_, items) in &mut map {
@@ -1478,8 +1478,9 @@ fn shorter<'a>(s: Option<&'a str>) -> &'a str {
 }
 
 #[inline]
-fn shorter_line(s: Option<&str>) -> String {
-    shorter(s).replace("\n", " ")
+fn plain_summary_line(s: Option<&str>) -> String {
+    let line = shorter(s).replace("\n", " ");
+    markdown::plain_summary_line(&line[..])
 }
 
 fn document(w: &mut fmt::Formatter, item: &clean::Item) -> fmt::Result {


### PR DESCRIPTION
this feature was broken by mistake some days ago: @2b11a80
(line 2201: https://github.com/rust-lang/rust/commit/2b11a80#diff-05c3c8b7c08a25764218b8c18d8204b7L2201)

r? @alexcrichton 
