### PR TITLE
configure: have --enable-debug set -C debug-assertions=on so `debug!()` works again

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -130,7 +130,7 @@ ifdef CFG_DISABLE_DEBUG
   CFG_RUSTC_FLAGS += --cfg ndebug
 else
   $(info cfg: enabling more debugging (CFG_ENABLE_DEBUG))
-  CFG_RUSTC_FLAGS += --cfg debug
+  CFG_RUSTC_FLAGS += --cfg debug -C debug-assertions=on
 endif
 
 ifdef SAVE_TEMPS

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -590,7 +590,7 @@ TEST_SREQ$(1)_T_$(2)_H_$(3) = \
 
 # The tests select when to use debug configuration on their own;
 # remove directive, if present, from CFG_RUSTC_FLAGS (issue #7898).
-CTEST_RUSTC_FLAGS := $$(subst -C debug-assertions,,$$(CFG_RUSTC_FLAGS))
+CTEST_RUSTC_FLAGS := $$(subst -C debug-assertions,,$$(subst -C debug-assertions=on,,$$(CFG_RUSTC_FLAGS)))
 
 # The tests cannot be optimized while the rest of the compiler is optimized, so
 # filter out the optimization (if any) from rustc and then figure out if we need


### PR DESCRIPTION
configure: have --enable-debug set -C debug-assertions=on so `debug!()` works again
