### PR TITLE
Refactor the way methods are stored in ast::ImplItem/TraitItem.

### DIFF
--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -143,8 +143,8 @@ pub trait LintPass {
     fn check_generics(&mut self, _: &Context, _: &ast::Generics) { }
     fn check_fn(&mut self, _: &Context,
         _: FnKind, _: &ast::FnDecl, _: &ast::Block, _: Span, _: ast::NodeId) { }
-    fn check_ty_method(&mut self, _: &Context, _: &ast::TypeMethod) { }
     fn check_trait_item(&mut self, _: &Context, _: &ast::TraitItem) { }
+    fn check_impl_item(&mut self, _: &Context, _: &ast::ImplItem) { }
     fn check_struct_def(&mut self, _: &Context,
         _: &ast::StructDef, _: ast::Ident, _: &ast::Generics, _: ast::NodeId) { }
     fn check_struct_def_post(&mut self, _: &Context,

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -808,7 +808,7 @@ fn encode_info_for_method<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
                                     impl_path: PathElems,
                                     is_default_impl: bool,
                                     parent_id: NodeId,
-                                    ast_item_opt: Option<&ast::ImplItem>) {
+                                    impl_item_opt: Option<&ast::ImplItem>) {
 
     debug!("encode_info_for_method: {:?} {:?}", m.def_id,
            token::get_name(m.name));
@@ -826,21 +826,20 @@ fn encode_info_for_method<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
 
     let elem = ast_map::PathName(m.name);
     encode_path(rbml_w, impl_path.chain(Some(elem).into_iter()));
-    match ast_item_opt {
-        Some(&ast::MethodImplItem(ref ast_method)) => {
-            encode_attributes(rbml_w, &ast_method.attrs);
+    if let Some(impl_item) = impl_item_opt {
+        if let ast::MethodImplItem(ref ast_method) = impl_item.node {
+            encode_attributes(rbml_w, &impl_item.attrs);
             let scheme = ty::lookup_item_type(ecx.tcx, m.def_id);
             let any_types = !scheme.generics.types.is_empty();
-            if any_types || is_default_impl || attr::requests_inline(&ast_method.attrs) {
+            if any_types || is_default_impl || attr::requests_inline(&impl_item.attrs) {
                 encode_inlined_item(ecx, rbml_w, IIImplItemRef(local_def(parent_id),
-                                                               ast_item_opt.unwrap()));
+                                                               impl_item));
             }
             if !any_types {
                 encode_symbol(ecx, rbml_w, m.def_id.node);
             }
             encode_method_argument_names(rbml_w, ast_method.pe_fn_decl());
         }
-        Some(_) | None => {}
     }
 
     rbml_w.end_tag();
@@ -851,7 +850,7 @@ fn encode_info_for_associated_type(ecx: &EncodeContext,
                                    associated_type: &ty::AssociatedType,
                                    impl_path: PathElems,
                                    parent_id: NodeId,
-                                   typedef_opt: Option<&ast::Typedef>) {
+                                   impl_item_opt: Option<&ast::ImplItem>) {
     debug!("encode_info_for_associated_type({:?},{:?})",
            associated_type.def_id,
            token::get_name(associated_type.name));
@@ -873,9 +872,9 @@ fn encode_info_for_associated_type(ecx: &EncodeContext,
     let elem = ast_map::PathName(associated_type.name);
     encode_path(rbml_w, impl_path.chain(Some(elem).into_iter()));
 
-    if let Some(typedef) = typedef_opt {
-        encode_attributes(rbml_w, &typedef.attrs);
-        encode_type(ecx, rbml_w, ty::node_id_to_type(ecx.tcx, typedef.id));
+    if let Some(ii) = impl_item_opt {
+        encode_attributes(rbml_w, &ii.attrs);
+        encode_type(ecx, rbml_w, ty::node_id_to_type(ecx.tcx, ii.id));
     }
 
     rbml_w.end_tag();
@@ -1232,11 +1231,8 @@ fn encode_info_for_item(ecx: &EncodeContext,
                 pos: rbml_w.mark_stable_position(),
             });
 
-            let trait_item_type =
-                ty::impl_or_trait_item(tcx, trait_item_def_id.def_id());
-            match (trait_item_type, ast_item) {
-                (ty::MethodTraitItem(ref method_type),
-                 Some(&ast::MethodImplItem(_))) => {
+            match ty::impl_or_trait_item(tcx, trait_item_def_id.def_id()) {
+                ty::MethodTraitItem(ref method_type) => {
                     encode_info_for_method(ecx,
                                            rbml_w,
                                            &**method_type,
@@ -1245,31 +1241,13 @@ fn encode_info_for_item(ecx: &EncodeContext,
                                            item.id,
                                            ast_item)
                 }
-                (ty::MethodTraitItem(ref method_type), _) => {
-                    encode_info_for_method(ecx,
-                                           rbml_w,
-                                           &**method_type,
-                                           path.clone(),
-                                           false,
-                                           item.id,
-                                           None)
-                }
-                (ty::TypeTraitItem(ref associated_type),
-                 Some(&ast::TypeImplItem(ref typedef))) => {
+                ty::TypeTraitItem(ref associated_type) => {
                     encode_info_for_associated_type(ecx,
                                                     rbml_w,
                                                     &**associated_type,
                                                     path.clone(),
                                                     item.id,
-                                                    Some(typedef))
-                }
-                (ty::TypeTraitItem(ref associated_type), _) => {
-                    encode_info_for_associated_type(ecx,
-                                                    rbml_w,
-                                                    &**associated_type,
-                                                    path.clone(),
-                                                    item.id,
-                                                    None)
+                                                    ast_item)
                 }
             }
         }
@@ -1393,25 +1371,22 @@ fn encode_info_for_item(ecx: &EncodeContext,
                     encode_bounds_and_type_for_item(rbml_w, ecx, item_def_id.def_id().local_id());
                 }
             };
-            match *trait_item {
+            encode_attributes(rbml_w, &trait_item.attrs);
+            match trait_item.node {
                 ast::RequiredMethod(ref m) => {
-                    encode_attributes(rbml_w, &m.attrs);
                     encode_trait_item(rbml_w);
                     encode_item_sort(rbml_w, 'r');
                     encode_method_argument_names(rbml_w, &*m.decl);
                 }
 
                 ast::ProvidedMethod(ref m) => {
-                    encode_attributes(rbml_w, &m.attrs);
                     encode_trait_item(rbml_w);
                     encode_item_sort(rbml_w, 'p');
                     encode_inlined_item(ecx, rbml_w, IITraitItemRef(def_id, trait_item));
                     encode_method_argument_names(rbml_w, &*m.pe_fn_decl());
                 }
 
-                ast::TypeTraitItem(ref associated_type) => {
-                    encode_attributes(rbml_w,
-                                      &associated_type.attrs);
+                ast::TypeTraitItem(..) => {
                     encode_item_sort(rbml_w, 't');
                 }
             }

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -838,7 +838,7 @@ fn encode_info_for_method<'a, 'tcx>(ecx: &EncodeContext<'a, 'tcx>,
             if !any_types {
                 encode_symbol(ecx, rbml_w, m.def_id.node);
             }
-            encode_method_argument_names(rbml_w, ast_method.pe_fn_decl());
+            encode_method_argument_names(rbml_w, &ast_method.pe_sig().decl);
         }
     }
 
@@ -1383,7 +1383,7 @@ fn encode_info_for_item(ecx: &EncodeContext,
                     encode_trait_item(rbml_w);
                     encode_item_sort(rbml_w, 'p');
                     encode_inlined_item(ecx, rbml_w, IITraitItemRef(def_id, trait_item));
-                    encode_method_argument_names(rbml_w, &*m.pe_fn_decl());
+                    encode_method_argument_names(rbml_w, &*m.pe_sig().decl);
                 }
 
                 ast::TypeTraitItem(..) => {

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -425,9 +425,9 @@ fn simplify_ast(ii: e::InlinedItemRef) -> ast::InlinedItem {
                 }
                 ast::TypeTraitItem(ref associated_type) => {
                     ast::TypeTraitItem(
-                        P(fold::noop_fold_associated_type(
-                            (**associated_type).clone(),
-                            &mut fld)))
+                        fold::noop_fold_associated_type(
+                            (*associated_type).clone(),
+                            &mut fld))
                 }
             })
         }
@@ -441,7 +441,7 @@ fn simplify_ast(ii: e::InlinedItemRef) -> ast::InlinedItem {
                 }
                 ast::TypeImplItem(ref td) => {
                     ast::TypeImplItem(
-                        P(fold::noop_fold_typedef((**td).clone(), &mut fld)))
+                        fold::noop_fold_typedef((*td).clone(), &mut fld))
                 }
             })
         }

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -357,7 +357,7 @@ impl<'v> Visitor<'v> for LifeSeeder {
             }
             ast::ItemImpl(_, _, _, Some(ref _trait_ref), _, ref impl_items) => {
                 for impl_item in impl_items {
-                    match *impl_item {
+                    match **impl_item {
                         ast::MethodImplItem(ref method) => {
                             self.worklist.push(method.id);
                         }
@@ -586,7 +586,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for DeadVisitor<'a, 'tcx> {
             ast::ProvidedMethod(ref method) => {
                 visit::walk_block(self, &*method.pe_body())
             }
-            ast::RequiredMethod(_) => {}
+            ast::RequiredMethod(_) |
             ast::TypeTraitItem(_) => {}
         }
     }

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -228,16 +228,11 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
                     _ => ()
                 }
             }
-            ast_map::NodeTraitItem(trait_method) => {
-                visit::walk_trait_item(self, trait_method);
+            ast_map::NodeTraitItem(trait_item) => {
+                visit::walk_trait_item(self, trait_item);
             }
             ast_map::NodeImplItem(impl_item) => {
-                match *impl_item {
-                    ast::MethodImplItem(ref method) => {
-                        visit::walk_method_helper(self, method);
-                    }
-                    ast::TypeImplItem(_) => {}
-                }
+                visit::walk_impl_item(self, impl_item);
             }
             ast_map::NodeForeignItem(foreign_item) => {
                 visit::walk_foreign_item(self, &*foreign_item);
@@ -355,11 +350,26 @@ impl<'v> Visitor<'v> for LifeSeeder {
             ast::ItemEnum(ref enum_def, _) if allow_dead_code => {
                 self.worklist.extend(enum_def.variants.iter().map(|variant| variant.node.id));
             }
-            ast::ItemImpl(_, _, _, Some(ref _trait_ref), _, ref impl_items) => {
+            ast::ItemTrait(_, _, _, ref trait_items) => {
+                for trait_item in trait_items {
+                    match trait_item.node {
+                        ast::ProvidedMethod(_) => {
+                            if has_allow_dead_code_or_lang_attr(&trait_item.attrs) {
+                                self.worklist.push(trait_item.id);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            ast::ItemImpl(_, _, _, ref opt_trait, _, ref impl_items) => {
                 for impl_item in impl_items {
-                    match **impl_item {
-                        ast::MethodImplItem(ref method) => {
-                            self.worklist.push(method.id);
+                    match impl_item.node {
+                        ast::MethodImplItem(_) => {
+                            if opt_trait.is_some() ||
+                                    has_allow_dead_code_or_lang_attr(&impl_item.attrs) {
+                                self.worklist.push(impl_item.id);
+                            }
                         }
                         ast::TypeImplItem(_) => {}
                     }
@@ -368,21 +378,6 @@ impl<'v> Visitor<'v> for LifeSeeder {
             _ => ()
         }
         visit::walk_item(self, item);
-    }
-
-    fn visit_fn(&mut self, fk: visit::FnKind<'v>,
-                _: &'v ast::FnDecl, block: &'v ast::Block,
-                _: codemap::Span, id: ast::NodeId) {
-        // Check for method here because methods are not ast::Item
-        match fk {
-            visit::FkMethod(_, _, method) => {
-                if has_allow_dead_code_or_lang_attr(&method.attrs) {
-                    self.worklist.push(id);
-                }
-            }
-            _ => ()
-        }
-        visit::walk_block(self, block);
     }
 }
 
@@ -561,7 +556,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for DeadVisitor<'a, 'tcx> {
                 span: codemap::Span, id: ast::NodeId) {
         // Have to warn method here because methods are not ast::Item
         match fk {
-            visit::FkMethod(name, _, _) => {
+            visit::FkMethod(name, _) => {
                 if !self.symbol_is_live(id, None) {
                     self.warn_dead_code(id, span, name, "method");
                 }
@@ -582,12 +577,12 @@ impl<'a, 'tcx, 'v> Visitor<'v> for DeadVisitor<'a, 'tcx> {
 
     // Overwrite so that we don't warn the trait method itself.
     fn visit_trait_item(&mut self, trait_method: &ast::TraitItem) {
-        match *trait_method {
+        match trait_method.node {
             ast::ProvidedMethod(ref method) => {
-                visit::walk_block(self, &*method.pe_body())
+                visit::walk_block(self, method.pe_body())
             }
             ast::RequiredMethod(_) |
-            ast::TypeTraitItem(_) => {}
+            ast::TypeTraitItem(..) => {}
         }
     }
 }

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -18,7 +18,6 @@ use middle::ty::MethodCall;
 use util::ppaux;
 
 use syntax::ast;
-use syntax::ast_util::PostExpansionMethod;
 use syntax::codemap::Span;
 use syntax::visit;
 use syntax::visit::Visitor;
@@ -90,8 +89,8 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EffectCheckVisitor<'a, 'tcx> {
         let (is_item_fn, is_unsafe_fn) = match fn_kind {
             visit::FkItemFn(_, _, fn_style, _) =>
                 (true, fn_style == ast::Unsafety::Unsafe),
-            visit::FkMethod(_, method) =>
-                (true, method.pe_sig().unsafety == ast::Unsafety::Unsafe),
+            visit::FkMethod(_, sig) =>
+                (true, sig.unsafety == ast::Unsafety::Unsafe),
             _ => (false, false),
         };
 

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -90,7 +90,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EffectCheckVisitor<'a, 'tcx> {
         let (is_item_fn, is_unsafe_fn) = match fn_kind {
             visit::FkItemFn(_, _, fn_style, _) =>
                 (true, fn_style == ast::Unsafety::Unsafe),
-            visit::FkMethod(_, _, method) =>
+            visit::FkMethod(_, method) =>
                 (true, method.pe_unsafety() == ast::Unsafety::Unsafe),
             _ => (false, false),
         };

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -91,7 +91,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EffectCheckVisitor<'a, 'tcx> {
             visit::FkItemFn(_, _, fn_style, _) =>
                 (true, fn_style == ast::Unsafety::Unsafe),
             visit::FkMethod(_, method) =>
-                (true, method.pe_unsafety() == ast::Unsafety::Unsafe),
+                (true, method.pe_sig().unsafety == ast::Unsafety::Unsafe),
             _ => (false, false),
         };
 

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -841,7 +841,7 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
                 ast_map::NodeItem(ref item) => {
                     match item.node {
                         ast::ItemFn(ref fn_decl, pur, _, ref gen, _) => {
-                            Some((&**fn_decl, gen, pur, item.ident, None, item.span))
+                            Some((fn_decl, gen, pur, item.ident, None, item.span))
                         },
                         _ => None
                     }
@@ -849,11 +849,11 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
                 ast_map::NodeImplItem(item) => {
                     match item.node {
                         ast::MethodImplItem(ref m) => {
-                            Some((m.pe_fn_decl(),
-                                  m.pe_generics(),
-                                  m.pe_unsafety(),
+                            Some((&m.pe_sig().decl,
+                                  &m.pe_sig().generics,
+                                  m.pe_sig().unsafety,
                                   item.ident,
-                                  Some(&m.pe_explicit_self().node),
+                                  Some(&m.pe_sig().explicit_self.node),
                                   item.span))
                         }
                         ast::TypeImplItem(_) => None,
@@ -862,11 +862,11 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
                 ast_map::NodeTraitItem(item) => {
                     match item.node {
                         ast::ProvidedMethod(ref m) => {
-                            Some((m.pe_fn_decl(),
-                                  m.pe_generics(),
-                                  m.pe_unsafety(),
+                            Some((&m.pe_sig().decl,
+                                  &m.pe_sig().generics,
+                                  m.pe_sig().unsafety,
                                   item.ident,
-                                  Some(&m.pe_explicit_self().node),
+                                  Some(&m.pe_sig().explicit_self.node),
                                   item.span))
                         }
                         _ => None
@@ -1732,7 +1732,7 @@ fn lifetimes_in_scope(tcx: &ty::ctxt,
             ast_map::NodeImplItem(ii) => {
                 match ii.node {
                     ast::MethodImplItem(ref m) => {
-                        taken.push_all(&m.pe_generics().lifetimes);
+                        taken.push_all(&m.pe_sig().generics.lifetimes);
                         Some(ii.id)
                     }
                     ast::TypeImplItem(_) => None,

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -846,28 +846,28 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
                         _ => None
                     }
                 }
-                ast_map::NodeImplItem(ref item) => {
-                    match **item {
+                ast_map::NodeImplItem(item) => {
+                    match item.node {
                         ast::MethodImplItem(ref m) => {
                             Some((m.pe_fn_decl(),
                                   m.pe_generics(),
                                   m.pe_unsafety(),
-                                  m.pe_ident(),
+                                  item.ident,
                                   Some(&m.pe_explicit_self().node),
-                                  m.span))
+                                  item.span))
                         }
                         ast::TypeImplItem(_) => None,
                     }
                 },
-                ast_map::NodeTraitItem(ref item) => {
-                    match **item {
+                ast_map::NodeTraitItem(item) => {
+                    match item.node {
                         ast::ProvidedMethod(ref m) => {
                             Some((m.pe_fn_decl(),
                                   m.pe_generics(),
                                   m.pe_unsafety(),
-                                  m.pe_ident(),
+                                  item.ident,
                                   Some(&m.pe_explicit_self().node),
-                                  m.span))
+                                  item.span))
                         }
                         _ => None
                     }
@@ -1730,10 +1730,10 @@ fn lifetimes_in_scope(tcx: &ty::ctxt,
                 _ => None
             },
             ast_map::NodeImplItem(ii) => {
-                match *ii {
+                match ii.node {
                     ast::MethodImplItem(ref m) => {
                         taken.push_all(&m.pe_generics().lifetimes);
-                        Some(m.id)
+                        Some(ii.id)
                     }
                     ast::TypeImplItem(_) => None,
                 }

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -315,7 +315,7 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
                 match *impl_item {
                     ast::MethodImplItem(ref method) => {
                         let did = self.tcx.map.get_parent_did(search_item);
-                        if method_might_be_inlined(self.tcx, &**method, did) {
+                        if method_might_be_inlined(self.tcx, method, did) {
                             visit::walk_block(self, method.pe_body())
                         }
                     }

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -57,7 +57,7 @@ fn method_might_be_inlined(tcx: &ty::ctxt, method: &ast::Method,
                            impl_item: &ast::ImplItem,
                            impl_src: ast::DefId) -> bool {
     if attr::requests_inline(&impl_item.attrs) ||
-        generics_require_inlining(method.pe_generics()) {
+        generics_require_inlining(&method.pe_sig().generics) {
         return true
     }
     if is_local(impl_src) {
@@ -191,7 +191,7 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
             Some(ast_map::NodeImplItem(impl_item)) => {
                 match impl_item.node {
                     ast::MethodImplItem(ref method) => {
-                        if generics_require_inlining(method.pe_generics()) ||
+                        if generics_require_inlining(&method.pe_sig().generics) ||
                                 attr::requests_inline(&impl_item.attrs) {
                             true
                         } else {

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -149,7 +149,7 @@ impl<'a, 'v> Visitor<'v> for LifetimeContext<'a> {
                 })
             }
             visit::FkMethod(_, m) => {
-                self.visit_early_late(subst::FnSpace, m.pe_generics(), |this| {
+                self.visit_early_late(subst::FnSpace, &m.pe_sig().generics, |this| {
                     visit::walk_fn(this, fk, fd, b, s)
                 })
             }

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -25,7 +25,6 @@ use middle::subst;
 use middle::ty;
 use std::fmt;
 use syntax::ast;
-use syntax::ast_util::PostExpansionMethod;
 use syntax::codemap::Span;
 use syntax::parse::token::special_idents;
 use syntax::parse::token;
@@ -148,8 +147,8 @@ impl<'a, 'v> Visitor<'v> for LifetimeContext<'a> {
                     visit::walk_fn(this, fk, fd, b, s)
                 })
             }
-            visit::FkMethod(_, m) => {
-                self.visit_early_late(subst::FnSpace, &m.pe_sig().generics, |this| {
+            visit::FkMethod(_, sig) => {
+                self.visit_early_late(subst::FnSpace, &sig.generics, |this| {
                     visit::walk_fn(this, fk, fd, b, s)
                 })
             }
@@ -191,9 +190,9 @@ impl<'a, 'v> Visitor<'v> for LifetimeContext<'a> {
     }
 
     fn visit_trait_item(&mut self, trait_item: &ast::TraitItem) {
-        if let ast::RequiredMethod(ref m) = trait_item.node {
+        if let ast::MethodTraitItem(ref sig, None) = trait_item.node {
             self.visit_early_late(
-                subst::FnSpace, &m.generics,
+                subst::FnSpace, &sig.generics,
                 |this| visit::walk_trait_item(this, trait_item))
         } else {
             visit::walk_trait_item(self, trait_item);

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -22,10 +22,10 @@ use syntax::codemap::{Span, DUMMY_SP};
 use syntax::{attr, visit};
 use syntax::ast;
 use syntax::ast::{Attribute, Block, Crate, DefId, FnDecl, NodeId, Variant};
-use syntax::ast::{Item, TypeMethod, Method, Generics, StructField};
+use syntax::ast::{Item, Generics, StructField};
 use syntax::ast_util::is_local;
 use syntax::attr::{Stability, AttrMetaMethods};
-use syntax::visit::{FnKind, FkMethod, Visitor};
+use syntax::visit::{FnKind, Visitor};
 use syntax::feature_gate::emit_feature_warn;
 use util::nodemap::{NodeMap, DefIdMap, FnvHashSet, FnvHashMap};
 use util::ppaux::Repr;
@@ -123,32 +123,20 @@ impl<'a, 'v> Visitor<'v> for Annotator<'a> {
         }
     }
 
-    fn visit_fn(&mut self, fk: FnKind<'v>, _: &'v FnDecl,
-                _: &'v Block, sp: Span, _: NodeId) {
-        if let FkMethod(_, _, meth) = fk {
-            // Methods are not already annotated, so we annotate it
-            self.annotate(meth.id, true, &meth.attrs, sp, |_| {}, true);
-        }
+    fn visit_fn(&mut self, _: FnKind<'v>, _: &'v FnDecl,
+                _: &'v Block, _: Span, _: NodeId) {
         // Items defined in a function body have no reason to have
         // a stability attribute, so we don't recurse.
     }
 
-    fn visit_trait_item(&mut self, t: &ast::TraitItem) {
-        let (id, attrs, sp) = match *t {
-            ast::RequiredMethod(TypeMethod {id, ref attrs, span, ..}) => (id, attrs, span),
+    fn visit_trait_item(&mut self, ti: &ast::TraitItem) {
+        self.annotate(ti.id, true, &ti.attrs, ti.span,
+                      |v| visit::walk_trait_item(v, ti), true);
+    }
 
-            // work around lack of pattern matching for @ types
-            ast::ProvidedMethod(ref method) => {
-                match *method {
-                    Method {ref attrs, id, span, ..} => (id, attrs, span),
-                }
-            }
-
-            ast::TypeTraitItem(ref typedef) => {
-                (typedef.ty_param.id, &typedef.attrs, typedef.ty_param.span)
-            }
-        };
-        self.annotate(id, true, attrs, sp, |v| visit::walk_trait_item(v, t), true);
+    fn visit_impl_item(&mut self, ii: &ast::ImplItem) {
+        self.annotate(ii.id, true, &ii.attrs, ii.span,
+                      |v| visit::walk_impl_item(v, ii), true);
     }
 
     fn visit_variant(&mut self, var: &Variant, g: &'v Generics) {
@@ -335,22 +323,11 @@ pub fn check_item(tcx: &ty::ctxt, item: &ast::Item, warn_about_defns: bool,
             let trait_items = ty::trait_items(tcx, trait_did);
 
             for impl_item in impl_items {
-                let (ident, span) = match **impl_item {
-                    ast::MethodImplItem(ref method) => {
-                        (match method.node {
-                            ast::MethDecl(ident, _, _, _, _, _, _, _) => ident,
-                            ast::MethMac(..) => unreachable!(),
-                        }, method.span)
-                    }
-                    ast::TypeImplItem(ref typedef) => {
-                        (typedef.ident, typedef.span)
-                    }
-                };
                 let item = trait_items.iter().find(|item| {
-                    item.name() == ident.name
+                    item.name() == impl_item.ident.name
                 }).unwrap();
                 if warn_about_defns {
-                    maybe_do_stability_check(tcx, item.def_id(), span, cb);
+                    maybe_do_stability_check(tcx, item.def_id(), impl_item.span, cb);
                 }
             }
         }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -829,8 +829,7 @@ impl<'tcx> Repr<'tcx> for ty::TraitDef<'tcx> {
 impl<'tcx> Repr<'tcx> for ast::TraitItem {
     fn repr(&self, _tcx: &ctxt) -> String {
         let kind = match self.node {
-            ast::RequiredMethod(_) => "RequiredMethod",
-            ast::ProvidedMethod(_) => "ProvidedMethod",
+            ast::MethodTraitItem(..) => "MethodTraitItem",
             ast::TypeTraitItem(..) => "TypeTraitItem",
         };
         format!("{}({}, id={})", kind, self.ident, self.id)

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -828,14 +828,12 @@ impl<'tcx> Repr<'tcx> for ty::TraitDef<'tcx> {
 
 impl<'tcx> Repr<'tcx> for ast::TraitItem {
     fn repr(&self, _tcx: &ctxt) -> String {
-        match *self {
-            ast::RequiredMethod(ref data) => format!("RequiredMethod({}, id={})",
-                                                     data.ident, data.id),
-            ast::ProvidedMethod(ref data) => format!("ProvidedMethod(id={})",
-                                                     data.id),
-            ast::TypeTraitItem(ref data) => format!("TypeTraitItem({}, id={})",
-                                                     data.ty_param.ident, data.ty_param.id),
-        }
+        let kind = match self.node {
+            ast::RequiredMethod(_) => "RequiredMethod",
+            ast::ProvidedMethod(_) => "ProvidedMethod",
+            ast::TypeTraitItem(..) => "TypeTraitItem",
+        };
+        format!("{}({}, id={})", kind, self.ident, self.id)
     }
 }
 

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -188,8 +188,8 @@ mod svh_visitor {
         SawTy,
         SawGenerics,
         SawFn,
-        SawTyMethod,
-        SawTraitMethod,
+        SawTraitItem,
+        SawImplItem,
         SawStructField,
         SawVariant,
         SawExplicitSelf,
@@ -463,12 +463,12 @@ mod svh_visitor {
             SawFn.hash(self.st); visit::walk_fn(self, fk, fd, b, s)
         }
 
-        fn visit_ty_method(&mut self, t: &TypeMethod) {
-            SawTyMethod.hash(self.st); visit::walk_ty_method(self, t)
+        fn visit_trait_item(&mut self, ti: &TraitItem) {
+            SawTraitItem.hash(self.st); visit::walk_trait_item(self, ti)
         }
 
-        fn visit_trait_item(&mut self, t: &TraitItem) {
-            SawTraitMethod.hash(self.st); visit::walk_trait_item(self, t)
+        fn visit_impl_item(&mut self, ii: &ImplItem) {
+            SawImplItem.hash(self.st); visit::walk_impl_item(self, ii)
         }
 
         fn visit_struct_field(&mut self, s: &StructField) {

--- a/src/librustc_borrowck/borrowck/fragments.rs
+++ b/src/librustc_borrowck/borrowck/fragments.rs
@@ -26,7 +26,6 @@ use rustc::util::ppaux::{Repr, UserString};
 use std::mem;
 use std::rc::Rc;
 use syntax::ast;
-use syntax::ast_map;
 use syntax::attr::AttrMetaMethods;
 use syntax::codemap::Span;
 
@@ -119,24 +118,9 @@ pub fn instrument_move_fragments<'tcx>(this: &MoveData<'tcx>,
                                        tcx: &ty::ctxt<'tcx>,
                                        sp: Span,
                                        id: ast::NodeId) {
-    let (span_err, print) = {
-        let attrs : &[ast::Attribute];
-        attrs = match tcx.map.find(id) {
-            Some(ast_map::NodeItem(ref item)) =>
-                &item.attrs,
-            Some(ast_map::NodeImplItem(&ast::MethodImplItem(ref m))) =>
-                &m.attrs,
-            Some(ast_map::NodeTraitItem(&ast::ProvidedMethod(ref m))) =>
-                &m.attrs,
-            _ => &[],
-        };
-
-        let span_err =
-            attrs.iter().any(|a| a.check_name("rustc_move_fragments"));
-        let print = tcx.sess.opts.debugging_opts.print_move_fragments;
-
-        (span_err, print)
-    };
+    let span_err = tcx.map.attrs(id).iter()
+                          .any(|a| a.check_name("rustc_move_fragments"));
+    let print = tcx.sess.opts.debugging_opts.print_move_fragments;
 
     if !span_err && !print { return; }
 

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -46,13 +46,12 @@ use std::{cmp, slice};
 use std::{i8, i16, i32, i64, u8, u16, u32, u64, f32, f64};
 
 use syntax::{abi, ast, ast_map};
-use syntax::ast_util::is_shift_binop;
+use syntax::ast_util::{self, is_shift_binop, local_def};
 use syntax::attr::{self, AttrMetaMethods};
 use syntax::codemap::{self, Span};
 use syntax::feature_gate::{KNOWN_ATTRIBUTES, AttributeType};
 use syntax::parse::token;
 use syntax::ast::{TyIs, TyUs, TyI8, TyU8, TyI16, TyU16, TyI32, TyU32, TyI64, TyU64};
-use syntax::ast_util;
 use syntax::ptr::P;
 use syntax::visit::{self, Visitor};
 
@@ -879,36 +878,18 @@ enum MethodContext {
     PlainImpl
 }
 
-fn method_context(cx: &Context, m: &ast::Method) -> MethodContext {
-    let did = ast::DefId {
-        krate: ast::LOCAL_CRATE,
-        node: m.id
-    };
-
-    match cx.tcx.impl_or_trait_items.borrow().get(&did).cloned() {
-        None => cx.sess().span_bug(m.span, "missing method descriptor?!"),
-        Some(ty::MethodTraitItem(md)) => {
-            match md.container {
-                ty::TraitContainer(..) => MethodContext::TraitDefaultImpl,
-                ty::ImplContainer(cid) => {
-                    match ty::impl_trait_ref(cx.tcx, cid) {
-                        Some(..) => MethodContext::TraitImpl,
-                        None => MethodContext::PlainImpl
-                    }
+fn method_context(cx: &Context, id: ast::NodeId, span: Span) -> MethodContext {
+    match cx.tcx.impl_or_trait_items.borrow().get(&local_def(id)) {
+        None => cx.sess().span_bug(span, "missing method descriptor?!"),
+        Some(item) => match item.container() {
+            ty::TraitContainer(..) => MethodContext::TraitDefaultImpl,
+            ty::ImplContainer(cid) => {
+                match ty::impl_trait_ref(cx.tcx, cid) {
+                    Some(_) => MethodContext::TraitImpl,
+                    None => MethodContext::PlainImpl
                 }
             }
-        },
-        Some(ty::TypeTraitItem(typedef)) => {
-            match typedef.container {
-                ty::TraitContainer(..) => MethodContext::TraitDefaultImpl,
-                ty::ImplContainer(cid) => {
-                    match ty::impl_trait_ref(cx.tcx, cid) {
-                        Some(..) => MethodContext::TraitImpl,
-                        None => MethodContext::PlainImpl
-                    }
-                }
-            }
-        },
+        }
     }
 }
 
@@ -999,9 +980,9 @@ impl LintPass for NonSnakeCase {
 
     fn check_fn(&mut self, cx: &Context,
                 fk: visit::FnKind, _: &ast::FnDecl,
-                _: &ast::Block, span: Span, _: ast::NodeId) {
+                _: &ast::Block, span: Span, id: ast::NodeId) {
         match fk {
-            visit::FkMethod(ident, _, m) => match method_context(cx, m) {
+            visit::FkMethod(ident, _) => match method_context(cx, id, span) {
                 MethodContext::PlainImpl => {
                     self.check_snake_case(cx, "method", ident, span)
                 },
@@ -1023,8 +1004,10 @@ impl LintPass for NonSnakeCase {
         }
     }
 
-    fn check_ty_method(&mut self, cx: &Context, t: &ast::TypeMethod) {
-        self.check_snake_case(cx, "trait method", t.ident, t.span);
+    fn check_trait_item(&mut self, cx: &Context, trait_item: &ast::TraitItem) {
+        if let ast::RequiredMethod(_) = trait_item.node {
+            self.check_snake_case(cx, "trait method", trait_item.ident, trait_item.span);
+        }
     }
 
     fn check_lifetime_def(&mut self, cx: &Context, t: &ast::LifetimeDef) {
@@ -1335,9 +1318,9 @@ impl LintPass for UnsafeCode {
             visit::FkItemFn(_, _, ast::Unsafety::Unsafe, _) =>
                 cx.span_lint(UNSAFE_CODE, span, "declaration of an `unsafe` function"),
 
-            visit::FkMethod(_, _, m) => {
-                if let ast::Method_::MethDecl(_, _, _, _, ast::Unsafety::Unsafe, _, _, _) = m.node {
-                    cx.span_lint(UNSAFE_CODE, m.span, "implementation of an `unsafe` method")
+            visit::FkMethod(_, m) => {
+                if let ast::MethDecl(_, _, _, ast::Unsafety::Unsafe, _, _) = *m {
+                    cx.span_lint(UNSAFE_CODE, span, "implementation of an `unsafe` method")
                 }
             },
 
@@ -1345,9 +1328,12 @@ impl LintPass for UnsafeCode {
         }
     }
 
-    fn check_ty_method(&mut self, cx: &Context, ty_method: &ast::TypeMethod) {
-        if let ast::TypeMethod { unsafety: ast::Unsafety::Unsafe, span, ..} = *ty_method {
-            cx.span_lint(UNSAFE_CODE, span, "declaration of an `unsafe` method")
+    fn check_trait_item(&mut self, cx: &Context, trait_item: &ast::TraitItem) {
+        if let ast::RequiredMethod(ref m) = trait_item.node {
+            if m.unsafety == ast::Unsafety::Unsafe {
+                cx.span_lint(UNSAFE_CODE, trait_item.span,
+                             "declaration of an `unsafe` method")
+            }
         }
     }
 }
@@ -1576,30 +1562,30 @@ impl LintPass for MissingDoc {
         self.check_missing_docs_attrs(cx, Some(it.id), &it.attrs, it.span, desc);
     }
 
-    fn check_fn(&mut self, cx: &Context, fk: visit::FnKind, _: &ast::FnDecl,
-                _: &ast::Block, _: Span, _: ast::NodeId) {
-        if let visit::FkMethod(_, _, m) = fk {
-            // If the method is an impl for a trait, don't doc.
-            if method_context(cx, m) == MethodContext::TraitImpl {
-                return;
-            }
-
-            // Otherwise, doc according to privacy. This will also check
-            // doc for default methods defined on traits.
-            self.check_missing_docs_attrs(cx, Some(m.id), &m.attrs, m.span, "a method");
-        }
+    fn check_trait_item(&mut self, cx: &Context, trait_item: &ast::TraitItem) {
+        let desc = match trait_item.node {
+            ast::ProvidedMethod(_) => "a default method",
+            ast::RequiredMethod(_) => "a trait method",
+            ast::TypeTraitItem(..) => "an associated type"
+        };
+        self.check_missing_docs_attrs(cx, Some(trait_item.id),
+                                      &trait_item.attrs,
+                                      trait_item.span, desc);
     }
 
-    fn check_ty_method(&mut self, cx: &Context, tm: &ast::TypeMethod) {
-        self.check_missing_docs_attrs(cx, Some(tm.id), &tm.attrs, tm.span, "a type method");
-    }
-
-    fn check_trait_item(&mut self, cx: &Context, it: &ast::TraitItem) {
-        if let ast::TraitItem::TypeTraitItem(ref ty) = *it {
-            let assoc_ty = &ty.ty_param;
-            self.check_missing_docs_attrs(cx, Some(assoc_ty.id), &ty.attrs,
-                                          assoc_ty.span, "an associated type");
+    fn check_impl_item(&mut self, cx: &Context, impl_item: &ast::ImplItem) {
+        // If the method is an impl for a trait, don't doc.
+        if method_context(cx, impl_item.id, impl_item.span) == MethodContext::TraitImpl {
+            return;
         }
+
+        let desc = match impl_item.node {
+            ast::MethodImplItem(_) => "a method",
+            ast::TypeImplItem(_) => "an associated type"
+        };
+        self.check_missing_docs_attrs(cx, Some(impl_item.id),
+                                      &impl_item.attrs,
+                                      impl_item.span, desc);
     }
 
     fn check_struct_field(&mut self, cx: &Context, sf: &ast::StructField) {
@@ -1644,10 +1630,7 @@ impl LintPass for MissingCopyImplementations {
         if !cx.exported_items.contains(&item.id) {
             return;
         }
-        if cx.tcx
-             .destructor_for_type
-             .borrow()
-             .contains_key(&ast_util::local_def(item.id)) {
+        if cx.tcx.destructor_for_type.borrow().contains_key(&local_def(item.id)) {
             return;
         }
         let ty = match item.node {
@@ -1655,16 +1638,14 @@ impl LintPass for MissingCopyImplementations {
                 if ast_generics.is_parameterized() {
                     return;
                 }
-                ty::mk_struct(cx.tcx,
-                              ast_util::local_def(item.id),
+                ty::mk_struct(cx.tcx, local_def(item.id),
                               cx.tcx.mk_substs(Substs::empty()))
             }
             ast::ItemEnum(_, ref ast_generics) => {
                 if ast_generics.is_parameterized() {
                     return;
                 }
-                ty::mk_enum(cx.tcx,
-                            ast_util::local_def(item.id),
+                ty::mk_enum(cx.tcx, local_def(item.id),
                             cx.tcx.mk_substs(Substs::empty()))
             }
             _ => return,
@@ -1828,13 +1809,13 @@ impl LintPass for UnconditionalRecursion {
 
         let (name, checker) = match fn_kind {
             visit::FkItemFn(name, _, _, _) => (name, id_refers_to_this_fn as F),
-            visit::FkMethod(name, _, _) => (name, id_refers_to_this_method as F),
+            visit::FkMethod(name, _) => (name, id_refers_to_this_method as F),
             // closures can't recur, so they don't matter.
             visit::FkFnBlock => return
         };
 
-        let impl_def_id = ty::impl_of_method(cx.tcx, ast_util::local_def(id))
-            .unwrap_or(ast_util::local_def(ast::DUMMY_NODE_ID));
+        let impl_def_id = ty::impl_of_method(cx.tcx, local_def(id))
+            .unwrap_or(local_def(ast::DUMMY_NODE_ID));
         assert!(ast_util::is_local(impl_def_id));
         let impl_node_id = impl_def_id.node;
 
@@ -1938,7 +1919,7 @@ impl LintPass for UnconditionalRecursion {
                                       _: ast::Ident,
                                       id: ast::NodeId) -> bool {
             tcx.def_map.borrow().get(&id)
-               .map_or(false, |def| def.def_id() == ast_util::local_def(fn_id))
+               .map_or(false, |def| def.def_id() == local_def(fn_id))
         }
 
         // check if the method call `id` refers to method `method_id`

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -46,7 +46,7 @@ use std::{cmp, slice};
 use std::{i8, i16, i32, i64, u8, u16, u32, u64, f32, f64};
 
 use syntax::{abi, ast, ast_map};
-use syntax::ast_util::{self, is_shift_binop, local_def};
+use syntax::ast_util::{self, is_shift_binop, local_def, PostExpansionMethod};
 use syntax::attr::{self, AttrMetaMethods};
 use syntax::codemap::{self, Span};
 use syntax::feature_gate::{KNOWN_ATTRIBUTES, AttributeType};
@@ -1319,7 +1319,7 @@ impl LintPass for UnsafeCode {
                 cx.span_lint(UNSAFE_CODE, span, "declaration of an `unsafe` function"),
 
             visit::FkMethod(_, m) => {
-                if let ast::MethDecl(_, _, _, ast::Unsafety::Unsafe, _, _) = *m {
+                if m.pe_sig().unsafety == ast::Unsafety::Unsafe {
                     cx.span_lint(UNSAFE_CODE, span, "implementation of an `unsafe` method")
                 }
             },

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -94,7 +94,7 @@ impl<'v> Visitor<'v> for ParentVisitor {
             // private.
             ast::ItemTrait(_, _, _, ref methods) if item.vis != ast::Public => {
                 for m in methods {
-                    match *m {
+                    match **m {
                         ast::ProvidedMethod(ref m) => {
                             self.parents.insert(m.id, item.id);
                         }
@@ -280,7 +280,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EmbargoVisitor<'a, 'tcx> {
 
                 if public_ty || public_trait {
                     for impl_item in impl_items {
-                        match *impl_item {
+                        match **impl_item {
                             ast::MethodImplItem(ref method) => {
                                 let meth_public =
                                     match method.pe_explicit_self().node {
@@ -301,7 +301,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EmbargoVisitor<'a, 'tcx> {
             // is public
             ast::ItemTrait(_, _, _, ref methods) if public_first => {
                 for method in methods {
-                    match *method {
+                    match **method {
                         ast::ProvidedMethod(ref m) => {
                             debug!("provided {}", m.id);
                             self.exported_items.insert(m.id);
@@ -1088,7 +1088,7 @@ impl<'a, 'tcx> SanePrivacyVisitor<'a, 'tcx> {
                                 "visibility qualifiers have no effect on trait \
                                  impls");
                 for impl_item in impl_items {
-                    match *impl_item {
+                    match **impl_item {
                         ast::MethodImplItem(ref m) => {
                             check_inherited(m.span, m.pe_vis(), "");
                         }
@@ -1123,7 +1123,7 @@ impl<'a, 'tcx> SanePrivacyVisitor<'a, 'tcx> {
 
             ast::ItemTrait(_, _, _, ref methods) => {
                 for m in methods {
-                    match *m {
+                    match **m {
                         ast::ProvidedMethod(ref m) => {
                             check_inherited(m.span, m.pe_vis(),
                                             "unnecessary visibility");
@@ -1165,7 +1165,7 @@ impl<'a, 'tcx> SanePrivacyVisitor<'a, 'tcx> {
         match item.node {
             ast::ItemImpl(_, _, _, _, _, ref impl_items) => {
                 for impl_item in impl_items {
-                    match *impl_item {
+                    match **impl_item {
                         ast::MethodImplItem(ref m) => {
                             check_inherited(tcx, m.span, m.pe_vis());
                         }
@@ -1188,7 +1188,7 @@ impl<'a, 'tcx> SanePrivacyVisitor<'a, 'tcx> {
 
             ast::ItemTrait(_, _, _, ref methods) => {
                 for m in methods {
-                    match *m {
+                    match **m {
                         ast::RequiredMethod(..) => {}
                         ast::ProvidedMethod(ref m) => check_inherited(tcx, m.span,
                                                                 m.pe_vis()),
@@ -1352,7 +1352,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
                     trait_ref.is_some() ||
                     impl_items.iter()
                               .any(|impl_item| {
-                                  match *impl_item {
+                                  match **impl_item {
                                       ast::MethodImplItem(ref m) => {
                                           self.exported_items.contains(&m.id)
                                       }
@@ -1369,9 +1369,9 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
                     match *trait_ref {
                         None => {
                             for impl_item in impl_items {
-                                match *impl_item {
+                                match **impl_item {
                                     ast::MethodImplItem(ref method) => {
-                                        visit::walk_method_helper(self, &**method)
+                                        visit::walk_method_helper(self, method)
                                     }
                                     ast::TypeImplItem(_) => {}
                                 }
@@ -1395,7 +1395,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
 
                             // Those in 3. are warned with this call.
                             for impl_item in impl_items {
-                                match *impl_item {
+                                match **impl_item {
                                     ast::MethodImplItem(..) => {},
                                     ast::TypeImplItem(ref typedef) => {
                                         self.visit_ty(&typedef.typ);
@@ -1409,14 +1409,14 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
                     // methods will be visible as `Public::foo`.
                     let mut found_pub_static = false;
                     for impl_item in impl_items {
-                        match *impl_item {
+                        match **impl_item {
                             ast::MethodImplItem(ref method) => {
                                 if method.pe_explicit_self().node ==
                                         ast::SelfStatic &&
                                         self.exported_items
                                             .contains(&method.id) {
                                     found_pub_static = true;
-                                    visit::walk_method_helper(self, &**method);
+                                    visit::walk_method_helper(self, method);
                                 }
                             }
                             ast::TypeImplItem(_) => {}

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -275,7 +275,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EmbargoVisitor<'a, 'tcx> {
                         match impl_item.node {
                             ast::MethodImplItem(ref method) => {
                                 let meth_public =
-                                    match method.pe_explicit_self().node {
+                                    match method.pe_sig().explicit_self.node {
                                         ast::SelfStatic => public_ty,
                                         _ => true,
                                     } && impl_item.vis == ast::Public;
@@ -1355,7 +1355,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
                     for impl_item in impl_items {
                         match impl_item.node {
                             ast::MethodImplItem(ref method) => {
-                                if method.pe_explicit_self().node ==
+                                if method.pe_sig().explicit_self.node ==
                                         ast::SelfStatic &&
                                         self.exported_items
                                             .contains(&impl_item.id) {

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -48,7 +48,7 @@ use syntax::ast::UnnamedField;
 use syntax::ast::{Variant, ViewPathGlob, ViewPathList, ViewPathSimple};
 use syntax::ast::{Visibility};
 use syntax::ast;
-use syntax::ast_util::{self, local_def, PostExpansionMethod};
+use syntax::ast_util::local_def;
 use syntax::attr::AttrMetaMethods;
 use syntax::parse::token::{self, special_idents};
 use syntax::codemap::{Span, DUMMY_SP};
@@ -525,53 +525,29 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
 
                 // Add the names of all the items to the trait info.
                 for trait_item in items {
-                    let (name, trait_item_id) = match **trait_item {
+                    let name_bindings = self.add_child(trait_item.ident.name,
+                                        &module_parent,
+                                        ForbidDuplicateTypesAndValues,
+                                        trait_item.span);
+
+                    match trait_item.node {
                         ast::RequiredMethod(_) |
                         ast::ProvidedMethod(_) => {
-                            let (id, name, span) = match **trait_item {
-                                ast::RequiredMethod(ref m) => {
-                                    (m.id, m.ident.name, m.span)
-                                }
-                                ast::ProvidedMethod(ref m) => {
-                                    (m.id, m.pe_ident().name, m.span)
-                                }
-                                _ => unreachable!()
-                            };
-
-                            // Add it as a name in the trait module.
-                            let def = DefMethod(local_def(id),
+                            let def = DefMethod(local_def(trait_item.id),
                                                 FromTrait(local_def(item.id)));
-
-                            let method_name_bindings =
-                                self.add_child(name,
-                                               &module_parent,
-                                               ForbidDuplicateTypesAndValues,
-                                               span);
                             // NB: not IMPORTABLE
-                            method_name_bindings.define_value(def, span, PUBLIC);
-
-                            (name, local_def(id))
+                            name_bindings.define_value(def, trait_item.span, PUBLIC);
                         }
-                        ast::TypeTraitItem(ref associated_type) => {
+                        ast::TypeTraitItem(..) => {
                             let def = DefAssociatedTy(local_def(item.id),
-                                                      local_def(associated_type.ty_param.id));
-
-                            let name_bindings =
-                                self.add_child(associated_type.ty_param.ident.name,
-                                               &module_parent,
-                                               ForbidDuplicateTypesAndValues,
-                                               associated_type.ty_param.span);
+                                                      local_def(trait_item.id));
                             // NB: not IMPORTABLE
-                            name_bindings.define_type(def,
-                                                      associated_type.ty_param.span,
-                                                      PUBLIC);
-
-                            (associated_type.ty_param.ident.name,
-                             local_def(associated_type.ty_param.id))
+                            name_bindings.define_type(def, trait_item.span, PUBLIC);
                         }
-                    };
+                    }
 
-                    self.trait_item_map.insert((name, def_id), trait_item_id);
+                    self.trait_item_map.insert((trait_item.ident.name, def_id),
+                                               local_def(trait_item.id));
                 }
 
                 name_bindings.define_type(DefTrait(def_id), sp, modifiers);

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -531,8 +531,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                                         trait_item.span);
 
                     match trait_item.node {
-                        ast::RequiredMethod(_) |
-                        ast::ProvidedMethod(_) => {
+                        ast::MethodTraitItem(..) => {
                             let def = DefMethod(local_def(trait_item.id),
                                                 FromTrait(local_def(item.id)));
                             // NB: not IMPORTABLE

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -243,8 +243,8 @@ impl<'a, 'v, 'tcx> Visitor<'v> for Resolver<'a, 'tcx> {
                 ItemRibKind
             }
             visit::FkMethod(_, method) => {
-                self.visit_generics(method.pe_generics());
-                self.visit_explicit_self(method.pe_explicit_self());
+                self.visit_generics(&method.pe_sig().generics);
+                self.visit_explicit_self(&method.pe_sig().explicit_self);
                 MethodRibKind
             }
             visit::FkFnBlock(..) => ClosureRibKind(node_id)
@@ -2814,13 +2814,13 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         // FIXME #4951: Do we need a node ID here?
 
                         let type_parameters = match trait_item.node {
-                            ast::RequiredMethod(ref ty_m) => {
-                                HasTypeParameters(&ty_m.generics,
+                            ast::RequiredMethod(ref sig) => {
+                                HasTypeParameters(&sig.generics,
                                                   FnSpace,
                                                   MethodRibKind)
                             }
                             ast::ProvidedMethod(ref m) => {
-                                HasTypeParameters(m.pe_generics(),
+                                HasTypeParameters(&m.pe_sig().generics,
                                                   FnSpace,
                                                   MethodRibKind)
                             }
@@ -3075,7 +3075,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                 // We also need a new scope for the method-
                                 // specific type parameters.
                                 let type_parameters =
-                                    HasTypeParameters(method.pe_generics(),
+                                    HasTypeParameters(&method.pe_sig().generics,
                                                       FnSpace,
                                                       MethodRibKind);
                                 this.with_type_parameter_rib(type_parameters, |this| {
@@ -3956,11 +3956,11 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 let explicit_self = match this.ast_map.get(did.node) {
                     ast_map::NodeTraitItem(trait_item) => match trait_item.node {
                         ast::RequiredMethod(ref m) => &m.explicit_self,
-                        ast::ProvidedMethod(ref m) => m.pe_explicit_self(),
+                        ast::ProvidedMethod(ref m) => &m.pe_sig().explicit_self,
                         _ => return false
                     },
                     ast_map::NodeImplItem(impl_item) => match impl_item.node {
-                        ast::MethodImplItem(ref m) => m.pe_explicit_self(),
+                        ast::MethodImplItem(ref m) => &m.pe_sig().explicit_self,
                         _ => return false
                     },
                     _ => return false

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -86,6 +86,7 @@ use syntax::ast_util::{PostExpansionMethod, local_def, walk_pat};
 use syntax::attr::AttrMetaMethods;
 use syntax::ext::mtwt;
 use syntax::parse::token::{self, special_names, special_idents};
+use syntax::ptr::P;
 use syntax::codemap::{self, Span, Pos};
 use syntax::visit::{self, Visitor};
 
@@ -2812,7 +2813,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         //
                         // FIXME #4951: Do we need a node ID here?
 
-                        let type_parameters = match *trait_item {
+                        let type_parameters = match **trait_item {
                             ast::RequiredMethod(ref ty_m) => {
                                 HasTypeParameters(&ty_m.generics,
                                                   FnSpace,
@@ -3049,7 +3050,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                               generics: &Generics,
                               opt_trait_reference: &Option<TraitRef>,
                               self_type: &Ty,
-                              impl_items: &[ImplItem]) {
+                              impl_items: &[P<ImplItem>]) {
         // If applicable, create a rib for the type parameters.
         self.with_type_parameter_rib(HasTypeParameters(generics,
                                                        TypeSpace,
@@ -3065,7 +3066,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
                 this.with_current_self_type(self_type, |this| {
                     for impl_item in impl_items {
-                        match *impl_item {
+                        match **impl_item {
                             MethodImplItem(ref method) => {
                                 // If this is a trait impl, ensure the method
                                 // exists in trait
@@ -3079,7 +3080,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                                       FnSpace,
                                                       MethodRibKind);
                                 this.with_type_parameter_rib(type_parameters, |this| {
-                                    visit::walk_method_helper(this, &**method);
+                                    visit::walk_method_helper(this, method);
                                 });
                             }
                             TypeImplItem(ref typedef) => {

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -656,7 +656,7 @@ impl <'l, 'tcx> DxrVisitor<'l, 'tcx> {
                     type_parameters: &ast::Generics,
                     trait_ref: &Option<ast::TraitRef>,
                     typ: &ast::Ty,
-                    impl_items: &Vec<ast::ImplItem>) {
+                    impl_items: &[P<ast::ImplItem>]) {
         let trait_id = trait_ref.as_ref().and_then(|tr| self.lookup_type_ref(tr.ref_id));
         match typ.node {
             // Common case impl for a struct or something basic.
@@ -698,9 +698,9 @@ impl <'l, 'tcx> DxrVisitor<'l, 'tcx> {
 
         self.process_generic_params(type_parameters, item.span, "", item.id);
         for impl_item in impl_items {
-            match *impl_item {
+            match **impl_item {
                 ast::MethodImplItem(ref method) => {
-                    visit::walk_method_helper(self, &**method)
+                    visit::walk_method_helper(self, method)
                 }
                 ast::TypeImplItem(ref typedef) => {
                     visit::walk_ty(self, &*typedef.typ)
@@ -713,7 +713,7 @@ impl <'l, 'tcx> DxrVisitor<'l, 'tcx> {
                      item: &ast::Item,
                      generics: &ast::Generics,
                      trait_refs: &OwnedSlice<ast::TyParamBound>,
-                     methods: &Vec<ast::TraitItem>) {
+                     methods: &[P<ast::TraitItem>]) {
         let qualname = format!("::{}", self.analysis.ty_cx.map.path_to_string(item.id));
         let val = self.span.snippet(item.span);
         let sub_span = self.span.sub_span_after_keyword(item.span, keywords::Trait);
@@ -1296,7 +1296,7 @@ impl<'l, 'tcx, 'v> Visitor<'v> for DxrVisitor<'l, 'tcx> {
                                             qualname,
                                             method_type.id);
             }
-            ast::ProvidedMethod(ref method) => self.process_method(&**method),
+            ast::ProvidedMethod(ref method) => self.process_method(method),
             ast::TypeTraitItem(_) => {}
         }
     }

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -382,21 +382,21 @@ impl <'l, 'tcx> DxrVisitor<'l, 'tcx> {
                             decl_id,
                             scope_id);
 
-        self.process_formals(&method.pe_fn_decl().inputs, qualname);
+        self.process_formals(&method.pe_sig().decl.inputs, qualname);
 
         // walk arg and return types
-        for arg in &method.pe_fn_decl().inputs {
+        for arg in &method.pe_sig().decl.inputs {
             self.visit_ty(&*arg.ty);
         }
 
-        if let ast::Return(ref ret_ty) = method.pe_fn_decl().output {
+        if let ast::Return(ref ret_ty) = method.pe_sig().decl.output {
             self.visit_ty(&**ret_ty);
         }
 
         // walk the fn body
         self.nest(id, |v| v.visit_block(&*method.pe_body()));
 
-        self.process_generic_params(method.pe_generics(),
+        self.process_generic_params(&method.pe_sig().generics,
                                     span,
                                     qualname,
                                     id);

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1283,7 +1283,7 @@ fn build_cfg(tcx: &ty::ctxt, id: ast::NodeId) -> (ast::NodeId, Option<cfg::CFG>)
                                   in has_nested_returns")
                 }
                 ast::TypeTraitItem(_) => {
-                    tcx.sess.bug("unexpected variant: type trait item in \
+                    tcx.sess.bug("unexpected variant: associated type trait item in \
                                   has_nested_returns")
                 }
             }
@@ -1299,7 +1299,7 @@ fn build_cfg(tcx: &ty::ctxt, id: ast::NodeId) -> (ast::NodeId, Option<cfg::CFG>)
                     }
                 }
                 ast::TypeImplItem(_) => {
-                    tcx.sess.bug("unexpected variant: type impl item in \
+                    tcx.sess.bug("unexpected variant: associated type impl item in \
                                   has_nested_returns")
                 }
             }
@@ -2826,18 +2826,18 @@ pub fn get_item_val(ccx: &CrateContext, id: ast::NodeId) -> ValueRef {
                                     method in get_item_val()");
                 }
                 ast::ProvidedMethod(ref m) => {
-                    register_method(ccx, id, &**m)
+                    register_method(ccx, id, m)
                 }
             }
         }
 
         ast_map::NodeImplItem(ii) => {
             match *ii {
-                ast::MethodImplItem(ref m) => register_method(ccx, id, &**m),
+                ast::MethodImplItem(ref m) => register_method(ccx, id, m),
                 ast::TypeImplItem(ref typedef) => {
                     ccx.sess().span_bug(typedef.span,
-                                        "unexpected variant: required impl \
-                                         method in get_item_val()")
+                                        "unexpected variant: associated type \
+                                        in get_item_val()")
                 }
             }
         }

--- a/src/librustc_trans/trans/debuginfo.rs
+++ b/src/librustc_trans/trans/debuginfo.rs
@@ -1292,7 +1292,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
 
             match item.node {
                 ast::ItemFn(ref fn_decl, _, _, ref generics, ref top_level_block) => {
-                    (item.ident, &**fn_decl, generics, &**top_level_block, item.span, true)
+                    (item.ident, fn_decl, generics, &**top_level_block, item.span, true)
                 }
                 _ => {
                     cx.sess().span_bug(item.span,
@@ -1308,8 +1308,8 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                     }
 
                     (impl_item.ident,
-                     method.pe_fn_decl(),
-                     method.pe_generics(),
+                     &method.pe_sig().decl,
+                     &method.pe_sig().generics,
                      method.pe_body(),
                      impl_item.span,
                      true)
@@ -1326,7 +1326,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                 ast::ExprClosure(_, ref fn_decl, ref top_level_block) => {
                     let name = format!("fn{}", token::gensym("fn"));
                     let name = token::str_to_ident(&name[..]);
-                    (name, &**fn_decl,
+                    (name, fn_decl,
                         // This is not quite right. It should actually inherit
                         // the generics of the enclosing function.
                         &empty_generics,
@@ -1347,8 +1347,8 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                     }
 
                     (trait_item.ident,
-                     method.pe_fn_decl(),
-                     method.pe_generics(),
+                     &method.pe_sig().decl,
+                     &method.pe_sig().generics,
                      method.pe_body(),
                      trait_item.span,
                      true)

--- a/src/librustc_trans/trans/debuginfo.rs
+++ b/src/librustc_trans/trans/debuginfo.rs
@@ -1300,22 +1300,22 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                 }
             }
         }
-        ast_map::NodeImplItem(ref item) => {
-            match **item {
+        ast_map::NodeImplItem(impl_item) => {
+            match impl_item.node {
                 ast::MethodImplItem(ref method) => {
-                    if contains_nodebug_attribute(&method.attrs) {
+                    if contains_nodebug_attribute(&impl_item.attrs) {
                         return FunctionDebugContext::FunctionWithoutDebugInfo;
                     }
 
-                    (method.pe_ident(),
+                    (impl_item.ident,
                      method.pe_fn_decl(),
                      method.pe_generics(),
                      method.pe_body(),
-                     method.span,
+                     impl_item.span,
                      true)
                 }
-                ast::TypeImplItem(ref typedef) => {
-                    cx.sess().span_bug(typedef.span,
+                ast::TypeImplItem(_) => {
+                    cx.sess().span_bug(impl_item.span,
                                        "create_function_debug_context() \
                                         called on associated type?!")
                 }
@@ -1339,18 +1339,18 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                         "create_function_debug_context: expected an expr_fn_block here")
             }
         }
-        ast_map::NodeTraitItem(ref trait_method) => {
-            match **trait_method {
+        ast_map::NodeTraitItem(trait_item) => {
+            match trait_item.node {
                 ast::ProvidedMethod(ref method) => {
-                    if contains_nodebug_attribute(&method.attrs) {
+                    if contains_nodebug_attribute(&trait_item.attrs) {
                         return FunctionDebugContext::FunctionWithoutDebugInfo;
                     }
 
-                    (method.pe_ident(),
+                    (trait_item.ident,
                      method.pe_fn_decl(),
                      method.pe_generics(),
                      method.pe_body(),
-                     method.span,
+                     trait_item.span,
                      true)
                 }
                 _ => {

--- a/src/librustc_trans/trans/inline.rs
+++ b/src/librustc_trans/trans/inline.rs
@@ -17,7 +17,7 @@ use trans::common::*;
 use middle::ty;
 
 use syntax::ast;
-use syntax::ast_util::{local_def, PostExpansionMethod};
+use syntax::ast_util::local_def;
 
 fn instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
     -> Option<ast::DefId> {
@@ -146,19 +146,19 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
             ccx.stats().n_inlines.set(ccx.stats().n_inlines.get() + 1);
 
             // Translate monomorphic impl methods immediately.
-            if let ast::MethodImplItem(ref mth) = impl_item.node {
+            if let ast::MethodImplItem(ref sig, ref body) = impl_item.node {
                 let impl_tpt = ty::lookup_item_type(ccx.tcx(), impl_did);
                 if impl_tpt.generics.types.is_empty() &&
-                        mth.pe_sig().generics.ty_params.is_empty() {
+                        sig.generics.ty_params.is_empty() {
                     let empty_substs = ccx.tcx().mk_substs(Substs::trans_empty());
                     let llfn = get_item_val(ccx, impl_item.id);
                     trans_fn(ccx,
-                            &*mth.pe_sig().decl,
-                            &*mth.pe_body(),
-                            llfn,
-                            empty_substs,
-                            impl_item.id,
-                            &[]);
+                             &sig.decl,
+                             body,
+                             llfn,
+                             empty_substs,
+                             impl_item.id,
+                             &[]);
                     // Use InternalLinkage so LLVM can optimize more aggressively.
                     SetLinkage(llfn, InternalLinkage);
                 }

--- a/src/librustc_trans/trans/inline.rs
+++ b/src/librustc_trans/trans/inline.rs
@@ -149,11 +149,11 @@ fn instantiate_inline(ccx: &CrateContext, fn_id: ast::DefId)
             if let ast::MethodImplItem(ref mth) = impl_item.node {
                 let impl_tpt = ty::lookup_item_type(ccx.tcx(), impl_did);
                 if impl_tpt.generics.types.is_empty() &&
-                        mth.pe_generics().ty_params.is_empty() {
+                        mth.pe_sig().generics.ty_params.is_empty() {
                     let empty_substs = ccx.tcx().mk_substs(Substs::trans_empty());
                     let llfn = get_item_val(ccx, impl_item.id);
                     trans_fn(ccx,
-                            &*mth.pe_fn_decl(),
+                            &*mth.pe_sig().decl,
                             &*mth.pe_body(),
                             llfn,
                             empty_substs,

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -80,13 +80,13 @@ pub fn trans_impl(ccx: &CrateContext,
     for impl_item in impl_items {
         match impl_item.node {
             ast::MethodImplItem(ref method) => {
-                if method.pe_generics().ty_params.len() == 0 {
+                if method.pe_sig().generics.ty_params.len() == 0 {
                     let trans_everywhere = attr::requests_inline(&impl_item.attrs);
                     for (ref ccx, is_origin) in ccx.maybe_iter(trans_everywhere) {
                         let llfn = get_item_val(ccx, impl_item.id);
                         let empty_substs = tcx.mk_substs(Substs::trans_empty());
                         trans_fn(ccx,
-                                 method.pe_fn_decl(),
+                                 &method.pe_sig().decl,
                                  method.pe_body(),
                                  llfn,
                                  empty_substs,

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -43,6 +43,7 @@ use syntax::parse::token;
 use syntax::{ast, ast_map, attr, visit};
 use syntax::ast_util::PostExpansionMethod;
 use syntax::codemap::DUMMY_SP;
+use syntax::ptr::P;
 
 // drop_glue pointer, size, align.
 const VTABLE_OFFSET: uint = 3;
@@ -53,7 +54,7 @@ const VTABLE_OFFSET: uint = 3;
 /// see `trans::base::lval_static_fn()` or `trans::base::monomorphic_fn()`.
 pub fn trans_impl(ccx: &CrateContext,
                   name: ast::Ident,
-                  impl_items: &[ast::ImplItem],
+                  impl_items: &[P<ast::ImplItem>],
                   generics: &ast::Generics,
                   id: ast::NodeId) {
     let _icx = push_ctxt("meth::trans_impl");
@@ -66,9 +67,9 @@ pub fn trans_impl(ccx: &CrateContext,
     if !generics.ty_params.is_empty() {
         let mut v = TransItemVisitor{ ccx: ccx };
         for impl_item in impl_items {
-            match *impl_item {
+            match **impl_item {
                 ast::MethodImplItem(ref method) => {
-                    visit::walk_method_helper(&mut v, &**method);
+                    visit::walk_method_helper(&mut v, method);
                 }
                 ast::TypeImplItem(_) => {}
             }
@@ -76,7 +77,7 @@ pub fn trans_impl(ccx: &CrateContext,
         return;
     }
     for impl_item in impl_items {
-        match *impl_item {
+        match **impl_item {
             ast::MethodImplItem(ref method) => {
                 if method.pe_generics().ty_params.len() == 0 {
                     let trans_everywhere = attr::requests_inline(&method.attrs);
@@ -99,7 +100,7 @@ pub fn trans_impl(ccx: &CrateContext,
                 let mut v = TransItemVisitor {
                     ccx: ccx,
                 };
-                visit::walk_method_helper(&mut v, &**method);
+                visit::walk_method_helper(&mut v, method);
             }
             ast::TypeImplItem(_) => {}
         }

--- a/src/librustc_trans/trans/monomorphize.rs
+++ b/src/librustc_trans/trans/monomorphize.rs
@@ -223,7 +223,7 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                     let needs_body = setup_lldecl(d, &impl_item.attrs);
                     if needs_body {
                         trans_fn(ccx,
-                                 mth.pe_fn_decl(),
+                                 &mth.pe_sig().decl,
                                  mth.pe_body(),
                                  d,
                                  psubsts,
@@ -243,7 +243,7 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                     let d = mk_lldecl(abi::Rust);
                     let needs_body = setup_lldecl(d, &trait_item.attrs);
                     if needs_body {
-                        trans_fn(ccx, mth.pe_fn_decl(), mth.pe_body(), d,
+                        trans_fn(ccx, &mth.pe_sig().decl, mth.pe_body(), d,
                                  psubsts, trait_item.id, &[]);
                     }
                     d

--- a/src/librustc_trans/trans/monomorphize.rs
+++ b/src/librustc_trans/trans/monomorphize.rs
@@ -216,18 +216,18 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
             }
             d
         }
-        ast_map::NodeImplItem(ii) => {
-            match *ii {
+        ast_map::NodeImplItem(impl_item) => {
+            match impl_item.node {
                 ast::MethodImplItem(ref mth) => {
                     let d = mk_lldecl(abi::Rust);
-                    let needs_body = setup_lldecl(d, &mth.attrs);
+                    let needs_body = setup_lldecl(d, &impl_item.attrs);
                     if needs_body {
                         trans_fn(ccx,
                                  mth.pe_fn_decl(),
                                  mth.pe_body(),
                                  d,
                                  psubsts,
-                                 mth.id,
+                                 impl_item.id,
                                  &[]);
                     }
                     d
@@ -237,14 +237,14 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                 }
             }
         }
-        ast_map::NodeTraitItem(method) => {
-            match *method {
+        ast_map::NodeTraitItem(trait_item) => {
+            match trait_item.node {
                 ast::ProvidedMethod(ref mth) => {
                     let d = mk_lldecl(abi::Rust);
-                    let needs_body = setup_lldecl(d, &mth.attrs);
+                    let needs_body = setup_lldecl(d, &trait_item.attrs);
                     if needs_body {
                         trans_fn(ccx, mth.pe_fn_decl(), mth.pe_body(), d,
-                                 psubsts, mth.id, &[]);
+                                 psubsts, trait_item.id, &[]);
                     }
                     d
                 }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1095,14 +1095,9 @@ fn associated_path_def_to_ty<'tcx>(this: &AstConv<'tcx>,
         // by type collection, which may be in progress at this point.
         match this.tcx().map.expect_item(trait_did.node).node {
             ast::ItemTrait(_, _, _, ref trait_items) => {
-                trait_items.iter().filter_map(|i| {
-                    if let ast::TypeTraitItem(ref assoc) = **i {
-                        if assoc.ty_param.ident.name == assoc_name {
-                            return Some(ast_util::local_def(assoc.ty_param.id));
-                        }
-                    }
-                    None
-                }).next().expect("missing associated type")
+                let item = trait_items.iter().find(|i| i.ident.name == assoc_name)
+                                      .expect("missing associated type");
+                ast_util::local_def(item.id)
             }
             _ => unreachable!()
         }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1442,22 +1442,19 @@ struct SelfInfo<'a, 'tcx> {
 }
 
 pub fn ty_of_method<'tcx>(this: &AstConv<'tcx>,
-                          unsafety: ast::Unsafety,
-                          untransformed_self_ty: Ty<'tcx>,
-                          explicit_self: &ast::ExplicitSelf,
-                          decl: &ast::FnDecl,
-                          abi: abi::Abi)
+                          sig: &ast::MethodSig,
+                          untransformed_self_ty: Ty<'tcx>)
                           -> (ty::BareFnTy<'tcx>, ty::ExplicitSelfCategory) {
     let self_info = Some(SelfInfo {
         untransformed_self_ty: untransformed_self_ty,
-        explicit_self: explicit_self,
+        explicit_self: &sig.explicit_self,
     });
     let (bare_fn_ty, optional_explicit_self_category) =
         ty_of_method_or_bare_fn(this,
-                                unsafety,
-                                abi,
+                                sig.unsafety,
+                                sig.abi,
                                 self_info,
-                                decl);
+                                &sig.decl);
     (bare_fn_ty, optional_explicit_self_category.unwrap())
 }
 

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1096,7 +1096,7 @@ fn associated_path_def_to_ty<'tcx>(this: &AstConv<'tcx>,
         match this.tcx().map.expect_item(trait_did.node).node {
             ast::ItemTrait(_, _, _, ref trait_items) => {
                 trait_items.iter().filter_map(|i| {
-                    if let ast::TypeTraitItem(ref assoc) = *i {
+                    if let ast::TypeTraitItem(ref assoc) = **i {
                         if assoc.ty_param.ident.name == assoc_name {
                             return Some(ast_util::local_def(assoc.ty_param.id));
                         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -119,8 +119,8 @@ use std::iter::repeat;
 use std::slice;
 use syntax::{self, abi, attr};
 use syntax::attr::AttrMetaMethods;
-use syntax::ast::{self, ProvidedMethod, RequiredMethod, TypeTraitItem, DefId, Visibility};
-use syntax::ast_util::{self, local_def, PostExpansionMethod};
+use syntax::ast::{self, DefId, Visibility};
+use syntax::ast_util::{self, local_def};
 use syntax::codemap::{self, Span};
 use syntax::owned_slice::OwnedSlice;
 use syntax::parse::token;
@@ -740,11 +740,12 @@ pub fn check_item<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx ast::Item) {
 
         for impl_item in impl_items {
             match impl_item.node {
-                ast::MethodImplItem(ref m) => {
-                    check_method_body(ccx, &impl_pty.generics, m,
+                ast::MethodImplItem(ref sig, ref body) => {
+                    check_method_body(ccx, &impl_pty.generics, sig, body,
                                       impl_item.id, impl_item.span);
                 }
-                ast::TypeImplItem(_) => {
+                ast::TypeImplItem(_) |
+                ast::MacImplItem(_) => {
                     // Nothing to do here.
                 }
             }
@@ -756,15 +757,15 @@ pub fn check_item<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx ast::Item) {
         let trait_def = ty::lookup_trait_def(ccx.tcx, local_def(it.id));
         for trait_item in trait_items {
             match trait_item.node {
-                RequiredMethod(..) => {
+                ast::MethodTraitItem(_, None) => {
                     // Nothing to do, since required methods don't have
                     // bodies to check.
                 }
-                ProvidedMethod(ref m) => {
-                    check_method_body(ccx, &trait_def.generics, m,
+                ast::MethodTraitItem(ref sig, Some(ref body)) => {
+                    check_method_body(ccx, &trait_def.generics, sig, body,
                                       trait_item.id, trait_item.span);
                 }
-                TypeTraitItem(..) => {
+                ast::TypeTraitItem(..) => {
                     // Nothing to do.
                 }
             }
@@ -857,7 +858,8 @@ fn check_trait_on_unimplemented<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 /// * `method`: the method definition
 fn check_method_body<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                item_generics: &ty::Generics<'tcx>,
-                               method: &'tcx ast::Method,
+                               sig: &'tcx ast::MethodSig,
+                               body: &'tcx ast::Block,
                                id: ast::NodeId, span: Span) {
     debug!("check_method_body(item_generics={}, id={})",
             item_generics.repr(ccx.tcx), id);
@@ -866,13 +868,7 @@ fn check_method_body<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     let fty = ty::node_id_to_type(ccx.tcx, id);
     debug!("check_method_body: fty={}", fty.repr(ccx.tcx));
 
-    check_bare_fn(ccx,
-                  &*method.pe_sig().decl,
-                  &*method.pe_body(),
-                  id,
-                  span,
-                  fty,
-                  param_env);
+    check_bare_fn(ccx, &sig.decl, body, id, span, fty, param_env);
 }
 
 fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
@@ -887,7 +883,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     // and compatible with trait signature
     for impl_item in impl_items {
         match impl_item.node {
-            ast::MethodImplItem(ref impl_method) => {
+            ast::MethodImplItem(_, ref body) => {
                 let impl_method_def_id = local_def(impl_item.id);
                 let impl_item_ty = ty::impl_or_trait_item(ccx.tcx,
                                                           impl_method_def_id);
@@ -905,7 +901,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                 compare_impl_method(ccx.tcx,
                                                     &**impl_method_ty,
                                                     impl_item.span,
-                                                    impl_method.pe_body().id,
+                                                    body.id,
                                                     &**trait_method_ty,
                                                     &*impl_trait_ref);
                             }
@@ -969,6 +965,8 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                     }
                 }
             }
+            ast::MacImplItem(_) => tcx.sess.span_bug(impl_item.span,
+                                                     "unexpanded macro")
         }
     }
 
@@ -981,10 +979,11 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                 let is_implemented =
                     impl_items.iter().any(|ii| {
                         match ii.node {
-                            ast::MethodImplItem(_) => {
+                            ast::MethodImplItem(..) => {
                                 ii.ident.name == trait_method.name
                             }
-                            ast::TypeImplItem(_) => false,
+                            ast::TypeImplItem(_) |
+                            ast::MacImplItem(_) => false,
                         }
                     });
                 let is_provided =
@@ -999,7 +998,8 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                         ast::TypeImplItem(_) => {
                             ii.ident.name == associated_type.name
                         }
-                        ast::MethodImplItem(_) => false,
+                        ast::MethodImplItem(..) |
+                        ast::MacImplItem(_) => false,
                     }
                 });
                 if !is_implemented {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -867,7 +867,7 @@ fn check_method_body<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     debug!("check_method_body: fty={}", fty.repr(ccx.tcx));
 
     check_bare_fn(ccx,
-                  &*method.pe_fn_decl(),
+                  &*method.pe_sig().decl,
                   &*method.pe_body(),
                   id,
                   span,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -739,9 +739,9 @@ pub fn check_item<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx ast::Item) {
           }
 
         for impl_item in impl_items {
-            match *impl_item {
+            match **impl_item {
                 ast::MethodImplItem(ref m) => {
-                    check_method_body(ccx, &impl_pty.generics, &**m);
+                    check_method_body(ccx, &impl_pty.generics, m);
                 }
                 ast::TypeImplItem(_) => {
                     // Nothing to do here.
@@ -754,13 +754,13 @@ pub fn check_item<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>, it: &'tcx ast::Item) {
         check_trait_on_unimplemented(ccx, generics, it);
         let trait_def = ty::lookup_trait_def(ccx.tcx, local_def(it.id));
         for trait_method in trait_methods {
-            match *trait_method {
+            match **trait_method {
                 RequiredMethod(..) => {
                     // Nothing to do, since required methods don't have
                     // bodies to check.
                 }
                 ProvidedMethod(ref m) => {
-                    check_method_body(ccx, &trait_def.generics, &**m);
+                    check_method_body(ccx, &trait_def.generics, m);
                 }
                 TypeTraitItem(_) => {
                     // Nothing to do.
@@ -876,7 +876,7 @@ fn check_method_body<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
                                             impl_span: Span,
                                             impl_trait_ref: &ty::TraitRef<'tcx>,
-                                            impl_items: &[ast::ImplItem]) {
+                                            impl_items: &[P<ast::ImplItem>]) {
     // Locate trait methods
     let tcx = ccx.tcx;
     let trait_items = ty::trait_items(tcx, impl_trait_ref.def_id);
@@ -884,7 +884,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     // Check existing impl methods to see if they are both present in trait
     // and compatible with trait signature
     for impl_item in impl_items {
-        match *impl_item {
+        match **impl_item {
             ast::MethodImplItem(ref impl_method) => {
                 let impl_method_def_id = local_def(impl_method.id);
                 let impl_item_ty = ty::impl_or_trait_item(ccx.tcx,
@@ -978,7 +978,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
             ty::MethodTraitItem(ref trait_method) => {
                 let is_implemented =
                     impl_items.iter().any(|ii| {
-                        match *ii {
+                        match **ii {
                             ast::MethodImplItem(ref m) => {
                                 m.pe_ident().name == trait_method.name
                             }
@@ -993,7 +993,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
             }
             ty::TypeTraitItem(ref associated_type) => {
                 let is_implemented = impl_items.iter().any(|ii| {
-                    match *ii {
+                    match **ii {
                         ast::TypeImplItem(ref typedef) => {
                             typedef.ident.name == associated_type.name
                         }

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -498,28 +498,24 @@ impl<'ccx, 'tcx, 'v> Visitor<'v> for CheckTypeWellFormedVisitor<'ccx, 'tcx> {
         visit::walk_fn(self, fk, fd, b, span)
     }
 
-    fn visit_trait_item(&mut self, t: &'v ast::TraitItem) {
-        match t {
-            &ast::TraitItem::ProvidedMethod(_) |
-            &ast::TraitItem::TypeTraitItem(_) => {}
-            &ast::TraitItem::RequiredMethod(ref method) => {
-                match ty::impl_or_trait_item(self.tcx(), local_def(method.id)) {
-                    ty::ImplOrTraitItem::MethodTraitItem(ty_method) => {
-                        reject_non_type_param_bounds(
-                            self.tcx(),
-                            method.span,
-                            &ty_method.predicates);
-                        reject_shadowing_type_parameters(
-                            self.tcx(),
-                            method.span,
-                            &ty_method.generics);
-                    }
-                    _ => {}
+    fn visit_trait_item(&mut self, trait_item: &'v ast::TraitItem) {
+        if let ast::RequiredMethod(_) = trait_item.node {
+            match ty::impl_or_trait_item(self.tcx(), local_def(trait_item.id)) {
+                ty::ImplOrTraitItem::MethodTraitItem(ty_method) => {
+                    reject_non_type_param_bounds(
+                        self.tcx(),
+                        trait_item.span,
+                        &ty_method.predicates);
+                    reject_shadowing_type_parameters(
+                        self.tcx(),
+                        trait_item.span,
+                        &ty_method.generics);
                 }
+                _ => {}
             }
         }
 
-        visit::walk_trait_item(self, t)
+        visit::walk_trait_item(self, trait_item)
     }
 }
 

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -499,7 +499,7 @@ impl<'ccx, 'tcx, 'v> Visitor<'v> for CheckTypeWellFormedVisitor<'ccx, 'tcx> {
     }
 
     fn visit_trait_item(&mut self, trait_item: &'v ast::TraitItem) {
-        if let ast::RequiredMethod(_) = trait_item.node {
+        if let ast::MethodTraitItem(_, None) = trait_item.node {
             match ty::impl_or_trait_item(self.tcx(), local_def(trait_item.id)) {
                 ty::ImplOrTraitItem::MethodTraitItem(ty_method) => {
                     reject_non_type_param_bounds(

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -501,7 +501,7 @@ impl<'ccx, 'tcx, 'v> Visitor<'v> for CheckTypeWellFormedVisitor<'ccx, 'tcx> {
     fn visit_trait_item(&mut self, t: &'v ast::TraitItem) {
         match t {
             &ast::TraitItem::ProvidedMethod(_) |
-            &ast::TraitItem::TypeTraitItem(_) => {},
+            &ast::TraitItem::TypeTraitItem(_) => {}
             &ast::TraitItem::RequiredMethod(ref method) => {
                 match ty::impl_or_trait_item(self.tcx(), local_def(method.id)) {
                     ty::ImplOrTraitItem::MethodTraitItem(ty_method) => {

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -275,20 +275,18 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
     // Converts an implementation in the AST to a vector of items.
     fn create_impl_from_item(&self, item: &Item) -> Vec<ImplOrTraitItemId> {
         match item.node {
-            ItemImpl(_, _, _, ref opt_trait, _, ref ast_items) => {
+            ItemImpl(_, _, _, ref opt_trait, _, ref impl_items) => {
                 let mut items: Vec<ImplOrTraitItemId> =
-                        ast_items.iter()
-                                 .map(|ast_item| {
-                            match **ast_item {
-                                ast::MethodImplItem(ref ast_method) => {
-                                    MethodTraitItemId(
-                                        local_def(ast_method.id))
-                                }
-                                ast::TypeImplItem(ref typedef) => {
-                                    TypeTraitItemId(local_def(typedef.id))
-                                }
-                            }
-                        }).collect();
+                        impl_items.iter().map(|impl_item| {
+                    match impl_item.node {
+                        ast::MethodImplItem(_) => {
+                            MethodTraitItemId(local_def(impl_item.id))
+                        }
+                        ast::TypeImplItem(_) => {
+                            TypeTraitItemId(local_def(impl_item.id))
+                        }
+                    }
+                }).collect();
 
                 if opt_trait.is_some() {
                     let trait_ref = ty::impl_id_to_trait_ref(self.crate_context.tcx,

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -279,7 +279,7 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
                 let mut items: Vec<ImplOrTraitItemId> =
                         ast_items.iter()
                                  .map(|ast_item| {
-                            match *ast_item {
+                            match **ast_item {
                                 ast::MethodImplItem(ref ast_method) => {
                                     MethodTraitItemId(
                                         local_def(ast_method.id))

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -279,11 +279,15 @@ impl<'a, 'tcx> CoherenceChecker<'a, 'tcx> {
                 let mut items: Vec<ImplOrTraitItemId> =
                         impl_items.iter().map(|impl_item| {
                     match impl_item.node {
-                        ast::MethodImplItem(_) => {
+                        ast::MethodImplItem(..) => {
                             MethodTraitItemId(local_def(impl_item.id))
                         }
                         ast::TypeImplItem(_) => {
                             TypeTraitItemId(local_def(impl_item.id))
+                        }
+                        ast::MacImplItem(_) => {
+                            self.crate_context.tcx.sess.span_bug(impl_item.span,
+                                                                 "unexpanded macro");
                         }
                     }
                 }).collect();

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -621,152 +621,52 @@ fn get_enum_variant_types<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
     }
 }
 
-fn collect_trait_methods<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                                   trait_id: ast::NodeId,
-                                   trait_def: &ty::TraitDef<'tcx>,
-                                   trait_predicates: &ty::GenericPredicates<'tcx>) {
-    let tcx = ccx.tcx;
-    if let ast_map::NodeItem(item) = tcx.map.get(trait_id) {
-        if let ast::ItemTrait(_, _, _, ref trait_items) = item.node {
-            // For each method, construct a suitable ty::Method and
-            // store it into the `tcx.impl_or_trait_items` table:
-            for trait_item in trait_items {
-                match trait_item.node {
-                    ast::RequiredMethod(_) |
-                    ast::ProvidedMethod(_) => {
-                        let ty_method = Rc::new(match trait_item.node {
-                            ast::RequiredMethod(ref m) => {
-                                ty_method_of_trait_method(
-                                    ccx,
-                                    trait_id,
-                                    &trait_def.generics,
-                                    &trait_predicates,
-                                    trait_item.id,
-                                    trait_item.ident,
-                                    &m.explicit_self,
-                                    m.abi,
-                                    &m.generics,
-                                    &m.unsafety,
-                                    &*m.decl)
-                            }
-                            ast::ProvidedMethod(ref m) => {
-                                ty_method_of_trait_method(
-                                    ccx,
-                                    trait_id,
-                                    &trait_def.generics,
-                                    &trait_predicates,
-                                    trait_item.id,
-                                    trait_item.ident,
-                                    m.pe_explicit_self(),
-                                    m.pe_abi(),
-                                    m.pe_generics(),
-                                    &m.pe_unsafety(),
-                                    &*m.pe_fn_decl())
-                            }
-                            ast::TypeTraitItem(..) => unreachable!()
-                        });
+fn convert_method<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
+                            container: ImplOrTraitItemContainer,
+                            sig: &ast::MethodSig,
+                            id: ast::NodeId,
+                            ident: ast::Ident,
+                            vis: ast::Visibility,
+                            untransformed_rcvr_ty: Ty<'tcx>,
+                            rcvr_ty_generics: &ty::Generics<'tcx>,
+                            rcvr_ty_predicates: &ty::GenericPredicates<'tcx>) {
+    let ty_generics = ty_generics_for_fn(ccx, &sig.generics, rcvr_ty_generics);
 
-                        debug!("ty_method_of_trait_method yielded {} for method {} of trait {}",
-                               ty_method.repr(ccx.tcx),
-                               trait_item.repr(ccx.tcx),
-                               local_def(trait_id).repr(ccx.tcx));
+    let ty_generic_predicates =
+        ty_generic_predicates_for_fn(ccx, &sig.generics, rcvr_ty_predicates);
 
-                        make_method_ty(ccx, &*ty_method);
+    let (fty, explicit_self_category) =
+        astconv::ty_of_method(&ccx.icx(&(rcvr_ty_predicates, &sig.generics)),
+                              sig, untransformed_rcvr_ty);
 
-                        tcx.impl_or_trait_items
-                            .borrow_mut()
-                            .insert(ty_method.def_id, ty::MethodTraitItem(ty_method));
-                    }
-                    ast::TypeTraitItem(..) => {
-                        let trait_did = local_def(trait_id);
-                        let associated_type = ty::AssociatedType {
-                            name: trait_item.ident.name,
-                            vis: ast::Public,
-                            def_id: local_def(trait_item.id),
-                            container: TraitContainer(trait_did),
-                        };
+    let def_id = local_def(id);
+    let ty_method = ty::Method::new(ident.name,
+                                    ty_generics,
+                                    ty_generic_predicates,
+                                    fty,
+                                    explicit_self_category,
+                                    vis,
+                                    def_id,
+                                    container,
+                                    None);
 
-                        let trait_item = ty::TypeTraitItem(Rc::new(associated_type));
-                        tcx.impl_or_trait_items
-                            .borrow_mut()
-                            .insert(associated_type.def_id, trait_item);
-                    }
-                }
-            }
+    let fty = ty::mk_bare_fn(ccx.tcx, Some(def_id),
+                             ccx.tcx.mk_bare_fn(ty_method.fty.clone()));
+    debug!("method {} (id {}) has type {}",
+            ident.repr(ccx.tcx), id, fty.repr(ccx.tcx));
+    ccx.tcx.tcache.borrow_mut().insert(def_id,TypeScheme {
+        generics: ty_method.generics.clone(),
+        ty: fty
+    });
+    ccx.tcx.predicates.borrow_mut().insert(def_id, ty_method.predicates.clone());
 
-            // Add an entry mapping
-            let trait_item_def_ids = Rc::new(trait_items.iter().map(|trait_item| {
-                let def_id = local_def(trait_item.id);
-                match trait_item.node {
-                    ast::RequiredMethod(_) |
-                    ast::ProvidedMethod(_) => {
-                        ty::MethodTraitItemId(def_id)
-                    }
-                    ast::TypeTraitItem(..) => {
-                        ty::TypeTraitItemId(def_id)
-                    }
-                }
-            }).collect());
+    write_ty_to_tcx(ccx.tcx, id, fty);
 
-            let trait_def_id = local_def(trait_id);
-            tcx.trait_item_def_ids.borrow_mut().insert(trait_def_id, trait_item_def_ids);
-        }
-    }
+    debug!("writing method type: def_id={:?} mty={}",
+            def_id, ty_method.repr(ccx.tcx));
 
-    fn make_method_ty<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>, m: &ty::Method<'tcx>) {
-        ccx.tcx.tcache.borrow_mut().insert(
-            m.def_id,
-            TypeScheme {
-                generics: m.generics.clone(),
-                ty: ty::mk_bare_fn(ccx.tcx, Some(m.def_id), ccx.tcx.mk_bare_fn(m.fty.clone()))
-            });
-        ccx.tcx.predicates.borrow_mut().insert(
-            m.def_id,
-            m.predicates.clone());
-    }
-
-    fn ty_method_of_trait_method<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                                           trait_id: ast::NodeId,
-                                           trait_generics: &ty::Generics<'tcx>,
-                                           trait_bounds: &ty::GenericPredicates<'tcx>,
-                                           m_id: ast::NodeId,
-                                           m_ident: ast::Ident,
-                                           m_explicit_self: &ast::ExplicitSelf,
-                                           m_abi: abi::Abi,
-                                           m_generics: &ast::Generics,
-                                           m_unsafety: &ast::Unsafety,
-                                           m_decl: &ast::FnDecl)
-                                           -> ty::Method<'tcx>
-    {
-        let ty_generics =
-            ty_generics_for_fn(ccx, m_generics, trait_generics);
-
-        let ty_generic_predicates =
-            ty_generic_predicates_for_fn(ccx, m_generics, trait_bounds);
-
-        let (fty, explicit_self_category) = {
-            let trait_self_ty = ty::mk_self_type(ccx.tcx);
-            astconv::ty_of_method(&ccx.icx(&(trait_bounds, m_generics)),
-                                  *m_unsafety,
-                                  trait_self_ty,
-                                  m_explicit_self,
-                                  m_decl,
-                                  m_abi)
-        };
-
-        ty::Method::new(
-            m_ident.name,
-            ty_generics,
-            ty_generic_predicates,
-            fty,
-            explicit_self_category,
-            // assume public, because this is only invoked on trait methods
-            ast::Public,
-            local_def(m_id),
-            TraitContainer(local_def(trait_id)),
-            None
-        )
-    }
+    ccx.tcx.impl_or_trait_items.borrow_mut().insert(def_id,
+        ty::MethodTraitItem(Rc::new(ty_method)));
 }
 
 fn convert_field<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
@@ -809,20 +709,19 @@ fn convert_field<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 }
 
 fn convert_associated_type<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                                     trait_def: &ty::TraitDef<'tcx>,
+                                     container: ImplOrTraitItemContainer,
                                      ident: ast::Ident,
-                                     id: ast::NodeId)
+                                     id: ast::NodeId,
+                                     vis: ast::Visibility)
 {
     let associated_type = Rc::new(ty::AssociatedType {
         name: ident.name,
-        vis: ast::Public,
+        vis: vis,
         def_id: local_def(id),
-        container: TraitContainer(trait_def.trait_ref.def_id),
+        container: container
     });
-    ccx.tcx
-       .impl_or_trait_items
-       .borrow_mut()
-       .insert(associated_type.def_id, ty::TypeTraitItem(associated_type));
+    ccx.tcx.impl_or_trait_items.borrow_mut()
+       .insert(local_def(id), ty::TypeTraitItem(associated_type));
 }
 
 fn convert_methods<'a,'tcx,'i,I>(ccx: &CrateCtxt<'a, 'tcx>,
@@ -830,9 +729,8 @@ fn convert_methods<'a,'tcx,'i,I>(ccx: &CrateCtxt<'a, 'tcx>,
                                  methods: I,
                                  untransformed_rcvr_ty: Ty<'tcx>,
                                  rcvr_ty_generics: &ty::Generics<'tcx>,
-                                 rcvr_ty_predicates: &ty::GenericPredicates<'tcx>,
-                                 rcvr_visibility: ast::Visibility)
-    where I: Iterator<Item=(&'i ast::Method, ast::NodeId, ast::Ident, ast::Visibility, Span)>
+                                 rcvr_ty_predicates: &ty::GenericPredicates<'tcx>)
+    where I: Iterator<Item=(&'i ast::MethodSig, ast::NodeId, ast::Ident, ast::Visibility, Span)>
 {
     debug!("convert_methods(untransformed_rcvr_ty={}, rcvr_ty_generics={}, rcvr_ty_predicates={})",
            untransformed_rcvr_ty.repr(ccx.tcx),
@@ -841,87 +739,20 @@ fn convert_methods<'a,'tcx,'i,I>(ccx: &CrateCtxt<'a, 'tcx>,
 
     let tcx = ccx.tcx;
     let mut seen_methods = FnvHashSet();
-    for (m, id, ident, vis, span) in methods {
+    for (sig, id, ident, vis, span) in methods {
         if !seen_methods.insert(ident.name) {
-            span_err!(tcx.sess, span, E0201, "duplicate method in trait impl");
+            span_err!(tcx.sess, span, E0201, "duplicate method");
         }
 
-        let m_def_id = local_def(id);
-
-        let mty = Rc::new(ty_of_method(ccx,
-                                       container,
-                                       m,
-                                       id,
-                                       ident,
-                                       vis,
-                                       untransformed_rcvr_ty,
-                                       rcvr_ty_generics,
-                                       rcvr_ty_predicates,
-                                       rcvr_visibility));
-        let fty = ty::mk_bare_fn(tcx, Some(m_def_id), tcx.mk_bare_fn(mty.fty.clone()));
-        debug!("method {} (id {}) has type {}",
-                ident.repr(tcx),
-                id,
-                fty.repr(tcx));
-        tcx.tcache.borrow_mut().insert(
-            m_def_id,
-            TypeScheme {
-                generics: mty.generics.clone(),
-                ty: fty
-            });
-        tcx.predicates.borrow_mut().insert(m_def_id, mty.predicates.clone());
-
-        write_ty_to_tcx(tcx, id, fty);
-
-        debug!("writing method type: def_id={:?} mty={}",
-               mty.def_id, mty.repr(ccx.tcx));
-
-        tcx.impl_or_trait_items
-           .borrow_mut()
-           .insert(mty.def_id, ty::MethodTraitItem(mty));
-    }
-
-    fn ty_of_method<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
-                              container: ImplOrTraitItemContainer,
-                              m: &ast::Method,
-                              id: ast::NodeId,
-                              ident: ast::Ident,
-                              vis: ast::Visibility,
-                              untransformed_rcvr_ty: Ty<'tcx>,
-                              rcvr_ty_generics: &ty::Generics<'tcx>,
-                              rcvr_ty_predicates: &ty::GenericPredicates<'tcx>,
-                              rcvr_visibility: ast::Visibility)
-                              -> ty::Method<'tcx>
-    {
-        let m_ty_generics =
-            ty_generics_for_fn(ccx, m.pe_generics(), rcvr_ty_generics);
-
-        let m_ty_generic_predicates =
-            ty_generic_predicates_for_fn(ccx, m.pe_generics(), rcvr_ty_predicates);
-
-        let (fty, explicit_self_category) =
-            astconv::ty_of_method(&ccx.icx(&(rcvr_ty_predicates, m.pe_generics())),
-                                  m.pe_unsafety(),
-                                  untransformed_rcvr_ty,
-                                  m.pe_explicit_self(),
-                                  &*m.pe_fn_decl(),
-                                  m.pe_abi());
-
-        // if the method specifies a visibility, use that, otherwise
-        // inherit the visibility from the impl (so `foo` in `pub impl
-        // { fn foo(); }` is public, but private in `priv impl { fn
-        // foo(); }`).
-        let method_vis = vis.inherit_from(rcvr_visibility);
-
-        ty::Method::new(ident.name,
-                        m_ty_generics,
-                        m_ty_generic_predicates,
-                        fty,
-                        explicit_self_category,
-                        method_vis,
-                        local_def(id),
-                        container,
-                        None)
+        convert_method(ccx,
+                       container,
+                       sig,
+                       id,
+                       ident,
+                       vis,
+                       untransformed_rcvr_ty,
+                       rcvr_ty_generics,
+                       rcvr_ty_predicates);
     }
 }
 
@@ -1013,6 +844,7 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
                 it.vis
             };
 
+            // Convert all the associated types.
             for impl_item in impl_items {
                 match impl_item.node {
                     ast::MethodImplItem(_) => {}
@@ -1021,6 +853,9 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
                             span_err!(tcx.sess, impl_item.span, E0202,
                                               "associated items are not allowed in inherent impls");
                         }
+
+                        convert_associated_type(ccx, ImplContainer(local_def(it.id)),
+                                                impl_item.ident, impl_item.id, impl_item.vis);
 
                         let typ = ccx.icx(&ty_predicates).to_ty(&ExplicitRscope, ty);
                         tcx.tcache.borrow_mut().insert(local_def(impl_item.id),
@@ -1031,17 +866,6 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
                         tcx.predicates.borrow_mut().insert(local_def(impl_item.id),
                                                            ty::GenericPredicates::empty());
                         write_ty_to_tcx(tcx, impl_item.id, typ);
-
-                        let associated_type = Rc::new(ty::AssociatedType {
-                            name: impl_item.ident.name,
-                            vis: impl_item.vis,
-                            def_id: local_def(impl_item.id),
-                            container: ty::ImplContainer(local_def(it.id)),
-                        });
-                        tcx.impl_or_trait_items
-                           .borrow_mut()
-                           .insert(local_def(impl_item.id),
-                                   ty::TypeTraitItem(associated_type));
                     }
                 }
             }
@@ -1049,7 +873,12 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
             let methods = impl_items.iter().filter_map(|ii| {
                 match ii.node {
                     ast::MethodImplItem(ref m) => {
-                        Some((m, ii.id, ii.ident, ii.vis, ii.span))
+                        // if the method specifies a visibility, use that, otherwise
+                        // inherit the visibility from the impl (so `foo` in `pub impl
+                        // { fn foo(); }` is public, but private in `priv impl { fn
+                        // foo(); }`).
+                        let method_vis = ii.vis.inherit_from(parent_visibility);
+                        Some((m.pe_sig(), ii.id, ii.ident, method_vis, ii.span))
                     }
                     ast::TypeImplItem(_) => None
                 }
@@ -1059,8 +888,7 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
                             methods,
                             selfty,
                             &ty_generics,
-                            &ty_predicates,
-                            parent_visibility);
+                            &ty_predicates);
 
             for impl_item in impl_items {
                 match impl_item.node {
@@ -1070,7 +898,7 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
                                                &BindingRscope::new(),
                                                ccx.method_ty(impl_item.id),
                                                selfty,
-                                               method.pe_explicit_self(),
+                                               &method.pe_sig().explicit_self,
                                                body_id);
                     }
                     ast::TypeImplItem(_) => {}
@@ -1095,63 +923,68 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
             let _: Result<(), ErrorReported> = // any error is already reported, can ignore
                 ccx.ensure_super_predicates(it.span, local_def(it.id));
             convert_trait_predicates(ccx, it);
-            let trait_predicates = ty::lookup_predicates(ccx.tcx, local_def(it.id));
+            let trait_predicates = ty::lookup_predicates(tcx, local_def(it.id));
 
             debug!("convert: trait_bounds={:?}", trait_predicates);
 
-            let methods = trait_items.iter().filter_map(|ti| {
-                match ti.node {
-                    ast::ProvidedMethod(ref m) => {
-                        Some((m, ti.id, ti.ident, ast::Inherited, ti.span))
-                    }
+            // Convert all the associated types.
+            for trait_item in trait_items {
+                match trait_item.node {
                     ast::RequiredMethod(_) |
-                    ast::TypeTraitItem(..) => None,
+                    ast::ProvidedMethod(_) => {}
+                    ast::TypeTraitItem(..) => {
+                        convert_associated_type(ccx, TraitContainer(local_def(it.id)),
+                                                trait_item.ident, trait_item.id, ast::Public);
+                    }
                 }
+            };
+
+            let methods = trait_items.iter().filter_map(|ti| {
+                let sig = match ti.node {
+                    ast::RequiredMethod(ref sig) => sig,
+                    ast::ProvidedMethod(ref m) => m.pe_sig(),
+                    ast::TypeTraitItem(..) => return None,
+                };
+                Some((sig, ti.id, ti.ident, ast::Inherited, ti.span))
             });
-            // Run convert_methods on the provided methods.
-            let untransformed_rcvr_ty = ty::mk_self_type(tcx);
+
+            // Run convert_methods on the trait methods.
             convert_methods(ccx,
                             TraitContainer(local_def(it.id)),
                             methods,
-                            untransformed_rcvr_ty,
+                            ty::mk_self_type(tcx),
                             &trait_def.generics,
-                            &trait_predicates,
-                            it.vis);
+                            &trait_predicates);
 
-            // We need to do this *after* converting methods, since
-            // convert_methods produces a tcache entry that is wrong for
-            // static trait methods. This is somewhat unfortunate.
-            collect_trait_methods(ccx, it.id, &*trait_def, &trait_predicates);
+            // Add an entry mapping
+            let trait_item_def_ids = Rc::new(trait_items.iter().map(|trait_item| {
+                let def_id = local_def(trait_item.id);
+                match trait_item.node {
+                    ast::RequiredMethod(_) |
+                    ast::ProvidedMethod(_) => {
+                        ty::MethodTraitItemId(def_id)
+                    }
+                    ast::TypeTraitItem(..) => {
+                        ty::TypeTraitItemId(def_id)
+                    }
+                }
+            }).collect());
+            tcx.trait_item_def_ids.borrow_mut().insert(local_def(it.id), trait_item_def_ids);
 
             // This must be done after `collect_trait_methods` so that
             // we have a method type stored for every method.
             for trait_item in trait_items {
-                let self_type = ty::mk_self_type(tcx);
-                match trait_item.node {
-                    ast::RequiredMethod(ref type_method) => {
-                        let rscope = BindingRscope::new();
-                        check_method_self_type(ccx,
-                                               &rscope,
-                                               ccx.method_ty(trait_item.id),
-                                               self_type,
-                                               &type_method.explicit_self,
-                                               it.id)
-                    }
-                    ast::ProvidedMethod(ref method) => {
-                        check_method_self_type(ccx,
-                                               &BindingRscope::new(),
-                                               ccx.method_ty(trait_item.id),
-                                               self_type,
-                                               method.pe_explicit_self(),
-                                               it.id)
-                    }
-                    ast::TypeTraitItem(..) => {
-                        convert_associated_type(ccx,
-                                                &*trait_def,
-                                                trait_item.ident,
-                                                trait_item.id);
-                    }
-                }
+                let sig = match trait_item.node {
+                    ast::RequiredMethod(ref sig) => sig,
+                    ast::ProvidedMethod(ref method) => method.pe_sig(),
+                    ast::TypeTraitItem(..) => continue
+                };
+                check_method_self_type(ccx,
+                                       &BindingRscope::new(),
+                                       ccx.method_ty(trait_item.id),
+                                       ty::mk_self_type(tcx),
+                                       &sig.explicit_self,
+                                       it.id)
             }
         },
         ast::ItemStruct(ref struct_def, _) => {

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -147,29 +147,13 @@ pub fn record_extern_fqn(cx: &DocContext, did: ast::DefId, kind: clean::TypeKind
 
 pub fn build_external_trait(cx: &DocContext, tcx: &ty::ctxt,
                             did: ast::DefId) -> clean::Trait {
-    use clean::TraitMethod;
-
     let def = ty::lookup_trait_def(tcx, did);
     let trait_items = ty::trait_items(tcx, did).clean(cx);
-    let provided = ty::provided_trait_methods(tcx, did);
-    let items = trait_items.into_iter().map(|trait_item| {
-        match trait_item.inner {
-            clean::TyMethodItem(_) => {
-                if provided.iter().any(|a| a.def_id == trait_item.def_id) {
-                    TraitMethod::ProvidedMethod(trait_item)
-                } else {
-                    TraitMethod::RequiredMethod(trait_item)
-                }
-            },
-            clean::AssociatedTypeItem(_) => TraitMethod::TypeTraitItem(trait_item),
-            _ => unreachable!()
-        }
-    });
     let predicates = ty::lookup_predicates(tcx, did);
     clean::Trait {
         unsafety: def.unsafety,
         generics: (&def.generics, &predicates, subst::TypeSpace).clean(cx),
-        items: items.collect(),
+        items: trait_items,
         bounds: vec![], // supertraits can be found in the list of predicates
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -951,8 +951,8 @@ pub struct Method {
 
 impl Clean<Method> for ast::Method {
     fn clean(&self, cx: &DocContext) -> Method {
-        let all_inputs = &self.pe_fn_decl().inputs;
-        let inputs = match self.pe_explicit_self().node {
+        let all_inputs = &self.pe_sig().decl.inputs;
+        let inputs = match self.pe_sig().explicit_self.node {
             ast::SelfStatic => &**all_inputs,
             _ => &all_inputs[1..]
         };
@@ -960,15 +960,15 @@ impl Clean<Method> for ast::Method {
             inputs: Arguments {
                 values: inputs.clean(cx),
             },
-            output: self.pe_fn_decl().output.clean(cx),
+            output: self.pe_sig().decl.output.clean(cx),
             attrs: Vec::new()
         };
         Method {
-            generics: self.pe_generics().clean(cx),
-            self_: self.pe_explicit_self().node.clean(cx),
-            unsafety: self.pe_unsafety().clone(),
+            generics: self.pe_sig().generics.clean(cx),
+            self_: self.pe_sig().explicit_self.node.clean(cx),
+            unsafety: self.pe_sig().unsafety.clone(),
             decl: decl,
-            abi: self.pe_abi()
+            abi: self.pe_sig().abi
         }
     }
 }
@@ -982,7 +982,7 @@ pub struct TyMethod {
     pub abi: abi::Abi
 }
 
-impl Clean<TyMethod> for ast::TypeMethod {
+impl Clean<TyMethod> for ast::MethodSig {
     fn clean(&self, cx: &DocContext) -> TyMethod {
         let inputs = match self.explicit_self.node {
             ast::SelfStatic => &*self.decl.inputs,

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -174,7 +174,7 @@ pub struct Constant {
 pub struct Trait {
     pub unsafety: ast::Unsafety,
     pub name: Ident,
-    pub items: Vec<ast::TraitItem>, //should be TraitItem
+    pub items: Vec<P<ast::TraitItem>>, //should be TraitItem
     pub generics: ast::Generics,
     pub bounds: Vec<ast::TyParamBound>,
     pub attrs: Vec<ast::Attribute>,
@@ -190,7 +190,7 @@ pub struct Impl {
     pub generics: ast::Generics,
     pub trait_: Option<ast::TraitRef>,
     pub for_: P<ast::Ty>,
-    pub items: Vec<ast::ImplItem>,
+    pub items: Vec<P<ast::ImplItem>>,
     pub attrs: Vec<ast::Attribute>,
     pub whence: Span,
     pub vis: ast::Visibility,

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -40,37 +40,13 @@ pub trait DocFolder : Sized {
                 EnumItem(i)
             },
             TraitItem(mut i) => {
-                fn vtrm<T: DocFolder>(this: &mut T, trm: TraitMethod)
-                        -> Option<TraitMethod> {
-                    match trm {
-                        RequiredMethod(it) => {
-                            match this.fold_item(it) {
-                                Some(x) => return Some(RequiredMethod(x)),
-                                None => return None,
-                            }
-                        },
-                        ProvidedMethod(it) => {
-                            match this.fold_item(it) {
-                                Some(x) => return Some(ProvidedMethod(x)),
-                                None => return None,
-                            }
-                        },
-                        TypeTraitItem(it) => {
-                            match this.fold_item(it) {
-                                Some(x) => return Some(TypeTraitItem(x)),
-                                None => return None,
-                            }
-                        }
-                    }
-                }
                 let mut foo = Vec::new(); swap(&mut foo, &mut i.items);
-                i.items.extend(foo.into_iter().filter_map(|x| vtrm(self, x)));
+                i.items.extend(foo.into_iter().filter_map(|x| self.fold_item(x)));
                 TraitItem(i)
             },
             ImplItem(mut i) => {
                 let mut foo = Vec::new(); swap(&mut foo, &mut i.items);
-                i.items.extend(foo.into_iter()
-                                  .filter_map(|x| self.fold_item(x)));
+                i.items.extend(foo.into_iter().filter_map(|x| self.fold_item(x)));
                 ImplItem(i)
             },
             VariantItem(i) => {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1081,14 +1081,14 @@ pub struct TypeMethod {
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub enum TraitItem {
     RequiredMethod(TypeMethod),
-    ProvidedMethod(P<Method>),
-    TypeTraitItem(P<AssociatedType>),
+    ProvidedMethod(Method),
+    TypeTraitItem(AssociatedType),
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub enum ImplItem {
-    MethodImplItem(P<Method>),
-    TypeImplItem(P<Typedef>),
+    MethodImplItem(Method),
+    TypeImplItem(Typedef),
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
@@ -1659,7 +1659,7 @@ pub enum Item_ {
     ItemTrait(Unsafety,
               Generics,
               TyParamBounds,
-              Vec<TraitItem>),
+              Vec<P<TraitItem>>),
 
     // Default trait implementations
     // `impl Trait for ..`
@@ -1669,7 +1669,7 @@ pub enum Item_ {
              Generics,
              Option<TraitRef>, // (optional) trait this impl implements
              P<Ty>, // self
-             Vec<ImplItem>),
+             Vec<P<ImplItem>>),
     /// A macro invocation (which includes macro definition)
     ItemMac(Mac),
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -22,7 +22,7 @@ pub use self::Expr_::*;
 pub use self::FloatTy::*;
 pub use self::FunctionRetTy::*;
 pub use self::ForeignItem_::*;
-pub use self::ImplItem::*;
+pub use self::ImplItem_::*;
 pub use self::InlinedItem::*;
 pub use self::IntTy::*;
 pub use self::Item_::*;
@@ -33,7 +33,7 @@ pub use self::LocalSource::*;
 pub use self::Mac_::*;
 pub use self::MacStmtStyle::*;
 pub use self::MetaItem_::*;
-pub use self::Method_::*;
+pub use self::Method::*;
 pub use self::Mutability::*;
 pub use self::Pat_::*;
 pub use self::PathListItem_::*;
@@ -44,7 +44,7 @@ pub use self::Stmt_::*;
 pub use self::StrStyle::*;
 pub use self::StructFieldKind::*;
 pub use self::TokenTree::*;
-pub use self::TraitItem::*;
+pub use self::TraitItem_::*;
 pub use self::Ty_::*;
 pub use self::TyParamBound::*;
 pub use self::UintTy::*;
@@ -1062,16 +1062,11 @@ pub struct TypeField {
 /// one without a default implementation
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct TypeMethod {
-    pub ident: Ident,
-    pub attrs: Vec<Attribute>,
     pub unsafety: Unsafety,
     pub abi: Abi,
     pub decl: P<FnDecl>,
     pub generics: Generics,
     pub explicit_self: ExplicitSelf,
-    pub id: NodeId,
-    pub span: Span,
-    pub vis: Visibility,
 }
 
 /// Represents a method declaration in a trait declaration, possibly including
@@ -1079,32 +1074,35 @@ pub struct TypeMethod {
 /// doesn't have an implementation, just a signature) or provided (meaning it
 /// has a default implementation).
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub enum TraitItem {
+pub struct TraitItem {
+    pub id: NodeId,
+    pub ident: Ident,
+    pub attrs: Vec<Attribute>,
+    pub node: TraitItem_,
+    pub span: Span,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum TraitItem_ {
     RequiredMethod(TypeMethod),
     ProvidedMethod(Method),
-    TypeTraitItem(AssociatedType),
+    TypeTraitItem(TyParamBounds, Option<P<Ty>>),
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub enum ImplItem {
-    MethodImplItem(Method),
-    TypeImplItem(Typedef),
-}
-
-#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub struct AssociatedType {
-    pub attrs: Vec<Attribute>,
-    pub ty_param: TyParam,
-}
-
-#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub struct Typedef {
+pub struct ImplItem {
     pub id: NodeId,
-    pub span: Span,
     pub ident: Ident,
     pub vis: Visibility,
     pub attrs: Vec<Attribute>,
-    pub typ: P<Ty>,
+    pub node: ImplItem_,
+    pub span: Span,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum ImplItem_ {
+    MethodImplItem(Method),
+    TypeImplItem(P<Ty>),
 }
 
 #[derive(Clone, Eq, RustcEncodable, RustcDecodable, Hash, Copy)]
@@ -1419,24 +1417,14 @@ pub enum ExplicitSelf_ {
 pub type ExplicitSelf = Spanned<ExplicitSelf_>;
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub struct Method {
-    pub attrs: Vec<Attribute>,
-    pub id: NodeId,
-    pub span: Span,
-    pub node: Method_,
-}
-
-#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub enum Method_ {
+pub enum Method {
     /// Represents a method declaration
-    MethDecl(Ident,
-             Generics,
+    MethDecl(Generics,
              Abi,
              ExplicitSelf,
              Unsafety,
              P<FnDecl>,
-             P<Block>,
-             Visibility),
+             P<Block>),
     /// Represents a macro in method position
     MethMac(Mac),
 }
@@ -1726,8 +1714,8 @@ impl ForeignItem_ {
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub enum InlinedItem {
     IIItem(P<Item>),
-    IITraitItem(DefId /* impl id */, TraitItem),
-    IIImplItem(DefId /* impl id */, ImplItem),
+    IITraitItem(DefId /* impl id */, P<TraitItem>),
+    IIImplItem(DefId /* impl id */, P<ImplItem>),
     IIForeign(P<ForeignItem>),
 }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1058,10 +1058,10 @@ pub struct TypeField {
     pub span: Span,
 }
 
-/// Represents a required method in a trait declaration,
-/// one without a default implementation
+/// Represents a method's signature in a trait declaration,
+/// or in an implementation.
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub struct TypeMethod {
+pub struct MethodSig {
     pub unsafety: Unsafety,
     pub abi: Abi,
     pub decl: P<FnDecl>,
@@ -1084,7 +1084,7 @@ pub struct TraitItem {
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub enum TraitItem_ {
-    RequiredMethod(TypeMethod),
+    RequiredMethod(MethodSig),
     ProvidedMethod(Method),
     TypeTraitItem(TyParamBounds, Option<P<Ty>>),
 }
@@ -1419,12 +1419,7 @@ pub type ExplicitSelf = Spanned<ExplicitSelf_>;
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub enum Method {
     /// Represents a method declaration
-    MethDecl(Generics,
-             Abi,
-             ExplicitSelf,
-             Unsafety,
-             P<FnDecl>,
-             P<Block>),
+    MethDecl(MethodSig, P<Block>),
     /// Represents a macro in method position
     MethMac(Mac),
 }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -33,7 +33,6 @@ pub use self::LocalSource::*;
 pub use self::Mac_::*;
 pub use self::MacStmtStyle::*;
 pub use self::MetaItem_::*;
-pub use self::Method::*;
 pub use self::Mutability::*;
 pub use self::Pat_::*;
 pub use self::PathListItem_::*;
@@ -1084,8 +1083,7 @@ pub struct TraitItem {
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub enum TraitItem_ {
-    RequiredMethod(MethodSig),
-    ProvidedMethod(Method),
+    MethodTraitItem(MethodSig, Option<P<Block>>),
     TypeTraitItem(TyParamBounds, Option<P<Ty>>),
 }
 
@@ -1101,8 +1099,9 @@ pub struct ImplItem {
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub enum ImplItem_ {
-    MethodImplItem(Method),
+    MethodImplItem(MethodSig, P<Block>),
     TypeImplItem(P<Ty>),
+    MacImplItem(Mac),
 }
 
 #[derive(Clone, Eq, RustcEncodable, RustcDecodable, Hash, Copy)]
@@ -1415,14 +1414,6 @@ pub enum ExplicitSelf_ {
 }
 
 pub type ExplicitSelf = Spanned<ExplicitSelf_>;
-
-#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub enum Method {
-    /// Represents a method declaration
-    MethDecl(MethodSig, P<Block>),
-    /// Represents a macro in method position
-    MethMac(Mac),
-}
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
 pub struct Mod {

--- a/src/libsyntax/ast_map/blocks.rs
+++ b/src/libsyntax/ast_map/blocks.rs
@@ -162,7 +162,7 @@ impl<'a> FnLikeNode<'a> {
 
     pub fn decl(self) -> &'a FnDecl {
         self.handle(|i: ItemFnParts<'a>|  &*i.decl,
-                    |_, _, m: &'a ast::Method, _|  m.pe_fn_decl(),
+                    |_, _, m: &'a ast::Method, _|  &m.pe_sig().decl,
                     |c: ClosureParts<'a>| c.decl)
     }
 

--- a/src/libsyntax/ast_map/blocks.rs
+++ b/src/libsyntax/ast_map/blocks.rs
@@ -206,12 +206,12 @@ impl<'a> FnLikeNode<'a> {
                 _ => panic!("item FnLikeNode that is not fn-like"),
             },
             ast_map::NodeTraitItem(t) => match *t {
-                ast::ProvidedMethod(ref m) => method(&**m),
+                ast::ProvidedMethod(ref m) => method(m),
                 _ => panic!("trait method FnLikeNode that is not fn-like"),
             },
             ast_map::NodeImplItem(ii) => {
                 match *ii {
-                    ast::MethodImplItem(ref m) => method(&**m),
+                    ast::MethodImplItem(ref m) => method(m),
                     ast::TypeImplItem(_) => {
                         panic!("impl method FnLikeNode that is not fn-like")
                     }

--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -929,16 +929,10 @@ fn node_id_to_string(map: &Map, id: NodeId, include_id: bool) -> String {
         }
         Some(NodeImplItem(ii)) => {
             match ii.node {
-                MethodImplItem(ref m) => {
-                    match *m {
-                        MethDecl(..) =>
-                            format!("method {} in {}{}",
-                                    token::get_ident(ii.ident),
-                                    map.path_to_string(id), id_str),
-                        MethMac(ref mac) =>
-                            format!("method macro {}{}",
-                                    pprust::mac_to_string(mac), id_str)
-                    }
+                MethodImplItem(..) => {
+                    format!("method {} in {}{}",
+                            token::get_ident(ii.ident),
+                            map.path_to_string(id), id_str)
                 }
                 TypeImplItem(_) => {
                     format!("assoc type {} in {}{}",
@@ -946,13 +940,17 @@ fn node_id_to_string(map: &Map, id: NodeId, include_id: bool) -> String {
                             map.path_to_string(id),
                             id_str)
                 }
+                MacImplItem(ref mac) => {
+                    format!("method macro {}{}",
+                            pprust::mac_to_string(mac), id_str)
+                }
             }
         }
         Some(NodeTraitItem(ti)) => {
             let kind = match ti.node {
-                RequiredMethod(_) => "required method",
-                ProvidedMethod(_) => "provided method",
+                MethodTraitItem(..) => "trait method",
                 TypeTraitItem(..) => "assoc type",
+//                 ConstTraitItem(..) => "assoc constant"
             };
 
             format!("{} {} in {}{}",

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -268,62 +268,6 @@ pub fn impl_pretty_name(trait_ref: &Option<TraitRef>, ty: Option<&Ty>) -> Ident 
     token::gensym_ident(&pretty[..])
 }
 
-pub fn trait_method_to_ty_method(method: &Method) -> TypeMethod {
-    match method.node {
-        MethDecl(ident,
-                 ref generics,
-                 abi,
-                 ref explicit_self,
-                 unsafety,
-                 ref decl,
-                 _,
-                 vis) => {
-            TypeMethod {
-                ident: ident,
-                attrs: method.attrs.clone(),
-                unsafety: unsafety,
-                decl: (*decl).clone(),
-                generics: generics.clone(),
-                explicit_self: (*explicit_self).clone(),
-                id: method.id,
-                span: method.span,
-                vis: vis,
-                abi: abi,
-            }
-        },
-        MethMac(_) => panic!("expected non-macro method declaration")
-    }
-}
-
-/// extract a TypeMethod from a TraitItem. if the TraitItem is
-/// a default, pull out the useful fields to make a TypeMethod
-//
-// NB: to be used only after expansion is complete, and macros are gone.
-pub fn trait_item_to_ty_method(method: &TraitItem) -> TypeMethod {
-    match *method {
-        RequiredMethod(ref m) => (*m).clone(),
-        ProvidedMethod(ref m) => trait_method_to_ty_method(&**m),
-        TypeTraitItem(_) => {
-            panic!("trait_method_to_ty_method(): expected method but found \
-                   typedef")
-        }
-    }
-}
-
-pub fn split_trait_methods(trait_methods: &[TraitItem])
-                           -> (Vec<TypeMethod>, Vec<P<Method>> ) {
-    let mut reqd = Vec::new();
-    let mut provd = Vec::new();
-    for trt_method in trait_methods {
-        match *trt_method {
-            RequiredMethod(ref tm) => reqd.push((*tm).clone()),
-            ProvidedMethod(ref m) => provd.push((*m).clone()),
-            TypeTraitItem(_) => {}
-        }
-    };
-    (reqd, provd)
-}
-
 pub fn struct_field_visibility(field: ast::StructField) -> Visibility {
     match field.node.kind {
         ast::NamedField(_, v) | ast::UnnamedField(v) => v

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use abi::Abi;
 use ast::*;
 use ast;
 use ast_util;
@@ -461,7 +460,7 @@ impl<'a, 'v, O: IdVisitingOperation> Visitor<'v> for IdVisitor<'a, O> {
                 self.visit_generics_helper(generics)
             }
             visit::FkMethod(_, m) => {
-                self.visit_generics_helper(m.pe_generics())
+                self.visit_generics_helper(&m.pe_sig().generics)
             }
             visit::FkFnBlock => {}
         }
@@ -653,11 +652,7 @@ pub fn lit_is_str(lit: &Lit) -> bool {
 /// not a macro invocation. This check is guaranteed to succeed, assuming
 /// that the invocations are indeed gone.
 pub trait PostExpansionMethod {
-    fn pe_generics<'a>(&'a self) -> &'a ast::Generics;
-    fn pe_abi(&self) -> Abi;
-    fn pe_explicit_self<'a>(&'a self) -> &'a ast::ExplicitSelf;
-    fn pe_unsafety(&self) -> ast::Unsafety;
-    fn pe_fn_decl<'a>(&'a self) -> &'a ast::FnDecl;
+    fn pe_sig<'a>(&'a self) -> &'a ast::MethodSig;
     fn pe_body<'a>(&'a self) -> &'a ast::Block;
 }
 
@@ -676,18 +671,8 @@ macro_rules! mf_method{
 
 
 impl PostExpansionMethod for Method {
-    mf_method! {
-        pe_generics,&'a ast::Generics,
-        MethDecl(ref generics,_,_,_,_,_),generics
-    }
-    mf_method! { pe_abi,Abi,MethDecl(_,abi,_,_,_,_),abi }
-    mf_method! {
-        pe_explicit_self,&'a ast::ExplicitSelf,
-        MethDecl(_,_,ref explicit_self,_,_,_),explicit_self
-    }
-    mf_method! { pe_unsafety,ast::Unsafety,MethDecl(_,_,_,unsafety,_,_),unsafety }
-    mf_method! { pe_fn_decl,&'a ast::FnDecl,MethDecl(_,_,_,_,ref decl,_),&**decl }
-    mf_method! { pe_body,&'a ast::Block,MethDecl(_,_,_,_,_,ref body),&**body }
+    mf_method! { pe_sig, &'a ast::MethodSig,MethDecl(ref sig, _), sig }
+    mf_method! { pe_body, &'a ast::Block,MethDecl(_, ref body), body }
 }
 
 #[cfg(test)]

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -118,13 +118,13 @@ fn fold_item_underscore<F>(cx: &mut Context<F>, item: ast::Item_) -> ast::Item_ 
     let item = match item {
         ast::ItemImpl(u, o, a, b, c, impl_items) => {
             let impl_items = impl_items.into_iter()
-                                       .filter(|ii| impl_item_in_cfg(cx, ii))
+                                       .filter(|ii| (cx.in_cfg)(&ii.attrs))
                                        .collect();
             ast::ItemImpl(u, o, a, b, c, impl_items)
         }
         ast::ItemTrait(u, a, b, methods) => {
             let methods = methods.into_iter()
-                                 .filter(|m| trait_method_in_cfg(cx, m))
+                                 .filter(|ti| (cx.in_cfg)(&ti.attrs))
                                  .collect();
             ast::ItemTrait(u, a, b, methods)
         }
@@ -244,25 +244,6 @@ fn foreign_item_in_cfg<F>(cx: &mut Context<F>, item: &ast::ForeignItem) -> bool 
     F: FnMut(&[ast::Attribute]) -> bool
 {
     return (cx.in_cfg)(&item.attrs);
-}
-
-fn trait_method_in_cfg<F>(cx: &mut Context<F>, meth: &ast::TraitItem) -> bool where
-    F: FnMut(&[ast::Attribute]) -> bool
-{
-    match *meth {
-        ast::RequiredMethod(ref meth) => (cx.in_cfg)(&meth.attrs),
-        ast::ProvidedMethod(ref meth) => (cx.in_cfg)(&meth.attrs),
-        ast::TypeTraitItem(ref typ) => (cx.in_cfg)(&typ.attrs),
-    }
-}
-
-fn impl_item_in_cfg<F>(cx: &mut Context<F>, impl_item: &ast::ImplItem) -> bool where
-    F: FnMut(&[ast::Attribute]) -> bool
-{
-    match *impl_item {
-        ast::MethodImplItem(ref meth) => (cx.in_cfg)(&meth.attrs),
-        ast::TypeImplItem(ref typ) => (cx.in_cfg)(&typ.attrs),
-    }
 }
 
 // Determine if an item should be translated in the current crate

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -228,8 +228,8 @@ pub trait MacResult {
         None
     }
 
-    /// Create zero or more methods.
-    fn make_methods(self: Box<Self>) -> Option<SmallVector<P<ast::ImplItem>>> {
+    /// Create zero or more impl items.
+    fn make_impl_items(self: Box<Self>) -> Option<SmallVector<P<ast::ImplItem>>> {
         None
     }
 
@@ -275,7 +275,7 @@ make_MacEager! {
     expr: P<ast::Expr>,
     pat: P<ast::Pat>,
     items: SmallVector<P<ast::Item>>,
-    methods: SmallVector<P<ast::ImplItem>>,
+    impl_items: SmallVector<P<ast::ImplItem>>,
     stmt: P<ast::Stmt>,
 }
 
@@ -288,8 +288,8 @@ impl MacResult for MacEager {
         self.items
     }
 
-    fn make_methods(self: Box<Self>) -> Option<SmallVector<P<ast::ImplItem>>> {
-        self.methods
+    fn make_impl_items(self: Box<Self>) -> Option<SmallVector<P<ast::ImplItem>>> {
+        self.impl_items
     }
 
     fn make_stmt(self: Box<Self>) -> Option<P<ast::Stmt>> {
@@ -377,7 +377,7 @@ impl MacResult for DummyResult {
             Some(SmallVector::zero())
         }
     }
-    fn make_methods(self: Box<DummyResult>) -> Option<SmallVector<P<ast::ImplItem>>> {
+    fn make_impl_items(self: Box<DummyResult>) -> Option<SmallVector<P<ast::ImplItem>>> {
         if self.expr_only {
             None
         } else {

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -724,13 +724,13 @@ impl<'a> MethodDef<'a> {
             span: trait_.span,
             vis: ast::Inherited,
             ident: method_ident,
-            node: ast::MethodImplItem(
-                ast::MethDecl(fn_generics,
-                              abi,
-                              explicit_self,
-                              ast::Unsafety::Normal,
-                              fn_decl,
-                              body_block))
+            node: ast::MethodImplItem(ast::MethDecl(ast::MethodSig {
+                generics: fn_generics,
+                abi: abi,
+                explicit_self: explicit_self,
+                unsafety: ast::Unsafety::Normal,
+                decl: fn_decl
+            }, body_block))
         })
     }
 

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -724,13 +724,13 @@ impl<'a> MethodDef<'a> {
             span: trait_.span,
             vis: ast::Inherited,
             ident: method_ident,
-            node: ast::MethodImplItem(ast::MethDecl(ast::MethodSig {
+            node: ast::MethodImplItem(ast::MethodSig {
                 generics: fn_generics,
                 abi: abi,
                 explicit_self: explicit_self,
                 unsafety: ast::Unsafety::Normal,
                 decl: fn_decl
-            }, body_block))
+            }, body_block)
         })
     }
 

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -386,23 +386,23 @@ impl<'a> TraitDef<'a> {
                            cx: &mut ExtCtxt,
                            type_ident: Ident,
                            generics: &Generics,
-                           methods: Vec<ast::Method>) -> P<ast::Item> {
+                           methods: Vec<P<ast::ImplItem>>) -> P<ast::Item> {
         let trait_path = self.path.to_path(cx, self.span, type_ident, generics);
 
-        // Transform associated types from `deriving::ty::Ty` into `ast::Typedef`
+        // Transform associated types from `deriving::ty::Ty` into `ast::ImplItem`
         let associated_types = self.associated_types.iter().map(|&(ident, ref type_def)| {
-            ast::Typedef {
+            P(ast::ImplItem {
                 id: ast::DUMMY_NODE_ID,
                 span: self.span,
                 ident: ident,
                 vis: ast::Inherited,
                 attrs: Vec::new(),
-                typ: type_def.to_ty(cx,
+                node: ast::TypeImplItem(type_def.to_ty(cx,
                     self.span,
                     type_ident,
                     generics
-                ),
-            }
+                )),
+            })
         });
 
         let Generics { mut lifetimes, ty_params, mut where_clause } =
@@ -510,14 +510,7 @@ impl<'a> TraitDef<'a> {
                           trait_generics,
                           opt_trait_ref,
                           self_type,
-                          methods.into_iter()
-                                 .map(|method| {
-                                     ast::MethodImplItem(method)
-                                 }).chain(
-                                     associated_types.map(|type_| {
-                                         ast::TypeImplItem(type_)
-                                     })
-                                 ).map(P).collect()))
+                          methods.into_iter().chain(associated_types).collect()))
     }
 
     fn expand_struct_def(&self,
@@ -702,7 +695,7 @@ impl<'a> MethodDef<'a> {
                      abi: Abi,
                      explicit_self: ast::ExplicitSelf,
                      arg_types: Vec<(Ident, P<ast::Ty>)> ,
-                     body: P<Expr>) -> ast::Method {
+                     body: P<Expr>) -> P<ast::ImplItem> {
         // create the generics that aren't for Self
         let fn_generics = self.generics.to_generics(cx, trait_.span, type_ident, generics);
 
@@ -725,19 +718,20 @@ impl<'a> MethodDef<'a> {
         let body_block = cx.block_expr(body);
 
         // Create the method.
-        ast::Method {
-            attrs: self.attributes.clone(),
+        P(ast::ImplItem {
             id: ast::DUMMY_NODE_ID,
+            attrs: self.attributes.clone(),
             span: trait_.span,
-            node: ast::MethDecl(method_ident,
-                                fn_generics,
-                                abi,
-                                explicit_self,
-                                ast::Unsafety::Normal,
-                                fn_decl,
-                                body_block,
-                                ast::Inherited)
-        }
+            vis: ast::Inherited,
+            ident: method_ident,
+            node: ast::MethodImplItem(
+                ast::MethDecl(fn_generics,
+                              abi,
+                              explicit_self,
+                              ast::Unsafety::Normal,
+                              fn_decl,
+                              body_block))
+        })
     }
 
     /// ```

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -386,12 +386,12 @@ impl<'a> TraitDef<'a> {
                            cx: &mut ExtCtxt,
                            type_ident: Ident,
                            generics: &Generics,
-                           methods: Vec<P<ast::Method>>) -> P<ast::Item> {
+                           methods: Vec<ast::Method>) -> P<ast::Item> {
         let trait_path = self.path.to_path(cx, self.span, type_ident, generics);
 
         // Transform associated types from `deriving::ty::Ty` into `ast::Typedef`
         let associated_types = self.associated_types.iter().map(|&(ident, ref type_def)| {
-            P(ast::Typedef {
+            ast::Typedef {
                 id: ast::DUMMY_NODE_ID,
                 span: self.span,
                 ident: ident,
@@ -402,7 +402,7 @@ impl<'a> TraitDef<'a> {
                     type_ident,
                     generics
                 ),
-            })
+            }
         });
 
         let Generics { mut lifetimes, ty_params, mut where_clause } =
@@ -517,7 +517,7 @@ impl<'a> TraitDef<'a> {
                                      associated_types.map(|type_| {
                                          ast::TypeImplItem(type_)
                                      })
-                                 ).collect()))
+                                 ).map(P).collect()))
     }
 
     fn expand_struct_def(&self,
@@ -702,7 +702,7 @@ impl<'a> MethodDef<'a> {
                      abi: Abi,
                      explicit_self: ast::ExplicitSelf,
                      arg_types: Vec<(Ident, P<ast::Ty>)> ,
-                     body: P<Expr>) -> P<ast::Method> {
+                     body: P<Expr>) -> ast::Method {
         // create the generics that aren't for Self
         let fn_generics = self.generics.to_generics(cx, trait_.span, type_ident, generics);
 
@@ -725,7 +725,7 @@ impl<'a> MethodDef<'a> {
         let body_block = cx.block_expr(body);
 
         // Create the method.
-        P(ast::Method {
+        ast::Method {
             attrs: self.attributes.clone(),
             id: ast::DUMMY_NODE_ID,
             span: trait_.span,
@@ -737,7 +737,7 @@ impl<'a> MethodDef<'a> {
                                 fn_decl,
                                 body_block,
                                 ast::Inherited)
-        })
+        }
     }
 
     /// ```

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1185,7 +1185,7 @@ fn expand_annotatable(a: Annotatable,
             }
             ast::TraitItem::TypeTraitItem(t) => {
                 SmallVector::one(Annotatable::TraitItem(
-                    ast::TraitItem::TypeTraitItem(P(fld.fold_associated_type((*t).clone())))))
+                    ast::TraitItem::TypeTraitItem(fld.fold_associated_type(t))))
             }
         },
         Annotatable::ImplItem(it) => match it {
@@ -1195,7 +1195,7 @@ fn expand_annotatable(a: Annotatable,
             }
             ast::ImplItem::TypeImplItem(t) => {
                 SmallVector::one(Annotatable::ImplItem(
-                    ast::ImplItem::TypeImplItem(P(fld.fold_typedef((*t).clone())))))
+                    ast::ImplItem::TypeImplItem(fld.fold_typedef(t))))
             }
         }
     };
@@ -1293,8 +1293,8 @@ fn expand_item_multi_modifier(mut it: Annotatable,
 }
 
 // expand a method
-fn expand_method(m: P<ast::Method>, fld: &mut MacroExpander) -> SmallVector<P<ast::Method>> {
-    m.and_then(|m| match m.node {
+fn expand_method(m: ast::Method, fld: &mut MacroExpander) -> SmallVector<ast::Method> {
+    match m.node {
         ast::MethDecl(ident,
                       generics,
                       abi,
@@ -1306,7 +1306,7 @@ fn expand_method(m: P<ast::Method>, fld: &mut MacroExpander) -> SmallVector<P<as
             let id = fld.new_id(m.id);
             let (rewritten_fn_decl, rewritten_body)
                 = expand_and_rename_fn_decl_and_block(decl, body, fld);
-            SmallVector::one(P(ast::Method {
+            SmallVector::one(ast::Method {
                     attrs: fold::fold_attrs(m.attrs, fld),
                     id: id,
                     span: fld.new_span(m.span),
@@ -1318,7 +1318,7 @@ fn expand_method(m: P<ast::Method>, fld: &mut MacroExpander) -> SmallVector<P<as
                                         rewritten_fn_decl,
                                         rewritten_body,
                                         vis)
-                }))
+                })
         },
         ast::MethMac(mac) => {
             let maybe_new_methods =
@@ -1339,7 +1339,7 @@ fn expand_method(m: P<ast::Method>, fld: &mut MacroExpander) -> SmallVector<P<as
                 None => SmallVector::zero()
             }
         }
-    })
+    }
 }
 
 /// Given a fn_decl and a block and a MacroExpander, expand the fn_decl, then use the
@@ -1418,7 +1418,7 @@ impl<'a, 'b> Folder for MacroExpander<'a, 'b> {
         expand_impl_item(i, self)
     }
 
-    fn fold_method(&mut self, method: P<ast::Method>) -> SmallVector<P<ast::Method>> {
+    fn fold_method(&mut self, method: ast::Method) -> SmallVector<ast::Method> {
         expand_method(method, self)
     }
 
@@ -1565,7 +1565,7 @@ fn mark_item(expr: P<ast::Item>, m: Mrk) -> P<ast::Item> {
 }
 
 // apply a given mark to the given item. Used following the expansion of a macro.
-fn mark_method(expr: P<ast::Method>, m: Mrk) -> P<ast::Method> {
+fn mark_method(expr: ast::Method, m: Mrk) -> ast::Method {
     Marker{mark:m}.fold_method(expr)
         .expect_one("marking an item didn't return exactly one method")
 }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1393,15 +1393,16 @@ impl<'a, 'b> Folder for MacroExpander<'a, 'b> {
 
     fn fold_method(&mut self, m: ast::Method) -> ast::Method {
         match m {
-            ast::MethDecl(generics, abi, explicit_self, fn_style, decl, body) => {
+            ast::MethDecl(sig, body) => {
                 let (rewritten_fn_decl, rewritten_body)
-                    = expand_and_rename_fn_decl_and_block(decl, body, self);
-                ast::MethDecl(self.fold_generics(generics),
-                              abi,
-                              self.fold_explicit_self(explicit_self),
-                              fn_style,
-                              rewritten_fn_decl,
-                              rewritten_body)
+                    = expand_and_rename_fn_decl_and_block(sig.decl, body, self);
+                ast::MethDecl(ast::MethodSig {
+                    generics: self.fold_generics(sig.generics),
+                    abi: sig.abi,
+                    explicit_self: self.fold_explicit_self(sig.explicit_self),
+                    unsafety: sig.unsafety,
+                    decl: rewritten_fn_decl
+                }, rewritten_body)
             }
             ast::MethMac(mac) => ast::MethMac(mac)
         }

--- a/src/libsyntax/ext/quote.rs
+++ b/src/libsyntax/ext/quote.rs
@@ -176,7 +176,6 @@ pub mod rt {
     impl_to_source! { ast::Arg, arg_to_string }
     impl_to_source! { Generics, generics_to_string }
     impl_to_source! { P<ast::Item>, item_to_string }
-    impl_to_source! { P<ast::Method>, method_to_string }
     impl_to_source! { P<ast::Stmt>, stmt_to_string }
     impl_to_source! { P<ast::Expr>, expr_to_string }
     impl_to_source! { P<ast::Pat>, pat_to_string }
@@ -311,7 +310,6 @@ pub mod rt {
     impl_to_tokens! { P<ast::Item> }
     impl_to_tokens! { P<ast::Pat> }
     impl_to_tokens! { ast::Arm }
-    impl_to_tokens! { P<ast::Method> }
     impl_to_tokens_lifetime! { &'a [P<ast::Item>] }
     impl_to_tokens! { ast::Ty }
     impl_to_tokens_lifetime! { &'a [ast::Ty] }
@@ -443,15 +441,6 @@ pub fn expand_quote_ty(cx: &mut ExtCtxt,
                        tts: &[ast::TokenTree])
                        -> Box<base::MacResult+'static> {
     let expanded = expand_parse_call(cx, sp, "parse_ty", vec!(), tts);
-    base::MacEager::expr(expanded)
-}
-
-pub fn expand_quote_method(cx: &mut ExtCtxt,
-                           sp: Span,
-                           tts: &[ast::TokenTree])
-                           -> Box<base::MacResult+'static> {
-    let expanded = expand_parse_call(cx, sp, "parse_method_with_outer_attributes",
-                                     vec!(), tts);
     base::MacEager::expr(expanded)
 }
 

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -82,7 +82,7 @@ impl<'a> MacResult for ParserAnyMacro<'a> {
         Some(ret)
     }
 
-    fn make_methods(self: Box<ParserAnyMacro<'a>>) -> Option<SmallVector<P<ast::Method>>> {
+    fn make_methods(self: Box<ParserAnyMacro<'a>>) -> Option<SmallVector<ast::Method>> {
         let mut ret = SmallVector::zero();
         loop {
             let mut parser = self.parser.borrow_mut();

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -71,7 +71,7 @@ impl<'a> MacResult for ParserAnyMacro<'a> {
         loop {
             let mut parser = self.parser.borrow_mut();
             // so... do outer attributes attached to the macro invocation
-            // just disappear? This question applies to make_methods, as
+            // just disappear? This question applies to make_impl_items, as
             // well.
             match parser.parse_item_with_outer_attributes() {
                 Some(item) => ret.push(item),
@@ -82,16 +82,14 @@ impl<'a> MacResult for ParserAnyMacro<'a> {
         Some(ret)
     }
 
-    fn make_methods(self: Box<ParserAnyMacro<'a>>)
-                    -> Option<SmallVector<P<ast::ImplItem>>> {
+    fn make_impl_items(self: Box<ParserAnyMacro<'a>>)
+                       -> Option<SmallVector<P<ast::ImplItem>>> {
         let mut ret = SmallVector::zero();
         loop {
             let mut parser = self.parser.borrow_mut();
             match parser.token {
                 token::Eof => break,
-                _ => {
-                    ret.push(parser.parse_method_with_outer_attributes());
-                }
+                _ => ret.push(parser.parse_impl_item_with_outer_attributes())
             }
         }
         self.ensure_complete_parse(false);

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -82,7 +82,8 @@ impl<'a> MacResult for ParserAnyMacro<'a> {
         Some(ret)
     }
 
-    fn make_methods(self: Box<ParserAnyMacro<'a>>) -> Option<SmallVector<ast::Method>> {
+    fn make_methods(self: Box<ParserAnyMacro<'a>>)
+                    -> Option<SmallVector<P<ast::ImplItem>>> {
         let mut ret = SmallVector::zero();
         loop {
             let mut parser = self.parser.borrow_mut();

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -977,15 +977,7 @@ pub fn noop_fold_trait_item<T: Folder>(i: P<TraitItem>, folder: &mut T)
         ident: folder.fold_ident(ident),
         attrs: fold_attrs(attrs, folder),
         node: match node {
-            RequiredMethod(TypeMethod { unsafety, abi, decl, generics, explicit_self }) => {
-                RequiredMethod(TypeMethod {
-                    unsafety: unsafety,
-                    abi: abi,
-                    decl: folder.fold_fn_decl(decl),
-                    generics: folder.fold_generics(generics),
-                    explicit_self: folder.fold_explicit_self(explicit_self)
-                })
-            }
+            RequiredMethod(sig) => RequiredMethod(noop_fold_method_sig(sig, folder)),
             ProvidedMethod(m) => ProvidedMethod(folder.fold_method(m)),
             TypeTraitItem(bounds, default) => {
                 TypeTraitItem(folder.fold_bounds(bounds),
@@ -1110,20 +1102,21 @@ pub fn noop_fold_foreign_item<T: Folder>(ni: P<ForeignItem>, folder: &mut T) -> 
 // Default fold over a method.
 pub fn noop_fold_method<T: Folder>(method: Method, folder: &mut T) -> Method {
     match method {
-        MethDecl(generics,
-                 abi,
-                 explicit_self,
-                 unsafety,
-                 decl,
-                 body) => {
-            MethDecl(folder.fold_generics(generics),
-                     abi,
-                     folder.fold_explicit_self(explicit_self),
-                     unsafety,
-                     folder.fold_fn_decl(decl),
+        MethDecl(sig, body) => {
+            MethDecl(noop_fold_method_sig(sig, folder),
                      folder.fold_block(body))
         },
         MethMac(mac) => MethMac(folder.fold_mac(mac))
+    }
+}
+
+pub fn noop_fold_method_sig<T: Folder>(sig: MethodSig, folder: &mut T) -> MethodSig {
+    MethodSig {
+        generics: folder.fold_generics(sig.generics),
+        abi: sig.abi,
+        explicit_self: folder.fold_explicit_self(sig.explicit_self),
+        unsafety: sig.unsafety,
+        decl: folder.fold_fn_decl(sig.decl)
     }
 }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1307,7 +1307,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse the items in a trait declaration
-    pub fn parse_trait_items(&mut self) -> Vec<TraitItem> {
+    pub fn parse_trait_items(&mut self) -> Vec<P<TraitItem>> {
         self.parse_unspanned_seq(
             &token::OpenDelim(token::Brace),
             &token::CloseDelim(token::Brace),
@@ -1316,7 +1316,7 @@ impl<'a> Parser<'a> {
             let attrs = p.parse_outer_attributes();
 
             if p.eat_keyword(keywords::Type) {
-                TypeTraitItem(P(p.parse_associated_type(attrs)))
+                P(TypeTraitItem(p.parse_associated_type(attrs)))
             } else {
                 let lo = p.span.lo;
 
@@ -1346,7 +1346,7 @@ impl<'a> Parser<'a> {
                   token::Semi => {
                     p.bump();
                     debug!("parse_trait_methods(): parsing required method");
-                    RequiredMethod(TypeMethod {
+                    P(RequiredMethod(TypeMethod {
                         ident: ident,
                         attrs: attrs,
                         unsafety: style,
@@ -1357,7 +1357,7 @@ impl<'a> Parser<'a> {
                         id: ast::DUMMY_NODE_ID,
                         span: mk_sp(lo, hi),
                         vis: vis,
-                    })
+                    }))
                   }
                   token::OpenDelim(token::Brace) => {
                     debug!("parse_trait_methods(): parsing provided method");
@@ -1365,7 +1365,7 @@ impl<'a> Parser<'a> {
                         p.parse_inner_attrs_and_block();
                     let mut attrs = attrs;
                     attrs.push_all(&inner_attrs[..]);
-                    ProvidedMethod(P(ast::Method {
+                    P(ProvidedMethod(ast::Method {
                         attrs: attrs,
                         id: ast::DUMMY_NODE_ID,
                         span: mk_sp(lo, hi),
@@ -4692,7 +4692,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a method in a trait impl
-    pub fn parse_method_with_outer_attributes(&mut self) -> P<Method> {
+    pub fn parse_method_with_outer_attributes(&mut self) -> Method {
         let attrs = self.parse_outer_attributes();
         let visa = self.parse_visibility();
         self.parse_method(attrs, visa)
@@ -4713,7 +4713,7 @@ impl<'a> Parser<'a> {
     pub fn parse_method(&mut self,
                         attrs: Vec<Attribute>,
                         visa: Visibility)
-                        -> P<Method> {
+                        -> Method {
         let lo = self.span.lo;
 
         // code copied from parse_macro_use_or_failure... abstraction!
@@ -4772,12 +4772,12 @@ impl<'a> Parser<'a> {
                  body_span.hi, new_attrs)
             }
         };
-        P(ast::Method {
+        ast::Method {
             attrs: new_attrs,
             id: ast::DUMMY_NODE_ID,
             span: mk_sp(lo, hi),
             node: method_,
-        })
+        }
     }
 
     /// Parse trait Foo { ... }
@@ -4808,7 +4808,7 @@ impl<'a> Parser<'a> {
         (ident, ItemTrait(unsafety, tps, bounds, meths), None)
     }
 
-    fn parse_impl_items(&mut self) -> (Vec<ImplItem>, Vec<Attribute>) {
+    fn parse_impl_items(&mut self) -> (Vec<P<ImplItem>>, Vec<Attribute>) {
         let mut impl_items = Vec::new();
         self.expect(&token::OpenDelim(token::Brace));
         let (inner_attrs, mut method_attrs) =
@@ -4821,13 +4821,13 @@ impl<'a> Parser<'a> {
 
             let vis = self.parse_visibility();
             if self.eat_keyword(keywords::Type) {
-                impl_items.push(TypeImplItem(P(self.parse_typedef(
+                impl_items.push(P(TypeImplItem(self.parse_typedef(
                             method_attrs,
                             vis))))
             } else {
-                impl_items.push(MethodImplItem(self.parse_method(
+                impl_items.push(P(MethodImplItem(self.parse_method(
                             method_attrs,
-                            vis)));
+                            vis))));
             }
             method_attrs = vec![];
         }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -11,7 +11,7 @@
 pub use self::PathParsingMode::*;
 
 use abi;
-use ast::{AssociatedType, BareFnTy};
+use ast::{BareFnTy};
 use ast::{RegionTyParamBound, TraitTyParamBound, TraitBoundModifier};
 use ast::{ProvidedMethod, Public, Unsafety};
 use ast::{Mod, BiAdd, Arg, Arm, Attribute, BindByRef, BindByValue};
@@ -38,7 +38,7 @@ use ast::{LitBool, LitChar, LitByte, LitBinary};
 use ast::{LitStr, LitInt, Local, LocalLet};
 use ast::{MacStmtWithBraces, MacStmtWithSemicolon, MacStmtWithoutBraces};
 use ast::{MutImmutable, MutMutable, Mac_, MacInvocTT, MatchSource};
-use ast::{Method, MutTy, BiMul, Mutability};
+use ast::{MutTy, BiMul, Mutability};
 use ast::{MethodImplItem, NamedField, UnNeg, NoReturn, NodeId, UnNot};
 use ast::{Pat, PatEnum, PatIdent, PatLit, PatRange, PatRegion, PatStruct};
 use ast::{PatTup, PatBox, PatWild, PatWildMulti, PatWildSingle};
@@ -55,7 +55,7 @@ use ast::{TyFixedLengthVec, TyBareFn};
 use ast::{TyTypeof, TyInfer, TypeMethod};
 use ast::{TyParam, TyParamBound, TyParen, TyPath, TyPolyTraitRef, TyPtr};
 use ast::{TyRptr, TyTup, TyU32, TyVec, UnUniq};
-use ast::{TypeImplItem, TypeTraitItem, Typedef,};
+use ast::{TypeImplItem, TypeTraitItem};
 use ast::{UnnamedField, UnsafeBlock};
 use ast::{ViewPath, ViewPathGlob, ViewPathList, ViewPathSimple};
 use ast::{Visibility, WhereClause};
@@ -1275,35 +1275,37 @@ impl<'a> Parser<'a> {
 
     /// Parses `type Foo;` in a trait declaration only. The `type` keyword has
     /// already been parsed.
-    fn parse_associated_type(&mut self, attrs: Vec<Attribute>)
-                             -> AssociatedType
-    {
-        let ty_param = self.parse_ty_param();
+    fn parse_assoc_ty_in_trait(&mut self, attrs: Vec<Attribute>)
+                               -> P<TraitItem> {
+        let TyParam {id, ident, bounds, default, span} = self.parse_ty_param();
         self.expect(&token::Semi);
-        AssociatedType {
+        P(TraitItem {
+            id: id,
+            ident: ident,
             attrs: attrs,
-            ty_param: ty_param,
-        }
+            node: TypeTraitItem(bounds, default),
+            span: span,
+        })
     }
 
     /// Parses `type Foo = TYPE;` in an implementation declaration only. The
     /// `type` keyword has already been parsed.
-    fn parse_typedef(&mut self, attrs: Vec<Attribute>, vis: Visibility)
-                     -> Typedef {
+    fn parse_assoc_ty_in_impl(&mut self, attrs: Vec<Attribute>, vis: Visibility)
+                              -> P<ImplItem> {
         let lo = self.span.lo;
         let ident = self.parse_ident();
         self.expect(&token::Eq);
         let typ = self.parse_ty_sum();
         let hi = self.span.hi;
         self.expect(&token::Semi);
-        Typedef {
+        P(ImplItem {
             id: ast::DUMMY_NODE_ID,
             span: mk_sp(lo, hi),
             ident: ident,
             vis: vis,
             attrs: attrs,
-            typ: typ,
-        }
+            node: TypeImplItem(typ),
+        })
     }
 
     /// Parse the items in a trait declaration
@@ -1313,14 +1315,13 @@ impl<'a> Parser<'a> {
             &token::CloseDelim(token::Brace),
             seq_sep_none(),
             |p| {
-            let attrs = p.parse_outer_attributes();
+            let mut attrs = p.parse_outer_attributes();
 
             if p.eat_keyword(keywords::Type) {
-                P(TypeTraitItem(p.parse_associated_type(attrs)))
+                p.parse_assoc_ty_in_trait(attrs)
             } else {
                 let lo = p.span.lo;
 
-                let vis = p.parse_visibility();
                 let style = p.parse_unsafety();
                 let abi = if p.eat_keyword(keywords::Extern) {
                     p.parse_opt_abi().unwrap_or(abi::C)
@@ -1342,42 +1343,29 @@ impl<'a> Parser<'a> {
                 p.parse_where_clause(&mut generics);
 
                 let hi = p.last_span.hi;
-                match p.token {
+                let node = match p.token {
                   token::Semi => {
                     p.bump();
                     debug!("parse_trait_methods(): parsing required method");
-                    P(RequiredMethod(TypeMethod {
-                        ident: ident,
-                        attrs: attrs,
+                    RequiredMethod(TypeMethod {
                         unsafety: style,
                         decl: d,
                         generics: generics,
                         abi: abi,
                         explicit_self: explicit_self,
-                        id: ast::DUMMY_NODE_ID,
-                        span: mk_sp(lo, hi),
-                        vis: vis,
-                    }))
+                    })
                   }
                   token::OpenDelim(token::Brace) => {
                     debug!("parse_trait_methods(): parsing provided method");
                     let (inner_attrs, body) =
                         p.parse_inner_attrs_and_block();
-                    let mut attrs = attrs;
                     attrs.push_all(&inner_attrs[..]);
-                    P(ProvidedMethod(ast::Method {
-                        attrs: attrs,
-                        id: ast::DUMMY_NODE_ID,
-                        span: mk_sp(lo, hi),
-                        node: ast::MethDecl(ident,
-                                            generics,
-                                            abi,
-                                            explicit_self,
-                                            style,
-                                            d,
-                                            body,
-                                            vis)
-                    }))
+                    ProvidedMethod(ast::MethDecl(generics,
+                                                 abi,
+                                                 explicit_self,
+                                                 style,
+                                                 d,
+                                                 body))
                   }
 
                   _ => {
@@ -1385,7 +1373,15 @@ impl<'a> Parser<'a> {
                       p.fatal(&format!("expected `;` or `{{`, found `{}`",
                                        token_str)[..])
                   }
-                }
+                };
+
+                P(TraitItem {
+                    id: ast::DUMMY_NODE_ID,
+                    ident: ident,
+                    attrs: attrs,
+                    node: node,
+                    span: mk_sp(lo, hi),
+                })
             }
         })
     }
@@ -4692,7 +4688,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a method in a trait impl
-    pub fn parse_method_with_outer_attributes(&mut self) -> Method {
+    pub fn parse_method_with_outer_attributes(&mut self) -> P<ImplItem> {
         let attrs = self.parse_outer_attributes();
         let visa = self.parse_visibility();
         self.parse_method(attrs, visa)
@@ -4712,12 +4708,12 @@ impl<'a> Parser<'a> {
     /// Parse a method in a trait impl, starting with `attrs` attributes.
     pub fn parse_method(&mut self,
                         attrs: Vec<Attribute>,
-                        visa: Visibility)
-                        -> Method {
+                        vis: Visibility)
+                        -> P<ImplItem> {
         let lo = self.span.lo;
 
         // code copied from parse_macro_use_or_failure... abstraction!
-        let (method_, hi, new_attrs) = {
+        let (method_, hi, new_attrs, ident) = {
             if !self.token.is_any_keyword()
                 && self.look_ahead(1, |t| *t == token::Not)
                 && (self.look_ahead(2, |t| *t == token::OpenDelim(token::Paren))
@@ -4725,7 +4721,7 @@ impl<'a> Parser<'a> {
                 // method macro.
 
                 let last_span = self.last_span;
-                self.complain_if_pub_macro(visa, last_span);
+                self.complain_if_pub_macro(vis, last_span);
 
                 let pth = self.parse_path(NoTypesAllowed);
                 self.expect(&token::Not);
@@ -4742,7 +4738,8 @@ impl<'a> Parser<'a> {
                 if delim != token::Brace {
                     self.expect(&token::Semi)
                 }
-                (ast::MethMac(m), self.span.hi, attrs)
+                (ast::MethMac(m), self.span.hi, attrs,
+                 token::special_idents::invalid)
             } else {
                 let unsafety = self.parse_unsafety();
                 let abi = if self.eat_keyword(keywords::Extern) {
@@ -4761,23 +4758,23 @@ impl<'a> Parser<'a> {
                 let body_span = body.span;
                 let mut new_attrs = attrs;
                 new_attrs.push_all(&inner_attrs[..]);
-                (ast::MethDecl(ident,
-                               generics,
+                (ast::MethDecl(generics,
                                abi,
                                explicit_self,
                                unsafety,
                                decl,
-                               body,
-                               visa),
-                 body_span.hi, new_attrs)
+                               body),
+                 body_span.hi, new_attrs, ident)
             }
         };
-        ast::Method {
-            attrs: new_attrs,
+        P(ImplItem {
             id: ast::DUMMY_NODE_ID,
+            attrs: new_attrs,
+            vis: vis,
+            ident: ident,
+            node: MethodImplItem(method_),
             span: mk_sp(lo, hi),
-            node: method_,
-        }
+        })
     }
 
     /// Parse trait Foo { ... }
@@ -4820,15 +4817,11 @@ impl<'a> Parser<'a> {
             }
 
             let vis = self.parse_visibility();
-            if self.eat_keyword(keywords::Type) {
-                impl_items.push(P(TypeImplItem(self.parse_typedef(
-                            method_attrs,
-                            vis))))
+            impl_items.push(if self.eat_keyword(keywords::Type) {
+                self.parse_assoc_ty_in_impl(method_attrs, vis)
             } else {
-                impl_items.push(P(MethodImplItem(self.parse_method(
-                            method_attrs,
-                            vis))));
-            }
+                self.parse_method(method_attrs, vis)
+            });
             method_attrs = vec![];
         }
         (impl_items, inner_attrs)

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -12,8 +12,7 @@ pub use self::AnnNode::*;
 
 use abi;
 use ast;
-use ast::{MethodImplItem, RegionTyParamBound, TraitTyParamBound, TraitBoundModifier};
-use ast::{RequiredMethod, ProvidedMethod, TypeImplItem, TypeTraitItem};
+use ast::{RegionTyParamBound, TraitTyParamBound, TraitBoundModifier};
 use ast_util;
 use attr;
 use owned_slice::OwnedSlice;
@@ -977,12 +976,12 @@ impl<'a> State<'a> {
                 try!(self.bopen());
                 try!(self.print_inner_attributes(&item.attrs));
                 for impl_item in impl_items {
-                    match *impl_item {
+                    match **impl_item {
                         ast::MethodImplItem(ref meth) => {
-                            try!(self.print_method(&**meth));
+                            try!(self.print_method(meth));
                         }
                         ast::TypeImplItem(ref typ) => {
-                            try!(self.print_typedef(&**typ));
+                            try!(self.print_typedef(typ));
                         }
                     }
                 }
@@ -1258,16 +1257,16 @@ impl<'a> State<'a> {
     pub fn print_trait_method(&mut self,
                               m: &ast::TraitItem) -> io::Result<()> {
         match *m {
-            RequiredMethod(ref ty_m) => self.print_ty_method(ty_m),
-            ProvidedMethod(ref m) => self.print_method(&**m),
-            TypeTraitItem(ref t) => self.print_associated_type(&**t),
+            ast::RequiredMethod(ref ty_m) => self.print_ty_method(ty_m),
+            ast::ProvidedMethod(ref m) => self.print_method(m),
+            ast::TypeTraitItem(ref t) => self.print_associated_type(t),
         }
     }
 
     pub fn print_impl_item(&mut self, ii: &ast::ImplItem) -> io::Result<()> {
         match *ii {
-            MethodImplItem(ref m) => self.print_method(&**m),
-            TypeImplItem(ref td) => self.print_typedef(&**td),
+            ast::MethodImplItem(ref m) => self.print_method(m),
+            ast::TypeImplItem(ref td) => self.print_typedef(td),
         }
     }
 

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -602,11 +602,11 @@ fn walk_method_helper<'v, V: Visitor<'v>>(visitor: &mut V,
                                           span: Span,
                                           method: &'v Method) {
     match *method {
-        MethDecl(_, _, _, _, ref decl, ref body) => {
+        MethDecl(ref sig, ref body) => {
             visitor.visit_ident(span, ident);
             visitor.visit_fn(FkMethod(ident, method),
-                             &**decl,
-                             &**body,
+                             &sig.decl,
+                             body,
                              span,
                              id);
         },
@@ -627,9 +627,9 @@ pub fn walk_fn<'v, V: Visitor<'v>>(visitor: &mut V,
         }
         FkMethod(_, method) => {
             match *method {
-                MethDecl(ref generics, _, ref explicit_self, _, _, _) => {
-                    visitor.visit_generics(generics);
-                    visitor.visit_explicit_self(explicit_self);
+                MethDecl(ref sig, _) => {
+                    visitor.visit_generics(&sig.generics);
+                    visitor.visit_explicit_self(&sig.explicit_self);
                 }
                 MethMac(ref mac) => visitor.visit_mac(mac)
             }
@@ -646,10 +646,10 @@ pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v Trai
         visitor.visit_attribute(attr);
     }
     match trait_item.node {
-        RequiredMethod(ref method_type) => {
-            visitor.visit_explicit_self(&method_type.explicit_self);
-            visitor.visit_generics(&method_type.generics);
-            walk_fn_decl(visitor, &method_type.decl);
+        RequiredMethod(ref sig) => {
+            visitor.visit_explicit_self(&sig.explicit_self);
+            visitor.visit_generics(&sig.generics);
+            walk_fn_decl(visitor, &sig.decl);
         }
         ProvidedMethod(ref method) => {
             walk_method_helper(visitor,

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -144,7 +144,7 @@ pub fn walk_inlined_item<'v,V>(visitor: &mut V, item: &'v InlinedItem)
         IIForeign(ref i) => visitor.visit_foreign_item(&**i),
         IITraitItem(_, ref ti) => visitor.visit_trait_item(ti),
         IIImplItem(_, MethodImplItem(ref m)) => {
-            walk_method_helper(visitor, &**m)
+            walk_method_helper(visitor, m)
         }
         IIImplItem(_, TypeImplItem(ref typedef)) => {
             visitor.visit_ident(typedef.span, typedef.ident);
@@ -294,9 +294,9 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
             }
             visitor.visit_ty(&**typ);
             for impl_item in impl_items {
-                match *impl_item {
+                match **impl_item {
                     MethodImplItem(ref method) => {
-                        walk_method_helper(visitor, &**method)
+                        walk_method_helper(visitor, method)
                     }
                     TypeImplItem(ref typedef) => {
                         visitor.visit_ident(typedef.span, typedef.ident);
@@ -678,7 +678,7 @@ pub fn walk_ty_method<'v, V: Visitor<'v>>(visitor: &mut V, method_type: &'v Type
 pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_method: &'v TraitItem) {
     match *trait_method {
         RequiredMethod(ref method_type) => visitor.visit_ty_method(method_type),
-        ProvidedMethod(ref method) => walk_method_helper(visitor, &**method),
+        ProvidedMethod(ref method) => walk_method_helper(visitor, method),
         TypeTraitItem(ref associated_type) => {
             walk_ty_param(visitor, &associated_type.ty_param);
         }

--- a/src/test/auxiliary/macro_crate_test.rs
+++ b/src/test/auxiliary/macro_crate_test.rs
@@ -81,16 +81,7 @@ fn expand_into_foo_multi(cx: &mut ExtCtxt,
                 ..(*quote_item!(cx, enum Foo2 { Bar2, Baz2 }).unwrap()).clone()
             }))
         }
-        Annotatable::ImplItem(it) => {
-            Annotatable::ImplItem(ImplItem::MethodImplItem(
-                quote_method!(cx, fn foo(&self) -> i32 { 42 })
-            ))
-        }
-        Annotatable::TraitItem(it) => {
-            Annotatable::TraitItem(TraitItem::ProvidedMethod(
-                quote_method!(cx, fn foo(&self) -> i32 { 0 })
-            ))
-        }
+        it => it
     }
 }
 

--- a/src/test/compile-fail/impl-duplicate-methods.rs
+++ b/src/test/compile-fail/impl-duplicate-methods.rs
@@ -11,7 +11,7 @@
 struct Foo;
 impl Foo {
     fn orange(&self){}
-    fn orange(&self){}   //~ ERROR error: duplicate method in trait impl
+    fn orange(&self){}   //~ ERROR error: duplicate method
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-4265.rs
+++ b/src/test/compile-fail/issue-4265.rs
@@ -17,7 +17,7 @@ impl Foo {
         Foo { baz: 0 }.bar();
     }
 
-    fn bar() { //~ ERROR duplicate method in trait impl
+    fn bar() { //~ ERROR duplicate method
     }
 }
 

--- a/src/test/compile-fail/lint-missing-doc.rs
+++ b/src/test/compile-fail/lint-missing-doc.rs
@@ -59,8 +59,8 @@ trait B {
 }
 
 pub trait C { //~ ERROR: missing documentation for a trait
-    fn foo(&self); //~ ERROR: missing documentation for a type method
-    fn foo_with_impl(&self) {} //~ ERROR: missing documentation for a method
+    fn foo(&self); //~ ERROR: missing documentation for a trait method
+    fn foo_with_impl(&self) {} //~ ERROR: missing documentation for a default method
 }
 
 #[allow(missing_docs)]

--- a/src/test/compile-fail/lint-missing-doc.rs
+++ b/src/test/compile-fail/lint-missing-doc.rs
@@ -60,7 +60,7 @@ trait B {
 
 pub trait C { //~ ERROR: missing documentation for a trait
     fn foo(&self); //~ ERROR: missing documentation for a trait method
-    fn foo_with_impl(&self) {} //~ ERROR: missing documentation for a default method
+    fn foo_with_impl(&self) {} //~ ERROR: missing documentation for a trait method
 }
 
 #[allow(missing_docs)]

--- a/src/test/compile-fail/unnecessary-private.rs
+++ b/src/test/compile-fail/unnecessary-private.rs
@@ -13,7 +13,7 @@ fn main() {
     pub struct A; //~ ERROR: visibility has no effect
     pub enum B {} //~ ERROR: visibility has no effect
     pub trait C { //~ ERROR: visibility has no effect
-        pub fn foo(&self) {} //~ ERROR: visibility has no effect
+        fn foo(&self) {}
     }
     impl A {
         pub fn foo(&self) {} //~ ERROR: visibility has no effect

--- a/src/test/parse-fail/issue-21153.rs
+++ b/src/test/parse-fail/issue-21153.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 trait MyTrait<T>: Iterator {
-    Item = T; //~ ERROR expected one of `extern`, `fn`, `pub`, `type`, or `unsafe`, found `Item`
+    Item = T; //~ ERROR expected one of `extern`, `fn`, `type`, or `unsafe`, found `Item`
 }

--- a/src/test/parse-fail/trait-pub-assoc-ty.rs
+++ b/src/test/parse-fail/trait-pub-assoc-ty.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,11 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub trait E {
-    pub fn foo(&self);               //~ ERROR: unnecessary visibility
-}
-trait F {
-    pub fn foo(&self);               //~ ERROR: unnecessary visibility
+trait Foo {
+    pub type Foo; //~ ERROR expected one of `extern`, `fn`, `type`, or `unsafe`, found `pub`
 }
 
 fn main() {}

--- a/src/test/parse-fail/trait-pub-method.rs
+++ b/src/test/parse-fail/trait-pub-method.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct A { pub i: isize }
-pub enum C { pub Variant }      //~ ERROR: unnecessary `pub`
-
-pub trait E {
-    fn foo(&self);
-}
-
-impl E for A {
-    pub fn foo(&self) {}             //~ ERROR: unnecessary visibility
+trait Foo {
+    pub fn foo(); //~ ERROR expected one of `extern`, `fn`, `type`, or `unsafe`, found `pub`
 }
 
 fn main() {}

--- a/src/test/run-pass-fulldeps/quote-tokens.rs
+++ b/src/test/run-pass-fulldeps/quote-tokens.rs
@@ -36,9 +36,6 @@ fn syntax_extension(cx: &ExtCtxt) {
     let i: Option<P<syntax::ast::Item>> = quote_item!(cx, #[derive(Eq)] struct Foo; );
     assert!(i.is_some());
 
-    let _j: P<syntax::ast::Method> = quote_method!(cx, fn foo(&self) {});
-    let _k: P<syntax::ast::Method> = quote_method!(cx, #[doc = "hello"] fn foo(&self) {});
-
     let _l: P<syntax::ast::Ty> = quote_ty!(cx, &int);
 
     let _m: Vec<syntax::ast::TokenTree> = quote_matcher!(cx, $($foo:tt,)* bar);


### PR DESCRIPTION
The end result is that common fields (id, name, attributes, etc.) are stored in now-structures `ImplItem` and `TraitItem`.
The signature of a method is no longer duplicated between methods with a body (default/impl) and those without, they now share `MethodSig`.

This is also a [breaking-change] because of minor bugfixes and changes to syntax extensions:
- `pub fn` methods in a trait no longer parse - remove the `pub`, it has no meaning anymore
- `MacResult::make_methods` is now `make_impl_items` and the return type has changed accordingly
- `quote_method` is gone, because `P<ast::Method>` doesn't exist and it couldn't represent a full method anyways - could be replaced by `quote_impl_item`/`quote_trait_item` in the future, but I do hope we realize how silly that combinatorial macro expansion is and settle on a single `quote` macro + some type hints - or just no types at all (only token-trees)

r? @nikomatsakis This is necessary (hopefully also sufficient) for associated constants.
