### PR TITLE
Generate relative paths for -C rpath again

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1243,6 +1243,9 @@ impl Path {
     }
 
     /// Returns a path that, when joined onto `base`, yields `self`.
+    ///
+    /// If `base` is not a prefix of `self` (i.e. `starts_with`
+    /// returns false), then `relative_from` returns `None`.
     #[unstable(feature = "path_relative_from", reason = "see #23284")]
     pub fn relative_from<'a, P: ?Sized>(&'a self, base: &'a P) -> Option<&Path> where
         P: AsPath


### PR DESCRIPTION
Fix regression in -C rpath that causes failures with symlinks

The new `relative_from` method no longer supports the case on unix
where both paths are absolute, which `-C rpath` depended on. This
version fixes the problem by copying the old path_relative_from
function into the rpath module.

Fixes #23140

After experimenting with the new `relative_from` function on `Path` I'm not sure what it's use case is. It no longer even figures out that the relative path from `/foo/bar` to `/foo/baz/qux` is `../baz/qux`.
