### PR TITLE
std: Remove #[old_orphan_check] from PartialEq

### DIFF
--- a/src/doc/trpl/macros.md
+++ b/src/doc/trpl/macros.md
@@ -37,7 +37,7 @@ number of elements.
 
 ```rust
 let x: Vec<u32> = vec![1, 2, 3];
-# assert_eq!(&[1,2,3], &x);
+# assert_eq!(x, [1, 2, 3]);
 ```
 
 This can't be an ordinary function, because it takes any number of arguments.
@@ -51,7 +51,7 @@ let x: Vec<u32> = {
     temp_vec.push(3);
     temp_vec
 };
-# assert_eq!(&[1,2,3], &x);
+# assert_eq!(x, [1, 2, 3]);
 ```
 
 We can implement this shorthand, using a macro: [^actual]
@@ -73,7 +73,7 @@ macro_rules! vec {
     };
 }
 # fn main() {
-#     assert_eq!([1,2,3], vec![1,2,3]);
+#     assert_eq!(vec![1,2,3], [1, 2, 3]);
 # }
 ```
 

--- a/src/libcollections/linked_list.rs
+++ b/src/libcollections/linked_list.rs
@@ -1079,7 +1079,7 @@ mod test {
         thread::spawn(move || {
             check_links(&n);
             let a: &[_] = &[&1,&2,&3];
-            assert_eq!(a, n.iter().collect::<Vec<_>>());
+            assert_eq!(a, &n.iter().collect::<Vec<_>>()[..]);
         }).join().ok().unwrap();
     }
 

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1533,22 +1533,22 @@ impl<T> Extend<T> for Vec<T> {
 }
 
 __impl_slice_eq1! { Vec<A>, Vec<B> }
-__impl_slice_eq2! { Vec<A>, &'b [B] }
-__impl_slice_eq2! { Vec<A>, &'b mut [B] }
-__impl_slice_eq2! { Cow<'a, [A]>, &'b [B], Clone }
-__impl_slice_eq2! { Cow<'a, [A]>, &'b mut [B], Clone }
-__impl_slice_eq2! { Cow<'a, [A]>, Vec<B>, Clone }
+__impl_slice_eq1! { Vec<A>, &'b [B] }
+__impl_slice_eq1! { Vec<A>, &'b mut [B] }
+__impl_slice_eq1! { Cow<'a, [A]>, &'b [B], Clone }
+__impl_slice_eq1! { Cow<'a, [A]>, &'b mut [B], Clone }
+__impl_slice_eq1! { Cow<'a, [A]>, Vec<B>, Clone }
 
 macro_rules! array_impls {
     ($($N: expr)+) => {
         $(
             // NOTE: some less important impls are omitted to reduce code bloat
-            __impl_slice_eq2! { Vec<A>, [B; $N] }
-            __impl_slice_eq2! { Vec<A>, &'b [B; $N] }
-            // __impl_slice_eq2! { Vec<A>, &'b mut [B; $N] }
-            // __impl_slice_eq2! { Cow<'a, [A]>, [B; $N], Clone }
-            // __impl_slice_eq2! { Cow<'a, [A]>, &'b [B; $N], Clone }
-            // __impl_slice_eq2! { Cow<'a, [A]>, &'b mut [B; $N], Clone }
+            __impl_slice_eq1! { Vec<A>, [B; $N] }
+            __impl_slice_eq1! { Vec<A>, &'b [B; $N] }
+            // __impl_slice_eq1! { Vec<A>, &'b mut [B; $N] }
+            // __impl_slice_eq1! { Cow<'a, [A]>, [B; $N], Clone }
+            // __impl_slice_eq1! { Cow<'a, [A]>, &'b [B; $N], Clone }
+            // __impl_slice_eq1! { Cow<'a, [A]>, &'b mut [B; $N], Clone }
         )+
     }
 }

--- a/src/libcollectionstest/enum_set.rs
+++ b/src/libcollectionstest/enum_set.rs
@@ -153,19 +153,19 @@ fn test_iterator() {
 
     e1.insert(A);
     let elems: Vec<_> = e1.iter().collect();
-    assert_eq!([A], elems);
+    assert_eq!(elems, [A]);
 
     e1.insert(C);
     let elems: Vec<_> = e1.iter().collect();
-    assert_eq!([A,C], elems);
+    assert_eq!(elems, [A,C]);
 
     e1.insert(C);
     let elems: Vec<_> = e1.iter().collect();
-    assert_eq!([A,C], elems);
+    assert_eq!(elems, [A,C]);
 
     e1.insert(B);
     let elems: Vec<_> = e1.iter().collect();
-    assert_eq!([A,B,C], elems);
+    assert_eq!(elems, [A,B,C]);
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -183,35 +183,35 @@ fn test_operators() {
 
     let e_union = e1 | e2;
     let elems: Vec<_> = e_union.iter().collect();
-    assert_eq!([A,B,C], elems);
+    assert_eq!(elems, [A,B,C]);
 
     let e_intersection = e1 & e2;
     let elems: Vec<_> = e_intersection.iter().collect();
-    assert_eq!([C], elems);
+    assert_eq!(elems, [C]);
 
     // Another way to express intersection
     let e_intersection = e1 - (e1 - e2);
     let elems: Vec<_> = e_intersection.iter().collect();
-    assert_eq!([C], elems);
+    assert_eq!(elems, [C]);
 
     let e_subtract = e1 - e2;
     let elems: Vec<_> = e_subtract.iter().collect();
-    assert_eq!([A], elems);
+    assert_eq!(elems, [A]);
 
     // Bitwise XOR of two sets, aka symmetric difference
     let e_symmetric_diff = e1 ^ e2;
     let elems: Vec<_> = e_symmetric_diff.iter().collect();
-    assert_eq!([A,B], elems);
+    assert_eq!(elems, [A,B]);
 
     // Another way to express symmetric difference
     let e_symmetric_diff = (e1 - e2) | (e2 - e1);
     let elems: Vec<_> = e_symmetric_diff.iter().collect();
-    assert_eq!([A,B], elems);
+    assert_eq!(elems, [A,B]);
 
     // Yet another way to express symmetric difference
     let e_symmetric_diff = (e1 | e2) - (e1 & e2);
     let elems: Vec<_> = e_symmetric_diff.iter().collect();
-    assert_eq!([A,B], elems);
+    assert_eq!(elems, [A,B]);
 }
 
 #[test]

--- a/src/libcollectionstest/str.rs
+++ b/src/libcollectionstest/str.rs
@@ -83,7 +83,7 @@ fn test_collect() {
 fn test_into_bytes() {
     let data = String::from_str("asdf");
     let buf = data.into_bytes();
-    assert_eq!(b"asdf", buf);
+    assert_eq!(buf, b"asdf");
 }
 
 #[test]

--- a/src/libcollectionstest/vec_deque.rs
+++ b/src/libcollectionstest/vec_deque.rs
@@ -821,7 +821,7 @@ fn test_as_slices() {
 
         let (left, right) = ring.as_slices();
         let expected: Vec<_> = (0..i+1).collect();
-        assert_eq!(left, expected);
+        assert_eq!(left, &expected[..]);
         assert_eq!(right, []);
     }
 
@@ -830,8 +830,8 @@ fn test_as_slices() {
         let (left, right) = ring.as_slices();
         let expected_left: Vec<_> = (-last..j+1).rev().collect();
         let expected_right: Vec<_> = (0..first).collect();
-        assert_eq!(left, expected_left);
-        assert_eq!(right, expected_right);
+        assert_eq!(left, &expected_left[..]);
+        assert_eq!(right, &expected_right[..]);
     }
 
     assert_eq!(ring.len() as i32, cap);
@@ -849,7 +849,7 @@ fn test_as_mut_slices() {
 
         let (left, right) = ring.as_mut_slices();
         let expected: Vec<_> = (0..i+1).collect();
-        assert_eq!(left, expected);
+        assert_eq!(left, &expected[..]);
         assert_eq!(right, []);
     }
 
@@ -858,8 +858,8 @@ fn test_as_mut_slices() {
         let (left, right) = ring.as_mut_slices();
         let expected_left: Vec<_> = (-last..j+1).rev().collect();
         let expected_right: Vec<_> = (0..first).collect();
-        assert_eq!(left, expected_left);
-        assert_eq!(right, expected_right);
+        assert_eq!(left, &expected_left[..]);
+        assert_eq!(right, &expected_right[..]);
     }
 
     assert_eq!(ring.len() as i32, cap);

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -64,7 +64,6 @@ use option::Option::{self, Some, None};
 /// inverse of `ne`; that is, `!(a == b)` if and only if `a != b`.
 #[lang="eq"]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[old_orphan_check]
 pub trait PartialEq<Rhs: ?Sized = Self> {
     /// This method tests for `self` and `other` values to be equal, and is used by `==`.
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/cmp_macros.rs
+++ b/src/libcore/cmp_macros.rs
@@ -15,8 +15,11 @@
 #[macro_export]
 macro_rules! __impl_slice_eq1 {
     ($Lhs: ty, $Rhs: ty) => {
+        __impl_slice_eq1! { $Lhs, $Rhs, Sized }
+    };
+    ($Lhs: ty, $Rhs: ty, $Bound: ident) => {
         #[stable(feature = "rust1", since = "1.0.0")]
-        impl<'a, 'b, A, B> PartialEq<$Rhs> for $Lhs where A: PartialEq<B> {
+        impl<'a, 'b, A: $Bound, B> PartialEq<$Rhs> for $Lhs where A: PartialEq<B> {
             #[inline]
             fn eq(&self, other: &$Rhs) -> bool { &self[..] == &other[..] }
             #[inline]
@@ -31,13 +34,7 @@ macro_rules! __impl_slice_eq2 {
         __impl_slice_eq2! { $Lhs, $Rhs, Sized }
     };
     ($Lhs: ty, $Rhs: ty, $Bound: ident) => {
-        #[stable(feature = "rust1", since = "1.0.0")]
-        impl<'a, 'b, A: $Bound, B> PartialEq<$Rhs> for $Lhs where A: PartialEq<B> {
-            #[inline]
-            fn eq(&self, other: &$Rhs) -> bool { &self[..] == &other[..] }
-            #[inline]
-            fn ne(&self, other: &$Rhs) -> bool { &self[..] != &other[..] }
-        }
+        __impl_slice_eq1!($Lhs, $Rhs, $Bound);
 
         #[stable(feature = "rust1", since = "1.0.0")]
         impl<'a, 'b, A: $Bound, B> PartialEq<$Lhs> for $Rhs where B: PartialEq<A> {

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -530,10 +530,9 @@ pub trait Iterator {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
-    /// let a = [1, 2, 3, 4, 5];
-    /// let b: Vec<_> = a.iter().cloned().collect();
-    /// assert_eq!(a, b);
+    /// let expected = [1, 2, 3, 4, 5];
+    /// let actual: Vec<_> = expected.iter().cloned().collect();
+    /// assert_eq!(actual, expected);
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -927,8 +926,8 @@ pub trait Iterator {
     /// # #![feature(core)]
     /// let a = [(1, 2), (3, 4)];
     /// let (left, right): (Vec<_>, Vec<_>) = a.iter().cloned().unzip();
-    /// assert_eq!([1, 3], left);
-    /// assert_eq!([2, 4], right);
+    /// assert_eq!(left, [1, 3]);
+    /// assert_eq!(right, [2, 4]);
     /// ```
     #[unstable(feature = "core", reason = "recent addition")]
     fn unzip<A, B, FromA, FromB>(self) -> (FromA, FromB) where

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -66,10 +66,10 @@ macro_rules! assert {
     );
 }
 
-/// Asserts that two expressions are equal to each other, testing equality in
-/// both directions.
+/// Asserts that two expressions are equal to each other.
 ///
-/// On panic, this macro will print the values of the expressions.
+/// On panic, this macro will print the values of the expressions with their
+/// debug representations.
 ///
 /// # Examples
 ///
@@ -84,10 +84,8 @@ macro_rules! assert_eq {
     ($left:expr , $right:expr) => ({
         match (&($left), &($right)) {
             (left_val, right_val) => {
-                // check both directions of equality....
-                if !((*left_val == *right_val) &&
-                     (*right_val == *left_val)) {
-                    panic!("assertion failed: `(left == right) && (right == left)` \
+                if !(*left_val == *right_val) {
+                    panic!("assertion failed: `(left == right)` \
                            (left: `{:?}`, right: `{:?}`)", *left_val, *right_val)
                 }
             }

--- a/src/libcoretest/mem.rs
+++ b/src/libcoretest/mem.rs
@@ -103,7 +103,7 @@ fn test_transmute() {
     }
 
     unsafe {
-        assert_eq!([76], transmute::<_, Vec<u8>>("L".to_string()));
+        assert_eq!(transmute::<_, Vec<u8>>("L".to_string()), [76]);
     }
 }
 

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -446,7 +446,7 @@ mod tests {
 
     fn same(fmt: &'static str, p: &[Piece<'static>]) {
         let parser = Parser::new(fmt);
-        assert!(p == parser.collect::<Vec<Piece<'static>>>());
+        assert!(parser.collect::<Vec<Piece<'static>>>() == p);
     }
 
     fn fmtdflt() -> FormatSpec<'static> {

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -808,12 +808,11 @@ fn walk_ty() {
         let tup2_ty = ty::mk_tup(tcx, vec!(tup1_ty, tup1_ty, uint_ty));
         let uniq_ty = ty::mk_uniq(tcx, tup2_ty);
         let walked: Vec<_> = uniq_ty.walk().collect();
-        assert_eq!([uniq_ty,
-                    tup2_ty,
-                    tup1_ty, int_ty, uint_ty, int_ty, uint_ty,
-                    tup1_ty, int_ty, uint_ty, int_ty, uint_ty,
-                    uint_ty],
-                   walked);
+        assert_eq!(walked, [uniq_ty,
+                            tup2_ty,
+                            tup1_ty, int_ty, uint_ty, int_ty, uint_ty,
+                            tup1_ty, int_ty, uint_ty, int_ty, uint_ty,
+                            uint_ty]);
     })
 }
 

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -215,25 +215,21 @@ impl<'cx, 'tcx> OrphanChecker<'cx, 'tcx> {
                 match traits::orphan_check(self.tcx, def_id) {
                     Ok(()) => { }
                     Err(traits::OrphanCheckErr::NoLocalInputType) => {
-                        if !ty::has_attr(self.tcx, trait_def_id, "old_orphan_check") {
-                            span_err!(
-                                self.tcx.sess, item.span, E0117,
-                                "the impl does not reference any \
-                                 types defined in this crate; \
-                                 only traits defined in the current crate can be \
-                                 implemented for arbitrary types");
-                            return;
-                        }
+                        span_err!(
+                            self.tcx.sess, item.span, E0117,
+                            "the impl does not reference any \
+                             types defined in this crate; \
+                             only traits defined in the current crate can be \
+                             implemented for arbitrary types");
+                        return;
                     }
                     Err(traits::OrphanCheckErr::UncoveredTy(param_ty)) => {
-                        if !ty::has_attr(self.tcx, trait_def_id, "old_orphan_check") {
-                            span_err!(self.tcx.sess, item.span, E0210,
-                                    "type parameter `{}` must be used as the type parameter for \
-                                     some local type (e.g. `MyStruct<T>`); only traits defined in \
-                                     the current crate can be implemented for a type parameter",
-                                    param_ty.user_string(self.tcx));
-                            return;
-                        }
+                        span_err!(self.tcx.sess, item.span, E0210,
+                                "type parameter `{}` must be used as the type parameter for \
+                                 some local type (e.g. `MyStruct<T>`); only traits defined in \
+                                 the current crate can be implemented for a type parameter",
+                                param_ty.user_string(self.tcx));
+                        return;
                     }
                 }
 

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -1192,7 +1192,7 @@ mod test_set {
         };
 
         let v = hs.into_iter().collect::<Vec<char>>();
-        assert!(['a', 'b'] == v || ['b', 'a'] == v);
+        assert!(v == ['a', 'b'] || v == ['b', 'a']);
     }
 
     #[test]

--- a/src/libstd/old_io/buffered.rs
+++ b/src/libstd/old_io/buffered.rs
@@ -548,7 +548,7 @@ mod test {
         let mut w = BufferedWriter::with_capacity(3, Vec::new());
         w.write_all(&[0, 1]).unwrap();
         let a: &[_] = &[];
-        assert_eq!(a, &w.get_ref()[..]);
+        assert_eq!(&w.get_ref()[..], a);
         let w = w.into_inner();
         let a: &[_] = &[0, 1];
         assert_eq!(a, &w[..]);

--- a/src/libstd/old_io/util.rs
+++ b/src/libstd/old_io/util.rs
@@ -334,7 +334,7 @@ mod test {
         let mut r = MemReader::new(vec!(0, 1, 2));
         {
             let mut r = LimitReader::new(r.by_ref(), 4);
-            assert_eq!([0, 1, 2], r.read_to_end().unwrap());
+            assert_eq!(r.read_to_end().unwrap(), [0, 1, 2]);
         }
     }
 
@@ -343,9 +343,9 @@ mod test {
         let mut r = MemReader::new(vec!(0, 1, 2));
         {
             let mut r = LimitReader::new(r.by_ref(), 2);
-            assert_eq!([0, 1], r.read_to_end().unwrap());
+            assert_eq!(r.read_to_end().unwrap(), [0, 1]);
         }
-        assert_eq!([2], r.read_to_end().unwrap());
+        assert_eq!(r.read_to_end().unwrap(), [2]);
     }
 
     #[test]
@@ -355,7 +355,7 @@ mod test {
         assert_eq!(3, r.limit());
         assert_eq!(0, r.read_byte().unwrap());
         assert_eq!(2, r.limit());
-        assert_eq!([1, 2], r.read_to_end().unwrap());
+        assert_eq!(r.read_to_end().unwrap(), [1, 2]);
         assert_eq!(0, r.limit());
     }
 
@@ -364,7 +364,7 @@ mod test {
         let mut r = MemReader::new(vec![0, 1, 2, 3, 4, 5]);
         let mut r = LimitReader::new(r.by_ref(), 1);
         r.consume(2);
-        assert_eq!([], r.read_to_end().unwrap());
+        assert_eq!(r.read_to_end().unwrap(), []);
     }
 
     #[test]
@@ -380,7 +380,7 @@ mod test {
         let mut s = ZeroReader;
         let mut buf = vec![1, 2, 3];
         assert_eq!(s.read(&mut buf), Ok(3));
-        assert_eq!([0, 0, 0], buf);
+        assert_eq!(buf, [0, 0, 0]);
     }
 
     #[test]
@@ -423,16 +423,16 @@ mod test {
         let rs = vec!(MemReader::new(vec!(0, 1)), MemReader::new(vec!()),
                       MemReader::new(vec!(2, 3)));
         let mut r = ChainedReader::new(rs.into_iter());
-        assert_eq!([0, 1, 2, 3], r.read_to_end().unwrap());
+        assert_eq!(r.read_to_end().unwrap(), [0, 1, 2, 3]);
     }
 
     #[test]
     fn test_tee_reader() {
         let mut r = TeeReader::new(MemReader::new(vec!(0, 1, 2)),
                                    Vec::new());
-        assert_eq!([0, 1, 2], r.read_to_end().unwrap());
+        assert_eq!(r.read_to_end().unwrap(), [0, 1, 2]);
         let (_, w) = r.into_inner();
-        assert_eq!([0, 1, 2], w);
+        assert_eq!(w, [0, 1, 2]);
     }
 
     #[test]
@@ -440,7 +440,7 @@ mod test {
         let mut r = MemReader::new(vec!(0, 1, 2, 3, 4));
         let mut w = Vec::new();
         copy(&mut r, &mut w).unwrap();
-        assert_eq!([0, 1, 2, 3, 4], w);
+        assert_eq!(w, [0, 1, 2, 3, 4]);
     }
 
     #[test]

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -102,9 +102,6 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Status)] = &[
     // A way to temporarily opt out of opt in copy. This will *never* be accepted.
     ("opt_out_copy", "1.0.0", Removed),
 
-    // A way to temporarily opt out of the new orphan rules. This will *never* be accepted.
-    ("old_orphan_check", "1.0.0", Deprecated),
-
     // OIBIT specific features
     ("optin_builtin_traits", "1.0.0", Active),
 
@@ -277,9 +274,6 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType)] = &[
     ("stable", Whitelisted),
     ("unstable", Whitelisted),
 
-    // FIXME: #19470 this shouldn't be needed forever
-    ("old_orphan_check", Whitelisted),
-
     ("rustc_paren_sugar", Gated("unboxed_closures",
                                 "unboxed_closures are still evolving")),
     ("rustc_reflect_like", Gated("reflect",
@@ -327,7 +321,6 @@ pub struct Features {
     pub allow_trace_macros: bool,
     pub allow_internal_unstable: bool,
     pub allow_custom_derive: bool,
-    pub old_orphan_check: bool,
     pub simd_ffi: bool,
     pub unmarked_api: bool,
     /// spans of #![feature] attrs for stable language features. for error reporting
@@ -349,7 +342,6 @@ impl Features {
             allow_trace_macros: false,
             allow_internal_unstable: false,
             allow_custom_derive: false,
-            old_orphan_check: false,
             simd_ffi: false,
             unmarked_api: false,
             declared_stable_lang_features: Vec::new(),
@@ -573,14 +565,6 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
                     },
                     _ => {}
                 }
-
-                if attr::contains_name(&i.attrs[..],
-                                       "old_orphan_check") {
-                    self.gate_feature(
-                        "old_orphan_check",
-                        i.span,
-                        "the new orphan check rules will eventually be strictly enforced");
-                }
             }
 
             _ => {}
@@ -737,7 +721,6 @@ fn check_crate_inner<F>(cm: &CodeMap, span_handler: &SpanHandler,
         allow_trace_macros: cx.has_feature("trace_macros"),
         allow_internal_unstable: cx.has_feature("allow_internal_unstable"),
         allow_custom_derive: cx.has_feature("custom_derive"),
-        old_orphan_check: cx.has_feature("old_orphan_check"),
         simd_ffi: cx.has_feature("simd_ffi"),
         unmarked_api: cx.has_feature("unmarked_api"),
         declared_stable_lang_features: accepted_features,

--- a/src/libsyntax/util/small_vector.rs
+++ b/src/libsyntax/util/small_vector.rs
@@ -226,13 +226,13 @@ mod test {
     fn test_move_iter() {
         let v = SmallVector::zero();
         let v: Vec<isize> = v.into_iter().collect();
-        assert_eq!(Vec::new(), v);
+        assert_eq!(v, Vec::new());
 
         let v = SmallVector::one(1);
-        assert_eq!([1], v.into_iter().collect::<Vec<_>>());
+        assert_eq!(v.into_iter().collect::<Vec<_>>(), [1]);
 
         let v = SmallVector::many(vec![1, 2, 3]);
-        assert_eq!([1, 2, 3], v.into_iter().collect::<Vec<_>>());
+        assert_eq!(v.into_iter().collect::<Vec<_>>(), [1, 2, 3]);
     }
 
     #[test]

--- a/src/test/run-fail/assert-eq-macro-panic.rs
+++ b/src/test/run-fail/assert-eq-macro-panic.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:assertion failed: `(left == right) && (right == left)` (left: `14`, right: `15`)
+// error-pattern:assertion failed: `(left == right)` (left: `14`, right: `15`)
 
 fn main() {
     assert_eq!(14,15);

--- a/src/test/run-pass/deriving-encodable-decodable-box.rs
+++ b/src/test/run-pass/deriving-encodable-decodable-box.rs
@@ -12,7 +12,7 @@
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]
-#![feature(old_orphan_check, rustc_private)]
+#![feature(rustc_private)]
 
 extern crate serialize;
 

--- a/src/test/run-pass/deriving-encodable-decodable-cell-refcell.rs
+++ b/src/test/run-pass/deriving-encodable-decodable-cell-refcell.rs
@@ -13,7 +13,7 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(old_orphan_check, rustc_private)]
+#![feature(rustc_private)]
 
 extern crate serialize;
 

--- a/src/test/run-pass/deriving-global.rs
+++ b/src/test/run-pass/deriving-global.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(old_orphan_check, rand, rustc_private)]
+#![feature(rand, rustc_private)]
 
 extern crate serialize;
 extern crate rand;

--- a/src/test/run-pass/issue-11881.rs
+++ b/src/test/run-pass/issue-11881.rs
@@ -10,7 +10,7 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(old_orphan_check, rustc_private, old_io)]
+#![feature(rustc_private, old_io)]
 
 extern crate rbml;
 extern crate serialize;

--- a/src/test/run-pass/issue-14021.rs
+++ b/src/test/run-pass/issue-14021.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(old_orphan_check, rustc_private)]
+#![feature(rustc_private)]
 
 extern crate serialize;
 

--- a/src/test/run-pass/issue-15734.rs
+++ b/src/test/run-pass/issue-15734.rs
@@ -13,7 +13,7 @@
 
 // pretty-expanded FIXME #23616
 
-#![feature(old_orphan_check, core)]
+#![feature(core)]
 
 use std::ops::Index;
 

--- a/src/test/run-pass/issue-3743.rs
+++ b/src/test/run-pass/issue-3743.rs
@@ -10,7 +10,6 @@
 
 // If `Mul` used an associated type for its output, this test would
 // work more smoothly.
-#![feature(old_orphan_check)]
 
 use std::ops::Mul;
 


### PR DESCRIPTION
This is a deprecated attribute that is slated for removal, and it also affects
all implementors of the trait. This commit removes the attribute and fixes up
implementors accordingly. The primary implementation which was lost was the
ability to compare `&[T]` and `Vec<T>` (in that order).

This change also modifies the `assert_eq!` macro to not consider both directions
of equality, only the one given in the left/right forms to the macro. This
modification is motivated due to the fact that `&[T] == Vec<T>` no longer
compiles, causing hundreds of errors in unit tests in the standard library (and
likely throughout the community as well).

Closes #19470
[breaking-change]
