### PR TITLE
Fix LLVM assertion when out-of-bounds indexing in a constant

### DIFF
--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -505,8 +505,10 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                   // pass. Reporting here is a bit late.
                   cx.sess().span_err(e.span,
                                      "const index-expr is out of bounds");
+                  C_undef(type_of::type_of(cx, bt).element_type())
+              } else {
+                  const_get_elt(cx, arr, &[iv as c_uint])
               }
-              const_get_elt(cx, arr, &[iv as c_uint])
           }
           ast::ExprCast(ref base, _) => {
             let llty = type_of::type_of(cx, ety);

--- a/src/test/compile-fail/const-array-oob.rs
+++ b/src/test/compile-fail/const-array-oob.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const FOO: [u32; 3] = [1, 2, 3];
+const BAR: u32 = FOO[5]; //~ ERROR const index-expr is out of bounds
+
+fn main() {
+    let _ = BAR;
+}


### PR DESCRIPTION
Fixes #23291
