### PR TITLE
Add monospace font back to literals table

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -229,14 +229,14 @@ cases mentioned in [Number literals](#number-literals) below.
 
 ##### Characters and strings
 
-|                                              | Example       | # sets | Characters  | Escapes             |
-|----------------------------------------------|---------------|--------|-------------|---------------------|
-| [Character](#character-literals)             | 'H'           | N/A    | All Unicode | \' & [Byte](#byte-escapes) & [Unicode](#unicode-escapes) |
-| [String](#string-literals)                   | "hello"       | N/A    | All Unicode | \" & [Byte](#byte-escapes) & [Unicode](#unicode-escapes) |
-| [Raw](#raw-string-literals)                  | r#"hello"#    | 0...   | All Unicode | N/A                                                      |
-| [Byte](#byte-literals)                       | b'H'          | N/A    | All ASCII   | \' & [Byte](#byte-escapes)                               |
-| [Byte string](#byte-string-literals)         | b"hello"      | N/A    | All ASCII   | \" & [Byte](#byte-escapes)                               |
-| [Raw byte string](#raw-byte-string-literals) | br#"hello"#   | 0...   | All ASCII   | N/A                                                      |
+|                                              | Example         | `#` sets   | Characters  | Escapes             |
+|----------------------------------------------|-----------------|------------|-------------|---------------------|
+| [Character](#character-literals)             | `'H'`           | `N/A`      | All Unicode | `\'` & [Byte](#byte-escapes) & [Unicode](#unicode-escapes) |
+| [String](#string-literals)                   | `"hello"`       | `N/A`      | All Unicode | `\"` & [Byte](#byte-escapes) & [Unicode](#unicode-escapes) |
+| [Raw](#raw-string-literals)                  | `r#"hello"#`    | `0...`     | All Unicode | `N/A`                                                      |
+| [Byte](#byte-literals)                       | `b'H'`          | `N/A`      | All ASCII   | `\'` & [Byte](#byte-escapes)                               |
+| [Byte string](#byte-string-literals)         | `b"hello"`      | `N/A`      | All ASCII   | `\"` & [Byte](#byte-escapes)                               |
+| [Raw byte string](#raw-byte-string-literals) | `br#"hello"#`   | `0...`     | All ASCII   | `N/A`                                                      |
 
 ##### Byte escapes
 


### PR DESCRIPTION
The [literals table](http://doc.rust-lang.org/reference.html#characters-and-strings) now looks ugly but compact. Add back the monospace text.
