### PR TITLE
Remove IteratorExt

### DIFF
--- a/src/libcollections/linked_list.rs
+++ b/src/libcollections/linked_list.rs
@@ -951,7 +951,7 @@ impl<A: Hash> Hash for LinkedList<A> {
 #[cfg(test)]
 mod test {
     use std::clone::Clone;
-    use std::iter::{Iterator, IteratorExt};
+    use std::iter::Iterator;
     use std::option::Option::{Some, None, self};
     use std::rand;
     use std::thread;

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -76,7 +76,6 @@
 //!   iterators.
 //! * Further methods that return iterators are `.split()`, `.splitn()`,
 //!   `.chunks()`, `.windows()` and more.
-
 #![doc(primitive = "slice")]
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -85,7 +84,7 @@ use core::convert::AsRef;
 use core::clone::Clone;
 use core::cmp::Ordering::{self, Greater, Less};
 use core::cmp::{self, Ord, PartialEq};
-use core::iter::{Iterator, IteratorExt};
+use core::iter::Iterator;
 use core::iter::MultiplicativeIterator;
 use core::marker::Sized;
 use core::mem::size_of;
@@ -131,7 +130,7 @@ mod hack {
     use alloc::boxed::Box;
     use core::clone::Clone;
     #[cfg(test)]
-    use core::iter::{Iterator, IteratorExt};
+    use core::iter::Iterator;
     use core::mem;
     #[cfg(test)]
     use core::option::Option::{Some, None};

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -58,7 +58,7 @@ use self::DecompositionType::*;
 
 use core::clone::Clone;
 use core::iter::AdditiveIterator;
-use core::iter::{Iterator, IteratorExt, Extend};
+use core::iter::{Iterator, Extend};
 use core::option::Option::{self, Some, None};
 use core::result::Result;
 use core::str as core_str;

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -1785,7 +1785,7 @@ impl<T: fmt::Debug> fmt::Debug for VecDeque<T> {
 
 #[cfg(test)]
 mod test {
-    use core::iter::{IteratorExt, self};
+    use core::iter::{Iterator, self};
     use core::option::Option::Some;
 
     use test;

--- a/src/libcollectionstest/bench.rs
+++ b/src/libcollectionstest/bench.rs
@@ -66,7 +66,7 @@ macro_rules! map_find_rand_bench {
     ($name: ident, $n: expr, $map: ident) => (
         #[bench]
         pub fn $name(b: &mut ::test::Bencher) {
-            use std::iter::IteratorExt;
+            use std::iter::Iterator;
             use std::rand::Rng;
             use std::rand;
             use std::vec::Vec;

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -17,7 +17,7 @@ pub use self::SignFormat::*;
 use char;
 use char::CharExt;
 use fmt;
-use iter::IteratorExt;
+use iter::Iterator;
 use num::{cast, Float, ToPrimitive};
 use num::FpCategory as Fp;
 use ops::FnOnce;

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -15,7 +15,7 @@
 use any;
 use cell::{Cell, RefCell, Ref, RefMut, BorrowState};
 use char::CharExt;
-use iter::{Iterator, IteratorExt};
+use iter::Iterator;
 use marker::{Copy, PhantomData, Sized};
 use mem;
 use option::Option;

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -15,7 +15,7 @@
 #![allow(unsigned_negation)]
 
 use fmt;
-use iter::IteratorExt;
+use iter::Iterator;
 use num::{Int, cast};
 use slice::SliceExt;
 use str;

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -23,7 +23,7 @@ use cmp::{PartialEq, Eq, PartialOrd, Ord};
 use error::Error;
 use fmt;
 use intrinsics;
-use iter::IteratorExt;
+use iter::Iterator;
 use marker::Copy;
 use mem::size_of;
 use ops::{Add, Sub, Mul, Div, Rem, Neg};

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -149,7 +149,7 @@ use clone::Clone;
 use cmp::{Eq, Ord};
 use default::Default;
 use iter::ExactSizeIterator;
-use iter::{Iterator, IteratorExt, DoubleEndedIterator, FromIterator, IntoIterator};
+use iter::{Iterator, DoubleEndedIterator, FromIterator, IntoIterator};
 use mem;
 use ops::FnOnce;
 use result::Result::{Ok, Err};

--- a/src/libcore/prelude.rs
+++ b/src/libcore/prelude.rs
@@ -37,7 +37,7 @@ pub use char::CharExt;
 pub use clone::Clone;
 pub use cmp::{PartialEq, PartialOrd, Eq, Ord};
 pub use convert::{AsRef, AsMut, Into, From};
-pub use iter::{Extend, IteratorExt};
+pub use iter::Extend;
 pub use iter::{Iterator, DoubleEndedIterator};
 pub use iter::{ExactSizeIterator};
 pub use option::Option::{self, Some, None};

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -243,8 +243,7 @@ use self::Result::{Ok, Err};
 
 use clone::Clone;
 use fmt;
-use iter::{Iterator, IteratorExt, DoubleEndedIterator,
-           FromIterator, ExactSizeIterator, IntoIterator};
+use iter::{Iterator, DoubleEndedIterator, FromIterator, ExactSizeIterator, IntoIterator};
 use ops::{FnMut, FnOnce};
 use option::Option::{self, None, Some};
 #[allow(deprecated)]

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -25,7 +25,7 @@ use default::Default;
 use error::Error;
 use fmt;
 use iter::ExactSizeIterator;
-use iter::{Map, Iterator, IteratorExt, DoubleEndedIterator};
+use iter::{Map, Iterator, DoubleEndedIterator};
 use marker::Sized;
 use mem;
 #[allow(deprecated)]
@@ -1237,7 +1237,7 @@ Section: Trait implementations
 mod traits {
     use cmp::{Ordering, Ord, PartialEq, PartialOrd, Eq};
     use cmp::Ordering::{Less, Equal, Greater};
-    use iter::IteratorExt;
+    use iter::Iterator;
     use option::Option;
     use option::Option::Some;
     use ops;

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -20,7 +20,7 @@ use cmp::{max, Eq, PartialEq};
 use default::Default;
 use fmt::{self, Debug};
 use hash::{Hash, SipHasher};
-use iter::{self, Iterator, ExactSizeIterator, IntoIterator, IteratorExt, FromIterator, Extend, Map};
+use iter::{self, Iterator, ExactSizeIterator, IntoIterator, FromIterator, Extend, Map};
 use marker::Sized;
 use mem::{self, replace};
 use ops::{Deref, FnMut, FnOnce, Index};

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -18,9 +18,7 @@ use default::Default;
 use fmt::Debug;
 use fmt;
 use hash::Hash;
-use iter::{
-    Iterator, IntoIterator, ExactSizeIterator, IteratorExt, FromIterator, Map, Chain, Extend,
-};
+use iter::{Iterator, IntoIterator, ExactSizeIterator, FromIterator, Map, Chain, Extend};
 use ops::{BitOr, BitAnd, BitXor, Sub};
 use option::Option::{Some, None, self};
 

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -15,7 +15,7 @@ use self::BucketState::*;
 use clone::Clone;
 use cmp;
 use hash::{Hash, Hasher};
-use iter::{Iterator, IteratorExt, ExactSizeIterator, count};
+use iter::{Iterator, ExactSizeIterator, count};
 use marker::{Copy, Send, Sync, Sized, self};
 use mem::{min_align_of, size_of};
 use mem;

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -261,7 +261,7 @@ mod dl {
 #[cfg(target_os = "windows")]
 mod dl {
     use ffi::OsStr;
-    use iter::IteratorExt;
+    use iter::Iterator;
     use libc;
     use libc::consts::os::extra::ERROR_CALL_NOT_IMPLEMENTED;
     use ops::FnOnce;

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -15,7 +15,7 @@ use cmp::{PartialEq, Eq, PartialOrd, Ord, Ordering};
 use error::{Error, FromError};
 use fmt;
 use io;
-use iter::IteratorExt;
+use iter::Iterator;
 use libc;
 use mem;
 #[allow(deprecated)]

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -16,7 +16,7 @@ use cmp;
 use unicode::str as core_str;
 use error as std_error;
 use fmt;
-use iter::{self, Iterator, IteratorExt, Extend};
+use iter::{self, Iterator, Extend};
 use marker::Sized;
 use ops::{Drop, FnOnce};
 use option::Option::{self, Some, None};

--- a/src/libstd/old_io/buffered.rs
+++ b/src/libstd/old_io/buffered.rs
@@ -15,7 +15,7 @@
 use cmp;
 use fmt;
 use old_io::{Reader, Writer, Stream, Buffer, DEFAULT_BUF_SIZE, IoResult};
-use iter::{IteratorExt, ExactSizeIterator, repeat};
+use iter::{Iterator, ExactSizeIterator, repeat};
 use ops::Drop;
 use option::Option;
 use option::Option::{Some, None};

--- a/src/libstd/old_io/mem.rs
+++ b/src/libstd/old_io/mem.rs
@@ -400,7 +400,7 @@ mod test {
     extern crate test as test_crate;
     use old_io::{SeekSet, SeekCur, SeekEnd, Reader, Writer, Seek, Buffer};
     use prelude::v1::{Ok, Err, Vec,  AsSlice};
-    use prelude::v1::IteratorExt;
+    use prelude::v1::Iterator;
     use old_io;
     use iter::repeat;
     use self::test_crate::Bencher;

--- a/src/libstd/old_io/mod.rs
+++ b/src/libstd/old_io/mod.rs
@@ -268,7 +268,7 @@ use default::Default;
 use error::Error;
 use fmt;
 use isize;
-use iter::{Iterator, IteratorExt};
+use iter::Iterator;
 use marker::{PhantomFn, Sized};
 use mem::transmute;
 use ops::FnOnce;

--- a/src/libstd/old_io/net/addrinfo.rs
+++ b/src/libstd/old_io/net/addrinfo.rs
@@ -19,7 +19,7 @@ pub use self::SocketType::*;
 pub use self::Flag::*;
 pub use self::Protocol::*;
 
-use iter::IteratorExt;
+use iter::Iterator;
 use old_io::IoResult;
 use old_io::net::ip::{SocketAddr, IpAddr};
 use option::Option;

--- a/src/libstd/old_io/net/ip.rs
+++ b/src/libstd/old_io/net/ip.rs
@@ -21,7 +21,7 @@ use boxed::Box;
 use fmt;
 use old_io::{self, IoResult, IoError};
 use old_io::net;
-use iter::{Iterator, IteratorExt};
+use iter::Iterator;
 use ops::{FnOnce, FnMut};
 use option::Option;
 use option::Option::{None, Some};

--- a/src/libstd/old_io/tempfile.rs
+++ b/src/libstd/old_io/tempfile.rs
@@ -12,7 +12,7 @@
 #![allow(deprecated)] // rand
 
 use env;
-use iter::IteratorExt;
+use iter::Iterator;
 use old_io::{fs, IoError, IoErrorKind, IoResult};
 use old_io;
 use ops::Drop;

--- a/src/libstd/old_path/mod.rs
+++ b/src/libstd/old_path/mod.rs
@@ -70,7 +70,7 @@ use core::marker::Sized;
 use ffi::CString;
 use clone::Clone;
 use fmt;
-use iter::IteratorExt;
+use iter::Iterator;
 use option::Option;
 use option::Option::{None, Some};
 use str;

--- a/src/libstd/old_path/posix.rs
+++ b/src/libstd/old_path/posix.rs
@@ -16,7 +16,7 @@ use fmt;
 use hash;
 use old_io::Writer;
 use iter::{AdditiveIterator, Extend};
-use iter::{Iterator, IteratorExt, Map};
+use iter::{Iterator, Map};
 use marker::Sized;
 use option::Option::{self, Some, None};
 use result::Result::{self, Ok, Err};
@@ -444,13 +444,13 @@ mod tests {
     use super::*;
 
     use clone::Clone;
-    use iter::IteratorExt;
     use option::Option::{self, Some, None};
     use old_path::GenericPath;
     use slice::AsSlice;
     use str::{self, Str};
     use string::ToString;
     use vec::Vec;
+    use iter::Iterator;
 
     macro_rules! t {
         (s: $path:expr, $exp:expr) => (

--- a/src/libstd/old_path/windows.rs
+++ b/src/libstd/old_path/windows.rs
@@ -21,7 +21,7 @@ use fmt;
 use hash;
 use old_io::Writer;
 use iter::{AdditiveIterator, Extend};
-use iter::{Iterator, IteratorExt, Map, repeat};
+use iter::{Iterator, Map, repeat};
 use mem;
 use option::Option::{self, Some, None};
 use result::Result::{self, Ok, Err};
@@ -1126,7 +1126,7 @@ mod tests {
     use super::*;
 
     use clone::Clone;
-    use iter::IteratorExt;
+    use iter::Iterator;
     use option::Option::{self, Some, None};
     use old_path::GenericPath;
     use slice::AsSlice;

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -43,7 +43,7 @@ use env;
 use error::{FromError, Error};
 use ffi::{OsString, OsStr};
 use fmt;
-use iter::{Iterator, IteratorExt};
+use iter::Iterator;
 use libc::{c_void, c_int, c_char};
 use libc;
 use marker::{Copy, Send};

--- a/src/libstd/prelude/v1.rs
+++ b/src/libstd/prelude/v1.rs
@@ -36,7 +36,7 @@
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)] pub use iter::ExactSizeIterator;
 #[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)] pub use iter::{Iterator, IteratorExt, Extend};
+#[doc(no_inline)] pub use iter::{Iterator, Extend};
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)] pub use option::Option::{self, Some, None};
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -231,7 +231,7 @@
 use cell::RefCell;
 use clone::Clone;
 use old_io::IoResult;
-use iter::{Iterator, IteratorExt};
+use iter::Iterator;
 use mem;
 use rc::Rc;
 use result::Result::{Ok, Err};

--- a/src/libstd/sys/windows/process2.rs
+++ b/src/libstd/sys/windows/process2.rs
@@ -127,7 +127,7 @@ impl Process {
 
         use env::split_paths;
         use mem;
-        use iter::IteratorExt;
+        use iter::Iterator;
 
         // To have the spawning semantics of unix/windows stay the same, we need to
         // read the *child's* PATH if one is provided. See #15149 for more details.


### PR DESCRIPTION
All methods are inlined into Iterator with `Self: Sized` bounds to make
sure Iterator is still object safe.

[breaking-change]

This is blocked on ICEs: https://gist.github.com/sfackler/5aff7c57cf8d896e2c6f
Seem to be similar to #23281.
