### PR TITLE
Avoid passing -L "" to rustc.

### DIFF
--- a/mk/llvm.mk
+++ b/mk/llvm.mk
@@ -44,10 +44,10 @@ $$(LLVM_STAMP_$(1)): $(S)src/rustllvm/llvm-auto-clean-trigger
 	touch -r $$@.start_time $$@ && rm $$@.start_time
 
 ifeq ($$(CFG_ENABLE_LLVM_STATIC_STDCPP),1)
-LLVM_STDCPP_LOCATION_$(1) = $$(shell $$(CC_$(1)) $$(CFG_GCCISH_CFLAGS_$(1)) \
-					-print-file-name=libstdc++.a)
+LLVM_STDCPP_RUSTFLAGS_$(1) = -L "$$(dir $$(shell $$(CC_$(1)) $$(CFG_GCCISH_CFLAGS_$(1)) \
+					-print-file-name=libstdc++.a))"
 else
-LLVM_STDCPP_LOCATION_$(1) =
+LLVM_STDCPP_RUSTFLAGS_$(1) =
 endif
 
 

--- a/mk/target.mk
+++ b/mk/target.mk
@@ -85,7 +85,7 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4): \
 		$$(RUST_LIB_FLAGS_ST$(1)) \
 		-L "$$(RT_OUTPUT_DIR_$(2))" \
 		-L "$$(LLVM_LIBDIR_$(2))" \
-		-L "$$(dir $$(LLVM_STDCPP_LOCATION_$(2)))" \
+		$$(LLVM_STDCPP_RUSTFLAGS_$(2)) \
 		$$(RUSTFLAGS_$(4)) \
 		--out-dir $$(@D) \
 		-C extra-filename=-$$(CFG_FILENAME_EXTRA) \


### PR DESCRIPTION
Currently, target.mk passes -L "" when LLVM_STDCPP_LOCATION_$(2) is empty.

This fixes #23287.
