### PR TITLE
Remove explicit syntax highlight from docs.

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -94,7 +94,7 @@ use heap::deallocate;
 /// With simple pipes, without `Arc`, a copy would have to be made for each
 /// task.
 ///
-/// ```rust
+/// ```
 /// use std::sync::Arc;
 /// use std::thread;
 ///

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -64,7 +64,7 @@ use core::raw::TraitObject;
 ///
 /// The following two examples are equivalent:
 ///
-/// ```rust
+/// ```
 /// #![feature(box_syntax)]
 /// use std::boxed::HEAP;
 ///

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -133,7 +133,7 @@ static FALSE: bool = false;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::collections::BitVec;
 ///
 /// let mut bv = BitVec::from_elem(10, false);

--- a/src/libcollections/borrow.rs
+++ b/src/libcollections/borrow.rs
@@ -129,7 +129,7 @@ impl<T> ToOwned for T where T: Clone {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::borrow::Cow;
 ///
 /// fn abs_all(input: &mut Cow<[i32]>) {

--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -422,7 +422,7 @@ use string;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::fmt;
 ///
 /// let s = fmt::format(format_args!("Hello, {}!", "world"));

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -134,7 +134,7 @@ pub trait SliceExt {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let mut v = [5, 4, 1, 3, 2];
     /// v.sort_by(|a, b| a.cmp(b));
     /// assert!(v == [1, 2, 3, 4, 5]);
@@ -160,7 +160,7 @@ pub trait SliceExt {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let mut a = [1, 2, 3, 4, 5];
     /// let b = vec![6, 7, 8];
     /// let num_moved = a.move_from(b, 0, 3);
@@ -282,7 +282,7 @@ pub trait SliceExt {
     /// Print the adjacent pairs of a slice (i.e. `[1,2]`, `[2,3]`,
     /// `[3,4]`):
     ///
-    /// ```rust
+    /// ```
     /// let v = &[1, 2, 3, 4];
     /// for win in v.windows(2) {
     ///     println!("{:?}", win);
@@ -305,7 +305,7 @@ pub trait SliceExt {
     /// Print the slice two elements at a time (i.e. `[1,2]`,
     /// `[3,4]`, `[5]`):
     ///
-    /// ```rust
+    /// ```
     /// let v = &[1, 2, 3, 4, 5];
     /// for win in v.chunks(2) {
     ///     println!("{:?}", win);
@@ -396,7 +396,7 @@ pub trait SliceExt {
     /// uniquely determined position; the second and third are not
     /// found; the fourth could match any position in `[1,4]`.
     ///
-    /// ```rust
+    /// ```
     /// let s = [0, 1, 1, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55];
     /// let s = s.as_slice();
     ///
@@ -531,7 +531,7 @@ pub trait SliceExt {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let mut v = ["a", "b", "c", "d"];
     /// v.swap(1, 3);
     /// assert!(v == ["a", "d", "c", "b"]);
@@ -551,7 +551,7 @@ pub trait SliceExt {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let mut v = [1, 2, 3, 4, 5, 6];
     ///
     /// // scoped to restrict the lifetime of the borrows
@@ -580,7 +580,7 @@ pub trait SliceExt {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let mut v = [1, 2, 3];
     /// v.reverse();
     /// assert!(v == [3, 2, 1]);
@@ -612,7 +612,7 @@ pub trait SliceExt {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let v = [1, 2, 3];
     /// let mut perms = v.permutations();
     ///
@@ -623,7 +623,7 @@ pub trait SliceExt {
     ///
     /// Iterating through permutations one by one.
     ///
-    /// ```rust
+    /// ```
     /// let v = [1, 2, 3];
     /// let mut perms = v.permutations();
     ///
@@ -640,7 +640,7 @@ pub trait SliceExt {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let mut dst = [0, 0, 0];
     /// let src = [1, 2];
     ///
@@ -660,7 +660,7 @@ pub trait SliceExt {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let mut v = [-5, 4, 1, -3, 2];
     ///
     /// v.sort();
@@ -682,7 +682,7 @@ pub trait SliceExt {
     /// uniquely determined position; the second and third are not
     /// found; the fourth could match any position in `[1,4]`.
     ///
-    /// ```rust
+    /// ```
     /// let s = [0, 1, 1, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55];
     /// let s = s.as_slice();
     ///
@@ -709,7 +709,7 @@ pub trait SliceExt {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let v: &mut [_] = &mut [0, 1, 2];
     /// v.next_permutation();
     /// let b: &mut [_] = &mut [0, 2, 1];
@@ -729,7 +729,7 @@ pub trait SliceExt {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let v: &mut [_] = &mut [1, 0, 2];
     /// v.prev_permutation();
     /// let b: &mut [_] = &mut [0, 2, 1];

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -906,7 +906,7 @@ pub trait StrExt: Index<RangeFull, Output = str> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// assert!("banana".ends_with("nana"));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -110,7 +110,7 @@ impl String {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::str::Utf8Error;
     ///
     /// let hello_vec = vec![104, 101, 108, 108, 111];
@@ -136,7 +136,7 @@ impl String {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let input = b"Hello \xF0\x90\x80World";
     /// let output = String::from_utf8_lossy(input);
     /// assert_eq!(output, "Hello \u{FFFD}World");
@@ -268,7 +268,7 @@ impl String {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// // 𝄞music
     /// let mut v = &mut [0xD834, 0xDD1E, 0x006d, 0x0075,
     ///                   0x0073, 0x0069, 0x0063];
@@ -296,7 +296,7 @@ impl String {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// // 𝄞mus<invalid>ic<invalid>
     /// let v = &[0xD834, 0xDD1E, 0x006d, 0x0075,
     ///           0x0073, 0xDD1E, 0x0069, 0x0063,

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -636,7 +636,7 @@ impl<T> Vec<T> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let mut vec = vec!(1, 2);
     /// vec.push(3);
     /// assert_eq!(vec, [1, 2, 3]);
@@ -674,7 +674,7 @@ impl<T> Vec<T> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let mut vec = vec![1, 2, 3];
     /// assert_eq!(vec.pop(), Some(3));
     /// assert_eq!(vec, [1, 2]);

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -200,7 +200,7 @@ impl<T> VecDeque<T> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -223,7 +223,7 @@ impl<T> VecDeque<T> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -257,7 +257,7 @@ impl<T> VecDeque<T> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -512,7 +512,7 @@ impl<T> VecDeque<T> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -535,7 +535,7 @@ impl<T> VecDeque<T> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -823,7 +823,7 @@ impl<T> VecDeque<T> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -848,7 +848,7 @@ impl<T> VecDeque<T> {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -948,7 +948,7 @@ impl<T> VecDeque<T> {
     /// Panics if `i` is greater than ringbuf's length
     ///
     /// # Examples
-    /// ```rust
+    /// ```
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -1150,7 +1150,7 @@ impl<T> VecDeque<T> {
     /// Returns `None` if `i` is out of bounds.
     ///
     /// # Examples
-    /// ```rust
+    /// ```
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -216,7 +216,7 @@ macro_rules! writeln {
 ///
 /// Match arms:
 ///
-/// ```rust
+/// ```
 /// fn foo(x: Option<int>) {
 ///     match x {
 ///         Some(n) if n >= 0 => println!("Some(Non-negative)"),
@@ -229,7 +229,7 @@ macro_rules! writeln {
 ///
 /// Iterators:
 ///
-/// ```rust
+/// ```
 /// fn divide_by_three(x: u32) -> u32 { // one of the poorest implementations of x/3
 ///     for i in std::iter::count(0, 1) {
 ///         if 3*i < i { panic!("u32 overflow"); }

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -310,7 +310,7 @@ impl<T:?Sized> MarkerTrait for T { }
 ///
 /// Therefore, we can model a method like this as follows:
 ///
-/// ```rust
+/// ```
 /// use std::marker::PhantomFn;
 /// trait Even : PhantomFn<Self> { }
 /// ```
@@ -318,7 +318,7 @@ impl<T:?Sized> MarkerTrait for T { }
 /// Another equivalent, but clearer, option would be to use
 /// `MarkerTrait`:
 ///
-/// ```rust
+/// ```
 /// use std::marker::MarkerTrait;
 /// trait Even : MarkerTrait { }
 /// ```

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -251,7 +251,7 @@ pub fn swap<T>(x: &mut T, y: &mut T) {
 /// `self.buf`. But `replace` can be used to disassociate the original value of `self.buf` from
 /// `self`, allowing it to be returned:
 ///
-/// ```rust
+/// ```
 /// use std::mem;
 /// # struct Buffer<T> { buf: Vec<T> }
 /// impl<T> Buffer<T> {

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -281,7 +281,7 @@ impl Float for f32 {
 
     /// The fractional part of the number, satisfying:
     ///
-    /// ```rust
+    /// ```
     /// use core::num::Float;
     ///
     /// let x = 1.65f32;

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -288,7 +288,7 @@ impl Float for f64 {
 
     /// The fractional part of the number, satisfying:
     ///
-    /// ```rust
+    /// ```
     /// use core::num::Float;
     ///
     /// let x = 1.65f64;

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -84,7 +84,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// let n = 0b01001100u8;
@@ -99,7 +99,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// let n = 0b01001100u8;
@@ -118,7 +118,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// let n = 0b0101000u16;
@@ -134,7 +134,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// let n = 0b0101000u16;
@@ -150,7 +150,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// let n = 0x0123456789ABCDEFu64;
@@ -167,7 +167,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// let n = 0x0123456789ABCDEFu64;
@@ -183,7 +183,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// let n = 0x0123456789ABCDEFu64;
@@ -200,7 +200,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// let n = 0x0123456789ABCDEFu64;
@@ -223,7 +223,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// let n = 0x0123456789ABCDEFu64;
@@ -246,7 +246,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// let n = 0x0123456789ABCDEFu64;
@@ -269,7 +269,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// let n = 0x0123456789ABCDEFu64;
@@ -291,7 +291,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// assert_eq!(5u16.checked_add(65530), Some(65535));
@@ -305,7 +305,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// assert_eq!((-127i8).checked_sub(1), Some(-128));
@@ -319,7 +319,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// assert_eq!(5u8.checked_mul(51), Some(255));
@@ -333,7 +333,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// assert_eq!((-127i8).checked_div(-1), Some(127));
@@ -371,7 +371,7 @@ pub trait Int
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::num::Int;
     ///
     /// assert_eq!(2.pow(4), 16);

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -78,7 +78,7 @@ use fmt;
 /// A trivial implementation of `Drop`. The `drop` method is called when `_x` goes
 /// out of scope, and therefore `main` prints `Dropping!`.
 ///
-/// ```rust
+/// ```
 /// struct HasDrop;
 ///
 /// impl Drop for HasDrop {
@@ -162,7 +162,7 @@ macro_rules! forward_ref_binop {
 /// A trivial implementation of `Add`. When `Foo + Foo` happens, it ends up
 /// calling `add`, and therefore, `main` prints `Adding!`.
 ///
-/// ```rust
+/// ```
 /// use std::ops::Add;
 ///
 /// #[derive(Copy)]
@@ -216,7 +216,7 @@ add_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 /// A trivial implementation of `Sub`. When `Foo - Foo` happens, it ends up
 /// calling `sub`, and therefore, `main` prints `Subtracting!`.
 ///
-/// ```rust
+/// ```
 /// use std::ops::Sub;
 ///
 /// #[derive(Copy)]
@@ -270,7 +270,7 @@ sub_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 /// A trivial implementation of `Mul`. When `Foo * Foo` happens, it ends up
 /// calling `mul`, and therefore, `main` prints `Multiplying!`.
 ///
-/// ```rust
+/// ```
 /// use std::ops::Mul;
 ///
 /// #[derive(Copy)]

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -897,7 +897,7 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
     /// Here is an example which increments every integer in a vector,
     /// checking for overflow:
     ///
-    /// ```rust
+    /// ```
     /// use std::u16;
     ///
     /// let v = vec!(1, 2);

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -896,7 +896,7 @@ impl<A, E, V: FromIterator<A>> FromIterator<Result<A, E>> for Result<V, E> {
     /// Here is an example which increments every integer in a vector,
     /// checking for overflow:
     ///
-    /// ```rust
+    /// ```
     /// use std::u32;
     ///
     /// let v = vec!(1, 2);

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1435,7 +1435,7 @@ pub fn mut_ref_slice<'a, A>(s: &'a mut A) -> &'a mut [A] {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::slice;
 ///
 /// // manifest a slice out of thin air!
@@ -1478,7 +1478,7 @@ pub unsafe fn from_raw_parts_mut<'a, T>(p: *mut T, len: usize) -> &'a mut [T] {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::slice;
 ///
 /// // manifest a slice out of thin air!

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -139,7 +139,7 @@ impl FromStr for bool {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::str::FromStr;
     ///
     /// assert_eq!(FromStr::from_str("true"), Ok(true));
@@ -150,7 +150,7 @@ impl FromStr for bool {
     /// Note, in many cases, the StrExt::parse() which is based on
     /// this FromStr::from_str() is more proper.
     ///
-    /// ```rust
+    /// ```
     /// assert_eq!("true".parse(), Ok(true));
     /// assert_eq!("false".parse(), Ok(false));
     /// assert!("not even a boolean".parse::<bool>().is_err());
@@ -1185,7 +1185,7 @@ mod traits {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let s = "Löwe 老虎 Léopard";
     /// assert_eq!(&s[0 .. 1], "L");
     ///

--- a/src/librand/distributions/exponential.rs
+++ b/src/librand/distributions/exponential.rs
@@ -59,7 +59,7 @@ impl Rand for Exp1 {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::rand;
 /// use std::rand::distributions::{Exp, IndependentSample};
 ///

--- a/src/librand/distributions/gamma.rs
+++ b/src/librand/distributions/gamma.rs
@@ -39,7 +39,7 @@ use super::{IndependentSample, Sample, Exp};
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::rand;
 /// use std::rand::distributions::{IndependentSample, Gamma};
 ///
@@ -186,7 +186,7 @@ impl IndependentSample<f64> for GammaLargeShape {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::rand;
 /// use std::rand::distributions::{ChiSquared, IndependentSample};
 ///
@@ -243,7 +243,7 @@ impl IndependentSample<f64> for ChiSquared {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::rand;
 /// use std::rand::distributions::{FisherF, IndependentSample};
 ///
@@ -287,7 +287,7 @@ impl IndependentSample<f64> for FisherF {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::rand;
 /// use std::rand::distributions::{StudentT, IndependentSample};
 ///

--- a/src/librand/distributions/mod.rs
+++ b/src/librand/distributions/mod.rs
@@ -95,7 +95,7 @@ pub struct Weighted<T> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::rand;
 /// use std::rand::distributions::{Weighted, WeightedChoice, IndependentSample};
 ///

--- a/src/librand/distributions/normal.rs
+++ b/src/librand/distributions/normal.rs
@@ -75,7 +75,7 @@ impl Rand for StandardNormal {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::rand;
 /// use std::rand::distributions::{Normal, IndependentSample};
 ///
@@ -123,7 +123,7 @@ impl IndependentSample<f64> for Normal {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::rand;
 /// use std::rand::distributions::{LogNormal, IndependentSample};
 ///

--- a/src/librand/distributions/range.rs
+++ b/src/librand/distributions/range.rs
@@ -35,7 +35,7 @@ use distributions::{Sample, IndependentSample};
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::rand::distributions::{IndependentSample, Range};
 ///
 /// fn main() {

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -148,7 +148,7 @@ pub trait Rng : Sized {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::rand::{thread_rng, Rng};
     ///
     /// let mut v = [0; 13579];
@@ -183,7 +183,7 @@ pub trait Rng : Sized {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::rand::{thread_rng, Rng};
     ///
     /// let mut rng = thread_rng();
@@ -228,7 +228,7 @@ pub trait Rng : Sized {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::rand::{thread_rng, Rng};
     ///
     /// let mut rng = thread_rng();
@@ -246,7 +246,7 @@ pub trait Rng : Sized {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::rand::{thread_rng, Rng};
     ///
     /// let mut rng = thread_rng();
@@ -260,7 +260,7 @@ pub trait Rng : Sized {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::rand::{thread_rng, Rng};
     ///
     /// let s: String = thread_rng().gen_ascii_chars().take(10).collect();
@@ -296,7 +296,7 @@ pub trait Rng : Sized {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::rand::{thread_rng, Rng};
     ///
     /// let mut rng = thread_rng();
@@ -359,7 +359,7 @@ pub trait SeedableRng<Seed>: Rng {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::rand::{Rng, SeedableRng, StdRng};
     ///
     /// let seed: &[_] = &[1, 2, 3, 4];
@@ -374,7 +374,7 @@ pub trait SeedableRng<Seed>: Rng {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::rand::{Rng, SeedableRng, StdRng};
     ///
     /// let seed: &[_] = &[1, 2, 3, 4];
@@ -478,7 +478,8 @@ impl Rand for XorShiftRng {
 /// `[0,1)`.
 ///
 /// # Examples
-/// ```rust
+///
+/// ```
 /// use std::rand::{random, Open01};
 ///
 /// let Open01(val) = random::<Open01<f32>>();
@@ -495,7 +496,7 @@ pub struct Open01<F>(pub F);
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::rand::{random, Closed01};
 ///
 /// let Closed01(val) = random::<Closed01<f32>>();

--- a/src/librand/reseeding.rs
+++ b/src/librand/reseeding.rs
@@ -102,7 +102,7 @@ impl<S, R: SeedableRng<S>, Rsdr: Reseeder<R> + Default>
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::rand::{Rng, SeedableRng, StdRng};
 /// use std::rand::reseeding::{Reseeder, ReseedingRng};
 ///

--- a/src/librustc/middle/traits/project.rs
+++ b/src/librustc/middle/traits/project.rs
@@ -535,7 +535,7 @@ fn assemble_candidates_from_param_env<'cx,'tcx>(
 /// In the case of a nested projection like <<A as Foo>::FooT as Bar>::BarT, we may find
 /// that the definition of `Foo` has some clues:
 ///
-/// ```rust
+/// ```
 /// trait Foo {
 ///     type FooT : Bar<BarT=i32>
 /// }

--- a/src/librustc/middle/ty_walk.rs
+++ b/src/librustc/middle/ty_walk.rs
@@ -82,7 +82,7 @@ impl<'tcx> TypeWalker<'tcx> {
     ///
     /// Example: Imagine you are walking `Foo<Bar<int>, uint>`.
     ///
-    /// ```rust
+    /// ```
     /// let mut iter: TypeWalker = ...;
     /// iter.next(); // yields Foo
     /// iter.next(); // yields Bar<int>

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -253,7 +253,7 @@ fn trans_fn_ref_with_substs_to_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 /// Translates an adapter that implements the `Fn` trait for a fn
 /// pointer. This is basically the equivalent of something like:
 ///
-/// ```rust
+/// ```
 /// impl<'a> Fn(&'a int) -> &'a int for fn(&int) -> &int {
 ///     extern "rust-abi" fn call(&self, args: (&'a int,)) -> &'a int {
 ///         (*self)(args.0)

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -31,7 +31,7 @@ impl ToHex for [u8] {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// extern crate serialize;
     /// use serialize::hex::ToHex;
     ///
@@ -100,7 +100,7 @@ impl FromHex for str {
     ///
     /// This converts a string literal to hexadecimal and back.
     ///
-    /// ```rust
+    /// ```
     /// extern crate serialize;
     /// use serialize::hex::{FromHex, ToHex};
     ///

--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -41,7 +41,7 @@ use sys::os as os_imp;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::env;
 ///
 /// // We assume that we are in a valid directory.
@@ -58,7 +58,7 @@ pub fn current_dir() -> io::Result<PathBuf> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::env;
 /// use std::path::Path;
 ///
@@ -102,7 +102,7 @@ pub struct VarsOs { inner: os_imp::Env }
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::env;
 ///
 /// // We will iterate through the references to the element returned by
@@ -125,7 +125,7 @@ pub fn vars() -> Vars {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::env;
 ///
 /// // We will iterate through the references to the element returned by
@@ -166,7 +166,7 @@ impl Iterator for VarsOs {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::env;
 ///
 /// let key = "HOME";
@@ -188,7 +188,7 @@ pub fn var<K: ?Sized>(key: &K) -> Result<String, VarError> where K: AsOsStr {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::env;
 ///
 /// let key = "HOME";
@@ -246,7 +246,7 @@ impl Error for VarError {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::env;
 ///
 /// let key = "KEY";
@@ -282,7 +282,7 @@ pub struct SplitPaths<'a> { inner: os_imp::SplitPaths<'a> }
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::env;
 ///
 /// let key = "PATH";
@@ -326,7 +326,7 @@ pub struct JoinPathsError {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::env;
 /// use std::path::PathBuf;
 ///
@@ -374,7 +374,7 @@ impl Error for JoinPathsError {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::env;
 ///
 /// match env::home_dir() {
@@ -416,7 +416,7 @@ pub fn temp_dir() -> PathBuf {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::env;
 ///
 /// match env::current_exe() {
@@ -481,7 +481,7 @@ pub struct ArgsOs { inner: os_imp::Args }
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::env;
 ///
 /// // Prints each argument on a separate line
@@ -503,7 +503,7 @@ pub fn args() -> Args {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::env;
 ///
 /// // Prints each argument on a separate line

--- a/src/libstd/fs/mod.rs
+++ b/src/libstd/fs/mod.rs
@@ -474,7 +474,7 @@ pub fn rename<P: AsPath + ?Sized, Q: AsPath + ?Sized>(from: &P, to: &Q)
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::fs;
 ///
 /// fs::copy("foo.txt", "bar.txt");
@@ -543,7 +543,7 @@ pub fn read_link<P: AsPath + ?Sized>(path: &P) -> io::Result<PathBuf> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::fs;
 ///
 /// fs::create_dir("/some/dir");
@@ -579,7 +579,7 @@ pub fn create_dir_all<P: AsPath + ?Sized>(path: &P) -> io::Result<()> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::fs;
 ///
 /// fs::remove_dir("/some/dir");
@@ -630,7 +630,7 @@ pub fn remove_dir_all<P: AsPath + ?Sized>(path: &P) -> io::Result<()> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::io;
 /// use std::fs::{self, PathExt, DirEntry};
 /// use std::path::Path;

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -179,7 +179,7 @@ pub mod builtin {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::fmt;
     ///
     /// let s = fmt::format(format_args!("hello {}", "world"));
@@ -202,7 +202,7 @@ pub mod builtin {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let path: &'static str = env!("PATH");
     /// println!("the $PATH variable at the time of compiling was: {}", path);
     /// ```
@@ -221,7 +221,7 @@ pub mod builtin {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let key: Option<&'static str> = option_env!("SECRET_KEY");
     /// println!("the secret key might be: {:?}", key);
     /// ```
@@ -369,7 +369,7 @@ pub mod builtin {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// mod test {
     ///     pub fn foo() {
     ///         assert!(module_path!().ends_with("test"));
@@ -392,7 +392,7 @@ pub mod builtin {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// let my_directory = if cfg!(windows) {
     ///     "windows-specific-directory"
     /// } else {

--- a/src/libstd/old_io/buffered.rs
+++ b/src/libstd/old_io/buffered.rs
@@ -33,7 +33,7 @@ use vec::Vec;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::old_io::{BufferedReader, File};
 ///
 /// let file = File::open(&Path::new("message.txt"));
@@ -136,7 +136,7 @@ impl<R: Reader> Reader for BufferedReader<R> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::old_io::{BufferedWriter, File};
 ///
 /// let file = File::create(&Path::new("message.txt")).unwrap();
@@ -322,7 +322,7 @@ impl<W: Reader> Reader for InternalBufferedWriter<W> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// # #![allow(unused_must_use)]
 /// use std::old_io::{BufferedStream, File};
 ///

--- a/src/libstd/old_io/fs.rs
+++ b/src/libstd/old_io/fs.rs
@@ -175,7 +175,7 @@ impl File {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::old_io::File;
     ///
     /// let contents = File::open(&Path::new("foo.txt")).read_to_end();
@@ -194,7 +194,7 @@ impl File {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// # #![allow(unused_must_use)]
     /// use std::old_io::File;
     ///
@@ -285,7 +285,7 @@ impl File {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// # #![allow(unused_must_use)]
 /// use std::old_io::fs;
 ///
@@ -316,7 +316,7 @@ pub fn unlink(path: &Path) -> IoResult<()> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::old_io::fs;
 ///
 /// let p = Path::new("/some/file/path.txt");
@@ -358,7 +358,7 @@ pub fn lstat(path: &Path) -> IoResult<FileStat> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// # #![allow(unused_must_use)]
 /// use std::old_io::fs;
 ///
@@ -386,7 +386,7 @@ pub fn rename(from: &Path, to: &Path) -> IoResult<()> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// # #![allow(unused_must_use)]
 /// use std::old_io::fs;
 ///
@@ -436,7 +436,7 @@ pub fn copy(from: &Path, to: &Path) -> IoResult<()> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// # #![allow(unused_must_use)]
 /// use std::old_io;
 /// use std::old_io::fs;
@@ -507,7 +507,7 @@ pub fn readlink(path: &Path) -> IoResult<Path> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// # #![allow(unused_must_use)]
 /// use std::old_io;
 /// use std::old_io::fs;
@@ -531,7 +531,7 @@ pub fn mkdir(path: &Path, mode: FilePermission) -> IoResult<()> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// # #![allow(unused_must_use)]
 /// use std::old_io::fs;
 ///
@@ -555,7 +555,7 @@ pub fn rmdir(path: &Path) -> IoResult<()> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::old_io::fs::PathExtensions;
 /// use std::old_io::fs;
 /// use std::old_io;

--- a/src/libstd/old_io/mem.rs
+++ b/src/libstd/old_io/mem.rs
@@ -53,7 +53,7 @@ impl Writer for Vec<u8> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// # #![allow(unused_must_use)]
 /// use std::old_io::MemWriter;
 ///
@@ -113,7 +113,7 @@ impl Writer for MemWriter {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// # #![allow(unused_must_use)]
 /// use std::old_io::MemReader;
 ///
@@ -243,7 +243,7 @@ impl<'a> Buffer for &'a [u8] {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// # #![allow(unused_must_use)]
 /// use std::old_io::BufWriter;
 ///
@@ -315,7 +315,7 @@ impl<'a> Seek for BufWriter<'a> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// # #![allow(unused_must_use)]
 /// use std::old_io::BufReader;
 ///

--- a/src/libstd/old_io/mod.rs
+++ b/src/libstd/old_io/mod.rs
@@ -1406,7 +1406,7 @@ pub trait Buffer: Reader {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::old_io::BufReader;
     ///
     /// let mut reader = BufReader::new(b"hello\nworld");

--- a/src/libstd/old_io/net/pipe.rs
+++ b/src/libstd/old_io/net/pipe.rs
@@ -52,7 +52,7 @@ impl UnixStream {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// # #![allow(unused_must_use)]
     /// use std::old_io::net::pipe::UnixStream;
     ///

--- a/src/libstd/old_io/stdio.rs
+++ b/src/libstd/old_io/stdio.rs
@@ -140,7 +140,7 @@ impl StdinReader {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::old_io;
     ///
     /// let mut stdin = old_io::stdin();

--- a/src/libstd/old_io/timer.rs
+++ b/src/libstd/old_io/timer.rs
@@ -115,7 +115,7 @@ impl Timer {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::old_io::Timer;
     /// use std::time::Duration;
     ///
@@ -128,7 +128,7 @@ impl Timer {
     /// ten_milliseconds.recv().unwrap();
     /// ```
     ///
-    /// ```rust
+    /// ```
     /// use std::old_io::Timer;
     /// use std::time::Duration;
     ///
@@ -167,7 +167,7 @@ impl Timer {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::old_io::Timer;
     /// use std::time::Duration;
     ///
@@ -186,7 +186,7 @@ impl Timer {
     /// ten_milliseconds.recv().unwrap();
     /// ```
     ///
-    /// ```rust
+    /// ```
     /// use std::old_io::Timer;
     /// use std::time::Duration;
     ///

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -125,7 +125,7 @@ pub const TMPBUF_SZ : uint = 1000;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::os;
 ///
 /// // We assume that we are in a valid directory.
@@ -145,7 +145,7 @@ pub fn getcwd() -> IoResult<Path> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::os;
 ///
 /// // We will iterate through the references to the element returned by os::env();
@@ -181,7 +181,7 @@ pub fn env_as_bytes() -> Vec<(Vec<u8>, Vec<u8>)> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::os;
 ///
 /// let key = "HOME";
@@ -223,7 +223,7 @@ fn byteify(s: OsString) -> Vec<u8> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::os;
 ///
 /// let key = "KEY";
@@ -263,7 +263,8 @@ pub fn unsetenv(n: &str) {
 /// environment variable.
 ///
 /// # Examples
-/// ```rust
+///
+/// ```
 /// use std::os;
 ///
 /// let key = "PATH";
@@ -295,7 +296,7 @@ pub fn split_paths<T: BytesContainer>(unparsed: T) -> Vec<Path> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::os;
 /// use std::old_path::Path;
 ///
@@ -356,7 +357,7 @@ pub fn dll_filename(base: &str) -> String {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::os;
 ///
 /// match os::self_exe_name() {
@@ -376,7 +377,7 @@ pub fn self_exe_name() -> Option<Path> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::os;
 ///
 /// match os::self_exe_path() {
@@ -405,7 +406,7 @@ pub fn self_exe_path() -> Option<Path> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::os;
 ///
 /// match os::homedir() {
@@ -494,7 +495,8 @@ pub fn tmpdir() -> Path {
 /// as is.
 ///
 /// # Examples
-/// ```rust
+///
+/// ```
 /// use std::os;
 /// use std::old_path::Path;
 ///
@@ -525,7 +527,8 @@ pub fn make_absolute(p: &Path) -> IoResult<Path> {
 /// whether the change was completed successfully or not.
 ///
 /// # Examples
-/// ```rust
+///
+/// ```
 /// use std::os;
 /// use std::old_path::Path;
 ///
@@ -546,7 +549,8 @@ pub fn errno() -> i32 {
 /// Return the string corresponding to an `errno()` value of `errnum`.
 ///
 /// # Examples
-/// ```rust
+///
+/// ```
 /// use std::os;
 ///
 /// // Same as println!("{}", last_os_error());
@@ -743,7 +747,7 @@ extern "system" {
 /// See `String::from_utf8_lossy` for details.
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::os;
 ///
 /// // Prints each argument on a separate line

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -855,7 +855,7 @@ impl<'a> cmp::Ord for Components<'a> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::path::PathBuf;
 ///
 /// let mut path = PathBuf::new("c:\\");
@@ -947,7 +947,7 @@ impl PathBuf {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::path::PathBuf;
     ///
     /// let mut buf = PathBuf::new("/");
@@ -1104,7 +1104,7 @@ impl AsOsStr for PathBuf {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::path::Path;
 ///
 /// let path = Path::new("/tmp/foo/bar.txt");
@@ -1209,7 +1209,7 @@ impl Path {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// use std::path::Path;
     ///
     /// let path = Path::new("/foo/bar");

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -426,7 +426,7 @@ pub fn random<T: Rand>() -> T {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::rand::{thread_rng, sample};
 ///
 /// let mut rng = thread_rng();

--- a/src/libstd/rand/reader.rs
+++ b/src/libstd/rand/reader.rs
@@ -24,7 +24,7 @@ use slice::SliceExt;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::rand::{reader, Rng};
 /// use std::old_io::MemReader;
 ///

--- a/src/libstd/sync/barrier.rs
+++ b/src/libstd/sync/barrier.rs
@@ -13,7 +13,7 @@ use sync::{Mutex, Condvar};
 /// A barrier enables multiple tasks to synchronize the beginning
 /// of some computation.
 ///
-/// ```rust
+/// ```
 /// use std::sync::{Arc, Barrier};
 /// use std::thread;
 ///

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -46,7 +46,7 @@ use fmt;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::sync::{Arc, Mutex};
 /// use std::thread;
 /// use std::sync::mpsc::channel;
@@ -84,7 +84,7 @@ use fmt;
 ///
 /// To recover from a poisoned mutex:
 ///
-/// ```rust
+/// ```
 /// use std::sync::{Arc, Mutex};
 /// use std::thread;
 ///
@@ -135,7 +135,7 @@ unsafe impl<T: Send> Sync for Mutex<T> { }
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::sync::{StaticMutex, MUTEX_INIT};
 ///
 /// static LOCK: StaticMutex = MUTEX_INIT;

--- a/src/libstd/sync/once.rs
+++ b/src/libstd/sync/once.rs
@@ -26,7 +26,7 @@ use sync::{StaticMutex, MUTEX_INIT};
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::sync::{Once, ONCE_INIT};
 ///
 /// static START: Once = ONCE_INIT;

--- a/src/libstd/sync/task_pool.rs
+++ b/src/libstd/sync/task_pool.rs
@@ -60,7 +60,7 @@ impl<'a> Drop for Sentinel<'a> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use std::sync::TaskPool;
 /// use std::iter::AdditiveIterator;
 /// use std::sync::mpsc::channel;

--- a/src/libunicode/u_str.rs
+++ b/src/libunicode/u_str.rs
@@ -481,7 +481,7 @@ impl<'a> Iterator for Utf16Items<'a> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// use unicode::str::Utf16Item::{ScalarValue, LoneSurrogate};
 ///
 /// // 𝄞mus<invalid>ic<invalid>


### PR DESCRIPTION
As suggested by @steveklabnik in #23254, I removed the redundant Rust syntax highlighting from the documentation.
