### PR TITLE
slice::from_raw_parts is preferred over transmuting a fresh raw::Slice

### DIFF
--- a/src/libcollections/btree/node.rs
+++ b/src/libcollections/btree/node.rs
@@ -348,14 +348,8 @@ impl<K, V> Node<K, V> {
     #[inline]
     pub fn as_slices<'a>(&'a self) -> (&'a [K], &'a [V]) {
         unsafe {(
-            mem::transmute(raw::Slice {
-                data: *self.keys as *const K,
-                len: self.len()
-            }),
-            mem::transmute(raw::Slice {
-                data: *self.vals as *const V,
-                len: self.len()
-            })
+            slice::from_raw_parts(*self.keys, self.len()),
+            slice::from_raw_parts(*self.vals, self.len()),
         )}
     }
 

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -24,7 +24,7 @@ use core::iter::{IntoIterator, FromIterator};
 use core::mem;
 use core::ops::{self, Deref, Add, Index};
 use core::ptr;
-use core::raw::Slice as RawSlice;
+use core::slice;
 use unicode::str as unicode_str;
 use unicode::str::Utf16Item;
 
@@ -468,11 +468,11 @@ impl String {
         unsafe {
             // Attempt to not use an intermediate buffer by just pushing bytes
             // directly onto this string.
-            let slice = RawSlice {
-                data: self.vec.as_ptr().offset(cur_len as isize),
-                len: 4,
-            };
-            let used = ch.encode_utf8(mem::transmute(slice)).unwrap_or(0);
+            let slice = slice::from_raw_parts_mut (
+                self.vec.as_mut_ptr().offset(cur_len as isize),
+                4
+            );
+            let used = ch.encode_utf8(slice).unwrap_or(0);
             self.vec.set_len(cur_len + used);
         }
     }

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -64,7 +64,6 @@ use core::ops::{Index, IndexMut, Deref, Add};
 use core::ops;
 use core::ptr;
 use core::ptr::Unique;
-use core::raw::Slice as RawSlice;
 use core::slice;
 use core::usize;
 
@@ -435,10 +434,7 @@ impl<T> Vec<T> {
         unsafe {
             let ptr = *self.ptr;
             assume(!ptr.is_null());
-            mem::transmute(RawSlice {
-                data: ptr,
-                len: self.len,
-            })
+            slice::from_raw_parts_mut(ptr, self.len)
         }
     }
 
@@ -1560,10 +1556,7 @@ impl<T> AsSlice<T> for Vec<T> {
         unsafe {
             let p = *self.ptr;
             assume(p != 0 as *mut T);
-            mem::transmute(RawSlice {
-                data: p,
-                len: self.len
-            })
+            slice::from_raw_parts(p, self.len)
         }
     }
 }

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -29,7 +29,7 @@ use core::num::{Int, UnsignedInt};
 use core::num::wrapping::WrappingOps;
 use core::ops::{Index, IndexMut};
 use core::ptr::{self, Unique};
-use core::raw::Slice as RawSlice;
+use core::slice;
 
 use core::hash::{Hash, Hasher};
 use core::cmp;
@@ -91,13 +91,13 @@ impl<T> VecDeque<T> {
     /// Turn ptr into a slice
     #[inline]
     unsafe fn buffer_as_slice(&self) -> &[T] {
-        mem::transmute(RawSlice { data: *self.ptr as *const T, len: self.cap })
+        slice::from_raw_parts(*self.ptr, self.cap)
     }
 
     /// Turn ptr into a mut slice
     #[inline]
     unsafe fn buffer_as_mut_slice(&mut self) -> &mut [T] {
-        mem::transmute(RawSlice { data: *self.ptr as *const T, len: self.cap })
+        slice::from_raw_parts_mut(*self.ptr, self.cap)
     }
 
     /// Moves an element out of the buffer

--- a/src/librustc_llvm/archive_ro.rs
+++ b/src/librustc_llvm/archive_ro.rs
@@ -14,8 +14,7 @@ use libc;
 use ArchiveRef;
 
 use std::ffi::CString;
-use std::mem;
-use std::raw;
+use std::slice;
 use std::path::Path;
 
 pub struct ArchiveRO {
@@ -62,10 +61,7 @@ impl ArchiveRO {
             if ptr.is_null() {
                 None
             } else {
-                Some(mem::transmute(raw::Slice {
-                    data: ptr,
-                    len: size as uint,
-                }))
+                Some(slice::from_raw_parts(ptr as *const u8, size as uint))
             }
         }
     }

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -26,7 +26,6 @@
 
 #![feature(box_syntax)]
 #![feature(collections)]
-#![feature(core)]
 #![feature(int_uint)]
 #![feature(libc)]
 #![feature(link_args)]
@@ -59,7 +58,7 @@ pub use self::Linkage::*;
 
 use std::ffi::CString;
 use std::cell::RefCell;
-use std::{raw, mem};
+use std::{slice, mem};
 use libc::{c_uint, c_ushort, uint64_t, c_int, size_t, c_char};
 use libc::{c_longlong, c_ulonglong, c_void};
 use debuginfo::{DIBuilderRef, DIDescriptor,
@@ -2227,10 +2226,7 @@ type RustStringRepr = *mut RefCell<Vec<u8>>;
 pub unsafe extern "C" fn rust_llvm_string_write_impl(sr: RustStringRef,
                                                      ptr: *const c_char,
                                                      size: size_t) {
-    let slice: &[u8] = mem::transmute(raw::Slice {
-        data: ptr as *const u8,
-        len: size as uint,
-    });
+    let slice = slice::from_raw_parts(ptr as *const u8, size as uint);
 
     let sr: RustStringRepr = mem::transmute(sr);
     (*sr).borrow_mut().push_all(slice);

--- a/src/libstd/old_io/mod.rs
+++ b/src/libstd/old_io/mod.rs
@@ -928,15 +928,15 @@ impl<'a> Reader for &'a mut (Reader+'a) {
 // Private function here because we aren't sure if we want to expose this as
 // API yet. If so, it should be a method on Vec.
 unsafe fn slice_vec_capacity<'a, T>(v: &'a mut Vec<T>, start: uint, end: uint) -> &'a mut [T] {
-    use raw::Slice;
+    use slice;
     use ptr::PtrExt;
 
     assert!(start <= end);
     assert!(end <= v.capacity());
-    transmute(Slice {
-        data: v.as_ptr().offset(start as int),
-        len: end - start
-    })
+    slice::from_raw_parts_mut(
+        v.as_mut_ptr().offset(start as int),
+        end - start
+    )
 }
 
 /// A `RefReader` is a struct implementing `Reader` which contains a reference

--- a/src/test/run-pass/method-mut-self-modifies-mut-slice-lvalue.rs
+++ b/src/test/run-pass/method-mut-self-modifies-mut-slice-lvalue.rs
@@ -12,7 +12,6 @@
 // type is `&mut [u8]`, passes in a pointer to the lvalue and not a
 // temporary. Issue #19147.
 
-use std::raw;
 use std::mem;
 use std::slice;
 use std::old_io::IoResult;
@@ -27,10 +26,10 @@ impl<'a> MyWriter for &'a mut [u8] {
 
         let write_len = buf.len();
         unsafe {
-            *self = mem::transmute(raw::Slice {
-                data: self.as_ptr().offset(write_len as int),
-                len: self.len() - write_len,
-            });
+            *self = slice::from_raw_parts(
+                self.as_ptr().offset(write_len as int),
+                self.len() - write_len
+            );
         }
 
         Ok(())

--- a/src/test/run-pass/method-mut-self-modifies-mut-slice-lvalue.rs
+++ b/src/test/run-pass/method-mut-self-modifies-mut-slice-lvalue.rs
@@ -26,8 +26,8 @@ impl<'a> MyWriter for &'a mut [u8] {
 
         let write_len = buf.len();
         unsafe {
-            *self = slice::from_raw_parts(
-                self.as_ptr().offset(write_len as int),
+            *self = slice::from_raw_parts_mut(
+                self.as_mut_ptr().offset(write_len as isize),
                 self.len() - write_len
             );
         }

--- a/src/test/run-pass/unsized3.rs
+++ b/src/test/run-pass/unsized3.rs
@@ -15,31 +15,32 @@
 
 use std::mem;
 use std::raw;
+use std::slice;
 
 struct Foo<T> {
     f: [T],
 }
 
 struct Bar {
-    f1: uint,
-    f2: [uint],
+    f1: usize,
+    f2: [usize],
 }
 
 struct Baz {
-    f1: uint,
+    f1: usize,
     f2: str,
 }
 
 trait Tr {
-    fn foo(&self) -> uint;
+    fn foo(&self) -> usize;
 }
 
 struct St {
-    f: uint
+    f: usize
 }
 
 impl Tr for St {
-    fn foo(&self) -> uint {
+    fn foo(&self) -> usize {
         self.f
     }
 }
@@ -67,18 +68,18 @@ pub fn main() {
         }
 
         let data: Box<Foo_<i32>> = box Foo_{f: [1, 2, 3] };
-        let x: &Foo<i32> = slice::from_raw_parts(&*data, 3);
+        let x: &Foo<i32> = mem::transmute(slice::from_raw_parts(&*data, 3));
         assert!(x.f.len() == 3);
         assert!(x.f[0] == 1);
 
         struct Baz_ {
-            f1: uint,
+            f1: usize,
             f2: [u8; 5],
         }
 
         let data: Box<_> = box Baz_ {
             f1: 42, f2: ['a' as u8, 'b' as u8, 'c' as u8, 'd' as u8, 'e' as u8] };
-        let x: &Baz = slice::from_raw_parts(&*data, 5);
+        let x: &Baz = mem::transmute(slice::from_raw_parts(&*data, 5));
         assert!(x.f1 == 42);
         let chs: Vec<char> = x.f2.chars().collect();
         assert!(chs.len() == 5);

--- a/src/test/run-pass/unsized3.rs
+++ b/src/test/run-pass/unsized3.rs
@@ -67,7 +67,7 @@ pub fn main() {
         }
 
         let data: Box<Foo_<i32>> = box Foo_{f: [1, 2, 3] };
-        let x: &Foo<i32> = mem::transmute(raw::Slice { len: 3, data: &*data });
+        let x: &Foo<i32> = slice::from_raw_parts(&*data, 3);
         assert!(x.f.len() == 3);
         assert!(x.f[0] == 1);
 
@@ -78,7 +78,7 @@ pub fn main() {
 
         let data: Box<_> = box Baz_ {
             f1: 42, f2: ['a' as u8, 'b' as u8, 'c' as u8, 'd' as u8, 'e' as u8] };
-        let x: &Baz = mem::transmute( raw::Slice { len: 5, data: &*data } );
+        let x: &Baz = slice::from_raw_parts(&*data, 5);
         assert!(x.f1 == 42);
         let chs: Vec<char> = x.f2.chars().collect();
         assert!(chs.len() == 5);


### PR DESCRIPTION
at least that's what the docs say: http://doc.rust-lang.org/std/slice/fn.from_raw_parts.html

A few situations got prettier. In some situations the mutability of the resulting and source pointers differed (and was cast away by transmute), the mutability matches now.
