### PR TITLE
implements read_into_string/read_into_vec for Read trait

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -213,6 +213,15 @@ pub trait Read {
         read_to_end(self, buf)
     }
 
+    /// Read all bytes until EOF in this source, returning them as a new `Vec`.
+    ///
+    /// See `read_to_end` for other semantics.
+    fn read_into_vec(&mut self) -> Result<Vec<u8>> {
+        let mut buf = Vec::new();
+        let res = self.read_to_end(&mut buf);
+        res.map(|_| buf)
+    }
+
     /// Read all bytes until EOF in this source, placing them into `buf`.
     ///
     /// # Errors
@@ -232,6 +241,15 @@ pub trait Read {
         // we pass it to our hardcoded `read_to_end` implementation which we
         // know is guaranteed to only read data into the end of the buffer.
         append_to_string(buf, |b| read_to_end(self, b))
+    }
+
+    /// Read all bytes until EOF in this source, returning them as a new buffer.
+    ///
+    /// See `read_to_string` for other semantics.
+    fn read_into_string(&mut self, buf: &mut String) -> Result<String> {
+        let mut buf = String::new();
+        let res = self.read_to_string(&mut buf);
+        res.map(|_| buf)
     }
 }
 


### PR DESCRIPTION
This implements RFC0841. It hasn't been decided the RFC gets accepted but I wanted to come up with an PR early on that I maintain as the RFC evolves.

It's also missing tests yet. It's my first real code change to the Rust project so I gotta figure out how to do things properly and run the test suite etc.
