### PR TITLE
Deprecate range, range_step, count, distributions

### DIFF
--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -33,6 +33,7 @@
 #![feature(unsafe_destructor)]
 #![feature(unique)]
 #![feature(unsafe_no_drop_flag)]
+#![feature(step_by)]
 #![cfg_attr(test, feature(rand, rustc_private, test))]
 #![cfg_attr(test, allow(deprecated))] // rand
 

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -92,7 +92,7 @@ use core::clone::Clone;
 use core::cmp::Ordering::{self, Greater, Less};
 use core::cmp::{self, Ord, PartialEq};
 use core::iter::{Iterator, IteratorExt};
-use core::iter::{range_step, MultiplicativeIterator};
+use core::iter::MultiplicativeIterator;
 use core::marker::Sized;
 use core::mem::size_of;
 use core::mem;
@@ -1387,7 +1387,7 @@ fn merge_sort<T, F>(v: &mut [T], mut compare: F) where F: FnMut(&T, &T) -> Order
     // We could hardcode the sorting comparisons here, and we could
     // manipulate/step the pointers themselves, rather than repeatedly
     // .offset-ing.
-    for start in range_step(0, len, insertion) {
+    for start in (0.. len).step_by(insertion) {
         // start <= i < len;
         for i in start..cmp::min(start + insertion, len) {
             // j satisfies: start <= j <= i;
@@ -1427,7 +1427,7 @@ fn merge_sort<T, F>(v: &mut [T], mut compare: F) where F: FnMut(&T, &T) -> Order
         // a time, placing the result in `buf_tmp`.
 
         // 0 <= start <= len.
-        for start in range_step(0, len, 2 * width) {
+        for start in (0..len).step_by(2 * width) {
             // manipulate pointers directly for speed (rather than
             // using a `for` loop with `range` and `.offset` inside
             // that loop).

--- a/src/libcore/prelude.rs
+++ b/src/libcore/prelude.rs
@@ -29,6 +29,7 @@ pub use marker::{Copy, Send, Sized, Sync};
 pub use ops::{Drop, Fn, FnMut, FnOnce};
 
 // Reexported functions
+#[allow(deprecated)]
 pub use iter::range;
 pub use mem::drop;
 

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -775,12 +775,12 @@ fn test_range_inclusive() {
 
 #[test]
 fn test_range_step() {
-    assert_eq!(range_step(0, 20, 5).collect::<Vec<int>>(), [0, 5, 10, 15]);
-    assert_eq!(range_step(20, 0, -5).collect::<Vec<int>>(), [20, 15, 10, 5]);
-    assert_eq!(range_step(20, 0, -6).collect::<Vec<int>>(), [20, 14, 8, 2]);
-    assert_eq!(range_step(200, 255, 50).collect::<Vec<u8>>(), [200, 250]);
-    assert_eq!(range_step(200, -5, 1).collect::<Vec<int>>(), []);
-    assert_eq!(range_step(200, 200, 1).collect::<Vec<int>>(), []);
+    assert_eq!((0..20).step_by(5).collect::<Vec<int>>(), [0, 5, 10, 15]);
+    assert_eq!((20..0).step_by(-5).collect::<Vec<int>>(), [20, 15, 10, 5]);
+    assert_eq!((20..0).step_by(-6).collect::<Vec<int>>(), [20, 14, 8, 2]);
+    assert_eq!((200..255).step_by(50).collect::<Vec<u8>>(), [200, 250]);
+    assert_eq!((200..-5).step_by(1).collect::<Vec<int>>(), []);
+    assert_eq!((200..200).step_by(1).collect::<Vec<int>>(), []);
 }
 
 #[test]

--- a/src/librand/distributions/mod.rs
+++ b/src/librand/distributions/mod.rs
@@ -17,8 +17,6 @@
 //! internally. The `IndependentSample` trait is for generating values
 //! that do not need to record state.
 
-#![unstable(feature = "rand")]
-
 use core::prelude::*;
 use core::num::{Float, Int};
 use core::marker::PhantomData;

--- a/src/librustc/middle/infer/combine.rs
+++ b/src/librustc/middle/infer/combine.rs
@@ -154,7 +154,7 @@ pub trait Combine<'tcx> : Sized {
                                                                  b_tys.len())));
             }
 
-            range(0, a_tys.len()).map(|i| {
+            (0.. a_tys.len()).map(|i| {
                 let a_ty = a_tys[i];
                 let b_ty = b_tys[i];
                 let v = variances.map_or(ty::Invariant, |v| v[i]);

--- a/src/librustc_back/lib.rs
+++ b/src/librustc_back/lib.rs
@@ -48,6 +48,7 @@
 #![feature(path_ext)]
 #![feature(std_misc)]
 #![feature(path_relative_from)]
+#![feature(step_by)]
 
 extern crate syntax;
 extern crate serialize;

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -48,7 +48,6 @@
 
 use std::fmt;
 use std::hash::{Hash, SipHasher, Hasher};
-use std::iter::range_step;
 use syntax::ast;
 use syntax::visit;
 
@@ -103,7 +102,7 @@ impl Svh {
 
         let hash = state.finish();
         return Svh {
-            hash: range_step(0, 64, 4).map(|i| hex(hash >> i)).collect()
+            hash: (0..64).step_by(4).map(|i| hex(hash >> i)).collect()
         };
 
         fn hex(b: u64) -> char {

--- a/src/librustc_trans/back/lto.rs
+++ b/src/librustc_trans/back/lto.rs
@@ -21,7 +21,6 @@ use libc;
 use flate;
 
 use std::ffi::CString;
-use std::iter;
 use std::mem;
 use std::num::Int;
 
@@ -62,7 +61,7 @@ pub fn run(sess: &session::Session, llmod: ModuleRef,
         let file = path.file_name().unwrap().to_str().unwrap();
         let file = &file[3..file.len() - 5]; // chop off lib/.rlib
         debug!("reading {}", file);
-        for i in iter::count(0, 1) {
+        for i in 0.. {
             let bc_encoded = time(sess.time_passes(),
                                   &format!("check for {}.{}.bytecode.deflate", name, i),
                                   (),
@@ -213,4 +212,3 @@ fn read_from_le_bytes<T: Int>(bytes: &[u8], position_in_bytes: uint) -> T {
 
     Int::from_le(data)
 }
-

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -16,8 +16,8 @@
 
 use prelude::v1::*;
 
+use ops::Range;
 use mem;
-use iter::Range;
 
 /// Extension methods for ASCII-subset only operations on owned strings
 #[unstable(feature = "std_misc",
@@ -270,7 +270,7 @@ pub fn escape_default(c: u8) -> EscapeDefault {
         _ => ([b'\\', b'x', hexify(c >> 4), hexify(c & 0xf)], 4),
     };
 
-    return EscapeDefault { range: range(0, len), data: data };
+    return EscapeDefault { range: (0.. len), data: data };
 
     fn hexify(b: u8) -> u8 {
         match b {

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -359,7 +359,7 @@ impl fmt::Display for Ipv6Addr {
                     let mut cur_span_len = 0;
                     let mut cur_span_at = 0;
 
-                    for i in range(0, 8) {
+                    for i in 0..8 {
                         if segments[i] == 0 {
                             if cur_span_len == 0 {
                                 cur_span_at = i;

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -586,7 +586,6 @@ pub fn get_exit_status() -> int {
 unsafe fn load_argc_and_argv(argc: int,
                              argv: *const *const c_char) -> Vec<Vec<u8>> {
     use ffi::CStr;
-    use iter::range;
 
     (0..argc).map(|i| {
         CStr::from_ptr(*argv.offset(i)).to_bytes().to_vec()

--- a/src/libstd/prelude/v1.rs
+++ b/src/libstd/prelude/v1.rs
@@ -57,6 +57,7 @@
 // NB: remove when I/O reform lands
 #[doc(no_inline)] pub use old_io::{Buffer, Writer, Reader, Seek, BufferPrelude};
 // NB: remove when range syntax lands
+#[allow(deprecated)]
 #[doc(no_inline)] pub use iter::range;
 
 #[doc(no_inline)] pub use num::wrapping::{Wrapping, WrappingOps};

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -286,7 +286,7 @@ pub fn args() -> Args {
     let vec = unsafe {
         let (argc, argv) = (*_NSGetArgc() as isize,
                             *_NSGetArgv() as *const *const c_char);
-        range(0, argc as isize).map(|i| {
+        (0.. argc as isize).map(|i| {
             let bytes = CStr::from_ptr(*argv.offset(i)).to_bytes().to_vec();
             OsStringExt::from_vec(bytes)
         }).collect::<Vec<_>>()

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -77,7 +77,6 @@ use owned_slice::OwnedSlice;
 
 use std::collections::HashSet;
 use std::io::prelude::*;
-use std::iter;
 use std::mem;
 use std::num::Float;
 use std::path::{Path, PathBuf};
@@ -749,7 +748,7 @@ impl<'a> Parser<'a> {
         // would encounter a `>` and stop. This lets the parser handle trailing
         // commas in generic parameters, because it can stop either after
         // parsing a type or after parsing a comma.
-        for i in iter::count(0, 1) {
+        for i in 0.. {
             if self.check(&token::Gt)
                 || self.token == token::BinOp(token::Shr)
                 || self.token == token::Ge


### PR DESCRIPTION
This commit deprecates the `count`, `range` and `range_step` functions
in `iter`, in favor of range notation. To recover all existing
functionality, a new `step_by` adapter is provided directly on `ops::Range`
and `ops::RangeFrom`.

[breaking-change]

r? @alexcrichton 
