### PR TITLE
Split rustdoc summary lines in a smarter way

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -407,7 +407,7 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> io::Result<String> {
                         ty: shortty(item),
                         name: item.name.clone().unwrap(),
                         path: fqp[..fqp.len() - 1].connect("::"),
-                        desc: shorter(item.doc_value()).to_string(),
+                        desc: shorter(item.doc_value()),
                         parent: Some(did),
                     });
                 },
@@ -876,7 +876,7 @@ impl DocFolder for Cache {
                         ty: shortty(&item),
                         name: s.to_string(),
                         path: path.connect("::").to_string(),
-                        desc: shorter(item.doc_value()).to_string(),
+                        desc: shorter(item.doc_value()),
                         parent: parent,
                     });
                 }
@@ -1467,13 +1467,14 @@ fn full_path(cx: &Context, item: &clean::Item) -> String {
     return s
 }
 
-fn shorter<'a>(s: Option<&'a str>) -> &'a str {
+fn shorter<'a>(s: Option<&'a str>) -> String {
     match s {
-        Some(s) => match s.find("\n\n") {
-            Some(pos) => &s[..pos],
-            None => s,
-        },
-        None => ""
+        Some(s) => s.lines().take_while(|line|{
+            (*line).chars().any(|chr|{
+                !chr.is_whitespace()
+            })
+        }).collect::<Vec<_>>().connect("\n"),
+        None => "".to_string()
     }
 }
 
@@ -1603,7 +1604,7 @@ fn item_module(w: &mut fmt::Formatter, cx: &Context,
                     </tr>
                 ",
                 *myitem.name.as_ref().unwrap(),
-                Markdown(shorter(myitem.doc_value())),
+                Markdown(&shorter(myitem.doc_value())[..]),
                 class = shortty(myitem),
                 href = item_path(myitem),
                 title = full_path(cx, myitem),


### PR DESCRIPTION
Previously it would fail on a trivial case like

```
/// Summary line
/// <trailing space>
/// Regular content
```

Compliant markdown preprocessor would render that as two separate paragraphs, but our summary line
extractor interprets both lines as the same paragraph and includes both into the short summary resulting in
![screenshot from 2015-03-13 22 47 08](https://cloud.githubusercontent.com/assets/679122/6648596/7ef792b2-c9e4-11e4-9c19-704c288ec4de.png)
