### PR TITLE
std: Stabilize portions of `std::os::$platform`

### DIFF
--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -210,7 +210,7 @@ pub fn getenv_as_bytes(n: &str) -> Option<Vec<u8>> {
 
 #[cfg(unix)]
 fn byteify(s: OsString) -> Vec<u8> {
-    use os::unix::*;
+    use os::unix::prelude::*;
     s.into_vec()
 }
 #[cfg(windows)]
@@ -238,7 +238,7 @@ fn byteify(s: OsString) -> Vec<u8> {
 pub fn setenv<T: BytesContainer>(n: &str, v: T) {
     #[cfg(unix)]
     fn _setenv(n: &str, v: &[u8]) {
-        use os::unix::*;
+        use os::unix::prelude::*;
         let v: OsString = OsStringExt::from_vec(v.to_vec());
         env::set_var(n, &v)
     }
@@ -1705,13 +1705,13 @@ mod tests {
 
         #[cfg(not(windows))]
         fn get_fd(file: &File) -> libc::c_int {
-            use os::unix::AsRawFd;
+            use os::unix::prelude::*;
             file.as_raw_fd()
         }
 
         #[cfg(windows)]
         fn get_fd(file: &File) -> libc::HANDLE {
-            use os::windows::AsRawHandle;
+            use os::windows::prelude::*;
             file.as_raw_handle()
         }
 

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -573,7 +573,7 @@ mod tests {
     #[cfg(all(unix, not(target_os="android")))]
     #[test]
     fn signal_reported_right() {
-        use os::unix::ExitStatusExt;
+        use os::unix::process::ExitStatusExt;
 
         let p = Command::new("/bin/sh").arg("-c").arg("kill -9 $$").spawn();
         assert!(p.is_ok());
@@ -633,7 +633,7 @@ mod tests {
     #[cfg(all(unix, not(target_os="android")))]
     #[test]
     fn uid_works() {
-        use os::unix::*;
+        use os::unix::prelude::*;
         use libc;
         let mut p = Command::new("/bin/sh")
                             .arg("-c").arg("true")
@@ -646,7 +646,7 @@ mod tests {
     #[cfg(all(unix, not(target_os="android")))]
     #[test]
     fn uid_to_root_fails() {
-        use os::unix::*;
+        use os::unix::prelude::*;
         use libc;
 
         // if we're already root, this isn't a valid test. Most of the bots run

--- a/src/libstd/sys/unix/ext.rs
+++ b/src/libstd/sys/unix/ext.rs
@@ -29,183 +29,206 @@
 //! }
 //! ```
 
-#![unstable(feature = "std_misc")]
+#![stable(feature = "rust1", since = "1.0.0")]
 
-use prelude::v1::*;
+/// Unix-specific extensions to general I/O primitives
+#[unstable(feature = "io_ext",
+           reason = "may want a slightly different organization or a more \
+                     general file descriptor primitive")]
+pub mod io {
+    #[allow(deprecated)] use old_io;
+    use fs;
+    use libc;
+    use net;
+    use sys_common::AsInner;
 
-use ffi::{CString, NulError, OsStr, OsString};
-use fs::{self, Permissions, OpenOptions};
-use net;
-use mem;
-use process;
-use sys;
-use sys::os_str::Buf;
-use sys_common::{AsInner, AsInnerMut, IntoInner, FromInner};
-use libc::{self, gid_t, uid_t};
+    /// Raw file descriptors.
+    pub type Fd = libc::c_int;
 
-#[allow(deprecated)] use old_io;
-
-/// Raw file descriptors.
-pub type Fd = libc::c_int;
-
-/// Extract raw file descriptor
-pub trait AsRawFd {
-    /// Extract the raw file descriptor, without taking any ownership.
-    fn as_raw_fd(&self) -> Fd;
-}
-
-#[allow(deprecated)]
-impl AsRawFd for old_io::fs::File {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
+    /// Extract raw file descriptor
+    pub trait AsRawFd {
+        /// Extract the raw file descriptor, without taking any ownership.
+        fn as_raw_fd(&self) -> Fd;
     }
-}
 
-impl AsRawFd for fs::File {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd().raw()
+    #[allow(deprecated)]
+    impl AsRawFd for old_io::fs::File {
+        fn as_raw_fd(&self) -> Fd {
+            self.as_inner().fd()
+        }
     }
-}
 
-#[allow(deprecated)]
-impl AsRawFd for old_io::pipe::PipeStream {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
+    impl AsRawFd for fs::File {
+        fn as_raw_fd(&self) -> Fd {
+            self.as_inner().fd().raw()
+        }
     }
-}
 
-#[allow(deprecated)]
-impl AsRawFd for old_io::net::pipe::UnixStream {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
+    #[allow(deprecated)]
+    impl AsRawFd for old_io::pipe::PipeStream {
+        fn as_raw_fd(&self) -> Fd {
+            self.as_inner().fd()
+        }
     }
-}
 
-#[allow(deprecated)]
-impl AsRawFd for old_io::net::pipe::UnixListener {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
+    #[allow(deprecated)]
+    impl AsRawFd for old_io::net::pipe::UnixStream {
+        fn as_raw_fd(&self) -> Fd {
+            self.as_inner().fd()
+        }
     }
-}
 
-#[allow(deprecated)]
-impl AsRawFd for old_io::net::pipe::UnixAcceptor {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
+    #[allow(deprecated)]
+    impl AsRawFd for old_io::net::pipe::UnixListener {
+        fn as_raw_fd(&self) -> Fd {
+            self.as_inner().fd()
+        }
     }
-}
 
-#[allow(deprecated)]
-impl AsRawFd for old_io::net::tcp::TcpStream {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
+    #[allow(deprecated)]
+    impl AsRawFd for old_io::net::pipe::UnixAcceptor {
+        fn as_raw_fd(&self) -> Fd {
+            self.as_inner().fd()
+        }
     }
-}
 
-#[allow(deprecated)]
-impl AsRawFd for old_io::net::tcp::TcpListener {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
+    #[allow(deprecated)]
+    impl AsRawFd for old_io::net::tcp::TcpStream {
+        fn as_raw_fd(&self) -> Fd {
+            self.as_inner().fd()
+        }
     }
-}
 
-#[allow(deprecated)]
-impl AsRawFd for old_io::net::tcp::TcpAcceptor {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
+    #[allow(deprecated)]
+    impl AsRawFd for old_io::net::tcp::TcpListener {
+        fn as_raw_fd(&self) -> Fd {
+            self.as_inner().fd()
+        }
     }
-}
 
-#[allow(deprecated)]
-impl AsRawFd for old_io::net::udp::UdpSocket {
-    fn as_raw_fd(&self) -> Fd {
-        self.as_inner().fd()
+    #[allow(deprecated)]
+    impl AsRawFd for old_io::net::tcp::TcpAcceptor {
+        fn as_raw_fd(&self) -> Fd {
+            self.as_inner().fd()
+        }
     }
-}
 
-impl AsRawFd for net::TcpStream {
-    fn as_raw_fd(&self) -> Fd { *self.as_inner().socket().as_inner() }
-}
-impl AsRawFd for net::TcpListener {
-    fn as_raw_fd(&self) -> Fd { *self.as_inner().socket().as_inner() }
-}
-impl AsRawFd for net::UdpSocket {
-    fn as_raw_fd(&self) -> Fd { *self.as_inner().socket().as_inner() }
+    #[allow(deprecated)]
+    impl AsRawFd for old_io::net::udp::UdpSocket {
+        fn as_raw_fd(&self) -> Fd {
+            self.as_inner().fd()
+        }
+    }
+
+    impl AsRawFd for net::TcpStream {
+        fn as_raw_fd(&self) -> Fd { *self.as_inner().socket().as_inner() }
+    }
+    impl AsRawFd for net::TcpListener {
+        fn as_raw_fd(&self) -> Fd { *self.as_inner().socket().as_inner() }
+    }
+    impl AsRawFd for net::UdpSocket {
+        fn as_raw_fd(&self) -> Fd { *self.as_inner().socket().as_inner() }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // OsString and OsStr
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Unix-specific extensions to `OsString`.
-pub trait OsStringExt {
-    /// Create an `OsString` from a byte vector.
-    fn from_vec(vec: Vec<u8>) -> Self;
+/// Unix-specific extension to the primitives in the `std::ffi` module
+#[stable(feature = "rust1", since = "1.0.0")]
+pub mod ffi {
+    use ffi::{CString, NulError, OsStr, OsString};
+    use mem;
+    use prelude::v1::*;
+    use sys::os_str::Buf;
+    use sys_common::{FromInner, IntoInner, AsInner};
 
-    /// Yield the underlying byte vector of this `OsString`.
-    fn into_vec(self) -> Vec<u8>;
-}
+    /// Unix-specific extensions to `OsString`.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait OsStringExt {
+        /// Create an `OsString` from a byte vector.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn from_vec(vec: Vec<u8>) -> Self;
 
-impl OsStringExt for OsString {
-    fn from_vec(vec: Vec<u8>) -> OsString {
-        FromInner::from_inner(Buf { inner: vec })
+        /// Yield the underlying byte vector of this `OsString`.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn into_vec(self) -> Vec<u8>;
     }
 
-    fn into_vec(self) -> Vec<u8> {
-        self.into_inner().inner
+    #[stable(feature = "rust1", since = "1.0.0")]
+    impl OsStringExt for OsString {
+        fn from_vec(vec: Vec<u8>) -> OsString {
+            FromInner::from_inner(Buf { inner: vec })
+        }
+        fn into_vec(self) -> Vec<u8> {
+            self.into_inner().inner
+        }
+    }
+
+    /// Unix-specific extensions to `OsStr`.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait OsStrExt {
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn from_bytes(slice: &[u8]) -> &Self;
+
+        /// Get the underlying byte view of the `OsStr` slice.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn as_bytes(&self) -> &[u8];
+
+        /// Convert the `OsStr` slice into a `CString`.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn to_cstring(&self) -> Result<CString, NulError>;
+    }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    impl OsStrExt for OsStr {
+        fn from_bytes(slice: &[u8]) -> &OsStr {
+            unsafe { mem::transmute(slice) }
+        }
+        fn as_bytes(&self) -> &[u8] {
+            &self.as_inner().inner
+        }
+        fn to_cstring(&self) -> Result<CString, NulError> {
+            CString::new(self.as_bytes())
+        }
     }
 }
 
-/// Unix-specific extensions to `OsStr`.
-pub trait OsStrExt {
-    fn from_bytes(slice: &[u8]) -> &OsStr;
+/// Unix-specific extensions to primitives in the `std::fs` module.
+#[unstable(feature = "fs_ext",
+           reason = "may want a more useful mode abstraction")]
+pub mod fs {
+    use sys_common::{FromInner, AsInner, AsInnerMut};
+    use fs::{Permissions, OpenOptions};
 
-    /// Get the underlying byte view of the `OsStr` slice.
-    fn as_bytes(&self) -> &[u8];
-
-    /// Convert the `OsStr` slice into a `CString`.
-    fn to_cstring(&self) -> Result<CString, NulError>;
-}
-
-impl OsStrExt for OsStr {
-    fn from_bytes(slice: &[u8]) -> &OsStr {
-        unsafe { mem::transmute(slice) }
-    }
-    fn as_bytes(&self) -> &[u8] {
-        &self.as_inner().inner
+    /// Unix-specific extensions to `Permissions`
+    pub trait PermissionsExt {
+        fn mode(&self) -> i32;
+        fn set_mode(&mut self, mode: i32);
     }
 
-    fn to_cstring(&self) -> Result<CString, NulError> {
-        CString::new(self.as_bytes())
+    impl PermissionsExt for Permissions {
+        fn mode(&self) -> i32 { self.as_inner().mode() }
+
+        fn set_mode(&mut self, mode: i32) {
+            *self = FromInner::from_inner(FromInner::from_inner(mode));
+        }
     }
-}
 
-// Unix-specific extensions to `Permissions`
-pub trait PermissionsExt {
-    fn mode(&self) -> i32;
-    fn set_mode(&mut self, mode: i32);
-}
-
-impl PermissionsExt for Permissions {
-    fn mode(&self) -> i32 { self.as_inner().mode() }
-
-    fn set_mode(&mut self, mode: i32) {
-        *self = FromInner::from_inner(FromInner::from_inner(mode));
+    /// Unix-specific extensions to `OpenOptions`
+    pub trait OpenOptionsExt {
+        /// Set the mode bits that a new file will be created with.
+        ///
+        /// If a new file is created as part of a `File::open_opts` call then this
+        /// specified `mode` will be used as the permission bits for the new file.
+        fn mode(&mut self, mode: i32) -> &mut Self;
     }
-}
 
-// Unix-specific extensions to `OpenOptions`
-pub trait OpenOptionsExt {
-    /// Set the mode bits that a new file will be created with.
-    ///
-    /// If a new file is created as part of a `File::open_opts` call then this
-    /// specified `mode` will be used as the permission bits for the new file.
-    fn mode(&mut self, mode: i32) -> &mut Self;
-}
-
-impl OpenOptionsExt for OpenOptions {
-    fn mode(&mut self, mode: i32) -> &mut OpenOptions {
-        self.as_inner_mut().mode(mode); self
+    impl OpenOptionsExt for OpenOptions {
+        fn mode(&mut self, mode: i32) -> &mut OpenOptions {
+            self.as_inner_mut().mode(mode); self
+        }
     }
 }
 
@@ -213,41 +236,58 @@ impl OpenOptionsExt for OpenOptions {
 // Process and Command
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Unix-specific extensions to the `std::process::Command` builder
-pub trait CommandExt {
-    /// Sets the child process's user id. This translates to a
-    /// `setuid` call in the child process. Failure in the `setuid`
-    /// call will cause the spawn to fail.
-    fn uid(&mut self, id: uid_t) -> &mut process::Command;
+/// Unix-specific extensions to primitives in the `std::process` module.
+#[stable(feature = "rust1", since = "1.0.0")]
+pub mod process {
+    use prelude::v1::*;
+    use libc::{uid_t, gid_t};
+    use process;
+    use sys;
+    use sys_common::{AsInnerMut, AsInner};
 
-    /// Similar to `uid`, but sets the group id of the child process. This has
-    /// the same semantics as the `uid` field.
-    fn gid(&mut self, id: gid_t) -> &mut process::Command;
-}
+    /// Unix-specific extensions to the `std::process::Command` builder
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait CommandExt {
+        /// Sets the child process's user id. This translates to a
+        /// `setuid` call in the child process. Failure in the `setuid`
+        /// call will cause the spawn to fail.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn uid(&mut self, id: uid_t) -> &mut process::Command;
 
-impl CommandExt for process::Command {
-    fn uid(&mut self, id: uid_t) -> &mut process::Command {
-        self.as_inner_mut().uid = Some(id);
-        self
+        /// Similar to `uid`, but sets the group id of the child process. This has
+        /// the same semantics as the `uid` field.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn gid(&mut self, id: gid_t) -> &mut process::Command;
     }
 
-    fn gid(&mut self, id: gid_t) -> &mut process::Command {
-        self.as_inner_mut().gid = Some(id);
-        self
+    #[stable(feature = "rust1", since = "1.0.0")]
+    impl CommandExt for process::Command {
+        fn uid(&mut self, id: uid_t) -> &mut process::Command {
+            self.as_inner_mut().uid = Some(id);
+            self
+        }
+
+        fn gid(&mut self, id: gid_t) -> &mut process::Command {
+            self.as_inner_mut().gid = Some(id);
+            self
+        }
     }
-}
 
-/// Unix-specific extensions to `std::process::ExitStatus`
-pub trait ExitStatusExt {
-    /// If the process was terminated by a signal, returns that signal.
-    fn signal(&self) -> Option<i32>;
-}
+    /// Unix-specific extensions to `std::process::ExitStatus`
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait ExitStatusExt {
+        /// If the process was terminated by a signal, returns that signal.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn signal(&self) -> Option<i32>;
+    }
 
-impl ExitStatusExt for process::ExitStatus {
-    fn signal(&self) -> Option<i32> {
-        match *self.as_inner() {
-            sys::process2::ExitStatus::Signal(s) => Some(s),
-            _ => None
+    #[stable(feature = "rust1", since = "1.0.0")]
+    impl ExitStatusExt for process::ExitStatus {
+        fn signal(&self) -> Option<i32> {
+            match *self.as_inner() {
+                sys::process2::ExitStatus::Signal(s) => Some(s),
+                _ => None
+            }
         }
     }
 }
@@ -259,9 +299,14 @@ impl ExitStatusExt for process::ExitStatus {
 /// A prelude for conveniently writing platform-specific code.
 ///
 /// Includes all extension traits, and some important type definitions.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub mod prelude {
     #[doc(no_inline)]
-    pub use super::{Fd, AsRawFd, OsStrExt, OsStringExt, PermissionsExt};
+    pub use super::io::{Fd, AsRawFd};
+    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
+    pub use super::ffi::{OsStrExt, OsStringExt};
     #[doc(no_inline)]
-    pub use super::{CommandExt, ExitStatusExt};
+    pub use super::fs::{PermissionsExt, OpenOptionsExt};
+    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
+    pub use super::process::{CommandExt, ExitStatusExt};
 }

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -13,7 +13,7 @@
 #![allow(unused_imports)] // lots of cfg code here
 
 use prelude::v1::*;
-use os::unix::*;
+use os::unix::prelude::*;
 
 use error::Error as StdError;
 use ffi::{CString, CStr, OsString, OsStr, AsOsStr};

--- a/src/libstd/sys/unix/process2.rs
+++ b/src/libstd/sys/unix/process2.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use prelude::v1::*;
+use os::unix::prelude::*;
 
 use collections::HashMap;
 use env;
@@ -17,7 +18,6 @@ use fmt;
 use io::{self, Error, ErrorKind};
 use libc::{self, pid_t, c_void, c_int, gid_t, uid_t};
 use mem;
-use os::unix::OsStrExt;
 use ptr;
 use sys::pipe2::AnonPipe;
 use sys::{self, retry, c, cvt};

--- a/src/libstd/sys/windows/ext.rs
+++ b/src/libstd/sys/windows/ext.rs
@@ -14,197 +14,225 @@
 //! descriptors, and sockets, but its functionality will grow over
 //! time.
 
-#![unstable(feature = "std_misc")]
+#![stable(feature = "rust1", since = "1.0.0")]
 
-pub use sys_common::wtf8::{Wtf8Buf, EncodeWide};
+#[unstable(feature = "io_ext",
+           reason = "organization may change slightly and the primitives \
+                     provided may be tweaked")]
+pub mod io {
+    use fs;
+    use libc;
+    use net;
+    use sys_common::AsInner;
 
-use ffi::{OsStr, OsString};
-use fs::{self, OpenOptions};
-use libc;
-use net;
-use sys::os_str::Buf;
-use sys_common::{AsInner, FromInner, AsInnerMut};
+    #[allow(deprecated)]
+    use old_io;
 
-#[allow(deprecated)]
-use old_io;
+    /// Raw HANDLEs.
+    pub type Handle = libc::HANDLE;
 
-/// Raw HANDLEs.
-pub type Handle = libc::HANDLE;
+    /// Raw SOCKETs.
+    pub type Socket = libc::SOCKET;
 
-/// Raw SOCKETs.
-pub type Socket = libc::SOCKET;
+    /// Extract raw handles.
+    pub trait AsRawHandle {
+        /// Extract the raw handle, without taking any ownership.
+        fn as_raw_handle(&self) -> Handle;
+    }
 
-/// Extract raw handles.
-pub trait AsRawHandle {
-    /// Extract the raw handle, without taking any ownership.
-    fn as_raw_handle(&self) -> Handle;
-}
+    #[allow(deprecated)]
+    impl AsRawHandle for old_io::fs::File {
+        fn as_raw_handle(&self) -> Handle {
+            self.as_inner().handle()
+        }
+    }
 
-#[allow(deprecated)]
-impl AsRawHandle for old_io::fs::File {
-    fn as_raw_handle(&self) -> Handle {
-        self.as_inner().handle()
+    impl AsRawHandle for fs::File {
+        fn as_raw_handle(&self) -> Handle {
+            self.as_inner().handle().raw()
+        }
+    }
+
+    #[allow(deprecated)]
+    impl AsRawHandle for old_io::pipe::PipeStream {
+        fn as_raw_handle(&self) -> Handle {
+            self.as_inner().handle()
+        }
+    }
+
+    #[allow(deprecated)]
+    impl AsRawHandle for old_io::net::pipe::UnixStream {
+        fn as_raw_handle(&self) -> Handle {
+            self.as_inner().handle()
+        }
+    }
+
+    #[allow(deprecated)]
+    impl AsRawHandle for old_io::net::pipe::UnixListener {
+        fn as_raw_handle(&self) -> Handle {
+            self.as_inner().handle()
+        }
+    }
+
+    #[allow(deprecated)]
+    impl AsRawHandle for old_io::net::pipe::UnixAcceptor {
+        fn as_raw_handle(&self) -> Handle {
+            self.as_inner().handle()
+        }
+    }
+
+    /// Extract raw sockets.
+    pub trait AsRawSocket {
+        fn as_raw_socket(&self) -> Socket;
+    }
+
+    #[allow(deprecated)]
+    impl AsRawSocket for old_io::net::tcp::TcpStream {
+        fn as_raw_socket(&self) -> Socket {
+            self.as_inner().fd()
+        }
+    }
+
+    #[allow(deprecated)]
+    impl AsRawSocket for old_io::net::tcp::TcpListener {
+        fn as_raw_socket(&self) -> Socket {
+            self.as_inner().socket()
+        }
+    }
+
+    #[allow(deprecated)]
+    impl AsRawSocket for old_io::net::tcp::TcpAcceptor {
+        fn as_raw_socket(&self) -> Socket {
+            self.as_inner().socket()
+        }
+    }
+
+    #[allow(deprecated)]
+    impl AsRawSocket for old_io::net::udp::UdpSocket {
+        fn as_raw_socket(&self) -> Socket {
+            self.as_inner().fd()
+        }
+    }
+
+    impl AsRawSocket for net::TcpStream {
+        fn as_raw_socket(&self) -> Socket { *self.as_inner().socket().as_inner() }
+    }
+    impl AsRawSocket for net::TcpListener {
+        fn as_raw_socket(&self) -> Socket { *self.as_inner().socket().as_inner() }
+    }
+    impl AsRawSocket for net::UdpSocket {
+        fn as_raw_socket(&self) -> Socket { *self.as_inner().socket().as_inner() }
     }
 }
 
-impl AsRawHandle for fs::File {
-    fn as_raw_handle(&self) -> Handle {
-        self.as_inner().handle().raw()
+/// Windows-specific extensions to the primitives in the `std::ffi` module.
+#[stable(feature = "rust1", since = "1.0.0")]
+pub mod ffi {
+    use ffi::{OsString, OsStr};
+    use sys::os_str::Buf;
+    use sys_common::wtf8::Wtf8Buf;
+    use sys_common::{FromInner, AsInner};
+
+    pub use sys_common::wtf8::EncodeWide;
+
+    /// Windows-specific extensions to `OsString`.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait OsStringExt {
+        /// Create an `OsString` from a potentially ill-formed UTF-16 slice of
+        /// 16-bit code units.
+        ///
+        /// This is lossless: calling `.encode_wide()` on the resulting string
+        /// will always return the original code units.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn from_wide(wide: &[u16]) -> Self;
+    }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    impl OsStringExt for OsString {
+        fn from_wide(wide: &[u16]) -> OsString {
+            FromInner::from_inner(Buf { inner: Wtf8Buf::from_wide(wide) })
+        }
+    }
+
+    /// Windows-specific extensions to `OsStr`.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait OsStrExt {
+        /// Re-encode an `OsStr` as a wide character sequence,
+        /// i.e. potentially ill-formed UTF-16.
+        ///
+        /// This is lossless. Note that the encoding does not include a final
+        /// null.
+        #[stable(feature = "rust1", since = "1.0.0")]
+        fn encode_wide(&self) -> EncodeWide;
+    }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    impl OsStrExt for OsStr {
+        fn encode_wide(&self) -> EncodeWide {
+            self.as_inner().inner.encode_wide()
+        }
     }
 }
 
-#[allow(deprecated)]
-impl AsRawHandle for old_io::pipe::PipeStream {
-    fn as_raw_handle(&self) -> Handle {
-        self.as_inner().handle()
+/// Windows-specific extensions for the primitives in `std::fs`
+#[unstable(feature = "fs_ext", reason = "may require more thought/methods")]
+pub mod fs {
+    use fs::OpenOptions;
+    use sys_common::AsInnerMut;
+
+    /// Windows-specific extensions to `OpenOptions`
+    pub trait OpenOptionsExt {
+        /// Override the `dwDesiredAccess` argument to the call to `CreateFile`
+        /// with the specified value.
+        fn desired_access(&mut self, access: i32) -> &mut Self;
+
+        /// Override the `dwCreationDisposition` argument to the call to
+        /// `CreateFile` with the specified value.
+        ///
+        /// This will override any values of the standard `create` flags, for
+        /// example.
+        fn creation_disposition(&mut self, val: i32) -> &mut Self;
+
+        /// Override the `dwFlagsAndAttributes` argument to the call to
+        /// `CreateFile` with the specified value.
+        ///
+        /// This will override any values of the standard flags on the
+        /// `OpenOptions` structure.
+        fn flags_and_attributes(&mut self, val: i32) -> &mut Self;
+
+        /// Override the `dwShareMode` argument to the call to `CreateFile` with
+        /// the specified value.
+        ///
+        /// This will override any values of the standard flags on the
+        /// `OpenOptions` structure.
+        fn share_mode(&mut self, val: i32) -> &mut Self;
     }
-}
 
-#[allow(deprecated)]
-impl AsRawHandle for old_io::net::pipe::UnixStream {
-    fn as_raw_handle(&self) -> Handle {
-        self.as_inner().handle()
-    }
-}
-
-#[allow(deprecated)]
-impl AsRawHandle for old_io::net::pipe::UnixListener {
-    fn as_raw_handle(&self) -> Handle {
-        self.as_inner().handle()
-    }
-}
-
-#[allow(deprecated)]
-impl AsRawHandle for old_io::net::pipe::UnixAcceptor {
-    fn as_raw_handle(&self) -> Handle {
-        self.as_inner().handle()
-    }
-}
-
-/// Extract raw sockets.
-pub trait AsRawSocket {
-    fn as_raw_socket(&self) -> Socket;
-}
-
-#[allow(deprecated)]
-impl AsRawSocket for old_io::net::tcp::TcpStream {
-    fn as_raw_socket(&self) -> Socket {
-        self.as_inner().fd()
-    }
-}
-
-#[allow(deprecated)]
-impl AsRawSocket for old_io::net::tcp::TcpListener {
-    fn as_raw_socket(&self) -> Socket {
-        self.as_inner().socket()
-    }
-}
-
-#[allow(deprecated)]
-impl AsRawSocket for old_io::net::tcp::TcpAcceptor {
-    fn as_raw_socket(&self) -> Socket {
-        self.as_inner().socket()
-    }
-}
-
-#[allow(deprecated)]
-impl AsRawSocket for old_io::net::udp::UdpSocket {
-    fn as_raw_socket(&self) -> Socket {
-        self.as_inner().fd()
-    }
-}
-
-impl AsRawSocket for net::TcpStream {
-    fn as_raw_socket(&self) -> Socket { *self.as_inner().socket().as_inner() }
-}
-impl AsRawSocket for net::TcpListener {
-    fn as_raw_socket(&self) -> Socket { *self.as_inner().socket().as_inner() }
-}
-impl AsRawSocket for net::UdpSocket {
-    fn as_raw_socket(&self) -> Socket { *self.as_inner().socket().as_inner() }
-}
-
-/// Windows-specific extensions to `OsString`.
-pub trait OsStringExt {
-    /// Create an `OsString` from a potentially ill-formed UTF-16 slice of 16-bit code units.
-    ///
-    /// This is lossless: calling `.encode_wide()` on the resulting string
-    /// will always return the original code units.
-    fn from_wide(wide: &[u16]) -> Self;
-}
-
-impl OsStringExt for OsString {
-    fn from_wide(wide: &[u16]) -> OsString {
-        FromInner::from_inner(Buf { inner: Wtf8Buf::from_wide(wide) })
-    }
-}
-
-/// Windows-specific extensions to `OsStr`.
-pub trait OsStrExt {
-    /// Re-encode an `OsStr` as a wide character sequence,
-    /// i.e. potentially ill-formed UTF-16.
-    ///
-    /// This is lossless. Note that the encoding does not include a final null.
-    fn encode_wide(&self) -> EncodeWide;
-}
-
-impl OsStrExt for OsStr {
-    fn encode_wide(&self) -> EncodeWide {
-        self.as_inner().inner.encode_wide()
-    }
-}
-
-// Windows-specific extensions to `OpenOptions`
-pub trait OpenOptionsExt {
-    /// Override the `dwDesiredAccess` argument to the call to `CreateFile` with
-    /// the specified value.
-    fn desired_access(&mut self, access: i32) -> &mut Self;
-
-    /// Override the `dwCreationDisposition` argument to the call to
-    /// `CreateFile` with the specified value.
-    ///
-    /// This will override any values of the standard `create` flags, for
-    /// example.
-    fn creation_disposition(&mut self, val: i32) -> &mut Self;
-
-    /// Override the `dwFlagsAndAttributes` argument to the call to
-    /// `CreateFile` with the specified value.
-    ///
-    /// This will override any values of the standard flags on the `OpenOptions`
-    /// structure.
-    fn flags_and_attributes(&mut self, val: i32) -> &mut Self;
-
-    /// Override the `dwShareMode` argument to the call to `CreateFile` with the
-    /// specified value.
-    ///
-    /// This will override any values of the standard flags on the `OpenOptions`
-    /// structure.
-    fn share_mode(&mut self, val: i32) -> &mut Self;
-}
-
-impl OpenOptionsExt for OpenOptions {
-    fn desired_access(&mut self, access: i32) -> &mut OpenOptions {
-        self.as_inner_mut().desired_access(access); self
-    }
-    fn creation_disposition(&mut self, access: i32) -> &mut OpenOptions {
-        self.as_inner_mut().creation_disposition(access); self
-    }
-    fn flags_and_attributes(&mut self, access: i32) -> &mut OpenOptions {
-        self.as_inner_mut().flags_and_attributes(access); self
-    }
-    fn share_mode(&mut self, access: i32) -> &mut OpenOptions {
-        self.as_inner_mut().share_mode(access); self
+    impl OpenOptionsExt for OpenOptions {
+        fn desired_access(&mut self, access: i32) -> &mut OpenOptions {
+            self.as_inner_mut().desired_access(access); self
+        }
+        fn creation_disposition(&mut self, access: i32) -> &mut OpenOptions {
+            self.as_inner_mut().creation_disposition(access); self
+        }
+        fn flags_and_attributes(&mut self, access: i32) -> &mut OpenOptions {
+            self.as_inner_mut().flags_and_attributes(access); self
+        }
+        fn share_mode(&mut self, access: i32) -> &mut OpenOptions {
+            self.as_inner_mut().share_mode(access); self
+        }
     }
 }
 
 /// A prelude for conveniently writing platform-specific code.
 ///
 /// Includes all extension traits, and some important type definitions.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub mod prelude {
     #[doc(no_inline)]
-    pub use super::{Socket, Handle, AsRawSocket, AsRawHandle};
+    pub use super::io::{Socket, Handle, AsRawSocket, AsRawHandle};
+    #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
+    pub use super::ffi::{OsStrExt, OsStringExt};
     #[doc(no_inline)]
-    pub use super::{OsStrExt, OsStringExt};
-    #[doc(no_inline)]
-    pub use super::OpenOptionsExt;
+    pub use super::fs::OpenOptionsExt;
 }

--- a/src/libstd/sys/windows/mod.rs
+++ b/src/libstd/sys/windows/mod.rs
@@ -20,7 +20,7 @@ use libc;
 use mem;
 use num::Int;
 use old_io::{self, IoResult, IoError};
-use os::windows::{OsStrExt, OsStringExt};
+use os::windows::ffi::{OsStrExt, OsStringExt};
 use path::PathBuf;
 use sync::{Once, ONCE_INIT};
 

--- a/src/libstd/sys/windows/os.rs
+++ b/src/libstd/sys/windows/os.rs
@@ -13,7 +13,7 @@
 #![allow(bad_style)]
 
 use prelude::v1::*;
-use os::windows::*;
+use os::windows::prelude::*;
 
 use error::Error as StdError;
 use ffi::{OsString, OsStr, AsOsStr};
@@ -25,6 +25,7 @@ use mem;
 #[allow(deprecated)]
 use old_io::{IoError, IoResult};
 use ops::Range;
+use os::windows::ffi::EncodeWide;
 use path::{self, PathBuf};
 use ptr;
 use slice;

--- a/src/libstd/sys/windows/process2.rs
+++ b/src/libstd/sys/windows/process2.rs
@@ -19,7 +19,7 @@ use fmt;
 use fs;
 use io::{self, Error};
 use libc::{self, c_void};
-use os::windows::OsStrExt;
+use os::windows::ffi::OsStrExt;
 use ptr;
 use sync::{StaticMutex, MUTEX_INIT};
 use sys::handle::Handle;


### PR DESCRIPTION
This commit starts to organize the `std::os::$platform` modules and in the
process stabilizes some of the functionality contained within. The organization
of these modules will reflect the organization of the standard library itself
with extension traits for primitives in the same corresponding module.

The OS-specific modules will grow more functionality over time including
concrete types that are not extending functionality of other structures, and
these will either go into the closest module in `std::os::$platform` or they
will grow a new module in the hierarchy.

The following items are now stable:
- `os::{unix, windows}`
- `unix::ffi`
- `unix::ffi::OsStrExt`
- `unix::ffi::OsStrExt::{from_bytes, as_bytes, to_cstring}`
- `unix::ffi::OsString`
- `unix::ffi::OsStringExt::{from_vec, into_vec}`
- `unix::process`
- `unix::process::CommandExt`
- `unix::process::CommandExt::{uid, gid}`
- `unix::process::ExitStatusExt`
- `unix::process::ExitStatusExt::signal`
- `unix::prelude`
- `windows::ffi`
- `windows::ffi::OsStringExt`
- `windows::ffi::OsStringExt::from_wide`
- `windows::ffi::OsStrExt`
- `windows::ffi::OsStrExt::encode_wide`
- `windows::prelude`

The following items remain unstable:
- `unix::io`
- `unix::io::{Fd, AsRawFd}`
- `unix::fs::{PermissionsExt, OpenOptionsExt}`
- `windows::io`
- `windows::io::{Handle, AsRawHandle}`
- `windows::io::{Socket, AsRawSocket}`
- `windows::fs`
- `windows::fs::OpenOptionsExt`

Due to the reorgnization of the platform extension modules, this commit is a
breaking change. Most imports can be fixed by adding the relevant libstd module
in the `use` path (such as `ffi` or `fs`).

[breaking-change]
