### PR TITLE
Improve camelcase suggestion

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -811,7 +811,7 @@ impl NonCamelCaseTypes {
                 if i == 0 {
                     c.to_uppercase().collect::<String>()
                 } else {
-                    c.to_string()
+                    c.to_lowercase().collect()
                 }
             )).collect::<Vec<_>>().concat()
         }

--- a/src/test/compile-fail/lint-non-camel-case-types.rs
+++ b/src/test/compile-fail/lint-non-camel-case-types.rs
@@ -11,6 +11,9 @@
 #![forbid(non_camel_case_types)]
 #![allow(dead_code)]
 
+struct ONE_TWO_THREE;
+//~^ ERROR type `ONE_TWO_THREE` should have a camel case name such as `OneTwoThree`
+
 struct foo { //~ ERROR type `foo` should have a camel case name such as `Foo`
     bar: isize,
 }


### PR DESCRIPTION
non_camel_case_types lint suggests `ONETWOTHREE` for non-camel type `ONE_TWO_THREE`, which doesn't look good.
This patch fixes it.
