### PR TITLE
Drop support for LLVM < 3.5 and fix compile errors with 3.5

### DIFF
--- a/configure
+++ b/configure
@@ -823,11 +823,11 @@ then
     LLVM_VERSION=$($LLVM_CONFIG --version)
 
     case $LLVM_VERSION in
-        (3.[2-6]*)
+        (3.[5-6]*)
             msg "found ok version of LLVM: $LLVM_VERSION"
             ;;
         (*)
-            err "bad LLVM version: $LLVM_VERSION, need >=3.0svn"
+            err "bad LLVM version: $LLVM_VERSION, need >=3.5"
             ;;
     esac
 fi


### PR DESCRIPTION
LLVM older that 3.6 has a bug that cause assertions when compiling certain
constructs. For 3.5 there's still a chance that the bug might get fixed
in 3.5.2, so let's keep allowing to compile with it for it for now.
