### PR TITLE
Fix a typo in the documentation.

### DIFF
--- a/src/doc/trpl/concurrency.md
+++ b/src/doc/trpl/concurrency.md
@@ -339,7 +339,7 @@ fn main() {
         });
     }
 
-   rx.recv().ok().expect("Could not recieve answer");
+   rx.recv().ok().expect("Could not receive answer");
 }
 ```
 


### PR DESCRIPTION
There was a minor typo in the book's concurrency section ("recieve" instead of "receive").
