### PR TITLE
Fix two bugs for [expr; n] expressions

### DIFF
--- a/src/librustc_trans/trans/tvec.rs
+++ b/src/librustc_trans/trans/tvec.rs
@@ -410,8 +410,12 @@ pub fn iter_vec_loop<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
     F: FnOnce(Block<'blk, 'tcx>, ValueRef, Ty<'tcx>) -> Block<'blk, 'tcx>,
 {
     let _icx = push_ctxt("tvec::iter_vec_loop");
-    let fcx = bcx.fcx;
 
+    if bcx.unreachable.get() {
+        return bcx;
+    }
+
+    let fcx = bcx.fcx;
     let loop_bcx = fcx.new_temp_block("expr_repeat");
     let next_bcx = fcx.new_temp_block("expr_repeat: next");
 

--- a/src/librustc_trans/trans/tvec.rs
+++ b/src/librustc_trans/trans/tvec.rs
@@ -293,7 +293,7 @@ pub fn write_content<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                 }
                 SaveIn(lldest) => {
                     match ty::eval_repeat_count(bcx.tcx(), &**count_expr) {
-                        0 => bcx,
+                        0 => expr::trans_into(bcx, &**element, Ignore),
                         1 => expr::trans_into(bcx, &**element, SaveIn(lldest)),
                         count => {
                             let elem = unpack_datum!(bcx, expr::trans(bcx, &**element));

--- a/src/test/run-fail/issue-23354-2.rs
+++ b/src/test/run-fail/issue-23354-2.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:panic evaluated
+
+#[allow(unused_variables)]
+fn main() {
+    // This used to trigger an LLVM assertion during compilation
+    let x = [panic!("panic evaluated"); 2];
+}

--- a/src/test/run-fail/issue-23354.rs
+++ b/src/test/run-fail/issue-23354.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:panic evaluated
+
+#[allow(unused_variables)]
+fn main() {
+    let x = [panic!("panic evaluated"); 0];
+}


### PR DESCRIPTION
[expr; 0] currently exhibits inconsistent behaviour and [expr; n] with n > 1 triggers an LLVM assertion in case that "expr" diverges.
