### PR TITLE
Add read_all to std:io::Read to parallel write_all in std::io::Write.

### DIFF
--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -107,6 +107,14 @@ pub enum ErrorKind {
     /// written.
     #[stable(feature = "rust1", since = "1.0.0")]
     WriteZero,
+    /// An error returned when an operation could not be completed because a
+    /// call to `read` returned `Ok(0)`.
+    ///
+    /// This typically means that an operation could only succeed if it read a
+    /// particular number of bytes but only a smaller number of bytes could be
+    /// read.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    ShortRead(usize),
     /// This operation was interrupted.
     ///
     /// Interrupted operations can typically be retried.

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -164,6 +164,9 @@ impl Read for Stdin {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.lock().read(buf)
     }
+    fn read_all(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.lock().read_all(buf)
+    }
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
         self.lock().read_to_end(buf)
     }


### PR DESCRIPTION
Fixes #23174
