### PR TITLE
Remove TyDesc.

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -44,10 +44,12 @@
 
 use marker::Sized;
 
+#[cfg(stage0)] // SNAP 270a677
 pub type GlueFn = extern "Rust" fn(*const i8);
 
 #[lang="ty_desc"]
 #[derive(Copy)]
+#[cfg(stage0)] // SNAP 270a677
 pub struct TyDesc {
     // sizeof(T)
     pub size: usize,
@@ -197,7 +199,12 @@ extern "rust-intrinsic" {
     pub fn pref_align_of<T>() -> usize;
 
     /// Get a static pointer to a type descriptor.
+    #[cfg(stage0)] // SNAP 270a677
     pub fn get_tydesc<T: ?Sized>() -> *const TyDesc;
+
+    /// Gets a static string slice containing the name of a type.
+    #[cfg(not(stage0))] // SNAP 270a677
+    pub fn type_name<T: ?Sized>() -> &'static str;
 
     /// Gets an identifier which is globally unique to the specified type. This
     /// function will return the same value for a type regardless of whichever

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -316,9 +316,6 @@ lets_do_this! {
 
     StartFnLangItem,                 "start",                   start_fn;
 
-    TyDescStructLangItem,            "ty_desc",                 ty_desc;
-    OpaqueStructLangItem,            "opaque",                  opaque;
-
     EhPersonalityLangItem,           "eh_personality",          eh_personality;
 
     ExchangeHeapLangItem,            "exchange_heap",           exchange_heap;

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -47,8 +47,7 @@ use middle::check_const;
 use middle::const_eval;
 use middle::def::{self, DefMap, ExportMap};
 use middle::dependency_format;
-use middle::lang_items::{FnTraitLangItem, FnMutTraitLangItem};
-use middle::lang_items::{FnOnceTraitLangItem, TyDescStructLangItem};
+use middle::lang_items::{FnTraitLangItem, FnMutTraitLangItem, FnOnceTraitLangItem};
 use middle::mem_categorization as mc;
 use middle::region;
 use middle::resolve_lifetime;
@@ -723,7 +722,6 @@ pub struct ctxt<'tcx> {
     pub object_cast_map: ObjectCastMap<'tcx>,
 
     pub map: ast_map::Map<'tcx>,
-    pub intrinsic_defs: RefCell<DefIdMap<Ty<'tcx>>>,
     pub freevars: RefCell<FreevarMap>,
     pub tcache: RefCell<DefIdMap<TypeScheme<'tcx>>>,
     pub rcache: RefCell<FnvHashMap<creader_cache_key, Ty<'tcx>>>,
@@ -2575,7 +2573,6 @@ pub fn mk_ctxt<'tcx>(s: Session,
         super_predicates: RefCell::new(DefIdMap()),
         object_cast_map: RefCell::new(NodeMap()),
         map: map,
-        intrinsic_defs: RefCell::new(DefIdMap()),
         freevars: freevars,
         tcache: RefCell::new(DefIdMap()),
         rcache: RefCell::new(FnvHashMap()),
@@ -5949,13 +5946,6 @@ pub fn required_region_bounds<'tcx>(tcx: &ctxt<'tcx>,
             }
         })
         .collect()
-}
-
-pub fn get_tydesc_ty<'tcx>(tcx: &ctxt<'tcx>) -> Result<Ty<'tcx>, String> {
-    tcx.lang_items.require(TyDescStructLangItem).map(|tydesc_lang_item| {
-        tcx.intrinsic_defs.borrow().get(&tydesc_lang_item).cloned()
-            .expect("Failed to resolve TyDesc")
-    })
 }
 
 pub fn item_variances(tcx: &ctxt, item_id: ast::DefId) -> Rc<ItemVariances> {

--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -660,7 +660,7 @@ fn bind_subslice_pat(bcx: Block,
                      offset_right: uint) -> ValueRef {
     let _icx = push_ctxt("match::bind_subslice_pat");
     let vec_ty = node_id_type(bcx, pat_id);
-    let vt = tvec::vec_types(bcx, ty::sequence_element_type(bcx.tcx(), ty::type_content(vec_ty)));
+    let unit_ty = ty::sequence_element_type(bcx.tcx(), ty::type_content(vec_ty));
     let vec_datum = match_datum(val, vec_ty);
     let (base, len) = vec_datum.get_vec_base_and_len(bcx);
 
@@ -669,7 +669,7 @@ fn bind_subslice_pat(bcx: Block,
     let slice_len = Sub(bcx, len, slice_len_offset, DebugLoc::None);
     let slice_ty = ty::mk_slice(bcx.tcx(),
                                 bcx.tcx().mk_region(ty::ReStatic),
-                                ty::mt {ty: vt.unit_ty, mutbl: ast::MutImmutable});
+                                ty::mt {ty: unit_ty, mutbl: ast::MutImmutable});
     let scratch = rvalue_scratch_datum(bcx, slice_ty, "");
     Store(bcx, slice_begin,
           GEPi(bcx, scratch.val, &[0, abi::FAT_PTR_ADDR]));

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -702,6 +702,10 @@ pub fn iter_structural_ty<'blk, 'tcx, F>(cx: Block<'blk, 'tcx>,
         let unit_ty = ty::sequence_element_type(cx.tcx(), t);
         cx = tvec::iter_vec_raw(cx, base, unit_ty, len, f);
       }
+      ty::ty_vec(_, None) | ty::ty_str => {
+        let unit_ty = ty::sequence_element_type(cx.tcx(), t);
+        cx = tvec::iter_vec_raw(cx, data_ptr, unit_ty, info.unwrap(), f);
+      }
       ty::ty_tup(ref args) => {
           let repr = adt::represent_type(cx.ccx(), t);
           for (i, arg) in args.iter().enumerate() {

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -316,15 +316,6 @@ pub fn gensym_name(name: &str) -> PathElem {
     PathName(token::gensym(&format!("{}:{}", name, num)))
 }
 
-#[derive(Copy)]
-pub struct tydesc_info<'tcx> {
-    pub ty: Ty<'tcx>,
-    pub tydesc: ValueRef,
-    pub size: ValueRef,
-    pub align: ValueRef,
-    pub name: ValueRef,
-}
-
 /*
 * A note on nomenclature of linking: "extern", "foreign", and "upcall".
 *

--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -314,7 +314,6 @@ pub fn const_expr<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                     let info =
                         expr::unsized_info(
                             cx, k, e.id, ty, param_substs,
-                            |t| ty::mk_imm_rptr(cx.tcx(), cx.tcx().mk_region(ty::ReStatic), t),
                             || const_get_elt(cx, llconst, &[abi::FAT_PTR_EXTRA as u32]));
 
                     let unsized_ty = ty::unsize_ty(cx.tcx(), ty, k, e.span);

--- a/src/librustc_trans/trans/context.rs
+++ b/src/librustc_trans/trans/context.rs
@@ -102,7 +102,7 @@ pub struct LocalCrateContext<'tcx> {
     monomorphized: RefCell<FnvHashMap<MonoId<'tcx>, ValueRef>>,
     monomorphizing: RefCell<DefIdMap<uint>>,
     /// Cache generated vtables
-    vtables: RefCell<FnvHashMap<(Ty<'tcx>, ty::PolyTraitRef<'tcx>), ValueRef>>,
+    vtables: RefCell<FnvHashMap<ty::PolyTraitRef<'tcx>, ValueRef>>,
     /// Cache of constant strings,
     const_cstr_cache: RefCell<FnvHashMap<InternedString, ValueRef>>,
 
@@ -614,8 +614,7 @@ impl<'b, 'tcx> CrateContext<'b, 'tcx> {
         &self.local.monomorphizing
     }
 
-    pub fn vtables<'a>(&'a self) -> &'a RefCell<FnvHashMap<(Ty<'tcx>, ty::PolyTraitRef<'tcx>),
-                                                            ValueRef>> {
+    pub fn vtables<'a>(&'a self) -> &'a RefCell<FnvHashMap<ty::PolyTraitRef<'tcx>, ValueRef>> {
         &self.local.vtables
     }
 

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -347,15 +347,10 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
             bcx = src.store_to(bcx, llargs[0]);
             C_nil(ccx)
         }
-        (_, "get_tydesc") => {
+        (_, "type_name") => {
             let tp_ty = *substs.types.get(FnSpace, 0);
-            let static_ti = get_tydesc(ccx, tp_ty);
-
-            // FIXME (#3730): ideally this shouldn't need a cast,
-            // but there's a circularity between translating rust types to llvm
-            // types and having a tydesc type available. So I can't directly access
-            // the llvm type of intrinsic::TyDesc struct.
-            PointerCast(bcx, static_ti.tydesc, llret_ty)
+            let ty_name = token::intern_and_get_ident(&ty_to_string(ccx.tcx(), tp_ty));
+            C_str_slice(ccx, ty_name)
         }
         (_, "type_id") => {
             let hash = ty::hash_crate_independent(

--- a/src/librustc_trans/trans/machine.rs
+++ b/src/librustc_trans/trans/machine.rs
@@ -12,9 +12,7 @@
 
 #![allow(non_camel_case_types)]
 
-use llvm;
-use llvm::{ValueRef};
-use llvm::False;
+use llvm::{self, ValueRef};
 use trans::common::*;
 
 use trans::type_::Type;
@@ -98,16 +96,6 @@ pub fn llalign_of_pref(cx: &CrateContext, ty: Type) -> llalign {
 pub fn llalign_of_min(cx: &CrateContext, ty: Type) -> llalign {
     unsafe {
         return llvm::LLVMABIAlignmentOfType(cx.td().lltd, ty.to_ref());
-    }
-}
-
-// Returns the "default" alignment of t, which is calculated by casting
-// null to a record containing a single-bit followed by a t value, then
-// doing gep(0,1) to get at the trailing (and presumably padded) t cell.
-pub fn llalign_of(cx: &CrateContext, ty: Type) -> ValueRef {
-    unsafe {
-        return llvm::LLVMConstIntCast(
-            llvm::LLVMAlignOf(ty.to_ref()), cx.int_type().to_ref(), False);
     }
 }
 

--- a/src/librustc_trans/trans/type_.rs
+++ b/src/librustc_trans/trans/type_.rs
@@ -175,39 +175,8 @@ impl Type {
         Type::array(&Type::i8p(ccx).ptr_to(), 1)
     }
 
-    pub fn generic_glue_fn(cx: &CrateContext) -> Type {
-        match cx.tn().find_type("glue_fn") {
-            Some(ty) => return ty,
-            None => ()
-        }
-
-        let ty = Type::glue_fn(cx, Type::i8p(cx));
-        cx.tn().associate_type("glue_fn", &ty);
-
-        ty
-    }
-
     pub fn glue_fn(ccx: &CrateContext, t: Type) -> Type {
         Type::func(&[t], &Type::void(ccx))
-    }
-
-    pub fn tydesc(ccx: &CrateContext, str_slice_ty: Type) -> Type {
-        let mut tydesc = Type::named_struct(ccx, "tydesc");
-        let glue_fn_ty = Type::glue_fn(ccx, Type::i8p(ccx)).ptr_to();
-
-        let int_ty = Type::int(ccx);
-
-        // Must mirror:
-        //
-        // std::unstable::intrinsics::TyDesc
-
-        let elems = [int_ty,     // size
-                     int_ty,     // align
-                     glue_fn_ty, // drop
-                     str_slice_ty]; // name
-        tydesc.set_struct_body(&elems, false);
-
-        tydesc
     }
 
     pub fn array(ty: &Type, len: u64) -> Type {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5347,17 +5347,8 @@ pub fn check_intrinsic_type(ccx: &CrateCtxt, it: &ast::ForeignItem) {
             "needs_drop" => (1, Vec::new(), ccx.tcx.types.bool),
             "owns_managed" => (1, Vec::new(), ccx.tcx.types.bool),
 
-            "get_tydesc" => {
-              let tydesc_ty = match ty::get_tydesc_ty(ccx.tcx) {
-                  Ok(t) => t,
-                  Err(s) => { span_fatal!(tcx.sess, it.span, E0240, "{}", &s[..]); }
-              };
-              let td_ptr = ty::mk_ptr(ccx.tcx, ty::mt {
-                  ty: tydesc_ty,
-                  mutbl: ast::MutImmutable
-              });
-              (1, Vec::new(), td_ptr)
-            }
+            "type_name" => (1, Vec::new(), ty::mk_str_slice(tcx, tcx.mk_region(ty::ReStatic),
+                                                             ast::MutImmutable)),
             "type_id" => (1, Vec::new(), ccx.tcx.types.u64),
             "offset" => {
               (1,

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -102,15 +102,6 @@ use syntax::visit;
 pub fn collect_item_types(tcx: &ty::ctxt) {
     let ccx = &CrateCtxt { tcx: tcx, stack: RefCell::new(Vec::new()) };
 
-    match ccx.tcx.lang_items.ty_desc() {
-        Some(id) => { collect_intrinsic_type(ccx, id); }
-        None => {}
-    }
-    match ccx.tcx.lang_items.opaque() {
-        Some(id) => { collect_intrinsic_type(ccx, id); }
-        None => {}
-    }
-
     let mut visitor = CollectTraitDefVisitor{ ccx: ccx };
     visit::walk_crate(&mut visitor, ccx.tcx.map.krate());
 
@@ -150,15 +141,6 @@ enum AstConvRequest {
     GetTraitDef(ast::DefId),
     EnsureSuperPredicates(ast::DefId),
     GetTypeParameterBounds(ast::NodeId),
-}
-
-///////////////////////////////////////////////////////////////////////////
-// Zeroth phase: collect types of intrinsics
-
-fn collect_intrinsic_type(ccx: &CrateCtxt,
-                          lang_item: ast::DefId) {
-    let ty::TypeScheme { ty, .. } = type_scheme_of_def_id(ccx, lang_item);
-    ccx.tcx.intrinsic_defs.borrow_mut().insert(lang_item, ty);
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/test/run-pass/issue-21058.rs
+++ b/src/test/run-pass/issue-21058.rs
@@ -13,17 +13,17 @@ struct NT(str);
 struct DST { a: u32, b: str }
 
 fn main() {
-    // get_tydesc should support unsized types
+    // type_name should support unsized types
     assert_eq!(unsafe {(
         // Slice
-        (*std::intrinsics::get_tydesc::<[u8]>()).name,
+        std::intrinsics::type_name::<[u8]>(),
         // str
-        (*std::intrinsics::get_tydesc::<str>()).name,
+        std::intrinsics::type_name::<str>(),
         // Trait
-        (*std::intrinsics::get_tydesc::<Copy>()).name,
+        std::intrinsics::type_name::<Copy>(),
         // Newtype
-        (*std::intrinsics::get_tydesc::<NT>()).name,
+        std::intrinsics::type_name::<NT>(),
         // DST
-        (*std::intrinsics::get_tydesc::<DST>()).name
+        std::intrinsics::type_name::<DST>()
     )}, ("[u8]", "str", "core::marker::Copy", "NT", "DST"));
 }

--- a/src/test/run-pass/tydesc-name.rs
+++ b/src/test/run-pass/tydesc-name.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-use std::intrinsics::get_tydesc;
+use std::intrinsics::type_name;
 
 struct Foo<T> {
     x: T
@@ -17,7 +17,7 @@ struct Foo<T> {
 
 pub fn main() {
     unsafe {
-        assert_eq!((*get_tydesc::<int>()).name, "isize");
-        assert_eq!((*get_tydesc::<Foo<uint>>()).name, "Foo<usize>");
+        assert_eq!(type_name::<int>(), "isize");
+        assert_eq!(type_name::<Foo<uint>>(), "Foo<usize>");
     }
 }


### PR DESCRIPTION
Final remnant of reflection is gone. Also, virtual `Trait` destructors are no longer tied to `Box`.
That means they can be used to drop any instance of the type (used in libarena to replace TyDesc).

This is [breaking-change] for direct users of intrinsics:
- use `intrinsics::type_name::<T>()` instead of `(*intrinsics::get_tydesc::<T>()).name`
- the only way to get the destructor is from a trait object's vtable (see libarena changes)

r? @pcwalton f? @dotdash
