### PR TITLE
Remove incorrect references to _raw stdio functions

### DIFF
--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -21,20 +21,20 @@ use sys::stdio;
 /// A handle to a raw instance of the standard input stream of this process.
 ///
 /// This handle is not synchronized or buffered in any fashion. Constructed via
-/// the `std::io::stdin_raw` function.
-pub struct StdinRaw(stdio::Stdin);
+/// the `std::io::stdio::stdin_raw` function.
+struct StdinRaw(stdio::Stdin);
 
 /// A handle to a raw instance of the standard output stream of this process.
 ///
 /// This handle is not synchronized or buffered in any fashion. Constructed via
-/// the `std::io::stdout_raw` function.
-pub struct StdoutRaw(stdio::Stdout);
+/// the `std::io::stdio::stdout_raw` function.
+struct StdoutRaw(stdio::Stdout);
 
 /// A handle to a raw instance of the standard output stream of this process.
 ///
 /// This handle is not synchronized or buffered in any fashion. Constructed via
-/// the `std::io::stderr_raw` function.
-pub struct StderrRaw(stdio::Stderr);
+/// the `std::io::stdio::stderr_raw` function.
+struct StderrRaw(stdio::Stderr);
 
 /// Construct a new raw handle to the standard input of this process.
 ///
@@ -43,7 +43,7 @@ pub struct StderrRaw(stdio::Stderr);
 /// handles is **not** available to raw handles returned from this function.
 ///
 /// The returned handle has no external synchronization or buffering.
-pub fn stdin_raw() -> StdinRaw { StdinRaw(stdio::Stdin::new()) }
+fn stdin_raw() -> StdinRaw { StdinRaw(stdio::Stdin::new()) }
 
 /// Construct a new raw handle to the standard input stream of this process.
 ///
@@ -54,7 +54,7 @@ pub fn stdin_raw() -> StdinRaw { StdinRaw(stdio::Stdin::new()) }
 ///
 /// The returned handle has no external synchronization or buffering layered on
 /// top.
-pub fn stdout_raw() -> StdoutRaw { StdoutRaw(stdio::Stdout::new()) }
+fn stdout_raw() -> StdoutRaw { StdoutRaw(stdio::Stdout::new()) }
 
 /// Construct a new raw handle to the standard input stream of this process.
 ///
@@ -63,7 +63,7 @@ pub fn stdout_raw() -> StdoutRaw { StdoutRaw(stdio::Stdout::new()) }
 ///
 /// The returned handle has no external synchronization or buffering layered on
 /// top.
-pub fn stderr_raw() -> StderrRaw { StderrRaw(stdio::Stderr::new()) }
+fn stderr_raw() -> StderrRaw { StderrRaw(stdio::Stderr::new()) }
 
 impl Read for StdinRaw {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.0.read(buf) }
@@ -109,9 +109,6 @@ pub struct StdinLock<'a> {
 /// The `Read` trait is implemented for the returned value but the `BufRead`
 /// trait is not due to the global nature of the standard input stream. The
 /// locked version, `StdinLock`, implements both `Read` and `BufRead`, however.
-///
-/// To avoid locking and buffering altogether, it is recommended to use the
-/// `stdin_raw` constructor.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn stdin() -> Stdin {
     static INSTANCE: Lazy<Mutex<BufReader<StdinRaw>>> = lazy_init!(stdin_init);
@@ -224,9 +221,6 @@ pub struct StdoutLock<'a> {
 /// provided via the `lock` method.
 ///
 /// The returned handle implements the `Write` trait.
-///
-/// To avoid locking and buffering altogether, it is recommended to use the
-/// `stdout_raw` constructor.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn stdout() -> Stdout {
     static INSTANCE: Lazy<Mutex<LineWriter<StdoutRaw>>> = lazy_init!(stdout_init);
@@ -297,9 +291,6 @@ pub struct StderrLock<'a> {
 /// this function. No handles are buffered, however.
 ///
 /// The returned handle implements the `Write` trait.
-///
-/// To avoid locking altogether, it is recommended to use the `stderr_raw`
-/// constructor.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn stderr() -> Stderr {
     static INSTANCE: Lazy<Mutex<StderrRaw>> = lazy_init!(stderr_init);


### PR DESCRIPTION
`std::io` does not currently expose the `stdin_raw`, `stdout_raw`, or
`stderr_raw` functions. According to the current plans for stdio (see
rust-lang/rfcs#517), raw access will likely be provided using the
platform-specific `std::os::{unix,windows}` modules. At the moment we
don't expose any way to do this. As such, delete all mention of the
`*_raw` functions from the `stdin`/`stdout`/`stderr` function
documentation.

While we're at it, remove a few `pub`s from items that aren't exposed.
This is done just to lessen the confusion experienced by anyone who
looks at the source in an attempt to find the `*_raw` functions.
