### PR TITLE
std: Fix create_dir_all for empty paths

### DIFF
--- a/src/libstd/fs/mod.rs
+++ b/src/libstd/fs/mod.rs
@@ -570,7 +570,7 @@ pub fn create_dir<P: AsPath + ?Sized>(path: &P) -> io::Result<()> {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn create_dir_all<P: AsPath + ?Sized>(path: &P) -> io::Result<()> {
     let path = path.as_path();
-    if path.is_dir() { return Ok(()) }
+    if path == Path::new("") || path.is_dir() { return Ok(()) }
     if let Some(p) = path.parent() { try!(create_dir_all(p)) }
     create_dir(path)
 }

--- a/src/test/run-pass/create-dir-all-bare.rs
+++ b/src/test/run-pass/create-dir-all-bare.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::env;
+use std::fs::{self, TempDir};
+
+fn main() {
+    let td = TempDir::new("create-dir-all-bare").unwrap();
+    env::set_current_dir(td.path()).unwrap();
+    fs::create_dir_all("create-dir-all-bare").unwrap();
+}


### PR DESCRIPTION
Recent changes in path semantics meant that if none of the components in a
relative path existed as a part of a call to `create_dir_all` then the call
would fail as `create_dir("")` would be attempted and would fail with an OS
error.

Closes #23624
