### PR TITLE
Fix `an String` in env.rs documentation

### DIFF
--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -452,7 +452,7 @@ pub fn get_exit_status() -> i32 {
     EXIT_STATUS.load(Ordering::SeqCst) as i32
 }
 
-/// An iterator over the arguments of a process, yielding an `String` value
+/// An iterator over the arguments of a process, yielding a `String` value
 /// for each argument.
 ///
 /// This structure is created through the `std::env::args` method.


### PR DESCRIPTION
This changed `an String` to `a String`. Very minor change!

The usage of `an String` was introduced in https://github.com/rust-lang/rust/commit/a828e7948069f310dc5b33be8edb65e5e8e0cf9a#diff-b596503c7c33ce457b6d047e351ac12bR423, which changed `an OsString` to `an String`.
