### PR TITLE
Fix deprecated `comm` link.

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -73,10 +73,10 @@
 //!
 //! ## Concurrency, I/O, and the runtime
 //!
-//! The [`thread`](thread/index.html) module contains Rust's threading abstractions,
-//! while [`comm`](comm/index.html) contains the channel types for message
-//! passing. [`sync`](sync/index.html) contains further, primitive, shared
-//! memory types, including [`atomic`](sync/atomic/index.html).
+//! The [`thread`](thread/index.html) module contains Rust's threading abstractions.
+//! [`sync`](sync/index.html) contains further, primitive, shared memory types,
+//! including [`atomic`](sync/atomic/index.html), and [`mpsc`](sync/mpmc/index.html),
+//! which contains the channel types for message passing.
 //!
 //! Common types of I/O, including files, TCP, UDP, pipes, Unix domain sockets,
 //! timers, and process spawning, are defined in the


### PR DESCRIPTION
Since module `std::sync::mpsc` is stable now, fix the deprecated link `comm` with `sync::mpsc`.
