### PR TITLE
powerpc: Support configure on native ppc[64] hosts

### DIFF
--- a/configure
+++ b/configure
@@ -461,7 +461,10 @@ case $CFG_CPUTYPE in
         CFG_CPUTYPE=aarch64
         ;;
 
-    powerpc)
+    # At some point, when ppc64[le] support happens, this will need to do
+    # something clever. For now it's safe to assume that we're only ever
+    # interested in building 32 bit.
+    powerpc | ppc | ppc64)
         CFG_CPUTYPE=powerpc
         ;;
 


### PR DESCRIPTION
Finally making progress on a fully native toolchain. Specifically, this makes it possible to move forward by building librustllvm on the target platform.
