### PR TITLE
Remove redundant method

### DIFF
--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -143,17 +143,6 @@ impl Error {
         }
     }
 
-    /// Returns a short description for this error message
-    #[unstable(feature = "io")]
-    #[deprecated(since = "1.0.0", reason = "use the Error trait's description \
-                                            method instead")]
-    pub fn description(&self) -> &str {
-        match self.repr {
-            Repr::Os(..) => "os error",
-            Repr::Custom(ref c) => c.desc,
-        }
-    }
-
     /// Returns a detailed error message for this error (if one is available)
     #[unstable(feature = "io")]
     #[deprecated(since = "1.0.0", reason = "use the to_string() method instead")]


### PR DESCRIPTION
`error::Error` is already implemented for `io::Error` in this file and the implementations are identical.
