### PR TITLE
std: Stabilize the Write::flush method

### DIFF
--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -175,7 +175,6 @@
 #![feature(int_uint)]
 #![feature(core)]
 #![feature(std_misc)]
-#![feature(io)]
 
 use std::boxed;
 use std::cell::RefCell;

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -356,7 +356,7 @@ pub trait Write {
     ///
     /// It is considered an error if not all bytes could be written due to
     /// I/O errors or EOF being reached.
-    #[unstable(feature = "io", reason = "waiting for RFC 950")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     fn flush(&mut self) -> Result<()>;
 
     /// Attempts to write an entire buffer into this write.

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -37,7 +37,6 @@
 #![feature(staged_api)]
 #![feature(std_misc)]
 #![feature(unicode)]
-#![feature(io)]
 #![feature(path_ext)]
 
 extern crate arena;

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -57,7 +57,6 @@
 #![feature(box_syntax)]
 #![feature(collections)]
 #![feature(int_uint)]
-#![feature(io)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
 #![feature(std_misc)]

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -42,7 +42,6 @@
 #![feature(rustc_private)]
 #![feature(staged_api)]
 #![feature(std_misc)]
-#![feature(io)]
 #![feature(libc)]
 #![feature(set_stdio)]
 


### PR DESCRIPTION
The [associated RFC](https://github.com/rust-lang/rfcs/pull/950) for possibly splitting out `flush` has been closed and
as a result there are no more blockers for stabilizing this method, so this
commit marks the method as such.
