### PR TITLE
Fix the Linux nightly build by adding a LLVM_CONFIG_<target-triple> dep.

### DIFF
--- a/mk/target.mk
+++ b/mk/target.mk
@@ -72,6 +72,7 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4): CFG_COMPILER_HOST_TRIPLE = $(2)
 $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.$(4): \
 		$$(CRATEFILE_$(4)) \
 		$$(CRATE_FULLDEPS_$(1)_T_$(2)_H_$(3)_$(4)) \
+		$$(LLVM_CONFIG_$(2)) \
 		$$(TSREQ$(1)_T_$(2)_H_$(3)) \
 		| $$(TLIB$(1)_T_$(2)_H_$(3))/
 	@$$(call E, rustc: $$(@D)/lib$(4))


### PR DESCRIPTION
The RUST_TARGET_STAGE_N rule uses LLVM_LIBDIR_RUSTFLAGS_<target-triple>,
which expands to -L "$(llvm-config --libdir)" when the target-triple is
also a host-triple. Rather than expand to -L "" if llvm-config has not yet
been built, add a dependency on the target llvm-config.

When the target-triple is not a host-triple, the new LLVM_CONFIG_$(2)
dependency should expand to nothing.

r? alexcrichton
