### PR TITLE
libc: Fix definition of sockaddr_storage on 32-bit linux

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -269,8 +269,8 @@ pub mod types {
                 #[repr(C)]
                 #[derive(Copy)] pub struct sockaddr_storage {
                     pub ss_family: sa_family_t,
-                    pub __ss_align: i64,
-                    pub __ss_pad2: [u8; 112],
+                    pub __ss_align: isize,
+                    pub __ss_pad2: [u8; 128 - 2 * (::core::isize::BYTES as usize)],
                 }
                 #[repr(C)]
                 #[derive(Copy)] pub struct sockaddr_in {


### PR DESCRIPTION
The alignment field is actually a "pointer sized" type instead of always i64,
requiring that the size of the padding field is also calculated slightly
differently.

Closes #23425
