### PR TITLE
Move fn safety out of the subtyping relationship and into coercions

### DIFF
--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -993,8 +993,14 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
                     })
                 }
 
+                ty::AdjustUnsafeFnPointer => {
+                    this.emit_enum_variant("AdjustUnsafeFnPointer", 2, 0, |_| {
+                        Ok(())
+                    })
+                }
+
                 ty::AdjustDerefRef(ref auto_deref_ref) => {
-                    this.emit_enum_variant("AdjustDerefRef", 2, 2, |this| {
+                    this.emit_enum_variant("AdjustDerefRef", 3, 2, |this| {
                         this.emit_enum_variant_arg(0,
                             |this| Ok(this.emit_auto_deref_ref(ecx, auto_deref_ref)))
                     })
@@ -1619,6 +1625,9 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
                         ty::AdjustReifyFnPointer(def_id)
                     }
                     2 => {
+                        ty::AdjustUnsafeFnPointer
+                    }
+                    3 => {
                         let auto_deref_ref: ty::AutoDerefRef =
                             this.read_enum_variant_arg(0,
                                 |this| Ok(this.read_auto_deref_ref(dcx))).unwrap();

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -790,7 +790,8 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
             None => { }
             Some(adjustment) => {
                 match *adjustment {
-                    ty::AdjustReifyFnPointer(..) => {
+                    ty::AdjustReifyFnPointer(..) |
+                    ty::AdjustUnsafeFnPointer(..) => {
                         // Creating a closure/fn-pointer consumes the
                         // input and stores it into the resulting
                         // rvalue.

--- a/src/librustc/middle/infer/bivariate.rs
+++ b/src/librustc/middle/infer/bivariate.rs
@@ -74,16 +74,6 @@ impl<'f, 'tcx> Combine<'tcx> for Bivariate<'f, 'tcx> {
         Ok(a)
     }
 
-    fn mts(&self, a: &ty::mt<'tcx>, b: &ty::mt<'tcx>) -> cres<'tcx, ty::mt<'tcx>> {
-        debug!("mts({} <: {})",
-               a.repr(self.fields.infcx.tcx),
-               b.repr(self.fields.infcx.tcx));
-
-        if a.mutbl != b.mutbl { return Err(ty::terr_mutability); }
-        let t = try!(self.tys(a.ty, b.ty));
-        Ok(ty::mt { mutbl: a.mutbl, ty: t })
-    }
-
     fn unsafeties(&self, a: Unsafety, b: Unsafety) -> cres<'tcx, Unsafety> {
         if a != b {
             Err(ty::terr_unsafety_mismatch(expected_found(self, a, b)))

--- a/src/librustc/middle/infer/bivariate.rs
+++ b/src/librustc/middle/infer/bivariate.rs
@@ -33,8 +33,6 @@ use middle::infer::{cres};
 use middle::infer::type_variable::{BiTo};
 use util::ppaux::{Repr};
 
-use syntax::ast::{Unsafety};
-
 pub struct Bivariate<'f, 'tcx: 'f> {
     fields: CombineFields<'f, 'tcx>
 }
@@ -72,14 +70,6 @@ impl<'f, 'tcx> Combine<'tcx> for Bivariate<'f, 'tcx> {
 
     fn regions(&self, a: ty::Region, _: ty::Region) -> cres<'tcx, ty::Region> {
         Ok(a)
-    }
-
-    fn unsafeties(&self, a: Unsafety, b: Unsafety) -> cres<'tcx, Unsafety> {
-        if a != b {
-            Err(ty::terr_unsafety_mismatch(expected_found(self, a, b)))
-        } else {
-            Ok(a)
-        }
     }
 
     fn builtin_bounds(&self,

--- a/src/librustc/middle/infer/combine.rs
+++ b/src/librustc/middle/infer/combine.rs
@@ -263,7 +263,13 @@ pub trait Combine<'tcx> : Sized {
         self.tys_with_variance(ty::Contravariant, a, b).and_then(|t| Ok(t))
     }
 
-    fn unsafeties(&self, a: Unsafety, b: Unsafety) -> cres<'tcx, Unsafety>;
+    fn unsafeties(&self, a: Unsafety, b: Unsafety) -> cres<'tcx, Unsafety> {
+        if a != b {
+            Err(ty::terr_unsafety_mismatch(expected_found(self, a, b)))
+        } else {
+            Ok(a)
+        }
+    }
 
     fn abi(&self, a: abi::Abi, b: abi::Abi) -> cres<'tcx, abi::Abi> {
         if a == b {

--- a/src/librustc/middle/infer/combine.rs
+++ b/src/librustc/middle/infer/combine.rs
@@ -74,7 +74,24 @@ pub trait Combine<'tcx> : Sized {
     fn lub<'a>(&'a self) -> Lub<'a, 'tcx> { Lub(self.fields().clone()) }
     fn glb<'a>(&'a self) -> Glb<'a, 'tcx> { Glb(self.fields().clone()) }
 
-    fn mts(&self, a: &ty::mt<'tcx>, b: &ty::mt<'tcx>) -> cres<'tcx, ty::mt<'tcx>>;
+    fn mts(&self, a: &ty::mt<'tcx>, b: &ty::mt<'tcx>) -> cres<'tcx, ty::mt<'tcx>> {
+        debug!("{}.mts({}, {})",
+               self.tag(),
+               a.repr(self.tcx()),
+               b.repr(self.tcx()));
+
+        if a.mutbl != b.mutbl {
+            Err(ty::terr_mutability)
+        } else {
+            let mutbl = a.mutbl;
+            let variance = match mutbl {
+                ast::MutImmutable => ty::Covariant,
+                ast::MutMutable => ty::Invariant,
+            };
+            let ty = try!(self.tys_with_variance(variance, a.ty, b.ty));
+            Ok(ty::mt {ty: ty, mutbl: mutbl})
+        }
+    }
 
     fn tys_with_variance(&self, variance: ty::Variance, a: Ty<'tcx>, b: Ty<'tcx>)
                          -> cres<'tcx, Ty<'tcx>>;

--- a/src/librustc/middle/infer/equate.rs
+++ b/src/librustc/middle/infer/equate.rs
@@ -54,15 +54,6 @@ impl<'f, 'tcx> Combine<'tcx> for Equate<'f, 'tcx> {
         Ok(a)
     }
 
-    fn mts(&self, a: &ty::mt<'tcx>, b: &ty::mt<'tcx>) -> cres<'tcx, ty::mt<'tcx>> {
-        debug!("mts({} <: {})",
-               a.repr(self.fields.infcx.tcx),
-               b.repr(self.fields.infcx.tcx));
-
-        if a.mutbl != b.mutbl { return Err(ty::terr_mutability); }
-        let t = try!(self.tys(a.ty, b.ty));
-        Ok(ty::mt { mutbl: a.mutbl, ty: t })
-    }
 
     fn unsafeties(&self, a: Unsafety, b: Unsafety) -> cres<'tcx, Unsafety> {
         if a != b {

--- a/src/librustc/middle/infer/equate.rs
+++ b/src/librustc/middle/infer/equate.rs
@@ -16,8 +16,6 @@ use middle::infer::{Subtype};
 use middle::infer::type_variable::{EqTo};
 use util::ppaux::{Repr};
 
-use syntax::ast::Unsafety;
-
 pub struct Equate<'f, 'tcx: 'f> {
     fields: CombineFields<'f, 'tcx>
 }
@@ -52,15 +50,6 @@ impl<'f, 'tcx> Combine<'tcx> for Equate<'f, 'tcx> {
                b.repr(self.fields.infcx.tcx));
         self.infcx().region_vars.make_eqregion(Subtype(self.trace()), a, b);
         Ok(a)
-    }
-
-
-    fn unsafeties(&self, a: Unsafety, b: Unsafety) -> cres<'tcx, Unsafety> {
-        if a != b {
-            Err(ty::terr_unsafety_mismatch(expected_found(self, a, b)))
-        } else {
-            Ok(a)
-        }
     }
 
     fn tys(&self, a: Ty<'tcx>, b: Ty<'tcx>) -> cres<'tcx, Ty<'tcx>> {

--- a/src/librustc/middle/infer/glb.rs
+++ b/src/librustc/middle/infer/glb.rs
@@ -55,36 +55,6 @@ impl<'f, 'tcx> Combine<'tcx> for Glb<'f, 'tcx> {
         }
     }
 
-    fn mts(&self, a: &ty::mt<'tcx>, b: &ty::mt<'tcx>) -> cres<'tcx, ty::mt<'tcx>> {
-        let tcx = self.fields.infcx.tcx;
-
-        debug!("{}.mts({}, {})",
-               self.tag(),
-               mt_to_string(tcx, a),
-               mt_to_string(tcx, b));
-
-        match (a.mutbl, b.mutbl) {
-            // If one side or both is mut, then the GLB must use
-            // the precise type from the mut side.
-            (MutMutable, MutMutable) => {
-                let t = try!(self.equate().tys(a.ty, b.ty));
-                Ok(ty::mt {ty: t, mutbl: MutMutable})
-            }
-
-            // If one side or both is immutable, we can use the GLB of
-            // both sides but mutbl must be `MutImmutable`.
-            (MutImmutable, MutImmutable) => {
-                let t = try!(self.tys(a.ty, b.ty));
-                Ok(ty::mt {ty: t, mutbl: MutImmutable})
-            }
-
-            // There is no mutual subtype of these combinations.
-            (MutMutable, MutImmutable) |
-            (MutImmutable, MutMutable) => {
-                Err(ty::terr_mutability)
-            }
-        }
-    }
 
     fn unsafeties(&self, a: Unsafety, b: Unsafety) -> cres<'tcx, Unsafety> {
         match (a, b) {

--- a/src/librustc/middle/infer/glb.rs
+++ b/src/librustc/middle/infer/glb.rs
@@ -15,8 +15,6 @@ use super::{cres};
 use super::Subtype;
 
 use middle::ty::{self, Ty};
-use syntax::ast::{MutImmutable, MutMutable, Unsafety};
-use util::ppaux::mt_to_string;
 use util::ppaux::Repr;
 
 /// "Greatest lower bound" (common subtype)
@@ -52,14 +50,6 @@ impl<'f, 'tcx> Combine<'tcx> for Glb<'f, 'tcx> {
             ty::Covariant => self.regions(a, b),
             ty::Bivariant => self.bivariate().regions(a, b),
             ty::Contravariant => self.lub().regions(a, b),
-        }
-    }
-
-
-    fn unsafeties(&self, a: Unsafety, b: Unsafety) -> cres<'tcx, Unsafety> {
-        match (a, b) {
-          (Unsafety::Normal, _) | (_, Unsafety::Normal) => Ok(Unsafety::Normal),
-          (Unsafety::Unsafe, Unsafety::Unsafe) => Ok(Unsafety::Unsafe)
         }
     }
 

--- a/src/librustc/middle/infer/lub.rs
+++ b/src/librustc/middle/infer/lub.rs
@@ -55,32 +55,6 @@ impl<'f, 'tcx> Combine<'tcx> for Lub<'f, 'tcx> {
         }
     }
 
-    fn mts(&self, a: &ty::mt<'tcx>, b: &ty::mt<'tcx>) -> cres<'tcx, ty::mt<'tcx>> {
-        let tcx = self.tcx();
-
-        debug!("{}.mts({}, {})",
-               self.tag(),
-               mt_to_string(tcx, a),
-               mt_to_string(tcx, b));
-
-        if a.mutbl != b.mutbl {
-            return Err(ty::terr_mutability)
-        }
-
-        let m = a.mutbl;
-        match m {
-            MutImmutable => {
-                let t = try!(self.tys(a.ty, b.ty));
-                Ok(ty::mt {ty: t, mutbl: m})
-            }
-
-            MutMutable => {
-                let t = try!(self.equate().tys(a.ty, b.ty));
-                Ok(ty::mt {ty: t, mutbl: m})
-            }
-        }
-    }
-
     fn unsafeties(&self, a: Unsafety, b: Unsafety) -> cres<'tcx, Unsafety> {
         match (a, b) {
           (Unsafety::Unsafe, _) | (_, Unsafety::Unsafe) => Ok(Unsafety::Unsafe),

--- a/src/librustc/middle/infer/lub.rs
+++ b/src/librustc/middle/infer/lub.rs
@@ -15,8 +15,6 @@ use super::{cres};
 use super::{Subtype};
 
 use middle::ty::{self, Ty};
-use syntax::ast::{MutMutable, MutImmutable, Unsafety};
-use util::ppaux::mt_to_string;
 use util::ppaux::Repr;
 
 /// "Least upper bound" (common supertype)
@@ -52,13 +50,6 @@ impl<'f, 'tcx> Combine<'tcx> for Lub<'f, 'tcx> {
             ty::Covariant => self.regions(a, b),
             ty::Bivariant => self.bivariate().regions(a, b),
             ty::Contravariant => self.glb().regions(a, b),
-        }
-    }
-
-    fn unsafeties(&self, a: Unsafety, b: Unsafety) -> cres<'tcx, Unsafety> {
-        match (a, b) {
-          (Unsafety::Unsafe, _) | (_, Unsafety::Unsafe) => Ok(Unsafety::Unsafe),
-          (Unsafety::Normal, Unsafety::Normal) => Ok(Unsafety::Normal),
         }
     }
 

--- a/src/librustc/middle/infer/sub.rs
+++ b/src/librustc/middle/infer/sub.rs
@@ -66,30 +66,6 @@ impl<'f, 'tcx> Combine<'tcx> for Sub<'f, 'tcx> {
         Ok(a)
     }
 
-    fn mts(&self, a: &ty::mt<'tcx>, b: &ty::mt<'tcx>) -> cres<'tcx, ty::mt<'tcx>> {
-        debug!("mts({} <: {})",
-               a.repr(self.tcx()),
-               b.repr(self.tcx()));
-
-        if a.mutbl != b.mutbl {
-            return Err(ty::terr_mutability);
-        }
-
-        match b.mutbl {
-            MutMutable => {
-                // If supertype is mut, subtype must match exactly
-                // (i.e., invariant if mut):
-                try!(self.equate().tys(a.ty, b.ty));
-            }
-            MutImmutable => {
-                // Otherwise we can be covariant:
-                try!(self.tys(a.ty, b.ty));
-            }
-        }
-
-        Ok(*a) // return is meaningless in sub, just return *a
-    }
-
     fn unsafeties(&self, a: Unsafety, b: Unsafety) -> cres<'tcx, Unsafety> {
         self.lub().unsafeties(a, b).compare(b, || {
             ty::terr_unsafety_mismatch(expected_found(self, a, b))

--- a/src/librustc/middle/infer/sub.rs
+++ b/src/librustc/middle/infer/sub.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use super::combine::*;
-use super::{cres, CresCompare};
+use super::{cres};
 use super::higher_ranked::HigherRankedRelations;
 use super::{Subtype};
 use super::type_variable::{SubtypeOf, SupertypeOf};
@@ -17,9 +17,6 @@ use super::type_variable::{SubtypeOf, SupertypeOf};
 use middle::ty::{self, Ty};
 use middle::ty::TyVar;
 use util::ppaux::{Repr};
-
-use syntax::ast::{MutImmutable, MutMutable, Unsafety};
-
 
 /// "Greatest lower bound" (common subtype)
 pub struct Sub<'f, 'tcx: 'f> {
@@ -64,12 +61,6 @@ impl<'f, 'tcx> Combine<'tcx> for Sub<'f, 'tcx> {
                b.repr(self.tcx()));
         self.infcx().region_vars.make_subregion(Subtype(self.trace()), a, b);
         Ok(a)
-    }
-
-    fn unsafeties(&self, a: Unsafety, b: Unsafety) -> cres<'tcx, Unsafety> {
-        self.lub().unsafeties(a, b).compare(b, || {
-            ty::terr_unsafety_mismatch(expected_found(self, a, b))
-        })
     }
 
     fn tys(&self, a: Ty<'tcx>, b: Ty<'tcx>) -> cres<'tcx, Ty<'tcx>> {

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -428,7 +428,8 @@ impl<'t,'tcx,TYPER:Typer<'tcx>> MemCategorizationContext<'t,TYPER> {
 
             Some(adjustment) => {
                 match *adjustment {
-                    ty::AdjustReifyFnPointer(..) => {
+                    ty::AdjustReifyFnPointer(..) |
+                    ty::AdjustUnsafeFnPointer(..) => {
                         debug!("cat_expr(AdjustReifyFnPointer): {}",
                                expr.repr(self.tcx()));
                         // Convert a bare fn to a closure by adding NULL env.

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -282,6 +282,7 @@ pub enum Variance {
 #[derive(Clone, Debug)]
 pub enum AutoAdjustment<'tcx> {
     AdjustReifyFnPointer(ast::DefId), // go from a fn-item type to a fn-pointer type
+    AdjustUnsafeFnPointer, // go from a safe fn pointer to an unsafe fn pointer
     AdjustDerefRef(AutoDerefRef<'tcx>)
 }
 
@@ -2637,6 +2638,17 @@ impl<'tcx> ctxt<'tcx> {
         substs
     }
 
+    /// Create an unsafe fn ty based on a safe fn ty.
+    pub fn safe_to_unsafe_fn_ty(&self, bare_fn: &BareFnTy<'tcx>) -> Ty<'tcx> {
+        assert_eq!(bare_fn.unsafety, ast::Unsafety::Normal);
+        let unsafe_fn_ty_a = self.mk_bare_fn(ty::BareFnTy {
+            unsafety: ast::Unsafety::Unsafe,
+            abi: bare_fn.abi,
+            sig: bare_fn.sig.clone()
+        });
+        ty::mk_bare_fn(self, None, unsafe_fn_ty_a)
+    }
+
     pub fn mk_bare_fn(&self, bare_fn: BareFnTy<'tcx>) -> &'tcx BareFnTy<'tcx> {
         if let Some(bare_fn) = self.bare_fn_interner.borrow().get(&bare_fn) {
             return *bare_fn;
@@ -4525,6 +4537,18 @@ pub fn adjust_ty<'tcx, F>(cx: &ctxt<'tcx>,
                         }
                     }
                 }
+
+               AdjustUnsafeFnPointer => {
+                    match unadjusted_ty.sty {
+                        ty::ty_bare_fn(None, b) => cx.safe_to_unsafe_fn_ty(b),
+                        ref b => {
+                            cx.sess.bug(
+                                &format!("AdjustReifyFnPointer adjustment on non-fn-item: \
+                                         {:?}",
+                                        b));
+                        }
+                    }
+               }
 
                 AdjustDerefRef(ref adj) => {
                     let mut adjusted_ty = unadjusted_ty;
@@ -6695,6 +6719,7 @@ impl<'tcx> AutoAdjustment<'tcx> {
     pub fn is_identity(&self) -> bool {
         match *self {
             AdjustReifyFnPointer(..) => false,
+            AdjustUnsafeFnPointer(..) => false,
             AdjustDerefRef(ref r) => r.is_identity(),
         }
     }
@@ -6843,6 +6868,9 @@ impl<'tcx> Repr<'tcx> for AutoAdjustment<'tcx> {
         match *self {
             AdjustReifyFnPointer(def_id) => {
                 format!("AdjustReifyFnPointer({})", def_id.repr(tcx))
+            }
+            AdjustUnsafeFnPointer => {
+                format!("AdjustUnsafeFnPointer")
             }
             AdjustDerefRef(ref data) => {
                 data.repr(tcx)

--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -253,6 +253,9 @@ pub fn const_expr<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             // FIXME(#19925) once fn item types are
             // zero-sized, we'll need to do something here
         }
+        Some(ty::AdjustUnsafeFnPointer) => {
+            // purely a type-level thing
+        }
         Some(ty::AdjustDerefRef(adj)) => {
             let mut ty = ety;
             // Save the last autoderef in case we can avoid it.

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -72,7 +72,7 @@ use trans::monomorphize;
 use trans::tvec;
 use trans::type_of;
 use middle::ty::{struct_fields, tup_fields};
-use middle::ty::{AdjustDerefRef, AdjustReifyFnPointer, AutoUnsafe};
+use middle::ty::{AdjustDerefRef, AdjustReifyFnPointer, AdjustUnsafeFnPointer, AutoUnsafe};
 use middle::ty::{AutoPtr};
 use middle::ty::{self, Ty};
 use middle::ty::MethodCall;
@@ -395,6 +395,9 @@ fn apply_adjustments<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         AdjustReifyFnPointer(_def_id) => {
             // FIXME(#19925) once fn item types are
             // zero-sized, we'll need to do something here
+        }
+        AdjustUnsafeFnPointer => {
+            // purely a type-level thing
         }
         AdjustDerefRef(ref adj) => {
             let (autoderefs, use_autoref) = match adj.autoref {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1532,8 +1532,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                        span: Span,
                                        adj: &ty::AutoAdjustment<'tcx>) {
         match *adj {
-            ty::AdjustReifyFnPointer(..) => {
-            }
+            ty::AdjustReifyFnPointer(..) => { }
+            ty::AdjustUnsafeFnPointer => { }
             ty::AdjustDerefRef(ref d_r) => {
                 match d_r.autoref {
                     Some(ref a_r) => {

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -265,6 +265,10 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                         ty::AdjustReifyFnPointer(def_id)
                     }
 
+                    ty::AdjustUnsafeFnPointer => {
+                        ty::AdjustUnsafeFnPointer
+                    }
+
                     ty::AdjustDerefRef(adj) => {
                         for autoderef in 0..adj.autoderefs {
                             let method_call = MethodCall::autoderef(id, autoderef);

--- a/src/test/compile-fail/unsafe-subtyping.rs
+++ b/src/test/compile-fail/unsafe-subtyping.rs
@@ -1,0 +1,21 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that safe fns are not a subtype of unsafe fns.
+
+fn foo(x: Option<fn(i32)>) -> Option<unsafe fn(i32)> {
+    x //~ ERROR mismatched types
+}
+
+fn bar(x: fn(i32)) -> unsafe fn(i32) {
+    x // OK, coercion!
+}
+
+fn main() { }

--- a/src/test/compile-fail/unsafe-trait-impl.rs
+++ b/src/test/compile-fail/unsafe-trait-impl.rs
@@ -1,0 +1,22 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that safe fns are not a subtype of unsafe fns.
+
+trait Foo {
+    unsafe fn len(&self) -> u32;
+}
+
+impl Foo for u32 {
+    fn len(&self) -> u32 { *self }
+    //~^ ERROR incompatible type for trait: expected unsafe fn, found normal fn
+}
+
+fn main() { }

--- a/src/test/compile-fail/variadic-ffi.rs
+++ b/src/test/compile-fail/variadic-ffi.rs
@@ -30,9 +30,9 @@ fn main() {
         //~| expected non-variadic fn
         //~| found variadic function
 
-        let y: unsafe extern "C" fn(f: isize, x: u8, ...) = bar;
+        let y: extern "C" fn(f: isize, x: u8, ...) = bar;
         //~^ ERROR: mismatched types
-        //~| expected `unsafe extern "C" fn(isize, u8, ...)`
+        //~| expected `extern "C" fn(isize, u8, ...)`
         //~| found `extern "C" fn(isize, u8) {bar}`
         //~| expected variadic fn
         //~| found non-variadic function

--- a/src/test/run-pass/unsafe-coercion.rs
+++ b/src/test/run-pass/unsafe-coercion.rs
@@ -1,0 +1,25 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that safe fns are not a subtype of unsafe fns.
+
+fn foo(x: i32) -> i32 {
+    x * 22
+}
+
+fn bar(x: fn(i32) -> i32) -> unsafe fn(i32) -> i32 {
+    x // OK, coercion!
+}
+
+fn main() {
+    let f = bar(foo);
+    let x = unsafe { f(2) };
+    assert_eq!(x, 44);
+}


### PR DESCRIPTION
Safe fns are no longer subtypes of unsafe fns, but you can coerce from one to the other.

This is a [breaking-change] in that impl fns must now be declared `unsafe` if the trait is declared `unsafe`. In some rare cases, the subtyping change may also direct affect you, but no such cases were encountered in practice.

Fixes #23449.

r? @nrc 
