### PR TITLE
Add frame_address intrinsic

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -241,6 +241,18 @@ extern "rust-intrinsic" {
     /// will trigger a compiler error.
     pub fn return_address() -> *const u8;
 
+    /// Attempts to return the address of the target-specific frame pointer value of the specified
+    /// frame.
+    ///
+    /// The intrinsic argument specifies which frame to return address for. Current frame is 0th,
+    /// caller frame is 1st and so on.
+    ///
+    /// The return value is, in most cases, quite inaccurate for `frame` ≠ 0 and 0 will be returned
+    /// if the frame cannot be identified. Calling this intrinsic does not prevent function
+    /// inlining or other aggressive transformations, so the value returned may not be obvious.
+    #[cfg(not(stage0))]
+    pub fn frame_address(frame: u32) -> *const u8;
+
     /// Returns `true` if the actual type given as `T` requires drop
     /// glue; returns `false` if the actual type provided for `T`
     /// implements `Copy`.

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -676,6 +676,11 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
             }
         }
 
+        (_, "frame_address") => {
+            let llfn = ccx.get_intrinsic(&("llvm.frameaddress"));
+            Call(bcx, llfn, &[llargs[0]], None, call_debug_location)
+        }
+
         // This requires that atomic intrinsics follow a specific naming pattern:
         // "atomic_<operation>[_<ordering>]", and no ordering means SeqCst
         (_, name) if name.starts_with("atomic_") => {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5521,6 +5521,11 @@ pub fn check_intrinsic_type(ccx: &CrateCtxt, it: &ast::ForeignItem) {
 
             "return_address" => (0, vec![], ty::mk_imm_ptr(tcx, tcx.types.u8)),
 
+            "frame_address" => (0, vec![tcx.types.u32], ty::mk_ptr(ccx.tcx, ty::mt {
+                ty: tcx.types.u8,
+                mutbl: ast::MutImmutable
+            })),
+
             "assume" => (0, vec![tcx.types.bool], ty::mk_nil(tcx)),
 
             ref other => {


### PR DESCRIPTION
This intrinsic provides that small piece of stack introspection power I might use making stacks not use `/proc/` anymore.
