### PR TITLE
std: Remove old_io/old_path from the prelude

### DIFF
--- a/src/compiletest/procsrv.rs
+++ b/src/compiletest/procsrv.rs
@@ -10,9 +10,10 @@
 
 #![allow(deprecated)] // for old path, for dynamic_lib
 
-use std::process::{ExitStatus, Command, Child, Output, Stdio};
-use std::io::prelude::*;
 use std::dynamic_lib::DynamicLibrary;
+use std::io::prelude::*;
+use std::old_path::Path;
+use std::process::{ExitStatus, Command, Child, Output, Stdio};
 
 fn add_target_env(cmd: &mut Command, lib_path: &str, aux_path: Option<&str>) {
     // Need to be sure to put both the lib_path and the aux path in the dylib

--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -262,6 +262,7 @@
 //!
 //! ```
 //! # #![allow(unused_must_use)]
+//! use std::io::Write;
 //! let mut w = Vec::new();
 //! write!(&mut w, "Hello {}!", "world");
 //! ```
@@ -288,15 +289,15 @@
 //!
 //! ```
 //! use std::fmt;
-//! use std::old_io;
+//! use std::io::{self, Write};
 //!
 //! fmt::format(format_args!("this returns {}", "String"));
 //!
-//! let mut some_writer = old_io::stdout();
+//! let mut some_writer = io::stdout();
 //! write!(&mut some_writer, "{}", format_args!("print with a {}", "macro"));
 //!
 //! fn my_fmt_fn(args: fmt::Arguments) {
-//!     write!(&mut old_io::stdout(), "{}", args);
+//!     write!(&mut io::stdout(), "{}", args);
 //! }
 //! my_fmt_fn(format_args!("or a {} too", "function"));
 //! ```

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -176,6 +176,7 @@ macro_rules! try {
 ///
 /// ```
 /// # #![allow(unused_must_use)]
+/// use std::io::Write;
 ///
 /// let mut w = Vec::new();
 /// write!(&mut w, "test");

--- a/src/libcore/prelude.rs
+++ b/src/libcore/prelude.rs
@@ -29,8 +29,6 @@ pub use marker::{Copy, Send, Sized, Sync};
 pub use ops::{Drop, Fn, FnMut, FnOnce};
 
 // Reexported functions
-#[allow(deprecated)]
-pub use iter::range;
 pub use mem::drop;
 
 // Reexported types and traits

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -110,7 +110,8 @@
 //! something like this:
 //!
 //! ```{.ignore}
-//! use std::old_io::{File, Open, Write};
+//! use std::old_io::*;
+//! use std::old_path::Path;
 //!
 //! let mut file = File::open_mode(&Path::new("valuable_data.txt"), Open, Write);
 //! // If `write_line` errors, then we'll never know, because the return
@@ -128,7 +129,8 @@
 //! a marginally useful message indicating why:
 //!
 //! ```{.no_run}
-//! use std::old_io::{File, Open, Write};
+//! use std::old_io::*;
+//! use std::old_path::Path;
 //!
 //! let mut file = File::open_mode(&Path::new("valuable_data.txt"), Open, Write);
 //! file.write_line("important message").ok().expect("failed to write message");
@@ -138,7 +140,8 @@
 //! You might also simply assert success:
 //!
 //! ```{.no_run}
-//! # use std::old_io::{File, Open, Write};
+//! # use std::old_io::*;
+//! # use std::old_path::Path;
 //!
 //! # let mut file = File::open_mode(&Path::new("valuable_data.txt"), Open, Write);
 //! assert!(file.write_line("important message").is_ok());
@@ -148,7 +151,8 @@
 //! Or propagate the error up the call stack with `try!`:
 //!
 //! ```
-//! # use std::old_io::{File, Open, Write, IoError};
+//! # use std::old_io::*;
+//! # use std::old_path::Path;
 //! fn write_message() -> Result<(), IoError> {
 //!     let mut file = File::open_mode(&Path::new("valuable_data.txt"), Open, Write);
 //!     try!(file.write_line("important message"));
@@ -167,7 +171,8 @@
 //! It replaces this:
 //!
 //! ```
-//! use std::old_io::{File, Open, Write, IoError};
+//! use std::old_io::*;
+//! use std::old_path::Path;
 //!
 //! struct Info {
 //!     name: String,
@@ -191,7 +196,8 @@
 //! With this:
 //!
 //! ```
-//! use std::old_io::{File, Open, Write, IoError};
+//! use std::old_io::*;
+//! use std::old_path::Path;
 //!
 //! struct Info {
 //!     name: String,
@@ -446,7 +452,7 @@ impl<T, E> Result<T, E> {
     /// ignoring I/O and parse errors:
     ///
     /// ```
-    /// use std::old_io::IoResult;
+    /// use std::old_io::*;
     ///
     /// let mut buffer: &[u8] = b"1\n2\n3\n4\n";
     /// let mut buffer = &mut buffer;

--- a/src/libcoretest/str.rs
+++ b/src/libcoretest/str.rs
@@ -35,7 +35,7 @@ fn test_bool_from_str() {
 fn check_contains_all_substrings(s: &str) {
     assert!(s.contains(""));
     for i in 0..s.len() {
-        for j in range(i+1, s.len() + 1) {
+        for j in i+1..s.len() + 1 {
             assert!(s.contains(&s[i..j]));
         }
     }

--- a/src/librustc_back/fs.rs
+++ b/src/librustc_back/fs.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use std::io;
-#[allow(deprecated)] use std::old_path;
+#[allow(deprecated)] use std::old_path::{self, GenericPath};
 #[allow(deprecated)] use std::old_io;
 use std::path::{Path, PathBuf};
 
@@ -72,6 +72,7 @@ mod test {
     use std::old_io::fs::{File, symlink, mkdir, mkdir_recursive};
     use super::old_realpath as realpath;
     use std::old_io::TempDir;
+    use std::old_path::{Path, GenericPath};
 
     #[test]
     fn realpath_works() {

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -64,6 +64,8 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::mpsc::channel;
 
+#[allow(deprecated)] use std::old_path::Path;
+
 use externalfiles::ExternalHtml;
 use serialize::Decodable;
 use serialize::json::{self, Json};

--- a/src/librustdoc/plugins.rs
+++ b/src/librustdoc/plugins.rs
@@ -16,6 +16,7 @@ use std::dynamic_lib as dl;
 use serialize::json;
 use std::mem;
 use std::string::String;
+use std::old_path::{Path, GenericPath};
 
 pub type PluginJson = Option<(String, json::Json)>;
 pub type PluginResult = (clean::Crate, PluginJson);

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -2622,6 +2622,7 @@ mod tests {
     use std::{i64, u64, f32, f64};
     use std::collections::BTreeMap;
     use std::string;
+    use std::old_io::Writer;
 
     #[derive(RustcDecodable, Eq, PartialEq, Debug)]
     struct OptionData {

--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -15,7 +15,7 @@ Core encoding and decoding interfaces.
 */
 
 #[allow(deprecated)]
-use std::old_path;
+use std::old_path::{self, GenericPath};
 use std::path;
 use std::rc::Rc;
 use std::cell::{Cell, RefCell};

--- a/src/libstd/dynamic_lib.rs
+++ b/src/libstd/dynamic_lib.rs
@@ -18,11 +18,12 @@
 
 use prelude::v1::*;
 
+use env;
 use ffi::CString;
 use mem;
-use env;
-use str;
+use old_path::{Path, GenericPath};
 use os;
+use str;
 
 pub struct DynamicLibrary {
     handle: *mut u8
@@ -133,6 +134,7 @@ mod test {
     use super::*;
     use prelude::v1::*;
     use libc;
+    use old_path::Path;
     use mem;
 
     #[test]
@@ -140,8 +142,7 @@ mod test {
     fn test_loading_cosine() {
         // The math library does not need to be loaded since it is already
         // statically linked in
-        let none: Option<&Path> = None; // appease the typechecker
-        let libm = match DynamicLibrary::open(none) {
+        let libm = match DynamicLibrary::open(None) {
             Err(error) => panic!("Could not load self as module: {}", error),
             Ok(libm) => libm
         };

--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -729,10 +729,11 @@ mod arch {
 mod tests {
     use prelude::v1::*;
     use super::*;
+
     use iter::repeat;
     use rand::{self, Rng};
     use ffi::{OsString, OsStr};
-    use path::PathBuf;
+    use path::{Path, PathBuf};
 
     fn make_rand_name() -> OsString {
         let mut rng = rand::thread_rng();

--- a/src/libstd/fs/mod.rs
+++ b/src/libstd/fs/mod.rs
@@ -801,6 +801,7 @@ mod tests {
     use prelude::v1::*;
     use io::prelude::*;
 
+    use env;
     use fs::{self, File, OpenOptions};
     use io::{ErrorKind, SeekFrom};
     use path::PathBuf;
@@ -848,8 +849,7 @@ mod tests {
     }
 
     pub fn tmpdir() -> TempDir {
-        let s = os::tmpdir();
-        let p = Path2::new(s.as_str().unwrap());
+        let p = env::temp_dir();
         let ret = p.join(&format!("rust-{}", rand::random::<u32>()));
         check!(fs::create_dir(&ret));
         TempDir(ret)
@@ -1082,7 +1082,7 @@ mod tests {
         let dir = &tmpdir.join("di_readdir");
         check!(fs::create_dir(dir));
         let prefix = "foo";
-        for n in range(0, 3) {
+        for n in 0..3 {
             let f = dir.join(&format!("{}.txt", n));
             let mut w = check!(File::create(&f));
             let msg_str = format!("{}{}", prefix, n.to_string());

--- a/src/libstd/io/prelude.rs
+++ b/src/libstd/io/prelude.rs
@@ -23,8 +23,5 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-pub use super::{Read, Write, BufRead};
+pub use super::{Read, Write, BufRead, Seek};
 pub use fs::PathExt;
-
-// FIXME: pub use as `Seek` when the name isn't in the actual prelude any more
-pub use super::Seek as NewSeek;

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -1650,7 +1650,7 @@ mod tests {
                 #![test]
                 assert_eq!((0 as $T).next_power_of_two(), 1);
                 let mut next_power = 1;
-                for i in range::<$T>(1, 40) {
+                for i in 1 as $T..40 {
                      assert_eq!(i.next_power_of_two(), next_power);
                      if i == next_power { next_power *= 2 }
                 }
@@ -1673,7 +1673,7 @@ mod tests {
                 assert_eq!(($T::MAX - 1).checked_next_power_of_two(), None);
                 assert_eq!($T::MAX.checked_next_power_of_two(), None);
                 let mut next_power = 1;
-                for i in range::<$T>(1, 40) {
+                for i in 1 as $T..40 {
                      assert_eq!(i.checked_next_power_of_two(), Some(next_power));
                      if i == next_power { next_power *= 2 }
                 }

--- a/src/libstd/old_io/buffered.rs
+++ b/src/libstd/old_io/buffered.rs
@@ -33,7 +33,8 @@ use vec::Vec;
 /// # Examples
 ///
 /// ```
-/// use std::old_io::{BufferedReader, File};
+/// use std::old_io::*;
+/// use std::old_path::Path;
 ///
 /// let file = File::open(&Path::new("message.txt"));
 /// let mut reader = BufferedReader::new(file);
@@ -136,7 +137,8 @@ impl<R: Reader> Reader for BufferedReader<R> {
 /// # Examples
 ///
 /// ```
-/// use std::old_io::{BufferedWriter, File};
+/// use std::old_io::*;
+/// use std::old_path::Path;
 ///
 /// let file = File::create(&Path::new("message.txt")).unwrap();
 /// let mut writer = BufferedWriter::new(file);
@@ -323,7 +325,8 @@ impl<W: Reader> Reader for InternalBufferedWriter<W> {
 ///
 /// ```
 /// # #![allow(unused_must_use)]
-/// use std::old_io::{BufferedStream, File};
+/// use std::old_io::*;
+/// use std::old_path::Path;
 ///
 /// let file = File::open(&Path::new("message.txt"));
 /// let mut stream = BufferedStream::new(file);
@@ -422,7 +425,7 @@ impl<S: Stream> Writer for BufferedStream<S> {
 #[cfg(test)]
 mod test {
     extern crate test;
-    use old_io;
+    use old_io::{self, Reader, Writer, Buffer, BufferPrelude};
     use prelude::v1::*;
     use super::*;
     use super::super::{IoResult, EndOfFile};

--- a/src/libstd/old_io/comm_adapters.rs
+++ b/src/libstd/old_io/comm_adapters.rs
@@ -24,7 +24,7 @@ use vec::Vec;
 ///
 /// ```
 /// use std::sync::mpsc::channel;
-/// use std::old_io::ChanReader;
+/// use std::old_io::*;
 ///
 /// let (tx, rx) = channel();
 /// # drop(tx);
@@ -116,7 +116,7 @@ impl Reader for ChanReader {
 /// ```
 /// # #![allow(unused_must_use)]
 /// use std::sync::mpsc::channel;
-/// use std::old_io::ChanWriter;
+/// use std::old_io::*;
 ///
 /// let (tx, rx) = channel();
 /// # drop(rx);
@@ -160,7 +160,7 @@ mod test {
 
     use sync::mpsc::channel;
     use super::*;
-    use old_io;
+    use old_io::{self, Reader, Writer, Buffer};
     use thread;
 
     #[test]

--- a/src/libstd/old_io/extensions.rs
+++ b/src/libstd/old_io/extensions.rs
@@ -179,7 +179,7 @@ pub fn u64_from_be_bytes(data: &[u8], start: uint, size: uint) -> u64 {
 #[cfg(test)]
 mod test {
     use prelude::v1::*;
-    use old_io;
+    use old_io::{self, Reader, Writer};
     use old_io::{MemReader, BytesReader};
 
     struct InitialZeroByteReader {

--- a/src/libstd/old_io/fs.rs
+++ b/src/libstd/old_io/fs.rs
@@ -32,7 +32,8 @@
 //! ```rust
 //! # #![allow(unused_must_use)]
 //! use std::old_io::fs::PathExtensions;
-//! use std::old_io::{File, fs};
+//! use std::old_io::*;
+//! use std::old_path::Path;
 //!
 //! let path = Path::new("foo.txt");
 //!
@@ -104,7 +105,8 @@ impl File {
     /// # Examples
     ///
     /// ```rust,should_fail
-    /// use std::old_io::{File, Open, ReadWrite};
+    /// use std::old_io::*;
+    /// use std::old_path::Path;
     ///
     /// let p = Path::new("/some/file/path.txt");
     ///
@@ -175,7 +177,8 @@ impl File {
     /// # Examples
     ///
     /// ```
-    /// use std::old_io::File;
+    /// use std::old_io::*;
+    /// use std::old_path::Path;
     ///
     /// let contents = File::open(&Path::new("foo.txt")).read_to_end();
     /// ```
@@ -195,7 +198,8 @@ impl File {
     ///
     /// ```
     /// # #![allow(unused_must_use)]
-    /// use std::old_io::File;
+    /// use std::old_io::*;
+    /// use std::old_path::Path;
     ///
     /// let mut f = File::create(&Path::new("foo.txt"));
     /// f.write(b"This is a sample file");
@@ -286,7 +290,8 @@ impl File {
 ///
 /// ```
 /// # #![allow(unused_must_use)]
-/// use std::old_io::fs;
+/// use std::old_io::*;
+/// use std::old_path::Path;
 ///
 /// let p = Path::new("/some/file/path.txt");
 /// fs::unlink(&p);
@@ -316,7 +321,8 @@ pub fn unlink(path: &Path) -> IoResult<()> {
 /// # Examples
 ///
 /// ```
-/// use std::old_io::fs;
+/// use std::old_io::*;
+/// use std::old_path::Path;
 ///
 /// let p = Path::new("/some/file/path.txt");
 /// match fs::stat(&p) {
@@ -359,7 +365,8 @@ pub fn lstat(path: &Path) -> IoResult<FileStat> {
 ///
 /// ```
 /// # #![allow(unused_must_use)]
-/// use std::old_io::fs;
+/// use std::old_io::*;
+/// use std::old_path::Path;
 ///
 /// fs::rename(&Path::new("foo"), &Path::new("bar"));
 /// ```
@@ -387,7 +394,8 @@ pub fn rename(from: &Path, to: &Path) -> IoResult<()> {
 ///
 /// ```
 /// # #![allow(unused_must_use)]
-/// use std::old_io::fs;
+/// use std::old_io::*;
+/// use std::old_path::Path;
 ///
 /// fs::copy(&Path::new("foo.txt"), &Path::new("bar.txt"));
 /// ```
@@ -438,7 +446,8 @@ pub fn copy(from: &Path, to: &Path) -> IoResult<()> {
 /// ```
 /// # #![allow(unused_must_use)]
 /// use std::old_io;
-/// use std::old_io::fs;
+/// use std::old_io::*;
+/// use std::old_path::Path;
 ///
 /// fs::chmod(&Path::new("file.txt"), old_io::USER_FILE);
 /// fs::chmod(&Path::new("file.txt"), old_io::USER_READ | old_io::USER_WRITE);
@@ -509,7 +518,8 @@ pub fn readlink(path: &Path) -> IoResult<Path> {
 /// ```
 /// # #![allow(unused_must_use)]
 /// use std::old_io;
-/// use std::old_io::fs;
+/// use std::old_io::*;
+/// use std::old_path::Path;
 ///
 /// let p = Path::new("/some/dir");
 /// fs::mkdir(&p, old_io::USER_RWX);
@@ -532,7 +542,8 @@ pub fn mkdir(path: &Path, mode: FilePermission) -> IoResult<()> {
 ///
 /// ```
 /// # #![allow(unused_must_use)]
-/// use std::old_io::fs;
+/// use std::old_io::*;
+/// use std::old_path::Path;
 ///
 /// let p = Path::new("/some/dir");
 /// fs::rmdir(&p);
@@ -556,8 +567,9 @@ pub fn rmdir(path: &Path) -> IoResult<()> {
 ///
 /// ```
 /// use std::old_io::fs::PathExtensions;
-/// use std::old_io::fs;
 /// use std::old_io;
+/// use std::old_io::*;
+/// use std::old_path::Path;
 ///
 /// // one possible implementation of fs::walk_dir only visiting files
 /// fn visit_dirs<F>(dir: &Path, cb: &mut F) -> old_io::IoResult<()> where
@@ -881,7 +893,8 @@ fn access_string(access: FileAccess) -> &'static str {
 mod test {
     use prelude::v1::*;
     use old_io::{SeekSet, SeekCur, SeekEnd, Read, Open, ReadWrite, FileType};
-    use old_io;
+    use old_io::{self, Reader, Writer, Seek};
+    use old_path::{Path, GenericPath};
     use str;
     use old_io::fs::*;
 

--- a/src/libstd/old_io/mem.rs
+++ b/src/libstd/old_io/mem.rs
@@ -55,7 +55,7 @@ impl Writer for Vec<u8> {
 ///
 /// ```
 /// # #![allow(unused_must_use)]
-/// use std::old_io::MemWriter;
+/// use std::old_io::*;
 ///
 /// let mut w = MemWriter::new();
 /// w.write(&[0, 1, 2]);
@@ -115,7 +115,7 @@ impl Writer for MemWriter {
 ///
 /// ```
 /// # #![allow(unused_must_use)]
-/// use std::old_io::MemReader;
+/// use std::old_io::*;
 ///
 /// let mut r = MemReader::new(vec!(0, 1, 2));
 ///
@@ -245,7 +245,7 @@ impl<'a> Buffer for &'a [u8] {
 ///
 /// ```
 /// # #![allow(unused_must_use)]
-/// use std::old_io::BufWriter;
+/// use std::old_io::*;
 ///
 /// let mut buf = [0; 4];
 /// {
@@ -317,7 +317,7 @@ impl<'a> Seek for BufWriter<'a> {
 ///
 /// ```
 /// # #![allow(unused_must_use)]
-/// use std::old_io::BufReader;
+/// use std::old_io::*;
 ///
 /// let buf = [0, 1, 2, 3];
 /// let mut r = BufReader::new(&buf);
@@ -394,8 +394,8 @@ impl<'a> Buffer for BufReader<'a> {
 #[cfg(test)]
 mod test {
     extern crate "test" as test_crate;
-    use old_io::{SeekSet, SeekCur, SeekEnd, Reader, Writer, Seek};
-    use prelude::v1::{Ok, Err, range,  Vec, Buffer,  AsSlice};
+    use old_io::{SeekSet, SeekCur, SeekEnd, Reader, Writer, Seek, Buffer};
+    use prelude::v1::{Ok, Err, Vec,  AsSlice};
     use prelude::v1::IteratorExt;
     use old_io;
     use iter::repeat;

--- a/src/libstd/old_io/mod.rs
+++ b/src/libstd/old_io/mod.rs
@@ -49,6 +49,7 @@
 //!
 //!     ```rust
 //!     use std::old_io as io;
+//!     use std::old_io::*;
 //!
 //!     let mut stdin = io::stdin();
 //!     for line in stdin.lock().lines() {
@@ -59,7 +60,8 @@
 //! * Read a complete file
 //!
 //!     ```rust
-//!     use std::old_io::File;
+//!     use std::old_io::*;
+//!     use std::old_path::Path;
 //!
 //!     let contents = File::open(&Path::new("message.txt")).read_to_end();
 //!     ```
@@ -68,7 +70,8 @@
 //!
 //!     ```rust
 //!     # #![allow(unused_must_use)]
-//!     use std::old_io::File;
+//!     use std::old_io::*;
+//!     use std::old_path::Path;
 //!
 //!     let mut file = File::create(&Path::new("message.txt"));
 //!     file.write_all(b"hello, file!\n");
@@ -79,8 +82,8 @@
 //! * Iterate over the lines of a file
 //!
 //!     ```rust,no_run
-//!     use std::old_io::BufferedReader;
-//!     use std::old_io::File;
+//!     use std::old_io::*;
+//!     use std::old_path::Path;
 //!
 //!     let path = Path::new("message.txt");
 //!     let mut file = BufferedReader::new(File::open(&path));
@@ -92,8 +95,8 @@
 //! * Pull the lines of a file into a vector of strings
 //!
 //!     ```rust,no_run
-//!     use std::old_io::BufferedReader;
-//!     use std::old_io::File;
+//!     use std::old_io::*;
+//!     use std::old_path::Path;
 //!
 //!     let path = Path::new("message.txt");
 //!     let mut file = BufferedReader::new(File::open(&path));
@@ -104,7 +107,7 @@
 //!
 //!     ```rust
 //!     # #![allow(unused_must_use)]
-//!     use std::old_io::TcpStream;
+//!     use std::old_io::*;
 //!
 //!     # // connection doesn't fail if a server is running on 8080
 //!     # // locally, we still want to be type checking this code, so lets
@@ -122,8 +125,7 @@
 //!     # fn main() { }
 //!     # fn foo() {
 //!     # #![allow(dead_code)]
-//!     use std::old_io::{TcpListener, TcpStream};
-//!     use std::old_io::{Acceptor, Listener};
+//!     use std::old_io::*;
 //!     use std::thread;
 //!
 //!     let listener = TcpListener::bind("127.0.0.1:80");
@@ -185,7 +187,8 @@
 //!
 //! ```rust
 //! # #![allow(unused_must_use)]
-//! use std::old_io::File;
+//! use std::old_io::*;
+//! use std::old_path::Path;
 //!
 //! match File::create(&Path::new("diary.txt")).write_all(b"Met a girl.\n") {
 //!     Ok(()) => (), // succeeded
@@ -218,7 +221,8 @@
 //! If you wanted to read several `u32`s from a file and return their product:
 //!
 //! ```rust
-//! use std::old_io::{File, IoResult};
+//! use std::old_io::*;
+//! use std::old_path::Path;
 //!
 //! fn file_product(p: &Path) -> IoResult<u32> {
 //!     let mut f = File::open(p);
@@ -945,7 +949,7 @@ unsafe fn slice_vec_capacity<'a, T>(v: &'a mut Vec<T>, start: uint, end: uint) -
 ///
 /// ```
 /// use std::old_io as io;
-/// use std::old_io::ByRefReader;
+/// use std::old_io::*;
 /// use std::old_io::util::LimitReader;
 ///
 /// fn process_input<R: Reader>(r: R) {}
@@ -1279,7 +1283,7 @@ impl<'a> Writer for &'a mut (Writer+'a) {
 ///
 /// ```
 /// use std::old_io::util::TeeReader;
-/// use std::old_io::{stdin, ByRefWriter};
+/// use std::old_io::*;
 ///
 /// fn process_input<R: Reader>(r: R) {}
 ///
@@ -1403,7 +1407,7 @@ pub trait Buffer: Reader {
     /// # Examples
     ///
     /// ```
-    /// use std::old_io::BufReader;
+    /// use std::old_io::*;
     ///
     /// let mut reader = BufReader::new(b"hello\nworld");
     /// assert_eq!("hello\n", &*reader.read_line().unwrap());
@@ -1717,6 +1721,7 @@ pub enum FileType {
 /// ```no_run
 ///
 /// use std::old_io::fs::PathExtensions;
+/// use std::old_path::Path;
 ///
 /// let info = match Path::new("foo.txt").stat() {
 ///     Ok(stat) => stat,
@@ -1845,7 +1850,8 @@ impl fmt::Display for FilePermission {
 mod tests {
     use self::BadReaderBehavior::*;
     use super::{IoResult, Reader, MemReader, NoProgress, InvalidInput, Writer};
-    use prelude::v1::{Ok, Vec, Buffer};
+    use super::Buffer;
+    use prelude::v1::{Ok, Vec};
     use usize;
 
     #[derive(Clone, PartialEq, Debug)]

--- a/src/libstd/old_io/net/pipe.rs
+++ b/src/libstd/old_io/net/pipe.rs
@@ -31,6 +31,7 @@ use prelude::v1::*;
 use ffi::CString;
 use old_path::BytesContainer;
 use old_io::{Listener, Acceptor, IoResult, TimedOut, standard_error};
+use old_io::{Reader, Writer};
 use sys::pipe::UnixAcceptor as UnixAcceptorImp;
 use sys::pipe::UnixListener as UnixListenerImp;
 use sys::pipe::UnixStream as UnixStreamImp;
@@ -55,6 +56,8 @@ impl UnixStream {
     /// ```
     /// # #![allow(unused_must_use)]
     /// use std::old_io::net::pipe::UnixStream;
+    /// use std::old_io::*;
+    /// use std::old_path::Path;
     ///
     /// let server = Path::new("path/to/my/socket");
     /// let mut stream = UnixStream::connect(&server);
@@ -180,7 +183,8 @@ impl UnixListener {
     /// ```
     /// # fn foo() {
     /// use std::old_io::net::pipe::UnixListener;
-    /// use std::old_io::{Listener, Acceptor};
+    /// use std::old_io::*;
+    /// use std::old_path::Path;
     ///
     /// let server = Path::new("/path/to/my/socket");
     /// let stream = UnixListener::bind(&server);
@@ -285,6 +289,7 @@ mod tests {
     use old_io::{EndOfFile, TimedOut, ShortWrite, IoError, ConnectionReset};
     use old_io::{NotConnected, BrokenPipe, FileNotFound, InvalidInput, OtherIoError};
     use old_io::{PermissionDenied, Acceptor, Listener};
+    use old_io::{Reader, Writer};
     use old_io::test::*;
     use super::*;
     use sync::mpsc::channel;

--- a/src/libstd/old_io/net/tcp.rs
+++ b/src/libstd/old_io/net/tcp.rs
@@ -41,7 +41,7 @@ use sys_common;
 /// # Examples
 ///
 /// ```no_run
-/// use std::old_io::TcpStream;
+/// use std::old_io::*;
 ///
 /// {
 ///     let mut stream = TcpStream::connect("127.0.0.1:34254");
@@ -134,8 +134,7 @@ impl TcpStream {
     ///
     /// ```no_run
     /// # #![allow(unused_must_use)]
-    /// use std::old_io::timer;
-    /// use std::old_io::TcpStream;
+    /// use std::old_io::*;
     /// use std::time::Duration;
     /// use std::thread;
     ///
@@ -280,8 +279,7 @@ impl sys_common::AsInner<TcpStreamImp> for TcpStream {
 ///
 /// ```
 /// # fn foo() {
-/// use std::old_io::{TcpListener, TcpStream};
-/// use std::old_io::{Acceptor, Listener};
+/// use std::old_io::*;
 /// use std::thread;
 ///
 /// let listener = TcpListener::bind("127.0.0.1:80").unwrap();
@@ -376,8 +374,7 @@ impl TcpAcceptor {
     /// # Examples
     ///
     /// ```no_run
-    /// use std::old_io::TcpListener;
-    /// use std::old_io::{Listener, Acceptor, TimedOut};
+    /// use std::old_io::*;
     ///
     /// let mut a = TcpListener::bind("127.0.0.1:8482").listen().unwrap();
     ///
@@ -420,7 +417,7 @@ impl TcpAcceptor {
     /// # Examples
     ///
     /// ```
-    /// use std::old_io::{TcpListener, Listener, Acceptor, EndOfFile};
+    /// use std::old_io::*;
     /// use std::thread;
     ///
     /// let mut a = TcpListener::bind("127.0.0.1:8482").listen().unwrap();
@@ -496,6 +493,7 @@ mod test {
     use old_io::{ConnectionReset, NotConnected, PermissionDenied, OtherIoError};
     use old_io::{InvalidInput};
     use old_io::{Acceptor, Listener};
+    use old_io::{Reader, Writer};
 
     // FIXME #11530 this fails on android because tests are run as root
     #[cfg_attr(any(windows, target_os = "android"), ignore)]

--- a/src/libstd/old_io/pipe.rs
+++ b/src/libstd/old_io/pipe.rs
@@ -17,7 +17,7 @@
 
 use prelude::v1::*;
 
-use old_io::IoResult;
+use old_io::{IoResult, Reader, Writer};
 use libc;
 use sync::Arc;
 
@@ -49,7 +49,7 @@ impl PipeStream {
     /// # #![allow(unused_must_use)]
     /// extern crate libc;
     ///
-    /// use std::old_io::pipe::PipeStream;
+    /// use std::old_io::*;
     ///
     /// fn main() {
     ///     let mut pipe = PipeStream::open(libc::STDERR_FILENO);
@@ -114,6 +114,7 @@ impl Writer for PipeStream {
 mod test {
     use prelude::v1::*;
 
+    use old_io::{Writer, Reader};
     use sync::mpsc::channel;
     use thread;
 

--- a/src/libstd/old_io/process.rs
+++ b/src/libstd/old_io/process.rs
@@ -24,8 +24,9 @@ use collections::HashMap;
 use ffi::CString;
 use fmt;
 use old_io::pipe::{PipeStream, PipePair};
-use old_io::{IoResult, IoError};
+use old_io::{IoResult, IoError, Reader, Writer};
 use old_io;
+use old_path::{Path, GenericPath};
 use libc;
 use os;
 use old_path::BytesContainer;
@@ -60,7 +61,7 @@ use thread;
 /// # Examples
 ///
 /// ```should_fail
-/// use std::old_io::Command;
+/// use std::old_io::*;
 ///
 /// let mut child = match Command::new("/bin/cat").arg("file.txt").spawn() {
 ///     Ok(child) => child,
@@ -163,7 +164,7 @@ pub type EnvMap = HashMap<EnvKey, CString>;
 /// to be changed (for example, by adding arguments) prior to spawning:
 ///
 /// ```
-/// use std::old_io::Command;
+/// use std::old_io::*;
 ///
 /// let mut process = match Command::new("sh").arg("-c").arg("echo hello").spawn() {
 ///   Ok(p) => p,
@@ -759,9 +760,11 @@ impl Drop for Process {
 #[cfg(test)]
 mod tests {
     use old_io::{Truncate, Write, TimedOut, timer, process, FileNotFound};
-    use prelude::v1::{Ok, Err, range, drop, Some, None, Vec};
-    use prelude::v1::{Path, String, Reader, Writer, Clone};
-    use prelude::v1::{Str, AsSlice, ToString, GenericPath};
+    use old_io::{Reader, Writer};
+    use prelude::v1::{Ok, Err, drop, Some, None, Vec};
+    use prelude::v1::{String, Clone};
+    use prelude::v1::{Str, AsSlice, ToString};
+    use old_path::{GenericPath, Path};
     use old_io::fs::PathExtensions;
     use old_io::timer::*;
     use rt::running_on_valgrind;

--- a/src/libstd/old_io/result.rs
+++ b/src/libstd/old_io/result.rs
@@ -80,7 +80,7 @@ impl<T, A: Acceptor<T>> Acceptor<T> for IoResult<A> {
 mod test {
     use prelude::v1::*;
     use super::super::mem::*;
-    use old_io;
+    use old_io::{self, Reader, Writer};
 
     #[test]
     fn test_option_writer() {

--- a/src/libstd/old_io/stdio.rs
+++ b/src/libstd/old_io/stdio.rs
@@ -20,6 +20,7 @@
 //! ```rust
 //! # #![allow(unused_must_use)]
 //! use std::old_io;
+//! use std::old_io::*;
 //!
 //! let mut out = old_io::stdout();
 //! out.write_all(b"Hello, world!");
@@ -140,6 +141,7 @@ impl StdinReader {
     ///
     /// ```
     /// use std::old_io;
+    /// use std::old_io::*;
     ///
     /// let mut stdin = old_io::stdin();
     /// for line in stdin.lock().lines() {

--- a/src/libstd/old_io/tempfile.rs
+++ b/src/libstd/old_io/tempfile.rs
@@ -29,7 +29,8 @@ use string::String;
 /// # Examples
 ///
 /// ```no_run
-/// use std::old_io::TempDir;
+/// use std::old_io::*;
+/// use std::old_path::{Path, GenericPath};
 ///
 /// {
 ///     // create a temporary directory

--- a/src/libstd/old_io/test.rs
+++ b/src/libstd/old_io/test.rs
@@ -14,7 +14,8 @@ use prelude::v1::*;
 
 use env;
 use libc;
-use std::old_io::net::ip::*;
+use old_io::net::ip::*;
+use old_path::{Path, GenericPath};
 use sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 
 /// Get a port number, starting at 9600, for use in tests

--- a/src/libstd/old_io/util.rs
+++ b/src/libstd/old_io/util.rs
@@ -14,7 +14,7 @@
 
 use prelude::v1::*;
 use cmp;
-use old_io;
+use old_io::{self, Reader, Writer, Buffer};
 use slice::bytes::MutableByteVector;
 
 /// Wraps a `Reader`, limiting the number of bytes that can be read from it.
@@ -325,7 +325,7 @@ impl<T: Iterator<Item=u8>> Reader for IterReader<T> {
 mod test {
     use prelude::v1::*;
 
-    use old_io::{MemReader, ByRefReader};
+    use old_io::{MemReader, ByRefReader, Reader, Writer, Buffer};
     use old_io;
     use super::*;
 

--- a/src/libstd/old_path/mod.rs
+++ b/src/libstd/old_path/mod.rs
@@ -50,6 +50,7 @@
 //!
 //! ```rust
 //! use std::old_io::fs::PathExtensions;
+//! use std::old_path::{Path, GenericPath};
 //!
 //! let mut path = Path::new("/tmp/path");
 //! println!("path: {}", path.display());
@@ -142,6 +143,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -166,6 +168,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -188,6 +191,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -205,6 +209,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -219,6 +224,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -234,6 +240,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -252,6 +259,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -269,6 +277,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -284,6 +293,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -303,6 +313,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -318,6 +329,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -337,6 +349,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -364,6 +377,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -384,6 +398,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -411,6 +426,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -429,6 +445,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -455,6 +472,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -505,6 +523,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -530,6 +549,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -554,6 +574,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -573,6 +594,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -588,6 +610,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -612,6 +635,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -641,6 +665,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -658,6 +683,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -683,6 +709,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -705,6 +732,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -722,6 +750,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -740,6 +769,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -759,6 +789,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {
@@ -775,6 +806,7 @@ pub trait GenericPath: Clone + GenericPathUnsafe {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// # foo();
     /// # #[cfg(windows)] fn foo() {}
     /// # #[cfg(unix)] fn foo() {

--- a/src/libstd/old_path/posix.rs
+++ b/src/libstd/old_path/posix.rs
@@ -1224,7 +1224,8 @@ mod bench {
     extern crate test;
     use self::test::Bencher;
     use super::*;
-    use prelude::v1::{Clone, GenericPath};
+    use old_path::GenericPath;
+    use prelude::v1::Clone;
 
     #[bench]
     fn join_home_dir(b: &mut Bencher) {

--- a/src/libstd/old_path/windows.rs
+++ b/src/libstd/old_path/windows.rs
@@ -605,6 +605,7 @@ impl Path {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// println!("{}", Path::new(r"C:\some\path").display());
     /// ```
     #[inline]
@@ -619,6 +620,7 @@ impl Path {
     /// # Examples
     ///
     /// ```
+    /// use std::old_path::{Path, GenericPath};
     /// let path = Path::new_opt(r"C:\some\path");
     ///
     /// match path {

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -126,6 +126,7 @@ pub const TMPBUF_SZ : uint = 1000;
 ///
 /// ```
 /// use std::os;
+/// use std::old_path::{Path, GenericPath};
 ///
 /// // We assume that we are in a valid directory.
 /// let current_working_directory = os::getcwd().unwrap();
@@ -265,6 +266,7 @@ pub fn unsetenv(n: &str) {
 ///
 /// ```
 /// use std::os;
+/// use std::old_path::{Path, GenericPath};
 ///
 /// let key = "PATH";
 /// match os::getenv_as_bytes(key) {
@@ -358,6 +360,7 @@ pub fn dll_filename(base: &str) -> String {
 ///
 /// ```
 /// use std::os;
+/// use std::old_path::{Path, GenericPath};
 ///
 /// match os::self_exe_name() {
 ///     Some(exe_path) => println!("Path of this executable is: {}", exe_path.display()),
@@ -378,6 +381,7 @@ pub fn self_exe_name() -> Option<Path> {
 ///
 /// ```
 /// use std::os;
+/// use std::old_path::{Path, GenericPath};
 ///
 /// match os::self_exe_path() {
 ///     Some(exe_path) => println!("Executable's Path is: {}", exe_path.display()),
@@ -407,6 +411,7 @@ pub fn self_exe_path() -> Option<Path> {
 ///
 /// ```
 /// use std::os;
+/// use std::old_path::{Path, GenericPath};
 ///
 /// match os::homedir() {
 ///     Some(ref p) => println!("{}", p.display()),
@@ -497,7 +502,7 @@ pub fn tmpdir() -> Path {
 ///
 /// ```
 /// use std::os;
-/// use std::old_path::Path;
+/// use std::old_path::{Path, GenericPath};
 ///
 /// // Assume we're in a path like /home/someuser
 /// let rel_path = Path::new("..");
@@ -529,7 +534,7 @@ pub fn make_absolute(p: &Path) -> IoResult<Path> {
 ///
 /// ```
 /// use std::os;
-/// use std::old_path::Path;
+/// use std::old_path::{Path, GenericPath};
 ///
 /// let root = Path::new("/");
 /// assert!(os::change_dir(&root).is_ok());
@@ -1496,6 +1501,8 @@ mod tests {
     use os;
     use rand::Rng;
     use rand;
+    use old_path::{Path, GenericPath};
+    use old_io::{Reader, Writer, Seek};
 
     #[test]
     pub fn last_os_error() {

--- a/src/libstd/prelude/v1.rs
+++ b/src/libstd/prelude/v1.rs
@@ -48,12 +48,5 @@
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)] pub use vec::Vec;
 
-// NB: remove when path reform lands
-#[doc(no_inline)] pub use old_path::{Path, GenericPath};
-// NB: remove when I/O reform lands
-#[doc(no_inline)] pub use old_io::{Buffer, Writer, Reader, Seek, BufferPrelude};
-// NB: remove when range syntax lands
-#[allow(deprecated)]
-#[doc(no_inline)] pub use iter::range;
-
+// FIXME(#23454) should these be here?
 #[doc(no_inline)] pub use num::wrapping::{Wrapping, WrappingOps};

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -533,8 +533,8 @@ mod tests {
     use io::prelude::*;
     use prelude::v1::{Ok, Err, drop, Some, Vec};
     use prelude::v1::{String, Clone};
-    use prelude::v1::{Str, AsSlice, ToString, GenericPath};
-    use old_path;
+    use prelude::v1::{Str, AsSlice, ToString};
+    use old_path::{self, GenericPath};
     use old_io::fs::PathExtensions;
     use rt::running_on_valgrind;
     use str;

--- a/src/libstd/rt/util.rs
+++ b/src/libstd/rt/util.rs
@@ -10,7 +10,6 @@
 //
 // ignore-lexer-test FIXME #15677
 
-use prelude::v1::*;
 use io::prelude::*;
 
 use env;

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -20,6 +20,7 @@ use old_io::{FilePermission, Write, UnstableFileStat, Open, FileAccess, FileMode
 use old_io::{IoResult, FileStat, SeekStyle};
 use old_io::{Read, Truncate, SeekCur, SeekSet, ReadWrite, SeekEnd, Append};
 use old_io;
+use old_path::{Path, GenericPath};
 use libc::{self, c_int, c_void};
 use mem;
 use ptr;

--- a/src/libstd/sys/windows/backtrace.rs
+++ b/src/libstd/sys/windows/backtrace.rs
@@ -26,14 +26,15 @@
 #![allow(deprecated)] // for old path for dynamic lib
 
 use prelude::v1::*;
+use io::prelude::*;
 
 use dynamic_lib::DynamicLibrary;
-use io;
-use io::prelude::*;
 use ffi::CStr;
 use intrinsics;
+use io;
 use libc;
 use mem;
+use old_path::Path;
 use ptr;
 use str;
 use sync::{StaticMutex, MUTEX_INIT};

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -22,6 +22,7 @@ use prelude::v1::*;
 use sys;
 use sys_common::{self, mkerr_libc};
 
+use old_path::{Path, GenericPath};
 use old_io::{FilePermission, Write, UnstableFileStat, Open, FileAccess, FileMode};
 use old_io::{IoResult, IoError, FileStat, SeekStyle};
 use old_io::{Read, Truncate, SeekCur, SeekSet, ReadWrite, SeekEnd, Append};

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -24,7 +24,7 @@ use old_io::process::{ProcessExit, ExitStatus};
 use old_io::{IoResult, IoError};
 use old_io;
 use os;
-use old_path::BytesContainer;
+use old_path::{BytesContainer, GenericPath};
 use ptr;
 use str;
 use sync::{StaticMutex, MUTEX_INIT};

--- a/src/libstd/sys/windows/tty.rs
+++ b/src/libstd/sys/windows/tty.rs
@@ -29,7 +29,7 @@
 
 use prelude::v1::*;
 
-use old_io::{self, IoError, IoResult, MemReader};
+use old_io::{self, IoError, IoResult, MemReader, Reader};
 use iter::repeat;
 use libc::types::os::arch::extra::LPCVOID;
 use libc::{c_int, HANDLE, LPDWORD, DWORD, LPVOID};

--- a/src/libstd/thread.rs
+++ b/src/libstd/thread.rs
@@ -150,11 +150,12 @@ use io;
 use marker::PhantomData;
 use rt::{self, unwind};
 use sync::{Mutex, Condvar, Arc};
+use sys::thread as imp;
+use sys_common::{stack, thread_info};
 use thunk::Thunk;
 use time::Duration;
 
-use sys::thread as imp;
-use sys_common::{stack, thread_info};
+#[allow(deprecated)] use old_io::Writer;
 
 /// Thread configuration. Provides detailed control over the properties
 /// and behavior of new threads.

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -333,7 +333,7 @@ pub fn winsorize<T: Float + FromPrimitive>(samples: &mut [T], pct: T) {
 mod tests {
     use stats::Stats;
     use stats::Summary;
-    use std::old_io;
+    use std::old_io::{self, Writer};
     use std::f64;
 
     macro_rules! assert_approx_eq {

--- a/src/test/auxiliary/linkage-visibility.rs
+++ b/src/test/auxiliary/linkage-visibility.rs
@@ -27,8 +27,7 @@ fn bar() { }
 fn baz() { }
 
 pub fn test() {
-    let none: Option<&Path> = None; // appease the typechecker
-    let lib = DynamicLibrary::open(none).unwrap();
+    let lib = DynamicLibrary::open(None).unwrap();
     unsafe {
         assert!(lib.symbol::<int>("foo").is_ok());
         assert!(lib.symbol::<int>("baz").is_err());

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -13,7 +13,8 @@
 
 #![feature(unboxed_closures)]
 
-use std::old_io::File;
+use std::old_io::*;
+use std::old_path::{Path, GenericPath};
 use std::iter::repeat;
 use std::mem::swap;
 use std::env;

--- a/src/test/bench/shootout-fasta-redux.rs
+++ b/src/test/bench/shootout-fasta-redux.rs
@@ -39,7 +39,7 @@
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::cmp::min;
-use std::old_io::{stdout, IoResult};
+use std::old_io::*;
 use std::iter::repeat;
 use std::env;
 use std::slice::bytes::copy_memory;

--- a/src/test/bench/shootout-fasta.rs
+++ b/src/test/bench/shootout-fasta.rs
@@ -39,8 +39,9 @@
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use std::cmp::min;
-use std::old_io::{BufferedWriter, File};
+use std::old_io::*;
 use std::old_io;
+use std::old_path::Path;
 use std::num::Float;
 use std::env;
 

--- a/src/test/bench/shootout-k-nucleotide-pipes.rs
+++ b/src/test/bench/shootout-k-nucleotide-pipes.rs
@@ -147,7 +147,7 @@ fn make_sequence_processor(sz: uint,
 
 // given a FASTA file on stdin, process sequence THREE
 fn main() {
-    use std::old_io::{stdio, MemReader, BufferedReader};
+    use std::old_io::*;
 
     let rdr = if env::var_os("RUST_BENCH").is_some() {
         let foo = include_bytes!("shootout-k-nucleotide.data");

--- a/src/test/bench/shootout-mandelbrot.rs
+++ b/src/test/bench/shootout-mandelbrot.rs
@@ -43,6 +43,7 @@
 // ignore-pretty very bad with line comments
 
 use std::old_io;
+use std::old_io::*;
 use std::env;
 use std::simd::f64x2;
 use std::sync::Arc;

--- a/src/test/bench/shootout-reverse-complement.rs
+++ b/src/test/bench/shootout-reverse-complement.rs
@@ -45,7 +45,7 @@
 extern crate libc;
 
 use std::old_io::stdio::{stdin_raw, stdout_raw};
-use std::old_io::{IoResult, EndOfFile};
+use std::old_io::*;
 use std::ptr::{copy_memory, Unique};
 use std::thread;
 

--- a/src/test/compile-fail/cannot-mutate-captured-non-mut-var.rs
+++ b/src/test/compile-fail/cannot-mutate-captured-non-mut-var.rs
@@ -10,6 +10,8 @@
 
 #![feature(unboxed_closures)]
 
+use std::io::Read;
+
 fn to_fn_once<A,F:FnOnce<A>>(f: F) -> F { f }
 
 fn main() {
@@ -17,7 +19,7 @@ fn main() {
     to_fn_once(move|| { x = 2; });
     //~^ ERROR: cannot assign to immutable captured outer variable
 
-    let s = std::old_io::stdin();
-    to_fn_once(move|| { s.read_to_end(); });
+    let s = std::io::stdin();
+    to_fn_once(move|| { s.read_to_end(&mut Vec::new()); });
     //~^ ERROR: cannot borrow immutable captured outer variable
 }

--- a/src/test/compile-fail/issue-11374.rs
+++ b/src/test/compile-fail/issue-11374.rs
@@ -8,15 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::old_io;
+use std::io::{self, Read};
 use std::vec;
 
 pub struct Container<'a> {
-    reader: &'a mut Reader
+    reader: &'a mut Read
 }
 
 impl<'a> Container<'a> {
-    pub fn wrap<'s>(reader: &'s mut Reader) -> Container<'s> {
+    pub fn wrap<'s>(reader: &'s mut io::Read) -> Container<'s> {
         Container { reader: reader }
     }
 
@@ -26,8 +26,8 @@ impl<'a> Container<'a> {
 }
 
 pub fn for_stdin<'a>() -> Container<'a> {
-    let mut r = old_io::stdin();
-    Container::wrap(&mut r as &mut Reader)
+    let mut r = io::stdin();
+    Container::wrap(&mut r as &mut io::Read)
 }
 
 fn main() {

--- a/src/test/run-make/extern-fn-reachable/main.rs
+++ b/src/test/run-make/extern-fn-reachable/main.rs
@@ -10,6 +10,7 @@
 
 use std::dynamic_lib::DynamicLibrary;
 use std::os;
+use std::old_path::Path;
 
 pub fn main() {
     unsafe {

--- a/src/test/run-make/unicode-input/multiple_files.rs
+++ b/src/test/run-make/unicode-input/multiple_files.rs
@@ -8,9 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{char, env};
-use std::old_io::{File, Command};
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::Path;
+use std::process::Command;
 use std::rand::{thread_rng, Rng};
+use std::{char, env};
 
 // creates unicode_input_multiple_files_{main,chars}.rs, where the
 // former imports the latter. `_chars` just contains an identifier
@@ -40,7 +43,7 @@ fn main() {
     let main_file = tmpdir.join("unicode_input_multiple_files_main.rs");
     {
         let _ = File::create(&main_file).unwrap()
-            .write_str("mod unicode_input_multiple_files_chars;");
+            .write_all(b"mod unicode_input_multiple_files_chars;").unwrap();
     }
 
     for _ in 0..100 {
@@ -48,7 +51,7 @@ fn main() {
             let randoms = tmpdir.join("unicode_input_multiple_files_chars.rs");
             let mut w = File::create(&randoms).unwrap();
             for _ in 0..30 {
-                let _ = w.write_char(random_char());
+                write!(&mut w, "{}", random_char()).unwrap();
             }
         }
 
@@ -58,10 +61,9 @@ fn main() {
                              .arg("-c")
                              .arg(&format!("{} {}",
                                            rustc,
-                                           main_file.as_str()
-                                                    .unwrap()))
+                                           main_file.display()))
                              .output().unwrap();
-        let err = String::from_utf8_lossy(&result.error);
+        let err = String::from_utf8_lossy(&result.stderr);
 
         // positive test so that this test will be updated when the
         // compiler changes.

--- a/src/test/run-make/unicode-input/span_length.rs
+++ b/src/test/run-make/unicode-input/span_length.rs
@@ -8,8 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::old_io::{File, Command};
+use std::fs::File;
+use std::io::prelude::*;
 use std::iter::repeat;
+use std::path::Path;
+use std::process::Command;
 use std::rand::{thread_rng, Rng};
 use std::{char, env};
 
@@ -54,11 +57,11 @@ fn main() {
                              .arg("-c")
                              .arg(&format!("{} {}",
                                            rustc,
-                                           main_file.as_str()
+                                           main_file.to_str()
                                                     .unwrap()))
                              .output().unwrap();
 
-        let err = String::from_utf8_lossy(&result.error);
+        let err = String::from_utf8_lossy(&result.stderr);
 
         // the span should end the line (e.g no extra ~'s)
         let expected_span = format!("^{}\n", repeat("~").take(n - 1)
@@ -73,17 +76,16 @@ fn main() {
     }
 
     // Extra characters. Every line is preceded by `filename:lineno <actual code>`
-    let offset = main_file.as_str().unwrap().len() + 3;
+    let offset = main_file.to_str().unwrap().len() + 3;
 
     let result = Command::new("sh")
                          .arg("-c")
                          .arg(format!("{} {}",
                                       rustc,
-                                      main_file.as_str()
-                                               .unwrap()))
+                                      main_file.display()))
                          .output().unwrap();
 
-    let err = String::from_utf8_lossy(result.error.as_slice());
+    let err = String::from_utf8_lossy(&result.stderr);
 
     // Test both the length of the snake and the leading spaces up to it
 

--- a/src/test/run-pass/capturing-logging.rs
+++ b/src/test/run-pass/capturing-logging.rs
@@ -19,7 +19,7 @@ extern crate log;
 use log::{set_logger, Logger, LogRecord};
 use std::sync::mpsc::channel;
 use std::fmt;
-use std::old_io::{ChanReader, ChanWriter};
+use std::old_io::{ChanReader, ChanWriter, Reader, Writer};
 use std::thread::Thread;
 
 struct MyWriter(ChanWriter);

--- a/src/test/run-pass/colorful-write-macros.rs
+++ b/src/test/run-pass/colorful-write-macros.rs
@@ -10,12 +10,11 @@
 
 // no-pretty-expanded
 
-#![allow(unused_must_use, dead_code, deprecated)]
-use std::old_io::MemWriter;
+use std::io::Write;
 use std::fmt;
 
 struct Foo<'a> {
-    writer: &'a mut (Writer+'a),
+    writer: &'a mut (Write+'a),
     other: &'a str,
 }
 
@@ -32,8 +31,8 @@ fn borrowing_writer_from_struct_and_formatting_struct_field(foo: Foo) {
 }
 
 fn main() {
-    let mut w = MemWriter::new();
-    write!(&mut w as &mut Writer, "");
+    let mut w = Vec::new();
+    write!(&mut w as &mut Write, "");
     write!(&mut w, ""); // should coerce
     println!("ok");
 

--- a/src/test/run-pass/into-iterator-type-inference-shift.rs
+++ b/src/test/run-pass/into-iterator-type-inference-shift.rs
@@ -31,7 +31,7 @@ impl<I> IntoIterator for I where I: Iterator {
 
 fn desugared_for_loop_bad(byte: u8) -> u8 {
     let mut result = 0;
-    let mut x = IntoIterator::into_iter(range(0, u8::BITS));
+    let mut x = IntoIterator::into_iter(0..u8::BITS);
     let mut y = Iterator::next(&mut x);
     let mut z = y.unwrap();
     byte >> z;

--- a/src/test/run-pass/issue-14940.rs
+++ b/src/test/run-pass/issue-14940.rs
@@ -9,12 +9,13 @@
 // except according to those terms.
 
 use std::env;
-use std::old_io::{stdio, Command};
+use std::process::Command;
+use std::io::{self, Write};
 
 fn main() {
     let mut args = env::args();
     if args.len() > 1 {
-        let mut out = stdio::stdout();
+        let mut out = io::stdout();
         out.write(&['a' as u8; 128 * 1024]).unwrap();
     } else {
         let out = Command::new(&args.next().unwrap()).arg("child").output();

--- a/src/test/run-pass/issue-17121.rs
+++ b/src/test/run-pass/issue-17121.rs
@@ -8,31 +8,29 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::old_io::BufReader;
-use std::old_io::BufferedReader;
-use std::old_io::File;
-use std::old_io::IoResult;
+use std::fs::File;
+use std::io::{self, BufReader, Read};
 
-struct Lexer<R: Reader>
+struct Lexer<R: Read>
 {
-    reader: BufferedReader<R>,
+    reader: BufReader<R>,
 }
 
-impl<R: Reader> Lexer<R>
+impl<R: Read> Lexer<R>
 {
     pub fn new_from_reader(r: R) -> Lexer<R>
     {
-        Lexer{reader: BufferedReader::new(r)}
+        Lexer{reader: BufReader::new(r)}
     }
 
-    pub fn new_from_file(p: Path) -> IoResult<Lexer<File>>
+    pub fn new_from_file(p: &str) -> io::Result<Lexer<File>>
     {
-        Ok(Lexer::new_from_reader(try!(File::open(&p))))
+        Ok(Lexer::new_from_reader(try!(File::open(p))))
     }
 
-    pub fn new_from_str<'a>(s: &'a str) -> Lexer<BufReader<'a>>
+    pub fn new_from_str<'a>(s: &'a str) -> Lexer<&'a [u8]>
     {
-        Lexer::new_from_reader(BufReader::new(s.as_bytes()))
+        Lexer::new_from_reader(s.as_bytes())
     }
 }
 

--- a/src/test/run-pass/issue-20644.rs
+++ b/src/test/run-pass/issue-20644.rs
@@ -11,24 +11,25 @@
 // A reduced version of the rustbook ice. The problem this encountered
 // had to do with trans ignoring binders.
 
-#![feature(associated_types)]
-#![feature(macro_rules)]
-
 use std::iter;
 use std::os;
-use std::old_io::File;
+use std::fs::File;
+use std::io::prelude::*;
+use std::env;
+use std::path::Path;
 
-#[allow(unused)]
-pub fn parse_summary<R: Reader>(_: R, _: &Path) {
+pub fn parse_summary<R: Read>(_: R, _: &Path) {
      let path_from_root = Path::new("");
-     Path::new(iter::repeat("../")
+     Path::new(&iter::repeat("../")
                .take(path_from_root.components().count() - 1)
                .collect::<String>());
  }
 
-fn main() {
-    let cwd = os::getcwd().unwrap();
+fn foo() {
+    let cwd = env::current_dir().unwrap();
     let src = cwd.clone();
-    let summary = File::open(&src.join("SUMMARY.md"));
+    let summary = File::open(&src.join("SUMMARY.md")).unwrap();
     let _ = parse_summary(summary, &src);
 }
+
+fn main() {}

--- a/src/test/run-pass/issue-20797.rs
+++ b/src/test/run-pass/issue-20797.rs
@@ -8,24 +8,27 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-android
-// ignore-windows
-
 // Regression test for #20797.
 
 use std::default::Default;
-use std::old_io::IoResult;
-use std::old_io::fs;
-use std::old_io::fs::PathExtensions;
+use std::io;
+use std::fs;
+use std::path::{PathBuf, Path};
+
+pub trait PathExtensions {
+    fn is_dir(&self) -> bool { false }
+}
+
+impl PathExtensions for PathBuf {}
 
 /// A strategy for acquiring more subpaths to walk.
 pub trait Strategy {
-  type P: PathExtensions;
-  /// Get additional subpaths from a given path.
-  fn get_more(&self, item: &Self::P) -> IoResult<Vec<Self::P>>;
-  /// Determine whether a path should be walked further.
-  /// This is run against each item from `get_more()`.
-  fn prune(&self, p: &Self::P) -> bool;
+    type P: PathExtensions;
+    /// Get additional subpaths from a given path.
+    fn get_more(&self, item: &Self::P) -> io::Result<Vec<Self::P>>;
+    /// Determine whether a path should be walked further.
+    /// This is run against each item from `get_more()`.
+    fn prune(&self, p: &Self::P) -> bool;
 }
 
 /// The basic fully-recursive strategy. Nothing is pruned.
@@ -33,10 +36,12 @@ pub trait Strategy {
 pub struct Recursive;
 
 impl Strategy for Recursive {
-  type P = Path;
-  fn get_more(&self, p: &Path) -> IoResult<Vec<Path>> { fs::readdir(p) }
+    type P = PathBuf;
+    fn get_more(&self, p: &PathBuf) -> io::Result<Vec<PathBuf>> {
+        Ok(fs::read_dir(p).unwrap().map(|s| s.unwrap().path()).collect())
+    }
 
-  fn prune(&self, _: &Path) -> bool { false }
+    fn prune(&self, _: &PathBuf) -> bool { false }
 }
 
 /// A directory walker of `P` using strategy `S`.
@@ -46,49 +51,51 @@ pub struct Subpaths<S: Strategy> {
 }
 
 impl<S: Strategy> Subpaths<S> {
-  /// Create a directory walker with a root path and strategy.
-  pub fn new(p: &S::P, strategy: S) -> IoResult<Subpaths<S>> {
-    let stack = try!(strategy.get_more(p));
-    Ok(Subpaths { stack: stack, strategy: strategy })
-  }
+    /// Create a directory walker with a root path and strategy.
+    pub fn new(p: &S::P, strategy: S) -> io::Result<Subpaths<S>> {
+        let stack = try!(strategy.get_more(p));
+        Ok(Subpaths { stack: stack, strategy: strategy })
+    }
 }
 
 impl<S: Default + Strategy> Subpaths<S> {
-  /// Create a directory walker with a root path and a default strategy.
-  pub fn walk(p: &S::P) -> IoResult<Subpaths<S>> {
-      Subpaths::new(p, Default::default())
-  }
+    /// Create a directory walker with a root path and a default strategy.
+    pub fn walk(p: &S::P) -> io::Result<Subpaths<S>> {
+        Subpaths::new(p, Default::default())
+    }
 }
 
 impl<S: Default + Strategy> Default for Subpaths<S> {
-  fn default() -> Subpaths<S> {
-    Subpaths { stack: Vec::new(), strategy: Default::default() }
-  }
+    fn default() -> Subpaths<S> {
+        Subpaths { stack: Vec::new(), strategy: Default::default() }
+    }
 }
 
 impl<S: Strategy> Iterator for Subpaths<S> {
-  type Item = S::P;
-  fn next (&mut self) -> Option<S::P> {
-    let mut opt_path = self.stack.pop();
-    while opt_path.is_some() && self.strategy.prune(opt_path.as_ref().unwrap()) {
-      opt_path = self.stack.pop();
-    }
-    match opt_path {
-      Some(path) => {
-        if PathExtensions::is_dir(&path) {
-          let result = self.strategy.get_more(&path);
-          match result {
-            Ok(dirs) => { self.stack.extend(dirs.into_iter()); },
-            Err(..) => { }
-          }
+    type Item = S::P;
+    fn next (&mut self) -> Option<S::P> {
+        let mut opt_path = self.stack.pop();
+        while opt_path.is_some() && self.strategy.prune(opt_path.as_ref().unwrap()) {
+            opt_path = self.stack.pop();
         }
-        Some(path)
-      }
-      None => None,
+        match opt_path {
+            Some(path) => {
+                if path.is_dir() {
+                    let result = self.strategy.get_more(&path);
+                    match result {
+                        Ok(dirs) => { self.stack.extend(dirs.into_iter()); },
+                        Err(..) => { }
+                    }
+                }
+                Some(path)
+            }
+            None => None,
+        }
     }
-  }
 }
 
-fn main() {
-  let mut walker: Subpaths<Recursive> = Subpaths::walk(&Path::new("/home")).unwrap();
+fn foo() {
+    let mut walker: Subpaths<Recursive> = Subpaths::walk(&PathBuf::new("/home")).unwrap();
 }
+
+fn main() {}

--- a/src/test/run-pass/issue22346.rs
+++ b/src/test/run-pass/issue22346.rs
@@ -10,7 +10,7 @@
 
 // This used to cause an ICE because the retslot for the "return" had the wrong type
 fn testcase<'a>() -> Box<Iterator<Item=usize> + 'a> {
-    return Box::new(range(0, 3).map(|i| { return i; }));
+    return Box::new((0..3).map(|i| { return i; }));
 }
 
 fn main() {

--- a/src/test/run-pass/process-spawn-with-unicode-params.rs
+++ b/src/test/run-pass/process-spawn-with-unicode-params.rs
@@ -28,9 +28,9 @@ use std::path::{Path, PathBuf};
 
 fn main() {
     let my_args = env::args().collect::<Vec<_>>();
-    let my_cwd  = PathBuf::new(os::getcwd().unwrap().as_str().unwrap());
+    let my_cwd  = env::current_dir().unwrap();
     let my_env  = env::vars().collect::<Vec<_>>();
-    let my_path = PathBuf::new(os::self_exe_name().unwrap().as_str().unwrap());
+    let my_path = env::current_exe().unwrap();
     let my_dir  = my_path.parent().unwrap();
     let my_ext  = my_path.extension().and_then(|s| s.to_str()).unwrap_or("");
 

--- a/src/test/run-pass/rename-directory.rs
+++ b/src/test/run-pass/rename-directory.rs
@@ -11,45 +11,23 @@
 // This test can't be a unit test in std,
 // because it needs TempDir, which is in extra
 
-extern crate libc;
-
 use std::ffi::CString;
-use std::old_io::TempDir;
-use std::old_io::fs::PathExtensions;
-use std::old_io::fs;
-use std::old_io;
-use std::os;
+use std::fs::{self, TempDir, File, PathExt};
 
 fn rename_directory() {
-    unsafe {
-        static U_RWX: i32 = (libc::S_IRUSR | libc::S_IWUSR | libc::S_IXUSR) as i32;
+    let tmpdir = TempDir::new("rename_directory").ok().expect("rename_directory failed");
+    let tmpdir = tmpdir.path();
+    let old_path = tmpdir.join("foo/bar/baz");
+    fs::create_dir_all(&old_path).unwrap();
+    let test_file = &old_path.join("temp.txt");
 
-        let tmpdir = TempDir::new("rename_directory").ok().expect("rename_directory failed");
-        let tmpdir = tmpdir.path();
-        let old_path = tmpdir.join_many(&["foo", "bar", "baz"]);
-        fs::mkdir_recursive(&old_path, old_io::USER_RWX);
-        let test_file = &old_path.join("temp.txt");
+    File::create(test_file).unwrap();
 
-        /* Write the temp input file */
-        let fromp = CString::new(test_file.as_vec()).unwrap();
-        let modebuf = CString::new(&b"w+b"[..]).unwrap();
-        let ostream = libc::fopen(fromp.as_ptr(), modebuf.as_ptr());
-        assert!((ostream as uint != 0));
-        let s = "hello".to_string();
-        let buf = CString::new(&b"hello"[..]).unwrap();
-        let write_len = libc::fwrite(buf.as_ptr() as *mut _,
-                                     1_usize as libc::size_t,
-                                     (s.len() + 1_usize) as libc::size_t,
-                                     ostream);
-        assert_eq!(write_len, (s.len() + 1) as libc::size_t);
-        assert_eq!(libc::fclose(ostream), (0_usize as libc::c_int));
-
-        let new_path = tmpdir.join_many(&["quux", "blat"]);
-        fs::mkdir_recursive(&new_path, old_io::USER_RWX);
-        fs::rename(&old_path, &new_path.join("newdir"));
-        assert!(new_path.join("newdir").is_dir());
-        assert!(new_path.join_many(&["newdir", "temp.txt"]).exists());
-    }
+    let new_path = tmpdir.join("quux/blat");
+    fs::create_dir_all(&new_path).unwrap();
+    fs::rename(&old_path, &new_path.join("newdir"));
+    assert!(new_path.join("newdir").is_dir());
+    assert!(new_path.join("newdir/temp.txt").exists());
 }
 
 pub fn main() { rename_directory() }

--- a/src/test/run-pass/sigpipe-should-be-ignored.rs
+++ b/src/test/run-pass/sigpipe-should-be-ignored.rs
@@ -11,18 +11,15 @@
 // Be sure that when a SIGPIPE would have been received that the entire process
 // doesn't die in a ball of fire, but rather it's gracefully handled.
 
-use std::os;
 use std::env;
-use std::old_io::PipeStream;
-use std::old_io::Command;
+use std::io::prelude::*;
+use std::io;
+use std::process::{Command, Stdio};
 
 fn test() {
-    let os::Pipe { reader, writer } = unsafe { os::pipe().unwrap() };
-    let reader = PipeStream::open(reader);
-    let mut writer = PipeStream::open(writer);
-    drop(reader);
-
-    let _ = writer.write(&[1]);
+    let _ = io::stdin().read_line(&mut String::new());
+    io::stdout().write(&[1]);
+    assert!(io::stdout().flush().is_err());
 }
 
 fn main() {
@@ -32,6 +29,9 @@ fn main() {
     }
 
     let mut p = Command::new(&args[0])
+                        .stdout(Stdio::piped())
+                        .stdin(Stdio::piped())
                         .arg("test").spawn().unwrap();
+    drop(p.stdout.take());
     assert!(p.wait().unwrap().success());
 }

--- a/src/test/run-pass/stat.rs
+++ b/src/test/run-pass/stat.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::old_io::fs::PathExtensions;
-use std::old_io::{File, TempDir};
+use std::fs::{File, TempDir};
+use std::io::prelude::*;
 
 pub fn main() {
-    let dir = TempDir::new_in(&Path::new("."), "").unwrap();
+    let dir = TempDir::new_in(".", "").unwrap();
     let path = dir.path().join("file");
 
     {
@@ -20,7 +20,7 @@ pub fn main() {
             Err(..) => unreachable!(),
             Ok(f) => {
                 let mut f = f;
-                for _ in 0_usize..1000 {
+                for _ in 0..1000 {
                     f.write(&[0]);
                 }
             }
@@ -28,5 +28,5 @@ pub fn main() {
     }
 
     assert!(path.exists());
-    assert_eq!(path.stat().unwrap().size, 1000);
+    assert_eq!(path.metadata().unwrap().len(), 1000);
 }

--- a/src/test/run-pass/tcp-stress.rs
+++ b/src/test/run-pass/tcp-stress.rs
@@ -19,7 +19,7 @@ extern crate libc;
 
 use std::sync::mpsc::channel;
 use std::old_io::net::tcp::{TcpListener, TcpStream};
-use std::old_io::{Acceptor, Listener};
+use std::old_io::{Acceptor, Listener, Reader, Writer};
 use std::thread::{Builder, Thread};
 use std::time::Duration;
 

--- a/src/test/run-pass/tempfile.rs
+++ b/src/test/run-pass/tempfile.rs
@@ -18,6 +18,7 @@
 // they're in a different location than before. Hence, these tests are all run
 // serially here.
 
+use std::old_path::{Path, GenericPath};
 use std::old_io::fs::PathExtensions;
 use std::old_io::{fs, TempDir};
 use std::old_io;

--- a/src/test/run-pass/trait-coercion.rs
+++ b/src/test/run-pass/trait-coercion.rs
@@ -8,10 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(unknown_features)]
 #![feature(box_syntax)]
 
-use std::old_io;
+use std::io::{self, Write};
 
 trait Trait {
     fn f(&self);
@@ -29,9 +28,7 @@ impl Trait for Struct {
     }
 }
 
-fn foo(mut a: Box<Writer>) {
-    a.write(b"Hello\n");
-}
+fn foo(mut a: Box<Write>) {}
 
 // FIXME (#22405): Replace `Box::new` with `box` here when/if possible.
 
@@ -42,6 +39,6 @@ pub fn main() {
     let c: &Trait = &a;
     c.f();
 
-    let out = old_io::stdout();
+    let out = io::stdout();
     foo(Box::new(out));
 }


### PR DESCRIPTION
This commit removes the reexports of `old_io` traits as well as `old_path` types
and traits from the prelude. This functionality is now all deprecated and needs
to be removed to make way for other functionality like `Seek` in the `std::io`
module (currently reexported as `NewSeek` in the io prelude).

Closes #23377
Closes #23378
