### PR TITLE
std: Stabilize marker::MarkerTrait

### DIFF
--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -270,6 +270,7 @@ macro_rules! impls{
 /// any methods, but instead is used to gate access to data.
 ///
 /// FIXME. Better documentation needed here!
+#[stable(feature = "rust1", since = "1.0.0")]
 pub trait MarkerTrait : PhantomFn<Self,Self> { }
 //                                    ~~~~~ <-- FIXME(#22806)?
 //


### PR DESCRIPTION
This trait has proven quite useful when defining marker traits to avoid the
semi-confusing `PhantomFn` trait and it looks like it will continue to be a
useful tool for defining these traits.
