### PR TITLE
Tweaks to the blanket impls of PartialEq

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -778,40 +778,24 @@ macro_rules! impl_eq {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl<'a> PartialEq<$rhs> for $lhs {
             #[inline]
-            fn eq(&self, other: &$rhs) -> bool { PartialEq::eq(&**self, &**other) }
+            fn eq(&self, other: &$rhs) -> bool { PartialEq::eq(&self[..], &other[..]) }
             #[inline]
-            fn ne(&self, other: &$rhs) -> bool { PartialEq::ne(&**self, &**other) }
+            fn ne(&self, other: &$rhs) -> bool { PartialEq::ne(&self[..], &other[..]) }
         }
 
         #[stable(feature = "rust1", since = "1.0.0")]
         impl<'a> PartialEq<$lhs> for $rhs {
             #[inline]
-            fn eq(&self, other: &$lhs) -> bool { PartialEq::eq(&**self, &**other) }
+            fn eq(&self, other: &$lhs) -> bool { PartialEq::eq(&self[..], &other[..]) }
             #[inline]
-            fn ne(&self, other: &$lhs) -> bool { PartialEq::ne(&**self, &**other) }
+            fn ne(&self, other: &$lhs) -> bool { PartialEq::ne(&self[..], &other[..]) }
         }
-
     }
 }
 
-impl_eq! { String, &'a str }
+impl_eq! { String, str }
+impl_eq! { Cow<'a, str>, str }
 impl_eq! { Cow<'a, str>, String }
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, 'b> PartialEq<&'b str> for Cow<'a, str> {
-    #[inline]
-    fn eq(&self, other: &&'b str) -> bool { PartialEq::eq(&**self, &**other) }
-    #[inline]
-    fn ne(&self, other: &&'b str) -> bool { PartialEq::ne(&**self, &**other) }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, 'b> PartialEq<Cow<'a, str>> for &'b str {
-    #[inline]
-    fn eq(&self, other: &Cow<'a, str>) -> bool { PartialEq::eq(&**self, &**other) }
-    #[inline]
-    fn ne(&self, other: &Cow<'a, str>) -> bool { PartialEq::ne(&**self, &**other) }
-}
 
 #[unstable(feature = "collections", reason = "waiting on Str stabilization")]
 impl Str for String {

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1502,22 +1502,15 @@ impl<T> Extend<T> for Vec<T> {
 }
 
 __impl_slice_eq1! { Vec<A>, Vec<B> }
-__impl_slice_eq2! { Vec<A>, &'b [B] }
-__impl_slice_eq2! { Vec<A>, &'b mut [B] }
-__impl_slice_eq2! { Cow<'a, [A]>, &'b [B], Clone }
-__impl_slice_eq2! { Cow<'a, [A]>, &'b mut [B], Clone }
+__impl_slice_eq2! { Vec<A>, [B] }
+__impl_slice_eq2! { Cow<'a, [A]>, [B], Clone }
 __impl_slice_eq2! { Cow<'a, [A]>, Vec<B>, Clone }
 
 macro_rules! array_impls {
     ($($N: expr)+) => {
         $(
-            // NOTE: some less important impls are omitted to reduce code bloat
             __impl_slice_eq2! { Vec<A>, [B; $N] }
-            __impl_slice_eq2! { Vec<A>, &'b [B; $N] }
-            // __impl_slice_eq2! { Vec<A>, &'b mut [B; $N] }
-            // __impl_slice_eq2! { Cow<'a, [A]>, [B; $N], Clone }
-            // __impl_slice_eq2! { Cow<'a, [A]>, &'b [B; $N], Clone }
-            // __impl_slice_eq2! { Cow<'a, [A]>, &'b mut [B; $N], Clone }
+            __impl_slice_eq2! { Cow<'a, [A]>, [B; $N], Clone }
         )+
     }
 }

--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -92,13 +92,8 @@ macro_rules! array_impls {
                 }
             }
 
-            // NOTE: some less important impls are omitted to reduce code bloat
             __impl_slice_eq1! { [A; $N], [B; $N] }
             __impl_slice_eq2! { [A; $N], [B] }
-            __impl_slice_eq2! { [A; $N], &'b [B] }
-            __impl_slice_eq2! { [A; $N], &'b mut [B] }
-            // __impl_slice_eq2! { [A; $N], &'b [B; $N] }
-            // __impl_slice_eq2! { [A; $N], &'b mut [B; $N] }
 
             #[stable(feature = "rust1", since = "1.0.0")]
             impl<T:Eq> Eq for [T; $N] { }

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -569,6 +569,45 @@ mod impls {
 
     // & pointers
 
+    /// A trait implemented for everything except for `&/&mut` references
+    trait NonRef: ::marker::MarkerTrait {}
+    impl NonRef for .. {}
+    impl<'a, T> !NonRef for &'a T {}
+    impl<'a, T> !NonRef for &'a mut T {}
+
+    // NOTE: The numerous impls below can be compressed with a macro
+    #[stable(feature = "rust1", since = "1.0.0")]
+    impl<'a, 'b, A: ?Sized, B: ?Sized + NonRef> PartialEq<B> for &'a A where A: PartialEq<B>
+    {
+        #[inline]
+        fn eq(&self, other: &B) -> bool { PartialEq::eq(*self, other) }
+        #[inline]
+        fn ne(&self, other: &B) -> bool { PartialEq::ne(*self, other) }
+    }
+    #[stable(feature = "rust1", since = "1.0.0")]
+    impl<'a, 'b, A: ?Sized, B: ?Sized + NonRef> PartialEq<B> for &'a mut A where A: PartialEq<B>
+    {
+        #[inline]
+        fn eq(&self, other: &B) -> bool { PartialEq::eq(*self, other) }
+        #[inline]
+        fn ne(&self, other: &B) -> bool { PartialEq::ne(*self, other) }
+    }
+    #[stable(feature = "rust1", since = "1.0.0")]
+    impl<'a, 'b, A: ?Sized + NonRef, B: ?Sized> PartialEq<&'b B> for A where A: PartialEq<B>
+    {
+        #[inline]
+        fn eq(&self, other: &&'b B) -> bool { PartialEq::eq(self, *other) }
+        #[inline]
+        fn ne(&self, other: &&'b B) -> bool { PartialEq::ne(self, *other) }
+    }
+    #[stable(feature = "rust1", since = "1.0.0")]
+    impl<'a, 'b, A: ?Sized + NonRef, B: ?Sized> PartialEq<&'b mut B> for A where A: PartialEq<B>
+    {
+        #[inline]
+        fn eq(&self, other: &&'b mut B) -> bool { PartialEq::eq(self, *other) }
+        #[inline]
+        fn ne(&self, other: &&'b mut B) -> bool { PartialEq::ne(self, *other) }
+    }
     #[stable(feature = "rust1", since = "1.0.0")]
     impl<'a, 'b, A: ?Sized, B: ?Sized> PartialEq<&'b B> for &'a A where A: PartialEq<B> {
         #[inline]

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -664,25 +664,25 @@ impl fmt::Display for InternedString {
     }
 }
 
-impl<'a> PartialEq<&'a str> for InternedString {
+impl PartialEq<str> for InternedString {
     #[inline(always)]
-    fn eq(&self, other: & &'a str) -> bool {
-        PartialEq::eq(&self.string[..], *other)
+    fn eq(&self, other: &str) -> bool {
+        PartialEq::eq(&self.string[..], other)
     }
     #[inline(always)]
-    fn ne(&self, other: & &'a str) -> bool {
-        PartialEq::ne(&self.string[..], *other)
+    fn ne(&self, other: &str) -> bool {
+        PartialEq::ne(&self.string[..], other)
     }
 }
 
-impl<'a> PartialEq<InternedString > for &'a str {
+impl PartialEq<InternedString > for str {
     #[inline(always)]
     fn eq(&self, other: &InternedString) -> bool {
-        PartialEq::eq(*self, &other.string[..])
+        PartialEq::eq(self, &other.string[..])
     }
     #[inline(always)]
     fn ne(&self, other: &InternedString) -> bool {
-        PartialEq::ne(*self, &other.string[..])
+        PartialEq::ne(self, &other.string[..])
     }
 }
 


### PR DESCRIPTION
NOTE: This is not ready to land yet (it's blocked by #23519), but I'd like to discuss the idea.

The idea is simple - currently while doing comparisons we effectively remove references from both operands until one of the operands become non-reference and then we perform the actual comparison.
After this patch we remove references from operands until _both_ of the operands become non-references and then perform the comparison. After the change all the concrete impls of `PartialEq` will be written for non-reference types (see `vec.rs` for the most impressive consequences). The same tweak can be applied to `PartialOrd` if needed.

It was discussed shortly in #22320
r? @alexcrichton 
cc @japaric
