### PR TITLE
Update docs for ToUppercase/ToLowercase structs

### DIFF
--- a/src/libunicode/char.rs
+++ b/src/libunicode/char.rs
@@ -462,7 +462,8 @@ impl CharExt for char {
 }
 
 /// An iterator over the lowercase mapping of a given character, returned from
-/// the `lowercase` method on characters.
+/// the [`to_lowercase` method](../primitive.char.html#method.to_lowercase) on
+/// characters.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct ToLowercase(Option<char>);
 
@@ -473,7 +474,8 @@ impl Iterator for ToLowercase {
 }
 
 /// An iterator over the uppercase mapping of a given character, returned from
-/// the `uppercase` method on characters.
+/// the [`to_uppercase` method](../primitive.char.html#method.to_uppercase) on
+/// characters.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct ToUppercase(Option<char>);
 


### PR DESCRIPTION
`uppercase` and `lowercase` are currently named `to_uppercase` and `to_lowercase`. Also adds a link to the `char` type documentation which has much more detail on these iterators.
