### PR TITLE
Remove rt::default_sched_threads and RUST_THREADS.

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -844,7 +844,7 @@ fn run_tests<F>(opts: &TestOpts,
 
 #[allow(deprecated)]
 fn get_concurrency() -> uint {
-    match env::var("RUST_TEST_THREADS") {
+    match env::var("RUST_TEST_TASKS") {
         Ok(s) => {
             let opt_n: Option<uint> = s.parse().ok();
             match opt_n {


### PR DESCRIPTION
As @alexcrichton says, this was really a libgreen thing, and isn't
relevant now.

As this removes a technically-public function, this is a

[breaking-change]
