### PR TITLE
Add AST to the glossary

### DIFF
--- a/src/doc/trpl/advanced-macros.md
+++ b/src/doc/trpl/advanced-macros.md
@@ -6,9 +6,11 @@ off.
 # Syntactic requirements
 
 Even when Rust code contains un-expanded macros, it can be parsed as a full
-syntax tree. This property can be very useful for editors and other tools that
-process code. It also has a few consequences for the design of Rust's macro
-system.
+[syntax tree][ast]. This property can be very useful for editors and other
+tools that process code. It also has a few consequences for the design of
+Rust's macro system.
+
+[ast]: glossary.html#abstract-syntax-tree
 
 One consequence is that Rust must determine, when it parses a macro invocation,
 whether the macro stands in for

--- a/src/doc/trpl/glossary.md
+++ b/src/doc/trpl/glossary.md
@@ -14,3 +14,26 @@ let z = (8, 2, 6);
 ```
 
 In the example above `x` and `y` have arity 2. `z` has arity 3.
+
+### Abstract Syntax Tree
+
+When a compiler is compiling your program, it does a number of different
+things. One of the things that it does is turn the text of your program into an
+'abstract syntax tree,' or 'AST.' This tree is a representation of the
+structure of your program. For example, `2 + 3` can be turned into a tree:
+
+```text
+  +
+ / \
+2   3
+```
+
+And `2 + (3 * 4)` would look like this:
+
+```text
+  +
+ / \
+2   *
+   / \
+  3   4
+```


### PR DESCRIPTION
Fixes #22551

('grammar' wasn't really used in the chapter at all)
