### PR TITLE
Make the `width` function of `char` return `u32`

### DIFF
--- a/src/etc/unicode.py
+++ b/src/etc/unicode.py
@@ -457,13 +457,13 @@ def emit_charwidth_module(f, width_table):
 """)
 
     f.write("""
-    pub fn width(c: char, is_cjk: bool) -> Option<usize> {
-        match c as usize {
+    pub fn width(c: char, is_cjk: bool) -> Option<u32> {
+        match c as u32 {
             _c @ 0 => Some(0),          // null is zero width
             cu if cu < 0x20 => None,    // control sequences have no width
             cu if cu < 0x7F => Some(1), // ASCII
             cu if cu < 0xA0 => None,    // more control sequences
-            _ => Some(bsearch_range_value_table(c, is_cjk, charwidth_table) as usize)
+            _ => Some(bsearch_range_value_table(c, is_cjk, charwidth_table) as u32)
         }
     }
 

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1456,7 +1456,7 @@ impl str {
     /// characters be treated as 1 column (i.e., `is_cjk = false`) if the locale is unknown.
     #[unstable(feature = "unicode",
                reason = "this functionality may only be provided by libunicode")]
-    pub fn width(&self, is_cjk: bool) -> usize {
+    pub fn width(&self, is_cjk: bool) -> u32 {
         UnicodeStr::width(&self[..], is_cjk)
     }
 

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -286,7 +286,7 @@ enum EscapeUnicodeState {
     Backslash,
     Type,
     LeftBrace,
-    Value(usize),
+    Value(u8),
     RightBrace,
     Done,
 }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -576,7 +576,7 @@ Available lint options:
         .map(|&s| s.name.width(true))
         .max().unwrap_or(0);
     let padded = |x: &str| {
-        let mut s = repeat(" ").take(max_name_len - x.chars().count())
+        let mut s = repeat(" ").take((max_name_len - x.width(true)) as usize)
                                .collect::<String>();
         s.push_str(x);
         s
@@ -603,7 +603,7 @@ Available lint options:
         .map(|&(s, _)| s.width(true))
         .max().unwrap_or(0);
     let padded = |x: &str| {
-        let mut s = repeat(" ").take(max_name_len - x.chars().count())
+        let mut s = repeat(" ").take((max_name_len - x.width(true)) as usize)
                                .collect::<String>();
         s.push_str(x);
         s

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -545,7 +545,7 @@ fn highlight_lines(err: &mut EmitterWriter,
                 _ => lastc.width(false).unwrap_or(0),
             };
             col += count;
-            s.extend(::std::iter::repeat('~').take(count));
+            s.extend(::std::iter::repeat('~').take(count as usize));
 
             let hi = cm.lookup_char_pos(sp.hi);
             if hi.col != lo.col {
@@ -556,7 +556,7 @@ fn highlight_lines(err: &mut EmitterWriter,
                         _ => ch.width(false).unwrap_or(0),
                     };
                     col += count;
-                    s.extend(::std::iter::repeat('~').take(count));
+                    s.extend(::std::iter::repeat('~').take(count as usize));
                 }
             }
 

--- a/src/libunicode/char.rs
+++ b/src/libunicode/char.rs
@@ -447,5 +447,5 @@ impl char {
     /// `is_cjk` = `false`) if the context cannot be reliably determined.
     #[unstable(feature = "unicode",
                reason = "needs expert opinion. is_cjk flag stands out as ugly")]
-    pub fn width(self, is_cjk: bool) -> Option<usize> { charwidth::width(self, is_cjk) }
+    pub fn width(self, is_cjk: bool) -> Option<u32> { charwidth::width(self, is_cjk) }
 }

--- a/src/libunicode/tables.rs
+++ b/src/libunicode/tables.rs
@@ -7603,13 +7603,13 @@ pub mod charwidth {
         }
     }
 
-    pub fn width(c: char, is_cjk: bool) -> Option<usize> {
-        match c as usize {
+    pub fn width(c: char, is_cjk: bool) -> Option<u32> {
+        match c as u32 {
             _c @ 0 => Some(0),          // null is zero width
             cu if cu < 0x20 => None,    // control sequences have no width
             cu if cu < 0x7F => Some(1), // ASCII
             cu if cu < 0xA0 => None,    // more control sequences
-            _ => Some(bsearch_range_value_table(c, is_cjk, charwidth_table) as usize)
+            _ => Some(bsearch_range_value_table(c, is_cjk, charwidth_table) as u32)
         }
     }
 

--- a/src/libunicode/u_str.rs
+++ b/src/libunicode/u_str.rs
@@ -41,7 +41,7 @@ pub trait UnicodeStr {
     fn words<'a>(&'a self) -> Words<'a>;
     fn is_whitespace(&self) -> bool;
     fn is_alphanumeric(&self) -> bool;
-    fn width(&self, is_cjk: bool) -> usize;
+    fn width(&self, is_cjk: bool) -> u32;
     fn trim<'a>(&'a self) -> &'a str;
     fn trim_left<'a>(&'a self) -> &'a str;
     fn trim_right<'a>(&'a self) -> &'a str;
@@ -76,7 +76,7 @@ impl UnicodeStr for str {
     fn is_alphanumeric(&self) -> bool { self.chars().all(|c| c.is_alphanumeric()) }
 
     #[inline]
-    fn width(&self, is_cjk: bool) -> usize {
+    fn width(&self, is_cjk: bool) -> u32 {
         self.chars().map(|c| c.width(is_cjk).unwrap_or(0)).sum()
     }
 


### PR DESCRIPTION
The width of a Unicode codepoint is not related to some in-memory buffer.
