### PR TITLE
Stabilize std::num

### DIFF
--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -189,7 +189,6 @@ mod imp {
     use core::option::Option;
     use core::option::Option::None;
     use core::ptr::{null_mut, null};
-    use core::num::Int;
     use libc::{c_char, c_int, c_void, size_t};
     use super::MIN_ALIGN;
 

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -91,7 +91,6 @@ use core::hash;
 use core::iter::RandomAccessIterator;
 use core::iter::{Chain, Enumerate, Repeat, Skip, Take, repeat, Cloned};
 use core::iter::{self, FromIterator, IntoIterator};
-use core::num::Int;
 use core::ops::Index;
 use core::slice;
 use core::{u8, u32, usize};

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -16,7 +16,6 @@
 use core::prelude::*;
 use core::marker;
 use core::fmt;
-use core::num::Int;
 use core::iter::{FromIterator, IntoIterator};
 use core::ops::{Sub, BitOr, BitAnd, BitXor};
 

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -89,6 +89,7 @@ use core::iter::MultiplicativeIterator;
 use core::marker::Sized;
 use core::mem::size_of;
 use core::mem;
+#[cfg(stage0)]
 use core::num::wrapping::WrappingOps;
 use core::ops::FnMut;
 use core::option::Option::{self, Some, None};

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -18,9 +18,6 @@
 //! (see below). It is not possible to move out of borrowed strings because they
 //! are owned elsewhere.
 //!
-//! Basic operations are implemented directly by the compiler, but more advanced
-//! operations are defined as methods on the `str` type.
-//!
 //! # Examples
 //!
 //! Here's some code that uses a `&str`:

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -25,6 +25,7 @@ use core::default::Default;
 use core::fmt;
 use core::iter::{self, repeat, FromIterator, IntoIterator, RandomAccessIterator};
 use core::mem;
+#[cfg(stage0)]
 use core::num::wrapping::WrappingOps;
 use core::ops::{Index, IndexMut};
 use core::ptr::{self, Unique};

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -20,8 +20,6 @@
 //!
 //! ```
 //! # #![feature(core)]
-//! use std::num::SignedInt;
-//!
 //! struct FuzzyNum {
 //!     num: i32,
 //! }

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -33,6 +33,7 @@ trait GenericRadix {
     fn digit(&self, x: u8) -> u8;
 
     /// Format an integer using the radix using a formatter.
+    #[allow(deprecated)] // Int
     fn fmt_int<T: Int>(&self, mut x: T, f: &mut fmt::Formatter) -> fmt::Result {
         // The radix can be as low as 2, so we need a buffer of at least 64
         // characters for a base 2 number.

--- a/src/libcore/hash/sip.rs
+++ b/src/libcore/hash/sip.rs
@@ -12,9 +12,10 @@
 
 //! An implementation of SipHash 2-4.
 
+#![allow(deprecated)] // until the next snapshot for inherent wrapping ops
+
 use prelude::*;
 use default::Default;
-use num::wrapping::WrappingOps;
 use super::Hasher;
 
 /// An implementation of SipHash 2-4.
@@ -71,7 +72,7 @@ macro_rules! u8to64_le {
 
 macro_rules! rotl {
     ($x:expr, $b:expr) =>
-    (($x << $b) | ($x >> (64.wrapping_sub($b))))
+    (($x << $b) | ($x >> (64_i32.wrapping_sub($b))))
 }
 
 macro_rules! compress {

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -22,12 +22,12 @@ use num::Float;
 use num::FpCategory as Fp;
 use option::Option;
 
-#[unstable(feature = "core", reason = "pending integer conventions")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub const RADIX: u32 = 2;
 
-#[unstable(feature = "core", reason = "pending integer conventions")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub const MANTISSA_DIGITS: u32 = 24;
-#[unstable(feature = "core", reason = "pending integer conventions")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub const DIGITS: u32 = 6;
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -56,14 +56,14 @@ pub const MIN_POSITIVE: f32 = 1.17549435e-38_f32;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MAX: f32 = 3.40282347e+38_f32;
 
-#[unstable(feature = "core", reason = "pending integer conventions")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN_EXP: i32 = -125;
-#[unstable(feature = "core", reason = "pending integer conventions")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub const MAX_EXP: i32 = 128;
 
-#[unstable(feature = "core", reason = "pending integer conventions")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN_10_EXP: i32 = -37;
-#[unstable(feature = "core", reason = "pending integer conventions")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub const MAX_10_EXP: i32 = 38;
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -73,61 +73,89 @@ pub const INFINITY: f32 = 1.0_f32/0.0_f32;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const NEG_INFINITY: f32 = -1.0_f32/0.0_f32;
 
-/// Various useful constants.
-#[unstable(feature = "core",
-           reason = "naming scheme needs to be revisited")]
+/// Basic mathematial constants.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub mod consts {
     // FIXME: replace with mathematical constants from cmath.
 
     /// Archimedes' constant
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const PI: f32 = 3.14159265358979323846264338327950288_f32;
 
     /// pi * 2.0
+    #[unstable(feature = "core", reason = "unclear naming convention/usefulness")]
     pub const PI_2: f32 = 6.28318530717958647692528676655900576_f32;
 
     /// pi/2.0
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_PI_2: f32 = 1.57079632679489661923132169163975144_f32;
 
     /// pi/3.0
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_PI_3: f32 = 1.04719755119659774615421446109316763_f32;
 
     /// pi/4.0
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_PI_4: f32 = 0.785398163397448309615660845819875721_f32;
 
     /// pi/6.0
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_PI_6: f32 = 0.52359877559829887307710723054658381_f32;
 
     /// pi/8.0
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_PI_8: f32 = 0.39269908169872415480783042290993786_f32;
 
     /// 1.0/pi
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_1_PI: f32 = 0.318309886183790671537767526745028724_f32;
 
     /// 2.0/pi
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_2_PI: f32 = 0.636619772367581343075535053490057448_f32;
 
     /// 2.0/sqrt(pi)
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const FRAC_2_SQRT_PI: f32 = 1.12837916709551257389615890312154517_f32;
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[deprecated(since = "1.0.0", reason = "renamed to FRAC_2_SQRT_PI")]
     pub const FRAC_2_SQRTPI: f32 = 1.12837916709551257389615890312154517_f32;
 
     /// sqrt(2.0)
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const SQRT_2: f32 = 1.41421356237309504880168872420969808_f32;
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[deprecated(since = "1.0.0", reason = "renamed to SQRT_2")]
     pub const SQRT2: f32 = 1.41421356237309504880168872420969808_f32;
 
     /// 1.0/sqrt(2.0)
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const FRAC_1_SQRT_2: f32 = 0.707106781186547524400844362104849039_f32;
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[deprecated(since = "1.0.0", reason = "renamed to FRAC_1_SQRT_2")]
     pub const FRAC_1_SQRT2: f32 = 0.707106781186547524400844362104849039_f32;
 
     /// Euler's number
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const E: f32 = 2.71828182845904523536028747135266250_f32;
 
     /// log2(e)
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const LOG2_E: f32 = 1.44269504088896340735992468100189214_f32;
 
     /// log10(e)
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const LOG10_E: f32 = 0.434294481903251827651128918916605082_f32;
 
     /// ln(2.0)
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const LN_2: f32 = 0.693147180559945309417232121458176568_f32;
 
     /// ln(10.0)
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const LN_10: f32 = 2.30258509299404568401799145468436421_f32;
 }
 

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -22,15 +22,12 @@ use num::Float;
 use num::FpCategory as Fp;
 use option::Option;
 
-// FIXME(#5527): These constants should be deprecated once associated
-// constants are implemented in favour of referencing the respective
-// members of `Bounded` and `Float`.
-
-#[unstable(feature = "core", reason = "pending integer conventions")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub const RADIX: u32 = 2;
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub const MANTISSA_DIGITS: u32 = 53;
-#[unstable(feature = "core", reason = "pending integer conventions")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub const DIGITS: u32 = 15;
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -59,14 +56,14 @@ pub const MIN_POSITIVE: f64 = 2.2250738585072014e-308_f64;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MAX: f64 = 1.7976931348623157e+308_f64;
 
-#[unstable(feature = "core", reason = "pending integer conventions")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN_EXP: i32 = -1021;
-#[unstable(feature = "core", reason = "pending integer conventions")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub const MAX_EXP: i32 = 1024;
 
-#[unstable(feature = "core", reason = "pending integer conventions")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN_10_EXP: i32 = -307;
-#[unstable(feature = "core", reason = "pending integer conventions")]
+#[stable(feature = "rust1", since = "1.0.0")]
 pub const MAX_10_EXP: i32 = 308;
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -76,65 +73,89 @@ pub const INFINITY: f64 = 1.0_f64/0.0_f64;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const NEG_INFINITY: f64 = -1.0_f64/0.0_f64;
 
-/// Various useful constants.
-#[unstable(feature = "core",
-           reason = "naming scheme needs to be revisited")]
+/// Basic mathematial constants.
+#[stable(feature = "rust1", since = "1.0.0")]
 pub mod consts {
     // FIXME: replace with mathematical constants from cmath.
 
-    // FIXME(#5527): These constants should be deprecated once associated
-    // constants are implemented in favour of referencing the respective members
-    // of `Float`.
-
     /// Archimedes' constant
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const PI: f64 = 3.14159265358979323846264338327950288_f64;
 
     /// pi * 2.0
+    #[unstable(feature = "core", reason = "unclear naming convention/usefulness")]
     pub const PI_2: f64 = 6.28318530717958647692528676655900576_f64;
 
     /// pi/2.0
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_PI_2: f64 = 1.57079632679489661923132169163975144_f64;
 
     /// pi/3.0
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_PI_3: f64 = 1.04719755119659774615421446109316763_f64;
 
     /// pi/4.0
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_PI_4: f64 = 0.785398163397448309615660845819875721_f64;
 
     /// pi/6.0
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_PI_6: f64 = 0.52359877559829887307710723054658381_f64;
 
     /// pi/8.0
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_PI_8: f64 = 0.39269908169872415480783042290993786_f64;
 
     /// 1.0/pi
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_1_PI: f64 = 0.318309886183790671537767526745028724_f64;
 
     /// 2.0/pi
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const FRAC_2_PI: f64 = 0.636619772367581343075535053490057448_f64;
 
     /// 2.0/sqrt(pi)
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const FRAC_2_SQRT_PI: f64 = 1.12837916709551257389615890312154517_f64;
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[deprecated(since = "1.0.0", reason = "renamed to FRAC_2_SQRT_PI")]
     pub const FRAC_2_SQRTPI: f64 = 1.12837916709551257389615890312154517_f64;
 
     /// sqrt(2.0)
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const SQRT_2: f64 = 1.41421356237309504880168872420969808_f64;
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[deprecated(since = "1.0.0", reason = "renamed to SQRT_2")]
     pub const SQRT2: f64 = 1.41421356237309504880168872420969808_f64;
 
     /// 1.0/sqrt(2.0)
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub const FRAC_1_SQRT_2: f64 = 0.707106781186547524400844362104849039_f64;
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[deprecated(since = "1.0.0", reason = "renamed to FRAC_1_SQRT_2")]
     pub const FRAC_1_SQRT2: f64 = 0.707106781186547524400844362104849039_f64;
 
     /// Euler's number
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const E: f64 = 2.71828182845904523536028747135266250_f64;
 
     /// log2(e)
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const LOG2_E: f64 = 1.44269504088896340735992468100189214_f64;
 
     /// log10(e)
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const LOG10_E: f64 = 0.434294481903251827651128918916605082_f64;
 
     /// ln(2.0)
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const LN_2: f64 = 0.693147180559945309417232121458176568_f64;
 
     /// ln(10.0)
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub const LN_10: f64 = 2.30258509299404568401799145468436421_f64;
 }
 

--- a/src/libcore/num/wrapping.rs
+++ b/src/libcore/num/wrapping.rs
@@ -7,7 +7,11 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
 #![allow(missing_docs)]
+#![allow(deprecated)]
+
+use super::Wrapping;
 
 use ops::*;
 
@@ -26,6 +30,8 @@ use intrinsics::{i16_mul_with_overflow, u16_mul_with_overflow};
 use intrinsics::{i32_mul_with_overflow, u32_mul_with_overflow};
 use intrinsics::{i64_mul_with_overflow, u64_mul_with_overflow};
 
+#[unstable(feature = "core", reason = "may be removed, renamed, or relocated")]
+#[deprecated(since = "1.0.0", reason = "moved to inherent methods")]
 pub trait WrappingOps {
     fn wrapping_add(self, rhs: Self) -> Self;
     fn wrapping_sub(self, rhs: Self) -> Self;
@@ -38,6 +44,49 @@ pub trait OverflowingOps {
     fn overflowing_sub(self, rhs: Self) -> (Self, bool);
     fn overflowing_mul(self, rhs: Self) -> (Self, bool);
 }
+
+macro_rules! sh_impl {
+    ($t:ty, $f:ty) => (
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl Shl<$f> for Wrapping<$t> {
+            type Output = Wrapping<$t>;
+
+            #[inline(always)]
+            fn shl(self, other: $f) -> Wrapping<$t> {
+                Wrapping(self.0 << other)
+            }
+        }
+
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl Shr<$f> for Wrapping<$t> {
+            type Output = Wrapping<$t>;
+
+            #[inline(always)]
+            fn shr(self, other: $f) -> Wrapping<$t> {
+                Wrapping(self.0 >> other)
+            }
+        }
+    )
+}
+
+// FIXME (#23545): uncomment the remaining impls
+macro_rules! sh_impl_all {
+    ($($t:ty)*) => ($(
+        // sh_impl! { $t, u8 }
+        // sh_impl! { $t, u16 }
+        // sh_impl! { $t, u32 }
+        // sh_impl! { $t, u64 }
+        sh_impl! { $t, usize }
+
+        // sh_impl! { $t, i8 }
+        // sh_impl! { $t, i16 }
+        // sh_impl! { $t, i32 }
+        // sh_impl! { $t, i64 }
+        // sh_impl! { $t, isize }
+    )*)
+}
+
+sh_impl_all! { u8 u16 u32 u64 usize i8 i16 i32 i64 isize }
 
 macro_rules! wrapping_impl {
     ($($t:ty)*) => ($(
@@ -61,94 +110,79 @@ macro_rules! wrapping_impl {
                 }
             }
         }
+
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl Add for Wrapping<$t> {
+            type Output = Wrapping<$t>;
+
+            #[inline(always)]
+            fn add(self, other: Wrapping<$t>) -> Wrapping<$t> {
+                Wrapping(self.0.wrapping_add(other.0))
+            }
+        }
+
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl Sub for Wrapping<$t> {
+            type Output = Wrapping<$t>;
+
+            #[inline(always)]
+            fn sub(self, other: Wrapping<$t>) -> Wrapping<$t> {
+                Wrapping(self.0.wrapping_sub(other.0))
+            }
+        }
+
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl Mul for Wrapping<$t> {
+            type Output = Wrapping<$t>;
+
+            #[inline(always)]
+            fn mul(self, other: Wrapping<$t>) -> Wrapping<$t> {
+                Wrapping(self.0.wrapping_mul(other.0))
+            }
+        }
+
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl Not for Wrapping<$t> {
+            type Output = Wrapping<$t>;
+
+            fn not(self) -> Wrapping<$t> {
+                Wrapping(!self.0)
+            }
+        }
+
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl BitXor for Wrapping<$t> {
+            type Output = Wrapping<$t>;
+
+            #[inline(always)]
+            fn bitxor(self, other: Wrapping<$t>) -> Wrapping<$t> {
+                Wrapping(self.0 ^ other.0)
+            }
+        }
+
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl BitOr for Wrapping<$t> {
+            type Output = Wrapping<$t>;
+
+            #[inline(always)]
+            fn bitor(self, other: Wrapping<$t>) -> Wrapping<$t> {
+                Wrapping(self.0 | other.0)
+            }
+        }
+
+        #[stable(feature = "rust1", since = "1.0.0")]
+        impl BitAnd for Wrapping<$t> {
+            type Output = Wrapping<$t>;
+
+            #[inline(always)]
+            fn bitand(self, other: Wrapping<$t>) -> Wrapping<$t> {
+                Wrapping(self.0 & other.0)
+            }
+        }
     )*)
 }
 
 wrapping_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
-
-#[unstable(feature = "core", reason = "may be removed, renamed, or relocated")]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
-pub struct Wrapping<T>(pub T);
-
-impl<T:WrappingOps> Add for Wrapping<T> {
-    type Output = Wrapping<T>;
-
-    #[inline(always)]
-    fn add(self, other: Wrapping<T>) -> Wrapping<T> {
-        Wrapping(self.0.wrapping_add(other.0))
-    }
-}
-
-impl<T:WrappingOps> Sub for Wrapping<T> {
-    type Output = Wrapping<T>;
-
-    #[inline(always)]
-    fn sub(self, other: Wrapping<T>) -> Wrapping<T> {
-        Wrapping(self.0.wrapping_sub(other.0))
-    }
-}
-
-impl<T:WrappingOps> Mul for Wrapping<T> {
-    type Output = Wrapping<T>;
-
-    #[inline(always)]
-    fn mul(self, other: Wrapping<T>) -> Wrapping<T> {
-        Wrapping(self.0.wrapping_mul(other.0))
-    }
-}
-
-impl<T:WrappingOps+Not<Output=T>> Not for Wrapping<T> {
-    type Output = Wrapping<T>;
-
-    fn not(self) -> Wrapping<T> {
-        Wrapping(!self.0)
-    }
-}
-
-impl<T:WrappingOps+BitXor<Output=T>> BitXor for Wrapping<T> {
-    type Output = Wrapping<T>;
-
-    #[inline(always)]
-    fn bitxor(self, other: Wrapping<T>) -> Wrapping<T> {
-        Wrapping(self.0 ^ other.0)
-    }
-}
-
-impl<T:WrappingOps+BitOr<Output=T>> BitOr for Wrapping<T> {
-    type Output = Wrapping<T>;
-
-    #[inline(always)]
-    fn bitor(self, other: Wrapping<T>) -> Wrapping<T> {
-        Wrapping(self.0 | other.0)
-    }
-}
-
-impl<T:WrappingOps+BitAnd<Output=T>> BitAnd for Wrapping<T> {
-    type Output = Wrapping<T>;
-
-    #[inline(always)]
-    fn bitand(self, other: Wrapping<T>) -> Wrapping<T> {
-        Wrapping(self.0 & other.0)
-    }
-}
-
-impl<T:WrappingOps+Shl<usize,Output=T>> Shl<usize> for Wrapping<T> {
-    type Output = Wrapping<T>;
-
-    #[inline(always)]
-    fn shl(self, other: usize) -> Wrapping<T> {
-        Wrapping(self.0 << other)
-    }
-}
-
-impl<T:WrappingOps+Shr<usize,Output=T>> Shr<usize> for Wrapping<T> {
-    type Output = Wrapping<T>;
-
-    #[inline(always)]
-    fn shr(self, other: usize) -> Wrapping<T> {
-        Wrapping(self.0 >> other)
-    }
-}
 
 macro_rules! overflowing_impl {
     ($($t:ident)*) => ($(

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -945,9 +945,9 @@ impl TwoWaySearcher {
     // critical factorization (u, v) and p = period(v)
     #[inline]
     #[allow(dead_code)]
+    #[allow(deprecated)]
     fn maximal_suffix(arr: &[u8], reversed: bool) -> (usize, usize) {
-        use num::wrapping::WrappingOps;
-        let mut left = -1; // Corresponds to i in the paper
+        let mut left: usize = -1; // Corresponds to i in the paper
         let mut right = 0; // Corresponds to j in the paper
         let mut offset = 1; // Corresponds to k in the paper
         let mut period = 1; // Corresponds to p in the paper

--- a/src/librand/isaac.rs
+++ b/src/librand/isaac.rs
@@ -14,8 +14,8 @@
 
 use core::prelude::*;
 use core::slice;
-use core::iter::{range_step, repeat};
-use core::num::wrapping::Wrapping as w;
+use core::iter::repeat;
+use core::num::Wrapping as w;
 
 use {Rng, SeedableRng, Rand};
 
@@ -95,7 +95,7 @@ impl IsaacRng {
         if use_rsl {
             macro_rules! memloop {
                 ($arr:expr) => {{
-                    for i in range_step(0, RAND_SIZE_USIZE, 8) {
+                    for i in (0..RAND_SIZE_USIZE).step_by(8) {
                         a=a+$arr[i  ]; b=b+$arr[i+1];
                         c=c+$arr[i+2]; d=d+$arr[i+3];
                         e=e+$arr[i+4]; f=f+$arr[i+5];
@@ -112,7 +112,7 @@ impl IsaacRng {
             memloop!(self.rsl);
             memloop!(self.mem);
         } else {
-            for i in range_step(0, RAND_SIZE_USIZE, 8) {
+            for i in (0..RAND_SIZE_USIZE).step_by(8) {
                 mix!();
                 self.mem[i  ]=a; self.mem[i+1]=b;
                 self.mem[i+2]=c; self.mem[i+3]=d;
@@ -136,7 +136,7 @@ impl IsaacRng {
         const MIDPOINT: usize = RAND_SIZE_USIZE / 2;
 
         macro_rules! ind {
-            ($x:expr) => ( self.mem[($x >> 2).0 as usize & (RAND_SIZE_USIZE - 1)] )
+            ($x:expr) => (self.mem[($x >> 2).0 as usize & (RAND_SIZE_USIZE - 1)] )
         }
 
         let r = [(0, MIDPOINT), (MIDPOINT, 0)];
@@ -172,7 +172,7 @@ impl IsaacRng {
                 }}
             }
 
-            for i in range_step(0, MIDPOINT, 4) {
+            for i in (0..MIDPOINT).step_by(4) {
                 rngstepp!(i + 0, 13);
                 rngstepn!(i + 1, 6);
                 rngstepp!(i + 2, 2);

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -30,6 +30,7 @@
 #![feature(staged_api)]
 #![staged_api]
 #![feature(core)]
+#![feature(step_by)]
 #![deprecated(reason = "use the crates.io `rand` library instead",
               since = "1.0.0-alpha")]
 

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -241,7 +241,6 @@ pub mod reader {
 
     use std::isize;
     use std::mem::transmute;
-    use std::num::Int;
     use std::slice::bytes;
 
     use serialize;
@@ -346,7 +345,7 @@ pub mod reader {
 
         unsafe {
             let ptr = data.as_ptr().offset(start as isize) as *const u32;
-            let val = Int::from_be(*ptr);
+            let val = u32::from_be(*ptr);
 
             let i = (val >> 28) as usize;
             let (shift, mask) = SHIFT_MASK_TABLE[i];
@@ -835,7 +834,6 @@ pub mod reader {
 
 pub mod writer {
     use std::mem;
-    use std::num::Int;
     use std::io::prelude::*;
     use std::io::{self, SeekFrom, Cursor};
     use std::slice::bytes;

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -35,7 +35,7 @@ use std::collections::HashMap;
 use std::hash::{self, Hash, SipHasher};
 use std::io::prelude::*;
 use std::io;
-use std::num::{FromPrimitive, Int};
+use std::num::FromPrimitive;
 use std::rc::Rc;
 use std::slice::bytes;
 use std::str;

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -5483,7 +5483,6 @@ pub fn type_is_empty(cx: &ctxt, ty: Ty) -> bool {
 
 pub fn enum_variants<'tcx>(cx: &ctxt<'tcx>, id: ast::DefId)
                            -> Rc<Vec<Rc<VariantInfo<'tcx>>>> {
-    use std::num::Int; // For checked_add
     memoized(&cx.enum_var_cache, id, |id: ast::DefId| {
         if ast::LOCAL_CRATE != id.krate {
             Rc::new(csearch::get_enum_variants(cx, id))

--- a/src/librustc_back/sha2.rs
+++ b/src/librustc_back/sha2.rs
@@ -64,7 +64,7 @@ impl ToBits for u64 {
 fn add_bytes_to_bits<T: Int + ToBits>(bits: T, bytes: T) -> T {
     let (new_high_bits, new_low_bits) = bytes.to_bits();
 
-    if new_high_bits > Int::zero() {
+    if new_high_bits > T::zero() {
         panic!("numeric overflow occurred.")
     }
 
@@ -537,7 +537,7 @@ mod tests {
     use self::rand::isaac::IsaacRng;
     use serialize::hex::FromHex;
     use std::iter::repeat;
-    use std::num::Int;
+    use std::u64;
     use super::{Digest, Sha256, FixedBuffer};
 
     // A normal addition - no overflow occurs
@@ -550,7 +550,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_add_bytes_to_bits_overflow() {
-        super::add_bytes_to_bits::<u64>(Int::max_value(), 1);
+        super::add_bytes_to_bits::<u64>(u64::MAX, 1);
     }
 
     struct Test {

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -41,7 +41,6 @@ use lint::{Level, Context, LintPass, LintArray, Lint};
 
 use std::collections::BitSet;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::num::SignedInt;
 use std::{cmp, slice};
 use std::{i8, i16, i32, i64, u8, u16, u32, u64, f32, f64};
 

--- a/src/librustc_trans/back/lto.rs
+++ b/src/librustc_trans/back/lto.rs
@@ -22,6 +22,7 @@ use flate;
 
 use std::ffi::CString;
 use std::mem;
+#[allow(deprecated)]
 use std::num::Int;
 
 pub fn run(sess: &session::Session, llmod: ModuleRef,
@@ -204,6 +205,7 @@ fn extract_compressed_bytecode_size_v1(bc: &[u8]) -> u64 {
     return read_from_le_bytes::<u64>(bc, link::RLIB_BYTECODE_OBJECT_V1_DATASIZE_OFFSET);
 }
 
+#[allow(deprecated)]
 fn read_from_le_bytes<T: Int>(bytes: &[u8], position_in_bytes: usize) -> T {
     let byte_data = &bytes[position_in_bytes..position_in_bytes + mem::size_of::<T>()];
     let data = unsafe {

--- a/src/librustc_trans/trans/adt.rs
+++ b/src/librustc_trans/trans/adt.rs
@@ -45,6 +45,7 @@
 
 pub use self::Repr::*;
 
+#[allow(deprecated)]
 use std::num::Int;
 use std::rc::Rc;
 

--- a/src/librustc_trans/trans/type_of.rs
+++ b/src/librustc_trans/trans/type_of.rs
@@ -21,6 +21,7 @@ use util::ppaux::Repr;
 
 use trans::type_::Type;
 
+#[allow(deprecated)]
 use std::num::Int;
 use syntax::abi;
 use syntax::ast;

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4622,7 +4622,7 @@ pub fn check_enum_variants<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
                           id: ast::NodeId,
                           hint: attr::ReprAttr)
                           -> Vec<Rc<ty::VariantInfo<'tcx>>> {
-        use std::num::Int;
+        #![allow(trivial_numeric_casts)]
 
         let rty = ty::node_id_to_type(ccx.tcx, id);
         let mut variants: Vec<Rc<ty::VariantInfo>> = Vec::new();

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -204,6 +204,8 @@ use std::io::prelude::*;
 use std::io;
 use std::mem::swap;
 use std::num::FpCategory as Fp;
+#[allow(deprecated)]
+use std::num::wrapping::WrappingOps;
 use std::ops::Index;
 use std::str::FromStr;
 use std::string;
@@ -1552,6 +1554,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
         }
     }
 
+    #[allow(deprecated)] // possible resolve bug is mapping these to traits
     fn parse_u64(&mut self) -> Result<u64, ParserError> {
         let mut accum = 0;
         let last_accum = 0; // necessary to detect overflow.

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -14,7 +14,6 @@ use io::prelude::*;
 use cmp;
 use io::{self, SeekFrom, Error, ErrorKind};
 use iter::repeat;
-use num::Int;
 use slice;
 
 /// A `Cursor` is a type which wraps a non-I/O object to provide a `Seek`

--- a/src/libstd/net/mod.rs
+++ b/src/libstd/net/mod.rs
@@ -18,6 +18,7 @@
 use prelude::v1::*;
 
 use io::{self, Error, ErrorKind};
+#[allow(deprecated)] // Int
 use num::Int;
 use sys_common::net2 as net_imp;
 
@@ -54,7 +55,9 @@ pub enum Shutdown {
     Both,
 }
 
+#[allow(deprecated)] // Int
 fn hton<I: Int>(i: I) -> I { i.to_be() }
+#[allow(deprecated)] // Int
 fn ntoh<I: Int>(i: I) -> I { Int::from_be(i) }
 
 fn each_addr<A: ToSocketAddrs, F, T>(addr: A, mut f: F) -> io::Result<T>

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -75,6 +75,7 @@ mod cmath {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated)]
 impl Float for f32 {
     #[inline]
     fn nan() -> f32 { num::Float::nan() }
@@ -361,227 +362,18 @@ impl Float for f32 {
 #[lang = "f32"]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl f32 {
-    // inlined methods from `num::Float`
-    /// Returns the `NaN` value.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let nan: f32 = Float::nan();
-    ///
-    /// assert!(nan.is_nan());
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    pub fn nan() -> f32 { num::Float::nan() }
-
-    /// Returns the infinite value.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    /// use std::f32;
-    ///
-    /// let infinity: f32 = Float::infinity();
-    ///
-    /// assert!(infinity.is_infinite());
-    /// assert!(!infinity.is_finite());
-    /// assert!(infinity > f32::MAX);
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    pub fn infinity() -> f32 { num::Float::infinity() }
-
-    /// Returns the negative infinite value.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    /// use std::f32;
-    ///
-    /// let neg_infinity: f32 = Float::neg_infinity();
-    ///
-    /// assert!(neg_infinity.is_infinite());
-    /// assert!(!neg_infinity.is_finite());
-    /// assert!(neg_infinity < f32::MIN);
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    pub fn neg_infinity() -> f32 { num::Float::neg_infinity() }
-
-    /// Returns `0.0`.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let inf: f32 = Float::infinity();
-    /// let zero: f32 = Float::zero();
-    /// let neg_zero: f32 = Float::neg_zero();
-    ///
-    /// assert_eq!(zero, neg_zero);
-    /// assert_eq!(7.0f32/inf, zero);
-    /// assert_eq!(zero * 10.0, zero);
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    pub fn zero() -> f32 { num::Float::zero() }
-
-    /// Returns `-0.0`.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let inf: f32 = Float::infinity();
-    /// let zero: f32 = Float::zero();
-    /// let neg_zero: f32 = Float::neg_zero();
-    ///
-    /// assert_eq!(zero, neg_zero);
-    /// assert_eq!(7.0f32/inf, zero);
-    /// assert_eq!(zero * 10.0, zero);
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    pub fn neg_zero() -> f32 { num::Float::neg_zero() }
-
-    /// Returns `1.0`.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let one: f32 = Float::one();
-    ///
-    /// assert_eq!(one, 1.0f32);
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    pub fn one() -> f32 { num::Float::one() }
-
-    // FIXME (#5527): These should be associated constants
-
-    /// Deprecated: use `std::f32::MANTISSA_DIGITS` or `std::f64::MANTISSA_DIGITS`
-    /// instead.
-    #[unstable(feature = "std_misc")]
-    #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::MANTISSA_DIGITS` or \
-                           `std::f64::MANTISSA_DIGITS` as appropriate")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn mantissa_digits(unused_self: Option<f32>) -> usize {
-        num::Float::mantissa_digits(unused_self)
-    }
-
-    /// Deprecated: use `std::f32::DIGITS` or `std::f64::DIGITS` instead.
-    #[unstable(feature = "std_misc")]
-    #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::DIGITS` or `std::f64::DIGITS` as appropriate")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn digits(unused_self: Option<f32>) -> usize { num::Float::digits(unused_self) }
-
-    /// Deprecated: use `std::f32::EPSILON` or `std::f64::EPSILON` instead.
-    #[unstable(feature = "std_misc")]
-    #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::EPSILON` or `std::f64::EPSILON` as appropriate")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn epsilon() -> f32 { num::Float::epsilon() }
-
-    /// Deprecated: use `std::f32::MIN_EXP` or `std::f64::MIN_EXP` instead.
-    #[unstable(feature = "std_misc")]
-    #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::MIN_EXP` or `std::f64::MIN_EXP` as appropriate")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn min_exp(unused_self: Option<f32>) -> isize { num::Float::min_exp(unused_self) }
-
-    /// Deprecated: use `std::f32::MAX_EXP` or `std::f64::MAX_EXP` instead.
-    #[unstable(feature = "std_misc")]
-    #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::MAX_EXP` or `std::f64::MAX_EXP` as appropriate")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn max_exp(unused_self: Option<f32>) -> isize { num::Float::max_exp(unused_self) }
-
-    /// Deprecated: use `std::f32::MIN_10_EXP` or `std::f64::MIN_10_EXP` instead.
-    #[unstable(feature = "std_misc")]
-    #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::MIN_10_EXP` or `std::f64::MIN_10_EXP` as appropriate")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn min_10_exp(unused_self: Option<f32>) -> isize { num::Float::min_10_exp(unused_self) }
-
-    /// Deprecated: use `std::f32::MAX_10_EXP` or `std::f64::MAX_10_EXP` instead.
-    #[unstable(feature = "std_misc")]
-    #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::MAX_10_EXP` or `std::f64::MAX_10_EXP` as appropriate")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn max_10_exp(unused_self: Option<f32>) -> isize { num::Float::max_10_exp(unused_self) }
-
-    /// Returns the smallest finite value that this type can represent.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    /// use std::f64;
-    ///
-    /// let x: f64 = Float::min_value();
-    ///
-    /// assert_eq!(x, f64::MIN);
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    #[allow(deprecated)]
-    pub fn min_value() -> f32 { num::Float::min_value() }
-
-    /// Returns the smallest normalized positive number that this type can represent.
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    #[allow(deprecated)]
-    pub fn min_pos_value(unused_self: Option<f32>) -> f32 { num::Float::min_pos_value(unused_self) }
-
-    /// Returns the largest finite value that this type can represent.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    /// use std::f64;
-    ///
-    /// let x: f64 = Float::max_value();
-    /// assert_eq!(x, f64::MAX);
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    #[allow(deprecated)]
-    pub fn max_value() -> f32 { num::Float::max_value() }
-
     /// Returns `true` if this value is `NaN` and false otherwise.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let nan = f64::NAN;
-    /// let f = 7.0;
+    /// let nan = f32::NAN;
+    /// let f = 7.0_f32;
     ///
     /// assert!(nan.is_nan());
     /// assert!(!f.is_nan());
     /// ```
-    #[unstable(feature = "std_misc", reason = "position is undecided")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_nan(self) -> bool { num::Float::is_nan(self) }
 
@@ -589,14 +381,12 @@ impl f32 {
     /// false otherwise.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
     /// use std::f32;
     ///
     /// let f = 7.0f32;
-    /// let inf: f32 = Float::infinity();
-    /// let neg_inf: f32 = Float::neg_infinity();
-    /// let nan: f32 = f32::NAN;
+    /// let inf = f32::INFINITY;
+    /// let neg_inf = f32::NEG_INFINITY;
+    /// let nan = f32::NAN;
     ///
     /// assert!(!f.is_infinite());
     /// assert!(!nan.is_infinite());
@@ -604,21 +394,19 @@ impl f32 {
     /// assert!(inf.is_infinite());
     /// assert!(neg_inf.is_infinite());
     /// ```
-    #[unstable(feature = "std_misc", reason = "position is undecided")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_infinite(self) -> bool { num::Float::is_infinite(self) }
 
     /// Returns `true` if this number is neither infinite nor `NaN`.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
     /// use std::f32;
     ///
     /// let f = 7.0f32;
-    /// let inf: f32 = Float::infinity();
-    /// let neg_inf: f32 = Float::neg_infinity();
-    /// let nan: f32 = f32::NAN;
+    /// let inf = f32::INFINITY;
+    /// let neg_inf = f32::NEG_INFINITY;
+    /// let nan = f32::NAN;
     ///
     /// assert!(f.is_finite());
     ///
@@ -626,7 +414,7 @@ impl f32 {
     /// assert!(!inf.is_finite());
     /// assert!(!neg_inf.is_finite());
     /// ```
-    #[unstable(feature = "std_misc", reason = "position is undecided")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_finite(self) -> bool { num::Float::is_finite(self) }
 
@@ -635,13 +423,12 @@ impl f32 {
     ///
     /// ```
     /// # #![feature(std_misc)]
-    /// use std::num::Float;
     /// use std::f32;
     ///
     /// let min = f32::MIN_POSITIVE; // 1.17549435e-38f32
     /// let max = f32::MAX;
     /// let lower_than_min = 1.0e-40_f32;
-    /// let zero = 0.0f32;
+    /// let zero = 0.0_f32;
     ///
     /// assert!(min.is_normal());
     /// assert!(max.is_normal());
@@ -653,7 +440,7 @@ impl f32 {
     /// assert!(!lower_than_min.is_normal());
     /// ```
     /// [subnormal]: http://en.wikipedia.org/wiki/Denormal_number
-    #[unstable(feature = "std_misc", reason = "position is undecided")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_normal(self) -> bool { num::Float::is_normal(self) }
 
@@ -662,11 +449,10 @@ impl f32 {
     /// predicate instead.
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::{Float, FpCategory};
+    /// use std::num::FpCategory;
     /// use std::f32;
     ///
-    /// let num = 12.4f32;
+    /// let num = 12.4_f32;
     /// let inf = f32::INFINITY;
     ///
     /// assert_eq!(num.classify(), FpCategory::Normal);
@@ -682,7 +468,7 @@ impl f32 {
     ///
     /// ```
     /// # #![feature(std_misc)]
-    /// use std::num::Float;
+    /// use std::f32;
     ///
     /// let num = 2.0f32;
     ///
@@ -695,7 +481,7 @@ impl f32 {
     /// // 1 * 8388608 * 2^(-22) == 2
     /// let abs_difference = (sign_f * mantissa_f * exponent_f - num).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     /// [floating-point]: ../../../../../reference.html#machine-types
     #[unstable(feature = "std_misc", reason = "signature is undecided")]
@@ -705,10 +491,8 @@ impl f32 {
     /// Returns the largest integer less than or equal to a number.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let f = 3.99;
-    /// let g = 3.0;
+    /// let f = 3.99_f32;
+    /// let g = 3.0_f32;
     ///
     /// assert_eq!(f.floor(), 3.0);
     /// assert_eq!(g.floor(), 3.0);
@@ -720,10 +504,8 @@ impl f32 {
     /// Returns the smallest integer greater than or equal to a number.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let f = 3.01;
-    /// let g = 4.0;
+    /// let f = 3.01_f32;
+    /// let g = 4.0_f32;
     ///
     /// assert_eq!(f.ceil(), 4.0);
     /// assert_eq!(g.ceil(), 4.0);
@@ -736,10 +518,8 @@ impl f32 {
     /// `0.0`.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let f = 3.3;
-    /// let g = -3.3;
+    /// let f = 3.3_f32;
+    /// let g = -3.3_f32;
     ///
     /// assert_eq!(f.round(), 3.0);
     /// assert_eq!(g.round(), -3.0);
@@ -751,10 +531,8 @@ impl f32 {
     /// Return the integer part of a number.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let f = 3.3;
-    /// let g = -3.7;
+    /// let f = 3.3_f32;
+    /// let g = -3.7_f32;
     ///
     /// assert_eq!(f.trunc(), 3.0);
     /// assert_eq!(g.trunc(), -3.0);
@@ -766,38 +544,36 @@ impl f32 {
     /// Returns the fractional part of a number.
     ///
     /// ```
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let x = 3.5;
-    /// let y = -3.5;
+    /// let x = 3.5_f32;
+    /// let y = -3.5_f32;
     /// let abs_difference_x = (x.fract() - 0.5).abs();
     /// let abs_difference_y = (y.fract() - (-0.5)).abs();
     ///
-    /// assert!(abs_difference_x < 1e-10);
-    /// assert!(abs_difference_y < 1e-10);
+    /// assert!(abs_difference_x <= f32::EPSILON);
+    /// assert!(abs_difference_y <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn fract(self) -> f32 { num::Float::fract(self) }
 
-    /// Computes the absolute value of `self`. Returns `Float::nan()` if the
-    /// number is `Float::nan()`.
+    /// Computes the absolute value of `self`. Returns `NAN` if the
+    /// number is `NAN`.
     ///
     /// ```
-    /// # #![feature(core, std_misc)]
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let x = 3.5;
-    /// let y = -3.5;
+    /// let x = 3.5_f32;
+    /// let y = -3.5_f32;
     ///
     /// let abs_difference_x = (x.abs() - x).abs();
     /// let abs_difference_y = (y.abs() - (-y)).abs();
     ///
-    /// assert!(abs_difference_x < 1e-10);
-    /// assert!(abs_difference_y < 1e-10);
+    /// assert!(abs_difference_x <= f32::EPSILON);
+    /// assert!(abs_difference_y <= f32::EPSILON);
     ///
-    /// assert!(f64::NAN.abs().is_nan());
+    /// assert!(f32::NAN.abs().is_nan());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -805,65 +581,69 @@ impl f32 {
 
     /// Returns a number that represents the sign of `self`.
     ///
-    /// - `1.0` if the number is positive, `+0.0` or `Float::infinity()`
-    /// - `-1.0` if the number is negative, `-0.0` or `Float::neg_infinity()`
-    /// - `Float::nan()` if the number is `Float::nan()`
+    /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
+    /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
+    /// - `NAN` if the number is `NAN`
     ///
     /// ```
-    /// # #![feature(core, std_misc)]
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let f = 3.5;
+    /// let f = 3.5_f32;
     ///
     /// assert_eq!(f.signum(), 1.0);
-    /// assert_eq!(f64::NEG_INFINITY.signum(), -1.0);
+    /// assert_eq!(f32::NEG_INFINITY.signum(), -1.0);
     ///
-    /// assert!(f64::NAN.signum().is_nan());
+    /// assert!(f32::NAN.signum().is_nan());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn signum(self) -> f32 { num::Float::signum(self) }
 
-    /// Returns `true` if `self` is positive, including `+0.0` and
-    /// `Float::infinity()`.
+    /// Returns `true` if `self`'s sign bit is positive, including
+    /// `+0.0` and `INFINITY`.
     ///
     /// ```
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let nan: f64 = f64::NAN;
+    /// let nan = f32::NAN;
+    /// let f = 7.0_f32;
+    /// let g = -7.0_f32;
     ///
-    /// let f = 7.0;
-    /// let g = -7.0;
-    ///
-    /// assert!(f.is_positive());
-    /// assert!(!g.is_positive());
+    /// assert!(f.is_sign_positive());
+    /// assert!(!g.is_sign_positive());
     /// // Requires both tests to determine if is `NaN`
-    /// assert!(!nan.is_positive() && !nan.is_negative());
+    /// assert!(!nan.is_sign_positive() && !nan.is_sign_negative());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
+    pub fn is_sign_positive(self) -> bool { num::Float::is_positive(self) }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[deprecated(since = "1.0.0", reason = "renamed to is_sign_positive")]
+    #[inline]
     pub fn is_positive(self) -> bool { num::Float::is_positive(self) }
 
-    /// Returns `true` if `self` is negative, including `-0.0` and
-    /// `Float::neg_infinity()`.
+    /// Returns `true` if `self`'s sign is negative, including `-0.0`
+    /// and `NEG_INFINITY`.
     ///
     /// ```
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let nan = f64::NAN;
+    /// let nan = f32::NAN;
+    /// let f = 7.0f32;
+    /// let g = -7.0f32;
     ///
-    /// let f = 7.0;
-    /// let g = -7.0;
-    ///
-    /// assert!(!f.is_negative());
-    /// assert!(g.is_negative());
+    /// assert!(!f.is_sign_negative());
+    /// assert!(g.is_sign_negative());
     /// // Requires both tests to determine if is `NaN`.
-    /// assert!(!nan.is_positive() && !nan.is_negative());
+    /// assert!(!nan.is_sign_positive() && !nan.is_sign_negative());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline]
+    pub fn is_sign_negative(self) -> bool { num::Float::is_negative(self) }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[deprecated(since = "1.0.0", reason = "renamed to is_sign_negative")]
     #[inline]
     pub fn is_negative(self) -> bool { num::Float::is_negative(self) }
 
@@ -872,36 +652,32 @@ impl f32 {
     /// a separate multiplication operation followed by an add.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let m = 10.0;
-    /// let x = 4.0;
-    /// let b = 60.0;
+    /// let m = 10.0_f32;
+    /// let x = 4.0_f32;
+    /// let b = 60.0_f32;
     ///
     /// // 100.0
     /// let abs_difference = (m.mul_add(x, b) - (m*x + b)).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn mul_add(self, a: f32, b: f32) -> f32 { num::Float::mul_add(self, a, b) }
 
     /// Take the reciprocal (inverse) of a number, `1/x`.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let x = 2.0;
+    /// let x = 2.0_f32;
     /// let abs_difference = (x.recip() - (1.0/x)).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn recip(self) -> f32 { num::Float::recip(self) }
 
@@ -910,12 +686,12 @@ impl f32 {
     /// Using this function is generally faster than using `powf`
     ///
     /// ```
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let x = 2.0;
+    /// let x = 2.0_f32;
     /// let abs_difference = (x.powi(2) - x*x).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -924,12 +700,12 @@ impl f32 {
     /// Raise a number to a floating point power.
     ///
     /// ```
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let x = 2.0;
+    /// let x = 2.0_f32;
     /// let abs_difference = (x.powf(2.0) - x*x).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -940,52 +716,51 @@ impl f32 {
     /// Returns NaN if `self` is a negative number.
     ///
     /// ```
-    /// # #![feature(core, std_misc)]
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let positive = 4.0;
-    /// let negative = -4.0;
+    /// let positive = 4.0_f32;
+    /// let negative = -4.0_f32;
     ///
     /// let abs_difference = (positive.sqrt() - 2.0).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// assert!(negative.sqrt().is_nan());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sqrt(self) -> f32 { num::Float::sqrt(self) }
 
-
     /// Take the reciprocal (inverse) square root of a number, `1/sqrt(x)`.
     ///
     /// ```
     /// # #![feature(std_misc)]
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let f = 4.0;
+    /// let f = 4.0f32;
     ///
     /// let abs_difference = (f.rsqrt() - 0.5).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[unstable(feature = "std_misc",
                reason = "unsure about its place in the world")]
+    #[deprecated(since = "1.0.0", reason = "use self.sqrt().recip() instead")]
     #[inline]
     pub fn rsqrt(self) -> f32 { num::Float::rsqrt(self) }
 
     /// Returns `e^(self)`, (the exponential function).
     ///
     /// ```
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let one = 1.0;
+    /// let one = 1.0f32;
     /// // e^1
     /// let e = one.exp();
     ///
     /// // ln(e) - 1 == 0
     /// let abs_difference = (e.ln() - 1.0).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -994,14 +769,14 @@ impl f32 {
     /// Returns `2^(self)`.
     ///
     /// ```
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let f = 2.0;
+    /// let f = 2.0f32;
     ///
     /// // 2^2 - 4 == 0
     /// let abs_difference = (f.exp2() - 4.0).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1010,16 +785,16 @@ impl f32 {
     /// Returns the natural logarithm of the number.
     ///
     /// ```
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let one = 1.0;
+    /// let one = 1.0f32;
     /// // e^1
     /// let e = one.exp();
     ///
     /// // ln(e) - 1 == 0
     /// let abs_difference = (e.ln() - 1.0).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1028,10 +803,10 @@ impl f32 {
     /// Returns the logarithm of the number with respect to an arbitrary base.
     ///
     /// ```
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let ten = 10.0;
-    /// let two = 2.0;
+    /// let ten = 10.0f32;
+    /// let two = 2.0f32;
     ///
     /// // log10(10) - 1 == 0
     /// let abs_difference_10 = (ten.log(10.0) - 1.0).abs();
@@ -1039,8 +814,8 @@ impl f32 {
     /// // log2(2) - 1 == 0
     /// let abs_difference_2 = (two.log(2.0) - 1.0).abs();
     ///
-    /// assert!(abs_difference_10 < 1e-10);
-    /// assert!(abs_difference_2 < 1e-10);
+    /// assert!(abs_difference_10 <= f32::EPSILON);
+    /// assert!(abs_difference_2 <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1049,14 +824,14 @@ impl f32 {
     /// Returns the base 2 logarithm of the number.
     ///
     /// ```
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let two = 2.0;
+    /// let two = 2.0f32;
     ///
     /// // log2(2) - 1 == 0
     /// let abs_difference = (two.log2() - 1.0).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1065,14 +840,14 @@ impl f32 {
     /// Returns the base 10 logarithm of the number.
     ///
     /// ```
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let ten = 10.0;
+    /// let ten = 10.0f32;
     ///
     /// // log10(10) - 1 == 0
     /// let abs_difference = (ten.log10() - 1.0).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1082,14 +857,13 @@ impl f32 {
     ///
     /// ```
     /// # #![feature(std_misc, core)]
-    /// use std::num::Float;
-    /// use std::f64::consts;
+    /// use std::f32::{self, consts};
     ///
     /// let angle = consts::PI;
     ///
     /// let abs_difference = (angle.to_degrees() - 180.0).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[unstable(feature = "std_misc", reason = "desirability is unclear")]
     #[inline]
@@ -1098,15 +872,14 @@ impl f32 {
     /// Convert degrees to radians.
     ///
     /// ```
-    /// # #![feature(std_misc, core)]
-    /// use std::num::Float;
-    /// use std::f64::consts;
+    /// # #![feature(std_misc)]
+    /// use std::f32::{self, consts};
     ///
-    /// let angle = 180.0;
+    /// let angle = 180.0f32;
     ///
     /// let abs_difference = (angle.to_radians() - consts::PI).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[unstable(feature = "std_misc", reason = "desirability is unclear")]
     #[inline]
@@ -1116,12 +889,11 @@ impl f32 {
     ///
     /// ```
     /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
+    /// use std::f32;
     /// // 3*2^2 - 12 == 0
-    /// let abs_difference = (Float::ldexp(3.0, 2) - 12.0).abs();
+    /// let abs_difference = (f32::ldexp(3.0, 2) - 12.0).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[unstable(feature = "std_misc",
                reason = "pending integer conventions")]
@@ -1138,17 +910,17 @@ impl f32 {
     ///
     /// ```
     /// # #![feature(std_misc)]
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let x = 4.0;
+    /// let x = 4.0f32;
     ///
     /// // (1/2)*2^3 -> 1 * 8/2 -> 4.0
     /// let f = x.frexp();
     /// let abs_difference_0 = (f.0 - 0.5).abs();
-    /// let abs_difference_1 = (f.1 as f64 - 3.0).abs();
+    /// let abs_difference_1 = (f.1 as f32 - 3.0).abs();
     ///
-    /// assert!(abs_difference_0 < 1e-10);
-    /// assert!(abs_difference_1 < 1e-10);
+    /// assert!(abs_difference_0 <= f32::EPSILON);
+    /// assert!(abs_difference_1 <= f32::EPSILON);
     /// ```
     #[unstable(feature = "std_misc",
                reason = "pending integer conventions")]
@@ -1166,13 +938,13 @@ impl f32 {
     ///
     /// ```
     /// # #![feature(std_misc)]
-    /// use std::num::Float;
+    /// use std::f32;
     ///
     /// let x = 1.0f32;
     ///
     /// let abs_diff = (x.next_after(2.0) - 1.00000011920928955078125_f32).abs();
     ///
-    /// assert!(abs_diff < 1e-10);
+    /// assert!(abs_diff <= f32::EPSILON);
     /// ```
     #[unstable(feature = "std_misc",
                reason = "unsure about its place in the world")]
@@ -1184,10 +956,8 @@ impl f32 {
     /// Returns the maximum of the two numbers.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let x = 1.0;
-    /// let y = 2.0;
+    /// let x = 1.0f32;
+    /// let y = 2.0f32;
     ///
     /// assert_eq!(x.max(y), y);
     /// ```
@@ -1200,10 +970,8 @@ impl f32 {
     /// Returns the minimum of the two numbers.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let x = 1.0;
-    /// let y = 2.0;
+    /// let x = 1.0f32;
+    /// let y = 2.0f32;
     ///
     /// assert_eq!(x.min(y), x);
     /// ```
@@ -1220,18 +988,18 @@ impl f32 {
     ///
     /// ```
     /// # #![feature(std_misc)]
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let x = 3.0;
-    /// let y = -3.0;
+    /// let x = 3.0f32;
+    /// let y = -3.0f32;
     ///
     /// let abs_difference_x = (x.abs_sub(1.0) - 2.0).abs();
     /// let abs_difference_y = (y.abs_sub(1.0) - 0.0).abs();
     ///
-    /// assert!(abs_difference_x < 1e-10);
-    /// assert!(abs_difference_y < 1e-10);
+    /// assert!(abs_difference_x <= f32::EPSILON);
+    /// assert!(abs_difference_y <= f32::EPSILON);
     /// ```
-    #[unstable(feature = "std_misc", reason = "may be renamed")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn abs_sub(self, other: f32) -> f32 {
         unsafe { cmath::fdimf(self, other) }
@@ -1241,16 +1009,16 @@ impl f32 {
     ///
     /// ```
     /// # #![feature(std_misc)]
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let x = 8.0;
+    /// let x = 8.0f32;
     ///
     /// // x^(1/3) - 2 == 0
     /// let abs_difference = (x.cbrt() - 2.0).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[unstable(feature = "std_misc", reason = "may be renamed")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cbrt(self) -> f32 {
         unsafe { cmath::cbrtf(self) }
@@ -1260,19 +1028,17 @@ impl f32 {
     /// legs of length `x` and `y`.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let x = 2.0;
-    /// let y = 3.0;
+    /// let x = 2.0f32;
+    /// let y = 3.0f32;
     ///
     /// // sqrt(x^2 + y^2)
     /// let abs_difference = (x.hypot(y) - (x.powi(2) + y.powi(2)).sqrt()).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn hypot(self, other: f32) -> f32 {
         unsafe { cmath::hypotf(self, other) }
@@ -1281,15 +1047,13 @@ impl f32 {
     /// Computes the sine of a number (in radians).
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let x = f64::consts::PI/2.0;
+    /// let x = f32::consts::PI/2.0;
     ///
     /// let abs_difference = (x.sin() - 1.0).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1300,15 +1064,13 @@ impl f32 {
     /// Computes the cosine of a number (in radians).
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let x = 2.0*f64::consts::PI;
+    /// let x = 2.0*f32::consts::PI;
     ///
     /// let abs_difference = (x.cos() - 1.0).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1319,14 +1081,12 @@ impl f32 {
     /// Computes the tangent of a number (in radians).
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/4.0;
     /// let abs_difference = (x.tan() - 1.0).abs();
     ///
-    /// assert!(abs_difference < 1e-14);
+    /// assert!(abs_difference < 1e-10);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1339,16 +1099,14 @@ impl f32 {
     /// [-1, 1].
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let f = f64::consts::PI / 2.0;
+    /// let f = f32::consts::PI / 2.0;
     ///
     /// // asin(sin(pi/2))
-    /// let abs_difference = (f.sin().asin() - f64::consts::PI / 2.0).abs();
+    /// let abs_difference = f.sin().asin().abs_sub(f32::consts::PI / 2.0);
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1361,16 +1119,14 @@ impl f32 {
     /// [-1, 1].
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let f = f64::consts::PI / 4.0;
+    /// let f = f32::consts::PI / 4.0;
     ///
     /// // acos(cos(pi/4))
-    /// let abs_difference = (f.cos().acos() - f64::consts::PI / 4.0).abs();
+    /// let abs_difference = f.cos().acos().abs_sub(f32::consts::PI / 4.0);
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1382,14 +1138,14 @@ impl f32 {
     /// range [-pi/2, pi/2];
     ///
     /// ```
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let f = 1.0;
+    /// let f = 1.0f32;
     ///
     /// // atan(tan(1))
-    /// let abs_difference = (f.tan().atan() - 1.0).abs();
+    /// let abs_difference = f.tan().atan().abs_sub(1.0);
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1405,25 +1161,23 @@ impl f32 {
     /// * `y < 0`: `arctan(y/x) - pi` -> `(-pi, -pi/2)`
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let pi = f64::consts::PI;
+    /// let pi = f32::consts::PI;
     /// // All angles from horizontal right (+x)
     /// // 45 deg counter-clockwise
-    /// let x1 = 3.0;
-    /// let y1 = -3.0;
+    /// let x1 = 3.0f32;
+    /// let y1 = -3.0f32;
     ///
     /// // 135 deg clockwise
-    /// let x2 = -3.0;
-    /// let y2 = 3.0;
+    /// let x2 = -3.0f32;
+    /// let y2 = 3.0f32;
     ///
     /// let abs_difference_1 = (y1.atan2(x1) - (-pi/4.0)).abs();
     /// let abs_difference_2 = (y2.atan2(x2) - 3.0*pi/4.0).abs();
     ///
-    /// assert!(abs_difference_1 < 1e-10);
-    /// assert!(abs_difference_2 < 1e-10);
+    /// assert!(abs_difference_1 <= f32::EPSILON);
+    /// assert!(abs_difference_2 <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1435,18 +1189,16 @@ impl f32 {
     /// `(sin(x), cos(x))`.
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let x = f64::consts::PI/4.0;
+    /// let x = f32::consts::PI/4.0;
     /// let f = x.sin_cos();
     ///
     /// let abs_difference_0 = (f.0 - x.sin()).abs();
     /// let abs_difference_1 = (f.1 - x.cos()).abs();
     ///
-    /// assert!(abs_difference_0 < 1e-10);
-    /// assert!(abs_difference_0 < 1e-10);
+    /// assert!(abs_difference_0 <= f32::EPSILON);
+    /// assert!(abs_difference_0 <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1458,17 +1210,16 @@ impl f32 {
     /// number is close to zero.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
+    /// use std::f64;
     ///
-    /// let x = 7.0;
+    /// let x = 7.0f64;
     ///
     /// // e^(ln(7)) - 1
-    /// let abs_difference = (x.ln().exp_m1() - 6.0).abs();
+    /// let abs_difference = x.ln().exp_m1().abs_sub(6.0);
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[unstable(feature = "std_misc", reason = "may be renamed")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp_m1(self) -> f32 {
         unsafe { cmath::expm1f(self) }
@@ -1478,18 +1229,16 @@ impl f32 {
     /// the operations were performed separately.
     ///
     /// ```
-    /// # #![feature(std_misc, core)]
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let x = f64::consts::E - 1.0;
+    /// let x = f32::consts::E - 1.0;
     ///
     /// // ln(1 + (e - 1)) == ln(e) == 1
     /// let abs_difference = (x.ln_1p() - 1.0).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[unstable(feature = "std_misc", reason = "may be renamed")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ln_1p(self) -> f32 {
         unsafe { cmath::log1pf(self) }
@@ -1498,19 +1247,17 @@ impl f32 {
     /// Hyperbolic sine function.
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let e = f64::consts::E;
-    /// let x = 1.0;
+    /// let e = f32::consts::E;
+    /// let x = 1.0f32;
     ///
     /// let f = x.sinh();
     /// // Solving sinh() at 1 gives `(e^2-1)/(2e)`
     /// let g = (e*e - 1.0)/(2.0*e);
     /// let abs_difference = (f - g).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1521,19 +1268,17 @@ impl f32 {
     /// Hyperbolic cosine function.
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let e = f64::consts::E;
-    /// let x = 1.0;
+    /// let e = f32::consts::E;
+    /// let x = 1.0f32;
     /// let f = x.cosh();
     /// // Solving cosh() at 1 gives this result
     /// let g = (e*e + 1.0)/(2.0*e);
-    /// let abs_difference = (f - g).abs();
+    /// let abs_difference = f.abs_sub(g);
     ///
     /// // Same result
-    /// assert!(abs_difference < 1.0e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1544,19 +1289,17 @@ impl f32 {
     /// Hyperbolic tangent function.
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let e = f64::consts::E;
-    /// let x = 1.0;
+    /// let e = f32::consts::E;
+    /// let x = 1.0f32;
     ///
     /// let f = x.tanh();
     /// // Solving tanh() at 1 gives `(1 - e^(-2))/(1 + e^(-2))`
     /// let g = (1.0 - e.powi(-2))/(1.0 + e.powi(-2));
     /// let abs_difference = (f - g).abs();
     ///
-    /// assert!(abs_difference < 1.0e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1567,15 +1310,14 @@ impl f32 {
     /// Inverse hyperbolic sine function.
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let x = 1.0;
+    /// let x = 1.0f32;
     /// let f = x.sinh().asinh();
     ///
     /// let abs_difference = (f - x).abs();
     ///
-    /// assert!(abs_difference < 1.0e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1589,15 +1331,14 @@ impl f32 {
     /// Inverse hyperbolic cosine function.
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
+    /// use std::f32;
     ///
-    /// let x = 1.0;
+    /// let x = 1.0f32;
     /// let f = x.cosh().acosh();
     ///
     /// let abs_difference = (f - x).abs();
     ///
-    /// assert!(abs_difference < 1.0e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1611,16 +1352,14 @@ impl f32 {
     /// Inverse hyperbolic tangent function.
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
-    /// use std::f64;
+    /// use std::f32;
     ///
-    /// let e = f64::consts::E;
+    /// let e = f32::consts::E;
     /// let f = e.tanh().atanh();
     ///
-    /// let abs_difference = (f - e).abs();
+    /// let abs_difference = f.abs_sub(e);
     ///
-    /// assert!(abs_difference < 1.0e-10);
+    /// assert!(abs_difference <= f32::EPSILON);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -1640,6 +1379,7 @@ impl f32 {
 /// * num - The float value
 #[inline]
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
+#[deprecated(since = "1.0.0", reason = "use the ToString trait instead")]
 pub fn to_string(num: f32) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 10, true, SignNeg, DigAll, ExpNone, false);
@@ -1653,6 +1393,7 @@ pub fn to_string(num: f32) -> String {
 /// * num - The float value
 #[inline]
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
+#[deprecated(since = "1.0.0", reason = "use format! instead")]
 pub fn to_str_hex(num: f32) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 16, true, SignNeg, DigAll, ExpNone, false);
@@ -1668,6 +1409,7 @@ pub fn to_str_hex(num: f32) -> String {
 /// * radix - The base to use
 #[inline]
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
+#[deprecated(since = "1.0.0", reason = "use format! instead")]
 pub fn to_str_radix_special(num: f32, rdx: u32) -> (String, bool) {
     strconv::float_to_str_common(num, rdx, true, SignNeg, DigAll, ExpNone, false)
 }
@@ -1764,8 +1506,8 @@ mod tests {
         assert!(!nan.is_infinite());
         assert!(!nan.is_finite());
         assert!(!nan.is_normal());
-        assert!(!nan.is_positive());
-        assert!(!nan.is_negative());
+        assert!(!nan.is_sign_positive());
+        assert!(!nan.is_sign_negative());
         assert_eq!(Fp::Nan, nan.classify());
     }
 
@@ -1774,8 +1516,8 @@ mod tests {
         let inf: f32 = Float::infinity();
         assert!(inf.is_infinite());
         assert!(!inf.is_finite());
-        assert!(inf.is_positive());
-        assert!(!inf.is_negative());
+        assert!(inf.is_sign_positive());
+        assert!(!inf.is_sign_negative());
         assert!(!inf.is_nan());
         assert!(!inf.is_normal());
         assert_eq!(Fp::Infinite, inf.classify());
@@ -1786,8 +1528,8 @@ mod tests {
         let neg_inf: f32 = Float::neg_infinity();
         assert!(neg_inf.is_infinite());
         assert!(!neg_inf.is_finite());
-        assert!(!neg_inf.is_positive());
-        assert!(neg_inf.is_negative());
+        assert!(!neg_inf.is_sign_positive());
+        assert!(neg_inf.is_sign_negative());
         assert!(!neg_inf.is_nan());
         assert!(!neg_inf.is_normal());
         assert_eq!(Fp::Infinite, neg_inf.classify());
@@ -1799,8 +1541,8 @@ mod tests {
         assert_eq!(0.0, zero);
         assert!(!zero.is_infinite());
         assert!(zero.is_finite());
-        assert!(zero.is_positive());
-        assert!(!zero.is_negative());
+        assert!(zero.is_sign_positive());
+        assert!(!zero.is_sign_negative());
         assert!(!zero.is_nan());
         assert!(!zero.is_normal());
         assert_eq!(Fp::Zero, zero.classify());
@@ -1812,8 +1554,8 @@ mod tests {
         assert_eq!(0.0, neg_zero);
         assert!(!neg_zero.is_infinite());
         assert!(neg_zero.is_finite());
-        assert!(!neg_zero.is_positive());
-        assert!(neg_zero.is_negative());
+        assert!(!neg_zero.is_sign_positive());
+        assert!(neg_zero.is_sign_negative());
         assert!(!neg_zero.is_nan());
         assert!(!neg_zero.is_normal());
         assert_eq!(Fp::Zero, neg_zero.classify());
@@ -1825,8 +1567,8 @@ mod tests {
         assert_eq!(1.0, one);
         assert!(!one.is_infinite());
         assert!(one.is_finite());
-        assert!(one.is_positive());
-        assert!(!one.is_negative());
+        assert!(one.is_sign_positive());
+        assert!(!one.is_sign_negative());
         assert!(!one.is_nan());
         assert!(one.is_normal());
         assert_eq!(Fp::Normal, one.classify());
@@ -2012,27 +1754,27 @@ mod tests {
     }
 
     #[test]
-    fn test_is_positive() {
-        assert!(INFINITY.is_positive());
-        assert!(1f32.is_positive());
-        assert!(0f32.is_positive());
-        assert!(!(-0f32).is_positive());
-        assert!(!(-1f32).is_positive());
-        assert!(!NEG_INFINITY.is_positive());
-        assert!(!(1f32/NEG_INFINITY).is_positive());
-        assert!(!NAN.is_positive());
+    fn test_is_sign_positive() {
+        assert!(INFINITY.is_sign_positive());
+        assert!(1f32.is_sign_positive());
+        assert!(0f32.is_sign_positive());
+        assert!(!(-0f32).is_sign_positive());
+        assert!(!(-1f32).is_sign_positive());
+        assert!(!NEG_INFINITY.is_sign_positive());
+        assert!(!(1f32/NEG_INFINITY).is_sign_positive());
+        assert!(!NAN.is_sign_positive());
     }
 
     #[test]
-    fn test_is_negative() {
-        assert!(!INFINITY.is_negative());
-        assert!(!1f32.is_negative());
-        assert!(!0f32.is_negative());
-        assert!((-0f32).is_negative());
-        assert!((-1f32).is_negative());
-        assert!(NEG_INFINITY.is_negative());
-        assert!((1f32/NEG_INFINITY).is_negative());
-        assert!(!NAN.is_negative());
+    fn test_is_sign_negative() {
+        assert!(!INFINITY.is_sign_negative());
+        assert!(!1f32.is_sign_negative());
+        assert!(!0f32.is_sign_negative());
+        assert!((-0f32).is_sign_negative());
+        assert!((-1f32).is_sign_negative());
+        assert!(NEG_INFINITY.is_sign_negative());
+        assert!((1f32/NEG_INFINITY).is_sign_negative());
+        assert!(!NAN.is_sign_negative());
     }
 
     #[test]

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -83,6 +83,7 @@ mod cmath {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated)]
 impl Float for f64 {
     // inlined methods from `num::Float`
     #[inline]
@@ -370,227 +371,18 @@ impl Float for f64 {
 #[lang = "f64"]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl f64 {
-    // inlined methods from `num::Float`
-    /// Returns the `NaN` value.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let nan: f32 = Float::nan();
-    ///
-    /// assert!(nan.is_nan());
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    pub fn nan() -> f64 { num::Float::nan() }
-
-    /// Returns the infinite value.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    /// use std::f32;
-    ///
-    /// let infinity: f32 = Float::infinity();
-    ///
-    /// assert!(infinity.is_infinite());
-    /// assert!(!infinity.is_finite());
-    /// assert!(infinity > f32::MAX);
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    pub fn infinity() -> f64 { num::Float::infinity() }
-
-    /// Returns the negative infinite value.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    /// use std::f32;
-    ///
-    /// let neg_infinity: f32 = Float::neg_infinity();
-    ///
-    /// assert!(neg_infinity.is_infinite());
-    /// assert!(!neg_infinity.is_finite());
-    /// assert!(neg_infinity < f32::MIN);
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    pub fn neg_infinity() -> f64 { num::Float::neg_infinity() }
-
-    /// Returns `0.0`.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let inf: f32 = Float::infinity();
-    /// let zero: f32 = Float::zero();
-    /// let neg_zero: f32 = Float::neg_zero();
-    ///
-    /// assert_eq!(zero, neg_zero);
-    /// assert_eq!(7.0f32/inf, zero);
-    /// assert_eq!(zero * 10.0, zero);
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    pub fn zero() -> f64 { num::Float::zero() }
-
-    /// Returns `-0.0`.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let inf: f32 = Float::infinity();
-    /// let zero: f32 = Float::zero();
-    /// let neg_zero: f32 = Float::neg_zero();
-    ///
-    /// assert_eq!(zero, neg_zero);
-    /// assert_eq!(7.0f32/inf, zero);
-    /// assert_eq!(zero * 10.0, zero);
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    pub fn neg_zero() -> f64 { num::Float::neg_zero() }
-
-    /// Returns `1.0`.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let one: f32 = Float::one();
-    ///
-    /// assert_eq!(one, 1.0f32);
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    pub fn one() -> f64 { num::Float::one() }
-
-    // FIXME (#5527): These should be associated constants
-
-    /// Deprecated: use `std::f32::MANTISSA_DIGITS` or `std::f64::MANTISSA_DIGITS`
-    /// instead.
-    #[unstable(feature = "std_misc")]
-    #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::MANTISSA_DIGITS` or \
-                           `std::f64::MANTISSA_DIGITS` as appropriate")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn mantissa_digits(unused_self: Option<f64>) -> usize {
-        num::Float::mantissa_digits(unused_self)
-    }
-
-    /// Deprecated: use `std::f32::DIGITS` or `std::f64::DIGITS` instead.
-    #[unstable(feature = "std_misc")]
-    #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::DIGITS` or `std::f64::DIGITS` as appropriate")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn digits(unused_self: Option<f64>) -> usize { num::Float::digits(unused_self) }
-
-    /// Deprecated: use `std::f32::EPSILON` or `std::f64::EPSILON` instead.
-    #[unstable(feature = "std_misc")]
-    #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::EPSILON` or `std::f64::EPSILON` as appropriate")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn epsilon() -> f64 { num::Float::epsilon() }
-
-    /// Deprecated: use `std::f32::MIN_EXP` or `std::f64::MIN_EXP` instead.
-    #[unstable(feature = "std_misc")]
-    #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::MIN_EXP` or `std::f64::MIN_EXP` as appropriate")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn min_exp(unused_self: Option<f64>) -> isize { num::Float::min_exp(unused_self) }
-
-    /// Deprecated: use `std::f32::MAX_EXP` or `std::f64::MAX_EXP` instead.
-    #[unstable(feature = "std_misc")]
-    #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::MAX_EXP` or `std::f64::MAX_EXP` as appropriate")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn max_exp(unused_self: Option<f64>) -> isize { num::Float::max_exp(unused_self) }
-
-    /// Deprecated: use `std::f32::MIN_10_EXP` or `std::f64::MIN_10_EXP` instead.
-    #[unstable(feature = "std_misc")]
-    #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::MIN_10_EXP` or `std::f64::MIN_10_EXP` as appropriate")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn min_10_exp(unused_self: Option<f64>) -> isize { num::Float::min_10_exp(unused_self) }
-
-    /// Deprecated: use `std::f32::MAX_10_EXP` or `std::f64::MAX_10_EXP` instead.
-    #[unstable(feature = "std_misc")]
-    #[deprecated(since = "1.0.0",
-                 reason = "use `std::f32::MAX_10_EXP` or `std::f64::MAX_10_EXP` as appropriate")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn max_10_exp(unused_self: Option<f64>) -> isize { num::Float::max_10_exp(unused_self) }
-
-    /// Returns the smallest finite value that this type can represent.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    /// use std::f64;
-    ///
-    /// let x: f64 = Float::min_value();
-    ///
-    /// assert_eq!(x, f64::MIN);
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    #[allow(deprecated)]
-    pub fn min_value() -> f64 { num::Float::min_value() }
-
-    /// Returns the smallest normalized positive number that this type can represent.
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    #[allow(deprecated)]
-    pub fn min_pos_value(unused_self: Option<f64>) -> f64 { num::Float::min_pos_value(unused_self) }
-
-    /// Returns the largest finite value that this type can represent.
-    ///
-    /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    /// use std::f64;
-    ///
-    /// let x: f64 = Float::max_value();
-    /// assert_eq!(x, f64::MAX);
-    /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
-    #[inline]
-    #[allow(deprecated)]
-    pub fn max_value() -> f64 { num::Float::max_value() }
-
     /// Returns `true` if this value is `NaN` and false otherwise.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let nan = f64::NAN;
-    /// let f = 7.0;
+    /// let f = 7.0_f64;
     ///
     /// assert!(nan.is_nan());
     /// assert!(!f.is_nan());
     /// ```
-    #[unstable(feature = "std_misc", reason = "position is undecided")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_nan(self) -> bool { num::Float::is_nan(self) }
 
@@ -598,14 +390,12 @@ impl f64 {
     /// false otherwise.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    /// use std::f32;
+    /// use std::f64;
     ///
-    /// let f = 7.0f32;
-    /// let inf: f32 = Float::infinity();
-    /// let neg_inf: f32 = Float::neg_infinity();
-    /// let nan: f32 = f32::NAN;
+    /// let f = 7.0f64;
+    /// let inf = f64::INFINITY;
+    /// let neg_inf = f64::NEG_INFINITY;
+    /// let nan = f64::NAN;
     ///
     /// assert!(!f.is_infinite());
     /// assert!(!nan.is_infinite());
@@ -613,21 +403,19 @@ impl f64 {
     /// assert!(inf.is_infinite());
     /// assert!(neg_inf.is_infinite());
     /// ```
-    #[unstable(feature = "std_misc", reason = "position is undecided")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_infinite(self) -> bool { num::Float::is_infinite(self) }
 
     /// Returns `true` if this number is neither infinite nor `NaN`.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    /// use std::f32;
+    /// use std::f64;
     ///
-    /// let f = 7.0f32;
-    /// let inf: f32 = Float::infinity();
-    /// let neg_inf: f32 = Float::neg_infinity();
-    /// let nan: f32 = f32::NAN;
+    /// let f = 7.0f64;
+    /// let inf: f64 = f64::INFINITY;
+    /// let neg_inf: f64 = f64::NEG_INFINITY;
+    /// let nan: f64 = f64::NAN;
     ///
     /// assert!(f.is_finite());
     ///
@@ -635,7 +423,7 @@ impl f64 {
     /// assert!(!inf.is_finite());
     /// assert!(!neg_inf.is_finite());
     /// ```
-    #[unstable(feature = "std_misc", reason = "position is undecided")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_finite(self) -> bool { num::Float::is_finite(self) }
 
@@ -643,11 +431,9 @@ impl f64 {
     /// [subnormal][subnormal], or `NaN`.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
     /// use std::f32;
     ///
-    /// let min = f32::MIN_POSITIVE; // 1.17549435e-38f32
+    /// let min = f32::MIN_POSITIVE; // 1.17549435e-38f64
     /// let max = f32::MAX;
     /// let lower_than_min = 1.0e-40_f32;
     /// let zero = 0.0f32;
@@ -662,7 +448,7 @@ impl f64 {
     /// assert!(!lower_than_min.is_normal());
     /// ```
     /// [subnormal]: http://en.wikipedia.org/wiki/Denormal_number
-    #[unstable(feature = "std_misc", reason = "position is undecided")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_normal(self) -> bool { num::Float::is_normal(self) }
 
@@ -671,12 +457,11 @@ impl f64 {
     /// predicate instead.
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::{Float, FpCategory};
-    /// use std::f32;
+    /// use std::num::FpCategory;
+    /// use std::f64;
     ///
-    /// let num = 12.4f32;
-    /// let inf = f32::INFINITY;
+    /// let num = 12.4_f64;
+    /// let inf = f64::INFINITY;
     ///
     /// assert_eq!(num.classify(), FpCategory::Normal);
     /// assert_eq!(inf.classify(), FpCategory::Infinite);
@@ -691,15 +476,13 @@ impl f64 {
     ///
     /// ```
     /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let num = 2.0f32;
+    /// let num = 2.0f64;
     ///
     /// // (8388608, -22, 1)
     /// let (mantissa, exponent, sign) = num.integer_decode();
-    /// let sign_f = sign as f32;
-    /// let mantissa_f = mantissa as f32;
-    /// let exponent_f = num.powf(exponent as f32);
+    /// let sign_f = sign as f64;
+    /// let mantissa_f = mantissa as f64;
+    /// let exponent_f = num.powf(exponent as f64);
     ///
     /// // 1 * 8388608 * 2^(-22) == 2
     /// let abs_difference = (sign_f * mantissa_f * exponent_f - num).abs();
@@ -714,10 +497,8 @@ impl f64 {
     /// Returns the largest integer less than or equal to a number.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let f = 3.99;
-    /// let g = 3.0;
+    /// let f = 3.99_f64;
+    /// let g = 3.0_f64;
     ///
     /// assert_eq!(f.floor(), 3.0);
     /// assert_eq!(g.floor(), 3.0);
@@ -729,10 +510,8 @@ impl f64 {
     /// Returns the smallest integer greater than or equal to a number.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let f = 3.01;
-    /// let g = 4.0;
+    /// let f = 3.01_f64;
+    /// let g = 4.0_f64;
     ///
     /// assert_eq!(f.ceil(), 4.0);
     /// assert_eq!(g.ceil(), 4.0);
@@ -745,10 +524,8 @@ impl f64 {
     /// `0.0`.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let f = 3.3;
-    /// let g = -3.3;
+    /// let f = 3.3_f64;
+    /// let g = -3.3_f64;
     ///
     /// assert_eq!(f.round(), 3.0);
     /// assert_eq!(g.round(), -3.0);
@@ -760,10 +537,8 @@ impl f64 {
     /// Return the integer part of a number.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let f = 3.3;
-    /// let g = -3.7;
+    /// let f = 3.3_f64;
+    /// let g = -3.7_f64;
     ///
     /// assert_eq!(f.trunc(), 3.0);
     /// assert_eq!(g.trunc(), -3.0);
@@ -775,10 +550,8 @@ impl f64 {
     /// Returns the fractional part of a number.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let x = 3.5;
-    /// let y = -3.5;
+    /// let x = 3.5_f64;
+    /// let y = -3.5_f64;
     /// let abs_difference_x = (x.fract() - 0.5).abs();
     /// let abs_difference_y = (y.fract() - (-0.5)).abs();
     ///
@@ -789,16 +562,14 @@ impl f64 {
     #[inline]
     pub fn fract(self) -> f64 { num::Float::fract(self) }
 
-    /// Computes the absolute value of `self`. Returns `Float::nan()` if the
-    /// number is `Float::nan()`.
+    /// Computes the absolute value of `self`. Returns `NAN` if the
+    /// number is `NAN`.
     ///
     /// ```
-    /// # #![feature(core, std_misc)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
-    /// let x = 3.5;
-    /// let y = -3.5;
+    /// let x = 3.5_f64;
+    /// let y = -3.5_f64;
     ///
     /// let abs_difference_x = (x.abs() - x).abs();
     /// let abs_difference_y = (y.abs() - (-y)).abs();
@@ -814,16 +585,14 @@ impl f64 {
 
     /// Returns a number that represents the sign of `self`.
     ///
-    /// - `1.0` if the number is positive, `+0.0` or `Float::infinity()`
-    /// - `-1.0` if the number is negative, `-0.0` or `Float::neg_infinity()`
-    /// - `Float::nan()` if the number is `Float::nan()`
+    /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
+    /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
+    /// - `NAN` if the number is `NAN`
     ///
     /// ```
-    /// # #![feature(core, std_misc)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
-    /// let f = 3.5;
+    /// let f = 3.5_f64;
     ///
     /// assert_eq!(f.signum(), 1.0);
     /// assert_eq!(f64::NEG_INFINITY.signum(), -1.0);
@@ -834,45 +603,53 @@ impl f64 {
     #[inline]
     pub fn signum(self) -> f64 { num::Float::signum(self) }
 
-    /// Returns `true` if `self` is positive, including `+0.0` and
-    /// `Float::infinity()`.
+    /// Returns `true` if `self`'s sign bit is positive, including
+    /// `+0.0` and `INFINITY`.
     ///
     /// ```
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let nan: f64 = f64::NAN;
     ///
-    /// let f = 7.0;
-    /// let g = -7.0;
+    /// let f = 7.0_f64;
+    /// let g = -7.0_f64;
     ///
-    /// assert!(f.is_positive());
-    /// assert!(!g.is_positive());
+    /// assert!(f.is_sign_positive());
+    /// assert!(!g.is_sign_positive());
     /// // Requires both tests to determine if is `NaN`
-    /// assert!(!nan.is_positive() && !nan.is_negative());
+    /// assert!(!nan.is_sign_positive() && !nan.is_sign_negative());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
+    pub fn is_sign_positive(self) -> bool { num::Float::is_positive(self) }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[deprecated(since = "1.0.0", reason = "renamed to is_sign_positive")]
+    #[inline]
     pub fn is_positive(self) -> bool { num::Float::is_positive(self) }
 
-    /// Returns `true` if `self` is negative, including `-0.0` and
-    /// `Float::neg_infinity()`.
+    /// Returns `true` if `self`'s sign is negative, including `-0.0`
+    /// and `NEG_INFINITY`.
     ///
     /// ```
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let nan = f64::NAN;
     ///
-    /// let f = 7.0;
-    /// let g = -7.0;
+    /// let f = 7.0_f64;
+    /// let g = -7.0_f64;
     ///
-    /// assert!(!f.is_negative());
-    /// assert!(g.is_negative());
+    /// assert!(!f.is_sign_negative());
+    /// assert!(g.is_sign_negative());
     /// // Requires both tests to determine if is `NaN`.
-    /// assert!(!nan.is_positive() && !nan.is_negative());
+    /// assert!(!nan.is_sign_positive() && !nan.is_sign_negative());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline]
+    pub fn is_sign_negative(self) -> bool { num::Float::is_negative(self) }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[deprecated(since = "1.0.0", reason = "renamed to is_sign_negative")]
     #[inline]
     pub fn is_negative(self) -> bool { num::Float::is_negative(self) }
 
@@ -881,36 +658,28 @@ impl f64 {
     /// a separate multiplication operation followed by an add.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let m = 10.0;
-    /// let x = 4.0;
-    /// let b = 60.0;
+    /// let m = 10.0_f64;
+    /// let x = 4.0_f64;
+    /// let b = 60.0_f64;
     ///
     /// // 100.0
     /// let abs_difference = (m.mul_add(x, b) - (m*x + b)).abs();
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn mul_add(self, a: f64, b: f64) -> f64 { num::Float::mul_add(self, a, b) }
 
     /// Take the reciprocal (inverse) of a number, `1/x`.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let x = 2.0;
+    /// let x = 2.0_f64;
     /// let abs_difference = (x.recip() - (1.0/x)).abs();
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn recip(self) -> f64 { num::Float::recip(self) }
 
@@ -919,9 +688,7 @@ impl f64 {
     /// Using this function is generally faster than using `powf`
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let x = 2.0;
+    /// let x = 2.0_f64;
     /// let abs_difference = (x.powi(2) - x*x).abs();
     ///
     /// assert!(abs_difference < 1e-10);
@@ -933,9 +700,7 @@ impl f64 {
     /// Raise a number to a floating point power.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let x = 2.0;
+    /// let x = 2.0_f64;
     /// let abs_difference = (x.powf(2.0) - x*x).abs();
     ///
     /// assert!(abs_difference < 1e-10);
@@ -949,11 +714,8 @@ impl f64 {
     /// Returns NaN if `self` is a negative number.
     ///
     /// ```
-    /// # #![feature(core, std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let positive = 4.0;
-    /// let negative = -4.0;
+    /// let positive = 4.0_f64;
+    /// let negative = -4.0_f64;
     ///
     /// let abs_difference = (positive.sqrt() - 2.0).abs();
     ///
@@ -968,9 +730,7 @@ impl f64 {
     ///
     /// ```
     /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let f = 4.0;
+    /// let f = 4.0_f64;
     ///
     /// let abs_difference = (f.rsqrt() - 0.5).abs();
     ///
@@ -978,15 +738,14 @@ impl f64 {
     /// ```
     #[unstable(feature = "std_misc",
                reason = "unsure about its place in the world")]
+    #[deprecated(since = "1.0.0", reason = "use self.sqrt().recip() instead")]
     #[inline]
     pub fn rsqrt(self) -> f64 { num::Float::rsqrt(self) }
 
     /// Returns `e^(self)`, (the exponential function).
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let one = 1.0;
+    /// let one = 1.0_f64;
     /// // e^1
     /// let e = one.exp();
     ///
@@ -1002,9 +761,7 @@ impl f64 {
     /// Returns `2^(self)`.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let f = 2.0;
+    /// let f = 2.0_f64;
     ///
     /// // 2^2 - 4 == 0
     /// let abs_difference = (f.exp2() - 4.0).abs();
@@ -1018,9 +775,7 @@ impl f64 {
     /// Returns the natural logarithm of the number.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let one = 1.0;
+    /// let one = 1.0_f64;
     /// // e^1
     /// let e = one.exp();
     ///
@@ -1036,10 +791,8 @@ impl f64 {
     /// Returns the logarithm of the number with respect to an arbitrary base.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let ten = 10.0;
-    /// let two = 2.0;
+    /// let ten = 10.0_f64;
+    /// let two = 2.0_f64;
     ///
     /// // log10(10) - 1 == 0
     /// let abs_difference_10 = (ten.log(10.0) - 1.0).abs();
@@ -1057,9 +810,7 @@ impl f64 {
     /// Returns the base 2 logarithm of the number.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let two = 2.0;
+    /// let two = 2.0_f64;
     ///
     /// // log2(2) - 1 == 0
     /// let abs_difference = (two.log2() - 1.0).abs();
@@ -1073,9 +824,7 @@ impl f64 {
     /// Returns the base 10 logarithm of the number.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let ten = 10.0;
+    /// let ten = 10.0_f64;
     ///
     /// // log10(10) - 1 == 0
     /// let abs_difference = (ten.log10() - 1.0).abs();
@@ -1089,8 +838,6 @@ impl f64 {
     /// Convert radians to degrees.
     ///
     /// ```
-    /// # #![feature(std_misc, core)]
-    /// use std::num::Float;
     /// use std::f64::consts;
     ///
     /// let angle = consts::PI;
@@ -1099,24 +846,22 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[unstable(feature = "std_misc", reason = "desirability is unclear")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn to_degrees(self) -> f64 { num::Float::to_degrees(self) }
 
     /// Convert degrees to radians.
     ///
     /// ```
-    /// # #![feature(std_misc, core)]
-    /// use std::num::Float;
     /// use std::f64::consts;
     ///
-    /// let angle = 180.0;
+    /// let angle = 180.0_f64;
     ///
     /// let abs_difference = (angle.to_radians() - consts::PI).abs();
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[unstable(feature = "std_misc", reason = "desirability is unclear")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn to_radians(self) -> f64 { num::Float::to_radians(self) }
 
@@ -1124,10 +869,8 @@ impl f64 {
     ///
     /// ```
     /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
     /// // 3*2^2 - 12 == 0
-    /// let abs_difference = (Float::ldexp(3.0, 2) - 12.0).abs();
+    /// let abs_difference = (f64::ldexp(3.0, 2) - 12.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
@@ -1146,9 +889,7 @@ impl f64 {
     ///
     /// ```
     /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let x = 4.0;
+    /// let x = 4.0_f64;
     ///
     /// // (1/2)*2^3 -> 1 * 8/2 -> 4.0
     /// let f = x.frexp();
@@ -1174,7 +915,6 @@ impl f64 {
     ///
     /// ```
     /// # #![feature(std_misc)]
-    /// use std::num::Float;
     ///
     /// let x = 1.0f32;
     ///
@@ -1192,10 +932,8 @@ impl f64 {
     /// Returns the maximum of the two numbers.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let x = 1.0;
-    /// let y = 2.0;
+    /// let x = 1.0_f64;
+    /// let y = 2.0_f64;
     ///
     /// assert_eq!(x.max(y), y);
     /// ```
@@ -1208,10 +946,8 @@ impl f64 {
     /// Returns the minimum of the two numbers.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let x = 1.0;
-    /// let y = 2.0;
+    /// let x = 1.0_f64;
+    /// let y = 2.0_f64;
     ///
     /// assert_eq!(x.min(y), x);
     /// ```
@@ -1227,11 +963,8 @@ impl f64 {
     /// * Else: `self - other`
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let x = 3.0;
-    /// let y = -3.0;
+    /// let x = 3.0_f64;
+    /// let y = -3.0_f64;
     ///
     /// let abs_difference_x = (x.abs_sub(1.0) - 2.0).abs();
     /// let abs_difference_y = (y.abs_sub(1.0) - 0.0).abs();
@@ -1239,7 +972,7 @@ impl f64 {
     /// assert!(abs_difference_x < 1e-10);
     /// assert!(abs_difference_y < 1e-10);
     /// ```
-    #[unstable(feature = "std_misc", reason = "may be renamed")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn abs_sub(self, other: f64) -> f64 {
         unsafe { cmath::fdim(self, other) }
@@ -1248,17 +981,14 @@ impl f64 {
     /// Take the cubic root of a number.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let x = 8.0;
+    /// let x = 8.0_f64;
     ///
     /// // x^(1/3) - 2 == 0
     /// let abs_difference = (x.cbrt() - 2.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[unstable(feature = "std_misc", reason = "may be renamed")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cbrt(self) -> f64 {
         unsafe { cmath::cbrt(self) }
@@ -1268,19 +998,15 @@ impl f64 {
     /// legs of length `x` and `y`.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let x = 2.0;
-    /// let y = 3.0;
+    /// let x = 2.0_f64;
+    /// let y = 3.0_f64;
     ///
     /// // sqrt(x^2 + y^2)
     /// let abs_difference = (x.hypot(y) - (x.powi(2) + y.powi(2)).sqrt()).abs();
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[unstable(feature = "std_misc",
-               reason = "unsure about its place in the world")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn hypot(self, other: f64) -> f64 {
         unsafe { cmath::hypot(self, other) }
@@ -1289,8 +1015,6 @@ impl f64 {
     /// Computes the sine of a number (in radians).
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/2.0;
@@ -1308,8 +1032,6 @@ impl f64 {
     /// Computes the cosine of a number (in radians).
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let x = 2.0*f64::consts::PI;
@@ -1327,8 +1049,6 @@ impl f64 {
     /// Computes the tangent of a number (in radians).
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/4.0;
@@ -1347,8 +1067,6 @@ impl f64 {
     /// [-1, 1].
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let f = f64::consts::PI / 2.0;
@@ -1369,8 +1087,6 @@ impl f64 {
     /// [-1, 1].
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let f = f64::consts::PI / 4.0;
@@ -1390,9 +1106,7 @@ impl f64 {
     /// range [-pi/2, pi/2];
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let f = 1.0;
+    /// let f = 1.0_f64;
     ///
     /// // atan(tan(1))
     /// let abs_difference = (f.tan().atan() - 1.0).abs();
@@ -1413,19 +1127,17 @@ impl f64 {
     /// * `y < 0`: `arctan(y/x) - pi` -> `(-pi, -pi/2)`
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let pi = f64::consts::PI;
     /// // All angles from horizontal right (+x)
     /// // 45 deg counter-clockwise
-    /// let x1 = 3.0;
-    /// let y1 = -3.0;
+    /// let x1 = 3.0_f64;
+    /// let y1 = -3.0_f64;
     ///
     /// // 135 deg clockwise
-    /// let x2 = -3.0;
-    /// let y2 = 3.0;
+    /// let x2 = -3.0_f64;
+    /// let y2 = 3.0_f64;
     ///
     /// let abs_difference_1 = (y1.atan2(x1) - (-pi/4.0)).abs();
     /// let abs_difference_2 = (y2.atan2(x2) - 3.0*pi/4.0).abs();
@@ -1443,8 +1155,6 @@ impl f64 {
     /// `(sin(x), cos(x))`.
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let x = f64::consts::PI/4.0;
@@ -1466,17 +1176,14 @@ impl f64 {
     /// number is close to zero.
     ///
     /// ```
-    /// # #![feature(std_misc)]
-    /// use std::num::Float;
-    ///
-    /// let x = 7.0;
+    /// let x = 7.0_f64;
     ///
     /// // e^(ln(7)) - 1
     /// let abs_difference = (x.ln().exp_m1() - 6.0).abs();
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[unstable(feature = "std_misc", reason = "may be renamed")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp_m1(self) -> f64 {
         unsafe { cmath::expm1(self) }
@@ -1486,8 +1193,6 @@ impl f64 {
     /// the operations were performed separately.
     ///
     /// ```
-    /// # #![feature(std_misc, core)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let x = f64::consts::E - 1.0;
@@ -1497,7 +1202,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[unstable(feature = "std_misc", reason = "may be renamed")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ln_1p(self) -> f64 {
         unsafe { cmath::log1p(self) }
@@ -1506,12 +1211,10 @@ impl f64 {
     /// Hyperbolic sine function.
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
-    /// let x = 1.0;
+    /// let x = 1.0_f64;
     ///
     /// let f = x.sinh();
     /// // Solving sinh() at 1 gives `(e^2-1)/(2e)`
@@ -1529,12 +1232,10 @@ impl f64 {
     /// Hyperbolic cosine function.
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
-    /// let x = 1.0;
+    /// let x = 1.0_f64;
     /// let f = x.cosh();
     /// // Solving cosh() at 1 gives this result
     /// let g = (e*e + 1.0)/(2.0*e);
@@ -1552,12 +1253,10 @@ impl f64 {
     /// Hyperbolic tangent function.
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
-    /// let x = 1.0;
+    /// let x = 1.0_f64;
     ///
     /// let f = x.tanh();
     /// // Solving tanh() at 1 gives `(1 - e^(-2))/(1 + e^(-2))`
@@ -1575,9 +1274,7 @@ impl f64 {
     /// Inverse hyperbolic sine function.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let x = 1.0;
+    /// let x = 1.0_f64;
     /// let f = x.sinh().asinh();
     ///
     /// let abs_difference = (f - x).abs();
@@ -1596,9 +1293,7 @@ impl f64 {
     /// Inverse hyperbolic cosine function.
     ///
     /// ```
-    /// use std::num::Float;
-    ///
-    /// let x = 1.0;
+    /// let x = 1.0_f64;
     /// let f = x.cosh().acosh();
     ///
     /// let abs_difference = (f - x).abs();
@@ -1617,8 +1312,6 @@ impl f64 {
     /// Inverse hyperbolic tangent function.
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::num::Float;
     /// use std::f64;
     ///
     /// let e = f64::consts::E;
@@ -1646,6 +1339,7 @@ impl f64 {
 /// * num - The float value
 #[inline]
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
+#[deprecated(since = "1.0.0", reason = "use the ToString trait instead")]
 pub fn to_string(num: f64) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 10, true, SignNeg, DigAll, ExpNone, false);
@@ -1659,6 +1353,7 @@ pub fn to_string(num: f64) -> String {
 /// * num - The float value
 #[inline]
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
+#[deprecated(since = "1.0.0", reason = "use format! instead")]
 pub fn to_str_hex(num: f64) -> String {
     let (r, _) = strconv::float_to_str_common(
         num, 16, true, SignNeg, DigAll, ExpNone, false);
@@ -1674,6 +1369,7 @@ pub fn to_str_hex(num: f64) -> String {
 /// * radix - The base to use
 #[inline]
 #[unstable(feature = "std_misc", reason = "may be removed or relocated")]
+#[deprecated(since = "1.0.0", reason = "use format! instead")]
 pub fn to_str_radix_special(num: f64, rdx: u32) -> (String, bool) {
     strconv::float_to_str_common(num, rdx, true, SignNeg, DigAll, ExpNone, false)
 }
@@ -1770,8 +1466,8 @@ mod tests {
         assert!(!nan.is_infinite());
         assert!(!nan.is_finite());
         assert!(!nan.is_normal());
-        assert!(!nan.is_positive());
-        assert!(!nan.is_negative());
+        assert!(!nan.is_sign_positive());
+        assert!(!nan.is_sign_negative());
         assert_eq!(Fp::Nan, nan.classify());
     }
 
@@ -1780,8 +1476,8 @@ mod tests {
         let inf: f64 = Float::infinity();
         assert!(inf.is_infinite());
         assert!(!inf.is_finite());
-        assert!(inf.is_positive());
-        assert!(!inf.is_negative());
+        assert!(inf.is_sign_positive());
+        assert!(!inf.is_sign_negative());
         assert!(!inf.is_nan());
         assert!(!inf.is_normal());
         assert_eq!(Fp::Infinite, inf.classify());
@@ -1792,8 +1488,8 @@ mod tests {
         let neg_inf: f64 = Float::neg_infinity();
         assert!(neg_inf.is_infinite());
         assert!(!neg_inf.is_finite());
-        assert!(!neg_inf.is_positive());
-        assert!(neg_inf.is_negative());
+        assert!(!neg_inf.is_sign_positive());
+        assert!(neg_inf.is_sign_negative());
         assert!(!neg_inf.is_nan());
         assert!(!neg_inf.is_normal());
         assert_eq!(Fp::Infinite, neg_inf.classify());
@@ -1805,8 +1501,8 @@ mod tests {
         assert_eq!(0.0, zero);
         assert!(!zero.is_infinite());
         assert!(zero.is_finite());
-        assert!(zero.is_positive());
-        assert!(!zero.is_negative());
+        assert!(zero.is_sign_positive());
+        assert!(!zero.is_sign_negative());
         assert!(!zero.is_nan());
         assert!(!zero.is_normal());
         assert_eq!(Fp::Zero, zero.classify());
@@ -1818,8 +1514,8 @@ mod tests {
         assert_eq!(0.0, neg_zero);
         assert!(!neg_zero.is_infinite());
         assert!(neg_zero.is_finite());
-        assert!(!neg_zero.is_positive());
-        assert!(neg_zero.is_negative());
+        assert!(!neg_zero.is_sign_positive());
+        assert!(neg_zero.is_sign_negative());
         assert!(!neg_zero.is_nan());
         assert!(!neg_zero.is_normal());
         assert_eq!(Fp::Zero, neg_zero.classify());
@@ -1831,8 +1527,8 @@ mod tests {
         assert_eq!(1.0, one);
         assert!(!one.is_infinite());
         assert!(one.is_finite());
-        assert!(one.is_positive());
-        assert!(!one.is_negative());
+        assert!(one.is_sign_positive());
+        assert!(!one.is_sign_negative());
         assert!(!one.is_nan());
         assert!(one.is_normal());
         assert_eq!(Fp::Normal, one.classify());
@@ -2017,27 +1713,27 @@ mod tests {
     }
 
     #[test]
-    fn test_is_positive() {
-        assert!(INFINITY.is_positive());
-        assert!(1f64.is_positive());
-        assert!(0f64.is_positive());
-        assert!(!(-0f64).is_positive());
-        assert!(!(-1f64).is_positive());
-        assert!(!NEG_INFINITY.is_positive());
-        assert!(!(1f64/NEG_INFINITY).is_positive());
-        assert!(!NAN.is_positive());
+    fn test_is_sign_positive() {
+        assert!(INFINITY.is_sign_positive());
+        assert!(1f64.is_sign_positive());
+        assert!(0f64.is_sign_positive());
+        assert!(!(-0f64).is_sign_positive());
+        assert!(!(-1f64).is_sign_positive());
+        assert!(!NEG_INFINITY.is_sign_positive());
+        assert!(!(1f64/NEG_INFINITY).is_sign_positive());
+        assert!(!NAN.is_sign_positive());
     }
 
     #[test]
-    fn test_is_negative() {
-        assert!(!INFINITY.is_negative());
-        assert!(!1f64.is_negative());
-        assert!(!0f64.is_negative());
-        assert!((-0f64).is_negative());
-        assert!((-1f64).is_negative());
-        assert!(NEG_INFINITY.is_negative());
-        assert!((1f64/NEG_INFINITY).is_negative());
-        assert!(!NAN.is_negative());
+    fn test_is_sign_negative() {
+        assert!(!INFINITY.is_sign_negative());
+        assert!(!1f64.is_sign_negative());
+        assert!(!0f64.is_sign_negative());
+        assert!((-0f64).is_sign_negative());
+        assert!((-1f64).is_sign_negative());
+        assert!(NEG_INFINITY.is_sign_negative());
+        assert!((1f64/NEG_INFINITY).is_sign_negative());
+        assert!(!NAN.is_sign_negative());
     }
 
     #[test]

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -15,6 +15,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]
+#![allow(deprecated)]
 
 #[cfg(test)] use fmt::Debug;
 use ops::{Add, Sub, Mul, Div, Rem, Neg};
@@ -23,22 +24,24 @@ use marker::Copy;
 use clone::Clone;
 use cmp::{PartialOrd, PartialEq};
 
-pub use core::num::{Int, SignedInt};
+pub use core::num::{Int, SignedInt, Zero, One};
 pub use core::num::{cast, FromPrimitive, NumCast, ToPrimitive};
 pub use core::num::{from_int, from_i8, from_i16, from_i32, from_i64};
 pub use core::num::{from_uint, from_u8, from_u16, from_u32, from_u64};
 pub use core::num::{from_f32, from_f64};
 pub use core::num::{FromStrRadix, from_str_radix};
 pub use core::num::{FpCategory, ParseIntError, ParseFloatError};
-pub use core::num::wrapping;
+pub use core::num::{wrapping, Wrapping};
 
 use option::Option;
 
-#[unstable(feature = "std_misc", reason = "may be removed or relocated")]
+#[unstable(feature = "std_misc", reason = "likely to be removed")]
 pub mod strconv;
 
 /// Mathematical operations on primitive floating point numbers.
 #[stable(feature = "rust1", since = "1.0.0")]
+#[deprecated(since = "1.0.0",
+             reason = "replaced by inherent methods; use rust-lang/num for generics")]
 pub trait Float
     : Copy + Clone
     + NumCast
@@ -272,6 +275,7 @@ pub trait Float
     /// ```
     #[unstable(feature = "std_misc", reason = "position is undecided")]
     fn is_finite(self) -> bool;
+
     /// Returns `true` if the number is neither zero, infinite,
     /// [subnormal][subnormal], or `NaN`.
     ///
@@ -1148,7 +1152,7 @@ pub fn test_num<T>(ten: T, two: T) where
 
 #[cfg(test)]
 mod tests {
-    use prelude::v1::*;
+    use core::prelude::*;
     use super::*;
     use i8;
     use i16;
@@ -1160,6 +1164,7 @@ mod tests {
     use u32;
     use u64;
     use usize;
+    use string::ToString;
 
     macro_rules! test_cast_20 {
         ($_20:expr) => ({

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -11,6 +11,7 @@
 // ignore-lexer-test FIXME #15679
 
 #![allow(missing_docs)]
+#![allow(deprecated)]
 
 use self::ExponentFormat::*;
 use self::SignificantDigits::*;

--- a/src/libstd/prelude/v1.rs
+++ b/src/libstd/prelude/v1.rs
@@ -51,6 +51,3 @@
 #[doc(no_inline)] pub use string::{String, ToString};
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)] pub use vec::Vec;
-
-// FIXME(#23454) should these be here?
-#[doc(no_inline)] pub use num::wrapping::{Wrapping, WrappingOps};

--- a/src/libstd/sys/common/mod.rs
+++ b/src/libstd/sys/common/mod.rs
@@ -14,6 +14,7 @@ use old_io::{self, IoError, IoResult};
 use prelude::v1::*;
 use sys::{last_error, retry};
 use ffi::CString;
+#[allow(deprecated)] // Int
 use num::Int;
 
 #[allow(deprecated)]

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -37,6 +37,7 @@ use fmt;
 use hash::{Hash, Hasher};
 use iter::{FromIterator, IntoIterator};
 use mem;
+#[allow(deprecated)] // Int
 use num::Int;
 use ops;
 use slice;

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -171,6 +171,7 @@ pub fn retry<T, F> (mut f: F) -> T where
     }
 }
 
+#[allow(deprecated)]
 pub fn cvt<T: SignedInt>(t: T) -> io::Result<T> {
     let one: T = Int::one();
     if t == -one {
@@ -180,6 +181,7 @@ pub fn cvt<T: SignedInt>(t: T) -> io::Result<T> {
     }
 }
 
+#[allow(deprecated)]
 pub fn cvt_r<T, F>(mut f: F) -> io::Result<T>
     where T: SignedInt, F: FnMut() -> T
 {

--- a/src/libstd/sys/windows/mod.rs
+++ b/src/libstd/sys/windows/mod.rs
@@ -18,6 +18,7 @@ use ffi::{OsStr, OsString};
 use io::{self, ErrorKind};
 use libc;
 use mem;
+#[allow(deprecated)]
 use num::Int;
 use old_io::{self, IoResult, IoError};
 use os::windows::ffi::{OsStrExt, OsStringExt};
@@ -315,6 +316,7 @@ pub fn truncate_utf16_at_nul<'a>(v: &'a [u16]) -> &'a [u16] {
     }
 }
 
+#[allow(deprecated)]
 fn cvt<I: Int>(i: I) -> io::Result<I> {
     if i == Int::zero() {
         Err(io::Error::last_os_error())

--- a/src/libstd/sys/windows/net.rs
+++ b/src/libstd/sys/windows/net.rs
@@ -15,6 +15,7 @@ use libc::consts::os::extra::INVALID_SOCKET;
 use libc::{self, c_int, c_void};
 use mem;
 use net::SocketAddr;
+#[allow(deprecated)]
 use num::{SignedInt, Int};
 use rt;
 use sync::{Once, ONCE_INIT};
@@ -50,6 +51,7 @@ fn last_error() -> io::Error {
 /// function must be called before another call to the socket API is made.
 ///
 /// FIXME: generics needed?
+#[allow(deprecated)]
 pub fn cvt<T: SignedInt>(t: T) -> io::Result<T> {
     let one: T = Int::one();
     if t == -one {
@@ -67,6 +69,7 @@ pub fn cvt_gai(err: c_int) -> io::Result<()> {
 }
 
 /// Provides the functionality of `cvt` for a closure.
+#[allow(deprecated)]
 pub fn cvt_r<T: SignedInt, F>(mut f: F) -> io::Result<T> where F: FnMut() -> T {
     cvt(f())
 }

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -16,6 +16,7 @@ use {fmt, i64};
 use ops::{Add, Sub, Mul, Div, Neg, FnOnce};
 use option::Option;
 use option::Option::{Some, None};
+#[allow(deprecated)] // Int
 use num::Int;
 use result::Result::Ok;
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -66,6 +66,7 @@ use parse::lexer;
 use ptr::P;
 
 use std::fmt;
+#[allow(deprecated)]
 use std::num::Int;
 use std::rc::Rc;
 use serialize::{Encodable, Decodable, Encoder, Decoder};
@@ -1141,6 +1142,7 @@ pub enum Sign {
 }
 
 impl Sign {
+    #[allow(deprecated)] // Int
     pub fn new<T:Int>(n: T) -> Sign {
         if n < Int::zero() {
             Minus

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -20,7 +20,6 @@ use std::borrow::{IntoCow, Cow};
 use std::char;
 use std::fmt;
 use std::mem::replace;
-use std::num;
 use std::rc::Rc;
 
 pub use ext::tt::transcribe::{TtReader, new_tt_reader, new_tt_reader_with_doc_flag};
@@ -622,8 +621,8 @@ impl<'a> StringReader<'a> {
 
         // find the integer representing the name
         self.scan_digits(base);
-        let encoded_name : u32 = self.with_str_from(start_bpos, |s| {
-            num::from_str_radix(s, 10).unwrap_or_else(|_| {
+        let encoded_name: u32 = self.with_str_from(start_bpos, |s| {
+            u32::from_str_radix(s, 10).unwrap_or_else(|_| {
                 panic!("expected digits representing a name, got {:?}, {}, range [{:?},{:?}]",
                       s, whence, start_bpos, self.last_pos);
             })
@@ -641,7 +640,7 @@ impl<'a> StringReader<'a> {
         let start_bpos = self.last_pos;
         self.scan_digits(base);
         let encoded_ctxt : ast::SyntaxContext = self.with_str_from(start_bpos, |s| {
-            num::from_str_radix(s, 10).unwrap_or_else(|_| {
+            u32::from_str_radix(s, 10).unwrap_or_else(|_| {
                 panic!("expected digits representing a ctxt, got {:?}, {}", s, whence);
             })
         });

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -21,6 +21,7 @@ use std::cell::{Cell, RefCell};
 use std::fs::File;
 use std::io::Read;
 use std::iter;
+#[allow(deprecated)] // Int
 use std::num::Int;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -372,7 +373,7 @@ pub fn maybe_aborted<T>(result: T, p: Parser) -> T {
 /// well. Can take any slice prefixed by a character escape. Returns the
 /// character and the number of characters consumed.
 pub fn char_lit(lit: &str) -> (char, isize) {
-    use std::{num, char};
+    use std::char;
 
     let mut chars = lit.chars();
     let c = match (chars.next(), chars.next()) {
@@ -399,7 +400,7 @@ pub fn char_lit(lit: &str) -> (char, isize) {
     let msg2 = &msg[..];
 
     fn esc(len: usize, lit: &str) -> Option<(char, isize)> {
-        num::from_str_radix(&lit[2..len], 16).ok()
+        u32::from_str_radix(&lit[2..len], 16).ok()
         .and_then(char::from_u32)
         .map(|x| (x, len as isize))
     }
@@ -408,7 +409,7 @@ pub fn char_lit(lit: &str) -> (char, isize) {
         if lit.as_bytes()[2] == b'{' {
             let idx = lit.find('}').expect(msg2);
             let subslice = &lit[3..idx];
-            num::from_str_radix(subslice, 16).ok()
+            u32::from_str_radix(subslice, 16).ok()
                 .and_then(char::from_u32)
                 .map(|x| (x, subslice.chars().count() as isize + 4))
         } else {
@@ -582,7 +583,7 @@ pub fn byte_lit(lit: &str) -> (u8, usize) {
             b'\'' => b'\'',
             b'0' => b'\0',
             _ => {
-                match ::std::num::from_str_radix::<u64>(&lit[2..4], 16).ok() {
+                match u64::from_str_radix(&lit[2..4], 16).ok() {
                     Some(c) =>
                         if c > 0xFF {
                             panic!(err(2))
@@ -733,7 +734,7 @@ pub fn integer_lit(s: &str, suffix: Option<&str>, sd: &SpanHandler, sp: Span) ->
     debug!("integer_lit: the type is {:?}, base {:?}, the new string is {:?}, the original \
            string was {:?}, the original suffix was {:?}", ty, base, s, orig, suffix);
 
-    let res: u64 = match ::std::num::from_str_radix(s, base).ok() {
+    let res = match u64::from_str_radix(s, base).ok() {
         Some(r) => r,
         None => { sd.span_err(sp, "int literal is too large"); 0 }
     };

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![allow(missing_docs)]
+#![allow(deprecated)] // Float
 
 use std::cmp::Ordering::{self, Less, Greater, Equal};
 use std::mem;

--- a/src/libunicode/u_str.rs
+++ b/src/libunicode/u_str.rs
@@ -22,7 +22,6 @@ use core::char;
 use core::cmp;
 use core::iter::{Filter, AdditiveIterator};
 use core::mem;
-use core::num::Int;
 use core::slice;
 use core::str::Split;
 

--- a/src/test/compile-fail/lint-dead-code-4.rs
+++ b/src/test/compile-fail/lint-dead-code-4.rs
@@ -16,8 +16,6 @@
 
 extern crate libc;
 
-use std::num::Int;
-
 struct Foo {
     x: usize,
     b: bool, //~ ERROR: struct field is never used

--- a/src/test/compile-fail/range-1.rs
+++ b/src/test/compile-fail/range-1.rs
@@ -15,9 +15,10 @@ pub fn main() {
     let _ = 0u32..10i32;
     //~^ ERROR start and end of range have incompatible types
 
-    // Float => does not implement iterator.
-    for i in 0f32..42f32 {}
-    //~^ ERROR the trait `core::num::Int` is not implemented for the type `f32`
+    // Bool => does not implement iterator.
+    for i in false..true {}
+    //~^ ERROR the trait
+    //~^^ ERROR the trait
 
     // Unsized type.
     let arr: &[_] = &[1, 2, 3];

--- a/src/test/run-pass/generic-extern-mangle.rs
+++ b/src/test/run-pass/generic-extern-mangle.rs
@@ -12,11 +12,11 @@
 
 #![feature(core)]
 
-use std::num::Int;
+use std::ops::Add;
 
-extern "C" fn foo<T: WrappingOps>(a: T, b: T) -> T { a.wrapping_add(b) }
+extern "C" fn foo<T: Add>(a: T, b: T) -> T::Output { a + b }
 
 fn main() {
-    assert_eq!(99u8, foo(255u8, 100u8));
-    assert_eq!(99u16, foo(65535u16, 100u16));
+    assert_eq!(100u8, foo(0u8, 100u8));
+    assert_eq!(100u16, foo(0u16, 100u16));
 }


### PR DESCRIPTION
This commit stabilizes the `std::num` module:
- The `Int` and `Float` traits are deprecated in favor of (1) the
  newly-added inherent methods and (2) the generic traits available in
  rust-lang/num.
- The `Zero` and `One` traits are reintroduced in `std::num`, which
  together with various other traits allow you to recover the most
  common forms of generic programming.
- The `FromStrRadix` trait, and associated free function, is deprecated
  in favor of inherent implementations.
- A wide range of methods and constants for both integers and floating
  point numbers are now `#[stable]`, having been adjusted for integer
  guidelines.
- `is_positive` and `is_negative` are renamed to `is_sign_positive` and
  `is_sign_negative`, in order to address #22985
- The `Wrapping` type is moved to `std::num` and stabilized;
  `WrappingOps` is deprecated in favor of inherent methods on the
  integer types, and direct implementation of operations on
  `Wrapping<X>` for each concrete integer type `X`.

Closes #22985
Closes #21069

[breaking-change]

r? @alexcrichton 
