### PR TITLE
Implement RFC 909: move thread_local into thread

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -249,30 +249,23 @@ pub mod num;
 /* Runtime and platform support */
 
 #[macro_use]
-pub mod thread_local;
-
-pub mod dynamic_lib;
-pub mod ffi;
-pub mod old_io;
-pub mod io;
-pub mod fs;
-pub mod net;
-pub mod os;
-pub mod env;
-pub mod path;
-pub mod old_path;
-pub mod process;
-pub mod rand;
-pub mod time;
-
-/* Common data structures */
+pub mod thread;
 
 pub mod collections;
-
-/* Threads and communication */
-
-pub mod thread;
+pub mod dynamic_lib;
+pub mod env;
+pub mod ffi;
+pub mod fs;
+pub mod io;
+pub mod net;
+pub mod old_io;
+pub mod old_path;
+pub mod os;
+pub mod path;
+pub mod process;
+pub mod rand;
 pub mod sync;
+pub mod time;
 
 #[macro_use]
 #[path = "sys/common/mod.rs"] mod sys_common;
@@ -305,7 +298,7 @@ mod std {
     pub use rt; // used for panic!()
     pub use vec; // used for vec![]
     pub use cell; // used for tls!
-    pub use thread_local; // used for thread_local!
+    pub use thread; // used for thread_local!
     pub use marker;  // used for tls!
     pub use ops; // used for bitflags!
 

--- a/src/libstd/sys/common/thread_info.rs
+++ b/src/libstd/sys/common/thread_info.rs
@@ -15,7 +15,7 @@ use core::prelude::*;
 use cell::RefCell;
 use string::String;
 use thread::Thread;
-use thread_local::State;
+use thread::LocalKeyState;
 
 struct ThreadInfo {
     stack_guard: uint,
@@ -26,7 +26,7 @@ thread_local! { static THREAD_INFO: RefCell<Option<ThreadInfo>> = RefCell::new(N
 
 impl ThreadInfo {
     fn with<R, F>(f: F) -> R where F: FnOnce(&mut ThreadInfo) -> R {
-        if THREAD_INFO.state() == State::Destroyed {
+        if THREAD_INFO.state() == LocalKeyState::Destroyed {
             panic!("Use of std::thread::current() is not possible after \
                     the thread's local data has been destroyed");
         }

--- a/src/libstd/thread/scoped.rs
+++ b/src/libstd/thread/scoped.rs
@@ -38,9 +38,7 @@
 //! });
 //! ```
 
-#![unstable(feature = "std_misc",
-            reason = "scoped TLS has yet to have wide enough use to fully consider \
-                      stabilizing its interface")]
+#![unstable(feature = "thread_local_internals")]
 
 use prelude::v1::*;
 
@@ -58,7 +56,10 @@ pub mod __impl {
 /// type `T` scoped to a particular lifetime. Keys provides two methods, `set`
 /// and `with`, both of which currently use closures to control the scope of
 /// their contents.
-pub struct Key<T> { #[doc(hidden)] pub inner: __impl::KeyInner<T> }
+#[unstable(feature = "scoped_tls",
+           reason = "scoped TLS has yet to have wide enough use to fully consider \
+                     stabilizing its interface")]
+pub struct ScopedKey<T> { #[doc(hidden)] pub inner: __impl::KeyInner<T> }
 
 /// Declare a new scoped thread local storage key.
 ///
@@ -86,7 +87,7 @@ macro_rules! __scoped_thread_local_inner {
                            target_os = "openbsd",
                            target_arch = "aarch64")),
                    thread_local)]
-        static $name: ::std::thread_local::scoped::Key<$t> =
+        static $name: ::std::thread::ScopedKey<$t> =
             __scoped_thread_local_inner!($t);
     );
     (pub static $name:ident: $t:ty) => (
@@ -96,11 +97,11 @@ macro_rules! __scoped_thread_local_inner {
                            target_os = "openbsd",
                            target_arch = "aarch64")),
                    thread_local)]
-        pub static $name: ::std::thread_local::scoped::Key<$t> =
+        pub static $name: ::std::thread::ScopedKey<$t> =
             __scoped_thread_local_inner!($t);
     );
     ($t:ty) => ({
-        use std::thread_local::scoped::Key as __Key;
+        use std::thread::ScopedKey as __Key;
 
         #[cfg(not(any(windows,
                       target_os = "android",
@@ -108,7 +109,7 @@ macro_rules! __scoped_thread_local_inner {
                       target_os = "openbsd",
                       target_arch = "aarch64")))]
         const _INIT: __Key<$t> = __Key {
-            inner: ::std::thread_local::scoped::__impl::KeyInner {
+            inner: ::std::thread::__scoped::__impl::KeyInner {
                 inner: ::std::cell::UnsafeCell { value: 0 as *mut _ },
             }
         };
@@ -119,8 +120,8 @@ macro_rules! __scoped_thread_local_inner {
                   target_os = "openbsd",
                   target_arch = "aarch64"))]
         const _INIT: __Key<$t> = __Key {
-            inner: ::std::thread_local::scoped::__impl::KeyInner {
-                inner: ::std::thread_local::scoped::__impl::OS_INIT,
+            inner: ::std::thread::__scoped::__impl::KeyInner {
+                inner: ::std::thread::__scoped::__impl::OS_INIT,
                 marker: ::std::marker::PhantomData::<::std::cell::Cell<$t>>,
             }
         };
@@ -129,7 +130,10 @@ macro_rules! __scoped_thread_local_inner {
     })
 }
 
-impl<T> Key<T> {
+#[unstable(feature = "scoped_tls",
+           reason = "scoped TLS has yet to have wide enough use to fully consider \
+                     stabilizing its interface")]
+impl<T> ScopedKey<T> {
     /// Insert a value into this scoped thread local storage slot for a
     /// duration of a closure.
     ///


### PR DESCRIPTION
This commit implements [RFC 909](https://github.com/rust-lang/rfcs/pull/909):

The `std::thread_local` module is now deprecated, and its contents are
available directly in `std::thread` as `LocalKey`, `LocalKeyState`, and
`ScopedKey`.

The macros remain exactly as they were, which means little if any code
should break. Nevertheless, this is technically a:

[breaking-change]

Closes #23547
