### PR TITLE
Use os::tmpdir instead of hard coded /home/ path in test case

### DIFF
--- a/src/test/run-pass/issue-20797.rs
+++ b/src/test/run-pass/issue-20797.rs
@@ -8,15 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-android
-// ignore-windows
-
 // Regression test for #20797.
 
 use std::default::Default;
 use std::old_io::IoResult;
 use std::old_io::fs;
 use std::old_io::fs::PathExtensions;
+use std::os;
 
 /// A strategy for acquiring more subpaths to walk.
 pub trait Strategy {
@@ -90,5 +88,5 @@ impl<S: Strategy> Iterator for Subpaths<S> {
 }
 
 fn main() {
-  let mut walker: Subpaths<Recursive> = Subpaths::walk(&Path::new("/home")).unwrap();
+  let mut walker: Subpaths<Recursive> = Subpaths::walk(&os::tmpdir()).unwrap();
 }


### PR DESCRIPTION
closes #23373

This PR uses `std::os::tmpdir()` instead of `Path::new("/home")`. I also removed `ignore-android` and `ignore-windows`, because I think the hardcoded path was the reason for them.
