### PR TITLE
Do not accept unicode escape characters in byte strings or as byte

### DIFF
--- a/src/test/parse-fail/issue-23620-invalid-escapes.rs
+++ b/src/test/parse-fail/issue-23620-invalid-escapes.rs
@@ -1,0 +1,45 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let _ = b"\u{a66e}";
+    //~^ ERROR unicode escape sequences cannot be used as a byte or in a byte string
+
+    let _ = b'\u{a66e}';
+    //~^ ERROR unicode escape sequences cannot be used as a byte or in a byte string
+
+    let _ = b'\u';
+    //~^ ERROR unknown byte escape: u
+
+    let _ = b'\x5';
+    //~^ ERROR numeric character escape is too short
+
+    let _ = b'\xxy';
+    //~^ ERROR illegal character in numeric character escape: x
+    //~^^ ERROR illegal character in numeric character escape: y
+
+    let _ = '\x5';
+    //~^ ERROR numeric character escape is too short
+
+    let _ = '\xxy';
+    //~^ ERROR illegal character in numeric character escape: x
+    //~^^ ERROR illegal character in numeric character escape: y
+
+    let _ = b"\u{a4a4} \xf \u";
+    //~^ ERROR unicode escape sequences cannot be used as a byte or in a byte string
+    //~^^ ERROR illegal character in numeric character escape:
+    //~^^^ ERROR unknown byte escape: u
+
+    let _ = "\u{ffffff} \xf \u";
+    //~^ ERROR illegal unicode character escape
+    //~^^ ERROR illegal character in numeric character escape:
+    //~^^^ ERROR form of character escape may only be used with characters in the range [\x00-\x7f]
+    //~^^^^ ERROR unknown character escape: u
+}

--- a/src/test/parse-fail/new-unicode-escapes-4.rs
+++ b/src/test/parse-fail/new-unicode-escapes-4.rs
@@ -9,5 +9,8 @@
 // except according to those terms.
 
 pub fn main() {
-    let s = "\u{lol}"; //~ ERROR illegal character in unicode escape
+    let s = "\u{lol}";
+     //~^ ERROR illegal character in unicode escape: l
+     //~^^ ERROR illegal character in unicode escape: o
+     //~^^^ ERROR illegal character in unicode escape: l
 }


### PR DESCRIPTION
closes #23620

This PR patches the issue mentioned in #23620, but there is also an ICE for invalid escape sequences in byte literals. This is due to the fact that the `scan_byte` function returns `token::intern("??")` for invalid bytes, resulting in an ICE later on. Is there a reason for this behavior? Shouldn't `scan_byte` fail when it encounters an invalid byte?

And I noticed a small inconsistency in the documentation. According to the formal byte literal definition in http://doc.rust-lang.org/reference.html#byte-and-byte-string-literals , a byte string literal contains `string_body *`, but according to the text (and the behavior of the lexer) it should not accept unicode escape sequences. Hence it should be replaced by `byte_body *`. If this is valid, I can add this fix to this PR.
