### PR TITLE
Fix a typo in the Rust Book ownership page.

### DIFF
--- a/src/doc/trpl/ownership.md
+++ b/src/doc/trpl/ownership.md
@@ -513,8 +513,8 @@ Otherwise, it is an error to elide an output lifetime.
 
 ### Examples
 
-Here are some examples of functions with elided lifetimes, and the version of
-what the elided lifetimes are expand to:
+Here are some examples of functions with elided lifetimes, along with versions
+of what the elided lifetimes expand to:
 
 ```{rust,ignore}
 fn print(s: &str); // elided

--- a/src/doc/trpl/ownership.md
+++ b/src/doc/trpl/ownership.md
@@ -513,8 +513,8 @@ Otherwise, it is an error to elide an output lifetime.
 
 ### Examples
 
-Here are some examples of functions with elided lifetimes, along with versions
-of what the elided lifetimes expand to:
+Here are some examples of functions with elided lifetimes.  We've paired each
+example of an elided lifetime with its expanded form.
 
 ```{rust,ignore}
 fn print(s: &str); // elided


### PR DESCRIPTION
Found a small typo on the Rust book "ownership" page.

Best,
Liam

r? @steveklabnik
