### PR TITLE
rustdoc: Relocate array primitive docs to a new page

### DIFF
--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -14,6 +14,8 @@
 
 #![unstable(feature = "core")] // not yet reviewed
 
+#![doc(primitive = "array")]
+
 use clone::Clone;
 use cmp::{PartialEq, Eq, PartialOrd, Ord, Ordering};
 use fmt;

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1322,7 +1322,8 @@ pub enum Type {
     /// For parameterized types, so the consumer of the JSON don't go
     /// looking for types which don't exist anywhere.
     Generic(String),
-    /// Primitives are just the fixed-size numeric types (plus int/uint/float), and char.
+    /// Primitives are the fixed-size numeric types (plus int/uint/float), char,
+    /// arrays, slices, and tuples.
     Primitive(PrimitiveType),
     /// extern "ABI" fn
     BareFunction(Box<BareFunctionDecl>),
@@ -1362,6 +1363,7 @@ pub enum PrimitiveType {
     Bool,
     Str,
     Slice,
+    Array,
     PrimitiveTuple,
 }
 
@@ -1396,6 +1398,7 @@ impl PrimitiveType {
             "str" => Some(Str),
             "f32" => Some(F32),
             "f64" => Some(F64),
+            "array" => Some(Array),
             "slice" => Some(Slice),
             "tuple" => Some(PrimitiveTuple),
             _ => None,
@@ -1440,6 +1443,7 @@ impl PrimitiveType {
             Str => "str",
             Bool => "bool",
             Char => "char",
+            Array => "array",
             Slice => "slice",
             PrimitiveTuple => "tuple",
         }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -486,7 +486,7 @@ impl fmt::Display for clean::Type {
                 primitive_link(f, clean::Slice, &format!("[{}]", **t))
             }
             clean::FixedVector(ref t, ref s) => {
-                primitive_link(f, clean::Slice,
+                primitive_link(f, clean::PrimitiveType::Array,
                                &format!("[{}; {}]", **t, *s))
             }
             clean::Bottom => f.write_str("!"),

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1026,7 +1026,8 @@ impl DocFolder for Cache {
                 match item {
                     clean::Item{ attrs, inner: clean::ImplItem(i), .. } => {
                         use clean::{Primitive, Vector, ResolvedPath, BorrowedRef};
-                        use clean::{FixedVector, Slice, Tuple, PrimitiveTuple};
+                        use clean::PrimitiveType::{Array, Slice, PrimitiveTuple};
+                        use clean::{FixedVector, Tuple};
 
                         // extract relevant documentation for this impl
                         let dox = match attrs.into_iter().find(|a| {
@@ -1056,12 +1057,16 @@ impl DocFolder for Cache {
                                 Some(ast_util::local_def(p.to_node_id()))
                             }
 
-                            // In a DST world, we may only need
-                            // Vector/FixedVector, but for now we also pick up
-                            // borrowed references
-                            Vector(..) | FixedVector(..) |
-                                BorrowedRef{ type_: box Vector(..), ..  } |
-                                BorrowedRef{ type_: box FixedVector(..), .. } =>
+                            FixedVector(..) |
+                                BorrowedRef { type_: box FixedVector(..), .. } =>
+                            {
+                                Some(ast_util::local_def(Array.to_node_id()))
+                            }
+
+                            // In a DST world, we may only need Vector, but for now we
+                            // also pick up borrowed references
+                            Vector(..) |
+                                BorrowedRef{ type_: box Vector(..), ..  } =>
                             {
                                 Some(ast_util::local_def(Slice.to_node_id()))
                             }

--- a/src/libstd/array.rs
+++ b/src/libstd/array.rs
@@ -1,0 +1,13 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! The fixed-size array type (`[T; n]`).
+
+#![doc(primitive = "array")]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -212,6 +212,9 @@ pub mod prelude;
 
 /* Primitive types */
 
+// NB: slice and str are primitive types too, but their module docs + primitive doc pages
+// are inlined from the public re-exports of core_collections::{slice, str} above.
+
 #[path = "num/float_macros.rs"]
 #[macro_use]
 mod float_macros;
@@ -285,8 +288,9 @@ pub mod sync;
 pub mod rt;
 mod panicking;
 
-// Documentation for primitive types
+// Modules that exist purely to document + host impl docs for primitive types
 
+mod array;
 mod bool;
 mod unit;
 mod tuple;


### PR DESCRIPTION
Previously, impls for `[T; n]` were collected in the same place as impls for `[T]` and `&[T]`. This splits them out into their own primitive page in both core and std.
