### PR TITLE
std: Stabilize the `Hasher::finish` method

### DIFF
--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -90,7 +90,7 @@ pub trait Hash {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Hasher {
     /// Completes a round of hashing, producing the output hash generated.
-    #[unstable(feature = "hash", reason = "module was recently redesigned")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     fn finish(&self) -> u64;
 
     /// Writes some data into this `Hasher`


### PR DESCRIPTION
This commit enables writing a stable implementation of the `Hasher` trait as
well as actually calculating the hash of a vlaue in a stable fashion. The
signature is stabilized as-is.
