### PR TITLE
check: Warn users with nonzero RLIMIT_CORE

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -166,7 +166,7 @@ $(foreach file,$(wildcard $(S)src/doc/trpl/*.md), \
 ######################################################################
 
 # The main testing target. Tests lots of stuff.
-check: cleantmptestlogs cleantestlibs all check-stage2 tidy
+check: check-sanitycheck cleantmptestlogs cleantestlibs all check-stage2 tidy
 	$(Q)$(CFG_PYTHON) $(S)src/etc/check-summary.py tmp/*.log
 
 # As above but don't bother running tidy.
@@ -192,6 +192,11 @@ check-docs: cleantestlibs cleantmptestlogs check-stage2-docs
 # Some less critical tests that are not prone to breakage.
 # Not run as part of the normal test suite, but tested by bors on checkin.
 check-secondary: check-build-compiletest check-build-lexer-verifier check-lexer check-pretty
+
+.PHONY: check-sanitycheck
+
+check-sanitycheck:
+	$(Q)$(CFG_PYTHON) $(S)src/etc/check-sanitycheck.py
 
 # check + check-secondary.
 #

--- a/src/etc/check-sanitycheck.py
+++ b/src/etc/check-sanitycheck.py
@@ -1,4 +1,15 @@
 #!/usr/bin/env python
+#
+# Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
 import os
 import sys
 import functools

--- a/src/etc/check-sanitycheck.py
+++ b/src/etc/check-sanitycheck.py
@@ -39,7 +39,7 @@ def only_on(platforms):
 def check_rlimit_core():
     soft, hard = resource.getrlimit(resource.RLIMIT_CORE)
     if soft > 0:
-        error_unless_permitted('ALLOW_NONZERO_ULIMIT',
+        error_unless_permitted('ALLOW_NONZERO_RLIMIT_CORE',
           ("The rust test suite will segfault many rustc's in the debuginfo phase.\n"
            "set ALLOW_NONZERO_ULIMIT to ignore this warning\n"))
 

--- a/src/etc/check-sanitycheck.py
+++ b/src/etc/check-sanitycheck.py
@@ -39,9 +39,11 @@ def only_on(platforms):
 def check_rlimit_core():
     soft, hard = resource.getrlimit(resource.RLIMIT_CORE)
     if soft > 0:
-        error_unless_permitted('ALLOW_NONZERO_RLIMIT_CORE',
-          ("The rust test suite will segfault many rustc's in the debuginfo phase.\n"
-           "set ALLOW_NONZERO_ULIMIT to ignore this warning\n"))
+        error_unless_permitted('ALLOW_NONZERO_RLIMIT_CORE', """\
+RLIMIT_CORE is set to a nonzero value (%d). During debuginfo, the test suite
+will segfault many rustc's, creating many potentially large core files.
+set ALLOW_NONZERO_RLIMIT_CORE to ignore this warning
+""" % (soft))
 
 
 def main():

--- a/src/etc/check-sanitycheck.py
+++ b/src/etc/check-sanitycheck.py
@@ -29,7 +29,7 @@ def only_on(platforms):
     def decorator(func):
         @functools.wraps(func)
         def inner():
-            if sys.platform in platforms:
+            if any(map(lambda x: sys.platform.startswith(x), platforms)):
                 func()
         return inner
     return decorator

--- a/src/etc/check-sanitycheck.py
+++ b/src/etc/check-sanitycheck.py
@@ -35,7 +35,7 @@ def only_on(platforms):
     return decorator
 
 
-@only_on(('linux', 'darwin'))
+@only_on(('linux', 'darwin', 'freebsd', 'openbsd'))
 def check_rlimit_core():
     soft, hard = resource.getrlimit(resource.RLIMIT_CORE)
     if soft > 0:

--- a/src/etc/check-sanitycheck.py
+++ b/src/etc/check-sanitycheck.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+import os
+import sys
+import functools
+import resource
+
+STATUS = 0
+
+
+def error_unless_permitted(env_var, message):
+    global STATUS
+    if not os.getenv(env_var):
+        sys.stderr.write(message)
+        STATUS = 1
+
+
+def only_on(platforms):
+    def decorator(func):
+        @functools.wraps(func)
+        def inner():
+            if sys.platform in platforms:
+                func()
+        return inner
+    return decorator
+
+
+@only_on(('linux', 'darwin'))
+def check_rlimit_core():
+    soft, hard = resource.getrlimit(resource.RLIMIT_CORE)
+    if soft > 0:
+        error_unless_permitted('ALLOW_NONZERO_ULIMIT',
+          ("The rust test suite will segfault many rustc's in the debuginfo phase.\n"
+           "set ALLOW_NONZERO_ULIMIT to ignore this warning\n"))
+
+
+def main():
+    check_rlimit_core()
+
+if __name__ == '__main__':
+    main()
+    sys.exit(STATUS)


### PR DESCRIPTION
Rationale for this, is that I lurked `ulimit -c unlimited` into my .profile to debug an unrelated crash, that I kept forgetting to set before hand. I then ran the test suite and discovered that I had 150 gigs of core dumps in `/cores`.

Very open to another approach, or to setting the limit to something higher than 0, but I think it would be nice if the build system tried to save you from yourself here.
