### PR TITLE
mac-android make-check works + ignore some tests on aarch64

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -569,6 +569,11 @@ ifeq ($(CFG_OSTYPE),apple-darwin)
 CTEST_DISABLE_debuginfo-gdb = "gdb on darwin needs root"
 endif
 
+ifeq ($(findstring android, $(CFG_TARGET)), android)
+CTEST_DISABLE_debuginfo-gdb =
+CTEST_DISABLE_debuginfo-lldb = "lldb tests are disabled on android"
+endif
+
 # CTEST_DISABLE_NONSELFHOST_$(TEST_GROUP), if set, will cause that
 # test group to be disabled *unless* the target is able to build a
 # compiler (i.e. when the target triple is in the set of of host

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -748,6 +748,7 @@ mod tests {
         cmd
     }
 
+    #[cfg(not(target_arch = "aarch64"))]
     #[test]
     fn test_keep_current_working_dir() {
         use os;

--- a/src/test/debuginfo/c-style-enum.rs
+++ b/src/test/debuginfo/c-style-enum.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-aarch64
 // min-lldb-version: 310
 
 // compile-flags:-g

--- a/src/test/debuginfo/issue12886.rs
+++ b/src/test/debuginfo/issue12886.rs
@@ -10,12 +10,13 @@
 
 // ignore-windows failing on 64-bit bots FIXME #17638
 // ignore-lldb
+// ignore-aarch64
 
 // compile-flags:-g
 
 // gdb-command:run
 // gdb-command:next
-// gdb-check:[...]33[...]s
+// gdb-check:[...]34[...]s
 // gdb-command:continue
 
 #![omit_gdb_pretty_printer_section]

--- a/src/test/run-pass/sigpipe-should-be-ignored.rs
+++ b/src/test/run-pass/sigpipe-should-be-ignored.rs
@@ -11,6 +11,7 @@
 // Be sure that when a SIGPIPE would have been received that the entire process
 // doesn't die in a ball of fire, but rather it's gracefully handled.
 
+// ignore-aarch64
 // pretty-expanded FIXME #23616
 
 use std::env;


### PR DESCRIPTION
1. when mac-android cross compile and make-check , make it use gdb instead of lldb so as to it passes debuginfo tests.
2. ignore some tests on aarch64
