### PR TITLE
Update docs to fix various 404s

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -92,7 +92,7 @@
 //! useful value.
 //!
 //! Consider the `write_line` method defined for I/O types
-//! by the [`Writer`](../io/trait.Writer.html) trait:
+//! by the [`Writer`](../old_io/trait.Writer.html) trait:
 //!
 //! ```
 //! # #![feature(old_io)]

--- a/src/librustc/plugin/mod.rs
+++ b/src/librustc/plugin/mod.rs
@@ -47,7 +47,7 @@
 //! #![plugin(myplugin)]
 //! ```
 //!
-//! See [the compiler plugin guide](../../guide-plugin.html)
+//! See the [Plugins Chapter](../../book/plugins.html) of the book
 //! for more examples.
 
 pub use self::registry::Registry;

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -67,9 +67,8 @@
 //! module encapsulates the platform-specific rules for dealing
 //! with file paths.
 //!
-//! `std` also includes modules for interoperating with the
-//! C language: [`c_str`](c_str/index.html) and
-//! [`c_vec`](c_vec/index.html).
+//! `std` also includes the [`ffi`](ffi/index.html) module for interoperating
+//! with the C language.
 //!
 //! ## Concurrency, I/O, and the runtime
 //!


### PR DESCRIPTION
Found a few 404s that seemed like simple fixes:

In footer.inc, certain 404 pages were 404ing on the request to jquery.js and playpen.js. This is easily demonstrated by visiting http://doc.rust-lang.org/foo then http://doc.rust-lang.org/foo/bar. The latter 404s, looking for foo/jquery.js.

The Result docs use old_io Writer as an example. Fix the link to old_io Writer. There's probably an effort to update the example away from a deprecated api but this was a simple fix.

rustc/plugin was pointing at the old guide and it was a broken link anyways (plugin vs plugins). Point at the book instead.

The main page of the API docs referenced c_{str,vec}. Looks like these were deleted in 25d5a3a19423fee01787de87a56d185dd4e0a4e7. Point at ffi docs instead.
