### PR TITLE
doc: change 0u32..10 to 0..10

### DIFF
--- a/src/doc/trpl/looping.md
+++ b/src/doc/trpl/looping.md
@@ -123,7 +123,7 @@ We now loop forever with `loop` and use `break` to break out early.
 iteration. This will only print the odd numbers:
 
 ```{rust}
-for x in 0u32..10 {
+for x in 0..10 {
     if x % 2 == 0 { continue; }
 
     println!("{}", x);


### PR DESCRIPTION
Was reading the 'Looping' section of the book and was puzzled why the last example uses `0u32..10` when the others don't.  Tried it out without and it seems to work, so I figured it should just be `0..10`.  If there is a reason it needs to be `0u32..10` it should be explained in the text (I'd offer to do it but I have no idea).

r? @steveklabnik 
