### PR TITLE
rustc: Remove support for old_impl_check

### DIFF
--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2208,18 +2208,10 @@ fn enforce_impl_ty_params_are_constrained<'tcx>(tcx: &ty::ctxt<'tcx>,
                                      idx: index as u32,
                                      name: ty_param.ident.name };
         if !input_parameters.contains(&param_ty) {
-            if ty::has_attr(tcx, impl_def_id, "old_impl_check") {
-                tcx.sess.span_warn(
-                    ty_param.span,
-                    &format!("the type parameter `{}` is not constrained by the \
-                              impl trait, self type, or predicates",
-                             param_ty.user_string(tcx)));
-            } else {
-                span_err!(tcx.sess, ty_param.span, E0207,
-                    "the type parameter `{}` is not constrained by the \
-                             impl trait, self type, or predicates",
-                            param_ty.user_string(tcx));
-            }
+            span_err!(tcx.sess, ty_param.span, E0207,
+                "the type parameter `{}` is not constrained by the \
+                         impl trait, self type, or predicates",
+                        param_ty.user_string(tcx));
         }
     }
 }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -114,7 +114,6 @@
 #![feature(lang_items)]
 #![feature(libc)]
 #![feature(linkage, thread_local, asm)]
-#![feature(old_impl_check)]
 #![feature(optin_builtin_traits)]
 #![feature(rand)]
 #![feature(staged_api)]

--- a/src/libstd/old_io/net/pipe.rs
+++ b/src/libstd/old_io/net/pipe.rs
@@ -202,7 +202,7 @@ impl UnixListener {
     }
 }
 
-impl Listener<UnixStream, UnixAcceptor> for UnixListener {
+impl Listener<UnixAcceptor> for UnixListener {
     fn listen(self) -> IoResult<UnixAcceptor> {
         self.inner.listen()
             .map(|inner| UnixAcceptor { inner: inner })
@@ -250,7 +250,8 @@ impl UnixAcceptor {
     }
 }
 
-impl Acceptor<UnixStream> for UnixAcceptor {
+impl Acceptor for UnixAcceptor {
+    type Connection = UnixStream;
     fn accept(&mut self) -> IoResult<UnixStream> {
         self.inner.accept().map(|s| {
             UnixStream { inner: s }

--- a/src/libstd/old_io/net/tcp.rs
+++ b/src/libstd/old_io/net/tcp.rs
@@ -338,7 +338,7 @@ impl TcpListener {
     }
 }
 
-impl Listener<TcpStream, TcpAcceptor> for TcpListener {
+impl Listener<TcpAcceptor> for TcpListener {
     fn listen(self) -> IoResult<TcpAcceptor> {
         self.inner.listen(128).map(|a| TcpAcceptor { inner: a })
     }
@@ -453,7 +453,8 @@ impl TcpAcceptor {
     }
 }
 
-impl Acceptor<TcpStream> for TcpAcceptor {
+impl Acceptor for TcpAcceptor {
+    type Connection = TcpStream;
     fn accept(&mut self) -> IoResult<TcpStream> {
         self.inner.accept().map(TcpStream::new)
     }

--- a/src/libstd/old_io/result.rs
+++ b/src/libstd/old_io/result.rs
@@ -58,7 +58,7 @@ impl<S: Seek> Seek for IoResult<S> {
     }
 }
 
-impl<T, A: Acceptor<T>, L: Listener<T, A>> Listener<T, A> for IoResult<L> {
+impl<A: Acceptor, L: Listener<A>> Listener<A> for IoResult<L> {
     fn listen(self) -> IoResult<A> {
         match self {
             Ok(listener) => listener.listen(),
@@ -67,8 +67,9 @@ impl<T, A: Acceptor<T>, L: Listener<T, A>> Listener<T, A> for IoResult<L> {
     }
 }
 
-impl<T, A: Acceptor<T>> Acceptor<T> for IoResult<A> {
-    fn accept(&mut self) -> IoResult<T> {
+impl<A: Acceptor> Acceptor for IoResult<A> {
+    type Connection = A::Connection;
+    fn accept(&mut self) -> IoResult<A::Connection> {
         match *self {
             Ok(ref mut acceptor) => acceptor.accept(),
             Err(ref e) => Err(e.clone()),

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -102,9 +102,6 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Status)] = &[
     // A way to temporarily opt out of the new orphan rules. This will *never* be accepted.
     ("old_orphan_check", "1.0.0", Deprecated),
 
-    // A way to temporarily opt out of the new impl rules. This will *never* be accepted.
-    ("old_impl_check", "1.0.0", Deprecated),
-
     // OIBIT specific features
     ("optin_builtin_traits", "1.0.0", Active),
 
@@ -280,7 +277,6 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType)] = &[
 
     // FIXME: #19470 this shouldn't be needed forever
     ("old_orphan_check", Whitelisted),
-    ("old_impl_check", Whitelisted),
     ("rustc_paren_sugar", Whitelisted), // FIXME: #18101 temporary unboxed closure hack
 
     // Crate level attributes
@@ -594,13 +590,6 @@ impl<'a, 'v> Visitor<'v> for PostExpansionVisitor<'a> {
                         "old_orphan_check",
                         i.span,
                         "the new orphan check rules will eventually be strictly enforced");
-                }
-
-                if attr::contains_name(&i.attrs[..],
-                                       "old_impl_check") {
-                    self.gate_feature("old_impl_check",
-                                      i.span,
-                                      "`#[old_impl_check]` will be removed in the future");
                 }
             }
 


### PR DESCRIPTION
This commit removes compiler support for the `old_impl_check` attribute which
should in theory be entirely removed now. The last remaining use of it in the
standard library has been updated by moving the type parameter on the
`old_io::Acceptor` trait into an associated type. As a result, this is a
breaking change for all current users of the deprecated `old_io::Acceptor`
trait. Code can be migrated by using the `Connection` associated type instead.

[breaking-change]
