### PR TITLE
syntax: Remove support for #[should_fail]

### DIFF
--- a/src/doc/trpl/documentation.md
+++ b/src/doc/trpl/documentation.md
@@ -352,7 +352,7 @@ Here’s an example of documenting a macro:
 /// # }
 /// ```
 ///
-/// ```should_fail
+/// ```should_panic
 /// # #[macro_use] extern crate foo;
 /// # fn main() {
 /// panic_unless!(true == false, “I’m broken.”);

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -320,7 +320,7 @@ impl<T> Option<T> {
     /// assert_eq!(x.expect("the world is ending"), "value");
     /// ```
     ///
-    /// ```{.should_fail}
+    /// ```{.should_panic}
     /// let x: Option<&str> = None;
     /// x.expect("the world is ending"); // panics with `world is ending`
     /// ```
@@ -352,7 +352,7 @@ impl<T> Option<T> {
     /// assert_eq!(x.unwrap(), "air");
     /// ```
     ///
-    /// ```{.should_fail}
+    /// ```{.should_panic}
     /// let x: Option<&str> = None;
     /// assert_eq!(x.unwrap(), "air"); // fails
     /// ```

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -762,7 +762,7 @@ impl<T, E: fmt::Debug> Result<T, E> {
     /// assert_eq!(x.unwrap(), 2);
     /// ```
     ///
-    /// ```{.should_fail}
+    /// ```{.should_panic}
     /// let x: Result<u32, &str> = Err("emergency failure");
     /// x.unwrap(); // panics with `emergency failure`
     /// ```
@@ -788,7 +788,7 @@ impl<T: fmt::Debug, E> Result<T, E> {
     ///
     /// # Examples
     ///
-    /// ```{.should_fail}
+    /// ```{.should_panic}
     /// let x: Result<u32, &str> = Ok(2);
     /// x.unwrap_err(); // panics with `2`
     /// ```

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -356,7 +356,7 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector) {
             });
             let text = lines.collect::<Vec<&str>>().connect("\n");
             tests.add_test(text.to_string(),
-                           block_info.should_fail, block_info.no_run,
+                           block_info.should_panic, block_info.no_run,
                            block_info.ignore, block_info.test_harness);
         }
     }
@@ -397,7 +397,7 @@ pub fn find_testable_code(doc: &str, tests: &mut ::test::Collector) {
 
 #[derive(Eq, PartialEq, Clone, Debug)]
 struct LangString {
-    should_fail: bool,
+    should_panic: bool,
     no_run: bool,
     ignore: bool,
     rust: bool,
@@ -407,7 +407,7 @@ struct LangString {
 impl LangString {
     fn all_false() -> LangString {
         LangString {
-            should_fail: false,
+            should_panic: false,
             no_run: false,
             ignore: false,
             rust: true,  // NB This used to be `notrust = false`
@@ -427,7 +427,7 @@ impl LangString {
         for token in tokens {
             match token {
                 "" => {},
-                "should_fail" => { data.should_fail = true; seen_rust_tags = true; },
+                "should_panic" => { data.should_panic = true; seen_rust_tags = true; },
                 "no_run" => { data.no_run = true; seen_rust_tags = true; },
                 "ignore" => { data.ignore = true; seen_rust_tags = true; },
                 "rust" => { data.rust = true; seen_rust_tags = true; },
@@ -528,9 +528,9 @@ mod tests {
     #[test]
     fn test_lang_string_parse() {
         fn t(s: &str,
-            should_fail: bool, no_run: bool, ignore: bool, rust: bool, test_harness: bool) {
+            should_panic: bool, no_run: bool, ignore: bool, rust: bool, test_harness: bool) {
             assert_eq!(LangString::parse(s), LangString {
-                should_fail: should_fail,
+                should_panic: should_panic,
                 no_run: no_run,
                 ignore: ignore,
                 rust: rust,
@@ -538,16 +538,16 @@ mod tests {
             })
         }
 
-        // marker                | should_fail | no_run | ignore | rust | test_harness
+        // marker                | should_panic| no_run | ignore | rust | test_harness
         t("",                      false,        false,   false,   true,  false);
         t("rust",                  false,        false,   false,   true,  false);
         t("sh",                    false,        false,   false,   false, false);
         t("ignore",                false,        false,   true,    true,  false);
-        t("should_fail",           true,         false,   false,   true,  false);
+        t("should_panic",          true,         false,   false,   true,  false);
         t("no_run",                false,        true,    false,   true,  false);
         t("test_harness",          false,        false,   false,   true,  true);
         t("{.no_run .example}",    false,        true,    false,   true,  false);
-        t("{.sh .should_fail}",    true,         false,   false,   true,  false);
+        t("{.sh .should_panic}",   true,         false,   false,   true,  false);
         t("{.example .rust}",      false,        false,   false,   true,  false);
         t("{.test_harness .rust}", false,        false,   false,   true,  true);
     }

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -681,7 +681,7 @@ mod tests {
     }
 
     #[test]
-    #[should_fail]
+    #[should_panic]
     fn dont_panic_in_drop_on_panicked_flush() {
         struct FailFlushWriter;
 

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -28,7 +28,7 @@
 ///
 /// # Examples
 ///
-/// ```should_fail
+/// ```should_panic
 /// # #![allow(unreachable_code)]
 /// panic!();
 /// panic!("this is a terrible mistake!");

--- a/src/libstd/old_io/fs.rs
+++ b/src/libstd/old_io/fs.rs
@@ -105,7 +105,7 @@ impl File {
     ///
     /// # Examples
     ///
-    /// ```rust,should_fail
+    /// ```rust,should_panic
     /// # #![feature(old_io, old_path)]
     /// use std::old_io::*;
     /// use std::old_path::Path;

--- a/src/libstd/old_io/process.rs
+++ b/src/libstd/old_io/process.rs
@@ -60,7 +60,7 @@ use thread;
 ///
 /// # Examples
 ///
-/// ```should_fail
+/// ```should_panic
 /// # #![feature(old_io)]
 /// use std::old_io::*;
 ///

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -37,7 +37,7 @@ use thread;
 ///
 /// # Examples
 ///
-/// ```should_fail
+/// ```should_panic
 /// # #![feature(process)]
 ///
 /// use std::process::Command;

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -821,13 +821,13 @@ mod test {
     }
 
     #[test]
-    #[should_fail]
+    #[should_panic]
     fn test_scoped_panic() {
         thread::scoped(|| panic!()).join();
     }
 
     #[test]
-    #[should_fail]
+    #[should_panic]
     fn test_scoped_implicit_panic() {
         let _ = thread::scoped(|| panic!());
     }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -201,7 +201,6 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType)] = &[
     ("no_mangle", Normal),
     ("no_link", Normal),
     ("derive", Normal),
-    ("should_fail", Normal),
     ("should_panic", Normal),
     ("ignore", Normal),
     ("no_implicit_prelude", Normal),

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -134,7 +134,7 @@ impl<'a> fold::Folder for TestHarnessGenerator<'a> {
                         path: self.cx.path.clone(),
                         bench: is_bench_fn(&self.cx, &*i),
                         ignore: is_ignored(&*i),
-                        should_panic: should_panic(&*i, self.cx.span_diagnostic)
+                        should_panic: should_panic(&*i)
                     };
                     self.cx.testfns.push(test);
                     self.tests.push(i.ident);
@@ -386,16 +386,8 @@ fn is_ignored(i: &ast::Item) -> bool {
     i.attrs.iter().any(|attr| attr.check_name("ignore"))
 }
 
-fn should_panic(i: &ast::Item, diag: &diagnostic::SpanHandler) -> ShouldPanic {
-    match i.attrs.iter().find(|attr| {
-        if attr.check_name("should_panic") { return true; }
-        if attr.check_name("should_fail") {
-            diag.span_warn(attr.span, "`#[should_fail]` is deprecated. Use `#[should_panic]` \
-                                       instead");
-            return true;
-        }
-        false
-    }) {
+fn should_panic(i: &ast::Item) -> ShouldPanic {
+    match i.attrs.iter().find(|attr| attr.check_name("should_panic")) {
         Some(attr) => {
             let msg = attr.meta_item_list()
                 .and_then(|list| list.iter().find(|mi| mi.check_name("expected")))


### PR DESCRIPTION
This attribute has been deprecated in favor of #[should_panic]. This also
updates rustdoc to no longer accept the `should_fail` directive and instead
renames it to `should_panic`.
