### PR TITLE
Revise use of conversion traits

### DIFF
--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -69,6 +69,14 @@ impl<'a, T: ?Sized, U: ?Sized> AsRef<U> for &'a mut T where T: AsRef<U> {
     }
 }
 
+// FIXME (#23442): replace the above impls for &/&mut with the following more general one:
+// // As lifts over Deref
+// impl<D: ?Sized + Deref, U: ?Sized> AsRef<U> for D where D::Target: AsRef<U> {
+//     fn as_ref(&self) -> &U {
+//         self.deref().as_ref()
+//     }
+// }
+
 // AsMut implies Into
 impl<'a, T: ?Sized, U: ?Sized> Into<&'a mut U> for &'a mut T where T: AsMut<U> {
     fn into(self) -> &'a mut U {
@@ -82,6 +90,14 @@ impl<'a, T: ?Sized, U: ?Sized> AsMut<U> for &'a mut T where T: AsMut<U> {
         (*self).as_mut()
     }
 }
+
+// FIXME (#23442): replace the above impl for &mut with the following more general one:
+// // AsMut lifts over DerefMut
+// impl<D: ?Sized + Deref, U: ?Sized> AsMut<U> for D where D::Target: AsMut<U> {
+//     fn as_mut(&mut self) -> &mut U {
+//         self.deref_mut().as_mut()
+//     }
+// }
 
 // From implies Into
 impl<T, U> Into<U> for T where U: From<T> {

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -113,23 +113,9 @@ impl From<String> for OsString {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> From<&'a String> for OsString {
-    fn from(s: &'a String) -> OsString {
-        OsString { inner: Buf::from_str(s) }
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> From<&'a str> for OsString {
-    fn from(s: &'a str) -> OsString {
-        OsString { inner: Buf::from_str(s) }
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> From<&'a OsStr> for OsString {
-    fn from(s: &'a OsStr) -> OsString {
-        OsString { inner: s.inner.to_owned() }
+impl<'a, T: ?Sized + AsRef<OsStr>> From<&'a T> for OsString {
+    fn from(s: &'a T) -> OsString {
+        s.as_ref().to_os_string()
     }
 }
 

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1038,44 +1038,9 @@ impl PathBuf {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> From<&'a Path> for PathBuf {
-    fn from(s: &'a Path) -> PathBuf {
-        s.to_path_buf()
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> From<&'a str> for PathBuf {
-    fn from(s: &'a str) -> PathBuf {
-        PathBuf::from(OsString::from(s))
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> From<&'a String> for PathBuf {
-    fn from(s: &'a String) -> PathBuf {
-        PathBuf::from(OsString::from(s))
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl From<String> for PathBuf {
-    fn from(s: String) -> PathBuf {
-        PathBuf::from(OsString::from(s))
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> From<&'a OsStr> for PathBuf {
-    fn from(s: &'a OsStr) -> PathBuf {
-        PathBuf::from(OsString::from(s))
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<'a> From<&'a OsString> for PathBuf {
-    fn from(s: &'a OsString) -> PathBuf {
-        PathBuf::from(s.to_os_string())
+impl<'a, T: ?Sized + AsRef<OsStr>> From<&'a T> for PathBuf {
+    fn from(s: &'a T) -> PathBuf {
+        PathBuf::from(s.as_ref().to_os_string())
     }
 }
 
@@ -1083,6 +1048,13 @@ impl<'a> From<&'a OsString> for PathBuf {
 impl From<OsString> for PathBuf {
     fn from(s: OsString) -> PathBuf {
         PathBuf { inner: s }
+    }
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl From<String> for PathBuf {
+    fn from(s: String) -> PathBuf {
+        PathBuf::from(OsString::from(s))
     }
 }
 

--- a/src/libstd/sys/unix/os_str.rs
+++ b/src/libstd/sys/unix/os_str.rs
@@ -46,10 +46,6 @@ impl Buf {
         Buf { inner: s.into_bytes() }
     }
 
-    pub fn from_str(s: &str) -> Buf {
-        Buf { inner: s.as_bytes().to_vec() }
-    }
-
     pub fn as_slice(&self) -> &Slice {
         unsafe { mem::transmute(&*self.inner) }
     }

--- a/src/libstd/sys/windows/os_str.rs
+++ b/src/libstd/sys/windows/os_str.rs
@@ -45,10 +45,6 @@ impl Buf {
         Buf { inner: Wtf8Buf::from_string(s) }
     }
 
-    pub fn from_str(s: &str) -> Buf {
-        Buf { inner: Wtf8Buf::from_str(s) }
-    }
-
     pub fn as_slice(&self) -> &Slice {
         unsafe { mem::transmute(self.inner.as_slice()) }
     }


### PR DESCRIPTION
This commit revises `path` and `os_str` to use blanket impls for `From`
on reference types. This both cuts down on the number of required impls,
and means that you can pass through e.g. `T: AsRef<OsStr>` to
`PathBuf::from` without an intermediate call to `as_ref`.

It also makes a FIXME note for later generalizing the blanket impls for
`AsRef` and `AsMut` to use `Deref`/`DerefMut`, once it is possible to do
so.
