### PR TITLE
rustc: Remove support for `-l foo:static`

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -959,24 +959,6 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
     let libs = matches.opt_strs("l").into_iter().map(|s| {
         let mut parts = s.splitn(1, '=');
         let kind = parts.next().unwrap();
-        if let Some(name) = parts.next() {
-            let kind = match kind {
-                "dylib" => cstore::NativeUnknown,
-                "framework" => cstore::NativeFramework,
-                "static" => cstore::NativeStatic,
-                s => {
-                    early_error(&format!("unknown library kind `{}`, expected \
-                                          one of dylib, framework, or static",
-                                         s));
-                }
-            };
-            return (name.to_string(), kind)
-        }
-
-        // FIXME(acrichto) remove this once crates have stopped using it, this
-        //                 is deprecated behavior now.
-        let mut parts = s.rsplitn(1, ':');
-        let kind = parts.next().unwrap();
         let (name, kind) = match (parts.next(), kind) {
             (None, name) |
             (Some(name), "dylib") => (name, cstore::NativeUnknown),

--- a/src/test/compile-fail/manual-link-bad-form.rs
+++ b/src/test/compile-fail/manual-link-bad-form.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags:-l :static
+// compile-flags:-l static=
 // error-pattern: empty library name given via `-l`
 
 fn main() {

--- a/src/test/compile-fail/manual-link-bad-kind.rs
+++ b/src/test/compile-fail/manual-link-bad-kind.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags:-l foo:bar
+// compile-flags:-l bar=foo
 // error-pattern: unknown library kind `bar`, expected one of dylib, framework, or static
 
 fn main() {

--- a/src/test/compile-fail/manual-link-framework.rs
+++ b/src/test/compile-fail/manual-link-framework.rs
@@ -10,7 +10,7 @@
 
 // ignore-macos
 // ignore-ios
-// compile-flags:-l foo:framework
+// compile-flags:-l framework=foo
 // error-pattern: native frameworks are only available on OSX targets
 
 fn main() {


### PR DESCRIPTION
This syntax has been renamed to `-l static=foo` some time ago.
