### PR TITLE
alloc: Don't run some Arc doc tests

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -33,7 +33,7 @@
 //!
 //! Sharing some immutable data between tasks:
 //!
-//! ```
+//! ```no_run
 //! use std::sync::Arc;
 //! use std::thread;
 //!
@@ -50,7 +50,7 @@
 //!
 //! Sharing mutable data safely between tasks with a `Mutex`:
 //!
-//! ```
+//! ```no_run
 //! use std::sync::{Arc, Mutex};
 //! use std::thread;
 //!

--- a/src/test/run-pass/spawn-fn.rs
+++ b/src/test/run-pass/spawn-fn.rs
@@ -8,23 +8,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(std_misc)]
+use std::thread;
 
-use std::thread::Thread;
-
-fn x(s: String, n: int) {
+fn x(s: String, n: isize) {
     println!("{}", s);
     println!("{}", n);
 }
 
 pub fn main() {
-    let _t = Thread::spawn(|| x("hello from first spawned fn".to_string(), 65) );
-    let _t = Thread::spawn(|| x("hello from second spawned fn".to_string(), 66) );
-    let _t = Thread::spawn(|| x("hello from third spawned fn".to_string(), 67) );
-    let mut i: int = 30;
+    let _t = thread::scoped(|| x("hello from first spawned fn".to_string(), 65) );
+    let _t = thread::scoped(|| x("hello from second spawned fn".to_string(), 66) );
+    let _t = thread::scoped(|| x("hello from third spawned fn".to_string(), 67) );
+    let mut i = 30;
     while i > 0 {
         i = i - 1;
         println!("parent sleeping");
-        Thread::yield_now();
+        thread::yield_now();
     }
 }


### PR DESCRIPTION
Windows gets quite unhappy when a thread fails while the main thread is exiting,
frequently leading to process deadlock. This has been causing quite a few
deadlocks on the windows bots recently. The child threads are presumably failing
because the `println!` is failing due to the main thread being shut down.
