### PR TITLE
num: Derive Debug for Wrapping

### DIFF
--- a/src/libcore/num/wrapping.rs
+++ b/src/libcore/num/wrapping.rs
@@ -67,7 +67,7 @@ macro_rules! wrapping_impl {
 wrapping_impl! { uint u8 u16 u32 u64 int i8 i16 i32 i64 }
 
 #[unstable(feature = "core", reason = "may be removed, renamed, or relocated")]
-#[derive(PartialEq,Eq,PartialOrd,Ord,Clone,Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
 pub struct Wrapping<T>(pub T);
 
 impl<T:WrappingOps> Add for Wrapping<T> {


### PR DESCRIPTION
This allows `Wrapping<T>` to be used in `assert_eq!`, for example.

One of the tests (compile-fail/xc-private-method.rs) fails, but I can hardly imagine it is related to this change. I would also like to add a tests to ensure that `assert_eq!` compiles and keeps working in the future for `Wrapped<T>` values, but there appear to be no tests in libcore. What would be a good place to add such a test?
