### PR TITLE
Omit 'obsolete' note for a warning with -Awarning

### DIFF
--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -80,7 +80,8 @@ impl<'a> ParserObsoleteMethods for parser::Parser<'a> {
             self.span_warn(sp, &format!("obsolete syntax: {}", kind_str));
         }
 
-        if !self.obsolete_set.contains(&kind) {
+        if !self.obsolete_set.contains(&kind) &&
+            (error || self.sess.span_diagnostic.handler().can_emit_warnings) {
             self.sess
                 .span_diagnostic
                 .handler()


### PR DESCRIPTION
When emmitting a note, previously it was not known if the note was for an error or a
warning. If it was for a warning, then with `-Awarnings` it should not have been print.
The `emit_for` function allows someone to specify which level should determine its visibility.

An example:

``` rust
extern crate "std" as std2;
fn main() {}
```

When compiling with `-Awarnings`, this would previously emit `note: use an identifier not in quotes instead` (and nothing else).
With this patch, it will be completely silent as expected.
