### PR TITLE
Fix wording for `Option<T>.unwrap`

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -331,7 +331,7 @@ impl<T> Option<T> {
         }
     }
 
-    /// Returns the inner `T` of a `Some(T)`.
+    /// Moves the value `v` out of the `Option<T>` if the content of the `Option<T>` is a `Some(v)`.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Fixes #23713.
