### PR TITLE
std: Don't deadlock/panic on recursive prints

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -127,6 +127,7 @@
 #![feature(str_char)]
 #![feature(into_cow)]
 #![feature(slice_patterns)]
+#![feature(std_misc)]
 #![cfg_attr(test, feature(test, rustc_private, std_misc))]
 
 // Don't link to std. We are std.

--- a/src/test/run-pass/issue-23781.rs
+++ b/src/test/run-pass/issue-23781.rs
@@ -1,0 +1,38 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::fmt;
+
+struct Foo;
+impl fmt::Debug for Foo {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        println!("<Foo as Debug>::fmt()");
+
+        write!(fmt, "")
+    }
+}
+
+fn test1() {
+    let foo_str = format!("{:?}", Foo);
+
+    println!("{}", foo_str);
+}
+
+fn test2() {
+    println!("{:?}", Foo);
+}
+
+fn main() {
+    // This works fine
+    test1();
+
+    // This fails
+    test2();
+}


### PR DESCRIPTION
Previously a panic was generated for recursive prints due to a double-borrow of
a `RefCell`. This was solved by the second borrow's output being directed
towards the global stdout instead of the per-thread stdout (still experimental
functionality).

After this functionality was altered, however, recursive prints still deadlocked
due to the overridden `write_fmt` method which locked itself first and then
wrote all the data. This was fixed by removing the override of the `write_fmt`
method. This means that unlocked usage of `write!` on a `Stdout`/`Stderr` may be
slower due to acquiring more locks, but it's easy to make more performant with a
call to `.lock()`.

Closes #23781
