### PR TITLE
Make `std::error::Error` not inherit from Send

### DIFF
--- a/src/libcore/error.rs
+++ b/src/libcore/error.rs
@@ -87,7 +87,7 @@ use fmt::{Debug, Display};
 
 /// Base functionality for all errors in Rust.
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait Error: Debug + Display + Send {
+pub trait Error: Debug + Display {
     /// A short description of the error.
     ///
     /// The description should not contain newlines or sentence-ending


### PR DESCRIPTION
The Send bound is an unnecessary restriction, and though provided as a convenience, can't be removed by downstream code.

The removal of this bound is a [breaking-change] since it removes an implicit Send bound on all `E: Error` and all `Error` trait objects.

To migrate, consider if your code actually requires the Send bound and, if so, add it explicitly.

Fixes #23774

r? @aturon
