### PR TITLE
Update debug helpers and use it for stdlib collections

### DIFF
--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -904,14 +904,11 @@ impl<K: Ord, V: Ord> Ord for BTreeMap<K, V> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<K: Debug, V: Debug> Debug for BTreeMap<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "{{"));
-
-        for (i, (k, v)) in self.iter().enumerate() {
-            if i != 0 { try!(write!(f, ", ")); }
-            try!(write!(f, "{:?}: {:?}", *k, *v));
+        let mut builder = f.debug_map();
+        for (k, v) in self {
+            builder = builder.entry(k, v);
         }
-
-        write!(f, "}}")
+        builder.finish()
     }
 }
 

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -904,11 +904,7 @@ impl<K: Ord, V: Ord> Ord for BTreeMap<K, V> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<K: Debug, V: Debug> Debug for BTreeMap<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut builder = f.debug_map();
-        for (k, v) in self {
-            builder = builder.entry(k, v);
-        }
-        builder.finish()
+        self.iter().fold(f.debug_map(), |b, (k, v)| b.entry(k, v)).finish()
     }
 }
 

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -628,14 +628,11 @@ impl<'a, 'b, T: Ord + Clone> BitOr<&'b BTreeSet<T>> for &'a BTreeSet<T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Debug> Debug for BTreeSet<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "{{"));
-
-        for (i, x) in self.iter().enumerate() {
-            if i != 0 { try!(write!(f, ", ")); }
-            try!(write!(f, "{:?}", *x));
+        let mut builder = f.debug_set();
+        for x in self {
+            builder = builder.entry(x);
         }
-
-        write!(f, "}}")
+        builder.finish()
     }
 }
 

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -628,11 +628,7 @@ impl<'a, 'b, T: Ord + Clone> BitOr<&'b BTreeSet<T>> for &'a BTreeSet<T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Debug> Debug for BTreeSet<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut builder = f.debug_set();
-        for x in self {
-            builder = builder.entry(x);
-        }
-        builder.finish()
+        self.iter().fold(f.debug_set(), |b, e| b.entry(e)).finish()
     }
 }
 

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -40,6 +40,7 @@
 #![feature(str_char)]
 #![feature(convert)]
 #![feature(slice_patterns)]
+#![feature(debug_builders)]
 #![cfg_attr(test, feature(rand, rustc_private, test, hash, collections))]
 #![cfg_attr(test, allow(deprecated))] // rand
 

--- a/src/libcollections/linked_list.rs
+++ b/src/libcollections/linked_list.rs
@@ -927,14 +927,11 @@ impl<A: Clone> Clone for LinkedList<A> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: fmt::Debug> fmt::Debug for LinkedList<A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "["));
-
-        for (i, e) in self.iter().enumerate() {
-            if i != 0 { try!(write!(f, ", ")); }
-            try!(write!(f, "{:?}", *e));
+        let mut builder = f.debug_list();
+        for e in self {
+            builder = builder.entry(e);
         }
-
-        write!(f, "]")
+        builder.finish()
     }
 }
 

--- a/src/libcollections/linked_list.rs
+++ b/src/libcollections/linked_list.rs
@@ -927,11 +927,7 @@ impl<A: Clone> Clone for LinkedList<A> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: fmt::Debug> fmt::Debug for LinkedList<A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut builder = f.debug_list();
-        for e in self {
-            builder = builder.entry(e);
-        }
-        builder.finish()
+        self.iter().fold(f.debug_list(), |b, e| b.entry(e)).finish()
     }
 }
 

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -32,7 +32,7 @@ pub use self::num::radix;
 pub use self::num::Radix;
 pub use self::num::RadixFmt;
 
-pub use self::builders::{DebugStruct, DebugTuple, DebugSet, DebugMap};
+pub use self::builders::{DebugStruct, DebugTuple, DebugSet, DebugList, DebugMap};
 
 mod num;
 mod float;
@@ -644,7 +644,7 @@ impl<'a> Formatter<'a> {
     /// // prints "Foo { bar: 10, baz: "Hello World" }"
     /// println!("{:?}", Foo { bar: 10, baz: "Hello World".to_string() });
     /// ```
-    #[unstable(feature = "core", reason = "method was just created")]
+    #[unstable(feature = "debug_builders", reason = "method was just created")]
     #[inline]
     pub fn debug_struct<'b>(&'b mut self, name: &str) -> DebugStruct<'b, 'a> {
         builders::debug_struct_new(self, name)
@@ -673,10 +673,40 @@ impl<'a> Formatter<'a> {
     /// // prints "Foo(10, "Hello World")"
     /// println!("{:?}", Foo(10, "Hello World".to_string()));
     /// ```
-    #[unstable(feature = "core", reason = "method was just created")]
+    #[unstable(feature = "debug_builders", reason = "method was just created")]
     #[inline]
     pub fn debug_tuple<'b>(&'b mut self, name: &str) -> DebugTuple<'b, 'a> {
         builders::debug_tuple_new(self, name)
+    }
+
+    /// Creates a `DebugList` builder designed to assist with creation of
+    /// `fmt::Debug` implementations for list-like structures.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #![feature(debug_builders, core)]
+    /// use std::fmt;
+    ///
+    /// struct Foo(Vec<i32>);
+    ///
+    /// impl fmt::Debug for Foo {
+    ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    ///         let mut builder = fmt.debug_list();
+    ///         for i in &self.0 {
+    ///             builder = builder.entry(i);
+    ///         }
+    ///         builder.finish()
+    ///     }
+    /// }
+    ///
+    /// // prints "Foo { 10, 11 }"
+    /// println!("{:?}", Foo(vec![10, 11]));
+    /// ```
+    #[unstable(feature = "debug_builders", reason = "method was just created")]
+    #[inline]
+    pub fn debug_list<'b>(&'b mut self) -> DebugList<'b, 'a> {
+        builders::debug_list_new(self)
     }
 
     /// Creates a `DebugSet` builder designed to assist with creation of
@@ -692,7 +722,7 @@ impl<'a> Formatter<'a> {
     ///
     /// impl fmt::Debug for Foo {
     ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    ///         let mut builder = fmt.debug_set("Foo");
+    ///         let mut builder = fmt.debug_set();
     ///         for i in &self.0 {
     ///             builder = builder.entry(i);
     ///         }
@@ -703,10 +733,10 @@ impl<'a> Formatter<'a> {
     /// // prints "Foo { 10, 11 }"
     /// println!("{:?}", Foo(vec![10, 11]));
     /// ```
-    #[unstable(feature = "core", reason = "method was just created")]
+    #[unstable(feature = "debug_builders", reason = "method was just created")]
     #[inline]
-    pub fn debug_set<'b>(&'b mut self, name: &str) -> DebugSet<'b, 'a> {
-        builders::debug_set_new(self, name)
+    pub fn debug_set<'b>(&'b mut self) -> DebugSet<'b, 'a> {
+        builders::debug_set_new(self)
     }
 
     /// Creates a `DebugMap` builder designed to assist with creation of
@@ -722,7 +752,7 @@ impl<'a> Formatter<'a> {
     ///
     /// impl fmt::Debug for Foo {
     ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    ///         let mut builder = fmt.debug_map("Foo");
+    ///         let mut builder = fmt.debug_map();
     ///         for &(ref key, ref value) in &self.0 {
     ///             builder = builder.entry(key, value);
     ///         }
@@ -733,10 +763,10 @@ impl<'a> Formatter<'a> {
     /// // prints "Foo { "A": 10, "B": 11 }"
     /// println!("{:?}", Foo(vec![("A".to_string(), 10), ("B".to_string(), 11)]));
     /// ```
-    #[unstable(feature = "core", reason = "method was just created")]
+    #[unstable(feature = "debug_builders", reason = "method was just created")]
     #[inline]
-    pub fn debug_map<'b>(&'b mut self, name: &str) -> DebugMap<'b, 'a> {
-        builders::debug_map_new(self, name)
+    pub fn debug_map<'b>(&'b mut self) -> DebugMap<'b, 'a> {
+        builders::debug_map_new(self)
     }
 }
 

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -696,7 +696,7 @@ impl<'a> Formatter<'a> {
     ///     }
     /// }
     ///
-    /// // prints "Foo { 10, 11 }"
+    /// // prints "[10, 11]"
     /// println!("{:?}", Foo(vec![10, 11]));
     /// ```
     #[unstable(feature = "debug_builders", reason = "method was just created")]
@@ -722,7 +722,7 @@ impl<'a> Formatter<'a> {
     ///     }
     /// }
     ///
-    /// // prints "Foo { 10, 11 }"
+    /// // prints "{10, 11}"
     /// println!("{:?}", Foo(vec![10, 11]));
     /// ```
     #[unstable(feature = "debug_builders", reason = "method was just created")]
@@ -744,11 +744,11 @@ impl<'a> Formatter<'a> {
     ///
     /// impl fmt::Debug for Foo {
     ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    ///         self.0.iter().fold(fmt.debug_map(), |b, (k, v)| b.entry(k, v)).finish()
+    ///         self.0.iter().fold(fmt.debug_map(), |b, &(ref k, ref v)| b.entry(k, v)).finish()
     ///     }
     /// }
     ///
-    /// // prints "Foo { "A": 10, "B": 11 }"
+    /// // prints "{"A": 10, "B": 11}"
     /// println!("{:?}", Foo(vec![("A".to_string(), 10), ("B".to_string(), 11)]));
     /// ```
     #[unstable(feature = "debug_builders", reason = "method was just created")]

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -692,11 +692,7 @@ impl<'a> Formatter<'a> {
     ///
     /// impl fmt::Debug for Foo {
     ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    ///         let mut builder = fmt.debug_list();
-    ///         for i in &self.0 {
-    ///             builder = builder.entry(i);
-    ///         }
-    ///         builder.finish()
+    ///         self.0.iter().fold(fmt.debug_list(), |b, e| b.entry(e)).finish()
     ///     }
     /// }
     ///
@@ -722,11 +718,7 @@ impl<'a> Formatter<'a> {
     ///
     /// impl fmt::Debug for Foo {
     ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    ///         let mut builder = fmt.debug_set();
-    ///         for i in &self.0 {
-    ///             builder = builder.entry(i);
-    ///         }
-    ///         builder.finish()
+    ///         self.0.iter().fold(fmt.debug_set(), |b, e| b.entry(e)).finish()
     ///     }
     /// }
     ///
@@ -752,11 +744,7 @@ impl<'a> Formatter<'a> {
     ///
     /// impl fmt::Debug for Foo {
     ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    ///         let mut builder = fmt.debug_map();
-    ///         for &(ref key, ref value) in &self.0 {
-    ///             builder = builder.entry(key, value);
-    ///         }
-    ///         builder.finish()
+    ///         self.0.iter().fold(fmt.debug_map(), |b, (k, v)| b.entry(k, v)).finish()
     ///     }
     /// }
     ///

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1017,22 +1017,7 @@ impl<'a> Debug for &'a (any::Any+'a) {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Debug> Debug for [T] {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        if f.flags & (1 << (FlagV1::Alternate as u32)) == 0 {
-            try!(write!(f, "["));
-        }
-        let mut is_first = true;
-        for x in self {
-            if is_first {
-                is_first = false;
-            } else {
-                try!(write!(f, ", "));
-            }
-            try!(write!(f, "{:?}", *x))
-        }
-        if f.flags & (1 << (FlagV1::Alternate as u32)) == 0 {
-            try!(write!(f, "]"));
-        }
-        Ok(())
+        self.iter().fold(f.debug_list(), |b, e| b.entry(e)).finish()
     }
 }
 

--- a/src/libcoretest/fmt/builders.rs
+++ b/src/libcoretest/fmt/builders.rs
@@ -211,12 +211,12 @@ mod debug_map {
 
         impl fmt::Debug for Foo {
             fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                fmt.debug_map("Foo").finish()
+                fmt.debug_map().finish()
             }
         }
 
-        assert_eq!("Foo {}", format!("{:?}", Foo));
-        assert_eq!("Foo {}", format!("{:#?}", Foo));
+        assert_eq!("{}", format!("{:?}", Foo));
+        assert_eq!("{}", format!("{:#?}", Foo));
     }
 
     #[test]
@@ -225,15 +225,15 @@ mod debug_map {
 
         impl fmt::Debug for Foo {
             fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                fmt.debug_map("Foo")
+                fmt.debug_map()
                     .entry(&"bar", &true)
                     .finish()
             }
         }
 
-        assert_eq!("Foo { \"bar\": true }", format!("{:?}", Foo));
+        assert_eq!("{\"bar\": true}", format!("{:?}", Foo));
         assert_eq!(
-"Foo {
+"{
     \"bar\": true
 }",
                    format!("{:#?}", Foo));
@@ -245,16 +245,16 @@ mod debug_map {
 
         impl fmt::Debug for Foo {
             fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                fmt.debug_map("Foo")
+                fmt.debug_map()
                     .entry(&"bar", &true)
                     .entry(&10i32, &format_args!("{}/{}", 10i32, 20i32))
                     .finish()
             }
         }
 
-        assert_eq!("Foo { \"bar\": true, 10: 10/20 }", format!("{:?}", Foo));
+        assert_eq!("{\"bar\": true, 10: 10/20}", format!("{:?}", Foo));
         assert_eq!(
-"Foo {
+"{
     \"bar\": true,
     10: 10/20
 }",
@@ -267,7 +267,7 @@ mod debug_map {
 
         impl fmt::Debug for Foo {
             fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                fmt.debug_map("Foo")
+                fmt.debug_map()
                     .entry(&"bar", &true)
                     .entry(&10i32, &format_args!("{}/{}", 10i32, 20i32))
                     .finish()
@@ -278,23 +278,23 @@ mod debug_map {
 
         impl fmt::Debug for Bar {
             fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                fmt.debug_map("Bar")
+                fmt.debug_map()
                     .entry(&"foo", &Foo)
                     .entry(&Foo, &"world")
                     .finish()
             }
         }
 
-        assert_eq!("Bar { \"foo\": Foo { \"bar\": true, 10: 10/20 }, \
-                    Foo { \"bar\": true, 10: 10/20 }: \"world\" }",
+        assert_eq!("{\"foo\": {\"bar\": true, 10: 10/20}, \
+                    {\"bar\": true, 10: 10/20}: \"world\"}",
                    format!("{:?}", Bar));
         assert_eq!(
-"Bar {
-    \"foo\": Foo {
+"{
+    \"foo\": {
         \"bar\": true,
         10: 10/20
     },
-    Foo {
+    {
         \"bar\": true,
         10: 10/20
     }: \"world\"
@@ -312,12 +312,12 @@ mod debug_set {
 
         impl fmt::Debug for Foo {
             fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                fmt.debug_set("Foo").finish()
+                fmt.debug_set().finish()
             }
         }
 
-        assert_eq!("Foo {}", format!("{:?}", Foo));
-        assert_eq!("Foo {}", format!("{:#?}", Foo));
+        assert_eq!("{}", format!("{:?}", Foo));
+        assert_eq!("{}", format!("{:#?}", Foo));
     }
 
     #[test]
@@ -326,15 +326,15 @@ mod debug_set {
 
         impl fmt::Debug for Foo {
             fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                fmt.debug_set("Foo")
+                fmt.debug_set()
                     .entry(&true)
                     .finish()
             }
         }
 
-        assert_eq!("Foo { true }", format!("{:?}", Foo));
+        assert_eq!("{true}", format!("{:?}", Foo));
         assert_eq!(
-"Foo {
+"{
     true
 }",
                    format!("{:#?}", Foo));
@@ -346,16 +346,16 @@ mod debug_set {
 
         impl fmt::Debug for Foo {
             fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                fmt.debug_set("Foo")
+                fmt.debug_set()
                     .entry(&true)
                     .entry(&format_args!("{}/{}", 10i32, 20i32))
                     .finish()
             }
         }
 
-        assert_eq!("Foo { true, 10/20 }", format!("{:?}", Foo));
+        assert_eq!("{true, 10/20}", format!("{:?}", Foo));
         assert_eq!(
-"Foo {
+"{
     true,
     10/20
 }",
@@ -368,7 +368,7 @@ mod debug_set {
 
         impl fmt::Debug for Foo {
             fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                fmt.debug_set("Foo")
+                fmt.debug_set()
                     .entry(&true)
                     .entry(&format_args!("{}/{}", 10i32, 20i32))
                     .finish()
@@ -379,23 +379,120 @@ mod debug_set {
 
         impl fmt::Debug for Bar {
             fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                fmt.debug_set("Bar")
+                fmt.debug_set()
                     .entry(&Foo)
                     .entry(&"world")
                     .finish()
             }
         }
 
-        assert_eq!("Bar { Foo { true, 10/20 }, \"world\" }",
+        assert_eq!("{{true, 10/20}, \"world\"}",
                    format!("{:?}", Bar));
         assert_eq!(
-"Bar {
-    Foo {
+"{
+    {
         true,
         10/20
     },
     \"world\"
 }",
+                   format!("{:#?}", Bar));
+    }
+}
+
+mod debug_list {
+    use std::fmt;
+
+    #[test]
+    fn test_empty() {
+        struct Foo;
+
+        impl fmt::Debug for Foo {
+            fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                fmt.debug_list().finish()
+            }
+        }
+
+        assert_eq!("[]", format!("{:?}", Foo));
+        assert_eq!("[]", format!("{:#?}", Foo));
+    }
+
+    #[test]
+    fn test_single() {
+        struct Foo;
+
+        impl fmt::Debug for Foo {
+            fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                fmt.debug_list()
+                    .entry(&true)
+                    .finish()
+            }
+        }
+
+        assert_eq!("[true]", format!("{:?}", Foo));
+        assert_eq!(
+"[
+    true
+]",
+                   format!("{:#?}", Foo));
+    }
+
+    #[test]
+    fn test_multiple() {
+        struct Foo;
+
+        impl fmt::Debug for Foo {
+            fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                fmt.debug_list()
+                    .entry(&true)
+                    .entry(&format_args!("{}/{}", 10i32, 20i32))
+                    .finish()
+            }
+        }
+
+        assert_eq!("[true, 10/20]", format!("{:?}", Foo));
+        assert_eq!(
+"[
+    true,
+    10/20
+]",
+                   format!("{:#?}", Foo));
+    }
+
+    #[test]
+    fn test_nested() {
+        struct Foo;
+
+        impl fmt::Debug for Foo {
+            fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                fmt.debug_list()
+                    .entry(&true)
+                    .entry(&format_args!("{}/{}", 10i32, 20i32))
+                    .finish()
+            }
+        }
+
+        struct Bar;
+
+        impl fmt::Debug for Bar {
+            fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                fmt.debug_list()
+                    .entry(&Foo)
+                    .entry(&"world")
+                    .finish()
+            }
+        }
+
+        assert_eq!("[[true, 10/20], \"world\"]",
+                   format!("{:?}", Bar));
+        assert_eq!(
+"[
+    [
+        true,
+        10/20
+    ],
+    \"world\"
+]",
                    format!("{:#?}", Bar));
     }
 }

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1226,11 +1226,7 @@ impl<K, V, S> Debug for HashMap<K, V, S>
     where K: Eq + Hash + Debug, V: Debug, S: HashState
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut builder = f.debug_map();
-        for (k, v) in self.iter() {
-            builder = builder.entry(k, v);
-        }
-        builder.finish()
+        self.iter().fold(f.debug_map(), |b, (k, v)| b.entry(k, v)).finish()
     }
 }
 

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1226,14 +1226,11 @@ impl<K, V, S> Debug for HashMap<K, V, S>
     where K: Eq + Hash + Debug, V: Debug, S: HashState
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "{{"));
-
-        for (i, (k, v)) in self.iter().enumerate() {
-            if i != 0 { try!(write!(f, ", ")); }
-            try!(write!(f, "{:?}: {:?}", *k, *v));
+        let mut builder = f.debug_map();
+        for (k, v) in self.iter() {
+            builder = builder.entry(k, v);
         }
-
-        write!(f, "}}")
+        builder.finish()
     }
 }
 

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -614,14 +614,11 @@ impl<T, S> fmt::Debug for HashSet<T, S>
           S: HashState
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "{{"));
-
-        for (i, x) in self.iter().enumerate() {
-            if i != 0 { try!(write!(f, ", ")); }
-            try!(write!(f, "{:?}", *x));
+        let mut builder = f.debug_set();
+        for x in self {
+            builder = builder.entry(x);
         }
-
-        write!(f, "}}")
+        builder.finish()
     }
 }
 

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -614,11 +614,7 @@ impl<T, S> fmt::Debug for HashSet<T, S>
           S: HashState
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut builder = f.debug_set();
-        for x in self {
-            builder = builder.entry(x);
-        }
-        builder.finish()
+        self.iter().fold(f.debug_set(), |b, e| b.entry(e)).finish()
     }
 }
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -128,6 +128,7 @@
 #![feature(into_cow)]
 #![feature(slice_patterns)]
 #![feature(std_misc)]
+#![feature(debug_builders)]
 #![cfg_attr(test, feature(test, rustc_private, std_misc))]
 
 // Don't link to std. We are std.


### PR DESCRIPTION
The collections debug helpers no longer prefix output with the
collection name, in line with the current conventions for Debug
implementations. Implementations that want to preserve the current
behavior can simply add a `try!(write!(fmt, "TypeName "));` at the
beginning of the `fmt` method.

[breaking-change]
