### PR TITLE
Correct Phil Dawes email address

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -606,7 +606,7 @@ Peter Schuller <peter.schuller@infidyne.com>
 Peter Williams <peter@newton.cx>
 Peter Zotov <whitequark@whitequark.org>
 Petter Remen <petter.remen@gmail.com>
-Phil Dawes <pdawes@drw.com>
+Phil Dawes <phil@phildawes.net>
 Phil Ruffwind <rf@rufflewind.com>
 Philip Munksgaard <pmunksgaard@gmail.com>
 Philipp Brüschweiler <blei42@gmail.com>


### PR DESCRIPTION
Hello! I noticed that the email address in AUTHORS.txt doesn't point to my home email. Could somebody merge this patch to correct it please?

Thanks very much!
