### PR TITLE
Change the type of constants BYTES/BITS to usize

### DIFF
--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -191,17 +191,17 @@ fn blocks_for_bits(bits: usize) -> usize {
     //
     // Note that we can technically avoid this branch with the expression
     // `(nbits + u32::BITS - 1) / 32::BITS`, but if nbits is almost usize::MAX this will overflow.
-    if bits % u32::BITS as usize == 0 {
-        bits / u32::BITS as usize
+    if bits % u32::BITS == 0 {
+        bits / u32::BITS
     } else {
-        bits / u32::BITS as usize + 1
+        bits / u32::BITS + 1
     }
 }
 
 /// Computes the bitmask for the final word of the vector
 fn mask_for_bits(bits: usize) -> u32 {
     // Note especially that a perfect multiple of u32::BITS should mask all 1s.
-    !0 >> (u32::BITS as usize - bits % u32::BITS as usize) % u32::BITS as usize
+    !0 >> (u32::BITS - bits % u32::BITS) % u32::BITS
 }
 
 impl BitVec {
@@ -239,7 +239,7 @@ impl BitVec {
     /// An operation might screw up the unused bits in the last block of the
     /// `BitVec`. As per (3), it's assumed to be all 0s. This method fixes it up.
     fn fix_last_block(&mut self) {
-        let extra_bits = self.len() % u32::BITS as usize;
+        let extra_bits = self.len() % u32::BITS;
         if extra_bits > 0 {
             let mask = (1 << extra_bits) - 1;
             let storage_len = self.storage.len();
@@ -318,7 +318,7 @@ impl BitVec {
     ///                     false, false, true, false]));
     /// ```
     pub fn from_bytes(bytes: &[u8]) -> BitVec {
-        let len = bytes.len().checked_mul(u8::BITS as usize).expect("capacity overflow");
+        let len = bytes.len().checked_mul(u8::BITS).expect("capacity overflow");
         let mut bit_vec = BitVec::with_capacity(len);
         let complete_words = bytes.len() / 4;
         let extra_bytes = bytes.len() % 4;
@@ -387,8 +387,8 @@ impl BitVec {
         if i >= self.nbits {
             return None;
         }
-        let w = i / u32::BITS as usize;
-        let b = i % u32::BITS as usize;
+        let w = i / u32::BITS;
+        let b = i % u32::BITS;
         self.storage.get(w).map(|&block|
             (block & (1 << b)) != 0
         )
@@ -415,8 +415,8 @@ impl BitVec {
                reason = "panic semantics are likely to change in the future")]
     pub fn set(&mut self, i: usize, x: bool) {
         assert!(i < self.nbits);
-        let w = i / u32::BITS as usize;
-        let b = i % u32::BITS as usize;
+        let w = i / u32::BITS;
+        let b = i % u32::BITS;
         let flag = 1 << b;
         let val = if x { self.storage[w] | flag }
                   else { self.storage[w] & !flag };
@@ -812,7 +812,7 @@ impl BitVec {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn capacity(&self) -> usize {
-        self.storage.capacity().checked_mul(u32::BITS as usize).unwrap_or(usize::MAX)
+        self.storage.capacity().checked_mul(u32::BITS).unwrap_or(usize::MAX)
     }
 
     /// Grows the `BitVec` in-place, adding `n` copies of `value` to the `BitVec`.
@@ -843,7 +843,7 @@ impl BitVec {
 
         // Correct the old tail word, setting or clearing formerly unused bits
         let num_cur_blocks = blocks_for_bits(self.nbits);
-        if self.nbits % u32::BITS as usize > 0 {
+        if self.nbits % u32::BITS > 0 {
             let mask = mask_for_bits(self.nbits);
             if value {
                 self.storage[num_cur_blocks - 1] |= !mask;
@@ -893,7 +893,7 @@ impl BitVec {
             // (3)
             self.set(i, false);
             self.nbits = i;
-            if self.nbits % u32::BITS as usize == 0 {
+            if self.nbits % u32::BITS == 0 {
                 // (2)
                 self.storage.pop();
             }
@@ -916,7 +916,7 @@ impl BitVec {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn push(&mut self, elem: bool) {
-        if self.nbits % u32::BITS as usize == 0 {
+        if self.nbits % u32::BITS == 0 {
             self.storage.push(0);
         }
         let insert_pos = self.nbits;
@@ -1442,7 +1442,7 @@ impl BitSet {
         // Truncate
         let trunc_len = cmp::max(old_len - n, 1);
         bit_vec.storage.truncate(trunc_len);
-        bit_vec.nbits = trunc_len * u32::BITS as usize;
+        bit_vec.nbits = trunc_len * u32::BITS;
     }
 
     /// Iterator over each u32 stored in the `BitSet`.
@@ -1880,13 +1880,13 @@ impl<'a> Iterator for TwoBitPositions<'a> {
     fn next(&mut self) -> Option<usize> {
         while self.next_idx < self.set.bit_vec.len() ||
               self.next_idx < self.other.bit_vec.len() {
-            let bit_idx = self.next_idx % u32::BITS as usize;
+            let bit_idx = self.next_idx % u32::BITS;
             if bit_idx == 0 {
                 let s_bit_vec = &self.set.bit_vec;
                 let o_bit_vec = &self.other.bit_vec;
                 // Merging the two words is a bit of an awkward dance since
                 // one BitVec might be longer than the other
-                let word_idx = self.next_idx / u32::BITS as usize;
+                let word_idx = self.next_idx / u32::BITS;
                 let w1 = if word_idx < s_bit_vec.storage.len() {
                              s_bit_vec.storage[word_idx]
                          } else { 0 };

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -83,7 +83,7 @@ pub trait CLike {
 fn bit<E:CLike>(e: &E) -> usize {
     use core::usize;
     let value = e.to_usize();
-    assert!(value < usize::BITS as usize,
+    assert!(value < usize::BITS,
             "EnumSet only supports up to {} variants.", usize::BITS - 1);
     1 << value
 }

--- a/src/libcollectionstest/bit/set.rs
+++ b/src/libcollectionstest/bit/set.rs
@@ -408,7 +408,7 @@ mod bench {
         let mut bit_vec = BitSet::new();
         b.iter(|| {
             for _ in 0..100 {
-                bit_vec.insert((r.next_u32() as usize) % u32::BITS as usize);
+                bit_vec.insert((r.next_u32() as usize) % u32::BITS);
             }
             black_box(&bit_vec);
         });

--- a/src/libcollectionstest/bit/vec.rs
+++ b/src/libcollectionstest/bit/vec.rs
@@ -541,43 +541,43 @@ fn test_big_bit_vec_tests() {
 
 #[test]
 fn test_bit_vec_push_pop() {
-    let mut s = BitVec::from_elem(5 * u32::BITS as usize - 2, false);
-    assert_eq!(s.len(), 5 * u32::BITS as usize - 2);
-    assert_eq!(s[5 * u32::BITS as usize - 3], false);
+    let mut s = BitVec::from_elem(5 * u32::BITS - 2, false);
+    assert_eq!(s.len(), 5 * u32::BITS - 2);
+    assert_eq!(s[5 * u32::BITS - 3], false);
     s.push(true);
     s.push(true);
-    assert_eq!(s[5 * u32::BITS as usize - 2], true);
-    assert_eq!(s[5 * u32::BITS as usize - 1], true);
+    assert_eq!(s[5 * u32::BITS - 2], true);
+    assert_eq!(s[5 * u32::BITS - 1], true);
     // Here the internal vector will need to be extended
     s.push(false);
-    assert_eq!(s[5 * u32::BITS as usize], false);
+    assert_eq!(s[5 * u32::BITS], false);
     s.push(false);
-    assert_eq!(s[5 * u32::BITS as usize + 1], false);
-    assert_eq!(s.len(), 5 * u32::BITS as usize + 2);
+    assert_eq!(s[5 * u32::BITS + 1], false);
+    assert_eq!(s.len(), 5 * u32::BITS + 2);
     // Pop it all off
     assert_eq!(s.pop(), Some(false));
     assert_eq!(s.pop(), Some(false));
     assert_eq!(s.pop(), Some(true));
     assert_eq!(s.pop(), Some(true));
-    assert_eq!(s.len(), 5 * u32::BITS as usize - 2);
+    assert_eq!(s.len(), 5 * u32::BITS - 2);
 }
 
 #[test]
 fn test_bit_vec_truncate() {
-    let mut s = BitVec::from_elem(5 * u32::BITS as usize, true);
+    let mut s = BitVec::from_elem(5 * u32::BITS, true);
 
-    assert_eq!(s, BitVec::from_elem(5 * u32::BITS as usize, true));
-    assert_eq!(s.len(), 5 * u32::BITS as usize);
-    s.truncate(4 * u32::BITS as usize);
-    assert_eq!(s, BitVec::from_elem(4 * u32::BITS as usize, true));
-    assert_eq!(s.len(), 4 * u32::BITS as usize);
+    assert_eq!(s, BitVec::from_elem(5 * u32::BITS, true));
+    assert_eq!(s.len(), 5 * u32::BITS);
+    s.truncate(4 * u32::BITS);
+    assert_eq!(s, BitVec::from_elem(4 * u32::BITS, true));
+    assert_eq!(s.len(), 4 * u32::BITS);
     // Truncating to a size > s.len() should be a noop
-    s.truncate(5 * u32::BITS as usize);
-    assert_eq!(s, BitVec::from_elem(4 * u32::BITS as usize, true));
-    assert_eq!(s.len(), 4 * u32::BITS as usize);
-    s.truncate(3 * u32::BITS as usize - 10);
-    assert_eq!(s, BitVec::from_elem(3 * u32::BITS as usize - 10, true));
-    assert_eq!(s.len(), 3 * u32::BITS as usize - 10);
+    s.truncate(5 * u32::BITS);
+    assert_eq!(s, BitVec::from_elem(4 * u32::BITS, true));
+    assert_eq!(s.len(), 4 * u32::BITS);
+    s.truncate(3 * u32::BITS - 10);
+    assert_eq!(s, BitVec::from_elem(3 * u32::BITS - 10, true));
+    assert_eq!(s.len(), 3 * u32::BITS - 10);
     s.truncate(0);
     assert_eq!(s, BitVec::from_elem(0, true));
     assert_eq!(s.len(), 0);
@@ -585,26 +585,26 @@ fn test_bit_vec_truncate() {
 
 #[test]
 fn test_bit_vec_reserve() {
-    let mut s = BitVec::from_elem(5 * u32::BITS as usize, true);
+    let mut s = BitVec::from_elem(5 * u32::BITS, true);
     // Check capacity
-    assert!(s.capacity() >= 5 * u32::BITS as usize);
-    s.reserve(2 * u32::BITS as usize);
-    assert!(s.capacity() >= 7 * u32::BITS as usize);
-    s.reserve(7 * u32::BITS as usize);
-    assert!(s.capacity() >= 12 * u32::BITS as usize);
-    s.reserve_exact(7 * u32::BITS as usize);
-    assert!(s.capacity() >= 12 * u32::BITS as usize);
-    s.reserve(7 * u32::BITS as usize + 1);
-    assert!(s.capacity() >= 12 * u32::BITS as usize + 1);
+    assert!(s.capacity() >= 5 * u32::BITS);
+    s.reserve(2 * u32::BITS);
+    assert!(s.capacity() >= 7 * u32::BITS);
+    s.reserve(7 * u32::BITS);
+    assert!(s.capacity() >= 12 * u32::BITS);
+    s.reserve_exact(7 * u32::BITS);
+    assert!(s.capacity() >= 12 * u32::BITS);
+    s.reserve(7 * u32::BITS + 1);
+    assert!(s.capacity() >= 12 * u32::BITS + 1);
     // Check that length hasn't changed
-    assert_eq!(s.len(), 5 * u32::BITS as usize);
+    assert_eq!(s.len(), 5 * u32::BITS);
     s.push(true);
     s.push(false);
     s.push(true);
-    assert_eq!(s[5 * u32::BITS as usize - 1], true);
-    assert_eq!(s[5 * u32::BITS as usize - 0], true);
-    assert_eq!(s[5 * u32::BITS as usize + 1], false);
-    assert_eq!(s[5 * u32::BITS as usize + 2], true);
+    assert_eq!(s[5 * u32::BITS - 1], true);
+    assert_eq!(s[5 * u32::BITS - 0], true);
+    assert_eq!(s[5 * u32::BITS + 1], false);
+    assert_eq!(s[5 * u32::BITS + 2], true);
 }
 
 #[test]
@@ -650,7 +650,7 @@ mod bench {
         let mut bit_vec = 0 as usize;
         b.iter(|| {
             for _ in 0..100 {
-                bit_vec |= 1 << ((r.next_u32() as usize) % u32::BITS as usize);
+                bit_vec |= 1 << ((r.next_u32() as usize) % u32::BITS);
             }
             black_box(&bit_vec);
         });
@@ -683,10 +683,10 @@ mod bench {
     #[bench]
     fn bench_bit_set_small(b: &mut Bencher) {
         let mut r = rng();
-        let mut bit_vec = BitVec::from_elem(u32::BITS as usize, false);
+        let mut bit_vec = BitVec::from_elem(u32::BITS, false);
         b.iter(|| {
             for _ in 0..100 {
-                bit_vec.set((r.next_u32() as usize) % u32::BITS as usize, true);
+                bit_vec.set((r.next_u32() as usize) % u32::BITS, true);
             }
             black_box(&bit_vec);
         });
@@ -703,7 +703,7 @@ mod bench {
 
     #[bench]
     fn bench_bit_vec_small_iter(b: &mut Bencher) {
-        let bit_vec = BitVec::from_elem(u32::BITS as usize, false);
+        let bit_vec = BitVec::from_elem(u32::BITS, false);
         b.iter(|| {
             let mut sum = 0;
             for _ in 0..10 {

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -194,7 +194,7 @@ mod impls {
                 fn hash_slice<H: Hasher>(data: &[$ty], state: &mut H) {
                     // FIXME(#23542) Replace with type ascription.
                     #![allow(trivial_casts)]
-                    let newlen = data.len() * ::$ty::BYTES as usize;
+                    let newlen = data.len() * ::$ty::BYTES;
                     let ptr = data.as_ptr() as *const u8;
                     state.write(unsafe { slice::from_raw_parts(ptr, newlen) })
                 }

--- a/src/libcore/num/int_macros.rs
+++ b/src/libcore/num/int_macros.rs
@@ -15,11 +15,11 @@ macro_rules! int_module { ($T:ty, $bits:expr) => (
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `mem::size_of` function.
 #[unstable(feature = "core")]
-pub const BITS : u32 = $bits;
+pub const BITS : usize = $bits;
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `mem::size_of` function.
 #[unstable(feature = "core")]
-pub const BYTES : u32 = ($bits / 8);
+pub const BYTES : usize = ($bits / 8);
 
 // FIXME(#11621): Should be deprecated once CTFE is implemented in favour of
 // calling the `Bounded::min_value` function.

--- a/src/libcore/num/uint_macros.rs
+++ b/src/libcore/num/uint_macros.rs
@@ -13,9 +13,9 @@
 macro_rules! uint_module { ($T:ty, $T_SIGNED:ty, $bits:expr) => (
 
 #[unstable(feature = "core")]
-pub const BITS : u32 = $bits;
+pub const BITS : usize = $bits;
 #[unstable(feature = "core")]
-pub const BYTES : u32 = ($bits / 8);
+pub const BYTES : usize = ($bits / 8);
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MIN: $T = 0 as $T;

--- a/src/libcoretest/num/int_macros.rs
+++ b/src/libcoretest/num/int_macros.rs
@@ -86,9 +86,9 @@ mod tests {
 
     #[test]
     fn test_count_zeros() {
-        assert!(A.count_zeros() == BITS - 3);
-        assert!(B.count_zeros() == BITS - 2);
-        assert!(C.count_zeros() == BITS - 5);
+        assert!(A.count_zeros() == BITS as u32 - 3);
+        assert!(B.count_zeros() == BITS as u32 - 2);
+        assert!(C.count_zeros() == BITS as u32 - 5);
     }
 
     #[test]

--- a/src/libcoretest/num/uint_macros.rs
+++ b/src/libcoretest/num/uint_macros.rs
@@ -54,9 +54,9 @@ mod tests {
 
     #[test]
     fn test_count_zeros() {
-        assert!(A.count_zeros() == BITS - 3);
-        assert!(B.count_zeros() == BITS - 2);
-        assert!(C.count_zeros() == BITS - 5);
+        assert!(A.count_zeros() == BITS as u32 - 3);
+        assert!(B.count_zeros() == BITS as u32 - 2);
+        assert!(C.count_zeros() == BITS as u32 - 5);
     }
 
     #[test]

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -195,7 +195,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
                oper: O,
                id_range: IdRange,
                bits_per_id: usize) -> DataFlowContext<'a, 'tcx, O> {
-        let words_per_id = (bits_per_id + usize::BITS as usize - 1) / usize::BITS as usize;
+        let words_per_id = (bits_per_id + usize::BITS - 1) / usize::BITS;
         let num_nodes = cfg.graph.all_nodes().len();
 
         debug!("DataFlowContext::new(analysis_name: {}, id_range={:?}, \
@@ -367,7 +367,7 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
 
         for (word_index, &word) in words.iter().enumerate() {
             if word != 0 {
-                let base_index = word_index * usize::BITS as usize;
+                let base_index = word_index * usize::BITS;
                 for offset in 0..usize::BITS {
                     let bit = 1 << offset;
                     if (word & bit) != 0 {
@@ -601,8 +601,8 @@ fn bitwise<Op:BitwiseOperator>(out_vec: &mut [usize],
 fn set_bit(words: &mut [usize], bit: usize) -> bool {
     debug!("set_bit: words={} bit={}",
            mut_bits_to_string(words), bit_str(bit));
-    let word = bit / usize::BITS as usize;
-    let bit_in_word = bit % usize::BITS as usize;
+    let word = bit / usize::BITS;
+    let bit_in_word = bit % usize::BITS;
     let bit_mask = 1 << bit_in_word;
     debug!("word={} bit_in_word={} bit_mask={}", word, bit_in_word, word);
     let oldv = words[word];

--- a/src/libstd/old_io/mod.rs
+++ b/src/libstd/old_io/mod.rs
@@ -726,28 +726,28 @@ pub trait Reader {
     ///
     /// The number of bytes returned is system-dependent.
     fn read_le_uint(&mut self) -> IoResult<usize> {
-        self.read_le_uint_n(usize::BYTES as usize).map(|i| i as usize)
+        self.read_le_uint_n(usize::BYTES).map(|i| i as usize)
     }
 
     /// Reads a little-endian integer.
     ///
     /// The number of bytes returned is system-dependent.
     fn read_le_int(&mut self) -> IoResult<isize> {
-        self.read_le_int_n(isize::BYTES as usize).map(|i| i as isize)
+        self.read_le_int_n(isize::BYTES).map(|i| i as isize)
     }
 
     /// Reads a big-endian unsigned integer.
     ///
     /// The number of bytes returned is system-dependent.
     fn read_be_uint(&mut self) -> IoResult<usize> {
-        self.read_be_uint_n(usize::BYTES as usize).map(|i| i as usize)
+        self.read_be_uint_n(usize::BYTES).map(|i| i as usize)
     }
 
     /// Reads a big-endian integer.
     ///
     /// The number of bytes returned is system-dependent.
     fn read_be_int(&mut self) -> IoResult<isize> {
-        self.read_be_int_n(isize::BYTES as usize).map(|i| i as isize)
+        self.read_be_int_n(isize::BYTES).map(|i| i as isize)
     }
 
     /// Reads a big-endian `u64`.
@@ -1110,25 +1110,25 @@ pub trait Writer {
     /// Write a little-endian usize (number of bytes depends on system).
     #[inline]
     fn write_le_uint(&mut self, n: usize) -> IoResult<()> {
-        extensions::u64_to_le_bytes(n as u64, usize::BYTES as usize, |v| self.write_all(v))
+        extensions::u64_to_le_bytes(n as u64, usize::BYTES, |v| self.write_all(v))
     }
 
     /// Write a little-endian isize (number of bytes depends on system).
     #[inline]
     fn write_le_int(&mut self, n: isize) -> IoResult<()> {
-        extensions::u64_to_le_bytes(n as u64, isize::BYTES as usize, |v| self.write_all(v))
+        extensions::u64_to_le_bytes(n as u64, isize::BYTES, |v| self.write_all(v))
     }
 
     /// Write a big-endian usize (number of bytes depends on system).
     #[inline]
     fn write_be_uint(&mut self, n: usize) -> IoResult<()> {
-        extensions::u64_to_be_bytes(n as u64, usize::BYTES as usize, |v| self.write_all(v))
+        extensions::u64_to_be_bytes(n as u64, usize::BYTES, |v| self.write_all(v))
     }
 
     /// Write a big-endian isize (number of bytes depends on system).
     #[inline]
     fn write_be_int(&mut self, n: isize) -> IoResult<()> {
-        extensions::u64_to_be_bytes(n as u64, isize::BYTES as usize, |v| self.write_all(v))
+        extensions::u64_to_be_bytes(n as u64, isize::BYTES, |v| self.write_all(v))
     }
 
     /// Write a big-endian u64 (8 bytes).

--- a/src/libstd/sys/unix/c.rs
+++ b/src/libstd/sys/unix/c.rs
@@ -194,12 +194,12 @@ mod select {
     #[repr(C)]
     pub struct fd_set {
         // FIXME: shouldn't this be a c_ulong?
-        fds_bits: [libc::uintptr_t; (FD_SETSIZE / usize::BITS as usize)]
+        fds_bits: [libc::uintptr_t; (FD_SETSIZE / usize::BITS)]
     }
 
     pub fn fd_set(set: &mut fd_set, fd: i32) {
         let fd = fd as usize;
-        set.fds_bits[fd / usize::BITS as usize] |= 1 << (fd % usize::BITS as usize);
+        set.fds_bits[fd / usize::BITS] |= 1 << (fd % usize::BITS);
     }
 }
 

--- a/src/test/run-pass/issue-13763.rs
+++ b/src/test/run-pass/issue-13763.rs
@@ -14,7 +14,7 @@
 
 use std::u8;
 
-const NUM: usize = u8::BITS as usize;
+const NUM: usize = u8::BITS;
 
 struct MyStruct { nums: [usize; 8] }
 

--- a/src/test/run-pass/vector-sort-panic-safe.rs
+++ b/src/test/run-pass/vector-sort-panic-safe.rs
@@ -57,7 +57,7 @@ impl Drop for DropCounter {
 }
 
 pub fn main() {
-    assert!(MAX_LEN <= std::usize::BITS as usize);
+    assert!(MAX_LEN <= std::usize::BITS);
     // len can't go above 64.
     for len in 2..MAX_LEN {
         for _ in 0..REPEATS {


### PR DESCRIPTION
These constants are small and can fit even in `u8`, but semantically they have type `usize` because they denote sizes and are almost always used in `usize` context. The change of their type to `u32` during the integer audit led only to the large amount of `as usize` noise (see the second commit, which removes this noise).

This is a minor [breaking-change] to an unstable interface.

r? @aturon 
