### PR TITLE
Remove about standard io chapter from the book (from arrays-vectors-and-slices chapter)

### DIFF
--- a/src/doc/trpl/arrays-vectors-and-slices.md
+++ b/src/doc/trpl/arrays-vectors-and-slices.md
@@ -99,5 +99,4 @@ You can also take a slice of a vector, `String`, or `&str`, because they are
 backed by arrays. Slices have type `&[T]`, which we'll talk about when we cover
 generics.
 
-We have now learned all of the most basic Rust concepts. Next, we learn how to
-get input from the keyboard.
+We have now learned all of the most basic Rust concepts.


### PR DESCRIPTION
Remove the last sentence about standard io chapter.

Additional Fixes #23760 
