### PR TITLE
rustdoc: prefer output from stderr on test panic

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -243,8 +243,9 @@ fn runtest(test: &str, cratename: &str, libs: SearchPaths,
             if should_panic && out.status.success() {
                 panic!("test executable succeeded when it should have failed");
             } else if !should_panic && !out.status.success() {
-                panic!("test executable failed:\n{:?}",
-                      str::from_utf8(&out.stdout));
+                panic!("test executable failed:\n{}\n{}",
+                       str::from_utf8(&out.stdout).unwrap_or(""),
+                       str::from_utf8(&out.stderr).unwrap_or(""));
             }
         }
     }


### PR DESCRIPTION
Currently if a rustdoc test panics then the fatal error message is not forwarded to the user. This change will have the test runner prefer forwarding anything on the stderr of the test process.
