### PR TITLE
Make Copy a subtrait of Clone

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1648,7 +1648,7 @@ specific type.
 Implementations are defined with the keyword `impl`.
 
 ```
-# #[derive(Copy)]
+# #[derive(Copy, Clone)]
 # struct Point {x: f64, y: f64};
 # type Surface = i32;
 # struct BoundingBox {x: f64, y: f64, width: f64, height: f64};
@@ -1660,6 +1660,10 @@ struct Circle {
 }
 
 impl Copy for Circle {}
+
+impl Clone for Circle {
+    fn clone(&self) -> Circle { *self }
+}
 
 impl Shape for Circle {
     fn draw(&self, s: Surface) { do_draw_circle(s, *self); }

--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -30,7 +30,7 @@
 //! use std::collections::BinaryHeap;
 //! use std::usize;
 //!
-//! #[derive(Copy, Eq, PartialEq)]
+//! #[derive(Copy, Clone, Eq, PartialEq)]
 //! struct State {
 //!     cost: usize,
 //!     position: usize,

--- a/src/libcollections/btree/node.rs
+++ b/src/libcollections/btree/node.rs
@@ -526,7 +526,7 @@ impl<K: Clone, V: Clone> Clone for Node<K, V> {
 ///     println!("Uninitialized memory: {:?}", handle.into_kv());
 /// }
 /// ```
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Handle<NodeRef, Type, NodeType> {
     node: NodeRef,
     index: usize,

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -21,7 +21,7 @@ use core::ops::{Sub, BitOr, BitAnd, BitXor};
 
 // FIXME(contentions): implement union family of methods? (general design may be wrong here)
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// A specialized set implementation to use enum types.
 ///
 /// It is a logic error for an item to be modified in such a way that the transformation of the
@@ -36,6 +36,10 @@ pub struct EnumSet<E> {
 }
 
 impl<E> Copy for EnumSet<E> {}
+
+impl<E> Clone for EnumSet<E> {
+    fn clone(&self) -> EnumSet<E> { *self }
+}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<E:CLike + fmt::Debug> fmt::Debug for EnumSet<E> {

--- a/src/libcollectionstest/enum_set.rs
+++ b/src/libcollectionstest/enum_set.rs
@@ -14,7 +14,7 @@ use collections::enum_set::{CLike, EnumSet};
 
 use self::Foo::*;
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 #[repr(usize)]
 enum Foo {
     A, B, C
@@ -218,7 +218,7 @@ fn test_operators() {
 #[should_panic]
 fn test_overflow() {
     #[allow(dead_code)]
-    #[derive(Copy)]
+    #[derive(Copy, Clone)]
     #[repr(usize)]
     enum Bar {
         V00, V01, V02, V03, V04, V05, V06, V07, V08, V09,

--- a/src/libcore/atomic.rs
+++ b/src/libcore/atomic.rs
@@ -122,7 +122,7 @@ unsafe impl<T> Sync for AtomicPtr<T> {}
 /// Rust's memory orderings are [the same as
 /// C++'s](http://gcc.gnu.org/wiki/Atomic/GCCMM/AtomicSync).
 #[stable(feature = "rust1", since = "1.0.0")]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum Ordering {
     /// No ordering constraints, only atomic operations.
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -15,6 +15,7 @@
 use any;
 use cell::{Cell, RefCell, Ref, RefMut, BorrowState};
 use char::CharExt;
+use clone::Clone;
 use iter::Iterator;
 use marker::{Copy, PhantomData, Sized};
 use mem;
@@ -54,7 +55,7 @@ pub type Result = result::Result<(), Error>;
 /// occurred. Any extra information must be arranged to be transmitted through
 /// some other means.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Error;
 
 /// A collection of methods that are required to format a message into a stream.
@@ -141,6 +142,12 @@ pub struct ArgumentV1<'a> {
     formatter: fn(&Void, &mut Formatter) -> Result,
 }
 
+impl<'a> Clone for ArgumentV1<'a> {
+    fn clone(&self) -> ArgumentV1<'a> {
+        *self
+    }
+}
+
 impl<'a> ArgumentV1<'a> {
     #[inline(never)]
     fn show_usize(x: &usize, f: &mut Formatter) -> Result {
@@ -175,7 +182,7 @@ impl<'a> ArgumentV1<'a> {
 }
 
 // flags available in the v1 format of format_args
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 #[allow(dead_code)] // SignMinus isn't currently used
 enum FlagV1 { SignPlus, SignMinus, Alternate, SignAwareZeroPad, }
 
@@ -222,7 +229,7 @@ impl<'a> Arguments<'a> {
 /// macro validates the format string at compile-time so usage of the `write`
 /// and `format` functions can be safely performed.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Arguments<'a> {
     // Format string pieces to print.
     pieces: &'a [&'a str],

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -139,7 +139,7 @@ impl GenericRadix for Radix {
 /// A helper type for formatting radixes.
 #[unstable(feature = "core",
            reason = "may be renamed or move to a different module")]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct RadixFmt<T, R>(T, R);
 
 /// Constructs a radix formatter in the range of `2..36`.

--- a/src/libcore/fmt/rt/v1.rs
+++ b/src/libcore/fmt/rt/v1.rs
@@ -16,7 +16,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Argument {
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -25,7 +25,7 @@ pub struct Argument {
     pub format: FormatSpec,
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct FormatSpec {
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -41,7 +41,7 @@ pub struct FormatSpec {
 }
 
 /// Possible alignments that can be requested as part of a formatting directive.
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum Alignment {
     /// Indication that contents should be left-aligned.
@@ -58,7 +58,7 @@ pub enum Alignment {
     Unknown,
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum Count {
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -71,7 +71,7 @@ pub enum Count {
     Implied,
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum Position {
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -154,7 +154,7 @@ pub trait Sized : MarkerTrait {
 /// change: that second example would fail to compile if we made `Foo` non-`Copy`.
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang="copy"]
-pub trait Copy : MarkerTrait {
+pub trait Copy : Clone {
     // Empty.
 }
 

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -75,7 +75,7 @@ pub trait Sized : MarkerTrait {
 ///
 /// ```
 /// // we can just derive a `Copy` implementation
-/// #[derive(Debug, Copy)]
+/// #[derive(Debug, Copy, Clone)]
 /// struct Foo;
 ///
 /// let x = Foo;
@@ -124,7 +124,7 @@ pub trait Sized : MarkerTrait {
 /// There are two ways to implement `Copy` on your type:
 ///
 /// ```
-/// #[derive(Copy)]
+/// #[derive(Copy, Clone)]
 /// struct MyStruct;
 /// ```
 ///
@@ -133,6 +133,7 @@ pub trait Sized : MarkerTrait {
 /// ```
 /// struct MyStruct;
 /// impl Copy for MyStruct {}
+/// impl Clone for MyStruct { fn clone(&self) -> MyStruct { *self } }
 /// ```
 ///
 /// There is a small difference between the two: the `derive` strategy will also place a `Copy`

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -2425,7 +2425,7 @@ impl_num_cast! { f32,   to_f32 }
 impl_num_cast! { f64,   to_f64 }
 
 /// Used for representing the classification of floating point numbers
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum FpCategory {
     /// "Not a Number", often obtained by dividing by zero

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -165,7 +165,7 @@ macro_rules! forward_ref_binop {
 /// ```
 /// use std::ops::Add;
 ///
-/// #[derive(Copy)]
+/// #[derive(Copy, Clone)]
 /// struct Foo;
 ///
 /// impl Add for Foo {
@@ -219,7 +219,7 @@ add_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 /// ```
 /// use std::ops::Sub;
 ///
-/// #[derive(Copy)]
+/// #[derive(Copy, Clone)]
 /// struct Foo;
 ///
 /// impl Sub for Foo {
@@ -273,7 +273,7 @@ sub_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 /// ```
 /// use std::ops::Mul;
 ///
-/// #[derive(Copy)]
+/// #[derive(Copy, Clone)]
 /// struct Foo;
 ///
 /// impl Mul for Foo {
@@ -327,7 +327,7 @@ mul_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 /// ```
 /// use std::ops::Div;
 ///
-/// #[derive(Copy)]
+/// #[derive(Copy, Clone)]
 /// struct Foo;
 ///
 /// impl Div for Foo {
@@ -381,7 +381,7 @@ div_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 /// ```
 /// use std::ops::Rem;
 ///
-/// #[derive(Copy)]
+/// #[derive(Copy, Clone)]
 /// struct Foo;
 ///
 /// impl Rem for Foo {
@@ -454,7 +454,7 @@ rem_float_impl! { f64, fmod }
 /// ```
 /// use std::ops::Neg;
 ///
-/// #[derive(Copy)]
+/// #[derive(Copy, Clone)]
 /// struct Foo;
 ///
 /// impl Neg for Foo {
@@ -511,7 +511,7 @@ neg_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 /// ```
 /// use std::ops::Not;
 ///
-/// #[derive(Copy)]
+/// #[derive(Copy, Clone)]
 /// struct Foo;
 ///
 /// impl Not for Foo {
@@ -565,7 +565,7 @@ not_impl! { bool usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
 /// ```
 /// use std::ops::BitAnd;
 ///
-/// #[derive(Copy)]
+/// #[derive(Copy, Clone)]
 /// struct Foo;
 ///
 /// impl BitAnd for Foo {
@@ -619,7 +619,7 @@ bitand_impl! { bool usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
 /// ```
 /// use std::ops::BitOr;
 ///
-/// #[derive(Copy)]
+/// #[derive(Copy, Clone)]
 /// struct Foo;
 ///
 /// impl BitOr for Foo {
@@ -673,7 +673,7 @@ bitor_impl! { bool usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
 /// ```
 /// use std::ops::BitXor;
 ///
-/// #[derive(Copy)]
+/// #[derive(Copy, Clone)]
 /// struct Foo;
 ///
 /// impl BitXor for Foo {
@@ -727,7 +727,7 @@ bitxor_impl! { bool usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
 /// ```
 /// use std::ops::Shl;
 ///
-/// #[derive(Copy)]
+/// #[derive(Copy, Clone)]
 /// struct Foo;
 ///
 /// impl Shl<Foo> for Foo {
@@ -799,7 +799,7 @@ shl_impl_all! { u8 u16 u32 u64 usize i8 i16 i32 i64 isize }
 /// ```
 /// use std::ops::Shr;
 ///
-/// #[derive(Copy)]
+/// #[derive(Copy, Clone)]
 /// struct Foo;
 ///
 /// impl Shr<Foo> for Foo {
@@ -871,7 +871,7 @@ shr_impl_all! { u8 u16 u32 u64 usize i8 i16 i32 i64 isize }
 /// ```
 /// use std::ops::Index;
 ///
-/// #[derive(Copy)]
+/// #[derive(Copy, Clone)]
 /// struct Foo;
 /// struct Bar;
 ///
@@ -912,7 +912,7 @@ pub trait Index<Idx: ?Sized> {
 /// ```
 /// use std::ops::{Index, IndexMut};
 ///
-/// #[derive(Copy)]
+/// #[derive(Copy, Clone)]
 /// struct Foo;
 /// struct Bar;
 ///

--- a/src/libcore/raw.rs
+++ b/src/libcore/raw.rs
@@ -18,6 +18,8 @@
 //!
 //! Their definition should always match the ABI defined in `rustc::back::abi`.
 
+use clone::Clone;
+use marker::Copy;
 use mem;
 
 /// The representation of a slice like `&[T]`.

--- a/src/libcore/raw.rs
+++ b/src/libcore/raw.rs
@@ -18,7 +18,6 @@
 //!
 //! Their definition should always match the ABI defined in `rustc::back::abi`.
 
-use marker::Copy;
 use mem;
 
 /// The representation of a slice like `&[T]`.
@@ -63,6 +62,9 @@ pub struct Slice<T> {
 }
 
 impl<T> Copy for Slice<T> {}
+impl<T> Clone for Slice<T> {
+    fn clone(&self) -> Slice<T> { *self }
+}
 
 /// The representation of a trait object like `&SomeTrait`.
 ///
@@ -136,7 +138,7 @@ impl<T> Copy for Slice<T> {}
 /// assert_eq!(synthesized.bar(), 457);
 /// ```
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct TraitObject {
     pub data: *mut (),
     pub vtable: *mut (),

--- a/src/libcore/simd.rs
+++ b/src/libcore/simd.rs
@@ -38,7 +38,7 @@
 
 #[unstable(feature = "core")]
 #[simd]
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct i8x16(pub i8, pub i8, pub i8, pub i8,
                  pub i8, pub i8, pub i8, pub i8,
@@ -47,26 +47,26 @@ pub struct i8x16(pub i8, pub i8, pub i8, pub i8,
 
 #[unstable(feature = "core")]
 #[simd]
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct i16x8(pub i16, pub i16, pub i16, pub i16,
                  pub i16, pub i16, pub i16, pub i16);
 
 #[unstable(feature = "core")]
 #[simd]
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct i32x4(pub i32, pub i32, pub i32, pub i32);
 
 #[unstable(feature = "core")]
 #[simd]
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct i64x2(pub i64, pub i64);
 
 #[unstable(feature = "core")]
 #[simd]
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct u8x16(pub u8, pub u8, pub u8, pub u8,
                  pub u8, pub u8, pub u8, pub u8,
@@ -75,31 +75,31 @@ pub struct u8x16(pub u8, pub u8, pub u8, pub u8,
 
 #[unstable(feature = "core")]
 #[simd]
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct u16x8(pub u16, pub u16, pub u16, pub u16,
                  pub u16, pub u16, pub u16, pub u16);
 
 #[unstable(feature = "core")]
 #[simd]
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct u32x4(pub u32, pub u32, pub u32, pub u32);
 
 #[unstable(feature = "core")]
 #[simd]
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct u64x2(pub u64, pub u64);
 
 #[unstable(feature = "core")]
 #[simd]
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
 
 #[unstable(feature = "core")]
 #[simd]
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct f64x2(pub f64, pub f64);

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1123,7 +1123,7 @@ static UTF8_CHAR_WIDTH: [u8; 256] = [
 /// Struct that contains a `char` and the index of the first byte of
 /// the next `char` in a string.  This can be used as a data structure
 /// for iterating over the UTF-8 bytes of a string.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 #[unstable(feature = "str_char",
            reason = "existence of this struct is uncertain as it is frequently \
                      able to be replaced with char.len_utf8() and/or \

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -40,7 +40,7 @@ use std::string;
 
 /// A piece is a portion of the format string which represents the next part
 /// to emit. These are emitted as a stream by the `Parser` class.
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Piece<'a> {
     /// A literal string which should directly be emitted
     String(&'a str),
@@ -50,7 +50,7 @@ pub enum Piece<'a> {
 }
 
 /// Representation of an argument specification.
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct Argument<'a> {
     /// Where to find this argument
     pub position: Position<'a>,
@@ -59,7 +59,7 @@ pub struct Argument<'a> {
 }
 
 /// Specification for the formatting of an argument in the format string.
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct FormatSpec<'a> {
     /// Optionally specified character to fill alignment with
     pub fill: Option<char>,
@@ -78,7 +78,7 @@ pub struct FormatSpec<'a> {
 }
 
 /// Enum describing where an argument for a format can be located.
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Position<'a> {
     /// The argument will be in the next position. This is the default.
     ArgumentNext,
@@ -89,7 +89,7 @@ pub enum Position<'a> {
 }
 
 /// Enum of alignments which are supported.
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Alignment {
     /// The value will be aligned to the left.
     AlignLeft,
@@ -103,7 +103,7 @@ pub enum Alignment {
 
 /// Various flags which can be applied to format strings. The meaning of these
 /// flags is defined by the formatters themselves.
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Flag {
     /// A `+` will be used to denote positive numbers.
     FlagSignPlus,
@@ -119,7 +119,7 @@ pub enum Flag {
 
 /// A count is used for the precision and width parameters of an integer, and
 /// can reference either an argument or a literal integer.
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Count<'a> {
     /// The count is specified explicitly.
     CountIs(usize),

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -213,7 +213,7 @@ pub enum Fail {
 }
 
 /// The type of failure that occurred.
-#[derive(Copy, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[allow(missing_docs)]
 pub enum FailType {
     ArgumentMissing_,
@@ -843,18 +843,18 @@ pub fn short_usage(program_name: &str, opts: &[OptGroup]) -> String {
     line
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum SplitWithinState {
     A,  // leading whitespace, initial state
     B,  // words
     C,  // internal and trailing whitespace
 }
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum Whitespace {
     Ws, // current char is whitespace
     Cr  // current char is not whitespace
 }
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum LengthLimit {
     UnderLim, // current char makes current substring still fit in limit
     OverLim   // current char makes current substring no longer fit in limit

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -524,7 +524,7 @@ pub trait GraphWalk<'a, N, E> {
     fn target(&'a self, edge: &E) -> N;
 }
 
-#[derive(Copy, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum RenderOption {
     NoEdgeLabels,
     NoNodeLabels,

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -227,7 +227,7 @@ pub mod types {
                 pub type rlim_t = u64;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct glob_t {
+                #[derive(Copy, Clone)] pub struct glob_t {
                     pub gl_pathc: size_t,
                     pub gl_pathv: *mut *mut c_char,
                     pub gl_offs:  size_t,
@@ -240,23 +240,23 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct timeval {
+                #[derive(Copy, Clone)] pub struct timeval {
                     pub tv_sec: time_t,
                     pub tv_usec: suseconds_t,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct timespec {
+                #[derive(Copy, Clone)] pub struct timespec {
                     pub tv_sec: time_t,
                     pub tv_nsec: c_long,
                 }
 
-                #[derive(Copy)] pub enum timezone {}
+                pub enum timezone {}
 
                 pub type sighandler_t = size_t;
 
                 #[repr(C)]
-                #[derive(Copy)]
+                #[derive(Copy, Clone)]
                 pub struct rlimit {
                     pub rlim_cur: rlim_t,
                     pub rlim_max: rlim_t,
@@ -269,7 +269,7 @@ pub mod types {
                 // This is also specified in POSIX 2001, but only has two fields. All implementors
                 // implement BSD 4.3 version.
                 #[repr(C)]
-                #[derive(Copy)]
+                #[derive(Copy, Clone)]
                 pub struct rusage {
                     pub ru_utime: timeval,
                     pub ru_stime: timeval,
@@ -291,6 +291,7 @@ pub mod types {
             }
 
             pub mod bsd44 {
+                use core::clone::Clone;
                 use types::common::c95::{c_void};
                 use types::os::arch::c95::{c_char, c_int, c_uint};
 
@@ -299,7 +300,7 @@ pub mod types {
                 pub type in_port_t = u16;
                 pub type in_addr_t = u32;
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr {
+                #[derive(Copy, Clone)] pub struct sockaddr {
                     pub sa_family: sa_family_t,
                     pub sa_data: [u8; 14],
                 }
@@ -312,19 +313,22 @@ pub mod types {
                     #[cfg(target_pointer_width = "64")]
                     pub __ss_pad2: [u8; 128 - 2 * 8],
                 }
+                impl Clone for sockaddr_storage {
+                    fn clone(&self) -> sockaddr_storage { *self }
+                }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_in {
+                #[derive(Copy, Clone)] pub struct sockaddr_in {
                     pub sin_family: sa_family_t,
                     pub sin_port: in_port_t,
                     pub sin_addr: in_addr,
                     pub sin_zero: [u8; 8],
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct in_addr {
+                #[derive(Copy, Clone)] pub struct in_addr {
                     pub s_addr: in_addr_t,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_in6 {
+                #[derive(Copy, Clone)] pub struct sockaddr_in6 {
                     pub sin6_family: sa_family_t,
                     pub sin6_port: in_port_t,
                     pub sin6_flowinfo: u32,
@@ -332,21 +336,21 @@ pub mod types {
                     pub sin6_scope_id: u32,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct in6_addr {
+                #[derive(Copy, Clone)] pub struct in6_addr {
                     pub s6_addr: [u16; 8]
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct ip_mreq {
+                #[derive(Copy, Clone)] pub struct ip_mreq {
                     pub imr_multiaddr: in_addr,
                     pub imr_interface: in_addr,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct ip6_mreq {
+                #[derive(Copy, Clone)] pub struct ip6_mreq {
                     pub ipv6mr_multiaddr: in6_addr,
                     pub ipv6mr_interface: c_uint,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct addrinfo {
+                #[derive(Copy, Clone)] pub struct addrinfo {
                     pub ai_flags: c_int,
                     pub ai_family: c_int,
                     pub ai_socktype: c_int,
@@ -372,9 +376,12 @@ pub mod types {
                     pub sun_family: sa_family_t,
                     pub sun_path: [c_char; 108]
                 }
+                impl Clone for sockaddr_un {
+                    fn clone(&self) -> sockaddr_un { *self }
+                }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct ifaddrs {
+                #[derive(Copy, Clone)] pub struct ifaddrs {
                     pub ifa_next: *mut ifaddrs,
                     pub ifa_name: *mut c_char,
                     pub ifa_flags: c_uint,
@@ -465,7 +472,7 @@ pub mod types {
                 pub type blkcnt_t = i32;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct stat {
+                #[derive(Copy, Clone)] pub struct stat {
                     pub st_dev: dev_t,
                     pub __pad1: c_short,
                     pub st_ino: ino_t,
@@ -489,13 +496,13 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct utimbuf {
+                #[derive(Copy, Clone)] pub struct utimbuf {
                     pub actime: time_t,
                     pub modtime: time_t,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct pthread_attr_t {
+                #[derive(Copy, Clone)] pub struct pthread_attr_t {
                     pub __size: [u32; 9]
                 }
             }
@@ -510,7 +517,7 @@ pub mod types {
                 pub type blkcnt_t = u32;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct stat {
+                #[derive(Copy, Clone)] pub struct stat {
                     pub st_dev: c_ulonglong,
                     pub __pad0: [c_uchar; 4],
                     pub __st_ino: ino_t,
@@ -533,13 +540,13 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct utimbuf {
+                #[derive(Copy, Clone)] pub struct utimbuf {
                     pub actime: time_t,
                     pub modtime: time_t,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct pthread_attr_t {
+                #[derive(Copy, Clone)] pub struct pthread_attr_t {
                     pub __size: [u32; 9]
                 }
             }
@@ -556,7 +563,7 @@ pub mod types {
                 pub type blkcnt_t = i32;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct stat {
+                #[derive(Copy, Clone)] pub struct stat {
                     pub st_dev: c_ulong,
                     pub st_pad1: [c_long; 3],
                     pub st_ino: ino_t,
@@ -580,13 +587,13 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct utimbuf {
+                #[derive(Copy, Clone)] pub struct utimbuf {
                     pub actime: time_t,
                     pub modtime: time_t,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct pthread_attr_t {
+                #[derive(Copy, Clone)] pub struct pthread_attr_t {
                     pub __size: [u32; 9]
                 }
             }
@@ -595,7 +602,7 @@ pub mod types {
             pub mod extra {
                 use types::os::arch::c95::{c_ushort, c_int, c_uchar};
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_ll {
+                #[derive(Copy, Clone)] pub struct sockaddr_ll {
                     pub sll_family: c_ushort,
                     pub sll_protocol: c_ushort,
                     pub sll_ifindex: c_int,
@@ -667,7 +674,7 @@ pub mod types {
                 pub type blkcnt_t = i64;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct stat {
+                #[derive(Copy, Clone)] pub struct stat {
                     pub st_dev: dev_t,
                     pub st_ino: ino_t,
                     pub st_nlink: nlink_t,
@@ -689,13 +696,13 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct utimbuf {
+                #[derive(Copy, Clone)] pub struct utimbuf {
                     pub actime: time_t,
                     pub modtime: time_t,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct pthread_attr_t {
+                #[derive(Copy, Clone)] pub struct pthread_attr_t {
                     pub __size: [u64; 7]
                 }
             }
@@ -711,7 +718,7 @@ pub mod types {
                 pub type blkcnt_t = i64;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct stat {
+                #[derive(Copy, Clone)] pub struct stat {
                     pub st_dev: dev_t,
                     pub st_ino: ino_t,
                     pub st_mode: mode_t,
@@ -734,13 +741,13 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct utimbuf {
+                #[derive(Copy, Clone)] pub struct utimbuf {
                     pub actime: time_t,
                     pub modtime: time_t,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct pthread_attr_t {
+                #[derive(Copy, Clone)] pub struct pthread_attr_t {
                     pub __size: [u64; 8]
                 }
             }
@@ -750,7 +757,7 @@ pub mod types {
             }
             pub mod extra {
                 use types::os::arch::c95::{c_ushort, c_int, c_uchar};
-                #[derive(Copy)] pub struct sockaddr_ll {
+                #[derive(Copy, Clone)] pub struct sockaddr_ll {
                     pub sll_family: c_ushort,
                     pub sll_protocol: c_ushort,
                     pub sll_ifindex: c_int,
@@ -777,7 +784,7 @@ pub mod types {
                 pub type rlim_t = i64;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct glob_t {
+                #[derive(Copy, Clone)] pub struct glob_t {
                     pub gl_pathc:  size_t,
                     pub __unused1: size_t,
                     pub gl_offs:   size_t,
@@ -794,23 +801,23 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct timeval {
+                #[derive(Copy, Clone)] pub struct timeval {
                     pub tv_sec: time_t,
                     pub tv_usec: suseconds_t,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct timespec {
+                #[derive(Copy, Clone)] pub struct timespec {
                     pub tv_sec: time_t,
                     pub tv_nsec: c_long,
                 }
 
-                #[derive(Copy)] pub enum timezone {}
+                #[derive(Copy, Clone)] pub enum timezone {}
 
                 pub type sighandler_t = size_t;
 
                 #[repr(C)]
-                #[derive(Copy)]
+                #[derive(Copy, Clone)]
                 pub struct rlimit {
                     pub rlim_cur: rlim_t,
                     pub rlim_max: rlim_t,
@@ -821,7 +828,7 @@ pub mod types {
                 use types::os::common::posix01::timeval;
                 use types::os::arch::c95::c_long;
                 #[repr(C)]
-                #[derive(Copy)]
+                #[derive(Copy, Clone)]
                 pub struct rusage {
                     pub ru_utime: timeval,
                     pub ru_stime: timeval,
@@ -851,13 +858,13 @@ pub mod types {
                 pub type in_port_t = u16;
                 pub type in_addr_t = u32;
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr {
+                #[derive(Copy, Clone)] pub struct sockaddr {
                     pub sa_len: u8,
                     pub sa_family: sa_family_t,
                     pub sa_data: [u8; 14],
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_storage {
+                #[derive(Copy, Clone)] pub struct sockaddr_storage {
                     pub ss_len: u8,
                     pub ss_family: sa_family_t,
                     pub __ss_pad1: [u8; 6],
@@ -865,7 +872,7 @@ pub mod types {
                     pub __ss_pad2: [u8; 112],
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_in {
+                #[derive(Copy, Clone)] pub struct sockaddr_in {
                     pub sin_len: u8,
                     pub sin_family: sa_family_t,
                     pub sin_port: in_port_t,
@@ -873,11 +880,11 @@ pub mod types {
                     pub sin_zero: [u8; 8],
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct in_addr {
+                #[derive(Copy, Clone)] pub struct in_addr {
                     pub s_addr: in_addr_t,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_in6 {
+                #[derive(Copy, Clone)] pub struct sockaddr_in6 {
                     pub sin6_len: u8,
                     pub sin6_family: sa_family_t,
                     pub sin6_port: in_port_t,
@@ -886,21 +893,21 @@ pub mod types {
                     pub sin6_scope_id: u32,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct in6_addr {
+                #[derive(Copy, Clone)] pub struct in6_addr {
                     pub s6_addr: [u16; 8]
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct ip_mreq {
+                #[derive(Copy, Clone)] pub struct ip_mreq {
                     pub imr_multiaddr: in_addr,
                     pub imr_interface: in_addr,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct ip6_mreq {
+                #[derive(Copy, Clone)] pub struct ip6_mreq {
                     pub ipv6mr_multiaddr: in6_addr,
                     pub ipv6mr_interface: c_uint,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct addrinfo {
+                #[derive(Copy, Clone)] pub struct addrinfo {
                     pub ai_flags: c_int,
                     pub ai_family: c_int,
                     pub ai_socktype: c_int,
@@ -911,13 +918,13 @@ pub mod types {
                     pub ai_next: *mut addrinfo,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_un {
+                #[derive(Copy, Clone)] pub struct sockaddr_un {
                     pub sun_len: u8,
                     pub sun_family: sa_family_t,
                     pub sun_path: [c_char; 104]
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct ifaddrs {
+                #[derive(Copy, Clone)] pub struct ifaddrs {
                     pub ifa_next: *mut ifaddrs,
                     pub ifa_name: *mut c_char,
                     pub ifa_flags: c_uint,
@@ -984,7 +991,7 @@ pub mod types {
                 pub type blkcnt_t = i64;
                 pub type fflags_t = u32;
                 #[repr(C)]
-                #[derive(Copy)] pub struct stat {
+                #[derive(Copy, Clone)] pub struct stat {
                     pub st_dev: dev_t,
                     pub st_ino: ino_t,
                     pub st_mode: mode_t,
@@ -1010,7 +1017,7 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct utimbuf {
+                #[derive(Copy, Clone)] pub struct utimbuf {
                     pub actime: time_t,
                     pub modtime: time_t,
                 }
@@ -1039,7 +1046,7 @@ pub mod types {
                 pub type rlim_t = i64;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct glob_t {
+                #[derive(Copy, Clone)] pub struct glob_t {
                     pub gl_pathc:  size_t,
                     pub __unused1: size_t,
                     pub gl_offs:   size_t,
@@ -1056,23 +1063,23 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct timeval {
+                #[derive(Copy, Clone)] pub struct timeval {
                     pub tv_sec: time_t,
                     pub tv_usec: suseconds_t,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct timespec {
+                #[derive(Copy, Clone)] pub struct timespec {
                     pub tv_sec: time_t,
                     pub tv_nsec: c_long,
                 }
 
-                #[derive(Copy)] pub enum timezone {}
+                #[derive(Copy, Clone)] pub enum timezone {}
 
                 pub type sighandler_t = size_t;
 
                 #[repr(C)]
-                #[derive(Copy)]
+                #[derive(Copy, Clone)]
                 pub struct rlimit {
                     pub rlim_cur: rlim_t,
                     pub rlim_max: rlim_t,
@@ -1083,7 +1090,7 @@ pub mod types {
                 use types::os::common::posix01::timeval;
                 use types::os::arch::c95::c_long;
                 #[repr(C)]
-                #[derive(Copy)]
+                #[derive(Copy, Clone)]
                 pub struct rusage {
                     pub ru_utime: timeval,
                     pub ru_stime: timeval,
@@ -1113,13 +1120,13 @@ pub mod types {
                 pub type in_port_t = u16;
                 pub type in_addr_t = u32;
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr {
+                #[derive(Copy, Clone)] pub struct sockaddr {
                     pub sa_len: u8,
                     pub sa_family: sa_family_t,
                     pub sa_data: [u8; 14],
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_storage {
+                #[derive(Copy, Clone)] pub struct sockaddr_storage {
                     pub ss_len: u8,
                     pub ss_family: sa_family_t,
                     pub __ss_pad1: [u8; 6],
@@ -1127,7 +1134,7 @@ pub mod types {
                     pub __ss_pad2: [u8; 112],
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_in {
+                #[derive(Copy, Clone)] pub struct sockaddr_in {
                     pub sin_len: u8,
                     pub sin_family: sa_family_t,
                     pub sin_port: in_port_t,
@@ -1135,11 +1142,11 @@ pub mod types {
                     pub sin_zero: [u8; 8],
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct in_addr {
+                #[derive(Copy, Clone)] pub struct in_addr {
                     pub s_addr: in_addr_t,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_in6 {
+                #[derive(Copy, Clone)] pub struct sockaddr_in6 {
                     pub sin6_len: u8,
                     pub sin6_family: sa_family_t,
                     pub sin6_port: in_port_t,
@@ -1148,21 +1155,21 @@ pub mod types {
                     pub sin6_scope_id: u32,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct in6_addr {
+                #[derive(Copy, Clone)] pub struct in6_addr {
                     pub s6_addr: [u16; 8]
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct ip_mreq {
+                #[derive(Copy, Clone)] pub struct ip_mreq {
                     pub imr_multiaddr: in_addr,
                     pub imr_interface: in_addr,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct ip6_mreq {
+                #[derive(Copy, Clone)] pub struct ip6_mreq {
                     pub ipv6mr_multiaddr: in6_addr,
                     pub ipv6mr_interface: c_uint,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct addrinfo {
+                #[derive(Copy, Clone)] pub struct addrinfo {
                     pub ai_flags: c_int,
                     pub ai_family: c_int,
                     pub ai_socktype: c_int,
@@ -1173,13 +1180,13 @@ pub mod types {
                     pub ai_next: *mut addrinfo,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_un {
+                #[derive(Copy, Clone)] pub struct sockaddr_un {
                     pub sun_len: u8,
                     pub sun_family: sa_family_t,
                     pub sun_path: [c_char; 104]
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct ifaddrs {
+                #[derive(Copy, Clone)] pub struct ifaddrs {
                     pub ifa_next: *mut ifaddrs,
                     pub ifa_name: *mut c_char,
                     pub ifa_flags: c_uint,
@@ -1246,7 +1253,7 @@ pub mod types {
                 pub type fflags_t = u32;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct stat {
+                #[derive(Copy, Clone)] pub struct stat {
                     pub st_ino: ino_t,
                     pub st_nlink: nlink_t,
                     pub st_dev: dev_t,
@@ -1271,7 +1278,7 @@ pub mod types {
                     pub st_qspare2: int64_t,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct utimbuf {
+                #[derive(Copy, Clone)] pub struct utimbuf {
                     pub actime: time_t,
                     pub modtime: time_t,
                 }
@@ -1301,7 +1308,7 @@ pub mod types {
 
                 #[cfg(target_os = "bitrig")]
                 #[repr(C)]
-                #[derive(Copy)] pub struct glob_t {
+                #[derive(Copy, Clone)] pub struct glob_t {
                     pub gl_pathc:  c_int,
                     pub gl_matchc: c_int,
                     pub gl_offs:   c_int,
@@ -1318,7 +1325,7 @@ pub mod types {
 
                 #[cfg(target_os = "openbsd")]
                 #[repr(C)]
-                #[derive(Copy)] pub struct glob_t {
+                #[derive(Copy, Clone)] pub struct glob_t {
                     pub gl_pathc:  c_int,
                     pub __unused1: c_int,
                     pub gl_offs:   c_int,
@@ -1336,23 +1343,23 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct timeval {
+                #[derive(Copy, Clone)] pub struct timeval {
                     pub tv_sec: time_t,
                     pub tv_usec: suseconds_t,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct timespec {
+                #[derive(Copy, Clone)] pub struct timespec {
                     pub tv_sec: time_t,
                     pub tv_nsec: c_long,
                 }
 
-                #[derive(Copy)] pub enum timezone {}
+                #[derive(Copy, Clone)] pub enum timezone {}
 
                 pub type sighandler_t = size_t;
 
                 #[repr(C)]
-                #[derive(Copy)]
+                #[derive(Copy, Clone)]
                 pub struct rlimit {
                     pub rlim_cur: rlim_t,
                     pub rlim_max: rlim_t,
@@ -1363,7 +1370,7 @@ pub mod types {
                 use types::os::common::posix01::timeval;
                 use types::os::arch::c95::c_long;
                 #[repr(C)]
-                #[derive(Copy)]
+                #[derive(Copy, Clone)]
                 pub struct rusage {
                     pub ru_utime: timeval,
                     pub ru_stime: timeval,
@@ -1393,13 +1400,13 @@ pub mod types {
                 pub type in_port_t = u16;
                 pub type in_addr_t = u32;
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr {
+                #[derive(Copy, Clone)] pub struct sockaddr {
                     pub sa_len: u8,
                     pub sa_family: sa_family_t,
                     pub sa_data: [u8; 14],
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_storage {
+                #[derive(Copy, Clone)] pub struct sockaddr_storage {
                     pub ss_len: u8,
                     pub ss_family: sa_family_t,
                     pub __ss_pad1: [u8; 6],
@@ -1407,7 +1414,7 @@ pub mod types {
                     pub __ss_pad3: [u8; 240],
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_in {
+                #[derive(Copy, Clone)] pub struct sockaddr_in {
                     pub sin_len: u8,
                     pub sin_family: sa_family_t,
                     pub sin_port: in_port_t,
@@ -1415,11 +1422,11 @@ pub mod types {
                     pub sin_zero: [u8; 8],
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct in_addr {
+                #[derive(Copy, Clone)] pub struct in_addr {
                     pub s_addr: in_addr_t,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_in6 {
+                #[derive(Copy, Clone)] pub struct sockaddr_in6 {
                     pub sin6_len: u8,
                     pub sin6_family: sa_family_t,
                     pub sin6_port: in_port_t,
@@ -1428,21 +1435,21 @@ pub mod types {
                     pub sin6_scope_id: u32,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct in6_addr {
+                #[derive(Copy, Clone)] pub struct in6_addr {
                     pub s6_addr: [u16; 8]
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct ip_mreq {
+                #[derive(Copy, Clone)] pub struct ip_mreq {
                     pub imr_multiaddr: in_addr,
                     pub imr_interface: in_addr,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct ip6_mreq {
+                #[derive(Copy, Clone)] pub struct ip6_mreq {
                     pub ipv6mr_multiaddr: in6_addr,
                     pub ipv6mr_interface: c_uint,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct addrinfo {
+                #[derive(Copy, Clone)] pub struct addrinfo {
                     pub ai_flags: c_int,
                     pub ai_family: c_int,
                     pub ai_socktype: c_int,
@@ -1453,13 +1460,13 @@ pub mod types {
                     pub ai_next: *mut addrinfo,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_un {
+                #[derive(Copy, Clone)] pub struct sockaddr_un {
                     pub sun_len: u8,
                     pub sun_family: sa_family_t,
                     pub sun_path: [c_char; 104]
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct ifaddrs {
+                #[derive(Copy, Clone)] pub struct ifaddrs {
                     pub ifa_next: *mut ifaddrs,
                     pub ifa_name: *mut c_char,
                     pub ifa_flags: c_uint,
@@ -1526,7 +1533,7 @@ pub mod types {
                 pub type fflags_t = u32; // type not declared, but struct stat have u_int32_t
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct stat {
+                #[derive(Copy, Clone)] pub struct stat {
                     pub st_mode: mode_t,
                     pub st_dev: dev_t,
                     pub st_ino: ino_t,
@@ -1549,7 +1556,7 @@ pub mod types {
                     pub st_birthtime_nsec: c_long,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct utimbuf {
+                #[derive(Copy, Clone)] pub struct utimbuf {
                     pub actime: time_t,
                     pub modtime: time_t,
                 }
@@ -1576,7 +1583,7 @@ pub mod types {
                 // pub Note: this is the struct called stat64 in Windows. Not stat,
                 // nor stati64.
                 #[repr(C)]
-                #[derive(Copy)] pub struct stat {
+                #[derive(Copy, Clone)] pub struct stat {
                     pub st_dev: dev_t,
                     pub st_ino: ino_t,
                     pub st_mode: u16,
@@ -1592,24 +1599,24 @@ pub mod types {
 
                 // note that this is called utimbuf64 in Windows
                 #[repr(C)]
-                #[derive(Copy)] pub struct utimbuf {
+                #[derive(Copy, Clone)] pub struct utimbuf {
                     pub actime: time64_t,
                     pub modtime: time64_t,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct timeval {
+                #[derive(Copy, Clone)] pub struct timeval {
                     pub tv_sec: c_long,
                     pub tv_usec: c_long,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct timespec {
+                #[derive(Copy, Clone)] pub struct timespec {
                     pub tv_sec: time_t,
                     pub tv_nsec: c_long,
                 }
 
-                #[derive(Copy)] pub enum timezone {}
+                #[derive(Copy, Clone)] pub enum timezone {}
             }
 
             pub mod bsd44 {
@@ -1622,30 +1629,30 @@ pub mod types {
                 pub type in_port_t = u16;
                 pub type in_addr_t = u32;
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr {
+                #[derive(Copy, Clone)] pub struct sockaddr {
                     pub sa_family: sa_family_t,
                     pub sa_data: [u8; 14],
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_storage {
+                #[derive(Copy, Clone)] pub struct sockaddr_storage {
                     pub ss_family: sa_family_t,
                     pub __ss_pad1: [u8; 6],
                     pub __ss_align: i64,
                     pub __ss_pad2: [u8; 112],
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_in {
+                #[derive(Copy, Clone)] pub struct sockaddr_in {
                     pub sin_family: sa_family_t,
                     pub sin_port: in_port_t,
                     pub sin_addr: in_addr,
                     pub sin_zero: [u8; 8],
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct in_addr {
+                #[derive(Copy, Clone)] pub struct in_addr {
                     pub s_addr: in_addr_t,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_in6 {
+                #[derive(Copy, Clone)] pub struct sockaddr_in6 {
                     pub sin6_family: sa_family_t,
                     pub sin6_port: in_port_t,
                     pub sin6_flowinfo: u32,
@@ -1653,21 +1660,21 @@ pub mod types {
                     pub sin6_scope_id: u32,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct in6_addr {
+                #[derive(Copy, Clone)] pub struct in6_addr {
                     pub s6_addr: [u16; 8]
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct ip_mreq {
+                #[derive(Copy, Clone)] pub struct ip_mreq {
                     pub imr_multiaddr: in_addr,
                     pub imr_interface: in_addr,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct ip6_mreq {
+                #[derive(Copy, Clone)] pub struct ip6_mreq {
                     pub ipv6mr_multiaddr: in6_addr,
                     pub ipv6mr_interface: c_uint,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct addrinfo {
+                #[derive(Copy, Clone)] pub struct addrinfo {
                     pub ai_flags: c_int,
                     pub ai_family: c_int,
                     pub ai_socktype: c_int,
@@ -1678,7 +1685,7 @@ pub mod types {
                     pub ai_next: *mut addrinfo,
                 }
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_un {
+                #[derive(Copy, Clone)] pub struct sockaddr_un {
                     pub sun_family: sa_family_t,
                     pub sun_path: [c_char; 108]
                 }
@@ -1807,7 +1814,7 @@ pub mod types {
                 pub type LPCH = *mut CHAR;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct SECURITY_ATTRIBUTES {
+                #[derive(Copy, Clone)] pub struct SECURITY_ATTRIBUTES {
                     pub nLength: DWORD,
                     pub lpSecurityDescriptor: LPVOID,
                     pub bInheritHandle: BOOL,
@@ -1831,7 +1838,7 @@ pub mod types {
                 pub type int64 = i64;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct STARTUPINFO {
+                #[derive(Copy, Clone)] pub struct STARTUPINFO {
                     pub cb: DWORD,
                     pub lpReserved: LPWSTR,
                     pub lpDesktop: LPWSTR,
@@ -1854,7 +1861,7 @@ pub mod types {
                 pub type LPSTARTUPINFO = *mut STARTUPINFO;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct PROCESS_INFORMATION {
+                #[derive(Copy, Clone)] pub struct PROCESS_INFORMATION {
                     pub hProcess: HANDLE,
                     pub hThread: HANDLE,
                     pub dwProcessId: DWORD,
@@ -1863,7 +1870,7 @@ pub mod types {
                 pub type LPPROCESS_INFORMATION = *mut PROCESS_INFORMATION;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct SYSTEM_INFO {
+                #[derive(Copy, Clone)] pub struct SYSTEM_INFO {
                     pub wProcessorArchitecture: WORD,
                     pub wReserved: WORD,
                     pub dwPageSize: DWORD,
@@ -1879,7 +1886,7 @@ pub mod types {
                 pub type LPSYSTEM_INFO = *mut SYSTEM_INFO;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct MEMORY_BASIC_INFORMATION {
+                #[derive(Copy, Clone)] pub struct MEMORY_BASIC_INFORMATION {
                     pub BaseAddress: LPVOID,
                     pub AllocationBase: LPVOID,
                     pub AllocationProtect: DWORD,
@@ -1891,7 +1898,7 @@ pub mod types {
                 pub type LPMEMORY_BASIC_INFORMATION = *mut MEMORY_BASIC_INFORMATION;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct OVERLAPPED {
+                #[derive(Copy, Clone)] pub struct OVERLAPPED {
                     pub Internal: *mut c_ulong,
                     pub InternalHigh: *mut c_ulong,
                     pub Offset: DWORD,
@@ -1902,7 +1909,7 @@ pub mod types {
                 pub type LPOVERLAPPED = *mut OVERLAPPED;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct FILETIME {
+                #[derive(Copy, Clone)] pub struct FILETIME {
                     pub dwLowDateTime: DWORD,
                     pub dwHighDateTime: DWORD,
                 }
@@ -1910,7 +1917,7 @@ pub mod types {
                 pub type LPFILETIME = *mut FILETIME;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct GUID {
+                #[derive(Copy, Clone)] pub struct GUID {
                     pub Data1: DWORD,
                     pub Data2: WORD,
                     pub Data3: WORD,
@@ -1918,7 +1925,7 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct WSAPROTOCOLCHAIN {
+                #[derive(Copy, Clone)] pub struct WSAPROTOCOLCHAIN {
                     pub ChainLen: c_int,
                     pub ChainEntries: [DWORD; MAX_PROTOCOL_CHAIN as usize],
                 }
@@ -1926,7 +1933,7 @@ pub mod types {
                 pub type LPWSAPROTOCOLCHAIN = *mut WSAPROTOCOLCHAIN;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct WSAPROTOCOL_INFO {
+                #[derive(Copy, Clone)] pub struct WSAPROTOCOL_INFO {
                     pub dwServiceFlags1: DWORD,
                     pub dwServiceFlags2: DWORD,
                     pub dwServiceFlags3: DWORD,
@@ -1954,7 +1961,7 @@ pub mod types {
                 pub type GROUP = c_uint;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct WIN32_FIND_DATAW {
+                #[derive(Copy, Clone)] pub struct WIN32_FIND_DATAW {
                     pub dwFileAttributes: DWORD,
                     pub ftCreationTime: FILETIME,
                     pub ftLastAccessTime: FILETIME,
@@ -1985,7 +1992,7 @@ pub mod types {
                 pub type rlim_t = u64;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct glob_t {
+                #[derive(Copy, Clone)] pub struct glob_t {
                     pub gl_pathc:  size_t,
                     pub __unused1: c_int,
                     pub gl_offs:   size_t,
@@ -2002,23 +2009,23 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct timeval {
+                #[derive(Copy, Clone)] pub struct timeval {
                     pub tv_sec: time_t,
                     pub tv_usec: suseconds_t,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct timespec {
+                #[derive(Copy, Clone)] pub struct timespec {
                     pub tv_sec: time_t,
                     pub tv_nsec: c_long,
                 }
 
-                #[derive(Copy)] pub enum timezone {}
+                #[derive(Copy, Clone)] pub enum timezone {}
 
                 pub type sighandler_t = size_t;
 
                 #[repr(C)]
-                #[derive(Copy)]
+                #[derive(Copy, Clone)]
                 pub struct rlimit {
                     pub rlim_cur: rlim_t,
                     pub rlim_max: rlim_t,
@@ -2029,7 +2036,7 @@ pub mod types {
                 use types::os::common::posix01::timeval;
                 use types::os::arch::c95::c_long;
                 #[repr(C)]
-                #[derive(Copy)]
+                #[derive(Copy, Clone)]
                 pub struct rusage {
                     pub ru_utime: timeval,
                     pub ru_stime: timeval,
@@ -2059,14 +2066,14 @@ pub mod types {
                 pub type in_port_t = u16;
                 pub type in_addr_t = u32;
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr {
+                #[derive(Copy, Clone)] pub struct sockaddr {
                     pub sa_len: u8,
                     pub sa_family: sa_family_t,
                     pub sa_data: [u8; 14],
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_storage {
+                #[derive(Copy, Clone)] pub struct sockaddr_storage {
                     pub ss_len: u8,
                     pub ss_family: sa_family_t,
                     pub __ss_pad1: [u8; 6],
@@ -2075,7 +2082,7 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_in {
+                #[derive(Copy, Clone)] pub struct sockaddr_in {
                     pub sin_len: u8,
                     pub sin_family: sa_family_t,
                     pub sin_port: in_port_t,
@@ -2084,12 +2091,12 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct in_addr {
+                #[derive(Copy, Clone)] pub struct in_addr {
                     pub s_addr: in_addr_t,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_in6 {
+                #[derive(Copy, Clone)] pub struct sockaddr_in6 {
                     pub sin6_len: u8,
                     pub sin6_family: sa_family_t,
                     pub sin6_port: in_port_t,
@@ -2099,24 +2106,24 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct in6_addr {
+                #[derive(Copy, Clone)] pub struct in6_addr {
                     pub s6_addr: [u16; 8]
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct ip_mreq {
+                #[derive(Copy, Clone)] pub struct ip_mreq {
                     pub imr_multiaddr: in_addr,
                     pub imr_interface: in_addr,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct ip6_mreq {
+                #[derive(Copy, Clone)] pub struct ip6_mreq {
                     pub ipv6mr_multiaddr: in6_addr,
                     pub ipv6mr_interface: c_uint,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct addrinfo {
+                #[derive(Copy, Clone)] pub struct addrinfo {
                     pub ai_flags: c_int,
                     pub ai_family: c_int,
                     pub ai_socktype: c_int,
@@ -2128,14 +2135,14 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct sockaddr_un {
+                #[derive(Copy, Clone)] pub struct sockaddr_un {
                     pub sun_len: u8,
                     pub sun_family: sa_family_t,
                     pub sun_path: [c_char; 104]
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct ifaddrs {
+                #[derive(Copy, Clone)] pub struct ifaddrs {
                     pub ifa_next: *mut ifaddrs,
                     pub ifa_name: *mut c_char,
                     pub ifa_flags: c_uint,
@@ -2200,7 +2207,7 @@ pub mod types {
                 pub type blkcnt_t = i64;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct stat {
+                #[derive(Copy, Clone)] pub struct stat {
                     pub st_dev: dev_t,
                     pub st_mode: mode_t,
                     pub st_nlink: nlink_t,
@@ -2226,13 +2233,13 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct utimbuf {
+                #[derive(Copy, Clone)] pub struct utimbuf {
                     pub actime: time_t,
                     pub modtime: time_t,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct pthread_attr_t {
+                #[derive(Copy, Clone)] pub struct pthread_attr_t {
                     pub __sig: c_long,
                     pub __opaque: [c_char; 36]
                 }
@@ -2243,7 +2250,7 @@ pub mod types {
             }
             pub mod extra {
                 #[repr(C)]
-                #[derive(Copy)] pub struct mach_timebase_info {
+                #[derive(Copy, Clone)] pub struct mach_timebase_info {
                     pub numer: u32,
                     pub denom: u32,
                 }
@@ -2306,7 +2313,7 @@ pub mod types {
                 pub type blkcnt_t = i64;
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct stat {
+                #[derive(Copy, Clone)] pub struct stat {
                     pub st_dev: dev_t,
                     pub st_mode: mode_t,
                     pub st_nlink: nlink_t,
@@ -2332,13 +2339,13 @@ pub mod types {
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct utimbuf {
+                #[derive(Copy, Clone)] pub struct utimbuf {
                     pub actime: time_t,
                     pub modtime: time_t,
                 }
 
                 #[repr(C)]
-                #[derive(Copy)] pub struct pthread_attr_t {
+                #[derive(Copy, Clone)] pub struct pthread_attr_t {
                     pub __sig: c_long,
                     pub __opaque: [c_char; 56]
                 }
@@ -2349,7 +2356,7 @@ pub mod types {
             }
             pub mod extra {
                 #[repr(C)]
-                #[derive(Copy)] pub struct mach_timebase_info {
+                #[derive(Copy, Clone)] pub struct mach_timebase_info {
                     pub numer: u32,
                     pub denom: u32,
                 }

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -812,7 +812,7 @@ pub mod types {
                     pub tv_nsec: c_long,
                 }
 
-                #[derive(Copy, Clone)] pub enum timezone {}
+                pub enum timezone {}
 
                 pub type sighandler_t = size_t;
 
@@ -1074,7 +1074,7 @@ pub mod types {
                     pub tv_nsec: c_long,
                 }
 
-                #[derive(Copy, Clone)] pub enum timezone {}
+                pub enum timezone {}
 
                 pub type sighandler_t = size_t;
 
@@ -1354,7 +1354,7 @@ pub mod types {
                     pub tv_nsec: c_long,
                 }
 
-                #[derive(Copy, Clone)] pub enum timezone {}
+                pub enum timezone {}
 
                 pub type sighandler_t = size_t;
 
@@ -1616,7 +1616,7 @@ pub mod types {
                     pub tv_nsec: c_long,
                 }
 
-                #[derive(Copy, Clone)] pub enum timezone {}
+                pub enum timezone {}
             }
 
             pub mod bsd44 {
@@ -2020,7 +2020,7 @@ pub mod types {
                     pub tv_nsec: c_long,
                 }
 
-                #[derive(Copy, Clone)] pub enum timezone {}
+                pub enum timezone {}
 
                 pub type sighandler_t = size_t;
 

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -239,7 +239,7 @@ pub trait Logger {
 struct DefaultLogger { handle: Stderr }
 
 /// Wraps the log level with fmt implementations.
-#[derive(Copy, PartialEq, PartialOrd, Debug)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct LogLevel(pub u32);
 
 impl fmt::Display for LogLevel {
@@ -355,7 +355,7 @@ pub struct LogRecord<'a> {
 }
 
 #[doc(hidden)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct LogLocation {
     pub module_path: &'static str,
     pub file: &'static str,

--- a/src/librand/distributions/exponential.rs
+++ b/src/librand/distributions/exponential.rs
@@ -29,7 +29,7 @@ use distributions::{ziggurat, ziggurat_tables, Sample, IndependentSample};
 /// Generate Normal Random
 /// Samples*](http://www.doornik.com/research/ziggurat.pdf). Nuffield
 /// College, Oxford
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Exp1(pub f64);
 
 // This could be done via `-rng.gen::<f64>().ln()` but that is slower.
@@ -68,7 +68,7 @@ impl Rand for Exp1 {
 /// let v = exp.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from a Exp(2) distribution", v);
 /// ```
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Exp {
     /// `lambda` stored as `1/lambda`, since this is what we scale by.
     lambda_inverse: f64

--- a/src/librand/distributions/normal.rs
+++ b/src/librand/distributions/normal.rs
@@ -28,7 +28,7 @@ use distributions::{ziggurat, ziggurat_tables, Sample, IndependentSample};
 /// Generate Normal Random
 /// Samples*](http://www.doornik.com/research/ziggurat.pdf). Nuffield
 /// College, Oxford
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct StandardNormal(pub f64);
 
 impl Rand for StandardNormal {
@@ -85,7 +85,7 @@ impl Rand for StandardNormal {
 /// let v = normal.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from a N(2, 9) distribution", v)
 /// ```
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Normal {
     mean: f64,
     std_dev: f64,
@@ -134,7 +134,7 @@ impl IndependentSample<f64> for Normal {
 /// let v = log_normal.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from an ln N(2, 9) distribution", v)
 /// ```
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct LogNormal {
     norm: Normal
 }

--- a/src/librand/reseeding.rs
+++ b/src/librand/reseeding.rs
@@ -134,7 +134,7 @@ pub trait Reseeder<R> {
 
 /// Reseed an RNG using a `Default` instance. This reseeds by
 /// replacing the RNG with the result of a `Default::default` call.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct ReseedWithDefault;
 
 impl<R: Rng + Default> Reseeder<R> for ReseedWithDefault {

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -175,7 +175,7 @@ pub struct TaggedDoc<'a> {
     pub doc: Doc<'a>,
 }
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum EbmlEncoderTag {
     // tags 00..1f are reserved for auto-serialization.
     // first NUM_IMPLICIT_TAGS tags are implicitly sized and lengths are not encoded.
@@ -265,7 +265,7 @@ pub mod reader {
         )
     }
 
-    #[derive(Copy)]
+    #[derive(Copy, Clone)]
     pub struct Res {
         pub val: usize,
         pub next: usize

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -113,7 +113,7 @@ declare_lint! {
 }
 /// Does nothing as a lint pass, but registers some `Lint`s
 /// which are used by other parts of the compiler.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct HardwiredLints;
 
 impl LintPass for HardwiredLints {

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -41,7 +41,7 @@ pub use lint::context::{Context, LintStore, raw_emit_lint, check_crate, gather_a
                         GatherNodeLevels};
 
 /// Specification of a single lint.
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Lint {
     /// A string identifier for the lint.
     ///

--- a/src/librustc/metadata/common.rs
+++ b/src/librustc/metadata/common.rs
@@ -116,7 +116,7 @@ pub const tag_items_data_item_reexport_def_id: usize = 0x47;
 pub const tag_items_data_item_reexport_name: usize = 0x48;
 
 // used to encode crate_ctxt side tables
-#[derive(Copy, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, PartialEq, FromPrimitive)]
 #[repr(usize)]
 pub enum astencode_tag { // Reserves 0x50 -- 0x6f
     tag_ast = 0x50,

--- a/src/librustc/metadata/csearch.rs
+++ b/src/librustc/metadata/csearch.rs
@@ -29,7 +29,7 @@ use syntax::parse::token;
 
 use std::collections::hash_map::HashMap;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct MethodInfo {
     pub name: ast::Name,
     pub def_id: ast::DefId,

--- a/src/librustc/metadata/filesearch.rs
+++ b/src/librustc/metadata/filesearch.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 use util::fs as myfs;
 use session::search_paths::{SearchPaths, PathKind};
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum FileMatch {
     FileMatches,
     FileDoesntMatch,

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -43,7 +43,7 @@ use syntax::parse::token;
 // def-id will depend on where it originated from.  Therefore, the conversion
 // function is given an indicator of the source of the def-id.  See
 // astencode.rs for more information.
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum DefIdSource {
     // Identifies a struct, trait, enum, etc.
     NominalType,

--- a/src/librustc/middle/cfg/construct.rs
+++ b/src/librustc/middle/cfg/construct.rs
@@ -25,7 +25,7 @@ struct CFGBuilder<'a, 'tcx: 'a> {
     loop_scopes: Vec<LoopScope>,
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct LoopScope {
     loop_id: ast::NodeId,     // id of loop/while node
     continue_index: CFGIndex, // where to go on a `loop`

--- a/src/librustc/middle/cfg/mod.rs
+++ b/src/librustc/middle/cfg/mod.rs
@@ -24,7 +24,7 @@ pub struct CFG {
     pub exit: CFGIndex,
 }
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum CFGNodeData {
     AST(ast::NodeId),
     Entry,

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -76,7 +76,7 @@ bitflags! {
     }
 }
 
-#[derive(Copy, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 enum Mode {
     Const,
     Static,

--- a/src/librustc/middle/check_loop.rs
+++ b/src/librustc/middle/check_loop.rs
@@ -21,7 +21,7 @@ enum Context {
     Normal, Loop, Closure
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct CheckLoopVisitor<'a> {
     sess: &'a Session,
     cx: Context

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -128,7 +128,7 @@ enum Usefulness {
     NotUseful
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum WitnessPreference {
     ConstructWitness,
     LeaveOutWitness

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -28,7 +28,7 @@ use syntax::visit;
 use syntax::print::{pp, pprust};
 use util::nodemap::NodeMap;
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum EntryOrExit {
     Entry,
     Exit,

--- a/src/librustc/middle/def.rs
+++ b/src/librustc/middle/def.rs
@@ -65,7 +65,7 @@ pub enum Def {
 ///     <T as Trait>::AssocX::AssocY::MethodOrAssocType
 ///           ^~~~~~~~~~~~~~  ^~~~~~~~~~~~~~~~~~~~~~~~~
 ///           base_def        depth = 2
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct PathResolution {
     pub base_def: Def,
     pub last_private: LastPrivate,
@@ -93,7 +93,7 @@ pub type DefMap = RefCell<NodeMap<PathResolution>>;
 // within.
 pub type ExportMap = NodeMap<Vec<Export>>;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Export {
     pub name: ast::Name,    // The name of the target.
     pub def_id: ast::DefId, // The definition of the target.

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -22,7 +22,7 @@ use syntax::codemap::Span;
 use syntax::visit;
 use syntax::visit::Visitor;
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 enum UnsafeContext {
     SafeContext,
     UnsafeFn,

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -94,7 +94,7 @@ pub trait Delegate<'tcx> {
               mode: MutateMode);
 }
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum LoanCause {
     ClosureCapture(Span),
     AddrOf,
@@ -106,20 +106,20 @@ pub enum LoanCause {
     MatchDiscriminant
 }
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum ConsumeMode {
     Copy,                // reference to x where x has a type that copies
     Move(MoveReason),    // reference to x where x has a type that moves
 }
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum MoveReason {
     DirectRefMove,
     PatBindingMove,
     CaptureMove,
 }
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum MatchMode {
     NonBindingMatch,
     BorrowingMatch,
@@ -127,7 +127,7 @@ pub enum MatchMode {
     MovingMatch,
 }
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 enum TrackMatchMode {
     Unknown,
     Definite(MatchMode),
@@ -194,14 +194,14 @@ impl TrackMatchMode {
     }
 }
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum MutateMode {
     Init,
     JustWrite,    // x = y
     WriteAndRead, // x += y
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum OverloadedCallType {
     FnOverloadedCall,
     FnMutOverloadedCall,

--- a/src/librustc/middle/graph.rs
+++ b/src/librustc/middle/graph.rs
@@ -66,13 +66,13 @@ pub struct NodeIndex(pub usize);
 #[allow(non_upper_case_globals)]
 pub const InvalidNodeIndex: NodeIndex = NodeIndex(usize::MAX);
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct EdgeIndex(pub usize);
 #[allow(non_upper_case_globals)]
 pub const InvalidEdgeIndex: EdgeIndex = EdgeIndex(usize::MAX);
 
 // Use a private field here to guarantee no more instances are created:
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Direction { repr: usize }
 #[allow(non_upper_case_globals)]
 pub const Outgoing: Direction = Direction { repr: 0 };

--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -294,7 +294,7 @@ pub enum RegionVariableOrigin<'tcx> {
     BoundRegionInCoherence(ast::Name),
 }
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum fixup_err {
     unresolved_int_ty(IntVid),
     unresolved_float_ty(FloatVid),

--- a/src/librustc/middle/infer/region_inference/mod.rs
+++ b/src/librustc/middle/infer/region_inference/mod.rs
@@ -74,13 +74,13 @@ pub enum GenericKind<'tcx> {
     Projection(ty::ProjectionTy<'tcx>),
 }
 
-#[derive(Copy, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct TwoRegions {
     a: Region,
     b: Region,
 }
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum UndoLogEntry {
     OpenSnapshot,
     CommitedSnapshot,
@@ -91,7 +91,7 @@ pub enum UndoLogEntry {
     AddCombination(CombineMapType, TwoRegions)
 }
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum CombineMapType {
     Lub, Glb
 }
@@ -944,10 +944,10 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
 
 // ______________________________________________________________________
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 enum Classification { Expanding, Contracting }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum VarValue { NoValue, Value(Region), ErrorValue }
 
 struct VarData {

--- a/src/librustc/middle/infer/type_variable.rs
+++ b/src/librustc/middle/infer/type_variable.rs
@@ -47,7 +47,7 @@ struct Delegate<'tcx>(PhantomData<&'tcx ()>);
 
 type Relation = (RelationDir, ty::TyVid);
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum RelationDir {
     SubtypeOf, SupertypeOf, EqTo, BiTo
 }

--- a/src/librustc/middle/infer/unify.rs
+++ b/src/librustc/middle/infer/unify.rs
@@ -92,7 +92,7 @@ pub struct Node<K:UnifyKey> {
     pub rank: usize,
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Delegate<K>(PhantomData<K>);
 
 // We can't use V:LatticeValue, much as I would like to,

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -46,7 +46,7 @@ macro_rules! lets_do_this {
         $( $variant:ident, $name:expr, $method:ident; )*
     ) => {
 
-#[derive(Copy, FromPrimitive, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, FromPrimitive, PartialEq, Eq, Hash)]
 pub enum LangItem {
     $($variant),*
 }

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -139,7 +139,7 @@ enum LoopKind<'a> {
     WhileLoop(&'a Expr),
 }
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 struct Variable(usize);
 
 #[derive(Copy, PartialEq)]
@@ -159,7 +159,7 @@ impl Clone for LiveNode {
     }
 }
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 enum LiveNodeKind {
     FreeVarNode(Span),
     ExprNode(Span),
@@ -245,13 +245,13 @@ struct CaptureInfo {
     var_nid: NodeId
 }
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 struct LocalInfo {
     id: NodeId,
     ident: ast::Ident
 }
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 enum VarKind {
     Arg(NodeId, ast::Ident),
     Local(LocalInfo),
@@ -534,7 +534,7 @@ fn invalid_users() -> Users {
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Specials {
     exit_ln: LiveNode,
     fallthrough_ln: LiveNode,

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -199,7 +199,7 @@ pub type cmt<'tcx> = Rc<cmt_<'tcx>>;
 
 // We pun on *T to mean both actual deref of a ptr as well
 // as accessing of components:
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum deref_kind {
     deref_ptr(PointerKind),
     deref_interior(InteriorKind),
@@ -263,6 +263,9 @@ pub struct MemCategorizationContext<'t,TYPER:'t> {
 }
 
 impl<'t,TYPER:'t> Copy for MemCategorizationContext<'t,TYPER> {}
+impl<'t,TYPER:'t> Clone for MemCategorizationContext<'t,TYPER> {
+    fn clone(&self) -> MemCategorizationContext<'t,TYPER> { *self }
+}
 
 pub type McResult<T> = Result<T, ()>;
 

--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -32,7 +32,7 @@ pub type ExternalExports = DefIdSet;
 /// reexporting a public struct doesn't inline the doc).
 pub type PublicItems = NodeSet;
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum LastPrivate {
     LastMod(PrivateDep),
     // `use` directives (imports) can refer to two separate definitions in the
@@ -46,14 +46,14 @@ pub enum LastPrivate {
                type_used: ImportUse},
 }
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum PrivateDep {
     AllPublic,
     DependsOn(ast::DefId),
 }
 
 // How an import is used.
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum ImportUse {
     Unused,       // The import is not used.
     Used,         // The import is used.

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -255,7 +255,7 @@ pub struct RegionMaps {
 /// Carries the node id for the innermost block or match expression,
 /// for building up the `var_map` which maps ids to the blocks in
 /// which they were declared.
-#[derive(PartialEq, Eq, Debug, Copy)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
 enum InnermostDeclaringBlock {
     None,
     Block(ast::NodeId),
@@ -280,7 +280,7 @@ impl InnermostDeclaringBlock {
 /// Contextual information for declarations introduced by a statement
 /// (i.e. `let`). It carries node-id's for statement and enclosing
 /// block both, as well as the statement's index within the block.
-#[derive(PartialEq, Eq, Debug, Copy)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
 struct DeclaringStatementContext {
     stmt_id: ast::NodeId,
     block_id: ast::NodeId,
@@ -296,7 +296,7 @@ impl DeclaringStatementContext {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Copy)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
 enum InnermostEnclosingExpr {
     None,
     Some(ast::NodeId),
@@ -318,7 +318,7 @@ impl InnermostEnclosingExpr {
     }
 }
 
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct Context {
     /// the scope that contains any new variables declared
     var_parent: InnermostDeclaringBlock,

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -96,7 +96,7 @@ pub enum MethodMatchResult {
     MethodDidNotMatch,
 }
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum MethodMatchedData {
     // In the case of a precise match, we don't really need to store
     // how the match was found. So don't.

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -261,7 +261,7 @@ pub struct field_ty {
 
 // Contains information needed to resolve types and (in the future) look up
 // the types of AST nodes.
-#[derive(Copy, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct creader_cache_key {
     pub cnum: CrateNum,
     pub pos: usize,
@@ -595,7 +595,7 @@ pub type ObjectCastMap<'tcx> = RefCell<NodeMap<ty::PolyTraitRef<'tcx>>>;
 /// will push one or more such restriction into the
 /// `transmute_restrictions` vector during `intrinsicck`. They are
 /// then checked during `trans` by the fn `check_intrinsics`.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct TransmuteRestriction<'tcx> {
     /// The span whence the restriction comes.
     pub span: Span,
@@ -885,7 +885,7 @@ macro_rules! sty_debug_print {
         // variable names.
         mod inner {
             use middle::ty;
-            #[derive(Copy)]
+            #[derive(Copy, Clone)]
             struct DebugStat {
                 total: usize,
                 region_infer: usize,
@@ -4012,7 +4012,7 @@ pub fn is_instantiable<'tcx>(cx: &ctxt<'tcx>, r_ty: Ty<'tcx>) -> bool {
 ///
 /// The ordering of the cases is significant. They are sorted so that cmp::max
 /// will keep the "more erroneous" of two values.
-#[derive(Copy, PartialOrd, Ord, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialOrd, Ord, Eq, PartialEq, Debug)]
 pub enum Representability {
     Representable,
     ContainsRecursive,
@@ -4743,7 +4743,7 @@ pub fn expr_is_lval(tcx: &ctxt, e: &ast::Expr) -> bool {
 /// two kinds of rvalues is an artifact of trans which reflects how we will
 /// generate code for that kind of expression.  See trans/expr.rs for more
 /// information.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum ExprKind {
     LvalueExpr,
     RvalueDpsExpr,
@@ -5439,7 +5439,7 @@ pub fn item_path_str(cx: &ctxt, id: ast::DefId) -> String {
     with_path(cx, id, |path| ast_map::path_to_string(path)).to_string()
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum DtorKind {
     NoDtor,
     TraitDtor(DefId, bool)
@@ -7163,7 +7163,7 @@ pub fn make_substs_for_receiver_types<'tcx>(tcx: &ty::ctxt<'tcx>,
     trait_ref.substs.clone().with_method(meth_tps, meth_regions)
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum CopyImplementationError {
     FieldDoesNotImplementCopy(ast::Name),
     VariantDoesNotImplementCopy(ast::Name),

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -247,7 +247,7 @@ pub fn basic_options() -> Options {
 // users can have their own entry
 // functions that don't start a
 // scheduler
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum EntryFnType {
     EntryMain,
     EntryStart,

--- a/src/librustc_back/target/apple_ios_base.rs
+++ b/src/librustc_back/target/apple_ios_base.rs
@@ -15,7 +15,7 @@ use target::TargetOptions;
 use self::Arch::*;
 
 #[allow(non_camel_case_types)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum Arch {
     Armv7,
     Armv7s,

--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -334,7 +334,7 @@ impl ToInteriorKind for mc::InteriorKind {
     }
 }
 
-#[derive(Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum LoanPathElem {
     LpDeref(mc::PointerKind),    // `*LV` in README.md
     LpInterior(InteriorKind),    // `LV.f` in README.md
@@ -500,13 +500,13 @@ pub struct BckError<'tcx> {
     code: bckerr_code
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum AliasableViolationKind {
     MutabilityViolation,
     BorrowViolation(euv::LoanCause)
 }
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum MovedValueUseKind {
     MovedInUse,
     MovedInCapture,

--- a/src/librustc_borrowck/borrowck/move_data.rs
+++ b/src/librustc_borrowck/borrowck/move_data.rs
@@ -94,7 +94,7 @@ impl Clone for MovePathIndex {
 const InvalidMovePathIndex: MovePathIndex = MovePathIndex(usize::MAX);
 
 /// Index into `MoveData.moves`, used like a pointer
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct MoveIndex(usize);
 
 impl MoveIndex {
@@ -125,7 +125,7 @@ pub struct MovePath<'tcx> {
     pub next_sibling: MovePathIndex,
 }
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum MoveKind {
     Declared,   // When declared, variables start out "moved".
     MoveExpr,   // Expression or binding that moves a variable
@@ -133,7 +133,7 @@ pub enum MoveKind {
     Captured    // Closure creation that moves a value
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Move {
     /// Path being moved.
     pub path: MovePathIndex,
@@ -148,7 +148,7 @@ pub struct Move {
     pub next_move: MoveIndex
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Assignment {
     /// Path being assigned.
     pub path: MovePathIndex,
@@ -160,7 +160,7 @@ pub struct Assignment {
     pub span: Span,
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct VariantMatch {
     /// downcast to the variant.
     pub path: MovePathIndex,

--- a/src/librustc_borrowck/graphviz.rs
+++ b/src/librustc_borrowck/graphviz.rs
@@ -26,7 +26,7 @@ use rustc::middle::dataflow;
 use std::rc::Rc;
 use std::borrow::IntoCow;
 
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub enum Variant {
     Loans,
     Moves,

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -182,7 +182,7 @@ fn make_input(free_matches: &[String]) -> Option<(Input, Option<PathBuf>)> {
 }
 
 // Whether to stop or continue compilation.
-#[derive(Copy, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Compilation {
     Stop,
     Continue,
@@ -265,7 +265,7 @@ pub trait CompilerCalls<'a> {
 }
 
 // CompilerCalls instance for a regular rustc build.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct RustcDefaultCalls;
 
 impl<'a> CompilerCalls<'a> for RustcDefaultCalls {

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -44,7 +44,7 @@ use std::option;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum PpSourceMode {
     PpmNormal,
     PpmEveryBodyLoops,
@@ -56,7 +56,7 @@ pub enum PpSourceMode {
 }
 
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum PpFlowGraphMode {
     Default,
     /// Drops the labels from the edges in the flowgraph output. This
@@ -65,7 +65,7 @@ pub enum PpFlowGraphMode {
     /// have become a pain to maintain.
     UnlabelledEdges,
 }
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum PpMode {
     PpmSource(PpSourceMode),
     PpmFlowGraph(PpFlowGraphMode),

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -63,7 +63,7 @@ declare_lint! {
     "suggest using `loop { }` instead of `while true { }`"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct WhileTrue;
 
 impl LintPass for WhileTrue {
@@ -107,7 +107,7 @@ declare_lint! {
     "shift exceeds the type's number of bits"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct TypeLimits {
     /// Id of the last visited negated expression
     negated_expr_id: ast::NodeId,
@@ -431,7 +431,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for ImproperCTypesVisitor<'a, 'tcx> {
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct ImproperCTypes;
 
 impl LintPass for ImproperCTypes {
@@ -474,7 +474,7 @@ declare_lint! {
     "use of owned (Box type) heap memory"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct BoxPointers;
 
 impl BoxPointers {
@@ -621,7 +621,7 @@ declare_lint! {
     "detects attributes that were not used by the compiler"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct UnusedAttributes;
 
 impl LintPass for UnusedAttributes {
@@ -662,7 +662,7 @@ declare_lint! {
     "path statements with no effect"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct PathStatements;
 
 impl LintPass for PathStatements {
@@ -696,7 +696,7 @@ declare_lint! {
     "unused result of an expression in a statement"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct UnusedResults;
 
 impl LintPass for UnusedResults {
@@ -764,7 +764,7 @@ declare_lint! {
     "types, variants, traits and type parameters should have camel case names"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct NonCamelCaseTypes;
 
 impl NonCamelCaseTypes {
@@ -874,7 +874,7 @@ declare_lint! {
     "methods, functions, lifetime parameters and modules should have snake case names"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct NonSnakeCase;
 
 impl NonSnakeCase {
@@ -1014,7 +1014,7 @@ declare_lint! {
     "static constants should have uppercase identifiers"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct NonUpperCaseGlobals;
 
 impl NonUpperCaseGlobals {
@@ -1072,7 +1072,7 @@ declare_lint! {
     "`if`, `match`, `while` and `return` do not need parentheses"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct UnusedParens;
 
 impl UnusedParens {
@@ -1166,7 +1166,7 @@ declare_lint! {
     "unnecessary braces around an imported item"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct UnusedImportBraces;
 
 impl LintPass for UnusedImportBraces {
@@ -1196,7 +1196,7 @@ declare_lint! {
     "using `Struct { x: x }` instead of `Struct { x }`"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct NonShorthandFieldPatterns;
 
 impl LintPass for NonShorthandFieldPatterns {
@@ -1233,7 +1233,7 @@ declare_lint! {
     "unnecessary use of an `unsafe` block"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct UnusedUnsafe;
 
 impl LintPass for UnusedUnsafe {
@@ -1258,7 +1258,7 @@ declare_lint! {
     "usage of `unsafe` code"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct UnsafeCode;
 
 impl LintPass for UnsafeCode {
@@ -1319,7 +1319,7 @@ declare_lint! {
     "detect mut variables which don't need to be mutable"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct UnusedMut;
 
 impl UnusedMut {
@@ -1388,7 +1388,7 @@ declare_lint! {
     "detects unnecessary allocations that can be eliminated"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct UnusedAllocation;
 
 impl LintPass for UnusedAllocation {
@@ -1625,7 +1625,7 @@ declare_lint! {
     "detects potentially-forgotten implementations of `Copy`"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct MissingCopyImplementations;
 
 impl LintPass for MissingCopyImplementations {
@@ -1740,7 +1740,7 @@ declare_lint! {
 }
 
 /// Checks for use of items with `#[deprecated]` attributes
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Stability;
 
 impl Stability {
@@ -1800,7 +1800,7 @@ declare_lint! {
     "functions that cannot return without calling themselves"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct UnconditionalRecursion;
 
 
@@ -1991,7 +1991,7 @@ declare_lint! {
     "compiler plugin used as ordinary library in non-plugin crate"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct PluginAsLibrary;
 
 impl LintPass for PluginAsLibrary {
@@ -2045,7 +2045,7 @@ declare_lint! {
     "const items will not have their symbols exported"
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct InvalidNoMangleItems;
 
 impl LintPass for InvalidNoMangleItems {
@@ -2088,7 +2088,7 @@ impl LintPass for InvalidNoMangleItems {
 }
 
 /// Forbids using the `#[feature(...)]` attribute
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct UnstableFeatures;
 
 declare_lint! {

--- a/src/librustc_llvm/diagnostic.rs
+++ b/src/librustc_llvm/diagnostic.rs
@@ -18,7 +18,7 @@ use std::ptr;
 
 use {ValueRef, TwineRef, DebugLocRef, DiagnosticInfoRef};
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum OptimizationDiagnosticKind {
     OptimizationRemark,
     OptimizationMissed,
@@ -38,7 +38,7 @@ impl OptimizationDiagnosticKind {
 }
 
 #[allow(raw_pointer_derive)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct OptimizationDiagnostic {
     pub kind: OptimizationDiagnosticKind,
     pub pass_name: *const c_char,
@@ -69,13 +69,12 @@ impl OptimizationDiagnostic {
     }
 }
 
+#[derive(Copy, Clone)]
 pub struct InlineAsmDiagnostic {
     pub cookie: c_uint,
     pub message: TwineRef,
     pub instruction: ValueRef,
 }
-
-impl Copy for InlineAsmDiagnostic {}
 
 impl InlineAsmDiagnostic {
     unsafe fn unpack(di: DiagnosticInfoRef)
@@ -96,7 +95,7 @@ impl InlineAsmDiagnostic {
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum Diagnostic {
     Optimization(OptimizationDiagnostic),
     InlineAsm(InlineAsmDiagnostic),

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -76,7 +76,7 @@ pub const False: Bool = 0 as Bool;
 
 // Consts for the LLVM CallConv type, pre-cast to usize.
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum CallConv {
     CCallConv = 0,
     FastCallConv = 8,
@@ -86,7 +86,7 @@ pub enum CallConv {
     X86_64_Win64 = 79,
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum Visibility {
     LLVMDefaultVisibility = 0,
     HiddenVisibility = 1,
@@ -97,7 +97,7 @@ pub enum Visibility {
 // DLLExportLinkage, GhostLinkage and LinkOnceODRAutoHideLinkage.
 // LinkerPrivateLinkage and LinkerPrivateWeakLinkage are not included either;
 // they've been removed in upstream LLVM commit r203866.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum Linkage {
     ExternalLinkage = 0,
     AvailableExternallyLinkage = 1,
@@ -113,7 +113,7 @@ pub enum Linkage {
 }
 
 #[repr(C)]
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum DiagnosticSeverity {
     Error,
     Warning,
@@ -154,7 +154,7 @@ bitflags! {
 
 
 #[repr(u64)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum OtherAttribute {
     // The following are not really exposed in
     // the LLVM c api so instead to add these
@@ -175,13 +175,13 @@ pub enum OtherAttribute {
     NonNullAttribute = 1 << 44,
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum SpecialAttribute {
     DereferenceableAttribute(u64)
 }
 
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum AttributeSet {
     ReturnIndex = 0,
     FunctionIndex = !0
@@ -273,7 +273,7 @@ impl AttrBuilder {
 }
 
 // enum for the LLVM IntPredicate type
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum IntPredicate {
     IntEQ = 32,
     IntNE = 33,
@@ -288,7 +288,7 @@ pub enum IntPredicate {
 }
 
 // enum for the LLVM RealPredicate type
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum RealPredicate {
     RealPredicateFalse = 0,
     RealOEQ = 1,
@@ -310,7 +310,7 @@ pub enum RealPredicate {
 
 // The LLVM TypeKind type - must stay in sync with the def of
 // LLVMTypeKind in llvm/include/llvm-c/Core.h
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 #[repr(C)]
 pub enum TypeKind {
     Void      = 0,
@@ -332,7 +332,7 @@ pub enum TypeKind {
 }
 
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum AtomicBinOp {
     AtomicXchg = 0,
     AtomicAdd  = 1,
@@ -348,7 +348,7 @@ pub enum AtomicBinOp {
 }
 
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum AtomicOrdering {
     NotAtomic = 0,
     Unordered = 1,
@@ -362,13 +362,13 @@ pub enum AtomicOrdering {
 
 // Consts for the LLVMCodeGenFileType type (in include/llvm/c/TargetMachine.h)
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum FileType {
     AssemblyFileType = 0,
     ObjectFileType = 1
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum MetadataType {
     MD_dbg = 0,
     MD_tbaa = 1,
@@ -385,13 +385,13 @@ pub enum MetadataType {
 }
 
 // Inline Asm Dialect
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum AsmDialect {
     AD_ATT   = 0,
     AD_Intel = 1
 }
 
-#[derive(Copy, PartialEq, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 #[repr(C)]
 pub enum CodeGenOptLevel {
     CodeGenLevelNone = 0,
@@ -400,7 +400,7 @@ pub enum CodeGenOptLevel {
     CodeGenLevelAggressive = 3,
 }
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 #[repr(C)]
 pub enum RelocMode {
     RelocDefault = 0,
@@ -410,7 +410,7 @@ pub enum RelocMode {
 }
 
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum CodeGenModel {
     CodeModelDefault = 0,
     CodeModelJITDefault = 1,
@@ -421,7 +421,7 @@ pub enum CodeGenModel {
 }
 
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum DiagnosticKind {
     DK_InlineAsm = 0,
     DK_StackSize,
@@ -533,7 +533,7 @@ pub mod debuginfo {
     pub type DIEnumerator = DIDescriptor;
     pub type DITemplateTypeParameter = DIDescriptor;
 
-    #[derive(Copy)]
+    #[derive(Copy, Clone)]
     pub enum DIDescriptorFlags {
       FlagPrivate            = 1 << 0,
       FlagProtected          = 1 << 1,

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -61,7 +61,7 @@ use std::rc::Rc;
 
 // Specifies how duplicates should be handled when adding a child item if
 // another item exists with the same name in some namespace.
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 enum DuplicateCheckingMode {
     ForbidDuplicateModules,
     ForbidDuplicateTypesAndModules,
@@ -70,7 +70,7 @@ enum DuplicateCheckingMode {
     OverwriteDuplicates
 }
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 enum NamespaceError {
     NoError,
     ModuleError,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -107,7 +107,7 @@ mod record_exports;
 mod build_reduced_graph;
 mod resolve_imports;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct BindingInfo {
     span: Span,
     binding_mode: BindingMode,
@@ -116,14 +116,14 @@ struct BindingInfo {
 // Map from the name in a pattern to its binding mode.
 type BindingMap = HashMap<Name, BindingInfo>;
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 enum PatternBindingMode {
     RefutableMode,
     LocalIrrefutableMode,
     ArgumentIrrefutableMode,
 }
 
-#[derive(Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 enum Namespace {
     TypeNS,
     ValueNS
@@ -277,7 +277,7 @@ enum FallbackSuggestion {
     TraitMethod(String),
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum TypeParameters<'a> {
     NoTypeParameters,
     HasTypeParameters(
@@ -294,7 +294,7 @@ enum TypeParameters<'a> {
 
 // The rib kind controls the translation of local
 // definitions (`DefLocal`) to upvars (`DefUpvar`).
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 enum RibKind {
     // No translation needs to be applied.
     NormalRibKind,
@@ -316,7 +316,7 @@ enum RibKind {
     ConstantItemRibKind
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum UseLexicalScopeFlag {
     DontUseLexicalScope,
     UseLexicalScope
@@ -327,7 +327,7 @@ enum ModulePrefixResult {
     PrefixFound(Rc<Module>, usize)
 }
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 enum NameSearchType {
     /// We're doing a name search in order to resolve a `use` directive.
     ImportSearch,
@@ -337,7 +337,7 @@ enum NameSearchType {
     PathSearch,
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum BareIdentifierPatternResolution {
     FoundStructOrEnumVariant(Def, LastPrivate),
     FoundConst(Def, LastPrivate),
@@ -369,7 +369,7 @@ enum ParentLink {
 }
 
 /// The type of module this is.
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 enum ModuleKind {
     NormalModuleKind,
     TraitModuleKind,
@@ -3539,7 +3539,7 @@ pub struct CrateMap {
     pub glob_map: Option<GlobMap>
 }
 
-#[derive(PartialEq,Copy)]
+#[derive(PartialEq,Copy, Clone)]
 pub enum MakeGlobMap {
     Yes,
     No

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -37,7 +37,7 @@ use std::rc::Rc;
 
 
 /// Contains data for specific types of import directives.
-#[derive(Copy,Debug)]
+#[derive(Copy, Clone,Debug)]
 pub enum ImportDirectiveSubclass {
     SingleImport(Name /* target */, Name /* source */),
     GlobImport

--- a/src/librustc_trans/save/recorder.rs
+++ b/src/librustc_trans/save/recorder.rs
@@ -62,7 +62,7 @@ macro_rules! svec {
     })
 }
 
-#[derive(Copy, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Row {
     Variable,
     Enum,

--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -228,7 +228,7 @@ use syntax::codemap::Span;
 use syntax::fold::Folder;
 use syntax::ptr::P;
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 struct ConstantExpr<'a>(&'a ast::Expr);
 
 impl<'a> ConstantExpr<'a> {
@@ -311,7 +311,7 @@ impl<'a, 'tcx> Opt<'a, 'tcx> {
     }
 }
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum BranchKind {
     NoBranch,
     Single,

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -2112,7 +2112,7 @@ pub fn llvm_linkage_by_name(name: &str) -> Option<Linkage> {
 
 
 /// Enum describing the origin of an LLVM `Value`, for linkage purposes.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum ValueOrigin {
     /// The LLVM `Value` is in this context because the corresponding item was
     /// assigned to the current compilation unit.

--- a/src/librustc_trans/trans/basic_block.rs
+++ b/src/librustc_trans/trans/basic_block.rs
@@ -13,7 +13,7 @@ use llvm::BasicBlockRef;
 use trans::value::{Users, Value};
 use std::iter::{Filter, Map};
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct BasicBlock(pub BasicBlockRef);
 
 pub type Preds = Map<Filter<Users, fn(&Value) -> bool>, fn(Value) -> BasicBlock>;

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -60,7 +60,7 @@ use syntax::ast;
 use syntax::ast_map;
 use syntax::ptr::P;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct MethodData {
     pub llfn: ValueRef,
     pub llself: ValueRef,
@@ -1110,7 +1110,7 @@ pub fn trans_args<'a, 'blk, 'tcx>(cx: Block<'blk, 'tcx>,
     bcx
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum AutorefArg {
     DontAutorefArg,
     DoAutorefArg(ast::NodeId)

--- a/src/librustc_trans/trans/cleanup.rs
+++ b/src/librustc_trans/trans/cleanup.rs
@@ -153,7 +153,7 @@ pub struct CleanupScope<'blk, 'tcx: 'blk> {
     cached_landing_pad: Option<BasicBlockRef>,
 }
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct CustomScopeIndex {
     index: usize
 }
@@ -184,14 +184,14 @@ impl<'blk, 'tcx: 'blk> fmt::Debug for CleanupScopeKind<'blk, 'tcx> {
     }
 }
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum EarlyExitLabel {
     UnwindExit,
     ReturnExit,
     LoopExit(ast::NodeId, usize)
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct CachedEarlyExit {
     label: EarlyExitLabel,
     cleanup_block: BasicBlockRef,
@@ -209,7 +209,7 @@ pub trait Cleanup<'tcx> {
 
 pub type CleanupObj<'tcx> = Box<Cleanup<'tcx>+'tcx>;
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum ScopeId {
     AstScope(ast::NodeId),
     CustomScope(CustomScopeIndex)
@@ -982,7 +982,7 @@ impl EarlyExitLabel {
 ///////////////////////////////////////////////////////////////////////////
 // Cleanup types
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct DropValue<'tcx> {
     is_immediate: bool,
     must_unwind: bool,
@@ -1021,12 +1021,12 @@ impl<'tcx> Cleanup<'tcx> for DropValue<'tcx> {
     }
 }
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum Heap {
     HeapExchange
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct FreeValue<'tcx> {
     ptr: ValueRef,
     heap: Heap,
@@ -1061,7 +1061,7 @@ impl<'tcx> Cleanup<'tcx> for FreeValue<'tcx> {
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct FreeSlice {
     ptr: ValueRef,
     size: ValueRef,
@@ -1098,7 +1098,7 @@ impl<'tcx> Cleanup<'tcx> for FreeSlice {
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct LifetimeEnd {
     ptr: ValueRef,
 }

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -343,7 +343,7 @@ pub fn gensym_name(name: &str) -> PathElem {
 *
 */
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct NodeIdAndSpan {
     pub id: ast::NodeId,
     pub span: Span,
@@ -1225,7 +1225,7 @@ pub fn drain_fulfillment_cx<'a,'tcx,T>(infcx: &infer::InferCtxt<'a,'tcx>,
 }
 
 // Key used to lookup values supplied for type parameters in an expr.
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum ExprOrMethodCall {
     // Type parameters for a path like `None::<int>`
     ExprId(ast::NodeId),

--- a/src/librustc_trans/trans/datum.rs
+++ b/src/librustc_trans/trans/datum.rs
@@ -172,7 +172,7 @@ impl Drop for Rvalue {
     fn drop(&mut self) { }
 }
 
-#[derive(Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum RvalueMode {
     /// `val` is a pointer to the actual value (and thus has type *T)
     ByRef,

--- a/src/librustc_trans/trans/debuginfo.rs
+++ b/src/librustc_trans/trans/debuginfo.rs
@@ -2382,7 +2382,7 @@ impl<'tcx> VariantMemberDescriptionFactory<'tcx> {
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum EnumDiscriminantInfo {
     RegularDiscriminant(DIType),
     OptimizedDiscriminant,
@@ -3106,7 +3106,7 @@ impl MetadataCreationResult {
     }
 }
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 enum InternalDebugLocation {
     KnownLocation { scope: DIScope, line: usize, col: usize },
     UnknownLocation

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -94,7 +94,7 @@ use std::rc::Rc;
 // These are passed around by the code generating functions to track the
 // destination of a computation's value.
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Dest {
     SaveIn(ValueRef),
     Ignore,
@@ -2038,7 +2038,7 @@ fn float_cast(bcx: Block,
     } else { llsrc };
 }
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum cast_kind {
     cast_pointer,
     cast_integral,

--- a/src/librustc_trans/trans/mod.rs
+++ b/src/librustc_trans/trans/mod.rs
@@ -57,7 +57,7 @@ mod basic_block;
 mod llrepr;
 mod cleanup;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct ModuleTranslation {
     pub llcx: ContextRef,
     pub llmod: ModuleRef,

--- a/src/librustc_trans/trans/tvec.rs
+++ b/src/librustc_trans/trans/tvec.rs
@@ -33,7 +33,7 @@ use util::ppaux::ty_to_string;
 use syntax::ast;
 use syntax::parse::token::InternedString;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct VecTypes<'tcx> {
     unit_ty: Ty<'tcx>,
     llunit_ty: Type

--- a/src/librustc_trans/trans/value.rs
+++ b/src/librustc_trans/trans/value.rs
@@ -14,7 +14,7 @@ use trans::basic_block::BasicBlock;
 use trans::common::Block;
 use libc::c_uint;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Value(pub ValueRef);
 
 macro_rules! opt_val { ($e:expr) => (
@@ -125,7 +125,7 @@ impl Value {
 }
 
 /// Wrapper for LLVM UseRef
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Use(UseRef);
 
 impl Use {

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -52,7 +52,7 @@ pub enum MethodError {
 
 // A pared down enum describing just the places from which a method
 // candidate can arise. Used for error reporting only.
-#[derive(Copy, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
 pub enum CandidateSource {
     ImplSource(ast::DefId),
     TraitSource(/* trait id */ ast::DefId),

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -109,7 +109,7 @@ pub enum PickAdjustment {
     AutoRef(ast::Mutability, Box<PickAdjustment>),
 }
 
-#[derive(PartialEq, Eq, Copy)]
+#[derive(PartialEq, Eq, Copy, Clone)]
 pub enum Mode {
     // An expression of the form `receiver.method_name(...)`.
     // Autoderefs are performed on `receiver`, lookup is done based on the

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -266,7 +266,7 @@ fn type_derefs_to_local<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     }).2.is_some()
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct TraitInfo {
     pub def_id: ast::DefId,
 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -204,7 +204,7 @@ struct CastCheck<'tcx> {
 
 /// When type-checking an expression, we propagate downward
 /// whatever type hint we are able in the form of an `Expectation`.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum Expectation<'tcx> {
     /// We know nothing about what type this expression should have.
     NoExpectation,
@@ -1951,14 +1951,14 @@ impl<'a, 'tcx> RegionScope for FnCtxt<'a, 'tcx> {
     }
 }
 
-#[derive(Copy, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum LvaluePreference {
     PreferMutLvalue,
     NoPreference
 }
 
 /// Whether `autoderef` requires types to resolve.
-#[derive(Copy, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum UnresolvedTypeAction {
     /// Produce an error and return `ty_err` whenever a type cannot
     /// be resolved (i.e. it is `ty_infer`).

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -249,11 +249,6 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
                                                         &fcx.inh.param_env.free_substs,
                                                         &trait_ref);
 
-            if fcx.tcx().lang_items.copy_trait() == Some(trait_ref.def_id) {
-                // This is checked in coherence.
-                return
-            }
-
             // We are stricter on the trait-ref in an impl than the
             // self-type.  In particular, we enforce region
             // relationships. The reason for this is that (at least

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -350,7 +350,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
 ///////////////////////////////////////////////////////////////////////////
 // Resolution reason.
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum ResolveReason {
     ResolvingExpr(Span),
     ResolvingLocal(Span),

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -135,7 +135,7 @@ struct ItemCtxt<'a,'tcx:'a> {
     param_bounds: &'a (GetTypeParameterBounds<'tcx>+'a),
 }
 
-#[derive(Copy, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 enum AstConvRequest {
     GetItemTypeScheme(ast::DefId),
     GetTraitDef(ast::DefId),

--- a/src/librustc_typeck/rscope.rs
+++ b/src/librustc_typeck/rscope.rs
@@ -40,7 +40,7 @@ pub trait RegionScope {
 
 // A scope in which all regions must be explicitly named. This is used
 // for types that appear in structs and so on.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct ExplicitRscope;
 
 impl RegionScope for ExplicitRscope {

--- a/src/librustc_typeck/variance.rs
+++ b/src/librustc_typeck/variance.rs
@@ -295,10 +295,10 @@ pub fn infer_variance(tcx: &ty::ctxt) {
 
 type VarianceTermPtr<'a> = &'a VarianceTerm<'a>;
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 struct InferredIndex(usize);
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum VarianceTerm<'a> {
     ConstantTerm(ty::Variance),
     TransformTerm(VarianceTermPtr<'a>, VarianceTermPtr<'a>),
@@ -336,7 +336,7 @@ struct TermsContext<'a, 'tcx: 'a> {
     inferred_infos: Vec<InferredInfo<'a>> ,
 }
 
-#[derive(Copy, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 enum ParamKind {
     TypeParam,
     RegionParam,
@@ -560,7 +560,7 @@ struct ConstraintContext<'a, 'tcx: 'a> {
 
 /// Declares that the variable `decl_id` appears in a location with
 /// variance `variance`.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Constraint<'a> {
     inferred: InferredIndex,
     variance: &'a VarianceTerm<'a>,

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -30,19 +30,19 @@ use html::render::{cache, CURRENT_LOCATION_KEY};
 
 /// Helper to render an optional visibility with a space after it (if the
 /// visibility is preset)
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct VisSpace(pub Option<ast::Visibility>);
 /// Similarly to VisSpace, this structure is used to render a function style with a
 /// space after it.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct UnsafetySpace(pub ast::Unsafety);
 /// Wrapper struct for properly emitting a method declaration.
 pub struct Method<'a>(pub &'a clean::SelfTy, pub &'a clean::FnDecl);
 /// Similar to VisSpace, but used for mutability
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct MutableSpace(pub clean::Mutability);
 /// Similar to VisSpace, but used for mutability
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct RawMutableSpace(pub clean::Mutability);
 /// Wrapper struct for properly emitting the stability level.
 pub struct Stability<'a>(pub &'a Option<clean::Stability>);

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -225,7 +225,7 @@ struct Source<'a>(&'a str);
 // Helper structs for rendering items/sidebars and carrying along contextual
 // information
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Item<'a> {
     cx: &'a Context,
     item: &'a clean::Item,

--- a/src/librustdoc/stability_summary.rs
+++ b/src/librustdoc/stability_summary.rs
@@ -27,7 +27,7 @@ use html::render::cache;
 
 #[derive(RustcEncodable, RustcDecodable, PartialEq, Eq)]
 /// The counts for each stability level.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Counts {
     pub deprecated: u64,
     pub unstable: u64,

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -62,7 +62,7 @@ pub trait FromHex {
 }
 
 /// Errors that can occur when decoding a hex encoded string
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum FromHexError {
     /// The input contained a character not part of the hex format
     InvalidHexCharacter(char, usize),

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -278,7 +278,7 @@ pub enum DecoderError {
     ApplicationError(string::String)
 }
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum EncoderError {
     FmtError(fmt::Error),
     BadHashmapKey,

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -87,6 +87,9 @@ struct RawBucket<K, V> {
 }
 
 impl<K,V> Copy for RawBucket<K,V> {}
+impl<K,V> Clone for RawBucket<K,V> {
+    fn clone(&self) -> RawBucket<K, V> { *self }
+}
 
 pub struct Bucket<K, V, M> {
     raw:   RawBucket<K, V>,
@@ -95,6 +98,9 @@ pub struct Bucket<K, V, M> {
 }
 
 impl<K,V,M:Copy> Copy for Bucket<K,V,M> {}
+impl<K,V,M:Copy> Clone for Bucket<K,V,M> {
+    fn clone(&self) -> Bucket<K,V,M> { *self }
+}
 
 pub struct EmptyBucket<K, V, M> {
     raw:   RawBucket<K, V>,
@@ -129,7 +135,7 @@ struct GapThenFull<K, V, M> {
 
 /// A hash that is not zero, since we use a hash of zero to represent empty
 /// buckets.
-#[derive(PartialEq, Copy)]
+#[derive(PartialEq, Copy, Clone)]
 pub struct SafeHash {
     hash: u64,
 }

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -25,7 +25,7 @@ use string::String;
 use vec::Vec;
 
 /// A flag that specifies whether to use exponential (scientific) notation.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum ExponentFormat {
     /// Do not use exponential notation.
     ExpNone,
@@ -40,7 +40,7 @@ pub enum ExponentFormat {
 
 /// The number of digits used for emitting the fractional part of a number, if
 /// any.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum SignificantDigits {
     /// All calculable digits will be printed.
     ///
@@ -57,7 +57,7 @@ pub enum SignificantDigits {
 }
 
 /// How to emit the sign of a number.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum SignFormat {
     /// No sign will be printed. The exponent sign will also be emitted.
     SignNone,

--- a/src/libstd/old_io/mod.rs
+++ b/src/libstd/old_io/mod.rs
@@ -391,7 +391,7 @@ impl Error for IoError {
 }
 
 /// A list specifying general categories of I/O error.
-#[derive(Copy, PartialEq, Eq, Clone, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum IoErrorKind {
     /// Any I/O error not part of this list.
     OtherIoError,
@@ -1553,7 +1553,7 @@ impl<T: Buffer> BufferPrelude for T {
 
 /// When seeking, the resulting cursor is offset from a base by the offset given
 /// to the `seek` function. The base used is specified by this enumeration.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum SeekStyle {
     /// Seek from the beginning of the stream
     SeekSet,
@@ -1744,7 +1744,7 @@ pub enum FileType {
 ///
 /// println!("byte size: {}", info.size);
 /// ```
-#[derive(Copy, Hash)]
+#[derive(Copy, Clone, Hash)]
 pub struct FileStat {
     /// The size of the file, in bytes
     pub size: u64,
@@ -1783,7 +1783,7 @@ pub struct FileStat {
 /// structure. This information is not necessarily platform independent, and may
 /// have different meanings or no meaning at all on some platforms.
 #[unstable(feature = "io")]
-#[derive(Copy, Hash)]
+#[derive(Copy, Clone, Hash)]
 pub struct UnstableFileStat {
     /// The ID of the device containing the file.
     pub device: u64,

--- a/src/libstd/old_io/net/addrinfo.rs
+++ b/src/libstd/old_io/net/addrinfo.rs
@@ -29,7 +29,7 @@ use sys;
 use vec::Vec;
 
 /// Hints to the types of sockets that are desired when looking up hosts
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum SocketType {
     Stream, Datagram, Raw
 }
@@ -38,7 +38,7 @@ pub enum SocketType {
 /// to manipulate how a query is performed.
 ///
 /// The meaning of each of these flags can be found with `man -s 3 getaddrinfo`
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum Flag {
     AddrConfig,
     All,
@@ -51,7 +51,7 @@ pub enum Flag {
 
 /// A transport protocol associated with either a hint or a return value of
 /// `lookup`
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum Protocol {
     TCP, UDP
 }
@@ -61,7 +61,7 @@ pub enum Protocol {
 ///
 /// For details on these fields, see their corresponding definitions via
 /// `man -s 3 getaddrinfo`
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Hint {
     pub family: usize,
     pub socktype: Option<SocketType>,
@@ -69,7 +69,7 @@ pub struct Hint {
     pub flags: usize,
 }
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Info {
     pub address: SocketAddr,
     pub family: usize,

--- a/src/libstd/old_io/util.rs
+++ b/src/libstd/old_io/util.rs
@@ -90,7 +90,7 @@ impl<R: Buffer> Buffer for LimitReader<R> {
 }
 
 /// A `Writer` which ignores bytes written to it, like /dev/null.
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[deprecated(since = "1.0.0", reason = "use std::io::sink() instead")]
 #[unstable(feature = "old_io")]
 pub struct NullWriter;
@@ -103,7 +103,7 @@ impl Writer for NullWriter {
 }
 
 /// A `Reader` which returns an infinite stream of 0 bytes, like /dev/zero.
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[deprecated(since = "1.0.0", reason = "use std::io::repeat(0) instead")]
 #[unstable(feature = "old_io")]
 pub struct ZeroReader;
@@ -130,7 +130,7 @@ impl Buffer for ZeroReader {
 }
 
 /// A `Reader` which is always at EOF, like /dev/null.
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 #[deprecated(since = "1.0.0", reason = "use std::io::empty() instead")]
 #[unstable(feature = "old_io")]
 pub struct NullReader;

--- a/src/libstd/rt/libunwind.rs
+++ b/src/libstd/rt/libunwind.rs
@@ -25,7 +25,7 @@ use libc;
 
 #[cfg(any(not(target_arch = "arm"), target_os = "ios"))]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum _Unwind_Action {
     _UA_SEARCH_PHASE = 1,
     _UA_CLEANUP_PHASE = 2,

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -197,7 +197,7 @@ macro_rules! __thread_local_inner {
 /// Indicator of the state of a thread local storage key.
 #[unstable(feature = "std_misc",
            reason = "state querying was recently added")]
-#[derive(Eq, PartialEq, Copy)]
+#[derive(Eq, PartialEq, Copy, Clone)]
 pub enum LocalKeyState {
     /// All keys are in this state whenever a thread starts. Keys will
     /// transition to the `Valid` state once the first call to `with` happens

--- a/src/libsyntax/abi.rs
+++ b/src/libsyntax/abi.rs
@@ -15,7 +15,7 @@ pub use self::AbiArchitecture::*;
 
 use std::fmt;
 
-#[derive(Copy, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Os {
     OsWindows,
     OsMacos,
@@ -49,7 +49,7 @@ pub enum Abi {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Architecture {
     X86,
     X86_64,
@@ -58,7 +58,7 @@ pub enum Architecture {
     Mipsel
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct AbiData {
     abi: Abi,
 
@@ -66,7 +66,7 @@ pub struct AbiData {
     name: &'static str,
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum AbiArchitecture {
     /// Not a real ABI (e.g., intrinsic)
     RustArch,

--- a/src/libsyntax/ast_map/blocks.rs
+++ b/src/libsyntax/ast_map/blocks.rs
@@ -40,7 +40,7 @@ use visit;
 ///   - The default implementation for a trait method.
 ///
 /// To construct one, use the `Code::from_node` function.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct FnLikeNode<'a> { node: ast_map::Node<'a> }
 
 /// MaybeFnLike wraps a method that indicates if an object
@@ -80,7 +80,7 @@ impl MaybeFnLike for ast::Expr {
 /// Carries either an FnLikeNode or a Block, as these are the two
 /// constructs that correspond to "code" (as in, something from which
 /// we can construct a control-flow graph).
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum Code<'a> {
     FnLikeCode(FnLikeNode<'a>),
     BlockCode(&'a Block),

--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -90,7 +90,7 @@ pub fn path_to_string<PI: Iterator<Item=PathElem>>(path: PI) -> String {
     })
 }
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum Node<'ast> {
     NodeItem(&'ast Item),
     NodeForeignItem(&'ast ForeignItem),

--- a/src/libsyntax/ast_util.rs
+++ b/src/libsyntax/ast_util.rs
@@ -291,7 +291,7 @@ pub fn empty_generics() -> Generics {
 // ______________________________________________________________________
 // Enumerating the IDs which appear in an AST
 
-#[derive(RustcEncodable, RustcDecodable, Debug, Copy)]
+#[derive(Copy, Clone, RustcEncodable, RustcDecodable, Debug)]
 pub struct IdRange {
     pub min: NodeId,
     pub max: NodeId,

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -282,7 +282,7 @@ pub fn find_crate_name(attrs: &[Attribute]) -> Option<InternedString> {
     first_attr_value_str_by_name(attrs, "crate_name")
 }
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum InlineAttr {
     None,
     Hint,
@@ -571,7 +571,7 @@ fn int_type_of_word(s: &str) -> Option<IntType> {
     }
 }
 
-#[derive(PartialEq, Debug, RustcEncodable, RustcDecodable, Copy)]
+#[derive(PartialEq, Debug, RustcEncodable, RustcDecodable, Copy, Clone)]
 pub enum ReprAttr {
     ReprAny,
     ReprInt(Span, IntType),
@@ -590,7 +590,7 @@ impl ReprAttr {
     }
 }
 
-#[derive(Eq, Hash, PartialEq, Debug, RustcEncodable, RustcDecodable, Copy)]
+#[derive(Eq, Hash, PartialEq, Debug, RustcEncodable, RustcDecodable, Copy, Clone)]
 pub enum IntType {
     SignedInt(ast::IntTy),
     UnsignedInt(ast::UintTy)

--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -47,7 +47,7 @@ pub struct BytePos(pub u32);
 /// A character offset. Because of multibyte utf8 characters, a byte offset
 /// is not equivalent to a character offset. The CodeMap will convert BytePos
 /// values to CharPos values as necessary.
-#[derive(Copy, PartialEq, Hash, PartialOrd, Debug)]
+#[derive(Copy, Clone, PartialEq, Hash, PartialOrd, Debug)]
 pub struct CharPos(pub usize);
 
 // FIXME: Lots of boilerplate in these impls, but so far my attempts to fix
@@ -305,7 +305,7 @@ pub struct FileLines {
 }
 
 /// Identifies an offset of a multi-byte character in a FileMap
-#[derive(Copy, RustcEncodable, RustcDecodable, Eq, PartialEq)]
+#[derive(Copy, Clone, RustcEncodable, RustcDecodable, Eq, PartialEq)]
 pub struct MultiByteChar {
     /// The absolute offset of the character in the CodeMap
     pub pos: BytePos,

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -71,12 +71,12 @@ pub trait Emitter {
 /// This structure is used to signify that a task has panicked with a fatal error
 /// from the diagnostics. You can use this with the `Any` trait to figure out
 /// how a rustc task died (if so desired).
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct FatalError;
 
 /// Signifies that the compiler died with an explicit call to `.bug`
 /// or `.span_bug` rather than a failed assertion, etc.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct ExplicitBug;
 
 /// A span-handler is like a handler but also

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -318,7 +318,7 @@ impl MacResult for MacEager {
 
 /// Fill-in macro expansion result, to allow compilation to continue
 /// after hitting errors.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct DummyResult {
     expr_only: bool,
     span: Span

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -84,7 +84,7 @@ pub fn expand_deriving_ord<F>(cx: &mut ExtCtxt,
     trait_def.expand(cx, mitem, item, push)
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum OrderingOp {
     PartialCmpOp, LtOp, LeOp, GtOp, GeOp,
 }

--- a/src/libsyntax/ext/mtwt.rs
+++ b/src/libsyntax/ext/mtwt.rs
@@ -38,7 +38,7 @@ pub struct SCTable {
     rename_memo: RefCell<HashMap<(SyntaxContext,Ident,Name),SyntaxContext>>,
 }
 
-#[derive(PartialEq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+#[derive(PartialEq, RustcEncodable, RustcDecodable, Hash, Debug, Copy, Clone)]
 pub enum SyntaxContext_ {
     EmptyCtxt,
     Mark (Mrk,SyntaxContext),

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -286,7 +286,7 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType)] = &[
     ("recursion_limit", CrateLevel),
 ];
 
-#[derive(PartialEq, Copy, Debug)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum AttributeType {
     /// Normal, builtin attribute that is consumed
     /// by the compiler before the unused_attribute check

--- a/src/libsyntax/parse/obsolete.rs
+++ b/src/libsyntax/parse/obsolete.rs
@@ -20,7 +20,7 @@ use parse::token;
 use ptr::P;
 
 /// The specific types of unsupported syntax
-#[derive(Copy, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ObsoleteSyntax {
     ClosureKind,
     ExternCrateString,

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -96,7 +96,7 @@ type ItemInfo = (Ident, Item_, Option<Vec<Attribute> >);
 
 /// How to parse a path. There are four different kinds of paths, all of which
 /// are parsed somewhat differently.
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum PathParsingMode {
     /// A path with no type parameters; e.g. `foo::bar::Baz`
     NoTypesAllowed,
@@ -109,7 +109,7 @@ pub enum PathParsingMode {
 }
 
 /// How to parse a bound, whether to allow bound modifiers such as `?`.
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum BoundParsingMode {
     Bare,
     Modified,

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -147,13 +147,13 @@ pub fn buf_str(toks: &[Token],
     s
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum PrintStackBreak {
     Fits,
     Broken(Breaks),
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct PrintStackElem {
     offset: isize,
     pbreak: PrintStackBreak

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -46,12 +46,12 @@ pub trait PpAnn {
     fn post(&self, _state: &mut State, _node: AnnNode) -> io::Result<()> { Ok(()) }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct NoAnn;
 
 impl PpAnn for NoAnn {}
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct CurrentCommentAndLiteral {
     cur_cmnt: usize,
     cur_lit: usize,

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -32,7 +32,7 @@ use codemap::Span;
 use ptr::P;
 use owned_slice::OwnedSlice;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum FnKind<'a> {
     /// fn foo() or extern "Abi" fn foo()
     FkItemFn(Ident, &'a Generics, Unsafety, Abi),

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -184,7 +184,7 @@ pub mod attr {
     /// Most attributes can only be turned on and must be turned off with term.reset().
     /// The ones that can be turned off explicitly take a boolean value.
     /// Color is also represented as an attribute for convenience.
-    #[derive(Copy)]
+    #[derive(Copy, Clone)]
     pub enum Attr {
         /// Bold (or possibly bright) mode
         Bold,

--- a/src/libterm/terminfo/parm.rs
+++ b/src/libterm/terminfo/parm.rs
@@ -18,7 +18,7 @@ use std::ascii::OwnedAsciiExt;
 use std::mem::replace;
 use std::iter::repeat;
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 enum States {
     Nothing,
     Percent,
@@ -35,7 +35,7 @@ enum States {
     SeekIfEndPercent(isize)
 }
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 enum FormatState {
     FormatStateFlags,
     FormatStateWidth,
@@ -444,7 +444,7 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
     Ok(output)
 }
 
-#[derive(Copy, PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 struct Flags {
     width: usize,
     precision: usize,
@@ -461,7 +461,7 @@ impl Flags {
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum FormatOp {
     FormatDigit,
     FormatOctal,

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -193,7 +193,7 @@ impl fmt::Debug for TestFn {
 /// This is fed into functions marked with `#[bench]` to allow for
 /// set-up & tear-down before running a piece of code repeatedly via a
 /// call to `iter`.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Bencher {
     iterations: u64,
     dur: Duration,
@@ -280,7 +280,7 @@ pub fn test_main_static(args: env::Args, tests: &[TestDescAndFn]) {
     test_main(&args, owned_tests)
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum ColorConfig {
     AutoColor,
     AlwaysColor,

--- a/src/test/auxiliary/issue-14422.rs
+++ b/src/test/auxiliary/issue-14422.rs
@@ -23,7 +23,7 @@ mod src {
     pub mod hidden_core {
         use super::aliases::B;
 
-        #[derive(Copy)]
+        #[derive(Copy, Clone)]
         pub struct A;
 
         pub fn make() -> B { A }

--- a/src/test/auxiliary/issue13213aux.rs
+++ b/src/test/auxiliary/issue13213aux.rs
@@ -13,13 +13,13 @@
 
 pub use private::P;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct S {
     p: P,
 }
 
 mod private {
-    #[derive(Copy)]
+    #[derive(Copy, Clone)]
     pub struct P {
         p: i32,
     }

--- a/src/test/auxiliary/method_self_arg1.rs
+++ b/src/test/auxiliary/method_self_arg1.rs
@@ -17,7 +17,7 @@ static mut COUNT: u64 = 1;
 
 pub fn get_count() -> u64 { unsafe { COUNT } }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Foo;
 
 impl Foo {

--- a/src/test/auxiliary/method_self_arg2.rs
+++ b/src/test/auxiliary/method_self_arg2.rs
@@ -17,7 +17,7 @@ static mut COUNT: u64 = 1;
 
 pub fn get_count() -> u64 { unsafe { COUNT } }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Foo;
 
 impl Foo {

--- a/src/test/auxiliary/struct_variant_xc_aux.rs
+++ b/src/test/auxiliary/struct_variant_xc_aux.rs
@@ -11,7 +11,7 @@
 #![crate_name="struct_variant_xc_aux"]
 #![crate_type = "lib"]
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum Enum {
     Variant(u8),
     StructVariant { arg: u8 }

--- a/src/test/auxiliary/xcrate_unit_struct.rs
+++ b/src/test/auxiliary/xcrate_unit_struct.rs
@@ -12,26 +12,26 @@
 
 // used by the rpass test
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Struct;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum Unit {
     UnitVariant,
     Argument(Struct)
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct TupleStruct(pub usize, pub &'static str);
 
 // used by the cfail test
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct StructWithFields {
     foo: isize,
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum EnumWithVariants {
     EnumVariant,
     EnumVariantArg(isize)

--- a/src/test/bench/noise.rs
+++ b/src/test/bench/noise.rs
@@ -18,7 +18,7 @@ use std::f32::consts::PI;
 use std::num::Float;
 use std::rand::{Rng, StdRng};
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Vec2 {
     x: f32,
     y: f32,

--- a/src/test/bench/shootout-chameneos-redux.rs
+++ b/src/test/bench/shootout-chameneos-redux.rs
@@ -54,7 +54,7 @@ fn print_complements() {
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum Color {
     Red,
     Yellow,
@@ -72,7 +72,7 @@ impl fmt::Debug for Color {
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct CreatureInfo {
     name: usize,
     color: Color

--- a/src/test/bench/shootout-fannkuch-redux.rs
+++ b/src/test/bench/shootout-fannkuch-redux.rs
@@ -63,12 +63,12 @@ fn next_permutation(perm: &mut [i32], count: &mut [i32]) {
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct P {
     p: [i32; 16],
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Perm {
     cnt: [i32; 16],
     fact: [u32; 16],

--- a/src/test/bench/shootout-fasta-redux.rs
+++ b/src/test/bench/shootout-fasta-redux.rs
@@ -105,7 +105,7 @@ fn sum_and_scale(a: &'static [AminoAcid]) -> Vec<AminoAcid> {
     result
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct AminoAcid {
     c: u8,
     p: f32,

--- a/src/test/bench/shootout-k-nucleotide.rs
+++ b/src/test/bench/shootout-k-nucleotide.rs
@@ -64,7 +64,7 @@ static OCCURRENCES: [&'static str;5] = [
 
 // Code implementation
 
-#[derive(Copy, PartialEq, PartialOrd, Ord, Eq)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Ord, Eq)]
 struct Code(u64);
 
 impl Code {

--- a/src/test/bench/shootout-nbody.rs
+++ b/src/test/bench/shootout-nbody.rs
@@ -96,7 +96,7 @@ static BODIES: [Planet;N_BODIES] = [
     },
 ];
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Planet {
     x: f64, y: f64, z: f64,
     vx: f64, vy: f64, vz: f64,

--- a/src/test/compile-fail/borrowck-borrow-from-owned-ptr.rs
+++ b/src/test/compile-fail/borrowck-borrow-from-owned-ptr.rs
@@ -9,13 +9,13 @@
 // except according to those terms.
 
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Foo {
   bar1: Bar,
   bar2: Bar
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Bar {
   int1: isize,
   int2: isize,

--- a/src/test/compile-fail/borrowck-borrow-from-stack-variable.rs
+++ b/src/test/compile-fail/borrowck-borrow-from-stack-variable.rs
@@ -8,13 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Foo {
   bar1: Bar,
   bar2: Bar
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Bar {
   int1: isize,
   int2: isize,

--- a/src/test/compile-fail/borrowck-loan-rcvr-overloaded-op.rs
+++ b/src/test/compile-fail/borrowck-loan-rcvr-overloaded-op.rs
@@ -10,7 +10,7 @@
 
 use std::ops::Add;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Point {
     x: isize,
     y: isize,

--- a/src/test/compile-fail/borrowck-use-mut-borrow.rs
+++ b/src/test/compile-fail/borrowck-use-mut-borrow.rs
@@ -10,7 +10,7 @@
 
 #![feature(box_syntax)]
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct A { a: isize, b: isize }
 
 struct B { a: isize, b: Box<isize> }

--- a/src/test/compile-fail/coherence-impls-copy.rs
+++ b/src/test/compile-fail/coherence-impls-copy.rs
@@ -22,7 +22,11 @@ struct NotSync;
 impl !Sync for NotSync {}
 
 impl Copy for TestE {}
+impl Clone for TestE { fn clone(&self) -> Self { *self } }
+
 impl Copy for MyType {}
+impl Clone for MyType { fn clone(&self) -> Self { *self } }
+
 impl Copy for (MyType, MyType) {}
 //~^ ERROR E0206
 
@@ -31,6 +35,8 @@ impl Copy for &'static NotSync {}
 
 impl Copy for [MyType] {}
 //~^ ERROR E0206
+//~| ERROR E0277
+//~| ERROR E0277
 
 impl Copy for &'static [NotSync] {}
 //~^ ERROR E0206

--- a/src/test/compile-fail/dst-index.rs
+++ b/src/test/compile-fail/dst-index.rs
@@ -14,7 +14,7 @@
 use std::ops::Index;
 use std::fmt::Debug;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct S;
 
 impl Index<usize> for S {
@@ -25,7 +25,7 @@ impl Index<usize> for S {
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct T;
 
 impl Index<usize> for T {

--- a/src/test/compile-fail/exclusive-drop-and-copy.rs
+++ b/src/test/compile-fail/exclusive-drop-and-copy.rs
@@ -12,14 +12,14 @@
 
 // issue #20126
 
-#[derive(Copy)] //~ ERROR the trait `Copy` may not be implemented
+#[derive(Copy, Clone)] //~ ERROR the trait `Copy` may not be implemented
 struct Foo;
 
 impl Drop for Foo {
     fn drop(&mut self) {}
 }
 
-#[derive(Copy)] //~ ERROR the trait `Copy` may not be implemented
+#[derive(Copy, Clone)] //~ ERROR the trait `Copy` may not be implemented
 struct Bar<T>(::std::marker::PhantomData<T>);
 
 #[unsafe_destructor]

--- a/src/test/compile-fail/feature-gate-simd-ffi.rs
+++ b/src/test/compile-fail/feature-gate-simd-ffi.rs
@@ -13,7 +13,7 @@
 
 use std::simd::f32x4;
 
-#[simd] #[derive(Copy)] #[repr(C)] struct LocalSimd(u8, u8);
+#[simd] #[derive(Copy, Clone)] #[repr(C)] struct LocalSimd(u8, u8);
 
 extern {
     fn foo() -> f32x4; //~ ERROR use of SIMD type

--- a/src/test/compile-fail/gated-simd-ffi.rs
+++ b/src/test/compile-fail/gated-simd-ffi.rs
@@ -13,7 +13,7 @@
 #![feature(simd)]
 
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 #[simd]
 pub struct f32x4(f32, f32, f32, f32);
 

--- a/src/test/compile-fail/kindck-copy.rs
+++ b/src/test/compile-fail/kindck-copy.rs
@@ -17,7 +17,7 @@ fn assert_copy<T:Copy>() { }
 
 trait Dummy : MarkerTrait { }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct MyStruct {
     x: isize,
     y: isize,

--- a/src/test/compile-fail/kindck-inherited-copy-bound.rs
+++ b/src/test/compile-fail/kindck-inherited-copy-bound.rs
@@ -25,13 +25,13 @@ fn take_param<T:Foo>(foo: &T) { }
 
 fn a() {
     let x: Box<_> = box 3;
-    take_param(&x); //~ ERROR `core::marker::Copy` is not implemented
+    take_param(&x); //~ ERROR E0277
 }
 
 fn b() {
     let x: Box<_> = box 3;
     let y = &x;
-    let z = &x as &Foo; //~ ERROR `core::marker::Copy` is not implemented
+    let z = &x as &Foo; //~ ERROR E0038
 }
 
 fn main() { }

--- a/src/test/compile-fail/opt-in-copy.rs
+++ b/src/test/compile-fail/opt-in-copy.rs
@@ -16,6 +16,7 @@ struct IWantToCopyThis {
 
 impl Copy for IWantToCopyThis {}
 //~^ ERROR the trait `Copy` may not be implemented for this type
+//~| ERROR E0277
 
 enum CantCopyThisEither {
     A,
@@ -28,5 +29,6 @@ enum IWantToCopyThisToo {
 
 impl Copy for IWantToCopyThisToo {}
 //~^ ERROR the trait `Copy` may not be implemented for this type
+//~| ERROR E0277
 
 fn main() {}

--- a/src/test/compile-fail/pub-method-macro.rs
+++ b/src/test/compile-fail/pub-method-macro.rs
@@ -20,7 +20,7 @@ mod bleh {
         )
     }
 
-    #[derive(Copy)]
+    #[derive(Copy, Clone)]
     pub struct S;
 
     impl S {

--- a/src/test/debuginfo/c-style-enum.rs
+++ b/src/test/debuginfo/c-style-enum.rs
@@ -105,21 +105,21 @@ use self::AutoDiscriminant::{One, Two, Three};
 use self::ManualDiscriminant::{OneHundred, OneThousand, OneMillion};
 use self::SingleVariant::TheOnlyVariant;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum AutoDiscriminant {
     One,
     Two,
     Three
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum ManualDiscriminant {
     OneHundred = 100,
     OneThousand = 1000,
     OneMillion = 1000000
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum SingleVariant {
     TheOnlyVariant
 }

--- a/src/test/debuginfo/generic-method-on-generic-struct.rs
+++ b/src/test/debuginfo/generic-method-on-generic-struct.rs
@@ -114,7 +114,7 @@
 #![feature(box_syntax)]
 #![omit_gdb_pretty_printer_section]
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Struct<T> {
     x: T
 }

--- a/src/test/debuginfo/method-on-enum.rs
+++ b/src/test/debuginfo/method-on-enum.rs
@@ -115,7 +115,7 @@
 #![feature(box_syntax)]
 #![omit_gdb_pretty_printer_section]
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum Enum {
     Variant1 { x: u16, y: u16 },
     Variant2 (u32)

--- a/src/test/debuginfo/method-on-generic-struct.rs
+++ b/src/test/debuginfo/method-on-generic-struct.rs
@@ -115,7 +115,7 @@
 #![feature(box_syntax)]
 #![omit_gdb_pretty_printer_section]
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Struct<T> {
     x: T
 }

--- a/src/test/debuginfo/method-on-struct.rs
+++ b/src/test/debuginfo/method-on-struct.rs
@@ -115,7 +115,7 @@
 #![feature(box_syntax)]
 #![omit_gdb_pretty_printer_section]
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Struct {
     x: isize
 }

--- a/src/test/debuginfo/method-on-trait.rs
+++ b/src/test/debuginfo/method-on-trait.rs
@@ -115,7 +115,7 @@
 #![feature(box_syntax)]
 #![omit_gdb_pretty_printer_section]
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Struct {
     x: isize
 }

--- a/src/test/debuginfo/method-on-tuple-struct.rs
+++ b/src/test/debuginfo/method-on-tuple-struct.rs
@@ -115,7 +115,7 @@
 #![feature(box_syntax)]
 #![omit_gdb_pretty_printer_section]
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct TupleStruct(isize, f64);
 
 impl TupleStruct {

--- a/src/test/debuginfo/self-in-default-method.rs
+++ b/src/test/debuginfo/self-in-default-method.rs
@@ -114,7 +114,7 @@
 #![feature(box_syntax)]
 #![omit_gdb_pretty_printer_section]
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Struct {
     x: isize
 }

--- a/src/test/debuginfo/self-in-generic-default-method.rs
+++ b/src/test/debuginfo/self-in-generic-default-method.rs
@@ -114,7 +114,7 @@
 #![feature(box_syntax)]
 #![omit_gdb_pretty_printer_section]
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Struct {
     x: isize
 }

--- a/src/test/pretty/block-disambig.rs
+++ b/src/test/pretty/block-disambig.rs
@@ -19,7 +19,7 @@ fn test1() { let val = &0; { } *val; }
 
 fn test2() -> isize { let val = &0; { } *val }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct S { eax: isize }
 
 fn test3() {

--- a/src/test/run-make/allow-non-lint-warnings-cmdline/foo.rs
+++ b/src/test/run-make/allow-non-lint-warnings-cmdline/foo.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #[derive()]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Foo;
 
 pub fn main() { }

--- a/src/test/run-make/extern-fn-with-packed-struct/test.rs
+++ b/src/test/run-make/extern-fn-with-packed-struct/test.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #[repr(packed)]
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 struct Foo {
     a: i8,
     b: i16,

--- a/src/test/run-make/save-analysis/foo.rs
+++ b/src/test/run-make/save-analysis/foo.rs
@@ -179,7 +179,7 @@ enum SomeEnum<'a> {
     MyTypes(MyType, MyType)
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum SomeOtherEnum {
     SomeConst1,
     SomeConst2,

--- a/src/test/run-pass/associated-types-normalize-unifield-struct.rs
+++ b/src/test/run-pass/associated-types-normalize-unifield-struct.rs
@@ -20,10 +20,10 @@ pub trait Offset {
     fn dummy(&self) { }
 }
 
-#[derive(Copy)] pub struct X;
+#[derive(Copy, Clone)] pub struct X;
 impl Offset for X { type State = Y; }
 
-#[derive(Copy)] pub struct Y;
+#[derive(Copy, Clone)] pub struct Y;
 impl OffsetState for Y {}
 
 pub fn now() -> DateTime<X> { from_utc(Y) }

--- a/src/test/run-pass/binops-issue-22743.rs
+++ b/src/test/run-pass/binops-issue-22743.rs
@@ -10,7 +10,7 @@
 
 use std::ops::Mul;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Foo {
     x: f64,
 }

--- a/src/test/run-pass/borrowck-univariant-enum.rs
+++ b/src/test/run-pass/borrowck-univariant-enum.rs
@@ -13,7 +13,7 @@
 
 use std::cell::Cell;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum newtype {
     newvar(isize)
 }

--- a/src/test/run-pass/builtin-superkinds-in-metadata.rs
+++ b/src/test/run-pass/builtin-superkinds-in-metadata.rs
@@ -20,7 +20,7 @@ use trait_superkinds_in_metadata::{RequiresRequiresShareAndSend, RequiresShare};
 use trait_superkinds_in_metadata::RequiresCopy;
 use std::marker;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct X<T>(T);
 
 impl<T:Sync> RequiresShare for X<T> { }

--- a/src/test/run-pass/class-impl-very-parameterized-trait.rs
+++ b/src/test/run-pass/class-impl-very-parameterized-trait.rs
@@ -11,7 +11,7 @@
 
 use std::cmp;
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 enum cat_type { tuxedo, tabby, tortoiseshell }
 
 impl cmp::PartialEq for cat_type {

--- a/src/test/run-pass/coherence-impl-in-fn.rs
+++ b/src/test/run-pass/coherence-impl-in-fn.rs
@@ -11,7 +11,7 @@
 // pretty-expanded FIXME #23616
 
 pub fn main() {
-    #[derive(Copy)]
+    #[derive(Copy, Clone)]
     enum x { foo }
     impl ::std::cmp::PartialEq for x {
         fn eq(&self, other: &x) -> bool {

--- a/src/test/run-pass/const-nullary-univariant-enum.rs
+++ b/src/test/run-pass/const-nullary-univariant-enum.rs
@@ -10,7 +10,7 @@
 
 // pretty-expanded FIXME #23616
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum Foo {
     Bar = 0xDEADBEE
 }

--- a/src/test/run-pass/copy-out-of-array-1.rs
+++ b/src/test/run-pass/copy-out-of-array-1.rs
@@ -14,9 +14,8 @@
 
 // pretty-expanded FIXME #23616
 
+#[derive(Copy, Clone)]
 struct C { _x: u8 }
-
-impl Copy for C { }
 
 fn main() {
     fn d() -> C { C { _x: 0 } }

--- a/src/test/run-pass/deriving-bounds.rs
+++ b/src/test/run-pass/deriving-bounds.rs
@@ -10,7 +10,7 @@
 
 // pretty-expanded FIXME #23616
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Test;
 
 pub fn main() {}

--- a/src/test/run-pass/dst-struct-sole.rs
+++ b/src/test/run-pass/dst-struct-sole.rs
@@ -32,7 +32,7 @@ fn foo2<T:ToBar>(x: &Fat<[T]>) {
     assert!(x.ptr[1].to_bar() == bar);
 }
 
-#[derive(Copy, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 struct Bar;
 
 trait ToBar {

--- a/src/test/run-pass/dst-struct.rs
+++ b/src/test/run-pass/dst-struct.rs
@@ -51,7 +51,7 @@ fn foo3(x: &Fat<Fat<[isize]>>) {
 }
 
 
-#[derive(Copy, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 struct Bar;
 
 trait ToBar {

--- a/src/test/run-pass/dst-trait.rs
+++ b/src/test/run-pass/dst-trait.rs
@@ -19,10 +19,10 @@ struct Fat<T: ?Sized> {
     ptr: T
 }
 
-#[derive(Copy, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 struct Bar;
 
-#[derive(Copy, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 struct Bar1 {
     f: isize
 }

--- a/src/test/run-pass/empty-tag.rs
+++ b/src/test/run-pass/empty-tag.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 enum chan { chan_t, }
 
 impl PartialEq for chan {

--- a/src/test/run-pass/enum-discrim-width-stuff.rs
+++ b/src/test/run-pass/enum-discrim-width-stuff.rs
@@ -12,7 +12,7 @@ macro_rules! check {
     ($m:ident, $t:ty, $v:expr) => {{
         mod $m {
             use std::mem::size_of;
-            #[derive(Copy, Debug)]
+            #[derive(Copy, Clone, Debug)]
             enum E {
                 V = $v,
                 A = 0

--- a/src/test/run-pass/explicit-self-generic.rs
+++ b/src/test/run-pass/explicit-self-generic.rs
@@ -13,7 +13,7 @@
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct LM { resize_at: usize, size: usize }
 
 enum HashMap<K,V> {

--- a/src/test/run-pass/expr-copy.rs
+++ b/src/test/run-pass/expr-copy.rs
@@ -15,7 +15,7 @@ fn f(arg: &mut A) {
     arg.a = 100;
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct A { a: isize }
 
 pub fn main() {

--- a/src/test/run-pass/expr-if-struct.rs
+++ b/src/test/run-pass/expr-if-struct.rs
@@ -14,7 +14,7 @@
 
 // Tests for if as expressions returning nominal types
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct I { i: isize }
 
 fn test_rec() {
@@ -22,7 +22,7 @@ fn test_rec() {
     assert_eq!(rs.i, 100);
 }
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 enum mood { happy, sad, }
 
 impl PartialEq for mood {

--- a/src/test/run-pass/expr-match-struct.rs
+++ b/src/test/run-pass/expr-match-struct.rs
@@ -13,7 +13,7 @@
 
 
 // Tests for match as expressions resulting in struct types
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct R { i: isize }
 
 fn test_rec() {
@@ -21,7 +21,7 @@ fn test_rec() {
     assert_eq!(rs.i, 100);
 }
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 enum mood { happy, sad, }
 
 impl PartialEq for mood {

--- a/src/test/run-pass/exterior.rs
+++ b/src/test/run-pass/exterior.rs
@@ -13,7 +13,7 @@
 
 use std::cell::Cell;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Point {x: isize, y: isize, z: isize}
 
 fn f(p: &Cell<Point>) {

--- a/src/test/run-pass/extern-pass-TwoU16s.rs
+++ b/src/test/run-pass/extern-pass-TwoU16s.rs
@@ -11,7 +11,7 @@
 // Test a foreign function that accepts and returns a struct
 // by value.
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct TwoU16s {
     one: u16, two: u16
 }

--- a/src/test/run-pass/extern-pass-TwoU32s.rs
+++ b/src/test/run-pass/extern-pass-TwoU32s.rs
@@ -11,7 +11,7 @@
 // Test a foreign function that accepts and returns a struct
 // by value.
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct TwoU32s {
     one: u32, two: u32
 }

--- a/src/test/run-pass/extern-pass-TwoU64s.rs
+++ b/src/test/run-pass/extern-pass-TwoU64s.rs
@@ -11,7 +11,7 @@
 // Test a foreign function that accepts and returns a struct
 // by value.
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct TwoU64s {
     one: u64, two: u64
 }

--- a/src/test/run-pass/extern-pass-TwoU8s.rs
+++ b/src/test/run-pass/extern-pass-TwoU8s.rs
@@ -11,7 +11,7 @@
 // Test a foreign function that accepts and returns a struct
 // by value.
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct TwoU8s {
     one: u8, two: u8
 }

--- a/src/test/run-pass/foreign-fn-with-byval.rs
+++ b/src/test/run-pass/foreign-fn-with-byval.rs
@@ -10,7 +10,7 @@
 
 // pretty-expanded FIXME #23616
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct S {
     x: u64,
     y: u64,

--- a/src/test/run-pass/generic-fn.rs
+++ b/src/test/run-pass/generic-fn.rs
@@ -12,7 +12,7 @@
 
 fn id<T>(x: T) -> T { return x; }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Triple {x: isize, y: isize, z: isize}
 
 pub fn main() {

--- a/src/test/run-pass/guards-not-exhaustive.rs
+++ b/src/test/run-pass/guards-not-exhaustive.rs
@@ -10,7 +10,7 @@
 
 // pretty-expanded FIXME #23616
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum Q { R(Option<usize>) }
 
 fn xyzzy(q: Q) -> usize {

--- a/src/test/run-pass/guards.rs
+++ b/src/test/run-pass/guards.rs
@@ -10,7 +10,7 @@
 
 // pretty-expanded FIXME #23616
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Pair { x: isize, y: isize }
 
 pub fn main() {

--- a/src/test/run-pass/hrtb-opt-in-copy.rs
+++ b/src/test/run-pass/hrtb-opt-in-copy.rs
@@ -22,7 +22,7 @@
 
 use std::marker::PhantomData;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Foo<T> { x: T }
 
 type Ty<'tcx> = &'tcx TyS<'tcx>;
@@ -31,7 +31,7 @@ enum TyS<'tcx> {
     Boop(PhantomData<*mut &'tcx ()>)
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum Bar<'tcx> {
     Baz(Foo<Ty<'tcx>>)
 }

--- a/src/test/run-pass/issue-12860.rs
+++ b/src/test/run-pass/issue-12860.rs
@@ -16,7 +16,7 @@ extern crate collections;
 
 use std::collections::HashSet;
 
-#[derive(Copy, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 struct XYZ {
     x: isize,
     y: isize,

--- a/src/test/run-pass/issue-13264.rs
+++ b/src/test/run-pass/issue-13264.rs
@@ -24,7 +24,7 @@ impl Deref for Root {
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct JSRef {
     node: *const Node
 }

--- a/src/test/run-pass/issue-19100.rs
+++ b/src/test/run-pass/issue-19100.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum Foo {
     Bar,
     Baz

--- a/src/test/run-pass/issue-20797.rs
+++ b/src/test/run-pass/issue-20797.rs
@@ -34,7 +34,7 @@ pub trait Strategy {
 }
 
 /// The basic fully-recursive strategy. Nothing is pruned.
-#[derive(Copy, Default)]
+#[derive(Copy, Clone, Default)]
 pub struct Recursive;
 
 impl Strategy for Recursive {

--- a/src/test/run-pass/issue-21296.rs
+++ b/src/test/run-pass/issue-21296.rs
@@ -14,4 +14,8 @@
 #[derive(Copy)]
 struct Test(*const i32);
 
+impl Clone for Test {
+    fn clone(&self) -> Test { *self }
+}
+
 fn main() {}

--- a/src/test/run-pass/issue-22536-copy-mustnt-zero.rs
+++ b/src/test/run-pass/issue-22536-copy-mustnt-zero.rs
@@ -22,12 +22,14 @@ struct BufferHandle<R: Resources> {
     raw: <R as Resources>::Buffer,
 }
 impl<R: Resources> Copy for BufferHandle<R> {}
+impl<R: Resources> Clone for BufferHandle<R> {
+    fn clone(&self) -> BufferHandle<R> { *self }
+}
 
 enum Res {}
 impl Resources for Res {
     type Buffer = u32;
 }
-impl Copy for Res { }
 
 fn main() {
     let b: BufferHandle<Res> = BufferHandle { raw: 1 };

--- a/src/test/run-pass/issue-2288.rs
+++ b/src/test/run-pass/issue-2288.rs
@@ -17,7 +17,7 @@ trait clam<A> {
   fn chowder(&self, y: A);
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct foo<A> {
   x: A,
 }

--- a/src/test/run-pass/issue-23550.rs
+++ b/src/test/run-pass/issue-23550.rs
@@ -13,7 +13,7 @@
 
 use std::intrinsics;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Wrap(i64);
 
 // These volatile and atomic intrinsics used to cause an ICE

--- a/src/test/run-pass/issue-2633.rs
+++ b/src/test/run-pass/issue-2633.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct cat {
     meow: extern "Rust" fn(),
 }
@@ -23,7 +23,7 @@ fn cat() -> cat {
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct KittyInfo {kitty: cat}
 
 // Code compiles and runs successfully if we add a + before the first arg

--- a/src/test/run-pass/issue-3121.rs
+++ b/src/test/run-pass/issue-3121.rs
@@ -13,11 +13,11 @@
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum side { mayo, catsup, vinegar }
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum order { hamburger, fries(side), shake }
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum meal { to_go(order), for_here(order) }
 
 fn foo(m: Box<meal>, cond: bool) {

--- a/src/test/run-pass/issue-3563-3.rs
+++ b/src/test/run-pass/issue-3563-3.rs
@@ -29,7 +29,7 @@ use std::iter::repeat;
 use std::slice;
 
 // Represents a position on a canvas.
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Point {
     x: isize,
     y: isize,
@@ -37,13 +37,13 @@ struct Point {
 
 // Represents an offset on a canvas. (This has the same structure as a Point.
 // but different semantics).
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Size {
     width: isize,
     height: isize,
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Rect {
     top_left: Point,
     size: Size,

--- a/src/test/run-pass/issue-3743.rs
+++ b/src/test/run-pass/issue-3743.rs
@@ -13,7 +13,7 @@
 
 use std::ops::Mul;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Vec2 {
     x: f64,
     y: f64

--- a/src/test/run-pass/issue-3753.rs
+++ b/src/test/run-pass/issue-3753.rs
@@ -16,13 +16,13 @@
 
 use std::f64;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Point {
     x: f64,
     y: f64
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub enum Shape {
     Circle(Point, f64),
     Rectangle(Point, Point)

--- a/src/test/run-pass/issue-5688.rs
+++ b/src/test/run-pass/issue-5688.rs
@@ -17,7 +17,7 @@ with the representation of [isize; n] and [isize] somehow, or at least
 failed to typecheck correctly.
 */
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct X { vec: &'static [isize] }
 
 static V: &'static [X] = &[X { vec: &[1, 2, 3] }];

--- a/src/test/run-pass/match-arm-statics.rs
+++ b/src/test/run-pass/match-arm-statics.rs
@@ -38,7 +38,7 @@ const VARIANT2_NORTH: EnumWithStructVariants = EnumWithStructVariants::Variant2 
     dir: Direction::North };
 
 pub mod glfw {
-    #[derive(Copy)]
+    #[derive(Copy, Clone)]
     pub struct InputState(usize);
 
     pub const RELEASE  : InputState = InputState(0);

--- a/src/test/run-pass/method-self-arg-trait.rs
+++ b/src/test/run-pass/method-self-arg-trait.rs
@@ -17,7 +17,7 @@
 
 static mut COUNT: u64 = 1;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Foo;
 
 trait Bar : Sized {

--- a/src/test/run-pass/method-self-arg.rs
+++ b/src/test/run-pass/method-self-arg.rs
@@ -17,7 +17,7 @@
 
 static mut COUNT: usize = 1;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Foo;
 
 impl Foo {

--- a/src/test/run-pass/monomorphize-abi-alignment.rs
+++ b/src/test/run-pass/monomorphize-abi-alignment.rs
@@ -18,7 +18,7 @@
  * and apply the wrong instance of the method `unwrap`.
  */
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct S<T> { i:u8, t:T }
 
 impl<T> S<T> {
@@ -27,10 +27,10 @@ impl<T> S<T> {
     }
 }
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 struct A((u32, u32));
 
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 struct B(u64);
 
 pub fn main() {

--- a/src/test/run-pass/multidispatch1.rs
+++ b/src/test/run-pass/multidispatch1.rs
@@ -16,7 +16,7 @@ trait MyTrait<T> {
     fn get(&self) -> T;
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct MyType {
     dummy: usize
 }

--- a/src/test/run-pass/multidispatch2.rs
+++ b/src/test/run-pass/multidispatch2.rs
@@ -25,7 +25,7 @@ impl<T> MyTrait<T> for T
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct MyType {
     dummy: usize
 }

--- a/src/test/run-pass/newtype.rs
+++ b/src/test/run-pass/newtype.rs
@@ -8,10 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct mytype(Mytype);
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Mytype {
     compute: fn(mytype) -> isize,
     val: isize,

--- a/src/test/run-pass/operator-overloading.rs
+++ b/src/test/run-pass/operator-overloading.rs
@@ -13,7 +13,7 @@
 use std::cmp;
 use std::ops;
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 struct Point {
     x: isize,
     y: isize

--- a/src/test/run-pass/out-pointer-aliasing.rs
+++ b/src/test/run-pass/out-pointer-aliasing.rs
@@ -10,7 +10,7 @@
 
 // pretty-expanded FIXME #23616
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Foo {
     f1: isize,
     _f2: isize,

--- a/src/test/run-pass/overloaded-autoderef-order.rs
+++ b/src/test/run-pass/overloaded-autoderef-order.rs
@@ -13,7 +13,7 @@
 use std::rc::Rc;
 use std::ops::Deref;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct DerefWrapper<X, Y> {
     x: X,
     y: Y
@@ -36,7 +36,7 @@ impl<X, Y> Deref for DerefWrapper<X, Y> {
 mod priv_test {
     use std::ops::Deref;
 
-    #[derive(Copy)]
+    #[derive(Copy, Clone)]
     pub struct DerefWrapperHideX<X, Y> {
         x: X,
         pub y: Y

--- a/src/test/run-pass/packed-struct-vec.rs
+++ b/src/test/run-pass/packed-struct-vec.rs
@@ -13,7 +13,7 @@
 use std::mem;
 
 #[repr(packed)]
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 struct Foo {
     bar: u8,
     baz: u64

--- a/src/test/run-pass/rec-tup.rs
+++ b/src/test/run-pass/rec-tup.rs
@@ -10,7 +10,7 @@
 
 // pretty-expanded FIXME #23616
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Point {x: isize, y: isize}
 
 type rect = (Point, Point);

--- a/src/test/run-pass/rec.rs
+++ b/src/test/run-pass/rec.rs
@@ -10,7 +10,7 @@
 
 // pretty-expanded FIXME #23616
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Rect {x: isize, y: isize, w: isize, h: isize}
 
 fn f(r: Rect, x: isize, y: isize, w: isize, h: isize) {

--- a/src/test/run-pass/regions-dependent-addr-of.rs
+++ b/src/test/run-pass/regions-dependent-addr-of.rs
@@ -30,7 +30,7 @@ struct B {
     v6: Option<C>
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct C {
     f: isize
 }

--- a/src/test/run-pass/regions-early-bound-used-in-bound-method.rs
+++ b/src/test/run-pass/regions-early-bound-used-in-bound-method.rs
@@ -17,7 +17,7 @@ trait GetRef<'a> {
     fn get(&self) -> &'a isize;
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Box<'a> {
     t: &'a isize
 }

--- a/src/test/run-pass/regions-early-bound-used-in-bound.rs
+++ b/src/test/run-pass/regions-early-bound-used-in-bound.rs
@@ -17,11 +17,10 @@ trait GetRef<'a, T> {
     fn get(&self) -> &'a T;
 }
 
+#[derive(Copy, Clone)]
 struct Box<'a, T:'a> {
     t: &'a T
 }
-
-impl<'a,T:'a> Copy for Box<'a,T> {}
 
 impl<'a,T:Clone> GetRef<'a,T> for Box<'a,T> {
     fn get(&self) -> &'a T {

--- a/src/test/run-pass/regions-early-bound-used-in-type-param.rs
+++ b/src/test/run-pass/regions-early-bound-used-in-type-param.rs
@@ -17,7 +17,7 @@ trait Get<T> {
     fn get(&self) -> T;
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Box<T> {
     t: T
 }

--- a/src/test/run-pass/regions-mock-tcx.rs
+++ b/src/test/run-pass/regions-mock-tcx.rs
@@ -29,7 +29,7 @@ use std::mem;
 
 type Type<'tcx> = &'tcx TypeStructure<'tcx>;
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 enum TypeStructure<'tcx> {
     TypeInt,
     TypeFunction(Type<'tcx>, Type<'tcx>),
@@ -94,20 +94,20 @@ impl<'tcx,'ast> TypeContext<'tcx, 'ast> {
     }
 }
 
-#[derive(Copy, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 struct NodeId {
     id: usize
 }
 
 type Ast<'ast> = &'ast AstStructure<'ast>;
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct AstStructure<'ast> {
     id: NodeId,
     kind: AstKind<'ast>
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum AstKind<'ast> {
     ExprInt,
     ExprVar(usize),

--- a/src/test/run-pass/self-in-mut-slot-immediate-value.rs
+++ b/src/test/run-pass/self-in-mut-slot-immediate-value.rs
@@ -13,7 +13,7 @@
 
 // pretty-expanded FIXME #23616
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Value {
     n: isize
 }

--- a/src/test/run-pass/simd-generics.rs
+++ b/src/test/run-pass/simd-generics.rs
@@ -16,7 +16,7 @@
 use std::ops;
 
 #[simd]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct f32x4(f32, f32, f32, f32);
 
 fn add<T: ops::Add<Output=T>>(lhs: T, rhs: T) -> T {

--- a/src/test/run-pass/small-enum-range-edge.rs
+++ b/src/test/run-pass/small-enum-range-edge.rs
@@ -18,14 +18,14 @@
  */
 
 #[repr(u8)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum Eu { Lu = 0, Hu = 255 }
 
 static CLu: Eu = Eu::Lu;
 static CHu: Eu = Eu::Hu;
 
 #[repr(i8)]
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum Es { Ls = -128, Hs = 127 }
 
 static CLs: Es = Es::Ls;

--- a/src/test/run-pass/struct-return.rs
+++ b/src/test/run-pass/struct-return.rs
@@ -10,10 +10,10 @@
 //
 // ignore-lexer-test FIXME #15883
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Quad { a: u64, b: u64, c: u64, d: u64 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Floats { a: f64, b: u8, c: f64 }
 
 mod rustrt {

--- a/src/test/run-pass/structured-compare.rs
+++ b/src/test/run-pass/structured-compare.rs
@@ -10,7 +10,7 @@
 
 
 
-#[derive(Copy, Debug)]
+#[derive(Copy, Clone, Debug)]
 enum foo { large, small, }
 
 impl PartialEq for foo {

--- a/src/test/run-pass/sync-send-iterators-in-libcollections.rs
+++ b/src/test/run-pass/sync-send-iterators-in-libcollections.rs
@@ -77,7 +77,7 @@ fn main() {
 
     all_sync_send!(LinkedList::<usize>::new(), iter, iter_mut, into_iter);
 
-    #[derive(Copy)]
+    #[derive(Copy, Clone)]
     #[repr(usize)]
     #[allow(dead_code)]
     enum Foo { A, B, C }

--- a/src/test/run-pass/tag-variant-disr-val.rs
+++ b/src/test/run-pass/tag-variant-disr-val.rs
@@ -11,7 +11,7 @@
 
 use color::{red, green, blue, black, white, imaginary, purple, orange};
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 enum color {
     red = 0xff0000,
     green = 0x00ff00,

--- a/src/test/run-pass/trait-coercion-generic.rs
+++ b/src/test/run-pass/trait-coercion-generic.rs
@@ -12,7 +12,7 @@ trait Trait<T> {
     fn f(&self, x: T);
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Struct {
     x: isize,
     y: isize,

--- a/src/test/run-pass/trait-coercion.rs
+++ b/src/test/run-pass/trait-coercion.rs
@@ -17,7 +17,7 @@ trait Trait {
     fn f(&self);
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Struct {
     x: isize,
     y: isize,

--- a/src/test/run-pass/ufcs-explicit-self.rs
+++ b/src/test/run-pass/ufcs-explicit-self.rs
@@ -11,7 +11,7 @@
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Foo {
     f: isize,
 }
@@ -28,7 +28,7 @@ impl Foo {
     }
 }
 
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 struct Bar<T> {
     f: T,
 }


### PR DESCRIPTION
Logically, `Copy: Clone` makes sense, since `Copy` basically means "I can clone this with just memcpy". This also means that one can start out with a `Copy` bound and relax it to a `Clone` bound.

This is a [breaking-change] because one must change `#[derive(Copy)]` to `#[derive(Copy,Clone)]`. In some cases, deriving doesn't create a proper clone impl (notably around fixed-length arrays), in which case you should write one by hand. Because the type in question is `Copy`, this is very simple:

``` rust
impl Clone for Foo { fn clone(&self) -> Foo { *self } }
```

Fixes https://github.com/rust-lang/rust/issues/23790.

r? @aturon (stabilization issue)
