### PR TITLE
Second attempt to fix #23713 based on follow-up comments in #23791.

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -333,7 +333,7 @@ impl<T> Option<T> {
         }
     }
 
-    /// Moves the value `v` out of the `Option<T>` if the content of the `Option<T>` is a `Some(v)`.
+    /// Moves the value `v` out of the `Option<T>` if it is `Some(v)`.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Based on the comment from @apasel422  in https://github.com/rust-lang/rust/pull/23791#issuecomment-87095298.
Where @apasel422 proposed

```
Moves the value out of the option if it is `Some`, or panics if it is `None`.
```

I include in this PR the version

```
Moves the value `v` out of the `Option` if it is `Some(v)`, or panics if it is `None`.
```

which 
- is a little bit more precise about what value is actually returned
- uses `Option` over just "option" in the part `out of the [Option]

r? @steveklabnik, @apasel422
