### PR TITLE
Rename tests modules to test to reflect guidelines.

### DIFF
--- a/src/doc/trpl/testing.md
+++ b/src/doc/trpl/testing.md
@@ -231,7 +231,7 @@ pub fn add_two(a: i32) -> i32 {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::add_two;
 
     #[test]
@@ -241,7 +241,7 @@ mod tests {
 }
 ```
 
-There's a few changes here. The first is the introduction of a `mod tests` with
+There's a few changes here. The first is the introduction of a `mod test` with
 a `cfg` attribute. The module allows us to group all of our tests together, and
 to also define helper functions if needed, that don't become a part of the rest
 of our crate. The `cfg` attribute only compiles our test code if we're
@@ -260,7 +260,7 @@ pub fn add_two(a: i32) -> i32 {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
 
     #[test]
@@ -382,7 +382,7 @@ pub fn add_two(a: i32) -> i32 {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
 
     #[test]

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -648,7 +648,7 @@ impl<T: Hash> Hash for Arc<T> {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use std::clone::Clone;
     use std::sync::mpsc::channel;
     use std::mem::drop;

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -816,7 +816,7 @@ impl<T> RcBoxPtr<T> for Weak<T> {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::{Rc, Weak, weak_count, strong_count};
     use std::boxed::Box;
     use std::cell::RefCell;

--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -527,7 +527,7 @@ impl<T> Drop for TypedArena<T> {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     extern crate test;
     use self::test::Bencher;
     use super::{Arena, TypedArena};

--- a/src/libcoretest/num/int_macros.rs
+++ b/src/libcoretest/num/int_macros.rs
@@ -10,7 +10,7 @@
 
 macro_rules! int_module { ($T:ty, $T_i:ident) => (
 #[cfg(test)]
-mod tests {
+mod test {
     use core::$T_i::*;
     use core::isize;
     use core::num::{FromStrRadix, Int, SignedInt};

--- a/src/libcoretest/num/uint_macros.rs
+++ b/src/libcoretest/num/uint_macros.rs
@@ -10,7 +10,7 @@
 
 macro_rules! uint_module { ($T:ty, $T_i:ident) => (
 #[cfg(test)]
-mod tests {
+mod test {
     use core::$T_i::*;
     use core::num::Int;
     use num;

--- a/src/libflate/lib.rs
+++ b/src/libflate/lib.rs
@@ -152,7 +152,7 @@ pub fn inflate_bytes_zlib(bytes: &[u8]) -> Result<Bytes,Error> {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     #![allow(deprecated)]
     use super::{inflate_bytes, deflate_bytes};
     use std::rand;

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -441,7 +441,7 @@ impl<'a> Parser<'a> {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
 
     fn same(fmt: &'static str, p: &[Piece<'static>]) {

--- a/src/libgetopts/lib.rs
+++ b/src/libgetopts/lib.rs
@@ -971,7 +971,7 @@ fn test_split_within() {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
     use super::Fail::*;
 

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -591,7 +591,7 @@ pub fn render_opts<'a, N:Clone+'a, E:Clone+'a, G:Labeller<'a,N,E>+GraphWalk<'a,N
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use self::NodeLabels::*;
     use super::{Id, Labeller, Nodes, Edges, GraphWalk, render};
     use super::LabelText::{self, LabelStr, EscStr};

--- a/src/liblog/directive.rs
+++ b/src/liblog/directive.rs
@@ -83,7 +83,7 @@ pub fn parse_logging_spec(spec: &str) -> (Vec<LogDirective>, Option<String>) {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::parse_logging_spec;
 
     #[test]

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -457,7 +457,7 @@ fn init() {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::enabled;
     use directive::LogDirective;
 

--- a/src/librand/distributions/mod.rs
+++ b/src/librand/distributions/mod.rs
@@ -263,7 +263,7 @@ fn ziggurat<R: Rng, P, Z>(
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use std::prelude::v1::*;
 
     use {Rng, Rand};

--- a/src/librand/distributions/normal.rs
+++ b/src/librand/distributions/normal.rs
@@ -161,7 +161,7 @@ impl IndependentSample<f64> for LogNormal {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use std::prelude::v1::*;
 
     use distributions::{Sample, IndependentSample};

--- a/src/librand/distributions/range.rs
+++ b/src/librand/distributions/range.rs
@@ -164,7 +164,7 @@ float_impl! { f32 }
 float_impl! { f64 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use std::num::Int;
     use std::prelude::v1::*;
     use distributions::{Sample, IndependentSample};

--- a/src/librand/rand_impls.rs
+++ b/src/librand/rand_impls.rs
@@ -213,7 +213,7 @@ impl<T:Rand> Rand for Option<T> {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use std::rand::{Rng, thread_rng, Open01, Closed01};
 
     struct ConstantRng(u64);

--- a/src/librustc_back/sha2.rs
+++ b/src/librustc_back/sha2.rs
@@ -529,7 +529,7 @@ static H256: [u32; 8] = [
 ];
 
 #[cfg(test)]
-mod tests {
+mod test {
     #![allow(deprecated)]
     extern crate rand;
 

--- a/src/librustc_bitflags/lib.rs
+++ b/src/librustc_bitflags/lib.rs
@@ -297,7 +297,7 @@ mod core {
 
 #[cfg(test)]
 #[allow(non_upper_case_globals)]
-mod tests {
+mod test {
     use std::hash::{self, SipHasher};
     use std::option::Option::{Some, None};
 

--- a/src/libserialize/hex.rs
+++ b/src/libserialize/hex.rs
@@ -150,7 +150,7 @@ impl FromHex for str {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     extern crate test;
     use self::test::Bencher;
     use hex::{FromHex, ToHex};

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -2610,7 +2610,7 @@ impl FromStr for Json {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     extern crate test;
     use self::Animal::*;
     use self::DecodeEnum::*;

--- a/src/libstd/ascii.rs
+++ b/src/libstd/ascii.rs
@@ -469,7 +469,7 @@ static ASCII_UPPERCASE_MAP: [u8; 256] = [
 
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
     use super::*;
     use char::from_u32;

--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -727,7 +727,7 @@ mod arch {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
     use super::*;
 

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -460,7 +460,7 @@ impl IntoBytes for Vec<u8> {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
     use super::*;
     use libc;

--- a/src/libstd/fs/mod.rs
+++ b/src/libstd/fs/mod.rs
@@ -873,7 +873,7 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     #![allow(deprecated)] //rand
 
     use prelude::v1::*;

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -475,7 +475,7 @@ impl<S: Write> fmt::Debug for BufStream<S> where S: fmt::Debug {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
     use io::prelude::*;
     use io::{self, BufReader, BufWriter, BufStream, Cursor, LineWriter};

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -163,7 +163,7 @@ impl Write for Cursor<Vec<u8>> {
 
 
 #[cfg(test)]
-mod tests {
+mod test {
     use core::prelude::*;
 
     use io::prelude::*;

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -207,7 +207,7 @@ impl Write for Vec<u8> {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use io::prelude::*;
     use vec::Vec;
     use test;

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -909,7 +909,7 @@ impl<B: BufRead> Iterator for Lines<B> {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
     use io::prelude::*;
     use io;

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -457,7 +457,7 @@ impl<'a, T: ToSocketAddrs + ?Sized> ToSocketAddrs for &'a T {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
     use io;
     use net::*;

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -246,7 +246,7 @@ impl AsInner<net_imp::TcpListener> for TcpListener {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
 
     use io::ErrorKind;

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -141,7 +141,7 @@ impl AsInner<net_imp::UdpSocket> for UdpSocket {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
 
     use io::ErrorKind;

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -1735,7 +1735,7 @@ pub fn to_str_exp_digits(num: f32, dig: usize, upper: bool) -> String {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use f32::*;
     use num::*;
     use num::FpCategory as Fp;

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -1741,7 +1741,7 @@ pub fn to_str_exp_digits(num: f64, dig: usize, upper: bool) -> String {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use f64::*;
     use num::*;
     use num::FpCategory as Fp;

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -1147,7 +1147,7 @@ pub fn test_num<T>(ten: T, two: T) where
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
     use super::*;
     use i8;

--- a/src/libstd/num/strconv.rs
+++ b/src/libstd/num/strconv.rs
@@ -424,7 +424,7 @@ const DIGIT_P_RADIX: u32 = ('p' as u32) - ('a' as u32) + 11;
 const DIGIT_E_RADIX: u32 = ('e' as u32) - ('a' as u32) + 11;
 
 #[cfg(test)]
-mod tests {
+mod test {
     use core::num::wrapping::WrappingOps;
     use string::ToString;
 

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -15,7 +15,7 @@
 macro_rules! uint_module { ($T:ty) => (
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
     use num::FromStrRadix;
 

--- a/src/libstd/old_io/net/pipe.rs
+++ b/src/libstd/old_io/net/pipe.rs
@@ -285,7 +285,7 @@ impl sys_common::AsInner<UnixAcceptorImp> for UnixAcceptor {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
 
     use old_io::fs::PathExtensions;

--- a/src/libstd/old_io/process.rs
+++ b/src/libstd/old_io/process.rs
@@ -763,7 +763,7 @@ impl Drop for Process {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use old_io::{Truncate, Write, TimedOut, timer, process, FileNotFound};
     use old_io::{Reader, Writer};
     use prelude::v1::{Ok, Err, drop, Some, None, Vec};

--- a/src/libstd/old_io/stdio.rs
+++ b/src/libstd/old_io/stdio.rs
@@ -523,7 +523,7 @@ impl Writer for StdWriter {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
 
     use super::*;

--- a/src/libstd/old_path/posix.rs
+++ b/src/libstd/old_path/posix.rs
@@ -440,7 +440,7 @@ static dot_static: &'static [u8] = b".";
 static dot_dot_static: &'static [u8] = b"..";
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
 
     use clone::Clone;

--- a/src/libstd/old_path/windows.rs
+++ b/src/libstd/old_path/windows.rs
@@ -1120,7 +1120,7 @@ fn prefix_len(p: Option<PathPrefix>) -> usize {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::PathPrefix::*;
     use super::parse_prefix;
     use super::*;

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -1504,7 +1504,7 @@ mod arch_consts {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     #![allow(deprecated)] // rand
 
     use prelude::v1::*;

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1541,7 +1541,7 @@ impl AsRef<Path> for PathBuf {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
     use core::prelude::*;
     use string::{ToString, String};

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -528,7 +528,7 @@ impl Child {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use io::ErrorKind;
     use io::prelude::*;
     use prelude::v1::{Ok, Err, drop, Some, Vec};

--- a/src/libstd/rt/args.rs
+++ b/src/libstd/rt/args.rs
@@ -106,7 +106,7 @@ mod imp {
     }
 
     #[cfg(test)]
-    mod tests {
+    mod test {
         use prelude::v1::*;
         use finally::Finally;
 

--- a/src/libstd/sync/barrier.rs
+++ b/src/libstd/sync/barrier.rs
@@ -106,7 +106,7 @@ impl BarrierWaitResult {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
 
     use sync::{Arc, Barrier};

--- a/src/libstd/sync/condvar.rs
+++ b/src/libstd/sync/condvar.rs
@@ -341,7 +341,7 @@ impl StaticCondvar {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
 
     use super::{StaticCondvar, CONDVAR_INIT};

--- a/src/libstd/sync/mpsc/mpsc_queue.rs
+++ b/src/libstd/sync/mpsc/mpsc_queue.rs
@@ -154,7 +154,7 @@ impl<T: Send> Drop for Queue<T> {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
 
     use sync::mpsc::channel;

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -405,7 +405,7 @@ impl<'a, T> Drop for RwLockWriteGuard<'a, T> {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     #![allow(deprecated)] // rand
 
     use prelude::v1::*;

--- a/src/libstd/sync/semaphore.rs
+++ b/src/libstd/sync/semaphore.rs
@@ -109,7 +109,7 @@ impl<'a> Drop for SemaphoreGuard<'a> {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
 
     use sync::Arc;

--- a/src/libstd/sys/common/thread_local.rs
+++ b/src/libstd/sys/common/thread_local.rs
@@ -243,7 +243,7 @@ impl Drop for Key {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
     use super::{Key, StaticKey, INIT_INNER};
 

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -843,7 +843,7 @@ impl AsciiExt for Wtf8 {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
     use borrow::Cow;
     use super::*;

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -374,7 +374,7 @@ pub fn utime(p: &Path, atime: u64, mtime: u64) -> IoResult<()> {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::FileDesc;
     use libc;
     use os;

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -473,7 +473,7 @@ fn free_handle(handle: *mut ()) {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
     use str;
     use ffi::CString;

--- a/src/libstd/sys/windows/process2.rs
+++ b/src/libstd/sys/windows/process2.rs
@@ -434,7 +434,7 @@ fn with_dirp<T, F>(d: Option<&OsString>, cb: F) -> T where
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
     use str;
     use ffi::{OsStr, OsString};

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -520,7 +520,7 @@ mod imp {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use prelude::v1::*;
 
     use sync::mpsc::{channel, Sender};

--- a/src/libstd/thread/scoped.rs
+++ b/src/libstd/thread/scoped.rs
@@ -275,7 +275,7 @@ mod imp {
 
 
 #[cfg(test)]
-mod tests {
+mod test {
     use cell::Cell;
     use prelude::v1::*;
 

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -427,7 +427,7 @@ fn div_rem_64(this: i64, other: i64) -> (i64, i64) {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::{Duration, MIN, MAX};
     use {i32, i64};
     use option::Option::{Some, None};

--- a/src/libsyntax/ext/mtwt.rs
+++ b/src/libsyntax/ext/mtwt.rs
@@ -274,7 +274,7 @@ fn xor_push(marks: &mut Vec<Mrk>, mark: Mrk) {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use self::TestSC::*;
     use ast::{EMPTY_CTXT, Ident, Mrk, Name, SyntaxContext};
     use super::{resolve, xor_push, apply_mark_internal, new_sctable_internal};

--- a/src/libsyntax/util/interner.rs
+++ b/src/libsyntax/util/interner.rs
@@ -229,7 +229,7 @@ impl StrInterner {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
     use ast::Name;
 

--- a/src/libtest/stats.rs
+++ b/src/libtest/stats.rs
@@ -330,7 +330,7 @@ pub fn winsorize<T: Float + FromPrimitive>(samples: &mut [T], pct: T) {
 // Test vectors generated from R, using the script src/etc/stat-test-vectors.r.
 
 #[cfg(test)]
-mod tests {
+mod test {
     use stats::Stats;
     use stats::Summary;
     use std::old_io::{self, Writer};

--- a/src/test/run-pass/privacy1.rs
+++ b/src/test/run-pass/privacy1.rs
@@ -18,7 +18,7 @@ pub mod test2 {
     trait A { fn foo(&self) {} }
     impl A for B {}
 
-    mod tests {
+    mod test {
         use super::A;
         fn foo() {
             let a = super::B;


### PR DESCRIPTION
Follow-up of #23839: Rename another occurence of "mod tests" in documentation as well and rename unit test modules in the repository accordingly to reflect [the guidelines](https://github.com/rust-lang/rust/blob/master/src/doc/style/testing/unit.md).

However, I had to leave the example for the benchmark tests as it is because importing libtest clashes with "mod test". The same applies for the "tests" submodules in libstd/old_io/mod.rs, librbml/lib.rs, librustdoc/html/markdown.rs and libtest/lib.rs, as they already expose a public module test or use libtest or another module named test.

Which makes me wonder if the convention to place unit tests in a submodule named "test" is the right choice as it is impossible to do so when importing libtest at the same time (renaming libtest is another option).
