### PR TITLE
std: Stabilize the rest of Any/BoxAny

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -233,24 +233,10 @@ impl<T: ?Sized + Hash> Hash for Box<T> {
     }
 }
 
-/// Extension methods for an owning `Any` trait object.
-#[unstable(feature = "alloc",
-           reason = "this trait will likely disappear once compiler bugs blocking \
-                     a direct impl on `Box<Any>` have been fixed ")]
-// FIXME(#18737): this should be a direct impl on `Box<Any>`. If you're
-//                removing this please make sure that you can downcase on
-//                `Box<Any + Send>` as well as `Box<Any>`
-pub trait BoxAny {
-    /// Returns the boxed value if it is of type `T`, or
-    /// `Err(Self)` if it isn't.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    fn downcast<T: Any>(self) -> Result<Box<T>, Box<Any>>;
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl BoxAny for Box<Any> {
+impl Box<Any> {
     #[inline]
-    fn downcast<T: Any>(self) -> Result<Box<T>, Box<Any>> {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub fn downcast<T: Any>(self) -> Result<Box<T>, Box<Any>> {
         if self.is::<T>() {
             unsafe {
                 // Get the raw representation of the trait object
@@ -267,10 +253,10 @@ impl BoxAny for Box<Any> {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
-impl BoxAny for Box<Any+Send> {
+impl Box<Any+Send> {
     #[inline]
-    fn downcast<T: Any>(self) -> Result<Box<T>, Box<Any>> {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub fn downcast<T: Any>(self) -> Result<Box<T>, Box<Any>> {
         <Box<Any>>::downcast(self)
     }
 }

--- a/src/liballoc/boxed_test.rs
+++ b/src/liballoc/boxed_test.rs
@@ -17,7 +17,6 @@ use core::clone::Clone;
 
 use std::boxed;
 use std::boxed::Box;
-use std::boxed::BoxAny;
 
 #[test]
 fn test_owned_clone() {

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -202,8 +202,7 @@ pub struct TypeId {
 impl TypeId {
     /// Returns the `TypeId` of the type this generic function has been
     /// instantiated with
-    #[unstable(feature = "core",
-               reason = "may grow a `Reflect` bound soon via marker traits")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     pub fn of<T: ?Sized + Any>() -> TypeId {
         TypeId {
             t: unsafe { intrinsics::type_id::<T>() },

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -810,7 +810,6 @@ mod test {
 
     use any::Any;
     use sync::mpsc::{channel, Sender};
-    use boxed::BoxAny;
     use result;
     use std::old_io::{ChanReader, ChanWriter};
     use super::{Builder};

--- a/src/test/run-pass/unit-like-struct-drop-run.rs
+++ b/src/test/run-pass/unit-like-struct-drop-run.rs
@@ -14,7 +14,6 @@
 
 #![feature(alloc)]
 
-use std::boxed::BoxAny;
 use std::thread;
 
 struct Foo;


### PR DESCRIPTION
This commit stabilizes the following APIs:
- `TypeId::of` - now that it has an `Any` bound it's ready to be stable.
- `Box<Any>::downcast` - now that an inherent impl on `Box<Any>` as well as
  `Box<Any+Send>` is allowed the `BoxAny` trait is removed in favor of these
  inherent methods.

This is a breaking change due to the removal of the `BoxAny` trait, but
consumers can simply remove imports to fix crates.

[breaking-change]
