### PR TITLE
convert: remove FromError, use From<E> instead

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -51,7 +51,7 @@ use core::prelude::*;
 use core::any::Any;
 use core::cmp::Ordering;
 use core::default::Default;
-use core::error::{Error, FromError};
+use core::error::Error;
 use core::fmt;
 use core::hash::{self, Hash};
 use core::mem;
@@ -322,8 +322,8 @@ impl<I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for Box<I> {
 impl<I: ExactSizeIterator + ?Sized> ExactSizeIterator for Box<I> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, E: Error + 'a> FromError<E> for Box<Error + 'a> {
-    fn from_error(err: E) -> Box<Error + 'a> {
+impl<'a, E: Error + 'a> From<E> for Box<Error + 'a> {
+    fn from(err: E) -> Box<Error + 'a> {
         Box::new(err)
     }
 }

--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -99,6 +99,13 @@ impl<'a, T: ?Sized, U: ?Sized> AsMut<U> for &'a mut T where T: AsMut<U> {
 //     }
 // }
 
+// From itself is always itself
+impl<T> From<T> for T {
+    fn from(t: T) -> T {
+        t
+    }
+}
+
 // From implies Into
 impl<T, U> Into<U> for T where U: From<T> {
     fn into(self) -> U {

--- a/src/libcore/error.rs
+++ b/src/libcore/error.rs
@@ -34,17 +34,6 @@
 //! particular implementation, but also reveal some of its implementation for
 //! debugging via `cause` chains.
 //!
-//! # The `FromError` trait
-//!
-//! `FromError` is a simple trait that expresses conversions between different
-//! error types. To provide maximum flexibility, it does not require either of
-//! the types to actually implement the `Error` trait, although this will be the
-//! common case.
-//!
-//! The main use of this trait is in the `try!` macro, which uses it to
-//! automatically convert a given error to the error specified in a function's
-//! return type.
-//!
 //! For example,
 //!
 //! ```
@@ -59,14 +48,14 @@
 //!     Map(MapError)
 //! }
 //!
-//! impl FromError<IoError> for MyError {
-//!     fn from_error(err: IoError) -> MyError {
+//! impl From<IoError> for MyError {
+//!     fn from(err: IoError) -> MyError {
 //!         MyError::Io(err)
 //!     }
 //! }
 //!
-//! impl FromError<MapError> for MyError {
-//!     fn from_error(err: MapError) -> MyError {
+//! impl From<MapError> for MyError {
+//!     fn from(err: MapError) -> MyError {
 //!         MyError::Map(err)
 //!     }
 //! }
@@ -99,20 +88,4 @@ pub trait Error: Debug + Display {
     /// The lower-level cause of this error, if any.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn cause(&self) -> Option<&Error> { None }
-}
-
-/// A trait for types that can be converted from a given error type `E`.
-#[stable(feature = "rust1", since = "1.0.0")]
-pub trait FromError<E> {
-    /// Perform the conversion.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    fn from_error(err: E) -> Self;
-}
-
-// Any type is convertable from itself
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<E> FromError<E> for E {
-    fn from_error(err: E) -> E {
-        err
-    }
 }

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -156,7 +156,7 @@ macro_rules! debug_assert_eq {
 
 /// Short circuiting evaluation on Err
 ///
-/// `libstd` contains a more general `try!` macro that uses `FromError`.
+/// `libstd` contains a more general `try!` macro that uses `From<E>`.
 #[macro_export]
 macro_rules! try {
     ($e:expr) => ({

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -365,8 +365,8 @@ impl std::error::Error for EncoderError {
     fn description(&self) -> &str { "encoder error" }
 }
 
-impl std::error::FromError<fmt::Error> for EncoderError {
-    fn from_error(err: fmt::Error) -> EncoderError { EncoderError::FmtError(err) }
+impl From<fmt::Error> for EncoderError {
+    fn from(err: fmt::Error) -> EncoderError { EncoderError::FmtError(err) }
 }
 
 pub type EncodeResult = Result<(), EncoderError>;

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -12,7 +12,7 @@
 
 use convert::Into;
 use cmp::{PartialEq, Eq, PartialOrd, Ord, Ordering};
-use error::{Error, FromError};
+use error::Error;
 use fmt;
 use io;
 use iter::Iterator;
@@ -298,8 +298,8 @@ impl fmt::Display for NulError {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl FromError<NulError> for io::Error {
-    fn from_error(_: NulError) -> io::Error {
+impl From<NulError> for io::Error {
+    fn from(_: NulError) -> io::Error {
         io::Error::new(io::ErrorKind::InvalidInput,
                        "data provided contains a nul byte", None)
     }
@@ -307,8 +307,8 @@ impl FromError<NulError> for io::Error {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow(deprecated)]
-impl FromError<NulError> for old_io::IoError {
-    fn from_error(_: NulError) -> old_io::IoError {
+impl From<NulError> for old_io::IoError {
+    fn from(_: NulError) -> old_io::IoError {
         old_io::IoError {
             kind: old_io::IoErrorKind::InvalidInput,
             desc: "data provided contains a nul byte",

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -16,7 +16,7 @@ use prelude::v1::*;
 use io::prelude::*;
 
 use cmp;
-use error::{self, FromError};
+use error;
 use fmt;
 use io::{self, DEFAULT_BUF_SIZE, Error, ErrorKind};
 use ptr;
@@ -264,8 +264,8 @@ impl<W> IntoInnerError<W> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<W> FromError<IntoInnerError<W>> for Error {
-    fn from_error(iie: IntoInnerError<W>) -> Error { iie.1 }
+impl<W> From<IntoInnerError<W>> for Error {
+    fn from(iie: IntoInnerError<W>) -> Error { iie.1 }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -97,7 +97,7 @@ macro_rules! try {
     ($expr:expr) => (match $expr {
         $crate::result::Result::Ok(val) => val,
         $crate::result::Result::Err(err) => {
-            return $crate::result::Result::Err($crate::error::FromError::from_error(err))
+            return $crate::result::Result::Err($crate::convert::From::from(err))
         }
     })
 }

--- a/src/libstd/os.rs
+++ b/src/libstd/os.rs
@@ -40,7 +40,7 @@ use boxed::Box;
 use clone::Clone;
 use convert::From;
 use env;
-use error::{FromError, Error};
+use error::Error;
 use ffi::{OsString, OsStr};
 use fmt;
 use iter::Iterator;

--- a/src/libstd/sync/poison.rs
+++ b/src/libstd/sync/poison.rs
@@ -11,7 +11,7 @@
 use prelude::v1::*;
 
 use cell::UnsafeCell;
-use error::{Error, FromError};
+use error::{Error};
 use fmt;
 use thread;
 
@@ -144,8 +144,8 @@ impl<T> PoisonError<T> {
     pub fn get_mut(&mut self) -> &mut T { &mut self.guard }
 }
 
-impl<T> FromError<PoisonError<T>> for TryLockError<T> {
-    fn from_error(err: PoisonError<T>) -> TryLockError<T> {
+impl<T> From<PoisonError<T>> for TryLockError<T> {
+    fn from(err: PoisonError<T>) -> TryLockError<T> {
         TryLockError::Poisoned(err)
     }
 }


### PR DESCRIPTION
This removes the FromError trait, since it can now be expressed using
the new convert::Into trait. All implementations of FromError<E> where
changed to From<E>, and `try!` was changed to use From::from instead.

Because this removes FromError, it is a breaking change, but fixing it
simply requires changing the words `FromError` to `From`, and
`from_error` to `from`.

[breaking-change]

r? @alexcrichton or @aturon 
