### PR TITLE
Don't reborrow the target of a `write!()`

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -184,7 +184,7 @@ macro_rules! try {
 /// ```
 #[macro_export]
 macro_rules! write {
-    ($dst:expr, $($arg:tt)*) => ((&mut *$dst).write_fmt(format_args!($($arg)*)))
+    ($dst:expr, $($arg:tt)*) => ($dst.write_fmt(format_args!($($arg)*)))
 }
 
 /// Equivalent to the `write!` macro, except that a newline is appended after


### PR DESCRIPTION
This means passing in e.g. a `Vec<u8>` or `String` will work as
intended, rather than deref-ing to `&mut [u8]` or `&mut str`.

[breaking-change]

Closes #23768
