### PR TITLE
Add (unstable) FnBox trait as a nicer replacement for `Thunk`. 

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -31,7 +31,6 @@ extern crate log;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::thunk::Thunk;
 use getopts::{optopt, optflag, reqopt};
 use common::Config;
 use common::{Pretty, DebugInfoGdb, DebugInfoLldb, Codegen};
@@ -351,7 +350,7 @@ pub fn make_test_name(config: &Config, testfile: &Path) -> test::TestName {
 pub fn make_test_closure(config: &Config, testfile: &Path) -> test::TestFn {
     let config = (*config).clone();
     let testfile = testfile.to_path_buf();
-    test::DynTestFn(Thunk::new(move || {
+    test::DynTestFn(Box::new(move || {
         runtest::run(config, &testfile)
     }))
 }

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -393,28 +393,25 @@ impl<'a, 'b> From<&'b str> for Box<Error + Send + 'a> {
 ///     }
 /// }
 /// ```
-#[cfg(not(stage0))]
 #[rustc_paren_sugar]
 #[unstable(feature = "core", reason = "Newly introduced")]
 pub trait FnBox<A> {
     type Output;
 
-    extern "rust-call" fn call_box(self: Box<Self>, args: A) -> Self::Output;
+    fn call_box(self: Box<Self>, args: A) -> Self::Output;
 }
 
-#[cfg(not(stage0))]
 impl<A,F> FnBox<A> for F
     where F: FnOnce<A>
 {
     type Output = F::Output;
 
-    extern "rust-call" fn call_box(self: Box<F>, args: A) -> F::Output {
+    fn call_box(self: Box<F>, args: A) -> F::Output {
         self.call_once(args)
     }
 }
 
-#[cfg(not(stage0))]
-impl<A,R> FnOnce<A> for Box<FnBox<A,Output=R>> {
+impl<'a,A,R> FnOnce<A> for Box<FnBox<A,Output=R>+'a> {
     type Output = R;
 
     extern "rust-call" fn call_once(self, args: A) -> R {
@@ -422,8 +419,7 @@ impl<A,R> FnOnce<A> for Box<FnBox<A,Output=R>> {
     }
 }
 
-#[cfg(not(stage0))]
-impl<A,R> FnOnce<A> for Box<FnBox<A,Output=R>+Send> {
+impl<'a,A,R> FnOnce<A> for Box<FnBox<A,Output=R>+Send+'a> {
     type Output = R;
 
     extern "rust-call" fn call_once(self, args: A) -> R {

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -355,3 +355,78 @@ impl<'a, 'b> From<&'b str> for Box<Error + Send + 'a> {
         }
     }
 }
+
+/// `FnBox` is a version of the `FnOnce` intended for use with boxed
+/// closure objects. The idea is that where one would normally store a
+/// `Box<FnOnce()>` in a data structure, you should use
+/// `Box<FnBox()>`. The two traits behave essentially the same, except
+/// that a `FnBox` closure can only be called if it is boxed. (Note
+/// that `FnBox` may be deprecated in the future if `Box<FnOnce()>`
+/// closures become directly usable.)
+///
+/// ### Example
+///
+/// Here is a snippet of code which creates a hashmap full of boxed
+/// once closures and then removes them one by one, calling each
+/// closure as it is removed. Note that the type of the closures
+/// stored in the map is `Box<FnBox() -> i32>` and not `Box<FnOnce()
+/// -> i32>`.
+///
+/// ```
+/// #![feature(core)]
+///
+/// use std::boxed::FnBox;
+/// use std::collections::HashMap;
+///
+/// fn make_map() -> HashMap<i32, Box<FnBox() -> i32>> {
+///     let mut map: HashMap<i32, Box<FnBox() -> i32>> = HashMap::new();
+///     map.insert(1, Box::new(|| 22));
+///     map.insert(2, Box::new(|| 44));
+///     map
+/// }
+///
+/// fn main() {
+///     let mut map = make_map();
+///     for i in &[1, 2] {
+///         let f = map.remove(&i).unwrap();
+///         assert_eq!(f(), i * 22);
+///     }
+/// }
+/// ```
+#[cfg(not(stage0))]
+#[rustc_paren_sugar]
+#[unstable(feature = "core", reason = "Newly introduced")]
+pub trait FnBox<A> {
+    type Output;
+
+    extern "rust-call" fn call_box(self: Box<Self>, args: A) -> Self::Output;
+}
+
+#[cfg(not(stage0))]
+impl<A,F> FnBox<A> for F
+    where F: FnOnce<A>
+{
+    type Output = F::Output;
+
+    extern "rust-call" fn call_box(self: Box<F>, args: A) -> F::Output {
+        self.call_once(args)
+    }
+}
+
+#[cfg(not(stage0))]
+impl<A,R> FnOnce<A> for Box<FnBox<A,Output=R>> {
+    type Output = R;
+
+    extern "rust-call" fn call_once(self, args: A) -> R {
+        self.call_box(args)
+    }
+}
+
+#[cfg(not(stage0))]
+impl<A,R> FnOnce<A> for Box<FnBox<A,Output=R>+Send> {
+    type Output = R;
+
+    extern "rust-call" fn call_once(self, args: A) -> R {
+        self.call_box(args)
+    }
+}

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -19,7 +19,6 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::str;
 use std::sync::{Arc, Mutex};
-use std::thunk::Thunk;
 
 use testing;
 use rustc_lint;
@@ -366,7 +365,7 @@ impl Collector {
                 ignore: should_ignore,
                 should_panic: testing::ShouldPanic::No, // compiler failures are test failures
             },
-            testfn: testing::DynTestFn(Thunk::new(move|| {
+            testfn: testing::DynTestFn(Box::new(move|| {
                 runtest(&test,
                         &cratename,
                         libs,

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -243,6 +243,7 @@ mod uint_macros;
 #[path = "num/f64.rs"]   pub mod f64;
 
 pub mod ascii;
+
 pub mod thunk;
 
 /* Common traits */

--- a/src/libstd/rt/at_exit_imp.rs
+++ b/src/libstd/rt/at_exit_imp.rs
@@ -64,7 +64,7 @@ pub fn cleanup() {
             if queue as usize != 0 {
                 let queue: Box<Queue> = Box::from_raw(queue);
                 for to_run in *queue {
-                    to_run.invoke(());
+                    to_run();
                 }
             }
         }

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -21,7 +21,6 @@
 
 use prelude::v1::*;
 use sys;
-use thunk::Thunk;
 use usize;
 
 // Reexport some of our utilities which are expected by other crates.
@@ -153,7 +152,7 @@ fn lang_start(main: *const u8, argc: isize, argv: *const *const u8) -> isize {
 /// that the closure could not be registered, meaning that it is not scheduled
 /// to be rune.
 pub fn at_exit<F: FnOnce() + Send + 'static>(f: F) -> Result<(), ()> {
-    if at_exit_imp::push(Thunk::new(f)) {Ok(())} else {Err(())}
+    if at_exit_imp::push(Box::new(f)) {Ok(())} else {Err(())}
 }
 
 /// One-time runtime cleanup.

--- a/src/libstd/sync/future.rs
+++ b/src/libstd/sync/future.rs
@@ -36,6 +36,7 @@
 use core::prelude::*;
 use core::mem::replace;
 
+use boxed::Box;
 use self::FutureState::*;
 use sync::mpsc::{Receiver, channel};
 use thunk::Thunk;
@@ -84,7 +85,7 @@ impl<A> Future<A> {
                 match replace(&mut self.state, Evaluating) {
                     Forced(_) | Evaluating => panic!("Logic error."),
                     Pending(f) => {
-                        self.state = Forced(f.invoke(()));
+                        self.state = Forced(f());
                         self.get_ref()
                     }
                 }
@@ -114,7 +115,7 @@ impl<A> Future<A> {
          * function. It is not spawned into another task.
          */
 
-        Future {state: Pending(Thunk::new(f))}
+        Future {state: Pending(Box::new(f))}
     }
 }
 

--- a/src/libstd/sys/common/thread.rs
+++ b/src/libstd/sys/common/thread.rs
@@ -25,6 +25,7 @@ pub fn start_thread(main: *mut libc::c_void) {
     unsafe {
         stack::record_os_managed_stack_bounds(0, usize::MAX);
         let _handler = stack_overflow::Handler::new();
-        Box::from_raw(main as *mut Thunk).invoke(());
+        let main: Box<Thunk> = Box::from_raw(main as *mut Thunk);
+        main();
     }
 }

--- a/src/libstd/thunk.rs
+++ b/src/libstd/thunk.rs
@@ -12,45 +12,9 @@
 #![allow(missing_docs)]
 #![unstable(feature = "std_misc")]
 
-use alloc::boxed::Box;
+use alloc::boxed::{Box, FnBox};
 use core::marker::Send;
-use core::ops::FnOnce;
 
-pub struct Thunk<'a, A=(),R=()> {
-    invoke: Box<Invoke<A,R>+Send + 'a>,
-}
+pub type Thunk<'a, A=(), R=()> =
+    Box<FnBox<A,Output=R> + Send + 'a>;
 
-impl<'a, R> Thunk<'a,(),R> {
-    pub fn new<F>(func: F) -> Thunk<'a,(),R>
-        where F : FnOnce() -> R, F : Send + 'a
-    {
-        Thunk::with_arg(move|()| func())
-    }
-}
-
-impl<'a,A,R> Thunk<'a,A,R> {
-    pub fn with_arg<F>(func: F) -> Thunk<'a,A,R>
-        where F : FnOnce(A) -> R, F : Send + 'a
-    {
-        Thunk {
-            invoke: Box::<F>::new(func)
-        }
-    }
-
-    pub fn invoke(self, arg: A) -> R {
-        self.invoke.invoke(arg)
-    }
-}
-
-pub trait Invoke<A=(),R=()> {
-    fn invoke(self: Box<Self>, arg: A) -> R;
-}
-
-impl<A,R,F> Invoke<A,R> for F
-    where F : FnOnce(A) -> R
-{
-    fn invoke(self: Box<F>, arg: A) -> R {
-        let f = *self;
-        f(arg)
-    }
-}

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -958,7 +958,7 @@ pub fn run_test(opts: &TestOpts,
         }
         DynMetricFn(f) => {
             let mut mm = MetricMap::new();
-            f.call_box((&mut mm,)); // TODO unfortunate
+            f.call_box((&mut mm,));
             monitor_ch.send((desc, TrMetrics(mm), Vec::new())).unwrap();
             return;
         }

--- a/src/test/run-pass/issue-11709.rs
+++ b/src/test/run-pass/issue-11709.rs
@@ -25,7 +25,7 @@ fn test(slot: &mut Option<Thunk<(),Thunk>>) -> () {
   let a = slot.take();
   let _a = match a {
     // `{let .. a(); }` would break
-    Some(a) => { let _a = a.invoke(()); },
+    Some(a) => { let _a = a(); },
     None => (),
   };
 }

--- a/src/test/run-pass/issue-11958.rs
+++ b/src/test/run-pass/issue-11958.rs
@@ -23,5 +23,5 @@ use std::thunk::Thunk;
 
 pub fn main() {
     let mut x = 1;
-    let _thunk = Thunk::new(move|| { x = 2; });
+    let _thunk = Box::new(move|| { x = 2; });
 }

--- a/src/test/run-pass/issue-17897.rs
+++ b/src/test/run-pass/issue-17897.rs
@@ -12,10 +12,10 @@
 
 use std::thunk::Thunk;
 
-fn action(cb: Thunk<usize, usize>) -> usize {
-    cb.invoke(1)
+fn action(cb: Thunk<(usize,), usize>) -> usize {
+    cb(1)
 }
 
 pub fn main() {
-    println!("num: {}", action(Thunk::with_arg(move |u| u)));
+    println!("num: {}", action(Box::new(move |u| u)));
 }

--- a/src/test/run-pass/issue-18188.rs
+++ b/src/test/run-pass/issue-18188.rs
@@ -16,13 +16,13 @@ use std::thunk::Thunk;
 
 pub trait Promisable: Send + Sync {}
 impl<T: Send + Sync> Promisable for T {}
-pub fn propagate<'a, T, E, F, G>(action: F) -> Thunk<'a,Result<T, E>, Result<T, E>>
+pub fn propagate<'a, T, E, F, G>(action: F) -> Thunk<'a, (Result<T, E>,), Result<T, E>>
     where
         T: Promisable + Clone + 'a,
         E: Promisable + Clone + 'a,
         F: FnOnce(&T) -> Result<T, E> + Send + 'a,
         G: FnOnce(Result<T, E>) -> Result<T, E> + 'a {
-    Thunk::with_arg(move |result: Result<T, E>| {
+    Box::new(move |result: Result<T, E>| {
         match result {
             Ok(ref t) => action(t),
             Err(ref e) => Err(e.clone()),

--- a/src/test/run-pass/issue-2190-1.rs
+++ b/src/test/run-pass/issue-2190-1.rs
@@ -18,11 +18,11 @@ use std::thunk::Thunk;
 static generations: usize = 1024+256+128+49;
 
 fn spawn(f: Thunk<'static>) {
-    Builder::new().stack_size(32 * 1024).spawn(move|| f.invoke(()));
+    Builder::new().stack_size(32 * 1024).spawn(move|| f());
 }
 
 fn child_no(x: usize) -> Thunk<'static> {
-    Thunk::new(move|| {
+    Box::new(move|| {
         if x < generations {
             spawn(child_no(x+1));
         }

--- a/src/test/run-pass/issue-3609.rs
+++ b/src/test/run-pass/issue-3609.rs
@@ -13,7 +13,6 @@
 
 use std::thread;
 use std::sync::mpsc::Sender;
-use std::thunk::Invoke;
 
 type RingBuffer = Vec<f64> ;
 type SamplesFn = Box<FnMut(&RingBuffer) + Send>;


### PR DESCRIPTION
Add (unstable) FnBox trait as a nicer replacement for `Thunk`. The doc comment includes a test that also shows how it can be used.

f? @aturon 
f? @alexcrichton 
