### PR TITLE
rustup: Default to the beta channel

### DIFF
--- a/src/etc/rustup.sh
+++ b/src/etc/rustup.sh
@@ -288,6 +288,7 @@ VAL_OPTIONS=""
 flag uninstall "only uninstall from the installation prefix"
 valopt prefix "" "set installation prefix"
 valopt date "" "use the YYYY-MM-DD nightly instead of the current nightly"
+valopt channel "nightly" "use the selected release channel [nightly]"
 flag save "save the downloaded nightlies to ~/.rustup"
 
 if [ $HELP -eq 1 ]
@@ -449,17 +450,24 @@ then
 fi
 
 RUST_URL="https://static.rust-lang.org/dist"
-RUST_PACKAGE_NAME=rust-nightly
+case "$CFG_CHANNEL" in
+    nightly)
+        # add a date suffix if we want a particular nighly.
+        if [ -n "${CFG_DATE}" ];
+        then
+            RUST_URL="${RUST_URL}/${CFG_DATE}"
+        fi
+
+        RUST_PACKAGE_NAME=rust-nightly
+        ;;
+    *)
+        err "Currently nightly is the only supported release channel"
+esac
+
 RUST_PACKAGE_NAME_AND_TRIPLE="${RUST_PACKAGE_NAME}-${HOST_TRIPLE}"
 RUST_TARBALL_NAME="${RUST_PACKAGE_NAME_AND_TRIPLE}.tar.gz"
 RUST_LOCAL_INSTALL_DIR="${CFG_TMP_DIR}/${RUST_PACKAGE_NAME_AND_TRIPLE}"
 RUST_LOCAL_INSTALL_SCRIPT="${RUST_LOCAL_INSTALL_DIR}/install.sh"
-
-# add a date suffix if we want a particular nighly.
-if [ -n "${CFG_DATE}" ];
-then
-    RUST_URL="${RUST_URL}/${CFG_DATE}"
-fi
 
 download_hash() {
     msg "Downloading ${remote_sha256}"

--- a/src/etc/rustup.sh
+++ b/src/etc/rustup.sh
@@ -307,7 +307,7 @@ CFG_CPUTYPE=$(uname -m)
 
 if [ $CFG_OSTYPE = Darwin -a $CFG_CPUTYPE = i386 ]
 then
-    # Darwin's `uname -s` lies and always returns i386. We have to use sysctl
+    # Darwin's `uname -m` lies and always returns i386. We have to use sysctl
     # instead.
     if sysctl hw.optional.x86_64 | grep -q ': 1'
     then

--- a/src/etc/rustup.sh
+++ b/src/etc/rustup.sh
@@ -452,7 +452,7 @@ fi
 RUST_URL="https://static.rust-lang.org/dist"
 case "$CFG_CHANNEL" in
     nightly)
-        # add a date suffix if we want a particular nighly.
+        # add a date suffix if we want a particular nightly.
         if [ -n "${CFG_DATE}" ];
         then
             RUST_URL="${RUST_URL}/${CFG_DATE}"

--- a/src/etc/rustup.sh
+++ b/src/etc/rustup.sh
@@ -288,7 +288,7 @@ VAL_OPTIONS=""
 flag uninstall "only uninstall from the installation prefix"
 valopt prefix "" "set installation prefix"
 valopt date "" "use the YYYY-MM-DD nightly instead of the current nightly"
-valopt channel "nightly" "use the selected release channel [nightly]"
+valopt channel "beta" "use the selected release channel [beta]"
 flag save "save the downloaded nightlies to ~/.rustup"
 
 if [ $HELP -eq 1 ]
@@ -460,8 +460,11 @@ case "$CFG_CHANNEL" in
 
         RUST_PACKAGE_NAME=rust-nightly
         ;;
+    beta)
+        RUST_PACKAGE_NAME=rust-1.0.0-beta
+        ;;
     *)
-        err "Currently nightly is the only supported release channel"
+        err "Currently 'beta' and 'nightly' are the only supported channels"
 esac
 
 RUST_PACKAGE_NAME_AND_TRIPLE="${RUST_PACKAGE_NAME}-${HOST_TRIPLE}"


### PR DESCRIPTION
Switches rustup to using the beta channel by default. Includes #23824 for the implementation.

cc #20453
Closes #21149
