### PR TITLE
Add Send/Sync bounds to many generic concurrent types.

### DIFF
--- a/src/libcollections/borrow.rs
+++ b/src/libcollections/borrow.rs
@@ -16,7 +16,7 @@ use core::clone::Clone;
 use core::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
 use core::convert::AsRef;
 use core::hash::{Hash, Hasher};
-use core::marker::Sized;
+use core::marker::{Send, Sized, Sync};
 use core::ops::Deref;
 use core::option::Option;
 
@@ -115,7 +115,7 @@ impl<T> Borrow<T> for rc::Rc<T> {
     fn borrow(&self) -> &T { &**self }
 }
 
-impl<T> Borrow<T> for arc::Arc<T> {
+impl<T: Send + Sync> Borrow<T> for arc::Arc<T> {
     fn borrow(&self) -> &T { &**self }
 }
 

--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -612,7 +612,7 @@ impl<T: Decodable> Decodable for RefCell<T> {
     }
 }
 
-impl<T:Encodable> Encodable for Arc<T> {
+impl<T:Sync+Send+Encodable> Encodable for Arc<T> {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         (**self).encode(s)
     }

--- a/src/libstd/io/lazy.rs
+++ b/src/libstd/io/lazy.rs
@@ -15,13 +15,13 @@ use cell::UnsafeCell;
 use rt;
 use sync::{StaticMutex, Arc};
 
-pub struct Lazy<T> {
+pub struct Lazy<T: Send + Sync> {
     pub lock: StaticMutex,
     pub ptr: UnsafeCell<*mut Arc<T>>,
     pub init: fn() -> Arc<T>,
 }
 
-unsafe impl<T> Sync for Lazy<T> {}
+unsafe impl<T: Send + Sync> Sync for Lazy<T> {}
 
 macro_rules! lazy_init {
     ($init:expr) => (::io::lazy::Lazy {

--- a/src/libstd/sync/mutex.rs
+++ b/src/libstd/sync/mutex.rs
@@ -170,6 +170,8 @@ pub struct MutexGuard<'a, T: 'a> {
     __poison: poison::Guard,
 }
 
+// It is undefined behaviour to unlock a mutex on a thread other than
+// the one that locked it.
 impl<'a, T> !marker::Send for MutexGuard<'a, T> {}
 
 /// Static initialization of a mutex. This constant can be used to initialize

--- a/src/libstd/sync/rwlock.rs
+++ b/src/libstd/sync/rwlock.rs
@@ -60,7 +60,7 @@ use fmt;
 /// } // write lock is dropped here
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct RwLock<T> {
+pub struct RwLock<T: Send + Sync> {
     inner: Box<StaticRwLock>,
     data: UnsafeCell<T>,
 }
@@ -251,7 +251,7 @@ impl<T: Send + Sync> RwLock<T> {
 
 #[unsafe_destructor]
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> Drop for RwLock<T> {
+impl<T: Send + Sync> Drop for RwLock<T> {
     fn drop(&mut self) {
         unsafe { self.inner.lock.destroy() }
     }


### PR DESCRIPTION
These types are purely designed for concurrent code, and, at the moment,
are restricted to be used in those situations. This solidifies that goal
by imposing a strict restriction on the generic types from the start,
i.e. in the definition itself.

This is the opposite to #23176 which relaxes the bounds entirely (it is
backwards compatible to switch to that more flexible approach).

Unfortunately the message-passing primitives in std (the return value
from a thread, and sync::mpsc) aren't great about how they work with
mutability and sharing, and so require hacky error-prone `unsafe impl`s.
However, they are purely implementation details: the interface isn't
affected by having to make that internal change, and clean-ups to the
code should be able to remove the hacks.
