### PR TITLE
Implement PartialEq<str> for String and Cow

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -796,9 +796,9 @@ impl<'a, 'b> Pattern<'a> for &'b String {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl PartialEq for String {
     #[inline]
-    fn eq(&self, other: &String) -> bool { PartialEq::eq(&**self, &**other) }
+    fn eq(&self, other: &String) -> bool { PartialEq::eq(&self[..], &other[..]) }
     #[inline]
-    fn ne(&self, other: &String) -> bool { PartialEq::ne(&**self, &**other) }
+    fn ne(&self, other: &String) -> bool { PartialEq::ne(&self[..], &other[..]) }
 }
 
 macro_rules! impl_eq {
@@ -806,17 +806,17 @@ macro_rules! impl_eq {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl<'a> PartialEq<$rhs> for $lhs {
             #[inline]
-            fn eq(&self, other: &$rhs) -> bool { PartialEq::eq(&**self, &**other) }
+            fn eq(&self, other: &$rhs) -> bool { PartialEq::eq(&self[..], &other[..]) }
             #[inline]
-            fn ne(&self, other: &$rhs) -> bool { PartialEq::ne(&**self, &**other) }
+            fn ne(&self, other: &$rhs) -> bool { PartialEq::ne(&self[..], &other[..]) }
         }
 
         #[stable(feature = "rust1", since = "1.0.0")]
         impl<'a> PartialEq<$lhs> for $rhs {
             #[inline]
-            fn eq(&self, other: &$lhs) -> bool { PartialEq::eq(&**self, &**other) }
+            fn eq(&self, other: &$lhs) -> bool { PartialEq::eq(&self[..], &other[..]) }
             #[inline]
-            fn ne(&self, other: &$lhs) -> bool { PartialEq::ne(&**self, &**other) }
+            fn ne(&self, other: &$lhs) -> bool { PartialEq::ne(&self[..], &other[..]) }
         }
 
     }
@@ -828,17 +828,17 @@ impl_eq! { Cow<'a, str>, String }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, 'b> PartialEq<&'b str> for Cow<'a, str> {
     #[inline]
-    fn eq(&self, other: &&'b str) -> bool { PartialEq::eq(&**self, &**other) }
+    fn eq(&self, other: &&'b str) -> bool { PartialEq::eq(&self[..], &other[..]) }
     #[inline]
-    fn ne(&self, other: &&'b str) -> bool { PartialEq::ne(&**self, &**other) }
+    fn ne(&self, other: &&'b str) -> bool { PartialEq::ne(&self[..], &other[..]) }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, 'b> PartialEq<Cow<'a, str>> for &'b str {
     #[inline]
-    fn eq(&self, other: &Cow<'a, str>) -> bool { PartialEq::eq(&**self, &**other) }
+    fn eq(&self, other: &Cow<'a, str>) -> bool { PartialEq::eq(&self[..], &other[..]) }
     #[inline]
-    fn ne(&self, other: &Cow<'a, str>) -> bool { PartialEq::ne(&**self, &**other) }
+    fn ne(&self, other: &Cow<'a, str>) -> bool { PartialEq::ne(&self[..], &other[..]) }
 }
 
 #[unstable(feature = "collections", reason = "waiting on Str stabilization")]

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -822,7 +822,9 @@ macro_rules! impl_eq {
     }
 }
 
+impl_eq! { String, str }
 impl_eq! { String, &'a str }
+impl_eq! { Cow<'a, str>, str }
 impl_eq! { Cow<'a, str>, String }
 
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
Right now comparing a `&String` (or a `&Cow`) to a `&str` requires redundant borrowing of the latter. Implementing `PartialEq<str>` tries to avoid this limitation.

``` rust
struct Foo (String);

fn main () {
    let s = Foo("foo".to_string());
    match s {
        Foo(ref x) if x == &"foo" => println!("foo!"),
        // avoid this -----^
        _ => {}
    }
}
```

I was hoping that #23521 would solve this but it didn't work out.
