### PR TITLE
Do not suggest `#![feature(...)]` if we are in beta or stable channel.

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -411,10 +411,7 @@ pub fn emit_feature_err(diag: &SpanHandler, feature: &str, span: Span, explain: 
     diag.span_err(span, explain);
 
     // #23973: do not suggest `#![feature(...)]` if we are in beta/stable
-    match option_env!("CFG_RELEASE_CHANNEL") {
-        Some("stable") | Some("beta") => return,
-        _ => {}
-    }
+    if option_env!("CFG_DISABLE_UNSTABLE_FEATURES").is_some() { return; }
     diag.fileline_help(span, &format!("add #![feature({})] to the \
                                    crate attributes to enable",
                                   feature));
@@ -424,10 +421,7 @@ pub fn emit_feature_warn(diag: &SpanHandler, feature: &str, span: Span, explain:
     diag.span_warn(span, explain);
 
     // #23973: do not suggest `#![feature(...)]` if we are in beta/stable
-    match option_env!("CFG_RELEASE_CHANNEL") {
-        Some("stable") | Some("beta") => return,
-        _ => {}
-    }
+    if option_env!("CFG_DISABLE_UNSTABLE_FEATURES").is_some() { return; }
     if diag.handler.can_emit_warnings {
         diag.fileline_help(span, &format!("add #![feature({})] to the \
                                        crate attributes to silence this warning",

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -409,6 +409,12 @@ impl<'a> Context<'a> {
 
 pub fn emit_feature_err(diag: &SpanHandler, feature: &str, span: Span, explain: &str) {
     diag.span_err(span, explain);
+
+    // #23973: do not suggest `#![feature(...)]` if we are in beta/stable
+    match option_env!("CFG_RELEASE_CHANNEL") {
+        Some("stable") | Some("beta") => return,
+        _ => {}
+    }
     diag.fileline_help(span, &format!("add #![feature({})] to the \
                                    crate attributes to enable",
                                   feature));
@@ -416,6 +422,12 @@ pub fn emit_feature_err(diag: &SpanHandler, feature: &str, span: Span, explain: 
 
 pub fn emit_feature_warn(diag: &SpanHandler, feature: &str, span: Span, explain: &str) {
     diag.span_warn(span, explain);
+
+    // #23973: do not suggest `#![feature(...)]` if we are in beta/stable
+    match option_env!("CFG_RELEASE_CHANNEL") {
+        Some("stable") | Some("beta") => return,
+        _ => {}
+    }
     if diag.handler.can_emit_warnings {
         diag.fileline_help(span, &format!("add #![feature({})] to the \
                                        crate attributes to silence this warning",

--- a/src/test/compile-fail-fulldeps/gated-macro-reexports.rs
+++ b/src/test/compile-fail-fulldeps/gated-macro-reexports.rs
@@ -19,4 +19,3 @@
 #[macro_use] #[no_link]
 extern crate macro_reexport_1;
 //~^ ERROR macros reexports are experimental and possibly buggy
-//~| HELP add #![feature(macro_reexport)] to the crate attributes to enable

--- a/src/test/compile-fail/gated-box-patterns.rs
+++ b/src/test/compile-fail/gated-box-patterns.rs
@@ -16,7 +16,6 @@ fn main() {
     match x {
         box 1 => (),
         //~^ box pattern syntax is experimental
-        //~| add #![feature(box_patterns)] to the crate attributes to enable
         _     => ()
     };
 }

--- a/src/test/compile-fail/gated-box-syntax.rs
+++ b/src/test/compile-fail/gated-box-syntax.rs
@@ -13,5 +13,4 @@
 fn main() {
     let x = box 3;
     //~^ ERROR box expression syntax is experimental; you can call `Box::new` instead.
-    //~| HELP add #![feature(box_syntax)] to the crate attributes to enable
 }

--- a/src/test/compile-fail/gated-link-args.rs
+++ b/src/test/compile-fail/gated-link-args.rs
@@ -14,6 +14,5 @@
 #[link_args = "aFdEfSeVEEE"]
 extern {}
 //~^ ERROR the `link_args` attribute is not portable across platforms
-//~| HELP add #![feature(link_args)] to the crate attributes to enable
 
 fn main() { }

--- a/src/test/compile-fail/gated-link-llvm-intrinsics.rs
+++ b/src/test/compile-fail/gated-link-llvm-intrinsics.rs
@@ -12,7 +12,6 @@ extern {
     #[link_name = "llvm.sqrt.f32"]
     fn sqrt(x: f32) -> f32;
     //~^ ERROR linking to LLVM intrinsics is experimental
-    //~| HELP add #![feature(link_llvm_intrinsics)] to the crate attributes
 }
 
 fn main(){

--- a/src/test/compile-fail/gated-plugin_registrar.rs
+++ b/src/test/compile-fail/gated-plugin_registrar.rs
@@ -15,5 +15,4 @@
 #[plugin_registrar]
 pub fn registrar() {}
 //~^ ERROR compiler plugins are experimental
-//~| HELP add #![feature(plugin_registrar)] to the crate attributes to enable
 fn main() {}

--- a/src/test/compile-fail/gated-unsafe-destructor.rs
+++ b/src/test/compile-fail/gated-unsafe-destructor.rs
@@ -18,8 +18,6 @@ struct D<'a>(&'a u32);
 
 #[unsafe_destructor]
 //~^ ERROR `#[unsafe_destructor]` does nothing anymore
-//~| HELP: add #![feature(unsafe_destructor)] to the crate attributes to enable
-// (but of couse there is no point in doing so)
 impl<'a> Drop for D<'a> {
     fn drop(&mut self) { }
 }


### PR DESCRIPTION
Do not suggest `#![feature(...)]` if we are in beta or stable channel.

Fix #23973
