### PR TITLE
doc/trpl: Fixing a comma splice in iterators.md.

### DIFF
--- a/src/doc/trpl/iterators.md
+++ b/src/doc/trpl/iterators.md
@@ -291,7 +291,7 @@ If you are trying to execute a closure on an iterator for its side effects,
 just use `for` instead.
 
 There are tons of interesting iterator adapters. `take(n)` will return an
-iterator over the next `n` elements of the original iterator, note that this
+iterator over the next `n` elements of the original iterator. Note that this
 has no side effect on the original iterator. Let's try it out with our infinite
 iterator from before:
 


### PR DESCRIPTION
I ran across a comma splice.

I didn't set the "note:" off inside parenthesis.  I looked around in other places and saw it both ways, but without surrounding parenthesis seemed to be the more common convention followed elsewhere in the docs.  Let me know if you have an overriding preference about that and I'll change it.

r? @steveklabnik
