### PR TITLE
Workaround `javac` popup on MacOS X

### DIFF
--- a/configure
+++ b/configure
@@ -669,7 +669,6 @@ probe CFG_LD               ld
 probe CFG_VALGRIND         valgrind
 probe CFG_PERF             perf
 probe CFG_ISCC             iscc
-probe CFG_JAVAC            javac
 probe CFG_ANTLR4           antlr4
 probe CFG_GRUN             grun
 probe CFG_FLEX             flex
@@ -678,6 +677,14 @@ probe CFG_PANDOC           pandoc
 probe CFG_XELATEX          xelatex
 probe CFG_GDB              gdb
 probe CFG_LLDB             lldb
+
+# On MacOS X, invoking `javac` pops up a dialog if the JDK is not
+# installed. Since `javac` is only used if `antlr4` is available,
+# probe for it only in this case.
+if [ ! -z "$CFG_ANTLR4" ]
+then
+   probe CFG_JAVAC            javac
+fi
 
 if [ ! -z "$CFG_GDB" ]
 then


### PR DESCRIPTION
MacOS X does not ship with Java installed by default. Instead it
includes binary stubs that upon execution pop up a message suggesting
the installation of the JDK.

Since `javac` is only used when `antlr4` is available, it is possible
to work around the popup by only probing for `javac` if `antlr4` has
been successfully detected (in which case the JDK is probably already
installed on the system).

Fixes #23138.
