### PR TITLE
Update the book install instructions for nightly

### DIFF
--- a/src/doc/trpl/installing-rust.md
+++ b/src/doc/trpl/installing-rust.md
@@ -2,19 +2,37 @@
 
 The first step to using Rust is to install it! There are a number of ways to
 install Rust, but the easiest is to use the `rustup` script. If you're on
-Linux or a Mac, all you need to do is this (note that you don't need to type
-in the `$`s, they just indicate the start of each command):
+Linux or a Mac, all you need to do is run one of these commands (note that
+you don't need to type in the `$`s, they just indicate the start of each
+command):
+
+For Beta:
 
 ```bash
 $ curl -sf -L https://static.rust-lang.org/rustup.sh | sudo sh
 ```
 
+For Nightly:
+
+```bash
+$ curl -s https://static.rust-lang.org/rustup.sh | sudo sh -s -- --channel=nightly
+```
+
 If you're concerned about the [potential insecurity](http://curlpipesh.tumblr.com/) of using `curl | sudo sh`,
 please keep reading and see our disclaimer below. And feel free to use a two-step version of the installation and examine our installation script:
+
+For Beta:
 
 ```bash
 $ curl -f -L https://static.rust-lang.org/rustup.sh -O
 $ sudo sh rustup.sh
+```
+
+For Nightly:
+
+```bash
+$ curl -f -L https://static.rust-lang.org/rustup.sh -O
+$ sudo sh rustup.sh --channel=nightly
 ```
 
 If you're on Windows, please download either the [32-bit


### PR DESCRIPTION
I wanted to use bullet points for a two item list but couldn't embed a code block in a bullet point.

It may be considered undesirable to put the nightly here but I thought it should be added because the two line instructions aren't on the [rust-lang.org](http://www.rust-lang.org/install.html) page. Maybe they should be there instead...
