### PR TITLE
Implement two features: Creating OS pipes and redirecting stdio of child processes to File handles

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -310,6 +310,9 @@ impl File {
 impl AsInner<fs_imp::File> for File {
     fn as_inner(&self) -> &fs_imp::File { &self.inner }
 }
+impl AsInnerMut<fs_imp::File> for File {
+    fn as_inner_mut(&mut self) -> &mut fs_imp::File { &mut self.inner }
+}
 impl FromInner<fs_imp::File> for File {
     fn from_inner(f: fs_imp::File) -> File {
         File { inner: f, path: None }

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -145,6 +145,17 @@ pub struct OpenOptions(fs_imp::OpenOptions);
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Permissions(fs_imp::FilePermissions);
 
+/// A low-level OS in-memory pipe.
+#[unstable(feature = "fs_pipe", reason = "feature was recently added")]
+pub struct Pipe {
+    /// A file representing the read end of the pipe. Data written
+    /// on the `writer` file can be read from this file.
+    pub reader: File,
+    /// A file representing the write end of the pipe. Data written
+    /// to this file can be read from the `reader` file.
+    pub writer: File,
+}
+
 impl File {
     /// Attempts to open a file in read-only mode.
     ///
@@ -625,6 +636,21 @@ impl FromInner<fs_imp::FilePermissions> for Permissions {
 
 impl AsInner<fs_imp::FilePermissions> for Permissions {
     fn as_inner(&self) -> &fs_imp::FilePermissions { &self.0 }
+}
+
+impl Pipe {
+    /// Creates a new low-level OS in-memory pipe.
+    ///
+    /// This function will return an error if there are no more resources
+    /// available to allocate a pipe.
+    #[unstable(feature = "fs_pipe", reason = "feature was recently added")]
+    pub fn new() -> io::Result<Pipe> {
+        let (reader, writer) = try!(fs_imp::pipe());
+        Ok(Pipe {
+            reader: File::from_inner(reader),
+            writer: File::from_inner(writer),
+        })
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/sys/unix/fs2.rs
+++ b/src/libstd/sys/unix/fs2.rs
@@ -381,3 +381,15 @@ pub fn utimes(p: &Path, atime: u64, mtime: u64) -> io::Result<()> {
     try!(cvt(unsafe { c::utimes(p.as_ptr(), buf.as_ptr()) }));
     Ok(())
 }
+
+pub fn pipe() -> io::Result<(File, File)> {
+    unsafe {
+        let mut fds = [0; 2];
+        if let Ok(0) = cvt_r(|| libc::pipe(fds.as_mut_ptr())) {
+            Ok((File::from_inner(fds[0]),
+                File::from_inner(fds[1])))
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+}

--- a/src/libstd/sys/unix/fs2.rs
+++ b/src/libstd/sys/unix/fs2.rs
@@ -20,6 +20,7 @@ use path::{Path, PathBuf};
 use ptr;
 use sync::Arc;
 use sys::fd::FileDesc;
+use sys::pipe2::AnonPipe;
 use sys::{c, cvt, cvt_r};
 use sys_common::FromInner;
 use vec::Vec;
@@ -55,6 +56,12 @@ pub struct OpenOptions {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct FilePermissions { mode: mode_t }
+
+impl File {
+    pub fn dup_as_anon_pipe(&self, _writable: bool) -> io::Result<AnonPipe> {
+        AnonPipe::clone_fd(self.0.raw())
+    }
+}
 
 impl FileAttr {
     pub fn is_dir(&self) -> bool {


### PR DESCRIPTION
This pull request implements two separate but related features:
- Safely creating an OS pipe which will create two `std::fs::File` handles (thus inheriting all their benefits). There was a similar struct in the past, however, it exposed raw file descriptors and was rather unsafe. It is feature gated behind `fs_pipe`.
- Allow for redirection of stdio of `std::process::Command`s to open file handles, this allows saving command output or piping output from two different `Command`s without having to manually buffer the data. This is currently feature gated behind `process_redirect`.
