### PR TITLE
book: use `mod test` consistently

### DIFF
--- a/src/doc/trpl/benchmark-tests.md
+++ b/src/doc/trpl/benchmark-tests.md
@@ -13,7 +13,7 @@ pub fn add_two(a: i32) -> i32 {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
     use test::Bencher;
 

--- a/src/doc/trpl/testing.md
+++ b/src/doc/trpl/testing.md
@@ -382,7 +382,7 @@ pub fn add_two(a: i32) -> i32 {
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
 
     #[test]


### PR DESCRIPTION
Fixes #24030

Of the four code samples with modules in TRPL:

```
- 2 use `mod test`
- 2 use `mod tests`
```

We should be consistent here, but which is right? The stdlib is split:

```
$ grep -r 'mod tests {' src/lib* | wc -l
      63
$ grep -r 'mod test {'  src/lib* | wc -l
      58
```

Subjectively, I like the plural, but both the language reference and the
style guide recommend the singular. So we'll go with that here, for now.

r? @steveklabnik
