### PR TITLE
book: use `mod tests` consistently

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1830,7 +1830,7 @@ explain, here's a few use cases and what they would entail:
   the second case.
 
 * When writing unit tests for a module, it's often a common idiom to have an
-  immediate child of the module to-be-tested named `mod test`. This module
+  immediate child of the module to-be-tested named `mod tests`. This module
   could access any items of the parent module through the second case, meaning
   that internal implementation details could also be seamlessly tested from the
   child module.
@@ -1882,7 +1882,7 @@ pub mod submodule {
     fn my_implementation() {}
 
     #[cfg(test)]
-    mod test {
+    mod tests {
 
         #[test]
         fn test_my_implementation() {

--- a/src/doc/style/testing/unit.md
+++ b/src/doc/style/testing/unit.md
@@ -1,10 +1,10 @@
 % Unit testing
 
-Unit tests should live in a `test` submodule at the bottom of the module they
-test. Mark the `test` submodule with `#[cfg(test)]` so it is only compiled when
+Unit tests should live in a `tests` submodule at the bottom of the module they
+test. Mark the `tests` submodule with `#[cfg(test)]` so it is only compiled when
 testing.
 
-The `test` module should contain:
+The `tests` module should contain:
 
 * Imports needed only for testing.
 * Functions marked with `#[test]` striving for full coverage of the parent module's
@@ -17,7 +17,7 @@ For example:
 // Excerpt from std::str
 
 #[cfg(test)]
-mod test {
+mod tests {
     #[test]
     fn test_eq() {
         assert!((eq(&"".to_owned(), &"".to_owned())));

--- a/src/doc/trpl/testing.md
+++ b/src/doc/trpl/testing.md
@@ -219,10 +219,10 @@ fn it_works() {
 This is a very common use of `assert_eq!`: call some function with
 some known arguments and compare it to the expected output.
 
-# The `test` module
+# The `tests` module
 
 There is one way in which our existing example is not idiomatic: it's
-missing the test module. The idiomatic way of writing our example
+missing the `tests` module. The idiomatic way of writing our example
 looks like this:
 
 ```{rust,ignore}
@@ -231,7 +231,7 @@ pub fn add_two(a: i32) -> i32 {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::add_two;
 
     #[test]
@@ -241,7 +241,7 @@ mod test {
 }
 ```
 
-There's a few changes here. The first is the introduction of a `mod test` with
+There's a few changes here. The first is the introduction of `mod tests` with
 a `cfg` attribute. The module allows us to group all of our tests together, and
 to also define helper functions if needed, that don't become a part of the rest
 of our crate. The `cfg` attribute only compiles our test code if we're
@@ -260,7 +260,7 @@ pub fn add_two(a: i32) -> i32 {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]
@@ -292,7 +292,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 
 It works!
 
-The current convention is to use the `test` module to hold your "unit-style"
+The current convention is to use the `tests` module to hold your "unit-style"
 tests. Anything that just tests one small bit of functionality makes sense to
 go here. But what about "integration-style" tests instead? For that, we have
 the `tests` directory
@@ -346,7 +346,7 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 Now we have three sections: our previous test is also run, as well as our new
 one.
 
-That's all there is to the `tests` directory. The `test` module isn't needed
+That's all there is to the `tests` directory. The `tests` module isn't needed
 here, since the whole thing is focused on tests.
 
 Let's finally check out that third section: documentation tests.


### PR DESCRIPTION
Fixes #24030

Of the four code samples with modules in TRPL:

```
- 2 use `mod test`
- 2 use `mod tests`
```

We should be consistent here, but which is right? The stdlib is split:

```
$ grep -r 'mod tests {' src/lib* | wc -l
      63
$ grep -r 'mod test {'  src/lib* | wc -l
      58
```

Subjectively, I like the plural. Maybe you, dear reviewer, do too?

r? @steveklabnik
