### PR TITLE
Make changing doc search unhighlight current result

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -468,6 +468,8 @@
                     if ($active.length) {
                         document.location.href = $active.find('a').prop('href');
                     }
+                } else {
+                  $active.removeClass('highlighted');
                 }
             });
         }


### PR DESCRIPTION
If a result is highlighted, when the search changes that state should no
longer be highlighted. Fixes #24044

cc @steveklabnik
