### PR TITLE
Added small note when two different closures fail typechecking.

### DIFF
--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -373,8 +373,9 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
     fn report_and_explain_type_error(&self,
                                      trace: TypeTrace<'tcx>,
                                      terr: &ty::type_err<'tcx>) {
+        let span = trace.origin.span();
         self.report_type_error(trace, terr);
-        ty::note_and_explain_type_err(self.tcx, terr);
+        ty::note_and_explain_type_err(self.tcx, terr, span);
     }
 
     /// Returns a string of the form "expected `{}`, found `{}`", or None if this is a derived

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -812,7 +812,7 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
         }
         self.give_suggestion(same_regions);
         for &(ref trace, terr) in trace_origins {
-            self.report_type_error(trace.clone(), &terr);
+            self.report_and_explain_type_error(trace.clone(), &terr);
         }
     }
 

--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -987,7 +987,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                     error_str));
 
                 if let Some(err) = err {
-                    ty::note_and_explain_type_err(self.tcx, err)
+                    ty::note_and_explain_type_err(self.tcx, err, sp)
                 }
             }
         }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -5132,7 +5132,8 @@ pub fn note_and_explain_type_err<'tcx>(cx: &ctxt<'tcx>, err: &type_err<'tcx>) {
             let found_str = ty_sort_string(cx, values.found);
             if expected_str == found_str && expected_str == "closure" {
                 cx.sess.note(&format!("no two closures, even if identical, have the same type"));
-                cx.sess.help(&format!("consider boxing your closure and/or using it as a trait object"));
+                cx.sess.help(&format!("consider boxing your closure and/or \
+                                        using it as a trait object"));
             }
         }
         _ => {}

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -5096,7 +5096,7 @@ pub fn type_err_to_str<'tcx>(cx: &ctxt<'tcx>, err: &type_err<'tcx>) -> String {
     }
 }
 
-pub fn note_and_explain_type_err<'tcx>(cx: &ctxt<'tcx>, err: &type_err<'tcx>) {
+pub fn note_and_explain_type_err<'tcx>(cx: &ctxt<'tcx>, err: &type_err<'tcx>, sp: Span) {
     match *err {
         terr_regions_does_not_outlive(subregion, superregion) => {
             note_and_explain_region(cx, "", subregion, "...");
@@ -5131,8 +5131,9 @@ pub fn note_and_explain_type_err<'tcx>(cx: &ctxt<'tcx>, err: &type_err<'tcx>) {
             let expected_str = ty_sort_string(cx, values.expected);
             let found_str = ty_sort_string(cx, values.found);
             if expected_str == found_str && expected_str == "closure" {
-                cx.sess.note(&format!("no two closures, even if identical, have the same type"));
-                cx.sess.help(&format!("consider boxing your closure and/or \
+                cx.sess.span_note(sp, &format!("no two closures, even if identical, have the same \
+                                                type"));
+                cx.sess.span_help(sp, &format!("consider boxing your closure and/or \
                                         using it as a trait object"));
             }
         }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -5096,7 +5096,7 @@ pub fn type_err_to_str<'tcx>(cx: &ctxt<'tcx>, err: &type_err<'tcx>) -> String {
     }
 }
 
-pub fn note_and_explain_type_err(cx: &ctxt, err: &type_err) {
+pub fn note_and_explain_type_err<'tcx>(cx: &ctxt<'tcx>, err: &type_err<'tcx>) {
     match *err {
         terr_regions_does_not_outlive(subregion, superregion) => {
             note_and_explain_region(cx, "", subregion, "...");
@@ -5126,6 +5126,14 @@ pub fn note_and_explain_type_err(cx: &ctxt, err: &type_err) {
             note_and_explain_region(cx,
                                     "expected concrete lifetime is ",
                                     conc_region, "");
+        }
+        terr_sorts(values) => {
+            let expected_str = ty_sort_string(cx, values.expected);
+            let found_str = ty_sort_string(cx, values.found);
+            if expected_str == found_str && expected_str == "closure" {
+                cx.sess.note(&format!("no two closures, even if identical, have the same type"));
+                cx.sess.help(&format!("consider boxing your closure and/or using it as a trait object"));
+            }
         }
         _ => {}
     }

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -155,7 +155,7 @@ impl Session {
         self.diagnostic().handler().note(msg)
     }
     pub fn help(&self, msg: &str) {
-        self.diagnostic().handler().note(msg)
+        self.diagnostic().handler().help(msg)
     }
     pub fn opt_span_bug(&self, opt_sp: Option<Span>, msg: &str) -> ! {
         match opt_sp {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3709,7 +3709,7 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                                             .ty_to_string(
                                                 actual_structure_type),
                                          type_error_description);
-                    ty::note_and_explain_type_err(tcx, &type_error);
+                    ty::note_and_explain_type_err(tcx, &type_error, path.span);
                 }
             }
         }

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -200,7 +200,7 @@ fn require_same_types<'a, 'tcx, M>(tcx: &ty::ctxt<'tcx>,
                                       msg(),
                                       ty::type_err_to_str(tcx,
                                                           terr));
-            ty::note_and_explain_type_err(tcx, terr);
+            ty::note_and_explain_type_err(tcx, terr, span);
             false
         }
     }

--- a/src/test/compile-fail/issue-24036.rs
+++ b/src/test/compile-fail/issue-24036.rs
@@ -1,0 +1,30 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn closure_to_loc() {
+    let mut x = |c| c + 1;
+    x = |c| c + 1;
+    //~^ ERROR mismatched types
+    //~| NOTE no two closures, even if identical, have the same type
+    //~| HELP consider boxing your closure and/or using it as a trait object
+}
+
+fn closure_from_match() {
+    let x = match 1usize {
+        1 => |c| c + 1,
+        2 => |c| c - 1,
+        _ => |c| c - 1
+    };
+    //~^^^^^ ERROR match arms have incompatible types
+    //~| NOTE no two closures, even if identical, have the same type
+    //~| HELP consider boxing your closure and/or using it as a trait object
+}
+
+fn main() { }


### PR DESCRIPTION
Also fixed bug calling .note() instead of .help()

See #24036
