### PR TITLE
docs: Vectors are to slices what String is to &str

### DIFF
--- a/src/doc/trpl/arrays-vectors-and-slices.md
+++ b/src/doc/trpl/arrays-vectors-and-slices.md
@@ -49,7 +49,7 @@ languages.
 
 A *vector* is a dynamic or "growable" array, implemented as the standard
 library type [`Vec<T>`](../std/vec/) (we'll talk about what the `<T>` means
-later). Vectors always allocate their data on the heap. Vectors are to slices
+later). Vectors always allocate their data on the heap. Vectors are to arrays
 what `String` is to `&str`. You can create them with the `vec!` macro:
 
 ```{rust}


### PR DESCRIPTION
This just doesn't sound right to me. I believe it's meant to say "arrays" instead of "slices". Slices aren't even mentioned until later in the page.

Please let me know if I'm just misunderstanding. Thanks
