### PR TITLE
traits.md: Fix example of using traits to match description

### DIFF
--- a/src/doc/trpl/traits.md
+++ b/src/doc/trpl/traits.md
@@ -229,8 +229,6 @@ everything is fine:
 
 ```{rust}
 # #![feature(core)]
-use shapes::HasArea;
-
 mod shapes {
     use std::f64::consts;
 
@@ -251,6 +249,7 @@ mod shapes {
     }
 }
 
+use shapes::HasArea;
 
 fn main() {
     let c = shapes::Circle {


### PR DESCRIPTION
traits.md said:

If we add a `use` line right above `main` and make the right things public,
everything is fine:

However, the use line was actually placed at the top of the file instead.  Move
the use line to right above main.  That also makes the example more evocative
of cases where the module is defined in a separate file.
