### PR TITLE
Minor documentation fixes.

### DIFF
--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -83,11 +83,12 @@ use marker::{Reflect, Sized};
 // Any trait
 ///////////////////////////////////////////////////////////////////////////////
 
-/// A type to emulate dynamic typing. See the [module-level documentation][mod] for more details.
+/// A type to emulate dynamic typing.
 ///
 /// Every type with no non-`'static` references implements `Any`.
+/// See the [module-level documentation][mod] for more details.
 ///
-/// [mod]: ../index.html
+/// [mod]: index.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Any: Reflect + 'static {
     /// Get the `TypeId` of `self`

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -618,9 +618,6 @@ pub trait BufRead: Read {
     /// The iterator returned from this function will yield instances of
     /// `io::Result<String>`. Each string returned will *not* have a newline
     /// byte (the 0xA byte) at the end.
-    ///
-    /// This function will yield errors whenever `read_string` would have also
-    /// yielded an error.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn lines(self) -> Lines<Self> where Self: Sized {
         Lines { buf: self }


### PR DESCRIPTION
- Fix broken "module-level documentation" link on the [`trait Any` docs](http://doc.rust-lang.org/std/any/trait.Any.html) and related broken markup on the [`std::any` docs](http://doc.rust-lang.org/std/any/index.html).
- Remove an outdated or incorrect notice in the `BufRead::lines` docs. There is no such `read_string` function, and `lines` never returns an error.

r? @steveklabnik 
