### PR TITLE
rustdoc: Add a custom callback for codespan to collapse whitespace

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -72,6 +72,9 @@ type blockcodefn = extern "C" fn(*mut hoedown_buffer, *const hoedown_buffer,
 type headerfn = extern "C" fn(*mut hoedown_buffer, *const hoedown_buffer,
                               libc::c_int, *mut libc::c_void);
 
+type codespanfn = extern "C" fn(*mut hoedown_buffer, *const hoedown_buffer,
+                                *mut libc::c_void);
+
 type linkfn = extern "C" fn (*mut hoedown_buffer, *const hoedown_buffer,
                              *const hoedown_buffer, *const hoedown_buffer,
                              *mut libc::c_void) -> libc::c_int;
@@ -89,11 +92,12 @@ struct hoedown_renderer {
     blockhtml: Option<extern "C" fn(*mut hoedown_buffer, *const hoedown_buffer,
                                     *mut libc::c_void)>,
     header: Option<headerfn>,
-
     other_block_level_callbacks: [libc::size_t; 9],
 
     /* span level callbacks - NULL or return 0 prints the span verbatim */
-    other_span_level_callbacks_1: [libc::size_t; 9],
+    autolink: libc::size_t, // unused
+    codespan: Option<codespanfn>,
+    other_span_level_callbacks_1: [libc::size_t; 7],
     link: Option<linkfn>,
     other_span_level_callbacks_2: [libc::size_t; 5],
     // hoedown will add `math` callback here, but we use an old version of it.
@@ -183,6 +187,30 @@ fn stripped_filtered_line<'a>(s: &'a str) -> Option<&'a str> {
     } else {
         None
     }
+}
+
+/// Returns a new string with all consecutive whitespace collapsed into
+/// single spaces.
+///
+/// The input is assumed to be already trimmed.
+fn collapse_whitespace(s: &str) -> String {
+    let mut buffer = String::with_capacity(s.len());
+    let mut previous_char_is_whitespace = false;
+
+    for c in s.chars() {
+        if c.is_whitespace() {
+            if !previous_char_is_whitespace {
+                buffer.push(' ');
+            }
+
+            previous_char_is_whitespace = true;
+        } else {
+            buffer.push(c);
+            previous_char_is_whitespace = false;
+        }
+    }
+
+    buffer
 }
 
 thread_local!(static USED_HEADER_MAP: RefCell<HashMap<String, usize>> = {
@@ -299,6 +327,20 @@ pub fn render(w: &mut fmt::Formatter, s: &str, print_toc: bool) -> fmt::Result {
 
     reset_headers();
 
+    extern fn codespan(ob: *mut hoedown_buffer, text: *const hoedown_buffer, _: *mut libc::c_void) {
+        let content = if text.is_null() {
+            "".to_string()
+        } else {
+            let bytes = unsafe { (*text).as_bytes() };
+            let s = str::from_utf8(bytes).unwrap();
+            collapse_whitespace(s)
+        };
+
+        let content = format!("<code>{}</code>", Escape(&content));
+        let element = CString::new(content).unwrap();
+        unsafe { hoedown_buffer_puts(ob, element.as_ptr()); }
+    }
+
     unsafe {
         let ob = hoedown_buffer_new(DEF_OUNIT);
         let renderer = hoedown_html_renderer_new(0, 0);
@@ -310,6 +352,7 @@ pub fn render(w: &mut fmt::Formatter, s: &str, print_toc: bool) -> fmt::Result {
                 = &mut opaque as *mut _ as *mut libc::c_void;
         (*renderer).blockcode = Some(block);
         (*renderer).header = Some(header);
+        (*renderer).codespan = Some(codespan);
 
         let document = hoedown_document_new(renderer, HOEDOWN_EXTENSIONS, 16);
         hoedown_document_render(document, ob, s.as_ptr(),
@@ -523,7 +566,7 @@ pub fn plain_summary_line(md: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{LangString, Markdown};
-    use super::plain_summary_line;
+    use super::{collapse_whitespace, plain_summary_line};
 
     #[test]
     fn test_lang_string_parse() {
@@ -570,5 +613,18 @@ mod tests {
         t("type `Type<'static>` ...", "type `Type<'static>` ...");
         t("# top header", "top header");
         t("## header", "header");
+    }
+
+    #[test]
+    fn test_collapse_whitespace() {
+        fn t(input: &str, expected: &str) {
+            let actual = collapse_whitespace(input);
+            assert_eq!(actual, expected);
+        }
+
+        t("foo", "foo");
+        t("foo   bar", "foo bar");
+        t("foo  bar\nbaz", "foo bar baz");
+        t("foo bar \n   baz\t\tqux", "foo bar baz qux");
     }
 }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -192,25 +192,11 @@ fn stripped_filtered_line<'a>(s: &'a str) -> Option<&'a str> {
 /// Returns a new string with all consecutive whitespace collapsed into
 /// single spaces.
 ///
-/// The input is assumed to be already trimmed.
+/// Any leading or trailing whitespace will be trimmed.
 fn collapse_whitespace(s: &str) -> String {
-    let mut buffer = String::with_capacity(s.len());
-    let mut previous_char_is_whitespace = false;
-
-    for c in s.chars() {
-        if c.is_whitespace() {
-            if !previous_char_is_whitespace {
-                buffer.push(' ');
-            }
-
-            previous_char_is_whitespace = true;
-        } else {
-            buffer.push(c);
-            previous_char_is_whitespace = false;
-        }
-    }
-
-    buffer
+    s.split(|c: char| c.is_whitespace()).filter(|s| {
+        !s.is_empty()
+    }).collect::<Vec<_>>().connect(" ")
 }
 
 thread_local!(static USED_HEADER_MAP: RefCell<HashMap<String, usize>> = {
@@ -623,8 +609,9 @@ mod tests {
         }
 
         t("foo", "foo");
-        t("foo   bar", "foo bar");
-        t("foo  bar\nbaz", "foo bar baz");
-        t("foo bar \n   baz\t\tqux", "foo bar baz qux");
+        t("foo bar baz", "foo bar baz");
+        t(" foo   bar", "foo bar");
+        t("\tfoo   bar\nbaz", "foo bar baz");
+        t("foo   bar \n   baz\t\tqux\n", "foo bar baz qux");
     }
 }


### PR DESCRIPTION
Because the current style for `code` in rustdoc is to prewrap whitespace, code spans that are hard wrapped in the source documentation are prematurely wrapped when rendered in HTML. [For example](https://doc.rust-lang.org/std/borrow/trait.Borrow.html),

```
/// ...
/// type can be borrowed as multiple different types. In particular, `Vec<T>:
/// Borrow<Vec<T>>` and `Vec<T>: Borrow<[T]>`.
```

renders as

![screen shot 2015-04-06 at 12 11 21](https://cloud.githubusercontent.com/assets/191331/7008216/2706b3b0-dc56-11e4-941e-1b0154fcbc5c.png)

because "`Vec<T>: Borrow<Vec<T>>`" wraps to the next line in the source.

CommonMark 0.18 [[1](http://spec.commonmark.org/0.18/)] specifies "interior spaces and line endings are collapsed into single spaces" for code spans, which would actually prevent this issue, but hoedown does not currently conform to the
CommonMark spec.

The added span-level callback attempts to adhere to how whitespace is handled as described by CommonMark, fixing the issue of early, unintentional wrapping of code spans in rendered HTML.
