### PR TITLE
Fix range performance regression

### DIFF
--- a/src/test/compile-fail/range-1.rs
+++ b/src/test/compile-fail/range-1.rs
@@ -19,6 +19,7 @@ pub fn main() {
     for i in false..true {}
     //~^ ERROR the trait
     //~^^ ERROR the trait
+    //~^^^ ERROR the trait
 
     // Unsized type.
     let arr: &[_] = &[1, 2, 3];


### PR DESCRIPTION
A recent change to the implementation of range iterators meant that,
even when stepping by 1, the iterators _always_ involved checked
arithmetic.

This commit reverts to the earlier behavior (while retaining the
refactoring into traits).

Fixes #24095
Closes #24119
cc #24014 

r? @alexcrichton 
