### PR TITLE
Fix link in Any documentation

### DIFF
--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -87,7 +87,7 @@ use marker::{Reflect, Sized};
 ///
 /// Every type with no non-`'static` references implements `Any`.
 ///
-/// [mod]: ../index.html
+/// [mod]: ./index.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Any: Reflect + 'static {
     /// Get the `TypeId` of `self`


### PR DESCRIPTION
The link in the documentation for `std::any::Any` linking to the module level documentation was mistakenly leading to `std` instead of `std::any`.

r? @steveklabnik
