### PR TITLE
Add `Sync` to the bounds in `io::Error`

### DIFF
--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -50,7 +50,7 @@
 use boxed::Box;
 use convert::From;
 use fmt::{self, Debug, Display};
-use marker::Send;
+use marker::{Send, Sync};
 use num;
 use option::Option;
 use option::Option::None;
@@ -81,15 +81,15 @@ impl<'a, E: Error + 'a> From<E> for Box<Error + 'a> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, E: Error + Send + 'a> From<E> for Box<Error + Send + 'a> {
-    fn from(err: E) -> Box<Error + Send + 'a> {
+impl<'a, E: Error + Send + Sync + 'a> From<E> for Box<Error + Send + Sync + 'a> {
+    fn from(err: E) -> Box<Error + Send + Sync + 'a> {
         Box::new(err)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl From<String> for Box<Error + Send> {
-    fn from(err: String) -> Box<Error + Send> {
+impl From<String> for Box<Error + Send + Sync> {
+    fn from(err: String) -> Box<Error + Send + Sync> {
         #[derive(Debug)]
         struct StringError(String);
 
@@ -108,8 +108,8 @@ impl From<String> for Box<Error + Send> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, 'b> From<&'b str> for Box<Error + Send + 'a> {
-    fn from(err: &'b str) -> Box<Error + Send + 'a> {
+impl<'a, 'b> From<&'b str> for Box<Error + Send + Sync + 'a> {
+    fn from(err: &'b str) -> Box<Error + Send + Sync + 'a> {
         From::from(String::from_str(err))
     }
 }

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -12,7 +12,7 @@ use boxed::Box;
 use convert::Into;
 use error;
 use fmt;
-use marker::Send;
+use marker::{Send, Sync};
 use option::Option::{self, Some, None};
 use result;
 use sys;
@@ -46,7 +46,7 @@ enum Repr {
 #[derive(Debug)]
 struct Custom {
     kind: ErrorKind,
-    error: Box<error::Error+Send>,
+    error: Box<error::Error+Send+Sync>,
 }
 
 /// A list specifying general categories of I/O error.
@@ -146,7 +146,7 @@ impl Error {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new<E>(kind: ErrorKind, error: E) -> Error
-        where E: Into<Box<error::Error+Send>>
+        where E: Into<Box<error::Error+Send+Sync>>
     {
         Error {
             repr: Repr::Custom(Box::new(Custom {
@@ -216,4 +216,9 @@ impl error::Error for Error {
             Repr::Custom(ref c) => c.error.description(),
         }
     }
+}
+
+fn _assert_error_is_sync_send() {
+    fn _is_sync_send<T: Sync+Send>() {}
+    _is_sync_send::<Error>();
 }


### PR DESCRIPTION
This allows `io::Error` values to be stored in `Arc` properly.

Because this requires `Sync` of any value passed to `io::Error::new()`
and modifies the relevant `convert::From` impls, this is a

[breaking-change]

Fixes #24049.
