### PR TITLE
Revert "std: Standardize (input, output) param orderings"

### DIFF
--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -300,7 +300,7 @@ mod imp {
             libc::realloc(ptr as *mut libc::c_void, size as libc::size_t) as *mut u8
         } else {
             let new_ptr = allocate(size, align);
-            ptr::copy(ptr, new_ptr, cmp::min(size, old_size));
+            ptr::copy(new_ptr, ptr, cmp::min(size, old_size));
             deallocate(ptr, old_size, align);
             new_ptr
         }

--- a/src/libcollections/btree/node.rs
+++ b/src/libcollections/btree/node.rs
@@ -1133,13 +1133,13 @@ impl<K, V> Node<K, V> {
     #[inline]
     unsafe fn insert_kv(&mut self, index: usize, key: K, val: V) -> &mut V {
         ptr::copy(
-            self.keys().as_ptr().offset(index as isize),
             self.keys_mut().as_mut_ptr().offset(index as isize + 1),
+            self.keys().as_ptr().offset(index as isize),
             self.len() - index
         );
         ptr::copy(
-            self.vals().as_ptr().offset(index as isize),
             self.vals_mut().as_mut_ptr().offset(index as isize + 1),
+            self.vals().as_ptr().offset(index as isize),
             self.len() - index
         );
 
@@ -1155,8 +1155,8 @@ impl<K, V> Node<K, V> {
     #[inline]
     unsafe fn insert_edge(&mut self, index: usize, edge: Node<K, V>) {
         ptr::copy(
-            self.edges().as_ptr().offset(index as isize),
             self.edges_mut().as_mut_ptr().offset(index as isize + 1),
+            self.edges().as_ptr().offset(index as isize),
             self.len() - index
         );
         ptr::write(self.edges_mut().get_unchecked_mut(index), edge);
@@ -1188,13 +1188,13 @@ impl<K, V> Node<K, V> {
         let val = ptr::read(self.vals().get_unchecked(index));
 
         ptr::copy(
-            self.keys().as_ptr().offset(index as isize + 1),
             self.keys_mut().as_mut_ptr().offset(index as isize),
+            self.keys().as_ptr().offset(index as isize + 1),
             self.len() - index - 1
         );
         ptr::copy(
-            self.vals().as_ptr().offset(index as isize + 1),
             self.vals_mut().as_mut_ptr().offset(index as isize),
+            self.vals().as_ptr().offset(index as isize + 1),
             self.len() - index - 1
         );
 
@@ -1209,8 +1209,8 @@ impl<K, V> Node<K, V> {
         let edge = ptr::read(self.edges().get_unchecked(index));
 
         ptr::copy(
-            self.edges().as_ptr().offset(index as isize + 1),
             self.edges_mut().as_mut_ptr().offset(index as isize),
+            self.edges().as_ptr().offset(index as isize + 1),
             // index can be == len+1, so do the +1 first to avoid underflow.
             (self.len() + 1) - index
         );
@@ -1237,19 +1237,19 @@ impl<K, V> Node<K, V> {
             right._len = self.len() / 2;
             let right_offset = self.len() - right.len();
             ptr::copy_nonoverlapping(
-                self.keys().as_ptr().offset(right_offset as isize),
                 right.keys_mut().as_mut_ptr(),
+                self.keys().as_ptr().offset(right_offset as isize),
                 right.len()
             );
             ptr::copy_nonoverlapping(
-                self.vals().as_ptr().offset(right_offset as isize),
                 right.vals_mut().as_mut_ptr(),
+                self.vals().as_ptr().offset(right_offset as isize),
                 right.len()
             );
             if !self.is_leaf() {
                 ptr::copy_nonoverlapping(
-                    self.edges().as_ptr().offset(right_offset as isize),
                     right.edges_mut().as_mut_ptr(),
+                    self.edges().as_ptr().offset(right_offset as isize),
                     right.len() + 1
                 );
             }
@@ -1278,19 +1278,19 @@ impl<K, V> Node<K, V> {
             ptr::write(self.vals_mut().get_unchecked_mut(old_len), val);
 
             ptr::copy_nonoverlapping(
-                right.keys().as_ptr(),
                 self.keys_mut().as_mut_ptr().offset(old_len as isize + 1),
+                right.keys().as_ptr(),
                 right.len()
             );
             ptr::copy_nonoverlapping(
-                right.vals().as_ptr(),
                 self.vals_mut().as_mut_ptr().offset(old_len as isize + 1),
+                right.vals().as_ptr(),
                 right.len()
             );
             if !self.is_leaf() {
                 ptr::copy_nonoverlapping(
-                    right.edges().as_ptr(),
                     self.edges_mut().as_mut_ptr().offset(old_len as isize + 1),
+                    right.edges().as_ptr(),
                     right.len() + 1
                 );
             }

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -1258,10 +1258,10 @@ fn insertion_sort<T, F>(v: &mut [T], mut compare: F) where F: FnMut(&T, &T) -> O
 
             if i != j {
                 let tmp = ptr::read(read_ptr);
-                ptr::copy(&*buf_v.offset(j),
-                          buf_v.offset(j + 1),
+                ptr::copy(buf_v.offset(j + 1),
+                          &*buf_v.offset(j),
                           (i - j) as usize);
-                ptr::copy_nonoverlapping(&tmp, buf_v.offset(j), 1);
+                ptr::copy_nonoverlapping(buf_v.offset(j), &tmp, 1);
                 mem::forget(tmp);
             }
         }
@@ -1334,10 +1334,10 @@ fn merge_sort<T, F>(v: &mut [T], mut compare: F) where F: FnMut(&T, &T) -> Order
                 // j + 1 could be `len` (for the last `i`), but in
                 // that case, `i == j` so we don't copy. The
                 // `.offset(j)` is always in bounds.
-                ptr::copy(&*buf_dat.offset(j),
-                          buf_dat.offset(j + 1),
+                ptr::copy(buf_dat.offset(j + 1),
+                          &*buf_dat.offset(j),
                           i - j as usize);
-                ptr::copy_nonoverlapping(read_ptr, buf_dat.offset(j), 1);
+                ptr::copy_nonoverlapping(buf_dat.offset(j), read_ptr, 1);
             }
         }
     }
@@ -1385,11 +1385,11 @@ fn merge_sort<T, F>(v: &mut [T], mut compare: F) where F: FnMut(&T, &T) -> Order
                     if left == right_start {
                         // the number remaining in this run.
                         let elems = (right_end as usize - right as usize) / mem::size_of::<T>();
-                        ptr::copy_nonoverlapping(&*right, out, elems);
+                        ptr::copy_nonoverlapping(out, &*right, elems);
                         break;
                     } else if right == right_end {
                         let elems = (right_start as usize - left as usize) / mem::size_of::<T>();
-                        ptr::copy_nonoverlapping(&*left, out, elems);
+                        ptr::copy_nonoverlapping(out, &*left, elems);
                         break;
                     }
 
@@ -1403,7 +1403,7 @@ fn merge_sort<T, F>(v: &mut [T], mut compare: F) where F: FnMut(&T, &T) -> Order
                     } else {
                         step(&mut left)
                     };
-                    ptr::copy_nonoverlapping(&*to_copy, out, 1);
+                    ptr::copy_nonoverlapping(out, &*to_copy, 1);
                     step(&mut out);
                 }
             }
@@ -1417,7 +1417,7 @@ fn merge_sort<T, F>(v: &mut [T], mut compare: F) where F: FnMut(&T, &T) -> Order
     // write the result to `v` in one go, so that there are never two copies
     // of the same object in `v`.
     unsafe {
-        ptr::copy_nonoverlapping(&*buf_dat, v.as_mut_ptr(), len);
+        ptr::copy_nonoverlapping(v.as_mut_ptr(), &*buf_dat, len);
     }
 
     // increment the pointer, returning the old pointer.

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -599,8 +599,8 @@ impl String {
         let ch = self.char_at(idx);
         let next = idx + ch.len_utf8();
         unsafe {
-            ptr::copy(self.vec.as_ptr().offset(next as isize),
-                      self.vec.as_mut_ptr().offset(idx as isize),
+            ptr::copy(self.vec.as_mut_ptr().offset(idx as isize),
+                      self.vec.as_ptr().offset(next as isize),
                       len - next);
             self.vec.set_len(len - (next - idx));
         }
@@ -629,11 +629,11 @@ impl String {
         let amt = ch.encode_utf8(&mut bits).unwrap();
 
         unsafe {
-            ptr::copy(self.vec.as_ptr().offset(idx as isize),
-                      self.vec.as_mut_ptr().offset((idx + amt) as isize),
+            ptr::copy(self.vec.as_mut_ptr().offset((idx + amt) as isize),
+                      self.vec.as_ptr().offset(idx as isize),
                       len - idx);
-            ptr::copy(bits.as_ptr(),
-                      self.vec.as_mut_ptr().offset(idx as isize),
+            ptr::copy(self.vec.as_mut_ptr().offset(idx as isize),
+                      bits.as_ptr(),
                       amt);
             self.vec.set_len(len + amt);
         }

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -260,17 +260,16 @@ impl<T> Vec<T> {
 
     /// Creates a vector by copying the elements from a raw pointer.
     ///
-    /// This function will copy `elts` contiguous elements starting at `ptr`
-    /// into a new allocation owned by the returned `Vec<T>`. The elements of
-    /// the buffer are copied into the vector without cloning, as if
-    /// `ptr::read()` were called on them.
+    /// This function will copy `elts` contiguous elements starting at `ptr` into a new allocation
+    /// owned by the returned `Vec<T>`. The elements of the buffer are copied into the vector
+    /// without cloning, as if `ptr::read()` were called on them.
     #[inline]
     #[unstable(feature = "collections",
                reason = "may be better expressed via composition")]
     pub unsafe fn from_raw_buf(ptr: *const T, elts: usize) -> Vec<T> {
         let mut dst = Vec::with_capacity(elts);
         dst.set_len(elts);
-        ptr::copy_nonoverlapping(ptr, dst.as_mut_ptr(), elts);
+        ptr::copy_nonoverlapping(dst.as_mut_ptr(), ptr, elts);
         dst
     }
 
@@ -289,9 +288,8 @@ impl<T> Vec<T> {
         self.cap
     }
 
-    /// Reserves capacity for at least `additional` more elements to be inserted
-    /// in the given `Vec<T>`. The collection may reserve more space to avoid
-    /// frequent reallocations.
+    /// Reserves capacity for at least `additional` more elements to be inserted in the given
+    /// `Vec<T>`. The collection may reserve more space to avoid frequent reallocations.
     ///
     /// # Panics
     ///
@@ -550,7 +548,7 @@ impl<T> Vec<T> {
                 let p = self.as_mut_ptr().offset(index as isize);
                 // Shift everything over to make space. (Duplicating the
                 // `index`th element into two consecutive places.)
-                ptr::copy(&*p, p.offset(1), len - index);
+                ptr::copy(p.offset(1), &*p, len - index);
                 // Write it in, overwriting the first copy of the `index`th
                 // element.
                 ptr::write(&mut *p, element);
@@ -588,7 +586,7 @@ impl<T> Vec<T> {
                 ret = ptr::read(ptr);
 
                 // Shift everything down to fill in that spot.
-                ptr::copy(&*ptr.offset(1), ptr, len - index - 1);
+                ptr::copy(ptr, &*ptr.offset(1), len - index - 1);
             }
             self.set_len(len - 1);
             ret
@@ -730,8 +728,8 @@ impl<T> Vec<T> {
         let len = self.len();
         unsafe {
             ptr::copy_nonoverlapping(
-                other.as_ptr(),
                 self.get_unchecked_mut(len),
+                other.as_ptr(),
                 other.len());
         }
 
@@ -1051,8 +1049,8 @@ impl<T> Vec<T> {
             other.set_len(other_len);
 
             ptr::copy_nonoverlapping(
-                self.as_ptr().offset(at as isize),
                 other.as_mut_ptr(),
+                self.as_ptr().offset(at as isize),
                 other.len());
         }
         other

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -137,8 +137,8 @@ impl<T> VecDeque<T> {
         debug_assert!(src + len <= self.cap, "dst={} src={} len={} cap={}", dst, src, len,
                       self.cap);
         ptr::copy(
-            self.ptr.offset(src as isize),
             self.ptr.offset(dst as isize),
+            self.ptr.offset(src as isize),
             len);
     }
 
@@ -150,8 +150,8 @@ impl<T> VecDeque<T> {
         debug_assert!(src + len <= self.cap, "dst={} src={} len={} cap={}", dst, src, len,
                       self.cap);
         ptr::copy_nonoverlapping(
-            self.ptr.offset(src as isize),
             self.ptr.offset(dst as isize),
+            self.ptr.offset(src as isize),
             len);
     }
 }
@@ -1357,21 +1357,21 @@ impl<T> VecDeque<T> {
                 // `at` lies in the first half.
                 let amount_in_first = first_len - at;
 
-                ptr::copy_nonoverlapping(first_half.as_ptr().offset(at as isize),
-                                         *other.ptr,
+                ptr::copy_nonoverlapping(*other.ptr,
+                                         first_half.as_ptr().offset(at as isize),
                                          amount_in_first);
 
                 // just take all of the second half.
-                ptr::copy_nonoverlapping(second_half.as_ptr(),
-                                         other.ptr.offset(amount_in_first as isize),
+                ptr::copy_nonoverlapping(other.ptr.offset(amount_in_first as isize),
+                                         second_half.as_ptr(),
                                          second_len);
             } else {
                 // `at` lies in the second half, need to factor in the elements we skipped
                 // in the first half.
                 let offset = at - first_len;
                 let amount_in_second = second_len - offset;
-                ptr::copy_nonoverlapping(second_half.as_ptr().offset(offset as isize),
-                                         *other.ptr,
+                ptr::copy_nonoverlapping(*other.ptr,
+                                         second_half.as_ptr().offset(offset as isize),
                                          amount_in_second);
             }
         }

--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -316,8 +316,8 @@ pub fn float_to_str_bytes_common<T: Float, U, F>(
 
             impl<'a> fmt::Write for Filler<'a> {
                 fn write_str(&mut self, s: &str) -> fmt::Result {
-                    slice::bytes::copy_memory(s.as_bytes(),
-                                              &mut self.buf[(*self.end)..]);
+                    slice::bytes::copy_memory(&mut self.buf[(*self.end)..],
+                                              s.as_bytes());
                     *self.end += s.len();
                     Ok(())
                 }

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -292,9 +292,9 @@ extern "rust-intrinsic" {
     ///         let mut t: T = mem::uninitialized();
     ///
     ///         // Perform the swap, `&mut` pointers never alias
-    ///         ptr::copy_nonoverlapping(x, &mut t, 1);
-    ///         ptr::copy_nonoverlapping(y, x, 1);
-    ///         ptr::copy_nonoverlapping(&t, y, 1);
+    ///         ptr::copy_nonoverlapping(&mut t, &*x, 1);
+    ///         ptr::copy_nonoverlapping(x, &*y, 1);
+    ///         ptr::copy_nonoverlapping(y, &t, 1);
     ///
     ///         // y and t now point to the same thing, but we need to completely forget `tmp`
     ///         // because it's no longer relevant.
@@ -303,12 +303,6 @@ extern "rust-intrinsic" {
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[cfg(not(stage0))]
-    pub fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
-
-    /// dox
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[cfg(stage0)]
     pub fn copy_nonoverlapping<T>(dst: *mut T, src: *const T, count: usize);
 
     /// Copies `count * size_of<T>` bytes from `src` to `dst`. The source
@@ -334,18 +328,12 @@ extern "rust-intrinsic" {
     /// unsafe fn from_buf_raw<T>(ptr: *const T, elts: usize) -> Vec<T> {
     ///     let mut dst = Vec::with_capacity(elts);
     ///     dst.set_len(elts);
-    ///     ptr::copy(ptr, dst.as_mut_ptr(), elts);
+    ///     ptr::copy(dst.as_mut_ptr(), ptr, elts);
     ///     dst
     /// }
     /// ```
     ///
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[cfg(not(stage0))]
-    pub fn copy<T>(src: *const T, dst: *mut T, count: usize);
-
-    /// dox
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[cfg(stage0)]
     pub fn copy<T>(dst: *mut T, src: *const T, count: usize);
 
     /// Invokes memset on the specified pointer, setting `count * size_of::<T>()`

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -224,9 +224,9 @@ pub fn swap<T>(x: &mut T, y: &mut T) {
         let mut t: T = uninitialized();
 
         // Perform the swap, `&mut` pointers never alias
-        ptr::copy_nonoverlapping(&*x, &mut t, 1);
-        ptr::copy_nonoverlapping(&*y, x, 1);
-        ptr::copy_nonoverlapping(&t, y, 1);
+        ptr::copy_nonoverlapping(&mut t, &*x, 1);
+        ptr::copy_nonoverlapping(x, &*y, 1);
+        ptr::copy_nonoverlapping(y, &t, 1);
 
         // y and t now point to the same thing, but we need to completely forget `t`
         // because it's no longer relevant.

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -104,27 +104,10 @@ use cmp::Ordering::{self, Less, Equal, Greater};
 // FIXME #19649: intrinsic docs don't render, so these have no docs :(
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg(not(stage0))]
 pub use intrinsics::copy_nonoverlapping;
 
-/// dox
-#[cfg(stage0)]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
-    intrinsics::copy_nonoverlapping(dst, src, count)
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-#[cfg(not(stage0))]
 pub use intrinsics::copy;
-
-/// dox
-#[cfg(stage0)]
-#[stable(feature = "rust1", since = "1.0.0")]
-pub unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
-    intrinsics::copy(dst, src, count)
-}
-
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use intrinsics::write_bytes;
@@ -169,11 +152,12 @@ pub fn null_mut<T>() -> *mut T { 0 as *mut T }
 pub unsafe fn swap<T>(x: *mut T, y: *mut T) {
     // Give ourselves some scratch space to work with
     let mut tmp: T = mem::uninitialized();
+    let t: *mut T = &mut tmp;
 
     // Perform the swap
-    copy_nonoverlapping(x, &mut tmp, 1);
-    copy(y, x, 1); // `x` and `y` may overlap
-    copy_nonoverlapping(&tmp, y, 1);
+    copy_nonoverlapping(t, &*x, 1);
+    copy(x, &*y, 1); // `x` and `y` may overlap
+    copy_nonoverlapping(y, &*t, 1);
 
     // y and t now point to the same thing, but we need to completely forget `tmp`
     // because it's no longer relevant.
@@ -209,7 +193,7 @@ pub unsafe fn replace<T>(dest: *mut T, mut src: T) -> T {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn read<T>(src: *const T) -> T {
     let mut tmp: T = mem::uninitialized();
-    copy_nonoverlapping(src, &mut tmp, 1);
+    copy_nonoverlapping(&mut tmp, src, 1);
     tmp
 }
 

--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -1521,14 +1521,14 @@ pub mod bytes {
     ///
     /// Panics if the length of `dst` is less than the length of `src`.
     #[inline]
-    pub fn copy_memory(src: &[u8], dst: &mut [u8]) {
+    pub fn copy_memory(dst: &mut [u8], src: &[u8]) {
         let len_src = src.len();
         assert!(dst.len() >= len_src);
         // `dst` is unaliasable, so we know statically it doesn't overlap
         // with `src`.
         unsafe {
-            ptr::copy_nonoverlapping(src.as_ptr(),
-                                     dst.as_mut_ptr(),
+            ptr::copy_nonoverlapping(dst.as_mut_ptr(),
+                                     src.as_ptr(),
                                      len_src);
         }
     }

--- a/src/libcoretest/ptr.rs
+++ b/src/libcoretest/ptr.rs
@@ -35,15 +35,18 @@ fn test() {
         let v0 = vec![32000u16, 32001u16, 32002u16];
         let mut v1 = vec![0u16, 0u16, 0u16];
 
-        copy(v0.as_ptr().offset(1), v1.as_mut_ptr().offset(1), 1);
+        copy(v1.as_mut_ptr().offset(1),
+             v0.as_ptr().offset(1), 1);
         assert!((v1[0] == 0u16 &&
                  v1[1] == 32001u16 &&
                  v1[2] == 0u16));
-        copy(v0.as_ptr().offset(2), v1.as_mut_ptr(), 1);
+        copy(v1.as_mut_ptr(),
+             v0.as_ptr().offset(2), 1);
         assert!((v1[0] == 32002u16 &&
                  v1[1] == 32001u16 &&
                  v1[2] == 0u16));
-        copy(v0.as_ptr(), v1.as_mut_ptr().offset(2), 1);
+        copy(v1.as_mut_ptr().offset(2),
+             v0.as_ptr(), 1);
         assert!((v1[0] == 32002u16 &&
                  v1[1] == 32001u16 &&
                  v1[2] == 32000u16));

--- a/src/librbml/lib.rs
+++ b/src/librbml/lib.rs
@@ -447,21 +447,21 @@ pub mod reader {
     pub fn doc_as_u16(d: Doc) -> u16 {
         assert_eq!(d.end, d.start + 2);
         let mut b = [0; 2];
-        bytes::copy_memory(&d.data[d.start..d.end], &mut b);
+        bytes::copy_memory(&mut b, &d.data[d.start..d.end]);
         unsafe { (*(b.as_ptr() as *const u16)).to_be() }
     }
 
     pub fn doc_as_u32(d: Doc) -> u32 {
         assert_eq!(d.end, d.start + 4);
         let mut b = [0; 4];
-        bytes::copy_memory(&d.data[d.start..d.end], &mut b);
+        bytes::copy_memory(&mut b, &d.data[d.start..d.end]);
         unsafe { (*(b.as_ptr() as *const u32)).to_be() }
     }
 
     pub fn doc_as_u64(d: Doc) -> u64 {
         assert_eq!(d.end, d.start + 8);
         let mut b = [0; 8];
-        bytes::copy_memory(&d.data[d.start..d.end], &mut b);
+        bytes::copy_memory(&mut b, &d.data[d.start..d.end]);
         unsafe { (*(b.as_ptr() as *const u64)).to_be() }
     }
 
@@ -935,7 +935,7 @@ pub mod writer {
                 {
                     let last_size_pos = last_size_pos as usize;
                     let data = &self.writer.get_ref()[last_size_pos+4..cur_pos as usize];
-                    bytes::copy_memory(data, &mut buf);
+                    bytes::copy_memory(&mut buf, data);
                 }
 
                 // overwrite the size and data and continue

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -62,7 +62,7 @@ pub type Cmd<'a> = &'a crate_metadata;
 
 fn u32_from_be_bytes(bytes: &[u8]) -> u32 {
     let mut b = [0; 4];
-    bytes::copy_memory(&bytes[..4], &mut b);
+    bytes::copy_memory(&mut b, &bytes[..4]);
     unsafe { (*(b.as_ptr() as *const u32)).to_be() }
 }
 

--- a/src/librustc_back/sha2.rs
+++ b/src/librustc_back/sha2.rs
@@ -139,15 +139,15 @@ impl FixedBuffer for FixedBuffer64 {
             let buffer_remaining = size - self.buffer_idx;
             if input.len() >= buffer_remaining {
                     copy_memory(
-                        &input[..buffer_remaining],
-                        &mut self.buffer[self.buffer_idx..size]);
+                        &mut self.buffer[self.buffer_idx..size],
+                        &input[..buffer_remaining]);
                 self.buffer_idx = 0;
                 func(&self.buffer);
                 i += buffer_remaining;
             } else {
                 copy_memory(
-                    input,
-                    &mut self.buffer[self.buffer_idx..self.buffer_idx + input.len()]);
+                    &mut self.buffer[self.buffer_idx..self.buffer_idx + input.len()],
+                    input);
                 self.buffer_idx += input.len();
                 return;
             }
@@ -165,8 +165,8 @@ impl FixedBuffer for FixedBuffer64 {
         // be empty.
         let input_remaining = input.len() - i;
         copy_memory(
-            &input[i..],
-            &mut self.buffer[..input_remaining]);
+            &mut self.buffer[..input_remaining],
+            &input[i..]);
         self.buffer_idx += input_remaining;
     }
 

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -398,8 +398,8 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                            false,
                            false,
                            *substs.types.get(FnSpace, 0),
-                           llargs[1],
                            llargs[0],
+                           llargs[1],
                            llargs[2],
                            call_debug_location)
         }
@@ -408,8 +408,8 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                            true,
                            false,
                            *substs.types.get(FnSpace, 0),
-                           llargs[1],
                            llargs[0],
+                           llargs[1],
                            llargs[2],
                            call_debug_location)
         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5043,21 +5043,7 @@ pub fn check_intrinsic_type(ccx: &CrateCtxt, it: &ast::ForeignItem) {
                    mutbl: ast::MutImmutable
                }))
             }
-            "copy" | "copy_nonoverlapping" => {
-              (1,
-               vec!(
-                  ty::mk_ptr(tcx, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::MutImmutable
-                  }),
-                  ty::mk_ptr(tcx, ty::mt {
-                      ty: param(ccx, 0),
-                      mutbl: ast::MutMutable
-                  }),
-                  tcx.types.usize,
-               ),
-               ty::mk_nil(tcx))
-            }
+            "copy" | "copy_nonoverlapping" |
             "volatile_copy_memory" | "volatile_copy_nonoverlapping_memory" => {
               (1,
                vec!(

--- a/src/libstd/collections/hash/table.rs
+++ b/src/libstd/collections/hash/table.rs
@@ -486,8 +486,8 @@ impl<K, V, M: Deref<Target=RawTable<K, V>>> GapThenFull<K, V, M> {
     pub fn shift(mut self) -> Option<GapThenFull<K, V, M>> {
         unsafe {
             *self.gap.raw.hash = mem::replace(&mut *self.full.raw.hash, EMPTY_BUCKET);
-            ptr::copy_nonoverlapping(self.full.raw.key, self.gap.raw.key, 1);
-            ptr::copy_nonoverlapping(self.full.raw.val, self.gap.raw.val, 1);
+            ptr::copy_nonoverlapping(self.gap.raw.key, self.full.raw.key, 1);
+            ptr::copy_nonoverlapping(self.gap.raw.val, self.full.raw.val, 1);
         }
 
         let FullBucket { raw: prev_raw, idx: prev_idx, .. } = self.full;

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -177,8 +177,8 @@ impl<W: Write> BufWriter<W> {
         if written > 0 {
             // NB: would be better expressed as .remove(0..n) if it existed
             unsafe {
-                ptr::copy(self.buf.as_ptr().offset(written as isize),
-                          self.buf.as_mut_ptr(),
+                ptr::copy(self.buf.as_mut_ptr(),
+                          self.buf.as_ptr().offset(written as isize),
                           len - written);
             }
         }

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -149,7 +149,7 @@ impl Write for Cursor<Vec<u8>> {
         // there (left), and what will be appended on the end (right)
         let space = self.inner.len() - pos as usize;
         let (left, right) = buf.split_at(cmp::min(space, buf.len()));
-        slice::bytes::copy_memory(left, &mut self.inner[(pos as usize)..]);
+        slice::bytes::copy_memory(&mut self.inner[(pos as usize)..], left);
         self.inner.push_all(right);
 
         // Bump us forward

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -149,7 +149,7 @@ impl<'a> Read for &'a [u8] {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let amt = cmp::min(buf.len(), self.len());
         let (a, b) = self.split_at(amt);
-        slice::bytes::copy_memory(a, buf);
+        slice::bytes::copy_memory(buf, a);
         *self = b;
         Ok(amt)
     }
@@ -170,7 +170,7 @@ impl<'a> Write for &'a mut [u8] {
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
         let amt = cmp::min(data.len(), self.len());
         let (a, b) = mem::replace(self, &mut []).split_at_mut(amt);
-        slice::bytes::copy_memory(&data[..amt], a);
+        slice::bytes::copy_memory(a, &data[..amt]);
         *self = b;
         Ok(amt)
     }

--- a/src/libstd/old_io/buffered.rs
+++ b/src/libstd/old_io/buffered.rs
@@ -118,7 +118,7 @@ impl<R: Reader> Reader for BufferedReader<R> {
         let nread = {
             let available = try!(self.fill_buf());
             let nread = cmp::min(available.len(), buf.len());
-            slice::bytes::copy_memory(&available[..nread], buf);
+            slice::bytes::copy_memory(buf, &available[..nread]);
             nread
         };
         self.pos += nread;
@@ -225,7 +225,7 @@ impl<W: Writer> Writer for BufferedWriter<W> {
             self.inner.as_mut().unwrap().write_all(buf)
         } else {
             let dst = &mut self.buf[self.pos..];
-            slice::bytes::copy_memory(buf, dst);
+            slice::bytes::copy_memory(dst, buf);
             self.pos += buf.len();
             Ok(())
         }

--- a/src/libstd/old_io/comm_adapters.rs
+++ b/src/libstd/old_io/comm_adapters.rs
@@ -91,7 +91,7 @@ impl Reader for ChanReader {
                 Some(src) => {
                     let dst = &mut buf[num_read..];
                     let count = cmp::min(src.len(), dst.len());
-                    bytes::copy_memory(&src[..count], dst);
+                    bytes::copy_memory(dst, &src[..count]);
                     count
                 },
                 None => 0,

--- a/src/libstd/old_io/extensions.rs
+++ b/src/libstd/old_io/extensions.rs
@@ -171,7 +171,7 @@ pub fn u64_from_be_bytes(data: &[u8], start: usize, size: usize) -> u64 {
     unsafe {
         let ptr = data.as_ptr().offset(start as isize);
         let out = buf.as_mut_ptr();
-        copy_nonoverlapping(ptr, out.offset((8 - size) as isize), size);
+        copy_nonoverlapping(out.offset((8 - size) as isize), ptr, size);
         (*(out as *const u64)).to_be()
     }
 }

--- a/src/libstd/old_io/mem.rs
+++ b/src/libstd/old_io/mem.rs
@@ -168,7 +168,7 @@ impl Reader for MemReader {
             let input = &self.buf[self.pos.. self.pos + write_len];
             let output = &mut buf[..write_len];
             assert_eq!(input.len(), output.len());
-            slice::bytes::copy_memory(input, output);
+            slice::bytes::copy_memory(output, input);
         }
         self.pos += write_len;
         assert!(self.pos <= self.buf.len());
@@ -212,7 +212,7 @@ impl<'a> Reader for &'a [u8] {
         {
             let input = &self[..write_len];
             let output = &mut buf[.. write_len];
-            slice::bytes::copy_memory(input, output);
+            slice::bytes::copy_memory(output, input);
         }
 
         *self = &self[write_len..];
@@ -287,13 +287,13 @@ impl<'a> Writer for BufWriter<'a> {
         let src_len = src.len();
 
         if dst_len >= src_len {
-            slice::bytes::copy_memory(src, dst);
+            slice::bytes::copy_memory(dst, src);
 
             self.pos += src_len;
 
             Ok(())
         } else {
-            slice::bytes::copy_memory(&src[..dst_len], dst);
+            slice::bytes::copy_memory(dst, &src[..dst_len]);
 
             self.pos += dst_len;
 
@@ -360,7 +360,7 @@ impl<'a> Reader for BufReader<'a> {
             let input = &self.buf[self.pos.. self.pos + write_len];
             let output = &mut buf[..write_len];
             assert_eq!(input.len(), output.len());
-            slice::bytes::copy_memory(input, output);
+            slice::bytes::copy_memory(output, input);
         }
         self.pos += write_len;
         assert!(self.pos <= self.buf.len());

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -345,8 +345,8 @@ impl Wtf8Buf {
                 Some((surrogate_pos, _)) => {
                     pos = surrogate_pos + 3;
                     slice::bytes::copy_memory(
-                        UTF8_REPLACEMENT_CHARACTER,
                         &mut self.bytes[surrogate_pos .. pos],
+                        UTF8_REPLACEMENT_CHARACTER
                     );
                 },
                 None => return unsafe { String::from_utf8_unchecked(self.bytes) }

--- a/src/test/bench/shootout-fasta-redux.rs
+++ b/src/test/bench/shootout-fasta-redux.rs
@@ -126,9 +126,10 @@ impl<'a, W: Writer> RepeatFasta<'a, W> {
         let mut buf = repeat(0).take(alu_len + LINE_LEN).collect::<Vec<_>>();
         let alu: &[u8] = self.alu.as_bytes();
 
-        copy_memory(alu, &mut buf);
+        copy_memory(&mut buf, alu);
         let buf_len = buf.len();
-        copy_memory(&alu[..LINE_LEN], &mut buf[alu_len..buf_len]);
+        copy_memory(&mut buf[alu_len..buf_len],
+                    &alu[..LINE_LEN]);
 
         let mut pos = 0;
         let mut bytes;

--- a/src/test/bench/shootout-reverse-complement.rs
+++ b/src/test/bench/shootout-reverse-complement.rs
@@ -181,8 +181,8 @@ fn reverse_complement(seq: &mut [u8], tables: &Tables) {
     let mut i = LINE_LEN;
     while i < len {
         unsafe {
-            copy(seq.as_ptr().offset((i - off) as isize),
-                 seq.as_mut_ptr().offset((i - off + 1) as isize), off);
+            copy(seq.as_mut_ptr().offset((i - off + 1) as isize),
+                 seq.as_ptr().offset((i - off) as isize), off);
             *seq.get_unchecked_mut(i - off) = b'\n';
         }
         i += LINE_LEN + 1;

--- a/src/test/run-pass/method-mut-self-modifies-mut-slice-lvalue.rs
+++ b/src/test/run-pass/method-mut-self-modifies-mut-slice-lvalue.rs
@@ -26,7 +26,7 @@ trait MyWriter {
 
 impl<'a> MyWriter for &'a mut [u8] {
     fn my_write(&mut self, buf: &[u8]) -> IoResult<()> {
-        slice::bytes::copy_memory(buf, *self);
+        slice::bytes::copy_memory(*self, buf);
 
         let write_len = buf.len();
         unsafe {


### PR DESCRIPTION
I don't know if I agree that this needed an RFC, but this was definitely the wrong call IMHO. I think it's bad enough that it should be a beta-period breaking change.

This reverts commit acd48a2b3e7fcc0372f7718a2fac1cf80e03db95.

r? @aturon
