### PR TITLE
Improves handling of statement macros.

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -772,20 +772,17 @@ fn expand_stmt(stmt: P<Stmt>, fld: &mut MacroExpander) -> SmallVector<P<Stmt>> {
     // If this is a macro invocation with a semicolon, then apply that
     // semicolon to the final statement produced by expansion.
     if style == MacStmtWithSemicolon {
-        match fully_expanded.pop() {
-            Some(stmt) => {
-                let new_stmt = stmt.map(|Spanned {node, span}| {
-                    Spanned {
-                        node: match node {
-                            StmtExpr(e, stmt_id) => StmtSemi(e, stmt_id),
-                            _ => node /* might already have a semi */
-                        },
-                        span: span
-                    }
-                });
-                fully_expanded.push(new_stmt);
-            }
-            None => (),
+        if let Some(stmt) = fully_expanded.pop() {
+            let new_stmt = stmt.map(|Spanned {node, span}| {
+                Spanned {
+                    node: match node {
+                        StmtExpr(e, stmt_id) => StmtSemi(e, stmt_id),
+                        _ => node /* might already have a semi */
+                    },
+                    span: span
+                }
+            });
+            fully_expanded.push(new_stmt);
         }
     }
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -745,34 +745,49 @@ pub fn expand_item_mac(it: P<ast::Item>,
 }
 
 /// Expand a stmt
-fn expand_stmt(s: Stmt, fld: &mut MacroExpander) -> SmallVector<P<Stmt>> {
-    let (mac, style) = match s.node {
+fn expand_stmt(stmt: P<Stmt>, fld: &mut MacroExpander) -> SmallVector<P<Stmt>> {
+    let stmt = stmt.and_then(|stmt| stmt);
+    let (mac, style) = match stmt.node {
         StmtMac(mac, style) => (mac, style),
-        _ => return expand_non_macro_stmt(s, fld)
+        _ => return expand_non_macro_stmt(stmt, fld)
     };
-    let expanded_stmt = match expand_mac_invoc(mac.and_then(|m| m), s.span,
-                                                |r| r.make_stmt(),
-                                                mark_stmt, fld) {
-        Some(stmt) => stmt,
-        None => {
-            return SmallVector::zero();
+
+    let maybe_new_items =
+        expand_mac_invoc(mac.and_then(|m| m), stmt.span,
+                         |r| r.make_stmts(),
+                         |stmts, mark| stmts.move_map(|m| mark_stmt(m, mark)),
+                         fld);
+
+    let fully_expanded = match maybe_new_items {
+        Some(stmts) => {
+            // Keep going, outside-in.
+            let new_items = stmts.into_iter().flat_map(|s| {
+                fld.fold_stmt(s).into_iter()
+            }).collect();
+            fld.cx.bt_pop();
+            new_items
         }
+        None => SmallVector::zero()
     };
 
-    // Keep going, outside-in.
-    let fully_expanded = fld.fold_stmt(expanded_stmt);
-    fld.cx.bt_pop();
-
-    if style == MacStmtWithSemicolon {
-        fully_expanded.into_iter().map(|s| s.map(|Spanned {node, span}| {
-            Spanned {
-                node: match node {
-                    StmtExpr(e, stmt_id) => StmtSemi(e, stmt_id),
-                    _ => node /* might already have a semi */
-                },
-                span: span
-            }
-        })).collect()
+    // If this is a macro invocation with a semicolon, then apply that
+    // semicolon to the final statement produced by expansion.
+    if style == MacStmtWithSemicolon && fully_expanded.len() > 0 {
+        let last_index = fully_expanded.len() - 1;
+        fully_expanded.into_iter().enumerate().map(|(i, stmt)|
+            if i == last_index {
+                stmt.map(|Spanned {node, span}| {
+                    Spanned {
+                        node: match node {
+                            StmtExpr(e, stmt_id) => StmtSemi(e, stmt_id),
+                            _ => node /* might already have a semi */
+                        },
+                        span: span
+                    }
+                })
+            } else {
+                stmt
+            }).collect()
     } else {
         fully_expanded
     }
@@ -1389,7 +1404,7 @@ impl<'a, 'b> Folder for MacroExpander<'a, 'b> {
     }
 
     fn fold_stmt(&mut self, stmt: P<ast::Stmt>) -> SmallVector<P<ast::Stmt>> {
-        stmt.and_then(|stmt| expand_stmt(stmt, self))
+        expand_stmt(stmt, self)
     }
 
     fn fold_block(&mut self, block: P<Block>) -> P<Block> {
@@ -1541,8 +1556,8 @@ fn mark_pat(pat: P<ast::Pat>, m: Mrk) -> P<ast::Pat> {
 }
 
 // apply a given mark to the given stmt. Used following the expansion of a macro.
-fn mark_stmt(expr: P<ast::Stmt>, m: Mrk) -> P<ast::Stmt> {
-    Marker{mark:m}.fold_stmt(expr)
+fn mark_stmt(stmt: P<ast::Stmt>, m: Mrk) -> P<ast::Stmt> {
+    Marker{mark:m}.fold_stmt(stmt)
         .expect_one("marking a stmt didn't return exactly one stmt")
 }
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -761,13 +761,14 @@ fn expand_stmt(stmt: P<Stmt>, fld: &mut MacroExpander) -> SmallVector<P<Stmt>> {
     let mut fully_expanded = match maybe_new_items {
         Some(stmts) => {
             // Keep going, outside-in.
-            stmts.into_iter().flat_map(|s| {
+            let new_items = stmts.into_iter().flat_map(|s| {
                 fld.fold_stmt(s).into_iter()
-            }).collect()
+            }).collect();
+            fld.cx.bt_pop();
+            new_items
         }
         None => SmallVector::zero()
     };
-    fld.cx.bt_pop();
 
     // If this is a macro invocation with a semicolon, then apply that
     // semicolon to the final statement produced by expansion.

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -771,7 +771,7 @@ fn expand_stmt(stmt: P<Stmt>, fld: &mut MacroExpander) -> SmallVector<P<Stmt>> {
 
     // If this is a macro invocation with a semicolon, then apply that
     // semicolon to the final statement produced by expansion.
-    if style == MacStmtWithSemicolon && !fully_expanded.is_empty() {
+    if style == MacStmtWithSemicolon {
         match fully_expanded.pop() {
             Some(stmt) => {
                 let new_stmt = stmt.map(|Spanned {node, span}| {

--- a/src/libsyntax/util/small_vector.rs
+++ b/src/libsyntax/util/small_vector.rs
@@ -79,29 +79,7 @@ impl<T> SmallVector<T> {
                     _ => unreachable!()
                 }
             }
-            Many(..) => {
-                let mut many = mem::replace(&mut self.repr, Zero);
-                let item =
-                    match many {
-                        Many(ref mut vs) if vs.len() == 1 => {
-                            // self.repr is already Zero
-                            vs.pop()
-                        },
-                        Many(ref mut vs) if vs.len() == 2 => {
-                            let item = vs.pop();
-                            mem::replace(&mut self.repr, One(vs.pop().unwrap()));
-                            item
-                        },
-                        Many(ref mut vs) if vs.len() > 2 => {
-                            let item = vs.pop();
-                            let rest = mem::replace(vs, vec!());
-                            mem::replace(&mut self.repr, Many(rest));
-                            item
-                        },
-                        _ => unreachable!()
-                    };
-                item
-            }
+            Many(ref mut vs) => vs.pop(),
         }
     }
 

--- a/src/libsyntax/util/small_vector.rs
+++ b/src/libsyntax/util/small_vector.rs
@@ -69,6 +69,42 @@ impl<T> SmallVector<T> {
         }
     }
 
+    pub fn pop(&mut self) -> Option<T> {
+        match self.repr {
+            Zero => None,
+            One(..) => {
+                let one = mem::replace(&mut self.repr, Zero);
+                match one {
+                    One(v1) => Some(v1),
+                    _ => unreachable!()
+                }
+            }
+            Many(..) => {
+                let mut many = mem::replace(&mut self.repr, Zero);
+                let item =
+                    match many {
+                        Many(ref mut vs) if vs.len() == 1 => {
+                            // self.repr is already Zero
+                            vs.pop()
+                        },
+                        Many(ref mut vs) if vs.len() == 2 => {
+                            let item = vs.pop();
+                            mem::replace(&mut self.repr, One(vs.pop().unwrap()));
+                            item
+                        },
+                        Many(ref mut vs) if vs.len() > 2 => {
+                            let item = vs.pop();
+                            let rest = mem::replace(vs, vec!());
+                            mem::replace(&mut self.repr, Many(rest));
+                            item
+                        },
+                        _ => unreachable!()
+                    };
+                item
+            }
+        }
+    }
+
     pub fn push(&mut self, v: T) {
         match self.repr {
             Zero => self.repr = One(v),

--- a/src/test/compile-fail/macro-incomplete-parse.rs
+++ b/src/test/compile-fail/macro-incomplete-parse.rs
@@ -17,7 +17,8 @@ macro_rules! ignored_item {
 }
 
 macro_rules! ignored_expr {
-    () => ( 1, 2 ) //~ ERROR macro expansion ignores token `,`
+    () => ( 1,  //~ ERROR unexpected token: `,`
+            2 ) //~ ERROR macro expansion ignores token `2`
 }
 
 macro_rules! ignored_pat {

--- a/src/test/run-pass/macro-nested_stmt_macros.rs
+++ b/src/test/run-pass/macro-nested_stmt_macros.rs
@@ -1,0 +1,32 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! foo {
+    () => {
+        struct Bar;
+        struct Baz;
+    }
+}
+
+macro_rules! grault {
+    () => {
+        foo!();
+        struct Xyzzy;
+    }
+}
+
+fn static_assert_exists<T>() { }
+
+fn main() {
+    grault!();
+    static_assert_exists::<Bar>();
+    static_assert_exists::<Baz>();
+    static_assert_exists::<Xyzzy>();
+}

--- a/src/test/run-pass/macro-stmt_macro_in_expr_macro.rs
+++ b/src/test/run-pass/macro-stmt_macro_in_expr_macro.rs
@@ -1,0 +1,29 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! foo {
+    () => {
+        struct Bar;
+        struct Baz;
+    }
+}
+
+macro_rules! grault {
+    () => {{
+        foo!();
+        struct Xyzzy;
+        0
+    }}
+}
+
+fn main() {
+    let x = grault!();
+    assert_eq!(x, 0);
+}


### PR DESCRIPTION
Statement macros are now treated somewhat like item macros, in that a statement macro can now expand into a series of statements, rather than just a single statement.

This allows statement macros to be nested inside other kinds of macros and expand properly, where previously the expansion would only work when no nesting was present.

See:
- `src/test/run-pass/macro-stmt_macro_in_expr_macro.rs`
- `src/test/run-pass/macro-nested_stmt_macro.rs`

This changes the interface of the MacResult trait.  make_stmt has become make_stmts and now returns a vector, rather than a single item.  Plugin writers who were implementing MacResult will have breakage, as well as anyone using MacEager::stmt.

See:
- `src/libsyntax/ext/base.rs`

This also causes a minor difference in behavior to the diagnostics produced by certain malformed macros.

See:
- `src/test/compile-fail/macro-incomplete-parse.rs`
