### PR TITLE
Add Clone impls for extern "C" and unsafe fns

### DIFF
--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -97,6 +97,27 @@ macro_rules! extern_fn_clone {
             #[inline]
             fn clone(&self) -> extern "Rust" fn($($A),*) -> ReturnType { *self }
         }
+
+        #[unstable(feature = "core", reason = "brand new")]
+        impl<$($A,)* ReturnType> Clone for extern "C" fn($($A),*) -> ReturnType {
+            /// Return a copy of a function pointer
+            #[inline]
+            fn clone(&self) -> extern "C" fn($($A),*) -> ReturnType { *self }
+        }
+
+        #[unstable(feature = "core", reason = "brand new")]
+        impl<$($A,)* ReturnType> Clone for unsafe extern "Rust" fn($($A),*) -> ReturnType {
+            /// Return a copy of a function pointer
+            #[inline]
+            fn clone(&self) -> unsafe extern "Rust" fn($($A),*) -> ReturnType { *self }
+        }
+
+        #[unstable(feature = "core", reason = "brand new")]
+        impl<$($A,)* ReturnType> Clone for unsafe extern "C" fn($($A),*) -> ReturnType {
+            /// Return a copy of a function pointer
+            #[inline]
+            fn clone(&self) -> unsafe extern "C" fn($($A),*) -> ReturnType { *self }
+        }
     )
 }
 

--- a/src/test/run-pass/issue-24161.rs
+++ b/src/test/run-pass/issue-24161.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[derive(Copy,Clone)]
+struct Functions {
+    a: fn(u32) -> u32,
+    b: extern "C" fn(u32) -> u32,
+    c: unsafe fn(u32) -> u32,
+    d: unsafe extern "C" fn(u32) -> u32
+}
+
+pub fn main() {}


### PR DESCRIPTION
We only implemented Clone on `extern "Rust" fn`s (for up to 8
parameters). This didn't cover `extern "C"` or `unsafe` (or
`unsafe extern "C"`) `fn`s, but there's no reason why they shouldn't be
cloneable as well.

The new impls are marked unstable because the existing impl for `extern
"Rust" fn`s is.

Fixes #24161.
