### PR TITLE
rustup: let RUSTUP_PREFIX env override default.

### DIFF
--- a/src/etc/rustup.sh
+++ b/src/etc/rustup.sh
@@ -286,7 +286,7 @@ BOOL_OPTIONS=""
 VAL_OPTIONS=""
 
 flag uninstall "only uninstall from the installation prefix"
-valopt prefix "" "set installation prefix"
+valopt prefix "${RUSTUP_PREFIX}" "set installation prefix"
 valopt date "" "use the YYYY-MM-DD nightly instead of the current nightly"
 valopt channel "beta" "use the selected release channel [beta]"
 flag save "save the downloaded nightlies to ~/.rustup"


### PR DESCRIPTION
The idea here is if you don't want rust in /usr/local
you can put something like this is your .profile:

```
export RUSTUP_PREFIX=$HOME/.local/rust
export PATH=$PATH:${RUSTUP_PREFIX}/bin
export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:${RUSTUP_PREFIX}/lib
```

Then when you run rustup, it will update the install
in ${RUSTUP_PREFIX} without having to remember to pass
an explicit --prefix argument every time.
