### PR TITLE
Replace slice methods tail(), init() with pop_first(), pop_last()

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -89,8 +89,7 @@ pub fn parse_config(args: Vec<String> ) -> Config {
           optflag("h", "help", "show this message"));
 
     assert!(!args.is_empty());
-    let argv0 = args[0].clone();
-    let args_ = args.tail();
+    let (argv0, args_) = args.pop_first().unwrap();
     if args[1] == "-h" || args[1] == "--help" {
         let message = format!("Usage: {} [OPTIONS] [TESTNAME...]", argv0);
         println!("{}", getopts::usage(&message, &groups));

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -460,20 +460,6 @@ impl<T> [T] {
         core_slice::SliceExt::first(self)
     }
 
-    /// Returns all but the first element of a slice.
-    #[unstable(feature = "collections", reason = "likely to be renamed")]
-    #[inline]
-    pub fn tail(&self) -> &[T] {
-        core_slice::SliceExt::tail(self)
-    }
-
-    /// Returns all but the last element of a slice.
-    #[unstable(feature = "collections", reason = "likely to be renamed")]
-    #[inline]
-    pub fn init(&self) -> &[T] {
-        core_slice::SliceExt::init(self)
-    }
-
     /// Returns the last element of a slice, or `None` if it is empty.
     ///
     /// # Examples
@@ -489,6 +475,42 @@ impl<T> [T] {
     #[inline]
     pub fn last(&self) -> Option<&T> {
         core_slice::SliceExt::last(self)
+    }
+
+    /// Removes the first element of the slice and returns it, along with the
+    /// remainder, or `None` if the slice is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let v = [10, 40, 30];
+    /// assert!(v.pop_first() == Some((&10, &[40, 30])));
+    ///
+    /// let w: &[i32] = &[];
+    /// assert!(w.pop_first() == None);
+    /// ```
+    #[unstable(feature = "collections", reason = "brand new")]
+    #[inline]
+    pub fn pop_first(&self) -> Option<(&T, &[T])> {
+        core_slice::SliceExt::pop_first(self)
+    }
+
+    /// Removes the last element of the slice and returns it, along with the
+    /// remainder, or `None` if the slice is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let v = [10, 40, 30];
+    /// assert!(v.pop_last() == Some((&30, &[10, 40])));
+    ///
+    /// let w: &[i32] = &[];
+    /// assert!(w.pop_last() == None);
+    /// ```
+    #[unstable(feature = "collections", reason = "brand new")]
+    #[inline]
+    pub fn pop_last(&self) -> Option<(&T, &[T])> {
+        core_slice::SliceExt::pop_last(self)
     }
 
     /// Returns a pointer to the element at the given index, without doing
@@ -600,27 +622,27 @@ impl<T> [T] {
         core_slice::SliceExt::first_mut(self)
     }
 
-    /// Returns all but the first element of a mutable slice
-    #[unstable(feature = "collections",
-               reason = "likely to be renamed or removed")]
-    #[inline]
-    pub fn tail_mut(&mut self) -> &mut [T] {
-        core_slice::SliceExt::tail_mut(self)
-    }
-
-    /// Returns all but the last element of a mutable slice
-    #[unstable(feature = "collections",
-               reason = "likely to be renamed or removed")]
-    #[inline]
-    pub fn init_mut(&mut self) -> &mut [T] {
-        core_slice::SliceExt::init_mut(self)
-    }
-
     /// Returns a mutable pointer to the last item in the slice.
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn last_mut(&mut self) -> Option<&mut T> {
         core_slice::SliceExt::last_mut(self)
+    }
+
+    /// Removes the first element from a mutable slice and returns it, along
+    /// with the remainder of the slice.
+    #[unstable(feature = "collections", reason = "brand new")]
+    #[inline]
+    pub fn pop_first_mut(&mut self) -> Option<(&mut T, &mut [T])> {
+        core_slice::SliceExt::pop_first_mut(self)
+    }
+
+    /// Removes the last element from a mutable slice and returns it, along
+    /// with the remainder of the slice.
+    #[unstable(feature = "collections", reason = "brand new")]
+    #[inline]
+    pub fn pop_last_mut(&mut self) -> Option<(&mut T, &mut [T])> {
+        core_slice::SliceExt::pop_last_mut(self)
     }
 
     /// Returns an iterator over mutable subslices separated by elements that

--- a/src/libcollectionstest/slice.rs
+++ b/src/libcollectionstest/slice.rs
@@ -119,74 +119,6 @@ fn test_first_mut() {
 }
 
 #[test]
-fn test_tail() {
-    let mut a = vec![11];
-    let b: &[i32] = &[];
-    assert_eq!(a.tail(), b);
-    a = vec![11, 12];
-    let b: &[i32] = &[12];
-    assert_eq!(a.tail(), b);
-}
-
-#[test]
-fn test_tail_mut() {
-    let mut a = vec![11];
-    let b: &mut [i32] = &mut [];
-    assert!(a.tail_mut() == b);
-    a = vec![11, 12];
-    let b: &mut [_] = &mut [12];
-    assert!(a.tail_mut() == b);
-}
-
-#[test]
-#[should_panic]
-fn test_tail_empty() {
-    let a = Vec::<i32>::new();
-    a.tail();
-}
-
-#[test]
-#[should_panic]
-fn test_tail_mut_empty() {
-    let mut a = Vec::<i32>::new();
-    a.tail_mut();
-}
-
-#[test]
-fn test_init() {
-    let mut a = vec![11];
-    let b: &[i32] = &[];
-    assert_eq!(a.init(), b);
-    a = vec![11, 12];
-    let b: &[_] = &[11];
-    assert_eq!(a.init(), b);
-}
-
-#[test]
-fn test_init_mut() {
-    let mut a = vec![11];
-    let b: &mut [i32] = &mut [];
-    assert!(a.init_mut() == b);
-    a = vec![11, 12];
-    let b: &mut [_] = &mut [11];
-    assert!(a.init_mut() == b);
-}
-
-#[test]
-#[should_panic]
-fn test_init_empty() {
-    let a = Vec::<i32>::new();
-    a.init();
-}
-
-#[test]
-#[should_panic]
-fn test_init_mut_empty() {
-    let mut a = Vec::<i32>::new();
-    a.init_mut();
-}
-
-#[test]
 fn test_last() {
     let mut a = vec![];
     assert_eq!(a.last(), None);
@@ -204,6 +136,46 @@ fn test_last_mut() {
     assert_eq!(*a.last_mut().unwrap(), 11);
     a = vec![11, 12];
     assert_eq!(*a.last_mut().unwrap(), 12);
+}
+
+#[test]
+fn test_pop_first() {
+    let a: &[i32] = &[];
+    assert_eq!(a.pop_first(), None);
+    let b: &[i32] = &[11];
+    assert_eq!(b.pop_first(), Some((&11, &[][..])));
+    let c: &[i32] = &[11, 12];
+    assert_eq!(c.pop_first(), Some((&11, &[12][..])));
+}
+
+#[test]
+fn test_pop_first_mut() {
+    let a: &mut [i32] = &mut [];
+    assert_eq!(a.pop_first_mut(), None);
+    let b: &mut [i32] = &mut [11];
+    assert_eq!(b.pop_first_mut(), Some((&mut 11, &mut [][..])));
+    let c: &mut [i32] = &mut [11, 12];
+    assert_eq!(c.pop_first_mut(), Some((&mut 11, &mut [12][..])));
+}
+
+#[test]
+fn test_pop_last() {
+    let a: &[i32] = &[];
+    assert_eq!(a.pop_last(), None);
+    let b: &[i32] = &[11];
+    assert_eq!(b.pop_last(), Some((&11, &[][..])));
+    let c: &[i32] = &[11, 12];
+    assert_eq!(c.pop_last(), Some((&12, &[11][..])));
+}
+
+#[test]
+fn test_pop_last_mut() {
+    let a: &mut [i32] = &mut [];
+    assert_eq!(a.pop_last_mut(), None);
+    let b: &mut [i32] = &mut [11];
+    assert_eq!(b.pop_last_mut(), Some((&mut 11, &mut [][..])));
+    let c: &mut [i32] = &mut [11, 12];
+    assert_eq!(c.pop_last_mut(), Some((&mut 12, &mut [11][..])));
 }
 
 #[test]

--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -707,7 +707,7 @@ pub fn maybe_get_item_ast<'tcx>(cdata: Cmd, tcx: &ty::ctxt<'tcx>, id: ast::NodeI
                                 -> csearch::FoundAst<'tcx> {
     debug!("Looking up item: {}", id);
     let item_doc = lookup_item(id, cdata.data());
-    let path = item_path(item_doc).init().to_vec();
+    let path = item_path(item_doc).pop_last().unwrap().1.to_vec();
     match decode_inlined_item(cdata, tcx, path, item_doc) {
         Ok(ii) => csearch::FoundAst::Found(ii),
         Err(path) => {

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -693,12 +693,12 @@ fn is_useful(cx: &MatchCheckCtxt,
             Some(constructor) => {
                 let matrix = rows.iter().filter_map(|r| {
                     if pat_is_binding_or_wild(&cx.tcx.def_map, raw_pat(r[0])) {
-                        Some(r.tail().to_vec())
+                        Some(r[1..].to_vec())
                     } else {
                         None
                     }
                 }).collect();
-                match is_useful(cx, &matrix, v.tail(), witness) {
+                match is_useful(cx, &matrix, &v[1..], witness) {
                     UsefulWithWitness(pats) => {
                         let arity = constructor_arity(cx, &constructor, left_ty);
                         let wild_pats: Vec<_> = repeat(DUMMY_WILD_PAT).take(arity).collect();

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -1352,7 +1352,7 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
             region_names,
         } = rebuild_info;
 
-        let last_seg = path.segments.last().unwrap();
+        let (last_seg, init_seg) = path.segments.pop_last().unwrap();
         let new_parameters = match last_seg.parameters {
             ast::ParenthesizedParameters(..) => {
                 last_seg.parameters.clone()
@@ -1409,7 +1409,7 @@ impl<'a, 'tcx> Rebuilder<'a, 'tcx> {
             parameters: new_parameters
         };
         let mut new_segs = Vec::new();
-        new_segs.push_all(path.segments.init());
+        new_segs.push_all(init_seg);
         new_segs.push(new_seg);
         ast::Path {
             span: path.span,

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -272,7 +272,7 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                 let module_path = match view_path.node {
                     ViewPathSimple(_, ref full_path) => {
                         full_path.segments
-                            .init()
+                            .pop_last().unwrap().1
                             .iter().map(|ident| ident.identifier.name)
                             .collect()
                     }
@@ -334,8 +334,8 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                                 PathListIdent { name, .. } =>
                                     (module_path.clone(), name.name),
                                 PathListMod { .. } => {
-                                    let name = match module_path.last() {
-                                        Some(name) => *name,
+                                    let (name, module_path) = match module_path.pop_last() {
+                                        Some((name, module_path)) => (*name, module_path),
                                         None => {
                                             self.resolve_error(source_item.span,
                                                 "`self` import can only appear in an import list \
@@ -343,7 +343,6 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
                                             continue;
                                         }
                                     };
-                                    let module_path = module_path.init();
                                     (module_path.to_vec(), name)
                                 }
                             };

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2719,7 +2719,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                     segments: &[ast::PathSegment],
                                     namespace: Namespace)
                                     -> Option<(Def, LastPrivate)> {
-        let module_path = segments.init().iter()
+        let module_path = segments.pop_last().unwrap().1.iter()
                                          .map(|ps| ps.identifier.name)
                                          .collect::<Vec<_>>();
 
@@ -2777,7 +2777,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                    segments: &[ast::PathSegment],
                                    namespace: Namespace)
                                        -> Option<(Def, LastPrivate)> {
-        let module_path = segments.init().iter()
+        let module_path = segments.pop_last().unwrap().1.iter()
                                          .map(|ps| ps.identifier.name)
                                          .collect::<Vec<_>>();
 

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1239,15 +1239,16 @@ pub fn finish_resolving_def_to_ty<'tcx>(this: &AstConv<'tcx>,
             // TyObjectSum, see that fn for details
             let mut projection_bounds = Vec::new();
 
+            let (last_segment, init_segments) = base_segments.pop_last().unwrap();
             let trait_ref = object_path_to_poly_trait_ref(this,
                                                           rscope,
                                                           span,
                                                           param_mode,
                                                           trait_def_id,
-                                                          base_segments.last().unwrap(),
+                                                          last_segment,
                                                           &mut projection_bounds);
 
-            check_path_args(tcx, base_segments.init(), NO_TPS | NO_REGIONS);
+            check_path_args(tcx, init_segments, NO_TPS | NO_REGIONS);
             trait_ref_to_object_type(this,
                                      rscope,
                                      span,
@@ -1256,10 +1257,11 @@ pub fn finish_resolving_def_to_ty<'tcx>(this: &AstConv<'tcx>,
                                      &[])
         }
         def::DefTy(did, _) | def::DefStruct(did) => {
-            check_path_args(tcx, base_segments.init(), NO_TPS | NO_REGIONS);
+            let (last_segment, init_segments) = base_segments.pop_last().unwrap();
+            check_path_args(tcx, init_segments, NO_TPS | NO_REGIONS);
             ast_path_to_ty(this, rscope, span,
                            param_mode, did,
-                           base_segments.last().unwrap())
+                           last_segment)
         }
         def::DefTyParam(space, index, _, name) => {
             check_path_args(tcx, base_segments, NO_TPS | NO_REGIONS);

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3347,7 +3347,7 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                                scheme, &predicates,
                                opt_self_ty, def, expr.span, id);
           } else {
-              let ty_segments = path.segments.init();
+              let (method_segment, ty_segments) = path.segments.pop_last().unwrap();
               let base_ty_end = path.segments.len() - path_res.depth;
               let ty = astconv::finish_resolving_def_to_ty(fcx,
                                                            fcx,
@@ -3357,7 +3357,6 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                                                            opt_self_ty,
                                                            &ty_segments[..base_ty_end],
                                                            &ty_segments[base_ty_end..]);
-              let method_segment = path.segments.last().unwrap();
               let method_name = method_segment.identifier.name;
               match method::resolve_ufcs(fcx, expr.span, method_name, ty, id) {
                   Ok((def, lp)) => {

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -174,8 +174,8 @@ impl<'ccx, 'tcx> CheckTypeWellFormedVisitor<'ccx, 'tcx> {
                 }
 
                 // For DST, all intermediate types must be sized.
-                if variant.fields.len() > 0 {
-                    for field in variant.fields.init() {
+                if let Some((_, init_fields)) = variant.fields.pop_last() {
+                    for field in init_fields {
                         fcx.register_builtin_bound(
                             field.ty,
                             ty::BoundSized,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -192,7 +192,7 @@ pub fn usage(argv0: &str) {
 }
 
 pub fn main_args(args: &[String]) -> isize {
-    let matches = match getopts::getopts(args.tail(), &opts()) {
+    let matches = match getopts::getopts(&args[1..], &opts()) {
         Ok(m) => m,
         Err(err) => {
             println!("{}", err);

--- a/src/librustdoc/passes.rs
+++ b/src/librustdoc/passes.rs
@@ -351,15 +351,16 @@ pub fn unindent(s: &str) -> String {
     });
 
     if lines.len() >= 1 {
-        let mut unindented = vec![ lines[0].trim().to_string() ];
-        unindented.push_all(&lines.tail().iter().map(|&line| {
+        let (first_line, tail_lines) = lines.pop_first().unwrap();
+        let mut unindented = vec![ first_line.trim().to_string() ];
+        unindented.extend(tail_lines.iter().map(|&line| {
             if line.chars().all(|c| c.is_whitespace()) {
                 line.to_string()
             } else {
                 assert!(line.len() >= min_indent);
                 line[min_indent..].to_string()
             }
-        }).collect::<Vec<_>>());
+        }));
         unindented.connect("\n")
     } else {
         s.to_string()

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -1081,7 +1081,7 @@ impl<'a> MethodDef<'a> {
                     subpats.push(p);
                     idents
                 };
-                for self_arg_name in self_arg_names.tail() {
+                for self_arg_name in &self_arg_names[1..] {
                     let (p, idents) = mk_self_pat(cx, &self_arg_name[..]);
                     subpats.push(p);
                     self_pats_idents.push(idents);

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -364,7 +364,7 @@ Test Attributes:
 
 // Parses command line arguments into test options
 pub fn parse_opts(args: &[String]) -> Option<OptRes> {
-    let args_ = args.tail();
+    let args_ = &args[1..];
     let matches =
         match getopts::getopts(args_, &optgroups()) {
           Ok(m) => m,


### PR DESCRIPTION
The `init`/`tail` terminology is not obvious to anyone who hasn't
already seen it in another language like Haskell, and we already got rid
of `head()` (the common pair for `tail()`).

Instead of merely renaming these functions, turn them into separate
functions

```
fn pop_first(&self) -> Option<(&T, &[T])>;
fn pop_last(&self) -> Option<(&T, &[T])>;
```

as these functions are often used in a context where the first/last
element wants to be inspected and it's a bit more ergonomic this way.

Fixes #24141.

[breaking-change]
