### PR TITLE
fmt::Pointer padding

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -861,8 +861,7 @@ impl<T> Pointer for *const T {
                 // The formats need two extra bytes, for the 0x
                 if cfg!(target_pointer_width = "32") {
                     f.width = Some(10);
-                }
-                if cfg!(target_pointer_width = "64") {
+                } else {
                     f.width = Some(18);
                 }
             }

--- a/src/test/run-pass/fmt-pointer-trait.rs
+++ b/src/test/run-pass/fmt-pointer-trait.rs
@@ -23,6 +23,14 @@ fn main() {
     let _ = format!("{:p}{:p}{:p}",
                     rc, arc, b);
 
+    if cfg!(target_pointer_width = "32") {
+        assert_eq!(format!("{:#p}", p),
+                   "0x00000000");
+    }
+    if cfg!(target_pointer_width = "64") {
+        assert_eq!(format!("{:#p}", p),
+                   "0x0000000000000000");
+    }
     assert_eq!(format!("{:p}", p),
                "0x0");
 }

--- a/src/test/run-pass/fmt-pointer-trait.rs
+++ b/src/test/run-pass/fmt-pointer-trait.rs
@@ -26,8 +26,7 @@ fn main() {
     if cfg!(target_pointer_width = "32") {
         assert_eq!(format!("{:#p}", p),
                    "0x00000000");
-    }
-    if cfg!(target_pointer_width = "64") {
+    } else {
         assert_eq!(format!("{:#p}", p),
                    "0x0000000000000000");
     }

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -72,6 +72,14 @@ pub fn main() {
     t!(format!("{:X}", 10_usize), "A");
     t!(format!("{}", "foo"), "foo");
     t!(format!("{}", "foo".to_string()), "foo");
+    if cfg!(target_pointer_width = "32") {
+        t!(format!("{:#p}", 0x1234 as *const isize), "0x00001234");
+        t!(format!("{:#p}", 0x1234 as *mut isize), "0x00001234");
+    }
+    if cfg!(target_pointer_width = "64") {
+        t!(format!("{:#p}", 0x1234 as *const isize), "0x0000000000001234");
+        t!(format!("{:#p}", 0x1234 as *mut isize), "0x0000000000001234");
+    }
     t!(format!("{:p}", 0x1234 as *const isize), "0x1234");
     t!(format!("{:p}", 0x1234 as *mut isize), "0x1234");
     t!(format!("{:x}", A), "aloha");

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -93,9 +93,8 @@ pub fn main() {
     t!(format!("{}", 5 + 5), "10");
     t!(format!("{:#4}", C), "☃123");
 
-    // FIXME(#20676)
-    // let a: &fmt::Debug = &1;
-    // t!(format!("{:?}", a), "1");
+    let a: &fmt::Debug = &1;
+    t!(format!("{:?}", a), "1");
 
 
     // Formatting strings and their arguments

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -75,8 +75,7 @@ pub fn main() {
     if cfg!(target_pointer_width = "32") {
         t!(format!("{:#p}", 0x1234 as *const isize), "0x00001234");
         t!(format!("{:#p}", 0x1234 as *mut isize), "0x00001234");
-    }
-    if cfg!(target_pointer_width = "64") {
+    } else {
         t!(format!("{:#p}", 0x1234 as *const isize), "0x0000000000001234");
         t!(format!("{:#p}", 0x1234 as *mut isize), "0x0000000000001234");
     }


### PR DESCRIPTION
This pads out the printing of pointers to their native width.

Extracted from and rebased on top of #24144
