### PR TITLE
Implement cloned for Option<&mut T>

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -726,6 +726,14 @@ impl<'a, T: Clone> Option<&'a T> {
     }
 }
 
+impl<'a, T: Clone> Option<&'a mut T> {
+    /// Maps an Option<&mut T> to an Option<T> by cloning the contents of the Option.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub fn cloned(self) -> Option<T> {
+        self.map(|t| t.clone())
+    }
+}
+
 impl<T: Default> Option<T> {
     /// Returns the contained value or a default
     ///

--- a/src/test/run-pass/option-cloned.rs
+++ b/src/test/run-pass/option-cloned.rs
@@ -1,0 +1,14 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    assert_eq!(Some(&1u8).cloned(), Some(1u8));
+    assert_eq!(Some(&mut 1u8).cloned(), Some(1u8));
+}


### PR DESCRIPTION
Mirror `Option<&T>.cloned()`.
