### PR TITLE
std: Set overlap/noinherit flags on windows sockets

### DIFF
--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -44,6 +44,8 @@ pub const WSA_WAIT_TIMEOUT: libc::DWORD = libc::consts::os::extra::WAIT_TIMEOUT;
 pub const WSA_WAIT_EVENT_0: libc::DWORD = libc::consts::os::extra::WAIT_OBJECT_0;
 pub const WSA_WAIT_FAILED: libc::DWORD = libc::consts::os::extra::WAIT_FAILED;
 pub const WSAESHUTDOWN: libc::c_int = 10058;
+pub const WSA_FLAG_OVERLAPPED: libc::DWORD = 0x01;
+pub const WSA_FLAG_NO_HANDLE_INHERIT: libc::DWORD = 0x80;
 
 pub const ERROR_NO_MORE_FILES: libc::DWORD = 18;
 pub const TOKEN_READ: libc::DWORD = 0x20008;

--- a/src/libstd/sys/windows/net.rs
+++ b/src/libstd/sys/windows/net.rs
@@ -80,7 +80,11 @@ impl Socket {
             SocketAddr::V4(..) => libc::AF_INET,
             SocketAddr::V6(..) => libc::AF_INET6,
         };
-        match unsafe { libc::socket(fam, ty, 0) } {
+        let socket = unsafe {
+            c::WSASocketW(fam, ty, 0, 0 as *mut _, 0,
+                          c::WSA_FLAG_OVERLAPPED | c::WSA_FLAG_NO_HANDLE_INHERIT)
+        };
+        match socket {
             INVALID_SOCKET => Err(last_error()),
             n => Ok(Socket(n)),
         }
@@ -103,7 +107,9 @@ impl Socket {
             match c::WSASocketW(info.iAddressFamily,
                                 info.iSocketType,
                                 info.iProtocol,
-                                &mut info, 0, 0) {
+                                &mut info, 0,
+                                c::WSA_FLAG_OVERLAPPED |
+                                    c::WSA_FLAG_NO_HANDLE_INHERIT) {
                 INVALID_SOCKET => Err(last_error()),
                 n => Ok(Socket(n)),
             }


### PR DESCRIPTION
This commit modifies the socket creation functions on windows to always specify
the `WSA_FLAG_OVERLAPPED` and `WSA_FLAG_NO_HANDLE_INHERIT` flags by default. The
overlapped flag enables IOCP APIs on Windows to be used with the socket at no
cost, enabling better interoperation with external libraries. The no handle
inherit flag mirrors the upcoming change to Unix to set CLOEXEC by default for
all handles.

Closes #24206
