### PR TITLE
std: Stabilize Clone::clone_from

### DIFF
--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -44,8 +44,7 @@ pub trait Clone : Sized {
     /// but can be overridden to reuse the resources of `a` to avoid unnecessary
     /// allocations.
     #[inline(always)]
-    #[unstable(feature = "core",
-               reason = "this function is rarely used")]
+    #[stable(feature = "rust1", since = "1.0.0")]
     fn clone_from(&mut self, source: &Self) {
         *self = source.clone()
     }


### PR DESCRIPTION
This method hasn't really changed since is inception, and it can often be a
nice performance win for some situations. This method also imposes no burden on
implementors or users of `Clone` as it's just a default method on the side.
