### PR TITLE
std: Stabilize io::Error::from_raw_os_error

### DIFF
--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -163,12 +163,18 @@ impl Error {
     /// `Error` for the error code.
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn last_os_error() -> Error {
-        Error::from_os_error(sys::os::errno() as i32)
+        Error::from_raw_os_error(sys::os::errno() as i32)
     }
 
     /// Creates a new instance of an `Error` from a particular OS error code.
-    #[unstable(feature = "io",
-               reason = "unclear whether this function is necessary")]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub fn from_raw_os_error(code: i32) -> Error {
+        Error { repr: Repr::Os(code) }
+    }
+
+    /// Creates a new instance of an `Error` from a particular OS error code.
+    #[unstable(feature = "io", reason = "deprecated")]
+    #[deprecated(since = "1.0.0", reason = "renamed to from_raw_os_error")]
     pub fn from_os_error(code: i32) -> Error {
         Error { repr: Repr::Os(code) }
     }

--- a/src/libstd/sys/unix/process2.rs
+++ b/src/libstd/sys/unix/process2.rs
@@ -193,7 +193,7 @@ impl Process {
                                 let errno = combine(&bytes[0.. 4]);
                                 assert!(p.wait().is_ok(),
                                         "wait() should either return Ok or panic");
-                                return Err(Error::from_os_error(errno))
+                                return Err(Error::from_raw_os_error(errno))
                             }
                             Ok(0) => return Ok(p),
                             Err(ref e) if e.kind() == ErrorKind::Interrupted => {}

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -212,7 +212,7 @@ pub unsafe fn create(stack: usize, p: Thunk) -> io::Result<rust_thread> {
     assert_eq!(pthread_attr_destroy(&mut attr), 0);
 
     return if ret != 0 {
-        Err(io::Error::from_os_error(ret))
+        Err(io::Error::from_raw_os_error(ret))
     } else {
         mem::forget(p); // ownership passed to pthread_create
         Ok(native)

--- a/src/libstd/sys/windows/net.rs
+++ b/src/libstd/sys/windows/net.rs
@@ -43,7 +43,7 @@ pub fn init() {
 
 /// Returns the last error from the Windows socket interface.
 fn last_error() -> io::Error {
-    io::Error::from_os_error(unsafe { c::WSAGetLastError() })
+    io::Error::from_raw_os_error(unsafe { c::WSAGetLastError() })
 }
 
 /// Checks if the signed integer is the Windows constant `SOCKET_ERROR` (-1)


### PR DESCRIPTION
This commit stabilizes the old `io::Error::from_os_error` after being renamed to
use the `raw_os_error` terminology instead. This function is often useful when
writing bindings to OS functions but only actually converting to an I/O error at
a later point.
