### PR TITLE
Remove `ignore-tidy-linelength` from tests that no longer need it

### DIFF
--- a/src/test/compile-fail/bad-mid-path-type-params.rs
+++ b/src/test/compile-fail/bad-mid-path-type-params.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-tidy-linelength
-
 struct S<T> {
     contents: T,
 }

--- a/src/test/compile-fail/bad-sized.rs
+++ b/src/test/compile-fail/bad-sized.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-tidy-linelength
-
 use std::cell::RefCell;
 
 trait Trait : ::std::marker::MarkerTrait {}

--- a/src/test/compile-fail/coherence-default-trait-impl.rs
+++ b/src/test/compile-fail/coherence-default-trait-impl.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-tidy-linelength
-
 #![feature(optin_builtin_traits)]
 
 use std::marker::MarkerTrait;

--- a/src/test/compile-fail/coherence-orphan.rs
+++ b/src/test/compile-fail/coherence-orphan.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-tidy-linelength
 // aux-build:coherence_orphan_lib.rs
 
 #![feature(optin_builtin_traits)]

--- a/src/test/compile-fail/issue-8767.rs
+++ b/src/test/compile-fail/issue-8767.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-tidy-linelength
-
 impl B { //~ ERROR use of undeclared type name `B`
 }
 

--- a/src/test/compile-fail/lint-stability.rs
+++ b/src/test/compile-fail/lint-stability.rs
@@ -12,7 +12,6 @@
 // aux-build:inherited_stability.rs
 // aux-build:stability_cfg1.rs
 // aux-build:stability_cfg2.rs
-// ignore-tidy-linelength
 
 #![deny(deprecated)]
 #![allow(dead_code)]

--- a/src/test/compile-fail/lint-uppercase-variables.rs
+++ b/src/test/compile-fail/lint-uppercase-variables.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-tidy-linelength
-
 #![allow(dead_code)]
 #![deny(non_snake_case)]
 

--- a/src/test/compile-fail/typeck-default-trait-impl-outside-crate.rs
+++ b/src/test/compile-fail/typeck-default-trait-impl-outside-crate.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-tidy-linelength
-
 #![feature(optin_builtin_traits)]
 
 impl Copy for .. {}

--- a/src/test/compile-fail/use-after-move-implicity-coerced-object.rs
+++ b/src/test/compile-fail/use-after-move-implicity-coerced-object.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-tidy-linelength
-
 #![feature(box_syntax)]
 
 use std::fmt;

--- a/src/test/debuginfo/gdb-pretty-std.rs
+++ b/src/test/debuginfo/gdb-pretty-std.rs
@@ -10,7 +10,6 @@
 
 // ignore-windows failing on win32 bot
 // ignore-freebsd: gdb package too new
-// ignore-tidy-linelength
 // ignore-lldb
 // ignore-android: FIXME(#10381)
 // compile-flags:-g


### PR DESCRIPTION
This is a really minor issue. I noticed some tests no longer need the ignore
tidy comment directive.

A quick grep turned up the following files:

```
src/test/compile-fail/bad-mid-path-type-params.rs
src/test/compile-fail/bad-sized.rs
src/test/compile-fail/coherence-default-trait-impl.rs
src/test/compile-fail/coherence-orphan.rs
src/test/compile-fail/issue-8767.rs
src/test/compile-fail/lint-stability.rs
src/test/compile-fail/lint-uppercase-variables.rs
src/test/compile-fail/typeck-default-trait-impl-outside-crate.rs
src/test/compile-fail/use-after-move-implicity-coerced-object.rs
src/test/debuginfo/gdb-pretty-std.rs
```

It didn't seem like it was worth opening an issue for this, but if that is not
the case (i.e. it is required), I'll open one up. Thanks!
