### PR TITLE
Ensure that .join().unwrap() works

### DIFF
--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -114,6 +114,16 @@ impl fmt::Debug for Any {
     }
 }
 
+// Ensure that the result of e.g. joining a thread can be printed and
+// hence used with `unwrap`. May eventually no longer be needed if
+// dispatch works with upcasting.
+#[stable(feature = "rust1", since = "1.0.0")]
+impl fmt::Debug for Any + Send {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.pad("Any")
+    }
+}
+
 impl Any {
     /// Returns true if the boxed type is the same as `T`
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/run-pass/issue-21291.rs
+++ b/src/test/run-pass/issue-21291.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for unwrapping the result of `join`, issue #21291
+
+use std::thread;
+
+fn main() {
+    thread::spawn(|| {}).join().unwrap()
+}


### PR DESCRIPTION
Make `Box<Any + Send>` implement `Debug`.

Fixes #21291
