### PR TITLE
Fix for #23150

### DIFF
--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -242,7 +242,7 @@ pub fn float_to_str_bytes_common<T: Float, U, F>(
                     if i < 0
                     || buf[i as usize] == b'-'
                     || buf[i as usize] == b'+' {
-                        for j in (i as usize + 1..end).rev() {
+                        for j in ((i + 1) as usize..end).rev() {
                             buf[j + 1] = buf[j];
                         }
                         buf[(i + 1) as usize] = value2ascii(1);

--- a/src/libcoretest/fmt/float.rs
+++ b/src/libcoretest/fmt/float.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[test]
+fn test_format_float() {
+    assert!("1" == format!("{:.0}", 1.0f64));
+    assert!("9" == format!("{:.0}", 9.4f64));
+    assert!("10" == format!("{:.0}", 9.9f64));
+    assert!("9.9" == format!("{:.1}", 9.85f64));
+}


### PR DESCRIPTION
This fixes the bug described in issue #23150.  This affected formatting any floating point number into a string in a formatting pattern that: a) required rounding up, and b) required an extra digit on the front.

So `format!("{:.0}", 9.9)` would fail, but `format!("{:.0}", 8.9)` would succeed.  This was due to a negative integer being cast to a `usize` resulting in an 'arithmetic operation overflowed' panic.

The fix was to change the order of operations so that the number is zero before casting.
