### PR TITLE
Use discriminant_value intrinsic for derive(PartialOrd)

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -569,4 +569,10 @@ extern "rust-intrinsic" {
     pub fn overflowing_sub<T>(a: T, b: T) -> T;
     /// Returns (a * b) mod 2^N, where N is the width of N in bits.
     pub fn overflowing_mul<T>(a: T, b: T) -> T;
+
+    /// Returns the value of the discriminant for the variant in 'v',
+    /// cast to a `u64`; if `T` has no discriminant, returns 0.
+    // SNAP 5520801
+    #[cfg(not(stage0))]
+    pub fn discriminant_value<T>(v: &T) -> u64;
 }

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -157,6 +157,7 @@ mod tuple;
 
 #[doc(hidden)]
 mod core {
+    pub use intrinsics;
     pub use panicking;
     pub use fmt;
     pub use clone;

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5073,6 +5073,12 @@ pub fn check_intrinsic_type(ccx: &CrateCtxt, it: &ast::ForeignItem) {
 
             "assume" => (0, vec![tcx.types.bool], ty::mk_nil(tcx)),
 
+            "discriminant_value" => (1, vec![
+                    ty::mk_imm_rptr(tcx,
+                                    tcx.mk_region(ty::ReLateBound(ty::DebruijnIndex::new(1),
+                                                                  ty::BrAnon(0))),
+                                    param(ccx, 0))], tcx.types.u64),
+
             ref other => {
                 span_err!(tcx.sess, it.span, E0093,
                     "unrecognized intrinsic function: `{}`", *other);

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -1067,8 +1067,8 @@ impl<'a> MethodDef<'a> {
             .collect::<Vec<ast::Ident>>();
 
         // The `vi_idents` will be bound, solely in the catch-all, to
-        // a series of let statements mapping each self_arg to an isize
-        // corresponding to its discriminant value.
+        // a series of let statements mapping each self_arg to an int
+        // value corresponding to its discriminant.
         let vi_idents: Vec<ast::Ident> = self_arg_names.iter()
             .map(|name| { let vi_suffix = format!("{}_vi", &name[..]);
                           cx.ident_of(&vi_suffix[..]) })
@@ -1186,18 +1186,19 @@ impl<'a> MethodDef<'a> {
             // Build a series of let statements mapping each self_arg
             // to its discriminant value. If this is a C-style enum
             // with a specific repr type, then casts the values to
-            // that type.  Otherwise casts to `isize`.
+            // that type.  Otherwise casts to `i32` (the default repr
+            // type).
             //
             // i.e. for `enum E<T> { A, B(1), C(T, T) }`, and a deriving
             // with three Self args, builds three statements:
             //
             // ```
             // let __self0_vi = unsafe {
-            //     std::intrinsics::discriminant_value(&self) } as isize;
+            //     std::intrinsics::discriminant_value(&self) } as i32;
             // let __self1_vi = unsafe {
-            //     std::intrinsics::discriminant_value(&__arg1) } as isize;
+            //     std::intrinsics::discriminant_value(&__arg1) } as i32;
             // let __self2_vi = unsafe {
-            //     std::intrinsics::discriminant_value(&__arg2) } as isize;
+            //     std::intrinsics::discriminant_value(&__arg2) } as i32;
             // ```
             let mut index_let_stmts: Vec<P<ast::Stmt>> = Vec::new();
 

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -1181,6 +1181,17 @@ impl<'a> MethodDef<'a> {
                     rules: ast::UnsafeBlock(ast::CompilerGenerated),
                     span: sp }));
 
+                // FIXME: This unconditionally casts to `isize`. However:
+                //
+                // 1. On 32-bit platforms, that will truncate 64-bit enums
+                //    that are making use of the upper 32 bits, and
+                //
+                // 2. On all platforms, it will misinterpret the sign bit
+                //    of a 64-bit enum.
+                //
+                // What it should do is lookup whether the enum has an
+                // repr-attribute and cast to that if necessary. But
+                // attributes are not yet available to this function.
                 let target_ty = cx.ty_ident(sp, cx.ident_of("isize"));
                 let variant_disr = cx.expr_cast(sp, variant_value, target_ty);
                 let let_stmt = cx.stmt_let(sp, false, ident, variant_disr);

--- a/src/test/run-pass/discriminant_value.rs
+++ b/src/test/run-pass/discriminant_value.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(core)]
+
 extern crate core;
 use core::intrinsics::discriminant_value;
 
@@ -22,6 +24,14 @@ enum CLike2 {
     A = 5,
     B = 2,
     C = 19,
+    D
+}
+
+#[repr(i8)]
+enum CLike3 {
+    A = 5,
+    B,
+    C = -1,
     D
 }
 
@@ -49,6 +59,11 @@ pub fn main() {
         assert_eq!(discriminant_value(&CLike2::B), 2);
         assert_eq!(discriminant_value(&CLike2::C), 19);
         assert_eq!(discriminant_value(&CLike2::D), 20);
+
+        assert_eq!(discriminant_value(&CLike3::A), 5);
+        assert_eq!(discriminant_value(&CLike3::B), 6);
+        assert_eq!(discriminant_value(&CLike3::C), -1_i8 as u64);
+        assert_eq!(discriminant_value(&CLike3::D), 0);
 
         assert_eq!(discriminant_value(&ADT::First(0,0)), 0);
         assert_eq!(discriminant_value(&ADT::Second(5)), 1);

--- a/src/test/run-pass/discriminant_value.rs
+++ b/src/test/run-pass/discriminant_value.rs
@@ -1,0 +1,62 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate core;
+use core::intrinsics::discriminant_value;
+
+enum CLike1 {
+    A,
+    B,
+    C,
+    D
+}
+
+enum CLike2 {
+    A = 5,
+    B = 2,
+    C = 19,
+    D
+}
+
+enum ADT {
+    First(u32, u32),
+    Second(u64)
+}
+
+enum NullablePointer {
+    Something(&'static u32),
+    Nothing
+}
+
+static CONST : u32 = 0xBEEF;
+
+pub fn main() {
+    unsafe {
+
+        assert_eq!(discriminant_value(&CLike1::A), 0);
+        assert_eq!(discriminant_value(&CLike1::B), 1);
+        assert_eq!(discriminant_value(&CLike1::C), 2);
+        assert_eq!(discriminant_value(&CLike1::D), 3);
+
+        assert_eq!(discriminant_value(&CLike2::A), 5);
+        assert_eq!(discriminant_value(&CLike2::B), 2);
+        assert_eq!(discriminant_value(&CLike2::C), 19);
+        assert_eq!(discriminant_value(&CLike2::D), 20);
+
+        assert_eq!(discriminant_value(&ADT::First(0,0)), 0);
+        assert_eq!(discriminant_value(&ADT::Second(5)), 1);
+
+        assert_eq!(discriminant_value(&NullablePointer::Nothing), 1);
+        assert_eq!(discriminant_value(&NullablePointer::Something(&CONST)), 0);
+
+        assert_eq!(discriminant_value(&10), 0);
+        assert_eq!(discriminant_value(&"test"), 0);
+    }
+}

--- a/src/test/run-pass/issue-15523-big.rs
+++ b/src/test/run-pass/issue-15523-big.rs
@@ -11,41 +11,38 @@
 // Issue 15523: derive(PartialOrd) should use the provided
 // discriminant values for the derived ordering.
 //
-// This is checking the basic functionality.
+// This test is checking corner cases that arise when you have
+// 64-bit values in the variants.
 
 #[derive(PartialEq, PartialOrd)]
-enum E1 {
+#[repr(u64)]
+enum Eu64 {
+    Pos2 = 2,
+    PosMax = !0,
+    Pos1 = 1,
+}
+
+#[derive(PartialEq, PartialOrd)]
+#[repr(i64)]
+enum Ei64 {
     Pos2 = 2,
     Neg1 = -1,
-    Pos1 = 1,
-}
-
-#[derive(PartialEq, PartialOrd)]
-#[repr(u8)]
-enum E2 {
-    Pos2 = 2,
-    PosMax = !0 as u8,
-    Pos1 = 1,
-}
-
-#[derive(PartialEq, PartialOrd)]
-#[repr(i8)]
-enum E3 {
-    Pos2 = 2,
-    Neg1 = -1_i8,
+    NegMin = 1 << 63,
+    PosMax = !(1 << 63),
     Pos1 = 1,
 }
 
 fn main() {
-    assert!(E1::Pos2 > E1::Pos1);
-    assert!(E1::Pos1 > E1::Neg1);
-    assert!(E1::Pos2 > E1::Neg1);
+    assert!(Eu64::Pos2 > Eu64::Pos1);
+    assert!(Eu64::Pos2 < Eu64::PosMax);
+    assert!(Eu64::Pos1 < Eu64::PosMax);
 
-    assert!(E2::Pos2 > E2::Pos1);
-    assert!(E2::Pos1 < E2::PosMax);
-    assert!(E2::Pos2 < E2::PosMax);
 
-    assert!(E3::Pos2 > E3::Pos1);
-    assert!(E3::Pos1 > E3::Neg1);
-    assert!(E3::Pos2 > E3::Neg1);
+    assert!(Ei64::Pos2 > Ei64::Pos1);
+    assert!(Ei64::Pos2 > Ei64::Neg1);
+    assert!(Ei64::Pos1 > Ei64::Neg1);
+    assert!(Ei64::Pos2 > Ei64::NegMin);
+    assert!(Ei64::Pos1 > Ei64::NegMin);
+    assert!(Ei64::Pos2 < Ei64::PosMax);
+    assert!(Ei64::Pos1 < Ei64::PosMax);
 }

--- a/src/test/run-pass/issue-15523.rs
+++ b/src/test/run-pass/issue-15523.rs
@@ -1,0 +1,49 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue 15523: derive(PartialOrd) should use the provided
+// discriminant values for the derived ordering.
+
+#[derive(PartialEq, PartialOrd)]
+enum E1 {
+    Pos2 = 2,
+    Neg1 = -1,
+    Pos1 = 1,
+}
+
+#[derive(PartialEq, PartialOrd)]
+#[repr(u8)]
+enum E2 {
+    Pos2 = 2,
+    PosMax = !0 as u8,
+    Pos1 = 1,
+}
+
+#[derive(PartialEq, PartialOrd)]
+#[repr(i8)]
+enum E3 {
+    Pos2 = 2,
+    Neg1 = -1_i8,
+    Pos1 = 1,
+}
+
+fn main() {
+    assert!(E1::Pos2 > E1::Pos1);
+    assert!(E1::Pos1 > E1::Neg1);
+    assert!(E1::Pos2 > E1::Neg1);
+
+    assert!(E2::Pos2 > E2::Pos1);
+    assert!(E2::Pos1 < E2::PosMax);
+    assert!(E2::Pos2 < E2::PosMax);
+
+    assert!(E3::Pos2 > E3::Pos1);
+    assert!(E3::Pos1 > E3::Neg1);
+    assert!(E3::Pos2 > E3::Neg1);
+}

--- a/src/test/run-pass/issue-18738.rs
+++ b/src/test/run-pass/issue-18738.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
-
 #[derive(Eq, PartialEq, PartialOrd, Ord)]
 enum Test<'a> {
     Int(&'a isize),

--- a/src/test/run-pass/while-prelude-drop.rs
+++ b/src/test/run-pass/while-prelude-drop.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
-
 #![feature(collections)]
 
 use std::string::String;


### PR DESCRIPTION
Use `discriminant_value` intrinsic for `derive(PartialOrd)`

[breaking-change]

This is a [breaking-change] because it can change the result of comparison operators when enum discriminants have been explicitly assigned.  Notably in a case like:

``` rust
#[derive(PartialOrd)]
enum E { A = 2, B = 1}
```

Under the old deriving, `A < B` held, because `A` came before `B` in the order of declaration.  But now we use the ordering according to the provided values, and thus `A > B`.  (However, this change is very unlikely to break much, if any, code, since the orderings themselves should all remain well-defined, total, etc.)

Fix #15523
