### PR TITLE
Added a hint for wrong escaping of curly braces in format strings. 

### DIFF
--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -843,12 +843,18 @@ impl<'a> StringReader<'a> {
                                     if ascii_only { "unknown byte escape" }
                                     else { "unknown character escape" },
                                     c);
+                                let sp = codemap::mk_sp(escaped_pos, last_pos);
                                 if e == '\r' {
-                                    let sp = codemap::mk_sp(escaped_pos, last_pos);
                                     self.span_diagnostic.span_help(
                                         sp,
                                         "this is an isolated carriage return; consider checking \
                                          your editor and version control settings")
+                                }
+                                if (e == '{' || e == '}') && !ascii_only {
+                                    self.span_diagnostic.span_help(
+                                        sp,
+                                        "if used in a formatting string, \
+                                        curly braces are escaped with `{{` and `}}`")
                                 }
                                 false
                             }

--- a/src/test/parse-fail/wrong-escape-of-curly-braces.rs
+++ b/src/test/parse-fail/wrong-escape-of-curly-braces.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn f() {
+    let ok = "{{everything fine}}";
+    let bad = "\{it is wrong\}";
+    //~^  ERROR unknown character escape: {
+    //~^^  HELP if used in a formatting string, curly braces are escaped with `{{` and `}}`
+    //~^^^ ERROR unknown character escape: }
+    //~^^^^  HELP if used in a formatting string, curly braces are escaped with `{{` and `}}`
+}


### PR DESCRIPTION
As i proposed in #24262 (and found acceptance in the IRC channel), added a compiler warning for wrong escaping of curly braces.
