### PR TITLE
std: Stabilize the Utf8Error type

### DIFF
--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -40,6 +40,7 @@
 #![feature(str_char)]
 #![feature(slice_patterns)]
 #![feature(debug_builders)]
+#![feature(utf8_error)]
 #![cfg_attr(test, feature(rand, rustc_private, test, hash, collections))]
 #![cfg_attr(test, allow(deprecated))] // rand
 

--- a/src/libcollectionstest/str.rs
+++ b/src/libcollectionstest/str.rs
@@ -1502,7 +1502,7 @@ fn test_str_from_utf8() {
     assert_eq!(from_utf8(xs), Ok("ศไทย中华Việt Nam"));
 
     let xs = b"hello\xFF";
-    assert_eq!(from_utf8(xs), Err(Utf8Error::TooShort));
+    assert!(from_utf8(xs).is_err());
 }
 
 #[test]

--- a/src/libcollectionstest/string.rs
+++ b/src/libcollectionstest/string.rs
@@ -45,7 +45,6 @@ fn test_from_utf8() {
 
     let xs = b"hello\xFF".to_vec();
     let err = String::from_utf8(xs).err().unwrap();
-    assert_eq!(err.utf8_error(), Utf8Error::TooShort);
     assert_eq!(err.into_bytes(), b"hello\xff".to_vec());
 }
 

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -122,10 +122,7 @@ impl Error for str::ParseBoolError {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Error for str::Utf8Error {
     fn description(&self) -> &str {
-        match *self {
-            str::Utf8Error::TooShort => "invalid utf-8: not enough bytes",
-            str::Utf8Error::InvalidByte(..) => "invalid utf-8: corrupt contents",
-        }
+        "invalid utf-8: corrupt contents"
     }
 }
 


### PR DESCRIPTION
The meaning of each variant of this enum was somewhat ambiguous and it's uncler
that we wouldn't even want to add more enumeration values in the future. As a
result this error has been altered to instead become an opaque structure.
Learning about the "first invalid byte index" is still an unstable feature, but
the type itself is now stable.
