### PR TITLE
Change the rt::unwind line argument type from usize to u32.

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -38,7 +38,7 @@
 //!   provided by the [rlibc crate](https://crates.io/crates/rlibc).
 //!
 //! * `rust_begin_unwind` - This function takes three arguments, a
-//!   `fmt::Arguments`, a `&str`, and a `usize`. These three arguments dictate
+//!   `fmt::Arguments`, a `&str`, and a `u32`. These three arguments dictate
 //!   the panic message, the file at which panic was invoked, and the line.
 //!   It is up to consumers of this core library to define this panic
 //!   function; it is only required to never return.

--- a/src/libcore/panicking.rs
+++ b/src/libcore/panicking.rs
@@ -16,7 +16,7 @@
 //! interface for panicking is:
 //!
 //! ```ignore
-//! fn panic_impl(fmt: fmt::Arguments, &(&'static str, usize)) -> !;
+//! fn panic_impl(fmt: fmt::Arguments, &(&'static str, u32)) -> !;
 //! ```
 //!
 //! This definition allows for panicking with any general message, but it does not
@@ -58,8 +58,8 @@ pub fn panic_fmt(fmt: fmt::Arguments, file_line: &(&'static str, u32)) -> ! {
     #[allow(improper_ctypes)]
     extern {
         #[lang = "panic_fmt"]
-        fn panic_impl(fmt: fmt::Arguments, file: &'static str, line: usize) -> !;
+        fn panic_impl(fmt: fmt::Arguments, file: &'static str, line: u32) -> !;
     }
     let (file, line) = *file_line;
-    unsafe { panic_impl(fmt, file, line as usize) }
+    unsafe { panic_impl(fmt, file, line) }
 }

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -26,7 +26,7 @@ thread_local! {
     }
 }
 
-pub fn on_panic(obj: &(Any+Send), file: &'static str, line: usize) {
+pub fn on_panic(obj: &(Any+Send), file: &'static str, line: u32) {
     let msg = match obj.downcast_ref::<&'static str>() {
         Some(s) => *s,
         None => match obj.downcast_ref::<String>() {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -767,7 +767,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         let loc = self.codemap().lookup_char_pos(span.lo);
         let expr_file = self.expr_str(span,
                                       token::intern_and_get_ident(&loc.file.name));
-        let expr_line = self.expr_usize(span, loc.line);
+        let expr_line = self.expr_u32(span, loc.line as u32);
         let expr_file_line_tuple = self.expr_tuple(span, vec!(expr_file, expr_line));
         let expr_file_line_ptr = self.expr_addr_of(span, expr_file_line_tuple);
         self.expr_call_global(


### PR DESCRIPTION
There are syntax extensions that call `std::rt::begin_unwind` passing it a `usize`.  I updated the syntax extension to instead pass `u32`, but for bootstrapping reasons, I needed to create a `#[cfg(stage0)]` version of `std::rt::begin_unwind` and therefore also `panic!`.
