### PR TITLE
References to `CString::from_vec` changed to `new`

### DIFF
--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -172,8 +172,9 @@ impl CString {
     /// Create a C-compatible string from a byte vector without checking for
     /// interior 0 bytes.
     ///
-    /// This method is equivalent to `from_vec` except that no runtime assertion
-    /// is made that `v` contains no 0 bytes.
+    /// This method is equivalent to `new` except that no runtime assertion
+    /// is made that `v` contains no 0 bytes, and it requires an actual
+    /// byte vector, not anyhting that can be converted to one with Into.
     #[stable(feature = "rust1", since = "1.0.0")]
     pub unsafe fn from_vec_unchecked(mut v: Vec<u8>) -> CString {
         v.push(0);
@@ -215,7 +216,7 @@ impl fmt::Debug for CString {
 
 impl NulError {
     /// Returns the position of the nul byte in the slice that was provided to
-    /// `CString::from_vec`.
+    /// `CString::new`.
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn nul_position(&self) -> usize { self.0 }
 


### PR DESCRIPTION
It looks like `from_vec` was subsumed by new at some point,
but the documentation still refers to it as `from_vec`.

This updates the documentation for `from_vec_unchecked`
so that it properly says that it's the unchecked version of `new`.

Also, from_vec_unchecked requires a actual Vec<u8> while
new can take anything that is Into<Vec<u8>>, so I also
mention that in the documentation.

Since this is documentation:
r? @steveklabnik
