### PR TITLE
Fix issue #24085

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -315,7 +315,8 @@ impl<'a, 'tcx> mc::Typer<'tcx> for FnCtxt<'a, 'tcx> {
     }
     fn type_moves_by_default(&self, span: Span, ty: Ty<'tcx>) -> bool {
         let ty = self.infcx().resolve_type_vars_if_possible(&ty);
-        !traits::type_known_to_meet_builtin_bound(self.infcx(), self, ty, ty::BoundCopy, span)
+        let infcx = infer::new_infer_ctxt(self.tcx());
+        !traits::type_known_to_meet_builtin_bound(&infcx, self, ty, ty::BoundCopy, span)
     }
     fn node_method_ty(&self, method_call: ty::MethodCall)
                       -> Option<Ty<'tcx>> {

--- a/src/test/run-pass/traits-issue-24085.rs
+++ b/src/test/run-pass/traits-issue-24085.rs
@@ -1,0 +1,29 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that trait selection for Copy does not introduce
+// bad region constraints.  Issue #24085.
+
+#[derive(Clone, Copy)]
+enum Path<'a:'b, 'b> {
+    Data(&'a i32),
+    Link(&'a i32, &'b Path<'a, 'b>)
+}
+
+fn foo<'a,'b,F>(_p: Path<'a, 'b>, _f: F)
+                where F: for<'c> FnMut(&Path<'a, 'c>) {
+}
+
+fn main() {
+    let y = 0;
+    let p = Path::Data(&y);
+
+    foo(p, |x| {*x;});
+}


### PR DESCRIPTION
Perform trait selection for builtin traits with a throw-away inference context, restoring the behavior prior to 83ef304.  This prevents unwanted region constraints that lead to later errors.

This is the simplest way to fix the issue, but I'm not sure it's the correct one.  I suspect `Copy` impl selection is generating overly-strict region equality constraints, so another approach might be to throw more type/region variables at it until inference is happy.

cc @nikomatsakis 
