### PR TITLE
Bump the version number to 1.1.0

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -13,7 +13,7 @@
 ######################################################################
 
 # The version number
-CFG_RELEASE_NUM=1.0.0
+CFG_RELEASE_NUM=1.1.0
 
 # An optional number to put after the label, e.g. '.2' -> '-beta.2'
 # NB Make sure it starts with a dot to conform to semver pre-release


### PR DESCRIPTION
My understanding of release channels is that on May 15, 1.0.0-beta will become 1.0.0, and what’s currently in Nightly/master will become 1.1.0-beta and six weeks later 1.1.0. Therefore, current nighties should be be numbered 1.1.0-nightly.
