### PR TITLE
Delay specific span_bug() call until abort_if_errors()

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -57,6 +57,8 @@ pub struct Session {
     pub crate_metadata: RefCell<Vec<String>>,
     pub features: RefCell<feature_gate::Features>,
 
+    pub delayed_span_bug: RefCell<Option<(codemap::Span, String)>>,
+
     /// The maximum recursion limit for potentially infinitely recursive
     /// operations such as auto-dereference and monomorphization.
     pub recursion_limit: Cell<usize>,
@@ -114,7 +116,15 @@ impl Session {
         self.diagnostic().handler().has_errors()
     }
     pub fn abort_if_errors(&self) {
-        self.diagnostic().handler().abort_if_errors()
+        self.diagnostic().handler().abort_if_errors();
+
+        let delayed_bug = self.delayed_span_bug.borrow();
+        match *delayed_bug {
+            Some((span, ref errmsg)) => {
+                self.diagnostic().span_bug(span, errmsg);
+            },
+            _ => {}
+        }
     }
     pub fn span_warn(&self, sp: Span, msg: &str) {
         if self.can_print_warnings {
@@ -170,6 +180,11 @@ impl Session {
             Some(sp) => self.span_bug(sp, msg),
             None => self.bug(msg),
         }
+    }
+    /// Delay a span_bug() call until abort_if_errors()
+    pub fn delay_span_bug(&self, sp: Span, msg: &str) {
+        let mut delayed = self.delayed_span_bug.borrow_mut();
+        *delayed = Some((sp, msg.to_string()));
     }
     pub fn span_bug(&self, sp: Span, msg: &str) -> ! {
         self.diagnostic().span_bug(sp, msg)
@@ -402,6 +417,7 @@ pub fn build_session_(sopts: config::Options,
         plugin_llvm_passes: RefCell::new(Vec::new()),
         crate_types: RefCell::new(Vec::new()),
         crate_metadata: RefCell::new(Vec::new()),
+        delayed_span_bug: RefCell::new(None),
         features: RefCell::new(feature_gate::Features::new()),
         recursion_limit: Cell::new(64),
         can_print_warnings: can_print_warnings

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -541,11 +541,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
             }
             Err(..) => {
                 let tcx = rcx.fcx.tcx();
-                if tcx.sess.has_errors() {
-                    // cannot run dropck; okay b/c in error state anyway.
-                } else {
-                    tcx.sess.delay_span_bug(expr.span, "cat_expr_unadjusted Errd");
-                }
+                tcx.sess.delay_span_bug(expr.span, "cat_expr_unadjusted Errd");
             }
         }
     }
@@ -562,11 +558,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
         }
         Err(..) => {
             let tcx = rcx.fcx.tcx();
-            if tcx.sess.has_errors() {
-                // cannot run dropck; okay b/c in error state anyway.
-            } else {
-                tcx.sess.delay_span_bug(expr.span, "cat_expr Errd");
-            }
+            tcx.sess.delay_span_bug(expr.span, "cat_expr Errd");
         }
     }
 

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -544,7 +544,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
                 if tcx.sess.has_errors() {
                     // cannot run dropck; okay b/c in error state anyway.
                 } else {
-                    tcx.sess.delay_span_bug(expr.span, "cat_expr Errd");
+                    tcx.sess.delay_span_bug(expr.span, "cat_expr_unadjusted Errd");
                 }
             }
         }

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -544,7 +544,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
                 if tcx.sess.has_errors() {
                     // cannot run dropck; okay b/c in error state anyway.
                 } else {
-                    tcx.sess.span_bug(expr.span, "cat_expr_unadjusted Errd");
+                    tcx.sess.delay_span_bug(expr.span, "cat_expr Errd");
                 }
             }
         }
@@ -565,7 +565,7 @@ fn visit_expr(rcx: &mut Rcx, expr: &ast::Expr) {
             if tcx.sess.has_errors() {
                 // cannot run dropck; okay b/c in error state anyway.
             } else {
-                tcx.sess.span_bug(expr.span, "cat_expr Errd");
+                tcx.sess.delay_span_bug(expr.span, "cat_expr Errd");
             }
         }
     }

--- a/src/test/compile-fail/issue-22897.rs
+++ b/src/test/compile-fail/issue-22897.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() { }
+
+// Before these errors would ICE as "cat_expr Errd" because the errors
+// were unknown when the bug was triggered.
+
+fn unconstrained_type() {
+    [];
+    //~^ ERROR cannot determine a type for this expression: unconstrained type
+}

--- a/src/test/compile-fail/issue-23041.rs
+++ b/src/test/compile-fail/issue-23041.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::any::Any;
+fn main()
+{
+    fn bar(x:i32) ->i32 { 3*x };
+    let b:Box<Any> = Box::new(bar as fn(_)->_);
+    b.downcast_ref::<fn(_)->_>();
+    //~^ ERROR cannot determine a type for this expression: unconstrained type
+}

--- a/src/test/compile-fail/issue-23966.rs
+++ b/src/test/compile-fail/issue-23966.rs
@@ -1,0 +1,14 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    "".chars().fold(|_, _| (), ());
+    //~^ ERROR cannot determine a type for this expression: unconstrained type
+}

--- a/src/test/compile-fail/issue-24013.rs
+++ b/src/test/compile-fail/issue-24013.rs
@@ -8,24 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-fn main() { }
-
-// Before these errors would ICE as "cat_expr Errd" because the errors
-// were unknown when the bug was triggered.
-
-fn unconstrained_type() {
-    [];
+fn main() {
+    use std::mem::{transmute, swap};
+    let a = 1;
+    let b = 2;
+    unsafe {swap::<&mut _>(transmute(&a), transmute(&b))};
     //~^ ERROR cannot determine a type for this expression: unconstrained type
-}
-
-fn invalid_impl_within_scope() {
-    {
-        use std::ops::Deref;
-        struct Something;
-
-        impl Deref for Something {}
-        //~^ ERROR not all trait items implemented, missing: `Target`, `deref`
-
-        *Something
-    };
 }

--- a/src/test/compile-fail/typeck-before-dropck-bug.rs
+++ b/src/test/compile-fail/typeck-before-dropck-bug.rs
@@ -1,0 +1,31 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() { }
+
+// Before these errors would ICE as "cat_expr Errd" because the errors
+// were unknown when the bug was triggered.
+
+fn unconstrained_type() {
+    [];
+    //~^ ERROR cannot determine a type for this expression: unconstrained type
+}
+
+fn invalid_impl_within_scope() {
+    {
+        use std::ops::Deref;
+        struct Something;
+
+        impl Deref for Something {}
+        //~^ ERROR not all trait items implemented, missing: `Target`, `deref`
+
+        *Something
+    };
+}


### PR DESCRIPTION
An actual typeck error is the cause of many failed compilations but an
unrelated bug is being reported instead. It is triggered because a typeck
error is presumably not yet identified during compiler execution, which
would normally bypass an invariant in the presence of other errors. In
this particular situation, we delay the reporting of the bug until
abort_if_errors().

Closes #23827, closes #24356, closes #23041, closes #22897, closes #23966,
closes #24013, and closes #23729

**There is at least one situation where this bug may still be genuinely
triggered (#23437).**
