### PR TITLE
extend #[link(name="...")] to allow filename

### DIFF
--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -264,6 +264,8 @@ impl<'a> CrateReader<'a> {
                                         cstore::NativeFramework
                                     } else if k == "framework" {
                                         cstore::NativeFramework
+                                    } else if k == "filepath" {
+                                        cstore::NativeFilepath
                                     } else if k == "dylib" {
                                         cstore::NativeUnknown
                                     } else {

--- a/src/librustc/metadata/cstore.rs
+++ b/src/librustc/metadata/cstore.rs
@@ -72,6 +72,7 @@ pub enum LinkagePreference {
 pub enum NativeLibraryKind {
     NativeStatic,    // native static library (.a archive)
     NativeFramework, // OSX-specific
+    NativeFilepath,  // dynamic library passed by filepath
     NativeUnknown,   // default way to specify a dynamic library
 }
 

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1726,7 +1726,9 @@ fn encode_native_libraries(ecx: &EncodeContext, rbml_w: &mut Encoder) {
                                .borrow().iter() {
         match kind {
             cstore::NativeStatic => {} // these libraries are not propagated
-            cstore::NativeFramework | cstore::NativeUnknown => {
+            cstore::NativeFramework
+            | cstore::NativeFilepath
+            | cstore::NativeUnknown => {
                 rbml_w.start_tag(tag_native_libraries_lib);
                 rbml_w.wr_tagged_u32(tag_native_libraries_kind, kind as u32);
                 rbml_w.wr_tagged_str(tag_native_libraries_name, lib);

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -770,8 +770,8 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
                    "[KIND=]PATH"),
         opt::multi("l", "",   "Link the generated crate(s) to the specified native
                              library NAME. The optional KIND can be one of,
-                             static, dylib, or framework. If omitted, dylib is
-                             assumed.", "[KIND=]NAME"),
+                             static, dylib, filepath, or framework. If omitted, dylib
+                             is assumed.", "[KIND=]NAME"),
         opt::multi("", "crate-type", "Comma separated list of types of crates
                                     for the compiler to emit",
                    "[bin|lib|rlib|dylib|staticlib]"),
@@ -963,11 +963,12 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         let (name, kind) = match (parts.next(), kind) {
             (None, name) |
             (Some(name), "dylib") => (name, cstore::NativeUnknown),
+            (Some(name), "filepath") => (name, cstore::NativeFilepath),
             (Some(name), "framework") => (name, cstore::NativeFramework),
             (Some(name), "static") => (name, cstore::NativeStatic),
             (_, s) => {
                 early_error(&format!("unknown library kind `{}`, expected \
-                                     one of dylib, framework, or static",
+                                     one of dylib, framework, filepath, or static",
                                     s));
             }
         };

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -557,7 +557,9 @@ fn link_rlib<'a>(sess: &'a Session,
             cstore::NativeStatic => {
                 ab.add_native_library(&l[..]).unwrap();
             }
-            cstore::NativeFramework | cstore::NativeUnknown => {}
+            cstore::NativeFramework
+            | cstore::NativeFilepath
+            | cstore::NativeUnknown => {}
         }
     }
 
@@ -776,6 +778,7 @@ fn link_staticlib(sess: &Session, obj_filename: &Path, out_filename: &Path) {
         let name = match kind {
             cstore::NativeStatic => "static library",
             cstore::NativeUnknown => "library",
+            cstore::NativeFilepath => "filepath",
             cstore::NativeFramework => "framework",
         };
         sess.note(&format!("{}: {}", name, *lib));
@@ -1128,6 +1131,9 @@ fn add_local_native_libraries(cmd: &mut Command, sess: &Session) {
             cstore::NativeUnknown => {
                 cmd.arg(&format!("-l{}", l));
             }
+            cstore::NativeFilepath => {
+                cmd.arg(&l[..]);
+            }
             cstore::NativeFramework => {
                 cmd.arg("-framework").arg(&l[..]);
             }
@@ -1313,6 +1319,9 @@ fn add_upstream_native_libraries(cmd: &mut Command, sess: &Session) {
             match kind {
                 cstore::NativeUnknown => {
                     cmd.arg(&format!("-l{}", *lib));
+                }
+                cstore::NativeFilepath => {
+                    cmd.arg(&lib[..]);
                 }
                 cstore::NativeFramework => {
                     cmd.arg("-framework");

--- a/src/test/compile-fail/manual-link-bad-kind.rs
+++ b/src/test/compile-fail/manual-link-bad-kind.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // compile-flags:-l bar=foo
-// error-pattern: unknown library kind `bar`, expected one of dylib, framework, or static
+// error-pattern: unknown library kind `bar`, expected one of dylib, framework, filepath, or static
 
 fn main() {
 }


### PR DESCRIPTION
The patch allow using #[link(name="...")] notation to reference a
library by filename.

The traditional behaviour is to pass to the linker -lxxx when
 #[link(name="xxx")] is encounter. With this patch, if "xxx" is a file,
the linker parameter will be the filename "xxx".

It permit to fully qualified the library version that would be linked to
the executable, in a context where multiple "xxx" libraries exists
(libxxx.so.1.0 and libxxx.so.2.0) and the wanted library isn't the
automatically selected-one.

Fixes #24345

---

this is patch is done as a proposition for resolv #24345.

On IRC, simukis said: `I’d prefer #[link(name="name only")] and #[link(path="path only")] if we ever go that way. avoids magic as well.` So other methods are possible (but would be more invasive and may request a RFC ?)
