### PR TITLE
Add lint to deny transmuting &T to &mut T

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -109,6 +109,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
                  InvalidNoMangleItems,
                  PluginAsLibrary,
                  DropWithReprExtern,
+                 MutableTransmutes,
                  );
 
     add_builtin_with_new!(sess,

--- a/src/test/auxiliary/issue_8401.rs
+++ b/src/test/auxiliary/issue_8401.rs
@@ -21,6 +21,6 @@ impl A for B {}
 fn bar<T>(_: &mut A, _: &T) {}
 
 fn foo<T>(t: &T) {
-    let b = B;
-    bar(unsafe { mem::transmute(&b as &A) }, t)
+    let mut b = B;
+    bar(&mut b as &mut A, t)
 }

--- a/src/test/compile-fail/transmute-imut-to-mut.rs
+++ b/src/test/compile-fail/transmute-imut-to-mut.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Tests that transmuting from &T to &mut T is Undefined Behavior.
+
+use std::mem::transmute;
+
+fn main() {
+    let _a: &mut u8 = unsafe { transmute(&1u8) };
+    //~^ ERROR mutating transmuted &mut T from &T may cause undefined behavior
+}
+
+

--- a/src/test/run-pass/issue-2718.rs
+++ b/src/test/run-pass/issue-2718.rs
@@ -170,7 +170,7 @@ pub mod pipes {
             unsafe {
                 if self.p != None {
                     let self_p: &mut Option<*const packet<T>> =
-                        mem::transmute(&self.p);
+                        mem::transmute(&mut self.p);
                     let p = replace(self_p, None);
                     sender_terminate(p.unwrap())
                 }
@@ -199,7 +199,7 @@ pub mod pipes {
             unsafe {
                 if self.p != None {
                     let self_p: &mut Option<*const packet<T>> =
-                        mem::transmute(&self.p);
+                        mem::transmute(&mut self.p);
                     let p = replace(self_p, None);
                     receiver_terminate(p.unwrap())
                 }


### PR DESCRIPTION
The [UnsafeCell documentation says it is undefined behavior](http://doc.rust-lang.org/nightly/std/cell/struct.UnsafeCell.html), so people shouldn't do it.

This happened to catch one case in libstd that was doing this, and I switched that to use an UnsafeCell internally.

Closes #13146 
