### PR TITLE
Fix up nightly installation instructions.

### DIFF
--- a/src/doc/trpl/nightly-rust.md
+++ b/src/doc/trpl/nightly-rust.md
@@ -18,7 +18,7 @@ use a two-step version of the installation and examine our installation script:
 
 ```bash
 $ curl -f -L https://static.rust-lang.org/rustup.sh -O
-$ sudo sh rustup.sh
+$ sudo sh rustup.sh --channel=nightly
 ```
 
 [insecurity]: http://curlpipesh.tumblr.com


### PR DESCRIPTION
The two-step command left off the nightly flag :frown:

Thanks @mdinger
