### PR TITLE
Point to From trait in error handling guide

### DIFF
--- a/src/doc/trpl/error-handling.md
+++ b/src/doc/trpl/error-handling.md
@@ -297,5 +297,5 @@ It's worth noting that you can only use `try!` from a function that returns a
 `Result`, which means that you cannot use `try!` inside of `main()`, because
 `main()` doesn't return anything.
 
-`try!` makes use of [`FromError`](../std/error/#the-fromerror-trait) to determine
+`try!` makes use of [`From<Error>`](../std/convert/trait.From.hml) to determine
 what to return in the error case.


### PR DESCRIPTION
Not sure if `From<Error>` is the correct way to reference that trait (maybe `From<E: Error>`?)

r? @steveklabnik
