### PR TITLE
configure: Don't disable optimizations when enabling debug

### DIFF
--- a/configure
+++ b/configure
@@ -192,6 +192,7 @@ valopt_core() {
     then
         local UOP=$(echo $OP | tr '[:lower:]' '[:upper:]' | tr '\-' '\_')
         local V="CFG_${UOP}"
+        local V_PROVIDED="${V}_PROVIDED"
         eval $V="$DEFAULT"
         for arg in $CFG_CONFIGURE_ARGS
         do
@@ -199,6 +200,7 @@ valopt_core() {
             then
                 val=$(echo "$arg" | cut -f2 -d=)
                 eval $V=$val
+                eval $V_PROVIDED=1
             fi
         done
         if [ "$SAVE" = "save" ]
@@ -247,8 +249,10 @@ opt_core() {
     if [ $DEFAULT -eq 0 ]
     then
         FLAG="enable"
+        DEFAULT_FLAG="disable"
     else
         FLAG="disable"
+        DEFAULT_FLAG="enable"
         DOC="don't $DOC"
     fi
 
@@ -261,11 +265,19 @@ opt_core() {
                 OP=$(echo $OP | tr 'a-z-' 'A-Z_')
                 FLAG=$(echo $FLAG | tr 'a-z' 'A-Z')
                 local V="CFG_${FLAG}_${OP}"
+                local V_PROVIDED="CFG_${FLAG}_${OP}_PROVIDED"
                 eval $V=1
+                eval $V_PROVIDED=1
                 if [ "$SAVE" = "save" ]
                 then
                    putvar $V
                 fi
+            elif [ "$arg" = "--${DEFAULT_FLAG}-${OP}" ]
+            then
+                OP=$(echo $OP | tr 'a-z-' 'A-Z_')
+                DEFAULT_FLAG=$(echo $DEFAULT_FLAG | tr 'a-z' 'A-Z')
+                local V_PROVIDED="CFG_${DEFAULT_FLAG}_${OP}_PROVIDED"
+                eval $V_PROVIDED=1
             fi
         done
     else

--- a/configure
+++ b/configure
@@ -633,8 +633,6 @@ esac
 # Adjust perf and debug options for debug mode
 if [ -n "$CFG_ENABLE_DEBUG" ]; then
     msg "debug mode enabled, setting performance options"
-    CFG_DISABLE_OPTIMIZE=1
-    CFG_DISABLE_OPTIMIZE_CXX=1
     CFG_ENABLE_LLVM_ASSERTIONS=1
     CFG_ENABLE_DEBUG_ASSERTIONS=1
     CFG_ENABLE_DEBUG_JEMALLOC=1

--- a/configure
+++ b/configure
@@ -645,6 +645,11 @@ esac
 # Adjust perf and debug options for debug mode
 if [ -n "$CFG_ENABLE_DEBUG" ]; then
     msg "debug mode enabled, setting performance options"
+    if [ -z "$CFG_ENABLE_OPTIMIZE_PROVIDED" ]; then
+        msg "optimization not explicitly enabled, disabling optimization"
+        CFG_DISABLE_OPTIMIZE=1
+        CFG_DISABLE_OPTIMIZE_CXX=1
+    fi
     CFG_ENABLE_LLVM_ASSERTIONS=1
     CFG_ENABLE_DEBUG_ASSERTIONS=1
     CFG_ENABLE_DEBUG_JEMALLOC=1


### PR DESCRIPTION
Optimization is now on by default. Closes #24405
