### PR TITLE
make clean deletes tmp, not tmp/*

### DIFF
--- a/mk/clean.mk
+++ b/mk/clean.mk
@@ -42,7 +42,7 @@ clean-misc:
 	$(Q)rm -f $(RUNTIME_OBJS) $(RUNTIME_DEF)
 	$(Q)rm -f $(RUSTLLVM_LIB_OBJS) $(RUSTLLVM_OBJS_OBJS) $(RUSTLLVM_DEF)
 	$(Q)rm -Rf $(GENERATED)
-	$(Q)rm -Rf tmp/*
+	$(Q)rm -Rf tmp/
 	$(Q)rm -Rf rust-stage0-*.tar.bz2 $(PKG_NAME)-*.tar.gz $(PKG_NAME)-*.exe
 	$(Q)rm -Rf dist/*
 	$(Q)rm -Rf doc


### PR DESCRIPTION
This might fix bug #12966.
I haven't been able to reproduce it yet however, so I'm not sure if this fixes it.

I have checked, and the tmp directory is properly remade with a plain `make` call.
