### PR TITLE
include_bytes! now registers the file included

### DIFF
--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -184,6 +184,11 @@ pub fn expand_include_bytes(cx: &mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
             return DummyResult::expr(sp);
         }
         Ok(..) => {
+            // Add this input file to the code map to make it available as
+            // dependency information, but don't enter it's contents
+            let filename = format!("{}", file.display());
+            cx.codemap().new_filemap(filename, "".to_string());
+
             base::MacEager::expr(cx.expr_lit(sp, ast::LitBinary(Rc::new(bytes))))
         }
     }

--- a/src/test/run-make/include_bytes_deps/Makefile
+++ b/src/test/run-make/include_bytes_deps/Makefile
@@ -1,0 +1,21 @@
+-include ../tools.mk
+
+# FIXME: ignore freebsd/windows
+# on windows `rustc --dep-info` produces Makefile dependency with
+# windows native paths (e.g. `c:\path\to\libfoo.a`)
+# but msys make seems to fail to recognize such paths, so test fails.
+ifneq ($(shell uname),FreeBSD)
+ifndef IS_WINDOWS
+all:
+	$(RUSTC) --emit dep-info main.rs
+	grep "input.txt" $(TMPDIR)/main.d
+	grep "input.bin" $(TMPDIR)/main.d
+else
+all:
+
+endif
+
+else
+all:
+
+endif

--- a/src/test/run-make/include_bytes_deps/input.bin
+++ b/src/test/run-make/include_bytes_deps/input.bin
@@ -1,0 +1,1 @@
+Hello world!

--- a/src/test/run-make/include_bytes_deps/input.txt
+++ b/src/test/run-make/include_bytes_deps/input.txt
@@ -1,0 +1,1 @@
+Hello world!

--- a/src/test/run-make/include_bytes_deps/main.rs
+++ b/src/test/run-make/include_bytes_deps/main.rs
@@ -1,0 +1,17 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub fn main() {
+    const INPUT_TXT: &'static str = include_str!("input.txt");
+    const INPUT_BIN: &'static [u8] = include_bytes!("input.bin");
+
+    println!("{}", INPUT_TXT);
+    println!("{:?}", INPUT_BIN);
+}


### PR DESCRIPTION
This is a little bit tricky, since with include_str!, we know that we
are including utf-8 content, so it's safe to store the source as a
String in a FileMap. We don't know that for include_bytes!, but I don't
think we actually need to track the contents anyways, so I'm passing "".

new_filemap does check for the zero length content, and it should be
reasonable, howeven I'm not sure if it would be better to pass None
instead of Some(Rc::new("")) as the src component of a FileMap.

Fixes bug #24348
