### PR TITLE
disabling a test for bitrig and openbsd

### DIFF
--- a/src/doc/trpl/no-stdlib.md
+++ b/src/doc/trpl/no-stdlib.md
@@ -103,7 +103,7 @@ necessary functionality for writing idiomatic and effective Rust code.
 As an example, here is a program that will calculate the dot product of two
 vectors provided from C, using idiomatic Rust practices.
 
-```
+```ignore
 #![feature(lang_items, start, no_std, core, libc)]
 #![no_std]
 


### PR DESCRIPTION
the code block in the no-stdlib.md file caused test failure on bitrig and openbsd.

Closes #24108 
