### PR TITLE
deprecate Unicode functions that will be moved to crates.io

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -52,7 +52,7 @@
 TARGET_CRATES := libc std flate arena term \
                  serialize getopts collections test rand \
                  log graphviz core rbml alloc \
-                 unicode rustc_bitflags
+                 rustc_unicode rustc_bitflags
 RUSTC_CRATES := rustc rustc_typeck rustc_borrowck rustc_resolve rustc_driver \
                 rustc_trans rustc_back rustc_llvm rustc_privacy rustc_lint
 HOST_CRATES := syntax $(RUSTC_CRATES) rustdoc fmt_macros
@@ -61,9 +61,9 @@ TOOLS := compiletest rustdoc rustc rustbook
 
 DEPS_core :=
 DEPS_libc := core
-DEPS_unicode := core
+DEPS_rustc_unicode := core
 DEPS_alloc := core libc native:jemalloc
-DEPS_std := core libc rand alloc collections unicode \
+DEPS_std := core libc rand alloc collections rustc_unicode \
 	native:rust_builtin native:backtrace native:rustrt_native \
 	rustc_bitflags
 DEPS_graphviz := std
@@ -94,7 +94,7 @@ DEPS_serialize := std log
 DEPS_rbml := std log serialize
 DEPS_term := std log
 DEPS_getopts := std
-DEPS_collections := core alloc unicode
+DEPS_collections := core alloc rustc_unicode
 DEPS_num := std
 DEPS_test := std getopts serialize rbml term native:rust_test_helpers
 DEPS_rand := core
@@ -115,11 +115,11 @@ ONLY_RLIB_libc := 1
 ONLY_RLIB_alloc := 1
 ONLY_RLIB_rand := 1
 ONLY_RLIB_collections := 1
-ONLY_RLIB_unicode := 1
+ONLY_RLIB_rustc_unicode := 1
 ONLY_RLIB_rustc_bitflags := 1
 
 # Documented-by-default crates
-DOC_CRATES := std alloc collections core libc unicode
+DOC_CRATES := std alloc collections core libc rustc_unicode
 
 ################################################################################
 # You should not need to edit below this line

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -15,14 +15,14 @@
 
 # The names of crates that must be tested
 
-# libcore/libunicode tests are in a separate crate
+# libcore/librustc_unicode tests are in a separate crate
 DEPS_coretest :=
 $(eval $(call RUST_CRATE,coretest))
 
 DEPS_collectionstest :=
 $(eval $(call RUST_CRATE,collectionstest))
 
-TEST_TARGET_CRATES = $(filter-out core unicode,$(TARGET_CRATES)) \
+TEST_TARGET_CRATES = $(filter-out core rustc_unicode,$(TARGET_CRATES)) \
 			collectionstest coretest
 TEST_DOC_CRATES = $(DOC_CRATES)
 TEST_HOST_CRATES = $(filter-out rustc_typeck rustc_borrowck rustc_resolve \

--- a/src/etc/unicode.py
+++ b/src/etc/unicode.py
@@ -518,11 +518,14 @@ def emit_norm_module(f, canon, compat, combine, norm_props):
     emit_table(f, "combining_class_table", combine, "&'static [(char, char, u8)]", is_pub=False,
             pfun=lambda x: "(%s,%s,%s)" % (escape_char(x[0]), escape_char(x[1]), x[2]))
 
-    f.write("    pub fn canonical_combining_class(c: char) -> u8 {\n"
-        + "        bsearch_range_value_table(c, combining_class_table)\n"
-        + "    }\n")
+    f.write("""    #[deprecated(reason = "use the crates.io `unicode-normalization` lib instead",
+                 since = "1.0.0")]
+    #[unstable(feature = "unicode",
+               reason = "this functionality will be moved to crates.io")]
+    pub fn canonical_combining_class(c: char) -> u8 {
+        bsearch_range_value_table(c, combining_class_table)
+    }
 
-    f.write("""
 }
 
 """)

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -50,7 +50,7 @@
 #[macro_use]
 extern crate core;
 
-extern crate unicode;
+extern crate rustc_unicode;
 extern crate alloc;
 
 #[cfg(test)] #[macro_use] extern crate std;

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -59,13 +59,13 @@ use core::result::Result;
 use core::str as core_str;
 use core::str::pattern::Pattern;
 use core::str::pattern::{Searcher, ReverseSearcher, DoubleEndedSearcher};
-use unicode::str::{UnicodeStr, Utf16Encoder};
+use rustc_unicode::str::{UnicodeStr, Utf16Encoder};
 
 use core::convert::AsRef;
 use vec_deque::VecDeque;
 use borrow::{Borrow, ToOwned};
 use string::String;
-use unicode;
+use rustc_unicode;
 use vec::Vec;
 use slice::SliceConcatExt;
 
@@ -78,7 +78,7 @@ pub use core::str::{Matches, RMatches};
 pub use core::str::{MatchIndices, RMatchIndices};
 pub use core::str::{from_utf8, Chars, CharIndices, Bytes};
 pub use core::str::{from_utf8_unchecked, ParseBoolError};
-pub use unicode::str::{Words, Graphemes, GraphemeIndices};
+pub use rustc_unicode::str::{Words, Graphemes, GraphemeIndices};
 pub use core::str::pattern;
 
 /*
@@ -161,6 +161,9 @@ enum DecompositionType {
 /// External iterator for a string decomposition's characters.
 ///
 /// For use with the `std::iter` module.
+#[allow(deprecated)]
+#[deprecated(reason = "use the crates.io `unicode-normalization` library instead",
+             since = "1.0.0")]
 #[derive(Clone)]
 #[unstable(feature = "unicode",
            reason = "this functionality may be replaced with a more generic \
@@ -172,6 +175,7 @@ pub struct Decompositions<'a> {
     sorted: bool
 }
 
+#[allow(deprecated)]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Iterator for Decompositions<'a> {
     type Item = char;
@@ -198,7 +202,7 @@ impl<'a> Iterator for Decompositions<'a> {
                 {
                     let callback = |d| {
                         let class =
-                            unicode::char::canonical_combining_class(d);
+                            rustc_unicode::char::canonical_combining_class(d);
                         if class == 0 && !*sorted {
                             canonical_sort(buffer);
                             *sorted = true;
@@ -207,10 +211,10 @@ impl<'a> Iterator for Decompositions<'a> {
                     };
                     match self.kind {
                         Canonical => {
-                            unicode::char::decompose_canonical(ch, callback)
+                            rustc_unicode::char::decompose_canonical(ch, callback)
                         }
                         Compatible => {
-                            unicode::char::decompose_compatible(ch, callback)
+                            rustc_unicode::char::decompose_compatible(ch, callback)
                         }
                     }
                 }
@@ -254,6 +258,9 @@ enum RecompositionState {
 /// External iterator for a string recomposition's characters.
 ///
 /// For use with the `std::iter` module.
+#[allow(deprecated)]
+#[deprecated(reason = "use the crates.io `unicode-normalization` library instead",
+             since = "1.0.0")]
 #[derive(Clone)]
 #[unstable(feature = "unicode",
            reason = "this functionality may be replaced with a more generic \
@@ -266,6 +273,7 @@ pub struct Recompositions<'a> {
     last_ccc: Option<u8>
 }
 
+#[allow(deprecated)]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Iterator for Recompositions<'a> {
     type Item = char;
@@ -276,7 +284,7 @@ impl<'a> Iterator for Recompositions<'a> {
             match self.state {
                 Composing => {
                     for ch in self.iter.by_ref() {
-                        let ch_class = unicode::char::canonical_combining_class(ch);
+                        let ch_class = rustc_unicode::char::canonical_combining_class(ch);
                         if self.composee.is_none() {
                             if ch_class != 0 {
                                 return Some(ch);
@@ -288,7 +296,7 @@ impl<'a> Iterator for Recompositions<'a> {
 
                         match self.last_ccc {
                             None => {
-                                match unicode::char::compose(k, ch) {
+                                match rustc_unicode::char::compose(k, ch) {
                                     Some(r) => {
                                         self.composee = Some(r);
                                         continue;
@@ -316,7 +324,7 @@ impl<'a> Iterator for Recompositions<'a> {
                                     self.last_ccc = Some(ch_class);
                                     continue;
                                 }
-                                match unicode::char::compose(k, ch) {
+                                match rustc_unicode::char::compose(k, ch) {
                                     Some(r) => {
                                         self.composee = Some(r);
                                         continue;
@@ -465,6 +473,9 @@ impl str {
 
     /// Returns an iterator over the string in Unicode Normalization Form D
     /// (canonical decomposition).
+    #[allow(deprecated)]
+    #[deprecated(reason = "use the crates.io `unicode-normalization` library instead",
+             since = "1.0.0")]
     #[inline]
     #[unstable(feature = "unicode",
                reason = "this functionality may be replaced with a more generic \
@@ -480,6 +491,9 @@ impl str {
 
     /// Returns an iterator over the string in Unicode Normalization Form KD
     /// (compatibility decomposition).
+    #[allow(deprecated)]
+    #[deprecated(reason = "use the crates.io `unicode-normalization` library instead",
+             since = "1.0.0")]
     #[inline]
     #[unstable(feature = "unicode",
                reason = "this functionality may be replaced with a more generic \
@@ -495,6 +509,9 @@ impl str {
 
     /// An Iterator over the string in Unicode Normalization Form C
     /// (canonical decomposition followed by canonical composition).
+    #[allow(deprecated)]
+    #[deprecated(reason = "use the crates.io `unicode-normalization` library instead",
+             since = "1.0.0")]
     #[inline]
     #[unstable(feature = "unicode",
                reason = "this functionality may be replaced with a more generic \
@@ -511,6 +528,9 @@ impl str {
 
     /// An Iterator over the string in Unicode Normalization Form KC
     /// (compatibility decomposition followed by canonical composition).
+    #[allow(deprecated)]
+    #[deprecated(reason = "use the crates.io `unicode-normalization` library instead",
+             since = "1.0.0")]
     #[inline]
     #[unstable(feature = "unicode",
                reason = "this functionality may be replaced with a more generic \
@@ -1690,6 +1710,8 @@ impl str {
     ///
     /// assert_eq!(&gr2[..], b);
     /// ```
+    #[deprecated(reason = "use the crates.io `unicode-segmentation` library instead",
+             since = "1.0.0")]
     #[unstable(feature = "unicode",
                reason = "this functionality may only be provided by libunicode")]
     pub fn graphemes(&self, is_extended: bool) -> Graphemes {
@@ -1709,6 +1731,8 @@ impl str {
     ///
     /// assert_eq!(&gr_inds[..], b);
     /// ```
+    #[deprecated(reason = "use the crates.io `unicode-segmentation` library instead",
+             since = "1.0.0")]
     #[unstable(feature = "unicode",
                reason = "this functionality may only be provided by libunicode")]
     pub fn grapheme_indices(&self, is_extended: bool) -> GraphemeIndices {
@@ -1749,6 +1773,8 @@ impl str {
     /// recommends that these
     /// characters be treated as 1 column (i.e., `is_cjk = false`) if the
     /// locale is unknown.
+    #[deprecated(reason = "use the crates.io `unicode-width` library instead",
+                 since = "1.0.0")]
     #[unstable(feature = "unicode",
                reason = "this functionality may only be provided by libunicode")]
     pub fn width(&self, is_cjk: bool) -> usize {

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -25,8 +25,8 @@ use core::ops::{self, Deref, Add, Index};
 use core::ptr;
 use core::slice;
 use core::str::pattern::Pattern;
-use unicode::str as unicode_str;
-use unicode::str::Utf16Item;
+use rustc_unicode::str as unicode_str;
+use rustc_unicode::str::Utf16Item;
 
 use borrow::{Cow, IntoCow};
 use str::{self, FromStr, Utf8Error};

--- a/src/libcollectionstest/lib.rs
+++ b/src/libcollectionstest/lib.rs
@@ -27,7 +27,7 @@
 
 extern crate collections;
 extern crate test;
-extern crate unicode;
+extern crate rustc_unicode;
 
 #[cfg(test)] #[macro_use] mod bench;
 

--- a/src/libcollectionstest/str.rs
+++ b/src/libcollectionstest/str.rs
@@ -19,6 +19,7 @@ fn test_le() {
     assert!("foo" != "bar");
 }
 
+#[allow(deprecated)]
 #[test]
 fn test_len() {
     assert_eq!("".len(), 0);
@@ -498,7 +499,7 @@ fn test_is_utf8() {
 
 #[test]
 fn test_is_utf16() {
-    use unicode::str::is_utf16;
+    use rustc_unicode::str::is_utf16;
 
     macro_rules! pos {
         ($($e:expr),*) => { { $(assert!(is_utf16($e));)* } }
@@ -944,6 +945,7 @@ fn test_words() {
     assert_eq!(words, ["Märy", "häd", "ä", "little", "lämb", "Little", "lämb"])
 }
 
+#[allow(deprecated)]
 #[test]
 fn test_nfd_chars() {
     macro_rules! t {
@@ -963,6 +965,7 @@ fn test_nfd_chars() {
     t!("\u{ac1c}", "\u{1100}\u{1162}");
 }
 
+#[allow(deprecated)]
 #[test]
 fn test_nfkd_chars() {
     macro_rules! t {
@@ -982,6 +985,7 @@ fn test_nfkd_chars() {
     t!("\u{ac1c}", "\u{1100}\u{1162}");
 }
 
+#[allow(deprecated)]
 #[test]
 fn test_nfc_chars() {
     macro_rules! t {
@@ -1002,6 +1006,7 @@ fn test_nfc_chars() {
     t!("a\u{300}\u{305}\u{315}\u{5ae}b", "\u{e0}\u{5ae}\u{305}\u{315}b");
 }
 
+#[allow(deprecated)]
 #[test]
 fn test_nfkc_chars() {
     macro_rules! t {
@@ -1033,6 +1038,7 @@ fn test_lines() {
     assert_eq!(lines, ["", "Märy häd ä little lämb", "", "Little lämb"]);
 }
 
+#[allow(deprecated)]
 #[test]
 fn test_graphemes() {
     use std::iter::order;
@@ -1629,7 +1635,7 @@ fn test_rev_split_char_iterator_no_trailing() {
 
 #[test]
 fn test_utf16_code_units() {
-    use unicode::str::Utf16Encoder;
+    use rustc_unicode::str::Utf16Encoder;
     assert_eq!(Utf16Encoder::new(vec!['é', '\u{1F4A9}'].into_iter()).collect::<Vec<u16>>(),
                [0xE9, 0xD83D, 0xDCA9])
 }

--- a/src/libcollectionstest/string.rs
+++ b/src/libcollectionstest/string.rs
@@ -135,7 +135,7 @@ fn test_from_utf16() {
         let s_as_utf16 = s.utf16_units().collect::<Vec<u16>>();
         let u_as_string = String::from_utf16(&u).unwrap();
 
-        assert!(::unicode::str::is_utf16(&u));
+        assert!(::rustc_unicode::str::is_utf16(&u));
         assert_eq!(s_as_utf16, u);
 
         assert_eq!(u_as_string, s);

--- a/src/libcore/char.rs
+++ b/src/libcore/char.rs
@@ -10,7 +10,7 @@
 
 //! Character manipulation.
 //!
-//! For more details, see ::unicode::char (a.k.a. std::char)
+//! For more details, see ::rustc_unicode::char (a.k.a. std::char)
 
 #![allow(non_snake_case)]
 #![doc(primitive = "char")]

--- a/src/libcoretest/char.rs
+++ b/src/libcoretest/char.rs
@@ -210,6 +210,7 @@ fn test_len_utf16() {
     assert!('\u{1f4a9}'.len_utf16() == 2);
 }
 
+#[allow(deprecated)]
 #[test]
 fn test_width() {
     assert_eq!('\x00'.width(false),Some(0));

--- a/src/libcoretest/lib.rs
+++ b/src/libcoretest/lib.rs
@@ -32,7 +32,7 @@
 extern crate core;
 extern crate test;
 extern crate libc;
-extern crate unicode;
+extern crate rustc_unicode;
 
 mod any;
 mod atomic;

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -35,7 +35,6 @@
 #![feature(staged_api)]
 #![feature(exit_status)]
 #![feature(set_stdio)]
-#![feature(unicode)]
 
 extern crate arena;
 extern crate flate;
@@ -574,7 +573,7 @@ Available lint options:
     let builtin_groups = sort_lint_groups(builtin_groups);
 
     let max_name_len = plugin.iter().chain(builtin.iter())
-        .map(|&s| s.name.width(true))
+        .map(|&s| s.name.chars().count())
         .max().unwrap_or(0);
     let padded = |x: &str| {
         let mut s = repeat(" ").take(max_name_len - x.chars().count())
@@ -601,7 +600,7 @@ Available lint options:
 
 
     let max_name_len = plugin_groups.iter().chain(builtin_groups.iter())
-        .map(|&(s, _)| s.width(true))
+        .map(|&(s, _)| s.chars().count())
         .max().unwrap_or(0);
     let padded = |x: &str| {
         let mut s = repeat(" ").take(max_name_len - x.chars().count())
@@ -790,7 +789,6 @@ fn parse_crate_attrs(sess: &Session, input: &Input) ->
 ///
 /// The diagnostic emitter yielded to the procedure should be used for reporting
 /// errors of the compiler.
-#[allow(deprecated)]
 pub fn monitor<F:FnOnce()+Send+'static>(f: F) {
     const STACK_SIZE: usize = 8 * 1024 * 1024; // 8MB
 

--- a/src/librustc_unicode/char.rs
+++ b/src/librustc_unicode/char.rs
@@ -37,7 +37,9 @@ use tables::{derived_property, property, general_category, conversions, charwidt
 pub use core::char::{MAX, from_u32, from_digit, EscapeUnicode, EscapeDefault};
 
 // unstable reexports
+#[allow(deprecated)]
 pub use normalize::{decompose_canonical, decompose_compatible, compose};
+#[allow(deprecated)]
 pub use tables::normalization::canonical_combining_class;
 pub use tables::UNICODE_VERSION;
 
@@ -445,6 +447,8 @@ impl char {
     /// [Unicode Standard Annex #11](http://www.unicode.org/reports/tr11/)
     /// recommends that these characters be treated as 1 column (i.e.,
     /// `is_cjk` = `false`) if the context cannot be reliably determined.
+    #[deprecated(reason = "use the crates.io `unicode-width` library instead",
+                 since = "1.0.0")]
     #[unstable(feature = "unicode",
                reason = "needs expert opinion. is_cjk flag stands out as ugly")]
     pub fn width(self, is_cjk: bool) -> Option<usize> { charwidth::width(self, is_cjk) }

--- a/src/librustc_unicode/lib.rs
+++ b/src/librustc_unicode/lib.rs
@@ -22,7 +22,7 @@
 
 // Do not remove on snapshot creation. Needed for bootstrap. (Issue #22364)
 #![cfg_attr(stage0, feature(custom_attribute))]
-#![crate_name = "unicode"]
+#![crate_name = "rustc_unicode"]
 #![unstable(feature = "unicode")]
 #![feature(lang_items)]
 #![feature(staged_api)]

--- a/src/librustc_unicode/normalize.rs
+++ b/src/librustc_unicode/normalize.rs
@@ -33,9 +33,17 @@ fn bsearch_table<T>(c: char, r: &'static [(char, &'static [T])]) -> Option<&'sta
 }
 
 /// Compute canonical Unicode decomposition for character
+#[deprecated(reason = "use the crates.io `unicode-normalization` library instead",
+             since = "1.0.0")]
+#[unstable(feature = "unicode",
+           reason = "this functionality will be moved to crates.io")]
 pub fn decompose_canonical<F>(c: char, mut i: F) where F: FnMut(char) { d(c, &mut i, false); }
 
 /// Compute canonical or compatible Unicode decomposition for character
+#[deprecated(reason = "use the crates.io `unicode-normalization` library instead",
+             since = "1.0.0")]
+#[unstable(feature = "unicode",
+           reason = "this functionality will be moved to crates.io")]
 pub fn decompose_compatible<F>(c: char, mut i: F) where F: FnMut(char) { d(c, &mut i, true); }
 
 // FIXME(#19596) This is a workaround, we should use `F` instead of `&mut F`
@@ -78,6 +86,10 @@ fn d<F>(c: char, i: &mut F, k: bool) where F: FnMut(char) {
     (*i)(c);
 }
 
+#[deprecated(reason = "use the crates.io `unicode-normalization` library instead",
+             since = "1.0.0")]
+#[unstable(feature = "unicode",
+           reason = "this functionality will be moved to crates.io")]
 pub fn compose(a: char, b: char) -> Option<char> {
     compose_hangul(a, b).or_else(|| {
         match bsearch_table(a, composition_table) {

--- a/src/librustc_unicode/tables.rs
+++ b/src/librustc_unicode/tables.rs
@@ -3951,6 +3951,10 @@ pub mod normalization {
         '\u{1d244}', 230), ('\u{1e8d0}', '\u{1e8d6}', 220)
     ];
 
+    #[deprecated(reason = "use the crates.io `unicode-normalization` lib instead",
+                 since = "1.0.0")]
+    #[unstable(feature = "unicode",
+               reason = "this functionality will be moved to crates.io")]
     pub fn canonical_combining_class(c: char) -> u8 {
         bsearch_range_value_table(c, combining_class_table)
     }

--- a/src/librustc_unicode/u_str.rs
+++ b/src/librustc_unicode/u_str.rs
@@ -75,6 +75,7 @@ impl UnicodeStr for str {
     #[inline]
     fn is_alphanumeric(&self) -> bool { self.chars().all(|c| c.is_alphanumeric()) }
 
+    #[allow(deprecated)]
     #[inline]
     fn width(&self, is_cjk: bool) -> usize {
         self.chars().map(|c| c.width(is_cjk).unwrap_or(0)).sum()
@@ -481,9 +482,9 @@ impl<'a> Iterator for Utf16Items<'a> {
 ///
 /// ```
 /// # #![feature(unicode)]
-/// extern crate unicode;
+/// extern crate rustc_unicode;
 ///
-/// use unicode::str::Utf16Item::{ScalarValue, LoneSurrogate};
+/// use rustc_unicode::str::Utf16Item::{ScalarValue, LoneSurrogate};
 ///
 /// fn main() {
 ///     // 𝄞mus<invalid>ic<invalid>
@@ -491,7 +492,7 @@ impl<'a> Iterator for Utf16Items<'a> {
 ///              0x0073, 0xDD1E, 0x0069, 0x0063,
 ///              0xD834];
 ///
-///     assert_eq!(unicode::str::utf16_items(&v).collect::<Vec<_>>(),
+///     assert_eq!(rustc_unicode::str::utf16_items(&v).collect::<Vec<_>>(),
 ///                vec![ScalarValue('𝄞'),
 ///                     ScalarValue('m'), ScalarValue('u'), ScalarValue('s'),
 ///                     LoneSurrogate(0xDD1E),

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -49,7 +49,7 @@ extern crate rustc_back;
 extern crate serialize;
 extern crate syntax;
 extern crate test as testing;
-extern crate unicode;
+extern crate rustc_unicode;
 #[macro_use] extern crate log;
 
 extern crate serialize as rustc_serialize; // used by deriving

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -300,7 +300,7 @@ pub fn maketest(s: &str, cratename: Option<&str>, dont_insert_main: bool,
 }
 
 fn partition_source(s: &str) -> (String, String) {
-    use unicode::str::UnicodeStr;
+    use rustc_unicode::str::UnicodeStr;
 
     let mut after_header = false;
     let mut before = String::new();

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -211,8 +211,8 @@ use std::str::FromStr;
 use std::string;
 use std::{char, f64, fmt, num, str};
 use std;
-use unicode::str as unicode_str;
-use unicode::str::Utf16Item;
+use rustc_unicode::str as unicode_str;
+use rustc_unicode::str::Utf16Item;
 
 use Encodable;
 

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -41,7 +41,7 @@ Core encoding and decoding interfaces.
 #[cfg(test)] extern crate test;
 #[macro_use] extern crate log;
 
-extern crate unicode;
+extern crate rustc_unicode;
 extern crate collections;
 
 pub use self::serialize::{Decoder, Encoder, Decodable, Encodable,

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -13,7 +13,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use cmp;
-use unicode::str as core_str;
+use rustc_unicode::str as core_str;
 use error as std_error;
 use fmt;
 use iter::{self, Iterator, Extend};

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -151,7 +151,7 @@ extern crate collections as core_collections;
 
 #[allow(deprecated)] extern crate rand as core_rand;
 extern crate alloc;
-extern crate unicode;
+extern crate rustc_unicode;
 extern crate libc;
 
 #[macro_use] #[no_link] extern crate rustc_bitflags;
@@ -196,7 +196,7 @@ pub use core_collections::string;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core_collections::vec;
 
-pub use unicode::char;
+pub use rustc_unicode::char;
 
 /* Exported macros */
 

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -44,7 +44,7 @@ use slice;
 use str;
 use string::String;
 use sys_common::AsInner;
-use unicode::str::{Utf16Item, utf16_items};
+use rustc_unicode::str::{Utf16Item, utf16_items};
 use vec::Vec;
 
 const UTF8_REPLACEMENT_CHARACTER: &'static [u8] = b"\xEF\xBF\xBD";

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -595,7 +595,7 @@ fn highlight_lines(err: &mut EmitterWriter,
         let mut s = String::new();
         // Skip is the number of characters we need to skip because they are
         // part of the 'filename:line ' part of the previous line.
-        let skip = fm.name.width(false) + digits + 3;
+        let skip = fm.name.chars().count() + digits + 3;
         for _ in 0..skip {
             s.push(' ');
         }
@@ -615,7 +615,7 @@ fn highlight_lines(err: &mut EmitterWriter,
                         col += 8 - col%8;
                         s.push('\t');
                     },
-                    c => for _ in 0..c.width(false).unwrap_or(0) {
+                    _ => {
                         col += 1;
                         s.push(' ');
                     },
@@ -627,7 +627,7 @@ fn highlight_lines(err: &mut EmitterWriter,
             let count = match lastc {
                 // Most terminals have a tab stop every eight columns by default
                 '\t' => 8 - col%8,
-                _ => lastc.width(false).unwrap_or(0),
+                _ => 1,
             };
             col += count;
             s.extend(::std::iter::repeat('~').take(count));
@@ -638,7 +638,7 @@ fn highlight_lines(err: &mut EmitterWriter,
                     if pos >= hi.col.to_usize() { break; }
                     let count = match ch {
                         '\t' => 8 - col%8,
-                        _ => ch.width(false).unwrap_or(0),
+                        _ => 1,
                     };
                     col += count;
                     s.extend(::std::iter::repeat('~').take(count));
@@ -664,6 +664,7 @@ fn highlight_lines(err: &mut EmitterWriter,
 /// than 6 lines), `end_highlight_lines` will print the first line, then
 /// dot dot dot, then last line, whereas `highlight_lines` prints the first
 /// six lines.
+#[allow(deprecated)]
 fn end_highlight_lines(w: &mut EmitterWriter,
                           cm: &codemap::CodeMap,
                           sp: Span,
@@ -694,7 +695,7 @@ fn end_highlight_lines(w: &mut EmitterWriter,
     }
     let last_line_start = format!("{}:{} ", fm.name, lines[lines.len()-1].line_index + 1);
     let hi = cm.lookup_char_pos(sp.hi);
-    let skip = last_line_start.width(false);
+    let skip = last_line_start.chars().count();
     let mut s = String::new();
     for _ in 0..skip {
         s.push(' ');
@@ -710,9 +711,7 @@ fn end_highlight_lines(w: &mut EmitterWriter,
             // position.
             match ch {
                 '\t' => s.push('\t'),
-                c => for _ in 0..c.width(false).unwrap_or(0) {
-                    s.push(' ');
-                },
+                _ => s.push(' '),
             }
         }
     }

--- a/src/test/run-make/unicode-input/span_length.rs
+++ b/src/test/run-make/unicode-input/span_length.rs
@@ -96,9 +96,12 @@ fn main() {
                                 repeat(" ").take(offset + 7).collect::<String>(),
                                 repeat("~").take(8).collect::<String>());
     assert!(err.contains(&expected_span));
-    // Second snake is 8 ~s long, with 36 preceding spaces
+    // Second snake is only 7 ~s long, with 36 preceding spaces,
+    // because rustc counts chars() now rather than width(). This
+    // is because width() functions are to be removed from
+    // librustc_unicode
     let expected_span = format!("\n{}^{}\n",
                                 repeat(" ").take(offset + 36).collect::<String>(),
-                                repeat("~").take(8).collect::<String>());
+                                repeat("~").take(7).collect::<String>());
     assert!(err.contains(&expected_span));
 }


### PR DESCRIPTION
This patch
1. renames libunicode to librustc_unicode,
2. deprecates several pieces of libunicode (see below), and
3. removes references to deprecated functions from
   librustc_driver and libsyntax. This may change pretty-printed
   output from these modules in cases involving wide or combining
   characters used in filenames, identifiers, etc.

The following functions are marked deprecated:
1. char.width() and str.width():
   --> use unicode-width crate
2. str.graphemes() and str.grapheme_indices():
   --> use unicode-segmentation crate
3. str.nfd_chars(), str.nfkd_chars(), str.nfc_chars(), str.nfkc_chars(),
   char.compose(), char.decompose_canonical(), char.decompose_compatible(),
   char.canonical_combining_class():
   --> use unicode-normalization crate
