### PR TITLE
Trace macros flag

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -606,6 +606,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
           "Force overflow checks on or off"),
     force_dropflag_checks: Option<bool> = (None, parse_opt_bool,
           "Force drop flag checks on or off"),
+    trace_macros: bool = (false, parse_bool,
+          "For every macro invocation, print its name and arguments"),
 }
 
 pub fn default_lib_output() -> CrateType {
@@ -667,7 +669,7 @@ pub fn build_target_config(opts: &Options, sp: &SpanHandler) -> Config {
         Ok(t) => t,
         Err(e) => {
             sp.handler().fatal(&format!("Error loading target specification: {}", e));
-    }
+        }
     };
 
     let (int_type, uint_type) = match &target.target_pointer_width[..] {

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -482,6 +482,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
                 crate_name: crate_name.to_string(),
                 features: Some(&features),
                 recursion_limit: sess.recursion_limit.get(),
+                trace_mac: sess.opt.debugging_opts.trace_macros,
             };
             let ret = syntax::ext::expand::expand_crate(&sess.parse_sess,
                                               cfg,

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -482,7 +482,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
                 crate_name: crate_name.to_string(),
                 features: Some(&features),
                 recursion_limit: sess.recursion_limit.get(),
-                trace_mac: sess.opt.debugging_opts.trace_macros,
+                trace_mac: sess.opts.debugging_opts.trace_macros,
             };
             let ret = syntax::ext::expand::expand_crate(&sess.parse_sess,
                                               cfg,

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -554,7 +554,6 @@ pub struct ExtCtxt<'a> {
     pub use_std: bool,
 
     pub mod_path: Vec<ast::Ident> ,
-    pub trace_mac: bool,
     pub exported_macros: Vec<ast::MacroDef>,
 
     pub syntax_env: SyntaxEnv,
@@ -572,7 +571,6 @@ impl<'a> ExtCtxt<'a> {
             mod_path: Vec::new(),
             ecfg: ecfg,
             use_std: true,
-            trace_mac: false,
             exported_macros: Vec::new(),
             syntax_env: env,
             recursion_count: 0,
@@ -732,10 +730,10 @@ impl<'a> ExtCtxt<'a> {
         self.parse_sess.span_diagnostic.handler().bug(msg);
     }
     pub fn trace_macros(&self) -> bool {
-        self.trace_mac
+        self.ecfg.trace_mac
     }
     pub fn set_trace_macros(&mut self, x: bool) {
-        self.trace_mac = x
+        self.ecfg.trace_mac = x
     }
     pub fn ident_of(&self, st: &str) -> ast::Ident {
         str_to_ident(st)

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1406,6 +1406,7 @@ pub struct ExpansionConfig<'feat> {
     pub crate_name: String,
     pub features: Option<&'feat Features>,
     pub recursion_limit: usize,
+    pub trace_mac: bool,
 }
 
 macro_rules! feature_tests {
@@ -1427,6 +1428,7 @@ impl<'feat> ExpansionConfig<'feat> {
             crate_name: crate_name,
             features: None,
             recursion_limit: 64,
+            trace_mac: false,
         }
     }
 

--- a/src/test/run-make/trace-macros-flag/Makefile
+++ b/src/test/run-make/trace-macros-flag/Makefile
@@ -5,5 +5,5 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) -o $(TMPDIR)/hello -Z trace-macros hello.rs &> $(TMPDIR)/hello.trace
+	$(RUSTC) -Z trace-macros hello.rs &> $(TMPDIR)/hello.trace
 	diff -u $(TMPDIR)/hello.trace hello.trace

--- a/src/test/run-make/trace-macros-flag/Makefile
+++ b/src/test/run-make/trace-macros-flag/Makefile
@@ -5,5 +5,5 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) -Z trace-macros hello.rs &> $(TMPDIR)/hello.out
+	$(RUSTC) -Z trace-macros hello.rs > $(TMPDIR)/hello.out
 	diff -u $(TMPDIR)/hello.out hello.trace

--- a/src/test/run-make/trace-macros-flag/Makefile
+++ b/src/test/run-make/trace-macros-flag/Makefile
@@ -5,5 +5,5 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) -Z trace-macros hello.rs &> $(TMPDIR)/hello.trace
-	diff -u $(TMPDIR)/hello.trace hello.trace
+	$(RUSTC) -Z trace-macros hello.rs &> $(TMPDIR)/hello.out
+	diff -u $(TMPDIR)/hello.out hello.trace

--- a/src/test/run-make/trace-macros-flag/Makefile
+++ b/src/test/run-make/trace-macros-flag/Makefile
@@ -1,0 +1,9 @@
+# This test verifies that "-Z trace-macros"  works as it should. The traditional
+# "hello world" program provides a small example of this as not only println! is
+# listed, but also print! (since println! expands to this)
+
+-include ../tools.mk
+
+all:
+	$(RUSTC) -o $(TMPDIR)/hello -Z trace-macros hello.rs &> $(TMPDIR)/hello.trace
+	diff -u $(TMPDIR)/hello.trace hello.trace

--- a/src/test/run-make/trace-macros-flag/hello.rs
+++ b/src/test/run-make/trace-macros-flag/hello.rs
@@ -1,0 +1,13 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    println!("Hello, World!");
+}

--- a/src/test/run-make/trace-macros-flag/hello.trace
+++ b/src/test/run-make/trace-macros-flag/hello.trace
@@ -1,0 +1,2 @@
+println! { "Hello, World!" }
+print! { concat ! ( "Hello, World!" , "\n" ) }


### PR DESCRIPTION
This is the second attempt at turning the trace_macros macro into a compiler flag.

See #22619
