### PR TITLE
Fix Link to std::ptr::null

### DIFF
--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -15,7 +15,7 @@
 //! Working with unsafe pointers in Rust is uncommon,
 //! typically limited to a few patterns.
 //!
-//! Use the [`null` function](fn.null.html) to create null pointers, and
+//! Use the [`null` function](ptr/fn.null.html) to create null pointers, and
 //! the `is_null` method of the `*const T` type  to check for null.
 //! The `*const T` type also defines the `offset` method, for pointer math.
 //!


### PR DESCRIPTION
The ["Primitive Type pointer"](http://doc.rust-lang.org/nightly/std/primitive.pointer.html) docs link to [`std/fn.null.html`](http://doc.rust-lang.org/nightly/std/fn.null.html) which does not exist.

This changes to link to [`std/ptr/fn.null.html`](http://doc.rust-lang.org/nightly/std/ptr/fn.null.html).
