### PR TITLE
Remove Incorrect Link from std::ptr::null Docs

### DIFF
--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -15,9 +15,9 @@
 //! Working with unsafe pointers in Rust is uncommon,
 //! typically limited to a few patterns.
 //!
-//! Use the [`null` function](fn.null.html) to create null pointers, and
-//! the `is_null` method of the `*const T` type  to check for null.
-//! The `*const T` type also defines the `offset` method, for pointer math.
+//! Use the `null` function to create null pointers, and the `is_null` method
+//! of the `*const T` type  to check for null. The `*const T` type also defines
+//! the `offset` method, for pointer math.
 //!
 //! # Common ways to create unsafe pointers
 //!


### PR DESCRIPTION
The link works on the `std/ptr/index.html` docs page, but not the `std/primitive.pointer.html` page. Instead of leaving it half-broken, it is removed.

I tried fixing this in #24432, but @alexcrichton mentioned that this doc string was used in two places (with different base paths unfortunately).

r? @alexcrichton 
