### PR TITLE
Strip configuration before checking feature gates of macros

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -395,6 +395,9 @@ pub fn phase_2_configure_and_expand(sess: &Session,
     //
     // baz! should not use this definition unless foo is enabled.
 
+    krate = time(time_passes, "configuration 1", krate, |krate|
+                 syntax::config::strip_unconfigured_items(sess.diagnostic(), krate));
+
     time(time_passes, "gated macro checking", (), |_| {
         let features =
             syntax::feature_gate::check_crate_macros(sess.codemap(),
@@ -406,8 +409,6 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         sess.abort_if_errors();
     });
 
-    krate = time(time_passes, "configuration 1", krate, |krate|
-                 syntax::config::strip_unconfigured_items(sess.diagnostic(), krate));
 
     krate = time(time_passes, "crate injection", krate, |krate|
                  syntax::std_inject::maybe_inject_crates_ref(krate,

--- a/src/test/run-pass/issue-24434.rs
+++ b/src/test/run-pass/issue-24434.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags:--cfg set1
+
+#![cfg_attr(set1, feature(custom_attribute))]
+
+#![foobar]
+fn main() {}


### PR DESCRIPTION
closes #24434 

This PR changes executes `syntax::config::strip_unconfigured_items` before `syntax::feature_gate::check_crate_macros(sess.codemap()`. As far as I know, `strip_unconfigured_items` should be independent of `check_crate_macros`.
