### PR TITLE
Rename test option --nocapture to --no-capture

### DIFF
--- a/man/rustc.1
+++ b/man/rustc.1
@@ -253,8 +253,8 @@ The test framework Rust provides executes tests in parallel. This variable sets
 the maximum number of threads used for this purpose.
 
 .TP
-\fBRUST_TEST_NOCAPTURE\fR
-A synonym for the --nocapture flag.
+\fBRUST_TEST_NO_CAPTURE\fR
+A synonym for the --no-capture flag.
 
 .TP
 \fBRUST_MIN_STACK\fR

--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -270,7 +270,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         logfile: config.logfile.clone(),
         run_tests: true,
         bench_benchmarks: true,
-        nocapture: env::var("RUST_TEST_NOCAPTURE").is_ok(),
+        no_capture: env::var("RUST_TEST_NO_CAPTURE").is_ok(),
         color: test::AutoColor,
     }
 }

--- a/src/compiletest/header.rs
+++ b/src/compiletest/header.rs
@@ -131,7 +131,7 @@ pub fn load_props(testfile: &Path) -> TestProps {
         true
     });
 
-    for key in vec!["RUST_TEST_NOCAPTURE", "RUST_TEST_THREADS"] {
+    for key in vec!["RUST_TEST_NO_CAPTURE", "RUST_TEST_THREADS"] {
         match env::var(key) {
             Ok(val) =>
                 if exec_env.iter().find(|&&(ref x, _)| *x == key.to_string()).is_none() {


### PR DESCRIPTION
Rust's built-in unit testing framework supports not capturing the output
of tests. The current flag `--nocapture` is inconsistent with the other
long name options, i.e, they are written in spinal-case (a.k.a.
kebab-case).

Codegen options `no-prepopulate-passes`, `no-vectorize-loops`,
`no-vectorize-slp`, `no-integrated-as`, and `no-redzone` are hyphenated
between "no" and the name. Cargo has `--no-default-features` and
`--no-deps`.

This change renames the test option `--nocapture` to `--no-capture` to
be consistent with Rust's naming of long name options. The ENV variable
`RUST_TEST_NOCAPTURE` is also renamed to `RUST_TEST_NO_CAPTURE`.

Because this is a public facing option, it is a [breaking-change].
