### PR TITLE
Fix link to rustbyexample.com

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -19,7 +19,7 @@ ideas behind Rust.
 donated to the Rust project. As the name implies, it teaches you Rust through a
 series of small examples.
 
-[rbe]: rustbyexample.com
+[rbe]: http://rustbyexample.com/
 
 # Community & Getting Help
 


### PR DESCRIPTION
Use external instead of relative link for rustbyexample.com in generated `src/doc/index.md`. (http://doc.rust-lang.org/nightly/index.html)

Previous: http://doc.rust-lang.org/nightly/rustbyexample.com
Desired: http://rustbyexample.com/
