### PR TITLE
Forbid is/us suffixes. Fixes #22496

### DIFF
--- a/src/librustc_trans/trans/tvec.rs
+++ b/src/librustc_trans/trans/tvec.rs
@@ -361,7 +361,7 @@ fn iter_vec_loop<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
         InBoundsGEP(bcx, data_ptr, &[loop_counter])
     };
     let bcx = f(bcx, lleltptr, vt.unit_ty);
-    let plusone = Add(bcx, loop_counter, C_uint(bcx.ccx(), 1us), DebugLoc::None);
+    let plusone = Add(bcx, loop_counter, C_uint(bcx.ccx(), 1usize), DebugLoc::None);
     AddIncomingToPhi(loop_counter, plusone, bcx.llbb);
 
     let cond_val = ICmp(bcx, llvm::IntULT, plusone, count, DebugLoc::None);

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -714,8 +714,6 @@ pub fn integer_lit(s: &str, suffix: Option<&str>, sd: &SpanHandler, sp: Span) ->
             "u16" => ast::UnsignedIntLit(ast::TyU16),
             "u32" => ast::UnsignedIntLit(ast::TyU32),
             "u64" => ast::UnsignedIntLit(ast::TyU64),
-            "is" => ast::SignedIntLit(ast::TyIs, ast::Plus),
-            "us" => ast::UnsignedIntLit(ast::TyUs),
             _ => {
                 // i<digits> and u<digits> look like widths, so lets
                 // give an error message along those lines

--- a/src/test/compile-fail/lint-type-limits.rs
+++ b/src/test/compile-fail/lint-type-limits.rs
@@ -52,12 +52,12 @@ fn qux() {
 }
 
 fn quy() {
-    let i = -23_us; //~ WARNING negation of unsigned int literal may be unintentional
+    let i = -23_usize; //~ WARNING negation of unsigned int literal may be unintentional
                   //~^ WARNING unused variable
 }
 
 fn quz() {
-    let i = 23_us;
+    let i = 23_usize;
     let j = -i;   //~ WARNING negation of unsigned int variable may be unintentional
                   //~^ WARNING unused variable
 }

--- a/src/test/compile-fail/old-suffixes-are-really-forbidden.rs
+++ b/src/test/compile-fail/old-suffixes-are-really-forbidden.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,19 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![deny(dead_code)]
-
-mod inner {
-    pub trait Trait {
-        fn f(&self) { f(); }
-    }
-
-    impl Trait for isize {}
-
-    fn f() {}
-}
-
-pub fn foo() {
-    let a = &1isize as &inner::Trait;
-    a.f();
+fn main() {
+    let a = 1_is; //~ ERROR illegal suffix
+    let b = 2_us; //~ ERROR illegal suffix
 }

--- a/src/test/run-make/symbols-are-reasonable/lib.rs
+++ b/src/test/run-make/symbols-are-reasonable/lib.rs
@@ -16,5 +16,5 @@ impl Foo for usize {}
 
 pub fn dummy() {
     // force the vtable to be created
-    let _x = &1us as &Foo;
+    let _x = &1usize as &Foo;
 }

--- a/src/test/run-pass/autoderef-method-on-trait.rs
+++ b/src/test/run-pass/autoderef-method-on-trait.rs
@@ -21,6 +21,6 @@ impl double for usize {
 }
 
 pub fn main() {
-    let x: Box<_> = box() (box 3us as Box<double>);
+    let x: Box<_> = box() (box 3usize as Box<double>);
     assert_eq!(x.double(), 6);
 }

--- a/src/test/run-pass/issue-15763.rs
+++ b/src/test/run-pass/issue-15763.rs
@@ -87,12 +87,12 @@ fn main() {
     assert_eq!(cc().unwrap(), 3);
     assert_eq!(dd().unwrap(), 3);
 
-    let i = box 32is as Box<A>;
+    let i = box 32isize as Box<A>;
     assert_eq!(i.aaa(), 3);
-    let i = box 32is as Box<A>;
+    let i = box 32isize as Box<A>;
     assert_eq!(i.bbb(), 3);
-    let i = box 32is as Box<A>;
+    let i = box 32isize as Box<A>;
     assert_eq!(i.ccc().unwrap(), 3);
-    let i = box 32is as Box<A>;
+    let i = box 32isize as Box<A>;
     assert_eq!(i.ddd().unwrap(), 3);
 }


### PR DESCRIPTION
It was an oversight that this was not done in the great int upheaval.

[breaking-change]
