### PR TITLE
Fix Debug impl for RangeFull

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -969,7 +969,7 @@ pub struct RangeFull;
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for RangeFull {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt("..", fmt)
+        write!(fmt, "..")
     }
 }
 


### PR DESCRIPTION
Fix Debug impl for RangeFull

The Debug impl was using quotes, which was inconsistent:

```
=> (.., 1.., 2..3, ..4)
("..", 1.., 2..3, ..4)
```

Fix to use just ..
