### PR TITLE
Fmt flags refactor

### DIFF
--- a/src/libcore/fmt/builders.rs
+++ b/src/libcore/fmt/builders.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use prelude::*;
-use fmt::{self, Write, FlagV1};
+use fmt::{self, Write, FlagV2};
 
 struct PadAdapter<'a, 'b: 'a> {
     fmt: &'a mut fmt::Formatter<'b>,
@@ -110,7 +110,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & (1 << (FlagV1::Alternate as usize)) != 0
+        self.fmt.flags() & FlagV2::Alternate != 0
     }
 }
 
@@ -173,7 +173,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & (1 << (FlagV1::Alternate as usize)) != 0
+        self.fmt.flags() & FlagV2::Alternate != 0
     }
 }
 
@@ -205,7 +205,7 @@ impl<'a, 'b: 'a> DebugInner<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & (1 << (FlagV1::Alternate as usize)) != 0
+        self.fmt.flags() & FlagV2::Alternate != 0
     }
 }
 
@@ -328,6 +328,6 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & (1 << (FlagV1::Alternate as usize)) != 0
+        self.fmt.flags() & FlagV2::Alternate != 0
     }
 }

--- a/src/libcore/fmt/builders.rs
+++ b/src/libcore/fmt/builders.rs
@@ -110,7 +110,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & FlagV2::Alternate != 0
+        self.fmt.flags() & FlagV2::ALTERNATE != 0
     }
 }
 
@@ -173,7 +173,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & FlagV2::Alternate != 0
+        self.fmt.flags() & FlagV2::ALTERNATE != 0
     }
 }
 
@@ -205,7 +205,7 @@ impl<'a, 'b: 'a> DebugInner<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & FlagV2::Alternate != 0
+        self.fmt.flags() & FlagV2::ALTERNATE != 0
     }
 }
 
@@ -328,6 +328,6 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & FlagV2::Alternate != 0
+        self.fmt.flags() & FlagV2::ALTERNATE != 0
     }
 }

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -187,7 +187,10 @@ impl<'a> ArgumentV1<'a> {
 
 #[allow(dead_code)] // SIGN_MINUS isn't currently used
 #[allow(non_snake_case)]
-mod FlagV2 {
+/// A faux enum used for formatting flags.
+///
+/// Public visibility only so that it can be consumed by libfmt_macros
+pub mod FlagV2 {
     pub const SIGN_PLUS             : u32 = 0b00000001;
     pub const SIGN_MINUS            : u32 = 0b00000010;
     pub const ALTERNATE             : u32 = 0b00000100;

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -185,12 +185,13 @@ impl<'a> ArgumentV1<'a> {
     }
 }
 
-#[allow(dead_code)] // SignMinus isn't currently used
+#[allow(dead_code)] // SIGN_MINUS isn't currently used
+#[allow(non_snake_case)]
 mod FlagV2 {
-    pub const SignPlus          : u32 = 0b00000001;
-    pub const SignMinus         : u32 = 0b00000010;
-    pub const Alternate         : u32 = 0b00000100;
-    pub const SignAwareZeroPad  : u32 = 0b00001000;
+    pub const SIGN_PLUS             : u32 = 0b00000001;
+    pub const SIGN_MINUS            : u32 = 0b00000010;
+    pub const ALTERNATE             : u32 = 0b00000100;
+    pub const SIGN_AWARE_ZERO_PAD   : u32 = 0b00001000;
 }
 
 impl<'a> Arguments<'a> {
@@ -444,7 +445,7 @@ impl<'a> Formatter<'a> {
     /// # Arguments
     ///
     /// * is_positive - whether the original integer was positive or not.
-    /// * prefix - if the '#' character (Alternate) is provided, this
+    /// * prefix - if the '#' character (ALTERNATE) is provided, this
     ///   is the prefix to put in front of the number.
     /// * buf - the byte array that the number has been formatted into
     ///
@@ -463,12 +464,12 @@ impl<'a> Formatter<'a> {
         let mut sign = None;
         if !is_positive {
             sign = Some('-'); width += 1;
-        } else if self.flags & FlagV2::SignPlus != 0 {
+        } else if self.flags & FlagV2::SIGN_PLUS != 0 {
             sign = Some('+'); width += 1;
         }
 
         let mut prefixed = false;
-        if self.flags & FlagV2::Alternate != 0 {
+        if self.flags & FlagV2::ALTERNATE != 0 {
             prefixed = true; width += prefix.char_len();
         }
 
@@ -498,7 +499,7 @@ impl<'a> Formatter<'a> {
             }
             // The sign and prefix goes before the padding if the fill character
             // is zero
-            Some(min) if self.flags & FlagV2::SignAwareZeroPad != 0 => {
+            Some(min) if self.flags & FlagV2::SIGN_AWARE_ZERO_PAD != 0 => {
                 self.fill = '0';
                 try!(write_prefix(self));
                 self.with_padding(min - width, Alignment::Right, |f| {
@@ -864,8 +865,8 @@ impl<T> Pointer for *const T {
         // it denotes whether to prefix with 0x. We use it to work out whether
         // or not to zero extend, and then unconditionally set it to get the
         // prefix.
-        if f.flags & FlagV2::Alternate > 0 {
-            f.flags |= FlagV2::SignAwareZeroPad;
+        if f.flags & FlagV2::ALTERNATE > 0 {
+            f.flags |= FlagV2::SIGN_AWARE_ZERO_PAD;
 
             if let None = f.width {
                 // The formats need two extra bytes, for the 0x
@@ -876,7 +877,7 @@ impl<T> Pointer for *const T {
                 }
             }
         }
-        f.flags |= FlagV2::Alternate;
+        f.flags |= FlagV2::ALTERNATE;
 
         let ret = LowerHex::fmt(&(*self as usize), f);
 

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -185,11 +185,12 @@ impl<'a> ArgumentV1<'a> {
     }
 }
 
+// A faux enum used for formatting flags.
+//
+// Public visibility only so that it can be consumed by libfmt_macros
+#[doc(hidden)]
 #[allow(dead_code)] // SIGN_MINUS isn't currently used
 #[allow(non_snake_case)]
-/// A faux enum used for formatting flags.
-///
-/// Public visibility only so that it can be consumed by libfmt_macros
 pub mod FlagV2 {
     pub const SIGN_PLUS             : u32 = 0b00000001;
     pub const SIGN_MINUS            : u32 = 0b00000010;

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -28,6 +28,9 @@
 
 #![feature(staged_api)]
 #![feature(unicode)]
+#![feature(core)]
+
+extern crate core;
 
 pub use self::Piece::*;
 pub use self::Position::*;
@@ -37,7 +40,7 @@ pub use self::Count::*;
 
 use std::str;
 use std::string;
-use std::fmt::FlagV2;
+use core::fmt::FlagV2;
 
 /// A piece is a portion of the format string which represents the next part
 /// to emit. These are emitted as a stream by the `Parser` class.
@@ -108,15 +111,15 @@ pub enum Alignment {
 #[repr(C)]
 pub enum Flag {
     /// A `+` will be used to denote positive numbers.
-    FlagSignPlus = FlagV2::SIGN_PLUS,
+    FlagSignPlus = FlagV2::SIGN_PLUS as isize,
     /// A `-` will be used to denote negative numbers. This is the default.
-    FlagSignMinus = FlagV2::SIGN_MINUS,
+    FlagSignMinus = FlagV2::SIGN_MINUS as isize,
     /// An alternate form will be used for the value. In the case of numbers,
     /// this means that the number will be prefixed with the supplied string.
-    FlagAlternate = FlagV2::ALTERNATE,
+    FlagAlternate = FlagV2::ALTERNATE as isize,
     /// For numbers, this means that the number will be padded with zeroes,
     /// and the sign (`+` or `-`) will precede them.
-    FlagSignAwareZeroPad = FlagV2::SIGN_AWARE_ZERO_PAD,
+    FlagSignAwareZeroPad = FlagV2::SIGN_AWARE_ZERO_PAD as isize,
 }
 
 /// A count is used for the precision and width parameters of an integer, and
@@ -317,13 +320,13 @@ impl<'a> Parser<'a> {
         }
         // Sign flags
         if self.consume('+') {
-            spec.flags |= FlagSignPlus;
+            spec.flags |= FlagSignPlus as u32;
         } else if self.consume('-') {
-            spec.flags |= FlagSignMinus;
+            spec.flags |= FlagSignMinus as u32;
         }
         // Alternate marker
         if self.consume('#') {
-            spec.flags |= FlagAlternate;
+            spec.flags |= FlagAlternate as u32;
         }
         // Width and precision
         let mut havewidth = false;
@@ -336,7 +339,7 @@ impl<'a> Parser<'a> {
                 spec.width = CountIsParam(0);
                 havewidth = true;
             } else {
-                spec.flags |= FlagSignAwareZeroPad;
+                spec.flags |= FlagSignAwareZeroPad as u32;
             }
         }
         if !havewidth {

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -37,6 +37,7 @@ pub use self::Count::*;
 
 use std::str;
 use std::string;
+use std::fmt::FlagV2;
 
 /// A piece is a portion of the format string which represents the next part
 /// to emit. These are emitted as a stream by the `Parser` class.
@@ -104,17 +105,18 @@ pub enum Alignment {
 /// Various flags which can be applied to format strings. The meaning of these
 /// flags is defined by the formatters themselves.
 #[derive(Copy, Clone, PartialEq)]
+#[repr(C)]
 pub enum Flag {
     /// A `+` will be used to denote positive numbers.
-    FlagSignPlus,
+    FlagSignPlus = FlagV2::SIGN_PLUS,
     /// A `-` will be used to denote negative numbers. This is the default.
-    FlagSignMinus,
+    FlagSignMinus = FlagV2::SIGN_MINUS,
     /// An alternate form will be used for the value. In the case of numbers,
     /// this means that the number will be prefixed with the supplied string.
-    FlagAlternate,
+    FlagAlternate = FlagV2::ALTERNATE,
     /// For numbers, this means that the number will be padded with zeroes,
     /// and the sign (`+` or `-`) will precede them.
-    FlagSignAwareZeroPad,
+    FlagSignAwareZeroPad = FlagV2::SIGN_AWARE_ZERO_PAD,
 }
 
 /// A count is used for the precision and width parameters of an integer, and
@@ -315,13 +317,13 @@ impl<'a> Parser<'a> {
         }
         // Sign flags
         if self.consume('+') {
-            spec.flags |= 1 << (FlagSignPlus as u32);
+            spec.flags |= FlagSignPlus;
         } else if self.consume('-') {
-            spec.flags |= 1 << (FlagSignMinus as u32);
+            spec.flags |= FlagSignMinus;
         }
         // Alternate marker
         if self.consume('#') {
-            spec.flags |= 1 << (FlagAlternate as u32);
+            spec.flags |= FlagAlternate;
         }
         // Width and precision
         let mut havewidth = false;
@@ -334,7 +336,7 @@ impl<'a> Parser<'a> {
                 spec.width = CountIsParam(0);
                 havewidth = true;
             } else {
-                spec.flags |= 1 << (FlagSignAwareZeroPad as u32);
+                spec.flags |= FlagSignAwareZeroPad;
             }
         }
         if !havewidth {
@@ -618,7 +620,7 @@ mod tests {
             format: FormatSpec {
                 fill: None,
                 align: AlignUnknown,
-                flags: (1 << FlagSignMinus as u32),
+                flags: FlagSignMinus,
                 precision: CountImplied,
                 width: CountImplied,
                 ty: "",
@@ -629,7 +631,7 @@ mod tests {
             format: FormatSpec {
                 fill: None,
                 align: AlignUnknown,
-                flags: (1 << FlagSignPlus as u32) | (1 << FlagAlternate as u32),
+                flags: FlagSignPlus | FlagAlternate,
                 precision: CountImplied,
                 width: CountImplied,
                 ty: "",


### PR DESCRIPTION
While implementing the fmt::Pointer traits, needing to awkwardly bitshift the variants of an enum everywhere irked me as being very awkward. Considering these values are never passed as arguments, it's not like their membership in the enum actually grants any type safety.

bitflags is not available in core, so I manually created the bitflags. This shouldn't break existing code, since they're not exported, but it seems that they should be, since there doesn't appear to be a blessed way to test for, eg the alternate flag in a formatter in user code.
