### PR TITLE
Check for overflow in arithmetic negation

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1321,7 +1321,11 @@ macro_rules! int_impl {
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
         pub fn abs(self) -> $T {
-            if self.is_negative() { -self } else { self }
+            if self.is_negative() {
+                self.wrapping_neg()
+            } else {
+                self
+            }
         }
 
         /// Returns a number representing sign of `self`.

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1540,7 +1540,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
             F64Value(res)
         } else {
             if neg {
-                let res = -(res as i64);
+                let res = (res as i64).wrapping_neg();
 
                 // Make sure we didn't underflow.
                 if res > 0 {

--- a/src/test/run-fail/overflowing-neg.rs
+++ b/src/test/run-fail/overflowing-neg.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:thread '<main>' panicked at 'attempted to negate with overflow'
+// compile-flags: -C debug-assertions
+
+// (Work around constant-evaluation)
+fn value() -> i8 { std::i8::MIN }
+
+fn main() {
+    let _x = -value();
+}


### PR DESCRIPTION
Add conditional overflow-checking to signed negate operator.

I argue this can land independently of #24420 , because one can write the implementation of `wrapped_neg()` inline if necessary (as illustrated in two cases on this PR).

[breaking-change]

If you are relying on the prior behavior of negate on `Integer::MIN_VALUE`, use the `wrapping_neg`  method instead.

This needs to go into beta channel.
