### PR TITLE
Fix broken links in the docs

### DIFF
--- a/src/doc/complement-design-faq.md
+++ b/src/doc/complement-design-faq.md
@@ -56,7 +56,7 @@ Types which are [`Sync`][sync] are thread-safe when multiple shared
 references to them are used concurrently. Types which are not `Sync` are not
 thread-safe, and thus when used in a global require unsafe code to use.
 
-[sync]: core/kinds/trait.Sync.html
+[sync]: core/marker/trait.Sync.html
 
 ### If mutable static items that implement `Sync` are safe, why is taking &mut SHARABLE unsafe?
 
@@ -139,7 +139,7 @@ and explicitly calling the `clone` method. Making user-defined copy operators
 explicit surfaces the underlying complexity, forcing the developer to opt-in
 to potentially expensive operations.
 
-[copy]: core/kinds/trait.Copy.html
+[copy]: core/marker/trait.Copy.html
 [clone]: core/clone/trait.Clone.html
 
 ## No move constructors

--- a/src/doc/trpl/closures.md
+++ b/src/doc/trpl/closures.md
@@ -205,11 +205,11 @@ you tons of control over what your code does, and closures are no different.
 
 Rust's implementation of closures is a bit different than other languages. They
 are effectively syntax sugar for traits. You'll want to make sure to have read
-the [traits chapter][traits] before this one, as well as the chapter on [static
-and dynamic dispatch][dispatch], which talks about trait objects.
+the [traits chapter][traits] before this one, as well as the chapter on [trait
+objects][trait-objects].
 
 [traits]: traits.html
-[dispatch]: static-and-dynamic-dispatch.html
+[trait-objects]: trait-objects.html
 
 Got all that? Good.
 

--- a/src/libcore/raw.rs
+++ b/src/libcore/raw.rs
@@ -71,11 +71,11 @@ impl<T> Clone for Slice<T> {
 /// The representation of a trait object like `&SomeTrait`.
 ///
 /// This struct has the same layout as types like `&SomeTrait` and
-/// `Box<AnotherTrait>`. The [Static and Dynamic Dispatch chapter of the
+/// `Box<AnotherTrait>`. The [Trait Objects chapter of the
 /// Book][moreinfo] contains more details about the precise nature of
 /// these internals.
 ///
-/// [moreinfo]: ../../book/static-and-dynamic-dispatch.html#representation
+/// [moreinfo]: ../../book/trait-objects.html#representation
 ///
 /// `TraitObject` is guaranteed to match layouts, but it is not the
 /// type of trait objects (e.g. the fields are not directly accessible

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -86,12 +86,12 @@
 //! useful value.
 //!
 //! Consider the `write_all` method defined for I/O types
-//! by the [`Write`](../io/trait.Write.html) trait:
+//! by the [`Write`](../../std/io/trait.Write.html) trait:
 //!
 //! ```
 //! use std::io;
 //!
-//! trait Writer {
+//! trait Write {
 //!     fn write_all(&mut self, bytes: &[u8]) -> Result<(), io::Error>;
 //! }
 //! ```

--- a/src/librustc/plugin/mod.rs
+++ b/src/librustc/plugin/mod.rs
@@ -47,7 +47,7 @@
 //! #![plugin(myplugin)]
 //! ```
 //!
-//! See the [Plugins Chapter](../../book/plugins.html) of the book
+//! See the [Plugins Chapter](../../book/compiler-plugins.html) of the book
 //! for more examples.
 
 pub use self::registry::Registry;


### PR DESCRIPTION
Fix broken links in various parts of the docs.
I also found a dead link [here](http://doc.rust-lang.org/nightly/alloc/boxed/) (the first link on the page), but the chapter of the book that it used to point at seems to be gone, and I'm not sure what should happen to that link.
