### PR TITLE
Suppress improper_ctypes warnings when compiling liballoc with external_features

### DIFF
--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -133,6 +133,7 @@ const MIN_ALIGN: usize = 16;
 
 #[cfg(feature = "external_funcs")]
 mod imp {
+    #[allow(improper_ctypes)]
     extern {
         fn rust_allocate(size: usize, align: usize) -> *mut u8;
         fn rust_deallocate(ptr: *mut u8, old_size: usize, align: usize);


### PR DESCRIPTION
When `liballoc` is compiled with `--cfg feature=\"external_features\"`, several `improper_ctypes` warnings are generated. Since these warnings are harmless, I have added a directive to suppress them.
