### PR TITLE
Call write_fmt directly to format an Arguments value.

### DIFF
--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -443,6 +443,6 @@ use string;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn format(args: Arguments) -> string::String {
     let mut output = string::String::new();
-    let _ = write!(&mut output, "{}", args);
+    let _ = output.write_fmt(args);
     output
 }

--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -504,7 +504,7 @@ pub fn begin_unwind_fmt(msg: fmt::Arguments, file_line: &(&'static str, u32)) ->
     // below).
 
     let mut s = String::new();
-    let _ = write!(&mut s, "{}", msg);
+    let _ = s.write_fmt(msg);
     begin_unwind_inner(Box::new(s), file_line)
 }
 

--- a/src/libstd/rt/util.rs
+++ b/src/libstd/rt/util.rs
@@ -65,7 +65,7 @@ pub const ENFORCE_SANITY: bool = true || !cfg!(rtopt) || cfg!(rtdebug) ||
                                   cfg!(rtassert);
 
 pub fn dumb_print(args: fmt::Arguments) {
-    let _ = write!(&mut Stderr::new(), "{}", args);
+    let _ = Stderr::new().write_fmt(args);
 }
 
 pub fn abort(args: fmt::Arguments) -> ! {


### PR DESCRIPTION
It's just as convenient, but it's much faster. Using write! requires an
extra call to fmt::write and a extra dynamically dispatched call to
Arguments' Display format function.
