### PR TITLE
Make a shallow clone of git submodules

### DIFF
--- a/configure
+++ b/configure
@@ -1171,7 +1171,7 @@ then
     fi
 
     msg "git: submodule update"
-    "${CFG_GIT}" submodule update
+    "${CFG_GIT}" submodule update --depth 1
     need_ok "git failed"
 
     msg "git: submodule foreach sync"


### PR DESCRIPTION
When building from source, the build system makes a deep clone of LLVM and other dependencies, downloading several hundred megabytes, which takes a significant time over a slow connection. A shallow clone (done with `git submodule update --depth 1`, see http://stackoverflow.com/a/17692710/2754323 ) would only download the latest revision of the dependencies, since the rest of the commit history is not needed, and save bandwidth and space at no (as far as I know) cost.
