### PR TITLE
std::rand::os: Fix race condition of atomics

### DIFF
--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -97,25 +97,24 @@ mod imp {
                   target_arch = "powerpc")))]
     fn is_getrandom_available() -> bool {
         use sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
+        use sync::{Once, ONCE_INIT};
 
-        static GETRANDOM_CHECKED: AtomicBool = ATOMIC_BOOL_INIT;
-        static GETRANDOM_AVAILABLE: AtomicBool = ATOMIC_BOOL_INIT;
+        static CHECKER: Once = ONCE_INIT;
+        static AVAILABLE: AtomicBool = ATOMIC_BOOL_INIT;
 
-        if !GETRANDOM_CHECKED.load(Ordering::Relaxed) {
+        CHECKER.call_once(|| {
             let mut buf: [u8; 0] = [];
             let result = getrandom(&mut buf);
             let available = if result == -1 {
-                let err = errno() as libc::c_int;
-                err != libc::ENOSYS
+                let err = io::Error::last_os_error().raw_os_error();
+                err != Some(libc::ENOSYS)
             } else {
                 true
             };
-            GETRANDOM_AVAILABLE.store(available, Ordering::Relaxed);
-            GETRANDOM_CHECKED.store(true, Ordering::Relaxed);
-            available
-        } else {
-            GETRANDOM_AVAILABLE.load(Ordering::Relaxed)
-        }
+            AVAILABLE.store(available, Ordering::Relaxed);
+        });
+
+        AVAILABLE.load(Ordering::Relaxed)
     }
 
     #[cfg(not(all(target_os = "linux",


### PR DESCRIPTION
Fixes #21538.
