### PR TITLE
Updating installing-rust.md - add `ldconfig` workaround on install

### DIFF
--- a/src/doc/trpl/installing-rust.md
+++ b/src/doc/trpl/installing-rust.md
@@ -86,7 +86,19 @@ read it offline. On UNIX systems, `/usr/local/share/doc/rust` is the location.
 On Windows, it's in a `share/doc` directory, inside wherever you installed Rust
 to.
 
-If not, there are a number of places where you can get help. The easiest is
+If not, but you saw this error:
+
+```
+rustc: error while loading shared libraries: librustc_driver-4e7c5e5c.so: cannot open shared object file: No such file or directory
+```
+
+You can fix it by running:
+
+```
+sudo ldconfig
+```
+
+Otherwise, there are a number of places where you can get help. The easiest is
 [the #rust IRC channel on irc.mozilla.org][irc], which you can access through
 [Mibbit][mibbit]. Click that link, and you'll be chatting with other Rustaceans
 (a silly nickname we call ourselves), and we can help you out. Other great


### PR DESCRIPTION
Add a workaround for the error (I twice personally have) observed when following the installation instructions:

```
nelo@HP-EliteBook-8540w:~$ curl -sf -L https://static.rust-lang.org/rustup.sh | sudo sh
[sudo] password for nelo: 
rustup: gpg available. signatures will be verified
rustup: downloading manifest for 'beta'
gpg: WARNING: unsafe ownership on configuration file `/home/nelo/.gnupg/gpg.conf'
rustup: downloading toolchain for 'beta'
######################################################################## 100.0%
gpg: WARNING: unsafe ownership on configuration file `/home/nelo/.gnupg/gpg.conf'
gpg: WARNING: unsafe ownership on configuration file `/home/nelo/.gnupg/gpg.conf'
gpg: Signature made Fri 17 Apr 2015 04:07:37 BST using RSA key ID 7B3B09DC
gpg: Good signature from "Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>"
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 108F 6620 5EAE B0AA A8DD  5E1C 85AB 96E6 FA1B E5FE
     Subkey fingerprint: C134 66B7 E169 A085 1886  3216 5CB4 A934 7B3B 09DC
rustup: extracting installer
rustup: installing toolchain for 'beta'
install: creating uninstall script at /usr/local/lib/rustlib/uninstall.sh
install: installing component 'rustc'
install: installing component 'cargo'
install: installing component 'rust-docs'

    Rust is ready to roll.

nelo@HP-EliteBook-8540w:~$ rustc --version
rustc: error while loading shared libraries: librustc_driver-4e7c5e5c.so: cannot open shared object file: No such file or directory
nelo@HP-EliteBook-8540w:~$ sudo ldconfig
nelo@HP-EliteBook-8540w:~$ rustc --version
rustc 1.0.0-beta.2 (e9080ec39 2015-04-16) (built 2015-04-16)
nelo@HP-EliteBook-8540w:~$ uname -a
Linux HP-EliteBook-8540w 3.13.0-49-generic #83-Ubuntu SMP Fri Apr 10 20:11:33 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux
```

A better fix would be to work out why we _appear_ to need to run `ldconfig` before the install works. If you agree then perhaps this can be changed into an issue and the docs left alone?
