### PR TITLE
Fix parallel `make check`

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -753,19 +753,21 @@ PRETTY_DEPS_pretty-rpass-full = $(RPASS_FULL_TESTS)
 PRETTY_DEPS_pretty-rfail = $(RFAIL_TESTS)
 PRETTY_DEPS_pretty-bench = $(BENCH_TESTS)
 PRETTY_DEPS_pretty-pretty = $(PRETTY_TESTS)
-# The stage- and host-specific dependencies are for e.g. macro_crate_test which pulls in
-# external crates.
-PRETTY_DEPS$(1)_H_$(3)_pretty-rpass =
-PRETTY_DEPS$(1)_H_$(3)_pretty-rpass-full = $$(HLIB$(1)_H_$(3))/stamp.syntax $$(HLIB$(1)_H_$(3))/stamp.rustc
-PRETTY_DEPS$(1)_H_$(3)_pretty-rfail =
-PRETTY_DEPS$(1)_H_$(3)_pretty-bench =
-PRETTY_DEPS$(1)_H_$(3)_pretty-pretty =
 PRETTY_DIRNAME_pretty-rpass = run-pass
 PRETTY_DIRNAME_pretty-rpass-valgrind = run-pass-valgrind
 PRETTY_DIRNAME_pretty-rpass-full = run-pass-fulldeps
 PRETTY_DIRNAME_pretty-rfail = run-fail
 PRETTY_DIRNAME_pretty-bench = bench
 PRETTY_DIRNAME_pretty-pretty = pretty
+
+define DEF_PRETTY_FULLDEPS
+PRETTY_DEPS$(1)_T_$(2)_H_$(3)_pretty-rpass-full = $$(CSREQ$(1)_T_$(3)_H_$(3))
+endef
+
+$(foreach host,$(CFG_HOST), \
+ $(foreach target,$(CFG_TARGET), \
+  $(foreach stage,$(STAGES), \
+   $(eval $(call DEF_PRETTY_FULLDEPS,$(stage),$(target),$(host))))))
 
 define DEF_RUN_PRETTY_TEST
 
@@ -780,7 +782,7 @@ check-stage$(1)-T-$(2)-H-$(3)-$(4)-exec: $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4
 $$(call TEST_OK_FILE,$(1),$(2),$(3),$(4)): \
 	        $$(TEST_SREQ$(1)_T_$(2)_H_$(3)) \
 	        $$(PRETTY_DEPS_$(4)) \
-	        $$(PRETTY_DEPS$(1)_H_$(3)_$(4))
+	        $$(PRETTY_DEPS$(1)_T_$(2)_H_$(3)_$(4))
 	@$$(call E, run pretty-rpass [$(2)]: $$<)
 	$$(Q)touch $$@.start_time
 	$$(Q)$$(call CFG_RUN_CTEST_$(2),$(1),$$<,$(3)) \

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -1452,7 +1452,7 @@ fn make_out_name(config: &Config, testfile: &Path, extension: &str) -> PathBuf {
 fn aux_output_dir_name(config: &Config, testfile: &Path) -> PathBuf {
     let f = output_base_name(config, testfile);
     let mut fname = f.file_name().unwrap().to_os_string();
-    fname.push("libaux");
+    fname.push(&format!(".{}.libaux", config.mode));
     f.with_file_name(&fname)
 }
 

--- a/src/test/compile-fail-fulldeps/macro-crate-rlib.rs
+++ b/src/test/compile-fail-fulldeps/macro-crate-rlib.rs
@@ -11,7 +11,6 @@
 // aux-build:rlib_crate_test.rs
 // ignore-stage1
 // ignore-tidy-linelength
-// ignore-android
 // ignore-cross-compile gives a different error message
 
 #![feature(plugin)]

--- a/src/test/run-make/simd-ffi/Makefile
+++ b/src/test/run-make/simd-ffi/Makefile
@@ -27,7 +27,8 @@ define MK_TARGETS
 # on some platforms, but LLVM just prints a warning so that's fine for
 # now.
 $(1): simd.rs
-	$$(RUSTC) --target=$(1) --emit=llvm-ir,asm simd.rs -C target-feature='+neon,+sse2'
+	$$(RUSTC) --target=$(1) --emit=llvm-ir,asm simd.rs \
+                -C target-feature='+neon,+sse2' -C extra-filename=-$(1)
 endef
 
 $(foreach targetxxx,$(TARGETS),$(eval $(call MK_TARGETS,$(targetxxx))))

--- a/src/test/run-pass-fulldeps/compiler-calls.rs
+++ b/src/test/run-pass-fulldeps/compiler-calls.rs
@@ -10,7 +10,7 @@
 
 // Test that the CompilerCalls interface to the compiler works.
 
-// ignore-android
+// ignore-cross-compile
 
 #![feature(rustc_private, path)]
 #![feature(core)]

--- a/src/test/run-pass-fulldeps/create-dir-all-bare.rs
+++ b/src/test/run-pass-fulldeps/create-dir-all-bare.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-android
+// ignore-cross-compile
 
 #![feature(rustc_private)]
 

--- a/src/test/run-pass-fulldeps/issue-15149.rs
+++ b/src/test/run-pass-fulldeps/issue-15149.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // no-prefer-dynamic
-// ignore-android
+// ignore-cross-compile
 
 #![feature(rustc_private)]
 

--- a/src/test/run-pass-fulldeps/issue-16992.rs
+++ b/src/test/run-pass-fulldeps/issue-16992.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // ignore-pretty
-// ignore-android
+// ignore-cross-compile
 
 #![feature(quote, rustc_private)]
 

--- a/src/test/run-pass-fulldeps/issue-18763-quote-token-tree.rs
+++ b/src/test/run-pass-fulldeps/issue-18763-quote-token-tree.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-android
+// ignore-cross-compile
 // ignore-pretty: does not work well with `--test`
 
 #![feature(quote, rustc_private)]

--- a/src/test/run-pass-fulldeps/qquote.rs
+++ b/src/test/run-pass-fulldeps/qquote.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-cross-compile
 // ignore-pretty
 // ignore-test
 

--- a/src/test/run-pass-fulldeps/quote-tokens.rs
+++ b/src/test/run-pass-fulldeps/quote-tokens.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-android
+// ignore-cross-compile
 // ignore-pretty: does not work well with `--test`
 
 #![feature(quote, rustc_private)]

--- a/src/test/run-pass-fulldeps/quote-unused-sp-no-warning.rs
+++ b/src/test/run-pass-fulldeps/quote-unused-sp-no-warning.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-android
+// ignore-cross-compile
 // ignore-pretty: does not work well with `--test`
 
 #![feature(quote, rustc_private)]

--- a/src/test/run-pass-fulldeps/rename-directory.rs
+++ b/src/test/run-pass-fulldeps/rename-directory.rs
@@ -11,7 +11,7 @@
 // This test can't be a unit test in std,
 // because it needs TempDir, which is in extra
 
-// ignore-android
+// ignore-cross-compile
 
 #![feature(rustc_private, path_ext)]
 

--- a/src/test/rustdoc/default-impl.rs
+++ b/src/test/rustdoc/default-impl.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:rustdoc-default-impl.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate rustdoc_default_impl as foo;
 

--- a/src/test/rustdoc/extern-default-method.rs
+++ b/src/test/rustdoc/extern-default-method.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:rustdoc-extern-default-method.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate rustdoc_extern_default_method as ext;
 

--- a/src/test/rustdoc/extern-method.rs
+++ b/src/test/rustdoc/extern-method.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:rustdoc-extern-method.rs
-// ignore-android
+// ignore-cross-compile
 
 #![feature(unboxed_closures)]
 

--- a/src/test/rustdoc/ffi.rs
+++ b/src/test/rustdoc/ffi.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:rustdoc-ffi.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate rustdoc_ffi as lib;
 

--- a/src/test/rustdoc/inline-default-methods.rs
+++ b/src/test/rustdoc/inline-default-methods.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:inline-default-methods.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate inline_default_methods;
 

--- a/src/test/rustdoc/issue-13698.rs
+++ b/src/test/rustdoc/issue-13698.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-13698.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate issue_13698;
 

--- a/src/test/rustdoc/issue-15318-2.rs
+++ b/src/test/rustdoc/issue-15318-2.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-15318.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate issue_15318;
 

--- a/src/test/rustdoc/issue-15318.rs
+++ b/src/test/rustdoc/issue-15318.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-15318.rs
-// ignore-android
+// ignore-cross-compile
 
 #![feature(no_std)]
 #![no_std]

--- a/src/test/rustdoc/issue-17476.rs
+++ b/src/test/rustdoc/issue-17476.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-17476.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate issue_17476;
 

--- a/src/test/rustdoc/issue-19190-3.rs
+++ b/src/test/rustdoc/issue-19190-3.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-19190-3.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate issue_19190_3;
 

--- a/src/test/rustdoc/issue-20646.rs
+++ b/src/test/rustdoc/issue-20646.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-20646.rs
-// ignore-android
+// ignore-cross-compile
 
 #![feature(associated_types)]
 

--- a/src/test/rustdoc/issue-20727-2.rs
+++ b/src/test/rustdoc/issue-20727-2.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-20727.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate issue_20727;
 

--- a/src/test/rustdoc/issue-20727-3.rs
+++ b/src/test/rustdoc/issue-20727-3.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-20727.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate issue_20727;
 

--- a/src/test/rustdoc/issue-20727-4.rs
+++ b/src/test/rustdoc/issue-20727-4.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-20727.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate issue_20727;
 

--- a/src/test/rustdoc/issue-20727.rs
+++ b/src/test/rustdoc/issue-20727.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-20727.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate issue_20727;
 

--- a/src/test/rustdoc/issue-21092.rs
+++ b/src/test/rustdoc/issue-21092.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-21092.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate issue_21092;
 

--- a/src/test/rustdoc/issue-21801.rs
+++ b/src/test/rustdoc/issue-21801.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-21801.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate issue_21801;
 

--- a/src/test/rustdoc/issue-22025.rs
+++ b/src/test/rustdoc/issue-22025.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue-22025.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate issue_22025;
 

--- a/src/test/rustdoc/issue-23207.rs
+++ b/src/test/rustdoc/issue-23207.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-23207-1.rs
 // aux-build:issue-23207-2.rs
-// ignore-android
+// ignore-cross-compile
 
 extern crate issue_23207_2;
 


### PR DESCRIPTION
This required fixing the `pretty-rpass-full` tests to have the same `$$(CSREQ$(1)_T_$(2)_H_$(3))`  dependencies as the `rpass-full` and `cfail-full` tests.  It also required fixing the `run-make/simd-ffi` test to use unique names for its output files.
