### PR TITLE
Lint non-snake-case crate names

### DIFF
--- a/src/test/compile-fail/lint-non-snake-case-crate-2.rs
+++ b/src/test/compile-fail/lint-non-snake-case-crate-2.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --crate-name NonSnakeCase
+// error-pattern: crate `NonSnakeCase` should have a snake case name such as `non_snake_case`
+
+#![deny(non_snake_case)]
+
+fn main() {}

--- a/src/test/compile-fail/lint-non-snake-case-crate.rs
+++ b/src/test/compile-fail/lint-non-snake-case-crate.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_name = "NonSnakeCase"]
+//~^ ERROR crate `NonSnakeCase` should have a snake case name such as `non_snake_case`
+#![deny(non_snake_case)]
+
+fn main() {}


### PR DESCRIPTION
Passing a non-snake-case name to `#![crate_name]` or `--crate-name` will now yield a warning from the `non_snake_case` lint.
