### PR TITLE
rustdoc: don't inject "extern crate std;"

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -277,7 +277,7 @@ pub fn maketest(s: &str, cratename: Option<&str>, dont_insert_main: bool,
 
     // Don't inject `extern crate std` because it's already injected by the
     // compiler.
-    if !s.contains("extern crate") && !opts.no_crate_inject {
+    if !s.contains("extern crate") && !opts.no_crate_inject && cratename != Some("std") {
         match cratename {
             Some(cratename) => {
                 if s.contains(cratename) {


### PR DESCRIPTION
This patch will make links like http://doc.rust-lang.org/std/collections/struct.BTreeMap.html#examples actually playable without modifying the code.

It seems that this patch cannot be tested on test/rustdoc.

And I suggest adding a `&run=1` to those links.

Thank @jorisgio for noticing me this!

r? @steveklabnik 

Closes https://github.com/rust-lang/rust/issues/24332
