### PR TITLE
Implement Debug for File

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -3296,6 +3296,8 @@ pub mod consts {
             pub const F_GETFL : c_int = 3;
             pub const F_SETFL : c_int = 4;
 
+            pub const O_ACCMODE : c_int = 3;
+
             pub const SIGTRAP : c_int = 5;
             pub const SIG_IGN: size_t = 1;
 

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -19,6 +19,7 @@
 
 use core::prelude::*;
 
+use fmt;
 use io::{self, Error, ErrorKind, SeekFrom, Seek, Read, Write};
 use path::{Path, PathBuf};
 use sys::fs2 as fs_imp;
@@ -302,6 +303,12 @@ impl AsInner<fs_imp::File> for File {
 impl FromInner<fs_imp::File> for File {
     fn from_inner(f: fs_imp::File) -> File {
         File { inner: f }
+    }
+}
+
+impl fmt::Debug for File {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.inner.fmt(f)
     }
 }
 

--- a/src/libstd/sys/windows/fs2.rs
+++ b/src/libstd/sys/windows/fs2.rs
@@ -14,6 +14,7 @@ use os::windows::prelude::*;
 
 use default::Default;
 use ffi::{OsString, AsOsStr};
+use fmt;
 use io::{self, Error, SeekFrom};
 use libc::{self, HANDLE};
 use mem;
@@ -268,6 +269,15 @@ impl File {
 impl FromInner<libc::HANDLE> for File {
     fn from_inner(handle: libc::HANDLE) -> File {
         File { handle: Handle::new(handle) }
+    }
+}
+
+impl fmt::Debug for File {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // FIXME(#24570): add more info here (e.g. path, mode)
+        f.debug_struct("File")
+            .field("handle", &self.handle.raw())
+            .finish()
     }
 }
 


### PR DESCRIPTION
This patch adds a `Debug` impl for `std::fs::File`.

On all platforms (Unix and Windows) it shows the file descriptor.

On Linux, it displays the path and access mode as well.

Ideally we should show the path/mode for all platforms, not just Linux,
but this will do for now.

cc #24570
