### PR TITLE
Explicitly use ::std::io::Write in write!

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -182,7 +182,9 @@ macro_rules! try {
 /// ```
 #[macro_export]
 macro_rules! write {
-    ($dst:expr, $($arg:tt)*) => ($dst.write_fmt(format_args!($($arg)*)))
+    ($dst:expr, $($arg:tt)*) => (
+        ::std::io::Write::write_fmt($dst, format_args!($($arg)*))
+    )
 }
 
 /// Equivalent to the `write!` macro, except that a newline is appended after


### PR DESCRIPTION
Currently the `write!` macro relies on `::std::io::Write` being in scope. This commit explicitly uses `::std::io::Write::write_fmt()`, which also fixes another potential issue with another trait with a `write_fmt()` method being in scope.
