### PR TITLE
Improve doc for `Result::unwrap()`

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -727,8 +727,8 @@ impl<T, E: fmt::Debug> Result<T, E> {
     ///
     /// # Panics
     ///
-    /// Panics if the value is an `Err`, with a custom panic message provided
-    /// by the `Err`'s value.
+    /// Panics if the value is an `Err`, with a panic message provided by the
+    /// `Err`'s value.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Get rid of the confusion that what does "custom" mean in this context.
