### PR TITLE
Simplify alloc::arc::Arc example in doc-comment

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -103,7 +103,7 @@ use heap::deallocate;
 /// use std::thread;
 ///
 /// fn main() {
-///     let numbers: Vec<_> = (0..100u32).map(|i| i as f32).collect();
+///     let numbers: Vec<_> = (0..100u32).collect();
 ///     let shared_numbers = Arc::new(numbers);
 ///
 ///     for _ in 0..10 {


### PR DESCRIPTION
As far as I can tell, this conversion to integer to floating point does not need to happen and is beside the point
