### PR TITLE
Refocus unsafe code chapter on unsafe itself.

### DIFF
--- a/src/doc/trpl/SUMMARY.md
+++ b/src/doc/trpl/SUMMARY.md
@@ -55,6 +55,7 @@
     * [Deref coercions](deref-coercions.md)
     * [Macros](macros.md)
     * [Raw Pointers](raw-pointers.md)
+    * [`unsafe`](unsafe.md)
 * [Nightly Rust](nightly-rust.md)
     * [Compiler Plugins](compiler-plugins.md)
     * [Inline Assembly](inline-assembly.md)

--- a/src/doc/trpl/unsafe.md
+++ b/src/doc/trpl/unsafe.md
@@ -1,4 +1,4 @@
-% Unsafe Code
+% Unsafe
 
 Rust’s main draw is its powerful static guarantees about behavior. But safety
 checks are conservative by nature: there are some programs that are actually
@@ -76,7 +76,7 @@ behaviors that are certainly bad, but are expressly _not_ unsafe:
 * Integer overflow
 
 Rust cannot prevent all kinds of software problems. Buggy code can and will be
-written in Rust. These things arne’t great, but they don’t qualify as `unsafe`
+written in Rust. These things aren’t great, but they don’t qualify as `unsafe`
 specifically.
 
 # Unsafe Superpowers

--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -208,7 +208,7 @@ fn main() {
     unsafe { f(); }
 }
 
-See also http://doc.rust-lang.org/book/unsafe-code.html
+See also http://doc.rust-lang.org/book/unsafe.html
 "##,
 
 E0152: r##"


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/24631 is related, as it will delete this from the TOC, but I want to keep it here.
