### PR TITLE
Rustdoc: ignore deref-inherited static methods

### DIFF
--- a/src/test/auxiliary/issue-19190-3.rs
+++ b/src/test/auxiliary/issue-19190-3.rs
@@ -22,6 +22,7 @@ pub struct Baz;
 
 impl Baz {
     pub fn baz(&self) {}
+    pub fn static_baz() {}
 }
 
 impl Deref for Bar {

--- a/src/test/rustdoc/issue-19190-2.rs
+++ b/src/test/rustdoc/issue-19190-2.rs
@@ -19,4 +19,4 @@ impl Deref for Bar {
 
 // @has issue_19190_2/struct.Bar.html
 // @has - '//*[@id="method.count_ones"]' 'fn count_ones(self) -> u32'
-
+// @!has - '//*[@id="method.min_value"]' 'fn min_value() -> i32'

--- a/src/test/rustdoc/issue-19190-3.rs
+++ b/src/test/rustdoc/issue-19190-3.rs
@@ -18,14 +18,17 @@ use issue_19190_3::Baz;
 
 // @has issue_19190_3/struct.Foo.html
 // @has - '//*[@id="method.count_ones"]' 'fn count_ones(self) -> u32'
+// @!has - '//*[@id="method.min_value"]' 'fn min_value() -> i32'
 pub use issue_19190_3::Foo;
 
 // @has issue_19190_3/struct.Bar.html
 // @has - '//*[@id="method.baz"]' 'fn baz(&self)'
+// @!has - '//*[@id="method.static_baz"]' 'fn static_baz()'
 pub use issue_19190_3::Bar;
 
 // @has issue_19190_3/struct.MyBar.html
 // @has - '//*[@id="method.baz"]' 'fn baz(&self)'
+// @!has - '//*[@id="method.static_baz"]' 'fn static_baz()'
 pub struct MyBar;
 
 impl Deref for MyBar {

--- a/src/test/rustdoc/issue-19190.rs
+++ b/src/test/rustdoc/issue-19190.rs
@@ -15,6 +15,7 @@ pub struct Bar;
 
 impl Foo {
     pub fn foo(&self) {}
+    pub fn static_foo() {}
 }
 
 impl Deref for Bar {
@@ -24,3 +25,4 @@ impl Deref for Bar {
 
 // @has issue_19190/struct.Bar.html
 // @has - '//*[@id="method.foo"]' 'fn foo(&self)'
+// @!has - '//*[@id="method.static_foo"]' 'fn static_foo()'


### PR DESCRIPTION
Fixes #24575 
Fixes #25673 

r? @alexcrichton 
