### PR TITLE
Add an example of using `&foo[..]` to completely slice an object to the `primitives` section of TRPL

### DIFF
--- a/src/doc/trpl/primitive-types.md
+++ b/src/doc/trpl/primitive-types.md
@@ -168,6 +168,7 @@ like arrays:
 ```rust
 let a = [0, 1, 2, 3, 4];
 let middle = &a[1..4]; // A slice of a: just the elements 1, 2, and 3
+let complete = &a[..]; // A slice containing all of the elements in a
 ```
 
 Slices have type `&[T]`. We’ll talk about that `T` when we cover


### PR DESCRIPTION
The documentation doesn't appear to describe the `&foo[..]` syntax.

I tried looking in `primitive-types.html#slices` and `std/primitive.slice.html`.

There's an example of partially slicing an array in trpl and a mention of `&foo[..]` in [the standard library documentation](https://doc.rust-lang.org/std/primitive.slice.html), but neither place, from what I can see, actually describes the behavior of `&foo[..]`.

+r? @steveklabnik 
