### PR TITLE
Change a few error messages to give code suggestions

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3138,7 +3138,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                           uses it like a function name",
                                          path_name));
 
-                        let msg = format!("Did you mean to write: \
+                        let msg = format!("did you mean to write: \
                                            `{} {{ /* fields */ }}`?",
                                           path_name);
                         if self.emit_errors {
@@ -3179,7 +3179,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                                 uses it like a function name",
                                                 path_name));
 
-                                let msg = format!("Did you mean to write: \
+                                let msg = format!("did you mean to write: \
                                                      `{} {{ /* fields */ }}`?",
                                                     path_name);
                                 if self.emit_errors {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1071,7 +1071,16 @@ fn report_cast_to_unsized_type<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                 ast::MutImmutable => ""
             };
             if ty::type_is_trait(t_1) {
-                span_help!(fcx.tcx().sess, t_span, "did you mean `&{}{}`?", mtstr, tstr);
+                match fcx.tcx().sess.codemap().span_to_snippet(t_span) {
+                    Ok(s) => {
+                        fcx.tcx().sess.span_suggestion(t_span,
+                                                       "try casting to a reference instead:",
+                                                       format!("&{}{}", mtstr, s));
+                    },
+                    Err(_) =>
+                        span_help!(fcx.tcx().sess, t_span,
+                                   "did you mean `&{}{}`?", mtstr, tstr),
+                }
             } else {
                 span_help!(fcx.tcx().sess, span,
                            "consider using an implicit coercion to `&{}{}` instead",
@@ -1079,7 +1088,15 @@ fn report_cast_to_unsized_type<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
             }
         }
         ty::ty_uniq(..) => {
-            span_help!(fcx.tcx().sess, t_span, "did you mean `Box<{}>`?", tstr);
+            match fcx.tcx().sess.codemap().span_to_snippet(t_span) {
+                Ok(s) => {
+                    fcx.tcx().sess.span_suggestion(t_span,
+                                                   "try casting to a `Box` instead:",
+                                                   format!("Box<{}>", s));
+                },
+                Err(_) =>
+                    span_help!(fcx.tcx().sess, t_span, "did you mean `Box<{}>`?", tstr),
+            }
         }
         _ => {
             span_help!(fcx.tcx().sess, e_span,

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -972,6 +972,9 @@ impl<'a> Parser<'a> {
     pub fn span_help(&self, sp: Span, m: &str) {
         self.sess.span_diagnostic.span_help(sp, m)
     }
+    pub fn span_suggestion(&self, sp: Span, m: &str, n: String) {
+        self.sess.span_diagnostic.span_suggestion(sp, m, n)
+    }
     pub fn fileline_help(&self, sp: Span, m: &str) {
         self.sess.span_diagnostic.fileline_help(sp, m)
     }
@@ -2594,6 +2597,7 @@ impl<'a> Parser<'a> {
             }
 
             let lo = self.span.lo;
+            let box_hi = self.span.hi;
 
             try!(self.bump());
 
@@ -2610,9 +2614,10 @@ impl<'a> Parser<'a> {
                         self.span_err(span,
                                       &format!("expected expression, found `{}`",
                                               this_token_to_string));
-                        let box_span = mk_sp(lo, self.last_span.hi);
-                        self.span_help(box_span,
-                                       "perhaps you meant `box() (foo)` instead?");
+                        let box_span = mk_sp(lo, box_hi);
+                        self.span_suggestion(box_span,
+                                             "try using `box()` instead:",
+                                             "box()".to_string());
                         self.abort_if_errors();
                     }
                     let subexpression = try!(self.parse_prefix_expr());

--- a/src/test/compile-fail/cast-to-unsized-trait-object-suggestion.rs
+++ b/src/test/compile-fail/cast-to-unsized-trait-object-suggestion.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -9,8 +9,12 @@
 // except according to those terms.
 
 fn main() {
-    box (1 + 1)
-    //~^ HELP try using `box()` instead:
-    //~| SUGGESTION box() (1 + 1)
-    ; //~ ERROR expected expression, found `;`
+    &1 as Copy;
+    //~^ ERROR cast to unsized type
+    //~| HELP try casting to a reference instead:
+    //~| SUGGESTION &1 as &Copy;
+    Box::new(1) as Copy;
+    //~^ ERROR cast to unsized type
+    //~| HELP try casting to a `Box` instead:
+    //~| SUGGESTION Box::new(1) as Box<Copy>;
 }

--- a/src/test/compile-fail/issue-17441.rs
+++ b/src/test/compile-fail/issue-17441.rs
@@ -16,7 +16,7 @@ fn main() {
     // FIXME (#22405): Replace `Box::new` with `box` here when/if possible.
     let _bar = Box::new(1_usize) as std::fmt::Debug;
     //~^ ERROR cast to unsized type: `Box<usize>` as `core::fmt::Debug`
-    //~^^ HELP did you mean `Box<core::fmt::Debug>`?
+    //~^^ HELP try casting to a `Box` instead
 
     let _baz = 1_usize as std::fmt::Debug;
     //~^ ERROR cast to unsized type: `usize` as `core::fmt::Debug`

--- a/src/test/compile-fail/issue-6702.rs
+++ b/src/test/compile-fail/issue-6702.rs
@@ -15,5 +15,5 @@ struct Monster {
 
 fn main() {
     let _m = Monster(); //~ ERROR `Monster` is a structure name, but
-    //~^ HELP Did you mean to write: `Monster { /* fields */ }`?
+    //~^ HELP did you mean to write: `Monster { /* fields */ }`?
 }

--- a/src/test/compile-fail/trait-object-reference-without-parens-suggestion.rs
+++ b/src/test/compile-fail/trait-object-reference-without-parens-suggestion.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -9,8 +9,12 @@
 // except according to those terms.
 
 fn main() {
-    box (1 + 1)
-    //~^ HELP try using `box()` instead:
-    //~| SUGGESTION box() (1 + 1)
-    ; //~ ERROR expected expression, found `;`
+    let _: &Copy + 'static;
+    //~^ ERROR expected a path
+    //~| HELP try adding parentheses
+    //~| SUGGESTION let _: &(Copy + 'static);
+    let _: &'static Copy + 'static;
+    //~^ ERROR expected a path
+    //~| HELP try adding parentheses
+    //~| SUGGESTION let _: &'static (Copy + 'static);
 }


### PR DESCRIPTION
This PR uses the inline error suggestions introduced in #24242 to modify a few existing `help` messages. The new errors look like this:

```
foobar.rs:5:12: 5:25 error: expected a path on the left-hand side of `+`,
                            not `&'static Copy` [E0178]
foobar.rs:5     let x: &'static Copy + 'static;
                       ^~~~~~~~~~~~~
foobar.rs:5:12: 5:35 help: try adding parentheses (per RFC 438):
foobar.rs:      let x: &'static (Copy + 'static);


foobar.rs:2:13: 2:23 error: cast to unsized type: `&_` as `core::marker::Copy`
foobar.rs:2     let x = &1 as Copy;
                        ^~~~~~~~~~
foobar.rs:2:19: 2:23 help: try casting to a reference instead:
foobar.rs:      let x = &1 as &Copy;


foobar.rs:7:24: 7:25 error: expected expression, found `;`
foobar.rs:7     let x = box (1 + 1);
                                   ^
foobar.rs:7:13: 7:16 help: try using `box()` instead:
foobar.rs:      let x = box() (1 + 1);
```

This also modifies compiletest to give the ability to directly test suggestions given by error messages.
