### PR TITLE
Add a write_char method to std::fmt::Formatter.

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -731,13 +731,6 @@ impl<'a> Formatter<'a> {
         self.buf.write_str(data)
     }
 
-    /// Writes a `char` to the underlying buffer contained within this
-    /// formatter.
-    #[stable(feature = "fmt_write_char", since = "1.1.0")]
-    pub fn write_char(&mut self, c: char) -> Result {
-        self.buf.write_char(c)
-    }
-
     /// Writes some formatted information into this instance
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn write_fmt(&mut self, fmt: Arguments) -> Result {
@@ -896,6 +889,21 @@ impl<'a> Formatter<'a> {
     #[inline]
     pub fn debug_map<'b>(&'b mut self) -> DebugMap<'b, 'a> {
         builders::debug_map_new(self)
+    }
+}
+
+#[stable(since = "1.2.0", feature = "formatter_write")]
+impl<'a> Write for Formatter<'a> {
+    fn write_str(&mut self, s: &str) -> Result {
+        self.buf.write_str(s)
+    }
+
+    fn write_char(&mut self, c: char) -> Result {
+        self.buf.write_char(c)
+    }
+
+    fn write_fmt(&mut self, args: Arguments) -> Result {
+        write(self.buf, args)
     }
 }
 

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -731,6 +731,13 @@ impl<'a> Formatter<'a> {
         self.buf.write_str(data)
     }
 
+    /// Writes a `char` to the underlying buffer contained within this
+    /// formatter.
+    #[stable(feature = "fmt_write_char", since = "1.1.0")]
+    pub fn write_char(&mut self, c: char) -> Result {
+        self.buf.write_char(c)
+    }
+
     /// Writes some formatted information into this instance
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn write_fmt(&mut self, fmt: Arguments) -> Result {
@@ -965,10 +972,7 @@ impl Debug for char {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Display for char {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        let mut utf8 = [0; 4];
-        let amt = self.encode_utf8(&mut utf8).unwrap_or(0);
-        let s: &str = unsafe { mem::transmute(&utf8[..amt]) };
-        Display::fmt(s, f)
+        f.write_char(*self)
     }
 }
 

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -21,6 +21,7 @@ use std::usize;
 struct A;
 struct B;
 struct C;
+struct D;
 
 impl fmt::LowerHex for A {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -35,6 +36,13 @@ impl fmt::UpperHex for B {
 impl fmt::Display for C {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad_integral(true, "☃", "123")
+    }
+}
+impl fmt::Binary for D {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(f.write_str("aa"));
+        try!(f.write_char('☃'));
+        f.write_str("bb")
     }
 }
 
@@ -90,6 +98,7 @@ pub fn main() {
     t!(format!("{foo_bar}", foo_bar=1), "1");
     t!(format!("{}", 5 + 5), "10");
     t!(format!("{:#4}", C), "☃123");
+    t!(format!("{:b}", D), "aa☃bb");
 
     let a: &fmt::Debug = &1;
     t!(format!("{:?}", a), "1");

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -15,7 +15,7 @@
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 
-use std::fmt;
+use std::fmt::{self, Write};
 use std::usize;
 
 struct A;


### PR DESCRIPTION
This is the logical next step after #24661, but I’m less sure about this one.

r? @alexcrichton
