### PR TITLE
Remove doc-comment default::Default imports

### DIFF
--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -459,7 +459,6 @@ impl<T: Default> Default for Rc<T> {
     ///
     /// ```
     /// use std::rc::Rc;
-    /// use std::default::Default;
     ///
     /// let x: Rc<i32> = Default::default();
     /// ```

--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -24,8 +24,6 @@
 //! How can we define some default values? You can use `Default`:
 //!
 //! ```
-//! use std::default::Default;
-//!
 //! #[derive(Default)]
 //! struct SomeOptions {
 //!     foo: i32,
@@ -42,8 +40,6 @@
 //! If you have your own type, you need to implement `Default` yourself:
 //!
 //! ```
-//! use std::default::Default;
-//!
 //! enum Kind {
 //!     A,
 //!     B,
@@ -70,7 +66,6 @@
 //! If you want to override a particular option, but still retain the other defaults:
 //!
 //! ```
-//! # use std::default::Default;
 //! # #[derive(Default)]
 //! # struct SomeOptions {
 //! #     foo: i32,
@@ -109,8 +104,6 @@ pub trait Default {
     /// Using built-in default values:
     ///
     /// ```
-    /// use std::default::Default;
-    ///
     /// let i: i8 = Default::default();
     /// let (x, y): (Option<String>, f64) = Default::default();
     /// let (a, b, (c, d)): (i32, u32, (bool, bool)) = Default::default();
@@ -119,8 +112,6 @@ pub trait Default {
     /// Making your own:
     ///
     /// ```
-    /// use std::default::Default;
-    ///
     /// enum Kind {
     ///     A,
     ///     B,

--- a/src/libstd/tuple.rs
+++ b/src/libstd/tuple.rs
@@ -43,8 +43,6 @@
 //! Using traits implemented for tuples:
 //!
 //! ```
-//! use std::default::Default;
-//!
 //! let a = (1, 2);
 //! let b = (3, 4);
 //! assert!(a != b);


### PR DESCRIPTION
In 8f5b5f94dcdb9884737dfbc8efd893d1d70f0b14, `default::Default` was
added to the prelude, so these imports are no longer necessary.
