### PR TITLE
mk: Remove version numbers from beta artifacts

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -30,8 +30,12 @@ CFG_PACKAGE_VERS=$(CFG_RELEASE_NUM)
 CFG_DISABLE_UNSTABLE_FEATURES=1
 endif
 ifeq ($(CFG_RELEASE_CHANNEL),beta)
-CFG_RELEASE=$(CFG_RELEASE_NUM)-beta$(CFG_PRERELEASE_VERSION)
-CFG_PACKAGE_VERS=$(CFG_RELEASE_NUM)-beta$(CFG_PRERELEASE_VERSION)
+CFG_RELEASE=$(CFG_RELEASE_NUM)-beta
+# When building beta distributables just reuse the same "beta" name
+# so when we upload we'll always override the previous beta. This
+# doesn't actually impact the version reported by rustc - it's just
+# for file naming.
+CFG_PACKAGE_VERS=beta
 CFG_DISABLE_UNSTABLE_FEATURES=1
 endif
 ifeq ($(CFG_RELEASE_CHANNEL),nightly)


### PR DESCRIPTION
Instead of rustc-1.0.0-beta-$triple.tar.gz, betas will be named
rustc-beta-$triple.tar.gz. This will give betas a stable download
URL, prevent old artifacts from accumulating in the dist server's
root directory, and not require the website to be updated every
beta.

As a tradeoff, it will be harder to download previous betas because
they will need to be located in the archives.

I'm still unsure about whether this is the right choice.

cc @alexcrichton @steveklabnik 
