### PR TITLE
rustdoc: toggle collapse/expand all docs using the same link

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1460,7 +1460,7 @@ impl<'a> fmt::Display for Item<'a> {
         try!(write!(fmt, "<span class='out-of-band'>"));
         try!(write!(fmt,
         r##"<span id='render-detail'>
-            <a id="collapse-all" href="#">[-]</a>&nbsp;<a id="expand-all" href="#">[+]</a>
+            <a id="toggle-all-docs" href="#" title="collapse all docs">[-]</a>
         </span>"##));
 
         // Write `src` tag
@@ -1473,8 +1473,8 @@ impl<'a> fmt::Display for Item<'a> {
             match self.href(self.cx) {
                 Some(l) => {
                     try!(write!(fmt, "<a id='src-{}' class='srclink' \
-                                       href='{}'>[src]</a>",
-                                self.item.def_id.node, l));
+                                       href='{}' title='{}'>[src]</a>",
+                                self.item.def_id.node, l, "goto source code"));
                 }
                 None => {}
             }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -806,18 +806,23 @@
         window.location = $('.srclink').attr('href');
     }
 
-    $("#expand-all").on("click", function() {
-        $(".docblock").show();
-        $(".toggle-label").hide();
-        $(".toggle-wrapper").removeClass("collapsed");
-        $(".collapse-toggle").children(".inner").html("-");
-    });
-
-    $("#collapse-all").on("click", function() {
-        $(".docblock").hide();
-        $(".toggle-label").show();
-        $(".toggle-wrapper").addClass("collapsed");
-        $(".collapse-toggle").children(".inner").html("+");
+    $("#toggle-all-docs").on("click", function() {
+        var toggle = $("#toggle-all-docs");
+        if (toggle.html() == "[-]") {
+            toggle.html("[+]");
+            toggle.attr("title", "expand all docs");
+            $(".docblock").hide();
+            $(".toggle-label").show();
+            $(".toggle-wrapper").addClass("collapsed");
+            $(".collapse-toggle").children(".inner").html("+");
+        } else {
+            toggle.html("[-]");
+            toggle.attr("title", "collapse all docs");
+            $(".docblock").show();
+            $(".toggle-label").hide();
+            $(".toggle-wrapper").removeClass("collapsed");
+            $(".collapse-toggle").children(".inner").html("-");
+        }
     });
 
     $(document).on("click", ".collapse-toggle", function() {


### PR DESCRIPTION
Combine the two links, [-] and [+], at top-right corner of the page, to use a single and the same one, so that:
- one less link to be created/displayed
- be consistent with other [-]/[+] links in the same page
- people can easily toggle docs without moving their mouse pointer

I also added tooltips/titles to these links.
