### PR TITLE
Work-around optimiser deficiencies in `Range` iterator.

### DIFF
--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -932,3 +932,10 @@ fn bench_max(b: &mut Bencher) {
         it.map(scatter).max()
     })
 }
+
+#[bench]
+fn bench_range_constant_fold(b: &mut Bencher) {
+    // this should be constant-folded to just '1000', and so this
+    // benchmark should run quickly...
+    b.iter(|| (0..1000).count())
+}


### PR DESCRIPTION
The conditional mutation of the previous implementation resulted in poor
code, making it unconditional makes `Range` less well behaved as an
Iterator (but still legal) but also makes it fast.

The intention is that this change will be reverted when rustc/LLVM
handle the best-behaved implementation better.

cc #24660
