### PR TITLE
Next round of removing feature flags from libsyntax

### DIFF
--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -20,10 +20,9 @@
 pub use self::MacroFormat::*;
 
 use std::cell::RefCell;
+use std::fmt;
 use std::ops::{Add, Sub};
 use std::rc::Rc;
-
-use std::fmt;
 
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 

--- a/src/libsyntax/ext/asm.rs
+++ b/src/libsyntax/ext/asm.rs
@@ -22,6 +22,7 @@ use feature_gate;
 use parse::token::InternedString;
 use parse::token;
 use ptr::P;
+use str::slice_shift_char;
 
 enum State {
     Asm,
@@ -109,7 +110,7 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
                     // It's the opposite of '=&' which means that the memory
                     // cannot be shared with any other operand (usually when
                     // a register is clobbered early.)
-                    let output = match constraint.slice_shift_char() {
+                    let output = match slice_shift_char(&constraint) {
                         Some(('=', _)) => None,
                         Some(('+', operand)) => {
                             Some(token::intern_and_get_ident(&format!(

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -25,7 +25,6 @@ use codemap::{respan, Span, Spanned};
 use owned_slice::OwnedSlice;
 use parse::token;
 use ptr::P;
-use std::ptr;
 use util::small_vector::SmallVector;
 
 use std::rc::Rc;
@@ -36,14 +35,8 @@ pub trait MoveMap<T> {
 }
 
 impl<T> MoveMap<T> for Vec<T> {
-    fn move_map<F>(mut self, mut f: F) -> Vec<T> where F: FnMut(T) -> T {
-        for p in &mut self {
-            unsafe {
-                // FIXME(#5016) this shouldn't need to zero to be safe.
-                ptr::write(p, f(ptr::read_and_drop(p)));
-            }
-        }
-        self
+    fn move_map<F>(self, mut f: F) -> Vec<T> where F: FnMut(T) -> T {
+        self.into_iter().map(|p| f(p)).collect()
     }
 }
 

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -31,7 +31,6 @@
 #![feature(rustc_private)]
 #![feature(staged_api)]
 #![feature(unicode)]
-#![feature(str_char)]
 
 extern crate arena;
 extern crate fmt_macros;

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -404,7 +404,11 @@ impl<'a> Parser<'a> {
                                    this_token_str)))
             }
         } else {
-            self.expect_one_of(slice::ref_slice(t), &[])
+            // FIXME: Using this because `slice::ref_slice` is unstable.
+            let slice = unsafe {
+                slice::from_raw_parts(t, 1)
+            };
+            self.expect_one_of(slice, &[])
         }
     }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -27,6 +27,7 @@ use print::pp::{Breaks, eof};
 use print::pp::Breaks::{Consistent, Inconsistent};
 use ptr::P;
 use std_inject;
+use str::slice_shift_char;
 
 use std::ascii;
 use std::io::{self, Write, Read};
@@ -1873,7 +1874,7 @@ impl<'a> State<'a> {
 
                 try!(self.commasep(Inconsistent, &a.outputs,
                                    |s, &(ref co, ref o, is_rw)| {
-                    match co.slice_shift_char() {
+                    match slice_shift_char(co) {
                         Some(('=', operand)) if is_rw => {
                             try!(s.print_string(&format!("+{}", operand),
                                                 ast::CookedStr))

--- a/src/libsyntax/ptr.rs
+++ b/src/libsyntax/ptr.rs
@@ -39,7 +39,6 @@
 use std::fmt::{self, Display, Debug};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
-use std::ptr;
 
 use serialize::{Encodable, Decodable, Encoder, Decoder};
 
@@ -66,15 +65,10 @@ impl<T: 'static> P<T> {
     }
 
     /// Transform the inner value, consuming `self` and producing a new `P<T>`.
-    pub fn map<F>(mut self, f: F) -> P<T> where
+    pub fn map<F>(self, f: F) -> P<T> where
         F: FnOnce(T) -> T,
     {
-        unsafe {
-            let p = &mut *self.ptr;
-            // FIXME(#5016) this shouldn't need to drop-fill to be safe.
-            ptr::write(p, f(ptr::read_and_drop(p)));
-        }
-        self
+        P(f(*self.ptr))
     }
 }
 

--- a/src/libsyntax/str.rs
+++ b/src/libsyntax/str.rs
@@ -8,6 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// FIXME: This was copied from core/str/mod.rs because it is currently unstable.
 pub fn char_at(s: &str, byte: usize) -> char {
     s[byte..].chars().next().unwrap()
+}
+
+// FIXME: This was copied from core/str/mod.rs because it is currently unstable.
+#[inline]
+pub fn slice_shift_char(s: &str) -> Option<(char, &str)> {
+    if s.is_empty() {
+        None
+    } else {
+        let ch = char_at(s, 0);
+        Some((ch, &s[ch.len_utf8()..]))
+    }
 }


### PR DESCRIPTION
This is part two of #24518, which is trying to get libsyntax to compile without feature flags. After this, all that remains is `#[feature(collections, libc, rustc_private, staged_api)]`. The one real unfortunate thing is that I had to copy some tables from `librustc_unicode`, but I couldn't figure out a great way to share these tables between the two modules.
