### PR TITLE
Stop mentioning obsolete integer suffixes

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -268,7 +268,7 @@ cases mentioned in [Number literals](#number-literals) below.
 ##### Suffixes
 | Integer | Floating-point |
 |---------|----------------|
-| `u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`, `i64`, `is` (`isize`), `us` (`usize`) | `f32`, `f64` |
+| `u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`, `i64`, `isize`, `usize` | `f32`, `f64` |
 
 #### Character and string literals
 


### PR DESCRIPTION
`us` and `is` were replaced with `usize` and `isize` some time ago. Other than that, 3.5.2.1.5 is correct.
