### PR TITLE
[doc] Mention multi-line coments in the book

### DIFF
--- a/src/doc/trpl/comments.md
+++ b/src/doc/trpl/comments.md
@@ -43,3 +43,18 @@ value passed to it is `false`.
 
 You can use the [`rustdoc`](documentation.html) tool to generate HTML documentation
 from these doc comments, and also to run the code examples as tests!
+
+Rust also supports a third kind of comment that is used less often.  A *multi-line
+comment* starts with `/*` and ends with `*/`.  Multi-line comments are useful
+for commenting out several lines of code temporarily, during development:
+
+```rust
+fn count(n) {
+    let range = 0..n;
+    /*
+    for i in range {
+        println!("{}", i);
+    }
+    */
+}
+```


### PR DESCRIPTION
I thought it would be useful to mention these briefly so that users aren't suprised when they come across them.  It's fine if you'd rather save this information for the reference, however.  Edits to the text and example are also welcome!
