### PR TITLE
Improve information about loops

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -3183,7 +3183,7 @@ for i in 0..256 {
 }
 ```
 
-Like `loop` expressions, `while` loops can be controlled with `break` or
+Like `loop` expressions, `for` loops can be controlled with `break` or
 `continue`, and may optionally have a _label_. See [infinite
 loops](#infinite-loops), [break expressions](#break-expressions), and
 [continue expressions](#continue-expressions) for more information.

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -3078,6 +3078,50 @@ fn ten_times<F>(f: F) where F: Fn(i32) {
 ten_times(|j| println!("hello, {}", j));
 ```
 
+### Infinite loops
+
+A `loop` expression denotes an infinite loop.
+
+```{.ebnf .gram}
+loop_expr : [ lifetime ':' ] "loop" '{' block '}';
+```
+
+A `loop` expression may optionally have a _label_. The label is written as
+a lifetime preceding the loop expression, as in `'foo: loop{ }`. If a
+label is present, then labeled `break` and `continue` expressions nested
+within this loop may exit out of this loop or return control to its head.
+See [Break expressions](#break-expressions) and [Continue
+expressions](#continue-expressions).
+
+### Break expressions
+
+```{.ebnf .gram}
+break_expr : "break" [ lifetime ];
+```
+
+A `break` expression has an optional _label_. If the label is absent, then
+executing a `break` expression immediately terminates the innermost loop
+enclosing it. It is only permitted in the body of a loop. If the label is
+present, then `break 'foo` terminates the loop with label `'foo`, which need not
+be the innermost label enclosing the `break` expression, but must enclose it.
+
+### Continue expressions
+
+```{.ebnf .gram}
+continue_expr : "continue" [ lifetime ];
+```
+
+A `continue` expression has an optional _label_. If the label is absent, then
+executing a `continue` expression immediately terminates the current iteration
+of the innermost loop enclosing it, returning control to the loop *head*. In
+the case of a `while` loop, the head is the conditional expression controlling
+the loop. In the case of a `for` loop, the head is the call-expression
+controlling the loop. If the label is present, then `continue 'foo` returns
+control to the head of the loop with label `'foo`, which need not be the
+innermost label enclosing the `break` expression, but must enclose it.
+
+A `continue` expression is only permitted in the body of a loop.
+
 ### While loops
 
 ```{.ebnf .gram}
@@ -3100,48 +3144,10 @@ while i < 10 {
 }
 ```
 
-### Infinite loops
-
-A `loop` expression denotes an infinite loop.
-
-```{.ebnf .gram}
-loop_expr : [ lifetime ':' ] "loop" '{' block '}';
-```
-
-A `loop` expression may optionally have a _label_. If a label is present, then
-labeled `break` and `continue` expressions nested within this loop may exit out
-of this loop or return control to its head. See [Break
-expressions](#break-expressions) and [Continue
-expressions](#continue-expressions).
-
-### Break expressions
-
-```{.ebnf .gram}
-break_expr : "break" [ lifetime ];
-```
-
-A `break` expression has an optional _label_. If the label is absent, then
-executing a `break` expression immediately terminates the innermost loop
-enclosing it. It is only permitted in the body of a loop. If the label is
-present, then `break foo` terminates the loop with label `foo`, which need not
-be the innermost label enclosing the `break` expression, but must enclose it.
-
-### Continue expressions
-
-```{.ebnf .gram}
-continue_expr : "continue" [ lifetime ];
-```
-
-A `continue` expression has an optional _label_. If the label is absent, then
-executing a `continue` expression immediately terminates the current iteration
-of the innermost loop enclosing it, returning control to the loop *head*. In
-the case of a `while` loop, the head is the conditional expression controlling
-the loop. In the case of a `for` loop, the head is the call-expression
-controlling the loop. If the label is present, then `continue foo` returns
-control to the head of the loop with label `foo`, which need not be the
-innermost label enclosing the `break` expression, but must enclose it.
-
-A `continue` expression is only permitted in the body of a loop.
+Like `loop` expressions, `while` loops can be controlled with `break` or
+`continue`, and may optionally have a _label_. See [infinite
+loops](#infinite-loops), [break expressions](#break-expressions), and
+[continue expressions](#continue-expressions) for more information.
 
 ### For expressions
 
@@ -3176,6 +3182,11 @@ for i in 0..256 {
     bar(i);
 }
 ```
+
+Like `loop` expressions, `while` loops can be controlled with `break` or
+`continue`, and may optionally have a _label_. See [infinite
+loops](#infinite-loops), [break expressions](#break-expressions), and
+[continue expressions](#continue-expressions) for more information.
 
 ### If expressions
 


### PR DESCRIPTION
1) Moved 'while' section below 'loop', 'break', and 'continue'; 2) Added information to 'while' and 'for' loops that they interact with 'break' and 'continue' and may have a lifetime label. 3) Clarified labeling syntax on the infinite loops.
