### PR TITLE
Reference manual 3.5.2.1.5

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -271,7 +271,7 @@ cases mentioned in [Number literals](#number-literals) below.
 ##### Suffixes
 | Integer | Floating-point |
 |---------|----------------|
-| `u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`, `i64`, `is` (`isize`), `us` (`usize`) | `f32`, `f64` |
+| `u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`, `i64`, `isize`, `usize` | `f32`, `f64` |
 
 #### Character and string literals
 


### PR DESCRIPTION
`is` and `us` suffixes are deprecated in favor of `isize` and `usize`.
