### PR TITLE
Reference: Update 7.2.20 (for loops) and fix formatting

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2503,7 +2503,7 @@ The currently implemented features of the reference compiler are:
                               terms of encapsulation).
 
 If a feature is promoted to a language feature, then all existing programs will
-start to receive compilation warnings about #[feature] directives which enabled
+start to receive compilation warnings about `#![feature]` directives which enabled
 the new feature (because the directive is no longer necessary). However, if a
 feature is decided to be removed from the language, errors will be issued (if
 there isn't a parser error first). The directive in this case is no longer

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -3192,7 +3192,7 @@ for_expr : [ lifetime ':' ] "for" pat "in" no_struct_literal_expr '{' block '}' 
 ```
 
 A `for` expression is a syntactic construct for looping over elements provided
-by an implementation of `std::iter::Iterator`.
+by an implementation of `std::iter::IntoIterator`.
 
 An example of a for loop over the contents of an array:
 
@@ -3205,8 +3205,8 @@ An example of a for loop over the contents of an array:
 
 let v: &[Foo] = &[a, b, c];
 
-for e in v.iter() {
-    bar(*e);
+for e in v {
+    bar(e);
 }
 ```
 


### PR DESCRIPTION
Update 7.2.20 (`for` expressions):
- `for` loops now use `IntoIterator` instead of just `Iterator`
- Simplify the example by removing unnecessary `Vec::iter` call.

...and a fix for a minor formatting error.

r? @steveklabnik
