### PR TITLE
std: Don't use a wrapper for the float error type

### DIFF
--- a/src/libcore/num/float_macros.rs
+++ b/src/libcore/num/float_macros.rs
@@ -35,8 +35,8 @@ macro_rules! from_str_radix_float_impl {
             }
 
             let (is_positive, src) =  match src.slice_shift_char() {
-                None             => return Err(PFE { kind: Empty }),
-                Some(('-', ""))  => return Err(PFE { kind: Empty }),
+                None             => return Err(PFE { __kind: Empty }),
+                Some(('-', ""))  => return Err(PFE { __kind: Empty }),
                 Some(('-', src)) => (false, src),
                 Some((_, _))     => (true,  src),
             };
@@ -88,7 +88,7 @@ macro_rules! from_str_radix_float_impl {
                             break;  // start of fractional part
                         },
                         _ => {
-                            return Err(PFE { kind: Invalid });
+                            return Err(PFE { __kind: Invalid });
                         },
                     },
                 }
@@ -122,7 +122,7 @@ macro_rules! from_str_radix_float_impl {
                                 break; // start of exponent
                             },
                             _ => {
-                                return Err(PFE { kind: Invalid });
+                                return Err(PFE { __kind: Invalid });
                             },
                         },
                     }
@@ -135,7 +135,7 @@ macro_rules! from_str_radix_float_impl {
                     let base = match c {
                         'E' | 'e' if radix == 10 => 10.0,
                         'P' | 'p' if radix == 16 => 2.0,
-                        _ => return Err(PFE { kind: Invalid }),
+                        _ => return Err(PFE { __kind: Invalid }),
                     };
 
                     // Parse the exponent as decimal integer
@@ -144,13 +144,13 @@ macro_rules! from_str_radix_float_impl {
                         Some(('-', src)) => (false, src.parse::<usize>()),
                         Some(('+', src)) => (true,  src.parse::<usize>()),
                         Some((_, _))     => (true,  src.parse::<usize>()),
-                        None             => return Err(PFE { kind: Invalid }),
+                        None             => return Err(PFE { __kind: Invalid }),
                     };
 
                     match (is_positive, exp) {
                         (true,  Ok(exp)) => base.powi(exp as i32),
                         (false, Ok(exp)) => 1.0 / base.powi(exp as i32),
-                        (_, Err(_))      => return Err(PFE { kind: Invalid }),
+                        (_, Err(_))      => return Err(PFE { __kind: Invalid }),
                     }
                 },
                 None => 1.0, // no exponent

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1524,7 +1524,11 @@ impl fmt::Display for ParseIntError {
 
 /// An error which can be returned when parsing a float.
 #[derive(Debug, Clone, PartialEq)]
-pub struct ParseFloatError { pub kind: FloatErrorKind }
+#[stable(feature = "rust1", since = "1.0.0")]
+pub struct ParseFloatError {
+    #[doc(hidden)]
+    pub __kind: FloatErrorKind
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum FloatErrorKind {
@@ -1533,9 +1537,9 @@ pub enum FloatErrorKind {
 }
 
 impl ParseFloatError {
-    #[unstable(feature = "core", reason = "available through Error trait")]
-    pub fn description(&self) -> &str {
-        match self.kind {
+    #[doc(hidden)]
+    pub fn __description(&self) -> &str {
+        match self.__kind {
             FloatErrorKind::Empty => "cannot parse float from empty string",
             FloatErrorKind::Invalid => "invalid float literal",
         }
@@ -1545,6 +1549,6 @@ impl ParseFloatError {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Display for ParseFloatError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.description().fmt(f)
+        self.__description().fmt(f)
     }
 }

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -147,7 +147,7 @@ impl Error for num::ParseIntError {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Error for num::ParseFloatError {
     fn description(&self) -> &str {
-        self.description()
+        self.__description()
     }
 }
 

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -21,7 +21,6 @@ use core::num;
 use intrinsics;
 use libc::c_int;
 use num::{FpCategory, ParseFloatError};
-use sys_common::FromInner;
 
 pub use core::f32::{RADIX, MANTISSA_DIGITS, DIGITS, EPSILON};
 pub use core::f32::{MIN_EXP, MAX_EXP, MIN_10_EXP};
@@ -77,7 +76,7 @@ impl f32 {
     /// Parses a float as with a given radix
     #[unstable(feature = "float_from_str_radix", reason = "recently moved API")]
     pub fn from_str_radix(s: &str, radix: u32) -> Result<f32, ParseFloatError> {
-        num::Float::from_str_radix(s, radix).map_err(FromInner::from_inner)
+        num::Float::from_str_radix(s, radix)
     }
 
     /// Returns `true` if this value is `NaN` and false otherwise.

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -20,7 +20,6 @@ use core::num;
 use intrinsics;
 use libc::c_int;
 use num::{FpCategory, ParseFloatError};
-use sys_common::FromInner;
 
 pub use core::f64::{RADIX, MANTISSA_DIGITS, DIGITS, EPSILON};
 pub use core::f64::{MIN_EXP, MAX_EXP, MIN_10_EXP};
@@ -85,7 +84,7 @@ impl f64 {
     /// Parses a float as with a given radix
     #[unstable(feature = "float_from_str_radix", reason = "recently moved API")]
     pub fn from_str_radix(s: &str, radix: u32) -> Result<f64, ParseFloatError> {
-        num::Float::from_str_radix(s, radix).map_err(FromInner::from_inner)
+        num::Float::from_str_radix(s, radix)
     }
 
     /// Returns `true` if this value is `NaN` and false otherwise.

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -16,16 +16,14 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]
 
-use fmt;
-use core::num;
-
 pub use core::num::{Zero, One};
-pub use core::num::{FpCategory, ParseIntError};
+pub use core::num::{FpCategory, ParseIntError, ParseFloatError};
 pub use core::num::{wrapping, Wrapping};
 
-#[cfg(test)] use ops::{Add, Sub, Mul, Div, Rem};
 #[cfg(test)] use cmp::PartialEq;
+#[cfg(test)] use fmt;
 #[cfg(test)] use marker::Copy;
+#[cfg(test)] use ops::{Add, Sub, Mul, Div, Rem};
 
 /// Helper function for testing numeric operations
 #[cfg(test)]
@@ -41,31 +39,6 @@ pub fn test_num<T>(ten: T, two: T) where
     assert_eq!(ten.mul(two),  ten * two);
     assert_eq!(ten.div(two),  ten / two);
     assert_eq!(ten.rem(two),  ten % two);
-}
-
-/// An error which can be returned when parsing a float.
-#[derive(Debug, Clone, PartialEq)]
-#[stable(feature = "rust1", since = "1.0.0")]
-pub struct ParseFloatError { inner: num::ParseFloatError }
-
-impl ::sys_common::FromInner<num::ParseFloatError> for ParseFloatError {
-    fn from_inner(inner: num::ParseFloatError) -> ParseFloatError {
-        ParseFloatError { inner: inner }
-    }
-}
-
-impl ParseFloatError {
-    #[unstable(feature = "core", reason = "available through Error trait")]
-    pub fn description(&self) -> &str {
-        self.inner.description()
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl fmt::Display for ParseFloatError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.description().fmt(f)
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Ensures that the same error type is propagated throughout. Unnecessary leakage
of the internals is prevented through the usage of stability attributes.

Closes #24748
