### PR TITLE
Add downcasting to std::error::Error

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -240,6 +240,7 @@ impl<T: ?Sized + Hash> Hash for Box<T> {
 impl Box<Any> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    /// Attempt to downcast the box to a concrete type.
     pub fn downcast<T: Any>(self) -> Result<Box<T>, Box<Any>> {
         if self.is::<T>() {
             unsafe {
@@ -257,11 +258,15 @@ impl Box<Any> {
     }
 }
 
-impl Box<Any+Send> {
+impl Box<Any + Send> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn downcast<T: Any>(self) -> Result<Box<T>, Box<Any>> {
-        <Box<Any>>::downcast(self)
+    /// Attempt to downcast the box to a concrete type.
+    pub fn downcast<T: Any>(self) -> Result<Box<T>, Box<Any + Send>> {
+        <Box<Any>>::downcast(self).map_err(|s| unsafe {
+            // reapply the Send marker
+            mem::transmute::<Box<Any>, Box<Any + Send>>(s)
+        })
     }
 }
 

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -97,9 +97,7 @@ pub trait Any: Reflect + 'static {
     fn get_type_id(&self) -> TypeId;
 }
 
-impl<T> Any for T
-    where T: Reflect + 'static
-{
+impl<T: Reflect + 'static> Any for T {
     fn get_type_id(&self) -> TypeId { TypeId::of::<T>() }
 }
 
@@ -222,7 +220,7 @@ impl TypeId {
     /// Returns the `TypeId` of the type this generic function has been
     /// instantiated with
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn of<T: ?Sized + Any>() -> TypeId {
+    pub fn of<T: ?Sized + Reflect + 'static>() -> TypeId {
         TypeId {
             t: unsafe { intrinsics::type_id::<T>() },
         }

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -416,6 +416,8 @@ mod impls {
 #[rustc_reflect_like]
 #[unstable(feature = "core", reason = "requires RFC and more experience")]
 #[allow(deprecated)]
+#[rustc_on_unimplemented = "`{Self}` does not implement `Any`; \
+                            ensure all type parameters are bounded by `Any`"]
 pub trait Reflect {}
 
 impl Reflect for .. { }

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -47,19 +47,22 @@
 // coherence challenge (e.g., specialization, neg impls, etc) we can
 // reconsider what crate these items belong in.
 
-use boxed::Box;
+use any::TypeId;
+use boxed::{self, Box};
 use convert::From;
 use fmt::{self, Debug, Display};
-use marker::{Send, Sync};
+use marker::{Send, Sync, Reflect};
+use mem::transmute;
 use num;
-use option::Option;
-use option::Option::None;
+use option::Option::{self, Some, None};
+use result::Result::{self, Ok, Err};
+use raw::TraitObject;
 use str;
 use string::{self, String};
 
 /// Base functionality for all errors in Rust.
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait Error: Debug + Display {
+pub trait Error: Debug + Display + Reflect {
     /// A short description of the error.
     ///
     /// The description should not contain newlines or sentence-ending
@@ -71,6 +74,14 @@ pub trait Error: Debug + Display {
     /// The lower-level cause of this error, if any.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn cause(&self) -> Option<&Error> { None }
+
+    /// Get the `TypeId` of `self`
+    #[doc(hidden)]
+    #[unstable(feature = "core",
+               reason = "unclear whether to commit to this public implementation detail")]
+    fn type_id(&self) -> TypeId where Self: 'static {
+        TypeId::of::<Self>()
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -154,3 +165,112 @@ impl Error for string::FromUtf16Error {
     }
 }
 
+// copied from any.rs
+impl Error + 'static {
+    /// Returns true if the boxed type is the same as `T`
+    #[unstable(feature = "error_downcast", reason = "recently added")]
+    #[inline]
+    pub fn is<T: Error + 'static>(&self) -> bool {
+        // Get TypeId of the type this function is instantiated with
+        let t = TypeId::of::<T>();
+
+        // Get TypeId of the type in the trait object
+        let boxed = self.type_id();
+
+        // Compare both TypeIds on equality
+        t == boxed
+    }
+
+    /// Returns some reference to the boxed value if it is of type `T`, or
+    /// `None` if it isn't.
+    #[unstable(feature = "error_downcast", reason = "recently added")]
+    #[inline]
+    pub fn downcast_ref<T: Error + 'static>(&self) -> Option<&T> {
+        if self.is::<T>() {
+            unsafe {
+                // Get the raw representation of the trait object
+                let to: TraitObject = transmute(self);
+
+                // Extract the data pointer
+                Some(transmute(to.data))
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Returns some mutable reference to the boxed value if it is of type `T`, or
+    /// `None` if it isn't.
+    #[unstable(feature = "error_downcast", reason = "recently added")]
+    #[inline]
+    pub fn downcast_mut<T: Error + 'static>(&mut self) -> Option<&mut T> {
+        if self.is::<T>() {
+            unsafe {
+                // Get the raw representation of the trait object
+                let to: TraitObject = transmute(self);
+
+                // Extract the data pointer
+                Some(transmute(to.data))
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl Error + 'static + Send {
+    /// Forwards to the method defined on the type `Any`.
+    #[unstable(feature = "error_downcast", reason = "recently added")]
+    #[inline]
+    pub fn is<T: Error + 'static>(&self) -> bool {
+        <Error + 'static>::is::<T>(self)
+    }
+
+    /// Forwards to the method defined on the type `Any`.
+    #[unstable(feature = "error_downcast", reason = "recently added")]
+    #[inline]
+    pub fn downcast_ref<T: Error + 'static>(&self) -> Option<&T> {
+        <Error + 'static>::downcast_ref::<T>(self)
+    }
+
+    /// Forwards to the method defined on the type `Any`.
+    #[unstable(feature = "error_downcast", reason = "recently added")]
+    #[inline]
+    pub fn downcast_mut<T: Error + 'static>(&mut self) -> Option<&mut T> {
+        <Error + 'static>::downcast_mut::<T>(self)
+    }
+}
+
+impl Error {
+    #[inline]
+    #[unstable(feature = "error_downcast", reason = "recently added")]
+    /// Attempt to downcast the box to a concrete type.
+    pub fn downcast<T: Error + 'static>(self: Box<Self>) -> Result<Box<T>, Box<Error>> {
+        if self.is::<T>() {
+            unsafe {
+                // Get the raw representation of the trait object
+                let raw = boxed::into_raw(self);
+                let to: TraitObject =
+                    transmute::<*mut Error, TraitObject>(raw);
+
+                // Extract the data pointer
+                Ok(Box::from_raw(to.data as *mut T))
+            }
+        } else {
+            Err(self)
+        }
+    }
+}
+
+impl Error + Send {
+    #[inline]
+    #[unstable(feature = "error_downcast", reason = "recently added")]
+    /// Attempt to downcast the box to a concrete type.
+    pub fn downcast<T: Error + 'static>(self: Box<Self>) -> Result<Box<T>, Box<Error + Send>> {
+        let err: Box<Error> = self;
+        <Error>::downcast(err).map_err(|s| unsafe {
+            // reapply the Send marker
+            transmute::<Box<Error>, Box<Error + Send>>(s)
+        })
+    }
+}

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -13,6 +13,7 @@
 use prelude::v1::*;
 use io::prelude::*;
 
+use marker::Reflect;
 use cmp;
 use error;
 use fmt;
@@ -322,7 +323,7 @@ impl<W> From<IntoInnerError<W>> for Error {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<W: Send + fmt::Debug> error::Error for IntoInnerError<W> {
+impl<W: Reflect + Send + fmt::Debug> error::Error for IntoInnerError<W> {
     fn description(&self) -> &str {
         error::Error::description(self.error())
     }

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -272,6 +272,7 @@ use error;
 use fmt;
 use mem;
 use cell::UnsafeCell;
+use marker::Reflect;
 
 pub use self::select::{Select, Handle};
 use self::select::StartResult;
@@ -955,8 +956,7 @@ impl<T> fmt::Display for SendError<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Send> error::Error for SendError<T> {
-
+impl<T: Send + Reflect> error::Error for SendError<T> {
     fn description(&self) -> &str {
         "sending on a closed channel"
     }
@@ -991,7 +991,7 @@ impl<T> fmt::Display for TrySendError<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Send> error::Error for TrySendError<T> {
+impl<T: Send + Reflect> error::Error for TrySendError<T> {
 
     fn description(&self) -> &str {
         match *self {

--- a/src/libstd/sys/common/poison.rs
+++ b/src/libstd/sys/common/poison.rs
@@ -10,6 +10,7 @@
 
 use prelude::v1::*;
 
+use marker::Reflect;
 use cell::UnsafeCell;
 use error::{Error};
 use fmt;
@@ -109,7 +110,7 @@ impl<T> fmt::Display for PoisonError<T> {
     }
 }
 
-impl<T: Send> Error for PoisonError<T> {
+impl<T: Send + Reflect> Error for PoisonError<T> {
     fn description(&self) -> &str {
         "poisoned lock: another task failed inside"
     }
@@ -155,13 +156,13 @@ impl<T> fmt::Debug for TryLockError<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Send> fmt::Display for TryLockError<T> {
+impl<T: Send + Reflect> fmt::Display for TryLockError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.description().fmt(f)
     }
 }
 
-impl<T: Send> Error for TryLockError<T> {
+impl<T: Send + Reflect> Error for TryLockError<T> {
     fn description(&self) -> &str {
         match *self {
             TryLockError::Poisoned(ref p) => p.description(),


### PR DESCRIPTION
This commit brings the `Error` trait in line with the [Error interoperation
RFC](https://github.com/rust-lang/rfcs/pull/201) by adding downcasting,
which has long been intended. This change means that for any `Error`
trait objects that are `'static`, you can downcast to concrete error
types.

To make this work, it is necessary for `Error` to inherit from
`Reflect` (which is currently used to mark concrete types as "permitted
for reflection, aka downcasting"). This is a breaking change: it means
that impls like

``` rust
impl<T> Error for MyErrorType<T> { ... }
```

must change to

``` rust
impl<T: Reflect> Error for MyErrorType<T> { ... }
```

This commit furthermore marks `Reflect` as stable, since we are already
essentially committed to it via `Any`. Note that in the future, if we
determine that the parametricity aspects of `Reflect` are not needed, we
can deprecate the trait and provide a blanket implementation for it
for _all_ types (rather than by using OIBIT), which would allow all
mentions of `Reflect` to be dropped over time. So there is not a strong
commitment here.

[breaking-change]

r? @alexcrichton 
