### PR TITLE
In [-] doc buttons, change hyphen ‘-’ to minus ‘−’

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1460,7 +1460,7 @@ impl<'a> fmt::Display for Item<'a> {
         try!(write!(fmt, "<span class='out-of-band'>"));
         try!(write!(fmt,
         r##"<span id='render-detail'>
-            <a id="toggle-all-docs" href="#" title="collapse all docs">[-]</a>
+            <a id="toggle-all-docs" href="#" title="collapse all docs">[−]</a>
         </span>"##));
 
         // Write `src` tag

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1460,7 +1460,7 @@ impl<'a> fmt::Display for Item<'a> {
         try!(write!(fmt, "<span class='out-of-band'>"));
         try!(write!(fmt,
         r##"<span id='render-detail'>
-            <a id="toggle-all-docs" href="#" title="collapse all docs">[−]</a>
+            <a id="toggle-all-docs" href="#" title="collapse all docs">[&minus;]</a>
         </span>"##));
 
         // Write `src` tag

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -808,7 +808,7 @@
 
     $("#toggle-all-docs").on("click", function() {
         var toggle = $("#toggle-all-docs");
-        if (toggle.html() == "[-]") {
+        if (toggle.html() == "[−]") {
             toggle.html("[+]");
             toggle.attr("title", "expand all docs");
             $(".docblock").hide();
@@ -816,12 +816,12 @@
             $(".toggle-wrapper").addClass("collapsed");
             $(".collapse-toggle").children(".inner").html("+");
         } else {
-            toggle.html("[-]");
+            toggle.html("[−]");
             toggle.attr("title", "collapse all docs");
             $(".docblock").show();
             $(".toggle-label").hide();
             $(".toggle-wrapper").removeClass("collapsed");
-            $(".collapse-toggle").children(".inner").html("-");
+            $(".collapse-toggle").children(".inner").html("−");
         }
     });
 
@@ -840,7 +840,7 @@
             } else {
                 relatedDoc.slideDown({duration:'fast', easing:'linear'});
                 toggle.parent(".toggle-wrapper").removeClass("collapsed");
-                toggle.children(".inner").html("-");
+                toggle.children(".inner").html("−");
                 toggle.children(".toggle-label").hide();
             }
         }
@@ -848,7 +848,7 @@
 
     $(function() {
         var toggle = $("<a/>", {'href': 'javascript:void(0)', 'class': 'collapse-toggle'})
-            .html("[<span class='inner'>-</span>]");
+            .html("[<span class='inner'>−</span>]");
 
         $(".method").each(function() {
             if ($(this).next().is(".docblock") ||

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -808,20 +808,20 @@
 
     $("#toggle-all-docs").on("click", function() {
         var toggle = $("#toggle-all-docs");
-        if (toggle.html() == "[−]") {
-            toggle.html("[+]");
+        if (toggle.html() == "[&minus;]") {
+            toggle.html("[&plus;]");
             toggle.attr("title", "expand all docs");
             $(".docblock").hide();
             $(".toggle-label").show();
             $(".toggle-wrapper").addClass("collapsed");
-            $(".collapse-toggle").children(".inner").html("+");
+            $(".collapse-toggle").children(".inner").html("&plus;");
         } else {
-            toggle.html("[−]");
+            toggle.html("[&minus;]");
             toggle.attr("title", "collapse all docs");
             $(".docblock").show();
             $(".toggle-label").hide();
             $(".toggle-wrapper").removeClass("collapsed");
-            $(".collapse-toggle").children(".inner").html("−");
+            $(".collapse-toggle").children(".inner").html("&minus;");
         }
     });
 
@@ -835,12 +835,12 @@
             if (relatedDoc.is(":visible")) {
                 relatedDoc.slideUp({duration:'fast', easing:'linear'});
                 toggle.parent(".toggle-wrapper").addClass("collapsed");
-                toggle.children(".inner").html("+");
+                toggle.children(".inner").html("&plus;");
                 toggle.children(".toggle-label").fadeIn();
             } else {
                 relatedDoc.slideDown({duration:'fast', easing:'linear'});
                 toggle.parent(".toggle-wrapper").removeClass("collapsed");
-                toggle.children(".inner").html("−");
+                toggle.children(".inner").html("&minus;");
                 toggle.children(".toggle-label").hide();
             }
         }
@@ -848,7 +848,7 @@
 
     $(function() {
         var toggle = $("<a/>", {'href': 'javascript:void(0)', 'class': 'collapse-toggle'})
-            .html("[<span class='inner'>−</span>]");
+            .html("[<span class='inner'>&minus;</span>]");
 
         $(".method").each(function() {
             if ($(this).next().is(".docblock") ||


### PR DESCRIPTION
The minus sign ‘−’ is the same width as the plus sign ‘+’, so the button’s transition between the two symbols will look slightly smoother.

If you don’t want to use literal Unicode characters, I can change ‘−’ to `\u2212`. I’m not starting with that suggestion because ‘−’ is easier to read and understand, and if I used `\u2212`, it would probably be necessary to also comment the usage on each line to explain what character is being used.
