### PR TITLE
Reference manual 3.5.2.3.1

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -269,10 +269,11 @@ r##"foo #"# bar"##;                // foo #"# bar
 ##### Byte literals
 
 A _byte literal_ is a single ASCII character (in the `U+0000` to `U+007F`
-range) enclosed within two `U+0027` (single-quote) characters, with the
-exception of `U+0027` itself, which must be _escaped_ by a preceding U+005C
-character (`\`), or a single _escape_. It is equivalent to a `u8` unsigned
-8-bit integer _number literal_.
+range) or a single _escape_ preceded by the characters `U+0062` (`b`) and
+`U+0027` (single-quote), and followed by the character `U+0027`. If the character
+`U+0027` is present within the literal, it must be _escaped_ by a preceding
+`U+005C` (`\`) character. It is equivalent to a `u8` unsigned 8-bit integer
+_number literal_.
 
 ##### Byte string literals
 


### PR DESCRIPTION
The description of the syntax for single byte literals is missing the preceding `b` distinction.
