### PR TITLE
rustdoc: change color of trait types

### DIFF
--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -392,7 +392,7 @@ a {
     text-decoration: underline;
 }
 
-.content span.trait, .content a.trait, .block a.current.trait { color: #ed9603; }
+.content span.trait, .content a.trait, .block a.current.trait { color: #8866ff; }
 .content span.mod, .content a.mod, block a.current.mod { color: #4d76ae; }
 .content span.enum, .content a.enum, .block a.current.enum { color: #5e9766; }
 .content span.struct, .content a.struct, .block a.current.struct { color: #e53700; }


### PR DESCRIPTION
Fixes #24441 

Preview:
![new-trait-color](https://cloud.githubusercontent.com/assets/346530/7331922/d6cbcf72-eb58-11e4-8a1d-4ca5e3683ed2.png)
