### PR TITLE
librustc_trans: Don't ICE on unsized type behind raw pointer in nullable pointer opt.

### DIFF
--- a/src/librustc_trans/trans/adt.rs
+++ b/src/librustc_trans/trans/adt.rs
@@ -414,6 +414,10 @@ fn find_discr_field_candidate<'tcx>(tcx: &ty::ctxt<'tcx>,
             assert_eq!(nonzero_fields.len(), 1);
             let nonzero_field = ty::lookup_field_type(tcx, did, nonzero_fields[0].id, substs);
             match nonzero_field.sty {
+                ty::ty_ptr(ty::mt { ty, .. }) if !type_is_sized(tcx, ty) => {
+                    path.push_all(&[0, FAT_PTR_ADDR]);
+                    Some(path)
+                },
                 ty::ty_ptr(..) | ty::ty_int(..) | ty::ty_uint(..) => {
                     path.push(0);
                     Some(path)

--- a/src/test/run-pass/issue-23433.rs
+++ b/src/test/run-pass/issue-23433.rs
@@ -1,0 +1,24 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Don't fail if we encounter a NonZero<*T> where T is an unsized type
+
+#![feature(unique)]
+
+use std::ptr::Unique;
+
+fn main() {
+    let mut a = [0u8; 5];
+    let b: Option<Unique<[u8]>> = unsafe { Some(Unique::new(&mut a)) };
+    match b {
+        Some(_) => println!("Got `Some`"),
+        None => panic!("Unexpected `None`"),
+    }
+}


### PR DESCRIPTION
Fixes #23433.
