### PR TITLE
Fix "Compiler Plugins" path in the Rust reference

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1976,7 +1976,7 @@ For any lint check `C`:
 
 The lint checks supported by the compiler can be found via `rustc -W help`,
 along with their default settings.  [Compiler
-plugins](book/plugins.html#lint-plugins) can provide additional lint checks.
+plugins](book/compiler-plugins.html#lint-plugins) can provide additional lint checks.
 
 ```{.ignore}
 mod m1 {
@@ -3646,4 +3646,4 @@ that have since been removed):
   pattern syntax
 
 [ffi]: book/ffi.html
-[plugin]: book/plugins.html
+[plugin]: book/compiler-plugins.html


### PR DESCRIPTION
The reference has broken links. This should fix it.
