### PR TITLE
Added a link address to Vectors page of the book

### DIFF
--- a/src/doc/trpl/vectors.md
+++ b/src/doc/trpl/vectors.md
@@ -56,3 +56,4 @@ Vectors have many more useful methods, which you can read about in [their
 API documentation][vec].
 
 [vec]: ../std/vec/index.html
+[generic]: generics.html


### PR DESCRIPTION
At https://doc.rust-lang.org/book/vectors.html, there should be a link to
Generics page but the link address is ommitted and thus link is not functioning
well. So I added a link definition to the vectors.md.

r? @steveklabnik
