### PR TITLE
Remove an unused import on windows

### DIFF
--- a/src/libstd/sys/windows/fs2.rs
+++ b/src/libstd/sys/windows/fs2.rs
@@ -13,7 +13,6 @@ use io::prelude::*;
 use os::windows::prelude::*;
 
 use ffi::OsString;
-use fmt;
 use io::{self, Error, SeekFrom};
 use libc::{self, HANDLE};
 use mem;


### PR DESCRIPTION
A fix for a new beta build (which failed on the bots)
