### PR TITLE
Fix the inline assembly examples

### DIFF
--- a/src/doc/trpl/inline-assembly.md
+++ b/src/doc/trpl/inline-assembly.md
@@ -77,7 +77,7 @@ asm!("xor %eax, %eax" ::: "{eax}");
 
 Input and output operands follow the same format: `:
 "constraints1"(expr1), "constraints2"(expr2), ..."`. Output operand
-expressions must be mutable lvalues:
+expressions must be mutable lvalues, or not yet assigned:
 
 ```
 # #![feature(asm)]

--- a/src/doc/trpl/inline-assembly.md
+++ b/src/doc/trpl/inline-assembly.md
@@ -58,7 +58,7 @@ but you must add the right number of `:` if you skip them:
 asm!("xor %eax, %eax"
     :
     :
-    : "eax"
+    : "{eax}"
    );
 # } }
 ```
@@ -69,7 +69,7 @@ Whitespace also doesn't matter:
 # #![feature(asm)]
 # #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 # fn main() { unsafe {
-asm!("xor %eax, %eax" ::: "eax");
+asm!("xor %eax, %eax" ::: "{eax}");
 # } }
 ```
 
@@ -83,7 +83,7 @@ expressions must be mutable lvalues:
 # #![feature(asm)]
 # #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn add(a: i32, b: i32) -> i32 {
-    let mut c = 0;
+    let c: i32;
     unsafe {
         asm!("add $2, $0"
              : "=r"(c)
@@ -100,6 +100,21 @@ fn main() {
 }
 ```
 
+If you would like to use real operands in this position, however,
+you are required to put curly braces `{}` around the register that
+you want, and you are required to put the specific size of the
+operand. This is useful for very low level programming, where 
+which register you use is important:
+
+```
+# #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+# unsafe fn read_byte_in(port: u16) -> u8 {
+let result: u8;
+asm!("in %dx, %al" : "={al}"(result) : "{dx}"(port));
+result
+# }
+```
+
 ## Clobbers
 
 Some instructions modify registers which might otherwise have held
@@ -112,7 +127,7 @@ stay valid.
 # #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 # fn main() { unsafe {
 // Put the value 0x200 in eax
-asm!("mov $$0x200, %eax" : /* no outputs */ : /* no inputs */ : "eax");
+asm!("mov $$0x200, %eax" : /* no outputs */ : /* no inputs */ : "{eax}");
 # } }
 ```
 
@@ -139,3 +154,14 @@ Current valid options are:
    the compiler to insert its usual stack alignment code
 3. *intel* - use intel syntax instead of the default AT&T.
 
+```
+# #![feature(asm)]
+# #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+# fn main() {
+let result: i32;
+unsafe {
+   asm!("mov eax, 2" : "={eax}"(result) : : : "intel")
+}
+println!("eax is currently {}", result);
+# } }
+```

--- a/src/doc/trpl/inline-assembly.md
+++ b/src/doc/trpl/inline-assembly.md
@@ -107,6 +107,7 @@ operand. This is useful for very low level programming, where
 which register you use is important:
 
 ```
+# #![feature(asm)]
 # #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 # unsafe fn read_byte_in(port: u16) -> u8 {
 let result: u8;
@@ -163,5 +164,5 @@ unsafe {
    asm!("mov eax, 2" : "={eax}"(result) : : : "intel")
 }
 println!("eax is currently {}", result);
-# } }
+# }
 ```


### PR DESCRIPTION
They now use the currently working syntax.

Also, I added two examples.
