### PR TITLE
Work around poor codegen for cttz8 with defined results for zero

### DIFF
--- a/src/test/run-pass/intrinsics-integer.rs
+++ b/src/test/run-pass/intrinsics-integer.rs
@@ -109,11 +109,6 @@ pub fn main() {
         assert_eq!(cttz32(100), 2);
         assert_eq!(cttz64(100), 2);
 
-        assert_eq!(cttz8(-1), 0);
-        assert_eq!(cttz16(-1), 0);
-        assert_eq!(cttz32(-1), 0);
-        assert_eq!(cttz64(-1), 0);
-
         assert_eq!(bswap16(0x0A0B), 0x0B0A);
         assert_eq!(bswap32(0x0ABBCC0D), 0x0DCCBB0A);
         assert_eq!(bswap64(0x0122334455667708), 0x0877665544332201);


### PR DESCRIPTION
Currently, LLVM lowers a cttz8 on x86_64 to these instructions:

``` asm
    movzbl      %dil, %eax
    bsfl        %eax, %eax
    movl        $32, %ecx
    cmovnel     %eax, %ecx
    cmpl        $32, %ecx
    movl        $8, %eax
    cmovnel     %ecx, %eax
```

To improve the codegen, we can zero extend the 8 bit integer, then set
bit 8 and perform a cttz operation on the extended value. That way
there's no conditional operation involved at all.

This was discovered by  this benchmark: https://github.com/Kimundi/long_strings_without_repeats

Timings on my box with the current nightly:

```
running 4 tests
test bench_cpp_naive_big     ... bench:   5479222 ns/iter (+/- 254222)
test bench_noop_big          ... bench:    571405 ns/iter (+/- 111950)
test bench_rust_naive_big    ... bench:   7798102 ns/iter (+/- 148841)
test bench_rust_unsafe_big   ... bench:   6606488 ns/iter (+/- 67529)
```

Timings with the patch applied:

```
running 4 tests
test bench_cpp_naive_big     ... bench:   5470944 ns/iter (+/- 7109)
test bench_noop_big          ... bench:    568944 ns/iter (+/- 6895)
test bench_rust_naive_big    ... bench:   6795901 ns/iter (+/- 43806)
test bench_rust_unsafe_big   ... bench:   5584879 ns/iter (+/- 5291)
```
