### PR TITLE
IMO better borrow_mut() documentation on RefCell

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -417,7 +417,7 @@ impl<T> RefCell<T> {
     ///
     /// let result = thread::spawn(move || {
     ///    let c = RefCell::new(5);
-    ///    let m = c.borrow_mut();
+    ///    let m = c.borrow();
     ///
     ///    let b = c.borrow_mut(); // this causes a panic
     /// }).join();


### PR DESCRIPTION
Previous borrow() is enough to make borrow_mut() panic, no need to have borrow_mut() twice. [This](http://is.gd/woKKAW)
