### PR TITLE
configure: Disable rpass-valgrind when there's no valgrind

### DIFF
--- a/configure
+++ b/configure
@@ -19,6 +19,11 @@ err() {
     exit 1
 }
 
+run() {
+    msg "$@"
+    "$@"
+}
+
 need_ok() {
     if [ $? -ne 0 ]
     then
@@ -36,8 +41,7 @@ need_cmd() {
 make_dir() {
     if [ ! -d $1 ]
     then
-        msg "mkdir -p $1"
-        mkdir -p $1
+        run mkdir -p $1
     fi
 }
 
@@ -46,8 +50,7 @@ copy_if_changed() {
     then
         msg "leaving $2 unchanged"
     else
-        msg "cp $1 $2"
-        cp -f $1 $2
+        run cp -f $1 $2
         chmod u-w $2 # make copied artifact read-only
     fi
 }
@@ -57,8 +60,7 @@ move_if_changed() {
     then
         msg "leaving $2 unchanged"
     else
-        msg "mv $1 $2"
-        mv -f $1 $2
+        run mv -f $1 $2
         chmod u-w $2 # make moved artifact read-only
     fi
 }

--- a/configure
+++ b/configure
@@ -733,6 +733,14 @@ then
    probe CFG_JAVAC            javac
 fi
 
+# the valgrind rpass tests will fail if you don't have a valgrind, but they're
+# only disabled if you opt out.
+if [ -z "$CFG_VALGRIND" ]
+then
+    CFG_DISABLE_VALGRIND_RPASS=1
+    putvar CFG_DISABLE_VALGRIND_RPASS
+fi
+
 if [ ! -z "$CFG_GDB" ]
 then
     # Store GDB's version

--- a/configure
+++ b/configure
@@ -737,8 +737,14 @@ fi
 # only disabled if you opt out.
 if [ -z "$CFG_VALGRIND" ]
 then
-    CFG_DISABLE_VALGRIND_RPASS=1
-    putvar CFG_DISABLE_VALGRIND_RPASS
+    # If the user has explicitly asked for valgrind tests, then fail
+    if [ -n "$CFG_ENABLE_VALGRIND" ] && [ -n "$CFG_ENABLE_VALGRIND_PROVIDED" ]
+    then
+        err "No valgrind present, but valgrind tests explicitly requested"
+    else
+        CFG_DISABLE_VALGRIND_RPASS=1
+        putvar CFG_DISABLE_VALGRIND_RPASS
+    fi
 fi
 
 if [ ! -z "$CFG_GDB" ]

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -195,6 +195,7 @@ ifndef CFG_DISABLE_VALGRIND_RPASS
   $(info cfg: valgrind-rpass command set to $(CFG_VALGRIND))
   CFG_VALGRIND_RPASS :=$(CFG_VALGRIND)
 else
+  $(info cfg: disabling valgrind run-pass tests)
   CFG_VALGRIND_RPASS :=
 endif
 


### PR DESCRIPTION
This stung me more than once in dev.

Bonus DRY'ing up of configure that I did on my way past.
