### PR TITLE
trpl: Clarify lib.rs vs main.rs

### DIFF
--- a/src/doc/trpl/hello-cargo.md
+++ b/src/doc/trpl/hello-cargo.md
@@ -32,6 +32,13 @@ $ mkdir src
 $ mv main.rs src/main.rs
 ```
 
+Note that since we're creating an executable, we used `main.rs`. If we
+want to make a library instead, we should use `lib.rs`.
+Custom file locations for the entry point can be specified
+with a [`[[lib]]` or `[[bin]]`][crates-custom] key in the TOML file described below.
+
+[crates-custom]: http://doc.crates.io/manifest.html#configuring-a-target
+
 Cargo expects your source files to live inside a `src` directory. That leaves
 the top level for other things, like READMEs, license information, and anything
 not related to your code. Cargo helps us keep our projects nice and tidy. A


### PR DESCRIPTION
A user in IRC was having trouble because they used `main.rs` when they were trying
to migrate a library. The `[[lib]]` key is not easily found, and the `main.rs`/`lib.rs`
distinction doesn't seem to exist in trpl

r? @steveklabnik
