### PR TITLE
Extend the diagnostics plugin with uniqueness tests and JSON output.

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -517,5 +517,3 @@ register_diagnostics! {
     E0316, // nested quantification of lifetimes
     E0370  // discriminant overflow
 }
-
-__build_diagnostic_array! { DIAGNOSTICS }

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -161,3 +161,9 @@ pub mod lib {
 mod rustc {
     pub use lint;
 }
+
+// Build the diagnostics array at the end so that the metadata includes error use sites.
+#[cfg(stage0)]
+__build_diagnostic_array! { DIAGNOSTICS }
+#[cfg(not(stage0))]
+__build_diagnostic_array! { librustc, DIAGNOSTICS }

--- a/src/librustc_borrowck/diagnostics.rs
+++ b/src/librustc_borrowck/diagnostics.rs
@@ -13,5 +13,3 @@
 register_diagnostics! {
     E0373 // closure may outlive current fn, but it borrows {}, which is owned by current fn
 }
-
-__build_diagnostic_array! { DIAGNOSTICS }

--- a/src/librustc_borrowck/lib.rs
+++ b/src/librustc_borrowck/lib.rs
@@ -47,3 +47,8 @@ pub mod diagnostics;
 mod borrowck;
 
 pub mod graphviz;
+
+#[cfg(stage0)]
+__build_diagnostic_array! { DIAGNOSTICS }
+#[cfg(not(stage0))]
+__build_diagnostic_array! { librustc_borrowck, DIAGNOSTICS }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -854,9 +854,10 @@ pub fn diagnostics_registry() -> diagnostics::registry::Registry {
     use syntax::diagnostics::registry::Registry;
 
     let all_errors = Vec::new() +
-        &rustc::diagnostics::DIAGNOSTICS[..] +
-        &rustc_typeck::diagnostics::DIAGNOSTICS[..] +
-        &rustc_resolve::diagnostics::DIAGNOSTICS[..];
+        &rustc::DIAGNOSTICS[..] +
+        &rustc_typeck::DIAGNOSTICS[..] +
+        &rustc_borrowck::DIAGNOSTICS[..] +
+        &rustc_resolve::DIAGNOSTICS[..];
 
     Registry::new(&*all_errors)
 }

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -28,5 +28,3 @@ register_diagnostics! {
     E0364, // item is private
     E0365  // item is private
 }
-
-__build_diagnostic_array! { DIAGNOSTICS }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3580,3 +3580,8 @@ pub fn resolve_crate<'a, 'tcx>(session: &'a Session,
                     },
     }
 }
+
+#[cfg(stage0)]
+__build_diagnostic_array! { DIAGNOSTICS }
+#[cfg(not(stage0))]
+__build_diagnostic_array! { librustc_resolve, DIAGNOSTICS }

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -183,5 +183,3 @@ register_diagnostics! {
     E0371, // impl Trait for Trait is illegal
     E0372  // impl Trait for Trait where Trait is not object safe
 }
-
-__build_diagnostic_array! { DIAGNOSTICS }

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -344,3 +344,8 @@ pub fn check_crate(tcx: &ty::ctxt, trait_map: ty::TraitMap) {
     check_for_entry_fn(&ccx);
     tcx.sess.abort_if_errors();
 }
+
+#[cfg(stage0)]
+__build_diagnostic_array! { DIAGNOSTICS }
+#[cfg(not(stage0))]
+__build_diagnostic_array! { librustc_typeck, DIAGNOSTICS }

--- a/src/libsyntax/diagnostics/metadata.rs
+++ b/src/libsyntax/diagnostics/metadata.rs
@@ -1,0 +1,155 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! This module contains utilities for outputting metadata for diagnostic errors.
+//!
+//! Each set of errors is mapped to a metadata file by a name, which is
+//! currently always a crate name.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::path::PathBuf;
+use std::fs::{read_dir, create_dir_all, OpenOptions, File};
+use std::io::{Read, Write};
+use std::error::Error;
+use rustc_serialize::json::{self, as_json};
+
+use codemap::Span;
+use ext::base::ExtCtxt;
+use diagnostics::plugin::{ErrorMap, ErrorInfo};
+
+pub use self::Uniqueness::*;
+
+// Default metadata directory to use for extended error JSON.
+const ERROR_METADATA_DIR_DEFAULT: &'static str = "tmp/extended-errors";
+
+// The name of the environment variable that sets the metadata dir.
+const ERROR_METADATA_VAR: &'static str = "ERROR_METADATA_DIR";
+
+/// JSON encodable/decodable version of `ErrorInfo`.
+#[derive(PartialEq, RustcDecodable, RustcEncodable)]
+pub struct ErrorMetadata {
+    pub description: Option<String>,
+    pub use_site: Option<ErrorLocation>
+}
+
+/// Mapping from error codes to metadata that can be (de)serialized.
+pub type ErrorMetadataMap = BTreeMap<String, ErrorMetadata>;
+
+/// JSON encodable error location type with filename and line number.
+#[derive(PartialEq, RustcDecodable, RustcEncodable)]
+pub struct ErrorLocation {
+    pub filename: String,
+    pub line: usize
+}
+
+impl ErrorLocation {
+    /// Create an error location from a span.
+    pub fn from_span(ecx: &ExtCtxt, sp: Span) -> ErrorLocation {
+        let loc = ecx.codemap().lookup_char_pos_adj(sp.lo);
+        ErrorLocation {
+            filename: loc.filename,
+            line: loc.line
+        }
+    }
+}
+
+/// Type for describing the uniqueness of a set of error codes, as returned by `check_uniqueness`.
+pub enum Uniqueness {
+    /// All errors in the set checked are unique according to the metadata files checked.
+    Unique,
+    /// One or more errors in the set occur in another metadata file.
+    /// This variant contains the first duplicate error code followed by the name
+    /// of the metadata file where the duplicate appears.
+    Duplicate(String, String)
+}
+
+/// Get the directory where metadata files should be stored.
+pub fn get_metadata_dir() -> PathBuf {
+    match env::var(ERROR_METADATA_VAR) {
+        Ok(v) => From::from(v),
+        Err(_) => From::from(ERROR_METADATA_DIR_DEFAULT)
+    }
+}
+
+/// Get the path where error metadata for the set named by `name` should be stored.
+fn get_metadata_path(name: &str) -> PathBuf {
+    get_metadata_dir().join(format!("{}.json", name))
+}
+
+/// Check that the errors in `err_map` aren't present in any metadata files in the
+/// metadata directory except the metadata file corresponding to `name`.
+pub fn check_uniqueness(name: &str, err_map: &ErrorMap) -> Result<Uniqueness, Box<Error>> {
+    let metadata_dir = get_metadata_dir();
+    let metadata_path = get_metadata_path(name);
+
+    // Create the error directory if it does not exist.
+    try!(create_dir_all(&metadata_dir));
+
+    // Check each file in the metadata directory.
+    for entry in try!(read_dir(&metadata_dir)) {
+        let path = try!(entry).path();
+
+        // Skip any existing file for this set.
+        if path == metadata_path {
+            continue;
+        }
+
+        // Read the metadata file into a string.
+        let mut metadata_str = String::new();
+        try!(
+            File::open(&path).and_then(|mut f|
+            f.read_to_string(&mut metadata_str))
+        );
+
+        // Parse the JSON contents.
+        let metadata: ErrorMetadataMap = try!(json::decode(&metadata_str));
+
+        // Check for duplicates.
+        for err in err_map.keys() {
+            let err_code = err.as_str();
+            if metadata.contains_key(err_code) {
+                return Ok(Duplicate(
+                    err_code.to_string(),
+                    path.to_string_lossy().into_owned()
+                ));
+            }
+        }
+    }
+
+    Ok(Unique)
+}
+
+/// Write metadata for the errors in `err_map` to disk, to a file corresponding to `name`.
+pub fn output_metadata(ecx: &ExtCtxt, name: &str, err_map: &ErrorMap)
+    -> Result<(), Box<Error>>
+{
+    let metadata_path = get_metadata_path(name);
+
+    // Open the dump file.
+    let mut dump_file = try!(OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(&metadata_path)
+    );
+
+    // Construct a serializable map.
+    let json_map = err_map.iter().map(|(k, &ErrorInfo { description, use_site })| {
+        let key = k.as_str().to_string();
+        let value = ErrorMetadata {
+            description: description.map(|n| n.as_str().to_string()),
+            use_site: use_site.map(|sp| ErrorLocation::from_span(ecx, sp))
+        };
+        (key, value)
+    }).collect::<ErrorMetadataMap>();
+
+    try!(write!(&mut dump_file, "{}", as_json(&json_map)));
+    Ok(())
+}

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -69,6 +69,7 @@ pub mod diagnostics {
     pub mod macros;
     pub mod plugin;
     pub mod registry;
+    pub mod metadata;
 }
 
 pub mod syntax {

--- a/src/test/run-make/issue-19371/foo.rs
+++ b/src/test/run-make/issue-19371/foo.rs
@@ -49,7 +49,7 @@ fn basic_sess(sysroot: PathBuf) -> Session {
     opts.output_types = vec![OutputTypeExe];
     opts.maybe_sysroot = Some(sysroot);
 
-    let descriptions = Registry::new(&rustc::diagnostics::DIAGNOSTICS);
+    let descriptions = Registry::new(&rustc::DIAGNOSTICS);
     let sess = build_session(opts, None, descriptions);
     rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
     sess


### PR DESCRIPTION
I've been working on improving the diagnostic registration system so that it can:
- Check uniqueness of error codes _across the whole compiler_. The current method using `errorck.py` is prone to failure as it relies on simple text search - I found that it breaks when referencing an error's ident within a string (e.g. `"See also E0303"`).
- Provide JSON output of error metadata, to eventually facilitate HTML output, as well as tracking of which errors need descriptions. The current schema is:

```
<error code>: {
    "description": <long description>,
    "use_site": {
        "filename": <filename where error is used>,
        "line": <line in file where error is used>
    }
}
```

[Here's](https://gist.github.com/michaelsproul/3246846ff1bea71bd049) a pretty-printed sample dump for `librustc`.

One thing to note is that I had to move the diagnostics arrays out of the diagnostics modules. I really wanted to be able to capture error usage information, which only becomes available as a crate is compiled. Hence all invocations of `__build_diagnostics_array!` have been moved to the ends of their respective `lib.rs` files. I tried to avoid moving the array by making a plugin that expands to nothing but couldn't invoke it in item position and gave up on hackily generating a fake item. I also briefly considered using a lint, but it seemed like it would impossible to get access to the data stored in the thread-local storage.

The next step will be to generate a web page that lists each error with its rendered description and use site. Simple mapping and filtering of the metadata files also allows us to work out which error numbers are absent, which errors are unused and which need descriptions.
