### PR TITLE
TRPL: Tiny incoherence in UFCS example.

### DIFF
--- a/src/doc/trpl/ufcs.md
+++ b/src/doc/trpl/ufcs.md
@@ -89,7 +89,7 @@ not, and so we need to pass an explicit `&b`.
 The form of UFCS we just talked about:
 
 ```rust,ignore
-Type::method(args);
+Trait::method(args);
 ```
 
 Is a short-hand. There’s an expanded form of this that’s needed in some


### PR DESCRIPTION
`Type` should be `Trait` to match the next example line.

r? @steveklabnik
