### PR TITLE
Add unsafe Option::unwrap_unchecked()

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -148,6 +148,7 @@ use self::Option::*;
 use clone::Clone;
 use cmp::{Eq, Ord};
 use default::Default;
+use intrinsics::unreachable;
 use iter::ExactSizeIterator;
 use iter::{Iterator, DoubleEndedIterator, FromIterator, IntoIterator};
 use mem;
@@ -396,6 +397,24 @@ impl<T> Option<T> {
             Some(x) => x,
             None => f()
         }
+    }
+
+    /// Moves the value `v` out of the `Option<T>` without checking for None.
+    ///
+    /// # Safety note
+    ///
+    /// Because it is undefined behavior to call this on a None, this function
+    /// is unsafe.
+    #[inline]
+    #[unstable(feature = "core")]
+    pub unsafe fn unwrap_unchecked(self) -> T {
+        if self.is_none() {
+            if cfg!(debug) {
+                panic!("called `Option::unwrap_unchecked()` on a `None` value");
+            }
+            unreachable();
+        }
+        unwrap(self)
     }
 
     /////////////////////////////////////////////////////////////////////////

--- a/src/libcoretest/option.rs
+++ b/src/libcoretest/option.rs
@@ -171,6 +171,13 @@ fn test_unwrap_or_else() {
 }
 
 #[test]
+fn test_unwrap_unchecked() {
+    assert_eq!(unsafe { Some(1).unwrap_unchecked() }, 1);
+    let s = unsafe { Some("hello".to_string()).unwrap_unchecked() };
+    assert_eq!(s, "hello");
+}
+
+#[test]
 fn test_iter() {
     let val = 5;
 


### PR DESCRIPTION
This adds a new function to the Option enum which allows for an
unchecked unwrap. In some cases, a developer may be able to statically
determine that an Option must be Some(V) but the compiler cannot. Being
able to forgo a conditional branch is desirable, even if unsafe.
