### PR TITLE
Grammar improvements

### DIFF
--- a/src/doc/grammar.md
+++ b/src/doc/grammar.md
@@ -176,7 +176,7 @@ excluded from the `ident` rule.
 
 ```antlr
 lit_suffix : ident;
-literal : [ string_lit | char_lit | byte_string_lit | byte_lit | num_lit ] lit_suffix ?;
+literal : [ string_lit | char_lit | byte_string_lit | byte_lit | num_lit | bool_lit ] lit_suffix ?;
 ```
 
 #### Character and string literals
@@ -238,7 +238,9 @@ dec_lit : [ dec_digit | '_' ] + ;
 
 #### Boolean literals
 
-**FIXME:** write grammar
+```antlr
+bool_lit : [ "true" | "false" ] ;
+```
 
 The two values of the boolean type are written `true` and `false`.
 

--- a/src/doc/grammar.md
+++ b/src/doc/grammar.md
@@ -179,6 +179,12 @@ lit_suffix : ident;
 literal : [ string_lit | char_lit | byte_string_lit | byte_lit | num_lit | bool_lit ] lit_suffix ?;
 ```
 
+The optional `lit_suffix` production is only used for certain numeric literals,
+but is reserved for future extension. That is, the above gives the lexical
+grammar, but a Rust parser will reject everything but the 12 special cases
+mentioned in [Number literals](reference.html#number-literals) in the
+reference.
+
 #### Character and string literals
 
 ```antlr

--- a/src/doc/grammar.md
+++ b/src/doc/grammar.md
@@ -297,7 +297,7 @@ transcriber : '(' transcriber * ')' | '[' transcriber * ']'
 
 ```antlr
 item : mod_item | fn_item | type_item | struct_item | enum_item
-     | static_item | trait_item | impl_item | extern_block ;
+     | const_item | static_item | trait_item | impl_item | extern_block ;
 ```
 
 ### Type Parameters
@@ -366,6 +366,10 @@ path_item : ident | "mod" ;
 **FIXME:** grammar?
 
 ### Structures
+
+**FIXME:** grammar?
+
+### Enumerations
 
 **FIXME:** grammar?
 

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -130,11 +130,6 @@ of tokens, that immediately and directly denotes the value it evaluates to,
 rather than referring to it by name or some other evaluation rule. A literal is
 a form of constant expression, so is evaluated (primarily) at compile time.
 
-The optional suffix is only used for certain numeric literals, but is
-reserved for future extension, that is, the above gives the lexical
-grammar, but a Rust parser will reject everything but the 12 special
-cases mentioned in [Number literals](#number-literals) below.
-
 #### Examples
 
 ##### Characters and strings


### PR DESCRIPTION
I'm interested in helping out with #16676 but more in the grammar than the reference-- here's my first chunk, more to come!! :tada: 

I did pull a bit _out_ of the reference, though, that was more relevant to the grammar but wasn't moved over as part of #24729.

I'm looking at, e.g. https://github.com/rust-lang/rust/blob/master/src/libsyntax/ast.rs, as the source of truth, please let me know if I should be checking against something else instead/in addition.

r? @steveklabnik
