### PR TITLE
Adapt benchmark tests to unit test guidelines

### DIFF
--- a/src/doc/trpl/benchmark-tests.md
+++ b/src/doc/trpl/benchmark-tests.md
@@ -13,7 +13,7 @@ pub fn add_two(a: i32) -> i32 {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use test::Bencher;
 


### PR DESCRIPTION
Since #24783, the style guidelines recommend that unit tests should live in a submodule `tests` rather than `test` to not clash with the possible use of libtest. This is especially important for benchmark tests as they require libtest. Fixes #24923.
