### PR TITLE
metadata: Fix zero-normalization of the pos of a `MultiByteChar`

### DIFF
--- a/src/librustc/metadata/creader.rs
+++ b/src/librustc/metadata/creader.rs
@@ -664,7 +664,7 @@ fn import_codemap(local_codemap: &codemap::CodeMap,
                     .into_inner()
                     .map_in_place(|mbc|
                         codemap::MultiByteChar {
-                            pos: mbc.pos + start_pos,
+                            pos: mbc.pos - start_pos,
                             bytes: mbc.bytes
                         });
 

--- a/src/test/auxiliary/issue24687_lib.rs
+++ b/src/test/auxiliary/issue24687_lib.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type="lib"]
+
+// This is a file that pulls in a separate file as a submodule, where
+// that separate file has many multi-byte characters, to try to
+// encourage the compiler to trip on them.
+
+mod issue24687_mbcs_in_comments;
+
+pub use issue24687_mbcs_in_comments::D;
+

--- a/src/test/auxiliary/issue24687_mbcs_in_comments.rs
+++ b/src/test/auxiliary/issue24687_mbcs_in_comments.rs
@@ -1,0 +1,37 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::fmt;
+
+// This ia file with many multi-byte characters, to try to encourage
+// the compiler to trip on them.  The Drop implementation below will
+// need to have its source location embedded into the debug info for
+// the output file.
+
+// αααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααααα
+// ββββββββββββββββββββββββββββββββββββββββββββββββββββββββββββββββββββββ
+// γγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγγ
+// δδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδδ
+// εεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεεε
+
+// ζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζζ
+// ηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηηη
+// θθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθθ
+// ιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιιι
+// κκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκκ
+
+pub struct D<X:fmt::Debug>(pub X);
+
+impl<X:fmt::Debug> Drop for D<X> {
+    fn drop(&mut self) {
+        // λλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλλ
+        println!("Dropping D({:?})", self.0);
+    }
+}

--- a/src/test/run-pass/issue24687-embed-debuginfo.rs
+++ b/src/test/run-pass/issue24687-embed-debuginfo.rs
@@ -1,0 +1,21 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue24687_lib.rs
+
+extern crate issue24687_lib as d;
+
+fn main() {
+    // Create a d, which has a destructor whose body will be trans'ed
+    // into the generated code here, and thus the local debuginfo will
+    // need references into the original source locations from
+    // `importer` above.
+    let _d = d::D("Hi");
+}


### PR DESCRIPTION
metdata: Fix zero-normalization of the pos of a `MultiByteChar`

Fix #24687

The source byte/character mappings for every crate track the collection of multi-characters from its source files specially.  When we import the source information for another file into the current compilation unit, we assign its byte-positions unique values by shifting them all by a fixed adjustment, tracked in the `start_pos` field.  But when we pull out the source span information for one function from one crate and into our own crate, we need to re-normalize the byte positions: subtracting the old `start_pos` and adding the new `start_pos`. The `new_imported_filemap(..)` method handles adding the new `start_pos`, so all `creader` needs to do is re-normalize each `pos` to zero.

It seems like it was indeed trying to do this, but it mistakenly added the old `start_pos` instead of subtracting it.
