### PR TITLE
link to .editorconfig for Rust files

### DIFF
--- a/src/etc/CONFIGS.md
+++ b/src/etc/CONFIGS.md
@@ -2,6 +2,7 @@
 
 Here are some links to repos with configs which ease the use of rust:
 
+* [.editorconfig](https://gist.github.com/derhuerst/c9d1b9309e308d9851fa) ([what is this?](http://editorconfig.org/))
 * [rust.vim](https://github.com/rust-lang/rust.vim)
 * [emacs rust-mode](https://github.com/rust-lang/rust-mode)
 * [gedit-config](https://github.com/rust-lang/gedit-config)

--- a/src/etc/CONFIGS.md
+++ b/src/etc/CONFIGS.md
@@ -1,11 +1,16 @@
 # Configs
 
-Here are some links to repos with configs which ease the use of rust:
+These are some links to repos with configs which ease the use of rust.
 
-* [.editorconfig](https://gist.github.com/derhuerst/c9d1b9309e308d9851fa) ([what is this?](http://editorconfig.org/))
+## Officially Maintained Configs
+
 * [rust.vim](https://github.com/rust-lang/rust.vim)
 * [emacs rust-mode](https://github.com/rust-lang/rust-mode)
 * [gedit-config](https://github.com/rust-lang/gedit-config)
 * [kate-config](https://github.com/rust-lang/kate-config)
 * [nano-config](https://github.com/rust-lang/nano-config)
 * [zsh-config](https://github.com/rust-lang/zsh-config)
+
+## Community-maintained Configs
+
+* [.editorconfig](https://gist.github.com/derhuerst/c9d1b9309e308d9851fa) ([what is this?](http://editorconfig.org/))


### PR DESCRIPTION
I've written a small [EditorConfig](http://editorconfig.org) file for Rust development.
