### PR TITLE
Add `-g` (to testcase) that I should have included in PR #24932.

### DIFF
--- a/src/test/run-pass/issue24687-embed-debuginfo.rs
+++ b/src/test/run-pass/issue24687-embed-debuginfo.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // aux-build:issue24687_lib.rs
+// compile-flags:-g
 
 extern crate issue24687_lib as d;
 


### PR DESCRIPTION
Add `-g` (to testcase) that I should have included in PR #24932.

Note it is safe, with respect to autobuilds, to land before #24945.

(In other words, landing this sooner won't break things for anyone any
worse than they were already broken, since there are _other_ tests
that also add `-g` to their flags via `compile-flags: -g`.)
