### PR TITLE
PIE on Android

### DIFF
--- a/src/librustc_back/target/aarch64_linux_android.rs
+++ b/src/librustc_back/target/aarch64_linux_android.rs
@@ -11,10 +11,6 @@
 use target::Target;
 
 pub fn target() -> Target {
-    let mut base = super::linux_base::opts();
-    base.pre_link_args.push("-Wl,--allow-multiple-definition".to_string());
-    base.is_like_android = true;
-    base.position_independent_executables = true;
     Target {
         data_layout: "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-\
                       f32:32:32-f64:64:64-v64:64:64-v128:128:128-a:0:64-\
@@ -25,6 +21,6 @@ pub fn target() -> Target {
         arch: "aarch64".to_string(),
         target_os: "android".to_string(),
         target_env: "".to_string(),
-        options: base,
+        options: super::android_base::opts(),
     }
 }

--- a/src/librustc_back/target/android_base.rs
+++ b/src/librustc_back/target/android_base.rs
@@ -1,0 +1,21 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use target::TargetOptions;
+
+pub fn opts() -> TargetOptions {
+    let mut base = super::linux_base::opts();
+    // Many of the symbols defined in compiler-rt are also defined in libgcc.
+    // Android's linker doesn't like that by default.
+    base.pre_link_args.push("-Wl,--allow-multiple-definition".to_string());
+    base.is_like_android = true;
+    base.position_independent_executables = true;
+    base
+}

--- a/src/librustc_back/target/arm_linux_androideabi.rs
+++ b/src/librustc_back/target/arm_linux_androideabi.rs
@@ -13,8 +13,6 @@ use target::Target;
 pub fn target() -> Target {
     let mut base = super::android_base::opts();
     base.features = "+v7".to_string();
-    // FIXME #17437 (and #17448): Android doesn't support position dependent executables anymore.
-    base.position_independent_executables = false;
 
     Target {
         data_layout: "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-\

--- a/src/librustc_back/target/arm_linux_androideabi.rs
+++ b/src/librustc_back/target/arm_linux_androideabi.rs
@@ -11,21 +11,15 @@
 use target::Target;
 
 pub fn target() -> Target {
-    let mut base = super::linux_base::opts();
+    let mut base = super::android_base::opts();
     base.features = "+v7".to_string();
-    // Many of the symbols defined in compiler-rt are also defined in libgcc.  Android
-    // linker doesn't like that by default.
-    base.pre_link_args.push("-Wl,--allow-multiple-definition".to_string());
-    base.is_like_android = true;
     // FIXME #17437 (and #17448): Android doesn't support position dependent executables anymore.
     base.position_independent_executables = false;
 
     Target {
-        data_layout: "e-p:32:32:32\
-                      -i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64\
-                      -f32:32:32-f64:64:64\
-                      -v64:64:64-v128:64:128\
-                      -a:0:64-n32".to_string(),
+        data_layout: "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-\
+                      f32:32:32-f64:64:64-v64:64:64-v128:64:128-a:0:64-\
+                      n32".to_string(),
         llvm_target: "arm-linux-androideabi".to_string(),
         target_endian: "little".to_string(),
         target_pointer_width: "32".to_string(),

--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -46,18 +46,19 @@
 //! specified by the target, rather than replace.
 
 use serialize::json::Json;
-use syntax::{diagnostic, abi};
 use std::default::Default;
 use std::io::prelude::*;
+use syntax::{diagnostic, abi};
 
-mod windows_base;
-mod linux_base;
+mod android_base;
 mod apple_base;
 mod apple_ios_base;
-mod freebsd_base;
-mod dragonfly_base;
 mod bitrig_base;
+mod dragonfly_base;
+mod freebsd_base;
+mod linux_base;
 mod openbsd_base;
+mod windows_base;
 
 /// Everything `rustc` knows about how to compile for a specific target.
 ///

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -10,6 +10,7 @@
 
 // no-pretty-expanded FIXME #15189
 // ignore-windows FIXME #13259
+// ignore-android FIXME #17520
 
 use std::env;
 use std::process::{Command, Stdio};


### PR DESCRIPTION
This is OK to do given:
- PIE is supported on Android starting with API 16.
- The bots are running API 18.
- API < 16 now has a 12.5% market share[0] as of 2015-04-29.

Closes #17437.

[0] https://developer.android.com/about/dashboards/index.html

r? @alexcrichton 
