### PR TITLE
Fix doc [−] button bug by escaping differently

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1460,7 +1460,7 @@ impl<'a> fmt::Display for Item<'a> {
         try!(write!(fmt, "<span class='out-of-band'>"));
         try!(write!(fmt,
         r##"<span id='render-detail'>
-            <a id="toggle-all-docs" href="#" title="collapse all docs">[&#x2212;]</a>
+            <a id="toggle-all-docs" href="javascript:void(0)" title="collapse all docs">[&#x2212;]</a>
         </span>"##));
 
         // Write `src` tag

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1460,8 +1460,9 @@ impl<'a> fmt::Display for Item<'a> {
         try!(write!(fmt, "<span class='out-of-band'>"));
         try!(write!(fmt,
         r##"<span id='render-detail'>
-            <a id="toggle-all-docs" href="javascript:void(0)"
-               title="collapse all docs">[&#x2212;]</a>
+            <a id="toggle-all-docs" href="javascript:void(0)" title="collapse all docs">
+                [<span class='inner'>&#x2212;</span>]
+            </a>
         </span>"##));
 
         // Write `src` tag

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1460,7 +1460,7 @@ impl<'a> fmt::Display for Item<'a> {
         try!(write!(fmt, "<span class='out-of-band'>"));
         try!(write!(fmt,
         r##"<span id='render-detail'>
-            <a id="toggle-all-docs" href="#" title="collapse all docs">[&minus;]</a>
+            <a id="toggle-all-docs" href="#" title="collapse all docs">[&#x2212;]</a>
         </span>"##));
 
         // Write `src` tag

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1460,7 +1460,8 @@ impl<'a> fmt::Display for Item<'a> {
         try!(write!(fmt, "<span class='out-of-band'>"));
         try!(write!(fmt,
         r##"<span id='render-detail'>
-            <a id="toggle-all-docs" href="javascript:void(0)" title="collapse all docs">[&#x2212;]</a>
+            <a id="toggle-all-docs" href="javascript:void(0)"
+               title="collapse all docs">[&#x2212;]</a>
         </span>"##));
 
         // Write `src` tag

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -581,7 +581,7 @@ pre.rust { position: relative; }
 
 .collapse-toggle > .inner {
     display: inline-block;
-    width: 1ch;
+    width: 1.2ch;
     text-align: center;
 }
 

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -808,20 +808,20 @@
 
     $("#toggle-all-docs").on("click", function() {
         var toggle = $("#toggle-all-docs");
-        if (toggle.html() == "[&minus;]") {
-            toggle.html("[&plus;]");
+        if (toggle.html() == "[\u2212]") {
+            toggle.html("[+]");
             toggle.attr("title", "expand all docs");
             $(".docblock").hide();
             $(".toggle-label").show();
             $(".toggle-wrapper").addClass("collapsed");
-            $(".collapse-toggle").children(".inner").html("&plus;");
+            $(".collapse-toggle").children(".inner").html("+");
         } else {
-            toggle.html("[&minus;]");
+            toggle.html("[\u2212]");
             toggle.attr("title", "collapse all docs");
             $(".docblock").show();
             $(".toggle-label").hide();
             $(".toggle-wrapper").removeClass("collapsed");
-            $(".collapse-toggle").children(".inner").html("&minus;");
+            $(".collapse-toggle").children(".inner").html("\u2212");
         }
     });
 
@@ -835,12 +835,12 @@
             if (relatedDoc.is(":visible")) {
                 relatedDoc.slideUp({duration:'fast', easing:'linear'});
                 toggle.parent(".toggle-wrapper").addClass("collapsed");
-                toggle.children(".inner").html("&plus;");
+                toggle.children(".inner").html("+");
                 toggle.children(".toggle-label").fadeIn();
             } else {
                 relatedDoc.slideDown({duration:'fast', easing:'linear'});
                 toggle.parent(".toggle-wrapper").removeClass("collapsed");
-                toggle.children(".inner").html("&minus;");
+                toggle.children(".inner").html("\u2212");
                 toggle.children(".toggle-label").hide();
             }
         }
@@ -848,7 +848,7 @@
 
     $(function() {
         var toggle = $("<a/>", {'href': 'javascript:void(0)', 'class': 'collapse-toggle'})
-            .html("[<span class='inner'>&minus;</span>]");
+            .html("[<span class='inner'>\u2212</span>]");
 
         $(".method").each(function() {
             if ($(this).next().is(".docblock") ||

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -816,7 +816,7 @@
             return "\u2212"; // "\u2212" is '−' minus sign
         }
     }
-    
+
     $("#toggle-all-docs").on("click", function() {
         var toggle = $("#toggle-all-docs");
         if (toggle.hasClass("will-expand")) {

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -806,22 +806,35 @@
         window.location = $('.srclink').attr('href');
     }
 
+    function labelForToggleButton(sectionIsCollapsed) {
+        if (sectionIsCollapsed) {
+            // button will expand the section
+            return "+";
+        } else {
+            // button will collapse the section
+            // note that this text is also set in the HTML template in render.rs
+            return "\u2212"; // "\u2212" is '−' minus sign
+        }
+    }
+    
     $("#toggle-all-docs").on("click", function() {
         var toggle = $("#toggle-all-docs");
-        if (toggle.html() == "[\u2212]") {
-            toggle.html("[+]");
-            toggle.attr("title", "expand all docs");
-            $(".docblock").hide();
-            $(".toggle-label").show();
-            $(".toggle-wrapper").addClass("collapsed");
-            $(".collapse-toggle").children(".inner").html("+");
-        } else {
-            toggle.html("[\u2212]");
+        if (toggle.hasClass("will-expand")) {
+            toggle.removeClass("will-expand");
+            toggle.children(".inner").text(labelForToggleButton(false));
             toggle.attr("title", "collapse all docs");
             $(".docblock").show();
             $(".toggle-label").hide();
             $(".toggle-wrapper").removeClass("collapsed");
-            $(".collapse-toggle").children(".inner").html("\u2212");
+            $(".collapse-toggle").children(".inner").text(labelForToggleButton(false));
+        } else {
+            toggle.addClass("will-expand");
+            toggle.children(".inner").text(labelForToggleButton(true));
+            toggle.attr("title", "expand all docs");
+            $(".docblock").hide();
+            $(".toggle-label").show();
+            $(".toggle-wrapper").addClass("collapsed");
+            $(".collapse-toggle").children(".inner").text(labelForToggleButton(true));
         }
     });
 
@@ -835,12 +848,12 @@
             if (relatedDoc.is(":visible")) {
                 relatedDoc.slideUp({duration:'fast', easing:'linear'});
                 toggle.parent(".toggle-wrapper").addClass("collapsed");
-                toggle.children(".inner").html("+");
+                toggle.children(".inner").text(labelForToggleButton(true));
                 toggle.children(".toggle-label").fadeIn();
             } else {
                 relatedDoc.slideDown({duration:'fast', easing:'linear'});
                 toggle.parent(".toggle-wrapper").removeClass("collapsed");
-                toggle.children(".inner").html("\u2212");
+                toggle.children(".inner").text(labelForToggleButton(false));
                 toggle.children(".toggle-label").hide();
             }
         }
@@ -848,7 +861,8 @@
 
     $(function() {
         var toggle = $("<a/>", {'href': 'javascript:void(0)', 'class': 'collapse-toggle'})
-            .html("[<span class='inner'>\u2212</span>]");
+            .html("[<span class='inner'></span>]");
+        toggle.children(".inner").text(labelForToggleButton(false));
 
         $(".method").each(function() {
             if ($(this).next().is(".docblock") ||


### PR DESCRIPTION
My change in #24797 had a bug, described in that issue’s comments, and first discovered in issue #24918. This fixes it.

I tested this new `main.js` by changing the `main.js` content of [a rendered docs page](https://doc.rust-lang.org/std/option/) to this new content. The ‘[−]’ button worked again.

I am also including another related fix, because it would require manual merging if I made a separate pull request for it. The page-global ‘[−]’ button currently adds `#` to the end of the URL whenever it is clicked. I am changing its `href` from `#` to `javascript:void(0)` (the same as the `href` for section-specific ‘[−]’ links) to fix that.
