### PR TITLE
Use the `bitflags!` macro to implement FlagV1

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -60,7 +60,8 @@ HOST_CRATES := syntax $(RUSTC_CRATES) rustdoc fmt_macros
 CRATES := $(TARGET_CRATES) $(HOST_CRATES)
 TOOLS := compiletest rustdoc rustc rustbook error-index-generator
 
-DEPS_core :=
+DEPS_rustc_bitflags :=
+DEPS_core := rustc_bitflags
 DEPS_libc := core
 DEPS_rustc_unicode := core
 DEPS_alloc := core libc native:jemalloc
@@ -87,7 +88,6 @@ DEPS_rustc_back := std syntax rustc_llvm flate log libc
 DEPS_rustc_data_structures := std log serialize
 DEPS_rustdoc := rustc rustc_driver native:hoedown serialize getopts \
                 test rustc_lint
-DEPS_rustc_bitflags := core
 DEPS_flate := std native:miniz
 DEPS_arena := std
 DEPS_graphviz := std

--- a/src/libcore/fmt/builders.rs
+++ b/src/libcore/fmt/builders.rs
@@ -110,7 +110,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & (1 << (FlagV1::Alternate as usize)) != 0
+        self.fmt.flags().intersects(FlagV1::ALTERNATE)
     }
 }
 
@@ -173,7 +173,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & (1 << (FlagV1::Alternate as usize)) != 0
+        self.fmt.flags().intersects(FlagV1::ALTERNATE)
     }
 }
 
@@ -205,7 +205,7 @@ impl<'a, 'b: 'a> DebugInner<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & (1 << (FlagV1::Alternate as usize)) != 0
+        self.fmt.flags().intersects(FlagV1::ALTERNATE)
     }
 }
 
@@ -328,6 +328,6 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     }
 
     fn is_pretty(&self) -> bool {
-        self.fmt.flags() & (1 << (FlagV1::Alternate as usize)) != 0
+        self.fmt.flags().intersects(FlagV1::ALTERNATE)
     }
 }

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -126,7 +126,7 @@ pub trait Write {
 /// traits.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Formatter<'a> {
-    flags: u32,
+    flags: FlagV1,
     fill: char,
     align: rt::v1::Alignment,
     width: Option<usize>,
@@ -193,10 +193,21 @@ impl<'a> ArgumentV1<'a> {
     }
 }
 
-// flags available in the v1 format of format_args
-#[derive(Copy, Clone)]
-#[allow(dead_code)] // SignMinus isn't currently used
-enum FlagV1 { SignPlus, SignMinus, Alternate, SignAwareZeroPad, }
+bitflags! {
+    // flags available in the v1 format of format_args
+    #[doc(hidden)]
+    flags FlagV1 : u32 {
+        #[doc(hidden)]
+        const SIGNPLUS         = 1 << 0,
+        #[doc(hidden)]
+        #[allow(dead_code)] // SIGNMINUS isn't currently used
+        const SIGNMINUS        = 1 << 1,
+        #[doc(hidden)]
+        const ALTERNATE        = 1 << 2,
+        #[doc(hidden)]
+        const SIGNAWAREZEROPAD = 1 << 3,
+    }
+}
 
 impl<'a> Arguments<'a> {
     /// When using the format_args!() macro, this function is used to generate the
@@ -360,7 +371,7 @@ pub trait UpperExp {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn write(output: &mut Write, args: Arguments) -> Result {
     let mut formatter = Formatter {
-        flags: 0,
+        flags: FlagV1::empty(),
         width: None,
         precision: None,
         buf: output,
@@ -410,7 +421,7 @@ impl<'a> Formatter<'a> {
         // Fill in the format parameters into the formatter
         self.fill = arg.format.fill;
         self.align = arg.format.align;
-        self.flags = arg.format.flags;
+        self.flags = FlagV1::from_bits_truncate(arg.format.flags);
         self.width = self.getcount(&arg.format.width);
         self.precision = self.getcount(&arg.format.precision);
 
@@ -466,12 +477,12 @@ impl<'a> Formatter<'a> {
         let mut sign = None;
         if !is_positive {
             sign = Some('-'); width += 1;
-        } else if self.flags & (1 << (FlagV1::SignPlus as u32)) != 0 {
+        } else if self.flags.intersects(FlagV1::SIGNPLUS) {
             sign = Some('+'); width += 1;
         }
 
         let mut prefixed = false;
-        if self.flags & (1 << (FlagV1::Alternate as u32)) != 0 {
+        if self.flags.intersects(FlagV1::ALTERNATE) {
             prefixed = true; width += prefix.char_len();
         }
 
@@ -501,7 +512,7 @@ impl<'a> Formatter<'a> {
             }
             // The sign and prefix goes before the padding if the fill character
             // is zero
-            Some(min) if self.flags & (1 << (FlagV1::SignAwareZeroPad as u32)) != 0 => {
+            Some(min) if self.flags.intersects(FlagV1::SIGNAWAREZEROPAD) => {
                 self.fill = '0';
                 try!(write_prefix(self));
                 self.with_padding(min - width, Alignment::Right, |f| {
@@ -619,7 +630,7 @@ impl<'a> Formatter<'a> {
 
     /// Flags for formatting (packed version of rt::Flag)
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn flags(&self) -> u32 { self.flags }
+    pub fn flags(&self) -> FlagV1 { self.flags }
 
     /// Character used as 'fill' whenever there is alignment
     #[unstable(feature = "core", reason = "method was just created")]
@@ -867,8 +878,8 @@ impl<T> Pointer for *const T {
         // it denotes whether to prefix with 0x. We use it to work out whether
         // or not to zero extend, and then unconditionally set it to get the
         // prefix.
-        if f.flags & 1 << (FlagV1::Alternate as u32) > 0 {
-            f.flags |= 1 << (FlagV1::SignAwareZeroPad as u32);
+        if f.flags.intersects(FlagV1::ALTERNATE) {
+            f.flags.insert(FlagV1::SIGNAWAREZEROPAD);
 
             if let None = f.width {
                 // The formats need two extra bytes, for the 0x
@@ -879,7 +890,7 @@ impl<T> Pointer for *const T {
                 }
             }
         }
-        f.flags |= 1 << (FlagV1::Alternate as u32);
+        f.flags.insert(FlagV1::ALTERNATE);
 
         let ret = LowerHex::fmt(&(*self as usize), f);
 

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -63,17 +63,20 @@
 #![allow(raw_pointer_derive)]
 #![deny(missing_docs)]
 
+#![feature(associated_consts)]
+#![feature(concat_idents)]
+#![feature(custom_attribute)]
+#![feature(fundamental)]
 #![feature(intrinsics, lang_items)]
 #![feature(on_unimplemented)]
+#![feature(optin_builtin_traits)]
+#![feature(reflect)]
+#![feature(rustc_attrs)]
 #![feature(simd)]
 #![feature(staged_api)]
 #![feature(unboxed_closures)]
-#![feature(rustc_attrs)]
-#![feature(optin_builtin_traits)]
-#![feature(fundamental)]
-#![feature(concat_idents)]
-#![feature(reflect)]
-#![feature(custom_attribute)]
+
+#[macro_use] #[no_link] extern crate rustc_bitflags;
 
 #[macro_use]
 mod macros;
@@ -173,4 +176,6 @@ mod core {
 mod std {
     // range syntax
     pub use ops;
+    // bitflags!{}
+    pub use option;
 }


### PR DESCRIPTION
Closes #15738.

r? @alexcrichton this is another go at #24697. It turns out that `rustc_bitflags` doesn't need `libcore`, so this works by putting `rustc_bitflags` at the start of the chain in place of `libcore`. What do you think?
