### PR TITLE
Guard against overflow in `codemap::span_to_lines`.

### DIFF
--- a/src/libsyntax/codemap.rs
+++ b/src/libsyntax/codemap.rs
@@ -670,6 +670,13 @@ impl CodeMap {
     pub fn span_to_lines(&self, sp: Span) -> FileLines {
         let lo = self.lookup_char_pos(sp.lo);
         let hi = self.lookup_char_pos(sp.hi);
+
+        // If you are hitting these errors, perhaps change your
+        // call-site to call span_to_snippet instead. (Or revise this
+        // code to return a similar Result...)
+        assert_eq!(lo.file.name, hi.file.name);
+        assert!(hi.line >= lo.line);
+
         let mut lines = Vec::with_capacity(hi.line - lo.line + 1);
 
         // The span starts partway through the first line,


### PR DESCRIPTION
Guard against overflow in `codemap::span_to_lines`.

There a number of recent issues that report the bug here.  See e.g. #24761 and #24954.

This change does _not_ fix them; it just makes the assert more immediate (and also injects a more conservative check, in that we are also checking that the files match up).

So, this does not directly fix any bugs, and is expected to actually inject new ICE's.  But those will all represent latent bugs that need fixing.
