### PR TITLE
Remove more mentions of removed keyword `priv`

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1562,8 +1562,7 @@ warnings are generated, or otherwise "you used a private item of another module
 and weren't allowed to."
 
 By default, everything in Rust is *private*, with one exception. Enum variants
-in a `pub` enum are also public by default. You are allowed to alter this
-default visibility with the `priv` keyword. When an item is declared as `pub`,
+in a `pub` enum are also public by default. When an item is declared as `pub`,
 it can be thought of as being accessible to the outside world. For example:
 
 ```

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -899,7 +899,7 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
                 if let ast::MethodImplItem(ref sig, _) = ii.node {
                     // if the method specifies a visibility, use that, otherwise
                     // inherit the visibility from the impl (so `foo` in `pub impl
-                    // { fn foo(); }` is public, but private in `priv impl { fn
+                    // { fn foo(); }` is public, but private in `impl { fn
                     // foo(); }`).
                     let method_vis = ii.vis.inherit_from(parent_visibility);
                     Some((sig, ii.id, ii.ident, method_vis, ii.span))

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4772,7 +4772,7 @@ impl<'a> Parser<'a> {
         return self.parse_single_struct_field(Inherited, attrs);
     }
 
-    /// Parse visibility: PUB, PRIV, or nothing
+    /// Parse visibility: PUB or nothing
     fn parse_visibility(&mut self) -> PResult<Visibility> {
         if try!(self.eat_keyword(keywords::Pub)) { Ok(Public) }
         else { Ok(Inherited) }

--- a/src/test/run-pass/issue-4241.rs
+++ b/src/test/run-pass/issue-4241.rs
@@ -28,7 +28,7 @@ enum Result {
   Status(String)
 }
 
-priv fn parse_data(len: usize, io: @io::Reader) -> Result {
+fn parse_data(len: usize, io: @io::Reader) -> Result {
   let res =
       if (len > 0) {
       let bytes = io.read_bytes(len as usize);
@@ -42,7 +42,7 @@ priv fn parse_data(len: usize, io: @io::Reader) -> Result {
   return res;
 }
 
-priv fn parse_list(len: usize, io: @io::Reader) -> Result {
+fn parse_list(len: usize, io: @io::Reader) -> Result {
     let mut list: ~[Result] = ~[];
     for _ in 0..len {
         let v = match io.read_char() {
@@ -55,11 +55,11 @@ priv fn parse_list(len: usize, io: @io::Reader) -> Result {
     return List(list);
 }
 
-priv fn chop(s: String) -> String {
+fn chop(s: String) -> String {
   s.slice(0, s.len() - 1).to_string()
 }
 
-priv fn parse_bulk(io: @io::Reader) -> Result {
+fn parse_bulk(io: @io::Reader) -> Result {
     match from_str::<isize>(chop(io.read_line())) {
     None => panic!(),
     Some(-1) => Nil,
@@ -68,7 +68,7 @@ priv fn parse_bulk(io: @io::Reader) -> Result {
     }
 }
 
-priv fn parse_multi(io: @io::Reader) -> Result {
+fn parse_multi(io: @io::Reader) -> Result {
     match from_str::<isize>(chop(io.read_line())) {
     None => panic!(),
     Some(-1) => Nil,
@@ -78,14 +78,14 @@ priv fn parse_multi(io: @io::Reader) -> Result {
     }
 }
 
-priv fn parse_int(io: @io::Reader) -> Result {
+fn parse_int(io: @io::Reader) -> Result {
     match from_str::<isize>(chop(io.read_line())) {
     None => panic!(),
     Some(i) => Int(i)
     }
 }
 
-priv fn parse_response(io: @io::Reader) -> Result {
+fn parse_response(io: @io::Reader) -> Result {
     match io.read_char() {
     '$' => parse_bulk(io),
     '*' => parse_multi(io),
@@ -96,7 +96,7 @@ priv fn parse_response(io: @io::Reader) -> Result {
     }
 }
 
-priv fn cmd_to_string(cmd: ~[String]) -> String {
+fn cmd_to_string(cmd: ~[String]) -> String {
   let mut res = "*".to_string();
   res.push_str(cmd.len().to_string());
   res.push_str("\r\n");


### PR DESCRIPTION
Hi! While researching stuff for the reference and the grammar, I came across a few mentions of using the `priv` keyword that was removed in 0.11.0 (#13547, #8122, rust-lang/rfcs#26, [RFC 0026](https://github.com/rust-lang/rfcs/blob/master/text/0026-remove-priv.md)).

One occurrence is a mention in the reference, a few are in comments, and a few are marking test functions. I left the test that makes sure you can't name an ident `priv` since it's still a reserved keyword. I did a little grepping around for `priv`, priv in backticks, `Private` etc and I think the remaining instances are fine, but if anyone knows anywhere in particular I should check for any other lingering mentions of `priv`, please let me know and I would be happy to! :fallen_leaf: :ocean:
