### PR TITLE
fix incorrect link tag in doc/trpl/nightly-rust.md

### DIFF
--- a/src/doc/trpl/nightly-rust.md
+++ b/src/doc/trpl/nightly-rust.md
@@ -93,8 +93,7 @@ If not, there are a number of places where you can get help. The easiest is
 [the #rust IRC channel on irc.mozilla.org][irc], which you can access through
 [Mibbit][mibbit]. Click that link, and you'll be chatting with other Rustaceans
 (a silly nickname we call ourselves), and we can help you out. Other great
-resources include [the user’s forum][users], and [Stack Overflow][stack
-overflow].
+resources include [the user’s forum][users], and [Stack Overflow][stack overflow].
 
 [irc]: irc://irc.mozilla.org/#rust
 [mibbit]: http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust


### PR DESCRIPTION
Fix incorrect link tag formatting in `doc/trpl/nightly-rust.md`. Notice the last word of the paragraph.

Before:
![before](https://cloud.githubusercontent.com/assets/8631/7413645/10754b7e-ef80-11e4-9bb1-15e87ce9308f.png)

After:
![after](https://cloud.githubusercontent.com/assets/8631/7413647/13b96202-ef80-11e4-990b-6ecf72925e7d.png)
