### PR TITLE
remove denied unused import: pid_t in raw

### DIFF
--- a/src/libstd/os/dragonfly/raw.rs
+++ b/src/libstd/os/dragonfly/raw.rs
@@ -11,7 +11,7 @@
 //! Dragonfly-specific raw type definitions
 
 use os::raw::c_long;
-use os::unix::raw::{pid_t, uid_t, gid_t};
+use os::unix::raw::{uid_t, gid_t};
 
 pub type blkcnt_t = i64;
 pub type blksize_t = u32;

--- a/src/libstd/os/freebsd/raw.rs
+++ b/src/libstd/os/freebsd/raw.rs
@@ -11,7 +11,7 @@
 //! FreeBSD-specific raw type definitions
 
 use os::raw::c_long;
-use os::unix::raw::{uid_t, gid_t, pid_t};
+use os::unix::raw::{uid_t, gid_t};
 
 pub type blkcnt_t = i64;
 pub type blksize_t = i64;

--- a/src/libstd/os/ios/raw.rs
+++ b/src/libstd/os/ios/raw.rs
@@ -11,7 +11,7 @@
 //! iOS-specific raw type definitions
 
 use os::raw::c_long;
-use os::unix::raw::{uid_t, gid_t, pid_t};
+use os::unix::raw::{uid_t, gid_t};
 
 pub type blkcnt_t = i64;
 pub type blksize_t = i32;

--- a/src/libstd/os/openbsd/raw.rs
+++ b/src/libstd/os/openbsd/raw.rs
@@ -11,7 +11,7 @@
 //! OpenBSD-specific raw type definitions
 
 use os::raw::c_long;
-use os::unix::raw::{uid_t, gid_t, pid_t};
+use os::unix::raw::{uid_t, gid_t};
 
 pub type blkcnt_t = i64;
 pub type blksize_t = u32;


### PR DESCRIPTION
- unbreak the build under openbsd
- while here, apply same modification to dragonfly, freebsd, ios (pid_t
  imported, but not used in raw.rs)

r? @alexcrichton 
cc @wg @mneumann @vhbit
