### PR TITLE
rustdoc: Fix rendering associated constants

### DIFF
--- a/src/test/rustdoc/assoc-consts.rs
+++ b/src/test/rustdoc/assoc-consts.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(associated_consts)]
+
+pub trait Foo {
+    // @has assoc_consts/trait.Foo.html '//*[@class="rust trait"]' \
+    //      'const FOO: usize;'
+    const FOO: usize;
+}
+
+pub struct Bar;
+
+impl Bar {
+    // @has assoc_consts/struct.Bar.html '//*[@id="assoc_const.BAR"]' \
+    //      'const BAR: usize = 3'
+    pub const BAR: usize = 3;
+}


### PR DESCRIPTION
Associated constants were now showing up for traits and would panic if they were
found on an inherent impl. This commit unblocks the nighly builders.
