### PR TITLE
Replaces instanced of 'an UTF' with 'a UTF'

### DIFF
--- a/src/librustc_unicode/u_str.rs
+++ b/src/librustc_unicode/u_str.rs
@@ -525,7 +525,7 @@ pub struct Utf16Encoder<I> {
 }
 
 impl<I> Utf16Encoder<I> {
-    /// Create an UTF-16 encoder from any `char` iterator.
+    /// Create a UTF-16 encoder from any `char` iterator.
     pub fn new(chars: I) -> Utf16Encoder<I> where I: Iterator<Item=char> {
         Utf16Encoder { chars: chars, extra: 0 }
     }

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -236,7 +236,7 @@ pub trait Read {
 
     /// Transforms this `Read` instance to an `Iterator` over `char`s.
     ///
-    /// This adaptor will attempt to interpret this reader as an UTF-8 encoded
+    /// This adaptor will attempt to interpret this reader as a UTF-8 encoded
     /// sequence of characters. The returned iterator will return `None` once
     /// EOF is reached for this reader. Otherwise each element yielded will be a
     /// `Result<char, E>` where `E` may contain information about what I/O error

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -161,7 +161,7 @@ impl Wtf8Buf {
         Wtf8Buf { bytes: Vec::with_capacity(n) }
     }
 
-    /// Creates a WTF-8 string from an UTF-8 `String`.
+    /// Creates a WTF-8 string from a UTF-8 `String`.
     ///
     /// This takes ownership of the `String` and does not copy.
     ///
@@ -171,7 +171,7 @@ impl Wtf8Buf {
         Wtf8Buf { bytes: string.into_bytes() }
     }
 
-    /// Creates a WTF-8 string from an UTF-8 `&str` slice.
+    /// Creates a WTF-8 string from a UTF-8 `&str` slice.
     ///
     /// This copies the content of the slice.
     ///
@@ -245,7 +245,7 @@ impl Wtf8Buf {
         self.bytes.capacity()
     }
 
-    /// Append an UTF-8 slice at the end of the string.
+    /// Append a UTF-8 slice at the end of the string.
     #[inline]
     pub fn push_str(&mut self, other: &str) {
         self.bytes.push_all(other.as_bytes())
@@ -527,7 +527,7 @@ impl Wtf8 {
     }
 
     /// Lossily converts the string to UTF-8.
-    /// Returns an UTF-8 `&str` slice if the contents are well-formed in UTF-8.
+    /// Returns a UTF-8 `&str` slice if the contents are well-formed in UTF-8.
     ///
     /// Surrogates are replaced with `"\u{FFFD}"` (the replacement character “�”).
     ///


### PR DESCRIPTION
Even spelled out, one would say 'a Universal Character Set'
