### PR TITLE
Add missing `windres.exe` dependencies to Windows distribution

### DIFF
--- a/src/etc/make-win-dist.py
+++ b/src/etc/make-win-dist.py
@@ -45,7 +45,8 @@ def make_win_dist(rust_root, gcc_root, target_triple):
         elif key == "libraries":
             lib_path.extend(val.lstrip(' =').split(';'))
 
-    target_tools = ["gcc.exe", "ld.exe", "ar.exe", "dlltool.exe", "windres.exe"]
+    target_tools = ["gcc.exe", "ld.exe", "ar.exe", "dlltool.exe", "windres.exe", "cc1.exe"]
+    target_dlls = ["libgmp-10.dll", "libwinpthread-1.dll", "zlib1.dll"]
 
     rustc_dlls = ["libstdc++-6.dll"]
     if target_triple.startswith("i686-"):
@@ -98,6 +99,7 @@ def make_win_dist(rust_root, gcc_root, target_triple):
 
     # Find mingw artifacts we want to bundle
     target_tools = find_files(target_tools, bin_path)
+    target_dlls = find_files(target_dlls, bin_path)
     rustc_dlls = find_files(rustc_dlls, bin_path)
     target_libs = find_files(target_libs, lib_path)
 
@@ -110,7 +112,7 @@ def make_win_dist(rust_root, gcc_root, target_triple):
     target_bin_dir = os.path.join(gcc_root, "bin", "rustlib", target_triple, "bin")
     if not os.path.exists(target_bin_dir):
         os.makedirs(target_bin_dir)
-    for src in target_tools:
+    for src in target_tools + target_dlls:
         shutil.copy(src, target_bin_dir)
 
     # Copy platform libs to platform-specific lib directory


### PR DESCRIPTION
As mentioned in #11207 and rust-lang/rfcs#721, `windres.exe` may be used for embedding Manifest files into Windows binaries. 
But `windres.exe` cannot compile `*.rc` files into `*.res` or `*.o` files without `cc1.exe`, which it uses as a preprocessor.
