### PR TITLE
Make sure casts from other types to fat pointers are illegal

### DIFF
--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -170,9 +170,10 @@ pub fn check_cast<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>, cast: &CastCheck<'tcx>) {
                 demand::coerce(fcx, e.span, t_1, &e);
             }
         }
-    } else if fcx.type_is_fat_ptr(t_e, span) && !fcx.type_is_fat_ptr(t_1, span) {
+    } else if fcx.type_is_fat_ptr(t_e, span) != fcx.type_is_fat_ptr(t_1, span) {
         fcx.type_error_message(span, |actual| {
-            format!("illegal cast; cast from fat pointer: `{}` as `{}`",
+            format!("illegal cast; cast to or from fat pointer: `{}` as `{}` \
+                     involving incompatible type.",
                     actual, fcx.infcx().ty_to_string(t_1))
         }, t_e, None);
     } else if !(t_e_is_scalar && t_1_is_trivial) {

--- a/src/test/compile-fail/fat-ptr-cast.rs
+++ b/src/test/compile-fail/fat-ptr-cast.rs
@@ -8,12 +8,24 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Make sure casts between thin pointer <-> fat pointer are illegal.
+
+pub trait Trait {}
+
 fn main() {
     let a: &[i32] = &[1, 2, 3];
     let b: Box<[i32]> = Box::new([1, 2, 3]);
     let p = a as *const [i32];
+    let q = a.as_ptr();
 
-    a as usize; //~ ERROR cast from fat pointer
-    b as usize; //~ ERROR cast from fat pointer
-    p as usize; //~ ERROR cast from fat pointer
+    a as usize; //~ ERROR illegal cast
+    b as usize; //~ ERROR illegal cast
+    p as usize; //~ ERROR illegal cast
+
+    // #22955
+    q as *const [i32]; //~ ERROR illegal cast
+
+    // #21397
+    let t: *mut (Trait + 'static) = 0 as *mut _; //~ ERROR illegal cast
+    let mut fail: *const str = 0 as *const str; //~ ERROR illegal cast
 }

--- a/src/test/compile-fail/issue-22034.rs
+++ b/src/test/compile-fail/issue-22034.rs
@@ -11,9 +11,9 @@
 extern crate libc;
 
 fn main() {
-    let foo: *mut libc::c_void;
-    let cb: &mut Fn() = unsafe {
-        &mut *(foo as *mut Fn())
-        //~^ ERROR use of possibly uninitialized variable: `foo`
+    let ptr: *mut () = 0 as *mut _;
+    let _: &mut Fn() = unsafe {
+        &mut *(ptr as *mut Fn())
+        //~^ ERROR illegal cast
     };
 }

--- a/src/test/compile-fail/issue-22289.rs
+++ b/src/test/compile-fail/issue-22289.rs
@@ -9,5 +9,5 @@
 // except according to those terms.
 
 fn main() {
-    0 as &std::any::Any; //~ ERROR non-scalar cast: `i32` as `&core::any::Any`
+    0 as &std::any::Any; //~ ERROR illegal cast
 }


### PR DESCRIPTION
typeck: Make sure casts from other types to fat pointers are illegal

Fixes ICEs where non-fat pointers and scalars are cast to fat pointers,

Fixes #21397
Fixes #22955
Fixes #23237
Fixes #24100
