### PR TITLE
test: Ignore out-of-stack for MUSL

### DIFF
--- a/src/test/run-pass/out-of-stack.rs
+++ b/src/test/run-pass/out-of-stack.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // ignore-android: FIXME (#20004)
+// ignore-musl
 
 #![feature(asm)]
 


### PR DESCRIPTION
Stack overflow detection does not currently work with MUSL, so this test needs
to be disabled.
