### PR TITLE
doc: #1398 stop passing --cfg ndebug and uses -C debug-assertions

### DIFF
--- a/src/liblog/macros.rs
+++ b/src/liblog/macros.rs
@@ -136,7 +136,7 @@ macro_rules! info {
 }
 
 /// A convenience macro for logging at the debug log level. This macro can also
-/// be omitted at compile time by passing `--cfg ndebug` to the compiler. If
+/// be omitted at compile time by passing `-C debug-assertions` to the compiler. If
 /// this option is not passed, then debug statements will be compiled.
 ///
 /// # Examples


### PR DESCRIPTION
According to #1398 and pull https://github.com/rust-lang/cargo/pull/1444 , fix doc overridable using -C debug-assertions 
