### PR TITLE
Override Iterator::count method for vec::IntoIter

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1777,6 +1777,11 @@ impl<T> Iterator for IntoIter<T> {
         let exact = diff / (if size == 0 {1} else {size});
         (exact, Some(exact))
     }
+
+    #[inline]
+    fn count(self) -> usize {
+        self.size_hint().0
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcollectionstest/vec.rs
+++ b/src/libcollectionstest/vec.rs
@@ -542,6 +542,11 @@ fn test_split_off() {
     assert_eq!(vec2, [5, 6]);
 }
 
+#[test]
+fn test_into_iter_count() {
+    assert_eq!(vec![1, 2, 3].into_iter().count(), 3);
+}
+
 #[bench]
 fn bench_new(b: &mut Bencher) {
     b.iter(|| {


### PR DESCRIPTION
Override methods `count`, `last`, and `nth` in vec::IntoIter.
#24214
