### PR TITLE
Run benchmarks once, as a test by default.

### DIFF
--- a/src/compiletest/compiletest.rs
+++ b/src/compiletest/compiletest.rs
@@ -269,7 +269,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         run_ignored: config.run_ignored,
         logfile: config.logfile.clone(),
         run_tests: true,
-        run_benchmarks: true,
+        bench_benchmarks: true,
         nocapture: env::var("RUST_TEST_NOCAPTURE").is_ok(),
         color: test::AutoColor,
     }


### PR DESCRIPTION
E.g. if `foo.rs` looks like

```
#![feature(test)]
extern crate test;

#[bench]
fn bar(b: &mut test::Bencher) {
    b.iter(|| {
        1
    })
}

#[test]
fn baz() {}

#[bench]
fn qux(b: &mut test::Bencher) {
    b.iter(|| {
        panic!()
    })
}
```

Then

```
$ rustc --test foo.rs
$ ./foo

running 3 tests
test baz ... ok
test qux ... FAILED
test bar ... ok

failures:

---- qux stdout ----
    thread 'qux' panicked at 'explicit panic', bench.rs:17

failures:
    qux

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured

$ ./foo --bench ba

running 2 tests
test baz ... ignored
test bar ... bench:        97 ns/iter (+/- 74)

test result: ok. 0 passed; 0 failed; 1 ignored; 1 measured
```

In particular, the two benchmark are being run as tests in the default
mode.

This helps for the main distribution, since benchmarks are only run with
`PLEASE_BENCH=1`, which is rarely set (and never set on the test bots),
and helps for code-coverage tools: benchmarks are run and so don't count
as dead code.

Fixes #15842.
