### PR TITLE
minor: ensure correct range bounds in concurreny examples in the rust book

### DIFF
--- a/src/doc/trpl/concurrency.md
+++ b/src/doc/trpl/concurrency.md
@@ -116,7 +116,7 @@ use std::thread;
 fn main() {
     let mut data = vec![1u32, 2, 3];
 
-    for i in 0..2 {
+    for i in 0..3 {
         thread::spawn(move || {
             data[i] += 1;
         });
@@ -154,7 +154,7 @@ use std::sync::Mutex;
 fn main() {
     let mut data = Mutex::new(vec![1u32, 2, 3]);
 
-    for i in 0..2 {
+    for i in 0..3 {
         let data = data.lock().unwrap();
         thread::spawn(move || {
             data[i] += 1;
@@ -196,7 +196,7 @@ use std::thread;
 fn main() {
     let data = Arc::new(Mutex::new(vec![1u32, 2, 3]));
 
-    for i in 0..2 {
+    for i in 0..3 {
         let data = data.clone();
         thread::spawn(move || {
             let mut data = data.lock().unwrap();
@@ -217,7 +217,7 @@ thread more closely:
 # use std::thread;
 # fn main() {
 #     let data = Arc::new(Mutex::new(vec![1u32, 2, 3]));
-#     for i in 0..2 {
+#     for i in 0..3 {
 #         let data = data.clone();
 thread::spawn(move || {
     let mut data = data.lock().unwrap();


### PR DESCRIPTION
- `0..2` iterates over `0,1`
- `0..3` iterates over `0,1,2`, which is what we want instead
