### PR TITLE
minor: add link to book source files

### DIFF
--- a/src/doc/trpl/README.md
+++ b/src/doc/trpl/README.md
@@ -40,6 +40,11 @@ want to dive in with a project, or ‘Syntax and Semantics’ if you prefer to
 start small, and learn a single concept thoroughly before moving onto the next.
 Copious cross-linking connects these parts together.
 
+### Contributing
+
+The source files from which this book is generated can be found on Github:
+[github.com/rust-lang/rust/tree/master/src/doc/trpl](https://github.com/rust-lang/rust/tree/master/src/doc/trpl)
+
 ## A brief introduction to Rust
 
 Is Rust a language you might be interested in? Let’s examine a few small code


### PR DESCRIPTION
- I found n error in the book, before contributing the patch to fix it, I had to find where they were hosted
- It took me quite look to find where within the rust-lang _organisation_ it was! ... and this should make it easier for the next person in the same position
