### PR TITLE
Fix some simple associated const issues.

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2528,8 +2528,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                 // If anything ends up here entirely resolved,
                                 // it's an error. If anything ends up here
                                 // partially resolved, that's OK, because it may
-                                // be a `T::CONST` that typeck will resolve to
-                                // an inherent impl.
+                                // be a `T::CONST` that typeck will resolve.
                                 if path_res.depth == 0 {
                                     self.resolve_error(
                                         path.span,
@@ -2537,6 +2536,10 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                                  token::get_ident(
                                                      path.segments.last().unwrap().identifier)));
                                 } else {
+                                    let const_name = path.segments.last().unwrap()
+                                                         .identifier.name;
+                                    let traits = self.get_traits_containing_item(const_name);
+                                    self.trait_map.insert(pattern.id, traits);
                                     self.record_def(pattern.id, path_res);
                                 }
                             }

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -136,7 +136,7 @@ pub fn probe<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     let steps = if mode == Mode::MethodCall {
         match create_steps(fcx, span, self_ty) {
             Some(steps) => steps,
-            None => return Err(MethodError::NoMatch(Vec::new(), Vec::new())),
+            None => return Err(MethodError::NoMatch(Vec::new(), Vec::new(), mode)),
         }
     } else {
         vec![CandidateStep {
@@ -866,7 +866,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
                     }
                 }
             }).collect(),
-            Some(Err(MethodError::NoMatch(_, others))) => {
+            Some(Err(MethodError::NoMatch(_, others, _))) => {
                 assert!(others.is_empty());
                 vec![]
             }
@@ -877,7 +877,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
             None => vec![],
         };
 
-        Err(MethodError::NoMatch(static_candidates, out_of_scope_traits))
+        Err(MethodError::NoMatch(static_candidates, out_of_scope_traits, self.mode))
     }
 
     fn pick_core(&mut self) -> Option<PickResult<'tcx>> {

--- a/src/test/compile-fail/associated-const-ambiguity-report.rs
+++ b/src/test/compile-fail/associated-const-ambiguity-report.rs
@@ -8,10 +8,26 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// tests the good error message, not "missing module Foo" or something else unexpected
+#![feature(associated_consts)]
 
-struct Foo;
+trait Foo {
+    const ID: i32;
+}
+
+trait Bar {
+    const ID: i32;
+}
+
+impl Foo for i32 {
+    const ID: i32 = 1;
+}
+
+impl Bar for i32 {
+    const ID: i32 = 3;
+}
+
+const X: i32 = <i32>::ID; //~ ERROR E0034
 
 fn main() {
-    Foo::bar(); //~ ERROR no associated item named `bar` found for type `Foo` in the current scope
+    assert_eq!(1, X);
 }

--- a/src/test/compile-fail/auto-ref-slice-plus-ref.rs
+++ b/src/test/compile-fail/auto-ref-slice-plus-ref.rs
@@ -15,11 +15,11 @@ fn main() {
     // vectors to slices then automatically create a self reference.
 
     let mut a = vec!(0);
-    a.test_mut(); //~ ERROR does not implement any method in scope named `test_mut`
-    a.test(); //~ ERROR does not implement any method in scope named `test`
+    a.test_mut(); //~ ERROR no method named `test_mut` found
+    a.test(); //~ ERROR no method named `test` found
 
-    ([1]).test(); //~ ERROR does not implement any method in scope named `test`
-    (&[1]).test(); //~ ERROR does not implement any method in scope named `test`
+    ([1]).test(); //~ ERROR no method named `test` found
+    (&[1]).test(); //~ ERROR no method named `test` found
 }
 
 trait MyIter {

--- a/src/test/compile-fail/class-cast-to-trait.rs
+++ b/src/test/compile-fail/class-cast-to-trait.rs
@@ -60,5 +60,5 @@ fn cat(in_x : usize, in_y : isize, in_name: String) -> cat {
 
 fn main() {
   let nyan: Box<noisy> = box cat(0, 2, "nyan".to_string()) as Box<noisy>;
-  nyan.eat(); //~ ERROR does not implement any method in scope named `eat`
+  nyan.eat(); //~ ERROR no method named `eat` found
 }

--- a/src/test/compile-fail/coherence_inherent.rs
+++ b/src/test/compile-fail/coherence_inherent.rs
@@ -38,7 +38,7 @@ mod NoImport {
     use Lib::TheStruct;
 
     fn call_the_fn(s: &TheStruct) {
-        s.the_fn(); //~ ERROR does not implement any method in scope named `the_fn`
+        s.the_fn(); //~ ERROR no method named `the_fn` found
     }
 }
 

--- a/src/test/compile-fail/coherence_inherent_cc.rs
+++ b/src/test/compile-fail/coherence_inherent_cc.rs
@@ -30,7 +30,7 @@ mod NoImport {
     use coherence_inherent_cc_lib::TheStruct;
 
     fn call_the_fn(s: &TheStruct) {
-        s.the_fn(); //~ ERROR does not implement any method in scope named `the_fn`
+        s.the_fn(); //~ ERROR no method named `the_fn` found
     }
 }
 

--- a/src/test/compile-fail/copy-a-resource.rs
+++ b/src/test/compile-fail/copy-a-resource.rs
@@ -26,6 +26,6 @@ fn foo(i:isize) -> foo {
 fn main() {
     let x = foo(10);
     let _y = x.clone();
-    //~^ ERROR does not implement any method in scope
+    //~^ ERROR no method named `clone` found
     println!("{:?}", x);
 }

--- a/src/test/compile-fail/issue-10465.rs
+++ b/src/test/compile-fail/issue-10465.rs
@@ -24,7 +24,7 @@ pub mod b {
         use b::B;
 
         fn foo(b: &B) {
-            b.foo(); //~ ERROR: does not implement any method in scope named
+            b.foo(); //~ ERROR: no method named `foo` found
         }
     }
 

--- a/src/test/compile-fail/issue-13853.rs
+++ b/src/test/compile-fail/issue-13853.rs
@@ -31,7 +31,7 @@ impl Node for Stuff {
 }
 
 fn iterate<N: Node, G: Graph<N>>(graph: &G) {
-    for node in graph.iter() { //~ ERROR does not implement any method in scope named
+    for node in graph.iter() { //~ ERROR no method named `iter` found
         node.zomg();  //~ error: the type of this value must be known in this context
     }
 }

--- a/src/test/compile-fail/issue-18343.rs
+++ b/src/test/compile-fail/issue-18343.rs
@@ -14,6 +14,6 @@ struct Obj<F> where F: FnMut() -> u32 {
 
 fn main() {
     let o = Obj { closure: || 42 };
-    o.closure(); //~ ERROR does not implement any method in scope named `closure`
+    o.closure(); //~ ERROR no method named `closure` found
     //~^ NOTE use `(s.closure)(...)` if you meant to call the function stored in the `closure` field
 }

--- a/src/test/compile-fail/issue-1871.rs
+++ b/src/test/compile-fail/issue-1871.rs
@@ -14,7 +14,7 @@ fn main() {
   let f = 42;
 
   let _g = if f < 5 {
-      f.honk() //~ ERROR does not implement any method in scope named `honk`
+      f.honk() //~ ERROR no method named `honk` found
   }
   else {
       ()

--- a/src/test/compile-fail/issue-19521.rs
+++ b/src/test/compile-fail/issue-19521.rs
@@ -11,5 +11,5 @@
 #![feature(unboxed_closures)]
 
 fn main() {
-    "".homura()(); //~ ERROR does not implement any method
+    "".homura()(); //~ ERROR no method named `homura` found
 }

--- a/src/test/compile-fail/issue-19692.rs
+++ b/src/test/compile-fail/issue-19692.rs
@@ -11,7 +11,7 @@
 struct Homura;
 
 fn akemi(homura: Homura) {
-    let Some(ref madoka) = Some(homura.kaname()); //~ ERROR does not implement any method
+    let Some(ref madoka) = Some(homura.kaname()); //~ ERROR no method named `kaname` found
     madoka.clone(); //~ ERROR the type of this value must be known in this context
 }
 

--- a/src/test/compile-fail/issue-2149.rs
+++ b/src/test/compile-fail/issue-2149.rs
@@ -22,5 +22,5 @@ impl<A> vec_monad<A> for Vec<A> {
 }
 fn main() {
     ["hi"].bind(|x| [x] );
-    //~^ ERROR type `[&str; 1]` does not implement any method in scope named `bind`
+    //~^ ERROR no method named `bind` found for type `[&str; 1]` in the current scope
 }

--- a/src/test/compile-fail/issue-2823.rs
+++ b/src/test/compile-fail/issue-2823.rs
@@ -20,5 +20,5 @@ impl Drop for C {
 
 fn main() {
     let c = C{ x: 2};
-    let _d = c.clone(); //~ ERROR does not implement any method in scope
+    let _d = c.clone(); //~ ERROR no method named `clone` found
 }

--- a/src/test/compile-fail/issue-3563.rs
+++ b/src/test/compile-fail/issue-3563.rs
@@ -11,7 +11,7 @@
 trait A {
     fn a(&self) {
         || self.b()
-        //~^ ERROR type `&Self` does not implement any method in scope named `b`
+        //~^ ERROR no method named `b` found for type `&Self` in the current scope
         //~| ERROR mismatched types
         //~| expected `()`
         //~| found closure

--- a/src/test/compile-fail/issue-3702-2.rs
+++ b/src/test/compile-fail/issue-3702-2.rs
@@ -23,7 +23,7 @@ trait Add {
 impl Add for isize {
     fn to_int(&self) -> isize { *self }
     fn add_dynamic(&self, other: &Add) -> isize {
-        self.to_int() + other.to_int() //~ ERROR multiple applicable methods in scope
+        self.to_int() + other.to_int() //~ ERROR multiple applicable items in scope
     }
 }
 

--- a/src/test/compile-fail/issue-3707.rs
+++ b/src/test/compile-fail/issue-3707.rs
@@ -17,7 +17,7 @@ impl Obj {
         return 1+1 == 2
     }
     pub fn chirp(&self) {
-        self.boom(); //~ ERROR `&Obj` does not implement any method in scope named `boom`
+        self.boom(); //~ ERROR no method named `boom` found for type `&Obj` in the current scope
     }
 }
 

--- a/src/test/compile-fail/issue-5153.rs
+++ b/src/test/compile-fail/issue-5153.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: type `&Foo` does not implement any method in scope named `foo`
-
 trait Foo {
     fn foo(self: Box<Self>);
 }
@@ -20,4 +18,5 @@ impl Foo for isize {
 
 fn main() {
     (&5 as &Foo).foo();
+    //~^ ERROR: no method named `foo` found for type `&Foo` in the current scope
 }

--- a/src/test/compile-fail/issue-7575.rs
+++ b/src/test/compile-fail/issue-7575.rs
@@ -71,15 +71,15 @@ impl ManyImplTrait for Myisize {}
 
 fn no_param_bound(u: usize, m: Myisize) -> usize {
     u.f8(42) + u.f9(342) + m.fff(42)
-            //~^ ERROR type `usize` does not implement any method in scope named `f9`
+            //~^ ERROR no method named `f9` found for type `usize` in the current scope
             //~^^ NOTE found defined static methods, maybe a `self` is missing?
-            //~^^^ ERROR type `Myisize` does not implement any method in scope named `fff`
+            //~^^^ ERROR no method named `fff` found for type `Myisize` in the current scope
             //~^^^^ NOTE found defined static methods, maybe a `self` is missing?
 }
 
 fn param_bound<T: ManyImplTrait>(t: T) -> bool {
     t.is_str()
-    //~^ ERROR type `T` does not implement any method in scope named `is_str`
+    //~^ ERROR no method named `is_str` found for type `T` in the current scope
     //~^^ NOTE found defined static methods, maybe a `self` is missing?
 }
 

--- a/src/test/compile-fail/macro-backtrace-invalid-internals.rs
+++ b/src/test/compile-fail/macro-backtrace-invalid-internals.rs
@@ -12,7 +12,7 @@
 
 macro_rules! fake_method_stmt { //~ NOTE in expansion of
      () => {
-          1.fake() //~ ERROR does not implement any method
+          1.fake() //~ ERROR no method named `fake` found
      }
 }
 
@@ -30,7 +30,7 @@ macro_rules! fake_anon_field_stmt { //~ NOTE in expansion of
 
 macro_rules! fake_method_expr { //~ NOTE in expansion of
      () => {
-          1.fake() //~ ERROR does not implement any method
+          1.fake() //~ ERROR no method named `fake` found
      }
 }
 

--- a/src/test/compile-fail/method-call-err-msg.rs
+++ b/src/test/compile-fail/method-call-err-msg.rs
@@ -25,6 +25,6 @@ fn main() {
 
     let y = Foo;
     y.zero()
-     .take()    //~ ERROR type `Foo` does not implement any method in scope named `take`
+     .take()    //~ ERROR no method named `take` found for type `Foo` in the current scope
      .one(0);
 }

--- a/src/test/compile-fail/method-suggestion-no-duplication.rs
+++ b/src/test/compile-fail/method-suggestion-no-duplication.rs
@@ -16,7 +16,7 @@ fn foo<F>(f: F) where F: FnMut(Foo) {}
 
 fn main() {
     foo(|s| s.is_empty());
-    //~^ ERROR does not implement any method
+    //~^ ERROR no method named `is_empty` found
     //~^^ HELP #1: `core::slice::SliceExt`
     //~^^^ HELP #2: `core::str::StrExt`
 }

--- a/src/test/compile-fail/no-method-suggested-traits.rs
+++ b/src/test/compile-fail/no-method-suggested-traits.rs
@@ -33,36 +33,36 @@ fn main() {
 
     1u32.method();
     //~^ HELP following traits are implemented but not in scope, perhaps add a `use` for one of them
-    //~^^ ERROR does not implement
+    //~^^ ERROR no method named
     //~^^^ HELP `foo::Bar`
     //~^^^^ HELP `no_method_suggested_traits::foo::PubPub`
     std::rc::Rc::new(&mut Box::new(&1u32)).method();
     //~^ HELP following traits are implemented but not in scope, perhaps add a `use` for one of them
-    //~^^ ERROR does not implement
+    //~^^ ERROR no method named
     //~^^^ HELP `foo::Bar`
     //~^^^^ HELP `no_method_suggested_traits::foo::PubPub`
 
     'a'.method();
-    //~^ ERROR does not implement
+    //~^ ERROR no method named
     //~^^ HELP the following trait is implemented but not in scope, perhaps add a `use` for it:
     //~^^^ HELP `foo::Bar`
     std::rc::Rc::new(&mut Box::new(&'a')).method();
-    //~^ ERROR does not implement
+    //~^ ERROR no method named
     //~^^ HELP the following trait is implemented but not in scope, perhaps add a `use` for it:
     //~^^^ HELP `foo::Bar`
 
     1i32.method();
-    //~^ ERROR does not implement
+    //~^ ERROR no method named
     //~^^ HELP the following trait is implemented but not in scope, perhaps add a `use` for it:
     //~^^^ HELP `no_method_suggested_traits::foo::PubPub`
     std::rc::Rc::new(&mut Box::new(&1i32)).method();
-    //~^ ERROR does not implement
+    //~^ ERROR no method named
     //~^^ HELP the following trait is implemented but not in scope, perhaps add a `use` for it:
     //~^^^ HELP `no_method_suggested_traits::foo::PubPub`
 
     Foo.method();
-    //~^ ERROR does not implement
-    //~^^ HELP following traits define a method `method`, perhaps you need to implement one of them
+    //~^ ERROR no method named
+    //~^^ HELP following traits define an item `method`, perhaps you need to implement one of them
     //~^^^ HELP `foo::Bar`
     //~^^^^ HELP `no_method_suggested_traits::foo::PubPub`
     //~^^^^^ HELP `no_method_suggested_traits::reexport::Reexported`
@@ -70,8 +70,8 @@ fn main() {
     //~^^^^^^^ HELP `no_method_suggested_traits::qux::PrivPub`
     //~^^^^^^^^ HELP `no_method_suggested_traits::quz::PrivPriv`
     std::rc::Rc::new(&mut Box::new(&Foo)).method();
-    //~^ ERROR does not implement
-    //~^^ HELP following traits define a method `method`, perhaps you need to implement one of them
+    //~^ ERROR no method named
+    //~^^ HELP following traits define an item `method`, perhaps you need to implement one of them
     //~^^^ HELP `foo::Bar`
     //~^^^^ HELP `no_method_suggested_traits::foo::PubPub`
     //~^^^^^ HELP `no_method_suggested_traits::reexport::Reexported`
@@ -80,55 +80,55 @@ fn main() {
     //~^^^^^^^^ HELP `no_method_suggested_traits::quz::PrivPriv`
 
     1u64.method2();
-    //~^ ERROR does not implement
-    //~^^ HELP the following trait defines a method `method2`, perhaps you need to implement it
+    //~^ ERROR no method named
+    //~^^ HELP the following trait defines an item `method2`, perhaps you need to implement it
     //~^^^ HELP `foo::Bar`
     std::rc::Rc::new(&mut Box::new(&1u64)).method2();
-    //~^ ERROR does not implement
-    //~^^ HELP the following trait defines a method `method2`, perhaps you need to implement it
+    //~^ ERROR no method named
+    //~^^ HELP the following trait defines an item `method2`, perhaps you need to implement it
     //~^^^ HELP `foo::Bar`
 
     no_method_suggested_traits::Foo.method2();
-    //~^ ERROR does not implement
-    //~^^ HELP following trait defines a method `method2`, perhaps you need to implement it
+    //~^ ERROR no method named
+    //~^^ HELP following trait defines an item `method2`, perhaps you need to implement it
     //~^^^ HELP `foo::Bar`
     std::rc::Rc::new(&mut Box::new(&no_method_suggested_traits::Foo)).method2();
-    //~^ ERROR does not implement
-    //~^^ HELP following trait defines a method `method2`, perhaps you need to implement it
+    //~^ ERROR no method named
+    //~^^ HELP following trait defines an item `method2`, perhaps you need to implement it
     //~^^^ HELP `foo::Bar`
     no_method_suggested_traits::Bar::X.method2();
-    //~^ ERROR does not implement
-    //~^^ HELP following trait defines a method `method2`, perhaps you need to implement it
+    //~^ ERROR no method named
+    //~^^ HELP following trait defines an item `method2`, perhaps you need to implement it
     //~^^^ HELP `foo::Bar`
     std::rc::Rc::new(&mut Box::new(&no_method_suggested_traits::Bar::X)).method2();
-    //~^ ERROR does not implement
-    //~^^ HELP following trait defines a method `method2`, perhaps you need to implement it
+    //~^ ERROR no method named
+    //~^^ HELP following trait defines an item `method2`, perhaps you need to implement it
     //~^^^ HELP `foo::Bar`
 
     Foo.method3();
-    //~^ ERROR does not implement
-    //~^^ HELP following trait defines a method `method3`, perhaps you need to implement it
+    //~^ ERROR no method named
+    //~^^ HELP following trait defines an item `method3`, perhaps you need to implement it
     //~^^^ HELP `no_method_suggested_traits::foo::PubPub`
     std::rc::Rc::new(&mut Box::new(&Foo)).method3();
-    //~^ ERROR does not implement
-    //~^^ HELP following trait defines a method `method3`, perhaps you need to implement it
+    //~^ ERROR no method named
+    //~^^ HELP following trait defines an item `method3`, perhaps you need to implement it
     //~^^^ HELP `no_method_suggested_traits::foo::PubPub`
     Bar::X.method3();
-    //~^ ERROR does not implement
-    //~^^ HELP following trait defines a method `method3`, perhaps you need to implement it
+    //~^ ERROR no method named
+    //~^^ HELP following trait defines an item `method3`, perhaps you need to implement it
     //~^^^ HELP `no_method_suggested_traits::foo::PubPub`
     std::rc::Rc::new(&mut Box::new(&Bar::X)).method3();
-    //~^ ERROR does not implement
-    //~^^ HELP following trait defines a method `method3`, perhaps you need to implement it
+    //~^ ERROR no method named
+    //~^^ HELP following trait defines an item `method3`, perhaps you need to implement it
     //~^^^ HELP `no_method_suggested_traits::foo::PubPub`
 
     // should have no help:
-    1_usize.method3(); //~ ERROR does not implement
-    std::rc::Rc::new(&mut Box::new(&1_usize)).method3(); //~ ERROR does not implement
-    no_method_suggested_traits::Foo.method3();  //~ ERROR does not implement
+    1_usize.method3(); //~ ERROR no method named
+    std::rc::Rc::new(&mut Box::new(&1_usize)).method3(); //~ ERROR no method named
+    no_method_suggested_traits::Foo.method3();  //~ ERROR no method named
     std::rc::Rc::new(&mut Box::new(&no_method_suggested_traits::Foo)).method3();
-    //~^ ERROR does not implement
-    no_method_suggested_traits::Bar::X.method3();  //~ ERROR does not implement
+    //~^ ERROR no method named
+    no_method_suggested_traits::Bar::X.method3();  //~ ERROR no method named
     std::rc::Rc::new(&mut Box::new(&no_method_suggested_traits::Bar::X)).method3();
-    //~^ ERROR does not implement
+    //~^ ERROR no method named
 }

--- a/src/test/compile-fail/non-copyable-void.rs
+++ b/src/test/compile-fail/non-copyable-void.rs
@@ -15,6 +15,6 @@ fn main() {
     let y : *const libc::c_void = x as *const libc::c_void;
     unsafe {
         let _z = (*y).clone();
-        //~^ ERROR does not implement any method in scope
+        //~^ ERROR no method named `clone` found
     }
 }

--- a/src/test/compile-fail/noncopyable-class.rs
+++ b/src/test/compile-fail/noncopyable-class.rs
@@ -41,6 +41,6 @@ fn foo(i:isize) -> foo {
 
 fn main() {
     let x = foo(10);
-    let _y = x.clone(); //~ ERROR does not implement any method in scope
+    let _y = x.clone(); //~ ERROR no method named `clone` found
     println!("{:?}", x);
 }

--- a/src/test/compile-fail/object-pointer-types.rs
+++ b/src/test/compile-fail/object-pointer-types.rs
@@ -19,19 +19,19 @@ trait Foo {
 fn borrowed_receiver(x: &Foo) {
     x.borrowed();
     x.borrowed_mut(); // See [1]
-    x.owned(); //~ ERROR does not implement any method
+    x.owned(); //~ ERROR no method named `owned` found
 }
 
 fn borrowed_mut_receiver(x: &mut Foo) {
     x.borrowed();
     x.borrowed_mut();
-    x.owned(); //~ ERROR does not implement any method
+    x.owned(); //~ ERROR no method named `owned` found
 }
 
 fn owned_receiver(x: Box<Foo>) {
     x.borrowed();
     x.borrowed_mut(); // See [1]
-    x.managed();  //~ ERROR does not implement any method
+    x.managed();  //~ ERROR no method named `managed` found
     x.owned();
 }
 

--- a/src/test/compile-fail/trait-impl-1.rs
+++ b/src/test/compile-fail/trait-impl-1.rs
@@ -22,5 +22,5 @@ impl T for i32 {}
 
 fn main() {
     let x = &42i32;
-    x.foo(); //~ERROR: type `&i32` does not implement any method in scope named `foo`
+    x.foo(); //~ERROR: no method named `foo` found for type `&i32` in the current scope
 }

--- a/src/test/compile-fail/unboxed-closures-static-call-wrong-trait.rs
+++ b/src/test/compile-fail/unboxed-closures-static-call-wrong-trait.rs
@@ -14,5 +14,5 @@ fn to_fn_mut<A,F:FnMut<A>>(f: F) -> F { f }
 
 fn main() {
     let mut_ = to_fn_mut(|x| x);
-    mut_.call((0, )); //~ ERROR does not implement any method in scope named `call`
+    mut_.call((0, )); //~ ERROR no method named `call` found
 }

--- a/src/test/compile-fail/unique-object-noncopyable.rs
+++ b/src/test/compile-fail/unique-object-noncopyable.rs
@@ -31,5 +31,5 @@ impl Foo for Bar {
 fn main() {
     let x = box Bar { x: 10 };
     let y: Box<Foo> = x as Box<Foo>;
-    let _z = y.clone(); //~ ERROR does not implement any method in scope
+    let _z = y.clone(); //~ ERROR no method named `clone` found
 }

--- a/src/test/compile-fail/unique-pinned-nocopy.rs
+++ b/src/test/compile-fail/unique-pinned-nocopy.rs
@@ -20,6 +20,6 @@ impl Drop for r {
 fn main() {
     // FIXME (#22405): Replace `Box::new` with `box` here when/if possible.
     let i = Box::new(r { b: true });
-    let _j = i.clone(); //~ ERROR not implement
+    let _j = i.clone(); //~ ERROR no method named `clone` found
     println!("{:?}", i);
 }

--- a/src/test/run-pass/associated-const-match-patterns.rs
+++ b/src/test/run-pass/associated-const-match-patterns.rs
@@ -42,6 +42,10 @@ fn main() {
     });
     // Trait impl
     assert!(match Bar::Var1 {
+        Foo::THEBAR => true,
+        _ => false,
+    });
+    assert!(match Bar::Var1 {
         <Foo>::THEBAR => true,
         _ => false,
     });


### PR DESCRIPTION
This fixes #24922 and #25017, and reduces the number of error messages that talk about "methods" when associated constants rather than methods are involved.

I will admit that I haven't thought very carefully about the error messages. My goal has been to make more of the messages technically correct in all situations, and to avoid ICEs. But in some cases we could probably talk specifically about "methods" rather than "items".
