### PR TITLE
Add #[inline(always)] to str::from_utf8_unchecked

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -136,6 +136,7 @@ pub fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
 
 /// Converts a slice of bytes to a string slice without checking
 /// that the string contains valid UTF-8.
+#[inline(always)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn from_utf8_unchecked<'a>(v: &'a [u8]) -> &'a str {
     mem::transmute(v)


### PR DESCRIPTION
Without the inline annotation this:
    str::from_utf8_unchecked( slice::from_raw_parts( ptr, len ) )
doesn't get inlined which can be pretty brutal performance-wise
when used in an inner loop of a low level string manipulation method.
