### PR TITLE
Fix severe bug in Book's Hello Cargo Chapter.

### DIFF
--- a/src/doc/trpl/hello-cargo.md
+++ b/src/doc/trpl/hello-cargo.md
@@ -60,6 +60,11 @@ Put this inside:
 name = "hello_world"
 version = "0.0.1"
 authors = [ "Your name <you@example.com>" ]
+
+[[bin]]
+name = "hello_world"
+test = false
+doc = false
 ```
 
 This file is in the [TOML][toml] format. Let’s let it explain itself to you:


### PR DESCRIPTION
Without these lines, a user following the directions will see:

$ cargo build
failed to parse manifest at `/Users/josh/proj/rust/Cargo.toml`

Caused by:
  either a [lib] or [[bin]] section must be present

After adding these lines they will see:
$ cargo build
   Compiling hello_world v0.0.1

$ cargo --version
cargo 0.2.0-nightly (83a6d0e 2015-04-16) (built 2015-04-16)

On a personal note, I want to say that I've always been fascinated with the idea of making something intentionally difficult for an applicant - like giving them the wrong directions, or making them stand on your porch for 3 days before they let you let them in. Would a community be better served to give out flawed "hello world" instructions to see who figures it out, a kind of secret cultural eugenics program? While part of me appreciates the delicious evil of this plan, the greater part just wants to get to play around with new langs like Rust and hopes to make the path a little easier for subsequent hikers on this trail.
