### PR TITLE
Implement Debug for std::net::{UdpSocket,TcpStream,TcpListener,Shutdown}

### DIFF
--- a/src/libstd/net/mod.rs
+++ b/src/libstd/net/mod.rs
@@ -32,7 +32,7 @@ mod parser;
 
 /// Possible values which can be passed to the `shutdown` method of `TcpStream`
 /// and `UdpSocket`.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum Shutdown {
     /// Indicates that the reading portion of this stream/socket should be shut

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -14,6 +14,7 @@
 use prelude::v1::*;
 use io::prelude::*;
 
+use fmt;
 use io;
 use net::{ToSocketAddrs, SocketAddr, Shutdown};
 use sys_common::net2 as net_imp;
@@ -167,6 +168,12 @@ impl FromInner<net_imp::TcpStream> for TcpStream {
     fn from_inner(inner: net_imp::TcpStream) -> TcpStream { TcpStream(inner) }
 }
 
+impl fmt::Debug for TcpStream {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl TcpListener {
     /// Creates a new `TcpListener` which will be bound to the specified
     /// address.
@@ -236,6 +243,12 @@ impl AsInner<net_imp::TcpListener> for TcpListener {
 impl FromInner<net_imp::TcpListener> for TcpListener {
     fn from_inner(inner: net_imp::TcpListener) -> TcpListener {
         TcpListener(inner)
+    }
+}
+
+impl fmt::Debug for TcpListener {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -151,6 +151,7 @@ mod tests {
     use net::*;
     use net::test::{next_test_ip4, next_test_ip6};
     use sync::mpsc::channel;
+    use sys_common::AsInner;
     use thread;
 
     fn each_ip(f: &mut FnMut(SocketAddr, SocketAddr)) {
@@ -307,5 +308,17 @@ mod tests {
             rx.recv().unwrap();
             serv_rx.recv().unwrap();
         })
+    }
+
+    #[test]
+    fn debug() {
+        let name = if cfg!(windows) {"socket"} else {"fd"};
+        let socket_addr = next_test_ip4();
+
+        let udpsock = t!(UdpSocket::bind(&socket_addr));
+        let udpsock_inner = udpsock.0.socket().as_inner();
+        let compare = format!("UdpSocket {{ addr: {:?}, {}: {:?} }}",
+                              socket_addr, name, udpsock_inner);
+        assert_eq!(format!("{:?}", udpsock), compare);
     }
 }

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -13,6 +13,7 @@
 
 use prelude::v1::*;
 
+use fmt;
 use io::{self, Error, ErrorKind};
 use net::{ToSocketAddrs, SocketAddr, IpAddr};
 use sys_common::net2 as net_imp;
@@ -134,6 +135,12 @@ impl AsInner<net_imp::UdpSocket> for UdpSocket {
 
 impl FromInner<net_imp::UdpSocket> for UdpSocket {
     fn from_inner(inner: net_imp::UdpSocket) -> UdpSocket { UdpSocket(inner) }
+}
+
+impl fmt::Debug for UdpSocket {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 #[cfg(test)]

--- a/src/libstd/sys/common/net2.rs
+++ b/src/libstd/sys/common/net2.rs
@@ -11,6 +11,7 @@
 use prelude::v1::*;
 
 use ffi::{CStr, CString};
+use fmt;
 use io::{self, Error, ErrorKind};
 use libc::{self, c_int, c_char, c_void, socklen_t};
 use mem;
@@ -268,6 +269,16 @@ impl FromInner<Socket> for TcpStream {
     }
 }
 
+impl fmt::Debug for TcpStream {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("TcpStream")
+        .field("addr", &self.socket_addr())
+        .field("peer", &self.peer_addr())
+        .field("inner", &self.inner.as_inner())
+        .finish()
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // TCP listeners
 ////////////////////////////////////////////////////////////////////////////////
@@ -324,6 +335,15 @@ impl TcpListener {
 impl FromInner<Socket> for TcpListener {
     fn from_inner(socket: Socket) -> TcpListener {
         TcpListener { inner: socket }
+    }
+}
+
+impl fmt::Debug for TcpListener {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("TcpListener")
+        .field("addr", &self.socket_addr())
+        .field("inner", &self.inner.as_inner())
+        .finish()
     }
 }
 
@@ -443,5 +463,14 @@ impl UdpSocket {
 impl FromInner<Socket> for UdpSocket {
     fn from_inner(socket: Socket) -> UdpSocket {
         UdpSocket { inner: socket }
+    }
+}
+
+impl fmt::Debug for UdpSocket {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("UdpSocket")
+        .field("addr", &self.socket_addr())
+        .field("inner", &self.inner.as_inner())
+        .finish()
     }
 }

--- a/src/libstd/sys/common/net2.rs
+++ b/src/libstd/sys/common/net2.rs
@@ -271,11 +271,18 @@ impl FromInner<Socket> for TcpStream {
 
 impl fmt::Debug for TcpStream {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("TcpStream")
-        .field("addr", &self.socket_addr())
-        .field("peer", &self.peer_addr())
-        .field("inner", &self.inner.as_inner())
-        .finish()
+        let mut res = f.debug_struct("TcpStream");
+
+        if let Ok(addr) = self.socket_addr() {
+            res = res.field("addr", &addr);
+        }
+
+        if let Ok(peer) = self.peer_addr() {
+            res = res.field("peer", &peer);
+        }
+
+        res = res.field("inner", &self.inner.as_inner());
+        res.finish()
     }
 }
 
@@ -340,10 +347,14 @@ impl FromInner<Socket> for TcpListener {
 
 impl fmt::Debug for TcpListener {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("TcpListener")
-        .field("addr", &self.socket_addr())
-        .field("inner", &self.inner.as_inner())
-        .finish()
+        let mut res = f.debug_struct("TcpListener");
+
+        if let Ok(addr) = self.socket_addr() {
+            res = res.field("addr", &addr);
+        }
+
+        res = res.field("inner", &self.inner.as_inner());
+        res.finish()
     }
 }
 
@@ -468,9 +479,13 @@ impl FromInner<Socket> for UdpSocket {
 
 impl fmt::Debug for UdpSocket {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("UdpSocket")
-        .field("addr", &self.socket_addr())
-        .field("inner", &self.inner.as_inner())
-        .finish()
+        let mut res = f.debug_struct("UdpSocket");
+
+        if let Ok(addr) = self.socket_addr() {
+            res = res.field("addr", &addr);
+        }
+
+        res = res.field("inner", &self.inner.as_inner());
+        res.finish()
     }
 }

--- a/src/libstd/sys/common/net2.rs
+++ b/src/libstd/sys/common/net2.rs
@@ -281,7 +281,8 @@ impl fmt::Debug for TcpStream {
             res = res.field("peer", &peer);
         }
 
-        res = res.field("inner", &self.inner.as_inner());
+        let name = if cfg!(windows) {"socket"} else {"fd"};
+        res = res.field(name, &self.inner.as_inner());
         res.finish()
     }
 }
@@ -353,7 +354,8 @@ impl fmt::Debug for TcpListener {
             res = res.field("addr", &addr);
         }
 
-        res = res.field("inner", &self.inner.as_inner());
+        let name = if cfg!(windows) {"socket"} else {"fd"};
+        res = res.field(name, &self.inner.as_inner());
         res.finish()
     }
 }
@@ -485,7 +487,8 @@ impl fmt::Debug for UdpSocket {
             res = res.field("addr", &addr);
         }
 
-        res = res.field("inner", &self.inner.as_inner());
+        let name = if cfg!(windows) {"socket"} else {"fd"};
+        res = res.field(name, &self.inner.as_inner());
         res.finish()
     }
 }


### PR DESCRIPTION
I'm uncertain whether the 3 implementations in `net2` should unwrap the socket address values. Without unwrapping it looks like this:

```
UdpSocket { addr: Ok(V4(127.0.0.1:34354)), inner: 3 }
TcpListener { addr: Ok(V4(127.0.0.1:9123)), inner: 4 }
TcpStream { addr: Ok(V4(127.0.0.1:9123)), peer: Ok(V4(127.0.0.1:58360)), inner: 5 }
```

One issue is that you can create, e.g. `UdpSocket`s with bad addresses, which means you can't just unwrap in the implementation:

```
#![feature(from_raw_os)]
use std::net::UdpSocket;
use std::os::unix::io::FromRawFd;

let sock: UdpSocket = unsafe { FromRawFd::from_raw_fd(-1) };
println!("{:?}", sock); // prints "UdpSocket { addr: Err(Error { repr: Os(9) }), inner: -1 }"

```

Fixes #23134.
