### PR TITLE
Mark &mut Iterator methods as inline

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1086,7 +1086,9 @@ fn select_fold1<I,B, FProj, FCmp>(mut it: I,
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, I: Iterator + ?Sized> Iterator for &'a mut I {
     type Item = I::Item;
+    #[inline(always)]
     fn next(&mut self) -> Option<I::Item> { (**self).next() }
+    #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) { (**self).size_hint() }
 }
 


### PR DESCRIPTION
This way external crates can always inline them.
