### PR TITLE
Remove mentions of the old tilde owned pointer syntax

### DIFF
--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -1125,7 +1125,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                         // that case we can adjust the length of the
                         // original vec accordingly, but we'd have to
                         // make trans do the right thing, and it would
-                        // only work for `Vec`s. It seems simpler
+                        // only work for `Box<[T]>`s. It seems simpler
                         // to just require that people call
                         // `vec.pop()` or `vec.unshift()`.
                         let slice_bk = ty::BorrowKind::from_mutbl(slice_mutbl);

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -1125,7 +1125,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                         // that case we can adjust the length of the
                         // original vec accordingly, but we'd have to
                         // make trans do the right thing, and it would
-                        // only work for `~` vectors. It seems simpler
+                        // only work for `Vec`s. It seems simpler
                         // to just require that people call
                         // `vec.pop()` or `vec.unshift()`.
                         let slice_bk = ty::BorrowKind::from_mutbl(slice_mutbl);

--- a/src/librustc/middle/traits/coherence.rs
+++ b/src/librustc/middle/traits/coherence.rs
@@ -323,7 +323,7 @@ fn ty_is_local_constructor<'tcx>(tcx: &ty::ctxt<'tcx>,
             def_id.krate == ast::LOCAL_CRATE
         }
 
-        ty::ty_uniq(_) => { // treat ~T like Box<T>
+        ty::ty_uniq(_) => { // Box<T>
             let krate = tcx.lang_items.owned_box().map(|d| d.krate);
             krate == Some(ast::LOCAL_CRATE)
         }

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -2441,10 +2441,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     /// `match_impl()`. For example, if `impl_def_id` is declared
     /// as:
     ///
-    ///    impl<T:Copy> Foo for ~T { ... }
+    ///    impl<T:Copy> Foo for Box<T> { ... }
     ///
-    /// and `obligation_self_ty` is `int`, we'd back an `Err(_)`
-    /// result. But if `obligation_self_ty` were `~int`, we'd get
+    /// and `obligation_self_ty` is `int`, we'd get back an `Err(_)`
+    /// result. But if `obligation_self_ty` were `Box<int>`, we'd get
     /// back `Ok(T=int)`.
     fn match_inherent_impl(&mut self,
                            impl_def_id: ast::DefId,

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -637,7 +637,7 @@ impl<'tcx, T:Repr<'tcx>> Repr<'tcx> for OwnedSlice<T> {
     }
 }
 
-// This is necessary to handle types like Option<~[T]>, for which
+// This is necessary to handle types like Option<Vec<T>>, for which
 // autoderef cannot convert the &[T] handler
 impl<'tcx, T:Repr<'tcx>> Repr<'tcx> for Vec<T> {
     fn repr(&self, tcx: &ctxt<'tcx>) -> String {

--- a/src/librustc_borrowck/borrowck/check_loans.rs
+++ b/src/librustc_borrowck/borrowck/check_loans.rs
@@ -732,7 +732,7 @@ impl<'a, 'tcx> CheckLoanCtxt<'a, 'tcx> {
     /// let p: Point;
     /// p.x = 22; // ok, even though `p` is uninitialized
     ///
-    /// let p: ~Point;
+    /// let p: Box<Point>;
     /// (*p).x = 22; // not ok, p is uninitialized, can't deref
     /// ```
     fn check_if_assigned_path_is_moved(&self,

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1314,7 +1314,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for VisiblePrivateTypesVisitor<'a, 'tcx> {
                 // `impl [... for] Private` is never visible.
                 let self_contains_private;
                 // impl [... for] Public<...>, but not `impl [... for]
-                // ~[Public]` or `(Public,)` etc.
+                // Vec<Public>` or `(Public,)` etc.
                 let self_is_public_path;
 
                 // check the properties of the Self type:

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -288,7 +288,7 @@ pub fn mangle<PI: Iterator<Item=PathElem>>(path: PI,
     // when using unix's linker. Perhaps one day when we just use a linker from LLVM
     // we won't need to do this name mangling. The problem with name mangling is
     // that it seriously limits the available characters. For example we can't
-    // have things like &T or ~[T] in symbol names when one would theoretically
+    // have things like &T or Vec<T> in symbol names when one would theoretically
     // want them for things like impls of traits on that type.
     //
     // To be able to work on all platforms and get *some* reasonable output, we

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -288,7 +288,7 @@ pub fn mangle<PI: Iterator<Item=PathElem>>(path: PI,
     // when using unix's linker. Perhaps one day when we just use a linker from LLVM
     // we won't need to do this name mangling. The problem with name mangling is
     // that it seriously limits the available characters. For example we can't
-    // have things like &T or Vec<T> in symbol names when one would theoretically
+    // have things like &T in symbol names when one would theoretically
     // want them for things like impls of traits on that type.
     //
     // To be able to work on all platforms and get *some* reasonable output, we

--- a/src/librustc_trans/save/span_utils.rs
+++ b/src/librustc_trans/save/span_utils.rs
@@ -230,8 +230,8 @@ impl<'a> SpanUtils<'a> {
     // Reparse span and return an owned vector of sub spans of the first limit
     // identifier tokens in the given nesting level.
     // example with Foo<Bar<T,V>, Bar<T,V>>
-    // Nesting = 0: all idents outside of brackets: ~[Foo]
-    // Nesting = 1: idents within one level of brackets: ~[Bar, Bar]
+    // Nesting = 0: all idents outside of brackets: Vec<Foo>
+    // Nesting = 1: idents within one level of brackets: Vec<Bar, Bar>
     pub fn spans_with_brackets(&self, span: Span, nesting: isize, limit: isize) -> Vec<Span> {
         let mut result: Vec<Span> = vec!();
 
@@ -352,7 +352,7 @@ impl<'a> SpanUtils<'a> {
             return vec!();
         }
         // Type params are nested within one level of brackets:
-        // i.e. we want ~[A, B] from Foo<A, B<T,U>>
+        // i.e. we want Vec<A, B> from Foo<A, B<T,U>>
         self.spans_with_brackets(span, 1, number)
     }
 

--- a/src/librustc_trans/trans/attributes.rs
+++ b/src/librustc_trans/trans/attributes.rs
@@ -196,7 +196,7 @@ pub fn from_fn_type<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_type: ty::Ty<'tcx
             // The `noalias` attribute on the return value is useful to a
             // function ptr caller.
             match ret_ty.sty {
-                // `~` pointer return values never alias because ownership
+                // `Box` pointer return values never alias because ownership
                 // is transferred
                 ty::ty_uniq(it) if common::type_is_sized(ccx.tcx(), it) => {
                     attrs.ret(llvm::Attribute::NoAliasAttribute);
@@ -239,7 +239,7 @@ pub fn from_fn_type<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_type: ty::Ty<'tcx
                 attrs.arg(idx, llvm::Attribute::ZExtAttribute);
             }
 
-            // `~` pointer parameters never alias because ownership is transferred
+            // `Box` pointer parameters never alias because ownership is transferred
             ty::ty_uniq(inner) => {
                 let llsz = machine::llsize_of_real(ccx, type_of::type_of(ccx, inner));
 

--- a/src/librustc_trans/trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/trans/debuginfo/metadata.rs
@@ -151,7 +151,7 @@ impl<'tcx> TypeMap<'tcx> {
         // mut reference (&mut)   -> {&mut :pointee-uid:}
         // ptr (*)                -> {* :pointee-uid:}
         // mut ptr (*mut)         -> {*mut :pointee-uid:}
-        // unique ptr (Box)       -> {Box :pointee-uid:}
+        // unique ptr (box)       -> {box :pointee-uid:}
         // @-ptr (@)              -> {@ :pointee-uid:}
         // sized vec ([T; x])     -> {[:size:] :element-uid:}
         // unsized vec ([T])      -> {[] :element-uid:}
@@ -200,7 +200,7 @@ impl<'tcx> TypeMap<'tcx> {
                 }
             },
             ty::ty_uniq(inner_type) => {
-                unique_type_id.push_str("Box ");
+                unique_type_id.push_str("box ");
                 let inner_type_id = self.get_unique_type_id_of_type(cx, inner_type);
                 let inner_type_id = self.get_unique_type_id_as_string(inner_type_id);
                 unique_type_id.push_str(&inner_type_id[..]);

--- a/src/librustc_trans/trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/trans/debuginfo/metadata.rs
@@ -142,26 +142,24 @@ impl<'tcx> TypeMap<'tcx> {
     fn get_unique_type_id_of_type<'a>(&mut self, cx: &CrateContext<'a, 'tcx>,
                                       type_: Ty<'tcx>) -> UniqueTypeId {
 
-        // basic type           -> {:name of the type:}
-        // tuple                -> {tuple_(:param-uid:)*}
-        // struct               -> {struct_:svh: / :node-id:_<(:param-uid:),*> }
-        // enum                 -> {enum_:svh: / :node-id:_<(:param-uid:),*> }
-        // enum variant         -> {variant_:variant-name:_:enum-uid:}
-        // reference (&)        -> {& :pointee-uid:}
-        // mut reference (&mut) -> {&mut :pointee-uid:}
-        // ptr (*)              -> {* :pointee-uid:}
-        // mut ptr (*mut)       -> {*mut :pointee-uid:}
-        // unique ptr (~)       -> {~ :pointee-uid:}
-        // @-ptr (@)            -> {@ :pointee-uid:}
-        // sized vec ([T; x])   -> {[:size:] :element-uid:}
-        // unsized vec ([T])    -> {[] :element-uid:}
-        // trait (T)            -> {trait_:svh: / :node-id:_<(:param-uid:),*> }
-        // closure              -> {<unsafe_> <once_> :store-sigil: |(:param-uid:),* <,_...>| -> \
+        // basic type             -> {:name of the type:}
+        // tuple                  -> {tuple_(:param-uid:)*}
+        // struct                 -> {struct_:svh: / :node-id:_<(:param-uid:),*> }
+        // enum                   -> {enum_:svh: / :node-id:_<(:param-uid:),*> }
+        // enum variant           -> {variant_:variant-name:_:enum-uid:}
+        // reference (&)          -> {& :pointee-uid:}
+        // mut reference (&mut)   -> {&mut :pointee-uid:}
+        // ptr (*)                -> {* :pointee-uid:}
+        // mut ptr (*mut)         -> {*mut :pointee-uid:}
+        // unique ptr (Box)       -> {Box :pointee-uid:}
+        // @-ptr (@)              -> {@ :pointee-uid:}
+        // sized vec ([T; x])     -> {[:size:] :element-uid:}
+        // unsized vec ([T])      -> {[] :element-uid:}
+        // trait (T)              -> {trait_:svh: / :node-id:_<(:param-uid:),*> }
+        // closure                -> {<unsafe_> <once_> :store-sigil: |(:param-uid:),* <,_...>| -> \
         //                             :return-type-uid: : (:bounds:)*}
-        // function             -> {<unsafe_> <abi_> fn( (:param-uid:)* <,_...> ) -> \
+        // function               -> {<unsafe_> <abi_> fn( (:param-uid:)* <,_...> ) -> \
         //                             :return-type-uid:}
-        // unique vec box (~[]) -> {HEAP_VEC_BOX<:pointee-uid:>}
-        // gc box               -> {GC_BOX<:pointee-uid:>}
 
         match self.type_to_unique_id.get(&type_).cloned() {
             Some(unique_type_id) => return unique_type_id,
@@ -202,7 +200,7 @@ impl<'tcx> TypeMap<'tcx> {
                 }
             },
             ty::ty_uniq(inner_type) => {
-                unique_type_id.push('~');
+                unique_type_id.push_str("Box ");
                 let inner_type_id = self.get_unique_type_id_of_type(cx, inner_type);
                 let inner_type_id = self.get_unique_type_id_as_string(inner_type_id);
                 unique_type_id.push_str(&inner_type_id[..]);

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2458,7 +2458,7 @@ fn check_expr_with_lvalue_pref<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>, expr: &'tcx ast::
 }
 
 // determine the `self` type, using fresh variables for all variables
-// declared on the impl declaration e.g., `impl<A,B> for ~[(A,B)]`
+// declared on the impl declaration e.g., `impl<A,B> for Vec<(A,B)>`
 // would return ($0, $1) where $0 and $1 are freshly instantiated type
 // variables.
 pub fn impl_self_ty<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,

--- a/src/librustc_typeck/variance.rs
+++ b/src/librustc_typeck/variance.rs
@@ -178,8 +178,8 @@
 //! further that for whatever reason I specifically supply the value of
 //! `String` for the type parameter `T`:
 //!
-//!     let mut vector = ~["string", ...];
-//!     convertAll::<int, String>(v);
+//!     let mut vector = vec!["string", ...];
+//!     convertAll::<int, String>(vector);
 //!
 //! Is this legal? To put another way, can we apply the `impl` for
 //! `Object` to the type `String`? The answer is yes, but to see why

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -897,7 +897,7 @@ impl<'tcx> Clean<Type> for ty::ProjectionTy<'tcx> {
     }
 }
 
-// maybe use a Generic enum and use ~[Generic]?
+// maybe use a Generic enum and use Vec<Generic>?
 #[derive(Clone, RustcEncodable, RustcDecodable, PartialEq, Debug)]
 pub struct Generics {
     pub lifetimes: Vec<Lifetime>,

--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -896,8 +896,8 @@ impl<'a> MethodDef<'a> {
                                  nonself_args: &[P<Expr>])
         -> P<Expr> {
 
-        let mut raw_fields = Vec::new(); // ~[[fields of self],
-                                 // [fields of next Self arg], [etc]]
+        let mut raw_fields = Vec::new(); // Vec<[fields of self],
+                                 // [fields of next Self arg], [etc]>
         let mut patterns = Vec::new();
         for i in 0..self_args.len() {
             let struct_path= cx.path(DUMMY_SP, vec!( type_ident ));

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1691,7 +1691,7 @@ mod tests {
     // induced by visit.  Each of these arrays contains a list of indexes,
     // interpreted as the varrefs in the varref traversal that this binding
     // should match.  So, for instance, in a program with two bindings and
-    // three varrefs, the array ~[~[1,2],~[0]] would indicate that the first
+    // three varrefs, the array [[1, 2], [0]] would indicate that the first
     // binding should match the second two varrefs, and the second binding
     // should match the first varref.
     //

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -312,7 +312,7 @@ impl<'a> Printer<'a> {
         self.token[self.right] = t;
     }
     pub fn pretty_print(&mut self, token: Token) -> io::Result<()> {
-        debug!("pp ~[{},{}]", self.left, self.right);
+        debug!("pp Vec<{},{}>", self.left, self.right);
         match token {
           Token::Eof => {
             if !self.scan_stack_empty {
@@ -329,7 +329,7 @@ impl<'a> Printer<'a> {
                 self.left = 0;
                 self.right = 0;
             } else { self.advance_right(); }
-            debug!("pp Begin({})/buffer ~[{},{}]",
+            debug!("pp Begin({})/buffer Vec<{},{}>",
                    b.offset, self.left, self.right);
             self.token[self.right] = token;
             self.size[self.right] = -self.right_total;
@@ -339,10 +339,10 @@ impl<'a> Printer<'a> {
           }
           Token::End => {
             if self.scan_stack_empty {
-                debug!("pp End/print ~[{},{}]", self.left, self.right);
+                debug!("pp End/print Vec<{},{}>", self.left, self.right);
                 self.print(token, 0)
             } else {
-                debug!("pp End/buffer ~[{},{}]", self.left, self.right);
+                debug!("pp End/buffer Vec<{},{}>", self.left, self.right);
                 self.advance_right();
                 self.token[self.right] = token;
                 self.size[self.right] = -1;
@@ -358,7 +358,7 @@ impl<'a> Printer<'a> {
                 self.left = 0;
                 self.right = 0;
             } else { self.advance_right(); }
-            debug!("pp Break({})/buffer ~[{},{}]",
+            debug!("pp Break({})/buffer Vec<{},{}>",
                    b.offset, self.left, self.right);
             self.check_stack(0);
             let right = self.right;
@@ -370,11 +370,11 @@ impl<'a> Printer<'a> {
           }
           Token::String(s, len) => {
             if self.scan_stack_empty {
-                debug!("pp String('{}')/print ~[{},{}]",
+                debug!("pp String('{}')/print Vec<{},{}>",
                        s, self.left, self.right);
                 self.print(Token::String(s, len), len)
             } else {
-                debug!("pp String('{}')/buffer ~[{},{}]",
+                debug!("pp String('{}')/buffer Vec<{},{}>",
                        s, self.left, self.right);
                 self.advance_right();
                 self.token[self.right] = Token::String(s, len);
@@ -386,7 +386,7 @@ impl<'a> Printer<'a> {
         }
     }
     pub fn check_stream(&mut self) -> io::Result<()> {
-        debug!("check_stream ~[{}, {}] with left_total={}, right_total={}",
+        debug!("check_stream Vec<{}, {}> with left_total={}, right_total={}",
                self.left, self.right, self.left_total, self.right_total);
         if self.right_total - self.left_total > self.space {
             debug!("scan window is {}, longer than space on line ({})",
@@ -446,7 +446,7 @@ impl<'a> Printer<'a> {
         assert!((self.right != self.left));
     }
     pub fn advance_left(&mut self) -> io::Result<()> {
-        debug!("advance_left ~[{},{}], sizeof({})={}", self.left, self.right,
+        debug!("advance_left Vec<{},{}>, sizeof({})={}", self.left, self.right,
                self.left, self.size[self.left]);
 
         let mut left_size = self.size[self.left];

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -259,8 +259,8 @@ pub fn test_main(args: &[String], tests: Vec<TestDescAndFn> ) {
 // This will panic (intentionally) when fed any dynamic tests, because
 // it is copying the static values out into a dynamic vector and cannot
 // copy dynamic values. It is doing this because from this point on
-// a ~[TestDescAndFn] is used in order to effect ownership-transfer
-// semantics into parallel test runners, which in turn requires a ~[]
+// a Vec<TestDescAndFn> is used in order to effect ownership-transfer
+// semantics into parallel test runners, which in turn requires a Vec<>
 // rather than a &[].
 pub fn test_main_static(args: env::Args, tests: &[TestDescAndFn]) {
     let args = args.collect::<Vec<_>>();

--- a/src/test/compile-fail/kindck-copy.rs
+++ b/src/test/compile-fail/kindck-copy.rs
@@ -37,7 +37,7 @@ fn test<'a,T,U:Copy>(_: &'a isize) {
     assert_copy::<&'static mut isize>(); //~ ERROR `core::marker::Copy` is not implemented
     assert_copy::<&'a mut isize>();  //~ ERROR `core::marker::Copy` is not implemented
 
-    // ~ pointers are not ok
+    // owned pointers are not ok
     assert_copy::<Box<isize>>();   //~ ERROR `core::marker::Copy` is not implemented
     assert_copy::<String>();   //~ ERROR `core::marker::Copy` is not implemented
     assert_copy::<Vec<isize> >(); //~ ERROR `core::marker::Copy` is not implemented

--- a/src/test/debuginfo/issue11600.rs
+++ b/src/test/debuginfo/issue11600.rs
@@ -13,7 +13,7 @@
 // ignore-test
 
 fn main() {
-    let args : ~[String] = ::std::os::args();
+    let args : Vec<String> = ::std::os::args();
     ::std::io::println(args[0]);
 }
 

--- a/src/test/debuginfo/issue11600.rs
+++ b/src/test/debuginfo/issue11600.rs
@@ -25,6 +25,6 @@ fn main() {
 // compile-flags:-g
 // gdb-command:list
 // gdb-check:1[...]fn main() {
-// gdb-check:2[...]let args : ~[String] = ::std::os::args();
+// gdb-check:2[...]let args : Vec<String> = ::std::os::args();
 // gdb-check:3[...]::std::io::println(args[0]);
 // gdb-check:4[...]}

--- a/src/test/run-pass/const-bound.rs
+++ b/src/test/run-pass/const-bound.rs
@@ -20,7 +20,7 @@ struct F { field: isize }
 pub fn main() {
     /*foo(1);
     foo("hi".to_string());
-    foo(~[1, 2, 3]);
+    foo(vec![1, 2, 3]);
     foo(F{field: 42});
     foo((1, 2));
     foo(@1);*/

--- a/src/test/run-pass/issue-3556.rs
+++ b/src/test/run-pass/issue-3556.rs
@@ -32,10 +32,6 @@ fn check_strs(actual: &str, expected: &str) -> bool
 
 pub fn main()
 {
-// assert!(check_strs(fmt!("%?", Text(@"foo".to_string())), "Text(@~\"foo\")"));
-// assert!(check_strs(fmt!("%?", ETag(@~["foo".to_string()], @"bar".to_string())),
-//                    "ETag(@~[ ~\"foo\" ], @~\"bar\")"));
-
     let t = Token::Text("foo".to_string());
     let u = Token::Section(vec!["alpha".to_string()],
                     true,

--- a/src/test/run-pass/issue-4241.rs
+++ b/src/test/run-pass/issue-4241.rs
@@ -22,8 +22,8 @@ use std::io::{ReaderUtil,WriterUtil};
 enum Result {
   Nil,
   Int(isize),
-  Data(~[u8]),
-  List(~[Result]),
+  Data(Vec<u8>),
+  List(Vec<Result>),
   Error(String),
   Status(String)
 }
@@ -35,7 +35,7 @@ fn parse_data(len: usize, io: @io::Reader) -> Result {
       assert_eq!(bytes.len(), len);
       Data(bytes)
   } else {
-      Data(~[])
+      Data(vec![])
   };
   assert_eq!(io.read_char(), '\r');
   assert_eq!(io.read_char(), '\n');
@@ -43,7 +43,7 @@ fn parse_data(len: usize, io: @io::Reader) -> Result {
 }
 
 fn parse_list(len: usize, io: @io::Reader) -> Result {
-    let mut list: ~[Result] = ~[];
+    let mut list: Vec<Result> = vec![];
     for _ in 0..len {
         let v = match io.read_char() {
             '$' => parse_bulk(io),
@@ -72,7 +72,7 @@ fn parse_multi(io: @io::Reader) -> Result {
     match from_str::<isize>(chop(io.read_line())) {
     None => panic!(),
     Some(-1) => Nil,
-    Some(0) => List(~[]),
+    Some(0) => List(vec![]),
     Some(len) if len >= 0 => parse_list(len as usize, io),
     Some(_) => panic!()
     }
@@ -96,7 +96,7 @@ fn parse_response(io: @io::Reader) -> Result {
     }
 }
 
-fn cmd_to_string(cmd: ~[String]) -> String {
+fn cmd_to_string(cmd: Vec<String>) -> String {
   let mut res = "*".to_string();
   res.push_str(cmd.len().to_string());
   res.push_str("\r\n");
@@ -107,7 +107,7 @@ fn cmd_to_string(cmd: ~[String]) -> String {
   res
 }
 
-fn query(cmd: ~[String], sb: TcpSocketBuf) -> Result {
+fn query(cmd: Vec<String>, sb: TcpSocketBuf) -> Result {
   let cmd = cmd_to_string(cmd);
   //println!("{}", cmd);
   sb.write_str(cmd);
@@ -115,7 +115,7 @@ fn query(cmd: ~[String], sb: TcpSocketBuf) -> Result {
   res
 }
 
-fn query2(cmd: ~[String]) -> Result {
+fn query2(cmd: Vec<String>) -> Result {
   let _cmd = cmd_to_string(cmd);
     io::with_str_reader("$3\r\nXXX\r\n".to_string())(|sb| {
     let res = parse_response(@sb as @io::Reader);


### PR DESCRIPTION
There were still some mentions of `~[T]` and `~T`, mostly in comments and debugging statements. I tried to do my best to preserve meaning, but I might have gotten some wrong-- I'm happy to fix anything :)
