### PR TITLE
Correct pretty-printing of `type Foo<T> where T: Bound = ...;`

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -903,10 +903,10 @@ impl<'a> State<'a> {
                 try!(self.print_generics(params));
                 try!(self.end()); // end the inner ibox
 
+                try!(self.print_where_clause(&params.where_clause));
                 try!(space(&mut self.s));
                 try!(self.word_space("="));
                 try!(self.print_type(&**ty));
-                try!(self.print_where_clause(&params.where_clause));
                 try!(word(&mut self.s, ";"));
                 try!(self.end()); // end the outer ibox
             }

--- a/src/test/pretty/issue-25031.rs
+++ b/src/test/pretty/issue-25031.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// Testing that type items with where clauses output correctly.
+
+// pp-exact
+
+fn main() {
+    type Foo<T> where T: Copy = Box<T>;
+}


### PR DESCRIPTION
Correct pretty-printing of `type Foo<T> where T: Bound = ...;`

Fix #25031
