### PR TITLE
Fix spelling errors in documentation.

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -713,7 +713,7 @@ impl str {
     /// is skipped if empty.
     ///
     /// This method can be used for string data that is _terminated_,
-    /// rather than _seperated_ by a pattern.
+    /// rather than _separated_ by a pattern.
     ///
     /// # Iterator behavior
     ///
@@ -760,7 +760,7 @@ impl str {
     /// skipped if empty.
     ///
     /// This method can be used for string data that is _terminated_,
-    /// rather than _seperated_ by a pattern.
+    /// rather than _separated_ by a pattern.
     ///
     /// # Iterator behavior
     ///

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -757,7 +757,7 @@ impl FromUtf8Error {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn into_bytes(self) -> Vec<u8> { self.bytes }
 
-    /// Accesss the underlying UTF8-error that was the cause of this error.
+    /// Access the underlying UTF8-error that was the cause of this error.
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn utf8_error(&self) -> Utf8Error { self.error }
 }

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -421,7 +421,7 @@ macro_rules! derive_pattern_clone {
 /// wrapping an private internal one that makes use of the `Pattern` API.
 ///
 /// For all patterns `P: Pattern<'a>` the following items will be
-/// generated (generics ommitted):
+/// generated (generics omitted):
 ///
 /// struct $forward_iterator($internal_iterator);
 /// struct $reverse_iterator($internal_iterator);

--- a/src/librustc/middle/infer/higher_ranked/mod.rs
+++ b/src/librustc/middle/infer/higher_ranked/mod.rs
@@ -461,7 +461,7 @@ impl<'a,'tcx> InferCtxtExt for InferCtxt<'a,'tcx> {
 
 /// Constructs and returns a substitution that, for a given type
 /// scheme parameterized by `generics`, will replace every generic
-/// parmeter in the type with a skolemized type/region (which one can
+/// parameter in the type with a skolemized type/region (which one can
 /// think of as a "fresh constant", except at the type/region level of
 /// reasoning).
 ///

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1908,7 +1908,7 @@ pub enum Predicate<'tcx> {
 }
 
 impl<'tcx> Predicate<'tcx> {
-    /// Performs a substituion suitable for going from a
+    /// Performs a substitution suitable for going from a
     /// poly-trait-ref to supertraits that must hold if that
     /// poly-trait-ref holds. This is slightly different from a normal
     /// substitution in terms of what happens with bound regions.  See

--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -434,7 +434,7 @@ pub mod builtin {
 
     /// Parse the current given file as an expression.
     ///
-    /// This is generally a bad idea, because it's going to behave unhygenically.
+    /// This is generally a bad idea, because it's going to behave unhygienically.
     ///
     /// # Examples
     ///

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -358,7 +358,7 @@ pub fn is_separator(c: char) -> bool {
     c.is_ascii() && is_sep_byte(c as u8)
 }
 
-/// The primary sperator for the current platform
+/// The primary separator for the current platform
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MAIN_SEPARATOR: char = platform::MAIN_SEP;
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -595,7 +595,7 @@ pub enum Pat_ {
 
     /// An associated const named using the qualified path `<T>::CONST` or
     /// `<T as Trait>::CONST`. Associated consts from inherent impls can be
-    /// refered to as simply `T::CONST`, in which case they will end up as
+    /// referred to as simply `T::CONST`, in which case they will end up as
     /// PatEnum, and the resolver will have to sort that out.
     PatQPath(QSelf, Path),
 


### PR DESCRIPTION
I corrected several spelling errors in the external documentation.
