### PR TITLE
std: Join threads in select! doctest

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -152,12 +152,14 @@ macro_rules! try {
 /// thread::spawn(move|| { long_running_task(); tx1.send(()).unwrap(); });
 /// thread::spawn(move|| { tx2.send(calculate_the_answer()).unwrap(); });
 ///
-/// select! (
+/// select! {
 ///     _ = rx1.recv() => println!("the long running task finished first"),
 ///     answer = rx2.recv() => {
 ///         println!("the answer was: {}", answer.unwrap());
 ///     }
-/// )
+/// }
+/// # drop(rx1.recv());
+/// # drop(rx2.recv());
 /// ```
 ///
 /// For more information about select, see the `std::sync::mpsc::Select` structure.


### PR DESCRIPTION
This test has deadlocked on Windows once or twice now and we've had lots of
problems in the past of threads panicking when the process is being shut down.
One of the two threads in this test is guaranteed to panic because of the
`.unwrap()` on the `send` calls, so just call `recv` on both receivers after the
test executes to ensure that both threads are dying/dead.
