### PR TITLE
doc: fix markup

### DIFF
--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -142,7 +142,8 @@ impl Ipv4Addr {
 
     /// Returns true if this address is in a range designated for documentation.
     ///
-    /// This is defined in RFC 5737
+    /// This is defined in RFC 5737:
+    ///
     /// - 192.0.2.0/24 (TEST-NET-1)
     /// - 198.51.100.0/24 (TEST-NET-2)
     /// - 203.0.113.0/24 (TEST-NET-3)


### PR DESCRIPTION
This did not render as intended:

> This is defined in RFC 5737 - 192.0.2.0/24 (TEST-NET-1) - 198.51.100.0/24 (TEST-NET-2) - 203.0.113.0/24 (TEST-NET-3)

vs.

> This is defined in RFC 5737 
> - 192.0.2.0/24 (TEST-NET-1)
> - 198.51.100.0/24 (TEST-NET-2)
> - 203.0.113.0/24 (TEST-NET-3)
