### PR TITLE
doc: Cargo documentation doesn't have https

### DIFF
--- a/src/doc/trpl/hello-cargo.md
+++ b/src/doc/trpl/hello-cargo.md
@@ -5,7 +5,7 @@ projects. Cargo is currently in a pre-1.0 state, and so it is still a work in
 progress. However, it is already good enough to use for many Rust projects, and
 so it is assumed that Rust projects will use Cargo from the beginning.
 
-[cratesio]: https://doc.crates.io
+[cratesio]: http://doc.crates.io
 
 Cargo manages three things: building your code, downloading the dependencies
 your code needs, and building those dependencies. At first, your


### PR DESCRIPTION
Right now it's all hosted over GitHub pages so https doesn't work, so only link
to the http version.
