### PR TITLE
Fix indentation in while-let example

### DIFF
--- a/src/doc/trpl/if-let.md
+++ b/src/doc/trpl/if-let.md
@@ -65,7 +65,7 @@ loop as long as a value matches a certain pattern. It turns code like this:
 loop {
     match option {
         Some(x) => println!("{}", x),
-	_ => break,
+        _ => break,
     }
 }
 ```


### PR DESCRIPTION
The indentation in this example is messed up. The `_ => break,` line was using a tab instead of spaces to indent.
