### PR TITLE
collections: Convert SliceConcatExt to use associated types

### DIFF
--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -996,9 +996,13 @@ impl<T> [T] {
 ////////////////////////////////////////////////////////////////////////////////
 // Extension traits for slices over specific kinds of data
 ////////////////////////////////////////////////////////////////////////////////
-#[unstable(feature = "collections", reason = "U should be an associated type")]
+#[unstable(feature = "collections", reason = "recently changed")]
 /// An extension trait for concatenating slices
-pub trait SliceConcatExt<T: ?Sized, U> {
+pub trait SliceConcatExt<T: ?Sized> {
+    #[unstable(feature = "collections", reason = "recently changed")]
+    /// The resulting type after concatenation
+    type Output;
+
     /// Flattens a slice of `T` into a single value `U`.
     ///
     /// # Examples
@@ -1011,7 +1015,7 @@ pub trait SliceConcatExt<T: ?Sized, U> {
     /// println!("{}", s); // prints "helloworld"
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn concat(&self) -> U;
+    fn concat(&self) -> Self::Output;
 
     /// Flattens a slice of `T` into a single value `U`, placing a given separator between each.
     ///
@@ -1025,10 +1029,12 @@ pub trait SliceConcatExt<T: ?Sized, U> {
     /// println!("{}", s); // prints "hello world"
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn connect(&self, sep: &T) -> U;
+    fn connect(&self, sep: &T) -> Self::Output;
 }
 
-impl<T: Clone, V: AsRef<[T]>> SliceConcatExt<T, Vec<T>> for [V] {
+impl<T: Clone, V: AsRef<[T]>> SliceConcatExt<T> for [V] {
+    type Output = Vec<T>;
+
     fn concat(&self) -> Vec<T> {
         let size = self.iter().fold(0, |acc, v| acc + v.as_ref().len());
         let mut result = Vec::with_capacity(size);

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -83,7 +83,9 @@ pub use core::str::pattern;
 Section: Creating a string
 */
 
-impl<S: AsRef<str>> SliceConcatExt<str, String> for [S] {
+impl<S: AsRef<str>> SliceConcatExt<str> for [S] {
+    type Output = String;
+
     fn concat(&self) -> String {
         if self.is_empty() {
             return String::new();


### PR DESCRIPTION
collections: Convert SliceConcatExt to use associated types

Coherence now allows this, we have `SliceConcatExt<T> for [V] where T: Sized + Clone` and`SliceConcatExt<str> for [S]`, these don't conflict because
str is never Sized.
