### PR TITLE
Report an error if selection unifies an error into all obligations.

### DIFF
--- a/src/librustc/middle/traits/error_reporting.rs
+++ b/src/librustc/middle/traits/error_reporting.rs
@@ -56,7 +56,10 @@ pub fn report_projection_error<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
 {
     let predicate =
         infcx.resolve_type_vars_if_possible(&obligation.predicate);
-    if !predicate.references_error() {
+    // The ty_err created by normalize_to_error can end up being unified
+    // into all obligations - we still have to report an error in that
+    // case.
+    if !infcx.tcx.sess.has_errors() || !predicate.references_error() {
         span_err!(infcx.tcx.sess, obligation.cause.span, E0271,
                 "type mismatch resolving `{}`: {}",
                 predicate.user_string(infcx.tcx),
@@ -183,7 +186,8 @@ pub fn report_selection_error<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
                             let trait_predicate =
                                 infcx.resolve_type_vars_if_possible(trait_predicate);
 
-                            if !trait_predicate.references_error() {
+                            if !infcx.tcx.sess.has_errors() ||
+                               !trait_predicate.references_error() {
                                 let trait_ref = trait_predicate.to_poly_trait_ref();
                                 span_err!(infcx.tcx.sess, obligation.cause.span, E0277,
                                         "the trait `{}` is not implemented for the type `{}`",

--- a/src/librustc/middle/traits/error_reporting.rs
+++ b/src/librustc/middle/traits/error_reporting.rs
@@ -57,8 +57,10 @@ pub fn report_projection_error<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
     let predicate =
         infcx.resolve_type_vars_if_possible(&obligation.predicate);
     // The ty_err created by normalize_to_error can end up being unified
-    // into all obligations - we still have to report an error in that
-    // case.
+    // into all obligations: for example, if our obligation is something
+    // like `$X = <() as Foo<$X>>::Out` and () does not implement Foo<_>,
+    // then $X will be unified with ty_err, but the error still needs to be
+    // reported.
     if !infcx.tcx.sess.has_errors() || !predicate.references_error() {
         span_err!(infcx.tcx.sess, obligation.cause.span, E0271,
                 "type mismatch resolving `{}`: {}",

--- a/src/librustc/middle/traits/project.rs
+++ b/src/librustc/middle/traits/project.rs
@@ -408,7 +408,10 @@ fn opt_normalize_projection_type<'a,'b,'tcx>(
 }
 
 /// in various error cases, we just set ty_err and return an obligation
-/// that, when fulfilled, will lead to an error
+/// that, when fulfilled, will lead to an error.
+///
+/// FIXME: the ty_err created here can enter the obligation we create,
+/// leading to error messages involving ty_err.
 fn normalize_to_error<'a,'tcx>(selcx: &mut SelectionContext<'a,'tcx>,
                                projection_ty: ty::ProjectionTy<'tcx>,
                                cause: ObligationCause<'tcx>,

--- a/src/test/compile-fail/issue-23966.rs
+++ b/src/test/compile-fail/issue-23966.rs
@@ -9,6 +9,5 @@
 // except according to those terms.
 
 fn main() {
-    "".chars().fold(|_, _| (), ());
-    //~^ ERROR cannot determine a type for this expression: unconstrained type
+    "".chars().fold(|_, _| (), ()); //~ ERROR is not implemented for the type `()`
 }

--- a/src/test/compile-fail/issue-25076.rs
+++ b/src/test/compile-fail/issue-25076.rs
@@ -1,0 +1,21 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct S;
+
+trait InOut<T> { type Out; }
+
+fn do_fold<B, F: InOut<B, Out=B>>(init: B, f: F) {}
+
+fn bot<T>() -> T { loop {} }
+
+fn main() {
+    do_fold(bot(), ()); //~ ERROR is not implemented for the type `()`
+}


### PR DESCRIPTION
Fix #25076.

r? @nikomatsakis 
