### PR TITLE
Stabilize from_raw_os feature in 1.1

### DIFF
--- a/src/libstd/sys/unix/ext/io.rs
+++ b/src/libstd/sys/unix/ext/io.rs
@@ -41,8 +41,7 @@ pub trait AsRawFd {
 
 /// A trait to express the ability to construct an object from a raw file
 /// descriptor.
-#[unstable(feature = "from_raw_os",
-           reason = "recent addition to std::os::unix::io")]
+#[stable(feature = "from_raw_os", since = "1.1.0")]
 pub trait FromRawFd {
     /// Constructs a new instances of `Self` from the given raw file
     /// descriptor.
@@ -56,6 +55,7 @@ pub trait FromRawFd {
     /// descriptor they are wrapping. Usage of this function could
     /// accidentally allow violating this contract which can cause memory
     /// unsafety in code that relies on it being true.
+    #[stable(feature = "from_raw_os", since = "1.1.0")]
     unsafe fn from_raw_fd(fd: RawFd) -> Self;
 }
 
@@ -65,7 +65,7 @@ impl AsRawFd for fs::File {
         self.as_inner().fd().raw()
     }
 }
-#[unstable(feature = "from_raw_os", reason = "trait is unstable")]
+#[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawFd for fs::File {
     unsafe fn from_raw_fd(fd: RawFd) -> fs::File {
         fs::File::from_inner(sys::fs2::File::from_inner(fd))
@@ -85,21 +85,21 @@ impl AsRawFd for net::UdpSocket {
     fn as_raw_fd(&self) -> RawFd { *self.as_inner().socket().as_inner() }
 }
 
-#[unstable(feature = "from_raw_os", reason = "trait is unstable")]
+#[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawFd for net::TcpStream {
     unsafe fn from_raw_fd(fd: RawFd) -> net::TcpStream {
         let socket = sys::net::Socket::from_inner(fd);
         net::TcpStream::from_inner(net2::TcpStream::from_inner(socket))
     }
 }
-#[unstable(feature = "from_raw_os", reason = "trait is unstable")]
+#[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawFd for net::TcpListener {
     unsafe fn from_raw_fd(fd: RawFd) -> net::TcpListener {
         let socket = sys::net::Socket::from_inner(fd);
         net::TcpListener::from_inner(net2::TcpListener::from_inner(socket))
     }
 }
-#[unstable(feature = "from_raw_os", reason = "trait is unstable")]
+#[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawFd for net::UdpSocket {
     unsafe fn from_raw_fd(fd: RawFd) -> net::UdpSocket {
         let socket = sys::net::Socket::from_inner(fd);

--- a/src/libstd/sys/windows/ext/io.rs
+++ b/src/libstd/sys/windows/ext/io.rs
@@ -33,8 +33,7 @@ pub trait AsRawHandle {
 }
 
 /// Construct I/O objects from raw handles.
-#[unstable(feature = "from_raw_os",
-           reason = "recent addition to the std::os::windows::io module")]
+#[stable(feature = "from_raw_os", since = "1.1.0")]
 pub trait FromRawHandle {
     /// Constructs a new I/O object from the specified raw handle.
     ///
@@ -47,6 +46,7 @@ pub trait FromRawHandle {
     /// descriptor they are wrapping. Usage of this function could
     /// accidentally allow violating this contract which can cause memory
     /// unsafety in code that relies on it being true.
+    #[stable(feature = "from_raw_os", since = "1.1.0")]
     unsafe fn from_raw_handle(handle: RawHandle) -> Self;
 }
 
@@ -57,7 +57,7 @@ impl AsRawHandle for fs::File {
     }
 }
 
-#[unstable(feature = "from_raw_os", reason = "trait is unstable")]
+#[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawHandle for fs::File {
     unsafe fn from_raw_handle(handle: RawHandle) -> fs::File {
         let handle = handle as ::libc::HANDLE;
@@ -74,7 +74,7 @@ pub trait AsRawSocket {
 }
 
 /// Create I/O objects from raw sockets.
-#[unstable(feature = "from_raw_os", reason = "recent addition to module")]
+#[stable(feature = "from_raw_os", since = "1.1.0")]
 pub trait FromRawSocket {
     /// Creates a new I/O object from the given raw socket.
     ///
@@ -86,6 +86,7 @@ pub trait FromRawSocket {
     /// descriptor they are wrapping. Usage of this function could
     /// accidentally allow violating this contract which can cause memory
     /// unsafety in code that relies on it being true.
+    #[stable(feature = "from_raw_os", since = "1.1.0")]
     unsafe fn from_raw_socket(sock: RawSocket) -> Self;
 }
 
@@ -108,21 +109,21 @@ impl AsRawSocket for net::UdpSocket {
     }
 }
 
-#[unstable(feature = "from_raw_os", reason = "trait is unstable")]
+#[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawSocket for net::TcpStream {
     unsafe fn from_raw_socket(sock: RawSocket) -> net::TcpStream {
         let sock = sys::net::Socket::from_inner(sock);
         net::TcpStream::from_inner(net2::TcpStream::from_inner(sock))
     }
 }
-#[unstable(feature = "from_raw_os", reason = "trait is unstable")]
+#[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawSocket for net::TcpListener {
     unsafe fn from_raw_socket(sock: RawSocket) -> net::TcpListener {
         let sock = sys::net::Socket::from_inner(sock);
         net::TcpListener::from_inner(net2::TcpListener::from_inner(sock))
     }
 }
-#[unstable(feature = "from_raw_os", reason = "trait is unstable")]
+#[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawSocket for net::UdpSocket {
     unsafe fn from_raw_socket(sock: RawSocket) -> net::UdpSocket {
         let sock = sys::net::Socket::from_inner(sock);


### PR DESCRIPTION
So, I realize this is really late in the game so it's unlikely to be accepted but `FromRawFd`/`FromRawHandle` are necessary for fine grain control over file creation. For example, the current `OpenOptions` does not provide a way to avoid file creation races (there's no way to specify `O_EXCL` or the windows equivalent). Stabilizing these traits and their implementations will give 1.0 users fine-grain control over file creation without committing to any new complex APIs.  Additionally, `AsRawFd`/`AsRawHandle` are already stable so I feel that that stabilizing their inverses is a reasonably small change.

Disclaimer: I'm asking because my crate, tempfile, depends on this feature.
