### PR TITLE
rustc: Fix more verbatim paths leaking to gcc

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -147,6 +147,7 @@ pub mod util {
     pub mod nodemap;
     pub mod lev_distance;
     pub mod num;
+    pub mod fs;
 }
 
 pub mod lib {

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -46,8 +46,9 @@ pub struct Session {
     pub entry_type: Cell<Option<config::EntryFnType>>,
     pub plugin_registrar_fn: Cell<Option<ast::NodeId>>,
     pub default_sysroot: Option<PathBuf>,
-    // The name of the root source file of the crate, in the local file system. The path is always
-    // expected to be absolute. `None` means that there is no source file.
+    // The name of the root source file of the crate, in the local file system.
+    // The path is always expected to be absolute. `None` means that there is no
+    // source file.
     pub local_crate_source_file: Option<PathBuf>,
     pub working_dir: PathBuf,
     pub lint_store: RefCell<lint::LintStore>,

--- a/src/librustc/util/fs.rs
+++ b/src/librustc/util/fs.rs
@@ -1,0 +1,38 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::path::{self, Path, PathBuf};
+use std::ffi::OsString;
+
+// Unfortunately, on windows, gcc cannot accept paths of the form `\\?\C:\...`
+// (a verbatim path). This form of path is generally pretty rare, but the
+// implementation of `fs::canonicalize` currently generates paths of this form,
+// meaning that we're going to be passing quite a few of these down to gcc.
+//
+// For now we just strip the "verbatim prefix" of `\\?\` from the path. This
+// will probably lose information in some cases, but there's not a whole lot
+// more we can do with a buggy gcc...
+pub fn fix_windows_verbatim_for_gcc(p: &Path) -> PathBuf {
+    if !cfg!(windows) {
+        return p.to_path_buf()
+    }
+    let mut components = p.components();
+    let prefix = match components.next() {
+        Some(path::Component::Prefix(p)) => p,
+        _ => return p.to_path_buf(),
+    };
+    let disk = match prefix.kind() {
+        path::Prefix::VerbatimDisk(disk) => disk,
+        _ => return p.to_path_buf(),
+    };
+    let mut base = OsString::from(format!("{}:", disk as char));
+    base.push(components.as_path());
+    PathBuf::from(base)
+}

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -479,7 +479,8 @@ pub fn phase_2_configure_and_expand(sess: &Session,
             let mut _old_path = OsString::new();
             if cfg!(windows) {
                 _old_path = env::var_os("PATH").unwrap_or(_old_path);
-                let mut new_path = sess.host_filesearch(PathKind::All).get_dylib_search_paths();
+                let mut new_path = sess.host_filesearch(PathKind::All)
+                                       .get_dylib_search_paths();
                 new_path.extend(env::split_paths(&_old_path));
                 env::set_var("PATH", &env::join_paths(new_path.iter()).unwrap());
             }


### PR DESCRIPTION
Turns out that a verbatim path was leaking through to gcc via the PATH
environment variable (pointing to the bundled gcc provided by the main
distribution) which was wreaking havoc when gcc itself was run. The fix here is
to just stop passing verbatim paths down by adding more liberal uses of
`fix_windows_verbatim_for_gcc`.

Closes #25072
