### PR TITLE
Iter Docs: Mention 'reduce' and 'inject'

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -578,6 +578,8 @@ pub trait Iterator {
     /// Performs a fold operation over the entire iterator, returning the
     /// eventual state at the end of the iteration.
     ///
+    /// This operation is sometimes called 'reduce' or 'inject'.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
Enhance Google-ability of `.fold()` by mentioning 'reduce' and 'inject' in the docs.

Motivation: [This thread on users.rust-lang.org](https://users.rust-lang.org/t/find-the-shortest-string-in-a-vector/1247)
