### PR TITLE
Add note about type signature searching to docs

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -111,6 +111,10 @@ r##"<!DOCTYPE html>
                 <code>trait</code>, <code>typedef</code> (or
                 <code>tdef</code>).
             </p>
+            <p>
+                Search functions by type signature (e.g.
+                <code>vec -> usize</code>)
+            </p>
         </div>
     </div>
 


### PR DESCRIPTION
I noticed this feature added in https://github.com/rust-lang/rust/pull/23289 was missing from the `Search tricks`. Thanks!

r? @steveklabnik
