### PR TITLE
Make panic! error message GCC compatible

### DIFF
--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -41,8 +41,8 @@ pub fn on_panic(obj: &(Any+Send), file: &'static str, line: u32) {
         Some(mut stderr) => {
             // FIXME: what to do when the thread printing panics?
             let _ = writeln!(stderr,
-                             "thread '{}' panicked at '{}', {}:{}\n",
-                             name, msg, file, line);
+                             "{}:{}: thread '{}' panicked at '{}'\n",
+                             file, line, name, msg);
             if backtrace::log_enabled() {
                 let _ = backtrace::write(&mut *stderr);
             }
@@ -52,8 +52,8 @@ pub fn on_panic(obj: &(Any+Send), file: &'static str, line: u32) {
             });
         }
         None => {
-            let _ = writeln!(&mut err, "thread '{}' panicked at '{}', {}:{}",
-                             name, msg, file, line);
+            let _ = writeln!(&mut err, "{}:{}: thread '{}' panicked at '{}'",
+                             file, line, name, msg);
             if backtrace::log_enabled() {
                 let _ = backtrace::write(&mut err);
             }

--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -41,7 +41,7 @@ pub fn on_panic(obj: &(Any+Send), file: &'static str, line: u32) {
         Some(mut stderr) => {
             // FIXME: what to do when the thread printing panics?
             let _ = writeln!(stderr,
-                             "{}:{}: thread '{}' panicked at '{}'\n",
+                             "{}:{}: thread '{}' panicked at '{}'",
                              file, line, name, msg);
             if backtrace::log_enabled() {
                 let _ = backtrace::write(&mut *stderr);


### PR DESCRIPTION
Reorders the output of thread error messages so that
the file:line location appears first on the line.

For example, this goes from

```
    thread 'test_fails' panicked at 'assertion failed: 0 == 1', src/main.rs:34
```

to

```
    src/main.rs:34: thread 'test_fails' panicked at 'assertion failed: 0 == 1'
```

Fixes: #25151
