### PR TITLE
Add #[inline(always)] to various instances of AsRef::as_ref and AsMut::as_mut

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -1052,6 +1052,7 @@ impl<T: fmt::Display + ?Sized> ToString for T {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRef<str> for String {
+    #[inline]
     fn as_ref(&self) -> &str {
         self
     }

--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -173,6 +173,7 @@ impl<T> AsMut<[T]> for [T] {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRef<str> for str {
+    #[inline]
     fn as_ref(&self) -> &str {
         self
     }


### PR DESCRIPTION
I was profiling my code again and this time AsRef<str> for String
was eating up a considerable chunk of my runtime; adding the inline
annotation made the program run almost twice as fast!

While I was at it I also added the annotation to other implementations
of AsRef as well as AsMut.
