### PR TITLE
Add missing inline attribute to Not impl for Wrapping<T>

### DIFF
--- a/src/libcore/num/wrapping.rs
+++ b/src/libcore/num/wrapping.rs
@@ -123,6 +123,7 @@ macro_rules! wrapping_impl {
         impl Not for Wrapping<$t> {
             type Output = Wrapping<$t>;
 
+            #[inline(always)]
             fn not(self) -> Wrapping<$t> {
                 Wrapping(!self.0)
             }


### PR DESCRIPTION
This was causing function calls to be emitted for bitwise complements, even with optimizations on.
Steps to reproduce:

```
$ cat wrapping.rs
fn main() {
    let a = std::num::Wrapping(std::env::args().len() as u32);
    let b = !a;
    println!("{}", b.0);
}
$ rustc -O wrapping.rs --emit=asm,link
$ grep Not wrapping.s
        callq   _ZN3num8wrapping23Wrapping$LT$u32$GT$.Not3not20hba4b266232e02b1dHkbE
```
