### PR TITLE
book: remove "input" assignment in first guessing_game example

### DIFF
--- a/src/doc/trpl/guessing-game.md
+++ b/src/doc/trpl/guessing-game.md
@@ -302,7 +302,7 @@ project.
 There’s just one line of this first example left:
 
 ```rust,ignore
-    println!("You guessed: {}", input);
+    println!("You guessed: {}", guess);
 }
 ```
 

--- a/src/doc/trpl/guessing-game.md
+++ b/src/doc/trpl/guessing-game.md
@@ -82,11 +82,11 @@ fn main() {
 
     let mut guess = String::new();
 
-    let input = io::stdin().read_line(&mut guess)
+    io::stdin().read_line(&mut guess)
         .ok()
         .expect("Failed to read line");
 
-    println!("You guessed: {}", input);
+    println!("You guessed: {}", guess);
 }
 ```
 


### PR DESCRIPTION
The original code snippet results in a confusing program where something like this happens:

```
Please input your guess.
5
You guessed: 3
```

For reasons I don't understand, I think the pattern is "You guessed: length of input + 2".

A later code sample with the random number generator at lines 459-463 leaves out that assignment to `input`, and that code works as expected.
