### PR TITLE
Add support for registering attributes with rustc in plugins

### DIFF
--- a/src/librustc/plugin/registry.rs
+++ b/src/librustc/plugin/registry.rs
@@ -20,6 +20,7 @@ use syntax::codemap::Span;
 use syntax::parse::token;
 use syntax::ptr::P;
 use syntax::ast;
+use syntax::feature_gate::AttributeType;
 
 use std::collections::HashMap;
 use std::borrow::ToOwned;
@@ -54,6 +55,9 @@ pub struct Registry<'a> {
 
     #[doc(hidden)]
     pub llvm_passes: Vec<String>,
+
+    #[doc(hidden)]
+    pub attributes: Vec<(String, AttributeType)>,
 }
 
 impl<'a> Registry<'a> {
@@ -67,6 +71,7 @@ impl<'a> Registry<'a> {
             lint_passes: vec!(),
             lint_groups: HashMap::new(),
             llvm_passes: vec!(),
+            attributes: vec!(),
         }
     }
 
@@ -129,5 +134,23 @@ impl<'a> Registry<'a> {
     /// execute.
     pub fn register_llvm_pass(&mut self, name: &str) {
         self.llvm_passes.push(name.to_owned());
+    }
+
+
+    /// Register an attribute with an attribute type
+    ///
+    /// Registered attributes will bypass the `custom_attribute` feature gate
+    ///
+    /// `Whitelisted` attributes will additionally not trigger the `unused_attribute`
+    /// lint
+    ///
+    /// `CrateLevel` attributes will not be allowed on anything other than a crate
+    pub fn register_attribute(&mut self, name: String, ty: AttributeType) {
+        if let AttributeType::Gated(..) = ty {
+            self.sess.err("plugin tried to register a gated attribute. \
+                           Only `Normal`, `Whitelisted`, and `CrateLevel` \
+                           attributes are allowed");
+        }
+        self.attributes.push((name, ty));
     }
 }

--- a/src/librustc/plugin/registry.rs
+++ b/src/librustc/plugin/registry.rs
@@ -137,7 +137,7 @@ impl<'a> Registry<'a> {
     }
 
 
-    /// Register an attribute with an attribute type
+    /// Register an attribute with an attribute type.
     ///
     /// Registered attributes will bypass the `custom_attribute` feature gate.
     /// `Whitelisted` attributes will additionally not trigger the `unused_attribute`

--- a/src/librustc/plugin/registry.rs
+++ b/src/librustc/plugin/registry.rs
@@ -139,17 +139,14 @@ impl<'a> Registry<'a> {
 
     /// Register an attribute with an attribute type
     ///
-    /// Registered attributes will bypass the `custom_attribute` feature gate
-    ///
+    /// Registered attributes will bypass the `custom_attribute` feature gate.
     /// `Whitelisted` attributes will additionally not trigger the `unused_attribute`
-    /// lint
-    ///
-    /// `CrateLevel` attributes will not be allowed on anything other than a crate
+    /// lint. `CrateLevel` attributes will not be allowed on anything other than a crate.
     pub fn register_attribute(&mut self, name: String, ty: AttributeType) {
         if let AttributeType::Gated(..) = ty {
-            self.sess.err("plugin tried to register a gated attribute. \
-                           Only `Normal`, `Whitelisted`, and `CrateLevel` \
-                           attributes are allowed");
+            self.sess.span_err(self.krate_span, "plugin tried to register a gated \
+                                                 attribute. Only `Normal`, `Whitelisted`, \
+                                                 and `CrateLevel` attributes are allowed");
         }
         self.attributes.push((name, ty));
     }

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -23,6 +23,7 @@ use syntax::parse;
 use syntax::parse::token;
 use syntax::parse::ParseSess;
 use syntax::{ast, codemap};
+use syntax::feature_gate::AttributeType;
 
 use rustc_back::target::Target;
 
@@ -54,6 +55,7 @@ pub struct Session {
     pub lint_store: RefCell<lint::LintStore>,
     pub lints: RefCell<NodeMap<Vec<(lint::LintId, codemap::Span, String)>>>,
     pub plugin_llvm_passes: RefCell<Vec<String>>,
+    pub plugin_attributes: RefCell<Vec<(String, AttributeType)>>,
     pub crate_types: RefCell<Vec<config::CrateType>>,
     pub crate_metadata: RefCell<Vec<String>>,
     pub features: RefCell<feature_gate::Features>,
@@ -416,6 +418,7 @@ pub fn build_session_(sopts: config::Options,
         lint_store: RefCell::new(lint::LintStore::new()),
         lints: RefCell::new(NodeMap()),
         plugin_llvm_passes: RefCell::new(Vec::new()),
+        plugin_attributes: RefCell::new(Vec::new()),
         crate_types: RefCell::new(Vec::new()),
         crate_metadata: RefCell::new(Vec::new()),
         delayed_span_bug: RefCell::new(None),

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -444,7 +444,8 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         }
     });
 
-    let Registry { syntax_exts, lint_passes, lint_groups, llvm_passes, .. } = registry;
+    let Registry { syntax_exts, lint_passes, lint_groups,
+                   llvm_passes, attributes, .. } = registry;
 
     {
         let mut ls = sess.lint_store.borrow_mut();
@@ -457,6 +458,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         }
 
         *sess.plugin_llvm_passes.borrow_mut() = llvm_passes;
+        *sess.plugin_attributes.borrow_mut() = attributes.clone();
     }
 
     // Lint plugins are registered; now we can process command line flags.
@@ -511,7 +513,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         let features =
             syntax::feature_gate::check_crate(sess.codemap(),
                                               &sess.parse_sess.span_diagnostic,
-                                              &krate);
+                                              &krate, &attributes);
         *sess.features.borrow_mut() = features;
         sess.abort_if_errors();
     });
@@ -541,7 +543,7 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         let features =
             syntax::feature_gate::check_crate(sess.codemap(),
                                               &sess.parse_sess.span_diagnostic,
-                                              &krate);
+                                              &krate, &attributes);
         *sess.features.borrow_mut() = features;
         sess.abort_if_errors();
     });

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -643,11 +643,8 @@ impl LintPass for UnusedAttributes {
 
         let plugin_attributes = cx.sess().plugin_attributes.borrow_mut();
         for &(ref name, ty) in plugin_attributes.iter() {
-            match ty {
-                AttributeType::Whitelisted if attr.check_name(&*name) => {
-                    break;
-                },
-                _ => ()
+            if ty == AttributeType::Whitelisted && attr.check_name(&*name) {
+                break;
             }
         }
 

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -641,9 +641,23 @@ impl LintPass for UnusedAttributes {
             }
         }
 
+        let plugin_attributes = cx.sess().plugin_attributes.borrow_mut();
+        for &(ref name, ty) in plugin_attributes.iter() {
+            match ty {
+                AttributeType::Whitelisted if attr.check_name(&*name) => {
+                    break;
+                },
+                _ => ()
+            }
+        }
+
         if !attr::is_used(attr) {
             cx.span_lint(UNUSED_ATTRIBUTES, attr.span, "unused attribute");
-            if KNOWN_ATTRIBUTES.contains(&(&attr.name(), AttributeType::CrateLevel)) {
+            if KNOWN_ATTRIBUTES.contains(&(&attr.name(), AttributeType::CrateLevel)) ||
+               plugin_attributes.iter()
+                                .find(|&&(ref x, t)| &*attr.name() == &*x &&
+                                                     AttributeType::CrateLevel == t)
+                                .is_some() {
                 let msg = match attr.node.style {
                     ast::AttrOuter => "crate-level attribute should be an inner \
                                        attribute: add an exclamation mark: #![foo]",

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -389,6 +389,8 @@ impl<'a> Context<'a> {
         for &(ref n, ref ty) in self.plugin_attributes.iter() {
             if &*n == name {
                 // Plugins can't gate attributes, so we don't check for it
+                // unlike the code above; we only use this loop to
+                // short-circuit to avoid the checks below
                 debug!("check_attribute: {:?} is registered by a plugin, {:?}", name, ty);
                 return;
             }
@@ -403,7 +405,10 @@ impl<'a> Context<'a> {
                               "attributes of the form `#[derive_*]` are reserved \
                                for the compiler");
         } else {
-            // Only do the custom attribute lint post-expansion
+            // Only run the custom attribute lint during regular
+            // feature gate checking. Macro gating runs
+            // before the plugin attributes are registered
+            // so we skip this then
             if !is_macro {
                 self.gate_feature("custom_attribute", attr.span,
                            &format!("The attribute `{}` is currently \

--- a/src/test/auxiliary/attr_plugin_test.rs
+++ b/src/test/auxiliary/attr_plugin_test.rs
@@ -1,0 +1,30 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+
+#![feature(plugin_registrar)]
+#![feature(rustc_private)]
+
+extern crate syntax;
+
+extern crate rustc;
+
+use syntax::feature_gate::AttributeType;
+use rustc::plugin::Registry;
+
+
+
+#[plugin_registrar]
+pub fn plugin_registrar(reg: &mut Registry) {
+    reg.register_attribute("foo".to_owned(), AttributeType::Normal);
+    reg.register_attribute("bar".to_owned(), AttributeType::CrateLevel);
+    reg.register_attribute("baz".to_owned(), AttributeType::Whitelisted);
+}

--- a/src/test/compile-fail-fulldeps/plugin-attr-register-deny.rs
+++ b/src/test/compile-fail-fulldeps/plugin-attr-register-deny.rs
@@ -1,0 +1,30 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:attr_plugin_test.rs
+// ignore-stage1
+
+#![feature(plugin)]
+#![plugin(attr_plugin_test)]
+#![deny(unused_attributes)]
+
+#[baz]
+fn baz() { } // no error
+
+#[foo]
+pub fn main() {
+     //~^^ ERROR unused
+    #[bar]
+    fn inner() {}
+    //~^^ ERROR crate
+    //~^^^ ERROR unused
+    baz();
+    inner();
+}


### PR DESCRIPTION
This lets plugin authors opt attributes out of the `custom_attribute`
and `unused_attribute` checks.

cc @thepowersgang
