### PR TITLE
Fix use of explicit UFCS syntax to call methods on associated types.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -110,15 +110,6 @@ pub enum PathParsingMode {
     LifetimeAndTypesWithColons,
 }
 
-/// How to parse a qualified path, whether to allow trailing parameters.
-#[derive(Copy, Clone, PartialEq)]
-pub enum QPathParsingMode {
-    /// No trailing parameters, e.g. `<T as Trait>::Item`
-    NoParameters,
-    /// Optional parameters, e.g. `<T as Trait>::item::<'a, U>`
-    MaybeParameters,
-}
-
 /// How to parse a bound, whether to allow bound modifiers such as `?`.
 #[derive(Copy, Clone, PartialEq)]
 pub enum BoundParsingMode {
@@ -1360,7 +1351,7 @@ impl<'a> Parser<'a> {
         } else if try!(self.eat_lt()) {
 
             let (qself, path) =
-                 try!(self.parse_qualified_path(QPathParsingMode::NoParameters));
+                 try!(self.parse_qualified_path(NoTypesAllowed));
 
             TyPath(Some(qself), path)
         } else if self.check(&token::ModSep) ||
@@ -1579,7 +1570,7 @@ impl<'a> Parser<'a> {
 
     // QUALIFIED PATH `<TYPE [as TRAIT_REF]>::IDENT[::<PARAMS>]`
     // Assumes that the leading `<` has been parsed already.
-    pub fn parse_qualified_path(&mut self, mode: QPathParsingMode)
+    pub fn parse_qualified_path(&mut self, mode: PathParsingMode)
                                 -> PResult<(QSelf, ast::Path)> {
         let self_type = try!(self.parse_ty_sum());
         let mut path = if try!(self.eat_keyword(keywords::As)) {
@@ -1600,29 +1591,18 @@ impl<'a> Parser<'a> {
         try!(self.expect(&token::Gt));
         try!(self.expect(&token::ModSep));
 
-        let item_name = try!(self.parse_ident());
-        let parameters = match mode {
-            QPathParsingMode::NoParameters => ast::PathParameters::none(),
-            QPathParsingMode::MaybeParameters => {
-                if try!(self.eat(&token::ModSep)) {
-                    try!(self.expect_lt());
-                    // Consumed `item::<`, go look for types
-                    let (lifetimes, types, bindings) =
-                        try!(self.parse_generic_values_after_lt());
-                    ast::AngleBracketedParameters(ast::AngleBracketedParameterData {
-                        lifetimes: lifetimes,
-                        types: OwnedSlice::from_vec(types),
-                        bindings: OwnedSlice::from_vec(bindings),
-                    })
-                } else {
-                    ast::PathParameters::none()
-                }
+        let segments = match mode {
+            LifetimeAndTypesWithoutColons => {
+                try!(self.parse_path_segments_without_colons())
+            }
+            LifetimeAndTypesWithColons => {
+                try!(self.parse_path_segments_with_colons())
+            }
+            NoTypesAllowed => {
+                try!(self.parse_path_segments_without_types())
             }
         };
-        path.segments.push(ast::PathSegment {
-            identifier: item_name,
-            parameters: parameters
-        });
+        path.segments.extend(segments);
 
         if path.segments.len() == 1 {
             path.span.lo = self.last_span.lo;
@@ -2097,7 +2077,7 @@ impl<'a> Parser<'a> {
                 if try!(self.eat_lt()){
 
                     let (qself, path) =
-                        try!(self.parse_qualified_path(QPathParsingMode::MaybeParameters));
+                        try!(self.parse_qualified_path(LifetimeAndTypesWithColons));
 
                     return Ok(self.mk_expr(lo, hi, ExprPath(Some(qself), path)));
                 }
@@ -3177,7 +3157,7 @@ impl<'a> Parser<'a> {
             let (qself, path) = if try!(self.eat_lt()) {
                 // Parse a qualified path
                 let (qself, path) =
-                    try!(self.parse_qualified_path(QPathParsingMode::NoParameters));
+                    try!(self.parse_qualified_path(NoTypesAllowed));
                 (Some(qself), path)
             } else {
                 // Parse an unqualified path
@@ -3271,7 +3251,7 @@ impl<'a> Parser<'a> {
                     let (qself, path) = if try!(self.eat_lt()) {
                         // Parse a qualified path
                         let (qself, path) =
-                            try!(self.parse_qualified_path(QPathParsingMode::NoParameters));
+                            try!(self.parse_qualified_path(NoTypesAllowed));
                         (Some(qself), path)
                     } else {
                         // Parse an unqualified path

--- a/src/test/run-pass/associated-item-long-paths.rs
+++ b/src/test/run-pass/associated-item-long-paths.rs
@@ -1,0 +1,55 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::mem::size_of;
+
+// The main point of this test is to ensure that we can parse and resolve
+// associated items on associated types.
+
+trait Foo {
+    type U;
+}
+
+trait Bar {
+    // Note 1: Chains of associated items in a path won't type-check.
+    // Note 2: Associated consts can't depend on type parameters or `Self`,
+    // which are the only types that an associated type can be referenced on for
+    // now, so we can only test methods.
+    fn method() -> u32;
+    fn generic_method<T>() -> usize;
+}
+
+struct MyFoo;
+struct MyBar;
+
+impl Foo for MyFoo {
+    type U = MyBar;
+}
+
+impl Bar for MyBar {
+    fn method() -> u32 {
+        2u32
+    }
+    fn generic_method<T>() -> usize {
+        size_of::<T>()
+    }
+}
+
+fn foo<T>()
+    where T: Foo,
+          T::U: Bar,
+{
+    assert_eq!(2u32, <T as Foo>::U::method());
+    assert_eq!(8usize, <T as Foo>::U::generic_method::<f64>());
+}
+
+fn main() {
+    foo::<MyFoo>();
+}


### PR DESCRIPTION
It is currently broken to use syntax such as `<T as Foo>::U::static_method()` where `<T as Foo>::U` is an associated type. I was able to fix this and simplify the parser a bit at the same time.

This also fixes the corresponding issue with associated types (#22139), but that's somewhat irrelevant because #22519 is still open, so this syntax still causes an error in type checking.

Similarly, although this fix applies to associated consts, #25046 forbids associated constants from using type parameters or `Self`, while #19559 means that associated types have to always have one of those two. Therefore, I think that you can't use an associated const from an associated type anyway.
