### PR TITLE
Expand OS X versions referenced in configure message

### DIFF
--- a/configure
+++ b/configure
@@ -844,7 +844,7 @@ then
     CFG_OSX_GCC_VERSION=$("$CFG_GCC" --version 2>&1 | grep "Apple LLVM version")
     if [ $? -eq 0 ]
     then
-        step_msg "on OS X 10.9, forcing use of clang"
+        step_msg "on OS X >=10.9, forcing use of clang"
         CFG_ENABLE_CLANG=1
     else
         if [ $("$CFG_GCC" --version 2>&1 | grep -c ' 4\.[0-6]') -ne 0 ]; then


### PR DESCRIPTION
Tiny tiny nitpick that I just noticed after getting a new laptop ( :beer: + :computer: = :angel: ) and thus needing to ./configure anew on Yosemite. 

It's weird to see a message that says you're on 10.9 if you're on 10.10, in a oh-i-wonder-what-else-is-wrong sort of sense-- easy fix with a `>=` since `gcc --version` on 10.10 with the newest xcode still says it's clang.

:heart: 
