### PR TITLE
Generate CFG_FILENAME_EXTRA from the version

### DIFF
--- a/configure
+++ b/configure
@@ -104,8 +104,8 @@ probe() {
         T=$(command -v $P 2>&1)
         if [ $? -eq 0 ]
         then
-            VER0=$($P --version 2>/dev/null | head -1 \
-                |  sed -e 's/[^0-9]*\([vV]\?[0-9.]\+[^ ]*\).*/\1/' )
+            VER0=$($P --version 2>/dev/null \
+                |  grep -o '[vV]\?[0-9][0-9.][a-z0-9.-]*' | head -1 )
             if [ $? -eq 0 -a "x${VER0}" != "x" ]
             then
               VER="($VER0)"

--- a/configure
+++ b/configure
@@ -709,6 +709,20 @@ else
     probe_need CFG_GIT     git
 fi
 
+# Use `md5sum` on GNU platforms, or `md5 -q` on BSD
+probe CFG_MD5              md5
+probe CFG_MD5SUM           md5sum
+if [ -n "$CFG_MD5" ]
+then
+    CFG_HASH_COMMAND="$CFG_MD5 -q | head -c 8"
+elif [ -n "$CFG_MD5SUM" ]
+then
+    CFG_HASH_COMMAND="$CFG_MD5SUM | head -c 8"
+else
+    err 'could not find one of: md5 md5sum'
+fi
+putvar CFG_HASH_COMMAND
+
 probe CFG_CLANG            clang++
 probe CFG_CCACHE           ccache
 probe CFG_GCC              gcc

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -22,7 +22,7 @@ CFG_PRERELEASE_VERSION=.1
 
 # Append a version-dependent hash to each library, so we can install different
 # versions in the same place
-CFG_FILENAME_EXTRA=$(shell echo -n $(CFG_RELEASE) | $(CFG_HASH_COMMAND))
+CFG_FILENAME_EXTRA=$(shell printf '%s' $(CFG_RELEASE) | $(CFG_HASH_COMMAND))
 
 ifeq ($(CFG_RELEASE_CHANNEL),stable)
 # This is the normal semver version string, e.g. "0.12.0", "0.12.0-nightly"

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -20,7 +20,9 @@ CFG_RELEASE_NUM=1.1.0
 # versions (section 9)
 CFG_PRERELEASE_VERSION=.1
 
-CFG_FILENAME_EXTRA=4e7c5e5c
+# Append a version-dependent hash to each library, so we can install different
+# versions in the same place
+CFG_FILENAME_EXTRA=$(shell echo -n $(CFG_RELEASE) | $(CFG_HASH_COMMAND))
 
 ifeq ($(CFG_RELEASE_CHANNEL),stable)
 # This is the normal semver version string, e.g. "0.12.0", "0.12.0-nightly"


### PR DESCRIPTION
The code takes a prefix of the MD5 hash of the version string.

Since the hash command differs across GNU and BSD platforms, we scan for
the right one in the configure script.

Closes #25007
