### PR TITLE
dropck: must assume `Box<Trait + 'a>` has a destructor of interest.

### DIFF
--- a/src/libstd/net/parser.rs
+++ b/src/libstd/net/parser.rs
@@ -61,7 +61,7 @@ impl<'a> Parser<'a> {
     }
 
     // Return result of first successful parser
-    fn read_or<T>(&mut self, parsers: &mut [Box<FnMut(&mut Parser) -> Option<T>>])
+    fn read_or<T>(&mut self, parsers: &mut [Box<FnMut(&mut Parser) -> Option<T> + 'static>])
                -> Option<T> {
         for pf in parsers.iter_mut() {
             match self.read_atomically(|p: &mut Parser| pf(p)) {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -986,9 +986,10 @@ fn expand_pat(p: P<ast::Pat>, fld: &mut MacroExpander) -> P<ast::Pat> {
                     let fm = fresh_mark();
                     let marked_before = mark_tts(&tts[..], fm);
                     let mac_span = fld.cx.original_span();
-                    let expanded = match expander.expand(fld.cx,
-                                        mac_span,
-                                        &marked_before[..]).make_pat() {
+                    let pat = expander.expand(fld.cx,
+                                              mac_span,
+                                              &marked_before[..]).make_pat();
+                    let expanded = match pat {
                         Some(e) => e,
                         None => {
                             fld.cx.span_err(

--- a/src/libsyntax/util/parser_testing.rs
+++ b/src/libsyntax/util/parser_testing.rs
@@ -73,7 +73,11 @@ pub fn string_to_stmt(source_str : String) -> P<ast::Stmt> {
 /// Parse a string, return a pat. Uses "irrefutable"... which doesn't
 /// (currently) affect parsing.
 pub fn string_to_pat(source_str: String) -> P<ast::Pat> {
-    string_to_parser(&new_parse_sess(), source_str).parse_pat()
+    // Binding `sess` and `parser` works around dropck-injected
+    // region-inference issues; see #25212, #22323, #22321.
+    let sess = new_parse_sess();
+    let mut parser = string_to_parser(&sess, source_str);
+    parser.parse_pat()
 }
 
 /// Convert a vector of strings to a vector of ast::Ident's

--- a/src/test/compile-fail/dropck_trait_cycle_checked.rs
+++ b/src/test/compile-fail/dropck_trait_cycle_checked.rs
@@ -1,0 +1,131 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Reject mixing cyclic structure and Drop when using trait
+// objects to hide the the cross-references.
+//
+// (Compare against compile-fail/dropck_vec_cycle_checked.rs)
+
+use std::cell::Cell;
+use id::Id;
+
+mod s {
+    use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+
+    static S_COUNT: AtomicUsize = ATOMIC_USIZE_INIT;
+
+    pub fn next_count() -> usize {
+        S_COUNT.fetch_add(1, Ordering::SeqCst) + 1
+    }
+}
+
+mod id {
+    use s;
+    #[derive(Debug)]
+    pub struct Id {
+        orig_count: usize,
+        count: usize,
+    }
+
+    impl Id {
+        pub fn new() -> Id {
+            let c = s::next_count();
+            println!("building Id {}", c);
+            Id { orig_count: c, count: c }
+        }
+        pub fn count(&self) -> usize {
+            println!("Id::count on {} returns {}", self.orig_count, self.count);
+            self.count
+        }
+    }
+
+    impl Drop for Id {
+        fn drop(&mut self) {
+            println!("dropping Id {}", self.count);
+            self.count = 0;
+        }
+    }
+}
+
+trait HasId {
+    fn count(&self) -> usize;
+}
+
+#[derive(Debug)]
+struct CheckId<T:HasId> {
+    v: T
+}
+
+#[allow(non_snake_case)]
+fn CheckId<T:HasId>(t: T) -> CheckId<T> { CheckId{ v: t } }
+
+impl<T:HasId> Drop for CheckId<T> {
+    fn drop(&mut self) {
+        assert!(self.v.count() > 0);
+    }
+}
+
+trait Obj<'a> : HasId {
+    fn set0(&self, b: &'a Box<Obj<'a>>);
+    fn set1(&self, b: &'a Box<Obj<'a>>);
+}
+
+struct O<'a> {
+    id: Id,
+    obj0: CheckId<Cell<Option<&'a Box<Obj<'a>>>>>,
+    obj1: CheckId<Cell<Option<&'a Box<Obj<'a>>>>>,
+}
+
+impl<'a> HasId for O<'a> {
+    fn count(&self) -> usize { self.id.count() }
+}
+
+impl<'a> O<'a> {
+    fn new() -> Box<O<'a>> {
+        Box::new(O {
+            id: Id::new(),
+            obj0: CheckId(Cell::new(None)),
+            obj1: CheckId(Cell::new(None)),
+        })
+    }
+}
+
+impl<'a> HasId for Cell<Option<&'a Box<Obj<'a>>>> {
+    fn count(&self) -> usize {
+        match self.get() {
+            None => 1,
+            Some(c) => c.count(),
+        }
+    }
+}
+
+impl<'a> Obj<'a> for O<'a> {
+    fn set0(&self, b: &'a Box<Obj<'a>>) {
+        self.obj0.v.set(Some(b))
+    }
+    fn set1(&self, b: &'a Box<Obj<'a>>) {
+        self.obj1.v.set(Some(b))
+    }
+}
+
+
+fn f() {
+    let (o1, o2, o3): (Box<Obj>, Box<Obj>, Box<Obj>) = (O::new(), O::new(), O::new());
+    o1.set0(&o2); //~ ERROR `o2` does not live long enough
+    o1.set1(&o3); //~ ERROR `o3` does not live long enough
+    o2.set0(&o2); //~ ERROR `o2` does not live long enough
+    o2.set1(&o3); //~ ERROR `o3` does not live long enough
+    o3.set0(&o1); //~ ERROR `o1` does not live long enough
+    o3.set1(&o2); //~ ERROR `o2` does not live long enough
+}
+
+fn main() {
+    f();
+}

--- a/src/test/compile-fail/issue-25199.rs
+++ b/src/test/compile-fail/issue-25199.rs
@@ -1,0 +1,83 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Regression test for Issue 25199: Check that one cannot hide a
+// destructor's access to borrowed data behind a boxed trait object.
+//
+// Prior to fixing Issue 25199, this example was able to be compiled
+// with rustc, and thus when you ran it, you would see the `Drop` impl
+// for `Test` accessing state that had already been dropping (which is
+// marked explicitly here with checking code within the `Drop` impl
+// for `VecHolder`, but in the general case could just do unsound
+// things like accessing memory that has been freed).
+//
+// Note that I would have liked to encode my go-to example of cyclic
+// structure that accesses its neighbors in drop (and thus is
+// fundamentally unsound) via this trick, but the closest I was able
+// to come was dropck_trait_cycle_checked.rs, which is not quite as
+// "good" as this regression test because the encoding of that example
+// was forced to attach a lifetime to the trait definition itself
+// (`trait Obj<'a>`) while *this* example is solely
+
+use std::cell::RefCell;
+
+trait Obj { }
+
+struct VecHolder {
+    v: Vec<(bool, &'static str)>,
+}
+
+impl Drop for VecHolder {
+    fn drop(&mut self) {
+        println!("Dropping Vec");
+        self.v[30].0 = false;
+        self.v[30].1 = "invalid access: VecHolder dropped already";
+    }
+}
+
+struct Container<'a> {
+    v: VecHolder,
+    d: RefCell<Vec<Box<Obj+'a>>>,
+}
+
+impl<'a> Container<'a> {
+    fn new() -> Container<'a> {
+        Container {
+            d: RefCell::new(Vec::new()),
+            v: VecHolder {
+                v: vec![(true, "valid"); 100]
+            }
+        }
+    }
+
+    fn store<T: Obj+'a>(&'a self, val: T) {
+        self.d.borrow_mut().push(Box::new(val));
+    }
+}
+
+struct Test<'a> {
+    test: &'a Container<'a>,
+}
+
+impl<'a> Obj for Test<'a> { }
+impl<'a> Drop for Test<'a> {
+    fn drop(&mut self) {
+        for e in &self.test.v.v {
+            assert!(e.0, e.1);
+        }
+    }
+}
+
+fn main() {
+    let container = Container::new();
+    let test = Test{test: &container}; //~ ERROR `container` does not live long enough
+    println!("container.v[30]: {:?}", container.v.v[30]);
+    container.store(test); //~ ERROR `container` does not live long enough
+}

--- a/src/test/compile-fail/unboxed-closures-failed-recursive-fn-1.rs
+++ b/src/test/compile-fail/unboxed-closures-failed-recursive-fn-1.rs
@@ -22,12 +22,24 @@ fn a() {
     let mut factorial: Option<Box<Fn(u32) -> u32>> = None;
 
     let f = |x: u32| -> u32 {
+        //~^ ERROR `factorial` does not live long enough
         let g = factorial.as_ref().unwrap();
         if x == 0 {1} else {x * g(x-1)}
     };
 
     factorial = Some(Box::new(f));
-    //~^ ERROR cannot assign to `factorial` because it is borrowed
+}
+
+fn b() {
+    let mut factorial: Option<Box<Fn(u32) -> u32 + 'static>> = None;
+
+    let f = |x: u32| -> u32 {
+        //~^ ERROR closure may outlive the current function, but it borrows `factorial`
+        let g = factorial.as_ref().unwrap();
+        if x == 0 {1} else {x * g(x-1)}
+    };
+
+    factorial = Some(Box::new(f));
 }
 
 fn main() { }

--- a/src/test/run-pass/issue-11205.rs
+++ b/src/test/run-pass/issue-11205.rs
@@ -21,7 +21,7 @@ fn foos(_: &[&Foo]) {}
 fn foog<T>(_: &[T], _: &[T]) {}
 
 fn bar(_: [Box<Foo>; 2]) {}
-fn bars(_: &[Box<Foo>]) {}
+fn bars(_: &[Box<Foo+'static>]) {}
 
 fn main() {
     let x: [&Foo; 2] = [&1, &2];
@@ -45,11 +45,11 @@ fn main() {
     bar(x);
     bar([Box::new(1), Box::new(2)]);
 
-    let x: &[Box<Foo>] = &[Box::new(1), Box::new(2)];
+    let x: &[Box<Foo+'static>] = &[Box::new(1), Box::new(2)];
     bars(x);
     bars(&[Box::new(1), Box::new(2)]);
 
-    let x: &[Box<Foo>] = &[Box::new(1), Box::new(2)];
+    let x: &[Box<Foo+'static>] = &[Box::new(1), Box::new(2)];
     foog(x, &[Box::new(1)]);
 
     struct T<'a> {


### PR DESCRIPTION
dropck: must assume `Box<Trait + 'a>` has a destructor of interest.

Fix #25199.

This detail was documented in [RFC 769](https://github.com/rust-lang/rfcs/blob/master/text/0769-sound-generic-drop.md#the-drop-check-rule); the implementation was just missing.

[breaking-change]

The breakage here falls into both obvious and non-obvious cases.

The obvious case: if you were relying on the unsoundness this exposes (namely being able to reference dead storage from a destructor, by doing it via a boxed trait object bounded by the lifetime of the dead storage), then this change disallows that.

The non-obvious cases: The way dropck works, it causes lifetimes to be extended to longer extents than they covered before. I.e.  lifetimes that are attached as trait-bounds may become longer than they were previously.
- This includes lifetimes that are only _implicitly_ attached as trait-bounds (due to [RFC 599](https://github.com/rust-lang/rfcs/blob/master/text/0599-default-object-bound.md)). So you may have code that was e.g. taking a parameter of type `&'a Box<Trait>` (which expands to `&'a Box<Trait+'a>`), that now may need to be assigned type `&'a Box<Trait+'static>` to ensure that `'a` is not inadvertantly inferred to a region that is actually too long.  (See commit ee06263 for an example of this.)
