### PR TITLE
mk: Add a missing folder to the dist directory

### DIFF
--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -52,6 +52,7 @@ PKG_FILES := \
       doc                                      \
       driver                                   \
       etc                                      \
+      error-index-generator                    \
       $(foreach crate,$(CRATES),lib$(crate))   \
       libcollectionstest                       \
       libcoretest                              \


### PR DESCRIPTION
This fixes the `distcheck` target and nightly builds.
