### PR TITLE
Rustdoc fixes for associated items

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -905,6 +905,8 @@ impl DocFolder for Cache {
         // Index this method for searching later on
         if let Some(ref s) = item.name {
             let (parent, is_method) = match item.inner {
+                clean::AssociatedTypeItem(..) |
+                clean::AssociatedConstItem(..) |
                 clean::TyMethodItem(..) |
                 clean::StructFieldItem(..) |
                 clean::VariantItem(..) => {

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1862,6 +1862,17 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
         try!(write!(w, "</div>"));
     }
 
+    if !consts.is_empty() {
+        try!(write!(w, "
+            <h2 id='associated-const'>Associated Constants</h2>
+            <div class='methods'>
+        "));
+        for t in &consts {
+            try!(trait_item(w, *t));
+        }
+        try!(write!(w, "</div>"));
+    }
+
     // Output the documentation for each function individually
     if !required.is_empty() {
         try!(write!(w, "

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -34,7 +34,8 @@
                      "macro",
                      "primitive",
                      "associatedtype",
-                     "constant"];
+                     "constant",
+                     "associatedconstant"];
 
     $('.js-only').removeClass('js-only');
 

--- a/src/test/rustdoc/assoc-consts.rs
+++ b/src/test/rustdoc/assoc-consts.rs
@@ -13,6 +13,7 @@
 pub trait Foo {
     // @has assoc_consts/trait.Foo.html '//*[@class="rust trait"]' \
     //      'const FOO: usize;'
+    // @has - '//*[@id="associatedconstant.FOO"]' 'const FOO'
     const FOO: usize;
 }
 


### PR DESCRIPTION
Rustdoc fixes for associated items

This is related to isssue #22442 and solves it partly.

This solves the search index links of associated types and constants,
so that they link to the trait page.

Also add an Associated Constants section if constants are present.
