### PR TITLE
Document panic behaviour of BitVec::split_off

### DIFF
--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -644,6 +644,10 @@ impl BitVec {
     /// Splits the `BitVec` into two at the given bit,
     /// retaining the first half in-place and returning the second one.
     ///
+    /// # Panics
+    ///
+    /// Panics if `at` is out of bounds.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
I forgot this in #24890.
