### PR TITLE
stop Hash implementation for str from writing extra byte.

### DIFF
--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -232,7 +232,6 @@ mod impls {
     impl Hash for str {
         fn hash<H: Hasher>(&self, state: &mut H) {
             state.write(self.as_bytes());
-            state.write_u8(0xff)
         }
     }
 


### PR DESCRIPTION
Calling hash() on a str eg:

```
let teststr: &str = "abc";
teststr.hash(&mut state);
```

Results in an extra 0xFF byte being written into the hasher after the string.

This is a simple PR that stops the extra byte from being written.
