### PR TITLE
Added start of last text block

### DIFF
--- a/src/doc/trpl/references-and-borrowing.md
+++ b/src/doc/trpl/references-and-borrowing.md
@@ -312,6 +312,7 @@ println!("{}", y);
 
 We get this error:
 
+```text
 error: `x` does not live long enough
     y = &x;
          ^


### PR DESCRIPTION
The start of the last text block in references was missing, I added it.

r? @steveklabnik
