### PR TITLE
std::io: New ErrorKind value InvalidData

### DIFF
--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -100,7 +100,7 @@ pub enum ErrorKind {
     /// Unlike `InvalidInput`, this typically means that the operation
     /// parameters were valid, however the error was caused by malformed
     /// input data.
-    #[stable(feature = "io_invalid_data", since = "1.1.0")]
+    #[stable(feature = "io_invalid_data", since = "1.2.0")]
     InvalidData,
     /// The I/O operation's timeout expired, causing it to be canceled.
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -95,6 +95,13 @@ pub enum ErrorKind {
     /// A parameter was incorrect.
     #[stable(feature = "rust1", since = "1.0.0")]
     InvalidInput,
+    /// Data not valid for the operation were encountered.
+    ///
+    /// Unlike `InvalidInput`, this typically means that the operation
+    /// parameters were valid, however the error was caused by malformed
+    /// input data.
+    #[stable(feature = "io_invalid_data", since = "1.1.0")]
+    InvalidData,
     /// The I/O operation's timeout expired, causing it to be canceled.
     #[stable(feature = "rust1", since = "1.0.0")]
     TimedOut,

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -80,7 +80,7 @@ fn append_to_string<F>(buf: &mut String, f: F) -> Result<usize>
         let ret = f(g.s);
         if str::from_utf8(&g.s[g.len..]).is_err() {
             ret.and_then(|_| {
-                Err(Error::new(ErrorKind::InvalidInput,
+                Err(Error::new(ErrorKind::InvalidData,
                                "stream did not contain valid UTF-8"))
             })
         } else {

--- a/src/libstd/sys/windows/stdio.rs
+++ b/src/libstd/sys/windows/stdio.rs
@@ -170,5 +170,5 @@ impl Output {
 }
 
 fn invalid_encoding() -> io::Error {
-    io::Error::new(io::ErrorKind::InvalidInput, "text was not valid unicode")
+    io::Error::new(io::ErrorKind::InvalidData, "text was not valid unicode")
 }


### PR DESCRIPTION
This takes the cases from `InvalidInput` where a data format error
was encountered. This is different from the documented semantics
of `InvalidInput`, which more likely indicate a programming error.

Fixes rust-lang/rfcs#906
