### PR TITLE
Convert #[lang="..."] to #[lang = "..."]

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2028,7 +2028,7 @@ makes it possible to declare these operations. For example, the `str` module
 in the Rust standard library defines the string equality function:
 
 ```{.ignore}
-#[lang="str_eq"]
+#[lang = "str_eq"]
 pub fn eq_slice(a: &str, b: &str) -> bool {
     // details elided
 }

--- a/src/doc/trpl/lang-items.md
+++ b/src/doc/trpl/lang-items.md
@@ -7,7 +7,7 @@
 The `rustc` compiler has certain pluggable operations, that is,
 functionality that isn't hard-coded into the language, but is
 implemented in libraries, with a special marker to tell the compiler
-it exists. The marker is the attribute `#[lang="..."]` and there are
+it exists. The marker is the attribute `#[lang = "..."]` and there are
 various different values of `...`, i.e. various different 'lang
 items'.
 
@@ -28,7 +28,7 @@ extern {
 #[lang = "owned_box"]
 pub struct Box<T>(*mut T);
 
-#[lang="exchange_malloc"]
+#[lang = "exchange_malloc"]
 unsafe fn allocate(size: usize, _align: usize) -> *mut u8 {
     let p = libc::malloc(size as libc::size_t) as *mut u8;
 
@@ -39,7 +39,7 @@ unsafe fn allocate(size: usize, _align: usize) -> *mut u8 {
 
     p
 }
-#[lang="exchange_free"]
+#[lang = "exchange_free"]
 unsafe fn deallocate(ptr: *mut u8, _size: usize, _align: usize) {
     libc::free(ptr as *mut libc::c_void)
 }

--- a/src/liballoc/heap.rs
+++ b/src/liballoc/heap.rs
@@ -95,7 +95,7 @@ pub const EMPTY: *mut () = 0x1 as *mut ();
 
 /// The allocator for unique pointers.
 #[cfg(not(test))]
-#[lang="exchange_malloc"]
+#[lang = "exchange_malloc"]
 #[inline]
 unsafe fn exchange_malloc(size: usize, align: usize) -> *mut u8 {
     if size == 0 {
@@ -108,7 +108,7 @@ unsafe fn exchange_malloc(size: usize, align: usize) -> *mut u8 {
 }
 
 #[cfg(not(test))]
-#[lang="exchange_free"]
+#[lang = "exchange_free"]
 #[inline]
 unsafe fn exchange_free(ptr: *mut u8, old_size: usize, align: usize) {
     deallocate(ptr, old_size, align);

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -634,7 +634,7 @@ impl<'b, T: ?Sized> DerefMut for RefMut<'b, T> {
 ///
 /// **NOTE:** `UnsafeCell<T>`'s fields are public to allow static initializers. It is not
 /// recommended to access its fields directly, `get` should be used instead.
-#[lang="unsafe_cell"]
+#[lang = "unsafe_cell"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct UnsafeCell<T: ?Sized> {
     /// Wrapped value

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -41,7 +41,7 @@ use option::Option::{self, Some, None};
 /// PartialEq only requires the `eq` method to be implemented; `ne` is defined in terms of it by
 /// default. Any manual implementation of `ne` *must* respect the rule that `eq` is a strict
 /// inverse of `ne`; that is, `!(a == b)` if and only if `a != b`.
-#[lang="eq"]
+#[lang = "eq"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait PartialEq<Rhs: ?Sized = Self> {
     /// This method tests for `self` and `other` values to be equal, and is used by `==`.
@@ -222,7 +222,7 @@ impl PartialOrd for Ordering {
 /// However it remains possible to implement the others separately for types which do not have a
 /// total order. For example, for floating point numbers, `NaN < 0 == false` and `NaN >= 0 ==
 /// false` (cf. IEEE 754-2008 section 5.11).
-#[lang="ord"]
+#[lang = "ord"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
     /// This method returns an ordering between `self` and `other` values if one exists.

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -82,7 +82,7 @@ fn _assert_is_object_safe(_: &Iterator<Item=()>) {}
 /// is returned. A concrete Iterator implementation may choose to behave however
 /// it wishes, either by returning `None` infinitely, or by doing something
 /// else.
-#[lang="iterator"]
+#[lang = "iterator"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_on_unimplemented = "`{Self}` is not an iterator; maybe try calling \
                             `.iter()` or a similar method"]

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -33,7 +33,7 @@ use hash::Hasher;
 
 /// Types able to be transferred across thread boundaries.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[lang="send"]
+#[lang = "send"]
 #[rustc_on_unimplemented = "`{Self}` cannot be sent between threads safely"]
 pub unsafe trait Send {
     // empty.
@@ -46,7 +46,7 @@ impl<T> !Send for *mut T { }
 
 /// Types with a constant size known at compile-time.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[lang="sized"]
+#[lang = "sized"]
 #[rustc_on_unimplemented = "`{Self}` does not have a constant size known at compile-time"]
 #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
 pub trait Sized {
@@ -154,7 +154,7 @@ pub trait Sized {
 /// then it might be prudent to not implement `Copy`. This is because removing `Copy` is a breaking
 /// change: that second example would fail to compile if we made `Foo` non-`Copy`.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[lang="copy"]
+#[lang = "copy"]
 pub trait Copy : Clone {
     // Empty.
 }
@@ -201,7 +201,7 @@ pub trait Copy : Clone {
 /// reference; not doing this is undefined behaviour (for example,
 /// `transmute`-ing from `&T` to `&mut T` is illegal).
 #[stable(feature = "rust1", since = "1.0.0")]
-#[lang="sync"]
+#[lang = "sync"]
 #[rustc_on_unimplemented = "`{Self}` cannot be shared between threads safely"]
 pub unsafe trait Sync {
     // Empty
@@ -217,7 +217,7 @@ impl<T> !Sync for *mut T { }
 /// ensure that they are never copied, even if they lack a destructor.
 #[unstable(feature = "core",
            reason = "likely to change with new variance strategy")]
-#[lang="no_copy_bound"]
+#[lang = "no_copy_bound"]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NoCopy;
 
@@ -359,7 +359,7 @@ macro_rules! impls{
 /// better to use a reference type, like `PhantomData<&'a T>`
 /// (ideally) or `PhantomData<*const T>` (if no lifetime applies), so
 /// as not to indicate ownership.
-#[lang="phantom_data"]
+#[lang = "phantom_data"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct PhantomData<T:?Sized>;
 

--- a/src/libcore/nonzero.rs
+++ b/src/libcore/nonzero.rs
@@ -31,7 +31,7 @@ unsafe impl Zeroable for u64 {}
 
 /// A wrapper type for raw pointers and integers that will never be
 /// NULL or 0 that might allow certain optimizations.
-#[lang="non_zero"]
+#[lang = "non_zero"]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 #[unstable(feature = "core")]
 pub struct NonZero<T: Zeroable>(T);

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -91,7 +91,7 @@ use fmt;
 ///     let _x = HasDrop;
 /// }
 /// ```
-#[lang="drop"]
+#[lang = "drop"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Drop {
     /// The `drop` method, called when the value goes out of scope.
@@ -181,7 +181,7 @@ macro_rules! forward_ref_binop {
 ///     Foo + Foo;
 /// }
 /// ```
-#[lang="add"]
+#[lang = "add"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Add<RHS=Self> {
     /// The resulting type after applying the `+` operator
@@ -235,7 +235,7 @@ add_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 ///     Foo - Foo;
 /// }
 /// ```
-#[lang="sub"]
+#[lang = "sub"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Sub<RHS=Self> {
     /// The resulting type after applying the `-` operator
@@ -289,7 +289,7 @@ sub_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 ///     Foo * Foo;
 /// }
 /// ```
-#[lang="mul"]
+#[lang = "mul"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Mul<RHS=Self> {
     /// The resulting type after applying the `*` operator
@@ -343,7 +343,7 @@ mul_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 ///     Foo / Foo;
 /// }
 /// ```
-#[lang="div"]
+#[lang = "div"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Div<RHS=Self> {
     /// The resulting type after applying the `/` operator
@@ -397,7 +397,7 @@ div_impl! { usize u8 u16 u32 u64 isize i8 i16 i32 i64 f32 f64 }
 ///     Foo % Foo;
 /// }
 /// ```
-#[lang="rem"]
+#[lang = "rem"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Rem<RHS=Self> {
     /// The resulting type after applying the `%` operator
@@ -470,7 +470,7 @@ rem_float_impl! { f64, fmod }
 ///     -Foo;
 /// }
 /// ```
-#[lang="neg"]
+#[lang = "neg"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Neg {
     /// The resulting type after applying the `-` operator
@@ -541,7 +541,7 @@ neg_impl_numeric! { isize i8 i16 i32 i64 f32 f64 }
 ///     !Foo;
 /// }
 /// ```
-#[lang="not"]
+#[lang = "not"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Not {
     /// The resulting type after applying the `!` operator
@@ -595,7 +595,7 @@ not_impl! { bool usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
 ///     Foo & Foo;
 /// }
 /// ```
-#[lang="bitand"]
+#[lang = "bitand"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait BitAnd<RHS=Self> {
     /// The resulting type after applying the `&` operator
@@ -649,7 +649,7 @@ bitand_impl! { bool usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
 ///     Foo | Foo;
 /// }
 /// ```
-#[lang="bitor"]
+#[lang = "bitor"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait BitOr<RHS=Self> {
     /// The resulting type after applying the `|` operator
@@ -703,7 +703,7 @@ bitor_impl! { bool usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
 ///     Foo ^ Foo;
 /// }
 /// ```
-#[lang="bitxor"]
+#[lang = "bitxor"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait BitXor<RHS=Self> {
     /// The resulting type after applying the `^` operator
@@ -757,7 +757,7 @@ bitxor_impl! { bool usize u8 u16 u32 u64 isize i8 i16 i32 i64 }
 ///     Foo << Foo;
 /// }
 /// ```
-#[lang="shl"]
+#[lang = "shl"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Shl<RHS> {
     /// The resulting type after applying the `<<` operator
@@ -829,7 +829,7 @@ shl_impl_all! { u8 u16 u32 u64 usize i8 i16 i32 i64 isize }
 ///     Foo >> Foo;
 /// }
 /// ```
-#[lang="shr"]
+#[lang = "shr"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Shr<RHS> {
     /// The resulting type after applying the `>>` operator
@@ -902,7 +902,7 @@ shr_impl_all! { u8 u16 u32 u64 usize i8 i16 i32 i64 isize }
 ///     Foo[Bar];
 /// }
 /// ```
-#[lang="index"]
+#[lang = "index"]
 #[rustc_on_unimplemented = "the type `{Self}` cannot be indexed by `{Idx}`"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Index<Idx: ?Sized> {
@@ -949,7 +949,7 @@ pub trait Index<Idx: ?Sized> {
 ///     &mut Foo[Bar];
 /// }
 /// ```
-#[lang="index_mut"]
+#[lang = "index_mut"]
 #[rustc_on_unimplemented = "the type `{Self}` cannot be mutably indexed by `{Idx}`"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
@@ -960,7 +960,7 @@ pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
 
 /// An unbounded range.
 #[derive(Copy, Clone, PartialEq, Eq)]
-#[lang="range_full"]
+#[lang = "range_full"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RangeFull;
 
@@ -973,7 +973,7 @@ impl fmt::Debug for RangeFull {
 
 /// A (half-open) range which is bounded at both ends.
 #[derive(Clone, PartialEq, Eq)]
-#[lang="range"]
+#[lang = "range"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Range<Idx> {
     /// The lower bound of the range (inclusive).
@@ -993,7 +993,7 @@ impl<Idx: fmt::Debug> fmt::Debug for Range<Idx> {
 
 /// A range which is only bounded below.
 #[derive(Clone, PartialEq, Eq)]
-#[lang="range_from"]
+#[lang = "range_from"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RangeFrom<Idx> {
     /// The lower bound of the range (inclusive).
@@ -1010,7 +1010,7 @@ impl<Idx: fmt::Debug> fmt::Debug for RangeFrom<Idx> {
 
 /// A range which is only bounded above.
 #[derive(Copy, Clone, PartialEq, Eq)]
-#[lang="range_to"]
+#[lang = "range_to"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RangeTo<Idx> {
     /// The upper bound of the range (exclusive).
@@ -1053,7 +1053,7 @@ impl<Idx: fmt::Debug> fmt::Debug for RangeTo<Idx> {
 ///     assert_eq!('a', *x);
 /// }
 /// ```
-#[lang="deref"]
+#[lang = "deref"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Deref {
     /// The resulting type after dereferencing
@@ -1114,7 +1114,7 @@ impl<'a, T: ?Sized> Deref for &'a mut T {
 ///     assert_eq!('b', *x);
 /// }
 /// ```
-#[lang="deref_mut"]
+#[lang = "deref_mut"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait DerefMut: Deref {
     /// The method called to mutably dereference a value
@@ -1128,7 +1128,7 @@ impl<'a, T: ?Sized> DerefMut for &'a mut T {
 }
 
 /// A version of the call operator that takes an immutable receiver.
-#[lang="fn"]
+#[lang = "fn"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_paren_sugar]
 #[fundamental] // so that regex can rely that `&str: !FnMut`
@@ -1138,7 +1138,7 @@ pub trait Fn<Args> : FnMut<Args> {
 }
 
 /// A version of the call operator that takes a mutable receiver.
-#[lang="fn_mut"]
+#[lang = "fn_mut"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_paren_sugar]
 #[fundamental] // so that regex can rely that `&str: !FnMut`
@@ -1148,7 +1148,7 @@ pub trait FnMut<Args> : FnOnce<Args> {
 }
 
 /// A version of the call operator that takes a by-value receiver.
-#[lang="fn_once"]
+#[lang = "fn_once"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_paren_sugar]
 #[fundamental] // so that regex can rely that `&str: !FnMut`

--- a/src/libcore/panicking.rs
+++ b/src/libcore/panicking.rs
@@ -33,7 +33,7 @@
 use fmt;
 
 #[cold] #[inline(never)] // this is the slow path, always
-#[lang="panic"]
+#[lang = "panic"]
 pub fn panic(expr_file_line: &(&'static str, &'static str, u32)) -> ! {
     // Use Arguments::new_v1 instead of format_args!("{}", expr) to potentially
     // reduce size overhead. The format_args! macro uses str's Display trait to
@@ -46,7 +46,7 @@ pub fn panic(expr_file_line: &(&'static str, &'static str, u32)) -> ! {
 }
 
 #[cold] #[inline(never)]
-#[lang="panic_bounds_check"]
+#[lang = "panic_bounds_check"]
 fn panic_bounds_check(file_line: &(&'static str, u32),
                      index: usize, len: usize) -> ! {
     panic_fmt(format_args!("index out of bounds: the len is {} but the index is {}",

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1185,7 +1185,7 @@ fn eq_slice_(a: &str, b: &str) -> bool {
 /// Bytewise slice equality
 /// NOTE: This function is (ab)used in rustc::middle::trans::_match
 /// to compare &[u8] byte slices that are not necessarily valid UTF-8.
-#[lang="str_eq"]
+#[lang = "str_eq"]
 #[inline]
 fn eq_slice(a: &str, b: &str) -> bool {
     eq_slice_(a, b)

--- a/src/libstd/rt/unwind.rs
+++ b/src/libstd/rt/unwind.rs
@@ -238,7 +238,7 @@ pub mod eabi {
             -> uw::_Unwind_Reason_Code;
     }
 
-    #[lang="eh_personality"]
+    #[lang = "eh_personality"]
     #[no_mangle] // referenced from rust_try.ll
     #[allow(private_no_mangle_fns)]
     extern fn rust_eh_personality(
@@ -292,7 +292,7 @@ pub mod eabi {
             -> uw::_Unwind_Reason_Code;
     }
 
-    #[lang="eh_personality"]
+    #[lang = "eh_personality"]
     #[no_mangle] // referenced from rust_try.ll
     pub extern "C" fn rust_eh_personality(
         version: c_int,
@@ -345,7 +345,7 @@ pub mod eabi {
             -> uw::_Unwind_Reason_Code;
     }
 
-    #[lang="eh_personality"]
+    #[lang = "eh_personality"]
     #[no_mangle] // referenced from rust_try.ll
     #[allow(private_no_mangle_fns)]
     extern "C" fn rust_eh_personality(
@@ -432,7 +432,7 @@ pub mod eabi {
         ) -> EXCEPTION_DISPOSITION;
     }
 
-    #[lang="eh_personality"]
+    #[lang = "eh_personality"]
     #[no_mangle] // referenced from rust_try.ll
     #[allow(private_no_mangle_fns)]
     extern "C" fn rust_eh_personality(


### PR DESCRIPTION
In my opinion this looks nicer, but also it matches the whitespace generally
used for stability markers.
