### PR TITLE
Upgraded warning for invalid crate_type attribute syntax to an error (#16974)

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -871,11 +871,8 @@ pub fn collect_crate_types(session: &Session,
                     None
                 }
                 _ => {
-                    session.add_lint(lint::builtin::UNKNOWN_CRATE_TYPES,
-                                     ast::CRATE_NODE_ID,
-                                     a.span,
-                                     "`crate_type` requires a \
-                                      value".to_string());
+                    session.span_err(a.span, "`crate_type` requires a value");
+                    session.note("for example: `#![crate_type=\"lib\"]`");
                     None
                 }
             }

--- a/src/test/compile-fail/invalid_crate_type_syntax.rs
+++ b/src/test/compile-fail/invalid_crate_type_syntax.rs
@@ -1,0 +1,14 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// regression test for issue 16974
+#![crate_type(lib)]  //~ ERROR `crate_type` requires a value
+
+fn my_lib_fn() {}


### PR DESCRIPTION
Fixes the problem in #16974 with unhelpful error messages when accidentally using the wrong syntax for the `crate_type="lib"` attribute. The attribute syntax error now shows up instead of "main function not found".
