### PR TITLE
Trivial documentation changes in Mutability, Match

### DIFF
--- a/src/doc/trpl/match.md
+++ b/src/doc/trpl/match.md
@@ -50,7 +50,7 @@ side of a `let` binding or directly where an expression is used:
 ```rust
 let x = 5;
 
-let numer = match x {
+let number = match x {
     1 => "one",
     2 => "two",
     3 => "three",

--- a/src/doc/trpl/mutability.md
+++ b/src/doc/trpl/mutability.md
@@ -78,8 +78,8 @@ When we call `clone()`, the `Arc<T>` needs to update the reference count. Yet
 we’ve not used any `mut`s here, `x` is an immutable binding, and we didn’t take
 `&mut 5` or anything. So what gives?
 
-To this, we have to go back to the core of Rust’s guiding philosophy, memory
-safety, and the mechanism by which Rust guarantees it, the
+To understand this, we have to go back to the core of Rust’s guiding
+philosophy, memory safety, and the mechanism by which Rust guarantees it, the
 [ownership][ownership] system, and more specifically, [borrowing][borrowing]:
 
 > You may have one or the other of these two kinds of borrows, but not both at


### PR DESCRIPTION
I think there's a trivial missing word in the Mutability document. I reformatted the resulting paragraph in vim, which seems to match what the rest of the document is doing as far as word wrapping.

Edit: I found another minor thing as I continued reading.

P.S. I'm re-reading the docs, since so much has changed since my first read, and they've gotten even better! Nice job!

r? @steveklabnik
