### PR TITLE
Remove obsolete comment in rustc::middle::subst.

### DIFF
--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -273,7 +273,6 @@ impl<T> VecPerParamSpace<T> {
 
     /// `t` is the type space.
     /// `s` is the self space.
-    /// `a` is the assoc space.
     /// `f` is the fn space.
     pub fn new(t: Vec<T>, s: Vec<T>, f: Vec<T>) -> VecPerParamSpace<T> {
         let type_limit = t.len();


### PR DESCRIPTION
This was added in d2f8074 along with the AssocSpace stuff. The AssocSpace
stuff was then removed in de8e0ae, except it seems the comment here was missed.
