### PR TITLE
Add error explanation for E0317, E0154, E0259, E0260.

### DIFF
--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -53,8 +53,8 @@ has been imported into the current module.
 
 Wrong example:
 ```
-extern a;
-extern crate_a as a;
+extern crate a;
+extern crate crate_a as a;
 ```
 
 The solution is to choose a different name that doesn't conflict with any
@@ -62,8 +62,8 @@ external crate imported into the current module.
 
 Correct example:
 ```
-extern a;
-extern crate_a as other_name;
+extern crate a;
+extern crate crate_a as other_name;
 ```
 "##,
 
@@ -72,7 +72,7 @@ The name for an item declaration conflicts with an external crate's name.
 
 For instance,
 ```
-extern abc;
+extern crate abc;
 
 struct abc;
 ```
@@ -82,7 +82,7 @@ There are two possible solutions:
 Solution #1: Rename the item.
 
 ```
-extern abc;
+extern crate abc;
 
 struct xyz;
 ```
@@ -90,7 +90,7 @@ struct xyz;
 Solution #2: Import the crate with a different name.
 
 ```
-extern abc as xyz;
+extern crate abc as xyz;
 
 struct abc;
 ```

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -19,7 +19,7 @@ E0154: r##"
 Imports (`use` statements) are not allowed after non-item statements, such as
 variable declarations and expression statements.
 
-Wrong example:
+Here is an example that demonstrates the error:
 ```
 fn f() {
     // Variable declaration before import
@@ -104,7 +104,7 @@ http://doc.rust-lang.org/reference.html#statements
 E0317: r##"
 User-defined types or type parameters cannot shadow the primitive types.
 This error indicates you tried to define a type, struct or enum with the same
-name as an existing primitive type, and is therefore invalid.
+name as an existing primitive type.
 
 See the Types section of the reference for more information about the primitive
 types:

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -47,6 +47,26 @@ about what constitutes an Item declaration and what does not:
 http://doc.rust-lang.org/reference.html#statements
 "##,
 
+E0259: r##"
+The name chosen for an external crate conflicts with another external crate that
+has been imported into the current module.
+
+Wrong example:
+```
+extern a;
+extern crate_a as a;
+```
+
+The solution is to choose a different name that doesn't conflict with any
+external crate imported into the current module.
+
+Correct example:
+```
+extern a;
+extern crate_a as other_name;
+```
+"##,
+
 E0317: r##"
 User-defined types or type parameters cannot shadow the primitive types.
 This error indicates you tried to define a type, struct or enum with the same
@@ -71,7 +91,6 @@ register_diagnostics! {
     E0256, // import conflicts with type in this module
     E0257, // inherent implementations are only allowed on types defined in the current module
     E0258, // import conflicts with existing submodule
-    E0259, // an extern crate has already been imported into this module
     E0260, // name conflicts with an external crate that has been imported into this module
     E0364, // item is private
     E0365  // item is private

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -10,6 +10,24 @@
 
 #![allow(non_snake_case)]
 
+// Error messages for EXXXX errors.
+// Each message should start and end with a new line, and be wrapped to 80 characters.
+// In vim you can `:set tw=80` and use `gq` to wrap paragraphs. Use `:set tw=0` to disable.
+register_long_diagnostics! {
+
+E0317: r##"
+User-defined types or type parameters cannot shadow the primitive types.
+This error indicates you tried to define a type, struct or enum with the same
+name as an existing primitive type, and is therefore invalid.
+
+See the Types section of the reference for more information about the primitive
+types:
+
+http://doc.rust-lang.org/nightly/reference.html#types
+"##
+
+}
+
 register_diagnostics! {
     E0154,
     E0157,
@@ -24,7 +42,6 @@ register_diagnostics! {
     E0258, // import conflicts with existing submodule
     E0259, // an extern crate has already been imported into this module
     E0260, // name conflicts with an external crate that has been imported into this module
-    E0317, // user-defined types or type parameters cannot shadow the primitive types
     E0364, // item is private
     E0365  // item is private
 }

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -23,7 +23,7 @@ name as an existing primitive type, and is therefore invalid.
 See the Types section of the reference for more information about the primitive
 types:
 
-http://doc.rust-lang.org/nightly/reference.html#types
+http://doc.rust-lang.org/reference.html#types
 "##
 
 }

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -15,6 +15,38 @@
 // In vim you can `:set tw=80` and use `gq` to wrap paragraphs. Use `:set tw=0` to disable.
 register_long_diagnostics! {
 
+E0154: r##"
+Imports (`use` statements) are not allowed after non-item statements, such as
+variable declarations and expression statements.
+
+Wrong example:
+```
+fn f() {
+    // Variable declaration before import
+    let x = 0;
+    use std::io::Read;
+    ...
+}
+```
+
+The solution is to declare the imports at the top of the block, function, or
+file.
+
+Here is the previous example again, with the correct order:
+```
+fn f() {
+    use std::io::Read;
+    let x = 0;
+    ...
+}
+```
+
+See the Declaration Statements section of the reference for more information
+about what constitutes an Item declaration and what does not:
+
+http://doc.rust-lang.org/reference.html#statements
+"##,
+
 E0317: r##"
 User-defined types or type parameters cannot shadow the primitive types.
 This error indicates you tried to define a type, struct or enum with the same
@@ -29,7 +61,6 @@ http://doc.rust-lang.org/reference.html#types
 }
 
 register_diagnostics! {
-    E0154,
     E0157,
     E0153,
     E0251, // a named type or value has already been imported in this module

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -67,6 +67,40 @@ extern crate_a as other_name;
 ```
 "##,
 
+E0260: r##"
+The name for an item declaration conflicts with an external crate's name.
+
+For instance,
+```
+extern abc;
+
+struct abc;
+```
+
+There are two possible solutions:
+
+Solution #1: Rename the item.
+
+```
+extern abc;
+
+struct xyz;
+```
+
+Solution #2: Import the crate with a different name.
+
+```
+extern abc as xyz;
+
+struct abc;
+```
+
+See the Declaration Statements section of the reference for more information
+about what constitutes an Item declaration and what does not:
+
+http://doc.rust-lang.org/reference.html#statements
+"##,
+
 E0317: r##"
 User-defined types or type parameters cannot shadow the primitive types.
 This error indicates you tried to define a type, struct or enum with the same
@@ -91,7 +125,6 @@ register_diagnostics! {
     E0256, // import conflicts with type in this module
     E0257, // inherent implementations are only allowed on types defined in the current module
     E0258, // import conflicts with existing submodule
-    E0260, // name conflicts with an external crate that has been imported into this module
     E0364, // item is private
     E0365  // item is private
 }


### PR DESCRIPTION
Add diagnostic message for E0317, E0154, E0259 and E0260; part of #24407.

About E0317, I was unsure if I should add an example of what could be wrong, such as `struct i64`, `enum char { A, B }` or `type isize = i64`. I decided against it, since the diagnostic message looks clear enough to me.

What do you think?
