### PR TITLE
Add some long diagnostic messages.

### DIFF
--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1603,7 +1603,8 @@ pub fn ast_ty_to_ty<'tcx>(this: &AstConv<'tcx>,
                                         Some(i as usize)),
                         _ => {
                             span_err!(tcx.sess, ast_ty.span, E0249,
-                                      "expected constant expr for array length");
+                                      "expected constant integer expression \
+                                       for array length");
                             this.tcx().types.err
                         }
                     }

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -164,18 +164,18 @@ register_diagnostics! {
     E0030,
     E0031,
     E0033,
-    E0034,
-    E0035,
-    E0036,
-    E0038,
+    E0034, // multiple applicable methods in scope
+    E0035, // does not take type parameters
+    E0036, // incorrect number of type parameters given for this method
+    E0038, // cannot convert to a trait object because trait is not object-safe
     E0040, // explicit use of destructor method
-    E0044,
-    E0045,
+    E0044, // foreign items may not have type parameters
+    E0045, // variadic function must have C calling convention
     E0049,
     E0050,
     E0053,
-    E0055,
-    E0057,
+    E0055, // method has an incompatible type for trait
+    E0057, // method has an incompatible type for trait
     E0059,
     E0060,
     E0061,

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -260,6 +260,38 @@ struct Foo { x: bool }
 
 struct Bar<S, T> { x: Foo<S, T> }
 ```
+"##,
+
+E0249: r##"
+This error indicates a constant expression for the array length was found, but
+it was not an integer (signed or unsigned) expression.
+
+Some examples of code that produces this error are:
+
+```
+const A: [u32; "hello"] = []; // error
+const B: [u32; true] = []; // error
+const C: [u32; 0.0] = []; // error
+"##,
+
+E0250: r##"
+This means there was an error while evaluating the expression for the length of
+a fixed-size array type.
+
+Some examples of code that produces this error are:
+
+```
+// divide by zero in the length expression
+const A: [u32; 1/0] = [];
+
+// Rust currently will not evaluate the function `foo` at compile time
+fn foo() -> usize { 12 }
+const B: [u32; foo()] = [];
+
+// it is an error to try to add `u8` and `f64`
+use std::{f64, u8};
+const C: [u32; u8::MAX + f64::EPSILON] = [];
+```
 "##
 
 }
@@ -403,8 +435,6 @@ register_diagnostics! {
     E0246, // illegal recursive type
     E0247, // found module name used as a type
     E0248, // found value name used as a type
-    E0249, // expected constant expr for array length
-    E0250, // expected constant expr for array length
     E0318, // can't create default impls for traits outside their crates
     E0319, // trait impls for defaulted traits allowed just for structs/enums
     E0320, // recursive overflow during dropck

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -183,8 +183,8 @@ struct Foo<'a> {
 }
 ```
 
-This fails because `&mut T` is not `Copy`, even when `T` is `Copy` (as opposed
-to `&T`, which is).
+This fails because `&mut T` is not `Copy`, even when `T` is `Copy` (this
+differs from the behavior for `&T`, which is `Copy` when `T` is `Copy`).
 "##,
 
 E0205: r##"
@@ -213,8 +213,8 @@ enum Foo<'a> {
 }
 ```
 
-This fails because `&mut T` is not `Copy`, even when `T` is `Copy` (as opposed
-to `&T`, which is).
+This fails because `&mut T` is not `Copy`, even when `T` is `Copy` (this
+differs from the behavior for `&T`, which is `Copy` when `T` is `Copy`).
 "##,
 
 E0206: r##"

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -150,6 +150,114 @@ attribute. Such a function must have the following type signature:
 ```
 fn(isize, *const *const u8) -> isize
 ```
+"##,
+
+E0184: r##"
+Explicitly implementing both Drop and Copy for a type is currently disallowed.
+This feature can make some sense in theory, but the current implementation is
+incorrect and can lead to memory unsafety (see issue #20126), so it has been
+disabled for now.
+"##,
+
+E0204: r##"
+An attempt to implement the `Copy` trait for a struct failed because one of the
+fields does not implement `Copy`. To fix this, you must implement `Copy` for the
+mentioned field. Note that this may not be possible, as in the example of
+
+```
+struct Foo {
+    foo : Vec<u32>,
+}
+
+impl Copy for Foo { }
+```
+
+This fails because `Vec<T>` does not implement `Copy` for any `T`.
+
+Here's another example that will fail:
+
+```
+#[derive(Copy)]
+struct Foo<'a> {
+    ty: &'a mut bool,
+}
+```
+
+This fails because `&mut T` is not `Copy`, even when `T` is `Copy` (as opposed
+to `&T`, which is).
+"##,
+
+E0205: r##"
+An attempt to implement the `Copy` trait for an enum failed because one of the
+variants does not implement `Copy`. To fix this, you must implement `Copy` for
+the mentioned variant. Note that this may not be possible, as in the example of
+
+```
+enum Foo {
+    Bar(Vec<u32>),
+    Baz,
+}
+
+impl Copy for Foo { }
+```
+
+This fails because `Vec<T>` does not implement `Copy` for any `T`.
+
+Here's another example that will fail:
+
+```
+#[derive(Copy)]
+enum Foo<'a> {
+    Bar(&'a mut bool),
+    Baz
+}
+```
+
+This fails because `&mut T` is not `Copy`, even when `T` is `Copy` (as opposed
+to `&T`, which is).
+"##,
+
+E0206: r##"
+You can only implement `Copy` for a struct or enum. For example, both of the
+following examples will fail, because neither `i32` nor `&'static mut Bar` is
+a struct or enum:
+
+```
+type Foo = i32;
+impl Copy for Foo { } // error
+
+#[derive(Copy, Clone)]
+struct Bar;
+impl Copy for &'static mut Bar { } // error
+```
+"##,
+
+E0243: r##"
+This error indicates that not enough type parameters were found in a type or
+trait.
+
+For example, the `Foo` struct below is defined to be generic in `T`, but the
+type parameter is missing in the definition of `Bar`:
+
+```
+struct Foo<T> { x: T }
+
+struct Bar { x: Foo }
+```
+"##,
+
+E0244: r##"
+This error indicates that too many type parameters were found in a type or
+trait.
+
+For example, the `Foo` struct below has no type parameters, but is supplied
+with two in the definition of `Bar`:
+
+```
+struct Foo { x: bool }
+
+struct Bar<S, T> { x: Foo<S, T> }
+```
 "##
 
 }
@@ -232,7 +340,6 @@ register_diagnostics! {
     E0178,
     E0182,
     E0183,
-    E0184,
     E0185,
     E0186,
     E0187, // can't infer the kind of the closure
@@ -254,12 +361,6 @@ register_diagnostics! {
     E0202, // associated items are not allowed in inherent impls
     E0203, // type parameter has more than one relaxed default bound,
            // and only one is supported
-    E0204, // trait `Copy` may not be implemented for this type; field
-           // does not implement `Copy`
-    E0205, // trait `Copy` may not be implemented for this type; variant
-           // does not implement `copy`
-    E0206, // trait `Copy` may not be implemented for this type; type is
-           // not a structure or enumeration
     E0207, // type parameter is not constrained by the impl trait, self type, or predicate
     E0208,
     E0209, // builtin traits can only be implemented on structs or enums
@@ -296,8 +397,6 @@ register_diagnostics! {
     E0240,
     E0241,
     E0242, // internal error looking up a definition
-    E0243, // wrong number of type arguments
-    E0244, // wrong number of type arguments
     E0245, // not a trait
     E0246, // illegal recursive type
     E0247, // found module name used as a type

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -218,9 +218,9 @@ differs from the behavior for `&T`, which is `Copy` when `T` is `Copy`).
 "##,
 
 E0206: r##"
-You can only implement `Copy` for a struct or enum. For example, both of the
-following examples will fail, because neither `i32` nor `&'static mut Bar` is
-a struct or enum:
+You can only implement `Copy` for a struct or enum. Both of the following
+examples will fail, because neither `i32` (primitive type) nor `&'static Bar`
+(reference to `Bar`) is a struct or enum:
 
 ```
 type Foo = i32;
@@ -228,7 +228,7 @@ impl Copy for Foo { } // error
 
 #[derive(Copy, Clone)]
 struct Bar;
-impl Copy for &'static mut Bar { } // error
+impl Copy for &'static Bar { } // error
 ```
 "##,
 

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -155,8 +155,10 @@ fn(isize, *const *const u8) -> isize
 E0184: r##"
 Explicitly implementing both Drop and Copy for a type is currently disallowed.
 This feature can make some sense in theory, but the current implementation is
-incorrect and can lead to memory unsafety (see issue #20126), so it has been
-disabled for now.
+incorrect and can lead to memory unsafety (see [issue #20126][iss20126]), so
+it has been disabled for now.
+
+[iss20126]: https://github.com/rust-lang/rust/issues/20126
 "##,
 
 E0204: r##"


### PR DESCRIPTION
Adds long diagnostic messages for:
- E0184
- E0204
- E0205
- E0206
- E0243
- E0244
- E0249
- E0250

This PR also adds some comments to the error codes in `librustc_typeck/diagnostics.rs`.

cc #24407 
