### PR TITLE
Remove extra parentheses

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -547,7 +547,7 @@ _name_ s that occur in its body. At the "current layer", they all must repeat
 the same number of times, so ` ( $( $i:ident ),* ; $( $j:ident ),* ) => ( $(
 ($i,$j) ),* )` is valid if given the argument `(a,b,c ; d,e,f)`, but not
 `(a,b,c ; d,e)`. The repetition walks through the choices at that layer in
-lockstep, so the former input transcribes to `( (a,d), (b,e), (c,f) )`.
+lockstep, so the former input transcribes to `(a,d), (b,e), (c,f)`.
 
 Nested repetitions are allowed.
 


### PR DESCRIPTION
As mentioned in https://github.com/rust-lang/rust/issues/16676#issuecomment-100676326 this makes it a little bit more correct.

I'm a bit unsure whether or not it should be explained that the transcriber can be wrapped in parentheses or curly braces if necessary.
