### PR TITLE
Handle overflow properly in core::slice

### DIFF
--- a/src/libcore/slice.rs
+++ b/src/libcore/slice.rs
@@ -665,10 +665,14 @@ macro_rules! iterator {
             #[inline]
             fn next(&mut self) -> Option<$elem> {
                 // could be implemented with slices, but this avoids bounds checks
-                unsafe {
-                    if self.ptr == self.end {
-                        None
-                    } else {
+                if self.ptr == self.end {
+                    None
+                } else {
+                    unsafe {
+                        if mem::size_of::<T>() != 0 {
+                            ::intrinsics::assume(!self.ptr.is_null());
+                            ::intrinsics::assume(!self.end.is_null());
+                        }
                         let old = self.ptr;
                         self.ptr = slice_offset!(self.ptr, 1);
                         Some(slice_ref!(old))
@@ -706,11 +710,15 @@ macro_rules! iterator {
             #[inline]
             fn next_back(&mut self) -> Option<$elem> {
                 // could be implemented with slices, but this avoids bounds checks
-                unsafe {
-                    if self.end == self.ptr {
-                        None
-                    } else {
+                if self.end == self.ptr {
+                    None
+                } else {
+                    unsafe {
                         self.end = slice_offset!(self.end, -1);
+                        if mem::size_of::<T>() != 0 {
+                            ::intrinsics::assume(!self.ptr.is_null());
+                            ::intrinsics::assume(!self.end.is_null());
+                        }
                         Some(slice_ref!(self.end))
                     }
                 }

--- a/src/test/run-pass/slice-of-zero-size-elements.rs
+++ b/src/test/run-pass/slice-of-zero-size-elements.rs
@@ -10,7 +10,25 @@
 
 // compile-flags: -C debug-assertions
 
+#![feature(core)]
+
 use std::slice;
+
+fn foo<T>(v: &[T]) -> Option<&[T]> {
+    let mut it = v.iter();
+    for _ in 0..5 {
+        let _ = it.next();
+    }
+    Some(it.as_slice())
+}
+
+fn foo_mut<T>(v: &mut [T]) -> Option<&mut [T]> {
+    let mut it = v.iter_mut();
+    for _ in 0..5 {
+        let _ = it.next();
+    }
+    Some(it.into_slice())
+}
 
 pub fn main() {
     // In a slice of zero-size elements the pointer is meaningless.
@@ -24,11 +42,19 @@ pub fn main() {
     assert!(it.nth(5).is_some());
     assert_eq!(it.count(), 4);
 
+    // Converting Iter to a slice should never have a null pointer
+    assert!(foo(slice).is_some());
+
+    // Test mutable iterators as well
     let slice: &mut [()] = unsafe { slice::from_raw_parts_mut(-5isize as *mut (), 10) };
     assert_eq!(slice.len(), 10);
     assert_eq!(slice.iter_mut().count(), 10);
 
-    let mut it = slice.iter_mut();
-    assert!(it.nth(5).is_some());
-    assert_eq!(it.count(), 4);
+    {
+        let mut it = slice.iter_mut();
+        assert!(it.nth(5).is_some());
+        assert_eq!(it.count(), 4);
+    }
+
+    assert!(foo_mut(slice).is_some())
 }

--- a/src/test/run-pass/slice-of-zero-size-elements.rs
+++ b/src/test/run-pass/slice-of-zero-size-elements.rs
@@ -1,0 +1,34 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -C debug-assertions
+
+use std::slice;
+
+pub fn main() {
+    // In a slice of zero-size elements the pointer is meaningless.
+    // Ensure iteration still works even if the pointer is at the end of the address space.
+    let slice: &[()] = unsafe { slice::from_raw_parts(-5isize as *const (), 10) };
+    assert_eq!(slice.len(), 10);
+    assert_eq!(slice.iter().count(), 10);
+
+    // .nth() on the iterator should also behave correctly
+    let mut it = slice.iter();
+    assert!(it.nth(5).is_some());
+    assert_eq!(it.count(), 4);
+
+    let slice: &mut [()] = unsafe { slice::from_raw_parts_mut(-5isize as *mut (), 10) };
+    assert_eq!(slice.len(), 10);
+    assert_eq!(slice.iter_mut().count(), 10);
+
+    let mut it = slice.iter_mut();
+    assert!(it.nth(5).is_some());
+    assert_eq!(it.count(), 4);
+}


### PR DESCRIPTION
core::slice was originally written to tolerate overflow (notably, with
slices of zero-sized elements), but it was never updated to use wrapping
arithmetic when overflow traps were added.

Also correctly handle the case of calling .nth() on an Iter with a
zero-sized element type. The iterator was assuming that the pointer
value of the returned reference was meaningful, but that's not true for
zero-sized elements.

Fixes #25016.
