### PR TITLE
Minor optimization for `VecMap::split_off`

### DIFF
--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -367,7 +367,7 @@ impl<V> VecMap<V> {
             // Move all elements to other
             swap(self, &mut other);
             return other
-        } else if at > self.v.len() {
+        } else if at >= self.v.len() {
             // No elements to copy
             return other;
         }


### PR DESCRIPTION
We don't need to copy any elements if `at` is behind the last element
in the map. The last element is at index `self.v.len() - 1`, so we
should not copy if `at` is greater **or equals** `self.v.len()`.

r? @Gankro
