### PR TITLE
Markdown formatting for error explanations.

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -745,6 +745,7 @@ variable.
 
 For example:
 
+```
 let x: i32 = "I am not a number!";
 //     ~~~   ~~~~~~~~~~~~~~~~~~~~
 //      |             |
@@ -752,6 +753,7 @@ let x: i32 = "I am not a number!";
 //      |    compiler infers type `&str`
 //      |
 //    type `i32` assigned to variable `x`
+```
 "##,
 
 E0309: r##"
@@ -760,6 +762,7 @@ how long the data stored within them is guaranteed to be live. This lifetime
 must be as long as the data needs to be alive, and missing the constraint that
 denotes this will cause this error.
 
+```
 // This won't compile because T is not constrained, meaning the data
 // stored in it is not guaranteed to last as long as the reference
 struct Foo<'a, T> {
@@ -770,6 +773,7 @@ struct Foo<'a, T> {
 struct Foo<'a, T: 'a> {
     foo: &'a T
 }
+```
 "##,
 
 E0310: r##"
@@ -778,6 +782,7 @@ how long the data stored within them is guaranteed to be live. This lifetime
 must be as long as the data needs to be alive, and missing the constraint that
 denotes this will cause this error.
 
+```
 // This won't compile because T is not constrained to the static lifetime
 // the reference needs
 struct Foo<T> {
@@ -788,6 +793,7 @@ struct Foo<T> {
 struct Foo<T: 'static> {
     foo: &'static T
 }
+```
 "##
 
 }


### PR DESCRIPTION
A few errors slipped through my filter. Markdown formatting is especially important now that http://doc.rust-lang.org/error-index.html is live!

Speaking of, the error index should probably be linked to from somewhere. It doesn't quite fit under any of the sections in the index, but I could create a new one for it? Or add it under "tools" despite it not exactly being an executable tool.
