### PR TITLE
readme: Rework the arch support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ fetch snapshots, and an OS that can execute the available snapshot binaries.
 
 Snapshot binaries are currently built and tested on several platforms:
 
-* Windows (7, 8, Server 2008 R2), x86 and x86-64 (64-bit support added in Rust 0.12.0)
-* Linux (2.6.18 or later, various distributions), x86 and x86-64
-* OSX 10.7 (Lion) or greater, x86 and x86-64
+| Platform \ Architecture        | x86 | x86_64 |
+|--------------------------------|-----|--------|
+| Windows (7, 8, Server 2008 R2) | ✓   | ✓      |
+| Linux (2.6.18 or later)        | ✓   | ✓      |
+| OSX (10.7 Lion or later)       | ✓   | ✓      |
 
 You may find that other platforms work, but these are our officially
 supported build environments that are most likely to work.


### PR DESCRIPTION
This makes the compatibility matrix render a little nicer on github, and also removes a note about windows support from 0.12 (Which is immaterial now that we're approaching 1.0)
