### PR TITLE
Add a link to the error index to the main doc page.

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -24,7 +24,7 @@ series of small examples.
 # Community & Getting Help
 
 If you need help with something, or just want to talk about Rust with others,
-there's a few places you can do that:
+there are a few places you can do that:
 
 The Rust IRC channels on [irc.mozilla.org](http://irc.mozilla.org/) are the
 fastest way to get help.
@@ -59,7 +59,7 @@ the language in as much detail as possible is in [the reference](reference.html)
 
 # Tools
 
-Rust's still a young language, so there isn't a ton of tooling yet, but the
+Rust is still a young language, so there isn't a ton of tooling yet, but the
 tools we have are really nice.
 
 [Cargo](http://crates.io) is Rust's package manager, and its website contains
@@ -69,16 +69,21 @@ lots of good documentation.
 
 # FAQs
 
-There are questions that are asked quite often, and so we've made FAQs for them:
+There are questions that are asked quite often, so we've made FAQs for them:
 
 * [Language Design FAQ](complement-design-faq.html)
 * [Language FAQ](complement-lang-faq.html)
 * [Project FAQ](complement-project-faq.html)
 * [How to submit a bug report](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports)
 
-# The standard library
+# The Standard Library
 
 We have [API documentation for the entire standard
 library](std/index.html). There's a list of crates on the left with more
 specific sections, or you can use the search bar at the top to search for
 something if you know its name.
+
+# The Error Index
+
+If you encounter an error while compiling your code you may be able to look it
+up in the [Rust Compiler Error Index](error-index.html).

--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -273,8 +273,8 @@ See also http://doc.rust-lang.org/book/unsafe.html
 
 E0137: r##"
 This error indicates that the compiler found multiple functions with the
-#[main] attribute. This is an error because there must be a unique entry point
-into a Rust program.
+`#[main]` attribute. This is an error because there must be a unique entry
+point into a Rust program.
 "##,
 
 E0152: r##"


### PR DESCRIPTION
At the moment, http://doc.rust-lang.org/error-index.html isn't linked to from anywhere (except Reddit). This should allow search engines to find error codes!

I also capitalised "The Standard Library" and neatened a few bits of grammar.

Also fixed: `#[main]` inside one of the error descriptions.
