### PR TITLE
Record correct span for static mut items in trans/save

### DIFF
--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -520,12 +520,12 @@ impl <'l, 'tcx> DxrVisitor<'l, 'tcx> {
         let qualname = format!("::{}", self.analysis.ty_cx.map.path_to_string(item.id));
 
         // If the variable is immutable, save the initialising expression.
-        let value = match mt {
-            ast::MutMutable => String::from_str("<mutable>"),
-            ast::MutImmutable => self.span.snippet(expr.span),
+        let (value, keyword) = match mt {
+            ast::MutMutable => (String::from_str("<mutable>"), keywords::Mut),
+            ast::MutImmutable => (self.span.snippet(expr.span), keywords::Static),
         };
 
-        let sub_span = self.span.sub_span_after_keyword(item.span, keywords::Static);
+        let sub_span = self.span.sub_span_after_keyword(item.span, keyword);
         self.fmt.static_str(item.span,
                             sub_span,
                             item.id,


### PR DESCRIPTION
As it is, save-analysis appears to return the span for the 'mut' in a declaration 'static mut identifier...' instead of the identifier. This minor change appears to fix the problem, by skipping the mut when it is present. 
