### PR TITLE
Update the bison grammar for various language changes and fixes

### DIFF
--- a/src/grammar/lexer.l
+++ b/src/grammar/lexer.l
@@ -311,7 +311,7 @@ r/#             {
 <str>\x22                { BEGIN(suffix); return LIT_STR; }
 
 <str><<EOF>>                { return -1; }
-<str>\\[n\nrt\\\x27\x220]   { yymore(); }
+<str>\\[n\nr\rt\\\x27\x220] { yymore(); }
 <str>\\x[0-9a-fA-F]{2}      { yymore(); }
 <str>\\u\{[0-9a-fA-F]?{6}\} { yymore(); }
 <str>\\[^n\nrt\\\x27\x220]  { return -1; }


### PR DESCRIPTION
- Correctly lex CRLF in string literals
- Update `extern CRATE as NAME` syntax
- Allow leading `::` in view paths
- Allow TySums in type ascriptions and impls
- Allow macros to have visibility and attributes
- Update syntax for qualified path types and expressions
- Allow block expressions to be called () and indexed []
