### PR TITLE
Create a FreshFloatTy separate from FreshIntTy

### DIFF
--- a/src/librustc/middle/infer/freshen.rs
+++ b/src/librustc/middle/infer/freshen.rs
@@ -129,11 +129,12 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
                                                       .probe(v)
                                                       .map(|v| v.to_type(tcx)),
                     ty::FloatVar(v),
-                    ty::FreshIntTy)
+                    ty::FreshFloatTy)
             }
 
             ty::ty_infer(ty::FreshTy(c)) |
-            ty::ty_infer(ty::FreshIntTy(c)) => {
+            ty::ty_infer(ty::FreshIntTy(c)) |
+            ty::ty_infer(ty::FreshFloatTy(c)) => {
                 if c >= self.freshen_count {
                     tcx.sess.bug(
                         &format!("Encountered a freshend type with id {} \

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1685,7 +1685,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             ty::ty_err => ok_if(Vec::new()),
 
             ty::ty_infer(ty::FreshTy(_))
-            | ty::ty_infer(ty::FreshIntTy(_)) => {
+            | ty::ty_infer(ty::FreshIntTy(_))
+            | ty::ty_infer(ty::FreshFloatTy(_)) => {
                 self.tcx().sess.bug(
                     &format!(
                         "asked to assemble builtin bounds of unexpected type: {}",
@@ -1747,7 +1748,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             ty::ty_projection(..) |
             ty::ty_infer(ty::TyVar(_)) |
             ty::ty_infer(ty::FreshTy(_)) |
-            ty::ty_infer(ty::FreshIntTy(_)) => {
+            ty::ty_infer(ty::FreshIntTy(_)) |
+            ty::ty_infer(ty::FreshFloatTy(_)) => {
                 self.tcx().sess.bug(
                     &format!(
                         "asked to assemble constituent types of unexpected type: {}",

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1688,11 +1688,8 @@ pub enum InferTy {
     /// unbound type variable. This is convenient for caching etc. See
     /// `middle::infer::freshen` for more details.
     FreshTy(u32),
-
-    // FIXME -- once integral fallback is impl'd, we should remove
-    // this type. It's only needed to prevent spurious errors for
-    // integers whose type winds up never being constrained.
     FreshIntTy(u32),
+    FreshFloatTy(u32)
 }
 
 #[derive(Clone, RustcEncodable, RustcDecodable, PartialEq, Eq, Hash, Debug, Copy)]
@@ -1764,6 +1761,7 @@ impl fmt::Debug for InferTy {
             FloatVar(ref v) => v.fmt(f),
             FreshTy(v) => write!(f, "FreshTy({:?})", v),
             FreshIntTy(v) => write!(f, "FreshIntTy({:?})", v),
+            FreshFloatTy(v) => write!(f, "FreshFloatTy({:?})", v)
         }
     }
 }
@@ -3765,7 +3763,7 @@ pub fn type_contents<'tcx>(cx: &ctxt<'tcx>, ty: Ty<'tcx>) -> TypeContents {
             }
 
             // Scalar and unique types are sendable, and durable
-            ty_infer(ty::FreshIntTy(_)) |
+            ty_infer(ty::FreshIntTy(_)) | ty_infer(ty::FreshFloatTy(_)) |
             ty_bool | ty_int(_) | ty_uint(_) | ty_float(_) |
             ty_bare_fn(..) | ty::ty_char => {
                 TC::None
@@ -4315,6 +4313,7 @@ pub fn type_is_fresh(ty: Ty) -> bool {
     match ty.sty {
       ty_infer(FreshTy(_)) => true,
       ty_infer(FreshIntTy(_)) => true,
+      ty_infer(FreshFloatTy(_)) => true,
       _ => false
     }
 }
@@ -5016,6 +5015,7 @@ pub fn ty_sort_string<'tcx>(cx: &ctxt<'tcx>, ty: Ty<'tcx>) -> String {
         ty_infer(FloatVar(_)) => "floating-point variable".to_string(),
         ty_infer(FreshTy(_)) => "skolemized type".to_string(),
         ty_infer(FreshIntTy(_)) => "skolemized integral type".to_string(),
+        ty_infer(FreshFloatTy(_)) => "skolemized floating-point type".to_string(),
         ty_projection(_) => "associated type".to_string(),
         ty_param(ref p) => {
             if p.space == subst::SelfSpace {

--- a/src/librustc/middle/ty_match.rs
+++ b/src/librustc/middle/ty_match.rs
@@ -67,7 +67,8 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Match<'a, 'tcx> {
 
         match (&a.sty, &b.sty) {
             (_, &ty::ty_infer(ty::FreshTy(_))) |
-            (_, &ty::ty_infer(ty::FreshIntTy(_))) => {
+            (_, &ty::ty_infer(ty::FreshIntTy(_))) |
+            (_, &ty::ty_infer(ty::FreshFloatTy(_))) => {
                 Ok(a)
             }
 

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -349,7 +349,8 @@ pub fn ty_to_string<'tcx>(cx: &ctxt<'tcx>, typ: &ty::TyS<'tcx>) -> String {
             ty::FloatVar(ref vid) if print_var_ids => vid.repr(cx),
             ty::TyVar(_) | ty::IntVar(_) | ty::FloatVar(_) => format!("_"),
             ty::FreshTy(v) => format!("FreshTy({})", v),
-            ty::FreshIntTy(v) => format!("FreshIntTy({})", v)
+            ty::FreshIntTy(v) => format!("FreshIntTy({})", v),
+            ty::FreshFloatTy(v) => format!("FreshFloatTy({})", v)
         }
     }
 

--- a/src/test/compile-fail/issue-22645.rs
+++ b/src/test/compile-fail/issue-22645.rs
@@ -1,0 +1,29 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::ops::Add;
+
+trait Scalar {}
+impl Scalar for f64 {}
+
+struct Bob;
+
+impl<RHS: Scalar> Add <RHS> for Bob {
+  type Output = Bob;
+  fn add(self, rhs : RHS) -> Bob {}
+}
+
+fn main() {
+  let b = Bob + 3.5;
+  b + 3 //~ ERROR: is not implemented
+  //~^ ERROR: is not implemented
+  //~^^ ERROR: is not implemented
+  //~^^^ ERROR: mismatched types
+}

--- a/src/test/compile-fail/issue-24352.rs
+++ b/src/test/compile-fail/issue-24352.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    1.0f64 - 1.0;
+    1.0f64 - 1 //~ ERROR: is not implemented
+    //~^ ERROR: is not implemented
+}

--- a/src/test/run-pass/issue-23825.rs
+++ b/src/test/run-pass/issue-23825.rs
@@ -1,0 +1,30 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Stringify {
+    fn to_string(&self) -> String;
+}
+
+impl Stringify for u32 {
+    fn to_string(&self) -> String { format!("u32: {}", *self) }
+}
+
+impl Stringify for f32 {
+    fn to_string(&self) -> String { format!("f32: {}", *self) }
+}
+
+fn print<T: Stringify>(x: T) -> String {
+    x.to_string()
+}
+
+fn main() {
+    assert_eq!(&print(5), "u32: 5");
+    assert_eq!(&print(5.0), "f32: 5");
+}


### PR DESCRIPTION
There is no subtyping relationship between the types (or their non-freshened
variants), so they can not be merged.

Fixes #22645
Fixes #24352
Fixes #23825

Fixes #25235 (no test in issue).
Fixes #19976 (test is outdated).
Fixes #18623.
Fixes #18954 
Fixes #23722
Fixes #24138
