### PR TITLE
Markdown formatting for error explanations.

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -427,8 +427,8 @@ be taken.
 
 E0271: r##"
 This is because of a type mismatch between the associated type of some
-trait (e.g. T::Bar, where T implements trait Quux { type Bar; })
-and another type U that is required to be equal to T::Bar, but is not.
+trait (e.g. `T::Bar`, where `T` implements `trait Quux { type Bar; }`)
+and another type `U` that is required to be equal to `T::Bar`, but is not.
 Examples follow.
 
 Here is a basic example:

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -20,6 +20,7 @@ Imports (`use` statements) are not allowed after non-item statements, such as
 variable declarations and expression statements.
 
 Here is an example that demonstrates the error:
+
 ```
 fn f() {
     // Variable declaration before import
@@ -33,6 +34,7 @@ The solution is to declare the imports at the top of the block, function, or
 file.
 
 Here is the previous example again, with the correct order:
+
 ```
 fn f() {
     use std::io::Read;
@@ -52,6 +54,7 @@ The name chosen for an external crate conflicts with another external crate that
 has been imported into the current module.
 
 Wrong example:
+
 ```
 extern crate a;
 extern crate crate_a as a;
@@ -61,6 +64,7 @@ The solution is to choose a different name that doesn't conflict with any
 external crate imported into the current module.
 
 Correct example:
+
 ```
 extern crate a;
 extern crate crate_a as other_name;
@@ -71,6 +75,7 @@ E0260: r##"
 The name for an item declaration conflicts with an external crate's name.
 
 For instance,
+
 ```
 extern crate abc;
 


### PR DESCRIPTION
Reading through the rendered error explanations in http://doc.rust-lang.org/error-index.html, I noticed a few opportunities to improve the output.
