### PR TITLE
(do not check in yet) Delete json error metadata for a crate if it is out-of-date.

### DIFF
--- a/mk/target.mk
+++ b/mk/target.mk
@@ -151,6 +151,20 @@ $$(TLIB$(1)_T_$(2)_H_$(3))/%: $$(RT_OUTPUT_DIR_$(2))/% \
 	$$(Q)cp $$< $$@
 endef
 
+ERROR_METADATA_DIR:="tmp/extended-errors"
+
+define TARGET_HOST_RUSTC_CRATE
+# This is solely adding a dependency to ensure that we do the
+# appropriate check for each rustc crate that its associated error
+# diagnostics data has not become stale.
+$$(TLIB$(1)_T_$(2)_H_$(3))/stamp.syntax: $$(TLIB$(1)_T_$(2)_H_$(3))/stamp.meta.$(4).check-ext-errors
+
+$$(TLIB$(1)_T_$(2)_H_$(3))/stamp.meta.$(4).check-ext-errors: $$(RSINPUTS_$(4))
+	$(CFG_SRC_DIR)src/etc/check-error-metadata.py $(ERROR_METADATA_DIR)/lib$(4).json $$(RSINPUTS_$(4))
+	touch $$@
+endef
+
+
 $(foreach source,$(CFG_HOST), \
  $(foreach target,$(CFG_TARGET), \
   $(eval $(call TARGET_HOST_RULES,0,$(target),$(source))) \
@@ -166,6 +180,14 @@ $(foreach crate,$(CRATES), \
    $(eval $(call RUST_TARGET_STAGE_N,1,$(target),$(source),$(crate))) \
    $(eval $(call RUST_TARGET_STAGE_N,2,$(target),$(source),$(crate))) \
    $(eval $(call RUST_TARGET_STAGE_N,3,$(target),$(source),$(crate))))))
+
+$(foreach crate,$(RUSTC_CRATES), \
+ $(foreach source,$(CFG_HOST), \
+  $(foreach target,$(CFG_TARGET), \
+   $(eval $(call TARGET_HOST_RUSTC_CRATE,0,$(target),$(source),$(crate))) \
+   $(eval $(call TARGET_HOST_RUSTC_CRATE,1,$(target),$(source),$(crate))) \
+   $(eval $(call TARGET_HOST_RUSTC_CRATE,2,$(target),$(source),$(crate))) \
+   $(eval $(call TARGET_HOST_RUSTC_CRATE,3,$(target),$(source),$(crate))))))
 
 $(foreach host,$(CFG_HOST), \
  $(foreach target,$(CFG_TARGET), \

--- a/src/etc/check-error-metadata.py
+++ b/src/etc/check-error-metadata.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#
+# Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# This script takes n+1 arguments. The first argument is a path to the
+# serialized error metadata file (usually a json file, though that
+# does not actually matter here). The rest of the arguments are the
+# paths to source files that we generate the error metadata file.
+#
+# If any of the source files are newer than the error metadata file,
+# then we *delete* the error metadata file. The driving assumption is
+# that it will be regenerated during the subsequent make-driven build.
+#
+# It is not an error if any of the files do not exist; they are simply
+# left out of the comparison in that case.
+
+import os
+import sys
+
+if __name__ == '__main__':
+    metadata = sys.argv[1]
+    # print "Running %s on metadata %s" % (sys.argv[0], metadata)
+    if not os.path.exists(metadata):
+        # print "Skipping metadata %s; does not exist" % metadata
+        sys.exit(0)
+    metadata_mtime = os.path.getmtime(metadata);
+    source_files = sys.argv[2:]
+    for f in source_files:
+        if not os.path.exists(f):
+            # print "Skipping comparison with %s since latter does not exist" % f
+            continue
+        f_mtime = os.path.getmtime(f);
+        # print("Comparing %s against %s" % (f, metadata))
+        # print("time (%d) against time (%d)" % (f_mtime, metadata_mtime))
+        if f_mtime > metadata_mtime:
+            print "Removing %s since %s is newer" % (metadata, f)
+            os.remove(metadata)
+        sys.exit(0)


### PR DESCRIPTION
Delete json error metadata for a crate if it is out-of-date.

I could not figure out a good way to encode this solely in makefile rules. Even the approach here is pretty ad-hoc; it is heavily relying on the fact that all rustc crates (and thus all the json files that compiling such crates would generate on the side) have to wait for `libsyntax` to be built before they can be compiled, and thus it should be sound to make this check a prereq for the `stamp.syntax`.

(At least, that is what I hope.)

Fix #25364
