### PR TITLE
rustc_typeck: export modules and fields for sub-passes.

### DIFF
--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -117,13 +117,13 @@ use std::cell::RefCell;
 // registered before they are used.
 pub mod diagnostics;
 
-mod check;
+pub mod check;
 mod rscope;
 mod astconv;
-mod collect;
+pub mod collect;
 mod constrained_type_params;
-mod coherence;
-mod variance;
+pub mod coherence;
+pub mod variance;
 
 pub struct TypeAndSubsts<'tcx> {
     pub substs: subst::Substs<'tcx>,
@@ -132,13 +132,13 @@ pub struct TypeAndSubsts<'tcx> {
 
 pub struct CrateCtxt<'a, 'tcx: 'a> {
     // A mapping from method call sites to traits that have that method.
-    trait_map: ty::TraitMap,
+    pub trait_map: ty::TraitMap,
     /// A vector of every trait accessible in the whole crate
     /// (i.e. including those from subcrates). This is used only for
     /// error reporting, and so is lazily initialised and generally
     /// shouldn't taint the common path (hence the RefCell).
-    all_traits: RefCell<Option<check::method::AllTraitsVec>>,
-    tcx: &'a ty::ctxt<'tcx>,
+    pub all_traits: RefCell<Option<check::method::AllTraitsVec>>,
+    pub tcx: &'a ty::ctxt<'tcx>,
 }
 
 // Functions that write types into the node type table


### PR DESCRIPTION
Needed for driving parts of type-checking manually.
