### PR TITLE
Move configuration 1 phase before crate metadata collection

### DIFF
--- a/src/test/auxiliary/crate-attributes-using-cfg_attr.rs
+++ b/src/test/auxiliary/crate-attributes-using-cfg_attr.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+// compile-flags: --cfg foo
+
+#![cfg_attr(foo, crate_type="lib")]
+
+pub fn foo() {}

--- a/src/test/run-pass/crate-attributes-using-cfg_attr.rs
+++ b/src/test/run-pass/crate-attributes-using-cfg_attr.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:crate-attributes-using-cfg_attr.rs
+
+extern crate crate_attributes_using_cfg_attr;
+
+pub fn main() {}


### PR DESCRIPTION
Stripping unconfigured items prior to collecting crate metadata means we
can say things like `#![cfg_attr(foo, crate_type="lib")]`.

Fixes #25347.
