### PR TITLE
trpl-docs: Specify correct type of variable binding

### DIFF
--- a/src/doc/trpl/while-loops.md
+++ b/src/doc/trpl/while-loops.md
@@ -3,7 +3,7 @@
 Rust also has a `while` loop. It looks like this:
 
 ```{rust}
-let mut x = 5; // mut x: u32
+let mut x = 5; // mut x: i32
 let mut done = false; // mut done: bool
 
 while !done {


### PR DESCRIPTION
This PR fixes a comment in the `while Loops` section of the Rust book with the correct type of a variable binding.
