### PR TITLE
std::io: new ErrorKind value InvalidParam

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -898,7 +898,7 @@ pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
     let from = from.as_ref();
     let to = to.as_ref();
     if !from.is_file() {
-        return Err(Error::new(ErrorKind::InvalidInput,
+        return Err(Error::new(ErrorKind::InvalidParam,
                               "the source path is not an existing file"))
     }
 

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -74,7 +74,7 @@ macro_rules! seek {
             };
 
             if pos < 0 {
-                Err(Error::new(ErrorKind::InvalidInput,
+                Err(Error::new(ErrorKind::InvalidParam,
                                "invalid seek to a negative position"))
             } else {
                 self.pos = pos as u64;

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -94,6 +94,9 @@ pub enum ErrorKind {
     WouldBlock,
     /// A parameter was incorrect.
     #[stable(feature = "rust1", since = "1.0.0")]
+    InvalidParam,
+    /// Invalid data were encountered in an I/O operation.
+    #[stable(feature = "rust1", since = "1.0.0")]
     InvalidInput,
     /// The I/O operation's timeout expired, causing it to be canceled.
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -433,7 +433,7 @@ impl ToSocketAddrs for str {
             ($e:expr, $msg:expr) => (
                 match $e {
                     Some(r) => r,
-                    None => return Err(io::Error::new(io::ErrorKind::InvalidInput,
+                    None => return Err(io::Error::new(io::ErrorKind::InvalidParam,
                                                       $msg)),
                 }
             )

--- a/src/libstd/net/mod.rs
+++ b/src/libstd/net/mod.rs
@@ -77,7 +77,7 @@ fn each_addr<A: ToSocketAddrs, F, T>(addr: A, mut f: F) -> io::Result<T>
         }
     }
     Err(last_err.unwrap_or_else(|| {
-        Error::new(ErrorKind::InvalidInput,
+        Error::new(ErrorKind::InvalidParam,
                    "could not resolve to any addresses")
     }))
 }

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -292,7 +292,7 @@ mod tests {
         match TcpStream::connect("0.0.0.0:1") {
             Ok(..) => panic!(),
             Err(e) => assert!(e.kind() == ErrorKind::ConnectionRefused ||
-                              e.kind() == ErrorKind::InvalidInput ||
+                              e.kind() == ErrorKind::InvalidParam ||
                               e.kind() == ErrorKind::AddrInUse ||
                               e.kind() == ErrorKind::AddrNotAvailable,
                               "bad error: {} {:?}", e, e.kind()),

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -75,7 +75,7 @@ impl UdpSocket {
                                      -> io::Result<usize> {
         match try!(addr.to_socket_addrs()).next() {
             Some(addr) => self.0.send_to(buf, &addr),
-            None => Err(Error::new(ErrorKind::InvalidInput,
+            None => Err(Error::new(ErrorKind::InvalidParam,
                                    "no addresses to send data to")),
         }
     }

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -448,7 +448,7 @@ impl Child {
         // newer process that happens to have the same (re-used) id
         if self.status.is_some() {
             return Err(Error::new(
-                ErrorKind::InvalidInput,
+                ErrorKind::InvalidParam,
                 "invalid argument: can't kill an exited process",
             ))
         }

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -76,7 +76,7 @@ fn sockaddr_to_addr(storage: &libc::sockaddr_storage,
             })))
         }
         _ => {
-            Err(Error::new(ErrorKind::InvalidInput, "invalid argument"))
+            Err(Error::new(ErrorKind::InvalidParam, "invalid argument"))
         }
     }
 }

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -362,7 +362,7 @@ impl DirBuilder {
 
 fn cstr(path: &Path) -> io::Result<CString> {
     path.as_os_str().to_cstring().ok_or(
-        io::Error::new(io::ErrorKind::InvalidInput, "path contained a null"))
+        io::Error::new(io::ErrorKind::InvalidParam, "path contained a null"))
 }
 
 impl FromInner<c_int> for File {

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -60,7 +60,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         libc::EADDRINUSE => ErrorKind::AddrInUse,
         libc::ENOENT => ErrorKind::NotFound,
         libc::EINTR => ErrorKind::Interrupted,
-        libc::EINVAL => ErrorKind::InvalidInput,
+        libc::EINVAL => ErrorKind::InvalidParam,
         libc::ETIMEDOUT => ErrorKind::TimedOut,
         libc::consts::os::posix88::EEXIST => ErrorKind::AlreadyExists,
 

--- a/src/libstd/sys/windows/mod.rs
+++ b/src/libstd/sys/windows/mod.rs
@@ -56,7 +56,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         libc::WSAECONNABORTED => ErrorKind::ConnectionAborted,
         libc::WSAECONNREFUSED => ErrorKind::ConnectionRefused,
         libc::WSAECONNRESET => ErrorKind::ConnectionReset,
-        libc::WSAEINVAL => ErrorKind::InvalidInput,
+        libc::WSAEINVAL => ErrorKind::InvalidParam,
         libc::WSAENOTCONN => ErrorKind::NotConnected,
         libc::WSAEWOULDBLOCK => ErrorKind::WouldBlock,
 


### PR DESCRIPTION
Resolves rust-lang/rfcs#906.

This is an alternative to #25246, done at the suggestion by @bluss that preserving the `InvalidInput` error code in cases where invalid external data may be involved is better for minimizing impact of the change.
