### PR TITLE
rustc_back: Don't pass 'u' to ar invocations

### DIFF
--- a/src/librustc_back/archive.rs
+++ b/src/librustc_back/archive.rs
@@ -152,7 +152,7 @@ impl<'a> Archive<'a> {
                 cmd.arg("d").arg(dst).arg(file);
             }
             Action::AddObjects(objs, update_symbols) => {
-                cmd.arg(if update_symbols {"crus"} else {"cruS"})
+                cmd.arg(if update_symbols {"crs"} else {"crS"})
                    .arg(dst)
                    .args(objs);
             }

--- a/src/test/auxiliary/issue-18913-1.rs
+++ b/src/test/auxiliary/issue-18913-1.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "rlib"]
+#![crate_name = "foo"]
+
+pub fn foo() -> i32 { 0 }

--- a/src/test/auxiliary/issue-18913-2.rs
+++ b/src/test/auxiliary/issue-18913-2.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "rlib"]
+#![crate_name = "foo"]
+
+pub fn foo() -> i32 { 1 }

--- a/src/test/run-pass/issue-18913.rs
+++ b/src/test/run-pass/issue-18913.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-18913-1.rs
+// aux-build:issue-18913-2.rs
+
+extern crate foo;
+
+fn main() {
+    assert_eq!(foo::foo(), 1);
+}


### PR DESCRIPTION
This flag indicates that when files are being replaced or added to archives (the
`r` flag) that the new file should not be inserted if it is not newer than the
file that already exists in the archive. The compiler never actually has a use
case of _not_ wanting to insert a file because it already exists, and this
causes rlibs to not be updated in some cases when the compiler was re-run too
quickly.

Closes #18913
