### PR TITLE
Add #[inline] to Borrow<str>::borrow for String.

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -396,6 +396,7 @@ macro_rules! utf8_acc_cont_byte {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Borrow<str> for String {
+    #[inline]
     fn borrow(&self) -> &str { &self[..] }
 }
 


### PR DESCRIPTION
Every time I profile my code I find something new to add #[inline] to. (:
