### PR TITLE
TRPL: Remove Duplicate Reference

### DIFF
--- a/src/doc/trpl/const-and-static.md
+++ b/src/doc/trpl/const-and-static.md
@@ -31,8 +31,6 @@ static N: i32 = 5;
 
 Unlike [`let`][let] bindings, you must annotate the type of a `static`.
 
-[let]: variable-bindings.html
-
 Statics live for the entire lifetime of a program, and therefore any
 reference stored in a constant has a [`’static` lifetime][lifetimes]:
 

--- a/src/doc/trpl/const-and-static.md
+++ b/src/doc/trpl/const-and-static.md
@@ -32,7 +32,7 @@ static N: i32 = 5;
 Unlike [`let`][let] bindings, you must annotate the type of a `static`.
 
 Statics live for the entire lifetime of a program, and therefore any
-reference stored in a constant has a [`’static` lifetime][lifetimes]:
+reference stored in a constant has a [`'static` lifetime][lifetimes]:
 
 ```rust
 static NAME: &'static str = "Steve";


### PR DESCRIPTION
`[let]` was already defined in line 11. Pandoc shows a warning for this. I'm not sure if it's actually invalid Markdown.

r? @steveklabnik 
