### PR TITLE
Fix download links of Nightly Windows installers

### DIFF
--- a/src/doc/trpl/nightly-rust.md
+++ b/src/doc/trpl/nightly-rust.md
@@ -26,8 +26,8 @@ $ sh rustup.sh --channel=nightly
 If you're on Windows, please download either the [32-bit installer][win32] or
 the [64-bit installer][win64] and run it.
 
-[win32]: https://static.rust-lang.org/dist/rust-1.0.0-beta-i686-pc-windows-gnu.msi
-[win64]: https://static.rust-lang.org/dist/rust-1.0.0-beta-x86_64-pc-windows-gnu.msi
+[win32]: https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-gnu.msi
+[win64]: https://static.rust-lang.org/dist/rust-nightly-x86_64-pc-windows-gnu.msi
 
 ## Uninstalling
 


### PR DESCRIPTION
The download links of Windows installers on the Nightly Rust page are using beta builds instead of nightly builds, which caused some confusions when I was setting up my env. Probably it's better to use the links of nightly builds here.
