### PR TITLE
trpl: change from "int" to "i32" in Traits

### DIFF
--- a/src/doc/trpl/traits.md
+++ b/src/doc/trpl/traits.md
@@ -208,7 +208,7 @@ let result = f.write("whatever".as_bytes());
 
 This will compile without error.
 
-This means that even if someone does something bad like add methods to `int`,
+This means that even if someone does something bad like add methods to `i32`,
 it won’t affect you, unless you `use` that trait.
 
 There’s one more restriction on implementing traits. Either the trait or the


### PR DESCRIPTION
The Traits chapter uses "adding methods to `int`" as an example of "something bad", but there is no such thing as `int` anymore, right? So I changed it to `i32`.
