### PR TITLE
std: Make abs() panic on overflow in debug mode

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -563,13 +563,22 @@ macro_rules! int_impl {
             acc
         }
 
-        /// Computes the absolute value of `self`. `Int::min_value()` will be
-        /// returned if the number is `Int::min_value()`.
+        /// Computes the absolute value of `self`.
+        ///
+        /// # Overflow behavior
+        ///
+        /// The absolute value of `i32::min_value()` cannot be represented as an
+        /// `i32`, and attempting to calculate it will cause an overflow. This
+        /// means that code in debug mode will trigger a panic on this case and
+        /// optimized code will return `i32::min_value()` without a panic.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
         pub fn abs(self) -> $T {
             if self.is_negative() {
-                self.wrapping_neg()
+                // Note that the #[inline] above means that the overflow
+                // semantics of this negation depend on the crate we're being
+                // inlined into.
+                -self
             } else {
                 self
             }

--- a/src/test/run-pass/int-abs-overflow.rs
+++ b/src/test/run-pass/int-abs-overflow.rs
@@ -1,0 +1,21 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -Z force-overflow-checks=on
+
+use std::thread;
+
+fn main() {
+    assert!(thread::spawn(|| i8::min_value().abs()).join().is_err());
+    assert!(thread::spawn(|| i16::min_value().abs()).join().is_err());
+    assert!(thread::spawn(|| i32::min_value().abs()).join().is_err());
+    assert!(thread::spawn(|| i64::min_value().abs()).join().is_err());
+    assert!(thread::spawn(|| isize::min_value().abs()).join().is_err());
+}


### PR DESCRIPTION
Debug overflow checks for arithmetic negation landed in #24500, at which time
the `abs` method on signed integers was changed to using `wrapping_neg` to
ensure that the function never panicked. This implied that `abs` of `INT_MIN`
would return `INT_MIN`, another negative value. When this change was back-ported
to beta, however, in #24708, the `wrapping_neg` function had not yet been
backported, so the implementation was changed in #24785 to `!self + 1`. This
change had the unintended side effect of enabling debug overflow checks for the
`abs` function. Consequently, the current state of affairs is that the beta
branch checks for overflow in debug mode for `abs` and the nightly branch does
not.

This commit alters the behavior of nightly to have `abs` always check for
overflow in debug mode. This change is more consistent with the way the standard
library treats overflow as well, and it is also not a breaking change as it's
what the beta branch currently does (albeit if by accident).

cc #25378
