### PR TITLE
Make description of Borrow trait uses match the example.

### DIFF
--- a/src/doc/trpl/borrow-and-asref.md
+++ b/src/doc/trpl/borrow-and-asref.md
@@ -47,9 +47,9 @@ This is because the standard library has `impl Borrow<str> for String`.
 
 For most types, when you want to take an owned or borrowed type, a `&T` is
 enough. But one area where `Borrow` is effective is when there’s more than one
-kind of borrowed value. Slices are an area where this is especially true: you
-can have both an `&[T]` or a `&mut [T]`. If we wanted to accept both of these
-types, `Borrow` is up for it:
+kind of borrowed value. This is especially true of references and slices: you
+can have both an `&T` or a `&mut T`. If we wanted to accept both of these types,
+`Borrow` is up for it:
 
 ```
 use std::borrow::Borrow;


### PR DESCRIPTION
Minor tweak: the text explaining the Borrow trait talks about slices, but the example immediately following just uses a simple reference; there are no slices involved.

r? @steveklabnik
