### PR TITLE
Fix link to C++ FQA

### DIFF
--- a/src/doc/complement-design-faq.md
+++ b/src/doc/complement-design-faq.md
@@ -79,7 +79,7 @@ feature.
 A nice replacement is the [lazy constructor macro][lcm] by [Marvin
 Löbel][kim].
 
-[fqa]: https://mail.mozilla.org/pipermail/rust-dev/2013-April/003815.html
+[fqa]: http://yosefk.com/c++fqa/ctors.html#fqa-10.12
 [elp]: http://ericlippert.com/2013/02/06/static-constructors-part-one/
 [lcm]: https://gist.github.com/Kimundi/8782487
 [kim]: https://github.com/Kimundi


### PR DESCRIPTION
Fix the link to the "static initialization order fiasco" discussion in the C++ Frequently Questioned Answers.

At present the link points to a mail message summarizing the decision not to have resumable exceptions, but the FAQ means to refer to a discussion of the "static initialization order fiasco". I've made my best guess at what it meant to refer to.
