### PR TITLE
Optimize &Iterator::nth

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1127,6 +1127,7 @@ impl<'a, I: Iterator + ?Sized> Iterator for &'a mut I {
     type Item = I::Item;
     fn next(&mut self) -> Option<I::Item> { (**self).next() }
     fn size_hint(&self) -> (usize, Option<usize>) { (**self).size_hint() }
+    fn nth(&mut self, n: usize) -> Option<I::Item> { (**self).nth(n) }
 }
 
 /// Conversion from an `Iterator`

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -161,7 +161,7 @@ pub trait Iterator {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn nth(&mut self, mut n: usize) -> Option<Self::Item> where Self: Sized {
-        for x in self.by_ref() {
+        for x in self {
             if n == 0 { return Some(x) }
             n -= 1;
         }
@@ -636,7 +636,7 @@ pub trait Iterator {
     fn all<F>(&mut self, mut f: F) -> bool where
         Self: Sized, F: FnMut(Self::Item) -> bool
     {
-        for x in self.by_ref() {
+        for x in self {
             if !f(x) {
                 return false;
             }
@@ -663,7 +663,7 @@ pub trait Iterator {
         Self: Sized,
         F: FnMut(Self::Item) -> bool
     {
-        for x in self.by_ref() {
+        for x in self {
             if f(x) {
                 return true;
             }
@@ -688,7 +688,7 @@ pub trait Iterator {
         Self: Sized,
         P: FnMut(&Self::Item) -> bool,
     {
-        for x in self.by_ref() {
+        for x in self {
             if predicate(&x) { return Some(x) }
         }
         None
@@ -724,7 +724,7 @@ pub trait Iterator {
         P: FnMut(Self::Item) -> bool,
     {
         // `enumerate` might overflow.
-        for (i, x) in self.by_ref().enumerate() {
+        for (i, x) in self.enumerate() {
             if predicate(x) {
                 return Some(i);
             }

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -160,7 +160,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn nth(&mut self, mut n: usize) -> Option<Self::Item> where Self: Sized {
+    fn nth(&mut self, mut n: usize) -> Option<Self::Item> {
         for x in self {
             if n == 0 { return Some(x) }
             n -= 1;

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -652,6 +652,20 @@ fn test_by_ref() {
 }
 
 #[test]
+fn test_by_ref_nth() {
+    let mut xs = 0..10;
+    let mut ys = 0..10;
+    let mut ysr = ys.by_ref();
+    loop {
+        match (xs.nth(2), ysr.nth(2)) {
+            (Some(x), Some(y)) => assert_eq!(x, y),
+            (None, None) => break,
+            _ => panic!("Both iterators should have finished at the same time."),
+        }
+    }
+}
+
+#[test]
 fn test_rev() {
     let xs = [2, 4, 6, 8, 10, 12, 14, 16];
     let mut it = xs.iter();


### PR DESCRIPTION
There are actually three changes here:
1. Remove unnecessary `by_ref` calls in the Iterator trait. I needed to remove the `by_ref` call from the `nth` method to make it object safe (`by_ref` isn't object safe) but I ended up removing all of them because they were pointless.
2. :warning: Make `nth` object safe. This changes `nth`'s signature but I'm nearly positive that this change can't break existing code (see the commit message).
3. Override `nth` on `by_ref` iterators to make it call though to `nth` on the underlying implementation (the type behind the reference). This way, if the underlying implementation provides an optimized `nth`, `by_ref` iterators can take advantage of it.

Part of #24214
