### PR TITLE
Correct two small typos in the Dining Philosophers example.

### DIFF
--- a/src/doc/trpl/dining-philosophers.md
+++ b/src/doc/trpl/dining-philosophers.md
@@ -320,7 +320,7 @@ from the standard library, and so we need to `use` it.
 We now print out two messages, with a `sleep_ms()` in the middle. This will
 simulate the time it takes a philosopher to eat.
 
-If you run this program, You should see each philosopher eat in turn:
+If you run this program, you should see each philosopher eat in turn:
 
 ```text
 Baruch Spinoza is eating.
@@ -480,7 +480,7 @@ struct Table {
 }
 ```
 
-This `Table` has an vector of `Mutex`es. A mutex is a way to control
+This `Table` has a vector of `Mutex`es. A mutex is a way to control
 concurrency: only one thread can access the contents at once. This is exactly
 the property we need with our forks. We use an empty tuple, `()`, inside the
 mutex, since we’re not actually going to use the value, just hold onto it.


### PR DESCRIPTION
This PR fixes two little typos in the Dining Philosophers example.

Also, there are two style points that may have been oversights but may have been deliberate, so I'll just bring them up here:

1) In the last paragraph, you say

> You’ll notice we can introduce a new binding to `table` here, and it will shadow the old one. This is often used so that you don’t need to come up with two unique names.

You already said something similar to this in the Guessing Game, but maybe you intended for this example to be independent of that one.

2) In "Rust Inside Other Languages," you introduce the idea of the "global interpreter lock" and then refer to it as the GIL a few paragraphs later without explicitly stating that GIL == global interpreter lock. It's reasonable to expect readers to make the connection, but maybe that's not what you intended.

Excellent work on the examples! Congrats on 1.0!

r? @steveklabnik
