### PR TITLE
fix #24968: more friend error message for `Self` in fn args

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2367,7 +2367,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                             maybe_qself.is_none() &&
                             path.segments[0].identifier.name == self_type_name;
                         let msg = if is_invalid_self_type_name {
-                            "use of Self outside of an impl".to_string()
+                            "use of `Self` outside of an impl or trait".to_string()
                         } else {
                             format!("use of undeclared {} `{}`",
                                 kind, path_names_to_string(path, 0))

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2361,8 +2361,18 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                             "type name"
                         };
 
-                        let msg = format!("use of undeclared {} `{}`", kind,
-                                          path_names_to_string(path, 0));
+                        let self_type_name = special_idents::type_self.name;
+                        let is_invalid_self_type_name =
+                            path.segments.len() > 0 &&
+                            maybe_qself.is_none() &&
+                            path.segments[0].identifier.name == self_type_name;
+                        let msg = if is_invalid_self_type_name {
+                            "expected type name, found keyword `Self`".to_string()
+                        } else {
+                            format!("use of undeclared {} `{}`",
+                                kind, path_names_to_string(path, 0))
+                        };
+
                         self.resolve_error(ty.span, &msg[..]);
                     }
                 }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2367,7 +2367,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                             maybe_qself.is_none() &&
                             path.segments[0].identifier.name == self_type_name;
                         let msg = if is_invalid_self_type_name {
-                            "expected type name, found keyword `Self`".to_string()
+                            "use of Self outside of an impl".to_string()
                         } else {
                             format!("use of undeclared {} `{}`",
                                 kind, path_names_to_string(path, 0))

--- a/src/test/compile-fail/issue-12796.rs
+++ b/src/test/compile-fail/issue-12796.rs
@@ -12,7 +12,7 @@ trait Trait {
     fn outer(self) {
         fn inner(_: Self) {
             //~^ ERROR can't use type parameters from outer function
-            //~^^ ERROR use of undeclared type name `Self`
+            //~^^ ERROR use of `Self` outside of an impl or trait
         }
     }
 }

--- a/src/test/compile-fail/issue-24968.rs
+++ b/src/test/compile-fail/issue-24968.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 fn foo(_: Self) {
-    //~^ ERROR use of `Self` outside of an impl or Trait
+    //~^ ERROR use of `Self` outside of an impl or trait
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-24968.rs
+++ b/src/test/compile-fail/issue-24968.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo(_: Self) {
+    //~^ ERROR use of `Self` outside of an impl or Trait
+}
+
+fn main() {}


### PR DESCRIPTION
fix #24968
report more friendly error message for Self when fn args
copy from https://github.com/rust-lang/rust/pull/25096
r? @nrc  @arielb1
