### PR TITLE
Clarify the error message for malformed `extern crate` statements

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5266,11 +5266,7 @@ impl<'a> Parser<'a> {
                 return Ok(Some(try!(self.parse_item_foreign_mod(lo, opt_abi, visibility, attrs))));
             }
 
-            let span = self.span;
-            let token_str = self.this_token_to_string();
-            return Err(self.span_fatal(span,
-                            &format!("expected `{}` or `fn`, found `{}`", "{",
-                                    token_str)))
+            try!(self.expect_one_of(&[], &[]));
         }
 
         if try!(self.eat_keyword_noexpect(keywords::Virtual) ){

--- a/src/test/parse-fail/extern-crate-unexpected-token.rs
+++ b/src/test/parse-fail/extern-crate-unexpected-token.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Z parse-only
-
-// Verifies that the expected token errors for `extern crate` are
-// raised
-
-extern "C" mod foo; //~ERROR expected one of `fn` or `{`, found `mod`
+extern crte foo; //~ ERROR expected one of `crate`, `fn`, or `{`, found `crte`


### PR DESCRIPTION
Closes #25468.
