### PR TITLE
std: Implement lowering and raising for process IO

### DIFF
--- a/src/libstd/sys/unix/ext/process.rs
+++ b/src/libstd/sys/unix/ext/process.rs
@@ -13,10 +13,11 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use os::unix::raw::{uid_t, gid_t};
+use os::unix::io::{FromRawFd, RawFd, AsRawFd};
 use prelude::v1::*;
 use process;
 use sys;
-use sys_common::{AsInnerMut, AsInner};
+use sys_common::{AsInnerMut, AsInner, FromInner};
 
 /// Unix-specific extensions to the `std::process::Command` builder
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -61,5 +62,51 @@ impl ExitStatusExt for process::ExitStatus {
             sys::process::ExitStatus::Signal(s) => Some(s),
             _ => None
         }
+    }
+}
+
+#[stable(feature = "from_raw_os", since = "1.1.0")]
+impl FromRawFd for process::Stdio {
+    /// Creates a new instance of `Stdio` from the raw underlying file
+    /// descriptor.
+    ///
+    /// When this `Stdio` is used as an I/O handle for a child process the given
+    /// file descriptor will be `dup`d into the destination file descriptor in
+    /// the child process.
+    ///
+    /// Note that this function **does not** take ownership of the file
+    /// descriptor provided and it will **not** be closed when `Stdio` goes out
+    /// of scope. As a result this method is unsafe because due to the lack of
+    /// knowledge about the lifetime of the provided file descriptor, this could
+    /// cause another I/O primitive's ownership property of its file descriptor
+    /// to be violated.
+    ///
+    /// Also note that this file descriptor may be used multiple times to spawn
+    /// processes. For example the `Command::spawn` function could be called
+    /// more than once to spawn more than one process sharing this file
+    /// descriptor.
+    unsafe fn from_raw_fd(fd: RawFd) -> process::Stdio {
+        process::Stdio::from_inner(sys::process::Stdio::Fd(fd))
+    }
+}
+
+#[stable(feature = "from_raw_os", since = "1.1.0")]
+impl AsRawFd for process::ChildStdin {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_inner().fd().raw()
+    }
+}
+
+#[stable(feature = "from_raw_os", since = "1.1.0")]
+impl AsRawFd for process::ChildStdout {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_inner().fd().raw()
+    }
+}
+
+#[stable(feature = "from_raw_os", since = "1.1.0")]
+impl AsRawFd for process::ChildStderr {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_inner().fd().raw()
     }
 }

--- a/src/libstd/sys/unix/pipe.rs
+++ b/src/libstd/sys/unix/pipe.rs
@@ -44,7 +44,6 @@ impl AnonPipe {
         self.0.write(buf)
     }
 
-    pub fn into_fd(self) -> FileDesc {
-        self.0
-    }
+    pub fn fd(&self) -> &FileDesc { &self.0 }
+    pub fn into_fd(self) -> FileDesc { self.0 }
 }

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -123,6 +123,7 @@ pub enum Stdio {
     Inherit,
     Piped(AnonPipe),
     None,
+    Fd(c_int),
 }
 
 const CLOEXEC_MSG_FOOTER: &'static [u8] = b"NOEX";
@@ -253,6 +254,7 @@ impl Process {
         let setup = |src: Stdio, dst: c_int| {
             let fd = match src {
                 Stdio::Inherit => return true,
+                Stdio::Fd(fd) => return cvt_r(|| libc::dup2(fd, dst)).is_ok(),
                 Stdio::Piped(pipe) => pipe.into_fd(),
 
                 // If a stdio file descriptor is set to be ignored, we open up
@@ -410,5 +412,16 @@ fn translate_status(status: c_int) -> ExitStatus {
         ExitStatus::Code(imp::WEXITSTATUS(status))
     } else {
         ExitStatus::Signal(imp::WTERMSIG(status))
+    }
+}
+
+impl Stdio {
+    pub fn clone_if_copy(&self) -> Stdio {
+        match *self {
+            Stdio::Inherit => Stdio::Inherit,
+            Stdio::None => Stdio::None,
+            Stdio::Fd(fd) => Stdio::Fd(fd),
+            Stdio::Piped(_) => unreachable!(),
+        }
     }
 }

--- a/src/libstd/sys/windows/ext/mod.rs
+++ b/src/libstd/sys/windows/ext/mod.rs
@@ -20,6 +20,7 @@ pub mod ffi;
 pub mod fs;
 pub mod io;
 pub mod raw;
+pub mod process;
 
 /// A prelude for conveniently writing platform-specific code.
 ///

--- a/src/libstd/sys/windows/ext/process.rs
+++ b/src/libstd/sys/windows/ext/process.rs
@@ -1,0 +1,69 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Extensions to `std::process` for Windows.
+
+#![stable(feature = "from_raw_os", since = "1.1.0")]
+
+use os::windows::io::{FromRawHandle, RawHandle, AsRawHandle};
+use process;
+use sys;
+use sys_common::{AsInner, FromInner};
+
+#[stable(feature = "from_raw_os", since = "1.1.0")]
+impl FromRawHandle for process::Stdio {
+    /// Creates a new instance of `Stdio` from the raw underlying handle.
+    ///
+    /// When this `Stdio` is used as an I/O handle for a child process the given
+    /// handle will be duplicated via `DuplicateHandle` to ensure that the
+    /// handle has the correct permissions to cross the process boundary.
+    ///
+    /// Note that this function **does not** take ownership of the handle
+    /// provided and it will **not** be closed when `Stdio` goes out of scope.
+    /// As a result this method is unsafe because due to the lack of knowledge
+    /// about the lifetime of the provided handle, this could cause another I/O
+    /// primitive's ownership property of its handle to be violated.
+    ///
+    /// Also note that this handle may be used multiple times to spawn
+    /// processes. For example the `Command::spawn` function could be called
+    /// more than once to spawn more than one process sharing this handle.
+    unsafe fn from_raw_handle(handle: RawHandle) -> process::Stdio {
+        let handle = sys::handle::RawHandle::new(handle as *mut _);
+        process::Stdio::from_inner(sys::process::Stdio::Handle(handle))
+    }
+}
+
+#[stable(feature = "from_raw_os", since = "1.1.0")]
+impl AsRawHandle for process::Child {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.as_inner().handle().raw() as *mut _
+    }
+}
+
+#[stable(feature = "from_raw_os", since = "1.1.0")]
+impl AsRawHandle for process::ChildStdin {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.as_inner().handle().raw() as *mut _
+    }
+}
+
+#[stable(feature = "from_raw_os", since = "1.1.0")]
+impl AsRawHandle for process::ChildStdout {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.as_inner().handle().raw() as *mut _
+    }
+}
+
+#[stable(feature = "from_raw_os", since = "1.1.0")]
+impl AsRawHandle for process::ChildStderr {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.as_inner().handle().raw() as *mut _
+    }
+}

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -27,7 +27,7 @@ use ptr;
 use sync::{StaticMutex, MUTEX_INIT};
 use sys::c;
 use sys::fs::{OpenOptions, File};
-use sys::handle::Handle;
+use sys::handle::{Handle, RawHandle};
 use sys::pipe::AnonPipe;
 use sys::stdio;
 use sys::{self, cvt};
@@ -109,6 +109,7 @@ pub enum Stdio {
     Inherit,
     Piped(AnonPipe),
     None,
+    Handle(RawHandle),
 }
 
 impl Process {
@@ -211,6 +212,8 @@ impl Process {
             }
         }
     }
+
+    pub fn handle(&self) -> &Handle { &self.handle }
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -347,6 +350,15 @@ fn make_dirp(d: Option<&OsString>) -> (*const u16, Vec<u16>) {
 }
 
 impl Stdio {
+    pub fn clone_if_copy(&self) -> Stdio {
+        match *self {
+            Stdio::Inherit => Stdio::Inherit,
+            Stdio::None => Stdio::None,
+            Stdio::Handle(handle) => Stdio::Handle(handle),
+            Stdio::Piped(_) => unreachable!(),
+        }
+    }
+
     fn to_handle(&self, stdio_id: libc::DWORD) -> io::Result<Handle> {
         use libc::DUPLICATE_SAME_ACCESS;
 
@@ -355,6 +367,9 @@ impl Stdio {
                 stdio::get(stdio_id).and_then(|io| {
                     io.handle().duplicate(0, true, DUPLICATE_SAME_ACCESS)
                 })
+            }
+            Stdio::Handle(ref handle) => {
+                handle.duplicate(0, true, DUPLICATE_SAME_ACCESS)
             }
             Stdio::Piped(ref pipe) => {
                 pipe.handle().duplicate(0, true, DUPLICATE_SAME_ACCESS)


### PR DESCRIPTION
This commit implements a number of standard traits for the standard library's
process I/O handles. The `FromRaw{Fd,Handle}` traits are now implemented for the
`Stdio` type and the `AsRaw{Fd,Handle}` traits are now implemented for the
`Child{Stdout,Stdin,Stderr}` types.

The stability markers for these implementations mention that they are stable for
1.1 as I will nominate this commit for cherry-picking to beta.
