### PR TITLE
std: Add an unstable method Child::id

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -456,6 +456,12 @@ impl Child {
         unsafe { self.handle.kill() }
     }
 
+    /// Returns the OS-assigned process identifier associated with this child.
+    #[unstable(feature = "process_id", reason = "api recently added")]
+    pub fn id(&self) -> u32 {
+        self.handle.id()
+    }
+
     /// Waits for the child to exit completely, returning the status that it
     /// exited with. This function will continue to have the same return value
     /// after it has been called at least once.

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -315,6 +315,10 @@ impl Process {
         fail(&mut output)
     }
 
+    pub fn id(&self) -> u32 {
+        self.pid as u32
+    }
+
     pub fn wait(&self) -> io::Result<ExitStatus> {
         let mut status = 0 as c_int;
         try!(cvt_r(|| unsafe { c::waitpid(self.pid, &mut status, 0) }));

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -482,6 +482,7 @@ extern "system" {
                                dwMilliseconds: libc::DWORD) -> libc::DWORD;
     pub fn SwitchToThread() -> libc::BOOL;
     pub fn Sleep(dwMilliseconds: libc::DWORD);
+    pub fn GetProcessId(handle: libc::HANDLE) -> libc::DWORD;
 }
 
 #[link(name = "userenv")]

--- a/src/libstd/sys/windows/process.rs
+++ b/src/libstd/sys/windows/process.rs
@@ -193,6 +193,12 @@ impl Process {
         Ok(())
     }
 
+    pub fn id(&self) -> u32 {
+        unsafe {
+            c::GetProcessId(self.handle.raw()) as u32
+        }
+    }
+
     pub fn wait(&self) -> io::Result<ExitStatus> {
         use libc::{STILL_ACTIVE, INFINITE, WAIT_OBJECT_0};
         use libc::{GetExitCodeProcess, WaitForSingleObject};


### PR DESCRIPTION
This commits adds a method to the `std::process` module to get the process
identifier of the child as a `u32`. On Windows the underlying identifier is
already a `u32`, and on Unix the type is typically defined as `c_int` (`i32` for
almost all our supported platforms), but the actually pid is normally a small
positive number.

Eventually we may add functions to load information about a process based on its
identifier or the ability to terminate a process based on its identifier, but
for now this function should enable this sort of functionality to exist outside
the standard library.
