### PR TITLE
std: Fix missing stability on iter::Cloned

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -1370,7 +1370,7 @@ impl<T: Clone> MinMaxResult<T> {
 }
 
 /// An iterator that clones the elements of an underlying iterator
-#[unstable(feature = "core", reason = "recent addition")]
+#[stable(feature = "iter_cloned", since = "1.1.0")]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
 pub struct Cloned<I> {


### PR DESCRIPTION
The method was stabilized but the structure was forgotten to be stabilized.

Closes #25480
