### PR TITLE
Avoid calling a variable 'string' when discussing strings.

### DIFF
--- a/src/doc/trpl/strings.md
+++ b/src/doc/trpl/strings.md
@@ -16,11 +16,11 @@ Rust has two main types of strings: `&str` and `String`. Let’s talk about
 `&'static str`:
 
 ```rust
-let string = "Hello there."; // string: &'static str
+let greeting = "Hello there."; // greeting: &'static str
 ```
 
 This string is statically allocated, meaning that it’s saved inside our
-compiled program, and exists for the entire duration it runs. The `string`
+compiled program, and exists for the entire duration it runs. The `greeting`
 binding is a reference to this statically allocated string. String slices
 have a fixed size, and cannot be mutated.
 


### PR DESCRIPTION
Newcomers to Rust need to learn the distinctinion between `&str` and
`String`, so additonally having `string` in an example risks confusion.
