### PR TITLE
fs::walk_dir example without unstable features

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1099,20 +1099,19 @@ pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// # Examples
 ///
 /// ```
-/// # #![feature(path_ext)]
 /// use std::io;
-/// use std::fs::{self, PathExt, DirEntry};
+/// use std::fs::{self, DirEntry};
 /// use std::path::Path;
 ///
 /// // one possible implementation of fs::walk_dir only visiting files
-/// fn visit_dirs(dir: &Path, cb: &mut FnMut(DirEntry)) -> io::Result<()> {
-///     if dir.is_dir() {
+/// fn visit_dirs(dir: &Path, cb: &Fn(&DirEntry)) -> io::Result<()> {
+///     if try!(fs::metadata(dir)).is_dir() {
 ///         for entry in try!(fs::read_dir(dir)) {
 ///             let entry = try!(entry);
-///             if entry.path().is_dir() {
+///             if try!(fs::metadata(entry.path())).is_dir() {
 ///                 try!(visit_dirs(&entry.path(), cb));
 ///             } else {
-///                 cb(entry);
+///                 cb(&entry);
 ///             }
 ///         }
 ///     }


### PR DESCRIPTION
The current version of the example won't compile due to unstable features.
This is an attempt to fix that, at the cost of slightly more verbose code.

Using rust 1.0.0 (a59de37e9).

It might be obvious, but I'm not well versed with rust, so feedback is very welcome.
