### PR TITLE
Fixed reserve_exact example

### DIFF
--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -433,7 +433,7 @@ impl String {
     ///
     /// ```
     /// let mut s = String::new();
-    /// s.reserve(10);
+    /// s.reserve_exact(10);
     /// assert!(s.capacity() >= 10);
     /// ```
     #[inline]


### PR DESCRIPTION
The same example for `reserve` were in the `reserve_exact`'s example.
