### PR TITLE
Clarify macro backtraces

### DIFF
--- a/src/compiletest/errors.rs
+++ b/src/compiletest/errors.rs
@@ -94,5 +94,5 @@ fn parse_expected(last_nonfollow_error: Option<usize>,
     debug!("line={} which={:?} kind={:?} msg={:?}", line_num, which, kind, msg);
     Some((which, ExpectedError { line: line,
                                  kind: kind,
-                                 msg: msg, }))
+                                 msg: msg }))
 }

--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -998,9 +998,13 @@ fn check_expected_errors(expected_errors: Vec<errors::ExpectedError> ,
                         break;
                     }
                 }
-                if (prefix_matches(line, &prefixes[i]) || continuation(line)) &&
-                    line.contains(&ee.kind) &&
-                    line.contains(&ee.msg) {
+                if line.contains(&ee.kind) && (
+                       ee.msg.contains("<>") &&
+                       line.contains(&ee.msg.replace("<>", &prefixes[i].trim_right_matches(':')))
+                   ||
+                       (prefix_matches(line, &prefixes[i]) || continuation(line)) &&
+                       line.contains(&ee.msg)
+                ) {
                     found_flags[i] = true;
                     was_expected = true;
                     break;

--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -767,18 +767,24 @@ fn print_macro_backtrace(w: &mut EmitterWriter,
                 let ss = ei.callee.span.map_or(String::new(),
                                                |span| cm.span_to_string(span));
                 let (pre, post) = match ei.callee.format {
-                    codemap::MacroAttribute => ("#[", "]"),
-                    codemap::MacroBang => ("", "!"),
+                    codemap::MacroAttribute => ("`#[", "]`"),
+                    codemap::MacroBang => ("`", "!`"),
                     codemap::CompilerExpansion => ("", ""),
                 };
-                try!(print_diagnostic(w, &ss, Note,
-                                      &format!("in expansion of {}{}{}",
+                try!(print_diagnostic(w, "", Note,
+                                      &format!("in expansion of {}{}{}{}",
                                                pre,
                                                ei.callee.name,
-                                               post),
+                                               post,
+                                               if ss.is_empty() { "".into() } else {
+                                                   format!(", defined at {}", ss)
+                                               }),
                                       None));
                 let ss = cm.span_to_string(ei.call_site);
-                try!(print_diagnostic(w, &ss, Note, "expansion site", None));
+                try!(print_diagnostic(w, "", Note,
+                                      &format!("expansion site: {}",
+                                               ss),
+                                      None));
                 Ok(Some(ei.call_site))
             }
             None => Ok(None)

--- a/src/test/compile-fail/macro-backtrace-invalid-internals.rs
+++ b/src/test/compile-fail/macro-backtrace-invalid-internals.rs
@@ -10,25 +10,25 @@
 
 // Macros in statement vs expression position handle backtraces differently.
 
-macro_rules! fake_method_stmt { //~ NOTE in expansion of
+macro_rules! fake_method_stmt { //~ NOTE in expansion of `fake_method_stmt!`, defined at <>
      () => {
           1.fake() //~ ERROR no method named `fake` found
      }
 }
 
-macro_rules! fake_field_stmt { //~ NOTE in expansion of
+macro_rules! fake_field_stmt { //~ NOTE in expansion of `fake_field_stmt!`, defined at <>
      () => {
           1.fake //~ ERROR no field with that name
      }
 }
 
-macro_rules! fake_anon_field_stmt { //~ NOTE in expansion of
+macro_rules! fake_anon_field_stmt { //~ NOTE in expansion of `fake_anon_field_stmt!`, defined at <>
      () => {
           (1).0 //~ ERROR type was not a tuple
      }
 }
 
-macro_rules! fake_method_expr { //~ NOTE in expansion of
+macro_rules! fake_method_expr { //~ NOTE in expansion of `fake_method_expr!`, defined at <>
      () => {
           1.fake() //~ ERROR no method named `fake` found
      }
@@ -47,11 +47,11 @@ macro_rules! fake_anon_field_expr {
 }
 
 fn main() {
-    fake_method_stmt!(); //~ NOTE expansion site
-    fake_field_stmt!(); //~ NOTE expansion site
-    fake_anon_field_stmt!(); //~ NOTE expansion site
+    fake_method_stmt!(); //~ NOTE expansion site: <>
+    fake_field_stmt!(); //~ NOTE expansion site: <>
+    fake_anon_field_stmt!(); //~ NOTE expansion site: <>
 
-    let _ = fake_method_expr!(); //~ NOTE expansion site
+    let _ = fake_method_expr!(); //~ NOTE expansion site: <>
     let _ = fake_field_expr!(); //~ ERROR no field with that name
     let _ = fake_anon_field_expr!(); //~ ERROR type was not a tuple
 }

--- a/src/test/compile-fail/macro-backtrace-nested.rs
+++ b/src/test/compile-fail/macro-backtrace-nested.rs
@@ -19,11 +19,11 @@ macro_rules! call_nested_expr {
     () => (nested_expr!())
 }
 
-macro_rules! call_nested_expr_sum { //~ NOTE in expansion of
+macro_rules! call_nested_expr_sum { //~ NOTE in expansion of `call_nested_expr_sum!`, defined at <>
     () => { 1 + nested_expr!(); } //~ ERROR unresolved name
 }
 
 fn main() {
     1 + call_nested_expr!(); //~ ERROR unresolved name
-    call_nested_expr_sum!(); //~ NOTE expansion site
+    call_nested_expr_sum!(); //~ NOTE expansion site: <>
 }

--- a/src/test/compile-fail/macro-backtrace-println.rs
+++ b/src/test/compile-fail/macro-backtrace-println.rs
@@ -16,14 +16,14 @@
 
 fn print(_args: std::fmt::Arguments) {}
 
-macro_rules! myprint { //~ NOTE in expansion of
+macro_rules! myprint { //~ NOTE in expansion of `myprint!`, defined at <>
     ($($arg:tt)*) => (print(format_args!($($arg)*)));
 }
 
-macro_rules! myprintln { //~ NOTE in expansion of
+macro_rules! myprintln { //~ NOTE in expansion of `myprintln!`, defined at <>
     ($fmt:expr) => (myprint!(concat!($fmt, "\n"))); //~ ERROR invalid reference to argument `0`
 }
 
 fn main() {
-    myprintln!("{}"); //~ NOTE expansion site
+    myprintln!("{}"); //~ NOTE expansion site: <>
 }


### PR DESCRIPTION
Currently, macro backtraces look like this:

```
<anon>:4:10: 4:13 error: unresolved name `bar`
<anon>:4     foo!(bar);
                  ^~~
<anon>:1:1: 1:42 note: in expansion of foo!
<anon>:4:5: 4:15 note: expansion site
```

This is somewhat unclear, as it’s not immediately obvious where the expansion site or the definition of `foo!` is. This changes these backtraces to look like this:

```
<anon>:4:10: 4:13 error: unresolved name `bar`
<anon>:4     foo!(bar);
                  ^~~
note: in expansion of `foo!`, defined at <anon>:1:1: 1:42
note: expansion site: <anon>:4:5: 4:15
```

Since backtraces no longer outupt spans in the normal manner, this also modifies compiletest to support testing for span-less errors using `@` and `<>`; for example, to test for the backtrace above, one would write something like this:

``` rust
macro_rules! foo { ($e: expr) => { ... } } //~@ NOTE in expansion of `foo`, defined at <>
foo!(bar); //~ ERROR unresolved name `bar`
//~^@ NOTE expansion site: <>
```
