### PR TITLE
Revert "Panic if the grammar verifier sees a token it doesn't recognize"

### DIFF
--- a/src/grammar/verify.rs
+++ b/src/grammar/verify.rs
@@ -111,7 +111,7 @@ fn parse_token_list(file: &str) -> HashMap<String, token::Token> {
             "LIT_BINARY_RAW"    => token::Literal(token::BinaryRaw(Name(0), 0), None),
             "QUESTION"          => token::Question,
             "SHEBANG"           => token::Shebang(Name(0)),
-            _                   => panic!("Bad token str `{}`", val),
+            _                   => continue,
         };
 
         res.insert(num.to_string(), tok);


### PR DESCRIPTION
Hiiii soooo I'm trying to get the reference grammar and associated tests running again, and I swear I tested before but I must have had multiple things going on when I did, because the change I made in #25137 to verify.rs is totally wrong. The RustLexer.tokens file that antlr generates has two sections:

```
EQ=1
LT=2
LE=3
EQEQ=4
NE=5
...
COMMENT=56
SHEBANG=57
UTF8_BOM=58
'='=1
'<'=2
'<='=3
'=='=4
...
```

and verify.rs is only interested in the first half-- the `continue` is to ignore the second half. In 9c7d5ae, I made it panic instead. I was trying to make sure verify.rs handled everything that might happen in the first half and complain if it didn't. That would mean the reference grammar was out of sync with at least verify.rs, if not the real grammar. But it's totally ok for verify.rs to not handle the entire second half of the file.

I'm sorry for breaking this :( Good thing these tests aren't being run regularly yet...? :flushed: 
