### PR TITLE
rustc_back: change default GNU linkers for Windows

### DIFF
--- a/src/etc/make-win-dist.py
+++ b/src/etc/make-win-dist.py
@@ -46,6 +46,10 @@ def make_win_dist(rust_root, gcc_root, target_triple):
             lib_path.extend(val.lstrip(' =').split(';'))
 
     target_tools = ["gcc.exe", "ld.exe", "ar.exe", "dlltool.exe", "windres.exe"]
+    if target_triple.startswith("i686-"):
+        target_tools.append("i686-w64-mingw32-gcc.exe")
+    else:
+        target_tools.append("x86_64-w64-mingw32-gcc.exe")
 
     rustc_dlls = ["libstdc++-6.dll"]
     if target_triple.startswith("i686-"):

--- a/src/librustc_back/target/i686_pc_windows_gnu.rs
+++ b/src/librustc_back/target/i686_pc_windows_gnu.rs
@@ -13,6 +13,7 @@ use target::Target;
 pub fn target() -> Target {
     let mut options = super::windows_base::opts();
     options.cpu = "pentium4".to_string();
+    options.linker = "i686-w64-mingw32-gcc".to_string();
 
     // Mark all dynamic libraries and executables as compatible with the larger 4GiB address
     // space available to x86 Windows binaries on x86_64.

--- a/src/librustc_back/target/x86_64_pc_windows_gnu.rs
+++ b/src/librustc_back/target/x86_64_pc_windows_gnu.rs
@@ -13,6 +13,7 @@ use target::Target;
 pub fn target() -> Target {
     let mut base = super::windows_base::opts();
     base.cpu = "x86-64".to_string();
+    base.linker = "x86_64-w64-mingw32-gcc".to_string();
     // On Win64 unwinding is handled by the OS, so we can link libgcc statically.
     base.pre_link_args.push("-static-libgcc".to_string());
     base.pre_link_args.push("-m64".to_string());


### PR DESCRIPTION
This fixes cross compilation to Windows.  Without this change you have to specify:
   -C linker=x86_64-w64-mingw32-gcc
when cross compiling with rustc.

There might be a chicken-and-egg problem with this change.  I had to update make-win-dist.py.  Said script packages up runtime dependencies required by rustc on Windows.  If this change fails CI then I guess I'll have to split this into two separate pull requests.
