### PR TITLE
syntax: Remove unused `packed` attribute

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -258,7 +258,6 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType)] = &[
     ("no_builtins", Whitelisted),
     ("no_mangle", Whitelisted),
     ("no_stack_check", Whitelisted),
-    ("packed", Whitelisted),
     ("static_assert", Gated("static_assert",
                             "`#[static_assert]` is an experimental feature, and has a poor API")),
     ("no_debug", Whitelisted),


### PR DESCRIPTION
The attribute was removed by #16499.
