### PR TITLE
Make debug builders take &mut self, add entries method

### DIFF
--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -926,7 +926,7 @@ impl<K: Ord, V: Ord> Ord for BTreeMap<K, V> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<K: Debug, V: Debug> Debug for BTreeMap<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.iter().fold(f.debug_map(), |b, (k, v)| b.entry(k, v)).finish()
+        f.debug_map().entries(self.iter()).finish()
     }
 }
 

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -622,7 +622,7 @@ impl<'a, 'b, T: Ord + Clone> BitOr<&'b BTreeSet<T>> for &'a BTreeSet<T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Debug> Debug for BTreeSet<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.iter().fold(f.debug_set(), |b, e| b.entry(e)).finish()
+        f.debug_set().entries(self.iter()).finish()
     }
 }
 

--- a/src/libcollections/linked_list.rs
+++ b/src/libcollections/linked_list.rs
@@ -917,7 +917,7 @@ impl<A: Clone> Clone for LinkedList<A> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: fmt::Debug> fmt::Debug for LinkedList<A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.iter().fold(f.debug_list(), |b, e| b.entry(e)).finish()
+        f.debug_list().entries(self.iter()).finish()
     }
 }
 

--- a/src/libcore/fmt/builders.rs
+++ b/src/libcore/fmt/builders.rs
@@ -93,8 +93,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
         self
     }
 
-    /// Consumes the `DebugStruct`, finishing output and returning any error
-    /// encountered.
+    /// Finishes output and returns any error encountered.
     #[unstable(feature = "debug_builders", reason = "method was just created")]
     pub fn finish(&mut self) -> fmt::Result {
         if self.has_fields {
@@ -156,8 +155,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
         self
     }
 
-    /// Consumes the `DebugTuple`, finishing output and returning any error
-    /// encountered.
+    /// Finishes output and returns any error encountered.
     #[unstable(feature = "debug_builders", reason = "method was just created")]
     pub fn finish(&mut self) -> fmt::Result {
         if self.has_fields {
@@ -246,8 +244,7 @@ impl<'a, 'b: 'a> DebugSet<'a, 'b> {
         self
     }
 
-    /// Consumes the `DebugSet`, finishing output and returning any error
-    /// encountered.
+    /// Finishes output and returns any error encountered.
     #[unstable(feature = "debug_builders", reason = "method was just created")]
     pub fn finish(&mut self) -> fmt::Result {
         self.inner.finish();
@@ -292,8 +289,7 @@ impl<'a, 'b: 'a> DebugList<'a, 'b> {
         self
     }
 
-    /// Consumes the `DebugSet`, finishing output and returning any error
-    /// encountered.
+    /// Finishes output and returns any error encountered.
     #[unstable(feature = "debug_builders", reason = "method was just created")]
     pub fn finish(&mut self) -> fmt::Result {
         self.inner.finish();
@@ -349,8 +345,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
         self
     }
 
-    /// Consumes the `DebugMap`, finishing output and returning any error
-    /// encountered.
+    /// Finishes output and returns any error encountered.
     #[unstable(feature = "debug_builders", reason = "method was just created")]
     pub fn finish(&mut self) -> fmt::Result {
         let prefix = if self.is_pretty() && self.has_fields { "\n" } else { "" };

--- a/src/libcore/fmt/builders.rs
+++ b/src/libcore/fmt/builders.rs
@@ -73,7 +73,7 @@ pub fn debug_struct_new<'a, 'b>(fmt: &'a mut fmt::Formatter<'b>, name: &str)
 impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     /// Adds a new field to the generated struct output.
     #[unstable(feature = "debug_builders", reason = "method was just created")]
-    pub fn field(mut self, name: &str, value: &fmt::Debug) -> DebugStruct<'a, 'b> {
+    pub fn field(&mut self, name: &str, value: &fmt::Debug) -> &mut DebugStruct<'a, 'b> {
         self.result = self.result.and_then(|_| {
             let prefix = if self.has_fields {
                 ","
@@ -96,7 +96,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     /// Consumes the `DebugStruct`, finishing output and returning any error
     /// encountered.
     #[unstable(feature = "debug_builders", reason = "method was just created")]
-    pub fn finish(mut self) -> fmt::Result {
+    pub fn finish(&mut self) -> fmt::Result {
         if self.has_fields {
             self.result = self.result.and_then(|_| {
                 if self.is_pretty() {
@@ -136,7 +136,7 @@ pub fn debug_tuple_new<'a, 'b>(fmt: &'a mut fmt::Formatter<'b>, name: &str) -> D
 impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     /// Adds a new field to the generated tuple struct output.
     #[unstable(feature = "debug_builders", reason = "method was just created")]
-    pub fn field(mut self, value: &fmt::Debug) -> DebugTuple<'a, 'b> {
+    pub fn field(&mut self, value: &fmt::Debug) -> &mut DebugTuple<'a, 'b> {
         self.result = self.result.and_then(|_| {
             let (prefix, space) = if self.has_fields {
                 (",", " ")
@@ -159,7 +159,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     /// Consumes the `DebugTuple`, finishing output and returning any error
     /// encountered.
     #[unstable(feature = "debug_builders", reason = "method was just created")]
-    pub fn finish(mut self) -> fmt::Result {
+    pub fn finish(&mut self) -> fmt::Result {
         if self.has_fields {
             self.result = self.result.and_then(|_| {
                 if self.is_pretty() {
@@ -231,15 +231,25 @@ pub fn debug_set_new<'a, 'b>(fmt: &'a mut fmt::Formatter<'b>) -> DebugSet<'a, 'b
 impl<'a, 'b: 'a> DebugSet<'a, 'b> {
     /// Adds a new entry to the set output.
     #[unstable(feature = "debug_builders", reason = "method was just created")]
-    pub fn entry(mut self, entry: &fmt::Debug) -> DebugSet<'a, 'b> {
+    pub fn entry(&mut self, entry: &fmt::Debug) -> &mut DebugSet<'a, 'b> {
         self.inner.entry(entry);
+        self
+    }
+
+    /// Adds the contents of an iterator of entries to the set output.
+    #[unstable(feature = "debug_builders", reason = "method was just created")]
+    pub fn entries<D, I>(&mut self, entries: I) -> &mut DebugSet<'a, 'b>
+            where D: fmt::Debug, I: IntoIterator<Item=D> {
+        for entry in entries {
+            self.entry(&entry);
+        }
         self
     }
 
     /// Consumes the `DebugSet`, finishing output and returning any error
     /// encountered.
     #[unstable(feature = "debug_builders", reason = "method was just created")]
-    pub fn finish(mut self) -> fmt::Result {
+    pub fn finish(&mut self) -> fmt::Result {
         self.inner.finish();
         self.inner.result.and_then(|_| self.inner.fmt.write_str("}"))
     }
@@ -265,17 +275,27 @@ pub fn debug_list_new<'a, 'b>(fmt: &'a mut fmt::Formatter<'b>) -> DebugList<'a, 
 }
 
 impl<'a, 'b: 'a> DebugList<'a, 'b> {
-    /// Adds a new entry to the set output.
+    /// Adds a new entry to the list output.
     #[unstable(feature = "debug_builders", reason = "method was just created")]
-    pub fn entry(mut self, entry: &fmt::Debug) -> DebugList<'a, 'b> {
+    pub fn entry(&mut self, entry: &fmt::Debug) -> &mut DebugList<'a, 'b> {
         self.inner.entry(entry);
+        self
+    }
+
+    /// Adds the contents of an iterator of entries to the list output.
+    #[unstable(feature = "debug_builders", reason = "method was just created")]
+    pub fn entries<D, I>(&mut self, entries: I) -> &mut DebugList<'a, 'b>
+            where D: fmt::Debug, I: IntoIterator<Item=D> {
+        for entry in entries {
+            self.entry(&entry);
+        }
         self
     }
 
     /// Consumes the `DebugSet`, finishing output and returning any error
     /// encountered.
     #[unstable(feature = "debug_builders", reason = "method was just created")]
-    pub fn finish(mut self) -> fmt::Result {
+    pub fn finish(&mut self) -> fmt::Result {
         self.inner.finish();
         self.inner.result.and_then(|_| self.inner.fmt.write_str("]"))
     }
@@ -303,7 +323,7 @@ pub fn debug_map_new<'a, 'b>(fmt: &'a mut fmt::Formatter<'b>) -> DebugMap<'a, 'b
 impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// Adds a new entry to the map output.
     #[unstable(feature = "debug_builders", reason = "method was just created")]
-    pub fn entry(mut self, key: &fmt::Debug, value: &fmt::Debug) -> DebugMap<'a, 'b> {
+    pub fn entry(&mut self, key: &fmt::Debug, value: &fmt::Debug) -> &mut DebugMap<'a, 'b> {
         self.result = self.result.and_then(|_| {
             if self.is_pretty() {
                 let mut writer = PadAdapter::new(self.fmt);
@@ -319,10 +339,20 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
         self
     }
 
+    /// Adds the contents of an iterator of entries to the map output.
+    #[unstable(feature = "debug_builders", reason = "method was just created")]
+    pub fn entries<K, V, I>(&mut self, entries: I) -> &mut DebugMap<'a, 'b>
+            where K: fmt::Debug, V: fmt::Debug, I: IntoIterator<Item=(K, V)> {
+        for (k, v) in entries {
+            self.entry(&k, &v);
+        }
+        self
+    }
+
     /// Consumes the `DebugMap`, finishing output and returning any error
     /// encountered.
     #[unstable(feature = "debug_builders", reason = "method was just created")]
-    pub fn finish(self) -> fmt::Result {
+    pub fn finish(&mut self) -> fmt::Result {
         let prefix = if self.is_pretty() && self.has_fields { "\n" } else { "" };
         self.result.and_then(|_| write!(self.fmt, "{}}}", prefix))
     }

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -787,7 +787,7 @@ impl<'a> Formatter<'a> {
     ///
     /// impl fmt::Debug for Foo {
     ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    ///         self.0.iter().fold(fmt.debug_list(), |b, e| b.entry(e)).finish()
+    ///         fnt.debug_list().entries(self.0.iter()).finish()
     ///     }
     /// }
     ///
@@ -813,7 +813,7 @@ impl<'a> Formatter<'a> {
     ///
     /// impl fmt::Debug for Foo {
     ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    ///         self.0.iter().fold(fmt.debug_set(), |b, e| b.entry(e)).finish()
+    ///         fmt.debug_set().entries(self.0.iter()).finish()
     ///     }
     /// }
     ///
@@ -839,7 +839,7 @@ impl<'a> Formatter<'a> {
     ///
     /// impl fmt::Debug for Foo {
     ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    ///         self.0.iter().fold(fmt.debug_map(), |b, &(ref k, ref v)| b.entry(k, v)).finish()
+    ///         fmt.debug_map().entries(self.0.iter()).finish()
     ///     }
     /// }
     ///
@@ -1120,7 +1120,7 @@ tuple! { T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Debug> Debug for [T] {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        self.iter().fold(f.debug_list(), |b, e| b.entry(e)).finish()
+        f.debug_list().entries(self.iter()).finish()
     }
 }
 

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -787,7 +787,7 @@ impl<'a> Formatter<'a> {
     ///
     /// impl fmt::Debug for Foo {
     ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    ///         fnt.debug_list().entries(self.0.iter()).finish()
+    ///         fmt.debug_list().entries(self.0.iter()).finish()
     ///     }
     /// }
     ///
@@ -839,7 +839,7 @@ impl<'a> Formatter<'a> {
     ///
     /// impl fmt::Debug for Foo {
     ///     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    ///         fmt.debug_map().entries(self.0.iter()).finish()
+    ///         fmt.debug_map().entries(self.0.iter().map(|&(ref k, ref v)| (k, v))).finish()
     ///     }
     /// }
     ///

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1222,7 +1222,7 @@ impl<K, V, S> Debug for HashMap<K, V, S>
     where K: Eq + Hash + Debug, V: Debug, S: HashState
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.iter().fold(f.debug_map(), |b, (k, v)| b.entry(k, v)).finish()
+        f.debug_map().entries(self.iter()).finish()
     }
 }
 

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -585,7 +585,7 @@ impl<T, S> fmt::Debug for HashSet<T, S>
           S: HashState
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.iter().fold(f.debug_set(), |b, e| b.entry(e)).finish()
+        f.debug_set().entries(self.iter()).finish()
     }
 }
 

--- a/src/libstd/sys/common/net.rs
+++ b/src/libstd/sys/common/net.rs
@@ -274,16 +274,16 @@ impl fmt::Debug for TcpStream {
         let mut res = f.debug_struct("TcpStream");
 
         if let Ok(addr) = self.socket_addr() {
-            res = res.field("addr", &addr);
+            res.field("addr", &addr);
         }
 
         if let Ok(peer) = self.peer_addr() {
-            res = res.field("peer", &peer);
+            res.field("peer", &peer);
         }
 
         let name = if cfg!(windows) {"socket"} else {"fd"};
-        res = res.field(name, &self.inner.as_inner());
-        res.finish()
+        res.field(name, &self.inner.as_inner())
+            .finish()
     }
 }
 
@@ -351,12 +351,12 @@ impl fmt::Debug for TcpListener {
         let mut res = f.debug_struct("TcpListener");
 
         if let Ok(addr) = self.socket_addr() {
-            res = res.field("addr", &addr);
+            res.field("addr", &addr);
         }
 
         let name = if cfg!(windows) {"socket"} else {"fd"};
-        res = res.field(name, &self.inner.as_inner());
-        res.finish()
+        res.field(name, &self.inner.as_inner())
+            .finish()
     }
 }
 
@@ -484,11 +484,11 @@ impl fmt::Debug for UdpSocket {
         let mut res = f.debug_struct("UdpSocket");
 
         if let Ok(addr) = self.socket_addr() {
-            res = res.field("addr", &addr);
+            res.field("addr", &addr);
         }
 
         let name = if cfg!(windows) {"socket"} else {"fd"};
-        res = res.field(name, &self.inner.as_inner());
-        res.finish()
+        res.field(name, &self.inner.as_inner())
+            .finish()
     }
 }

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -408,12 +408,13 @@ impl fmt::Debug for File {
         }
 
         let fd = self.0.raw();
-        let mut b = f.debug_struct("File").field("fd", &fd);
+        let mut b = f.debug_struct("File");
+        b.field("fd", &fd);
         if let Some(path) = get_path(fd) {
-            b = b.field("path", &path);
+            b.field("path", &path);
         }
         if let Some((read, write)) = get_mode(fd) {
-            b = b.field("read", &read).field("write", &write);
+            b.field("read", &read).field("write", &write);
         }
         b.finish()
     }


### PR DESCRIPTION
Based on feedback from https://internals.rust-lang.org/t/final-comment-period-for-debug-builders-stabilization/2007/2
