### PR TITLE
Make #[derive(Debug)] work with unsized fields

### DIFF
--- a/src/libsyntax/ext/deriving/show.rs
+++ b/src/libsyntax/ext/deriving/show.rs
@@ -75,6 +75,7 @@ fn show_substructure(cx: &mut ExtCtxt, span: Span,
 
     match *substr.fields {
         Struct(ref fields) | EnumMatching(_, _, ref fields) => {
+
             if fields.is_empty() || fields[0].name.is_none() {
                 // tuple struct/"normal" variant
                 expr = cx.expr_method_call(span,
@@ -83,11 +84,14 @@ fn show_substructure(cx: &mut ExtCtxt, span: Span,
                                            vec![name]);
 
                 for field in fields {
+                    // Use double indirection to make sure this works for unsized types
+                    let field = cx.expr_addr_of(field.span, field.self_.clone());
+                    let field = cx.expr_addr_of(field.span, field);
+
                     expr = cx.expr_method_call(span,
                                                expr,
                                                token::str_to_ident("field"),
-                                               vec![cx.expr_addr_of(field.span,
-                                                                    field.self_.clone())]);
+                                               vec![field]);
                 }
             } else {
                 // normal struct/struct variant
@@ -100,12 +104,14 @@ fn show_substructure(cx: &mut ExtCtxt, span: Span,
                     let name = cx.expr_lit(field.span, ast::Lit_::LitStr(
                             token::get_ident(field.name.clone().unwrap()),
                             ast::StrStyle::CookedStr));
+
+                    // Use double indirection to make sure this works for unsized types
+                    let field = cx.expr_addr_of(field.span, field.self_.clone());
+                    let field = cx.expr_addr_of(field.span, field);
                     expr = cx.expr_method_call(span,
                                                expr,
                                                token::str_to_ident("field"),
-                                               vec![name,
-                                                    cx.expr_addr_of(field.span,
-                                                                    field.self_.clone())]);
+                                               vec![name, field]);
                 }
             }
         }

--- a/src/test/run-pass/issue-25394.rs
+++ b/src/test/run-pass/issue-25394.rs
@@ -1,0 +1,14 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[derive(Debug)]
+struct Row<T>([T]);
+
+fn main() {}


### PR DESCRIPTION
Closes #25394 
