### PR TITLE
Show the span of feature that is unstable when using a feature-list.

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -2203,7 +2203,11 @@ impl LintPass for UnstableFeatures {
     }
     fn check_attribute(&mut self, ctx: &Context, attr: &ast::Attribute) {
         if attr::contains_name(&[attr.node.value.clone()], "feature") {
-            ctx.span_lint(UNSTABLE_FEATURES, attr.span, "unstable feature");
+            if let Some(items) = attr.node.value.meta_item_list() {
+                for item in items {
+                    ctx.span_lint(UNSTABLE_FEATURES, item.span, "unstable feature");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
It is hard to find the actual unstable feature which caused the error when using a list of stable and unstable features as the span marks the whole line

```
src/k8055.rs:22:1: 22:64 error: unstable feature
src/k8055.rs:22 #![feature(slice_patterns, rustc_private, core, convert, libc)]
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR spawns an error for each unstable feature in the list:

```
est.rs:1:12: 1:26 error: unstable feature [-D unstable-features]
test.rs:1 #![feature(slice_patterns, rustc_private, core, convert, libc)]
                     ^~~~~~~~~~~~~~
test.rs:1:28: 1:41 error: unstable feature [-D unstable-features]
test.rs:1 #![feature(slice_patterns, rustc_private, core, convert, libc)]
                                     ^~~~~~~~~~~~~
test.rs:1:43: 1:47 error: unstable feature [-D unstable-features]
test.rs:1 #![feature(slice_patterns, rustc_private, core, convert, libc)]
                                                    ^~~~
test.rs:1:49: 1:56 error: unstable feature [-D unstable-features]
test.rs:1 #![feature(slice_patterns, rustc_private, core, convert, libc)]
                                                          ^~~~~~~
test.rs:1:58: 1:62 error: unstable feature [-D unstable-features]
test.rs:1 #![feature(slice_patterns, rustc_private, core, convert, libc)]
                                                                   ^~~~
```
