### PR TITLE
Flush stdout on read from stdin again

### DIFF
--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -165,6 +165,9 @@ impl Stdin {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Read for Stdin {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // Flush stdout so that weird issues like a print!'d prompt not being
+        // shown until after the user hits enter.
+        drop(stdout().flush());
         self.lock().read(buf)
     }
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {

--- a/src/test/run-pass/print-read-flushes.rs
+++ b/src/test/run-pass/print-read-flushes.rs
@@ -1,0 +1,44 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::env;
+use std::io;
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+
+fn main(){
+    if env::args().count() > 1 && env::args().nth(1) == Some("child".to_string()) {
+        child()
+    } else {
+        let mut p = Command::new(env::args().nth(0).unwrap())
+                .arg("child")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .spawn().unwrap();
+        {
+            let mut buf = [0; 1];
+            assert!(p.stdout.as_mut().unwrap().read(&mut buf).unwrap() >= 1);
+            assert_eq!(buf[0], b'>');
+            assert!(p.stdin.as_mut().unwrap().write(b"abcd\n").unwrap() >= 1);
+        }
+        // FIXME(#25572): timeout and fail on timeout
+        assert!(p.wait().unwrap().success());
+    }
+}
+
+fn child(){
+    let stdout = io::stdout();
+    let lstdout = stdout.lock();
+    let mut stdin = io::stdin();
+    print!(">");
+    let mut letter = [0; 1];
+    stdin.read(&mut letter).unwrap();
+}


### PR DESCRIPTION
This is possible now since we have reentrant mutexes. Fixes #25555.
