### PR TITLE
Fix typo in dining philosophers example

### DIFF
--- a/src/doc/trpl/dining-philosophers.md
+++ b/src/doc/trpl/dining-philosophers.md
@@ -647,7 +647,7 @@ let philosophers = vec![
     Philosopher::new("Gilles Deleuze", 1, 2),
     Philosopher::new("Karl Marx", 2, 3),
     Philosopher::new("Friedrich Nietzsche", 3, 4),
-    Philosopher::new("Michel Foucault", 0, 4),
+    Philosopher::new("Michel Foucault", 4, 0),
 ];
 ```
 


### PR DESCRIPTION
Baruch Spinoza and Michel Foucault can't _both_ have fork `0` on their left, right?
