### PR TITLE
Fix left margin for type aliases

### DIFF
--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -348,7 +348,7 @@ nav.sub {
 .content .impl-items .docblock, .content .impl-items .stability {
     margin-left: 40px;
 }
-.content .impl-items .method, .content .impl-items .type {
+.content .impl-items .method, .content .impl-items > .type {
     margin-left: 20px;
 }
 


### PR DESCRIPTION
rustdoc: Fix left margin for type aliases

Fixes #24655

Margin for associated types was applied to type aliases (in return
value) by mistake.
