### PR TITLE
Use stable code in doc examples (libcollections)

### DIFF
--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -32,7 +32,7 @@
 //! and have the `Owner` remain allocated as long as any `Gadget` points at it.
 //!
 //! ```rust
-//! # #![feature(alloc, collections)]
+//! # #![feature(alloc)]
 //! use std::rc::Rc;
 //!
 //! struct Owner {
@@ -49,7 +49,7 @@
 //! fn main() {
 //!     // Create a reference counted Owner.
 //!     let gadget_owner : Rc<Owner> = Rc::new(
-//!             Owner { name: String::from_str("Gadget Man") }
+//!             Owner { name: String::from("Gadget Man") }
 //!     );
 //!
 //!     // Create Gadgets belonging to gadget_owner. To increment the reference

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -1291,14 +1291,13 @@ impl<K, V> BTreeMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
     /// use std::collections::BTreeMap;
     ///
     /// let mut a = BTreeMap::new();
     /// a.insert(1, "a");
     /// a.insert(2, "b");
     ///
-    /// let keys: Vec<usize> = a.keys().cloned().collect();
+    /// let keys: Vec<_> = a.keys().cloned().collect();
     /// assert_eq!(keys, [1, 2]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -1314,7 +1313,6 @@ impl<K, V> BTreeMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
     /// use std::collections::BTreeMap;
     ///
     /// let mut a = BTreeMap::new();
@@ -1555,7 +1553,6 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
     /// use std::collections::BTreeMap;
     ///
     /// let mut count: BTreeMap<&str, usize> = BTreeMap::new();

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -115,7 +115,6 @@ impl<T> BTreeSet<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
     /// use std::collections::BTreeSet;
     ///
     /// let set: BTreeSet<usize> = [1, 2, 3, 4].iter().cloned().collect();
@@ -124,7 +123,7 @@ impl<T> BTreeSet<T> {
     ///     println!("{}", x);
     /// }
     ///
-    /// let v: Vec<usize> = set.iter().cloned().collect();
+    /// let v: Vec<_> = set.iter().cloned().collect();
     /// assert_eq!(v, [1, 2, 3, 4]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -171,7 +170,6 @@ impl<T: Ord> BTreeSet<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
     /// use std::collections::BTreeSet;
     ///
     /// let mut a = BTreeSet::new();
@@ -182,7 +180,7 @@ impl<T: Ord> BTreeSet<T> {
     /// b.insert(2);
     /// b.insert(3);
     ///
-    /// let diff: Vec<usize> = a.difference(&b).cloned().collect();
+    /// let diff: Vec<_> = a.difference(&b).cloned().collect();
     /// assert_eq!(diff, [1]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -195,7 +193,6 @@ impl<T: Ord> BTreeSet<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
     /// use std::collections::BTreeSet;
     ///
     /// let mut a = BTreeSet::new();
@@ -206,7 +203,7 @@ impl<T: Ord> BTreeSet<T> {
     /// b.insert(2);
     /// b.insert(3);
     ///
-    /// let sym_diff: Vec<usize> = a.symmetric_difference(&b).cloned().collect();
+    /// let sym_diff: Vec<_> = a.symmetric_difference(&b).cloned().collect();
     /// assert_eq!(sym_diff, [1, 3]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -220,7 +217,6 @@ impl<T: Ord> BTreeSet<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
     /// use std::collections::BTreeSet;
     ///
     /// let mut a = BTreeSet::new();
@@ -231,7 +227,7 @@ impl<T: Ord> BTreeSet<T> {
     /// b.insert(2);
     /// b.insert(3);
     ///
-    /// let intersection: Vec<usize> = a.intersection(&b).cloned().collect();
+    /// let intersection: Vec<_> = a.intersection(&b).cloned().collect();
     /// assert_eq!(intersection, [2]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -245,7 +241,6 @@ impl<T: Ord> BTreeSet<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
     /// use std::collections::BTreeSet;
     ///
     /// let mut a = BTreeSet::new();
@@ -254,7 +249,7 @@ impl<T: Ord> BTreeSet<T> {
     /// let mut b = BTreeSet::new();
     /// b.insert(2);
     ///
-    /// let union: Vec<usize> = a.union(&b).cloned().collect();
+    /// let union: Vec<_> = a.union(&b).cloned().collect();
     /// assert_eq!(union, [1, 2]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -318,7 +313,6 @@ impl<T: Ord> BTreeSet<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
     /// use std::collections::BTreeSet;
     ///
     /// let set: BTreeSet<_> = [1, 2, 3].iter().cloned().collect();
@@ -336,7 +330,6 @@ impl<T: Ord> BTreeSet<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
     /// use std::collections::BTreeSet;
     ///
     /// let a: BTreeSet<_> = [1, 2, 3].iter().cloned().collect();
@@ -358,7 +351,6 @@ impl<T: Ord> BTreeSet<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
     /// use std::collections::BTreeSet;
     ///
     /// let sup: BTreeSet<_> = [1, 2, 3].iter().cloned().collect();
@@ -401,7 +393,6 @@ impl<T: Ord> BTreeSet<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
     /// use std::collections::BTreeSet;
     ///
     /// let sub: BTreeSet<_> = [1, 2].iter().cloned().collect();
@@ -483,12 +474,11 @@ impl<T> IntoIterator for BTreeSet<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
     /// use std::collections::BTreeSet;
     ///
     /// let set: BTreeSet<usize> = [1, 2, 3, 4].iter().cloned().collect();
     ///
-    /// let v: Vec<usize> = set.into_iter().collect();
+    /// let v: Vec<_> = set.into_iter().collect();
     /// assert_eq!(v, [1, 2, 3, 4]);
     /// ```
     fn into_iter(self) -> IntoIter<T> {

--- a/src/libcollections/linked_list.rs
+++ b/src/libcollections/linked_list.rs
@@ -230,7 +230,6 @@ impl<T> LinkedList<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
     /// use std::collections::LinkedList;
     ///
     /// let mut a = LinkedList::new();
@@ -473,7 +472,6 @@ impl<T> LinkedList<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
     /// use std::collections::LinkedList;
     ///
     /// let mut dl = LinkedList::new();
@@ -521,7 +519,6 @@ impl<T> LinkedList<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
     /// use std::collections::LinkedList;
     ///
     /// let mut d = LinkedList::new();
@@ -540,7 +537,6 @@ impl<T> LinkedList<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
     /// use std::collections::LinkedList;
     ///
     /// let mut d = LinkedList::new();
@@ -566,7 +562,6 @@ impl<T> LinkedList<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
     /// use std::collections::LinkedList;
     ///
     /// let mut d = LinkedList::new();

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -529,7 +529,6 @@ impl<T> [T] {
     /// found; the fourth could match any position in `[1,4]`.
     ///
     /// ```rust
-    /// # #![feature(core)]
     /// let s = [0, 1, 1, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55];
     ///
     /// let seek = 13;
@@ -865,7 +864,6 @@ impl<T> [T] {
     /// found; the fourth could match any position in `[1,4]`.
     ///
     /// ```rust
-    /// # #![feature(core)]
     /// let s = [0, 1, 1, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55];
     ///
     /// assert_eq!(s.binary_search(&13),  Ok(9));

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -121,9 +121,6 @@ impl String {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
-    /// use std::str::Utf8Error;
-    ///
     /// let hello_vec = vec![104, 101, 108, 108, 111];
     /// let s = String::from_utf8(hello_vec).unwrap();
     /// assert_eq!(s, "hello");
@@ -346,8 +343,7 @@ impl String {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// let s = String::from_str("hello");
+    /// let s = String::from("hello");
     /// let bytes = s.into_bytes();
     /// assert_eq!(bytes, [104, 101, 108, 108, 111]);
     /// ```
@@ -370,8 +366,7 @@ impl String {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// let mut s = String::from_str("foo");
+    /// let mut s = String::from("foo");
     /// s.push_str("bar");
     /// assert_eq!(s, "foobar");
     /// ```
@@ -447,8 +442,7 @@ impl String {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// let mut s = String::from_str("foo");
+    /// let mut s = String::from("foo");
     /// s.reserve(100);
     /// assert!(s.capacity() >= 100);
     /// s.shrink_to_fit();
@@ -465,8 +459,7 @@ impl String {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// let mut s = String::from_str("abc");
+    /// let mut s = String::from("abc");
     /// s.push('1');
     /// s.push('2');
     /// s.push('3');
@@ -501,8 +494,7 @@ impl String {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// let s = String::from_str("hello");
+    /// let s = String::from("hello");
     /// let b: &[_] = &[104, 101, 108, 108, 111];
     /// assert_eq!(s.as_bytes(), b);
     /// ```
@@ -522,8 +514,7 @@ impl String {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// let mut s = String::from_str("hello");
+    /// let mut s = String::from("hello");
     /// s.truncate(2);
     /// assert_eq!(s, "he");
     /// ```
@@ -540,8 +531,7 @@ impl String {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// let mut s = String::from_str("foo");
+    /// let mut s = String::from("foo");
     /// assert_eq!(s.pop(), Some('o'));
     /// assert_eq!(s.pop(), Some('o'));
     /// assert_eq!(s.pop(), Some('f'));
@@ -578,8 +568,7 @@ impl String {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// let mut s = String::from_str("foo");
+    /// let mut s = String::from("foo");
     /// assert_eq!(s.remove(0), 'f');
     /// assert_eq!(s.remove(1), 'o');
     /// assert_eq!(s.remove(0), 'o');
@@ -641,8 +630,7 @@ impl String {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
-    /// let mut s = String::from_str("hello");
+    /// let mut s = String::from("hello");
     /// unsafe {
     ///     let vec = s.as_mut_vec();
     ///     assert!(vec == &[104, 101, 108, 108, 111]);

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -91,7 +91,6 @@ static MAX_MEMORY_SIZE: usize = isize::MAX as usize;
 /// # Examples
 ///
 /// ```
-/// # #![feature(collections)]
 /// let mut vec = Vec::new();
 /// vec.push(1);
 /// vec.push(2);
@@ -105,9 +104,9 @@ static MAX_MEMORY_SIZE: usize = isize::MAX as usize;
 /// vec[0] = 7;
 /// assert_eq!(vec[0], 7);
 ///
-/// vec.push_all(&[1, 2, 3]);
+/// vec.extend([1, 2, 3].iter().cloned());
 ///
-/// for x in vec.iter() {
+/// for x in &vec {
 ///     println!("{}", x);
 /// }
 /// assert_eq!(vec, [7, 1, 2, 3]);
@@ -369,9 +368,8 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
     /// let mut vec = Vec::with_capacity(10);
-    /// vec.push_all(&[1, 2, 3]);
+    /// vec.extend([1, 2, 3].iter().cloned());
     /// assert_eq!(vec.capacity(), 10);
     /// vec.shrink_to_fit();
     /// assert!(vec.capacity() >= 3);
@@ -425,7 +423,6 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
     /// let mut vec = vec![1, 2, 3, 4];
     /// vec.truncate(2);
     /// assert_eq!(vec, [1, 2]);
@@ -555,7 +552,6 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
     /// let mut v = vec![1, 2, 3];
     /// assert_eq!(v.remove(1), 2);
     /// assert_eq!(v, [1, 3]);
@@ -743,7 +739,7 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections_drain, collections_range)]
+    /// # #![feature(collections_drain)]
     ///
     /// // Draining using `..` clears the whole vector.
     /// let mut v = vec![1, 2, 3];

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -247,7 +247,6 @@ impl<T> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -275,7 +274,6 @@ impl<T> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
     /// use std::collections::VecDeque;
     ///
     /// let buf: VecDeque<i32> = VecDeque::with_capacity(10);
@@ -299,7 +297,6 @@ impl<T> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
     /// use std::collections::VecDeque;
     ///
     /// let mut buf: VecDeque<i32> = vec![1].into_iter().collect();
@@ -321,7 +318,6 @@ impl<T> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collections)]
     /// use std::collections::VecDeque;
     ///
     /// let mut buf: VecDeque<i32> = vec![1].into_iter().collect();
@@ -508,7 +504,6 @@ impl<T> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();
@@ -533,7 +528,6 @@ impl<T> VecDeque<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(core)]
     /// use std::collections::VecDeque;
     ///
     /// let mut buf = VecDeque::new();


### PR DESCRIPTION
Use stable code in doc examples (libcollections)

Main task is to change from String::from_str to String::from in examples for String
(the latter constructor is stable). While I'm at it, also remove redundant feature flags,
fix some other instances of unstable code in examples (in examples for stable
methods), and remove some use of usize in examples too.
