### PR TITLE
syntax: Remove diagnostic validation temporarily

### DIFF
--- a/src/libsyntax/diagnostics/plugin.rs
+++ b/src/libsyntax/diagnostics/plugin.rs
@@ -14,7 +14,6 @@ use std::collections::BTreeMap;
 use ast;
 use ast::{Ident, Name, TokenTree};
 use codemap::Span;
-use diagnostics::metadata::{check_uniqueness, output_metadata, Duplicate};
 use ext::base::{ExtCtxt, MacEager, MacResult};
 use ext::build::AstBuilder;
 use parse::token;
@@ -148,7 +147,7 @@ pub fn expand_build_diagnostic_array<'cx>(ecx: &'cx mut ExtCtxt,
                                           token_tree: &[TokenTree])
                                           -> Box<MacResult+'cx> {
     assert_eq!(token_tree.len(), 3);
-    let (crate_name, name) = match (&token_tree[0], &token_tree[2]) {
+    let (_crate_name, name) = match (&token_tree[0], &token_tree[2]) {
         (
             // Crate name.
             &ast::TtToken(_, token::Ident(ref crate_name, _)),
@@ -157,22 +156,6 @@ pub fn expand_build_diagnostic_array<'cx>(ecx: &'cx mut ExtCtxt,
         ) => (crate_name.as_str(), name),
         _ => unreachable!()
     };
-
-    // Check uniqueness of errors and output metadata.
-    with_registered_diagnostics(|diagnostics| {
-        match check_uniqueness(crate_name, &*diagnostics) {
-            Ok(Duplicate(err, location)) => {
-                ecx.span_err(span, &format!(
-                    "error {} from `{}' also found in `{}'",
-                    err, crate_name, location
-                ));
-            },
-            Ok(_) => (),
-            Err(e) => panic!("{}", e.description())
-        }
-
-        output_metadata(&*ecx, crate_name, &*diagnostics).ok().expect("metadata output error");
-    });
 
     // Construct the output expression.
     let (count, expr) =


### PR DESCRIPTION
This commit removes the syntax diagnostic validation as it's been plauging the
bots for two separate reasons and needs a quick fix for now:
1. It's possible to read the stale metadata of previous builds, causing spurious
   failures that can only be solved by blowing away `tmp`.
2. The code does not currently handle concurrent compilations where JSON files
   in the metadata directory may be half-written and hence contain invalid JSON
   when read.

This validation should come back, but it should likely be part of a lint pass
run at the very end of the build that doesn't run into consistency or
concurrency problems.
