### PR TITLE
Add error explanations for E0185, E0186, E0202, E0326. Fix E0053.

### DIFF
--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -877,7 +877,7 @@ fn convert_item(ccx: &CrateCtxt, it: &ast::Item) {
                 if let ast::TypeImplItem(ref ty) = impl_item.node {
                     if opt_trait_ref.is_none() {
                         span_err!(tcx.sess, impl_item.span, E0202,
-                                  "associated items are not allowed in inherent impls");
+                                  "associated types are not allowed in inherent impls");
                     }
 
                     as_refsociated_type(ccx, ImplContainer(local_def(it.id)),

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -443,6 +443,48 @@ it has been disabled for now.
 [iss20126]: https://github.com/rust-lang/rust/issues/20126
 "##,
 
+E0185: r##"
+An associated function for a trait was defined to be static, but an
+implementation of the trait declared the same function to be a method (i.e. to
+take a `self` parameter).
+
+Here's an example of this error:
+
+```
+trait Foo {
+    fn foo();
+}
+
+struct Bar;
+
+impl Foo for Bar {
+    // error, method `foo` has a `&self` declaration in the impl, but not in
+    // the trait
+    fn foo(&self) {}
+}
+"##,
+
+E0186: r##"
+An associated function for a trait was defined to be a method (i.e. to take a
+`self` parameter), but an implementation of the trait declared the same function
+to be static.
+
+Here's an example of this error:
+
+```
+trait Foo {
+    fn foo(&self);
+}
+
+struct Bar;
+
+impl Foo for Bar {
+    // error, method `foo` has a `&self` declaration in the trait, but not in
+    // the impl
+    fn foo() {}
+}
+"##,
+
 E0197: r##"
 Inherent implementations (one that do not implement a trait but provide
 methods associated with a type) are always safe because they are not
@@ -828,8 +870,6 @@ register_diagnostics! {
     E0174, // explicit use of unboxed closure methods are experimental
     E0182,
     E0183,
-    E0185,
-    E0186,
     E0187, // can't infer the kind of the closure
     E0188, // types differ in mutability
     E0189, // can only cast a boxed pointer to a boxed object

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -684,6 +684,25 @@ for types as needed by the compiler, and it is currently disallowed to
 explicitly implement it for a type.
 "##,
 
+E0326: r##"
+The types of any associated constants in a trait implementation must match the
+types in the trait definition. This error indicates that there was a mismatch.
+
+Here's an example of this error:
+
+```
+trait Foo {
+    const BAR: bool;
+}
+
+struct Bar;
+
+impl Foo for Bar {
+    const BAR: u32 = 5; // error, expected bool, found u32
+}
+```
+"##,
+
 E0368: r##"
 This error indicates that a binary assignment operator like `+=` or `^=` was
 applied to the wrong types.
@@ -885,7 +904,6 @@ register_diagnostics! {
     E0323, // implemented an associated const when another trait item expected
     E0324, // implemented a method when another trait item expected
     E0325, // implemented an associated type when another trait item expected
-    E0326, // associated const implemented with different type from trait
     E0327, // referred to method instead of constant in match pattern
     E0328, // cannot implement Unsize explicitly
     E0366, // dropck forbid specialization to concrete type or region

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -573,6 +573,14 @@ impl Foo {
 ```
 "##,
 
+E0202: r##"
+Inherent associated types were part of [RFC 195] but are not yet implemented.
+See [the tracking issue][iss8995] for the status of this implementation.
+
+[RFC 195]: https://github.com/rust-lang/rfcs/pull/195
+[iss8995]: https://github.com/rust-lang/rust/issues/8995
+"##,
+
 E0204: r##"
 An attempt to implement the `Copy` trait for a struct failed because one of the
 fields does not implement `Copy`. To fix this, you must implement `Copy` for the
@@ -881,7 +889,6 @@ register_diagnostics! {
     E0194,
     E0195, // lifetime parameters or bounds on method do not match the trait declaration
     E0196, // cannot determine a type for this closure
-    E0202, // associated items are not allowed in inherent impls
     E0203, // type parameter has more than one relaxed default bound,
            // and only one is supported
     E0207, // type parameter is not constrained by the impl trait, self type, or predicate

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -65,40 +65,27 @@ impl Foo for Bar {
 "##,
 
 E0053: r##"
-For any given method of a trait, the mutabilities of the parameters must match
-between the trait definition and the implementation.
+The parameters of any trait method must match between a trait implementation
+and the trait definition.
 
-Here's an example where the mutability of the `self` parameter is wrong:
+Here are a couple examples of this error:
 
 ```
-trait Foo { fn foo(&self); }
+trait Foo {
+    fn foo(x: u16);
+    fn bar(&self);
+}
 
 struct Bar;
 
 impl Foo for Bar {
-    // error, the signature should be `fn foo(&self)` instead
+    // error, expected u16, found i16
+    fn foo(x: i16) { }
+
+    // error, values differ in mutability
     fn foo(&mut self) { }
 }
-
-fn main() {}
 ```
-
-Here's another example, this time for a non-`self` parameter:
-
-```
-trait Foo { fn foo(x: &mut bool) -> bool; }
-
-struct Bar;
-
-impl Foo for Bar {
-    // error, the type of `x` should be `&mut bool` instead
-    fn foo(x: &bool) -> bool { *x }
-}
-
-fn main() {}
-```
-
-
 "##,
 
 E0054: r##"

--- a/src/test/compile-fail/assoc-inherent.rs
+++ b/src/test/compile-fail/assoc-inherent.rs
@@ -13,7 +13,7 @@
 struct Foo;
 
 impl Foo {
-    type Bar = isize; //~ERROR associated items are not allowed in inherent impls
+    type Bar = isize; //~ERROR associated types are not allowed in inherent impls
 }
 
 fn main() {}


### PR DESCRIPTION
Changes:
- adds explanations for E0185, E0186, E0202, E0326
- fixes the explanation for E0053. The previous description was too narrow; there are other error cases.
- changes the error message for E0202 to be specific for associated types, since it seems inherent associated constants are implemented.

Part of #24407 
