### PR TITLE
Don't call drop when taking the address of unsized fields

### DIFF
--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -730,8 +730,9 @@ fn trans_field<'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
             let info = Load(bcx, get_len(bcx, base_datum.val));
             Store(bcx, info, get_len(bcx, scratch.val));
 
-            DatumBlock::new(bcx, scratch.to_expr_datum())
-
+            // Always generate an lvalue datum, because this pointer doesn't own
+            // the data and cleanup is scheduled elsewhere.
+            DatumBlock::new(bcx, Datum::new(scratch.val, scratch.ty, LvalueExpr))
         }
     })
 

--- a/src/test/run-pass/issue-25515.rs
+++ b/src/test/run-pass/issue-25515.rs
@@ -1,0 +1,29 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::rc::Rc;
+
+struct Foo<'r>(&'r mut i32);
+
+impl<'r> Drop for Foo<'r> {
+    fn drop(&mut self) {
+        *self.0 += 1;
+    }
+}
+
+fn main() {
+    let mut drops = 0;
+
+    {
+        let _: Rc<Send> = Rc::new(Foo(&mut drops));
+    }
+
+    assert_eq!(1, drops);
+}

--- a/src/test/run-pass/issue-25549-multiple-drop.rs
+++ b/src/test/run-pass/issue-25549-multiple-drop.rs
@@ -1,0 +1,41 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo<'r>(&'r mut i32);
+
+impl<'r> Drop for Foo<'r> {
+    fn drop(&mut self) {
+        *self.0 += 1;
+    }
+}
+
+trait Trait {}
+impl<'r> Trait for Foo<'r> {}
+
+struct Holder<T: ?Sized>(T);
+
+fn main() {
+    let mut drops = 0;
+
+    {
+        let y = &Holder([Foo(&mut drops)]) as &Holder<[Foo]>;
+        // this used to cause an extra drop of the Foo instance
+        let x = &y.0;
+    }
+    assert_eq!(1, drops);
+
+    drops = 0;
+    {
+        let y = &Holder(Foo(&mut drops)) as &Holder<Trait>;
+        // this used to cause an extra drop of the Foo instance
+        let x = &y.0;
+    }
+    assert_eq!(1, drops);
+}


### PR DESCRIPTION
When taking the address of an unsized field we generate a rvalue datum
for the field and then convert it to an lvalue datum. At that point,
cleanup is scheduled for the field, leading to multiple drop calls.

The problem is that we generate an rvalue datum for the field, since the
pointer does not own the data and there's already cleanup scheduled
elsewhere by the true owner. Instead, an lvalue datum must be created.

Thanks to @eddyb for identifying the underlying cause and suggesting the
correct fix.

Fixes #25549.
