### PR TITLE
fmt.rs: add note about lack of padding support for some types

### DIFF
--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -353,6 +353,10 @@
 //! * `^` - the argument is center-aligned in `width` columns
 //! * `>` - the argument is right-aligned in `width` columns
 //!
+//! Note that alignment may not be implemented by some types. A good way
+//! to ensure padding is applied is to format your input, then use this
+//! resulting string to pad your output.
+//!
 //! ## Sign/#/0
 //!
 //! These can all be interpreted as flags for a particular formatter.


### PR DESCRIPTION
Padding and alignment are often not implemented by types and can cause confusion in the user.  Per discussion with @alexcrichton, here is my PR.

/cc https://github.com/rust-lang/time/issues/98
