### PR TITLE
removes syntax diagnostic err code uniqueness check

### DIFF
--- a/src/libsyntax/diagnostics/plugin.rs
+++ b/src/libsyntax/diagnostics/plugin.rs
@@ -14,7 +14,7 @@ use std::collections::BTreeMap;
 use ast;
 use ast::{Ident, Name, TokenTree};
 use codemap::Span;
-use diagnostics::metadata::{check_uniqueness, output_metadata, Duplicate};
+use diagnostics::metadata::{output_metadata};
 use ext::base::{ExtCtxt, MacEager, MacResult};
 use ext::build::AstBuilder;
 use parse::token;
@@ -158,19 +158,11 @@ pub fn expand_build_diagnostic_array<'cx>(ecx: &'cx mut ExtCtxt,
         _ => unreachable!()
     };
 
-    // Check uniqueness of errors and output metadata.
+    // Output metadata.
     with_registered_diagnostics(|diagnostics| {
-        match check_uniqueness(crate_name, &*diagnostics) {
-            Ok(Duplicate(err, location)) => {
-                ecx.span_err(span, &format!(
-                    "error {} from `{}' also found in `{}'",
-                    err, crate_name, location
-                ));
-            },
-            Ok(_) => (),
-            Err(e) => panic!("{}", e.description())
-        }
-
+        // FIXME (25364, 25592): used to ensure error code uniqueness
+        // here, but the approach employed was too brittle. Need to
+        // put such a check back in (e.g. in `make tidy`).
         output_metadata(&*ecx, crate_name, &*diagnostics).ok().expect("metadata output error");
     });
 


### PR DESCRIPTION
This commit removes the syntax diagnostic validation as it's been plaguing the bots for two separate reasons and needs a quick fix for now:
1. It's possible to read the stale metadata of previous builds, causing spurious failures that can only be solved by blowing away `tmp`.
2. The code does not currently handle concurrent compilations where JSON files in the metadata directory may be half-written and hence contain invalid JSON when read.

This validation should come back, but it should likely be part of a lint pass run at the very end of the build that doesn't run into consistency or concurrency problems.

---

This commit is a revised version of PR #25592; this approach differs in that it continues to output the JSON metadata, so that the error index page continues to work (assuming that people do not accidentally put in duplicate entries in the meantime).
