### PR TITLE
trpl/macros: Fix description of assert!

### DIFF
--- a/src/doc/trpl/macros.md
+++ b/src/doc/trpl/macros.md
@@ -683,9 +683,9 @@ let v = vec![0; 100];
 
 ## assert! and assert_eq!
 
-These two macros are used in tests. `assert!` takes a boolean, and `assert_eq!`
-takes two values and compares them. Truth passes, success `panic!`s. Like
-this:
+These two macros are used in tests. `assert!` takes a boolean. `assert_eq!`
+takes two values and checks them for equality. `true` passes, `false` `panic!`s.
+Like this:
 
 ```rust,no_run
 // A-ok!


### PR DESCRIPTION
"Truth passes, success `panic!`s" seems to be a typo. The closest fix would be something like "Success passes, failure `panic!`s" but to me a "comparison failure" suggests that we couldn't compare the two values at all, not that we could successfully compare them and that the result was non-equality. So I opted to rewrite the paragraph a bit. If there's a better alternative please let me know.

r? @steveklabnik 
