### PR TITLE
Fix panic in lint for out of range literals

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -206,8 +206,8 @@ impl LintPass for TypeLimits {
                                 let (min, max) = int_ty_range(int_type);
                                 let negative = self.negated_expr_id == e.id;
 
-                                if (negative && v > min.wrapping_neg() as u64) ||
-                                   (!negative && v > (max.abs() as u64)) {
+                                if (negative && min != i64::MIN && v > -min as u64) ||
+                                   (!negative && v > max as u64) {
                                     cx.span_lint(OVERFLOWING_LITERALS, e.span,
                                                  &*format!("literal out of range for {:?}", t));
                                     return;


### PR DESCRIPTION
Reported here https://github.com/rust-lang/rust/pull/25441#issuecomment-103513930
