### PR TITLE
std: Handle DT_DIR file types in `dirent` pointers

### DIFF
--- a/src/rt/rust_builtin.c
+++ b/src/rt/rust_builtin.c
@@ -50,7 +50,7 @@ rust_list_dir_val(struct dirent* entry_ptr) {
 
 int
 rust_dir_get_mode(struct dirent* entry_ptr) {
-#if defined(_DIRENT_HAVE_D_TYPE)
+#if defined(_DIRENT_HAVE_D_TYPE) || defined(__APPLE__)
     switch (entry_ptr->d_type) {
         case DT_BLK: return S_IFBLK;
         case DT_CHR: return S_IFCHR;
@@ -58,6 +58,7 @@ rust_dir_get_mode(struct dirent* entry_ptr) {
         case DT_LNK: return S_IFLNK;
         case DT_REG: return S_IFREG;
         case DT_SOCK: return S_IFSOCK;
+        case DT_DIR: return S_IFDIR;
     }
 #endif
     return -1;


### PR DESCRIPTION
This "fast path" in `DirEntry::file_type` on Unix wasn't turning out to be so
much of a fast path as the `DT_DIR` case wasn't handled, so directories fell
back to using `lstat` instead. This commit adds the missing case to return
quickly if a path is a directory and `DirEntry::file_type` is used.
