### PR TITLE
liblibc: Prototype getopt on Linux as taking a mutable argument

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -5699,7 +5699,12 @@ pub mod funcs {
                 pub fn getgroups(ngroups_max: c_int, groups: *mut gid_t)
                                  -> c_int;
                 pub fn getlogin() -> *mut c_char;
+                #[cfg(not(target_os = "linux"))]
                 pub fn getopt(argc: c_int, argv: *const *const c_char,
+                              optstr: *const c_char) -> c_int;
+                // GNU getopt(3) modifies its arguments despite the prototype.
+                #[cfg(target_os = "linux")]
+                pub fn getopt(argc: c_int, argv: *mut *mut c_char,
                               optstr: *const c_char) -> c_int;
                 pub fn getpgrp() -> pid_t;
                 pub fn getpid() -> pid_t;

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -5490,17 +5490,17 @@ pub mod funcs {
                 pub fn dup2(src: c_int, dst: c_int) -> c_int;
                 #[link_name = "_execv"]
                 pub fn execv(prog: *const c_char,
-                             argv: *mut *const c_char) -> intptr_t;
+                             argv: *const *const c_char) -> intptr_t;
                 #[link_name = "_execve"]
-                pub fn execve(prog: *const c_char, argv: *mut *const c_char,
-                              envp: *mut *const c_char)
+                pub fn execve(prog: *const c_char, argv: *const *const c_char,
+                              envp: *const *const c_char)
                               -> c_int;
                 #[link_name = "_execvp"]
                 pub fn execvp(c: *const c_char,
-                              argv: *mut *const c_char) -> c_int;
+                              argv: *const *const c_char) -> c_int;
                 #[link_name = "_execvpe"]
-                pub fn execvpe(c: *const c_char, argv: *mut *const c_char,
-                               envp: *mut *const c_char) -> c_int;
+                pub fn execvpe(c: *const c_char, argv: *const *const c_char,
+                               envp: *const *const c_char) -> c_int;
                 #[link_name = "_getcwd"]
                 pub fn getcwd(buf: *mut c_char, size: size_t) -> *mut c_char;
                 #[link_name = "_getpid"]
@@ -5684,12 +5684,12 @@ pub mod funcs {
                 pub fn dup(fd: c_int) -> c_int;
                 pub fn dup2(src: c_int, dst: c_int) -> c_int;
                 pub fn execv(prog: *const c_char,
-                             argv: *mut *const c_char) -> c_int;
-                pub fn execve(prog: *const c_char, argv: *mut *const c_char,
-                              envp: *mut *const c_char)
+                             argv: *const *const c_char) -> c_int;
+                pub fn execve(prog: *const c_char, argv: *const *const c_char,
+                              envp: *const *const c_char)
                               -> c_int;
                 pub fn execvp(c: *const c_char,
-                              argv: *mut *const c_char) -> c_int;
+                              argv: *const *const c_char) -> c_int;
                 pub fn fork() -> pid_t;
                 pub fn fpathconf(filedes: c_int, name: c_int) -> c_long;
                 pub fn getcwd(buf: *mut c_char, size: size_t) -> *mut c_char;
@@ -5699,7 +5699,7 @@ pub mod funcs {
                 pub fn getgroups(ngroups_max: c_int, groups: *mut gid_t)
                                  -> c_int;
                 pub fn getlogin() -> *mut c_char;
-                pub fn getopt(argc: c_int, argv: *mut *const c_char,
+                pub fn getopt(argc: c_int, argv: *const *const c_char,
                               optstr: *const c_char) -> c_int;
                 pub fn getpgrp() -> pid_t;
                 pub fn getpid() -> pid_t;
@@ -5749,19 +5749,19 @@ pub mod funcs {
                 pub fn dup(fd: c_int) -> c_int;
                 pub fn dup2(src: c_int, dst: c_int) -> c_int;
                 pub fn execv(prog: *const c_char,
-                             argv: *mut *const c_char) -> c_int;
-                pub fn execve(prog: *const c_char, argv: *mut *const c_char,
-                              envp: *mut *const c_char)
+                             argv: *const *const c_char) -> c_int;
+                pub fn execve(prog: *const c_char, argv: *const *const c_char,
+                              envp: *const *const c_char)
                               -> c_int;
                 pub fn execvp(c: *const c_char,
-                              argv: *mut *const c_char) -> c_int;
+                              argv: *const *const c_char) -> c_int;
                 pub fn fork() -> pid_t;
                 pub fn getcwd(buf: *mut c_char, size: size_t) -> *mut c_char;
                 pub fn getegid() -> gid_t;
                 pub fn geteuid() -> uid_t;
                 pub fn getgid() -> gid_t;
                 pub fn getlogin() -> *mut c_char;
-                pub fn getopt(argc: c_int, argv: *mut *const c_char,
+                pub fn getopt(argc: c_int, argv: *const *const c_char,
                               optstr: *const c_char) -> c_int;
                 pub fn getuid() -> uid_t;
                 pub fn getsid(pid: pid_t) -> pid_t;

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -311,7 +311,7 @@ impl Process {
         if !envp.is_null() {
             *sys::os::environ() = envp as *const _;
         }
-        let _ = libc::execvp(*argv, argv as *mut _);
+        let _ = libc::execvp(*argv, argv);
         fail(&mut output)
     }
 


### PR DESCRIPTION
[This is a followup PR to #25641 and contains that commit: this PR only proposes the [second commit](https://github.com/rust-lang/rust/compare/pull/25641/head...geofft:getopt-const) that GitHub lists.]

There's a GNU-specific weirdness in its getopt implementation (presumably assuming that the function will be called with a mutable argv from main). Quoting the ["conforming to" section of its manpage](http://man7.org/linux/man-pages/man3/getopt.3.html#CONFORMING_TO):

> POSIX.2 and POSIX.1-2001, provided the environment variable `POSIXLY_CORRECT` is set. Otherwise, the elements of argv aren't really const, because we permute them.

Since we have no way to enforce that that variable is set in an FFI binding, I think the safe thing to do is to mark the function as taking a mutable array.

I'm not sure if this is really the right approach. Should we change the other `getopt` prototypes to match, for consistency of compilation? Should we exempt other Linux libcs like Musl?
