### PR TITLE
use posix command to extract first 8 chars

### DIFF
--- a/configure
+++ b/configure
@@ -717,10 +717,10 @@ probe CFG_MD5              md5
 probe CFG_MD5SUM           md5sum
 if [ -n "$CFG_MD5" ]
 then
-    CFG_HASH_COMMAND="$CFG_MD5 -q | head -c 8"
+    CFG_HASH_COMMAND="$CFG_MD5 -q | cut -c 1-8"
 elif [ -n "$CFG_MD5SUM" ]
 then
-    CFG_HASH_COMMAND="$CFG_MD5SUM | head -c 8"
+    CFG_HASH_COMMAND="$CFG_MD5SUM | cut -c 1-8"
 else
     err 'could not find one of: md5 md5sum'
 fi


### PR DESCRIPTION
the "-c" option of head isn't a posix option, and it isn't supported
under openbsd.

prefer the use of cut -c 1-8 (which is posix) to extract the first 8
chars.

r? @alexcrichton
