### PR TITLE
Substitute free lifetimes when `Self` is used within a method body

### DIFF
--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1395,7 +1395,11 @@ fn base_def_to_ty<'tcx>(this: &AstConv<'tcx>,
             // Self in impl (we know the concrete type).
             check_path_args(tcx, base_segments, NO_TPS | NO_REGIONS);
             if let Some(&ty) = tcx.ast_ty_to_ty_cache.borrow().get(&self_ty_id) {
-                ty
+                if let Some(free_substs) = this.get_free_substs() {
+                    ty.subst(tcx, free_substs)
+                } else {
+                    ty
+                }
             } else {
                 tcx.sess.span_bug(span, "self type has not been fully resolved")
             }

--- a/src/test/run-pass/issue-24308.rs
+++ b/src/test/run-pass/issue-24308.rs
@@ -1,0 +1,26 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub trait Foo {
+    fn method1() {}
+    fn method2();
+}
+
+struct Slice<'a, T: 'a>(&'a [T]);
+
+impl<'a, T: 'a> Foo for Slice<'a, T> {
+    fn method2() {
+        <Self as Foo>::method1();
+    }
+}
+
+fn main() {
+    <Slice<()> as Foo>::method2();
+}

--- a/src/test/run-pass/issue-25279.rs
+++ b/src/test/run-pass/issue-25279.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct S<'a>(&'a ());
+
+impl<'a> S<'a> {
+    fn foo(self) -> &'a () {
+        <Self>::bar(self)
+    }
+
+    fn bar(self) -> &'a () {
+        self.0
+    }
+}
+
+fn main() {
+    S(&()).foo();
+}


### PR DESCRIPTION
This is needed because `Self` can be substituted to a type with
lifetime parameters.

Fixes #24308
Fixes #25071
Fixes #25259
Fixes #25279
