### PR TITLE
Fix the typo in The Rust Programming Language book, 5.18. Strings

### DIFF
--- a/src/doc/trpl/strings.md
+++ b/src/doc/trpl/strings.md
@@ -123,7 +123,7 @@ let world = "world!".to_string();
 let hello_world = hello + &world;
 ```
 
-This is because `&String` can automatically coerece to a `&str`. This is a
+This is because `&String` can automatically coerce to a `&str`. This is a
 feature called ‘[`Deref` coercions][dc]’.
 
 [dc]: deref-coercions.html


### PR DESCRIPTION
fix a small typo in the official tutorial. "coerce" instead of "coerece"
r? @steveklabnik
