### PR TITLE
rustdoc: Associated type fixes

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -216,7 +216,7 @@ fn build_type(cx: &DocContext, tcx: &ty::ctxt, did: ast::DefId) -> clean::ItemEn
     clean::TypedefItem(clean::Typedef {
         type_: t.ty.clean(cx),
         generics: (&t.generics, &predicates, subst::TypeSpace).clean(cx),
-    })
+    }, false)
 }
 
 pub fn build_impls(cx: &DocContext, tcx: &ty::ctxt,
@@ -368,7 +368,7 @@ pub fn build_impl(cx: &DocContext,
                                subst::ParamSpace::TypeSpace).clean(cx);
                 Some(clean::Item {
                     name: Some(assoc_ty.name.clean(cx)),
-                    inner: clean::TypedefItem(typedef),
+                    inner: clean::TypedefItem(typedef, true),
                     source: clean::Span::empty(),
                     attrs: vec![],
                     visibility: None,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -343,7 +343,7 @@ pub enum ItemEnum {
     EnumItem(Enum),
     FunctionItem(Function),
     ModuleItem(Module),
-    TypedefItem(Typedef),
+    TypedefItem(Typedef, bool /* is associated type */),
     StaticItem(Static),
     ConstantItem(Constant),
     TraitItem(Trait),
@@ -1282,7 +1282,7 @@ impl Clean<Item> for ast::ImplItem {
                     type_params: Vec::new(),
                     where_predicates: Vec::new()
                 },
-            }),
+            }, true),
             ast::MacImplItem(_) => {
                 MacroItem(Macro {
                     source: self.span.to_src(cx),
@@ -2078,7 +2078,7 @@ impl Clean<Item> for doctree::Typedef {
             inner: TypedefItem(Typedef {
                 type_: self.ty.clean(cx),
                 generics: self.gen.clean(cx),
-            }),
+            }, false),
         }
     }
 }
@@ -2248,7 +2248,7 @@ fn build_deref_target_impls(cx: &DocContext,
 
     for item in items {
         let target = match item.inner {
-            TypedefItem(ref t) => &t.type_,
+            TypedefItem(ref t, true) => &t.type_,
             _ => continue,
         };
         let primitive = match *target {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -664,6 +664,7 @@ impl Clean<TyParamBound> for ty::BuiltinBound {
                 path: path,
                 typarams: None,
                 did: did,
+                is_generic: false,
             },
             lifetimes: vec![]
         }, ast::TraitBoundModifier::None)
@@ -706,7 +707,12 @@ impl<'tcx> Clean<TyParamBound> for ty::TraitRef<'tcx> {
         }
 
         TraitBound(PolyTrait {
-            trait_: ResolvedPath { path: path, typarams: None, did: self.def_id, },
+            trait_: ResolvedPath {
+                path: path,
+                typarams: None,
+                did: self.def_id,
+                is_generic: false,
+            },
             lifetimes: late_bounds
         }, ast::TraitBoundModifier::None)
     }
@@ -1394,11 +1400,13 @@ pub struct PolyTrait {
 /// it does not preserve mutability or boxes.
 #[derive(Clone, RustcEncodable, RustcDecodable, PartialEq, Debug)]
 pub enum Type {
-    /// structs/enums/traits (anything that'd be an ast::TyPath)
+    /// structs/enums/traits (most that'd be an ast::TyPath)
     ResolvedPath {
         path: Path,
         typarams: Option<Vec<TyParamBound>>,
         did: ast::DefId,
+        /// true if is a `T::Name` path for associated types
+        is_generic: bool,
     },
     /// For parameterized types, so the consumer of the JSON don't go
     /// looking for types which don't exist anywhere.
@@ -1587,8 +1595,13 @@ impl Clean<Type> for ast::Ty {
             TyObjectSum(ref lhs, ref bounds) => {
                 let lhs_ty = lhs.clean(cx);
                 match lhs_ty {
-                    ResolvedPath { path, typarams: None, did } => {
-                        ResolvedPath { path: path, typarams: Some(bounds.clean(cx)), did: did}
+                    ResolvedPath { path, typarams: None, did, is_generic } => {
+                        ResolvedPath {
+                            path: path,
+                            typarams: Some(bounds.clean(cx)),
+                            did: did,
+                            is_generic: is_generic,
+                        }
                     }
                     _ => {
                         lhs_ty // shouldn't happen
@@ -1668,6 +1681,7 @@ impl<'tcx> Clean<Type> for ty::Ty<'tcx> {
                     path: path,
                     typarams: None,
                     did: did,
+                    is_generic: false,
                 }
             }
             ty::ty_trait(box ty::TyTrait { ref principal, ref bounds }) => {
@@ -1682,6 +1696,7 @@ impl<'tcx> Clean<Type> for ty::Ty<'tcx> {
                     path: path,
                     typarams: Some(typarams),
                     did: did,
+                    is_generic: false,
                 }
             }
             ty::ty_tup(ref t) => Tuple(t.clean(cx)),
@@ -2572,10 +2587,7 @@ fn resolve_type(cx: &DocContext,
         None => panic!("unresolved id not in defmap")
     };
 
-    match def {
-        def::DefSelfTy(..) if path.segments.len() == 1 => {
-            return Generic(token::get_name(special_idents::type_self.name).to_string());
-        }
+    let is_generic = match def {
         def::DefPrimTy(p) => match p {
             ast::TyStr => return Primitive(Str),
             ast::TyBool => return Primitive(Bool),
@@ -2593,13 +2605,14 @@ fn resolve_type(cx: &DocContext,
             ast::TyFloat(ast::TyF32) => return Primitive(F32),
             ast::TyFloat(ast::TyF64) => return Primitive(F64),
         },
-        def::DefTyParam(_, _, _, n) => {
-            return Generic(token::get_name(n).to_string())
+        def::DefSelfTy(..) if path.segments.len() == 1 => {
+            return Generic(token::get_name(special_idents::type_self.name).to_string());
         }
-        _ => {}
+        def::DefSelfTy(..) | def::DefTyParam(..) => true,
+        _ => false,
     };
     let did = register_def(&*cx, def);
-    ResolvedPath { path: path, typarams: None, did: did }
+    ResolvedPath { path: path, typarams: None, did: did, is_generic: is_generic }
 }
 
 fn register_def(cx: &DocContext, def: def::Def) -> ast::DefId {
@@ -2798,6 +2811,7 @@ fn lang_struct(cx: &DocContext, did: Option<ast::DefId>,
                 }
             }],
         },
+        is_generic: false,
     }
 }
 

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -427,9 +427,9 @@ impl fmt::Display for clean::Type {
             clean::Generic(ref name) => {
                 f.write_str(name)
             }
-            clean::ResolvedPath{ did, ref typarams, ref path } => {
-                // Paths like Self::Output should be rendered with all segments
-                try!(resolved_path(f, did, path, path.segments[0].name == "Self"));
+            clean::ResolvedPath{ did, ref typarams, ref path, is_generic } => {
+                // Paths like T::Output and Self::Output should be rendered with all segments
+                try!(resolved_path(f, did, path, is_generic));
                 tybounds(f, typarams)
             }
             clean::Infer => write!(f, "_"),

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2429,10 +2429,11 @@ fn render_impl(w: &mut fmt::Formatter, i: &Impl, link: AssocItemLink,
 
 fn item_typedef(w: &mut fmt::Formatter, it: &clean::Item,
                 t: &clean::Typedef) -> fmt::Result {
-    try!(write!(w, "<pre class='rust typedef'>type {}{} = {};</pre>",
+    try!(write!(w, "<pre class='rust typedef'>type {}{}{where_clause} = {type_};</pre>",
                   it.name.as_ref().unwrap(),
                   t.generics,
-                  t.type_));
+                  where_clause = WhereClause(&t.generics),
+                  type_ = t.type_));
 
     document(w, it)
 }

--- a/src/test/rustdoc/assoc-types.rs
+++ b/src/test/rustdoc/assoc-types.rs
@@ -18,3 +18,25 @@ pub trait Index<I: ?Sized> {
     //      "fn index<'a>(&'a self, index: I) -> &'a Self::Output"
     fn index<'a>(&'a self, index: I) -> &'a Self::Output;
 }
+
+// @has assoc_types/fn.use_output.html
+// @has - '//*[@class="rust fn"]' '-> &T::Output'
+pub fn use_output<T: Index<usize>>(obj: &T, index: usize) -> &T::Output {
+    obj.index(index)
+}
+
+pub trait Feed {
+    type Input;
+}
+
+// @has assoc_types/fn.use_input.html
+// @has - '//*[@class="rust fn"]' 'T::Input'
+pub fn use_input<T: Feed>(_feed: &T, _element: T::Input) { }
+
+// @has assoc_types/fn.cmp_input.html
+// @has - '//*[@class="rust fn"]' 'where T::Input: PartialEq<U::Input>'
+pub fn cmp_input<T: Feed, U: Feed>(a: &T::Input, b: &U::Input) -> bool
+    where T::Input: PartialEq<U::Input>
+{
+    a == b
+}

--- a/src/test/rustdoc/search-index.rs
+++ b/src/test/rustdoc/search-index.rs
@@ -10,6 +10,8 @@
 
 #![crate_name = "rustdoc_test"]
 
+use std::ops::Deref;
+
 // @has search-index.js Foo
 pub use private::Foo;
 
@@ -23,4 +25,12 @@ mod private {
     pub trait PrivateTrait {
         fn trait_method(&self) {} // @!has - priv_method
     }
+}
+
+pub struct Bar;
+
+impl Deref for Bar {
+    // @!has search-index.js Target
+    type Target = Bar;
+    fn deref(&self) -> &Bar { self }
 }

--- a/src/test/rustdoc/where.rs
+++ b/src/test/rustdoc/where.rs
@@ -42,3 +42,7 @@ pub enum Foxtrot<F> { Foxtrot1(F) }
 // @has foo/trait.MyTrait.html '//*[@id="implementors-list"]//code' \
 //          "impl<F> MyTrait for Foxtrot<F> where F: MyTrait"
 impl<F> MyTrait for Foxtrot<F> where F: MyTrait {}
+
+// @has foo/type.Golf.html '//pre[@class="rust typedef"]' \
+//          "type Golf<T> where T: Clone = (T, T)"
+pub type Golf<T> where T: Clone = (T, T);


### PR DESCRIPTION
rustdoc: Associated type fixes

The first commit fixes a bug with "dud" items in the search index from
misrepresented `type` items in trait impl blocks.

For a trait _implementation_ there are typedefs which are the types for
that particular trait and implementor. Skip these in the search index.

There were lots of dud items in the search index due to this (search for
Item, Iterator's associated type).

Add a boolean to clean::TypedefItem so that it tracks whether the it is
a type alias on its own, or if it's a `type` item in a trait impl.

The second commit fixes a bug that made signatures and where bounds
using associated types (if they were not on `Self`) incorrect.

The third commit fixes so that where clauses in type alias definititons
are shown.

Fixes #22442
Fixes #24417
Fixes #25769
