### PR TITLE
Simplify `core::num` using `Self`

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1362,9 +1362,9 @@ pub trait Float {
 }
 
 macro_rules! from_str_float_impl {
-    ($T:ident) => {
+    ($t:ty) => {
         #[stable(feature = "rust1", since = "1.0.0")]
-        impl FromStr for $T {
+        impl FromStr for $t {
             type Err = ParseFloatError;
 
             /// Converts a string in base 10 to a float.
@@ -1405,10 +1405,10 @@ from_str_float_impl!(f32);
 from_str_float_impl!(f64);
 
 macro_rules! from_str_radix_int_impl {
-    ($($T:ident)*) => {$(
+    ($($t:ty)*) => {$(
         #[stable(feature = "rust1", since = "1.0.0")]
         #[allow(deprecated)]
-        impl FromStr for $T {
+        impl FromStr for $t {
             type Err = ParseIntError;
             fn from_str(src: &str) -> Result<Self, ParseIntError> {
                 from_str_radix(src, 10)
@@ -1428,7 +1428,7 @@ trait FromStrRadixHelper: PartialOrd + Copy {
 }
 
 macro_rules! doit {
-    ($($t:ident)*) => ($(impl FromStrRadixHelper for $t {
+    ($($t:ty)*) => ($(impl FromStrRadixHelper for $t {
         fn min_value() -> Self { Self::min_value() }
         fn from_u32(u: u32) -> Self { u as Self }
         fn checked_mul(&self, other: u32) -> Option<Self> {

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -73,11 +73,11 @@ macro_rules! zero_one_impl {
     ($($t:ty)*) => ($(
         impl Zero for $t {
             #[inline]
-            fn zero() -> $t { 0 }
+            fn zero() -> Self { 0 }
         }
         impl One for $t {
             #[inline]
-            fn one() -> $t { 1 }
+            fn one() -> Self { 1 }
         }
     )*)
 }
@@ -87,20 +87,20 @@ macro_rules! zero_one_impl_float {
     ($($t:ty)*) => ($(
         impl Zero for $t {
             #[inline]
-            fn zero() -> $t { 0.0 }
+            fn zero() -> Self { 0.0 }
         }
         impl One for $t {
             #[inline]
-            fn one() -> $t { 1.0 }
+            fn one() -> Self { 1.0 }
         }
     )*)
 }
 zero_one_impl_float! { f32 f64 }
 
 macro_rules! checked_op {
-    ($T:ty, $U:ty, $op:path, $x:expr, $y:expr) => {{
+    ($U:ty, $op:path, $x:expr, $y:expr) => {{
         let (result, overflowed) = unsafe { $op($x as $U, $y as $U) };
-        if overflowed { None } else { Some(result as $T) }
+        if overflowed { None } else { Some(result as Self) }
     }}
 }
 
@@ -110,22 +110,22 @@ unsafe fn bswap8(x: u8) -> u8 { x }
 
 // `Int` + `SignedInt` implemented for signed integers
 macro_rules! int_impl {
-    ($T:ident = $ActualT:ty, $UnsignedT:ty, $BITS:expr,
+    ($ActualT:ty, $UnsignedT:ty, $BITS:expr,
      $add_with_overflow:path,
      $sub_with_overflow:path,
      $mul_with_overflow:path) => {
         /// Returns the smallest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn min_value() -> $T {
-            (-1 as $T) << ($BITS - 1)
+        pub fn min_value() -> Self {
+            (-1 as Self) << ($BITS - 1)
         }
 
         /// Returns the largest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn max_value() -> $T {
-            let min = $T::min_value(); !min
+        pub fn max_value() -> Self {
+            let min = Self::min_value(); !min
         }
 
         /// Converts a string slice in a given base to an integer.
@@ -139,7 +139,7 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[allow(deprecated)]
-        pub fn from_str_radix(src: &str, radix: u32) -> Result<$T, ParseIntError> {
+        pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
             from_str_radix(src, radix)
         }
 
@@ -216,8 +216,8 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn rotate_left(self, n: u32) -> $T {
-            (self as $UnsignedT).rotate_left(n) as $T
+        pub fn rotate_left(self, n: u32) -> Self {
+            (self as $UnsignedT).rotate_left(n) as Self
         }
 
         /// Shifts the bits to the right by a specified amount, `n`,
@@ -234,8 +234,8 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn rotate_right(self, n: u32) -> $T {
-            (self as $UnsignedT).rotate_right(n) as $T
+        pub fn rotate_right(self, n: u32) -> Self {
+            (self as $UnsignedT).rotate_right(n) as Self
         }
 
         /// Reverses the byte order of the integer.
@@ -250,8 +250,8 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn swap_bytes(self) -> $T {
-            (self as $UnsignedT).swap_bytes() as $T
+        pub fn swap_bytes(self) -> Self {
+            (self as $UnsignedT).swap_bytes() as Self
         }
 
         /// Converts an integer from big endian to the target's endianness.
@@ -272,7 +272,7 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn from_be(x: $T) -> $T {
+        pub fn from_be(x: Self) -> Self {
             if cfg!(target_endian = "big") { x } else { x.swap_bytes() }
         }
 
@@ -294,7 +294,7 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn from_le(x: $T) -> $T {
+        pub fn from_le(x: Self) -> Self {
             if cfg!(target_endian = "little") { x } else { x.swap_bytes() }
         }
 
@@ -316,7 +316,7 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn to_be(self) -> $T { // or not to be?
+        pub fn to_be(self) -> Self { // or not to be?
             if cfg!(target_endian = "big") { self } else { self.swap_bytes() }
         }
 
@@ -338,7 +338,7 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn to_le(self) -> $T {
+        pub fn to_le(self) -> Self {
             if cfg!(target_endian = "little") { self } else { self.swap_bytes() }
         }
 
@@ -353,8 +353,8 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn checked_add(self, other: $T) -> Option<$T> {
-            checked_op!($T, $ActualT, $add_with_overflow, self, other)
+        pub fn checked_add(self, other: Self) -> Option<Self> {
+            checked_op!($ActualT, $add_with_overflow, self, other)
         }
 
         /// Checked integer subtraction. Computes `self - other`, returning
@@ -368,8 +368,8 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn checked_sub(self, other: $T) -> Option<$T> {
-            checked_op!($T, $ActualT, $sub_with_overflow, self, other)
+        pub fn checked_sub(self, other: Self) -> Option<Self> {
+            checked_op!($ActualT, $sub_with_overflow, self, other)
         }
 
         /// Checked integer multiplication. Computes `self * other`, returning
@@ -383,8 +383,8 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn checked_mul(self, other: $T) -> Option<$T> {
-            checked_op!($T, $ActualT, $mul_with_overflow, self, other)
+        pub fn checked_mul(self, other: Self) -> Option<Self> {
+            checked_op!($ActualT, $mul_with_overflow, self, other)
         }
 
         /// Checked integer division. Computes `self / other`, returning `None`
@@ -399,10 +399,10 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn checked_div(self, v: $T) -> Option<$T> {
+        pub fn checked_div(self, v: Self) -> Option<Self> {
             match v {
                 0   => None,
-               -1 if self == <$T>::min_value()
+               -1 if self == Self::min_value()
                     => None,
                 v   => Some(self / v),
             }
@@ -412,11 +412,11 @@ macro_rules! int_impl {
         /// the numeric bounds instead of overflowing.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn saturating_add(self, other: $T) -> $T {
+        pub fn saturating_add(self, other: Self) -> Self {
             match self.checked_add(other) {
                 Some(x)                       => x,
-                None if other >= <$T as Zero>::zero() => <$T>::max_value(),
-                None => <$T>::min_value(),
+                None if other >= Self::zero() => Self::max_value(),
+                None => Self::min_value(),
             }
         }
 
@@ -424,11 +424,11 @@ macro_rules! int_impl {
         /// at the numeric bounds instead of overflowing.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn saturating_sub(self, other: $T) -> $T {
+        pub fn saturating_sub(self, other: Self) -> Self {
             match self.checked_sub(other) {
                 Some(x)                      => x,
-                None if other >= <$T as Zero>::zero() => <$T>::min_value(),
-                None => <$T>::max_value(),
+                None if other >= Self::zero() => Self::min_value(),
+                None => Self::max_value(),
             }
         }
 
@@ -436,7 +436,7 @@ macro_rules! int_impl {
         /// wrapping around at the boundary of the type.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn wrapping_add(self, rhs: $T) -> $T {
+        pub fn wrapping_add(self, rhs: Self) -> Self {
             unsafe {
                 intrinsics::overflowing_add(self, rhs)
             }
@@ -446,7 +446,7 @@ macro_rules! int_impl {
         /// wrapping around at the boundary of the type.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn wrapping_sub(self, rhs: $T) -> $T {
+        pub fn wrapping_sub(self, rhs: Self) -> Self {
             unsafe {
                 intrinsics::overflowing_sub(self, rhs)
             }
@@ -456,7 +456,7 @@ macro_rules! int_impl {
         /// other`, wrapping around at the boundary of the type.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn wrapping_mul(self, rhs: $T) -> $T {
+        pub fn wrapping_mul(self, rhs: Self) -> Self {
             unsafe {
                 intrinsics::overflowing_mul(self, rhs)
             }
@@ -473,7 +473,7 @@ macro_rules! int_impl {
         /// itself..
         #[unstable(feature = "core", since = "1.0.0")]
         #[inline(always)]
-        pub fn wrapping_div(self, rhs: $T) -> $T {
+        pub fn wrapping_div(self, rhs: Self) -> Self {
             self.overflowing_div(rhs).0
         }
 
@@ -486,7 +486,7 @@ macro_rules! int_impl {
         /// minimal value). In such a case, this function returns `0`.
         #[unstable(feature = "core", since = "1.0.0")]
         #[inline(always)]
-        pub fn wrapping_rem(self, rhs: $T) -> $T {
+        pub fn wrapping_rem(self, rhs: Self) -> Self {
             self.overflowing_rem(rhs).0
         }
 
@@ -500,7 +500,7 @@ macro_rules! int_impl {
         /// a case, this function returns `MIN` itself.
         #[unstable(feature = "core", since = "1.0.0")]
         #[inline(always)]
-        pub fn wrapping_neg(self) -> $T {
+        pub fn wrapping_neg(self) -> Self {
             self.overflowing_neg().0
         }
 
@@ -509,7 +509,7 @@ macro_rules! int_impl {
         /// would cause the shift to exceed the bitwidth of the type.
         #[unstable(feature = "core", since = "1.0.0")]
         #[inline(always)]
-        pub fn wrapping_shl(self, rhs: u32) -> $T {
+        pub fn wrapping_shl(self, rhs: u32) -> Self {
             self.overflowing_shl(rhs).0
         }
 
@@ -518,7 +518,7 @@ macro_rules! int_impl {
         /// would cause the shift to exceed the bitwidth of the type.
         #[unstable(feature = "core", since = "1.0.0")]
         #[inline(always)]
-        pub fn wrapping_shr(self, rhs: u32) -> $T {
+        pub fn wrapping_shr(self, rhs: u32) -> Self {
             self.overflowing_shr(rhs).0
         }
 
@@ -533,9 +533,9 @@ macro_rules! int_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn pow(self, mut exp: u32) -> $T {
+        pub fn pow(self, mut exp: u32) -> Self {
             let mut base = self;
-            let mut acc = <$T as One>::one();
+            let mut acc = Self::one();
 
             let mut prev_base = self;
             let mut base_oflo = false;
@@ -569,7 +569,7 @@ macro_rules! int_impl {
         /// optimized code will return `i32::min_value()` without a panic.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn abs(self) -> $T {
+        pub fn abs(self) -> Self {
             if self.is_negative() {
                 // Note that the #[inline] above means that the overflow
                 // semantics of this negation depend on the crate we're being
@@ -587,7 +587,7 @@ macro_rules! int_impl {
         /// - `-1` if the number is negative
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn signum(self) -> $T {
+        pub fn signum(self) -> Self {
             match self {
                 n if n > 0 =>  1,
                 0          =>  0,
@@ -611,7 +611,7 @@ macro_rules! int_impl {
 
 #[lang = "i8"]
 impl i8 {
-    int_impl! { i8 = i8, u8, 8,
+    int_impl! { i8, u8, 8,
         intrinsics::i8_add_with_overflow,
         intrinsics::i8_sub_with_overflow,
         intrinsics::i8_mul_with_overflow }
@@ -619,7 +619,7 @@ impl i8 {
 
 #[lang = "i16"]
 impl i16 {
-    int_impl! { i16 = i16, u16, 16,
+    int_impl! { i16, u16, 16,
         intrinsics::i16_add_with_overflow,
         intrinsics::i16_sub_with_overflow,
         intrinsics::i16_mul_with_overflow }
@@ -627,7 +627,7 @@ impl i16 {
 
 #[lang = "i32"]
 impl i32 {
-    int_impl! { i32 = i32, u32, 32,
+    int_impl! { i32, u32, 32,
         intrinsics::i32_add_with_overflow,
         intrinsics::i32_sub_with_overflow,
         intrinsics::i32_mul_with_overflow }
@@ -635,7 +635,7 @@ impl i32 {
 
 #[lang = "i64"]
 impl i64 {
-    int_impl! { i64 = i64, u64, 64,
+    int_impl! { i64, u64, 64,
         intrinsics::i64_add_with_overflow,
         intrinsics::i64_sub_with_overflow,
         intrinsics::i64_mul_with_overflow }
@@ -644,7 +644,7 @@ impl i64 {
 #[cfg(target_pointer_width = "32")]
 #[lang = "isize"]
 impl isize {
-    int_impl! { isize = i32, u32, 32,
+    int_impl! { i32, u32, 32,
         intrinsics::i32_add_with_overflow,
         intrinsics::i32_sub_with_overflow,
         intrinsics::i32_mul_with_overflow }
@@ -653,7 +653,7 @@ impl isize {
 #[cfg(target_pointer_width = "64")]
 #[lang = "isize"]
 impl isize {
-    int_impl! { isize = i64, u64, 64,
+    int_impl! { i64, u64, 64,
         intrinsics::i64_add_with_overflow,
         intrinsics::i64_sub_with_overflow,
         intrinsics::i64_mul_with_overflow }
@@ -661,7 +661,7 @@ impl isize {
 
 // `Int` + `UnsignedInt` implemented for signed integers
 macro_rules! uint_impl {
-    ($T:ty = $ActualT:ty, $BITS:expr,
+    ($ActualT:ty, $BITS:expr,
      $ctpop:path,
      $ctlz:path,
      $cttz:path,
@@ -671,11 +671,11 @@ macro_rules! uint_impl {
      $mul_with_overflow:path) => {
         /// Returns the smallest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub fn min_value() -> $T { 0 }
+        pub fn min_value() -> Self { 0 }
 
         /// Returns the largest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub fn max_value() -> $T { !0 }
+        pub fn max_value() -> Self { !0 }
 
         /// Converts a string slice in a given base to an integer.
         ///
@@ -692,7 +692,7 @@ macro_rules! uint_impl {
         /// Otherwise, `Ok(n)` where `n` is the integer represented by `src`.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[allow(deprecated)]
-        pub fn from_str_radix(src: &str, radix: u32) -> Result<$T, ParseIntError> {
+        pub fn from_str_radix(src: &str, radix: u32) -> Result<Self, ParseIntError> {
             from_str_radix(src, radix)
         }
 
@@ -784,7 +784,7 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn rotate_left(self, n: u32) -> $T {
+        pub fn rotate_left(self, n: u32) -> Self {
             // Protect against undefined behaviour for over-long bit shifts
             let n = n % $BITS;
             (self << n) | (self >> (($BITS - n) % $BITS))
@@ -804,7 +804,7 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn rotate_right(self, n: u32) -> $T {
+        pub fn rotate_right(self, n: u32) -> Self {
             // Protect against undefined behaviour for over-long bit shifts
             let n = n % $BITS;
             (self >> n) | (self << (($BITS - n) % $BITS))
@@ -822,8 +822,8 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn swap_bytes(self) -> $T {
-            unsafe { $bswap(self as $ActualT) as $T }
+        pub fn swap_bytes(self) -> Self {
+            unsafe { $bswap(self as $ActualT) as Self }
         }
 
         /// Converts an integer from big endian to the target's endianness.
@@ -844,7 +844,7 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn from_be(x: $T) -> $T {
+        pub fn from_be(x: Self) -> Self {
             if cfg!(target_endian = "big") { x } else { x.swap_bytes() }
         }
 
@@ -866,7 +866,7 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn from_le(x: $T) -> $T {
+        pub fn from_le(x: Self) -> Self {
             if cfg!(target_endian = "little") { x } else { x.swap_bytes() }
         }
 
@@ -888,7 +888,7 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn to_be(self) -> $T { // or not to be?
+        pub fn to_be(self) -> Self { // or not to be?
             if cfg!(target_endian = "big") { self } else { self.swap_bytes() }
         }
 
@@ -910,7 +910,7 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn to_le(self) -> $T {
+        pub fn to_le(self) -> Self {
             if cfg!(target_endian = "little") { self } else { self.swap_bytes() }
         }
 
@@ -925,8 +925,8 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn checked_add(self, other: $T) -> Option<$T> {
-            checked_op!($T, $ActualT, $add_with_overflow, self, other)
+        pub fn checked_add(self, other: Self) -> Option<Self> {
+            checked_op!($ActualT, $add_with_overflow, self, other)
         }
 
         /// Checked integer subtraction. Computes `self - other`, returning
@@ -940,8 +940,8 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn checked_sub(self, other: $T) -> Option<$T> {
-            checked_op!($T, $ActualT, $sub_with_overflow, self, other)
+        pub fn checked_sub(self, other: Self) -> Option<Self> {
+            checked_op!($ActualT, $sub_with_overflow, self, other)
         }
 
         /// Checked integer multiplication. Computes `self * other`, returning
@@ -955,8 +955,8 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn checked_mul(self, other: $T) -> Option<$T> {
-            checked_op!($T, $ActualT, $mul_with_overflow, self, other)
+        pub fn checked_mul(self, other: Self) -> Option<Self> {
+            checked_op!($ActualT, $mul_with_overflow, self, other)
         }
 
         /// Checked integer division. Computes `self / other`, returning `None`
@@ -971,7 +971,7 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn checked_div(self, v: $T) -> Option<$T> {
+        pub fn checked_div(self, v: Self) -> Option<Self> {
             match v {
                 0 => None,
                 v => Some(self / v),
@@ -982,11 +982,11 @@ macro_rules! uint_impl {
         /// the numeric bounds instead of overflowing.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn saturating_add(self, other: $T) -> $T {
+        pub fn saturating_add(self, other: Self) -> Self {
             match self.checked_add(other) {
                 Some(x)                       => x,
-                None if other >= <$T as Zero>::zero() => <$T>::max_value(),
-                None => <$T>::min_value(),
+                None if other >= Self::zero() => Self::max_value(),
+                None => Self::min_value(),
             }
         }
 
@@ -994,11 +994,11 @@ macro_rules! uint_impl {
         /// at the numeric bounds instead of overflowing.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn saturating_sub(self, other: $T) -> $T {
+        pub fn saturating_sub(self, other: Self) -> Self {
             match self.checked_sub(other) {
                 Some(x)                       => x,
-                None if other >= <$T as Zero>::zero() => <$T>::min_value(),
-                None => <$T>::max_value(),
+                None if other >= Self::zero() => Self::min_value(),
+                None => Self::max_value(),
             }
         }
 
@@ -1006,7 +1006,7 @@ macro_rules! uint_impl {
         /// wrapping around at the boundary of the type.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn wrapping_add(self, rhs: $T) -> $T {
+        pub fn wrapping_add(self, rhs: Self) -> Self {
             unsafe {
                 intrinsics::overflowing_add(self, rhs)
             }
@@ -1016,7 +1016,7 @@ macro_rules! uint_impl {
         /// wrapping around at the boundary of the type.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn wrapping_sub(self, rhs: $T) -> $T {
+        pub fn wrapping_sub(self, rhs: Self) -> Self {
             unsafe {
                 intrinsics::overflowing_sub(self, rhs)
             }
@@ -1026,7 +1026,7 @@ macro_rules! uint_impl {
         /// other`, wrapping around at the boundary of the type.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn wrapping_mul(self, rhs: $T) -> $T {
+        pub fn wrapping_mul(self, rhs: Self) -> Self {
             unsafe {
                 intrinsics::overflowing_mul(self, rhs)
             }
@@ -1043,7 +1043,7 @@ macro_rules! uint_impl {
         /// itself..
         #[unstable(feature = "core", since = "1.0.0")]
         #[inline(always)]
-        pub fn wrapping_div(self, rhs: $T) -> $T {
+        pub fn wrapping_div(self, rhs: Self) -> Self {
             self.overflowing_div(rhs).0
         }
 
@@ -1056,7 +1056,7 @@ macro_rules! uint_impl {
         /// minimal value). In such a case, this function returns `0`.
         #[unstable(feature = "core", since = "1.0.0")]
         #[inline(always)]
-        pub fn wrapping_rem(self, rhs: $T) -> $T {
+        pub fn wrapping_rem(self, rhs: Self) -> Self {
             self.overflowing_rem(rhs).0
         }
 
@@ -1070,7 +1070,7 @@ macro_rules! uint_impl {
         /// a case, this function returns `MIN` itself.
         #[unstable(feature = "core", since = "1.0.0")]
         #[inline(always)]
-        pub fn wrapping_neg(self) -> $T {
+        pub fn wrapping_neg(self) -> Self {
             self.overflowing_neg().0
         }
 
@@ -1079,7 +1079,7 @@ macro_rules! uint_impl {
         /// would cause the shift to exceed the bitwidth of the type.
         #[unstable(feature = "core", since = "1.0.0")]
         #[inline(always)]
-        pub fn wrapping_shl(self, rhs: u32) -> $T {
+        pub fn wrapping_shl(self, rhs: u32) -> Self {
             self.overflowing_shl(rhs).0
         }
 
@@ -1088,7 +1088,7 @@ macro_rules! uint_impl {
         /// would cause the shift to exceed the bitwidth of the type.
         #[unstable(feature = "core", since = "1.0.0")]
         #[inline(always)]
-        pub fn wrapping_shr(self, rhs: u32) -> $T {
+        pub fn wrapping_shr(self, rhs: u32) -> Self {
             self.overflowing_shr(rhs).0
         }
 
@@ -1101,9 +1101,9 @@ macro_rules! uint_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn pow(self, mut exp: u32) -> $T {
+        pub fn pow(self, mut exp: u32) -> Self {
             let mut base = self;
-            let mut acc = <$T as One>::one();
+            let mut acc = Self::one();
 
             let mut prev_base = self;
             let mut base_oflo = false;
@@ -1131,17 +1131,17 @@ macro_rules! uint_impl {
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
         pub fn is_power_of_two(self) -> bool {
-            (self.wrapping_sub(<$T as One>::one())) & self == <$T as Zero>::zero() &&
-                !(self == <$T as Zero>::zero())
+            (self.wrapping_sub(Self::one())) & self == Self::zero() &&
+                !(self == Self::zero())
         }
 
         /// Returns the smallest power of two greater than or equal to `self`.
         /// Unspecified behavior on overflow.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline]
-        pub fn next_power_of_two(self) -> $T {
-            let bits = size_of::<$T>() * 8;
-            let one: $T = <$T as One>::one();
+        pub fn next_power_of_two(self) -> Self {
+            let bits = size_of::<Self>() * 8;
+            let one: Self = Self::one();
             one << ((bits - self.wrapping_sub(one).leading_zeros() as usize) % bits)
         }
 
@@ -1149,7 +1149,7 @@ macro_rules! uint_impl {
         /// the next power of two is greater than the type's maximum value,
         /// `None` is returned, otherwise the power of two is wrapped in `Some`.
         #[stable(feature = "rust1", since = "1.0.0")]
-        pub fn checked_next_power_of_two(self) -> Option<$T> {
+        pub fn checked_next_power_of_two(self) -> Option<Self> {
             let npot = self.next_power_of_two();
             if npot >= self {
                 Some(npot)
@@ -1162,7 +1162,7 @@ macro_rules! uint_impl {
 
 #[lang = "u8"]
 impl u8 {
-    uint_impl! { u8 = u8, 8,
+    uint_impl! { u8, 8,
         intrinsics::ctpop8,
         intrinsics::ctlz8,
         intrinsics::cttz8,
@@ -1174,7 +1174,7 @@ impl u8 {
 
 #[lang = "u16"]
 impl u16 {
-    uint_impl! { u16 = u16, 16,
+    uint_impl! { u16, 16,
         intrinsics::ctpop16,
         intrinsics::ctlz16,
         intrinsics::cttz16,
@@ -1186,7 +1186,7 @@ impl u16 {
 
 #[lang = "u32"]
 impl u32 {
-    uint_impl! { u32 = u32, 32,
+    uint_impl! { u32, 32,
         intrinsics::ctpop32,
         intrinsics::ctlz32,
         intrinsics::cttz32,
@@ -1199,7 +1199,7 @@ impl u32 {
 
 #[lang = "u64"]
 impl u64 {
-    uint_impl! { u64 = u64, 64,
+    uint_impl! { u64, 64,
         intrinsics::ctpop64,
         intrinsics::ctlz64,
         intrinsics::cttz64,
@@ -1212,7 +1212,7 @@ impl u64 {
 #[cfg(target_pointer_width = "32")]
 #[lang = "usize"]
 impl usize {
-    uint_impl! { usize = u32, 32,
+    uint_impl! { u32, 32,
         intrinsics::ctpop32,
         intrinsics::ctlz32,
         intrinsics::cttz32,
@@ -1225,7 +1225,7 @@ impl usize {
 #[cfg(target_pointer_width = "64")]
 #[lang = "usize"]
 impl usize {
-    uint_impl! { usize = u64, 64,
+    uint_impl! { u64, 64,
         intrinsics::ctpop64,
         intrinsics::ctlz64,
         intrinsics::cttz64,
@@ -1395,8 +1395,8 @@ macro_rules! from_str_float_impl {
             /// number represented by `src`.
             #[inline]
             #[allow(deprecated)]
-            fn from_str(src: &str) -> Result<$T, ParseFloatError> {
-                $T::from_str_radix(src, 10)
+            fn from_str(src: &str) -> Result<Self, ParseFloatError> {
+                Self::from_str_radix(src, 10)
             }
         }
     }
@@ -1410,7 +1410,7 @@ macro_rules! from_str_radix_int_impl {
         #[allow(deprecated)]
         impl FromStr for $T {
             type Err = ParseIntError;
-            fn from_str(src: &str) -> Result<$T, ParseIntError> {
+            fn from_str(src: &str) -> Result<Self, ParseIntError> {
                 from_str_radix(src, 10)
             }
         }
@@ -1429,16 +1429,16 @@ trait FromStrRadixHelper: PartialOrd + Copy {
 
 macro_rules! doit {
     ($($t:ident)*) => ($(impl FromStrRadixHelper for $t {
-        fn min_value() -> Self { <$t>::min_value() }
-        fn from_u32(u: u32) -> Self { u as $t }
+        fn min_value() -> Self { Self::min_value() }
+        fn from_u32(u: u32) -> Self { u as Self }
         fn checked_mul(&self, other: u32) -> Option<Self> {
-            <$t>::checked_mul(*self, other as $t)
+            Self::checked_mul(*self, other as Self)
         }
         fn checked_sub(&self, other: u32) -> Option<Self> {
-            <$t>::checked_sub(*self, other as $t)
+            Self::checked_sub(*self, other as Self)
         }
         fn checked_add(&self, other: u32) -> Option<Self> {
-            <$t>::checked_add(*self, other as $t)
+            Self::checked_add(*self, other as Self)
         }
     })*)
 }


### PR DESCRIPTION
Cleanup extracted from #25684. r? @alexcrichton 
