### PR TITLE
Two minor friendliness patches to ./configure

### DIFF
--- a/configure
+++ b/configure
@@ -33,8 +33,8 @@ need_ok() {
 
 need_cmd() {
     if command -v $1 >/dev/null 2>&1
-    then msg "found program $1"
-    else err "need program $1"
+    then msg "found program '$1'"
+    else err "program '$1' is missing, please install it"
     fi
 }
 

--- a/configure
+++ b/configure
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 msg() {
-    echo "configure: $1"
+    echo "configure: $*"
 }
 
 step_msg() {


### PR DESCRIPTION
Make the error message about missing dependencies clearer, since "need program file" is pretty confusing, and make full commands get logged, since that seems to have been the intention.
