### PR TITLE
Remove error diagnostics uniqueness check and .json generation.

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -77,7 +77,8 @@ ERR_IDX_GEN = $(RPATH_VAR2_T_$(CFG_BUILD)_H_$(CFG_BUILD)) $(ERR_IDX_GEN_EXE)
 
 D := $(S)src/doc
 
-DOC_TARGETS := trpl style error-index
+# FIXME (#25705) eventually may want to put error-index target back here.
+DOC_TARGETS := trpl style
 COMPILER_DOC_TARGETS :=
 DOC_L10N_TARGETS :=
 


### PR DESCRIPTION
Remove error diagnostics uniqueness check and .json generation.

This is yet another revamping of PR #25592, more in line with its original strategy.

As @alexcrichton said on that PR:

> the syntax diagnostic validation as it's been plaguing the bots for two separate reasons and needs a quick fix for now:
> -  It's possible to read the stale metadata of previous builds, causing spurious failures that can only be solved by blowing away tmp.
> -  The code does not currently handle concurrent compilations where JSON files in the metadata directory may be half-written and hence contain invalid JSON when read.

This is meant to be a temporary measure to get the builds to be reliable again; see also Issue #25705.
