### PR TITLE
Let MultiItemDecorator take `&Annotatable`

### DIFF
--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -154,18 +154,18 @@ pub trait MultiItemDecorator {
               ecx: &mut ExtCtxt,
               sp: Span,
               meta_item: &ast::MetaItem,
-              item: Annotatable,
+              item: &Annotatable,
               push: &mut FnMut(Annotatable));
 }
 
 impl<F> MultiItemDecorator for F
-    where F : Fn(&mut ExtCtxt, Span, &ast::MetaItem, Annotatable, &mut FnMut(Annotatable))
+    where F : Fn(&mut ExtCtxt, Span, &ast::MetaItem, &Annotatable, &mut FnMut(Annotatable))
 {
     fn expand(&self,
               ecx: &mut ExtCtxt,
               sp: Span,
               meta_item: &ast::MetaItem,
-              item: Annotatable,
+              item: &Annotatable,
               push: &mut FnMut(Annotatable)) {
         (*self)(ecx, sp, meta_item, item, push)
     }

--- a/src/libsyntax/ext/deriving/bounds.rs
+++ b/src/libsyntax/ext/deriving/bounds.rs
@@ -17,7 +17,7 @@ use ext::deriving::generic::ty::*;
 pub fn expand_deriving_unsafe_bound(cx: &mut ExtCtxt,
                                     span: Span,
                                     _: &MetaItem,
-                                    _: Annotatable,
+                                    _: &Annotatable,
                                     _: &mut FnMut(Annotatable))
 {
     cx.span_err(span, "this unsafe trait should be implemented explicitly");
@@ -26,7 +26,7 @@ pub fn expand_deriving_unsafe_bound(cx: &mut ExtCtxt,
 pub fn expand_deriving_copy(cx: &mut ExtCtxt,
                             span: Span,
                             mitem: &MetaItem,
-                            item: Annotatable,
+                            item: &Annotatable,
                             push: &mut FnMut(Annotatable))
 {
     let path = Path::new(vec![
@@ -45,5 +45,5 @@ pub fn expand_deriving_copy(cx: &mut ExtCtxt,
         associated_types: Vec::new(),
     };
 
-    trait_def.expand(cx, mitem, &item, push);
+    trait_def.expand(cx, mitem, item, push);
 }

--- a/src/libsyntax/ext/deriving/clone.rs
+++ b/src/libsyntax/ext/deriving/clone.rs
@@ -20,7 +20,7 @@ use ptr::P;
 pub fn expand_deriving_clone(cx: &mut ExtCtxt,
                              span: Span,
                              mitem: &MetaItem,
-                             item: Annotatable,
+                             item: &Annotatable,
                              push: &mut FnMut(Annotatable))
 {
     let inline = cx.meta_word(span, InternedString::new("inline"));
@@ -48,7 +48,7 @@ pub fn expand_deriving_clone(cx: &mut ExtCtxt,
         associated_types: Vec::new(),
     };
 
-    trait_def.expand(cx, mitem, &item, push)
+    trait_def.expand(cx, mitem, item, push)
 }
 
 fn cs_clone(

--- a/src/libsyntax/ext/deriving/cmp/eq.rs
+++ b/src/libsyntax/ext/deriving/cmp/eq.rs
@@ -20,7 +20,7 @@ use ptr::P;
 pub fn expand_deriving_eq(cx: &mut ExtCtxt,
                           span: Span,
                           mitem: &MetaItem,
-                          item: Annotatable,
+                          item: &Annotatable,
                           push: &mut FnMut(Annotatable))
 {
     fn cs_total_eq_assert(cx: &mut ExtCtxt, span: Span, substr: &Substructure) -> P<Expr> {
@@ -67,5 +67,5 @@ pub fn expand_deriving_eq(cx: &mut ExtCtxt,
         ),
         associated_types: Vec::new(),
     };
-    trait_def.expand(cx, mitem, &item, push)
+    trait_def.expand(cx, mitem, item, push)
 }

--- a/src/libsyntax/ext/deriving/cmp/ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/ord.rs
@@ -21,7 +21,7 @@ use ptr::P;
 pub fn expand_deriving_ord(cx: &mut ExtCtxt,
                            span: Span,
                            mitem: &MetaItem,
-                           item: Annotatable,
+                           item: &Annotatable,
                            push: &mut FnMut(Annotatable))
 {
     let inline = cx.meta_word(span, InternedString::new("inline"));
@@ -49,7 +49,7 @@ pub fn expand_deriving_ord(cx: &mut ExtCtxt,
         associated_types: Vec::new(),
     };
 
-    trait_def.expand(cx, mitem, &item, push)
+    trait_def.expand(cx, mitem, item, push)
 }
 
 

--- a/src/libsyntax/ext/deriving/cmp/partial_eq.rs
+++ b/src/libsyntax/ext/deriving/cmp/partial_eq.rs
@@ -20,7 +20,7 @@ use ptr::P;
 pub fn expand_deriving_partial_eq(cx: &mut ExtCtxt,
                                   span: Span,
                                   mitem: &MetaItem,
-                                  item: Annotatable,
+                                  item: &Annotatable,
                                   push: &mut FnMut(Annotatable))
 {
     // structures are equal if all fields are equal, and non equal, if
@@ -91,5 +91,5 @@ pub fn expand_deriving_partial_eq(cx: &mut ExtCtxt,
         ),
         associated_types: Vec::new(),
     };
-    trait_def.expand(cx, mitem, &item, push)
+    trait_def.expand(cx, mitem, item, push)
 }

--- a/src/libsyntax/ext/deriving/cmp/partial_ord.rs
+++ b/src/libsyntax/ext/deriving/cmp/partial_ord.rs
@@ -23,7 +23,7 @@ use ptr::P;
 pub fn expand_deriving_partial_ord(cx: &mut ExtCtxt,
                                    span: Span,
                                    mitem: &MetaItem,
-                                   item: Annotatable,
+                                   item: &Annotatable,
                                    push: &mut FnMut(Annotatable))
 {
     macro_rules! md {
@@ -82,7 +82,7 @@ pub fn expand_deriving_partial_ord(cx: &mut ExtCtxt,
         ],
         associated_types: Vec::new(),
     };
-    trait_def.expand(cx, mitem, &item, push)
+    trait_def.expand(cx, mitem, item, push)
 }
 
 #[derive(Copy, Clone)]

--- a/src/libsyntax/ext/deriving/decodable.rs
+++ b/src/libsyntax/ext/deriving/decodable.rs
@@ -24,7 +24,7 @@ use ptr::P;
 pub fn expand_deriving_rustc_decodable(cx: &mut ExtCtxt,
                                        span: Span,
                                        mitem: &MetaItem,
-                                       item: Annotatable,
+                                       item: &Annotatable,
                                        push: &mut FnMut(Annotatable))
 {
     expand_deriving_decodable_imp(cx, span, mitem, item, push, "rustc_serialize")
@@ -33,7 +33,7 @@ pub fn expand_deriving_rustc_decodable(cx: &mut ExtCtxt,
 pub fn expand_deriving_decodable(cx: &mut ExtCtxt,
                                  span: Span,
                                  mitem: &MetaItem,
-                                 item: Annotatable,
+                                 item: &Annotatable,
                                  push: &mut FnMut(Annotatable))
 {
     expand_deriving_decodable_imp(cx, span, mitem, item, push, "serialize")
@@ -42,7 +42,7 @@ pub fn expand_deriving_decodable(cx: &mut ExtCtxt,
 fn expand_deriving_decodable_imp(cx: &mut ExtCtxt,
                                  span: Span,
                                  mitem: &MetaItem,
-                                 item: Annotatable,
+                                 item: &Annotatable,
                                  push: &mut FnMut(Annotatable),
                                  krate: &'static str)
 {
@@ -88,7 +88,7 @@ fn expand_deriving_decodable_imp(cx: &mut ExtCtxt,
         associated_types: Vec::new(),
     };
 
-    trait_def.expand(cx, mitem, &item, push)
+    trait_def.expand(cx, mitem, item, push)
 }
 
 fn decodable_substructure(cx: &mut ExtCtxt, trait_span: Span,

--- a/src/libsyntax/ext/deriving/default.rs
+++ b/src/libsyntax/ext/deriving/default.rs
@@ -20,7 +20,7 @@ use ptr::P;
 pub fn expand_deriving_default(cx: &mut ExtCtxt,
                                span: Span,
                                mitem: &MetaItem,
-                               item: Annotatable,
+                               item: &Annotatable,
                                push: &mut FnMut(Annotatable))
 {
     let inline = cx.meta_word(span, InternedString::new("inline"));
@@ -47,7 +47,7 @@ pub fn expand_deriving_default(cx: &mut ExtCtxt,
         ),
         associated_types: Vec::new(),
     };
-    trait_def.expand(cx, mitem, &item, push)
+    trait_def.expand(cx, mitem, item, push)
 }
 
 fn default_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Expr> {

--- a/src/libsyntax/ext/deriving/encodable.rs
+++ b/src/libsyntax/ext/deriving/encodable.rs
@@ -100,7 +100,7 @@ use ptr::P;
 pub fn expand_deriving_rustc_encodable(cx: &mut ExtCtxt,
                                        span: Span,
                                        mitem: &MetaItem,
-                                       item: Annotatable,
+                                       item: &Annotatable,
                                        push: &mut FnMut(Annotatable))
 {
     expand_deriving_encodable_imp(cx, span, mitem, item, push, "rustc_serialize")
@@ -109,7 +109,7 @@ pub fn expand_deriving_rustc_encodable(cx: &mut ExtCtxt,
 pub fn expand_deriving_encodable(cx: &mut ExtCtxt,
                                  span: Span,
                                  mitem: &MetaItem,
-                                 item: Annotatable,
+                                 item: &Annotatable,
                                  push: &mut FnMut(Annotatable))
 {
     expand_deriving_encodable_imp(cx, span, mitem, item, push, "serialize")
@@ -118,7 +118,7 @@ pub fn expand_deriving_encodable(cx: &mut ExtCtxt,
 fn expand_deriving_encodable_imp(cx: &mut ExtCtxt,
                                  span: Span,
                                  mitem: &MetaItem,
-                                 item: Annotatable,
+                                 item: &Annotatable,
                                  push: &mut FnMut(Annotatable),
                                  krate: &'static str)
 {
@@ -164,7 +164,7 @@ fn expand_deriving_encodable_imp(cx: &mut ExtCtxt,
         associated_types: Vec::new(),
     };
 
-    trait_def.expand(cx, mitem, &item, push)
+    trait_def.expand(cx, mitem, item, push)
 }
 
 fn encodable_substructure(cx: &mut ExtCtxt, trait_span: Span,

--- a/src/libsyntax/ext/deriving/hash.rs
+++ b/src/libsyntax/ext/deriving/hash.rs
@@ -19,7 +19,7 @@ use ptr::P;
 pub fn expand_deriving_hash(cx: &mut ExtCtxt,
                             span: Span,
                             mitem: &MetaItem,
-                            item: Annotatable,
+                            item: &Annotatable,
                             push: &mut FnMut(Annotatable))
 {
 
@@ -53,7 +53,7 @@ pub fn expand_deriving_hash(cx: &mut ExtCtxt,
         associated_types: Vec::new(),
     };
 
-    hash_trait_def.expand(cx, mitem, &item, push);
+    hash_trait_def.expand(cx, mitem, item, push);
 }
 
 fn hash_substructure(cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Expr> {

--- a/src/libsyntax/ext/deriving/mod.rs
+++ b/src/libsyntax/ext/deriving/mod.rs
@@ -134,7 +134,7 @@ macro_rules! derive_traits {
                               ecx: &mut ExtCtxt,
                               sp: Span,
                               mitem: &MetaItem,
-                              annotatable: Annotatable,
+                              annotatable: &Annotatable,
                               push: &mut FnMut(Annotatable)) {
                         warn_if_deprecated(ecx, sp, $name);
                         $func(ecx, sp, mitem, annotatable, push);

--- a/src/libsyntax/ext/deriving/primitive.rs
+++ b/src/libsyntax/ext/deriving/primitive.rs
@@ -21,7 +21,7 @@ use ptr::P;
 pub fn expand_deriving_from_primitive(cx: &mut ExtCtxt,
                                       span: Span,
                                       mitem: &MetaItem,
-                                      item: Annotatable,
+                                      item: &Annotatable,
                                       push: &mut FnMut(Annotatable))
 {
     let inline = cx.meta_word(span, InternedString::new("inline"));
@@ -69,7 +69,7 @@ pub fn expand_deriving_from_primitive(cx: &mut ExtCtxt,
         associated_types: Vec::new(),
     };
 
-    trait_def.expand(cx, mitem, &item, push)
+    trait_def.expand(cx, mitem, item, push)
 }
 
 fn cs_from(name: &str, cx: &mut ExtCtxt, trait_span: Span, substr: &Substructure) -> P<Expr> {

--- a/src/libsyntax/ext/deriving/show.rs
+++ b/src/libsyntax/ext/deriving/show.rs
@@ -21,7 +21,7 @@ use ptr::P;
 pub fn expand_deriving_show(cx: &mut ExtCtxt,
                             span: Span,
                             mitem: &MetaItem,
-                            item: Annotatable,
+                            item: &Annotatable,
                             push: &mut FnMut(Annotatable))
 {
     // &mut ::std::fmt::Formatter
@@ -50,7 +50,7 @@ pub fn expand_deriving_show(cx: &mut ExtCtxt,
         ],
         associated_types: Vec::new(),
     };
-    trait_def.expand(cx, mitem, &item, push)
+    trait_def.expand(cx, mitem, item, push)
 }
 
 /// We use the debug builders to do the heavy lifting here

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1212,7 +1212,7 @@ fn expand_decorators(a: Annotatable,
                     dec.expand(fld.cx,
                                attr.span,
                                &attr.node.value,
-                               a.clone(),
+                               &a,
                                &mut |ann| items.push(ann));
                     decorator_items.extend(items.into_iter()
                         .flat_map(|ann| expand_annotatable(ann, fld).into_iter()));

--- a/src/test/auxiliary/custom_derive_plugin.rs
+++ b/src/test/auxiliary/custom_derive_plugin.rs
@@ -37,7 +37,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
 fn expand(cx: &mut ExtCtxt,
           span: Span,
           mitem: &ast::MetaItem,
-          item: Annotatable,
+          item: &Annotatable,
           push: &mut FnMut(Annotatable)) {
     let trait_def = TraitDef {
         span: span,
@@ -71,5 +71,5 @@ fn expand(cx: &mut ExtCtxt,
         ],
     };
 
-    trait_def.expand(cx, mitem, &item, push)
+    trait_def.expand(cx, mitem, item, push)
 }

--- a/src/test/auxiliary/custom_derive_plugin_attr.rs
+++ b/src/test/auxiliary/custom_derive_plugin_attr.rs
@@ -39,7 +39,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
 fn expand(cx: &mut ExtCtxt,
           span: Span,
           mitem: &ast::MetaItem,
-          item: Annotatable,
+          item: &Annotatable,
           push: &mut FnMut(Annotatable)) {
     let trait_def = TraitDef {
         span: span,
@@ -62,7 +62,7 @@ fn expand(cx: &mut ExtCtxt,
         ],
     };
 
-    trait_def.expand(cx, mitem, &item, push)
+    trait_def.expand(cx, mitem, item, push)
 }
 
 // Mostly copied from syntax::ext::deriving::hash

--- a/src/test/auxiliary/macro_crate_test.rs
+++ b/src/test/auxiliary/macro_crate_test.rs
@@ -108,7 +108,7 @@ fn expand_into_foo_multi(cx: &mut ExtCtxt,
 fn expand_duplicate(cx: &mut ExtCtxt,
                     sp: Span,
                     mi: &MetaItem,
-                    it: Annotatable,
+                    it: &Annotatable,
                     push: &mut FnMut(Annotatable))
 {
     let copy_name = match mi.node {


### PR DESCRIPTION
fixes #25683

I have a very nonscientific measurement of the data via valgrind/massif [here](https://gist.github.com/Manishearth/4c47f15f6835cb3957c4)

I measured the memory usage for both --pretty=expanded and -Z no-trans

It _seems_ like there's a 20-25MB decrease during expansion on stage2 librustc; but I'm not quite sure.

r? @eddyb

cc @nrc @huon

![](https://camo.githubusercontent.com/5f16a3bdd4df1592ee312305f7749dabd611399c/68747470733a2f2f692e696d6775722e636f6d2f696132664738382e706e67)
