### PR TITLE
Allow patterns in macros to be followed by if and in.

### DIFF
--- a/src/doc/trpl/macros.md
+++ b/src/doc/trpl/macros.md
@@ -478,7 +478,7 @@ There are additional rules regarding the next token after a metavariable:
 
 * `expr` variables may only be followed by one of: `=> , ;`
 * `ty` and `path` variables may only be followed by one of: `=> , : = > as`
-* `pat` variables may only be followed by one of: `=> , =`
+* `pat` variables may only be followed by one of: `=> , = if in`
 * Other variables may be followed by any token.
 
 These rules provide some flexibility for Rust’s syntax to evolve without

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -495,6 +495,7 @@ fn is_in_follow(_: &ExtCtxt, tok: &Token, frag: &str) -> Result<bool, String> {
             "pat" => {
                 match *tok {
                     FatArrow | Comma | Eq => Ok(true),
+                    Ident(i, _) if i.as_str() == "if" || i.as_str() == "in" => Ok(true),
                     _ => Ok(false)
                 }
             },

--- a/src/test/run-pass/macro-pat-follow.rs
+++ b/src/test/run-pass/macro-pat-follow.rs
@@ -1,0 +1,30 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! pat_in {
+    ($p:pat in $e:expr) => {{
+        let mut iter = $e.into_iter();
+        while let $p = iter.next() {}
+    }}
+}
+
+macro_rules! pat_if {
+    ($p:pat if $e:expr) => {{
+        match Some(1u8) {
+            $p if $e => {},
+            _ => {}
+        }
+    }}
+}
+
+fn main() {
+    pat_in!(Some(_) in 0..10);
+    pat_if!(Some(x) if x > 0);
+}


### PR DESCRIPTION
Needed to support:

``` rust
match X {
  pattern if Y ...
}

for pattern in Y {}
```

IMO, this shouldn't require an RFC because it can't interfere with any future language changes (because `pattern if` and `pattern in` are already legal in rust) and can't cause any ambiguity.
