### PR TITLE
Specify linkers for cross-compile scenarios

### DIFF
--- a/mk/cfg/i686-apple-darwin.mk
+++ b/mk/cfg/i686-apple-darwin.mk
@@ -1,5 +1,6 @@
 # i686-apple-darwin configuration
 CC_i686-apple-darwin=$(CC)
+LINK_i686-apple-darwin=cc
 CXX_i686-apple-darwin=$(CXX)
 CPP_i686-apple-darwin=$(CPP)
 AR_i686-apple-darwin=$(AR)

--- a/mk/cfg/i686-unknown-linux-gnu.mk
+++ b/mk/cfg/i686-unknown-linux-gnu.mk
@@ -1,5 +1,6 @@
 # i686-unknown-linux-gnu configuration
 CC_i686-unknown-linux-gnu=$(CC)
+LINK_i686-unknown-linux-gnu=cc
 CXX_i686-unknown-linux-gnu=$(CXX)
 CPP_i686-unknown-linux-gnu=$(CPP)
 AR_i686-unknown-linux-gnu=$(AR)

--- a/mk/cfg/x86_64-apple-darwin.mk
+++ b/mk/cfg/x86_64-apple-darwin.mk
@@ -1,5 +1,6 @@
 # x86_64-apple-darwin configuration
 CC_x86_64-apple-darwin=$(CC)
+LINK_x86_64-apple-darwin=cc
 CXX_x86_64-apple-darwin=$(CXX)
 CPP_x86_64-apple-darwin=$(CPP)
 AR_x86_64-apple-darwin=$(AR)

--- a/mk/cfg/x86_64-unknown-linux-gnu.mk
+++ b/mk/cfg/x86_64-unknown-linux-gnu.mk
@@ -1,5 +1,6 @@
 # x86_64-unknown-linux-gnu configuration
 CC_x86_64-unknown-linux-gnu=$(CC)
+LINK_x86_64-unknown-linux-gnu=cc
 CXX_x86_64-unknown-linux-gnu=$(CXX)
 CPP_x86_64-unknown-linux-gnu=$(CPP)
 AR_x86_64-unknown-linux-gnu=$(AR)


### PR DESCRIPTION
The recent MSVC patch made the build system pass explicit linkers to
rustc, but did not set that up for anything other than MSVC.

This is blocking nightlies.
