### PR TITLE
allow clang 3.7 to be used when configuring Fixes #25720

### DIFF
--- a/configure
+++ b/configure
@@ -986,7 +986,7 @@ then
             | cut -d ' ' -f 2)
 
         case $CFG_CLANG_VERSION in
-            (3.2* | 3.3* | 3.4* | 3.5* | 3.6*)
+            (3.2* | 3.3* | 3.4* | 3.5* | 3.6* | 3.7*)
             step_msg "found ok version of CLANG: $CFG_CLANG_VERSION"
             if [ -z "$CC" ]
             then


### PR DESCRIPTION
Was able to successfully configure.  Building and testing now.
