### PR TITLE
Stable: Compatibility fixes for LLVM 3.5

### DIFF
--- a/src/librustc_trans/trans/context.rs
+++ b/src/librustc_trans/trans/context.rs
@@ -871,11 +871,33 @@ fn declare_intrinsic(ccx: &CrateContext, key: & &'static str) -> Option<ValueRef
     ifn!("llvm.lifetime.end", fn(t_i64, i8p) -> void);
 
     ifn!("llvm.expect.i1", fn(i1, i1) -> i1);
-    ifn!("llvm.assume", fn(i1) -> void);
 
     // Some intrinsics were introduced in later versions of LLVM, but they have
     // fallbacks in libc or libm and such.
     macro_rules! compatible_ifn {
+        ($name:expr, noop($cname:ident ($($arg:expr),*) -> void), $llvm_version:expr) => (
+            if unsafe { llvm::LLVMVersionMinor() >= $llvm_version } {
+                // The `if key == $name` is already in ifn!
+                ifn!($name, fn($($arg),*) -> void);
+            } else if *key == $name {
+                let f = declare::declare_cfn(ccx, stringify!($cname),
+                                             Type::func(&[$($arg),*], &void),
+                                             ty::mk_nil(ccx.tcx()));
+                llvm::SetLinkage(f, llvm::InternalLinkage);
+
+                let bld = ccx.builder();
+                let llbb = unsafe {
+                    llvm::LLVMAppendBasicBlockInContext(ccx.llcx(), f,
+                                                        "entry-block\0".as_ptr() as *const _)
+                };
+
+                bld.position_at_end(llbb);
+                bld.ret_void();
+
+                ccx.intrinsics().borrow_mut().insert($name, f.clone());
+                return Some(f);
+            }
+        );
         ($name:expr, $cname:ident ($($arg:expr),*) -> $ret:expr, $llvm_version:expr) => (
             if unsafe { llvm::LLVMVersionMinor() >= $llvm_version } {
                 // The `if key == $name` is already in ifn!
@@ -894,6 +916,7 @@ fn declare_intrinsic(ccx: &CrateContext, key: & &'static str) -> Option<ValueRef
     compatible_ifn!("llvm.copysign.f64", copysign(t_f64, t_f64) -> t_f64, 4);
     compatible_ifn!("llvm.round.f32", roundf(t_f32) -> t_f32, 4);
     compatible_ifn!("llvm.round.f64", round(t_f64) -> t_f64, 4);
+    compatible_ifn!("llvm.assume", noop(llvmcompat_assume(i1) -> void), 6);
 
 
     if ccx.sess().opts.debuginfo != NoDebugInfo {

--- a/src/librustc_trans/trans/context.rs
+++ b/src/librustc_trans/trans/context.rs
@@ -874,11 +874,10 @@ fn declare_intrinsic(ccx: &CrateContext, key: & &'static str) -> Option<ValueRef
     ifn!("llvm.assume", fn(i1) -> void);
 
     // Some intrinsics were introduced in later versions of LLVM, but they have
-    // fallbacks in libc or libm and such. Currently, all of these intrinsics
-    // were introduced in LLVM 3.4, so we case on that.
+    // fallbacks in libc or libm and such.
     macro_rules! compatible_ifn {
-        ($name:expr, $cname:ident ($($arg:expr),*) -> $ret:expr) => (
-            if unsafe { llvm::LLVMVersionMinor() >= 4 } {
+        ($name:expr, $cname:ident ($($arg:expr),*) -> $ret:expr, $llvm_version:expr) => (
+            if unsafe { llvm::LLVMVersionMinor() >= $llvm_version } {
                 // The `if key == $name` is already in ifn!
                 ifn!($name, fn($($arg),*) -> $ret);
             } else if *key == $name {
@@ -891,10 +890,10 @@ fn declare_intrinsic(ccx: &CrateContext, key: & &'static str) -> Option<ValueRef
         )
     }
 
-    compatible_ifn!("llvm.copysign.f32", copysignf(t_f32, t_f32) -> t_f32);
-    compatible_ifn!("llvm.copysign.f64", copysign(t_f64, t_f64) -> t_f64);
-    compatible_ifn!("llvm.round.f32", roundf(t_f32) -> t_f32);
-    compatible_ifn!("llvm.round.f64", round(t_f64) -> t_f64);
+    compatible_ifn!("llvm.copysign.f32", copysignf(t_f32, t_f32) -> t_f32, 4);
+    compatible_ifn!("llvm.copysign.f64", copysign(t_f64, t_f64) -> t_f64, 4);
+    compatible_ifn!("llvm.round.f32", roundf(t_f32) -> t_f32, 4);
+    compatible_ifn!("llvm.round.f64", round(t_f64) -> t_f64, 4);
 
 
     if ccx.sess().opts.debuginfo != NoDebugInfo {


### PR DESCRIPTION
Based on the pull request from Luca Bruno (#21588)

I'm trying to get the 1.0.0 release running on a Fedora system using the system supplied llvm.
It's still not running, but i getting somewhere.

Is this patch correct? This was my first practical contact with Rust code, and "hey, it's the rust compiler itself" :-)

Now i'm having a dynamical system llvm linked stage1 rustc, which can compile small rust programms. Next stages still don't work - not the referenced ICE, i get here illegal instructions, but only if i activate optimizations in rustc - need to investigate this.
