### PR TITLE
[liballoc] Fix unused import warning in stage0

### DIFF
--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -159,7 +159,9 @@ use core::cmp::{PartialEq, PartialOrd, Eq, Ord, Ordering};
 use core::default::Default;
 use core::fmt;
 use core::hash::{Hasher, Hash};
-use core::marker::{self, Sized};
+use core::marker;
+#[cfg(not(stage0))]
+use core::marker::Sized;
 use core::mem::{self, min_align_of, size_of, forget};
 use core::nonzero::NonZero;
 use core::ops::{Deref, Drop};


### PR DESCRIPTION
`Sized` is only used in code marked `#[cfg(not(stage0))]`, so when building stage0, this warning is generated:

```
/home/wesley/code/rust/rust/src/liballoc/rc.rs:162:26: 162:31 warning: unused import, #[warn(unused_imports)] on by default
/home/wesley/code/rust/rust/src/liballoc/rc.rs:162 use core::marker::{self, Sized};
                                                                            ^~~~~
```
