### PR TITLE
compiletest: Remove jit test support

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -1126,16 +1126,10 @@ impl fmt::Display for Status {
 
 fn compile_test(config: &Config, props: &TestProps,
                 testfile: &Path) -> ProcRes {
-    compile_test_(config, props, testfile, &[])
-}
-
-fn compile_test_(config: &Config, props: &TestProps,
-                 testfile: &Path, extra_args: &[String]) -> ProcRes {
     let aux_dir = aux_output_dir_name(config, testfile);
     // FIXME (#9639): This needs to handle non-utf8 paths
-    let mut link_args = vec!("-L".to_string(),
-                             aux_dir.to_str().unwrap().to_string());
-    link_args.extend(extra_args.iter().cloned());
+    let link_args = vec!("-L".to_string(),
+                         aux_dir.to_str().unwrap().to_string());
     let args = make_compile_args(config,
                                  props,
                                  link_args,
@@ -1144,7 +1138,7 @@ fn compile_test_(config: &Config, props: &TestProps,
 }
 
 fn document(config: &Config, props: &TestProps,
-            testfile: &Path, extra_args: &[String]) -> (ProcRes, PathBuf) {
+            testfile: &Path) -> (ProcRes, PathBuf) {
     let aux_dir = aux_output_dir_name(config, testfile);
     let out_dir = output_base_name(config, testfile);
     let _ = fs::remove_dir_all(&out_dir);
@@ -1154,7 +1148,6 @@ fn document(config: &Config, props: &TestProps,
                         "-o".to_string(),
                         out_dir.to_str().unwrap().to_string(),
                         testfile.to_str().unwrap().to_string()];
-    args.extend(extra_args.iter().cloned());
     args.extend(split_maybe_args(&props.compile_flags));
     let args = ProcArgs {
         prog: config.rustdoc_path.to_str().unwrap().to_string(),
@@ -1717,7 +1710,7 @@ fn charset() -> &'static str {
 }
 
 fn run_rustdoc_test(config: &Config, props: &TestProps, testfile: &Path) {
-    let (proc_res, out_dir) = document(config, props, testfile, &[]);
+    let (proc_res, out_dir) = document(config, props, testfile);
     if !proc_res.status.success() {
         fatal_proc_rec("rustdoc failed!", &proc_res);
     }


### PR DESCRIPTION
jit support was removed from rustc in 6b34ba242d7372b779bf50682b9401b61183828e
(December 2013), so passing `--jit` wouldn't even work.
