### PR TITLE
TRPL: Clean up some Markdown links

### DIFF
--- a/src/doc/trpl/installing-rust.md
+++ b/src/doc/trpl/installing-rust.md
@@ -43,11 +43,11 @@ Some people, and somewhat rightfully so, get very upset when we tell you to
 `curl | sh`. Basically, when you do this, you are trusting that the good
 people who maintain Rust aren't going to hack your computer and do bad things.
 That's a good instinct! If you're one of those people, please check out the
-documentation on [building Rust from Source][from source], or [the official
-binary downloads][install page].
+documentation on [building Rust from Source][from-source], or [the official
+binary downloads][install-page].
 
-[from source]: https://github.com/rust-lang/rust#building-from-source
-[install page]: http://www.rust-lang.org/install.html
+[from-source]: https://github.com/rust-lang/rust#building-from-source
+[install-page]: http://www.rust-lang.org/install.html
 
 Oh, we should also mention the officially supported platforms:
 

--- a/src/doc/trpl/macros.md
+++ b/src/doc/trpl/macros.md
@@ -30,8 +30,8 @@ mind.
 
 # Defining a macro
 
-You may have seen the `vec!` macro, used to initialize a [vector][] with any
-number of elements.
+You may have seen the `vec!` macro, used to initialize a [vector][vector] with
+any number of elements.
 
 [vector]: vectors.html
 
@@ -349,7 +349,7 @@ fn main() {
 }
 ```
 
-This holds for `let` bindings and loop labels, but not for [items][].
+This holds for `let` bindings and loop labels, but not for [items][items].
 So the following code does compile:
 
 ```rust
@@ -470,7 +470,7 @@ which syntactic form it matches.
 * `stmt`: a single statement. Example: `let x = 3`.
 * `block`: a brace-delimited sequence of statements. Example:
   `{ log(error, "hi"); return 12; }`.
-* `item`: an [item][]. Examples: `fn foo() { }`; `struct Bar;`.
+* `item`: an [item][item]. Examples: `fn foo() { }`; `struct Bar;`.
 * `meta`: a "meta item", as found in attributes. Example: `cfg(target_os = "windows")`.
 * `tt`: a single token tree.
 

--- a/src/doc/trpl/nightly-rust.md
+++ b/src/doc/trpl/nightly-rust.md
@@ -46,11 +46,11 @@ Some people, and somewhat rightfully so, get very upset when we tell you to
 `curl | sh`. Basically, when you do this, you are trusting that the good
 people who maintain Rust aren't going to hack your computer and do bad things.
 That's a good instinct! If you're one of those people, please check out the
-documentation on [building Rust from Source][from source], or [the official
-binary downloads][install page].
+documentation on [building Rust from Source][from-source], or [the official
+binary downloads][install-page].
 
-[from source]: https://github.com/rust-lang/rust#building-from-source
-[install page]: http://www.rust-lang.org/install.html
+[from-source]: https://github.com/rust-lang/rust#building-from-source
+[install-page]: http://www.rust-lang.org/install.html
 
 Oh, we should also mention the officially supported platforms:
 
@@ -91,9 +91,9 @@ If not, there are a number of places where you can get help. The easiest is
 [the #rust IRC channel on irc.mozilla.org][irc], which you can access through
 [Mibbit][mibbit]. Click that link, and you'll be chatting with other Rustaceans
 (a silly nickname we call ourselves), and we can help you out. Other great
-resources include [the user’s forum][users], and [Stack Overflow][stack overflow].
+resources include [the user’s forum][users], and [Stack Overflow][stackoverflow].
 
 [irc]: irc://irc.mozilla.org/#rust
 [mibbit]: http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust
 [users]: http://users.rust-lang.org/ 
-[stack overflow]: http://stackoverflow.com/questions/tagged/rust
+[stackoverflow]: http://stackoverflow.com/questions/tagged/rust


### PR DESCRIPTION
In all other places the IDs of link references are without spaces (and explicitly set).

These are just some cleanups I did for the PDF version.

r? @steveklabnik 
