### PR TITLE
Add mention of gcc for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Read ["Installing Rust"] from [The Book].
    $ pacman -S mingw-w64-x86_64-toolchain
 
    $ pacman -S base-devel
+   
+   # If `gcc` isn't already installed
+   $ pacman -S gcc
    ```
 
 3. Run `mingw32_shell.bat` or `mingw64_shell.bat` from wherever you installed


### PR DESCRIPTION
I thought `base-devel` or `mingw-w64-i686-toolchain` would contain `gcc`, but when following the exact steps from the README whilst building on windows, with a fresh msys install, I get an error about missing `gcc`/`clang`.

`pacman -S gcc` worked for me. I'm not sure if this is necessary for all or if this is a general case.

r? @retep998
