### PR TITLE
Fix auto_ref for fat pointers

### DIFF
--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -2180,7 +2180,9 @@ fn auto_ref<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     // Construct the resulting datum, using what was the "by ref"
     // ValueRef of type `referent_ty` to be the "by value" ValueRef
     // of type `&referent_ty`.
-    DatumBlock::new(bcx, Datum::new(llref, ptr_ty, RvalueExpr(Rvalue::new(ByValue))))
+    // Pointers to DST types are non-immediate, and therefore still use ByRef.
+    let kind  = if type_is_sized(bcx.tcx(), referent_ty) { ByValue } else { ByRef };
+    DatumBlock::new(bcx, Datum::new(llref, ptr_ty, RvalueExpr(Rvalue::new(kind))))
 }
 
 fn deref_multiple<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,

--- a/src/test/run-pass/issue-24589.rs
+++ b/src/test/run-pass/issue-24589.rs
@@ -1,0 +1,26 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct _X([u8]);
+
+impl std::ops::Deref for _X {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+pub fn _g(x: &_X) -> &[u8] {
+    x
+}
+
+fn main() {
+}


### PR DESCRIPTION
Fat pointers aren't immediate, so in a datum, they're not actually
ByValue but ByRef.

Fixes #24589
