### PR TITLE
- Fix regression of literal out of range check for negative i64 value

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -203,10 +203,12 @@ impl LintPass for TypeLimits {
                                 } else {
                                     t
                                 };
-                                let (min, max) = int_ty_range(int_type);
+                                let (_, max) = int_ty_range(int_type);
                                 let negative = self.negated_expr_id == e.id;
 
-                                if (negative && min != i64::MIN && v > -min as u64) ||
+                                // Detect literal value out of range [min, max] inclusive
+                                // avoiding use of -min to prevent overflow/panic
+                                if (negative && v > max as u64 + 1) ||
                                    (!negative && v > max as u64) {
                                     cx.span_lint(OVERFLOWING_LITERALS, e.span,
                                                  &*format!("literal out of range for {:?}", t));

--- a/src/test/compile-fail/lint-type-overflow.rs
+++ b/src/test/compile-fail/lint-type-overflow.rs
@@ -52,6 +52,8 @@ fn main() {
     let x = 9223372036854775808_i64; //~ error: literal out of range for i64
     let x = -9223372036854775808_i64; // should be OK
     let x = 18446744073709551615_i64; //~ error: literal out of range for i64
+    let x: i64 = -9223372036854775809; //~ error: literal out of range for i64
+    let x = -9223372036854775809_i64; //~ error: literal out of range for i64
 
     let x = -3.40282348e+38_f32; //~ error: literal out of range for f32
     let x =  3.40282348e+38_f32; //~ error: literal out of range for f32


### PR DESCRIPTION
A regression was introduced by commit https://github.com/rust-lang/rust/commit/7b1916d25347913fce3e336517ef22025ccd875f #25612.  Negative signed integer literals less than -9223372036854775808i64 were no longer properly reported as #[warn(overflowing_literals)].

Also adding missing test cases to test/compile-fail/lint-type-overflow.rs which could have detected the regression.

Further explanation:

The expression `(negative && v > max as u64 + 1)` relies on the fact that algebraically speaking `-min == max + 1` to avoid negation and removing the need for `min` completely.

If i128 or i256 are ever added, it should also work for these types without requiring a change to `min != i64::MIN &&` also simplifying maintenance.

r? @pnkfelix
