### PR TITLE
Associate each path in a `use` declaration with the item in the AST map

### DIFF
--- a/src/libsyntax/ast_map/mod.rs
+++ b/src/libsyntax/ast_map/mod.rs
@@ -714,6 +714,16 @@ impl<'ast> Visitor<'ast> for NodeCollector<'ast> {
                     self.insert(ti.id, NodeTraitItem(ti));
                 }
             }
+            ItemUse(ref view_path) => {
+                match view_path.node {
+                    ViewPathList(_, ref paths) => {
+                        for path in paths {
+                            self.insert(path.node.id(), NodeItem(i));
+                        }
+                    }
+                    _ => ()
+                }
+            }
             _ => {}
         }
         visit::walk_item(self, i);

--- a/src/test/compile-fail/use-paths-as-items.rs
+++ b/src/test/compile-fail/use-paths-as-items.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Each path node in a `use` declaration must be treated as an item. If not, the following code
+// will trigger an ICE.
+//
+// Related issue: #25763
+
+use std::{mem, ptr};
+use std::mem; //~ ERROR has already been imported
+
+fn main() {}


### PR DESCRIPTION
Currently, for `use` declarations with multiple paths, only the `use` item itself is saved in the AST map, not the individual path nodes. This can lead to a problem when a span of a specific path node is needed.

For example, #24818 caused an ICE because of this, in `ImportResolver::check_for_conflicting_import()`.

Fixes #25763.
