### PR TITLE
Remove redundant compiler check. Allow CC override

### DIFF
--- a/configure
+++ b/configure
@@ -863,11 +863,6 @@ then
     CFG_DISABLE_JEMALLOC=1
 fi
 
-if [ -z "$CFG_ENABLE_CLANG" -a -z "$CFG_GCC" ]
-then
-    err "either clang or gcc is required"
-fi
-
 # OS X 10.9, gcc is actually clang. This can cause some confusion in the build
 # system, so if we find that gcc is clang, we should just use clang directly.
 if [ $CFG_OSTYPE = apple-darwin -a -z "$CFG_ENABLE_CLANG" ]


### PR DESCRIPTION
Currently, there are two conditional blocks that exist to check for "clang or gcc"

On line 866:

```
if [ -z "$CFG_ENABLE_CLANG" -a -z "$CFG_GCC" ]
then
    err "either clang or gcc is required"
fi
```

and on line 1019:

```
if [ -z "$CC" -a -z "$CFG_ENABLE_CLANG" -a -z "$CFG_GCC" ]
then
    err "either clang or gcc is required"
fi
```

Given the order of the clauses, this results in the "either clang or gcc is required" error from the earlier block, (even) when CC is set. 

The expected behaviour is to honour user-flags, in this case CC.

Aside from removing all hand-holdy compiler checks in favour of actual compiler _feature_ checks, this change removes the redundant former block in favour of the latter block, which appears designed to allow the expected behaviour.
