### PR TITLE
Do not trip an assert when coercing &Trait to &Trait in constants.

### DIFF
--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -342,9 +342,11 @@ pub fn const_expr<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                 let info = expr::unsized_info(cx, pointee_ty, unsized_ty,
                                               old_info, param_substs);
 
-                let prev_const = cx.const_unsized().borrow_mut()
-                                   .insert(base, llconst);
-                assert!(prev_const.is_none() || prev_const == Some(llconst));
+                if old_info.is_none() {
+                    let prev_const = cx.const_unsized().borrow_mut()
+                                       .insert(base, llconst);
+                    assert!(prev_const.is_none() || prev_const == Some(llconst));
+                }
                 assert_eq!(abi::FAT_PTR_ADDR, 0);
                 assert_eq!(abi::FAT_PTR_EXTRA, 1);
                 llconst = C_struct(cx, &[base, info], false);

--- a/src/test/run-pass/const-trait-to-trait.rs
+++ b/src/test/run-pass/const-trait-to-trait.rs
@@ -1,0 +1,31 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Issue #24644 - block causes a &Trait -> &Trait coercion:
+trait Trait {}
+
+struct Bar;
+impl Trait for Bar {}
+
+fn main() {
+    let x: &[&Trait] = &[{ &Bar }];
+}
+
+// Issue #25748 - the cast causes an &Encoding -> &Encoding coercion:
+pub struct UTF8Encoding;
+pub const UTF_8: &'static UTF8Encoding = &UTF8Encoding;
+pub trait Encoding {}
+impl Encoding for UTF8Encoding {}
+pub fn f() -> &'static Encoding { UTF_8 as &'static Encoding }
+
+// Root of the problem: &Trait -> &Trait coercions:
+const FOO: &'static Trait = &Bar;
+const BAR: &'static Trait = FOO;
+fn foo() { let _x = BAR; }


### PR DESCRIPTION
Fixes #24644.
