### PR TITLE
Stabilize step_by for 1.2.0

### DIFF
--- a/src/doc/trpl/iterators.md
+++ b/src/doc/trpl/iterators.md
@@ -285,7 +285,6 @@ has no side effect on the original iterator. Let's try it out with our infinite
 iterator from before:
 
 ```rust
-# #![feature(step_by)]
 for i in (1..).step_by(5).take(5) {
     println!("{}", i);
 }

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -38,7 +38,7 @@
 //! [sieve]: http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
 //!
 //! ```
-//! # #![feature(collections, core, step_by)]
+//! # #![feature(collections, core)]
 //! use std::collections::{BitSet, BitVec};
 //! use std::iter;
 //!

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -35,7 +35,6 @@
 #![feature(unicode)]
 #![feature(unique)]
 #![feature(unsafe_no_drop_flag, filling_drop)]
-#![feature(step_by)]
 #![feature(str_char)]
 #![feature(slice_patterns)]
 #![feature(utf8_error)]

--- a/src/libcollectionstest/lib.rs
+++ b/src/libcollectionstest/lib.rs
@@ -22,7 +22,6 @@
 #![feature(unboxed_closures)]
 #![feature(unicode)]
 #![feature(into_cow)]
-#![feature(step_by)]
 #![cfg_attr(test, feature(str_char))]
 #![cfg_attr(test, feature(vec_deque_retain))]
 

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -513,13 +513,15 @@ pub trait Iterator {
     /// # Examples
     ///
     /// ```
+    /// # #![feature(core)]
+    ///
     /// let a = [1, 4, 2, 3, 8, 9, 6];
     /// let sum: i32 = a.iter()
     ///                 .map(|x| *x)
     ///                 .inspect(|&x| println!("filtering {}", x))
     ///                 .filter(|&x| x % 2 == 0)
     ///                 .inspect(|&x| println!("{} made it through", x))
-    ///                 .fold(0, |sum, i| sum + i);
+    ///                 .sum();
     /// println!("{}", sum);
     /// ```
     #[inline]
@@ -569,6 +571,7 @@ pub trait Iterator {
     /// do not.
     ///
     /// ```
+    /// # #![feature(core)]
     /// let vec = vec![1, 2, 3, 4];
     /// let (even, odd): (Vec<_>, Vec<_>) = vec.into_iter().partition(|&n| n % 2 == 0);
     /// assert_eq!(even, [2, 4]);
@@ -893,6 +896,7 @@ pub trait Iterator {
     ///
     /// ```
     /// # #![feature(core)]
+    ///
     /// let a = [-3_i32, 0, 1, 5, -10];
     /// assert_eq!(*a.iter().max_by(|x| x.abs()).unwrap(), -10);
     /// ```
@@ -921,6 +925,7 @@ pub trait Iterator {
     ///
     /// ```
     /// # #![feature(core)]
+    ///
     /// let a = [-3_i32, 0, 1, 5, -10];
     /// assert_eq!(*a.iter().min_by(|x| x.abs()).unwrap(), 0);
     /// ```
@@ -965,6 +970,7 @@ pub trait Iterator {
     /// # Examples
     ///
     /// ```
+    /// # #![feature(core)]
     /// let a = [(1, 2), (3, 4)];
     /// let (left, right): (Vec<_>, Vec<_>) = a.iter().cloned().unzip();
     /// assert_eq!(left, [1, 3]);
@@ -1058,6 +1064,7 @@ pub trait Iterator {
     ///
     /// ```
     /// # #![feature(core)]
+    ///
     /// let a = [1, 2, 3, 4, 5];
     /// let it = a.iter();
     /// assert_eq!(it.sum::<i32>(), 15);
@@ -1076,6 +1083,7 @@ pub trait Iterator {
     ///
     /// ```
     /// # #![feature(core)]
+    ///
     /// fn factorial(n: u32) -> u32 {
     ///     (1..).take_while(|&i| i <= n).product()
     /// }
@@ -2683,7 +2691,7 @@ step_impl_no_between!(u64 i64);
 /// parameter is the type being iterated over, while `R` is the range
 /// type (usually one of `std::ops::{Range, RangeFrom}`.
 #[derive(Clone)]
-#[unstable(feature = "step_by", reason = "recent addition")]
+#[stable(feature = "step_by", since = "1.2.0")]
 pub struct StepBy<A, R> {
     step_by: A,
     range: R,
@@ -2702,7 +2710,7 @@ impl<A: Step> RangeFrom<A> {
     /// ```
     ///
     /// This prints all even `u8` values.
-    #[unstable(feature = "step_by", reason = "recent addition")]
+    #[stable(feature = "step_by", since = "1.2.0")]
     pub fn step_by(self, by: A) -> StepBy<A, Self> {
         StepBy {
             step_by: by,
@@ -2721,7 +2729,6 @@ impl<A: Step> ops::Range<A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(step_by)]
     /// for i in (0..10).step_by(2) {
     ///     println!("{}", i);
     /// }
@@ -2736,7 +2743,7 @@ impl<A: Step> ops::Range<A> {
     /// 6
     /// 8
     /// ```
-    #[unstable(feature = "step_by", reason = "recent addition")]
+    #[stable(feature = "step_by", since = "1.2.0")]
     pub fn step_by(self, by: A) -> StepBy<A, Self> {
         StepBy {
             step_by: by,

--- a/src/libcoretest/lib.rs
+++ b/src/libcoretest/lib.rs
@@ -22,7 +22,6 @@
 #![feature(libc)]
 #![feature(hash)]
 #![feature(unique)]
-#![feature(step_by)]
 #![feature(slice_patterns)]
 #![feature(float_from_str_radix)]
 #![feature(cell_extras)]

--- a/src/librand/lib.rs
+++ b/src/librand/lib.rs
@@ -31,7 +31,6 @@
 #![feature(core)]
 #![feature(no_std)]
 #![feature(staged_api)]
-#![feature(step_by)]
 
 #![cfg_attr(test, feature(test, rand, rustc_private))]
 

--- a/src/librustc_back/lib.rs
+++ b/src/librustc_back/lib.rs
@@ -39,7 +39,6 @@
 #![feature(staged_api)]
 #![feature(rand)]
 #![feature(path_ext)]
-#![feature(step_by)]
 #![feature(libc)]
 #![feature(fs_canonicalize)]
 #![cfg_attr(test, feature(test, rand))]

--- a/src/test/bench/shootout-binarytrees.rs
+++ b/src/test/bench/shootout-binarytrees.rs
@@ -38,7 +38,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#![feature(rustc_private, core, step_by)]
+#![feature(rustc_private, core)]
 
 extern crate arena;
 

--- a/src/test/bench/shootout-fannkuch-redux.rs
+++ b/src/test/bench/shootout-fannkuch-redux.rs
@@ -38,8 +38,6 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#![feature(step_by)]
-
 use std::{cmp, mem};
 use std::thread;
 


### PR DESCRIPTION
`step_by` is generally useful (it was used in multiple places in the
standard library). When it landed in mid-March, it was marked unstable
because it was a "recent addition" to the API. It's been two months, and
there seems to be no controversy about its inclusion in Rust. Therefore,
I propose that we stabilize `step_by`.
