### PR TITLE
mk: Ensure LINK_$(1) is defined for all targets

### DIFF
--- a/mk/cfg/aarch64-linux-android.mk
+++ b/mk/cfg/aarch64-linux-android.mk
@@ -1,7 +1,6 @@
 # aarch64-linux-android configuration
 # CROSS_PREFIX_aarch64-linux-android-
 CC_aarch64-linux-android=$(CFG_ANDROID_CROSS_PATH)/bin/aarch64-linux-android-gcc
-LINK_aarch64-linux-android=$(CFG_ANDROID_CROSS_PATH)/bin/aarch64-linux-android-gcc
 CXX_aarch64-linux-android=$(CFG_ANDROID_CROSS_PATH)/bin/aarch64-linux-android-g++
 CPP_aarch64-linux-android=$(CFG_ANDROID_CROSS_PATH)/bin/aarch64-linux-android-gcc -E
 AR_aarch64-linux-android=$(CFG_ANDROID_CROSS_PATH)/bin/aarch64-linux-android-ar

--- a/mk/cfg/aarch64-unknown-linux-gnu.mk
+++ b/mk/cfg/aarch64-unknown-linux-gnu.mk
@@ -1,7 +1,6 @@
 # aarch64-unknown-linux-gnu configuration
 CROSS_PREFIX_aarch64-unknown-linux-gnu=aarch64-linux-gnu-
 CC_aarch64-unknown-linux-gnu=gcc
-LINK_aarch64-unknown-linux-gnu=gcc
 CXX_aarch64-unknown-linux-gnu=g++
 CPP_aarch64-unknown-linux-gnu=gcc -E
 AR_aarch64-unknown-linux-gnu=ar

--- a/mk/cfg/arm-linux-androideabi.mk
+++ b/mk/cfg/arm-linux-androideabi.mk
@@ -1,5 +1,4 @@
 # arm-linux-androideabi configuration
-LINK_arm-linux-androideabi=$(CFG_ANDROID_CROSS_PATH)/bin/arm-linux-androideabi-gcc
 CC_arm-linux-androideabi=$(CFG_ANDROID_CROSS_PATH)/bin/arm-linux-androideabi-gcc
 CXX_arm-linux-androideabi=$(CFG_ANDROID_CROSS_PATH)/bin/arm-linux-androideabi-g++
 CPP_arm-linux-androideabi=$(CFG_ANDROID_CROSS_PATH)/bin/arm-linux-androideabi-gcc -E

--- a/mk/cfg/i686-apple-darwin.mk
+++ b/mk/cfg/i686-apple-darwin.mk
@@ -1,6 +1,5 @@
 # i686-apple-darwin configuration
 CC_i686-apple-darwin=$(CC)
-LINK_i686-apple-darwin=cc
 CXX_i686-apple-darwin=$(CXX)
 CPP_i686-apple-darwin=$(CPP)
 AR_i686-apple-darwin=$(AR)

--- a/mk/cfg/i686-unknown-linux-gnu.mk
+++ b/mk/cfg/i686-unknown-linux-gnu.mk
@@ -1,6 +1,5 @@
 # i686-unknown-linux-gnu configuration
 CC_i686-unknown-linux-gnu=$(CC)
-LINK_i686-unknown-linux-gnu=cc
 CXX_i686-unknown-linux-gnu=$(CXX)
 CPP_i686-unknown-linux-gnu=$(CPP)
 AR_i686-unknown-linux-gnu=$(AR)

--- a/mk/cfg/x86_64-apple-darwin.mk
+++ b/mk/cfg/x86_64-apple-darwin.mk
@@ -1,6 +1,5 @@
 # x86_64-apple-darwin configuration
 CC_x86_64-apple-darwin=$(CC)
-LINK_x86_64-apple-darwin=cc
 CXX_x86_64-apple-darwin=$(CXX)
 CPP_x86_64-apple-darwin=$(CPP)
 AR_x86_64-apple-darwin=$(AR)

--- a/mk/cfg/x86_64-pc-windows-gnu.mk
+++ b/mk/cfg/x86_64-pc-windows-gnu.mk
@@ -1,7 +1,6 @@
 # x86_64-pc-windows-gnu configuration
 CROSS_PREFIX_x86_64-pc-windows-gnu=x86_64-w64-mingw32-
 CC_x86_64-pc-windows-gnu=gcc
-LINK_x86_64-pc-windows-gnu=gcc
 CXX_x86_64-pc-windows-gnu=g++
 CPP_x86_64-pc-windows-gnu=gcc -E
 AR_x86_64-pc-windows-gnu=ar

--- a/mk/cfg/x86_64-unknown-linux-gnu.mk
+++ b/mk/cfg/x86_64-unknown-linux-gnu.mk
@@ -1,6 +1,5 @@
 # x86_64-unknown-linux-gnu configuration
 CC_x86_64-unknown-linux-gnu=$(CC)
-LINK_x86_64-unknown-linux-gnu=cc
 CXX_x86_64-unknown-linux-gnu=$(CXX)
 CPP_x86_64-unknown-linux-gnu=$(CPP)
 AR_x86_64-unknown-linux-gnu=$(AR)

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -120,6 +120,15 @@ endef
 $(foreach target,$(CFG_TARGET), \
   $(eval $(call ADD_INSTALLED_OBJECTS,$(target))))
 
+define DEFINE_LINKER
+  ifndef LINK_$(1)
+    LINK_$(1) := $$(CC_$(1))
+  endif
+endef
+
+$(foreach target,$(CFG_TARGET), \
+  $(eval $(call DEFINE_LINKER,$(target))))
+
 # The -Qunused-arguments sidesteps spurious warnings from clang
 define FILTER_FLAGS
   ifeq ($$(CFG_USING_CLANG),1)


### PR DESCRIPTION
The changes scaled back in 4cc025d8 were a little too aggressive and broke a
bunch of cross compilations by not defining the `LINK_$(1)` variable for all
targets. This commit ensures that the variable is defined for all targets by
defaulting it to the normal compiler if it's not already defined (it's only
defined specially for MSVC).

Closes #25723
Closes #25802
