### PR TITLE
Introduce a selection fast-path for builtin bounds

### DIFF
--- a/src/librustc_bitflags/lib.rs
+++ b/src/librustc_bitflags/lib.rs
@@ -16,6 +16,7 @@
 #![feature(staged_api)]
 #![staged_api]
 #![crate_type = "rlib"]
+#![feature(core)]
 #![feature(no_std)]
 #![no_std]
 #![unstable(feature = "rustc_private")]
@@ -23,6 +24,7 @@
 
 //! A typesafe bitmask flag generator.
 
+extern crate core;
 #[cfg(test)] #[macro_use] extern crate std;
 
 /// The `bitflags!` macro generates a `struct` that holds a set of C-style
@@ -288,13 +290,6 @@ macro_rules! bitflags {
             }
         }
     };
-}
-
-// This is a no_std crate. So the test code's invocation of #[derive] etc, via
-// bitflags!, will use names from the underlying crates.
-#[cfg(test)]
-mod core {
-    pub use std::{fmt, hash, clone, cmp, marker, option};
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Before:
748.97user 9.60system 9:56.54elapsed 127%CPU (0avgtext+0avgdata 2535256maxresident)

After:
731.82user 7.15system 9:39.20elapsed 127%CPU (0avgtext+0avgdata 2526224maxresident)

For a 2-3% total performance improvement.

To avoid lots of unwrap-ing, now all crates must have working Sized and Copy
traits. This is a [breaking-change] for some people using #![no_std].
