### PR TITLE
Enable colored test output when capturing output of tests

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -740,7 +740,7 @@ fn should_sort_failures_before_printing_them() {
 
 fn use_color(opts: &TestOpts) -> bool {
     match opts.color {
-        AutoColor => get_concurrency() == 1 && stdout_isatty(),
+        AutoColor => !opts.nocapture && stdout_isatty(),
         AlwaysColor => true,
         NeverColor => false,
     }


### PR DESCRIPTION
The output of individual tests can be captured now so it's safe to use
colorized output even when running tests in parallel. Closes #782.
