### PR TITLE
Add accessors for io::Error's inner Error

### DIFF
--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -215,6 +215,13 @@ impl error::Error for Error {
             Repr::Custom(ref c) => c.error.description(),
         }
     }
+
+    fn cause(&self) -> Option<&Error> {
+        match self.repr {
+            Repr::Os(..) => None,
+            Repr::Custom(ref c) => c.error.cause(),
+        }
+    }
 }
 
 fn _assert_error_is_sync_send() {

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -187,7 +187,8 @@ impl Error {
     ///
     /// If this `Error` was constructed via `new` then this function will
     /// return `Some`, otherwise it will return `None`.
-    #[unstable(feature = "io_error_inner", reason = "recently added")]
+    #[unstable(feature = "io_error_inner",
+               reason = "recently added and requires UFCS to downcast")]
     pub fn get_ref(&self) -> Option<&(error::Error+Send+Sync+'static)> {
         match self.repr {
             Repr::Os(..) => None,
@@ -200,7 +201,8 @@ impl Error {
     ///
     /// If this `Error` was constructed via `new` then this function will
     /// return `Some`, otherwise it will return `None`.
-    #[unstable(feature = "io_error_inner", reason = "recently added")]
+    #[unstable(feature = "io_error_inner",
+               reason = "recently added and requires UFCS to downcast")]
     pub fn get_mut(&mut self) -> Option<&mut (error::Error+Send+Sync+'static)> {
         match self.repr {
             Repr::Os(..) => None,
@@ -212,7 +214,8 @@ impl Error {
     ///
     /// If this `Error` was constructed via `new` then this function will
     /// return `Some`, otherwise it will return `None`.
-    #[unstable(feature = "io_error_inner", reason = "recently added")]
+    #[unstable(feature = "io_error_inner",
+               reason = "recently added and requires UFCS to downcast")]
     pub fn into_inner(self) -> Option<Box<error::Error+Send+Sync>> {
         match self.repr {
             Repr::Os(..) => None,


### PR DESCRIPTION
The first commit simply forwards `io::Error`'s `cause` implementation to the inner error.

The second commit adds accessor methods for the inner error. Method names mirror those used elsewhere like `BufReader`.

r? @alexcrichton 
