### PR TITLE
Implement std::iter::once/empty (RFC 771)

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -3030,6 +3030,100 @@ pub fn repeat<T: Clone>(elt: T) -> Repeat<T> {
     Repeat{element: elt}
 }
 
+/// An iterator that yields nothing.
+#[unstable(feature="iter_empty", reason = "new addition")]
+pub struct Empty<T>(marker::PhantomData<T>);
+
+#[unstable(feature="iter_empty", reason = "new addition")]
+impl<T> Iterator for Empty<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>){
+        (0, Some(0))
+    }
+}
+
+#[unstable(feature="iter_empty", reason = "new addition")]
+impl<T> DoubleEndedIterator for Empty<T> {
+    fn next_back(&mut self) -> Option<T> {
+        None
+    }
+}
+
+#[unstable(feature="iter_empty", reason = "new addition")]
+impl<T> ExactSizeIterator for Empty<T> {
+    fn len(&self) -> usize {
+        0
+    }
+}
+
+// not #[derive] because that adds a Clone bound on T,
+// which isn't necessary.
+#[unstable(feature="iter_empty", reason = "new addition")]
+impl<T> Clone for Empty<T> {
+    fn clone(&self) -> Empty<T> {
+        Empty(marker::PhantomData)
+    }
+}
+
+// not #[derive] because that adds a Default bound on T,
+// which isn't necessary.
+#[unstable(feature="iter_empty", reason = "new addition")]
+impl<T> Default for Empty<T> {
+    fn default() -> Empty<T> {
+        Empty(marker::PhantomData)
+    }
+}
+
+/// Creates an iterator that yields nothing.
+#[unstable(feature="iter_empty", reason = "new addition")]
+pub fn empty<T>() -> Empty<T> {
+    Empty(marker::PhantomData)
+}
+
+/// An iterator that yields an element exactly once.
+#[unstable(feature="iter_once", reason = "new addition")]
+pub struct Once<T> {
+    inner: ::option::IntoIter<T>
+}
+
+#[unstable(feature="iter_once", reason = "new addition")]
+impl<T> Iterator for Once<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        self.inner.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+#[unstable(feature="iter_once", reason = "new addition")]
+impl<T> DoubleEndedIterator for Once<T> {
+    fn next_back(&mut self) -> Option<T> {
+        self.inner.next_back()
+    }
+}
+
+#[unstable(feature="iter_once", reason = "new addition")]
+impl<T> ExactSizeIterator for Once<T> {
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+/// Creates an iterator that yields an element exactly once.
+#[unstable(feature="iter_once", reason = "new addition")]
+pub fn once<T>(value: T) -> Once<T> {
+    Once { inner: Some(value).into_iter() }
+}
+
 /// Functions for lexicographical ordering of sequences.
 ///
 /// Lexicographical ordering through `<`, `<=`, `>=`, `>` requires

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -1096,6 +1096,19 @@ fn test_fuse_count() {
     // Can't check len now because count consumes.
 }
 
+#[test]
+fn test_once() {
+    let mut it = once(42);
+    assert_eq!(it.next(), Some(42));
+    assert_eq!(it.next(), None);
+}
+
+#[test]
+fn test_empty() {
+    let mut it = empty::<i32>();
+    assert_eq!(it.next(), None);
+}
+
 #[bench]
 fn bench_rposition(b: &mut Bencher) {
     let it: Vec<usize> = (0..300).collect();

--- a/src/libcoretest/lib.rs
+++ b/src/libcoretest/lib.rs
@@ -25,6 +25,8 @@
 #![feature(slice_patterns)]
 #![feature(float_from_str_radix)]
 #![feature(cell_extras)]
+#![feature(iter_empty)]
+#![feature(iter_once)]
 
 extern crate core;
 extern crate test;


### PR DESCRIPTION
Closes #24443.
