### PR TITLE
test: Join child threads on windows in tests

### DIFF
--- a/src/test/run-pass/macro-with-braces-in-expr-position.rs
+++ b/src/test/run-pass/macro-with-braces-in-expr-position.rs
@@ -8,15 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(std_misc)]
-
 use std::thread;
 
 macro_rules! expr { ($e: expr) => { $e } }
 
 macro_rules! spawn {
     ($($code: tt)*) => {
-        expr!(thread::spawn(move|| {$($code)*}))
+        expr!(thread::spawn(move|| {$($code)*}).join())
     }
 }
 


### PR DESCRIPTION
Windows tests can often deadlock if a child thread continues after the main
thread and then panics, and a `println!` executed in a child thread after the
main thread has exited is at risk of panicking.
