### PR TITLE
remove references to IoResult

### DIFF
--- a/src/doc/style/errors/ergonomics.md
+++ b/src/doc/style/errors/ergonomics.md
@@ -63,4 +63,4 @@ for more details.
 ### The `Result`-`impl` pattern [FIXME]
 
 > **[FIXME]** Document the way that the `io` module uses trait impls
-> on `IoResult` to painlessly propagate errors.
+> on `std::io::Result` to painlessly propagate errors.

--- a/src/doc/style/features/functions-and-methods/input.md
+++ b/src/doc/style/features/functions-and-methods/input.md
@@ -121,7 +121,7 @@ The primary exception: sometimes a function is meant to modify data
 that the caller already owns, for example to re-use a buffer:
 
 ```rust
-fn read(&mut self, buf: &mut [u8]) -> IoResult<usize>
+fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize>
 ```
 
 (From the [Reader trait](http://static.rust-lang.org/doc/master/std/io/trait.Reader.html#tymethod.read).)

--- a/src/doc/style/ownership/builders.md
+++ b/src/doc/style/ownership/builders.md
@@ -75,7 +75,7 @@ impl Command {
     }
 
     /// Executes the command as a child process, which is returned.
-    pub fn spawn(&self) -> IoResult<Process> {
+    pub fn spawn(&self) -> std::io::Result<Process> {
         ...
     }
 }

--- a/src/libcollections/fmt.rs
+++ b/src/libcollections/fmt.rs
@@ -164,8 +164,8 @@
 //! provides some helper methods.
 //!
 //! Additionally, the return value of this function is `fmt::Result` which is a
-//! typedef to `Result<(), IoError>` (also known as `IoResult<()>`). Formatting
-//! implementations should ensure that they return errors from `write!`
+//! typedef to `Result<(), std::io::Error>` (also known as `std::io::Result<()>`).
+//! Formatting implementations should ensure that they return errors from `write!`
 //! correctly (propagating errors upward).
 //!
 //! An example of implementing the formatting traits would look

--- a/src/libstd/rand/mod.rs
+++ b/src/libstd/rand/mod.rs
@@ -95,7 +95,7 @@ impl StdRng {
     /// appropriate.
     ///
     /// Reading the randomness from the OS may fail, and any error is
-    /// propagated via the `IoResult` return value.
+    /// propagated via the `io::Result` return value.
     pub fn new() -> io::Result<StdRng> {
         OsRng::new().map(|mut r| StdRng { rng: r.gen() })
     }


### PR DESCRIPTION
This is now std::io::Result
