### PR TITLE
Prevent comparison and dereferencing of raw pointers in constexprs

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -892,6 +892,8 @@ register_diagnostics! {
     E0316, // nested quantification of lifetimes
     E0370, // discriminant overflow
     E0378, // method calls limited to constant inherent methods
-    E0394  // cannot refer to other statics by value, use the address-of
+    E0394, // cannot refer to other statics by value, use the address-of
            // operator or a constant instead
+    E0395, // pointer comparison in const-expr
+    E0396  // pointer dereference in const-expr
 }

--- a/src/test/compile-fail/const-deref-ptr.rs
+++ b/src/test/compile-fail/const-deref-ptr.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-static X: usize = 0 as *const usize as usize;
-//~^ ERROR: raw pointers cannot be cast to integers in statics
+// Check that you can't dereference raw pointers in constants.
 
 fn main() {
-    assert_eq!(X, 0);
+    static C: u64 = unsafe {*(0xdeadbeef as *const u64)}; //~ ERROR E0396
+    println!("{}", C);
 }

--- a/src/test/compile-fail/issue-25826.rs
+++ b/src/test/compile-fail/issue-25826.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-static X: usize = 0 as *const usize as usize;
-//~^ ERROR: raw pointers cannot be cast to integers in statics
-
+fn id<T>(t: T) -> T { t }
 fn main() {
-    assert_eq!(X, 0);
+    const A: bool = id::<u8> as *const () < id::<u16> as *const ();
+    //~^ ERROR raw pointers cannot be compared in constants [E0395]
+    println!("{}", A);
 }


### PR DESCRIPTION
Fixes #25826.
