### PR TITLE
std: Stabilize a number of new fs features

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,21 @@
+Version 1.1.0 (July 2015)
+========================
+
+* NNNN changes, numerous bugfixes
+
+Libraries
+---------
+
+* The [`std::fs` module has been expanded][fs-expand] to expand the set of
+  functionality exposed:
+  * `DirEntry` now supports optimizations like `file_type` and `metadata` which
+    don't incur a syscall on some platforms.
+  * A `symlink_metadata` function has been added.
+  * The `fs::Metadata` structure now lowers to its OS counterpart, providing
+    access to all underlying information.
+
+[fs-expand]: https://github.com/rust-lang/rust/pull/25844
+
 Version 1.0.0 (May 2015)
 ========================
 

--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -38,7 +38,6 @@
 #![feature(staged_api)]
 #![feature(unicode)]
 #![feature(path_ext)]
-#![feature(fs)]
 #![feature(path_relative_from)]
 #![feature(std_misc)]
 

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -148,7 +148,7 @@ pub struct OpenOptions(fs_imp::OpenOptions);
 pub struct Permissions(fs_imp::FilePermissions);
 
 /// An structure representing a type of file with accessors for each file type.
-#[unstable(feature = "file_type", reason = "recently added API")]
+#[stable(feature = "file_type", since = "1.1.0")]
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct FileType(fs_imp::FileType);
 
@@ -206,14 +206,6 @@ impl File {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn create<P: AsRef<Path>>(path: P) -> io::Result<File> {
         OpenOptions::new().write(true).create(true).truncate(true).open(path)
-    }
-
-    /// Returns `None`.
-    #[unstable(feature = "file_path",
-               reason = "this abstraction was imposed by this library and was removed")]
-    #[deprecated(since = "1.0.0", reason = "abstraction was removed")]
-    pub fn path(&self) -> Option<&Path> {
-        None
     }
 
     /// Attempts to sync all OS-internal metadata to disk.
@@ -501,7 +493,7 @@ impl AsInnerMut<fs_imp::OpenOptions> for OpenOptions {
 
 impl Metadata {
     /// Returns the file type for this metadata.
-    #[unstable(feature = "file_type", reason = "recently added API")]
+    #[stable(feature = "file_type", since = "1.1.0")]
     pub fn file_type(&self) -> FileType {
         FileType(self.0.file_type())
     }
@@ -575,38 +567,6 @@ impl Metadata {
     pub fn permissions(&self) -> Permissions {
         Permissions(self.0.perm())
     }
-
-    /// Returns the most recent access time for a file.
-    ///
-    /// The return value is in milliseconds since the epoch.
-    #[unstable(feature = "fs_time",
-               reason = "the return type of u64 is not quite appropriate for \
-                         this method and may change if the standard library \
-                         gains a type to represent a moment in time")]
-    #[deprecated(since = "1.1.0",
-                 reason = "use os::platform::fs::MetadataExt extension traits")]
-    pub fn accessed(&self) -> u64 {
-        self.adjust_time(self.0.accessed())
-    }
-
-    /// Returns the most recent modification time for a file.
-    ///
-    /// The return value is in milliseconds since the epoch.
-    #[unstable(feature = "fs_time",
-               reason = "the return type of u64 is not quite appropriate for \
-                         this method and may change if the standard library \
-                         gains a type to represent a moment in time")]
-    #[deprecated(since = "1.1.0",
-                 reason = "use os::platform::fs::MetadataExt extension traits")]
-    pub fn modified(&self) -> u64 {
-        self.adjust_time(self.0.modified())
-    }
-
-    fn adjust_time(&self, val: u64) -> u64 {
-        // FILETIME (what `val` represents) is in 100ns intervals and there are
-        // 10000 intervals in a millisecond.
-        if cfg!(windows) {val / 10000} else {val}
-    }
 }
 
 impl AsInner<fs_imp::FileAttr> for Metadata {
@@ -663,15 +623,17 @@ impl Permissions {
     }
 }
 
-#[unstable(feature = "file_type", reason = "recently added API")]
 impl FileType {
     /// Test whether this file type represents a directory.
+    #[stable(feature = "file_type", since = "1.1.0")]
     pub fn is_dir(&self) -> bool { self.0.is_dir() }
 
     /// Test whether this file type represents a regular file.
+    #[stable(feature = "file_type", since = "1.1.0")]
     pub fn is_file(&self) -> bool { self.0.is_file() }
 
     /// Test whether this file type represents a symbolic link.
+    #[stable(feature = "file_type", since = "1.1.0")]
     pub fn is_symlink(&self) -> bool { self.0.is_symlink() }
 }
 
@@ -736,7 +698,7 @@ impl DirEntry {
     /// On Windows this function is cheap to call (no extra system calls
     /// needed), but on Unix platforms this function is the equivalent of
     /// calling `symlink_metadata` on the path.
-    #[unstable(feature = "dir_entry_ext", reason = "recently added API")]
+    #[stable(feature = "dir_entry_ext", since = "1.1.0")]
     pub fn metadata(&self) -> io::Result<Metadata> {
         self.0.metadata().map(Metadata)
     }
@@ -751,14 +713,14 @@ impl DirEntry {
     /// On Windows and most Unix platforms this function is free (no extra
     /// system calls needed), but some Unix platforms may require the equivalent
     /// call to `symlink_metadata` to learn about the target file type.
-    #[unstable(feature = "dir_entry_ext", reason = "recently added API")]
+    #[stable(feature = "dir_entry_ext", since = "1.1.0")]
     pub fn file_type(&self) -> io::Result<FileType> {
         self.0.file_type().map(FileType)
     }
 
     /// Returns the bare file name of this directory entry without any other
     /// leading path component.
-    #[unstable(feature = "dir_entry_ext", reason = "recently added API")]
+    #[stable(feature = "dir_entry_ext", since = "1.1.0")]
     pub fn file_name(&self) -> OsString {
         self.0.file_name()
     }
@@ -828,7 +790,6 @@ pub fn metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
 /// # Examples
 ///
 /// ```rust
-/// #![feature(symlink_metadata)]
 /// # fn foo() -> std::io::Result<()> {
 /// use std::fs;
 ///
@@ -837,7 +798,7 @@ pub fn metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
 /// # Ok(())
 /// # }
 /// ```
-#[unstable(feature = "symlink_metadata", reason = "recently added API")]
+#[stable(feature = "symlink_metadata", since = "1.1.0")]
 pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
     fs_imp::lstat(path.as_ref()).map(Metadata)
 }
@@ -1270,7 +1231,6 @@ pub fn set_file_times<P: AsRef<Path>>(path: P, accessed: u64,
 /// # Examples
 ///
 /// ```
-/// # #![feature(fs)]
 /// # fn foo() -> std::io::Result<()> {
 /// use std::fs;
 ///
@@ -1286,14 +1246,13 @@ pub fn set_file_times<P: AsRef<Path>>(path: P, accessed: u64,
 /// This function will return an error if the provided `path` doesn't exist, if
 /// the process lacks permissions to change the attributes of the file, or if
 /// some other I/O error is encountered.
-#[unstable(feature = "fs",
-           reason = "a more granual ability to set specific permissions may \
-                     be exposed on the Permissions structure itself and this \
-                     method may not always exist")]
-pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result<()> {
+#[stable(feature = "set_permissions", since = "1.1.0")]
+pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions)
+                                       -> io::Result<()> {
     fs_imp::set_perm(path.as_ref(), perm.0)
 }
 
+#[unstable(feature = "dir_builder", reason = "recently added API")]
 impl DirBuilder {
     /// Creates a new set of options with default mode/security settings for all
     /// platforms and also non-recursive.
@@ -2066,9 +2025,24 @@ mod tests {
         // These numbers have to be bigger than the time in the day to account
         // for timezones Windows in particular will fail in certain timezones
         // with small enough values
-        check!(fs::set_file_times(&path, 100000, 200000));
-        assert_eq!(check!(path.metadata()).accessed(), 100000);
-        assert_eq!(check!(path.metadata()).modified(), 200000);
+        check!(fs::set_file_times(&path, 100_000, 200_000));
+
+        check(&check!(path.metadata()));
+
+        #[cfg(unix)]
+        fn check(metadata: &fs::Metadata) {
+            use os::unix::prelude::*;
+            assert_eq!(metadata.atime(), 100);
+            assert_eq!(metadata.atime_nsec(), 0);
+            assert_eq!(metadata.mtime(), 200);
+            assert_eq!(metadata.mtime_nsec(), 0);
+        }
+        #[cfg(windows)]
+        fn check(metadata: &fs::Metadata) {
+            use os::windows::prelude::*;
+            assert_eq!(metadata.last_access_time(), 100_000 * 10_000);
+            assert_eq!(metadata.last_write_time(), 200_000 * 10_000);
+        }
     }
 
     #[test]

--- a/src/libstd/os/android/mod.rs
+++ b/src/libstd/os/android/mod.rs
@@ -10,10 +10,11 @@
 
 //! Android-specific definitions
 
-#![unstable(feature = "raw_ext", reason = "recently added API")]
+#![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
 
 pub mod fs {
+    #![stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/android/raw.rs
+++ b/src/libstd/os/android/raw.rs
@@ -10,6 +10,8 @@
 
 //! Android-specific raw type definitions
 
+#![stable(feature = "raw_ext", since = "1.1.0")]
+
 #[doc(inline)]
 pub use self::arch::{dev_t, mode_t, blkcnt_t, blksize_t, ino_t, nlink_t, off_t, stat, time_t};
 
@@ -18,36 +20,64 @@ mod arch {
     use os::raw::{c_uint, c_uchar, c_ulonglong, c_longlong, c_ulong};
     use os::unix::raw::{uid_t, gid_t};
 
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type dev_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type mode_t = u16;
 
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type blkcnt_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type blksize_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type ino_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type nlink_t = u16;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type off_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type time_t = i32;
 
     #[repr(C)]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_dev: c_ulonglong,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad0: [c_uchar; 4],
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __st_ino: ino_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mode: c_uint,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_nlink: c_uint,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_uid: uid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_gid: gid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_rdev: c_ulonglong,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad3: [c_uchar; 4],
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_size: c_longlong,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blksize: blksize_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blocks: c_ulonglong,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime_nsec: c_ulong,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime_nsec: c_ulong,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: c_ulong,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ino: c_ulonglong,
     }
 
@@ -59,37 +89,64 @@ mod arch {
     use os::raw::{c_uchar, c_ulong};
     use os::unix::raw::{uid_t, gid_t};
 
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type dev_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type mode_t = u32;
 
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type blkcnt_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type blksize_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type nlink_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type off_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub type time_t = i64;
 
     #[repr(C)]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_dev: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad0: [c_uchar; 4],
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __st_ino: ino_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mode: mode_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_nlink: nlink_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_uid: uid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_gid: gid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_rdev: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad3: [c_uchar; 4],
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_size: off_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blksize: blksize_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blocks: blkcnt_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime_nsec: c_ulong,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime_nsec: c_ulong,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: c_ulong,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ino: ino_t,
     }
-
 }

--- a/src/libstd/os/bitrig/mod.rs
+++ b/src/libstd/os/bitrig/mod.rs
@@ -10,10 +10,11 @@
 
 //! Bitrig-specific definitions
 
-#![unstable(feature = "raw_ext", reason = "recently added API")]
+#![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
 
 pub mod fs {
+    #![stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/bitrig/raw.rs
+++ b/src/libstd/os/bitrig/raw.rs
@@ -10,39 +10,62 @@
 
 //! Bitrig-specific raw type definitions
 
+#![stable(feature = "raw_ext", since = "1.1.0")]
+
 use os::raw::c_long;
 use os::unix::raw::{uid_t, gid_t};
 
-pub type blkcnt_t = i64;
-pub type blksize_t = u32;
-pub type dev_t = i32;
-pub type fflags_t = u32; // type not declared, but struct stat have u_int32_t
-pub type ino_t = u64;
-pub type mode_t = u32;
-pub type nlink_t = u32;
-pub type off_t = i64;
-pub type time_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[repr(C)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mode: mode_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_dev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ino: ino_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_nlink: nlink_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_uid: uid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gid: gid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_rdev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_size: off_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_blocks: blkcnt_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_blksize: blksize_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_flags: fflags_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gen: u32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_birthtime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_birthtime_nsec: c_long,
 }

--- a/src/libstd/os/dragonfly/mod.rs
+++ b/src/libstd/os/dragonfly/mod.rs
@@ -10,10 +10,11 @@
 
 //! Dragonfly-specific definitions
 
-#![unstable(feature = "raw_ext", reason = "recently added API")]
+#![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
 
 pub mod fs {
+    #![stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/dragonfly/raw.rs
+++ b/src/libstd/os/dragonfly/raw.rs
@@ -10,41 +10,66 @@
 
 //! Dragonfly-specific raw type definitions
 
+#![stable(feature = "raw_ext", since = "1.1.0")]
+
 use os::raw::c_long;
 use os::unix::raw::{uid_t, gid_t};
 
-pub type blkcnt_t = i64;
-pub type blksize_t = u32;
-pub type dev_t = u32;
-pub type fflags_t = u32;
-pub type ino_t = u64;
-pub type mode_t = u16;
-pub type nlink_t = u16;
-pub type off_t = i64;
-pub type time_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u16;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u16;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[repr(C)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ino: ino_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_nlink: nlink_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_dev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mode: mode_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_padding1: u16,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_uid: uid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gid: gid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_rdev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_size: off_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_blocks: blkcnt_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_blksize: blksize_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_flags: fflags_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gen: uint32_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_lspare: int32_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_qspare1: int64_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_qspare2: int64_t,
 }

--- a/src/libstd/os/freebsd/mod.rs
+++ b/src/libstd/os/freebsd/mod.rs
@@ -10,10 +10,11 @@
 
 //! FreeBSD-specific definitions
 
-#![unstable(feature = "raw_ext", reason = "recently added API")]
+#![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
 
 pub mod fs {
+    #![stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/freebsd/raw.rs
+++ b/src/libstd/os/freebsd/raw.rs
@@ -10,41 +10,75 @@
 
 //! FreeBSD-specific raw type definitions
 
+#![stable(feature = "raw_ext", since = "1.1.0")]
+
 use os::raw::c_long;
 use os::unix::raw::{uid_t, gid_t};
 
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub type blkcnt_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub type blksize_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub type dev_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub type fflags_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub type ino_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub type mode_t = u16;
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub type nlink_t = u16;
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub type off_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub type time_t = i64;
 
 #[repr(C)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_dev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ino: ino_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mode: mode_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_nlink: nlink_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_uid: uid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gid: gid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_rdev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_size: off_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_blocks: blkcnt_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_blksize: blksize_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_flags: fflags_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gen: u32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_lspare: i32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_birthtime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_birthtime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub __unused: [u8; 2],
 }

--- a/src/libstd/os/ios/mod.rs
+++ b/src/libstd/os/ios/mod.rs
@@ -10,10 +10,11 @@
 
 //! iOS-specific definitions
 
-#![unstable(feature = "raw_ext", reason = "recently added API")]
+#![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
 
 pub mod fs {
+    #![stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/ios/raw.rs
+++ b/src/libstd/os/ios/raw.rs
@@ -10,40 +10,65 @@
 
 //! iOS-specific raw type definitions
 
+#![stable(feature = "raw_ext", since = "1.1.0")]
+
 use os::raw::c_long;
 use os::unix::raw::{uid_t, gid_t};
 
-pub type blkcnt_t = i64;
-pub type blksize_t = i32;
-pub type dev_t = i32;
-pub type ino_t = u64;
-pub type mode_t = u16;
-pub type nlink_t = u16;
-pub type off_t = i64;
-pub type time_t = c_long;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u16;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u16;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = c_long;
 
 #[repr(C)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_dev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mode: mode_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_nlink: nlink_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ino: ino_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_uid: uid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gid: gid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_rdev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_birthtime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_birthtime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_size: off_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_blocks: blkcnt_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_blksize: blksize_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_flags: u32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gen: u32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_lspare: i32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_qspare: [i64; 2],
 }

--- a/src/libstd/os/linux/mod.rs
+++ b/src/libstd/os/linux/mod.rs
@@ -10,10 +10,11 @@
 
 //! Linux-specific definitions
 
-#![unstable(feature = "raw_ext", reason = "recently added API")]
+#![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
 
 pub mod fs {
+    #![stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/linux/raw.rs
+++ b/src/libstd/os/linux/raw.rs
@@ -10,8 +10,10 @@
 
 //! Linux-specific raw type definitions
 
-pub type dev_t = u64;
-pub type mode_t = u32;
+#![stable(feature = "raw_ext", since = "1.1.0")]
+
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
 
 #[doc(inline)]
 pub use self::arch::{off_t, ino_t, nlink_t, blksize_t, blkcnt_t, stat, time_t};
@@ -25,34 +27,55 @@ mod arch {
     use os::raw::{c_long, c_short};
     use os::unix::raw::{gid_t, uid_t};
 
-    pub type blkcnt_t = i32;
-    pub type blksize_t = i32;
-    pub type ino_t = u32;
-    pub type nlink_t = u32;
-    pub type off_t = i32;
-    pub type time_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;
 
     #[repr(C)]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_dev: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad1: c_short,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ino: ino_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mode: mode_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_nlink: nlink_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_uid: uid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_gid: gid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_rdev: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad2: c_short,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_size: off_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blksize: blksize_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blocks: blkcnt_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __unused4: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __unused5: c_long,
     }
 }
@@ -64,34 +87,55 @@ mod arch {
     use os::raw::{c_long, c_ulong};
     use os::unix::raw::{gid_t, uid_t};
 
-    pub type blkcnt_t = i32;
-    pub type blksize_t = i32;
-    pub type ino_t = u32;
-    pub type nlink_t = u32;
-    pub type off_t = i32;
-    pub type time_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;
 
     #[repr(C)]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_dev: c_ulong,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_pad1: [c_long; 3],
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ino: ino_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mode: mode_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_nlink: nlink_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_uid: uid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_gid: gid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_rdev: c_ulong,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_pad2: [c_long; 2],
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_size: off_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_pad3: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blksize: blksize_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blocks: blkcnt_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_pad5: [c_long; 14],
     }
 }
@@ -102,33 +146,53 @@ mod arch {
     use os::raw::{c_long, c_int};
     use os::unix::raw::{gid_t, uid_t};
 
-    pub type blkcnt_t = i64;
-    pub type blksize_t = i32;
-    pub type ino_t = u64;
-    pub type nlink_t = u32;
-    pub type off_t = i64;
-    pub type time_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
     #[repr(C)]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_dev: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ino: ino_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mode: mode_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_nlink: nlink_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_uid: uid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_gid: gid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_rdev: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad1: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_size: off_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blksize: blksize_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad2: c_int,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blocks: blkcnt_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __unused: [c_int; 2],
     }
 }
@@ -139,32 +203,51 @@ mod arch {
     use os::raw::{c_long, c_int};
     use os::unix::raw::{gid_t, uid_t};
 
-    pub type blkcnt_t = i64;
-    pub type blksize_t = i64;
-    pub type ino_t = u64;
-    pub type nlink_t = u64;
-    pub type off_t = i64;
-    pub type time_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
     #[repr(C)]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_dev: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ino: ino_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_nlink: nlink_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mode: mode_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_uid: uid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_gid: gid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad0: c_int,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_rdev: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_size: off_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blksize: blksize_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blocks: blkcnt_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __unused: [c_long; 3],
     }
 }

--- a/src/libstd/os/macos/mod.rs
+++ b/src/libstd/os/macos/mod.rs
@@ -10,10 +10,11 @@
 
 //! MacOS-specific definitions
 
-#![unstable(feature = "raw_ext", reason = "recently added API")]
+#![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
 
 pub mod fs {
+    #![stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/macos/raw.rs
+++ b/src/libstd/os/macos/raw.rs
@@ -10,40 +10,65 @@
 
 //! MacOS-specific raw type definitions
 
+#![stable(feature = "raw_ext", since = "1.1.0")]
+
 use os::raw::c_long;
 use os::unix::raw::{uid_t, gid_t};
 
-pub type blkcnt_t = i64;
-pub type blksize_t = i32;
-pub type dev_t = i32;
-pub type ino_t = u64;
-pub type mode_t = u16;
-pub type nlink_t = u16;
-pub type off_t = i64;
-pub type time_t = c_long;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u16;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u16;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = c_long;
 
 #[repr(C)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_dev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mode: mode_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_nlink: nlink_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ino: ino_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_uid: uid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gid: gid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_rdev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_birthtime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_birthtime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_size: off_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_blocks: blkcnt_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_blksize: blksize_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_flags: u32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gen: u32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_lspare: i32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_qspare: [i64; 2],
 }

--- a/src/libstd/os/nacl/mod.rs
+++ b/src/libstd/os/nacl/mod.rs
@@ -10,10 +10,11 @@
 
 //! Nacl-specific definitions
 
-#![unstable(feature = "raw_ext", reason = "recently added API")]
+#![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
 
 pub mod fs {
+    #![stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/nacl/raw.rs
+++ b/src/libstd/os/nacl/raw.rs
@@ -10,8 +10,10 @@
 
 //! Nacl-specific raw type definitions
 
-pub type dev_t = u64;
-pub type mode_t = u32;
+#![stable(feature = "raw_ext", since = "1.1.0")]
+
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
 
 pub use self::arch::{off_t, ino_t, nlink_t, blksize_t, blkcnt_t, stat, time_t};
 
@@ -24,34 +26,55 @@ mod arch {
     use os::raw::{c_long, c_short};
     use os::unix::raw::{gid_t, uid_t};
 
-    pub type blkcnt_t = i32;
-    pub type blksize_t = i32;
-    pub type ino_t = u32;
-    pub type nlink_t = u32;
-    pub type off_t = i32;
-    pub type time_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;
 
     #[repr(C)]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_dev: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad1: c_short,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ino: ino_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mode: mode_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_nlink: nlink_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_uid: uid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_gid: gid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_rdev: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad2: c_short,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_size: off_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blksize: blksize_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blocks: blkcnt_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __unused4: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __unused5: c_long,
     }
 }
@@ -63,34 +86,55 @@ mod arch {
     use os::raw::c_long;
     use os::unix::raw::{gid_t, uid_t};
 
-    pub type blkcnt_t = i32;
-    pub type blksize_t = i32;
-    pub type ino_t = u32;
-    pub type nlink_t = u32;
-    pub type off_t = i32;
-    pub type time_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i32;
 
     #[repr(C)]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_dev: c_ulong,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_pad1: [c_long; 3],
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ino: ino_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mode: mode_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_nlink: nlink_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_uid: uid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_gid: gid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_rdev: c_ulong,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_pad2: [c_long; 2],
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_size: off_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_pad3: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blksize: blksize_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blocks: blkcnt_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_pad5: [c_long; 14],
     }
 }
@@ -101,33 +145,53 @@ mod arch {
     use os::raw::{c_long, c_int};
     use os::unix::raw::{gid_t, uid_t};
 
-    pub type blkcnt_t = i64;
-    pub type blksize_t = i32;
-    pub type ino_t = u64;
-    pub type nlink_t = u32;
-    pub type off_t = i64;
-    pub type time_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
     #[repr(C)]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_dev: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ino: ino_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mode: mode_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_nlink: nlink_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_uid: uid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_gid: gid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_rdev: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad1: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_size: off_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blksize: blksize_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad2: c_int,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blocks: blkcnt_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __unused: [c_int; 2],
     }
 }
@@ -138,32 +202,51 @@ mod arch {
     use os::raw::{c_long, c_int};
     use os::unix::raw::{gid_t, uid_t};
 
-    pub type blkcnt_t = i64;
-    pub type blksize_t = i64;
-    pub type ino_t = u64;
-    pub type nlink_t = u64;
-    pub type off_t = i64;
-    pub type time_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+    #[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
     #[repr(C)]
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub struct stat {
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_dev: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ino: ino_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_nlink: nlink_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mode: mode_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_uid: uid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_gid: gid_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __pad0: c_int,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_rdev: dev_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_size: off_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blksize: blksize_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_blocks: blkcnt_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_atime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_mtime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime: time_t,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub st_ctime_nsec: c_long,
+        #[stable(feature = "raw_ext", since = "1.1.0")]
         pub __unused: [c_long; 3],
     }
 }

--- a/src/libstd/os/openbsd/mod.rs
+++ b/src/libstd/os/openbsd/mod.rs
@@ -10,10 +10,11 @@
 
 //! OpenBSD-specific definitions
 
-#![unstable(feature = "raw_ext", reason = "recently added API")]
+#![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod raw;
 
 pub mod fs {
+    #![stable(feature = "raw_ext", since = "1.1.0")]
     pub use sys::fs::MetadataExt;
 }

--- a/src/libstd/os/openbsd/raw.rs
+++ b/src/libstd/os/openbsd/raw.rs
@@ -10,39 +10,62 @@
 
 //! OpenBSD-specific raw type definitions
 
+#![stable(feature = "raw_ext", since = "1.1.0")]
+
 use os::raw::c_long;
 use os::unix::raw::{uid_t, gid_t};
 
-pub type blkcnt_t = i64;
-pub type blksize_t = u32;
-pub type dev_t = i32;
-pub type fflags_t = u32; // type not declared, but struct stat have u_int32_t
-pub type ino_t = u64;
-pub type mode_t = u32;
-pub type nlink_t = u32;
-pub type off_t = i64;
-pub type time_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blkcnt_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type blksize_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type fflags_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type ino_t = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type nlink_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type off_t = i64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type time_t = i64;
 
 #[repr(C)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
 pub struct stat {
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mode: mode_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_dev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ino: ino_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_nlink: nlink_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_uid: uid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gid: gid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_rdev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_atime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_mtime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_ctime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_size: off_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_blocks: blkcnt_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_blksize: blksize_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_flags: fflags_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_gen: u32,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_birthtime: time_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
     pub st_birthtime_nsec: c_long,
 }

--- a/src/libstd/os/raw.rs
+++ b/src/libstd/os/raw.rs
@@ -10,24 +10,30 @@
 
 //! Raw OS-specific types for the current platform/architecture
 
-#![unstable(feature = "raw_os", reason = "recently added API")]
+#![stable(feature = "raw_os", since = "1.1.0")]
 
-#[cfg(target_arch = "aarch64")]      pub type c_char = u8;
-#[cfg(not(target_arch = "aarch64"))] pub type c_char = i8;
-pub type c_schar = i8;
-pub type c_uchar = u8;
-pub type c_short = i16;
-pub type c_ushort = u16;
-pub type c_int = i32;
-pub type c_uint = u32;
-#[cfg(any(target_pointer_width = "32", windows))] pub type c_long = i32;
-#[cfg(any(target_pointer_width = "32", windows))] pub type c_ulong = u32;
-#[cfg(all(target_pointer_width = "64", not(windows)))] pub type c_long = i64;
-#[cfg(all(target_pointer_width = "64", not(windows)))] pub type c_ulong = u64;
-pub type c_longlong = i64;
-pub type c_ulonglong = u64;
-pub type c_float = f32;
-pub type c_double = f64;
+#[cfg(target_arch = "aarch64")]
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_char = u8;
+#[cfg(not(target_arch = "aarch64"))]
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_char = i8;
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_schar = i8;
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_uchar = u8;
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_short = i16;
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_ushort = u16;
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_int = i32;
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_uint = u32;
+#[cfg(any(target_pointer_width = "32", windows))]
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_long = i32;
+#[cfg(any(target_pointer_width = "32", windows))]
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_ulong = u32;
+#[cfg(all(target_pointer_width = "64", not(windows)))]
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_long = i64;
+#[cfg(all(target_pointer_width = "64", not(windows)))]
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_ulong = u64;
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_longlong = i64;
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_ulonglong = u64;
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_float = f32;
+#[stable(feature = "raw_os", since = "1.1.0")] pub type c_double = f64;
 
 /// Type used to construct void pointers for use with C.
 ///
@@ -41,8 +47,11 @@ pub type c_double = f64;
 //     variants, because the compiler complains about the repr attribute
 //     otherwise.
 #[repr(u8)]
+#[stable(feature = "raw_os", since = "1.1.0")]
 pub enum c_void {
+    #[unstable(feature = "c_void_variant", reason = "should not have to exist")]
     #[doc(hidden)] __variant1,
+    #[unstable(feature = "c_void_variant", reason = "should not have to exist")]
     #[doc(hidden)] __variant2,
 }
 

--- a/src/libstd/sys/unix/ext/raw.rs
+++ b/src/libstd/sys/unix/ext/raw.rs
@@ -10,11 +10,11 @@
 
 //! Unix-specific primitives available on all unix platforms
 
-#![unstable(feature = "raw_ext", reason = "recently added API")]
+#![stable(feature = "raw_ext", since = "1.1.0")]
 
-pub type uid_t = u32;
-pub type gid_t = u32;
-pub type pid_t = i32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type uid_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type gid_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type pid_t = i32;
 
 #[doc(inline)]
 pub use sys::platform::raw::{dev_t, ino_t, mode_t, nlink_t, off_t, blksize_t};

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -69,22 +69,8 @@ impl FileAttr {
         FilePermissions { mode: (self.stat.st_mode as mode_t) & 0o777 }
     }
 
-    pub fn accessed(&self) -> u64 {
-        self.mktime(self.stat.st_atime as u64, self.stat.st_atime_nsec as u64)
-    }
-    pub fn modified(&self) -> u64 {
-        self.mktime(self.stat.st_mtime as u64, self.stat.st_mtime_nsec as u64)
-    }
-
     pub fn file_type(&self) -> FileType {
         FileType { mode: self.stat.st_mode as mode_t }
-    }
-
-    pub fn raw(&self) -> &raw::stat { &self.stat }
-
-    // times are in milliseconds (currently)
-    fn mktime(&self, secs: u64, nsecs: u64) -> u64 {
-        secs * 1000 + nsecs / 1000000
     }
 }
 
@@ -92,17 +78,22 @@ impl AsInner<raw::stat> for FileAttr {
     fn as_inner(&self) -> &raw::stat { &self.stat }
 }
 
-#[unstable(feature = "metadata_ext", reason = "recently added API")]
+/// OS-specific extension methods for `fs::Metadata`
+#[stable(feature = "metadata_ext", since = "1.1.0")]
 pub trait MetadataExt {
+    /// Gain a reference to the underlying `stat` structure which contains the
+    /// raw information returned by the OS.
+    ///
+    /// The contents of the returned `stat` are **not** consistent across Unix
+    /// platforms. The `os::unix::fs::MetadataExt` trait contains the cross-Unix
+    /// abstractions contained within the raw stat.
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
     fn as_raw_stat(&self) -> &raw::stat;
 }
 
+#[stable(feature = "metadata_ext", since = "1.1.0")]
 impl MetadataExt for ::fs::Metadata {
     fn as_raw_stat(&self) -> &raw::stat { &self.as_inner().stat }
-}
-
-impl MetadataExt for ::os::unix::fs::Metadata {
-    fn as_raw_stat(&self) -> &raw::stat { self.as_inner() }
 }
 
 impl FilePermissions {

--- a/src/libstd/sys/windows/ext/fs.rs
+++ b/src/libstd/sys/windows/ext/fs.rs
@@ -21,7 +21,8 @@ use sys;
 use sys_common::{AsInnerMut, AsInner};
 
 /// Windows-specific extensions to `OpenOptions`
-#[unstable(feature = "fs_ext", reason = "may require more thought/methods")]
+#[unstable(feature = "open_options_ext",
+           reason = "may require more thought/methods")]
 pub trait OpenOptionsExt {
     /// Overrides the `dwDesiredAccess` argument to the call to `CreateFile`
     /// with the specified value.
@@ -66,39 +67,45 @@ impl OpenOptionsExt for OpenOptions {
 
 /// Extension methods for `fs::Metadata` to access the raw fields contained
 /// within.
-#[unstable(feature = "metadata_ext", reason = "recently added API")]
+#[stable(feature = "metadata_ext", since = "1.1.0")]
 pub trait MetadataExt {
     /// Returns the value of the `dwFileAttributes` field of this metadata.
     ///
     /// This field contains the file system attribute information for a file
     /// or directory.
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
     fn file_attributes(&self) -> u32;
 
     /// Returns the value of the `ftCreationTime` field of this metadata.
     ///
     /// The returned 64-bit value represents the number of 100-nanosecond
     /// intervals since January 1, 1601 (UTC).
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
     fn creation_time(&self) -> u64;
 
     /// Returns the value of the `ftLastAccessTime` field of this metadata.
     ///
     /// The returned 64-bit value represents the number of 100-nanosecond
     /// intervals since January 1, 1601 (UTC).
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
     fn last_access_time(&self) -> u64;
 
     /// Returns the value of the `ftLastWriteTime` field of this metadata.
     ///
     /// The returned 64-bit value represents the number of 100-nanosecond
     /// intervals since January 1, 1601 (UTC).
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
     fn last_write_time(&self) -> u64;
 
     /// Returns the value of the `nFileSize{High,Low}` fields of this
     /// metadata.
     ///
     /// The returned value does not have meaning for directories.
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
     fn file_size(&self) -> u64;
 }
 
+#[stable(feature = "metadata_ext", since = "1.1.0")]
 impl MetadataExt for Metadata {
     fn file_attributes(&self) -> u32 { self.as_inner().attrs() }
     fn creation_time(&self) -> u64 { self.as_inner().created() }

--- a/src/libstd/sys/windows/ext/raw.rs
+++ b/src/libstd/sys/windows/ext/raw.rs
@@ -10,12 +10,12 @@
 
 //! Windows-specific primitives
 
-#![unstable(feature = "raw_ext", reason = "recently added API")]
+#[stable(feature = "raw_ext", since = "1.1.0")]
 
-use os::raw;
+use os::raw::c_void;
 
-pub type HANDLE = *mut raw::c_void;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type HANDLE = *mut c_void;
 #[cfg(target_pointer_width = "32")]
-pub type SOCKET = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type SOCKET = u32;
 #[cfg(target_pointer_width = "64")]
-pub type SOCKET = u64;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type SOCKET = u64;


### PR DESCRIPTION
This commit stabilizes the following APIs, slating them all to be cherry-picked
into the 1.1 release.
- fs::FileType (and transitively the derived trait implementations)
- fs::Metadata::file_type
- fs::FileType::is_dir
- fs::FileType::is_file
- fs::FileType::is_symlink
- fs::DirEntry::metadata
- fs::DirEntry::file_type
- fs::DirEntry::file_name
- fs::set_permissions
- fs::symlink_metadata
- os::raw::{self, *}
- os::{android, bitrig, linux, ...}::raw::{self, *}
- os::{android, bitrig, linux, ...}::fs::MetadataExt
- os::{android, bitrig, linux, ...}::fs::MetadataExt::as_raw_stat
- os::unix::fs::PermissionsExt
- os::unix::fs::PermissionsExt::mode
- os::unix::fs::PermissionsExt::set_mode
- os::unix::fs::PermissionsExt::from_mode
- os::unix::fs::OpenOptionsExt
- os::unix::fs::OpenOptionsExt::mode
- os::unix::fs::DirEntryExt
- os::unix::fs::DirEntryExt::ino
- os::windows::fs::MetadataExt
- os::windows::fs::MetadataExt::file_attributes
- os::windows::fs::MetadataExt::creation_time
- os::windows::fs::MetadataExt::last_access_time
- os::windows::fs::MetadataExt::last_write_time
- os::windows::fs::MetadataExt::file_size

The `os::unix::fs::Metadata` structure was also removed entirely, moving all of
its associated methods into the `os::unix::fs::MetadataExt` trait instead. The
methods are all marked as `#[stable]` still.

As some minor cleanup, some deprecated and unstable fs apis were also removed:
- File::path
- Metadata::accessed
- Metadata::modified

Features that were explicitly left unstable include:
- fs::WalkDir - the semantics of this were not considered in the recent fs
  expansion RFC.
- fs::DirBuilder - it's still not 100% clear if the naming is right here and if
  the set of functionality exposed is appropriate.
- fs::canonicalize - the implementation on Windows here is specifically in
  question as it always returns a verbatim path. Additionally the Unix
  implementation is susceptible to buffer overflows on long paths unfortunately.
- fs::PathExt - as this is just a convenience trait, it is not stabilized at
  this time.
- fs::set_file_times - this funciton is still waiting on a time abstraction.
