### PR TITLE
mk: Fix MSVC bootstrapping itself

### DIFF
--- a/mk/cfg/x86_64-pc-windows-msvc.mk
+++ b/mk/cfg/x86_64-pc-windows-msvc.mk
@@ -80,3 +80,8 @@ CUSTOM_DEPS_rustc_llvm_T_x86_64-pc-windows-msvc += \
 x86_64-pc-windows-msvc/rt/rustc_llvm.def: $(S)src/etc/mklldef.py \
 			$(S)src/librustc_llvm/lib.rs
 	$(CFG_PYTHON) $^ $@ rustc_llvm-$(CFG_FILENAME_EXTRA)
+
+# All windows nightiles are currently a GNU triple, so this MSVC triple is not
+# bootstrapping from itself. This is relevant during stage0, and other parts of
+# the build system take this into account.
+BOOTSTRAP_FROM_x86_64-pc-windows-msvc := x86_64-pc-windows-gnu


### PR DESCRIPTION
Now that MSVC support has landed in the most recent nightlies we can now have
MSVC bootstrap itself without going through a GNU compiler first. Unfortunately,
however, the bootstrap currently fails due to the compiler not being able to
find the llvm-ar.exe tool during the stage0 libcore compile. The compiler cannot
find this tool because it's looking inside a directory that does not exist:

```
$SYSROOT/rustlib/x86_64-pc-windows-gnu/bin
```

The `gnu` on this triple is because the bootstrap compiler's host architecture
is GNU. The build system, however, only arranges for the llvm-ar.exe tool to be
available in this location:

```
$SYSROOT/rustlib/x86_64-pc-windows-msvc/bin
```

To resolve this discrepancy, the build system has been modified to understand
triples that are bootstrapped from another triple, and in this case copy the
native tools to the right location.
