### PR TITLE
std: Add an option to disable ELF based TLS

### DIFF
--- a/configure
+++ b/configure
@@ -593,6 +593,7 @@ valopt musl-root "/usr/local" "MUSL root installation directory"
 opt_nosave manage-submodules 1 "let the build manage the git submodules"
 opt_nosave clang 0 "prefer clang to gcc for building the runtime"
 opt_nosave jemalloc 1 "build liballoc with jemalloc"
+opt elf-tls 1 "elf thread local storage on platforms where supported"
 
 valopt_nosave prefix "/usr/local" "set installation prefix"
 valopt_nosave local-rust-root "/usr/local" "set prefix for local rust binary"

--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -150,3 +150,7 @@ TOOL_INPUTS_$(1) := $$(call rwildcard,$$(dir $$(TOOL_SOURCE_$(1))),*.rs)
 endef
 
 $(foreach crate,$(TOOLS),$(eval $(call RUST_TOOL,$(crate))))
+
+ifdef CFG_DISABLE_ELF_TLS
+RUSTFLAGS_std := --cfg no_elf_tls
+endif

--- a/src/libstd/thread/scoped_tls.rs
+++ b/src/libstd/thread/scoped_tls.rs
@@ -60,9 +60,11 @@ pub struct ScopedKey<T> { inner: imp::KeyInner<T> }
 /// This macro declares a `static` item on which methods are used to get and
 /// set the value stored within.
 ///
-/// See [ScopedKey documentation](thread/struct.ScopedKey.html) for more information.
+/// See [ScopedKey documentation](thread/struct.ScopedKey.html) for more
+/// information.
 #[macro_export]
 #[allow_internal_unstable]
+#[cfg(not(no_elf_tls))]
 macro_rules! scoped_thread_local {
     (static $name:ident: $t:ty) => (
         #[cfg_attr(not(any(windows,
@@ -81,6 +83,20 @@ macro_rules! scoped_thread_local {
                            target_os = "openbsd",
                            target_arch = "aarch64")),
                    thread_local)]
+        pub static $name: ::std::thread::ScopedKey<$t> =
+            ::std::thread::ScopedKey::new();
+    );
+}
+
+#[macro_export]
+#[allow_internal_unstable]
+#[cfg(no_elf_tls)]
+macro_rules! scoped_thread_local {
+    (static $name:ident: $t:ty) => (
+        static $name: ::std::thread::ScopedKey<$t> =
+            ::std::thread::ScopedKey::new();
+    );
+    (pub static $name:ident: $t:ty) => (
         pub static $name: ::std::thread::ScopedKey<$t> =
             ::std::thread::ScopedKey::new();
     );
@@ -187,7 +203,8 @@ impl<T> ScopedKey<T> {
               target_os = "android",
               target_os = "ios",
               target_os = "openbsd",
-              target_arch = "aarch64")))]
+              target_arch = "aarch64",
+              no_elf_tls)))]
 mod imp {
     use std::cell::Cell;
 
@@ -208,7 +225,8 @@ mod imp {
           target_os = "android",
           target_os = "ios",
           target_os = "openbsd",
-          target_arch = "aarch64"))]
+          target_arch = "aarch64",
+          no_elf_tls))]
 mod imp {
     use prelude::v1::*;
 


### PR DESCRIPTION
This commit adds a ./configure option called `--disable-elf-tls` which disables
ELF based TLS (that which is communicated to LLVM) on platforms which already
support it. OSX 10.6 does not support this form of TLS, and some users of Rust
need to target 10.6 and are unable to do so due to the usage of TLS. The
standard library will continue to use ELF based TLS on OSX by default (as the
officially supported platform is 10.7+), but this adds an option to compile the
standard library in a way that is compatible with 10.6.

Closes #25342
