### PR TITLE
Update style guide with latest commits from rust-guidelines

### DIFF
--- a/src/doc/style/features/functions-and-methods/README.md
+++ b/src/doc/style/features/functions-and-methods/README.md
@@ -20,6 +20,7 @@ for any operation that is clearly associated with a particular
 type.
 
 Methods have numerous advantages over functions:
+
 * They do not need to be imported or qualified to be used: all you
   need is a value of the appropriate type.
 * Their invocation performs autoborrowing (including mutable borrows).

--- a/src/doc/style/features/functions-and-methods/input.md
+++ b/src/doc/style/features/functions-and-methods/input.md
@@ -159,7 +159,7 @@ fn foo(a: u8) { ... }
 Note that
 [`ascii::Ascii`](http://static.rust-lang.org/doc/master/std/ascii/struct.Ascii.html)
 is a _wrapper_ around `u8` that guarantees the highest bit is zero; see
-[newtype patterns]() for more details on creating typesafe wrappers.
+[newtype patterns](../types/newtype.md) for more details on creating typesafe wrappers.
 
 Static enforcement usually comes at little run-time cost: it pushes the
 costs to the boundaries (e.g. when a `u8` is first converted into an

--- a/src/doc/style/features/let.md
+++ b/src/doc/style/features/let.md
@@ -44,7 +44,7 @@ over
 ```rust
 let foo;
 match bar {
-    Baz  => {
+    Baz => {
         foo = 0;
     }
     Quux => {

--- a/src/doc/style/features/let.md
+++ b/src/doc/style/features/let.md
@@ -61,8 +61,8 @@ conditional expression.
 Prefer
 
 ```rust
-s.iter().map(|x| x * 2)
-        .collect::<Vec<_>>()
+let v = s.iter().map(|x| x * 2)
+                .collect::<Vec<_>>();
 ```
 
 over

--- a/src/doc/style/features/let.md
+++ b/src/doc/style/features/let.md
@@ -34,7 +34,7 @@ Prefer
 
 ```rust
 let foo = match bar {
-    Baz  => 0,
+    Baz => 0,
     Quux => 1
 };
 ```

--- a/src/doc/style/ownership/builders.md
+++ b/src/doc/style/ownership/builders.md
@@ -16,7 +16,7 @@ If `T` is such a data structure, consider introducing a `T` _builder_:
    value. When possible, choose a better name: e.g. `Command` is the builder for
    `Process`.
 2. The builder constructor should take as parameters only the data _required_ to
-   to make a `T`.
+   make a `T`.
 3. The builder should offer a suite of convenient methods for configuration,
    including setting up compound inputs (like slices) incrementally.
    These methods should return `self` to allow chaining.


### PR DESCRIPTION
So that rust-guidelines can be deleted and src/doc/style can prosper as the official home of the rust guidelines. :smiley: 
