### PR TITLE
Deprecate UnsafeCell::value

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -641,6 +641,8 @@ pub struct UnsafeCell<T: ?Sized> {
     ///
     /// This field should not be accessed directly, it is made public for static
     /// initializers.
+    #[deprecated(since = "1.2.0", reason = "use `get` to access the wrapped \
+        value or `new` to initialize `UnsafeCell` in statics")]
     #[unstable(feature = "core")]
     pub value: T,
 }
@@ -664,6 +666,7 @@ impl<T> UnsafeCell<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub const fn new(value: T) -> UnsafeCell<T> {
+        #![allow(deprecated)]
         UnsafeCell { value: value }
     }
 
@@ -685,7 +688,10 @@ impl<T> UnsafeCell<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub unsafe fn into_inner(self) -> T { self.value }
+    pub unsafe fn into_inner(self) -> T {
+        #![allow(deprecated)]
+        self.value
+    }
 }
 
 impl<T: ?Sized> UnsafeCell<T> {
@@ -705,6 +711,7 @@ impl<T: ?Sized> UnsafeCell<T> {
     pub fn get(&self) -> *mut T {
         // FIXME(#23542) Replace with type ascription.
         #![allow(trivial_casts)]
+        #![allow(deprecated)]
         &self.value as *const T as *mut T
     }
 }


### PR DESCRIPTION
Now when const functions are implemented and used, the `value` field of `UnsafeCell` can be made deprecated (and then private as intended).
