### PR TITLE
thread: Add Sync bound to ScopedKey (fixes #25894)

### DIFF
--- a/src/libstd/thread/scoped_tls.rs
+++ b/src/libstd/thread/scoped_tls.rs
@@ -193,7 +193,7 @@ mod imp {
 
     pub struct KeyInner<T> { inner: Cell<*mut T> }
 
-    unsafe impl<T> ::marker::Sync for KeyInner<T> { }
+    unsafe impl<T: ::marker::Sync> ::marker::Sync for KeyInner<T> { }
 
     impl<T> KeyInner<T> {
         pub const fn new() -> KeyInner<T> {
@@ -221,7 +221,7 @@ mod imp {
         pub marker: marker::PhantomData<Cell<T>>,
     }
 
-    unsafe impl<T> marker::Sync for KeyInner<T> { }
+    unsafe impl<T: marker::Sync> marker::Sync for KeyInner<T> { }
 
     impl<T> KeyInner<T> {
         pub const fn new() -> KeyInner<T> {


### PR DESCRIPTION
I have no clue what I'm doing. Someone should verify that this is
the necessary/sufficient fix to #25894 before merging :stuck_out_tongue:
