### PR TITLE
Rustdoc: Explain the copy trait more clearly (doc book)

### DIFF
--- a/src/doc/trpl/ownership.md
+++ b/src/doc/trpl/ownership.md
@@ -157,7 +157,7 @@ But, unlike a move, we can still use `v` afterward. This is because an `i32`
 has no pointers to data somewhere else, copying it is a full copy.
 
 All primitive types implement the `Copy` trait and their ownership is
-therefore not moved like one would assume, following the **ownership rules**.
+therefore not moved like one would assume, following the ´ownership rules´.
 To give an example, the two following snippets of code only compile because the 
 `i32` and `bool` types implement the `Copy` trait. 
 
@@ -195,9 +195,6 @@ error: use of moved value: `a`
 println!("{}", a);
                ^
 ```
-
-This is quite important to understand, because it is an exception to the most 
-fundamental rule in the Rust language.
 
 We will discuss how to make your own types `Copy` in the [traits][traits]
 section.

--- a/src/doc/trpl/ownership.md
+++ b/src/doc/trpl/ownership.md
@@ -156,6 +156,49 @@ that, just like a move, when we assign `v` to `v2`, a copy of the data is made.
 But, unlike a move, we can still use `v` afterward. This is because an `i32`
 has no pointers to data somewhere else, copying it is a full copy.
 
+All primitive types implement the `Copy` trait and their ownership is
+therefore not moved like one would assume, following the **ownership rules**.
+To give an example, the two following snippets of code only compile because the 
+`i32` and `bool` types implement the `Copy` trait. 
+
+```rust
+fn main() {
+    let a = 5;
+
+    let _y = double(a);
+    println!("{}", a);
+}
+
+fn double(x: i32) -> i32 {
+    x * 2
+}
+```
+
+```rust
+fn main() {
+    let a = true;
+
+    let _y = change_truth(a);
+    println!("{}", a);
+}
+
+fn change_truth(x: bool) -> bool {
+    !x
+}
+```
+
+If we would have used types that do not implement the `Copy` trait,
+we would have gotten a compile error because we tried to use a moved value.
+
+```text
+error: use of moved value: `a`
+println!("{}", a);
+               ^
+```
+
+This is quite important to understand, because it is an exception to the most 
+fundamental rule in the Rust language.
+
 We will discuss how to make your own types `Copy` in the [traits][traits]
 section.
 


### PR DESCRIPTION
As mentioned in #25893 the copy trait is not very well explained for beginners. There is no clear mention that all primitive types implement the copy trait and there are not a lot of examples. 

With this change I try to make it more visible and understandable for new users. 

I myself have struggled with this, see [my question on stackoverflow](http://stackoverflow.com/questions/30540419/why-are-booleans-copyable-even-though-the-documentation-doesnt-indicate-that). And I want to make it more transparent for others. 

I filed issue #25893 but I thought that I could give it a shot myself to relieve some of the work from the devs :)

If it is not well written or there are some changes to be made before it can be merged, let me know.

Cheers,
Mathieu
