### PR TITLE
Fixes consistency in before/after example

### DIFF
--- a/src/doc/trpl/error-handling.md
+++ b/src/doc/trpl/error-handling.md
@@ -284,7 +284,7 @@ struct Info {
 }
 
 fn write_info(info: &Info) -> io::Result<()> {
-    let mut file = try!(File::create("my_best_friends.txt"));
+    let mut file = File::create("my_best_friends.txt").unwrap();
 
     try!(writeln!(&mut file, "name: {}", info.name));
     try!(writeln!(&mut file, "age: {}", info.age));


### PR DESCRIPTION
The doc indicates that you can replace 'before' with 'after' showing the use of try!. The two examples should be equivalent, but they are not.

In the File::create we were inducing a panic before in case of error, not propagating. It is important for newbies (like myself) to understand that try! propagates failures, while unwrap can induce a panic.

The other alternative is to make the 'before' File::create also manually handle Err like the other calls. Either way it would be consistent.
