### PR TITLE
Remove duplicate "don't" in configure options

### DIFF
--- a/configure
+++ b/configure
@@ -565,7 +565,7 @@ opt rpath 0 "build rpaths into rustc itself"
 # This is used by the automation to produce single-target nightlies
 opt dist-host-only 0 "only install bins for the host architecture"
 opt inject-std-version 1 "inject the current compiler version of libstd into programs"
-opt llvm-version-check 1 "don't check if the LLVM version is supported, build anyway"
+opt llvm-version-check 1 "check if the LLVM version is supported, build anyway"
 
 # Optimization and debugging options. These may be overridden by the release channel, etc.
 opt_nosave optimize 1 "build optimized rust code"


### PR DESCRIPTION
Previous:

```
    --disable-llvm-version-check     don't don't check if the LLVM version is supported, build anyway
```

New:

```
    --disable-llvm-version-check     don't check if the LLVM version is supported, build anyway
```
