### PR TITLE
Rustdoc: Add loopcounter (enumerate) section to the for-loop chapter

### DIFF
--- a/src/doc/trpl/for-loops.md
+++ b/src/doc/trpl/for-loops.md
@@ -42,35 +42,41 @@ Rust does not have the “C-style” `for` loop on purpose. Manually controlling
 each element of the loop is complicated and error prone, even for experienced C
 developers.
 
-# Loopcounter
+# Enumerate
 
 When you need to keep track of how many times you already looped, you can use the `.enumerate()` function.
 
-#### On ranges:
+## On ranges:
 
 ```rust
 for (i,j) in (5..10).enumerate() {
     println!("i = {} and j = {}", i, j);
 }
 ```
+
 Outputs:
-```
+
+```rust
 i = 0 and j = 5
 i = 1 and j = 6
 i = 2 and j = 7
 i = 3 and j = 8
 i = 4 and j = 9
 ```
+
 Don't forget to add the parentheses around the range.
 
-#### On iterators: 
+## On iterators:
+
 ```rust
 for (linenumber, line) in lines.enumerate() {
     println!("{}: {}", linenumber, line);
 }
 ```
+
 Outputs:
-```
+
+```rust
 0: Content of line one
 1: Content of line two
 2: Content of line tree

--- a/src/doc/trpl/for-loops.md
+++ b/src/doc/trpl/for-loops.md
@@ -69,6 +69,7 @@ Don't forget to add the parentheses around the range.
 ## On iterators:
 
 ```rust
+# let lines = "hello\nworld".lines();
 for (linenumber, line) in lines.enumerate() {
     println!("{}: {}", linenumber, line);
 }

--- a/src/doc/trpl/for-loops.md
+++ b/src/doc/trpl/for-loops.md
@@ -41,3 +41,38 @@ so our loop will print `0` through `9`, not `10`.
 Rust does not have the “C-style” `for` loop on purpose. Manually controlling
 each element of the loop is complicated and error prone, even for experienced C
 developers.
+
+# Loopcounter
+
+When you need to keep track of how many times you already looped, you can use the `.enumerate()` function.
+
+#### On ranges:
+
+```rust
+for (i,j) in (5..10).enumerate() {
+    println!("i = {} and j = {}", i, j);
+}
+```
+Outputs:
+```
+i = 0 and j = 5
+i = 1 and j = 6
+i = 2 and j = 7
+i = 3 and j = 8
+i = 4 and j = 9
+```
+Don't forget to add the parentheses around the range.
+
+#### On iterators: 
+```rust
+for (linenumber, line) in lines.enumerate() {
+    println!("{}: {}", linenumber, line);
+}
+```
+Outputs:
+```
+0: Content of line one
+1: Content of line two
+2: Content of line tree
+3: Content of line four
+```

--- a/src/doc/trpl/for-loops.md
+++ b/src/doc/trpl/for-loops.md
@@ -56,7 +56,7 @@ for (i,j) in (5..10).enumerate() {
 
 Outputs:
 
-```rust
+```text
 i = 0 and j = 5
 i = 1 and j = 6
 i = 2 and j = 7
@@ -76,7 +76,7 @@ for (linenumber, line) in lines.enumerate() {
 
 Outputs:
 
-```rust
+```text
 0: Content of line one
 1: Content of line two
 2: Content of line tree


### PR DESCRIPTION
Hi

I added a little section in the for loops about the `enumerate()` function.
I think it's useful for beginners to know this function and how you can use it. 

I used the title loopcounter, but it's probably not the best word to describe it. So let me know if there is a better word :)
