### PR TITLE
rustdoc: Tweak css of function where clauses

### DIFF
--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -338,10 +338,10 @@ nav.sub {
     font-size: 1em;
     position: relative;
 }
-/* Shift "where ..." part of method definition down a line */
-.content .method .where { display: block; }
+/* Shift "where ..." part of method or fn definition down a line */
+.content .method .where, .content .fn .where { display: block; }
 /* Bit of whitespace to indent it */
-.content .method .where::before { content: '  '; }
+.content .method .where::before, .content .fn .where::before { content: '  '; }
 
 .content .methods > div { margin-left: 40px; }
 


### PR DESCRIPTION
rustdoc: Tweak css of function where clauses

Method where clauses are put indented on a new line, do the same tweak
to free functions, which makes it cleaner and easier to read.
