### PR TITLE
[libcollections] Fix unused import warnings during stage0 build

### DIFF
--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -37,12 +37,11 @@
 #![feature(unsafe_no_drop_flag, filling_drop)]
 #![feature(step_by)]
 #![feature(str_char)]
-#![feature(str_words)]
 #![feature(slice_patterns)]
 #![feature(utf8_error)]
-#![cfg_attr(test, feature(rand, rustc_private, test, hash, collections,
-                          collections_drain, collections_range))]
+#![cfg_attr(test, feature(rand, test))]
 #![cfg_attr(test, allow(deprecated))] // rand
+#![cfg_attr(not(test), feature(str_words))]
 
 #![feature(no_std)]
 #![no_std]

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -79,6 +79,10 @@
 #![doc(primitive = "slice")]
 #![stable(feature = "rust1", since = "1.0.0")]
 
+// Many of the usings in this module are only used in the test configuration.
+// It's cleaner to just turn off the unused_imports warning than to fix them.
+#![allow(unused_imports)]
+
 use alloc::boxed::Box;
 use core::clone::Clone;
 use core::cmp::Ordering::{self, Greater, Less};

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -47,6 +47,10 @@
 #![doc(primitive = "str")]
 #![stable(feature = "rust1", since = "1.0.0")]
 
+// Many of the usings in this module are only used in the test configuration.
+// It's cleaner to just turn off the unused_imports warning than to fix them.
+#![allow(unused_imports)]
+
 use self::RecompositionState::*;
 use self::DecompositionType::*;
 

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -1801,7 +1801,7 @@ impl<T: fmt::Debug> fmt::Debug for VecDeque<T> {
 
 #[cfg(test)]
 mod tests {
-    use core::iter::{Iterator, self};
+    use core::iter::Iterator;
     use core::option::Option::Some;
 
     use test;


### PR DESCRIPTION
Fixes a bunch of warnings that are generated during the stage0 build of libcollections.
