### PR TITLE
Fix freebsd configure

### DIFF
--- a/configure
+++ b/configure
@@ -848,13 +848,6 @@ then
     putvar CFG_LOCAL_RUST_ROOT
 fi
 
-# Force freebsd to build with clang; gcc doesn't like us there
-if [ $CFG_OSTYPE = unknown-freebsd ]
-then
-    step_msg "on FreeBSD, forcing use of clang"
-    CFG_ENABLE_CLANG=1
-fi
-
 # Force bitrig to build with clang; gcc doesn't like us there
 if [ $CFG_OSTYPE = unknown-bitrig ]
 then

--- a/src/librustc_back/target/freebsd_base.rs
+++ b/src/librustc_back/target/freebsd_base.rs
@@ -18,11 +18,6 @@ pub fn opts() -> TargetOptions {
         executables: true,
         morestack: true,
         has_rpath: true,
-        pre_link_args: vec!(
-            "-L/usr/local/lib".to_string(),
-            "-L/usr/local/lib/gcc46".to_string(),
-            "-L/usr/local/lib/gcc44".to_string(),
-        ),
 
         .. Default::default()
     }


### PR DESCRIPTION
Bug fixes for configure on FreeBSD:
- Don't ban using gcc; newer versions can be installed and other checks should enforce its suitability.
- Don't force Rust to link itself with /usr/local/lib{,gcc4[46]}, which causes builds to fail if Rust is already installed.  I've not been able to find an use case where this is actually necessary.
