### PR TITLE
Remove broken links from Rust book example

### DIFF
--- a/src/doc/trpl/dining-philosophers.md
+++ b/src/doc/trpl/dining-philosophers.md
@@ -70,8 +70,8 @@ fn main() {
 }
 ```
 
-Here, we make a [`struct`][struct] to represent a philosopher. For now,
-a name is all we need. We choose the [`String`][string] type for the name,
+Here, we make a `struct` to represent a philosopher. For now,
+a name is all we need. We choose the `String` type for the name,
 rather than `&str`. Generally speaking, working with a type which owns its
 data is easier than working with one that uses references.
 


### PR DESCRIPTION
This fixes some broken links that are not being properly turned into HTML links, and are instead being inserted into the final page verbatim. I'm not sure what changes can/should be made to alleviate this problem in the long term, and figure that simply removing the broken links for now is the quickest solution.

Here is what it currently looks like: https://www.dropbox.com/s/cjn120ur6m1dfgk/Screenshot%202015-06-01%2012.55.30.png?dl=0
