### PR TITLE
Stop passing the old ndebug/debug cfg directives

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -130,9 +130,7 @@ CFG_JEMALLOC_FLAGS += $(JEMALLOC_FLAGS)
 
 ifdef CFG_ENABLE_DEBUG_ASSERTIONS
   $(info cfg: enabling debug assertions (CFG_ENABLE_DEBUG_ASSERTIONS))
-  CFG_RUSTC_FLAGS += --cfg debug -C debug-assertions=on
-else
-  CFG_RUSTC_FLAGS += --cfg ndebug
+  CFG_RUSTC_FLAGS += -C debug-assertions=on
 endif
 
 ifdef CFG_ENABLE_DEBUGINFO


### PR DESCRIPTION
As of rust-lang/rust#22980 only `cfg(debug_assertions)` is used in the
standard library and rustc code.
