### PR TITLE
Document behavior of {f32,f64}::{min,max} on NaN

### DIFF
--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -660,6 +660,8 @@ impl f32 {
     ///
     /// assert_eq!(x.max(y), y);
     /// ```
+    ///
+    /// If one of the arguments is NaN, then the other argument is returned.
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn max(self, other: f32) -> f32 {
@@ -674,6 +676,8 @@ impl f32 {
     ///
     /// assert_eq!(x.min(y), x);
     /// ```
+    ///
+    /// If one of the arguments is NaN, then the other argument is returned.
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn min(self, other: f32) -> f32 {

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -636,6 +636,8 @@ impl f64 {
     ///
     /// assert_eq!(x.max(y), y);
     /// ```
+    ///
+    /// If one of the arguments is NaN, then the other argument is returned.
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn max(self, other: f64) -> f64 {
@@ -650,6 +652,8 @@ impl f64 {
     ///
     /// assert_eq!(x.min(y), x);
     /// ```
+    ///
+    /// If one of the arguments is NaN, then the other argument is returned.
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn min(self, other: f64) -> f64 {


### PR DESCRIPTION
This is based on the documented behavior of cmath::{fmin,fmax}.  It is also tested by existing unit tests in this module.
