### PR TITLE
std: Fix unsoundness of std::thread::ScopedKey

### DIFF
--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -217,6 +217,7 @@ pub use self::local::{LocalKey, LocalKeyState};
 pub use self::scoped_tls::ScopedKey;
 
 #[doc(hidden)] pub use self::local::__KeyInner as __LocalKeyInner;
+#[doc(hidden)] pub use self::scoped_tls::__KeyInner as __ScopedKeyInner;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Builder


### PR DESCRIPTION
Currently the compiler has no knowledge of `#[thread_local]` which forces users
to take on two burdens of unsafety:
- The lifetime of the borrow of a `#[thread_local]` static is **not** `'static`
- Types in `static`s are required to be `Sync`

The thread-local modules mostly curb these facets of unsafety by only allowing
very limited scopes of borrows as well as allowing all types to be stored in a
thread-local key (regardless of whether they are `Sync`) through an `unsafe
impl`.

Unfortunately these measures have the consequence of being able to take the
address of the key itself and send it to another thread, allowing the same key
to be accessed from two different threads. This is clearly unsafe, and this
commit fixes this problem with the same trick used by `LocalKey`, which is to
have an indirect function call to find the address of the _current thread's_
thread local. This way the address of thread local keys can safely be sent among
threads as their lifetime truly is `'static`.

This commit will reduce the performance of cross-crate scoped thread locals as
it now requires an indirect function call, but this can likely be overcome in a
future commit.

Closes #25894
