### PR TITLE
Fix compiler docs makefile flag

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -265,7 +265,7 @@ endef
 $(foreach crate,$(CRATES),$(eval $(call DEF_LIB_DOC,$(crate))))
 
 COMPILER_DOC_TARGETS := $(CRATES:%=doc/%/index.html)
-ifdef CFG_COMPILER_DOCS
+ifdef CFG_ENABLE_COMPILER_DOCS
   DOC_TARGETS += $(COMPILER_DOC_TARGETS)
 else
   DOC_TARGETS += $(DOC_CRATES:%=doc/%/index.html)


### PR DESCRIPTION
`./configure --enable-compiler-docs` doesn't work without this

r? @steveklabnik
