### PR TITLE
crate libc: Correct signature of `WriteFile`

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -6308,8 +6308,8 @@ pub mod funcs {
                                 lpOverlapped: LPOVERLAPPED) -> BOOL;
                 pub fn WriteFile(hFile: HANDLE,
                                  lpBuffer: LPVOID,
-                                 nNumberOfBytesToRead: DWORD,
-                                 lpNumberOfBytesRead: LPDWORD,
+                                 nNumberOfBytesToWrite: DWORD,
+                                 lpNumberOfBytesWritten: LPDWORD,
                                  lpOverlapped: LPOVERLAPPED) -> BOOL;
                 pub fn SetFilePointerEx(hFile: HANDLE,
                                         liDistanceToMove: LARGE_INTEGER,


### PR DESCRIPTION
nNumberOfBytesToRead --> nNumberOfBytesToWrite
lpNumberOfBytesRead --> lpNumberOfBytesWritten
LPVOID --> LPCVOID

See https://msdn.microsoft.com/en-us/library/windows/desktop/aa365747(v=vs.85).aspx
