### PR TITLE
Fix the dropck doc formatting to avoid hitting four-space indent.

### DIFF
--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -238,14 +238,12 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'tcx>(
 /// Let `v` be some value (either temporary or named) and 'a be some
 /// lifetime (scope). If the type of `v` owns data of type `D`, where
 ///
-///   (1.) `D` has a lifetime- or type-parametric Drop implementation, and
-///   (2.) the structure of `D` can reach a reference of type `&'a _`, and
-///   (3.) either:
-///
-///     (A.) the Drop impl for `D` instantiates `D` at 'a directly,
+/// * (1.) `D` has a lifetime- or type-parametric Drop implementation, and
+/// * (2.) the structure of `D` can reach a reference of type `&'a _`, and
+/// * (3.) either:
+///   * (A.) the Drop impl for `D` instantiates `D` at 'a directly,
 ///          i.e. `D<'a>`, or,
-///
-///     (B.) the Drop impl for `D` has some type parameter with a
+///   * (B.) the Drop impl for `D` has some type parameter with a
 ///          trait bound `T` where `T` is a trait that has at least
 ///          one method,
 ///


### PR DESCRIPTION
Fix the dropck doc formatting to avoid hitting four-space indent.

This was causing `rustdoc` to interpret the part starting with `(A.) ...` as a code block based on its four-space indentation, which then was treated by `rustdoc` as a _Rust_ code snippet, and thus was attempting (and failing) to parse my english as Rust code. Thus causing the compiler-docs build to fail.

Independently, we should probably change `rustdoc` to not interpret four-space indents as code that needs to be tested; it seems too perilous to me at least.

(But the formatting here needed to be changed either way.)

cc Issue #25699.
