### PR TITLE
Implement RFC 839

### DIFF
--- a/src/libcollections/binary_heap.rs
+++ b/src/libcollections/binary_heap.rs
@@ -760,3 +760,10 @@ impl<T: Ord> Extend<T> for BinaryHeap<T> {
         }
     }
 }
+
+#[stable(feature = "extend_ref", since = "1.2.0")]
+impl<'a, T: 'a + Ord + Copy> Extend<&'a T> for BinaryHeap<T> {
+    fn extend<I: IntoIterator<Item=&'a T>>(&mut self, iter: I) {
+        self.extend(iter.into_iter().cloned());
+    }
+}

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -1070,6 +1070,13 @@ impl Extend<bool> for BitVec {
     }
 }
 
+#[stable(feature = "extend_ref", since = "1.2.0")]
+impl<'a> Extend<&'a bool> for BitVec {
+    fn extend<I: IntoIterator<Item=&'a bool>>(&mut self, iter: I) {
+        self.extend(iter.into_iter().cloned());
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Clone for BitVec {
     #[inline]
@@ -1275,6 +1282,13 @@ impl Extend<usize> for BitSet {
         for i in iter {
             self.insert(i);
         }
+    }
+}
+
+#[stable(feature = "extend_ref", since = "1.2.0")]
+impl<'a> Extend<&'a usize> for BitSet {
+    fn extend<I: IntoIterator<Item=&'a usize>>(&mut self, iter: I) {
+        self.extend(iter.into_iter().cloned());
     }
 }
 

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -879,6 +879,13 @@ impl<K: Ord, V> Extend<(K, V)> for BTreeMap<K, V> {
     }
 }
 
+#[stable(feature = "extend_ref", since = "1.2.0")]
+impl<'a, K: Ord + Copy, V: Copy> Extend<(&'a K, &'a V)> for BTreeMap<K, V> {
+    fn extend<I: IntoIterator<Item=(&'a K, &'a V)>>(&mut self, iter: I) {
+        self.extend(iter.into_iter().map(|(&key, &value)| (key, value)));
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<K: Hash, V: Hash> Hash for BTreeMap<K, V> {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -509,6 +509,13 @@ impl<T: Ord> Extend<T> for BTreeSet<T> {
     }
 }
 
+#[stable(feature = "extend_ref", since = "1.2.0")]
+impl<'a, T: 'a + Ord + Copy> Extend<&'a T> for BTreeSet<T> {
+    fn extend<I: IntoIterator<Item=&'a T>>(&mut self, iter: I) {
+        self.extend(iter.into_iter().cloned());
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Ord> Default for BTreeSet<T> {
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcollections/enum_set.rs
+++ b/src/libcollections/enum_set.rs
@@ -288,3 +288,10 @@ impl<E:CLike> Extend<E> for EnumSet<E> {
         }
     }
 }
+
+#[stable(feature = "extend_ref", since = "1.2.0")]
+impl<'a, E: 'a + CLike + Copy> Extend<&'a E> for EnumSet<E> {
+    fn extend<I: IntoIterator<Item=&'a E>>(&mut self, iter: I) {
+        self.extend(iter.into_iter().cloned());
+    }
+}

--- a/src/libcollections/linked_list.rs
+++ b/src/libcollections/linked_list.rs
@@ -871,6 +871,13 @@ impl<A> Extend<A> for LinkedList<A> {
     }
 }
 
+#[stable(feature = "extend_ref", since = "1.2.0")]
+impl<'a, T: 'a + Copy> Extend<&'a T> for LinkedList<T> {
+    fn extend<I: IntoIterator<Item=&'a T>>(&mut self, iter: I) {
+        self.extend(iter.into_iter().cloned());
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A: PartialEq> PartialEq for LinkedList<A> {
     fn eq(&self, other: &LinkedList<A>) -> bool {

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -793,6 +793,13 @@ impl Extend<char> for String {
     }
 }
 
+#[stable(feature = "extend_ref", since = "1.2.0")]
+impl<'a> Extend<&'a char> for String {
+    fn extend<I: IntoIterator<Item=&'a char>>(&mut self, iter: I) {
+        self.extend(iter.into_iter().cloned());
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Extend<&'a str> for String {
     fn extend<I: IntoIterator<Item=&'a str>>(&mut self, iterable: I) {

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1578,6 +1578,13 @@ impl<T> Extend<T> for Vec<T> {
     }
 }
 
+#[stable(feature = "extend_ref", since = "1.2.0")]
+impl<'a, T: 'a + Copy> Extend<&'a T> for Vec<T> {
+    fn extend<I: IntoIterator<Item=&'a T>>(&mut self, iter: I) {
+        self.extend(iter.into_iter().cloned());
+    }
+}
+
 __impl_slice_eq1! { Vec<A>, Vec<B> }
 __impl_slice_eq1! { Vec<A>, &'b [B] }
 __impl_slice_eq1! { Vec<A>, &'b mut [B] }

--- a/src/libcollections/vec_deque.rs
+++ b/src/libcollections/vec_deque.rs
@@ -1785,6 +1785,13 @@ impl<A> Extend<A> for VecDeque<A> {
     }
 }
 
+#[stable(feature = "extend_ref", since = "1.2.0")]
+impl<'a, T: 'a + Copy> Extend<&'a T> for VecDeque<T> {
+    fn extend<I: IntoIterator<Item=&'a T>>(&mut self, iter: I) {
+        self.extend(iter.into_iter().cloned());
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: fmt::Debug> fmt::Debug for VecDeque<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -828,6 +828,13 @@ impl<V> Extend<(usize, V)> for VecMap<V> {
     }
 }
 
+#[stable(feature = "extend_ref", since = "1.2.0")]
+impl<'a, V: Copy> Extend<(usize, &'a V)> for VecMap<V> {
+    fn extend<I: IntoIterator<Item=(usize, &'a V)>>(&mut self, iter: I) {
+        self.extend(iter.into_iter().map(|(key, &value)| (key, value)));
+    }
+}
+
 impl<V> Index<usize> for VecMap<V> {
     type Output = V;
 

--- a/src/libcollectionstest/binary_heap.rs
+++ b/src/libcollectionstest/binary_heap.rs
@@ -217,3 +217,28 @@ fn test_drain() {
 
     assert!(q.is_empty());
 }
+
+#[test]
+fn test_extend_ref() {
+    let mut a = BinaryHeap::new();
+    a.push(1);
+    a.push(2);
+
+    a.extend(&[3, 4, 5]);
+
+    assert_eq!(a.len(), 5);
+    assert_eq!(a.into_sorted_vec(), [1, 2, 3, 4, 5]);
+
+    let mut a = BinaryHeap::new();
+    a.push(1);
+    a.push(2);
+    let mut b = BinaryHeap::new();
+    b.push(3);
+    b.push(4);
+    b.push(5);
+
+    a.extend(&b);
+
+    assert_eq!(a.len(), 5);
+    assert_eq!(a.into_sorted_vec(), [1, 2, 3, 4, 5]);
+}

--- a/src/libcollectionstest/bit/set.rs
+++ b/src/libcollectionstest/bit/set.rs
@@ -448,6 +448,26 @@ fn test_bit_set_split_off() {
                                                             0b00101011, 0b10101101])));
 }
 
+#[test]
+fn test_bit_set_extend_ref() {
+    let mut a = BitSet::new();
+    a.insert(3);
+
+    a.extend(&[5, 7, 10]);
+
+    assert_eq!(a.len(), 4);
+    assert_eq!(a, BitSet::from_bit_vec(BitVec::from_bytes(&[0b00010101,0b00100000])));
+
+    let mut b = BitSet::new();
+    b.insert(11);
+    b.insert(15);
+
+    a.extend(&b);
+
+    assert_eq!(a.len(), 6);
+    assert_eq!(a, BitSet::from_bit_vec(BitVec::from_bytes(&[0b00010101,0b00110001])));
+}
+
 mod bench {
     use std::collections::{BitSet, BitVec};
     use std::__rand::{Rng, thread_rng, ThreadRng};

--- a/src/libcollectionstest/bit/vec.rs
+++ b/src/libcollectionstest/bit/vec.rs
@@ -631,6 +631,24 @@ fn test_bit_vec_extend() {
 }
 
 #[test]
+fn test_bit_vecextend_ref() {
+    let mut bv = BitVec::from_bytes(&[0b10100011]);
+    bv.extend(&[true, false, true]);
+
+    assert_eq!(bv.len(), 11);
+    assert!(bv.eq_vec(&[true, false, true, false, false, false, true, true,
+                        true, false, true]));
+
+    let bw = BitVec::from_bytes(&[0b00010001]);
+    bv.extend(&bw);
+
+    assert_eq!(bv.len(), 19);
+    assert!(bv.eq_vec(&[true, false, true, false, false, false, true, true,
+                        true, false, true, false, false, false, true, false,
+                        false, false, true]));
+}
+
+#[test]
 fn test_bit_vec_append() {
     // Append to BitVec that holds a multiple of u32::BITS bits
     let mut a = BitVec::from_bytes(&[0b10100000, 0b00010010, 0b10010010, 0b00110011]);

--- a/src/libcollectionstest/btree/map.rs
+++ b/src/libcollectionstest/btree/map.rs
@@ -249,6 +249,22 @@ fn test_entry(){
     assert_eq!(map.len(), 6);
 }
 
+#[test]
+fn test_extend_ref() {
+    let mut a = BTreeMap::new();
+    a.insert(1, "one");
+    let mut b = BTreeMap::new();
+    b.insert(2, "two");
+    b.insert(3, "three");
+
+    a.extend(&b);
+
+    assert_eq!(a.len(), 3);
+    assert_eq!(a[&1], "one");
+    assert_eq!(a[&2], "two");
+    assert_eq!(a[&3], "three");
+}
+
 mod bench {
     use std::collections::BTreeMap;
     use std::__rand::{Rng, thread_rng};

--- a/src/libcollectionstest/btree/set.rs
+++ b/src/libcollectionstest/btree/set.rs
@@ -184,3 +184,31 @@ fn test_show() {
     assert_eq!(set_str, "{1, 2}");
     assert_eq!(format!("{:?}", empty), "{}");
 }
+
+#[test]
+fn test_extend_ref() {
+    let mut a = BTreeSet::new();
+    a.insert(1);
+
+    a.extend(&[2, 3, 4]);
+
+    assert_eq!(a.len(), 4);
+    assert!(a.contains(&1));
+    assert!(a.contains(&2));
+    assert!(a.contains(&3));
+    assert!(a.contains(&4));
+
+    let mut b = BTreeSet::new();
+    b.insert(5);
+    b.insert(6);
+
+    a.extend(&b);
+
+    assert_eq!(a.len(), 6);
+    assert!(a.contains(&1));
+    assert!(a.contains(&2));
+    assert!(a.contains(&3));
+    assert!(a.contains(&4));
+    assert!(a.contains(&5));
+    assert!(a.contains(&6));
+}

--- a/src/libcollectionstest/enum_set.rs
+++ b/src/libcollectionstest/enum_set.rs
@@ -242,3 +242,25 @@ fn test_overflow() {
     let mut set = EnumSet::new();
     set.insert(Bar::V64);
 }
+
+#[test]
+fn test_extend_ref() {
+    let mut a = EnumSet::new();
+    a.insert(A);
+
+    a.extend(&[A, C]);
+
+    assert_eq!(a.len(), 2);
+    assert!(a.contains(&A));
+    assert!(a.contains(&C));
+
+    let mut b = EnumSet::new();
+    b.insert(B);
+
+    a.extend(&b);
+
+    assert_eq!(a.len(), 3);
+    assert!(a.contains(&A));
+    assert!(a.contains(&B));
+    assert!(a.contains(&C));
+}

--- a/src/libcollectionstest/linked_list.rs
+++ b/src/libcollectionstest/linked_list.rs
@@ -321,6 +321,25 @@ fn test_show() {
     assert_eq!(format!("{:?}", list), "[\"just\", \"one\", \"test\", \"more\"]");
 }
 
+#[test]
+fn test_extend_ref() {
+    let mut a = LinkedList::new();
+    a.push_back(1);
+
+    a.extend(&[2, 3, 4]);
+
+    assert_eq!(a.len(), 4);
+    assert_eq!(a, list_from(&[1, 2, 3, 4]));
+
+    let mut b = LinkedList::new();
+    b.push_back(5);
+    b.push_back(6);
+    a.extend(&b);
+
+    assert_eq!(a.len(), 6);
+    assert_eq!(a, list_from(&[1, 2, 3, 4, 5, 6]));
+}
+
 #[bench]
 fn bench_collect_into(b: &mut test::Bencher) {
     let v = &[0; 64];

--- a/src/libcollectionstest/string.rs
+++ b/src/libcollectionstest/string.rs
@@ -365,6 +365,14 @@ fn test_drain() {
     assert_eq!(t, "");
 }
 
+#[test]
+fn test_extend_ref() {
+    let mut a = "foo".to_string();
+    a.extend(&['b', 'a', 'r']);
+
+    assert_eq!(&a, "foobar");
+}
+
 #[bench]
 fn bench_with_capacity(b: &mut Bencher) {
     b.iter(|| {

--- a/src/libcollectionstest/vec.rs
+++ b/src/libcollectionstest/vec.rs
@@ -113,6 +113,21 @@ fn test_extend() {
 }
 
 #[test]
+fn test_extend_ref() {
+    let mut v = vec![1, 2];
+    v.extend(&[3, 4, 5]);
+
+    assert_eq!(v.len(), 5);
+    assert_eq!(v, [1, 2, 3, 4, 5]);
+
+    let w = vec![6, 7];
+    v.extend(&w);
+
+    assert_eq!(v.len(), 7);
+    assert_eq!(v, [1, 2, 3, 4, 5, 6, 7]);
+}
+
+#[test]
 fn test_slice_from_mut() {
     let mut values = vec![1, 2, 3, 4, 5];
     {

--- a/src/libcollectionstest/vec_deque.rs
+++ b/src/libcollectionstest/vec_deque.rs
@@ -894,3 +894,29 @@ fn test_retain() {
     let v: Vec<_> = buf.into_iter().collect();
     assert_eq!(&v[..], &[2, 4]);
 }
+
+#[test]
+fn test_extend_ref() {
+    let mut v = VecDeque::new();
+    v.push_back(1);
+    v.extend(&[2, 3, 4]);
+
+    assert_eq!(v.len(), 4);
+    assert_eq!(v[0], 1);
+    assert_eq!(v[1], 2);
+    assert_eq!(v[2], 3);
+    assert_eq!(v[3], 4);
+
+    let mut w = VecDeque::new();
+    w.push_back(5);
+    w.push_back(6);
+    v.extend(&w);
+
+    assert_eq!(v.len(), 6);
+    assert_eq!(v[0], 1);
+    assert_eq!(v[1], 2);
+    assert_eq!(v[2], 3);
+    assert_eq!(v[3], 4);
+    assert_eq!(v[4], 5);
+    assert_eq!(v[5], 6);
+}

--- a/src/libcollectionstest/vec_map.rs
+++ b/src/libcollectionstest/vec_map.rs
@@ -493,6 +493,22 @@ fn test_entry(){
     assert_eq!(map.len(), 6);
 }
 
+#[test]
+fn test_extend_ref() {
+    let mut a = VecMap::new();
+    a.insert(1, "one");
+    let mut b = VecMap::new();
+    b.insert(2, "two");
+    b.insert(3, "three");
+
+    a.extend(&b);
+
+    assert_eq!(a.len(), 3);
+    assert_eq!(a[&1], "one");
+    assert_eq!(a[&2], "two");
+    assert_eq!(a[&3], "three");
+}
+
 mod bench {
     use std::collections::VecMap;
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -2284,7 +2284,7 @@ fn render_assoc_items(w: &mut fmt::Formatter,
         }
         try!(write!(w, "<h2 id='implementations'>Trait \
                           Implementations</h2>"));
-        let (derived, manual): (Vec<_>, _) = traits.iter().partition(|i| {
+        let (derived, manual): (Vec<_>, Vec<&Impl>) = traits.iter().partition(|i| {
             i.impl_.derived
         });
         for i in &manual {


### PR DESCRIPTION
I had to use `impl<'a, V: Copy> Extend<(usize, &'a V)> for VecMap<V>` instead of `impl<'a, V: Copy> Extend<(&'a usize, &'a V)> for VecMap<V>` as that's what is needed for doing

``` rust
let mut a = VecMap::new();
let b = VecMap::new();
b.insert(1, "foo");

a.extend(&b)
```

I can squash the commits after review.

r? @Gankro 
