### PR TITLE
configure: Fix LLVM output dir on MSVC

### DIFF
--- a/configure
+++ b/configure
@@ -1307,6 +1307,12 @@ CFG_LLVM_SRC_DIR=${CFG_SRC_DIR}src/llvm/
 for t in $CFG_HOST
 do
     do_reconfigure=1
+    is_msvc=0
+    case "$t" in
+        (*-msvc)
+        is_msvc=1
+        ;;
+    esac
 
     if [ -z $CFG_LLVM_ROOT ]
     then
@@ -1326,7 +1332,13 @@ do
             LLVM_ASSERTION_OPTS="--disable-assertions"
         else
             LLVM_ASSERTION_OPTS="--enable-assertions"
-            LLVM_INST_DIR=${LLVM_INST_DIR}+Asserts
+
+            # Apparently even if we request assertions be enabled for MSVC,
+            # LLVM's CMake build system ignore this and outputs in `Release`
+            # anyway.
+            if [ ${is_msvc} -eq 0 ]; then
+                LLVM_INST_DIR=${LLVM_INST_DIR}+Asserts
+            fi
         fi
     else
         msg "not reconfiguring LLVM, external LLVM root"
@@ -1356,14 +1368,7 @@ do
         done
     fi
 
-    use_cmake=0
-    case "$t" in
-        (*-msvc)
-        use_cmake=1
-        ;;
-    esac
-
-    if [ ${do_reconfigure} -ne 0 ] && [ ${use_cmake} -ne 0 ]
+    if [ ${do_reconfigure} -ne 0 ] && [ ${is_msvc} -ne 0 ]
     then
         msg "configuring LLVM for $t with cmake"
 
@@ -1388,7 +1393,7 @@ do
         need_ok "LLVM cmake configure failed"
     fi
 
-    if [ ${do_reconfigure} -ne 0 ] && [ ${use_cmake} -eq 0 ]
+    if [ ${do_reconfigure} -ne 0 ] && [ ${is_msvc} -eq 0 ]
     then
         # LLVM's configure doesn't recognize the new Windows triples yet
         gnu_t=$(to_gnu_triple $t)


### PR DESCRIPTION
If LLVM assertions are enabled for MSVC, it looks like the output directory is
still just `Release` (or assertions are just always ignored on MSVC).
