### PR TITLE
Minor fix to documentation of constraints on mut/non-mut references

### DIFF
--- a/src/doc/trpl/references-and-borrowing.md
+++ b/src/doc/trpl/references-and-borrowing.md
@@ -155,7 +155,7 @@ First, any borrow must last for a smaller scope than the owner. Second, you may
 have one or the other of these two kinds of borrows, but not both at the same
 time:
 
-* 0 to N references (`&T`) to a resource.
+* one or more references (`&T`) to a resource.
 * exactly one mutable reference (`&mut T`)
 
 


### PR DESCRIPTION
The statement is not completely exact, because it is valid to have
both 0 non-mutable references and 1 mutable reference. Instead, use
the same wording as in mutability.md.
