### PR TITLE
Mark std::as_bytes as inline

### DIFF
--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -1466,6 +1466,7 @@ impl str {
     /// assert_eq!("bors".as_bytes(), b"bors");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline(always)]
     pub fn as_bytes(&self) -> &[u8] {
         core_str::StrExt::as_bytes(&self[..])
     }


### PR DESCRIPTION
This wasn't marked inline, so wasn't being inlined cross-crate. It's
actually a no-op function, since it's a wrapper around `mem::transmute`.
Marking it inline means that programs calling it can see that it's a
no-op and act accordingly during optimisation.
