### PR TITLE
Only report Self: Sized violation once.

### DIFF
--- a/src/test/compile-fail-fulldeps/plugin-MacroRulesTT.rs
+++ b/src/test/compile-fail-fulldeps/plugin-MacroRulesTT.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,6 +11,7 @@
 // aux-build:macro_crate_MacroRulesTT.rs
 // ignore-stage1
 // error-pattern: plugin tried to register a new MacroRulesTT
+// error-pattern: aborting due to previous error
 
 #![feature(plugin)]
 #![plugin(macro_crate_MacroRulesTT)]

--- a/src/test/compile-fail/arg-count-mismatch.rs
+++ b/src/test/compile-fail/arg-count-mismatch.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: parameters were supplied
-
 fn f(x: isize) { }
 
-fn main() { let i: (); i = f(); }
+fn main() {
+    let i: ();
+    i = f(); //~ ERROR this function takes 1 parameter but 0 parameters were supplied
+}

--- a/src/test/compile-fail/arg-type-mismatch.rs
+++ b/src/test/compile-fail/arg-type-mismatch.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -9,8 +9,9 @@
 // except according to those terms.
 
 
-// error-pattern: mismatched types
-
 fn f(x: isize) { }
 
-fn main() { let i: (); i = f(()); }
+fn main() {
+    let i: ();
+    i = f(()); //~ ERROR mismatched types
+}

--- a/src/test/compile-fail/asm-src-loc-codegen-units.rs
+++ b/src/test/compile-fail/asm-src-loc-codegen-units.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -12,6 +12,8 @@
 // ignore-stage1
 // compile-flags: -C codegen-units=2
 // error-pattern: build without -C codegen-units for more exact errors
+// error-pattern: aborting due to previous error
+// error-pattern: aborting due to worker thread panic
 
 #![feature(asm)]
 

--- a/src/test/compile-fail/attr-bad-crate-attr.rc
+++ b/src/test/compile-fail/attr-bad-crate-attr.rc
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: expected item
-
 #![attr = "val"]
 #[attr = "val"] // Unterminated
+//~^ ERROR expected item after attributes

--- a/src/test/compile-fail/bad-env-capture.rs
+++ b/src/test/compile-fail/bad-env-capture.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: can't capture dynamic environment in a fn item;
 fn foo() {
     let x: isize;
-    fn bar() { log(debug, x); }
+    fn bar() {
+        println!("{}", x);
+        //~^ ERROR can't capture dynamic environment in a fn item; use the || { ... } closure
+        // form instead
+        //~| ERROR unresolved name `x`
+    }
 }
 fn main() { foo(); }

--- a/src/test/compile-fail/bad-env-capture2.rs
+++ b/src/test/compile-fail/bad-env-capture2.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: can't capture dynamic environment in a fn item;
 fn foo(x: isize) {
-    fn bar() { log(debug, x); }
+    fn bar() {
+        println!("{}", x);
+        //~^ ERROR can't capture dynamic environment in a fn item; use the || { ... } closure
+        // form instead
+        //~| ERROR unresolved name `x`
+    }
 }
 fn main() { foo(2); }

--- a/src/test/compile-fail/bad-env-capture3.rs
+++ b/src/test/compile-fail/bad-env-capture3.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: can't capture dynamic environment in a fn item;
 fn foo(x: isize) {
     fn mth() {
-        fn bar() { log(debug, x); }
+        fn bar() {
+            println!("{}", x);
+            //~^ ERROR can't capture dynamic environment in a fn item; use the || { ... } closure
+            // form instead
+            //~| ERROR unresolved name `x`
+        }
     }
 }
 

--- a/src/test/compile-fail/bad-expr-path.rs
+++ b/src/test/compile-fail/bad-expr-path.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unresolved name `m1::arguments`. Did you mean `arguments`?
-
 mod m1 {}
 
-fn main(arguments: Vec<String>) { log(debug, m1::arguments); }
+fn main(arguments: Vec<String>) {
+    println!("{:?}", m1::arguments);
+    //~^ ERROR unresolved name `m1::arguments`. Did you mean `arguments`?
+}

--- a/src/test/compile-fail/bad-expr-path2.rs
+++ b/src/test/compile-fail/bad-expr-path2.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unresolved name `m1::arguments`. Did you mean `arguments`?
-
 mod m1 {
     pub mod arguments {}
 }
 
 fn main(arguments: Vec<String>) {
-    log(debug, m1::arguments);
+    println!("{:?}", m1::arguments);
+    //~^ ERROR unresolved name `m1::arguments`. Did you mean `arguments`?
 }

--- a/src/test/compile-fail/bad-module.rs
+++ b/src/test/compile-fail/bad-module.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unresolved name
-
-fn main() { let foo = thing::len(Vec::new()); }
+fn main() {
+    let foo = thing::len(Vec::new());
+    //~^ ERROR failed to resolve. Use of undeclared type or module `thing`
+    //~| ERROR unresolved name `thing::len`
+}

--- a/src/test/compile-fail/binop-bitxor-str.rs
+++ b/src/test/compile-fail/binop-bitxor-str.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:`^` cannot be applied to type `collections::string::String`
-
 fn main() { let x = "a".to_string() ^ "b".to_string(); }
+//~^ ERROR binary operation `^` cannot be applied to type `collections::string::String`

--- a/src/test/compile-fail/binop-mul-bool.rs
+++ b/src/test/compile-fail/binop-mul-bool.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:`*` cannot be applied to type `bool`
-
 fn main() { let x = true * false; }
+//~^ ERROR binary operation `*` cannot be applied to type `bool`

--- a/src/test/compile-fail/bogus-tag.rs
+++ b/src/test/compile-fail/bogus-tag.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,15 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-// error-pattern: unresolved
-
 enum color { rgb(isize, isize, isize), rgba(isize, isize, isize, isize), }
 
 fn main() {
-    let red: color = rgb(255, 0, 0);
+    let red: color = rgb(255, 0, 0); //~ ERROR unresolved name `rgb`
     match red {
-      rgb(r, g, b) => { println!("rgb"); }
-      hsl(h, s, l) => { println!("hsl"); }
+      rgb(r, g, b) => { println!("rgb"); } //~ ERROR unresolved enum variant, struct or const `rgb`
+      hsl(h, s, l) => { println!("hsl"); } //~ ERROR unresolved enum variant, struct or const `hsl`
     }
 }

--- a/src/test/compile-fail/capture1.rs
+++ b/src/test/compile-fail/capture1.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
-// error-pattern: can't capture dynamic environment in a fn item;
-
 fn main() {
     let bar: isize = 5;
     fn foo() -> isize { return bar; }
+    //~^ ERROR can't capture dynamic environment in a fn item; use the || { ... } closure
+    // form instead
+    //~| ERROR unresolved name `bar`
 }

--- a/src/test/compile-fail/cast-as-bool.rs
+++ b/src/test/compile-fail/cast-as-bool.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,5 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: cannot cast as `bool`, compare with zero instead
-fn main() { let u = (5 as bool); }
+fn main() { let u = (5 as bool); } //~ ERROR cannot cast as `bool`, compare with zero instead

--- a/src/test/compile-fail/cast-from-nil.rs
+++ b/src/test/compile-fail/cast-from-nil.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,5 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: non-scalar cast: `()` as `u32`
-fn main() { let u = (assert!(true) as u32); }
+fn main() {
+    let u = (assert!(true) as u32); //~ ERROR non-scalar cast: `()` as `u32`
+}

--- a/src/test/compile-fail/cast-to-nil.rs
+++ b/src/test/compile-fail/cast-to-nil.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,5 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: non-scalar cast: `u32` as `()`
-fn main() { let u = 0u32 as (); }
+fn main() {
+    let u = 0u32 as (); //~ ERROR non-scalar cast: `u32` as `()`
+}

--- a/src/test/compile-fail/cfg-attr-cfg-2.rs
+++ b/src/test/compile-fail/cfg-attr-cfg-2.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 //
 // error-pattern: main function not found
+// error-pattern: aborting due to previous error
 // compile-flags: --cfg foo
 
 // main is conditionally compiled, but the conditional compilation

--- a/src/test/compile-fail/cfg-in-crate-1.rs
+++ b/src/test/compile-fail/cfg-in-crate-1.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:main function not found
+// error-pattern: main function not found
+// error-pattern: aborting due to previous error
 
 #![cfg(bar)]

--- a/src/test/compile-fail/const-eval-overflow-2.rs
+++ b/src/test/compile-fail/const-eval-overflow-2.rs
@@ -24,7 +24,7 @@ const NEG_NEG_128: i8 = -NEG_128;
 
 fn main() {
     match -128i8 {
-        NEG_NEG_128 => println!("A"),
+        NEG_NEG_128 => println!("A"), //~ NOTE in pattern here
         _ => println!("B"),
     }
 }

--- a/src/test/compile-fail/const-eval-overflow-3.rs
+++ b/src/test/compile-fail/const-eval-overflow-3.rs
@@ -17,8 +17,6 @@
 // self-hosted and a cross-compiled setup; therefore resorting to
 // error-pattern for now.
 
-// error-pattern: expected constant integer for repeat count, but attempted to add with overflow
-
 #![allow(unused_imports)]
 
 use std::fmt;
@@ -28,6 +26,8 @@ use std::{u8, u16, u32, u64, usize};
 const A_I8_I
     : [u32; (i8::MAX as usize) + 1]
     = [0; (i8::MAX + 1) as usize];
+    //~^ ERROR expected constant integer for repeat count, but attempted to add with overflow
+
 
 fn main() {
     foo(&A_I8_I[..]);

--- a/src/test/compile-fail/const-eval-overflow-3b.rs
+++ b/src/test/compile-fail/const-eval-overflow-3b.rs
@@ -21,8 +21,6 @@
 // self-hosted and a cross-compiled setup; therefore resorting to
 // error-pattern for now.
 
-// error-pattern: mismatched types
-
 #![allow(unused_imports)]
 
 use std::fmt;
@@ -32,6 +30,9 @@ use std::{u8, u16, u32, u64, usize};
 const A_I8_I
     : [u32; (i8::MAX as usize) + 1]
     = [0; (i8::MAX + 1u8) as usize];
+    //~^ ERROR mismatched types
+    //~| ERROR the trait `core::ops::Add<u8>` is not implemented for the type `i8`
+    //~| ERROR the trait `core::ops::Add<u8>` is not implemented for the type `i8`
 
 fn main() {
     foo(&A_I8_I[..]);

--- a/src/test/compile-fail/const-recursive.rs
+++ b/src/test/compile-fail/const-recursive.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: recursive constant
 static a: isize = b;
+//~^ ERROR recursive constant
 static b: isize = a;
-
-fn main() {
-}
+//~^ ERROR recursive constant
+fn main() {}

--- a/src/test/compile-fail/crateresolve1.rs
+++ b/src/test/compile-fail/crateresolve1.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,7 +11,9 @@
 // aux-build:crateresolve1-1.rs
 // aux-build:crateresolve1-2.rs
 // aux-build:crateresolve1-3.rs
-// error-pattern:multiple matching crates for `crateresolve1`
+// error-pattern: multiple matching crates for `crateresolve1`
+// error-pattern: can't find crate for `crateresolve1`
+// error-pattern: aborting due to 2 previous errors
 
 extern crate crateresolve1;
 

--- a/src/test/compile-fail/dead-code-ret.rs
+++ b/src/test/compile-fail/dead-code-ret.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,11 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unreachable statement
-
 #![deny(unreachable_code)]
+//~^ NOTE lint level defined here
 
 fn main() {
     return;
-    println!("Paul is dead");
+    let _x = "Paul is dead"; //~ ERROR unreachable statement
 }

--- a/src/test/compile-fail/does-nothing.rs
+++ b/src/test/compile-fail/does-nothing.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,5 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unresolved name `this_does_nothing_what_the`
-fn main() { println!("doing"); this_does_nothing_what_the; println!("boing"); }
+fn main() {
+    println!("doing");
+    this_does_nothing_what_the; //~ ERROR unresolved name `this_does_nothing_what_the`
+    println!("boing");
+}

--- a/src/test/compile-fail/dupe-symbols-4.rs
+++ b/src/test/compile-fail/dupe-symbols-4.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 //
-// error-pattern: symbol `fail` is already defined
 #![crate_type="rlib"]
 #![allow(warnings)]
 
@@ -27,5 +26,5 @@ impl A for B {
 
 impl A for C {
     #[no_mangle]
-    fn fail(self) {}
+    fn fail(self) {} //~ ERROR symbol `fail` is already defined
 }

--- a/src/test/compile-fail/dupe-symbols-7.rs
+++ b/src/test/compile-fail/dupe-symbols-7.rs
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 //
-// error-pattern: entry symbol `main` defined multiple times
 #![allow(warnings)]
 
 #[no_mangle]
-fn main(){}
+fn main(){} //~ ERROR entry symbol `main` defined multiple times

--- a/src/test/compile-fail/elided-test.rs
+++ b/src/test/compile-fail/elided-test.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // error-pattern: main function not found
+// error-pattern: aborting due to previous error
 
 // Since we're not compiling a test runner this function should be elided
 // and the build will fail because main doesn't exist

--- a/src/test/compile-fail/empty-extern-arg.rs
+++ b/src/test/compile-fail/empty-extern-arg.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 // compile-flags: --extern std=
+// error-pattern: extern location for std does not exist:
 // error-pattern: can't find crate for `std`
+// error-pattern: aborting due to 2 previous errors
 
 fn main() {}

--- a/src/test/compile-fail/enums-pats-not-idents.rs
+++ b/src/test/compile-fail/enums-pats-not-idents.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//error-pattern:unresolved enum variant
-
 fn main() {
     // a bug in the parser is allowing this:
     let a(1) = 13;
+    //~^ ERROR unresolved enum variant, struct or const `a`
 }

--- a/src/test/compile-fail/export-fully-qualified.rs
+++ b/src/test/compile-fail/export-fully-qualified.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,14 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unresolved name
-
 // In this test baz isn't resolved when called as foo.baz even though
 // it's called from inside foo. This is somewhat surprising and may
 // want to change eventually.
 
 mod foo {
-    pub fn bar() { foo::baz(); }
+    pub fn bar() {
+        foo::baz();
+        //~^ ERROR failed to resolve. Use of undeclared type or module `foo`
+        //~| ERROR unresolved name `foo::baz`
+    }
 
     fn baz() { }
 }

--- a/src/test/compile-fail/export.rs
+++ b/src/test/compile-fail/export.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unresolved name
 mod foo {
-    pub fn x(y: isize) { log(debug, y); }
-    fn z(y: isize) { log(debug, y); }
+    pub fn x(y: isize) {
+        println!("{}", y);
+    }
+    fn z(y: isize) {
+        println!("{}", y);
+    }
 }
 
-fn main() { foo::z(10); }
+fn main() {
+    foo::z(10); //~ ERROR function `z` is private
+}

--- a/src/test/compile-fail/export2.rs
+++ b/src/test/compile-fail/export2.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unresolved name
-
 mod foo {
-    pub fn x() { bar::x(); }
+    pub fn x() {
+        bar::x();
+        //~^ ERROR failed to resolve. Use of undeclared type or module `bar`
+        //~| ERROR unresolved name `bar::x`
+    }
 }
 
 mod bar {

--- a/src/test/compile-fail/ext-nonexistent.rs
+++ b/src/test/compile-fail/ext-nonexistent.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,5 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:macro undefined
-fn main() { iamnotanextensionthatexists!(""); }
+fn main() {
+    iamnotanextensionthatexists!("");
+    //~^ ERROR macro undefined: 'iamnotanextensionthatexists!'
+}

--- a/src/test/compile-fail/fail-simple.rs
+++ b/src/test/compile-fail/fail-simple.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 
-// error-pattern:unexpected token
 fn main() {
-  panic!(@);
+  panic!(@); //~ ERROR unexpected token: `@`
 }

--- a/src/test/compile-fail/fn-bad-block-type.rs
+++ b/src/test/compile-fail/fn-bad-block-type.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:mismatched types
-
 fn f() -> isize { true }
+//~^ ERROR mismatched types
 
 fn main() { }

--- a/src/test/compile-fail/for-expn-2.rs
+++ b/src/test/compile-fail/for-expn-2.rs
@@ -10,9 +10,7 @@
 
 // Test that we get an expansion stack for `for` loops.
 
-// error-pattern:in expansion of for loop expansion
-
 fn main() {
-    for t in &foo {
+    for t in &foo { //~ ERROR unresolved name `foo`
     }
 }

--- a/src/test/compile-fail/huge-enum.rs
+++ b/src/test/compile-fail/huge-enum.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,16 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: Option
+// error-pattern: too big for the current architecture
 
 // FIXME: work properly with higher limits
 
 #[cfg(target_pointer_width = "32")]
 fn main() {
-    let big: Option<[u32; (1<<29)-1]> = None;
+    let _big: Option<[u32; (1<<29)-1]> = None;
 }
 
 #[cfg(target_pointer_width = "64")]
 fn main() {
-    let big: Option<[u32; (1<<45)-1]> = None;
+    let _big: Option<[u32; (1<<45)-1]> = None;
 }

--- a/src/test/compile-fail/if-typeck.rs
+++ b/src/test/compile-fail/if-typeck.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:mismatched types
 // issue #513
 
 fn f() { }
@@ -17,4 +16,5 @@ fn main() {
 
     // f is not a bool
     if f { }
+    //~^ ERROR mismatched types
 }

--- a/src/test/compile-fail/import-glob-0.rs
+++ b/src/test/compile-fail/import-glob-0.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -7,8 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
-// error-pattern: unresolved name
 
 use module_of_many_things::*;
 
@@ -23,6 +21,6 @@ mod module_of_many_things {
 fn main() {
     f1();
     f2();
-    f999(); // 'export' currently doesn't work?
+    f999(); //~ ERROR unresolved name `f999`
     f4();
 }

--- a/src/test/compile-fail/import-glob-circular.rs
+++ b/src/test/compile-fail/import-glob-circular.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -7,8 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
-// error-pattern: unresolved
 
 mod circ1 {
     pub use circ2::f2;
@@ -25,5 +23,7 @@ mod circ2 {
 mod test {
     use circ1::*;
 
-    fn test() { f1066(); }
+    fn test() {
+        f1066(); //~ ERROR unresolved name `f1066`
+    }
 }

--- a/src/test/compile-fail/import-loop-2.rs
+++ b/src/test/compile-fail/import-loop-2.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,14 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:import
-
 mod a {
-    pub use b::x;
+    pub use b::x; //~ ERROR unresolved import
 }
 
 mod b {
-    pub use a::x;
+    pub use a::x; //~ ERROR unresolved import
 
     fn main() { let y = x; }
 }

--- a/src/test/compile-fail/import-loop.rs
+++ b/src/test/compile-fail/import-loop.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:import
-
-use y::x;
+use y::x; //~ ERROR unresolved import
 
 mod y {
-    pub use y::x;
+    pub use y::x; //~ ERROR unresolved import `y::x`. There is no `x` in `y`
 }
 
 fn main() { }

--- a/src/test/compile-fail/import3.rs
+++ b/src/test/compile-fail/import3.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unresolved
 use main::bar;
+//~^ ERROR unresolved import `main::bar`. Maybe a missing `extern crate main`?
 
 fn main() { println!("foo"); }

--- a/src/test/compile-fail/import4.rs
+++ b/src/test/compile-fail/import4.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: import
 
-
-mod a { pub use b::foo; }
-mod b { pub use a::foo; }
+mod a { pub use b::foo; } //~ ERROR unresolved import
+mod b { pub use a::foo; } //~ ERROR unresolved import
 
 fn main() { println!("loop"); }

--- a/src/test/compile-fail/infinite-autoderef.rs
+++ b/src/test/compile-fail/infinite-autoderef.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -7,8 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
-// error-pattern: reached the recursion limit while auto-dereferencing
 
 #![feature(box_syntax)]
 
@@ -27,11 +25,17 @@ impl Deref for Foo {
 pub fn main() {
     let mut x;
     loop {
-        x = box x;
-        x.foo;
+        x = box x; //~ ERROR mismatched types
+        x.foo; //~ ERROR the type of this value must be known in this context
         x.bar();
     }
 
     Foo.foo;
+    //~^ ERROR reached the recursion limit while auto-dereferencing Foo
+    //~| ERROR reached the recursion limit while auto-dereferencing Foo
+    //~| ERROR attempted access of field `foo` on type `Foo`, but no field with that name was
+    // found
     Foo.bar();
+    //~^ ERROR reached the recursion limit while auto-dereferencing Foo
+    //~| ERROR no method named `bar` found for type `Foo` in the current scope
 }

--- a/src/test/compile-fail/infinite-tag-type-recursion.rs
+++ b/src/test/compile-fail/infinite-tag-type-recursion.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -9,8 +9,7 @@
 // except according to those terms.
 
 
-// error-pattern: illegal recursive enum type; wrap the inner value in a box
-
 enum mlist { cons(isize, mlist), nil, }
+//~^ ERROR illegal recursive enum type; wrap the inner value in a box to make it representable
 
 fn main() { let a = mlist::cons(10, mlist::cons(11, mlist::nil)); }

--- a/src/test/compile-fail/internal-unstable-noallow.rs
+++ b/src/test/compile-fail/internal-unstable-noallow.rs
@@ -18,6 +18,7 @@
 // error-pattern:use of unstable library feature 'struct_field'
 // error-pattern:use of unstable library feature 'method'
 // error-pattern:use of unstable library feature 'struct2_field'
+// error-pattern:aborting due to 4 previous errors
 
 #[macro_use]
 extern crate internal_unstable;

--- a/src/test/compile-fail/issue-10536.rs
+++ b/src/test/compile-fail/issue-10536.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,8 +11,6 @@
 // We only want to assert that this doesn't ICE, we don't particularly care
 // about whether it nor it fails to compile.
 
-// error-pattern:
-
 macro_rules! foo{
     () => {{
         macro_rules! bar{() => (())}
@@ -24,8 +22,11 @@ pub fn main() {
     foo!();
 
     assert!({one! two()});
+    //~^ ERROR
+    //~| ERROR
 
     // regardless of whether nested macro_rules works, the following should at
     // least throw a conventional error.
     assert!({one! two});
+    //~^ ERROR
 }

--- a/src/test/compile-fail/issue-10656.rs
+++ b/src/test/compile-fail/issue-10656.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: missing documentation for crate
-
 #![deny(missing_docs)]
+//~^ NOTE lint level defined here
+//~^^ ERROR missing documentation for crate
 #![crate_type="lib"]

--- a/src/test/compile-fail/issue-11154.rs
+++ b/src/test/compile-fail/issue-11154.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,5 +11,7 @@
 // compile-flags: -C lto -C prefer-dynamic
 
 // error-pattern: cannot prefer dynamic linking
+// error-pattern: only 'staticlib' and 'bin' outputs are supported with LTO
+// error-pattern: aborting due to previous error
 
 fn main() {}

--- a/src/test/compile-fail/issue-11154.rs
+++ b/src/test/compile-fail/issue-11154.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/test/compile-fail/issue-13446.rs
+++ b/src/test/compile-fail/issue-13446.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,8 +11,6 @@
 
 // Used to cause ICE
 
-// error-pattern: mismatched types
-
-static VEC: [u32; 256] = vec!();
+static VEC: [u32; 256] = vec!(); //~ ERROR mismatched types
 
 fn main() {}

--- a/src/test/compile-fail/issue-14091-2.rs
+++ b/src/test/compile-fail/issue-14091-2.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // error-pattern: cannot apply unary operator `!` to type `BytePos`
+// error-pattern: aborting due to previous error
 
 // Very
 

--- a/src/test/compile-fail/issue-14091.rs
+++ b/src/test/compile-fail/issue-14091.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -13,5 +13,6 @@
 // error-pattern:found `_`
 // error-pattern:expected bool
 // error-pattern:found integral variable
+// error-pattern: aborting due to previous error
 
 fn main(){assert!(1,1);}

--- a/src/test/compile-fail/issue-16966.rs
+++ b/src/test/compile-fail/issue-16966.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:type annotations required
+// error-pattern: type annotations required
+// error-pattern: aborting due to previous error
 fn main() {
     panic!(
         std::default::Default::default()

--- a/src/test/compile-fail/issue-1900.rs
+++ b/src/test/compile-fail/issue-1900.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,5 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: main function is not allowed to have type parameters
-fn main<T>() { }
+fn main<T>() { } //~ ERROR main function is not allowed to have type parameters

--- a/src/test/compile-fail/issue-19660.rs
+++ b/src/test/compile-fail/issue-19660.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // error-pattern: requires `copy` lang_item
+// error-pattern: aborting due to previous error
 
 #![feature(lang_items, start, no_std)]
 #![no_std]

--- a/src/test/compile-fail/issue-20692.rs
+++ b/src/test/compile-fail/issue-20692.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Foo: Sized { }
+trait Bar: Foo { }
+
+fn foo<T: Bar>(x: &T) {
+    let _ = x as &Bar;
+    //~^ ERROR cannot convert to a trait object because trait `Bar` is not object-safe
+    //~| NOTE the trait cannot require that `Self : Sized`
+}
+
+fn main() {}

--- a/src/test/compile-fail/issue-21146.rs
+++ b/src/test/compile-fail/issue-21146.rs
@@ -9,5 +9,6 @@
 // except according to those terms.
 
 // error-pattern: expected item, found `parse_error`
+// error-pattern: ^~~~~~
 include!("../auxiliary/issue-21146-inc.rs");
 fn main() {}

--- a/src/test/compile-fail/issue-2281-part1.rs
+++ b/src/test/compile-fail/issue-2281-part1.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unresolved name `foobar`
-
 fn main() { println!("{}", foobar); }
+//~^ ERROR unresolved name `foobar`

--- a/src/test/compile-fail/issue-5927.rs
+++ b/src/test/compile-fail/issue-5927.rs
@@ -1,4 +1,4 @@
-// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -9,12 +9,10 @@
 // except according to those terms.
 
 
-
-// error-pattern:unresolved enum variant
-
 fn main() {
     let z = match 3 {
-        x(1) => x(1)
+        x(1) => x(1) //~ ERROR unresolved enum variant, struct or const `x`
+                     //~| ERROR unresolved name `x`
     };
     assert_eq!(z,3);
 }

--- a/src/test/compile-fail/issue-6596-1.rs
+++ b/src/test/compile-fail/issue-6596-1.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,11 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unknown macro variable `nonexistent`
-
 macro_rules! e {
     ($inp:ident) => (
-        $nonexistent
+        $nonexistent //~ ERROR unknown macro variable `nonexistent`
     );
 }
 

--- a/src/test/compile-fail/issue-6596-2.rs
+++ b/src/test/compile-fail/issue-6596-2.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,14 +10,15 @@
 
 #![feature(macro_rules)]
 
-// error-pattern: unknown macro variable `nonexistent`
-
 macro_rules! g {
     ($inp:ident) => (
         { $inp $nonexistent }
+        //~^ ERROR unknown macro variable `nonexistent`
+        //~| ERROR macro expansion ignores token `$nonexistent` and any following
     );
 }
 
 fn main() {
     g!(foo);
+//~^ NOTE caused by the macro expansion here; the usage of `g` is likely invalid in this context
 }

--- a/src/test/compile-fail/issue-8727.rs
+++ b/src/test/compile-fail/issue-8727.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,13 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:reached the recursion limit during monomorphization
-
 // Verify the compiler fails with an error on infinite function
 // recursions.
 
 fn generic<T>() {
+//~^ WARNING function cannot return without recurring
+//~^^ HELP a `loop` may express intention better
+//~^^^ ERROR  reached the recursion limit during monomorphization
     generic::<Option<T>>();
+    //~^ NOTE recursive call site
 }
 
 

--- a/src/test/compile-fail/lang-item-missing.rs
+++ b/src/test/compile-fail/lang-item-missing.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -12,6 +12,9 @@
 // see #17392.
 
 // error-pattern: requires `sized` lang_item
+// error-pattern: requires `sized` lang_item
+// error-pattern: requires `sized` lang_item
+// error-pattern: aborting due to 3 previous errors
 
 #![feature(start, no_std)]
 #![no_std]

--- a/src/test/compile-fail/lint-non-snake-case-crate-2.rs
+++ b/src/test/compile-fail/lint-non-snake-case-crate-2.rs
@@ -10,6 +10,7 @@
 
 // compile-flags: --crate-name NonSnakeCase
 // error-pattern: crate `NonSnakeCase` should have a snake case name such as `non_snake_case`
+// error-pattern: aborting due to previous error
 
 #![deny(non_snake_case)]
 

--- a/src/test/compile-fail/lint-stability2.rs
+++ b/src/test/compile-fail/lint-stability2.rs
@@ -10,6 +10,7 @@
 
 // aux-build:lint_stability.rs
 // error-pattern: use of deprecated item
+// error-pattern: aborting due to previous error
 
 #![deny(deprecated)]
 

--- a/src/test/compile-fail/lint-stability3.rs
+++ b/src/test/compile-fail/lint-stability3.rs
@@ -10,6 +10,7 @@
 
 // aux-build:lint_stability.rs
 // error-pattern: use of deprecated item
+// error-pattern: aborting due to previous error
 
 #![deny(deprecated)]
 #![allow(warnings)]

--- a/src/test/compile-fail/liveness-forgot-ret.rs
+++ b/src/test/compile-fail/liveness-forgot-ret.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: not all control paths return a value
-
 fn god_exists(a: isize) -> bool { return god_exists(a); }
 
 fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
+//~^ ERROR not all control paths return a value
 
 fn main() { f(12); }

--- a/src/test/compile-fail/liveness-missing-ret2.rs
+++ b/src/test/compile-fail/liveness-missing-ret2.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: not all control paths return a value
-
 fn f() -> isize {
+//~^ ERROR not all control paths return a value
     // Make sure typestate doesn't interpret this match expression as
     // the function result
    match true { true => { } _ => {} };

--- a/src/test/compile-fail/macro-with-seps-err-msg.rs
+++ b/src/test/compile-fail/macro-with-seps-err-msg.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:expected macro name without module separators
-
 fn main() {
-    globnar::brotz!();
+    globnar::brotz!(); //~ ERROR expected macro name without module separators
 }

--- a/src/test/compile-fail/manual-link-bad-form.rs
+++ b/src/test/compile-fail/manual-link-bad-form.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,6 +10,7 @@
 
 // compile-flags:-l static=
 // error-pattern: empty library name given via `-l`
+// error-pattern: aborting due to previous error
 
 fn main() {
 }

--- a/src/test/compile-fail/manual-link-framework.rs
+++ b/src/test/compile-fail/manual-link-framework.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -12,6 +12,7 @@
 // ignore-ios
 // compile-flags:-l framework=foo
 // error-pattern: native frameworks are only available on OSX targets
+// error-pattern: aborting due to previous error
 
 fn main() {
 }

--- a/src/test/compile-fail/match-range-fail-dominate.rs
+++ b/src/test/compile-fail/match-range-fail-dominate.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,40 +8,34 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//error-pattern: unreachable
-//error-pattern: unreachable
-//error-pattern: unreachable
-//error-pattern: unreachable
-//error-pattern: unreachable
-
 fn main() {
     match 5 {
       1 ... 10 => { }
-      5 ... 6 => { }
+      5 ... 6 => { } //~ ERROR unreachable pattern
       _ => {}
     };
 
     match 5 {
       3 ... 6 => { }
-      4 ... 6 => { }
+      4 ... 6 => { } //~ ERROR unreachable pattern
       _ => {}
     };
 
     match 5 {
       4 ... 6 => { }
-      4 ... 6 => { }
+      4 ... 6 => { } //~ ERROR unreachable pattern
       _ => {}
     };
 
     match 'c' {
       'A' ... 'z' => {}
-      'a' ... 'z' => {}
+      'a' ... 'z' => {} //~ ERROR unreachable pattern
       _ => {}
     };
 
     match 1.0f64 {
       0.01f64 ... 6.5f64 => {}
-      0.02f64 => {}
+      0.02f64 => {} //~ ERROR unreachable pattern
       _ => {}
     };
 }

--- a/src/test/compile-fail/match-range-fail.rs
+++ b/src/test/compile-fail/match-range-fail.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/test/compile-fail/match-tag-nullary.rs
+++ b/src/test/compile-fail/match-tag-nullary.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: mismatched types
-
 enum a { A, }
 enum b { B, }
 
-fn main() { let x: a = a::A; match x { b::B => { } } }
+fn main() {
+    let x: a = a::A;
+    match x { b::B => { } } //~ ERROR mismatched types
+}

--- a/src/test/compile-fail/match-tag-unary.rs
+++ b/src/test/compile-fail/match-tag-unary.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: mismatched types
-
 enum a { A(isize), }
 enum b { B(isize), }
 
-fn main() { let x: a = a::A(0); match x { b::B(y) => { } } }
+fn main() {
+    let x: a = a::A(0);
+    match x { b::B(y) => { } } //~ ERROR mismatched types
+}

--- a/src/test/compile-fail/minus-string.rs
+++ b/src/test/compile-fail/minus-string.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:cannot apply unary operator `-` to type `collections::string::String`
-
 fn main() { -"foo".to_string(); }
+//~^ ERROR cannot apply unary operator `-` to type `collections::string::String`

--- a/src/test/compile-fail/missing-main.rs
+++ b/src/test/compile-fail/missing-main.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,5 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:main function not found
+// error-pattern: main function not found
+// error-pattern: aborting due to previous error
+
 fn mian() { }

--- a/src/test/compile-fail/missing-return.rs
+++ b/src/test/compile-fail/missing-return.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: return
-
-fn f() -> isize { }
+fn f() -> isize { } //~ ERROR not all control paths return a value
 
 fn main() { f(); }

--- a/src/test/compile-fail/mod_file_not_owning.rs
+++ b/src/test/compile-fail/mod_file_not_owning.rs
@@ -11,6 +11,7 @@
 // compile-flags: -Z parse-only
 
 // error-pattern: cannot declare a new module at this location
+// error-pattern: aborting due to previous error
 
 mod mod_file_not_owning_aux1;
 

--- a/src/test/compile-fail/multiple-plugin-registrars.rs
+++ b/src/test/compile-fail/multiple-plugin-registrars.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -9,6 +9,9 @@
 // except according to those terms.
 
 // error-pattern: multiple plugin registration functions found
+// error-pattern: one is here
+// error-pattern: one is here
+// error-pattern: aborting due to previous error
 
 #![feature(plugin_registrar)]
 

--- a/src/test/compile-fail/name-clash-nullary.rs
+++ b/src/test/compile-fail/name-clash-nullary.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:declaration of `None` shadows
 use std::option::*;
 
 fn main() {
   let None: isize = 42;
-  log(debug, None);
+  //~^ ERROR declaration of `None` shadows an enum variant or unit-like struct in scope
+  println!("{}", None);
 }

--- a/src/test/compile-fail/nested-ty-params.rs
+++ b/src/test/compile-fail/nested-ty-params.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:can't use type parameters from outer function; try using
 fn hd<U>(v: Vec<U> ) -> U {
     fn hd1(w: [U]) -> U { return w[0]; }
+    //~^ ERROR can't use type parameters from outer function; try using a local type
+    // parameter instead
+    //~| ERROR use of undeclared type name `U`
+    //~| ERROR can't use type parameters from outer function; try using a local type
+    // parameter instead
+    //~| ERROR use of undeclared type name `U`
 
     return hd1(v);
 }

--- a/src/test/compile-fail/no-capture-arc.rs
+++ b/src/test/compile-fail/no-capture-arc.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -7,8 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
-// error-pattern: use of moved value
 
 use std::sync::Arc;
 use std::thread;
@@ -22,6 +20,9 @@ fn main() {
     });
 
     assert_eq!((*arc_v)[2], 3);
+    //~^ ERROR use of moved value: `arc_v`
+    //~| NOTE expansion site
 
     println!("{:?}", *arc_v);
+    //~^ ERROR use of moved value: `arc_v`
 }

--- a/src/test/compile-fail/nolink-with-link-args.rs
+++ b/src/test/compile-fail/nolink-with-link-args.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:aFdEfSeVEE
+// error-pattern: linking with `cc` failed
+// error-pattern:
+// error-pattern: aFdEfSeVEE
+// error-pattern: aborting due to previous error
 
 /* We're testing that link_args are indeed passed when nolink is specified.
 So we try to compile with junk link_args and make sure they are visible in

--- a/src/test/compile-fail/nonscalar-cast.rs
+++ b/src/test/compile-fail/nonscalar-cast.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,13 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:non-scalar cast
-
 #[derive(Debug)]
 struct foo {
     x: isize
 }
 
 fn main() {
-    println!("{}", foo{ x: 1 } as isize);
+    println!("{}", foo{ x: 1 } as isize); //~ ERROR non-scalar cast: `foo` as `isize`
 }

--- a/src/test/compile-fail/not-utf8.rs
+++ b/src/test/compile-fail/not-utf8.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: did not contain valid UTF-8
-
 fn foo() {
     include!("not-utf8.bin")
+    //~^ ERROR
 }

--- a/src/test/compile-fail/occurs-check-3.rs
+++ b/src/test/compile-fail/occurs-check-3.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:mismatched types
 // From Issue #778
 enum clam<T> { a(T), }
-fn main() { let c; c = clam::a(c); match c { clam::a::<isize>(_) => { } } }
+fn main() {
+    let c; c = clam::a(c); //~ ERROR mismatched types
+    match c { clam::a::<isize>(_) => { } }
+}

--- a/src/test/compile-fail/or-patter-mismatch.rs
+++ b/src/test/compile-fail/or-patter-mismatch.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: mismatched types
-
 enum blah { a(isize, isize, usize), b(isize, isize), }
 
-fn main() { match blah::a(1, 1, 2) { blah::a(_, x, y) | blah::b(x, y) => { } } }
+fn main() {
+    match blah::a(1, 1, 2) {
+        blah::a(_, x, y) | blah::b(x, y) => { } //~ ERROR mismatched types
+    }
+}

--- a/src/test/compile-fail/output-type-mismatch.rs
+++ b/src/test/compile-fail/output-type-mismatch.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: mismatched types
-
 fn f() { }
 
-fn main() { let i: isize; i = f(); }
+fn main() { let i: isize; i = f(); } //~ ERROR mismatched types

--- a/src/test/compile-fail/packed-struct-generic-transmute.rs
+++ b/src/test/compile-fail/packed-struct-generic-transmute.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -13,9 +13,9 @@
 // the error points to the start of the file, not the line with the
 // transmute
 
-// error-pattern: transmute called on types with different size
-
 use std::mem;
+
+#[allow(unused)]
 
 #[repr(packed)]
 struct Foo<T,S> {
@@ -32,6 +32,8 @@ fn main() {
     let foo = Foo { bar: [1u8, 2, 3, 4, 5], baz: 10i32 };
     unsafe {
         let oof: Oof<[u8; 5], i32> = mem::transmute(foo);
+        //~^ ERROR transmute called on types with different sizes: Foo<[u8; 5], i32> (72 bits)
+        // to Oof<[u8; 5], i32> (96 bits)
         println!("{:?} {:?}", &oof.rab[..], oof.zab);
     }
 }

--- a/src/test/compile-fail/packed-struct-transmute.rs
+++ b/src/test/compile-fail/packed-struct-transmute.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -13,9 +13,9 @@
 // the error points to the start of the file, not the line with the
 // transmute
 
-// error-pattern: transmute called on types with different size
-
 use std::mem;
+
+#[allow(unused)]
 
 #[repr(packed)]
 struct Foo {
@@ -33,6 +33,8 @@ fn main() {
     let foo = Foo { bar: 1, baz: 10 };
     unsafe {
         let oof: Oof = mem::transmute(foo);
+        //~^ ERROR transmute called on types with different sizes: Foo (72 bits) to Oof (128 bits)
+
         println!("{:?}", oof);
     }
 }

--- a/src/test/compile-fail/pattern-tyvar.rs
+++ b/src/test/compile-fail/pattern-tyvar.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,13 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: mismatched types
-
 enum bar { t1((), Option<Vec<isize> >), t2, }
 
 fn foo(t: bar) {
     match t {
-      bar::t1(_, Some::<isize>(x)) => {
+      bar::t1(_, Some::<isize>(x)) => { //~ ERROR mismatched types
         println!("{}", x);
       }
       _ => { panic!(); }

--- a/src/test/compile-fail/private-method.rs
+++ b/src/test/compile-fail/private-method.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -7,8 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
-// error-pattern:method `nap` is private
 
 mod kitties {
     pub struct cat {
@@ -31,5 +29,5 @@ mod kitties {
 
 fn main() {
   let nyan : kitties::cat = kitties::cat(52, 99);
-  nyan.nap();
+  nyan.nap(); //~ ERROR method `nap` is private
 }

--- a/src/test/compile-fail/recursive-enum.rs
+++ b/src/test/compile-fail/recursive-enum.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: illegal recursive enum type
-
 enum list<T> { cons(T, list<T>), nil }
+//~^ ERROR illegal recursive enum type; wrap the inner value in a box to make it representable
 
 fn main() {}

--- a/src/test/compile-fail/ret-non-nil.rs
+++ b/src/test/compile-fail/ret-non-nil.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: `return;` in a function whose return type is not `()`
-
 fn f() { return; }
 
 fn g() -> isize { return; }
+//~^ ERROR `return;` in a function whose return type is not `()`
 
 fn main() { f(); g(); }

--- a/src/test/compile-fail/tag-type-args.rs
+++ b/src/test/compile-fail/tag-type-args.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,10 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:wrong number of type arguments
-
 enum quux<T> { bar }
 
 fn foo(c: quux) { assert!((false)); }
+//~^ ERROR wrong number of type arguments: expected 1, found 0
 
 fn main() { panic!(); }

--- a/src/test/compile-fail/tag-variant-cast-non-nullary.rs
+++ b/src/test/compile-fail/tag-variant-cast-non-nullary.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//error-pattern: non-scalar cast
-
 enum non_nullary {
     nullary,
     other(isize),
@@ -17,5 +15,5 @@ enum non_nullary {
 
 fn main() {
     let v = non_nullary::nullary;
-    let val = v as isize;
+    let val = v as isize; //~ ERROR non-scalar cast: `non_nullary` as `isize`
 }

--- a/src/test/compile-fail/tag-variant-disr-dup.rs
+++ b/src/test/compile-fail/tag-variant-disr-dup.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,16 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//error-pattern:discriminant value
-
 // black and white have the same discriminator value ...
 
 enum color {
     red = 0xff0000,
     green = 0x00ff00,
     blue = 0x0000ff,
-    black = 0x000000,
-    white = 0x000000,
+    black = 0x000000, //~ NOTE conflicting discriminant here
+    white = 0x000000, //~ ERROR discriminant value `0` already exists
 }
 
 fn main() { }

--- a/src/test/compile-fail/tail-typeck.rs
+++ b/src/test/compile-fail/tail-typeck.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,9 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: mismatched types
-
-fn f() -> isize { return g(); }
+fn f() -> isize { return g(); } //~ ERROR mismatched types
 
 fn g() -> usize { return 0; }
 

--- a/src/test/compile-fail/type-arg-out-of-scope.rs
+++ b/src/test/compile-fail/type-arg-out-of-scope.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:can't use type parameters from outer function; try using
 fn foo<T>(x: T) {
     fn bar(f: Box<FnMut(T) -> T>) { }
+    //~^ ERROR can't use type parameters from outer function; try using a local type
+    // parameter instead
+    //~| ERROR use of undeclared type name `T`
+    //~| ERROR can't use type parameters from outer function; try using a local type
+    // parameter instead
+    //~| ERROR use of undeclared type name `T`
 }
 fn main() { foo(1); }

--- a/src/test/compile-fail/type-recursive.rs
+++ b/src/test/compile-fail/type-recursive.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:this type cannot be instantiated
 struct t1 {
+//~^ ERROR illegal recursive struct type; wrap the inner value in a box to make it representable
+//~| ERROR this type cannot be instantiated without an instance of itself
     foo: isize,
     foolish: t1
 }

--- a/src/test/compile-fail/unreachable-arm.rs
+++ b/src/test/compile-fail/unreachable-arm.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,11 +8,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:unreachable pattern
-
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 
 enum foo { a(Box<foo>, isize), b(usize), }
 
-fn main() { match foo::b(1) { foo::b(_) | foo::a(box _, 1) => { } foo::a(_, 1) => { } } }
+fn main() {
+    match foo::b(1) {
+    //~^ ERROR non-exhaustive patterns: `a(_, _)` not covered
+        foo::b(_) | foo::a(box _, 1) => { },
+        foo::a(_, 1) => { }, //~ ERROR unreachable pattern
+    }
+}

--- a/src/test/compile-fail/unsupported-cast.rs
+++ b/src/test/compile-fail/unsupported-cast.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:illegal cast
-
 #![feature(libc)]
 
 extern crate libc;
 
 fn main() {
-  println!("{:?}", 1.0 as *const libc::FILE); // Can't cast float to foreign.
+  println!("{:?}", 1.0 as *const libc::FILE); //~ ERROR illegal cast; cast through a usize first: `f64` as `*const libc::types::common::c95::FILE`
 }

--- a/src/test/compile-fail/unsupported-cast.rs
+++ b/src/test/compile-fail/unsupported-cast.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -13,5 +13,7 @@
 extern crate libc;
 
 fn main() {
-  println!("{:?}", 1.0 as *const libc::FILE); //~ ERROR illegal cast; cast through a usize first: `f64` as `*const libc::types::common::c95::FILE`
+  println!("{:?}", 1.0 as *const libc::FILE);
+  //~^ ERROR illegal cast; cast through a usize first: `f64` as `*const
+  // libc::types::common::c95::FILE`
 }

--- a/src/test/compile-fail/use-meta-mismatch.rs
+++ b/src/test/compile-fail/use-meta-mismatch.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:can't find crate for `extra`
-
-extern crate fake_crate as extra;
+extern crate fake_crate as extra; //~ ERROR can't find crate for `extra`
 
 fn main() { }

--- a/src/test/compile-fail/use-meta-mismatch.rs
+++ b/src/test/compile-fail/use-meta-mismatch.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/test/compile-fail/weak-lang-item.rs
+++ b/src/test/compile-fail/weak-lang-item.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -12,6 +12,7 @@
 // error-pattern: language item required, but not found: `panic_fmt`
 // error-pattern: language item required, but not found: `stack_exhausted`
 // error-pattern: language item required, but not found: `eh_personality`
+// error-pattern: aborting due to 3 previous errors
 
 #![feature(no_std)]
 #![no_std]

--- a/src/test/compile-fail/while-type-error.rs
+++ b/src/test/compile-fail/while-type-error.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/test/compile-fail/while-type-error.rs
+++ b/src/test/compile-fail/while-type-error.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,4 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: mismatched types
-
-fn main() { while main { } }
+fn main() { while main { } } //~ ERROR mismatched types

--- a/src/test/compile-fail/wrong-ret-type.rs
+++ b/src/test/compile-fail/wrong-ret-type.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/test/compile-fail/wrong-ret-type.rs
+++ b/src/test/compile-fail/wrong-ret-type.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,6 +8,5 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: mismatched types
-fn mk_int() -> usize { let i: isize = 3; return i; }
+fn mk_int() -> usize { let i: isize = 3; return i; } //~ ERROR mismatched types
 fn main() { }

--- a/src/test/parse-fail/attr-bad-meta.rs
+++ b/src/test/parse-fail/attr-bad-meta.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,8 +10,8 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern:expected `]`
 
 // asterisk is bogus
 #[attr*]
+//~^ ERROR expected `]`
 mod m {}

--- a/src/test/parse-fail/attr-before-stmt.rs
+++ b/src/test/parse-fail/attr-before-stmt.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,7 +10,8 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern:expected item
+// error-pattern: expected item after attributes
+// error-pattern: aborting due to previous error
 
 fn f() {
   #[foo = "bar"]

--- a/src/test/parse-fail/attr-dangling-in-fn.rs
+++ b/src/test/parse-fail/attr-dangling-in-fn.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,7 +10,8 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern:expected item
+// error-pattern: expected item after attributes
+// error-pattern: aborting due to previous error
 
 fn f() {
   #[foo = "bar"]

--- a/src/test/parse-fail/attr-dangling-in-mod.rs
+++ b/src/test/parse-fail/attr-dangling-in-mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,7 +10,8 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern:expected item
+// error-pattern: expected item after attributes
+// error-pattern: aborting due to previous error
 
 fn main() {
 }

--- a/src/test/parse-fail/bad-match.rs
+++ b/src/test/parse-fail/bad-match.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,10 +10,9 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern: expected
-
 fn main() {
   let isize x = 5;
+  //~^ ERROR expected one of
   match x;
 }
 

--- a/src/test/parse-fail/bad-name.rs
+++ b/src/test/parse-fail/bad-name.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,8 +10,7 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern: expected
-
 fn main() {
   let x.y::<isize>.z foo;
+  //~^ ERROR expected one of
 }

--- a/src/test/parse-fail/class-implements-bad-trait.rs
+++ b/src/test/parse-fail/class-implements-bad-trait.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,8 +10,8 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern:nonexistent
 class cat : nonexistent {
+//~^ ERROR expected item, found `class`
   let meows: usize;
   new(in_x : usize) { self.meows = in_x; }
 }

--- a/src/test/parse-fail/duplicate-visibility.rs
+++ b/src/test/parse-fail/duplicate-visibility.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,7 +10,7 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern:unmatched visibility `pub`
 extern {
     pub pub fn foo();
+    //~^ ERROR unmatched visibility `pub`
 }

--- a/src/test/parse-fail/import-from-path.rs
+++ b/src/test/parse-fail/import-from-path.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,5 +10,5 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern:expected
 use foo::{bar}::baz
+//~^ ERROR expected `;`

--- a/src/test/parse-fail/import-from-rename.rs
+++ b/src/test/parse-fail/import-from-rename.rs
@@ -10,9 +10,8 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern:expected
-
 use foo::{bar} as baz;
+//~^ ERROR expected `;`
 
 mod foo {
     pub fn bar() {}

--- a/src/test/parse-fail/import-glob-path.rs
+++ b/src/test/parse-fail/import-glob-path.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,5 +10,5 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern:expected
 use foo::*::bar
+//~^ ERROR expected `;`

--- a/src/test/parse-fail/import-glob-rename.rs
+++ b/src/test/parse-fail/import-glob-rename.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,9 +10,8 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern:expected
-
 use foo::* as baz;
+//~^ ERROR expected `;`
 
 mod foo {
     pub fn bar() {}

--- a/src/test/parse-fail/issue-1655.rs
+++ b/src/test/parse-fail/issue-1655.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,9 +10,9 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern:expected `[`, found `vec`
 mod blade_runner {
     #vec[doc(
+    //~^ ERROR expected `[`, found `vec`
         brief = "Blade Runner is probably the best movie ever",
         desc = "I like that in the world of Blade Runner it is always
                 raining, and that it's always night time. And Aliens

--- a/src/test/parse-fail/issue-1802-1.rs
+++ b/src/test/parse-fail/issue-1802-1.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,6 +11,7 @@
 // compile-flags: -Z parse-only
 
 // error-pattern:no valid digits found for number
+// error-pattern: aborting due to previous error
 fn main() {
     log(error, 0b);
 }

--- a/src/test/parse-fail/issue-1802-2.rs
+++ b/src/test/parse-fail/issue-1802-2.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,6 +11,7 @@
 // compile-flags: -Z parse-only
 
 // error-pattern:no valid digits found for number
+// error-pattern: aborting due to previous error
 fn main() {
     log(error, 0b_usize);
 }

--- a/src/test/parse-fail/multiline-comment-line-tracking.rs
+++ b/src/test/parse-fail/multiline-comment-line-tracking.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:18:3
-
 /* 1
  * 2
  * 3
  */
 fn main() {
-  %; // parse error on line 18, but is reported on line 6 instead.
+  %;
+  //~^ ERROR unexpected token: `%`
 }

--- a/src/test/parse-fail/no-binary-float-literal.rs
+++ b/src/test/parse-fail/no-binary-float-literal.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,10 +10,8 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern:binary float literal is not supported
-
 fn main() {
-    0b101010f64;
-    0b101.010;
-    0b101p4f64;
+    0b101010f64; //~ ERROR binary float literal is not supported
+    0b101.010;   //~ ERROR binary float literal is not supported
+    0b101p4f64;  //~ ERROR illegal suffix `p4f64`
 }

--- a/src/test/parse-fail/no-hex-float-literal.rs
+++ b/src/test/parse-fail/no-hex-float-literal.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,10 +10,8 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern:hexadecimal float literal is not supported
-
 fn main() {
     0xABC.Df;
-    0x567.89;
-    0xDEAD.BEEFp-2f;
+    0x567.89; //~ ERROR hexadecimal float literal is not supported
+    0xDEAD.BEEFp-2f; //~ ERROR illegal suffix
 }

--- a/src/test/parse-fail/not-a-pred.rs
+++ b/src/test/parse-fail/not-a-pred.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,9 +10,8 @@
 
 // compile-flags: -Z parse-only
 
-// error-pattern: lt
-
 fn f(a: isize, b: isize) : lt(a, b) { }
+//~^ ERROR expected one of `->`, `where`, or `{`
 
 fn lt(a: isize, b: isize) { }
 

--- a/src/test/parse-fail/tag-variant-disr-non-nullary.rs
+++ b/src/test/parse-fail/tag-variant-disr-non-nullary.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,13 +10,11 @@
 
 // compile-flags: -Z parse-only
 
-//error-pattern: discriminator values can only be used with a c-like enum
-
 enum color {
     red = 0xff0000,
     green = 0x00ff00,
     blue = 0x0000ff,
     black = 0x000000,
-    white = 0xffffff,
+    white = 0xffffff, //~ ERROR discriminator values can only be used with a c-like enum
     other (str),
 }

--- a/src/test/parse-fail/unbalanced-doublequote.rs
+++ b/src/test/parse-fail/unbalanced-doublequote.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,10 +10,7 @@
 
 // compile-flags: -Z parse-only
 
-
-// error-pattern: unterminated double quote string
-
-
 fn main() {
     "
+    //~^ ERROR unterminated double quote string
 }

--- a/src/test/run-fail-fulldeps/qquote.rs
+++ b/src/test/run-fail-fulldeps/qquote.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,6 +11,7 @@
 // ignore-cross-compile
 
 // error-pattern:expected identifier, found keyword `let`
+// error-pattern:thread '<main>' panicked at 'index out of bounds: the len is 0 but the index is 0'
 
 #![feature(quote, rustc_private)]
 

--- a/src/test/run-fail/panic-task-name-none.rs
+++ b/src/test/run-fail/panic-task-name-none.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/test/run-fail/panic-task-name-none.rs
+++ b/src/test/run-fail/panic-task-name-none.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // error-pattern:thread '<unnamed>' panicked at 'test'
+// error-pattern:thread '<main>' panicked at 'assertion failed: r.is_ok()'
 
 use std::thread;
 

--- a/src/test/run-fail/panic-task-name-owned.rs
+++ b/src/test/run-fail/panic-task-name-owned.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/test/run-fail/panic-task-name-owned.rs
+++ b/src/test/run-fail/panic-task-name-owned.rs
@@ -9,11 +9,12 @@
 // except according to those terms.
 
 // error-pattern:thread 'owned name' panicked at 'test'
+// error-pattern:thread '<main>' panicked at 'called `Result::unwrap()` on an `Err` value: Any'
 
 use std::thread::Builder;
 
 fn main() {
-    let r: () = Builder::new().name("owned name".to_string()).spawn(move|| {
+    let _r: () = Builder::new().name("owned name".to_string()).spawn(move|| {
         panic!("test");
         ()
     }).unwrap().join().unwrap();

--- a/src/test/run-fail/rt-set-exit-status-panic.rs
+++ b/src/test/run-fail/rt-set-exit-status-panic.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // error-pattern:whatever
+// error-pattern:thread '<main>' panicked at 'explicit panic'
 
 #![feature(exit_status, rustc_private)]
 

--- a/src/test/run-fail/rt-set-exit-status-panic.rs
+++ b/src/test/run-fail/rt-set-exit-status-panic.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/test/run-fail/rt-set-exit-status-panic2.rs
+++ b/src/test/run-fail/rt-set-exit-status-panic2.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 // error-pattern:whatever
+// error-pattern:thread '<main>' panicked at 'explicit panic'
 
 #![feature(exit_status, rustc_private)]
 

--- a/src/test/run-fail/rt-set-exit-status-panic2.rs
+++ b/src/test/run-fail/rt-set-exit-status-panic2.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //

--- a/src/test/run-fail/run-unexported-tests.rs
+++ b/src/test/run-fail/run-unexported-tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -9,6 +9,10 @@
 // except according to those terms.
 
 // error-pattern:runned an unexported test
+// error-pattern:failures:
+// error-pattern:    m::unexported
+// error-pattern:test result: FAILED
+// error-pattern:thread '<main>' panicked at
 // compile-flags:--test
 // check-stdout
 // ignore-pretty: does not work well with `--test`

--- a/src/test/run-fail/task-spawn-barefn.rs
+++ b/src/test/run-fail/task-spawn-barefn.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,7 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:Ensure that the child thread runs by panicking
+// error-pattern:thread '<unnamed>' panicked at 'assertion failed: "Not empty".is_empty()'
+// error-pattern:thread '<main>' panicked at 'explicit panic'
 
 use std::thread;
 
@@ -22,5 +23,7 @@ fn main() {
 }
 
 fn startfn() {
-    assert!("Ensure that the child thread runs by panicking".is_empty());
+    // Ensure that the child thread runs by panicking
+    assert!("Not empty".is_empty());
+    panic!();
 }

--- a/src/test/run-fail/test-panic.rs
+++ b/src/test/run-fail/test-panic.rs
@@ -1,4 +1,4 @@
-// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2013-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,6 +10,10 @@
 
 // check-stdout
 // error-pattern:thread 'test_foo' panicked at
+// error-pattern:failures:
+// error-pattern:    test_foo
+// error-pattern:test result: FAILED
+// error-pattern:thread '<main>' panicked at
 // compile-flags: --test
 // ignore-pretty: does not work well with `--test`
 

--- a/src/test/run-fail/test-should-fail-bad-message.rs
+++ b/src/test/run-fail/test-should-fail-bad-message.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -10,6 +10,10 @@
 
 // check-stdout
 // error-pattern:thread 'test_foo' panicked at
+// error-pattern:failures:
+// error-pattern:    test_foo
+// error-pattern:test result: FAILED
+// error-pattern:thread '<main>' panicked at
 // compile-flags: --test
 // ignore-pretty: does not work well with `--test`
 


### PR DESCRIPTION
## Background

The cause of #20692 seems to be in [middle::trait::object_safety::object_safety_violations](https://github.com/rust-lang/rust/blob/7ae4a8e9f3150f62964151ef54b3da3cd24ee123/src/librustc/middle/traits/object_safety.rs#L78-L85). The `supertrait_def_ids` call returns an iterator that iterates over trait definition ids. The iteration seems to start at the current trait and then traverse supertraits in order. For example, in the following block of code, it goes `Bar` -> `Foo` -> `Sized`:

``` rust
trait Foo: Sized { }
trait Bar: Foo { }

fn foo<T: Bar>(x: &T) {
    let _ = x as &Bar; //~ ERROR cannot convert to a trait object because trait `Bar` is not object-safe
}

fn main () {}
```

However for each trait in the hierarchy, `object_safety_violations_in_trait` gets called (in the `.flat_map()` call). Each call (all 3 of them) results in a `Self : Sized` violation since each trait in the hierarchy has `Sized` as a supertrait. That is why the above code compiles with 2 extra notes today:

```
: rustc 20692.rs
20692.rs:5:13: 5:14 error: cannot convert to a trait object because trait `Bar` is not object-safe [E0038]
20692.rs:5     let _ = x as &Bar; //~ ERROR cannot convert to a trait object because trait `Bar` is not object-safe
                       ^
20692.rs:5:13: 5:14 note: the trait cannot require that `Self : Sized`
20692.rs:5     let _ = x as &Bar; //~ ERROR cannot convert to a trait object because trait `Bar` is not object-safe
                       ^
20692.rs:5:13: 5:14 note: the trait cannot require that `Self : Sized`
20692.rs:5     let _ = x as &Bar; //~ ERROR cannot convert to a trait object because trait `Bar` is not object-safe
                       ^
20692.rs:5:13: 5:14 note: the trait cannot require that `Self : Sized`
20692.rs:5     let _ = x as &Bar; //~ ERROR cannot convert to a trait object because trait `Bar` is not object-safe
                       ^
```
## The fix

The fix I've submitted is to move the `trait_has_sized_self` check out of `object_safety_violations_in_trait` to `object_safety_violations` so it's only called once, and not for each supertrait.
## How to test?

I need help here. I don't see how to test it. This doesn't work:

``` rust
trait Foo: Sized { }
trait Bar: Foo { }

fn foo<T: Bar>(x: &T) {
    let _ = x as &Bar; //~ ERROR cannot convert to a trait object because trait `Foo` is not object-safe
                       //~^ NOTE the trait cannot require that `Self : Sized`
}

fn main() {}
```

Putting this in compile-fail passes without the fix. It seems that this doesn't try to match the number of notes exactly, so even though compilation results in 3 notes emitted today, it matches the one that is expected in the test and ignores the extra error output.

Any advice on how to test this fix?

Fixes #20692.
