### PR TITLE
Clarified naming convention for Cargo

### DIFF
--- a/src/doc/trpl/hello-cargo.md
+++ b/src/doc/trpl/hello-cargo.md
@@ -34,7 +34,7 @@ $ mv main.rs src/main.rs
 
 Note that since we're creating an executable, we used `main.rs`. If we
 want to make a library instead, we should use `lib.rs`. This convention is required
-for Cargo to successfully compile our projects. 
+for Cargo to successfully compile our projects, but it can be overridden if we wish. 
 Custom file locations for the entry point can be specified
 with a [`[[lib]]` or `[[bin]]`][crates-custom] key in the TOML file described below.
 
@@ -64,7 +64,7 @@ authors = [ "Your name <you@example.com>" ]
 ```
 
 This file is in the [TOML][toml] format. TOML is similar to INI, but has some 
-extra goodies. According to the Rust docs, 
+extra goodies. According to the TOML docs, 
 
 > TOML aims to be a minimal configuration file format that's easy to read due
 > to obvious semantics. TOML is designed to map unambiguously to a hash table.

--- a/src/doc/trpl/hello-cargo.md
+++ b/src/doc/trpl/hello-cargo.md
@@ -118,7 +118,7 @@ name = "hello_world"
 version = "0.0.1"
 ```
 
-The `Cargo.lock` is used by Cargo to keep track of dependencies in your application.
+The `Cargo.lock` file is used by Cargo to keep track of dependencies in your application.
 Right now, we don’t have any, so it’s a bit sparse. You won't ever need
 to touch this file yourself, just let Cargo handle it.
 

--- a/src/doc/trpl/hello-cargo.md
+++ b/src/doc/trpl/hello-cargo.md
@@ -33,7 +33,8 @@ $ mv main.rs src/main.rs
 ```
 
 Note that since we're creating an executable, we used `main.rs`. If we
-want to make a library instead, we should use `lib.rs`.
+want to make a library instead, we should use `lib.rs`. This convention is required
+for Cargo to successfully compile our projects. 
 Custom file locations for the entry point can be specified
 with a [`[[lib]]` or `[[bin]]`][crates-custom] key in the TOML file described below.
 

--- a/src/doc/trpl/hello-cargo.md
+++ b/src/doc/trpl/hello-cargo.md
@@ -63,18 +63,17 @@ version = "0.0.1"
 authors = [ "Your name <you@example.com>" ]
 ```
 
-This file is in the [TOML][toml] format. Let’s let it explain itself to you:
+This file is in the [TOML][toml] format. TOML is similar to INI, but has some 
+extra goodies. According to the Rust docs, 
 
 > TOML aims to be a minimal configuration file format that's easy to read due
 > to obvious semantics. TOML is designed to map unambiguously to a hash table.
 > TOML should be easy to parse into data structures in a wide variety of
 > languages.
 
-TOML is very similar to INI, but with some extra goodies.
-
 [toml]: https://github.com/toml-lang/toml
 
-Once you have this file in place, we should be ready to build! Try this:
+Once you have this file in place, we should be ready to build! To do so, run:
 
 ```bash
 $ cargo build
@@ -83,7 +82,7 @@ $ ./target/debug/hello_world
 Hello, world!
 ```
 
-Bam! We build our project with `cargo build`, and run it with
+Bam! We built our project with `cargo build`, and ran it with
 `./target/debug/hello_world`. We can do both in one step with `cargo run`:
 
 ```bash
@@ -104,9 +103,9 @@ Hello, world!
 ```
 
 This hasn’t bought us a whole lot over our simple use of `rustc`, but think
-about the future: when our project gets more complex, we would need to do more
+about the future: when our project gets more complex, we need to do more
 things to get all of the parts to properly compile. With Cargo, as our project
-grows, we can just `cargo build`, and it’ll work the right way.
+grows, we can just run `cargo build`, and it’ll work the right way.
 
 When your project is finally ready for release, you can use
 `cargo build --release` to compile your project with optimizations.
@@ -119,7 +118,7 @@ name = "hello_world"
 version = "0.0.1"
 ```
 
-This file is used by Cargo to keep track of dependencies in your application.
+The `Cargo.lock` is used by Cargo to keep track of dependencies in your application.
 Right now, we don’t have any, so it’s a bit sparse. You won't ever need
 to touch this file yourself, just let Cargo handle it.
 


### PR DESCRIPTION
Added a sentence that tells the user that using main.rs and/or lib.rs is required for Cargo.
