### PR TITLE
deprecate BitSet and BitVec

### DIFF
--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![deprecated(reason = "BitVec and BitSet have been migrated to cargo as bit-vec and bit-set",
-              since = "1.2.0")]
+              since = "1.3.0")]
 #![unstable(feature = "collections", reason = "deprecated")]
 #![allow(deprecated)]
 

--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -8,6 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![deprecated(reason = "BitVec and BitSet have been migrated to cargo as bit-vec and bit-set",
+              since = "1.2.0")]
+#![unstable(feature = "collections", reason = "deprecated")]
+#![allow(deprecated)]
+
 // FIXME(Gankro): BitVec and BitSet are very tightly coupled. Ideally (for
 // maintenance), they should be in separate files/modules, with BitSet only
 // using BitVec's public API. This will be hard for performance though, because

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -77,7 +77,9 @@ extern crate alloc;
 #[cfg(test)] extern crate test;
 
 pub use binary_heap::BinaryHeap;
+#[allow(deprecated)]
 pub use bit_vec::BitVec;
+#[allow(deprecated)]
 pub use bit_set::BitSet;
 pub use btree_map::BTreeMap;
 pub use btree_set::BTreeSet;
@@ -111,11 +113,13 @@ pub mod vec_map;
 
 #[unstable(feature = "bitvec", reason = "RFC 509")]
 pub mod bit_vec {
+    #![allow(deprecated)]
     pub use bit::{BitVec, Iter};
 }
 
 #[unstable(feature = "bitset", reason = "RFC 509")]
 pub mod bit_set {
+    #![allow(deprecated)]
     pub use bit::{BitSet, Union, Intersection, Difference, SymmetricDifference};
     pub use bit::SetIter as Iter;
 }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -28,6 +28,9 @@
 //! Use the former for unit-like structs and the latter for structs with
 //! a `pub fn new()`.
 
+// BitSet
+#![allow(deprecated)]
+
 use metadata::{csearch, decoder};
 use middle::def::*;
 use middle::mem_categorization::Typer;

--- a/src/libsyntax/attr.rs
+++ b/src/libsyntax/attr.rs
@@ -10,6 +10,9 @@
 
 // Functions dealing with attributes and meta items
 
+// BitSet
+#![allow(deprecated)]
+
 pub use self::StabilityLevel::*;
 pub use self::ReprAttr::*;
 pub use self::IntType::*;


### PR DESCRIPTION
I've mirrored them out to crates (bit-vec and bit-set) that build on stable.

(not sure if this actually correctly deprecates them in std)
