### PR TITLE
Convert playpen.js to plain JS

### DIFF
--- a/src/doc/footer.inc
+++ b/src/doc/footer.inc
@@ -5,5 +5,4 @@ or the <a href="http://opensource.org/licenses/MIT">MIT license</a>, at your opt
 </p><p>
 This file may not be copied, modified, or distributed except according to those terms.
 </p></footer>
-<script type="text/javascript" src="jquery.js"></script>
 <script type="text/javascript" src="playpen.js"></script>

--- a/src/librustdoc/html/static/playpen.js
+++ b/src/librustdoc/html/static/playpen.js
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -11,17 +11,37 @@
 /*jslint browser: true, es5: true */
 /*globals $: true, rootPath: true */
 
-(function() {
-    if (window.playgroundUrl) {
-        $('pre.rust').hover(function() {
-            var a = $('<a>').text('⇱').attr('class', 'test-arrow');
-            var code = $(this).prev(".rusttest").text();
-            a.attr('href', window.playgroundUrl + '?code=' +
-                           encodeURIComponent(code));
-            a.attr('target', '_blank');
-            $(this).append(a);
-        }, function() {
-            $(this).find('a.test-arrow').remove();
-        });
+document.addEventListener('DOMContentLoaded', function() {
+    if (!window.playgroundUrl) {
+        return;
     }
-}());
+
+    var elements = document.querySelectorAll('pre.rust');
+
+    Array.prototype.forEach.call(elements, function(el) {
+        el.onmouseover = function(e) {
+            if (el.contains(e.relatedTarget)) {
+                return;
+            }
+
+            var a = document.createElement('a');
+            a.textContent = '⇱';
+            a.setAttribute('class', 'test-arrow');
+
+            var code = el.previousElementSibling.textContent;
+            a.setAttribute('href', window.playgroundUrl + '?code=' +
+                           encodeURIComponent(code));
+            a.setAttribute('target', '_blank');
+
+            el.appendChild(a);
+        };
+
+        el.onmouseout = function(e) {
+            if (el.contains(e.relatedTarget)) {
+                return;
+            }
+
+            el.removeChild(el.querySelectorAll('a.test-arrow')[0]);
+        };
+    });
+});

--- a/src/rustbook/build.rs
+++ b/src/rustbook/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -158,10 +158,7 @@ fn render(book: &Book, tgt: &Path) -> CliResult<()> {
     // create index.html from the root README
     try!(fs::copy(&tgt.join("README.html"), &tgt.join("index.html")));
 
-    // Copy some js for playpen
-    let mut jquery = try!(File::create(tgt.join("jquery.js")));
-    let js = include_bytes!("../librustdoc/html/static/jquery-2.1.0.min.js");
-    try!(jquery.write_all(js));
+    // Copy js for playpen
     let mut playpen = try!(File::create(tgt.join("playpen.js")));
     let js = include_bytes!("../librustdoc/html/static/playpen.js");
     try!(playpen.write_all(js));

--- a/src/rustbook/javascript.rs
+++ b/src/rustbook/javascript.rs
@@ -71,6 +71,5 @@ document.addEventListener("DOMContentLoaded", function(event) {
 
 });
 </script>
-<script type="text/javascript" src="jquery.js"></script>
 <script type="text/javascript" src="playpen.js"></script>
 "#;


### PR DESCRIPTION
Since the "Book" already avoids jQuery in its inline script tags and playpen.js is tiny, I figured I would convert it to plain old JS as well.

Side note: This is a separate issue, but another thing I noticed in my testing is that the "⇱" character doesn't display correctly in Chrome on Windows 7. (Firefox and IE work fine; other browsers not tested)

r? @steveklabnik

Edit: Github didn't like the "script" tag above
Edit 2: Actually, now IE seems to render "⇱" fine for me. Odd.
