### PR TITLE
Allow nested generics for the last field of structs in unsizing.

### DIFF
--- a/src/test/run-pass/dst-coerce-rc.rs
+++ b/src/test/run-pass/dst-coerce-rc.rs
@@ -12,6 +12,7 @@
 
 #![feature(core)]
 
+use std::cell::RefCell;
 use std::rc::Rc;
 
 trait Baz {
@@ -36,4 +37,8 @@ fn main() {
     assert_eq!(b.get(), 42);
 
     let _c = b.clone();
+
+    let a: Rc<RefCell<i32>> = Rc::new(RefCell::new(42));
+    let b: Rc<RefCell<Baz>> = a.clone();
+    assert_eq!(b.borrow().get(), 42);
 }


### PR DESCRIPTION
Allows `Rc<RefCell<Trait>>` and other containers. Fixes #25351.
r? @nrc This is the discussed strategy, more or less.
