### PR TITLE
Don’t ICE if fs::canonicalise fails in meta-load

### DIFF
--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -429,13 +429,14 @@ impl<'a> Context<'a> {
             let slot = candidates.entry(hash_str)
                                  .or_insert_with(|| (HashMap::new(), HashMap::new()));
             let (ref mut rlibs, ref mut dylibs) = *slot;
-            if rlib {
-                rlibs.insert(fs::canonicalize(path).unwrap(), kind);
-            } else {
-                dylibs.insert(fs::canonicalize(path).unwrap(), kind);
-            }
-
-            FileMatches
+            fs::canonicalize(path).map(|p| {
+                if rlib {
+                    rlibs.insert(p, kind);
+                } else {
+                    dylibs.insert(p, kind);
+                }
+                FileMatches
+            }).unwrap_or(FileDoesntMatch)
         });
         self.rejected_via_kind.extend(staticlibs.into_iter());
 

--- a/src/test/run-make/issue-26006/Makefile
+++ b/src/test/run-make/issue-26006/Makefile
@@ -1,0 +1,16 @@
+-include ../tools.mk
+
+ifndef IS_WINDOWS
+all: time
+
+time: libc
+	mkdir -p out/time out/time/deps
+	ln -sf out/libc/liblibc.rlib out/time/deps/
+	$(RUSTC) in/time/lib.rs -Ldependency=out/time/deps/
+
+libc:
+	mkdir -p out/libc
+	$(RUSTC) in/libc/lib.rs --crate-name=libc -o out/libc/liblibc.rlib
+else
+all:
+endif

--- a/src/test/run-make/issue-26006/in/libc/lib.rs
+++ b/src/test/run-make/issue-26006/in/libc/lib.rs
@@ -1,0 +1,12 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![crate_type="rlib"]
+
+pub fn something(){}

--- a/src/test/run-make/issue-26006/in/time/lib.rs
+++ b/src/test/run-make/issue-26006/in/time/lib.rs
@@ -1,0 +1,13 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(libc)]
+extern crate libc;
+
+fn main(){}


### PR DESCRIPTION
This might fail when --extern library is a symlink to an invalid location. Instead just pretend it
doesn’t exist at all.

Fixes #26006
