### PR TITLE
Doc fix for process.rs

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -300,7 +300,7 @@ impl Command {
     /// Executes a command as a child process, waiting for it to finish and
     /// collecting its exit status.
     ///
-    /// By default, stdin, stdout and stderr are inherited by the parent.
+    /// By default, stdin, stdout and stderr are inherited from the parent.
     ///
     /// # Examples
     ///

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -268,7 +268,7 @@ impl Command {
 
     /// Executes the command as a child process, returning a handle to it.
     ///
-    /// By default, stdin, stdout and stderr are inherited by the parent.
+    /// By default, stdin, stdout and stderr are inherited from the parent.
     #[stable(feature = "process", since = "1.0.0")]
     pub fn spawn(&mut self) -> io::Result<Child> {
         self.spawn_inner(StdioImp::Raw(imp::Stdio::Inherit))


### PR DESCRIPTION
File handles are inherited from, not by, the parent process
