### PR TITLE
Updated Cargo.toml version number output

### DIFF
--- a/src/doc/trpl/hello-cargo.md
+++ b/src/doc/trpl/hello-cargo.md
@@ -170,7 +170,7 @@ This is all we need to get started. First, let’s check out `Cargo.toml`:
 [package]
 
 name = "hello_world"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Your Name <you@example.com>"]
 ```
 


### PR DESCRIPTION
The sensible default used here for the version number in the
auto-generated Cargo.toml is 0.1.0, not 0.0.1 (at least as of cargo
0.2.0-nightly efb482d).
