### PR TITLE
expose llvm's stack intrinsics

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -169,6 +169,21 @@ extern "rust-intrinsic" {
     /// own, or if it does not enable any significant optimizations.
     pub fn assume(b: bool);
 
+    /// Returns the current position on the stack
+    #[cfg(not(stage0))]
+    pub fn stacksave() -> *const i8;
+
+    /// Allocates `n` consecutive uninitialized values of type T on the stack
+    /// and returns a pointer to the first one
+    #[cfg(not(stage0))]
+    pub fn stackalloc<T>(n: usize) -> *mut T;
+
+    /// Restores the stack to the location at which `stacksave` was called to
+    /// obtain the StackPosition value. This is useful to erase any memory
+    /// allocated by `stackalloc`
+    #[cfg(not(stage0))]
+    pub fn stackrestore(pos: *const i8);
+
     /// Executes a breakpoint trap, for inspection by a debugger.
     pub fn breakpoint();
 

--- a/src/librustc_trans/trans/context.rs
+++ b/src/librustc_trans/trans/context.rs
@@ -567,10 +567,7 @@ impl<'b, 'tcx> CrateContext<'b, 'tcx> {
         if let Some(v) = self.intrinsics().borrow().get(key).cloned() {
             return v;
         }
-        match declare_intrinsic(self, key) {
-            Some(v) => return v,
-            None => panic!()
-        }
+        declare_intrinsic(self, key).expect(&format!("intrinsic declaration failed: {}", key))
     }
 
     pub fn is_split_stack_supported(&self) -> bool {
@@ -929,6 +926,9 @@ fn declare_intrinsic(ccx: &CrateContext, key: & &'static str) -> Option<ValueRef
 
     ifn!("llvm.expect.i1", fn(i1, i1) -> i1);
     ifn!("llvm.assume", fn(i1) -> void);
+
+    ifn!("llvm.stacksave", fn() -> i8p);
+    ifn!("llvm.stackrestore", fn(i8p) -> void);
 
     // Some intrinsics were introduced in later versions of LLVM, but they have
     // fallbacks in libc or libm and such. Currently, all of these intrinsics

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5235,6 +5235,24 @@ pub fn check_intrinsic_type(ccx: &CrateCtxt, it: &ast::ForeignItem) {
                                                                   ty::BrAnon(0))),
                                     param(ccx, 0))], tcx.types.u64),
 
+            "stackrestore" => (
+                0,
+                vec![ty::mk_imm_ptr(tcx, tcx.types.i8)],
+                ty::mk_nil(tcx),
+            ),
+
+            "stacksave" => (
+                0,
+                vec![],
+                ty::mk_imm_ptr(tcx, tcx.types.i8),
+            ),
+
+            "stackalloc" => (
+                1,
+                vec![tcx.types.usize],
+                ty::mk_mut_ptr(tcx, param(ccx, 0)),
+            ),
+
             ref other => {
                 span_err!(tcx.sess, it.span, E0093,
                     "unrecognized intrinsic function: `{}`", *other);

--- a/src/test/run-fail/stackalloc_overflow.rs
+++ b/src/test/run-fail/stackalloc_overflow.rs
@@ -1,0 +1,44 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern:out of stack while using stackalloc
+
+#![feature(core, test)]
+
+use std::intrinsics::{
+    stacksave,
+    stackalloc,
+    stackrestore,
+    size_of,
+};
+
+extern crate test;
+
+fn main() {
+    let n = std::env::args().count() + 1000000;
+    for _ in 1..100 {
+        unsafe {
+            let n = size_of::<i32>()*n;
+            let data1: *mut i32 = stackalloc(n);
+            let data2 = std::raw::Slice {
+                data: data1 as *const i32,
+                len: n,
+            };
+            let data3: &mut [i32] = std::mem::transmute(data2);
+            data3[n - 1] = 42;
+            test::black_box(data3);
+        }
+    }
+}
+
+#[no_mangle]
+pub extern fn __morestack_allocate_stack_space() {
+    panic!("out of stack while using stackalloc");
+}

--- a/src/test/run-pass/alloca.rs
+++ b/src/test/run-pass/alloca.rs
@@ -1,0 +1,44 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(core, test)]
+
+use std::intrinsics::{
+    stacksave,
+    stackalloc,
+    stackrestore,
+    size_of,
+};
+
+extern crate test;
+
+fn main() {
+    let n = std::env::args().count() + 10;
+    for _ in 1..10000 {
+        unsafe {
+            let stack = stacksave();
+            let n = size_of::<i32>()*n;
+            let data1: *mut i32 = stackalloc(n);
+            let data2 = std::raw::Slice {
+                data: data1 as *const i32,
+                len: n,
+            };
+            let data3: &mut [i32] = std::mem::transmute(data2);
+            data3[n - 1] = 42;
+            test::black_box(data3);
+            stackrestore(stack);
+        }
+    }
+}
+
+#[no_mangle]
+pub extern fn __morestack_allocate_stack_space() {
+    panic!("out of stack while using stackalloc");
+}


### PR DESCRIPTION
while I was doing this I found loads of dead code like the `ArrayAlloca` function. Does it make sense to remove such functions or should we just wait until someone implements code coverage testing for rustc and does this properly?
