### PR TITLE
rustbook: fix path in toc links

### DIFF
--- a/src/rustbook/build.rs
+++ b/src/rustbook/build.rs
@@ -59,7 +59,7 @@ fn write_toc(book: &Book, current_page: &BookItem, out: &mut Write) -> io::Resul
 
         try!(writeln!(out, "<li><a {} href='{}'><b>{}</b> {}</a>",
                  class_string,
-                 item.path_to_root.join(&item.path.with_extension("html")).display(),
+                 current_page.path_to_root.join(&item.path).with_extension("html").display(),
                  section,
                  item.title));
         if !item.children.is_empty() {


### PR DESCRIPTION
Case: 
Russian translate of trpl use this structure:

``` bash
rust_book_ru $ tree
.
├── README.md
├── src
│   ├── academic-research.md
...
└── SUMMARY.md
```

Links in table of content generated relative to the root dir, for example if i'm on the page `http://kgv.github.io/rust_book_ru/src/academic-research.html` link to README.html will be `http://kgv.github.io/rust_book_ru/src/README.html`, not `http://kgv.github.io/rust_book_ru/README.html`.
Now we use old version of rustbook.
Sorry for my english
