### PR TITLE
Clear cached landing pads before generating a call.

### DIFF
--- a/src/librustc_trans/trans/cleanup.rs
+++ b/src/librustc_trans/trans/cleanup.rs
@@ -954,8 +954,15 @@ impl<'blk, 'tcx> CleanupScope<'blk, 'tcx> {
         }
     }
 
+    /// Manipulate cleanup scope for call arguments. Conceptually, each
+    /// argument to a call is an lvalue, and performing the call moves each
+    /// of the arguments into a new rvalue (which gets cleaned up by the
+    /// callee). As an optimization, instead of actually performing all of
+    /// those moves, trans just manipulates the cleanup scope to obtain the
+    /// same effect.
     pub fn drop_non_lifetime_clean(&mut self) {
         self.cleanups.retain(|c| c.is_lifetime_end());
+        self.clear_cached_exits();
     }
 }
 

--- a/src/test/run-pass/issue-25089.rs
+++ b/src/test/run-pass/issue-25089.rs
@@ -1,0 +1,40 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::thread;
+
+struct Foo(i32);
+
+impl Drop for Foo {
+    fn drop(&mut self) {
+        static mut DROPPED: bool = false;
+        unsafe {
+            assert!(!DROPPED);
+            DROPPED = true;
+        }
+    }
+}
+
+struct Empty;
+
+fn empty() -> Empty { Empty }
+
+fn should_panic(_: Foo, _: Empty) {
+    panic!("test panic");
+}
+
+fn test() {
+    should_panic(Foo(1), empty());
+}
+
+fn main() {
+    let ret = thread::spawn(test).join();
+    assert!(ret.is_err());
+}


### PR DESCRIPTION
Using the wrong landing pad has obvious bad effects, like dropping a value
twice.

Testcase written by Alex Crichton.

Fixes #25089.
