### PR TITLE
Use `assert_eq!` instead of `assert!` in tests

### DIFF
--- a/src/test/auxiliary/extern_calling_convention.rs
+++ b/src/test/auxiliary/extern_calling_convention.rs
@@ -14,10 +14,10 @@
 #[inline(never)]
 #[cfg(target_arch = "x86_64")]
 pub extern "win64" fn foo(a: isize, b: isize, c: isize, d: isize) {
-    assert!(a == 1);
-    assert!(b == 2);
-    assert!(c == 3);
-    assert!(d == 4);
+    assert_eq!(a, 1);
+    assert_eq!(b, 2);
+    assert_eq!(c, 3);
+    assert_eq!(d, 4);
 
     println!("a: {}, b: {}, c: {}, d: {}",
              a, b, c, d)
@@ -26,10 +26,10 @@ pub extern "win64" fn foo(a: isize, b: isize, c: isize, d: isize) {
 #[inline(never)]
 #[cfg(any(target_arch = "x86", target_arch = "arm", target_arch = "aarch64"))]
 pub extern fn foo(a: isize, b: isize, c: isize, d: isize) {
-    assert!(a == 1);
-    assert!(b == 2);
-    assert!(c == 3);
-    assert!(d == 4);
+    assert_eq!(a, 1);
+    assert_eq!(b, 2);
+    assert_eq!(c, 3);
+    assert_eq!(d, 4);
 
     println!("a: {}, b: {}, c: {}, d: {}",
              a, b, c, d)

--- a/src/test/bench/shootout-mandelbrot.rs
+++ b/src/test/bench/shootout-mandelbrot.rs
@@ -54,7 +54,7 @@ const LIMIT: f64 = 2.0;
 const WORKERS: usize = 16;
 
 fn mandelbrot<W: Write>(w: usize, mut out: W) -> io::Result<()> {
-    assert!(WORKERS % 2 == 0);
+    assert_eq!(WORKERS % 2, 0);
 
     // Ensure w and h are multiples of 8.
     let w = (w + 7) / 8 * 8;
@@ -76,7 +76,7 @@ fn mandelbrot<W: Write>(w: usize, mut out: W) -> io::Result<()> {
     let v_consts = f64x2(1.5, 1.0);
 
     // A lot of this code assumes this (so do other lang benchmarks)
-    assert!(w == h);
+    assert_eq!(w, h);
     let mut precalc_r = Vec::with_capacity(w);
     let mut precalc_i = Vec::with_capacity(h);
 

--- a/src/test/compile-fail/builtin-superkinds-self-type.rs
+++ b/src/test/compile-fail/builtin-superkinds-self-type.rs
@@ -23,5 +23,5 @@ impl <T: Sync> Foo for T { }
 fn main() {
     let (tx, rx) = channel();
     1193182.foo(tx);
-    assert!(rx.recv() == 1193182);
+    assert_eq!(rx.recv(), 1193182);
 }

--- a/src/test/compile-fail/match-static-const-lc.rs
+++ b/src/test/compile-fail/match-static-const-lc.rs
@@ -22,7 +22,7 @@ fn f() {
         //~^ ERROR constant in pattern `a` should have an upper case name such as `A`
         (x, y) => 1 + x + y,
     };
-    assert!(r == 1);
+    assert_eq!(r, 1);
 }
 
 mod m {
@@ -37,7 +37,7 @@ fn g() {
         //~^ ERROR constant in pattern `aha` should have an upper case name such as `AHA`
         (x, y)   => 1 + x + y,
     };
-    assert!(r == 1);
+    assert_eq!(r, 1);
 }
 
 mod n {
@@ -51,7 +51,7 @@ fn h() {
 //~^ ERROR constant in pattern `not_okay` should have an upper case name such as `NOT_OKAY`
         (x, y)   => 1 + x + y,
     };
-    assert!(r == 1);
+    assert_eq!(r, 1);
 }
 
 fn main () {

--- a/src/test/compile-fail/mod_file_correct_spans.rs
+++ b/src/test/compile-fail/mod_file_correct_spans.rs
@@ -13,5 +13,5 @@
 mod mod_file_aux;
 
 fn main() {
-    assert!(mod_file_aux::bar() == 10); //~ ERROR unresolved name
+    assert_eq!(mod_file_aux::bar(), 10); //~ ERROR unresolved name
 }

--- a/src/test/compile-fail/private-struct-field-cross-crate.rs
+++ b/src/test/compile-fail/private-struct-field-cross-crate.rs
@@ -14,6 +14,6 @@ use cci_class::kitties::cat;
 
 fn main() {
   let nyan : cat = cat(52, 99);
-  assert!((nyan.meows == 52));
+  assert_eq!(nyan.meows, 52);
   //~^ ERROR field `meows` of struct `cci_class::kitties::cat` is private
 }

--- a/src/test/compile-fail/private-struct-field.rs
+++ b/src/test/compile-fail/private-struct-field.rs
@@ -20,5 +20,5 @@ mod cat {
 
 fn main() {
     let nyan = cat::new_cat();
-    assert!(nyan.meows == 52);    //~ ERROR field `meows` of struct `cat::Cat` is private
+    assert_eq!(nyan.meows, 52);    //~ ERROR field `meows` of struct `cat::Cat` is private
 }

--- a/src/test/compile-fail/syntax-extension-minor.rs
+++ b/src/test/compile-fail/syntax-extension-minor.rs
@@ -17,6 +17,5 @@ pub fn main() {
     assert_eq!(concat_idents!(asd, f_f, dsa), "<.<".to_string());
     //~^ ERROR: unresolved name `asdf_fdsa`
 
-    assert!(stringify!(use_mention_distinction) ==
-                "use_mention_distinction");
+    assert_eq!(stringify!(use_mention_distinction), "use_mention_distinction");
 }

--- a/src/test/parse-fail/macros-no-semicolon.rs
+++ b/src/test/parse-fail/macros-no-semicolon.rs
@@ -11,7 +11,7 @@
 // compile-flags: -Z parse-only
 
 fn main() {
-    assert!(1 == 2)
-    assert!(3 == 4) //~ ERROR expected one of `.`, `;`, `}`, or an operator, found `assert`
+    assert_eq!(1, 2)
+    assert_eq!(3, 4) //~ ERROR expected one of `.`, `;`, `}`, or an operator, found `assert_eq`
     println!("hello");
 }

--- a/src/test/pretty/do1.rs
+++ b/src/test/pretty/do1.rs
@@ -12,4 +12,4 @@
 
 fn f<F>(f: F) where F: Fn(isize) { f(10) }
 
-fn main() { f(|i| { assert!(i == 10) }) }
+fn main() { f(|i| { assert_eq!(i , 10) }) }

--- a/src/test/run-fail/panic.rs
+++ b/src/test/run-fail/panic.rs
@@ -9,4 +9,4 @@
 // except according to those terms.
 
 // error-pattern:1 == 2
-fn main() { assert!((1 == 2)); }
+fn main() { assert!(1 == 2); }

--- a/src/test/run-make/extern-flag-disambiguates/d.rs
+++ b/src/test/run-make/extern-flag-disambiguates/d.rs
@@ -16,6 +16,6 @@ extern crate c;
 fn t(a: &'static usize) -> usize { a as *const _ as usize }
 
 fn main() {
-    assert!(t(a::token()) == t(b::a_token()));
+    assert_eq!(t(a::token()), t(b::a_token()));
     assert!(t(a::token()) != t(c::a_token()));
 }

--- a/src/test/run-make/static-unwinding/main.rs
+++ b/src/test/run-make/static-unwinding/main.rs
@@ -28,7 +28,7 @@ fn main() {
     }).join().err().unwrap();
 
     unsafe {
-        assert!(lib::statik == 1);
-        assert!(statik == 1);
+        assert_eq!(lib::statik, 1);
+        assert_eq!(statik, 1);
     }
 }

--- a/src/test/run-pass-fulldeps/compiler-calls.rs
+++ b/src/test/run-pass-fulldeps/compiler-calls.rs
@@ -78,5 +78,5 @@ fn main() {
     // we should never get use this filename, but lets make sure they are valid args.
     let args = vec!["compiler-calls".to_string(), "foo.rs".to_string()];
     rustc_driver::run_compiler(&args, &mut tc);
-    assert!(tc.count == 30);
+    assert_eq!(tc.count, 30);
 }

--- a/src/test/run-pass-valgrind/dst-dtor-2.rs
+++ b/src/test/run-pass-valgrind/dst-dtor-2.rs
@@ -27,6 +27,6 @@ pub fn main() {
         let _x: Box<Fat<[Foo]>> = Box::<Fat<[Foo; 3]>>::new(Fat { f: [Foo, Foo, Foo] });
     }
     unsafe {
-        assert!(DROP_RAN == 3);
+        assert_eq!(DROP_RAN, 3);
     }
 }

--- a/src/test/run-pass/arith-2.rs
+++ b/src/test/run-pass/arith-2.rs
@@ -13,6 +13,6 @@
 
 pub fn main() {
     let i32_c: isize = 0x10101010;
-    assert!(i32_c + i32_c * 2 / 3 * 2 + (i32_c - 7 % 3) ==
+    assert_eq!(i32_c + i32_c * 2 / 3 * 2 + (i32_c - 7 % 3),
                  i32_c + i32_c * 2 / 3 * 2 + (i32_c - 7 % 3));
 }

--- a/src/test/run-pass/artificial-block.rs
+++ b/src/test/run-pass/artificial-block.rs
@@ -11,4 +11,4 @@
 
 fn f() -> isize { { return 3; } }
 
-pub fn main() { assert!((f() == 3)); }
+pub fn main() { assert_eq!(f(), 3); }

--- a/src/test/run-pass/assignability-trait.rs
+++ b/src/test/run-pass/assignability-trait.rs
@@ -43,7 +43,7 @@ fn length<A, T: iterable<A>>(x: T) -> usize {
 pub fn main() {
     let x: Vec<isize> = vec!(0,1,2,3);
     // Call a method
-    x.iterate(|y| { assert!(x[*y as usize] == *y); true });
+    x.iterate(|y| { assert_eq!(x[*y as usize], *y); true });
     // Call a parameterized function
     assert_eq!(length(x.clone()), x.len());
     // Call a parameterized function, with type arguments that require

--- a/src/test/run-pass/associated-types-return.rs
+++ b/src/test/run-pass/associated-types-return.rs
@@ -16,7 +16,7 @@ pub trait Foo {
     fn boo(&self) -> <Self as Foo>::A;
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 pub struct Bar;
 
 impl Foo for isize {
@@ -44,12 +44,12 @@ fn foo2<I: Foo>(x: I) -> <I as Foo>::A {
 
 pub fn main() {
     let a = 42;
-    assert!(foo2(a) == 42);
+    assert_eq!(foo2(a), 42);
 
     let a = Bar;
-    assert!(foo2(a) == 43);
+    assert_eq!(foo2(a), 43);
 
     let a = 'a';
     foo1(a);
-    assert!(foo2(a) == Bar);
+    assert_eq!(foo2(a), Bar);
 }

--- a/src/test/run-pass/bool.rs
+++ b/src/test/run-pass/bool.rs
@@ -74,8 +74,8 @@ fn main() {
     assert!(true >= false);
     assert!(!(true <= false));
 
-    assert!(true.cmp(&true) == Equal);
-    assert!(false.cmp(&false) == Equal);
-    assert!(true.cmp(&false) == Greater);
-    assert!(false.cmp(&true) == Less);
+    assert_eq!(true.cmp(&true), Equal);
+    assert_eq!(false.cmp(&false), Equal);
+    assert_eq!(true.cmp(&false), Greater);
+    assert_eq!(false.cmp(&true), Less);
 }

--- a/src/test/run-pass/builtin-superkinds-capabilities-transitive.rs
+++ b/src/test/run-pass/builtin-superkinds-capabilities-transitive.rs
@@ -30,5 +30,5 @@ fn foo<T: Foo + 'static>(val: T, chan: Sender<T>) {
 pub fn main() {
     let (tx, rx) = channel();
     foo(31337, tx);
-    assert!(rx.recv().unwrap() == 31337);
+    assert_eq!(rx.recv().unwrap(), 31337);
 }

--- a/src/test/run-pass/builtin-superkinds-capabilities-xc.rs
+++ b/src/test/run-pass/builtin-superkinds-capabilities-xc.rs
@@ -20,7 +20,7 @@ extern crate trait_superkinds_in_metadata;
 use std::sync::mpsc::{channel, Sender, Receiver};
 use trait_superkinds_in_metadata::{RequiresRequiresShareAndSend, RequiresShare};
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 struct X<T>(T);
 
 impl <T: Sync> RequiresShare for X<T> { }
@@ -33,5 +33,5 @@ fn foo<T: RequiresRequiresShareAndSend + 'static>(val: T, chan: Sender<T>) {
 pub fn main() {
     let (tx, rx): (Sender<X<isize>>, Receiver<X<isize>>) = channel();
     foo(X(31337), tx);
-    assert!(rx.recv().unwrap() == X(31337));
+    assert_eq!(rx.recv().unwrap(), X(31337));
 }

--- a/src/test/run-pass/builtin-superkinds-capabilities.rs
+++ b/src/test/run-pass/builtin-superkinds-capabilities.rs
@@ -26,5 +26,5 @@ fn foo<T: Foo + 'static>(val: T, chan: Sender<T>) {
 pub fn main() {
     let (tx, rx): (Sender<isize>, Receiver<isize>) = channel();
     foo(31337, tx);
-    assert!(rx.recv().unwrap() == 31337);
+    assert_eq!(rx.recv().unwrap(), 31337);
 }

--- a/src/test/run-pass/builtin-superkinds-self-type.rs
+++ b/src/test/run-pass/builtin-superkinds-self-type.rs
@@ -25,5 +25,5 @@ impl <T: Send + 'static> Foo for T { }
 pub fn main() {
     let (tx, rx) = channel();
     1193182.foo(tx);
-    assert!(rx.recv().unwrap() == 1193182);
+    assert_eq!(rx.recv().unwrap(), 1193182);
 }

--- a/src/test/run-pass/c-stack-returning-int64.rs
+++ b/src/test/run-pass/c-stack-returning-int64.rs
@@ -37,6 +37,6 @@ fn atoll(s: String) -> i64 {
 
 pub fn main() {
     assert_eq!(atol("1024".to_string()) * 10, atol("10240".to_string()));
-    assert!((atoll("11111111111111111".to_string()) * 10) ==
+    assert_eq!((atoll("11111111111111111".to_string()) * 10),
              atoll("111111111111111110".to_string()));
 }

--- a/src/test/run-pass/cci_impl_exe.rs
+++ b/src/test/run-pass/cci_impl_exe.rs
@@ -22,6 +22,6 @@ pub fn main() {
 
         //let bt1 = sys::frame_address();
         //println!("%?", bt1);
-        //assert!(bt0 == bt1);
+        //assert_eq!(bt0, bt1);
     })
 }

--- a/src/test/run-pass/cci_iter_exe.rs
+++ b/src/test/run-pass/cci_iter_exe.rs
@@ -17,6 +17,6 @@ pub fn main() {
     //println!("%?", bt0);
     cci_iter_lib::iter(&[1, 2, 3], |i| {
         println!("{}", *i);
-        //assert!(bt0 == sys::rusti::frame_address(2));
+        //assert_eq!(bt0, sys::rusti::frame_address(2));
     })
 }

--- a/src/test/run-pass/check-static-slice.rs
+++ b/src/test/run-pass/check-static-slice.rs
@@ -28,14 +28,14 @@ static cf: isize = af[2];
 
 fn main () {
     let b: &[isize] = &[1, 2, 3];
-    assert!(ac == b);
-    assert!(ad == b);
-    assert!(af == b);
+    assert_eq!(ac, b);
+    assert_eq!(ad, b);
+    assert_eq!(af, b);
 
-    assert!(ca == 1);
-    assert!(cb == 2);
-    assert!(cc == 3);
-    assert!(cd == 1);
-    assert!(ce == 2);
-    assert!(cf == 3);
+    assert_eq!(ca, 1);
+    assert_eq!(cb, 2);
+    assert_eq!(cc, 3);
+    assert_eq!(cd, 1);
+    assert_eq!(ce, 2);
+    assert_eq!(cf, 3);
 }

--- a/src/test/run-pass/class-impl-very-parameterized-trait.rs
+++ b/src/test/run-pass/class-impl-very-parameterized-trait.rs
@@ -104,7 +104,7 @@ impl<T> cat<T> {
 pub fn main() {
     let mut nyan: cat<String> = cat::new(0, 2, "nyan".to_string());
     for _ in 1_usize..5 { nyan.speak(); }
-    assert!(*nyan.find(&1).unwrap() == "nyan".to_string());
+    assert_eq!(*nyan.find(&1).unwrap(), "nyan".to_string());
     assert_eq!(nyan.find(&10), None);
     let mut spotty: cat<cat_type> = cat::new(2, 57, cat_type::tuxedo);
     for _ in 0_usize..6 { spotty.speak(); }

--- a/src/test/run-pass/cmp-default.rs
+++ b/src/test/run-pass/cmp-default.rs
@@ -13,6 +13,7 @@ use std::cmp::Ordering;
 
 // Test default methods in PartialOrd and PartialEq
 //
+#[derive(Debug)]
 struct Fool(bool);
 
 impl PartialEq for Fool {
@@ -74,8 +75,8 @@ pub fn main() {
     assert!(RevInt(1) >= RevInt(2));
     assert!(RevInt(1) >= RevInt(1));
 
-    assert!(Fool(true)  == Fool(false));
+    assert_eq!(Fool(true), Fool(false));
     assert!(Fool(true)  != Fool(true));
     assert!(Fool(false) != Fool(false));
-    assert!(Fool(false) == Fool(true));
+    assert_eq!(Fool(false), Fool(true));
 }

--- a/src/test/run-pass/const-big-enum.rs
+++ b/src/test/run-pass/const-big-enum.rs
@@ -23,7 +23,7 @@ pub fn main() {
         _ => panic!()
     }
     match Y {
-        Foo::Bar(s) => assert!(s == 2654435769),
+        Foo::Bar(s) => assert_eq!(s, 2654435769),
         _ => panic!()
     }
     match Z {

--- a/src/test/run-pass/const-enum-structlike.rs
+++ b/src/test/run-pass/const-enum-structlike.rs
@@ -19,6 +19,6 @@ static C: E = E::S1 { u: 23 };
 pub fn main() {
     match C {
         E::S0 { .. } => panic!(),
-        E::S1 { u } => assert!(u == 23)
+        E::S1 { u } => assert_eq!(u, 23)
     }
 }

--- a/src/test/run-pass/const-enum-vec-index.rs
+++ b/src/test/run-pass/const-enum-vec-index.rs
@@ -23,7 +23,7 @@ pub fn main() {
         _ => panic!()
     }
     match C1 {
-        E::V1(n) => assert!(n == 0xDEADBEE),
+        E::V1(n) => assert_eq!(n, 0xDEADBEE),
         _ => panic!()
     }
 
@@ -32,7 +32,7 @@ pub fn main() {
         _ => panic!()
     }
     match D1 {
-        E::V1(n) => assert!(n == 0xDEADBEE),
+        E::V1(n) => assert_eq!(n, 0xDEADBEE),
         _ => panic!()
     }
 }

--- a/src/test/run-pass/const-enum-vec-ptr.rs
+++ b/src/test/run-pass/const-enum-vec-ptr.rs
@@ -14,7 +14,7 @@ static C: &'static [E] = &[E::V0, E::V1(0xDEADBEE), E::V0];
 
 pub fn main() {
     match C[1] {
-        E::V1(n) => assert!(n == 0xDEADBEE),
+        E::V1(n) => assert_eq!(n, 0xDEADBEE),
         _ => panic!()
     }
     match C[2] {

--- a/src/test/run-pass/const-enum-vector.rs
+++ b/src/test/run-pass/const-enum-vector.rs
@@ -14,7 +14,7 @@ static C: [E; 3] = [E::V0, E::V1(0xDEADBEE), E::V0];
 
 pub fn main() {
     match C[1] {
-        E::V1(n) => assert!(n == 0xDEADBEE),
+        E::V1(n) => assert_eq!(n, 0xDEADBEE),
         _ => panic!()
     }
     match C[2] {

--- a/src/test/run-pass/const-str-ptr.rs
+++ b/src/test/run-pass/const-str-ptr.rs
@@ -19,7 +19,7 @@ pub fn main() {
     unsafe {
         let foo = &A as *const u8;
         assert_eq!(str::from_utf8_unchecked(&A), "hi");
-        assert!(*C == A[0]);
-        assert!(*(&B[0] as *const u8) == A[0]);
+        assert_eq!(*C, A[0]);
+        assert_eq!(*(&B[0] as *const u8), A[0]);
     }
 }

--- a/src/test/run-pass/deep.rs
+++ b/src/test/run-pass/deep.rs
@@ -16,4 +16,4 @@ fn f(x: isize) -> isize {
     if x == 1 { return 1; } else { let y: isize = 1 + f(x - 1); return y; }
 }
 
-pub fn main() { assert!((f(5000) == 5000)); }
+pub fn main() { assert_eq!(f(5000), 5000); }

--- a/src/test/run-pass/deref-rc.rs
+++ b/src/test/run-pass/deref-rc.rs
@@ -13,5 +13,5 @@ use std::rc::Rc;
 
 fn main() {
     let x = Rc::new([1, 2, 3, 4]);
-    assert!(*x == [1, 2, 3, 4]);
+    assert_eq!(*x, [1, 2, 3, 4]);
 }

--- a/src/test/run-pass/deriving-encodable-decodable-box.rs
+++ b/src/test/run-pass/deriving-encodable-decodable-box.rs
@@ -28,5 +28,5 @@ fn main() {
     let obj = A { foo: Box::new([true, false]) };
     let s = json::encode(&obj).unwrap();
     let obj2: A = json::decode(&s).unwrap();
-    assert!(obj.foo == obj2.foo);
+    assert_eq!(obj.foo, obj2.foo);
 }

--- a/src/test/run-pass/deriving-encodable-decodable-cell-refcell.rs
+++ b/src/test/run-pass/deriving-encodable-decodable-cell-refcell.rs
@@ -38,6 +38,6 @@ fn main() {
     };
     let s = json::encode(&obj).unwrap();
     let obj2: B = json::decode(&s).unwrap();
-    assert!(obj.foo.get() == obj2.foo.get());
-    assert!(obj.bar.borrow().baz == obj2.bar.borrow().baz);
+    assert_eq!(obj.foo.get(), obj2.foo.get());
+    assert_eq!(obj.bar.borrow().baz, obj2.bar.borrow().baz);
 }

--- a/src/test/run-pass/deriving-eq-ord-boxed-slice.rs
+++ b/src/test/run-pass/deriving-eq-ord-boxed-slice.rs
@@ -8,14 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[derive(PartialEq, PartialOrd, Eq, Ord)]
+#[derive(PartialEq, PartialOrd, Eq, Ord, Debug)]
 struct Foo(Box<[u8]>);
 
 pub fn main() {
     // FIXME (#22405): Replace `Box::new` with `box` here when/if possible.
     let a = Foo(Box::new([0, 1, 2]));
     let b = Foo(Box::new([0, 1, 2]));
-    assert!(a == b);
+    assert_eq!(a, b);
     println!("{}", a != b);
     println!("{}", a < b);
     println!("{}", a <= b);

--- a/src/test/run-pass/deriving-hash.rs
+++ b/src/test/run-pass/deriving-hash.rs
@@ -35,6 +35,6 @@ fn main() {
         name: "Bob".to_string(),
         phone: 555_666_7777
     };
-    assert!(hash(&person1) == hash(&person1));
+    assert_eq!(hash(&person1), hash(&person1));
     assert!(hash(&person1) != hash(&person2));
 }

--- a/src/test/run-pass/deriving-via-extension-struct-tuple.rs
+++ b/src/test/run-pass/deriving-via-extension-struct-tuple.rs
@@ -16,8 +16,8 @@ pub fn main() {
   let a2 = Foo(5, 6, "abc".to_string());
   let b = Foo(5, 7, "def".to_string());
 
-  assert!(a1 == a1);
-  assert!(a2 == a1);
+  assert_eq!(a1, a1);
+  assert_eq!(a2, a1);
   assert!(!(a1 == b));
 
   assert!(a1 != b);

--- a/src/test/run-pass/dst-deref-mut.rs
+++ b/src/test/run-pass/dst-deref-mut.rs
@@ -33,9 +33,9 @@ impl DerefMut for Arr {
 
 pub fn foo(arr: &mut Arr) {
     let x: &mut [usize] = &mut **arr;
-    assert!(x[0] == 1);
-    assert!(x[1] == 2);
-    assert!(x[2] == 3);
+    assert_eq!(x[0], 1);
+    assert_eq!(x[1], 2);
+    assert_eq!(x[2], 3);
 }
 
 fn main() {

--- a/src/test/run-pass/dst-deref.rs
+++ b/src/test/run-pass/dst-deref.rs
@@ -26,11 +26,11 @@ impl Deref for Arr {
 }
 
 pub fn foo(arr: &Arr) {
-    assert!(arr.len() == 3);
+    assert_eq!(arr.len(), 3);
     let x: &[usize] = &**arr;
-    assert!(x[0] == 1);
-    assert!(x[1] == 2);
-    assert!(x[2] == 3);
+    assert_eq!(x[0], 1);
+    assert_eq!(x[1], 2);
+    assert_eq!(x[2], 3);
 }
 
 fn main() {

--- a/src/test/run-pass/dst-raw.rs
+++ b/src/test/run-pass/dst-raw.rs
@@ -35,7 +35,7 @@ pub fn main() {
     let r = unsafe {
         (&*z).foo()
     };
-    assert!(r == 42);
+    assert_eq!(r, 42);
 
     // raw DST struct
     let p = Foo {f: A { f: 42 }};
@@ -43,33 +43,33 @@ pub fn main() {
     let r = unsafe {
         (&*o).f.foo()
     };
-    assert!(r == 42);
+    assert_eq!(r, 42);
 
     // raw slice
     let a: *const [_] = &[1, 2, 3];
     unsafe {
         let b = (*a)[2];
-        assert!(b == 3);
+        assert_eq!(b, 3);
         let len = (*a).len();
-        assert!(len == 3);
+        assert_eq!(len, 3);
     }
 
     // raw slice with explicit cast
     let a = &[1, 2, 3] as *const [i32];
     unsafe {
         let b = (*a)[2];
-        assert!(b == 3);
+        assert_eq!(b, 3);
         let len = (*a).len();
-        assert!(len == 3);
+        assert_eq!(len, 3);
     }
 
     // raw DST struct with slice
     let c: *const Foo<[_]> = &Foo {f: [1, 2, 3]};
     unsafe {
         let b = (&*c).f[0];
-        assert!(b == 1);
+        assert_eq!(b, 1);
         let len = (&*c).f.len();
-        assert!(len == 3);
+        assert_eq!(len, 3);
     }
 
     // all of the above with *mut
@@ -78,36 +78,36 @@ pub fn main() {
     let r = unsafe {
         (&*z).foo()
     };
-    assert!(r == 42);
+    assert_eq!(r, 42);
 
     let mut p = Foo {f: A { f: 42 }};
     let o: *mut Foo<Trait> = &mut p;
     let r = unsafe {
         (&*o).f.foo()
     };
-    assert!(r == 42);
+    assert_eq!(r, 42);
 
     let a: *mut [_] = &mut [1, 2, 3];
     unsafe {
         let b = (*a)[2];
-        assert!(b == 3);
+        assert_eq!(b, 3);
         let len = (*a).len();
-        assert!(len == 3);
+        assert_eq!(len, 3);
     }
 
     let a = &mut [1, 2, 3] as *mut [i32];
     unsafe {
         let b = (*a)[2];
-        assert!(b == 3);
+        assert_eq!(b, 3);
         let len = (*a).len();
-        assert!(len == 3);
+        assert_eq!(len, 3);
     }
 
     let c: *mut Foo<[_]> = &mut Foo {f: [1, 2, 3]};
     unsafe {
         let b = (&*c).f[0];
-        assert!(b == 1);
+        assert_eq!(b, 1);
         let len = (&*c).f.len();
-        assert!(len == 3);
+        assert_eq!(len, 3);
     }
 }

--- a/src/test/run-pass/dst-struct-sole.rs
+++ b/src/test/run-pass/dst-struct-sole.rs
@@ -18,20 +18,20 @@ struct Fat<T: ?Sized> {
 // x is a fat pointer
 fn foo(x: &Fat<[isize]>) {
     let y = &x.ptr;
-    assert!(x.ptr.len() == 3);
-    assert!(y[0] == 1);
-    assert!(x.ptr[1] == 2);
+    assert_eq!(x.ptr.len(), 3);
+    assert_eq!(y[0], 1);
+    assert_eq!(x.ptr[1], 2);
 }
 
 fn foo2<T:ToBar>(x: &Fat<[T]>) {
     let y = &x.ptr;
     let bar = Bar;
-    assert!(x.ptr.len() == 3);
-    assert!(y[0].to_bar() == bar);
-    assert!(x.ptr[1].to_bar() == bar);
+    assert_eq!(x.ptr.len(), 3);
+    assert_eq!(y[0].to_bar(), bar);
+    assert_eq!(x.ptr[1].to_bar(), bar);
 }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 struct Bar;
 
 trait ToBar {
@@ -73,9 +73,9 @@ pub fn main() {
     // Assignment.
     let f5: &mut Fat<[isize]> = &mut Fat { ptr: [1, 2, 3] };
     f5.ptr[1] = 34;
-    assert!(f5.ptr[0] == 1);
-    assert!(f5.ptr[1] == 34);
-    assert!(f5.ptr[2] == 3);
+    assert_eq!(f5.ptr[0], 1);
+    assert_eq!(f5.ptr[1], 34);
+    assert_eq!(f5.ptr[2], 3);
 
     // Zero size vec.
     let f5: &Fat<[isize]> = &Fat { ptr: [] };

--- a/src/test/run-pass/dst-struct.rs
+++ b/src/test/run-pass/dst-struct.rs
@@ -21,36 +21,36 @@ struct Fat<T: ?Sized> {
 // x is a fat pointer
 fn foo(x: &Fat<[isize]>) {
     let y = &x.ptr;
-    assert!(x.ptr.len() == 3);
-    assert!(y[0] == 1);
-    assert!(x.ptr[1] == 2);
-    assert!(x.f1 == 5);
-    assert!(x.f2 == "some str");
+    assert_eq!(x.ptr.len(), 3);
+    assert_eq!(y[0], 1);
+    assert_eq!(x.ptr[1], 2);
+    assert_eq!(x.f1, 5);
+    assert_eq!(x.f2, "some str");
 }
 
 fn foo2<T:ToBar>(x: &Fat<[T]>) {
     let y = &x.ptr;
     let bar = Bar;
-    assert!(x.ptr.len() == 3);
-    assert!(y[0].to_bar() == bar);
-    assert!(x.ptr[1].to_bar() == bar);
-    assert!(x.f1 == 5);
-    assert!(x.f2 == "some str");
+    assert_eq!(x.ptr.len(), 3);
+    assert_eq!(y[0].to_bar(), bar);
+    assert_eq!(x.ptr[1].to_bar(), bar);
+    assert_eq!(x.f1, 5);
+    assert_eq!(x.f2, "some str");
 }
 
 fn foo3(x: &Fat<Fat<[isize]>>) {
     let y = &x.ptr.ptr;
-    assert!(x.f1 == 5);
-    assert!(x.f2 == "some str");
-    assert!(x.ptr.f1 == 8);
-    assert!(x.ptr.f2 == "deep str");
-    assert!(x.ptr.ptr.len() == 3);
-    assert!(y[0] == 1);
-    assert!(x.ptr.ptr[1] == 2);
+    assert_eq!(x.f1, 5);
+    assert_eq!(x.f2, "some str");
+    assert_eq!(x.ptr.f1, 8);
+    assert_eq!(x.ptr.f2, "deep str");
+    assert_eq!(x.ptr.ptr.len(), 3);
+    assert_eq!(y[0], 1);
+    assert_eq!(x.ptr.ptr[1], 2);
 }
 
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 struct Bar;
 
 trait ToBar {
@@ -92,9 +92,9 @@ pub fn main() {
     // Assignment.
     let f5: &mut Fat<[isize]> = &mut Fat { f1: 5, f2: "some str", ptr: [1, 2, 3] };
     f5.ptr[1] = 34;
-    assert!(f5.ptr[0] == 1);
-    assert!(f5.ptr[1] == 34);
-    assert!(f5.ptr[2] == 3);
+    assert_eq!(f5.ptr[0], 1);
+    assert_eq!(f5.ptr[1], 34);
+    assert_eq!(f5.ptr[2], 3);
 
     // Zero size vec.
     let f5: &Fat<[isize]> = &Fat { f1: 5, f2: "some str", ptr: [] };
@@ -117,9 +117,9 @@ pub fn main() {
 
     // Box.
     let f1 = Box::new([1, 2, 3]);
-    assert!((*f1)[1] == 2);
+    assert_eq!((*f1)[1], 2);
     let f2: Box<[isize]> = f1;
-    assert!((*f2)[1] == 2);
+    assert_eq!((*f2)[1], 2);
 
     // Nested Box.
     let f1 : Box<Fat<[isize; 3]>> = box Fat { f1: 5, f2: "some str", ptr: [1, 2, 3] };

--- a/src/test/run-pass/dst-trait.rs
+++ b/src/test/run-pass/dst-trait.rs
@@ -18,7 +18,7 @@ struct Fat<T: ?Sized> {
     ptr: T
 }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 struct Bar;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -50,32 +50,32 @@ impl ToBar for Bar1 {
 
 // x is a fat pointer
 fn foo(x: &Fat<ToBar>) {
-    assert!(x.f1 == 5);
-    assert!(x.f2 == "some str");
-    assert!(x.ptr.to_bar() == Bar);
-    assert!(x.ptr.to_val() == 42);
+    assert_eq!(x.f1, 5);
+    assert_eq!(x.f2, "some str");
+    assert_eq!(x.ptr.to_bar(), Bar);
+    assert_eq!(x.ptr.to_val(), 42);
 
     let y = &x.ptr;
-    assert!(y.to_bar() == Bar);
-    assert!(y.to_val() == 42);
+    assert_eq!(y.to_bar(), Bar);
+    assert_eq!(y.to_val(), 42);
 }
 
 fn bar(x: &ToBar) {
-    assert!(x.to_bar() == Bar);
-    assert!(x.to_val() == 42);
+    assert_eq!(x.to_bar(), Bar);
+    assert_eq!(x.to_val(), 42);
 }
 
 fn baz(x: &Fat<Fat<ToBar>>) {
-    assert!(x.f1 == 5);
-    assert!(x.f2 == "some str");
-    assert!(x.ptr.f1 == 8);
-    assert!(x.ptr.f2 == "deep str");
-    assert!(x.ptr.ptr.to_bar() == Bar);
-    assert!(x.ptr.ptr.to_val() == 42);
+    assert_eq!(x.f1, 5);
+    assert_eq!(x.f2, "some str");
+    assert_eq!(x.ptr.f1, 8);
+    assert_eq!(x.ptr.f2, "deep str");
+    assert_eq!(x.ptr.ptr.to_bar(), Bar);
+    assert_eq!(x.ptr.ptr.to_val(), 42);
 
     let y = &x.ptr.ptr;
-    assert!(y.to_bar() == Bar);
-    assert!(y.to_val() == 42);
+    assert_eq!(y.to_bar(), Bar);
+    assert_eq!(y.to_val(), 42);
 
 }
 
@@ -93,7 +93,7 @@ pub fn main() {
 
     // Zero size object.
     let f6: &Fat<ToBar> = &Fat { f1: 5, f2: "some str", ptr: Bar };
-    assert!(f6.ptr.to_bar() == Bar);
+    assert_eq!(f6.ptr.to_bar(), Bar);
 
     // &*
     //

--- a/src/test/run-pass/enum-discr.rs
+++ b/src/test/run-pass/enum-discr.rs
@@ -26,6 +26,6 @@ enum Hero {
 pub fn main() {
     let pet: Animal = Animal::Snake;
     let hero: Hero = Hero::Superman;
-    assert!(pet as usize == 3);
-    assert!(hero as isize == -2);
+    assert_eq!(pet as usize, 3);
+    assert_eq!(hero as isize, -2);
 }

--- a/src/test/run-pass/enum-disr-val-pretty.rs
+++ b/src/test/run-pass/enum-disr-val-pretty.rs
@@ -21,5 +21,5 @@ pub fn main() {
 }
 
 fn test_color(color: color, val: isize, _name: String) {
-    assert!(color as isize == val);
+    assert_eq!(color as isize , val);
 }

--- a/src/test/run-pass/env-home-dir.rs
+++ b/src/test/run-pass/env-home-dir.rs
@@ -19,7 +19,7 @@ fn main() {
     let oldhome = var("HOME");
 
     set_var("HOME", "/home/MountainView");
-    assert!(home_dir() == Some(PathBuf::from("/home/MountainView")));
+    assert_eq!(home_dir(), Some(PathBuf::from("/home/MountainView")));
 
     remove_var("HOME");
     if cfg!(target_os = "android") {
@@ -40,14 +40,14 @@ fn main() {
     assert!(home_dir().is_some());
 
     set_var("HOME", "/home/MountainView");
-    assert!(home_dir() == Some(PathBuf::from("/home/MountainView")));
+    assert_eq!(home_dir(), Some(PathBuf::from("/home/MountainView")));
 
     remove_var("HOME");
 
     set_var("USERPROFILE", "/home/MountainView");
-    assert!(home_dir() == Some(PathBuf::from("/home/MountainView")));
+    assert_eq!(home_dir(), Some(PathBuf::from("/home/MountainView")));
 
     set_var("HOME", "/home/MountainView");
     set_var("USERPROFILE", "/home/PaloAlto");
-    assert!(home_dir() == Some(PathBuf::from("/home/MountainView")));
+    assert_eq!(home_dir(), Some(PathBuf::from("/home/MountainView")));
 }

--- a/src/test/run-pass/eq-multidispatch.rs
+++ b/src/test/run-pass/eq-multidispatch.rs
@@ -9,10 +9,13 @@
 // except according to those terms.
 
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 struct Bar;
+#[derive(Debug)]
 struct Baz;
+#[derive(Debug)]
 struct Foo;
+#[derive(Debug)]
 struct Fu;
 
 impl PartialEq for Baz { fn eq(&self, _: &Baz) -> bool  { true } }
@@ -27,10 +30,10 @@ fn main() {
     assert!(Bar != Foo);
     assert!(Foo != Bar);
 
-    assert!(Bar == Bar);
+    assert_eq!(Bar, Bar);
 
-    assert!(Baz == Baz);
+    assert_eq!(Baz, Baz);
 
-    assert!(Foo == Fu);
-    assert!(Fu == Foo);
+    assert_eq!(Foo, Fu);
+    assert_eq!(Fu, Foo);
 }

--- a/src/test/run-pass/expr-block-fn.rs
+++ b/src/test/run-pass/expr-block-fn.rs
@@ -14,7 +14,7 @@
 fn test_fn() {
     fn ten() -> isize { return 10; }
     let rs = ten;
-    assert!((rs() == 10));
+    assert_eq!(rs(), 10);
 }
 
 pub fn main() { test_fn(); }

--- a/src/test/run-pass/expr-block-unique.rs
+++ b/src/test/run-pass/expr-block-unique.rs
@@ -13,4 +13,4 @@
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 
-pub fn main() { let x: Box<_> = { box 100 }; assert!((*x == 100)); }
+pub fn main() { let x: Box<_> = { box 100 }; assert_eq!(*x, 100); }

--- a/src/test/run-pass/expr-block.rs
+++ b/src/test/run-pass/expr-block.rs
@@ -18,7 +18,7 @@ fn test_basic() { let rs: bool = { true }; assert!((rs)); }
 
 struct RS { v1: isize, v2: isize }
 
-fn test_rec() { let rs = { RS {v1: 10, v2: 20} }; assert!((rs.v2 == 20)); }
+fn test_rec() { let rs = { RS {v1: 10, v2: 20} }; assert_eq!(rs.v2, 20); }
 
 fn test_filled_with_stuff() {
     let rs = { let mut a = 0; while a < 10 { a += 1; } a };

--- a/src/test/run-pass/expr-if-panic.rs
+++ b/src/test/run-pass/expr-if-panic.rs
@@ -11,7 +11,7 @@
 
 fn test_if_panic() {
     let x = if false { panic!() } else { 10 };
-    assert!((x == 10));
+    assert_eq!(x, 10);
 }
 
 fn test_else_panic() {

--- a/src/test/run-pass/exterior.rs
+++ b/src/test/run-pass/exterior.rs
@@ -16,9 +16,9 @@ use std::cell::Cell;
 struct Point {x: isize, y: isize, z: isize}
 
 fn f(p: &Cell<Point>) {
-    assert!((p.get().z == 12));
+    assert_eq!(p.get().z, 12);
     p.set(Point {x: 10, y: 11, z: 13});
-    assert!((p.get().z == 13));
+    assert_eq!(p.get().z, 13);
 }
 
 pub fn main() {

--- a/src/test/run-pass/fat-ptr-cast.rs
+++ b/src/test/run-pass/fat-ptr-cast.rs
@@ -26,13 +26,13 @@ fn main() {
     let a: *const [i32] = &[1, 2, 3];
     let b = a as *const [i32; 2];
     unsafe {
-        assert!(*b == [1, 2]);
+        assert_eq!(*b, [1, 2]);
     }
 
     // Test conversion to an address (usize).
     let a: *const [i32; 3] = &[1, 2, 3];
     let b: *const [i32] = a;
-    assert!(a as usize == b as *const () as usize);
+    assert_eq!(a as usize, b as *const () as usize);
 
     // And conversion to a void pointer/address for trait objects too.
     let a: *mut Foo = &mut Bar;
@@ -43,7 +43,7 @@ fn main() {
         r.data
     };
 
-    assert!(b == d);
-    assert!(c == d as usize);
+    assert_eq!(b, d);
+    assert_eq!(c, d as usize);
 
 }

--- a/src/test/run-pass/foreach-external-iterators-break.rs
+++ b/src/test/run-pass/foreach-external-iterators-break.rs
@@ -18,5 +18,5 @@ pub fn main() {
         }
         y += *i;
     }
-    assert!(y == 11);
+    assert_eq!(y, 11);
 }

--- a/src/test/run-pass/foreach-external-iterators-nested.rs
+++ b/src/test/run-pass/foreach-external-iterators-nested.rs
@@ -20,5 +20,5 @@ pub fn main() {
         }
         q += *i + p;
     }
-    assert!(q == 1010100);
+    assert_eq!(q, 1010100);
 }

--- a/src/test/run-pass/foreach-external-iterators.rs
+++ b/src/test/run-pass/foreach-external-iterators.rs
@@ -15,5 +15,5 @@ pub fn main() {
     for i in &x[..] {
         y += *i
     }
-    assert!(y == 100);
+    assert_eq!(y, 100);
 }

--- a/src/test/run-pass/generic-fn-infer.rs
+++ b/src/test/run-pass/generic-fn-infer.rs
@@ -16,4 +16,4 @@
 
 fn id<T>(x: T) -> T { return x; }
 
-pub fn main() { let x: isize = 42; let y: isize = id(x); assert!((x == y)); }
+pub fn main() { let x: isize = 42; let y: isize = id(x); assert_eq!(x, y); }

--- a/src/test/run-pass/generic-tag-values.rs
+++ b/src/test/run-pass/generic-tag-values.rs
@@ -14,7 +14,7 @@ struct Pair { x: isize, y: isize }
 
 pub fn main() {
     let nop: noption<isize> = noption::some::<isize>(5);
-    match nop { noption::some::<isize>(n) => { println!("{}", n); assert!((n == 5)); } }
+    match nop { noption::some::<isize>(n) => { println!("{}", n); assert_eq!(n, 5); } }
     let nop2: noption<Pair> = noption::some(Pair{x: 17, y: 42});
     match nop2 {
       noption::some(t) => {

--- a/src/test/run-pass/generic-temporary.rs
+++ b/src/test/run-pass/generic-temporary.rs
@@ -11,7 +11,7 @@
 
 fn mk() -> isize { return 1; }
 
-fn chk(a: isize) { println!("{}", a); assert!((a == 1)); }
+fn chk(a: isize) { println!("{}", a); assert_eq!(a, 1); }
 
 fn apply<T>(produce: fn() -> T,
             consume: fn(T)) {

--- a/src/test/run-pass/global-scope.rs
+++ b/src/test/run-pass/global-scope.rs
@@ -14,7 +14,10 @@ pub fn f() -> isize { return 1; }
 
 pub mod foo {
     pub fn f() -> isize { return 2; }
-    pub fn g() { assert!((f() == 2)); assert!((::f() == 1)); }
+    pub fn g() {
+        assert_eq!(f(), 2);
+        assert_eq!(::f(), 1);
+    }
 }
 
 pub fn main() { return foo::g(); }

--- a/src/test/run-pass/i32-sub.rs
+++ b/src/test/run-pass/i32-sub.rs
@@ -12,4 +12,4 @@
 
 
 
-pub fn main() { let mut x: i32 = -400; x = 0 - x; assert!((x == 400)); }
+pub fn main() { let mut x: i32 = -400; x = 0 - x; assert_eq!(x, 400); }

--- a/src/test/run-pass/intrinsics-math.rs
+++ b/src/test/run-pass/intrinsics-math.rs
@@ -102,13 +102,13 @@ pub fn main() {
 
         // Causes linker error
         // undefined reference to llvm.ceil.f32/64
-        //assert!((ceilf32(-2.3f32) == -2.0f32));
-        //assert!((ceilf64(3.8f64) == 4.0f64));
+        //assert_eq!(ceilf32(-2.3f32), -2.0f32);
+        //assert_eq!(ceilf64(3.8f64), 4.0f64);
 
         // Causes linker error
         // undefined reference to llvm.trunc.f32/64
-        //assert!((truncf32(0.1f32) == 0.0f32));
-        //assert!((truncf64(-0.1f64) == 0.0f64));
+        //assert_eq!(truncf32(0.1f32), 0.0f32);
+        //assert_eq!(truncf64(-0.1f64), 0.0f64);
     }
 
 }

--- a/src/test/run-pass/issue-10734.rs
+++ b/src/test/run-pass/issue-10734.rs
@@ -34,7 +34,7 @@ pub fn main() {
         let _a = Foo{ dropped: false };
     }
     // Check that we dropped already (as expected from a `{ expr }`).
-    unsafe { assert!(drop_count == 1); }
+    unsafe { assert_eq!(drop_count, 1); }
 
     // An `if false {} else { expr }` statement should compile the same as `{ expr }`.
     if false {
@@ -43,5 +43,5 @@ pub fn main() {
         let _a = Foo{ dropped: false };
     }
     // Check that we dropped already (as expected from a `{ expr }`).
-    unsafe { assert!(drop_count == 2); }
+    unsafe { assert_eq!(drop_count, 2); }
 }

--- a/src/test/run-pass/issue-15080.rs
+++ b/src/test/run-pass/issue-15080.rs
@@ -29,5 +29,5 @@ fn main() {
                 break
         }
     }
-    assert!(result == [2, 4]);
+    assert_eq!(result, [2, 4]);
 }

--- a/src/test/run-pass/issue-15689-1.rs
+++ b/src/test/run-pass/issue-15689-1.rs
@@ -9,11 +9,11 @@
 // except according to those terms.
 
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 enum Test<'a> {
     Slice(&'a isize)
 }
 
 fn main() {
-    assert!(Test::Slice(&1) == Test::Slice(&1))
+    assert_eq!(Test::Slice(&1), Test::Slice(&1))
 }

--- a/src/test/run-pass/issue-15734.rs
+++ b/src/test/run-pass/issue-15734.rs
@@ -57,14 +57,14 @@ fn main() {
     let m = Mat::new(vec!(1, 2, 3, 4, 5, 6), 3);
     let r = m.row(1);
 
-    assert!(r.index(2) == &6);
-    assert!(r[2] == 6);
-    assert!(r[2] == 6);
-    assert!(6 == r[2]);
+    assert_eq!(r.index(2), &6);
+    assert_eq!(r[2], 6);
+    assert_eq!(r[2], 6);
+    assert_eq!(6, r[2]);
 
     let e = r[2];
-    assert!(e == 6);
+    assert_eq!(e, 6);
 
     let e: usize = r[2];
-    assert!(e == 6);
+    assert_eq!(e, 6);
 }

--- a/src/test/run-pass/issue-16530.rs
+++ b/src/test/run-pass/issue-16530.rs
@@ -17,5 +17,5 @@ use std::hash::{SipHasher, hash};
 struct Empty;
 
 pub fn main() {
-    assert!(hash::<_, SipHasher>(&Empty) == hash::<_, SipHasher>(&Empty));
+    assert_eq!(hash::<_, SipHasher>(&Empty), hash::<_, SipHasher>(&Empty));
 }

--- a/src/test/run-pass/issue-21384.rs
+++ b/src/test/run-pass/issue-21384.rs
@@ -15,16 +15,16 @@ fn test<T : Clone>(arg: T) -> T {
     arg.clone()
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 struct Test(isize);
 
 fn main() {
     // Check that ranges implement clone
-    assert!(test(1..5) == (1..5));
-    assert!(test(..5) == (..5));
-    assert!(test(1..) == (1..));
-    assert!(test(RangeFull) == (RangeFull));
+    assert_eq!(test(1..5), (1..5));
+    assert_eq!(test(..5), (..5));
+    assert_eq!(test(1..), (1..));
+    assert_eq!(test(RangeFull), (RangeFull));
 
     // Check that ranges can still be used with non-clone limits
-    assert!((Test(1)..Test(5)) == (Test(1)..Test(5)));
+    assert_eq!((Test(1)..Test(5)), (Test(1)..Test(5)));
 }

--- a/src/test/run-pass/issue-2904.rs
+++ b/src/test/run-pass/issue-2904.rs
@@ -70,14 +70,14 @@ fn read_board_grid<rdr:'static + Read>(mut input: rdr)
     }
     grid.push(row);
     let width = grid[0].len();
-    for row in &grid { assert!(row.len() == width) }
+    for row in &grid { assert_eq!(row.len(), width) }
     grid
 }
 
 mod test {
     #[test]
     pub fn trivial_to_string() {
-        assert!(lambda.to_string() == "\\")
+        assert_eq!(lambda.to_string(), "\\")
     }
 }
 

--- a/src/test/run-pass/issue-333.rs
+++ b/src/test/run-pass/issue-333.rs
@@ -13,4 +13,4 @@ fn quux<T>(x: T) -> T { let f = id::<T>; return f(x); }
 
 fn id<T>(x: T) -> T { return x; }
 
-pub fn main() { assert!((quux(10) == 10)); }
+pub fn main() { assert_eq!(quux(10), 10); }

--- a/src/test/run-pass/issue-5239-2.rs
+++ b/src/test/run-pass/issue-5239-2.rs
@@ -14,5 +14,5 @@
 pub fn main() {
     let _f = |ref x: isize| { *x };
     let foo = 10;
-    assert!(_f(foo) == 10);
+    assert_eq!(_f(foo), 10);
 }

--- a/src/test/run-pass/issue-7663.rs
+++ b/src/test/run-pass/issue-7663.rs
@@ -19,7 +19,7 @@ mod test1 {
     pub mod baz {
         use test1::bar::p;
 
-        pub fn my_main() { assert!(p() == 2); }
+        pub fn my_main() { assert_eq!(p(), 2); }
     }
 }
 
@@ -31,7 +31,7 @@ mod test2 {
     pub mod baz {
         use test2::bar::p;
 
-        pub fn my_main() { assert!(p() == 2); }
+        pub fn my_main() { assert_eq!(p(), 2); }
     }
 }
 

--- a/src/test/run-pass/issue-7784.rs
+++ b/src/test/run-pass/issue-7784.rs
@@ -37,6 +37,6 @@ fn main() {
     let out = bar("baz", "foo");
     let [a, xs.., d] = out;
     assert_eq!(a, "baz");
-    assert!(xs == ["foo", "foo"]);
+    assert_eq!(xs, ["foo", "foo"]);
     assert_eq!(d, "baz");
 }

--- a/src/test/run-pass/issue-8498.rs
+++ b/src/test/run-pass/issue-8498.rs
@@ -13,14 +13,14 @@ pub fn main() {
     match &[(Box::new(5),Box::new(7))] {
         ps => {
            let (ref y, _) = ps[0];
-           assert!(**y == 5);
+           assert_eq!(**y, 5);
         }
     }
 
     match Some(&[(Box::new(5),)]) {
         Some(ps) => {
            let (ref y,) = ps[0];
-           assert!(**y == 5);
+           assert_eq!(**y, 5);
         }
         None => ()
     }
@@ -28,8 +28,8 @@ pub fn main() {
     match Some(&[(Box::new(5),Box::new(7))]) {
         Some(ps) => {
            let (ref y, ref z) = ps[0];
-           assert!(**y == 5);
-           assert!(**z == 7);
+           assert_eq!(**y, 5);
+           assert_eq!(**z, 7);
         }
         None => ()
     }

--- a/src/test/run-pass/istr.rs
+++ b/src/test/run-pass/istr.rs
@@ -16,7 +16,7 @@ fn test_stack_assign() {
     let s: String = "a".to_string();
     println!("{}", s.clone());
     let t: String = "a".to_string();
-    assert!(s == t);
+    assert_eq!(s, t);
     let u: String = "b".to_string();
     assert!((s != u));
 }
@@ -26,7 +26,7 @@ fn test_heap_lit() { "a big string".to_string(); }
 fn test_heap_assign() {
     let s: String = "a big ol' string".to_string();
     let t: String = "a big ol' string".to_string();
-    assert!(s == t);
+    assert_eq!(s, t);
     let u: String = "a bad ol' string".to_string();
     assert!((s != u));
 }
@@ -48,10 +48,10 @@ fn test_append() {
 
     let mut s = String::from("c");
     s.push_str("offee");
-    assert!(s == "coffee");
+    assert_eq!(s, "coffee");
 
     s.push_str("&tea");
-    assert!(s == "coffee&tea");
+    assert_eq!(s, "coffee&tea");
 }
 
 pub fn main() {

--- a/src/test/run-pass/linear-for-loop.rs
+++ b/src/test/run-pass/linear-for-loop.rs
@@ -19,11 +19,11 @@ pub fn main() {
     let s = "hello there".to_string();
     let mut i: isize = 0;
     for c in s.bytes() {
-        if i == 0 { assert!((c == 'h' as u8)); }
-        if i == 1 { assert!((c == 'e' as u8)); }
-        if i == 2 { assert!((c == 'l' as u8)); }
-        if i == 3 { assert!((c == 'l' as u8)); }
-        if i == 4 { assert!((c == 'o' as u8)); }
+        if i == 0 { assert_eq!(c, 'h' as u8); }
+        if i == 1 { assert_eq!(c, 'e' as u8); }
+        if i == 2 { assert_eq!(c, 'l' as u8); }
+        if i == 3 { assert_eq!(c, 'l' as u8); }
+        if i == 4 { assert_eq!(c, 'o' as u8); }
         // ...
 
         i += 1;

--- a/src/test/run-pass/logging-only-prints-once.rs
+++ b/src/test/run-pass/logging-only-prints-once.rs
@@ -20,7 +20,7 @@ struct Foo(Cell<isize>);
 impl fmt::Debug for Foo {
     fn fmt(&self, _fmt: &mut fmt::Formatter) -> fmt::Result {
         let Foo(ref f) = *self;
-        assert!(f.get() == 0);
+        assert_eq!(f.get(), 0);
         f.set(1);
         Ok(())
     }
@@ -31,6 +31,6 @@ pub fn main() {
         let mut f = Foo(Cell::new(0));
         println!("{:?}", f);
         let Foo(ref mut f) = f;
-        assert!(f.get() == 1);
+        assert_eq!(f.get(), 1);
     }).join().ok().unwrap();
 }

--- a/src/test/run-pass/macro-2.rs
+++ b/src/test/run-pass/macro-2.rs
@@ -19,5 +19,5 @@ pub fn main() {
         })
     }
 
-    assert!(mylambda_tt!(y, y * 2)(8) == 16);
+    assert_eq!(mylambda_tt!(y, y * 2)(8), 16);
 }

--- a/src/test/run-pass/match-implicit-copy-unique.rs
+++ b/src/test/run-pass/match-implicit-copy-unique.rs
@@ -19,7 +19,9 @@ pub fn main() {
     let x_internal = &mut *x;
     match *x_internal {
       Pair {a: ref mut a, b: ref mut _b} => {
-        assert!(**a == 10); *a = box 30; assert!(**a == 30);
+        assert_eq!(**a, 10);
+        *a = box 30;
+        assert_eq!(**a, 30);
       }
     }
 }

--- a/src/test/run-pass/match-pattern-lit.rs
+++ b/src/test/run-pass/match-pattern-lit.rs
@@ -18,4 +18,7 @@ fn altlit(f: isize) -> isize {
     }
 }
 
-pub fn main() { assert!((altlit(10) == 20)); assert!((altlit(11) == 22)); }
+pub fn main() {
+    assert_eq!(altlit(10), 20);
+    assert_eq!(altlit(11), 22);
+}

--- a/src/test/run-pass/match-static-const-rename.rs
+++ b/src/test/run-pass/match-static-const-rename.rs
@@ -26,12 +26,12 @@ fn f() {
         (0, A) => 0,
         (x, y) => 1 + x + y,
     };
-    assert!(r == 1);
+    assert_eq!(r, 1);
     let r = match (0,97) {
         (0, A) => 0,
         (x, y) => 1 + x + y,
     };
-    assert!(r == 0);
+    assert_eq!(r, 0);
 }
 
 mod m {
@@ -45,12 +45,12 @@ fn g() {
         (0, AHA) => 0,
         (x, y)   => 1 + x + y,
     };
-    assert!(r == 1);
+    assert_eq!(r, 1);
     let r = match (0,7) {
         (0, AHA) => 0,
         (x, y)   => 1 + x + y,
     };
-    assert!(r == 0);
+    assert_eq!(r, 0);
 }
 
 fn h() {
@@ -58,12 +58,12 @@ fn h() {
         (0, self::m::aha) => 0,
         (x, y)      => 1 + x + y,
     };
-    assert!(r == 1);
+    assert_eq!(r, 1);
     let r = match (0,7) {
         (0, self::m::aha) => 0,
         (x, y)      => 1 + x + y,
     };
-    assert!(r == 0);
+    assert_eq!(r, 0);
 }
 
 pub fn main () {

--- a/src/test/run-pass/method-self-arg-aux1.rs
+++ b/src/test/run-pass/method-self-arg-aux1.rs
@@ -27,5 +27,5 @@ fn main() {
 
     x.foo(&x);
 
-    assert!(method_self_arg1::get_count() == 2*3*3*3*5*5*5*7*7*7);
+    assert_eq!(method_self_arg1::get_count(), 2*3*3*3*5*5*5*7*7*7);
 }

--- a/src/test/run-pass/method-self-arg-aux2.rs
+++ b/src/test/run-pass/method-self-arg-aux2.rs
@@ -31,5 +31,5 @@ fn main() {
 
     x.run_trait();
 
-    assert!(method_self_arg2::get_count() == 2*2*3*3*5*5*7*7*11*11*13*13*17);
+    assert_eq!(method_self_arg2::get_count(), 2*2*3*3*5*5*7*7*11*11*13*13*17);
 }

--- a/src/test/run-pass/method-self-arg-trait.rs
+++ b/src/test/run-pass/method-self-arg-trait.rs
@@ -76,5 +76,5 @@ fn main() {
 
     x.baz();
 
-    unsafe { assert!(COUNT == 2*2*3*3*5*5*7*7*11*11*13*13*17); }
+    unsafe { assert_eq!(COUNT, 2*2*3*3*5*5*7*7*11*11*13*13*17); }
 }

--- a/src/test/run-pass/method-self-arg.rs
+++ b/src/test/run-pass/method-self-arg.rs
@@ -55,5 +55,5 @@ fn main() {
 
     x.foo(&x);
 
-    unsafe { assert!(COUNT == 2*3*3*3*5*5*5*7*7*7); }
+    unsafe { assert_eq!(COUNT, 2*3*3*3*5*5*5*7*7*7); }
 }

--- a/src/test/run-pass/move-2-unique.rs
+++ b/src/test/run-pass/move-2-unique.rs
@@ -17,5 +17,5 @@ struct X { x: isize, y: isize, z: isize }
 pub fn main() {
     let x: Box<_> = box X{x: 1, y: 2, z: 3};
     let y = x;
-    assert!((y.y == 2));
+    assert_eq!(y.y, 2);
 }

--- a/src/test/run-pass/move-2.rs
+++ b/src/test/run-pass/move-2.rs
@@ -14,4 +14,4 @@
 
 struct X { x: isize, y: isize, z: isize }
 
-pub fn main() { let x: Box<_> = box X {x: 1, y: 2, z: 3}; let y = x; assert!((y.y == 2)); }
+pub fn main() { let x: Box<_> = box X {x: 1, y: 2, z: 3}; let y = x; assert_eq!(y.y, 2); }

--- a/src/test/run-pass/move-4-unique.rs
+++ b/src/test/run-pass/move-4-unique.rs
@@ -25,5 +25,5 @@ fn test(foo: Box<Triple>) -> Box<Triple> {
 pub fn main() {
     let x = box Triple{a: 1, b: 2, c: 3};
     let y = test(x);
-    assert!((y.c == 3));
+    assert_eq!(y.c, 3);
 }

--- a/src/test/run-pass/move-arg-2-unique.rs
+++ b/src/test/run-pass/move-arg-2-unique.rs
@@ -12,7 +12,7 @@
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 
-fn test(foo: Box<Vec<isize>> ) { assert!(((*foo)[0] == 10)); }
+fn test(foo: Box<Vec<isize>> ) { assert_eq!((*foo)[0], 10); }
 
 pub fn main() {
     let x = box vec!(10);

--- a/src/test/run-pass/move-arg-2.rs
+++ b/src/test/run-pass/move-arg-2.rs
@@ -12,7 +12,7 @@
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 
-fn test(foo: Box<Vec<isize>>) { assert!(((*foo)[0] == 10)); }
+fn test(foo: Box<Vec<isize>>) { assert_eq!((*foo)[0], 10); }
 
 pub fn main() {
     let x = box vec!(10);

--- a/src/test/run-pass/move-arg.rs
+++ b/src/test/run-pass/move-arg.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 
-fn test(foo: isize) { assert!((foo == 10)); }
+fn test(foo: isize) { assert_eq!(foo, 10); }
 
 pub fn main() { let x = 10; test(x); }

--- a/src/test/run-pass/multi-let.rs
+++ b/src/test/run-pass/multi-let.rs
@@ -12,5 +12,5 @@
 pub fn main() {
     let x = 10;
     let y = x;
-    assert!((y == 10));
+    assert_eq!(y, 10);
 }

--- a/src/test/run-pass/mut-function-arguments.rs
+++ b/src/test/run-pass/mut-function-arguments.rs
@@ -18,7 +18,7 @@ fn f(mut y: Box<isize>) {
 }
 
 fn g() {
-    let frob = |mut q: Box<isize>| { *q = 2; assert!(*q == 2); };
+    let frob = |mut q: Box<isize>| { *q = 2; assert_eq!(*q, 2); };
     let w = box 37;
     frob(w);
 

--- a/src/test/run-pass/mutability-inherits-through-fixed-length-vec.rs
+++ b/src/test/run-pass/mutability-inherits-through-fixed-length-vec.rs
@@ -18,7 +18,7 @@ fn test1() {
 fn test2() {
     let mut ints = [0; 32];
     for i in &mut ints { *i += 22; }
-    for i in &ints { assert!(*i == 22); }
+    for i in &ints { assert_eq!(*i, 22); }
 }
 
 pub fn main() {

--- a/src/test/run-pass/nullable-pointer-iotareduction.rs
+++ b/src/test/run-pass/nullable-pointer-iotareduction.rs
@@ -40,7 +40,7 @@ impl<T> E<T> {
 
 macro_rules! check_option {
     ($e:expr, $T:ty) => {{
-        check_option!($e, $T, |ptr| assert!(*ptr == $e));
+        check_option!($e, $T, |ptr| assert_eq!(*ptr, $e));
     }};
     ($e:expr, $T:ty, |$v:ident| $chk:expr) => {{
         assert!(option::Option::None::<$T>.is_none());
@@ -53,7 +53,7 @@ macro_rules! check_option {
 
 macro_rules! check_fancy {
     ($e:expr, $T:ty) => {{
-        check_fancy!($e, $T, |ptr| assert!(*ptr == $e));
+        check_fancy!($e, $T, |ptr| assert_eq!(*ptr, $e));
     }};
     ($e:expr, $T:ty, |$v:ident| $chk:expr) => {{
         assert!(E::Nothing::<$T>((), ((), ()), [23; 0]).is_none());
@@ -81,6 +81,6 @@ pub fn main() {
     check_type!(vec!(20, 22), Vec<isize> );
     let mint: usize = unsafe { mem::transmute(main) };
     check_type!(main, fn(), |pthing| {
-        assert!(mint == unsafe { mem::transmute(*pthing) })
+        assert_eq!(mint, unsafe { mem::transmute(*pthing) })
     });
 }

--- a/src/test/run-pass/operator-associativity.rs
+++ b/src/test/run-pass/operator-associativity.rs
@@ -13,4 +13,4 @@
 
 // Testcase for issue #130, operator associativity.
 
-pub fn main() { assert!((3 * 5 / 2 == 7)); }
+pub fn main() { assert_eq!(3 * 5 / 2, 7); }

--- a/src/test/run-pass/overloaded-autoderef-vtable.rs
+++ b/src/test/run-pass/overloaded-autoderef-vtable.rs
@@ -43,5 +43,5 @@ impl Foo {
 pub fn main() {
     let x: DerefWithHelper<Option<Foo>, Foo> =
         DerefWithHelper { helper: Some(Foo {x: 5}), value: Foo { x: 2 } };
-    assert!(x.foo() == 5);
+    assert_eq!(x.foo(), 5);
 }

--- a/src/test/run-pass/overloaded-autoderef.rs
+++ b/src/test/run-pass/overloaded-autoderef.rs
@@ -37,8 +37,8 @@ pub fn main() {
     let mut_s = Rc::new(RefCell::new(String::from("foo")));
     mut_s.borrow_mut().push_str("bar");
     // HACK assert_eq! would panic here because it stores the LHS and RHS in two locals.
-    assert!(&**mut_s.borrow() == "foobar");
-    assert!(&**mut_s.borrow_mut() == "foobar");
+    assert_eq!(&**mut_s.borrow(), "foobar");
+    assert_eq!(&**mut_s.borrow_mut(), "foobar");
 
     let p = Rc::new(RefCell::new(Point {x: 1, y: 2}));
     p.borrow_mut().x = 3;

--- a/src/test/run-pass/overloaded-deref.rs
+++ b/src/test/run-pass/overloaded-deref.rs
@@ -37,8 +37,8 @@ pub fn main() {
     let mut_s = Rc::new(RefCell::new(String::from("foo")));
     (*(*mut_s).borrow_mut()).push_str("bar");
     // assert_eq! would panic here because it stores the LHS and RHS in two locals.
-    assert!((*(*mut_s).borrow()) == "foobar");
-    assert!((*(*mut_s).borrow_mut()) == "foobar");
+    assert_eq!((*(*mut_s).borrow()), "foobar");
+    assert_eq!((*(*mut_s).borrow_mut()), "foobar");
 
     let p = Rc::new(RefCell::new(Point {x: 1, y: 2}));
     (*(*p).borrow_mut()).x = 3;

--- a/src/test/run-pass/overloaded-index-assoc-list.rs
+++ b/src/test/run-pass/overloaded-index-assoc-list.rs
@@ -52,9 +52,9 @@ pub fn main() {
     list.push(foo.clone(), 22);
     list.push(bar.clone(), 44);
 
-    assert!(list[&foo] == 22);
-    assert!(list[&bar] == 44);
+    assert_eq!(list[&foo], 22);
+    assert_eq!(list[&bar], 44);
 
-    assert!(list[&foo] == 22);
-    assert!(list[&bar] == 44);
+    assert_eq!(list[&foo], 22);
+    assert_eq!(list[&bar], 44);
 }

--- a/src/test/run-pass/packed-struct-generic-layout.rs
+++ b/src/test/run-pass/packed-struct-generic-layout.rs
@@ -23,7 +23,7 @@ pub fn main() {
         let s = S { a: 0xff_ff_ff_ffu32, b: 1, c: 0xaa_aa_aa_aa as i32 };
         let transd : [u8; 9] = mem::transmute(s);
         // Don't worry about endianness, the numbers are palindromic.
-        assert!(transd ==
+        assert_eq!(transd,
                    [0xff, 0xff, 0xff, 0xff,
                     1,
                     0xaa, 0xaa, 0xaa, 0xaa]);
@@ -32,7 +32,7 @@ pub fn main() {
         let s = S { a: 1u8, b: 2u8, c: 0b10000001_10000001 as i16};
         let transd : [u8; 4] = mem::transmute(s);
         // Again, no endianness problems.
-        assert!(transd ==
+        assert_eq!(transd,
                    [1, 2, 0b10000001, 0b10000001]);
     }
 }

--- a/src/test/run-pass/packed-struct-layout.rs
+++ b/src/test/run-pass/packed-struct-layout.rs
@@ -27,11 +27,11 @@ pub fn main() {
     unsafe {
         let s4 = S4 { a: 1, b: [2,3,4] };
         let transd : [u8; 4] = mem::transmute(s4);
-        assert!(transd == [1, 2, 3, 4]);
+        assert_eq!(transd, [1, 2, 3, 4]);
 
         let s5 = S5 { a: 1, b: 0xff_00_00_ff };
         let transd : [u8; 5] = mem::transmute(s5);
         // Don't worry about endianness, the u32 is palindromic.
-        assert!(transd == [1, 0xff, 0, 0, 0xff]);
+        assert_eq!(transd, [1, 0xff, 0, 0, 0xff]);
     }
 }

--- a/src/test/run-pass/packed-tuple-struct-layout.rs
+++ b/src/test/run-pass/packed-tuple-struct-layout.rs
@@ -21,11 +21,11 @@ pub fn main() {
     unsafe {
         let s4 = S4(1, [2,3,4]);
         let transd : [u8; 4] = mem::transmute(s4);
-        assert!(transd == [1, 2, 3, 4]);
+        assert_eq!(transd, [1, 2, 3, 4]);
 
         let s5 = S5(1, 0xff_00_00_ff);
         let transd : [u8; 5] = mem::transmute(s5);
         // Don't worry about endianness, the u32 is palindromic.
-        assert!(transd == [1, 0xff, 0, 0, 0xff]);
+        assert_eq!(transd, [1, 0xff, 0, 0, 0xff]);
     }
 }

--- a/src/test/run-pass/range.rs
+++ b/src/test/run-pass/range.rs
@@ -23,7 +23,7 @@ pub fn main() {
         assert!(i >= 0 && i < 10);
         count += i;
     }
-    assert!(count == 45);
+    assert_eq!(count, 45);
 
     let mut count = 0;
     let mut range = 0_usize..10;
@@ -31,7 +31,7 @@ pub fn main() {
         assert!(i >= 0 && i < 10);
         count += i;
     }
-    assert!(count == 45);
+    assert_eq!(count, 45);
 
     let mut count = 0;
     let mut rf = 3_usize..;
@@ -39,7 +39,7 @@ pub fn main() {
         assert!(i >= 3 && i < 13);
         count += i;
     }
-    assert!(count == 75);
+    assert_eq!(count, 75);
 
     let _ = 0_usize..4+4-3;
     let _ = 0..foo();

--- a/src/test/run-pass/ranges-precedence.rs
+++ b/src/test/run-pass/ranges-precedence.rs
@@ -22,30 +22,30 @@ impl Foo {
 
 fn main() {
     let x = 1+3..4+5;
-    assert!(x == (4..9));
+    assert_eq!(x, (4..9));
 
     let x = 1..4+5;
-    assert!(x == (1..9));
+    assert_eq!(x, (1..9));
 
     let x = 1+3..4;
-    assert!(x == (4..4));
+    assert_eq!(x, (4..4));
 
     let a = Foo { foo: 3 };
     let x = a.foo..a.bar();
-    assert!(x == (3..5));
+    assert_eq!(x, (3..5));
 
     let x = 1+3..;
-    assert!(x == (4..));
+    assert_eq!(x, (4..));
     let x = ..1+3;
-    assert!(x == (..4));
+    assert_eq!(x, (..4));
 
     let a = &[0, 1, 2, 3, 4, 5, 6];
     let x = &a[1+1..2+2];
-    assert!(x == &a[2..4]);
+    assert_eq!(x, &a[2..4]);
     let x = &a[..1+2];
-    assert!(x == &a[..3]);
+    assert_eq!(x, &a[..3]);
     let x = &a[1+2..];
-    assert!(x == &a[3..]);
+    assert_eq!(x, &a[3..]);
 
     for _i in 2+4..10-3 {}
 
@@ -54,8 +54,8 @@ fn main() {
     for _ in 1.. { break; }
 
     let x = [1]..[2];
-    assert!(x == (([1])..([2])));
+    assert_eq!(x, (([1])..([2])));
 
     let y = ..;
-    assert!(y == (..));
+    assert_eq!(y, (..));
 }

--- a/src/test/run-pass/readalias.rs
+++ b/src/test/run-pass/readalias.rs
@@ -14,6 +14,6 @@
 
 struct Point {x: isize, y: isize, z: isize}
 
-fn f(p: Point) { assert!((p.z == 12)); }
+fn f(p: Point) { assert_eq!(p.z, 12); }
 
 pub fn main() { let x: Point = Point {x: 10, y: 11, z: 12}; f(x); }

--- a/src/test/run-pass/regions-lifetime-static-items-enclosing-scopes.rs
+++ b/src/test/run-pass/regions-lifetime-static-items-enclosing-scopes.rs
@@ -14,8 +14,8 @@
 
 use std::cmp::PartialEq;
 
-fn f<T:PartialEq>(o: &mut Option<T>) {
-    assert!(*o == None);
+fn f<T:PartialEq+std::fmt::Debug>(o: &mut Option<T>) {
+    assert_eq!(*o, None);
 }
 
 pub fn main() {

--- a/src/test/run-pass/repeat-expr-in-static.rs
+++ b/src/test/run-pass/repeat-expr-in-static.rs
@@ -13,5 +13,5 @@ static FOO: [isize; 4] = [32; 4];
 static BAR: [isize; 4] = [32, 32, 32, 32];
 
 pub fn main() {
-    assert!(FOO == BAR);
+    assert_eq!(FOO, BAR);
 }

--- a/src/test/run-pass/resolve-issue-2428.rs
+++ b/src/test/run-pass/resolve-issue-2428.rs
@@ -11,4 +11,4 @@
 
 const foo: isize = 4 >> 1;
 enum bs { thing = foo }
-pub fn main() { assert!((bs::thing as isize == foo)); }
+pub fn main() { assert_eq!(bs::thing as isize, foo); }

--- a/src/test/run-pass/resource-destruct.rs
+++ b/src/test/run-pass/resource-destruct.rs
@@ -32,7 +32,7 @@ fn shrinky_pointer(i: &Cell<isize>) -> shrinky_pointer {
 
 pub fn main() {
     let my_total = &Cell::new(10);
-    { let pt = shrinky_pointer(my_total); assert!((pt.look_at() == 10)); }
+    { let pt = shrinky_pointer(my_total); assert_eq!(pt.look_at(), 10); }
     println!("my_total = {}", my_total.get());
     assert_eq!(my_total.get(), 9);
 }

--- a/src/test/run-pass/self-re-assign.rs
+++ b/src/test/run-pass/self-re-assign.rs
@@ -20,9 +20,9 @@ use std::rc::Rc;
 pub fn main() {
    let mut x: Box<_> = box 3;
    x = x;
-   assert!(*x == 3);
+   assert_eq!(*x, 3);
 
    let mut x = Rc::new(3);
    x = x;
-   assert!(*x == 3);
+   assert_eq!(*x, 3);
 }

--- a/src/test/run-pass/self-shadowing-import.rs
+++ b/src/test/run-pass/self-shadowing-import.rs
@@ -19,7 +19,7 @@ mod a {
 
 mod c {
     use a::b::a;
-    pub fn bar() { assert!((a::foo() == 1)); }
+    pub fn bar() { assert_eq!(a::foo(), 1); }
 }
 
 pub fn main() { c::bar(); }

--- a/src/test/run-pass/shadow.rs
+++ b/src/test/run-pass/shadow.rs
@@ -27,4 +27,4 @@ fn foo(c: Vec<isize> ) {
 
 enum t<T> { none, some(T), }
 
-pub fn main() { let x = 10; let x = x + 20; assert!((x == 30)); foo(Vec::new()); }
+pub fn main() { let x = 10; let x = x + 20; assert_eq!(x, 30); foo(Vec::new()); }

--- a/src/test/run-pass/slice-2.rs
+++ b/src/test/run-pass/slice-2.rs
@@ -14,57 +14,57 @@
 fn main() {
     let x: &[isize] = &[1, 2, 3, 4, 5];
     let cmp: &[isize] = &[1, 2, 3, 4, 5];
-    assert!(&x[..] == cmp);
+    assert_eq!(&x[..], cmp);
     let cmp: &[isize] = &[3, 4, 5];
-    assert!(&x[2..] == cmp);
+    assert_eq!(&x[2..], cmp);
     let cmp: &[isize] = &[1, 2, 3];
-    assert!(&x[..3] == cmp);
+    assert_eq!(&x[..3], cmp);
     let cmp: &[isize] = &[2, 3, 4];
-    assert!(&x[1..4] == cmp);
+    assert_eq!(&x[1..4], cmp);
 
     let x: Vec<isize> = vec![1, 2, 3, 4, 5];
     let cmp: &[isize] = &[1, 2, 3, 4, 5];
-    assert!(&x[..] == cmp);
+    assert_eq!(&x[..], cmp);
     let cmp: &[isize] = &[3, 4, 5];
-    assert!(&x[2..] == cmp);
+    assert_eq!(&x[2..], cmp);
     let cmp: &[isize] = &[1, 2, 3];
-    assert!(&x[..3] == cmp);
+    assert_eq!(&x[..3], cmp);
     let cmp: &[isize] = &[2, 3, 4];
-    assert!(&x[1..4] == cmp);
+    assert_eq!(&x[1..4], cmp);
 
     let x: &mut [isize] = &mut [1, 2, 3, 4, 5];
     {
         let cmp: &mut [isize] = &mut [1, 2, 3, 4, 5];
-        assert!(&mut x[..] == cmp);
+        assert_eq!(&mut x[..], cmp);
     }
     {
         let cmp: &mut [isize] = &mut [3, 4, 5];
-        assert!(&mut x[2..] == cmp);
+        assert_eq!(&mut x[2..], cmp);
     }
     {
         let cmp: &mut [isize] = &mut [1, 2, 3];
-        assert!(&mut x[..3] == cmp);
+        assert_eq!(&mut x[..3], cmp);
     }
     {
         let cmp: &mut [isize] = &mut [2, 3, 4];
-        assert!(&mut x[1..4] == cmp);
+        assert_eq!(&mut x[1..4], cmp);
     }
 
     let mut x: Vec<isize> = vec![1, 2, 3, 4, 5];
     {
         let cmp: &mut [isize] = &mut [1, 2, 3, 4, 5];
-        assert!(&mut x[..] == cmp);
+        assert_eq!(&mut x[..], cmp);
     }
     {
         let cmp: &mut [isize] = &mut [3, 4, 5];
-        assert!(&mut x[2..] == cmp);
+        assert_eq!(&mut x[2..], cmp);
     }
     {
         let cmp: &mut [isize] = &mut [1, 2, 3];
-        assert!(&mut x[..3] == cmp);
+        assert_eq!(&mut x[..3], cmp);
     }
     {
         let cmp: &mut [isize] = &mut [2, 3, 4];
-        assert!(&mut x[1..4] == cmp);
+        assert_eq!(&mut x[1..4], cmp);
     }
 }

--- a/src/test/run-pass/slice-panic-1.rs
+++ b/src/test/run-pass/slice-panic-1.rs
@@ -28,5 +28,5 @@ fn foo() {
 
 fn main() {
     let _ = thread::spawn(move|| foo()).join();
-    unsafe { assert!(DTOR_COUNT == 2); }
+    unsafe { assert_eq!(DTOR_COUNT, 2); }
 }

--- a/src/test/run-pass/slice-panic-2.rs
+++ b/src/test/run-pass/slice-panic-2.rs
@@ -32,5 +32,5 @@ fn foo() {
 
 fn main() {
     let _ = thread::spawn(move|| foo()).join();
-    unsafe { assert!(DTOR_COUNT == 2); }
+    unsafe { assert_eq!(DTOR_COUNT, 2); }
 }

--- a/src/test/run-pass/slice.rs
+++ b/src/test/run-pass/slice.rs
@@ -86,6 +86,6 @@ fn main() {
     &mut x[..Foo];
     &mut x[Foo..Foo];
     unsafe {
-        assert!(COUNT == 8);
+        assert_eq!(COUNT, 8);
     }
 }

--- a/src/test/run-pass/spawn.rs
+++ b/src/test/run-pass/spawn.rs
@@ -14,4 +14,4 @@ pub fn main() {
     thread::spawn(move|| child(10)).join().ok().unwrap();
 }
 
-fn child(i: isize) { println!("{}", i); assert!((i == 10)); }
+fn child(i: isize) { println!("{}", i); assert_eq!(i, 10); }

--- a/src/test/run-pass/static-mut-foreign.rs
+++ b/src/test/run-pass/static-mut-foreign.rs
@@ -30,16 +30,16 @@ fn static_bound_set(a: &'static mut libc::c_int) {
 }
 
 unsafe fn run() {
-    assert!(rust_dbg_static_mut == 3);
+    assert_eq!(rust_dbg_static_mut, 3);
     rust_dbg_static_mut = 4;
-    assert!(rust_dbg_static_mut == 4);
+    assert_eq!(rust_dbg_static_mut, 4);
     rust_dbg_static_mut_check_four();
     rust_dbg_static_mut += 1;
-    assert!(rust_dbg_static_mut == 5);
+    assert_eq!(rust_dbg_static_mut, 5);
     rust_dbg_static_mut *= 3;
-    assert!(rust_dbg_static_mut == 15);
+    assert_eq!(rust_dbg_static_mut, 15);
     rust_dbg_static_mut = -3;
-    assert!(rust_dbg_static_mut == -3);
+    assert_eq!(rust_dbg_static_mut, -3);
     static_bound(&rust_dbg_static_mut);
     static_bound_set(&mut rust_dbg_static_mut);
 }

--- a/src/test/run-pass/static-mut-xc.rs
+++ b/src/test/run-pass/static-mut-xc.rs
@@ -24,15 +24,15 @@ fn static_bound_set(a: &'static mut isize) {
 }
 
 unsafe fn run() {
-    assert!(static_mut_xc::a == 3);
+    assert_eq!(static_mut_xc::a, 3);
     static_mut_xc::a = 4;
-    assert!(static_mut_xc::a == 4);
+    assert_eq!(static_mut_xc::a, 4);
     static_mut_xc::a += 1;
-    assert!(static_mut_xc::a == 5);
+    assert_eq!(static_mut_xc::a, 5);
     static_mut_xc::a *= 3;
-    assert!(static_mut_xc::a == 15);
+    assert_eq!(static_mut_xc::a, 15);
     static_mut_xc::a = -3;
-    assert!(static_mut_xc::a == -3);
+    assert_eq!(static_mut_xc::a, -3);
     static_bound(&static_mut_xc::a);
     static_bound_set(&mut static_mut_xc::a);
 }

--- a/src/test/run-pass/string-escapes.rs
+++ b/src/test/run-pass/string-escapes.rs
@@ -12,5 +12,5 @@
 fn main() {
     let x = "\\\\\
     ";
-    assert!(x == r"\\"); // extraneous whitespace stripped
+    assert_eq!(x, r"\\"); // extraneous whitespace stripped
 }

--- a/src/test/run-pass/swap-1.rs
+++ b/src/test/run-pass/swap-1.rs
@@ -14,5 +14,6 @@ use std::mem::swap;
 pub fn main() {
     let mut x = 3; let mut y = 7;
     swap(&mut x, &mut y);
-    assert!((x == 7)); assert!((y == 3));
+    assert_eq!(x, 7);
+    assert_eq!(y, 3);
 }

--- a/src/test/run-pass/syntax-extension-source-utils-files/includeme.fragment
+++ b/src/test/run-pass/syntax-extension-source-utils-files/includeme.fragment
@@ -2,6 +2,6 @@
 
 {
     assert!(file!().ends_with("includeme.fragment"));
-    assert!(line!() == 5u32);
+    assert_eq!(line!(), 5u32);
     format!("victory robot {}", line!())
 }

--- a/src/test/run-pass/syntax-extension-source-utils.rs
+++ b/src/test/run-pass/syntax-extension-source-utils.rs
@@ -25,7 +25,7 @@ macro_rules! indirect_line { () => ( line!() ) }
 
 pub fn main() {
     assert_eq!(line!(), 27);
-    assert!((column!() == 4));
+    assert_eq!(column!(), 4);
     assert_eq!(indirect_line!(), 29);
     assert!((file!().ends_with("syntax-extension-source-utils.rs")));
     assert_eq!(stringify!((2*3) + 5).to_string(), "( 2 * 3 ) + 5".to_string());

--- a/src/test/run-pass/tag-variant-disr-val.rs
+++ b/src/test/run-pass/tag-variant-disr-val.rs
@@ -41,10 +41,10 @@ pub fn main() {
 }
 
 fn test_color(color: color, val: isize, name: String) {
-    //assert!(unsafe::transmute(color) == val);
+    //assert_eq!(unsafe::transmute(color), val);
     assert_eq!(color as isize, val);
-    assert!(get_color_alt(color) == name);
-    assert!(get_color_if(color) == name);
+    assert_eq!(get_color_alt(color), name);
+    assert_eq!(get_color_if(color), name);
 }
 
 fn get_color_alt(color: color) -> String {

--- a/src/test/run-pass/task-comm-10.rs
+++ b/src/test/run-pass/task-comm-10.rs
@@ -20,10 +20,10 @@ fn start(tx: &Sender<Sender<String>>) {
     let mut a;
     let mut b;
     a = rx.recv().unwrap();
-    assert!(a == "A".to_string());
+    assert_eq!(a, "A".to_string());
     println!("{}", a);
     b = rx.recv().unwrap();
-    assert!(b == "B".to_string());
+    assert_eq!(b, "B".to_string());
     println!("{}", b);
 }
 

--- a/src/test/run-pass/trait-impl.rs
+++ b/src/test/run-pass/trait-impl.rs
@@ -42,7 +42,7 @@ fn main() {
     T::foo(x);
     T::bar();
 
-    unsafe { assert!(COUNT == 12); }
+    unsafe { assert_eq!(COUNT, 12); }
 
     // Cross-crait case
     let x: &Bar = &Foo;

--- a/src/test/run-pass/trait-inheritance-subst.rs
+++ b/src/test/run-pass/trait-inheritance-subst.rs
@@ -32,5 +32,5 @@ fn mi(v: isize) -> MyInt { MyInt { val: v } }
 pub fn main() {
     let (x, y) = (mi(3), mi(5));
     let z = f(x, y);
-    assert!(z.val == 8)
+    assert_eq!(z.val, 8)
 }

--- a/src/test/run-pass/trait-to-str.rs
+++ b/src/test/run-pass/trait-to-str.rs
@@ -29,16 +29,16 @@ impl<T:to_str> to_str for Vec<T> {
 }
 
 pub fn main() {
-    assert!(1.to_string_() == "1".to_string());
-    assert!((vec!(2, 3, 4)).to_string_() == "[2, 3, 4]".to_string());
+    assert_eq!(1.to_string_(), "1".to_string());
+    assert_eq!((vec!(2, 3, 4)).to_string_(), "[2, 3, 4]".to_string());
 
     fn indirect<T:to_str>(x: T) -> String {
         format!("{}!", x.to_string_())
     }
-    assert!(indirect(vec!(10, 20)) == "[10, 20]!".to_string());
+    assert_eq!(indirect(vec!(10, 20)), "[10, 20]!".to_string());
 
     fn indirect2<T:to_str>(x: T) -> String {
         indirect(x)
     }
-    assert!(indirect2(vec!(1)) == "[1]!".to_string());
+    assert_eq!(indirect2(vec!(1)), "[1]!".to_string());
 }

--- a/src/test/run-pass/type-namespace.rs
+++ b/src/test/run-pass/type-namespace.rs
@@ -13,4 +13,4 @@ struct A { a: isize }
 
 fn a(a: A) -> isize { return a.a; }
 
-pub fn main() { let x: A = A {a: 1}; assert!((a(x) == 1)); }
+pub fn main() { let x: A = A {a: 1}; assert_eq!(a(x), 1); }

--- a/src/test/run-pass/type-sizes.rs
+++ b/src/test/run-pass/type-sizes.rs
@@ -40,7 +40,7 @@ pub fn main() {
     assert_eq!(size_of::<u>(), 3 as usize);
     // Alignment causes padding before the char and the u32.
 
-    assert!(size_of::<v>() ==
+    assert_eq!(size_of::<v>(),
                 16 as usize);
     assert_eq!(size_of::<isize>(), size_of::<usize>());
     assert_eq!(size_of::<w>(), size_of::<isize>());

--- a/src/test/run-pass/typestate-multi-decl.rs
+++ b/src/test/run-pass/typestate-multi-decl.rs
@@ -12,5 +12,5 @@
 pub fn main() {
     let (x, y) = (10, 20);
     let z = x + y;
-    assert!((z == 30));
+    assert_eq!(z, 30);
 }

--- a/src/test/run-pass/unboxed-closures-manual-impl.rs
+++ b/src/test/run-pass/unboxed-closures-manual-impl.rs
@@ -38,6 +38,6 @@ fn call_box(f: &mut FnMut(i32) -> i32, x: i32) -> i32 {
 fn main() {
     let x = call_it(S, 1);
     let y = call_box(&mut S, 1);
-    assert!(x == 4);
-    assert!(y == 4);
+    assert_eq!(x, 4);
+    assert_eq!(y, 4);
 }

--- a/src/test/run-pass/unique-cmp.rs
+++ b/src/test/run-pass/unique-cmp.rs
@@ -14,7 +14,7 @@
 
 pub fn main() {
     let i: Box<_> = box 100;
-    assert!(i == box 100);
+    assert_eq!(i, box 100);
     assert!(i < box 101);
     assert!(i <= box 100);
     assert!(i > box 99);

--- a/src/test/run-pass/unique-in-vec.rs
+++ b/src/test/run-pass/unique-in-vec.rs
@@ -14,5 +14,5 @@
 
 pub fn main() {
     let vect : Vec<Box<_>> = vec!(box 100);
-    assert!(vect[0] == box 100);
+    assert_eq!(vect[0], box 100);
 }

--- a/src/test/run-pass/unique-kinds.rs
+++ b/src/test/run-pass/unique-kinds.rs
@@ -13,11 +13,12 @@
 #![feature(box_syntax)]
 
 use std::cmp::PartialEq;
+use std::fmt::Debug;
 
 fn sendable() {
 
-    fn f<T:Send + PartialEq>(i: T, j: T) {
-        assert!(i == j);
+    fn f<T:Send + PartialEq + Debug>(i: T, j: T) {
+        assert_eq!(i, j);
     }
 
     fn g<T:Send + PartialEq>(i: T, j: T) {
@@ -34,8 +35,8 @@ fn sendable() {
 
 fn copyable() {
 
-    fn f<T:PartialEq>(i: T, j: T) {
-        assert!(i == j);
+    fn f<T:PartialEq + Debug>(i: T, j: T) {
+        assert_eq!(i, j);
     }
 
     fn g<T:PartialEq>(i: T, j: T) {
@@ -52,8 +53,8 @@ fn copyable() {
 
 fn noncopyable() {
 
-    fn f<T:PartialEq>(i: T, j: T) {
-        assert!(i == j);
+    fn f<T:PartialEq + Debug>(i: T, j: T) {
+        assert_eq!(i, j);
     }
 
     fn g<T:PartialEq>(i: T, j: T) {

--- a/src/test/run-pass/unsized3.rs
+++ b/src/test/run-pass/unsized3.rs
@@ -70,8 +70,8 @@ pub fn main() {
 
         let data: Box<Foo_<i32>> = box Foo_{f: [1, 2, 3] };
         let x: &Foo<i32> = mem::transmute(slice::from_raw_parts(&*data, 3));
-        assert!(x.f.len() == 3);
-        assert!(x.f[0] == 1);
+        assert_eq!(x.f.len(), 3);
+        assert_eq!(x.f[0], 1);
 
         struct Baz_ {
             f1: usize,
@@ -81,14 +81,14 @@ pub fn main() {
         let data: Box<_> = box Baz_ {
             f1: 42, f2: ['a' as u8, 'b' as u8, 'c' as u8, 'd' as u8, 'e' as u8] };
         let x: &Baz = mem::transmute(slice::from_raw_parts(&*data, 5));
-        assert!(x.f1 == 42);
+        assert_eq!(x.f1, 42);
         let chs: Vec<char> = x.f2.chars().collect();
-        assert!(chs.len() == 5);
-        assert!(chs[0] == 'a');
-        assert!(chs[1] == 'b');
-        assert!(chs[2] == 'c');
-        assert!(chs[3] == 'd');
-        assert!(chs[4] == 'e');
+        assert_eq!(chs.len(), 5);
+        assert_eq!(chs[0], 'a');
+        assert_eq!(chs[1], 'b');
+        assert_eq!(chs[2], 'c');
+        assert_eq!(chs[3], 'd');
+        assert_eq!(chs[4], 'e');
 
         struct Qux_ {
             f: St
@@ -100,6 +100,6 @@ pub fn main() {
         let data: Box<_> = box Qux_{ f: St { f: 234 } };
         let x: &Qux = mem::transmute(raw::TraitObject { vtable: obj.vtable,
                                                         data: mem::transmute(&*data) });
-        assert!(x.f.foo() == 234);
+        assert_eq!(x.f.foo(), 234);
     }
 }

--- a/src/test/run-pass/utf8_chars.rs
+++ b/src/test/run-pass/utf8_chars.rs
@@ -19,12 +19,12 @@ pub fn main() {
     let s: String = chs.iter().cloned().collect();
     let schs: Vec<char> = s.chars().collect();
 
-    assert!(s.len() == 10);
-    assert!(s.chars().count() == 4);
-    assert!(schs.len() == 4);
-    assert!(schs.iter().cloned().collect::<String>() == s);
-    assert!(s.char_at(0) == 'e');
-    assert!(s.char_at(1) == 'é');
+    assert_eq!(s.len(), 10);
+    assert_eq!(s.chars().count(), 4);
+    assert_eq!(schs.len(), 4);
+    assert_eq!(schs.iter().cloned().collect::<String>(), s);
+    assert_eq!(s.char_at(0), 'e');
+    assert_eq!(s.char_at(1), 'é');
 
     assert!((str::from_utf8(s.as_bytes()).is_ok()));
     // invalid prefix

--- a/src/test/run-pass/vec-dst.rs
+++ b/src/test/run-pass/vec-dst.rs
@@ -16,21 +16,21 @@ pub fn main() {
     // Tests for indexing into box/& [T; n]
     let x: [isize; 3] = [1, 2, 3];
     let mut x: Box<[isize; 3]> = box x;
-    assert!(x[0] == 1);
-    assert!(x[1] == 2);
-    assert!(x[2] == 3);
+    assert_eq!(x[0], 1);
+    assert_eq!(x[1], 2);
+    assert_eq!(x[2], 3);
     x[1] = 45;
-    assert!(x[0] == 1);
-    assert!(x[1] == 45);
-    assert!(x[2] == 3);
+    assert_eq!(x[0], 1);
+    assert_eq!(x[1], 45);
+    assert_eq!(x[2], 3);
 
     let mut x: [isize; 3] = [1, 2, 3];
     let x: &mut [isize; 3] = &mut x;
-    assert!(x[0] == 1);
-    assert!(x[1] == 2);
-    assert!(x[2] == 3);
+    assert_eq!(x[0], 1);
+    assert_eq!(x[1], 2);
+    assert_eq!(x[2], 3);
     x[1] = 45;
-    assert!(x[0] == 1);
-    assert!(x[1] == 45);
-    assert!(x[2] == 3);
+    assert_eq!(x[0], 1);
+    assert_eq!(x[1], 45);
+    assert_eq!(x[2], 3);
 }

--- a/src/test/run-pass/vec-matching-autoslice.rs
+++ b/src/test/run-pass/vec-matching-autoslice.rs
@@ -16,7 +16,7 @@ pub fn main() {
     match x {
         [2, _, _] => panic!(),
         [1, a, b] => {
-            assert!([a, b] == [2, 3]);
+            assert_eq!([a, b], [2, 3]);
         }
         [_, _, _] => panic!(),
     }

--- a/src/test/run-pass/vec-tail-matching.rs
+++ b/src/test/run-pass/vec-tail-matching.rs
@@ -24,10 +24,10 @@ pub fn main() {
     ];
     match x {
         [ref first, tail..] => {
-            assert!(first.string == "foo".to_string());
+            assert_eq!(first.string, "foo".to_string());
             assert_eq!(tail.len(), 2);
-            assert!(tail[0].string == "bar".to_string());
-            assert!(tail[1].string == "baz".to_string());
+            assert_eq!(tail[0].string, "bar".to_string());
+            assert_eq!(tail[1].string, "baz".to_string());
 
             match tail {
                 [Foo { .. }, _, Foo { .. }, _tail..] => {

--- a/src/test/run-pass/where-for-self.rs
+++ b/src/test/run-pass/where-for-self.rs
@@ -55,6 +55,6 @@ fn main() {
     foo1(&x);
     foo2(&x);
     unsafe {
-        assert!(COUNT == 12);
+        assert_eq!(COUNT, 12);
     }
 }

--- a/src/test/run-pass/zero-size-type-destructors.rs
+++ b/src/test/run-pass/zero-size-type-destructors.rs
@@ -28,5 +28,5 @@ pub fn foo() {
 
 pub fn main() {
   foo();
-  assert!((unsafe { destructions } == 0));
+  assert_eq!(unsafe { destructions }, 0);
 }

--- a/src/test/rustdoc/hidden-line.rs
+++ b/src/test/rustdoc/hidden-line.rs
@@ -22,7 +22,7 @@
 ///
 /// fn test() {
 ///     let x = Bar(Foo);
-///     assert!(x == x); // check that the derivings worked
+///     assert_eq!(x, x); // check that the derivings worked
 /// }
 ///
 /// }


### PR DESCRIPTION
`assert_eq!` has better diagnostics than `assert!` and is more helpful when something actually breaks, but the diagnostics has it's price - `assert_eq!` generate some formatting code which is slower to compile and possibly run.
[My measurements](https://internals.rust-lang.org/t/assert-a-b-or-assert-eq-a-b/1367/12?u=petrochenkov) show that presence of this formatting code doesn't affect compilation + execution time of the test suite significantly, so `assert_eq!` can be used instead of `assert!` consistently.

(Some tests doesn't reside in src/test, they are not affected by these changes, I'll probably open a separate PR for them later)
