### PR TITLE
Update doctest in comments.md

### DIFF
--- a/src/doc/trpl/comments.md
+++ b/src/doc/trpl/comments.md
@@ -29,6 +29,9 @@ The other kind of comment is a doc comment. Doc comments use `///` instead of
 /// let five = 5;
 ///
 /// assert_eq!(6, add_one(5));
+/// # fn add_one(x: i32) -> i32 {
+/// #     x + 1
+/// # }
 /// ```
 fn add_one(x: i32) -> i32 {
     x + 1


### PR DESCRIPTION
For a user following the path of reading Chapter 5: Syntax & Symantics
prior to Chapter 4: Learn Rust, this will be the first time they have
encountered executable tests inside documentation comments.

The test will fail because the `add_one` function is not defined in
the context of the doctest. This might not be the optimal place to
introduce and explain the `/// #` notation but I think it is important
that this snippet pass as a test when `rustdoc --test` is run against
it.
