### PR TITLE
Deprecate String::from_str in favor of String::from

### DIFF
--- a/src/compiletest/runtest.rs
+++ b/src/compiletest/runtest.rs
@@ -651,7 +651,7 @@ fn run_debuginfo_lldb_test(config: &Config, props: &TestProps, testfile: &Path) 
 
     // Write debugger script:
     // We don't want to hang when calling `quit` while the process is still running
-    let mut script_str = String::from_str("settings set auto-confirm true\n");
+    let mut script_str = String::from("settings set auto-confirm true\n");
 
     // Make LLDB emit its version, so we have it documented in the test output
     script_str.push_str("version\n");

--- a/src/grammar/verify.rs
+++ b/src/grammar/verify.rs
@@ -287,7 +287,7 @@ fn main() {
     let options = config::basic_options();
     let session = session::build_session(options, None,
                                          syntax::diagnostics::registry::Registry::new(&[]));
-    let filemap = session.parse_sess.codemap().new_filemap(String::from_str("<n/a>"), code);
+    let filemap = session.parse_sess.codemap().new_filemap(String::from("<n/a>"), code);
     let mut lexer = lexer::StringReader::new(session.diagnostic(), filemap);
     let cm = session.codemap();
 

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -89,7 +89,7 @@ impl String {
     ///
     /// ```
     /// # #![feature(collections)]
-    /// let s = String::from_str("hello");
+    /// let s = String::from("hello");
     /// assert_eq!(&s[..], "hello");
     /// ```
     #[inline]
@@ -1002,7 +1002,7 @@ pub fn as_string<'a>(x: &'a str) -> DerefString<'a> {
     DerefString { x: as_vec(x.as_bytes()) }
 }
 
-/// Error returned from `String::from_str`
+/// Error returned from `String::from`
 #[unstable(feature = "str_parse_error", reason = "may want to be replaced with \
                                                   Void if it ever exists")]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -1013,7 +1013,7 @@ impl FromStr for String {
     type Err = ParseError;
     #[inline]
     fn from_str(s: &str) -> Result<String, ParseError> {
-        Ok(String::from_str(s))
+        Ok(String::from(s))
     }
 }
 

--- a/src/libcollections/string.rs
+++ b/src/libcollections/string.rs
@@ -93,8 +93,8 @@ impl String {
     /// assert_eq!(&s[..], "hello");
     /// ```
     #[inline]
-    #[unstable(feature = "collections",
-               reason = "needs investigation to see if to_string() can match perf")]
+    #[unstable(feature = "collections", reason = "use `String::from` instead")]
+    #[deprecated(since = "1.2.0", reason = "use `String::from` instead")]
     #[cfg(not(test))]
     pub fn from_str(string: &str) -> String {
         String { vec: <[_]>::to_vec(string.as_bytes()) }

--- a/src/libcollectionstest/str.rs
+++ b/src/libcollectionstest/str.rs
@@ -71,17 +71,17 @@ fn test_rfind() {
 
 #[test]
 fn test_collect() {
-    let empty = String::from_str("");
+    let empty = String::from("");
     let s: String = empty.chars().collect();
     assert_eq!(empty, s);
-    let data = String::from_str("ประเทศไทย中");
+    let data = String::from("ประเทศไทย中");
     let s: String = data.chars().collect();
     assert_eq!(data, s);
 }
 
 #[test]
 fn test_into_bytes() {
-    let data = String::from_str("asdf");
+    let data = String::from("asdf");
     let buf = data.into_bytes();
     assert_eq!(buf, b"asdf");
 }
@@ -98,7 +98,7 @@ fn test_find_str() {
     assert!(data[2..4].find("ab").is_none());
 
     let string = "ประเทศไทย中华Việt Nam";
-    let mut data = String::from_str(string);
+    let mut data = String::from(string);
     data.push_str(string);
     assert!(data.find("ไท华").is_none());
     assert_eq!(data[0..43].find(""), Some(0));
@@ -211,7 +211,7 @@ fn test_unsafe_slice() {
     }
     let letters = a_million_letter_a();
     assert!(half_a_million_letter_a() ==
-        unsafe {String::from_str(letters.slice_unchecked(
+        unsafe {String::from(letters.slice_unchecked(
                                  0,
                                  500000))});
 }
@@ -247,13 +247,13 @@ fn test_is_empty() {
 #[test]
 fn test_replace() {
     let a = "a";
-    assert_eq!("".replace(a, "b"), String::from_str(""));
-    assert_eq!("a".replace(a, "b"), String::from_str("b"));
-    assert_eq!("ab".replace(a, "b"), String::from_str("bb"));
+    assert_eq!("".replace(a, "b"), String::from(""));
+    assert_eq!("a".replace(a, "b"), String::from("b"));
+    assert_eq!("ab".replace(a, "b"), String::from("bb"));
     let test = "test";
     assert!(" test test ".replace(test, "toast") ==
-        String::from_str(" toast toast "));
-    assert_eq!(" test test ".replace(test, ""), String::from_str("   "));
+        String::from(" toast toast "));
+    assert_eq!(" test test ".replace(test, ""), String::from("   "));
 }
 
 #[test]
@@ -328,7 +328,7 @@ fn test_slice() {
     }
     let letters = a_million_letter_x();
     assert!(half_a_million_letter_x() ==
-        String::from_str(&letters[0..3 * 500000]));
+        String::from(&letters[0..3 * 500000]));
 }
 
 #[test]
@@ -581,7 +581,7 @@ fn test_as_bytes() {
 fn test_as_bytes_fail() {
     // Don't double free. (I'm not sure if this exercises the
     // original problem code path anymore.)
-    let s = String::from_str("");
+    let s = String::from("");
     let _bytes = s.as_bytes();
     panic!();
 }
@@ -623,10 +623,10 @@ fn test_subslice_offset_2() {
 
 #[test]
 fn vec_str_conversions() {
-    let s1: String = String::from_str("All mimsy were the borogoves");
+    let s1: String = String::from("All mimsy were the borogoves");
 
     let v: Vec<u8> = s1.as_bytes().to_vec();
-    let s2: String = String::from_str(from_utf8(&v).unwrap());
+    let s2: String = String::from(from_utf8(&v).unwrap());
     let mut i = 0;
     let n1 = s1.len();
     let n2 = v.len();
@@ -691,39 +691,39 @@ fn test_char_at_reverse() {
 #[test]
 fn test_escape_unicode() {
     assert_eq!("abc".escape_unicode(),
-               String::from_str("\\u{61}\\u{62}\\u{63}"));
+               String::from("\\u{61}\\u{62}\\u{63}"));
     assert_eq!("a c".escape_unicode(),
-               String::from_str("\\u{61}\\u{20}\\u{63}"));
+               String::from("\\u{61}\\u{20}\\u{63}"));
     assert_eq!("\r\n\t".escape_unicode(),
-               String::from_str("\\u{d}\\u{a}\\u{9}"));
+               String::from("\\u{d}\\u{a}\\u{9}"));
     assert_eq!("'\"\\".escape_unicode(),
-               String::from_str("\\u{27}\\u{22}\\u{5c}"));
+               String::from("\\u{27}\\u{22}\\u{5c}"));
     assert_eq!("\x00\x01\u{fe}\u{ff}".escape_unicode(),
-               String::from_str("\\u{0}\\u{1}\\u{fe}\\u{ff}"));
+               String::from("\\u{0}\\u{1}\\u{fe}\\u{ff}"));
     assert_eq!("\u{100}\u{ffff}".escape_unicode(),
-               String::from_str("\\u{100}\\u{ffff}"));
+               String::from("\\u{100}\\u{ffff}"));
     assert_eq!("\u{10000}\u{10ffff}".escape_unicode(),
-               String::from_str("\\u{10000}\\u{10ffff}"));
+               String::from("\\u{10000}\\u{10ffff}"));
     assert_eq!("ab\u{fb00}".escape_unicode(),
-               String::from_str("\\u{61}\\u{62}\\u{fb00}"));
+               String::from("\\u{61}\\u{62}\\u{fb00}"));
     assert_eq!("\u{1d4ea}\r".escape_unicode(),
-               String::from_str("\\u{1d4ea}\\u{d}"));
+               String::from("\\u{1d4ea}\\u{d}"));
 }
 
 #[test]
 fn test_escape_default() {
-    assert_eq!("abc".escape_default(), String::from_str("abc"));
-    assert_eq!("a c".escape_default(), String::from_str("a c"));
-    assert_eq!("\r\n\t".escape_default(), String::from_str("\\r\\n\\t"));
-    assert_eq!("'\"\\".escape_default(), String::from_str("\\'\\\"\\\\"));
+    assert_eq!("abc".escape_default(), String::from("abc"));
+    assert_eq!("a c".escape_default(), String::from("a c"));
+    assert_eq!("\r\n\t".escape_default(), String::from("\\r\\n\\t"));
+    assert_eq!("'\"\\".escape_default(), String::from("\\'\\\"\\\\"));
     assert_eq!("\u{100}\u{ffff}".escape_default(),
-               String::from_str("\\u{100}\\u{ffff}"));
+               String::from("\\u{100}\\u{ffff}"));
     assert_eq!("\u{10000}\u{10ffff}".escape_default(),
-               String::from_str("\\u{10000}\\u{10ffff}"));
+               String::from("\\u{10000}\\u{10ffff}"));
     assert_eq!("ab\u{fb00}".escape_default(),
-               String::from_str("ab\\u{fb00}"));
+               String::from("ab\\u{fb00}"));
     assert_eq!("\u{1d4ea}\r".escape_default(),
-               String::from_str("\\u{1d4ea}\\r"));
+               String::from("\\u{1d4ea}\\r"));
 }
 
 #[test]
@@ -1490,12 +1490,12 @@ fn test_str_container() {
         v.iter().map(|x| x.len()).sum()
     }
 
-    let s = String::from_str("01234");
+    let s = String::from("01234");
     assert_eq!(5, sum_len(&["012", "", "34"]));
-    assert_eq!(5, sum_len(&[&String::from_str("01"),
-                            &String::from_str("2"),
-                            &String::from_str("34"),
-                            &String::from_str("")]));
+    assert_eq!(5, sum_len(&[&String::from("01"),
+                            &String::from("2"),
+                            &String::from("34"),
+                            &String::from("")]));
     assert_eq!(5, sum_len(&[&s]));
 }
 

--- a/src/libcollectionstest/string.rs
+++ b/src/libcollectionstest/string.rs
@@ -37,11 +37,11 @@ fn test_unsized_to_string() {
 fn test_from_utf8() {
     let xs = b"hello".to_vec();
     assert_eq!(String::from_utf8(xs).unwrap(),
-               String::from_str("hello"));
+               String::from("hello"));
 
     let xs = "ศไทย中华Việt Nam".as_bytes().to_vec();
     assert_eq!(String::from_utf8(xs).unwrap(),
-               String::from_str("ศไทย中华Việt Nam"));
+               String::from("ศไทย中华Việt Nam"));
 
     let xs = b"hello\xFF".to_vec();
     let err = String::from_utf8(xs).err().unwrap();
@@ -60,44 +60,44 @@ fn test_from_utf8_lossy() {
 
     let xs = b"Hello\xC2 There\xFF Goodbye";
     assert_eq!(String::from_utf8_lossy(xs),
-               String::from_str("Hello\u{FFFD} There\u{FFFD} Goodbye").into_cow());
+               String::from("Hello\u{FFFD} There\u{FFFD} Goodbye").into_cow());
 
     let xs = b"Hello\xC0\x80 There\xE6\x83 Goodbye";
     assert_eq!(String::from_utf8_lossy(xs),
-               String::from_str("Hello\u{FFFD}\u{FFFD} There\u{FFFD} Goodbye").into_cow());
+               String::from("Hello\u{FFFD}\u{FFFD} There\u{FFFD} Goodbye").into_cow());
 
     let xs = b"\xF5foo\xF5\x80bar";
     assert_eq!(String::from_utf8_lossy(xs),
-               String::from_str("\u{FFFD}foo\u{FFFD}\u{FFFD}bar").into_cow());
+               String::from("\u{FFFD}foo\u{FFFD}\u{FFFD}bar").into_cow());
 
     let xs = b"\xF1foo\xF1\x80bar\xF1\x80\x80baz";
     assert_eq!(String::from_utf8_lossy(xs),
-               String::from_str("\u{FFFD}foo\u{FFFD}bar\u{FFFD}baz").into_cow());
+               String::from("\u{FFFD}foo\u{FFFD}bar\u{FFFD}baz").into_cow());
 
     let xs = b"\xF4foo\xF4\x80bar\xF4\xBFbaz";
     assert_eq!(String::from_utf8_lossy(xs),
-               String::from_str("\u{FFFD}foo\u{FFFD}bar\u{FFFD}\u{FFFD}baz").into_cow());
+               String::from("\u{FFFD}foo\u{FFFD}bar\u{FFFD}\u{FFFD}baz").into_cow());
 
     let xs = b"\xF0\x80\x80\x80foo\xF0\x90\x80\x80bar";
-    assert_eq!(String::from_utf8_lossy(xs), String::from_str("\u{FFFD}\u{FFFD}\u{FFFD}\u{FFFD}\
+    assert_eq!(String::from_utf8_lossy(xs), String::from("\u{FFFD}\u{FFFD}\u{FFFD}\u{FFFD}\
                                            foo\u{10000}bar").into_cow());
 
     // surrogates
     let xs = b"\xED\xA0\x80foo\xED\xBF\xBFbar";
-    assert_eq!(String::from_utf8_lossy(xs), String::from_str("\u{FFFD}\u{FFFD}\u{FFFD}foo\
+    assert_eq!(String::from_utf8_lossy(xs), String::from("\u{FFFD}\u{FFFD}\u{FFFD}foo\
                                            \u{FFFD}\u{FFFD}\u{FFFD}bar").into_cow());
 }
 
 #[test]
 fn test_from_utf16() {
     let pairs =
-        [(String::from_str("𐍅𐌿𐌻𐍆𐌹𐌻𐌰\n"),
+        [(String::from("𐍅𐌿𐌻𐍆𐌹𐌻𐌰\n"),
           vec![0xd800, 0xdf45, 0xd800, 0xdf3f,
             0xd800, 0xdf3b, 0xd800, 0xdf46,
             0xd800, 0xdf39, 0xd800, 0xdf3b,
             0xd800, 0xdf30, 0x000a]),
 
-         (String::from_str("𐐒𐑉𐐮𐑀𐐲𐑋 𐐏𐐲𐑍\n"),
+         (String::from("𐐒𐑉𐐮𐑀𐐲𐑋 𐐏𐐲𐑍\n"),
           vec![0xd801, 0xdc12, 0xd801,
             0xdc49, 0xd801, 0xdc2e, 0xd801,
             0xdc40, 0xd801, 0xdc32, 0xd801,
@@ -105,7 +105,7 @@ fn test_from_utf16() {
             0xd801, 0xdc32, 0xd801, 0xdc4d,
             0x000a]),
 
-         (String::from_str("𐌀𐌖𐌋𐌄𐌑𐌉·𐌌𐌄𐌕𐌄𐌋𐌉𐌑\n"),
+         (String::from("𐌀𐌖𐌋𐌄𐌑𐌉·𐌌𐌄𐌕𐌄𐌋𐌉𐌑\n"),
           vec![0xd800, 0xdf00, 0xd800, 0xdf16,
             0xd800, 0xdf0b, 0xd800, 0xdf04,
             0xd800, 0xdf11, 0xd800, 0xdf09,
@@ -114,7 +114,7 @@ fn test_from_utf16() {
             0xdf04, 0xd800, 0xdf0b, 0xd800,
             0xdf09, 0xd800, 0xdf11, 0x000a ]),
 
-         (String::from_str("𐒋𐒘𐒈𐒑𐒛𐒒 𐒕𐒓 𐒈𐒚𐒍 𐒏𐒜𐒒𐒖𐒆 𐒕𐒆\n"),
+         (String::from("𐒋𐒘𐒈𐒑𐒛𐒒 𐒕𐒓 𐒈𐒚𐒍 𐒏𐒜𐒒𐒖𐒆 𐒕𐒆\n"),
           vec![0xd801, 0xdc8b, 0xd801, 0xdc98,
             0xd801, 0xdc88, 0xd801, 0xdc91,
             0xd801, 0xdc9b, 0xd801, 0xdc92,
@@ -127,7 +127,7 @@ fn test_from_utf16() {
             0xd801, 0xdc95, 0xd801, 0xdc86,
             0x000a ]),
          // Issue #12318, even-numbered non-BMP planes
-         (String::from_str("\u{20000}"),
+         (String::from("\u{20000}"),
           vec![0xD840, 0xDC00])];
 
     for p in &pairs {
@@ -165,22 +165,22 @@ fn test_utf16_invalid() {
 fn test_from_utf16_lossy() {
     // completely positive cases tested above.
     // lead + eof
-    assert_eq!(String::from_utf16_lossy(&[0xD800]), String::from_str("\u{FFFD}"));
+    assert_eq!(String::from_utf16_lossy(&[0xD800]), String::from("\u{FFFD}"));
     // lead + lead
     assert_eq!(String::from_utf16_lossy(&[0xD800, 0xD800]),
-               String::from_str("\u{FFFD}\u{FFFD}"));
+               String::from("\u{FFFD}\u{FFFD}"));
 
     // isolated trail
-    assert_eq!(String::from_utf16_lossy(&[0x0061, 0xDC00]), String::from_str("a\u{FFFD}"));
+    assert_eq!(String::from_utf16_lossy(&[0x0061, 0xDC00]), String::from("a\u{FFFD}"));
 
     // general
     assert_eq!(String::from_utf16_lossy(&[0xD800, 0xd801, 0xdc8b, 0xD800]),
-               String::from_str("\u{FFFD}𐒋\u{FFFD}"));
+               String::from("\u{FFFD}𐒋\u{FFFD}"));
 }
 
 #[test]
 fn test_push_bytes() {
-    let mut s = String::from_str("ABC");
+    let mut s = String::from("ABC");
     unsafe {
         let mv = s.as_mut_vec();
         mv.push_all(&[b'D']);
@@ -201,7 +201,7 @@ fn test_push_str() {
 
 #[test]
 fn test_push() {
-    let mut data = String::from_str("ประเทศไทย中");
+    let mut data = String::from("ประเทศไทย中");
     data.push('华');
     data.push('b'); // 1 byte
     data.push('¢'); // 2 byte
@@ -212,7 +212,7 @@ fn test_push() {
 
 #[test]
 fn test_pop() {
-    let mut data = String::from_str("ประเทศไทย中华b¢€𤭢");
+    let mut data = String::from("ประเทศไทย中华b¢€𤭢");
     assert_eq!(data.pop().unwrap(), '𤭢'); // 4 bytes
     assert_eq!(data.pop().unwrap(), '€'); // 3 bytes
     assert_eq!(data.pop().unwrap(), '¢'); // 2 bytes
@@ -223,7 +223,7 @@ fn test_pop() {
 
 #[test]
 fn test_str_truncate() {
-    let mut s = String::from_str("12345");
+    let mut s = String::from("12345");
     s.truncate(5);
     assert_eq!(s, "12345");
     s.truncate(3);
@@ -231,7 +231,7 @@ fn test_str_truncate() {
     s.truncate(0);
     assert_eq!(s, "");
 
-    let mut s = String::from_str("12345");
+    let mut s = String::from("12345");
     let p = s.as_ptr();
     s.truncate(3);
     s.push_str("6");
@@ -242,20 +242,20 @@ fn test_str_truncate() {
 #[test]
 #[should_panic]
 fn test_str_truncate_invalid_len() {
-    let mut s = String::from_str("12345");
+    let mut s = String::from("12345");
     s.truncate(6);
 }
 
 #[test]
 #[should_panic]
 fn test_str_truncate_split_codepoint() {
-    let mut s = String::from_str("\u{FC}"); // ü
+    let mut s = String::from("\u{FC}"); // ü
     s.truncate(1);
 }
 
 #[test]
 fn test_str_clear() {
-    let mut s = String::from_str("12345");
+    let mut s = String::from("12345");
     s.clear();
     assert_eq!(s.len(), 0);
     assert_eq!(s, "");
@@ -263,7 +263,7 @@ fn test_str_clear() {
 
 #[test]
 fn test_str_add() {
-    let a = String::from_str("12345");
+    let a = String::from("12345");
     let b = a + "2";
     let b = b + "2";
     assert_eq!(b.len(), 7);
@@ -473,7 +473,7 @@ fn bench_from_str(b: &mut Bencher) {
     let s = "Hello there, the quick brown fox jumped over the lazy dog! \
              Lorem ipsum dolor sit amet, consectetur. ";
     b.iter(|| {
-        String::from_str(s)
+        String::from(s)
     })
 }
 

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -1783,7 +1783,7 @@ impl LifeGiver {
     fn give_lifetime(&self) -> ast::Lifetime {
         let mut lifetime;
         loop {
-            let mut s = String::from_str("'");
+            let mut s = String::from("'");
             s.push_str(&num_to_string(self.counter.get()));
             if !self.taken.contains(&s) {
                 lifetime = name_to_dummy_lifetime(

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -210,7 +210,7 @@ fn symbol_hash<'tcx>(tcx: &ty::ctxt<'tcx>,
     symbol_hasher.input_str("-");
     symbol_hasher.input_str(&encoder::encoded_ty(tcx, t));
     // Prefix with 'h' so that it never blends into adjacent digits
-    let mut hash = String::from_str("h");
+    let mut hash = String::from("h");
     hash.push_str(&truncated_hash_result(symbol_hasher));
     hash
 }
@@ -294,7 +294,7 @@ pub fn mangle<PI: Iterator<Item=PathElem>>(path: PI,
     // To be able to work on all platforms and get *some* reasonable output, we
     // use C++ name-mangling.
 
-    let mut n = String::from_str("_ZN"); // _Z == Begin name-sequence, N == nested
+    let mut n = String::from("_ZN"); // _Z == Begin name-sequence, N == nested
 
     fn push(n: &mut String, s: &str) {
         let sani = sanitize(s);

--- a/src/librustc_trans/save/dump_csv.rs
+++ b/src/librustc_trans/save/dump_csv.rs
@@ -318,7 +318,7 @@ impl <'l, 'tcx> DumpCsvVisitor<'l, 'tcx> {
                     scope_id = item.id;
                     match item.node {
                         ast::ItemImpl(_, _, _, _, ref ty, _) => {
-                            let mut result = String::from_str("<");
+                            let mut result = String::from("<");
                             result.push_str(&ty_to_string(&**ty));
 
                             match ty::trait_of_item(&self.analysis.ty_cx,
@@ -1341,7 +1341,7 @@ impl<'l, 'tcx, 'v> Visitor<'v> for DumpCsvVisitor<'l, 'tcx> {
                     return
                 }
 
-                let mut id = String::from_str("$");
+                let mut id = String::from("$");
                 id.push_str(&ex.id.to_string());
                 self.process_formals(&decl.inputs, &id);
 

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -152,7 +152,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
 
                 // If the variable is immutable, save the initialising expression.
                 let (value, keyword) = match mt {
-                    ast::MutMutable => (String::from_str("<mutable>"), keywords::Mut),
+                    ast::MutMutable => (String::from("<mutable>"), keywords::Mut),
                     ast::MutImmutable => (self.span_utils.snippet(expr.span), keywords::Static),
                 };
 
@@ -326,7 +326,7 @@ pub fn process_crate(sess: &Session,
         Some(name) => name.to_string(),
         None => {
             info!("Could not find crate name, using 'unknown_crate'");
-            String::from_str("unknown_crate")
+            String::from("unknown_crate")
         },
     };
 

--- a/src/librustc_trans/save/recorder.rs
+++ b/src/librustc_trans/save/recorder.rs
@@ -178,7 +178,7 @@ impl<'a> FmtStrs<'a> {
         });
 
         let pairs = fields.iter().zip(values);
-        let strs = pairs.map(|(f, v)| format!(",{},\"{}\"", f, escape(String::from_str(v))));
+        let strs = pairs.map(|(f, v)| format!(",{},\"{}\"", f, escape(String::from(v))));
         Some(strs.fold(String::new(), |mut s, ss| {
             s.push_str(&ss[..]);
             s
@@ -207,7 +207,7 @@ impl<'a> FmtStrs<'a> {
             None => return,
         };
 
-        let mut result = String::from_str(label);
+        let mut result = String::from(label);
         result.push_str(&values_str[..]);
         result.push_str("\n");
         self.recorder.record(&result[..]);
@@ -269,7 +269,7 @@ impl<'a> FmtStrs<'a> {
         // the local case they can be overridden in one block and there is no nice way
         // to refer to such a scope in english, so we just hack it by appending the
         // variable def's node id
-        let mut qualname = String::from_str(name);
+        let mut qualname = String::from(name);
         qualname.push_str("$");
         qualname.push_str(&id.to_string());
         self.check_and_record(Variable,
@@ -286,7 +286,7 @@ impl<'a> FmtStrs<'a> {
                       fn_name: &str,
                       name: &str,
                       typ: &str) {
-        let mut qualname = String::from_str(fn_name);
+        let mut qualname = String::from(fn_name);
         qualname.push_str("::");
         qualname.push_str(name);
         self.check_and_record(Variable,

--- a/src/librustc_trans/save/span_utils.rs
+++ b/src/librustc_trans/save/span_utils.rs
@@ -83,7 +83,7 @@ impl<'a> SpanUtils<'a> {
         // the codemap as a new filemap. This is mostly OK, but means we should
         // not iterate over the codemap. Also, any spans over the new filemap
         // are incompatible with spans over other filemaps.
-        let filemap = self.sess.codemap().new_filemap(String::from_str("<anon-dxr>"),
+        let filemap = self.sess.codemap().new_filemap(String::from("<anon-dxr>"),
                                                       self.snippet(span));
         let s = self.sess;
         lexer::StringReader::new(s.diagnostic(), filemap)

--- a/src/librustc_trans/trans/builder.rs
+++ b/src/librustc_trans/trans/builder.rs
@@ -71,7 +71,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // Pass 2: concat strings for each elt, skipping
                 // forwards over any cycles by advancing to rightmost
                 // occurrence of each element in path.
-                let mut s = String::from_str(".");
+                let mut s = String::from(".");
                 i = 0;
                 while i < len {
                     i = mm[v[i]];

--- a/src/librustc_trans/trans/debuginfo/mod.rs
+++ b/src/librustc_trans/trans/debuginfo/mod.rs
@@ -331,7 +331,7 @@ pub fn create_function_debug_context<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
 
     // Get_template_parameters() will append a `<...>` clause to the function
     // name if necessary.
-    let mut function_name = String::from_str(&token::get_name(name));
+    let mut function_name = String::from(&*token::get_name(name));
     let template_parameters = get_template_parameters(cx,
                                                       generics,
                                                       param_substs,

--- a/src/librustc_trans/trans/debuginfo/namespace.rs
+++ b/src/librustc_trans/trans/debuginfo/namespace.rs
@@ -41,7 +41,7 @@ impl NamespaceTreeNode {
             output.push_str(&string);
         }
 
-        let mut name = String::from_str("_ZN");
+        let mut name = String::from("_ZN");
         fill_nested(self, &mut name);
         name.push_str(&format!("{}", item_name.len()));
         name.push_str(item_name);

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2521,7 +2521,7 @@ fn lit_to_string(lit: &ast::Lit) -> String {
         ast::LitStr(ref st, _) => st.to_string(),
         ast::LitBinary(ref data) => format!("{:?}", data),
         ast::LitByte(b) => {
-            let mut res = String::from_str("b'");
+            let mut res = String::from("b'");
             for c in (b as char).escape_default() {
                 res.push(c);
             }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -335,8 +335,7 @@ fn resolved_path(w: &mut fmt::Formatter, did: ast::DefId, path: &clean::Path,
     if print_all {
         let amt = path.segments.len() - 1;
         match rel_root {
-            Some(root) => {
-                let mut root = String::from_str(&root);
+            Some(mut root) => {
                 for seg in &path.segments[..amt] {
                     if "super" == seg.name || "self" == seg.name {
                         try!(write!(w, "{}::", seg.name));

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -817,7 +817,7 @@ impl<'a> SourceCollector<'a> {
 
         // Create the intermediate directories
         let mut cur = self.dst.clone();
-        let mut root_path = String::from_str("../../");
+        let mut root_path = String::from("../../");
         clean_srcpath(&self.cx.src_root, &p, false, |component| {
             cur.push(component);
             mkdir(&cur).unwrap();

--- a/src/librustdoc/html/toc.rs
+++ b/src/librustdoc/html/toc.rs
@@ -145,7 +145,7 @@ impl TocBuilder {
                     (0, &self.top_level)
                 }
                 Some(entry) => {
-                    sec_number = String::from_str(&entry.sec_number);
+                    sec_number = entry.sec_number.clone();
                     sec_number.push_str(".");
                     (entry.level, &entry.children)
                 }

--- a/src/librustdoc/plugins.rs
+++ b/src/librustdoc/plugins.rs
@@ -90,7 +90,7 @@ fn libname(mut n: String) -> String {
 
 #[cfg(all(not(target_os="windows"), not(target_os="macos")))]
 fn libname(n: String) -> String {
-    let mut i = String::from_str("lib");
+    let mut i = String::from("lib");
     i.push_str(&n);
     i.push_str(".so");
     i

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -457,7 +457,7 @@ fn spaces(wr: &mut fmt::Write, mut n: usize) -> EncodeResult {
 
 fn fmt_number_or_null(v: f64) -> string::String {
     match v.classify() {
-        Fp::Nan | Fp::Infinite => string::String::from_str("null"),
+        Fp::Nan | Fp::Infinite => string::String::from("null"),
         _ if v.fract() != 0f64 => v.to_string(),
         _ => v.to_string() + ".0",
     }

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -121,7 +121,7 @@ impl From<String> for Box<Error + Send + Sync> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, 'b> From<&'b str> for Box<Error + Send + Sync + 'a> {
     fn from(err: &'b str) -> Box<Error + Send + Sync + 'a> {
-        From::from(String::from_str(err))
+        From::from(String::from(err))
     }
 }
 

--- a/src/libstd/sys/common/wtf8.rs
+++ b/src/libstd/sys/common/wtf8.rs
@@ -906,8 +906,8 @@ mod tests {
 
     #[test]
     fn wtf8buf_from_string() {
-        assert_eq!(Wtf8Buf::from_string(String::from_str("")).bytes, b"");
-        assert_eq!(Wtf8Buf::from_string(String::from_str("aé 💩")).bytes,
+        assert_eq!(Wtf8Buf::from_string(String::from("")).bytes, b"");
+        assert_eq!(Wtf8Buf::from_string(String::from("aé 💩")).bytes,
                    b"a\xC3\xA9 \xF0\x9F\x92\xA9");
     }
 
@@ -1049,7 +1049,7 @@ mod tests {
     #[test]
     fn wtf8buf_into_string() {
         let mut string = Wtf8Buf::from_str("aé 💩");
-        assert_eq!(string.clone().into_string(), Ok(String::from_str("aé 💩")));
+        assert_eq!(string.clone().into_string(), Ok(String::from("aé 💩")));
         string.push(CodePoint::from_u32(0xD800).unwrap());
         assert_eq!(string.clone().into_string(), Err(string));
     }
@@ -1057,9 +1057,9 @@ mod tests {
     #[test]
     fn wtf8buf_into_string_lossy() {
         let mut string = Wtf8Buf::from_str("aé 💩");
-        assert_eq!(string.clone().into_string_lossy(), String::from_str("aé 💩"));
+        assert_eq!(string.clone().into_string_lossy(), String::from("aé 💩"));
         string.push(CodePoint::from_u32(0xD800).unwrap());
-        assert_eq!(string.clone().into_string_lossy(), String::from_str("aé 💩�"));
+        assert_eq!(string.clone().into_string_lossy(), String::from("aé 💩�"));
     }
 
     #[test]
@@ -1226,7 +1226,7 @@ mod tests {
         assert_eq!(Wtf8::from_str("aé 💩").to_string_lossy(), Cow::Borrowed("aé 💩"));
         let mut string = Wtf8Buf::from_str("aé 💩");
         string.push(CodePoint::from_u32(0xD800).unwrap());
-        let expected: Cow<str> = Cow::Owned(String::from_str("aé 💩�"));
+        let expected: Cow<str> = Cow::Owned(String::from("aé 💩�"));
         assert_eq!(string.to_string_lossy(), expected);
     }
 

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -127,7 +127,7 @@ enum NamePadding {
 
 impl TestDesc {
     fn padded_name(&self, column_count: usize, align: NamePadding) -> String {
-        let mut name = String::from_str(self.name.as_slice());
+        let mut name = String::from(self.name.as_slice());
         let fill = column_count.saturating_sub(name.len());
         let pad = repeat(" ").take(fill).collect::<String>();
         match align {

--- a/src/test/run-pass/issue-19811-escape-unicode.rs
+++ b/src/test/run-pass/issue-19811-escape-unicode.rs
@@ -12,7 +12,7 @@
 #![feature(collections)]
 
 fn main() {
-    let mut escaped = String::from_str("");
+    let mut escaped = String::from("");
     for c in '\u{10401}'.escape_unicode() {
         escaped.push(c);
     }

--- a/src/test/run-pass/istr.rs
+++ b/src/test/run-pass/istr.rs
@@ -41,12 +41,12 @@ fn test_append() {
     s.push_str("a");
     assert_eq!(s, "a");
 
-    let mut s = String::from_str("a");
+    let mut s = String::from("a");
     s.push_str("b");
     println!("{}", s.clone());
     assert_eq!(s, "ab");
 
-    let mut s = String::from_str("c");
+    let mut s = String::from("c");
     s.push_str("offee");
     assert!(s == "coffee");
 

--- a/src/test/run-pass/new-unicode-escapes.rs
+++ b/src/test/run-pass/new-unicode-escapes.rs
@@ -19,7 +19,7 @@ pub fn main() {
     assert_eq!(s, "⨐⨁⪠");
 
     let s = "\\{20}";
-    let mut correct_s = String::from_str("\\");
+    let mut correct_s = String::from("\\");
     correct_s.push_str("{20}");
     assert_eq!(s, correct_s);
 }

--- a/src/test/run-pass/overloaded-autoderef.rs
+++ b/src/test/run-pass/overloaded-autoderef.rs
@@ -34,7 +34,7 @@ pub fn main() {
     let s = Rc::new("foo".to_string());
     assert_eq!(&**s, "foo");
 
-    let mut_s = Rc::new(RefCell::new(String::from_str("foo")));
+    let mut_s = Rc::new(RefCell::new(String::from("foo")));
     mut_s.borrow_mut().push_str("bar");
     // HACK assert_eq! would panic here because it stores the LHS and RHS in two locals.
     assert!(&**mut_s.borrow() == "foobar");

--- a/src/test/run-pass/overloaded-deref.rs
+++ b/src/test/run-pass/overloaded-deref.rs
@@ -34,7 +34,7 @@ pub fn main() {
     assert_eq!(*s, "foo".to_string());
     assert_eq!((*s), "foo");
 
-    let mut_s = Rc::new(RefCell::new(String::from_str("foo")));
+    let mut_s = Rc::new(RefCell::new(String::from("foo")));
     (*(*mut_s).borrow_mut()).push_str("bar");
     // assert_eq! would panic here because it stores the LHS and RHS in two locals.
     assert!((*(*mut_s).borrow()) == "foobar");

--- a/src/test/run-pass/while-prelude-drop.rs
+++ b/src/test/run-pass/while-prelude-drop.rs
@@ -17,7 +17,7 @@ enum t { a, b(String), }
 
 fn make(i: isize) -> t {
     if i > 10 { return t::a; }
-    let mut s = String::from_str("hello");
+    let mut s = String::from("hello");
     // Ensure s is non-const.
 
     s.push_str("there");


### PR DESCRIPTION
With the latter is provided by the `From` conversion trait, the former is now completely redundant. Their code is identical. Let’s deprecate now and plan to remove in the next cycle. (It’s `#[unstable]`.)

r? @alexcrichton 
CC @nagisa 
