### PR TITLE
Make all leaks safe in language reference

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -1038,7 +1038,7 @@ be undesired.
 
 * Deadlocks
 * Reading data from private fields (`std::repr`)
-* Leaks due to reference count cycles, even in the global heap
+* Leaks of memory and other resources
 * Exiting without calling destructors
 * Sending signals
 * Accessing/modifying the file system


### PR DESCRIPTION
It was determined that no leaks were unsafe, make the language reference clear about this.
