### PR TITLE
Translate "ignored" closure expressions.

### DIFF
--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -139,9 +139,12 @@ pub fn trans_into<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                 // have different types.
                 let lldest = PointerCast(bcx, lldest, val_ty(global));
                 memcpy_ty(bcx, lldest, global, expr_ty_adjusted(bcx, expr));
+                return bcx;
             }
-            // Don't do anything in the Ignore case, consts don't need drop.
-            return bcx;
+            // Even if we don't have a value to emit, and the expression
+            // doesn't have any side-effects, we still have to translate the
+            // body of any closures.
+            // FIXME: Find a better way of handling this case.
         } else {
             // The only way we're going to see a `const` at this point is if
             // it prefers in-place instantiation, likely because it contains

--- a/src/test/run-pass/issue-24779.rs
+++ b/src/test/run-pass/issue-24779.rs
@@ -1,0 +1,13 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    assert_eq!((||||42)()(), 42);
+}


### PR DESCRIPTION
This isn't a very clean fix, but I'm not sure what a better fix would look
like.

Fixes #24779.
