### PR TITLE
Don't compress metadata when not producing dylibs

### DIFF
--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -389,7 +389,9 @@ pub fn link_binary(sess: &Session,
                    outputs: &OutputFilenames,
                    crate_name: &str) -> Vec<PathBuf> {
     let mut out_filenames = Vec::new();
+    let mut dylib = false;
     for &crate_type in &*sess.crate_types.borrow() {
+        dylib = dylib || crate_type == config::CrateTypeDylib;
         if invalid_output_for_target(sess, crate_type) {
             sess.bug(&format!("invalid output type `{:?}` for target os `{}`",
                              crate_type, sess.opts.target_triple));
@@ -405,7 +407,10 @@ pub fn link_binary(sess: &Session,
         if !sess.opts.output_types.contains(&OutputTypeObject) {
             remove(sess, &obj_filename);
         }
-        remove(sess, &obj_filename.with_extension("metadata.o"));
+        if dylib {
+            // metadata.o is only produced for dylibs
+            remove(sess, &obj_filename.with_extension("metadata.o"));
+        }
     }
 
     out_filenames

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -642,9 +642,9 @@ pub fn run_passes(sess: &Session,
     // doesn't actually matter.)
     let mut work_items = Vec::with_capacity(1 + trans.modules.len());
 
-    {
+    if let Some(m) = trans.metadata_module {
         let work = build_work_item(sess,
-                                   trans.metadata_module,
+                                   m,
                                    metadata_config.clone(),
                                    crate_output.clone(),
                                    "metadata".to_string());
@@ -850,7 +850,8 @@ pub fn run_passes(sess: &Session,
             }
         }
 
-        if metadata_config.emit_bc && !user_wants_bitcode {
+        if metadata_config.emit_bc &&
+            trans.metadata_module.is_some() && !user_wants_bitcode {
             remove(sess, &crate_output.with_extension("metadata.bc"));
         }
     }

--- a/src/librustc_trans/trans/mod.rs
+++ b/src/librustc_trans/trans/mod.rs
@@ -70,7 +70,7 @@ unsafe impl Sync for ModuleTranslation { }
 
 pub struct CrateTranslation {
     pub modules: Vec<ModuleTranslation>,
-    pub metadata_module: ModuleTranslation,
+    pub metadata_module: Option<ModuleTranslation>,
     pub link: LinkMeta,
     pub metadata: Vec<u8>,
     pub reachable: Vec<String>,


### PR DESCRIPTION
This didn't accomplish as much as I hoped, shaving maybe 1% off servo builds. r? @alexcrichton 
