### PR TITLE
Improve typo suggestion hueristics

### DIFF
--- a/src/test/compile-fail/bad-expr-path.rs
+++ b/src/test/compile-fail/bad-expr-path.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unresolved name `m1::a`. Did you mean `args`?
+// error-pattern: unresolved name `m1::arguments`. Did you mean `arguments`?
 
 mod m1 {}
 
-fn main(args: Vec<String>) { log(debug, m1::a); }
+fn main(arguments: Vec<String>) { log(debug, m1::arguments); }

--- a/src/test/compile-fail/typo-suggestion.rs
+++ b/src/test/compile-fail/typo-suggestion.rs
@@ -1,4 +1,4 @@
-// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,12 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: unresolved name `m1::arguments`. Did you mean `arguments`?
+fn main() {
+    let foo = 1;
 
-mod m1 {
-    pub mod arguments {}
-}
+    // `foo` shouldn't be suggested, it is too dissimilar from `bar`.
+    println!("Hello {}", bar);
+    //~^ ERROR: unresolved name `bar`
 
-fn main(arguments: Vec<String>) {
-    log(debug, m1::arguments);
+    // But this is close enough.
+    println!("Hello {}", fob);
+    //~^ ERROR: unresolved name `fob`. Did you mean `foo`?
 }


### PR DESCRIPTION
This makes the maximum edit distance of typo suggestions a function of the typo'd name's length. FWIW, clang uses this same hueristic, and I've found their suggestions to be better than rustc's. Without something like this, you end up with suggestions that aren't related at all when there are short variable names.

See also https://github.com/rust-lang/rust/issues/20028#issuecomment-109767159
