### PR TITLE
Fix ICE when pretty printing `println!{"hello world"}`

### DIFF
--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -770,7 +770,7 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>,
         ast::ExprAssign(..) |
         ast::ExprAssignOp(..) |
         ast::ExprInlineAsm(_) |
-        ast::ExprMac(_) => {
+        ast::ExprMac(_, _) => {
             v.add_qualif(ConstQualif::NOT_CONST);
             if v.mode != Mode::Var {
                 span_err!(v.tcx.sess, e.span, E0019,

--- a/src/librustc_trans/trans/debuginfo/create_scope_map.rs
+++ b/src/librustc_trans/trans/debuginfo/create_scope_map.rs
@@ -414,7 +414,7 @@ fn walk_expr(cx: &CrateContext,
                                           Found unexpanded for loop.");
         }
 
-        ast::ExprMac(_) => {
+        ast::ExprMac(..) => {
             cx.sess().span_bug(exp.span, "debuginfo::create_scope_map() - \
                                           Found unexpanded macro.");
         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3303,7 +3303,7 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
           }
           fcx.write_nil(id);
       }
-      ast::ExprMac(_) => tcx.sess.bug("unexpanded macro"),
+      ast::ExprMac(..) => tcx.sess.bug("unexpanded macro"),
       ast::ExprBreak(_) => { fcx.write_ty(id, fcx.infcx().next_diverging_ty_var()); }
       ast::ExprAgain(_) => { fcx.write_ty(id, fcx.infcx().next_diverging_ty_var()); }
       ast::ExprRet(ref expr_opt) => {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -892,7 +892,7 @@ pub enum Expr_ {
     ExprInlineAsm(InlineAsm),
 
     /// A macro invocation; pre-expansion
-    ExprMac(Mac),
+    ExprMac(Mac, token::DelimToken),
 
     /// A struct literal expression.
     ///

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -49,7 +49,7 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
     e.and_then(|ast::Expr {id, node, span}| match node {
         // expr_mac should really be expr_ext or something; it's the
         // entry-point for all syntax extensions.
-        ast::ExprMac(mac) => {
+        ast::ExprMac(mac, _) => {
             let expanded_expr = match expand_mac_invoc(mac, span,
                                                        |r| r.make_expr(),
                                                        mark_expr, fld) {

--- a/src/libsyntax/fold.rs
+++ b/src/libsyntax/fold.rs
@@ -1321,7 +1321,7 @@ pub fn noop_fold_expr<T: Folder>(Expr {id, node, span}: Expr, folder: &mut T) ->
                 dialect: dialect,
                 expn_id: expn_id,
             }),
-            ExprMac(mac) => ExprMac(folder.fold_mac(mac)),
+            ExprMac(mac, delim) => ExprMac(folder.fold_mac(mac), delim),
             ExprStruct(path, fields, maybe_expr) => {
                 ExprStruct(folder.fold_path(path),
                         fields.move_map(|x| folder.fold_field(x)),

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -1078,7 +1078,7 @@ mod tests {
             "foo!( fn main() { body } )".to_string(), vec![], &sess);
 
         let tts = match expr.node {
-            ast::ExprMac(ref mac) => {
+            ast::ExprMac(ref mac, _) => {
                 let ast::MacInvocTT(_, ref tts, _) = mac.node;
                 tts.clone()
             }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1942,10 +1942,14 @@ impl<'a> Parser<'a> {
         ExprAssignOp(binop, lhs, rhs)
     }
 
-    pub fn mk_mac_expr(&mut self, lo: BytePos, hi: BytePos, m: Mac_) -> P<Expr> {
+    pub fn mk_mac_expr(&mut self,
+                       lo: BytePos,
+                       hi: BytePos,
+                       m: Mac_,
+                       delim: token::DelimToken) -> P<Expr> {
         P(Expr {
             id: ast::DUMMY_NODE_ID,
-            node: ExprMac(codemap::Spanned {node: m, span: mk_sp(lo, hi)}),
+            node: ExprMac(codemap::Spanned {node: m, span: mk_sp(lo, hi)}, delim),
             span: mk_sp(lo, hi),
         })
     }
@@ -2166,9 +2170,8 @@ impl<'a> Parser<'a> {
 
                         return Ok(self.mk_mac_expr(lo,
                                                    hi,
-                                                   MacInvocTT(pth,
-                                                              tts,
-                                                              EMPTY_CTXT)));
+                                                   MacInvocTT(pth, tts, EMPTY_CTXT),
+                                                   delim));
                     }
                     if self.check(&token::OpenDelim(token::Brace)) {
                         // This is a struct literal, unless we're prohibited
@@ -3610,8 +3613,10 @@ impl<'a> Parser<'a> {
                             try!(self.bump());
                         }
                         _ => {
-                            let e = self.mk_mac_expr(span.lo, span.hi,
-                                                     mac.and_then(|m| m.node));
+                            let e = self.mk_mac_expr(span.lo,
+                                                     span.hi,
+                                                     mac.and_then(|m| m.node),
+                                                     token::Brace);
                             let e = try!(self.parse_dot_or_call_expr_with(e));
                             let e = try!(self.parse_more_binops(e, 0));
                             let e = try!(self.parse_assign_expr_with(e));
@@ -3636,8 +3641,10 @@ impl<'a> Parser<'a> {
                         token::CloseDelim(token::Brace) => {
                             // if a block ends in `m!(arg)` without
                             // a `;`, it must be an expr
-                            expr = Some(self.mk_mac_expr(span.lo, span.hi,
-                                                         m.and_then(|x| x.node)));
+                            expr = Some(self.mk_mac_expr(span.lo,
+                                                         span.hi,
+                                                         m.and_then(|x| x.node),
+                                                         token::Brace));
                         }
                         _ => {
                             stmts.push(P(Spanned {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -507,8 +507,8 @@ impl<'a> State<'a> {
                    indented: usize) -> io::Result<()> {
         self.bclose_maybe_open(span, indented, true)
     }
-    pub fn bclose_maybe_open (&mut self, span: codemap::Span,
-                              indented: usize, close_box: bool) -> io::Result<()> {
+    pub fn bclose_maybe_open(&mut self, span: codemap::Span,
+                             indented: usize, close_box: bool) -> io::Result<()> {
         try!(self.maybe_print_comment(span.hi));
         try!(self.break_offset_if_not_bol(1, -(indented as isize)));
         try!(word(&mut self.s, "}"));
@@ -1531,7 +1531,12 @@ impl<'a> State<'a> {
                 match delim {
                     token::Paren => try!(self.popen()),
                     token::Bracket => try!(word(&mut self.s, "[")),
-                    token::Brace => try!(self.bopen()),
+                    token::Brace => {
+                        // We need to create some boxes because `bopen` and `bclose` close boxes.
+                        // Using `head` here takes care of setting this up for us.
+                        try!(self.head(""));
+                        try!(self.bopen())
+                    }
                 }
                 try!(self.print_tts(tts));
                 match delim {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1969,7 +1969,7 @@ impl<'a> State<'a> {
 
                 try!(self.pclose());
             }
-            ast::ExprMac(ref m) => try!(self.print_mac(m, token::Paren)),
+            ast::ExprMac(ref m, delim) => try!(self.print_mac(m, delim)),
             ast::ExprParen(ref e) => {
                 try!(self.popen());
                 try!(self.print_expr(&**e));

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -852,7 +852,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
         ExprRet(ref optional_expression) => {
             walk_expr_opt(visitor, optional_expression)
         }
-        ExprMac(ref mac) => visitor.visit_mac(mac),
+        ExprMac(ref mac, _) => visitor.visit_mac(mac),
         ExprParen(ref subexpression) => {
             visitor.visit_expr(&**subexpression)
         }

--- a/src/test/pretty/issue-26072.rs
+++ b/src/test/pretty/issue-26072.rs
@@ -1,0 +1,13 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// Testing that expression macros with brackets pretty prints correctly
+// pp-exact
+fn main() { println!{"hello world" } () }


### PR DESCRIPTION
This fixes an ICE when pretty printing:

``` rust
fn main() {
    println!{"hello world"}
    ()
}
```

This also preserves braces in expression macros. Closes #26072.
