### PR TITLE
StructField span should include `pub`

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3395,7 +3395,10 @@ impl<'a> Parser<'a> {
     /// Parse a structure field
     fn parse_name_and_ty(&mut self, pr: Visibility,
                          attrs: Vec<Attribute> ) -> PResult<StructField> {
-        let lo = self.span.lo;
+        let lo = match pr {
+            Inherited => self.span.lo,
+            Public => self.last_span.lo,
+        };
         if !self.token.is_plain_ident() {
             return Err(self.fatal("expected ident"));
         }

--- a/src/test/compile-fail/pub-struct-field-span-26083.rs
+++ b/src/test/compile-fail/pub-struct-field-span-26083.rs
@@ -1,0 +1,20 @@
+// Regression test for issue #26083
+// Test that span for public struct fields start at `pub` instead of the identifier
+
+struct Foo {
+    pub bar: u8,
+
+    pub
+    //~^ error: field `bar` is already declared [E0124]
+    bar: u8,
+
+    pub bar:
+    //~^ error: field `bar` is already declared [E0124]
+    u8,
+
+    bar:
+    //~^ error: field `bar` is already declared [E0124]
+    u8,
+}
+
+fn main() { }

--- a/src/test/compile-fail/pub-struct-field-span-26083.rs
+++ b/src/test/compile-fail/pub-struct-field-span-26083.rs
@@ -1,3 +1,13 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 // Regression test for issue #26083
 // Test that span for public struct fields start at `pub` instead of the identifier
 


### PR DESCRIPTION
Issue: #26083 

Re-submitting https://github.com/rust-lang/rust/pull/26084

r? @nrc 
