### PR TITLE
Add ability to change `ar` tool from target specification json

### DIFF
--- a/src/librustc_back/target/mod.rs
+++ b/src/librustc_back/target/mod.rs
@@ -272,6 +272,7 @@ impl Target {
         }
 
         key!(cpu);
+        key!(ar);
         key!(linker);
         key!(relocation_model);
         key!(code_model);


### PR DESCRIPTION
Looks like this was missed from af56e2efde5cd82564e32598889d25d798c02722.

This will help with defining cross-compile workflows for rust.
