### PR TITLE
Fixed old occurences of the removed array syntax in comments

### DIFF
--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -1663,11 +1663,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             }
 
             ty::ty_vec(element_ty, ref len) => {
-                // [T, ..n] and [T]
+                // [T; n] and [T]
                 match bound {
                     ty::BoundCopy => {
                         match *len {
-                            // [T, ..n] is copy iff T is copy
+                            // [T; n] is copy iff T is copy
                             Some(_) => ok_if(vec![element_ty]),
 
                             // [T] is unsized and hence affine

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -234,8 +234,8 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
     }
 
 
-    // &[T, ..n] or &mut [T, ..n] -> &[T]
-    // or &mut [T, ..n] -> &mut [T]
+    // &[T; n] or &mut [T; n] -> &[T]
+    // or &mut [T; n] -> &mut [T]
     // or &Concrete -> &Trait, etc.
     fn coerce_unsized(&self,
                       source: Ty<'tcx>,

--- a/src/librustc_typeck/check/method/README.md
+++ b/src/librustc_typeck/check/method/README.md
@@ -18,7 +18,7 @@ into a more explicit UFCS form:
 Here `ADJ` is some kind of adjustment, which is typically a series of
 autoderefs and then possibly an autoref (e.g., `&**receiver`). However
 we sometimes do other adjustments and coercions along the way, in
-particular unsizing (e.g., converting from `[T, ..n]` to `[T]`).
+particular unsizing (e.g., converting from `[T; n]` to `[T]`).
 
 ## The Two Phases
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2085,7 +2085,7 @@ fn lookup_indexing<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
         return final_mt;
     }
 
-    // After we have fully autoderef'd, if the resulting type is [T, ..n], then
+    // After we have fully autoderef'd, if the resulting type is [T; n], then
     // do a final unsized coercion to yield [T].
     if let ty::ty_vec(element_ty, Some(_)) = ty.sty {
         let adjusted_ty = ty::mk_vec(fcx.tcx(), element_ty, None);


### PR DESCRIPTION
As per RFC#520 the syntax for arrays has changed,
this changes the remaining comments to reflect
the new syntax.

I checked for existing occurences of this with the following command:

`ag "\[., \.\..\]"` which by now should only return a single occurence.
