### PR TITLE
mk: Report the prerelease version on beta again. Fixes #25618

### DIFF
--- a/mk/main.mk
+++ b/mk/main.mk
@@ -32,7 +32,7 @@ CFG_PACKAGE_VERS=$(CFG_RELEASE_NUM)
 CFG_DISABLE_UNSTABLE_FEATURES=1
 endif
 ifeq ($(CFG_RELEASE_CHANNEL),beta)
-CFG_RELEASE=$(CFG_RELEASE_NUM)-beta
+CFG_RELEASE=$(CFG_RELEASE_NUM)-beta$(CFG_PRERELEASE_VERSION)
 # When building beta distributables just reuse the same "beta" name
 # so when we upload we'll always override the previous beta. This
 # doesn't actually impact the version reported by rustc - it's just


### PR DESCRIPTION
I have fixed this exact bug at least 4 times now. Because of this both of our 1.1 betas have been called '1.1.0-beta'.
