### PR TITLE
Clarify difference

### DIFF
--- a/src/doc/trpl/dining-philosophers.md
+++ b/src/doc/trpl/dining-philosophers.md
@@ -2,8 +2,8 @@
 
 For our second project, let’s look at a classic concurrency problem. It’s
 called ‘the dining philosophers’. It was originally conceived by Dijkstra in
-1965, but we’ll use a lightly adapted version from [this paper][paper] by Tony
-Hoare in 1985.
+1965, but we’ll use a version from [this paper][paper] by Tony
+Hoare in 1985, adjusted to use gender-neutral language.
 
 [paper]: http://www.usingcsp.com/cspbook.pdf
 


### PR DESCRIPTION
When reading this, I wondered how it had been "lightly adjusted". After careful diffing I discovered the change was the removal of gender-specific terms. I am happy with this change, but I feel you should be concrete about changes which have been made to long direct quotes, so readers know how they differ from the source material.
