### PR TITLE
Adding Iterator Sync/Send tests for libcore/iter.rs

### DIFF
--- a/src/test/run-pass/sync-send-iterators-in-libcore.rs
+++ b/src/test/run-pass/sync-send-iterators-in-libcore.rs
@@ -10,19 +10,58 @@
 
 // pretty-expanded FIXME #23616
 
+#![allow(unused_mut)]
+#![feature(core)]
 #![feature(collections)]
+#![feature(step_by)]
+#![feature(iter_empty)]
+#![feature(iter_once)]
+
+use std::iter::{empty, once, range_inclusive, repeat, Unfold};
 
 fn is_sync<T>(_: T) where T: Sync {}
 fn is_send<T>(_: T) where T: Send {}
 
 macro_rules! all_sync_send {
+    ($ctor:expr, $iter:ident) => ({
+        let mut x = $ctor;
+        is_sync(x.$iter());
+        let mut y = $ctor;
+        is_send(y.$iter());
+    });
+    ($ctor:expr, $iter:ident($($param:expr),+)) => ({
+        let mut x = $ctor;
+        is_sync(x.$iter($( $param ),+));
+        let mut y = $ctor;
+        is_send(y.$iter($( $param ),+));
+    });
+    ($ctor:expr, $iter:ident, $($rest:tt)*) => ({
+        all_sync_send!($ctor, $iter);
+        all_sync_send!($ctor, $($rest)*);
+    });
+    ($ctor:expr, $iter:ident($($param:expr),+), $($rest:tt)*) => ({
+        all_sync_send!($ctor, $iter($( $param ),+));
+        all_sync_send!($ctor, $($rest)*);
+    });
+}
+
+macro_rules! all_sync_send_mutable_ref {
     ($ctor:expr, $($iter:ident),+) => ({
         $(
             let mut x = $ctor;
-            is_sync(x.$iter());
+            is_sync((&mut x).$iter());
             let mut y = $ctor;
-            is_send(y.$iter());
+            is_send((&mut y).$iter());
         )+
+    })
+}
+
+macro_rules! is_sync_send {
+    ($ctor:expr) => ({
+        let x = $ctor;
+        is_sync(x);
+        let y = $ctor;
+        is_send(y);
     })
 }
 
@@ -31,7 +70,41 @@ fn main() {
     all_sync_send!("Я", escape_default, escape_unicode);
 
     // for iter.rs
-    // FIXME
+    all_sync_send_mutable_ref!([1], iter);
+
+    // Bytes implements DoubleEndedIterator
+    all_sync_send!("a".bytes(), rev);
+
+    let a = [1];
+    let b = [2];
+    all_sync_send!(a.iter(),
+                   cloned,
+                   cycle,
+                   chain([2].iter()),
+                   zip([2].iter()),
+                   map(|_| 1),
+                   filter(|_| true),
+                   filter_map(|_| Some(1)),
+                   enumerate,
+                   peekable,
+                   skip_while(|_| true),
+                   take_while(|_| true),
+                   skip(1),
+                   take(1),
+                   scan(1, |_, _| Some(1)),
+                   flat_map(|_| b.iter()),
+                   fuse,
+                   inspect(|_| ()));
+
+    is_sync_send!(Unfold::new(Some(1), |&mut v| v));
+    is_sync_send!((1..).step_by(2));
+    is_sync_send!(range_inclusive(1, 1));
+    is_sync_send!((1..2).step_by(2));
+    is_sync_send!((1..2));
+    is_sync_send!((1..));
+    is_sync_send!(repeat(1));
+    is_sync_send!(empty::<usize>());
+    is_sync_send!(once(1));
 
     // for option.rs
     // FIXME


### PR DESCRIPTION
This addresses an item in #22709. SizeHint in libcore/iter.rs also implements Iterator, but it's implementation is not accessible and is only used to send size hints to extend (it appears to be a performance improvement to avoid unnecessary memory reallocations). The is the only implementation of Iterator within libcore/iter.rs that is not/cannot be tested in this PR.
