### PR TITLE
Fix some copyediting in TRPL: method-syntax

### DIFF
--- a/src/doc/trpl/method-syntax.md
+++ b/src/doc/trpl/method-syntax.md
@@ -86,8 +86,8 @@ impl Circle {
 # Chaining method calls
 
 So, now we know how to call a method, such as `foo.bar()`. But what about our
-original example, `foo.bar().baz()`? This is called ‘method chaining’, and we
-can do it by returning `self`.
+original example, `foo.bar().baz()`? This is called ‘method chaining’. Let’s
+look at an example:
 
 ```rust
 struct Circle {


### PR DESCRIPTION
As this example got changed, we stopped showing how to return self as
the first example, so this text is outdated.

Fixes #25803
