### PR TITLE
Exise 'owned pointer' from the codebase

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -22,9 +22,9 @@
 //!
 //! ## Boxed values
 //!
-//! The [`Box`](boxed/index.html) type is the core owned pointer type in Rust.
-//! There can only be one owner of a `Box`, and the owner can decide to mutate
-//! the contents, which live on the heap.
+//! The [`Box`](boxed/index.html) type is a smart pointer type. There can
+//! only be one owner of a `Box`, and the owner can decide to mutate the
+//! contents, which live on the heap.
 //!
 //! This type can be sent among threads efficiently as the size of a `Box` value
 //! is the same as that of a pointer. Tree-like data structures are often built

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -13,10 +13,10 @@
 //
 // - For each *mutable* static item, it checks that its **type**:
 //     - doesn't have a destructor
-//     - doesn't own an owned pointer
+//     - doesn't own a box
 //
 // - For each *immutable* static item, it checks that its **value**:
-//       - doesn't own owned, managed pointers
+//       - doesn't own a box
 //       - doesn't contain a struct literal or a call to an enum variant / struct constructor where
 //           - the type of the struct/enum has a dtor
 //

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -1410,7 +1410,7 @@ pub enum AliasableReason {
 
 impl<'tcx> cmt_<'tcx> {
     pub fn guarantor(&self) -> cmt<'tcx> {
-        //! Returns `self` after stripping away any owned pointer derefs or
+        //! Returns `self` after stripping away any derefs or
         //! interior content. The return value is basically the `cmt` which
         //! determines how long the value in `self` remains live.
 

--- a/src/librustc_borrowck/borrowck/README.md
+++ b/src/librustc_borrowck/borrowck/README.md
@@ -170,7 +170,7 @@ overwrite (or freeze) `(*x).f`, and thus invalidate the reference
 that was created. In general it holds that when a path is
 lent, restrictions are issued for all the owning prefixes of that
 path. In this case, the path `*x` owns the path `(*x).f` and,
-because `x` is an owned pointer, the path `x` owns the path `*x`.
+because `x` has ownership, the path `x` owns the path `*x`.
 Therefore, borrowing `(*x).f` yields restrictions on both
 `*x` and `x`.
 
@@ -286,7 +286,7 @@ MUTABILITY(X, imm)                  // M-Var-Imm
 
 ### Checking mutability of owned content
 
-Fields and owned pointers inherit their mutability from
+Fields and boxes inherit their mutability from
 their base expressions, so both of their rules basically
 delegate the check to the base expression `LV`:
 
@@ -387,7 +387,7 @@ LIFETIME(X, LT, MQ)                 // L-Local
 
 ### Checking lifetime for owned content
 
-The lifetime of a field or owned pointer is the same as the lifetime
+The lifetime of a field or box is the same as the lifetime
 of its owner:
 
 ```text
@@ -466,10 +466,10 @@ origin of inherited mutability.
 
 Because the mutability of owned referents is inherited, restricting an
 owned referent is similar to restricting a field, in that it implies
-restrictions on the pointer. However, owned pointers have an important
+restrictions on the pointer. However, boxes have an important
 twist: if the owner `LV` is mutated, that causes the owned referent
 `*LV` to be freed! So whenever an owned referent `*LV` is borrowed, we
-must prevent the owned pointer `LV` from being mutated, which means
+must prevent the box `LV` from being mutated, which means
 that we always add `MUTATE` and `CLAIM` to the restriction set imposed
 on `LV`:
 
@@ -648,7 +648,7 @@ fn main() {
 ```
 
 Clause (2) propagates the restrictions on the referent to the pointer
-itself. This is the same as with an owned pointer, though the
+itself. This is the same as with an box, though the
 reasoning is mildly different. The basic goal in all cases is to
 prevent the user from establishing another route to the same data. To
 see what I mean, let's examine various cases of what can go wrong and

--- a/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
@@ -110,7 +110,7 @@ impl<'a, 'tcx> RestrictionsContext<'a, 'tcx> {
                     mc::Unique => {
                         // R-Deref-Send-Pointer
                         //
-                        // When we borrow the interior of an owned pointer, we
+                        // When we borrow the interior of a box, we
                         // cannot permit the base to be mutated, because that
                         // would cause the unique pointer to be freed.
                         //

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -76,7 +76,7 @@
 //! the borrow itself (L2).  What do I mean by "guaranteed" by a
 //! borrowed pointer? I mean any data that is reached by first
 //! dereferencing a borrowed pointer and then either traversing
-//! interior offsets or owned pointers.  We say that the guarantor
+//! interior offsets or boxes.  We say that the guarantor
 //! of such data it the region of the borrowed pointer that was
 //! traversed.  This is essentially the same as the ownership
 //! relation, except that a borrowed pointer never owns its

--- a/src/test/compile-fail/issue-6801.rs
+++ b/src/test/compile-fail/issue-6801.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// Creating a stack closure which references an owned pointer and then
-// transferring ownership of the owned box before invoking the stack
+// Creating a stack closure which references an box and then
+// transferring ownership of the box before invoking the stack
 // closure results in a crash.
 
 #![feature(box_syntax)]

--- a/src/test/compile-fail/kindck-copy.rs
+++ b/src/test/compile-fail/kindck-copy.rs
@@ -37,7 +37,7 @@ fn test<'a,T,U:Copy>(_: &'a isize) {
     assert_copy::<&'static mut isize>(); //~ ERROR `core::marker::Copy` is not implemented
     assert_copy::<&'a mut isize>();  //~ ERROR `core::marker::Copy` is not implemented
 
-    // owned pointers are not ok
+    // boxes are not ok
     assert_copy::<Box<isize>>();   //~ ERROR `core::marker::Copy` is not implemented
     assert_copy::<String>();   //~ ERROR `core::marker::Copy` is not implemented
     assert_copy::<Vec<isize> >(); //~ ERROR `core::marker::Copy` is not implemented

--- a/src/test/run-pass/trait-with-bounds-default.rs
+++ b/src/test/run-pass/trait-with-bounds-default.rs
@@ -10,7 +10,7 @@
 //
 
 pub trait Clone2 {
-    /// Returns a copy of the value. The contents of owned pointers
+    /// Returns a copy of the value. The contents of boxes
     /// are copied to maintain uniqueness, while the contents of
     /// managed pointers are not copied.
     fn clone(&self) -> Self;


### PR DESCRIPTION
Still some references left to this old term, I've updated them to say boxes.

Related to #25851
