### PR TITLE
Exise 'unsafe pointer' in favor of 'raw pointer'

### DIFF
--- a/src/doc/trpl/ffi.md
+++ b/src/doc/trpl/ffi.md
@@ -238,7 +238,7 @@ However it is often desired that the callback is targeted to a special
 Rust object. This could be the object that represents the wrapper for the
 respective C object.
 
-This can be achieved by passing an unsafe pointer to the object down to the
+This can be achieved by passing an raw pointer to the object down to the
 C library. The C library can then include the pointer to the Rust object in
 the notification. This will allow the callback to unsafely access the
 referenced Rust object.
@@ -368,7 +368,7 @@ On OSX, frameworks behave with the same semantics as a dynamic library.
 
 # Unsafe blocks
 
-Some operations, like dereferencing unsafe pointers or calling functions that have been marked
+Some operations, like dereferencing raw pointers or calling functions that have been marked
 unsafe are only allowed inside unsafe blocks. Unsafe blocks isolate unsafety and are a promise to
 the compiler that the unsafety does not leak out of the block.
 

--- a/src/doc/trpl/raw-pointers.md
+++ b/src/doc/trpl/raw-pointers.md
@@ -52,9 +52,9 @@ println!("raw points at {}", *raw);
 It gives this error:
 
 ```text
-error: dereference of unsafe pointer requires unsafe function or block [E0133]
-     println!("raw points at{}", *raw);
-                                 ^~~~
+error: dereference of raw pointer requires unsafe function or block [E0133]
+     println!("raw points at {}", *raw);
+                                  ^~~~
 ```
 
 When you dereference a raw pointer, you’re taking responsibility that it’s not

--- a/src/libcollections/slice.rs
+++ b/src/libcollections/slice.rs
@@ -370,7 +370,7 @@ impl<T> [T] {
         core_slice::SliceExt::get_unchecked_mut(self, index)
     }
 
-    /// Returns an unsafe pointer to the slice's buffer
+    /// Returns an raw pointer to the slice's buffer
     ///
     /// The caller must ensure that the slice outlives the pointer this
     /// function returns, or else it will end up pointing to garbage.

--- a/src/libcollections/str.rs
+++ b/src/libcollections/str.rs
@@ -525,7 +525,7 @@ impl str {
         core_str::StrExt::as_bytes(&self[..])
     }
 
-    /// Returns an unsafe pointer to the `&str`'s buffer.
+    /// Returns a raw pointer to the `&str`'s buffer.
     ///
     /// The caller must ensure that the string outlives this pointer, and
     /// that it is not

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1215,7 +1215,7 @@ impl<T: PartialEq> Vec<T> {
             let ln = self.len();
             if ln < 1 { return; }
 
-            // Avoid bounds checks by using unsafe pointers.
+            // Avoid bounds checks by using raw pointers.
             let p = self.as_mut_ptr();
             let mut r: usize = 1;
             let mut w: usize = 1;

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -46,7 +46,7 @@ use marker::Sized;
 
 extern "rust-intrinsic" {
 
-    // NB: These intrinsics take unsafe pointers because they mutate aliased
+    // NB: These intrinsics take raw pointers because they mutate aliased
     // memory, which is not valid for either `&` or `&mut`.
 
     pub fn atomic_cxchg<T>(dst: *mut T, old: T, src: T) -> T;

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -357,7 +357,7 @@ macro_rules! impls{
 /// struct is dropped, it may in turn drop one or more instances of
 /// the type `T`, though that may not be apparent from the other
 /// structure of the type itself. This is commonly necessary if the
-/// structure is using an unsafe pointer like `*mut T` whose referent
+/// structure is using a raw pointer like `*mut T` whose referent
 /// may be dropped when the type is dropped, as a `*mut T` is
 /// otherwise not treated as owned.
 ///

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -10,16 +10,16 @@
 
 // FIXME: talk about offset, copy_memory, copy_nonoverlapping_memory
 
-//! Operations on unsafe pointers, `*const T`, and `*mut T`.
+//! Operations on raw pointers, `*const T`, and `*mut T`.
 //!
-//! Working with unsafe pointers in Rust is uncommon,
+//! Working with raw pointers in Rust is uncommon,
 //! typically limited to a few patterns.
 //!
 //! Use the `null` function to create null pointers, and the `is_null` method
 //! of the `*const T` type  to check for null. The `*const T` type also defines
 //! the `offset` method, for pointer math.
 //!
-//! # Common ways to create unsafe pointers
+//! # Common ways to create raw pointers
 //!
 //! ## 1. Coerce a reference (`&T`) or mutable reference (`&mut T`).
 //!
@@ -86,7 +86,7 @@
 //!
 //! Usually you wouldn't literally use `malloc` and `free` from Rust,
 //! but C APIs hand out a lot of pointers generally, so are a common source
-//! of unsafe pointers in Rust.
+//! of raw pointers in Rust.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![doc(primitive = "pointer")]

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -162,7 +162,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EffectCheckVisitor<'a, 'tcx> {
                 debug!("effect: unary case, base type is {}",
                        ppaux::ty_to_string(self.tcx, base_type));
                 if let ty::ty_ptr(_) = base_type.sty {
-                    self.require_unsafe(expr.span, "dereference of unsafe pointer")
+                    self.require_unsafe(expr.span, "dereference of raw pointer")
                 }
             }
             ast::ExprAssign(ref base, _) | ast::ExprAssignOp(_, ref base, _) => {

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -1546,7 +1546,7 @@ impl<'tcx> cmt_<'tcx> {
                                 format!("`Box` content")
                             }
                             UnsafePtr(..) => {
-                                format!("dereference of unsafe pointer")
+                                format!("dereference of raw pointer")
                             }
                             BorrowedPtr(..) => {
                                 format!("borrowed content")

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -3644,7 +3644,7 @@ impl TypeContents {
             *self & TC::ReachesAll)
     }
 
-    /// Includes only those bits that still apply when indirected through an unsafe pointer (`*`)
+    /// Includes only those bits that still apply when indirected through a raw pointer (`*`)
     pub fn unsafe_pointer(&self) -> TypeContents {
         *self & TC::ReachesAll
     }

--- a/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
@@ -137,7 +137,7 @@ fn gather_move<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>,
                                move_info.id, move_info.kind);
         }
         None => {
-            // move from rvalue or unsafe pointer, hence ok
+            // move from rvalue or raw pointer, hence ok
         }
     }
 }

--- a/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/restrictions.rs
@@ -145,7 +145,7 @@ impl<'a, 'tcx> RestrictionsContext<'a, 'tcx> {
                             }
                         }
                     }
-                    // Borrowck is not relevant for unsafe pointers
+                    // Borrowck is not relevant for raw pointers
                     mc::UnsafePtr(..) => Safe
                 }
             }

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -341,8 +341,8 @@ impl<'tcx> CastCheck<'tcx> {
                 // Due to the limitations of LLVM global constants,
                 // region pointers end up pointing at copies of
                 // vector elements instead of the original values.
-                // To allow unsafe pointers to work correctly, we
-                // need to special-case obtaining an unsafe pointer
+                // To allow raw pointers to work correctly, we
+                // need to special-case obtaining a raw pointer
                 // from a region pointer to a vector.
 
                 // this will report a type mismatch if needed

--- a/src/libstd/sys/common/thread_local.rs
+++ b/src/libstd/sys/common/thread_local.rs
@@ -102,7 +102,7 @@ pub struct StaticKey {
 /// type is entirely safe to use.
 ///
 /// Implementations will likely, however, contain unsafe code as this type only
-/// operates on `*mut u8`, an unsafe pointer.
+/// operates on `*mut u8`, a raw pointer.
 ///
 /// # Examples
 ///

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4215,7 +4215,7 @@ impl<'a> Parser<'a> {
                 };
                 if self.is_self_ident() {
                     let span = self.span;
-                    self.span_err(span, "cannot pass self by unsafe pointer");
+                    self.span_err(span, "cannot pass self by raw pointer");
                     try!(self.bump());
                 }
                 // error case, making bogus self ident:

--- a/src/test/compile-fail/borrowck-move-from-unsafe-ptr.rs
+++ b/src/test/compile-fail/borrowck-move-from-unsafe-ptr.rs
@@ -10,7 +10,7 @@
 
 
 fn foo(x: *const Box<isize>) -> Box<isize> {
-    let y = *x; //~ ERROR dereference of unsafe pointer requires unsafe function or block
+    let y = *x; //~ ERROR dereference of raw pointer requires unsafe function or block
     return y;
 }
 

--- a/src/test/compile-fail/issue-20801.rs
+++ b/src/test/compile-fail/issue-20801.rs
@@ -40,8 +40,8 @@ pub fn main() {
     //~^ ERROR cannot move out of borrowed content
 
     let c = unsafe { *mut_ptr() };
-    //~^ ERROR cannot move out of dereference of unsafe pointer
+    //~^ ERROR cannot move out of dereference of raw pointer
 
     let d = unsafe { *const_ptr() };
-    //~^ ERROR cannot move out of dereference of unsafe pointer
+    //~^ ERROR cannot move out of dereference of raw pointer
 }

--- a/src/test/compile-fail/regions-bounded-by-trait-requiring-static.rs
+++ b/src/test/compile-fail/regions-bounded-by-trait-requiring-static.rs
@@ -54,7 +54,7 @@ fn box_with_region_not_ok<'a>() {
     assert_send::<Box<&'a isize>>(); //~ ERROR does not fulfill the required lifetime
 }
 
-// unsafe pointers are ok unless they point at unsendable things
+// raw pointers are ok unless they point at unsendable things
 
 fn unsafe_ok1<'a>(_: &'a isize) {
     assert_send::<*const isize>();

--- a/src/test/compile-fail/unsafe-fn-assign-deref-ptr.rs
+++ b/src/test/compile-fail/unsafe-fn-assign-deref-ptr.rs
@@ -10,7 +10,7 @@
 
 
 fn f(p: *const u8) {
-    *p = 0; //~ ERROR dereference of unsafe pointer requires unsafe function or block
+    *p = 0; //~ ERROR dereference of raw pointer requires unsafe function or block
     return;
 }
 

--- a/src/test/compile-fail/unsafe-fn-deref-ptr.rs
+++ b/src/test/compile-fail/unsafe-fn-deref-ptr.rs
@@ -10,7 +10,7 @@
 
 
 fn f(p: *const u8) -> u8 {
-    return *p; //~ ERROR dereference of unsafe pointer requires unsafe function or block
+    return *p; //~ ERROR dereference of raw pointer requires unsafe function or block
 }
 
 fn main() {

--- a/src/test/parse-fail/no-unsafe-self.rs
+++ b/src/test/parse-fail/no-unsafe-self.rs
@@ -11,14 +11,14 @@
 // compile-flags: -Z parse-only
 
 trait A {
-    fn foo(*mut self); //~ ERROR cannot pass self by unsafe pointer
-    fn bar(*self); //~ ERROR cannot pass self by unsafe pointer
+    fn foo(*mut self); //~ ERROR cannot pass self by raw pointer
+    fn bar(*self); //~ ERROR cannot pass self by raw pointer
 }
 
 struct X;
 impl A for X {
-    fn foo(*mut self) { } //~ ERROR cannot pass self by unsafe pointer
-    fn bar(*self) { } //~ ERROR cannot pass self by unsafe pointer
+    fn foo(*mut self) { } //~ ERROR cannot pass self by raw pointer
+    fn bar(*self) { } //~ ERROR cannot pass self by raw pointer
 }
 
 fn main() { }


### PR DESCRIPTION
Using two terms for one thing is confusing, these are called 'raw pointers' today.
