### PR TITLE
Use the correct type of undef value for ignored return values in trans_named_tuple_constructor

### DIFF
--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1676,7 +1676,7 @@ pub fn trans_named_tuple_constructor<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
             if !type_is_zero_size(ccx, result_ty) {
                 alloc_ty(bcx, result_ty, "constructor_result")
             } else {
-                C_undef(type_of::type_of(ccx, result_ty))
+                C_undef(type_of::type_of(ccx, result_ty).ptr_to())
             }
         }
     };

--- a/src/test/run-pass/issue26127.rs
+++ b/src/test/run-pass/issue26127.rs
@@ -1,0 +1,21 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+trait Tr { type T; }
+impl Tr for u8 { type T=(); }
+struct S<I: Tr>(I::T);
+
+fn foo<I: Tr>(i: I::T) {
+    S::<I>(i);
+}
+
+fn main() {
+    foo::<u8>(());
+}


### PR DESCRIPTION
Fixes #26127
