### PR TITLE
disabling socking timing tests because openbsd/bitrig get/set are not…

### DIFF
--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -902,6 +902,9 @@ mod tests {
         assert_eq!(format!("{:?}", stream), compare);
     }
 
+    // FIXME: re-enabled bitrig/openbsd tests once their socket timeout code
+    //        no longer has rounding errors.
+    #[cfg_attr(any(target_os = "bitrig", target_os = "openbsd"), ignore)]
     #[test]
     fn timeouts() {
         let addr = next_test_ip4();

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -360,6 +360,9 @@ mod tests {
         assert_eq!(format!("{:?}", udpsock), compare);
     }
 
+    // FIXME: re-enabled bitrig/openbsd tests once their socket timeout code
+    //        no longer has rounding errors.
+    #[cfg_attr(any(target_os = "bitrig", target_os = "openbsd"), ignore)]
     #[test]
     fn timeouts() {
         let addr = next_test_ip4();


### PR DESCRIPTION
… congruent due to rounding errors

@semarie this affected both openbsd and bitrig.  it seems the correct solution is to switch to fixed point arithmetic in the timeout code, the same as freebsd.
