### PR TITLE
std: Tweak process raising/lowering implementations

### DIFF
--- a/src/libstd/sys/unix/ext/process.rs
+++ b/src/libstd/sys/unix/ext/process.rs
@@ -65,46 +65,28 @@ impl ExitStatusExt for process::ExitStatus {
     }
 }
 
-#[stable(feature = "from_raw_os", since = "1.1.0")]
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl FromRawFd for process::Stdio {
-    /// Creates a new instance of `Stdio` from the raw underlying file
-    /// descriptor.
-    ///
-    /// When this `Stdio` is used as an I/O handle for a child process the given
-    /// file descriptor will be `dup`d into the destination file descriptor in
-    /// the child process.
-    ///
-    /// Note that this function **does not** take ownership of the file
-    /// descriptor provided and it will **not** be closed when `Stdio` goes out
-    /// of scope. As a result this method is unsafe because due to the lack of
-    /// knowledge about the lifetime of the provided file descriptor, this could
-    /// cause another I/O primitive's ownership property of its file descriptor
-    /// to be violated.
-    ///
-    /// Also note that this file descriptor may be used multiple times to spawn
-    /// processes. For example the `Command::spawn` function could be called
-    /// more than once to spawn more than one process sharing this file
-    /// descriptor.
     unsafe fn from_raw_fd(fd: RawFd) -> process::Stdio {
-        process::Stdio::from_inner(sys::process::Stdio::Fd(fd))
+        process::Stdio::from_inner(sys::fd::FileDesc::new(fd))
     }
 }
 
-#[stable(feature = "from_raw_os", since = "1.1.0")]
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawFd for process::ChildStdin {
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().raw()
     }
 }
 
-#[stable(feature = "from_raw_os", since = "1.1.0")]
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawFd for process::ChildStdout {
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().raw()
     }
 }
 
-#[stable(feature = "from_raw_os", since = "1.1.0")]
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawFd for process::ChildStderr {
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().raw()

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -283,8 +283,6 @@ impl File {
         Ok(File(fd))
     }
 
-    pub fn into_fd(self) -> FileDesc { self.0 }
-
     pub fn file_attr(&self) -> io::Result<FileAttr> {
         let mut stat: raw::stat = unsafe { mem::zeroed() };
         try!(cvt(unsafe {

--- a/src/libstd/sys/unix/pipe.rs
+++ b/src/libstd/sys/unix/pipe.rs
@@ -44,6 +44,6 @@ impl AnonPipe {
         self.0.write(buf)
     }
 
+    pub fn raw(&self) -> libc::c_int { self.0.raw() }
     pub fn fd(&self) -> &FileDesc { &self.0 }
-    pub fn into_fd(self) -> FileDesc { self.0 }
 }

--- a/src/libstd/sys/windows/ext/process.rs
+++ b/src/libstd/sys/windows/ext/process.rs
@@ -10,58 +10,43 @@
 
 //! Extensions to `std::process` for Windows.
 
-#![stable(feature = "from_raw_os", since = "1.1.0")]
+#![stable(feature = "process_extensions", since = "1.2.0")]
 
 use os::windows::io::{FromRawHandle, RawHandle, AsRawHandle};
 use process;
 use sys;
 use sys_common::{AsInner, FromInner};
 
-#[stable(feature = "from_raw_os", since = "1.1.0")]
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl FromRawHandle for process::Stdio {
-    /// Creates a new instance of `Stdio` from the raw underlying handle.
-    ///
-    /// When this `Stdio` is used as an I/O handle for a child process the given
-    /// handle will be duplicated via `DuplicateHandle` to ensure that the
-    /// handle has the correct permissions to cross the process boundary.
-    ///
-    /// Note that this function **does not** take ownership of the handle
-    /// provided and it will **not** be closed when `Stdio` goes out of scope.
-    /// As a result this method is unsafe because due to the lack of knowledge
-    /// about the lifetime of the provided handle, this could cause another I/O
-    /// primitive's ownership property of its handle to be violated.
-    ///
-    /// Also note that this handle may be used multiple times to spawn
-    /// processes. For example the `Command::spawn` function could be called
-    /// more than once to spawn more than one process sharing this handle.
     unsafe fn from_raw_handle(handle: RawHandle) -> process::Stdio {
-        let handle = sys::handle::RawHandle::new(handle as *mut _);
-        process::Stdio::from_inner(sys::process::Stdio::Handle(handle))
+        let handle = sys::handle::Handle::new(handle as *mut _);
+        process::Stdio::from_inner(handle)
     }
 }
 
-#[stable(feature = "from_raw_os", since = "1.1.0")]
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawHandle for process::Child {
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as *mut _
     }
 }
 
-#[stable(feature = "from_raw_os", since = "1.1.0")]
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawHandle for process::ChildStdin {
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as *mut _
     }
 }
 
-#[stable(feature = "from_raw_os", since = "1.1.0")]
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawHandle for process::ChildStdout {
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as *mut _
     }
 }
 
-#[stable(feature = "from_raw_os", since = "1.1.0")]
+#[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawHandle for process::ChildStderr {
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as *mut _

--- a/src/libstd/sys/windows/pipe.rs
+++ b/src/libstd/sys/windows/pipe.rs
@@ -38,6 +38,8 @@ pub fn anon_pipe() -> io::Result<(AnonPipe, AnonPipe)> {
 impl AnonPipe {
     pub fn handle(&self) -> &Handle { &self.inner }
 
+    pub fn raw(&self) -> libc::HANDLE { self.inner.raw() }
+
     pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.read(buf)
     }


### PR DESCRIPTION
- Slate these features to be stable in 1.2 instead of 1.1 (not being backported)
- Have the `FromRawFd` implementations follow the contract of the `FromRawFd`
  trait by taking ownership of the primitive specified.
- Refactor the implementations slightly to remove the `unreachable!` blocks as
  well as separating the stdio representation of `std::process` from
  `std::sys::process`.

cc #25494 
