### PR TITLE
Revert "Added AsRef implementations for Arc and Rc"

### DIFF
--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -330,15 +330,6 @@ impl<T: ?Sized> Deref for Arc<T> {
     }
 }
 
-#[stable(feature = "rc_arc_as_ref", since = "1.2.0")]
-impl<T: ?Sized> AsRef<T> for Arc<T> {
-
-    #[inline]
-    fn as_ref(&self) -> &T {
-        &self.inner().data
-    }
-}
-
 impl<T: Clone> Arc<T> {
     /// Make a mutable reference from the given `Arc<T>`.
     ///

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -156,7 +156,6 @@ use std::boxed;
 use core::cell::Cell;
 use core::clone::Clone;
 use core::cmp::{PartialEq, PartialOrd, Eq, Ord, Ordering};
-use core::convert::AsRef;
 use core::default::Default;
 use core::fmt;
 use core::hash::{Hasher, Hash};
@@ -376,15 +375,6 @@ impl<T: ?Sized> Deref for Rc<T> {
 
     #[inline(always)]
     fn deref(&self) -> &T {
-        &self.inner().value
-    }
-}
-
-#[stable(feature = "rc_arc_as_ref", since = "1.2.0")]
-impl<T: ?Sized> AsRef<T> for Rc<T> {
-
-    #[inline(always)]
-    fn as_ref(&self) -> &T {
         &self.inner().value
     }
 }


### PR DESCRIPTION
This is a revert of PR #26008 which caused the unintended breakage reported in #26096. We may want to add these implementations in the long run, but for now this revert allows us to take some more time to evaluate the impact of such a change (e.g. run it through crater).

Closes #26096
