### PR TITLE
early return if 1 element

### DIFF
--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -1213,7 +1213,7 @@ impl<T: PartialEq> Vec<T> {
             // Duplicate, advance r. End of vec. Truncate to w.
 
             let ln = self.len();
-            if ln < 1 { return; }
+            if ln <= 1 { return; }
 
             // Avoid bounds checks by using unsafe pointers.
             let p = self.as_mut_ptr();


### PR DESCRIPTION
No need to dedup if there is only 1 element in the vec, can early return
