### PR TITLE
Implement RFC 1014

### DIFF
--- a/src/libstd/panicking.rs
+++ b/src/libstd/panicking.rs
@@ -33,7 +33,10 @@ pub fn on_panic(obj: &(Any+Send), file: &'static str, line: u32) {
             None => "Box<Any>",
         }
     };
-    let mut err = Stderr::new();
+    let mut err = match Stderr::new() {
+        Ok(err) => err,
+        _ => return,
+    };
     let thread = thread_info::current_thread();
     let name = thread.as_ref().and_then(|t| t.name()).unwrap_or("<unnamed>");
     let prev = LOCAL_STDERR.with(|s| s.borrow_mut().take());

--- a/src/libstd/rt/util.rs
+++ b/src/libstd/rt/util.rs
@@ -63,7 +63,7 @@ pub const ENFORCE_SANITY: bool = true || !cfg!(rtopt) || cfg!(rtdebug) ||
                                   cfg!(rtassert);
 
 pub fn dumb_print(args: fmt::Arguments) {
-    let _ = Stderr::new().write_fmt(args);
+    let _ = Stderr::new().map(|mut stderr| stderr.write_fmt(args));
 }
 
 pub fn abort(args: fmt::Arguments) -> ! {

--- a/src/libstd/sys/unix/stdio.rs
+++ b/src/libstd/sys/unix/stdio.rs
@@ -19,7 +19,7 @@ pub struct Stdout(());
 pub struct Stderr(());
 
 impl Stdin {
-    pub fn new() -> Stdin { Stdin(()) }
+    pub fn new() -> io::Result<Stdin> { Ok(Stdin(())) }
 
     pub fn read(&self, data: &mut [u8]) -> io::Result<usize> {
         let fd = FileDesc::new(libc::STDIN_FILENO);
@@ -30,7 +30,7 @@ impl Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> Stdout { Stdout(()) }
+    pub fn new() -> io::Result<Stdout> { Ok(Stdout(())) }
 
     pub fn write(&self, data: &[u8]) -> io::Result<usize> {
         let fd = FileDesc::new(libc::STDOUT_FILENO);
@@ -41,7 +41,7 @@ impl Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> Stderr { Stderr(()) }
+    pub fn new() -> io::Result<Stderr> { Ok(Stderr(())) }
 
     pub fn write(&self, data: &[u8]) -> io::Result<usize> {
         let fd = FileDesc::new(libc::STDERR_FILENO);

--- a/src/libstd/sys/windows/stdio.rs
+++ b/src/libstd/sys/windows/stdio.rs
@@ -77,11 +77,13 @@ fn write(out: &Output, data: &[u8]) -> io::Result<usize> {
 }
 
 impl Stdin {
-    pub fn new() -> Stdin {
-        Stdin {
-            handle: get(c::STD_INPUT_HANDLE).unwrap(),
-            utf8: Mutex::new(Cursor::new(Vec::new())),
-        }
+    pub fn new() -> io::Result<Stdin> {
+        get(c::STD_INPUT_HANDLE).map(|handle| {
+            Stdin {
+                handle: handle,
+                utf8: Mutex::new(Cursor::new(Vec::new())),
+            }
+        })
     }
 
     pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
@@ -116,8 +118,8 @@ impl Stdin {
 }
 
 impl Stdout {
-    pub fn new() -> Stdout {
-        Stdout(get(c::STD_OUTPUT_HANDLE).unwrap())
+    pub fn new() -> io::Result<Stdout> {
+        get(c::STD_OUTPUT_HANDLE).map(Stdout)
     }
 
     pub fn write(&self, data: &[u8]) -> io::Result<usize> {
@@ -126,8 +128,8 @@ impl Stdout {
 }
 
 impl Stderr {
-    pub fn new() -> Stderr {
-        Stderr(get(c::STD_ERROR_HANDLE).unwrap())
+    pub fn new() -> io::Result<Stderr> {
+        get(c::STD_ERROR_HANDLE).map(Stderr)
     }
 
     pub fn write(&self, data: &[u8]) -> io::Result<usize> {

--- a/src/test/run-pass/rfc-1014-2.rs
+++ b/src/test/run-pass/rfc-1014-2.rs
@@ -1,0 +1,32 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(libc)]
+
+extern crate libc;
+
+#[cfg(windows)]
+extern "system" {
+    fn SetStdHandle(nStdHandle: libc::DWORD, nHandle: libc::HANDLE) -> libc::BOOL;
+}
+
+#[cfg(windows)]
+fn close_stdout() {
+    const STD_OUTPUT_HANDLE: libc::DWORD = -11i32 as libc::DWORD;
+    unsafe { SetStdHandle(STD_OUTPUT_HANDLE, 0 as libc::HANDLE); }
+}
+
+#[cfg(windows)]
+fn main() {
+    close_stdout();
+    println!("hello world");
+}
+
+#[cfg(not(windows))]
+fn main() {}

--- a/src/test/run-pass/rfc-1014.rs
+++ b/src/test/run-pass/rfc-1014.rs
@@ -1,0 +1,33 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+#![feature(libc)]
+
+extern crate libc;
+
+#[cfg(windows)]
+extern "system" {
+    pub fn GetStdHandle(which: libc::DWORD) -> libc::HANDLE;
+}
+
+#[cfg(windows)]
+fn close_stdout() {
+    const STD_OUTPUT_HANDLE: libc::DWORD = -11i32 as libc::DWORD;
+    unsafe { libc::CloseHandle(GetStdHandle(STD_OUTPUT_HANDLE)); }
+}
+
+#[cfg(not(windows))]
+fn close_stdout() {
+    unsafe { libc::close(libc::STDOUT_FILENO); }
+}
+
+fn main() {
+    close_stdout();
+    println!("hello world");
+}


### PR DESCRIPTION
Closes #25977

The various `stdfoo_raw` methods in std::io now return `io::Result`s,
since they may not exist on Windows. They will always return `Ok` on
Unix-like platforms.

[breaking-change]
