### PR TITLE
trpl: why (assignment == empty tuple) #26120

### DIFF
--- a/src/doc/trpl/functions.md
+++ b/src/doc/trpl/functions.md
@@ -145,7 +145,7 @@ Note that assigning to an already-bound variable (e.g. `y = 5`) is still an
 expression, although its value is not particularly useful. Unlike other
 languages where an assignment evaluates to the assigned value (e.g. `5` in the
 previous example), in Rust the value of an assignment is an empty tuple `()`
-because the assigned value can have (just one owner)[ownership.html], and any
+because the assigned value can have [just one owner](ownership.html), and any
 other returned value would be too surprising:
 
 ```rust

--- a/src/doc/trpl/functions.md
+++ b/src/doc/trpl/functions.md
@@ -144,7 +144,9 @@ an expression, and a `let` can only begin a statement, not an expression.
 Note that assigning to an already-bound variable (e.g. `y = 5`) is still an
 expression, although its value is not particularly useful. Unlike other
 languages where an assignment evaluates to the assigned value (e.g. `5` in the
-previous example), in Rust the value of an assignment is an empty tuple `()`:
+previous example), in Rust the value of an assignment is an empty tuple `()`
+because the assigned value can have (just one owner)[ownership.html], and any
+other returned value would be too surprising:
 
 ```rust
 let mut y = 5;


### PR DESCRIPTION
Doc patch for #26120.  Extra words here, because "value" is repeated.

I haven't read about whether/how it should go to stable (sorry), but I think it would help newcomers.

Thanks,
