### PR TITLE
desugaring-based box placement-in (take-4 branch)

### DIFF
--- a/src/doc/trpl/lang-items.md
+++ b/src/doc/trpl/lang-items.md
@@ -11,53 +11,94 @@ it exists. The marker is the attribute `#[lang = "..."]` and there are
 various different values of `...`, i.e. various different 'lang
 items'.
 
-For example, `Box` pointers require two lang items, one for allocation
-and one for deallocation. A freestanding program that uses the `Box`
-sugar for dynamic allocations via `malloc` and `free`:
+For example, some traits in the standard library have special
+treatment. One is `Copy`: there is a `copy` lang-item attached to the
+`Copy` trait, and the Rust compiler treats this specially in two ways:
 
-```rust
-#![feature(lang_items, box_syntax, start, no_std, libc)]
+ 1. If `x` has type that implements `Copy`, then `x` can be freely
+    copied by the assignment operator:
+    ```rust,ignore
+    let y = x;
+    let z = x;
+    ```
+
+ 2. If a type tries to implement `Copy`, the Rust compiler will
+    ensure that duplicating a value of that type will not cause any
+    noncopyable type to be duplicated.
+
+    For example, this code will be rejected:
+
+    ```rust,ignore
+    #[derive(Clone)]
+    struct ThisTypeIsNotCopy(Box<i32>);
+
+    #[derive(Clone)]
+    struct TryToMakeThisCopy { okay: i32, not_okay: ThisTypeIsNotCopy }
+
+    // This attempt to implement `Copy` will fail.
+    impl Copy for TryToMakeThisCopy { }
+    ```
+
+The above two properties are both special qualities of the `Copy`
+trait that other traits do not share, and thus they are associated
+with whatever trait is given the `copy` lang item.
+
+Here is a freestanding program that provides its own definition of the
+`copy` lang item, that is slightly different than the definition in
+the Rust standard library:
+
+```
+#![feature(lang_items, intrinsics, start, no_std)]
 #![no_std]
 
-extern crate libc;
-
-extern {
-    fn abort() -> !;
+#[lang = "copy"]
+pub trait MyCopy {
+    // Empty.
 }
 
-#[lang = "owned_box"]
-pub struct Box<T>(*mut T);
-
-#[lang = "exchange_malloc"]
-unsafe fn allocate(size: usize, _align: usize) -> *mut u8 {
-    let p = libc::malloc(size as libc::size_t) as *mut u8;
-
-    // malloc failed
-    if p as usize == 0 {
-        abort();
-    }
-
-    p
-}
-#[lang = "exchange_free"]
-unsafe fn deallocate(ptr: *mut u8, _size: usize, _align: usize) {
-    libc::free(ptr as *mut libc::c_void)
-}
+struct C(i32, i32);
+impl MyCopy for C { }
 
 #[start]
-fn main(argc: isize, argv: *const *const u8) -> isize {
-    let x = box 1;
+fn main(_argc: isize, _argv: *const *const u8) -> isize {
+    let mut x = C(3, 4);
+    let mut y = x;
+    let mut z = x;
+    x.0 = 5;
+    y.0 = 6;
+    z.0 = 7;
 
-    0
+    #[link(name="c")]
+    extern { fn printf(f: *const u8, ...); }
+
+    let template = b"x: C(%d, %d) y: C(%d, %d), z: C(%d, %d)\n\0";
+    unsafe { printf(template as *const u8, x.0, x.1, y.0, y.1, z.0, z.1); }
+    return 0;
 }
+
+// Again, these functions and traits are used by the compiler, and are
+// normally provided by libstd.
 
 #[lang = "stack_exhausted"] extern fn stack_exhausted() {}
 #[lang = "eh_personality"] extern fn eh_personality() {}
 #[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }
+
+#[lang="sized"] pub trait Sized: PhantomFn {}
+#[lang="phantom_fn"] pub trait PhantomFn {}
 ```
 
-Note the use of `abort`: the `exchange_malloc` lang item is assumed to
-return a valid pointer, and so needs to do the check internally.
+This compiles successfully. When we run the above code, it prints:
+```text
+x: C(5, 4) y: C(6, 4), z: C(7, 4)
+```
+So we can freely copy instances of `C`, since it implements `MyCopy`.
+
+A potentially interesting detail about the above program is that it
+differs from the Rust standard library in more than just the name
+`MyCopy`. The `std::marker::Copy` extends `std::clone::Clone`,
+ensuring that every type that implements `Copy` has a `clone` method.
+The `MyCopy` trait does *not* extend `Clone`; these values have no
+`clone` methods.
 
 Other features provided by lang items include:
 
@@ -65,15 +106,16 @@ Other features provided by lang items include:
   `==`, `<`, dereferencing (`*`) and `+` (etc.) operators are all
   marked with lang items; those specific four are `eq`, `ord`,
   `deref`, and `add` respectively.
-- stack unwinding and general failure; the `eh_personality`, `fail`
-  and `fail_bounds_checks` lang items.
+- stack unwinding and general failure; the `eh_personality`, `panic`
+  `panic_fmt`, and `panic_bounds_check` lang items.
 - the traits in `std::marker` used to indicate types of
   various kinds; lang items `send`, `sync` and `copy`.
 - the marker types and variance indicators found in
   `std::marker`; lang items `covariant_type`,
   `contravariant_lifetime`, etc.
+- matching with string literal patterns; the `str_eq` lang item.
 
 Lang items are loaded lazily by the compiler; e.g. if one never uses
-`Box` then there is no need to define functions for `exchange_malloc`
-and `exchange_free`. `rustc` will emit an error when an item is needed
-but not found in the current crate or any that it depends on.
+array indexing (`a[i]`) then there is no need to define a function for
+`panic_bounds_check`. `rustc` will emit an error when an item is
+needed but not found in the current crate or any that it depends on.

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -68,19 +68,21 @@ use core::ops::{Placer, Boxed, Place, InPlace, BoxPlace};
 use core::ptr::{Unique};
 use core::raw::{TraitObject};
 
+// FIXME (#22181): Put in the new placement-in syntax once that lands.
+
 /// A value that represents the heap. This is the place that the `box`
 /// keyword allocates into.
 ///
 /// The following two examples are equivalent:
 ///
 /// ```
-/// # #![feature(box_heap)]
+/// # #![feature(box_heap, core)]
 /// #![feature(box_syntax)]
 /// #![feature(placement_in_syntax)]
 /// use std::boxed::HEAP;
 ///
 /// fn main() {
-///     let foo = in HEAP { 5 };
+///     let foo = box (HEAP) { 5 };
 ///     let foo: Box<_> = box 5;
 /// }
 /// ```

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -68,19 +68,20 @@ use core::ops::{Placer, Boxed, Place, InPlace, BoxPlace};
 use core::ptr::{Unique};
 use core::raw::{TraitObject};
 
-/// A value that represents the heap. This is the default place that the `box`
-/// keyword allocates into when no place is supplied.
+/// A value that represents the heap. This is the place that the `box`
+/// keyword allocates into.
 ///
 /// The following two examples are equivalent:
 ///
 /// ```
 /// # #![feature(box_heap)]
 /// #![feature(box_syntax)]
+/// #![feature(placement_in_syntax)]
 /// use std::boxed::HEAP;
 ///
 /// fn main() {
-///     let foo = box(HEAP) 5;
-///     let foo = box 5;
+///     let foo = in HEAP { 5 };
+///     let foo: Box<_> = box 5;
 /// }
 /// ```
 #[lang = "exchange_heap"]

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -91,8 +91,8 @@ pub const HEAP: ExchangeHeapSingleton =
     ExchangeHeapSingleton { _force_singleton: () };
 
 /// This the singleton type used solely for `boxed::HEAP`.
+#[derive(Copy, Clone)]
 pub struct ExchangeHeapSingleton { _force_singleton: () }
-impl Copy for ExchangeHeapSingleton { }
 
 /// A pointer type for heap allocation.
 ///
@@ -123,12 +123,13 @@ pub struct Box<T: ?Sized>(Unique<T>);
 #[unstable(feature = "placement_in", reason = "placement box design is still being worked out.")]
 pub struct IntermediateBox<T: ?Sized>{
     ptr: *mut u8,
-    size: uint,
-    align: uint,
+    size: usize,
+    align: usize,
     marker: marker::PhantomData<*mut T>,
 }
 
-impl<T: ?Sized> Place<T> for IntermediateBox<T> {
+impl<T> Place<T> for IntermediateBox<T> {
+    // FIXME: what about unsized T?
     fn pointer(&mut self) -> *mut T { self.ptr as *mut T }
 }
 
@@ -180,7 +181,6 @@ impl<T> Placer<T> for ExchangeHeapSingleton {
     }
 }
 
-#[unsafe_destructor]
 impl<T: ?Sized> Drop for IntermediateBox<T> {
     fn drop(&mut self) {
         if self.size > 0 {

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -55,13 +55,16 @@
 
 use core::prelude::*;
 
+use heap;
+
 use core::any::Any;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{self, Hash};
-use core::marker::Unsize;
+use core::marker::{self, Unsize};
 use core::mem;
 use core::ops::{CoerceUnsized, Deref, DerefMut};
+use core::ops::{Placer, Boxed, Place, InPlace, BoxPlace};
 use core::ptr::{Unique};
 use core::raw::{TraitObject};
 
@@ -83,7 +86,12 @@ use core::raw::{TraitObject};
 #[lang = "exchange_heap"]
 #[unstable(feature = "box_heap",
            reason = "may be renamed; uncertain about custom allocator design")]
-pub const HEAP: () = ();
+pub const HEAP: ExchangeHeapSingleton =
+    ExchangeHeapSingleton { _force_singleton: () };
+
+/// This the singleton type used solely for `boxed::HEAP`.
+pub struct ExchangeHeapSingleton { _force_singleton: () }
+impl Copy for ExchangeHeapSingleton { }
 
 /// A pointer type for heap allocation.
 ///
@@ -91,7 +99,96 @@ pub const HEAP: () = ();
 #[lang = "owned_box"]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[fundamental]
-pub struct Box<T>(Unique<T>);
+pub struct Box<T: ?Sized>(Unique<T>);
+
+/// `IntermediateBox` represents uninitialized backing storage for `Box`.
+///
+/// FIXME (pnkfelix): Ideally we would just reuse `Box<T>` instead of
+/// introducing a separate `IntermediateBox<T>`; but then you hit
+/// issues when you e.g. attempt to destructure an instance of `Box`,
+/// since it is a lang item and so it gets special handling by the
+/// compiler.  Easier just to make this parallel type for now.
+///
+/// FIXME (pnkfelix): Currently the `box` protocol only supports
+/// creating instances of sized types. This IntermediateBox is
+/// designed to be forward-compatible with a future protocol that
+/// supports creating instances of unsized types; that is why the type
+/// parameter has the `?Sized` generalization marker, and is also why
+/// this carries an explicit size. However, it probably does not need
+/// to carry the explicit alignment; that is just a work-around for
+/// the fact that the `align_of` intrinsic currently requires the
+/// input type to be Sized (which I do not think is strictly
+/// necessary).
+#[unstable(feature = "placement_in", reason = "placement box design is still being worked out.")]
+pub struct IntermediateBox<T: ?Sized>{
+    ptr: *mut u8,
+    size: uint,
+    align: uint,
+    marker: marker::PhantomData<*mut T>,
+}
+
+impl<T: ?Sized> Place<T> for IntermediateBox<T> {
+    fn pointer(&mut self) -> *mut T { self.ptr as *mut T }
+}
+
+unsafe fn finalize<T>(b: IntermediateBox<T>) -> Box<T> {
+    let p = b.ptr as *mut T;
+    mem::forget(b);
+    mem::transmute(p)
+}
+
+fn make_place<T>() -> IntermediateBox<T> {
+    let size = mem::size_of::<T>();
+    let align = mem::align_of::<T>();
+
+    let p = if size == 0 {
+        heap::EMPTY as *mut u8
+    } else {
+        let p = unsafe {
+            heap::allocate(size, align)
+        };
+        if p.is_null() {
+            panic!("Box make_place allocation failure.");
+        }
+        p
+    };
+
+    IntermediateBox { ptr: p, size: size, align: align, marker: marker::PhantomData }
+}
+
+impl<T> BoxPlace<T> for IntermediateBox<T> {
+    fn make_place() -> IntermediateBox<T> { make_place() }
+}
+
+impl<T> InPlace<T> for IntermediateBox<T> {
+    type Owner = Box<T>;
+    unsafe fn finalize(self) -> Box<T> { finalize(self) }
+}
+
+impl<T> Boxed for Box<T> {
+    type Data = T;
+    type Place = IntermediateBox<T>;
+    unsafe fn finalize(b: IntermediateBox<T>) -> Box<T> { finalize(b) }
+}
+
+impl<T> Placer<T> for ExchangeHeapSingleton {
+    type Place = IntermediateBox<T>;
+
+    fn make_place(self) -> IntermediateBox<T> {
+        make_place()
+    }
+}
+
+#[unsafe_destructor]
+impl<T: ?Sized> Drop for IntermediateBox<T> {
+    fn drop(&mut self) {
+        if self.size > 0 {
+            unsafe {
+                heap::deallocate(self.ptr, self.size, self.align)
+            }
+        }
+    }
+}
 
 impl<T> Box<T> {
     /// Allocates memory on the heap and then moves `x` into it.
@@ -199,8 +296,7 @@ impl<T: Clone> Clone for Box<T> {
     /// let y = x.clone();
     /// ```
     #[inline]
-    fn clone(&self) -> Box<T> { box {(**self).clone()} }
-
+    fn clone(&self) -> Box<T> { box (HEAP) {(**self).clone()} }
     /// Copies `source`'s contents into `self` without creating a new allocation.
     ///
     /// # Examples

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -130,9 +130,11 @@ pub struct IntermediateBox<T: ?Sized>{
 
 impl<T> Place<T> for IntermediateBox<T> {
     // FIXME: what about unsized T?
+    #[inline]
     fn pointer(&mut self) -> *mut T { self.ptr as *mut T }
 }
 
+#[inline]
 unsafe fn finalize<T>(b: IntermediateBox<T>) -> Box<T> {
     let p = b.ptr as *mut T;
     mem::forget(b);
@@ -159,23 +161,27 @@ fn make_place<T>() -> IntermediateBox<T> {
 }
 
 impl<T> BoxPlace<T> for IntermediateBox<T> {
+    #[inline]
     fn make_place() -> IntermediateBox<T> { make_place() }
 }
 
 impl<T> InPlace<T> for IntermediateBox<T> {
     type Owner = Box<T>;
+    #[inline]
     unsafe fn finalize(self) -> Box<T> { finalize(self) }
 }
 
 impl<T> Boxed for Box<T> {
     type Data = T;
     type Place = IntermediateBox<T>;
+    #[inline]
     unsafe fn finalize(b: IntermediateBox<T>) -> Box<T> { finalize(b) }
 }
 
 impl<T> Placer<T> for ExchangeHeapSingleton {
     type Place = IntermediateBox<T>;
 
+    #[inline]
     fn make_place(self) -> IntermediateBox<T> {
         make_place()
     }

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -70,6 +70,9 @@
        test(no_crate_inject))]
 #![no_std]
 
+// SNAP ba0e1cd
+#![allow(unused_features)] // for placement_in_syntax
+
 #![feature(allocator)]
 #![feature(box_syntax)]
 #![feature(coerce_unsized)]

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -84,6 +84,7 @@
 #![feature(optin_builtin_traits)]
 #![feature(raw)]
 #![feature(staged_api)]
+#![feature(placement_in_syntax)]
 #![feature(unboxed_closures)]
 #![feature(unique)]
 #![feature(unsafe_no_drop_flag, filling_drop)]

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -184,6 +184,14 @@ extern "rust-intrinsic" {
     /// elements.
     pub fn size_of<T>() -> usize;
 
+    #[cfg(not(stage0))]
+    /// Moves a value to an uninitialized memory location.
+    ///
+    /// Drop glue is not run on the destination.
+    pub fn move_val_init<T>(dst: *mut T, src: T);
+
+    // SNAP ba0e1cd
+    #[cfg(stage0)]
     /// Moves a value to an uninitialized memory location.
     ///
     /// Drop glue is not run on the destination.

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -1267,3 +1267,115 @@ impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *mut T {}
 
 // *const T -> *const U
 impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *const T {}
+
+/// Both `in (PLACE) EXPR` and `box EXPR` desugar into expressions
+/// that allocate an intermediate "place" that holds uninitialized
+/// state.  The desugaring evaluates EXPR, and writes the result at
+/// the address returned by the `pointer` method of this trait.
+///
+/// A `Place` can be thought of as a special representation for a
+/// hypothetical `&uninit` reference (which Rust cannot currently
+/// express directly). That is, it represents a pointer to
+/// uninitialized storage.
+///
+/// The client is responsible for two steps: First, initializing the
+/// payload (it can access its address via `pointer`). Second,
+/// converting the agent to an instance of the owning pointer, via the
+/// appropriate `finalize` method (see the `InPlace`.
+///
+/// If evaluating EXPR fails, then the destructor for the
+/// implementation of Place to clean up any intermediate state
+/// (e.g. deallocate box storage, pop a stack, etc).
+pub trait Place<Data: ?Sized> {
+    /// Returns the address where the input value will be written.
+    /// Note that the data at this address is generally uninitialized,
+    /// and thus one should use `ptr::write` for initializing it.
+    fn pointer(&mut self) -> *mut Data;
+}
+
+/// Interface to implementations of  `in (PLACE) EXPR`.
+///
+/// `in (PLACE) EXPR` effectively desugars into:
+///
+/// ```rust,ignore
+/// let p = PLACE;
+/// let mut place = Placer::make_place(p);
+/// let raw_place = Place::pointer(&mut place);
+/// let value = EXPR;
+/// unsafe {
+///     std::ptr::write(raw_place, value);
+///     InPlace::finalize(place)
+/// }
+/// ```
+///
+/// The type of `in (PLACE) EXPR` is derived from the type of `PLACE`;
+/// if the type of `PLACE` is `P`, then the final type of the whole
+/// expression is `P::Place::Owner` (see the `InPlace` and `Boxed`
+/// traits).
+///
+/// Values for types implementing this trait usually are transient
+/// intermediate values (e.g. the return value of `Vec::emplace_back`)
+/// or `Copy`, since the `make_place` method takes `self` by value.
+pub trait Placer<Data: ?Sized> {
+    /// `Place` is the intermedate agent guarding the
+    /// uninitialized state for `Data`.
+    type Place: InPlace<Data>;
+
+    /// Creates a fresh place from `self`.
+    fn make_place(self) -> Self::Place;
+}
+
+/// Specialization of `Place` trait supporting `in (PLACE) EXPR`.
+pub trait InPlace<Data: ?Sized>: Place<Data> {
+    /// `Owner` is the type of the end value of `in (PLACE) EXPR`
+    ///
+    /// Note that when `in (PLACE) EXPR` is solely used for
+    /// side-effecting an existing data-structure,
+    /// e.g. `Vec::emplace_back`, then `Owner` need not carry any
+    /// information at all (e.g. it can be the unit type `()` in that
+    /// case).
+    type Owner;
+
+    /// Converts self into the final value, shifting
+    /// deallocation/cleanup responsibilities (if any remain), over to
+    /// the returned instance of `Owner` and forgetting self.
+    unsafe fn finalize(self) -> Self::Owner;
+}
+
+/// Core trait for the `box EXPR` form.
+///
+/// `box EXPR` effectively desugars into:
+///
+/// ```rust,ignore
+/// let mut place = BoxPlace::make_place();
+/// let raw_place = Place::pointer(&mut place);
+/// let value = EXPR;
+/// unsafe {
+///     ::std::ptr::write(raw_place, value);
+///     Boxed::finalize(place)
+/// }
+/// ```
+///
+/// The type of `box EXPR` is supplied from its surrounding
+/// context; in the above expansion, the result type `T` is used
+/// to determine which implementation of `Boxed` to use, and that
+/// `<T as Boxed>` in turn dictates determines which
+/// implementation of `BoxPlace` to use, namely:
+/// `<<T as Boxed>::Place as BoxPlace>`.
+pub trait Boxed {
+    /// The kind of data that is stored in this kind of box.
+    type Data;  /* (`Data` unused b/c cannot yet express below bound.) */
+    /// The place that will negotiate the storage of the data.
+    type Place; /* should be bounded by BoxPlace<Self::Data> */
+
+    /// Converts filled place into final owning value, shifting
+    /// deallocation/cleanup responsibilities (if any remain), over to
+    /// returned instance of `Self` and forgetting `filled`.
+    unsafe fn finalize(filled: Self::Place) -> Self;
+}
+
+/// Specialization of `Place` trait supporting `box EXPR`.
+pub trait BoxPlace<Data: ?Sized> : Place<Data> {
+    /// Creates a globally fresh place.
+    fn make_place() -> Self;
+}

--- a/src/libcoretest/any.rs
+++ b/src/libcoretest/any.rs
@@ -35,7 +35,9 @@ fn any_referenced() {
 
 #[test]
 fn any_owning() {
-    let (a, b, c) = (box 5_usize as Box<Any>, box TEST as Box<Any>, box Test as Box<Any>);
+    let (a, b, c) = (Box::new(5_usize) as Box<Any>,
+                     Box::new(TEST) as Box<Any>,
+                     Box::new(Test) as Box<Any>);
 
     assert!(a.is::<usize>());
     assert!(!b.is::<usize>());

--- a/src/libcoretest/mem.rs
+++ b/src/libcoretest/mem.rs
@@ -95,7 +95,7 @@ fn test_transmute() {
     trait Foo { fn dummy(&self) { } }
     impl Foo for isize {}
 
-    let a = box 100isize as Box<Foo>;
+    let a = Box::new(100isize) as Box<Foo>;
     unsafe {
         let x: ::core::raw::TraitObject = transmute(a);
         assert!(*(x.data as *const isize) == 100);

--- a/src/libcoretest/option.rs
+++ b/src/libcoretest/option.rs
@@ -234,7 +234,7 @@ fn test_collect() {
 
     // test that it does not take more elements than it needs
     let mut functions: [Box<Fn() -> Option<()>>; 3] =
-        [box || Some(()), box || None, box || panic!()];
+        [Box::new(|| Some(())), Box::new(|| None), Box::new(|| panic!())];
 
     let v: Option<Vec<()>> = functions.iter_mut().map(|f| (*f)()).collect();
 

--- a/src/libcoretest/result.rs
+++ b/src/libcoretest/result.rs
@@ -80,7 +80,7 @@ fn test_collect() {
 
     // test that it does not take more elements than it needs
     let mut functions: [Box<Fn() -> Result<(), isize>>; 3] =
-        [box || Ok(()), box || Err(1), box || panic!()];
+        [Box::new(|| Ok(())), Box::new(|| Err(1)), Box::new(|| panic!())];
 
     let v: Result<Vec<()>, isize> = functions.iter_mut().map(|f| (*f)()).collect();
     assert!(v == Err(1));

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -307,7 +307,7 @@ pub fn log(level: u32, loc: &'static LogLocation, args: fmt::Arguments) {
     let mut logger: Box<Logger + Send> = LOCAL_LOGGER.with(|s| {
         s.borrow_mut().take()
     }).unwrap_or_else(|| {
-        box DefaultLogger { handle: io::stderr() }
+        Box::new(DefaultLogger { handle: io::stderr() })
     });
     logger.log(&LogRecord {
         level: LogLevel(level),

--- a/src/liblog/lib.rs
+++ b/src/liblog/lib.rs
@@ -307,7 +307,8 @@ pub fn log(level: u32, loc: &'static LogLocation, args: fmt::Arguments) {
     let mut logger: Box<Logger + Send> = LOCAL_LOGGER.with(|s| {
         s.borrow_mut().take()
     }).unwrap_or_else(|| {
-        Box::new(DefaultLogger { handle: io::stderr() })
+        let b: Box<DefaultLogger> = box DefaultLogger { handle: io::stderr() };
+        b
     });
     logger.log(&LogRecord {
         level: LogLevel(level),

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -218,7 +218,7 @@ fn inline_const_fn_from_external_crate(tcx: &ty::ctxt, def_id: ast::DefId)
     }
 
     let fn_id = match csearch::maybe_get_item_ast(tcx, def_id,
-        box |a, b, c, d| astencode::decode_inlined_item(a, b, c, d)) {
+        Box::new(|a, b, c, d| astencode::decode_inlined_item(a, b, c, d))) {
         csearch::FoundAst::Found(&ast::IIItem(ref item)) => Some(item.id),
         csearch::FoundAst::Found(&ast::IIImplItem(_, ref item)) => Some(item.id),
         _ => None

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -521,7 +521,7 @@ impl<'a, 'tcx, O:DataFlowOperator+Clone+'static> DataFlowContext<'a, 'tcx, O> {
         debug!("Dataflow result for {}:", self.analysis_name);
         debug!("{}", {
             let mut v = Vec::new();
-            self.pretty_print_to(box &mut v, blk).unwrap();
+            self.pretty_print_to(Box::new(&mut v), blk).unwrap();
             println!("{}", String::from_utf8(v).unwrap());
             ""
         });

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -10,7 +10,7 @@
 
 //! Enforces the Rust effect system. Currently there is just one effect,
 //! `unsafe`.
-use self::UnsafeContext::*;
+use self::RootUnsafeContext::*;
 
 use middle::def;
 use middle::ty::{self, Ty};
@@ -21,8 +21,20 @@ use syntax::codemap::Span;
 use syntax::visit;
 use syntax::visit::Visitor;
 
+#[derive(Copy, Clone)]
+struct UnsafeContext {
+    push_unsafe_count: usize,
+    root: RootUnsafeContext,
+}
+
+impl UnsafeContext {
+    fn new(root: RootUnsafeContext) -> UnsafeContext {
+        UnsafeContext { root: root, push_unsafe_count: 0 }
+    }
+}
+
 #[derive(Copy, Clone, PartialEq)]
-enum UnsafeContext {
+enum RootUnsafeContext {
     SafeContext,
     UnsafeFn,
     UnsafeBlock(ast::NodeId),
@@ -44,7 +56,8 @@ struct EffectCheckVisitor<'a, 'tcx: 'a> {
 
 impl<'a, 'tcx> EffectCheckVisitor<'a, 'tcx> {
     fn require_unsafe(&mut self, span: Span, description: &str) {
-        match self.unsafe_context {
+        if self.unsafe_context.push_unsafe_count > 0 { return; }
+        match self.unsafe_context.root {
             SafeContext => {
                 // Report an error.
                 span_err!(self.tcx.sess, span, E0133,
@@ -75,9 +88,9 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EffectCheckVisitor<'a, 'tcx> {
 
         let old_unsafe_context = self.unsafe_context;
         if is_unsafe_fn {
-            self.unsafe_context = UnsafeFn
+            self.unsafe_context = UnsafeContext::new(UnsafeFn)
         } else if is_item_fn {
-            self.unsafe_context = SafeContext
+            self.unsafe_context = UnsafeContext::new(SafeContext)
         }
 
         visit::walk_fn(self, fn_kind, fn_decl, block, span);
@@ -105,9 +118,17 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EffectCheckVisitor<'a, 'tcx> {
                 // external blocks (e.g. `unsafe { println("") }`,
                 // expands to `unsafe { ... unsafe { ... } }` where
                 // the inner one is compiler generated).
-                if self.unsafe_context == SafeContext || source == ast::CompilerGenerated {
-                    self.unsafe_context = UnsafeBlock(block.id)
+                if self.unsafe_context.root == SafeContext || source == ast::CompilerGenerated {
+                    self.unsafe_context.root = UnsafeBlock(block.id)
                 }
+            }
+            ast::PushUnsafeBlock(..) => {
+                self.unsafe_context.push_unsafe_count =
+                    self.unsafe_context.push_unsafe_count.saturating_add(1);
+            }
+            ast::PopUnsafeBlock(..) => {
+                self.unsafe_context.push_unsafe_count =
+                    self.unsafe_context.push_unsafe_count.saturating_sub(1);
             }
         }
 
@@ -162,7 +183,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EffectCheckVisitor<'a, 'tcx> {
 pub fn check_crate(tcx: &ty::ctxt) {
     let mut visitor = EffectCheckVisitor {
         tcx: tcx,
-        unsafe_context: SafeContext,
+        unsafe_context: UnsafeContext::new(SafeContext),
     };
 
     visit::walk_crate(&mut visitor, tcx.map.krate());

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -555,6 +555,11 @@ impl<'d,'t,'a,'tcx> ExprUseVisitor<'d,'t,'a,'tcx> {
                     None => {}
                 }
                 self.consume_expr(&**base);
+                if place.is_some() {
+                    self.tcx().sess.span_bug(
+                        expr.span,
+                        "box with explicit place remains after expansion");
+                }
             }
 
             ast::ExprMac(..) => {

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -543,9 +543,19 @@ pub fn check_pat(tcx: &ty::ctxt, pat: &ast::Pat,
 
 fn maybe_do_stability_check(tcx: &ty::ctxt, id: ast::DefId, span: Span,
                             cb: &mut FnMut(ast::DefId, Span, &Option<&Stability>)) {
-    if !is_staged_api(tcx, id) { return  }
-    if is_internal(tcx, span) { return }
+    if !is_staged_api(tcx, id) {
+        debug!("maybe_do_stability_check: \
+                skipping id={:?} since it is not staged_api", id);
+        return;
+    }
+    if is_internal(tcx, span) {
+        debug!("maybe_do_stability_check: \
+                skipping span={:?} since it is internal", span);
+        return;
+    }
     let ref stability = lookup(tcx, id);
+    debug!("maybe_do_stability_check: \
+            inspecting id={:?} span={:?} of stability={:?}", id, span, stability);
     cb(id, span, stability);
 }
 

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -237,7 +237,7 @@ impl<'a> PhaseController<'a> {
     pub fn basic() -> PhaseController<'a> {
         PhaseController {
             stop: Compilation::Continue,
-            callback: box |_| {},
+            callback: Box::new(|_| {}),
         }
     }
 }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -375,13 +375,13 @@ impl<'a> CompilerCalls<'a> for RustcDefaultCalls {
         }
 
         if sess.opts.debugging_opts.save_analysis {
-            control.after_analysis.callback = box |state| {
+            control.after_analysis.callback = Box::new(|state| {
                 time(state.session.time_passes(),
                      "save analysis", (),
                      |_| save::process_crate(state.tcx.unwrap(),
                                              state.analysis.unwrap(),
                                              state.out_dir));
-            };
+            });
             control.make_glob_map = resolve::MakeGlobMap::Yes;
         }
 
@@ -800,7 +800,7 @@ pub fn monitor<F:FnOnce()+Send+'static>(f: F) {
         cfg = cfg.stack_size(STACK_SIZE);
     }
 
-    match cfg.spawn(move || { io::set_panic(box err); f() }).unwrap().join() {
+    match cfg.spawn(move || { io::set_panic(Box::new(err)); f() }).unwrap().join() {
         Ok(()) => { /* fallthrough */ }
         Err(value) => {
             // Thread panicked without emitting a fatal diagnostic
@@ -836,7 +836,7 @@ pub fn monitor<F:FnOnce()+Send+'static>(f: F) {
             // Panic so the process returns a failure code, but don't pollute the
             // output with some unnecessary panic messages, we've already
             // printed everything that we needed to.
-            io::set_panic(box io::sink());
+            io::set_panic(Box::new(io::sink()));
             panic!();
         }
     }

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -583,7 +583,7 @@ pub fn pretty_print_input(sess: Session,
         (PpmSource(s), None) => {
             let out: &mut Write = &mut out;
             s.call_with_pp_support(
-                sess, ast_map, &arenas, id, box out, |annotation, out| {
+                sess, ast_map, &arenas, id, Box::new(out), |annotation, out| {
                     debug!("pretty printing source code {:?}", s);
                     let sess = annotation.sess();
                     pprust::print_crate(sess.codemap(),
@@ -610,7 +610,7 @@ pub fn pretty_print_input(sess: Session,
                                                       sess.diagnostic(),
                                                       src_name.to_string(),
                                                       &mut rdr,
-                                                      box out,
+                                                      Box::new(out),
                                                       annotation.pp_ann(),
                                                       is_expanded);
                     for node_id in uii.all_matching_node_ids(ast_map) {

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -92,7 +92,7 @@ impl Emitter for ExpectErrorEmitter {
 
 fn errors(msgs: &[&str]) -> (Box<Emitter+Send>, usize) {
     let v = msgs.iter().map(|m| m.to_string()).collect();
-    (box ExpectErrorEmitter { messages: v } as Box<Emitter+Send>, msgs.len())
+    (Box::new(ExpectErrorEmitter { messages: v }) as Box<Emitter+Send>, msgs.len())
 }
 
 fn test_env<F>(source_string: &str,

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -65,7 +65,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
     macro_rules! add_builtin {
         ($sess:ident, $($name:ident),*,) => (
             {$(
-                store.register_pass($sess, false, box builtin::$name);
+                store.register_pass($sess, false, Box::new(builtin::$name));
                 )*}
             )
     }
@@ -73,7 +73,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
     macro_rules! add_builtin_with_new {
         ($sess:ident, $($name:ident),*,) => (
             {$(
-                store.register_pass($sess, false, box builtin::$name::new());
+                store.register_pass($sess, false, Box::new(builtin::$name::new()));
                 )*}
             )
     }
@@ -128,7 +128,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
                     UNUSED_UNSAFE, PATH_STATEMENTS);
 
     // We have one lint pass defined specially
-    store.register_pass(sess, false, box lint::GatherNodeLevels);
+    store.register_pass(sess, false, Box::new(lint::GatherNodeLevels));
 
     // Insert temporary renamings for a one-time deprecation
     store.register_renamed("raw_pointer_deriving", "raw_pointer_derive");

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -262,12 +262,12 @@ impl AttrBuilder {
     }
 
     pub fn arg<'a, T: AttrHelper + 'static>(&'a mut self, idx: usize, a: T) -> &'a mut AttrBuilder {
-        self.attrs.push((idx, box a as Box<AttrHelper+'static>));
+        self.attrs.push((idx, Box::new(a) as Box<AttrHelper+'static>));
         self
     }
 
     pub fn ret<'a, T: AttrHelper + 'static>(&'a mut self, a: T) -> &'a mut AttrBuilder {
-        self.attrs.push((ReturnIndex as usize, box a as Box<AttrHelper+'static>));
+        self.attrs.push((ReturnIndex as usize, Box::new(a) as Box<AttrHelper+'static>));
         self
     }
 

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -870,7 +870,7 @@ fn run_work_multithreaded(sess: &Session,
         futures.push(rx);
 
         thread::Builder::new().name(format!("codegen-{}", i)).spawn(move || {
-            let diag_handler = Handler::with_emitter(true, box diag_emitter);
+            let diag_handler = Handler::with_emitter(true, Box::new(diag_emitter));
 
             // Must construct cgcx inside the proc because it has non-Send
             // fields.

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -729,7 +729,7 @@ pub fn process_crate(tcx: &ty::ctxt,
     let mut out_name = cratename.clone();
     out_name.push_str(".csv");
     root_path.push(&out_name);
-    let output_file = match File::create(&root_path) {
+    let output_file: Box<_> = match File::create(&root_path) {
         Ok(f) => box f,
         Err(e) => {
             let disp = root_path.display();

--- a/src/librustc_trans/trans/cleanup.rs
+++ b/src/librustc_trans/trans/cleanup.rs
@@ -369,7 +369,7 @@ impl<'blk, 'tcx> CleanupMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx> {
     fn schedule_lifetime_end(&self,
                              cleanup_scope: ScopeId,
                              val: ValueRef) {
-        let drop = box LifetimeEnd {
+        let drop: Box<_> = box LifetimeEnd {
             ptr: val,
         };
 
@@ -386,7 +386,7 @@ impl<'blk, 'tcx> CleanupMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx> {
                          val: ValueRef,
                          ty: Ty<'tcx>) {
         if !self.type_needs_drop(ty) { return; }
-        let drop = box DropValue {
+        let drop: Box<_> = box DropValue {
             is_immediate: false,
             val: val,
             ty: ty,
@@ -411,7 +411,7 @@ impl<'blk, 'tcx> CleanupMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx> {
                                   ty: Ty<'tcx>) {
         if !self.type_needs_drop(ty) { return; }
 
-        let drop = box DropValue {
+        let drop: Box<_> = box DropValue {
             is_immediate: false,
             val: val,
             ty: ty,
@@ -442,7 +442,7 @@ impl<'blk, 'tcx> CleanupMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx> {
         // is just an optimization, so sound to be conservative.
         if !self.type_needs_drop(ty) { return; }
 
-        let drop = box DropValue {
+        let drop: Box<_> = box DropValue {
             is_immediate: false,
             val: val,
             ty: ty,
@@ -467,7 +467,7 @@ impl<'blk, 'tcx> CleanupMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx> {
                                ty: Ty<'tcx>) {
 
         if !self.type_needs_drop(ty) { return; }
-        let drop = box DropValue {
+        let drop: Box<_> = box DropValue {
             is_immediate: true,
             val: val,
             ty: ty,
@@ -491,7 +491,7 @@ impl<'blk, 'tcx> CleanupMethods<'blk, 'tcx> for FunctionContext<'blk, 'tcx> {
                            val: ValueRef,
                            heap: Heap,
                            content_ty: Ty<'tcx>) {
-        let drop = box FreeValue { ptr: val, heap: heap, content_ty: content_ty };
+        let drop: Box<_> = box FreeValue { ptr: val, heap: heap, content_ty: content_ty };
 
         debug!("schedule_free_value({:?}, val={}, heap={:?})",
                cleanup_scope,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4899,9 +4899,7 @@ pub fn check_intrinsic_type(ccx: &CrateCtxt, it: &ast::ForeignItem) {
             "move_val_init" => {
                 (1,
                  vec!(
-                    tcx.mk_mut_ref(tcx.mk_region(ty::ReLateBound(ty::DebruijnIndex::new(1),
-                                                                  ty::BrAnon(0))),
-                                    param(ccx, 0)),
+                    tcx.mk_mut_ptr(param(ccx, 0)),
                     param(ccx, 0)
                   ),
                tcx.mk_nil())

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -232,12 +232,13 @@ impl<'tcx> Expectation<'tcx> {
 pub struct UnsafetyState {
     pub def: ast::NodeId,
     pub unsafety: ast::Unsafety,
+    pub unsafe_push_count: u32,
     from_fn: bool
 }
 
 impl UnsafetyState {
     pub fn function(unsafety: ast::Unsafety, def: ast::NodeId) -> UnsafetyState {
-        UnsafetyState { def: def, unsafety: unsafety, from_fn: true }
+        UnsafetyState { def: def, unsafety: unsafety, unsafe_push_count: 0, from_fn: true }
     }
 
     pub fn recurse(&mut self, blk: &ast::Block) -> UnsafetyState {
@@ -249,13 +250,20 @@ impl UnsafetyState {
             ast::Unsafety::Unsafe if self.from_fn => *self,
 
             unsafety => {
-                let (unsafety, def) = match blk.rules {
-                    ast::UnsafeBlock(..) => (ast::Unsafety::Unsafe, blk.id),
-                    ast::DefaultBlock => (unsafety, self.def),
+                let (unsafety, def, count) = match blk.rules {
+                    ast::PushUnsafeBlock(..) =>
+                        (unsafety, blk.id, self.unsafe_push_count.saturating_add(1)),
+                    ast::PopUnsafeBlock(..) =>
+                        (unsafety, blk.id, self.unsafe_push_count.saturating_sub(1)),
+                    ast::UnsafeBlock(..) =>
+                        (ast::Unsafety::Unsafe, blk.id, self.unsafe_push_count),
+                    ast::DefaultBlock =>
+                        (unsafety, self.def, self.unsafe_push_count),
                 };
                 UnsafetyState{ def: def,
-                             unsafety: unsafety,
-                             from_fn: false }
+                               unsafety: unsafety,
+                               unsafe_push_count: count,
+                               from_fn: false }
             }
         }
     }

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -201,13 +201,13 @@ fn runtest(test: &str, cratename: &str, libs: SearchPaths,
         }
     }
     let data = Arc::new(Mutex::new(Vec::new()));
-    let emitter = diagnostic::EmitterWriter::new(box Sink(data.clone()), None);
-    let old = io::set_panic(box Sink(data.clone()));
-    let _bomb = Bomb(data, old.unwrap_or(box io::stdout()));
+    let emitter = diagnostic::EmitterWriter::new(Box::new(Sink(data.clone())), None);
+    let old = io::set_panic(Box::new(Sink(data.clone())));
+    let _bomb = Bomb(data, old.unwrap_or(Box::new(io::stdout())));
 
     // Compile the code
     let codemap = CodeMap::new();
-    let diagnostic_handler = diagnostic::Handler::with_emitter(true, box emitter);
+    let diagnostic_handler = diagnostic::Handler::with_emitter(true, Box::new(emitter));
     let span_diagnostic_handler =
         diagnostic::SpanHandler::new(diagnostic_handler, codemap);
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -134,6 +134,7 @@
 #![feature(no_std)]
 #![feature(oom)]
 #![feature(optin_builtin_traits)]
+#![feature(placement_in_syntax)]
 #![feature(rand)]
 #![feature(raw)]
 #![feature(reflect_marker)]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -103,6 +103,7 @@
        test(no_crate_inject, attr(deny(warnings))),
        test(attr(allow(dead_code, deprecated, unused_variables, unused_mut))))]
 
+#![cfg_attr(stage0, allow(unused_features))]
 #![feature(alloc)]
 #![feature(allow_internal_unstable)]
 #![feature(associated_consts)]

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -38,7 +38,7 @@ unsafe impl Sync for Thread {}
 impl Thread {
     pub unsafe fn new<'a>(stack: usize, p: Box<FnBox() + 'a>)
                           -> io::Result<Thread> {
-        let p = box p;
+        let p = Box::new(p);
         let mut native: libc::pthread_t = mem::zeroed();
         let mut attr: libc::pthread_attr_t = mem::zeroed();
         assert_eq!(pthread_attr_init(&mut attr), 0);

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -967,7 +967,7 @@ mod tests {
     #[test]
     fn test_try_panic_message_any() {
         match thread::spawn(move|| {
-            panic!(box 413u16 as Box<Any + Send>);
+            panic!(Box::new(413u16) as Box<Any + Send>);
         }).join() {
             Err(e) => {
                 type T = Box<Any + Send>;

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -809,6 +809,8 @@ pub type SpannedIdent = Spanned<Ident>;
 pub enum BlockCheckMode {
     DefaultBlock,
     UnsafeBlock(UnsafeSource),
+    PushUnsafeBlock(UnsafeSource),
+    PopUnsafeBlock(UnsafeSource),
 }
 
 #[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -591,6 +591,12 @@ fn initial_syntax_expander_table<'feat>(ecfg: &expand::ExpansionConfig<'feat>)
     syntax_expanders.insert(intern("cfg"),
                             builtin_normal_expander(
                                     ext::cfg::expand_cfg));
+    syntax_expanders.insert(intern("push_unsafe"),
+                            builtin_normal_expander(
+                                ext::pushpop_safe::expand_push_unsafe));
+    syntax_expanders.insert(intern("pop_unsafe"),
+                            builtin_normal_expander(
+                                ext::pushpop_safe::expand_pop_unsafe));
     syntax_expanders.insert(intern("trace_macros"),
                             builtin_normal_expander(
                                     ext::trace_macros::expand_trace_macros));

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1693,6 +1693,7 @@ impl<'feat> ExpansionConfig<'feat> {
         fn enable_trace_macros = allow_trace_macros,
         fn enable_allow_internal_unstable = allow_internal_unstable,
         fn enable_custom_derive = allow_custom_derive,
+        fn enable_pushpop_unsafe = allow_pushpop_unsafe,
     }
 }
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -96,6 +96,12 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
             //     InPlace::finalize(place)
             // }
 
+            // Ensure feature-gate is enabled
+            feature_gate::check_for_placement_in(
+                fld.cx.ecfg.features,
+                &fld.cx.parse_sess.span_diagnostic,
+                expr_span);
+
             let value_span = value_expr.span;
             let placer_span = placer.span;
 
@@ -180,6 +186,12 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
             //     ::std::ptr::write(raw_place, value);
             //     Boxed::finalize(place)
             // }
+
+            // Ensure feature-gate is enabled
+            feature_gate::check_for_box_syntax(
+                fld.cx.ecfg.features,
+                &fld.cx.parse_sess.span_diagnostic,
+                expr_span);
 
             let value_span = value_expr.span;
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -33,6 +33,16 @@ use visit;
 use visit::Visitor;
 use std_inject;
 
+// Given suffix ["b","c","d"], returns path `::std::b::c::d` when
+// `fld.cx.use_std`, and `::core::b::c::d` otherwise.
+fn mk_core_path(fld: &mut MacroExpander,
+                span: Span,
+                suffix: &[&'static str]) -> ast::Path {
+    let mut idents = vec![fld.cx.ident_of_std("core")];
+    for s in suffix.iter() { idents.push(fld.cx.ident_of(*s)); }
+    fld.cx.path_global(span, idents)
+}
+
 pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
     fn push_compiler_expansion(fld: &mut MacroExpander, span: Span, expansion_desc: &str) {
         fld.cx.bt_push(ExpnInfo {
@@ -46,7 +56,9 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
         });
     }
 
+    let expr_span = e.span;
     e.and_then(|ast::Expr {id, node, span}| match node {
+
         // expr_mac should really be expr_ext or something; it's the
         // entry-point for all syntax extensions.
         ast::ExprMac(mac) => {
@@ -69,6 +81,171 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
                 node: e.node,
                 span: span,
             })
+        }
+
+        // Desugar ExprBox: `in (PLACE) EXPR`
+        ast::ExprBox(Some(placer), value_expr) => {
+            // to:
+            //
+            // let p = PLACE;
+            // let mut place = Placer::make_place(p);
+            // let raw_place = InPlace::pointer(&mut place);
+            // let value = EXPR;
+            // unsafe {
+            //     std::ptr::write(raw_place, value);
+            //     InPlace::finalize(place)
+            // }
+
+            let value_span = value_expr.span;
+            let placer_span = placer.span;
+
+            let placer_expr = fld.fold_expr(placer);
+            let value_expr = fld.fold_expr(value_expr);
+
+            let placer_ident = token::gensym_ident("placer");
+            let agent_ident = token::gensym_ident("place");
+            let value_ident = token::gensym_ident("value");
+            let p_ptr_ident = token::gensym_ident("p_ptr");
+
+            let placer = fld.cx.expr_ident(span, placer_ident);
+            let agent = fld.cx.expr_ident(span, agent_ident);
+            let value = fld.cx.expr_ident(span, value_ident);
+            let p_ptr = fld.cx.expr_ident(span, p_ptr_ident);
+
+            let make_place = ["ops", "Placer", "make_place"];
+            let place_pointer = ["ops", "Place", "pointer"];
+            let ptr_write = ["ptr", "write"];
+            let inplace_finalize = ["ops", "InPlace", "finalize"];
+
+            let make_call = |fld: &mut MacroExpander, p, args| {
+                let path = mk_core_path(fld, placer_span, p);
+                let path = fld.cx.expr_path(path);
+                fld.cx.expr_call(span, path, args)
+            };
+
+            let stmt_let = |fld: &mut MacroExpander, bind, expr| {
+                fld.cx.stmt_let(placer_span, false, bind, expr)
+            };
+            let stmt_let_mut = |fld: &mut MacroExpander, bind, expr| {
+                fld.cx.stmt_let(placer_span, true, bind, expr)
+            };
+
+            // let placer = <placer_expr> ;
+            let s1 = stmt_let(fld, placer_ident, placer_expr);
+
+            // let mut place = Placer::make_place(placer);
+            let s2 = {
+                let call = make_call(fld, &make_place, vec![placer]);
+                stmt_let_mut(fld, agent_ident, call)
+            };
+
+            // let p_ptr = Place::pointer(&mut place);
+            let s3 = {
+                let args = vec![fld.cx.expr_mut_addr_of(placer_span, agent.clone())];
+                let call = make_call(fld, &place_pointer, args);
+                stmt_let(fld, p_ptr_ident, call)
+            };
+
+            // let value = <value_expr>;
+            let s4 = fld.cx.stmt_let(value_span, false, value_ident, value_expr);
+
+            // unsafe { ptr::write(p_ptr, value); InPlace::finalize(place) }
+            let expr = {
+                let call_ptr_write = StmtSemi(make_call(
+                    fld, &ptr_write, vec![p_ptr, value]), ast::DUMMY_NODE_ID);
+                let call_ptr_write = codemap::respan(value_span, call_ptr_write);
+
+                let call = make_call(fld, &inplace_finalize, vec![agent]);
+                Some(fld.cx.expr_block(P(ast::Block {
+                    stmts: vec![P(call_ptr_write)],
+                    expr: Some(call),
+                    id: ast::DUMMY_NODE_ID,
+                    rules: ast::UnsafeBlock(ast::CompilerGenerated),
+                    span: span,
+                })))
+            };
+
+            let block = fld.cx.block_all(span, vec![s1, s2, s3, s4], expr);
+            fld.cx.expr_block(block)
+        }
+
+        // Desugar ExprBox: `box EXPR`
+        ast::ExprBox(None, value_expr) => {
+            // to:
+            //
+            // let mut place = BoxPlace::make_place();
+            // let raw_place = Place::pointer(&mut place);
+            // let value = $value;
+            // unsafe {
+            //     ::std::ptr::write(raw_place, value);
+            //     Boxed::finalize(place)
+            // }
+
+            let value_span = value_expr.span;
+
+            let value_expr = fld.fold_expr(value_expr);
+
+            let agent_ident = token::gensym_ident("place");
+            let value_ident = token::gensym_ident("value");
+            let p_ptr_ident = token::gensym_ident("p_ptr");
+
+            let agent = fld.cx.expr_ident(span, agent_ident);
+            let value = fld.cx.expr_ident(span, value_ident);
+            let p_ptr = fld.cx.expr_ident(span, p_ptr_ident);
+
+            let boxplace_make_place = ["ops", "BoxPlace", "make_place"];
+            let place_pointer = ["ops", "Place", "pointer"];
+            let ptr_write = ["ptr", "write"];
+            let boxed_finalize = ["ops", "Boxed", "finalize"];
+
+            let make_call = |fld: &mut MacroExpander, p, args| {
+                let path = mk_core_path(fld, expr_span, p);
+                let path = fld.cx.expr_path(path);
+                fld.cx.expr_call(span, path, args)
+            };
+
+            let stmt_let = |fld: &mut MacroExpander, bind, expr| {
+                fld.cx.stmt_let(expr_span, false, bind, expr)
+            };
+            let stmt_let_mut = |fld: &mut MacroExpander, bind, expr| {
+                fld.cx.stmt_let(expr_span, true, bind, expr)
+            };
+
+            // let mut place = BoxPlace::make_place();
+            let s1 = {
+                let call = make_call(fld, &boxplace_make_place, vec![]);
+                stmt_let_mut(fld, agent_ident, call)
+            };
+
+            // let p_ptr = Place::pointer(&mut place);
+            let s2 = {
+                let args = vec![fld.cx.expr_mut_addr_of(expr_span, agent.clone())];
+                let call = make_call(fld, &place_pointer, args);
+                stmt_let(fld, p_ptr_ident, call)
+            };
+
+            // let value = <value_expr>;
+            let s3 = fld.cx.stmt_let(value_span, false, value_ident, value_expr);
+
+            // unsafe { ptr::write(p_ptr, value); Boxed::finalize(place) }
+            let expr = {
+                let call_ptr_write =
+                    StmtSemi(make_call(fld, &ptr_write, vec![p_ptr, value]),
+                             ast::DUMMY_NODE_ID);
+                let call_ptr_write = codemap::respan(value_span, call_ptr_write);
+
+                let call = make_call(fld, &boxed_finalize, vec![agent]);
+                Some(fld.cx.expr_block(P(ast::Block {
+                    stmts: vec![P(call_ptr_write)],
+                    expr: Some(call),
+                    id: ast::DUMMY_NODE_ID,
+                    rules: ast::UnsafeBlock(ast::CompilerGenerated),
+                    span: span,
+                })))
+            };
+
+            let block = fld.cx.block_all(span, vec![s1, s2, s3], expr);
+            fld.cx.expr_block(block)
         }
 
         ast::ExprWhile(cond, body, opt_ident) => {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -101,6 +101,8 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
                 &fld.cx.parse_sess.span_diagnostic,
                 expr_span);
 
+            push_compiler_expansion(fld, expr_span, "placement-in expansion");
+
             let value_span = value_expr.span;
             let placer_span = placer.span;
 
@@ -166,7 +168,9 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
             };
 
             let block = fld.cx.block_all(span, vec![s1, s2, s3], expr);
-            fld.cx.expr_block(block)
+            let result = fld.cx.expr_block(block);
+            fld.cx.bt_pop();
+            result
         }
 
         // Desugar ExprBox: `box EXPR`
@@ -185,6 +189,8 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
                 fld.cx.ecfg.features,
                 &fld.cx.parse_sess.span_diagnostic,
                 expr_span);
+
+            push_compiler_expansion(fld, expr_span, "box expansion");
 
             let value_span = value_expr.span;
 
@@ -245,7 +251,9 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
             };
 
             let block = fld.cx.block_all(span, vec![s1, s2], expr);
-            fld.cx.expr_block(block)
+            let result = fld.cx.expr_block(block);
+            fld.cx.bt_pop();
+            result
         }
 
         ast::ExprWhile(cond, body, opt_ident) => {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -57,7 +57,7 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
     }
 
     let expr_span = e.span;
-    e.and_then(|ast::Expr {id, node, span}| match node {
+    return e.and_then(|ast::Expr {id, node, span}| match node {
 
         // expr_mac should really be expr_ext or something; it's the
         // entry-point for all syntax extensions.
@@ -89,12 +89,11 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
             //
             // let p = PLACE;
             // let mut place = Placer::make_place(p);
-            // let raw_place = InPlace::pointer(&mut place);
-            // let value = EXPR;
-            // unsafe {
-            //     std::ptr::write(raw_place, value);
+            // let raw_place = Place::pointer(&mut place);
+            // push_unsafe!({
+            //     std::intrinsics::move_val_init(raw_place, pop_unsafe!( EXPR ));
             //     InPlace::finalize(place)
-            // }
+            // })
 
             // Ensure feature-gate is enabled
             feature_gate::check_for_placement_in(
@@ -110,17 +109,15 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
 
             let placer_ident = token::gensym_ident("placer");
             let agent_ident = token::gensym_ident("place");
-            let value_ident = token::gensym_ident("value");
             let p_ptr_ident = token::gensym_ident("p_ptr");
 
             let placer = fld.cx.expr_ident(span, placer_ident);
             let agent = fld.cx.expr_ident(span, agent_ident);
-            let value = fld.cx.expr_ident(span, value_ident);
             let p_ptr = fld.cx.expr_ident(span, p_ptr_ident);
 
             let make_place = ["ops", "Placer", "make_place"];
             let place_pointer = ["ops", "Place", "pointer"];
-            let ptr_write = ["ptr", "write"];
+            let move_val_init = ["intrinsics", "move_val_init"];
             let inplace_finalize = ["ops", "InPlace", "finalize"];
 
             let make_call = |fld: &mut MacroExpander, p, args| {
@@ -152,26 +149,23 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
                 stmt_let(fld, p_ptr_ident, call)
             };
 
-            // let value = <value_expr>;
-            let s4 = fld.cx.stmt_let(value_span, false, value_ident, value_expr);
+            // pop_unsafe!(EXPR));
+            let pop_unsafe_expr = pop_unsafe_expr(fld.cx, value_expr, value_span);
 
-            // unsafe { ptr::write(p_ptr, value); InPlace::finalize(place) }
+            // push_unsafe!({
+            //     ptr::write(p_ptr, pop_unsafe!(<value_expr>));
+            //     InPlace::finalize(place)
+            // })
             let expr = {
-                let call_ptr_write = StmtSemi(make_call(
-                    fld, &ptr_write, vec![p_ptr, value]), ast::DUMMY_NODE_ID);
-                let call_ptr_write = codemap::respan(value_span, call_ptr_write);
+                let call_move_val_init = StmtSemi(make_call(
+                    fld, &move_val_init, vec![p_ptr, pop_unsafe_expr]), ast::DUMMY_NODE_ID);
+                let call_move_val_init = codemap::respan(value_span, call_move_val_init);
 
                 let call = make_call(fld, &inplace_finalize, vec![agent]);
-                Some(fld.cx.expr_block(P(ast::Block {
-                    stmts: vec![P(call_ptr_write)],
-                    expr: Some(call),
-                    id: ast::DUMMY_NODE_ID,
-                    rules: ast::UnsafeBlock(ast::CompilerGenerated),
-                    span: span,
-                })))
+                Some(push_unsafe_expr(fld.cx, vec![P(call_move_val_init)], call, span))
             };
 
-            let block = fld.cx.block_all(span, vec![s1, s2, s3, s4], expr);
+            let block = fld.cx.block_all(span, vec![s1, s2, s3], expr);
             fld.cx.expr_block(block)
         }
 
@@ -181,11 +175,10 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
             //
             // let mut place = BoxPlace::make_place();
             // let raw_place = Place::pointer(&mut place);
-            // let value = $value;
-            // unsafe {
-            //     ::std::ptr::write(raw_place, value);
+            // push_unsafe!({
+            //     ::std::intrinsics::move_val_init(raw_place, pop_unsafe!(EXPR));
             //     Boxed::finalize(place)
-            // }
+            // })
 
             // Ensure feature-gate is enabled
             feature_gate::check_for_box_syntax(
@@ -198,16 +191,14 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
             let value_expr = fld.fold_expr(value_expr);
 
             let agent_ident = token::gensym_ident("place");
-            let value_ident = token::gensym_ident("value");
             let p_ptr_ident = token::gensym_ident("p_ptr");
 
             let agent = fld.cx.expr_ident(span, agent_ident);
-            let value = fld.cx.expr_ident(span, value_ident);
             let p_ptr = fld.cx.expr_ident(span, p_ptr_ident);
 
             let boxplace_make_place = ["ops", "BoxPlace", "make_place"];
             let place_pointer = ["ops", "Place", "pointer"];
-            let ptr_write = ["ptr", "write"];
+            let move_val_init = ["intrinsics", "move_val_init"];
             let boxed_finalize = ["ops", "Boxed", "finalize"];
 
             let make_call = |fld: &mut MacroExpander, p, args| {
@@ -236,27 +227,24 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
                 stmt_let(fld, p_ptr_ident, call)
             };
 
-            // let value = <value_expr>;
-            let s3 = fld.cx.stmt_let(value_span, false, value_ident, value_expr);
+            // pop_unsafe!(<value_expr>))
+            let pop_unsafe_expr = pop_unsafe_expr(fld.cx, value_expr, value_span);
 
-            // unsafe { ptr::write(p_ptr, value); Boxed::finalize(place) }
+            // push_unsafe!({
+            //     ptr::write(p_ptr, pop_unsafe!(<value_expr>));
+            //     Boxed::finalize(place)
+            // })
             let expr = {
-                let call_ptr_write =
-                    StmtSemi(make_call(fld, &ptr_write, vec![p_ptr, value]),
+                let call_move_val_init =
+                    StmtSemi(make_call(fld, &move_val_init, vec![p_ptr, pop_unsafe_expr]),
                              ast::DUMMY_NODE_ID);
-                let call_ptr_write = codemap::respan(value_span, call_ptr_write);
+                let call_move_val_init = codemap::respan(value_span, call_move_val_init);
 
                 let call = make_call(fld, &boxed_finalize, vec![agent]);
-                Some(fld.cx.expr_block(P(ast::Block {
-                    stmts: vec![P(call_ptr_write)],
-                    expr: Some(call),
-                    id: ast::DUMMY_NODE_ID,
-                    rules: ast::UnsafeBlock(ast::CompilerGenerated),
-                    span: span,
-                })))
+                Some(push_unsafe_expr(fld.cx, vec![P(call_move_val_init)], call, span))
             };
 
-            let block = fld.cx.block_all(span, vec![s1, s2, s3], expr);
+            let block = fld.cx.block_all(span, vec![s1, s2], expr);
             fld.cx.expr_block(block)
         }
 
@@ -549,7 +537,26 @@ pub fn expand_expr(e: P<ast::Expr>, fld: &mut MacroExpander) -> P<ast::Expr> {
                 span: span
             }, fld))
         }
-    })
+    });
+
+    fn push_unsafe_expr(cx: &mut ExtCtxt, stmts: Vec<P<ast::Stmt>>,
+                        expr: P<ast::Expr>, span: Span)
+                        -> P<ast::Expr> {
+        let rules = ast::PushUnsafeBlock(ast::CompilerGenerated);
+        cx.expr_block(P(ast::Block {
+            rules: rules, span: span, id: ast::DUMMY_NODE_ID,
+            stmts: stmts, expr: Some(expr),
+        }))
+    }
+
+    fn pop_unsafe_expr(cx: &mut ExtCtxt, expr: P<ast::Expr>, span: Span)
+                       -> P<ast::Expr> {
+        let rules = ast::PopUnsafeBlock(ast::CompilerGenerated);
+        cx.expr_block(P(ast::Block {
+            rules: rules, span: span, id: ast::DUMMY_NODE_ID,
+            stmts: vec![], expr: Some(expr),
+        }))
+    }
 }
 
 /// Expand a (not-ident-style) macro invocation. Returns the result

--- a/src/libsyntax/ext/pushpop_safe.rs
+++ b/src/libsyntax/ext/pushpop_safe.rs
@@ -1,0 +1,94 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/*
+ * The compiler code necessary to support the `push_unsafe!` and
+ * `pop_unsafe!` macros.
+ *
+ * This is a hack to allow a kind of "safety hygiene", where a macro
+ * can generate code with an interior expression that inherits the
+ * safety of some outer context.
+ *
+ * For example, in:
+ *
+ * ```rust
+ * fn foo() { push_unsafe!( { EXPR_1; pop_unsafe!( EXPR_2 ) } ) }
+ * ```
+ *
+ * the `EXPR_1` is considered to be in an `unsafe` context,
+ * but `EXPR_2` is considered to be in a "safe" (i.e. checked) context.
+ *
+ * For comparison, in:
+ *
+ * ```rust
+ * fn foo() { unsafe { push_unsafe!( { EXPR_1; pop_unsafe!( EXPR_2 ) } ) } }
+ * ```
+ *
+ * both `EXPR_1` and `EXPR_2` are considered to be in `unsafe`
+ * contexts.
+ *
+ */
+
+use ast;
+use codemap::Span;
+use ext::base::*;
+use ext::base;
+use ext::build::AstBuilder;
+use feature_gate;
+use ptr::P;
+
+enum PushPop { Push, Pop }
+
+pub fn expand_push_unsafe<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
+                               -> Box<base::MacResult+'cx> {
+    feature_gate::check_for_pushpop_syntax(
+        cx.ecfg.features, &cx.parse_sess.span_diagnostic, sp);
+    expand_pushpop_unsafe(cx, sp, tts, PushPop::Push)
+}
+
+pub fn expand_pop_unsafe<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree])
+                               -> Box<base::MacResult+'cx> {
+    feature_gate::check_for_pushpop_syntax(
+        cx.ecfg.features, &cx.parse_sess.span_diagnostic, sp);
+    expand_pushpop_unsafe(cx, sp, tts, PushPop::Pop)
+}
+
+fn expand_pushpop_unsafe<'cx>(cx: &'cx mut ExtCtxt, sp: Span, tts: &[ast::TokenTree],
+                                  pp: PushPop) -> Box<base::MacResult+'cx> {
+    let mut exprs = match get_exprs_from_tts(cx, sp, tts) {
+        Some(exprs) => exprs.into_iter(),
+        None => return DummyResult::expr(sp),
+    };
+    let expr = match (exprs.next(), exprs.next()) {
+        (Some(expr), None) => expr,
+        _ => {
+            let msg = match pp {
+                PushPop::Push => "push_unsafe! takes 1 arguments",
+                PushPop::Pop => "pop_unsafe! takes 1 arguments",
+            };
+            cx.span_err(sp, msg);
+            return DummyResult::expr(sp);
+        }
+    };
+
+    let source = ast::UnsafeSource::CompilerGenerated;
+    let check_mode = match pp {
+        PushPop::Push => ast::BlockCheckMode::PushUnsafeBlock(source),
+        PushPop::Pop => ast::BlockCheckMode::PopUnsafeBlock(source),
+    };
+
+    MacEager::expr(cx.expr_block(P(ast::Block {
+        stmts: vec![],
+        expr: Some(expr),
+        id: ast::DUMMY_NODE_ID,
+        rules: check_mode,
+        span: sp
+    })))
+}

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -80,6 +80,7 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Status)] = &[
     ("visible_private_types", "1.0.0", Active),
     ("slicing_syntax", "1.0.0", Accepted),
     ("box_syntax", "1.0.0", Active),
+    ("placement_in_syntax", "1.0.0", Active),
     ("on_unimplemented", "1.0.0", Active),
     ("simd_ffi", "1.0.0", Active),
     ("allocator", "1.0.0", Active),
@@ -325,6 +326,8 @@ pub struct Features {
     pub allow_trace_macros: bool,
     pub allow_internal_unstable: bool,
     pub allow_custom_derive: bool,
+    pub allow_placement_in: bool,
+    pub allow_box: bool,
     pub simd_ffi: bool,
     pub unmarked_api: bool,
     pub negate_unsigned: bool,
@@ -348,6 +351,8 @@ impl Features {
             allow_trace_macros: false,
             allow_internal_unstable: false,
             allow_custom_derive: false,
+            allow_placement_in: false,
+            allow_box: false,
             simd_ffi: false,
             unmarked_api: false,
             negate_unsigned: false,
@@ -358,6 +363,26 @@ impl Features {
     }
 }
 
+const EXPLAIN_BOX_SYNTAX: &'static str =
+    "box expression syntax is experimental; you can call `Box::new` instead.";
+
+const EXPLAIN_PLACEMENT_IN: &'static str =
+    "placement-in expression syntax is experimental and subject to change.";
+
+pub fn check_for_box_syntax(f: Option<&Features>, diag: &SpanHandler, span: Span) {
+    if let Some(&Features { allow_box: true, .. }) = f {
+        return;
+    }
+    emit_feature_err(diag, "box_syntax", span, EXPLAIN_BOX_SYNTAX);
+}
+
+pub fn check_for_placement_in(f: Option<&Features>, diag: &SpanHandler, span: Span) {
+    if let Some(&Features { allow_placement_in: true, .. }) = f {
+        return;
+    }
+    emit_feature_err(diag, "placement_in_syntax", span, EXPLAIN_PLACEMENT_IN);
+}
+
 struct Context<'a> {
     features: Vec<&'static str>,
     span_handler: &'a SpanHandler,
@@ -366,6 +391,11 @@ struct Context<'a> {
 }
 
 impl<'a> Context<'a> {
+    fn enable_feature(&mut self, feature: &'static str) {
+        debug!("enabling feature: {}", feature);
+        self.features.push(feature);
+    }
+
     fn gate_feature(&self, feature: &str, span: Span, explain: &str) {
         let has_feature = self.has_feature(feature);
         debug!("gate_feature(feature = {:?}, span = {:?}); has? {}", feature, span, has_feature);
@@ -487,6 +517,26 @@ impl<'a, 'v> Visitor<'v> for MacroVisitor<'a> {
 
     fn visit_attribute(&mut self, attr: &'v ast::Attribute) {
         self.context.check_attribute(attr, true);
+    }
+
+    fn visit_expr(&mut self, e: &ast::Expr) {
+        // Issue 22181: overloaded-`box` and placement-`in` are
+        // implemented via a desugaring expansion, so their feature
+        // gates go into MacroVisitor since that works pre-expansion.
+        //
+        // Issue 22234: we also check during expansion as well.
+        // But we keep these checks as a pre-expansion check to catch
+        // uses in e.g. conditionalized code.
+
+        if let ast::ExprBox(None, _) = e.node {
+            self.context.gate_feature("box_syntax", e.span, EXPLAIN_BOX_SYNTAX);
+        }
+
+        if let ast::ExprBox(Some(_), _) = e.node {
+            self.context.gate_feature("placement_in_syntax", e.span, EXPLAIN_PLACEMENT_IN);
+        }
+
+        visit::walk_expr(self, e);
     }
 }
 
@@ -754,7 +804,7 @@ fn check_crate_inner<F>(cm: &CodeMap, span_handler: &SpanHandler,
                     match KNOWN_FEATURES.iter()
                                         .find(|& &(n, _, _)| name == n) {
                         Some(&(name, _, Active)) => {
-                            cx.features.push(name);
+                            cx.enable_feature(name);
                         }
                         Some(&(_, _, Removed)) => {
                             span_handler.span_err(mi.span, "feature has been removed");
@@ -787,6 +837,8 @@ fn check_crate_inner<F>(cm: &CodeMap, span_handler: &SpanHandler,
         allow_trace_macros: cx.has_feature("trace_macros"),
         allow_internal_unstable: cx.has_feature("allow_internal_unstable"),
         allow_custom_derive: cx.has_feature("custom_derive"),
+        allow_placement_in: cx.has_feature("placement_in_syntax"),
+        allow_box: cx.has_feature("box_syntax"),
         simd_ffi: cx.has_feature("simd_ffi"),
         unmarked_api: cx.has_feature("unmarked_api"),
         negate_unsigned: cx.has_feature("negate_unsigned"),

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -81,6 +81,7 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Status)] = &[
     ("slicing_syntax", "1.0.0", Accepted),
     ("box_syntax", "1.0.0", Active),
     ("placement_in_syntax", "1.0.0", Active),
+    ("pushpop_unsafe", "1.2.0", Active),
     ("on_unimplemented", "1.0.0", Active),
     ("simd_ffi", "1.0.0", Active),
     ("allocator", "1.0.0", Active),
@@ -328,6 +329,7 @@ pub struct Features {
     pub allow_custom_derive: bool,
     pub allow_placement_in: bool,
     pub allow_box: bool,
+    pub allow_pushpop_unsafe: bool,
     pub simd_ffi: bool,
     pub unmarked_api: bool,
     pub negate_unsigned: bool,
@@ -353,6 +355,7 @@ impl Features {
             allow_custom_derive: false,
             allow_placement_in: false,
             allow_box: false,
+            allow_pushpop_unsafe: false,
             simd_ffi: false,
             unmarked_api: false,
             negate_unsigned: false,
@@ -369,6 +372,9 @@ const EXPLAIN_BOX_SYNTAX: &'static str =
 const EXPLAIN_PLACEMENT_IN: &'static str =
     "placement-in expression syntax is experimental and subject to change.";
 
+const EXPLAIN_PUSHPOP_UNSAFE: &'static str =
+    "push/pop_unsafe macros are experimental and subject to change.";
+
 pub fn check_for_box_syntax(f: Option<&Features>, diag: &SpanHandler, span: Span) {
     if let Some(&Features { allow_box: true, .. }) = f {
         return;
@@ -381,6 +387,13 @@ pub fn check_for_placement_in(f: Option<&Features>, diag: &SpanHandler, span: Sp
         return;
     }
     emit_feature_err(diag, "placement_in_syntax", span, EXPLAIN_PLACEMENT_IN);
+}
+
+pub fn check_for_pushpop_syntax(f: Option<&Features>, diag: &SpanHandler, span: Span) {
+    if let Some(&Features { allow_pushpop_unsafe: true, .. }) = f {
+        return;
+    }
+    emit_feature_err(diag, "pushpop_unsafe", span, EXPLAIN_PUSHPOP_UNSAFE);
 }
 
 struct Context<'a> {
@@ -839,6 +852,7 @@ fn check_crate_inner<F>(cm: &CodeMap, span_handler: &SpanHandler,
         allow_custom_derive: cx.has_feature("custom_derive"),
         allow_placement_in: cx.has_feature("placement_in_syntax"),
         allow_box: cx.has_feature("box_syntax"),
+        allow_pushpop_unsafe: cx.has_feature("pushpop_unsafe"),
         simd_ffi: cx.has_feature("simd_ffi"),
         unmarked_api: cx.has_feature("unmarked_api"),
         negate_unsigned: cx.has_feature("negate_unsigned"),

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -119,6 +119,7 @@ pub mod ext {
     pub mod log_syntax;
     pub mod mtwt;
     pub mod quote;
+    pub mod pushpop_safe;
     pub mod source_util;
     pub mod trace_macros;
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -53,7 +53,7 @@ use ast::{TtDelimited, TtSequence, TtToken};
 use ast::{TupleVariantKind, Ty, Ty_, TypeBinding};
 use ast::{TyFixedLengthVec, TyBareFn, TyTypeof, TyInfer};
 use ast::{TyParam, TyParamBound, TyParen, TyPath, TyPolyTraitRef, TyPtr};
-use ast::{TyRptr, TyTup, TyU32, TyVec, UnUniq};
+use ast::{TyRptr, TyTup, TyU32, TyVec};
 use ast::{TypeImplItem, TypeTraitItem};
 use ast::{UnnamedField, UnsafeBlock};
 use ast::{ViewPath, ViewPathGlob, ViewPathList, ViewPathSimple};
@@ -2646,10 +2646,7 @@ impl<'a> Parser<'a> {
             // Otherwise, we use the unique pointer default.
             let subexpression = try!(self.parse_prefix_expr());
             hi = subexpression.span.hi;
-            // FIXME (pnkfelix): After working out kinks with box
-            // desugaring, should be `ExprBox(None, subexpression)`
-            // instead.
-            ex = self.mk_unary(UnUniq, subexpression);
+            ex = ExprBox(None, subexpression);
           }
           _ => return self.parse_dot_or_call_expr()
         }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1434,8 +1434,8 @@ impl<'a> State<'a> {
                                       attrs: &[ast::Attribute],
                                       close_box: bool) -> io::Result<()> {
         match blk.rules {
-            ast::UnsafeBlock(..) => try!(self.word_space("unsafe")),
-            ast::DefaultBlock => ()
+            ast::UnsafeBlock(..) | ast::PushUnsafeBlock(..) => try!(self.word_space("unsafe")),
+            ast::DefaultBlock    | ast::PopUnsafeBlock(..) => ()
         }
         try!(self.maybe_print_comment(blk.span.lo));
         try!(self.ann.pre(self, NodeBlock(blk)));

--- a/src/libterm/lib.rs
+++ b/src/libterm/lib.rs
@@ -101,7 +101,7 @@ impl Write for WriterWrapper {
 /// opened.
 pub fn stdout() -> Option<Box<Terminal<WriterWrapper> + Send>> {
     TerminfoTerminal::new(WriterWrapper {
-        wrapped: box std::io::stdout(),
+        wrapped: Box::new(std::io::stdout()),
     })
 }
 
@@ -128,7 +128,7 @@ pub fn stdout() -> Option<Box<Terminal<WriterWrapper> + Send>> {
 /// opened.
 pub fn stderr() -> Option<Box<Terminal<WriterWrapper> + Send>> {
     TerminfoTerminal::new(WriterWrapper {
-        wrapped: box std::io::stderr(),
+        wrapped: Box::new(std::io::stderr()),
     })
 }
 

--- a/src/libterm/terminfo/mod.rs
+++ b/src/libterm/terminfo/mod.rs
@@ -186,11 +186,11 @@ impl<T: Write+Send+'static> TerminfoTerminal<T> {
             Err(err) => return match env::var("MSYSCON") {
                 Ok(ref val) if &val[..] == "mintty.exe" => {
                     // msys terminal
-                    Some(box TerminfoTerminal{
-                        out: out,
-                        ti: msys_terminfo(),
-                        num_colors: 8,
-                    })
+                    Some(Box::new(TerminfoTerminal{
+                            out: out,
+                            ti: msys_terminfo(),
+                            num_colors: 8,
+                    }))
                 },
                 _ => {
                     debug!("error finding terminfo entry: {:?}", err);
@@ -211,9 +211,9 @@ impl<T: Write+Send+'static> TerminfoTerminal<T> {
                      inf.numbers.get("colors").map_or(0, |&n| n)
                  } else { 0 };
 
-        return Some(box TerminfoTerminal {out: out,
-                                          ti: inf,
-                                          num_colors: nc});
+        return Some(Box::new(TerminfoTerminal {out: out,
+                                               ti: inf,
+                                               num_colors: nc}));
     }
 
     fn dim_if_necessary(&self, color: color::Color) -> color::Color {

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -991,8 +991,8 @@ pub fn run_test(opts: &TestOpts,
 
             let result_guard = cfg.spawn(move || {
                 if !nocapture {
-                    io::set_print(box Sink(data2.clone()));
-                    io::set_panic(box Sink(data2));
+                    io::set_print(Box::new(Sink(data2.clone())));
+                    io::set_panic(Box::new(Sink(data2)));
                 }
                 testfn()
             }).unwrap();

--- a/src/test/auxiliary/custom_derive_plugin.rs
+++ b/src/test/auxiliary/custom_derive_plugin.rs
@@ -11,7 +11,6 @@
 // force-host
 
 #![feature(plugin_registrar)]
-#![feature(box_syntax)]
 #![feature(rustc_private)]
 
 extern crate syntax;
@@ -31,7 +30,7 @@ use rustc::plugin::Registry;
 pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_syntax_extension(
         token::intern("derive_TotalSum"),
-        MultiDecorator(box expand));
+        MultiDecorator(Box::new(expand)));
 }
 
 fn expand(cx: &mut ExtCtxt,
@@ -55,7 +54,7 @@ fn expand(cx: &mut ExtCtxt,
                 ret_ty: Literal(Path::new_local("isize")),
                 attributes: vec![],
                 is_unsafe: false,
-                combine_substructure: combine_substructure(box |cx, span, substr| {
+                combine_substructure: combine_substructure(Box::new(|cx, span, substr| {
                     let zero = cx.expr_isize(span, 0);
                     cs_fold(false,
                             |cx, span, subexpr, field, _| {
@@ -64,9 +63,9 @@ fn expand(cx: &mut ExtCtxt,
                                         token::str_to_ident("total_sum"), vec![]))
                             },
                             zero,
-                            box |cx, span, _, _| { cx.span_bug(span, "wtf??"); },
+                            Box::new(|cx, span, _, _| { cx.span_bug(span, "wtf??"); }),
                             cx, span, substr)
-                }),
+                })),
             },
         ],
     };

--- a/src/test/auxiliary/custom_derive_plugin_attr.rs
+++ b/src/test/auxiliary/custom_derive_plugin_attr.rs
@@ -11,7 +11,6 @@
 // force-host
 
 #![feature(plugin_registrar)]
-#![feature(box_syntax)]
 #![feature(rustc_private)]
 
 extern crate syntax;
@@ -33,7 +32,7 @@ use rustc::plugin::Registry;
 pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_syntax_extension(
         token::intern("derive_TotalSum"),
-        MultiDecorator(box expand));
+        MultiDecorator(Box::new(expand)));
 }
 
 fn expand(cx: &mut ExtCtxt,

--- a/src/test/auxiliary/issue-2380.rs
+++ b/src/test/auxiliary/issue-2380.rs
@@ -22,5 +22,6 @@ pub trait i<T>
 pub fn f<T>() -> Box<i<T>+'static> {
     impl<T> i<T> for () { }
 
-    box() () as Box<i<T>+'static>
+    let b: Box<_> = box() ();
+    b as Box<i<T>+'static>
 }

--- a/src/test/auxiliary/lint_for_crate.rs
+++ b/src/test/auxiliary/lint_for_crate.rs
@@ -11,7 +11,6 @@
 // force-host
 
 #![feature(plugin_registrar, rustc_private)]
-#![feature(box_syntax)]
 
 extern crate syntax;
 #[macro_use] extern crate rustc;
@@ -39,5 +38,5 @@ impl LintPass for Pass {
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_lint_pass(box Pass as LintPassObject);
+    reg.register_lint_pass(Box::new(Pass) as LintPassObject);
 }

--- a/src/test/auxiliary/lint_group_plugin_test.rs
+++ b/src/test/auxiliary/lint_group_plugin_test.rs
@@ -11,7 +11,7 @@
 // force-host
 
 #![feature(plugin_registrar)]
-#![feature(box_syntax, rustc_private)]
+#![feature(rustc_private)]
 
 extern crate syntax;
 
@@ -47,6 +47,6 @@ impl LintPass for Pass {
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_lint_pass(box Pass as LintPassObject);
+    reg.register_lint_pass(Box::new(Pass) as LintPassObject);
     reg.register_lint_group("lint_me", vec![TEST_LINT, PLEASE_LINT]);
 }

--- a/src/test/auxiliary/lint_plugin_test.rs
+++ b/src/test/auxiliary/lint_plugin_test.rs
@@ -11,7 +11,7 @@
 // force-host
 
 #![feature(plugin_registrar)]
-#![feature(box_syntax, rustc_private)]
+#![feature(rustc_private)]
 
 extern crate syntax;
 
@@ -43,5 +43,5 @@ impl LintPass for Pass {
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_lint_pass(box Pass as LintPassObject);
+    reg.register_lint_pass(Box::new(Pass) as LintPassObject);
 }

--- a/src/test/auxiliary/plugin_crate_outlive_expansion_phase.rs
+++ b/src/test/auxiliary/plugin_crate_outlive_expansion_phase.rs
@@ -11,7 +11,7 @@
 // force-host
 
 #![feature(plugin_registrar)]
-#![feature(box_syntax, rustc_private)]
+#![feature(rustc_private)]
 
 extern crate rustc;
 
@@ -30,5 +30,5 @@ impl Drop for Foo {
 #[plugin_registrar]
 pub fn registrar(_: &mut Registry) {
     thread_local!(static FOO: RefCell<Option<Box<Any+Send>>> = RefCell::new(None));
-    FOO.with(|s| *s.borrow_mut() = Some(box Foo { foo: 10 } as Box<Any+Send>));
+    FOO.with(|s| *s.borrow_mut() = Some(Box::new(Foo { foo: 10 }) as Box<Any+Send>));
 }

--- a/src/test/compile-fail/check-static-values-constraints.rs
+++ b/src/test/compile-fail/check-static-values-constraints.rs
@@ -99,7 +99,22 @@ static STATIC10: UnsafeStruct = UnsafeStruct;
 struct MyOwned;
 
 static STATIC11: Box<MyOwned> = box MyOwned;
-//~^ ERROR allocations are not allowed in statics
+//~^ ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR references in statics may only refer to immutable values
 
 // The following examples test that mutable structs are just forbidden
 // to have types with destructors
@@ -121,13 +136,77 @@ static mut STATIC14: SafeStruct = SafeStruct {
 };
 
 static STATIC15: &'static [Box<MyOwned>] = &[
-    box MyOwned, //~ ERROR allocations are not allowed in statics
-    box MyOwned, //~ ERROR allocations are not allowed in statics
+    box MyOwned,
+    //~^ ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR references in statics may only refer to immutable values
+    box MyOwned,
+    //~^ ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR references in statics may only refer to immutable values
 ];
 
 static STATIC16: (&'static Box<MyOwned>, &'static Box<MyOwned>) = (
-    &box MyOwned, //~ ERROR allocations are not allowed in statics
-    &box MyOwned, //~ ERROR allocations are not allowed in statics
+    &box MyOwned,
+    //~^ ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR references in statics may only refer to immutable values
+    &box MyOwned,
+    //~^ ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR references in statics may only refer to immutable values
 );
 
 static mut STATIC17: SafeEnum = SafeEnum::Variant1;
@@ -135,9 +214,39 @@ static mut STATIC17: SafeEnum = SafeEnum::Variant1;
 
 static STATIC19: Box<isize> =
     box 3;
-//~^ ERROR allocations are not allowed in statics
+//~^ ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR references in statics may only refer to immutable values
 
 pub fn main() {
     let y = { static x: Box<isize> = box 3; x };
-    //~^ ERROR allocations are not allowed in statics
+    //~^ ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR statics are not allowed to have destructors
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR blocks in statics are limited to items and tail expressions
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR function calls in statics are limited to struct and enum constructors
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR references in statics may only refer to immutable values
 }

--- a/src/test/compile-fail/check-static-values-constraints.rs
+++ b/src/test/compile-fail/check-static-values-constraints.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-tidy-linelength
+
 // Verifies all possible restrictions for statics values.
 
 #![feature(box_syntax)]

--- a/src/test/compile-fail/check-static-values-constraints.rs
+++ b/src/test/compile-fail/check-static-values-constraints.rs
@@ -105,12 +105,10 @@ static STATIC11: Box<MyOwned> = box MyOwned;
 //~| ERROR blocks in statics are limited to items and tail expressions
 //~| ERROR blocks in statics are limited to items and tail expressions
 //~| ERROR blocks in statics are limited to items and tail expressions
-//~| ERROR blocks in statics are limited to items and tail expressions
-//~| ERROR function calls in statics are limited to struct and enum constructors
-//~| ERROR function calls in statics are limited to struct and enum constructors
-//~| ERROR function calls in statics are limited to struct and enum constructors
-//~| ERROR function calls in statics are limited to struct and enum constructors
-//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
 //~| ERROR paths in statics may only refer to constants or functions
 //~| ERROR paths in statics may only refer to constants or functions
 //~| ERROR paths in statics may only refer to constants or functions
@@ -143,12 +141,10 @@ static STATIC15: &'static [Box<MyOwned>] = &[
     //~| ERROR blocks in statics are limited to items and tail expressions
     //~| ERROR blocks in statics are limited to items and tail expressions
     //~| ERROR blocks in statics are limited to items and tail expressions
-    //~| ERROR blocks in statics are limited to items and tail expressions
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
     //~| ERROR paths in statics may only refer to constants or functions
     //~| ERROR paths in statics may only refer to constants or functions
     //~| ERROR paths in statics may only refer to constants or functions
@@ -160,12 +156,10 @@ static STATIC15: &'static [Box<MyOwned>] = &[
     //~| ERROR blocks in statics are limited to items and tail expressions
     //~| ERROR blocks in statics are limited to items and tail expressions
     //~| ERROR blocks in statics are limited to items and tail expressions
-    //~| ERROR blocks in statics are limited to items and tail expressions
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
     //~| ERROR paths in statics may only refer to constants or functions
     //~| ERROR paths in statics may only refer to constants or functions
     //~| ERROR paths in statics may only refer to constants or functions
@@ -180,12 +174,10 @@ static STATIC16: (&'static Box<MyOwned>, &'static Box<MyOwned>) = (
     //~| ERROR blocks in statics are limited to items and tail expressions
     //~| ERROR blocks in statics are limited to items and tail expressions
     //~| ERROR blocks in statics are limited to items and tail expressions
-    //~| ERROR blocks in statics are limited to items and tail expressions
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
     //~| ERROR paths in statics may only refer to constants or functions
     //~| ERROR paths in statics may only refer to constants or functions
     //~| ERROR paths in statics may only refer to constants or functions
@@ -197,12 +189,10 @@ static STATIC16: (&'static Box<MyOwned>, &'static Box<MyOwned>) = (
     //~| ERROR blocks in statics are limited to items and tail expressions
     //~| ERROR blocks in statics are limited to items and tail expressions
     //~| ERROR blocks in statics are limited to items and tail expressions
-    //~| ERROR blocks in statics are limited to items and tail expressions
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
     //~| ERROR paths in statics may only refer to constants or functions
     //~| ERROR paths in statics may only refer to constants or functions
     //~| ERROR paths in statics may only refer to constants or functions
@@ -220,12 +210,10 @@ static STATIC19: Box<isize> =
 //~| ERROR blocks in statics are limited to items and tail expressions
 //~| ERROR blocks in statics are limited to items and tail expressions
 //~| ERROR blocks in statics are limited to items and tail expressions
-//~| ERROR blocks in statics are limited to items and tail expressions
-//~| ERROR function calls in statics are limited to struct and enum constructors
-//~| ERROR function calls in statics are limited to struct and enum constructors
-//~| ERROR function calls in statics are limited to struct and enum constructors
-//~| ERROR function calls in statics are limited to struct and enum constructors
-//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
 //~| ERROR paths in statics may only refer to constants or functions
 //~| ERROR paths in statics may only refer to constants or functions
 //~| ERROR paths in statics may only refer to constants or functions
@@ -239,12 +227,10 @@ pub fn main() {
     //~| ERROR blocks in statics are limited to items and tail expressions
     //~| ERROR blocks in statics are limited to items and tail expressions
     //~| ERROR blocks in statics are limited to items and tail expressions
-    //~| ERROR blocks in statics are limited to items and tail expressions
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR function calls in statics are limited to struct and enum constructors
-    //~| ERROR paths in statics may only refer to constants or functions
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+    //~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
     //~| ERROR paths in statics may only refer to constants or functions
     //~| ERROR paths in statics may only refer to constants or functions
     //~| ERROR paths in statics may only refer to constants or functions

--- a/src/test/compile-fail/class-cast-to-trait.rs
+++ b/src/test/compile-fail/class-cast-to-trait.rs
@@ -59,6 +59,7 @@ fn cat(in_x : usize, in_y : isize, in_name: String) -> cat {
 }
 
 fn main() {
-  let nyan: Box<noisy> = box cat(0, 2, "nyan".to_string()) as Box<noisy>;
+  let b: Box<_> = box cat(0, 2, "nyan".to_string());
+  let nyan: Box<noisy> = b as Box<noisy>;
   nyan.eat(); //~ ERROR no method named `eat` found
 }

--- a/src/test/compile-fail/destructure-trait-ref.rs
+++ b/src/test/compile-fail/destructure-trait-ref.rs
@@ -35,7 +35,8 @@ fn main() {
     // n == m
     let &x = &1isize as &T;      //~ ERROR type `&T` cannot be dereferenced
     let &&x = &(&1isize as &T);  //~ ERROR type `&T` cannot be dereferenced
-    let box x = box 1isize as Box<T>; //~ ERROR the trait `core::marker::Sized` is not implemented
+    let b: Box<_> = box 1isize;
+    let box x = b as Box<T>; //~ ERROR the trait `core::marker::Sized` is not implemented
 
     // n > m
     let &&x = &1isize as &T;
@@ -50,7 +51,8 @@ fn main() {
     //~| found `&_`
     //~| expected trait T
     //~| found &-ptr
-    let box box x = box 1isize as Box<T>;
+    let b: Box<_> = box 1isize;
+    let box box x = b as Box<T>;
     //~^ ERROR mismatched types
     //~| expected `T`
     //~| found `Box<_>`

--- a/src/test/compile-fail/dst-rvalue.rs
+++ b/src/test/compile-fail/dst-rvalue.rs
@@ -14,11 +14,15 @@
 
 pub fn main() {
     let _x: Box<str> = box *"hello world";
-    //~^ ERROR E0161
-    //~^^ ERROR cannot move out of borrowed content
+    //~^ ERROR E0277
+    //~| ERROR the trait `core::marker::Sized` is not implemented for the type `str`
+    //~| ERROR the trait `core::marker::Sized` is not implemented for the type `str`
+    //~| ERROR the trait `core::marker::Sized` is not implemented for the type `str`
 
     let array: &[isize] = &[1, 2, 3];
     let _x: Box<[isize]> = box *array;
-    //~^ ERROR E0161
-    //~^^ ERROR cannot move out of borrowed content
+    //~^ ERROR E0277
+    //~| ERROR the trait `core::marker::Sized` is not implemented for the type `[isize]`
+    //~| ERROR the trait `core::marker::Sized` is not implemented for the type `[isize]`
+    //~| ERROR the trait `core::marker::Sized` is not implemented for the type `[isize]`
 }

--- a/src/test/compile-fail/dst-rvalue.rs
+++ b/src/test/compile-fail/dst-rvalue.rs
@@ -17,12 +17,10 @@ pub fn main() {
     //~^ ERROR E0277
     //~| ERROR the trait `core::marker::Sized` is not implemented for the type `str`
     //~| ERROR the trait `core::marker::Sized` is not implemented for the type `str`
-    //~| ERROR the trait `core::marker::Sized` is not implemented for the type `str`
 
     let array: &[isize] = &[1, 2, 3];
     let _x: Box<[isize]> = box *array;
     //~^ ERROR E0277
-    //~| ERROR the trait `core::marker::Sized` is not implemented for the type `[isize]`
     //~| ERROR the trait `core::marker::Sized` is not implemented for the type `[isize]`
     //~| ERROR the trait `core::marker::Sized` is not implemented for the type `[isize]`
 }

--- a/src/test/compile-fail/feature-gate-box-expr.rs
+++ b/src/test/compile-fail/feature-gate-box-expr.rs
@@ -11,15 +11,16 @@
 fn main() {
     use std::boxed::HEAP;
 
-    let x = box 'c'; //~ ERROR box expression syntax is experimental
+    let x: Box<_> = box 'c'; //~ ERROR box expression syntax is experimental
     println!("x: {}", x);
 
-    let x = box () 'c'; //~ ERROR box expression syntax is experimental
+    let x: Box<_> = box () 'c'; //~ ERROR box expression syntax is experimental
     println!("x: {}", x);
 
-    let x = box (HEAP) 'c'; //~ ERROR placement-in expression syntax is experimental
+    let x: Box<_> = box (HEAP) 'c'; //~ ERROR placement-in expression syntax is experimental
     println!("x: {}", x);
 
-    let x = in HEAP { 'c' }; //~ ERROR placement-in expression syntax is experimental
-    println!("x: {}", x);
+    // XXX
+    // let x = in HEAP { 'c' };
+    // println!("x: {}", x);
 }

--- a/src/test/compile-fail/feature-gate-box-expr.rs
+++ b/src/test/compile-fail/feature-gate-box-expr.rs
@@ -20,7 +20,7 @@ fn main() {
     let x: Box<_> = box (HEAP) 'c'; //~ ERROR placement-in expression syntax is experimental
     println!("x: {}", x);
 
-    // XXX
+    // FIXME (#22181) put back when new placement-in syntax is supported
     // let x = in HEAP { 'c' };
     // println!("x: {}", x);
 }

--- a/src/test/compile-fail/feature-gate-box-expr.rs
+++ b/src/test/compile-fail/feature-gate-box-expr.rs
@@ -17,6 +17,9 @@ fn main() {
     let x = box () 'c'; //~ ERROR box expression syntax is experimental
     println!("x: {}", x);
 
-    let x = box (HEAP) 'c'; //~ ERROR box expression syntax is experimental
+    let x = box (HEAP) 'c'; //~ ERROR placement-in expression syntax is experimental
+    println!("x: {}", x);
+
+    let x = in HEAP { 'c' }; //~ ERROR placement-in expression syntax is experimental
     println!("x: {}", x);
 }

--- a/src/test/compile-fail/feature-gate-pushpop-unsafe.rs
+++ b/src/test/compile-fail/feature-gate-pushpop-unsafe.rs
@@ -1,0 +1,14 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let c = push_unsafe!('c'); //~ ERROR push/pop_unsafe macros are experimental
+    let c = pop_unsafe!('c'); //~ ERROR push/pop_unsafe macros are experimental
+}

--- a/src/test/compile-fail/fn-trait-formatting.rs
+++ b/src/test/compile-fail/fn-trait-formatting.rs
@@ -14,19 +14,19 @@
 fn needs_fn<F>(x: F) where F: Fn(isize) -> isize {}
 
 fn main() {
-    let _: () = (box |_: isize| {}) as Box<FnOnce(isize)>;
+    let _: () = Box::new(|_: isize| {}) as Box<FnOnce(isize)>;
     //~^ ERROR mismatched types
     //~| expected `()`
     //~| found `Box<core::ops::FnOnce(isize)>`
     //~| expected ()
     //~| found box
-    let _: () = (box |_: isize, isize| {}) as Box<Fn(isize, isize)>;
+    let _: () = Box::new(|_: isize, isize| {}) as Box<Fn(isize, isize)>;
     //~^ ERROR mismatched types
     //~| expected `()`
     //~| found `Box<core::ops::Fn(isize, isize)>`
     //~| expected ()
     //~| found box
-    let _: () = (box || -> isize { unimplemented!() }) as Box<FnMut() -> isize>;
+    let _: () = Box::new(|| -> isize { unimplemented!() }) as Box<FnMut() -> isize>;
     //~^ ERROR mismatched types
     //~| expected `()`
     //~| found `Box<core::ops::FnMut() -> isize>`

--- a/src/test/compile-fail/issue-14084.rs
+++ b/src/test/compile-fail/issue-14084.rs
@@ -8,9 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(box_syntax)]
+#![feature(placement_in_syntax)]
 
 fn main() {
-    box ( () ) 0;
-    //~^ ERROR: only the exchange heap is currently supported
+    let _bx: Box<_> = box ( () ) 0;
+    //~^ ERROR: the trait `core::ops::Placer<_>` is not implemented for the type `()`
+    //~| ERROR: the trait `core::ops::Placer<_>` is not implemented for the type `()`
 }

--- a/src/test/compile-fail/issue-7013.rs
+++ b/src/test/compile-fail/issue-7013.rs
@@ -33,6 +33,7 @@ struct A {
 }
 
 fn main() {
-    let a = A {v: box B{v: None} as Box<Foo+Send>};
+    let b: Box<_> = box B{v: None};
+    let a = A {v: b as Box<Foo+Send>};
     //~^ ERROR the trait `core::marker::Send` is not implemented
 }

--- a/src/test/compile-fail/issue-7364.rs
+++ b/src/test/compile-fail/issue-7364.rs
@@ -23,11 +23,13 @@ static boxed: Box<RefCell<isize>> = box RefCell::new(0);
 //~| ERROR blocks in statics are limited to items and tail expressions
 //~| ERROR blocks in statics are limited to items and tail expressions
 //~| ERROR blocks in statics are limited to items and tail expressions
-//~| ERROR blocks in statics are limited to items and tail expressions
 //~| ERROR paths in statics may only refer to constants or functions
 //~| ERROR paths in statics may only refer to constants or functions
 //~| ERROR paths in statics may only refer to constants or functions
-//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
 //~| ERROR references in statics may only refer to immutable values
 
 fn main() { }

--- a/src/test/compile-fail/issue-7364.rs
+++ b/src/test/compile-fail/issue-7364.rs
@@ -15,8 +15,19 @@ use std::cell::RefCell;
 
 // Regression test for issue 7364
 static boxed: Box<RefCell<isize>> = box RefCell::new(0);
-//~^ ERROR allocations are not allowed in statics
+//~^ ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
 //~| ERROR the trait `core::marker::Sync` is not implemented for the type
 //~| ERROR the trait `core::marker::Sync` is not implemented for the type
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR references in statics may only refer to immutable values
 
 fn main() { }

--- a/src/test/compile-fail/lint-owned-heap-memory.rs
+++ b/src/test/compile-fail/lint-owned-heap-memory.rs
@@ -11,6 +11,7 @@
 #![allow(dead_code)]
 #![forbid(box_pointers)]
 #![feature(box_syntax)]
+#![feature(core)]
 
 struct Foo {
     x: Box<isize> //~ ERROR type uses owned
@@ -19,4 +20,7 @@ struct Foo {
 fn main() {
     let _x : Foo = Foo {x : box 10};
     //~^ ERROR type uses owned
+    //~| ERROR type uses owned
+    //~| ERROR type uses owned
+    //~| ERROR type uses owned
 }

--- a/src/test/compile-fail/lint-owned-heap-memory.rs
+++ b/src/test/compile-fail/lint-owned-heap-memory.rs
@@ -11,7 +11,6 @@
 #![allow(dead_code)]
 #![forbid(box_pointers)]
 #![feature(box_syntax)]
-#![feature(core)]
 
 struct Foo {
     x: Box<isize> //~ ERROR type uses owned

--- a/src/test/compile-fail/occurs-check-2.rs
+++ b/src/test/compile-fail/occurs-check-2.rs
@@ -11,12 +11,21 @@
 #![feature(box_syntax)]
 
 fn main() {
-    let f;
+    let f: Box<_>;
     let g;
     g = f;
     f = box g;
-    //~^  ERROR mismatched types
-    //~| expected `_`
-    //~| found `Box<_>`
-    //~| cyclic type of infinite size
+    //~^ ERROR the trait `core::ops::Place<Box<_>>` is not implemented for the type
+
+    // (At one time, we produced a nicer error message like below.
+    //  but right now, the desugaring produces the above error instead
+    //  for the cyclic type here; its especially unfortunate because
+    //  printed error leaves out the information necessary for one to
+    //  deduce that the necessary type for the given impls *is*
+    //  cyclic.)
+    //
+    // ^  ERROR mismatched types
+    // | expected `_`
+    // | found `Box<_>`
+    // | cyclic type of infinite size
 }

--- a/src/test/compile-fail/occurs-check.rs
+++ b/src/test/compile-fail/occurs-check.rs
@@ -11,10 +11,19 @@
 #![feature(box_syntax)]
 
 fn main() {
-    let f;
+    let f: Box<_>;
     f = box f;
-    //~^ ERROR mismatched types
-    //~| expected `_`
-    //~| found `Box<_>`
-    //~| cyclic type of infinite size
+    //~^ ERROR the trait `core::ops::Place<Box<_>>` is not implemented for the type
+
+    // (At one time, we produced a nicer error message like below.
+    //  but right now, the desugaring produces the above error instead
+    //  for the cyclic type here; its especially unfortunate because
+    //  printed error leaves out the information necessary for one to
+    //  deduce that the necessary type for the given impls *is*
+    //  cyclic.)
+    //
+    // ^ ERROR mismatched types
+    // | expected `_`
+    // | found `Box<_>`
+    // | cyclic type of infinite size
 }

--- a/src/test/compile-fail/pushpop-unsafe-rejects.rs
+++ b/src/test/compile-fail/pushpop-unsafe-rejects.rs
@@ -13,6 +13,8 @@
 // positive number of pushes in the stack, or if we are within a
 // normal `unsafe` block, but otherwise cannot.
 
+#![feature(pushpop_unsafe)]
+
 static mut X: i32 = 0;
 
 unsafe fn f() { X += 1; return; }

--- a/src/test/compile-fail/pushpop-unsafe-rejects.rs
+++ b/src/test/compile-fail/pushpop-unsafe-rejects.rs
@@ -1,0 +1,71 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Basic sanity check for `push_unsafe!(EXPR)` and
+// `pop_unsafe!(EXPR)`: we can call unsafe code when there are a
+// positive number of pushes in the stack, or if we are within a
+// normal `unsafe` block, but otherwise cannot.
+
+static mut X: i32 = 0;
+
+unsafe fn f() { X += 1; return; }
+fn g() { unsafe { X += 1_000; } return; }
+
+fn main() {
+    push_unsafe!( {
+        f(); pop_unsafe!({
+            f() //~ ERROR: call to unsafe function
+        })
+    } );
+
+    push_unsafe!({
+        f();
+        pop_unsafe!({
+            g();
+            f(); //~ ERROR: call to unsafe function
+        })
+    } );
+
+    push_unsafe!({
+        g(); pop_unsafe!({
+            unsafe {
+                f();
+            }
+            f(); //~ ERROR: call to unsafe function
+        })
+    });
+
+
+    // Note: For implementation simplicity I have chosen to just have
+    // the stack do "saturated pop", but perhaps we would prefer to
+    // have cases like these two here be errors:
+
+    pop_unsafe!{ g() };
+
+    push_unsafe!({
+        pop_unsafe!(pop_unsafe!{ g() })
+    });
+
+
+    // Okay, back to examples that do error, even in the presence of
+    // "saturated pop"
+
+    push_unsafe!({
+        g();
+        pop_unsafe!(pop_unsafe!({
+            f() //~ ERROR: call to unsafe function
+        }))
+    });
+
+    pop_unsafe!({
+        f(); //~ ERROR: call to unsafe function
+    })
+
+}

--- a/src/test/compile-fail/regions-close-object-into-object-1.rs
+++ b/src/test/compile-fail/regions-close-object-into-object-1.rs
@@ -18,8 +18,10 @@ trait X { }
 
 impl<'a, T> X for B<'a, T> {}
 
+fn id<T>(x: T) -> T { x }
+
 fn f<'a, T:'static, U>(v: Box<A<T>+'static>) -> Box<X+'static> {
-    box B(&*v) as Box<X> //~ ERROR `*v` does not live long enough
+    id::<Box<_>>(box B(&*v)) as Box<X> //~ ERROR `*v` does not live long enough
 }
 
 fn main() {}

--- a/src/test/compile-fail/regions-close-object-into-object-2.rs
+++ b/src/test/compile-fail/regions-close-object-into-object-2.rs
@@ -16,8 +16,10 @@ struct B<'a, T>(&'a (A<T>+'a));
 trait X { }
 impl<'a, T> X for B<'a, T> {}
 
+fn id<T>(x: T) -> T { x }
+
 fn g<'a, T: 'static>(v: Box<A<T>+'a>) -> Box<X+'static> {
-    box B(&*v) as Box<X> //~ ERROR cannot infer
+    id::<Box<_>>(box B(&*v)) as Box<X> //~ ERROR cannot infer
 }
 
 fn main() { }

--- a/src/test/compile-fail/regions-close-object-into-object-3.rs
+++ b/src/test/compile-fail/regions-close-object-into-object-3.rs
@@ -17,8 +17,10 @@ struct B<'a, T>(&'a (A<T>+'a));
 trait X { }
 impl<'a, T> X for B<'a, T> {}
 
+fn id<T>(x: T) -> T { x }
+
 fn h<'a, T, U:'static>(v: Box<A<U>+'static>) -> Box<X+'static> {
-    box B(&*v) as Box<X> //~ ERROR `*v` does not live long enough
+    id::<Box<_>>(box B(&*v)) as Box<X> //~ ERROR `*v` does not live long enough
 }
 
 fn main() {}

--- a/src/test/compile-fail/regions-close-object-into-object-4.rs
+++ b/src/test/compile-fail/regions-close-object-into-object-4.rs
@@ -16,8 +16,10 @@ struct B<'a, T>(&'a (A<T>+'a));
 trait X { }
 impl<'a, T> X for B<'a, T> {}
 
+fn id<T>(x: T) -> T { x }
+
 fn i<'a, T, U>(v: Box<A<U>+'a>) -> Box<X+'static> {
-    box B(&*v) as Box<X> //~ ERROR cannot infer
+    id::<Box<_>>(box B(&*v)) as Box<X> //~ ERROR cannot infer
 }
 
 fn main() {}

--- a/src/test/compile-fail/regions-close-object-into-object-5.rs
+++ b/src/test/compile-fail/regions-close-object-into-object-5.rs
@@ -22,8 +22,10 @@ trait X { fn foo(&self) {} }
 
 impl<'a, T> X for B<'a, T> {}
 
+fn id<T>(x: T) -> T { x }
+
 fn f<'a, T, U>(v: Box<A<T>+'static>) -> Box<X+'static> {
-    box B(&*v) as Box<X> //~ ERROR the parameter type `T` may not live long enough
+    id::<Box<_>>(box B(&*v)) as Box<X> //~ ERROR the parameter type `T` may not live long enough
         //~^ ERROR the parameter type `T` may not live long enough
 }
 

--- a/src/test/compile-fail/regions-close-over-borrowed-ref-in-obj.rs
+++ b/src/test/compile-fail/regions-close-over-borrowed-ref-in-obj.rs
@@ -18,6 +18,7 @@ fn main() {
     let blah;
     {
         let ss: &isize = &1; //~ ERROR borrowed value does not live long enough
-        blah = box ss as Box<Foo>;
+        let b: Box<_> = box ss;
+        blah = b as Box<Foo>;
     }
 }

--- a/src/test/compile-fail/regions-close-over-type-parameter-1.rs
+++ b/src/test/compile-fail/regions-close-over-type-parameter-1.rs
@@ -17,17 +17,20 @@
 trait SomeTrait { fn get(&self) -> isize; }
 
 fn make_object1<A:SomeTrait>(v: A) -> Box<SomeTrait+'static> {
-    box v as Box<SomeTrait+'static>
+    let b: Box<_> = box v;
+    b as Box<SomeTrait+'static>
         //~^ ERROR the parameter type `A` may not live long enough
         //~^^ ERROR the parameter type `A` may not live long enough
 }
 
 fn make_object2<'a,A:SomeTrait+'a>(v: A) -> Box<SomeTrait+'a> {
-    box v as Box<SomeTrait+'a>
+    let b: Box<_> = box v;
+    b as Box<SomeTrait+'a>
 }
 
 fn make_object3<'a,'b,A:SomeTrait+'a>(v: A) -> Box<SomeTrait+'b> {
-    box v as Box<SomeTrait+'b>
+    let b: Box<_> = box v;
+    b as Box<SomeTrait+'b>
         //~^ ERROR the parameter type `A` may not live long enough
         //~^^ ERROR the parameter type `A` may not live long enough
 }

--- a/src/test/compile-fail/regions-close-over-type-parameter-2.rs
+++ b/src/test/compile-fail/regions-close-over-type-parameter-2.rs
@@ -21,7 +21,8 @@ impl<A> Foo for A {
 }
 
 fn repeater3<'a,A:'a>(v: A) -> Box<Foo+'a> {
-    box v as Box<Foo+'a>
+    let b: Box<_> = box v;
+    b as Box<Foo+'a>
 }
 
 fn main() {

--- a/src/test/compile-fail/regions-close-over-type-parameter-multiple.rs
+++ b/src/test/compile-fail/regions-close-over-type-parameter-multiple.rs
@@ -17,17 +17,20 @@ trait SomeTrait { fn get(&self) -> isize; }
 
 fn make_object_good1<'a,'b,A:SomeTrait+'a+'b>(v: A) -> Box<SomeTrait+'a> {
     // A outlives 'a AND 'b...
-    box v as Box<SomeTrait+'a> // ...hence this type is safe.
+    let b: Box<_> = box v;
+    b as Box<SomeTrait+'a> // ...hence this type is safe.
 }
 
 fn make_object_good2<'a,'b,A:SomeTrait+'a+'b>(v: A) -> Box<SomeTrait+'b> {
     // A outlives 'a AND 'b...
-    box v as Box<SomeTrait+'b> // ...hence this type is safe.
+    let b: Box<_> = box v;
+    b as Box<SomeTrait+'b> // ...hence this type is safe.
 }
 
 fn make_object_bad<'a,'b,'c,A:SomeTrait+'a+'b>(v: A) -> Box<SomeTrait+'c> {
     // A outlives 'a AND 'b...but not 'c.
-    box v as Box<SomeTrait+'a> //~ ERROR lifetime bound not satisfied
+    let b: Box<_> = box v;
+    b as Box<SomeTrait+'a> //~ ERROR lifetime bound not satisfied
 }
 
 fn main() {

--- a/src/test/compile-fail/static-mut-not-constant.rs
+++ b/src/test/compile-fail/static-mut-not-constant.rs
@@ -11,7 +11,23 @@
 #![feature(box_syntax)]
 
 static mut a: Box<isize> = box 3;
-//~^ ERROR allocations are not allowed in statics
-//~^^ ERROR mutable statics are not allowed to have boxes
+//~^ ERROR mutable statics are not allowed to have boxes
+//~| ERROR statics are not allowed to have destructors
+//^| ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
+//~| ERROR statics are not allowed to have destructors
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR blocks in statics are limited to items and tail expressions
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR function calls in statics are limited to struct and enum constructors
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR references in statics may only refer to immutable values
 
 fn main() {}

--- a/src/test/compile-fail/static-mut-not-constant.rs
+++ b/src/test/compile-fail/static-mut-not-constant.rs
@@ -19,12 +19,10 @@ static mut a: Box<isize> = box 3;
 //~| ERROR blocks in statics are limited to items and tail expressions
 //~| ERROR blocks in statics are limited to items and tail expressions
 //~| ERROR blocks in statics are limited to items and tail expressions
-//~| ERROR blocks in statics are limited to items and tail expressions
-//~| ERROR function calls in statics are limited to struct and enum constructors
-//~| ERROR function calls in statics are limited to struct and enum constructors
-//~| ERROR function calls in statics are limited to struct and enum constructors
-//~| ERROR function calls in statics are limited to struct and enum constructors
-//~| ERROR paths in statics may only refer to constants or functions
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
+//~| ERROR function calls in statics are limited to constant functions, struct and enum constructors
 //~| ERROR paths in statics may only refer to constants or functions
 //~| ERROR paths in statics may only refer to constants or functions
 //~| ERROR paths in statics may only refer to constants or functions

--- a/src/test/compile-fail/trait-test-2.rs
+++ b/src/test/compile-fail/trait-test-2.rs
@@ -17,6 +17,7 @@ impl bar for u32 { fn dup(&self) -> u32 { *self } fn blah<X>(&self) {} }
 fn main() {
     10.dup::<i32>(); //~ ERROR does not take type parameters
     10.blah::<i32, i32>(); //~ ERROR incorrect number of type parameters
-    (box 10 as Box<bar>).dup(); //~ ERROR cannot convert to a trait object
+    let b: Box<_> = box 10;
+    (b as Box<bar>).dup(); //~ ERROR cannot convert to a trait object
     //~^ ERROR the trait `bar` is not implemented for the type `bar`
 }

--- a/src/test/compile-fail/unique-object-noncopyable.rs
+++ b/src/test/compile-fail/unique-object-noncopyable.rs
@@ -29,7 +29,7 @@ impl Foo for Bar {
 }
 
 fn main() {
-    let x = box Bar { x: 10 };
+    let x: Box<_> = box Bar { x: 10 };
     let y: Box<Foo> = x as Box<Foo>;
     let _z = y.clone(); //~ ERROR no method named `clone` found
 }

--- a/src/test/debuginfo/box.rs
+++ b/src/test/debuginfo/box.rs
@@ -32,11 +32,14 @@
 
 #![allow(unused_variables)]
 #![feature(box_syntax)]
+#![feature(placement_in_syntax)]
 #![omit_gdb_pretty_printer_section]
 
+use std::boxed::HEAP;
+
 fn main() {
-    let a = box 1;
-    let b = box() (2, 3.5f64);
+    let a: Box<_> = box 1;
+    let b = in HEAP { (2, 3.5f64) };
 
     zzz(); // #break
 }

--- a/src/test/debuginfo/box.rs
+++ b/src/test/debuginfo/box.rs
@@ -33,13 +33,16 @@
 #![allow(unused_variables)]
 #![feature(box_syntax)]
 #![feature(placement_in_syntax)]
+// both needed for HEAP use for some reason
+#![feature(core, alloc)]
 #![omit_gdb_pretty_printer_section]
 
 use std::boxed::HEAP;
 
 fn main() {
     let a: Box<_> = box 1;
-    let b = in HEAP { (2, 3.5f64) };
+    // FIXME (#22181): Put in the new placement-in syntax once that lands.
+    let b = box (HEAP) { (2, 3.5f64) };
 
     zzz(); // #break
 }

--- a/src/test/debuginfo/trait-pointers.rs
+++ b/src/test/debuginfo/trait-pointers.rs
@@ -33,5 +33,5 @@ impl Trait for Struct {}
 fn main() {
     let stack_struct = Struct { a:0, b: 1.0 };
     let reference: &Trait = &stack_struct as &Trait;
-    let unique: Box<Trait> = box Struct { a:2, b: 3.0 } as Box<Trait>;
+    let unique: Box<Trait> = Box::new(Struct { a:2, b: 3.0 }) as Box<Trait>;
 }

--- a/src/test/run-fail/panic-macro-any.rs
+++ b/src/test/run-fail/panic-macro-any.rs
@@ -14,5 +14,5 @@
 #![feature(box_syntax)]
 
 fn main() {
-    panic!(box 413 as Box<::std::any::Any+Send>);
+    panic!(Box::new(413) as Box<::std::any::Any+Send>);
 }

--- a/src/test/run-make/save-analysis/foo.rs
+++ b/src/test/run-make/save-analysis/foo.rs
@@ -253,9 +253,10 @@ fn hello<X: SomeTrait>((z, a) : (u32, String), ex: X) {
     let x = 32.0f32;
     let _ = (x + ((x * x) + 1.0).sqrt()).ln();
 
-    let s: Box<SomeTrait> = box some_fields {field1: 43};
+    let b: Box<some_fields> = box some_fields {field1: 43};
+    let s: Box<SomeTrait> = b;
     let s2: Box<some_fields> =  box some_fields {field1: 43};
-    let s3 = box nofields;
+    let s3: Box<_> = box nofields;
 
     s.Method(43);
     s3.Method(43);
@@ -288,7 +289,7 @@ pub struct blah {
 }
 
 fn main() { // foo
-    let s = box some_fields {field1: 43};
+    let s: Box<_> = box some_fields {field1: 43};
     hello((43, "a".to_string()), *s);
     sub::sub2::hello();
     sub2::sub3::hello();

--- a/src/test/run-pass-valgrind/cleanup-auto-borrow-obj.rs
+++ b/src/test/run-pass-valgrind/cleanup-auto-borrow-obj.rs
@@ -30,7 +30,8 @@ impl Trait for Foo {}
 
 pub fn main() {
     {
-        let _x: &Trait = &*(box Foo as Box<Trait>);
+        let b: Box<_> = box Foo;
+        let _x: &Trait = &*(b as Box<Trait>);
     }
     unsafe {
         assert!(DROP_RAN);

--- a/src/test/run-pass/alignment-gep-tup-like-1.rs
+++ b/src/test/run-pass/alignment-gep-tup-like-1.rs
@@ -31,10 +31,11 @@ impl<A:Clone> Invokable<A> for Invoker<A> {
 }
 
 fn f<A:Clone + 'static>(a: A, b: u16) -> Box<Invokable<A>+'static> {
-    box Invoker {
+    // FIXME(22450): workaround pretty-printer deficiency via parens.
+    (box Invoker {
         a: a,
         b: b,
-    } as (Box<Invokable<A>+'static>)
+    }) as (Box<Invokable<A>+'static>)
 }
 
 pub fn main() {

--- a/src/test/run-pass/alignment-gep-tup-like-1.rs
+++ b/src/test/run-pass/alignment-gep-tup-like-1.rs
@@ -31,11 +31,9 @@ impl<A:Clone> Invokable<A> for Invoker<A> {
 }
 
 fn f<A:Clone + 'static>(a: A, b: u16) -> Box<Invokable<A>+'static> {
+    let b: Box<_> = box Invoker { a: a, b: b, };
     // FIXME(22450): workaround pretty-printer deficiency via parens.
-    (box Invoker {
-        a: a,
-        b: b,
-    }) as (Box<Invokable<A>+'static>)
+    b as (Box<Invokable<A>+'static>)
 }
 
 pub fn main() {

--- a/src/test/run-pass/autoderef-method-on-trait.rs
+++ b/src/test/run-pass/autoderef-method-on-trait.rs
@@ -21,6 +21,7 @@ impl double for usize {
 }
 
 pub fn main() {
-    let x: Box<_> = box() (box 3usize as Box<double>);
+    let b: Box<usize> = box 3usize;
+    let x: Box<_> = box() (b as Box<double>);
     assert_eq!(x.double(), 6);
 }

--- a/src/test/run-pass/bitv-perf-test.rs
+++ b/src/test/run-pass/bitv-perf-test.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![feature(bitvec)]
 

--- a/src/test/run-pass/borrowck-field-sensitivity.rs
+++ b/src/test/run-pass/borrowck-field-sensitivity.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/borrowck-use-mut-borrow.rs
+++ b/src/test/run-pass/borrowck-use-mut-borrow.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/cancel-clean-via-immediate-rvalue-ref.rs
+++ b/src/test/run-pass/cancel-clean-via-immediate-rvalue-ref.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/class-cast-to-trait-cross-crate-2.rs
+++ b/src/test/run-pass/class-cast-to-trait-cross-crate-2.rs
@@ -25,6 +25,7 @@ fn print_out(thing: Box<ToString>, expected: String) {
 }
 
 pub fn main() {
-  let nyan: Box<ToString> = box cat(0, 2, "nyan".to_string()) as Box<ToString>;
+  let b: Box<cat> = box cat(0, 2, "nyan".to_string());
+  let nyan: Box<ToString> = b as Box<ToString>;
   print_out(nyan, "nyan".to_string());
 }

--- a/src/test/run-pass/class-separate-impl.rs
+++ b/src/test/run-pass/class-separate-impl.rs
@@ -67,6 +67,7 @@ fn print_out(thing: Box<ToString>, expected: String) {
 }
 
 pub fn main() {
-  let nyan: Box<ToString> = box cat(0, 2, "nyan".to_string()) as Box<ToString>;
+  let b: Box<cat> = box cat(0, 2, "nyan".to_string());
+  let nyan: Box<ToString> = b as Box<ToString>;
   print_out(nyan, "nyan".to_string());
 }

--- a/src/test/run-pass/cleanup-arm-conditional.rs
+++ b/src/test/run-pass/cleanup-arm-conditional.rs
@@ -21,7 +21,7 @@
 // Test that cleanup scope for temporaries created in a match
 // arm is confined to the match arm itself.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax, os)]

--- a/src/test/run-pass/close-over-big-then-small-data.rs
+++ b/src/test/run-pass/close-over-big-then-small-data.rs
@@ -35,10 +35,11 @@ impl<A:Clone> Invokable<A> for Invoker<A> {
 }
 
 fn f<A:Clone + 'static>(a: A, b: u16) -> Box<Invokable<A>+'static> {
-    box Invoker {
+    // FIXME(22450): workaround pretty-printer deficiency via parens.
+    (box Invoker {
         a: a,
         b: b,
-    } as (Box<Invokable<A>+'static>)
+    }) as (Box<Invokable<A>+'static>)
 }
 
 pub fn main() {

--- a/src/test/run-pass/close-over-big-then-small-data.rs
+++ b/src/test/run-pass/close-over-big-then-small-data.rs
@@ -35,11 +35,9 @@ impl<A:Clone> Invokable<A> for Invoker<A> {
 }
 
 fn f<A:Clone + 'static>(a: A, b: u16) -> Box<Invokable<A>+'static> {
+    let b: Box<_> = box Invoker { a: a, b: b, };
     // FIXME(22450): workaround pretty-printer deficiency via parens.
-    (box Invoker {
-        a: a,
-        b: b,
-    }) as (Box<Invokable<A>+'static>)
+    b as (Box<Invokable<A>+'static>)
 }
 
 pub fn main() {

--- a/src/test/run-pass/coerce-match.rs
+++ b/src/test/run-pass/coerce-match.rs
@@ -10,7 +10,7 @@
 
 // Check that coercions are propagated through match and if expressions.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/crate-method-reexport-grrrrrrr.rs
+++ b/src/test/run-pass/crate-method-reexport-grrrrrrr.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/deref.rs
+++ b/src/test/run-pass/deref.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/drop-on-empty-block-exit.rs
+++ b/src/test/run-pass/drop-on-empty-block-exit.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/drop-struct-as-object.rs
+++ b/src/test/run-pass/drop-struct-as-object.rs
@@ -43,7 +43,7 @@ impl Drop for Cat {
 
 pub fn main() {
     {
-        let x = box Cat {name: 22};
+        let x: Box<Cat> = box Cat {name: 22};
         let nyan: Box<Dummy> = x as Box<Dummy>;
     }
     unsafe {

--- a/src/test/run-pass/drop-struct-as-object.rs
+++ b/src/test/run-pass/drop-struct-as-object.rs
@@ -15,7 +15,13 @@
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 
-static mut value: usize = 0;
+mod s {
+    // FIXME(22181,22462) workaround hygiene issues between box
+    // desugaring, macro-hygiene (or lack thereof) and static bindings
+    // by forcing the static binding `value` into its own module.
+
+    pub static mut value: usize = 0;
+}
 
 struct Cat {
     name : usize,
@@ -31,7 +37,7 @@ impl Dummy for Cat {
 
 impl Drop for Cat {
     fn drop(&mut self) {
-        unsafe { value = self.name; }
+        unsafe { s::value = self.name; }
     }
 }
 
@@ -41,6 +47,6 @@ pub fn main() {
         let nyan: Box<Dummy> = x as Box<Dummy>;
     }
     unsafe {
-        assert_eq!(value, 22);
+        assert_eq!(s::value, 22);
     }
 }

--- a/src/test/run-pass/explicit-self-objects-uniq.rs
+++ b/src/test/run-pass/explicit-self-objects-uniq.rs
@@ -27,7 +27,7 @@ impl Foo for S {
 }
 
 pub fn main() {
-    let x = box S { x: 3 };
+    let x: Box<S> = box S { x: 3 };
     let y = x as Box<Foo>;
     y.f();
 }

--- a/src/test/run-pass/generic-object.rs
+++ b/src/test/run-pass/generic-object.rs
@@ -27,7 +27,7 @@ impl Foo<isize> for S {
 }
 
 pub fn main() {
-    let x = box S { x: 1 };
+    let x: Box<S> = box S { x: 1 };
     let y = x as Box<Foo<isize>>;
     assert_eq!(y.get(), 1);
 }

--- a/src/test/run-pass/generic-tag.rs
+++ b/src/test/run-pass/generic-tag.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(dead_assignment)]
 #![allow(unused_variable)]

--- a/src/test/run-pass/intrinsic-move-val.rs
+++ b/src/test/run-pass/intrinsic-move-val.rs
@@ -20,7 +20,7 @@ use std::mem::{self, transmute};
 mod rusti {
     extern "rust-intrinsic" {
         pub fn init<T>() -> T;
-        pub fn move_val_init<T>(dst: &mut T, src: T);
+        pub fn move_val_init<T>(dst: *mut T, src: T);
     }
 }
 

--- a/src/test/run-pass/issue-10682.rs
+++ b/src/test/run-pass/issue-10682.rs
@@ -11,7 +11,7 @@
 // Regression test for issue #10682
 // Nested `proc` usage can't use outer owned data
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/issue-10767.rs
+++ b/src/test/run-pass/issue-10767.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/issue-10802.rs
+++ b/src/test/run-pass/issue-10802.rs
@@ -44,13 +44,15 @@ impl  Whatever {
 fn main() {
     {
         let f: Box<_> = box DroppableStruct;
-        let _a = Whatever::new(box f as Box<MyTrait>);
+        let b: Box<_> = box f;
+        let _a = Whatever::new(b as Box<MyTrait>);
     }
     assert!(unsafe { DROPPED });
     unsafe { DROPPED = false; }
     {
         let f: Box<_> = box DroppableEnum::DroppableVariant1;
-        let _a = Whatever::new(box f as Box<MyTrait>);
+        let b: Box<_> = box f;
+        let _a = Whatever::new(b as Box<MyTrait>);
     }
     assert!(unsafe { DROPPED });
 }

--- a/src/test/run-pass/issue-14399.rs
+++ b/src/test/run-pass/issue-14399.rs
@@ -13,7 +13,7 @@
 // value was coerced to a trait object. (v.clone() returns Box<B1>
 // which is coerced to Box<A>).
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/issue-15763.rs
+++ b/src/test/run-pass/issue-15763.rs
@@ -87,12 +87,16 @@ fn main() {
     assert_eq!(cc().unwrap(), 3);
     assert_eq!(dd().unwrap(), 3);
 
-    let i = box 32isize as Box<A>;
+    let b: Box<isize> = box 32isize;
+    let i = b as Box<A>;
     assert_eq!(i.aaa(), 3);
-    let i = box 32isize as Box<A>;
+    let b: Box<isize> = box 32isize;
+    let i = b as Box<A>;
     assert_eq!(i.bbb(), 3);
-    let i = box 32isize as Box<A>;
+    let b: Box<isize> = box 32isize;
+    let i = b as Box<A>;
     assert_eq!(i.ccc().unwrap(), 3);
-    let i = box 32isize as Box<A>;
+    let b: Box<isize> = box 32isize;
+    let i = b as Box<A>;
     assert_eq!(i.ddd().unwrap(), 3);
 }

--- a/src/test/run-pass/issue-16739.rs
+++ b/src/test/run-pass/issue-16739.rs
@@ -50,12 +50,15 @@ impl FnOnce<(u32,u32)> for Foo {
 }
 
 fn main() {
-    let mut f = box Foo { foo: 42 } as Box<FnMut() -> u32>;
+    let b: Box<Foo> = box Foo { foo: 42 };
+    let mut f = b as Box<FnMut() -> u32>;
     assert_eq!(f.call_mut(()), 42);
 
-    let mut f = box Foo { foo: 40 } as Box<FnMut(u32) -> u32>;
+    let b: Box<Foo> = box Foo { foo: 40 };
+    let mut f = b as Box<FnMut(u32) -> u32>;
     assert_eq!(f.call_mut((2,)), 42);
 
-    let mut f = box Foo { foo: 40 } as Box<FnMut(u32, u32) -> u32>;
+    let b: Box<Foo> = box Foo { foo: 40 };
+    let mut f = b as Box<FnMut(u32, u32) -> u32>;
     assert_eq!(f.call_mut((1, 1)), 42);
 }

--- a/src/test/run-pass/issue-17322.rs
+++ b/src/test/run-pass/issue-17322.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax, io)]

--- a/src/test/run-pass/issue-17322.rs
+++ b/src/test/run-pass/issue-17322.rs
@@ -20,6 +20,7 @@ fn f(wr: &mut Write) {
 }
 
 fn main() {
-    let mut wr = box io::stdout() as Box<Write>;
+    let b: Box<_> = box io::stdout();
+    let mut wr = b as Box<Write>;
     f(&mut wr);
 }

--- a/src/test/run-pass/issue-21033.rs
+++ b/src/test/run-pass/issue-21033.rs
@@ -7,7 +7,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-// pretty-expanded FIXME #23616
+
+// no-pretty-expanded FIXME #26067
 
 #![feature(box_patterns)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/issue-2288.rs
+++ b/src/test/run-pass/issue-2288.rs
@@ -40,6 +40,7 @@ fn f<A>(x: Box<clam<A>>, a: A) {
 pub fn main() {
 
   let c = foo(42);
-  let d: Box<clam<isize>> = box c as Box<clam<isize>>;
+  let b: Box<_> = box c;
+  let d: Box<clam<isize>> = b as Box<clam<isize>>;
   f(d, c.x);
 }

--- a/src/test/run-pass/issue-2288.rs
+++ b/src/test/run-pass/issue-2288.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/issue-2633-2.rs
+++ b/src/test/run-pass/issue-2633-2.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/issue-2708.rs
+++ b/src/test/run-pass/issue-2708.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/issue-2734.rs
+++ b/src/test/run-pass/issue-2734.rs
@@ -19,7 +19,8 @@ trait hax {
 impl<A> hax for A { }
 
 fn perform_hax<T: 'static>(x: Box<T>) -> Box<hax+'static> {
-    box x as Box<hax+'static>
+    // FIXME(22450): workaround pretty-printer deficiency via parens.
+    (box x) as Box<hax+'static>
 }
 
 fn deadcode() {

--- a/src/test/run-pass/issue-2734.rs
+++ b/src/test/run-pass/issue-2734.rs
@@ -19,8 +19,8 @@ trait hax {
 impl<A> hax for A { }
 
 fn perform_hax<T: 'static>(x: Box<T>) -> Box<hax+'static> {
-    // FIXME(22450): workaround pretty-printer deficiency via parens.
-    (box x) as Box<hax+'static>
+    let b: Box<_> = box x;
+    b as Box<hax+'static>
 }
 
 fn deadcode() {

--- a/src/test/run-pass/issue-2734.rs
+++ b/src/test/run-pass/issue-2734.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/issue-2735.rs
+++ b/src/test/run-pass/issue-2735.rs
@@ -19,7 +19,8 @@ trait hax {
 impl<A> hax for A { }
 
 fn perform_hax<T: 'static>(x: Box<T>) -> Box<hax+'static> {
-    box x as Box<hax+'static>
+    // FIXME(22450): workaround pretty-printer deficiency via parens.
+    (box x) as Box<hax+'static>
 }
 
 fn deadcode() {

--- a/src/test/run-pass/issue-2735.rs
+++ b/src/test/run-pass/issue-2735.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/issue-2735.rs
+++ b/src/test/run-pass/issue-2735.rs
@@ -19,8 +19,9 @@ trait hax {
 impl<A> hax for A { }
 
 fn perform_hax<T: 'static>(x: Box<T>) -> Box<hax+'static> {
+    let b: Box<_> = box x;
     // FIXME(22450): workaround pretty-printer deficiency via parens.
-    (box x) as Box<hax+'static>
+    b as Box<hax+'static>
 }
 
 fn deadcode() {

--- a/src/test/run-pass/issue-2935.rs
+++ b/src/test/run-pass/issue-2935.rs
@@ -28,7 +28,8 @@ pub fn main() {
   //   let y = box ({a: 4});
   //    let z = box ({a: 4} as it);
   //    let z = box ({a: true} as it);
-    let z: Box<_> = box () (box true as Box<it>);
+    let b: Box<_> = box true;
+    let z: Box<_> = box () (b as Box<it>);
     //  x.f();
     // y.f();
     // (*z).f();

--- a/src/test/run-pass/issue-3012-2.rs
+++ b/src/test/run-pass/issue-3012-2.rs
@@ -10,7 +10,7 @@
 
 // aux-build:issue-3012-1.rs
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax, libc)]

--- a/src/test/run-pass/issue-3026.rs
+++ b/src/test/run-pass/issue-3026.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax, collections)]

--- a/src/test/run-pass/issue-3121.rs
+++ b/src/test/run-pass/issue-3121.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/issue-3878.rs
+++ b/src/test/run-pass/issue-3878.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(path_statement)]
 #![allow(unknown_features)]

--- a/src/test/run-pass/issue-4735.rs
+++ b/src/test/run-pass/issue-4735.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax, libc)]

--- a/src/test/run-pass/issue-4759.rs
+++ b/src/test/run-pass/issue-4759.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/issue-5192.rs
+++ b/src/test/run-pass/issue-5192.rs
@@ -46,5 +46,6 @@ impl Scheduler {
 }
 
 pub fn main() {
-    let _sched = Scheduler::new(box UvEventLoop::new() as Box<EventLoop>);
+    let b: Box<_> = box UvEventLoop::new();
+    let _sched = Scheduler::new(b as Box<EventLoop>);
 }

--- a/src/test/run-pass/issue-5192.rs
+++ b/src/test/run-pass/issue-5192.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/issue-5666.rs
+++ b/src/test/run-pass/issue-5666.rs
@@ -27,8 +27,8 @@ impl Barks for Dog {
 
 
 pub fn main() {
-    let snoopy = box Dog{name: "snoopy".to_string()};
-    let bubbles = box Dog{name: "bubbles".to_string()};
+    let snoopy: Box<_> = box Dog{name: "snoopy".to_string()};
+    let bubbles: Box<_> = box Dog{name: "bubbles".to_string()};
     let barker = [snoopy as Box<Barks>, bubbles as Box<Barks>];
 
     for pup in &barker {

--- a/src/test/run-pass/issue-5718.rs
+++ b/src/test/run-pass/issue-5718.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/issue-5884.rs
+++ b/src/test/run-pass/issue-5884.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/issue-6318.rs
+++ b/src/test/run-pass/issue-6318.rs
@@ -26,7 +26,8 @@ pub struct Struct;
 impl Foo for Struct {}
 
 pub fn main() {
-    match Thing::A(box Struct as Box<Foo+'static>) {
+    let b: Box<_> = box Struct;
+    match Thing::A(b as Box<Foo+'static>) {
         Thing::A(_a) => 0,
     };
 }

--- a/src/test/run-pass/issue-6318.rs
+++ b/src/test/run-pass/issue-6318.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/issue-7673-cast-generically-implemented-trait.rs
+++ b/src/test/run-pass/issue-7673-cast-generically-implemented-trait.rs
@@ -28,4 +28,5 @@ trait A {
 impl<T: 'static> A for T {}
 
 fn owned2<T: 'static>(a: Box<T>) { a as Box<A>; }
-fn owned3<T: 'static>(a: Box<T>) { box a as Box<A>; }
+// FIXME(22450): workaround pretty-printer deficiency via parens.
+fn owned3<T: 'static>(a: Box<T>) { (box a) as Box<A>; }

--- a/src/test/run-pass/issue-7673-cast-generically-implemented-trait.rs
+++ b/src/test/run-pass/issue-7673-cast-generically-implemented-trait.rs
@@ -28,5 +28,4 @@ trait A {
 impl<T: 'static> A for T {}
 
 fn owned2<T: 'static>(a: Box<T>) { a as Box<A>; }
-// FIXME(22450): workaround pretty-printer deficiency via parens.
-fn owned3<T: 'static>(a: Box<T>) { (box a) as Box<A>; }
+fn owned3<T: 'static>(a: Box<T>) { let b: Box<_> = box a; b as Box<A>; }

--- a/src/test/run-pass/issue-7673-cast-generically-implemented-trait.rs
+++ b/src/test/run-pass/issue-7673-cast-generically-implemented-trait.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 /*
 

--- a/src/test/run-pass/issue-9129.rs
+++ b/src/test/run-pass/issue-9129.rs
@@ -37,6 +37,7 @@ pub fn light_fuse(fld: Box<bomb>) {
 }
 
 pub fn main() {
-    let b = box S as Box<bomb>;
+    let b: Box<_> = box S;
+    let b = b as Box<bomb>;
     light_fuse(b);
 }

--- a/src/test/run-pass/issue-9382.rs
+++ b/src/test/run-pass/issue-9382.rs
@@ -1,5 +1,3 @@
-// pretty-expanded FIXME #23616
-
  // Copyright 2013 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
@@ -9,6 +7,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+// no-pretty-expanded FIXME #26067
 
 #![allow(unnecessary_allocation)]
 #![allow(unknown_features)]

--- a/src/test/run-pass/kindck-owned-trait-contains-1.rs
+++ b/src/test/run-pass/kindck-owned-trait-contains-1.rs
@@ -21,8 +21,8 @@ impl<A:Clone + 'static> repeat<A> for Box<A> {
 }
 
 fn repeater<A:Clone + 'static>(v: Box<A>) -> Box<repeat<A>+'static> {
-    // FIXME(22450): workaround pretty-printer deficiency via parens.
-    (box v) as Box<repeat<A>+'static> // No
+    let b: Box<_> = box v;
+    b as Box<repeat<A>+'static> // No
 }
 
 pub fn main() {

--- a/src/test/run-pass/kindck-owned-trait-contains-1.rs
+++ b/src/test/run-pass/kindck-owned-trait-contains-1.rs
@@ -21,7 +21,8 @@ impl<A:Clone + 'static> repeat<A> for Box<A> {
 }
 
 fn repeater<A:Clone + 'static>(v: Box<A>) -> Box<repeat<A>+'static> {
-    box v as Box<repeat<A>+'static> // No
+    // FIXME(22450): workaround pretty-printer deficiency via parens.
+    (box v) as Box<repeat<A>+'static> // No
 }
 
 pub fn main() {

--- a/src/test/run-pass/leak-unique-as-tydesc.rs
+++ b/src/test/run-pass/leak-unique-as-tydesc.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/list.rs
+++ b/src/test/run-pass/list.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/match-value-binding-in-guard-3291.rs
+++ b/src/test/run-pass/match-value-binding-in-guard-3291.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/move-guard-const.rs
+++ b/src/test/run-pass/move-guard-const.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![feature(box_syntax)]
 

--- a/src/test/run-pass/new-box-syntax.rs
+++ b/src/test/run-pass/new-box-syntax.rs
@@ -15,6 +15,7 @@
 
 #![allow(warnings)]
 #![feature(box_syntax, box_heap)]
+#![feature(placement_in_syntax)]
 
 // Tests that the new `box` syntax works with unique pointers.
 
@@ -26,8 +27,8 @@ struct Structure {
 }
 
 pub fn main() {
-    let x: Box<isize> = box(HEAP) 2;
+    let x: Box<isize> = in HEAP { 2 };
     let y: Box<isize> = box 2;
-    let b: Box<isize> = box()(1 + 2);
-    let c = box()(3 + 4);
+    let b: Box<isize> = box () (1 + 2);
+    let c: Box<_> = box () (3 + 4);
 }

--- a/src/test/run-pass/new-box-syntax.rs
+++ b/src/test/run-pass/new-box-syntax.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */

--- a/src/test/run-pass/new-box-syntax.rs
+++ b/src/test/run-pass/new-box-syntax.rs
@@ -27,7 +27,7 @@ struct Structure {
 }
 
 pub fn main() {
-    // XXX
+    // FIXME (#22181) put back when new placement-in syntax is supported
     // let x: Box<isize> = in HEAP { 2 };
     let y: Box<isize> = box 2;
     let b: Box<isize> = box () (1 + 2);

--- a/src/test/run-pass/new-box-syntax.rs
+++ b/src/test/run-pass/new-box-syntax.rs
@@ -27,7 +27,8 @@ struct Structure {
 }
 
 pub fn main() {
-    let x: Box<isize> = in HEAP { 2 };
+    // XXX
+    // let x: Box<isize> = in HEAP { 2 };
     let y: Box<isize> = box 2;
     let b: Box<isize> = box () (1 + 2);
     let c: Box<_> = box () (3 + 4);

--- a/src/test/run-pass/new-box.rs
+++ b/src/test/run-pass/new-box.rs
@@ -37,5 +37,6 @@ fn g(x: Box<Trait>) {
 
 fn main() {
     f(box 1234);
-    g(box Struct as Box<Trait>);
+    let b: Box<_> = box Struct;
+    g(b as Box<Trait>);
 }

--- a/src/test/run-pass/object-one-type-two-traits.rs
+++ b/src/test/run-pass/object-one-type-two-traits.rs
@@ -35,7 +35,8 @@ fn is<T:Any>(x: &Any) -> bool {
 }
 
 fn main() {
-    let x = box 22isize as Box<Wrap>;
+    let b: Box<_> = box 22isize;
+    let x = b as Box<Wrap>;
     println!("x={}", x.get());
     let y = x.wrap();
 }

--- a/src/test/run-pass/objects-owned-object-borrowed-method-headerless.rs
+++ b/src/test/run-pass/objects-owned-object-borrowed-method-headerless.rs
@@ -33,9 +33,12 @@ impl FooTrait for BarStruct {
 
 pub fn main() {
     let foos: Vec<Box<FooTrait>> = vec!(
-        box BarStruct{ x: 0 } as Box<FooTrait>,
-        box BarStruct{ x: 1 } as Box<FooTrait>,
-        box BarStruct{ x: 2 } as Box<FooTrait>
+        { let b: Box<_> = box BarStruct{ x: 0 };
+          b as Box<FooTrait> },
+        { let b: Box<_> = box BarStruct{ x: 1 };
+          b as Box<FooTrait> },
+        { let b: Box<_> = box BarStruct{ x: 2 };
+          b as Box<FooTrait> }
     );
 
     for i in 0..foos.len() {

--- a/src/test/run-pass/objects-owned-object-owned-method.rs
+++ b/src/test/run-pass/objects-owned-object-owned-method.rs
@@ -31,6 +31,7 @@ impl FooTrait for BarStruct {
 }
 
 pub fn main() {
-    let foo = box BarStruct{ x: 22 } as Box<FooTrait>;
+    let b: Box<_> = box BarStruct{ x: 22 };
+    let foo = b as Box<FooTrait>;
     assert_eq!(22, foo.foo());
 }

--- a/src/test/run-pass/output-slot-variants.rs
+++ b/src/test/run-pass/output-slot-variants.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(dead_assignment)]
 #![allow(unused_variable)]

--- a/src/test/run-pass/pure-sum.rs
+++ b/src/test/run-pass/pure-sum.rs
@@ -10,7 +10,7 @@
 
 // Check that functions can modify local state.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/pushpop-unsafe-okay.rs
+++ b/src/test/run-pass/pushpop-unsafe-okay.rs
@@ -1,0 +1,56 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Basic sanity check for `push_unsafe!(EXPR)` and
+// `pop_unsafe!(EXPR)`: we can call unsafe code when there are a
+// positive number of pushes in the stack, or if we are within a
+// normal `unsafe` block, but otherwise cannot.
+
+// ignore-pretty because the `push_unsafe!` and `pop_unsafe!` macros
+// are not integrated with the pretty-printer.
+
+#![feature(pushpop_unsafe)]
+
+static mut X: i32 = 0;
+
+unsafe fn f() { X += 1; return; }
+fn g() { unsafe { X += 1_000; } return; }
+
+fn check_reset_x(x: i32) -> bool {
+    #![allow(unused_parens)] // dont you judge my style choices!
+    unsafe {
+        let ret = (x == X);
+        X = 0;
+        ret
+    }
+}
+
+fn main() {
+    // double-check test infrastructure
+    assert!(check_reset_x(0));
+    unsafe { f(); }
+    assert!(check_reset_x(1));
+    assert!(check_reset_x(0));
+    { g(); }
+    assert!(check_reset_x(1000));
+    assert!(check_reset_x(0));
+    unsafe { f(); g(); g(); }
+    assert!(check_reset_x(2001));
+
+    push_unsafe!( { f(); pop_unsafe!( g() ) } );
+    assert!(check_reset_x(1_001));
+    push_unsafe!( { g(); pop_unsafe!( unsafe { f(); f(); } ) } );
+    assert!(check_reset_x(1_002));
+
+    unsafe { push_unsafe!( { f(); pop_unsafe!( { f(); f(); } ) } ); }
+    assert!(check_reset_x(3));
+    push_unsafe!( { f(); push_unsafe!( { pop_unsafe!( { f(); f(); f(); } ) } ); } );
+    assert!(check_reset_x(4));
+}

--- a/src/test/run-pass/regions-close-over-type-parameter-successfully.rs
+++ b/src/test/run-pass/regions-close-over-type-parameter-successfully.rs
@@ -24,7 +24,8 @@ impl<'a> SomeTrait for &'a isize {
 }
 
 fn make_object<'a,A:SomeTrait+'a>(v: A) -> Box<SomeTrait+'a> {
-    box v as Box<SomeTrait+'a>
+    // FIXME(22450): workaround pretty-printer deficiency via parens.
+    (box v) as Box<SomeTrait+'a>
 }
 
 fn main() {

--- a/src/test/run-pass/regions-close-over-type-parameter-successfully.rs
+++ b/src/test/run-pass/regions-close-over-type-parameter-successfully.rs
@@ -24,8 +24,8 @@ impl<'a> SomeTrait for &'a isize {
 }
 
 fn make_object<'a,A:SomeTrait+'a>(v: A) -> Box<SomeTrait+'a> {
-    // FIXME(22450): workaround pretty-printer deficiency via parens.
-    (box v) as Box<SomeTrait+'a>
+    let b: Box<_> = box v;
+    b as Box<SomeTrait+'a>
 }
 
 fn main() {

--- a/src/test/run-pass/regions-lifetime-nonfree-late-bound.rs
+++ b/src/test/run-pass/regions-lifetime-nonfree-late-bound.rs
@@ -22,7 +22,7 @@
 // doing region-folding, when really all clients of the region-folding
 // case only want to see FREE lifetime variables, not bound ones.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/self-impl.rs
+++ b/src/test/run-pass/self-impl.rs
@@ -10,7 +10,7 @@
 
 // Test that we can use `Self` types in impls in the expected way.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/trait-bounds-in-arc.rs
+++ b/src/test/run-pass/trait-bounds-in-arc.rs
@@ -77,10 +77,10 @@ pub fn main() {
         swim_speed: 998,
         name: "alec_guinness".to_string(),
     };
-    let arc = Arc::new(vec!(box catte  as Box<Pet+Sync+Send>,
-                            box dogge1 as Box<Pet+Sync+Send>,
-                            box fishe  as Box<Pet+Sync+Send>,
-                            box dogge2 as Box<Pet+Sync+Send>));
+    let arc = Arc::new(vec!(Box::new(catte)  as Box<Pet+Sync+Send>,
+                            Box::new(dogge1) as Box<Pet+Sync+Send>,
+                            Box::new(fishe)  as Box<Pet+Sync+Send>,
+                            Box::new(dogge2) as Box<Pet+Sync+Send>));
     let (tx1, rx1) = channel();
     let arc1 = arc.clone();
     let t1 = thread::spawn(move|| { check_legs(arc1); tx1.send(()); });

--- a/src/test/run-pass/trait-object-generics.rs
+++ b/src/test/run-pass/trait-object-generics.rs
@@ -49,6 +49,7 @@ impl<V> Trait<u8,V> for () {
 }
 
 pub fn main() {
-    let a = box() () as Box<Trait<u8, u8>>;
+    let b: Box<_> = box() ();
+    let a = b as Box<Trait<u8, u8>>;
     assert_eq!(a.method(Type::Constant((1, 2))), 0);
 }

--- a/src/test/run-pass/type-param-constraints.rs
+++ b/src/test/run-pass/type-param-constraints.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/unboxed-closures-boxed.rs
+++ b/src/test/run-pass/unboxed-closures-boxed.rs
@@ -15,8 +15,8 @@
 use std::ops::FnMut;
 
  fn make_adder(x: i32) -> Box<FnMut(i32)->i32+'static> {
-    (box move |y: i32| -> i32 { x + y }) as
-        Box<FnMut(i32)->i32+'static>
+    let b: Box<_> = box move |y: i32| -> i32 { x + y };
+    b as Box<FnMut(i32)->i32+'static>
 }
 
 pub fn main() {

--- a/src/test/run-pass/unique-containing-tag.rs
+++ b/src/test/run-pass/unique-containing-tag.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/unique-create.rs
+++ b/src/test/run-pass/unique-create.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/unique-drop-complex.rs
+++ b/src/test/run-pass/unique-drop-complex.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/unique-init.rs
+++ b/src/test/run-pass/unique-init.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/unique-object-move.rs
+++ b/src/test/run-pass/unique-object-move.rs
@@ -24,6 +24,7 @@ pub struct UvEventLoop {
 impl EventLoop for UvEventLoop { }
 
 pub fn main() {
-    let loop_: Box<EventLoop> = box UvEventLoop { uvio: 0 } as Box<EventLoop>;
+    let b: Box<_> = box UvEventLoop { uvio: 0 };
+    let loop_: Box<EventLoop> = b as Box<EventLoop>;
     let _loop2_ = loop_;
 }

--- a/src/test/run-pass/unique-object-move.rs
+++ b/src/test/run-pass/unique-object-move.rs
@@ -10,7 +10,7 @@
 
 // Issue #5192
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/unused-move-capture.rs
+++ b/src/test/run-pass/unused-move-capture.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]

--- a/src/test/run-pass/unused-move.rs
+++ b/src/test/run-pass/unused-move.rs
@@ -12,7 +12,7 @@
 // Issue Name: Unused move causes a crash
 // Abstract: zero-fill to block after drop
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(path_statement)]
 #![allow(unknown_features)]

--- a/src/test/run-pass/vector-no-ann-2.rs
+++ b/src/test/run-pass/vector-no-ann-2.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// no-pretty-expanded FIXME #26067
 
 #![allow(unknown_features)]
 #![feature(box_syntax)]


### PR DESCRIPTION
Macro-desugaring of `box` and placement-`box` into "simpler" expressions.

Includes `Placer` API that one can override to integrate support for `box` into one's own type.

Part of #22181

Does not turn on the `in <place-expr> { <block> ... }` syntax proposed in https://github.com/rust-lang/rfcs/pull/809 , so there is still more to be done in that area.  But I wanted to get this into the review pipeline now, since it is more invasive than we originally anticipated it being.
