### PR TITLE
allowing fallback to clang on freebsd when needed

### DIFF
--- a/configure
+++ b/configure
@@ -861,16 +861,6 @@ then
     CFG_DISABLE_JEMALLOC=1
 fi
 
-if [ $CFG_OSTYPE = unknown-freebsd ]
-then
-  CFG_FREEBSD_GCC_VERSION=$("CFG_GCC" --version 2>&1)
-  if [ $? -ne 0 ]
-  then
-    step_msg "GCC not installed on FreeBSD, forcing clang"
-    CFG_ENABLE_CLANG=1
-  fi
-fi
-
 # OS X 10.9, gcc is actually clang. This can cause some confusion in the build
 # system, so if we find that gcc is clang, we should just use clang directly.
 if [ $CFG_OSTYPE = apple-darwin -a -z "$CFG_ENABLE_CLANG" ]
@@ -907,6 +897,18 @@ then
 
         fi
     fi
+fi
+
+# If the clang isn't already enabled, check for GCC, and if it is missing, turn
+# on clang as a backup.
+if [ -z "$CFG_ENABLE_CLANG" ]
+then
+  CFG_GCC_VERSION=$("CFG_GCC" --version 2>&1)
+  if [ $? -ne 0 ]
+  then
+    step_msg "GCC not installed, will try using Clang"
+    CFG_ENABLE_CLANG=1
+  fi
 fi
 
 # Okay, at this point, we have made up our minds about whether we are

--- a/configure
+++ b/configure
@@ -903,7 +903,7 @@ fi
 # on clang as a backup.
 if [ -z "$CFG_ENABLE_CLANG" ]
 then
-  CFG_GCC_VERSION=$("CFG_GCC" --version 2>&1)
+  CFG_GCC_VERSION=$("$CFG_GCC" --version 2>&1)
   if [ $? -ne 0 ]
   then
     step_msg "GCC not installed, will try using Clang"

--- a/configure
+++ b/configure
@@ -861,6 +861,16 @@ then
     CFG_DISABLE_JEMALLOC=1
 fi
 
+if [ $CFG_OSTYPE = unknown-freebsd ]
+then
+  CFG_FREEBSD_GCC_VERSION=$("CFG_GCC" --version 2>&1)
+  if [ $? -ne 0 ]
+  then
+    step_msg "GCC not installed on FreeBSD, forcing clang"
+    CFG_ENABLE_CLANG=1
+  fi
+fi
+
 # OS X 10.9, gcc is actually clang. This can cause some confusion in the build
 # system, so if we find that gcc is clang, we should just use clang directly.
 if [ $CFG_OSTYPE = apple-darwin -a -z "$CFG_ENABLE_CLANG" ]


### PR DESCRIPTION
On FreeBSD machines without GCC installed, the configure script will now fall back to using clang.
