### PR TITLE
core: impl Clone for option::IntoIter and iter::Once

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -3077,6 +3077,7 @@ pub fn empty<T>() -> Empty<T> {
 }
 
 /// An iterator that yields an element exactly once.
+#[derive(Clone)]
 #[unstable(feature="iter_once", reason = "new addition")]
 pub struct Once<T> {
     inner: ::option::IntoIter<T>

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -865,6 +865,7 @@ impl<'a, A> DoubleEndedIterator for IterMut<'a, A> {
 impl<'a, A> ExactSizeIterator for IterMut<'a, A> {}
 
 /// An iterator over the item contained inside an Option.
+#[derive(Clone)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct IntoIter<A> { inner: Item<A> }
 


### PR DESCRIPTION
core: impl Clone for option::IntoIter and iter::Once
