### PR TITLE
Add extra error handling to build_output_filenames to handle the empty string

### DIFF
--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -33,7 +33,7 @@ use super::Compilation;
 use serialize::json;
 
 use std::env;
-use std::ffi::OsString;
+use std::ffi::{OsString, OsStr};
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -966,7 +966,7 @@ pub fn build_output_filenames(input: &Input,
 
             OutputFilenames {
                 out_directory: out_file.parent().unwrap_or(cur_dir).to_path_buf(),
-                out_filestem: out_file.file_stem().unwrap()
+                out_filestem: out_file.file_stem().unwrap_or(OsStr::new(""))
                                       .to_str().unwrap().to_string(),
                 single_output_file: ofile,
                 extra: sess.opts.cg.extra_filename.clone(),

--- a/src/test/run-make/issue-26092/Makefile
+++ b/src/test/run-make/issue-26092/Makefile
@@ -1,0 +1,5 @@
+-include ../tools.mk
+
+all:
+		$(RUSTC) -o "" blank.rs 2>&1 | \
+			grep 'No such file or directory'

--- a/src/test/run-make/issue-26092/blank.rs
+++ b/src/test/run-make/issue-26092/blank.rs
@@ -1,0 +1,11 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {}


### PR DESCRIPTION
`driver::build_output_filenames` calls `file_stem` on a PathBuf obtained from the output file compiler flag. It's possible to pass the empty string to this compiler flag. When file_stem is called on an empty Path, it returns None, which is unwrapped and the compiler panics.

This change modifies the `unwrap` to an `unwrap_or` so that the empty string is passed through the compilation pipeline until it reaches `trans::back::write_output_file`, which will emit an appropriate error.

Instead of panicking, the error that is emitted now is:

```
$ rustc -o "" thing.rs
error: could not write output to : No such file or directory
```

The `:` is a little strange, but it /is/ reporting the filename (the empty string) correctly, I suppose. Both gcc and clang hand the output file to ld, which emits a similar error message when faced with the empty string as an output file:

```
$ clang -o "" thing.c
ld: can't open output file for writing: , errno=2 for architecture x86_64
```

This PR also adds a test for this, in `run-make`. This fixes issue #26092.
