### PR TITLE
OpenBSD don't support morestack

### DIFF
--- a/src/rustllvm/ExecutionEngineWrapper.cpp
+++ b/src/rustllvm/ExecutionEngineWrapper.cpp
@@ -16,8 +16,8 @@ using namespace llvm;
 using namespace llvm::sys;
 using namespace llvm::object;
 
-// libmorestack is not used on Windows
-#if !defined(_WIN32) && !defined(__FreeBSD__) && !defined(__DragonFly__) && !defined(__Bitrig__)
+// libmorestack is not used on other platforms
+#if defined(__linux__) || defined(__APPLE__)
 extern "C" void __morestack(void);
 
 static void* morestack_addr() {
@@ -35,7 +35,7 @@ class RustJITMemoryManager : public SectionMemoryManager
 
     uint64_t getSymbolAddress(const std::string &Name) override
     {
-#if !defined(_WIN32) && !defined(__FreeBSD__) && !defined(__DragonFly__) && !defined(__Bitrig__)
+#if defined(__linux__) || defined(__APPLE__)
         if (Name == "__morestack" || Name == "___morestack")
             return reinterpret_cast<uint64_t>(__morestack);
         if (Name == "__morestack_addr" || Name == "___morestack_addr")


### PR DESCRIPTION
don't try to bind __morestack symbol under OpenBSD as the platform don't
have morestack support.

r? @alexcrichton 

it unbreak build under OpenBSD. Does some others platforms don't have morestack too ? They should be impacted by this problem too.
