### PR TITLE
Use more precise span when checking type definitions

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1626,10 +1626,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let t = ast_ty_to_ty(self, self, ast_t);
 
         let mut bounds_checker = wf::BoundsChecker::new(self,
-                                                        ast_t.span,
                                                         self.body_id,
                                                         None);
-        bounds_checker.check_ty(t);
+        bounds_checker.check_ty(t, ast_t.span);
 
         t
     }

--- a/src/test/compile-fail/trait-bounds-on-structs-and-enums.rs
+++ b/src/test/compile-fail/trait-bounds-on-structs-and-enums.rs
@@ -32,23 +32,19 @@ impl<T> Foo<T> {
 }
 
 struct Baz {
-//~^ ERROR not implemented
-    a: Foo<isize>,
+    a: Foo<isize>, //~ ERROR not implemented
 }
 
 enum Boo {
-//~^ ERROR not implemented
-    Quux(Bar<usize>),
+    Quux(Bar<usize>), //~ ERROR not implemented
 }
 
 struct Badness<U> {
-//~^ ERROR not implemented
-    b: Foo<U>,
+    b: Foo<U>, //~ ERROR not implemented
 }
 
 enum MoreBadness<V> {
-//~^ ERROR not implemented
-    EvenMoreBadness(Bar<V>),
+    EvenMoreBadness(Bar<V>), //~ ERROR not implemented
 }
 
 trait PolyTrait<T>

--- a/src/test/compile-fail/trait-bounds-on-structs-and-enums.rs
+++ b/src/test/compile-fail/trait-bounds-on-structs-and-enums.rs
@@ -47,6 +47,14 @@ enum MoreBadness<V> {
     EvenMoreBadness(Bar<V>), //~ ERROR not implemented
 }
 
+struct TupleLike(
+    Foo<i32>, //~ ERROR not implemented
+);
+
+enum Enum {
+    DictionaryLike { field: Bar<i32> }, //~ ERROR not implemented
+}
+
 trait PolyTrait<T>
 {
     fn whatever(&self, t: T) {}


### PR DESCRIPTION
When checking field types of struct or enum definitions, use spans for field types instead of the entire item.
