### PR TITLE
travis comment: point to buildbot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ before_script:
 script:
   - make tidy
 
+# Real testing happens on http://buildbot.rust-lang.org/
+#
+# See https://github.com/rust-lang/rust-buildbot
+#     CONTRIBUTING.md#pull-requests
+
 notifications:
   email: false
 


### PR DESCRIPTION
Suggesting this because I was confused by what is now visible from the Travis CI / buildbot split.

Found the hint  in bors comments on d911936d
Couldn't find anything on https://internals.rust-lang.org/
