### PR TITLE
Prevent raw pointers from being used as an explicit self

### DIFF
--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2174,7 +2174,7 @@ fn check_method_self_type<'a, 'tcx, RS:RegionScope>(
     if let ast::SelfExplicit(ref ast_type, _) = explicit_self.node {
         let typ = ccx.icx(&method_type.predicates).to_ty(rs, &**ast_type);
         let base_type = match typ.sty {
-            ty::ty_ptr(tm) | ty::ty_rptr(_, tm) => tm.ty,
+            ty::ty_rptr(_, tm) => tm.ty,
             ty::ty_uniq(typ) => typ,
             _ => typ,
         };
@@ -2220,7 +2220,7 @@ fn check_method_self_type<'a, 'tcx, RS:RegionScope>(
                         ppaux::ty_to_string(tcx, required_type))
         }));
 
-        // We could conceviably add more free-reion relations here,
+        // We could conceviably add more free-region relations here,
         // but since this code is just concerned with checking that
         // the `&Self` types etc match up, it's not really necessary.
         // It would just allow people to be more approximate in some

--- a/src/test/compile-fail/issue-26194.rs
+++ b/src/test/compile-fail/issue-26194.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct S(String);
+
+impl S {
+    fn f(self: *mut S) -> String { self.0 }
+    //~^ ERROR mismatched self type
+}
+
+fn main() { S("".to_owned()).f(); }


### PR DESCRIPTION
This can't be made to work with the current setup.

Technically a [breaking-change], but a simple bug fix.

Fixes #26194.
