### PR TITLE
Implement append and split_off for BTreeMap and BTreeSet

### DIFF
--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -453,6 +453,74 @@ impl<T: Ord> BTreeSet<T> {
     pub fn remove<Q: ?Sized>(&mut self, value: &Q) -> bool where T: Borrow<Q>, Q: Ord {
         self.map.remove(value).is_some()
     }
+
+    /// Moves all elements from `other` into `Self`, leaving `other` empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(btree_append_split_off)]
+    /// use std::collections::BTreeMap;
+    ///
+    /// let mut a = BTreeSet::new();
+    /// a.insert(1);
+    /// a.insert(2);
+    /// a.insert(3);
+    ///
+    /// let mut b = BTreeSet::new();
+    /// b.insert(3);
+    /// b.insert(4);
+    /// b.insert(5);
+    ///
+    /// a.append(&mut b);
+    ///
+    /// assert_eq!(a.len(), 5);
+    /// assert_eq!(b.len(), 0);
+    ///
+    /// assert!(a.contains(&1));
+    /// assert!(a.contains(&2));
+    /// assert!(a.contains(&3));
+    /// assert!(a.contains(&4));
+    /// assert!(a.contains(&5));
+    /// ```
+    #[unstable(feature = "btree_append_split_off",
+               reason = "recently added as part of collections reform 2")]
+    pub fn append(&mut self, other: &mut Self) {
+        self.map.append(&mut other.map);
+    }
+
+    /// Splits the set into two at the given key,
+    /// retaining the first half in-place and returning the second one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(btree_append_split_off)]
+    /// use std::collections::BTreeMap;
+    ///
+    /// a.insert(1)
+    /// a.insert(2)
+    /// a.insert(3)
+    /// a.insert(4)
+    /// a.insert(5)
+    ///
+    /// let b = a.split_off(3);
+    ///
+    /// assert_eq!(a.len(), 2);
+    /// assert_eq!(b.len(), 3);
+    ///
+    /// assert!(a.contains(&1));
+    /// assert!(a.contains(&2));
+    /// assert!(b.contains(&3));
+    /// assert!(b.contains(&4));
+    /// assert!(b.contains(&5));
+    /// ```
+    #[unstable(feature = "btree_append_split_off",
+               reason = "recently added as part of collections reform 2")]
+    pub fn split_off<Q: ?Sized>(&mut self, at: &Q) -> Self
+        where T: Borrow<Q>, Q: Ord {
+        BTreeSet { map: self.map.split_off(at) }
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcollectionstest/btree/map.rs
+++ b/src/libcollectionstest/btree/map.rs
@@ -294,6 +294,105 @@ fn test_extend_ref() {
     assert_eq!(a[&3], "three");
 }
 
+#[test]
+fn test_append() {
+    let mut a = BTreeMap::new();
+    a.insert(1, "a");
+    a.insert(2, "b");
+    a.insert(3, "c");
+
+    let mut b = BTreeMap::new();
+    b.insert(3, "d");  // Overwrite element from a
+    b.insert(4, "e");
+    b.insert(5, "f");
+
+    a.append(&mut b);
+
+    assert_eq!(a.len(), 5);
+    assert_eq!(b.len(), 0);
+
+    assert_eq!(a[&1], "a");
+    assert_eq!(a[&2], "b");
+    assert_eq!(a[&3], "d");
+    assert_eq!(a[&4], "e");
+    assert_eq!(a[&5], "f");
+}
+
+#[test]
+fn test_split_off() {
+    // Split empty map
+    let mut a: BTreeMap<usize, usize> = BTreeMap::new();
+
+    let b = a.split_off(&2);
+
+    assert_eq!(a.len(), 0);
+    assert_eq!(b.len(), 0);
+
+    // Split before first element
+    let mut a = BTreeMap::new();
+    a.insert(4, "a");
+    a.insert(5, "b");
+    a.insert(6, "c");
+
+    let b = a.split_off(&2);
+
+    assert_eq!(a.len(), 0);
+    assert_eq!(b.len(), 3);
+
+    assert_eq!(b[&4], "a");
+    assert_eq!(b[&5], "b");
+    assert_eq!(b[&6], "c");
+
+    // Split at first element
+    let mut a = BTreeMap::new();
+    a.insert(4, "a");
+    a.insert(5, "b");
+    a.insert(6, "c");
+
+    let b = a.split_off(&4);
+
+    assert_eq!(a.len(), 0);
+    assert_eq!(b.len(), 3);
+
+    assert_eq!(b[&4], "a");
+    assert_eq!(b[&5], "b");
+    assert_eq!(b[&6], "c");
+
+    // Split behind last element
+    let mut a = BTreeMap::new();
+    a.insert(1, "a");
+    a.insert(2, "b");
+    a.insert(3, "c");
+
+    let b = a.split_off(&4);
+
+    assert_eq!(a.len(), 3);
+    assert_eq!(b.len(), 0);
+
+    assert_eq!(a[&1], "a");
+    assert_eq!(a[&2], "b");
+    assert_eq!(a[&3], "c");
+
+    // Split at arbitrary position
+    let mut a = BTreeMap::new();
+    a.insert(1, "a");
+    a.insert(2, "b");
+    a.insert(3, "c");
+    a.insert(4, "d");
+    a.insert(5, "e");
+
+    let b = a.split_off(&3);
+
+    assert_eq!(a.len(), 2);
+    assert_eq!(b.len(), 3);
+
+    assert_eq!(a[&1], "a");
+    assert_eq!(a[&2], "b");
+    assert_eq!(b[&3], "c");
+    assert_eq!(b[&4], "d");
+    assert_eq!(b[&5], "e");
+}
+
 mod bench {
     use std::collections::BTreeMap;
     use std::__rand::{Rng, thread_rng};

--- a/src/libcollectionstest/btree/map.rs
+++ b/src/libcollectionstest/btree/map.rs
@@ -294,29 +294,49 @@ fn test_extend_ref() {
     assert_eq!(a[&3], "three");
 }
 
-#[test]
-fn test_append() {
-    let mut a = BTreeMap::new();
-    a.insert(1, "a");
-    a.insert(2, "b");
-    a.insert(3, "c");
+macro_rules! create_append_test {
+    ($name:ident, $len:expr) => {
+        #[test]
+        fn $name() {
+            let mut a = BTreeMap::with_b(6);
+            for i in 0..8 {
+                a.insert(i, i);
+            }
 
-    let mut b = BTreeMap::new();
-    b.insert(3, "d");  // Overwrite element from a
-    b.insert(4, "e");
-    b.insert(5, "f");
+            let mut b = BTreeMap::with_b(6);
+            for i in 5..$len {
+                b.insert(i, 2*i);
+            }
 
-    a.append(&mut b);
+            a.append(&mut b);
 
-    assert_eq!(a.len(), 5);
-    assert_eq!(b.len(), 0);
+            assert_eq!(a.len(), $len);
+            assert_eq!(b.len(), 0);
 
-    assert_eq!(a[&1], "a");
-    assert_eq!(a[&2], "b");
-    assert_eq!(a[&3], "d");
-    assert_eq!(a[&4], "e");
-    assert_eq!(a[&5], "f");
+            for i in 0..$len {
+                if i < 5 {
+                    assert_eq!(a[&i], i);
+                } else {
+                    assert_eq!(a[&i], 2*i);
+                }
+            }
+        }
+    };
 }
+
+// These are mostly for testing the algorithm that "fixes" the right edge after insertion.
+// Single node.
+create_append_test!(test_append_9, 9);
+// Two leafs that don't need fixing.
+create_append_test!(test_append_17, 17);
+// Two leafs where the second one ends up underfull and needs stealing at the end.
+create_append_test!(test_append_14, 14);
+// Two leafs where the first one isn't full; finish insertion at root.
+create_append_test!(test_append_12, 12);
+// Three levels; finish insertion at root.
+create_append_test!(test_append_144, 144);
+// Three levels; finish insertion at leaf without a node on the second level.
+create_append_test!(test_append_145, 145);
 
 #[test]
 fn test_split_off() {

--- a/src/libcollectionstest/btree/set.rs
+++ b/src/libcollectionstest/btree/set.rs
@@ -212,3 +212,102 @@ fn test_extend_ref() {
     assert!(a.contains(&5));
     assert!(a.contains(&6));
 }
+
+#[test]
+fn test_append() {
+    let mut a = BTreeSet::new();
+    a.insert(1);
+    a.insert(2);
+    a.insert(3);
+
+    let mut b = BTreeSet::new();
+    b.insert(3);
+    b.insert(4);
+    b.insert(5);
+
+    a.append(&mut b);
+
+    assert_eq!(a.len(), 5);
+    assert_eq!(b.len(), 0);
+
+    assert_eq!(a.contains(&1), true);
+    assert_eq!(a.contains(&2), true);
+    assert_eq!(a.contains(&3), true);
+    assert_eq!(a.contains(&4), true);
+    assert_eq!(a.contains(&5), true);
+}
+
+#[test]
+fn test_split_off() {
+    // Split empty set
+    let mut a: BTreeSet<usize> = BTreeMap::new();
+
+    let b = a.split_off(2);
+
+    assert_eq!(a.len(), 0);
+    assert_eq!(b.len(), 0);
+
+    // Split before first element
+    let mut a = BTreeSet::new();
+    a.insert(4);
+    a.insert(5);
+    a.insert(6);
+
+    let b = a.split_off(2);
+
+    assert_eq!(a.len(), 0);
+    assert_eq!(b.len(), 3);
+
+    assert!(b.contains(&4));
+    assert!(b.contains(&5));
+    assert!(b.contains(&6));
+
+    // Split at first element
+    let mut a = BTreeSet::new();
+    a.insert(4);
+    a.insert(5);
+    a.insert(6);
+
+    let b = a.split_off(4);
+
+    assert_eq!(a.len(), 0);
+    assert_eq!(b.len(), 3);
+
+    assert_eq!(b.contains(&4));
+    assert_eq!(b.contains(&5));
+    assert_eq!(b.contains(&6));
+
+    // Split behind last element
+    let mut a = BTreeSet::new();
+    a.insert(1);
+    a.insert(2);
+    a.insert(3);
+
+    let b = a.split_off(4);
+
+    assert_eq!(a.len(), 3);
+    assert_eq!(b.len(), 0);
+
+    assert_eq!(a.contains(&1));
+    assert_eq!(a.contains(&2));
+    assert_eq!(a.contains(&3));
+
+    // Split at arbitrary position
+    let mut a = BTreeSet::new();
+    a.insert(1);
+    a.insert(2);
+    a.insert(3);
+    a.insert(4);
+    a.insert(5);
+
+    let b = a.split_off(3);
+
+    assert_eq!(a.len(), 2);
+    assert_eq!(b.len(), 3);
+
+    assert_eq!(a.contains(&1));
+    assert_eq!(a.contains(&2));
+    assert_eq!(b.contains(&3));
+    assert_eq!(b.contains(&4));
+    assert_eq!(b.contains(&5));
+}


### PR DESCRIPTION
Changes the internal SearchStack API to return the key on removal as well.
