### PR TITLE
Cleanup: rename middle::ty::sty and its variants.

### DIFF
--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -719,7 +719,7 @@ pub fn get_enum_variants<'tcx>(intr: Rc<IdentInterner>, cdata: Cmd, id: ast::Nod
                                 item, tcx, cdata);
         let name = item_name(&*intr, item);
         let (ctor_ty, arg_tys, arg_names) = match ctor_ty.sty {
-            ty::ty_bare_fn(_, ref f) =>
+            ty::TyBareFn(_, ref f) =>
                 (Some(ctor_ty), f.sig.0.inputs.clone(), None),
             _ => { // Nullary or struct enum variant.
                 let mut arg_names = Vec::new();

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -28,7 +28,7 @@ use syntax::abi;
 use syntax::ast;
 use syntax::parse::token;
 
-// Compact string representation for Ty values. API ty_str &
+// Compact string representation for Ty values. API TyStr &
 // parse_from_str. Extra parameters are for converting to/from def_ids in the
 // data buffer. Whatever format you choose should not contain pipe characters.
 

--- a/src/librustc/middle/cast.rs
+++ b/src/librustc/middle/cast.rs
@@ -61,16 +61,16 @@ impl<'tcx> CastTy<'tcx> {
     pub fn from_ty(tcx: &ty::ctxt<'tcx>, t: Ty<'tcx>)
                    -> Option<CastTy<'tcx>> {
         match t.sty {
-            ty::ty_bool => Some(CastTy::Int(IntTy::Bool)),
-            ty::ty_char => Some(CastTy::Int(IntTy::Char)),
-            ty::ty_int(_) => Some(CastTy::Int(IntTy::I)),
-            ty::ty_uint(u) => Some(CastTy::Int(IntTy::U(u))),
-            ty::ty_float(_) => Some(CastTy::Float),
-            ty::ty_enum(..) if ty::type_is_c_like_enum(
+            ty::TyBool => Some(CastTy::Int(IntTy::Bool)),
+            ty::TyChar => Some(CastTy::Int(IntTy::Char)),
+            ty::TyInt(_) => Some(CastTy::Int(IntTy::I)),
+            ty::TyUint(u) => Some(CastTy::Int(IntTy::U(u))),
+            ty::TyFloat(_) => Some(CastTy::Float),
+            ty::TyEnum(..) if ty::type_is_c_like_enum(
                 tcx, t) => Some(CastTy::Int(IntTy::CEnum)),
-            ty::ty_ptr(ref mt) => Some(CastTy::Ptr(mt)),
-            ty::ty_rptr(_, ref mt) => Some(CastTy::RPtr(mt)),
-            ty::ty_bare_fn(..) => Some(CastTy::FnPtr),
+            ty::TyRawPtr(ref mt) => Some(CastTy::Ptr(mt)),
+            ty::TyRef(_, ref mt) => Some(CastTy::RPtr(mt)),
+            ty::TyBareFn(..) => Some(CastTy::FnPtr),
             _ => None,
         }
     }

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -732,11 +732,11 @@ pub fn eval_const_expr_with_substs<'tcx, S>(tcx: &ty::ctxt<'tcx>,
     // bindings so that isize/usize is mapped to a type with an
     // inherently known bitwidth.
     let expr_int_type = ety.and_then(|ty| {
-        if let ty::ty_int(t) = ty.sty {
+        if let ty::TyInt(t) = ty.sty {
             Some(IntTy::from(tcx, t)) } else { None }
     });
     let expr_uint_type = ety.and_then(|ty| {
-        if let ty::ty_uint(t) = ty.sty {
+        if let ty::TyUint(t) = ty.sty {
             Some(UintTy::from(tcx, t)) } else { None }
     });
 
@@ -1093,33 +1093,33 @@ fn cast_const<'tcx>(tcx: &ty::ctxt<'tcx>, val: const_val, ty: Ty) -> CastResult 
 
     // Issue #23890: If isize/usize, then dispatch to appropriate target representation type
     match (&ty.sty, tcx.sess.target.int_type, tcx.sess.target.uint_type) {
-        (&ty::ty_int(ast::TyIs), ast::TyI32, _) => return convert_val!(i32, const_int, i64),
-        (&ty::ty_int(ast::TyIs), ast::TyI64, _) => return convert_val!(i64, const_int, i64),
-        (&ty::ty_int(ast::TyIs), _, _) => panic!("unexpected target.int_type"),
+        (&ty::TyInt(ast::TyIs), ast::TyI32, _) => return convert_val!(i32, const_int, i64),
+        (&ty::TyInt(ast::TyIs), ast::TyI64, _) => return convert_val!(i64, const_int, i64),
+        (&ty::TyInt(ast::TyIs), _, _) => panic!("unexpected target.int_type"),
 
-        (&ty::ty_uint(ast::TyUs), _, ast::TyU32) => return convert_val!(u32, const_uint, u64),
-        (&ty::ty_uint(ast::TyUs), _, ast::TyU64) => return convert_val!(u64, const_uint, u64),
-        (&ty::ty_uint(ast::TyUs), _, _) => panic!("unexpected target.uint_type"),
+        (&ty::TyUint(ast::TyUs), _, ast::TyU32) => return convert_val!(u32, const_uint, u64),
+        (&ty::TyUint(ast::TyUs), _, ast::TyU64) => return convert_val!(u64, const_uint, u64),
+        (&ty::TyUint(ast::TyUs), _, _) => panic!("unexpected target.uint_type"),
 
         _ => {}
     }
 
     match ty.sty {
-        ty::ty_int(ast::TyIs) => unreachable!(),
-        ty::ty_uint(ast::TyUs) => unreachable!(),
+        ty::TyInt(ast::TyIs) => unreachable!(),
+        ty::TyUint(ast::TyUs) => unreachable!(),
 
-        ty::ty_int(ast::TyI8) => convert_val!(i8, const_int, i64),
-        ty::ty_int(ast::TyI16) => convert_val!(i16, const_int, i64),
-        ty::ty_int(ast::TyI32) => convert_val!(i32, const_int, i64),
-        ty::ty_int(ast::TyI64) => convert_val!(i64, const_int, i64),
+        ty::TyInt(ast::TyI8) => convert_val!(i8, const_int, i64),
+        ty::TyInt(ast::TyI16) => convert_val!(i16, const_int, i64),
+        ty::TyInt(ast::TyI32) => convert_val!(i32, const_int, i64),
+        ty::TyInt(ast::TyI64) => convert_val!(i64, const_int, i64),
 
-        ty::ty_uint(ast::TyU8) => convert_val!(u8, const_uint, u64),
-        ty::ty_uint(ast::TyU16) => convert_val!(u16, const_uint, u64),
-        ty::ty_uint(ast::TyU32) => convert_val!(u32, const_uint, u64),
-        ty::ty_uint(ast::TyU64) => convert_val!(u64, const_uint, u64),
+        ty::TyUint(ast::TyU8) => convert_val!(u8, const_uint, u64),
+        ty::TyUint(ast::TyU16) => convert_val!(u16, const_uint, u64),
+        ty::TyUint(ast::TyU32) => convert_val!(u32, const_uint, u64),
+        ty::TyUint(ast::TyU64) => convert_val!(u64, const_uint, u64),
 
-        ty::ty_float(ast::TyF32) => convert_val!(f32, const_float, f64),
-        ty::ty_float(ast::TyF64) => convert_val!(f64, const_float, f64),
+        ty::TyFloat(ast::TyF32) => convert_val!(f32, const_float, f64),
+        ty::TyFloat(ast::TyF64) => convert_val!(f64, const_float, f64),
         _ => Err(ErrKind::CannotCast),
     }
 }
@@ -1135,7 +1135,7 @@ fn lit_to_const(lit: &ast::Lit, ty_hint: Option<Ty>) -> const_val {
         ast::LitInt(n, ast::SignedIntLit(_, ast::Plus)) => const_int(n as i64),
         ast::LitInt(n, ast::UnsuffixedIntLit(ast::Plus)) => {
             match ty_hint.map(|ty| &ty.sty) {
-                Some(&ty::ty_uint(_)) => const_uint(n),
+                Some(&ty::TyUint(_)) => const_uint(n),
                 _ => const_int(n as i64)
             }
         }

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -129,7 +129,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
 
     fn handle_field_access(&mut self, lhs: &ast::Expr, name: ast::Name) {
         match ty::expr_ty_adjusted(self.tcx, lhs).sty {
-            ty::ty_struct(id, _) => {
+            ty::TyStruct(id, _) => {
                 let fields = ty::lookup_struct_fields(self.tcx, id);
                 let field_id = fields.iter()
                     .find(|field| field.name == name).unwrap().id;
@@ -141,7 +141,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
 
     fn handle_tup_field_access(&mut self, lhs: &ast::Expr, idx: usize) {
         match ty::expr_ty_adjusted(self.tcx, lhs).sty {
-            ty::ty_struct(id, _) => {
+            ty::TyStruct(id, _) => {
                 let fields = ty::lookup_struct_fields(self.tcx, id);
                 let field_id = fields[idx].id;
                 self.live_symbols.insert(field_id.node);

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -31,7 +31,7 @@ enum UnsafeContext {
 
 fn type_is_unsafe_function(ty: Ty) -> bool {
     match ty.sty {
-        ty::ty_bare_fn(_, ref f) => f.unsafety == ast::Unsafety::Unsafe,
+        ty::TyBareFn(_, ref f) => f.unsafety == ast::Unsafety::Unsafe,
         _ => false,
     }
 }
@@ -69,11 +69,11 @@ impl<'a, 'tcx> EffectCheckVisitor<'a, 'tcx> {
         debug!("effect: checking index with base type {}",
                 ppaux::ty_to_string(self.tcx, base_type));
         match base_type.sty {
-            ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ty, ..}) => if ty::ty_str == ty.sty {
+            ty::TyBox(ty) | ty::TyRef(_, ty::mt{ty, ..}) => if ty::TyStr == ty.sty {
                 span_err!(self.tcx.sess, e.span, E0134,
                           "modification of string types is not allowed");
             },
-            ty::ty_str => {
+            ty::TyStr => {
                 span_err!(self.tcx.sess, e.span, E0135,
                           "modification of string types is not allowed");
             }
@@ -161,7 +161,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EffectCheckVisitor<'a, 'tcx> {
                 let base_type = ty::node_id_to_type(self.tcx, base.id);
                 debug!("effect: unary case, base type is {}",
                        ppaux::ty_to_string(self.tcx, base_type));
-                if let ty::ty_ptr(_) = base_type.sty {
+                if let ty::TyRawPtr(_) = base_type.sty {
                     self.require_unsafe(expr.span, "dereference of raw pointer")
                 }
             }

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -622,10 +622,10 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                callee.repr(self.tcx()), callee_ty.repr(self.tcx()));
         let call_scope = region::CodeExtent::from_node_id(call.id);
         match callee_ty.sty {
-            ty::ty_bare_fn(..) => {
+            ty::TyBareFn(..) => {
                 self.consume_expr(callee);
             }
-            ty::ty_err => { }
+            ty::TyError => { }
             _ => {
                 let overloaded_call_type =
                     match self.typer.node_method_origin(MethodCall::expr(call.id)) {
@@ -740,7 +740,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
         // Select just those fields of the `with`
         // expression that will actually be used
         let with_fields = match with_cmt.ty.sty {
-            ty::ty_struct(did, substs) => {
+            ty::TyStruct(did, substs) => {
                 ty::struct_fields(self.tcx(), did, substs)
             }
             _ => {
@@ -826,7 +826,7 @@ impl<'d,'t,'tcx,TYPER:mc::Typer<'tcx>> ExprUseVisitor<'d,'t,'tcx,TYPER> {
                     let self_ty = ty::no_late_bound_regions(self.tcx(), &self_ty).unwrap();
 
                     let (m, r) = match self_ty.sty {
-                        ty::ty_rptr(r, ref m) => (m.mutbl, r),
+                        ty::TyRef(r, ref m) => (m.mutbl, r),
                         _ => self.tcx().sess.span_bug(expr.span,
                                 &format!("bad overloaded deref type {}",
                                     method_ty.repr(self.tcx())))

--- a/src/librustc/middle/fast_reject.rs
+++ b/src/librustc/middle/fast_reject.rs
@@ -48,51 +48,51 @@ pub fn simplify_type(tcx: &ty::ctxt,
                      -> Option<SimplifiedType>
 {
     match ty.sty {
-        ty::ty_bool => Some(BoolSimplifiedType),
-        ty::ty_char => Some(CharSimplifiedType),
-        ty::ty_int(int_type) => Some(IntSimplifiedType(int_type)),
-        ty::ty_uint(uint_type) => Some(UintSimplifiedType(uint_type)),
-        ty::ty_float(float_type) => Some(FloatSimplifiedType(float_type)),
-        ty::ty_enum(def_id, _) => Some(EnumSimplifiedType(def_id)),
-        ty::ty_str => Some(StrSimplifiedType),
-        ty::ty_vec(..) => Some(VecSimplifiedType),
-        ty::ty_ptr(_) => Some(PtrSimplifiedType),
-        ty::ty_trait(ref trait_info) => {
+        ty::TyBool => Some(BoolSimplifiedType),
+        ty::TyChar => Some(CharSimplifiedType),
+        ty::TyInt(int_type) => Some(IntSimplifiedType(int_type)),
+        ty::TyUint(uint_type) => Some(UintSimplifiedType(uint_type)),
+        ty::TyFloat(float_type) => Some(FloatSimplifiedType(float_type)),
+        ty::TyEnum(def_id, _) => Some(EnumSimplifiedType(def_id)),
+        ty::TyStr => Some(StrSimplifiedType),
+        ty::TyArray(..) => Some(VecSimplifiedType),
+        ty::TyRawPtr(_) => Some(PtrSimplifiedType),
+        ty::TyTrait(ref trait_info) => {
             Some(TraitSimplifiedType(trait_info.principal_def_id()))
         }
-        ty::ty_struct(def_id, _) => {
+        ty::TyStruct(def_id, _) => {
             Some(StructSimplifiedType(def_id))
         }
-        ty::ty_rptr(_, mt) => {
+        ty::TyRef(_, mt) => {
             // since we introduce auto-refs during method lookup, we
             // just treat &T and T as equivalent from the point of
             // view of possibly unifying
             simplify_type(tcx, mt.ty, can_simplify_params)
         }
-        ty::ty_uniq(_) => {
+        ty::TyBox(_) => {
             // treat like we would treat `Box`
             let def_id = tcx.lang_items.owned_box().unwrap();
             Some(StructSimplifiedType(def_id))
         }
-        ty::ty_closure(def_id, _) => {
+        ty::TyClosure(def_id, _) => {
             Some(ClosureSimplifiedType(def_id))
         }
-        ty::ty_tup(ref tys) => {
+        ty::TyTuple(ref tys) => {
             Some(TupleSimplifiedType(tys.len()))
         }
-        ty::ty_bare_fn(_, ref f) => {
+        ty::TyBareFn(_, ref f) => {
             Some(FunctionSimplifiedType(f.sig.0.inputs.len()))
         }
-        ty::ty_projection(_) => {
+        ty::TyProjection(_) => {
             None
         }
-        ty::ty_param(_) => {
+        ty::TyParam(_) => {
             if can_simplify_params {
                 Some(ParameterSimplifiedType)
             } else {
                 None
             }
         }
-        ty::ty_infer(_) | ty::ty_err => None,
+        ty::TyInfer(_) | ty::TyError => None,
     }
 }

--- a/src/librustc/middle/infer/bivariate.rs
+++ b/src/librustc/middle/infer/bivariate.rs
@@ -81,17 +81,17 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Bivariate<'a, 'tcx> {
         let a = infcx.type_variables.borrow().replace_if_possible(a);
         let b = infcx.type_variables.borrow().replace_if_possible(b);
         match (&a.sty, &b.sty) {
-            (&ty::ty_infer(TyVar(a_id)), &ty::ty_infer(TyVar(b_id))) => {
+            (&ty::TyInfer(TyVar(a_id)), &ty::TyInfer(TyVar(b_id))) => {
                 infcx.type_variables.borrow_mut().relate_vars(a_id, BiTo, b_id);
                 Ok(a)
             }
 
-            (&ty::ty_infer(TyVar(a_id)), _) => {
+            (&ty::TyInfer(TyVar(a_id)), _) => {
                 try!(self.fields.instantiate(b, BiTo, a_id));
                 Ok(a)
             }
 
-            (_, &ty::ty_infer(TyVar(b_id))) => {
+            (_, &ty::TyInfer(TyVar(b_id))) => {
                 try!(self.fields.instantiate(a, BiTo, b_id));
                 Ok(a)
             }

--- a/src/librustc/middle/infer/combine.rs
+++ b/src/librustc/middle/infer/combine.rs
@@ -70,44 +70,44 @@ pub fn super_combine_tys<'a,'tcx:'a,R>(infcx: &InferCtxt<'a, 'tcx>,
 
     match (&a.sty, &b.sty) {
         // Relate integral variables to other types
-        (&ty::ty_infer(ty::IntVar(a_id)), &ty::ty_infer(ty::IntVar(b_id))) => {
+        (&ty::TyInfer(ty::IntVar(a_id)), &ty::TyInfer(ty::IntVar(b_id))) => {
             try!(infcx.int_unification_table
                       .borrow_mut()
                       .unify_var_var(a_id, b_id)
                       .map_err(|e| int_unification_error(a_is_expected, e)));
             Ok(a)
         }
-        (&ty::ty_infer(ty::IntVar(v_id)), &ty::ty_int(v)) => {
+        (&ty::TyInfer(ty::IntVar(v_id)), &ty::TyInt(v)) => {
             unify_integral_variable(infcx, a_is_expected, v_id, IntType(v))
         }
-        (&ty::ty_int(v), &ty::ty_infer(ty::IntVar(v_id))) => {
+        (&ty::TyInt(v), &ty::TyInfer(ty::IntVar(v_id))) => {
             unify_integral_variable(infcx, !a_is_expected, v_id, IntType(v))
         }
-        (&ty::ty_infer(ty::IntVar(v_id)), &ty::ty_uint(v)) => {
+        (&ty::TyInfer(ty::IntVar(v_id)), &ty::TyUint(v)) => {
             unify_integral_variable(infcx, a_is_expected, v_id, UintType(v))
         }
-        (&ty::ty_uint(v), &ty::ty_infer(ty::IntVar(v_id))) => {
+        (&ty::TyUint(v), &ty::TyInfer(ty::IntVar(v_id))) => {
             unify_integral_variable(infcx, !a_is_expected, v_id, UintType(v))
         }
 
         // Relate floating-point variables to other types
-        (&ty::ty_infer(ty::FloatVar(a_id)), &ty::ty_infer(ty::FloatVar(b_id))) => {
+        (&ty::TyInfer(ty::FloatVar(a_id)), &ty::TyInfer(ty::FloatVar(b_id))) => {
             try!(infcx.float_unification_table
                       .borrow_mut()
                       .unify_var_var(a_id, b_id)
                       .map_err(|e| float_unification_error(relation.a_is_expected(), e)));
             Ok(a)
         }
-        (&ty::ty_infer(ty::FloatVar(v_id)), &ty::ty_float(v)) => {
+        (&ty::TyInfer(ty::FloatVar(v_id)), &ty::TyFloat(v)) => {
             unify_float_variable(infcx, a_is_expected, v_id, v)
         }
-        (&ty::ty_float(v), &ty::ty_infer(ty::FloatVar(v_id))) => {
+        (&ty::TyFloat(v), &ty::TyInfer(ty::FloatVar(v_id))) => {
             unify_float_variable(infcx, !a_is_expected, v_id, v)
         }
 
         // All other cases of inference are errors
-        (&ty::ty_infer(_), _) |
-        (_, &ty::ty_infer(_)) => {
+        (&ty::TyInfer(_), _) |
+        (_, &ty::TyInfer(_)) => {
             Err(ty::terr_sorts(ty_relate::expected_found(relation, &a, &b)))
         }
 
@@ -262,7 +262,7 @@ impl<'a, 'tcx> CombineFields<'a, 'tcx> {
 
     /// Attempts to generalize `ty` for the type variable `for_vid`.  This checks for cycle -- that
     /// is, whether the type `ty` references `for_vid`. If `make_region_vars` is true, it will also
-    /// replace all regions with fresh variables. Returns `ty_err` in the case of a cycle, `Ok`
+    /// replace all regions with fresh variables. Returns `TyError` in the case of a cycle, `Ok`
     /// otherwise.
     fn generalize(&self,
                   ty: Ty<'tcx>,
@@ -308,7 +308,7 @@ impl<'cx, 'tcx> ty_fold::TypeFolder<'tcx> for Generalizer<'cx, 'tcx> {
         // (In particular, you could have something like `$0 = Box<$1>`
         //  where `$1` has already been instantiated with `Box<$0>`)
         match t.sty {
-            ty::ty_infer(ty::TyVar(vid)) => {
+            ty::TyInfer(ty::TyVar(vid)) => {
                 if vid == self.for_vid {
                     self.cycle_detected = true;
                     self.tcx().types.err

--- a/src/librustc/middle/infer/equate.rs
+++ b/src/librustc/middle/infer/equate.rs
@@ -53,17 +53,17 @@ impl<'a, 'tcx> TypeRelation<'a,'tcx> for Equate<'a, 'tcx> {
         let a = infcx.type_variables.borrow().replace_if_possible(a);
         let b = infcx.type_variables.borrow().replace_if_possible(b);
         match (&a.sty, &b.sty) {
-            (&ty::ty_infer(TyVar(a_id)), &ty::ty_infer(TyVar(b_id))) => {
+            (&ty::TyInfer(TyVar(a_id)), &ty::TyInfer(TyVar(b_id))) => {
                 infcx.type_variables.borrow_mut().relate_vars(a_id, EqTo, b_id);
                 Ok(a)
             }
 
-            (&ty::ty_infer(TyVar(a_id)), _) => {
+            (&ty::TyInfer(TyVar(a_id)), _) => {
                 try!(self.fields.instantiate(b, EqTo, a_id));
                 Ok(a)
             }
 
-            (_, &ty::ty_infer(TyVar(b_id))) => {
+            (_, &ty::TyInfer(TyVar(b_id))) => {
                 try!(self.fields.instantiate(a, EqTo, b_id));
                 Ok(a)
             }

--- a/src/librustc/middle/infer/freshen.rs
+++ b/src/librustc/middle/infer/freshen.rs
@@ -111,14 +111,14 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
         let tcx = self.infcx.tcx;
 
         match t.sty {
-            ty::ty_infer(ty::TyVar(v)) => {
+            ty::TyInfer(ty::TyVar(v)) => {
                 self.freshen(
                     self.infcx.type_variables.borrow().probe(v),
                     ty::TyVar(v),
                     ty::FreshTy)
             }
 
-            ty::ty_infer(ty::IntVar(v)) => {
+            ty::TyInfer(ty::IntVar(v)) => {
                 self.freshen(
                     self.infcx.int_unification_table.borrow_mut()
                                                     .probe(v)
@@ -127,7 +127,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
                     ty::FreshIntTy)
             }
 
-            ty::ty_infer(ty::FloatVar(v)) => {
+            ty::TyInfer(ty::FloatVar(v)) => {
                 self.freshen(
                     self.infcx.float_unification_table.borrow_mut()
                                                       .probe(v)
@@ -136,9 +136,9 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
                     ty::FreshFloatTy)
             }
 
-            ty::ty_infer(ty::FreshTy(c)) |
-            ty::ty_infer(ty::FreshIntTy(c)) |
-            ty::ty_infer(ty::FreshFloatTy(c)) => {
+            ty::TyInfer(ty::FreshTy(c)) |
+            ty::TyInfer(ty::FreshIntTy(c)) |
+            ty::TyInfer(ty::FreshFloatTy(c)) => {
                 if c >= self.freshen_count {
                     tcx.sess.bug(
                         &format!("Encountered a freshend type with id {} \
@@ -149,25 +149,25 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
                 t
             }
 
-            ty::ty_bool |
-            ty::ty_char |
-            ty::ty_int(..) |
-            ty::ty_uint(..) |
-            ty::ty_float(..) |
-            ty::ty_enum(..) |
-            ty::ty_uniq(..) |
-            ty::ty_str |
-            ty::ty_err |
-            ty::ty_vec(..) |
-            ty::ty_ptr(..) |
-            ty::ty_rptr(..) |
-            ty::ty_bare_fn(..) |
-            ty::ty_trait(..) |
-            ty::ty_struct(..) |
-            ty::ty_closure(..) |
-            ty::ty_tup(..) |
-            ty::ty_projection(..) |
-            ty::ty_param(..) => {
+            ty::TyBool |
+            ty::TyChar |
+            ty::TyInt(..) |
+            ty::TyUint(..) |
+            ty::TyFloat(..) |
+            ty::TyEnum(..) |
+            ty::TyBox(..) |
+            ty::TyStr |
+            ty::TyError |
+            ty::TyArray(..) |
+            ty::TyRawPtr(..) |
+            ty::TyRef(..) |
+            ty::TyBareFn(..) |
+            ty::TyTrait(..) |
+            ty::TyStruct(..) |
+            ty::TyClosure(..) |
+            ty::TyTuple(..) |
+            ty::TyProjection(..) |
+            ty::TyParam(..) => {
                 ty_fold::super_fold_ty(self, t)
             }
         }

--- a/src/librustc/middle/infer/lattice.rs
+++ b/src/librustc/middle/infer/lattice.rs
@@ -64,15 +64,15 @@ pub fn super_lattice_tys<'a,'tcx,L:LatticeDir<'a,'tcx>>(this: &mut L,
     let a = infcx.type_variables.borrow().replace_if_possible(a);
     let b = infcx.type_variables.borrow().replace_if_possible(b);
     match (&a.sty, &b.sty) {
-        (&ty::ty_infer(TyVar(..)), &ty::ty_infer(TyVar(..)))
+        (&ty::TyInfer(TyVar(..)), &ty::TyInfer(TyVar(..)))
             if infcx.type_var_diverges(a) && infcx.type_var_diverges(b) => {
             let v = infcx.next_diverging_ty_var();
             try!(this.relate_bound(v, a, b));
             Ok(v)
         }
 
-        (&ty::ty_infer(TyVar(..)), _) |
-        (_, &ty::ty_infer(TyVar(..))) => {
+        (&ty::TyInfer(TyVar(..)), _) |
+        (_, &ty::TyInfer(TyVar(..))) => {
             let v = infcx.next_ty_var();
             try!(this.relate_bound(v, a, b));
             Ok(v)

--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -440,7 +440,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
     pub fn type_var_diverges(&'a self, ty: Ty) -> bool {
         match ty.sty {
-            ty::ty_infer(ty::TyVar(vid)) => self.type_variables.borrow().var_diverges(vid),
+            ty::TyInfer(ty::TyVar(vid)) => self.type_variables.borrow().var_diverges(vid),
             _ => false
         }
     }
@@ -452,14 +452,14 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     pub fn type_is_unconstrained_numeric(&'a self, ty: Ty) -> UnconstrainedNumeric {
         use middle::ty::UnconstrainedNumeric::{Neither, UnconstrainedInt, UnconstrainedFloat};
         match ty.sty {
-            ty::ty_infer(ty::IntVar(vid)) => {
+            ty::TyInfer(ty::IntVar(vid)) => {
                 if self.int_unification_table.borrow_mut().has_value(vid) {
                     Neither
                 } else {
                     UnconstrainedInt
                 }
             },
-            ty::ty_infer(ty::FloatVar(vid)) => {
+            ty::TyInfer(ty::FloatVar(vid)) => {
                 if self.float_unification_table.borrow_mut().has_value(vid) {
                     Neither
                 } else {
@@ -878,7 +878,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
     pub fn shallow_resolve(&self, typ: Ty<'tcx>) -> Ty<'tcx> {
         match typ.sty {
-            ty::ty_infer(ty::TyVar(v)) => {
+            ty::TyInfer(ty::TyVar(v)) => {
                 // Not entirely obvious: if `typ` is a type variable,
                 // it can be resolved to an int/float variable, which
                 // can then be recursively resolved, hence the
@@ -894,7 +894,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                     .unwrap_or(typ)
             }
 
-            ty::ty_infer(ty::IntVar(v)) => {
+            ty::TyInfer(ty::IntVar(v)) => {
                 self.int_unification_table
                     .borrow_mut()
                     .probe(v)
@@ -902,7 +902,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                     .unwrap_or(typ)
             }
 
-            ty::ty_infer(ty::FloatVar(v)) => {
+            ty::TyInfer(ty::FloatVar(v)) => {
                 self.float_unification_table
                     .borrow_mut()
                     .probe(v)
@@ -945,13 +945,13 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     }
 
     // [Note-Type-error-reporting]
-    // An invariant is that anytime the expected or actual type is ty_err (the special
+    // An invariant is that anytime the expected or actual type is TyError (the special
     // error type, meaning that an error occurred when typechecking this expression),
     // this is a derived error. The error cascaded from another error (that was already
     // reported), so it's not useful to display it to the user.
     // The following four methods -- type_error_message_str, type_error_message_str_with_expected,
     // type_error_message, and report_mismatched_types -- implement this logic.
-    // They check if either the actual or expected type is ty_err, and don't print the error
+    // They check if either the actual or expected type is TyError, and don't print the error
     // in this case. The typechecker should only ever report type errors involving mismatched
     // types using one of these four methods, and should not call span_err directly for such
     // errors.
@@ -1004,7 +1004,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     {
         let actual_ty = self.resolve_type_vars_if_possible(&actual_ty);
 
-        // Don't report an error if actual type is ty_err.
+        // Don't report an error if actual type is TyError.
         if ty::type_is_error(actual_ty) {
             return;
         }

--- a/src/librustc/middle/infer/resolve.rs
+++ b/src/librustc/middle/infer/resolve.rs
@@ -81,19 +81,19 @@ impl<'a, 'tcx> ty_fold::TypeFolder<'tcx> for FullTypeResolver<'a, 'tcx> {
         } else {
             let t = self.infcx.shallow_resolve(t);
             match t.sty {
-                ty::ty_infer(ty::TyVar(vid)) => {
+                ty::TyInfer(ty::TyVar(vid)) => {
                     self.err = Some(unresolved_ty(vid));
                     self.tcx().types.err
                 }
-                ty::ty_infer(ty::IntVar(vid)) => {
+                ty::TyInfer(ty::IntVar(vid)) => {
                     self.err = Some(unresolved_int_ty(vid));
                     self.tcx().types.err
                 }
-                ty::ty_infer(ty::FloatVar(vid)) => {
+                ty::TyInfer(ty::FloatVar(vid)) => {
                     self.err = Some(unresolved_float_ty(vid));
                     self.tcx().types.err
                 }
-                ty::ty_infer(_) => {
+                ty::TyInfer(_) => {
                     self.infcx.tcx.sess.bug(
                         &format!("Unexpected type in full type resolver: {}",
                                 t.repr(self.infcx.tcx)));

--- a/src/librustc/middle/infer/sub.rs
+++ b/src/librustc/middle/infer/sub.rs
@@ -57,24 +57,24 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Sub<'a, 'tcx> {
         let a = infcx.type_variables.borrow().replace_if_possible(a);
         let b = infcx.type_variables.borrow().replace_if_possible(b);
         match (&a.sty, &b.sty) {
-            (&ty::ty_infer(TyVar(a_id)), &ty::ty_infer(TyVar(b_id))) => {
+            (&ty::TyInfer(TyVar(a_id)), &ty::TyInfer(TyVar(b_id))) => {
                 infcx.type_variables
                     .borrow_mut()
                     .relate_vars(a_id, SubtypeOf, b_id);
                 Ok(a)
             }
-            (&ty::ty_infer(TyVar(a_id)), _) => {
+            (&ty::TyInfer(TyVar(a_id)), _) => {
                 try!(self.fields
                          .switch_expected()
                          .instantiate(b, SupertypeOf, a_id));
                 Ok(a)
             }
-            (_, &ty::ty_infer(TyVar(b_id))) => {
+            (_, &ty::TyInfer(TyVar(b_id))) => {
                 try!(self.fields.instantiate(a, SubtypeOf, b_id));
                 Ok(a)
             }
 
-            (&ty::ty_err, _) | (_, &ty::ty_err) => {
+            (&ty::TyError, _) | (_, &ty::TyError) => {
                 Ok(self.tcx().types.err)
             }
 

--- a/src/librustc/middle/infer/type_variable.rs
+++ b/src/librustc/middle/infer/type_variable.rs
@@ -131,7 +131,7 @@ impl<'tcx> TypeVariableTable<'tcx> {
 
     pub fn replace_if_possible(&self, t: Ty<'tcx>) -> Ty<'tcx> {
         match t.sty {
-            ty::ty_infer(ty::TyVar(v)) => {
+            ty::TyInfer(ty::TyVar(v)) => {
                 match self.probe(v) {
                     None => t,
                     Some(u) => u

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -12,7 +12,7 @@ use ast_map::NodeForeignItem;
 use metadata::csearch;
 use middle::def::DefFn;
 use middle::subst::{Subst, Substs, EnumeratedItems};
-use middle::ty::{TransmuteRestriction, ctxt, ty_bare_fn};
+use middle::ty::{TransmuteRestriction, ctxt, TyBareFn};
 use middle::ty::{self, Ty};
 use util::ppaux::Repr;
 
@@ -54,7 +54,7 @@ struct IntrinsicCheckingVisitor<'a, 'tcx: 'a> {
 impl<'a, 'tcx> IntrinsicCheckingVisitor<'a, 'tcx> {
     fn def_id_is_transmute(&self, def_id: DefId) -> bool {
         let intrinsic = match ty::lookup_item_type(self.tcx, def_id).ty.sty {
-            ty::ty_bare_fn(_, ref bfty) => bfty.abi == RustIntrinsic,
+            ty::TyBareFn(_, ref bfty) => bfty.abi == RustIntrinsic,
             _ => return false
         };
         if def_id.krate == ast::LOCAL_CRATE {
@@ -256,7 +256,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for IntrinsicCheckingVisitor<'a, 'tcx> {
                 DefFn(did, _) if self.def_id_is_transmute(did) => {
                     let typ = ty::node_id_to_type(self.tcx, expr.id);
                     match typ.sty {
-                        ty_bare_fn(_, ref bare_fn_ty) if bare_fn_ty.abi == RustIntrinsic => {
+                        TyBareFn(_, ref bare_fn_ty) if bare_fn_ty.abi == RustIntrinsic => {
                             if let ty::FnConverging(to) = bare_fn_ty.sig.0.output {
                                 let from = bare_fn_ty.sig.0.inputs[0];
                                 self.check_transmute(expr.span, from, to, expr.id);

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1498,7 +1498,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
     fn fn_ret(&self, id: NodeId) -> ty::PolyFnOutput<'tcx> {
         let fn_ty = ty::node_id_to_type(self.ir.tcx, id);
         match fn_ty.sty {
-            ty::ty_closure(closure_def_id, substs) =>
+            ty::TyClosure(closure_def_id, substs) =>
                 self.ir.tcx.closure_type(closure_def_id, substs).sig.output(),
             _ =>
                 ty::ty_fn_ret(fn_ty),

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -387,7 +387,7 @@ pub fn check_expr(tcx: &ty::ctxt, e: &ast::Expr,
         ast::ExprField(ref base_e, ref field) => {
             span = field.span;
             match ty::expr_ty_adjusted(tcx, base_e).sty {
-                ty::ty_struct(did, _) => {
+                ty::TyStruct(did, _) => {
                     ty::lookup_struct_fields(tcx, did)
                         .iter()
                         .find(|f| f.name == field.node.name)
@@ -404,7 +404,7 @@ pub fn check_expr(tcx: &ty::ctxt, e: &ast::Expr,
         ast::ExprTupField(ref base_e, ref field) => {
             span = field.span;
             match ty::expr_ty_adjusted(tcx, base_e).sty {
-                ty::ty_struct(did, _) => {
+                ty::TyStruct(did, _) => {
                     ty::lookup_struct_fields(tcx, did)
                         .get(field.node)
                         .unwrap_or_else(|| {
@@ -413,7 +413,7 @@ pub fn check_expr(tcx: &ty::ctxt, e: &ast::Expr,
                         })
                         .id
                 }
-                ty::ty_tup(..) => return,
+                ty::TyTuple(..) => return,
                 _ => tcx.sess.span_bug(e.span,
                                        "stability::check_expr: unnamed field access on \
                                         something other than a tuple or struct")
@@ -422,7 +422,7 @@ pub fn check_expr(tcx: &ty::ctxt, e: &ast::Expr,
         ast::ExprStruct(_, ref expr_fields, _) => {
             let type_ = ty::expr_ty(tcx, e);
             match type_.sty {
-                ty::ty_struct(did, _) => {
+                ty::TyStruct(did, _) => {
                     let struct_fields = ty::lookup_struct_fields(tcx, did);
                     // check the stability of each field that appears
                     // in the construction expression.
@@ -445,7 +445,7 @@ pub fn check_expr(tcx: &ty::ctxt, e: &ast::Expr,
                 // we don't look at stability attributes on
                 // struct-like enums (yet...), but it's definitely not
                 // a bug to have construct one.
-                ty::ty_enum(..) => return,
+                ty::TyEnum(..) => return,
                 _ => {
                     tcx.sess.span_bug(e.span,
                                       &format!("stability::check_expr: struct construction \
@@ -478,7 +478,7 @@ pub fn check_pat(tcx: &ty::ctxt, pat: &ast::Pat,
     if is_internal(tcx, pat.span) { return; }
 
     let did = match ty::pat_ty_opt(tcx, pat) {
-        Some(&ty::TyS { sty: ty::ty_struct(did, _), .. }) => did,
+        Some(&ty::TyS { sty: ty::TyStruct(did, _), .. }) => did,
         Some(_) | None => return,
     };
     let struct_fields = ty::lookup_struct_fields(tcx, did);

--- a/src/librustc/middle/subst.rs
+++ b/src/librustc/middle/subst.rs
@@ -647,7 +647,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for SubstFolder<'a, 'tcx> {
         self.ty_stack_depth += 1;
 
         let t1 = match t.sty {
-            ty::ty_param(p) => {
+            ty::TyParam(p) => {
                 self.ty_for_param(p, t)
             }
             _ => {

--- a/src/librustc/middle/traits/coherence.rs
+++ b/src/librustc/middle/traits/coherence.rs
@@ -265,7 +265,7 @@ fn uncovered_tys<'tcx>(tcx: &ty::ctxt<'tcx>,
 fn is_type_parameter<'tcx>(ty: Ty<'tcx>) -> bool {
     match ty.sty {
         // FIXME(#20590) straighten story about projection types
-        ty::ty_projection(..) | ty::ty_param(..) => true,
+        ty::TyProjection(..) | ty::TyParam(..) => true,
         _ => false,
     }
 }
@@ -279,11 +279,11 @@ fn ty_is_local<'tcx>(tcx: &ty::ctxt<'tcx>, ty: Ty<'tcx>, infer_is_local: InferIs
 fn fundamental_ty<'tcx>(tcx: &ty::ctxt<'tcx>, ty: Ty<'tcx>) -> bool
 {
     match ty.sty {
-        ty::ty_uniq(..) | ty::ty_rptr(..) =>
+        ty::TyBox(..) | ty::TyRef(..) =>
             true,
-        ty::ty_enum(def_id, _) | ty::ty_struct(def_id, _) =>
+        ty::TyEnum(def_id, _) | ty::TyStruct(def_id, _) =>
             ty::has_attr(tcx, def_id, "fundamental"),
-        ty::ty_trait(ref data) =>
+        ty::TyTrait(ref data) =>
             ty::has_attr(tcx, data.principal_def_id(), "fundamental"),
         _ =>
             false
@@ -298,42 +298,42 @@ fn ty_is_local_constructor<'tcx>(tcx: &ty::ctxt<'tcx>,
     debug!("ty_is_local_constructor({})", ty.repr(tcx));
 
     match ty.sty {
-        ty::ty_bool |
-        ty::ty_char |
-        ty::ty_int(..) |
-        ty::ty_uint(..) |
-        ty::ty_float(..) |
-        ty::ty_str(..) |
-        ty::ty_bare_fn(..) |
-        ty::ty_vec(..) |
-        ty::ty_ptr(..) |
-        ty::ty_rptr(..) |
-        ty::ty_tup(..) |
-        ty::ty_param(..) |
-        ty::ty_projection(..) => {
+        ty::TyBool |
+        ty::TyChar |
+        ty::TyInt(..) |
+        ty::TyUint(..) |
+        ty::TyFloat(..) |
+        ty::TyStr(..) |
+        ty::TyBareFn(..) |
+        ty::TyArray(..) |
+        ty::TyRawPtr(..) |
+        ty::TyRef(..) |
+        ty::TyTuple(..) |
+        ty::TyParam(..) |
+        ty::TyProjection(..) => {
             false
         }
 
-        ty::ty_infer(..) => {
+        ty::TyInfer(..) => {
             infer_is_local.0
         }
 
-        ty::ty_enum(def_id, _) |
-        ty::ty_struct(def_id, _) => {
+        ty::TyEnum(def_id, _) |
+        ty::TyStruct(def_id, _) => {
             def_id.krate == ast::LOCAL_CRATE
         }
 
-        ty::ty_uniq(_) => { // Box<T>
+        ty::TyBox(_) => { // Box<T>
             let krate = tcx.lang_items.owned_box().map(|d| d.krate);
             krate == Some(ast::LOCAL_CRATE)
         }
 
-        ty::ty_trait(ref tt) => {
+        ty::TyTrait(ref tt) => {
             tt.principal_def_id().krate == ast::LOCAL_CRATE
         }
 
-        ty::ty_closure(..) |
-        ty::ty_err => {
+        ty::TyClosure(..) |
+        ty::TyError => {
             tcx.sess.bug(
                 &format!("ty_is_local invoked on unexpected type: {}",
                         ty.repr(tcx)))

--- a/src/librustc/middle/traits/error_reporting.rs
+++ b/src/librustc/middle/traits/error_reporting.rs
@@ -60,10 +60,10 @@ pub fn report_projection_error<'a, 'tcx>(infcx: &InferCtxt<'a, 'tcx>,
 {
     let predicate =
         infcx.resolve_type_vars_if_possible(&obligation.predicate);
-    // The ty_err created by normalize_to_error can end up being unified
+    // The TyError created by normalize_to_error can end up being unified
     // into all obligations: for example, if our obligation is something
     // like `$X = <() as Foo<$X>>::Out` and () does not implement Foo<_>,
-    // then $X will be unified with ty_err, but the error still needs to be
+    // then $X will be unified with TyError, but the error still needs to be
     // reported.
     if !infcx.tcx.sess.has_errors() || !predicate.references_error() {
         span_err!(infcx.tcx.sess, obligation.cause.span, E0271,

--- a/src/librustc/middle/traits/object_safety.rs
+++ b/src/librustc/middle/traits/object_safety.rs
@@ -308,7 +308,7 @@ fn contains_illegal_self_type_reference<'tcx>(tcx: &ty::ctxt<'tcx>,
     let mut error = false;
     ty::maybe_walk_ty(ty, |ty| {
         match ty.sty {
-            ty::ty_param(ref param_ty) => {
+            ty::TyParam(ref param_ty) => {
                 if param_ty.space == SelfSpace {
                     error = true;
                 }
@@ -316,7 +316,7 @@ fn contains_illegal_self_type_reference<'tcx>(tcx: &ty::ctxt<'tcx>,
                 false // no contained types to walk
             }
 
-            ty::ty_projection(ref data) => {
+            ty::TyProjection(ref data) => {
                 // This is a projected type `<Foo as SomeTrait>::X`.
 
                 // Compute supertraits of current trait lazily.
@@ -367,7 +367,7 @@ impl<'tcx> Repr<'tcx> for ObjectSafetyViolation<'tcx> {
 
 fn is_self<'tcx>(ty: Ty<'tcx>) -> bool {
     match ty.sty {
-        ty::ty_param(ref data) => data.space == subst::SelfSpace,
+        ty::TyParam(ref data) => data.space == subst::SelfSpace,
         _ => false,
     }
 }

--- a/src/librustc/middle/traits/project.rs
+++ b/src/librustc/middle/traits/project.rs
@@ -153,7 +153,7 @@ fn consider_unification_despite_ambiguity<'cx,'tcx>(selcx: &mut SelectionContext
     debug!("consider_unification_despite_ambiguity: self_ty.sty={:?}",
            self_ty.sty);
     match self_ty.sty {
-        ty::ty_closure(closure_def_id, substs) => {
+        ty::TyClosure(closure_def_id, substs) => {
             let closure_typer = selcx.closure_typer();
             let closure_type = closure_typer.closure_type(closure_def_id, substs);
             let ty::Binder((_, ret_type)) =
@@ -261,7 +261,7 @@ impl<'a,'b,'tcx> TypeFolder<'tcx> for AssociatedTypeNormalizer<'a,'b,'tcx> {
 
         let ty = ty_fold::super_fold_ty(self, ty);
         match ty.sty {
-            ty::ty_projection(ref data) if !data.has_escaping_regions() => { // (*)
+            ty::TyProjection(ref data) if !data.has_escaping_regions() => { // (*)
 
                 // (*) This is kind of hacky -- we need to be able to
                 // handle normalization within binders because
@@ -408,11 +408,11 @@ fn opt_normalize_projection_type<'a,'b,'tcx>(
     }
 }
 
-/// in various error cases, we just set ty_err and return an obligation
+/// in various error cases, we just set TyError and return an obligation
 /// that, when fulfilled, will lead to an error.
 ///
-/// FIXME: the ty_err created here can enter the obligation we create,
-/// leading to error messages involving ty_err.
+/// FIXME: the TyError created here can enter the obligation we create,
+/// leading to error messages involving TyError.
 fn normalize_to_error<'a,'tcx>(selcx: &mut SelectionContext<'a,'tcx>,
                                projection_ty: ty::ProjectionTy<'tcx>,
                                cause: ObligationCause<'tcx>,
@@ -554,8 +554,8 @@ fn assemble_candidates_from_trait_def<'cx,'tcx>(
 {
     // Check whether the self-type is itself a projection.
     let trait_ref = match obligation_trait_ref.self_ty().sty {
-        ty::ty_projection(ref data) => data.trait_ref.clone(),
-        ty::ty_infer(ty::TyVar(_)) => {
+        ty::TyProjection(ref data) => data.trait_ref.clone(),
+        ty::TyInfer(ty::TyVar(_)) => {
             // If the self-type is an inference variable, then it MAY wind up
             // being a projected type, so induce an ambiguity.
             candidate_set.ambiguous = true;
@@ -625,7 +625,7 @@ fn assemble_candidates_from_object_type<'cx,'tcx>(
     debug!("assemble_candidates_from_object_type(object_ty={})",
            object_ty.repr(infcx.tcx));
     let data = match object_ty.sty {
-        ty::ty_trait(ref data) => data,
+        ty::TyTrait(ref data) => data,
         _ => {
             selcx.tcx().sess.span_bug(
                 obligation.cause.span,
@@ -883,7 +883,7 @@ fn confirm_impl_candidate<'cx,'tcx>(
                     // definition for the associated type. This error
                     // ought to be reported by the type checker method
                     // `check_impl_items_against_trait`, so here we
-                    // just return ty_err.
+                    // just return TyError.
                     return (selcx.tcx().types.err, vec!());
                 }
             }

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -590,51 +590,51 @@ pub fn super_fold_ty<'tcx, T: TypeFolder<'tcx>>(this: &mut T,
                                                 ty: Ty<'tcx>)
                                                 -> Ty<'tcx> {
     let sty = match ty.sty {
-        ty::ty_uniq(typ) => {
-            ty::ty_uniq(typ.fold_with(this))
+        ty::TyBox(typ) => {
+            ty::TyBox(typ.fold_with(this))
         }
-        ty::ty_ptr(ref tm) => {
-            ty::ty_ptr(tm.fold_with(this))
+        ty::TyRawPtr(ref tm) => {
+            ty::TyRawPtr(tm.fold_with(this))
         }
-        ty::ty_vec(typ, sz) => {
-            ty::ty_vec(typ.fold_with(this), sz)
+        ty::TyArray(typ, sz) => {
+            ty::TyArray(typ.fold_with(this), sz)
         }
-        ty::ty_enum(tid, ref substs) => {
+        ty::TyEnum(tid, ref substs) => {
             let substs = substs.fold_with(this);
-            ty::ty_enum(tid, this.tcx().mk_substs(substs))
+            ty::TyEnum(tid, this.tcx().mk_substs(substs))
         }
-        ty::ty_trait(box ty::TyTrait { ref principal, ref bounds }) => {
-            ty::ty_trait(box ty::TyTrait {
+        ty::TyTrait(box ty::TraitTy { ref principal, ref bounds }) => {
+            ty::TyTrait(box ty::TraitTy {
                 principal: principal.fold_with(this),
                 bounds: bounds.fold_with(this),
             })
         }
-        ty::ty_tup(ref ts) => {
-            ty::ty_tup(ts.fold_with(this))
+        ty::TyTuple(ref ts) => {
+            ty::TyTuple(ts.fold_with(this))
         }
-        ty::ty_bare_fn(opt_def_id, ref f) => {
+        ty::TyBareFn(opt_def_id, ref f) => {
             let bfn = f.fold_with(this);
-            ty::ty_bare_fn(opt_def_id, this.tcx().mk_bare_fn(bfn))
+            ty::TyBareFn(opt_def_id, this.tcx().mk_bare_fn(bfn))
         }
-        ty::ty_rptr(r, ref tm) => {
+        ty::TyRef(r, ref tm) => {
             let r = r.fold_with(this);
-            ty::ty_rptr(this.tcx().mk_region(r), tm.fold_with(this))
+            ty::TyRef(this.tcx().mk_region(r), tm.fold_with(this))
         }
-        ty::ty_struct(did, ref substs) => {
+        ty::TyStruct(did, ref substs) => {
             let substs = substs.fold_with(this);
-            ty::ty_struct(did, this.tcx().mk_substs(substs))
+            ty::TyStruct(did, this.tcx().mk_substs(substs))
         }
-        ty::ty_closure(did, ref substs) => {
+        ty::TyClosure(did, ref substs) => {
             let s = substs.fold_with(this);
-            ty::ty_closure(did, this.tcx().mk_substs(s))
+            ty::TyClosure(did, this.tcx().mk_substs(s))
         }
-        ty::ty_projection(ref data) => {
-            ty::ty_projection(data.fold_with(this))
+        ty::TyProjection(ref data) => {
+            ty::TyProjection(data.fold_with(this))
         }
-        ty::ty_bool | ty::ty_char | ty::ty_str |
-        ty::ty_int(_) | ty::ty_uint(_) | ty::ty_float(_) |
-        ty::ty_err | ty::ty_infer(_) |
-        ty::ty_param(..) => {
+        ty::TyBool | ty::TyChar | ty::TyStr |
+        ty::TyInt(_) | ty::TyUint(_) | ty::TyFloat(_) |
+        ty::TyError | ty::TyInfer(_) |
+        ty::TyParam(..) => {
             ty.sty.clone()
         }
     };

--- a/src/librustc/middle/ty_match.rs
+++ b/src/librustc/middle/ty_match.rs
@@ -66,18 +66,18 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Match<'a, 'tcx> {
         if a == b { return Ok(a); }
 
         match (&a.sty, &b.sty) {
-            (_, &ty::ty_infer(ty::FreshTy(_))) |
-            (_, &ty::ty_infer(ty::FreshIntTy(_))) |
-            (_, &ty::ty_infer(ty::FreshFloatTy(_))) => {
+            (_, &ty::TyInfer(ty::FreshTy(_))) |
+            (_, &ty::TyInfer(ty::FreshIntTy(_))) |
+            (_, &ty::TyInfer(ty::FreshFloatTy(_))) => {
                 Ok(a)
             }
 
-            (&ty::ty_infer(_), _) |
-            (_, &ty::ty_infer(_)) => {
+            (&ty::TyInfer(_), _) |
+            (_, &ty::TyInfer(_)) => {
                 Err(ty::terr_sorts(ty_relate::expected_found(self, &a, &b)))
             }
 
-            (&ty::ty_err, _) | (_, &ty::ty_err) => {
+            (&ty::TyError, _) | (_, &ty::TyError) => {
                 Ok(self.tcx().types.err)
             }
 

--- a/src/librustc/middle/ty_walk.rs
+++ b/src/librustc/middle/ty_walk.rs
@@ -68,33 +68,33 @@ pub fn walk_shallow<'tcx>(ty: Ty<'tcx>) -> IntoIter<Ty<'tcx>> {
 
 fn push_subtypes<'tcx>(stack: &mut Vec<Ty<'tcx>>, parent_ty: Ty<'tcx>) {
     match parent_ty.sty {
-        ty::ty_bool | ty::ty_char | ty::ty_int(_) | ty::ty_uint(_) | ty::ty_float(_) |
-        ty::ty_str | ty::ty_infer(_) | ty::ty_param(_) | ty::ty_err => {
+        ty::TyBool | ty::TyChar | ty::TyInt(_) | ty::TyUint(_) | ty::TyFloat(_) |
+        ty::TyStr | ty::TyInfer(_) | ty::TyParam(_) | ty::TyError => {
         }
-        ty::ty_uniq(ty) | ty::ty_vec(ty, _) => {
+        ty::TyBox(ty) | ty::TyArray(ty, _) => {
             stack.push(ty);
         }
-        ty::ty_ptr(ref mt) | ty::ty_rptr(_, ref mt) => {
+        ty::TyRawPtr(ref mt) | ty::TyRef(_, ref mt) => {
             stack.push(mt.ty);
         }
-        ty::ty_projection(ref data) => {
+        ty::TyProjection(ref data) => {
             push_reversed(stack, data.trait_ref.substs.types.as_slice());
         }
-        ty::ty_trait(box ty::TyTrait { ref principal, ref bounds }) => {
+        ty::TyTrait(box ty::TraitTy { ref principal, ref bounds }) => {
             push_reversed(stack, principal.substs().types.as_slice());
             push_reversed(stack, &bounds.projection_bounds.iter().map(|pred| {
                 pred.0.ty
             }).collect::<Vec<_>>());
         }
-        ty::ty_enum(_, ref substs) |
-        ty::ty_struct(_, ref substs) |
-        ty::ty_closure(_, ref substs) => {
+        ty::TyEnum(_, ref substs) |
+        ty::TyStruct(_, ref substs) |
+        ty::TyClosure(_, ref substs) => {
             push_reversed(stack, substs.types.as_slice());
         }
-        ty::ty_tup(ref ts) => {
+        ty::TyTuple(ref ts) => {
             push_reversed(stack, ts);
         }
-        ty::ty_bare_fn(_, ref ft) => {
+        ty::TyBareFn(_, ref ft) => {
             push_sig_subtypes(stack, &ft.sig);
         }
     }

--- a/src/librustc_borrowck/borrowck/check_loans.rs
+++ b/src/librustc_borrowck/borrowck/check_loans.rs
@@ -752,7 +752,7 @@ impl<'a, 'tcx> CheckLoanCtxt<'a, 'tcx> {
             }
             LpExtend(ref lp_base, _, LpInterior(InteriorField(_))) => {
                 match lp_base.to_type().sty {
-                    ty::ty_struct(def_id, _) | ty::ty_enum(def_id, _) => {
+                    ty::TyStruct(def_id, _) | ty::TyEnum(def_id, _) => {
                         if ty::has_dtor(self.tcx(), def_id) {
                             // In the case where the owner implements drop, then
                             // the path must be initialized to prevent a case of

--- a/src/librustc_borrowck/borrowck/fragments.rs
+++ b/src/librustc_borrowck/borrowck/fragments.rs
@@ -339,7 +339,7 @@ fn add_fragment_siblings_for_extension<'tcx>(this: &MoveData<'tcx>,
     };
 
     match (&parent_ty.sty, enum_variant_info) {
-        (&ty::ty_tup(ref v), None) => {
+        (&ty::TyTuple(ref v), None) => {
             let tuple_idx = match *origin_field_name {
                 mc::PositionalField(tuple_idx) => tuple_idx,
                 mc::NamedField(_) =>
@@ -354,7 +354,7 @@ fn add_fragment_siblings_for_extension<'tcx>(this: &MoveData<'tcx>,
             }
         }
 
-        (&ty::ty_struct(def_id, ref _substs), None) => {
+        (&ty::TyStruct(def_id, ref _substs), None) => {
             let fields = ty::lookup_struct_fields(tcx, def_id);
             match *origin_field_name {
                 mc::NamedField(ast_name) => {
@@ -378,7 +378,7 @@ fn add_fragment_siblings_for_extension<'tcx>(this: &MoveData<'tcx>,
             }
         }
 
-        (&ty::ty_enum(enum_def_id, substs), ref enum_variant_info) => {
+        (&ty::TyEnum(enum_def_id, substs), ref enum_variant_info) => {
             let variant_info = {
                 let mut variants = ty::substd_enum_variants(tcx, enum_def_id, substs);
                 match *enum_variant_info {

--- a/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/gather_moves.rs
@@ -179,7 +179,7 @@ fn check_and_get_illegal_move_origin<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>,
         mc::cat_interior(ref b, mc::InteriorField(_)) |
         mc::cat_interior(ref b, mc::InteriorElement(Kind::Pattern, _)) => {
             match b.ty.sty {
-                ty::ty_struct(did, _) | ty::ty_enum(did, _) => {
+                ty::TyStruct(did, _) | ty::TyEnum(did, _) => {
                     if ty::has_dtor(bccx.tcx, did) {
                         Some(cmt.clone())
                     } else {

--- a/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
+++ b/src/librustc_borrowck/borrowck/gather_loans/move_error.rs
@@ -137,8 +137,8 @@ fn report_cannot_move_out_of<'a, 'tcx>(bccx: &BorrowckCtxt<'a, 'tcx>,
         mc::cat_downcast(ref b, _) |
         mc::cat_interior(ref b, mc::InteriorField(_)) => {
             match b.ty.sty {
-                ty::ty_struct(did, _) |
-                ty::ty_enum(did, _) if ty::has_dtor(bccx.tcx, did) => {
+                ty::TyStruct(did, _) |
+                ty::TyEnum(did, _) if ty::has_dtor(bccx.tcx, did) => {
                     bccx.span_err(
                         move_from.span,
                         &format!("cannot move out of type `{}`, \

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -656,7 +656,7 @@ fn glb_bound_free_infer() {
         // `&'_ isize`
         let t_resolve1 = env.infcx.shallow_resolve(t_infer1);
         match t_resolve1.sty {
-            ty::ty_rptr(..) => { }
+            ty::TyRef(..) => { }
             _ => { panic!("t_resolve1={}", t_resolve1.repr(env.infcx.tcx)); }
         }
     })

--- a/src/librustc_trans/save/dump_csv.rs
+++ b/src/librustc_trans/save/dump_csv.rs
@@ -903,7 +903,7 @@ impl <'l, 'tcx> DumpCsvVisitor<'l, 'tcx> {
 
         let ty = &ty::expr_ty_adjusted(&self.analysis.ty_cx, ex).sty;
         let struct_def = match *ty {
-            ty::ty_struct(def_id, _) => {
+            ty::TyStruct(def_id, _) => {
                 let sub_span = self.span.span_for_last_ident(path.span);
                 self.fmt.ref_str(recorder::StructRef,
                                  path.span,
@@ -1316,7 +1316,7 @@ impl<'l, 'tcx, 'v> Visitor<'v> for DumpCsvVisitor<'l, 'tcx> {
 
                 let ty = &ty::expr_ty_adjusted(&self.analysis.ty_cx, &**sub_ex).sty;
                 match *ty {
-                    ty::ty_struct(def_id, _) => {
+                    ty::TyStruct(def_id, _) => {
                         let fields = ty::lookup_struct_fields(&self.analysis.ty_cx, def_id);
                         for (i, f) in fields.iter().enumerate() {
                             if i == idx.node {
@@ -1330,7 +1330,7 @@ impl<'l, 'tcx, 'v> Visitor<'v> for DumpCsvVisitor<'l, 'tcx> {
                             }
                         }
                     }
-                    ty::ty_tup(_) => {}
+                    ty::TyTuple(_) => {}
                     _ => self.sess.span_bug(ex.span,
                                             &format!("Expected struct or tuple \
                                                       type, found {:?}", ty)),

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -223,7 +223,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
             ast::ExprField(ref sub_ex, ident) => {
                 let ty = &ty::expr_ty_adjusted(&self.analysis.ty_cx, &sub_ex).sty;
                 match *ty {
-                    ty::ty_struct(def_id, _) => {
+                    ty::TyStruct(def_id, _) => {
                         let fields = ty::lookup_struct_fields(&self.analysis.ty_cx, def_id);
                         for f in &fields {
                             if f.name == ident.node.name {

--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -850,10 +850,10 @@ fn compare_values<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
     }
 
     match rhs_t.sty {
-        ty::ty_rptr(_, mt) => match mt.ty.sty {
-            ty::ty_str => compare_str(cx, lhs, rhs, rhs_t, debug_loc),
-            ty::ty_vec(ty, _) => match ty.sty {
-                ty::ty_uint(ast::TyU8) => {
+        ty::TyRef(_, mt) => match mt.ty.sty {
+            ty::TyStr => compare_str(cx, lhs, rhs, rhs_t, debug_loc),
+            ty::TyArray(ty, _) => match ty.sty {
+                ty::TyUint(ast::TyU8) => {
                     // NOTE: cast &[u8] and &[u8; N] to &str and abuse the str_eq lang item,
                     // which calls memcmp().
                     let pat_len = val_ty(rhs).element_type().array_length();
@@ -1092,7 +1092,7 @@ fn compile_submatch_continue<'a, 'p, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         ).collect();
 
         match left_ty.sty {
-            ty::ty_struct(def_id, substs) if !type_is_sized(bcx.tcx(), left_ty) => {
+            ty::TyStruct(def_id, substs) if !type_is_sized(bcx.tcx(), left_ty) => {
                 // The last field is technically unsized but
                 // since we can only ever match that field behind
                 // a reference we construct a fat ptr here.
@@ -1116,7 +1116,7 @@ fn compile_submatch_continue<'a, 'p, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         Some(vec!(Load(bcx, val)))
     } else {
         match left_ty.sty {
-            ty::ty_vec(_, Some(n)) => {
+            ty::TyArray(_, Some(n)) => {
                 let args = extract_vec_elems(bcx, left_ty, n, 0, val);
                 Some(args.vals)
             }

--- a/src/librustc_trans/trans/attributes.rs
+++ b/src/librustc_trans/trans/attributes.rs
@@ -128,8 +128,8 @@ pub fn from_fn_type<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_type: ty::Ty<'tcx
 
     let function_type;
     let (fn_sig, abi, env_ty) = match fn_type.sty {
-        ty::ty_bare_fn(_, ref f) => (&f.sig, f.abi, None),
-        ty::ty_closure(closure_did, substs) => {
+        ty::TyBareFn(_, ref f) => (&f.sig, f.abi, None),
+        ty::TyClosure(closure_did, substs) => {
             let typer = common::NormalizingClosureTyper::new(ccx.tcx());
             function_type = typer.closure_type(closure_did, substs);
             let self_type = base::self_type_for_closure(ccx, closure_did, fn_type);
@@ -146,11 +146,11 @@ pub fn from_fn_type<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_type: ty::Ty<'tcx
     // These have an odd calling convention, so we need to manually
     // unpack the input ty's
     let input_tys = match fn_type.sty {
-        ty::ty_closure(..) => {
+        ty::TyClosure(..) => {
             assert!(abi == abi::RustCall);
 
             match fn_sig.inputs[0].sty {
-                ty::ty_tup(ref inputs) => {
+                ty::TyTuple(ref inputs) => {
                     let mut full_inputs = vec![env_ty.expect("Missing closure environment")];
                     full_inputs.push_all(inputs);
                     full_inputs
@@ -158,11 +158,11 @@ pub fn from_fn_type<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_type: ty::Ty<'tcx
                 _ => ccx.sess().bug("expected tuple'd inputs")
             }
         },
-        ty::ty_bare_fn(..) if abi == abi::RustCall => {
+        ty::TyBareFn(..) if abi == abi::RustCall => {
             let mut inputs = vec![fn_sig.inputs[0]];
 
             match fn_sig.inputs[1].sty {
-                ty::ty_tup(ref t_in) => {
+                ty::TyTuple(ref t_in) => {
                     inputs.push_all(&t_in[..]);
                     inputs
                 }
@@ -198,7 +198,7 @@ pub fn from_fn_type<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_type: ty::Ty<'tcx
             match ret_ty.sty {
                 // `Box` pointer return values never alias because ownership
                 // is transferred
-                ty::ty_uniq(it) if common::type_is_sized(ccx.tcx(), it) => {
+                ty::TyBox(it) if common::type_is_sized(ccx.tcx(), it) => {
                     attrs.ret(llvm::Attribute::NoAlias);
                 }
                 _ => {}
@@ -207,15 +207,15 @@ pub fn from_fn_type<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_type: ty::Ty<'tcx
             // We can also mark the return value as `dereferenceable` in certain cases
             match ret_ty.sty {
                 // These are not really pointers but pairs, (pointer, len)
-                ty::ty_rptr(_, ty::mt { ty: inner, .. })
-                | ty::ty_uniq(inner) if common::type_is_sized(ccx.tcx(), inner) => {
+                ty::TyRef(_, ty::mt { ty: inner, .. })
+                | ty::TyBox(inner) if common::type_is_sized(ccx.tcx(), inner) => {
                     let llret_sz = machine::llsize_of_real(ccx, type_of::type_of(ccx, inner));
                     attrs.ret(llvm::DereferenceableAttribute(llret_sz));
                 }
                 _ => {}
             }
 
-            if let ty::ty_bool = ret_ty.sty {
+            if let ty::TyBool = ret_ty.sty {
                 attrs.ret(llvm::Attribute::ZExt);
             }
         }
@@ -235,12 +235,12 @@ pub fn from_fn_type<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_type: ty::Ty<'tcx
                      .arg(idx, llvm::DereferenceableAttribute(llarg_sz));
             }
 
-            ty::ty_bool => {
+            ty::TyBool => {
                 attrs.arg(idx, llvm::Attribute::ZExt);
             }
 
             // `Box` pointer parameters never alias because ownership is transferred
-            ty::ty_uniq(inner) => {
+            ty::TyBox(inner) => {
                 let llsz = machine::llsize_of_real(ccx, type_of::type_of(ccx, inner));
 
                 attrs.arg(idx, llvm::Attribute::NoAlias)
@@ -252,7 +252,7 @@ pub fn from_fn_type<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_type: ty::Ty<'tcx
             // `&T` where `T` contains no `UnsafeCell<U>` is immutable, and can be marked as both
             // `readonly` and `noalias`, as LLVM's definition of `noalias` is based solely on
             // memory dependencies rather than pointer equality
-            ty::ty_rptr(b, mt) if mt.mutbl == ast::MutMutable ||
+            ty::TyRef(b, mt) if mt.mutbl == ast::MutMutable ||
                                   !ty::type_contents(ccx.tcx(), mt.ty).interior_unsafe() => {
 
                 let llsz = machine::llsize_of_real(ccx, type_of::type_of(ccx, mt.ty));
@@ -270,7 +270,7 @@ pub fn from_fn_type<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_type: ty::Ty<'tcx
 
             // When a reference in an argument has no named lifetime, it's impossible for that
             // reference to escape this function (returned or stored beyond the call by a closure).
-            ty::ty_rptr(&ReLateBound(_, BrAnon(_)), mt) => {
+            ty::TyRef(&ReLateBound(_, BrAnon(_)), mt) => {
                 let llsz = machine::llsize_of_real(ccx, type_of::type_of(ccx, mt.ty));
                 attrs.arg(idx, llvm::Attribute::NoCapture)
                      .arg(idx, llvm::DereferenceableAttribute(llsz));
@@ -278,7 +278,7 @@ pub fn from_fn_type<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, fn_type: ty::Ty<'tcx
 
             // & pointer parameters are also never null and we know exactly how
             // many bytes we can dereference
-            ty::ty_rptr(_, mt) => {
+            ty::TyRef(_, mt) => {
                 let llsz = machine::llsize_of_real(ccx, type_of::type_of(ccx, mt.ty));
                 attrs.arg(idx, llvm::DereferenceableAttribute(llsz));
             }

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -107,7 +107,7 @@ fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
                                 -> Callee<'blk, 'tcx> {
         let DatumBlock { bcx, datum, .. } = expr::trans(bcx, expr);
         match datum.ty.sty {
-            ty::ty_bare_fn(..) => {
+            ty::TyBareFn(..) => {
                 let llval = datum.to_llscalarish(bcx);
                 return Callee {
                     bcx: bcx,
@@ -156,7 +156,7 @@ fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
                 }
             }
             def::DefFn(did, _) if match expr_ty.sty {
-                ty::ty_bare_fn(_, ref f) => f.abi == synabi::RustIntrinsic,
+                ty::TyBareFn(_, ref f) => f.abi == synabi::RustIntrinsic,
                 _ => false
             } => {
                 let substs = common::node_id_substs(bcx.ccx(),
@@ -299,7 +299,7 @@ pub fn trans_fn_pointer_shim<'a, 'tcx>(
     // which is the fn pointer, and `args`, which is the arguments tuple.
     let (opt_def_id, sig) =
         match bare_fn_ty.sty {
-            ty::ty_bare_fn(opt_def_id,
+            ty::TyBareFn(opt_def_id,
                            &ty::BareFnTy { unsafety: ast::Unsafety::Normal,
                                            abi: synabi::Rust,
                                            ref sig }) => {
@@ -621,7 +621,7 @@ pub fn trans_method_call<'a, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let method_ty = match bcx.tcx().method_map.borrow().get(&method_call) {
         Some(method) => match method.origin {
             ty::MethodTraitObject(_) => match method.ty.sty {
-                ty::ty_bare_fn(_, ref fty) => {
+                ty::TyBareFn(_, ref fty) => {
                     ty::mk_bare_fn(bcx.tcx(), None, meth::opaque_method_ty(bcx.tcx(), fty))
                 }
                 _ => method.ty
@@ -699,7 +699,7 @@ pub fn trans_call_inner<'a, 'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
     let mut bcx = callee.bcx;
 
     let (abi, ret_ty) = match callee_ty.sty {
-        ty::ty_bare_fn(_, ref f) => {
+        ty::TyBareFn(_, ref f) => {
             let output = ty::erase_late_bound_regions(bcx.tcx(), &f.sig.output());
             (f.abi, output)
         }
@@ -943,7 +943,7 @@ fn trans_args_under_call_abi<'blk, 'tcx>(
     let tuple_type = common::node_id_type(bcx, tuple_expr.id);
 
     match tuple_type.sty {
-        ty::ty_tup(ref field_types) => {
+        ty::TyTuple(ref field_types) => {
             let tuple_datum = unpack_datum!(bcx,
                                             expr::trans(bcx, &**tuple_expr));
             let tuple_lvalue_datum =
@@ -1002,7 +1002,7 @@ fn trans_overloaded_call_args<'blk, 'tcx>(
     // Now untuple the rest of the arguments.
     let tuple_type = arg_tys[1];
     match tuple_type.sty {
-        ty::ty_tup(ref field_types) => {
+        ty::TyTuple(ref field_types) => {
             for (i, &field_type) in field_types.iter().enumerate() {
                 let arg_datum =
                     unpack_datum!(bcx, expr::trans(bcx, arg_exprs[i + 1]));

--- a/src/librustc_trans/trans/closure.rs
+++ b/src/librustc_trans/trans/closure.rs
@@ -143,7 +143,7 @@ pub fn get_or_create_declaration_if_closure<'a, 'tcx>(ccx: &CrateContext<'a, 'tc
     // duplicate declarations
     let function_type = erase_regions(ccx.tcx(), &function_type);
     let params = match function_type.sty {
-        ty::ty_closure(_, substs) => &substs.types,
+        ty::TyClosure(_, substs) => &substs.types,
         _ => unreachable!()
     };
     let mono_id = MonoId {
@@ -421,7 +421,7 @@ fn trans_fn_once_adapter_shim<'a, 'tcx>(
 
     // the remaining arguments will be packed up in a tuple.
     let input_tys = match sig.inputs[1].sty {
-        ty::ty_tup(ref tys) => &**tys,
+        ty::TyTuple(ref tys) => &**tys,
         _ => bcx.sess().bug(&format!("trans_fn_once_adapter_shim: not rust-call! \
                                       closure_def_id={}",
                                      closure_def_id.repr(tcx)))

--- a/src/librustc_trans/trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/trans/debuginfo/metadata.rs
@@ -171,26 +171,26 @@ impl<'tcx> TypeMap<'tcx> {
         unique_type_id.push('{');
 
         match type_.sty {
-            ty::ty_bool     |
-            ty::ty_char     |
-            ty::ty_str      |
-            ty::ty_int(_)   |
-            ty::ty_uint(_)  |
-            ty::ty_float(_) => {
+            ty::TyBool     |
+            ty::TyChar     |
+            ty::TyStr      |
+            ty::TyInt(_)   |
+            ty::TyUint(_)  |
+            ty::TyFloat(_) => {
                 push_debuginfo_type_name(cx, type_, false, &mut unique_type_id);
             },
-            ty::ty_enum(def_id, substs) => {
+            ty::TyEnum(def_id, substs) => {
                 unique_type_id.push_str("enum ");
                 from_def_id_and_substs(self, cx, def_id, substs, &mut unique_type_id);
             },
-            ty::ty_struct(def_id, substs) => {
+            ty::TyStruct(def_id, substs) => {
                 unique_type_id.push_str("struct ");
                 from_def_id_and_substs(self, cx, def_id, substs, &mut unique_type_id);
             },
-            ty::ty_tup(ref component_types) if component_types.is_empty() => {
+            ty::TyTuple(ref component_types) if component_types.is_empty() => {
                 push_debuginfo_type_name(cx, type_, false, &mut unique_type_id);
             },
-            ty::ty_tup(ref component_types) => {
+            ty::TyTuple(ref component_types) => {
                 unique_type_id.push_str("tuple ");
                 for &component_type in component_types {
                     let component_type_id =
@@ -200,13 +200,13 @@ impl<'tcx> TypeMap<'tcx> {
                     unique_type_id.push_str(&component_type_id[..]);
                 }
             },
-            ty::ty_uniq(inner_type) => {
+            ty::TyBox(inner_type) => {
                 unique_type_id.push_str("box ");
                 let inner_type_id = self.get_unique_type_id_of_type(cx, inner_type);
                 let inner_type_id = self.get_unique_type_id_as_string(inner_type_id);
                 unique_type_id.push_str(&inner_type_id[..]);
             },
-            ty::ty_ptr(ty::mt { ty: inner_type, mutbl } ) => {
+            ty::TyRawPtr(ty::mt { ty: inner_type, mutbl } ) => {
                 unique_type_id.push('*');
                 if mutbl == ast::MutMutable {
                     unique_type_id.push_str("mut");
@@ -216,7 +216,7 @@ impl<'tcx> TypeMap<'tcx> {
                 let inner_type_id = self.get_unique_type_id_as_string(inner_type_id);
                 unique_type_id.push_str(&inner_type_id[..]);
             },
-            ty::ty_rptr(_, ty::mt { ty: inner_type, mutbl }) => {
+            ty::TyRef(_, ty::mt { ty: inner_type, mutbl }) => {
                 unique_type_id.push('&');
                 if mutbl == ast::MutMutable {
                     unique_type_id.push_str("mut");
@@ -226,7 +226,7 @@ impl<'tcx> TypeMap<'tcx> {
                 let inner_type_id = self.get_unique_type_id_as_string(inner_type_id);
                 unique_type_id.push_str(&inner_type_id[..]);
             },
-            ty::ty_vec(inner_type, optional_length) => {
+            ty::TyArray(inner_type, optional_length) => {
                 match optional_length {
                     Some(len) => {
                         unique_type_id.push_str(&format!("[{}]", len));
@@ -240,7 +240,7 @@ impl<'tcx> TypeMap<'tcx> {
                 let inner_type_id = self.get_unique_type_id_as_string(inner_type_id);
                 unique_type_id.push_str(&inner_type_id[..]);
             },
-            ty::ty_trait(ref trait_data) => {
+            ty::TyTrait(ref trait_data) => {
                 unique_type_id.push_str("trait ");
 
                 let principal =
@@ -253,7 +253,7 @@ impl<'tcx> TypeMap<'tcx> {
                                        principal.substs,
                                        &mut unique_type_id);
             },
-            ty::ty_bare_fn(_, &ty::BareFnTy{ unsafety, abi, ref sig } ) => {
+            ty::TyBareFn(_, &ty::BareFnTy{ unsafety, abi, ref sig } ) => {
                 if unsafety == ast::Unsafety::Unsafe {
                     unique_type_id.push_str("unsafe ");
                 }
@@ -289,7 +289,7 @@ impl<'tcx> TypeMap<'tcx> {
                     }
                 }
             },
-            ty::ty_closure(def_id, substs) => {
+            ty::TyClosure(def_id, substs) => {
                 let typer = NormalizingClosureTyper::new(cx.tcx());
                 let closure_ty = typer.closure_type(def_id, substs);
                 self.get_unique_type_id_of_closure_type(cx,
@@ -635,7 +635,7 @@ fn subroutine_type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
     // return type
     signature_metadata.push(match signature.output {
         ty::FnConverging(ret_ty) => match ret_ty.sty {
-            ty::ty_tup(ref tys) if tys.is_empty() => ptr::null_mut(),
+            ty::TyTuple(ref tys) if tys.is_empty() => ptr::null_mut(),
             _ => type_metadata(cx, ret_ty, span)
         },
         ty::FnDiverging => diverging_type_metadata(cx)
@@ -674,7 +674,7 @@ fn trait_pointer_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
     // But it does not describe the trait's methods.
 
     let def_id = match trait_type.sty {
-        ty::ty_trait(ref data) => data.principal_def_id(),
+        ty::TyTrait(ref data) => data.principal_def_id(),
         _ => {
             let pp_type_name = ppaux::ty_to_string(cx.tcx(), trait_type);
             cx.sess().bug(&format!("debuginfo: Unexpected trait-object type in \
@@ -742,39 +742,39 @@ pub fn type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
 
     let sty = &t.sty;
     let MetadataCreationResult { metadata, already_stored_in_typemap } = match *sty {
-        ty::ty_bool     |
-        ty::ty_char     |
-        ty::ty_int(_)   |
-        ty::ty_uint(_)  |
-        ty::ty_float(_) => {
+        ty::TyBool     |
+        ty::TyChar     |
+        ty::TyInt(_)   |
+        ty::TyUint(_)  |
+        ty::TyFloat(_) => {
             MetadataCreationResult::new(basic_type_metadata(cx, t), false)
         }
-        ty::ty_tup(ref elements) if elements.is_empty() => {
+        ty::TyTuple(ref elements) if elements.is_empty() => {
             MetadataCreationResult::new(basic_type_metadata(cx, t), false)
         }
-        ty::ty_enum(def_id, _) => {
+        ty::TyEnum(def_id, _) => {
             prepare_enum_metadata(cx, t, def_id, unique_type_id, usage_site_span).finalize(cx)
         }
-        ty::ty_vec(typ, len) => {
+        ty::TyArray(typ, len) => {
             fixed_vec_metadata(cx, unique_type_id, typ, len.map(|x| x as u64), usage_site_span)
         }
-        ty::ty_str => {
+        ty::TyStr => {
             fixed_vec_metadata(cx, unique_type_id, cx.tcx().types.i8, None, usage_site_span)
         }
-        ty::ty_trait(..) => {
+        ty::TyTrait(..) => {
             MetadataCreationResult::new(
                         trait_pointer_metadata(cx, t, None, unique_type_id),
             false)
         }
-        ty::ty_uniq(ty) | ty::ty_ptr(ty::mt{ty, ..}) | ty::ty_rptr(_, ty::mt{ty, ..}) => {
+        ty::TyBox(ty) | ty::TyRawPtr(ty::mt{ty, ..}) | ty::TyRef(_, ty::mt{ty, ..}) => {
             match ty.sty {
-                ty::ty_vec(typ, None) => {
+                ty::TyArray(typ, None) => {
                     vec_slice_metadata(cx, t, typ, unique_type_id, usage_site_span)
                 }
-                ty::ty_str => {
+                ty::TyStr => {
                     vec_slice_metadata(cx, t, cx.tcx().types.u8, unique_type_id, usage_site_span)
                 }
-                ty::ty_trait(..) => {
+                ty::TyTrait(..) => {
                     MetadataCreationResult::new(
                         trait_pointer_metadata(cx, ty, Some(t), unique_type_id),
                         false)
@@ -794,15 +794,15 @@ pub fn type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                 }
             }
         }
-        ty::ty_bare_fn(_, ref barefnty) => {
+        ty::TyBareFn(_, ref barefnty) => {
             subroutine_type_metadata(cx, unique_type_id, &barefnty.sig, usage_site_span)
         }
-        ty::ty_closure(def_id, substs) => {
+        ty::TyClosure(def_id, substs) => {
             let typer = NormalizingClosureTyper::new(cx.tcx());
             let sig = typer.closure_type(def_id, substs).sig;
             subroutine_type_metadata(cx, unique_type_id, &sig, usage_site_span)
         }
-        ty::ty_struct(def_id, substs) => {
+        ty::TyStruct(def_id, substs) => {
             prepare_struct_metadata(cx,
                                     t,
                                     def_id,
@@ -810,7 +810,7 @@ pub fn type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                                     unique_type_id,
                                     usage_site_span).finalize(cx)
         }
-        ty::ty_tup(ref elements) => {
+        ty::TyTuple(ref elements) => {
             prepare_tuple_metadata(cx,
                                    t,
                                    &elements[..],
@@ -936,25 +936,25 @@ fn basic_type_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
     debug!("basic_type_metadata: {:?}", t);
 
     let (name, encoding) = match t.sty {
-        ty::ty_tup(ref elements) if elements.is_empty() =>
+        ty::TyTuple(ref elements) if elements.is_empty() =>
             ("()".to_string(), DW_ATE_unsigned),
-        ty::ty_bool => ("bool".to_string(), DW_ATE_boolean),
-        ty::ty_char => ("char".to_string(), DW_ATE_unsigned_char),
-        ty::ty_int(int_ty) => match int_ty {
+        ty::TyBool => ("bool".to_string(), DW_ATE_boolean),
+        ty::TyChar => ("char".to_string(), DW_ATE_unsigned_char),
+        ty::TyInt(int_ty) => match int_ty {
             ast::TyIs => ("isize".to_string(), DW_ATE_signed),
             ast::TyI8 => ("i8".to_string(), DW_ATE_signed),
             ast::TyI16 => ("i16".to_string(), DW_ATE_signed),
             ast::TyI32 => ("i32".to_string(), DW_ATE_signed),
             ast::TyI64 => ("i64".to_string(), DW_ATE_signed)
         },
-        ty::ty_uint(uint_ty) => match uint_ty {
+        ty::TyUint(uint_ty) => match uint_ty {
             ast::TyUs => ("usize".to_string(), DW_ATE_unsigned),
             ast::TyU8 => ("u8".to_string(), DW_ATE_unsigned),
             ast::TyU16 => ("u16".to_string(), DW_ATE_unsigned),
             ast::TyU32 => ("u32".to_string(), DW_ATE_unsigned),
             ast::TyU64 => ("u64".to_string(), DW_ATE_unsigned)
         },
-        ty::ty_float(float_ty) => match float_ty {
+        ty::TyFloat(float_ty) => match float_ty {
             ast::TyF32 => ("f32".to_string(), DW_ATE_float),
             ast::TyF64 => ("f64".to_string(), DW_ATE_float),
         },
@@ -1179,7 +1179,7 @@ fn prepare_struct_metadata<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
     let mut fields = ty::struct_fields(cx.tcx(), def_id, substs);
 
     // The `Ty` values returned by `ty::struct_fields` can still contain
-    // `ty_projection` variants, so normalize those away.
+    // `TyProjection` variants, so normalize those away.
     for field in &mut fields {
         field.mt.ty = monomorphize::normalize_associated_type(cx.tcx(), &field.mt.ty);
     }

--- a/src/librustc_trans/trans/declare.rs
+++ b/src/librustc_trans/trans/declare.rs
@@ -114,10 +114,10 @@ pub fn declare_rust_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, name: &str,
 
     let function_type; // placeholder so that the memory ownership works out ok
     let (sig, abi, env) = match fn_type.sty {
-        ty::ty_bare_fn(_, ref f) => {
+        ty::TyBareFn(_, ref f) => {
             (&f.sig, f.abi, None)
         }
-        ty::ty_closure(closure_did, substs) => {
+        ty::TyClosure(closure_did, substs) => {
             let typer = common::NormalizingClosureTyper::new(ccx.tcx());
             function_type = typer.closure_type(closure_did, substs);
             let self_type = base::self_type_for_closure(ccx, closure_did, fn_type);

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -163,7 +163,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
     let _icx = push_ctxt("trans_intrinsic_call");
 
     let ret_ty = match callee_ty.sty {
-        ty::ty_bare_fn(_, ref f) => {
+        ty::TyBareFn(_, ref f) => {
             ty::erase_late_bound_regions(bcx.tcx(), &f.sig.output())
         }
         _ => panic!("expected bare_fn in trans_intrinsic_call")
@@ -755,7 +755,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         (_, "discriminant_value") => {
             let val_ty = substs.types.get(FnSpace, 0);
             match val_ty.sty {
-                ty::ty_enum(..) => {
+                ty::TyEnum(..) => {
                     let repr = adt::represent_type(ccx, *val_ty);
                     adt::trans_get_discr(bcx, &*repr, llargs[0], Some(llret_ty))
                 }

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -493,7 +493,7 @@ pub fn trans_trait_callee_from_llval<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
     // Replace the self type (&Self or Box<Self>) with an opaque pointer.
     let llcallee_ty = match callee_ty.sty {
-        ty::ty_bare_fn(_, ref f) if f.abi == Rust || f.abi == RustCall => {
+        ty::TyBareFn(_, ref f) if f.abi == Rust || f.abi == RustCall => {
             let fake_sig =
                 ty::Binder(ty::FnSig {
                     inputs: f.sig.0.inputs[1..].to_vec(),
@@ -563,7 +563,7 @@ pub fn trans_object_shim<'a, 'tcx>(
 
     let object_trait_ref =
         match object_ty.sty {
-            ty::ty_trait(ref data) => {
+            ty::TyTrait(ref data) => {
                 data.principal_trait_ref_with_self_ty(tcx, object_ty)
             }
             _ => {
@@ -624,7 +624,7 @@ pub fn trans_object_shim<'a, 'tcx>(
             RustCall => {
                 // unpack the tuple to extract the input type arguments:
                 match sig.inputs[1].sty {
-                    ty::ty_tup(ref tys) => &**tys,
+                    ty::TyTuple(ref tys) => &**tys,
                     _ => {
                         bcx.sess().bug(
                             &format!("rust-call expects a tuple not {}",

--- a/src/librustc_trans/trans/tvec.rs
+++ b/src/librustc_trans/trans/tvec.rs
@@ -310,15 +310,15 @@ pub fn get_base_and_len<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let ccx = bcx.ccx();
 
     match vec_ty.sty {
-        ty::ty_vec(_, Some(n)) => get_fixed_base_and_len(bcx, llval, n),
-        ty::ty_vec(_, None) | ty::ty_str => {
+        ty::TyArray(_, Some(n)) => get_fixed_base_and_len(bcx, llval, n),
+        ty::TyArray(_, None) | ty::TyStr => {
             let base = Load(bcx, expr::get_dataptr(bcx, llval));
             let len = Load(bcx, expr::get_len(bcx, llval));
             (base, len)
         }
 
         // Only used for pattern matching.
-        ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ty, ..}) => {
+        ty::TyBox(ty) | ty::TyRef(_, ty::mt{ty, ..}) => {
             let inner = if type_is_sized(bcx.tcx(), ty) {
                 Load(bcx, llval)
             } else {

--- a/src/librustc_trans/trans/type_of.rs
+++ b/src/librustc_trans/trans/type_of.rs
@@ -79,7 +79,7 @@ pub fn untuple_arguments_if_necessary<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     }
 
     match inputs[inputs.len() - 1].sty {
-        ty::ty_tup(ref tupled_arguments) => {
+        ty::TyTuple(ref tupled_arguments) => {
             debug!("untuple_arguments_if_necessary(): untupling arguments");
             for &tupled_argument in tupled_arguments {
                 result.push(tupled_argument);
@@ -147,7 +147,7 @@ pub fn type_of_rust_fn<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
 // Given a function type and a count of ty params, construct an llvm type
 pub fn type_of_fn_from_ty<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, fty: Ty<'tcx>) -> Type {
     match fty.sty {
-        ty::ty_bare_fn(_, ref f) => {
+        ty::TyBareFn(_, ref f) => {
             // FIXME(#19925) once fn item types are
             // zero-sized, we'll need to do something here
             if f.abi == abi::Rust || f.abi == abi::RustCall {
@@ -184,13 +184,13 @@ pub fn sizing_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> Typ
             Type::struct_(cx, &[Type::i8p(cx), Type::i8p(cx)], false)
         }
 
-        ty::ty_bool => Type::bool(cx),
-        ty::ty_char => Type::char(cx),
-        ty::ty_int(t) => Type::int_from_ty(cx, t),
-        ty::ty_uint(t) => Type::uint_from_ty(cx, t),
-        ty::ty_float(t) => Type::float_from_ty(cx, t),
+        ty::TyBool => Type::bool(cx),
+        ty::TyChar => Type::char(cx),
+        ty::TyInt(t) => Type::int_from_ty(cx, t),
+        ty::TyUint(t) => Type::uint_from_ty(cx, t),
+        ty::TyFloat(t) => Type::float_from_ty(cx, t),
 
-        ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ty, ..}) | ty::ty_ptr(ty::mt{ty, ..}) => {
+        ty::TyBox(ty) | ty::TyRef(_, ty::mt{ty, ..}) | ty::TyRawPtr(ty::mt{ty, ..}) => {
             if type_is_sized(cx.tcx(), ty) {
                 Type::i8p(cx)
             } else {
@@ -198,25 +198,25 @@ pub fn sizing_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> Typ
             }
         }
 
-        ty::ty_bare_fn(..) => Type::i8p(cx),
+        ty::TyBareFn(..) => Type::i8p(cx),
 
-        ty::ty_vec(ty, Some(size)) => {
+        ty::TyArray(ty, Some(size)) => {
             let llty = sizing_type_of(cx, ty);
             let size = size as u64;
             ensure_array_fits_in_address_space(cx, llty, size, t);
             Type::array(&llty, size)
         }
 
-        ty::ty_tup(ref tys) if tys.is_empty() => {
+        ty::TyTuple(ref tys) if tys.is_empty() => {
             Type::nil(cx)
         }
 
-        ty::ty_tup(..) | ty::ty_enum(..) | ty::ty_closure(..) => {
+        ty::TyTuple(..) | ty::TyEnum(..) | ty::TyClosure(..) => {
             let repr = adt::represent_type(cx, t);
             adt::sizing_type_of(cx, &*repr, false)
         }
 
-        ty::ty_struct(..) => {
+        ty::TyStruct(..) => {
             if ty::type_is_simd(cx.tcx(), t) {
                 let llet = type_of(cx, ty::simd_type(cx.tcx(), t));
                 let n = ty::simd_size(cx.tcx(), t) as u64;
@@ -228,11 +228,11 @@ pub fn sizing_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> Typ
             }
         }
 
-        ty::ty_projection(..) | ty::ty_infer(..) | ty::ty_param(..) | ty::ty_err(..) => {
+        ty::TyProjection(..) | ty::TyInfer(..) | ty::TyParam(..) | ty::TyError(..) => {
             cx.sess().bug(&format!("fictitious type {} in sizing_type_of()",
                                   ppaux::ty_to_string(cx.tcx(), t)))
         }
-        ty::ty_vec(_, None) | ty::ty_trait(..) | ty::ty_str => unreachable!()
+        ty::TyArray(_, None) | ty::TyTrait(..) | ty::TyStr => unreachable!()
     };
 
     cx.llsizingtypes().borrow_mut().insert(t, llsizingty);
@@ -323,12 +323,12 @@ pub fn in_memory_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> 
     }
 
     let mut llty = match t.sty {
-      ty::ty_bool => Type::bool(cx),
-      ty::ty_char => Type::char(cx),
-      ty::ty_int(t) => Type::int_from_ty(cx, t),
-      ty::ty_uint(t) => Type::uint_from_ty(cx, t),
-      ty::ty_float(t) => Type::float_from_ty(cx, t),
-      ty::ty_enum(did, ref substs) => {
+      ty::TyBool => Type::bool(cx),
+      ty::TyChar => Type::char(cx),
+      ty::TyInt(t) => Type::int_from_ty(cx, t),
+      ty::TyUint(t) => Type::uint_from_ty(cx, t),
+      ty::TyFloat(t) => Type::float_from_ty(cx, t),
+      ty::TyEnum(did, ref substs) => {
           // Only create the named struct, but don't fill it in. We
           // fill it in *after* placing it into the type cache. This
           // avoids creating more than one copy of the enum when one
@@ -338,7 +338,7 @@ pub fn in_memory_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> 
           let name = llvm_type_name(cx, did, tps);
           adt::incomplete_type_of(cx, &*repr, &name[..])
       }
-      ty::ty_closure(..) => {
+      ty::TyClosure(..) => {
           // Only create the named struct, but don't fill it in. We
           // fill it in *after* placing it into the type cache.
           let repr = adt::represent_type(cx, t);
@@ -349,9 +349,9 @@ pub fn in_memory_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> 
           adt::incomplete_type_of(cx, &*repr, "closure")
       }
 
-      ty::ty_uniq(ty) | ty::ty_rptr(_, ty::mt{ty, ..}) | ty::ty_ptr(ty::mt{ty, ..}) => {
+      ty::TyBox(ty) | ty::TyRef(_, ty::mt{ty, ..}) | ty::TyRawPtr(ty::mt{ty, ..}) => {
           if !type_is_sized(cx.tcx(), ty) {
-              if let ty::ty_str = ty.sty {
+              if let ty::TyStr = ty.sty {
                   // This means we get a nicer name in the output (str is always
                   // unsized).
                   cx.tn().find_type("str_slice").unwrap()
@@ -359,10 +359,10 @@ pub fn in_memory_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> 
                   let ptr_ty = in_memory_type_of(cx, ty).ptr_to();
                   let unsized_part = ty::struct_tail(cx.tcx(), ty);
                   let info_ty = match unsized_part.sty {
-                      ty::ty_str | ty::ty_vec(..) => {
+                      ty::TyStr | ty::TyArray(..) => {
                           Type::uint_from_ty(cx, ast::TyUs)
                       }
-                      ty::ty_trait(_) => Type::vtable_ptr(cx),
+                      ty::TyTrait(_) => Type::vtable_ptr(cx),
                       _ => panic!("Unexpected type returned from \
                                    struct_tail: {} for ty={}",
                                   unsized_part.repr(cx.tcx()), ty.repr(cx.tcx()))
@@ -374,7 +374,7 @@ pub fn in_memory_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> 
           }
       }
 
-      ty::ty_vec(ty, Some(size)) => {
+      ty::TyArray(ty, Some(size)) => {
           let size = size as u64;
           let llty = in_memory_type_of(cx, ty);
           ensure_array_fits_in_address_space(cx, llty, size, t);
@@ -385,18 +385,18 @@ pub fn in_memory_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> 
       // traits have the type of u8. This is so that the data pointer inside
       // fat pointers is of the right type (e.g. for array accesses), even
       // when taking the address of an unsized field in a struct.
-      ty::ty_vec(ty, None) => in_memory_type_of(cx, ty),
-      ty::ty_str | ty::ty_trait(..) => Type::i8(cx),
+      ty::TyArray(ty, None) => in_memory_type_of(cx, ty),
+      ty::TyStr | ty::TyTrait(..) => Type::i8(cx),
 
-      ty::ty_bare_fn(..) => {
+      ty::TyBareFn(..) => {
           type_of_fn_from_ty(cx, t).ptr_to()
       }
-      ty::ty_tup(ref tys) if tys.is_empty() => Type::nil(cx),
-      ty::ty_tup(..) => {
+      ty::TyTuple(ref tys) if tys.is_empty() => Type::nil(cx),
+      ty::TyTuple(..) => {
           let repr = adt::represent_type(cx, t);
           adt::type_of(cx, &*repr)
       }
-      ty::ty_struct(did, ref substs) => {
+      ty::TyStruct(did, ref substs) => {
           if ty::type_is_simd(cx.tcx(), t) {
               let llet = in_memory_type_of(cx, ty::simd_type(cx.tcx(), t));
               let n = ty::simd_size(cx.tcx(), t) as u64;
@@ -413,10 +413,10 @@ pub fn in_memory_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> 
           }
       }
 
-      ty::ty_infer(..) => cx.sess().bug("type_of with ty_infer"),
-      ty::ty_projection(..) => cx.sess().bug("type_of with ty_projection"),
-      ty::ty_param(..) => cx.sess().bug("type_of with ty_param"),
-      ty::ty_err(..) => cx.sess().bug("type_of with ty_err"),
+      ty::TyInfer(..) => cx.sess().bug("type_of with TyInfer"),
+      ty::TyProjection(..) => cx.sess().bug("type_of with TyProjection"),
+      ty::TyParam(..) => cx.sess().bug("type_of with ty_param"),
+      ty::TyError(..) => cx.sess().bug("type_of with TyError"),
     };
 
     debug!("--> mapped t={} {:?} to llty={}",
@@ -428,7 +428,7 @@ pub fn in_memory_type_of<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, t: Ty<'tcx>) -> 
 
     // If this was an enum or struct, fill in the type now.
     match t.sty {
-        ty::ty_enum(..) | ty::ty_struct(..) | ty::ty_closure(..)
+        ty::TyEnum(..) | ty::TyStruct(..) | ty::TyClosure(..)
                 if !ty::type_is_simd(cx.tcx(), t) => {
             let repr = adt::represent_type(cx, t);
             adt::finish_type_of(cx, &*repr, &mut llty);

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -127,12 +127,12 @@ fn try_overloaded_call_step<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 
     // If the callee is a bare function or a closure, then we're all set.
     match structurally_resolved_type(fcx, callee_expr.span, adjusted_ty).sty {
-        ty::ty_bare_fn(..) => {
+        ty::TyBareFn(..) => {
             fcx.write_autoderef_adjustment(callee_expr.id, autoderefs);
             return Some(CallStep::Builtin);
         }
 
-        ty::ty_closure(def_id, substs) => {
+        ty::TyClosure(def_id, substs) => {
             assert_eq!(def_id.krate, ast::LOCAL_CRATE);
 
             // Check whether this is a call to a closure where we
@@ -165,7 +165,7 @@ fn try_overloaded_call_step<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
         // over the top. The simplest fix by far is to just ignore
         // this case and deref again, so we wind up with
         // `FnMut::call_mut(&mut *x, ())`.
-        ty::ty_rptr(..) if autoderefs == 0 => {
+        ty::TyRef(..) if autoderefs == 0 => {
             return None;
         }
 
@@ -222,7 +222,7 @@ fn confirm_builtin_call<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
     let error_fn_sig;
 
     let fn_sig = match callee_ty.sty {
-        ty::ty_bare_fn(_, &ty::BareFnTy {ref sig, ..}) => {
+        ty::TyBareFn(_, &ty::BareFnTy {ref sig, ..}) => {
             sig
         }
         _ => {

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -74,17 +74,17 @@ fn unsize_kind<'a,'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                         t: Ty<'tcx>)
                         -> Option<UnsizeKind<'tcx>> {
     match t.sty {
-        ty::ty_vec(_, None) | ty::ty_str => Some(UnsizeKind::Length),
-        ty::ty_trait(_) => Some(UnsizeKind::Vtable),
-        ty::ty_struct(did, substs) => {
+        ty::TyArray(_, None) | ty::TyStr => Some(UnsizeKind::Length),
+        ty::TyTrait(_) => Some(UnsizeKind::Vtable),
+        ty::TyStruct(did, substs) => {
             match ty::struct_fields(fcx.tcx(), did, substs).pop() {
                 None => None,
                 Some(f) => unsize_kind(fcx, f.mt.ty)
             }
         }
         // We should really try to normalize here.
-        ty::ty_projection(ref pi) => Some(UnsizeKind::OfProjection(pi)),
-        ty::ty_param(ref p) => Some(UnsizeKind::OfParam(p)),
+        ty::TyProjection(ref pi) => Some(UnsizeKind::OfProjection(pi)),
+        ty::TyParam(ref p) => Some(UnsizeKind::OfParam(p)),
         _ => None
     }
 }
@@ -337,7 +337,7 @@ impl<'tcx> CastCheck<'tcx> {
         // array-ptr-cast.
 
         if m_expr.mutbl == ast::MutImmutable && m_cast.mutbl == ast::MutImmutable {
-            if let ty::ty_vec(ety, Some(_)) = m_expr.ty.sty {
+            if let ty::TyArray(ety, Some(_)) = m_expr.ty.sty {
                 // Due to the limitations of LLVM global constants,
                 // region pointers end up pointing at copies of
                 // vector elements instead of the original values.

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -107,7 +107,7 @@ fn deduce_expectations_from_expected_type<'a,'tcx>(
            expected_ty.repr(fcx.tcx()));
 
     match expected_ty.sty {
-        ty::ty_trait(ref object_type) => {
+        ty::TyTrait(ref object_type) => {
             let proj_bounds = object_type.projection_bounds_with_self_ty(fcx.tcx(),
                                                                          fcx.tcx().types.err);
             let sig = proj_bounds.iter()
@@ -116,7 +116,7 @@ fn deduce_expectations_from_expected_type<'a,'tcx>(
             let kind = fcx.tcx().lang_items.fn_trait_kind(object_type.principal_def_id());
             (sig, kind)
         }
-        ty::ty_infer(ty::TyVar(vid)) => {
+        ty::TyInfer(ty::TyVar(vid)) => {
             deduce_expectations_from_obligations(fcx, vid)
         }
         _ => {
@@ -214,7 +214,7 @@ fn deduce_sig_from_projection<'a,'tcx>(
     debug!("deduce_sig_from_projection: arg_param_ty {}", arg_param_ty.repr(tcx));
 
     let input_tys = match arg_param_ty.sty {
-        ty::ty_tup(ref tys) => { (*tys).clone() }
+        ty::TyTuple(ref tys) => { (*tys).clone() }
         _ => { return None; }
     };
     debug!("deduce_sig_from_projection: input_tys {}", input_tys.repr(tcx));
@@ -244,7 +244,7 @@ fn self_type_matches_expected_vid<'a,'tcx>(
            trait_ref.repr(fcx.tcx()),
            self_ty.repr(fcx.tcx()));
     match self_ty.sty {
-        ty::ty_infer(ty::TyVar(v)) if expected_vid == v => Some(trait_ref),
+        ty::TyInfer(ty::TyVar(v)) if expected_vid == v => Some(trait_ref),
         _ => None,
     }
 }

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -296,7 +296,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
     }
 
     fn extract_trait_ref<R, F>(&mut self, self_ty: Ty<'tcx>, mut closure: F) -> R where
-        F: FnMut(&mut ConfirmContext<'a, 'tcx>, Ty<'tcx>, &ty::TyTrait<'tcx>) -> R,
+        F: FnMut(&mut ConfirmContext<'a, 'tcx>, Ty<'tcx>, &ty::TraitTy<'tcx>) -> R,
     {
         // If we specified that this is an object method, then the
         // self-type ought to be something that can be dereferenced to
@@ -311,7 +311,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
                                               NoPreference,
                                               |ty, _| {
             match ty.sty {
-                ty::ty_trait(ref data) => Some(closure(self, ty, &**data)),
+                ty::TyTrait(ref data) => Some(closure(self, ty, &**data)),
                 _ => None,
             }
         });
@@ -456,12 +456,12 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
     fn fixup_derefs_on_method_receiver_if_necessary(&self,
                                                     method_callee: &MethodCallee) {
         let sig = match method_callee.ty.sty {
-            ty::ty_bare_fn(_, ref f) => f.sig.clone(),
+            ty::TyBareFn(_, ref f) => f.sig.clone(),
             _ => return,
         };
 
         match sig.0.inputs[0].sty {
-            ty::ty_rptr(_, ty::mt {
+            ty::TyRef(_, ty::mt {
                 ty: _,
                 mutbl: ast::MutMutable,
             }) => {}

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -254,7 +254,7 @@ pub fn lookup_in_trait_adjusted<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                     // Trait method is fn(&self) or fn(&mut self), need an
                     // autoref. Pull the region etc out of the type of first argument.
                     match transformed_self_ty.sty {
-                        ty::ty_rptr(region, ty::mt { mutbl, ty: _ }) => {
+                        ty::TyRef(region, ty::mt { mutbl, ty: _ }) => {
                             fcx.write_adjustment(self_expr.id,
                                 ty::AdjustDerefRef(ty::AutoDerefRef {
                                     autoderefs: autoderefs,

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -202,7 +202,7 @@ fn create_steps<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     });
 
     match final_ty.sty {
-        ty::ty_vec(elem_ty, Some(_)) => {
+        ty::TyArray(elem_ty, Some(_)) => {
             let slice_ty = ty::mk_vec(fcx.tcx(), elem_ty, None);
             steps.push(CandidateStep {
                 self_ty: slice_ty,
@@ -210,7 +210,7 @@ fn create_steps<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                 unsize: true
             });
         }
-        ty::ty_err => return None,
+        ty::TyError => return None,
         _ => (),
     }
 
@@ -270,88 +270,88 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
                self_ty.repr(self.tcx()));
 
         match self_ty.sty {
-            ty::ty_trait(box ref data) => {
+            ty::TyTrait(box ref data) => {
                 self.assemble_inherent_candidates_from_object(self_ty, data);
                 self.assemble_inherent_impl_candidates_for_type(data.principal_def_id());
             }
-            ty::ty_enum(did, _) |
-            ty::ty_struct(did, _) |
-            ty::ty_closure(did, _) => {
+            ty::TyEnum(did, _) |
+            ty::TyStruct(did, _) |
+            ty::TyClosure(did, _) => {
                 self.assemble_inherent_impl_candidates_for_type(did);
             }
-            ty::ty_uniq(_) => {
+            ty::TyBox(_) => {
                 if let Some(box_did) = self.tcx().lang_items.owned_box() {
                     self.assemble_inherent_impl_candidates_for_type(box_did);
                 }
             }
-            ty::ty_param(p) => {
+            ty::TyParam(p) => {
                 self.assemble_inherent_candidates_from_param(self_ty, p);
             }
-            ty::ty_char => {
+            ty::TyChar => {
                 let lang_def_id = self.tcx().lang_items.char_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_str => {
+            ty::TyStr => {
                 let lang_def_id = self.tcx().lang_items.str_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_vec(_, None) => {
+            ty::TyArray(_, None) => {
                 let lang_def_id = self.tcx().lang_items.slice_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_ptr(ty::mt { ty: _, mutbl: ast::MutImmutable }) => {
+            ty::TyRawPtr(ty::mt { ty: _, mutbl: ast::MutImmutable }) => {
                 let lang_def_id = self.tcx().lang_items.const_ptr_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_ptr(ty::mt { ty: _, mutbl: ast::MutMutable }) => {
+            ty::TyRawPtr(ty::mt { ty: _, mutbl: ast::MutMutable }) => {
                 let lang_def_id = self.tcx().lang_items.mut_ptr_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_int(ast::TyI8) => {
+            ty::TyInt(ast::TyI8) => {
                 let lang_def_id = self.tcx().lang_items.i8_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_int(ast::TyI16) => {
+            ty::TyInt(ast::TyI16) => {
                 let lang_def_id = self.tcx().lang_items.i16_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_int(ast::TyI32) => {
+            ty::TyInt(ast::TyI32) => {
                 let lang_def_id = self.tcx().lang_items.i32_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_int(ast::TyI64) => {
+            ty::TyInt(ast::TyI64) => {
                 let lang_def_id = self.tcx().lang_items.i64_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_int(ast::TyIs) => {
+            ty::TyInt(ast::TyIs) => {
                 let lang_def_id = self.tcx().lang_items.isize_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_uint(ast::TyU8) => {
+            ty::TyUint(ast::TyU8) => {
                 let lang_def_id = self.tcx().lang_items.u8_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_uint(ast::TyU16) => {
+            ty::TyUint(ast::TyU16) => {
                 let lang_def_id = self.tcx().lang_items.u16_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_uint(ast::TyU32) => {
+            ty::TyUint(ast::TyU32) => {
                 let lang_def_id = self.tcx().lang_items.u32_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_uint(ast::TyU64) => {
+            ty::TyUint(ast::TyU64) => {
                 let lang_def_id = self.tcx().lang_items.u64_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_uint(ast::TyUs) => {
+            ty::TyUint(ast::TyUs) => {
                 let lang_def_id = self.tcx().lang_items.usize_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_float(ast::TyF32) => {
+            ty::TyFloat(ast::TyF32) => {
                 let lang_def_id = self.tcx().lang_items.f32_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::ty_float(ast::TyF64) => {
+            ty::TyFloat(ast::TyF64) => {
                 let lang_def_id = self.tcx().lang_items.f64_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
@@ -413,7 +413,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
 
     fn assemble_inherent_candidates_from_object(&mut self,
                                                 self_ty: Ty<'tcx>,
-                                                data: &ty::TyTrait<'tcx>) {
+                                                data: &ty::TraitTy<'tcx>) {
         debug!("assemble_inherent_candidates_from_object(self_ty={})",
                self_ty.repr(self.tcx()));
 
@@ -460,7 +460,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
                 match *predicate {
                     ty::Predicate::Trait(ref trait_predicate) => {
                         match trait_predicate.0.trait_ref.self_ty().sty {
-                            ty::ty_param(ref p) if *p == param_ty => {
+                            ty::TyParam(ref p) if *p == param_ty => {
                                 Some(trait_predicate.to_poly_trait_ref())
                             }
                             _ => None
@@ -702,7 +702,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
         let steps = self.steps.clone();
         for step in steps.iter() {
             let closure_def_id = match step.self_ty.sty {
-                ty::ty_closure(a, _) => a,
+                ty::TyClosure(a, _) => a,
                 _ => continue,
             };
 
@@ -759,7 +759,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
                    step.repr(self.tcx()));
 
             let projection_trait_ref = match step.self_ty.sty {
-                ty::ty_projection(ref data) => &data.trait_ref,
+                ty::TyProjection(ref data) => &data.trait_ref,
                 _ => continue,
             };
 
@@ -924,7 +924,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
             pick.autoderefs = step.autoderefs;
 
             // Insert a `&*` or `&mut *` if this is a reference type:
-            if let ty::ty_rptr(_, mt) = step.self_ty.sty {
+            if let ty::TyRef(_, mt) = step.self_ty.sty {
                 pick.autoderefs += 1;
                 pick.autoref = Some(mt.mutbl);
             }

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -61,7 +61,7 @@ pub fn report_error<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                 None);
 
             // If the item has the name of a field, give a help note
-            if let (&ty::ty_struct(did, _), Some(_)) = (&rcvr_ty.sty, rcvr_expr) {
+            if let (&ty::TyStruct(did, _), Some(_)) = (&rcvr_ty.sty, rcvr_expr) {
                 let fields = ty::lookup_struct_fields(cx, did);
                 if fields.iter().any(|f| f.name == item_name) {
                     cx.sess.span_note(span,
@@ -238,11 +238,11 @@ fn type_derefs_to_local<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                                   rcvr_expr: Option<&ast::Expr>) -> bool {
     fn is_local(ty: Ty) -> bool {
         match ty.sty {
-            ty::ty_enum(did, _) | ty::ty_struct(did, _) => ast_util::is_local(did),
+            ty::TyEnum(did, _) | ty::TyStruct(did, _) => ast_util::is_local(did),
 
-            ty::ty_trait(ref tr) => ast_util::is_local(tr.principal_def_id()),
+            ty::TyTrait(ref tr) => ast_util::is_local(tr.principal_def_id()),
 
-            ty::ty_param(_) => true,
+            ty::TyParam(_) => true,
 
             // everything else (primitive types etc.) is effectively
             // non-local (there are "edge" cases, e.g. (LocalType,), but

--- a/src/librustc_typeck/check/wf.rs
+++ b/src/librustc_typeck/check/wf.rs
@@ -403,7 +403,7 @@ fn reject_non_type_param_bounds<'tcx>(tcx: &ty::ctxt<'tcx>,
 
     fn is_ty_param(ty: ty::Ty) -> bool {
         match &ty.sty {
-            &ty::sty::ty_param(_) => true,
+            &ty::TyParam(_) => true,
             _ => false
         }
     }
@@ -568,8 +568,8 @@ impl<'cx,'tcx> TypeFolder<'tcx> for BoundsChecker<'cx,'tcx> {
         }
 
         match t.sty{
-            ty::ty_struct(type_id, substs) |
-            ty::ty_enum(type_id, substs) => {
+            ty::TyStruct(type_id, substs) |
+            ty::TyEnum(type_id, substs) => {
                 let type_predicates = ty::lookup_predicates(self.fcx.tcx(), type_id);
                 let bounds = self.fcx.instantiate_bounds(self.span, substs,
                                                          &type_predicates);

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -69,129 +69,129 @@ impl<'cx, 'tcx> OrphanChecker<'cx, 'tcx> {
                 debug!("coherence2::orphan check: inherent impl {}", item.repr(self.tcx));
                 let self_ty = ty::lookup_item_type(self.tcx, def_id).ty;
                 match self_ty.sty {
-                    ty::ty_enum(def_id, _) |
-                    ty::ty_struct(def_id, _) => {
+                    ty::TyEnum(def_id, _) |
+                    ty::TyStruct(def_id, _) => {
                         self.check_def_id(item, def_id);
                     }
-                    ty::ty_trait(ref data) => {
+                    ty::TyTrait(ref data) => {
                         self.check_def_id(item, data.principal_def_id());
                     }
-                    ty::ty_uniq(..) => {
+                    ty::TyBox(..) => {
                         self.check_def_id(item, self.tcx.lang_items.owned_box().unwrap());
                     }
-                    ty::ty_char => {
+                    ty::TyChar => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.char_impl(),
                                                   "char",
                                                   "char",
                                                   item.span);
                     }
-                    ty::ty_str => {
+                    ty::TyStr => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.str_impl(),
                                                   "str",
                                                   "str",
                                                   item.span);
                     }
-                    ty::ty_vec(_, None) => {
+                    ty::TyArray(_, None) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.slice_impl(),
                                                   "slice",
                                                   "[T]",
                                                   item.span);
                     }
-                    ty::ty_ptr(ty::mt { ty: _, mutbl: ast::MutImmutable }) => {
+                    ty::TyRawPtr(ty::mt { ty: _, mutbl: ast::MutImmutable }) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.const_ptr_impl(),
                                                   "const_ptr",
                                                   "*const T",
                                                   item.span);
                     }
-                    ty::ty_ptr(ty::mt { ty: _, mutbl: ast::MutMutable }) => {
+                    ty::TyRawPtr(ty::mt { ty: _, mutbl: ast::MutMutable }) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.mut_ptr_impl(),
                                                   "mut_ptr",
                                                   "*mut T",
                                                   item.span);
                     }
-                    ty::ty_int(ast::TyI8) => {
+                    ty::TyInt(ast::TyI8) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.i8_impl(),
                                                   "i8",
                                                   "i8",
                                                   item.span);
                     }
-                    ty::ty_int(ast::TyI16) => {
+                    ty::TyInt(ast::TyI16) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.i16_impl(),
                                                   "i16",
                                                   "i16",
                                                   item.span);
                     }
-                    ty::ty_int(ast::TyI32) => {
+                    ty::TyInt(ast::TyI32) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.i32_impl(),
                                                   "i32",
                                                   "i32",
                                                   item.span);
                     }
-                    ty::ty_int(ast::TyI64) => {
+                    ty::TyInt(ast::TyI64) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.i64_impl(),
                                                   "i64",
                                                   "i64",
                                                   item.span);
                     }
-                    ty::ty_int(ast::TyIs) => {
+                    ty::TyInt(ast::TyIs) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.isize_impl(),
                                                   "isize",
                                                   "isize",
                                                   item.span);
                     }
-                    ty::ty_uint(ast::TyU8) => {
+                    ty::TyUint(ast::TyU8) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.u8_impl(),
                                                   "u8",
                                                   "u8",
                                                   item.span);
                     }
-                    ty::ty_uint(ast::TyU16) => {
+                    ty::TyUint(ast::TyU16) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.u16_impl(),
                                                   "u16",
                                                   "u16",
                                                   item.span);
                     }
-                    ty::ty_uint(ast::TyU32) => {
+                    ty::TyUint(ast::TyU32) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.u32_impl(),
                                                   "u32",
                                                   "u32",
                                                   item.span);
                     }
-                    ty::ty_uint(ast::TyU64) => {
+                    ty::TyUint(ast::TyU64) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.u64_impl(),
                                                   "u64",
                                                   "u64",
                                                   item.span);
                     }
-                    ty::ty_uint(ast::TyUs) => {
+                    ty::TyUint(ast::TyUs) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.usize_impl(),
                                                   "usize",
                                                   "usize",
                                                   item.span);
                     }
-                    ty::ty_float(ast::TyF32) => {
+                    ty::TyFloat(ast::TyF32) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.f32_impl(),
                                                   "f32",
                                                   "f32",
                                                   item.span);
                     }
-                    ty::ty_float(ast::TyF64) => {
+                    ty::TyFloat(ast::TyF64) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.f64_impl(),
                                                   "f64",
@@ -275,9 +275,9 @@ impl<'cx, 'tcx> OrphanChecker<'cx, 'tcx> {
                 {
                     let self_ty = trait_ref.self_ty();
                     let opt_self_def_id = match self_ty.sty {
-                        ty::ty_struct(self_def_id, _) | ty::ty_enum(self_def_id, _) =>
+                        ty::TyStruct(self_def_id, _) | ty::TyEnum(self_def_id, _) =>
                             Some(self_def_id),
-                        ty::ty_uniq(..) =>
+                        ty::TyBox(..) =>
                             self.tcx.lang_items.owned_box(),
                         _ =>
                             None

--- a/src/librustc_typeck/coherence/overlap.rs
+++ b/src/librustc_typeck/coherence/overlap.rs
@@ -198,7 +198,7 @@ impl<'cx, 'tcx,'v> visit::Visitor<'v> for OverlapChecker<'cx, 'tcx> {
                 let trait_ref = ty::impl_trait_ref(self.tcx, impl_def_id).unwrap();
                 let trait_def_id = trait_ref.def_id;
                 match trait_ref.self_ty().sty {
-                    ty::ty_trait(ref data) => {
+                    ty::TyTrait(ref data) => {
                         // This is something like impl Trait1 for Trait2. Illegal
                         // if Trait1 is a supertrait of Trait2 or Trait2 is not object safe.
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1882,7 +1882,7 @@ fn get_or_create_type_parameter_def<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
 
             ty::walk_ty(ty, |t| {
                 match t.sty {
-                    ty::ty_param(p) => if p.idx > cur_idx {
+                    ty::TyParam(p) => if p.idx > cur_idx {
                         span_err!(tcx.sess, path.span, E0128,
                                   "type parameters with a default cannot use \
                                    forward declared identifiers");
@@ -2174,8 +2174,8 @@ fn check_method_self_type<'a, 'tcx, RS:RegionScope>(
     if let ast::SelfExplicit(ref ast_type, _) = explicit_self.node {
         let typ = ccx.icx(&method_type.predicates).to_ty(rs, &**ast_type);
         let base_type = match typ.sty {
-            ty::ty_rptr(_, tm) => tm.ty,
-            ty::ty_uniq(typ) => typ,
+            ty::TyRef(_, tm) => tm.ty,
+            ty::TyBox(typ) => typ,
             _ => typ,
         };
 

--- a/src/librustc_typeck/constrained_type_params.rs
+++ b/src/librustc_typeck/constrained_type_params.rs
@@ -40,14 +40,14 @@ pub fn parameters_for_trait_ref<'tcx>(trait_ref: &ty::TraitRef<'tcx>) -> Vec<Par
 
 fn parameters_for_type_shallow<'tcx>(ty: Ty<'tcx>) -> Vec<Parameter> {
     match ty.sty {
-        ty::ty_param(ref d) =>
+        ty::TyParam(ref d) =>
             vec![Parameter::Type(d.clone())],
-        ty::ty_rptr(region, _) =>
+        ty::TyRef(region, _) =>
             parameters_for_region(region).into_iter().collect(),
-        ty::ty_struct(_, substs) |
-        ty::ty_enum(_, substs) =>
+        ty::TyStruct(_, substs) |
+        ty::TyEnum(_, substs) =>
             parameters_for_regions_in_substs(substs),
-        ty::ty_trait(ref data) =>
+        ty::TyTrait(ref data) =>
             parameters_for_regions_in_substs(&data.principal.skip_binder().substs),
         _ =>
             vec![],

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -212,7 +212,7 @@ fn check_main_fn_ty(ccx: &CrateCtxt,
     let tcx = ccx.tcx;
     let main_t = ty::node_id_to_type(tcx, main_id);
     match main_t.sty {
-        ty::ty_bare_fn(..) => {
+        ty::TyBareFn(..) => {
             match tcx.map.find(main_id) {
                 Some(ast_map::NodeItem(it)) => {
                     match it.node {
@@ -259,7 +259,7 @@ fn check_start_fn_ty(ccx: &CrateCtxt,
     let tcx = ccx.tcx;
     let start_t = ty::node_id_to_type(tcx, start_id);
     match start_t.sty {
-        ty::ty_bare_fn(..) => {
+        ty::TyBareFn(..) => {
             match tcx.map.find(start_id) {
                 Some(ast_map::NodeItem(it)) => {
                     match it.node {

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -167,7 +167,7 @@ pub fn build_external_trait(cx: &DocContext, tcx: &ty::ctxt,
 fn build_external_function(cx: &DocContext, tcx: &ty::ctxt, did: ast::DefId) -> clean::Function {
     let t = ty::lookup_item_type(tcx, did);
     let (decl, style, abi) = match t.ty.sty {
-        ty::ty_bare_fn(_, ref f) => ((did, &f.sig).clean(cx), f.unsafety, f.abi),
+        ty::TyBareFn(_, ref f) => ((did, &f.sig).clean(cx), f.unsafety, f.abi),
         _ => panic!("bad function"),
     };
     let predicates = ty::lookup_predicates(tcx, did);
@@ -204,7 +204,7 @@ fn build_type(cx: &DocContext, tcx: &ty::ctxt, did: ast::DefId) -> clean::ItemEn
     let t = ty::lookup_item_type(tcx, did);
     let predicates = ty::lookup_predicates(tcx, did);
     match t.ty.sty {
-        ty::ty_enum(edid, _) if !csearch::is_typedef(&tcx.sess.cstore, did) => {
+        ty::TyEnum(edid, _) if !csearch::is_typedef(&tcx.sess.cstore, did) => {
             return clean::EnumItem(clean::Enum {
                 generics: (&t.generics, &predicates, subst::TypeSpace).clean(cx),
                 variants_stripped: false,

--- a/src/test/auxiliary/issue13507.rs
+++ b/src/test/auxiliary/issue13507.rs
@@ -34,54 +34,54 @@ pub mod testtypes {
 
     // Skipping ty_bot
 
-    // Tests ty_bool
+    // Tests TyBool
     pub type FooBool = bool;
 
-    // Tests ty_char
+    // Tests TyChar
     pub type FooChar = char;
 
-    // Tests ty_int (does not test all variants of IntTy)
+    // Tests TyInt (does not test all variants of IntTy)
     pub type FooInt = isize;
 
-    // Tests ty_uint (does not test all variants of UintTy)
+    // Tests TyUint (does not test all variants of UintTy)
     pub type FooUint = usize;
 
-    // Tests ty_float (does not test all variants of FloatTy)
+    // Tests TyFloat (does not test all variants of FloatTy)
     pub type FooFloat = f64;
 
-    // For ty_str, what kind of string should I use? &'static str? String? Raw str?
+    // For TyStr, what kind of string should I use? &'static str? String? Raw str?
 
-    // Tests ty_enum
+    // Tests TyEnum
     pub enum FooEnum {
         VarA(usize),
         VarB(usize, usize)
     }
 
-    // Tests ty_uniq (of u8)
+    // Tests TyBox (of u8)
     pub type FooUniq = Box<u8>;
 
-    // As with ty_str, what type should be used for ty_vec?
+    // As with TyStr, what type should be used for TyArray?
 
-    // Tests ty_ptr
+    // Tests TyRawPtr
     pub type FooPtr = *const u8;
 
-    // Skipping ty_rptr
+    // Skipping TyRef
 
-    // Skipping ty_bare_fn (how do you get a bare function type, rather than proc or closure?)
+    // Skipping TyBareFn (how do you get a bare function type, rather than proc or closure?)
 
-    // Tests ty_trait
+    // Tests TyTrait
     pub trait FooTrait {
         fn foo_method(&self) -> usize;
         fn foo_static_method() -> usize;
     }
 
-    // Tests ty_struct
+    // Tests TyStruct
     pub struct FooStruct {
         pub pub_foo_field: usize,
         foo_field: usize
     }
 
-    // Tests ty_tup
+    // Tests TyTuple
     pub type FooTuple = (u8, i8, bool);
 
     // Skipping ty_param
@@ -90,7 +90,7 @@ pub mod testtypes {
 
     // Skipping ty_self
 
-    // Skipping ty_infer
+    // Skipping TyInfer
 
-    // Skipping ty_err
+    // Skipping TyError
 }

--- a/src/test/run-pass/unboxed-closures-unique-type-id.rs
+++ b/src/test/run-pass/unboxed-closures-unique-type-id.rs
@@ -12,7 +12,7 @@
 //
 //    error: internal compiler error: get_unique_type_id_of_type() -
 //    unexpected type: closure,
-//    ty_closure(syntax::ast::DefId{krate: 0, node: 66},
+//    TyClosure(syntax::ast::DefId{krate: 0, node: 66},
 //    ReScope(63))
 //
 // This is a regression test for issue #17021.


### PR DESCRIPTION
Use camel-case naming, and use names which actually make sense in modern Rust.
