### PR TITLE
rustc: --emit=rlibmeta outputs an rlib with only metadata, works with -Z no-trans.

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -251,8 +251,10 @@ fn encode_symbol(ecx: &EncodeContext,
             rbml_w.wr_tagged_str(tag_items_data_item_symbol, x);
         }
         None => {
-            ecx.diag.handler().bug(
-                &format!("encode_symbol: id not found {}", id));
+            if !ecx.tcx.sess.opts.no_trans {
+                ecx.diag.handler().bug(
+                    &format!("encode_symbol: id not found {}", id));
+            }
         }
     }
 }

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -620,7 +620,8 @@ pub fn run_passes(sess: &Session,
                 modules_config.emit_obj = true;
                 metadata_config.emit_obj = true;
             },
-            config::OutputTypeDepInfo => {}
+            config::OutputTypeDepInfo |
+            config::OutputTypeRlibMeta => {}
         }
     }
 
@@ -793,7 +794,8 @@ pub fn run_passes(sess: &Session,
                     link_obj(&crate_output.temp_path(config::OutputTypeObject));
                 }
             }
-            config::OutputTypeDepInfo => {}
+            config::OutputTypeDepInfo |
+            config::OutputTypeRlibMeta => {}
         }
     }
     let user_wants_bitcode = user_wants_bitcode;

--- a/src/librustc_trans/back/write.rs
+++ b/src/librustc_trans/back/write.rs
@@ -36,15 +36,6 @@ use std::sync::mpsc::channel;
 use std::thread;
 use libc::{self, c_uint, c_int, c_void};
 
-#[derive(Clone, Copy, PartialEq, PartialOrd, Ord, Eq)]
-pub enum OutputType {
-    OutputTypeBitcode,
-    OutputTypeAssembly,
-    OutputTypeLlvmAssembly,
-    OutputTypeObject,
-    OutputTypeExe,
-}
-
 pub fn llvm_err(handler: &diagnostic::Handler, msg: String) -> ! {
     unsafe {
         let cstr = llvm::LLVMRustGetLastError();

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -35,6 +35,7 @@ use lint;
 use llvm::{BasicBlockRef, Linkage, ValueRef, Vector, get_param};
 use llvm;
 use metadata::{csearch, encoder, loader};
+use metadata::common::LinkMeta;
 use middle::astencode;
 use middle::cfg;
 use middle::lang_items::{LangItem, ExchangeMallocFnLangItem, StartFnLangItem};
@@ -61,7 +62,7 @@ use trans::common::{node_id_type, return_type_is_void};
 use trans::common::{type_is_immediate, type_is_zero_size, val_ty};
 use trans::common;
 use trans::consts;
-use trans::context::SharedCrateContext;
+use trans::context::{self, SharedCrateContext};
 use trans::controlflow;
 use trans::datum;
 use trans::debuginfo::{self, DebugLoc, ToDebugLoc};
@@ -82,7 +83,7 @@ use trans::value::Value;
 use util::common::indenter;
 use util::ppaux::{Repr, ty_to_string};
 use util::sha2::Sha256;
-use util::nodemap::NodeMap;
+use util::nodemap::{NodeMap, NodeSet, FnvHashMap};
 
 use arena::TypedArena;
 use libc::c_uint;
@@ -2477,55 +2478,57 @@ fn register_method(ccx: &CrateContext, id: ast::NodeId,
     }
 }
 
-pub fn crate_ctxt_to_encode_parms<'a, 'tcx>(cx: &'a SharedCrateContext<'tcx>,
-                                            ie: encoder::EncodeInlinedItem<'a>)
-                                            -> encoder::EncodeParams<'a, 'tcx> {
-    encoder::EncodeParams {
-        diag: cx.sess().diagnostic(),
-        tcx: cx.tcx(),
-        reexports: cx.export_map(),
-        item_symbols: cx.item_symbols(),
-        link_meta: cx.link_meta(),
-        cstore: &cx.sess().cstore,
-        encode_inlined_item: ie,
-        reachable: cx.reachable(),
-    }
-}
-
-pub fn write_metadata(cx: &SharedCrateContext, krate: &ast::Crate) -> Vec<u8> {
+pub fn write_metadata(tcx: &ty::ctxt, link_meta: &LinkMeta,
+                      ccx: Option<&SharedCrateContext>)
+                      -> (Vec<u8>, ModuleTranslation) {
     use flate;
 
-    let any_library = cx.sess().crate_types.borrow().iter().any(|ty| {
+    let any_library = tcx.sess.crate_types.borrow().iter().any(|ty| {
         *ty != config::CrateTypeExecutable
     });
+
+    let (llcx, llmod) = context::create_context_and_module(&tcx.sess, "metadata");
+    let module = ModuleTranslation {
+        llcx: llcx,
+        llmod: llmod
+    };
     if !any_library {
-        return Vec::new()
+        return (vec![], module);
     }
 
-    let encode_inlined_item: encoder::EncodeInlinedItem =
-        Box::new(|ecx, rbml_w, ii| astencode::encode_inlined_item(ecx, rbml_w, ii));
-
-    let encode_parms = crate_ctxt_to_encode_parms(cx, encode_inlined_item);
-    let metadata = encoder::encode_metadata(encode_parms, krate);
+    let empty_reexports = FnvHashMap();
+    let empty_item_symbols = RefCell::new(NodeMap());
+    let empty_reachable = NodeSet();
+    let encode_parms = encoder::EncodeParams {
+        diag: tcx.sess.diagnostic(),
+        tcx: tcx,
+        reexports: ccx.map_or(&empty_reexports, |cx| cx.export_map()),
+        item_symbols: ccx.map_or(&empty_item_symbols, |cx| cx.item_symbols()),
+        link_meta: link_meta,
+        cstore: &tcx.sess.cstore,
+        encode_inlined_item: box astencode::encode_inlined_item,
+        reachable: ccx.map_or(&empty_reachable, |cx| cx.reachable()),
+    };
+    let metadata = encoder::encode_metadata(encode_parms, tcx.map.krate());
     let mut compressed = encoder::metadata_encoding_version.to_vec();
     compressed.push_all(&flate::deflate_bytes(&metadata));
-    let llmeta = C_bytes_in_context(cx.metadata_llcx(), &compressed[..]);
-    let llconst = C_struct_in_context(cx.metadata_llcx(), &[llmeta], false);
+
+    let llmeta = C_bytes_in_context(llcx, &compressed[..]);
+    let llconst = C_struct_in_context(llcx, &[llmeta], false);
     let name = format!("rust_metadata_{}_{}",
-                       cx.link_meta().crate_name,
-                       cx.link_meta().crate_hash);
+                       link_meta.crate_name,
+                       link_meta.crate_hash);
     let buf = CString::new(name).unwrap();
     let llglobal = unsafe {
-        llvm::LLVMAddGlobal(cx.metadata_llmod(), val_ty(llconst).to_ref(),
-                            buf.as_ptr())
+        llvm::LLVMAddGlobal(llmod, val_ty(llconst).to_ref(), buf.as_ptr())
     };
     unsafe {
         llvm::LLVMSetInitializer(llglobal, llconst);
-        let name = loader::meta_section_name(&cx.sess().target.target);
+        let name = loader::meta_section_name(&tcx.sess.target.target);
         let name = CString::new(name).unwrap();
         llvm::LLVMSetSection(llglobal, name.as_ptr())
     }
-    return metadata;
+    (metadata, module)
 }
 
 /// Find any symbols that are defined in one compilation unit, but not declared
@@ -2613,6 +2616,26 @@ fn internalize_symbols(cx: &SharedCrateContext, reachable: &HashSet<String>) {
     }
 }
 
+fn initialize_llvm(sess: &Session) {
+    // Before we touch LLVM, make sure that multithreading is enabled.
+    unsafe {
+        use std::sync::Once;
+        static INIT: Once = Once::new();
+        static mut POISONED: bool = false;
+        INIT.call_once(|| {
+            if llvm::LLVMStartMultithreaded() != 1 {
+                // use an extra bool to make sure that all future usage of LLVM
+                // cannot proceed despite the Once not running more than once.
+                POISONED = true;
+            }
+        });
+
+        if POISONED {
+            sess.bug("couldn't enable multi-threaded LLVM");
+        }
+    }
+}
+
 pub fn trans_crate<'tcx>(analysis: ty::CrateAnalysis<'tcx>)
                          -> (ty::ctxt<'tcx>, CrateTranslation) {
     let ty::CrateAnalysis { ty_cx: tcx, export_map, reachable, name, .. } = analysis;
@@ -2630,24 +2653,7 @@ pub fn trans_crate<'tcx>(analysis: ty::CrateAnalysis<'tcx>)
         tcx.sess.opts.debug_assertions
     };
 
-    // Before we touch LLVM, make sure that multithreading is enabled.
-    unsafe {
-        use std::sync::Once;
-        static INIT: Once = Once::new();
-        static mut POISONED: bool = false;
-        INIT.call_once(|| {
-            if llvm::LLVMStartMultithreaded() != 1 {
-                // use an extra bool to make sure that all future usage of LLVM
-                // cannot proceed despite the Once not running more than once.
-                POISONED = true;
-            }
-        });
-
-        if POISONED {
-            tcx.sess.bug("couldn't enable multi-threaded LLVM");
-        }
-    }
-
+    initialize_llvm(&tcx.sess);
     let link_meta = link::build_link_meta(&tcx.sess, krate, name);
 
     let codegen_units = tcx.sess.opts.cg.codegen_units;
@@ -2681,7 +2687,8 @@ pub fn trans_crate<'tcx>(analysis: ty::CrateAnalysis<'tcx>)
     }
 
     // Translate the metadata.
-    let metadata = write_metadata(&shared_ccx, krate);
+    let (metadata, metadata_module) = write_metadata(shared_ccx.tcx(), &link_meta,
+                                                     Some(&shared_ccx));
 
     if shared_ccx.sess().trans_stats() {
         let stats = shared_ccx.stats();
@@ -2748,10 +2755,6 @@ pub fn trans_crate<'tcx>(analysis: ty::CrateAnalysis<'tcx>)
         internalize_symbols(&shared_ccx, &reachable.iter().cloned().collect());
     }
 
-    let metadata_module = ModuleTranslation {
-        llcx: shared_ccx.metadata_llcx(),
-        llmod: shared_ccx.metadata_llmod(),
-    };
     let formats = shared_ccx.tcx().dependency_formats.borrow().clone();
     let no_builtins = attr::contains_name(&krate.attrs, "no_builtins");
 
@@ -2766,4 +2769,19 @@ pub fn trans_crate<'tcx>(analysis: ty::CrateAnalysis<'tcx>)
     };
 
     (shared_ccx.take_tcx(), translation)
+}
+
+pub fn trans_only_metadata(tcx: &ty::ctxt, name: String) -> CrateTranslation {
+    initialize_llvm(&tcx.sess);
+    let link_meta = link::build_link_meta(&tcx.sess, tcx.map.krate(), name);
+    let (metadata, metadata_module) = write_metadata(tcx, &link_meta, None);
+    CrateTranslation {
+        modules: vec![],
+        metadata_module: metadata_module,
+        link: link_meta,
+        metadata: metadata,
+        reachable: vec![],
+        crate_formats: tcx.dependency_formats.borrow().clone(),
+        no_builtins: true
+    }
 }

--- a/src/librustc_trans/trans/context.rs
+++ b/src/librustc_trans/trans/context.rs
@@ -60,9 +60,6 @@ pub struct Stats {
 pub struct SharedCrateContext<'tcx> {
     local_ccxs: Vec<LocalCrateContext<'tcx>>,
 
-    metadata_llmod: ModuleRef,
-    metadata_llcx: ContextRef,
-
     export_map: ExportMap,
     reachable: NodeSet,
     item_symbols: RefCell<NodeMap<String>>,
@@ -221,20 +218,21 @@ impl<'a, 'tcx> Iterator for CrateContextMaybeIterator<'a, 'tcx> {
     }
 }
 
+pub fn create_context_and_module(sess: &Session, mod_name: &str) -> (ContextRef, ModuleRef) {
+    unsafe {
+        let llcx = llvm::LLVMContextCreate();
+        let mod_name = CString::new(mod_name).unwrap();
+        let llmod = llvm::LLVMModuleCreateWithNameInContext(mod_name.as_ptr(), llcx);
 
-unsafe fn create_context_and_module(sess: &Session, mod_name: &str) -> (ContextRef, ModuleRef) {
-    let llcx = llvm::LLVMContextCreate();
-    let mod_name = CString::new(mod_name).unwrap();
-    let llmod = llvm::LLVMModuleCreateWithNameInContext(mod_name.as_ptr(), llcx);
+        let data_layout = sess.target.target.data_layout.as_bytes();
+        let data_layout = CString::new(data_layout).unwrap();
+        llvm::LLVMSetDataLayout(llmod, data_layout.as_ptr());
 
-    let data_layout = sess.target.target.data_layout.as_bytes();
-    let data_layout = CString::new(data_layout).unwrap();
-    llvm::LLVMSetDataLayout(llmod, data_layout.as_ptr());
-
-    let llvm_target = sess.target.target.llvm_target.as_bytes();
-    let llvm_target = CString::new(llvm_target).unwrap();
-    llvm::LLVMRustSetNormalizedTarget(llmod, llvm_target.as_ptr());
-    (llcx, llmod)
+        let llvm_target = sess.target.target.llvm_target.as_bytes();
+        let llvm_target = CString::new(llvm_target).unwrap();
+        llvm::LLVMRustSetNormalizedTarget(llmod, llvm_target.as_ptr());
+        (llcx, llmod)
+    }
 }
 
 impl<'tcx> SharedCrateContext<'tcx> {
@@ -248,10 +246,6 @@ impl<'tcx> SharedCrateContext<'tcx> {
                check_overflow: bool,
                check_drop_flag_for_sanity: bool)
                -> SharedCrateContext<'tcx> {
-        let (metadata_llcx, metadata_llmod) = unsafe {
-            create_context_and_module(&tcx.sess, "metadata")
-        };
-
         // An interesting part of Windows which MSVC forces our hand on (and
         // apparently MinGW didn't) is the usage of `dllimport` and `dllexport`
         // attributes in LLVM IR as well as native dependencies (in C these
@@ -299,8 +293,6 @@ impl<'tcx> SharedCrateContext<'tcx> {
 
         let mut shared_ccx = SharedCrateContext {
             local_ccxs: Vec::with_capacity(local_count),
-            metadata_llmod: metadata_llmod,
-            metadata_llcx: metadata_llcx,
             export_map: export_map,
             reachable: reachable,
             item_symbols: RefCell::new(NodeMap()),
@@ -372,14 +364,6 @@ impl<'tcx> SharedCrateContext<'tcx> {
     }
 
 
-    pub fn metadata_llmod(&self) -> ModuleRef {
-        self.metadata_llmod
-    }
-
-    pub fn metadata_llcx(&self) -> ContextRef {
-        self.metadata_llcx
-    }
-
     pub fn export_map<'a>(&'a self) -> &'a ExportMap {
         &self.export_map
     }
@@ -390,10 +374,6 @@ impl<'tcx> SharedCrateContext<'tcx> {
 
     pub fn item_symbols<'a>(&'a self) -> &'a RefCell<NodeMap<String>> {
         &self.item_symbols
-    }
-
-    pub fn link_meta<'a>(&'a self) -> &'a LinkMeta {
-        &self.link_meta
     }
 
     pub fn tcx<'a>(&'a self) -> &'a ty::ctxt<'tcx> {
@@ -421,9 +401,8 @@ impl<'tcx> LocalCrateContext<'tcx> {
     fn new(shared: &SharedCrateContext<'tcx>,
            name: &str)
            -> LocalCrateContext<'tcx> {
+        let (llcx, llmod) = create_context_and_module(&shared.tcx.sess, name);
         unsafe {
-            let (llcx, llmod) = create_context_and_module(&shared.tcx.sess, name);
-
             let td = mk_target_data(&shared.tcx
                                           .sess
                                           .target

--- a/src/librustc_trans/trans/mod.rs
+++ b/src/librustc_trans/trans/mod.rs
@@ -12,7 +12,7 @@ use llvm::{ContextRef, ModuleRef};
 use metadata::common::LinkMeta;
 use middle::dependency_format;
 
-pub use self::base::trans_crate;
+pub use self::base::{trans_crate, trans_only_metadata};
 pub use self::context::CrateContext;
 pub use self::common::gensym_name;
 


### PR DESCRIPTION
Useful for running analysis passes on downstream crates without actually doing codegen.
cc @bstrie who wants to use this for a `cargo check` command.
