### PR TITLE
re-enable 'html literals' macro test

### DIFF
--- a/src/test/run-pass/html-literals.rs
+++ b/src/test/run-pass/html-literals.rs
@@ -10,8 +10,6 @@
 
 // A test of the macro system. Can we do HTML literals?
 
-// ignore-test FIXME #20673
-
 /*
 
 This is an HTML parser written as a macro. It's all CPS, and we have


### PR DESCRIPTION
This test now works again

Fixes #20673

r? @alexcrichton 
