### PR TITLE
mk: Build crates with relative paths to rustc

### DIFF
--- a/configure
+++ b/configure
@@ -521,6 +521,7 @@ fi
 DEFAULT_BUILD="${CFG_CPUTYPE}-${CFG_OSTYPE}"
 
 CFG_SRC_DIR="$(abs_path $(dirname $0))/"
+CFG_SRC_DIR_RELATIVE="$(dirname $0)/"
 CFG_BUILD_DIR="$(pwd)/"
 CFG_SELF="$0"
 CFG_CONFIGURE_ARGS="$@"
@@ -1558,6 +1559,7 @@ done
 step_msg "writing configuration"
 
 putvar CFG_SRC_DIR
+putvar CFG_SRC_DIR_RELATIVE
 putvar CFG_BUILD_DIR
 putvar CFG_OSTYPE
 putvar CFG_CPUTYPE

--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -134,7 +134,7 @@ DOC_CRATES := std alloc collections core libc rustc_unicode
 #
 # $(1) is the crate to generate variables for
 define RUST_CRATE
-CRATEFILE_$(1) := $$(S)src/lib$(1)/lib.rs
+CRATEFILE_$(1) := $$(SREL)src/lib$(1)/lib.rs
 RSINPUTS_$(1) := $$(call rwildcard,$(S)src/lib$(1)/,*.rs)
 RUST_DEPS_$(1) := $$(filter-out native:%,$$(DEPS_$(1)))
 NATIVE_DEPS_$(1) := $$(patsubst native:%,%,$$(filter native:%,$$(DEPS_$(1))))

--- a/mk/main.mk
+++ b/mk/main.mk
@@ -322,6 +322,7 @@ $(foreach host,$(CFG_HOST), \
 # exported
 
 export CFG_SRC_DIR
+export CFG_SRC_DIR_RELATIVE
 export CFG_BUILD_DIR
 ifdef CFG_VER_DATE
 export CFG_VER_DATE

--- a/mk/reconfig.mk
+++ b/mk/reconfig.mk
@@ -34,4 +34,4 @@ Makefile config.mk: config.stamp
 
 config.stamp: $(S)configure $(S)Makefile.in $(S)src/snapshots.txt
 	@$(call E, cfg: reconfiguring)
-	$(S)configure $(CFG_CONFIGURE_ARGS)
+	$(SREL)configure $(CFG_CONFIGURE_ARGS)

--- a/mk/util.mk
+++ b/mk/util.mk
@@ -20,3 +20,4 @@ print-%:
 	@echo $*=$($*)
 
 S := $(CFG_SRC_DIR)
+SREL := $(CFG_SRC_DIR_RELATIVE)


### PR DESCRIPTION
mk: Build crates with relative source file paths

The path we pass to rustc will be visible in panic messages and
backtraces: they will be user visible!

Avoid junk in these paths by passing relative paths to rustc.

For most advanced users, `libcore` or `libstd` in the path will be
a clue to the location -- inside our code, not theirs.

Store both the relative path to the source as well as the absolute.
Use the relative path where it matters, compiling the main crates,
instead of changing all of the build process to cope with relative
paths.

Example output after this patch:

```
$ ./testunwrap
thread '<main>' panicked at 'called `Option::unwrap()` on a `None` value', ../src/libcore/option.rs:362
$ RUST_BACKTRACE=1 ./testunwrap
thread '<main>' panicked at 'called `Option::unwrap()` on a `None` value', ../src/libcore/option.rs:362
stack backtrace:
   1:     0x7ff59c1e9956 - sys::backtrace::write::h67a542fd2b201576des
                        at ../src/libstd/sys/unix/backtrace.rs:158
   2:     0x7ff59c1ed5b6 - panicking::on_panic::h3d21c41cdd5c12d41Xw
                        at ../src/libstd/panicking.rs:58
   3:     0x7ff59c1e7b6e - rt::unwind::begin_unwind_inner::h9f3a5440cebb8baeLDw
                        at ../src/libstd/rt/unwind/mod.rs:273
   4:     0x7ff59c1e7f84 - rt::unwind::begin_unwind_fmt::h4fe8a903e0c296b0RCw
                        at ../src/libstd/rt/unwind/mod.rs:212
   5:     0x7ff59c1eced7 - rust_begin_unwind
   6:     0x7ff59c22c11a - panicking::panic_fmt::h00b0cd49c98a9220i5B
                        at ../src/libcore/panicking.rs:64
   7:     0x7ff59c22b9e0 - panicking::panic::hf549420c0ee03339P3B
                        at ../src/libcore/panicking.rs:45
   8:     0x7ff59c1e621d - option::Option<T>::unwrap::h501963526474862829
   9:     0x7ff59c1e61b1 - main::hb5c91ce92347d1e6eaa
  10:     0x7ff59c1f1c18 - rust_try_inner
  11:     0x7ff59c1f1c05 - rust_try
  12:     0x7ff59c1ef374 - rt::lang_start::h7e51e19c6677cffe5Sw
                        at ../src/libstd/rt/unwind/mod.rs:147
                        at ../src/libstd/rt/unwind/mod.rs:130
                        at ../src/libstd/rt/mod.rs:128
  13:     0x7ff59c1e628e - main
  14:     0x7ff59b3f6b44 - __libc_start_main
  15:     0x7ff59c1e6078 - <unknown>
  16:                0x0 - <unknown>
```
