### PR TITLE
Split TyArray into TyArray and TySlice.

### DIFF
--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -113,11 +113,12 @@ pub fn enc_ty<'a, 'tcx>(w: &mut Encoder, cx: &ctxt<'a, 'tcx>, t: Ty<'tcx>) {
         ty::TyArray(t, sz) => {
             mywrite!(w, "V");
             enc_ty(w, cx, t);
-            mywrite!(w, "/");
-            match sz {
-                Some(n) => mywrite!(w, "{}|", n),
-                None => mywrite!(w, "|"),
-            }
+            mywrite!(w, "/{}|", sz);
+        }
+        ty::TySlice(t) => {
+            mywrite!(w, "V");
+            enc_ty(w, cx, t);
+            mywrite!(w, "/|");
         }
         ty::TyStr => {
             mywrite!(w, "v");

--- a/src/librustc/middle/fast_reject.rs
+++ b/src/librustc/middle/fast_reject.rs
@@ -55,7 +55,7 @@ pub fn simplify_type(tcx: &ty::ctxt,
         ty::TyFloat(float_type) => Some(FloatSimplifiedType(float_type)),
         ty::TyEnum(def_id, _) => Some(EnumSimplifiedType(def_id)),
         ty::TyStr => Some(StrSimplifiedType),
-        ty::TyArray(..) => Some(VecSimplifiedType),
+        ty::TyArray(..) | ty::TySlice(_) => Some(VecSimplifiedType),
         ty::TyRawPtr(_) => Some(PtrSimplifiedType),
         ty::TyTrait(ref trait_info) => {
             Some(TraitSimplifiedType(trait_info.principal_def_id()))

--- a/src/librustc/middle/implicator.rs
+++ b/src/librustc/middle/implicator.rs
@@ -117,6 +117,7 @@ impl<'a, 'tcx> Implicator<'a, 'tcx> {
             }
 
             ty::TyArray(t, _) |
+            ty::TySlice(t) |
             ty::TyRawPtr(ty::mt { ty: t, .. }) |
             ty::TyBox(t) => {
                 self.accumulate_from_ty(t)

--- a/src/librustc/middle/infer/freshen.rs
+++ b/src/librustc/middle/infer/freshen.rs
@@ -159,6 +159,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
             ty::TyStr |
             ty::TyError |
             ty::TyArray(..) |
+            ty::TySlice(..) |
             ty::TyRawPtr(..) |
             ty::TyRef(..) |
             ty::TyBareFn(..) |

--- a/src/librustc/middle/traits/coherence.rs
+++ b/src/librustc/middle/traits/coherence.rs
@@ -306,6 +306,7 @@ fn ty_is_local_constructor<'tcx>(tcx: &ty::ctxt<'tcx>,
         ty::TyStr(..) |
         ty::TyBareFn(..) |
         ty::TyArray(..) |
+        ty::TySlice(..) |
         ty::TyRawPtr(..) |
         ty::TyRef(..) |
         ty::TyTuple(..) |

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -599,6 +599,9 @@ pub fn super_fold_ty<'tcx, T: TypeFolder<'tcx>>(this: &mut T,
         ty::TyArray(typ, sz) => {
             ty::TyArray(typ.fold_with(this), sz)
         }
+        ty::TySlice(typ) => {
+            ty::TySlice(typ.fold_with(this))
+        }
         ty::TyEnum(tid, ref substs) => {
             let substs = substs.fold_with(this);
             ty::TyEnum(tid, this.tcx().mk_substs(substs))

--- a/src/librustc/middle/ty_relate/mod.rs
+++ b/src/librustc/middle/ty_relate/mod.rs
@@ -518,7 +518,7 @@ pub fn super_relate_tys<'a,'tcx:'a,R>(relation: &mut R,
             Ok(ty::mk_rptr(tcx, tcx.mk_region(r), mt))
         }
 
-        (&ty::TyArray(a_t, Some(sz_a)), &ty::TyArray(b_t, Some(sz_b))) =>
+        (&ty::TyArray(a_t, sz_a), &ty::TyArray(b_t, sz_b)) =>
         {
             let t = try!(relation.relate(&a_t, &b_t));
             if sz_a == sz_b {
@@ -528,7 +528,7 @@ pub fn super_relate_tys<'a,'tcx:'a,R>(relation: &mut R,
             }
         }
 
-        (&ty::TyArray(a_t, None), &ty::TyArray(b_t, None)) =>
+        (&ty::TySlice(a_t), &ty::TySlice(b_t)) =>
         {
             let t = try!(relation.relate(&a_t, &b_t));
             Ok(ty::mk_vec(tcx, t, None))

--- a/src/librustc/middle/ty_walk.rs
+++ b/src/librustc/middle/ty_walk.rs
@@ -71,7 +71,7 @@ fn push_subtypes<'tcx>(stack: &mut Vec<Ty<'tcx>>, parent_ty: Ty<'tcx>) {
         ty::TyBool | ty::TyChar | ty::TyInt(_) | ty::TyUint(_) | ty::TyFloat(_) |
         ty::TyStr | ty::TyInfer(_) | ty::TyParam(_) | ty::TyError => {
         }
-        ty::TyBox(ty) | ty::TyArray(ty, _) => {
+        ty::TyBox(ty) | ty::TyArray(ty, _) | ty::TySlice(ty) => {
             stack.push(ty);
         }
         ty::TyRawPtr(ref mt) | ty::TyRef(_, ref mt) => {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -20,7 +20,7 @@ use middle::ty::{ReFree, ReScope, ReInfer, ReStatic, Region, ReEmpty};
 use middle::ty::{ReSkolemized, ReVar, BrEnv};
 use middle::ty::{mt, Ty, ParamTy};
 use middle::ty::{TyBool, TyChar, TyStruct, TyEnum};
-use middle::ty::{TyError, TyStr, TyArray, TyFloat, TyBareFn};
+use middle::ty::{TyError, TyStr, TyArray, TySlice, TyFloat, TyBareFn};
 use middle::ty::{TyParam, TyRawPtr, TyRef, TyTuple};
 use middle::ty::TyClosure;
 use middle::ty::{TyBox, TyTrait, TyInt, TyUint, TyInfer};
@@ -432,11 +432,10 @@ pub fn ty_to_string<'tcx>(cx: &ctxt<'tcx>, typ: &ty::TyS<'tcx>) -> String {
             })
         }
         TyArray(t, sz) => {
-            let inner_str = ty_to_string(cx, t);
-            match sz {
-                Some(n) => format!("[{}; {}]", inner_str, n),
-                None => format!("[{}]", inner_str),
-            }
+            format!("[{}; {}]", ty_to_string(cx, t), sz)
+        }
+        TySlice(t) => {
+            format!("[{}]", ty_to_string(cx, t))
         }
     }
 }

--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -852,7 +852,7 @@ fn compare_values<'blk, 'tcx>(cx: Block<'blk, 'tcx>,
     match rhs_t.sty {
         ty::TyRef(_, mt) => match mt.ty.sty {
             ty::TyStr => compare_str(cx, lhs, rhs, rhs_t, debug_loc),
-            ty::TyArray(ty, _) => match ty.sty {
+            ty::TyArray(ty, _) | ty::TySlice(ty) => match ty.sty {
                 ty::TyUint(ast::TyU8) => {
                     // NOTE: cast &[u8] and &[u8; N] to &str and abuse the str_eq lang item,
                     // which calls memcmp().
@@ -1116,7 +1116,7 @@ fn compile_submatch_continue<'a, 'p, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         Some(vec!(Load(bcx, val)))
     } else {
         match left_ty.sty {
-            ty::TyArray(_, Some(n)) => {
+            ty::TyArray(_, n) => {
                 let args = extract_vec_elems(bcx, left_ty, n, 0, val);
                 Some(args.vals)
             }

--- a/src/librustc_trans/trans/adt.rs
+++ b/src/librustc_trans/trans/adt.rs
@@ -472,7 +472,7 @@ fn find_discr_field_candidate<'tcx>(tcx: &ty::ctxt<'tcx>,
 
         // Is this a fixed-size array of something non-zero
         // with at least one element?
-        ty::TyArray(ety, Some(d)) if d > 0 => {
+        ty::TyArray(ety, d) if d > 0 => {
             if let Some(mut vpath) = find_discr_field_candidate(tcx, ety, path) {
                 vpath.push(0);
                 Some(vpath)

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -444,12 +444,12 @@ pub fn iter_structural_ty<'blk, 'tcx, F>(cx: Block<'blk, 'tcx>,
               cx = f(cx, llupvar, upvar.ty);
           }
       }
-      ty::TyArray(_, Some(n)) => {
+      ty::TyArray(_, n) => {
         let (base, len) = tvec::get_fixed_base_and_len(cx, data_ptr, n);
         let unit_ty = ty::sequence_element_type(cx.tcx(), t);
         cx = tvec::iter_vec_raw(cx, base, unit_ty, len, f);
       }
-      ty::TyArray(_, None) | ty::TyStr => {
+      ty::TySlice(_) | ty::TyStr => {
         let unit_ty = ty::sequence_element_type(cx.tcx(), t);
         cx = tvec::iter_vec_raw(cx, data_ptr, unit_ty, info.unwrap(), f);
       }

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -246,7 +246,7 @@ pub fn type_is_immediate<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>, ty: Ty<'tcx>) -
         return false;
     }
     match ty.sty {
-        ty::TyStruct(..) | ty::TyEnum(..) | ty::TyTuple(..) | ty::TyArray(_, Some(_)) |
+        ty::TyStruct(..) | ty::TyEnum(..) | ty::TyTuple(..) | ty::TyArray(_, _) |
         ty::TyClosure(..) => {
             let llty = sizing_type_of(ccx, ty);
             llsize_of_alloc(ccx, llty) <= llsize_of_alloc(ccx, ccx.int_type())

--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -609,13 +609,13 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
                                           "index is not an integer-constant expression")
               };
               let (arr, len) = match bt.sty {
-                  ty::TyArray(_, Some(u)) => (bv, C_uint(cx, u)),
-                  ty::TyArray(_, None) | ty::TyStr => {
+                  ty::TyArray(_, u) => (bv, C_uint(cx, u)),
+                  ty::TySlice(_) | ty::TyStr => {
                       let e1 = const_get_elt(cx, bv, &[0]);
                       (const_deref_ptr(cx, e1), const_get_elt(cx, bv, &[1]))
                   }
                   ty::TyRef(_, mt) => match mt.ty.sty {
-                      ty::TyArray(_, Some(u)) => {
+                      ty::TyArray(_, u) => {
                           (const_deref_ptr(cx, bv), C_uint(cx, u))
                       },
                       _ => cx.sess().span_bug(base.span,

--- a/src/librustc_trans/trans/debuginfo/type_names.rs
+++ b/src/librustc_trans/trans/debuginfo/type_names.rs
@@ -94,17 +94,15 @@ pub fn push_debuginfo_type_name<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
 
             push_debuginfo_type_name(cx, inner_type, true, output);
         },
-        ty::TyArray(inner_type, optional_length) => {
+        ty::TyArray(inner_type, len) => {
             output.push('[');
             push_debuginfo_type_name(cx, inner_type, true, output);
-
-            match optional_length {
-                Some(len) => {
-                    output.push_str(&format!("; {}", len));
-                }
-                None => { /* nothing to do */ }
-            };
-
+            output.push_str(&format!("; {}", len));
+            output.push(']');
+        },
+        ty::TySlice(inner_type) => {
+            output.push('[');
+            push_debuginfo_type_name(cx, inner_type, true, output);
             output.push(']');
         },
         ty::TyTrait(ref trait_data) => {

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -313,7 +313,7 @@ pub fn unsized_info<'ccx, 'tcx>(ccx: &CrateContext<'ccx, 'tcx>,
                                 -> ValueRef {
     let (source, target) = ty::struct_lockstep_tails(ccx.tcx(), source, target);
     match (&source.sty, &target.sty) {
-        (&ty::TyArray(_, Some(len)), &ty::TyArray(_, None)) => C_uint(ccx, len),
+        (&ty::TyArray(_, len), &ty::TySlice(_)) => C_uint(ccx, len),
         (&ty::TyTrait(_), &ty::TyTrait(_)) => {
             // For now, upcasts are limited to changes in marker
             // traits, and hence never actually require an actual

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -435,7 +435,7 @@ pub fn size_and_align_of_dst<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, t: Ty<'tcx>, in
             let align_ptr = GEPi(bcx, info, &[2]);
             (Load(bcx, size_ptr), Load(bcx, align_ptr))
         }
-        ty::TyArray(_, None) | ty::TyStr => {
+        ty::TySlice(_) | ty::TyStr => {
             let unit_ty = ty::sequence_element_type(bcx.tcx(), t);
             // The info in this case is the length of the str, so the size is that
             // times the unit size.

--- a/src/librustc_trans/trans/tvec.rs
+++ b/src/librustc_trans/trans/tvec.rs
@@ -310,8 +310,8 @@ pub fn get_base_and_len<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let ccx = bcx.ccx();
 
     match vec_ty.sty {
-        ty::TyArray(_, Some(n)) => get_fixed_base_and_len(bcx, llval, n),
-        ty::TyArray(_, None) | ty::TyStr => {
+        ty::TyArray(_, n) => get_fixed_base_and_len(bcx, llval, n),
+        ty::TySlice(_) | ty::TyStr => {
             let base = Load(bcx, expr::get_dataptr(bcx, llval));
             let len = Load(bcx, expr::get_len(bcx, llval));
             (base, len)

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -59,7 +59,7 @@ pub fn check_pat<'a, 'tcx>(pcx: &pat_ctxt<'a, 'tcx>,
                 if let ast::LitBinary(_) = lt.node {
                     let expected_ty = structurally_resolved_type(fcx, pat.span, expected);
                     if let ty::TyRef(_, mt) = expected_ty.sty {
-                        if let ty::TyArray(_, None) = mt.ty.sty {
+                        if let ty::TySlice(_) = mt.ty.sty {
                             pat_ty = ty::mk_slice(tcx, tcx.mk_region(ty::ReStatic),
                                 ty::mt{ ty: tcx.types.u8, mutbl: ast::MutImmutable })
                         }
@@ -293,7 +293,7 @@ pub fn check_pat<'a, 'tcx>(pcx: &pat_ctxt<'a, 'tcx>,
             let expected_ty = structurally_resolved_type(fcx, pat.span, expected);
             let inner_ty = fcx.infcx().next_ty_var();
             let pat_ty = match expected_ty.sty {
-                ty::TyArray(_, Some(size)) => ty::mk_vec(tcx, inner_ty, Some({
+                ty::TyArray(_, size) => ty::mk_vec(tcx, inner_ty, Some({
                     let min_len = before.len() + after.len();
                     match *slice {
                         Some(_) => cmp::max(min_len, size),

--- a/src/librustc_typeck/check/cast.rs
+++ b/src/librustc_typeck/check/cast.rs
@@ -74,7 +74,7 @@ fn unsize_kind<'a,'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                         t: Ty<'tcx>)
                         -> Option<UnsizeKind<'tcx>> {
     match t.sty {
-        ty::TyArray(_, None) | ty::TyStr => Some(UnsizeKind::Length),
+        ty::TySlice(_) | ty::TyStr => Some(UnsizeKind::Length),
         ty::TyTrait(_) => Some(UnsizeKind::Vtable),
         ty::TyStruct(did, substs) => {
             match ty::struct_fields(fcx.tcx(), did, substs).pop() {
@@ -337,7 +337,7 @@ impl<'tcx> CastCheck<'tcx> {
         // array-ptr-cast.
 
         if m_expr.mutbl == ast::MutImmutable && m_cast.mutbl == ast::MutImmutable {
-            if let ty::TyArray(ety, Some(_)) = m_expr.ty.sty {
+            if let ty::TyArray(ety, _) = m_expr.ty.sty {
                 // Due to the limitations of LLVM global constants,
                 // region pointers end up pointing at copies of
                 // vector elements instead of the original values.

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -202,7 +202,7 @@ fn create_steps<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     });
 
     match final_ty.sty {
-        ty::TyArray(elem_ty, Some(_)) => {
+        ty::TyArray(elem_ty, _) => {
             let slice_ty = ty::mk_vec(fcx.tcx(), elem_ty, None);
             steps.push(CandidateStep {
                 self_ty: slice_ty,
@@ -295,7 +295,7 @@ impl<'a,'tcx> ProbeContext<'a,'tcx> {
                 let lang_def_id = self.tcx().lang_items.str_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }
-            ty::TyArray(_, None) => {
+            ty::TySlice(_) => {
                 let lang_def_id = self.tcx().lang_items.slice_impl();
                 self.assemble_inherent_impl_for_primitive(lang_def_id);
             }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2095,7 +2095,7 @@ fn lookup_indexing<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 
     // After we have fully autoderef'd, if the resulting type is [T; n], then
     // do a final unsized coercion to yield [T].
-    if let ty::TyArray(element_ty, Some(_)) = ty.sty {
+    if let ty::TyArray(element_ty, _) = ty.sty {
         let adjusted_ty = ty::mk_vec(fcx.tcx(), element_ty, None);
         try_index_step(fcx, MethodCall::expr(expr.id), expr, base_expr,
                        adjusted_ty, autoderefs, true, lvalue_pref, idx_ty)
@@ -3452,7 +3452,7 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
       ast::ExprVec(ref args) => {
         let uty = expected.to_option(fcx).and_then(|uty| {
             match uty.sty {
-                ty::TyArray(ty, _) => Some(ty),
+                ty::TyArray(ty, _) | ty::TySlice(ty) => Some(ty),
                 _ => None
             }
         });
@@ -3482,7 +3482,7 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
         let uty = match expected {
             ExpectHasType(uty) => {
                 match uty.sty {
-                    ty::TyArray(ty, _) => Some(ty),
+                    ty::TyArray(ty, _) | ty::TySlice(ty) => Some(ty),
                     _ => None
                 }
             }
@@ -3862,7 +3862,7 @@ impl<'tcx> Expectation<'tcx> {
     /// for examples of where this comes up,.
     fn rvalue_hint(ty: Ty<'tcx>) -> Expectation<'tcx> {
         match ty.sty {
-            ty::TyArray(_, None) | ty::TyTrait(..) => {
+            ty::TySlice(_) | ty::TyTrait(..) => {
                 ExpectRvalueLikeUnsized(ty)
             }
             _ => ExpectHasType(ty)

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -997,7 +997,7 @@ fn constrain_index<'a, 'tcx>(rcx: &mut Rcx<'a, 'tcx>,
     let r_index_expr = ty::ReScope(CodeExtent::from_node_id(index_expr.id));
     if let ty::TyRef(r_ptr, mt) = indexed_ty.sty {
         match mt.ty.sty {
-            ty::TyArray(_, None) | ty::TyStr => {
+            ty::TySlice(_) | ty::TyStr => {
                 rcx.fcx.mk_subr(infer::IndexSlice(index_expr.span),
                                 r_index_expr, *r_ptr);
             }

--- a/src/librustc_typeck/coherence/mod.rs
+++ b/src/librustc_typeck/coherence/mod.rs
@@ -25,7 +25,7 @@ use middle::ty::{MethodTraitItemId, TypeTraitItemId, ParameterEnvironment};
 use middle::ty::{Ty, TyBool, TyChar, TyEnum, TyError};
 use middle::ty::{TyParam, TypeScheme, TyRawPtr};
 use middle::ty::{TyRef, TyStruct, TyTrait, TyTuple};
-use middle::ty::{TyStr, TyArray, TyFloat, TyInfer, TyInt};
+use middle::ty::{TyStr, TyArray, TySlice, TyFloat, TyInfer, TyInt};
 use middle::ty::{TyUint, TyClosure, TyBox, TyBareFn};
 use middle::ty::TyProjection;
 use middle::ty;
@@ -70,7 +70,7 @@ fn get_base_type_def_id<'a, 'tcx>(inference_context: &InferCtxt<'a, 'tcx>,
         }
 
         TyBool | TyChar | TyInt(..) | TyUint(..) | TyFloat(..) |
-        TyStr(..) | TyArray(..) | TyBareFn(..) | TyTuple(..) |
+        TyStr(..) | TyArray(..) | TySlice(..) | TyBareFn(..) | TyTuple(..) |
         TyParam(..) | TyError |
         TyRawPtr(_) | TyRef(_, _) | TyProjection(..) => {
             None

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -93,7 +93,7 @@ impl<'cx, 'tcx> OrphanChecker<'cx, 'tcx> {
                                                   "str",
                                                   item.span);
                     }
-                    ty::TyArray(_, None) => {
+                    ty::TySlice(_) => {
                         self.check_primitive_impl(def_id,
                                                   self.tcx.lang_items.slice_impl(),
                                                   "slice",

--- a/src/librustc_typeck/variance.rs
+++ b/src/librustc_typeck/variance.rs
@@ -889,7 +889,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                 self.add_constraints_from_mt(generics, mt, variance);
             }
 
-            ty::TyBox(typ) | ty::TyArray(typ, _) => {
+            ty::TyBox(typ) | ty::TyArray(typ, _) | ty::TySlice(typ) => {
                 self.add_constraints_from_ty(generics, typ, variance);
             }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1652,9 +1652,9 @@ impl<'tcx> Clean<Type> for ty::Ty<'tcx> {
                 });
                 lang_struct(cx, box_did, t, "Box", Unique)
             }
-            ty::TyArray(ty, None) => Vector(box ty.clean(cx)),
-            ty::TyArray(ty, Some(i)) => FixedVector(box ty.clean(cx),
-                                                   format!("{}", i)),
+            ty::TySlice(ty) => Vector(box ty.clean(cx)),
+            ty::TyArray(ty, i) => FixedVector(box ty.clean(cx),
+                                              format!("{}", i)),
             ty::TyRawPtr(mt) => RawPointer(mt.mutbl.clean(cx), box mt.ty.clean(cx)),
             ty::TyRef(r, mt) => BorrowedRef {
                 lifetime: r.clean(cx),


### PR DESCRIPTION
Arrays and slices are closely related, but not that closely; making the
separation more explicit is generally more clear.
