### PR TITLE
Find type of orphan methods for rustdoc search.

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -456,13 +456,15 @@ fn build_index(krate: &clean::Crate, cache: &mut Cache) -> io::Result<String> {
             let did = ast_util::local_def(pid);
             match paths.get(&did) {
                 Some(&(ref fqp, _)) => {
+                    // Needed to determine `self` type.
+                    let parent_basename = Some(fqp[fqp.len() - 1].clone());
                     search_index.push(IndexItem {
                         ty: shortty(item),
                         name: item.name.clone().unwrap(),
                         path: fqp[..fqp.len() - 1].connect("::"),
                         desc: shorter(item.doc_value()),
                         parent: Some(did),
-                        search_type: None,
+                        search_type: get_index_search_type(&item, parent_basename),
                     });
                 },
                 None => {}


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/23289, I did not include the type information for searching for orphan methods (methods that are defined in a module and implemented in another - doing this causes rustdoc sometimes to first find the impl before the actual type).

This PR fixes this. By merging this, searches for `char -> bool` will also find `is_alphabetic`, for example (which otherwise was only found for `charext -> bool`).

cc @alexcrichton 
