### PR TITLE
remove confusing 1i32

### DIFF
--- a/src/doc/trpl/traits.md
+++ b/src/doc/trpl/traits.md
@@ -332,7 +332,7 @@ fn normal<T: ConvertTo<i64>>(x: &T) -> i64 {
 fn inverse<T>() -> T
         // this is using ConvertTo as if it were "ConvertFrom<i32>"
         where i32: ConvertTo<T> {
-    1i32.convert()
+    42.convert()
 }
 ```
 


### PR DESCRIPTION
The font can make this hard to read, and we don't even strictly need
the annotation, so let's just remove it

Fixes #26287
