### PR TITLE
core: impl LowerHex and UpperHex for [u8]

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1175,14 +1175,14 @@ impl<T: Debug> Debug for [T] {
     }
 }
 
-#[stable(feature = "rust1", since = "1.2.0")]
+#[stable(feature = "lowerhex_debug", since = "1.2.0")]
 impl<T: LowerHex + Debug> LowerHex for [T] {
     fn fmt(&self, f: &mut Formatter) -> Result {
         f.debug_list().entries(self.iter()).finish()
     }
 }
 
-#[stable(feature = "rust1", since = "1.2.0")]
+#[stable(feature = "lowerhex_debug", since = "1.2.0")]
 impl<T: UpperHex + Debug> UpperHex for [T] {
     fn fmt(&self, f: &mut Formatter) -> Result {
         f.debug_list().entries(self.iter()).finish()

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1175,6 +1175,20 @@ impl<T: Debug> Debug for [T] {
     }
 }
 
+#[stable(feature = "rust1", since = "1.2.0")]
+impl<T: LowerHex + Debug> LowerHex for [T] {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+#[stable(feature = "rust1", since = "1.2.0")]
+impl<T: UpperHex + Debug> UpperHex for [T] {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Debug for () {
     fn fmt(&self, f: &mut Formatter) -> Result {

--- a/src/test/run-pass/ifmt.rs
+++ b/src/test/run-pass/ifmt.rs
@@ -77,6 +77,13 @@ pub fn main() {
     t!(format!("{:o}", 10_usize), "12");
     t!(format!("{:x}", 10_usize), "a");
     t!(format!("{:X}", 10_usize), "A");
+
+    t!(format!("{:x}", [100]), "[0x64]");
+    t!(format!("{:X}", [100]), "[0X64]");
+
+    t!(format!("{:?}", [100]), "[100]");
+    t!(format!("{:?}", [100]), "[100]");
+
     t!(format!("{}", "foo"), "foo");
     t!(format!("{}", "foo".to_string()), "foo");
     if cfg!(target_pointer_width = "32") {


### PR DESCRIPTION
This is a fairly speculative PR, since I have a bunch of open questions:
- Is it actually as much work as it looks to implement this without the Debug bound? (Is that desirable? Happy to do it if it would get merged)
- Is marking this stable OK? It seems pretty minor
- More subjectively, this seemed to be right on the cusp of worth macro-ifying. I suspect that it's actually worth doing this for all of [u8], [u16] and friends, so I presume that I should actually macro it?
