### PR TITLE
test: Fix a bug in bench result formatting

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -629,11 +629,11 @@ impl<T: Write> ConsoleTestState<T> {
 fn fmt_thousands_sep(mut n: usize, sep: char) -> String {
     use std::fmt::Write;
     let mut output = String::new();
-    let mut first = true;
+    let mut trailing = false;
     for &pow in &[9, 6, 3, 0] {
         let base = 10_usize.pow(pow);
-        if pow == 0 || n / base != 0 {
-            if first {
+        if pow == 0 || trailing || n / base != 0 {
+            if !trailing {
                 output.write_fmt(format_args!("{}", n / base)).unwrap();
             } else {
                 output.write_fmt(format_args!("{:03}", n / base)).unwrap();
@@ -641,7 +641,7 @@ fn fmt_thousands_sep(mut n: usize, sep: char) -> String {
             if pow != 0 {
                 output.push(sep);
             }
-            first = false;
+            trailing = true;
         }
         n %= base;
     }


### PR DESCRIPTION
test: Fix a bug in bench result formatting

It would skip the middle part if it was 0, displaying a number a 1000
times too small. The MB/s number next to it gave it away.

Fixed it looks like this:

```
test h ... bench:   1,000,129 ns/iter (+/- 4,730)
```
