### PR TITLE
Document behavior of bitwise operators with boolean arguments

### DIFF
--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2768,22 +2768,24 @@ meaning of the operators on standard types is given here.
 Like the [arithmetic operators](#arithmetic-operators), bitwise operators are
 syntactic sugar for calls to methods of built-in traits. This means that
 bitwise operators can be overridden for user-defined types. The default
-meaning of the operators on standard types is given here.
+meaning of the operators on standard types is given here. Bitwise `&`, `|` and
+`^` applied to boolean arguments are equivalent to logical `&&`, `||` and `!=`
+evaluated in non-lazy fashion.
 
 * `&`
-  : And.
+  : Bitwise AND.
     Calls the `bitand` method of the `std::ops::BitAnd` trait.
 * `|`
-  : Inclusive or.
+  : Bitwise inclusive OR.
     Calls the `bitor` method of the `std::ops::BitOr` trait.
 * `^`
-  : Exclusive or.
+  : Bitwise exclusive OR.
     Calls the `bitxor` method of the `std::ops::BitXor` trait.
 * `<<`
   : Left shift.
     Calls the `shl` method of the `std::ops::Shl` trait.
 * `>>`
-  : Right shift.
+  : Right shift (arithmetic).
     Calls the `shr` method of the `std::ops::Shr` trait.
 
 #### Lazy boolean operators


### PR DESCRIPTION
I'm surprised that bitwise operators `&`, `|` and `^` are implemented for `bool` arguments, because inspection of boolean's bits is not something that should be encouraged and because `&&` -> `&` is a common typo, but if they are implemented, then their behavior should be documented.
