### PR TITLE
Remove the unecessary ParamBounds struct

### DIFF
--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -380,23 +380,9 @@ pub fn enc_builtin_bounds(w: &mut Encoder, _cx: &ctxt, bs: &ty::BuiltinBounds) {
 pub fn enc_existential_bounds<'a,'tcx>(w: &mut Encoder,
                                        cx: &ctxt<'a,'tcx>,
                                        bs: &ty::ExistentialBounds<'tcx>) {
-    let param_bounds = ty::ParamBounds { trait_bounds: vec!(),
-                                         region_bounds: vec!(bs.region_bound),
-                                         builtin_bounds: bs.builtin_bounds,
-                                         projection_bounds: bs.projection_bounds.clone() };
-    enc_bounds(w, cx, &param_bounds);
-}
-
-pub fn enc_bounds<'a, 'tcx>(w: &mut Encoder, cx: &ctxt<'a, 'tcx>,
-                            bs: &ty::ParamBounds<'tcx>) {
     enc_builtin_bounds(w, cx, &bs.builtin_bounds);
 
-    enc_region_bounds(w, cx, &bs.region_bounds);
-
-    for tp in &bs.trait_bounds {
-        mywrite!(w, "I");
-        enc_trait_ref(w, cx, tp.0);
-    }
+    enc_region(w, cx, bs.region_bound);
 
     for tp in &bs.projection_bounds {
         mywrite!(w, "P");

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1847,21 +1847,8 @@ pub enum type_err<'tcx> {
     terr_projection_bounds_length(expected_found<usize>),
 }
 
-/// Bounds suitable for a named type parameter like `A` in `fn foo<A>`
-/// as well as the existential type parameter in an object type.
-#[derive(PartialEq, Eq, Hash, Clone)]
-pub struct ParamBounds<'tcx> {
-    pub region_bounds: Vec<ty::Region>,
-    pub builtin_bounds: BuiltinBounds,
-    pub trait_bounds: Vec<PolyTraitRef<'tcx>>,
-    pub projection_bounds: Vec<PolyProjectionPredicate<'tcx>>,
-}
-
 /// Bounds suitable for an existentially quantified type parameter
-/// such as those that appear in object types or closure types. The
-/// major difference between this case and `ParamBounds` is that
-/// general purpose trait bounds are omitted and there must be
-/// *exactly one* region.
+/// such as those that appear in object types or closure types.
 #[derive(PartialEq, Eq, Hash, Clone)]
 pub struct ExistentialBounds<'tcx> {
     pub region_bound: ty::Region,
@@ -1873,12 +1860,23 @@ pub struct ExistentialBounds<'tcx> {
 pub struct BuiltinBounds(EnumSet<BuiltinBound>);
 
 impl BuiltinBounds {
-    pub fn empty() -> BuiltinBounds {
+       pub fn empty() -> BuiltinBounds {
         BuiltinBounds(EnumSet::new())
     }
 
     pub fn iter(&self) -> enum_set::Iter<BuiltinBound> {
         self.into_iter()
+    }
+
+    pub fn to_predicates<'tcx>(&self,
+                               tcx: &ty::ctxt<'tcx>,
+                               self_ty: Ty<'tcx>) -> Vec<Predicate<'tcx>> {
+        self.iter().filter_map(|builtin_bound|
+            match traits::trait_ref_for_builtin_bound(tcx, builtin_bound, self_ty) {
+                Ok(trait_ref) => Some(trait_ref.as_predicate()),
+                Err(ErrorReported) => { None }
+            }
+        ).collect()
     }
 }
 
@@ -3700,17 +3698,6 @@ impl<'tcx> ItemSubsts<'tcx> {
 
     pub fn is_noop(&self) -> bool {
         self.substs.is_noop()
-    }
-}
-
-impl<'tcx> ParamBounds<'tcx> {
-    pub fn empty() -> ParamBounds<'tcx> {
-        ParamBounds {
-            builtin_bounds: BuiltinBounds::empty(),
-            trait_bounds: Vec::new(),
-            region_bounds: Vec::new(),
-            projection_bounds: Vec::new(),
-        }
     }
 }
 
@@ -6140,39 +6127,6 @@ pub fn lookup_super_predicates<'tcx>(cx: &ctxt<'tcx>, did: ast::DefId)
     lookup_locally_or_in_crate_store(
         "super_predicates", did, &cx.super_predicates,
         || csearch::get_super_predicates(cx, did))
-}
-
-pub fn predicates<'tcx>(
-    tcx: &ctxt<'tcx>,
-    param_ty: Ty<'tcx>,
-    bounds: &ParamBounds<'tcx>)
-    -> Vec<Predicate<'tcx>>
-{
-    let mut vec = Vec::new();
-
-    for builtin_bound in &bounds.builtin_bounds {
-        match traits::trait_ref_for_builtin_bound(tcx, builtin_bound, param_ty) {
-            Ok(trait_ref) => { vec.push(trait_ref.as_predicate()); }
-            Err(ErrorReported) => { }
-        }
-    }
-
-    for &region_bound in &bounds.region_bounds {
-        // account for the binder being introduced below; no need to shift `param_ty`
-        // because, at present at least, it can only refer to early-bound regions
-        let region_bound = ty_fold::shift_region(region_bound, 1);
-        vec.push(ty::Binder(ty::OutlivesPredicate(param_ty, region_bound)).as_predicate());
-    }
-
-    for bound_trait_ref in &bounds.trait_bounds {
-        vec.push(bound_trait_ref.as_predicate());
-    }
-
-    for projection in &bounds.projection_bounds {
-        vec.push(projection.as_predicate());
-    }
-
-    vec
 }
 
 /// Get the attributes of a definition.

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -350,17 +350,6 @@ impl<'tcx> TypeFoldable<'tcx> for ty::ExistentialBounds<'tcx> {
     }
 }
 
-impl<'tcx> TypeFoldable<'tcx> for ty::ParamBounds<'tcx> {
-    fn fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> ty::ParamBounds<'tcx> {
-        ty::ParamBounds {
-            region_bounds: self.region_bounds.fold_with(folder),
-            builtin_bounds: self.builtin_bounds.fold_with(folder),
-            trait_bounds: self.trait_bounds.fold_with(folder),
-            projection_bounds: self.projection_bounds.fold_with(folder),
-        }
-    }
-}
-
 impl<'tcx> TypeFoldable<'tcx> for ty::TypeParameterDef<'tcx> {
     fn fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> ty::TypeParameterDef<'tcx> {
         ty::TypeParameterDef {

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -347,23 +347,6 @@ impl fmt::Debug for subst::RegionSubsts {
     }
 }
 
-
-impl<'tcx> fmt::Debug for ty::ParamBounds<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "{:?}", self.builtin_bounds));
-        let mut bounds = self.trait_bounds.iter();
-        if self.builtin_bounds.is_empty() {
-            if let Some(bound) = bounds.next() {
-                try!(write!(f, "{:?}", bound));
-            }
-        }
-        for bound in bounds {
-            try!(write!(f, " + {:?}", bound));
-        }
-        Ok(())
-    }
-}
-
 impl<'tcx> fmt::Debug for ty::TraitRef<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // when printing out the debug representation, we don't need
@@ -536,22 +519,6 @@ impl<'tcx> fmt::Debug for ty::MethodObject<'tcx> {
                self.trait_ref,
                self.method_num,
                self.vtable_index)
-    }
-}
-
-impl<'tcx> fmt::Display for ty::ParamBounds<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "{}", self.builtin_bounds));
-        let mut bounds = self.trait_bounds.iter();
-        if self.builtin_bounds.is_empty() {
-            if let Some(bound) = bounds.next() {
-                try!(write!(f, "{}", bound));
-            }
-        }
-        for bound in bounds {
-            try!(write!(f, " + {}", bound));
-        }
-        Ok(())
     }
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -716,19 +716,6 @@ impl<'tcx> Clean<TyParamBound> for ty::TraitRef<'tcx> {
     }
 }
 
-impl<'tcx> Clean<Vec<TyParamBound>> for ty::ParamBounds<'tcx> {
-    fn clean(&self, cx: &DocContext) -> Vec<TyParamBound> {
-        let mut v = Vec::new();
-        for t in &self.trait_bounds {
-            v.push(t.clean(cx));
-        }
-        for r in self.region_bounds.iter().filter_map(|r| r.clean(cx)) {
-            v.push(RegionBound(r));
-        }
-        v
-    }
-}
-
 impl<'tcx> Clean<Option<Vec<TyParamBound>>> for subst::Substs<'tcx> {
     fn clean(&self, cx: &DocContext) -> Option<Vec<TyParamBound>> {
         let mut v = Vec::new();


### PR DESCRIPTION
This pull request removes `ParamBounds` a old holdover in the type checker that we (@nikomatsakis and I) had wanted to remove. I'm not sure if the current form is the best possible refactor but I figured we can use this as a place to discuss it.

r? @nikomatsakis 
