### PR TITLE
Implement better object defaults (RFC #1156)

### DIFF
--- a/src/librustc/diagnostics.rs
+++ b/src/librustc/diagnostics.rs
@@ -1160,6 +1160,42 @@ static mut FOO: Option<Box<usize>> = None;
 // error: mutable statics are not allowed to have destructors
 static mut BAR: Option<Vec<i32>> = None;
 ```
+"##,
+
+E0398: r##"
+In Rust 1.3, the default object lifetime bounds are expected to
+change, as described in RFC #1156 [1]. You are getting a warning
+because the compiler thinks it is possible that this change will cause
+a compilation error in your code. It is possible, though unlikely,
+that this is a false alarm.
+
+The heart of the change is that where `&'a Box<SomeTrait>` used to
+default to `&'a Box<SomeTrait+'a>`, it now defaults to `&'a
+Box<SomeTrait+'static>` (here, `SomeTrait` is the name of some trait
+type). Note that the only types which are affected are references to
+boxes, like `&Box<SomeTrait>` or `&[Box<SomeTrait>]`.  More common
+types like `&SomeTrait` or `Box<SomeTrait>` are unaffected.
+
+To silence this warning, edit your code to use an explicit bound.
+Most of the time, this means that you will want to change the
+signature of a function that you are calling. For example, if
+the error is reported on a call like `foo(x)`, and `foo` is
+defined as follows:
+
+```
+fn foo(arg: &Box<SomeTrait>) { ... }
+```
+
+you might change it to:
+
+```
+fn foo<'a>(arg: &Box<SomeTrait+'a>) { ... }
+```
+
+This explicitly states that you expect the trait object `SomeTrait` to
+contain references (with a maximum lifetime of `'a`).
+
+[1]: https://github.com/rust-lang/rfcs/pull/1156
 "##
 
 }

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -843,15 +843,15 @@ fn parse_type_param_def_<'a, 'tcx, F>(st: &mut PState<'a, 'tcx>, conv: &mut F)
 
 fn parse_object_lifetime_default<'a,'tcx, F>(st: &mut PState<'a,'tcx>,
                                              conv: &mut F)
-                                             -> Option<ty::ObjectLifetimeDefault>
+                                             -> ty::ObjectLifetimeDefault
     where F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
 {
     match next(st) {
-        'n' => None,
-        'a' => Some(ty::ObjectLifetimeDefault::Ambiguous),
+        'a' => ty::ObjectLifetimeDefault::Ambiguous,
+        'b' => ty::ObjectLifetimeDefault::BaseDefault,
         's' => {
             let region = parse_region_(st, conv);
-            Some(ty::ObjectLifetimeDefault::Specific(region))
+            ty::ObjectLifetimeDefault::Specific(region)
         }
         _ => panic!("parse_object_lifetime_default: bad input")
     }

--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -887,9 +887,16 @@ fn parse_existential_bounds_<'a,'tcx, F>(st: &mut PState<'a,'tcx>,
         }
     }
 
+    let region_bound_will_change = match next(st) {
+        'y' => true,
+        'n' => false,
+        c => panic!("parse_ty: expected y/n not '{}'", c)
+    };
+
     return ty::ExistentialBounds { region_bound: region_bound,
                                    builtin_bounds: builtin_bounds,
-                                   projection_bounds: projection_bounds };
+                                   projection_bounds: projection_bounds,
+                                   region_bound_will_change: region_bound_will_change };
 }
 
 fn parse_builtin_bounds<F>(st: &mut PState, mut _conv: F) -> ty::BuiltinBounds where

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -414,12 +414,12 @@ pub fn enc_type_param_def<'a, 'tcx>(w: &mut Encoder, cx: &ctxt<'a, 'tcx>,
 
 fn enc_object_lifetime_default<'a, 'tcx>(w: &mut Encoder,
                                          cx: &ctxt<'a, 'tcx>,
-                                         default: Option<ty::ObjectLifetimeDefault>)
+                                         default: ty::ObjectLifetimeDefault)
 {
     match default {
-        None => mywrite!(w, "n"),
-        Some(ty::ObjectLifetimeDefault::Ambiguous) => mywrite!(w, "a"),
-        Some(ty::ObjectLifetimeDefault::Specific(r)) => {
+        ty::ObjectLifetimeDefault::Ambiguous => mywrite!(w, "a"),
+        ty::ObjectLifetimeDefault::BaseDefault => mywrite!(w, "b"),
+        ty::ObjectLifetimeDefault::Specific(r) => {
             mywrite!(w, "s");
             enc_region(w, cx, r);
         }

--- a/src/librustc/metadata/tyencode.rs
+++ b/src/librustc/metadata/tyencode.rs
@@ -390,6 +390,8 @@ pub fn enc_existential_bounds<'a,'tcx>(w: &mut Encoder,
     }
 
     mywrite!(w, ".");
+
+    mywrite!(w, "{}", if bs.region_bound_will_change {'y'} else {'n'});
 }
 
 pub fn enc_region_bounds<'a, 'tcx>(w: &mut Encoder,

--- a/src/librustc/middle/infer/bivariate.rs
+++ b/src/librustc/middle/infer/bivariate.rs
@@ -49,6 +49,11 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Bivariate<'a, 'tcx> {
 
     fn a_is_expected(&self) -> bool { self.fields.a_is_expected }
 
+    fn will_change(&mut self, _: bool, _: bool) -> bool {
+        // since we are not comparing regions, we don't care
+        false
+    }
+
     fn relate_with_variance<T:Relate<'a,'tcx>>(&mut self,
                                                variance: ty::Variance,
                                                a: &T,

--- a/src/librustc/middle/infer/combine.rs
+++ b/src/librustc/middle/infer/combine.rs
@@ -56,6 +56,7 @@ pub struct CombineFields<'a, 'tcx: 'a> {
     pub infcx: &'a InferCtxt<'a, 'tcx>,
     pub a_is_expected: bool,
     pub trace: TypeTrace<'tcx>,
+    pub cause: Option<ty_relate::Cause>,
 }
 
 pub fn super_combine_tys<'a,'tcx:'a,R>(infcx: &InferCtxt<'a, 'tcx>,

--- a/src/librustc/middle/infer/equate.rs
+++ b/src/librustc/middle/infer/equate.rs
@@ -34,6 +34,11 @@ impl<'a, 'tcx> TypeRelation<'a,'tcx> for Equate<'a, 'tcx> {
 
     fn a_is_expected(&self) -> bool { self.fields.a_is_expected }
 
+    fn will_change(&mut self, a: bool, b: bool) -> bool {
+        // if either side changed from what it was, that could cause equality to fail
+        a || b
+    }
+
     fn relate_with_variance<T:Relate<'a,'tcx>>(&mut self,
                                                _: ty::Variance,
                                                a: &T,

--- a/src/librustc/middle/infer/error_reporting.rs
+++ b/src/librustc/middle/infer/error_reporting.rs
@@ -593,7 +593,8 @@ impl<'a, 'tcx> ErrorReporting<'tcx> for InferCtxt<'a, 'tcx> {
                                sub: Region,
                                sup: Region) {
         match origin {
-            infer::Subtype(trace) => {
+            infer::Subtype(trace) |
+            infer::DefaultExistentialBound(trace) => {
                 let terr = ty::terr_regions_does_not_outlive(sup, sub);
                 self.report_and_explain_type_error(trace, &terr);
             }
@@ -1569,7 +1570,8 @@ impl<'a, 'tcx> ErrorReportingHelpers<'tcx> for InferCtxt<'a, 'tcx> {
 
     fn note_region_origin(&self, origin: &SubregionOrigin<'tcx>) {
         match *origin {
-            infer::Subtype(ref trace) => {
+            infer::Subtype(ref trace) |
+            infer::DefaultExistentialBound(ref trace) => {
                 let desc = match trace.origin {
                     infer::Misc(_) => {
                         "types are compatible"

--- a/src/librustc/middle/infer/glb.rs
+++ b/src/librustc/middle/infer/glb.rs
@@ -35,6 +35,16 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Glb<'a, 'tcx> {
 
     fn a_is_expected(&self) -> bool { self.fields.a_is_expected }
 
+    fn will_change(&mut self, a: bool, b: bool) -> bool {
+        // Hmm, so the result of GLB will still be a LB if one or both
+        // sides change to 'static, but it may no longer be the GLB.
+        // I'm going to go with `a || b` here to be conservative,
+        // since the result of this operation may be affected, though
+        // I think it would mostly be more accepting than before (since the result
+        // would be a bigger region).
+        a || b
+    }
+
     fn relate_with_variance<T:Relate<'a,'tcx>>(&mut self,
                                                variance: ty::Variance,
                                                a: &T,

--- a/src/librustc/middle/infer/lub.rs
+++ b/src/librustc/middle/infer/lub.rs
@@ -35,6 +35,11 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Lub<'a, 'tcx> {
 
     fn a_is_expected(&self) -> bool { self.fields.a_is_expected }
 
+    fn will_change(&mut self, a: bool, b: bool) -> bool {
+        // result will be 'static if a || b
+        a || b
+    }
+
     fn relate_with_variance<T:Relate<'a,'tcx>>(&mut self,
                                                variance: ty::Variance,
                                                a: &T,

--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -194,6 +194,9 @@ pub enum SubregionOrigin<'tcx> {
     // Arose from a subtyping relation
     Subtype(TypeTrace<'tcx>),
 
+    // Arose from a subtyping relation
+    DefaultExistentialBound(TypeTrace<'tcx>),
+
     // Stack-allocated closures cannot outlive innermost loop
     // or function so as to ensure we only require finite stack
     InfStackClosure(Span),
@@ -658,7 +661,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                       -> CombineFields<'a, 'tcx> {
         CombineFields {infcx: self,
                        a_is_expected: a_is_expected,
-                       trace: trace}
+                       trace: trace,
+                       cause: None}
     }
 
     // public so that it can be used from the rustc_driver unit tests
@@ -1464,6 +1468,7 @@ impl<'tcx> SubregionOrigin<'tcx> {
     pub fn span(&self) -> Span {
         match *self {
             Subtype(ref a) => a.span(),
+            DefaultExistentialBound(ref a) => a.span(),
             InfStackClosure(a) => a,
             InvokeClosure(a) => a,
             DerefPointer(a) => a,

--- a/src/librustc/middle/infer/sub.rs
+++ b/src/librustc/middle/infer/sub.rs
@@ -10,16 +10,17 @@
 
 use super::combine::{self, CombineFields};
 use super::higher_ranked::HigherRankedRelations;
-use super::Subtype;
+use super::SubregionOrigin;
 use super::type_variable::{SubtypeOf, SupertypeOf};
 
 use middle::ty::{self, Ty};
 use middle::ty::TyVar;
-use middle::ty_relate::{Relate, RelateResult, TypeRelation};
+use middle::ty_relate::{Cause, Relate, RelateResult, TypeRelation};
+use std::mem;
 
 /// "Greatest lower bound" (common subtype)
 pub struct Sub<'a, 'tcx: 'a> {
-    fields: CombineFields<'a, 'tcx>
+    fields: CombineFields<'a, 'tcx>,
 }
 
 impl<'a, 'tcx> Sub<'a, 'tcx> {
@@ -32,6 +33,25 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Sub<'a, 'tcx> {
     fn tag(&self) -> &'static str { "Sub" }
     fn tcx(&self) -> &'a ty::ctxt<'tcx> { self.fields.infcx.tcx }
     fn a_is_expected(&self) -> bool { self.fields.a_is_expected }
+
+    fn with_cause<F,R>(&mut self, cause: Cause, f: F) -> R
+        where F: FnOnce(&mut Self) -> R
+    {
+        debug!("sub with_cause={:?}", cause);
+        let old_cause = mem::replace(&mut self.fields.cause, Some(cause));
+        let r = f(self);
+        debug!("sub old_cause={:?}", old_cause);
+        self.fields.cause = old_cause;
+        r
+    }
+
+    fn will_change(&mut self, a: bool, b: bool) -> bool {
+        // if we have (Foo+'a) <: (Foo+'b), this requires that 'a:'b.
+        // So if 'a becomes 'static, no additional errors can occur.
+        // OTOH, if 'a stays the same, but 'b becomes 'static, we
+        // could have a problem.
+        !a && b
+    }
 
     fn relate_with_variance<T:Relate<'a,'tcx>>(&mut self,
                                                variance: ty::Variance,
@@ -84,11 +104,14 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Sub<'a, 'tcx> {
     }
 
     fn regions(&mut self, a: ty::Region, b: ty::Region) -> RelateResult<'tcx, ty::Region> {
-        debug!("{}.regions({:?}, {:?})",
-               self.tag(),
-               a,
-               b);
-        let origin = Subtype(self.fields.trace.clone());
+        debug!("{}.regions({:?}, {:?}) self.cause={:?}",
+               self.tag(), a, b, self.fields.cause);
+        let origin = match self.fields.cause {
+            Some(Cause::ExistentialRegionBound(true)) =>
+                SubregionOrigin::DefaultExistentialBound(self.fields.trace.clone()),
+            _ =>
+                SubregionOrigin::Subtype(self.fields.trace.clone()),
+        };
         self.fields.infcx.region_vars.make_subregion(origin, a, b);
         Ok(a)
     }

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -2445,6 +2445,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     region_bound: data_b.bounds.region_bound,
                     builtin_bounds: data_b.bounds.builtin_bounds,
                     projection_bounds: data_a.bounds.projection_bounds.clone(),
+                    region_bound_will_change: data_b.bounds.region_bound_will_change,
                 };
 
                 let new_trait = tcx.mk_trait(data_a.principal.clone(), bounds);

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2055,6 +2055,11 @@ pub struct ExistentialBounds<'tcx> {
     pub region_bound: ty::Region,
     pub builtin_bounds: BuiltinBounds,
     pub projection_bounds: Vec<PolyProjectionPredicate<'tcx>>,
+
+    // If true, this TyTrait used a "default bound" in the surface
+    // syntax.  This makes no difference to the type system but is
+    // handy for error reporting.
+    pub region_bound_will_change: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -2245,6 +2245,9 @@ pub enum ObjectLifetimeDefault {
     /// `T:'a` constraints are found.
     Ambiguous,
 
+    /// Use the base default, typically 'static, but in a fn body it is a fresh variable
+    BaseDefault,
+
     /// Use the given region as the default.
     Specific(Region),
 }
@@ -2256,7 +2259,7 @@ pub struct TypeParameterDef<'tcx> {
     pub space: subst::ParamSpace,
     pub index: u32,
     pub default: Option<Ty<'tcx>>,
-    pub object_lifetime_default: Option<ObjectLifetimeDefault>,
+    pub object_lifetime_default: ObjectLifetimeDefault,
 }
 
 #[derive(RustcEncodable, RustcDecodable, Clone, Debug)]
@@ -7328,6 +7331,7 @@ impl<'tcx> fmt::Debug for ObjectLifetimeDefault {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             ObjectLifetimeDefault::Ambiguous => write!(f, "Ambiguous"),
+            ObjectLifetimeDefault::BaseDefault => format!("BaseDefault"),
             ObjectLifetimeDefault::Specific(ref r) => write!(f, "{:?}", r),
         }
     }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -7336,7 +7336,7 @@ impl<'tcx> fmt::Debug for ObjectLifetimeDefault {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             ObjectLifetimeDefault::Ambiguous => write!(f, "Ambiguous"),
-            ObjectLifetimeDefault::BaseDefault => format!("BaseDefault"),
+            ObjectLifetimeDefault::BaseDefault => write!(f, "BaseDefault"),
             ObjectLifetimeDefault::Specific(ref r) => write!(f, "{:?}", r),
         }
     }

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -369,6 +369,9 @@ impl<'tcx> TypeFoldable<'tcx> for ty::ObjectLifetimeDefault {
             ty::ObjectLifetimeDefault::Ambiguous =>
                 ty::ObjectLifetimeDefault::Ambiguous,
 
+            ty::ObjectLifetimeDefault::BaseDefault =>
+                ty::ObjectLifetimeDefault::BaseDefault,
+
             ty::ObjectLifetimeDefault::Specific(r) =>
                 ty::ObjectLifetimeDefault::Specific(r.fold_with(folder)),
         }

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -728,6 +728,7 @@ pub fn super_fold_existential_bounds<'tcx, T: TypeFolder<'tcx>>(
         region_bound: bounds.region_bound.fold_with(this),
         builtin_bounds: bounds.builtin_bounds,
         projection_bounds: bounds.projection_bounds.fold_with(this),
+        region_bound_will_change: bounds.region_bound_will_change,
     }
 }
 

--- a/src/librustc/middle/ty_match.rs
+++ b/src/librustc/middle/ty_match.rs
@@ -42,6 +42,11 @@ impl<'a, 'tcx> TypeRelation<'a, 'tcx> for Match<'a, 'tcx> {
     fn tcx(&self) -> &'a ty::ctxt<'tcx> { self.tcx }
     fn a_is_expected(&self) -> bool { true } // irrelevant
 
+    fn will_change(&mut self, _: bool, _: bool) -> bool {
+        // we're ignoring regions in this code
+        false
+    }
+
     fn relate_with_variance<T:Relate<'a,'tcx>>(&mut self,
                                                _: ty::Variance,
                                                a: &T,

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -299,6 +299,10 @@ impl<'tcx> fmt::Display for ty::TraitTy<'tcx> {
             }
         }
 
+        if bounds.region_bound_will_change && tcx.sess.verbose() {
+            components.push(format!("WILL-CHANGE"));
+        }
+
         Ok(())
     }
 }

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -290,17 +290,18 @@ impl<'tcx> fmt::Display for ty::TraitTy<'tcx> {
             try!(write!(f, " + {:?}", bound));
         }
 
-        // Region, if not obviously implied by builtin bounds.
-        if bounds.region_bound != ty::ReStatic {
-            // Region bound is implied by builtin bounds:
-            let bound = bounds.region_bound.to_string();
-            if !bound.is_empty() {
-                try!(write!(f, " + {}", bound));
-            }
+        // FIXME: It'd be nice to compute from context when this bound
+        // is implied, but that's non-trivial -- we'd perhaps have to
+        // use thread-local data of some kind? There are also
+        // advantages to just showing the region, since it makes
+        // people aware that it's there.
+        let bound = bounds.region_bound.to_string();
+        if !bound.is_empty() {
+            try!(write!(f, " + {}", bound));
         }
 
-        if bounds.region_bound_will_change && tcx.sess.verbose() {
-            components.push(format!("WILL-CHANGE"));
+        if bounds.region_bound_will_change && verbose() {
+            try!(write!(f, " [WILL-CHANGE]"));
         }
 
         Ok(())

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -82,6 +82,16 @@ pub fn erase_regions<'tcx,T>(cx: &ty::ctxt<'tcx>, value: &T) -> T
             return t_norm;
         }
 
+        fn fold_existential_bounds(&mut self, s: &ty::ExistentialBounds<'tcx>)
+                                   -> ty::ExistentialBounds<'tcx> {
+            let mut s = ty_fold::super_fold_existential_bounds(self, s);
+
+            // this annoying flag messes up trans normalization
+            s.region_bound_will_change = false;
+
+            s
+        }
+
         fn fold_binder<T>(&mut self, t: &ty::Binder<T>) -> ty::Binder<T>
             where T : TypeFoldable<'tcx>
         {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1779,6 +1779,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
 impl<'a, 'tcx> RegionScope for FnCtxt<'a, 'tcx> {
     fn object_lifetime_default(&self, span: Span) -> Option<ty::Region> {
+        Some(self.base_object_lifetime_default(span))
+    }
+
+    fn base_object_lifetime_default(&self, span: Span) -> ty::Region {
         // RFC #599 specifies that object lifetime defaults take
         // precedence over other defaults. But within a fn body we
         // don't have a *default* region, rather we use inference to
@@ -1786,7 +1790,7 @@ impl<'a, 'tcx> RegionScope for FnCtxt<'a, 'tcx> {
         // (and anyway, within a fn body the right region may not even
         // be something the user can write explicitly, since it might
         // be some expression).
-        Some(self.infcx().next_region_var(infer::MiscVariable(span)))
+        self.infcx().next_region_var(infer::MiscVariable(span))
     }
 
     fn anon_regions(&self, span: Span, count: usize)

--- a/src/librustc_typeck/rscope.rs
+++ b/src/librustc_typeck/rscope.rs
@@ -45,6 +45,13 @@ pub trait RegionScope {
     /// be derived from the object traits, what should we use? If
     /// `None` is returned, an explicit annotation is required.
     fn object_lifetime_default(&self, span: Span) -> Option<ty::Region>;
+
+    /// The "base" default is the initial default for a scope. This is
+    /// 'static except for in fn bodies, where it is a fresh inference
+    /// variable. You shouldn't call this except for as part of
+    /// computing `object_lifetime_default` (in particular, in legacy
+    /// modes, it may not be relevant).
+    fn base_object_lifetime_default(&self, span: Span) -> ty::Region;
 }
 
 // A scope in which all regions must be explicitly named. This is used
@@ -53,15 +60,19 @@ pub trait RegionScope {
 pub struct ExplicitRscope;
 
 impl RegionScope for ExplicitRscope {
-    fn object_lifetime_default(&self, _span: Span) -> Option<ty::Region> {
-        Some(ty::ReStatic)
-    }
-
     fn anon_regions(&self,
                     _span: Span,
                     _count: usize)
                     -> Result<Vec<ty::Region>, Option<Vec<ElisionFailureInfo>>> {
         Err(None)
+    }
+
+    fn object_lifetime_default(&self, span: Span) -> Option<ty::Region> {
+        Some(self.base_object_lifetime_default(span))
+    }
+
+    fn base_object_lifetime_default(&self, _span: Span) -> ty::Region {
+        ty::ReStatic
     }
 }
 
@@ -75,16 +86,20 @@ impl UnelidableRscope {
 }
 
 impl RegionScope for UnelidableRscope {
-    fn object_lifetime_default(&self, _span: Span) -> Option<ty::Region> {
-        Some(ty::ReStatic)
-    }
-
     fn anon_regions(&self,
                     _span: Span,
                     _count: usize)
                     -> Result<Vec<ty::Region>, Option<Vec<ElisionFailureInfo>>> {
         let UnelidableRscope(ref v) = *self;
         Err(v.clone())
+    }
+
+    fn object_lifetime_default(&self, span: Span) -> Option<ty::Region> {
+        Some(self.base_object_lifetime_default(span))
+    }
+
+    fn base_object_lifetime_default(&self, _span: Span) -> ty::Region {
+        ty::ReStatic
     }
 }
 
@@ -103,11 +118,15 @@ impl ElidableRscope {
 }
 
 impl RegionScope for ElidableRscope {
-    fn object_lifetime_default(&self, _span: Span) -> Option<ty::Region> {
+    fn object_lifetime_default(&self, span: Span) -> Option<ty::Region> {
         // Per RFC #599, object-lifetimes default to 'static unless
         // overridden by context, and this takes precedence over
         // lifetime elision.
-        Some(ty::ReStatic)
+        Some(self.base_object_lifetime_default(span))
+    }
+
+    fn base_object_lifetime_default(&self, _span: Span) -> ty::Region {
+        ty::ReStatic
     }
 
     fn anon_regions(&self,
@@ -140,11 +159,15 @@ impl BindingRscope {
 }
 
 impl RegionScope for BindingRscope {
-    fn object_lifetime_default(&self, _span: Span) -> Option<ty::Region> {
+    fn object_lifetime_default(&self, span: Span) -> Option<ty::Region> {
         // Per RFC #599, object-lifetimes default to 'static unless
         // overridden by context, and this takes precedence over the
-        // binding defaults.
-        Some(ty::ReStatic)
+        // binding defaults in a fn signature.
+        Some(self.base_object_lifetime_default(span))
+    }
+
+    fn base_object_lifetime_default(&self, _span: Span) -> ty::Region {
+        ty::ReStatic
     }
 
     fn anon_regions(&self,
@@ -159,12 +182,12 @@ impl RegionScope for BindingRscope {
 /// A scope which overrides the default object lifetime but has no other effect.
 pub struct ObjectLifetimeDefaultRscope<'r> {
     base_scope: &'r (RegionScope+'r),
-    default: Option<ty::ObjectLifetimeDefault>,
+    default: ty::ObjectLifetimeDefault,
 }
 
 impl<'r> ObjectLifetimeDefaultRscope<'r> {
     pub fn new(base_scope: &'r (RegionScope+'r),
-               default: Option<ty::ObjectLifetimeDefault>)
+               default: ty::ObjectLifetimeDefault)
                -> ObjectLifetimeDefaultRscope<'r>
     {
         ObjectLifetimeDefaultRscope {
@@ -177,9 +200,25 @@ impl<'r> ObjectLifetimeDefaultRscope<'r> {
 impl<'r> RegionScope for ObjectLifetimeDefaultRscope<'r> {
     fn object_lifetime_default(&self, span: Span) -> Option<ty::Region> {
         match self.default {
-            None => self.base_scope.object_lifetime_default(span),
-            Some(ty::ObjectLifetimeDefault::Ambiguous) => None,
-            Some(ty::ObjectLifetimeDefault::Specific(r)) => Some(r),
+            ty::ObjectLifetimeDefault::Ambiguous =>
+                None,
+
+            ty::ObjectLifetimeDefault::BaseDefault =>
+                if false { // this will become the behavior in Rust 1.3
+                    Some(self.base_object_lifetime_default(span))
+                } else {
+                    self.base_scope.object_lifetime_default(span)
+                },
+
+            ty::ObjectLifetimeDefault::Specific(r) =>
+                Some(r),
+        }
+    }
+
+    fn base_object_lifetime_default(&self, span: Span) -> ty::Region {
+        assert!(false, "this code should not execute until Rust 1.3");
+        self.base_scope.base_object_lifetime_default(span)
+    }
         }
     }
 
@@ -208,6 +247,10 @@ impl<'r> RegionScope for ShiftedRscope<'r> {
     fn object_lifetime_default(&self, span: Span) -> Option<ty::Region> {
         self.base_scope.object_lifetime_default(span)
             .map(|r| ty_fold::shift_region(r, 1))
+    }
+
+    fn base_object_lifetime_default(&self, span: Span) -> ty::Region {
+        ty_fold::shift_region(self.base_scope.base_object_lifetime_default(span), 1)
     }
 
     fn anon_regions(&self,

--- a/src/librustc_typeck/rscope.rs
+++ b/src/librustc_typeck/rscope.rs
@@ -52,6 +52,19 @@ pub trait RegionScope {
     /// computing `object_lifetime_default` (in particular, in legacy
     /// modes, it may not be relevant).
     fn base_object_lifetime_default(&self, span: Span) -> ty::Region;
+
+    /// Used to issue warnings in Rust 1.2, not needed after that.
+    /// True if the result of `object_lifetime_default` will change in 1.3.
+    fn object_lifetime_default_will_change_in_1_3(&self) -> bool {
+        false
+    }
+
+    /// Used to issue warnings in Rust 1.2, not needed after that.
+    /// True if the result of `base_object_lifetime_default` differs
+    /// from the result of `object_lifetime_default`.
+    fn base_object_lifetime_default_differs(&self) -> bool {
+        false
+    }
 }
 
 // A scope in which all regions must be explicitly named. This is used
@@ -219,6 +232,30 @@ impl<'r> RegionScope for ObjectLifetimeDefaultRscope<'r> {
         assert!(false, "this code should not execute until Rust 1.3");
         self.base_scope.base_object_lifetime_default(span)
     }
+
+    fn object_lifetime_default_will_change_in_1_3(&self) -> bool {
+        debug!("object_lifetime_default_will_change_in_1_3: {:?}", self.default);
+
+        match self.default {
+            ty::ObjectLifetimeDefault::Ambiguous |
+            ty::ObjectLifetimeDefault::Specific(_) =>
+                false,
+
+            ty::ObjectLifetimeDefault::BaseDefault =>
+                self.base_scope.base_object_lifetime_default_differs()
+        }
+    }
+
+    fn base_object_lifetime_default_differs(&self) -> bool {
+        debug!("base_object_lifetime_default_differs: {:?}", self.default);
+
+        match self.default {
+            ty::ObjectLifetimeDefault::Ambiguous |
+            ty::ObjectLifetimeDefault::Specific(_) =>
+                true,
+
+            ty::ObjectLifetimeDefault::BaseDefault =>
+                self.base_scope.base_object_lifetime_default_differs(),
         }
     }
 

--- a/src/test/auxiliary/lifetime_bound_will_change_warning_lib.rs
+++ b/src/test/auxiliary/lifetime_bound_will_change_warning_lib.rs
@@ -1,0 +1,21 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rlib"]
+
+// Helper for testing that we get suitable warnings when lifetime
+// bound change will cause breakage.
+
+pub fn just_ref(x: &Fn()) {
+}
+
+pub fn ref_obj(x: &Box<Fn()>) {
+    // this will change to &Box<Fn()+'static>...
+}

--- a/src/test/compile-fail/issue-24446.rs
+++ b/src/test/compile-fail/issue-24446.rs
@@ -11,7 +11,7 @@
 fn main() {
     static foo: Fn() -> u32 = || -> u32 {
         //~^ ERROR: mismatched types:
-        //~| expected `core::ops::Fn() -> u32`,
+        //~| expected `core::ops::Fn() -> u32 + 'static`,
         //~| found closure
         //~| (expected trait core::ops::Fn,
         //~| found closure)

--- a/src/test/compile-fail/lifetime-bound-will-change-warning.rs
+++ b/src/test/compile-fail/lifetime-bound-will-change-warning.rs
@@ -1,0 +1,64 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:lifetime_bound_will_change_warning_lib.rs
+
+// Test that we get suitable warnings when lifetime bound change will
+// cause breakage.
+
+#![allow(dead_code)]
+#![allow(unused_variables)]
+#![feature(rustc_attrs)]
+
+extern crate lifetime_bound_will_change_warning_lib as lib;
+
+fn just_ref(x: &Fn()) {
+}
+
+fn ref_obj(x: &Box<Fn()>) {
+    // this will change to &Box<Fn()+'static>...
+
+    // Note: no warning is issued here, because the type of `x` will change to 'static
+    if false { ref_obj(x); }
+}
+
+fn test1<'a>(x: &'a Box<Fn()+'a>) {
+    // just_ref will stay the same.
+    just_ref(&**x)
+}
+
+fn test1cc<'a>(x: &'a Box<Fn()+'a>) {
+    // same as test1, but cross-crate
+    lib::just_ref(&**x)
+}
+
+fn test2<'a>(x: &'a Box<Fn()+'a>) {
+    // but ref_obj will not, so warn.
+    ref_obj(x) //~ WARNING this code may fail to compile in Rust 1.3
+}
+
+fn test2cc<'a>(x: &'a Box<Fn()+'a>) {
+    // same as test2, but cross crate
+    lib::ref_obj(x) //~ WARNING this code may fail to compile in Rust 1.3
+}
+
+fn test3<'a>(x: &'a Box<Fn()+'static>) {
+    // here, we have a 'static bound, so even when ref_obj changes, no error results
+    ref_obj(x)
+}
+
+fn test3cc<'a>(x: &'a Box<Fn()+'static>) {
+    // same as test3, but cross crate
+    lib::ref_obj(x)
+}
+
+#[rustc_error]
+fn main() { //~ ERROR compilation successful
+}

--- a/src/test/compile-fail/object-lifetime-default-elision.rs
+++ b/src/test/compile-fail/object-lifetime-default-elision.rs
@@ -41,6 +41,7 @@ fn load0<'a>(ss: &'a Box<SomeTrait>) -> Box<SomeTrait> {
 
     deref(ss)
         //~^ ERROR cannot infer
+        //~| WARNING E0398
 }
 
 fn load1(ss: &SomeTrait) -> &SomeTrait {

--- a/src/test/compile-fail/object-lifetime-default-elision.rs
+++ b/src/test/compile-fail/object-lifetime-default-elision.rs
@@ -41,7 +41,6 @@ fn load0<'a>(ss: &'a Box<SomeTrait>) -> Box<SomeTrait> {
 
     deref(ss)
         //~^ ERROR cannot infer
-        //~| WARNING E0398
 }
 
 fn load1(ss: &SomeTrait) -> &SomeTrait {

--- a/src/test/compile-fail/object-lifetime-default-mybox.rs
+++ b/src/test/compile-fail/object-lifetime-default-mybox.rs
@@ -28,7 +28,6 @@ fn deref<T>(ss: &T) -> T {
 
 fn load0(ss: &MyBox<SomeTrait>) -> MyBox<SomeTrait> {
     deref(ss) //~ ERROR cannot infer
-        //~^ WARNING E0398
 }
 
 fn load1<'a,'b>(a: &'a MyBox<SomeTrait>,
@@ -38,6 +37,10 @@ fn load1<'a,'b>(a: &'a MyBox<SomeTrait>,
     a
       //~^ ERROR cannot infer
       //~| ERROR mismatched types
+}
+
+fn load2<'a>(ss: &MyBox<SomeTrait+'a>) -> MyBox<SomeTrait+'a> {
+    load0(ss) //~ WARNING E0398
 }
 
 fn main() {

--- a/src/test/compile-fail/object-lifetime-default-mybox.rs
+++ b/src/test/compile-fail/object-lifetime-default-mybox.rs
@@ -28,6 +28,7 @@ fn deref<T>(ss: &T) -> T {
 
 fn load0(ss: &MyBox<SomeTrait>) -> MyBox<SomeTrait> {
     deref(ss) //~ ERROR cannot infer
+        //~^ WARNING E0398
 }
 
 fn load1<'a,'b>(a: &'a MyBox<SomeTrait>,

--- a/src/test/compile-fail/object-lifetime-default.rs
+++ b/src/test/compile-fail/object-lifetime-default.rs
@@ -11,10 +11,10 @@
 #![feature(rustc_attrs)]
 
 #[rustc_object_lifetime_default]
-struct A<T>(T); //~ ERROR None
+struct A<T>(T); //~ ERROR BaseDefault
 
 #[rustc_object_lifetime_default]
-struct B<'a,T>(&'a (), T); //~ ERROR None
+struct B<'a,T>(&'a (), T); //~ ERROR BaseDefault
 
 #[rustc_object_lifetime_default]
 struct C<'a,T:'a>(&'a T); //~ ERROR 'a

--- a/src/test/compile-fail/object-lifetime-default.rs
+++ b/src/test/compile-fail/object-lifetime-default.rs
@@ -29,6 +29,6 @@ struct E<'a,'b:'a,T:'b>(&'a T, &'b T); //~ ERROR 'b
 struct F<'a,'b,T:'a,U:'b>(&'a T, &'b U); //~ ERROR 'a,'b
 
 #[rustc_object_lifetime_default]
-struct G<'a,'b,T:'a,U:'a+'b>(&'a T, &'b U); //~ ERROR 'a,Some(Ambiguous)
+struct G<'a,'b,T:'a,U:'a+'b>(&'a T, &'b U); //~ ERROR 'a,Ambiguous
 
 fn main() { }

--- a/src/test/compile-fail/trait-bounds-cant-coerce.rs
+++ b/src/test/compile-fail/trait-bounds-cant-coerce.rs
@@ -22,8 +22,8 @@ fn c(x: Box<Foo+Sync+Send>) {
 
 fn d(x: Box<Foo>) {
     a(x); //~  ERROR mismatched types
-          //~| expected `Box<Foo + Send>`
-          //~| found `Box<Foo>`
+          //~| expected `Box<Foo + Send + 'static>`
+          //~| found `Box<Foo + 'static>`
           //~| expected bounds `Send`
           //~| found no bounds
 }

--- a/src/test/run-pass/issue-21058.rs
+++ b/src/test/run-pass/issue-21058.rs
@@ -26,5 +26,5 @@ fn main() {
         std::intrinsics::type_name::<NT>(),
         // DST
         std::intrinsics::type_name::<DST>()
-    )}, ("[u8]", "str", "core::marker::Copy", "NT", "DST"));
+    )}, ("[u8]", "str", "core::marker::Copy + 'static", "NT", "DST"));
 }


### PR DESCRIPTION
This is an implementation of RFC rust-lang/rfcs#1156. It includes the code to implement the new rules, but that code is currently disabled. It also includes code to issue warnings when the change will cause breakage. These warnings try hard to be targeted but are also somewhat approximate. They could, with some effort, be made _more_ targeted by adjusting the code in ty_relate that propagates the "will change" flag to consider the specific operation. Might be worth doing.

r? @pnkfelix (I think you understand region inference best)
