### PR TITLE
mk: Fix reconfiguring top-level ./configure

### DIFF
--- a/mk/reconfig.mk
+++ b/mk/reconfig.mk
@@ -32,6 +32,12 @@ endif
 
 Makefile config.mk: config.stamp
 
+ifeq ($(SREL),)
+SREL_ROOT := ./
+else
+SREL_ROOT := $(SREL)
+endif
+
 config.stamp: $(S)configure $(S)Makefile.in $(S)src/snapshots.txt
 	@$(call E, cfg: reconfiguring)
-	$(SREL)configure $(CFG_CONFIGURE_ARGS)
+	$(SREL_ROOT)configure $(CFG_CONFIGURE_ARGS)


### PR DESCRIPTION
In #26252 support was added to have prettier paths printed out on failure by not
passing the full path to the source file to the compiler, but instead just a
small relative path. To preserve this relative path across configurations, the
`SREL` variable was used for reconfiguring, but if `SREL` is empty then it will
attempt to run the command `configure` which is distinct from running
`./configure` (e.g. doesn't run the local script).

This commit modifies the `SREL` value to re-run the configure script by setting
it to `./` in the case where `SREL` is empty.
