### PR TITLE
Fix the E0252 error message to use better names for things.

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -12,6 +12,7 @@ use self::ImportDirectiveSubclass::*;
 
 use DefModifiers;
 use Module;
+use ModuleKind;
 use Namespace::{self, TypeNS, ValueNS};
 use NameBindings;
 use NamespaceResult::{BoundResult, UnboundResult, UnknownResult};
@@ -899,7 +900,19 @@ impl<'a, 'b:'a, 'tcx:'b> ImportResolver<'a, 'b, 'tcx> {
         match target {
             Some(ref target) if target.shadowable != Shadowable::Always => {
                 let ns_word = match namespace {
-                    TypeNS => "type",
+                    TypeNS => {
+                        if let Some(ref ty_def) = *target.bindings.type_def.borrow() {
+                            match ty_def.module_def {
+                                Some(ref module)
+                                    if module.kind.get() == ModuleKind::NormalModuleKind =>
+                                        "module",
+                                Some(ref module)
+                                    if module.kind.get() == ModuleKind::TraitModuleKind =>
+                                        "trait",
+                                _ => "type",
+                            }
+                        } else { "type" }
+                    },
                     ValueNS => "value",
                 };
                 span_err!(self.resolver.session, import_span, E0252,

--- a/src/test/compile-fail/issue-25396.rs
+++ b/src/test/compile-fail/issue-25396.rs
@@ -1,0 +1,37 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use foo::baz;
+use bar::baz; //~ ERROR a module named `baz` has already been imported
+
+use foo::Quux;
+use bar::Quux; //~ ERROR a trait named `Quux` has already been imported
+
+use foo::blah;
+use bar::blah; //~ ERROR a type named `blah` has already been imported
+
+use foo::WOMP;
+use bar::WOMP; //~ ERROR a value named `WOMP` has already been imported
+
+fn main() {}
+
+mod foo {
+    pub mod baz {}
+    pub trait Quux { }
+    pub type blah = (f64, u32);
+    pub const WOMP: u8 = 5;
+}
+
+mod bar {
+    pub mod baz {}
+    pub type Quux = i32;
+    struct blah { x: i8 }
+    pub const WOMP: i8 = -5;
+}


### PR DESCRIPTION
Currently in the E0252 message, traits and modules are all called types (as in "a type named `Foo` has already been imported", even when `Foo` was a trait or module). This commit changes that to additionally detect when the import in question is a trait or module and report it accordingly.

Fixes #25396.
