### PR TITLE
Work-around optimiser deficiencies in `Range` iterator.

### DIFF
--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -2797,14 +2797,12 @@ impl<A> Iterator for RangeInclusive<A> where
 
     #[inline]
     fn next(&mut self) -> Option<A> {
-        self.range.next().or_else(|| {
-            if !self.done && self.range.start == self.range.end {
-                self.done = true;
-                Some(self.range.end.clone())
-            } else {
-                None
-            }
-        })
+        if !self.done && self.range.start == self.range.end {
+            self.done = true;
+            Some(self.range.end.clone())
+        } else {
+            self.range.next()
+        }
     }
 
     #[inline]

--- a/src/libcore/iter.rs
+++ b/src/libcore/iter.rs
@@ -2896,9 +2896,17 @@ impl<A: Step + One> Iterator for ops::Range<A> where
 
     #[inline]
     fn next(&mut self) -> Option<A> {
-        if self.start < self.end {
-            let mut n = &self.start + &A::one();
-            mem::swap(&mut n, &mut self.start);
+        // FIXME #24660: this may start returning Some after returning
+        // None if the + overflows. This is OK per Iterator's
+        // definition, but it would be really nice for a core iterator
+        // like `x..y` to be as well behaved as
+        // possible. Unfortunately, for types like `i32`, LLVM
+        // mishandles the version that places the mutation inside the
+        // `if`: it seems to optimise the `Option<i32>` in a way that
+        // confuses it.
+        let mut n = &self.start + &A::one();
+        mem::swap(&mut n, &mut self.start);
+        if n < self.end {
             Some(n)
         } else {
             None

--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -1167,3 +1167,10 @@ fn bench_max(b: &mut Bencher) {
         it.map(scatter).max()
     })
 }
+
+#[bench]
+fn bench_range_constant_fold(b: &mut Bencher) {
+    // this should be constant-folded to just '1000', and so this
+    // benchmark should run quickly...
+    b.iter(|| (0..1000).count())
+}


### PR DESCRIPTION
closes #24705

the issue in the other PR was that the inclusive range iterator depended on internals of the normal range iterator

> range_inclusive (https://github.com/rust-lang/rust/blob/master/src/libcore/iter.rs#L2799-2808) won't work anymore due to the `self.range.start == self.range.end` check. This will cause https://github.com/rust-lang/rust/blob/master/src/librustc/middle/check_match.rs#L605 to produce `0` elements for `range_inclusive(0, 0)`

which then causes the match arm reachability to fail

This was not detected by the test-suite, because the failure happens during stage1 compilation of the standard libraries.

r? @aturon 
cc @huonw @pythonesque @pnkfelix 
