### PR TITLE
remove unused functions from trans and llvm

### DIFF
--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -1300,20 +1300,8 @@ extern {
                         -> ValueRef;
 
     /* Memory */
-    pub fn LLVMBuildMalloc(B: BuilderRef, Ty: TypeRef, Name: *const c_char)
-                           -> ValueRef;
-    pub fn LLVMBuildArrayMalloc(B: BuilderRef,
-                                Ty: TypeRef,
-                                Val: ValueRef,
-                                Name: *const c_char)
-                                -> ValueRef;
     pub fn LLVMBuildAlloca(B: BuilderRef, Ty: TypeRef, Name: *const c_char)
                            -> ValueRef;
-    pub fn LLVMBuildArrayAlloca(B: BuilderRef,
-                                Ty: TypeRef,
-                                Val: ValueRef,
-                                Name: *const c_char)
-                                -> ValueRef;
     pub fn LLVMBuildFree(B: BuilderRef, PointerVal: ValueRef) -> ValueRef;
     pub fn LLVMBuildLoad(B: BuilderRef,
                          PointerVal: ValueRef,

--- a/src/librustc_trans/trans/build.rs
+++ b/src/librustc_trans/trans/build.rs
@@ -522,30 +522,6 @@ pub fn Not(cx: Block, v: ValueRef, debug_loc: DebugLoc) -> ValueRef {
     B(cx).not(v)
 }
 
-/* Memory */
-pub fn Malloc(cx: Block, ty: Type, debug_loc: DebugLoc) -> ValueRef {
-    unsafe {
-        if cx.unreachable.get() {
-            return llvm::LLVMGetUndef(Type::i8p(cx.ccx()).to_ref());
-        }
-        debug_loc.apply(cx.fcx);
-        B(cx).malloc(ty)
-    }
-}
-
-pub fn ArrayMalloc(cx: Block,
-                   ty: Type,
-                   val: ValueRef,
-                   debug_loc: DebugLoc) -> ValueRef {
-    unsafe {
-        if cx.unreachable.get() {
-            return llvm::LLVMGetUndef(Type::i8p(cx.ccx()).to_ref());
-        }
-        debug_loc.apply(cx.fcx);
-        B(cx).array_malloc(ty, val)
-    }
-}
-
 pub fn Alloca(cx: Block, ty: Type, name: &str) -> ValueRef {
     unsafe {
         if cx.unreachable.get() { return llvm::LLVMGetUndef(ty.ptr_to().to_ref()); }
@@ -558,16 +534,6 @@ pub fn AllocaFcx(fcx: &FunctionContext, ty: Type, name: &str) -> ValueRef {
     b.position_before(fcx.alloca_insert_pt.get().unwrap());
     DebugLoc::None.apply(fcx);
     b.alloca(ty, name)
-}
-
-pub fn ArrayAlloca(cx: Block, ty: Type, val: ValueRef) -> ValueRef {
-    unsafe {
-        if cx.unreachable.get() { return llvm::LLVMGetUndef(ty.ptr_to().to_ref()); }
-        let b = cx.fcx.ccx.builder();
-        b.position_before(cx.fcx.alloca_insert_pt.get().unwrap());
-        DebugLoc::None.apply(cx.fcx);
-        b.array_alloca(ty, val)
-    }
 }
 
 pub fn Free(cx: Block, pointer_val: ValueRef) {

--- a/src/librustc_trans/trans/builder.rs
+++ b/src/librustc_trans/trans/builder.rs
@@ -410,21 +410,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         }
     }
 
-    /* Memory */
-    pub fn malloc(&self, ty: Type) -> ValueRef {
-        self.count_insn("malloc");
-        unsafe {
-            llvm::LLVMBuildMalloc(self.llbuilder, ty.to_ref(), noname())
-        }
-    }
-
-    pub fn array_malloc(&self, ty: Type, val: ValueRef) -> ValueRef {
-        self.count_insn("arraymalloc");
-        unsafe {
-            llvm::LLVMBuildArrayMalloc(self.llbuilder, ty.to_ref(), val, noname())
-        }
-    }
-
     pub fn alloca(&self, ty: Type, name: &str) -> ValueRef {
         self.count_insn("alloca");
         unsafe {
@@ -435,13 +420,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 llvm::LLVMBuildAlloca(self.llbuilder, ty.to_ref(),
                                       name.as_ptr())
             }
-        }
-    }
-
-    pub fn array_alloca(&self, ty: Type, val: ValueRef) -> ValueRef {
-        self.count_insn("arrayalloca");
-        unsafe {
-            llvm::LLVMBuildArrayAlloca(self.llbuilder, ty.to_ref(), val, noname())
         }
     }
 


### PR DESCRIPTION
These aren't used anywhere and to my current knowledge it's unlikely that they are going to be used in the future
