### PR TITLE
Pass fat pointers in two immediate arguments

### DIFF
--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -2252,6 +2252,18 @@ pub fn get_param(llfn: ValueRef, index: c_uint) -> ValueRef {
     }
 }
 
+pub fn get_params(llfn: ValueRef) -> Vec<ValueRef> {
+    unsafe {
+        let num_params = LLVMCountParams(llfn);
+        let mut params = Vec::with_capacity(num_params as usize);
+        for idx in 0..num_params {
+            params.push(LLVMGetParam(llfn, idx));
+        }
+
+        params
+    }
+}
+
 #[allow(missing_copy_implementations)]
 pub enum RustString_opaque {}
 pub type RustStringRef = *mut RustString_opaque;

--- a/src/librustc_trans/trans/closure.rs
+++ b/src/librustc_trans/trans/closure.rs
@@ -411,7 +411,8 @@ fn trans_fn_once_adapter_shim<'a, 'tcx>(
     let self_scope = fcx.push_custom_cleanup_scope();
     let self_scope_id = CustomScope(self_scope);
     let rvalue_mode = datum::appropriate_rvalue_mode(ccx, closure_ty);
-    let llself = llargs[fcx.arg_pos(0)];
+    let self_idx = fcx.arg_offset();
+    let llself = llargs[self_idx];
     let env_datum = Datum::new(llself, closure_ty, Rvalue::new(rvalue_mode));
     let env_datum = unpack_datum!(bcx,
                                   env_datum.to_lvalue_datum_in_scope(bcx, "self",
@@ -431,7 +432,7 @@ fn trans_fn_once_adapter_shim<'a, 'tcx>(
                                    DebugLoc::None,
                                    llref_fn_ty,
                                    |bcx, _| Callee { bcx: bcx, data: callee_data },
-                                   ArgVals(&llargs[fcx.arg_pos(1)..]),
+                                   ArgVals(&llargs[(self_idx + 1)..]),
                                    dest).bcx;
 
     fcx.pop_custom_cleanup_scope(self_scope);

--- a/src/librustc_trans/trans/closure.rs
+++ b/src/librustc_trans/trans/closure.rs
@@ -10,7 +10,7 @@
 
 use arena::TypedArena;
 use back::link::{self, mangle_internal_name_by_path_and_seq};
-use llvm::{ValueRef, get_param};
+use llvm::{ValueRef, get_params};
 use middle::mem_categorization::Typer;
 use trans::adt;
 use trans::attributes;
@@ -405,11 +405,13 @@ fn trans_fn_once_adapter_shim<'a, 'tcx>(
                       &block_arena);
     let mut bcx = init_function(&fcx, false, sig.output);
 
+    let llargs = get_params(fcx.llfn);
+
     // the first argument (`self`) will be the (by value) closure env.
     let self_scope = fcx.push_custom_cleanup_scope();
     let self_scope_id = CustomScope(self_scope);
     let rvalue_mode = datum::appropriate_rvalue_mode(ccx, closure_ty);
-    let llself = get_param(lloncefn, fcx.arg_pos(0) as u32);
+    let llself = llargs[fcx.arg_pos(0)];
     let env_datum = Datum::new(llself, closure_ty, Rvalue::new(rvalue_mode));
     let env_datum = unpack_datum!(bcx,
                                   env_datum.to_lvalue_datum_in_scope(bcx, "self",
@@ -417,19 +419,6 @@ fn trans_fn_once_adapter_shim<'a, 'tcx>(
 
     debug!("trans_fn_once_adapter_shim: env_datum={}",
            bcx.val_to_string(env_datum.val));
-
-    // the remaining arguments will be packed up in a tuple.
-    let input_tys = match sig.inputs[1].sty {
-        ty::TyTuple(ref tys) => &**tys,
-        _ => bcx.sess().bug(&format!("trans_fn_once_adapter_shim: not rust-call! \
-                                      closure_def_id={:?}",
-                                     closure_def_id))
-    };
-    let llargs: Vec<_> =
-        input_tys.iter()
-                 .enumerate()
-                 .map(|(i, _)| get_param(lloncefn, fcx.arg_pos(i+1) as u32))
-                 .collect();
 
     let dest =
         fcx.llretslotptr.get().map(
@@ -442,7 +431,7 @@ fn trans_fn_once_adapter_shim<'a, 'tcx>(
                                    DebugLoc::None,
                                    llref_fn_ty,
                                    |bcx, _| Callee { bcx: bcx, data: callee_data },
-                                   ArgVals(&llargs),
+                                   ArgVals(&llargs[fcx.arg_pos(1)..]),
                                    dest).bcx;
 
     fcx.pop_custom_cleanup_scope(self_scope);

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -421,13 +421,8 @@ pub struct FunctionContext<'a, 'tcx: 'a> {
 }
 
 impl<'a, 'tcx> FunctionContext<'a, 'tcx> {
-    pub fn arg_pos(&self, arg: usize) -> usize {
-        let arg = self.env_arg_pos() + arg;
-        if self.llenv.is_some() {
-            arg + 1
-        } else {
-            arg
-        }
+    pub fn arg_offset(&self) -> usize {
+        self.env_arg_pos() + if self.llenv.is_some() { 1 } else { 0 }
     }
 
     pub fn env_arg_pos(&self) -> usize {

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -293,6 +293,9 @@ pub fn get_dataptr(bcx: Block, fat_ptr: ValueRef) -> ValueRef {
     GEPi(bcx, fat_ptr, &[0, abi::FAT_PTR_ADDR])
 }
 
+pub fn make_fat_ptr(bcx: Block, ty: Type, data: ValueRef, extra: ValueRef) -> ValueRef {
+    InsertValue(bcx, InsertValue(bcx, C_undef(ty), data, 0), extra, 1)
+}
 pub fn copy_fat_ptr(bcx: Block, src_ptr: ValueRef, dst_ptr: ValueRef) {
     Store(bcx, Load(bcx, get_dataptr(bcx, src_ptr)), get_dataptr(bcx, dst_ptr));
     Store(bcx, Load(bcx, get_len(bcx, src_ptr)), get_len(bcx, dst_ptr));

--- a/src/librustc_trans/trans/glue.rs
+++ b/src/librustc_trans/trans/glue.rs
@@ -259,7 +259,7 @@ fn get_drop_glue_core<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     // llfn is expected be declared to take a parameter of the appropriate
     // type, so we don't need to explicitly cast the function parameter.
 
-    let llrawptr0 = get_param(llfn, fcx.arg_pos(0) as c_uint);
+    let llrawptr0 = get_param(llfn, fcx.arg_offset() as c_uint);
     let bcx = make_drop_glue(bcx, llrawptr0, g);
     finish_fn(&fcx, bcx, ty::FnConverging(ty::mk_nil(ccx.tcx())), DebugLoc::None);
 

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -275,17 +275,13 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
             } else {
                 (&exprs[0], &exprs[1])
             };
-            let arg_tys = ty::erase_late_bound_regions(bcx.tcx(), &ty::ty_fn_args(callee_ty));
 
             // evaluate destination address
-            let lldest_addr = unpack_result!(bcx, {
-                let dest_datum = unpack_datum!(bcx, expr::trans(bcx, dest_expr));
-                callee::trans_arg_datum(bcx,
-                                        arg_tys[0],
-                                        dest_datum,
-                                        cleanup::CustomScope(cleanup_scope),
-                                        callee::DontAutorefArg)
-            });
+            let dest_datum = unpack_datum!(bcx, expr::trans(bcx, dest_expr));
+            let dest_datum = unpack_datum!(
+                bcx, dest_datum.to_rvalue_datum(bcx, "arg"));
+            let dest_datum = unpack_datum!(
+                bcx, dest_datum.to_appropriate_datum(bcx));
 
             // `expr::trans_into(bcx, expr, dest)` is equiv to
             //
@@ -294,7 +290,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
             // which for `dest == expr::SaveIn(addr)`, is equivalent to:
             //
             //    `trans(bcx, expr).store_to(bcx, addr)`.
-            let lldest = expr::Dest::SaveIn(lldest_addr);
+            let lldest = expr::Dest::SaveIn(dest_datum.val);
             bcx = expr::trans_into(bcx, source_expr, lldest);
 
             let llresult = C_nil(ccx);
@@ -370,8 +366,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         (_, "size_of_val") => {
             let tp_ty = *substs.types.get(FnSpace, 0);
             if !type_is_sized(tcx, tp_ty) {
-                let info = Load(bcx, expr::get_len(bcx, llargs[0]));
-                let (llsize, _) = glue::size_and_align_of_dst(bcx, tp_ty, info);
+                let (llsize, _) = glue::size_and_align_of_dst(bcx, tp_ty, llargs[1]);
                 llsize
             } else {
                 let lltp_ty = type_of::type_of(ccx, tp_ty);
@@ -385,8 +380,7 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         (_, "min_align_of_val") => {
             let tp_ty = *substs.types.get(FnSpace, 0);
             if !type_is_sized(tcx, tp_ty) {
-                let info = Load(bcx, expr::get_len(bcx, llargs[0]));
-                let (_, llalign) = glue::size_and_align_of_dst(bcx, tp_ty, info);
+                let (_, llalign) = glue::size_and_align_of_dst(bcx, tp_ty, llargs[1]);
                 llalign
             } else {
                 C_uint(ccx, type_of::align_of(ccx, tp_ty))
@@ -399,7 +393,16 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         }
         (_, "drop_in_place") => {
             let tp_ty = *substs.types.get(FnSpace, 0);
-            glue::drop_ty(bcx, llargs[0], tp_ty, call_debug_location);
+            let ptr = if type_is_sized(tcx, tp_ty) {
+                llargs[0]
+            } else {
+                let scratch = rvalue_scratch_datum(bcx, tp_ty, "tmp");
+                Store(bcx, llargs[0], expr::get_dataptr(bcx, scratch.val));
+                Store(bcx, llargs[1], expr::get_len(bcx, scratch.val));
+                fcx.schedule_lifetime_end(cleanup::CustomScope(cleanup_scope), scratch.val);
+                scratch.val
+            };
+            glue::drop_ty(bcx, ptr, tp_ty, call_debug_location);
             C_nil(ccx)
         }
         (_, "type_name") => {
@@ -980,7 +983,7 @@ fn with_overflow_intrinsic<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let ret = C_undef(type_of::type_of(bcx.ccx(), t));
     let ret = InsertValue(bcx, ret, result, 0);
     let ret = InsertValue(bcx, ret, overflow, 1);
-    if type_is_immediate(bcx.ccx(), t) {
+    if !arg_is_indirect(bcx.ccx(), t) {
         let tmp = alloc_ty(bcx, t, "tmp");
         Store(bcx, ret, tmp);
         load_ty(bcx, tmp, t)

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -468,7 +468,9 @@ fn trans_trait_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         self_datum.val
     };
 
-    trans_trait_callee_from_llval(bcx, method_ty, vtable_index, llval)
+    let llself = Load(bcx, GEPi(bcx, llval, &[0, abi::FAT_PTR_ADDR]));
+    let llvtable = Load(bcx, GEPi(bcx, llval, &[0, abi::FAT_PTR_EXTRA]));
+    trans_trait_callee_from_llval(bcx, method_ty, vtable_index, llself, llvtable)
 }
 
 /// Same as `trans_trait_callee()` above, except that it is given a by-ref pointer to the object
@@ -476,19 +478,18 @@ fn trans_trait_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 pub fn trans_trait_callee_from_llval<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                                  callee_ty: Ty<'tcx>,
                                                  vtable_index: usize,
-                                                 llpair: ValueRef)
+                                                 llself: ValueRef,
+                                                 llvtable: ValueRef)
                                                  -> Callee<'blk, 'tcx> {
     let _icx = push_ctxt("meth::trans_trait_callee");
     let ccx = bcx.ccx();
 
     // Load the data pointer from the object.
-    debug!("trans_trait_callee_from_llval(callee_ty={}, vtable_index={}, llpair={})",
+    debug!("trans_trait_callee_from_llval(callee_ty={}, vtable_index={}, llself={}, llvtable={})",
            callee_ty,
            vtable_index,
-           bcx.val_to_string(llpair));
-    let llboxptr = GEPi(bcx, llpair, &[0, abi::FAT_PTR_ADDR]);
-    let llbox = Load(bcx, llboxptr);
-    let llself = PointerCast(bcx, llbox, Type::i8p(ccx));
+           bcx.val_to_string(llself),
+           bcx.val_to_string(llvtable));
 
     // Replace the self type (&Self or Box<Self>) with an opaque pointer.
     let llcallee_ty = match callee_ty.sty {
@@ -505,19 +506,13 @@ pub fn trans_trait_callee_from_llval<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             ccx.sess().bug("meth::trans_trait_callee given non-bare-rust-fn");
         }
     };
-    let llvtable = Load(bcx,
-                        PointerCast(bcx,
-                                    GEPi(bcx, llpair,
-                                         &[0, abi::FAT_PTR_EXTRA]),
-                                    Type::vtable(ccx).ptr_to().ptr_to()));
-    let mptr = Load(bcx, GEPi(bcx, llvtable, &[0, vtable_index + VTABLE_OFFSET]));
-    let mptr = PointerCast(bcx, mptr, llcallee_ty.ptr_to());
+    let mptr = Load(bcx, GEPi(bcx, llvtable, &[vtable_index + VTABLE_OFFSET]));
 
     return Callee {
         bcx: bcx,
         data: TraitItem(MethodData {
-            llfn: mptr,
-            llself: llself,
+            llfn: PointerCast(bcx, mptr, llcallee_ty.ptr_to()),
+            llself: PointerCast(bcx, llself, Type::i8p(ccx)),
         })
     };
 }
@@ -613,11 +608,12 @@ pub fn trans_object_shim<'a, 'tcx>(
 
     let llargs = get_params(fcx.llfn);
 
-    // the first argument (`self`) will be a trait object
-    let llobject = llargs[fcx.arg_pos(0)];
+    let self_idx = fcx.arg_offset();
+    let llself = llargs[self_idx];
+    let llvtable = llargs[self_idx + 1];
 
-    debug!("trans_object_shim: llobject={}",
-           bcx.val_to_string(llobject));
+    debug!("trans_object_shim: llself={}, llvtable={}",
+           bcx.val_to_string(llself), bcx.val_to_string(llvtable));
 
     assert!(!fcx.needs_ret_allocas);
 
@@ -639,8 +635,8 @@ pub fn trans_object_shim<'a, 'tcx>(
                            |bcx, _| trans_trait_callee_from_llval(bcx,
                                                                   method_bare_fn_ty,
                                                                   method_offset_in_vtable,
-                                                                  llobject),
-                           ArgVals(&llargs[fcx.arg_pos(1)..]),
+                                                                  llself, llvtable),
+                           ArgVals(&llargs[(self_idx + 2)..]),
                            dest).bcx;
 
     finish_fn(&fcx, bcx, sig.output, DebugLoc::None);

--- a/src/librustc_trans/trans/type_.rs
+++ b/src/librustc_trans/trans/type_.rs
@@ -171,10 +171,6 @@ impl Type {
         Type::struct_(ccx, &[], false)
     }
 
-    pub fn vtable(ccx: &CrateContext) -> Type {
-        Type::array(&Type::i8p(ccx).ptr_to(), 1)
-    }
-
     pub fn glue_fn(ccx: &CrateContext, t: Type) -> Type {
         Type::func(&[t], &Type::void(ccx))
     }

--- a/src/test/codegen/function-arguments.rs
+++ b/src/test/codegen/function-arguments.rs
@@ -87,6 +87,53 @@ pub fn struct_return() -> S {
   }
 }
 
+// Hack to get the correct size for the length part in slices
+// CHECK: @helper([[USIZE:i[0-9]+]])
+#[no_mangle]
+fn helper(_: usize) {
+}
+
+// CHECK: @slice(i8* noalias nonnull readonly, [[USIZE]])
+// FIXME #25759 This should also have `nocapture`
+#[no_mangle]
+fn slice(_: &[u8]) {
+}
+
+// CHECK: @mutable_slice(i8* noalias nonnull, [[USIZE]])
+// FIXME #25759 This should also have `nocapture`
+#[no_mangle]
+fn mutable_slice(_: &mut [u8]) {
+}
+
+// CHECK: @unsafe_slice(%UnsafeInner* nonnull, [[USIZE]])
+// unsafe interior means this isn't actually readonly and there may be aliases ...
+#[no_mangle]
+pub fn unsafe_slice(_: &[UnsafeInner]) {
+}
+
+// CHECK: @str(i8* noalias nonnull readonly, [[USIZE]])
+// FIXME #25759 This should also have `nocapture`
+#[no_mangle]
+fn str(_: &[u8]) {
+}
+
+// CHECK: @trait_borrow(i8* nonnull, void (i8*)** nonnull)
+// FIXME #25759 This should also have `nocapture`
+#[no_mangle]
+fn trait_borrow(_: &Drop) {
+}
+
+// CHECK: @trait_box(i8* noalias nonnull, void (i8*)** nonnull)
+#[no_mangle]
+fn trait_box(_: Box<Drop>) {
+}
+
+// CHECK: { i16*, [[USIZE]] } @return_slice(i16* noalias nonnull readonly, [[USIZE]])
+#[no_mangle]
+fn return_slice(x: &[u16]) -> &[u16] {
+  x
+}
+
 // CHECK: noalias i8* @allocator()
 #[no_mangle]
 #[allocator]

--- a/src/test/run-pass/backtrace-debuginfo.rs
+++ b/src/test/run-pass/backtrace-debuginfo.rs
@@ -97,10 +97,6 @@ fn inner_inlined(counter: &mut i32, main_pos: Pos, outer_pos: Pos) {
     let inner_pos = pos!(); aux::callback_inlined(|aux_pos| {
         check!(counter; main_pos, outer_pos, inner_pos, aux_pos);
     });
-
-    // this tests a distinction between two independent calls to the inlined function.
-    // (un)fortunately, LLVM somehow merges two consecutive such calls into one node.
-    inner_further_inlined(counter, main_pos, outer_pos, pos!());
 }
 
 #[inline(never)]


### PR DESCRIPTION
This has a number of advantages compared to creating a copy in memory
and passing a pointer. The obvious one is that we don't have to put the
data into memory but can keep it in registers. Since we're currently
passing a pointer anyway (instead of using e.g. a known offset on the
stack, which is what the `byval` attribute would achieve), we only use a
single additional register for each fat pointer, but save at least two
pointers worth of stack in exchange (sometimes more because more than
one copy gets eliminated). On archs that pass arguments on the stack, we
save a pointer worth of stack even without considering the omitted
copies.

Additionally, LLVM can optimize the code a lot better, to a large degree
due to the fact that lots of copies are gone or can be optimized away.
Additionally, we can now emit attributes like nonnull on the data and/or
vtable pointers contained in the fat pointer, potentially allowing for
even more optimizations.

This results in LLVM passes being about 3-7% faster (depending on the
crate), and the resulting code is also a few percent smaller, for
example:

| text | data | filename |
| --- | --- | --- |
| 5671479 | 3941461 | before/librustc-d8ace771.so |
| 5447663 | 3905745 | after/librustc-d8ace771.so |
|  |  |  |
| 1944425 | 2394024 | before/libstd-d8ace771.so |
| 1896769 | 2387610 | after/libstd-d8ace771.so |

I had to remove a call in the backtrace-debuginfo test, because LLVM can
now merge the tails of some blocks when optimizations are turned on,
which can't correctly preserve line info.

Fixes #22924

Cc #22891 (at least for fat pointers the code is good now)
