### PR TITLE
std: Add FromRaw{Fd,Handle,Socket} to os preludes

### DIFF
--- a/src/libstd/sys/unix/ext/mod.rs
+++ b/src/libstd/sys/unix/ext/mod.rs
@@ -41,7 +41,7 @@ pub mod raw;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub mod prelude {
     #[doc(no_inline)]
-    pub use super::io::{RawFd, AsRawFd};
+    pub use super::io::{RawFd, AsRawFd, FromRawFd};
     #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::ffi::{OsStrExt, OsStringExt};
     #[doc(no_inline)]

--- a/src/libstd/sys/windows/ext/mod.rs
+++ b/src/libstd/sys/windows/ext/mod.rs
@@ -29,6 +29,8 @@ pub mod process;
 pub mod prelude {
     #[doc(no_inline)]
     pub use super::io::{RawSocket, RawHandle, AsRawSocket, AsRawHandle};
+    #[doc(no_inline)]
+    pub use super::io::{FromRawSocket, FromRawHandle};
     #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::ffi::{OsStrExt, OsStringExt};
     #[doc(no_inline)]


### PR DESCRIPTION
These were just left out by mistake!
