### PR TITLE
Rename AsPredicate to ToPredicate in order to match naming conventions

### DIFF
--- a/src/librustc/metadata/tydecode.rs
+++ b/src/librustc/metadata/tydecode.rs
@@ -21,7 +21,7 @@ pub use self::DefIdSource::*;
 use middle::region;
 use middle::subst;
 use middle::subst::VecPerParamSpace;
-use middle::ty::{self, AsPredicate, Ty};
+use middle::ty::{self, ToPredicate, Ty};
 
 use std::str;
 use syntax::abi;
@@ -775,14 +775,14 @@ fn parse_predicate_<'a,'tcx, F>(st: &mut PState<'a, 'tcx>,
     F: FnMut(DefIdSource, ast::DefId) -> ast::DefId,
 {
     match next(st) {
-        't' => ty::Binder(parse_trait_ref_(st, conv)).as_predicate(),
+        't' => ty::Binder(parse_trait_ref_(st, conv)).to_predicate(),
         'e' => ty::Binder(ty::EquatePredicate(parse_ty_(st, conv),
-                                              parse_ty_(st, conv))).as_predicate(),
+                                              parse_ty_(st, conv))).to_predicate(),
         'r' => ty::Binder(ty::OutlivesPredicate(parse_region_(st, conv),
-                                                parse_region_(st, conv))).as_predicate(),
+                                                parse_region_(st, conv))).to_predicate(),
         'o' => ty::Binder(ty::OutlivesPredicate(parse_ty_(st, conv),
-                                                parse_region_(st, conv))).as_predicate(),
-        'p' => ty::Binder(parse_projection_predicate_(st, conv)).as_predicate(),
+                                                parse_region_(st, conv))).to_predicate(),
+        'p' => ty::Binder(parse_projection_predicate_(st, conv)).to_predicate(),
         c => panic!("Encountered invalid character in metadata: {}", c)
     }
 }

--- a/src/librustc/middle/implicator.rs
+++ b/src/librustc/middle/implicator.rs
@@ -13,7 +13,7 @@
 use middle::infer::{InferCtxt, GenericKind};
 use middle::subst::Substs;
 use middle::traits;
-use middle::ty::{self, RegionEscape, ToPolyTraitRef, AsPredicate, Ty};
+use middle::ty::{self, RegionEscape, ToPolyTraitRef, ToPredicate, Ty};
 use middle::ty_fold::{TypeFoldable, TypeFolder};
 
 use syntax::ast;
@@ -445,7 +445,7 @@ pub fn object_region_bounds<'tcx>(
     let trait_refs = vec!(ty::Binder(ty::TraitRef::new(principal.0.def_id, substs)));
 
     let mut predicates = others.to_predicates(tcx, open_ty);
-    predicates.extend(trait_refs.iter().map(|t| t.as_predicate()));
+    predicates.extend(trait_refs.iter().map(|t| t.to_predicate()));
 
     ty::required_region_bounds(tcx, open_ty, predicates)
 }

--- a/src/librustc/middle/traits/error_reporting.rs
+++ b/src/librustc/middle/traits/error_reporting.rs
@@ -25,7 +25,7 @@ use super::{
 
 use fmt_macros::{Parser, Piece, Position};
 use middle::infer::InferCtxt;
-use middle::ty::{self, AsPredicate, ReferencesError, ToPolyTraitRef, TraitRef};
+use middle::ty::{self, ToPredicate, ReferencesError, ToPolyTraitRef, TraitRef};
 use middle::ty_fold::TypeFoldable;
 use std::collections::HashMap;
 use std::fmt;
@@ -464,7 +464,7 @@ fn note_obligation_cause_code<'a, 'tcx, T>(infcx: &InferCtxt<'a, 'tcx>,
             span_note!(tcx.sess, cause_span,
                        "required because it appears within the type `{}`",
                        parent_trait_ref.0.self_ty());
-            let parent_predicate = parent_trait_ref.as_predicate();
+            let parent_predicate = parent_trait_ref.to_predicate();
             note_obligation_cause_code(infcx, &parent_predicate, cause_span, &*data.parent_code);
         }
         ObligationCauseCode::ImplDerivedObligation(ref data) => {
@@ -473,7 +473,7 @@ fn note_obligation_cause_code<'a, 'tcx, T>(infcx: &InferCtxt<'a, 'tcx>,
                        "required because of the requirements on the impl of `{}` for `{}`",
                        parent_trait_ref,
                        parent_trait_ref.0.self_ty());
-            let parent_predicate = parent_trait_ref.as_predicate();
+            let parent_predicate = parent_trait_ref.to_predicate();
             note_obligation_cause_code(infcx, &parent_predicate, cause_span, &*data.parent_code);
         }
         ObligationCauseCode::CompareImplMethodObligation => {

--- a/src/librustc/middle/traits/project.rs
+++ b/src/librustc/middle/traits/project.rs
@@ -23,7 +23,7 @@ use super::util;
 
 use middle::infer;
 use middle::subst::Subst;
-use middle::ty::{self, AsPredicate, ReferencesError, RegionEscape,
+use middle::ty::{self, ToPredicate, ReferencesError, RegionEscape,
                  HasProjectionTypes, ToPolyTraitRef, Ty};
 use middle::ty_fold::{self, TypeFoldable, TypeFolder};
 use syntax::parse::token;
@@ -336,7 +336,7 @@ pub fn normalize_projection_type<'a,'b,'tcx>(
                 projection_ty: projection_ty,
                 ty: ty_var
             });
-            let obligation = Obligation::with_depth(cause, depth+1, projection.as_predicate());
+            let obligation = Obligation::with_depth(cause, depth+1, projection.to_predicate());
             Normalized {
                 value: ty_var,
                 obligations: vec!(obligation)
@@ -432,7 +432,7 @@ fn normalize_to_error<'a,'tcx>(selcx: &mut SelectionContext<'a,'tcx>,
     let trait_ref = projection_ty.trait_ref.to_poly_trait_ref();
     let trait_obligation = Obligation { cause: cause,
                                         recursion_depth: depth,
-                                        predicate: trait_ref.as_predicate() };
+                                        predicate: trait_ref.to_predicate() };
     Normalized {
         value: selcx.tcx().types.err,
         obligations: vec!(trait_obligation)
@@ -646,7 +646,7 @@ fn assemble_candidates_from_object_type<'cx,'tcx>(
     };
     let projection_bounds = data.projection_bounds_with_self_ty(selcx.tcx(), object_ty);
     let env_predicates = projection_bounds.iter()
-                                          .map(|p| p.as_predicate())
+                                          .map(|p| p.to_predicate())
                                           .collect();
     let env_predicates = elaborate_predicates(selcx.tcx(), env_predicates);
     assemble_candidates_from_predicates(selcx, obligation, obligation_trait_ref,

--- a/src/librustc/middle/traits/select.rs
+++ b/src/librustc/middle/traits/select.rs
@@ -38,7 +38,7 @@ use super::util;
 
 use middle::fast_reject;
 use middle::subst::{Subst, Substs, TypeSpace};
-use middle::ty::{self, AsPredicate, RegionEscape, ToPolyTraitRef, Ty};
+use middle::ty::{self, ToPredicate, RegionEscape, ToPolyTraitRef, Ty};
 use middle::infer;
 use middle::infer::{InferCtxt, TypeFreshener};
 use middle::ty_fold::TypeFoldable;
@@ -2465,7 +2465,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                                      data_b.bounds.region_bound);
                 nested.push(Obligation::with_depth(cause,
                                                    obligation.recursion_depth + 1,
-                                                   ty::Binder(outlives).as_predicate()));
+                                                   ty::Binder(outlives).to_predicate()));
             }
 
             // T -> Trait.
@@ -2485,7 +2485,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 };
 
                 // Create the obligation for casting from T to Trait.
-                push(data.principal_trait_ref_with_self_ty(tcx, source).as_predicate());
+                push(data.principal_trait_ref_with_self_ty(tcx, source).to_predicate());
 
                 // We can only make objects from sized types.
                 let mut builtin_bounds = data.bounds.builtin_bounds;
@@ -2497,7 +2497,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 // for the Send check.)
                 for bound in &builtin_bounds {
                     if let Ok(tr) = util::trait_ref_for_builtin_bound(tcx, bound, source) {
-                        push(tr.as_predicate());
+                        push(tr.to_predicate());
                     } else {
                         return Err(Unimplemented);
                     }
@@ -2505,14 +2505,14 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
                 // Create obligations for the projection predicates.
                 for bound in data.projection_bounds_with_self_ty(tcx, source) {
-                    push(bound.as_predicate());
+                    push(bound.to_predicate());
                 }
 
                 // If the type is `Foo+'a`, ensures that the type
                 // being cast to `Foo+'a` outlives `'a`:
                 let outlives = ty::OutlivesPredicate(source,
                                                      data.bounds.region_bound);
-                push(ty::Binder(outlives).as_predicate());
+                push(ty::Binder(outlives).to_predicate());
             }
 
             // [T; n] -> [T].

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -10,7 +10,7 @@
 
 use middle::subst::Substs;
 use middle::infer::InferCtxt;
-use middle::ty::{self, Ty, AsPredicate, ToPolyTraitRef};
+use middle::ty::{self, Ty, ToPredicate, ToPolyTraitRef};
 use std::fmt;
 use syntax::ast;
 use syntax::codemap::Span;
@@ -83,7 +83,7 @@ pub fn elaborate_trait_ref<'cx, 'tcx>(
     trait_ref: ty::PolyTraitRef<'tcx>)
     -> Elaborator<'cx, 'tcx>
 {
-    elaborate_predicates(tcx, vec![trait_ref.as_predicate()])
+    elaborate_predicates(tcx, vec![trait_ref.to_predicate()])
 }
 
 pub fn elaborate_trait_refs<'cx, 'tcx>(
@@ -92,7 +92,7 @@ pub fn elaborate_trait_refs<'cx, 'tcx>(
     -> Elaborator<'cx, 'tcx>
 {
     let predicates = trait_refs.iter()
-                               .map(|trait_ref| trait_ref.as_predicate())
+                               .map(|trait_ref| trait_ref.to_predicate())
                                .collect();
     elaborate_predicates(tcx, predicates)
 }
@@ -347,7 +347,7 @@ pub fn predicate_for_trait_ref<'tcx>(
     Obligation {
         cause: cause,
         recursion_depth: recursion_depth,
-        predicate: trait_ref.as_predicate(),
+        predicate: trait_ref.to_predicate(),
     }
 }
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -1873,7 +1873,7 @@ impl BuiltinBounds {
                                self_ty: Ty<'tcx>) -> Vec<Predicate<'tcx>> {
         self.iter().filter_map(|builtin_bound|
             match traits::trait_ref_for_builtin_bound(tcx, builtin_bound, self_ty) {
-                Ok(trait_ref) => Some(trait_ref.as_predicate()),
+                Ok(trait_ref) => Some(trait_ref.to_predicate()),
                 Err(ErrorReported) => { None }
             }
         ).collect()
@@ -2390,12 +2390,12 @@ impl<'tcx> ToPolyTraitRef<'tcx> for PolyProjectionPredicate<'tcx> {
     }
 }
 
-pub trait AsPredicate<'tcx> {
-    fn as_predicate(&self) -> Predicate<'tcx>;
+pub trait ToPredicate<'tcx> {
+    fn to_predicate(&self) -> Predicate<'tcx>;
 }
 
-impl<'tcx> AsPredicate<'tcx> for TraitRef<'tcx> {
-    fn as_predicate(&self) -> Predicate<'tcx> {
+impl<'tcx> ToPredicate<'tcx> for TraitRef<'tcx> {
+    fn to_predicate(&self) -> Predicate<'tcx> {
         // we're about to add a binder, so let's check that we don't
         // accidentally capture anything, or else that might be some
         // weird debruijn accounting.
@@ -2407,32 +2407,32 @@ impl<'tcx> AsPredicate<'tcx> for TraitRef<'tcx> {
     }
 }
 
-impl<'tcx> AsPredicate<'tcx> for PolyTraitRef<'tcx> {
-    fn as_predicate(&self) -> Predicate<'tcx> {
+impl<'tcx> ToPredicate<'tcx> for PolyTraitRef<'tcx> {
+    fn to_predicate(&self) -> Predicate<'tcx> {
         ty::Predicate::Trait(self.to_poly_trait_predicate())
     }
 }
 
-impl<'tcx> AsPredicate<'tcx> for PolyEquatePredicate<'tcx> {
-    fn as_predicate(&self) -> Predicate<'tcx> {
+impl<'tcx> ToPredicate<'tcx> for PolyEquatePredicate<'tcx> {
+    fn to_predicate(&self) -> Predicate<'tcx> {
         Predicate::Equate(self.clone())
     }
 }
 
-impl<'tcx> AsPredicate<'tcx> for PolyRegionOutlivesPredicate {
-    fn as_predicate(&self) -> Predicate<'tcx> {
+impl<'tcx> ToPredicate<'tcx> for PolyRegionOutlivesPredicate {
+    fn to_predicate(&self) -> Predicate<'tcx> {
         Predicate::RegionOutlives(self.clone())
     }
 }
 
-impl<'tcx> AsPredicate<'tcx> for PolyTypeOutlivesPredicate<'tcx> {
-    fn as_predicate(&self) -> Predicate<'tcx> {
+impl<'tcx> ToPredicate<'tcx> for PolyTypeOutlivesPredicate<'tcx> {
+    fn to_predicate(&self) -> Predicate<'tcx> {
         Predicate::TypeOutlives(self.clone())
     }
 }
 
-impl<'tcx> AsPredicate<'tcx> for PolyProjectionPredicate<'tcx> {
-    fn as_predicate(&self) -> Predicate<'tcx> {
+impl<'tcx> ToPredicate<'tcx> for PolyProjectionPredicate<'tcx> {
+    fn to_predicate(&self) -> Predicate<'tcx> {
         Predicate::Projection(self.clone())
     }
 }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -56,7 +56,7 @@ use middle::resolve_lifetime as rl;
 use middle::privacy::{AllPublic, LastMod};
 use middle::subst::{FnSpace, TypeSpace, SelfSpace, Subst, Substs};
 use middle::traits;
-use middle::ty::{self, RegionEscape, Ty, AsPredicate};
+use middle::ty::{self, RegionEscape, Ty, ToPredicate};
 use middle::ty_fold;
 use rscope::{self, UnelidableRscope, RegionScope, ElidableRscope, ExplicitRscope,
              ObjectLifetimeDefaultRscope, ShiftedRscope, BindingRscope};
@@ -2213,7 +2213,7 @@ impl<'tcx> Bounds<'tcx> {
 
         for builtin_bound in &self.builtin_bounds {
             match traits::trait_ref_for_builtin_bound(tcx, builtin_bound, param_ty) {
-                Ok(trait_ref) => { vec.push(trait_ref.as_predicate()); }
+                Ok(trait_ref) => { vec.push(trait_ref.to_predicate()); }
                 Err(ErrorReported) => { }
             }
         }
@@ -2222,15 +2222,15 @@ impl<'tcx> Bounds<'tcx> {
             // account for the binder being introduced below; no need to shift `param_ty`
             // because, at present at least, it can only refer to early-bound regions
             let region_bound = ty_fold::shift_region(region_bound, 1);
-            vec.push(ty::Binder(ty::OutlivesPredicate(param_ty, region_bound)).as_predicate());
+            vec.push(ty::Binder(ty::OutlivesPredicate(param_ty, region_bound)).to_predicate());
         }
 
         for bound_trait_ref in &self.trait_bounds {
-            vec.push(bound_trait_ref.as_predicate());
+            vec.push(bound_trait_ref.to_predicate());
         }
 
         for projection in &self.projection_bounds {
-            vec.push(projection.as_predicate());
+            vec.push(projection.to_predicate());
         }
 
         vec

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -16,7 +16,7 @@ use middle::def;
 use middle::privacy::{AllPublic, DependsOn, LastPrivate, LastMod};
 use middle::subst;
 use middle::traits;
-use middle::ty::{self, AsPredicate, ToPolyTraitRef, TraitRef};
+use middle::ty::{self, ToPredicate, ToPolyTraitRef, TraitRef};
 use middle::infer;
 
 use syntax::ast::DefId;
@@ -192,7 +192,7 @@ pub fn lookup_in_trait_adjusted<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     let poly_trait_ref = trait_ref.to_poly_trait_ref();
     let obligation = traits::Obligation::misc(span,
                                               fcx.body_id,
-                                              poly_trait_ref.as_predicate());
+                                              poly_trait_ref.to_predicate());
 
     // Now we want to know if this can be matched
     let mut selcx = traits::SelectionContext::new(fcx.infcx(), fcx);

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -15,7 +15,7 @@ use CrateCtxt;
 
 use astconv::AstConv;
 use check::{self, FnCtxt};
-use middle::ty::{self, Ty, ToPolyTraitRef, AsPredicate};
+use middle::ty::{self, Ty, ToPolyTraitRef, ToPredicate};
 use middle::def;
 use middle::lang_items::FnOnceTraitLangItem;
 use middle::subst::Substs;
@@ -101,7 +101,7 @@ pub fn report_error<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                             let poly_trait_ref = trait_ref.to_poly_trait_ref();
                             let obligation = Obligation::misc(span,
                                                               fcx.body_id,
-                                                              poly_trait_ref.as_predicate());
+                                                              poly_trait_ref.to_predicate());
                             let mut selcx = SelectionContext::new(infcx, fcx);
 
                             if selcx.evaluate_obligation(&obligation) {


### PR DESCRIPTION
@nikomatsakis and I ran into this earlier and I figured we should rename the trait and method to match the typical naming convention.
