### PR TITLE
Custom Debug impl for io::Error

### DIFF
--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -292,6 +292,16 @@ mod test {
     use error;
     use error::Error as error_Error;
     use fmt;
+    use sys::os::error_string;
+
+    #[test]
+    fn test_debug_error() {
+        let code = 6;
+        let msg = error_string(code);
+        let err = Error { repr: super::Repr::Os(code) };
+        let expected = format!("Error {{ repr: Os {{ code: {:?}, message: {:?} }} }}", code, msg);
+        assert_eq!(format!("{:?}", err), expected);
+    }
 
     #[test]
     fn test_downcasting() {

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -37,7 +37,6 @@ pub struct Error {
     repr: Repr,
 }
 
-#[derive(Debug)]
 enum Repr {
     Os(i32),
     Custom(Box<Custom>),
@@ -236,6 +235,17 @@ impl Error {
         match self.repr {
             Repr::Os(code) => sys::decode_error_kind(code),
             Repr::Custom(ref c) => c.kind,
+        }
+    }
+}
+
+impl fmt::Debug for Repr {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &Repr::Os(ref code) =>
+                fmt.debug_struct("Os").field("code", code)
+                   .field("message", &sys::os::error_string(*code)).finish(),
+            &Repr::Custom(ref c) => fmt.debug_tuple("Custom").field(c).finish(),
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/26408

Example output when using `Result::unwrap`:

```
thread '<main>' panicked at 'called `Result::unwrap()` on an `Err` value: Error { repr: Os { code: 2, message: "The system cannot find the file specified.\r\n" } }', src/libcore\result.rs:731
```

This could technically be considered a breaking change for any code that depends on the format of the `Debug` output for `io::Error` but I sincerely hope nobody wrote code like that.
