### PR TITLE
Make a better error message for using #[feature] on stable rust

### DIFF
--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -247,9 +247,6 @@ pub enum LintSource {
 
     /// Lint level was set by a command-line flag.
     CommandLine,
-
-    /// Lint level was set by the release channel.
-    ReleaseChannel
 }
 
 pub type LevelSource = (Level, LintSource);

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -32,6 +32,7 @@ use syntax::attr::AttrMetaMethods;
 use syntax::diagnostic::{ColorConfig, Auto, Always, Never, SpanHandler};
 use syntax::parse;
 use syntax::parse::token::InternedString;
+use syntax::feature_gate::UnstableFeatures;
 
 use getopts;
 use std::collections::HashMap;
@@ -117,21 +118,6 @@ pub struct Options {
     pub alt_std_name: Option<String>,
     /// Indicates how the compiler should treat unstable features
     pub unstable_features: UnstableFeatures
-}
-
-#[derive(Clone, Copy)]
-pub enum UnstableFeatures {
-    /// Hard errors for unstable features are active, as on
-    /// beta/stable channels.
-    Disallow,
-    /// Use the default lint levels
-    Default,
-    /// Errors are bypassed for bootstrapping. This is required any time
-    /// during the build that feature-related lints are set to warn or above
-    /// because the build turns on warnings-as-errors and uses lots of unstable
-    /// features. As a result, this this is always required for building Rust
-    /// itself.
-    Cheat
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -1074,7 +1060,7 @@ pub fn get_unstable_features_setting() -> UnstableFeatures {
     match (disable_unstable_features, bootstrap_secret_key, bootstrap_provided_key) {
         (_, Some(ref s), Some(ref p)) if s == p => UnstableFeatures::Cheat,
         (true, _, _) => UnstableFeatures::Disallow,
-        (false, _, _) => UnstableFeatures::Default
+        (false, _, _) => UnstableFeatures::Allow
     }
 }
 

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -513,7 +513,8 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         let features =
             syntax::feature_gate::check_crate(sess.codemap(),
                                               &sess.parse_sess.span_diagnostic,
-                                              &krate, &attributes);
+                                              &krate, &attributes,
+                                              sess.opts.unstable_features);
         *sess.features.borrow_mut() = features;
         sess.abort_if_errors();
     });
@@ -543,7 +544,8 @@ pub fn phase_2_configure_and_expand(sess: &Session,
         let features =
             syntax::feature_gate::check_crate(sess.codemap(),
                                               &sess.parse_sess.span_diagnostic,
-                                              &krate, &attributes);
+                                              &krate, &attributes,
+                                              sess.opts.unstable_features);
         *sess.features.borrow_mut() = features;
         sess.abort_if_errors();
     });

--- a/src/librustc_driver/test.rs
+++ b/src/librustc_driver/test.rs
@@ -36,6 +36,7 @@ use syntax::codemap;
 use syntax::codemap::{Span, CodeMap, DUMMY_SP};
 use syntax::diagnostic::{Level, RenderSpan, Bug, Fatal, Error, Warning, Note, Help};
 use syntax::parse::token;
+use syntax::feature_gate::UnstableFeatures;
 
 struct Env<'a, 'tcx: 'a> {
     infcx: &'a infer::InferCtxt<'a, 'tcx>,
@@ -103,6 +104,7 @@ fn test_env<F>(source_string: &str,
     let mut options =
         config::basic_options();
     options.debugging_opts.verbose = true;
+    options.unstable_features = UnstableFeatures::Allow;
     let codemap =
         CodeMap::new();
     let diagnostic_handler =

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -2215,7 +2215,7 @@ pub struct UnstableFeatures;
 declare_lint! {
     UNSTABLE_FEATURES,
     Allow,
-    "enabling unstable features"
+    "enabling unstable features (deprecated. do not use)"
 }
 
 impl LintPass for UnstableFeatures {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -12,7 +12,6 @@ pub use self::MaybeTyped::*;
 use rustc_lint;
 use rustc_driver::driver;
 use rustc::session::{self, config};
-use rustc::session::config::UnstableFeatures;
 use rustc::middle::{privacy, ty};
 use rustc::ast_map;
 use rustc::lint;
@@ -20,6 +19,7 @@ use rustc_trans::back::link;
 use rustc_resolve as resolve;
 
 use syntax::{ast, codemap, diagnostic};
+use syntax::feature_gate::UnstableFeatures;
 
 use std::cell::{RefCell, Cell};
 use std::collections::{HashMap, HashSet};
@@ -106,7 +106,7 @@ pub fn run_core(search_paths: SearchPaths, cfgs: Vec<String>, externs: Externs,
         target_triple: triple.unwrap_or(config::host_triple().to_string()),
         cfg: config::parse_cfgspecs(cfgs),
         // Ensure that rustdoc works even if rustc is feature-staged
-        unstable_features: UnstableFeatures::Default,
+        unstable_features: UnstableFeatures::Allow,
         ..config::basic_options().clone()
     };
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -430,18 +430,6 @@ pub fn emit_feature_err(diag: &SpanHandler, feature: &str, span: Span, explain: 
                                   feature));
 }
 
-pub fn emit_feature_warn(diag: &SpanHandler, feature: &str, span: Span, explain: &str) {
-    diag.span_warn(span, explain);
-
-    // #23973: do not suggest `#![feature(...)]` if we are in beta/stable
-    if option_env!("CFG_DISABLE_UNSTABLE_FEATURES").is_some() { return; }
-    if diag.handler.can_emit_warnings {
-        diag.fileline_help(span, &format!("add #![feature({})] to the \
-                                       crate attributes to silence this warning",
-                                      feature));
-    }
-}
-
 pub const EXPLAIN_ASM: &'static str =
     "inline assembly is not stable enough for use and is subject to change";
 


### PR DESCRIPTION
It now says '#[feature] may not be used on the stable release channel'.

I had to convert this error from a lint to a normal compiler error.

I left the lint previously-used for this in place since removing it is
a breaking change. It will just go unused until the end of time.

Fixes #24125
