### PR TITLE
Implement likely/unlikely intrinsics

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -602,4 +602,9 @@ extern "rust-intrinsic" {
     /// Returns the value of the discriminant for the variant in 'v',
     /// cast to a `u64`; if `T` has no discriminant, returns 0.
     pub fn discriminant_value<T>(v: &T) -> u64;
+
+    #[cfg(not(stage0))]
+    pub fn likely(v: bool) -> bool;
+    #[cfg(not(stage0))]
+    pub fn unlikely(v: bool) -> bool;
 }

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -603,8 +603,23 @@ extern "rust-intrinsic" {
     /// cast to a `u64`; if `T` has no discriminant, returns 0.
     pub fn discriminant_value<T>(v: &T) -> u64;
 
+    /// Hints to the compiler that a branch is likely to be taken. Returns the value
+    /// passed to it. In order for the hint to take effect, it should be used as follows:
+    ///
+    /// ```
+    /// unsafe fn foo(a: i32, b: i32) -> i32 {
+    ///     if likely(a == b) {
+    ///         1
+    ///     } else {
+    ///         2
+    ///     }
+    /// }
+    /// ```
     #[cfg(not(stage0))]
     pub fn likely(v: bool) -> bool;
+
+    /// Hints to the compiler that a branch is not likely to be taken. See `likely` for
+    /// more details
     #[cfg(not(stage0))]
     pub fn unlikely(v: bool) -> bool;
 }

--- a/src/librustc_trans/trans/base.rs
+++ b/src/librustc_trans/trans/base.rs
@@ -1672,8 +1672,7 @@ pub fn trans_named_tuple_constructor<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                                                  disr: ty::Disr,
                                                  args: callee::CallArgs,
                                                  dest: expr::Dest,
-                                                 debug_loc: DebugLoc)
-                                                 -> Result<'blk, 'tcx> {
+                                                 debug_loc: DebugLoc) -> Result<'blk, 'tcx> {
 
     let ccx = bcx.fcx.ccx;
     let tcx = ccx.tcx();
@@ -1717,6 +1716,12 @@ pub fn trans_named_tuple_constructor<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         }
     }
 
+    let val = if type_is_immediate(ccx, result_ty) && !type_is_zero_size(ccx, result_ty) {
+        load_ty(bcx, llresult, result_ty)
+    } else {
+        common::C_nil(ccx)
+    };
+
     // If the caller doesn't care about the result
     // drop the temporary we made
     let bcx = match dest {
@@ -1730,7 +1735,7 @@ pub fn trans_named_tuple_constructor<'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
         }
     };
 
-    Result::new(bcx, llresult)
+    Result::new(bcx, val)
 }
 
 pub fn trans_tuple_struct<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,

--- a/src/librustc_trans/trans/build.rs
+++ b/src/librustc_trans/trans/build.rs
@@ -31,7 +31,14 @@ pub fn terminate(cx: Block, _: &str) {
 
 pub fn check_not_terminated(cx: Block) {
     if cx.terminated.get() {
-        panic!("already terminated!");
+        let fcx = cx.fcx;
+        if let Some(span) = fcx.span {
+            cx.tcx().sess.span_bug(
+                span,
+                "already terminated!");
+        } else {
+            cx.tcx().sess.bug("already terminated!");
+        }
     }
 }
 

--- a/src/librustc_trans/trans/builder.rs
+++ b/src/librustc_trans/trans/builder.rs
@@ -718,6 +718,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     pub fn icmp(&self, op: IntPredicate, lhs: ValueRef, rhs: ValueRef) -> ValueRef {
         self.count_insn("icmp");
         unsafe {
+            assert!(val_ty(lhs) == val_ty(rhs), "Cannot compare {} and {}",
+                    self.ccx.tn().val_to_string(lhs),
+                    self.ccx.tn().val_to_string(rhs));
             llvm::LLVMBuildICmp(self.llbuilder, op as c_uint, lhs, rhs, noname())
         }
     }

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -87,8 +87,8 @@ pub struct Callee<'blk, 'tcx: 'blk> {
     pub data: CalleeData<'tcx>,
 }
 
-fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
-                     -> Callee<'blk, 'tcx> {
+pub fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
+                         -> Callee<'blk, 'tcx> {
     let _icx = push_ctxt("trans_callee");
     debug!("callee::trans(expr={})", expr.repr(bcx.tcx()));
 

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -860,13 +860,25 @@ pub fn trans_call_inner<'a, 'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
                          abi);
         fcx.scopes.borrow_mut().last_mut().unwrap().drop_non_lifetime_clean();
 
-        bcx = foreign::trans_native_call(bcx,
+        let (llret, b) = foreign::trans_native_call(bcx,
                                          callee_ty,
                                          llfn,
                                          opt_llretslot.unwrap(),
                                          &llargs[..],
                                          arg_tys,
                                          debug_loc);
+
+        bcx = b;
+        match (opt_llretslot, ret_ty) {
+            (Some(_), ty::FnConverging(ret_ty)) => {
+                if !type_of::return_uses_outptr(bcx.ccx(), ret_ty) &&
+                    !common::type_is_zero_size(bcx.ccx(), ret_ty)
+                {
+                    llresult = llret;
+                }
+            }
+            (_, _) => {}
+        }
     }
 
     fcx.pop_and_trans_custom_cleanup_scope(bcx, arg_cleanup_scope);

--- a/src/librustc_trans/trans/controlflow.rs
+++ b/src/librustc_trans/trans/controlflow.rs
@@ -19,6 +19,7 @@ use trans::cleanup::CleanupMethods;
 use trans::cleanup;
 use trans::common::*;
 use trans::consts;
+use trans::datum;
 use trans::debuginfo;
 use trans::debuginfo::{DebugLoc, ToDebugLoc};
 use trans::expr;
@@ -143,6 +144,48 @@ pub fn trans_block<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
     return bcx;
 }
+
+/// Same as `trans_block` except it returns a `DatumBlock` instead of storing the
+/// the result to a destination. This avoids going through a temporary when it's
+/// not needed, primarily to ensure that `unsafe { likely(cond) }` and similar patterns
+/// work.
+pub fn trans_block_datum<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+                                     b: &ast::Block)
+                                     -> datum::DatumBlock<'blk, 'tcx, datum::Expr> {
+    let _icx = push_ctxt("trans_block_datum");
+
+    if bcx.unreachable.get() {
+        let llval = C_nil(bcx.ccx());
+        let datum = datum::immediate_rvalue(llval, ty::mk_nil(bcx.tcx()));
+        return datum::DatumBlock {bcx: bcx, datum: datum.to_expr_datum()};
+    }
+
+    let fcx = bcx.fcx;
+    let mut bcx = bcx;
+
+    let cleanup_debug_loc =
+        debuginfo::get_cleanup_debug_loc_for_ast_node(bcx.ccx(), b.id, b.span, true);
+    fcx.push_ast_cleanup_scope(cleanup_debug_loc);
+
+    for s in &b.stmts {
+        bcx = trans_stmt(bcx, &**s);
+    }
+
+    let datum = match b.expr {
+        Some(ref e) if !bcx.unreachable.get() => {
+            unpack_datum!(bcx, expr::trans(bcx, &**e))
+        }
+        _ => {
+            let llval = C_nil(bcx.ccx());
+            datum::immediate_rvalue(llval, ty::mk_nil(bcx.tcx())).to_expr_datum()
+        }
+    };
+
+    bcx = fcx.pop_and_trans_ast_cleanup_scope(bcx, b.id);
+
+    datum::DatumBlock {bcx: bcx, datum: datum}
+}
+
 
 pub fn trans_if<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                             if_id: ast::NodeId,

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -82,7 +82,6 @@ use util::ppaux::Repr;
 use trans::machine::{llsize_of, llsize_of_alloc};
 use trans::type_::Type;
 
-use syntax::abi as synabi;
 use syntax::{ast, ast_util, codemap};
 use syntax::parse::token::InternedString;
 use syntax::ptr::P;
@@ -580,42 +579,7 @@ fn trans_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
     debuginfo::set_source_location(bcx.fcx, expr.id, expr.span);
 
-    match expr.node {
-        ast::ExprCall(ref f, ref args) if !bcx.tcx().is_method_call(expr.id) => {
-            if let ast::ExprPath(..) = f.node {
-                let fn_ty = expr_ty_adjusted(bcx, f);
-                let (fty, ret_ty) = match fn_ty.sty {
-                    ty::TyBareFn(_, ref fty) => {
-                        (fty, ty::erase_late_bound_regions(bcx.tcx(), &fty.sig.output()))
-                    }
-                    _ => panic!("Not calling a function?!")
-                };
-
-                if let ty::FnConverging(ret_ty) = ret_ty {
-                    let is_rust_fn = fty.abi == synabi::Rust ||
-                        fty.abi == synabi::RustIntrinsic;
-
-                    let needs_drop = type_needs_drop(bcx.tcx(), ret_ty);
-                    let uses_output = type_of::return_uses_outptr(bcx.ccx(), ret_ty);
-
-                    if is_rust_fn && !uses_output && !needs_drop {
-                        let args = callee::ArgExprs(&args[..]);
-                        let result = callee::trans_call_inner(bcx,
-                                                              expr.debug_loc(),
-                                                              fn_ty,
-                                                              |cx, _| callee::trans(cx, f),
-                                                              args, Some(Ignore));
-
-                        return immediate_rvalue_bcx(result.bcx, result.val, ret_ty)
-                            .to_expr_datumblock();
-                    }
-                }
-            }
-        }
-        _ => {}
-    }
-
-    return match ty::expr_kind(bcx.tcx(), expr) {
+    return match expr_kind(bcx, expr) {
         ty::LvalueExpr | ty::RvalueDatumExpr => {
             let datum = unpack_datum!(bcx, {
                 trans_datum_unadjusted(bcx, expr)
@@ -662,6 +626,39 @@ fn trans_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         let datum = immediate_rvalue(llval, ty);
         DatumBlock::new(bcx, datum.to_expr_datum())
     }
+}
+
+// Get the appropriate expression kind for the expression. Most of the time this just uses
+// ty::expr_kind, but `ExprCall`s can be treated as `RvalueDatumExpr`s in some cases.
+fn expr_kind<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr) -> ty::ExprKind {
+    match expr.node {
+        ast::ExprCall(ref f, _) if !bcx.tcx().is_method_call(expr.id) => {
+            if let ast::ExprPath(..) = f.node {
+                let fn_ty = expr_ty_adjusted(bcx, f);
+
+                let ret_ty = match fn_ty.sty {
+                    ty::TyBareFn(_, ref fty) =>
+                        ty::erase_late_bound_regions(bcx.tcx(), &fty.sig.output()),
+                    _ => bcx.tcx().sess.bug("Not calling a function?")
+                };
+
+                let is_datum = if let ty::FnConverging(output) = ret_ty {
+                    !type_of::return_uses_outptr(bcx.ccx(), output) &&
+                        !bcx.fcx.type_needs_drop(output)
+                } else {
+                    true
+                };
+
+
+                if is_datum {
+                    return ty::RvalueDatumExpr;
+                }
+            }
+        }
+        _ => ()
+    }
+
+    return ty::expr_kind(bcx.tcx(), expr);
 }
 
 fn trans_datum_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
@@ -730,6 +727,35 @@ fn trans_datum_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         ast::ExprCast(ref val, _) => {
             // Datum output mode means this is a scalar cast:
             trans_imm_cast(bcx, &**val, expr.id)
+        }
+        ast::ExprCall(ref f, ref args) => {
+            let fn_ty = expr_ty_adjusted(bcx, f);
+
+            let ret_ty = match fn_ty.sty {
+                ty::TyBareFn(_, ref fty) => {
+                    ty::erase_late_bound_regions(bcx.tcx(), &fty.sig.output())
+                }
+                _ => panic!("Not calling a function?!")
+            };
+
+            let args = callee::ArgExprs(&args[..]);
+            let result = callee::trans_call_inner(bcx,
+                                                  expr.debug_loc(),
+                                                  fn_ty,
+                                                  |cx, _| callee::trans(cx, f),
+                                                  args, Some(Ignore));
+
+            if let ty::FnConverging(ret_ty) = ret_ty {
+                immediate_rvalue_bcx(result.bcx, result.val, ret_ty)
+                    .to_expr_datumblock()
+            } else {
+                // We called a diverging function, generate an undef value of the appropriate
+                // type.
+                let ty = expr_ty(bcx, expr);
+                let llval = C_undef(type_of::arg_type_of(bcx.ccx(), ty));
+                let datum = immediate_rvalue(llval, ty);
+                DatumBlock::new(bcx, datum.to_expr_datum())
+            }
         }
         _ => {
             bcx.tcx().sess.span_bug(

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -596,8 +596,9 @@ fn trans_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                         fty.abi == synabi::RustIntrinsic;
 
                     let needs_drop = type_needs_drop(bcx.tcx(), ret_ty);
+                    let uses_output = type_of::return_uses_outptr(bcx.ccx(), ret_ty);
 
-                    if is_rust_fn && type_is_immediate(bcx.ccx(), ret_ty) && !needs_drop {
+                    if is_rust_fn && !uses_output && !needs_drop {
                         let args = callee::ArgExprs(&args[..]);
                         let result = callee::trans_call_inner(bcx,
                                                               expr.debug_loc(),

--- a/src/librustc_trans/trans/foreign.rs
+++ b/src/librustc_trans/trans/foreign.rs
@@ -230,7 +230,7 @@ pub fn trans_native_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                      llargs_rust: &[ValueRef],
                                      passed_arg_tys: Vec<Ty<'tcx>>,
                                      call_debug_loc: DebugLoc)
-                                     -> Block<'blk, 'tcx>
+                                     -> (ValueRef, Block<'blk, 'tcx>)
 {
     let ccx = bcx.ccx();
     let tcx = bcx.tcx();
@@ -389,6 +389,7 @@ pub fn trans_native_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     // type to match because some ABIs will use a different type than
     // the Rust type. e.g., a {u32,u32} struct could be returned as
     // u64.
+    let llretval = llforeign_retval;
     if llsig.ret_def && !fn_type.ret_ty.is_indirect() {
         let llrust_ret_ty = llsig.llret_ty;
         let llforeign_ret_ty = match fn_type.ret_ty.cast {
@@ -436,7 +437,7 @@ pub fn trans_native_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         }
     }
 
-    return bcx;
+    return (llretval, bcx);
 }
 
 // feature gate SIMD types in FFI, since I (huonw) am not sure the

--- a/src/librustc_trans/trans/intrinsic.rs
+++ b/src/librustc_trans/trans/intrinsic.rs
@@ -763,6 +763,17 @@ pub fn trans_intrinsic_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
             }
         }
 
+        (_, "likely") => {
+            let llfn = ccx.get_intrinsic(&("llvm.expect.i1"));
+            let expected = C_bool(ccx, true);
+            Call(bcx, llfn, &[llargs[0], expected], None, call_debug_location)
+        }
+        (_, "unlikely") => {
+            let llfn = ccx.get_intrinsic(&("llvm.expect.i1"));
+            let expected = C_bool(ccx, false);
+            Call(bcx, llfn, &[llargs[0], expected], None, call_debug_location)
+        }
+
         // This requires that atomic intrinsics follow a specific naming pattern:
         // "atomic_<operation>[_<ordering>]", and no ordering means SeqCst
         (_, name) if name.starts_with("atomic_") => {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5239,6 +5239,7 @@ pub fn check_intrinsic_type(ccx: &CrateCtxt, it: &ast::ForeignItem) {
                                     tcx.mk_region(ty::ReLateBound(ty::DebruijnIndex::new(1),
                                                                   ty::BrAnon(0))),
                                     param(ccx, 0))], tcx.types.u64),
+            "likely" | "unlikely" => (0, vec![tcx.types.bool], tcx.types.bool),
 
             ref other => {
                 span_err!(tcx.sess, it.span, E0093,

--- a/src/libstd/rt/unwind/mod.rs
+++ b/src/libstd/rt/unwind/mod.rs
@@ -306,7 +306,7 @@ pub unsafe fn register(f: Callback) -> bool {
         // been incremented, but the callback has not been stored. We're
         // guaranteed that the slot we're storing into is 0.
         n if n < MAX_CALLBACKS => {
-            let prev = CALLBACKS[n].swap(mem::transmute(f), Ordering::SeqCst);
+            let prev = CALLBACKS[n].swap(f as usize, Ordering::SeqCst);
             rtassert!(prev == 0);
             true
         }

--- a/src/test/codegen/expect.rs
+++ b/src/test/codegen/expect.rs
@@ -1,0 +1,56 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: -C no-prepopulate-passes
+
+// The expect intrinsic needs to have the output from the call fed directly
+// into the branch, these tests make sure that happens
+
+#![feature(core)]
+
+use std::intrinsics::{likely,unlikely};
+
+// CHECK-LABEL: direct_likely
+#[no_mangle]
+pub fn direct_likely(x: i32) {
+    unsafe {
+        // CHECK: [[VAR:%[0-9]+]] = call i1 @llvm.expect.i1(i1 %{{.*}}, i1 true)
+        // CHECK: br i1 [[VAR]], label %{{.+}}, label %{{.*}}
+        if likely(x == 1) {}
+    }
+}
+
+// CHECK-LABEL: direct_unlikely
+#[no_mangle]
+pub fn direct_unlikely(x: i32) {
+    unsafe {
+        // CHECK: [[VAR:%[0-9]+]] = call i1 @llvm.expect.i1(i1 %{{.*}}, i1 false)
+        // CHECK: br i1 [[VAR]], label %{{.+}}, label %{{.*}}
+        if unlikely(x == 1) {}
+    }
+}
+
+// CHECK-LABEL: wrapped_likely
+// Make sure you can wrap just the call to the intrinsic in `unsafe` and still
+// have it work
+#[no_mangle]
+pub fn wrapped_likely(x: i32) {
+    // CHECK: [[VAR:%[0-9]+]] = call i1 @llvm.expect.i1(i1 %{{.*}}, i1 true)
+    // CHECK: br i1 [[VAR]], label %{{.+}}, label %{{.*}}
+    if unsafe { likely(x == 1) } {}
+}
+
+// CHECK-LABEL: wrapped_unlikely
+#[no_mangle]
+pub fn wrapped_unlikely(x: i32) {
+    // CHECK: [[VAR:%[0-9]+]] = call i1 @llvm.expect.i1(i1 %{{.*}}, i1 false)
+    // CHECK: br i1 [[VAR]], label %{{.+}}, label %{{.*}}
+    if unsafe { unlikely(x == 1) } {}
+}


### PR DESCRIPTION
Implementation for RFC 1131 (rust-lang/rfcs#1131). Tracking issue #26179.

Most of the work here is actually improvements/changes to code generation to ensure that the branch hints actually take effect. LLVM runs the lowering pass pretty early in the pipeline, and requires the result of the intrinsic call to be used directly in the branch. The existing code would cause the return value of the intrinsic to go into, and then back out of, a stack slot.

The main changes are avoiding the temporary stack slots for functions that return immediate values and a similar change for blocks that have a trailing expression. The change to blocks is to be able to handle this case: `unsafe { likely(foo) }`.

/cc @rust-lang/compiler 
