### PR TITLE
Suggest missing trait bounds when a method exists but the bounds aren't satisfied

### DIFF
--- a/src/test/compile-fail/method-help-unsatisfied-bound.rs
+++ b/src/test/compile-fail/method-help-unsatisfied-bound.rs
@@ -1,0 +1,18 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo;
+
+fn main() {
+    let a: Result<(), Foo> = Ok(());
+    a.unwrap();
+    //~^ ERROR no method named `unwrap` found for type `core::result::Result<(), Foo>`
+    //~| NOTE the following trait bounds were not satisfied: `Foo : core::fmt::Debug`
+}


### PR DESCRIPTION
When a method exists in an impl but can not be used due to missing trait bounds for the type parameters, we should inform the user which trait bounds are missing.

For example, this code

```
// Note this is missing a Debug impl
struct Foo;

fn main() {
    let a: Result<(), Foo> = Ok(());
    a.unwrap()
}
```

Now gives the following error:

```
/home/gulshan/tmp/tmp.rs:6:7: 6:15 error: no method named `unwrap` found for type `core::result::Result<(), Foo>` in the current scope
/home/gulshan/tmp/tmp.rs:6     a.unwrap()
                                 ^~~~~~~~
/home/gulshan/tmp/tmp.rs:6:7: 6:15 note: The method `unwrap` exists but the following trait bounds were not satisfied: `Foo : core::fmt::Debug`
error: aborting due to previous error
```

Fixes https://github.com/rust-lang/rust/issues/20941.
