### PR TITLE
Resurrect the Compiler Error Index.

### DIFF
--- a/mk/docs.mk
+++ b/mk/docs.mk
@@ -77,8 +77,7 @@ ERR_IDX_GEN = $(RPATH_VAR2_T_$(CFG_BUILD)_H_$(CFG_BUILD)) $(ERR_IDX_GEN_EXE)
 
 D := $(S)src/doc
 
-# FIXME (#25705) eventually may want to put error-index target back here.
-DOC_TARGETS := trpl style
+DOC_TARGETS := trpl style error-index
 COMPILER_DOC_TARGETS :=
 DOC_L10N_TARGETS :=
 

--- a/src/error-index-generator/main.rs
+++ b/src/error-index-generator/main.rs
@@ -17,6 +17,7 @@ extern crate serialize as rustc_serialize;
 use std::collections::BTreeMap;
 use std::fs::{read_dir, File};
 use std::io::{Read, Write};
+use std::env;
 use std::path::Path;
 use std::error::Error;
 
@@ -106,7 +107,8 @@ r##"<!DOCTYPE html>
 }
 
 fn main_with_result() -> Result<(), Box<Error>> {
-    let metadata_dir = get_metadata_dir();
+    let build_arch = try!(env::var("CFG_BUILD"));
+    let metadata_dir = get_metadata_dir(&build_arch);
     let err_map = try!(load_all_errors(&metadata_dir));
     try!(render_error_page(&err_map, Path::new("doc/error-index.html")));
     Ok(())

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -586,9 +586,11 @@ struct ListNode {
 This type cannot have a well-defined size, because it needs to be arbitrarily
 large (since we would be able to nest `ListNode`s to any depth). Specifically,
 
-    size of `ListNode` = 1 byte for `head`
-                       + 1 byte for the discriminant of the `Option`
-                       + size of `ListNode`
+```plain
+size of `ListNode` = 1 byte for `head`
+                   + 1 byte for the discriminant of the `Option`
+                   + size of `ListNode`
+```
 
 One way to fix this is by wrapping `ListNode` in a `Box`, like so:
 

--- a/src/libsyntax/diagnostics/plugin.rs
+++ b/src/libsyntax/diagnostics/plugin.rs
@@ -10,6 +10,7 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::env;
 
 use ast;
 use ast::{Ident, Name, TokenTree};
@@ -19,6 +20,8 @@ use ext::build::AstBuilder;
 use parse::token;
 use ptr::P;
 use util::small_vector::SmallVector;
+
+use diagnostics::metadata::output_metadata;
 
 // Maximum width of any line in an extended error description (inclusive).
 const MAX_DESCRIPTION_WIDTH: usize = 80;
@@ -154,7 +157,7 @@ pub fn expand_build_diagnostic_array<'cx>(ecx: &'cx mut ExtCtxt,
                                           token_tree: &[TokenTree])
                                           -> Box<MacResult+'cx> {
     assert_eq!(token_tree.len(), 3);
-    let (_crate_name, name) = match (&token_tree[0], &token_tree[2]) {
+    let (crate_name, name) = match (&token_tree[0], &token_tree[2]) {
         (
             // Crate name.
             &ast::TtToken(_, token::Ident(ref crate_name, _)),
@@ -164,9 +167,18 @@ pub fn expand_build_diagnostic_array<'cx>(ecx: &'cx mut ExtCtxt,
         _ => unreachable!()
     };
 
-    // FIXME (#25705): we used to ensure error code uniqueness and
-    // output error description JSON metadata here, but the approach
-    // employed was too brittle.
+    // Output error metadata to `tmp/extended-errors/<target arch>/<crate name>.json`
+    let target_triple = env::var("CFG_COMPILER_HOST_TRIPLE")
+        .ok().expect("unable to determine target arch from $CFG_COMPILER_HOST_TRIPLE");
+
+    with_registered_diagnostics(|diagnostics| {
+        if let Err(e) = output_metadata(ecx, &target_triple, crate_name, &diagnostics) {
+            ecx.span_bug(span, &format!(
+                "error writing metadata for triple `{}` and crate `{}`, error: {}, cause: {:?}",
+                target_triple, crate_name, e.description(), e.cause()
+            ));
+        }
+    });
 
     // Construct the output expression.
     let (count, expr) =


### PR DESCRIPTION
As per #26009 this PR implements a new collation system for extended-error metadata. I've tried to keep it as simple as possible for now, so there's no uniqueness checking and minimal modularity.

Although using a lint was discussed in #26009 I decided against this because it would require converting the AST output from the plugin back into an internal data-structure. Emitting the metadata from within the plugin prevents this double-handling. We also didn't identify this as the source of the failures last time, although something untoward was definitely happening... With that in mind I would like as much feedback as possible on this before it's merged, I don't want to break the bots again!

I've successfully built for my host architecture and I'm building an ARM cross-compiler now to test my assumptions about the various `CFG` variables. Despite the confusing name of `CFG_COMPILER_HOST_TRIPLE` it is actually the compile time target triple, as explained in `mk/target.mk`.

```
# This is the compile-time target-triple for the compiler. For the compiler at
# runtime, this should be considered the host-triple. More explanation for why
# this exists can be found on issue #2400
export CFG_COMPILER_HOST_TRIPLE
```

CC @pnkfelix @brson @nrc @alexcrichton 

Closes #25705, closes #26009.
