### PR TITLE
Remove mention of `UdpSocket` in `Shutdown` docs.

### DIFF
--- a/src/libstd/net/mod.rs
+++ b/src/libstd/net/mod.rs
@@ -30,8 +30,7 @@ mod udp;
 mod parser;
 #[cfg(test)] mod test;
 
-/// Possible values which can be passed to the `shutdown` method of `TcpStream`
-/// and `UdpSocket`.
+/// Possible values which can be passed to the `shutdown` method of `TcpStream`.
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub enum Shutdown {


### PR DESCRIPTION
The documentation of `std::net::Shutdown` mentions says it can be passed to the `shutdown` method of `UdpSocket`, which isn't true because `UdpSocket` has no such method. This commit removes that mention.
