### PR TITLE
std: Allow to spawn a process as a session leader on UNIX

### DIFF
--- a/src/libstd/sys/unix/ext/process.rs
+++ b/src/libstd/sys/unix/ext/process.rs
@@ -32,6 +32,17 @@ pub trait CommandExt {
     /// the same semantics as the `uid` field.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn gid(&mut self, id: gid_t) -> &mut process::Command;
+
+    /// Create a new session (cf. `setsid(2)`) for the child process. This means that the child is
+    /// the leader of a new process group. The parent process remains the child reaper of the new
+    /// process.
+    ///
+    /// This is not enough to create a daemon process. The *init* process should be the child
+    /// reaper of a daemon. This can be achieved if the parent process exit. Moreover, a daemon
+    /// should not have a controlling terminal. To acheive this, a session leader (the child) must
+    /// spawn another process (the daemon) in the same session.
+    #[unstable(feature = "process_session_leader", reason = "recently added")]
+    fn session_leader(&mut self, on: bool) -> &mut process::Command;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -43,6 +54,11 @@ impl CommandExt for process::Command {
 
     fn gid(&mut self, id: gid_t) -> &mut process::Command {
         self.as_inner_mut().gid = Some(id);
+        self
+    }
+
+    fn session_leader(&mut self, on: bool) -> &mut process::Command {
+        self.as_inner_mut().session_leader = on;
         self
     }
 }

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -36,7 +36,7 @@ pub struct Command {
     pub cwd: Option<CString>,
     pub uid: Option<uid_t>,
     pub gid: Option<gid_t>,
-    pub detach: bool, // not currently exposed in std::process
+    pub session_leader: bool,
 }
 
 impl Command {
@@ -48,7 +48,7 @@ impl Command {
             cwd: None,
             uid: None,
             gid: None,
-            detach: false,
+            session_leader: false,
         }
     }
 
@@ -302,7 +302,7 @@ impl Process {
                 fail(&mut output);
             }
         }
-        if cfg.detach {
+        if cfg.session_leader {
             // Don't check the error of setsid because it fails if we're the
             // process leader already. We just forked so it shouldn't return
             // error, but ignore it anyway.


### PR DESCRIPTION
Add a new method `CommandExt::session_leader(&mut self, on: bool)` to create a new session (cf. `setsid(2)`) for the child process. This means that the child is the leader of a new process group. The parent process remains the child reaper of the new process.

This is not enough to create a daemon process. The _init_ process should be the child reaper of a daemon. This can be achieved if the parent process exit. Moreover, a daemon should not have a controlling terminal. To acheive this, a session leader (the child) must spawn another process (the daemon) in the same session.

cc rust-lang/rfcs#941
cc #17176
