### PR TITLE
Make expr_is_lval more robust

### DIFF
--- a/src/test/compile-fail/issue-23173.rs
+++ b/src/test/compile-fail/issue-23173.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+enum Token { LeftParen, RightParen, Plus, Minus, /* etc */ }
+
+fn use_token(token: &Token) { unimplemented!() }
+
+fn main() {
+    use_token(&Token::Homura); //~ ERROR no associated item named
+}

--- a/src/test/compile-fail/issue-24322.rs
+++ b/src/test/compile-fail/issue-24322.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct B;
+
+impl B {
+    fn func(&self) -> u32 { 42 }
+}
+
+fn main() {
+    let x: &fn(&B) -> u32 = &B::func; //~ ERROR mismatched types
+}

--- a/src/test/run-pass/issue-25757.rs
+++ b/src/test/run-pass/issue-25757.rs
@@ -1,0 +1,27 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct Foo {
+    a: u32
+}
+
+impl Foo {
+    fn x(&mut self) {
+        self.a = 5;
+    }
+}
+
+const FUNC: &'static Fn(&mut Foo) -> () = &Foo::x;
+
+fn main() {
+    let mut foo = Foo { a: 137 };
+    FUNC(&mut foo); //~ ERROR bad
+    assert_eq!(foo.a, 5);
+}


### PR DESCRIPTION
Previously it also tried to find out the best way to translate the
expression, which could ICE during type-checking.

Fixes #23173
Fixes #24322
Fixes #25757

r? @eddyb
