### PR TITLE
std: Stabilize the catch_panic feature

### DIFF
--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -456,7 +456,6 @@ pub fn panicking() -> bool {
 /// # Examples
 ///
 /// ```
-/// # #![feature(catch_panic)]
 /// use std::thread;
 ///
 /// let result = thread::catch_panic(|| {
@@ -469,7 +468,7 @@ pub fn panicking() -> bool {
 /// });
 /// assert!(result.is_err());
 /// ```
-#[unstable(feature = "catch_panic", reason = "recent API addition")]
+#[stable(feature = "catch_panic", since = "1.3.0")]
 pub fn catch_panic<F, R>(f: F) -> Result<R>
     where F: FnOnce() -> R + Send + 'static
 {

--- a/src/test/run-pass/binary-heap-panic-safe.rs
+++ b/src/test/run-pass/binary-heap-panic-safe.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(std_misc, collections, catch_panic, rand, sync_poison)]
+#![feature(std_misc, collections, rand, sync_poison)]
 
 use std::__rand::{thread_rng, Rng};
 use std::thread;

--- a/src/test/run-pass/running-with-no-runtime.rs
+++ b/src/test/run-pass/running-with-no-runtime.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(catch_panic, start)]
+#![feature(start)]
 
 use std::ffi::CStr;
 use std::process::{Command, Output};


### PR DESCRIPTION
This function has remained in std for quite some time now without modifications,
and it's a core building block for robust FFI, so this commit stabilizes the
signature as-is.

It is possible to relax the `Send` or `'static` bounds in the future
additionally.

Closes #25662
