### PR TITLE
Do not consider fields matched by wildcard patterns to be used

### DIFF
--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -172,6 +172,9 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
         };
         let fields = ty::lookup_struct_fields(self.tcx, id);
         for pat in pats {
+            if let ast::PatWild(ast::PatWildSingle) = pat.node.pat.node {
+                continue;
+            }
             let field_id = fields.iter()
                 .find(|field| field.name == pat.node.ident.name).unwrap().id;
             self.live_symbols.insert(field_id.node);

--- a/src/test/compile-fail/lint-dead-code-4.rs
+++ b/src/test/compile-fail/lint-dead-code-4.rs
@@ -25,14 +25,15 @@ enum XYZ {
     X, //~ ERROR variant is never used
     Y { //~ ERROR variant is never used
         a: String,
-        b: isize //~ ERROR: struct field is never used
+        b: i32, //~ ERROR: struct field is never used
+        c: i32, //~ ERROR: struct field is never used
     },
     Z
 }
 
 fn field_match_in_patterns(b: XYZ) -> String {
     match b {
-        XYZ::Y { a, .. } => a,
+        XYZ::Y { a, b: _, .. } => a,
         _ => "".to_string()
     }
 }
@@ -40,6 +41,7 @@ fn field_match_in_patterns(b: XYZ) -> String {
 struct Bar {
     x: usize, //~ ERROR: struct field is never used
     b: bool,
+    c: bool, //~ ERROR: struct field is never used
     _guard: ()
 }
 
@@ -49,13 +51,13 @@ struct Baz {
 }
 
 fn field_match_in_let(f: Bar) -> bool {
-    let Bar { b, .. } = f;
+    let Bar { b, c: _, .. } = f;
     b
 }
 
 fn main() {
     field_read(Foo { x: 1, b: false });
     field_match_in_patterns(XYZ::Z);
-    field_match_in_let(Bar { x: 42, b: true, _guard: () });
+    field_match_in_let(Bar { x: 42, b: true, c: false, _guard: () });
     let _ = Baz { x: 0 };
 }


### PR DESCRIPTION
Fix #26353.
