### PR TITLE
Do not warn about unused arguments in default methods

### DIFF
--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -109,6 +109,7 @@ use self::LoopKind::*;
 use self::LiveNodeKind::*;
 use self::VarKind::*;
 
+use ast_map;
 use middle::def::*;
 use middle::mem_categorization::Typer;
 use middle::pat_util;
@@ -412,6 +413,12 @@ fn visit_fn(ir: &mut IrMaps,
     // check for various error conditions
     lsets.visit_block(body);
     lsets.check_ret(id, sp, fk, entry_ln, body);
+
+    // Do not warn about unused arguments in default methods
+    if let Some(ast_map::NodeTraitItem(..)) = ir.tcx.map.find(id) {
+        return;
+    }
+
     lsets.warn_about_unused_args(decl, entry_ln);
 }
 

--- a/src/test/run-pass/lint-unused-variables.rs
+++ b/src/test/run-pass/lint-unused-variables.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(unused_variables)]
+
+trait Foo {
+    fn bar(&self, a: i32) {}
+}
+
+fn main() {}


### PR DESCRIPTION
Fix #26487.
