### PR TITLE
Use a more descriptive variable name.

### DIFF
--- a/src/doc/trpl/error-handling.md
+++ b/src/doc/trpl/error-handling.md
@@ -225,9 +225,9 @@ There's another way of doing this that's a bit nicer than `unwrap()`:
 
 ```rust,ignore
 let mut buffer = String::new();
-let input = io::stdin().read_line(&mut buffer)
-                       .ok()
-                       .expect("Failed to read line");
+let num_bytes_read = io::stdin().read_line(&mut buffer)
+                                .ok()
+                                .expect("Failed to read line");
 ```
 
 `ok()` converts the `Result` into an `Option`, and `expect()` does the same


### PR DESCRIPTION
I'm currently reading the rust book and this variable name tripped me up.
Because it was called "input", I thought at first it might contain the line
read by read_line(). This new variable name will be more instructive to rust
beginners.
