### PR TITLE
Add some more headers to installation documentation

### DIFF
--- a/src/doc/trpl/installing-rust.md
+++ b/src/doc/trpl/installing-rust.md
@@ -41,6 +41,8 @@ $ sudo /usr/local/lib/rustlib/uninstall.sh
 If you used the Windows installer, just re-run the `.msi` and it will give you
 an uninstall option.
 
+## That disclaimer we promised
+
 Some people, and somewhat rightfully so, get very upset when we tell you to
 `curl | sh`. Basically, when you do this, you are trusting that the good
 people who maintain Rust aren't going to hack your computer and do bad things.
@@ -49,6 +51,8 @@ documentation on [building Rust from Source][from-source], or [the official
 binary downloads][install-page].
 
 [from-source]: https://github.com/rust-lang/rust#building-from-source
+
+## Platform support
 
 Oh, we should also mention the officially supported platforms:
 
@@ -65,6 +69,8 @@ platform upon release, but if we're honest, the Windows experience isn't as
 integrated as the Linux/OS X experience is. We're working on it! If anything
 does not work, it is a bug. Please let us know if that happens. Each and every
 commit is tested against Windows just like any other platform.
+
+## After installation
 
 If you've got Rust installed, you can open up a shell, and type this:
 


### PR DESCRIPTION
In particular, I found that the disclaimer (promised in the second paragraph) doesn't stand out right now. I think the extra headers help with scanning this document, and making it easier to discern which steps are relevant to my particular flow through the options.
