### PR TITLE
Add member operations to collections

### DIFF
--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -213,7 +213,7 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&V> where K: Borrow<Q>, Q: Ord {
-        self.get_member(key).map(|x| x.1)
+        self.keyed_get(key).map(|x| x.1)
     }
 
     /// Returns a reference to the key and the value corresponding to the key.
@@ -224,17 +224,17 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collection_member)]
+    /// # #![feature(collection_keyed)]
     /// use std::collections::BTreeMap;
     ///
     /// let mut map = BTreeMap::new();
     /// map.insert(1, "a");
-    /// assert_eq!(map.get_member(&1), Some((&1, &"a")));
+    /// assert_eq!(map.keyed_get(&1), Some((&1, &"a")));
     /// assert_eq!(map.get(&2), None);
     /// ```
-    #[unstable(feature = "collection_member",
-            reason="member stuff is unclear")]
-    pub fn get_member<Q: ?Sized>(&self, key: &Q) -> Option<(&K, &V)> where K: Borrow<Q>, Q: Ord {
+    #[unstable(feature = "collection_keyed",
+            reason="keyed was recently added")]
+    pub fn keyed_get<Q: ?Sized>(&self, key: &Q) -> Option<(&K, &V)> where K: Borrow<Q>, Q: Ord {
         let mut cur_node = &self.root;
         loop {
             match Node::search(cur_node, key) {
@@ -290,12 +290,41 @@ impl<K: Ord, V> BTreeMap<K, V> {
     // See `get` for implementation notes, this is basically a copy-paste with mut's added
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut V> where K: Borrow<Q>, Q: Ord {
+        self.keyed_get_mut(key).map(|x| x.1)
+    }
+
+    /// Returns a mutable reference to the value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but the ordering
+    /// on the borrowed form *must* match the ordering on the key type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(collection_keyed)]
+    /// use std::collections::BTreeMap;
+    ///
+    /// let mut map = BTreeMap::new();
+    /// map.insert(1, "a");
+    /// if let Some((key, x)) = map.keyed_get_mut(&1) {
+    ///     assert_eq!(key, &1);
+    ///     *x = "b";
+    /// }
+    /// assert_eq!(map[&1], "b");
+    /// ```
+    // See `keyed_get` for implementation notes, this is basically a copy-paste with mut's added
+    #[unstable(feature = "collection_keyed",
+            reason="keyed was recently added")]
+    pub fn keyed_get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<(&K, &mut V)> where K: Borrow<Q>, Q: Ord {
         // temp_node is a Borrowck hack for having a mutable value outlive a loop iteration
         let mut temp_node = &mut self.root;
         loop {
             let cur_node = temp_node;
             match Node::search(cur_node, key) {
-                Found(handle) => return Some(handle.into_kv_mut().1),
+                Found(handle) => {
+                    let (key, value) = handle.into_kv_mut();
+                    return Some((&*key, value));
+                },
                 GoDown(handle) => match handle.force() {
                     Leaf(_) => return None,
                     Internal(internal_handle) => {
@@ -351,7 +380,7 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
-        self.insert_member(key, value).map(|x| x.1)
+        self.keyed_insert(key, value).map(|x| x.1)
     }
 
     /// Inserts a key-value pair into the map. If the key already had a value
@@ -361,20 +390,20 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collection_member)]
+    /// # #![feature(collection_keyed)]
     /// use std::collections::BTreeMap;
     ///
     /// let mut map = BTreeMap::new();
-    /// assert_eq!(map.insert_member(37, "a"), None);
+    /// assert_eq!(map.keyed_insert(37, "a"), None);
     /// assert_eq!(map.is_empty(), false);
     ///
     /// map.insert(37, "b");
-    /// assert_eq!(map.insert_member(37, "c"), Some((37, "b")));
+    /// assert_eq!(map.keyed_insert(37, "c"), Some((37, "b")));
     /// assert_eq!(map[&37], "c");
     /// ```
-    #[unstable(feature = "collection_member",
-            reason="member stuff is unclear")]
-    pub fn insert_member(&mut self, mut key: K, mut value: V) -> Option<(K, V)> {
+    #[unstable(feature = "collection_keyed",
+            reason="keyed was recently added")]
+    pub fn keyed_insert(&mut self, mut key: K, mut value: V) -> Option<(K, V)> {
         // This is a stack of rawptrs to nodes paired with indices, respectively
         // representing the nodes and edges of our search path. We have to store rawptrs
         // because as far as Rust is concerned, we can mutate aliased data with such a
@@ -485,7 +514,7 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn remove<Q: ?Sized>(&mut self, key: &Q) -> Option<V> where K: Borrow<Q>, Q: Ord {
-        self.remove_member(key).map(|x| x.1)
+        self.keyed_remove(key).map(|x| x.1)
     }
 
     /// Removes a key from the map, returning the key and the value at the key
@@ -497,17 +526,17 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collection_member)]
+    /// # #![feature(collection_keyed)]
     /// use std::collections::BTreeMap;
     ///
     /// let mut map = BTreeMap::new();
     /// map.insert(1, "a");
-    /// assert_eq!(map.remove_member(&1), Some((1, "a")));
-    /// assert_eq!(map.remove_member(&1), None);
+    /// assert_eq!(map.keyed_remove(&1), Some((1, "a")));
+    /// assert_eq!(map.keyed_remove(&1), None);
     /// ```
-    #[unstable(feature = "collection_member",
-            reason="member stuff is unclear")]
-    pub fn remove_member<Q: ?Sized>(&mut self, key: &Q) -> Option<(K, V)> where
+    #[unstable(feature = "collection_keyed",
+            reason="keyed was recently added")]
+    pub fn keyed_remove<Q: ?Sized>(&mut self, key: &Q) -> Option<(K, V)> where
             K: Borrow<Q>, Q: Ord {
         // See `swap` for a more thorough description of the stuff going on in here
         let mut stack = stack::PartialSearchStack::new(self);
@@ -516,7 +545,7 @@ impl<K: Ord, V> BTreeMap<K, V> {
                 match Node::search(node, key) {
                     Found(handle) => {
                         // Perfect match. Terminate the stack here, and remove the entry
-                        Finished(Some(pusher.seal(handle).remove_member()))
+                        Finished(Some(pusher.seal(handle).keyed_remove()))
                     },
                     GoDown(handle) => {
                         // We need to keep searching, try to go down the next edge
@@ -820,7 +849,7 @@ mod stack {
 
         /// Removes the key and value in the top element of the stack, then handles underflows as
         /// described in BTree's pop function.
-        pub fn remove_member(self) -> (K, V) {
+        pub fn keyed_remove(self) -> (K, V) {
             // Ensure that the search stack goes to a leaf. This is necessary to perform deletion
             // in a BTree. Note that this may put the tree in an inconsistent state (further
             // described in into_leaf's comments), but this is immediately fixed by the

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -315,7 +315,8 @@ impl<K: Ord, V> BTreeMap<K, V> {
     // See `keyed_get` for implementation notes, this is basically a copy-paste with mut's added
     #[unstable(feature = "collection_keyed",
             reason="keyed was recently added")]
-    pub fn keyed_get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<(&K, &mut V)> where K: Borrow<Q>, Q: Ord {
+    pub fn keyed_get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<(&K, &mut V)> where
+            K: Borrow<Q>, Q: Ord {
         // temp_node is a Borrowck hack for having a mutable value outlive a loop iteration
         let mut temp_node = &mut self.root;
         loop {

--- a/src/libcollections/btree/map.rs
+++ b/src/libcollections/btree/map.rs
@@ -595,7 +595,8 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// ```
     #[unstable(feature = "collection_member",
             reason="member stuff is unclear")]
-    pub fn remove_member<Q: ?Sized>(&mut self, key: &Q) -> Option<(K, V)> where K: Borrow<Q>, Q: Ord {
+    pub fn remove_member<Q: ?Sized>(&mut self, key: &Q) -> Option<(K, V)> where
+            K: Borrow<Q>, Q: Ord {
         // See `swap` for a more thorough description of the stuff going on in here
         let mut stack = stack::PartialSearchStack::new(self);
         loop {

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -490,14 +490,7 @@ impl<V> VecMap<V> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get(&self, key: &usize) -> Option<&V> {
-        if *key < self.v.len() {
-            match self.v[*key] {
-              Some(ref value) => Some(value),
-              None => None
-            }
-        } else {
-            None
-        }
+        self.get_member(key).map(|x| x.1)
     }
 
     /// Returns a reference to the key and the value corresponding to the key.
@@ -592,11 +585,7 @@ impl<V> VecMap<V> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn insert(&mut self, key: usize, value: V) -> Option<V> {
-        let len = self.v.len();
-        if len <= key {
-            self.v.extend((0..key - len + 1).map(|_| None));
-        }
-        replace(&mut self.v[key], Some(value))
+        self.insert_member(key, value).map(|x| x.1)
     }
 
     /// Inserts a key-value pair into the map. If the key already had a value
@@ -644,11 +633,7 @@ impl<V> VecMap<V> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn remove(&mut self, key: &usize) -> Option<V> {
-        if *key >= self.v.len() {
-            return None;
-        }
-        let result = &mut self.v[*key];
-        result.take()
+        self.remove_member(key).map(|x| x.1)
     }
 
     /// Removes a key from the map, returning the key and value at the key if

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -500,6 +500,33 @@ impl<V> VecMap<V> {
         }
     }
 
+    /// Returns a reference to the key and the value corresponding to the key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(vecmap)]
+    /// # #![feature(collection_member)]
+    /// use std::collections::VecMap;
+    ///
+    /// let mut map = VecMap::new();
+    /// map.insert(1, "a");
+    /// assert_eq!(map.get_member(&1), Some((&1, &"a")));
+    /// assert_eq!(map.get_member(&2), None);
+    /// ```
+    #[unstable(feature = "collection_member",
+            reason="member stuff is unclear")]
+    pub fn get_member<'a>(&self, key: &'a usize) -> Option<(&'a usize, &V)> {
+        if *key < self.v.len() {
+            match self.v[*key] {
+              Some(ref value) => Some((key, value)),
+              None => None
+            }
+        } else {
+            None
+        }
+    }
+
     /// Returns true if the map contains a value for the specified key.
     ///
     /// # Examples
@@ -572,6 +599,35 @@ impl<V> VecMap<V> {
         replace(&mut self.v[key], Some(value))
     }
 
+    /// Inserts a key-value pair into the map. If the key already had a value
+    /// present in the map, that key and value are returned. Otherwise,
+    /// `None` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(vecmap)]
+    /// # #![feature(collection_member)]
+    /// use std::collections::VecMap;
+    ///
+    /// let mut map = VecMap::new();
+    /// assert_eq!(map.insert_member(37, "a"), None);
+    /// assert_eq!(map.is_empty(), false);
+    ///
+    /// map.insert(37, "b");
+    /// assert_eq!(map.insert_member(37, "c"), Some((37, "b")));
+    /// assert_eq!(map[37], "c");
+    /// ```
+    #[unstable(feature = "collection_member",
+            reason="member stuff is unclear")]
+    pub fn insert_member(&mut self, key: usize, value: V) -> Option<(usize, V)> {
+        let len = self.v.len();
+        if len <= key {
+            self.v.extend((0..key - len + 1).map(|_| None));
+        }
+        replace(&mut self.v[key], Some(value)).map(|x| (key, x))
+    }
+
     /// Removes a key from the map, returning the value at the key if the key
     /// was previously in the map.
     ///
@@ -593,6 +649,30 @@ impl<V> VecMap<V> {
         }
         let result = &mut self.v[*key];
         result.take()
+    }
+
+    /// Removes a key from the map, returning the key and value at the key if
+    /// it was previously in the map.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(vecmap)]
+    /// # #![feature(collection_member)]
+    /// use std::collections::VecMap;
+    ///
+    /// let mut map = VecMap::new();
+    /// map.insert(1, "a");
+    /// assert_eq!(map.remove_member(&1), Some((1, "a")));
+    /// assert_eq!(map.remove_member(&1), None);
+    /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub fn remove_member(&mut self, key: &usize) -> Option<(usize, V)> {
+        if *key >= self.v.len() {
+            return None;
+        }
+        let result = &mut self.v[*key];
+        result.take().map(|x| (*key, x))
     }
 
     /// Gets the given key's corresponding entry in the map for in-place manipulation.

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -490,7 +490,7 @@ impl<V> VecMap<V> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get(&self, key: &usize) -> Option<&V> {
-        self.get_member(key).map(|x| x.1)
+        self.keyed_get(key).map(|x| x.1)
     }
 
     /// Returns a reference to the key and the value corresponding to the key.
@@ -499,17 +499,17 @@ impl<V> VecMap<V> {
     ///
     /// ```
     /// # #![feature(vecmap)]
-    /// # #![feature(collection_member)]
+    /// # #![feature(collection_keyed)]
     /// use std::collections::VecMap;
     ///
     /// let mut map = VecMap::new();
     /// map.insert(1, "a");
-    /// assert_eq!(map.get_member(&1), Some((&1, &"a")));
-    /// assert_eq!(map.get_member(&2), None);
+    /// assert_eq!(map.keyed_get(&1), Some((&1, &"a")));
+    /// assert_eq!(map.keyed_get(&2), None);
     /// ```
-    #[unstable(feature = "collection_member",
-            reason="member stuff is unclear")]
-    pub fn get_member<'a>(&self, key: &'a usize) -> Option<(&'a usize, &V)> {
+    #[unstable(feature = "collection_keyed",
+            reason="keyed was recently added")]
+    pub fn keyed_get<'a>(&self, key: &'a usize) -> Option<(&'a usize, &V)> {
         if *key < self.v.len() {
             match self.v[*key] {
               Some(ref value) => Some((key, value)),
@@ -556,9 +556,32 @@ impl<V> VecMap<V> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn get_mut(&mut self, key: &usize) -> Option<&mut V> {
+        self.keyed_get_mut(key).map(|x| x.1)
+    }
+
+    /// Returns a mutable reference to the value corresponding to the key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(collection_keyed)]
+    /// # #![feature(vecmap)]
+    /// use std::collections::VecMap;
+    ///
+    /// let mut map = VecMap::new();
+    /// map.insert(1, "a");
+    /// if let Some((key, x)) = map.keyed_get_mut(&1) {
+    ///     assert_eq!(key, &1);
+    ///     *x = "b";
+    /// }
+    /// assert_eq!(map[1], "b");
+    /// ```
+    #[unstable(feature = "collection_keyed",
+            reason="keyed was recently added")]
+    pub fn keyed_get_mut<'a>(&mut self, key: &'a usize) -> Option<(&'a usize, &mut V)> {
         if *key < self.v.len() {
             match *(&mut self.v[*key]) {
-              Some(ref mut value) => Some(value),
+              Some(ref mut value) => Some((key, value)),
               None => None
             }
         } else {
@@ -585,7 +608,7 @@ impl<V> VecMap<V> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn insert(&mut self, key: usize, value: V) -> Option<V> {
-        self.insert_member(key, value).map(|x| x.1)
+        self.keyed_insert(key, value).map(|x| x.1)
     }
 
     /// Inserts a key-value pair into the map. If the key already had a value
@@ -596,20 +619,20 @@ impl<V> VecMap<V> {
     ///
     /// ```
     /// # #![feature(vecmap)]
-    /// # #![feature(collection_member)]
+    /// # #![feature(collection_keyed)]
     /// use std::collections::VecMap;
     ///
     /// let mut map = VecMap::new();
-    /// assert_eq!(map.insert_member(37, "a"), None);
+    /// assert_eq!(map.keyed_insert(37, "a"), None);
     /// assert_eq!(map.is_empty(), false);
     ///
     /// map.insert(37, "b");
-    /// assert_eq!(map.insert_member(37, "c"), Some((37, "b")));
+    /// assert_eq!(map.keyed_insert(37, "c"), Some((37, "b")));
     /// assert_eq!(map[37], "c");
     /// ```
-    #[unstable(feature = "collection_member",
-            reason="member stuff is unclear")]
-    pub fn insert_member(&mut self, key: usize, value: V) -> Option<(usize, V)> {
+    #[unstable(feature = "collection_keyed",
+            reason="keyed was recently added")]
+    pub fn keyed_insert(&mut self, key: usize, value: V) -> Option<(usize, V)> {
         let len = self.v.len();
         if len <= key {
             self.v.extend((0..key - len + 1).map(|_| None));
@@ -633,7 +656,7 @@ impl<V> VecMap<V> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn remove(&mut self, key: &usize) -> Option<V> {
-        self.remove_member(key).map(|x| x.1)
+        self.keyed_remove(key).map(|x| x.1)
     }
 
     /// Removes a key from the map, returning the key and value at the key if
@@ -643,16 +666,16 @@ impl<V> VecMap<V> {
     ///
     /// ```
     /// # #![feature(vecmap)]
-    /// # #![feature(collection_member)]
+    /// # #![feature(collection_keyed)]
     /// use std::collections::VecMap;
     ///
     /// let mut map = VecMap::new();
     /// map.insert(1, "a");
-    /// assert_eq!(map.remove_member(&1), Some((1, "a")));
-    /// assert_eq!(map.remove_member(&1), None);
+    /// assert_eq!(map.keyed_remove(&1), Some((1, "a")));
+    /// assert_eq!(map.keyed_remove(&1), None);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn remove_member(&mut self, key: &usize) -> Option<(usize, V)> {
+    pub fn keyed_remove(&mut self, key: &usize) -> Option<(usize, V)> {
         if *key >= self.v.len() {
             return None;
         }

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1033,17 +1033,17 @@ impl<K, V, S> HashMap<K, V, S>
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collection_member)]
+    /// # #![feature(collection_keyed)]
     /// use std::collections::HashMap;
     ///
     /// let mut map = HashMap::new();
     /// map.insert(1, "a");
-    /// assert_eq!(map.get_member(&1), Some((&1, &"a")));
-    /// assert_eq!(map.get_member(&2), None);
+    /// assert_eq!(map.keyed_get(&1), Some((&1, &"a")));
+    /// assert_eq!(map.keyed_get(&2), None);
     /// ```
-    #[unstable(feature = "collection_member",
-            reason="member stuff is unclear")]
-    pub fn get_member<Q: ?Sized>(&self, k: &Q) -> Option<(&K, &V)>
+    #[unstable(feature = "collection_keyed",
+            reason="keyed was recently added")]
+    pub fn keyed_get<Q: ?Sized>(&self, k: &Q) -> Option<(&K, &V)>
         where K: Borrow<Q>, Q: Hash + Eq
     {
         self.search(k).map(|bucket| bucket.into_refs())
@@ -1069,7 +1069,7 @@ impl<K, V, S> HashMap<K, V, S>
     pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
         where K: Borrow<Q>, Q: Hash + Eq
     {
-        self.get_member(k).map(|x| x.1)
+        self.keyed_get(k).map(|x| x.1)
     }
 
     /// Returns true if the map contains a value for the specified key.
@@ -1117,7 +1117,38 @@ impl<K, V, S> HashMap<K, V, S>
     pub fn get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut V>
         where K: Borrow<Q>, Q: Hash + Eq
     {
-        self.search_mut(k).map(|bucket| bucket.into_mut_refs().1)
+        self.keyed_get_mut(k).map(|x| x.1)
+    }
+
+    /// Returns a mutable reference to the value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// `Hash` and `Eq` on the borrowed form *must* match those for
+    /// the key type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(collection_keyed)]
+    /// use std::collections::HashMap;
+    ///
+    /// let mut map = HashMap::new();
+    /// map.insert(1, "a");
+    /// if let Some((key, x)) = map.keyed_get_mut(&1) {
+    ///     assert_eq!(key, &1);
+    ///     *x = "b";
+    /// }
+    /// assert_eq!(map[&1], "b");
+    /// ```
+    #[unstable(feature = "collection_keyed",
+            reason="keyed was recently added")]
+    pub fn keyed_get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<(&K, &mut V)>
+        where K: Borrow<Q>, Q: Hash + Eq
+    {
+        self.search_mut(k).map(|bucket| {
+            let (k, v) = bucket.into_mut_refs();
+            (&*k, v)
+        })
     }
 
     /// Inserts a key-value pair into the map. If the key already had a value
@@ -1138,7 +1169,7 @@ impl<K, V, S> HashMap<K, V, S>
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn insert(&mut self, k: K, v: V) -> Option<V> {
-        self.insert_member(k, v).map(|x| x.1)
+        self.keyed_insert(k, v).map(|x| x.1)
     }
 
     /// Inserts a key-value pair into the map. If the key already had a value
@@ -1148,20 +1179,20 @@ impl<K, V, S> HashMap<K, V, S>
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collection_member)]
+    /// # #![feature(collection_keyed)]
     /// use std::collections::HashMap;
     ///
     /// let mut map = HashMap::new();
-    /// assert_eq!(map.insert_member(37, "a"), None);
+    /// assert_eq!(map.keyed_insert(37, "a"), None);
     /// assert_eq!(map.is_empty(), false);
     ///
     /// map.insert(37, "b");
-    /// assert_eq!(map.insert_member(37, "c"), Some((37, "b")));
+    /// assert_eq!(map.keyed_insert(37, "c"), Some((37, "b")));
     /// assert_eq!(map[&37], "c");
     /// ```
-    #[unstable(feature = "collection_member",
-            reason="member stuff is unclear")]
-    pub fn insert_member(&mut self, k: K, v: V) -> Option<(K, V)> {
+    #[unstable(feature = "collection_keyed",
+            reason="keyed was recently added")]
+    pub fn keyed_insert(&mut self, k: K, v: V) -> Option<(K, V)> {
         let hash = self.make_hash(&k);
         self.reserve(1);
 
@@ -1193,7 +1224,7 @@ impl<K, V, S> HashMap<K, V, S>
     pub fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<V>
         where K: Borrow<Q>, Q: Hash + Eq
     {
-        self.remove_member(k).map(|x| x.1)
+        self.keyed_remove(k).map(|x| x.1)
     }
 
     /// Removes a key from the map, returning the key and the value at the key
@@ -1206,17 +1237,17 @@ impl<K, V, S> HashMap<K, V, S>
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collection_member)]
+    /// # #![feature(collection_keyed)]
     /// use std::collections::HashMap;
     ///
     /// let mut map = HashMap::new();
     /// map.insert(1, "a");
-    /// assert_eq!(map.remove_member(&1), Some((1, "a")));
-    /// assert_eq!(map.remove_member(&1), None);
+    /// assert_eq!(map.keyed_remove(&1), Some((1, "a")));
+    /// assert_eq!(map.keyed_remove(&1), None);
     /// ```
-    #[unstable(feature = "collection_member",
-            reason="member stuff is unclear")]
-    pub fn remove_member<Q: ?Sized>(&mut self, k: &Q) -> Option<(K, V)>
+    #[unstable(feature = "collection_keyed",
+            reason="keyed was recently added")]
+    pub fn keyed_remove<Q: ?Sized>(&mut self, k: &Q) -> Option<(K, V)>
         where K: Borrow<Q>, Q: Hash + Eq
     {
         if self.table.size() == 0 {

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1069,7 +1069,7 @@ impl<K, V, S> HashMap<K, V, S>
     pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
         where K: Borrow<Q>, Q: Hash + Eq
     {
-        self.search(k).map(|bucket| bucket.into_refs().1)
+        self.get_member(k).map(|x| x.1)
     }
 
     /// Returns true if the map contains a value for the specified key.
@@ -1138,14 +1138,7 @@ impl<K, V, S> HashMap<K, V, S>
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn insert(&mut self, k: K, v: V) -> Option<V> {
-        let hash = self.make_hash(&k);
-        self.reserve(1);
-
-        let mut retval = None;
-        self.insert_or_replace_with(hash, k, v, |_, _, val_ref, val| {
-            retval = Some(replace(val_ref, val));
-        });
-        retval
+        self.insert_member(k, v).map(|x| x.1)
     }
 
     /// Inserts a key-value pair into the map. If the key already had a value
@@ -1200,11 +1193,7 @@ impl<K, V, S> HashMap<K, V, S>
     pub fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<V>
         where K: Borrow<Q>, Q: Hash + Eq
     {
-        if self.table.size() == 0 {
-            return None
-        }
-
-        self.search_mut(k).map(|bucket| pop_internal(bucket).1)
+        self.remove_member(k).map(|x| x.1)
     }
 
     /// Removes a key from the map, returning the key and the value at the key

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -575,7 +575,9 @@ impl<T, S> HashSet<T, S>
     /// ```
     #[unstable(feature = "collection_member",
             reason="member stuff is unclear")]
-    pub fn insert_member(&mut self, value: T) -> Option<T> { self.map.insert_member(value, ()).map(|x| x.0) }
+    pub fn insert_member(&mut self, value: T) -> Option<T> {
+        self.map.insert_member(value, ()).map(|x| x.0)
+    }
 
     /// Removes a value from the set. Returns `true` if the value was
     /// present in the set.

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -459,18 +459,18 @@ impl<T, S> HashSet<T, S>
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collection_member)]
+    /// # #![feature(collection_keyed)]
     /// use std::collections::HashSet;
     ///
     /// let mut set = HashSet::new();
     ///
     /// assert_eq!(set.insert(2), true);
-    /// assert_eq!(set.get_member(&2), Some(&2));
+    /// assert_eq!(set.get(&2), Some(&2));
     /// ```
-    #[unstable(feature = "collection_member",
-            reason="member stuff is unclear")]
-    pub fn get_member(&mut self, value: &T) -> Option<&T> {
-        self.map.get_member(value).map(|x| x.0)
+    #[unstable(feature = "collection_keyed",
+            reason="keyed was recently added")]
+    pub fn get(&mut self, value: &T) -> Option<&T> {
+        self.map.keyed_get(value).map(|x| x.0)
     }
 
     /// Returns `true` if the set has no elements in common with `other`.
@@ -564,19 +564,19 @@ impl<T, S> HashSet<T, S>
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collection_member)]
+    /// # #![feature(collection_keyed)]
     /// use std::collections::HashSet;
     ///
     /// let mut set = HashSet::new();
     ///
-    /// assert_eq!(set.insert_member(2), None);
-    /// assert_eq!(set.insert_member(2), Some(2));
+    /// assert_eq!(set.insert_item(2), None);
+    /// assert_eq!(set.insert_item(2), Some(2));
     /// assert_eq!(set.len(), 1);
     /// ```
-    #[unstable(feature = "collection_member",
-            reason="member stuff is unclear")]
-    pub fn insert_member(&mut self, value: T) -> Option<T> {
-        self.map.insert_member(value, ()).map(|x| x.0)
+    #[unstable(feature = "collection_keyed",
+            reason="keyed was recently added")]
+    pub fn insert_item(&mut self, value: T) -> Option<T> {
+        self.map.keyed_insert(value, ()).map(|x| x.0)
     }
 
     /// Removes a value from the set. Returns `true` if the value was
@@ -614,21 +614,21 @@ impl<T, S> HashSet<T, S>
     /// # Examples
     ///
     /// ```
-    /// # #![feature(collection_member)]
+    /// # #![feature(collection_keyed)]
     /// use std::collections::HashSet;
     ///
     /// let mut set = HashSet::new();
     ///
     /// set.insert(2);
-    /// assert_eq!(set.remove_member(&2), Some(2));
-    /// assert_eq!(set.remove_member(&2), None);
+    /// assert_eq!(set.remove_item(&2), Some(2));
+    /// assert_eq!(set.remove_item(&2), None);
     /// ```
-    #[unstable(feature = "collection_member",
-            reason="member stuff is unclear")]
-    pub fn remove_member<Q: ?Sized>(&mut self, value: &Q) -> Option<T>
+    #[unstable(feature = "collection_keyed",
+            reason="keyed was recently added")]
+    pub fn remove_item<Q: ?Sized>(&mut self, value: &Q) -> Option<T>
         where T: Borrow<Q>, Q: Hash + Eq
     {
-        self.map.remove_member(value).map(|x| x.0)
+        self.map.keyed_remove(value).map(|x| x.0)
     }
 }
 

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -454,6 +454,25 @@ impl<T, S> HashSet<T, S>
         self.map.contains_key(value)
     }
 
+    /// Gets a value from a set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(collection_member)]
+    /// use std::collections::HashSet;
+    ///
+    /// let mut set = HashSet::new();
+    ///
+    /// assert_eq!(set.insert(2), true);
+    /// assert_eq!(set.get_member(&2), Some(&2));
+    /// ```
+    #[unstable(feature = "collection_member",
+            reason="member stuff is unclear")]
+    pub fn get_member(&mut self, value: &T) -> Option<&T> {
+        self.map.get_member(value).map(|x| x.0)
+    }
+
     /// Returns `true` if the set has no elements in common with `other`.
     /// This is equivalent to checking for an empty intersection.
     ///
@@ -539,6 +558,25 @@ impl<T, S> HashSet<T, S>
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn insert(&mut self, value: T) -> bool { self.map.insert(value, ()).is_none() }
 
+    /// Adds a value to the set. Returns the value that was already in the set,
+    /// if any.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(collection_member)]
+    /// use std::collections::HashSet;
+    ///
+    /// let mut set = HashSet::new();
+    ///
+    /// assert_eq!(set.insert_member(2), None);
+    /// assert_eq!(set.insert_member(2), Some(2));
+    /// assert_eq!(set.len(), 1);
+    /// ```
+    #[unstable(feature = "collection_member",
+            reason="member stuff is unclear")]
+    pub fn insert_member(&mut self, value: T) -> Option<T> { self.map.insert_member(value, ()).map(|x| x.0) }
+
     /// Removes a value from the set. Returns `true` if the value was
     /// present in the set.
     ///
@@ -562,6 +600,33 @@ impl<T, S> HashSet<T, S>
         where T: Borrow<Q>, Q: Hash + Eq
     {
         self.map.remove(value).is_some()
+    }
+
+    /// Removes a value from the set. Returns the value if it was
+    /// present in the set.
+    ///
+    /// The value may be any borrowed form of the set's value type, but
+    /// `Hash` and `Eq` on the borrowed form *must* match those for
+    /// the value type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(collection_member)]
+    /// use std::collections::HashSet;
+    ///
+    /// let mut set = HashSet::new();
+    ///
+    /// set.insert(2);
+    /// assert_eq!(set.remove_member(&2), Some(2));
+    /// assert_eq!(set.remove_member(&2), None);
+    /// ```
+    #[unstable(feature = "collection_member",
+            reason="member stuff is unclear")]
+    pub fn remove_member<Q: ?Sized>(&mut self, value: &Q) -> Option<T>
+        where T: Borrow<Q>, Q: Hash + Eq
+    {
+        self.map.remove_member(value).map(|x| x.0)
     }
 }
 


### PR DESCRIPTION
Set and Map will may the type on get, insert and remove using
get_member, insert_member and remove_member.

Previous to this commit, there is no way to recovering the key from a
map upon removal, and it might even be useful for get because two
elements that are equal are not necessarily the same, or
indistinguishible.

This patch fixes https://github.com/rust-lang/rfcs/issues/691 and helps with https://github.com/rust-lang/rfcs/issues/690
