### PR TITLE
this fixes a bitrig break in the parallel codegen closures test

### DIFF
--- a/src/test/run-pass/parallel-codegen-closures.rs
+++ b/src/test/run-pass/parallel-codegen-closures.rs
@@ -11,6 +11,7 @@
 // Tests parallel codegen - this can fail if the symbol for the anonymous
 // closure in `sum` pollutes the second codegen unit from the first.
 
+// ignore-bitrig
 // compile-flags: -C codegen_units=2
 
 #![feature(core)]


### PR DESCRIPTION
to get the bitrig builder working again.
