### PR TITLE
support llvm version 3.7 in configure

### DIFF
--- a/configure
+++ b/configure
@@ -920,7 +920,7 @@ then
     LLVM_VERSION=$($LLVM_CONFIG --version)
 
     case $LLVM_VERSION in
-        (3.[5-6]*)
+        (3.[5-7]*)
             msg "found ok version of LLVM: $LLVM_VERSION"
             ;;
         (*)


### PR DESCRIPTION
LLVM version 3.7 should be supported as external version (when using
--llvm-root configure option), as the current embedded LLVM version is
3.7.0svn.
