### PR TITLE
Remove remaining use of `bit_vec_append_splitoff` feature gate.

### DIFF
--- a/src/libcollectionstest/lib.rs
+++ b/src/libcollectionstest/lib.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 #![feature(append)]
-#![feature(bit_vec_append_split_off)]
 #![feature(bitset)]
 #![feature(bitvec)]
 #![feature(box_syntax)]


### PR DESCRIPTION
This seems to have slipped through the cracks in #26192.

r? @alexcrichton 
