### PR TITLE
Use correct type for "use of moved value" error with closures.

### DIFF
--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -734,7 +734,7 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                             has type `{}`, which is {}",
                             ol,
                             moved_lp_msg,
-                            expr_ty,
+                            moved_lp.ty,
                             suggestion));
                 self.tcx.sess.fileline_help(expr_span, help);
             }

--- a/src/test/compile-fail/issue-18119.rs
+++ b/src/test/compile-fail/issue-18119.rs
@@ -1,0 +1,22 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+const X: u8 = 1;
+static Y: u8 = 1;
+fn foo() {}
+
+impl X {}
+//~^ ERROR use of undeclared type name `X`
+impl Y {}
+//~^ ERROR use of undeclared type name `Y`
+impl foo {}
+//~^ ERROR use of undeclared type name `foo`
+
+fn main() {}

--- a/src/test/compile-fail/issue-24357.rs
+++ b/src/test/compile-fail/issue-24357.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct NoCopy;
+fn main() {
+   let x = NoCopy;
+   let f = move || { let y = x; };
+   //~^ NOTE `x` moved into closure environment here because it has type `NoCopy`
+   let z = x;
+   //~^ ERROR use of moved value: `x`
+}


### PR DESCRIPTION
Fixes #24357.

Also adds a (totally separate) regression test, which

Closes #18119
