### PR TITLE
Ignore KDevelop 4 (and 5 pre-release) project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 *.exe
 *.fn
 *.html
+*.kdev4
 *.ky
 *.ll
 *.llvm


### PR DESCRIPTION
This is just a simple change to ignore KDevelop 4 (and pre-release versions of KDevelop 5) project files.
