### PR TITLE
Rewrite the improper_ctypes lint.

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -38,6 +38,7 @@
 #![feature(ref_slice)]
 #![feature(rustc_diagnostic_macros)]
 #![feature(rustc_private)]
+#![feature(slice_patterns)]
 #![feature(staged_api)]
 #![feature(str_char)]
 

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -685,7 +685,7 @@ extern {
     pub fn LLVMGetArrayLength(ArrayTy: TypeRef) -> c_uint;
     pub fn LLVMGetPointerAddressSpace(PointerTy: TypeRef) -> c_uint;
     pub fn LLVMGetPointerToGlobal(EE: ExecutionEngineRef, V: ValueRef)
-                                  -> *const ();
+                                  -> *const c_void;
     pub fn LLVMGetVectorSize(VectorTy: TypeRef) -> c_uint;
 
     /* Operations on other types */

--- a/src/librustc_trans/back/msvc/registry.rs
+++ b/src/librustc_trans/back/msvc/registry.rs
@@ -13,6 +13,7 @@ use std::ffi::{OsString, OsStr};
 use std::os::windows::prelude::*;
 use std::ops::RangeFrom;
 use libc::{DWORD, LPCWSTR, LONG, LPDWORD, LPBYTE, ERROR_SUCCESS};
+use libc::c_void;
 
 const HKEY_LOCAL_MACHINE: HKEY = 0x80000002 as HKEY;
 const KEY_WOW64_32KEY: REGSAM = 0x0200;
@@ -32,7 +33,7 @@ pub type HKEY = *mut __HKEY__;
 pub type PHKEY = *mut HKEY;
 pub type REGSAM = DWORD;
 pub type LPWSTR = *mut u16;
-pub type PFILETIME = *mut ();
+pub type PFILETIME = *mut c_void;
 
 #[link(name = "advapi32")]
 extern "system" {

--- a/src/libstd/rt/unwind/gcc.rs
+++ b/src/libstd/rt/unwind/gcc.rs
@@ -251,12 +251,11 @@ pub mod eabi {
     use rt::libunwind as uw;
     use libc::{c_void, c_int};
 
-    #[repr(C)]
-    pub struct EXCEPTION_RECORD;
-    #[repr(C)]
-    pub struct CONTEXT;
-    #[repr(C)]
-    pub struct DISPATCHER_CONTEXT;
+    // Fake definitions; these are actually complicated structs,
+    // but we don't use the contents here.
+    pub type EXCEPTION_RECORD = c_void;
+    pub type CONTEXT = c_void;
+    pub type DISPATCHER_CONTEXT = c_void;
 
     #[repr(C)]
     #[derive(Copy, Clone)]

--- a/src/libstd/sys/windows/stack_overflow.rs
+++ b/src/libstd/sys/windows/stack_overflow.rs
@@ -82,6 +82,7 @@ pub unsafe fn make_handler() -> Handler {
     Handler { _data: 0 as *mut libc::c_void }
 }
 
+#[repr(C)]
 pub struct EXCEPTION_RECORD {
     pub ExceptionCode: DWORD,
     pub ExceptionFlags: DWORD,
@@ -91,6 +92,7 @@ pub struct EXCEPTION_RECORD {
     pub ExceptionInformation: [LPVOID; EXCEPTION_MAXIMUM_PARAMETERS]
 }
 
+#[repr(C)]
 pub struct EXCEPTION_POINTERS {
     pub ExceptionRecord: *mut EXCEPTION_RECORD,
     pub ContextRecord: LPVOID

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -335,13 +335,13 @@ mod imp {
             #[linkage = "extern_weak"]
             static __dso_handle: *mut u8;
             #[linkage = "extern_weak"]
-            static __cxa_thread_atexit_impl: *const ();
+            static __cxa_thread_atexit_impl: *const libc::c_void;
         }
         if !__cxa_thread_atexit_impl.is_null() {
             type F = unsafe extern fn(dtor: unsafe extern fn(*mut u8),
                                       arg: *mut u8,
                                       dso_handle: *mut u8) -> libc::c_int;
-            mem::transmute::<*const (), F>(__cxa_thread_atexit_impl)
+            mem::transmute::<*const libc::c_void, F>(__cxa_thread_atexit_impl)
             (dtor, t, &__dso_handle as *const _ as *mut _);
             return
         }

--- a/src/test/compile-fail/issue-14309.rs
+++ b/src/test/compile-fail/issue-14309.rs
@@ -37,7 +37,7 @@ struct D {
 }
 
 extern "C" {
-    fn foo(x: A); //~ ERROR found type without foreign-function-safe
+    fn foo(x: A); //~ ERROR found struct without foreign-function-safe
     fn bar(x: B); //~ ERROR foreign-function-safe
     fn baz(x: C);
     fn qux(x: A2); //~ ERROR foreign-function-safe

--- a/src/test/compile-fail/issue-16250.rs
+++ b/src/test/compile-fail/issue-16250.rs
@@ -11,7 +11,7 @@
 #![deny(warnings)]
 
 extern {
-    pub fn foo(x: (isize)); //~ ERROR found rust type `isize` in foreign module
+    pub fn foo(x: (isize)); //~ ERROR found Rust type `isize` in foreign module
 }
 
 fn main() {

--- a/src/test/compile-fail/lint-ctypes-enum.rs
+++ b/src/test/compile-fail/lint-ctypes-enum.rs
@@ -18,9 +18,9 @@ enum T { E, F, G }
 
 extern {
    fn zf(x: Z);
-   fn uf(x: U); //~ ERROR found type without foreign-function-safe
-   fn bf(x: B); //~ ERROR found type without foreign-function-safe
-   fn tf(x: T); //~ ERROR found type without foreign-function-safe
+   fn uf(x: U); //~ ERROR found enum without foreign-function-safe
+   fn bf(x: B); //~ ERROR found enum without foreign-function-safe
+   fn tf(x: T); //~ ERROR found enum without foreign-function-safe
 }
 
 pub fn main() { }

--- a/src/test/compile-fail/lint-ctypes.rs
+++ b/src/test/compile-fail/lint-ctypes.rs
@@ -13,14 +13,45 @@
 
 extern crate libc;
 
+trait Mirror { type It; }
+impl<T> Mirror for T { type It = Self; }
+#[repr(C)]
+pub struct StructWithProjection(*mut <StructWithProjection as Mirror>::It);
+#[repr(C)]
+pub struct StructWithProjectionAndLifetime<'a>(
+    &'a mut <StructWithProjectionAndLifetime<'a> as Mirror>::It
+);
+pub type I32Pair = (i32, i32);
+#[repr(C)]
+pub struct ZeroSize;
+pub type RustFn = fn();
+pub type RustBadRet = extern fn() -> Box<u32>;
+
 extern {
-    pub fn bare_type1(size: isize); //~ ERROR: found rust type
-    pub fn bare_type2(size: usize); //~ ERROR: found rust type
-    pub fn ptr_type1(size: *const isize); //~ ERROR: found rust type
-    pub fn ptr_type2(size: *const usize); //~ ERROR: found rust type
+    pub fn bare_type1(size: isize); //~ ERROR: found Rust type
+    pub fn bare_type2(size: usize); //~ ERROR: found Rust type
+    pub fn ptr_type1(size: *const isize); //~ ERROR: found Rust type
+    pub fn ptr_type2(size: *const usize); //~ ERROR: found Rust type
+    pub fn slice_type(p: &[u32]); //~ ERROR: found Rust slice type
+    pub fn str_type(p: &str); //~ ERROR: found Rust type
+    pub fn box_type(p: Box<u32>); //~ ERROR found Rust type
+    pub fn char_type(p: char); //~ ERROR found Rust type
+    pub fn trait_type(p: &Clone); //~ ERROR found Rust trait type
+    pub fn tuple_type(p: (i32, i32)); //~ ERROR found Rust tuple type
+    pub fn tuple_type2(p: I32Pair); //~ ERROR found Rust tuple type
+    pub fn zero_size(p: ZeroSize); //~ ERROR found zero-size struct
+    pub fn fn_type(p: RustFn); //~ ERROR found function pointer with Rust
+    pub fn fn_type2(p: fn()); //~ ERROR found function pointer with Rust
+    pub fn fn_contained(p: RustBadRet); //~ ERROR: found Rust type
 
     pub fn good1(size: *const libc::c_int);
     pub fn good2(size: *const libc::c_uint);
+    pub fn good3(fptr: Option<extern fn()>);
+    pub fn good4(aptr: &[u8; 4 as usize]);
+    pub fn good5(s: StructWithProjection);
+    pub fn good6(s: StructWithProjectionAndLifetime);
+    pub fn good7(fptr: extern fn() -> ());
+    pub fn good8(fptr: extern fn() -> !);
 }
 
 fn main() {

--- a/src/test/compile-fail/warn-foreign-int-types.rs
+++ b/src/test/compile-fail/warn-foreign-int-types.rs
@@ -13,9 +13,9 @@
 
 mod xx {
     extern {
-        pub fn strlen(str: *const u8) -> usize; //~ ERROR found rust type `usize`
-        pub fn foo(x: isize, y: usize); //~ ERROR found rust type `isize`
-        //~^ ERROR found rust type `usize`
+        pub fn strlen(str: *const u8) -> usize; //~ ERROR found Rust type `usize`
+        pub fn foo(x: isize, y: usize); //~ ERROR found Rust type `isize`
+        //~^ ERROR found Rust type `usize`
     }
 }
 

--- a/src/test/run-make/execution-engine/test.rs
+++ b/src/test/run-make/execution-engine/test.rs
@@ -9,7 +9,9 @@
 // except according to those terms.
 
 #![feature(rustc_private)]
+#![feature(libc)]
 
+extern crate libc;
 extern crate rustc;
 extern crate rustc_driver;
 extern crate rustc_lint;
@@ -29,6 +31,7 @@ use rustc::session::config::{self, basic_options, build_configuration, Input, Op
 use rustc::session::build_session;
 use rustc_driver::driver;
 use rustc_resolve::MakeGlobMap;
+use libc::c_void;
 
 use syntax::diagnostics::registry::Registry;
 
@@ -111,7 +114,7 @@ impl ExecutionEngine {
     }
 
     /// Returns a raw pointer to the named function.
-    pub fn get_function(&mut self, name: &str) -> Option<*const ()> {
+    pub fn get_function(&mut self, name: &str) -> Option<*const c_void> {
         let s = CString::new(name.as_bytes()).unwrap();
 
         for &m in &self.modules {
@@ -128,7 +131,7 @@ impl ExecutionEngine {
     }
 
     /// Returns a raw pointer to the named global item.
-    pub fn get_global(&mut self, name: &str) -> Option<*const ()> {
+    pub fn get_global(&mut self, name: &str) -> Option<*const c_void> {
         let s = CString::new(name.as_bytes()).unwrap();
 
         for &m in &self.modules {


### PR DESCRIPTION
Makes the lint a bit more accurate, and improves the quality of the diagnostic
messages by explicitly returning an error message.
