### PR TITLE
Allow using an undeclared '_ as an anonymous input or inference region.

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4598,7 +4598,7 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
             let region_count = region_defs.len(space);
             assert_eq!(substs.regions().len(space), 0);
             for (i, lifetime) in data.lifetimes.iter().enumerate() {
-                let r = ast_region_to_region(fcx.tcx(), lifetime);
+                let r = ast_region_to_region(fcx.tcx(), fcx, lifetime);
                 if i < region_count {
                     substs.mut_regions().push(space, r);
                 } else if i == region_count {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1763,7 +1763,7 @@ fn ty_generic_predicates<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
                 name: param.lifetime.name
             });
         for bound in &param.bounds {
-            let bound_region = ast_region_to_region(ccx.tcx, bound);
+            let bound_region = ast_region_to_region(tcx, &ExplicitRscope, bound);
             let outlives = ty::Binder(ty::OutlivesPredicate(region, bound_region));
             result.predicates.push(space, outlives.to_predicate());
         }
@@ -1797,7 +1797,7 @@ fn ty_generic_predicates<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
                         }
 
                         &ast::TyParamBound::RegionTyParamBound(ref lifetime) => {
-                            let region = ast_region_to_region(tcx, lifetime);
+                            let region = ast_region_to_region(tcx, &ExplicitRscope, lifetime);
                             let pred = ty::Binder(ty::OutlivesPredicate(ty, region));
                             result.predicates.push(space, ty::Predicate::TypeOutlives(pred))
                         }
@@ -1806,9 +1806,9 @@ fn ty_generic_predicates<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
             }
 
             &ast::WherePredicate::RegionPredicate(ref region_pred) => {
-                let r1 = ast_region_to_region(tcx, &region_pred.lifetime);
+                let r1 = ast_region_to_region(tcx, &ExplicitRscope, &region_pred.lifetime);
                 for bound in &region_pred.bounds {
-                    let r2 = ast_region_to_region(tcx, bound);
+                    let r2 = ast_region_to_region(tcx, &ExplicitRscope, bound);
                     let pred = ty::Binder(ty::OutlivesPredicate(r1, r2));
                     result.predicates.push(space, ty::Predicate::RegionOutlives(pred))
                 }
@@ -1838,7 +1838,7 @@ fn ty_generics<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
     let early_lifetimes = early_bound_lifetimes_from_generics(space, ast_generics);
     for (i, l) in early_lifetimes.iter().enumerate() {
         let bounds = l.bounds.iter()
-                             .map(|l| ast_region_to_region(tcx, l))
+                             .map(|l| ast_region_to_region(tcx, &ExplicitRscope, l))
                              .collect();
         let def = ty::RegionParameterDef { name: l.lifetime.name,
                                            space: space,
@@ -1954,7 +1954,7 @@ fn compute_object_lifetime_default<'a,'tcx>(ccx: &CrateCtxt<'a,'tcx>,
                       ast::TraitTyParamBound(..) =>
                           None,
                       ast::RegionTyParamBound(ref lifetime) =>
-                          Some(astconv::ast_region_to_region(ccx.tcx, lifetime)),
+                          Some(ast_region_to_region(ccx.tcx, &ExplicitRscope, lifetime)),
                   }
               })
               .collect()
@@ -2037,7 +2037,7 @@ fn predicates_from_bound<'tcx>(astconv: &AstConv<'tcx>,
                        .collect()
         }
         ast::RegionTyParamBound(ref lifetime) => {
-            let region = ast_region_to_region(astconv.tcx(), lifetime);
+            let region = ast_region_to_region(astconv.tcx(), &ExplicitRscope, lifetime);
             let pred = ty::Binder(ty::OutlivesPredicate(param_ty, region));
             vec![ty::Predicate::TypeOutlives(pred)]
         }
@@ -2085,7 +2085,7 @@ fn conv_param_bounds<'a,'tcx>(astconv: &AstConv<'tcx>,
 
     let region_bounds: Vec<ty::Region> =
         region_bounds.into_iter()
-                     .map(|r| ast_region_to_region(tcx, r))
+                     .map(|r| ast_region_to_region(tcx, &ExplicitRscope, r))
                      .collect();
 
     astconv::Bounds {

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -155,6 +155,9 @@ const KNOWN_FEATURES: &'static [(&'static str, &'static str, Status)] = &[
 
     // Allows the definition of `const fn` functions.
     ("const_fn", "1.2.0", Active),
+
+    // Allows the usage of `'_` for function arguments and inference.
+    ("anon_lifetime", "1.2.0", Active),
 ];
 // (changing above list without updating src/doc/reference.md makes @cmr sad)
 
@@ -329,6 +332,7 @@ pub struct Features {
     /// #![feature] attrs for non-language (library) features
     pub declared_lib_features: Vec<(InternedString, Span)>,
     pub const_fn: bool,
+    pub anon_lifetime: bool,
 }
 
 impl Features {
@@ -350,6 +354,7 @@ impl Features {
             declared_stable_lang_features: Vec::new(),
             declared_lib_features: Vec::new(),
             const_fn: false,
+            anon_lifetime: false,
         }
     }
 }
@@ -789,6 +794,7 @@ fn check_crate_inner<F>(cm: &CodeMap, span_handler: &SpanHandler,
         declared_stable_lang_features: accepted_features,
         declared_lib_features: unknown_features,
         const_fn: cx.has_feature("const_fn"),
+        anon_lifetime: cx.has_feature("anon_lifetime"),
     }
 }
 

--- a/src/test/compile-fail/feature-gate-anon-lifetime.rs
+++ b/src/test/compile-fail/feature-gate-anon-lifetime.rs
@@ -1,0 +1,13 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let _: &'_ () = &(); //~ ERROR use of undeclared lifetime name `'_`
+}

--- a/src/test/run-pass/regions-explicit-anon.rs
+++ b/src/test/run-pass/regions-explicit-anon.rs
@@ -1,0 +1,31 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// pretty-expanded FIXME #23616
+
+#![feature(anon_lifetime)]
+
+struct Foo<'a, 'b: 'a, T: 'b>(&'a Vec<&'b T>);
+
+fn from<'c, 'd, T>(foo: &'c Foo<'_, 'd, T>) -> Result<&'c T, &'d T> {
+    if 1 == 1 {
+        Ok(&foo.0[0])
+    } else {
+        Err(&foo.0[1])
+    }
+}
+
+impl<'a, 'b, T> Foo<'a, 'b, T> {
+    fn to(&self) {
+        let _: Result<&'_ T, &'_ _> = from/*::<'_, 'b>*/(self);
+    }
+}
+
+pub fn main() {}


### PR DESCRIPTION
Needed in #26575 and future type context refactoring.
r? @nikomatsakis
