### PR TITLE
stage info

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -487,10 +487,6 @@ pub fn stage_str() -> Option<&'static str> {
         Some("stage0")
     } else if cfg!(stage1) {
         Some("stage1")
-    } else if cfg!(stage2) {
-        Some("stage2")
-    } else if cfg!(stage3) {
-        Some("stage3")
     } else {
         None
     }
@@ -508,7 +504,9 @@ pub fn version(binary: &str, matches: &getopts::Matches) {
         println!("commit-date: {}", unw(commit_date_str()));
         println!("host: {}", config::host_triple());
         println!("release: {}", unw(release_str()));
-        println!("stage: {}", unw(stage_str()));
+        if let Some(stage) = stage_str() {
+            println!("stage: {}", stage);
+        }
     }
 }
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -481,6 +481,21 @@ pub fn commit_date_str() -> Option<&'static str> {
     option_env!("CFG_VER_DATE")
 }
 
+/// Returns a stage string, such as "stage0".
+pub fn stage_str() -> Option<&'static str> {
+    if cfg!(stage0) {
+        Some("stage0")
+    } else if cfg!(stage1) {
+        Some("stage1")
+    } else if cfg!(stage2) {
+        Some("stage2")
+    } else if cfg!(stage3) {
+        Some("stage3")
+    } else {
+        None
+    }
+}
+
 /// Prints version information
 pub fn version(binary: &str, matches: &getopts::Matches) {
     let verbose = matches.opt_present("verbose");
@@ -493,6 +508,7 @@ pub fn version(binary: &str, matches: &getopts::Matches) {
         println!("commit-date: {}", unw(commit_date_str()));
         println!("host: {}", config::host_triple());
         println!("release: {}", unw(release_str()));
+        println!("stage: {}", unw(stage_str()));
     }
 }
 


### PR DESCRIPTION
This will add information about the stage that a rustc was built with to the verbose version info

I have symlinks into $(HOST)/stage{0,1,2} into the rust version switcher thing I use, and occasionally need to know which stage a given rustc is.
