### PR TITLE
core: rustc: improve compile message for unsized types

### DIFF
--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -47,7 +47,8 @@ impl<T> !Send for *mut T { }
 /// Types with a constant size known at compile-time.
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "sized"]
-#[rustc_on_unimplemented = "`{Self}` does not have a constant size known at compile-time"]
+#[rustc_on_unimplemented = "`{Self}` does not have a constant size known at compile-time. \
+                            Try to use `&{Self}` or `Box<{Self}>`?"]
 #[fundamental] // for Default, for example, which requires that `[T]: !Default` be evaluatable
 pub trait Sized {
     // Empty.


### PR DESCRIPTION
Currently, the compiler only tell us there is unsized type, but it's not clear how to fix the error, especially for a newbie.

```
t.rs:5:17: 5:18 error: the trait `core::marker::Sized` is not implemented for the type `MyTrait` [E0277]
t.rs:5 fn do_something(t: MyTrait) {
                       ^
t.rs:5:17: 5:18 note: `MyTrait` does not have a constant size known at compile-time
t.rs:5 fn do_something(t: MyTrait) {
                       ^
error: aborting due to previous error
```
