### PR TITLE
Clarifying deallocation order of resources within same scope

### DIFF
--- a/src/doc/trpl/references-and-borrowing.md
+++ b/src/doc/trpl/references-and-borrowing.md
@@ -336,7 +336,9 @@ In other words, `y` is only valid for the scope where `x` exists. As soon as
 the borrow ‘doesn’t live long enough’ because it’s not valid for the right
 amount of time.
 
-The same problem occurs when the reference is declared _before_ the variable it refers to:
+The same problem occurs when the reference is declared _before_ the variable it
+refers to. This is because resources within the same scope are freed in the
+opposite order they were declared:
 
 ```rust,ignore
 let y: &i32;
@@ -369,3 +371,6 @@ statement 1 at 3:14
     println!("{}", y);
 }
 ```
+
+In the above example, `y` is declared before `x`, meaning that `y` lives longer
+than `x`, which is not allowed.


### PR DESCRIPTION
In Chapter 5.9 (References and Borrowing), there is an example [at the very end](https://doc.rust-lang.org/stable/book/references-and-borrowing.html#use-after-free) which shows that declaring a reference before declaring the variable that it points to results in a compilation error. The book does not really mention why this happens though -- in the sections before, it has described how different scopes affects the lifetime of resources, but there is no mention of how resources within the same scope work.

This confused me a little, so I asked on #rust and got the answer that the resources are destroyed in the reverse order that they are declared, but the book makes no mention of it (as far as I can find) -- except in Chapter 5.21 (Drop), where it says:

> When `x` goes out of scope at the end of `main()`, the code for `Drop` will run. `Drop` has one method, which is also called `drop()`. It takes a mutable reference to `self`.
> 
> That’s it! The mechanics of `Drop` are very simple, but there are some subtleties. For example, values are dropped in the opposite order they are declared. [...]

---

I feel like Chapter 5.9 (References and Borrowing) is probably the best place to put this information (as I have done in my additions), since it deals with other types of referencing and borrowing. However, since English is not my native language, the wording of my additions perhaps are a little "off" -- any feedback on them is appreciated.
