### PR TITLE
Fix most warnings in tests

### DIFF
--- a/src/libcoretest/iter.rs
+++ b/src/libcoretest/iter.rs
@@ -452,6 +452,7 @@ fn test_inspect() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_unfoldr() {
     fn count(st: &mut usize) -> Option<usize> {
         if *st < 10 {
@@ -782,6 +783,7 @@ fn test_rposition_panic() {
 
 
 #[cfg(test)]
+#[allow(deprecated)]
 fn check_randacc_iter<A, T>(a: T, len: usize) where
     A: PartialEq,
     T: Clone + RandomAccessIterator + Iterator<Item=A>,
@@ -821,6 +823,7 @@ fn test_double_ended_flat_map() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_random_access_chain() {
     let xs = [1, 2, 3, 4, 5];
     let ys = [7, 9, 11];
@@ -884,6 +887,7 @@ fn test_random_access_skip() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_random_access_inspect() {
     let xs = [1, 2, 3, 4, 5];
 
@@ -897,6 +901,7 @@ fn test_random_access_inspect() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_random_access_map() {
     let xs = [1, 2, 3, 4, 5];
 
@@ -985,10 +990,17 @@ fn test_range_step() {
 }
 
 #[test]
-fn test_reverse() {
+#[allow(deprecated)]
+fn test_reverse_in_place() {
     let mut ys = [1, 2, 3, 4, 5];
     ys.iter_mut().reverse_in_place();
     assert!(ys == [5, 4, 3, 2, 1]);
+}
+
+#[test]
+fn test_reverse() {
+    let ys = [1, 2, 3, 4, 5].iter().cloned().rev().collect::<Vec<_>>();
+    assert_eq!(&ys, &[5, 4, 3, 2, 1]);
 }
 
 #[test]
@@ -1031,6 +1043,7 @@ fn test_min_max_result() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_iterate() {
     let mut it = iterate(1, |x| x * 2);
     assert_eq!(it.next(), Some(1));

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1311,7 +1311,6 @@ mod tests {
     use io::{ErrorKind, SeekFrom};
     use path::PathBuf;
     use path::Path as Path2;
-    use os;
     use rand::{self, StdRng, Rng};
     use str;
 

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -741,6 +741,7 @@ mod tests {
     // This is just here to make sure that we don't infinite loop in the
     // newtype struct autoderef weirdness
     #[test]
+    #[allow(deprecated)]
     fn test_buffered_stream() {
         struct S;
 
@@ -892,6 +893,7 @@ mod tests {
     }
 
     #[bench]
+    #[allow(deprecated)]
     fn bench_buffered_stream(b: &mut test::Bencher) {
         let mut buf = Cursor::new(Vec::new());
         b.iter(|| {

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -309,7 +309,7 @@ mod test {
         struct TestError;
 
         impl fmt::Display for TestError {
-            fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, _fmt: &mut fmt::Formatter) -> fmt::Result {
                 Ok(())
             }
         }

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -458,9 +458,7 @@ impl<'a, T: ToSocketAddrs + ?Sized> ToSocketAddrs for &'a T {
 #[cfg(test)]
 mod tests {
     use prelude::v1::*;
-    use io;
     use net::*;
-    use net::Ipv6MulticastScope::*;
     use net::test::{tsa, sa6, sa4};
 
     #[test]

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -514,7 +514,6 @@ impl FromInner<libc::in6_addr> for Ipv6Addr {
 #[cfg(test)]
 mod tests {
     use prelude::v1::*;
-    use io;
     use net::*;
     use net::Ipv6MulticastScope::*;
     use net::test::{tsa, sa6, sa4};

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -908,7 +908,7 @@ mod tests {
     #[test]
     fn timeouts() {
         let addr = next_test_ip4();
-        let listener = t!(TcpListener::bind(&addr));
+        let _listener = t!(TcpListener::bind(&addr));
 
         let stream = t!(TcpStream::connect(&("localhost", addr.port())));
         let dur = Duration::new(15410, 0);
@@ -933,7 +933,7 @@ mod tests {
     #[test]
     fn test_read_timeout() {
         let addr = next_test_ip4();
-        let listener = t!(TcpListener::bind(&addr));
+        let _listener = t!(TcpListener::bind(&addr));
 
         let mut stream = t!(TcpStream::connect(&("localhost", addr.port())));
         t!(stream.set_read_timeout(Some(Duration::from_millis(1000))));

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -391,7 +391,7 @@ mod tests {
     fn test_read_timeout() {
         let addr = next_test_ip4();
 
-        let mut stream = t!(UdpSocket::bind(&addr));
+        let stream = t!(UdpSocket::bind(&addr));
         t!(stream.set_read_timeout(Some(Duration::from_millis(1000))));
 
         let mut buf = [0; 10];
@@ -407,7 +407,7 @@ mod tests {
     fn test_read_with_timeout() {
         let addr = next_test_ip4();
 
-        let mut stream = t!(UdpSocket::bind(&addr));
+        let stream = t!(UdpSocket::bind(&addr));
         t!(stream.set_read_timeout(Some(Duration::from_millis(1000))));
 
         t!(stream.send_to(b"hello world", &addr));

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -15,12 +15,11 @@
 #![allow(unsigned_negation)]
 #![doc(primitive = "f32")]
 
-use prelude::v1::*;
-
-use core::num;
-use intrinsics;
-use libc::c_int;
-use num::{FpCategory, ParseFloatError};
+#[cfg(not(test))] use prelude::v1::*;
+#[cfg(not(test))] use core::num;
+#[cfg(not(test))] use intrinsics;
+#[cfg(not(test))] use libc::c_int;
+#[cfg(not(test))] use num::{FpCategory, ParseFloatError};
 
 pub use core::f32::{RADIX, MANTISSA_DIGITS, DIGITS, EPSILON};
 pub use core::f32::{MIN_EXP, MAX_EXP, MIN_10_EXP};
@@ -1690,6 +1689,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_real_consts() {
         use super::consts;
 

--- a/src/libstd/num/f64.rs
+++ b/src/libstd/num/f64.rs
@@ -14,12 +14,11 @@
 #![allow(missing_docs)]
 #![doc(primitive = "f64")]
 
-use prelude::v1::*;
-
-use core::num;
-use intrinsics;
-use libc::c_int;
-use num::{FpCategory, ParseFloatError};
+#[cfg(not(test))] use prelude::v1::*;
+#[cfg(not(test))] use core::num;
+#[cfg(not(test))] use intrinsics;
+#[cfg(not(test))] use libc::c_int;
+#[cfg(not(test))] use num::{FpCategory, ParseFloatError};
 
 pub use core::f64::{RADIX, MANTISSA_DIGITS, DIGITS, EPSILON};
 pub use core::f64::{MIN_EXP, MAX_EXP, MIN_10_EXP};
@@ -1646,6 +1645,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_real_consts() {
         use super::consts;
         let pi: f64 = consts::PI;

--- a/src/libstd/num/mod.rs
+++ b/src/libstd/num/mod.rs
@@ -45,11 +45,6 @@ pub fn test_num<T>(ten: T, two: T) where
 mod tests {
     use core::prelude::*;
     use super::*;
-    use i8;
-    use i16;
-    use i32;
-    use i64;
-    use isize;
     use u8;
     use u16;
     use u32;

--- a/src/libstd/os/raw.rs
+++ b/src/libstd/os/raw.rs
@@ -83,6 +83,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[test]
     fn unix() {
         {
             use os::unix::raw;

--- a/src/libstd/rand/os.rs
+++ b/src/libstd/rand/os.rs
@@ -346,8 +346,6 @@ mod imp {
 
 #[cfg(test)]
 mod tests {
-    use prelude::v1::*;
-
     use sync::mpsc::channel;
     use rand::Rng;
     use super::OsRng;

--- a/src/libstd/rand/reader.rs
+++ b/src/libstd/rand/reader.rs
@@ -64,8 +64,6 @@ impl<R: Read> Rng for ReaderRng<R> {
 
 #[cfg(test)]
 mod tests {
-    use prelude::v1::*;
-
     use super::ReaderRng;
     use rand::Rng;
 

--- a/src/libstd/rt/mod.rs
+++ b/src/libstd/rt/mod.rs
@@ -23,7 +23,6 @@
 
 use prelude::v1::*;
 use sys;
-use usize;
 
 // Reexport some of our utilities which are expected by other crates.
 pub use self::util::{min_stack, running_on_valgrind};
@@ -51,15 +50,16 @@ mod libunwind;
 /// of exiting cleanly.
 pub const DEFAULT_ERROR_CODE: isize = 101;
 
-#[cfg(any(windows, android))]
+#[cfg(all(any(windows, android), not(test)))]
 const OS_DEFAULT_STACK_ESTIMATE: usize = 1 << 20;
-#[cfg(all(unix, not(android)))]
+#[cfg(all(unix, not(android), not(test)))]
 const OS_DEFAULT_STACK_ESTIMATE: usize = 2 * (1 << 20);
 
 #[cfg(not(test))]
 #[lang = "start"]
 fn lang_start(main: *const u8, argc: isize, argv: *const *const u8) -> isize {
     use prelude::v1::*;
+    use usize;
 
     use mem;
     use env;

--- a/src/libstd/sys/common/stack.rs
+++ b/src/libstd/sys/common/stack.rs
@@ -216,6 +216,7 @@ pub unsafe fn record_sp_limit(limit: usize) {
 /// As with the setter, this function does not have a __morestack header and can
 /// therefore be called in a "we're out of stack" situation.
 #[inline(always)]
+#[cfg(not(test))]
 pub unsafe fn get_sp_limit() -> usize {
     return target_get_sp_limit();
 

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -446,8 +446,7 @@ mod tests {
     use mem;
     use ptr;
     use libc;
-    use slice;
-    use sys::{self, c, cvt, pipe};
+    use sys::{self, c, cvt};
 
     #[cfg(not(target_os = "android"))]
     extern {

--- a/src/libstd/thread/scoped_tls.rs
+++ b/src/libstd/thread/scoped_tls.rs
@@ -272,7 +272,6 @@ mod imp {
 #[cfg(test)]
 mod tests {
     use cell::Cell;
-    use prelude::v1::*;
 
     scoped_thread_local!(static FOO: u32);
 


### PR DESCRIPTION
This PR attempts to fix most warnings spewed by running `make check`:
- Adds several `#[allow(deprecated)]` attributes to tests which test deprecated code: `unfoldr`, `BufStream`, `RandomAccessIterator`, `reverse_in_place`, `thread::scoped`.
- Adds underscores to a bunch of unused args and locals.
- Adds `#[cfg(not(test))]` to places like primitive inherent impls where, AFAIU, where at test time the impls themselves are not requried since they are already provied by the `libstd` crate against which we link. 
- Removes several unused imports from a bunch of places.
- Replaces `Thunk` to `FnBox` in `remutex.rs` and gets rid of `thread::scoped`.

After these changes, I still get _some_ warnings, which I find really strange:
- In `sync::future` the tests throw deprecation warnings despite the toplevel module attribute allowing deprecation. Weird.
- I get a warning with the text for the `Future` deprecation, but target at libstd/lib.rs line 1 column 1:

```
src/libstd/lib.rs:1:1: 1:1 warning: use of deprecated item: implementation does not match the quality of the standard library and this will likely be prototyped outside in crates.io first, #[warn(deprecated)] on by default
src/libstd/lib.rs:1 // Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
```
- Unknown feature for definitely known feature. Is this some kind of weird artifact of how staging works? Would some kind of `#[cfg(not(test))]` for the feature be helpful?

```
src/libstd/lib.rs:118:12: 118:22 warning: unused or unknown feature, #[warn(unused_features)] on by default
src/libstd/lib.rs:118 #![feature(core_float)]
                                 ^~~~~~~~~~
```
- Unused warnings for things which are definitely used:

```
src/libstd/sys/unix/stack_overflow.rs:64:5: 64:37 warning: static item is never used: `PAGE_SIZE`, #[warn(dead_code)] on by default
src/libstd/sys/unix/stack_overflow.rs:64     static mut PAGE_SIZE: usize = 0;
                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/libstd/sys/unix/stack_overflow.rs:67:5: 95:6 warning: function is never used: `signal_handler`, #[warn(dead_code)] on by default
src/libstd/sys/unix/stack_overflow.rs:67     unsafe extern fn signal_handler(signum: libc::c_int,
src/libstd/sys/unix/stack_overflow.rs:68                                      info: *mut siginfo,
src/libstd/sys/unix/stack_overflow.rs:69                                      _data: *mut libc::c_void) {
src/libstd/sys/unix/stack_overflow.rs:70
src/libstd/sys/unix/stack_overflow.rs:71         // We can not return from a SIGSEGV or SIGBUS signal.
src/libstd/sys/unix/stack_overflow.rs:72         // See: https://www.gnu.org/software/libc/manual/html_node/Handler-Returns.html
                                         ...
src/libstd/sys/unix/stack_overflow.rs:74:9: 80:10 warning: function is never used: `term`, #[warn(dead_code)] on by default
src/libstd/sys/unix/stack_overflow.rs:74         unsafe fn term(signum: libc::c_int) -> ! {
src/libstd/sys/unix/stack_overflow.rs:75             use core::mem::transmute;
src/libstd/sys/unix/stack_overflow.rs:76
src/libstd/sys/unix/stack_overflow.rs:77             signal(signum, transmute(SIG_DFL));
src/libstd/sys/unix/stack_overflow.rs:78             raise(signum);
src/libstd/sys/unix/stack_overflow.rs:79             intrinsics::abort();
                                         ...
src/libstd/sys/unix/stack_overflow.rs:99:5: 116:6 warning: function is never used: `init`, #[warn(dead_code)] on by default
src/libstd/sys/unix/stack_overflow.rs:99     pub unsafe fn init() {
src/libstd/sys/unix/stack_overflow.rs:100         let psize = libc::sysconf(libc::consts::os::sysconf::_SC_PAGESIZE);
src/libstd/sys/unix/stack_overflow.rs:101         if psize == -1 {
src/libstd/sys/unix/stack_overflow.rs:102             panic!("failed to get page size");
src/libstd/sys/unix/stack_overflow.rs:103         }
src/libstd/sys/unix/stack_overflow.rs:104
```
