### PR TITLE
refactor svh

### DIFF
--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -1998,12 +1998,12 @@ fn encode_crate_dep(rbml_w: &mut Encoder,
                     dep: decoder::CrateDep) {
     rbml_w.start_tag(tag_crate_dep);
     rbml_w.wr_tagged_str(tag_crate_dep_crate_name, &dep.name);
-    rbml_w.wr_tagged_str(tag_crate_dep_hash, dep.hash.as_str());
+    rbml_w.wr_tagged_str(tag_crate_dep_hash, &dep.hash.to_string());
     rbml_w.end_tag();
 }
 
 fn encode_hash(rbml_w: &mut Encoder, hash: &Svh) {
-    rbml_w.wr_tagged_str(tag_crate_hash, hash.as_str());
+    rbml_w.wr_tagged_str(tag_crate_hash, &hash.to_string());
 }
 
 fn encode_crate_name(rbml_w: &mut Encoder, crate_name: &str) {

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -601,7 +601,7 @@ impl<'a> Context<'a> {
                     info!("Rejecting via hash: expected {} got {}", *myhash, hash);
                     self.rejected_via_hash.push(CrateMismatch {
                         path: libpath.to_path_buf(),
-                        got: myhash.as_str().to_string()
+                        got: myhash.to_string()
                     });
                     false
                 } else {

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -51,15 +51,6 @@ use std::hash::{Hash, SipHasher, Hasher};
 use syntax::ast;
 use syntax::visit;
 
-fn hex(b: u64) -> char {
-    let b = (b & 0xf) as u8;
-    let b = match b {
-        0 ... 9 => '0' as u8 + b,
-        _ => 'a' as u8 + b - 10,
-    };
-    b as char
-}
-
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Svh {
     raw: u64,
@@ -68,7 +59,7 @@ pub struct Svh {
 impl Svh {
     pub fn new(hash: &str) -> Svh {
         assert!(hash.len() == 16);
-        // Ideally we'd just reverse the nibbles on LE machines during as_string, unfortunately
+        // Ideally we'd just reverse the nibbles on LE machines during to_string, unfortunately
         // this would break the abi so I guess we're just doing this now.
 
         let s = if cfg!(target_endian = "big") {
@@ -80,10 +71,6 @@ impl Svh {
         Svh {
             raw: u64::from_str_radix(&s, 16).unwrap(),
         }
-    }
-
-    pub fn as_string(&self) -> String {
-        (0..64).step_by(4).map(|i| hex(self.raw >> i)).collect()
     }
 
     pub fn calculate(metadata: &Vec<String>, krate: &ast::Crate) -> Svh {
@@ -136,7 +123,7 @@ impl Hash for Svh {
 
 impl fmt::Display for Svh {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.pad(&self.as_string())
+        f.pad(&self.to_string())
     }
 }
 

--- a/src/librustc_back/svh.rs
+++ b/src/librustc_back/svh.rs
@@ -126,6 +126,14 @@ impl Svh {
     }
 }
 
+impl Hash for Svh {
+    fn hash<H>(&self, state: &mut H) where H: Hasher {
+        // We have to hash a &str since that's what the old implementations did, and otherwise we
+        // break the abi
+        &self.to_string()[..].hash(state);
+    }
+}
+
 impl fmt::Display for Svh {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad(&self.as_string())

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -481,8 +481,7 @@ pub fn commit_date_str() -> Option<&'static str> {
     option_env!("CFG_VER_DATE")
 }
 
-/// Prints version information and returns None on success or an error
-/// message on panic.
+/// Prints version information
 pub fn version(binary: &str, matches: &getopts::Matches) {
     let verbose = matches.opt_present("verbose");
 

--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -204,7 +204,7 @@ fn symbol_hash<'tcx>(tcx: &ty::ctxt<'tcx>,
     symbol_hasher.reset();
     symbol_hasher.input_str(&link_meta.crate_name);
     symbol_hasher.input_str("-");
-    symbol_hasher.input_str(link_meta.crate_hash.as_str());
+    symbol_hasher.input_str(&link_meta.crate_hash.to_string());
     for meta in tcx.sess.crate_metadata.borrow().iter() {
         symbol_hasher.input_str(&meta[..]);
     }

--- a/src/librustc_trans/trans/debuginfo/metadata.rs
+++ b/src/librustc_trans/trans/debuginfo/metadata.rs
@@ -336,7 +336,7 @@ impl<'tcx> TypeMap<'tcx> {
                 cx.sess().cstore.get_crate_hash(source_def_id.krate)
             };
 
-            output.push_str(crate_hash.as_str());
+            output.push_str(&crate_hash.to_string());
             output.push_str("/");
             output.push_str(&format!("{:x}", def_id.node));
 

--- a/src/rt/rust_try.ll
+++ b/src/rt/rust_try.ll
@@ -12,7 +12,7 @@
 ; When f(...) returns normally, the return value is null.
 ; When f(...) throws, the return value is a pointer to the caught exception object.
 
-; See also: libstd/rt/unwind.rs
+; See also: libstd/rt/unwind/mod.rs
 
 define i8* @rust_try(void (i8*)* %f, i8* %env) {
 


### PR DESCRIPTION
This is an excercise in yak shaving, started because I wanted to implement a lint for duplicated attrs, which lead me into the Svh machinery.

Unfortunately, due to [this comment](https://github.com/rust-lang/rust/blob/master/src/librustc_back/svh.rs#L90-L98) I suspect it's still not possible, but this simplifies the interfaces and internal representations of Svh.

(Opening the PR and then immediately rebasing because it won't merge, but I think github might nuke my comment)
