### PR TITLE
Add tip to do partial compile.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -62,6 +62,7 @@
 #   * tidy-basic - show file / line stats
 #   * tidy-errors - show the highest rustc error code
 #   * tidy-features - show the status of language and lib features
+#   * rustc-stage$(stage) - Only build up to a specific stage
 #
 # Then mix in some of these environment variables to harness the
 # ultimate power of The Rust Build System.


### PR DESCRIPTION
I keep forgetting the command to do partial stage1 compile, so I think it would be helpful to add it into `make tips`.
