### PR TITLE
Hacky patch to configure for Apple's LLVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# The Rust Programming Language
+# Temporary Rust Patch for El Capitan
+
+##This is a terrible, hacky, patch to keep rust compiling on OS X El Capitan for the time being
+
+##This fork should not be developed on further
 
 Rust is a fast systems programming language that guarantees
 memory safety and offers painless concurrency ([no data races]).

--- a/configure
+++ b/configure
@@ -991,7 +991,7 @@ then
             | cut -d ' ' -f 2)
 
         case $CFG_CLANG_VERSION in
-            (3.2* | 3.3* | 3.4* | 3.5* | 3.6* | 3.7*)
+            (3.2* | 3.3* | 3.4* | 3.5* | 3.6* | 3.7* | 7.0*)
             step_msg "found ok version of CLANG: $CFG_CLANG_VERSION"
             if [ -z "$CC" ]
             then


### PR DESCRIPTION
Added 7.0\* to the clang versions accepted so it will compile on OS X El Capitan for now.
