### PR TITLE
Handle two edge cases in the unconditional recursion lint

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1973,8 +1973,13 @@ impl LintPass for UnconditionalRecursion {
                                       fn_id: ast::NodeId,
                                       _: ast::Ident,
                                       id: ast::NodeId) -> bool {
-            tcx.def_map.borrow().get(&id)
-               .map_or(false, |def| def.def_id() == local_def(fn_id))
+            match tcx.map.get(id) {
+                ast_map::NodeExpr(&ast::Expr { node: ast::ExprCall(ref callee, _), .. }) => {
+                    tcx.def_map.borrow().get(&callee.id)
+                        .map_or(false, |def| def.def_id() == local_def(fn_id))
+                }
+                _ => false
+            }
         }
 
         // check if the method call `id` refers to method `method_id`

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -2007,6 +2007,15 @@ impl LintPass for UnconditionalRecursion {
                     // method instead.
                     ty::MethodTypeParam(
                         ty::MethodParam { ref trait_ref, method_num, impl_def_id: None, }) => {
+
+                        let on_self = m.substs.self_ty().map_or(false, |t| t.is_self());
+                        if !on_self {
+                            // we can only be recurring in a default
+                            // method if we're being called literally
+                            // on the `Self` type.
+                            return false
+                        }
+
                         tcx.trait_item(trait_ref.def_id, method_num).def_id()
                     }
 

--- a/src/test/compile-fail/lint-unconditional-recursion.rs
+++ b/src/test/compile-fail/lint-unconditional-recursion.rs
@@ -67,4 +67,11 @@ fn all_fine() {
     let _f = all_fine;
 }
 
+// issue 26333
+trait Bar {
+    fn method<T: Bar>(&self, x: &T) {
+        x.method(x)
+    }
+}
+
 fn main() {}

--- a/src/test/compile-fail/lint-unconditional-recursion.rs
+++ b/src/test/compile-fail/lint-unconditional-recursion.rs
@@ -63,4 +63,8 @@ impl Baz {
     }
 }
 
+fn all_fine() {
+    let _f = all_fine;
+}
+
 fn main() {}


### PR DESCRIPTION
This fixes two false positives for the unconditional recursion lint, when functions use themselves (or almost-themselves) internally, without actually being recursive.

``` rust
fn main() { let _ = main; }
```

``` rust
trait Bar {
    fn method<T: Bar>(&self, x: &T) {
        x.method(x)
    }
}
```
