### PR TITLE
[Fix for #26016] In the docs js: support keyboard events for non-english keyboard layouts

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -76,17 +76,46 @@
     highlightSourceLines(null);
     $(window).on('hashchange', highlightSourceLines);
 
-    $(document).on('keyup', function handleKeyboardShortcut(e) {
+    // Helper function for Keyboard events,
+    // Get's the char from the keypress event
+    //
+    // This method is used because e.wich === x is not
+    // compatible with non-english keyboard layouts
+    //
+    // Note: event.type must be keypress !
+    function getChar(event) {
+      if (event.which == null) {
+        return String.fromCharCode(event.keyCode) // IE
+      } else if (event.which!=0 && event.charCode!=0) {
+        return String.fromCharCode(event.which)   // the rest
+      } else {
+        return null // special key
+      }
+    }
+
+    $(document).on('keypress', function handleKeyboardShortcut(e) {
         if (document.activeElement.tagName === 'INPUT') {
             return;
         }
 
-        if (e.which === 191) { // question mark
+        if (getChar(e) === '?') {
             if (e.shiftKey && $('#help').hasClass('hidden')) {
                 e.preventDefault();
                 $('#help').removeClass('hidden');
             }
-        } else if (e.which === 27) { // esc
+        } else if (getChar(e) === 's' || getChar(e) === 'S') {
+            e.preventDefault();
+            $('.search-input').focus();
+        }
+    }).on('keydown', function(e) {
+        // The escape key event has to be captured with the keydown event.
+        // Because keypressed has no keycode for the escape key
+        // (and other special keys in general)...
+        if (document.activeElement.tagName === 'INPUT') {
+            return;
+        }
+
+        if (e.keyCode === 27) { // escape key
             if (!$('#help').hasClass('hidden')) {
                 e.preventDefault();
                 $('#help').addClass('hidden');
@@ -95,15 +124,13 @@
                 $('#search').addClass('hidden');
                 $('#main').removeClass('hidden');
             }
-        } else if (e.which === 83) { // S
-            e.preventDefault();
-            $('.search-input').focus();
         }
     }).on('click', function(e) {
         if (!$(e.target).closest('#help').length) {
             $('#help').addClass('hidden');
         }
     });
+
 
     $('.version-selector').on('change', function() {
         var i, match,


### PR DESCRIPTION
Like explained in #26016, typing `?` had no effect with non-english keyboard layouts in the docs. 

This patch seems to resolve this issue, **tested with AZERTY keyboard in Google Chrome and Firefox**. I haven't tested it with more exotic keyboard layouts or with other browsers though.

This code is based on the information found on: http://javascript.info/tutorial/keyboard-events

**More specifically:**

> The only event which reliably provides the character is keypress.

**And**

> ```
> // event.type must be keypress
> function getChar(event) {
>   if (event.which == null) {
>     return String.fromCharCode(event.keyCode) // IE
>   } else if (event.which!=0 && event.charCode!=0) {
>     return String.fromCharCode(event.which)   // the rest
>   } else {
>     return null // special key
>   }
> }
> ```

`?` and `S` work, `escape` however does not (on an Azerty keyboard). 

It would be good if some people could test it with other browsers and keyboard layouts: http://www.mathieudavid.org/test/rustdoc/std/index.html

**Edit:**
- swedish layout works on Firefox and Chromium
- french (azerty) mac layout works on Safari
