### PR TITLE
Add a lint for unused type parameters

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -63,6 +63,7 @@
 #![feature(no_std)]
 #![no_std]
 #![allow(raw_pointer_derive)]
+#![allow(unused_type_parameters)]
 #![deny(missing_docs)]
 
 #![feature(intrinsics)]

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -23,6 +23,12 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub UNUSED_TYPE_PARAMETERS,
+    Warn,
+    "type parameters that are never used"
+}
+
+declare_lint! {
     pub UNUSED_EXTERN_CRATES,
     Allow,
     "extern crates that are never used"
@@ -120,6 +126,7 @@ impl LintPass for HardwiredLints {
     fn get_lints(&self) -> LintArray {
         lint_array!(
             UNUSED_IMPORTS,
+            UNUSED_TYPE_PARAMETERS,
             UNUSED_EXTERN_CRATES,
             UNUSED_QUALIFICATIONS,
             UNKNOWN_LINTS,

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -123,7 +123,8 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
                     NON_CAMEL_CASE_TYPES, NON_SNAKE_CASE, NON_UPPER_CASE_GLOBALS);
 
     add_lint_group!(sess, "unused",
-                    UNUSED_IMPORTS, UNUSED_VARIABLES, UNUSED_ASSIGNMENTS, DEAD_CODE,
+                    UNUSED_IMPORTS, UNUSED_TYPE_PARAMETERS,
+                    UNUSED_VARIABLES, UNUSED_ASSIGNMENTS, DEAD_CODE,
                     UNUSED_MUT, UNREACHABLE_CODE, UNUSED_MUST_USE,
                     UNUSED_UNSAFE, PATH_STATEMENTS);
 

--- a/src/libstd/io/error.rs
+++ b/src/libstd/io/error.rs
@@ -280,6 +280,7 @@ impl error::Error for Error {
     }
 }
 
+#[allow(unused_type_parameters)]
 fn _assert_error_is_sync_send() {
     fn _is_sync_send<T: Sync+Send>() {}
     _is_sync_send::<Error>();

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -753,6 +753,7 @@ impl<'a, T: Send + 'a> Drop for JoinGuard<'a, T> {
     }
 }
 
+#[allow(unused_type_parameters)]
 fn _assert_sync_and_send() {
     fn _assert_both<T: Send + Sync>() {}
     _assert_both::<JoinHandle<()>>();

--- a/src/test/compile-fail/lint-dead-code-1.rs
+++ b/src/test/compile-fail/lint-dead-code-1.rs
@@ -81,6 +81,7 @@ enum used_enum {
     bar3 //~ ERROR variant is never used
 }
 
+#[allow(unused_type_parameters)]
 fn f<T>() {}
 
 pub fn pub_fn() {

--- a/src/test/compile-fail/lint-unused-type-parameters.rs
+++ b/src/test/compile-fail/lint-unused-type-parameters.rs
@@ -1,0 +1,42 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(unused_type_parameters)]
+
+pub fn f<T>() {} //~ ERROR unused type parameter
+
+pub struct S;
+impl S {
+    pub fn m<T>() {} //~ ERROR unused type parameter
+}
+
+trait Trait {
+    fn m<T>() {} //~ ERROR unused type parameter
+}
+
+// Now test allow attributes
+
+pub mod allow {
+    #[allow(unused_type_parameters)]
+    pub fn f<T>() {}
+
+    pub struct S;
+    impl S {
+        #[allow(unused_type_parameters)]
+        pub fn m<T>() {}
+    }
+
+    trait Trait {
+        #[allow(unused_type_parameters)]
+        fn m<T>() {}
+    }
+}
+
+fn main() {}

--- a/src/test/compile-fail/object-safety-phantom-fn.rs
+++ b/src/test/compile-fail/object-safety-phantom-fn.rs
@@ -12,6 +12,7 @@
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]
+#![allow(unused_type_parameters)]
 
 trait Baz {
 }


### PR DESCRIPTION
Fix #25871.
