### PR TITLE
Report memory use in time-passes

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -62,6 +62,7 @@
 #![feature(vec_push_all)]
 #![feature(wrapping)]
 #![feature(cell_extras)]
+#![feature(page_size)]
 #![cfg_attr(test, feature(test))]
 
 #![allow(trivial_casts)]


### PR DESCRIPTION
Reports the resident set size after each pass (linux-only).

r? @huonw or @alexcrichton 
