### PR TITLE
rustc: remove ty::MethodOrigin and replace its uses with equivalent logic.

### DIFF
--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -755,14 +755,8 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
                     })
                 }
 
-                ty::MethodStaticClosure(def_id) => {
-                    this.emit_enum_variant("MethodStaticClosure", 1, 1, |this| {
-                        Ok(this.emit_def_id(def_id))
-                    })
-                }
-
                 ty::MethodTypeParam(ref p) => {
-                    this.emit_enum_variant("MethodTypeParam", 2, 1, |this| {
+                    this.emit_enum_variant("MethodTypeParam", 1, 1, |this| {
                         this.emit_struct("MethodParam", 2, |this| {
                             try!(this.emit_struct_field("trait_ref", 0, |this| {
                                 Ok(this.emit_trait_ref(ecx, &p.trait_ref))
@@ -786,7 +780,7 @@ impl<'a, 'tcx> rbml_writer_helpers<'tcx> for Encoder<'a> {
                 }
 
                 ty::MethodTraitObject(ref o) => {
-                    this.emit_enum_variant("MethodTraitObject", 3, 1, |this| {
+                    this.emit_enum_variant("MethodTraitObject", 2, 1, |this| {
                         this.emit_struct("MethodObject", 2, |this| {
                             try!(this.emit_struct_field("trait_ref", 0, |this| {
                                 Ok(this.emit_trait_ref(ecx, &o.trait_ref))
@@ -1239,8 +1233,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
                                   -> ty::MethodOrigin<'tcx>
     {
         self.read_enum("MethodOrigin", |this| {
-            let variants = &["MethodStatic", "MethodStaticClosure",
-                             "MethodTypeParam", "MethodTraitObject"];
+            let variants = &["MethodStatic", "MethodTypeParam", "MethodTraitObject"];
             this.read_enum_variant(variants, |this, i| {
                 Ok(match i {
                     0 => {
@@ -1249,11 +1242,6 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
                     }
 
                     1 => {
-                        let def_id = this.read_def_id(dcx);
-                        ty::MethodStaticClosure(def_id)
-                    }
-
-                    2 => {
                         this.read_struct("MethodTypeParam", 2, |this| {
                             Ok(ty::MethodTypeParam(
                                 ty::MethodParam {
@@ -1282,7 +1270,7 @@ impl<'a, 'tcx> rbml_decoder_decoder_helpers<'tcx> for reader::Decoder<'a> {
                         }).unwrap()
                     }
 
-                    3 => {
+                    2 => {
                         this.read_struct("MethodTraitObject", 2, |this| {
                             Ok(ty::MethodTraitObject(
                                 ty::MethodObject {

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -609,20 +609,17 @@ fn encode_method_callee<'a, 'tcx>(ecx: &e::EncodeContext<'a, 'tcx>,
                                   method: &ty::MethodCallee<'tcx>) {
     use serialize::Encoder;
 
-    rbml_w.emit_struct("MethodCallee", 5, |rbml_w| {
+    rbml_w.emit_struct("MethodCallee", 4, |rbml_w| {
         rbml_w.emit_struct_field("autoderef", 0, |rbml_w| {
             autoderef.encode(rbml_w)
         });
         rbml_w.emit_struct_field("def_id", 1, |rbml_w| {
             Ok(rbml_w.emit_def_id(method.def_id))
         });
-        rbml_w.emit_struct_field("origin", 2, |rbml_w| {
-            method.origin.encode(rbml_w)
-        });
-        rbml_w.emit_struct_field("ty", 3, |rbml_w| {
+        rbml_w.emit_struct_field("ty", 2, |rbml_w| {
             Ok(rbml_w.emit_ty(ecx, method.ty))
         });
-        rbml_w.emit_struct_field("substs", 4, |rbml_w| {
+        rbml_w.emit_struct_field("substs", 3, |rbml_w| {
             Ok(rbml_w.emit_substs(ecx, &method.substs))
         })
     }).unwrap();
@@ -632,19 +629,17 @@ impl<'a, 'tcx> read_method_callee_helper<'tcx> for reader::Decoder<'a> {
     fn read_method_callee<'b, 'c>(&mut self, dcx: &DecodeContext<'b, 'c, 'tcx>)
                                   -> (u32, ty::MethodCallee<'tcx>) {
 
-        self.read_struct("MethodCallee", 5, |this| {
+        self.read_struct("MethodCallee", 4, |this| {
             let autoderef = this.read_struct_field("autoderef", 0,
                                                    Decodable::decode).unwrap();
             Ok((autoderef, ty::MethodCallee {
                 def_id: this.read_struct_field("def_id", 1, |this| {
                     Ok(this.read_def_id(dcx))
                 }).unwrap(),
-                origin: this.read_struct_field("origin", 2,
-                                               Decodable::decode).unwrap(),
-                ty: this.read_struct_field("ty", 3, |this| {
+                ty: this.read_struct_field("ty", 2, |this| {
                     Ok(this.read_ty(dcx))
                 }).unwrap(),
-                substs: this.read_struct_field("substs", 4, |this| {
+                substs: this.read_struct_field("substs", 3, |this| {
                     Ok(dcx.tcx.mk_substs(this.read_substs(dcx)))
                 }).unwrap()
             }))

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -696,11 +696,10 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>,
             }
         }
         ast::ExprMethodCall(..) => {
-            let is_const = match v.tcx.tables.borrow().method_map[&method_call] {
-                ty::MethodCallee { def_id, origin: ty::MethodOrigin::Inherent, .. } => {
-                    v.handle_const_fn_call(e, def_id, node_ty)
-                }
-                _ => false
+            let method = v.tcx.tables.borrow().method_map[&method_call];
+            let is_const = match v.tcx.impl_or_trait_item(method.def_id).container() {
+                ty::ImplContainer(_) => v.handle_const_fn_call(e, method.def_id, node_ty),
+                ty::TraitContainer(_) => false
             };
             if !is_const {
                 v.add_qualif(ConstQualif::NOT_CONST);

--- a/src/librustc/middle/check_const.rs
+++ b/src/librustc/middle/check_const.rs
@@ -696,13 +696,11 @@ fn check_expr<'a, 'tcx>(v: &mut CheckCrateVisitor<'a, 'tcx>,
             }
         }
         ast::ExprMethodCall(..) => {
-            let method_did = match v.tcx.tables.borrow().method_map[&method_call].origin {
-                ty::MethodStatic(did) => Some(did),
-                _ => None
-            };
-            let is_const = match method_did {
-                Some(did) => v.handle_const_fn_call(e, did, node_ty),
-                None => false
+            let is_const = match v.tcx.tables.borrow().method_map[&method_call] {
+                ty::MethodCallee { def_id, origin: ty::MethodOrigin::Inherent, .. } => {
+                    v.handle_const_fn_call(e, def_id, node_ty)
+                }
+                _ => false
             };
             if !is_const {
                 v.add_qualif(ConstQualif::NOT_CONST);

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -93,17 +93,10 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
         });
     }
 
-    fn lookup_and_handle_method(&mut self, id: ast::NodeId,
-                                span: codemap::Span) {
+    fn lookup_and_handle_method(&mut self, id: ast::NodeId) {
         let method_call = ty::MethodCall::expr(id);
-        match self.tcx.tables.borrow().method_map.get(&method_call) {
-            Some(method) => self.check_def_id(method.def_id),
-            None => {
-                self.tcx.sess.span_bug(span,
-                                       "method call expression not \
-                                        in method map?!")
-            }
-        }
+        let method = self.tcx.tables.borrow().method_map[&method_call];
+        self.check_def_id(method.def_id);
     }
 
     fn handle_field_access(&mut self, lhs: &ast::Expr, name: ast::Name) {
@@ -239,7 +232,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for MarkSymbolVisitor<'a, 'tcx> {
     fn visit_expr(&mut self, expr: &ast::Expr) {
         match expr.node {
             ast::ExprMethodCall(..) => {
-                self.lookup_and_handle_method(expr.id, expr.span);
+                self.lookup_and_handle_method(expr.id);
             }
             ast::ExprField(ref lhs, ref ident) => {
                 self.handle_field_access(&**lhs, ident.node.name);

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -97,29 +97,7 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
                                 span: codemap::Span) {
         let method_call = ty::MethodCall::expr(id);
         match self.tcx.tables.borrow().method_map.get(&method_call) {
-            Some(method) => {
-                match method.origin {
-                    ty::MethodStatic(def_id) => {
-                        match self.tcx.provided_source(def_id) {
-                            Some(p_did) => self.check_def_id(p_did),
-                            None => self.check_def_id(def_id)
-                        }
-                    }
-                    ty::MethodTypeParam(ty::MethodParam {
-                        ref trait_ref,
-                        method_num: index,
-                        ..
-                    }) |
-                    ty::MethodTraitObject(ty::MethodObject {
-                        ref trait_ref,
-                        method_num: index,
-                        ..
-                    }) => {
-                        let trait_item = self.tcx.trait_item(trait_ref.def_id, index);
-                        self.check_def_id(trait_item.def_id());
-                    }
-                }
-            }
+            Some(method) => self.check_def_id(method.def_id),
             None => {
                 self.tcx.sess.span_bug(span,
                                        "method call expression not \

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -105,7 +105,6 @@ impl<'a, 'tcx> MarkSymbolVisitor<'a, 'tcx> {
                             None => self.check_def_id(def_id)
                         }
                     }
-                    ty::MethodStaticClosure(_) => {}
                     ty::MethodTypeParam(ty::MethodParam {
                         ref trait_ref,
                         method_num: index,

--- a/src/librustc/middle/effect.rs
+++ b/src/librustc/middle/effect.rs
@@ -140,7 +140,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for EffectCheckVisitor<'a, 'tcx> {
         match expr.node {
             ast::ExprMethodCall(_, _, _) => {
                 let method_call = MethodCall::expr(expr.id);
-                let base_type = self.tcx.tables.borrow().method_map.get(&method_call).unwrap().ty;
+                let base_type = self.tcx.tables.borrow().method_map[&method_call].ty;
                 debug!("effect: method call case, base type is {:?}",
                         base_type);
                 if type_is_unsafe_function(base_type) {

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -23,10 +23,7 @@ use self::OverloadedCallType::*;
 use middle::{def, region, pat_util};
 use middle::infer;
 use middle::mem_categorization as mc;
-use middle::ty::{self};
-use middle::ty::{MethodCall, MethodObject, MethodTraitObject};
-use middle::ty::{MethodOrigin, MethodParam, MethodTypeParam};
-use middle::ty::{MethodStatic, MethodStaticClosure};
+use middle::ty;
 
 use syntax::{ast, ast_util};
 use syntax::ptr::P;
@@ -229,42 +226,8 @@ impl OverloadedCallType {
 
     fn from_method_id(tcx: &ty::ctxt, method_id: ast::DefId)
                       -> OverloadedCallType {
-        let method_descriptor = match tcx.impl_or_trait_item(method_id) {
-            ty::MethodTraitItem(ref method_descriptor) => {
-                (*method_descriptor).clone()
-            }
-            _ => {
-                tcx.sess.bug("overloaded call method wasn't in method map")
-            }
-        };
-        let impl_id = match method_descriptor.container {
-            ty::TraitContainer(_) => {
-                tcx.sess.bug("statically resolved overloaded call method \
-                              belonged to a trait?!")
-            }
-            ty::ImplContainer(impl_id) => impl_id,
-        };
-        let trait_ref = match tcx.impl_trait_ref(impl_id) {
-            None => {
-                tcx.sess.bug("statically resolved overloaded call impl \
-                              didn't implement a trait?!")
-            }
-            Some(ref trait_ref) => (*trait_ref).clone(),
-        };
-        OverloadedCallType::from_trait_id(tcx, trait_ref.def_id)
-    }
-
-    fn from_method_origin(tcx: &ty::ctxt, origin: &MethodOrigin)
-                          -> OverloadedCallType {
-        match *origin {
-            MethodStatic(def_id) => {
-                OverloadedCallType::from_method_id(tcx, def_id)
-            }
-            MethodTypeParam(MethodParam { ref trait_ref, .. }) |
-            MethodTraitObject(MethodObject { ref trait_ref, .. }) => {
-                OverloadedCallType::from_trait_id(tcx, trait_ref.def_id)
-            }
-        }
+        let method = tcx.impl_or_trait_item(method_id);
+        OverloadedCallType::from_trait_id(tcx, method.container().id())
     }
 }
 
@@ -614,11 +577,9 @@ impl<'d,'t,'a,'tcx> ExprUseVisitor<'d,'t,'a,'tcx> {
             ty::TyError => { }
             _ => {
                 let overloaded_call_type =
-                    match self.typer.node_method_origin(MethodCall::expr(call.id)) {
-                        Some(method_origin) => {
-                            OverloadedCallType::from_method_origin(
-                                self.tcx(),
-                                &method_origin)
+                    match self.typer.node_method_id(ty::MethodCall::expr(call.id)) {
+                        Some(method_id) => {
+                            OverloadedCallType::from_method_id(self.tcx(), method_id)
                         }
                         None => {
                             self.tcx().sess.span_bug(

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -254,26 +254,11 @@ impl OverloadedCallType {
         OverloadedCallType::from_trait_id(tcx, trait_ref.def_id)
     }
 
-    fn from_closure(tcx: &ty::ctxt, closure_did: ast::DefId)
-                    -> OverloadedCallType {
-        let trait_did =
-            tcx.tables
-               .borrow()
-               .closure_kinds
-               .get(&closure_did)
-               .expect("OverloadedCallType::from_closure: didn't find closure id")
-               .trait_did(tcx);
-        OverloadedCallType::from_trait_id(tcx, trait_did)
-    }
-
     fn from_method_origin(tcx: &ty::ctxt, origin: &MethodOrigin)
                           -> OverloadedCallType {
         match *origin {
             MethodStatic(def_id) => {
                 OverloadedCallType::from_method_id(tcx, def_id)
-            }
-            MethodStaticClosure(def_id) => {
-                OverloadedCallType::from_closure(tcx, def_id)
             }
             MethodTypeParam(MethodParam { ref trait_ref, .. }) |
             MethodTraitObject(MethodObject { ref trait_ref, .. }) => {

--- a/src/librustc/middle/infer/mod.rs
+++ b/src/librustc/middle/infer/mod.rs
@@ -1327,7 +1327,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     }
 
     pub fn node_method_ty(&self, method_call: ty::MethodCall)
-                      -> Option<Ty<'tcx>> {
+                          -> Option<Ty<'tcx>> {
         self.tables
             .borrow()
             .method_map
@@ -1336,14 +1336,13 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             .map(|ty| self.resolve_type_vars_if_possible(&ty))
     }
 
-    pub fn node_method_origin(&self, method_call: ty::MethodCall)
-                          -> Option<ty::MethodOrigin<'tcx>>
-    {
+    pub fn node_method_id(&self, method_call: ty::MethodCall)
+                          -> Option<ast::DefId> {
         self.tables
             .borrow()
             .method_map
             .get(&method_call)
-            .map(|method| method.origin.clone())
+            .map(|method| method.def_id)
     }
 
     pub fn adjustments(&self) -> Ref<NodeMap<ty::AutoAdjustment<'tcx>>> {

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1148,7 +1148,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
 
           ast::ExprMethodCall(_, _, ref args) => {
             let method_call = ty::MethodCall::expr(expr.id);
-            let method_ty = self.ir.tcx.tables.borrow().method_map.get(&method_call).unwrap().ty;
+            let method_ty = self.ir.tcx.tables.borrow().method_map[&method_call].ty;
             let succ = if method_ty.fn_ret().diverges() {
                 self.s.exit_ln
             } else {

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -128,8 +128,9 @@ impl<'a, 'tcx, 'v> Visitor<'v> for ReachableContext<'a, 'tcx> {
             }
             ast::ExprMethodCall(..) => {
                 let method_call = ty::MethodCall::expr(expr.id);
-                match self.tcx.tables.borrow().method_map[&method_call] {
-                    ty::MethodCallee { def_id, origin: ty::MethodOrigin::Inherent, .. } => {
+                let def_id = self.tcx.tables.borrow().method_map[&method_call].def_id;
+                match self.tcx.impl_or_trait_item(def_id).container() {
+                    ty::ImplContainer(_) => {
                         if is_local(def_id) {
                             if self.def_id_represents_local_inlined_item(def_id) {
                                 self.worklist.push(def_id.node)
@@ -137,7 +138,7 @@ impl<'a, 'tcx, 'v> Visitor<'v> for ReachableContext<'a, 'tcx> {
                             self.reachable_symbols.insert(def_id.node);
                         }
                     }
-                    _ => {}
+                    ty::TraitContainer(_) => {}
                 }
             }
             _ => {}

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -128,8 +128,8 @@ impl<'a, 'tcx, 'v> Visitor<'v> for ReachableContext<'a, 'tcx> {
             }
             ast::ExprMethodCall(..) => {
                 let method_call = ty::MethodCall::expr(expr.id);
-                match self.tcx.tables.borrow().method_map.get(&method_call).unwrap().origin {
-                    ty::MethodStatic(def_id) => {
+                match self.tcx.tables.borrow().method_map[&method_call] {
+                    ty::MethodCallee { def_id, origin: ty::MethodOrigin::Inherent, .. } => {
                         if is_local(def_id) {
                             if self.def_id_represents_local_inlined_item(def_id) {
                                 self.worklist.push(def_id.node)

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -406,10 +406,7 @@ pub fn check_expr(tcx: &ty::ctxt, e: &ast::Expr,
         ast::ExprMethodCall(i, _, _) => {
             span = i.span;
             let method_call = ty::MethodCall::expr(e.id);
-            match tcx.tables.borrow().method_map.get(&method_call) {
-                Some(method) => method.def_id,
-                None => return
-            }
+            tcx.tables.borrow().method_map[&method_call].def_id
         }
         ast::ExprField(ref base_e, ref field) => {
             span = field.span;

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -407,25 +407,7 @@ pub fn check_expr(tcx: &ty::ctxt, e: &ast::Expr,
             span = i.span;
             let method_call = ty::MethodCall::expr(e.id);
             match tcx.tables.borrow().method_map.get(&method_call) {
-                Some(method) => {
-                    match method.origin {
-                        ty::MethodStatic(def_id) => {
-                            def_id
-                        }
-                        ty::MethodTypeParam(ty::MethodParam {
-                            ref trait_ref,
-                            method_num: index,
-                            ..
-                        }) |
-                        ty::MethodTraitObject(ty::MethodObject {
-                            ref trait_ref,
-                            method_num: index,
-                            ..
-                        }) => {
-                            tcx.trait_item(trait_ref.def_id, index).def_id()
-                        }
-                    }
-                }
+                Some(method) => method.def_id,
                 None => return
             }
         }

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -412,9 +412,6 @@ pub fn check_expr(tcx: &ty::ctxt, e: &ast::Expr,
                         ty::MethodStatic(def_id) => {
                             def_id
                         }
-                        ty::MethodStaticClosure(def_id) => {
-                            def_id
-                        }
                         ty::MethodTypeParam(ty::MethodParam {
                             ref trait_ref,
                             method_num: index,

--- a/src/librustc/middle/traits/mod.rs
+++ b/src/librustc/middle/traits/mod.rs
@@ -291,11 +291,13 @@ pub struct VtableBuiltinData<N> {
 /// for the object type `Foo`.
 #[derive(PartialEq,Eq,Clone)]
 pub struct VtableObjectData<'tcx> {
-    /// the object type `Foo`.
-    pub object_ty: Ty<'tcx>,
-
     /// `Foo` upcast to the obligation trait. This will be some supertrait of `Foo`.
     pub upcast_trait_ref: ty::PolyTraitRef<'tcx>,
+
+    /// The vtable is formed by concatenating together the method lists of
+    /// the base object trait and all supertraits; this is the start of
+    /// `upcast_trait_ref`'s methods in that vtable.
+    pub vtable_base: usize
 }
 
 /// Creates predicate obligations from the generic bounds.

--- a/src/librustc/middle/traits/project.rs
+++ b/src/librustc/middle/traits/project.rs
@@ -629,9 +629,10 @@ fn assemble_candidates_from_object_type<'cx,'tcx>(
     selcx: &mut SelectionContext<'cx,'tcx>,
     obligation:  &ProjectionTyObligation<'tcx>,
     obligation_trait_ref: &ty::TraitRef<'tcx>,
-    candidate_set: &mut ProjectionTyCandidateSet<'tcx>,
-    object_ty: Ty<'tcx>)
+    candidate_set: &mut ProjectionTyCandidateSet<'tcx>)
 {
+    let self_ty = obligation_trait_ref.self_ty();
+    let object_ty = selcx.infcx().shallow_resolve(self_ty);
     debug!("assemble_candidates_from_object_type(object_ty={:?})",
            object_ty);
     let data = match object_ty.sty {
@@ -684,10 +685,9 @@ fn assemble_candidates_from_impls<'cx,'tcx>(
             candidate_set.vec.push(
                 ProjectionTyCandidate::Impl(data));
         }
-        super::VtableObject(data) => {
+        super::VtableObject(_) => {
             assemble_candidates_from_object_type(
-                selcx, obligation, obligation_trait_ref, candidate_set,
-                data.object_ty);
+                selcx, obligation, obligation_trait_ref, candidate_set);
         }
         super::VtableClosure(data) => {
             candidate_set.vec.push(

--- a/src/librustc/middle/traits/util.rs
+++ b/src/librustc/middle/traits/util.rs
@@ -397,19 +397,19 @@ pub fn upcast<'tcx>(tcx: &ty::ctxt<'tcx>,
 }
 
 /// Given an object of type `object_trait_ref`, returns the index of
-/// the method `n_method` found in the trait `trait_def_id` (which
-/// should be a supertrait of `object_trait_ref`) within the vtable
-/// for `object_trait_ref`.
+/// the method `method_def_id` (which should be part of a supertrait
+/// of `object_trait_ref`) within the vtable for `object_trait_ref`.
 pub fn get_vtable_index_of_object_method<'tcx>(tcx: &ty::ctxt<'tcx>,
                                                object_trait_ref: ty::PolyTraitRef<'tcx>,
-                                               trait_def_id: ast::DefId,
-                                               method_offset_in_trait: usize) -> usize {
+                                               method_def_id: ast::DefId) -> usize {
     // We need to figure the "real index" of the method in a
     // listing of all the methods of an object. We do this by
     // iterating down the supertraits of the object's trait until
     // we find the trait the method came from, counting up the
     // methods from them.
     let mut method_count = 0;
+
+    let trait_def_id = tcx.impl_or_trait_item(method_def_id).container().id();
 
     for bound_ref in transitive_bounds(tcx, &[object_trait_ref]) {
         if bound_ref.def_id() == trait_def_id {
@@ -427,21 +427,24 @@ pub fn get_vtable_index_of_object_method<'tcx>(tcx: &ty::ctxt<'tcx>,
 
     // count number of methods preceding the one we are selecting and
     // add them to the total offset; skip over associated types.
-    let trait_items = tcx.trait_items(trait_def_id);
-    for trait_item in trait_items.iter().take(method_offset_in_trait) {
+    for trait_item in &tcx.trait_items(trait_def_id)[..] {
+        if trait_item.def_id() == method_def_id {
+            // The item with the ID we were given really ought to be a method.
+            assert!(match *trait_item {
+                ty::MethodTraitItem(_) => true,
+                _ => false
+            });
+
+            return method_count;
+        }
         match *trait_item {
             ty::MethodTraitItem(_) => method_count += 1,
             _ => {}
         }
     }
 
-    // the item at the offset we were given really ought to be a method
-    assert!(match trait_items[method_offset_in_trait] {
-        ty::MethodTraitItem(_) => true,
-        _ => false
-    });
-
-    method_count
+    tcx.sess.bug(&format!("get_vtable_index_of_object_method: {:?} was not found",
+                          method_def_id));
 }
 
 pub enum TupleArgumentsFlag { Yes, No }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -631,9 +631,6 @@ pub enum MethodOrigin<'tcx> {
     // fully statically resolved method
     MethodStatic(ast::DefId),
 
-    // fully statically resolved closure invocation
-    MethodStaticClosure(ast::DefId),
-
     // method invoked on a type parameter with a bounded trait
     MethodTypeParam(MethodParam<'tcx>),
 

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -625,17 +625,13 @@ pub enum CustomCoerceUnsized {
     Struct(usize)
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, RustcEncodable, RustcDecodable, Debug)]
 pub enum MethodOrigin {
     /// Inherent impl method call.
     Inherent,
 
     /// Statically dispatched trait method call.
-    /// The DefId is the impl for the trait from which the method comes.
-    /// This should only be used for certain linting/heuristic purposes
-    /// since there is no guarantee that this is Some in every situation
-    /// that it could/should be.
-    Trait(Option<ast::DefId>),
+    Trait,
 
     /// Dynamically dispatched trait method call.
     /// The usize is the index into the actual runtime vtable.

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -625,20 +625,10 @@ pub enum CustomCoerceUnsized {
     Struct(usize)
 }
 
-#[derive(Clone, Copy, RustcEncodable, RustcDecodable, Debug)]
-pub enum MethodOrigin {
-    /// Inherent impl method call.
-    Inherent,
-
-    /// Trait method call.
-    Trait
-}
-
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct MethodCallee<'tcx> {
     /// Impl method ID, for inherent methods, or trait method ID, otherwise.
     pub def_id: ast::DefId,
-    pub origin: MethodOrigin,
     pub ty: Ty<'tcx>,
     pub substs: &'tcx subst::Substs<'tcx>
 }

--- a/src/librustc/middle/ty.rs
+++ b/src/librustc/middle/ty.rs
@@ -630,15 +630,8 @@ pub enum MethodOrigin {
     /// Inherent impl method call.
     Inherent,
 
-    /// Statically dispatched trait method call.
-    Trait,
-
-    /// Dynamically dispatched trait method call.
-    /// The usize is the index into the actual runtime vtable.
-    /// The vtable is formed by concatenating together the method lists of
-    /// the base object trait and all supertraits; this is the index into
-    /// that vtable.
-    Object(usize)
+    /// Trait method call.
+    Trait
 }
 
 #[derive(Clone, Debug)]

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -310,31 +310,6 @@ impl<'tcx> TypeFoldable<'tcx> for ty::AutoRef<'tcx> {
     }
 }
 
-impl<'tcx> TypeFoldable<'tcx> for ty::MethodOrigin<'tcx> {
-    fn fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> ty::MethodOrigin<'tcx> {
-        match *self {
-            ty::MethodStatic(def_id) => {
-                ty::MethodStatic(def_id)
-            }
-            ty::MethodTypeParam(ref param) => {
-                ty::MethodTypeParam(ty::MethodParam {
-                    trait_ref: param.trait_ref.fold_with(folder),
-                    method_num: param.method_num,
-                    impl_def_id: param.impl_def_id,
-                })
-            }
-            ty::MethodTraitObject(ref object) => {
-                ty::MethodTraitObject(ty::MethodObject {
-                    trait_ref: object.trait_ref.fold_with(folder),
-                    object_trait_id: object.object_trait_id,
-                    method_num: object.method_num,
-                    vtable_index: object.vtable_index,
-                })
-            }
-        }
-    }
-}
-
 impl<'tcx> TypeFoldable<'tcx> for ty::BuiltinBounds {
     fn fold_with<F: TypeFolder<'tcx>>(&self, _folder: &mut F) -> ty::BuiltinBounds {
         *self

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -492,8 +492,8 @@ impl<'tcx, N: TypeFoldable<'tcx>> TypeFoldable<'tcx> for traits::Vtable<'tcx, N>
 impl<'tcx> TypeFoldable<'tcx> for traits::VtableObjectData<'tcx> {
     fn fold_with<F:TypeFolder<'tcx>>(&self, folder: &mut F) -> traits::VtableObjectData<'tcx> {
         traits::VtableObjectData {
-            object_ty: self.object_ty.fold_with(folder),
             upcast_trait_ref: self.upcast_trait_ref.fold_with(folder),
+            vtable_base: self.vtable_base
         }
     }
 }

--- a/src/librustc/middle/ty_fold.rs
+++ b/src/librustc/middle/ty_fold.rs
@@ -316,9 +316,6 @@ impl<'tcx> TypeFoldable<'tcx> for ty::MethodOrigin<'tcx> {
             ty::MethodStatic(def_id) => {
                 ty::MethodStatic(def_id)
             }
-            ty::MethodStaticClosure(def_id) => {
-                ty::MethodStaticClosure(def_id)
-            }
             ty::MethodTypeParam(ref param) => {
                 ty::MethodTypeParam(ty::MethodParam {
                     trait_ref: param.trait_ref.fold_with(folder),

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -494,35 +494,6 @@ impl<'tcx> fmt::Display for ty::FnSig<'tcx> {
     }
 }
 
-impl<'tcx> fmt::Debug for ty::MethodOrigin<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            ty::MethodStatic(def_id) => {
-                write!(f, "MethodStatic({:?})", def_id)
-            }
-            ty::MethodTypeParam(ref p) => write!(f, "{:?}", p),
-            ty::MethodTraitObject(ref p) => write!(f, "{:?}", p)
-        }
-    }
-}
-
-impl<'tcx> fmt::Debug for ty::MethodParam<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "MethodParam({:?},{})",
-               self.trait_ref,
-               self.method_num)
-    }
-}
-
-impl<'tcx> fmt::Debug for ty::MethodObject<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "MethodObject({:?},{},{})",
-               self.trait_ref,
-               self.method_num,
-               self.vtable_index)
-    }
-}
-
 impl<'tcx> fmt::Debug for ty::ExistentialBounds<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut empty = true;

--- a/src/librustc/util/ppaux.rs
+++ b/src/librustc/util/ppaux.rs
@@ -500,9 +500,6 @@ impl<'tcx> fmt::Debug for ty::MethodOrigin<'tcx> {
             ty::MethodStatic(def_id) => {
                 write!(f, "MethodStatic({:?})", def_id)
             }
-            ty::MethodStaticClosure(def_id) => {
-                write!(f, "MethodStaticClosure({:?})", def_id)
-            }
             ty::MethodTypeParam(ref p) => write!(f, "{:?}", p),
             ty::MethodTraitObject(ref p) => write!(f, "{:?}", p)
         }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -2003,7 +2003,7 @@ impl LintPass for UnconditionalRecursion {
                     ty::MethodTraitObject(_) => return false,
 
                     // This `did` refers directly to the method definition.
-                    ty::MethodStatic(did) | ty::MethodStaticClosure(did) => did,
+                    ty::MethodStatic(did) => did,
 
                     // MethodTypeParam are methods from traits:
 

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1995,9 +1995,9 @@ impl LintPass for UnconditionalRecursion {
         fn expr_refers_to_this_method(tcx: &ty::ctxt,
                                       method: &ty::Method,
                                       id: ast::NodeId) -> bool {
-            let tables = tcx.tables.borrow();
-            let callee = match tables.method_map.get(&ty::MethodCall::expr(id)) {
-                Some(m) => m,
+            let method_call = ty::MethodCall::expr(id);
+            let callee = match tcx.tables.borrow().method_map.get(&method_call) {
+                Some(&m) => m,
                 None => return false
             };
             let callee_item = tcx.impl_or_trait_item(callee.def_id);

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -33,8 +33,10 @@
 
 use metadata::{csearch, decoder};
 use middle::def::*;
+use middle::infer;
 use middle::subst::Substs;
 use middle::ty::{self, Ty};
+use middle::traits;
 use middle::{def, pat_util, stability};
 use middle::const_eval::{eval_const_expr_partial, ConstVal};
 use middle::cfg;
@@ -1863,23 +1865,17 @@ impl LintPass for UnconditionalRecursion {
 
     fn check_fn(&mut self, cx: &Context, fn_kind: visit::FnKind, _: &ast::FnDecl,
                 blk: &ast::Block, sp: Span, id: ast::NodeId) {
-        // FIXME(#23542) Replace with type ascription.
-        #![allow(trivial_casts)]
-
         type F = for<'tcx> fn(&ty::ctxt<'tcx>,
                               ast::NodeId, ast::NodeId, ast::Ident, ast::NodeId) -> bool;
 
-        let (name, checker) = match fn_kind {
-            visit::FkItemFn(name, _, _, _, _, _) => (name, id_refers_to_this_fn as F),
-            visit::FkMethod(name, _, _) => (name, id_refers_to_this_method as F),
+        let method = match fn_kind {
+            visit::FkItemFn(..) => None,
+            visit::FkMethod(..) => {
+                cx.tcx.impl_or_trait_item(local_def(id)).as_opt_method()
+            }
             // closures can't recur, so they don't matter.
             visit::FkFnBlock => return
         };
-
-        let impl_def_id = cx.tcx.impl_of_method(local_def(id))
-            .unwrap_or(local_def(ast::DUMMY_NODE_ID));
-        assert!(ast_util::is_local(impl_def_id));
-        let impl_node_id = impl_def_id.node;
 
         // Walk through this function (say `f`) looking to see if
         // every possible path references itself, i.e. the function is
@@ -1931,7 +1927,17 @@ impl LintPass for UnconditionalRecursion {
             let node_id = cfg.graph.node_data(idx).id();
 
             // is this a recursive call?
-            if node_id != ast::DUMMY_NODE_ID && checker(cx.tcx, impl_node_id, id, name, node_id) {
+            let self_recursive = if node_id != ast::DUMMY_NODE_ID {
+                match method {
+                    Some(ref method) => {
+                        expr_refers_to_this_method(cx.tcx, method, node_id)
+                    }
+                    None => expr_refers_to_this_fn(cx.tcx, id, node_id)
+                }
+            } else {
+                false
+            };
+            if self_recursive {
                 self_call_spans.push(cx.tcx.map.span(node_id));
                 // this is a self call, so we shouldn't explore past
                 // this node in the CFG.
@@ -1970,15 +1976,12 @@ impl LintPass for UnconditionalRecursion {
         // all done
         return;
 
-        // Functions for identifying if the given NodeId `id`
-        // represents a call to the function `fn_id`/method
-        // `method_id`.
+        // Functions for identifying if the given Expr NodeId `id`
+        // represents a call to the function `fn_id`/method `method`.
 
-        fn id_refers_to_this_fn<'tcx>(tcx: &ty::ctxt<'tcx>,
-                                      _: ast::NodeId,
-                                      fn_id: ast::NodeId,
-                                      _: ast::Ident,
-                                      id: ast::NodeId) -> bool {
+        fn expr_refers_to_this_fn(tcx: &ty::ctxt,
+                                  fn_id: ast::NodeId,
+                                  id: ast::NodeId) -> bool {
             match tcx.map.get(id) {
                 ast_map::NodeExpr(&ast::Expr { node: ast::ExprCall(ref callee, _), .. }) => {
                     tcx.def_map.borrow().get(&callee.id)
@@ -1988,59 +1991,68 @@ impl LintPass for UnconditionalRecursion {
             }
         }
 
-        // check if the method call `id` refers to method `method_id`
-        // (with name `method_name` contained in impl `impl_id`).
-        fn id_refers_to_this_method<'tcx>(tcx: &ty::ctxt<'tcx>,
-                                          impl_id: ast::NodeId,
-                                          method_id: ast::NodeId,
-                                          method_name: ast::Ident,
-                                          id: ast::NodeId) -> bool {
-            let did = match tcx.tables.borrow().method_map.get(&ty::MethodCall::expr(id)) {
-                None => return false,
-                Some(m) => match m.origin {
-                    // There's no way to know if a method call via a
-                    // vtable is recursion, so we assume it's not.
-                    ty::MethodOrigin::Object(_) => return false,
+        // Check if the method call `id` refers to method `method`.
+        fn expr_refers_to_this_method(tcx: &ty::ctxt,
+                                      method: &ty::Method,
+                                      id: ast::NodeId) -> bool {
+            let tables = tcx.tables.borrow();
+            let callee = match tables.method_map.get(&ty::MethodCall::expr(id)) {
+                Some(m) => m,
+                None => return false
+            };
+            let callee_item = tcx.impl_or_trait_item(callee.def_id);
 
-                    // This `did` refers directly to the method definition.
-                    ty::MethodOrigin::Inherent => m.def_id,
+            match callee_item.container() {
+                // This is an inherent method, so the `def_id` refers
+                // directly to the method definition.
+                ty::ImplContainer(_) => {
+                    callee.def_id == method.def_id
+                }
 
-                    // The `impl ... for ...` of this method call
-                    // isn't known, e.g. it might be a default method
-                    // in a trait, so we get the def-id of the trait
-                    // method instead.
-                    ty::MethodOrigin::Trait(None) => {
-                        let on_self = m.substs.self_ty().map_or(false, |t| t.is_self());
-                        if !on_self {
-                            // we can only be recurring in a default
+                // A trait method, from any number of possible sources.
+                // Attempt to select a concrete impl before checking.
+                ty::TraitContainer(trait_def_id) => {
+                    let trait_substs = callee.substs.clone().method_to_trait();
+                    let trait_substs = tcx.mk_substs(trait_substs);
+                    let trait_ref = ty::TraitRef::new(trait_def_id, trait_substs);
+                    let trait_ref = ty::Binder(trait_ref);
+                    let span = tcx.map.span(id);
+                    let obligation =
+                        traits::Obligation::new(traits::ObligationCause::misc(span, id),
+                                                trait_ref.to_poly_trait_predicate());
+
+                    let param_env = ty::ParameterEnvironment::for_item(tcx, method.def_id.node);
+                    let infcx = infer::new_infer_ctxt(tcx, &tcx.tables, Some(param_env), false);
+                    let mut selcx = traits::SelectionContext::new(&infcx);
+                    match selcx.select(&obligation) {
+                        // The method comes from a `T: Trait` bound.
+                        // If `T` is `Self`, then this call is inside
+                        // a default method definition.
+                        Ok(Some(traits::VtableParam(_))) => {
+                            let self_ty = callee.substs.self_ty();
+                            let on_self = self_ty.map_or(false, |t| t.is_self());
+                            // We can only be recurring in a default
                             // method if we're being called literally
                             // on the `Self` type.
-                            return false
+                            on_self && callee.def_id == method.def_id
                         }
-                        m.def_id
-                    }
 
+                        // The `impl` is known, so we check that with a
+                        // special case:
+                        Ok(Some(traits::VtableImpl(vtable_impl))) => {
+                            let container = ty::ImplContainer(vtable_impl.impl_def_id);
+                            // It matches if it comes from the same impl,
+                            // and has the same method name.
+                            container == method.container
+                                && callee_item.name() == method.name
+                        }
 
-                    // The `impl` is known, so we check that with a
-                    // special case:
-                    ty::MethodOrigin::Trait(Some(impl_def_id)) => {
-
-                        let name = match tcx.map.expect_expr(id).node {
-                            ast::ExprMethodCall(ref sp_ident, _, _) => sp_ident.node,
-                            _ => tcx.sess.span_bug(
-                                tcx.map.span(id),
-                                "non-method call expr behaving like a method call?")
-                        };
-                        // It matches if it comes from the same impl,
-                        // and has the same method name.
-                        return ast_util::is_local(impl_def_id)
-                            && impl_def_id.node == impl_id
-                            && method_name.name == name.name
+                        // There's no way to know if this call is
+                        // recursive, so we assume it's not.
+                        _ => return false
                     }
                 }
-            };
-
-            ast_util::is_local(did) && did.node == method_id
+            }
         }
     }
 }

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -852,7 +852,7 @@ impl<'a, 'tcx> PrivacyVisitor<'a, 'tcx> {
             }
             // Trait methods are always all public. The only controlling factor
             // is whether the trait itself is accessible or not.
-            ty::MethodOrigin::Trait(_) | ty::MethodOrigin::Object(_) => {
+            ty::MethodOrigin::Trait | ty::MethodOrigin::Object(_) => {
                 let method = self.tcx.impl_or_trait_item(callee.def_id);
                 self.report_error(self.ensure_public(span, method.container().id(),
                                                      None, "source trait"));

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -854,7 +854,6 @@ impl<'a, 'tcx> PrivacyVisitor<'a, 'tcx> {
             MethodStatic(method_id) => {
                 self.check_static_method(span, method_id, name)
             }
-            MethodStaticClosure(_) => {}
             // Trait methods are always all public. The only controlling factor
             // is whether the trait itself is accessible or not.
             MethodTypeParam(MethodParam { ref trait_ref, .. }) |

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -852,7 +852,7 @@ impl<'a, 'tcx> PrivacyVisitor<'a, 'tcx> {
             }
             // Trait methods are always all public. The only controlling factor
             // is whether the trait itself is accessible or not.
-            ty::MethodOrigin::Trait | ty::MethodOrigin::Object(_) => {
+            ty::MethodOrigin::Trait => {
                 let method = self.tcx.impl_or_trait_item(callee.def_id);
                 self.report_error(self.ensure_public(span, method.container().id(),
                                                      None, "source trait"));

--- a/src/librustc_trans/save/dump_csv.rs
+++ b/src/librustc_trans/save/dump_csv.rs
@@ -889,8 +889,7 @@ impl <'l, 'tcx> DumpCsvVisitor<'l, 'tcx> {
         let method_map = &self.tcx.tables.borrow().method_map;
         let method_callee = method_map.get(&ty::MethodCall::expr(ex.id)).unwrap();
         let (def_id, decl_id) = match method_callee.origin {
-            ty::MethodStatic(def_id) |
-            ty::MethodStaticClosure(def_id) => {
+            ty::MethodStatic(def_id) => {
                 // method invoked on an object with a concrete type (not a static method)
                 let decl_id =
                     match self.tcx.trait_item_of_item(def_id) {
@@ -907,7 +906,7 @@ impl <'l, 'tcx> DumpCsvVisitor<'l, 'tcx> {
                     _ => self.sess
                              .span_bug(ex.span,
                                        "save::process_method_call: non-method \
-                                        DefId in MethodStatic or MethodStaticClosure"),
+                                        DefId in MethodStatic"),
                 };
                 (Some(def_id), decl_id)
             }

--- a/src/librustc_trans/save/dump_csv.rs
+++ b/src/librustc_trans/save/dump_csv.rs
@@ -892,8 +892,7 @@ impl <'l, 'tcx> DumpCsvVisitor<'l, 'tcx> {
             ty::MethodOrigin::Inherent => {
                 (Some(method_callee.def_id), None)
             }
-            ty::MethodOrigin::Trait(_) |
-            ty::MethodOrigin::Object(_) => {
+            ty::MethodOrigin::Trait | ty::MethodOrigin::Object(_) => {
                 (None, Some(method_callee.def_id))
             }
         };

--- a/src/librustc_trans/save/dump_csv.rs
+++ b/src/librustc_trans/save/dump_csv.rs
@@ -892,7 +892,7 @@ impl <'l, 'tcx> DumpCsvVisitor<'l, 'tcx> {
             ty::MethodOrigin::Inherent => {
                 (Some(method_callee.def_id), None)
             }
-            ty::MethodOrigin::Trait | ty::MethodOrigin::Object(_) => {
+            ty::MethodOrigin::Trait => {
                 (None, Some(method_callee.def_id))
             }
         };

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -612,7 +612,7 @@ pub fn trans_method_call<'a, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let method_call = MethodCall::expr(call_expr.id);
     let method_ty = match bcx.tcx().tables.borrow().method_map.get(&method_call) {
         Some(method) => match method.origin {
-            ty::MethodTraitObject(_) => match method.ty.sty {
+            ty::MethodOrigin::Object(_) => match method.ty.sty {
                 ty::TyBareFn(_, ref fty) => {
                     bcx.tcx().mk_fn(None, meth::opaque_method_ty(bcx.tcx(), fty))
                 }

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -499,7 +499,7 @@ pub fn trans_fn_ref_with_substs<'a, 'tcx>(
             let ref_ty = match node {
                 ExprId(id) => tcx.node_id_to_type(id),
                 MethodCallKey(method_call) => {
-                    tcx.tables.borrow().method_map.get(&method_call).unwrap().ty
+                    tcx.tables.borrow().method_map[&method_call].ty
                 }
             };
             let ref_ty = monomorphize::apply_param_substs(tcx,

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -22,7 +22,6 @@ use arena::TypedArena;
 use back::link;
 use session;
 use llvm::{self, ValueRef, get_params};
-use metadata::csearch;
 use middle::def;
 use middle::subst;
 use middle::subst::{Subst, Substs};
@@ -66,7 +65,7 @@ pub struct MethodData {
 pub enum CalleeData<'tcx> {
     // Constructor for enum variant/tuple-like-struct
     // i.e. Some, Ok
-    NamedTupleConstructor(subst::Substs<'tcx>, ty::Disr),
+    NamedTupleConstructor(ty::Disr),
 
     // Represents a (possibly monomorphized) top-level fn item or method
     // item. Note that this is just the fn-ptr and is not a Rust closure
@@ -81,6 +80,7 @@ pub enum CalleeData<'tcx> {
 pub struct Callee<'blk, 'tcx: 'blk> {
     pub bcx: Block<'blk, 'tcx>,
     pub data: CalleeData<'tcx>,
+    pub ty: Ty<'tcx>
 }
 
 fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
@@ -104,11 +104,11 @@ fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
         let DatumBlock { bcx, datum, .. } = expr::trans(bcx, expr);
         match datum.ty.sty {
             ty::TyBareFn(..) => {
-                let llval = datum.to_llscalarish(bcx);
-                return Callee {
+                Callee {
                     bcx: bcx,
-                    data: Fn(llval),
-                };
+                    ty: datum.ty,
+                    data: Fn(datum.to_llscalarish(bcx))
+                }
             }
             _ => {
                 bcx.tcx().sess.span_bug(
@@ -119,12 +119,13 @@ fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
         }
     }
 
-    fn fn_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, llfn: ValueRef)
+    fn fn_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, datum: Datum<'tcx, Rvalue>)
                              -> Callee<'blk, 'tcx> {
-        return Callee {
+        Callee {
             bcx: bcx,
-            data: Fn(llfn),
-        };
+            data: Fn(datum.val),
+            ty: datum.ty
+        }
     }
 
     fn trans_def<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
@@ -143,12 +144,10 @@ fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
                     _ => false
                 }
             } => {
-                let substs = common::node_id_substs(bcx.ccx(),
-                                                    ExprId(ref_expr.id),
-                                                    bcx.fcx.param_substs);
                 Callee {
                     bcx: bcx,
-                    data: NamedTupleConstructor(substs, 0)
+                    data: NamedTupleConstructor(0),
+                    ty: expr_ty
                 }
             }
             def::DefFn(did, _) if match expr_ty.sty {
@@ -159,40 +158,36 @@ fn trans<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, expr: &ast::Expr)
                                                     ExprId(ref_expr.id),
                                                     bcx.fcx.param_substs);
                 let def_id = inline::maybe_instantiate_inline(bcx.ccx(), did);
-                Callee { bcx: bcx, data: Intrinsic(def_id.node, substs) }
+                Callee { bcx: bcx, data: Intrinsic(def_id.node, substs), ty: expr_ty }
             }
             def::DefFn(did, _) | def::DefMethod(did, def::FromImpl(_)) => {
                 fn_callee(bcx, trans_fn_ref(bcx.ccx(), did, ExprId(ref_expr.id),
-                                            bcx.fcx.param_substs).val)
+                                            bcx.fcx.param_substs))
             }
             def::DefMethod(meth_did, def::FromTrait(trait_did)) => {
                 fn_callee(bcx, meth::trans_static_method_callee(bcx.ccx(),
                                                                 meth_did,
                                                                 trait_did,
                                                                 ref_expr.id,
-                                                                bcx.fcx.param_substs).val)
+                                                                bcx.fcx.param_substs))
             }
             def::DefVariant(tid, vid, _) => {
                 let vinfo = bcx.tcx().enum_variant_with_id(tid, vid);
-                let substs = common::node_id_substs(bcx.ccx(),
-                                                    ExprId(ref_expr.id),
-                                                    bcx.fcx.param_substs);
 
                 // Nullary variants are not callable
                 assert!(!vinfo.args.is_empty());
 
                 Callee {
                     bcx: bcx,
-                    data: NamedTupleConstructor(substs, vinfo.disr_val)
+                    data: NamedTupleConstructor(vinfo.disr_val),
+                    ty: expr_ty
                 }
             }
             def::DefStruct(_) => {
-                let substs = common::node_id_substs(bcx.ccx(),
-                                                    ExprId(ref_expr.id),
-                                                    bcx.fcx.param_substs);
                 Callee {
                     bcx: bcx,
-                    data: NamedTupleConstructor(substs, 0)
+                    data: NamedTupleConstructor(0),
+                    ty: expr_ty
                 }
             }
             def::DefStatic(..) |
@@ -230,21 +225,6 @@ pub fn trans_fn_ref<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
            node,
            substs);
     trans_fn_ref_with_substs(ccx, def_id, node, param_substs, substs)
-}
-
-fn trans_fn_ref_with_substs_to_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
-                                                  def_id: ast::DefId,
-                                                  ref_id: ast::NodeId,
-                                                  substs: subst::Substs<'tcx>)
-                                                  -> Callee<'blk, 'tcx> {
-    Callee {
-        bcx: bcx,
-        data: Fn(trans_fn_ref_with_substs(bcx.ccx(),
-                                          def_id,
-                                          ExprId(ref_id),
-                                          bcx.fcx.param_substs,
-                                          substs).val),
-    }
 }
 
 /// Translates an adapter that implements the `Fn` trait for a fn
@@ -356,12 +336,13 @@ pub fn trans_fn_pointer_shim<'a, 'tcx>(
         expr::SaveIn(fcx.get_ret_slot(bcx, sig.output, "ret_slot"))
     );
 
-    bcx = trans_call_inner(bcx,
-                           DebugLoc::None,
-                           bare_fn_ty,
-                           |bcx, _| Callee { bcx: bcx, data: Fn(llfnpointer) },
-                           ArgVals(&llargs[(self_idx + 1)..]),
-                           dest).bcx;
+    bcx = trans_call_inner(bcx, DebugLoc::None, |bcx, _| {
+        Callee {
+            bcx: bcx,
+            data: Fn(llfnpointer),
+            ty: bare_fn_ty
+        }
+    }, ArgVals(&llargs[(self_idx + 1)..]), dest).bcx;
 
     finish_fn(&fcx, bcx, sig.output, DebugLoc::None);
 
@@ -586,17 +567,16 @@ pub fn trans_fn_ref_with_substs<'a, 'tcx>(
 // ______________________________________________________________________
 // Translating calls
 
-pub fn trans_call<'a, 'blk, 'tcx>(in_cx: Block<'blk, 'tcx>,
+pub fn trans_call<'a, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                   call_expr: &ast::Expr,
                                   f: &ast::Expr,
                                   args: CallArgs<'a, 'tcx>,
                                   dest: expr::Dest)
                                   -> Block<'blk, 'tcx> {
     let _icx = push_ctxt("trans_call");
-    trans_call_inner(in_cx,
+    trans_call_inner(bcx,
                      call_expr.debug_loc(),
-                     common::expr_ty_adjusted(in_cx, f),
-                     |cx, _| trans(cx, f),
+                     |bcx, _| trans(bcx, f),
                      args,
                      Some(dest)).bcx
 }
@@ -610,22 +590,9 @@ pub fn trans_method_call<'a, 'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     let _icx = push_ctxt("trans_method_call");
     debug!("trans_method_call(call_expr={:?})", call_expr);
     let method_call = MethodCall::expr(call_expr.id);
-    let method_ty = match bcx.tcx().tables.borrow().method_map.get(&method_call) {
-        Some(method) => match method.origin {
-            ty::MethodOrigin::Object(_) => match method.ty.sty {
-                ty::TyBareFn(_, ref fty) => {
-                    bcx.tcx().mk_fn(None, meth::opaque_method_ty(bcx.tcx(), fty))
-                }
-                _ => method.ty
-            },
-            _ => method.ty
-        },
-        None => panic!("method not found in trans_method_call")
-    };
     trans_call_inner(
         bcx,
         call_expr.debug_loc(),
-        common::monomorphize_type(bcx, method_ty),
         |cx, arg_cleanup_scope| {
             meth::trans_method_callee(cx, method_call, Some(rcvr), arg_cleanup_scope)
         },
@@ -639,22 +606,18 @@ pub fn trans_lang_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                    dest: Option<expr::Dest>,
                                    debug_loc: DebugLoc)
                                    -> Result<'blk, 'tcx> {
-    let fty = if did.krate == ast::LOCAL_CRATE {
-        bcx.tcx().node_id_to_type(did.node)
-    } else {
-        csearch::get_type(bcx.tcx(), did).ty
-    };
-    callee::trans_call_inner(bcx,
-                             debug_loc,
-                             fty,
-                             |bcx, _| {
-                                trans_fn_ref_with_substs_to_callee(bcx,
-                                                                   did,
-                                                                   0,
-                                                                   subst::Substs::trans_empty())
-                             },
-                             ArgVals(args),
-                             dest)
+    callee::trans_call_inner(bcx, debug_loc, |bcx, _| {
+        let datum = trans_fn_ref_with_substs(bcx.ccx(),
+                                             did,
+                                             ExprId(0),
+                                             bcx.fcx.param_substs,
+                                             subst::Substs::trans_empty());
+        Callee {
+            bcx: bcx,
+            data: Fn(datum.val),
+            ty: datum.ty
+        }
+    }, ArgVals(args), dest)
 }
 
 /// This behemoth of a function translates function calls. Unfortunately, in order to generate more
@@ -669,7 +632,6 @@ pub fn trans_lang_call<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 /// somewhere. Nonetheless we return the actual return value of the function.
 pub fn trans_call_inner<'a, 'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
                                            debug_loc: DebugLoc,
-                                           callee_ty: Ty<'tcx>,
                                            get_callee: F,
                                            args: CallArgs<'a, 'tcx>,
                                            dest: Option<expr::Dest>)
@@ -690,7 +652,7 @@ pub fn trans_call_inner<'a, 'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
     let callee = get_callee(bcx, cleanup::CustomScope(arg_cleanup_scope));
     let mut bcx = callee.bcx;
 
-    let (abi, ret_ty) = match callee_ty.sty {
+    let (abi, ret_ty) = match callee.ty.sty {
         ty::TyBareFn(_, ref f) => {
             let output = bcx.tcx().erase_late_bound_regions(&f.sig.output());
             (f.abi, output)
@@ -716,18 +678,17 @@ pub fn trans_call_inner<'a, 'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
                 }
             };
 
-            return intrinsic::trans_intrinsic_call(bcx, node, callee_ty,
+            return intrinsic::trans_intrinsic_call(bcx, node, callee.ty,
                                                    arg_cleanup_scope, args,
                                                    dest.unwrap(), substs,
                                                    call_info);
         }
-        NamedTupleConstructor(substs, disr) => {
+        NamedTupleConstructor(disr) => {
             assert!(dest.is_some());
             fcx.pop_custom_cleanup_scope(arg_cleanup_scope);
 
-            let ctor_ty = callee_ty.subst(bcx.tcx(), &substs);
             return base::trans_named_tuple_constructor(bcx,
-                                                       ctor_ty,
+                                                       callee.ty,
                                                        disr,
                                                        args,
                                                        dest.unwrap(),
@@ -802,7 +763,7 @@ pub fn trans_call_inner<'a, 'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
         // Push the arguments.
         bcx = trans_args(bcx,
                          args,
-                         callee_ty,
+                         callee.ty,
                          &mut llargs,
                          cleanup::CustomScope(arg_cleanup_scope),
                          llself.is_some(),
@@ -814,7 +775,7 @@ pub fn trans_call_inner<'a, 'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
         let (llret, b) = base::invoke(bcx,
                                       llfn,
                                       &llargs[..],
-                                      callee_ty,
+                                      callee.ty,
                                       debug_loc);
         bcx = b;
         llresult = llret;
@@ -843,7 +804,7 @@ pub fn trans_call_inner<'a, 'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
         };
         bcx = trans_args(bcx,
                          args,
-                         callee_ty,
+                         callee.ty,
                          &mut llargs,
                          cleanup::CustomScope(arg_cleanup_scope),
                          false,
@@ -851,7 +812,7 @@ pub fn trans_call_inner<'a, 'blk, 'tcx, F>(bcx: Block<'blk, 'tcx>,
         fcx.scopes.borrow_mut().last_mut().unwrap().drop_non_lifetime_clean();
 
         bcx = foreign::trans_native_call(bcx,
-                                         callee_ty,
+                                         callee.ty,
                                          llfn,
                                          opt_llretslot.unwrap(),
                                          &llargs[..],

--- a/src/librustc_trans/trans/closure.rs
+++ b/src/librustc_trans/trans/closure.rs
@@ -429,12 +429,13 @@ fn trans_fn_once_adapter_shim<'a, 'tcx>(
     let callee_data = TraitItem(MethodData { llfn: llreffn,
                                              llself: env_datum.val });
 
-    bcx = callee::trans_call_inner(bcx,
-                                   DebugLoc::None,
-                                   llref_fn_ty,
-                                   |bcx, _| Callee { bcx: bcx, data: callee_data },
-                                   ArgVals(&llargs[(self_idx + 1)..]),
-                                   dest).bcx;
+    bcx = callee::trans_call_inner(bcx, DebugLoc::None, |bcx, _| {
+        Callee {
+            bcx: bcx,
+            data: callee_data,
+            ty: llref_fn_ty
+        }
+    }, ArgVals(&llargs[(self_idx + 1)..]), dest).bcx;
 
     fcx.pop_custom_cleanup_scope(self_scope);
 

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -874,7 +874,6 @@ pub fn fulfill_obligation<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     debug!("trans fulfill_obligation: trait_ref={:?} def_id={:?}",
            trait_ref, trait_ref.def_id());
 
-    tcx.populate_implementations_for_trait_if_necessary(trait_ref.def_id());
 
     // Do the initial selection for the obligation. This yields the
     // shallow result we are looking for -- that is, what specific impl.

--- a/src/librustc_trans/trans/common.rs
+++ b/src/librustc_trans/trans/common.rs
@@ -1025,7 +1025,7 @@ pub fn node_id_substs<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
             tcx.node_id_item_substs(id).substs
         }
         MethodCallKey(method_call) => {
-            tcx.tables.borrow().method_map.get(&method_call).unwrap().substs.clone()
+            tcx.tables.borrow().method_map[&method_call].substs.clone()
         }
     };
 

--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -894,10 +894,7 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
           ast::ExprMethodCall(_, _, ref args) => {
               let arg_vals = map_list(args);
               let method_call = ty::MethodCall::expr(e.id);
-              let method_did = match cx.tcx().tables.borrow().method_map[&method_call].origin {
-                  ty::MethodStatic(did) => did,
-                  _ => cx.sess().span_bug(e.span, "expected a const method def")
-              };
+              let method_did = cx.tcx().tables.borrow().method_map[&method_call].def_id;
               const_fn_call(cx, MethodCallKey(method_call),
                             method_did, &arg_vals, param_substs)
           }

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -805,7 +805,7 @@ fn trans_index<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                                index_expr,
                                                method_call,
                                                base_datum,
-                                               vec![(ix_datum, idx.id)],
+                                               Some((ix_datum, idx.id)),
                                                Some(SaveIn(scratch.val)),
                                                false));
             let datum = scratch.to_expr_datum();
@@ -1175,21 +1175,21 @@ fn trans_rvalue_dps_unadjusted<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             let lhs = unpack_datum!(bcx, trans(bcx, &**lhs));
             let rhs_datum = unpack_datum!(bcx, trans(bcx, &**rhs));
             trans_overloaded_op(bcx, expr, MethodCall::expr(expr.id), lhs,
-                                vec![(rhs_datum, rhs.id)], Some(dest),
+                                Some((rhs_datum, rhs.id)), Some(dest),
                                 !ast_util::is_by_value_binop(op.node)).bcx
         }
         ast::ExprUnary(op, ref subexpr) => {
             // if not overloaded, would be RvalueDatumExpr
             let arg = unpack_datum!(bcx, trans(bcx, &**subexpr));
             trans_overloaded_op(bcx, expr, MethodCall::expr(expr.id),
-                                arg, Vec::new(), Some(dest), !ast_util::is_by_value_unop(op)).bcx
+                                arg, None, Some(dest), !ast_util::is_by_value_unop(op)).bcx
         }
         ast::ExprIndex(ref base, ref idx) => {
             // if not overloaded, would be RvalueDatumExpr
             let base = unpack_datum!(bcx, trans(bcx, &**base));
             let idx_datum = unpack_datum!(bcx, trans(bcx, &**idx));
             trans_overloaded_op(bcx, expr, MethodCall::expr(expr.id), base,
-                                vec![(idx_datum, idx.id)], Some(dest), true).bcx
+                                Some((idx_datum, idx.id)), Some(dest), true).bcx
         }
         ast::ExprCast(..) => {
             // Trait casts used to come this way, now they should be coercions.
@@ -1943,7 +1943,7 @@ fn trans_overloaded_op<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                    expr: &ast::Expr,
                                    method_call: MethodCall,
                                    lhs: Datum<'tcx, Expr>,
-                                   rhs: Vec<(Datum<'tcx, Expr>, ast::NodeId)>,
+                                   rhs: Option<(Datum<'tcx, Expr>, ast::NodeId)>,
                                    dest: Option<Dest>,
                                    autoref: bool)
                                    -> Result<'blk, 'tcx> {
@@ -2259,7 +2259,7 @@ fn deref_once<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             let scratch = rvalue_scratch_datum(bcx, ref_ty, "overloaded_deref");
 
             unpack_result!(bcx, trans_overloaded_op(bcx, expr, method_call,
-                                                    datum, Vec::new(), Some(SaveIn(scratch.val)),
+                                                    datum, None, Some(SaveIn(scratch.val)),
                                                     false));
             scratch.to_expr_datum()
         }

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -1947,15 +1947,8 @@ fn trans_overloaded_op<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                    dest: Option<Dest>,
                                    autoref: bool)
                                    -> Result<'blk, 'tcx> {
-    let method_ty = bcx.tcx()
-                       .tables
-                       .borrow()
-                       .method_map
-                       .get(&method_call).unwrap().ty;
-
     callee::trans_call_inner(bcx,
                              expr.debug_loc(),
-                             monomorphize_type(bcx, method_ty),
                              |bcx, arg_cleanup_scope| {
                                 meth::trans_method_callee(bcx,
                                                           method_call,
@@ -1974,20 +1967,11 @@ fn trans_overloaded_call<'a, 'blk, 'tcx>(mut bcx: Block<'blk, 'tcx>,
                                          -> Block<'blk, 'tcx> {
     debug!("trans_overloaded_call {}", expr.id);
     let method_call = MethodCall::expr(expr.id);
-    let method_type = bcx.tcx()
-                         .tables
-                         .borrow()
-                         .method_map
-                         .get(&method_call)
-                         .unwrap()
-                         .ty;
     let mut all_args = vec!(callee);
     all_args.extend(args.iter().map(|e| &**e));
     unpack_result!(bcx,
                    callee::trans_call_inner(bcx,
                                             expr.debug_loc(),
-                                            monomorphize_type(bcx,
-                                                              method_type),
                                             |bcx, arg_cleanup_scope| {
                                                 meth::trans_method_callee(
                                                     bcx,

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -39,7 +39,6 @@ use trans::type_of::*;
 use middle::ty::{self, Ty, HasTypeFlags};
 use middle::ty::MethodCall;
 
-use syntax::abi::{Rust, RustCall};
 use syntax::parse::token;
 use syntax::{ast, attr, visit};
 use syntax::codemap::DUMMY_SP;
@@ -119,12 +118,14 @@ pub fn trans_method_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
     match origin {
         ty::MethodOrigin::Inherent => {
             debug!("trans_method_callee: static, {:?}", method_id);
+            let datum = callee::trans_fn_ref(bcx.ccx(),
+                                             method_id,
+                                             MethodCallKey(method_call),
+                                             bcx.fcx.param_substs);
             Callee {
                 bcx: bcx,
-                data: Fn(callee::trans_fn_ref(bcx.ccx(),
-                                              method_id,
-                                              MethodCallKey(method_call),
-                                              bcx.fcx.param_substs).val),
+                data: Fn(datum.val),
+                ty: datum.ty
             }
         }
 
@@ -149,26 +150,27 @@ pub fn trans_method_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             debug!("origin = {:?}", origin);
             trans_monomorphized_callee(bcx,
                                        method_call,
+                                       self_expr,
                                        trait_def_id,
                                        method_id,
-                                       origin)
+                                       method_ty,
+                                       origin,
+                                       arg_cleanup_scope)
         }
+    }
+}
 
-        ty::MethodOrigin::Object(vtable_index) => {
-            let self_expr = match self_expr {
-                Some(self_expr) => self_expr,
-                None => {
-                    bcx.sess().span_bug(bcx.tcx().map.span(method_call.expr_id),
-                                        "self expr wasn't provided for trait object \
-                                         callee (trying to call overloaded op?)")
-                }
-            };
-            trans_trait_callee(bcx,
-                               monomorphize_type(bcx, method_ty),
-                               vtable_index,
-                               self_expr,
-                               arg_cleanup_scope)
-        }
+fn method_offset_in_object_vtable<'tcx>(tcx: &ty::ctxt<'tcx>,
+                                        object_ty: Ty<'tcx>,
+                                        method_id: ast::DefId)
+                                        -> usize {
+    if let ty::TyTrait(ref data) = object_ty.sty {
+        let trait_ref = data.principal_trait_ref_with_self_ty(tcx, object_ty);
+        traits::get_vtable_index_of_object_method(tcx, trait_ref, method_id)
+    } else {
+        tcx.sess.bug(&format!(
+            "trans::methd::object_ty_to_trait_ref() called on non-object: {:?}",
+            object_ty));
     }
 }
 
@@ -237,8 +239,7 @@ pub fn trans_static_method_callee<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                                              Vec::new()));
     let trait_substs = tcx.mk_substs(trait_substs);
     debug!("trait_substs={:?}", trait_substs);
-    let trait_ref = ty::Binder(ty::TraitRef { def_id: trait_id,
-                                              substs: trait_substs });
+    let trait_ref = ty::Binder(ty::TraitRef::new(trait_id, trait_substs));
     let vtbl = fulfill_obligation(ccx,
                                   DUMMY_SP,
                                   trait_ref);
@@ -284,12 +285,11 @@ pub fn trans_static_method_callee<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
                                      callee_substs)
         }
         traits::VtableObject(ref data) => {
-            let (llfn, ty) =
-                trans_object_shim(ccx,
-                                  data.object_ty,
-                                  data.upcast_trait_ref.clone(),
-                                  method_id);
-            immediate_rvalue(llfn, ty)
+            let idx = method_offset_in_object_vtable(tcx, data.object_ty, method_id);
+            trans_object_shim(ccx,
+                              data.upcast_trait_ref.clone(),
+                              method_id,
+                              idx)
         }
         _ => {
             tcx.sess.bug(&format!("static call to invalid vtable: {:?}",
@@ -322,9 +322,12 @@ fn method_with_name(ccx: &CrateContext, impl_id: ast::DefId, name: ast::Name)
 
 fn trans_monomorphized_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                           method_call: MethodCall,
+                                          self_expr: Option<&ast::Expr>,
                                           trait_id: ast::DefId,
                                           method_id: ast::DefId,
-                                          vtable: traits::Vtable<'tcx, ()>)
+                                          method_ty: Ty<'tcx>,
+                                          vtable: traits::Vtable<'tcx, ()>,
+                                          arg_cleanup_scope: cleanup::ScopeId)
                                           -> Callee<'blk, 'tcx> {
     let _icx = push_ctxt("meth::trans_monomorphized_callee");
     match vtable {
@@ -347,13 +350,13 @@ fn trans_monomorphized_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                     bcx, MethodCallKey(method_call), vtable_impl.substs);
 
             // translate the function
-            let llfn = trans_fn_ref_with_substs(bcx.ccx(),
-                                                mth_id,
-                                                MethodCallKey(method_call),
-                                                bcx.fcx.param_substs,
-                                                callee_substs).val;
+            let datum = trans_fn_ref_with_substs(bcx.ccx(),
+                                                 mth_id,
+                                                 MethodCallKey(method_call),
+                                                 bcx.fcx.param_substs,
+                                                 callee_substs);
 
-            Callee { bcx: bcx, data: Fn(llfn) }
+            Callee { bcx: bcx, data: Fn(datum.val), ty: datum.ty }
         }
         traits::VtableClosure(vtable_closure) => {
             // The substitutions should have no type parameters remaining
@@ -368,19 +371,31 @@ fn trans_monomorphized_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             Callee {
                 bcx: bcx,
                 data: Fn(llfn),
+                ty: monomorphize_type(bcx, method_ty)
             }
         }
         traits::VtableFnPointer(fn_ty) => {
             let trait_closure_kind = bcx.tcx().lang_items.fn_trait_kind(trait_id).unwrap();
             let llfn = trans_fn_pointer_shim(bcx.ccx(), trait_closure_kind, fn_ty);
-            Callee { bcx: bcx, data: Fn(llfn) }
+            Callee {
+                bcx: bcx,
+                data: Fn(llfn),
+                ty: monomorphize_type(bcx, method_ty)
+            }
         }
         traits::VtableObject(ref data) => {
-            let (llfn, _) = trans_object_shim(bcx.ccx(),
-                                              data.object_ty,
-                                              data.upcast_trait_ref.clone(),
-                                              method_id);
-            Callee { bcx: bcx, data: Fn(llfn) }
+            let idx = method_offset_in_object_vtable(bcx.tcx(), data.object_ty, method_id);
+            if let Some(self_expr) = self_expr {
+                if let ty::TyBareFn(_, ref fty) = monomorphize_type(bcx, method_ty).sty {
+                    let ty = bcx.tcx().mk_fn(None, opaque_method_ty(bcx.tcx(), fty));
+                    return trans_trait_callee(bcx, ty, idx, self_expr, arg_cleanup_scope);
+                }
+            }
+            let datum = trans_object_shim(bcx.ccx(),
+                                          data.upcast_trait_ref.clone(),
+                                          method_id,
+                                          idx);
+            Callee { bcx: bcx, data: Fn(datum.val), ty: datum.ty }
         }
         traits::VtableBuiltin(..) |
         traits::VtableDefaultImpl(..) |
@@ -434,7 +449,7 @@ fn combine_impl_and_methods_tps<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 /// object. Objects are represented as a pair, so we first evaluate the self expression and then
 /// extract the self data and vtable out of the pair.
 fn trans_trait_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
-                                  method_ty: Ty<'tcx>,
+                                  opaque_fn_ty: Ty<'tcx>,
                                   vtable_index: usize,
                                   self_expr: &ast::Expr,
                                   arg_cleanup_scope: cleanup::ScopeId)
@@ -467,51 +482,39 @@ fn trans_trait_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
     let llself = Load(bcx, GEPi(bcx, llval, &[0, abi::FAT_PTR_ADDR]));
     let llvtable = Load(bcx, GEPi(bcx, llval, &[0, abi::FAT_PTR_EXTRA]));
-    trans_trait_callee_from_llval(bcx, method_ty, vtable_index, llself, llvtable)
+    trans_trait_callee_from_llval(bcx, opaque_fn_ty, vtable_index, llself, llvtable)
 }
 
 /// Same as `trans_trait_callee()` above, except that it is given a by-ref pointer to the object
 /// pair.
-pub fn trans_trait_callee_from_llval<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
-                                                 callee_ty: Ty<'tcx>,
-                                                 vtable_index: usize,
-                                                 llself: ValueRef,
-                                                 llvtable: ValueRef)
-                                                 -> Callee<'blk, 'tcx> {
+fn trans_trait_callee_from_llval<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
+                                             opaque_fn_ty: Ty<'tcx>,
+                                             vtable_index: usize,
+                                             llself: ValueRef,
+                                             llvtable: ValueRef)
+                                             -> Callee<'blk, 'tcx> {
     let _icx = push_ctxt("meth::trans_trait_callee");
     let ccx = bcx.ccx();
 
     // Load the data pointer from the object.
     debug!("trans_trait_callee_from_llval(callee_ty={}, vtable_index={}, llself={}, llvtable={})",
-           callee_ty,
+           opaque_fn_ty,
            vtable_index,
            bcx.val_to_string(llself),
            bcx.val_to_string(llvtable));
 
     // Replace the self type (&Self or Box<Self>) with an opaque pointer.
-    let llcallee_ty = match callee_ty.sty {
-        ty::TyBareFn(_, ref f) if f.abi == Rust || f.abi == RustCall => {
-            let fake_sig =
-                ty::Binder(ty::FnSig {
-                    inputs: f.sig.0.inputs[1..].to_vec(),
-                    output: f.sig.0.output,
-                    variadic: f.sig.0.variadic,
-                });
-            type_of_rust_fn(ccx, Some(Type::i8p(ccx)), &fake_sig, f.abi)
-        }
-        _ => {
-            ccx.sess().bug("meth::trans_trait_callee given non-bare-rust-fn");
-        }
-    };
     let mptr = Load(bcx, GEPi(bcx, llvtable, &[vtable_index + VTABLE_OFFSET]));
+    let llcallee_ty = type_of_fn_from_ty(ccx, opaque_fn_ty);
 
-    return Callee {
+    Callee {
         bcx: bcx,
         data: TraitItem(MethodData {
             llfn: PointerCast(bcx, mptr, llcallee_ty.ptr_to()),
             llself: PointerCast(bcx, llself, Type::i8p(ccx)),
-        })
-    };
+        }),
+        ty: opaque_fn_ty
+    }
 }
 
 /// Generate a shim function that allows an object type like `SomeTrait` to
@@ -538,29 +541,17 @@ pub fn trans_trait_callee_from_llval<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 /// that go through this shim function.
 fn trans_object_shim<'a, 'tcx>(
     ccx: &'a CrateContext<'a, 'tcx>,
-    object_ty: Ty<'tcx>,
     upcast_trait_ref: ty::PolyTraitRef<'tcx>,
-    method_id: ast::DefId)
-    -> (ValueRef, Ty<'tcx>)
+    method_id: ast::DefId,
+    vtable_index: usize)
+    -> Datum<'tcx, Rvalue>
 {
     let _icx = push_ctxt("trans_object_shim");
     let tcx = ccx.tcx();
 
-    debug!("trans_object_shim(object_ty={:?}, upcast_trait_ref={:?}, method_id={:?})",
-           object_ty,
+    debug!("trans_object_shim(upcast_trait_ref={:?}, method_id={:?})",
            upcast_trait_ref,
            method_id);
-
-    let object_trait_ref =
-        match object_ty.sty {
-            ty::TyTrait(ref data) => {
-                data.principal_trait_ref_with_self_ty(tcx, object_ty)
-            }
-            _ => {
-                tcx.sess.bug(&format!("trans_object_shim() called on non-object: {:?}",
-                                      object_ty));
-            }
-        };
 
     // Upcast to the trait in question and extract out the substitutions.
     let upcast_trait_ref = tcx.erase_late_bound_regions(&upcast_trait_ref);
@@ -617,26 +608,21 @@ fn trans_object_shim<'a, 'tcx>(
         fcx.llretslotptr.get().map(
             |_| expr::SaveIn(fcx.get_ret_slot(bcx, sig.output, "ret_slot")));
 
-    let method_offset_in_vtable =
-        traits::get_vtable_index_of_object_method(bcx.tcx(),
-                                                  object_trait_ref.clone(),
-                                                  method_id);
     debug!("trans_object_shim: method_offset_in_vtable={}",
-           method_offset_in_vtable);
+           vtable_index);
 
     bcx = trans_call_inner(bcx,
                            DebugLoc::None,
-                           method_bare_fn_ty,
                            |bcx, _| trans_trait_callee_from_llval(bcx,
                                                                   method_bare_fn_ty,
-                                                                  method_offset_in_vtable,
+                                                                  vtable_index,
                                                                   llself, llvtable),
                            ArgVals(&llargs[(self_idx + 2)..]),
                            dest).bcx;
 
     finish_fn(&fcx, bcx, sig.output, DebugLoc::None);
 
-    (llfn, method_bare_fn_ty)
+    immediate_rvalue(llfn, shim_fn_ty)
 }
 
 /// Creates a returns a dynamic vtable for the given type and vtable origin.
@@ -819,8 +805,8 @@ fn emit_vtable_methods<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
 }
 
 /// Replace the self type (&Self or Box<Self>) with an opaque pointer.
-pub fn opaque_method_ty<'tcx>(tcx: &ty::ctxt<'tcx>, method_ty: &ty::BareFnTy<'tcx>)
-        -> &'tcx ty::BareFnTy<'tcx> {
+fn opaque_method_ty<'tcx>(tcx: &ty::ctxt<'tcx>, method_ty: &ty::BareFnTy<'tcx>)
+                          -> &'tcx ty::BareFnTy<'tcx> {
     let mut inputs = method_ty.sig.0.inputs.clone();
     inputs[0] = tcx.mk_mut_ptr(tcx.mk_mach_int(ast::TyI8));
 

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -117,8 +117,7 @@ pub fn trans_method_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
            .unwrap();
 
     match origin {
-        ty::MethodStatic(did) |
-        ty::MethodStaticClosure(did) => {
+        ty::MethodStatic(did) => {
             debug!("trans_method_callee: static, {:?}", did);
             Callee {
                 bcx: bcx,

--- a/src/librustc_trans/trans/meth.rs
+++ b/src/librustc_trans/trans/meth.rs
@@ -128,7 +128,7 @@ pub fn trans_method_callee<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
             }
         }
 
-        ty::MethodOrigin::Trait(_) => {
+        ty::MethodOrigin::Trait => {
             let method_item = bcx.tcx().impl_or_trait_item(method_id);
             let trait_def_id = method_item.container().id();
 

--- a/src/librustc_trans/trans/monomorphize.rs
+++ b/src/librustc_trans/trans/monomorphize.rs
@@ -59,7 +59,8 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
     let item_ty = ccx.tcx().lookup_item_type(fn_id).ty;
 
     debug!("monomorphic_fn about to subst into {:?}", item_ty);
-    let mono_ty = item_ty.subst(ccx.tcx(), psubsts);
+    let mono_ty = apply_param_substs(ccx.tcx(), psubsts, &item_ty);
+    debug!("mono_ty = {:?} (post-substitution)", mono_ty);
 
     match ccx.monomorphized().borrow().get(&hash_id) {
         Some(&val) => {
@@ -95,11 +96,6 @@ pub fn monomorphic_fn<'a, 'tcx>(ccx: &CrateContext<'a, 'tcx>,
             return (get_item_val(ccx, fn_id.node), mono_ty, true);
         }
     }
-
-    debug!("mono_ty = {:?} (post-substitution)", mono_ty);
-
-    let mono_ty = normalize_associated_type(ccx.tcx(), &mono_ty);
-    debug!("mono_ty = {:?} (post-normalization)", mono_ty);
 
     ccx.stats().n_monos.set(ccx.stats().n_monos.get() + 1);
 

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -15,8 +15,6 @@ use check::UnresolvedTypeAction;
 use middle::subst::{self};
 use middle::traits;
 use middle::ty::{self, Ty};
-use middle::ty::{MethodCall, MethodCallee, MethodObject, MethodOrigin,
-                 MethodParam, MethodStatic, MethodTraitObject, MethodTypeParam};
 use middle::ty_fold::TypeFoldable;
 use middle::infer;
 use middle::infer::InferCtxt;
@@ -52,7 +50,7 @@ pub fn confirm<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                          unadjusted_self_ty: Ty<'tcx>,
                          pick: probe::Pick<'tcx>,
                          supplied_method_types: Vec<Ty<'tcx>>)
-                         -> MethodCallee<'tcx>
+                         -> ty::MethodCallee<'tcx>
 {
     debug!("confirm(unadjusted_self_ty={:?}, pick={:?}, supplied_method_types={:?})",
            unadjusted_self_ty,
@@ -77,7 +75,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
                unadjusted_self_ty: Ty<'tcx>,
                pick: probe::Pick<'tcx>,
                supplied_method_types: Vec<Ty<'tcx>>)
-               -> MethodCallee<'tcx>
+               -> ty::MethodCallee<'tcx>
     {
         // Adjust the self expression the user provided and obtain the adjusted type.
         let self_ty = self.adjust_self_ty(unadjusted_self_ty, &pick);
@@ -112,10 +110,11 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
             unsafety: method_ty.fty.unsafety,
             abi: method_ty.fty.abi.clone(),
         }));
-        let callee = MethodCallee {
+        let callee = ty::MethodCallee {
+            def_id: pick.item.def_id(),
             origin: method_origin,
             ty: fty,
-            substs: all_substs
+            substs: self.tcx().mk_substs(all_substs)
         };
 
         // If this is an `&mut self` method, bias the receiver
@@ -194,18 +193,20 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
     fn fresh_receiver_substs(&mut self,
                              self_ty: Ty<'tcx>,
                              pick: &probe::Pick<'tcx>)
-                             -> (subst::Substs<'tcx>, MethodOrigin<'tcx>)
+                             -> (subst::Substs<'tcx>, ty::MethodOrigin)
     {
         match pick.kind {
-            probe::InherentImplPick(impl_def_id) => {
+            probe::InherentImplPick => {
+                let impl_def_id = pick.item.container().id();
                 assert!(self.tcx().impl_trait_ref(impl_def_id).is_none(),
                         "impl {:?} is not an inherent impl", impl_def_id);
                 let impl_polytype = check::impl_self_ty(self.fcx, self.span, impl_def_id);
 
-                (impl_polytype.substs, MethodStatic(pick.item.def_id()))
+                (impl_polytype.substs, ty::MethodOrigin::Inherent)
             }
 
-            probe::ObjectPick(trait_def_id, method_num, vtable_index) => {
+            probe::ObjectPick => {
+                let trait_def_id = pick.item.container().id();
                 self.extract_trait_ref(self_ty, |this, object_ty, data| {
                     // The object data has no entry for the Self
                     // Type. For the purposes of this method call, we
@@ -228,17 +229,16 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
                            upcast_trait_ref,
                            trait_def_id);
                     let substs = upcast_trait_ref.substs.clone();
-                    let origin = MethodTraitObject(MethodObject {
-                        trait_ref: upcast_trait_ref,
-                        object_trait_id: trait_def_id,
-                        method_num: method_num,
-                        vtable_index: vtable_index,
-                    });
-                    (substs, origin)
+
+                    let vtable_index =
+                        traits::get_vtable_index_of_object_method(this.tcx(),
+                                                                  original_poly_trait_ref,
+                                                                  pick.item.def_id());
+                    (substs, ty::MethodOrigin::Object(vtable_index))
                 })
             }
 
-            probe::ExtensionImplPick(impl_def_id, method_num) => {
+            probe::ExtensionImplPick(impl_def_id) => {
                 // The method being invoked is the method as defined on the trait,
                 // so return the substitutions from the trait. Consider:
                 //
@@ -254,13 +254,12 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
                         self.span,
                         &impl_polytype.substs,
                         &self.tcx().impl_trait_ref(impl_def_id).unwrap());
-                let origin = MethodTypeParam(MethodParam { trait_ref: impl_trait_ref.clone(),
-                                                           method_num: method_num,
-                                                           impl_def_id: Some(impl_def_id) });
-                (impl_trait_ref.substs.clone(), origin)
+                let substs = impl_trait_ref.substs.clone();
+                (substs, ty::MethodOrigin::Trait(Some(impl_def_id)))
             }
 
-            probe::TraitPick(trait_def_id, method_num) => {
+            probe::TraitPick => {
+                let trait_def_id = pick.item.container().id();
                 let trait_def = self.tcx().lookup_trait_def(trait_def_id);
 
                 // Make a trait reference `$0 : Trait<$1...$n>`
@@ -272,23 +271,15 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
                                                                  &trait_def.generics,
                                                                  self.infcx().next_ty_var());
 
-                let trait_ref =
-                    ty::TraitRef::new(trait_def_id, self.tcx().mk_substs(substs.clone()));
-                let origin = MethodTypeParam(MethodParam { trait_ref: trait_ref,
-                                                           method_num: method_num,
-                                                           impl_def_id: None });
-                (substs, origin)
+                (substs, ty::MethodOrigin::Trait(None))
             }
 
-            probe::WhereClausePick(ref poly_trait_ref, method_num) => {
+            probe::WhereClausePick(ref poly_trait_ref) => {
                 // Where clauses can have bound regions in them. We need to instantiate
                 // those to convert from a poly-trait-ref to a trait-ref.
                 let trait_ref = self.replace_late_bound_regions_with_fresh_var(&*poly_trait_ref);
                 let substs = trait_ref.substs.clone();
-                let origin = MethodTypeParam(MethodParam { trait_ref: trait_ref,
-                                                           method_num: method_num,
-                                                           impl_def_id: None });
-                (substs, origin)
+                (substs, ty::MethodOrigin::Trait(None))
             }
         }
     }
@@ -450,7 +441,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
     /// auto-derefs, indices, etc from `Deref` and `Index` into `DerefMut` and `IndexMut`
     /// respectively.
     fn fixup_derefs_on_method_receiver_if_necessary(&self,
-                                                    method_callee: &MethodCallee) {
+                                                    method_callee: &ty::MethodCallee) {
         let sig = match method_callee.ty.sty {
             ty::TyBareFn(_, ref f) => f.sig.clone(),
             _ => return,
@@ -570,7 +561,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
 
                         let result = check::try_index_step(
                             self.fcx,
-                            MethodCall::expr(expr.id),
+                            ty::MethodCall::expr(expr.id),
                             expr,
                             &**base_expr,
                             adjusted_base_ty,
@@ -589,7 +580,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
                     ast::ExprUnary(ast::UnDeref, ref base_expr) => {
                         // if this is an overloaded deref, then re-evaluate with
                         // a preference for mut
-                        let method_call = MethodCall::expr(expr.id);
+                        let method_call = ty::MethodCall::expr(expr.id);
                         if self.fcx.inh.tables.borrow().method_map.contains_key(&method_call) {
                             check::try_overloaded_deref(
                                 self.fcx,

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -255,7 +255,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
                         &impl_polytype.substs,
                         &self.tcx().impl_trait_ref(impl_def_id).unwrap());
                 let substs = impl_trait_ref.substs.clone();
-                (substs, ty::MethodOrigin::Trait(Some(impl_def_id)))
+                (substs, ty::MethodOrigin::Trait)
             }
 
             probe::TraitPick => {
@@ -271,7 +271,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
                                                                  &trait_def.generics,
                                                                  self.infcx().next_ty_var());
 
-                (substs, ty::MethodOrigin::Trait(None))
+                (substs, ty::MethodOrigin::Trait)
             }
 
             probe::WhereClausePick(ref poly_trait_ref) => {
@@ -279,7 +279,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
                 // those to convert from a poly-trait-ref to a trait-ref.
                 let trait_ref = self.replace_late_bound_regions_with_fresh_var(&*poly_trait_ref);
                 let substs = trait_ref.substs.clone();
-                (substs, ty::MethodOrigin::Trait(None))
+                (substs, ty::MethodOrigin::Trait)
             }
         }
     }

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -230,11 +230,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
                            trait_def_id);
                     let substs = upcast_trait_ref.substs.clone();
 
-                    let vtable_index =
-                        traits::get_vtable_index_of_object_method(this.tcx(),
-                                                                  original_poly_trait_ref,
-                                                                  pick.item.def_id());
-                    (substs, ty::MethodOrigin::Object(vtable_index))
+                    (substs, ty::MethodOrigin::Trait)
                 })
             }
 

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -307,7 +307,6 @@ pub fn lookup_in_trait_adjusted<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 
     let callee = ty::MethodCallee {
         def_id: method_item.def_id(),
-        origin: ty::MethodOrigin::Trait,
         ty: fty,
         substs: trait_ref.substs
     };

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -74,8 +74,6 @@ pub enum CandidateSource {
     TraitSource(/* trait id */ ast::DefId),
 }
 
-type ItemIndex = usize; // just for doc purposes
-
 /// Determines whether the type `self_ty` supports a method name `method_name` or not.
 pub fn exists<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                         span: Span,
@@ -204,14 +202,13 @@ pub fn lookup_in_trait_adjusted<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     // Trait must have a method named `m_name` and it should not have
     // type parameters or early-bound regions.
     let tcx = fcx.tcx();
-    let (method_num, method_ty) = trait_item(tcx, trait_def_id, m_name)
-            .and_then(|(idx, item)| item.as_opt_method().map(|m| (idx, m)))
-            .unwrap();
+    let method_item = trait_item(tcx, trait_def_id, m_name).unwrap();
+    let method_ty = method_item.as_opt_method().unwrap();
     assert_eq!(method_ty.generics.types.len(subst::FnSpace), 0);
     assert_eq!(method_ty.generics.regions.len(subst::FnSpace), 0);
 
-    debug!("lookup_in_trait_adjusted: method_num={} method_ty={:?}",
-           method_num, method_ty);
+    debug!("lookup_in_trait_adjusted: method_item={:?} method_ty={:?}",
+           method_item, method_ty);
 
     // Instantiate late-bound regions and substitute the trait
     // parameters into the method type to get the actual method type.
@@ -309,11 +306,10 @@ pub fn lookup_in_trait_adjusted<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     }
 
     let callee = ty::MethodCallee {
-        origin: ty::MethodTypeParam(ty::MethodParam{trait_ref: trait_ref.clone(),
-                                                    method_num: method_num,
-                                                    impl_def_id: None}),
+        def_id: method_item.def_id(),
+        origin: ty::MethodOrigin::Trait(None),
         ty: fty,
-        substs: trait_ref.substs.clone()
+        substs: trait_ref.substs
     };
 
     debug!("callee = {:?}", callee);
@@ -332,14 +328,15 @@ pub fn resolve_ufcs<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     let pick = try!(probe::probe(fcx, span, mode, method_name, self_ty, expr_id));
     let def_id = pick.item.def_id();
     let mut lp = LastMod(AllPublic);
+    let container_def_id = pick.item.container().id();
     let provenance = match pick.kind {
-        probe::InherentImplPick(impl_def_id) => {
+        probe::InherentImplPick => {
             if pick.item.vis() != ast::Public {
                 lp = LastMod(DependsOn(def_id));
             }
-            def::FromImpl(impl_def_id)
+            def::FromImpl(container_def_id)
         }
-        _ => def::FromTrait(pick.item.container().id())
+        _ => def::FromTrait(container_def_id)
     };
     let def_result = match pick.item {
         ty::ImplOrTraitItem::MethodTraitItem(..) => def::DefMethod(def_id, provenance),
@@ -352,19 +349,17 @@ pub fn resolve_ufcs<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 }
 
 
-/// Find item with name `item_name` defined in `trait_def_id` and return it, along with its
-/// index (or `None`, if no such item).
+/// Find item with name `item_name` defined in `trait_def_id`
+/// and return it, or `None`, if no such item.
 fn trait_item<'tcx>(tcx: &ty::ctxt<'tcx>,
                     trait_def_id: ast::DefId,
                     item_name: ast::Name)
-                    -> Option<(usize, ty::ImplOrTraitItem<'tcx>)>
+                    -> Option<ty::ImplOrTraitItem<'tcx>>
 {
     let trait_items = tcx.trait_items(trait_def_id);
-    trait_items
-        .iter()
-        .enumerate()
-        .find(|&(_, ref item)| item.name() == item_name)
-        .map(|(num, item)| (num, (*item).clone()))
+    trait_items.iter()
+               .find(|item| item.name() == item_name)
+               .cloned()
 }
 
 fn impl_item<'tcx>(tcx: &ty::ctxt<'tcx>,

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -307,7 +307,7 @@ pub fn lookup_in_trait_adjusted<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
 
     let callee = ty::MethodCallee {
         def_id: method_item.def_id(),
-        origin: ty::MethodOrigin::Trait(None),
+        origin: ty::MethodOrigin::Trait,
         ty: fty,
         substs: trait_ref.substs
     };

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -203,7 +203,7 @@ pub fn report_error<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                                impl_ty);
                 }
                 CandidateSource::TraitSource(trait_did) => {
-                    let (_, item) = trait_item(fcx.tcx(), trait_did, item_name).unwrap();
+                    let item = trait_item(fcx.tcx(), trait_did, item_name).unwrap();
                     let item_span = fcx.tcx().map.def_id_span(item.def_id(), span);
                     span_note!(fcx.sess(), item_span,
                                "candidate #{} is defined in the trait `{}`",

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -303,7 +303,6 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                        method);
                 let new_method = MethodCallee {
                     def_id: method.def_id,
-                    origin: method.origin,
                     ty: self.resolve(&method.ty, reason),
                     substs: self.tcx().mk_substs(self.resolve(method.substs, reason)),
                 };

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -302,9 +302,10 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                        method_call,
                        method);
                 let new_method = MethodCallee {
-                    origin: self.resolve(&method.origin, reason),
+                    def_id: method.def_id,
+                    origin: method.origin,
                     ty: self.resolve(&method.ty, reason),
-                    substs: self.resolve(&method.substs, reason),
+                    substs: self.tcx().mk_substs(self.resolve(method.substs, reason)),
                 };
 
                 Some(new_method)

--- a/src/test/run-pass/traits-issue-26339.rs
+++ b/src/test/run-pass/traits-issue-26339.rs
@@ -1,0 +1,40 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that the right implementation is called through a trait
+// object when supertraits include multiple references to the
+// same trait, with different type parameters.
+
+trait A: PartialEq<Foo> + PartialEq<Bar> { }
+
+struct Foo;
+struct Bar;
+
+struct Aimpl;
+
+impl PartialEq<Foo> for Aimpl {
+    fn eq(&self, _rhs: &Foo) -> bool {
+        true
+    }
+}
+
+impl PartialEq<Bar> for Aimpl {
+    fn eq(&self, _rhs: &Bar) -> bool {
+        false
+    }
+}
+
+impl A for Aimpl { }
+
+fn main() {
+    let a = &Aimpl as &A;
+
+    assert!(*a == Foo);
+}


### PR DESCRIPTION
`MethodCallee` now has no information about the method, other than its `DefId`.
The previous bits of information can be recovered as follows:

``` rust
let method_item = tcx.impl_or_trait_item(callee.def_id);
let container = method_item.container();
```

The method is inherent if `container` is a `ty::ImplContainer`:
- the `impl` the method comes from is `container.id()`

The method is a trait method if `container` is a `ty::TraitContainer`:
- the `trait` the method is part of is `container.id()`
- a `ty::TraitRef` can be constructed by putting together:
  - `container.id()` as the `trait` ID
  - `callee.substs.clone().method_to_trait()` as the `trait` substs (including `Self`)
- the above `trait_ref` is a valid `T: Trait<A, B, C>` predicate
- selecting `trait_ref` could result in one of the following:
  - `traits::VtableImpl(data)`: static dispatch to `data.impl_def_id`
  - `traits::VtableObject(data)`: dynamic dispatch, with the vtable index:
    `traits::get_vtable_index_of_object_method(tcx, data, callee.def_id)`
  - other variants of `traits::Vtable`: various other `impl` sources
