### PR TITLE
Hide SampleRange trait from docs

### DIFF
--- a/src/librand/distributions/range.rs
+++ b/src/librand/distributions/range.rs
@@ -58,6 +58,7 @@ impl<Sup: SampleRange> IndependentSample<Sup> for Range<Sup> {
 /// The helper trait for types that have a sensible way to sample
 /// uniformly between two values. This should not be used directly,
 /// and is only to facilitate `Range`.
+#[doc(hidden)]
 pub trait SampleRange {
     /// Construct the `Range` object that `sample_range`
     /// requires. This should not ever be called directly, only via


### PR DESCRIPTION
A follow up to #26530, hide SampleRange too. The numerical types implement this trait.
