### PR TITLE
Add a regression test for #8640.

### DIFF
--- a/src/test/compile-fail/issue-8640.rs
+++ b/src/test/compile-fail/issue-8640.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[allow(unused_imports)]
+
+mod foo {
+    use baz::bar;
+    //~^ ERROR import `bar` conflicts with existing submodule
+    mod bar {}
+}
+mod baz { pub mod bar {} }
+
+fn main() {}


### PR DESCRIPTION
This doesn't add a test for the main problem in #8640 since it seems that
was already fixed (including a test) in PR https://github.com/rust-lang/rust/pull/19522. This just adds a test
for a program mentioned in the comments that used to erroneously compile.

Closes #8640.
