### PR TITLE
Add OsStr::from_bytes()

### DIFF
--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -275,7 +275,7 @@ impl OsStr {
     /// On Windows systems, only UTF-8 byte sequences will successfully
     /// convert; non UTF-8 data will produce `None`.
     #[unstable(feature = "convert", reason = "recently added")]
-    pub fn from_bytes_slice(bytes: &[u8]) -> Option<&OsStr> {
+    pub fn from_bytes_opt(bytes: &[u8]) -> Option<&OsStr> {
         if cfg!(windows) {
             str::from_utf8(bytes).ok().map(|s| s.as_ref())
         } else {

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -41,6 +41,7 @@ use mem;
 use string::String;
 use ops;
 use cmp;
+use str;
 use hash::{Hash, Hasher};
 use vec::Vec;
 
@@ -262,6 +263,23 @@ impl OsStr {
             self.to_str().map(|s| s.as_bytes())
         } else {
             Some(self.bytes())
+        }
+    }
+
+    /// Converts a byte slice to an `OsStr` slice.
+    ///
+    /// # Platform behavior
+    ///
+    /// On Unix systems, this is a no-op.
+    ///
+    /// On Windows systems, only UTF-8 byte sequences will successfully
+    /// convert; non UTF-8 data will produce `None`.
+    #[unstable(feature = "convert", reason = "recently added")]
+    pub fn from_bytes_slice(bytes: &[u8]) -> Option<&OsStr> {
+        if cfg!(windows) {
+            str::from_utf8(bytes).ok().map(|s| s.as_ref())
+        } else {
+            Some(unsafe { mem::transmute(bytes) })
         }
     }
 

--- a/src/test/run-pass/osstr_conversions.rs
+++ b/src/test/run-pass/osstr_conversions.rs
@@ -30,12 +30,12 @@ fn main() {
 
     // Valid UTF-8
     let by1: &[u8] = b"t\xC3\xA9st";
-    let oss1: &OsStr = OsStr::from_bytes_slice(by1).unwrap();
+    let oss1: &OsStr = OsStr::from_bytes_opt(by1).unwrap();
     assert_eq!(oss1.to_bytes().unwrap().as_ptr(), by1.as_ptr());
     assert_eq!(oss1.to_str().unwrap().as_ptr(), by1.as_ptr());
     // Not UTF-8
     let by2: &[u8] = b"t\xE9st";
-    let oss2: &OsStr = OsStr::from_bytes_slice(by2).unwrap();
+    let oss2: &OsStr = OsStr::from_bytes_opt(by2).unwrap();
     if cfg!(windows) {
         assert_eq!(oss2.to_bytes(), None);
     } else {

--- a/src/test/run-pass/osstr_conversions.rs
+++ b/src/test/run-pass/osstr_conversions.rs
@@ -1,0 +1,49 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(convert)]
+
+use std::ffi::{OsStr, OsString};
+
+fn main() {
+    // Valid UTF-8
+    let vec1: Vec<u8> = b"t\xC3\xA9st".to_vec();
+    let oso1: OsString = OsString::from_bytes(vec1).unwrap();
+    assert!(oso1.to_bytes() == Some(b"t\xC3\xA9st"));
+    assert!(oso1.to_str() == Some("t\u{E9}st"));
+    // Not UTF-8
+    let vec2: Vec<u8> = b"t\xE9st".to_vec();
+    let oso2: OsString = OsString::from_bytes(vec2).unwrap();
+    if cfg!(windows) {
+        assert!(oso2.to_bytes() == None);
+    } else {
+        assert!(oso2.to_bytes() == Some(b"t\xE9st"));
+    }
+    assert_eq!(oso2.to_str(), None);
+
+    // Valid UTF-8
+    let by1: &[u8] = b"t\xC3\xA9st";
+    let oss1: &OsStr = OsStr::from_bytes_slice(by1).unwrap();
+    assert_eq!(oss1.to_bytes().unwrap().as_ptr(), by1.as_ptr());
+    assert_eq!(oss1.to_str().unwrap().as_ptr(), by1.as_ptr());
+    // Not UTF-8
+    let by2: &[u8] = b"t\xE9st";
+    let oss2: &OsStr = OsStr::from_bytes_slice(by2).unwrap();
+    if cfg!(windows) {
+        assert_eq!(oss2.to_bytes(), None);
+    } else {
+        assert_eq!(oss2.to_bytes().unwrap().as_ptr(), by2.as_ptr());
+    }
+    assert_eq!(oss2.to_str(), None);
+
+    if cfg!(windows) {
+        // FIXME: needs valid-windows-utf16-invalid-unicode test cases
+    }
+}


### PR DESCRIPTION
`OsString::from_bytes()` turns `Vec<u8>`  into `OsString`. This adds the same thing, from `&[u8]` to `&OsStr`:

``` rust
pub fn OsString::from_bytes(vec: Vec<u8>) -> Option<OsString>
pub fn OsStr::from_bytes(bytes: &[u8]) -> Option<&OsStr>
```

Problem is that `OsStrExt` has a conflicting `from_bytes()` (that always succeeds; unix-only). This PR removes it, which might need an RFC (it was Rust 1.0.0).
`OsStrExt` then only has an always-succeeding `as_bytes()`, which could also be replaced by `to_bytes().unwrap()` without loss of functionality.
