### PR TITLE
Remove OsStrExt

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -31,6 +31,7 @@
 #![feature(box_syntax)]
 #![feature(clone_from_slice)]
 #![feature(collections)]
+#![feature(convert)]
 #![feature(const_fn)]
 #![feature(duration)]
 #![feature(duration_span)]

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -232,10 +232,10 @@ pub fn memoized<T, U, S, F>(cache: &RefCell<HashMap<T, U, S>>, arg: T, f: F) -> 
 
 #[cfg(unix)]
 pub fn path2cstr(p: &Path) -> CString {
-    use std::os::unix::prelude::*;
     use std::ffi::OsStr;
     let p: &OsStr = p.as_ref();
-    CString::new(p.as_bytes()).unwrap()
+    // to_bytes() never returns None on unix
+    CString::new(p.to_bytes().unwrap()).unwrap()
 }
 #[cfg(windows)]
 pub fn path2cstr(p: &Path) -> CString {

--- a/src/librustc_llvm/archive_ro.rs
+++ b/src/librustc_llvm/archive_ro.rs
@@ -47,16 +47,10 @@ impl ArchiveRO {
             }
         };
 
-        #[cfg(unix)]
         fn path2cstr(p: &Path) -> CString {
-            use std::os::unix::prelude::*;
             use std::ffi::OsStr;
             let p: &OsStr = p.as_ref();
-            CString::new(p.as_bytes()).unwrap()
-        }
-        #[cfg(windows)]
-        fn path2cstr(p: &Path) -> CString {
-            CString::new(p.to_str().unwrap()).unwrap()
+            CString::new(p.to_bytes().unwrap()).unwrap()
         }
     }
 

--- a/src/librustc_llvm/lib.rs
+++ b/src/librustc_llvm/lib.rs
@@ -27,6 +27,7 @@
 
 #![feature(associated_consts)]
 #![feature(box_syntax)]
+#![feature(convert)]
 #![feature(libc)]
 #![feature(link_args)]
 #![feature(staged_api)]

--- a/src/libstd/ffi/os_str.rs
+++ b/src/libstd/ffi/os_str.rs
@@ -41,6 +41,7 @@ use mem;
 use string::String;
 use ops;
 use cmp;
+use str;
 use hash::{Hash, Hasher};
 use vec::Vec;
 
@@ -262,6 +263,23 @@ impl OsStr {
             self.to_str().map(|s| s.as_bytes())
         } else {
             Some(self.bytes())
+        }
+    }
+
+    /// Converts a byte slice to an `OsStr` slice.
+    ///
+    /// # Platform behavior
+    ///
+    /// On Unix systems, this is a no-op.
+    ///
+    /// On Windows systems, only UTF-8 byte sequences will successfully
+    /// convert; non UTF-8 data will produce `None`.
+    #[unstable(feature = "convert", reason = "recently added")]
+    pub fn from_bytes(bytes: &[u8]) -> Option<&OsStr> {
+        if cfg!(windows) {
+            str::from_utf8(bytes).ok().map(|s| s.as_ref())
+        } else {
+            Some(unsafe { mem::transmute(bytes) })
         }
     }
 

--- a/src/libstd/sys/unix/backtrace.rs
+++ b/src/libstd/sys/unix/backtrace.rs
@@ -251,7 +251,6 @@ fn print(w: &mut Write, idx: isize, addr: *mut libc::c_void,
 fn print(w: &mut Write, idx: isize, addr: *mut libc::c_void,
          symaddr: *mut libc::c_void) -> io::Result<()> {
     use env;
-    use os::unix::prelude::*;
     use ptr;
 
     ////////////////////////////////////////////////////////////////////////
@@ -370,7 +369,8 @@ fn print(w: &mut Write, idx: isize, addr: *mut libc::c_void,
         };
         let filename = match selfname {
             Some(path) => {
-                let bytes = path.as_os_str().as_bytes();
+                // to_bytes() never returns None on unix
+                let bytes = path.as_os_str().to_bytes().unwrap();
                 if bytes.len() < LAST_FILENAME.len() {
                     let i = bytes.iter();
                     for (slot, val) in LAST_FILENAME.iter_mut().zip(i) {

--- a/src/libstd/sys/unix/ext/ffi.rs
+++ b/src/libstd/sys/unix/ext/ffi.rs
@@ -13,7 +13,6 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use ffi::{OsStr, OsString};
-use mem;
 use prelude::v1::*;
 use sys::os_str::Buf;
 use sys_common::{FromInner, IntoInner, AsInner};
@@ -43,9 +42,6 @@ impl OsStringExt for OsString {
 /// Unix-specific extensions to `OsStr`.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait OsStrExt {
-    #[stable(feature = "rust1", since = "1.0.0")]
-    fn from_bytes(slice: &[u8]) -> &Self;
-
     /// Gets the underlying byte view of the `OsStr` slice.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn as_bytes(&self) -> &[u8];
@@ -53,9 +49,6 @@ pub trait OsStrExt {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl OsStrExt for OsStr {
-    fn from_bytes(slice: &[u8]) -> &OsStr {
-        unsafe { mem::transmute(slice) }
-    }
     fn as_bytes(&self) -> &[u8] {
         &self.as_inner().inner
     }

--- a/src/libstd/sys/unix/ext/ffi.rs
+++ b/src/libstd/sys/unix/ext/ffi.rs
@@ -12,10 +12,10 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use ffi::{OsStr, OsString};
+use ffi::OsString;
 use prelude::v1::*;
 use sys::os_str::Buf;
-use sys_common::{FromInner, IntoInner, AsInner};
+use sys_common::{FromInner, IntoInner};
 
 /// Unix-specific extensions to `OsString`.
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -36,20 +36,5 @@ impl OsStringExt for OsString {
     }
     fn into_vec(self) -> Vec<u8> {
         self.into_inner().inner
-    }
-}
-
-/// Unix-specific extensions to `OsStr`.
-#[stable(feature = "rust1", since = "1.0.0")]
-pub trait OsStrExt {
-    /// Gets the underlying byte view of the `OsStr` slice.
-    #[stable(feature = "rust1", since = "1.0.0")]
-    fn as_bytes(&self) -> &[u8];
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl OsStrExt for OsStr {
-    fn as_bytes(&self) -> &[u8] {
-        &self.as_inner().inner
     }
 }

--- a/src/libstd/sys/unix/ext/mod.rs
+++ b/src/libstd/sys/unix/ext/mod.rs
@@ -43,7 +43,7 @@ pub mod prelude {
     #[doc(no_inline)]
     pub use super::io::{RawFd, AsRawFd, FromRawFd};
     #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
-    pub use super::ffi::{OsStrExt, OsStringExt};
+    pub use super::ffi::OsStringExt;
     #[doc(no_inline)]
     pub use super::fs::{PermissionsExt, OpenOptionsExt, MetadataExt};
     #[doc(no_inline)]

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -166,11 +166,13 @@ impl Drop for Dir {
 
 impl DirEntry {
     pub fn path(&self) -> PathBuf {
-        self.root.join(<OsStr as OsStrExt>::from_bytes(self.name_bytes()))
+        // from_bytes() never returns None on unix
+        self.root.join(OsStr::from_bytes(self.name_bytes()).unwrap())
     }
 
     pub fn file_name(&self) -> OsString {
-        OsStr::from_bytes(self.name_bytes()).to_os_string()
+        // from_bytes() never returns None on unix
+        OsStr::from_bytes(self.name_bytes()).unwrap().to_os_string()
     }
 
     pub fn metadata(&self) -> io::Result<FileAttr> {

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -166,7 +166,7 @@ impl Drop for Dir {
 
 impl DirEntry {
     pub fn path(&self) -> PathBuf {
-        // from_bytes() never returns None on unix
+        // to_bytes() never returns None on unix
         self.root.join(OsStr::from_bytes(self.name_bytes()).unwrap())
     }
 
@@ -506,7 +506,8 @@ pub fn utimes(p: &Path, atime: u64, mtime: u64) -> io::Result<()> {
 }
 
 pub fn canonicalize(p: &Path) -> io::Result<PathBuf> {
-    let path = try!(CString::new(p.as_os_str().as_bytes()));
+    // from_bytes() never returns None on unix
+    let path = try!(CString::new(p.as_os_str().to_bytes().unwrap()));
     let mut buf = vec![0u8; 16 * 1024];
     unsafe {
         let r = c::realpath(path.as_ptr(), buf.as_mut_ptr() as *mut _);

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -39,7 +39,8 @@ fn bytes2path(b: &[u8]) -> PathBuf {
 }
 
 fn os2path(os: OsString) -> PathBuf {
-    bytes2path(os.as_bytes())
+    // to_bytes() never returns None on unix
+    bytes2path(os.to_bytes().unwrap())
 }
 
 /// Returns the platform-specific value of errno
@@ -125,7 +126,8 @@ pub fn getcwd() -> io::Result<PathBuf> {
 
 pub fn chdir(p: &path::Path) -> io::Result<()> {
     let p: &OsStr = p.as_ref();
-    let p = try!(CString::new(p.as_bytes()));
+    // to_bytes() never returns None on unix
+    let p = try!(CString::new(p.to_bytes().unwrap()));
     unsafe {
         match libc::chdir(p.as_ptr()) == (0 as c_int) {
             true => Ok(()),
@@ -141,7 +143,8 @@ pub struct SplitPaths<'a> {
 
 pub fn split_paths<'a>(unparsed: &'a OsStr) -> SplitPaths<'a> {
     fn is_colon(b: &u8) -> bool { *b == b':' }
-    let unparsed = unparsed.as_bytes();
+    // to_bytes() never returns None on unix
+    let unparsed = unparsed.to_bytes().unwrap();
     SplitPaths {
         iter: unparsed.split(is_colon as fn(&u8) -> bool)
                       .map(bytes2path as fn(&'a [u8]) -> PathBuf)
@@ -164,7 +167,8 @@ pub fn join_paths<I, T>(paths: I) -> Result<OsString, JoinPathsError>
     let sep = b':';
 
     for (i, path) in paths.enumerate() {
-        let path = path.as_ref().as_bytes();
+        // to_bytes() never returns None on unix
+        let path = path.as_ref().to_bytes().unwrap();
         if i > 0 { joined.push(sep) }
         if path.contains(&sep) {
             return Err(JoinPathsError)

--- a/src/libstd/sys/unix/os.rs
+++ b/src/libstd/sys/unix/os.rs
@@ -34,7 +34,8 @@ const BUF_BYTES: usize = 2048;
 const TMPBUF_SZ: usize = 128;
 
 fn bytes2path(b: &[u8]) -> PathBuf {
-    PathBuf::from(<OsStr as OsStrExt>::from_bytes(b))
+    // from_bytes() never returns None on unix
+    PathBuf::from(OsStr::from_bytes(b).unwrap())
 }
 
 fn os2path(os: OsString) -> PathBuf {

--- a/src/libstd/sys/unix/process.rs
+++ b/src/libstd/sys/unix/process.rs
@@ -390,9 +390,10 @@ fn make_envp(env: Option<&HashMap<OsString, OsString>>)
 
         for pair in env {
             let mut kv = Vec::new();
-            kv.push_all(pair.0.as_bytes());
+            // to_bytes() never returns None on unix
+            kv.push_all(pair.0.to_bytes().unwrap());
             kv.push('=' as u8);
-            kv.push_all(pair.1.as_bytes());
+            kv.push_all(pair.1.to_bytes().unwrap());
             kv.push(0); // terminating null
             tmps.push(kv);
         }


### PR DESCRIPTION
Mentioned from #26730, this goes further and totally removes `OsStrExt`. I don't know if anyone will consider this but I happen to have written it.

GitHub shows previous PR's commits as well because this is how PRs work; this is actually one commit.
