### PR TITLE
deprecate vecmap

### DIFF
--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -88,6 +88,7 @@ pub use enum_set::EnumSet;
 pub use vec_deque::VecDeque;
 pub use string::String;
 pub use vec::Vec;
+#[allow(deprecated)]
 pub use vec_map::VecMap;
 
 // Needed for the vec! macro
@@ -109,6 +110,7 @@ pub mod str;
 pub mod string;
 pub mod vec;
 pub mod vec_deque;
+#[allow(deprecated)]
 pub mod vec_map;
 
 #[unstable(feature = "bitvec", reason = "RFC 509")]

--- a/src/libcollections/vec_map.rs
+++ b/src/libcollections/vec_map.rs
@@ -11,9 +11,12 @@
 //! A simple map based on a vector for small integer keys. Space requirements
 //! are O(highest integer key).
 
+#![deprecated(reason = "VecMap moved to crates.io as vec_map",
+              since = "1.3.0")]
+#![unstable(feature = "vecmap", reason = "deprecated")]
+#![allow(deprecated)]
+
 #![allow(missing_docs)]
-#![unstable(feature = "vecmap",
-            reason = "may not be stabilized in the standard library")]
 
 use self::Entry::*;
 

--- a/src/libserialize/collection_impls.rs
+++ b/src/libserialize/collection_impls.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// VecMap
+#![allow(deprecated)]
+
 //! Implementations of serialization for structures found in libcollections
 
 use std::usize;


### PR DESCRIPTION
VecMap doesn't really fit with the current standard library's strategy (small!).

I've mirrored the code to https://github.com/contain-rs/vec-map

but @GBGamer has already claimed the name on crates.io a couple months ago for the same purpose. It hasn't been updated since, though.

CC @rust-lang/libs 
