### PR TITLE
Add missed unix filetypes (block/char devices, fifos and sockets)

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -2522,6 +2522,7 @@ pub mod consts {
             pub const S_IFDIR : c_int = 16384;
             pub const S_IFREG : c_int = 32768;
             pub const S_IFLNK : c_int = 40960;
+            pub const S_IFSOCK : mode_t = 49152;
             pub const S_IFMT : c_int = 61440;
             pub const S_IEXEC : c_int = 64;
             pub const S_IWRITE : c_int = 128;
@@ -2881,6 +2882,7 @@ pub mod consts {
             pub const S_IFDIR : mode_t = 16384;
             pub const S_IFREG : mode_t = 32768;
             pub const S_IFLNK : mode_t = 40960;
+            pub const S_IFSOCK : mode_t = 49152;
             pub const S_IFMT : mode_t = 61440;
             pub const S_IEXEC : mode_t = 64;
             pub const S_IWRITE : mode_t = 128;
@@ -3103,6 +3105,7 @@ pub mod consts {
             pub const S_IFDIR : mode_t = 16384;
             pub const S_IFREG : mode_t = 32768;
             pub const S_IFLNK : mode_t = 40960;
+            pub const S_IFSOCK : mode_t = 49152;
             pub const S_IFMT : mode_t = 61440;
             pub const S_IEXEC : mode_t = 64;
             pub const S_IWRITE : mode_t = 128;
@@ -3905,6 +3908,7 @@ pub mod consts {
             pub const S_IFDIR : mode_t = 16384;
             pub const S_IFREG : mode_t = 32768;
             pub const S_IFLNK : mode_t = 40960;
+            pub const S_IFSOCK : mode_t = 49152;
             pub const S_IFMT : mode_t = 61440;
             pub const S_IEXEC : mode_t = 64;
             pub const S_IWRITE : mode_t = 128;
@@ -4365,6 +4369,7 @@ pub mod consts {
             pub const S_IFDIR : mode_t = 16384;
             pub const S_IFREG : mode_t = 32768;
             pub const S_IFLNK : mode_t = 40960;
+            pub const S_IFSOCK : mode_t = 49152;
             pub const S_IFMT : mode_t = 61440;
             pub const S_IEXEC : mode_t = 64;
             pub const S_IWRITE : mode_t = 128;
@@ -4791,6 +4796,7 @@ pub mod consts {
             pub const S_IFDIR : mode_t = 16384;
             pub const S_IFREG : mode_t = 32768;
             pub const S_IFLNK : mode_t = 40960;
+            pub const S_IFSOCK : mode_t = 49152;
             pub const S_IFMT : mode_t = 61440;
             pub const S_IEXEC : mode_t = 64;
             pub const S_IWRITE : mode_t = 128;

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -637,6 +637,10 @@ impl FileType {
     pub fn is_symlink(&self) -> bool { self.0.is_symlink() }
 }
 
+impl AsInner<fs_imp::FileType> for FileType {
+    fn as_inner(&self) -> &fs_imp::FileType { &self.0 }
+}
+
 impl FromInner<fs_imp::FilePermissions> for Permissions {
     fn from_inner(f: fs_imp::FilePermissions) -> Permissions {
         Permissions(f)

--- a/src/libstd/sys/unix/ext/fs.rs
+++ b/src/libstd/sys/unix/ext/fs.rs
@@ -16,6 +16,7 @@ use prelude::v1::*;
 
 use fs::{self, Permissions, OpenOptions};
 use io;
+use libc;
 use os::raw::c_long;
 use os::unix::raw;
 use path::Path;
@@ -176,6 +177,27 @@ impl MetadataExt for fs::Metadata {
     fn blocks(&self) -> raw::blkcnt_t {
         self.as_raw_stat().st_blocks as raw::blkcnt_t
     }
+}
+
+/// Add special unix types (block/char device, fifo and socket)
+#[unstable(feature = "file_type_ext", reason = "recently added API")]
+pub trait FileTypeExt {
+    /// Returns whether this file type is a block device.
+    fn is_block_device(&self) -> bool;
+    /// Returns whether this file type is a char device.
+    fn is_char_device(&self) -> bool;
+    /// Returns whether this file type is a fifo.
+    fn is_fifo(&self) -> bool;
+    /// Returns whether this file type is a socket.
+    fn is_socket(&self) -> bool;
+}
+
+#[unstable(feature = "file_type_ext", reason = "recently added API")]
+impl FileTypeExt for fs::FileType {
+    fn is_block_device(&self) -> bool { self.as_inner().is(libc::S_IFBLK) }
+    fn is_char_device(&self) -> bool { self.as_inner().is(libc::S_IFCHR) }
+    fn is_fifo(&self) -> bool { self.as_inner().is(libc::S_IFIFO) }
+    fn is_socket(&self) -> bool { self.as_inner().is(libc::S_IFSOCK) }
 }
 
 /// Unix-specific extension methods for `fs::DirEntry`

--- a/src/libstd/sys/unix/ext/mod.rs
+++ b/src/libstd/sys/unix/ext/mod.rs
@@ -45,7 +45,7 @@ pub mod prelude {
     #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]
     pub use super::ffi::{OsStrExt, OsStringExt};
     #[doc(no_inline)]
-    pub use super::fs::{PermissionsExt, OpenOptionsExt, MetadataExt};
+    pub use super::fs::{PermissionsExt, OpenOptionsExt, MetadataExt, FileTypeExt};
     #[doc(no_inline)]
     pub use super::fs::{DirEntryExt};
     #[doc(no_inline)] #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -113,7 +113,7 @@ impl FileType {
     pub fn is_file(&self) -> bool { self.is(libc::S_IFREG) }
     pub fn is_symlink(&self) -> bool { self.is(libc::S_IFLNK) }
 
-    fn is(&self, mode: mode_t) -> bool { self.mode & libc::S_IFMT == mode }
+    pub fn is(&self, mode: mode_t) -> bool { self.mode & libc::S_IFMT == mode }
 }
 
 impl FromInner<raw::mode_t> for FilePermissions {


### PR DESCRIPTION
I find that isn't supported on the current API and I think is necesary.

It is my first PR to rust (I'm not a rust expert and I'm not sure if this is the better way to propose this thinks), of course any suggestion of change will be welcome.

I'm almost sure that in windows aren't supported this filetypes, then, i put in the api of win::fs the functions with a fixed false in the response, I hope this is correct.
