### PR TITLE
Illustrate deadlock in dining-philosophers.md

### DIFF
--- a/src/doc/trpl/dining-philosophers.md
+++ b/src/doc/trpl/dining-philosophers.md
@@ -259,8 +259,8 @@ Michel Foucault is done eating.
 Easy enough, they’re all done! We haven’t actually implemented the real problem
 yet, though, so we’re not done yet!
 
-Next, we want to make our philosophers not just finish eating, but actually
-eat. Here’s the next version:
+For our philosophers to finish eating they first must have started eating. Here’s
+the next version:
 
 ```rust
 use std::thread;
@@ -277,7 +277,7 @@ impl Philosopher {
     }
     
     fn eat(&self) {
-        println!("{} is eating.", self.name);
+        println!("{} is about to eat.", self.name);
 
         thread::sleep_ms(1000);
 
@@ -311,7 +311,7 @@ from the standard library, and so we need to `use` it.
 
 ```rust,ignore
     fn eat(&self) {
-        println!("{} is eating.", self.name);
+        println!("{} is about to eat.", self.name);
 
         thread::sleep_ms(1000);
 
@@ -325,15 +325,15 @@ simulate the time it takes a philosopher to eat.
 If you run this program, you should see each philosopher eat in turn:
 
 ```text
-Judith Butler is eating.
+Judith Butler is about to eat.
 Judith Butler is done eating.
-Gilles Deleuze is eating.
+Gilles Deleuze is about to eat.
 Gilles Deleuze is done eating.
-Karl Marx is eating.
+Karl Marx is about to eat.
 Karl Marx is done eating.
-Emma Goldman is eating.
+Emma Goldman is about to eat.
 Emma Goldman is done eating.
-Michel Foucault is eating.
+Michel Foucault is about to eat.
 Michel Foucault is done eating.
 ```
 
@@ -358,7 +358,7 @@ impl Philosopher {
     }
 
     fn eat(&self) {
-        println!("{} is eating.", self.name);
+        println!("{} is about to eat.", self.name);
 
         thread::sleep_ms(1000);
 
@@ -460,14 +460,14 @@ If you run this program, you’ll see that the philosophers eat out of order!
 We have multi-threading!
 
 ```text
-Gilles Deleuze is eating.
+Gilles Deleuze is about to eat.
 Gilles Deleuze is done eating.
-Emma Goldman is eating.
+Emma Goldman is about to eat.
 Emma Goldman is done eating.
-Michel Foucault is eating.
-Judith Butler is eating.
+Michel Foucault is about to eat.
+Judith Butler is about to eat.
 Judith Butler is done eating.
-Karl Marx is eating.
+Karl Marx is about to eat.
 Karl Marx is done eating.
 Michel Foucault is done eating.
 ```
@@ -511,7 +511,7 @@ impl Philosopher {
     }
 
     fn eat(&self, table: &Table) {
-        println!("{} is eating.", self.name);
+        println!("{} is about to eat.", self.name);
         
         let _left = table.forks[self.left].lock().unwrap();
         thread::sleep_ms(1000);
@@ -595,7 +595,7 @@ We now need to construct those `left` and `right` values, so we add them to
 
 ```rust,ignore
 fn eat(&self, table: &Table) {
-    println!("{} is eating.", self.name);
+    println!("{} is about to eat.", self.name);
     
     let _left = table.forks[self.left].lock().unwrap();
     thread::sleep_ms(1000);
@@ -686,14 +686,14 @@ With this, our program works! Only two philosophers can eat at any one time,
 and so you’ll get some output like this:
 
 ```text
-Gilles Deleuze is eating.
-Emma Goldman is eating.
+Gilles Deleuze is about to eat.
+Emma Goldman is about to eat.
 Emma Goldman is done eating.
 Gilles Deleuze is done eating.
-Judith Butler is eating.
-Karl Marx is eating.
+Judith Butler is about to eat.
+Karl Marx is about to eat.
 Judith Butler is done eating.
-Michel Foucault is eating.
+Michel Foucault is about to eat.
 Karl Marx is done eating.
 Michel Foucault is done eating.
 ```

--- a/src/doc/trpl/dining-philosophers.md
+++ b/src/doc/trpl/dining-philosophers.md
@@ -659,7 +659,7 @@ you look at the pattern, it’s all consistent until the very end. Monsieur
 Foucault should have `4, 0` as arguments, but instead, has `0, 4`. This is what
 prevents deadlock, actually: one of our philosophers is left handed! This is
 one way to solve the problem, and in my opinion, it’s the simplest. If you
-switched these round and caused a deadlock you can use `Ctrl-C` to interrupt
+switched these around and caused a deadlock you can use `Ctrl-C` to interrupt
 execution of the program.
 
 ```rust,ignore

--- a/src/doc/trpl/dining-philosophers.md
+++ b/src/doc/trpl/dining-philosophers.md
@@ -511,13 +511,12 @@ impl Philosopher {
     }
 
     fn eat(&self, table: &Table) {
-        let _left = table.forks[self.left].lock().unwrap();
-        let _right = table.forks[self.right].lock().unwrap();
-
         println!("{} is eating.", self.name);
-
+        
+        let _left = table.forks[self.left].lock().unwrap();
         thread::sleep_ms(1000);
-
+        let _right = table.forks[self.right].lock().unwrap();
+        
         println!("{} is done eating.", self.name);
     }
 }
@@ -596,13 +595,12 @@ We now need to construct those `left` and `right` values, so we add them to
 
 ```rust,ignore
 fn eat(&self, table: &Table) {
-    let _left = table.forks[self.left].lock().unwrap();
-    let _right = table.forks[self.right].lock().unwrap();
-
     println!("{} is eating.", self.name);
-
+    
+    let _left = table.forks[self.left].lock().unwrap();
     thread::sleep_ms(1000);
-
+    let _right = table.forks[self.right].lock().unwrap();
+    
     println!("{} is done eating.", self.name);
 }
 ```
@@ -660,7 +658,9 @@ We need to pass in our `left` and `right` values to the constructors for our
 you look at the pattern, it’s all consistent until the very end. Monsieur
 Foucault should have `4, 0` as arguments, but instead, has `0, 4`. This is what
 prevents deadlock, actually: one of our philosophers is left handed! This is
-one way to solve the problem, and in my opinion, it’s the simplest.
+one way to solve the problem, and in my opinion, it’s the simplest. If you
+switched these round and caused a deadlock you can use `Ctrl-C` to interrupt
+execution of the program.
 
 ```rust,ignore
 let handles: Vec<_> = philosophers.into_iter().map(|p| {


### PR DESCRIPTION
Originally the program would not (or would only very rarely) deadlock even if the numbers were in the "incorrect" order (`4, 0`). This means the statement

> But there’s one more detail here, and it’s very important. If you look at the pattern, it’s all consistent
> until the very end. Monsieur Foucault should have 4, 0 as arguments, but instead, has 0, 4. This is
> what prevents deadlock, actually: one of our philosophers is left handed!

could be very confusing, if no deadlock occurs why would the detail be very important?

This change means that a deadlock will (almost?) always occur if the numbers are in the order `4, 0`, allowing people to see why the change is actually needed.

r? @steveklabnik
