### PR TITLE
Fix different behaviour of OpenOptions between Windows en Linux

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -414,6 +414,8 @@ impl OpenOptions {
     ///
     /// This option, when true, means that writes will append to a file instead
     /// of overwriting previous contents.
+    /// Note that setting `.write(true).append(true)` has the same effect as
+    /// setting only `.append(true)`.
     ///
     /// # Examples
     ///
@@ -450,6 +452,9 @@ impl OpenOptions {
     ///
     /// This option indicates whether a new file will be created if the file
     /// does not yet already exist.
+    ///
+    /// The access mode (e.g. read, write and/or append) does not influence whether
+    /// a new file is created, or with which permissions it is created.
     ///
     /// # Examples
     ///

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -359,7 +359,7 @@ impl<'a> Seek for &'a File {
 }
 
 impl OpenOptions {
-    /// Creates a blank net set of options ready for configuration.
+    /// Creates a blank new set of options ready for configuration.
     ///
     /// All options are initially set to `false`.
     ///
@@ -368,7 +368,8 @@ impl OpenOptions {
     /// ```no_run
     /// use std::fs::OpenOptions;
     ///
-    /// let file = OpenOptions::new().open("foo.txt");
+    /// let mut options = OpenOptions::new();
+    /// let file = options.read(true).open("foo.txt");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new() -> OpenOptions {
@@ -419,7 +420,7 @@ impl OpenOptions {
     /// ```no_run
     /// use std::fs::OpenOptions;
     ///
-    /// let file = OpenOptions::new().write(true).append(true).open("foo.txt");
+    /// let file = OpenOptions::new().append(true).open("foo.txt");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn append(&mut self, append: bool) -> &mut OpenOptions {
@@ -430,6 +431,8 @@ impl OpenOptions {
     ///
     /// If a file is successfully opened with this option set it will truncate
     /// the file to 0 length if it already exists.
+    ///
+    /// The file must be opened with write access for truncate to work.
     ///
     /// # Examples
     ///
@@ -453,7 +456,7 @@ impl OpenOptions {
     /// ```no_run
     /// use std::fs::OpenOptions;
     ///
-    /// let file = OpenOptions::new().create(true).open("foo.txt");
+    /// let file = OpenOptions::new().write(true).create(true).open("foo.txt");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn create(&mut self, create: bool) -> &mut OpenOptions {

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -256,7 +256,7 @@ impl OpenOptions {
         let append = (self.flags & libc::O_APPEND) == libc::O_APPEND;
         let truncate = (self.flags & libc::O_TRUNC) == libc::O_TRUNC;
 
-        if truncate && !(self.write || append) {
+        if truncate && (!self.write || append) {
             // The result of using O_TRUNC with O_RDONLY is undefined.
             // Not allowed, for consistency with Windows.
             Err(Error::from_raw_os_error(libc::EINVAL))

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -201,13 +201,7 @@ impl OpenOptions {
                 (true, true) => libc::CREATE_ALWAYS,
                 (true, false) => libc::OPEN_ALWAYS,
                 (false, false) => libc::OPEN_EXISTING,
-                (false, true) => {
-                    if self.write && !self.append {
-                        libc::CREATE_ALWAYS
-                    } else {
-                        libc::TRUNCATE_EXISTING
-                    }
-                }
+                (false, true) => libc::TRUNCATE_EXISTING,
             }
         })
     }

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -176,13 +176,14 @@ impl OpenOptions {
 
     fn get_desired_access(&self) -> libc::DWORD {
         self.desired_access.unwrap_or({
-            let mut base = if self.read {libc::FILE_GENERIC_READ} else {0} |
-                           if self.write {libc::FILE_GENERIC_WRITE} else {0};
-            if self.append {
-                /* append has the same bits set as write, but without FILE_WRITE_DATA */
-                base |= libc::FILE_GENERIC_WRITE;
-                base &= !libc::FILE_WRITE_DATA;
-            }
+            let base = if self.read {libc::GENERIC_READ} else {0} |
+                if self.append {
+                    /* append has the same bits set as those that are implied
+                       for write, but without FILE_WRITE_DATA */
+                    libc::FILE_GENERIC_WRITE & !libc::FILE_WRITE_DATA
+                } else if self.write {
+                    libc::GENERIC_WRITE
+                } else {0};
             base
         })
     }

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -179,8 +179,9 @@ impl OpenOptions {
             let mut base = if self.read {libc::FILE_GENERIC_READ} else {0} |
                            if self.write {libc::FILE_GENERIC_WRITE} else {0};
             if self.append {
+                /* append has the same bits set as write, but without FILE_WRITE_DATA */
+                base |= libc::FILE_GENERIC_WRITE;
                 base &= !libc::FILE_WRITE_DATA;
-                base |= libc::FILE_APPEND_DATA;
             }
             base
         })


### PR DESCRIPTION
case #1:
A file is opened as read-only and with `.truncate(true)`.
On Windows this fails with `Error { repr: Os { code: 87, message: "The parameter is incorrect.\r\n" } }`.
On Unix the behaviour is undefined.
Solution: also fail on Linux with `Error { repr: Os { code: 22, message: "Invalid argument" } }`
This is a breaking change, but only for code that relies on the current undefined behaviour.

case #2:
A file is opened with `.append(true)`, but without `.write(true)`.
On Windows it is possible to append to the file, on linux it fails.
Solution: let `.append(true)` imply `.write(true)` on linux.

case #3:
A file is opened without access options.
On Windows it fails at the first read or write.
On Linux this falls back to read-only mode.
Solution: I prefer to also fail on Linux, with "Invalid argument". But this is a breaking change...
It is also possible to add the same fallback on Windows.

I think that calling setting `.create(true)` with read-only access is also undefined behaviour.
Should we check for this also?  OpenBSD might be a good candidate to test this.
