### PR TITLE
Add missing #[inline] to min_value/max_value on integers

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -668,10 +668,12 @@ macro_rules! uint_impl {
      $mul_with_overflow:path) => {
         /// Returns the smallest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]
+        #[inline]
         pub fn min_value() -> Self { 0 }
 
         /// Returns the largest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]
+        #[inline]
         pub fn max_value() -> Self { !0 }
 
         /// Converts a string slice in a given base to an integer.


### PR DESCRIPTION
Add missing #[inline] to min_value/max_value on integers

Spotted a compiled function call to num::usize::min_value, I'd prefer
the 0 to be inlined.
