### PR TITLE
Show better error message for incorrect unicode escape sequences syntax

### DIFF
--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -742,6 +742,16 @@ impl<'a> StringReader<'a> {
                                    valid
                                 }
                             }
+                            'u' => {
+                                self.err_span_(
+                                    escaped_pos,
+                                    self.last_pos,
+                                    "`\\u` in string literals start unicode escape sequences; \
+                                    for example, use `\\u{30a2}` to specify codepoint U+30A2, \
+                                    or did you mean `\\\\u`?"
+                                );
+                                false
+                            }
                             '\n' if delim == '"' => {
                                 self.consume_whitespace();
                                 true

--- a/src/test/compile-fail/unicode-escape-sequences.rs
+++ b/src/test/compile-fail/unicode-escape-sequences.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Test that a covariant struct permits the lifetime of a reference to
+// be shortened.
+
+fn main() { "\u123"; }
+//~^ error: `\u` in string literals start unicode escape sequences; for example, use `\u{30a2}`


### PR DESCRIPTION
This patch gives better error message if the braces are missing when you use unicode escape sequences in string literals.
