### PR TITLE
rustc_lint: handle more method calls in unconditional_recursion.

### DIFF
--- a/src/librustc/metadata/decoder.rs
+++ b/src/librustc/metadata/decoder.rs
@@ -299,15 +299,7 @@ fn item_to_def_like(cdata: Cmd, item: rbml::Doc, did: ast::DefId) -> DefLike {
         Constant  => {
             // Check whether we have an associated const item.
             if item_sort(item) == Some('C') {
-                // Check whether the associated const is from a trait or impl.
-                // See the comment for methods below.
-                let provenance = if reader::maybe_get_doc(
-                      item, tag_item_trait_parent_sort).is_some() {
-                    def::FromTrait(item_require_parent_item(cdata, item))
-                } else {
-                    def::FromImpl(item_require_parent_item(cdata, item))
-                };
-                DlDef(def::DefAssociatedConst(did, provenance))
+                DlDef(def::DefAssociatedConst(did))
             } else {
                 // Regular const item.
                 DlDef(def::DefConst(did))
@@ -319,18 +311,7 @@ fn item_to_def_like(cdata: Cmd, item: rbml::Doc, did: ast::DefId) -> DefLike {
         Fn        => DlDef(def::DefFn(did, false)),
         CtorFn    => DlDef(def::DefFn(did, true)),
         Method | StaticMethod => {
-            // def_static_method carries an optional field of its enclosing
-            // trait or enclosing impl (if this is an inherent static method).
-            // So we need to detect whether this is in a trait or not, which
-            // we do through the mildly hacky way of checking whether there is
-            // a trait_parent_sort.
-            let provenance = if reader::maybe_get_doc(
-                  item, tag_item_trait_parent_sort).is_some() {
-                def::FromTrait(item_require_parent_item(cdata, item))
-            } else {
-                def::FromImpl(item_require_parent_item(cdata, item))
-            };
-            DlDef(def::DefMethod(did, provenance))
+            DlDef(def::DefMethod(did))
         }
         Type => {
             if item_sort(item) == Some('t') {

--- a/src/librustc/middle/astencode.rs
+++ b/src/librustc/middle/astencode.rs
@@ -444,9 +444,7 @@ impl tr for def::Def {
     fn tr(&self, dcx: &DecodeContext) -> def::Def {
         match *self {
           def::DefFn(did, is_ctor) => def::DefFn(did.tr(dcx), is_ctor),
-          def::DefMethod(did, p) => {
-            def::DefMethod(did.tr(dcx), p.map(|did2| did2.tr(dcx)))
-          }
+          def::DefMethod(did) => def::DefMethod(did.tr(dcx)),
           def::DefSelfTy(opt_did, impl_ids) => { def::DefSelfTy(opt_did.map(|did| did.tr(dcx)),
                                                                 impl_ids.map(|(nid1, nid2)| {
                                                                     (dcx.tr_id(nid1),
@@ -456,9 +454,7 @@ impl tr for def::Def {
           def::DefForeignMod(did) => { def::DefForeignMod(did.tr(dcx)) }
           def::DefStatic(did, m) => { def::DefStatic(did.tr(dcx), m) }
           def::DefConst(did) => { def::DefConst(did.tr(dcx)) }
-          def::DefAssociatedConst(did, p) => {
-              def::DefAssociatedConst(did.tr(dcx), p.map(|did2| did2.tr(dcx)))
-          }
+          def::DefAssociatedConst(did) => def::DefAssociatedConst(did.tr(dcx)),
           def::DefLocal(nid) => { def::DefLocal(dcx.tr_id(nid)) }
           def::DefVariant(e_did, v_did, is_s) => {
             def::DefVariant(e_did.tr(dcx), v_did.tr(dcx), is_s)

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -442,7 +442,7 @@ impl<'a, 'tcx> Folder for StaticInliner<'a, 'tcx> {
             ast::PatIdent(..) | ast::PatEnum(..) | ast::PatQPath(..) => {
                 let def = self.tcx.def_map.borrow().get(&pat.id).map(|d| d.full_def());
                 match def {
-                    Some(DefAssociatedConst(did, _)) |
+                    Some(DefAssociatedConst(did)) |
                     Some(DefConst(did)) => match lookup_const_by_id(self.tcx, did, Some(pat.id)) {
                         Some(const_expr) => {
                             const_expr_to_pat(self.tcx, const_expr, pat.span).map(|new_pat| {

--- a/src/librustc/middle/check_static_recursion.rs
+++ b/src/librustc/middle/check_static_recursion.rs
@@ -238,7 +238,7 @@ impl<'a, 'ast: 'a> Visitor<'ast> for CheckItemRecursionVisitor<'a, 'ast> {
             ast::ExprPath(..) => {
                 match self.def_map.borrow().get(&e.id).map(|d| d.base_def) {
                     Some(DefStatic(def_id, _)) |
-                    Some(DefAssociatedConst(def_id, _)) |
+                    Some(DefAssociatedConst(def_id)) |
                     Some(DefConst(def_id))
                            if ast_util::is_local(def_id) => {
                         match self.ast_map.get(def_id.node) {

--- a/src/librustc/middle/def.rs
+++ b/src/librustc/middle/def.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 pub use self::Def::*;
-pub use self::MethodProvenance::*;
 
 use middle::privacy::LastPrivate;
 use middle::subst::ParamSpace;
@@ -28,7 +27,7 @@ pub enum Def {
     DefForeignMod(ast::DefId),
     DefStatic(ast::DefId, bool /* is_mutbl */),
     DefConst(ast::DefId),
-    DefAssociatedConst(ast::DefId /* const */, MethodProvenance),
+    DefAssociatedConst(ast::DefId),
     DefLocal(ast::NodeId),
     DefVariant(ast::DefId /* enum */, ast::DefId /* variant */, bool /* is_structure */),
     DefTy(ast::DefId, bool /* is_enum */),
@@ -51,7 +50,7 @@ pub enum Def {
     DefStruct(ast::DefId),
     DefRegion(ast::NodeId),
     DefLabel(ast::NodeId),
-    DefMethod(ast::DefId /* method */, MethodProvenance),
+    DefMethod(ast::DefId),
 }
 
 /// The result of resolving a path.
@@ -112,23 +111,6 @@ pub struct Export {
     pub def_id: ast::DefId, // The definition of the target.
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
-pub enum MethodProvenance {
-    FromTrait(ast::DefId),
-    FromImpl(ast::DefId),
-}
-
-impl MethodProvenance {
-    pub fn map<F>(self, f: F) -> MethodProvenance where
-        F: FnOnce(ast::DefId) -> ast::DefId,
-    {
-        match self {
-            FromTrait(did) => FromTrait(f(did)),
-            FromImpl(did) => FromImpl(f(did))
-        }
-    }
-}
-
 impl Def {
     pub fn local_node_id(&self) -> ast::NodeId {
         let def_id = self.def_id();
@@ -141,7 +123,7 @@ impl Def {
             DefFn(id, _) | DefMod(id) | DefForeignMod(id) | DefStatic(id, _) |
             DefVariant(_, id, _) | DefTy(id, _) | DefAssociatedTy(_, id) |
             DefTyParam(_, _, id, _) | DefUse(id) | DefStruct(id) | DefTrait(id) |
-            DefMethod(id, _) | DefConst(id) | DefAssociatedConst(id, _) |
+            DefMethod(id) | DefConst(id) | DefAssociatedConst(id) |
             DefSelfTy(Some(id), None)=> {
                 id
             }

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -545,14 +545,12 @@ impl<'a, 'b:'a, 'tcx:'b> GraphBuilder<'a, 'b, 'tcx> {
 
                     match trait_item.node {
                         ast::ConstTraitItem(..) => {
-                            let def = DefAssociatedConst(local_def(trait_item.id),
-                                                         FromTrait(local_def(item.id)));
+                            let def = DefAssociatedConst(local_def(trait_item.id));
                             // NB: not DefModifiers::IMPORTABLE
                             name_bindings.define_value(def, trait_item.span, DefModifiers::PUBLIC);
                         }
                         ast::MethodTraitItem(..) => {
-                            let def = DefMethod(local_def(trait_item.id),
-                                                FromTrait(local_def(item.id)));
+                            let def = DefMethod(local_def(trait_item.id));
                             // NB: not DefModifiers::IMPORTABLE
                             name_bindings.define_value(def, trait_item.span, DefModifiers::PUBLIC);
                         }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3448,7 +3448,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         // Look for a method in the current self type's impl module.
         if let Some(module) = get_module(self, path.span, &name_path) {
             if let Some(binding) = module.children.borrow().get(&name) {
-                if let Some(DefMethod(did, _)) = binding.def_for_namespace(ValueNS) {
+                if let Some(DefMethod(did)) = binding.def_for_namespace(ValueNS) {
                     if is_static_method(self, did) {
                         return StaticMethod(path_names_to_string(&path, 0))
                     }

--- a/src/librustc_trans/save/dump_csv.rs
+++ b/src/librustc_trans/save/dump_csv.rs
@@ -719,7 +719,7 @@ impl <'l, 'tcx> DumpCsvVisitor<'l, 'tcx> {
         let def_map = self.tcx.def_map.borrow();
         let def = def_map.get(&id).unwrap().full_def();
         match def {
-            def::DefMethod(did, _) => {
+            def::DefMethod(did) => {
                 let ti = self.tcx.impl_or_trait_item(did);
                 if let ty::MethodTraitItem(m) = ti {
                     if m.explicit_self == ty::StaticExplicitSelfCategory {

--- a/src/librustc_trans/save/mod.rs
+++ b/src/librustc_trans/save/mod.rs
@@ -551,12 +551,12 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                     scope: self.enclosing_scope(id),
                 }))
             }
-            def::DefMethod(decl_id, provenence) => {
+            def::DefMethod(decl_id) => {
                 let sub_span = self.span_utils.sub_span_for_meth_name(path.span);
                 let def_id = if decl_id.krate == ast::LOCAL_CRATE {
                     let ti = self.tcx.impl_or_trait_item(decl_id);
-                    match provenence {
-                        def::FromTrait(def_id) => {
+                    match ti.container() {
+                        ty::TraitContainer(def_id) => {
                             self.tcx.trait_items(def_id)
                                 .iter()
                                 .find(|mr| {
@@ -564,7 +564,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                                 })
                                 .map(|mr| mr.def_id())
                         }
-                        def::FromImpl(def_id) => {
+                        ty::ImplContainer(def_id) => {
                             let impl_items = self.tcx.impl_items.borrow();
                             Some(impl_items.get(&def_id)
                                            .unwrap()

--- a/src/librustc_typeck/check/method/mod.rs
+++ b/src/librustc_typeck/check/method/mod.rs
@@ -334,19 +334,14 @@ pub fn resolve_ufcs<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
     let pick = try!(probe::probe(fcx, span, mode, method_name, self_ty, expr_id));
     let def_id = pick.item.def_id();
     let mut lp = LastMod(AllPublic);
-    let container_def_id = pick.item.container().id();
-    let provenance = match pick.kind {
-        probe::InherentImplPick => {
-            if pick.item.vis() != ast::Public {
-                lp = LastMod(DependsOn(def_id));
-            }
-            def::FromImpl(container_def_id)
+    if let probe::InherentImplPick = pick.kind {
+        if pick.item.vis() != ast::Public {
+            lp = LastMod(DependsOn(def_id));
         }
-        _ => def::FromTrait(container_def_id)
-    };
+    }
     let def_result = match pick.item {
-        ty::ImplOrTraitItem::MethodTraitItem(..) => def::DefMethod(def_id, provenance),
-        ty::ImplOrTraitItem::ConstTraitItem(..) => def::DefAssociatedConst(def_id, provenance),
+        ty::ImplOrTraitItem::MethodTraitItem(..) => def::DefMethod(def_id),
+        ty::ImplOrTraitItem::ConstTraitItem(..) => def::DefAssociatedConst(def_id),
         ty::ImplOrTraitItem::TypeTraitItem(..) => {
             fcx.tcx().sess.span_bug(span, "resolve_ufcs: probe picked associated type");
         }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -107,7 +107,7 @@ fn try_inline_def(cx: &DocContext, tcx: &ty::ctxt,
             record_extern_fqn(cx, did, clean::TypeStatic);
             clean::StaticItem(build_static(cx, tcx, did, mtbl))
         }
-        def::DefConst(did) | def::DefAssociatedConst(did, _) => {
+        def::DefConst(did) | def::DefAssociatedConst(did) => {
             record_extern_fqn(cx, did, clean::TypeConst);
             clean::ConstantItem(build_const(cx, tcx, did))
         }


### PR DESCRIPTION
After #26694, the overloaded operator and "impl not known at method lookup time" cases started triggering the lint.
I've also added checks for overloaded autoderef and method calls via paths (i.e. `T::method()`).
All new 8 test cases did not trigger the lint before #26694.
r? @huonw
