### PR TITLE
Stabilize the Duration API

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -33,7 +33,6 @@
 #![feature(collections)]
 #![feature(const_fn)]
 #![feature(core)]
-#![feature(duration)]
 #![feature(duration_span)]
 #![feature(dynamic_lib)]
 #![feature(enumset)]

--- a/src/librustc/metadata/loader.rs
+++ b/src/librustc/metadata/loader.rs
@@ -722,7 +722,7 @@ fn get_metadata_section(target: &Target, filename: &Path)
     let dur = Duration::span(|| {
         ret = Some(get_metadata_section_imp(target, filename));
     });
-    info!("reading {:?} => {}", filename.file_name().unwrap(), dur);
+    info!("reading {:?} => {:?}", filename.file_name().unwrap(), dur);
     return ret.unwrap();;
 }
 

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -596,8 +596,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
           "Force drop flag checks on or off"),
     trace_macros: bool = (false, parse_bool,
           "For every macro invocation, print its name and arguments"),
-    disable_nonzeroing_move_hints: bool = (false, parse_bool,
-          "Force nonzeroing move optimization off"),
+    enable_nonzeroing_move_hints: bool = (false, parse_bool,
+          "Force nonzeroing move optimization on"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -273,7 +273,7 @@ impl Session {
         self.opts.debugging_opts.print_enum_sizes
     }
     pub fn nonzeroing_move_hints(&self) -> bool {
-        !self.opts.debugging_opts.disable_nonzeroing_move_hints
+        self.opts.debugging_opts.enable_nonzeroing_move_hints
     }
     pub fn sysroot<'a>(&'a self) -> &'a Path {
         match self.opts.maybe_sysroot {

--- a/src/librustc/util/common.rs
+++ b/src/librustc/util/common.rs
@@ -57,8 +57,8 @@ pub fn time<T, U, F>(do_it: bool, what: &str, u: U, f: F) -> T where
     // Hack up our own formatting for the duration to make it easier for scripts
     // to parse (always use the same number of decimal places and the same unit).
     const NANOS_PER_SEC: f64 = 1_000_000_000.0;
-    let secs = dur.secs() as f64;
-    let secs = secs + dur.extra_nanos() as f64 / NANOS_PER_SEC;
+    let secs = dur.as_secs() as f64;
+    let secs = secs + dur.subsec_nanos() as f64 / NANOS_PER_SEC;
 
     let mem_string = match get_resident() {
         Some(n) => {

--- a/src/libstd/sys/unix/condvar.rs
+++ b/src/libstd/sys/unix/condvar.rs
@@ -61,11 +61,11 @@ impl Condvar {
         let r = ffi::gettimeofday(&mut sys_now, ptr::null_mut());
         debug_assert_eq!(r, 0);
 
-        let nsec = dur.extra_nanos() as libc::c_long +
+        let nsec = dur.subsec_nanos() as libc::c_long +
                    (sys_now.tv_usec * 1000) as libc::c_long;
         let extra = (nsec / 1_000_000_000) as libc::time_t;
         let nsec = nsec % 1_000_000_000;
-        let seconds = dur.secs() as libc::time_t;
+        let seconds = dur.as_secs() as libc::time_t;
 
         let timeout = sys_now.tv_sec.checked_add(extra).and_then(|s| {
             s.checked_add(seconds)

--- a/src/libstd/sys/unix/net.rs
+++ b/src/libstd/sys/unix/net.rs
@@ -79,19 +79,19 @@ impl Socket {
     pub fn set_timeout(&self, dur: Option<Duration>, kind: libc::c_int) -> io::Result<()> {
         let timeout = match dur {
             Some(dur) => {
-                if dur.secs() == 0 && dur.extra_nanos() == 0 {
+                if dur.as_secs() == 0 && dur.subsec_nanos() == 0 {
                     return Err(io::Error::new(io::ErrorKind::InvalidInput,
                                               "cannot set a 0 duration timeout"));
                 }
 
-                let secs = if dur.secs() > libc::time_t::max_value() as u64 {
+                let secs = if dur.as_secs() > libc::time_t::max_value() as u64 {
                     libc::time_t::max_value()
                 } else {
-                    dur.secs() as libc::time_t
+                    dur.as_secs() as libc::time_t
                 };
                 let mut timeout = libc::timeval {
                     tv_sec: secs,
-                    tv_usec: (dur.extra_nanos() / 1000) as libc::suseconds_t,
+                    tv_usec: (dur.subsec_nanos() / 1000) as libc::suseconds_t,
                 };
                 if timeout.tv_sec == 0 && timeout.tv_usec == 0 {
                     timeout.tv_usec = 1;

--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -131,8 +131,8 @@ impl Thread {
 
     pub fn sleep(dur: Duration) {
         let mut ts = libc::timespec {
-            tv_sec: dur.secs() as libc::time_t,
-            tv_nsec: dur.extra_nanos() as libc::c_long,
+            tv_sec: dur.as_secs() as libc::time_t,
+            tv_nsec: dur.subsec_nanos() as libc::c_long,
         };
 
         // If we're awoken with a signal then the return value will be -1 and

--- a/src/libstd/sys/windows/mod.rs
+++ b/src/libstd/sys/windows/mod.rs
@@ -162,10 +162,10 @@ fn dur2timeout(dur: Duration) -> libc::DWORD {
     // * Nanosecond precision is rounded up
     // * Greater than u32::MAX milliseconds (50 days) is rounded up to INFINITE
     //   (never time out).
-    dur.secs().checked_mul(1000).and_then(|ms| {
-        ms.checked_add((dur.extra_nanos() as u64) / 1_000_000)
+    dur.as_secs().checked_mul(1000).and_then(|ms| {
+        ms.checked_add((dur.subsec_nanos() as u64) / 1_000_000)
     }).and_then(|ms| {
-        ms.checked_add(if dur.extra_nanos() % 1_000_000 > 0 {1} else {0})
+        ms.checked_add(if dur.subsec_nanos() % 1_000_000 > 0 {1} else {0})
     }).map(|ms| {
         if ms > <libc::DWORD>::max_value() as u64 {
             libc::INFINITE

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -96,6 +96,14 @@ impl Duration {
     #[stable(feature = "duration", since = "1.3.0")]
     pub fn as_secs(&self) -> u64 { self.secs }
 
+    #[deprecated(reason = "renamed to `as_secs`", since = "1.3.0")]
+    #[unstable(feature = "duration_deprecated")]
+    /// Returns the number of whole seconds represented by this duration.
+    ///
+    /// The extra precision represented by this duration is ignored (e.g. extra
+    /// nanoseconds are not represented in the returned value).
+    pub fn secs(&self) -> u64 { self.as_secs() }
+
     /// Returns the nanosecond precision represented by this duration.
     ///
     /// This method does **not** return the length of the duration when
@@ -103,6 +111,15 @@ impl Duration {
     /// fractional portion of a second (e.g. it is less than one billion).
     #[stable(feature = "duration", since = "1.3.0")]
     pub fn subsec_nanos(&self) -> u32 { self.nanos }
+
+    #[deprecated(reason = "renamed to `subsec_nanos`", since = "1.3.0")]
+    #[unstable(feature = "duration_deprecated")]
+    /// Returns the nanosecond precision represented by this duration.
+    ///
+    /// This method does **not** return the length of the duration when
+    /// represented by nanoseconds. The returned number always represents a
+    /// fractional portion of a second (e.g. it is less than one billion).
+    pub fn extra_nanos(&self) -> u32 { self.subsec_nanos() }
 }
 
 impl Add for Duration {

--- a/src/libstd/time/duration.rs
+++ b/src/libstd/time/duration.rs
@@ -32,7 +32,6 @@ const MILLIS_PER_SEC: u64 = 1_000;
 /// # Examples
 ///
 /// ```
-/// #![feature(duration)]
 /// use std::time::Duration;
 ///
 /// let five_seconds = Duration::new(5, 0);

--- a/src/libstd/time/mod.rs
+++ b/src/libstd/time/mod.rs
@@ -10,7 +10,7 @@
 
 //! Temporal quantification.
 
-#![unstable(feature = "time")]
+#![stable(feature = "time", since = "1.3.0")]
 
 pub use self::duration::Duration;
 

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -36,7 +36,6 @@
 
 #![feature(asm)]
 #![feature(box_syntax)]
-#![feature(duration)]
 #![feature(duration_span)]
 #![feature(fnbox)]
 #![feature(iter_cmp)]
@@ -1105,7 +1104,7 @@ impl Bencher {
     }
 
     pub fn ns_elapsed(&mut self) -> u64 {
-        self.dur.secs() * 1_000_000_000 + (self.dur.extra_nanos() as u64)
+        self.dur.as_secs() * 1_000_000_000 + (self.dur.subsec_nanos() as u64)
     }
 
     pub fn ns_per_iter(&mut self) -> u64 {

--- a/src/test/bench/core-map.rs
+++ b/src/test/bench/core-map.rs
@@ -16,7 +16,7 @@ use std::__rand::{Rng, thread_rng};
 use std::time::Duration;
 
 fn timed<F>(label: &str, f: F) where F: FnMut() {
-    println!("  {}: {}", label, Duration::span(f));
+    println!("  {}: {:?}", label, Duration::span(f));
 }
 
 trait MutableMap {

--- a/src/test/bench/core-set.rs
+++ b/src/test/bench/core-set.rs
@@ -153,7 +153,7 @@ fn write_header(header: &str) {
 }
 
 fn write_row(label: &str, value: Duration) {
-    println!("{:30} {} s\n", label, value);
+    println!("{:30} {:?} s\n", label, value);
 }
 
 fn write_results(label: &str, results: &Results) {

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -51,7 +51,7 @@ fn maybe_run_test<F>(argv: &[String], name: String, test: F) where F: FnOnce() {
 
     let dur = Duration::span(test);
 
-    println!("{}:\t\t{}", name, dur);
+    println!("{}:\t\t{:?}", name, dur);
 }
 
 fn shift_push() {

--- a/src/test/bench/msgsend-pipes-shared.rs
+++ b/src/test/bench/msgsend-pipes-shared.rs
@@ -88,8 +88,8 @@ fn run(args: &[String]) {
     });
     let result = result.unwrap();
     print!("Count is {}\n", result);
-    print!("Test took {}\n", dur);
-    let thruput = ((size / workers * workers) as f64) / (dur.secs() as f64);
+    print!("Test took {:?}\n", dur);
+    let thruput = ((size / workers * workers) as f64) / (dur.as_secs() as f64);
     print!("Throughput={} per sec\n", thruput);
     assert_eq!(result, num_bytes * size);
 }

--- a/src/test/bench/msgsend-pipes.rs
+++ b/src/test/bench/msgsend-pipes.rs
@@ -95,8 +95,8 @@ fn run(args: &[String]) {
     });
     let result = result.unwrap();
     print!("Count is {}\n", result);
-    print!("Test took {}\n", dur);
-    let thruput = ((size / workers * workers) as f64) / (dur.secs() as f64);
+    print!("Test took {:?}\n", dur);
+    let thruput = ((size / workers * workers) as f64) / (dur.as_secs() as f64);
     print!("Throughput={} per sec\n", thruput);
     assert_eq!(result, num_bytes * size);
 }

--- a/src/test/bench/msgsend-ring-mutex-arcs.rs
+++ b/src/test/bench/msgsend-ring-mutex-arcs.rs
@@ -107,9 +107,9 @@ fn main() {
 
     // all done, report stats.
     let num_msgs = num_tasks * msg_per_task;
-    let rate = (num_msgs as f64) / (dur.secs() as f64);
+    let rate = (num_msgs as f64) / (dur.as_secs() as f64);
 
-    println!("Sent {} messages in {}", num_msgs, dur);
+    println!("Sent {} messages in {:?}", num_msgs, dur);
     println!("  {} messages / second", rate);
     println!("  {} μs / message", 1000000. / rate);
 }

--- a/src/test/bench/shootout-pfib.rs
+++ b/src/test/bench/shootout-pfib.rs
@@ -114,7 +114,7 @@ fn main() {
                 let dur = Duration::span(|| fibn = Some(fib(n)));
                 let fibn = fibn.unwrap();
 
-                println!("{}\t{}\t{}", n, fibn, dur);
+                println!("{}\t{}\t{:?}", n, fibn, dur);
             }
         }
     }

--- a/src/test/bench/std-smallintmap.rs
+++ b/src/test/bench/std-smallintmap.rs
@@ -54,8 +54,8 @@ fn main() {
 
     let maxf = max as f64;
 
-    println!("insert(): {} seconds\n", checkf);
-    println!("        : {} op/s\n", maxf / checkf.secs() as f64);
-    println!("get()   : {} seconds\n", appendf);
-    println!("        : {} op/s\n", maxf / appendf.secs() as f64);
+    println!("insert(): {:?} seconds\n", checkf);
+    println!("        : {} op/s\n", maxf / checkf.as_secs() as f64);
+    println!("get()   : {:?} seconds\n", appendf);
+    println!("        : {} op/s\n", maxf / appendf.as_secs() as f64);
 }

--- a/src/test/bench/task-perf-alloc-unwind.rs
+++ b/src/test/bench/task-perf-alloc-unwind.rs
@@ -36,7 +36,7 @@ fn run(repeat: isize, depth: isize) {
                 recurse_or_panic(depth, None)
             }).join();
         });
-        println!("iter: {}", dur);
+        println!("iter: {:?}", dur);
     }
 }
 

--- a/src/test/run-pass/issue-27401-dropflag-reinit.rs
+++ b/src/test/run-pass/issue-27401-dropflag-reinit.rs
@@ -1,0 +1,34 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// Check that when a `let`-binding occurs in a loop, its associated
+// drop-flag is reinitialized (to indicate "needs-drop" at the end of
+// the owning variable's scope).
+
+struct A<'a>(&'a mut i32);
+
+impl<'a> Drop for A<'a> {
+    fn drop(&mut self) {
+        *self.0 += 1;
+    }
+}
+
+fn main() {
+    let mut cnt = 0;
+    for i in 0..2 {
+        let a = A(&mut cnt);
+        if i == 1 { // Note that
+            break;  //  both this break
+        }           //   and also
+        drop(a);    //    this move of `a`
+        // are necessary to expose the bug
+    }
+    assert_eq!(cnt, 2);
+}

--- a/src/test/run-pass/issue-27401-dropflag-reinit.rs
+++ b/src/test/run-pass/issue-27401-dropflag-reinit.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// ignore-pretty #27582
+
 // Check that when a `let`-binding occurs in a loop, its associated
 // drop-flag is reinitialized (to indicate "needs-drop" at the end of
 // the owning variable's scope).


### PR DESCRIPTION
This commit stabilizes the `std::time` module and the `Duration` type.
`Duration::span` remains unstable, and the `Display` implementation for
`Duration` has been removed as it is still being reworked and all trait
implementations for stable types are de facto stable.

This is a [breaking-change] to those using `Duration`'s `Display`
implementation.

I'm opening this PR as a platform for discussion - there may be some method renaming to do as part of the stabilization process.
