### PR TITLE
Suggest using `ref` inline in an error

### DIFF
--- a/src/librustc_borrowck/borrowck/mod.rs
+++ b/src/librustc_borrowck/borrowck/mod.rs
@@ -705,8 +705,19 @@ impl<'a, 'tcx> BorrowckCtxt<'a, 'tcx> {
                             ol,
                             moved_lp_msg,
                             pat_ty));
-                self.tcx.sess.fileline_help(span,
-                    "use `ref` to override");
+                match self.tcx.sess.codemap().span_to_snippet(span) {
+                    Ok(string) => {
+                        self.tcx.sess.span_suggestion(
+                            span,
+                            &format!("if you would like to borrow the value instead, \
+                                      use a `ref` binding as shown:"),
+                            format!("ref {}", string));
+                    },
+                    Err(_) => {
+                        self.tcx.sess.fileline_help(span,
+                            "use `ref` to override");
+                    },
+                }
             }
 
             move_data::Captured => {

--- a/src/test/compile-fail/ref-suggestion.rs
+++ b/src/test/compile-fail/ref-suggestion.rs
@@ -1,0 +1,33 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = vec![1];
+    let y = x;
+    //~^ HELP use a `ref` binding as shown
+    //~| SUGGESTION let ref y = x;
+    x; //~ ERROR use of moved value
+
+    let x = vec![1];
+    let mut y = x;
+    //~^ HELP use a `ref` binding as shown
+    //~| SUGGESTION let ref mut y = x;
+    x; //~ ERROR use of moved value
+
+    let x = (Some(vec![1]), ());
+
+    match x {
+        (Some(y), ()) => {},
+        //~^ HELP use a `ref` binding as shown
+        //~| SUGGESTION (Some(ref y), ()) => {},
+        _ => {},
+    }
+    x; //~ ERROR use of partially moved value
+}


### PR DESCRIPTION
The error now looks like this:

```
<anon>:4:9: 4:10 error: use of moved value: `x` [E0382]
<anon>:4     foo(x);
                 ^
<anon>:3:9: 3:10 note: `x` moved here because it has type `Box<i32>`, which is moved by default
<anon>:3     let y = x;
                 ^
<anon>:3:9: 3:10 help: use `ref` to take a reference instead:
<anon>:      let ref y = x;
```
