### PR TITLE
Document temporary lifetime rules in the reference

### DIFF
--- a/src/doc/grammar.md
+++ b/src/doc/grammar.md
@@ -786,6 +786,34 @@ bound := path | lifetime
 
 ### Memory allocation and lifetime
 
+#### Temporary lifetimes
+
+```text
+E& = & ET
+   | StructName { ..., f: E&, ... }
+   | [ ..., E&, ... ]
+   | ( ..., E&, ... )
+   | {...; E&}
+   | box E&
+   | E& as ...
+   | ( E& )
+
+P& = ref X
+   | StructName { ..., P&, ... }
+   | VariantName(..., P&, ...)
+   | [ ..., P&, ... ]
+   | ( ..., P&, ... )
+   | box P&
+
+ET = *ET
+   | ET[...]
+   | ET.f
+   | (ET)
+   | <rvalue>
+```
+
+
+
 ### Memory ownership
 
 ### Variables

--- a/src/doc/reference.md
+++ b/src/doc/reference.md
@@ -2505,6 +2505,8 @@ would still count.)
 3. `ET`, which matches both rvalues like `foo()` as well as lvalues
 based on rvalues like `foo().x[2].y`.
 
+You can see these grammars in the [grammar reference](grammar.html).
+
 With these grammers, a subexpression `<rvalue>` that appears in a let
 initializer `let pat [: ty] = expr` has an extended temporary lifetime if any
 of the following conditions are met:


### PR DESCRIPTION
Fixes #12032

I am having a hard time figuring out a way to explain this that doesn't lose precision, and since this is the reference, the language can be a bit technical anyway, I guess.

r? @nikomatsakis 
