### PR TITLE
Define and use a `print_maybe_styled!` macro in libsyntax/diagnostic.rs 

### DIFF
--- a/src/libsyntax/diagnostic.rs
+++ b/src/libsyntax/diagnostic.rs
@@ -318,6 +318,20 @@ enum Destination {
     Raw(Box<Write + Send>),
 }
 
+/// Do not use this for messages that end in `\n` – use `println_maybe_styled` instead. See
+/// `EmitterWriter::print_maybe_styled` for details.
+macro_rules! print_maybe_styled {
+    ($writer: expr, $style: expr, $($arg: tt)*) => {
+        $writer.print_maybe_styled(format_args!($($arg)*), $style, false)
+    }
+}
+
+macro_rules! println_maybe_styled {
+    ($writer: expr, $style: expr, $($arg: tt)*) => {
+        $writer.print_maybe_styled(format_args!($($arg)*), $style, true)
+    }
+}
+
 impl EmitterWriter {
     pub fn stderr(color_config: ColorConfig,
                   registry: Option<diagnostics::registry::Registry>) -> EmitterWriter {
@@ -346,8 +360,9 @@ impl EmitterWriter {
     }
 
     fn print_maybe_styled(&mut self,
-                          msg: &str,
-                          color: term::attr::Attr) -> io::Result<()> {
+                          args: fmt::Arguments,
+                          color: term::attr::Attr,
+                          print_newline_at_end: bool) -> io::Result<()> {
         match self.dst {
             Terminal(ref mut t) => {
                 try!(t.attr(color));
@@ -364,17 +379,22 @@ impl EmitterWriter {
                 // once, which still leaves the opportunity for interleaved output
                 // to be miscolored. We assume this is rare enough that we don't
                 // have to worry about it.
-                if msg.ends_with("\n") {
-                    try!(t.write_all(msg[..msg.len()-1].as_bytes()));
-                    try!(t.reset());
-                    try!(t.write_all(b"\n"));
+                try!(t.write_fmt(args));
+                try!(t.reset());
+                if print_newline_at_end {
+                    t.write_all(b"\n")
                 } else {
-                    try!(t.write_all(msg.as_bytes()));
-                    try!(t.reset());
+                    Ok(())
                 }
-                Ok(())
             }
-            Raw(ref mut w) => w.write_all(msg.as_bytes()),
+            Raw(ref mut w) => {
+                try!(w.write_fmt(args));
+                if print_newline_at_end {
+                    w.write_all(b"\n")
+                } else {
+                    Ok(())
+                }
+            }
         }
     }
 
@@ -384,15 +404,14 @@ impl EmitterWriter {
             try!(write!(&mut self.dst, "{} ", topic));
         }
 
-        try!(self.print_maybe_styled(&format!("{}: ", lvl.to_string()),
-                                     term::attr::ForegroundColor(lvl.color())));
-        try!(self.print_maybe_styled(&format!("{}", msg),
-                                     term::attr::Bold));
+        try!(print_maybe_styled!(self, term::attr::ForegroundColor(lvl.color()),
+                                 "{}: ", lvl.to_string()));
+        try!(print_maybe_styled!(self, term::attr::Bold, "{}", msg));
 
         match code {
             Some(code) => {
                 let style = term::attr::ForegroundColor(term::color::BRIGHT_MAGENTA);
-                try!(self.print_maybe_styled(&format!(" [{}]", code.clone()), style));
+                try!(print_maybe_styled!(self, style, " [{}]", code.clone()));
             }
             None => ()
         }
@@ -623,8 +642,8 @@ impl EmitterWriter {
                     s.pop();
                 }
 
-                try!(self.print_maybe_styled(&format!("{}\n", s),
-                                             term::attr::ForegroundColor(lvl.color())));
+                try!(println_maybe_styled!(self, term::attr::ForegroundColor(lvl.color()),
+                                           "{}", s));
             }
         }
         Ok(())
@@ -696,9 +715,8 @@ impl EmitterWriter {
             }
         }
         s.push('^');
-        s.push('\n');
-        self.print_maybe_styled(&s[..],
-                                term::attr::ForegroundColor(lvl.color()))
+        println_maybe_styled!(self, term::attr::ForegroundColor(lvl.color()),
+                              "{}", s)
     }
 
     fn print_macro_backtrace(&mut self,


### PR DESCRIPTION
`EmitterWriter::print_maybe_styled` was basically always used with `format!`, so this macro makes some code cleaner. It should also remove some unnecessary allocations (most `print_maybe_styled` invocations allocated a `String` previously, whereas the new macro uses `write_fmt` to write the formatted string directly to the terminal).

This probably could have been part of #26838, but it’s too late now. It’s also rebased on #26838’s branch because otherwise pretty much all of the changes in this PR would conflict with the other PR’s changes.
