### PR TITLE
Revert putting stage number in --version

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -487,6 +487,10 @@ pub fn stage_str() -> Option<&'static str> {
         Some("stage0")
     } else if cfg!(stage1) {
         Some("stage1")
+    } else if cfg!(stage2) {
+        Some("stage2")
+    } else if cfg!(stage3) {
+        Some("stage3")
     } else {
         None
     }
@@ -504,9 +508,7 @@ pub fn version(binary: &str, matches: &getopts::Matches) {
         println!("commit-date: {}", unw(commit_date_str()));
         println!("host: {}", config::host_triple());
         println!("release: {}", unw(release_str()));
-        if let Some(stage) = stage_str() {
-            println!("stage: {}", stage);
-        }
+        println!("stage: {}", unw(stage_str()));
     }
 }
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -481,21 +481,6 @@ pub fn commit_date_str() -> Option<&'static str> {
     option_env!("CFG_VER_DATE")
 }
 
-/// Returns a stage string, such as "stage0".
-pub fn stage_str() -> Option<&'static str> {
-    if cfg!(stage0) {
-        Some("stage0")
-    } else if cfg!(stage1) {
-        Some("stage1")
-    } else if cfg!(stage2) {
-        Some("stage2")
-    } else if cfg!(stage3) {
-        Some("stage3")
-    } else {
-        None
-    }
-}
-
 /// Prints version information
 pub fn version(binary: &str, matches: &getopts::Matches) {
     let verbose = matches.opt_present("verbose");
@@ -508,7 +493,6 @@ pub fn version(binary: &str, matches: &getopts::Matches) {
         println!("commit-date: {}", unw(commit_date_str()));
         println!("host: {}", config::host_triple());
         println!("release: {}", unw(release_str()));
-        println!("stage: {}", unw(stage_str()));
     }
 }
 


### PR DESCRIPTION
This reverts https://github.com/rust-lang/rust/pull/26599, which puts the stage number in the output of `--version -v`, but is not supposed to put it in the 'stage2' compiler, which is what most people refer to the binary we deploy.

The picture is not so clear though because of how stage 'promotions' happen in the build and also because the windows build deploys stage3, not stage2.

cc @richo 
