### PR TITLE
msvc: Get codegen-units working

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -148,4 +148,5 @@ pub fn oom() -> ! {
 //                optimize it out).
 #[doc(hidden)]
 #[unstable(feature = "issue_14344_fixme")]
+#[cfg(stage0)]
 pub fn fixme_14344_be_sure_to_link_to_collections() {}

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -138,6 +138,7 @@ pub mod btree_set {
 // FIXME(#14344) this shouldn't be necessary
 #[doc(hidden)]
 #[unstable(feature = "issue_14344_fixme")]
+#[cfg(stage0)]
 pub fn fixme_14344_be_sure_to_link_to_collections() {}
 
 #[cfg(not(test))]

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -6431,6 +6431,7 @@ pub mod funcs {
 }
 
 #[doc(hidden)]
+#[cfg(stage0)]
 pub fn issue_14344_workaround() {} // FIXME #14344 force linkage to happen correctly
 
 #[test] fn work_on_windows() { } // FIXME #10872 needed for a happy windows

--- a/src/librustc/metadata/encoder.rs
+++ b/src/librustc/metadata/encoder.rs
@@ -2136,11 +2136,7 @@ fn encode_metadata_inner(wr: &mut Cursor<Vec<u8>>,
     let mut rbml_w = Encoder::new(wr);
 
     encode_crate_name(&mut rbml_w, &ecx.link_meta.crate_name);
-    encode_crate_triple(&mut rbml_w,
-                        &tcx.sess
-                           .opts
-                           .target_triple
-                           );
+    encode_crate_triple(&mut rbml_w, &tcx.sess.opts.target_triple);
     encode_hash(&mut rbml_w, &ecx.link_meta.crate_hash);
     encode_dylib_dependency_formats(&mut rbml_w, &ecx);
 

--- a/src/librustc_driver/driver.rs
+++ b/src/librustc_driver/driver.rs
@@ -804,8 +804,8 @@ fn write_out_deps(sess: &Session,
         match *output_type {
             config::OutputTypeExe => {
                 for output in sess.crate_types.borrow().iter() {
-                    let p = link::filename_for_input(sess, *output,
-                                                     id, &file);
+                    let p = link::filename_for_input(sess, *output, id,
+                                                     outputs);
                     out_filenames.push(p);
                 }
             }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -452,10 +452,8 @@ impl RustcDefaultCalls {
                     let metadata = driver::collect_crate_metadata(sess, attrs);
                     *sess.crate_metadata.borrow_mut() = metadata;
                     for &style in &crate_types {
-                        let fname = link::filename_for_input(sess,
-                                                             style,
-                                                             &id,
-                                                             &t_outputs.with_extension(""));
+                        let fname = link::filename_for_input(sess, style, &id,
+                                                             &t_outputs);
                         println!("{}", fname.file_name().unwrap()
                                             .to_string_lossy());
                     }

--- a/src/test/auxiliary/issue-14344-1.rs
+++ b/src/test/auxiliary/issue-14344-1.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "rlib"]
+
+pub fn foo() {}

--- a/src/test/auxiliary/issue-14344-2.rs
+++ b/src/test/auxiliary/issue-14344-2.rs
@@ -1,0 +1,13 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate issue_14344_1;
+
+pub fn bar() {}

--- a/src/test/auxiliary/issue-25185-1.rs
+++ b/src/test/auxiliary/issue-25185-1.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "rlib"]
+
+#[link(name = "rust_test_helpers", kind = "static")]
+extern {
+    pub fn rust_dbg_extern_identity_u32(u: u32) -> u32;
+}

--- a/src/test/auxiliary/issue-25185-2.rs
+++ b/src/test/auxiliary/issue-25185-2.rs
@@ -1,0 +1,13 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate issue_25185_1;
+
+pub use issue_25185_1::rust_dbg_extern_identity_u32;

--- a/src/test/run-make/extern-fn-reachable/Makefile
+++ b/src/test/run-make/extern-fn-reachable/Makefile
@@ -4,6 +4,6 @@
 TARGET_RPATH_DIR:=$(TARGET_RPATH_DIR):$(TMPDIR)
 
 all:
-	$(RUSTC) dylib.rs -o $(TMPDIR)/libdylib.so
-	$(RUSTC) main.rs
+	$(RUSTC) dylib.rs -o $(TMPDIR)/libdylib.so -C prefer-dynamic
+	$(RUSTC) main.rs -C prefer-dynamic
 	$(call RUN,main)

--- a/src/test/run-make/extra-filename-with-temp-outputs/Makefile
+++ b/src/test/run-make/extra-filename-with-temp-outputs/Makefile
@@ -2,5 +2,5 @@
 
 all:
 	$(RUSTC) -C extra-filename=bar foo.rs -C save-temps
-	rm $(TMPDIR)/foobar.o
+	rm $(TMPDIR)/foobar.0.o
 	rm $(TMPDIR)/$(call BIN,foobar)

--- a/src/test/run-pass/issue-14344.rs
+++ b/src/test/run-pass/issue-14344.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-14344-1.rs
+// aux-build:issue-14344-2.rs
+
+extern crate issue_14344_1;
+extern crate issue_14344_2;
+
+fn main() {
+    issue_14344_1::foo();
+    issue_14344_2::bar();
+}

--- a/src/test/run-pass/issue-25185.rs
+++ b/src/test/run-pass/issue-25185.rs
@@ -1,0 +1,21 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:issue-25185-1.rs
+// aux-build:issue-25185-2.rs
+
+extern crate issue_25185_2;
+
+fn main() {
+    let x = unsafe {
+        issue_25185_2::rust_dbg_extern_identity_u32(1)
+    };
+    assert_eq!(x, 1);
+}


### PR DESCRIPTION
This commit alters the implementation of multiple codegen units slightly to be
compatible with the MSVC linker. Currently the implementation will take the N
object files created by each codegen unit and will run `ld -r` to create a new
object file which is then passed along. The MSVC linker, however, is not able to
do this operation.

The compiler will now no longer attempt to assemble object files together but
will instead just pass through all the object files as usual. This implies that
rlibs may not contain more than one object file (if the library is compiled with
more than one codegen unit) and the output of `-C save-temps` will have changed
slightly as object files with the extension `0.o` will not be renamed to `o`
unless requested otherwise.
