### PR TITLE
core: fmt: debug builders pretty print tuple structs and enum variants in a single line

### DIFF
--- a/src/libcore/fmt/builders.rs
+++ b/src/libcore/fmt/builders.rs
@@ -145,12 +145,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
                 ("(", "")
             };
 
-            if self.is_pretty() {
-                let mut writer = PadAdapter::new(self.fmt);
-                fmt::write(&mut writer, format_args!("{}\n{:#?}", prefix, value))
-            } else {
-                write!(self.fmt, "{}{}{:?}", prefix, space, value)
-            }
+            write!(self.fmt, "{}{}{:?}", prefix, space, value)
         });
 
         self.has_fields = true;
@@ -162,18 +157,10 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     pub fn finish(&mut self) -> fmt::Result {
         if self.has_fields {
             self.result = self.result.and_then(|_| {
-                if self.is_pretty() {
-                    self.fmt.write_str("\n)")
-                } else {
-                    self.fmt.write_str(")")
-                }
+                self.fmt.write_str(")")
             });
         }
         self.result
-    }
-
-    fn is_pretty(&self) -> bool {
-        self.fmt.flags() & (1 << (FlagV1::Alternate as usize)) != 0
     }
 }
 

--- a/src/libcoretest/fmt/builders.rs
+++ b/src/libcoretest/fmt/builders.rs
@@ -120,6 +120,9 @@ mod debug_tuple {
 
         assert_eq!("Foo", format!("{:?}", Foo));
         assert_eq!("Foo", format!("{:#?}", Foo));
+
+        assert_eq!("None", format!("{:?}", None::<Foo>));
+        assert_eq!("None", format!("{:#?}", None::<Foo>));
     }
 
     #[test]
@@ -135,11 +138,13 @@ mod debug_tuple {
         }
 
         assert_eq!("Foo(true)", format!("{:?}", Foo));
-        assert_eq!(
-"Foo(
-    true
-)",
-                   format!("{:#?}", Foo));
+        assert_eq!("Foo(true)", format!("{:#?}", Foo));
+
+        assert_eq!("Some(1)", format!("{:?}", Some(1)));
+        assert_eq!("Some(1)", format!("{:#?}", Some(1)));
+
+        assert_eq!("(true,)", format!("{:?}", (true,)));
+        assert_eq!("(true,)", format!("{:#?}", (true,)));
     }
 
     #[test]
@@ -156,12 +161,10 @@ mod debug_tuple {
         }
 
         assert_eq!("Foo(true, 10/20)", format!("{:?}", Foo));
-        assert_eq!(
-"Foo(
-    true,
-    10/20
-)",
-                   format!("{:#?}", Foo));
+        assert_eq!("Foo(true, 10/20)", format!("{:#?}", Foo));
+
+        assert_eq!("(true, 123)", format!("{:?}", (true, 123)));
+        assert_eq!("(true, 123)", format!("{:#?}", (true, 123)));
     }
 
     #[test]
@@ -190,15 +193,16 @@ mod debug_tuple {
 
         assert_eq!("Bar(Foo(true, 10/20), \"world\")",
                    format!("{:?}", Bar));
-        assert_eq!(
-"Bar(
-    Foo(
-        true,
-        10/20
-    ),
-    \"world\"
-)",
+        assert_eq!("Bar(Foo(true, 10/20), \"world\")",
                    format!("{:#?}", Bar));
+
+        #[derive(Debug)]
+        struct Baz {
+            value: i32
+        }
+
+        assert_eq!("(true, Baz { value: 1 })", format!("{:?}", (true, Baz { value: 1 })));
+        assert_eq!("(true, Baz { value: 1 })", format!("{:#?}", (true, Baz { value: 1 })));
     }
 }
 


### PR DESCRIPTION
Before this PR, `println!("{:#?}", Some(1));` pretty prints debug output as:

```
Some(
    1
)
```

(by adding newlines and indent)

But I don't think it's _pretty_ print: it's weird, even not a preferred code style. 

`Some(1)` itself (without newlines and indent) is **pretty** print, IMO.

This PR change the pretty print output, to print tuple structs and enum variants _in a single line_. (We already pretty print tuples in this way.)

Perhaps this is a [breaking-change]? And an RFC is required? I don't known.
