### PR TITLE
librustdoc: sharpen help dialogue edges

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -72,7 +72,7 @@ r##"<!DOCTYPE html>
             <div class="search-container">
                 <input class="search-input" name="search"
                        autocomplete="off"
-                       placeholder="Click or press 'S' to search, '?' for more options..."
+                       placeholder="Click or press ‘S’ to search, ‘?’ for more options…"
                        type="search">
             </div>
         </form>
@@ -85,7 +85,7 @@ r##"<!DOCTYPE html>
 
     <div id="help" class="hidden">
         <div class="shortcuts">
-            <h1>Keyboard shortcuts</h1>
+            <h1>Keyboard Shortcuts</h1>
             <dl>
                 <dt>?</dt>
                 <dd>Show this help dialog</dd>
@@ -100,7 +100,7 @@ r##"<!DOCTYPE html>
             </dl>
         </div>
         <div class="infos">
-            <h1>Search tricks</h1>
+            <h1>Search Tricks</h1>
             <p>
                 Prefix searches with a type followed by a colon (e.g.
                 <code>fn:</code>) to restrict the search to a given type.

--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -447,7 +447,6 @@ tr.result span.primitive::after { content: ' (primitive type)'; font-style: ital
 
 #help {
     background: #e9e9e9;
-    border-radius: 4px;
     box-shadow: 0 0 6px rgba(0,0,0,.2);
     position: absolute;
     top: 300px;
@@ -461,7 +460,7 @@ tr.result span.primitive::after { content: ' (primitive type)'; font-style: ital
 
 #help dt {
     float: left;
-    border-radius: 3px;
+    border-radius: 4px;
     border: 1px solid #bfbfbf;
     background: #fff;
     width: 23px;


### PR DESCRIPTION
Sharpens the help dialogues edges by removing border-padding, which
matches better with the rest of the document.

Also increases somewhat the rounded edges of the key symbols to
make it clear they are symbols.

Also introduces closing apostrophes and ellipsis for search field
placeholder.
