### PR TITLE
Stdin::read_line: read_line does not need a mutable borrow

### DIFF
--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -227,7 +227,7 @@ impl Stdin {
     //    in which case it will wait for the Enter key to be pressed before
     ///   continuing
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn read_line(&mut self, buf: &mut String) -> io::Result<usize> {
+    pub fn read_line(&self, buf: &mut String) -> io::Result<usize> {
         self.lock().read_line(buf)
     }
 }


### PR DESCRIPTION
This fixes #26890.

To be honest, the local compile-test is still running. This just takes so long. But this looks trivial enough...
