### PR TITLE
Use vec![] for vector creation

### DIFF
--- a/src/libcollections/bit.rs
+++ b/src/libcollections/bit.rs
@@ -283,7 +283,7 @@ impl BitVec {
     pub fn from_elem(nbits: usize, bit: bool) -> BitVec {
         let nblocks = blocks_for_bits(nbits);
         let mut bit_vec = BitVec {
-            storage: repeat(if bit { !0 } else { 0 }).take(nblocks).collect(),
+            storage: vec![if bit { !0 } else { 0 }; nblocks],
             nbits: nbits
         };
         bit_vec.fix_last_block();

--- a/src/libcollectionstest/slice.rs
+++ b/src/libcollectionstest/slice.rs
@@ -1318,7 +1318,7 @@ mod bench {
 
     #[bench]
     fn mut_iterator(b: &mut Bencher) {
-        let mut v: Vec<_> = repeat(0).take(100).collect();
+        let mut v = vec![0; 100];
 
         b.iter(|| {
             let mut i = 0;
@@ -1419,7 +1419,7 @@ mod bench {
     #[bench]
     fn zero_1kb_from_elem(b: &mut Bencher) {
         b.iter(|| {
-            repeat(0u8).take(1024).collect::<Vec<_>>()
+            vec![0u8; 1024]
         });
     }
 
@@ -1467,7 +1467,7 @@ mod bench {
     fn random_inserts(b: &mut Bencher) {
         let mut rng = thread_rng();
         b.iter(|| {
-            let mut v: Vec<_> = repeat((0, 0)).take(30).collect();
+            let mut v = vec![(0, 0); 30];
             for _ in 0..100 {
                 let l = v.len();
                 v.insert(rng.gen::<usize>() % (l + 1),
@@ -1479,7 +1479,7 @@ mod bench {
     fn random_removes(b: &mut Bencher) {
         let mut rng = thread_rng();
         b.iter(|| {
-            let mut v: Vec<_> = repeat((0, 0)).take(130).collect();
+            let mut v = vec![(0, 0); 130];
             for _ in 0..100 {
                 let l = v.len();
                 v.remove(rng.gen::<usize>() % l);

--- a/src/libcoretest/ptr.rs
+++ b/src/libcoretest/ptr.rs
@@ -10,7 +10,6 @@
 
 use core::ptr::*;
 use core::mem;
-use std::iter::repeat;
 
 #[test]
 fn test() {
@@ -110,7 +109,7 @@ fn test_as_mut() {
 #[test]
 fn test_ptr_addition() {
     unsafe {
-        let xs = repeat(5).take(16).collect::<Vec<_>>();
+        let xs = vec![5; 16];
         let mut ptr = xs.as_ptr();
         let end = ptr.offset(16);
 
@@ -128,7 +127,7 @@ fn test_ptr_addition() {
             m_ptr = m_ptr.offset(1);
         }
 
-        assert!(xs_mut == repeat(10).take(16).collect::<Vec<_>>());
+        assert!(xs_mut == vec![10; 16]);
     }
 }
 

--- a/src/libgraphviz/lib.rs
+++ b/src/libgraphviz/lib.rs
@@ -599,7 +599,6 @@ mod tests {
     use std::io;
     use std::io::prelude::*;
     use std::borrow::IntoCow;
-    use std::iter::repeat;
 
     /// each node is an index in a vector in the graph.
     type Node = usize;
@@ -647,7 +646,7 @@ mod tests {
         fn to_opt_strs(self) -> Vec<Option<&'static str>> {
             match self {
                 UnlabelledNodes(len)
-                    => repeat(None).take(len).collect(),
+                    => vec![None; len],
                 AllNodesLabelled(lbls)
                     => lbls.into_iter().map(
                         |l|Some(l)).collect(),

--- a/src/librand/reseeding.rs
+++ b/src/librand/reseeding.rs
@@ -186,7 +186,7 @@ mod tests {
     const FILL_BYTES_V_LEN: usize = 13579;
     #[test]
     fn test_rng_fill_bytes() {
-        let mut v = repeat(0).take(FILL_BYTES_V_LEN).collect::<Vec<_>>();
+        let mut v = vec![0; FILL_BYTES_V_LEN];
         ::test::rng().fill_bytes(&mut v);
 
         // Sanity test: if we've gotten here, `fill_bytes` has not infinitely

--- a/src/librustc/middle/check_match.rs
+++ b/src/librustc/middle/check_match.rs
@@ -704,7 +704,7 @@ fn is_useful(cx: &MatchCheckCtxt,
                 match is_useful(cx, &matrix, v.tail(), witness) {
                     UsefulWithWitness(pats) => {
                         let arity = constructor_arity(cx, &constructor, left_ty);
-                        let wild_pats: Vec<_> = repeat(DUMMY_WILD_PAT).take(arity).collect();
+                        let wild_pats = vec![DUMMY_WILD_PAT; arity];
                         let enum_pat = construct_witness(cx, &constructor, wild_pats, left_ty);
                         let mut new_pats = vec![enum_pat];
                         new_pats.extend(pats);
@@ -862,7 +862,7 @@ pub fn specialize<'a>(cx: &MatchCheckCtxt, r: &[&'a Pat],
     } = raw_pat(r[col]);
     let head: Option<Vec<&Pat>> = match *node {
         ast::PatWild(_) =>
-            Some(repeat(DUMMY_WILD_PAT).take(arity).collect()),
+            Some(vec![DUMMY_WILD_PAT; arity]),
 
         ast::PatIdent(_, _, _) => {
             let opt_def = cx.tcx.def_map.borrow().get(&pat_id).map(|d| d.full_def());
@@ -875,7 +875,7 @@ pub fn specialize<'a>(cx: &MatchCheckCtxt, r: &[&'a Pat],
                 } else {
                     None
                 },
-                _ => Some(repeat(DUMMY_WILD_PAT).take(arity).collect())
+                _ => Some(vec![DUMMY_WILD_PAT; arity])
             }
         }
 
@@ -889,7 +889,7 @@ pub fn specialize<'a>(cx: &MatchCheckCtxt, r: &[&'a Pat],
                 DefVariant(..) | DefStruct(..) => {
                     Some(match args {
                         &Some(ref args) => args.iter().map(|p| &**p).collect(),
-                        &None => repeat(DUMMY_WILD_PAT).take(arity).collect(),
+                        &None => vec![DUMMY_WILD_PAT; arity],
                     })
                 }
                 _ => None

--- a/src/librustc/middle/dataflow.rs
+++ b/src/librustc/middle/dataflow.rs
@@ -21,7 +21,6 @@ use middle::cfg::CFGIndex;
 use middle::ty;
 use std::io;
 use std::usize;
-use std::iter::repeat;
 use syntax::ast;
 use syntax::ast_util::IdRange;
 use syntax::visit;
@@ -239,11 +238,11 @@ impl<'a, 'tcx, O:DataFlowOperator> DataFlowContext<'a, 'tcx, O> {
 
         let entry = if oper.initial_value() { usize::MAX } else {0};
 
-        let zeroes: Vec<_> = repeat(0).take(num_nodes * words_per_id).collect();
-        let gens: Vec<_> = zeroes.clone();
-        let kills1: Vec<_> = zeroes.clone();
-        let kills2: Vec<_> = zeroes;
-        let on_entry: Vec<_> = repeat(entry).take(num_nodes * words_per_id).collect();
+        let zeroes = vec![0; num_nodes * words_per_id];
+        let gens = zeroes.clone();
+        let kills1 = zeroes.clone();
+        let kills2 = zeroes;
+        let on_entry = vec![entry; num_nodes * words_per_id];
 
         let nodeid_to_index = build_nodeid_to_index(decl, cfg);
 
@@ -511,7 +510,7 @@ impl<'a, 'tcx, O:DataFlowOperator+Clone+'static> DataFlowContext<'a, 'tcx, O> {
                 changed: true
             };
 
-            let mut temp: Vec<_> = repeat(0).take(words_per_id).collect();
+            let mut temp = vec![0; words_per_id];
             while propcx.changed {
                 propcx.changed = false;
                 propcx.reset(&mut temp);

--- a/src/librustc/middle/infer/region_inference/mod.rs
+++ b/src/librustc/middle/infer/region_inference/mod.rs
@@ -34,7 +34,6 @@ use util::nodemap::{FnvHashMap, FnvHashSet};
 use std::cell::{Cell, RefCell};
 use std::cmp::Ordering::{self, Less, Greater, Equal};
 use std::fmt;
-use std::iter::repeat;
 use std::u32;
 use syntax::ast;
 
@@ -1304,7 +1303,7 @@ impl<'a, 'tcx> RegionVarBindings<'a, 'tcx> {
         // idea is to report errors that derive from independent
         // regions of the graph, but not those that derive from
         // overlapping locations.
-        let mut dup_vec: Vec<_> = repeat(u32::MAX).take(self.num_vars() as usize).collect();
+        let mut dup_vec = vec![u32::MAX; self.num_vars() as usize];
 
         for idx in 0..self.num_vars() as usize {
             match var_data[idx].value {

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -119,7 +119,6 @@ use util::nodemap::NodeMap;
 use std::{fmt, usize};
 use std::io::prelude::*;
 use std::io;
-use std::iter::repeat;
 use std::rc::Rc;
 use syntax::ast::{self, NodeId, Expr};
 use syntax::codemap::{BytePos, original_sp, Span};
@@ -566,8 +565,8 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
         Liveness {
             ir: ir,
             s: specials,
-            successors: repeat(invalid_node()).take(num_live_nodes).collect(),
-            users: repeat(invalid_users()).take(num_live_nodes * num_vars).collect(),
+            successors: vec![invalid_node(); num_live_nodes],
+            users: vec![invalid_users(); num_live_nodes * num_vars],
             loop_scope: Vec::new(),
             break_ln: NodeMap(),
             cont_ln: NodeMap(),

--- a/src/librustc_back/sha2.rs
+++ b/src/librustc_back/sha2.rs
@@ -12,7 +12,6 @@
 //! use. This implementation is not intended for external use or for any use where security is
 //! important.
 
-use std::iter::repeat;
 use std::slice::bytes::{MutableByteVector, copy_memory};
 use serialize::hex::ToHex;
 
@@ -255,7 +254,7 @@ pub trait Digest {
     /// Convenience function that retrieves the result of a digest as a
     /// newly allocated vec of bytes.
     fn result_bytes(&mut self) -> Vec<u8> {
-        let mut buf: Vec<u8> = repeat(0).take((self.output_bits()+7)/8).collect();
+        let mut buf = vec![0; (self.output_bits()+7)/8];
         self.result(&mut buf);
         buf
     }
@@ -534,7 +533,6 @@ mod tests {
     use self::rand::Rng;
     use self::rand::isaac::IsaacRng;
     use serialize::hex::FromHex;
-    use std::iter::repeat;
     use std::u64;
     use super::{Digest, Sha256, FixedBuffer};
 
@@ -613,7 +611,7 @@ mod tests {
     /// correct.
     fn test_digest_1million_random<D: Digest>(digest: &mut D, blocksize: usize, expected: &str) {
         let total_size = 1000000;
-        let buffer: Vec<u8> = repeat('a' as u8).take(blocksize * 2).collect();
+        let buffer = vec![b'a'; blocksize * 2];
         let mut rng = IsaacRng::new_unseeded();
         let mut count = 0;
 

--- a/src/librustc_data_structures/bitvec.rs
+++ b/src/librustc_data_structures/bitvec.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::iter;
-
 /// A very simple BitVector type.
 pub struct BitVector {
     data: Vec<u64>
@@ -18,7 +16,7 @@ pub struct BitVector {
 impl BitVector {
     pub fn new(num_bits: usize) -> BitVector {
         let num_words = (num_bits + 63) / 64;
-        BitVector { data: iter::repeat(0).take(num_words).collect() }
+        BitVector { data: vec![0; num_words] }
     }
 
     fn word_mask(&self, bit: usize) -> (usize, u64) {

--- a/src/librustc_trans/trans/cabi_x86_64.rs
+++ b/src/librustc_trans/trans/cabi_x86_64.rs
@@ -21,7 +21,6 @@ use trans::context::CrateContext;
 use trans::type_::Type;
 
 use std::cmp;
-use std::iter::repeat;
 
 #[derive(Clone, Copy, PartialEq)]
 enum RegClass {
@@ -319,7 +318,7 @@ fn classify_ty(ty: Type) -> Vec<RegClass> {
     }
 
     let words = (ty_size(ty) + 7) / 8;
-    let mut cls: Vec<_> = repeat(NoClass).take(words).collect();
+    let mut cls = vec![NoClass; words];
     if words > 4 {
         all_mem(&mut cls);
         return cls;

--- a/src/librustc_trans/trans/consts.rs
+++ b/src/librustc_trans/trans/consts.rs
@@ -35,7 +35,6 @@ use middle::subst::Substs;
 use middle::ty::{self, Ty};
 use util::nodemap::NodeMap;
 
-use std::iter::repeat;
 use libc::c_uint;
 use syntax::{ast, ast_util};
 use syntax::parse::token;
@@ -780,7 +779,7 @@ fn const_expr_unadjusted<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>,
             let llunitty = type_of::type_of(cx, unit_ty);
             let n = cx.tcx().eval_repeat_count(count);
             let unit_val = const_expr(cx, &**elem, param_substs, fn_args).0;
-            let vs: Vec<_> = repeat(unit_val).take(n).collect();
+            let vs = vec![unit_val; n];
             if val_ty(unit_val) != llunitty {
                 C_struct(cx, &vs[..], false)
             } else {

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -83,7 +83,6 @@ use syntax::{ast, ast_util, codemap};
 use syntax::parse::token::InternedString;
 use syntax::ptr::P;
 use syntax::parse::token;
-use std::iter::repeat;
 use std::mem;
 
 // Destinations
@@ -1401,7 +1400,7 @@ fn trans_struct<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
     let tcx = bcx.tcx();
     with_field_tys(tcx, ty, Some(expr_id), |discr, field_tys| {
-        let mut need_base: Vec<bool> = repeat(true).take(field_tys.len()).collect();
+        let mut need_base = vec![true; field_tys.len()];
 
         let numbered_fields = fields.iter().map(|field| {
             let opt_pos =

--- a/src/librustc_trans/trans/type_.rs
+++ b/src/librustc_trans/trans/type_.rs
@@ -23,7 +23,6 @@ use std::ffi::CString;
 use std::mem;
 use std::ptr;
 use std::cell::RefCell;
-use std::iter::repeat;
 
 use libc::c_uint;
 
@@ -253,7 +252,7 @@ impl Type {
             if n_elts == 0 {
                 return Vec::new();
             }
-            let mut elts: Vec<_> = repeat(Type { rf: ptr::null_mut() }).take(n_elts).collect();
+            let mut elts = vec![Type { rf: ptr::null_mut() }; n_elts];
             llvm::LLVMGetStructElementTypes(self.to_ref(),
                                             elts.as_mut_ptr() as *mut TypeRef);
             elts
@@ -267,7 +266,7 @@ impl Type {
     pub fn func_params(&self) -> Vec<Type> {
         unsafe {
             let n_args = llvm::LLVMCountParamTypes(self.to_ref()) as usize;
-            let mut args: Vec<_> = repeat(Type { rf: ptr::null_mut() }).take(n_args).collect();
+            let mut args = vec![Type { rf: ptr::null_mut() }; n_args];
             llvm::LLVMGetParamTypes(self.to_ref(),
                                     args.as_mut_ptr() as *mut TypeRef);
             args

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -64,7 +64,6 @@ use rscope::{self, UnelidableRscope, RegionScope, ElidableRscope, ExplicitRscope
 use util::common::{ErrorReported, FN_OUTPUT_NAME};
 use util::nodemap::FnvHashSet;
 
-use std::iter::repeat;
 use std::slice;
 use syntax::{abi, ast, ast_util};
 use syntax::codemap::{Span, Pos};
@@ -588,7 +587,7 @@ fn convert_parenthesized_parameters<'tcx>(this: &AstConv<'tcx>,
                                                0, &region_substs, a_t))
                    .collect::<Vec<Ty<'tcx>>>();
 
-    let input_params: Vec<_> = repeat(String::new()).take(inputs.len()).collect();
+    let input_params = vec![String::new(); inputs.len()];
     let implied_output_region = find_implied_output_region(this.tcx(), &inputs, input_params);
 
     let input_ty = this.tcx().mk_tup(inputs);

--- a/src/librustc_typeck/check/method/confirm.rs
+++ b/src/librustc_typeck/check/method/confirm.rs
@@ -20,7 +20,6 @@ use middle::infer;
 use middle::infer::InferCtxt;
 use syntax::ast;
 use syntax::codemap::Span;
-use std::iter::repeat;
 
 struct ConfirmContext<'a, 'tcx:'a> {
     fcx: &'a FnCtxt<'a, 'tcx>,
@@ -322,7 +321,7 @@ impl<'a,'tcx> ConfirmContext<'a,'tcx> {
             } else if num_supplied_types != num_method_types {
                 span_err!(self.tcx().sess, self.span, E0036,
                     "incorrect number of type parameters given for this method");
-                repeat(self.tcx().types.err).take(num_method_types).collect()
+                vec![self.tcx().types.err; num_method_types]
             } else {
                 supplied_method_types
             }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -108,7 +108,6 @@ use util::lev_distance::lev_distance;
 
 use std::cell::{Cell, Ref, RefCell};
 use std::mem::replace;
-use std::iter::repeat;
 use std::slice;
 use syntax::{self, abi, attr};
 use syntax::attr::AttrMetaMethods;
@@ -4340,7 +4339,7 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
         def::DefTyParam(..) => {
             // Everything but the final segment should have no
             // parameters at all.
-            segment_spaces = repeat(None).take(segments.len() - 1).collect();
+            segment_spaces = vec![None; segments.len() - 1];
             segment_spaces.push(Some(subst::TypeSpace));
         }
 
@@ -4348,7 +4347,7 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
         def::DefFn(..) |
         def::DefConst(..) |
         def::DefStatic(..) => {
-            segment_spaces = repeat(None).take(segments.len() - 1).collect();
+            segment_spaces = vec![None; segments.len() - 1];
             segment_spaces.push(Some(subst::FnSpace));
         }
 
@@ -4362,7 +4361,7 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
             }
 
             if segments.len() >= 2 {
-                segment_spaces = repeat(None).take(segments.len() - 2).collect();
+                segment_spaces = vec![None; segments.len() - 2];
                 segment_spaces.push(Some(subst::TypeSpace));
                 segment_spaces.push(Some(subst::FnSpace));
             } else {
@@ -4382,7 +4381,7 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
             }
 
             if segments.len() >= 2 {
-                segment_spaces = repeat(None).take(segments.len() - 2).collect();
+                segment_spaces = vec![None; segments.len() - 2];
                 segment_spaces.push(Some(subst::TypeSpace));
                 segment_spaces.push(None);
             } else {
@@ -4400,7 +4399,7 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
         def::DefRegion(..) |
         def::DefLabel(..) |
         def::DefUpvar(..) => {
-            segment_spaces = repeat(None).take(segments.len()).collect();
+            segment_spaces = vec![None; segments.len()];
         }
     }
     assert_eq!(segment_spaces.len(), segments.len());
@@ -4681,7 +4680,7 @@ pub fn instantiate_path<'a, 'tcx>(fcx: &FnCtxt<'a, 'tcx>,
                 if required_len == 1 {""} else {"s"},
                 provided_len,
                 if provided_len == 1 {""} else {"s"});
-            substs.types.replace(space, repeat(fcx.tcx().types.err).take(desired.len()).collect());
+            substs.types.replace(space, vec![fcx.tcx().types.err; desired.len()]);
             return;
         }
 
@@ -4813,7 +4812,7 @@ pub fn check_bounds_are_used<'a, 'tcx>(ccx: &CrateCtxt<'a, 'tcx>,
 
     // make a vector of booleans initially false, set to true when used
     if tps.is_empty() { return; }
-    let mut tps_used: Vec<_> = repeat(false).take(tps.len()).collect();
+    let mut tps_used = vec![false; tps.len()];
 
     for leaf_ty in ty.walk() {
         if let ty::TyParam(ParamTy {idx, ..}) = leaf_ty.sty {

--- a/src/librustc_typeck/rscope.rs
+++ b/src/librustc_typeck/rscope.rs
@@ -13,7 +13,6 @@ use middle::ty;
 use middle::ty_fold;
 
 use std::cell::Cell;
-use std::iter::repeat;
 use syntax::codemap::Span;
 
 #[derive(Clone)]
@@ -147,7 +146,7 @@ impl RegionScope for ElidableRscope {
                     count: usize)
                     -> Result<Vec<ty::Region>, Option<Vec<ElisionFailureInfo>>>
     {
-        Ok(repeat(self.default).take(count).collect())
+        Ok(vec![self.default; count])
     }
 }
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1920,7 +1920,7 @@ fn item_trait(w: &mut fmt::Formatter, cx: &Context, it: &clean::Item,
     try!(write!(w, r#"<script type="text/javascript" async
                               src="{root_path}/implementors/{path}/{ty}.{name}.js">
                       </script>"#,
-                root_path = repeat("..").take(cx.current.len()).collect::<Vec<_>>().connect("/"),
+                root_path = vec![".."; cx.current.len()].connect("/"),
                 path = if ast_util::is_local(it.def_id) {
                     cx.current.connect("/")
                 } else {

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1638,7 +1638,7 @@ mod test_map {
 
     use super::HashMap;
     use super::Entry::{Occupied, Vacant};
-    use iter::{range_inclusive, repeat};
+    use iter::range_inclusive;
     use cell::RefCell;
     use rand::{thread_rng, Rng};
 
@@ -1698,7 +1698,7 @@ mod test_map {
     #[test]
     fn test_drops() {
         DROP_VECTOR.with(|slot| {
-            *slot.borrow_mut() = repeat(0).take(200).collect();
+            *slot.borrow_mut() = vec![0; 200];
         });
 
         {
@@ -1757,7 +1757,7 @@ mod test_map {
     #[test]
     fn test_move_iter_drops() {
         DROP_VECTOR.with(|v| {
-            *v.borrow_mut() = repeat(0).take(200).collect();
+            *v.borrow_mut() = vec![0; 200];
         });
 
         let hm = {

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -13,7 +13,6 @@ use io::prelude::*;
 
 use cmp;
 use io::{self, SeekFrom, Error, ErrorKind};
-use iter::repeat;
 use slice;
 
 /// A `Cursor` is a type which wraps a non-I/O object to provide a `Seek`
@@ -143,7 +142,9 @@ impl Write for Cursor<Vec<u8>> {
         // currently are
         let pos = self.position();
         let amt = pos.saturating_sub(self.inner.len() as u64);
-        self.inner.extend(repeat(0).take(amt as usize));
+        // use `resize` so that the zero filling is as efficient as possible
+        let len = self.inner.len();
+        self.inner.resize(len + amt as usize, 0);
 
         // Figure out what bytes will be used to overwrite what's currently
         // there (left), and what will be appended on the end (right)

--- a/src/libstd/sys/windows/stdio.rs
+++ b/src/libstd/sys/windows/stdio.rs
@@ -12,7 +12,6 @@ use prelude::v1::*;
 use io::prelude::*;
 
 use io::{self, Cursor};
-use iter::repeat;
 use libc;
 use ptr;
 use str;
@@ -94,7 +93,7 @@ impl Stdin {
         let mut utf8 = self.utf8.lock().unwrap();
         // Read more if the buffer is empty
         if utf8.position() as usize == utf8.get_ref().len() {
-            let mut utf16: Vec<u16> = repeat(0u16).take(0x1000).collect();
+            let mut utf16 = vec![0u16; 0x1000];
             let mut num = 0;
             try!(cvt(unsafe {
                 c::ReadConsoleW(handle,

--- a/src/libsyntax/ext/format.rs
+++ b/src/libsyntax/ext/format.rs
@@ -23,7 +23,6 @@ use parse::token;
 use ptr::P;
 
 use std::collections::HashMap;
-use std::iter::repeat;
 
 #[derive(PartialEq)]
 enum ArgumentType {
@@ -469,7 +468,7 @@ impl<'a, 'b> Context<'a, 'b> {
     /// to
     fn into_expr(mut self) -> P<ast::Expr> {
         let mut locals = Vec::new();
-        let mut names: Vec<_> = repeat(None).take(self.name_positions.len()).collect();
+        let mut names = vec![None; self.name_positions.len()];
         let mut pats = Vec::new();
         let mut heads = Vec::new();
 

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -61,7 +61,6 @@
 
 use std::io;
 use std::string;
-use std::iter::repeat;
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum Breaks {
@@ -166,9 +165,9 @@ pub fn mk_printer<'a>(out: Box<io::Write+'a>, linewidth: usize) -> Printer<'a> {
     // fall behind.
     let n: usize = 3 * linewidth;
     debug!("mk_printer {}", linewidth);
-    let token: Vec<Token> = repeat(Token::Eof).take(n).collect();
-    let size: Vec<isize> = repeat(0).take(n).collect();
-    let scan_stack: Vec<usize> = repeat(0).take(n).collect();
+    let token = vec![Token::Eof; n];
+    let size = vec![0_isize; n];
+    let scan_stack = vec![0_usize; n];
     Printer {
         out: out,
         buf_len: n,

--- a/src/test/bench/core-std.rs
+++ b/src/test/bench/core-std.rs
@@ -12,7 +12,6 @@
 
 #![feature(rand, vec_push_all, duration, duration_span)]
 
-use std::iter::repeat;
 use std::mem::swap;
 use std::env;
 use std::__rand::{thread_rng, Rng};
@@ -56,7 +55,7 @@ fn maybe_run_test<F>(argv: &[String], name: String, test: F) where F: FnOnce() {
 }
 
 fn shift_push() {
-    let mut v1 = repeat(1).take(30000).collect::<Vec<_>>();
+    let mut v1 = vec![1; 30000];
     let mut v2 = Vec::new();
 
     while !v1.is_empty() {
@@ -70,7 +69,7 @@ fn vec_plus() {
     let mut v = Vec::new();
     let mut i = 0;
     while i < 1500 {
-        let rv = repeat(i).take(r.gen_range(0, i + 1)).collect::<Vec<_>>();
+        let rv = vec![i; r.gen_range(0, i + 1)];
         if r.gen() {
             v.extend(rv);
         } else {
@@ -88,7 +87,7 @@ fn vec_append() {
     let mut v = Vec::new();
     let mut i = 0;
     while i < 1500 {
-        let rv = repeat(i).take(r.gen_range(0, i + 1)).collect::<Vec<_>>();
+        let rv = vec![i; r.gen_range(0, i + 1)];
         if r.gen() {
             let mut t = v.clone();
             t.push_all(&rv);
@@ -108,7 +107,7 @@ fn vec_push_all() {
 
     let mut v = Vec::new();
     for i in 0..1500 {
-        let mut rv = repeat(i).take(r.gen_range(0, i + 1)).collect::<Vec<_>>();
+        let mut rv = vec![i; r.gen_range(0, i + 1)];
         if r.gen() {
             v.push_all(&rv);
         }

--- a/src/test/bench/shootout-fasta-redux.rs
+++ b/src/test/bench/shootout-fasta-redux.rs
@@ -42,7 +42,6 @@ use std::cmp::min;
 use std::env;
 use std::io;
 use std::io::prelude::*;
-use std::iter::repeat;
 
 const LINE_LEN: usize = 60;
 const LOOKUP_SIZE: usize = 4 * 1024;
@@ -121,7 +120,7 @@ impl<'a, W: Write> RepeatFasta<'a, W> {
 
     fn make(&mut self, n: usize) -> io::Result<()> {
         let alu_len = self.alu.len();
-        let mut buf = repeat(0).take(alu_len + LINE_LEN).collect::<Vec<_>>();
+        let mut buf = vec![0; alu_len + LINE_LEN];
         let alu: &[u8] = self.alu.as_bytes();
 
         for (slot, val) in buf.iter_mut().zip(alu) {

--- a/src/test/bench/shootout-meteor.rs
+++ b/src/test/bench/shootout-meteor.rs
@@ -42,7 +42,6 @@
 
 #![feature(iter_cmp)]
 
-use std::iter::repeat;
 use std::sync::Arc;
 use std::sync::mpsc::channel;
 use std::thread;
@@ -221,7 +220,7 @@ fn get_id(m: u64) -> u8 {
 
 // Converts a list of mask to a Vec<u8>.
 fn to_vec(raw_sol: &List<u64>) -> Vec<u8> {
-    let mut sol = repeat('.' as u8).take(50).collect::<Vec<_>>();
+    let mut sol = vec![b'.'; 50];
     for &m in raw_sol.iter() {
         let id = '0' as u8 + get_id(m);
         for i in 0..50 {

--- a/src/test/bench/shootout-spectralnorm.rs
+++ b/src/test/bench/shootout-spectralnorm.rs
@@ -43,7 +43,6 @@
 #![allow(non_snake_case)]
 #![feature(unboxed_closures, iter_arith, core_simd, scoped)]
 
-use std::iter::repeat;
 use std::thread;
 use std::env;
 use std::simd::f64x2;
@@ -62,7 +61,7 @@ fn main() {
 
 fn spectralnorm(n: usize) -> f64 {
     assert!(n % 2 == 0, "only even lengths are accepted");
-    let mut u = repeat(1.0).take(n).collect::<Vec<_>>();
+    let mut u = vec![1.0; n];
     let mut v = u.clone();
     let mut tmp = v.clone();
     for _ in 0..10 {

--- a/src/test/bench/sudoku.rs
+++ b/src/test/bench/sudoku.rs
@@ -15,7 +15,6 @@
 
 use std::io::prelude::*;
 use std::io;
-use std::iter::repeat;
 use std::env;
 
 // Computes a single solution to a given 9x9 sudoku
@@ -59,8 +58,7 @@ impl Sudoku {
         reader.read_line(&mut s).unwrap();
         assert_eq!(s, "9,9\n");
 
-        let mut g = repeat(vec![0, 0, 0, 0, 0, 0, 0, 0, 0])
-                          .take(10).collect::<Vec<_>>();
+        let mut g = vec![vec![0, 0, 0, 0, 0, 0, 0, 0, 0]; 10];
         for line in reader.lines() {
             let line = line.unwrap();
             let comps: Vec<&str> = line

--- a/src/test/run-pass/issue-3563-3.rs
+++ b/src/test/run-pass/issue-3563-3.rs
@@ -68,12 +68,9 @@ impl Drop for AsciiArt {
 // If there is a canonical constructor it is typically named the same as the type.
 // Other constructor sort of functions are typically named from_foo, from_bar, etc.
 fn AsciiArt(width: usize, height: usize, fill: char) -> AsciiArt {
-    // Use an anonymous function to build a vector of vectors containing
-    // blank characters for each position in our canvas.
-    let mut lines = Vec::new();
-    for _ in 0..height {
-        lines.push(repeat('.').take(width).collect::<Vec<_>>());
-    }
+    // Build a vector of vectors containing blank characters for each position in
+    // our canvas.
+    let lines = vec![vec!['.'; width]; height];
 
     // Rust code often returns values by omitting the trailing semi-colon
     // instead of using an explicit return statement.

--- a/src/test/run-pass/realloc-16687.rs
+++ b/src/test/run-pass/realloc-16687.rs
@@ -19,7 +19,6 @@ extern crate alloc;
 
 use alloc::heap;
 use std::ptr;
-use std::iter::repeat;
 
 fn main() {
     unsafe {
@@ -29,7 +28,7 @@ fn main() {
 
 unsafe fn test_triangle() -> bool {
     static COUNT : usize = 16;
-    let mut ascend = repeat(ptr::null_mut()).take(COUNT).collect::<Vec<_>>();
+    let mut ascend = vec![ptr::null_mut(); COUNT];
     let ascend = &mut *ascend;
     static ALIGN : usize = 1;
 


### PR DESCRIPTION
In a followup to PR #26849, improve one more location for I/O where
we can use `Vec::resize` to ensure better performance when zeroing
buffers.

Use the `vec![elt; n]` macro everywhere we can in the tree. It replaces
`repeat(elt).take(n).collect()` which is more verbose, requires type
hints, and right now produces worse code. `vec![]` is preferable for vector
initialization.

The `vec![]` replacement touches upon one I/O path too, Stdin::read
for windows, and that should be a small improvement.

r? @alexcrichton 
