### PR TITLE
Change tuple Debug impls to use builders

### DIFF
--- a/src/libcore/fmt/builders.rs
+++ b/src/libcore/fmt/builders.rs
@@ -175,6 +175,12 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     fn is_pretty(&self) -> bool {
         self.fmt.flags() & (1 << (FlagV1::Alternate as usize)) != 0
     }
+
+    /// Returns the wrapped `Formatter`.
+    #[unstable(feature = "debug_builder_formatter", reason = "recently added")]
+    pub fn formatter(&mut self) -> &mut fmt::Formatter<'b> {
+        &mut self.fmt
+    }
 }
 
 struct DebugInner<'a, 'b: 'a> {

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1488,20 +1488,10 @@ macro_rules! tuple {
         impl<$($name:Debug),*> Debug for ($($name,)*) {
             #[allow(non_snake_case, unused_assignments)]
             fn fmt(&self, f: &mut Formatter) -> Result {
-                try!(write!(f, "("));
+                let mut builder = f.debug_tuple("");
                 let ($(ref $name,)*) = *self;
-                let mut n = 0;
-                $(
-                    if n > 0 {
-                        try!(write!(f, ", "));
-                    }
-                    try!(write!(f, "{:?}", *$name));
-                    n += 1;
-                )*
-                if n == 1 {
-                    try!(write!(f, ","));
-                }
-                write!(f, ")")
+                $(builder.field($name);)*
+                builder.finish()
             }
         }
         peel! { $($name,)* }

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1490,7 +1490,16 @@ macro_rules! tuple {
             fn fmt(&self, f: &mut Formatter) -> Result {
                 let mut builder = f.debug_tuple("");
                 let ($(ref $name,)*) = *self;
-                $(builder.field($name);)*
+                let mut n = 0;
+                $(
+                    builder.field($name);
+                    n += 1;
+                )*
+
+                if n == 1 {
+                    try!(write!(builder.formatter(), ","));
+                }
+
                 builder.finish()
             }
         }

--- a/src/libcoretest/tuple.rs
+++ b/src/libcoretest/tuple.rs
@@ -60,7 +60,7 @@ fn test_tuple_cmp() {
 #[test]
 fn test_show() {
     let s = format!("{:?}", (1,));
-    assert_eq!(s, "(1)");
+    assert_eq!(s, "(1,)");
     let s = format!("{:?}", (1, true));
     assert_eq!(s, "(1, true)");
     let s = format!("{:?}", (1, "hi", true));

--- a/src/libcoretest/tuple.rs
+++ b/src/libcoretest/tuple.rs
@@ -60,7 +60,7 @@ fn test_tuple_cmp() {
 #[test]
 fn test_show() {
     let s = format!("{:?}", (1,));
-    assert_eq!(s, "(1,)");
+    assert_eq!(s, "(1)");
     let s = format!("{:?}", (1, true));
     assert_eq!(s, "(1, true)");
     let s = format!("{:?}", (1, "hi", true));


### PR DESCRIPTION
This does change the Debug output for 1-tuples to `(foo)` instead of `(foo,)` but I don't think it's that big  of a deal.

r? @alexcrichton 
