### PR TITLE
Show better diagnostics for unicode escapes

### DIFF
--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -742,7 +742,7 @@ impl<'a> StringReader<'a> {
                                 let valid = self.scan_unicode_escape(delim);
                                 if valid && ascii_only {
                                     self.err_span_(
-                                        escaped_pos,
+                                        start,
                                         self.last_pos,
                                         "unicode escape sequences cannot be used as a byte or in \
                                         a byte string"
@@ -753,9 +753,9 @@ impl<'a> StringReader<'a> {
                                 }
                             }
                             'u' if !ascii_only => {
-                                self.err_span_(escaped_pos, self.last_pos,
+                                self.err_span_(start, self.last_pos,
                                     "incomplete unicode escape sequence");
-                                self.help_span_(escaped_pos, self.last_pos,
+                                self.help_span_(start, self.last_pos,
                                     "format of unicode escape sequences is `\\u{…}`");
                                 false
                             }
@@ -862,14 +862,12 @@ impl<'a> StringReader<'a> {
             valid = false;
         }
 
-        self.bump(); // past the ending }
-
         if valid && (char::from_u32(accum_int).is_none() || count == 0) {
             self.err_span_(start_bpos, self.last_pos, "illegal unicode character escape");
             valid = false;
         }
 
-
+        self.bump(); // past the ending }
         valid
     }
 

--- a/src/test/parse-fail/issue-23620-invalid-escapes.rs
+++ b/src/test/parse-fail/issue-23620-invalid-escapes.rs
@@ -16,7 +16,8 @@ fn main() {
     //~^ ERROR unicode escape sequences cannot be used as a byte or in a byte string
 
     let _ = b'\u';
-    //~^ ERROR unknown byte escape: u
+    //~^ ERROR incorrect unicode escape sequence
+    //~^^ ERROR unicode escape sequences cannot be used as a byte or in a byte string
 
     let _ = b'\x5';
     //~^ ERROR numeric character escape is too short
@@ -35,11 +36,12 @@ fn main() {
     let _ = b"\u{a4a4} \xf \u";
     //~^ ERROR unicode escape sequences cannot be used as a byte or in a byte string
     //~^^ ERROR illegal character in numeric character escape:
-    //~^^^ ERROR unknown byte escape: u
+    //~^^^ ERROR incorrect unicode escape sequence
+    //~^^^^ ERROR unicode escape sequences cannot be used as a byte or in a byte string
 
     let _ = "\u{ffffff} \xf \u";
     //~^ ERROR illegal unicode character escape
     //~^^ ERROR illegal character in numeric character escape:
     //~^^^ ERROR form of character escape may only be used with characters in the range [\x00-\x7f]
-    //~^^^^ ERROR incomplete unicode escape sequence
+    //~^^^^ ERROR incorrect unicode escape sequence
 }

--- a/src/test/parse-fail/issue-23620-invalid-escapes.rs
+++ b/src/test/parse-fail/issue-23620-invalid-escapes.rs
@@ -41,5 +41,5 @@ fn main() {
     //~^ ERROR illegal unicode character escape
     //~^^ ERROR illegal character in numeric character escape:
     //~^^^ ERROR form of character escape may only be used with characters in the range [\x00-\x7f]
-    //~^^^^ ERROR unknown character escape: u
+    //~^^^^ ERROR incomplete unicode escape sequence
 }


### PR DESCRIPTION
Inspired by the now-mysteriously-closed https://github.com/rust-lang/rust/pull/26782.

This PR introduces better error messages when unicode escapes have invalid format (e.g. `\uFFFF`). It also makes rustc always tell the user that escape may not be used in byte-strings and bytes and fixes some spans to not include unecessary characters and include escape backslash in some others.
