### PR TITLE
std: Fix a TLS destructor bug on OSX

### DIFF
--- a/src/test/run-pass/down-with-thread-dtors.rs
+++ b/src/test/run-pass/down-with-thread-dtors.rs
@@ -1,0 +1,38 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+thread_local!(static FOO: Foo = Foo);
+thread_local!(static BAR: Bar = Bar(1));
+thread_local!(static BAZ: Baz = Baz);
+
+struct Foo;
+struct Bar(i32);
+struct Baz;
+
+impl Drop for Foo {
+    fn drop(&mut self) {
+        BAR.with(|_| {});
+    }
+}
+
+impl Drop for Bar {
+    fn drop(&mut self) {
+        assert_eq!(self.0, 1);
+        self.0 = 2;
+        BAZ.with(|_| {});
+        assert_eq!(self.0, 2);
+    }
+}
+
+fn main() {
+    std::thread::spawn(|| {
+        FOO.with(|_| {});
+    }).join().unwrap();
+}


### PR DESCRIPTION
TLS tests have been deadlocking on the OSX bots for quite some time now and this
commit is the result of the investigation into what's going on. It turns out
that a value in TLS which is being destroyed (e.g. the destructor is run) can be
reset back to the initial state **while the destructor is running** if TLS is
re-accessed.

To fix this we stop calling drop_in_place on OSX and instead move the data to a
temporary location on the stack.
