### PR TITLE
doc: remove playground links for structs and traits

### DIFF
--- a/src/librustdoc/html/static/playpen.js
+++ b/src/librustdoc/html/static/playpen.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     var featureRegexp = new RegExp('^\s*#!\\[feature\\(\.*?\\)\\]');
-    var elements = document.querySelectorAll('pre.rust');
+    var elements = document.querySelectorAll('pre.rust-example-rendered');
 
     Array.prototype.forEach.call(elements, function(el) {
         el.onmouseover = function(e) {


### PR DESCRIPTION
The very first code fragment off every struct and trait documentation page generates wrong playground code. This pull request adjusts `playpen.js` to only create a link for real examples.

Documentation:

``` rust
pub struct String {
    // some fields omitted
}
```

Playground:

``` rust
Struct std::String

                [−]

        [src]
```

r? @steveklabnik
