### PR TITLE
libc: (Windows) Add SYSTEMTIME/LPSYSTEMTIME and some associated FFI functions

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -2049,6 +2049,20 @@ pub mod types {
                 }
 
                 pub type LPFILETIME = *mut FILETIME;
+                
+                #[repr(C)]
+                #[derive(Copy, Clone)] pub struct SYSTEMTIME {
+                    pub wYear: WORD,
+                    pub wMonth: WORD,
+                    pub wDayOfWeek: WORD,
+                    pub wDay: WORD,
+                    pub wHour: WORD,
+                    pub wMinute: WORD,
+                    pub wSecond: WORD,
+                    pub wMilliseconds: WORD
+                }
+                
+                pub type LPSYSTEMTIME = *mut SYSTEMTIME;
 
                 #[repr(C)]
                 #[derive(Copy, Clone)] pub struct GUID {

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -6481,8 +6481,11 @@ pub mod funcs {
                                         dwMoveMethod: DWORD) -> BOOL;
                 pub fn SetEndOfFile(hFile: HANDLE) -> BOOL;
 
+                pub fn GetSystemTime(lpSystemTime: LPSYSTEMTIME);
                 pub fn GetSystemTimeAsFileTime(
                             lpSystemTimeAsFileTime: LPFILETIME);
+
+                pub fn GetLocalTime(lpSystemTime: LPSYSTEMTIME);
 
                 pub fn QueryPerformanceFrequency(
                             lpFrequency: *mut LARGE_INTEGER) -> BOOL;

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -2049,7 +2049,7 @@ pub mod types {
                 }
 
                 pub type LPFILETIME = *mut FILETIME;
-                
+
                 #[repr(C)]
                 #[derive(Copy, Clone)] pub struct SYSTEMTIME {
                     pub wYear: WORD,
@@ -2061,7 +2061,7 @@ pub mod types {
                     pub wSecond: WORD,
                     pub wMilliseconds: WORD
                 }
-                
+
                 pub type LPSYSTEMTIME = *mut SYSTEMTIME;
 
                 #[repr(C)]

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -6343,7 +6343,8 @@ pub mod funcs {
                                                LPMEMORY_BASIC_INFORMATION,
                                                LPSYSTEM_INFO, HANDLE, LPHANDLE,
                                                LARGE_INTEGER, PLARGE_INTEGER,
-                                               LPFILETIME, LPWIN32_FIND_DATAW};
+                                               LPFILETIME, LPSYSTEMTIME,
+                                               LPWIN32_FIND_DATAW};
 
             extern "system" {
                 pub fn GetEnvironmentVariableW(n: LPCWSTR,


### PR DESCRIPTION
Currently implemented functions are:
- GetSystemTime(lpSystemTime: LPSYSTEMTIME)
- GetLocalTime(lpSystemTime: LPSYSTEMTIME)

---

I need access to SYSTEMTIME / LPSYSTEMTIME for a time library I was working on before I discovered (lib)libc.

I changed FILETIME over but, surprisingly, there was no mention of SYSTEMTIME apart from GetSystemTimeAsFileTime(lpSystemTimeAsFileTime: LPFILETIME)

I haven't yet implemented the other Windows Time API functions, but if this is accepted, I'll take that as an invitation to do so. Otherwise, I won't bother since it would be obvious that it should be done elsewhere :stuck_out_tongue: 
