### PR TITLE
Skip diagnostic codes occurring inside a long diagnostic in errorck.

### DIFF
--- a/src/etc/errorck.py
+++ b/src/etc/errorck.py
@@ -23,6 +23,15 @@ src_dir = sys.argv[1]
 errcode_map = {}
 error_re = re.compile("(E\d\d\d\d)")
 
+# In the register_long_diagnostics! macro, entries look like this:
+#
+# EXXXX: r##"
+# <Long diagnostic message>
+# "##,
+#
+# These two variables are for detecting the beginning and end of diagnostic
+# messages so that duplicate error codes are not reported when a code occurs
+# inside a diagnostic message
 long_diag_begin = "r##\""
 long_diag_end = "\"##"
 
@@ -41,6 +50,7 @@ for (dirpath, dirnames, filenames) in os.walk(src_dir):
             inside_long_diag = False
             for line_num, line in enumerate(f, start=1):
                 if inside_long_diag:
+                    # Skip duplicate error code checking for this line
                     if long_diag_end in line:
                         inside_long_diag = False
                     continue


### PR DESCRIPTION
Currently errorck yields bogus `duplicate error code` messages when an error code occurs inside of a long diagnostic message (see https://github.com/rust-lang/rust/pull/26982), because errorck just goes line by line checking for error codes and recording them all.

A simplistic approach to fixing this is just to detect the beginning of a long diagnostic raw string literal (`r##"`) and skip lines until the end of the raw string literal is encountered. I'm not completely confident in this approach, but I think a more robust approach would be more complicated and I wanted to get feedback before pursuing that.
