### PR TITLE
libc: (Windows) Add a few missing integral types

### DIFF
--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -1909,9 +1909,9 @@ pub mod types {
                 use consts::os::extra::{MAX_PROTOCOL_CHAIN,
                                               WSAPROTOCOL_LEN};
                 use types::common::c95::c_void;
-                use types::os::arch::c95::{c_char, c_int, c_uint, size_t};
-                use types::os::arch::c95::{c_long, c_ulong};
-                use types::os::arch::c95::{wchar_t};
+                use types::os::arch::c95::{c_char, c_schar, c_int, c_uint};
+                use types::os::arch::c95::{size_t, c_short, c_long, c_ulong};
+                use types::os::arch::c95::{c_uchar, c_ushort, wchar_t};
                 #[cfg(target_arch = "x86")]
                 use types::os::arch::c95::c_double;
                 use types::os::arch::c99::{c_ulonglong, c_longlong, uintptr_t};
@@ -1921,6 +1921,18 @@ pub mod types {
                 pub type BOOLEAN = BYTE;
                 pub type CCHAR = c_char;
                 pub type CHAR = c_char;
+
+                pub type INT = c_int;
+                pub type INT8 = c_schar;
+                pub type INT16 = c_short;
+                pub type INT32 = c_int;
+                pub type INT64 = i64;
+
+                pub type UINT = c_uint;
+                pub type UINT8 = c_uchar;
+                pub type UINT16 = c_ushort;
+                pub type UINT32 = c_uint;
+                pub type UINT64 = u64;
 
                 pub type DWORD = c_ulong;
                 pub type DWORDLONG = c_ulonglong;

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -1930,10 +1930,17 @@ pub mod types {
                 pub type LONG = c_long;
                 pub type PLONG = *mut c_long;
 
+                pub type ULONG = c_ulong;
+
                 #[cfg(target_arch = "x86")]
                 pub type LONG_PTR = c_long;
                 #[cfg(target_arch = "x86_64")]
                 pub type LONG_PTR = i64;
+
+                #[cfg(target_arch = "x86")]
+                pub type ULONG_PTR = c_ulong;
+                #[cfg(target_arch = "x86_64")]
+                pub type ULONG_PTR = u64;
 
                 pub type LARGE_INTEGER = c_longlong;
                 pub type PLARGE_INTEGER = *mut c_longlong;

--- a/src/liblibc/lib.rs
+++ b/src/liblibc/lib.rs
@@ -1912,6 +1912,8 @@ pub mod types {
                 use types::os::arch::c95::{c_char, c_int, c_uint, size_t};
                 use types::os::arch::c95::{c_long, c_ulong};
                 use types::os::arch::c95::{wchar_t};
+                #[cfg(target_arch = "x86")]
+                use types::os::arch::c95::c_double;
                 use types::os::arch::c99::{c_ulonglong, c_longlong, uintptr_t};
 
                 pub type BOOL = c_int;
@@ -1930,7 +1932,17 @@ pub mod types {
                 pub type LONG = c_long;
                 pub type PLONG = *mut c_long;
 
+                #[cfg(target_arch = "x86")]
+                pub type LONGLONG = c_double;
+                #[cfg(target_arch = "x86_64")]
+                pub type LONGLONG = i64;
+
                 pub type ULONG = c_ulong;
+
+                #[cfg(target_arch = "x86")]
+                pub type ULONGLONG = c_double;
+                #[cfg(target_arch = "x86_64")]
+                pub type ULONGLONG = u64;
 
                 #[cfg(target_arch = "x86")]
                 pub type LONG_PTR = c_long;
@@ -1941,6 +1953,9 @@ pub mod types {
                 pub type ULONG_PTR = c_ulong;
                 #[cfg(target_arch = "x86_64")]
                 pub type ULONG_PTR = u64;
+
+                pub type LONG32 = c_int;
+                pub type LONG64 = i64;
 
                 pub type LARGE_INTEGER = c_longlong;
                 pub type PLARGE_INTEGER = *mut c_longlong;


### PR DESCRIPTION
Well, this was fun. I'm fairly sure I got this right, but I'll add a comment to a part I'm not too sure about.

This adds a few missing integral types to (lib)libc.

What was added is the following:
- ULONG
- ULONG_PTR
- LONGLONG
- ULONGLONG (required for a coming-soon pull request :+1:)
- LONG32
- LONG64

---

I added another commit, which adds the following named types:
- INT
- INT8
- INT16
- INT32
- INT64
- UINT
- UINT8
- UINT16
- UINT32
- UINT64

This is a change made in advance for a future PR series that starts working on Fiber support (_first_ in Windows). I don't have it anywhere near a working state, but if I make these changes now, I won't have to wait for these changes. It will take a while to get it right :(
