### PR TITLE
debuginfo: Instruct MSVC linker to generate PDB file if debuginfo is enabled

### DIFF
--- a/src/librustc_trans/back/link.rs
+++ b/src/librustc_trans/back/link.rs
@@ -954,6 +954,9 @@ fn link_args(cmd: &mut Linker,
     // Pass optimization flags down to the linker.
     cmd.optimize();
 
+    // Pass debuginfo flags down to the linker.
+    cmd.debuginfo();
+
     // We want to prevent the compiler from accidentally leaking in any system
     // libraries, so we explicitly ask gcc to not link to any libraries by
     // default. Note that this does not happen for windows because windows pulls


### PR DESCRIPTION
This PR will enable RUSTC to generate PDB debuginfo files when targeting the MSVC toolchain. Mind that these are not full featured PDB files -- they just contain line tables, so you can get proper backtraces and step through your code, but variable values can't be inspected. We are just levering (LLVM's current support)[http://clang.llvm.org/docs/MSVCCompatibility.html] for creating Windows debuginfo. When LLVM's support gets better, we should benefit from that too without much effort.

I also wanted to include some kind of auto test with this PR but I could not get the `rmake` tests to work properly when targeting MSVC.

EDIT:
Closes #19533
