### PR TITLE
syntax: Allow semi tokens after macro ty/path

### DIFF
--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -501,7 +501,7 @@ fn is_in_follow(_: &ExtCtxt, tok: &Token, frag: &str) -> Result<bool, String> {
             },
             "path" | "ty" => {
                 match *tok {
-                    Comma | FatArrow | Colon | Eq | Gt => Ok(true),
+                    Comma | FatArrow | Colon | Eq | Gt | Semi => Ok(true),
                     Ident(i, _) if i.as_str() == "as" => Ok(true),
                     _ => Ok(false)
                 }

--- a/src/test/run-pass/semi-after-macro-ty.rs
+++ b/src/test/run-pass/semi-after-macro-ty.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! foo {
+    ($t:ty; $p:path;) => {}
+}
+
+fn main() {
+    foo!(i32; i32;);
+}


### PR DESCRIPTION
This commit expands the follow set of the `ty` and `path` macro fragments to
include the semicolon token as well. A semicolon is already allowed after these
tokens, so it's currently a little too restrictive to not have a semicolon
allowed. For example:

```
extern {
    fn foo() -> i32; // semicolon after type
}

fn main() {
    struct Foo;

    Foo; // semicolon after path
}
```
