### PR TITLE
docs: set zero padding for pre tags

### DIFF
--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -128,6 +128,9 @@ code, pre {
     border-radius: 3px;
     padding: 0 0.2em;
 }
+.docblock pre code {
+    padding: 0;
+}
 pre {
     background-color: #F5F5F5;
     padding: 14px;


### PR DESCRIPTION
The current nonzero side padding of `code` tags is good for legibility in paragraphs and lists; however, it introduces an awkward indentation to `pre` tags. Specifically, when a `pre` tag contains preformatted text with multiple lines, the fist line gets pushed slightly to the right, running the vertical alignment. An example can be seen [here](http://doc.rust-lang.org/std/fmt/#syntax). I propose setting the padding to zero for `code`s contained in `pre`s.

Regards,
Ivan
