### PR TITLE
docs: Correct left/right fork (silverware) assignment for Dining Philosophers

### DIFF
--- a/src/doc/trpl/dining-philosophers.md
+++ b/src/doc/trpl/dining-philosophers.md
@@ -540,7 +540,7 @@ fn main() {
         Philosopher::new("Gilles Deleuze", 1, 2),
         Philosopher::new("Karl Marx", 2, 3),
         Philosopher::new("Emma Goldman", 3, 4),
-        Philosopher::new("Michel Foucault", 0, 4),
+        Philosopher::new("Michel Foucault", 4, 0),
     ];
 
     let handles: Vec<_> = philosophers.into_iter().map(|p| {


### PR DESCRIPTION
Both the the first and last Philosophers had fork 0 to their left. Corrected by switching the order of the forks for Michel Foucault to 4, 0 rather than 0, 4.

r? @steveklabnik
