### PR TITLE
Correctly detect reassignments to the interior of matched structs/tuples

### DIFF
--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -1384,7 +1384,8 @@ impl<'tcx> euv::Delegate<'tcx> for ReassignmentChecker {
                 match base_cmt.cat {
                     mc::cat_upvar(mc::Upvar { id: ty::UpvarId { var_id: vid, .. }, .. }) |
                     mc::cat_local(vid) => {
-                        self.reassigned |= self.node == vid && Some(field) == self.field
+                        self.reassigned |= self.node == vid &&
+                            (self.field.is_none() || Some(field) == self.field)
                     },
                     _ => {}
                 }

--- a/src/test/run-pass/issue-26996.rs
+++ b/src/test/run-pass/issue-26996.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let mut c = (1, "".to_owned());
+    match c {
+        c2 => {
+            c.0 = 2;
+            assert_eq!(c2.0, 1);
+        }
+    }
+}


### PR DESCRIPTION
If we match a whole struct or tuple, the "field" for the reassignment
checker will be "None" which means that mutating any field should count
as a reassignment.

Fixes #26996.
