### PR TITLE
doc: Add a link to LLVM's new inline assembly docs

### DIFF
--- a/src/doc/trpl/inline-assembly.md
+++ b/src/doc/trpl/inline-assembly.md
@@ -103,7 +103,7 @@ fn main() {
 If you would like to use real operands in this position, however,
 you are required to put curly braces `{}` around the register that
 you want, and you are required to put the specific size of the
-operand. This is useful for very low level programming, where 
+operand. This is useful for very low level programming, where
 which register you use is important:
 
 ```rust
@@ -166,3 +166,12 @@ unsafe {
 println!("eax is currently {}", result);
 # }
 ```
+
+## More Information
+
+The current implementation of the `asm!` macro is a direct binding to [LLVM's
+inline assembler expressions][llvm-docs], so be sure to check out [their
+documentation as well][llvm-docs] for more information about clobbers,
+constraints, etc.
+
+[llvm-docs]: http://llvm.org/docs/LangRef.html#inline-assembler-expressions


### PR DESCRIPTION
Hot off the press, we've now got some nice documentation to link to in LLVM
officially!
