### PR TITLE
don't ICE when FRU is used on an enum variant

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3426,6 +3426,11 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
         let def = lookup_full_def(tcx, path.span, id);
         let struct_id = match def {
             def::DefVariant(enum_id, variant_id, true) => {
+                if let &Some(ref base_expr) = base_expr {
+                    span_err!(tcx.sess, base_expr.span, E0401,
+                              "functional record update syntax requires a struct");
+                    fcx.write_error(base_expr.id);
+                }
                 check_struct_enum_variant(fcx, id, expr.span, enum_id,
                                           variant_id, &fields[..]);
                 enum_id

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -2209,6 +2209,7 @@ register_diagnostics! {
     E0392, // parameter `{}` is never used
     E0393, // the type parameter `{}` must be explicitly specified in an object
            // type because its default value `{}` references the type `Self`"
-    E0399  // trait items need to be implemented because the associated
+    E0399, // trait items need to be implemented because the associated
            // type `{}` was overridden
+    E0401  // functional record update requires a struct
 }

--- a/src/test/compile-fail/issue-26948.rs
+++ b/src/test/compile-fail/issue-26948.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    enum Foo { A { x: u32 } }
+    let orig = Foo::A { x: 5 };
+    Foo::A { x: 6, ..orig };
+    //~^ ERROR functional record update syntax requires a struct
+}


### PR DESCRIPTION
Fixes #26948.

r? @eddyb
