### PR TITLE
Fix section of __morestack for aarch64-unknown-linux-gnu

### DIFF
--- a/src/rt/arch/aarch64/morestack.S
+++ b/src/rt/arch/aarch64/morestack.S
@@ -24,7 +24,7 @@
 #endif
 
 #if !defined(__APPLE__)
-.type MORESTACK,%function
+func MORESTACK
 #endif
 
 // FIXME(AARCH64): this might not be perfectly right but works for now
@@ -33,3 +33,7 @@ MORESTACK:
 	bl STACK_EXHAUSTED
 	// the above function ensures that it never returns
 	.cfi_endproc
+
+#if !defined(__APPLE__)
+endfunc MORESTACK
+#endif


### PR DESCRIPTION
When building for AArch64/Linux, __morestack ends up in the .note.GNU-stack section,
which causes missing references for the linker. By using the func/endfunc macros
from macros.S we get __morestack right to .text (and a bit more on the side).
