### PR TITLE
Fixed snippet to return the proper error.

### DIFF
--- a/src/doc/trpl/error-handling.md
+++ b/src/doc/trpl/error-handling.md
@@ -50,6 +50,8 @@ is very wrong. Wrong enough that we can't continue with things in the current
 state. Another example is using the `unreachable!()` macro:
 
 ```rust,ignore
+use Event::NewRelease;
+
 enum Event {
     NewRelease,
 }
@@ -71,7 +73,7 @@ fn descriptive_probability(event: Event) -> &'static str {
 }
 
 fn main() {
-    std::io::println(descriptive_probability(NewRelease));
+    println!("{}", descriptive_probability(NewRelease));
 }
 ```
 


### PR DESCRIPTION
This PR fixes a snippet of code on the error handling chapter of "The Rust Programming Language".

//cc @steveklabnik 

The docs state that trying to compile the snippet will yield the following error:

``` bash
anon>:13:5: 20:6 error: non-exhaustive patterns: `_` not covered [E0004]
```

But instead the error received is:

``` bash
<anon>:22:46: 22:56 error: unresolved name `NewRelease`
<anon>:22     std::io::println(descriptive_probability(NewRelease));
                                                       ^~~~~~~~~~
<anon>:22:5: 22:21 error: unresolved name `std::io::println`
<anon>:22     std::io::println(descriptive_probability(NewRelease));
              ^~~~~~~~~~~~~~~~
error: aborting due to 2 previous errors
playpen: application terminated with error code 101
```

After applying this PR the expected error is returned:

``` bash
anon>:13:5: 20:6 error: non-exhaustive patterns: `_` not covered [E0004]
<anon>:13     match probability(&event) {
<anon>:14         1.00 => "certain",
<anon>:15         0.00 => "impossible",
<anon>:16         0.00 ... 0.25 => "very unlikely",
<anon>:17         0.25 ... 0.50 => "unlikely",
<anon>:18         0.50 ... 0.75 => "likely",
          ...
<anon>:13:5: 20:6 help: see the detailed explanation for E0004
error: aborting due to previous error
```
