### PR TITLE
Use Vec::drain in BufWriter

### DIFF
--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -18,7 +18,6 @@ use cmp;
 use error;
 use fmt;
 use io::{self, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom};
-use ptr;
 
 /// The `BufReader` struct adds buffering to any reader.
 ///
@@ -308,14 +307,8 @@ impl<W: Write> BufWriter<W> {
             }
         }
         if written > 0 {
-            // NB: would be better expressed as .remove(0..n) if it existed
-            unsafe {
-                ptr::copy(self.buf.as_ptr().offset(written as isize),
-                          self.buf.as_mut_ptr(),
-                          len - written);
-            }
+            self.buf.drain(..written);
         }
-        self.buf.truncate(len - written);
         ret
     }
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -119,6 +119,7 @@
 #![feature(core_intrinsics)]
 #![feature(core_prelude)]
 #![feature(core_simd)]
+#![feature(drain)]
 #![feature(fnbox)]
 #![feature(heap_api)]
 #![feature(int_error_internals)]


### PR DESCRIPTION
Use Vec::drain in BufWriter

I happened past a comment that asked for functionality that we now have.
