### PR TITLE
Fix negate_unsigned feature gate check

### DIFF
--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -12,8 +12,6 @@
 
 // FIXME: #6220 Implement floating point formatting
 
-#![allow(unsigned_negation)]
-
 use prelude::*;
 
 use fmt;

--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -517,7 +517,6 @@ pub trait Neg {
 macro_rules! neg_impl_core {
     ($id:ident => $body:expr, $($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
-        #[allow(unsigned_negation)]
         impl Neg for $t {
             #[stable(feature = "rust1", since = "1.0.0")]
             type Output = $t;

--- a/src/libcoretest/fmt/num.rs
+++ b/src/libcoretest/fmt/num.rs
@@ -7,8 +7,6 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![allow(unsigned_negation)]
-
 use core::fmt::radix;
 
 #[test]

--- a/src/librand/isaac.rs
+++ b/src/librand/isaac.rs
@@ -126,7 +126,6 @@ impl IsaacRng {
 
     /// Refills the output buffer (`self.rsl`)
     #[inline]
-    #[allow(unsigned_negation)]
     fn isaac(&mut self) {
         self.c = self.c + w(1);
         // abbreviations

--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 #![allow(non_camel_case_types)]
-#![allow(unsigned_negation)]
 
 use self::ConstVal::*;
 
@@ -27,7 +26,6 @@ use util::num::ToPrimitive;
 use syntax::ast::{self, Expr};
 use syntax::ast_util;
 use syntax::codemap::Span;
-use syntax::feature_gate;
 use syntax::parse::token::InternedString;
 use syntax::ptr::P;
 use syntax::{codemap, visit};
@@ -745,13 +743,6 @@ pub fn eval_const_expr_with_substs<'tcx, S>(tcx: &ty::ctxt<'tcx>,
           Float(f) => Float(-f),
           Int(n) =>  try!(const_int_checked_neg(n, e, expr_int_type)),
           Uint(i) => {
-              if !tcx.sess.features.borrow().negate_unsigned {
-                  feature_gate::emit_feature_err(
-                      &tcx.sess.parse_sess.span_diagnostic,
-                      "negate_unsigned",
-                      e.span,
-                      "unary negation of unsigned integers may be removed in the future");
-              }
               try!(const_uint_checked_neg(i, e, expr_uint_type))
           }
           Str(_) => signal!(e, NegateOnString),

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -134,4 +134,6 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
     store.register_renamed("raw_pointer_deriving", "raw_pointer_derive");
 
     store.register_renamed("unknown_features", "unused_features");
+
+    store.register_removed("unsigned_negation", "replaced by negate_unsigned feature gate");
 }

--- a/src/librustc_trans/trans/adt.rs
+++ b/src/librustc_trans/trans/adt.rs
@@ -41,8 +41,6 @@
 //!   used unboxed and any field can have pointers (including mutable)
 //!   taken to it, implementing them for Rust seems difficult.
 
-#![allow(unsigned_negation)]
-
 pub use self::Repr::*;
 
 use std::rc::Rc;

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -114,7 +114,6 @@ use syntax::attr::AttrMetaMethods;
 use syntax::ast::{self, DefId, Visibility};
 use syntax::ast_util::{self, local_def};
 use syntax::codemap::{self, Span};
-use syntax::feature_gate;
 use syntax::owned_slice::OwnedSlice;
 use syntax::parse::token;
 use syntax::print::pprust;
@@ -3073,15 +3072,6 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
                         oprnd_t = op::check_user_unop(fcx, "-", "neg",
                                                       tcx.lang_items.neg_trait(),
                                                       expr, &**oprnd, oprnd_t, unop);
-                    }
-                    if let ty::TyUint(_) = oprnd_t.sty {
-                        if !tcx.sess.features.borrow().negate_unsigned {
-                            feature_gate::emit_feature_err(
-                                &tcx.sess.parse_sess.span_diagnostic,
-                                "negate_unsigned",
-                                expr.span,
-                                "unary negation of unsigned integers may be removed in the future");
-                        }
                     }
                 }
             }

--- a/src/libstd/num/f32.rs
+++ b/src/libstd/num/f32.rs
@@ -12,7 +12,6 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]
-#![allow(unsigned_negation)]
 #![doc(primitive = "f32")]
 
 use prelude::v1::*;

--- a/src/libstd/num/uint_macros.rs
+++ b/src/libstd/num/uint_macros.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 #![doc(hidden)]
-#![allow(unsigned_negation)]
 
 macro_rules! uint_module { ($T:ident) => (
 

--- a/src/test/compile-fail/const-eval-overflow.rs
+++ b/src/test/compile-fail/const-eval-overflow.rs
@@ -17,7 +17,6 @@
 // evaluation below (e.g. that performed by trans and llvm), so if you
 // change this warn to a deny, then the compiler will exit before
 // those errors are detected.
-#![warn(unsigned_negation)]
 
 use std::fmt;
 use std::{i8, i16, i32, i64, isize};
@@ -69,8 +68,6 @@ const VALS_I64: (i64, i64, i64, i64) =
 
 const VALS_U8: (u8, u8, u8, u8) =
     (-u8::MIN,
-     //~^ WARNING negation of unsigned int variable may be unintentional
-     // (The above is separately linted; unsigned negation is defined to be !x+1.)
      u8::MIN - 1,
      //~^ ERROR attempted to sub with overflow
      u8::MAX + 1,
@@ -81,8 +78,6 @@ const VALS_U8: (u8, u8, u8, u8) =
 
 const VALS_U16: (u16, u16, u16, u16) =
     (-u16::MIN,
-     //~^ WARNING negation of unsigned int variable may be unintentional
-     // (The above is separately linted; unsigned negation is defined to be !x+1.)
      u16::MIN - 1,
      //~^ ERROR attempted to sub with overflow
      u16::MAX + 1,
@@ -93,8 +88,6 @@ const VALS_U16: (u16, u16, u16, u16) =
 
 const VALS_U32: (u32, u32, u32, u32) =
     (-u32::MIN,
-     //~^ WARNING negation of unsigned int variable may be unintentional
-     // (The above is separately linted; unsigned negation is defined to be !x+1.)
      u32::MIN - 1,
      //~^ ERROR attempted to sub with overflow
      u32::MAX + 1,
@@ -105,8 +98,6 @@ const VALS_U32: (u32, u32, u32, u32) =
 
 const VALS_U64: (u64, u64, u64, u64) =
     (-u64::MIN,
-     //~^ WARNING negation of unsigned int variable may be unintentional
-     // (The above is separately linted; unsigned negation is defined to be !x+1.)
      u64::MIN - 1,
      //~^ ERROR attempted to sub with overflow
      u64::MAX + 1,

--- a/src/test/compile-fail/feature-gate-negate-unsigned.rs
+++ b/src/test/compile-fail/feature-gate-negate-unsigned.rs
@@ -11,7 +11,28 @@
 // Test that negating unsigned integers is gated by `negate_unsigned` feature
 // gate
 
-const MAX: usize = -1;
+struct S;
+impl std::ops::Neg for S {
+    type Output = u32;
+    fn neg(self) -> u32 { 0 }
+}
+
+const _MAX: usize = -1;
 //~^ ERROR unary negation of unsigned integers may be removed in the future
 
-fn main() {}
+fn main() {
+    let a = -1;
+    //~^ ERROR unary negation of unsigned integers may be removed in the future
+    let _b : u8 = a; // for infering variable a to u8.
+
+    -a;
+    //~^ ERROR unary negation of unsigned integers may be removed in the future
+
+    let _d = -1u8;
+    //~^ ERROR unary negation of unsigned integers may be removed in the future
+
+    for _ in -10..10u8 {}
+    //~^ ERROR unary negation of unsigned integers may be removed in the future
+
+    -S; // should not trigger the gate; issue 26840
+}

--- a/src/test/compile-fail/lint-type-limits.rs
+++ b/src/test/compile-fail/lint-type-limits.rs
@@ -50,14 +50,3 @@ fn qux() {
         i += 1;
     }
 }
-
-fn quy() {
-    let i = -23_usize; //~ WARNING negation of unsigned int literal may be unintentional
-                  //~^ WARNING unused variable
-}
-
-fn quz() {
-    let i = 23_usize;
-    let j = -i;   //~ WARNING negation of unsigned int variable may be unintentional
-                  //~^ WARNING unused variable
-}

--- a/src/test/run-pass/feature-gate-negate-unsigned.rs
+++ b/src/test/run-pass/feature-gate-negate-unsigned.rs
@@ -18,21 +18,21 @@ impl std::ops::Neg for S {
 }
 
 const _MAX: usize = -1;
-//~^ ERROR unary negation of unsigned integers may be removed in the future
+//~^ WARN unary negation of unsigned integers will be feature gated in the future
 
 fn main() {
     let a = -1;
-    //~^ ERROR unary negation of unsigned integers may be removed in the future
+    //~^ WARN unary negation of unsigned integers will be feature gated in the future
     let _b : u8 = a; // for infering variable a to u8.
 
     -a;
-    //~^ ERROR unary negation of unsigned integers may be removed in the future
+    //~^ WARN unary negation of unsigned integers will be feature gated in the future
 
     let _d = -1u8;
-    //~^ ERROR unary negation of unsigned integers may be removed in the future
+    //~^ WARN unary negation of unsigned integers will be feature gated in the future
 
     for _ in -10..10u8 {}
-    //~^ ERROR unary negation of unsigned integers may be removed in the future
+    //~^ WARN unary negation of unsigned integers will be feature gated in the future
 
     -S; // should not trigger the gate; issue 26840
 }


### PR DESCRIPTION
This commit fixes the negate_unsigned feature gate to appropriately
account for inferred variables.

This is technically a [breaking-change], but I’d consider it a bug fix.

cc @brson for your relnotes.

Fixes https://github.com/rust-lang/rust/issues/24676
Fixes #26840 
Fixes https://github.com/rust-lang/rust/issues/25206
