### PR TITLE
ratchet up travis to build stage1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
-# Use something that's not 'ruby' so we don't set up things like
-# RVM/bundler/ruby and whatnot. Right now 'rust' as a language actually
-# downloads a rust/cargo snapshot, which we don't really want for building rust.
+# ccache support is disabled unless your language is a C-derivative. However
+# `language: C` unconditionally sets `CC=compiler`. If we just set it in our
+# `env` it will be overwritten by the default (gcc 4.6).
 language: c
+compiler: /usr/bin/gcc-4.7
+cache: ccache
 sudo: false
 
 # The test suite is in general way too stressful for travis, especially in
@@ -9,12 +11,28 @@ sudo: false
 # back to only build the stage1 compiler and run a subset of tests, but this
 # didn't end up panning out very well.
 #
-# As a result, we're just using travis to run `make tidy` now. It'll help
-# everyone find out about their trailing spaces early on!
+# As a result, we're just using travis to run `make tidy` and *only* build
+# stage1 but *not* test it for now (a strict subset of the bootstrap). This will
+# catch "obvious" errors like style or not even compiling.
+#
+# We need gcc4.7 or higher to build LLVM, and travis (well, Ubuntu 12.04)
+# currently ships with 4.6. Gotta download our own.
 before_script:
-  - ./configure --llvm-root=path/to/nowhere
+  - ./configure --enable-ccache
 script:
   - make tidy
+  - make rustc-stage1 -j4
+
+env:
+  - CXX=/usr/bin/g++-4.7
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.7
+    - g++-4.7
 
 # Real testing happens on http://buildbot.rust-lang.org/
 #

--- a/configure
+++ b/configure
@@ -1016,15 +1016,12 @@ fi
 
 if [ ! -z "$CFG_ENABLE_CCACHE" ]
 then
-    if [ -z "$CC" ]
+    if [ -z "$CFG_CCACHE" ]
     then
-        if [ -z "$CFG_CCACHE" ]
-        then
-            err "ccache requested but not found"
-        fi
-
-        CFG_CC="ccache $CFG_CC"
+        err "ccache requested but not found"
     fi
+
+    CFG_CC="ccache $CFG_CC"
 fi
 
 if [ -z "$CC" -a -z "$CFG_ENABLE_CLANG" -a -z "$CFG_GCC" ]
@@ -1513,11 +1510,26 @@ do
 
             (*)
             msg "inferring LLVM_CXX/CC from CXX/CC = $CXX/$CC"
-            LLVM_CXX_32="$CXX"
-            LLVM_CC_32="$CC"
+            if [ ! -z "$CFG_ENABLE_CCACHE" ]
+            then
+                if [ -z "$CFG_CCACHE" ]
+                then
+                    err "ccache requested but not found"
+                fi
 
-            LLVM_CXX_64="$CXX"
-            LLVM_CC_64="$CC"
+                LLVM_CXX_32="ccache $CXX"
+                LLVM_CC_32="ccache $CC"
+
+                LLVM_CXX_64="ccache $CXX"
+                LLVM_CC_64="ccache $CC"
+            else
+                LLVM_CXX_32="$CXX"
+                LLVM_CC_32="$CC"
+
+                LLVM_CXX_64="$CXX"
+                LLVM_CC_64="$CC"
+            fi
+
             ;;
         esac
 


### PR DESCRIPTION
This has travis build LLVM and rustc up to stage1, but not run any tests. It seems wasteful to have the ultimate might of travis running on every PR just to check for whitespace errors. This is a pure subset of the bootstrap, so it shouldn't ever spuriously break.

`make tidy` still runs first, so we still get "fast errors" on bad style. However once make tidy passes, the build will simply keep running to try to make rustc. `tidy` takes ~3 mins to complete, so if your build runs longer you can be confident we've gone on to build LLVM/rustc. In principle this is configured to use ccache (it shows up in the build logs as uploaded/downloaded), but I found no actual performance changes in using it. 

Maybe someone at @travis-ci knows what's up with that.

For reference, here is a successful build with ccache enabled: https://travis-ci.org/Gankro/rust/builds/70821237

and one without: https://travis-ci.org/Gankro/rust/builds/70812814

Builds seem to take about 41mins regardless.

r? @alexcrichton 
