### PR TITLE
Implement synchronization primitive fallbacks for Windows XP/Vista

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -150,6 +150,7 @@
 #![feature(wrapping)]
 #![feature(zero_one)]
 #![cfg_attr(windows, feature(str_utf16))]
+#![cfg_attr(windows, feature(num_bits_bytes))]
 #![cfg_attr(test, feature(float_from_str_radix, range_inclusive, float_extras, hash_default))]
 #![cfg_attr(test, feature(test, rustc_private, float_consts))]
 #![cfg_attr(target_env = "msvc", feature(link_args))]

--- a/src/libstd/sys/windows/compat.rs
+++ b/src/libstd/sys/windows/compat.rs
@@ -25,14 +25,14 @@ use prelude::v1::*;
 
 use ffi::CString;
 use libc::{LPVOID, LPCWSTR, HMODULE, LPCSTR};
-use sync::atomic::{AtomicUsize, Ordering};
+use sync::atomic::{AtomicPtr, Ordering};
 
 extern "system" {
     fn GetModuleHandleW(lpModuleName: LPCWSTR) -> HMODULE;
     fn GetProcAddress(hModule: HMODULE, lpProcName: LPCSTR) -> LPVOID;
 }
 
-pub fn lookup(module: &str, symbol: &str) -> Option<usize> {
+pub fn lookup(module: &str, symbol: &str) -> Option<*mut ()> {
     let mut module: Vec<u16> = module.utf16_units().collect();
     module.push(0);
     let symbol = CString::new(symbol).unwrap();
@@ -40,15 +40,15 @@ pub fn lookup(module: &str, symbol: &str) -> Option<usize> {
         let handle = GetModuleHandleW(module.as_ptr());
         match GetProcAddress(handle, symbol.as_ptr()) as usize {
             0 => None,
-            n => Some(n),
+            n => Some(n as *mut ()),
         }
     }
 }
 
-pub fn store_func(ptr: &AtomicUsize, module: &str, symbol: &str,
-                  fallback: usize) -> usize {
+pub fn store_func(ptr: &AtomicPtr<()>, module: &str, symbol: &str,
+                  fallback: *mut ()) -> *mut () {
     let value = lookup(module, symbol).unwrap_or(fallback);
-    ptr.store(value, Ordering::SeqCst);
+    ptr.store(value, Ordering::Relaxed);
     value
 }
 
@@ -59,30 +59,109 @@ macro_rules! compat_fn {
             $($body:expr);*
         }
     )*) => ($(
-        #[allow(unused_variables)]
+        #[inline]
         pub unsafe fn $symbol($($argname: $argtype),*) -> $rettype {
-            use sync::atomic::{AtomicUsize, Ordering};
+            use sync::atomic::{AtomicPtr, Ordering};
             use mem;
             type F = unsafe extern "system" fn($($argtype),*) -> $rettype;
 
-            static PTR: AtomicUsize = AtomicUsize::new(0);
+            static PTR: AtomicPtr<()> = AtomicPtr::new(load as *mut ());
 
-            fn load() -> usize {
-                ::sys::compat::store_func(&PTR,
-                                          stringify!($module),
-                                          stringify!($symbol),
-                                          fallback as usize)
+            unsafe extern "system" fn load($($argname: $argtype),*)
+                                           -> $rettype {
+                let ptr = ::sys::compat::store_func(&PTR,
+                                                    stringify!($module),
+                                                    stringify!($symbol),
+                                                    fallback as *mut ());
+                mem::transmute::<*mut (), F>(ptr)($($argname),*)
             }
+
+            #[allow(unused_variables)]
             unsafe extern "system" fn fallback($($argname: $argtype),*)
                                                -> $rettype {
                 $($body);*
             }
 
-            let addr = match PTR.load(Ordering::SeqCst) {
-                0 => load(),
-                n => n,
-            };
-            mem::transmute::<usize, F>(addr)($($argname),*)
+            let ptr = PTR.load(Ordering::Relaxed);
+            mem::transmute::<*mut (), F>(ptr)($($argname),*)
         }
     )*)
+}
+
+macro_rules! compat_group {
+    ($gtype:ident, $gstatic:ident, $gload:ident, $module:ident: $(
+        pub fn $symbol:ident($($argname:ident: $argtype:ty),*)
+                                  -> $rettype:ty {
+            $($body:expr);*
+        }
+    )*) => (
+        struct $gtype {
+            $($symbol: ::sync::atomic::AtomicPtr<()>),*
+        }
+        static $gstatic: $gtype = $gtype {$(
+            $symbol: ::sync::atomic::AtomicPtr::new({
+                type F = unsafe extern "system" fn($($argtype),*) -> $rettype;
+                unsafe extern "system" fn $symbol($($argname: $argtype),*)
+                                                  -> $rettype {
+                    use self::$symbol;
+                    $gload();
+                    $symbol($($argname),*)
+                }
+                $symbol as *mut ()
+            })
+        ),*};
+
+        fn $gload() {
+            use option::Option::{None, Some};
+            use sync::atomic::Ordering;
+            use ptr;
+            $(
+                #[allow(unused_variables)]
+                unsafe extern "system" fn $symbol($($argname: $argtype),*)
+                                                  -> $rettype {
+                    $($body);*
+                }
+            )*
+
+            struct FuncPtrs {
+                $($symbol: *mut ()),*
+            }
+
+            const FALLBACKS: FuncPtrs = FuncPtrs {
+                $($symbol: $symbol as *mut ()),*
+            };
+
+            fn store_funcs(funcs: &FuncPtrs) {
+                $($gstatic.$symbol.store(funcs.$symbol, Ordering::Relaxed);)*
+            }
+
+            let mut funcs: FuncPtrs = FuncPtrs {
+                $($symbol: ptr::null_mut()),*
+            };
+
+            $(
+                let ptr = ::sys::compat::lookup(stringify!($module), stringify!($symbol));
+                match ptr {
+                    Some(ptr) => { funcs.$symbol = ptr; },
+                    None => {
+                        store_funcs(&FALLBACKS);
+                        return;
+                    }
+                }
+            )*
+
+            store_funcs(&funcs);
+        }
+
+        $(
+            #[inline]
+            pub unsafe fn $symbol($($argname: $argtype),*) -> $rettype {
+                use sync::atomic::Ordering;
+                use mem;
+                type F = unsafe extern "system" fn($($argtype),*) -> $rettype;
+                let ptr = $gstatic.$symbol.load(Ordering::Relaxed);
+                mem::transmute::<*mut (), F>(ptr)($($argname),*)
+            }
+        )*
+    )
 }

--- a/src/libstd/sys/windows/mutex.rs
+++ b/src/libstd/sys/windows/mutex.rs
@@ -23,136 +23,45 @@
 //!
 //! 3. While CriticalSection is fair and SRWLock is not, the current Rust policy
 //!    is there there are no guarantees of fairness.
-//!
-//! The downside of this approach, however, is that SRWLock is not available on
-//! Windows XP, so we continue to have a fallback implementation where
-//! CriticalSection is used and we keep track of who's holding the mutex to
-//! detect recursive locks.
 
 use prelude::v1::*;
 
 use cell::UnsafeCell;
 use mem;
-use sync::atomic::{AtomicUsize, Ordering};
 use sys::c;
-use sys::compat;
 
-pub struct Mutex {
-    lock: AtomicUsize,
-    held: UnsafeCell<bool>,
-}
+pub struct Mutex { inner: UnsafeCell<c::SRWLOCK> }
 
 unsafe impl Send for Mutex {}
 unsafe impl Sync for Mutex {}
 
-#[derive(Clone, Copy)]
-enum Kind {
-    SRWLock = 1,
-    CriticalSection = 2,
-}
-
 #[inline]
 pub unsafe fn raw(m: &Mutex) -> c::PSRWLOCK {
-    debug_assert!(mem::size_of::<c::SRWLOCK>() <= mem::size_of_val(&m.lock));
-    &m.lock as *const _ as *mut _
+    m.inner.get()
 }
 
 impl Mutex {
+    #[inline]
     pub const fn new() -> Mutex {
-        Mutex {
-            lock: AtomicUsize::new(0),
-            held: UnsafeCell::new(false),
-        }
+        Mutex { inner: UnsafeCell::new(c::SRWLOCK_INIT) }
     }
+    #[inline]
     pub unsafe fn lock(&self) {
-        match kind() {
-            Kind::SRWLock => c::AcquireSRWLockExclusive(raw(self)),
-            Kind::CriticalSection => {
-                let re = self.remutex();
-                (*re).lock();
-                if !self.flag_locked() {
-                    (*re).unlock();
-                    panic!("cannot recursively lock a mutex");
-                }
-            }
-        }
+        c::AcquireSRWLockExclusive(self.inner.get())
     }
+    #[inline]
     pub unsafe fn try_lock(&self) -> bool {
-        match kind() {
-            Kind::SRWLock => c::TryAcquireSRWLockExclusive(raw(self)) != 0,
-            Kind::CriticalSection => {
-                let re = self.remutex();
-                if !(*re).try_lock() {
-                    false
-                } else if self.flag_locked() {
-                    true
-                } else {
-                    (*re).unlock();
-                    false
-                }
-            }
-        }
+        c::TryAcquireSRWLockExclusive(self.inner.get()) != 0
     }
+    #[inline]
     pub unsafe fn unlock(&self) {
-        *self.held.get() = false;
-        match kind() {
-            Kind::SRWLock => c::ReleaseSRWLockExclusive(raw(self)),
-            Kind::CriticalSection => (*self.remutex()).unlock(),
-        }
+        c::ReleaseSRWLockExclusive(self.inner.get())
     }
+
+    #[inline]
     pub unsafe fn destroy(&self) {
-        match kind() {
-            Kind::SRWLock => {}
-            Kind::CriticalSection => {
-                match self.lock.load(Ordering::SeqCst) {
-                    0 => {}
-                    n => { Box::from_raw(n as *mut ReentrantMutex).destroy(); }
-                }
-            }
-        }
+        // ...
     }
-
-    unsafe fn remutex(&self) -> *mut ReentrantMutex {
-        match self.lock.load(Ordering::SeqCst) {
-            0 => {}
-            n => return n as *mut _,
-        }
-        let mut re = Box::new(ReentrantMutex::uninitialized());
-        re.init();
-        let re = Box::into_raw(re);
-        match self.lock.compare_and_swap(0, re as usize, Ordering::SeqCst) {
-            0 => re,
-            n => { Box::from_raw(re).destroy(); n as *mut _ }
-        }
-    }
-
-    unsafe fn flag_locked(&self) -> bool {
-        if *self.held.get() {
-            false
-        } else {
-            *self.held.get() = true;
-            true
-        }
-
-    }
-}
-
-fn kind() -> Kind {
-    static KIND: AtomicUsize = AtomicUsize::new(0);
-
-    let val = KIND.load(Ordering::SeqCst);
-    if val == Kind::SRWLock as usize {
-        return Kind::SRWLock
-    } else if val == Kind::CriticalSection as usize {
-        return Kind::CriticalSection
-    }
-
-    let ret = match compat::lookup("kernel32", "AcquireSRWLockExclusive") {
-        None => Kind::CriticalSection,
-        Some(..) => Kind::SRWLock,
-    };
-    KIND.store(ret as usize, Ordering::SeqCst);
-    return ret;
 }
 
 pub struct ReentrantMutex { inner: UnsafeCell<c::CRITICAL_SECTION> }


### PR DESCRIPTION
Since Windows Vista has partial support for SRWLocks (the
`TryAcquireSRWLock*` functions are missing,) the fallback functions
for the synchronization primitives are grouped such that if any of
the functions are unavailable, all of the fallback functions will be
used instead.

This at least partially addresses #26654.
