### PR TITLE
core: Revive SipHash's tests

### DIFF
--- a/src/libcore/hash/sip.rs
+++ b/src/libcore/hash/sip.rs
@@ -10,8 +10,6 @@
 
 //! An implementation of SipHash 2-4.
 
-#![allow(deprecated)] // until the next snapshot for inherent wrapping ops
-
 use prelude::*;
 use super::Hasher;
 

--- a/src/libcoretest/hash/mod.rs
+++ b/src/libcoretest/hash/mod.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+mod sip;
+
 use std::mem;
 use std::hash::{Hash, Hasher};
 use std::default::Default;


### PR DESCRIPTION
core: Revive SipHash's tests

These tests were bitrotting, include them in the crate and bring them up
to date and compiling.. and they pass.
