### PR TITLE
Rewrite the pattern matching code in trans.

### DIFF
--- a/src/librustc_trans/lib.rs
+++ b/src/librustc_trans/lib.rs
@@ -29,7 +29,6 @@
 #![feature(box_syntax)]
 #![feature(const_fn)]
 #![feature(iter_cmp)]
-#![feature(iter_arith)]
 #![feature(libc)]
 #![feature(path_ext)]
 #![feature(path_ext)]

--- a/src/librustc_trans/trans/_match.rs
+++ b/src/librustc_trans/trans/_match.rs
@@ -200,7 +200,7 @@ fn extract_variant_args<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
 
 /// Helper for converting from the ValueRef that we pass around in the match
 /// code, which is always an lvalue, into a Datum. Eventually we should just
-/// pass around a Datum and be done with it. 
+/// pass around a Datum and be done with it.
 fn match_datum<'tcx>(val: ValueRef, left_ty: Ty<'tcx>) -> Datum<'tcx, Lvalue> {
     Datum::new(val, left_ty, Lvalue)
 }

--- a/src/librustc_trans/trans/adt.rs
+++ b/src/librustc_trans/trans/adt.rs
@@ -56,7 +56,6 @@ use middle::ty::Disr;
 use syntax::ast;
 use syntax::attr;
 use syntax::attr::IntType;
-use trans::_match;
 use trans::build::*;
 use trans::cleanup;
 use trans::cleanup::CleanupMethods;
@@ -776,19 +775,17 @@ fn struct_llfields<'a, 'tcx>(cx: &CrateContext<'a, 'tcx>, st: &Struct<'tcx>,
 
 /// Obtain a representation of the discriminant sufficient to translate
 /// destructuring; this may or may not involve the actual discriminant.
-///
-/// This should ideally be less tightly tied to `_match`.
 pub fn trans_switch<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
                                 r: &Repr<'tcx>, scrutinee: ValueRef)
-                                -> (_match::BranchKind, Option<ValueRef>) {
+                                -> Option<ValueRef> {
     match *r {
         CEnum(..) | General(..) |
         RawNullablePointer { .. } | StructWrappedNullablePointer { .. } => {
-            (_match::Switch, Some(trans_get_discr(bcx, r, scrutinee, None)))
+            Some(trans_get_discr(bcx, r, scrutinee, None))
         }
         Univariant(..) => {
             // N.B.: Univariant means <= 1 enum variants (*not* == 1 variants).
-            (_match::Single, None)
+            None
         }
     }
 }
@@ -864,26 +861,24 @@ fn load_discr(bcx: Block, ity: IntType, ptr: ValueRef, min: Disr, max: Disr)
 
 /// Yield information about how to dispatch a case of the
 /// discriminant-like value returned by `trans_switch`.
-///
-/// This should ideally be less tightly tied to `_match`.
-pub fn trans_case<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, r: &Repr, discr: Disr)
-                              -> _match::OptResult<'blk, 'tcx> {
+pub fn trans_case<'bcx, 'tcx>(ccx: &CrateContext<'bcx, 'tcx>,
+                              r: &Repr,
+                              discr: Disr)
+                              -> ValueRef {
     match *r {
         CEnum(ity, _, _) => {
-            _match::SingleResult(Result::new(bcx, C_integral(ll_inttype(bcx.ccx(), ity),
-                                                              discr as u64, true)))
+            C_integral(ll_inttype(ccx, ity), discr as u64, true)
         }
         General(ity, _, _) => {
-            _match::SingleResult(Result::new(bcx, C_integral(ll_inttype(bcx.ccx(), ity),
-                                                              discr as u64, true)))
+            C_integral(ll_inttype(ccx, ity), discr as u64, true)
         }
         Univariant(..) => {
-            bcx.ccx().sess().bug("no cases for univariants or structs")
+            ccx.sess().bug("no cases for univariants or structs")
         }
         RawNullablePointer { .. } |
         StructWrappedNullablePointer { .. } => {
             assert!(discr == 0 || discr == 1);
-            _match::SingleResult(Result::new(bcx, C_bool(bcx.ccx(), discr != 0)))
+            C_bool(ccx, discr != 0)
         }
     }
 }
@@ -995,6 +990,39 @@ pub fn trans_field_ptr<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, r: &Repr<'tcx>,
         StructWrappedNullablePointer { ref nonnull, nndiscr, .. } => {
             assert_eq!(discr, nndiscr);
             struct_field_ptr(bcx, nonnull, val, ix, false)
+        }
+    }
+}
+
+/// Get a field's type.
+pub fn trans_field_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, r: &Repr<'tcx>,
+                                  discr: Disr, ix: usize) -> Ty<'tcx> {
+    // Note: if this ever needs to generate conditionals (e.g., if we
+    // decide to do some kind of cdr-coding-like non-unique repr
+    // someday), it will need to return a possibly-new bcx as well.
+    match *r {
+        CEnum(..) => {
+            bcx.ccx().sess().bug("element access in C-like enum")
+        }
+        Univariant(ref st, _dtor) => {
+            assert_eq!(discr, 0);
+            st.fields[ix]
+        }
+        General(_, ref cases, _) => {
+            &cases[discr as usize].fields[ix + 1]
+        }
+        RawNullablePointer { nndiscr, ref nullfields, .. } |
+        StructWrappedNullablePointer { nndiscr, ref nullfields, .. } if discr != nndiscr => {
+            nullfields[ix]
+        }
+        RawNullablePointer { nndiscr, nnty, .. } => {
+            assert_eq!(ix, 0);
+            assert_eq!(discr, nndiscr);
+            nnty
+        }
+        StructWrappedNullablePointer { ref nonnull, nndiscr, .. } => {
+            assert_eq!(discr, nndiscr);
+            nonnull.fields[ix]
         }
     }
 }

--- a/src/librustc_trans/trans/adt.rs
+++ b/src/librustc_trans/trans/adt.rs
@@ -997,14 +997,11 @@ pub fn trans_field_ptr<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, r: &Repr<'tcx>,
 /// Get a field's type.
 pub fn trans_field_ty<'blk, 'tcx>(bcx: Block<'blk, 'tcx>, r: &Repr<'tcx>,
                                   discr: Disr, ix: usize) -> Ty<'tcx> {
-    // Note: if this ever needs to generate conditionals (e.g., if we
-    // decide to do some kind of cdr-coding-like non-unique repr
-    // someday), it will need to return a possibly-new bcx as well.
     match *r {
         CEnum(..) => {
             bcx.ccx().sess().bug("element access in C-like enum")
         }
-        Univariant(ref st, _dtor) => {
+        Univariant(ref st, _) => {
             assert_eq!(discr, 0);
             st.fields[ix]
         }

--- a/src/librustc_trans/trans/callee.rs
+++ b/src/librustc_trans/trans/callee.rs
@@ -902,12 +902,11 @@ fn trans_args_under_call_abi<'blk, 'tcx>(
             let repr = adt::represent_type(bcx.ccx(), tuple_type);
             let repr_ptr = &*repr;
             for (i, field_type) in field_types.iter().enumerate() {
-                let arg_datum = tuple_lvalue_datum.get_element(
+                let arg_datum = tuple_lvalue_datum.get_field(
                     bcx,
-                    field_type,
-                    |srcval| {
-                        adt::trans_field_ptr(bcx, repr_ptr, srcval, 0, i)
-                    }).to_expr_datum();
+                    repr_ptr,
+                    0,
+                    i).to_expr_datum();
                 bcx = trans_arg_datum(bcx,
                                       field_type,
                                       arg_datum,

--- a/src/test/run-pass/issue-18060.rs
+++ b/src/test/run-pass/issue-18060.rs
@@ -1,0 +1,14 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    assert_eq!(2, match (1, 3) { (0, 2...5) => 1, (1, 3) => 2, (_, 3) => 3, (_, _) => 4 });
+    assert_eq!(2, match (1, 3) { (0, 2...5) => 1, (1, 3) => 2, (_, 2...5) => 3, (_, _) => 4 });
+}

--- a/src/test/run-pass/issue-19064.rs
+++ b/src/test/run-pass/issue-19064.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+struct Foo(pub str);
+
+impl Foo {
+  fn print(&self) -> &str {
+    match self {
+      &Foo(ref s) => s,
+    }
+  }
+}
+
+fn main() {
+    let f: &Foo = unsafe { std::mem::transmute("foo") };
+    assert_eq!(f.print(), "foo");
+}

--- a/src/test/run-pass/issue-20046.rs
+++ b/src/test/run-pass/issue-20046.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[derive(PartialEq)]
+enum IoErrorKind { BrokenPipe, XXX }
+struct IoError {
+    pub kind: IoErrorKind,
+    pub detail: Option<String>
+}
+fn main() {
+    let e: Result<u8, _> = Err(IoError{ kind: IoErrorKind::XXX, detail: None });
+    match e {
+        Ok(_) => true,
+        Err(ref e) if e.kind == IoErrorKind::BrokenPipe => return,
+        Err(IoError { kind: IoErrorKind::BrokenPipe, ..}) => return,
+        Err(err) => panic!(err)
+    };
+}

--- a/src/test/run-pass/issue-20046.rs
+++ b/src/test/run-pass/issue-20046.rs
@@ -17,9 +17,9 @@ struct IoError {
 fn main() {
     let e: Result<u8, _> = Err(IoError{ kind: IoErrorKind::XXX, detail: None });
     match e {
-        Ok(_) => true,
-        Err(ref e) if e.kind == IoErrorKind::BrokenPipe => return,
-        Err(IoError { kind: IoErrorKind::BrokenPipe, ..}) => return,
-        Err(err) => panic!(err)
+        Ok(_) => panic!(),
+        Err(ref e) if e.kind == IoErrorKind::BrokenPipe => panic!(),
+        Err(IoError { kind: IoErrorKind::BrokenPipe, ..}) => panic!(),
+        Err(err) => return
     };
 }

--- a/src/test/run-pass/issue-23311.rs
+++ b/src/test/run-pass/issue-23311.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(slice_patterns)]
+
+fn main() {
+    match "foo".as_bytes() {
+        b"food" => panic!(),
+        [b'f', ..] => (),
+        _ => panic!()
+    }
+}

--- a/src/test/run-pass/issue-24875.rs
+++ b/src/test/run-pass/issue-24875.rs
@@ -1,0 +1,25 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(slice_patterns)]
+
+fn main() {
+    let v = vec![1, 2];
+    assert_eq!(101, test(&v));
+}
+
+fn test(a: &[u64]) -> u64 {
+    match a {
+        [a, _b ..]  if a == 3  => 100,
+        [a, _b]     if a == 1  => 101,
+        [_a, _b ..]             => 102,
+        _                     => 103
+    }
+}

--- a/src/test/run-pass/issue-26251.rs
+++ b/src/test/run-pass/issue-26251.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    let x = 'a';
+
+    match x {
+            'a'...'b' if false => panic!(),
+            'a' => {},
+            'a'...'b' => panic!(),
+            _ => panic!("what?")
+    }
+}

--- a/src/test/run-pass/issue-26989.rs
+++ b/src/test/run-pass/issue-26989.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    match (0, 0) {
+        (0, ref _a) => {}
+        (_, 0) => {}
+        _ => {}
+    }
+}


### PR DESCRIPTION
The old code was not well structured, difficult to understand,
and buggy.

The new implementation is completely naive, so there may be a slight
runtime performance loss. That said, adding optimizations on top of
a clear and correct implementation seems easier than trying to
fix the old mess.

Fixes issue #19064.
Fixes issue #26989.
Fixes issue #26251.
Fixes issue #18060.
Fixes issue #24875.
Fixes issue #23311.
Fixes issue #20046.
