### PR TITLE
doc: add rel=prev/next for links to adjacent sections

### DIFF
--- a/src/rustbook/javascript.rs
+++ b/src/rustbook/javascript.rs
@@ -57,11 +57,13 @@ document.addEventListener("DOMContentLoaded", function(event) {
       if (i > 0) {
         var prevNode = toc[i-1].cloneNode(true);
         prevNode.className = 'left';
+        prevNode.setAttribute('rel', 'prev');
         nav.appendChild(prevNode);
       }
       if (i < toc.length - 1) {
         var nextNode = toc[i+1].cloneNode(true);
         nextNode.className = 'right';
+        nextNode.setAttribute('rel', 'next');
         nav.appendChild(nextNode);
       }
       document.getElementById('page').appendChild(nav);


### PR DESCRIPTION
This help people using keyboard navigation or with disabilities to
easily browse through pagination. For example, in Vimium, a reader can
do `[[` or `]]` to browse through the pages.

r? @steveklabnik 
