### PR TITLE
Improve register_diagnostics macro

### DIFF
--- a/src/libsyntax/diagnostics/macros.rs
+++ b/src/libsyntax/diagnostics/macros.rs
@@ -73,5 +73,8 @@ macro_rules! register_diagnostics {
 macro_rules! register_long_diagnostics {
     ($($code:tt: $description:tt),*) => (
         $(register_diagnostic! { $code, $description })*
+    );
+    ($($code:tt: $description:tt),*,) => (
+        $(register_diagnostic! { $code, $description })*
     )
 }

--- a/src/libsyntax/diagnostics/macros.rs
+++ b/src/libsyntax/diagnostics/macros.rs
@@ -63,6 +63,9 @@ macro_rules! fileline_help {
 macro_rules! register_diagnostics {
     ($($code:tt),*) => (
         $(register_diagnostic! { $code })*
+    );
+    ($($code:tt),*,) => (
+        $(register_diagnostic! { $code })*
     )
 }
 


### PR DESCRIPTION
Now the macro argument list can be finished by a comma (not sure this is correct english...).

cc @tamird
r? @bluss
