### PR TITLE
Improve error message for variant values used as types

### DIFF
--- a/src/librustc/ast_map/mod.rs
+++ b/src/librustc/ast_map/mod.rs
@@ -498,9 +498,8 @@ impl<'ast> Map<'ast> {
     {
         let parent = self.get_parent(id);
         let parent = match self.find_entry(id) {
-            Some(EntryForeignItem(..)) | Some(EntryVariant(..)) => {
-                // Anonymous extern items, enum variants and struct ctors
-                // go in the parent scope.
+            Some(EntryForeignItem(..)) => {
+                // Anonymous extern items go in the parent scope.
                 self.get_parent(parent)
             }
             // But tuple struct ctors don't have names, so use the path of its

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1476,8 +1476,10 @@ fn base_def_to_ty<'tcx>(this: &AstConv<'tcx>,
             prim_ty_to_ty(tcx, base_segments, prim_ty)
         }
         _ => {
+            let node = def.def_id().node;
             span_err!(tcx.sess, span, E0248,
-                      "found value name used as a type: {:?}", *def);
+                      "found value `{}` used as a type",
+                      tcx.map.path_to_string(node));
             return this.tcx().types.err;
         }
     }

--- a/src/test/compile-fail/enum-variant-type-2.rs
+++ b/src/test/compile-fail/enum-variant-type-2.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -14,6 +14,6 @@ enum Foo {
     Bar
 }
 
-fn foo(x: Foo::Bar) {} //~ERROR found value name used as a type
+fn foo(x: Foo::Bar) {} //~ERROR found value `Foo::Bar` used as a type
 
 fn main() {}

--- a/src/test/compile-fail/issue-17546.rs
+++ b/src/test/compile-fail/issue-17546.rs
@@ -1,0 +1,50 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use foo::MyEnum::Result;
+use foo::NoResult; // Through a re-export
+
+mod foo {
+    pub use self::MyEnum::NoResult;
+
+    enum MyEnum {
+        Result,
+        NoResult
+    }
+
+    fn new() -> NoResult<MyEnum, String> {
+        //~^ ERROR: found value `foo::MyEnum::NoResult` used as a type
+        unimplemented!()
+    }
+}
+
+mod bar {
+    use foo::MyEnum::Result;
+    use foo;
+
+    fn new() -> Result<foo::MyEnum, String> {
+        //~^ ERROR: found value `foo::MyEnum::Result` used as a type
+        unimplemented!()
+    }
+}
+
+fn new() -> Result<foo::MyEnum, String> {
+    //~^ ERROR: found value `foo::MyEnum::Result` used as a type
+    unimplemented!()
+}
+
+fn newer() -> NoResult<foo::MyEnum, String> {
+    //~^ ERROR: found value `foo::MyEnum::NoResult` used as a type
+    unimplemented!()
+}
+
+fn main() {
+    let _ = new();
+}

--- a/src/test/compile-fail/move-fragments-2.rs
+++ b/src/test/compile-fail/move-fragments-2.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -30,7 +30,7 @@ pub enum Lonely<X,Y> { Zero, One(X), Two(X, Y) }
 #[rustc_move_fragments]
 pub fn test_match_partial(p: Lonely<D, D>) {
     //~^ ERROR                 parent_of_fragments: `$(local p)`
-    //~| ERROR                  assigned_leaf_path: `($(local p) as Zero)`
+    //~| ERROR                  assigned_leaf_path: `($(local p) as Lonely::Zero)`
     match p {
         Zero(..) => {}
         _ => {}
@@ -40,9 +40,9 @@ pub fn test_match_partial(p: Lonely<D, D>) {
 #[rustc_move_fragments]
 pub fn test_match_full(p: Lonely<D, D>) {
     //~^ ERROR                 parent_of_fragments: `$(local p)`
-    //~| ERROR                  assigned_leaf_path: `($(local p) as Zero)`
-    //~| ERROR                  assigned_leaf_path: `($(local p) as One)`
-    //~| ERROR                  assigned_leaf_path: `($(local p) as Two)`
+    //~| ERROR                  assigned_leaf_path: `($(local p) as Lonely::Zero)`
+    //~| ERROR                  assigned_leaf_path: `($(local p) as Lonely::One)`
+    //~| ERROR                  assigned_leaf_path: `($(local p) as Lonely::Two)`
     match p {
         Zero(..) => {}
         One(..) => {}
@@ -53,10 +53,10 @@ pub fn test_match_full(p: Lonely<D, D>) {
 #[rustc_move_fragments]
 pub fn test_match_bind_one(p: Lonely<D, D>) {
     //~^ ERROR                 parent_of_fragments: `$(local p)`
-    //~| ERROR                  assigned_leaf_path: `($(local p) as Zero)`
-    //~| ERROR                 parent_of_fragments: `($(local p) as One)`
-    //~| ERROR                     moved_leaf_path: `($(local p) as One).#0`
-    //~| ERROR                  assigned_leaf_path: `($(local p) as Two)`
+    //~| ERROR                  assigned_leaf_path: `($(local p) as Lonely::Zero)`
+    //~| ERROR                 parent_of_fragments: `($(local p) as Lonely::One)`
+    //~| ERROR                     moved_leaf_path: `($(local p) as Lonely::One).#0`
+    //~| ERROR                  assigned_leaf_path: `($(local p) as Lonely::Two)`
     //~| ERROR                  assigned_leaf_path: `$(local data)`
     match p {
         Zero(..) => {}
@@ -68,13 +68,13 @@ pub fn test_match_bind_one(p: Lonely<D, D>) {
 #[rustc_move_fragments]
 pub fn test_match_bind_many(p: Lonely<D, D>) {
     //~^ ERROR                 parent_of_fragments: `$(local p)`
-    //~| ERROR                  assigned_leaf_path: `($(local p) as Zero)`
-    //~| ERROR                 parent_of_fragments: `($(local p) as One)`
-    //~| ERROR                     moved_leaf_path: `($(local p) as One).#0`
+    //~| ERROR                  assigned_leaf_path: `($(local p) as Lonely::Zero)`
+    //~| ERROR                 parent_of_fragments: `($(local p) as Lonely::One)`
+    //~| ERROR                     moved_leaf_path: `($(local p) as Lonely::One).#0`
     //~| ERROR                  assigned_leaf_path: `$(local data)`
-    //~| ERROR                 parent_of_fragments: `($(local p) as Two)`
-    //~| ERROR                     moved_leaf_path: `($(local p) as Two).#0`
-    //~| ERROR                     moved_leaf_path: `($(local p) as Two).#1`
+    //~| ERROR                 parent_of_fragments: `($(local p) as Lonely::Two)`
+    //~| ERROR                     moved_leaf_path: `($(local p) as Lonely::Two).#0`
+    //~| ERROR                     moved_leaf_path: `($(local p) as Lonely::Two).#1`
     //~| ERROR                  assigned_leaf_path: `$(local left)`
     //~| ERROR                  assigned_leaf_path: `$(local right)`
     match p {

--- a/src/test/compile-fail/move-fragments-3.rs
+++ b/src/test/compile-fail/move-fragments-3.rs
@@ -1,4 +1,4 @@
-// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -30,11 +30,11 @@ pub enum Lonely<X,Y> { Zero, One(X), Two(X, Y) }
 #[rustc_move_fragments]
 pub fn test_match_bind_and_underscore(p: Lonely<D, D>) {
     //~^ ERROR                 parent_of_fragments: `$(local p)`
-    //~| ERROR                  assigned_leaf_path: `($(local p) as Zero)`
-    //~| ERROR                  assigned_leaf_path: `($(local p) as One)`
-    //~| ERROR                 parent_of_fragments: `($(local p) as Two)`
-    //~| ERROR                     moved_leaf_path: `($(local p) as Two).#0`
-    //~| ERROR                    unmoved_fragment: `($(local p) as Two).#1`
+    //~| ERROR                  assigned_leaf_path: `($(local p) as Lonely::Zero)`
+    //~| ERROR                  assigned_leaf_path: `($(local p) as Lonely::One)`
+    //~| ERROR                 parent_of_fragments: `($(local p) as Lonely::Two)`
+    //~| ERROR                     moved_leaf_path: `($(local p) as Lonely::Two).#0`
+    //~| ERROR                    unmoved_fragment: `($(local p) as Lonely::Two).#1`
     //~| ERROR                  assigned_leaf_path: `$(local left)`
 
     match p {


### PR DESCRIPTION
This also changes how variant values are printed in errors, they are no
longer printed in their parent scope. As far as I can tell, this is
leftover from pre-namespacing of enums.

Closes #17546.
