### PR TITLE
Don't recurse down closures for duplicate-label checking

### DIFF
--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -372,6 +372,12 @@ fn extract_labels<'v, 'a>(ctxt: &mut LifetimeContext<'a>, b: &'v ast::Block) {
 
     impl<'v, 'a> Visitor<'v> for GatherLabels<'a> {
         fn visit_expr(&mut self, ex: &'v ast::Expr) {
+            // do not recurse into closures defined in the block
+            // since they are treated as separate fns from the POV of
+            // labels_in_fn
+            if let ast::ExprClosure(..) = ex.node {
+                return
+            }
             if let Some(label) = expression_label(ex) {
                 for &(prior, prior_span) in &self.labels_in_fn[..] {
                     // FIXME (#24278): non-hygienic comparison

--- a/src/test/run-pass/issue-25343.rs
+++ b/src/test/run-pass/issue-25343.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    || {
+        'label: loop {
+        }
+    };
+}


### PR DESCRIPTION
Fixes #25343

To be honest I'm not sure if this is the right fix (I haven't yet fully understood the code),
but it seems to work. I'll look closer at the code when I have some time, in the meantime if this
is the right fix it would be nice to get verification from someone who does understand the code :smile:

r? @pnkfelix
