### PR TITLE
Fix rustdoc formatting of impls

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -540,6 +540,19 @@ impl fmt::Display for clean::Type {
     }
 }
 
+impl fmt::Display for clean::Impl {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(f, "impl{} ", self.generics));
+        if let Some(ref ty) = self.trait_ {
+            try!(write!(f, "{}{} for ",
+                        if self.polarity == Some(clean::ImplPolarity::Negative) { "!" } else { "" },
+                        *ty));
+        }
+        try!(write!(f, "{}{}", self.for_, WhereClause(&self.generics)));
+        Ok(())
+    }
+}
+
 impl fmt::Display for clean::Arguments {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for (i, input) in self.values.iter().enumerate() {

--- a/src/test/auxiliary/rustdoc-impl-parts-crosscrate.rs
+++ b/src/test/auxiliary/rustdoc-impl-parts-crosscrate.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(optin_builtin_traits)]
+
+pub trait AnOibit {}
+
+impl AnOibit for .. {}

--- a/src/test/rustdoc/impl-parts-crosscrate.rs
+++ b/src/test/rustdoc/impl-parts-crosscrate.rs
@@ -1,0 +1,30 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:rustdoc-impl-parts-crosscrate.rs
+// ignore-cross-compile
+
+#![feature(optin_builtin_traits)]
+
+extern crate rustdoc_impl_parts_crosscrate;
+
+pub struct Bar<T> { t: T }
+
+// The output file is html embeded in javascript, so the html tags
+// aren't stripped by the processing script and we can't check for the
+// full impl string.  Instead, just make sure something from each part
+// is mentioned.
+
+// @has implementors/rustdoc_impl_parts_crosscrate/trait.AnOibit.js Bar
+// @has - Send
+// @has - !AnOibit
+// @has - Copy
+impl<T: Send> !rustdoc_impl_parts_crosscrate::AnOibit for Bar<T>
+    where T: Copy {}

--- a/src/test/rustdoc/impl-parts.rs
+++ b/src/test/rustdoc/impl-parts.rs
@@ -1,0 +1,23 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(optin_builtin_traits)]
+
+pub trait AnOibit {}
+
+impl AnOibit for .. {}
+
+pub struct Foo<T> { field: T }
+
+// @has impl_parts/struct.Foo.html '//*[@class="impl"]//code' \
+//     "impl<T: Clone> !AnOibit for Foo<T> where T: Sync"
+// @has impl_parts/trait.AnOibit.html '//*[@class="item-list"]//code' \
+//     "impl<T: Clone> !AnOibit for Foo<T> where T: Sync"
+impl<T: Clone> !AnOibit for Foo<T> where T: Sync {}


### PR DESCRIPTION
This fixes a couple of bugs visible on https://doc.rust-lang.org/nightly/std/marker/trait.Sync.html .  For example:
- `impl<T> Sync for *const T` should read `impl<T> !Sync for *const T`
- `impl<T> !Sync for Weak<T>` should read `impl<T> !Sync for Weak<T> where T: ?Sized`

This does change a struct in librustdoc and it seems that almost everything there is marked public, so if librustdoc has stability guarantees that could be a problem.  If it is, I'll find a way to rework the change to avoid modifying public structures.
