### PR TITLE
Make `$foo: ident` refutable in macro_rules!

### DIFF
--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -409,12 +409,19 @@ pub fn parse(sess: &ParseSess,
                             top_elts: Tt(TtSequence(sp, seq)),
                         }));
                     }
-                    TtToken(_, MatchNt(..)) => {
-                        // Built-in nonterminals never start with these tokens,
-                        // so we can eliminate them from consideration.
-                        match tok {
-                            token::CloseDelim(_) => {},
-                            _ => bb_eis.push(ei),
+                    TtToken(_, MatchNt(_, name, _, _)) => {
+                        if token::get_ident(name) == "ident" {
+                            match tok {
+                                token::Ident(..) => bb_eis.push(ei),
+                                _ =>  {}
+                            }
+                        } else {
+                            // Built-in nonterminals never start with these tokens,
+                            // so we can eliminate them from consideration.
+                            match tok {
+                                token::CloseDelim(_) => {},
+                                _ => bb_eis.push(ei),
+                            }
                         }
                     }
                     TtToken(sp, SubstNt(..)) => {

--- a/src/test/run-pass/macro-rules-refutable-ident.rs
+++ b/src/test/run-pass/macro-rules-refutable-ident.rs
@@ -1,0 +1,27 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! https://github.com/rust-lang/rust/pull/27115
+
+fn takes_str_argument(s: &str) -> &str { s }
+
+macro_rules! string_or_ident {
+    ($x: ident) => {
+        takes_str_argument(stringify!($x))
+    };
+    ($x: expr) => {
+        takes_str_argument($x)
+    };
+}
+
+fn main() {
+    assert_eq!(string_or_ident!(foo), "foo");
+    assert_eq!(string_or_ident!("foo"), "foo");
+}


### PR DESCRIPTION
This enables macros like:

``` rust
macro_rules! atom {
    ($atom: ident) => {
        $crate::Atom::from_slice(stringify!($atom))
    };
    ($atom: expr) => {
        $crate::Atom::from_slice($atom)
    };
}
```

that can be used either with an ident or a string: `atom!(html) == atom!("html")`. (`Atom::from_slice` takes a `&str`.)

r? @eddyb
