### PR TITLE
add separate errors for out-of-place associated consts and types

### DIFF
--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -305,5 +305,7 @@ register_diagnostics! {
     E0432, // unresolved import
     E0433, // failed to resolve
     E0434, // can't capture dynamic environment in a fn item
-    E0435  // attempt to use a non-constant value in a constant
+    E0435, // attempt to use a non-constant value in a constant
+    E0437, // type is not a member of trait
+    E0438, // const is not a member of trait
 }

--- a/src/test/compile-fail/trait-impl-can-not-have-untraitful-items.rs
+++ b/src/test/compile-fail/trait-impl-can-not-have-untraitful-items.rs
@@ -8,9 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(associated_consts)]
+
 trait A { }
 
 impl A for isize {
+    const BAR: () = (); //~ ERROR const `BAR` is not a member of trait `A`
+    type Baz = (); //~ ERROR type `Baz` is not a member of trait `A`
     fn foo(&self) { } //~ ERROR method `foo` is not a member of trait `A`
 }
 


### PR DESCRIPTION
Previously, these would both be labeled as methods.
