### PR TITLE
RFC: Btree query API

### DIFF
--- a/src/libcollections/btree/set.rs
+++ b/src/libcollections/btree/set.rs
@@ -304,11 +304,11 @@ impl<T: Ord> BTreeSet<T> {
         self.map.clear()
     }
 
-    /// Returns `true` if the set contains a value.
+    /// Returns `true` if the set contains the given element.
     ///
-    /// The value may be any borrowed form of the set's value type,
+    /// The element may be any borrowed form of the set's element type,
     /// but the ordering on the borrowed form *must* match the
-    /// ordering on the value type.
+    /// ordering on the element type.
     ///
     /// # Examples
     ///
@@ -320,8 +320,42 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(set.contains(&4), false);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn contains<Q: ?Sized>(&self, value: &Q) -> bool where T: Borrow<Q>, Q: Ord {
-        self.map.contains_key(value)
+    pub fn contains<Q: ?Sized>(&self, elem: &Q) -> bool where T: Borrow<Q>, Q: Ord {
+        self.map.contains_key(elem)
+    }
+
+    /// Gets the minimum element in the set.
+    pub fn min(&self) -> Option<&T> {
+        self.map.min().map(|r| r.0)
+    }
+
+    /// Gets the maximum element in the set.
+    pub fn max(&self) -> Option<&T> {
+        self.map.max().map(|r| r.0)
+    }
+
+    /// Gets the closest element to the given element that is less than it.
+    pub fn get_lt<Q: ?Sized>(&self, elem: &Q) -> Option<&T>
+    where T: Borrow<Q>, Q: Ord {
+        self.map.get_lt(elem).map(|r| r.0)
+    }
+
+    /// Gets the closest element to the given element that is less than or equal to it.
+    pub fn get_le<Q: ?Sized>(&self, elem: &Q) -> Option<&T>
+    where T: Borrow<Q>, Q: Ord {
+        self.map.get_le(elem).map(|r| r.0)
+    }
+
+    /// Gets the closest element to the given element that is greater than it.
+    pub fn get_gt<Q: ?Sized>(&self, elem: &Q) -> Option<&T>
+    where T: Borrow<Q>, Q: Ord {
+        self.map.get_gt(elem).map(|r| r.0)
+    }
+
+    /// Gets the closest element to the given element that is greater than or equal to it.
+    pub fn get_ge<Q: ?Sized>(&self, elem: &Q) -> Option<&T>
+    where T: Borrow<Q>, Q: Ord {
+        self.map.get_ge(elem).map(|r| r.0)
     }
 
     /// Returns `true` if the set has no elements in common with `other`.

--- a/src/libcollectionstest/bench.rs
+++ b/src/libcollectionstest/bench.rs
@@ -62,7 +62,7 @@ macro_rules! map_insert_seq_bench {
 }
 
 macro_rules! map_find_rand_bench {
-    ($name: ident, $n: expr, $map: ident) => (
+    ($name: ident, $n: expr, $map: ident, $lookup: ident) => (
         #[bench]
         pub fn $name(b: &mut ::test::Bencher) {
             use std::iter::Iterator;
@@ -86,7 +86,7 @@ macro_rules! map_find_rand_bench {
             // measure
             let mut i = 0;
             b.iter(|| {
-                let t = map.get(&keys[i]);
+                let t = $lookup(&map, &keys[i]);
                 i = (i + 1) % n;
                 black_box(t);
             })
@@ -95,7 +95,7 @@ macro_rules! map_find_rand_bench {
 }
 
 macro_rules! map_find_seq_bench {
-    ($name: ident, $n: expr, $map: ident) => (
+    ($name: ident, $n: expr, $map: ident, $lookup: ident) => (
         #[bench]
         pub fn $name(b: &mut ::test::Bencher) {
             use test::black_box;
@@ -111,7 +111,7 @@ macro_rules! map_find_seq_bench {
             // measure
             let mut i = 0;
             b.iter(|| {
-                let x = map.get(&i);
+                let x = $lookup(&map, &i);
                 i = (i + 1) % n;
                 black_box(x);
             })

--- a/src/libcollectionstest/vec_map.rs
+++ b/src/libcollectionstest/vec_map.rs
@@ -512,15 +512,17 @@ fn test_extend_ref() {
 mod bench {
     use std::collections::VecMap;
 
+    fn get<'a, V>(map: &'a VecMap<V>, key: &usize) -> Option<&'a V> { map.get(key) }
+
     map_insert_rand_bench!{insert_rand_100,    100,    VecMap}
     map_insert_rand_bench!{insert_rand_10_000, 10_000, VecMap}
 
     map_insert_seq_bench!{insert_seq_100,    100,    VecMap}
     map_insert_seq_bench!{insert_seq_10_000, 10_000, VecMap}
 
-    map_find_rand_bench!{find_rand_100,    100,    VecMap}
-    map_find_rand_bench!{find_rand_10_000, 10_000, VecMap}
+    map_find_rand_bench!{find_rand_100,    100,    VecMap, get}
+    map_find_rand_bench!{find_rand_10_000, 10_000, VecMap, get}
 
-    map_find_seq_bench!{find_seq_100,    100,    VecMap}
-    map_find_seq_bench!{find_seq_10_000, 10_000, VecMap}
+    map_find_seq_bench!{find_seq_100,    100,    VecMap, get}
+    map_find_seq_bench!{find_seq_10_000, 10_000, VecMap, get}
 }


### PR DESCRIPTION
This is an implementation of the core functionality of https://github.com/rust-lang/rfcs/pull/1195 which is not yet accepted (largely due to bikeshedding naming -- but also on what removal/entry APIs to expose).

Note that the vast majority of the code was generated by a program (see comments).

I believe I've exhaustively tested every single code path with my unit test.

Note that removal/entry APIs are not yet provided; I'm of the opinion that a major refactor of the internals to use parent pointers should be done first. Then search/removal/entry/range can basically share the exact same source code with no overhead. It's also expected to be substantially more efficient due to not needing to maintain an explicit search stack for insert/remove/range/entry.
