### PR TITLE
Fix iteration of destructor checker.

### DIFF
--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -525,6 +525,7 @@ fn iterate_over_potentially_unsafe_regions_in_type<'a, 'tcx>(
                     // and bare functions don't own instances
                     // of the types appearing within them.
                     walker.skip_current_subtree();
+                    breadcrumbs.pop();
                 }
                 _ => {}
             };

--- a/src/test/run-pass/issue-25750.rs
+++ b/src/test/run-pass/issue-25750.rs
@@ -1,0 +1,15 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn foo() -> Option<(Box<Fn(&Sized)>, Box<Fn(&Sized)>)> {
+    None
+}
+
+fn main() {}


### PR DESCRIPTION
Don't add a type to breadcrumbs vector when it is reference, pointer, or bare functions.
Fixes #25750
## 

The following example contains two `&Sized`.

``` rust
fn foo() -> Option<(Box<Fn(&Sized)>, Box<Fn(&Sized)>)> {
    None
}
```

So `&Sized` appears twice as `typ` [here](https://github.com/rust-lang/rust/blob/master/src/librustc_typeck/check/dropck.rs#L356).
Each time `&Sized` appears, `walker.skip_current_subtree()` should be called [here](https://github.com/rust-lang/rust/blob/master/src/librustc_typeck/check/dropck.rs#L527) in this case.
However, if `&Sized` is pushed to `breadcrumbs` at the first appearance, `skip_current_subtree()` will not be called at the second time.
