### PR TITLE
fixes #27124 for openbsd

### DIFF
--- a/src/librustc_back/target/openbsd_base.rs
+++ b/src/librustc_back/target/openbsd_base.rs
@@ -27,7 +27,7 @@ pub fn opts() -> TargetOptions {
             "-Wl,--as-needed".to_string(),
         ),
         position_independent_executables: true,
-        archive_format: "bsd".to_string(),
+        archive_format: "gnu".to_string(),
         .. Default::default()
     }
 }


### PR DESCRIPTION
the "bsd" archive_format don't work under openbsd.
use of "" (system ar) is ok.
use of "gnu" is ok too.

r? @alexcrichton 
