### PR TITLE
Make File's specialisation of read_to_end use the length of the file to size the Vec it gets passed

### DIFF
--- a/src/libstd/sys/common/io.rs
+++ b/src/libstd/sys/common/io.rs
@@ -24,9 +24,14 @@ use slice::from_raw_parts_mut;
 //  *  The implementation of read never reads the buffer provided.
 //  *  The implementation of read correctly reports how many bytes were written.
 pub unsafe fn read_to_end_uninitialized(r: &mut Read, buf: &mut Vec<u8>) -> io::Result<usize> {
+    read_to_end_uninitialized_hint(r, buf, 16)
+}
+
+pub unsafe fn read_to_end_uninitialized_hint(r: &mut Read, buf: &mut Vec<u8>, size_hint: usize)
+                                             -> io::Result<usize> {
 
     let start_len = buf.len();
-    buf.reserve(16);
+    buf.reserve(size_hint);
 
     // Always try to read into the empty space of the vector (from the length to the capacity).
     // If the vector ever fills up then we reserve an extra byte which should trigger the normal


### PR DESCRIPTION
Performance optimisation for File::read_to_end.  Currently reallocing in the vector takes a very large percentage of runtime for loading a large file.  This is unnecessary because File allows us to work out how much we have left to read, and we can use that information to size the vec in advance.
## Performance figures:
### Large (230MB+ file, 1024 initial vec capacity)

test sys_common::io::tests::bench_uninitialized_file            ... bench: 283,419,418 ns/iter (+/- 33,257,419)
test sys_common::io::tests::bench_uninitialized_file_hint       ... bench: 153,119,795 ns/iter (+/- 34,983,881)
### Small files:

Since I was concerned about small files - that there might be overhead when working out the remaining size of the file - I also did a test loading a large variety of 4KB files filled with random data.  I then experimented with different sizes of Vec being passed into the read_to_end function.  It looks like in the worst case (where the Vec is exactly sized to the file), the new code is a little slower, but otherwise it's generally faster.  I'm not too concerned about this - if you've already worked out the exact size of the file, you might just as well use read() instead.
#### Using Vec::new()

test sys_common::io::tests::bench_uninitialized_file_small      ... bench:       9,811 ns/iter (+/- 1,346)
test sys_common::io::tests::bench_uninitialized_file_small_hint ... bench:       6,789 ns/iter (+/- 579)
#### Using Vec::with_capacity(1024)

test sys_common::io::tests::bench_uninitialized_file_small      ... bench:       6,193 ns/iter (+/- 955)
test sys_common::io::tests::bench_uninitialized_file_small_hint ... bench:       5,896 ns/iter (+/- 525)
#### Using Vec::with_capacity(4096)

test sys_common::io::tests::bench_uninitialized_file_small      ... bench:       5,123 ns/iter (+/- 2,129)
test sys_common::io::tests::bench_uninitialized_file_small_hint ... bench:       5,936 ns/iter (+/- 605)
### 'Real' application

I tested loading the large file in a simple rust application, and the runtime of the app averaged ~200ms with this optimisation and ~350ms without.
