### PR TITLE
Revert "Fix `missing_docs` lint for const and static."

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1610,8 +1610,6 @@ impl LintPass for MissingDoc {
                 }
                 return
             },
-            ast::ItemConst(..) => "a constant",
-            ast::ItemStatic(..) => "a static",
             _ => return
         };
 

--- a/src/test/compile-fail/lint-missing-doc.rs
+++ b/src/test/compile-fail/lint-missing-doc.rs
@@ -149,27 +149,6 @@ pub enum PubBaz3 {
 #[doc(hidden)]
 pub fn baz() {}
 
-
-const FOO: u32 = 0;
-/// dox
-pub const FOO1: u32 = 0;
-#[allow(missing_docs)]
-pub const FOO2: u32 = 0;
-#[doc(hidden)]
-pub const FOO3: u32 = 0;
-pub const FOO4: u32 = 0; //~ ERROR: missing documentation for a const
-
-
-static BAR: u32 = 0;
-/// dox
-pub static BAR1: u32 = 0;
-#[allow(missing_docs)]
-pub static BAR2: u32 = 0;
-#[doc(hidden)]
-pub static BAR3: u32 = 0;
-pub static BAR4: u32 = 0; //~ ERROR: missing documentation for a static
-
-
 mod internal_impl {
     /// dox
     pub fn documented() {}


### PR DESCRIPTION
This reverts commit 00130cff99f88e13fec87378bdf476cfea6aa147.

As mentioned in a regression report[1](https://internals.rust-lang.org/t/new-crater-reports-1-1-stable-vs-beta-2015-07-10-and-nightly-2015-07-10/2358), this caused a notable amount
of breakage. Because there's a plan to mitigate[2](https://github.com/rust-lang/rfcs/pull/1193) this type of
breakage, I'm reverting this until then.
