### PR TITLE
Replace should_panic with {.should_panic}

### DIFF
--- a/src/doc/trpl/documentation.md
+++ b/src/doc/trpl/documentation.md
@@ -349,7 +349,7 @@ Here’s an example of documenting a macro:
 /// # }
 /// ```
 ///
-/// ```should_panic
+/// ```{.should_panic}
 /// # #[macro_use] extern crate foo;
 /// # fn main() {
 /// panic_unless!(true == false, “I’m broken.”);
@@ -398,14 +398,14 @@ with `text` if it's not code, or using `#`s to get a working example that
 only shows the part you care about.
 
 ```rust
-/// ```should_panic
+/// ```{.should_panic}
 /// assert!(false);
 /// ```
 # fn foo() {}
 ```
 
-`should_panic` tells `rustdoc` that the code should compile correctly, but
-not actually pass as a test.
+`{.should_panic}` tells `rustdoc` that the code should compile correctly,
+but not actually pass as a test.
 
 ```rust
 /// ```no_run


### PR DESCRIPTION
I found that `should_panic` in rustdoc tests by itself doesn't work for me. In the stdlib, I found use of `{.should_panic}`, which did the trick. Thus this doc change reflects current usage.

r? @steveklabnik
