### PR TITLE
Derive Copy for std::ops::Range and RangeFrom

### DIFF
--- a/src/libcore/ops.rs
+++ b/src/libcore/ops.rs
@@ -1001,7 +1001,7 @@ impl fmt::Debug for RangeFull {
 }
 
 /// A (half-open) range which is bounded at both ends.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[lang = "range"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Range<Idx> {
@@ -1021,7 +1021,7 @@ impl<Idx: fmt::Debug> fmt::Debug for Range<Idx> {
 }
 
 /// A range which is only bounded below.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[lang = "range_from"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RangeFrom<Idx> {


### PR DESCRIPTION
`RangeTo` and `RangeFull` already have it.
