### PR TITLE
expose drop_in_place as ptr::drop_in_place

### DIFF
--- a/src/doc/nomicon/destructors.md
+++ b/src/doc/nomicon/destructors.md
@@ -26,11 +26,10 @@ this is totally fine.
 For instance, a custom implementation of `Box` might write `Drop` like this:
 
 ```rust
-#![feature(heap_api, core_intrinsics, unique)]
+#![feature(heap_api, drop_in_place, unique)]
 
 use std::rt::heap;
-use std::ptr::Unique;
-use std::intrinsics::drop_in_place;
+use std::ptr::{drop_in_place, Unique};
 use std::mem;
 
 struct Box<T>{ ptr: Unique<T> }
@@ -54,11 +53,10 @@ use-after-free the `ptr` because when drop exits, it becomes inacessible.
 However this wouldn't work:
 
 ```rust
-#![feature(heap_api, core_intrinsics, unique)]
+#![feature(heap_api, drop_in_place, unique)]
 
 use std::rt::heap;
-use std::ptr::Unique;
-use std::intrinsics::drop_in_place;
+use std::ptr::{drop_in_place, Unique};
 use std::mem;
 
 struct Box<T>{ ptr: Unique<T> }
@@ -129,11 +127,10 @@ The classic safe solution to overriding recursive drop and allowing moving out
 of Self during `drop` is to use an Option:
 
 ```rust
-#![feature(heap_api, core_intrinsics, unique)]
+#![feature(heap_api, drop_in_place, unique)]
 
 use std::rt::heap;
-use std::ptr::Unique;
-use std::intrinsics::drop_in_place;
+use std::ptr::{drop_in_place, Unique};
 use std::mem;
 
 struct Box<T>{ ptr: Unique<T> }

--- a/src/liballoc/arc.rs
+++ b/src/liballoc/arc.rs
@@ -76,7 +76,7 @@ use core::atomic::Ordering::{Relaxed, Release, Acquire, SeqCst};
 use core::fmt;
 use core::cmp::Ordering;
 use core::mem::{align_of_val, size_of_val};
-use core::intrinsics::{drop_in_place, abort};
+use core::intrinsics::abort;
 use core::mem;
 use core::nonzero::NonZero;
 use core::ops::{Deref, CoerceUnsized};
@@ -265,7 +265,7 @@ impl<T: ?Sized> Arc<T> {
 
         // Destroy the data at this time, even though we may not free the box
         // allocation itself (there may still be weak pointers lying around).
-        drop_in_place(&mut (*ptr).data);
+        ptr::drop_in_place(&mut (*ptr).data);
 
         if self.inner().weak.fetch_sub(1, Release) == 1 {
             atomic::fence(Acquire);

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -96,6 +96,8 @@
 #![feature(unsize)]
 #![feature(core_slice_ext)]
 #![feature(core_str_ext)]
+#![feature(drop_in_place)]
+
 #![cfg_attr(stage0, feature(alloc_system))]
 #![cfg_attr(not(stage0), feature(needs_allocator))]
 

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -159,7 +159,7 @@ use core::cell::Cell;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hasher, Hash};
-use core::intrinsics::{assume, drop_in_place, abort};
+use core::intrinsics::{assume, abort};
 use core::marker::{self, Unsize};
 use core::mem::{self, align_of, size_of, align_of_val, size_of_val, forget};
 use core::nonzero::NonZero;
@@ -417,7 +417,7 @@ impl<T: ?Sized> Drop for Rc<T> {
                 self.dec_strong();
                 if self.strong() == 0 {
                     // destroy the contained object
-                    drop_in_place(&mut (*ptr).value);
+                    ptr::drop_in_place(&mut (*ptr).value);
 
                     // remove the implicit "strong weak" pointer now that we've
                     // destroyed the contents.

--- a/src/libcollections/lib.rs
+++ b/src/libcollections/lib.rs
@@ -56,6 +56,8 @@
 #![feature(unique)]
 #![feature(unsafe_no_drop_flag, filling_drop)]
 #![feature(utf8_error)]
+#![feature(drop_in_place)]
+
 #![cfg_attr(test, feature(rand, test))]
 
 #![feature(no_std)]

--- a/src/libcollections/vec.rs
+++ b/src/libcollections/vec.rs
@@ -65,7 +65,7 @@ use alloc::heap::EMPTY;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{self, Hash};
-use core::intrinsics::{arith_offset, assume, drop_in_place};
+use core::intrinsics::{arith_offset, assume};
 use core::iter::FromIterator;
 use core::mem;
 use core::ops::{Index, IndexMut, Deref};
@@ -1329,7 +1329,7 @@ impl<T> Drop for Vec<T> {
         // don't need unsafe_no_drop_flag shenanigans anymore.
         if self.buf.unsafe_no_drop_flag_needs_drop() {
             for x in self.iter_mut() {
-                unsafe { drop_in_place(x); }
+                unsafe { ptr::drop_in_place(x); }
             }
         }
         // RawVec handles deallocation

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -195,7 +195,26 @@ extern "rust-intrinsic" {
 
     pub fn size_of_val<T: ?Sized>(_: &T) -> usize;
     pub fn min_align_of_val<T: ?Sized>(_: &T) -> usize;
-    pub fn drop_in_place<T: ?Sized>(_: *mut T);
+
+    /// Executes the destructor (if any) of the pointed-to value.
+    ///
+    /// This has two usecases:
+    ///
+    /// * It is *required* to use `drop_in_place` to drop unsized types like
+    ///   trait objects, because they can't be read out onto the stack and
+    ///   dropped normally.
+    ///
+    /// * It is friendlier to the optimizer to do this over `ptr::read` when
+    ///   dropping manually allocated memory (e.g. when writing Box/Rc/Vec),
+    ///   as the compiler doesn't need to prove that it's sound to elide the
+    ///   copy.
+    ///
+    /// # Undefined Behaviour
+    ///
+    /// This has all the same safety problems as `ptr::read` with respect to
+    /// invalid pointers, types, and double drops.
+    #[unstable(feature = "drop_in_place", reason = "just exposed, needs FCP", issue = "27908")]
+    pub fn drop_in_place<T: ?Sized>(to_drop: *mut T);
 
     /// Gets a static string slice containing the name of a type.
     pub fn type_name<T: ?Sized>() -> &'static str;

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -39,6 +39,8 @@ pub use intrinsics::copy;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use intrinsics::write_bytes;
 
+pub use intrinsics::drop_in_place;
+
 /// Creates a null raw pointer.
 ///
 /// # Examples

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -245,6 +245,8 @@
 #![feature(vec_resize)]
 #![feature(wrapping)]
 #![feature(zero_one)]
+#![feature(drop_in_place)]
+
 #![cfg_attr(windows, feature(str_utf16))]
 #![cfg_attr(test, feature(float_from_str_radix, range_inclusive, float_extras, hash_default))]
 #![cfg_attr(test, feature(test, rustc_private, float_consts))]

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -411,7 +411,7 @@ mod imp {
         if cfg!(target_os = "macos") {
             ptr::read((*ptr).inner.get());
         } else {
-            intrinsics::drop_in_place((*ptr).inner.get());
+            ptr::drop_in_place((*ptr).inner.get());
         }
     }
 }

--- a/src/test/run-pass/extern_fat_drop.rs
+++ b/src/test/run-pass/extern_fat_drop.rs
@@ -10,7 +10,7 @@
 
 // aux-build:fat_drop.rs
 
-#![feature(core_intrinsics)]
+#![feature(core_intrinsics, drop_in_place)]
 
 extern crate fat_drop;
 


### PR DESCRIPTION
This intrinsic is necessary to drop DSTs and should generally be the way to drop memory before manually deallocating it. As such, it should be properly exposed by the standard library.
