### PR TITLE
make travis extreme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,7 @@ sudo: false
 before_script:
   - ./configure --enable-ccache
 script:
-  - make tidy
-  - make rustc-stage1 -j4
+  - make tidy check -j4
 
 env:
   - CXX=/usr/bin/g++-4.7


### PR DESCRIPTION
Only `make -j4` takes ~50 mins
`make check` bumps it up to ~1hr 30min

Travis seems more than happy to let this happen. 

Time limits appear to be meaningless.

Similar to the previous PR, it's easy to tell how much your PR definitely builds by checking the current logs or just considering how long it's been building for.
