### PR TITLE
Write deterministic archives

### DIFF
--- a/src/rustllvm/ArchiveWrapper.cpp
+++ b/src/rustllvm/ArchiveWrapper.cpp
@@ -168,7 +168,7 @@ LLVMRustWriteArchive(char *Dst,
       Members.push_back(NewArchiveIterator(Member->child, Member->name));
     }
   }
-  auto pair = writeArchive(Dst, Members, WriteSymbtab, Kind, false);
+  auto pair = writeArchive(Dst, Members, WriteSymbtab, Kind, true);
   if (!pair.second)
     return 0;
   LLVMRustSetLastError(pair.second.message().c_str());


### PR DESCRIPTION
Currently, `rustc` generates nondeterministic archives, which contain system timestamps. These don't really serve any useful purpose, and enabling deterministic archives moves us a little closer to completely deterministic builds. For a small toy library using `std::ops::{Deref,DerefMut}`, this change actually results in a bit-for-bit identical build every time.
