### PR TITLE
Added entries to explain expression-oriented languages

### DIFF
--- a/src/doc/trpl/glossary.md
+++ b/src/doc/trpl/glossary.md
@@ -3,24 +3,12 @@
 Not every Rustacean has a background in systems programming, nor in computer
 science, so we've added explanations of terms that might be unfamiliar.
 
-### Arity
-
-Arity refers to the number of arguments a function or operation takes.
-
-```rust
-let x = (2, 3);
-let y = (4, 6);
-let z = (8, 2, 6);
-```
-
-In the example above `x` and `y` have arity 2. `z` has arity 3.
-
 ### Abstract Syntax Tree
 
-When a compiler is compiling your program, it does a number of different
-things. One of the things that it does is turn the text of your program into an
-‘abstract syntax tree’, or ‘AST’. This tree is a representation of the
-structure of your program. For example, `2 + 3` can be turned into a tree:
+When a compiler is compiling your program, it does a number of different things.
+One of the things that it does is turn the text of your program into an
+‘abstract syntax tree’, or ‘AST’. This tree is a representation of the structure
+of your program. For example, `2 + 3` can be turned into a tree:
 
 ```text
   +
@@ -37,3 +25,39 @@ And `2 + (3 * 4)` would look like this:
    / \
   3   4
 ```
+
+### Arity
+
+Arity refers to the number of arguments a function or operation takes.
+
+```rust
+let x = (2, 3);
+let y = (4, 6);
+let z = (8, 2, 6);
+```
+
+In the example above `x` and `y` have arity 2. `z` has arity 3.
+
+### Expression
+
+In computer programming, an expression is a combination of values, constants,
+variables, operators and functions that evaluate to a single value. For example,
+`2 + (3 * 4)` is an expression that returns the value 14. It is worth noting
+that expressions can have side-effects. For example, a function included in an
+expression might perform actions other than simply returning a value.
+
+### Expression-Oriented Language
+
+In early programming languages [expressions] and [statements] were two separate
+syntactic categories: expressions had a value and statements did things.
+However, later languages blurred this distinction, allowing expressions to do
+things and statements to have a value. In an expression-oriented language,
+(nearly) every statement is an expression and therefore returns a value.
+
+[expressions]: glossary.html#expression
+[statements]: glossary.html#statement
+
+### Statement
+
+In computer programming, a statement is the smallest standalone element of a
+programming language that commands a computer to perform an action.

--- a/src/doc/trpl/glossary.md
+++ b/src/doc/trpl/glossary.md
@@ -53,6 +53,8 @@ syntactic categories: expressions had a value and statements did things.
 However, later languages blurred this distinction, allowing expressions to do
 things and statements to have a value. In an expression-oriented language,
 (nearly) every statement is an expression and therefore returns a value.
+Consequently these expression statements can themselves form part of larger
+expressions.
 
 [expressions]: glossary.html#expression
 [statements]: glossary.html#statement

--- a/src/doc/trpl/glossary.md
+++ b/src/doc/trpl/glossary.md
@@ -48,12 +48,12 @@ expression might perform actions other than simply returning a value.
 
 ### Expression-Oriented Language
 
-In early programming languages [expressions][expression] and
+In early programming languages, [expressions][expression] and
 [statements][statement] were two separate syntactic categories: expressions had
 a value and statements did things. However, later languages blurred this
 distinction, allowing expressions to do things and statements to have a value.
 In an expression-oriented language, (nearly) every statement is an expression
-and therefore returns a value. Consequently these expression statements can
+and therefore returns a value. Consequently, these expression statements can
 themselves form part of larger expressions.
 
 [expression]: glossary.html#expression

--- a/src/doc/trpl/glossary.md
+++ b/src/doc/trpl/glossary.md
@@ -48,16 +48,16 @@ expression might perform actions other than simply returning a value.
 
 ### Expression-Oriented Language
 
-In early programming languages [expressions] and [statements] were two separate
-syntactic categories: expressions had a value and statements did things.
-However, later languages blurred this distinction, allowing expressions to do
-things and statements to have a value. In an expression-oriented language,
-(nearly) every statement is an expression and therefore returns a value.
-Consequently these expression statements can themselves form part of larger
-expressions.
+In early programming languages [expressions][expression] and
+[statements][statement] were two separate syntactic categories: expressions had
+a value and statements did things. However, later languages blurred this
+distinction, allowing expressions to do things and statements to have a value.
+In an expression-oriented language, (nearly) every statement is an expression
+and therefore returns a value. Consequently these expression statements can
+themselves form part of larger expressions.
 
-[expressions]: glossary.html#expression
-[statements]: glossary.html#statement
+[expression]: glossary.html#expression
+[statement]: glossary.html#statement
 
 ### Statement
 

--- a/src/doc/trpl/hello-world.md
+++ b/src/doc/trpl/hello-world.md
@@ -111,10 +111,13 @@ string to the screen. Easy enough!
 
 [allocation]: the-stack-and-the-heap.html
 
-Finally, the line ends with a semicolon (`;`). Rust is an ‘expression oriented’
-language, which means that most things are expressions, rather than statements.
-The `;` is used to indicate that this expression is over, and the next one is
-ready to begin. Most lines of Rust code end with a `;`.
+Finally, the line ends with a semicolon (`;`). Rust is an [‘expression oriented’
+language][expression-oriented language], which means that most things are
+expressions, rather than statements. The `;` is used to indicate that this
+expression is over, and the next one is ready to begin. Most lines of Rust code
+end with a `;`.
+
+[expression-oriented language]: glossary.html#expression-oriented-language
 
 Finally, actually compiling and running our program. We can compile with our
 compiler, `rustc`, by passing it the name of our source file:


### PR DESCRIPTION
Added definitions for 'Expression', 'Expression-Oriented Language' and 'Statement' to glossary.
Sorted the definitions alphabetically.

r? @steveklabnik
