### PR TITLE
add `#[allow(unused_qualifications)]` to derived impls

### DIFF
--- a/src/libsyntax/ext/deriving/generic/mod.rs
+++ b/src/libsyntax/ext/deriving/generic/mod.rs
@@ -606,7 +606,13 @@ impl<'a> TraitDef<'a> {
         attr::mark_used(&attr);
         let opt_trait_ref = Some(trait_ref);
         let ident = ast_util::impl_pretty_name(&opt_trait_ref, Some(&*self_type));
-        let mut a = vec![attr];
+        let unused_qual = cx.attribute(
+            self.span,
+            cx.meta_list(self.span,
+                         InternedString::new("allow"),
+                         vec![cx.meta_word(self.span,
+                                           InternedString::new("unused_qualifications"))]));
+        let mut a = vec![attr, unused_qual];
         a.extend(self.attributes.iter().cloned());
         cx.item(
             self.span,

--- a/src/test/run-pass/issue-19102.rs
+++ b/src/test/run-pass/issue-19102.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![deny(unused_qualifications)]
+
+use self::A::B;
+
+#[derive(PartialEq)]
+pub enum A {
+    B,
+}
+
+fn main() {}


### PR DESCRIPTION
closes #19102
