### PR TITLE
Fix for issue #27008

### DIFF
--- a/src/librustc/middle/const_eval.rs
+++ b/src/librustc/middle/const_eval.rs
@@ -967,6 +967,9 @@ pub fn eval_const_expr_partial<'tcx>(tcx: &ty::ctxt<'tcx>,
               Some(def::DefVariant(enum_def, variant_def, _)) => {
                   (lookup_variant_by_id(tcx, enum_def, variant_def), None)
               }
+              Some(def::DefStruct(_)) => {
+                  return Ok(ConstVal::Struct(e.id))
+              }
               _ => (None, None)
           };
           let const_expr = match const_expr {

--- a/src/test/compile-fail/issue-27008.rs
+++ b/src/test/compile-fail/issue-27008.rs
@@ -1,0 +1,21 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+struct S;
+
+fn main() {
+    let b = [0; S];
+    //~^ ERROR mismatched types
+    //~| expected `usize`
+    //~| found `S`
+    //~| expected usize
+    //~| found struct `S`
+    //~| ERROR expected positive integer for repeat count, found struct
+}


### PR DESCRIPTION
Hi all.
This is my first contribution to Rust and fixes an issue causing an invalid error message to be presented to the user when using unit struct as length of a repeat expression, issue #27008. The solution is based on suggestions by @oli-obk, but as I'm a complete newbie to this, I have no clue if I got them right :)
The biggest concern I have is that if the `NodeId` I'm returning is the correct one or not (it's not meaningful in this case but I think it would be nice to get it right).
