### PR TITLE
trans: Try to detect the Universal CRT on MSVC

### DIFF
--- a/configure
+++ b/configure
@@ -1177,8 +1177,13 @@ do
             # INCLUDE and LIB variables for MSVC so we can set those in the
             # build system as well.
             install=$(reg QUERY \
-                       'HKLM\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\12.0' \
+                       'HKLM\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\14.0' \
                        -v InstallDir)
+            if [ -z "$install" ]; then
+              install=$(reg QUERY \
+                         'HKLM\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\12.0' \
+                         -v InstallDir)
+            fi
             need_ok "couldn't find visual studio install root"
             CFG_MSVC_ROOT=$(echo "$install" | grep InstallDir | sed 's/.*REG_SZ[ ]*//')
             CFG_MSVC_ROOT=$(dirname "$CFG_MSVC_ROOT")
@@ -1460,12 +1465,22 @@ do
 
         msg "configuring LLVM with:"
         msg "$CMAKE_ARGS"
+        case "$CFG_MSVC_ROOT" in
+            *14.0*)
+                generator="Visual Studio 14 2015"
+                ;;
+            *12.0*)
+                generator="Visual Studio 12 2013"
+                ;;
+            *)
+                err "can't determine generator for LLVM cmake"
+                ;;
+        esac
         case "$t" in
             x86_64-*)
-                generator="Visual Studio 12 2013 Win64"
+                generator="$generator Win64"
                 ;;
             i686-*)
-                generator="Visual Studio 12 2013"
                 ;;
             *)
                 err "can only build LLVM for x86 platforms"


### PR DESCRIPTION
Visual Studio 2015, recently released, includes the Universal CRT, a different
flavor than was provided before. The binaries and header files for this library
are included in new locations not previously known about by gcc-rs, and this
commit adds support for the necessary probing to find these.

Unfortunately there are no prior examples of this probing to be found in
frameworks like CMake or clang, so this is done is a bit of a sketchy method
today. It assumes that the installation is in a relatively standard format and
then blindly looks for the location of the UCRT. I'd love to switch this over to
using registry keys for probing, but I was currently unable to find such keys.

This should enable the compiler to work outside VS 2015 dev tools prompts.
