### PR TITLE
Unbalanced delimiters in macro_rules cause ICE

### DIFF
--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -302,8 +302,8 @@ fn check_lhs_nt_follows(cx: &mut ExtCtxt, lhs: &NamedMatch, sp: Span) {
             tt @ &TtSequence(..) => {
                 check_matcher(cx, Some(tt).into_iter(), &Eof);
             },
-            _ => cx.span_bug(sp, "wrong-structured lhs for follow check (didn't find \
-            a TtDelimited or TtSequence)")
+            _ => cx.span_err(sp, "Invalid macro matcher; matchers must be contained \
+               in balanced delimiters or a repetition indicator")
         },
         _ => cx.span_bug(sp, "wrong-structured lhs for follow check (didn't find a \
            MatchedNonterminal)")

--- a/src/test/compile-fail/invalid-macro-matcher.rs
+++ b/src/test/compile-fail/invalid-macro-matcher.rs
@@ -1,0 +1,6 @@
+macro_rules! invalid { //~ ERROR Invalid macro matcher
+    _ => ();
+}
+
+fn main() {
+}

--- a/src/test/compile-fail/invalid-macro-matcher.rs
+++ b/src/test/compile-fail/invalid-macro-matcher.rs
@@ -1,5 +1,15 @@
-macro_rules! invalid { //~ ERROR Invalid macro matcher
-    _ => ();
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! invalid {
+    _ => (); //~^ ERROR Invalid macro matcher
 }
 
 fn main() {


### PR DESCRIPTION
This introduces a test for #23389 and improves the error behaviour to treat the malformed LHS as an error, not a compiler bug.

The parse phase that precedes the call to `check_lhs_nt_follows` could possibly be enhanced to police the format itself (which the old code suggests was the original intention), but I'm not sure that's any nicer than just parsing the matcher as generic rust code and then policing the specific requirements for being a macro matcher afterwards (as this does).

Fixes #23389
