### PR TITLE
Speed up fannkuch-redux with unsafe code

### DIFF
--- a/src/test/bench/shootout-fannkuch-redux.rs
+++ b/src/test/bench/shootout-fannkuch-redux.rs
@@ -47,6 +47,7 @@ use std::intrinsics::copy;
 fn rotate(x: &mut [i32]) {
     let tmp = x[0];
     let last = x.len() - 1;
+    if last <= 0 { return; }
     unsafe { copy(&x[1], &mut x[0], last); }
     x[last] = tmp;
 }

--- a/src/test/bench/shootout-fannkuch-redux.rs
+++ b/src/test/bench/shootout-fannkuch-redux.rs
@@ -42,12 +42,13 @@
 
 use std::{cmp, mem};
 use std::thread;
+use std::intrinsics::copy;
 
 fn rotate(x: &mut [i32]) {
-    let mut prev = x[0];
-    for place in x.iter_mut().rev() {
-        prev = mem::replace(place, prev)
-    }
+    let tmp = x[0];
+    let last = x.len() - 1;
+    unsafe { copy(&x[1], &mut x[0], last); }
+    x[last] = tmp;
 }
 
 fn next_permutation(perm: &mut [i32], count: &mut [i32]) {


### PR DESCRIPTION
Knowing that the current version of fannkuch-redux uses a loop to rotate the slice (heh, good pun), I created a small microbenchmark using std::intrinsics::copy instead, rotating a 16-int-array. Results on my machine:

```
test bench_rotate_16     ... bench:         797 ns/iter (+/- 4)
test bench_rotate_16_new ... bench:          65 ns/iter (+/- 1)
```

Tested on nightly, but I think it _should_ work with beta, too. Seeing that reverse-complement already uses unsafe, we also may want to pursue it here.

r? @BurntSushi 
