### PR TITLE
rustc: Add a --cap-lints flag to the compiler

### DIFF
--- a/src/test/compile-fail/bad-lint-cap.rs
+++ b/src/test/compile-fail/bad-lint-cap.rs
@@ -1,0 +1,14 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --cap-lints test
+// error-pattern: unknown lint level: `test`
+
+fn main() {}

--- a/src/test/compile-fail/bad-lint-cap2.rs
+++ b/src/test/compile-fail/bad-lint-cap2.rs
@@ -1,0 +1,17 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --cap-lints deny
+
+#![deny(warnings)]
+
+use std::option; //~ ERROR
+
+fn main() {}

--- a/src/test/compile-fail/bad-lint-cap3.rs
+++ b/src/test/compile-fail/bad-lint-cap3.rs
@@ -1,0 +1,20 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --cap-lints warn
+
+#![deny(warnings)]
+#![feature(rustc_attrs)]
+
+use std::option; //~ WARN
+
+#[rustc_error]
+fn main() {} //~ ERROR: compilation successful
+

--- a/src/test/run-pass/lint-cap.rs
+++ b/src/test/run-pass/lint-cap.rs
@@ -1,0 +1,18 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// compile-flags: --cap-lints allow
+
+#![deny(warnings)]
+
+use std::option;
+
+fn main() {}
+


### PR DESCRIPTION
This commit is an implementation of [RFC 1193](https://github.com/rust-lang/rfcs/pull/1193) which adds the ability to
the compiler to cap the lint level for the entire compilation session. This flag
will ensure that no lints will go above this level, and Cargo will primarily use
this flag passing `--cap-lints allow` to all upstream dependencies.

Closes #27259
