### PR TITLE
Mention `pub` for structs and fields

### DIFF
--- a/src/doc/trpl/crates-and-modules.md
+++ b/src/doc/trpl/crates-and-modules.md
@@ -355,6 +355,10 @@ Hello in English: Hello!
 Goodbye in English: Goodbye.
 ```
 
+`pub` also applies to `struct`s and their member fields. In keeping with Rust’s
+tendency toward safety, simply making a `struct` public won't automatically
+make its members public: you must mark the fields individually with `pub`.
+
 Now that our functions are public, we can use them. Great! However, typing out
 `phrases::english::greetings::hello()` is very long and repetitive. Rust has
 another keyword for importing names into the current scope, so that you can


### PR DESCRIPTION
The reader could probably infer this from the current text, but for C++ programmers it's not obvious that struct fields don't automatically become public.

Apparently I wasn't the only one to be confused:

http://stackoverflow.com/questions/29157300/field-of-struct-is-private-when-importing-module

I don't think an example is necessary, but can add one if desired.

r? @steveklabnik 
