### PR TITLE
std::os::linux::raw: New definitions for mode_t

### DIFF
--- a/src/libstd/os/linux/raw.rs
+++ b/src/libstd/os/linux/raw.rs
@@ -12,8 +12,46 @@
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
+use os::raw;
+
+#[unstable(feature = "raw_linux_arch_dependant_ext",
+           reason = "Recently added and incomplete for other types")]
+#[cfg(not(any(target_arch = "cris",
+              target_arch = "parisc",
+              target_arch = "microblaze",
+              target_arch = "m68k",
+              target_arch = "sh",
+              target_arch = "arm",
+              target_arch = "avr32",
+              target_arch = "sparc",
+              target_arch = "frv",
+              target_arch = "blackfin",
+              target_arch = "mn10300",
+              target_arch = "x86",
+              target_arch = "x86_64",
+              target_arch = "m32r")))]
+pub type __kernel_mode_t = raw::c_uint;
+
+#[unstable(feature = "raw_linux_arch_dependant_ext",
+           reason = "Recently added and incomplete for other types")]
+#[cfg(any(target_arch = "cris",
+         target_arch = "parisc",
+         target_arch = "microblaze",
+         target_arch = "m68k",
+         target_arch = "sh",
+         target_arch = "arm",
+         target_arch = "avr32",
+         target_arch = "sparc",
+         target_arch = "frv",
+         target_arch = "blackfin",
+         target_arch = "mn10300",
+         target_arch = "x86",
+         target_arch = "x86_64",
+         target_arch = "m32r"))]
+pub type __kernel_mode_t = raw::c_ushort;
+
 #[stable(feature = "raw_ext", since = "1.1.0")] pub type dev_t = u64;
-#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = u32;
+#[stable(feature = "raw_ext", since = "1.1.0")] pub type mode_t = __kernel_mode_t;
 
 #[doc(inline)]
 pub use self::arch::{off_t, ino_t, nlink_t, blksize_t, blkcnt_t, stat, time_t};

--- a/src/libstd/sys/unix/ext/fs.rs
+++ b/src/libstd/sys/unix/ext/fs.rs
@@ -194,10 +194,10 @@ pub trait FileTypeExt {
 
 #[unstable(feature = "file_type_ext", reason = "recently added API")]
 impl FileTypeExt for fs::FileType {
-    fn is_block_device(&self) -> bool { self.as_inner().is(libc::S_IFBLK) }
-    fn is_char_device(&self) -> bool { self.as_inner().is(libc::S_IFCHR) }
-    fn is_fifo(&self) -> bool { self.as_inner().is(libc::S_IFIFO) }
-    fn is_socket(&self) -> bool { self.as_inner().is(libc::S_IFSOCK) }
+    fn is_block_device(&self) -> bool { self.as_inner().is(libc::S_IFBLK as raw::mode_t) }
+    fn is_char_device(&self) -> bool { self.as_inner().is(libc::S_IFCHR as raw::mode_t) }
+    fn is_fifo(&self) -> bool { self.as_inner().is(libc::S_IFIFO as raw::mode_t) }
+    fn is_socket(&self) -> bool { self.as_inner().is(libc::S_IFSOCK as raw::mode_t) }
 }
 
 /// Unix-specific extension methods for `fs::DirEntry`


### PR DESCRIPTION
The current definition of mode_t in std::os::linux::raw is incorrect, as it is either c_uint or c_ushort depending on the system's architecture

This pull request does the following:
- Changes std::os::linux::raw::mode_t to the correct type
- Introduces (unstable due to newness) std::os::linux::raw::__kernel_mode_t. I can introduce more __kernel_\* types if you'd like and mark them unstable under the same feature
- Introduces temporary filesystem workarounds. In a future PR, I'll introduce longer-lasting changes and remove these

Thanks in advance, hopefully I haven't messed up too badly :) It builds and tests okay on my local system, so it should be okay. 
