### PR TITLE
coercion: use a generalization of the target to specialize the source to coerce instead of propagating the wrong type.

### DIFF
--- a/src/test/compile-fail/destructure-trait-ref.rs
+++ b/src/test/compile-fail/destructure-trait-ref.rs
@@ -35,7 +35,7 @@ fn main() {
     // n == m
     let &x = &1isize as &T;      //~ ERROR type `&T` cannot be dereferenced
     let &&x = &(&1isize as &T);  //~ ERROR type `&T` cannot be dereferenced
-    let box x = box 1isize as Box<T>; //~ ERROR the trait `core::marker::Sized` is not implemented
+    let box x = box 1isize as Box<T>; //~ ERROR type `Box<T>` cannot be dereferenced
 
     // n > m
     let &&x = &1isize as &T;

--- a/src/test/run-pass/coerce-box-protocol.rs
+++ b/src/test/run-pass/coerce-box-protocol.rs
@@ -1,0 +1,134 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::rc::Rc;
+
+mod protocol {
+    use std::ptr;
+
+    pub trait BoxPlace<T>: Place<T> {
+        fn make() -> Self;
+    }
+
+    pub trait Place<T> {
+        // NOTE(eddyb) The use of `&mut T` here is to force
+        // the LLVM `noalias` and `dereferenceable(sizeof(T))`
+        // attributes, which are required for eliding the copy
+        // and producing actual in-place initialization via RVO.
+        // Neither of those attributes are present on `*mut T`,
+        // but `&mut T` is not a great choice either, the proper
+        // way might be to add those attributes to `Unique<T>`.
+        unsafe fn pointer(&mut self) -> &mut T;
+    }
+
+    pub trait Boxed<T>: Sized {
+        type P: Place<T>;
+        fn write_and_fin(mut place: Self::P,
+                        value: T)
+                        -> Self {
+            unsafe {
+                ptr::write(place.pointer(), value);
+                Self::fin(place)
+            }
+        }
+        unsafe fn fin(filled: Self::P) -> Self;
+    }
+}
+
+macro_rules! box_ {
+    ($x:expr) => {
+        ::protocol::Boxed::write_and_fin(::protocol::BoxPlace::make(), $x)
+    }
+}
+
+// Hacky implementations of the box protocol for Box<T> and Rc<T>.
+// They pass mem::uninitialized() to Box::new, and Rc::new, respectively,
+// to allocate memory and will leak the allocation in case of unwinding.
+mod boxed {
+    use std::mem;
+    use protocol;
+
+    pub struct Place<T> {
+        ptr: *mut T
+    }
+
+    impl<T> protocol::BoxPlace<T> for Place<T> {
+        fn make() -> Place<T> {
+            unsafe {
+                Place {
+                    ptr: mem::transmute(Box::new(mem::uninitialized::<T>()))
+                }
+            }
+        }
+    }
+
+    impl<T> protocol::Place<T> for Place<T> {
+        unsafe fn pointer(&mut self) -> &mut T { &mut *self.ptr }
+    }
+
+    impl<T> protocol::Boxed<T> for Box<T> {
+        type P = Place<T>;
+        unsafe fn fin(place: Place<T>) -> Box<T> {
+            mem::transmute(place.ptr)
+        }
+    }
+}
+
+mod rc {
+    use std::mem;
+    use std::rc::Rc;
+    use protocol;
+
+    pub struct Place<T> {
+        rc_ptr: *mut (),
+        data_ptr: *mut T
+    }
+
+    impl<T> protocol::BoxPlace<T> for Place<T> {
+        fn make() -> Place<T> {
+            unsafe {
+                let rc = Rc::new(mem::uninitialized::<T>());
+                Place {
+                    data_ptr: &*rc as *const _ as *mut _,
+                    rc_ptr: mem::transmute(rc)
+                }
+            }
+        }
+    }
+
+    impl<T> protocol::Place<T> for Place<T> {
+        unsafe fn pointer(&mut self) -> &mut T {
+            &mut *self.data_ptr
+        }
+    }
+
+    impl<T> protocol::Boxed<T> for Rc<T> {
+        type P = Place<T>;
+        unsafe fn fin(place: Place<T>) -> Rc<T> {
+            mem::transmute(place.rc_ptr)
+        }
+    }
+}
+
+fn main() {
+    let v = vec![1, 2, 3];
+
+    let bx: Box<_> = box_!(|| &v);
+    let rc: Rc<_> = box_!(|| &v);
+
+    assert_eq!(bx(), &v);
+    assert_eq!(rc(), &v);
+
+    let bx_trait: Box<Fn() -> _> = box_!(|| &v);
+    let rc_trait: Rc<Fn() -> _> = box_!(|| &v);
+
+    assert_eq!(bx(), &v);
+    assert_eq!(rc(), &v);
+}


### PR DESCRIPTION
The issue solved here involved generic "constructor" traits and unsizing coercions.
A real usecase is `box` desugaring, which is being demonstrated as a test-case.

Given such a trait with more than one implementation, e.g. for `Box<T>` and `Rc<T>`:

``` rust
trait Make<T> {
    fn make(T) -> Self;
}
impl<T> Make<T> for Box<T> {
    fn make(x: T) -> Box<T> { Box::new(x) }
}
impl<T> Make<T> for Rc<T> {
    fn make(x: T) -> Rc<T> { Rc::new(x) }
}
```

An direct call would be too unconstrained for a coercion, so the expected type ends up propagated:

``` rust
fn make_boxed_trait<E: Error>(x: E) -> Box<Error> {
    // error: Make<E> not implemented for Box<Error>.
    Make::make(x)
}
```

The workaround was to manually specify enough about the produced type to allow resolving it:

``` rust
fn make_boxed_trait<E: Error>(x: T) -> Box<Error> {
    let boxed: Box<_> = Make::make(x);
    // <Box<_> as Make<E>> gets selected to the appropriate impl, and so
    // boxed has the type Box<E> at this point, which can coerce to Box<Error>.
   boxed
}
```

That workaround is implemented in this PR, for all coercions where unsizing was ambiguous.
A generalized type is picked based on the `CoerceUnsize` impl that could be used for coercing.

For example, `CoerceUnsized<Box<Error>>` is implemented by `Box<T> forall T`, so the generalized
type is `Box<_>`, which matches both `Box<E>` and `Box<Error>`.
Such generalization allows constraining the source of the potential coercion while still allowing
it to be any type that could coerce to the target, or the target type itself.
