### PR TITLE
Rustdoc: Round out the search bar

### DIFF
--- a/src/librustdoc/html/static/main.css
+++ b/src/librustdoc/html/static/main.css
@@ -413,7 +413,7 @@ a {
     box-sizing: border-box !important;
     outline: none;
     border: none;
-    border-radius: 1px;
+    border-radius: 2em;
     color: #555;
     margin-top: 5px;
     padding: 10px 16px;


### PR DESCRIPTION
Please ignore the bad fill on the search bar, I haven't been bothered getting my themes fixed.

![rounded-search](https://cloud.githubusercontent.com/assets/639417/8892514/1bf0e848-339e-11e5-8857-d3520718c428.png)
Signed-off-by: Cruz Julian Bishop cruzjbishop@gmail.com
