### PR TITLE
Standardize on non-zero checks for configure

### DIFF
--- a/configure
+++ b/configure
@@ -283,7 +283,7 @@ opt_core() {
             fi
         done
     else
-        if [ ! -z "$META" ]
+        if [ -n "$META" ]
         then
             OP="$OP=<$META>"
         fi
@@ -317,7 +317,7 @@ envopt() {
     fi
 
     # If script or environment provided a value, save it.
-    if [ ! -z "$VV" ]
+    if [ -n "$VV" ]
     then
         putvar $V
     fi
@@ -767,7 +767,7 @@ probe CFG_LLDB             lldb
 # On MacOS X, invoking `javac` pops up a dialog if the JDK is not
 # installed. Since `javac` is only used if `antlr4` is available,
 # probe for it only in this case.
-if [ ! -z "$CFG_ANTLR4" ]
+if [ -n "$CFG_ANTLR4" ]
 then
    probe CFG_JAVAC            javac
 fi
@@ -786,14 +786,14 @@ then
     fi
 fi
 
-if [ ! -z "$CFG_GDB" ]
+if [ -n "$CFG_GDB" ]
 then
     # Store GDB's version
     CFG_GDB_VERSION=$($CFG_GDB --version 2>/dev/null | head -1)
     putvar CFG_GDB_VERSION
 fi
 
-if [ ! -z "$CFG_LLDB" ]
+if [ -n "$CFG_LLDB" ]
 then
     # Store LLDB's version
     CFG_LLDB_VERSION=$($CFG_LLDB --version 2>/dev/null | head -1)
@@ -819,7 +819,7 @@ step_msg "looking for target specific programs"
 
 probe CFG_ADB        adb
 
-if [ ! -z "$CFG_PANDOC" ]
+if [ -n "$CFG_PANDOC" ]
 then
     # Extract "MAJOR MINOR" from Pandoc's version number
     PV_MAJOR_MINOR=$(pandoc --version | grep '^pandoc' |
@@ -845,7 +845,7 @@ then
     BIN_SUF=.exe
 fi
 
-if [ ! -z "$CFG_ENABLE_LOCAL_RUST" ]
+if [ -n "$CFG_ENABLE_LOCAL_RUST" ]
 then
     system_rustc=$(which rustc)
     if [ -f ${CFG_LOCAL_RUST_ROOT}/bin/rustc${BIN_SUF} ]
@@ -930,18 +930,18 @@ fi
 
 # Okay, at this point, we have made up our minds about whether we are
 # going to force CFG_ENABLE_CLANG or not; save the setting if so.
-if [ ! -z "$CFG_ENABLE_CLANG" ]
+if [ -n "$CFG_ENABLE_CLANG" ]
 then
     putvar CFG_ENABLE_CLANG
 fi
 
 # Same with jemalloc.  save the setting here.
-if [ ! -z "$CFG_DISABLE_JEMALLOC" ]
+if [ -n "$CFG_DISABLE_JEMALLOC" ]
 then
     putvar CFG_DISABLE_JEMALLOC
 fi
 
-if [ ! -z "$CFG_LLVM_ROOT" -a -z "$CFG_DISABLE_LLVM_VERSION_CHECK" -a -e "$CFG_LLVM_ROOT/bin/llvm-config" ]
+if [ -n "$CFG_LLVM_ROOT" -a -z "$CFG_DISABLE_LLVM_VERSION_CHECK" -a -e "$CFG_LLVM_ROOT/bin/llvm-config" ]
 then
     step_msg "using custom LLVM at $CFG_LLVM_ROOT"
 
@@ -970,7 +970,7 @@ fi
 # CFG_ENABLE_CLANG is set, that indicates that we are opting into
 # running such safeguards.
 
-if [ ! -z "$CC" ]
+if [ -n "$CC" ]
 then
     msg "skipping compiler inference steps; using provided CC=$CC"
     CFG_CC="$CC"
@@ -983,7 +983,7 @@ then
         putvar CFG_USING_CLANG
     fi
 else
-    if [ ! -z "$CFG_ENABLE_CLANG" ]
+    if [ -n "$CFG_ENABLE_CLANG" ]
     then
         if [ -z "$CFG_CLANG" ]
         then
@@ -997,7 +997,7 @@ else
     fi
 fi
 
-if [ ! -z "$CFG_ENABLE_CLANG" ]
+if [ -n "$CFG_ENABLE_CLANG" ]
 then
     case "$CC" in
         (''|*clang)
@@ -1013,7 +1013,7 @@ then
             CFG_CLANG_VERSION=$(echo $CFG_CLANG_REPORTED_VERSION | sed 's/.*version \(.*\) .*/\1/')
         fi
 
-        if [ ! -z "$CFG_OSX_CLANG_VERSION" ]
+        if [ -n "$CFG_OSX_CLANG_VERSION" ]
         then
             case $CFG_OSX_CLANG_VERSION in
                 (7.0*)
@@ -1042,7 +1042,7 @@ then
     esac
 fi
 
-if [ ! -z "$CFG_ENABLE_CCACHE" ]
+if [ -n "$CFG_ENABLE_CCACHE" ]
 then
     if [ -z "$CFG_CCACHE" ]
     then
@@ -1199,7 +1199,7 @@ do
                     ;;
             esac
             bindir="${CFG_MSVC_ROOT}/VC/bin"
-            if [ ! -z "$msvc_part" ]; then
+            if [ -n "$msvc_part" ]; then
                 bindir="$bindir/$msvc_part"
             fi
             eval CFG_MSVC_BINDIR_$bits="\"$bindir\""
@@ -1229,7 +1229,7 @@ do
     esac
 done
 
-if [ ! -z "$CFG_PERF" ]
+if [ -n "$CFG_PERF" ]
 then
     HAVE_PERF_LOGFD=`$CFG_PERF stat --log-fd 2>&1 | grep 'unknown option'`
     if [ -z "$HAVE_PERF_LOGFD" ];
@@ -1339,11 +1339,11 @@ then
     "${CFG_GIT}" submodule init
 
     # Disable submodules that we're not using
-    if [ ! -z "${CFG_LLVM_ROOT}" ]; then
+    if [ -n "${CFG_LLVM_ROOT}" ]; then
         msg "git: submodule deinit src/llvm"
         "${CFG_GIT}" submodule deinit src/llvm
     fi
-    if [ ! -z "${CFG_JEMALLOC_ROOT}" ]; then
+    if [ -n "${CFG_JEMALLOC_ROOT}" ]; then
         msg "git: submodule deinit src/jemalloc"
         "${CFG_GIT}" submodule deinit src/jemalloc
     fi
@@ -1390,7 +1390,7 @@ do
     if [ -z $CFG_LLVM_ROOT ]
     then
         LLVM_BUILD_DIR=${CFG_BUILD_DIR}$t/llvm
-        if [ ! -z "$CFG_DISABLE_OPTIMIZE_LLVM" ]
+        if [ -n "$CFG_DISABLE_OPTIMIZE_LLVM" ]
         then
             LLVM_DBG_OPTS="--enable-debug-symbols --disable-optimized"
             # Just use LLVM straight from its build directory to
@@ -1446,7 +1446,7 @@ do
         msg "configuring LLVM for $t with cmake"
 
         CMAKE_ARGS="-DLLVM_INCLUDE_TESTS=OFF"
-        if [ ! -z "$CFG_DISABLE_OPTIMIZE_LLVM" ]; then
+        if [ -n "$CFG_DISABLE_OPTIMIZE_LLVM" ]; then
             CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_BUILD_TYPE=Debug"
         else
             CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release"
@@ -1538,7 +1538,7 @@ do
 
             (*)
             msg "inferring LLVM_CXX/CC from CXX/CC = $CXX/$CC"
-            if [ ! -z "$CFG_ENABLE_CCACHE" ]
+            if [ -n "$CFG_ENABLE_CCACHE" ]
             then
                 if [ -z "$CFG_CCACHE" ]
                 then
@@ -1672,20 +1672,20 @@ putvar CFG_MANDIR
 
 # Avoid spurious warnings from clang by feeding it original source on
 # ccache-miss rather than preprocessed input.
-if [ ! -z "$CFG_ENABLE_CCACHE" ] && [ ! -z "$CFG_USING_CLANG" ]
+if [ -n "$CFG_ENABLE_CCACHE" ] && [ -n "$CFG_USING_CLANG" ]
 then
     CFG_CCACHE_CPP2=1
     putvar CFG_CCACHE_CPP2
 fi
 
-if [ ! -z "$CFG_ENABLE_CCACHE" ]
+if [ -n "$CFG_ENABLE_CCACHE" ]
 then
     CFG_CCACHE_BASEDIR=${CFG_SRC_DIR}
     putvar CFG_CCACHE_BASEDIR
 fi
 
 
-if [ ! -z $BAD_PANDOC ]
+if [ -n $BAD_PANDOC ]
 then
     CFG_PANDOC=
     putvar CFG_PANDOC


### PR DESCRIPTION
It's odd that "! -z" was used instead of "-n" in some places.  Is perhaps, "! -z" more portable or something?
