### PR TITLE
Assorted diagnostics improvements

### DIFF
--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -674,8 +674,7 @@ impl<'a> LifetimeContext<'a> {
             for lifetime in lifetimes {
                 if special_idents.iter().any(|&i| i.name == lifetime.lifetime.name) {
                     span_err!(self.sess, lifetime.lifetime.span, E0262,
-                        "illegal lifetime parameter name: `{}`",
-                                lifetime.lifetime.name);
+                        "invalid lifetime parameter name: `{}`", lifetime.lifetime.name);
                 }
             }
 

--- a/src/librustc_trans/trans/expr.rs
+++ b/src/librustc_trans/trans/expr.rs
@@ -2325,7 +2325,7 @@ fn deref_once<'blk, 'tcx>(bcx: Block<'blk, 'tcx>,
         _ => {
             bcx.tcx().sess.span_bug(
                 expr.span,
-                &format!("deref invoked on expr of illegal type {:?}",
+                &format!("deref invoked on expr of invalid type {:?}",
                         datum.ty));
         }
     };

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4273,10 +4273,8 @@ pub fn check_representable(tcx: &ty::ctxt,
     // caught by case 1.
     match rty.is_representable(tcx, sp) {
       ty::SelfRecursive => {
-        span_err!(tcx.sess, sp, E0072,
-            "illegal recursive {} type; \
-             wrap the inner value in a box to make it representable",
-            designation);
+        span_err!(tcx.sess, sp, E0072, "invalid recursive {} type", designation);
+        tcx.sess.fileline_help(sp, "wrap the inner value in a box to make it representable");
         return false
       }
       ty::Representable | ty::ContainsRecursive => (),

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3468,7 +3468,7 @@ fn check_expr_with_unifier<'a, 'tcx, F>(fcx: &FnCtxt<'a, 'tcx>,
         let tcx = fcx.tcx();
         if !tcx.expr_is_lval(&**lhs) {
             span_err!(tcx.sess, expr.span, E0070,
-                "illegal left-hand side expression");
+                "invalid left-hand side expression");
         }
 
         let lhs_ty = fcx.expr_ty(&**lhs);

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -57,7 +57,7 @@ pub fn check_binop_assign<'a,'tcx>(fcx: &FnCtxt<'a,'tcx>,
 
     let tcx = fcx.tcx();
     if !tcx.expr_is_lval(lhs_expr) {
-        span_err!(tcx.sess, lhs_expr.span, E0067, "illegal left-hand side expression");
+        span_err!(tcx.sess, lhs_expr.span, E0067, "invalid left-hand side expression");
     }
 
     fcx.require_expr_have_sized_type(lhs_expr, traits::AssignmentLhsSized);

--- a/src/librustc_typeck/diagnostics.rs
+++ b/src/librustc_typeck/diagnostics.rs
@@ -778,7 +778,7 @@ the pointer the size of the type would need to be unbounded.
 Consider the following erroneous definition of a type for a list of bytes:
 
 ```
-// error, illegal recursive struct type
+// error, invalid recursive struct type
 struct ListNode {
     head: u8,
     tail: Option<ListNode>,
@@ -2345,7 +2345,7 @@ register_diagnostics! {
     E0241,
     E0242, // internal error looking up a definition
     E0245, // not a trait
-    E0246, // illegal recursive type
+    E0246, // invalid recursive type
     E0247, // found module name used as a type
     E0248, // found value name used as a type
     E0319, // trait impls for defaulted traits allowed just for structs/enums

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -694,7 +694,7 @@ impl<'a> StringReader<'a> {
             accum_int *= 16;
             accum_int += c.to_digit(16).unwrap_or_else(|| {
                 self.err_span_char(self.last_pos, self.pos,
-                              "illegal character in numeric character escape", c);
+                              "invalid character in numeric character escape", c);
 
                 valid = false;
                 0
@@ -714,7 +714,7 @@ impl<'a> StringReader<'a> {
             Some(_) => valid,
             None => {
                 let last_bpos = self.last_pos;
-                self.err_span_(start_bpos, last_bpos, "illegal numeric character escape");
+                self.err_span_(start_bpos, last_bpos, "invalid numeric character escape");
                 false
             }
         }
@@ -846,7 +846,7 @@ impl<'a> StringReader<'a> {
                                      "unterminated unicode escape (needed a `}`)");
                 } else {
                     self.err_span_char(self.last_pos, self.pos,
-                                   "illegal character in unicode escape", c);
+                                   "invalid character in unicode escape", c);
                 }
                 valid = false;
                 0
@@ -862,7 +862,7 @@ impl<'a> StringReader<'a> {
         }
 
         if valid && (char::from_u32(accum_int).is_none() || count == 0) {
-            self.err_span_(start_bpos, self.last_pos, "illegal unicode character escape");
+            self.err_span_(start_bpos, self.last_pos, "invalid unicode character escape");
             valid = false;
         }
 
@@ -1138,8 +1138,8 @@ impl<'a> StringReader<'a> {
                 let last_bpos = self.last_pos;
                 let curr_char = self.curr.unwrap();
                 self.fatal_span_char(start_bpos, last_bpos,
-                                "only `#` is allowed in raw string delimitation; \
-                                 found illegal character",
+                                "found invalid character; \
+                                 only `#` is allowed in raw string delimitation",
                                 curr_char);
             }
             self.bump();
@@ -1323,8 +1323,8 @@ impl<'a> StringReader<'a> {
             let last_pos = self.last_pos;
             let ch = self.curr.unwrap();
             self.fatal_span_char(start_bpos, last_pos,
-                            "only `#` is allowed in raw string delimitation; \
-                             found illegal character",
+                            "found invalid character; \
+                             only `#` is allowed in raw string delimitation",
                             ch);
         }
         self.bump();

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -446,11 +446,11 @@ fn filtered_float_lit(data: token::InternedString, suffix: Option<&str>,
         Some(suf) => {
             if suf.len() >= 2 && looks_like_width_suffix(&['f'], suf) {
                 // if it looks like a width, lets try to be helpful.
-                sd.span_err(sp, &*format!("illegal width `{}` for float literal, \
-                                          valid widths are 32 and 64", &suf[1..]));
+                sd.span_err(sp, &*format!("invalid width `{}` for float literal", &suf[1..]));
+                sd.fileline_help(sp, "valid widths are 32 and 64");
             } else {
-                sd.span_err(sp, &*format!("illegal suffix `{}` for float literal, \
-                                          valid suffixes are `f32` and `f64`", suf));
+                sd.span_err(sp, &*format!("invalid suffix `{}` for float literal", suf));
+                sd.fileline_help(sp, "valid suffixes are `f32` and `f64`");
             }
 
             ast::LitFloatUnsuffixed(data)
@@ -619,11 +619,11 @@ pub fn integer_lit(s: &str,
                 // i<digits> and u<digits> look like widths, so lets
                 // give an error message along those lines
                 if looks_like_width_suffix(&['i', 'u'], suf) {
-                    sd.span_err(sp, &*format!("illegal width `{}` for integer literal; \
-                                              valid widths are 8, 16, 32 and 64",
+                    sd.span_err(sp, &*format!("invalid width `{}` for integer literal",
                                               &suf[1..]));
+                    sd.fileline_help(sp, "valid widths are 8, 16, 32 and 64");
                 } else {
-                    sd.span_err(sp, &*format!("illegal suffix `{}` for numeric literal", suf));
+                    sd.span_err(sp, &*format!("invalid suffix `{}` for numeric literal", suf));
                     sd.fileline_help(sp, "the suffix must be one of the integral types \
                                       (`u32`, `isize`, etc)");
                 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -681,7 +681,7 @@ impl<'a> Parser<'a> {
                 if text.is_empty() {
                     self.span_bug(sp, "found empty literal suffix in Some")
                 }
-                self.span_err(sp, &*format!("{} with a suffix is illegal", kind));
+                self.span_err(sp, &*format!("{} with a suffix is invalid", kind));
             }
         }
     }
@@ -5286,7 +5286,7 @@ impl<'a> Parser<'a> {
                         let last_span = self.last_span;
                         self.span_err(
                             last_span,
-                            &format!("illegal ABI: expected one of [{}], \
+                            &format!("invalid ABI: expected one of [{}], \
                                      found `{}`",
                                     abi::all_names().join(", "),
                                     s));

--- a/src/test/compile-fail/bad-expr-lhs.rs
+++ b/src/test/compile-fail/bad-expr-lhs.rs
@@ -9,12 +9,12 @@
 // except according to those terms.
 
 fn main() {
-    1 = 2; //~ ERROR illegal left-hand side expression
-    1 += 2; //~ ERROR illegal left-hand side expression
-    (1, 2) = (3, 4); //~ ERROR illegal left-hand side expression
+    1 = 2; //~ ERROR invalid left-hand side expression
+    1 += 2; //~ ERROR invalid left-hand side expression
+    (1, 2) = (3, 4); //~ ERROR invalid left-hand side expression
 
     let (a, b) = (1, 2);
-    (a, b) = (3, 4); //~ ERROR illegal left-hand side expression
+    (a, b) = (3, 4); //~ ERROR invalid left-hand side expression
 
-    None = Some(3); //~ ERROR illegal left-hand side expression
+    None = Some(3); //~ ERROR invalid left-hand side expression
 }

--- a/src/test/compile-fail/cast-as-bool.rs
+++ b/src/test/compile-fail/cast-as-bool.rs
@@ -8,5 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: cannot cast as `bool`, compare with zero instead
-fn main() { let u = (5 as bool); }
+fn main() {
+    let u = (5 as bool);
+    //~^ ERROR cannot cast as `bool`
+    //~^^ HELP compare with zero instead
+}

--- a/src/test/compile-fail/cast-rfc0401.rs
+++ b/src/test/compile-fail/cast-rfc0401.rs
@@ -10,12 +10,16 @@
 
 fn illegal_cast<U:?Sized,V:?Sized>(u: *const U) -> *const V
 {
-    u as *const V //~ ERROR vtable kinds
+    u as *const V
+    //~^ ERROR casting
+    //~^^ NOTE vtable kinds
 }
 
 fn illegal_cast_2<U:?Sized>(u: *const U) -> *const str
 {
-    u as *const str //~ ERROR vtable kinds
+    u as *const str
+    //~^ ERROR casting
+    //~^^ NOTE vtable kinds
 }
 
 trait Foo { fn foo(&self) {} }
@@ -41,32 +45,58 @@ fn main()
     let _ = v as (u32,); //~ ERROR non-scalar
     let _ = Some(&v) as *const u8; //~ ERROR non-scalar
 
-    let _ = v as f32; //~ ERROR through a usize first
-    let _ = main as f64; //~ ERROR through a usize first
-    let _ = &v as usize; //~ ERROR through a raw pointer first
-    let _ = f as *const u8; //~ ERROR through a usize first
-    let _ = 3 as bool; //~ ERROR compare with zero
-    let _ = E::A as bool; //~ ERROR compare with zero
+    let _ = v as f32;
+    //~^ ERROR casting
+    //~^^ HELP through a usize first
+    let _ = main as f64;
+    //~^ ERROR casting
+    //~^^ HELP through a usize first
+    let _ = &v as usize;
+    //~^ ERROR casting
+    //~^^ HELP through a raw pointer first
+    let _ = f as *const u8;
+    //~^ ERROR casting
+    //~^^ HELP through a usize first
+    let _ = 3 as bool;
+    //~^ ERROR cannot cast as `bool`
+    //~^^ HELP compare with zero
+    let _ = E::A as bool;
+    //~^ ERROR cannot cast as `bool`
+    //~^^ HELP compare with zero
     let _ = 0x61u32 as char; //~ ERROR only `u8` can be cast
 
-    let _ = false as f32; //~ ERROR through an integer first
-    let _ = E::A as f32; //~ ERROR through an integer first
-    let _ = 'a' as f32; //~ ERROR through an integer first
+    let _ = false as f32;
+    //~^ ERROR casting
+    //~^^ HELP through an integer first
+    let _ = E::A as f32;
+    //~^ ERROR casting
+    //~^^ HELP through an integer first
+    let _ = 'a' as f32;
+    //~^ ERROR casting
+    //~^^ HELP through an integer first
 
-    let _ = false as *const u8; //~ ERROR through a usize first
-    let _ = E::A as *const u8; //~ ERROR through a usize first
-    let _ = 'a' as *const u8; //~ ERROR through a usize first
+    let _ = false as *const u8;
+    //~^ ERROR casting
+    //~^^ HELP through a usize first
+    let _ = E::A as *const u8;
+    //~^ ERROR casting
+    //~^^ HELP through a usize first
+    let _ = 'a' as *const u8;
+    //~^ ERROR casting
+    //~^^ HELP through a usize first
 
-    let _ = 42usize as *const [u8]; //~ ERROR illegal cast
-    let _ = v as *const [u8]; //~ ERROR illegal cast
+    let _ = 42usize as *const [u8]; //~ ERROR casting
+    let _ = v as *const [u8]; //~ ERROR casting
     let _ = fat_v as *const Foo;
     //~^ ERROR `core::marker::Sized` is not implemented for the type `[u8]`
-    let _ = foo as *const str; //~ ERROR illegal cast
-    let _ = foo as *mut str; //~ ERROR illegal cast
-    let _ = main as *mut str; //~ ERROR illegal cast
-    let _ = &f as *mut f32; //~ ERROR illegal cast
-    let _ = &f as *const f64; //~ ERROR illegal cast
-    let _ = fat_v as usize; //~ ERROR through a raw pointer first
+    let _ = foo as *const str; //~ ERROR casting
+    let _ = foo as *mut str; //~ ERROR casting
+    let _ = main as *mut str; //~ ERROR casting
+    let _ = &f as *mut f32; //~ ERROR casting
+    let _ = &f as *const f64; //~ ERROR casting
+    let _ = fat_v as usize;
+    //~^ ERROR casting
+    //~^^ HELP through a raw pointer first
 
     let a : *const str = "hello";
     let _ = a as *const Foo;
@@ -76,6 +106,10 @@ fn main()
     let _ = main.f as *const u32; //~ ERROR attempted access of field
 
     let cf: *const Foo = &0;
-    let _ = cf as *const [u8]; //~ ERROR vtable kinds
-    let _ = cf as *const Bar; //~ ERROR vtable kinds
+    let _ = cf as *const [u8];
+    //~^ ERROR casting
+    //~^^ NOTE vtable kinds
+    let _ = cf as *const Bar;
+    //~^ ERROR casting
+    //~^^ NOTE vtable kinds
 }

--- a/src/test/compile-fail/const-cast-different-types.rs
+++ b/src/test/compile-fail/const-cast-different-types.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 
 static a: &'static str = "foo";
-static b: *const u8 = a as *const u8; //~ ERROR illegal cast
-static c: *const u8 = &a as *const u8; //~ ERROR illegal cast
+static b: *const u8 = a as *const u8; //~ ERROR casting
+static c: *const u8 = &a as *const u8; //~ ERROR casting
 
 fn main() {
 }

--- a/src/test/compile-fail/enum-to-float-cast-2.rs
+++ b/src/test/compile-fail/enum-to-float-cast-2.rs
@@ -21,8 +21,8 @@ enum F {
 }
 
 pub fn main() {
-    let a = E::L0 as f32;  //~ ERROR illegal cast
-    let c = F::H1 as f32;  //~ ERROR illegal cast
+    let a = E::L0 as f32;  //~ ERROR casting
+    let c = F::H1 as f32;  //~ ERROR casting
     assert_eq!(a, -1.0f32);
     assert_eq!(c, -1.0f32);
 }

--- a/src/test/compile-fail/enum-to-float-cast.rs
+++ b/src/test/compile-fail/enum-to-float-cast.rs
@@ -20,8 +20,8 @@ enum F {
     H1 = 0xFFFFFFFFFFFFFFFF
 }
 
-static C0: f32 = E::L0 as f32; //~ ERROR illegal cast
-static C1: f32 = F::H1 as f32; //~ ERROR illegal cast
+static C0: f32 = E::L0 as f32; //~ ERROR casting
+static C1: f32 = F::H1 as f32; //~ ERROR casting
 
 pub fn main() {
     let b = C0;

--- a/src/test/compile-fail/fat-ptr-cast.rs
+++ b/src/test/compile-fail/fat-ptr-cast.rs
@@ -17,14 +17,16 @@ fn main() {
     let p = a as *const [i32];
     let q = a.as_ptr();
 
-    a as usize; //~ ERROR illegal cast
+    a as usize; //~ ERROR casting
     b as usize; //~ ERROR non-scalar cast
-    p as usize; //~ ERROR illegal cast; cast through a raw pointer
+    p as usize;
+    //~^ ERROR casting
+    //~^^ HELP cast through a raw pointer
 
     // #22955
-    q as *const [i32]; //~ ERROR illegal cast
+    q as *const [i32]; //~ ERROR casting
 
     // #21397
-    let t: *mut (Trait + 'static) = 0 as *mut _; //~ ERROR illegal cast
-    let mut fail: *const str = 0 as *const str; //~ ERROR illegal cast
+    let t: *mut (Trait + 'static) = 0 as *mut _; //~ ERROR casting
+    let mut fail: *const str = 0 as *const str; //~ ERROR casting
 }

--- a/src/test/compile-fail/infinite-tag-type-recursion.rs
+++ b/src/test/compile-fail/infinite-tag-type-recursion.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 
-// error-pattern: illegal recursive enum type; wrap the inner value in a box
+// error-pattern: invalid recursive enum type
 
 enum mlist { cons(isize, mlist), nil, }
 

--- a/src/test/compile-fail/issue-13407.rs
+++ b/src/test/compile-fail/issue-13407.rs
@@ -14,6 +14,6 @@ mod A {
 
 fn main() {
     A::C = 1;
-    //~^ ERROR: illegal left-hand side expression
+    //~^ ERROR: invalid left-hand side expression
     //~| ERROR: mismatched types
 }

--- a/src/test/compile-fail/issue-14845.rs
+++ b/src/test/compile-fail/issue-14845.rs
@@ -15,8 +15,8 @@ struct X {
 
 fn main() {
     let x = X { a: [0] };
-    let _f = &x.a as *mut u8; //~ ERROR illegal cast
+    let _f = &x.a as *mut u8; //~ ERROR casting
 
     let local: [u8; 1] = [0];
-    let _v = &local as *mut u8; //~ ERROR illegal cast
+    let _v = &local as *mut u8; //~ ERROR casting
 }

--- a/src/test/compile-fail/issue-17431-1.rs
+++ b/src/test/compile-fail/issue-17431-1.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct Foo { foo: Option<Option<Foo>> }
-//~^ ERROR illegal recursive struct type; wrap the inner value in a box to make it representable
+//~^ ERROR invalid recursive struct type
 
 impl Foo { fn bar(&self) {} }
 

--- a/src/test/compile-fail/issue-17431-2.rs
+++ b/src/test/compile-fail/issue-17431-2.rs
@@ -9,10 +9,10 @@
 // except according to those terms.
 
 struct Baz { q: Option<Foo> }
-//~^ ERROR illegal recursive struct type; wrap the inner value in a box to make it representable
+//~^ ERROR invalid recursive struct type
 
 struct Foo { q: Option<Baz> }
-//~^ ERROR illegal recursive struct type; wrap the inner value in a box to make it representable
+//~^ ERROR invalid recursive struct type
 
 impl Foo { fn bar(&self) {} }
 

--- a/src/test/compile-fail/issue-17431-3.rs
+++ b/src/test/compile-fail/issue-17431-3.rs
@@ -11,7 +11,7 @@
 use std::sync::Mutex;
 
 struct Foo { foo: Mutex<Option<Foo>> }
-//~^ ERROR illegal recursive struct type; wrap the inner value in a box to make it representable
+//~^ ERROR invalid recursive struct type
 
 impl Foo { fn bar(&self) {} }
 

--- a/src/test/compile-fail/issue-17431-4.rs
+++ b/src/test/compile-fail/issue-17431-4.rs
@@ -11,7 +11,7 @@
 use std::marker;
 
 struct Foo<T> { foo: Option<Option<Foo<T>>>, marker: marker::PhantomData<T> }
-//~^ ERROR illegal recursive struct type; wrap the inner value in a box to make it representable
+//~^ ERROR invalid recursive struct type
 
 impl<T> Foo<T> { fn bar(&self) {} }
 

--- a/src/test/compile-fail/issue-17431-5.rs
+++ b/src/test/compile-fail/issue-17431-5.rs
@@ -12,7 +12,7 @@ use std::marker;
 
 struct Foo { foo: Bar<Foo> }
 struct Bar<T> { x: Bar<Foo> , marker: marker::PhantomData<T> }
-//~^ ERROR illegal recursive struct type; wrap the inner value in a box to make it representable
+//~^ ERROR invalid recursive struct type
 
 impl Foo { fn foo(&self) {} }
 

--- a/src/test/compile-fail/issue-17431-6.rs
+++ b/src/test/compile-fail/issue-17431-6.rs
@@ -11,7 +11,7 @@
 use std::sync::Mutex;
 
 enum Foo { X(Mutex<Option<Foo>>) }
-//~^ ERROR illegal recursive enum type; wrap the inner value in a box to make it representable
+//~^ ERROR invalid recursive enum type
 
 impl Foo { fn bar(self) {} }
 

--- a/src/test/compile-fail/issue-17431-7.rs
+++ b/src/test/compile-fail/issue-17431-7.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 enum Foo { Voo(Option<Option<Foo>>) }
-//~^ ERROR illegal recursive enum type; wrap the inner value in a box to make it representable
+//~^ ERROR invalid recursive enum type
 
 impl Foo { fn bar(&self) {} }
 

--- a/src/test/compile-fail/issue-17444.rs
+++ b/src/test/compile-fail/issue-17444.rs
@@ -14,5 +14,6 @@ enum Test {
 
 fn main() {
     let _x = Test::Foo as *const isize;
-    //~^ ERROR illegal cast; cast through a usize first: `Test` as `*const isize`
+    //~^ ERROR casting `Test` as `*const isize` is invalid
+    //~^^ HELP cast through a usize first
 }

--- a/src/test/compile-fail/issue-21554.rs
+++ b/src/test/compile-fail/issue-21554.rs
@@ -11,5 +11,7 @@
 struct Inches(i32);
 
 fn main() {
-    Inches as f32; //~ ERROR illegal cast; cast through a usize first
+    Inches as f32;
+    //~^ ERROR casting
+    //~^^ cast through a usize first
 }

--- a/src/test/compile-fail/issue-2718-a.rs
+++ b/src/test/compile-fail/issue-2718-a.rs
@@ -16,7 +16,7 @@ mod pingpong {
     use send_packet;
     pub type ping = send_packet<pong>;
     pub struct pong(send_packet<ping>);
-    //~^ ERROR illegal recursive struct type; wrap the inner value in a box to make it representable
+    //~^ ERROR invalid recursive struct type
 }
 
 fn main() {}

--- a/src/test/compile-fail/issue-3008-1.rs
+++ b/src/test/compile-fail/issue-3008-1.rs
@@ -10,7 +10,7 @@
 
 enum foo { foo_(bar) }
 enum bar { bar_none, bar_some(bar) }
-//~^ ERROR illegal recursive enum type; wrap the inner value in a box to make it representable
+//~^ ERROR invalid recursive enum type
 
 fn main() {
 }

--- a/src/test/compile-fail/issue-3008-2.rs
+++ b/src/test/compile-fail/issue-3008-2.rs
@@ -12,7 +12,7 @@
 
 enum foo { foo_(bar) }
 struct bar { x: bar }
-//~^ ERROR illegal recursive struct type; wrap the inner value in a box to make it representable
+//~^ ERROR invalid recursive struct type
 
 fn main() {
 }

--- a/src/test/compile-fail/issue-3008-3.rs
+++ b/src/test/compile-fail/issue-3008-3.rs
@@ -12,7 +12,7 @@ use std::marker;
 
 enum E1 { V1(E2<E1>), }
 enum E2<T> { V2(E2<E1>, marker::PhantomData<T>), }
-//~^ ERROR illegal recursive enum type; wrap the inner value in a box to make it representable
+//~^ ERROR invalid recursive enum type
 
 impl E1 { fn foo(&self) {} }
 

--- a/src/test/compile-fail/issue-3779.rs
+++ b/src/test/compile-fail/issue-3779.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 struct S {
-    //~^ ERROR illegal recursive struct type; wrap the inner value in a box to make it representable
+    //~^ ERROR invalid recursive struct type
     element: Option<S>
 }
 

--- a/src/test/compile-fail/old-suffixes-are-really-forbidden.rs
+++ b/src/test/compile-fail/old-suffixes-are-really-forbidden.rs
@@ -9,6 +9,6 @@
 // except according to those terms.
 
 fn main() {
-    let a = 1_is; //~ ERROR illegal suffix
-    let b = 2_us; //~ ERROR illegal suffix
+    let a = 1_is; //~ ERROR invalid suffix
+    let b = 2_us; //~ ERROR invalid suffix
 }

--- a/src/test/compile-fail/recursive-enum.rs
+++ b/src/test/compile-fail/recursive-enum.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern: illegal recursive enum type
+// error-pattern: invalid recursive enum type
 
 enum list<T> { cons(T, list<T>), nil }
 

--- a/src/test/compile-fail/regions-name-static.rs
+++ b/src/test/compile-fail/regions-name-static.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-struct Foo<'static> { //~ ERROR illegal lifetime parameter name: `'static`
+struct Foo<'static> { //~ ERROR invalid lifetime parameter name: `'static`
     x: &'static isize
 }
 

--- a/src/test/compile-fail/type-recursive.rs
+++ b/src/test/compile-fail/type-recursive.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:illegal recursive struct type
+// error-pattern:invalid recursive struct type
 struct t1 {
     foo: isize,
     foolish: t1

--- a/src/test/compile-fail/typeck-cast-pointer-to-float.rs
+++ b/src/test/compile-fail/typeck-cast-pointer-to-float.rs
@@ -11,5 +11,6 @@
 fn main() {
     let x : i16 = 22;
     ((&x) as *const i16) as f32;
-    //~^ ERROR illegal cast; cast through a usize first: `*const i16` as `f32`
+    //~^ ERROR casting `*const i16` as `f32` is invalid
+    //~^^ HELP cast through a usize first
 }

--- a/src/test/compile-fail/unsupported-cast.rs
+++ b/src/test/compile-fail/unsupported-cast.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// error-pattern:illegal cast
+// error-pattern:casting
 
 #![feature(libc)]
 

--- a/src/test/compile-fail/vector-cast-weirdness.rs
+++ b/src/test/compile-fail/vector-cast-weirdness.rs
@@ -28,7 +28,7 @@ fn main() {
     let mut x1 = X { y: [0, 0] };
 
     // This is still an error since we don't allow casts from &mut [T; n] to *mut T.
-    let p1: *mut u8 = &mut x1.y as *mut _;  //~ ERROR illegal cast
+    let p1: *mut u8 = &mut x1.y as *mut _;  //~ ERROR casting
     let t1: *mut [u8; 2] = &mut x1.y as *mut _;
     let h1: *mut [u8; 2] = &mut x1.y as *mut [u8; 2];
 }

--- a/src/test/parse-fail/bad-lit-suffixes.rs
+++ b/src/test/parse-fail/bad-lit-suffixes.rs
@@ -12,28 +12,28 @@
 
 
 extern
-    "C"suffix //~ ERROR ABI spec with a suffix is illegal
+    "C"suffix //~ ERROR ABI spec with a suffix is invalid
     fn foo() {}
 
 extern
-    "C"suffix //~ ERROR ABI spec with a suffix is illegal
+    "C"suffix //~ ERROR ABI spec with a suffix is invalid
 {}
 
 fn main() {
-    ""suffix; //~ ERROR str literal with a suffix is illegal
-    b""suffix; //~ ERROR binary str literal with a suffix is illegal
-    r#""#suffix; //~ ERROR str literal with a suffix is illegal
-    br#""#suffix; //~ ERROR binary str literal with a suffix is illegal
-    'a'suffix; //~ ERROR char literal with a suffix is illegal
-    b'a'suffix; //~ ERROR byte literal with a suffix is illegal
+    ""suffix; //~ ERROR str literal with a suffix is invalid
+    b""suffix; //~ ERROR binary str literal with a suffix is invalid
+    r#""#suffix; //~ ERROR str literal with a suffix is invalid
+    br#""#suffix; //~ ERROR binary str literal with a suffix is invalid
+    'a'suffix; //~ ERROR char literal with a suffix is invalid
+    b'a'suffix; //~ ERROR byte literal with a suffix is invalid
 
-    1234u1024; //~ ERROR illegal width `1024` for integer literal
-    1234i1024; //~ ERROR illegal width `1024` for integer literal
-    1234f1024; //~ ERROR illegal width `1024` for float literal
-    1234.5f1024; //~ ERROR illegal width `1024` for float literal
+    1234u1024; //~ ERROR invalid width `1024` for integer literal
+    1234i1024; //~ ERROR invalid width `1024` for integer literal
+    1234f1024; //~ ERROR invalid width `1024` for float literal
+    1234.5f1024; //~ ERROR invalid width `1024` for float literal
 
-    1234suffix; //~ ERROR illegal suffix `suffix` for numeric literal
-    0b101suffix; //~ ERROR illegal suffix `suffix` for numeric literal
-    1.0suffix; //~ ERROR illegal suffix `suffix` for float literal
-    1.0e10suffix; //~ ERROR illegal suffix `suffix` for float literal
+    1234suffix; //~ ERROR invalid suffix `suffix` for numeric literal
+    0b101suffix; //~ ERROR invalid suffix `suffix` for numeric literal
+    1.0suffix; //~ ERROR invalid suffix `suffix` for float literal
+    1.0e10suffix; //~ ERROR invalid suffix `suffix` for float literal
 }

--- a/src/test/parse-fail/byte-literals.rs
+++ b/src/test/parse-fail/byte-literals.rs
@@ -17,7 +17,7 @@ static FOO: u8 = b'\f';  //~ ERROR unknown byte escape
 
 pub fn main() {
     b'\f';  //~ ERROR unknown byte escape
-    b'\x0Z';  //~ ERROR illegal character in numeric character escape: Z
+    b'\x0Z';  //~ ERROR invalid character in numeric character escape: Z
     b'	';  //~ ERROR byte constant must be escaped
     b''';  //~ ERROR byte constant must be escaped
     b'é';  //~ ERROR byte constant must be ASCII

--- a/src/test/parse-fail/byte-string-literals.rs
+++ b/src/test/parse-fail/byte-string-literals.rs
@@ -17,7 +17,7 @@ static FOO: &'static [u8] = b"\f";  //~ ERROR unknown byte escape
 
 pub fn main() {
     b"\f";  //~ ERROR unknown byte escape
-    b"\x0Z";  //~ ERROR illegal character in numeric character escape: Z
+    b"\x0Z";  //~ ERROR invalid character in numeric character escape: Z
     b"é";  //~ ERROR byte constant must be ASCII
     b"a  //~ ERROR unterminated double quote byte string
 }

--- a/src/test/parse-fail/issue-23620-invalid-escapes.rs
+++ b/src/test/parse-fail/issue-23620-invalid-escapes.rs
@@ -23,25 +23,25 @@ fn main() {
     //~^ ERROR numeric character escape is too short
 
     let _ = b'\xxy';
-    //~^ ERROR illegal character in numeric character escape: x
-    //~^^ ERROR illegal character in numeric character escape: y
+    //~^ ERROR invalid character in numeric character escape: x
+    //~^^ ERROR invalid character in numeric character escape: y
 
     let _ = '\x5';
     //~^ ERROR numeric character escape is too short
 
     let _ = '\xxy';
-    //~^ ERROR illegal character in numeric character escape: x
-    //~^^ ERROR illegal character in numeric character escape: y
+    //~^ ERROR invalid character in numeric character escape: x
+    //~^^ ERROR invalid character in numeric character escape: y
 
     let _ = b"\u{a4a4} \xf \u";
     //~^ ERROR unicode escape sequences cannot be used as a byte or in a byte string
-    //~^^ ERROR illegal character in numeric character escape:
+    //~^^ ERROR invalid character in numeric character escape:
     //~^^^ ERROR incorrect unicode escape sequence
     //~^^^^ ERROR unicode escape sequences cannot be used as a byte or in a byte string
 
     let _ = "\u{ffffff} \xf \u";
-    //~^ ERROR illegal unicode character escape
-    //~^^ ERROR illegal character in numeric character escape:
+    //~^ ERROR invalid unicode character escape
+    //~^^ ERROR invalid character in numeric character escape:
     //~^^^ ERROR form of character escape may only be used with characters in the range [\x00-\x7f]
     //~^^^^ ERROR incorrect unicode escape sequence
 }

--- a/src/test/parse-fail/issue-8537.rs
+++ b/src/test/parse-fail/issue-8537.rs
@@ -11,7 +11,7 @@
 // compile-flags: -Z parse-only
 
 pub extern
-  "invalid-ab_isize" //~ ERROR illegal ABI
+  "invalid-ab_isize" //~ ERROR invalid ABI
 fn foo() {}
 
 fn main() {}

--- a/src/test/parse-fail/new-unicode-escapes-3.rs
+++ b/src/test/parse-fail/new-unicode-escapes-3.rs
@@ -11,5 +11,5 @@
 // compile-flags: -Z parse-only
 
 pub fn main() {
-    let s = "\u{d805}"; //~ ERROR illegal unicode character escape
+    let s = "\u{d805}"; //~ ERROR invalid unicode character escape
 }

--- a/src/test/parse-fail/new-unicode-escapes-4.rs
+++ b/src/test/parse-fail/new-unicode-escapes-4.rs
@@ -12,7 +12,7 @@
 
 pub fn main() {
     let s = "\u{lol}";
-     //~^ ERROR illegal character in unicode escape: l
-     //~^^ ERROR illegal character in unicode escape: o
-     //~^^^ ERROR illegal character in unicode escape: l
+     //~^ ERROR invalid character in unicode escape: l
+     //~^^ ERROR invalid character in unicode escape: o
+     //~^^^ ERROR invalid character in unicode escape: l
 }

--- a/src/test/parse-fail/raw-str-delim.rs
+++ b/src/test/parse-fail/raw-str-delim.rs
@@ -11,5 +11,5 @@
 // compile-flags: -Z parse-only
 
 static s: &'static str =
-    r#x"#"x# //~ ERROR only `#` is allowed in raw string delimitation; found illegal character
+    r#x"#"x# //~ ERROR found invalid character; only `#` is allowed in raw string delimitation
 ;


### PR DESCRIPTION
Improves diagnostics in various locations, namely:
- A few error messages that orignally were a mix of an error message and suggestion how to fix it have been split up into two messages: an error and help/hint.
- Never report “illegal”. Fixes https://github.com/rust-lang/rust/issues/27288
