### PR TITLE
Fix escaping of chars in Debug for Wtf8 backed OsStr

### DIFF
--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -1287,7 +1287,7 @@ impl Debug for str {
     fn fmt(&self, f: &mut Formatter) -> Result {
         try!(write!(f, "\""));
         for c in self.chars().flat_map(|c| c.escape_default()) {
-            try!(write!(f, "{}", c));
+            try!(f.write_char(c))
         }
         write!(f, "\"")
     }
@@ -1306,7 +1306,7 @@ impl Debug for char {
         use char::CharExt;
         try!(write!(f, "'"));
         for c in self.escape_default() {
-            try!(write!(f, "{}", c));
+            try!(f.write_char(c))
         }
         write!(f, "'")
     }


### PR DESCRIPTION
I had to modify some tests : since `wtf8buf_show` and `wtf8_show` were doing the exact same thing, I repurposed `wtf8_show` to `wtf8buf_show_str` which ensures `Wtf8Buf` `Debug`-formats the same as `str`.

`write_str_escaped` might also be shared amongst other `fmt` but I just left it there within `Wtf8::fmt` for review.
